### PR TITLE
feat(web): add multi-search provider plugin

### DIFF
--- a/plugins/web/multi_search/__init__.py
+++ b/plugins/web/multi_search/__init__.py
@@ -1,0 +1,14 @@
+"""Multi-provider web search plugin — Exa + Tavily + web-search-prime.
+
+Registers a single WebSearchProvider (name ``multi-search``) that fans out
+to three search backends in parallel, merges and deduplicates results.
+"""
+
+from __future__ import annotations
+
+from .provider import MultiSearchProvider
+
+
+def register(ctx) -> None:
+    """Register the multi-provider with the plugin context."""
+    ctx.register_web_search_provider(MultiSearchProvider())

--- a/plugins/web/multi_search/plugin.yaml
+++ b/plugins/web/multi_search/plugin.yaml
@@ -1,0 +1,7 @@
+name: web-multi-search
+version: 1.0.0
+description: "Multi-provider fan-out search: queries Exa + Tavily + web-search-prime (z.ai MCP) in parallel, merges and deduplicates for maximum recall. Requires EXA_API_KEY, TAVILY_API_KEY, and web-search-prime MCP configured."
+author: custom
+kind: backend
+provides_web_providers:
+  - multi-search

--- a/plugins/web/multi_search/provider.py
+++ b/plugins/web/multi_search/provider.py
@@ -1,0 +1,355 @@
+"""Multi-provider web search: Exa + Tavily + web-search-prime fan-out.
+
+Registers as a single ``WebSearchProvider`` named ``multi-search``. When
+configured as ``web.backend``, ``web_search`` calls THREE backends in
+parallel:
+
+1. **Tavily** — via the registered ``tavily`` provider (keyword search)
+2. **Exa** — via the registered ``exa`` provider (neural/semantic search)
+3. **web-search-prime** — via the z.ai MCP tool ``mcp_web_search_prime_web_search_prime``
+   (Chinese-region optimized search)
+
+Results are interleaved (round-robin), deduplicated by normalized URL, and
+returned as a single merged set — maximizing recall and diversity.
+
+For ``web_extract``, Tavily's batch ``/extract`` is primary; Exa
+``get_contents`` is the fallback for any URLs Tavily failed on.
+
+Requirements:
+    - ``EXA_API_KEY`` and ``TAVILY_API_KEY`` environment variables
+    - ``web-search-prime`` MCP server configured in ``mcp_servers``
+
+Config::
+
+    web:
+      backend: "multi-search"
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from concurrent.futures import ThreadPoolExecutor
+from typing import Any, Dict, List, Optional
+from urllib.parse import urlparse
+
+from agent.web_search_provider import WebSearchProvider
+
+logger = logging.getLogger(__name__)
+
+# MCP tool name for web-search-prime (mcp_{server}_{tool})
+_WSP_TOOL_NAME = "mcp_web_search_prime_web_search_prime"
+
+
+def _normalize_url(url: str) -> str:
+    """Normalize URL for dedup: lowercase scheme+host, strip trailing slash."""
+    if not url:
+        return ""
+    u = urlparse(url.strip())
+    if not u.scheme or not u.netloc:
+        return url.strip().lower()
+    path = u.path.rstrip("/")
+    return f"{u.scheme.lower()}://{u.netloc.lower()}{path}"
+
+
+def _search_via_tavily(query: str, limit: int) -> Dict[str, Any]:
+    """Call the registered Tavily provider."""
+    from agent.web_search_registry import get_provider
+
+    p = get_provider("tavily")
+    if p is None:
+        return {"success": False, "error": "tavily provider not registered"}
+    return p.search(query, limit)
+
+
+def _search_via_exa(query: str, limit: int) -> Dict[str, Any]:
+    """Call the registered Exa provider."""
+    from agent.web_search_registry import get_provider
+
+    p = get_provider("exa")
+    if p is None:
+        return {"success": False, "error": "exa provider not registered"}
+    return p.search(query, limit)
+
+
+def _search_via_wsp(query: str, limit: int) -> Dict[str, Any]:
+    """Call web-search-prime via the MCP tool registry dispatch.
+
+    Falls back gracefully if the MCP server is not connected.
+    """
+    try:
+        from tools.registry import registry
+
+        entry = registry.get_entry(_WSP_TOOL_NAME)
+        if entry is None:
+            return {"success": False, "error": "web-search-prime MCP not connected"}
+
+        result_str = registry.dispatch(
+            _WSP_TOOL_NAME,
+            {
+                "search_query": query,
+                "content_size": "medium",
+            },
+        )
+        result = json.loads(result_str) if isinstance(result_str, str) else result_str
+
+        # web-search-prime returns results in a different shape — normalize
+        # to {success, data: {web: [{title, url, description, position}]}}
+        return _normalize_wsp_result(result, limit)
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("web-search-prime search error: %s", exc)
+        return {"success": False, "error": f"web-search-prime: {exc}"}
+
+
+def _normalize_wsp_result(result: Any, limit: int) -> Dict[str, Any]:
+    """Normalize web-search-prime MCP response to standard search shape.
+
+    The MCP dispatch wraps the tool output as ``{"result": "<json_string>"}``
+    where the inner JSON string is a serialized array of items with
+    ``title``, ``link``, ``content``, ``refer`` fields. Some wrappers may
+    return already-parsed shapes, so we try several known formats.
+    """
+    # ── Unwrap MCP dispatch envelope ──────────────────────────────────
+    # registry.dispatch() returns json string; _search_via_wsp already
+    # json.loads it. But the MCP tool itself wraps its payload as
+    # {"result": "<another json string>"} — unwrap that here.
+    if isinstance(result, dict):
+        inner = result.get("result")
+        if isinstance(inner, str):
+            try:
+                result = json.loads(inner)
+            except (json.JSONDecodeError, ValueError):
+                pass  # might be plain text
+
+    for _ in range(2):
+        if not isinstance(result, str):
+            break
+        try:
+            result = json.loads(result)
+        except (json.JSONDecodeError, ValueError):
+            break
+
+    # Check for error at envelope level
+    if isinstance(result, dict) and result.get("error"):
+        return {"success": False, "error": f"web-search-prime: {result['error']}"}
+
+    # ── Extract items list from various shapes ────────────────────────
+    items: List[Dict[str, Any]] = []
+
+    if isinstance(result, list):
+        # Already a list of result items
+        items = result
+    elif isinstance(result, dict):
+        # Shape: {data: {web: [...]}}
+        if isinstance(result.get("data"), dict):
+            items = result["data"].get("web", [])
+        # Shape: {results: [...]}
+        if not items:
+            items = result.get("results", [])
+        # Shape: {searchResults: [...]} or {search_results: [...]}
+        if not items:
+            items = result.get("searchResults", result.get("search_results", []))
+        # Shape: {result: [...]}  (already json.loads'd by caller)
+        if not items and isinstance(result.get("result"), list):
+            items = result["result"]
+
+    web_results: List[Dict[str, Any]] = []
+    for i, item in enumerate(items[:limit]):
+        if not isinstance(item, dict):
+            continue
+        web_results.append(
+            {
+                "title": item.get("title", item.get("name", "")),
+                "url": item.get("url", item.get("link", item.get("href", ""))),
+                "description": item.get(
+                    "description",
+                    item.get("snippet", item.get("summary", item.get("content", ""))),
+                ),
+                "position": i + 1,
+            }
+        )
+
+    if not web_results:
+        return {"success": False, "error": "web-search-prime: no results parsed"}
+
+    return {"success": True, "data": {"web": web_results}}
+
+
+class MultiSearchProvider(WebSearchProvider):
+    """Triple fan-out search across Tavily + Exa + web-search-prime."""
+
+    @property
+    def name(self) -> str:
+        return "multi-search"
+
+    @property
+    def display_name(self) -> str:
+        return "Multi (Tavily+Exa+WSP)"
+
+    def is_available(self) -> bool:
+        """True when at least Tavily or Exa is configured.
+
+        web-search-prime availability is checked dynamically per-call
+        since MCP connection state changes.
+        """
+        return bool(
+            os.getenv("TAVILY_API_KEY", "").strip()
+            or os.getenv("EXA_API_KEY", "").strip()
+        )
+
+    def supports_search(self) -> bool:
+        return True
+
+    def supports_extract(self) -> bool:
+        return True
+
+    def search(self, query: str, limit: int = 5) -> Dict[str, Any]:
+        """Call Tavily, Exa, and web-search-prime in parallel; merge & dedup."""
+        try:
+            from tools.interrupt import is_interrupted
+
+            if is_interrupted():
+                return {"success": False, "error": "Interrupted"}
+        except ImportError:
+            pass
+
+        per_provider_limit = max(limit, 5)
+
+        tavily_result: Dict[str, Any] = {}
+        exa_result: Dict[str, Any] = {}
+        wsp_result: Dict[str, Any] = {}
+
+        # ── Parallel triple fan-out ─────────────────────────────────────
+        with ThreadPoolExecutor(max_workers=3) as pool:
+            futures = {
+                "tavily": pool.submit(_search_via_tavily, query, per_provider_limit),
+                "exa": pool.submit(_search_via_exa, query, per_provider_limit),
+                "wsp": pool.submit(_search_via_wsp, query, per_provider_limit),
+            }
+            for name, fut in futures.items():
+                try:
+                    result = fut.result(timeout=45)
+                except Exception as exc:  # noqa: BLE001
+                    logger.warning("%s search raised: %s", name, exc)
+                    result = {"success": False, "error": f"{name}: {exc}"}
+                if name == "tavily":
+                    tavily_result = result
+                elif name == "exa":
+                    exa_result = result
+                else:
+                    wsp_result = result
+
+        # ── Collect errors for logging ──────────────────────────────────
+        errors: List[str] = []
+        sources_data: Dict[str, List[Dict[str, Any]]] = {}
+
+        for name, result in [("tavily", tavily_result), ("exa", exa_result), ("wsp", wsp_result)]:
+            if result.get("success"):
+                sources_data[name] = result.get("data", {}).get("web", [])
+            else:
+                errors.append(f"{name}: {result.get('error', 'unknown')}")
+                sources_data[name] = []
+
+        # ── Interleave (round-robin) for diversity, dedup by URL ────────
+        seen: set[str] = set()
+        merged: List[Dict[str, Any]] = []
+        source_order = ("tavily", "exa", "wsp")
+        max_len = max((len(sources_data[s]) for s in source_order), default=0)
+
+        position = 1
+        for i in range(max_len):
+            for src in source_order:
+                items = sources_data[src]
+                if i < len(items):
+                    item = dict(items[i])
+                    norm = _normalize_url(item.get("url", ""))
+                    if norm and norm in seen:
+                        continue
+                    if norm:
+                        seen.add(norm)
+                    item["position"] = position
+                    item["source"] = src
+                    merged.append(item)
+                    position += 1
+
+        if not merged:
+            return {
+                "success": False,
+                "error": "; ".join(errors) or "All providers returned no results.",
+            }
+
+        if errors:
+            logger.warning(
+                "Multi-search partial failures: %s (returning %d merged results)",
+                "; ".join(errors),
+                len(merged),
+            )
+
+        logger.info(
+            "Multi-search '%s': tavily=%d exa=%d wsp=%d → merged=%d (deduped)",
+            query,
+            len(sources_data["tavily"]),
+            len(sources_data["exa"]),
+            len(sources_data["wsp"]),
+            len(merged),
+        )
+
+        return {"success": True, "data": {"web": merged}}
+
+    def extract(self, urls: List[str], **kwargs: Any) -> List[Dict[str, Any]]:
+        """Tavily batch extract as primary; Exa fallback for failed URLs."""
+        try:
+            from tools.interrupt import is_interrupted
+
+            if is_interrupted():
+                return [{"url": u, "error": "Interrupted", "title": ""} for u in urls]
+        except ImportError:
+            pass
+
+        from agent.web_search_registry import get_provider
+
+        tavily_p = get_provider("tavily")
+        exa_p = get_provider("exa")
+
+        results: List[Dict[str, Any]] = []
+
+        if tavily_p is not None:
+            tavily_docs = tavily_p.extract(urls)
+            failed_urls: List[str] = []
+            for doc, url in zip(tavily_docs, urls):
+                if doc.get("error") or not (doc.get("content") or "").strip():
+                    failed_urls.append(url)
+                else:
+                    results.append(doc)
+
+            if failed_urls and exa_p is not None:
+                logger.info(
+                    "Exa fallback extract for %d/%d URLs", len(failed_urls), len(urls)
+                )
+                exa_docs = exa_p.extract(failed_urls)
+                results.extend(exa_docs)
+            elif failed_urls:
+                results.extend(
+                    d for d, u in zip(tavily_docs, urls) if u in failed_urls
+                )
+        elif exa_p is not None:
+            results = exa_p.extract(urls)
+        else:
+            results = [
+                {"url": u, "title": "", "content": "", "error": "No extract provider"}
+                for u in urls
+            ]
+
+        return results
+
+    def get_setup_schema(self) -> Dict[str, Any]:
+        return {
+            "name": "Multi Search",
+            "badge": "paid",
+            "tag": "Fan-out across Tavily + Exa + web-search-prime for maximum recall.",
+            "env_vars": [
+                {"key": "TAVILY_API_KEY", "prompt": "Tavily API key", "url": "https://app.tavily.com/home"},
+                {"key": "EXA_API_KEY", "prompt": "Exa API key", "url": "https://exa.ai"},
+            ],
+        }

--- a/tests/plugins/web/test_multi_search_provider.py
+++ b/tests/plugins/web/test_multi_search_provider.py
@@ -1,0 +1,83 @@
+"""Tests for the multi-search web provider."""
+
+from __future__ import annotations
+
+import json
+
+from plugins.web.multi_search.provider import _normalize_wsp_result
+
+
+def test_wsp_normalizer_accepts_double_encoded_result_string() -> None:
+    """web-search-prime may wrap its JSON array as a JSON string twice."""
+    payload = json.dumps(
+        {
+            "result": json.dumps(
+                json.dumps(
+                    [
+                        {
+                            "title": "OpenAI Platform",
+                            "link": "https://platform.openai.com/",
+                            "content": "API docs and developer tools.",
+                            "refer": "ref_1",
+                        }
+                    ]
+                )
+            )
+        }
+    )
+
+    result = _normalize_wsp_result(json.loads(payload), 5)
+
+    assert result == {
+        "success": True,
+        "data": {
+            "web": [
+                {
+                    "title": "OpenAI Platform",
+                    "url": "https://platform.openai.com/",
+                    "description": "API docs and developer tools.",
+                    "position": 1,
+                }
+            ]
+        },
+    }
+
+
+def test_web_tools_accepts_configured_multi_search_backend(monkeypatch) -> None:
+    from tools import web_tools
+
+    monkeypatch.setattr(web_tools, "_load_web_config", lambda: {"backend": "multi-search"})
+
+    assert web_tools._get_backend() == "multi-search"
+
+
+def test_web_tools_reports_multi_search_available_with_tavily_or_exa(
+    monkeypatch,
+) -> None:
+    from tools import web_tools
+
+    monkeypatch.delenv("TAVILY_API_KEY", raising=False)
+    monkeypatch.delenv("EXA_API_KEY", raising=False)
+    assert web_tools._is_backend_available("multi-search") is False
+
+    monkeypatch.setenv("TAVILY_API_KEY", "tavily-test")
+    assert web_tools._is_backend_available("multi-search") is True
+
+    monkeypatch.delenv("TAVILY_API_KEY", raising=False)
+    monkeypatch.setenv("EXA_API_KEY", "exa-test")
+    assert web_tools._is_backend_available("multi-search") is True
+
+
+def test_web_tools_accepts_configured_multi_search_search_backend(
+    monkeypatch,
+) -> None:
+    from tools import web_tools
+
+    monkeypatch.setenv("TAVILY_API_KEY", "tavily-test")
+    monkeypatch.setattr(
+        web_tools,
+        "_load_web_config",
+        lambda: {"search_backend": "multi-search"},
+    )
+
+    assert web_tools._get_search_backend() == "multi-search"

--- a/tests/plugins/web/test_web_search_provider_plugins.py
+++ b/tests/plugins/web/test_web_search_provider_plugins.py
@@ -2,8 +2,8 @@
 
 Covers:
 
-- All eight bundled plugins (brave-free, ddgs, searxng, exa, parallel,
-  tavily, firecrawl, xai) instantiate and self-report the expected
+- All nine bundled plugins (brave-free, ddgs, searxng, exa, parallel,
+  tavily, firecrawl, xai, multi-search) instantiate and self-report the expected
   capabilities + ABC-derived defaults.
 - Each plugin's ``is_available()`` correctly reflects env-var presence.
 - The web_search_registry resolves an active provider in the documented
@@ -68,7 +68,7 @@ def _isolate_env(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 class TestBundledPluginsRegister:
-    """All eight bundled web plugins discover and register correctly."""
+    """All bundled web plugins discover and register correctly."""
 
     def test_all_seven_plugins_present_in_registry(self) -> None:
         _ensure_plugins_loaded()
@@ -80,6 +80,7 @@ class TestBundledPluginsRegister:
             "ddgs",
             "exa",
             "firecrawl",
+            "multi-search",
             "parallel",
             "searxng",
             "tavily",
@@ -96,6 +97,7 @@ class TestBundledPluginsRegister:
             ("parallel", True, True),
             ("tavily", True, True),
             ("firecrawl", True, True),
+            ("multi-search", True, True),
             # xai: search-only via Grok's agentic web_search tool.
             ("xai", True, False),
         ],
@@ -116,7 +118,17 @@ class TestBundledPluginsRegister:
 
     @pytest.mark.parametrize(
         "plugin_name",
-        ["brave-free", "ddgs", "searxng", "exa", "parallel", "tavily", "firecrawl", "xai"],
+        [
+            "brave-free",
+            "ddgs",
+            "searxng",
+            "exa",
+            "parallel",
+            "tavily",
+            "firecrawl",
+            "multi-search",
+            "xai",
+        ],
     )
     def test_each_plugin_has_name_and_display_name(self, plugin_name: str) -> None:
         _ensure_plugins_loaded()
@@ -129,7 +141,17 @@ class TestBundledPluginsRegister:
 
     @pytest.mark.parametrize(
         "plugin_name",
-        ["brave-free", "ddgs", "searxng", "exa", "parallel", "tavily", "firecrawl", "xai"],
+        [
+            "brave-free",
+            "ddgs",
+            "searxng",
+            "exa",
+            "parallel",
+            "tavily",
+            "firecrawl",
+            "multi-search",
+            "xai",
+        ],
     )
     def test_each_plugin_has_setup_schema(self, plugin_name: str) -> None:
         """``get_setup_schema()`` returns a dict the picker can consume."""
@@ -180,6 +202,21 @@ class TestIsAvailable:
         assert p is not None
         assert p.is_available() is False
         monkeypatch.setenv("TAVILY_API_KEY", "real")
+        assert p.is_available() is True
+
+    def test_multi_search_requires_tavily_or_exa_key(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _ensure_plugins_loaded()
+        from agent.web_search_registry import get_provider
+
+        p = get_provider("multi-search")
+        assert p is not None
+        assert p.is_available() is False
+        monkeypatch.setenv("TAVILY_API_KEY", "real")
+        assert p.is_available() is True
+        monkeypatch.delenv("TAVILY_API_KEY", raising=False)
+        monkeypatch.setenv("EXA_API_KEY", "real")
         assert p.is_available() is True
 
     def test_exa_requires_api_key(self, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tools/web_tools.py
+++ b/tools/web_tools.py
@@ -141,6 +141,22 @@ def _load_web_config() -> dict:
     except (ImportError, Exception):
         return {}
 
+
+_CONFIGURABLE_WEB_BACKENDS = frozenset(
+    {
+        "parallel",
+        "firecrawl",
+        "tavily",
+        "exa",
+        "searxng",
+        "brave-free",
+        "ddgs",
+        "xai",
+        "multi-search",
+    }
+)
+
+
 def _get_backend() -> str:
     """Determine which web backend to use (shared fallback).
 
@@ -149,7 +165,7 @@ def _get_backend() -> str:
     keys manually without running setup.
     """
     configured = (_load_web_config().get("backend") or "").lower().strip()
-    if configured in {"parallel", "firecrawl", "tavily", "exa", "searxng", "brave-free", "ddgs", "xai"}:
+    if configured in _CONFIGURABLE_WEB_BACKENDS:
         return configured
 
     # Fallback for manual / legacy config — pick the highest-priority
@@ -240,6 +256,8 @@ def _is_backend_available(backend: str) -> bool:
             return has_xai_credentials()
         except Exception:
             return False
+    if backend == "multi-search":
+        return _has_env("TAVILY_API_KEY") or _has_env("EXA_API_KEY")
     return False
 
 
@@ -1185,7 +1203,7 @@ async def web_extract_tool(
 def check_web_api_key() -> bool:
     """Check whether the configured web backend is available."""
     configured = _load_web_config().get("backend", "").lower().strip()
-    if configured in {"exa", "parallel", "firecrawl", "tavily", "searxng", "brave-free", "ddgs", "xai"}:
+    if configured in _CONFIGURABLE_WEB_BACKENDS:
         return _is_backend_available(configured)
     return any(
         _is_backend_available(backend)


### PR DESCRIPTION
## Summary
- Add a `multi-search` bundled web provider plugin that fans out across Tavily, Exa, and web-search-prime MCP
- Merge results round-robin, dedupe by normalized URL, and annotate source provider
- Support Tavily extract with Exa fallback for failed/empty URL extracts
- Allow `web.backend` / `web.search_backend` to select `multi-search`

## Test Plan
- `python -m pytest tests/plugins/web/test_web_search_provider_plugins.py tests/plugins/web/test_multi_search_provider.py tests/tools/test_web_tools_config.py tests/integration/test_web_tools.py -q -o 'addopts='`

Note: the focused test run passes with the existing async-marker warnings in `tests/tools/test_web_tools_config.py`.
