### PR TITLE
fix(models): accept unlisted models with warning per comment intent

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -3913,11 +3913,7 @@ def validate_requested_model(
                 "message": None,
             }
         else:
-            # API responded but model is not listed.  Accept anyway —
-            # the user may have access to models not shown in the public
-            # listing (e.g. Z.AI Pro/Max plans can use glm-5 on coding
-            # endpoints even though it's not in /models).  Warn but allow.
-
+            # API responded but model is not in the live listing.
             # Auto-correct if the top match is very similar (e.g. typo)
             auto = get_close_matches(requested_for_lookup, api_models, n=1, cutoff=0.9)
             if auto:
@@ -3927,6 +3923,23 @@ def validate_requested_model(
                     "recognized": True,
                     "corrected_model": auto[0],
                     "message": f"Auto-corrected `{requested}` → `{auto[0]}`",
+                }
+
+            # Check curated catalog — the model may be known to Hermes
+            # even if the provider's live /models endpoint hasn't listed
+            # it yet (e.g. Z.AI glm-5.2 was added to _PROVIDER_MODELS
+            # before the API listed it).
+            if _model_in_provider_catalog(
+                requested_for_lookup.lower(), _provider_keys(normalized)
+            ):
+                return {
+                    "accepted": True,
+                    "persist": True,
+                    "recognized": False,
+                    "message": (
+                        f"Note: `{requested}` was not found in the live model listing "
+                        f"but is a known model for this provider.  It may still work."
+                    ),
                 }
 
             suggestions = get_close_matches(requested, api_models, n=3, cutoff=0.5)

--- a/tests/hermes_cli/test_model_validation.py
+++ b/tests/hermes_cli/test_model_validation.py
@@ -577,6 +577,20 @@ class TestValidateApiNotFound:
         assert result.get("corrected_model") is None
         assert "not found" in result["message"]
 
+    def test_model_known_to_curated_catalog_accepted_with_warning(self):
+        """Models in curated catalog but not in live API are accepted with warning.
+
+        Regression test for Z.AI glm-5.2: the model was added to _PROVIDER_MODELS
+        but the provider's live /models endpoint hadn't listed it yet. The
+        validator should accept it with a warning instead of rejecting it.
+        """
+        # Z.AI uses unprefixed model IDs (glm-5.2, not zai/glm-5.2)
+        result = _validate("glm-5.2", provider="zai", api_models=["glm-5.1"])
+        assert result["accepted"] is True
+        assert result["persist"] is True
+        assert result["recognized"] is False
+        assert "known model" in result["message"].lower() or "still work" in result["message"].lower()
+
 
 # -- validate — API unreachable — soft-accept via catalog or warning --------
 


### PR DESCRIPTION
## Problem

When a provider's live `/models` endpoint is reachable but doesn't list a model that exists in Hermes' curated catalog (`_PROVIDER_MODELS`), the validator rejects it outright. This blocks real, working models.

**Real-world case:** Z.AI added `glm-5.2` to `_PROVIDER_MODELS["zai"]` (commit bff78a34d), but the provider's `/models` endpoint hasn't listed it yet. Users who select `glm-5.2` get:

```
✗ Model glm-5.2 was not found in this provider's model listing.
  Similar models: glm-5.1, glm-5, glm-4.7
```

even though the model works fine.

## Root Cause

`validate_requested_model()` checks the live API listing only. When the API responds successfully but the model isn't found:

1. Auto-correction for near-typos (0.9 similarity) — keeps this
2. Reject everything else — too aggressive

It never consults the curated catalog (`_PROVIDER_MODELS`) in the API-reachable path. The catalog is only used as a last-resort fallback when the API is entirely unreachable (lines 4008-4049).

## Fix

Added a curated-catalog check between the auto-correct step and the final reject (lines 3928-3943):

- If the model IS in `_PROVIDER_MODELS` for this provider → accept with a warning
- If the model is NOT in any catalog → reject as before (preserves anti-typo protection from ebe327043)

This is deliberately NOT a blanket "accept all unlisted models" change. Unknown models (e.g. `anthropic/claude-nonexistent`) are still rejected; only models Hermes already knows about get through.

## Changes

- `hermes_cli/models.py:3928-3943` — catalog check before reject
- `tests/hermes_cli/test_model_validation.py` — added `test_model_known_to_curated_catalog_accepted_with_warning` regression test

## How to Test

```bash
bash scripts/run_tests.sh tests/hermes_cli/test_model_validation.py
```