### PR TITLE
fix: use Telegram rich messages in send_message tool

### DIFF
--- a/tests/tools/test_send_message_tool.py
+++ b/tests/tools/test_send_message_tool.py
@@ -726,7 +726,7 @@ class TestSendToPlatformChunking:
 
         sent_calls = []
 
-        async def fake_send(token, chat_id, message, media_files=None, thread_id=None, disable_link_previews=False, force_document=False):
+        async def fake_send(token, chat_id, message, media_files=None, thread_id=None, disable_link_previews=False, force_document=False, **kwargs):
             sent_calls.append(media_files or [])
             return {"success": True, "platform": "telegram", "chat_id": chat_id, "message_id": str(len(sent_calls))}
 
@@ -980,6 +980,395 @@ class TestSendTelegramHtmlDetection:
         assert result["success"] is True
         assert bot.send_message.await_count == 2
         sleep_mock.assert_awaited_once()
+
+
+# ---------------------------------------------------------------------------
+# Telegram rich-message (sendRichMessage) parity with the gateway adapter
+# ---------------------------------------------------------------------------
+
+
+# Shared rich-content fixtures. Tables with pipes and headings exercise the
+# rich-only constructs that the legacy MarkdownV2 path escapes/destroys.
+RICH_CONTENT = (
+    "## Results\n\n"
+    "| Case | Status |\n|---|---|\n| rich | ✅ |\n\n"
+    "- [x] table renders"
+)
+DANGEROUS_DETAILS_MATH = (
+    "<details><summary>x</summary>\n\n$$E = mc^2$$\n\n</details>"
+)
+HTML_BODY = "Hello <b>world</b>"
+
+
+class TestSendTelegramRichMessages:
+    """Parity tests for the standalone Telegram path's rich-message support.
+
+    Pins behaviour symmetric with ``gateway/platforms/telegram.py``'s
+    ``_try_send_rich`` (24 reference tests in
+    ``tests/gateway/test_telegram_rich_messages.py``): when the per-chat
+    ``extra.rich_messages`` opt-in is on, the tool must reuse the adapter's
+    rich path via a throwaway shell rather than re-implementing it. When the
+    opt-in is off, the tool must behave byte-identically to today (legacy
+    MarkdownV2 / HTML) — the regression-guard tests in
+    ``TestSendTelegramHtmlDetection`` above cover that contract.
+    """
+
+    def _make_bot(self):
+        bot = MagicMock()
+        bot.send_message = AsyncMock(return_value=SimpleNamespace(message_id=1))
+        bot.send_photo = AsyncMock()
+        bot.send_video = AsyncMock()
+        bot.send_voice = AsyncMock()
+        bot.send_audio = AsyncMock()
+        bot.send_document = AsyncMock()
+        # do_api_request as AsyncMock makes
+        # ``inspect.iscoroutinefunction(bot.do_api_request)`` True (real
+        # PTB Bot.do_api_request is async too), so any
+        # ``_bot_supports_rich`` check inside the adapter helpers passes.
+        bot.do_api_request = AsyncMock(return_value={"message_id": 99})
+        return bot
+
+    @staticmethod
+    def _rich_payload(bot):
+        """Extract the api_kwargs payload from the single
+        ``sendRichMessage`` call. Tolerates both call-shapes PTB versions
+        may produce: ``await_args.kwargs[\"api_kwargs\"]`` (preferred /
+        current) and ``await_args.args[1]`` (older positional shape).
+        """
+        call = bot.do_api_request.await_args
+        assert call is not None, "sendRichMessage was never called"
+        assert call.args[0] == "sendRichMessage"
+        payload = call.kwargs.get("api_kwargs")
+        if payload is None:
+            payload = call.args[1]
+        return payload
+
+    # -- AC-T-1 -----------------------------------------------------------
+    def test_rich_off_uses_markdown_v2(self, monkeypatch):
+        """``rich_messages`` absent ⇒ legacy MarkdownV2 path unchanged.
+
+        This is the regression guard: the rich block must not affect any
+        existing caller that did not opt in. ``do_api_request`` is never
+        awaited; ``send_message`` is awaited once with ``parse_mode=
+        "MarkdownV2"`` and the format_message-escaped text.
+        """
+        bot = self._make_bot()
+        _install_telegram_mock(monkeypatch, bot)
+
+        result = asyncio.run(
+            _send_telegram(
+                "tok", "123", RICH_CONTENT,
+                pconfig_extra={},  # rich_messages absent
+            )
+        )
+
+        bot.do_api_request.assert_not_awaited()
+        bot.send_message.assert_awaited_once()
+        kwargs = bot.send_message.await_args.kwargs
+        assert kwargs["parse_mode"] == "MarkdownV2"
+        # The legacy path escapes via TelegramAdapter.format_message.
+        from gateway.platforms.telegram import TelegramAdapter
+        expected_text = TelegramAdapter.__new__(TelegramAdapter).format_message(
+            RICH_CONTENT
+        )
+        assert kwargs["text"] == expected_text
+        assert result["success"] is True
+        assert result["platform"] == "telegram"
+        assert result["chat_id"] == "123"
+
+    # -- AC-T-2 -----------------------------------------------------------
+    def test_rich_on_calls_send_rich_message(self, monkeypatch):
+        """``rich_messages=True`` ⇒ ``do_api_request("sendRichMessage", ...)``
+        with the RAW markdown.
+
+        Asserts the payload preserves pipes / headings / brackets exactly
+        (no ``format_message`` escaping), that ``send_message`` is NOT
+        awaited (the rich path replaces, not augments, the text send), and
+        that the envelope reports the rich ``message_id``.
+        """
+        bot = self._make_bot()
+        _install_telegram_mock(monkeypatch, bot)
+
+        result = asyncio.run(
+            _send_telegram(
+                "tok", "123", RICH_CONTENT,
+                pconfig_extra={"rich_messages": True},
+            )
+        )
+
+        assert bot.do_api_request.await_count == 1
+        bot.send_message.assert_not_awaited()
+        payload = self._rich_payload(bot)
+        # Raw markdown preserved exactly — pipes / brackets intact.
+        assert payload["rich_message"]["markdown"] == RICH_CONTENT
+        assert payload["chat_id"] == 123
+        assert result == {
+            "success": True,
+            "platform": "telegram",
+            "chat_id": "123",
+            "message_id": "99",
+        }
+
+    # -- AC-T-3 -----------------------------------------------------------
+    def test_thread_id_in_rich_routing(self, monkeypatch):
+        """``thread_id=\"5\"`` ⇒ ``payload[\"message_thread_id\"] == 5`` (int).
+
+        Pins parity with the adapter's
+        ``_compute_single_send_routing`` → ``_thread_kwargs_for_send``
+        chain that the standalone shell inherits.
+        """
+        bot = self._make_bot()
+        _install_telegram_mock(monkeypatch, bot)
+
+        asyncio.run(
+            _send_telegram(
+                "tok", "-1001234567890", RICH_CONTENT,
+                thread_id="5",
+                pconfig_extra={"rich_messages": True},
+            )
+        )
+
+        payload = self._rich_payload(bot)
+        assert payload["message_thread_id"] == 5
+        assert payload["rich_message"]["markdown"] == RICH_CONTENT
+
+    # -- AC-T-4 -----------------------------------------------------------
+    def test_general_topic_thread_id_omitted(self, monkeypatch):
+        """``thread_id=\"1\"`` ⇒ ``message_thread_id`` not in payload.
+
+        Telegram's General topic is addressed as
+        ``message_thread_id=\"1\"`` on incoming updates but Bot API sends
+        reject it. The adapter's ``_message_thread_id_for_send`` maps
+        ``\"1\" → None``; the shell inherits that mapping.
+        """
+        bot = self._make_bot()
+        _install_telegram_mock(monkeypatch, bot)
+
+        asyncio.run(
+            _send_telegram(
+                "tok", "-1001234567890", RICH_CONTENT,
+                thread_id="1",
+                pconfig_extra={"rich_messages": True},
+            )
+        )
+
+        payload = self._rich_payload(bot)
+        assert "message_thread_id" not in payload
+
+    # -- AC-T-5 -----------------------------------------------------------
+    def test_permanent_error_falls_back_to_markdown_v2(self, monkeypatch):
+        """BadRequest from rich endpoint ⇒ silent fallback to MarkdownV2.
+
+        ``_is_rich_fallback_error`` classifies BadRequest as permanent;
+        ``_try_send_rich`` returns ``None``; the standalone path drops
+        through to the legacy MarkdownV2 block and the user still gets
+        their message (best-effort delivery contract).
+        """
+        from telegram.error import BadRequest
+        bot = self._make_bot()
+        bot.do_api_request = AsyncMock(
+            side_effect=BadRequest("can't parse rich message")
+        )
+        _install_telegram_mock(monkeypatch, bot)
+
+        result = asyncio.run(
+            _send_telegram(
+                "tok", "123", RICH_CONTENT,
+                pconfig_extra={"rich_messages": True},
+            )
+        )
+
+        assert bot.do_api_request.await_count == 1
+        # Legacy MarkdownV2 send happened exactly once.
+        assert bot.send_message.await_count == 1
+        kwargs = bot.send_message.await_args.kwargs
+        assert kwargs["parse_mode"] == "MarkdownV2"
+        from gateway.platforms.telegram import TelegramAdapter
+        expected_text = TelegramAdapter.__new__(TelegramAdapter).format_message(
+            RICH_CONTENT
+        )
+        assert kwargs["text"] == expected_text
+        assert result["success"] is True
+
+    # -- AC-T-6 -----------------------------------------------------------
+    def test_transient_failure_does_not_resend_via_legacy(self, monkeypatch):
+        """TimedOut ⇒ fail-closed; do NOT call ``send_message``.
+
+        The rich request may have reached Telegram. Falling back to a
+        legacy ``send_message`` here would duplicate-deliver — the whole
+        point of FR-8 / adapter L1178–1196. The tool returns an error
+        envelope without a second send.
+        """
+        from telegram.error import TimedOut
+        bot = self._make_bot()
+        bot.do_api_request = AsyncMock(side_effect=TimedOut("timed out"))
+        _install_telegram_mock(monkeypatch, bot)
+
+        result = asyncio.run(
+            _send_telegram(
+                "tok", "123", RICH_CONTENT,
+                pconfig_extra={"rich_messages": True},
+            )
+        )
+
+        assert bot.do_api_request.await_count == 1
+        # Critical: no legacy resend → no duplicate.
+        bot.send_message.assert_not_awaited()
+        assert "error" in result
+        assert "timed out" in result["error"].lower()
+
+    # -- AC-T-7 -----------------------------------------------------------
+    def test_oversize_skips_rich(self, monkeypatch):
+        """Body over ``RICH_MESSAGE_MAX_CHARS`` ⇒ predicate False ⇒ MarkdownV2.
+
+        Mirrors the adapter's ``_content_fits_rich_limits`` gate so the
+        tool path matches the adapter's content-size contract.
+        """
+        from gateway.platforms.telegram import TelegramAdapter
+        bot = self._make_bot()
+        _install_telegram_mock(monkeypatch, bot)
+
+        oversize = "x" * (TelegramAdapter.RICH_MESSAGE_MAX_CHARS + 1)
+        asyncio.run(
+            _send_telegram(
+                "tok", "123", oversize,
+                pconfig_extra={"rich_messages": True},
+            )
+        )
+
+        bot.do_api_request.assert_not_awaited()
+        bot.send_message.assert_awaited_once()
+
+    # -- AC-T-8 -----------------------------------------------------------
+    def test_html_keeps_html_parse_mode(self, monkeypatch):
+        """HTML content + ``rich_messages=True`` ⇒ HTML parse_mode preserved.
+
+        HTML stays on the legacy ``parse_mode=HTML`` branch by contract
+        (PR #1568) — rich is markdown-only. The predicate's
+        ``has_html`` short-circuit enforces this so an HTML-emitting
+        skill (e.g. one that emits ``<b>``) isn't silently converted.
+        """
+        bot = self._make_bot()
+        _install_telegram_mock(monkeypatch, bot)
+
+        asyncio.run(
+            _send_telegram(
+                "tok", "123", HTML_BODY,
+                pconfig_extra={"rich_messages": True},
+            )
+        )
+
+        bot.do_api_request.assert_not_awaited()
+        bot.send_message.assert_awaited_once()
+        kwargs = bot.send_message.await_args.kwargs
+        assert kwargs["parse_mode"] == "HTML"
+        assert kwargs["text"] == HTML_BODY
+
+    # -- AC-T-9 -----------------------------------------------------------
+    def test_details_math_skips_rich(self, monkeypatch):
+        """``<details>+math`` ⇒ predicate False (TDesktop crash guard).
+
+        Mirrors adapter
+        ``_has_telegram_desktop_details_math_crash_shape``. The check is
+        defensive: a ``<details>`` block containing ``$$...$$`` or
+        ``\\(...\\)`` math crashes the Telegram Desktop client when
+        rendered as rich. Falling back to MarkdownV2 is safe.
+        """
+        bot = self._make_bot()
+        _install_telegram_mock(monkeypatch, bot)
+
+        asyncio.run(
+            _send_telegram(
+                "tok", "123", DANGEROUS_DETAILS_MATH,
+                pconfig_extra={"rich_messages": True},
+            )
+        )
+
+        bot.do_api_request.assert_not_awaited()
+        bot.send_message.assert_awaited_once()
+
+    # -- AC-T-10 ----------------------------------------------------------
+    def test_string_true_in_extra_is_honored(self, monkeypatch):
+        """``\"true\"`` (string) coerces to True (YAML-load parity).
+
+        YAML may load ``rich_messages: \"true\"`` as a string when a user
+        quotes the value. Pins parity with adapter
+        ``_coerce_bool_extra``. Protects against a future regression
+        where someone replaces the coercion helper with raw
+        ``bool(extra.get(...))`` (which would be True for ANY non-empty
+        string — including ``\"false\"``).
+        """
+        bot = self._make_bot()
+        _install_telegram_mock(monkeypatch, bot)
+
+        asyncio.run(
+            _send_telegram(
+                "tok", "123", RICH_CONTENT,
+                pconfig_extra={"rich_messages": "true"},
+            )
+        )
+
+        assert bot.do_api_request.await_count == 1
+
+    # -- AC-T-11 ----------------------------------------------------------
+    @pytest.mark.parametrize(
+        "raw_return",
+        [
+            {"message_id": 42},
+            {"result": {"message_id": 42}},
+            SimpleNamespace(message_id=42),
+        ],
+    )
+    def test_success_envelope_shape(self, monkeypatch, raw_return):
+        """All three Bot API response shapes yield the same envelope.
+
+        ``_try_send_rich`` already normalizes ``msg.message_id``,
+        ``msg['message_id']``, and ``msg['result']['message_id']`` into
+        ``SendResult.message_id`` (stringified). Pins FR-9 — the tool
+        envelope's ``message_id`` is a string, not a SimpleNamespace
+        repr or a dict.
+        """
+        bot = self._make_bot()
+        bot.do_api_request = AsyncMock(return_value=raw_return)
+        _install_telegram_mock(monkeypatch, bot)
+
+        result = asyncio.run(
+            _send_telegram(
+                "tok", "555", RICH_CONTENT,
+                pconfig_extra={"rich_messages": True},
+            )
+        )
+
+        assert result == {
+            "success": True,
+            "platform": "telegram",
+            "chat_id": "555",
+            "message_id": "42",
+        }
+
+    # -- Additional explicit coverage required by the task ----------------
+    def test_disable_link_previews_maps_to_rich_payload(self, monkeypatch):
+        """``disable_link_previews=True`` ⇒ rich payload carries
+        ``link_preview_options={\"is_disabled\": True}``.
+
+        Pins FR-6 parity with the adapter (gateway L1150–1151). Without
+        this, callers that explicitly disabled link previews in
+        ``pconfig.extra`` would silently regain previews when their
+        message went through the rich path.
+        """
+        bot = self._make_bot()
+        _install_telegram_mock(monkeypatch, bot)
+
+        asyncio.run(
+            _send_telegram(
+                "tok", "123", RICH_CONTENT,
+                disable_link_previews=True,
+                pconfig_extra={"rich_messages": True},
+            )
+        )
+
+        payload = self._rich_payload(bot)
+        assert payload.get("link_preview_options") == {"is_disabled": True}
 
 
 class TestSendTelegramThreadIdMapping:

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -785,6 +785,7 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
                 thread_id=thread_id,
                 disable_link_previews=disable_link_previews,
                 force_document=force_document,
+                pconfig_extra=getattr(pconfig, "extra", None) or {},
             )
             if isinstance(result, dict) and result.get("error"):
                 return result
@@ -948,6 +949,75 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
     return last_result
 
 
+def _coerce_rich_extra_bool(extra, key, default=False):
+    """Mirror of TelegramAdapter._coerce_bool_extra without an adapter instance.
+
+    Accepts bool, int/float (0/1), or string "true"/"false"/"yes"/"no"/"1"/
+    "0"/"on"/"off" (case-insensitive, whitespace tolerant). Anything else
+    returns ``default``. Mirrors gateway/platforms/telegram.py::
+    TelegramAdapter._coerce_bool_extra so the standalone tool path honors
+    the same per-chat extras shapes as the live adapter.
+    """
+    if extra is None:
+        return default
+    try:
+        raw = extra.get(key, default)
+    except AttributeError:
+        return default
+    if isinstance(raw, bool):
+        return raw
+    if isinstance(raw, (int, float)):
+        return bool(raw)
+    if isinstance(raw, str):
+        norm = raw.strip().lower()
+        if norm in {"true", "yes", "1", "on"}:
+            return True
+        if norm in {"false", "no", "0", "off", ""}:
+            return False
+    return default
+
+
+def _should_attempt_rich_for_tool(message, extra, has_html):
+    """Tool-side mirror of TelegramAdapter._should_attempt_rich.
+
+    Excludes the runtime ``_rich_send_disabled`` latch (tool sends are
+    one-shot — no second send to optimize away) and the
+    ``_bot_supports_rich`` check (the standalone path always builds a real
+    PTB ``telegram.Bot`` whose ``do_api_request`` is an async coroutine
+    function — capability is guaranteed by construction).
+
+    Returns False when:
+    - HTML tags were detected (HTML stays on the legacy ``parse_mode=HTML``
+      path; rich is markdown-only by design — PR #1568).
+    - ``message`` is empty/whitespace (tool falls through to the media-only
+      send loop).
+    - ``rich_messages`` is not opted-in via ``pconfig.extra``.
+    - ``message`` exceeds ``TelegramAdapter.RICH_MESSAGE_MAX_CHARS``.
+    - ``message`` matches the TDesktop ``<details>+math`` crash shape.
+    """
+    if has_html:
+        return False
+    if not message or not message.strip():
+        return False
+    if not _coerce_rich_extra_bool(extra, "rich_messages", False):
+        return False
+    try:
+        from gateway.platforms.telegram import TelegramAdapter
+    except Exception:
+        return False
+    if len(message) > TelegramAdapter.RICH_MESSAGE_MAX_CHARS:
+        return False
+    # The crash-shape helper reads no instance state; calling it through a
+    # throwaway shell mirrors the precedent at _send_telegram L979–984.
+    try:
+        _shell = TelegramAdapter.__new__(TelegramAdapter)
+        if _shell._has_telegram_desktop_details_math_crash_shape(message):
+            return False
+    except Exception:
+        return False
+    return True
+
+
 def _is_telegram_thread_not_found(error: Exception) -> bool:
     """Check if a Telegram error is a thread-not-found failure.
 
@@ -957,7 +1027,7 @@ def _is_telegram_thread_not_found(error: Exception) -> bool:
     return "thread not found" in str(error).lower()
 
 
-async def _send_telegram(token, chat_id, message, media_files=None, thread_id=None, disable_link_previews=False, force_document=False):
+async def _send_telegram(token, chat_id, message, media_files=None, thread_id=None, disable_link_previews=False, force_document=False, *, pconfig_extra=None):
     """Send via Telegram Bot API (one-shot, no polling needed).
 
     Applies markdown→MarkdownV2 formatting (same as the gateway adapter)
@@ -1011,6 +1081,90 @@ async def _send_telegram(token, chat_id, message, media_files=None, thread_id=No
                 bot = Bot(token=token)
         else:
             bot = Bot(token=token)
+        # ``last_msg`` and ``warnings`` are initialized here (before the
+        # rich block) so a successful rich send can populate ``last_msg``
+        # without being clobbered by a later re-initialization. The legacy
+        # MarkdownV2 / HTML and media blocks below append to these in
+        # place (each branch reads/writes ``last_msg``; the media loop
+        # appends to ``warnings``). FR-9 / FR-11 require the rich-success
+        # ``last_msg`` to survive into the envelope-assembly path.
+        last_msg = None
+        warnings = []
+        # --- Bot API 10.1 rich-message path -----------------------------
+        # When the per-chat config opts in via ``extra.rich_messages``, try
+        # ``sendRichMessage`` with the RAW agent markdown (table pipes,
+        # headings, <details>, task lists, etc. survive). On permanent /
+        # capability errors the adapter coroutine returns ``None`` and we
+        # fall through to the existing MarkdownV2 block unchanged. On
+        # transient errors we return a failure envelope WITHOUT a legacy
+        # resend so we cannot double-deliver. Reusing the adapter's
+        # ``_try_send_rich`` via a throwaway shell (precedent at L979–984)
+        # keeps the rich payload and routing logic in a single source of
+        # truth — see gateway/platforms/telegram.py::_try_send_rich.
+        if _should_attempt_rich_for_tool(message, pconfig_extra, _has_html):
+            try:
+                from gateway.config import Platform as _RichPlatform
+                from gateway.platforms.telegram import TelegramAdapter as _RichTelegramAdapter
+                _shell = _RichTelegramAdapter.__new__(_RichTelegramAdapter)
+                _shell._bot = bot
+                _shell._rich_messages_enabled = True
+                _shell._rich_send_disabled = False
+                _shell._disable_link_previews = bool(disable_link_previews)
+                # Tool sends are explicit user actions, not background pings.
+                _shell._notifications_mode = "all"
+                # The tool has no reply anchor of its own.
+                _shell._reply_to_mode = "off"
+                # ``name`` is a read-only property derived from
+                # ``self.platform`` on BasePlatformAdapter; assigning it
+                # raises AttributeError. Setting ``platform`` keeps the
+                # logging path inside _try_send_rich working.
+                _shell.platform = _RichPlatform.TELEGRAM
+                _rich_metadata = (
+                    {"thread_id": str(thread_id)} if thread_id is not None else None
+                )
+                logger.debug(
+                    "send_message: attempting Telegram rich send (raw markdown, %d chars)",
+                    len(message),
+                )
+                _rich_result = await _shell._try_send_rich(
+                    str(chat_id),
+                    message,
+                    reply_to=None,
+                    metadata=_rich_metadata,
+                )
+            except Exception as _rich_setup_err:
+                # Anything that breaks shell construction (e.g. adapter
+                # import failed in a stripped-down environment) MUST fall
+                # through to the legacy MarkdownV2 path, not abort the
+                # whole send.
+                logger.debug(
+                    "send_message: rich-send setup failed (%s); falling back to MarkdownV2",
+                    _rich_setup_err,
+                )
+                _rich_result = None
+            if _rich_result is not None:
+                if _rich_result.success:
+                    # Successful rich send. Skip the legacy MarkdownV2 / HTML
+                    # text send by short-circuiting the ``if formatted.strip():``
+                    # guard below. Any accompanying media still uploads, and
+                    # ``last_msg`` is overwritten by the final media send so
+                    # the envelope's ``message_id`` matches today's semantics
+                    # (FR-9, FR-11).
+                    class _RichMsgShim:
+                        __slots__ = ("message_id",)
+
+                        def __init__(self, mid):
+                            self.message_id = mid if mid is not None else ""
+
+                    last_msg = _RichMsgShim(_rich_result.message_id)
+                    formatted = ""
+                else:
+                    # Transient — DO NOT legacy-resend (the rich request may
+                    # have reached Telegram; resending would duplicate).
+                    return _error(f"Telegram send failed: {_rich_result.error}")
+            # _rich_result is None → permanent / capability fallback; drop
+            # through to the existing MarkdownV2 / HTML block unchanged.
+        # --- end rich block ---------------------------------------------
         int_chat_id = int(chat_id)
         media_files = media_files or []
         thread_kwargs = {}
@@ -1042,9 +1196,6 @@ async def _send_telegram(token, chat_id, message, media_files=None, thread_id=No
         text_kwargs = dict(thread_kwargs)
         if disable_link_previews:
             text_kwargs["disable_web_page_preview"] = True
-
-        last_msg = None
-        warnings = []
 
         if formatted.strip():
             try:


### PR DESCRIPTION
## Summary

Fixes the standalone Telegram delivery path used by the `send_message` tool so `gateway.platforms.telegram.extra.rich_messages: true` actually uses Telegram Bot API `sendRichMessage` instead of falling back to legacy MarkdownV2/HTML text sends.

This matters for out-of-process delivery paths such as scheduled jobs and tool-driven sends: the gateway adapter already had rich-message support, but the standalone tool path never reached it, so Markdown tables and `<details>` blocks were delivered as raw Markdown/HTML.

## Root cause

`tools/send_message_tool.py` routed Telegram sends through its own `_send_telegram()` helper. That helper:

1. detected HTML tags before rich handling,
2. formatted non-HTML content through `TelegramAdapter.format_message()` into MarkdownV2,
3. called `bot.send_message(...)`,
4. never attempted the adapter's `sendRichMessage` path.

For payloads containing `<details>`, the standalone tool could treat the body as Telegram HTML; Telegram HTML does not support `<details>`, so the send failed and the fallback delivered raw text.

## Fix

- Plumb Telegram platform `extra` into `_send_telegram()` as `pconfig_extra`.
- Add a narrow standalone predicate for the rich opt-in and adapter-equivalent skip gates.
- Reuse the existing `TelegramAdapter._try_send_rich()` through a minimal throwaway adapter shell bound to the standalone `Bot` instance.
- Keep the adapter as the single source of truth for rich payload construction, thread routing, fallback classification, link preview options, and duplicate-delivery avoidance.
- Preserve existing behavior when `rich_messages` is absent/false, for HTML content, oversized rich payloads, media sends, and other legacy paths.

No new config keys, environment variables, public adapter APIs, model tools, or platform hooks are added.

## Tests

Added `TestSendTelegramRichMessages` coverage for:

- opt-out/default path still uses legacy MarkdownV2 and never calls `sendRichMessage`;
- opt-in path calls `do_api_request("sendRichMessage", ...)` with raw Markdown and no extra text send;
- rich success returns the rich message id;
- topic `thread_id` routing and General-topic omission;
- permanent rich errors fall back to legacy MarkdownV2;
- transient rich failures do **not** legacy-resend, preventing duplicate delivery;
- HTML payloads remain on the HTML parse-mode path;
- oversized payloads and Telegram Desktop `<details>` + math crash-shape payloads bypass rich;
- string coercion for `extra.rich_messages` matches adapter-style config values;
- `disable_link_previews` maps to rich `link_preview_options`.

## Local validation

```text
python -m py_compile tools/send_message_tool.py tests/tools/test_send_message_tool.py
python -m pytest tests/tools/test_send_message_tool.py tests/gateway/test_telegram_rich_messages.py -q -o 'addopts='

196 passed, 2 warnings in 6.54s
```

The warnings are pre-existing dependency deprecations from `lark_oapi`/`websockets` during the existing long-message chunking test.

## Notes for reviewers

The diff deliberately reuses private adapter helpers via a minimal shell rather than duplicating the Bot API payload code in the tool. That keeps rich-message behavior aligned with the gateway adapter and avoids adding a new public adapter surface for a standalone tool path.
