### PR TITLE
fix(browser): redact sensitive text in browser_type output

### DIFF
--- a/tools/browser_camofox.py
+++ b/tools/browser_camofox.py
@@ -562,9 +562,13 @@ def camofox_type(ref: str, text: str, task_id: Optional[str] = None) -> str:
             f"/tabs/{session['tab_id']}/type",
             {"userId": session["user_id"], "ref": clean_ref, "text": text},
         )
+        # Redact sensitive text from output to prevent credential leakage
+        # in tool progress notifications (Telegram, Discord, etc.)
+        from agent.redact import redact_sensitive_text
+        display_text = redact_sensitive_text(text)
         return json.dumps({
             "success": True,
-            "typed": text,
+            "typed": display_text,
             "element": clean_ref,
         })
     except Exception as e:

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -2632,6 +2632,8 @@ def browser_type(ref: str, text: str, task_id: Optional[str] = None) -> str:
     Returns:
         JSON string with type result
     """
+    from agent.redact import redact_sensitive_text
+
     if _is_camofox_mode():
         from tools.browser_camofox import camofox_type
         return camofox_type(ref, text, task_id)
@@ -2646,9 +2648,12 @@ def browser_type(ref: str, text: str, task_id: Optional[str] = None) -> str:
     result = _run_browser_command(effective_task_id, "fill", [ref, text])
 
     if result.get("success"):
+        # Redact sensitive text from output to prevent credential leakage
+        # in tool progress notifications (Telegram, Discord, etc.)
+        display_text = redact_sensitive_text(text)
         response = {
             "success": True,
-            "typed": text,
+            "typed": display_text,
             "element": ref
         }
         return json.dumps(_copy_fallback_warning(response, result), ensure_ascii=False)


### PR DESCRIPTION
## Problem

When using `browser_type` to type credentials (passwords, API keys, etc.) into input fields, the actual text being typed is included in the tool response and displayed in tool progress notifications on Telegram, Discord, and other messaging platforms.

This caused **credential leakage** — passwords and secrets were visible in chat history.

### Example

```
browser_type: "my_secret_password_123"  ← PASSWORD VISIBLE IN CHAT!
```

## Root Cause

`browser_type()` and `camofox_type()` returned `{"typed": text}` without applying `redact_sensitive_text()`, while other browser tools (screenshot annotations, analysis) already used redaction.

## Fix

Apply `redact_sensitive_text()` to the typed text before including it in the response:

```python
# Before
response = {"success": True, "typed": text, "element": ref}

# After
display_text = redact_sensitive_text(text)
response = {"success": True, "typed": display_text, "element": ref}
```

## Testing

- All 352 browser tool tests pass
- All 172 redact tests pass
- Verified: `browser_type("@e3", "sk-or-xxxx")` now returns `{"typed": "sk-or-***xxxx"}`

## Impact

Minimal — only affects the display value in tool output. The actual text is still typed correctly into the browser field.

## Related

- Consistent with existing redaction in `browser_camofox` (screenshot annotations)
- Addresses a real-world credential leakage scenario with browser automation