### PR TITLE
fix(agent): cap total subdirectory hints to prevent tool output inflation

### DIFF
--- a/agent/subdirectory_hints.py
+++ b/agent/subdirectory_hints.py
@@ -35,6 +35,11 @@ _HINT_FILENAMES = [
 # Maximum chars per hint file to prevent context bloat
 _MAX_HINT_CHARS = 8_000
 
+# Maximum total chars for all hints appended to a single tool result.
+# Prevents massive output inflation when multiple ancestor directories
+# each contribute hint files (e.g. 5 ancestors × 3 files × 8k = 120k).
+_MAX_TOTAL_HINT_CHARS = 16_000
+
 # Tool argument keys that typically contain file paths
 _PATH_ARG_KEYS = {"path", "file_path", "workdir"}
 
@@ -95,7 +100,13 @@ class SubdirectoryHintTracker:
         if not all_hints:
             return None
 
-        return "\n\n" + "\n\n".join(all_hints)
+        combined = "\n\n" + "\n\n".join(all_hints)
+        if len(combined) > _MAX_TOTAL_HINT_CHARS:
+            combined = (
+                combined[:_MAX_TOTAL_HINT_CHARS]
+                + "\n\n[...subdirectory hints truncated to save context]"
+            )
+        return combined
 
     def _extract_directories(
         self, tool_name: str, args: Dict[str, Any]

--- a/tests/agent/test_subdirectory_hints.py
+++ b/tests/agent/test_subdirectory_hints.py
@@ -234,6 +234,27 @@ class TestSubdirectoryHintTracker:
         # Should be capped
         assert len(result) < 20_000
 
+    def test_total_hint_cap_multiple_ancestors(self, tmp_path):
+        """Total hints from multiple ancestors should be capped."""
+        # Create nested dirs: a/b/c/d/e/file.py, each with a large AGENTS.md
+        # _MAX_ANCESTOR_WALK=5 so 5 ancestor levels get scanned
+        d = tmp_path
+        for name in ["a", "b", "c"]:
+            d = d / name
+            d.mkdir(exist_ok=True)
+            (d / "AGENTS.md").write_text("X" * 8_000)
+        deep_file = d / "file.py"
+        deep_file.write_text("# test")
+
+        tracker = SubdirectoryHintTracker(working_dir=str(tmp_path))
+        result = tracker.check_tool_call("read_file", {"path": str(deep_file)})
+        assert result is not None
+        # Without the total cap, this would be ~24k chars (3 × 8k)
+        # With the cap, it should be <= _MAX_TOTAL_HINT_CHARS + marker
+        from agent.subdirectory_hints import _MAX_TOTAL_HINT_CHARS
+        assert len(result) <= _MAX_TOTAL_HINT_CHARS + 100
+        assert "truncated" in result.lower()
+
     def test_empty_args(self, project):
         """Empty args should not crash."""
         tracker = SubdirectoryHintTracker(working_dir=str(project))


### PR DESCRIPTION
## What does this PR do?

Adds a hard cap (`_MAX_TOTAL_HINT_CHARS = 16_000`) on the combined subdirectory hint output appended to a single tool result, preventing massive context inflation when multiple ancestor directories each contribute hint files.

## Related Issue

Fixes #47194

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/subdirectory_hints.py`: Added `_MAX_TOTAL_HINT_CHARS = 16_000` constant and truncation logic in `check_tool_call()` to cap the combined hint output. Individual file caps (`_MAX_HINT_CHARS = 8_000`) remain unchanged.
- `tests/agent/test_subdirectory_hints.py`: Added `test_total_hint_cap_multiple_ancestors` regression test that creates 3 nested directories each with 8k AGENTS.md files and verifies the total output is capped.

## How to Test

1. Create a deeply nested project structure with large AGENTS.md files at multiple levels (e.g., `a/AGENTS.md`, `a/b/AGENTS.md`, `a/b/c/AGENTS.md`, each 8k+ chars)
2. Run `search_files` or `read_file` targeting a file deep in the hierarchy
3. Verify the appended subdirectory hints do not exceed ~16k chars total (previously would be ~24k+)
4. Run `pytest tests/agent/test_subdirectory_hints.py -q` — all 26 tests should pass

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

⚠️ GitNexus unavailable — grep-based fallback used.
- Checked: `agent/subdirectory_hints.py` (check_tool_call, _load_hints_for_directory, _MAX_HINT_CHARS)
- Checked: `agent/tool_executor.py` (line 1368-1374, hint injection point)
- Blast radius: LOW — only caps combined output size, no behavioral change for hints under 16k total
- Related patterns: existing per-file cap at `_MAX_HINT_CHARS = 8_000` (unchanged)
