### PR TITLE
docs(ui-tui): expand App model, Commands, and Event surface sections in README

### DIFF
--- a/ui-tui/README.md
+++ b/ui-tui/README.md
@@ -74,10 +74,34 @@ npm run test:watch
 - `createSlashHandler.ts` — local slash command dispatch
 - `useComposerState.ts` — draft, multiline buffer, queue editing
 - `useInputHandlers.ts` — keypress routing
+- `useMainApp.ts` — top-level composition hook: wires all sub-hooks, manages transcript history, session polling, and exposes props consumed by `app.tsx`
+- `useSessionLifecycle.ts` — session create / resume / activate / close and visible-history reset
+- `useSubmission.ts` — message send, shell exec (`!cmd`), inline interpolation (`{!cmd}`), and busy-input-mode dispatch (queue / steer / interrupt)
 - `useTurnState.ts` — agent turn lifecycle
+- `turnController.ts` — stateful class that drives the turn lifecycle: buffers streaming deltas, manages tool/reasoning state, handles interrupt and message-complete transitions
+- `turnStore.ts` — nanostore for turn state (streaming text, tools, reasoning, subagents, todos, activity trail)
+- `useConfigSync.ts` — fetches `config.get full` on session start and polls config mtime every 5 s; applies display settings and triggers MCP reload on change
+- `useLongRunToolCharms.ts` — fires ambient activity messages for tools running longer than 8 s
 - `overlayStore.ts` / `uiStore.ts` — nanostores for overlay and UI state
+- `delegationStore.ts` — nanostore for subagent spawning caps and overlay accordion state
+- `spawnHistoryStore.ts` — in-memory ring (last 10) of finished subagent fan-out snapshots; populated at turn end for `/replay`
+- `inputSelectionStore.ts` — nanostore exposing the active text-input selection handle
 - `gatewayContext.tsx` — React context for the gateway client
+- `gatewayRecovery.ts` — pure function that decides whether to respawn and resume after a gateway crash, with a 3-attempt / 60 s budget
+- `setupHandoff.ts` — launches external `hermes setup`, suspends Ink while it runs, opens a new session on success
+- `scroll.ts` — scrolls the viewport while keeping the text selection anchor in sync
 - `constants.ts`, `helpers.ts`, `interfaces.ts`
+
+### Slash command subsystem (`src/app/slash/`)
+
+- `types.ts` — `SlashCommand` interface and `SlashRunCtx` execution context (gateway rpc, transcript helpers, session refs, stale-guard)
+- `registry.ts` — assembles `SLASH_COMMANDS` from all command files in registration order (core → credits → session → ops → setup → debug) and exposes `findSlashCommand(name)` for case-insensitive lookup
+- `commands/core.ts` — general TUI commands
+- `commands/credits.ts` — `/credits`
+- `commands/session.ts` — session and agent commands
+- `commands/ops.ts` — operations commands
+- `commands/setup.ts` — `/setup`
+- `commands/debug.ts` — `/heapdump`, `/mem`
 
 The top-level `app.tsx` composes these into the Ink tree with `Static` transcript output, a live streaming assistant row, prompt overlays, queue preview, status rule, input line, and completion list.
 
@@ -197,32 +221,38 @@ These are stateful UI branches in `app.tsx`, not separate screens.
 
 ## Commands
 
-The local slash handler covers the built-ins that need direct client behavior:
+The following commands are handled directly by the TUI client. Unrecognized commands fall through to the Python gateway via `slash.exec` and `command.dispatch`.
 
-- `/help`
-- `/quit`, `/exit`, `/q`
-- `/clear`
-- `/new`
-- `/compact`
-- `/resume`
-- `/copy`
-- `/paste`
-- `/details`
-- `/logs`
-- `/statusbar`, `/sb`
-- `/queue`
-- `/undo`
-- `/retry`
+### Core (`core.ts`)
+`/help`, `/quit` (alias `/exit`), `/update`, `/clear` (alias `/new`),
+`/compact`, `/copy`, `/paste`, `/details` (alias `/detail`),
+`/statusbar` (alias `/sb`), `/queue` (alias `/q`), `/logs`, `/history`,
+`/save`, `/undo`, `/retry`, `/steer`, `/mouse` (alias `/scroll`),
+`/status`, `/title`, `/fortune`, `/redraw`, `/terminal-setup`
 
-Notes:
+### Session (`session.ts`)
+`/model`, `/sessions` (aliases `/switch`, `/session`, `/resume`),
+`/background` (aliases `/bg`, `/btw`), `/image`, `/personality`,
+`/compress`, `/branch` (alias `/fork`), `/voice`, `/skin`,
+`/indicator`, `/yolo`, `/reasoning`, `/fast`, `/busy`, `/verbose`, `/usage`
 
-- `/copy` sends the selected assistant response through OSC 52.
-- `/paste` with no args asks the gateway to attach a clipboard image.
-- Text paste remains inline-only; `Cmd+V` / `Ctrl+V` handle layered text/OSC52/image fallback before `/paste` is needed.
-- `/details [hidden|collapsed|expanded|cycle]` controls thinking/tool-detail visibility.
-- `/statusbar` toggles the status rule on/off.
+### Ops (`ops.ts`)
+`/stop`, `/reload-mcp` (alias `/reload_mcp`), `/reload`, `/browser`,
+`/rollback`, `/agents` (alias `/tasks`), `/replay`, `/replay-diff`,
+`/skills`, `/reload-skills` (alias `/reload_skills`), `/plugins`, `/tools`
 
-Anything else falls through to:
+### Credits (`credits.ts`)
+`/credits` — Nous credit balance and browser top-up
+
+### Setup (`setup.ts`)
+`/setup` — launches external `hermes setup` wizard, suspends Ink while it runs
+
+### Debug (`debug.ts`)
+`/heapdump`, `/mem` — V8 memory diagnostics
+
+---
+
+Anything not matched above falls through to:
 
 1. `slash.exec`
 2. `command.dispatch`
@@ -233,28 +263,43 @@ That lets Python own aliases, plugins, skills, and registry-backed commands with
 
 Primary event types the client handles today:
 
-| Event                    | Payload                                         |
-| ------------------------ | ----------------------------------------------- |
-| `gateway.ready`          | `{ skin? }`                                     |
-| `session.info`           | session metadata for banner + tool/skill panels |
-| `message.start`          | start assistant streaming                       |
-| `message.delta`          | `{ text, rendered? }`                           |
-| `message.complete`       | `{ text, rendered?, usage, status }`            |
-| `thinking.delta`         | `{ text }`                                      |
-| `reasoning.delta`        | `{ text }`                                      |
-| `reasoning.available`    | `{ text }`                                      |
-| `status.update`          | `{ kind, text }`                                |
-| `tool.start`             | `{ tool_id, name, context? }`                   |
-| `tool.progress`          | `{ name, preview }`                             |
-| `tool.complete`          | `{ tool_id, name }`                             |
-| `clarify.request`        | `{ question, choices?, request_id }`            |
-| `approval.request`       | `{ command, description }`                      |
-| `sudo.request`           | `{ request_id }`                                |
-| `secret.request`         | `{ prompt, env_var, request_id }`               |
-| `background.complete`    | `{ task_id, text }`                             |
-| `error`                  | `{ message }`                                   |
-| `gateway.stderr`         | synthesized from child stderr                   |
-| `gateway.protocol_error` | synthesized from malformed stdout               |
+| Event                      | Payload                                                                     |
+| -------------------------- | --------------------------------------------------------------------------- |
+| `gateway.ready`            | `{ skin? }`                                                                 |
+| `skin.changed`             | `{ skin }`                                                                  |
+| `session.info`             | session metadata for banner + tool/skill panels                             |
+| `message.start`            | start assistant streaming                                                   |
+| `message.delta`            | `{ text, rendered? }`                                                       |
+| `message.complete`         | `{ text, rendered?, usage, status }`                                        |
+| `thinking.delta`           | `{ text }`                                                                  |
+| `reasoning.delta`          | `{ text, verbose? }`                                                        |
+| `reasoning.available`      | `{ text, verbose? }`                                                        |
+| `status.update`            | `{ kind, text }`                                                            |
+| `notification.show`        | `{ id, key, kind, level, text, ttl_ms? }`                                   |
+| `notification.clear`       | `{ key }`                                                                   |
+| `tool.start`               | `{ tool_id, name, context?, args_text? }`                                   |
+| `tool.generating`          | `{ name }`                                                                  |
+| `tool.progress`            | `{ name, preview }`                                                         |
+| `tool.complete`            | `{ tool_id, name, error?, summary?, duration_s?, inline_diff?, todos? }`    |
+| `clarify.request`          | `{ question, choices?, request_id }`                                        |
+| `approval.request`         | `{ command, description, allow_permanent? }`                                |
+| `sudo.request`             | `{ request_id }`                                                            |
+| `secret.request`           | `{ prompt, env_var, request_id }`                                           |
+| `background.complete`      | `{ task_id, text }`                                                         |
+| `review.summary`           | `{ text }`                                                                  |
+| `browser.progress`         | `{ message }`                                                               |
+| `voice.status`             | `{ state }`                                                                 |
+| `voice.transcript`         | `{ text, no_speech_limit? }`                                                |
+| `subagent.spawn_requested` | `{ subagent_id?, task_index, goal?, depth?, parent_id? }`                   |
+| `subagent.start`           | `{ subagent_id?, task_index, goal?, depth?, parent_id? }`                   |
+| `subagent.thinking`        | `{ text }`                                                                  |
+| `subagent.tool`            | `{ tool_name?, tool_preview?, text? }`                                      |
+| `subagent.progress`        | `{ text }`                                                                  |
+| `subagent.complete`        | `{ status, summary?, text?, duration_seconds? }`                            |
+| `error`                    | `{ message }`                                                               |
+| `gateway.stderr`           | synthesized from child stderr                                               |
+| `gateway.protocol_error`   | synthesized from malformed stdout                                           |
+| `gateway.start_timeout`    | `{ cwd?, python?, stderr_tail? }`                                           |
 
 ## Theme model
 


### PR DESCRIPTION
## What does this PR do?

`ui-tui/README.md` has three sections that were significantly out of date compared to the actual codebase. This PR syncs the documentation with the current state of the code — no code changes, documentation only.

**App model** — the file list covered 8 of 22+ files in `src/app/`. The `slash/` subsystem subdirectory was not mentioned at all.

**Commands** — the flat list covered 14 commands. The TUI client currently handles ~50 commands across 6 files in `src/app/slash/commands/`.

**Event surface** — the table listed 20 events. `createGatewayEventHandler.ts` currently handles 34 events in its switch statement. 14 events were missing entirely.

## Related Issue

Fixes #

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [x] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `ui-tui/README.md` — **App model section**: expanded file list from 8 to 22+ entries with one-line descriptions sourced from inline comments and JSDoc; added `### Slash command subsystem` block documenting `src/app/slash/` structure (`types.ts`, `registry.ts`, `commands/`)
- `ui-tui/README.md` — **Commands section**: replaced flat 14-item list with grouped list organized by source file (`core.ts`, `session.ts`, `ops.ts`, `credits.ts`, `setup.ts`, `debug.ts`); added note that unrecognized commands fall through to Python gateway via `slash.exec` and `command.dispatch`
- `ui-tui/README.md` — **Event surface section**: added 14 missing events (`skin.changed`, `notification.show`, `notification.clear`, `tool.generating`, `browser.progress`, `voice.status`, `voice.transcript`, `review.summary`, `gateway.start_timeout`, `subagent.spawn_requested`, `subagent.start`, `subagent.thinking`, `subagent.tool`, `subagent.progress`, `subagent.complete`); expanded payloads for `tool.start`, `tool.complete`, `approval.request`, `reasoning.delta`, `reasoning.available`

## How to Test

1. Open `ui-tui/README.md` in preview mode
2. Verify `src/app/` file list matches actual directory contents via `ls ui-tui/src/app/`
3. Verify Commands list matches `src/app/slash/commands/*.ts` — each command name visible in the `name:` field of each file
4. Verify Event surface table matches the `switch (ev.type)` statement in `ui-tui/src/app/createGatewayEventHandler.ts`

## Checklist

### Code
- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — N/A (documentation only)
- [ ] I've added tests for my changes — N/A (documentation only)
- [x] I've tested on my platform: macOS 15 / Windows 11

### Documentation & Housekeeping
- [x] I've updated relevant documentation (README, `docs/`, docstrings)
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [ ] I've considered cross-platform impact (Windows, macOS) — N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

<!-- Add before/after screenshots of the rendered README sections if possible -->