### PR TITLE
Add global gateway restart alert toggle

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -549,6 +549,14 @@ session_reset:
 # local runtime lease registry cannot be read or locked.
 max_concurrent_sessions: null
 
+# Gateway lifecycle restart/shutdown/startup alerts are enabled by default.
+# Set false to suppress the user-facing "Gateway restarting" / "Gateway online"
+# notifications across every messaging platform. Per-platform
+# gateway_restart_notification flags can still mute individual platforms when
+# this global switch remains true.
+gateway:
+  restart_alerts_enabled: true
+
 # When true, group/channel chats use one session per participant when the platform
 # provides a user ID. This is the secure default and prevents users in the same
 # room from sharing context, interrupts, and token costs. Set false only if you

--- a/gateway/config.py
+++ b/gateway/config.py
@@ -543,6 +543,12 @@ class GatewayConfig:
     # Streaming configuration
     streaming: StreamingConfig = field(default_factory=StreamingConfig)
 
+    # Global gateway lifecycle notification switch.  When false, suppresses
+    # restart/shutdown/startup user-facing alerts on every platform, while the
+    # per-platform gateway_restart_notification flag can still mute individual
+    # platforms when this remains true.
+    restart_alerts_enabled: bool = True
+
     # Session store pruning: drop SessionEntry records older than this many
     # days from the in-memory dict and sessions.json.  Keeps the store from
     # growing unbounded in gateways serving many chats/threads/users over
@@ -644,6 +650,7 @@ class GatewayConfig:
             "max_concurrent_sessions": self.max_concurrent_sessions,
             "unauthorized_dm_behavior": self.unauthorized_dm_behavior,
             "streaming": self.streaming.to_dict(),
+            "restart_alerts_enabled": self.restart_alerts_enabled,
             "session_store_max_age_days": self.session_store_max_age_days,
         }
     
@@ -727,6 +734,9 @@ class GatewayConfig:
             max_concurrent_sessions=max_concurrent_sessions,
             unauthorized_dm_behavior=unauthorized_dm_behavior,
             streaming=StreamingConfig.from_dict(data.get("streaming", {})),
+            restart_alerts_enabled=_coerce_bool(
+                data.get("restart_alerts_enabled"), True
+            ),
             session_store_max_age_days=session_store_max_age_days,
         )
 
@@ -818,6 +828,9 @@ def load_gateway_config() -> GatewayConfig:
             gateway_section = yaml_cfg.get("gateway")
             if isinstance(gateway_section, dict) and "max_concurrent_sessions" in gateway_section:
                 gw_data["max_concurrent_sessions"] = gateway_section["max_concurrent_sessions"]
+
+            if isinstance(gateway_section, dict) and "restart_alerts_enabled" in gateway_section:
+                gw_data["restart_alerts_enabled"] = gateway_section["restart_alerts_enabled"]
 
             if "max_concurrent_sessions" in yaml_cfg:
                 gw_data["max_concurrent_sessions"] = yaml_cfg["max_concurrent_sessions"]

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -4108,6 +4108,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         logged and swallowed so they never block the shutdown sequence.
         """
         active = self._snapshot_running_agents()
+        if not getattr(self.config, "restart_alerts_enabled", True):
+            logger.info(
+                "Shutdown/restart notifications suppressed: gateway.restart_alerts_enabled=false"
+            )
+            return
+
         restart_source = self._restart_command_source if self._restart_requested else None
 
         action = "restarting" if self._restart_requested else "shutting down"
@@ -11796,6 +11802,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             thread_id = data.get("thread_id")
             message_id = data.get("message_id")
 
+            if not getattr(self.config, "restart_alerts_enabled", True):
+                logger.info(
+                    "Restart notification suppressed: gateway.restart_alerts_enabled=false"
+                )
+                return None
+
             if not platform_str or not chat_id:
                 return None
 
@@ -11866,6 +11878,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         when a more specific restart notification is queued for the same chat.
         """
         delivered: set[tuple[str, str, Optional[str]]] = set()
+        if not getattr(self.config, "restart_alerts_enabled", True):
+            logger.info(
+                "Home-channel startup notifications suppressed: gateway.restart_alerts_enabled=false"
+            )
+            return delivered
+
         skipped = skip_targets or set()
         message = "♻️ Gateway online — Hermes is back and ready."
 

--- a/tests/gateway/test_config.py
+++ b/tests/gateway/test_config.py
@@ -203,6 +203,7 @@ class TestGatewayConfigRoundtrip:
             quick_commands={"limits": {"type": "exec", "command": "echo ok"}},
             group_sessions_per_user=False,
             thread_sessions_per_user=True,
+            restart_alerts_enabled=False,
         )
         d = config.to_dict()
         restored = GatewayConfig.from_dict(d)
@@ -213,6 +214,15 @@ class TestGatewayConfigRoundtrip:
         assert restored.quick_commands == {"limits": {"type": "exec", "command": "echo ok"}}
         assert restored.group_sessions_per_user is False
         assert restored.thread_sessions_per_user is True
+        assert restored.restart_alerts_enabled is False
+
+    def test_restart_alerts_enabled_defaults_true(self):
+        assert GatewayConfig().restart_alerts_enabled is True
+        assert GatewayConfig.from_dict({}).restart_alerts_enabled is True
+
+    def test_restart_alerts_enabled_from_dict_coerces_quoted_false(self):
+        restored = GatewayConfig.from_dict({"restart_alerts_enabled": "false"})
+        assert restored.restart_alerts_enabled is False
 
     def test_max_concurrent_sessions_from_dict_normalizes_disabled_values(self):
         assert GatewayConfig.from_dict({}).max_concurrent_sessions is None
@@ -334,6 +344,23 @@ class TestLoadGatewayConfig:
         config = load_gateway_config()
 
         assert config.thread_sessions_per_user is True
+
+    def test_bridges_restart_alerts_enabled_from_gateway_config_yaml(
+        self, tmp_path, monkeypatch
+    ):
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        config_path = hermes_home / "config.yaml"
+        config_path.write_text(
+            "gateway:\n  restart_alerts_enabled: false\n",
+            encoding="utf-8",
+        )
+
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        config = load_gateway_config()
+
+        assert config.restart_alerts_enabled is False
 
     def test_thread_sessions_per_user_defaults_to_false(self, tmp_path, monkeypatch):
         hermes_home = tmp_path / ".hermes"

--- a/tests/gateway/test_restart_drain.py
+++ b/tests/gateway/test_restart_drain.py
@@ -385,6 +385,20 @@ async def test_shutdown_notification_suppressed_when_flag_disabled():
 
 
 @pytest.mark.asyncio
+async def test_shutdown_notification_suppressed_when_global_alerts_disabled():
+    """Global opt-out mutes active-session shutdown/restart alerts."""
+    runner, adapter = make_restart_runner()
+    runner._restart_requested = True
+    runner.config.restart_alerts_enabled = False
+    session_key = "agent:main:telegram:dm:999"
+    runner._running_agents[session_key] = MagicMock()
+
+    await runner._notify_active_sessions_of_shutdown()
+
+    assert adapter.sent == []
+
+
+@pytest.mark.asyncio
 async def test_shutdown_notification_home_channel_suppressed_when_flag_disabled():
     """Home-channel ping during shutdown is muted when the flag is False."""
     from gateway.config import HomeChannel, Platform

--- a/tests/gateway/test_restart_notification.py
+++ b/tests/gateway/test_restart_notification.py
@@ -559,6 +559,28 @@ async def test_send_home_channel_startup_notification_skipped_when_flag_disabled
 
 
 @pytest.mark.asyncio
+async def test_send_home_channel_startup_notification_skipped_when_global_alerts_disabled(
+    tmp_path, monkeypatch
+):
+    """Global opt-out mutes startup lifecycle pings across all platforms."""
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+
+    runner, adapter = make_restart_runner()
+    runner.config.restart_alerts_enabled = False
+    runner.config.platforms[Platform.TELEGRAM].home_channel = HomeChannel(
+        platform=Platform.TELEGRAM,
+        chat_id="home-42",
+        name="Ops Home",
+    )
+    adapter.send = AsyncMock()
+
+    delivered = await runner._send_home_channel_startup_notifications()
+
+    assert delivered == set()
+    adapter.send.assert_not_called()
+
+
+@pytest.mark.asyncio
 async def test_send_home_channel_startup_notification_default_flag_true(
     tmp_path, monkeypatch
 ):
@@ -603,6 +625,30 @@ async def test_send_restart_notification_skipped_when_flag_disabled(
 
     runner, adapter = make_restart_runner()
     runner.config.platforms[Platform.TELEGRAM].gateway_restart_notification = False
+    adapter.send = AsyncMock()
+
+    delivered_target = await runner._send_restart_notification()
+
+    assert delivered_target is None
+    adapter.send.assert_not_called()
+    assert not notify_path.exists()
+
+
+@pytest.mark.asyncio
+async def test_send_restart_notification_skipped_when_global_alerts_disabled(
+    tmp_path, monkeypatch
+):
+    """Global opt-out mutes the /restart originator lifecycle ping."""
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+
+    notify_path = tmp_path / ".restart_notify.json"
+    notify_path.write_text(json.dumps({
+        "platform": "telegram",
+        "chat_id": "42",
+    }))
+
+    runner, adapter = make_restart_runner()
+    runner.config.restart_alerts_enabled = False
     adapter.send = AsyncMock()
 
     delivered_target = await runner._send_restart_notification()

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -1522,6 +1522,15 @@ fails open if the registry cannot be read or locked so users are not stranded.
 It is intended for a single host/profile runtime, not a shared `$HERMES_HOME`
 mounted across multiple machines.
 
+Control whether the gateway sends restart/shutdown/startup lifecycle alerts such as "Gateway restarting" and "Gateway online" to messaging platforms:
+
+```yaml
+gateway:
+  restart_alerts_enabled: true  # default; set false to suppress these alerts globally
+```
+
+When this global switch is `false`, Hermes suppresses those lifecycle alerts on every gateway platform. Leave it `true` and use per-platform `gateway_restart_notification: false` if only one platform should be muted.
+
 Control whether shared chats keep one conversation per room or one conversation per participant:
 
 ```yaml

--- a/website/docs/user-guide/messaging/index.md
+++ b/website/docs/user-guide/messaging/index.md
@@ -525,7 +525,14 @@ Once upstream is healthy, `/platform resume <name>` clears the breaker and re-ar
 
 ### Restart notifications
 
-When the gateway restarts (or is shut down with in-flight sessions), it can send a one-shot "the agent is back" / "the agent was interrupted" message to each platform's home channel. This is controlled per-platform by the `gateway_restart_notification` flag in `gateway-config.yaml`, which defaults to `true`:
+When the gateway restarts (or is shut down with in-flight sessions), it can send one-shot lifecycle alerts such as "the agent is back" / "the agent was interrupted". Global restart alerts default to enabled. Disable them across every platform with `gateway.restart_alerts_enabled: false`:
+
+```yaml
+gateway:
+  restart_alerts_enabled: false   # disables gateway restart/shutdown/startup alerts globally
+```
+
+If global alerts remain enabled, you can still mute individual platforms with the per-platform `gateway_restart_notification` flag, which defaults to `true`:
 
 ```yaml
 gateway:
@@ -538,7 +545,7 @@ gateway:
       # gateway_restart_notification omitted → defaults to true
 ```
 
-Disable it on noisy or low-priority platforms while leaving it on for your primary chat. The notification is sent once per restart, regardless of how many sessions were in flight.
+Use the global switch when operator restarts are intentionally quiet everywhere; use the per-platform flag when one noisy or low-priority platform should be muted while your primary chat still gets lifecycle pings. The notification is sent once per restart, regardless of how many sessions were in flight.
 
 ### Session resume across gateway restarts
 
@@ -550,7 +557,7 @@ This behaviour is on by default and is logged at gateway start:
 Scheduled auto-resume for N restart-interrupted session(s)
 ```
 
-No configuration is required. If you don't want the heads-up, set `gateway_restart_notification: false` on the platform.
+No configuration is required. If you don't want the heads-up anywhere, set `gateway.restart_alerts_enabled: false`; if you only want to mute one platform, set `gateway_restart_notification: false` on that platform.
 
 ### Mobile-friendly progress defaults
 


### PR DESCRIPTION
## Summary
- Adds `gateway.restart_alerts_enabled` as a global config switch for restart/shutdown/startup lifecycle alerts.
- Suppresses active-session shutdown/restart warnings, `/restart` originator pings, and home-channel startup pings when disabled.
- Documents the global setting while preserving existing per-platform `gateway_restart_notification` behavior.

Release notes: not applicable

## Test plan
- `python -m pytest tests/gateway/test_config.py tests/gateway/test_restart_notification.py tests/gateway/test_restart_drain.py -q -o 'addopts='`
- `git diff --check`
