### PR TITLE
feat(whatsapp): wire channel prompts into the WhatsApp adapter

### DIFF
--- a/gateway/platforms/whatsapp.py
+++ b/gateway/platforms/whatsapp.py
@@ -187,6 +187,7 @@ from gateway.platforms.base import (
     SUPPORTED_DOCUMENT_TYPES,
     cache_image_from_url,
     cache_audio_from_url,
+    resolve_channel_prompt,
 )
 
 
@@ -1078,6 +1079,10 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
                 user_id=data.get("senderId"),
                 user_name=data.get("senderName"),
             )
+            channel_prompt = resolve_channel_prompt(
+                self.config.extra,
+                str(data.get("chatId", "")),
+            )
             
             # Download media URLs to the local cache so agent tools
             # can access them reliably regardless of URL expiration.
@@ -1171,6 +1176,7 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
                 message_id=data.get("messageId"),
                 media_urls=cached_urls,
                 media_types=media_types,
+                channel_prompt=channel_prompt,
             )
         except Exception as e:
             print(f"[{self.name}] Error building event: {e}")

--- a/tests/gateway/test_whatsapp_group_gating.py
+++ b/tests/gateway/test_whatsapp_group_gating.py
@@ -1,11 +1,14 @@
 import json
 from unittest.mock import AsyncMock
 
+import pytest
+
 from gateway.config import Platform, PlatformConfig, load_gateway_config
 
 
 def _make_adapter(require_mention=None, mention_patterns=None, free_response_chats=None,
-                  dm_policy=None, allow_from=None, group_policy=None, group_allow_from=None):
+                  dm_policy=None, allow_from=None, group_policy=None, group_allow_from=None,
+                  channel_prompts=None):
     from gateway.platforms.whatsapp import WhatsAppAdapter
 
     extra = {}
@@ -23,6 +26,8 @@ def _make_adapter(require_mention=None, mention_patterns=None, free_response_cha
         extra["group_policy"] = group_policy
     if group_allow_from is not None:
         extra["group_allow_from"] = group_allow_from
+    if channel_prompts is not None:
+        extra["channel_prompts"] = channel_prompts
 
     adapter = object.__new__(WhatsAppAdapter)
     adapter.platform = Platform.WHATSAPP
@@ -169,6 +174,21 @@ def test_mention_stripping_preserves_body_when_no_mention():
     data = _group_message("just a normal message")
     cleaned = adapter._clean_bot_mention_text(data["body"], data)
     assert cleaned == "just a normal message"
+
+
+@pytest.mark.asyncio
+async def test_build_message_event_sets_whatsapp_channel_prompt():
+    adapter = _make_adapter(
+        require_mention=False,
+        channel_prompts={
+            "120363001234567890@g.us": "Keep it warm and short.",
+        },
+    )
+
+    event = await adapter._build_message_event(_group_message("say hi"))
+
+    assert event is not None
+    assert event.channel_prompt == "Keep it warm and short."
 
 
 # --- New dm_policy tests ---


### PR DESCRIPTION
Upstream supports per-channel prompts (`resolve_channel_prompt` in `gateway/platforms/base.py`) and bridges `channel_prompts` config for all platforms — but the WhatsApp adapter never calls `resolve_channel_prompt` or passes `channel_prompt` to `MessageEvent`, unlike Slack/Telegram/Discord/Mattermost. This wires it up, closing the gap.