### PR TITLE
fix(models): pass model.base_url to fetch_models in /model picker

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -2368,7 +2368,7 @@ def provider_model_ids(provider: Optional[str], *, force_refresh: bool = False) 
             if not base_url:
                 base_url = _p.base_url
             if api_key:
-                live = _p.fetch_models(api_key=api_key)
+                live = _p.fetch_models(api_key=api_key, base_url=base_url or None)
                 if live:
                     if normalized in {"kimi-coding", "kimi-coding-cn"}:
                         curated = list(_PROVIDER_MODELS.get(normalized, []))

--- a/plugins/model-providers/anthropic/__init__.py
+++ b/plugins/model-providers/anthropic/__init__.py
@@ -17,6 +17,7 @@ class AnthropicProfile(ProviderProfile):
         self,
         *,
         api_key: str | None = None,
+        base_url: str | None = None,
         timeout: float = 8.0,
     ) -> list[str] | None:
         """Anthropic uses x-api-key header and anthropic-version."""

--- a/plugins/model-providers/bedrock/__init__.py
+++ b/plugins/model-providers/bedrock/__init__.py
@@ -11,6 +11,7 @@ class BedrockProfile(ProviderProfile):
         self,
         *,
         api_key: str | None = None,
+        base_url: str | None = None,
         timeout: float = 8.0,
     ) -> list[str] | None:
         """Bedrock model listing requires AWS SDK, not a REST call."""

--- a/plugins/model-providers/copilot-acp/__init__.py
+++ b/plugins/model-providers/copilot-acp/__init__.py
@@ -16,6 +16,7 @@ class CopilotACPProfile(ProviderProfile):
         self,
         *,
         api_key: str | None = None,
+        base_url: str | None = None,
         timeout: float = 8.0,
     ) -> list[str] | None:
         """Model listing is handled by the ACP subprocess."""

--- a/plugins/model-providers/custom/__init__.py
+++ b/plugins/model-providers/custom/__init__.py
@@ -43,12 +43,13 @@ class CustomProfile(ProviderProfile):
         self,
         *,
         api_key: str | None = None,
+        base_url: str | None = None,
         timeout: float = 8.0,
     ) -> list[str] | None:
         """Custom/Ollama: base_url is user-configured; fetch if set."""
-        if not self.base_url:
+        if not (base_url or self.base_url):
             return None
-        return super().fetch_models(api_key=api_key, timeout=timeout)
+        return super().fetch_models(api_key=api_key, base_url=base_url, timeout=timeout)
 
 
 custom = CustomProfile(

--- a/plugins/model-providers/openrouter/__init__.py
+++ b/plugins/model-providers/openrouter/__init__.py
@@ -51,6 +51,7 @@ class OpenRouterProfile(ProviderProfile):
         self,
         *,
         api_key: str | None = None,
+        base_url: str | None = None,
         timeout: float = 8.0,
     ) -> list[str] | None:
         """Fetch from public OpenRouter catalog — no auth required.
@@ -64,7 +65,7 @@ class OpenRouterProfile(ProviderProfile):
         if _CACHE is not None:
             return _CACHE
         try:
-            result = super().fetch_models(api_key=None, timeout=timeout)
+            result = super().fetch_models(api_key=None, base_url=base_url, timeout=timeout)
             if result is not None:
                 _CACHE = result
             return result

--- a/providers/base.py
+++ b/providers/base.py
@@ -163,6 +163,7 @@ class ProviderProfile:
         self,
         *,
         api_key: str | None = None,
+        base_url: str | None = None,
         timeout: float = 8.0,
     ) -> list[str] | None:
         """Fetch the live model list from the provider's models endpoint.
@@ -175,7 +176,8 @@ class ProviderProfile:
              endpoint differs from the inference base URL, e.g. OpenRouter
              exposes a public catalog at /api/v1/models while inference is
              at /api/v1)
-          2. self.base_url + "/models"  (standard OpenAI-compat fallback)
+          2. base_url (caller override — user-configured model.base_url)
+          3. self.base_url + "/models"  (standard OpenAI-compat fallback)
 
         The default implementation sends Bearer auth when api_key is given
         and forwards self.default_headers. Override to customise auth, path,
@@ -184,11 +186,12 @@ class ProviderProfile:
         Callers must always fall back to the static _PROVIDER_MODELS list
         when this returns None.
         """
+        effective_base = base_url or self.base_url
         url = (self.models_url or "").strip()
         if not url:
-            if not self.base_url:
+            if not effective_base:
                 return None
-            url = self.base_url.rstrip("/") + "/models"
+            url = effective_base.rstrip("/") + "/models"
 
         import json
         import urllib.request

--- a/tests/providers/test_fetch_models_base_url.py
+++ b/tests/providers/test_fetch_models_base_url.py
@@ -1,0 +1,140 @@
+"""Tests for ProviderProfile.fetch_models base_url override (issue #47009)."""
+
+import json
+from http.server import HTTPServer, BaseHTTPRequestHandler
+from threading import Thread
+from unittest.mock import patch, MagicMock
+
+from providers.base import ProviderProfile
+
+
+class _FakeModelHandler(BaseHTTPRequestHandler):
+    """Serves /models with a configurable model list."""
+
+    models = [{"id": "custom-model-1"}, {"id": "custom-model-2"}]
+
+    def do_GET(self):
+        if self.path.rstrip("/") == "/models":
+            body = json.dumps({"data": self.models}).encode()
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.end_headers()
+            self.wfile.write(body)
+        else:
+            self.send_response(404)
+            self.end_headers()
+
+    def log_message(self, format, *args):
+        pass  # suppress noise
+
+
+def _start_server(models=None):
+    """Start a local HTTP server returning given models. Returns (server, port)."""
+    if models is not None:
+        _FakeModelHandler.models = models
+    server = HTTPServer(("127.0.0.1", 0), _FakeModelHandler)
+    port = server.server_address[1]
+    thread = Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    return server, port
+
+
+class TestFetchModelsBaseUrlOverride:
+    """fetch_models() should use caller-provided base_url when given."""
+
+    def test_base_url_override_used(self):
+        """When base_url is passed, it overrides self.base_url."""
+        server, port = _start_server([{"id": "proxy-model-a"}])
+        try:
+            profile = ProviderProfile(
+                name="test",
+                base_url="http://127.0.0.1:1",  # wrong port — should not be used
+            )
+            result = profile.fetch_models(
+                api_key="test-key",
+                base_url=f"http://127.0.0.1:{port}",
+            )
+            assert result == ["proxy-model-a"]
+        finally:
+            server.shutdown()
+
+    def test_fallback_to_self_base_url(self):
+        """When base_url is None, falls back to self.base_url."""
+        server, port = _start_server([{"id": "default-model"}])
+        try:
+            profile = ProviderProfile(
+                name="test",
+                base_url=f"http://127.0.0.1:{port}",
+            )
+            result = profile.fetch_models(api_key="test-key")
+            assert result == ["default-model"]
+        finally:
+            server.shutdown()
+
+    def test_no_base_url_returns_none(self):
+        """When both base_url and self.base_url are empty, returns None."""
+        profile = ProviderProfile(name="test", base_url="")
+        result = profile.fetch_models(api_key="test-key", base_url="")
+        assert result is None
+
+    def test_base_url_override_with_models_url_set(self):
+        """When self.models_url is set, base_url override is ignored (models_url wins)."""
+        server, port = _start_server([{"id": "from-models-url"}])
+        try:
+            profile = ProviderProfile(
+                name="test",
+                base_url="http://127.0.0.1:1",
+                models_url=f"http://127.0.0.1:{port}/models",
+            )
+            # base_url override should NOT be used because models_url takes priority
+            result = profile.fetch_models(
+                api_key="test-key",
+                base_url="http://127.0.0.1:1",
+            )
+            assert result == ["from-models-url"]
+        finally:
+            server.shutdown()
+
+
+class TestCustomProviderBaseUrlPassthrough:
+    """Custom provider (ollama/local) should pass base_url through to super."""
+
+    def test_custom_passes_base_url(self):
+        """CustomProfile.fetch_models passes base_url to super()."""
+        server, port = _start_server([{"id": "ollama-model"}])
+        try:
+            from plugins.model_providers.custom import CustomProfile
+            profile = CustomProfile(
+                name="custom",
+                base_url="http://127.0.0.1:1",  # wrong port
+            )
+            result = profile.fetch_models(
+                api_key="",
+                base_url=f"http://127.0.0.1:{port}",
+            )
+            assert result == ["ollama-model"]
+        finally:
+            server.shutdown()
+
+
+class TestModelPickerBaseUrlIntegration:
+    """The /model picker path should pass model.base_url to fetch_models."""
+
+    def test_picker_passes_base_url(self):
+        """Verify models.py caller passes base_url to fetch_models."""
+        mock_profile = MagicMock()
+        mock_profile.auth_type = "api_key"
+        mock_profile.base_url = "https://default.api.com"
+        mock_profile.fetch_models.return_value = ["model-a"]
+
+        with (
+            patch("providers.get_provider_profile", return_value=mock_profile),
+            patch("hermes_cli.auth.resolve_api_key_provider_credentials",
+                  return_value={"api_key": "sk-test", "base_url": "https://custom.proxy.com"}),
+        ):
+            from hermes_cli.models import provider_model_ids
+            result = provider_model_ids("test-provider")
+            # Verify fetch_models was called with base_url
+            mock_profile.fetch_models.assert_called_once()
+            call_kwargs = mock_profile.fetch_models.call_args
+            assert call_kwargs.kwargs.get("base_url") == "https://custom.proxy.com"


### PR DESCRIPTION
## What does this PR do?

Fixes the `/model` interactive picker to respect `model.base_url` from config.yaml when fetching available models from the provider's API endpoint. Previously, the picker always queried the provider's hardcoded default URL, ignoring any user-configured custom base URL.

## Related Issue

Fixes #47009

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `providers/base.py`: Add optional `base_url` parameter to `ProviderProfile.fetch_models()` — when provided, it overrides `self.base_url` for URL construction (models_url still takes priority)
- `hermes_cli/models.py`: Pass the resolved `base_url` from credentials to `_p.fetch_models()` in `provider_model_ids()`
- `plugins/model-providers/custom/__init__.py`: Pass `base_url` through to `super().fetch_models()` and use it for the empty-check guard
- `plugins/model-providers/openrouter/__init__.py`: Pass `base_url` through to `super().fetch_models()`
- `plugins/model-providers/anthropic/__init__.py`: Accept `base_url` parameter for signature compatibility (not used — Anthropic hardcodes its own URL)
- `plugins/model-providers/bedrock/__init__.py`: Accept `base_url` parameter for signature compatibility (returns None — no REST endpoint)
- `plugins/model-providers/copilot-acp/__init__.py`: Accept `base_url` parameter for signature compatibility (returns None — ACP subprocess)
- `tests/providers/test_fetch_models_base_url.py`: 6 regression tests covering base_url override, fallback to self.base_url, empty base_url, models_url priority, custom provider passthrough, and integration with the picker caller

## How to Test

1. Set `model.base_url: http://localhost:11434` in config.yaml with `provider: custom`
2. Run `hermes` and type `/model`
3. Verify the picker queries `http://localhost:11434/models` (not the default empty URL)
4. Run `pytest tests/providers/test_fetch_models_base_url.py -q` — all 6 tests should pass
5. Run `pytest tests/providers/test_provider_profiles.py -q` — all 53 existing tests should pass

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `providers/base.py:fetch_models` (base class URL construction), `hermes_cli/models.py:provider_model_ids` (picker caller path)
- Blast radius: LOW — additive parameter with default None; all existing call sites unchanged
- Related patterns: `runtime_provider.py:371-382` already reads `model.base_url` for runtime inference; this PR mirrors that logic for the picker path
