### PR TITLE
feat(skills): add macos-spotlight skill for blazing-fast global search

### DIFF
--- a/scripts/macos_mdfind.py
+++ b/scripts/macos_mdfind.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+"""
+macOS Spotlight (mdfind) wrapper for Hermes Agent.
+Provides safe, limited, and structured access to macOS global search.
+"""
+import argparse
+import subprocess
+import sys
+import platform
+
+def main():
+    if platform.system() != "Darwin":
+        print("Error: This script is only supported on macOS.", file=sys.stderr)
+        sys.exit(1)
+
+    parser = argparse.ArgumentParser(description="Search files globally using macOS mdfind.")
+    parser.add_argument("--name", help="Search by file name (case-insensitive)")
+    parser.add_argument("--content", help="Search by file content (including rich documents)")
+    parser.add_argument("--type", help="File extension/type (e.g., pdf, md)")
+    parser.add_argument("--days", type=int, help="Modified within the last N days")
+    parser.add_argument("--limit", type=int, default=50, help="Maximum number of results to return (prevent token overflow)")
+    parser.add_argument("--onlyin", help="Restrict search to a specific absolute directory path")
+
+    args = parser.parse_args()
+
+    query_parts = []
+    # Using 'cd' modifier for case-insensitive and diacritic-insensitive matching
+    if args.name:
+        query_parts.append(f'kMDItemFSName == "*{args.name}*"cd')
+    if args.content:
+        query_parts.append(f'kMDItemTextContent == "*{args.content}*"cd')
+    if args.type:
+        query_parts.append(f'kMDItemFSName == "*.{args.type}"')
+    if args.days:
+        query_parts.append(f'kMDItemFSContentChangeDate >= $time.today(-{args.days})')
+
+    if not query_parts:
+        print("Error: At least one search criteria (--name, --content, --type, --days) must be provided.", file=sys.stderr)
+        sys.exit(1)
+
+    query = " && ".join(query_parts)
+    
+    cmd = ["mdfind"]
+    if args.onlyin:
+        cmd.extend(["-onlyin", args.onlyin])
+    cmd.append(query)
+
+    try:
+        # Secure execution: passing list of arguments prevents shell injection
+        result = subprocess.run(cmd, capture_output=True, text=True, check=True)
+        lines = [line.strip() for line in result.stdout.split('\n') if line.strip()]
+        
+        if not lines:
+            print("No results found.")
+            return
+
+        limited_lines = lines[:args.limit]
+        for line in limited_lines:
+            print(line)
+            
+        if len(lines) > args.limit:
+            print(f"\n... and {len(lines) - args.limit} more results. Showing top {args.limit}.")
+            
+    except subprocess.CalledProcessError as e:
+        print(f"Error executing mdfind: {e.stderr}", file=sys.stderr)
+        sys.exit(1)
+
+if __name__ == "__main__":
+    main()

--- a/skills/productivity/macos-spotlight/SKILL.md
+++ b/skills/productivity/macos-spotlight/SKILL.md
@@ -1,0 +1,54 @@
+---
+name: macos-spotlight
+description: Search macOS globally using Spotlight mdfind.
+author: bytedance
+platforms: [macos]
+---
+
+# macOS Spotlight Skill
+
+This skill performs blazing-fast global file searches on macOS using the native Spotlight index (`mdfind`). It replaces slow, recursive directory traversal with instant, metadata-aware querying.
+
+## When to Use
+
+- When you need to find a file but do not know its exact directory on the Mac.
+- When searching for specific text content inside PDFs, Word documents, or presentations globally.
+- When filtering files by modification date across the entire filesystem.
+
+## Prerequisites
+
+- Operating System: **macOS** only.
+- The `mdfind` command-line tool (built into macOS).
+
+## Procedure
+
+Use the `terminal` tool to execute the helper script `scripts/macos_mdfind.py`. Do NOT run raw `mdfind` commands directly in the shell to prevent context window token overflow. The python wrapper safely limits output lines.
+
+### Options:
+- `--name "text"`: Search by filename (case-insensitive).
+- `--content "text"`: Search by file content (including rich documents).
+- `--type "ext"`: Filter by file extension (e.g., `pdf`, `md`).
+- `--days N`: Restrict to files modified within the last N days.
+- `--onlyin "/path"`: Restrict search to a specific absolute directory.
+- `--limit N`: Max results (default is 50).
+
+### Examples
+
+**Search for a PDF containing the word "budget" anywhere on the Mac:**
+```bash
+python3 scripts/macos_mdfind.py --content "budget" --type "pdf"
+```
+
+**Find markdown files modified in the last 7 days:**
+```bash
+python3 scripts/macos_mdfind.py --type "md" --days 7
+```
+
+**Find a project folder or file by name within the Documents folder:**
+```bash
+python3 scripts/macos_mdfind.py --name "Hermes" --onlyin "$HOME/Documents"
+```
+
+## Verification
+
+If the script returns paths, use the standard `read_file` tool to read the contents of the target file, or the `terminal` tool to interact with the located files.

--- a/tests/skills/test_macos-spotlight_skill.py
+++ b/tests/skills/test_macos-spotlight_skill.py
@@ -1,0 +1,74 @@
+import unittest
+from unittest.mock import patch, MagicMock
+import sys
+import os
+
+# Add scripts directory to path to import the wrapper script
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../../scripts')))
+
+import macos_mdfind
+
+class TestMacOSSpotlight(unittest.TestCase):
+    
+    @patch('macos_mdfind.platform.system')
+    def test_platform_check_fails_on_non_mac(self, mock_system):
+        """Test that the script exits with an error on non-macOS systems."""
+        mock_system.return_value = "Linux"
+        with self.assertRaises(SystemExit) as cm:
+            macos_mdfind.main()
+        self.assertEqual(cm.exception.code, 1)
+
+    @patch('macos_mdfind.platform.system')
+    @patch('macos_mdfind.subprocess.run')
+    @patch('sys.argv', ['macos_mdfind.py', '--name', 'report', '--type', 'pdf'])
+    @patch('sys.stdout', new_callable=MagicMock)
+    def test_mdfind_command_construction(self, mock_stdout, mock_run, mock_system):
+        """Test if the mdfind command is constructed securely and correctly."""
+        mock_system.return_value = "Darwin"
+        mock_process = MagicMock()
+        mock_process.stdout = "/path/to/report.pdf\n"
+        mock_run.return_value = mock_process
+
+        macos_mdfind.main()
+
+        # Verify subprocess.run was called once
+        mock_run.assert_called_once()
+        
+        # Verify the command list passed to subprocess
+        called_cmd = mock_run.call_args[0][0]
+        self.assertEqual(called_cmd[0], 'mdfind')
+        
+        # Check if the query logic is properly combined with '&&'
+        query_string = called_cmd[1]
+        self.assertIn('kMDItemFSName == "*report*"cd', query_string)
+        self.assertIn('kMDItemFSName == "*.pdf"', query_string)
+        self.assertIn('&&', query_string)
+
+    @patch('macos_mdfind.platform.system')
+    @patch('macos_mdfind.subprocess.run')
+    @patch('sys.argv', ['macos_mdfind.py', '--content', 'budget', '--limit', '2'])
+    @patch('sys.stdout', new_callable=MagicMock)
+    def test_mdfind_limit_truncation(self, mock_stdout, mock_run, mock_system):
+        """Test if the output is properly truncated to prevent token overflow."""
+        mock_system.return_value = "Darwin"
+        mock_process = MagicMock()
+        # Simulate mdfind returning 3 results
+        mock_process.stdout = "/path/1.txt\n/path/2.txt\n/path/3.txt\n"
+        mock_run.return_value = mock_process
+
+        macos_mdfind.main()
+
+        # Extract all prints
+        prints = [call.args[0] for call in mock_stdout.write.call_args_list if call.args[0] != '\n']
+        
+        # Output should contain exactly 2 file paths due to --limit 2, plus the truncation message
+        self.assertIn('/path/1.txt', prints)
+        self.assertIn('/path/2.txt', prints)
+        self.assertNotIn('/path/3.txt', prints)
+        
+        # Check truncation warning
+        truncation_msg = next((p for p in prints if "... and 1 more results" in p), None)
+        self.assertIsNotNone(truncation_msg)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
**What & Why:**
Added a new bundled skill `macos-spotlight` to enable instant global file searching on macOS using the native Spotlight index (`mdfind`). 

Previously, searching for files globally or inside rich documents (PDFs, Word) relied on the `search_files` tool (ripgrep/find), which is slow for full-disk traversal and blind to rich metadata. This skill solves that by exposing `mdfind` via a safe wrapper, saving significant LLM token context and wait time.

**How it works:**
- Created `scripts/macos_mdfind.py` to construct secure `mdfind` queries, strictly passing arguments as lists to prevent shell injection.
- **Token Overflow Protection:** The wrapper enforces a `--limit 50` output truncation to prevent `mdfind` from blowing up the agent's context window.
- Defined `skills/productivity/macos-spotlight/SKILL.md` with explicit `platforms: [macos]` and strict adherence to Hermes native tool names (`` `terminal` ``, `` `read_file` ``).

**How to test:**
```bash
# Run the hermetic unit tests (runs purely on mocks, safe for CI)
scripts/run_tests.sh tests/skills/test_macos-spotlight_skill.py -q

# Manual test (on macOS)
python3 scripts/macos_mdfind.py --content "budget" --type "pdf" --days 30
```

**Tested Platforms:**
- macOS
- Linux / Windows (Unit tests run perfectly on all platforms as they are fully mocked and `platform.system()` fallback is handled).

**Compliance Checklist (HARDLINE):**
- [x] Skill `description` is <= 60 chars, single sentence, ending with a period.
- [x] Specified `platforms: [macos]` in the frontmatter.
- [x] Tools referenced in prose use backticks and native names (e.g., `` `terminal` ``).
- [x] Tests live in `tests/skills/test_<skill>_skill.py` and are strictly mocked without live network/filesystem calls.
- [x] Follows Conventional Commits.
