### PR TITLE
fix(mcp): reset circuit breaker on rediscovery + lengthen one-shot CLI tool-wait

### DIFF
--- a/hermes_cli/mcp_startup.py
+++ b/hermes_cli/mcp_startup.py
@@ -51,8 +51,15 @@ def start_background_mcp_discovery(*, logger, thread_name: str) -> None:
         thread.start()
 
 
-def wait_for_mcp_discovery(timeout: float = 0.75) -> None:
-    """Briefly wait for background MCP discovery before the first tool snapshot."""
+def wait_for_mcp_discovery(timeout: float = 5.0) -> None:
+    """Wait briefly for background MCP discovery before the first tool snapshot.
+
+    Local stdio MCP servers routinely need a couple of seconds to spawn and
+    enumerate tools.  If this default is too short, the first one-shot CLI turn
+    snapshots tools before MCP registration finishes, so the model cannot see
+    tools that appear in logs milliseconds later.  Keep the wait bounded so a
+    slow or broken server still cannot freeze startup indefinitely.
+    """
     thread = _mcp_discovery_thread
     if thread is None or not thread.is_alive():
         return

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -3651,6 +3651,11 @@ async def _discover_and_register_server(name: str, config: dict) -> List[str]:
 
     registered_names = _register_server_tools(name, server, config)
     server._registered_tool_names = list(registered_names)
+    # A successful discovery/reconnect is an unambiguous health signal. Clear
+    # any prior circuit-breaker state so manual /reload-mcp can recover a
+    # server that was temporarily poisoned by stale config or transient backend
+    # failures instead of leaving the live session in "unreachable" mode.
+    _reset_server_error(name)
 
     transport_type = "HTTP" if "url" in config else "stdio"
     logger.info(


### PR DESCRIPTION
Two related MCP reliability fixes:

1. **Breaker never resets on rediscovery.** `_discover_and_register_server()` doesn't clear circuit-breaker state on success. The only existing reset paths are a successful tool *call* and OAuth recovery — both require the server already unblocked. A server that trips the breaker during initial discovery stays dead until process restart. Fix: reset the breaker after a successful discovery/reload.
2. **One-shot CLI misses MCP tools.** `wait_for_mcp_discovery()` hardcodes a 0.75s timeout — too short for stdio MCP servers (the common transport) to spawn and enumerate tools, so the first turn of `hermes -p "..."` runs without them. Raised to 5s (bounded; a broken server still can't stall startup).