### PR TITLE
fix(agent): handle YAML null in context_length_cache

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -916,7 +916,7 @@ def _load_context_cache() -> Dict[str, int]:
     try:
         with open(path, encoding="utf-8") as f:
             data = yaml.safe_load(f) or {}
-        return data.get("context_lengths", {})
+        return data.get("context_lengths") or {}
     except Exception as e:
         logger.debug("Failed to load context length cache: %s", e)
         return {}

--- a/tests/agent/test_model_metadata.py
+++ b/tests/agent/test_model_metadata.py
@@ -28,6 +28,7 @@ from agent.model_metadata import (
     parse_context_limit_from_error,
     save_context_length,
     fetch_model_metadata,
+    _load_context_cache,
     _MODEL_CACHE_TTL,
 )
 
@@ -1467,6 +1468,39 @@ class TestContextLengthCache:
         with patch("agent.model_metadata._get_context_cache_path", return_value=cache_file):
             save_context_length(model, url, 200000)
             assert get_cached_context_length(model, url) == 200000
+
+    def test_yaml_null_value_returns_empty_dict(self, tmp_path):
+        """context_lengths: (no value) parses as YAML null; must not crash.
+
+        Regression test for the case where context_length_cache.yaml
+        contains ``context_lengths:`` with no value.  YAML parses this
+        as ``{"context_lengths": None}``.  ``dict.get(key, default)``
+        returns the default only when the key is *absent*; when the
+        value is ``None`` it returns ``None`` — which then crashes
+        downstream callers that call ``.get()`` on the result.
+        """
+        cache_file = tmp_path / "cache.yaml"
+        cache_file.write_text("context_lengths:\n")
+        with patch("agent.model_metadata._get_context_cache_path", return_value=cache_file):
+            # Must return {}, not None
+            assert _load_context_cache() == {}
+            # Downstream must not crash
+            assert get_cached_context_length("model", "http://x") is None
+
+    def test_yaml_null_then_valid_write(self, tmp_path):
+        """After a null-value cache is fixed, writing a new entry works."""
+        cache_file = tmp_path / "cache.yaml"
+        cache_file.write_text("context_lengths:\n")
+        with patch("agent.model_metadata._get_context_cache_path", return_value=cache_file):
+            save_context_length("model", "http://x", 128000)
+            assert get_cached_context_length("model", "http://x") == 128000
+
+    def test_valid_cache_non_regression(self, tmp_path):
+        """Valid cache file with actual data still works correctly."""
+        cache_file = tmp_path / "cache.yaml"
+        cache_file.write_text("context_lengths:\n  model@http://x: 128000\n")
+        with patch("agent.model_metadata._get_context_cache_path", return_value=cache_file):
+            assert get_cached_context_length("model", "http://x") == 128000
 
 
 class TestGrok43StaleCacheGuard:


### PR DESCRIPTION
## Summary

`_load_context_cache()` crashes with `AttributeError: 'NoneType' object has no attribute 'get'` when `context_length_cache.yaml` contains `context_lengths:` (no value). YAML parses this as `{"context_lengths": None}`, and `dict.get(key, default)` only returns the default when the key is absent — not when the value is `None`.

## Fix

One-line change in `agent/model_metadata.py`:

```python
# before
return data.get("context_lengths", {})
# after
return data.get("context_lengths") or {}
```

Handles both cases: key absent (returns `{}`) and key present with `None` value (returns `{}`).

## Test

Added three regression tests in `tests/agent/test_model_metadata.py`:

- `test_yaml_null_value_returns_empty_dict` — verifies `_load_context_cache()` returns `{}` and `get_cached_context_length()` does not crash when the cache file contains a YAML null value
- `test_yaml_null_then_valid_write` — verifies recovery: after a null-value cache, writing a new entry works correctly
- `test_valid_cache_non_regression` — verifies valid cache files with actual data still work correctly

## Impact

- **Severity**: High — gateway crashes entirely, no responses possible
- **Scope**: Any user whose `context_length_cache.yaml` becomes malformed (manual editing, interrupted write, concurrent access)
- **Risk**: Minimal — single-line defensive fix with full test coverage

Closes #47135