### PR TITLE
fix(qqbot): allow C2C file attachment host in URL safety bypass (#47123)

### DIFF
--- a/tests/tools/test_url_safety.py
+++ b/tests/tools/test_url_safety.py
@@ -222,6 +222,42 @@ class TestIsSafeUrl:
         with patch("socket.getaddrinfo", side_effect=socket.gaierror("Name resolution failed")):
             assert is_safe_url("https://multimedia.nt.qq.com.cn/download?id=123") is False
 
+    def test_qq_c2c_grouptalk_hostname_allowed_with_benchmark_ip(self):
+        """grouptalk.c2c.qq.com is the QQ Bot C2C file-attachment download host.
+        When the local network (Clash TUN / corporate proxy / VPN) resolves it
+        to a 198.18.0.0/15 benchmark-range IP, downloads were silently
+        blocked because the host was missing from
+        _TRUSTED_PRIVATE_IP_HOSTS. Allowlist it (issue #47123)."""
+        with patch("socket.getaddrinfo", return_value=[
+            (2, 1, 6, "", ("198.18.2.16", 0)),
+        ]):
+            assert is_safe_url(
+                "https://grouptalk.c2c.qq.com/asn.com/qqdownloadftnv5?id=xxx"
+            ) is True
+
+    def test_qq_c2c_grouptalk_hostname_exception_is_exact_match(self):
+        """The allowlist is an exact-match frozenset. A subdomain like
+        evil.grouptalk.c2c.qq.com must still be blocked even with the
+        grouptalk.c2c.qq.com entry — the helper only matches the bare
+        hostname, not suffix matching."""
+        with patch("socket.getaddrinfo", return_value=[
+            (2, 1, 6, "", ("198.18.2.16", 0)),
+        ]):
+            assert is_safe_url(
+                "https://evil.grouptalk.c2c.qq.com/download?id=xxx"
+            ) is False
+
+    def test_qq_c2c_grouptalk_hostname_exception_requires_https(self):
+        """The bypass only applies to HTTPS. Plain HTTP must still be
+        blocked so a downgrade attack on the proxy cannot reach a private
+        IP via the allowlisted host."""
+        with patch("socket.getaddrinfo", return_value=[
+            (2, 1, 6, "", ("198.18.2.16", 0)),
+        ]):
+            assert is_safe_url(
+                "http://grouptalk.c2c.qq.com/asn.com/qqdownloadftnv5?id=xxx"
+            ) is False
+
 
 class TestAsyncIsSafeUrl:
     """async_is_safe_url must match is_safe_url (runs DNS in a thread pool)."""

--- a/tools/url_safety.py
+++ b/tools/url_safety.py
@@ -112,8 +112,12 @@ _ALWAYS_BLOCKED_NETWORKS = (
 # Exact HTTPS hostnames allowed to resolve to private/benchmark-space IPs.
 # This is intentionally narrow: QQ media downloads can legitimately resolve
 # to 198.18.0.0/15 behind local proxy/benchmark infrastructure.
+#   - multimedia.nt.qq.com.cn — QQ Bot media (image / video) downloads
+#   - grouptalk.c2c.qq.com    — QQ Bot C2C file-attachment downloads
+#     (issue #47123)
 _TRUSTED_PRIVATE_IP_HOSTS = frozenset({
     "multimedia.nt.qq.com.cn",
+    "grouptalk.c2c.qq.com",
 })
 
 # 100.64.0.0/10 (CGNAT / Shared Address Space, RFC 6598) is NOT covered by


### PR DESCRIPTION
## Summary

- allow the QQ Bot C2C attachment host `grouptalk.c2c.qq.com` to use the existing HTTPS-only private/benchmark-IP bypass
- keep the bypass exact-host only, matching the current `multimedia.nt.qq.com.cn` pattern
- add regression coverage for the allowed host plus subdomain and HTTP downgrade rejection

## Why

Issue #47123 reports that C2C file attachments can be dropped when `grouptalk.c2c.qq.com` resolves to `198.18.0.0/15` behind Clash TUN, corporate proxy, or VPN setups. The existing `url_safety` logic already has a narrow allowlist for QQ media hosts in this benchmark-range case; the C2C file host was missing from that list.

## Verification

- RED proof on upstream/main: `test_qq_c2c_grouptalk_hostname_allowed_with_benchmark_ip` fails with `AssertionError: assert False is True` and logs `Blocked request to private/internal address: grouptalk.c2c.qq.com -> 198.18.2.16`.
- `/Users/evinova-self/.hermes/hermes-agent/venv/bin/python3 -m pytest tests/tools/test_url_safety.py -v -o "addopts=" --tb=short` → `121 passed`
- `/Users/evinova-self/.hermes/hermes-agent/venv/bin/python3 -m pytest tests/gateway/test_qqbot.py -q -o "addopts=" --tb=short` → `161 passed, 4 warnings` (pre-existing coroutine warnings in qqbot tests)
- Branch verified exactly one commit ahead of `upstream/main`: `0 1`

## Duplicate / competitor check

Before publication I checked open PRs by issue number, Tranquil-Flow branch pattern, `grouptalk.c2c.qq.com`, and `_TRUSTED_PRIVATE_IP_HOSTS`. No open competing PR targets #47123 or this host.

Auto-published by Moonsong via Path B automated pipeline.
