### PR TITLE
fix(model-picker): custom provider's own models survive aggregator dedup

### DIFF
--- a/hermes_cli/inventory.py
+++ b/hermes_cli/inventory.py
@@ -174,12 +174,24 @@ def build_models_payload(
     if _is_aggregator is not None:
         user_models: set[str] = set()
         for row in rows:
-            if row.get("is_user_defined"):
+            # Only collect models from non-aggregator user-defined providers
+            # (e.g. litellm-proxy). Aggregator-shaped custom providers
+            # (any `custom:*` slug) must be excluded from the dedup source
+            # set — they're full-catalog endpoints, not narrow user proxies,
+            # so their models must not be subtracted from the same provider's
+            # own picker row. Without this guard, a custom provider with
+            # many models ends up with `models=[]` in the picker payload.
+            if row.get("is_user_defined") and not _is_aggregator(row.get("slug", "")):
                 user_models.update(m.lower() for m in (row.get("models") or []))
         if user_models:
             for row in rows:
                 slug = row.get("slug", "")
                 if not _is_aggregator(slug):
+                    continue
+                # Never dedup a custom provider against its own models —
+                # a `custom:foo` row's own model list is the source of truth
+                # for that endpoint, not a candidate for filtering.
+                if slug.lower().startswith("custom:"):
                     continue
                 original = row.get("models") or []
                 filtered = [m for m in original if m.lower() not in user_models]

--- a/tests/hermes_cli/test_inventory.py
+++ b/tests/hermes_cli/test_inventory.py
@@ -606,3 +606,90 @@ def test_aggregator_dedup_multiple_user_providers():
     assert or_row["models"] == ["model-z"]
     assert or_row["total_models"] == 1
 
+
+# ─── Custom-provider dedup guard (named custom providers are NOT their
+# own dedup source — a `custom:foo` row's models must stay in the picker
+# because that endpoint IS the model's source of truth, not a user-side
+# proxy serving a subset). Without this guard, build_models_payload zeros
+# out a custom provider's models when it is the only authenticated row.
+
+
+def _custom_provider_row(slug: str, models: list[str]) -> dict:
+    """Mirror the real shape of a custom_providers row in
+    list_authenticated_providers — `api_url` and `is_user_defined=True`
+    are what `is_aggregator` keys on to treat it as aggregator-shaped.
+    """
+    return {
+        "slug": slug,
+        "name": slug.split(":", 1)[-1].title(),
+        "models": models,
+        "total_models": len(models),
+        "is_current": False,
+        "is_user_defined": True,
+        "source": "user-config",
+        "api_url": "https://example.invalid/v1",
+    }
+
+
+def test_custom_provider_keeps_own_models_in_dedup():
+    """A named custom provider (``custom:foo``) is aggregator-shaped by
+    ``is_aggregator()`` but its own model list is the source of truth
+    for that endpoint. ``build_models_payload`` must NOT subtract its
+    own models from itself — the picker should see all 62, not 0.
+
+    Without the guard, a custom provider with models = [] in the picker
+    payload even though ``list_authenticated_providers`` populated it
+    with the full live ``/v1/models`` catalog.
+    """
+    rows = [
+        _custom_provider_row(
+            "custom:tokendance.space",
+            ["glm-5.1", "deepseek-v4-pro", "kimi-k2.7-code", "qwen3.7-max"],
+        ),
+    ]
+    ctx = _empty_ctx(provider="custom:tokendance.space", model="glm-5.1")
+    with _list_auth_returning(rows):
+        payload = build_models_payload(ctx)
+
+    custom_row = payload["providers"][0]
+    assert custom_row["slug"] == "custom:tokendance.space"
+    assert custom_row["models"] == [
+        "glm-5.1", "deepseek-v4-pro", "kimi-k2.7-code", "qwen3.7-max",
+    ]
+    assert custom_row["total_models"] == 4
+
+
+def test_dedup_skips_user_defined_aggregator_shaped_rows():
+    """When a custom aggregator-shaped row sits alongside a real
+    aggregator (openrouter), the custom provider's models must not be
+    added to the dedup-source set — those models live on the user's
+    endpoint, not the aggregator.  Real aggregator dedup against a
+    non-aggregator user proxy still works.
+    """
+    rows = [
+        _custom_provider_row(
+            "custom:tokendance.space",
+            ["glm-5.1", "deepseek-v4-pro"],  # live catalog
+        ),
+        _user_provider_row("litellm-proxy", ["custom-only-1"]),
+        _aggregator_row("openrouter", [
+            "glm-5.1",         # happens to share a name; must NOT be removed
+            "custom-only-1",   # this one IS removed — proxy is narrower
+            "anthropic/claude-sonnet-4.6",
+        ]),
+    ]
+    ctx = _empty_ctx()
+    with _list_auth_returning(rows):
+        payload = build_models_payload(ctx)
+
+    or_row = next(r for r in payload["providers"] if r["slug"] == "openrouter")
+    # Only the non-aggregator user proxy's model was subtracted;
+    # the custom aggregator's shared model survived.
+    assert or_row["models"] == ["glm-5.1", "anthropic/claude-sonnet-4.6"]
+    assert or_row["total_models"] == 2
+
+    custom_row = next(r for r in payload["providers"]
+                      if r["slug"] == "custom:tokendance.space")
+    # Custom provider's own list is untouched.
+    assert custom_row["models"] == ["glm-5.1", "deepseek-v4-pro"]
+


### PR DESCRIPTION
## What does this PR do?

`build_models_payload` in `hermes_cli/inventory.py` runs an aggregator-overlap dedup pass (#45954) to keep a model from showing up under both an aggregator and a user-defined proxy. The pass unconditionally pulls models from every row with `is_user_defined=True` and uses them to subtract from aggregator rows.

The bug: `is_aggregator()` returns `True` for any slug starting with `custom:`. That meant a named custom provider (`custom:tokendance.space`, `custom:my-gateway`, etc.) had its **own** live `/v1/models` catalog added to the dedup source set, then subtracted from itself — zeroing out its picker row.

**Reproduction (no fix):**

```python
from hermes_cli.inventory import load_picker_context, build_models_payload
ctx = load_picker_context()
payload = build_models_payload(ctx, max_models=50, picker_hints=True)
for p in payload['providers']:
    if p['slug'] == 'custom:tokendance.space':
        print(p['models'])  # → []  (62 models disappear)
```

The picker consumed via `/api/model/options` (desktop), the TUI `model.options` JSON-RPC handler, and the CLI `hermes model` picker all show the custom provider with zero models — even though `list_authenticated_providers` correctly populated it.

**With the fix**, the same payload returns all 62 models.

**Fix:**
1. Skip `custom:*` rows when collecting the dedup source set — a `custom:foo` row's models are the endpoint's source of truth, not a candidate for filtering other rows.
2. Also skip `custom:*` rows as dedup targets — even if a real aggregator happened to share a model id with the user's custom endpoint, the custom row is the user's own endpoint, not something the picker should narrow.

Both are the smallest-possible guards: they only add early `continue`s and one extra `not` clause. No other dedup behavior changes.

## Related Issue

- Discovered while reproducing a user's report that the desktop app's model selector showed a custom provider with an empty model list even though the API endpoint exposed 60+ models.
- Closely related to the original dedup-introducing #45954, but no specific issue number is available.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/inventory.py` — guard `build_models_payload`'s dedup pass against `custom:*` rows (13 lines added, 1 removed)
- `tests/hermes_cli/test_inventory.py` — 2 regression tests covering the single-custom-provider and mixed-custom+aggregator cases (87 lines added)

## How to Test

1. Configure a named custom provider in `config.yaml`:
   ```yaml
   custom_providers:
     - name: my-gateway
       base_url: https://my-gateway.example/v1
       api_key: ...
       model: gpt-4o-mini
   ```
2. Run `python -c "from hermes_cli.inventory import load_picker_context, build_models_payload; p = build_models_payload(load_picker_context()); print([(r['slug'], len(r['models'])) for r in p['providers'] if r['slug'].startswith('custom:')])"`
3. Before fix: `[]` (zero rows returned because the dedup zeroed it)
4. After fix: `[('custom:my-gateway', 14)]` (or whatever `/v1/models` returns)
5. `pytest tests/hermes_cli/test_inventory.py -q` → 30 passed (including 2 new regression tests)

## Checklist

### Code
- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(model-picker): …`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [x] I've run `pytest tests/hermes_cli/test_inventory.py -q` and all tests pass (30/30)
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11, Python 3.12

### Documentation & Housekeeping
- [x] I've updated relevant documentation — N/A (no user-facing config keys changed; the fix is transparent to users)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) — N/A (pure-Python logic, no platform specifics)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

Reproduction before fix:
```
=== build_models_payload AFTER fix ===
  custom:tokendance.space             models= 62 src=user-config
  copilot                             models= 16 src=built-in
  minimax-cn                          models=  5 src=built-in
```

Same call before the fix produced:
```
  custom:tokendance.space             models=  0 src=user-config
```

Test output:
```
tests/hermes_cli/test_inventory.py::test_custom_provider_keeps_own_models_in_dedup PASSED
tests/hermes_cli/test_inventory.py::test_dedup_skips_user_defined_aggregator_shaped_rows PASSED
============================= 30 passed in 10.20s =============================
```
