### PR TITLE
[codex] test tool dispatch helper coverage

### DIFF
--- a/tests/agent/test_tool_dispatch_helpers.py
+++ b/tests/agent/test_tool_dispatch_helpers.py
@@ -1,4 +1,6 @@
-"""Tests for the tool-result message builder — focuses on the untrusted-content
+"""Tests for tool dispatch helpers — parallel gating and tool-result messages.
+
+The tool-result message builder tests focus on the untrusted-content
 delimiter wrapping that hardens against indirect prompt injection (#496).
 
 Promptware defense: results from tools that fetch attacker-controllable content
@@ -8,13 +10,303 @@ NOT a regex scan — it's an unconditional architectural mark on every result
 from a known-untrusted source.
 """
 
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
 import pytest
 
+from agent import tool_dispatch_helpers as helpers
 from agent.tool_dispatch_helpers import (
+    _append_subdir_hint_to_multimodal,
+    _extract_error_preview,
+    _extract_file_mutation_targets,
+    _extract_parallel_scope_path,
+    _is_destructive_command,
+    _is_multimodal_tool_result,
     _is_untrusted_tool,
     _maybe_wrap_untrusted,
+    _multimodal_text_summary,
+    _paths_overlap,
+    _should_parallelize_tool_batch,
+    _trajectory_normalize_msg,
     make_tool_result_message,
 )
+
+
+def _tool_call(name: str, arguments):
+    if not isinstance(arguments, str):
+        arguments = json.dumps(arguments)
+    return SimpleNamespace(
+        function=SimpleNamespace(
+            name=name,
+            arguments=arguments,
+        )
+    )
+
+
+# =========================================================================
+# Parallel dispatch gating
+# =========================================================================
+
+
+class TestDestructiveCommandHeuristic:
+    @pytest.mark.parametrize(
+        ("command", "expected"),
+        [
+            ("", False),
+            ("cat README.md", False),
+            ("grep -R needle . >> matches.txt", False),
+            ("rm -rf build", True),
+            ("git reset --hard HEAD", True),
+            ("sed -i '' s/a/b/ file.txt", True),
+            ("echo changed > file.txt", True),
+        ],
+    )
+    def test_destructive_command_detection(self, command, expected):
+        assert _is_destructive_command(command) is expected
+
+
+class TestParallelToolBatch:
+    def test_single_call_is_sequential(self):
+        assert not _should_parallelize_tool_batch(
+            [_tool_call("read_file", {"path": "a.txt"})]
+        )
+
+    def test_never_parallel_tool_blocks_batch(self):
+        calls = [
+            _tool_call("read_file", {"path": "a.txt"}),
+            _tool_call("clarify", {"question": "choose"}),
+        ]
+
+        assert not _should_parallelize_tool_batch(calls)
+
+    def test_malformed_or_non_dict_arguments_are_sequential(self):
+        assert not _should_parallelize_tool_batch(
+            [
+                _tool_call("read_file", '{"path":'),
+                _tool_call("search_files", {"pattern": "x"}),
+            ]
+        )
+        assert not _should_parallelize_tool_batch(
+            [
+                _tool_call("read_file", ["not", "a", "dict"]),
+                _tool_call("search_files", {"pattern": "x"}),
+            ]
+        )
+
+    def test_read_only_tools_can_parallelize(self):
+        calls = [
+            _tool_call("search_files", {"pattern": "needle"}),
+            _tool_call("web_search", {"query": "Hermes"}),
+        ]
+
+        assert _should_parallelize_tool_batch(calls)
+
+    def test_path_scoped_tools_parallelize_when_paths_do_not_overlap(
+        self,
+        tmp_path,
+        monkeypatch,
+    ):
+        monkeypatch.chdir(tmp_path)
+        calls = [
+            _tool_call("read_file", {"path": "docs/a.md"}),
+            _tool_call("write_file", {"path": "src/b.py", "content": "x"}),
+        ]
+
+        assert _should_parallelize_tool_batch(calls)
+
+    def test_path_scoped_tools_reject_missing_or_overlapping_paths(
+        self,
+        tmp_path,
+        monkeypatch,
+    ):
+        monkeypatch.chdir(tmp_path)
+
+        assert not _should_parallelize_tool_batch(
+            [
+                _tool_call("read_file", {"path": ""}),
+                _tool_call("search_files", {"pattern": "x"}),
+            ]
+        )
+        assert not _should_parallelize_tool_batch(
+            [
+                _tool_call("write_file", {"path": "src", "content": "x"}),
+                _tool_call("patch", {"path": "src/app.py", "old_string": "x", "new_string": "y"}),
+            ]
+        )
+
+    def test_unknown_tools_require_mcp_parallel_opt_in(self, monkeypatch):
+        calls = [
+            _tool_call("mcp_docs_search", {"query": "api"}),
+            _tool_call("read_file", {"path": "README.md"}),
+        ]
+
+        monkeypatch.setattr(helpers, "_is_mcp_tool_parallel_safe", lambda _name: False)
+        assert not _should_parallelize_tool_batch(calls)
+
+        monkeypatch.setattr(helpers, "_is_mcp_tool_parallel_safe", lambda _name: True)
+        assert _should_parallelize_tool_batch(calls)
+
+
+class TestPathScopeHelpers:
+    def test_scope_path_requires_path_scoped_tool_and_path(self):
+        assert _extract_parallel_scope_path("web_search", {"path": "x"}) is None
+        assert _extract_parallel_scope_path("read_file", {}) is None
+        assert _extract_parallel_scope_path("read_file", {"path": "   "}) is None
+
+    def test_scope_path_normalizes_relative_and_absolute(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        relative = _extract_parallel_scope_path("read_file", {"path": "docs/a.md"})
+        absolute = _extract_parallel_scope_path(
+            "read_file",
+            {"path": str(tmp_path / "docs" / "a.md")},
+        )
+
+        assert relative == absolute
+
+    def test_paths_overlap_for_same_subtree_only(self):
+        assert _paths_overlap(Path("/tmp/project"), Path("/tmp/project/a.py"))
+        assert _paths_overlap(Path("/tmp/project/a.py"), Path("/tmp/project/a.py"))
+        assert not _paths_overlap(Path("/tmp/project/a.py"), Path("/tmp/other/a.py"))
+
+
+# =========================================================================
+# Multimodal envelopes
+# =========================================================================
+
+
+class TestMultimodalHelpers:
+    def test_multimodal_detection_requires_envelope_shape(self):
+        assert _is_multimodal_tool_result(
+            {"_multimodal": True, "content": [{"type": "text", "text": "x"}]}
+        )
+        assert not _is_multimodal_tool_result({"_multimodal": True, "content": "x"})
+        assert not _is_multimodal_tool_result("plain")
+
+    def test_text_summary_prefers_summary_then_text_parts(self):
+        assert (
+            _multimodal_text_summary(
+                {
+                    "_multimodal": True,
+                    "content": [{"type": "text", "text": "verbose"}],
+                    "text_summary": "short",
+                }
+            )
+            == "short"
+        )
+        assert (
+            _multimodal_text_summary(
+                {
+                    "_multimodal": True,
+                    "content": [
+                        {"type": "text", "text": "one"},
+                        {"type": "image_url", "image_url": {"url": "data:"}},
+                        {"type": "text", "text": "two"},
+                    ],
+                }
+            )
+            == "one\ntwo"
+        )
+        assert (
+            _multimodal_text_summary(
+                {"_multimodal": True, "content": [{"type": "image_url"}]}
+            )
+            == "[multimodal tool result]"
+        )
+        assert _multimodal_text_summary("already text") == "already text"
+        assert _multimodal_text_summary({"ok": True}) == '{"ok": true}'
+
+    def test_append_subdir_hint_updates_text_or_inserts_text_part(self):
+        envelope = {
+            "_multimodal": True,
+            "content": [
+                {"type": "text", "text": "summary"},
+                {"type": "image_url", "image_url": {"url": "data:"}},
+            ],
+            "text_summary": "summary",
+        }
+
+        _append_subdir_hint_to_multimodal(envelope, "\n[subdir]")
+
+        assert envelope["content"][0]["text"] == "summary\n[subdir]"
+        assert envelope["content"][1]["type"] == "image_url"
+        assert envelope["text_summary"] == "summary\n[subdir]"
+
+        image_only = {
+            "_multimodal": True,
+            "content": [{"type": "image_url", "image_url": {"url": "data:"}}],
+        }
+
+        _append_subdir_hint_to_multimodal(image_only, "[hint]")
+
+        assert image_only["content"][0] == {"type": "text", "text": "[hint]"}
+
+    def test_append_subdir_hint_ignores_non_multimodal_values(self):
+        value = {"content": [{"type": "text", "text": "unchanged"}]}
+
+        _append_subdir_hint_to_multimodal(value, "[hint]")
+
+        assert value == {"content": [{"type": "text", "text": "unchanged"}]}
+
+
+# =========================================================================
+# Mutation tracking and trajectory helpers
+# =========================================================================
+
+
+class TestMutationAndTrajectoryHelpers:
+    def test_unknown_patch_mode_has_no_mutation_targets(self):
+        assert _extract_file_mutation_targets(
+            "patch",
+            {"mode": "append", "path": "a.py"},
+        ) == []
+
+    def test_error_preview_handles_malformed_json_and_bad_stringification(
+        self,
+        monkeypatch,
+    ):
+        assert _extract_error_preview("{") == "{"
+
+        class BadString:
+            def __str__(self):
+                raise RuntimeError("no string")
+
+        monkeypatch.setattr(helpers, "_multimodal_text_summary", lambda _value: BadString())
+
+        assert _extract_error_preview({"not": "used"}) == ""
+
+    def test_trajectory_normalize_handles_non_dict_multimodal_and_image_parts(self):
+        assert _trajectory_normalize_msg("not a message") == "not a message"
+
+        multimodal_msg = {
+            "role": "tool",
+            "content": {
+                "_multimodal": True,
+                "content": [{"type": "text", "text": "verbose"}],
+                "text_summary": "short",
+            },
+        }
+        assert _trajectory_normalize_msg(multimodal_msg)["content"] == "short"
+
+        image_msg = {
+            "role": "tool",
+            "content": [
+                {"type": "text", "text": "keep"},
+                {"type": "image", "data": "..."},
+                {"type": "image_url", "image_url": {"url": "data:"}},
+                {"type": "input_image", "image_url": {"url": "data:"}},
+            ],
+        }
+
+        cleaned = _trajectory_normalize_msg(image_msg)
+
+        assert cleaned["content"][0] == {"type": "text", "text": "keep"}
+        assert cleaned["content"][1:] == [
+            {"type": "text", "text": "[screenshot]"},
+            {"type": "text", "text": "[screenshot]"},
+            {"type": "text", "text": "[screenshot]"},
+        ]
 
 
 # =========================================================================


### PR DESCRIPTION
## Summary

- Add targeted coverage for `agent.tool_dispatch_helpers` parallel dispatch gating, destructive-command detection, path-scope overlap checks, MCP parallel opt-in handling, multimodal result envelopes, mutation-target fallbacks, error previews, and trajectory normalization.
- Keep the change scoped to tests; no production behavior changes.

## Why

Issue #36320 tracks bringing `agent/tool_dispatch_helpers.py` above the 70% coverage threshold. These helpers sit on the tool communication boundary: they decide when tool calls can run concurrently, how multimodal tool results are reduced for text-only paths, and how file mutation failures are tracked. Focused coverage here protects the harness layer without changing runtime behavior.

Fixes #36320.

## Validation

- `uv run --locked --python 3.11 --extra all --extra dev python -m pytest tests/agent/test_tool_dispatch_helpers.py -q`
- `uv run --locked --python 3.11 --extra all --extra dev ruff check tests/agent/test_tool_dispatch_helpers.py`
- `uv run --python 3.11 --extra all --extra dev --with pytest-cov python -m pytest tests/agent/test_tool_dispatch_helpers.py tests/run_agent/test_file_mutation_verifier.py tests/run_agent/test_tool_name_db_persistence.py --cov=agent.tool_dispatch_helpers --cov-report=term-missing -q`

Coverage for `agent/tool_dispatch_helpers.py`: 95% (`182` statements, `9` missing).