### PR TITLE
fix(compression): flush messages before session rotation to prevent data loss

### DIFF
--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -512,6 +512,9 @@ def compress_context(
             old_title = agent._session_db.get_session_title(agent.session_id)
             # Trigger memory extraction on the old session before it rotates.
             agent.commit_memory_session(messages)
+            # Flush un-persisted messages _before_ rotating session_id, otherwise
+            # messages from the current turn are permanently lost (#47202).
+            agent._flush_messages_to_session_db(messages)
             agent._session_db.end_session(agent.session_id, "compression")
             old_session_id = agent.session_id
             agent.session_id = f"{datetime.now().strftime('%Y%m%d_%H%M%S')}_{uuid.uuid4().hex[:6]}"

--- a/cli.py
+++ b/cli.py
@@ -5958,6 +5958,12 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
         old_session_id = self.session_id
         if self._session_db and old_session_id:
             try:
+                # Flush un-persisted messages before rotating session_id (#47202)
+                if self.agent and hasattr(self.agent, '_flush_messages_to_session_db'):
+                    self.agent._flush_messages_to_session_db(self.conversation_history)
+            except Exception:
+                pass
+            try:
                 self._session_db.end_session(old_session_id, "new_session")
             except Exception:
                 pass


### PR DESCRIPTION
## Problem

`compress_context()` in `conversation_compression.py` and `new_session()` in `cli.py` call `end_session()` without first flushing in-memory messages to the session DB. When auto-compression triggers **mid-turn** (context exceeds threshold), messages generated during the current turn that haven't yet been persisted are **permanently lost**:

- The old session ends with `message_count` from its last clean turn
- All messages from the turn that triggered compression are gone
- `session_search`, `/resume`, and offline backup all show a gap

This is especially painful for long tool-heavy turns (vision analysis, code execution, multi-step workflows) where 50+ messages can be generated in a single turn.

## Fix

Add `_flush_messages_to_session_db(messages)` **before** `end_session()` in both sites:

1. **`agent/conversation_compression.py:compress_context()`** — flush before `end_session` when auto-compression rotates the session
2. **`cli.py:new_session()`** — flush before `end_session` when the `/new` command rotates the session

Both fixes use the existing `_flush_messages_to_session_db()` method which is already idempotent (tracks `_last_flushed_db_idx`) and has proper error handling.

Closes #47202