### PR TITLE
fix: start gateway before dashboard when messaging is offline

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -287,7 +287,7 @@ from hermes_cli.subcommands.config import build_config_parser
 from hermes_cli.subcommands.version import build_version_parser
 from hermes_cli.subcommands.update import build_update_parser
 from hermes_cli.subcommands.uninstall import build_uninstall_parser
-from hermes_cli.subcommands.dashboard import build_dashboard_parser
+from hermes_cli.subcommands.dashboard import build_dashboard_parser, _ensure_gateway_starts_with_dashboard
 from hermes_cli.subcommands.gui import build_gui_parser
 from hermes_cli.subcommands.logs import build_logs_parser
 from hermes_cli.subcommands.prompt_size import build_prompt_size_parser
@@ -10712,6 +10712,11 @@ def cmd_dashboard(args):
         # we killed at least one, 1 if they were all unkillable.
         remaining = _find_stale_dashboard_pids()
         sys.exit(1 if remaining else 0)
+
+    # Gateway self-heal: the dashboard is the desktop's primary entrypoint, so
+    # messaging should come up even if the user launched the UI before the
+    # gateway service was loaded.
+    _ensure_gateway_starts_with_dashboard()
 
     # ── Unified profile launch routing ────────────────────────────────
     # The dashboard is a MACHINE management surface: it can read/write any

--- a/hermes_cli/subcommands/dashboard.py
+++ b/hermes_cli/subcommands/dashboard.py
@@ -10,6 +10,40 @@ import argparse
 from typing import Callable
 
 
+def _ensure_gateway_starts_with_dashboard() -> None:
+    """Best-effort self-heal: dashboard startup should not leave messaging offline."""
+    try:
+        from hermes_cli.gateway import (
+            get_gateway_runtime_snapshot,
+            is_macos,
+            launchd_start,
+            supports_systemd_services,
+            systemd_start,
+        )
+    except Exception as exc:
+        print(f"⚠ Could not inspect Hermes gateway state before dashboard startup: {exc}")
+        return
+
+    try:
+        snapshot = get_gateway_runtime_snapshot(system=False)
+        if snapshot.service_running or snapshot.gateway_pids:
+            return
+    except Exception as exc:
+        print(f"⚠ Could not inspect Hermes gateway state before dashboard startup: {exc}")
+        return
+
+    print("Gateway is not running; starting Hermes gateway before dashboard.")
+    try:
+        if is_macos():
+            launchd_start()
+        elif supports_systemd_services():
+            systemd_start(system=False)
+        else:
+            print("Gateway service manager is not supported here; run `hermes gateway start` manually.")
+    except Exception as exc:
+        print(f"⚠ Could not start Hermes gateway before dashboard startup: {exc}")
+
+
 def build_dashboard_parser(
     subparsers, *, cmd_dashboard: Callable, cmd_dashboard_register: Callable
 ) -> None:


### PR DESCRIPTION
## Summary
Dashboard is the desktop primary entrypoint, but it could start while the Hermes gateway service was offline. This adds a best-effort self-heal guard before dashboard profile routing/server startup:

- Inspect gateway runtime snapshot.
- Return immediately if gateway is already running.
- Start launchd on macOS or systemd service where supported.
- Print a clear manual fallback when no supported service manager is available.

## Verification
- `python -m compileall hermes_cli/subcommands/dashboard.py hermes_cli/main.py` — exit 0
- `_ensure_gateway_starts_with_dashboard()` import/call — exit 0
- `hermes gateway status --full` — gateway loaded, `PID = 41947`
- `git diff --check` — exit 0

## Notes
- No deployment was run.
- Existing gateway launchd config remains unchanged.