### PR TITLE
fix(telegram): include custom base_url hostname in proxy_targets for NO_PROXY bypass

### DIFF
--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -1936,6 +1936,13 @@ class TelegramAdapter(BasePlatformAdapter):
                 )
 
             proxy_targets = ["api.telegram.org", *fallback_ips]
+            # Include custom base_url hostname so NO_PROXY entries for it
+            # are respected (e.g. self-hosted Bot API or proxy worker).
+            if custom_base_url:
+                from urllib.parse import urlparse
+                custom_host = urlparse(custom_base_url).hostname
+                if custom_host and custom_host not in proxy_targets:
+                    proxy_targets.append(custom_host)
             proxy_url = resolve_proxy_url("TELEGRAM_PROXY", target_hosts=proxy_targets)
             if fallback_ips and not proxy_url and not disable_fallback:
                 logger.info(

--- a/tests/gateway/test_telegram_proxy_targets.py
+++ b/tests/gateway/test_telegram_proxy_targets.py
@@ -1,0 +1,87 @@
+"""Regression tests for Telegram proxy_targets including custom base_url hostname.
+
+When telegram.extra.base_url is configured (e.g. a self-hosted Bot API server
+or Cloudflare Worker proxy), the gateway adapter must include the custom
+hostname in proxy_targets so that NO_PROXY entries for it are respected.
+
+Without this, requests to the custom host incorrectly go through the HTTP
+proxy even when NO_PROXY lists the hostname.
+
+Issue: #47188
+"""
+
+from __future__ import annotations
+
+from urllib.parse import urlparse
+
+import pytest
+
+from gateway.platforms.base import resolve_proxy_url, should_bypass_proxy
+
+
+class TestProxyTargetsCustomBaseUrl:
+    """Verify that custom base_url hostnames are included in proxy target
+    resolution, enabling NO_PROXY bypass for self-hosted Telegram endpoints."""
+
+    def test_no_proxy_bypasses_custom_host_in_targets(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """When NO_PROXY includes the custom host and it's in target_hosts,
+        resolve_proxy_url returns None (proxy bypassed)."""
+        custom_host = "tgapi.example.com"
+        monkeypatch.setenv("HTTPS_PROXY", "http://proxy.local:8080")
+        monkeypatch.setenv("NO_PROXY", custom_host)
+        monkeypatch.delenv("no_proxy", raising=False)
+
+        # With custom host in targets → bypass
+        result = resolve_proxy_url("TELEGRAM_PROXY", target_hosts=["api.telegram.org", custom_host])
+        assert result is None
+
+    def test_no_proxy_does_not_bypass_without_custom_host(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """When NO_PROXY lists the custom host but it's NOT in target_hosts,
+        the proxy is NOT bypassed (the bug scenario)."""
+        custom_host = "tgapi.example.com"
+        monkeypatch.setenv("HTTPS_PROXY", "http://proxy.local:8080")
+        monkeypatch.setenv("NO_PROXY", custom_host)
+        monkeypatch.delenv("no_proxy", raising=False)
+
+        # Without custom host in targets → proxy applied
+        result = resolve_proxy_url("TELEGRAM_PROXY", target_hosts=["api.telegram.org"])
+        assert result is not None
+        assert "proxy.local" in result
+
+    def test_should_bypass_proxy_with_custom_host(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """should_bypass_proxy returns True when custom host matches NO_PROXY."""
+        monkeypatch.setenv("NO_PROXY", "tgapi.example.com")
+        monkeypatch.delenv("no_proxy", raising=False)
+
+        assert should_bypass_proxy(["api.telegram.org", "tgapi.example.com"]) is True
+
+    def test_should_bypass_proxy_without_custom_host(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """should_bypass_proxy returns False when custom host is missing from targets."""
+        monkeypatch.setenv("NO_PROXY", "tgapi.example.com")
+        monkeypatch.delenv("no_proxy", raising=False)
+
+        assert should_bypass_proxy(["api.telegram.org"]) is False
+
+    def test_custom_host_extraction_from_base_url(self) -> None:
+        """Verify hostname extraction from various base_url formats."""
+        cases = [
+            ("https://tgapi.example.com/bot", "tgapi.example.com"),
+            ("https://my-proxy.workers.dev", "my-proxy.workers.dev"),
+            ("http://192.168.1.100:8081/bot", "192.168.1.100"),
+            ("https://api.telegram.org/bot", "api.telegram.org"),
+        ]
+        for base_url, expected_host in cases:
+            host = urlparse(base_url).hostname
+            assert host == expected_host, f"urlparse({base_url!r}).hostname = {host!r}, expected {expected_host!r}"
+
+    def test_wildcard_no_proxy_bypasses_all(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """NO_PROXY=* bypasses proxy for all targets including custom host."""
+        monkeypatch.setenv("HTTPS_PROXY", "http://proxy.local:8080")
+        monkeypatch.setenv("NO_PROXY", "*")
+        monkeypatch.delenv("no_proxy", raising=False)
+
+        result = resolve_proxy_url(
+            "TELEGRAM_PROXY",
+            target_hosts=["api.telegram.org", "tgapi.example.com"],
+        )
+        assert result is None


### PR DESCRIPTION
## What does this PR do?

Fixes `resolve_proxy_url()` ignoring `NO_PROXY` entries for custom Telegram base_url hostnames. When `telegram.extra.base_url` is configured (e.g. a self-hosted Bot API server or Cloudflare Worker proxy), the `proxy_targets` list only contained `api.telegram.org` and fallback IPs, causing requests to the custom host to incorrectly go through the HTTP proxy.

## Related Issue

Fixes #47188

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/platforms/telegram.py`: Extract hostname from `custom_base_url` via `urlparse()` and append to `proxy_targets` before calling `resolve_proxy_url()`. This ensures `should_bypass_proxy()` can match `NO_PROXY` entries against the custom host.
- `tests/gateway/test_telegram_proxy_targets.py`: 6 regression tests covering NO_PROXY bypass with/without custom host in targets, hostname extraction from various base_url formats, and wildcard NO_PROXY.

## How to Test

1. Configure a custom Telegram base_url in `config.yaml`:
   ```yaml
   telegram:
     extra:
       base_url: "https://tgapi.example.com/bot"
   ```
2. Set `NO_PROXY=tgapi.example.com` and `HTTPS_PROXY=http://proxy.local:8080`
3. Run the gateway — requests to `tgapi.example.com` should connect directly, bypassing the proxy
4. Run `pytest tests/gateway/test_telegram_proxy_targets.py -q` — all 6 tests should pass

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A (fix uses stdlib urlparse, cross-platform safe)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `gateway/platforms/telegram.py:_start_polling` (proxy_targets construction at line 1938)
- Blast radius: LOW — single code path in Telegram adapter, no behavioral change when `base_url` is not configured
- Related patterns: `resolve_proxy_url()` + `should_bypass_proxy()` in `gateway/platforms/base.py` — existing NO_PROXY infrastructure, no changes needed
