### PR TITLE
fix(models): merge curated list with live /v1/models for zai provider

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -2370,7 +2370,11 @@ def provider_model_ids(provider: Optional[str], *, force_refresh: bool = False) 
             if api_key:
                 live = _p.fetch_models(api_key=api_key)
                 if live:
-                    if normalized in {"kimi-coding", "kimi-coding-cn"}:
+                    if normalized in {"kimi-coding", "kimi-coding-cn", "zai"}:
+                        # zai's live /v1/models endpoint sometimes omits newer
+                        # models (e.g. glm-5.2).  Merge curated first, then
+                        # append live additions so the picker never drops
+                        # models the curated list knows about.  (#47162)
                         curated = list(_PROVIDER_MODELS.get(normalized, []))
                         merged = list(curated)
                         merged_lower = {m.lower() for m in curated}


### PR DESCRIPTION
## Problem

When using the Z.AI (GLM) provider, the `/model` picker shows only models returned by the live `/v1/models` endpoint, silently dropping entries from the curated `_PROVIDER_MODELS` list. When the live endpoint omits newer models (e.g. `glm-5.2`), users can't see them in the picker even though they work when set directly via `/model` or config.

## Root Cause

In `provider_model_ids()` (`hermes_cli/models.py:2379`), the generic profile-based live fetch path merges curated + live results **only** for `kimi-coding` / `kimi-coding-cn`. The `zai` provider falls through to `return live`, discarding the curated list entirely.

## Fix

Add `zai` to the merge set so curated models come first, then live additions are appended — ensuring no curated model is ever hidden by an incomplete live response.

Closes #47162