### PR TITLE
fix(telegram): accept AMR audio documents for STT

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -1137,6 +1137,7 @@ SUPPORTED_DOCUMENT_TYPES = {
     ".ts": "text/plain",
     ".py": "text/plain",
     ".sh": "text/plain",
+    ".amr": "audio/amr",
 }
 
 
@@ -1362,7 +1363,7 @@ def cache_media_bytes(
         or default_kind == "image"
     )
     is_video = mime.startswith("video/") or ext in SUPPORTED_VIDEO_TYPES or default_kind == "video"
-    is_audio = mime.startswith("audio/") or default_kind == "audio"
+    is_audio = mime.startswith("audio/") or ext in {".amr"} or default_kind == "audio"
 
     if is_image:
         img_ext = ext if ext in SUPPORTED_IMAGE_DOCUMENT_TYPES else ".jpg"
@@ -1379,7 +1380,7 @@ def cache_media_bytes(
         return CachedMedia(to_agent_visible_cache_path(path), SUPPORTED_VIDEO_TYPES.get(vid_ext, "video/mp4"), "video", display)
 
     if is_audio:
-        aud_ext = ext if ext in {".ogg", ".mp3", ".wav", ".m4a", ".opus", ".flac"} else ".ogg"
+        aud_ext = ext if ext in {".ogg", ".mp3", ".wav", ".m4a", ".opus", ".flac", ".amr"} else ".ogg"
         path = cache_audio_from_bytes(data, ext=aud_ext)
         out_mime = mime if mime.startswith("audio/") else f"audio/{aud_ext.lstrip('.')}"
         return CachedMedia(to_agent_visible_cache_path(path), out_mime, "audio", display)

--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -6199,6 +6199,17 @@ class TelegramAdapter(BasePlatformAdapter):
                     await self.handle_message(event)
                     return
 
+                if ext == ".amr" or doc_mime in {"audio/amr", "audio/amr-nb", "audio/amr-wb"}:
+                    file_obj = await doc.get_file()
+                    audio_bytes = await file_obj.download_as_bytearray()
+                    cached_path = cache_audio_from_bytes(bytes(audio_bytes), ext=".amr")
+                    event.media_urls = [cached_path]
+                    event.media_types = [doc_mime if doc_mime.startswith("audio/") else "audio/amr"]
+                    event.message_type = MessageType.VOICE
+                    logger.info("[Telegram] Cached user AMR document as voice at %s", cached_path)
+                    await self.handle_message(event)
+                    return
+
                 # NOTE: image-document handling is performed earlier in this
                 # function (ext in _TELEGRAM_IMAGE_EXTENSIONS or image/* mime),
                 # which returns before reaching here.  Any subsequent

--- a/tests/gateway/test_document_cache.py
+++ b/tests/gateway/test_document_cache.py
@@ -162,6 +162,7 @@ class TestSupportedDocumentTypes:
             ".xlsx",
             ".ppt",
             ".pptx",
+            ".amr",
         ],
     )
     def test_expected_extensions_present(self, ext):
@@ -210,6 +211,14 @@ class TestCacheMediaBytes:
         assert result is not None
         assert result.kind == "video"
         assert result.media_type == "video/mp4"
+
+    def test_amr_routes_to_audio_by_extension(self):
+        from gateway.platforms.base import cache_media_bytes
+        result = cache_media_bytes(b"#!AMR\n", filename="call.amr", mime_type="application/octet-stream")
+        assert result is not None
+        assert result.kind == "audio"
+        assert result.media_type == "audio/amr"
+        assert result.path.endswith(".amr")
 
     def test_mime_only_resolves_extension(self):
         from gateway.platforms.base import cache_media_bytes

--- a/tests/gateway/test_telegram_documents.py
+++ b/tests/gateway/test_telegram_documents.py
@@ -149,6 +149,9 @@ def _redirect_cache(tmp_path, monkeypatch):
     monkeypatch.setattr(
         "gateway.platforms.base.VIDEO_CACHE_DIR", tmp_path / "video_cache"
     )
+    monkeypatch.setattr(
+        "gateway.platforms.base.AUDIO_CACHE_DIR", tmp_path / "audio_cache"
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -259,6 +262,26 @@ class TestDocumentDownloadBlock:
         event = adapter.handle_message.call_args[0][0]
         assert event.media_urls and event.media_urls[0].endswith("archive.zip")
         assert event.media_types == ["application/zip"]
+
+    @pytest.mark.asyncio
+    async def test_amr_document_is_routed_as_voice_audio(self, adapter):
+        """Telegram may deliver mobile recorder AMR files as documents; route them to STT."""
+        file_obj = _make_file_obj(b"#!AMR\n")
+        doc = _make_document(
+            file_name="call.amr",
+            mime_type="audio/amr-nb",
+            file_size=6,
+            file_obj=file_obj,
+        )
+        msg = _make_message(document=doc)
+        update = _make_update(msg)
+
+        await adapter._handle_media_message(update, MagicMock())
+        event = adapter.handle_message.call_args[0][0]
+        assert event.message_type == MessageType.VOICE
+        assert event.media_urls and event.media_urls[0].endswith(".amr")
+        assert os.path.exists(event.media_urls[0])
+        assert event.media_types == ["audio/amr-nb"]
 
     @pytest.mark.asyncio
     async def test_png_document_is_routed_as_image(self, adapter):

--- a/tests/tools/test_transcription.py
+++ b/tests/tools/test_transcription.py
@@ -106,6 +106,12 @@ class TestValidateAudioFile:
         from tools.transcription_tools import _validate_audio_file
         assert _validate_audio_file(str(f)) is None
 
+    def test_amr_file_is_supported(self, tmp_path):
+        f = tmp_path / "test.amr"
+        f.write_bytes(b"#!AMR\n")
+        from tools.transcription_tools import _validate_audio_file
+        assert _validate_audio_file(str(f)) is None
+
     def test_too_large(self, tmp_path):
         f = tmp_path / "big.ogg"
         f.write_bytes(b"x")

--- a/tools/transcription_tools.py
+++ b/tools/transcription_tools.py
@@ -16,7 +16,7 @@ Provides speech-to-text transcription with six providers:
 Used by the messaging gateway to automatically transcribe voice messages
 sent by users on Telegram, Discord, WhatsApp, Slack, and Signal.
 
-Supported input formats: mp3, mp4, mpeg, mpga, m4a, wav, webm, ogg, aac
+Supported input formats: mp3, mp4, mpeg, mpga, m4a, wav, webm, ogg, aac, flac, amr
 
 Usage::
 
@@ -99,7 +99,7 @@ OPENAI_BASE_URL = os.getenv("STT_OPENAI_BASE_URL", "https://api.openai.com/v1")
 XAI_STT_BASE_URL = os.getenv("XAI_STT_BASE_URL", "https://api.x.ai/v1")
 ELEVENLABS_STT_BASE_URL = os.getenv("ELEVENLABS_STT_BASE_URL", "https://api.elevenlabs.io/v1")
 
-SUPPORTED_FORMATS = {".mp3", ".mp4", ".mpeg", ".mpga", ".m4a", ".wav", ".webm", ".ogg", ".aac", ".flac"}
+SUPPORTED_FORMATS = {".mp3", ".mp4", ".mpeg", ".mpga", ".m4a", ".wav", ".webm", ".ogg", ".aac", ".flac", ".amr"}
 LOCAL_NATIVE_AUDIO_FORMATS = {".wav", ".aiff", ".aif"}
 MAX_FILE_SIZE = 25 * 1024 * 1024  # 25 MB
 


### PR DESCRIPTION
## Summary
- accept Telegram-uploaded `.amr` documents as audio/voice input
- preserve `.amr` in the gateway audio cache instead of coercing it to `.ogg`
- allow `.amr` through the STT input validator
- add regression coverage for document caching, Telegram document handling, and transcription validation

## Why
Mobile call-recorder apps commonly export audio as AMR. When a Telegram user uploads an `.amr` recording as a document, Hermes currently rejects it before the agent can transcribe it:

```text
Unsupported document type '.amr'
```

This routes AMR document uploads through the same audio/voice path used by transcribable media, while keeping the existing document allowlist behavior for unsupported non-audio file types.

## Test Plan
```text
UV_PROJECT_ENVIRONMENT=.venv-amr uv run --extra dev python -m pytest tests/tools/test_transcription.py tests/gateway/test_document_cache.py tests/gateway/test_telegram_documents.py -q -o 'addopts='
103 passed in 5.32s
```

Smoke check:
```text
doc_allowlist_amr= audio/amr
cache_kind= audio media_type= audio/amr path_ext= .amr
stt_supported_amr= True
validate_error= None
```
