### PR TITLE
fix(desktop): show late available reasoning

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-message-stream.test.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest'
+
+import { reasoningPart, textPart } from '@/lib/chat-messages'
+
+import { applyReasoningAvailable } from './use-message-stream'
+
+describe('applyReasoningAvailable', () => {
+  it('inserts available reasoning before existing assistant text', () => {
+    const parts = applyReasoningAvailable([textPart('Final answer.')], 'Late reasoning.')
+
+    expect(parts.map(part => part.type)).toEqual(['reasoning', 'text'])
+    expect(parts[0]).toEqual(reasoningPart('Late reasoning.'))
+    expect(parts[1]).toEqual(textPart('Final answer.'))
+  })
+
+  it('keeps the current reasoning part when one already exists', () => {
+    const existing = [reasoningPart('Streaming reasoning.'), textPart('Final answer.')]
+    const parts = applyReasoningAvailable(existing, 'Late reasoning.')
+
+    expect(parts).toBe(existing)
+  })
+})

--- a/apps/desktop/src/app/session/hooks/use-message-stream.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream.ts
@@ -131,6 +131,20 @@ function hasSessionInfoStatePatch(patch: SessionRuntimeStatePatch): boolean {
   return Object.keys(patch).length > 0
 }
 
+export function applyReasoningAvailable(parts: ChatMessagePart[], text: string): ChatMessagePart[] {
+  if (parts.some(part => part.type === 'reasoning')) {
+    return parts
+  }
+
+  const textIndex = parts.findIndex(part => part.type === 'text')
+
+  if (textIndex < 0) {
+    return [...parts, reasoningPart(text)]
+  }
+
+  return [...parts.slice(0, textIndex), reasoningPart(text), ...parts.slice(textIndex)]
+}
+
 // Minimum gap between two assistant-text flushes during a stream. Was 16ms
 // (rAF only), which at typical LLM token rates of ~30-80 tok/sec meant every
 // token got its own React commit + Streamdown markdown re-parse, scaling
@@ -464,17 +478,7 @@ export function useMessageStream({
 
       mutateStream(
         sessionId,
-        (parts, message) => {
-          if (replace && chatMessageText(message).trim()) {
-            return parts
-          }
-
-          if (replace) {
-            return [...parts.filter(part => part.type !== 'reasoning'), reasoningPart(delta)]
-          }
-
-          return appendReasoningPart(parts, delta)
-        },
+        parts => (replace ? applyReasoningAvailable(parts, delta) : appendReasoningPart(parts, delta)),
         () => [reasoningPart(delta)]
       )
     },


### PR DESCRIPTION
Fixes the live desktop path where `reasoning.available` could be ignored after assistant text had already streamed.

The stream reducer now only skips the available reasoning event when a reasoning part already exists. If the live message only has text, it inserts the reasoning part before the text so the live transcript matches the hydrated transcript after reload.

Closes #47165

Checked with:
- `npm run test:ui -- src/app/session/hooks/use-message-stream.test.ts`
- `npx eslint src/app/session/hooks/use-message-stream.ts src/app/session/hooks/use-message-stream.test.ts`
- `npm run typecheck`