### PR TITLE
feat(tui_gateway): add session.archive RPC to match desktop parity

### DIFF
--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -4646,6 +4646,43 @@ def _(rid, params: dict) -> dict:
         return _err(rid, 5007, str(e))
 
 
+@method("session.archive")
+def _(rid, params: dict) -> dict:
+    """Archive or unarchive a session.
+
+    Mirrors the Desktop ``setSessionArchived()`` flow: toggles the
+    ``archived`` flag on the session row (and its compression lineage).
+    Archived sessions are hidden from default lists but keep all messages.
+    """
+    session, err = _sess_nowait(params, rid)
+    if err:
+        return err
+    db = _get_db()
+    if db is None:
+        return _db_unavailable_error(rid, code=5007)
+    key = session["session_key"]
+    archived = params.get("archived")
+    if archived is None:
+        return _err(rid, 4024, "archived field required")
+    try:
+        ok = db.set_session_archived(key, bool(archived))
+        if ok:
+            return _ok(rid, {"archived": bool(archived), "session_key": key})
+        # rowcount == 0 can mean "already that value" or "missing row".
+        existing_row = db.get_session(key)
+        if existing_row:
+            return _ok(
+                rid,
+                {
+                    "archived": bool(archived),
+                    "session_key": key,
+                },
+            )
+        return _err(rid, 4007, "session not found")
+    except Exception as e:
+        return _err(rid, 5007, str(e))
+
+
 @method("handoff.request")
 def _(rid, params: dict) -> dict:
     """Queue a handoff of this session to a messaging platform.


### PR DESCRIPTION
## What

Adds  to  so TUI users can archive/unarchive sessions via JSON-RPC.

## Why

Desktop already supports session archiving via  with  (see ). The TUI gateway had no equivalent RPC method, forcing TUI users to either keep all sessions visible or permanently delete them.

Fixes #47168

## Changes

- New  RPC handler in 
- Accepts 
- Calls  which handles compression lineage recursive archiving
- Returns  on success, appropriate errors on failure
- Follows the same pattern as existing  and  handlers

## Test plan

- [x] Syntax check passes ()
- [x] Diff is exactly one file change ()
- [x] Commit message follows conventional-commit style
- [ ] E2E: start a TUI session, call , verify session is hidden from  but still accessible via  with 

## Related

- #47168 — the issue this PR closes
- #44449 — related web_server PATCH endpoint issue
- #37099 — original desktop archive feature
