### PR TITLE
fix(telegram): forum topics in channel directory + topic-scoped free response

### DIFF
--- a/gateway/channel_directory.py
+++ b/gateway/channel_directory.py
@@ -11,6 +11,8 @@ import logging
 from datetime import datetime
 from typing import Any, Dict, List, Optional
 
+import yaml
+
 from hermes_cli.config import get_hermes_home
 from utils import atomic_json_write
 
@@ -137,6 +139,9 @@ async def build_channel_directory(adapters: Dict[Any, Any]) -> Dict[str, Any]:
             continue
         platforms[plat_name] = _build_from_sessions(plat_name)
 
+    if "telegram" in platforms:
+        _merge_configured_telegram_group_topics(platforms["telegram"])
+
     # Include plugin-registered platforms (dynamic enum members aren't in
     # Platform.__members__, so the loop above misses them).
     try:
@@ -198,6 +203,73 @@ def _build_discord(adapter) -> List[Dict[str, str]]:
     # Merge any DMs from session history
     channels.extend(_build_from_sessions("discord"))
     return channels
+
+
+def _merge_configured_telegram_group_topics(entries: List[Dict[str, Any]]) -> None:
+    """Merge configured Telegram forum topics into the directory cache.
+
+    Session discovery only sees topics after a user has spoken there. Configured
+    topics must still resolve for cron/send targets immediately after creation.
+    """
+    config_path = get_hermes_home() / "config.yaml"
+    if not config_path.exists():
+        return
+
+    try:
+        config = yaml.safe_load(config_path.read_text(encoding="utf-8")) or {}
+    except Exception as exc:
+        logger.debug("Channel directory: failed to read configured Telegram topics: %s", exc)
+        return
+
+    group_topics = (
+        config.get("platforms", {})
+        .get("telegram", {})
+        .get("extra", {})
+        .get("group_topics", [])
+    )
+    if not isinstance(group_topics, list):
+        return
+
+    seen_ids = {str(entry.get("id")) for entry in entries if entry.get("id") is not None}
+    chat_names: Dict[str, str] = {}
+    for entry in entries:
+        entry_id = str(entry.get("id", ""))
+        if not entry_id:
+            continue
+        chat_id = entry_id.split(":", 1)[0]
+        name = str(entry.get("name") or "")
+        if name:
+            chat_names.setdefault(chat_id, name.split(" / ", 1)[0])
+
+    for group in group_topics:
+        if not isinstance(group, dict):
+            continue
+        chat_id_raw = group.get("chat_id")
+        if chat_id_raw is None:
+            continue
+        chat_id = str(chat_id_raw)
+        chat_name = str(group.get("name") or group.get("chat_name") or chat_names.get(chat_id) or "Telegram")
+        topics = group.get("topics") or []
+        if not isinstance(topics, list):
+            continue
+        for topic in topics:
+            if not isinstance(topic, dict):
+                continue
+            thread_id_raw = topic.get("thread_id")
+            if thread_id_raw is None:
+                continue
+            thread_id = str(thread_id_raw)
+            entry_id = f"{chat_id}:{thread_id}"
+            if entry_id in seen_ids:
+                continue
+            topic_name = str(topic.get("name") or f"topic {thread_id}")
+            entries.append({
+                "id": entry_id,
+                "name": f"{chat_name} / {topic_name}",
+                "type": "group",
+                "thread_id": thread_id,
+            })
+            seen_ids.add(entry_id)
 
 
 async def _build_slack(adapter) -> List[Dict[str, Any]]:

--- a/gateway/config.py
+++ b/gateway/config.py
@@ -1095,6 +1095,11 @@ def load_gateway_config() -> GatewayConfig:
                     if isinstance(frc, list):
                         frc = ",".join(str(v) for v in frc)
                     os.environ["TELEGRAM_FREE_RESPONSE_CHATS"] = str(frc)
+                frt = telegram_cfg.get("free_response_topics")
+                if frt is not None and not os.getenv("TELEGRAM_FREE_RESPONSE_TOPICS"):
+                    if isinstance(frt, list):
+                        frt = ",".join(str(v) for v in frt)
+                    os.environ["TELEGRAM_FREE_RESPONSE_TOPICS"] = str(frt)
                 # allowed_chats: if set, bot ONLY responds in these group chats (whitelist)
                 ac = telegram_cfg.get("allowed_chats")
                 if ac is not None and not os.getenv("TELEGRAM_ALLOWED_CHATS"):

--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -5103,6 +5103,29 @@ class TelegramAdapter(BasePlatformAdapter):
             return {str(part).strip() for part in raw if str(part).strip()}
         return {part.strip() for part in str(raw).split(",") if part.strip()}
 
+    def _telegram_free_response_topics(self) -> set[str]:
+        """Return forum topics that bypass Telegram's mention gate.
+
+        Entries may be either ``<chat_id>:<thread_id>`` for precise routing or
+        a bare ``<thread_id>`` for legacy single-chat deployments. Prefer the
+        explicit chat/topic form for multi-group gateways.
+        """
+        raw = self.config.extra.get("free_response_topics")
+        if raw is None:
+            raw = os.getenv("TELEGRAM_FREE_RESPONSE_TOPICS", "")
+        if isinstance(raw, list):
+            return {str(part).strip() for part in raw if str(part).strip()}
+        return {part.strip() for part in str(raw).split(",") if part.strip()}
+
+    def _is_free_response_topic(self, message) -> bool:
+        topics = self._telegram_free_response_topics()
+        if not topics:
+            return False
+        chat_id = str(getattr(getattr(message, "chat", None), "id", ""))
+        thread_id = getattr(message, "message_thread_id", None)
+        topic_id = str(thread_id) if thread_id is not None else self._GENERAL_TOPIC_THREAD_ID
+        return f"{chat_id}:{topic_id}" in topics or topic_id in topics
+
     def _telegram_allowed_chats(self) -> set[str]:
         """Return the whitelist of group/supergroup chat IDs the bot will respond in.
 
@@ -5426,7 +5449,7 @@ class TelegramAdapter(BasePlatformAdapter):
         # Only observe messages skipped by the require_mention gate.  If the
         # message would be processed normally, let the dispatcher handle it;
         # if require_mention is disabled, every group message is a request.
-        if chat_id_str in self._telegram_free_response_chats():
+        if chat_id_str in self._telegram_free_response_chats() or self._is_free_response_topic(message):
             return False
         if not self._telegram_require_mention():
             return False
@@ -5723,7 +5746,7 @@ class TelegramAdapter(BasePlatformAdapter):
 
         if guest_mention:
             return True
-        if chat_id_str in self._telegram_free_response_chats():
+        if chat_id_str in self._telegram_free_response_chats() or self._is_free_response_topic(message):
             return True
         if not self._telegram_require_mention():
             return True


### PR DESCRIPTION
Two fixes for Telegram forum/supergroup topics:

1. **Configured topics missing from the channel directory.** Topics set via `platforms.telegram.extra.group_topics` aren't injected at directory-build time, so cron/proactive sends to a topic fail until someone posts there first. Fix: merge configured topics into the directory on build.
2. **Free-response is chat-level only.** A forum supergroup is one chat with many topics, but `free_response_chats` can't target individual topics. Adds `free_response_topics` (+ `TELEGRAM_FREE_RESPONSE_TOPICS` env) — an additive extension of the existing pattern.