### PR TITLE
fix(telegram): retry transient photo downloads

### DIFF
--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -837,6 +837,50 @@ class TelegramAdapter(BasePlatformAdapter):
         return isinstance(error, OSError)
 
     @staticmethod
+    def _looks_like_media_download_error(error: Exception) -> bool:
+        """Return True for transient Telegram media download failures."""
+        if isinstance(error, (TimeoutError, OSError)):
+            return True
+        try:
+            from telegram.error import NetworkError, TimedOut
+            if isinstance(error, (NetworkError, TimedOut)):
+                return True
+        except ImportError:
+            pass
+        name = error.__class__.__name__.lower()
+        text = str(error).lower()
+        return name in {"networkerror", "timedout"} or "timed out" in text
+
+    async def _download_telegram_media_bytes(
+        self,
+        get_file,
+        *,
+        label: str,
+        attempts: int = 3,
+    ) -> tuple[Any, bytearray]:
+        """Fetch a Telegram file and its bytes with bounded transient retries."""
+        last_error: Exception | None = None
+        for attempt in range(1, max(1, attempts) + 1):
+            try:
+                file_obj = await get_file()
+                return file_obj, await file_obj.download_as_bytearray()
+            except Exception as exc:
+                last_error = exc
+                if attempt >= attempts or not self._looks_like_media_download_error(exc):
+                    raise
+                wait = min(0.25 * attempt, 1.0)
+                logger.warning(
+                    "[Telegram] %s download failed (attempt %d/%d), retrying in %.2fs: %s",
+                    label,
+                    attempt,
+                    attempts,
+                    wait,
+                    exc,
+                )
+                await asyncio.sleep(wait)
+        raise last_error or RuntimeError(f"{label} download failed")
+
+    @staticmethod
     def _looks_like_connect_timeout(error: Exception) -> bool:
         """Return True when a Telegram TimedOut wraps a connect-timeout.
 
@@ -6034,9 +6078,10 @@ class TelegramAdapter(BasePlatformAdapter):
             try:
                 # msg.photo is a list of PhotoSize sorted by size; take the largest
                 photo = msg.photo[-1]
-                file_obj = await photo.get_file()
-                # Download the image bytes directly into memory
-                image_bytes = await file_obj.download_as_bytearray()
+                file_obj, image_bytes = await self._download_telegram_media_bytes(
+                    photo.get_file,
+                    label="photo",
+                )
                 # Determine extension from the file path if available
                 ext = ".jpg"
                 if file_obj.file_path:
@@ -6059,6 +6104,11 @@ class TelegramAdapter(BasePlatformAdapter):
 
             except Exception as e:
                 logger.warning("[Telegram] Failed to cache photo: %s", e, exc_info=True)
+                if self._looks_like_media_download_error(e):
+                    event.text = self._append_observed_note(
+                        event.text,
+                        "Telegram photo could not be downloaded after retries; image was not attached.",
+                    )
 
         # Download voice/audio messages to cache for STT transcription
         if msg.voice:

--- a/tests/gateway/test_telegram_documents.py
+++ b/tests/gateway/test_telegram_documents.py
@@ -435,6 +435,44 @@ class TestVideoDownloadBlock:
 
 class TestMediaGroups:
     @pytest.mark.asyncio
+    async def test_photo_download_retries_transient_timeout(self, adapter):
+        file_obj = _make_file_obj(b"retried-photo")
+        photo = MagicMock()
+        photo.get_file = AsyncMock(side_effect=[TimeoutError("Timed out"), file_obj])
+        msg = _make_message(caption="inspect", photo=[photo])
+
+        with (
+            patch("gateway.platforms.telegram.cache_image_from_bytes", return_value="/tmp/retried.jpg"),
+            patch("gateway.platforms.telegram.asyncio.sleep", new_callable=AsyncMock),
+            patch.object(adapter, "_photo_batch_key", return_value="batch-retry"),
+            patch.object(adapter, "_enqueue_photo_event") as enqueue_mock,
+        ):
+            await adapter._handle_media_message(_make_update(msg), MagicMock())
+
+        assert photo.get_file.await_count == 2
+        file_obj.download_as_bytearray.assert_awaited_once()
+        enqueue_mock.assert_called_once()
+        event = enqueue_mock.call_args.args[1]
+        assert event.media_urls == ["/tmp/retried.jpg"]
+        assert event.text == "inspect"
+
+    @pytest.mark.asyncio
+    async def test_photo_download_timeout_adds_note_after_retries(self, adapter):
+        photo = MagicMock()
+        photo.get_file = AsyncMock(side_effect=TimeoutError("Timed out"))
+        msg = _make_message(caption="inspect", photo=[photo])
+
+        with patch("gateway.platforms.telegram.asyncio.sleep", new_callable=AsyncMock):
+            await adapter._handle_media_message(_make_update(msg), MagicMock())
+
+        assert photo.get_file.await_count == 3
+        adapter.handle_message.assert_awaited_once()
+        event = adapter.handle_message.await_args.args[0]
+        assert "inspect" in event.text
+        assert "Telegram photo could not be downloaded after retries" in event.text
+        assert event.media_urls == []
+
+    @pytest.mark.asyncio
     async def test_non_album_photo_burst_is_buffered_and_combined(self, adapter):
         first_photo = _make_photo(_make_file_obj(b"first"))
         second_photo = _make_photo(_make_file_obj(b"second"))


### PR DESCRIPTION
## What does this PR do?

Telegram photo handling currently calls `photo.get_file()` and `download_as_bytearray()` once. If Telegram raises a transient timeout before the image is cached, Hermes logs `Failed to cache photo` and continues with a text-only turn, so the agent never sees the image.

This adds a bounded retry helper for Telegram media downloads and uses it for inbound photos. If all retry attempts fail with a transient download error, the event text includes an explicit note that the Telegram photo could not be downloaded instead of silently dropping the attachment.

## Related Issue

Fixes #47093

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `gateway/platforms/telegram.py`: add bounded retry handling for transient Telegram media download failures.
- `gateway/platforms/telegram.py`: use the retry helper for inbound photo `get_file()` / byte downloads.
- `tests/gateway/test_telegram_documents.py`: cover retry success and retry exhaustion with an explicit note.

## How to Test

1. Configure Telegram gateway with native image input enabled.
2. Send a Telegram photo while `photo.get_file()` or file download hits a transient timeout.
3. Verify Hermes retries before dropping the image; if retries are exhausted, the agent turn includes a note that the Telegram photo could not be downloaded.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS with `uv` Python 3.12

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

N/A

## Screenshots / Logs

```text
$ uv run pytest tests/gateway/test_telegram_documents.py -q
43 passed in 3.37s

$ uv run ruff check gateway/platforms/telegram.py tests/gateway/test_telegram_documents.py
All checks passed!

$ git diff --check
(no output)
```
