### PR TITLE
perf(gateway,agent): reduce hot-path config and copy overhead

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -471,15 +471,21 @@ def repair_message_sequence_with_cursor(agent, messages: List[Dict]) -> int:
 
     repairs = repair_message_sequence(agent, messages)
 
-    if repairs > 0 and hasattr(agent, "_last_flushed_db_idx"):
-        if pre_repair_flushed_ids is not None:
-            agent._last_flushed_db_idx = sum(
-                1 for m in messages if id(m) in pre_repair_flushed_ids
-            )
-        else:
-            agent._last_flushed_db_idx = min(
-                agent._last_flushed_db_idx, len(messages)
-            )
+    if repairs > 0:
+        if hasattr(agent, "_last_flushed_db_idx"):
+            if pre_repair_flushed_ids is not None:
+                agent._last_flushed_db_idx = sum(
+                    1 for m in messages if id(m) in pre_repair_flushed_ids
+                )
+            else:
+                agent._last_flushed_db_idx = min(
+                    agent._last_flushed_db_idx, len(messages)
+                )
+        # Incremental flush scan cursor indexes into the pre-repair list;
+        # compaction can shift unflushed rows below the cursor. Rescan from
+        # the start — flushed_ids still dedupes already-written rows.
+        if hasattr(agent, "_flush_scan_cursor"):
+            agent._flush_scan_cursor = 0
 
     return repairs
 
@@ -1519,6 +1525,8 @@ def switch_model(agent, new_model, new_provider, api_key='', base_url='', api_mo
 
         # ── Swap core runtime fields ──
         agent.model = new_model
+        agent._supports_vision_cache = None
+        agent._tools_char_estimate = None
         agent.provider = new_provider
         # Use new base_url when provided; only fall back to current when the
         # new provider genuinely has no endpoint (e.g. native SDK providers).
@@ -2024,33 +2032,31 @@ def sanitize_api_messages(messages: List[Dict[str, Any]]) -> List[Dict[str, Any]
     is present — so orphans from session loading or manual message
     manipulation are always caught.
     """
-    # --- Role allowlist: drop messages with roles the API won't accept ---
-    filtered = []
+    valid_roles = _ra().AIAgent._VALID_API_ROLES
+    filtered: List[Dict[str, Any]] = []
+    surviving_call_ids: set = set()
+    result_call_ids: set = set()
+
     for msg in messages:
         role = msg.get("role")
-        if role not in _ra().AIAgent._VALID_API_ROLES:
+        if role not in valid_roles:
             _ra().logger.debug(
                 "Pre-call sanitizer: dropping message with invalid role %r",
                 role,
             )
             continue
         filtered.append(msg)
-    messages = filtered
-
-    surviving_call_ids: set = set()
-    for msg in messages:
-        if msg.get("role") == "assistant":
+        if role == "assistant":
             for tc in msg.get("tool_calls") or []:
                 cid = _ra().AIAgent._get_tool_call_id_static(tc)
                 if cid:
                     surviving_call_ids.add(cid)
-
-    result_call_ids: set = set()
-    for msg in messages:
-        if msg.get("role") == "tool":
+        elif role == "tool":
             cid = msg.get("tool_call_id")
             if cid:
                 result_call_ids.add(cid)
+
+    messages = filtered
 
     # 1. Drop tool results with no matching assistant call
     orphaned_results = result_call_ids - surviving_call_ids
@@ -2063,6 +2069,7 @@ def sanitize_api_messages(messages: List[Dict[str, Any]]) -> List[Dict[str, Any]
             "Pre-call sanitizer: removed %d orphaned tool result(s)",
             len(orphaned_results),
         )
+        result_call_ids -= orphaned_results
 
     # 2. Inject stub results for calls whose result was dropped
     missing_results = surviving_call_ids - result_call_ids

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -819,8 +819,14 @@ def run_conversation(
         # Calculate approximate request size for logging
         total_chars = sum(len(str(msg)) for msg in api_messages)
         approx_tokens = estimate_messages_tokens_rough(api_messages)
+        _tools_char_estimate = getattr(agent, "_tools_char_estimate", None)
+        if _tools_char_estimate is None and agent.tools:
+            _tools_char_estimate = len(str(agent.tools))
+            agent._tools_char_estimate = _tools_char_estimate
         approx_request_tokens = estimate_request_tokens_rough(
-            api_messages, tools=agent.tools or None
+            api_messages,
+            tools=agent.tools or None,
+            tools_char_estimate=_tools_char_estimate,
         )
 
         _runtime_context_error = _ollama_context_limit_error(

--- a/agent/curator.py
+++ b/agent/curator.py
@@ -119,8 +119,8 @@ def is_paused() -> bool:
 def _load_config() -> Dict[str, Any]:
     """Read curator.* config from ~/.hermes/config.yaml. Tolerates missing file."""
     try:
-        from hermes_cli.config import load_config
-        cfg = load_config()
+        from hermes_cli.config import load_config_readonly
+        cfg = load_config_readonly()
     except Exception as e:
         logger.debug("Failed to load config for curator: %s", e)
         return {}

--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -2066,6 +2066,7 @@ def estimate_request_tokens_rough(
     *,
     system_prompt: str = "",
     tools: Optional[List[Dict[str, Any]]] = None,
+    tools_char_estimate: Optional[int] = None,
 ) -> int:
     """Rough token estimate for a full chat-completions request.
 
@@ -2074,12 +2075,17 @@ def estimate_request_tokens_rough(
     tools enabled, schemas alone can add 20-30K tokens — a significant
     blind spot when only counting messages. Image content is counted
     at a flat per-image cost (see estimate_messages_tokens_rough).
+
+    Pass ``tools_char_estimate`` when tool schemas are stable for the
+    session to avoid re-stringifying the full tools list every iteration.
     """
     total = 0
     if system_prompt:
         total += (len(system_prompt) + 3) // 4
     if messages:
         total += estimate_messages_tokens_rough(messages)
-    if tools:
+    if tools_char_estimate is not None:
+        total += (tools_char_estimate + 3) // 4
+    elif tools:
         total += (len(str(tools)) + 3) // 4
     return total

--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -940,10 +940,10 @@ def build_environment_hints() -> str:
     extra = (os.getenv("HERMES_ENVIRONMENT_HINT") or "").strip()
     if not extra:
         try:
-            from hermes_cli.config import load_config
+            from hermes_cli.config import load_config_readonly
 
             extra = str(
-                (load_config().get("agent", {}) or {}).get("environment_hint", "")
+                (load_config_readonly().get("agent", {}) or {}).get("environment_hint", "")
             ).strip()
         except Exception as e:
             logger.debug("Could not read agent.environment_hint from config: %s", e)

--- a/agent/prompt_caching.py
+++ b/agent/prompt_caching.py
@@ -8,7 +8,6 @@ single session.
 Pure functions -- no class state, no AIAgent dependency.
 """
 
-import copy
 from typing import Any, Dict, List
 
 
@@ -56,24 +55,33 @@ def apply_anthropic_cache_control(
     Places up to 4 cache_control breakpoints: system prompt + last 3 non-system
     messages, all at the same TTL.
 
-    Returns:
-        Deep copy of messages with cache_control breakpoints injected.
+    Mutates shallow copies of only the messages that receive breakpoints.
+    ``api_messages`` must already be an API-only copy (as built by
+    ``conversation_loop``) — callers must not pass the persisted session list.
     """
-    messages = copy.deepcopy(api_messages)
-    if not messages:
-        return messages
+    if not api_messages:
+        return api_messages
 
     marker = _build_marker(cache_ttl)
 
+    indices_to_mark: List[int] = []
     breakpoints_used = 0
 
-    if messages[0].get("role") == "system":
-        _apply_cache_marker(messages[0], marker, native_anthropic=native_anthropic)
+    if api_messages[0].get("role") == "system":
+        indices_to_mark.append(0)
         breakpoints_used += 1
 
     remaining = 4 - breakpoints_used
-    non_sys = [i for i in range(len(messages)) if messages[i].get("role") != "system"]
-    for idx in non_sys[-remaining:]:
+    non_sys = [i for i in range(len(api_messages)) if api_messages[i].get("role") != "system"]
+    indices_to_mark.extend(non_sys[-remaining:])
+
+    if not indices_to_mark:
+        return api_messages
+
+    messages = list(api_messages)
+    for idx in indices_to_mark:
+        if messages[idx] is api_messages[idx]:
+            messages[idx] = api_messages[idx].copy()
         _apply_cache_marker(messages[idx], marker, native_anthropic=native_anthropic)
 
     return messages

--- a/agent/transports/chat_completions.py
+++ b/agent/transports/chat_completions.py
@@ -194,10 +194,35 @@ class ChatCompletionsTransport(ProviderTransport):
         if not needs_sanitize:
             return messages
 
-        sanitized = copy.deepcopy(messages)
-        for msg in sanitized:
+        def _msg_needs_sanitize(msg: dict) -> bool:
+            if (
+                "codex_reasoning_items" in msg
+                or "codex_message_items" in msg
+                or "tool_name" in msg
+            ):
+                return True
+            if any(isinstance(k, str) and k.startswith("_") for k in msg):
+                return True
+            tool_calls = msg.get("tool_calls")
+            if isinstance(tool_calls, list):
+                for tc in tool_calls:
+                    if isinstance(tc, dict) and (
+                        "call_id" in tc
+                        or "response_item_id" in tc
+                        or (strip_extra_content and "extra_content" in tc)
+                    ):
+                        return True
+            return False
+
+        sanitized: list = []
+        for msg in messages:
             if not isinstance(msg, dict):
+                sanitized.append(msg)
                 continue
+            if not _msg_needs_sanitize(msg):
+                sanitized.append(msg)
+                continue
+            msg = copy.deepcopy(msg)
             msg.pop("codex_reasoning_items", None)
             msg.pop("codex_message_items", None)
             msg.pop("tool_name", None)
@@ -214,6 +239,7 @@ class ChatCompletionsTransport(ProviderTransport):
                         tc.pop("response_item_id", None)
                         if strip_extra_content:
                             tc.pop("extra_content", None)
+            sanitized.append(msg)
         return sanitized
 
     def convert_tools(self, tools: list[dict[str, Any]]) -> list[dict[str, Any]]:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2199,6 +2199,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             self.config.sessions_dir, self.config,
             has_active_processes_fn=lambda key: process_registry.has_active_for_session(key),
         )
+        self.session_store._transcript_mutation_cb = (
+            self._invalidate_transcript_cache_for_session_id
+        )
         self.delivery_router = DeliveryRouter(self.config)
         self._running = False
         self._gateway_loop: Optional[asyncio.AbstractEventLoop] = None
@@ -13002,6 +13005,25 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         else:
             cache.clear()
 
+    def _invalidate_transcript_cache_for_session_id(self, session_id: str) -> None:
+        """Drop cached transcripts for every session key sharing *session_id*."""
+        if not session_id:
+            return
+        cache = getattr(self, "_transcript_cache", None)
+        if not cache:
+            return
+        for key in [k for k, v in list(cache.items()) if v[0] == session_id]:
+            cache.pop(key, None)
+
+    def _get_transcript_cache_token(self, session_id: Optional[str]) -> Optional[tuple]:
+        if self._session_db is None or not session_id:
+            return None
+        try:
+            return self._session_db.get_transcript_cache_token(session_id)
+        except Exception:
+            pass
+        return None
+
     def _get_session_message_count(self, session_id: Optional[str]) -> Optional[int]:
         if self._session_db is None or not session_id:
             return None
@@ -13019,14 +13041,14 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         session_key: Optional[str] = None,
     ) -> List[Dict[str, Any]]:
         """Load transcript from SessionDB, reusing a per-session cache when valid."""
-        msg_count = self._get_session_message_count(session_id)
+        cache_token = self._get_transcript_cache_token(session_id)
         cache = getattr(self, "_transcript_cache", None)
-        if cache is not None and session_key and msg_count is not None:
+        if cache is not None and session_key and cache_token is not None:
             cached = cache.get(session_key)
             if (
                 cached is not None
                 and cached[0] == session_id
-                and cached[1] == msg_count
+                and cached[1] == cache_token
             ):
                 try:
                     cache.move_to_end(session_key)
@@ -13035,8 +13057,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 return cached[2]
 
         history = self.session_store.load_transcript(session_id)
-        if cache is not None and session_key and msg_count is not None:
-            cache[session_key] = (session_id, msg_count, history)
+        if cache is not None and session_key and cache_token is not None:
+            cache[session_key] = (session_id, cache_token, history)
             try:
                 cache.move_to_end(session_key)
                 while len(cache) > getattr(self, "_transcript_cache_max", 512):

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1799,13 +1799,13 @@ def _load_gateway_config() -> dict:
     """
     config_path = _hermes_home / 'config.yaml'
     try:
-        from hermes_cli.config import get_config_path, read_raw_config
+        from hermes_cli.config import get_config_path, read_raw_config_readonly
         # Fast path: if _hermes_home agrees with the canonical config
         # location, reuse the shared cache. Otherwise fall through to a
         # direct read (keeps test fixtures with a monkeypatched
         # _hermes_home working).
         if config_path == get_config_path():
-            return read_raw_config()
+            return read_raw_config_readonly()
     except Exception:
         pass
 
@@ -1819,6 +1819,10 @@ def _load_gateway_config() -> dict:
     return {}
 
 
+# Memoized expanded gateway runtime config keyed on (path, mtime_ns, size).
+_GATEWAY_RUNTIME_CONFIG_CACHE: Dict[str, tuple] = {}
+
+
 def _load_gateway_runtime_config() -> dict:
     """Load gateway config for runtime reads, expanding supported ``${VAR}`` refs.
 
@@ -1830,13 +1834,29 @@ def _load_gateway_runtime_config() -> dict:
     Expansion failures are intentionally NOT swallowed — silently returning
     the unexpanded dict would mask the very bug this helper exists to fix.
     """
+    config_path = _hermes_home / 'config.yaml'
+    path_key = str(config_path)
+    try:
+        st = config_path.stat()
+        cache_key = (st.st_mtime_ns, st.st_size)
+    except (FileNotFoundError, OSError):
+        cache_key = None
+
+    if cache_key is not None:
+        cached = _GATEWAY_RUNTIME_CONFIG_CACHE.get(path_key)
+        if cached is not None and cached[:2] == cache_key:
+            return cached[2]
+
     cfg = _load_gateway_config()
     if not isinstance(cfg, dict) or not cfg:
         return {}
     from hermes_cli.config import _expand_env_vars
 
     expanded = _expand_env_vars(cfg)
-    return expanded if isinstance(expanded, dict) else {}
+    result = expanded if isinstance(expanded, dict) else {}
+    if cache_key is not None:
+        _GATEWAY_RUNTIME_CONFIG_CACHE[path_key] = (cache_key[0], cache_key[1], result)
+    return result
 
 
 def _resolve_gateway_model(config: dict | None = None) -> str:
@@ -2260,6 +2280,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         import threading as _threading
         self._agent_cache: "OrderedDict[str, tuple]" = OrderedDict()
         self._agent_cache_lock = _threading.Lock()
+        # Transcript cache: session_key -> (session_id, message_count, history)
+        self._transcript_cache: "OrderedDict[str, tuple]" = OrderedDict()
+        self._transcript_cache_max = 512
 
         # Per-session model overrides from /model command.
         # Key: session_key, Value: dict with model/provider/api_key/base_url/api_mode
@@ -8310,6 +8333,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         if getattr(session_entry, "is_fresh_reset", False):
             session_entry.is_fresh_reset = False
         if _is_new_session:
+            self._invalidate_transcript_cache(session_key)
             await self.hooks.emit("session:start", {
                 "platform": source.platform.value if source.platform else "",
                 "user_id": source.user_id,
@@ -8434,8 +8458,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             except Exception as e:
                 logger.warning("[Gateway] Failed to auto-load skill(s) %s: %s", _skill_names, e)
 
-        # Load conversation history from transcript
-        history = self.session_store.load_transcript(session_entry.session_id)
+        # Load conversation history from transcript (off event loop; cached per session)
+        history = await asyncio.to_thread(
+            self._load_transcript_sync,
+            session_entry.session_id,
+            session_key,
+        )
         
         # -----------------------------------------------------------------
         # Session hygiene: auto-compress pathologically large transcripts
@@ -8452,308 +8480,30 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         #    by 30-50% on code/JSON-heavy sessions, but that just
         #    means hygiene fires a bit early — safe and harmless.
         # -----------------------------------------------------------------
+        _hyg_plan = None
         if history and len(history) >= 4:
-            from agent.model_metadata import (
-                estimate_messages_tokens_rough,
-                get_model_context_length,
-            )
-
-            # Read model + compression config from config.yaml.
-            # NOTE: hygiene threshold is intentionally HIGHER than the agent's
-            # own compressor (0.85 vs 0.50).  Hygiene is a safety net for
-            # sessions that grew too large between turns — it fires pre-agent
-            # to prevent API failures.  The agent's own compressor handles
-            # normal context management during its tool loop with accurate
-            # real token counts.  Having hygiene at 0.50 caused premature
-            # compression on every turn in long gateway sessions.
-            _hyg_model = "anthropic/claude-sonnet-4.6"
-            _hyg_threshold_pct = 0.85
-            _hyg_compression_enabled = True
-            _hyg_hard_msg_limit = 400
-            _hyg_config_context_length = None
-            _hyg_provider = None
-            _hyg_base_url = None
-            _hyg_api_key = None
-            _hyg_data = {}
             try:
-                _hyg_data = _load_gateway_config()
-                if _hyg_data:
-                    # Resolve model name (same logic as run_sync)
-                    _model_cfg = _hyg_data.get("model", {})
-                    if isinstance(_model_cfg, str):
-                        _hyg_model = _model_cfg
-                    elif isinstance(_model_cfg, dict):
-                        _hyg_model = _model_cfg.get("default") or _model_cfg.get("model") or _hyg_model
-                        # Read explicit context_length override from model config
-                        # (same as run_agent.py lines 995-1005)
-                        _raw_ctx = _model_cfg.get("context_length")
-                        if _raw_ctx is not None:
-                            try:
-                                _hyg_config_context_length = int(_raw_ctx)
-                            except (TypeError, ValueError):
-                                pass
-                        # Read provider for accurate context detection
-                        _hyg_provider = _model_cfg.get("provider") or None
-                        _hyg_base_url = _model_cfg.get("base_url") or None
-
-                    # Read compression settings — only use enabled flag.
-                    # The threshold is intentionally separate from the agent's
-                    # compression.threshold (hygiene runs higher).
-                    _comp_cfg = _hyg_data.get("compression", {})
-                    if isinstance(_comp_cfg, dict):
-                        _hyg_compression_enabled = str(
-                            _comp_cfg.get("enabled", True)
-                        ).lower() in {"true", "1", "yes"}
-                        _raw_hard_limit = _comp_cfg.get("hygiene_hard_message_limit")
-                        if _raw_hard_limit is not None:
-                            try:
-                                _parsed = int(_raw_hard_limit)
-                                if _parsed > 0:
-                                    _hyg_hard_msg_limit = _parsed
-                            except (TypeError, ValueError):
-                                pass
-
-                try:
-                    _hyg_model, _hyg_runtime = self._resolve_session_agent_runtime(
-                        source=source,
-                        session_key=session_key,
-                        user_config=_hyg_data if isinstance(_hyg_data, dict) else None,
-                    )
-                    _hyg_provider = _hyg_runtime.get("provider") or _hyg_provider
-                    _hyg_base_url = _hyg_runtime.get("base_url") or _hyg_base_url
-                    _hyg_api_key = _hyg_runtime.get("api_key") or _hyg_api_key
-                except Exception:
-                    pass
-
-                # Check custom_providers per-model context_length
-                # (same fallback as run_agent.py lines 1171-1189).
-                # Must run after runtime resolution so _hyg_base_url is set.
-                if _hyg_config_context_length is None and _hyg_base_url:
-                    try:
-                        try:
-                            from hermes_cli.config import get_compatible_custom_providers as _gw_gcp
-                            _hyg_custom_providers = _gw_gcp(_hyg_data)
-                        except Exception:
-                            _hyg_custom_providers = _hyg_data.get("custom_providers")
-                            if not isinstance(_hyg_custom_providers, list):
-                                _hyg_custom_providers = []
-                        for _cp in _hyg_custom_providers:
-                            if not isinstance(_cp, dict):
-                                continue
-                            _cp_url = (_cp.get("base_url") or "").rstrip("/")
-                            if _cp_url and _cp_url == _hyg_base_url.rstrip("/"):
-                                _cp_models = _cp.get("models", {})
-                                if isinstance(_cp_models, dict):
-                                    _cp_model_cfg = _cp_models.get(_hyg_model, {})
-                                    if isinstance(_cp_model_cfg, dict):
-                                        _cp_ctx = _cp_model_cfg.get("context_length")
-                                        if _cp_ctx is not None:
-                                            _hyg_config_context_length = int(_cp_ctx)
-                                break
-                    except (TypeError, ValueError):
-                        pass
-            except Exception:
-                pass
-
-            if _hyg_compression_enabled:
-                _hyg_context_length = get_model_context_length(
-                    _hyg_model,
-                    base_url=_hyg_base_url or "",
-                    api_key=_hyg_api_key or "",
-                    config_context_length=_hyg_config_context_length,
-                    provider=_hyg_provider or "",
+                _hyg_plan = await asyncio.to_thread(
+                    self._plan_session_hygiene_sync,
+                    history,
+                    session_entry,
+                    session_key,
+                    source,
                 )
-                _compress_token_threshold = int(
-                    _hyg_context_length * _hyg_threshold_pct
+            except Exception as _hyg_plan_err:
+                logger.warning(
+                    "Session hygiene planning failed: %s", _hyg_plan_err
                 )
-                _warn_token_threshold = int(_hyg_context_length * 0.95)
-
-                _msg_count = len(history)
-
-                # Prefer actual API-reported tokens from the last turn
-                # (stored in session entry) over the rough char-based estimate.
-                _stored_tokens = session_entry.last_prompt_tokens
-                if _stored_tokens > 0:
-                    _approx_tokens = _stored_tokens
-                    _token_source = "actual"
-                else:
-                    _approx_tokens = estimate_messages_tokens_rough(history)
-                    _token_source = "estimated"
-                    # Note: rough estimates overestimate by 30-50% for code/JSON-heavy
-                    # sessions, but that just means hygiene fires a bit early — which
-                    # is safe and harmless.  The 85% threshold already provides ample
-                    # headroom (agent's own compressor runs at 50%).  A previous 1.4x
-                    # multiplier tried to compensate by inflating the threshold, but
-                    # 85% * 1.4 = 119% of context — which exceeds the model's limit
-                    # and prevented hygiene from ever firing for ~200K models (GLM-5).
-
-                # Hard safety valve: force compression if message count is
-                # extreme, regardless of token estimates.  This breaks the
-                # death spiral where API disconnects prevent token data
-                # collection, which prevents compression, which causes more
-                # disconnects.  400 messages is well above normal sessions
-                # but catches runaway growth before it becomes unrecoverable.
-                # Threshold is configurable via
-                # compression.hygiene_hard_message_limit.
-                # (#2153)
-                _HARD_MSG_LIMIT = _hyg_hard_msg_limit
-                _needs_compress = (
-                    _approx_tokens >= _compress_token_threshold
-                    or _msg_count >= _HARD_MSG_LIMIT
+                _hyg_plan = None
+            if _hyg_plan:
+                history = await self._run_session_hygiene_compress(
+                    _hyg_plan,
+                    history,
+                    session_entry,
+                    session_key,
+                    source,
+                    event,
                 )
-
-                if _needs_compress:
-                    logger.info(
-                        "Session hygiene: %s messages, ~%s tokens (%s) — auto-compressing "
-                        "(threshold: %s%% of %s = %s tokens)",
-                        _msg_count, f"{_approx_tokens:,}", _token_source,
-                        int(_hyg_threshold_pct * 100),
-                        f"{_hyg_context_length:,}",
-                        f"{_compress_token_threshold:,}",
-                    )
-
-                    _hyg_meta = self._thread_metadata_for_source(source, self._reply_anchor_for_event(event))
-
-                    try:
-                        from run_agent import AIAgent
-
-                        _hyg_model, _hyg_runtime = self._resolve_session_agent_runtime(
-                            source=source,
-                            session_key=session_key,
-                            user_config=_hyg_data if isinstance(_hyg_data, dict) else None,
-                        )
-                        if _hyg_runtime.get("api_key"):
-                            _hyg_msgs = [
-                                {"role": m.get("role"), "content": m.get("content")}
-                                for m in history
-                                if m.get("role") in {"user", "assistant"}
-                                and m.get("content")
-                            ]
-
-                            if len(_hyg_msgs) >= 4:
-                                _hyg_agent = AIAgent(
-                                    **_hyg_runtime,
-                                    model=_hyg_model,
-                                    max_iterations=4,
-                                    quiet_mode=True,
-                                    skip_memory=True,
-                                    enabled_toolsets=["memory"],
-                                    session_id=session_entry.session_id,
-                                )
-                                try:
-                                    _hyg_agent._print_fn = lambda *a, **kw: None
-
-                                    loop = asyncio.get_running_loop()
-                                    _compressed, _ = await loop.run_in_executor(
-                                        None,
-                                        lambda: _hyg_agent._compress_context(
-                                            _hyg_msgs, "",
-                                            approx_tokens=_approx_tokens,
-                                        ),
-                                    )
-
-                                    # _compress_context ends the old session and creates
-                                    # a new session_id.  Write compressed messages into
-                                    # the NEW session so the old transcript stays intact
-                                    # and searchable via session_search.
-                                    _hyg_new_sid = _hyg_agent.session_id
-                                    if _hyg_new_sid != session_entry.session_id:
-                                        session_entry.session_id = _hyg_new_sid
-                                        self.session_store._save()
-                                        self._sync_telegram_topic_binding(
-                                            source, session_entry,
-                                            reason="hygiene-compression",
-                                        )
-
-                                    self.session_store.rewrite_transcript(
-                                        session_entry.session_id, _compressed
-                                    )
-                                    # Reset stored token count — transcript was rewritten
-                                    session_entry.last_prompt_tokens = 0
-                                    history = _compressed
-                                    _new_count = len(_compressed)
-                                    _new_tokens = estimate_messages_tokens_rough(
-                                        _compressed
-                                    )
-
-                                    logger.info(
-                                        "Session hygiene: compressed %s → %s msgs, "
-                                        "~%s → ~%s tokens",
-                                        _msg_count, _new_count,
-                                        f"{_approx_tokens:,}", f"{_new_tokens:,}",
-                                    )
-
-                                    if _new_tokens >= _warn_token_threshold:
-                                        logger.warning(
-                                            "Session hygiene: still ~%s tokens after "
-                                            "compression",
-                                            f"{_new_tokens:,}",
-                                        )
-
-                                    # If summary generation failed, the
-                                    # compressor aborts entirely and returns
-                                    # messages unchanged — nothing is dropped.
-                                    # Surface a visible warning to the gateway
-                                    # user — agent.log alone is invisible on
-                                    # TG/Discord/etc. — so they know the chat
-                                    # is "frozen" at the current size and can
-                                    # /compress to retry or /reset to start
-                                    # fresh.
-                                    _comp = getattr(_hyg_agent, "context_compressor", None)
-                                    if _comp is not None and getattr(_comp, "_last_compress_aborted", False):
-                                        _err = getattr(_comp, "_last_summary_error", None) or "unknown error"
-                                        _warn_msg = (
-                                            "⚠️ Context compression aborted "
-                                            f"({_err}). No messages were dropped — "
-                                            "conversation is unchanged. Run /compress "
-                                            "to retry, /reset for a clean session, or "
-                                            "check your auxiliary.compression model "
-                                            "configuration."
-                                        )
-                                        try:
-                                            _adapter = self.adapters.get(source.platform)
-                                            if _adapter and source.chat_id:
-                                                await _adapter.send(source.chat_id, _warn_msg, metadata=_hyg_meta)
-                                        except Exception as _werr:
-                                            logger.warning(
-                                                "Failed to deliver compression-failure warning to user: %s",
-                                                _werr,
-                                            )
-                                    # Separately: if the user's CONFIGURED aux
-                                    # model failed and we recovered by falling
-                                    # back to the main model, tell them — a
-                                    # misconfigured auxiliary.compression.model
-                                    # is something only they can fix, and
-                                    # silent recovery would hide it.
-                                    elif _comp is not None and getattr(_comp, "_last_aux_model_failure_model", None):
-                                        _aux_model = getattr(_comp, "_last_aux_model_failure_model", "")
-                                        _aux_err = getattr(_comp, "_last_aux_model_failure_error", None) or "unknown error"
-                                        _aux_msg = (
-                                            f"ℹ️ Configured compression model `{_aux_model}` "
-                                            f"failed ({_aux_err}). Recovered using your main "
-                                            "model — context is intact — but you may want to "
-                                            "check `auxiliary.compression.model` in config.yaml."
-                                        )
-                                        try:
-                                            _adapter = self.adapters.get(source.platform)
-                                            if _adapter and source.chat_id:
-                                                await _adapter.send(source.chat_id, _aux_msg, metadata=_hyg_meta)
-                                        except Exception as _werr:
-                                            logger.warning(
-                                                "Failed to deliver aux-model-fallback notice to user: %s",
-                                                _werr,
-                                            )
-                                finally:
-                                    # Evict the cached agent so the next turn
-                                    # rebuilds its system prompt from current
-                                    # SOUL.md, memory, and skills.
-                                    self._evict_cached_agent(session_key)
-                                    self._cleanup_agent_resources(_hyg_agent)
-
-                    except Exception as e:
-                        logger.warning(
-                            "Session hygiene auto-compress failed: %s", e
-                        )
 
         # First-message onboarding -- only on the very first interaction ever
         if not history and not self.session_store.has_any_sessions():
@@ -8951,6 +8701,18 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             self._refresh_agent_cache_message_count(
                 session_key, session_entry.session_id
             )
+            try:
+                await asyncio.to_thread(
+                    self._load_transcript_sync,
+                    session_entry.session_id,
+                    session_key,
+                )
+            except Exception:
+                logger.debug(
+                    "Failed to warm transcript cache after turn for %s",
+                    session_key,
+                    exc_info=True,
+                )
 
             # Successful turn — clear any stuck-loop counter for this session.
             # This ensures the counter only accumulates across CONSECUTIVE
@@ -12933,6 +12695,356 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         if release_running_state:
             self._release_running_agent_state(session_key)
 
+    def _plan_session_hygiene_sync(
+        self,
+        history: List[Dict[str, Any]],
+        session_entry,
+        session_key: str,
+        source,
+    ) -> Optional[Dict[str, Any]]:
+        """Evaluate whether pre-agent session hygiene compression is needed.
+
+        Runs synchronously — call via ``asyncio.to_thread`` from the gateway
+        event loop. Returns ``None`` when hygiene is disabled, skipped, or
+        not needed; otherwise a dict with compression parameters.
+        """
+        from agent.model_metadata import (
+            estimate_messages_tokens_rough,
+            get_model_context_length,
+        )
+
+        _hyg_model = "anthropic/claude-sonnet-4.6"
+        _hyg_threshold_pct = 0.85
+        _hyg_compression_enabled = True
+        _hyg_hard_msg_limit = 400
+        _hyg_config_context_length = None
+        _hyg_provider = None
+        _hyg_base_url = None
+        _hyg_api_key = None
+        _hyg_data: dict = {}
+        _hyg_runtime: dict = {}
+        _msg_count = len(history)
+        _stored_tokens = int(getattr(session_entry, "last_prompt_tokens", 0) or 0)
+
+        try:
+            _hyg_data = _load_gateway_config()
+            if _hyg_data:
+                _model_cfg = _hyg_data.get("model", {})
+                if isinstance(_model_cfg, str):
+                    _hyg_model = _model_cfg
+                elif isinstance(_model_cfg, dict):
+                    _hyg_model = _model_cfg.get("default") or _model_cfg.get("model") or _hyg_model
+                    _raw_ctx = _model_cfg.get("context_length")
+                    if _raw_ctx is not None:
+                        try:
+                            _hyg_config_context_length = int(_raw_ctx)
+                        except (TypeError, ValueError):
+                            pass
+                    _hyg_provider = _model_cfg.get("provider") or None
+                    _hyg_base_url = _model_cfg.get("base_url") or None
+
+                _comp_cfg = _hyg_data.get("compression", {})
+                if isinstance(_comp_cfg, dict):
+                    _hyg_compression_enabled = str(
+                        _comp_cfg.get("enabled", True)
+                    ).lower() in {"true", "1", "yes"}
+                    _raw_hard_limit = _comp_cfg.get("hygiene_hard_message_limit")
+                    if _raw_hard_limit is not None:
+                        try:
+                            _parsed = int(_raw_hard_limit)
+                            if _parsed > 0:
+                                _hyg_hard_msg_limit = _parsed
+                        except (TypeError, ValueError):
+                            pass
+
+            try:
+                _hyg_model, _hyg_runtime = self._resolve_session_agent_runtime(
+                    source=source,
+                    session_key=session_key,
+                    user_config=_hyg_data if isinstance(_hyg_data, dict) else None,
+                )
+                _hyg_provider = _hyg_runtime.get("provider") or _hyg_provider
+                _hyg_base_url = _hyg_runtime.get("base_url") or _hyg_base_url
+                _hyg_api_key = _hyg_runtime.get("api_key") or _hyg_api_key
+            except Exception:
+                pass
+
+            if _hyg_config_context_length is None and _hyg_base_url:
+                try:
+                    try:
+                        from hermes_cli.config import get_compatible_custom_providers as _gw_gcp
+                        _hyg_custom_providers = _gw_gcp(_hyg_data)
+                    except Exception:
+                        _hyg_custom_providers = _hyg_data.get("custom_providers")
+                        if not isinstance(_hyg_custom_providers, list):
+                            _hyg_custom_providers = []
+                    for _cp in _hyg_custom_providers:
+                        if not isinstance(_cp, dict):
+                            continue
+                        _cp_url = (_cp.get("base_url") or "").rstrip("/")
+                        if _cp_url and _cp_url == _hyg_base_url.rstrip("/"):
+                            _cp_models = _cp.get("models", {})
+                            if isinstance(_cp_models, dict):
+                                _cp_model_cfg = _cp_models.get(_hyg_model, {})
+                                if isinstance(_cp_model_cfg, dict):
+                                    _cp_ctx = _cp_model_cfg.get("context_length")
+                                    if _cp_ctx is not None:
+                                        _hyg_config_context_length = int(_cp_ctx)
+                            break
+                except (TypeError, ValueError):
+                    pass
+        except Exception:
+            pass
+
+        if not _hyg_compression_enabled:
+            return None
+
+        _hyg_context_length = get_model_context_length(
+            _hyg_model,
+            base_url=_hyg_base_url or "",
+            api_key=_hyg_api_key or "",
+            config_context_length=_hyg_config_context_length,
+            provider=_hyg_provider or "",
+        )
+        _compress_token_threshold = int(_hyg_context_length * _hyg_threshold_pct)
+        _warn_token_threshold = int(_hyg_context_length * 0.95)
+
+        if _stored_tokens > 0:
+            _approx_tokens = _stored_tokens
+            _token_source = "actual"
+        else:
+            _approx_tokens = estimate_messages_tokens_rough(history)
+            _token_source = "estimated"
+
+        _needs_compress = (
+            _approx_tokens >= _compress_token_threshold
+            or _msg_count >= _hyg_hard_msg_limit
+        )
+        if not _needs_compress:
+            return None
+
+        return {
+            "needs_compress": True,
+            "hyg_model": _hyg_model,
+            "hyg_runtime": _hyg_runtime,
+            "hyg_data": _hyg_data,
+            "approx_tokens": _approx_tokens,
+            "token_source": _token_source,
+            "msg_count": _msg_count,
+            "hyg_context_length": _hyg_context_length,
+            "compress_token_threshold": _compress_token_threshold,
+            "warn_token_threshold": _warn_token_threshold,
+            "hyg_threshold_pct": _hyg_threshold_pct,
+            "hyg_hard_msg_limit": _hyg_hard_msg_limit,
+        }
+
+    async def _run_session_hygiene_compress(
+        self,
+        plan: Dict[str, Any],
+        history: List[Dict[str, Any]],
+        session_entry,
+        session_key: str,
+        source,
+        event,
+    ) -> List[Dict[str, Any]]:
+        """Run pre-agent hygiene compression when ``_plan_session_hygiene_sync`` says so."""
+        from agent.model_metadata import estimate_messages_tokens_rough
+        from run_agent import AIAgent
+
+        _approx_tokens = plan["approx_tokens"]
+        _token_source = plan["token_source"]
+        _msg_count = plan["msg_count"]
+        _hyg_context_length = plan["hyg_context_length"]
+        _compress_token_threshold = plan["compress_token_threshold"]
+        _warn_token_threshold = plan["warn_token_threshold"]
+        _hyg_threshold_pct = plan["hyg_threshold_pct"]
+        _hyg_model = plan["hyg_model"]
+        _hyg_runtime = plan["hyg_runtime"]
+
+        logger.info(
+            "Session hygiene: %s messages, ~%s tokens (%s) — auto-compressing "
+            "(threshold: %s%% of %s = %s tokens)",
+            _msg_count, f"{_approx_tokens:,}", _token_source,
+            int(_hyg_threshold_pct * 100),
+            f"{_hyg_context_length:,}",
+            f"{_compress_token_threshold:,}",
+        )
+
+        _hyg_meta = self._thread_metadata_for_source(
+            source, self._reply_anchor_for_event(event)
+        )
+
+        try:
+            if not _hyg_runtime.get("api_key"):
+                return history
+            _hyg_msgs = [
+                {"role": m.get("role"), "content": m.get("content")}
+                for m in history
+                if m.get("role") in {"user", "assistant"}
+                and m.get("content")
+            ]
+            if len(_hyg_msgs) < 4:
+                return history
+
+            _hyg_agent = AIAgent(
+                **_hyg_runtime,
+                model=_hyg_model,
+                max_iterations=4,
+                quiet_mode=True,
+                skip_memory=True,
+                enabled_toolsets=["memory"],
+                session_id=session_entry.session_id,
+            )
+            try:
+                _hyg_agent._print_fn = lambda *a, **kw: None
+
+                loop = asyncio.get_running_loop()
+                _compressed, _ = await loop.run_in_executor(
+                    None,
+                    lambda: _hyg_agent._compress_context(
+                        _hyg_msgs, "",
+                        approx_tokens=_approx_tokens,
+                    ),
+                )
+
+                _hyg_new_sid = _hyg_agent.session_id
+                if _hyg_new_sid != session_entry.session_id:
+                    session_entry.session_id = _hyg_new_sid
+                    self.session_store._save()
+                    self._sync_telegram_topic_binding(
+                        source, session_entry,
+                        reason="hygiene-compression",
+                    )
+
+                self.session_store.rewrite_transcript(
+                    session_entry.session_id, _compressed
+                )
+                session_entry.last_prompt_tokens = 0
+                self._invalidate_transcript_cache(session_key)
+                _new_count = len(_compressed)
+                _new_tokens = estimate_messages_tokens_rough(_compressed)
+
+                logger.info(
+                    "Session hygiene: compressed %s → %s msgs, "
+                    "~%s → ~%s tokens",
+                    _msg_count, _new_count,
+                    f"{_approx_tokens:,}", f"{_new_tokens:,}",
+                )
+
+                if _new_tokens >= _warn_token_threshold:
+                    logger.warning(
+                        "Session hygiene: still ~%s tokens after compression",
+                        f"{_new_tokens:,}",
+                    )
+
+                _comp = getattr(_hyg_agent, "context_compressor", None)
+                if _comp is not None and getattr(_comp, "_last_compress_aborted", False):
+                    _err = getattr(_comp, "_last_summary_error", None) or "unknown error"
+                    _warn_msg = (
+                        "⚠️ Context compression aborted "
+                        f"({_err}). No messages were dropped — "
+                        "conversation is unchanged. Run /compress "
+                        "to retry, /reset for a clean session, or "
+                        "check your auxiliary.compression model "
+                        "configuration."
+                    )
+                    try:
+                        _adapter = self.adapters.get(source.platform)
+                        if _adapter and source.chat_id:
+                            await _adapter.send(
+                                source.chat_id, _warn_msg, metadata=_hyg_meta
+                            )
+                    except Exception as _werr:
+                        logger.warning(
+                            "Failed to deliver compression-failure warning to user: %s",
+                            _werr,
+                        )
+                elif _comp is not None and getattr(
+                    _comp, "_last_aux_model_failure_model", None
+                ):
+                    _aux_model = getattr(_comp, "_last_aux_model_failure_model", "")
+                    _aux_err = (
+                        getattr(_comp, "_last_aux_model_failure_error", None)
+                        or "unknown error"
+                    )
+                    _aux_msg = (
+                        f"ℹ️ Configured compression model `{_aux_model}` "
+                        f"failed ({_aux_err}). Recovered using your main "
+                        "model — context is intact — but you may want to "
+                        "check `auxiliary.compression.model` in config.yaml."
+                    )
+                    try:
+                        _adapter = self.adapters.get(source.platform)
+                        if _adapter and source.chat_id:
+                            await _adapter.send(
+                                source.chat_id, _aux_msg, metadata=_hyg_meta
+                            )
+                    except Exception as _werr:
+                        logger.warning(
+                            "Failed to deliver aux-model-fallback notice to user: %s",
+                            _werr,
+                        )
+                return _compressed
+            finally:
+                self._evict_cached_agent(session_key)
+                self._cleanup_agent_resources(_hyg_agent)
+        except Exception as e:
+            logger.warning("Session hygiene auto-compress failed: %s", e)
+        return history
+
+    def _invalidate_transcript_cache(self, session_key: Optional[str] = None) -> None:
+        """Drop cached transcript snapshots for one session or all sessions."""
+        cache = getattr(self, "_transcript_cache", None)
+        if not cache:
+            return
+        if session_key:
+            cache.pop(session_key, None)
+        else:
+            cache.clear()
+
+    def _get_session_message_count(self, session_id: Optional[str]) -> Optional[int]:
+        if self._session_db is None or not session_id:
+            return None
+        try:
+            row = self._session_db.get_session(session_id)
+            if row:
+                return row.get("message_count", 0)
+        except Exception:
+            pass
+        return None
+
+    def _load_transcript_sync(
+        self,
+        session_id: str,
+        session_key: Optional[str] = None,
+    ) -> List[Dict[str, Any]]:
+        """Load transcript from SessionDB, reusing a per-session cache when valid."""
+        msg_count = self._get_session_message_count(session_id)
+        cache = getattr(self, "_transcript_cache", None)
+        if cache is not None and session_key and msg_count is not None:
+            cached = cache.get(session_key)
+            if (
+                cached is not None
+                and cached[0] == session_id
+                and cached[1] == msg_count
+            ):
+                try:
+                    cache.move_to_end(session_key)
+                except Exception:
+                    pass
+                return cached[2]
+
+        history = self.session_store.load_transcript(session_id)
+        if cache is not None and session_key and msg_count is not None:
+            cache[session_key] = (session_id, msg_count, history)
+            try:
+                cache.move_to_end(session_key)
+                while len(cache) > getattr(self, "_transcript_cache_max", 512):
+                    cache.popitem(last=False)
+            except Exception:
+                pass
+        return history
+
     def _refresh_agent_cache_message_count(
         self, session_key: str, session_id: Optional[str]
     ) -> None:
@@ -13008,6 +13120,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         ``_agent_cache_lock`` on slow socket teardown — mirrors the
         cap-enforcer and idle-sweeper paths.
         """
+        self._invalidate_transcript_cache(session_key)
         _lock = getattr(self, "_agent_cache_lock", None)
         evicted = None
         if _lock:

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -714,6 +714,7 @@ class SessionStore:
         self._loaded = False
         self._lock = threading.Lock()
         self._has_active_processes_fn = has_active_processes_fn
+        self._transcript_mutation_cb = None
         
         # Initialize SQLite session database
         self._db = None
@@ -1337,6 +1338,12 @@ class SessionStore:
                 self._db.replace_messages(session_id, messages)
             except Exception as e:
                 logger.debug("Failed to rewrite transcript in DB: %s", e)
+        cb = getattr(self, "_transcript_mutation_cb", None)
+        if cb:
+            try:
+                cb(session_id)
+            except Exception:
+                logger.debug("transcript mutation callback failed", exc_info=True)
 
     def load_transcript(self, session_id: str) -> List[Dict[str, Any]]:
         """Load all messages from a session's transcript.
@@ -1399,6 +1406,12 @@ class SessionStore:
             target_text = content
         else:
             target_text = ""
+        cb = getattr(self, "_transcript_mutation_cb", None)
+        if cb:
+            try:
+                cb(session_id)
+            except Exception:
+                logger.debug("transcript mutation callback failed", exc_info=True)
         return {
             "rewound_count": result.get("rewound_count", 0),
             "turns_undone": target_idx + 1,

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -27,6 +27,7 @@ import threading
 import time
 from dataclasses import dataclass
 from pathlib import Path
+from collections.abc import Iterator, Mapping
 from typing import Dict, Any, Optional, List, Tuple
 
 from hermes_cli.secret_prompt import masked_secret_prompt
@@ -223,11 +224,11 @@ _LAST_EXPANDED_CONFIG_BY_PATH: Dict[str, Any] = {}
 # save_config() + migrate_config() write via atomic_yaml_write which
 # produces a fresh inode, so stat() sees a new mtime_ns and the next
 # load repopulates automatically — no explicit invalidation hook.
-_LOAD_CONFIG_CACHE: Dict[str, Tuple[int, int, Dict[str, Any]]] = {}
+_LOAD_CONFIG_CACHE: Dict[str, Tuple[int, int, Dict[str, Any], "_ReadonlyConfigView"]] = {}
 # (path, mtime_ns, size) -> cached raw yaml dict. Same pattern as
 # _LOAD_CONFIG_CACHE but for read_raw_config() — used when callers want
 # the user's on-disk values without defaults merged in.
-_RAW_CONFIG_CACHE: Dict[str, Tuple[int, int, Dict[str, Any]]] = {}
+_RAW_CONFIG_CACHE: Dict[str, Tuple[int, int, Dict[str, Any], "_ReadonlyConfigView"]] = {}
 # Serializes all config read/write paths. libyaml's C extension is not
 # thread-safe for concurrent safe_load() on the same file, and multiple
 # tool threads (approval.py, browser_tool.py, setup flows) hit
@@ -236,6 +237,37 @@ _RAW_CONFIG_CACHE: Dict[str, Tuple[int, int, Dict[str, Any]]] = {}
 # calls read_raw_config. Also covers mutation of the module-level cache
 # dicts above.
 _CONFIG_LOCK = threading.RLock()
+
+
+class _ReadonlyConfigView(Mapping):
+    """Zero-copy read-only facade over a cached config dict.
+
+    Prevents accidental in-place mutation of the shared config cache without
+    paying for a defensive deepcopy on every readonly load.
+    """
+
+    __slots__ = ("_data",)
+
+    def __init__(self, data: Dict[str, Any]) -> None:
+        self._data = data
+
+    def __getitem__(self, key: str) -> Any:
+        val = self._data[key]
+        if type(val) is dict:
+            return _ReadonlyConfigView(val)
+        return val
+
+    def __iter__(self) -> Iterator:
+        return iter(self._data)
+
+    def __len__(self) -> int:
+        return len(self._data)
+
+    def get(self, key: str, default: Any = None) -> Any:
+        if key not in self._data:
+            return default
+        return self[key]
+
 # Env var names written to .env that aren't in OPTIONAL_ENV_VARS
 # (managed by setup/provider flows directly).
 _EXTRA_ENV_KEYS = frozenset({
@@ -5260,17 +5292,18 @@ def read_raw_config() -> Dict[str, Any]:
 
         if not isinstance(data, dict):
             data = {}
-        _RAW_CONFIG_CACHE[path_key] = (cache_key[0], cache_key[1], copy.deepcopy(data))
+        stored = copy.deepcopy(data)
+        view = _ReadonlyConfigView(stored)
+        _RAW_CONFIG_CACHE[path_key] = (cache_key[0], cache_key[1], stored, view)
         return data
 
 
 def read_raw_config_readonly() -> Dict[str, Any]:
     """Fast-path variant of ``read_raw_config()`` for callers that ONLY READ.
 
-    Returns the cached raw YAML dict directly without the defensive deepcopy
-    that ``read_raw_config()`` applies. **Mutating the returned dict corrupts
-    the in-process cache** — only use when your code path will not write to
-    the result. If you need to mutate or pass to ``save_config``, call
+    Returns a read-only view over the cached raw YAML dict without the
+    defensive deepcopy that ``read_raw_config()`` applies. Mutations raise
+    ``TypeError``. If you need to mutate or pass to ``save_config``, call
     ``read_raw_config()`` instead.
     """
     with _CONFIG_LOCK:
@@ -5279,25 +5312,26 @@ def read_raw_config_readonly() -> Dict[str, Any]:
             st = config_path.stat()
             cache_key = (st.st_mtime_ns, st.st_size)
         except (FileNotFoundError, OSError):
-            return {}
+            return _ReadonlyConfigView({})
 
         path_key = str(config_path)
         cached = _RAW_CONFIG_CACHE.get(path_key)
         if cached is not None and cached[:2] == cache_key:
-            return cached[2]
+            return cached[3]
 
         try:
             with open(config_path, encoding="utf-8") as f:
                 data = yaml.safe_load(f) or {}
         except Exception as e:
             _warn_config_parse_failure(config_path, e)
-            return {}
+            return _ReadonlyConfigView({})
 
         if not isinstance(data, dict):
             data = {}
         stored = copy.deepcopy(data)
-        _RAW_CONFIG_CACHE[path_key] = (cache_key[0], cache_key[1], stored)
-        return stored
+        view = _ReadonlyConfigView(stored)
+        _RAW_CONFIG_CACHE[path_key] = (cache_key[0], cache_key[1], stored, view)
+        return view
 
 
 def load_config() -> Dict[str, Any]:
@@ -5320,22 +5354,16 @@ def load_config() -> Dict[str, Any]:
 def load_config_readonly() -> Dict[str, Any]:
     """Fast-path variant of ``load_config()`` for callers that ONLY READ.
 
-    Returns the cached config dict directly without the defensive deepcopy
-    that ``load_config()`` applies. **Mutating the returned dict (or any
-    nested structure) corrupts the in-process cache for every subsequent
-    caller** — only use this when you are absolutely sure your code path
-    will not write to the result. If you need to mutate or pass to
-    ``save_config``, call ``load_config()`` instead.
+    Returns a read-only view over the cached config dict without the
+    defensive deepcopy that ``load_config()`` applies. Mutations raise
+    ``TypeError``. If you need to mutate or pass to ``save_config``, call
+    ``load_config()`` instead.
 
     Why this exists: ``load_config()`` cache-hit cost is ~265us per call,
     half of which (~135us) is the defensive deepcopy. The agent loop calls
     into config reads (timeouts, thresholds, feature flags) ~20-50x per
     conversation; skipping deepcopy here removes a measurable allocation
     source and the GC pressure that comes with it.
-
-    Note: this returns a plain ``dict`` (not ``MappingProxyType``) so
-    existing ``isinstance(x, dict)`` guards downstream keep working. The
-    safety guarantee is purely documented, not enforced — be careful.
     """
     return _load_config_impl(want_deepcopy=False)
 
@@ -5442,7 +5470,7 @@ def _load_config_impl(*, want_deepcopy: bool) -> Dict[str, Any]:
 
         cached = _LOAD_CONFIG_CACHE.get(path_key)
         if cached is not None and cache_key is not None and cached[:2] == cache_key:
-            return copy.deepcopy(cached[2]) if want_deepcopy else cached[2]
+            return copy.deepcopy(cached[2]) if want_deepcopy else cached[3]
 
         config = copy.deepcopy(DEFAULT_CONFIG)
 
@@ -5471,14 +5499,16 @@ def _load_config_impl(*, want_deepcopy: bool) -> Dict[str, Any]:
             # cached value, and ``load_config_readonly()`` (deepcopy=False)
             # callers all see the same stable cached object.
             cached_copy = copy.deepcopy(expanded)
-            _LOAD_CONFIG_CACHE[path_key] = (cache_key[0], cache_key[1], cached_copy)
-            # On the readonly path return the same cached object subsequent
-            # calls will see — keeps "two readonly calls return the same
-            # object" invariant that callers may rely on for identity checks.
+            readonly_view = _ReadonlyConfigView(cached_copy)
+            _LOAD_CONFIG_CACHE[path_key] = (
+                cache_key[0], cache_key[1], cached_copy, readonly_view,
+            )
             if not want_deepcopy:
-                return cached_copy
+                return readonly_view
         else:
             _LOAD_CONFIG_CACHE.pop(path_key, None)
+        if not want_deepcopy:
+            return _ReadonlyConfigView(expanded)
         # First-load result is a fresh dict (not aliased to the cache); safe
         # to return directly. For the deepcopy=True path this is the
         # canonical "freshly-built mutable result" the function has always

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -5264,6 +5264,42 @@ def read_raw_config() -> Dict[str, Any]:
         return data
 
 
+def read_raw_config_readonly() -> Dict[str, Any]:
+    """Fast-path variant of ``read_raw_config()`` for callers that ONLY READ.
+
+    Returns the cached raw YAML dict directly without the defensive deepcopy
+    that ``read_raw_config()`` applies. **Mutating the returned dict corrupts
+    the in-process cache** — only use when your code path will not write to
+    the result. If you need to mutate or pass to ``save_config``, call
+    ``read_raw_config()`` instead.
+    """
+    with _CONFIG_LOCK:
+        try:
+            config_path = get_config_path()
+            st = config_path.stat()
+            cache_key = (st.st_mtime_ns, st.st_size)
+        except (FileNotFoundError, OSError):
+            return {}
+
+        path_key = str(config_path)
+        cached = _RAW_CONFIG_CACHE.get(path_key)
+        if cached is not None and cached[:2] == cache_key:
+            return cached[2]
+
+        try:
+            with open(config_path, encoding="utf-8") as f:
+                data = yaml.safe_load(f) or {}
+        except Exception as e:
+            _warn_config_parse_failure(config_path, e)
+            return {}
+
+        if not isinstance(data, dict):
+            data = {}
+        stored = copy.deepcopy(data)
+        _RAW_CONFIG_CACHE[path_key] = (cache_key[0], cache_key[1], stored)
+        return stored
+
+
 def load_config() -> Dict[str, Any]:
     """Load configuration from ~/.hermes/config.yaml.
 

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -27,7 +27,7 @@ import threading
 import time
 from dataclasses import dataclass
 from pathlib import Path
-from collections.abc import Iterator, Mapping
+from collections.abc import Iterator
 from typing import Dict, Any, Optional, List, Tuple
 
 from hermes_cli.secret_prompt import masked_secret_prompt
@@ -239,17 +239,19 @@ _RAW_CONFIG_CACHE: Dict[str, Tuple[int, int, Dict[str, Any], "_ReadonlyConfigVie
 _CONFIG_LOCK = threading.RLock()
 
 
-class _ReadonlyConfigView(Mapping):
-    """Zero-copy read-only facade over a cached config dict.
+class _ReadonlyConfigView(dict):
+    """Zero-copy read-only ``dict`` subclass over a cached config mapping.
 
-    Prevents accidental in-place mutation of the shared config cache without
-    paying for a defensive deepcopy on every readonly load.
+    Subclasses ``dict`` so existing ``isinstance(cfg, dict)`` guards keep
+    working. Reads proxy the backing store; writes raise ``TypeError``.
     """
 
     __slots__ = ("_data",)
 
-    def __init__(self, data: Dict[str, Any]) -> None:
-        self._data = data
+    def __new__(cls, data: Dict[str, Any]) -> "_ReadonlyConfigView":
+        inst = super().__new__(cls)
+        object.__setattr__(inst, "_data", data)
+        return inst
 
     def __getitem__(self, key: str) -> Any:
         val = self._data[key]
@@ -263,10 +265,48 @@ class _ReadonlyConfigView(Mapping):
     def __len__(self) -> int:
         return len(self._data)
 
+    def __contains__(self, key: object) -> bool:
+        return key in self._data
+
     def get(self, key: str, default: Any = None) -> Any:
         if key not in self._data:
             return default
         return self[key]
+
+    def keys(self):
+        return self._data.keys()
+
+    def values(self):
+        for key in self._data:
+            yield self[key]
+
+    def items(self):
+        for key in self._data:
+            yield key, self[key]
+
+    def __setitem__(self, key, value) -> None:
+        raise TypeError("config is read-only; use load_config() to mutate")
+
+    def __delitem__(self, key) -> None:
+        raise TypeError("config is read-only; use load_config() to mutate")
+
+    def update(self, *args, **kwargs) -> None:
+        raise TypeError("config is read-only; use load_config() to mutate")
+
+    def pop(self, *args, **kwargs):
+        raise TypeError("config is read-only; use load_config() to mutate")
+
+    def popitem(self):
+        raise TypeError("config is read-only; use load_config() to mutate")
+
+    def clear(self) -> None:
+        raise TypeError("config is read-only; use load_config() to mutate")
+
+    def setdefault(self, key, default=None):
+        if key in self._data:
+            return self[key]
+        return default
+
 
 # Env var names written to .env that aren't in OPTIONAL_ENV_VARS
 # (managed by setup/provider flows directly).

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -3473,72 +3473,95 @@ class SessionDB:
                     matches = [dict(row) for row in cursor.fetchall()]
 
         # Add surrounding context (1 message before + after each match).
-        # Done outside the lock so we don't hold it across N sequential queries.
-        for match in matches:
-            try:
-                with self._lock:
-                    ctx_cursor = self._conn.execute(
-                        """WITH target AS (
-                               SELECT session_id, timestamp, id
-                               FROM messages
-                               WHERE id = ?
-                           )
-                           SELECT role, content
-                           FROM (
-                               SELECT m.id, m.timestamp, m.role, m.content
-                               FROM messages m
-                               JOIN target t ON t.session_id = m.session_id
-                               WHERE (m.timestamp < t.timestamp)
-                                  OR (m.timestamp = t.timestamp AND m.id < t.id)
-                               ORDER BY m.timestamp DESC, m.id DESC
-                               LIMIT 1
-                           )
-                           UNION ALL
-                           SELECT role, content
-                           FROM messages
-                           WHERE id = ?
-                           UNION ALL
-                           SELECT role, content
-                           FROM (
-                               SELECT m.id, m.timestamp, m.role, m.content
-                               FROM messages m
-                               JOIN target t ON t.session_id = m.session_id
-                               WHERE (m.timestamp > t.timestamp)
-                                  OR (m.timestamp = t.timestamp AND m.id > t.id)
-                               ORDER BY m.timestamp ASC, m.id ASC
-                               LIMIT 1
-                           )""",
-                        (match["id"], match["id"]),
-                    )
-                    context_msgs = []
-                    for r in ctx_cursor.fetchall():
-                        raw = r["content"]
-                        decoded = self._decode_content(raw)
-                        # Multimodal context: render a compact text-only
-                        # summary for search previews.
-                        if isinstance(decoded, list):
-                            text_parts = [
-                                p.get("text", "") for p in decoded
-                                if isinstance(p, dict) and p.get("type") == "text"
-                            ]
-                            text = " ".join(t for t in text_parts if t).strip()
-                            preview = text or "[multimodal content]"
-                        elif isinstance(decoded, str):
-                            preview = decoded
-                        else:
-                            preview = ""
-                        context_msgs.append(
-                            {"role": r["role"], "content": preview[:200]}
-                        )
-                match["context"] = context_msgs
-            except Exception:
-                match["context"] = []
+        if matches:
+            contexts = self._fetch_search_match_contexts([m["id"] for m in matches])
+            for match in matches:
+                match["context"] = contexts.get(match["id"], [])
 
         # Remove full content from result (snippet is enough, saves tokens)
         for match in matches:
             match.pop("content", None)
 
         return matches
+
+    def _fetch_search_match_contexts(
+        self,
+        match_ids: List[int],
+    ) -> Dict[int, List[Dict[str, Any]]]:
+        """Fetch before/anchor/after context for many search hits in one query."""
+        if not match_ids:
+            return {}
+
+        placeholders = ",".join("?" for _ in match_ids)
+        sql = f"""
+            WITH targets AS (
+                SELECT id, session_id, timestamp
+                FROM messages
+                WHERE id IN ({placeholders})
+            ),
+            before_msgs AS (
+                SELECT t.id AS match_id, m.role, m.content,
+                       ROW_NUMBER() OVER (
+                           PARTITION BY t.id
+                           ORDER BY m.timestamp DESC, m.id DESC
+                       ) AS rn
+                FROM targets t
+                JOIN messages m ON m.session_id = t.session_id
+                WHERE (m.timestamp < t.timestamp)
+                   OR (m.timestamp = t.timestamp AND m.id < t.id)
+            ),
+            after_msgs AS (
+                SELECT t.id AS match_id, m.role, m.content,
+                       ROW_NUMBER() OVER (
+                           PARTITION BY t.id
+                           ORDER BY m.timestamp ASC, m.id ASC
+                       ) AS rn
+                FROM targets t
+                JOIN messages m ON m.session_id = t.session_id
+                WHERE (m.timestamp > t.timestamp)
+                   OR (m.timestamp = t.timestamp AND m.id > t.id)
+            ),
+            anchor AS (
+                SELECT t.id AS match_id, m.role, m.content
+                FROM targets t
+                JOIN messages m ON m.id = t.id
+            )
+            SELECT match_id, role, content, 0 AS sort_order
+            FROM before_msgs WHERE rn = 1
+            UNION ALL
+            SELECT match_id, role, content, 1 FROM anchor
+            UNION ALL
+            SELECT match_id, role, content, 2
+            FROM after_msgs WHERE rn = 1
+            ORDER BY match_id, sort_order
+        """
+
+        contexts: Dict[int, List[Dict[str, Any]]] = {mid: [] for mid in match_ids}
+        try:
+            with self._lock:
+                rows = self._conn.execute(sql, tuple(match_ids)).fetchall()
+        except Exception:
+            return contexts
+
+        for row in rows:
+            match_id = row["match_id"]
+            raw = row["content"]
+            decoded = self._decode_content(raw)
+            if isinstance(decoded, list):
+                text_parts = [
+                    p.get("text", "") for p in decoded
+                    if isinstance(p, dict) and p.get("type") == "text"
+                ]
+                text = " ".join(t for t in text_parts if t).strip()
+                preview = text or "[multimodal content]"
+            elif isinstance(decoded, str):
+                preview = decoded
+            else:
+                preview = ""
+            contexts.setdefault(match_id, []).append(
+                {"role": row["role"], "content": preview[:200]}
+            )
+        return contexts
 
     def search_sessions_by_id(
         self,

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -1704,6 +1704,27 @@ class SessionDB:
             row = cursor.fetchone()
         return dict(row) if row else None
 
+    def get_transcript_cache_token(self, session_id: str) -> Optional[Tuple[int, int]]:
+        """Return ``(active_message_count, max_active_message_id)`` for cache keys.
+
+        Counts only ``active=1`` rows — matches what ``load_transcript`` returns
+        and changes on append, rewrite, and rewind even when ``message_count``
+        on the session row is stale.
+        """
+        if not session_id:
+            return None
+        with self._lock:
+            row = self._conn.execute(
+                "SELECT COUNT(*), MAX(id) FROM messages "
+                "WHERE session_id = ? AND active = 1",
+                (session_id,),
+            ).fetchone()
+        if row is None:
+            return None
+        count = int(row[0] or 0)
+        max_id = int(row[1]) if row[1] is not None else 0
+        return (count, max_id)
+
     def resolve_session_id(self, session_id_or_prefix: str) -> Optional[str]:
         """Resolve an exact or uniquely prefixed session ID to the full ID.
 

--- a/run_agent.py
+++ b/run_agent.py
@@ -2220,6 +2220,18 @@ class AIAgent:
             return redacted
         return content
 
+    @staticmethod
+    def _session_log_tail_state(msg: Dict[str, Any]) -> tuple:
+        """Cheap fingerprint of the last message for JSON snapshot debounce."""
+        content = msg.get("content")
+        if isinstance(content, str):
+            tail = content[:512]
+        elif isinstance(content, list):
+            tail = str(content)[:512]
+        else:
+            tail = str(content)
+        return (msg.get("role"), tail)
+
     def _save_session_log(self, messages: List[Dict[str, Any]] = None):
         """Optional per-session JSON snapshot writer.
 
@@ -2244,7 +2256,7 @@ class AIAgent:
         _log_state = (
             getattr(self, "session_id", None),
             len(messages),
-            id(messages[-1]) if messages else None,
+            self._session_log_tail_state(messages[-1]),
         )
         if _log_state == getattr(self, "_last_session_log_state", None):
             return

--- a/run_agent.py
+++ b/run_agent.py
@@ -1487,6 +1487,10 @@ class AIAgent:
         self._save_session_log(messages)
         self._flush_messages_to_session_db(messages, conversation_history)
 
+    def _reset_flush_scan_cursor(self) -> None:
+        """Reset DB flush scan cursor (call on session id change)."""
+        self._flush_scan_cursor = 0
+
     def _drop_trailing_empty_response_scaffolding(self, messages: List[Dict]) -> None:
         """Remove private empty-response retry/failure scaffolding from transcript tails.
 
@@ -1560,23 +1564,12 @@ class AIAgent:
             # Retry row creation if the earlier attempt failed transiently.
             if not self._session_db_created:
                 self._ensure_db_session()
-            # Positional flushing used to slice at
-            # max(len(conversation_history), _last_flushed_db_idx). That
-            # assumes the live `messages` list is the original history plus a
-            # new tail. repair_message_sequence can shrink/merge the history
-            # copy before the final flush, making len(conversation_history)
-            # larger than len(messages); the slice is then empty and delivered
-            # assistant responses never reach state.db (#46053).
-            #
-            # Track object identities instead. `messages` is a shallow copy of
-            # `conversation_history`, so history dicts are skipped by identity,
-            # and new dicts appended during this turn are written once even if
-            # repair compacts the list around them.
             current_session_id = getattr(self, "session_id", None)
             flushed_session_id = getattr(self, "_flushed_db_message_session_id", None)
             if flushed_session_id != current_session_id or self._last_flushed_db_idx == 0:
                 self._flushed_db_message_ids = set()
                 self._flushed_db_message_session_id = current_session_id
+                self._flush_scan_cursor = 0
             flushed_ids = getattr(self, "_flushed_db_message_ids", None)
             if not isinstance(flushed_ids, set):
                 flushed_ids = set()
@@ -1586,7 +1579,10 @@ class AIAgent:
                 if isinstance(item, dict)
             }
 
-            for msg in messages:
+            scan_from = getattr(self, "_flush_scan_cursor", 0)
+            if scan_from > len(messages):
+                scan_from = 0
+            for msg in messages[scan_from:]:
                 if not isinstance(msg, dict):
                     continue
                 msg_id = id(msg)
@@ -1635,6 +1631,7 @@ class AIAgent:
                 )
                 flushed_ids.add(msg_id)
             self._last_flushed_db_idx = len(messages)
+            self._flush_scan_cursor = len(messages)
         except Exception as e:
             logger.warning("Session DB append_message failed: %s", e)
 
@@ -2244,6 +2241,14 @@ class AIAgent:
         if not messages:
             return
 
+        _log_state = (
+            getattr(self, "session_id", None),
+            len(messages),
+            id(messages[-1]) if messages else None,
+        )
+        if _log_state == getattr(self, "_last_session_log_state", None):
+            return
+
         # Re-derive the target path each call so /branch and /compress
         # session-id changes land in the right file without any re-point
         # bookkeeping at the call sites.
@@ -2303,6 +2308,7 @@ class AIAgent:
                 indent=2,
                 default=str,
             )
+            self._last_session_log_state = _log_state
 
         except Exception as e:
             if self.verbose_logging:
@@ -4370,13 +4376,19 @@ class AIAgent:
         Custom/local models absent from models.dev would otherwise be
         misclassified as non-vision and have their images stripped.
         """
+        provider = (getattr(self, "provider", "") or "").strip()
+        model = (getattr(self, "model", "") or "").strip()
+        cache_key = (provider, model)
+        cached = getattr(self, "_supports_vision_cache", None)
+        if cached is not None and cached[0] == cache_key:
+            return cached[1]
         try:
-            from hermes_cli.config import load_config
+            from hermes_cli.config import load_config_readonly
             from agent.image_routing import _lookup_supports_vision
-            cfg = load_config()
-            provider = (getattr(self, "provider", "") or "").strip()
-            model = (getattr(self, "model", "") or "").strip()
-            return _lookup_supports_vision(provider, model, cfg) is True
+            cfg = load_config_readonly()
+            result = _lookup_supports_vision(provider, model, cfg) is True
+            self._supports_vision_cache = (cache_key, result)
+            return result
         except Exception:
             return False
 
@@ -4475,17 +4487,26 @@ class AIAgent:
         if self._model_supports_vision():
             return api_messages
 
-        # Non-vision Anthropic model (rare today, but keep the fallback for
-        # compat): replace each image part with a vision_analyze text note.
-        transformed = copy.deepcopy(api_messages)
-        for msg in transformed:
+        # Non-vision model: shallow-copy only messages that carry images.
+        return self._strip_image_parts_shallow_copy(api_messages)
+
+    def _strip_image_parts_shallow_copy(self, api_messages: list) -> list:
+        """Replace image parts with text notes, copying only affected messages."""
+        transformed = list(api_messages)
+        changed = False
+        for idx, msg in enumerate(transformed):
             if not isinstance(msg, dict):
                 continue
-            msg["content"] = self._preprocess_anthropic_content(
-                msg.get("content"),
-                str(msg.get("role", "user") or "user"),
+            if not self._content_has_image_parts(msg.get("content")):
+                continue
+            if transformed[idx] is api_messages[idx]:
+                transformed[idx] = msg.copy()
+            transformed[idx]["content"] = self._preprocess_anthropic_content(
+                transformed[idx].get("content"),
+                str(transformed[idx].get("role", "user") or "user"),
             )
-        return transformed
+            changed = True
+        return transformed if changed else api_messages
 
     def _prepare_messages_for_non_vision_model(self, api_messages: list) -> list:
         """Strip native image parts when the active model lacks vision.
@@ -4505,19 +4526,7 @@ class AIAgent:
         if self._model_supports_vision():
             return api_messages
 
-        transformed = copy.deepcopy(api_messages)
-        for msg in transformed:
-            if not isinstance(msg, dict):
-                continue
-            # Reuse the Anthropic text-fallback preprocessor — the behaviour is
-            # identical (walk content parts, replace images with cached
-            # descriptions, merge back into a single text or structured
-            # content). Naming is historical.
-            msg["content"] = self._preprocess_anthropic_content(
-                msg.get("content"),
-                str(msg.get("role", "user") or "user"),
-            )
-        return transformed
+        return self._strip_image_parts_shallow_copy(api_messages)
 
     def _tool_result_content_for_active_model(self, tool_name: str, result: Any) -> Any:
         """Return the tool message content that is safe for the active model.

--- a/tests/agent/test_prompt_caching.py
+++ b/tests/agent/test_prompt_caching.py
@@ -68,7 +68,7 @@ class TestApplyAnthropicCacheControl:
         result = apply_anthropic_cache_control([])
         assert result == []
 
-    def test_returns_deep_copy(self):
+    def test_returns_shallow_copy_of_marked_messages(self):
         msgs = [{"role": "user", "content": "Hello"}]
         result = apply_anthropic_cache_control(msgs)
         assert result is not msgs

--- a/tests/gateway/test_transcript_cache.py
+++ b/tests/gateway/test_transcript_cache.py
@@ -1,0 +1,73 @@
+"""Tests for gateway transcript cache (_load_transcript_sync)."""
+
+from __future__ import annotations
+
+from collections import OrderedDict
+from unittest.mock import MagicMock
+
+import pytest
+
+from gateway.config import GatewayConfig
+from gateway.run import GatewayRunner
+
+
+@pytest.fixture
+def runner():
+    gw = GatewayRunner(GatewayConfig())
+    gw._transcript_cache = OrderedDict()
+    gw._session_db = MagicMock()
+    gw.session_store = MagicMock()
+    return gw
+
+
+def test_transcript_cache_hit_skips_load_transcript(runner):
+    history = [{"role": "user", "content": "hello"}]
+    runner._session_db.get_session.return_value = {"message_count": 1}
+    runner.session_store.load_transcript.return_value = history
+
+    first = runner._load_transcript_sync("session-1", "key-1")
+    second = runner._load_transcript_sync("session-1", "key-1")
+
+    assert first is history
+    assert second is history
+    runner.session_store.load_transcript.assert_called_once_with("session-1")
+
+
+def test_transcript_cache_miss_on_message_count_change(runner):
+    history_v1 = [{"role": "user", "content": "v1"}]
+    history_v2 = history_v1 + [{"role": "assistant", "content": "v2"}]
+    runner.session_store.load_transcript.side_effect = [history_v1, history_v2]
+
+    runner._session_db.get_session.return_value = {"message_count": 1}
+    runner._load_transcript_sync("session-1", "key-1")
+
+    runner._session_db.get_session.return_value = {"message_count": 2}
+    second = runner._load_transcript_sync("session-1", "key-1")
+
+    assert second is history_v2
+    assert runner.session_store.load_transcript.call_count == 2
+
+
+def test_transcript_cache_invalidated_on_evict(runner):
+    history = [{"role": "user", "content": "hello"}]
+    runner._session_db.get_session.return_value = {"message_count": 1}
+    runner.session_store.load_transcript.return_value = history
+
+    runner._load_transcript_sync("session-1", "key-1")
+    runner._invalidate_transcript_cache("key-1")
+    runner._load_transcript_sync("session-1", "key-1")
+
+    assert runner.session_store.load_transcript.call_count == 2
+
+
+def test_transcript_cache_miss_on_session_id_change(runner):
+    history_a = [{"role": "user", "content": "a"}]
+    history_b = [{"role": "user", "content": "b"}]
+    runner.session_store.load_transcript.side_effect = [history_a, history_b]
+    runner._session_db.get_session.return_value = {"message_count": 1}
+
+    runner._load_transcript_sync("session-a", "key-1")
+    second = runner._load_transcript_sync("session-b", "key-1")
+
+    assert second is history_b
+    assert runner.session_store.load_transcript.call_count == 2

--- a/tests/gateway/test_transcript_cache.py
+++ b/tests/gateway/test_transcript_cache.py
@@ -22,7 +22,7 @@ def runner():
 
 def test_transcript_cache_hit_skips_load_transcript(runner):
     history = [{"role": "user", "content": "hello"}]
-    runner._session_db.get_session.return_value = {"message_count": 1}
+    runner._session_db.get_transcript_cache_token.return_value = (1, 42)
     runner.session_store.load_transcript.return_value = history
 
     first = runner._load_transcript_sync("session-1", "key-1")
@@ -33,15 +33,31 @@ def test_transcript_cache_hit_skips_load_transcript(runner):
     runner.session_store.load_transcript.assert_called_once_with("session-1")
 
 
-def test_transcript_cache_miss_on_message_count_change(runner):
+def test_transcript_cache_miss_on_token_change(runner):
     history_v1 = [{"role": "user", "content": "v1"}]
     history_v2 = history_v1 + [{"role": "assistant", "content": "v2"}]
     runner.session_store.load_transcript.side_effect = [history_v1, history_v2]
 
-    runner._session_db.get_session.return_value = {"message_count": 1}
+    runner._session_db.get_transcript_cache_token.return_value = (1, 10)
     runner._load_transcript_sync("session-1", "key-1")
 
-    runner._session_db.get_session.return_value = {"message_count": 2}
+    runner._session_db.get_transcript_cache_token.return_value = (2, 11)
+    second = runner._load_transcript_sync("session-1", "key-1")
+
+    assert second is history_v2
+    assert runner.session_store.load_transcript.call_count == 2
+
+
+def test_transcript_cache_miss_when_head_id_changes_same_count(runner):
+    """Rewrites/rewinds can change active head id without changing count."""
+    history_v1 = [{"role": "user", "content": "before"}]
+    history_v2 = [{"role": "user", "content": "after"}]
+    runner.session_store.load_transcript.side_effect = [history_v1, history_v2]
+
+    runner._session_db.get_transcript_cache_token.return_value = (1, 10)
+    runner._load_transcript_sync("session-1", "key-1")
+
+    runner._session_db.get_transcript_cache_token.return_value = (1, 20)
     second = runner._load_transcript_sync("session-1", "key-1")
 
     assert second is history_v2
@@ -50,7 +66,7 @@ def test_transcript_cache_miss_on_message_count_change(runner):
 
 def test_transcript_cache_invalidated_on_evict(runner):
     history = [{"role": "user", "content": "hello"}]
-    runner._session_db.get_session.return_value = {"message_count": 1}
+    runner._session_db.get_transcript_cache_token.return_value = (1, 42)
     runner.session_store.load_transcript.return_value = history
 
     runner._load_transcript_sync("session-1", "key-1")
@@ -60,11 +76,23 @@ def test_transcript_cache_invalidated_on_evict(runner):
     assert runner.session_store.load_transcript.call_count == 2
 
 
+def test_transcript_cache_invalidated_by_session_id(runner):
+    history = [{"role": "user", "content": "hello"}]
+    runner._session_db.get_transcript_cache_token.return_value = (1, 42)
+    runner.session_store.load_transcript.return_value = history
+
+    runner._load_transcript_sync("session-1", "key-1")
+    runner._invalidate_transcript_cache_for_session_id("session-1")
+    runner._load_transcript_sync("session-1", "key-1")
+
+    assert runner.session_store.load_transcript.call_count == 2
+
+
 def test_transcript_cache_miss_on_session_id_change(runner):
     history_a = [{"role": "user", "content": "a"}]
     history_b = [{"role": "user", "content": "b"}]
     runner.session_store.load_transcript.side_effect = [history_a, history_b]
-    runner._session_db.get_session.return_value = {"message_count": 1}
+    runner._session_db.get_transcript_cache_token.return_value = (1, 1)
 
     runner._load_transcript_sync("session-a", "key-1")
     second = runner._load_transcript_sync("session-b", "key-1")

--- a/tests/hermes_cli/test_config_readonly.py
+++ b/tests/hermes_cli/test_config_readonly.py
@@ -82,3 +82,29 @@ def test_load_config_readonly_rejects_mutation(monkeypatch, tmp_path):
     cfg = load_config_readonly()
     with pytest.raises(TypeError):
         cfg["agent"]["max_turns"] = 99
+
+
+def test_readonly_views_pass_isinstance_dict_checks(monkeypatch, tmp_path):
+    """Readonly config must satisfy existing isinstance(cfg, dict) guards."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    _write_config(
+        tmp_path,
+        """\
+        providers:
+          openrouter:
+            request_timeout_seconds: 120
+            models:
+              test-model:
+                timeout_seconds: 90
+        agent:
+          max_turns: 42
+        """,
+    )
+
+    from hermes_cli.config import load_config_readonly
+    from hermes_cli.timeouts import get_provider_request_timeout
+
+    cfg = load_config_readonly()
+    assert isinstance(cfg, dict)
+    assert isinstance(cfg.get("providers"), dict)
+    assert get_provider_request_timeout("openrouter", "test-model") == 90.0

--- a/tests/hermes_cli/test_config_readonly.py
+++ b/tests/hermes_cli/test_config_readonly.py
@@ -4,13 +4,15 @@ from __future__ import annotations
 
 import textwrap
 
+import pytest
+
 
 def _write_config(tmp_path, body: str) -> None:
     (tmp_path / "config.yaml").write_text(textwrap.dedent(body), encoding="utf-8")
 
 
 def test_read_raw_config_readonly_returns_cached_object(monkeypatch, tmp_path):
-    """Cache hits return the same dict object — callers must not mutate."""
+    """Cache hits return the same view object — callers must not mutate."""
     monkeypatch.setenv("HERMES_HOME", str(tmp_path))
     _write_config(tmp_path, "model:\n  default: alpha\n")
 
@@ -20,6 +22,19 @@ def test_read_raw_config_readonly_returns_cached_object(monkeypatch, tmp_path):
     second = read_raw_config_readonly()
     assert first is second
     assert first["model"]["default"] == "alpha"
+
+
+def test_read_raw_config_readonly_rejects_mutation(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    _write_config(tmp_path, "model:\n  default: alpha\n")
+
+    from hermes_cli.config import read_raw_config_readonly
+
+    cfg = read_raw_config_readonly()
+    with pytest.raises(TypeError):
+        cfg["model"] = {}
+    with pytest.raises(TypeError):
+        cfg["model"]["default"] = "mutated"
 
 
 def test_read_raw_config_returns_defensive_copy(monkeypatch, tmp_path):
@@ -50,3 +65,20 @@ def test_load_config_readonly_matches_load_config_values(monkeypatch, tmp_path):
     from hermes_cli.config import load_config, load_config_readonly
 
     assert load_config_readonly()["agent"]["max_turns"] == load_config()["agent"]["max_turns"]
+
+
+def test_load_config_readonly_rejects_mutation(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    _write_config(
+        tmp_path,
+        """\
+        agent:
+          max_turns: 42
+        """,
+    )
+
+    from hermes_cli.config import load_config_readonly
+
+    cfg = load_config_readonly()
+    with pytest.raises(TypeError):
+        cfg["agent"]["max_turns"] = 99

--- a/tests/hermes_cli/test_config_readonly.py
+++ b/tests/hermes_cli/test_config_readonly.py
@@ -1,0 +1,52 @@
+"""Tests for read-only config fast paths (load_config_readonly, read_raw_config_readonly)."""
+
+from __future__ import annotations
+
+import textwrap
+
+
+def _write_config(tmp_path, body: str) -> None:
+    (tmp_path / "config.yaml").write_text(textwrap.dedent(body), encoding="utf-8")
+
+
+def test_read_raw_config_readonly_returns_cached_object(monkeypatch, tmp_path):
+    """Cache hits return the same dict object — callers must not mutate."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    _write_config(tmp_path, "model:\n  default: alpha\n")
+
+    from hermes_cli.config import read_raw_config_readonly
+
+    first = read_raw_config_readonly()
+    second = read_raw_config_readonly()
+    assert first is second
+    assert first["model"]["default"] == "alpha"
+
+
+def test_read_raw_config_returns_defensive_copy(monkeypatch, tmp_path):
+    """Mutating read_raw_config() must not affect read_raw_config_readonly() cache."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    _write_config(tmp_path, "model:\n  default: alpha\n")
+
+    from hermes_cli.config import read_raw_config, read_raw_config_readonly
+
+    cached = read_raw_config_readonly()
+    mutable = read_raw_config()
+    mutable["model"]["default"] = "mutated"
+
+    assert read_raw_config_readonly()["model"]["default"] == "alpha"
+    assert cached["model"]["default"] == "alpha"
+
+
+def test_load_config_readonly_matches_load_config_values(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    _write_config(
+        tmp_path,
+        """\
+        agent:
+          max_turns: 42
+        """,
+    )
+
+    from hermes_cli.config import load_config, load_config_readonly
+
+    assert load_config_readonly()["agent"]["max_turns"] == load_config()["agent"]["max_turns"]

--- a/tests/run_agent/test_860_dedup.py
+++ b/tests/run_agent/test_860_dedup.py
@@ -99,6 +99,30 @@ class TestFlushDeduplication:
                 agent._flush_messages_to_session_db(messages, conversation_history)
                 rows = db.get_messages(agent.session_id)
                 assert len(rows) == 3, f"Expected 3 total messages, got {len(rows)}"
+                assert agent._flush_scan_cursor == len(messages)
+            finally:
+                db.close()
+
+    def test_flush_scan_cursor_resets_on_session_change(self):
+        """Cursor resets when session_id changes so a new session is fully scanned."""
+        from hermes_state import SessionDB
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = Path(tmpdir) / "test.db"
+            db = SessionDB(db_path=db_path)
+            try:
+                agent = self._make_agent(db)
+                messages = [{"role": "user", "content": "hello"}]
+                agent._flush_messages_to_session_db(messages, [])
+                assert agent._flush_scan_cursor == 1
+
+                agent.session_id = "other-session-860"
+                agent._session_db_created = False
+                agent._ensure_db_session()
+                agent._flush_messages_to_session_db(messages, [])
+                assert agent._flush_scan_cursor == 1
+                rows = db.get_messages("other-session-860")
+                assert len(rows) == 1
             finally:
                 db.close()
 

--- a/tests/run_agent/test_message_sequence_repair.py
+++ b/tests/run_agent/test_message_sequence_repair.py
@@ -272,6 +272,25 @@ def test_cursor_helper_safe_without_cursor_attribute():
     assert not hasattr(agent, "_last_flushed_db_idx")
 
 
+def test_flush_scan_cursor_resets_when_repair_compacts_list():
+    """Incremental DB flush scan cursor must reset after repair shrinks the
+    list, or unflushed rows shifted below the cursor are skipped."""
+    agent = _bare_agent()
+    flushed_a = {"role": "user", "content": "first"}
+    flushed_b = {"role": "user", "content": "second"}
+    unflushed_assistant = {"role": "assistant", "content": "answer"}
+    messages = [flushed_a, flushed_b, unflushed_assistant]
+    agent._last_flushed_db_idx = 2
+    agent._flush_scan_cursor = 2
+    agent._flushed_db_message_ids = {id(flushed_a), id(flushed_b)}
+
+    repairs = repair_message_sequence_with_cursor(agent, messages)
+
+    assert repairs == 1
+    assert len(messages) == 2
+    assert agent._flush_scan_cursor == 0
+
+
 def test_flush_guard_clamps_overshooting_cursor():
     """_flush_messages_to_session_db safety net: an overshooting cursor must
     not produce a negative-start slice that skips everything (#44837)."""

--- a/tests/run_agent/test_vision_aware_preprocessing.py
+++ b/tests/run_agent/test_vision_aware_preprocessing.py
@@ -155,6 +155,7 @@ class TestModelSupportsVision:
         with patch("agent.models_dev.get_model_capabilities", return_value=fake_caps):
             assert agent._model_supports_vision() is True
         fake_caps.supports_vision = False
+        agent._supports_vision_cache = None
         with patch("agent.models_dev.get_model_capabilities", return_value=fake_caps):
             assert agent._model_supports_vision() is False
 
@@ -172,7 +173,7 @@ class TestModelSupportsVision:
         agent = _make_agent()
         agent.provider = "custom"
         agent.model = "my-llava"
-        with patch("hermes_cli.config.load_config", return_value={"model": {"supports_vision": True}}), \
+        with patch("hermes_cli.config.load_config_readonly", return_value={"model": {"supports_vision": True}}), \
              patch("agent.models_dev.get_model_capabilities", return_value=None):
             assert agent._model_supports_vision() is True
 
@@ -181,7 +182,7 @@ class TestModelSupportsVision:
         agent.provider = "custom"
         agent.model = "my-llava"
         cfg = {"providers": {"custom": {"models": {"my-llava": {"supports_vision": True}}}}}
-        with patch("hermes_cli.config.load_config", return_value=cfg), \
+        with patch("hermes_cli.config.load_config_readonly", return_value=cfg), \
              patch("agent.models_dev.get_model_capabilities", return_value=None):
             assert agent._model_supports_vision() is True
 
@@ -196,7 +197,7 @@ class TestModelSupportsVision:
             "model": {"provider": "my-vllm", "default": "my-llava"},
             "providers": {"my-vllm": {"models": {"my-llava": {"supports_vision": True}}}},
         }
-        with patch("hermes_cli.config.load_config", return_value=cfg), \
+        with patch("hermes_cli.config.load_config_readonly", return_value=cfg), \
              patch("agent.models_dev.get_model_capabilities", return_value=None):
             assert agent._model_supports_vision() is True
 
@@ -204,6 +205,6 @@ class TestModelSupportsVision:
         agent = _make_agent()
         fake_caps = MagicMock()
         fake_caps.supports_vision = True
-        with patch("hermes_cli.config.load_config", return_value={"model": {"supports_vision": False}}), \
+        with patch("hermes_cli.config.load_config_readonly", return_value={"model": {"supports_vision": False}}), \
              patch("agent.models_dev.get_model_capabilities", return_value=fake_caps):
             assert agent._model_supports_vision() is False

--- a/tools/tirith_security.py
+++ b/tools/tirith_security.py
@@ -74,8 +74,8 @@ def _load_security_config() -> dict:
         "tirith_fail_open": True,
     }
     try:
-        from hermes_cli.config import load_config
-        cfg = load_config().get("security", {}) or {}
+        from hermes_cli.config import load_config_readonly
+        cfg = load_config_readonly().get("security", {}) or {}
     except Exception:
         cfg = {}
 

--- a/tools/transcription_tools.py
+++ b/tools/transcription_tools.py
@@ -120,8 +120,8 @@ _local_model_name: Optional[str] = None
 def _load_stt_config() -> dict:
     """Load the ``stt`` section from user config, falling back to defaults."""
     try:
-        from hermes_cli.config import load_config
-        return load_config().get("stt", {})
+        from hermes_cli.config import load_config_readonly
+        return load_config_readonly().get("stt", {})
     except Exception:
         return {}
 

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -1268,7 +1268,7 @@ def _load_cfg() -> dict:
         mtime = p.stat().st_mtime if p.exists() else None
         with _cfg_lock:
             if _cfg_cache is not None and _cfg_mtime == mtime and _cfg_path == p:
-                return copy.deepcopy(_cfg_cache)
+                return _cfg_cache
         if p.exists():
             with open(p, encoding="utf-8") as f:
                 data = yaml.safe_load(f) or {}
@@ -1638,7 +1638,7 @@ def _persist_live_session_runtime(session: dict | None) -> None:
 
 
 def _write_config_key(key_path: str, value):
-    cfg = _load_cfg()
+    cfg = copy.deepcopy(_load_cfg())
     current = cfg
     keys = key_path.split(".")
     for key in keys[:-1]:


### PR DESCRIPTION
## Summary

- Add readonly config fast paths (`read_raw_config_readonly`, `load_config_readonly`) and memoized gateway runtime config to avoid repeated YAML parse + deepcopy on hot paths
- Cache gateway transcripts by `(session_id, message_count)`; move session hygiene planning off the event loop via `asyncio.to_thread`
- Replace full `deepcopy` with shallow-copy optimizations in prompt caching, vision stripping, and chat_completions sanitize; incremental session DB flush scan; batched FTS search context fetch

## Why

Contribution priority #4 (performance/robustness): typical gateway turns spend measurable CPU on config reloads, transcript rehydration, and per-iteration message copying. These changes target that overhead without altering model API behavior or breaking per-conversation prompt caching.

## Test plan

- [x] `scripts/run_tests.sh tests/gateway/test_transcript_cache.py tests/gateway/test_session_hygiene.py tests/gateway/test_agent_cache.py tests/hermes_cli/test_config_readonly.py tests/run_agent/test_860_dedup.py tests/run_agent/test_message_sequence_repair.py tests/run_agent/test_vision_aware_preprocessing.py tests/agent/test_prompt_caching.py tests/test_hermes_state.py`

## Platforms tested

- macOS (darwin 25.5.0), Python 3.12

Made with [Cursor](https://cursor.com)