### PR TITLE
fix(agent): handle YAML null value in context_length_cache (#47135)

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -916,7 +916,7 @@ def _load_context_cache() -> Dict[str, int]:
     try:
         with open(path, encoding="utf-8") as f:
             data = yaml.safe_load(f) or {}
-        return data.get("context_lengths", {})
+        return data.get("context_lengths") or {}
     except Exception as e:
         logger.debug("Failed to load context length cache: %s", e)
         return {}


### PR DESCRIPTION
Fixes #47135. _load_context_cache() returns None when context_length_cache.yaml has context_lengths: (no value), because YAML parses this as None and dict.get(key, default) only returns default when key is absent, not when value is None. Changed to use or {} fallback.