### PR TITLE
fix(cli): include tui sessions in /resume listing

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -5792,7 +5792,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
 
             return query_session_listing(
                 self._session_db,
-                source="cli",
+                source=["cli", "tui"],
                 current_session_id=self.session_id,
                 include_all_sources=False,
                 include_unnamed=True,

--- a/hermes_cli/session_listing.py
+++ b/hermes_cli/session_listing.py
@@ -36,7 +36,7 @@ def parse_session_listing_args(raw_args: str) -> tuple[bool, bool, str]:
 def query_session_listing(
     session_db: Any,
     *,
-    source: str | None,
+    source: str | list[str] | None,
     current_session_id: str | None = None,
     include_all_sources: bool = False,
     include_unnamed: bool = False,

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -25,7 +25,7 @@ from pathlib import Path
 
 from agent.memory_manager import sanitize_context
 from hermes_constants import get_hermes_home
-from typing import Any, Callable, Dict, List, Optional, Tuple, TypeVar
+from typing import Any, Callable, Dict, List, Optional, Tuple, TypeVar, Union
 
 logger = logging.getLogger(__name__)
 
@@ -1979,7 +1979,7 @@ class SessionDB:
 
     def list_sessions_rich(
         self,
-        source: str = None,
+        source: Union[str, List[str], None] = None,
         exclude_sources: List[str] = None,
         limit: int = 20,
         offset: int = 0,
@@ -2040,8 +2040,13 @@ class SessionDB:
             where_clauses.append(f"{_delegate_from_json('s.model_config')} IS NULL")
 
         if source:
-            where_clauses.append("s.source = ?")
-            params.append(source)
+            if isinstance(source, list):
+                placeholders = ",".join("?" for _ in source)
+                where_clauses.append(f"s.source IN ({placeholders})")
+                params.extend(source)
+            else:
+                where_clauses.append("s.source = ?")
+                params.append(source)
         if exclude_sources:
             placeholders = ",".join("?" for _ in exclude_sources)
             where_clauses.append(f"s.source NOT IN ({placeholders})")

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -4141,3 +4141,46 @@ class TestListCronJobRuns:
         detail = " ".join(row[-1] for row in plan)
         assert "USING INDEX" in detail or "USING COVERING INDEX" in detail, detail
         assert "idx_sessions_source" in detail, detail
+
+
+class TestListSessionsRichSourceList:
+    """Test list_sessions_rich with source as a list of allowed sources."""
+
+    def test_source_list_includes_matching(self, db):
+        db.create_session("s1", "cli")
+        db.create_session("s2", "tui")
+        db.create_session("s3", "telegram")
+        sessions = db.list_sessions_rich(source=["cli", "tui"])
+        ids = [s["id"] for s in sessions]
+        assert "s1" in ids
+        assert "s2" in ids
+        assert "s3" not in ids
+
+    def test_source_list_single_item(self, db):
+        db.create_session("s1", "cli")
+        db.create_session("s2", "tui")
+        sessions = db.list_sessions_rich(source=["cli"])
+        ids = [s["id"] for s in sessions]
+        assert "s1" in ids
+        assert "s2" not in ids
+
+    def test_source_list_with_exclude(self, db):
+        db.create_session("s1", "cli")
+        db.create_session("s2", "tui")
+        db.create_session("s3", "tool")
+        sessions = db.list_sessions_rich(
+            source=["cli", "tui"], exclude_sources=["tool"]
+        )
+        ids = [s["id"] for s in sessions]
+        assert "s1" in ids
+        assert "s2" in ids
+        assert "s3" not in ids
+
+    def test_source_string_still_works(self, db):
+        """Backward compat: single string source still works."""
+        db.create_session("s1", "cli")
+        db.create_session("s2", "tui")
+        sessions = db.list_sessions_rich(source="cli")
+        ids = [s["id"] for s in sessions]
+        assert "s1" in ids
+        assert "s2" not in ids


### PR DESCRIPTION
## What does this PR do?

Extends `list_sessions_rich()` to accept `source` as a list of allowed sources, and changes `_list_recent_sessions()` to include both `cli` and `tui` sessions in the `/resume` listing.

## Related Issue

Fixes #47214

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_state.py`: Extend `source` parameter to accept `str | list[str]`, generating `s.source IN (?,?)` SQL when a list is passed. Added `Union` to typing imports.
- `hermes_cli/session_listing.py`: Update `query_session_listing` type hint for `source` to accept `list[str]`.
- `cli.py`: Change `_list_recent_sessions()` from `source="cli"` to `source=["cli", "tui"]` so desktop-app TUI sessions are included in `/resume`.
- `tests/test_hermes_state.py`: Add 4 tests for list-based source filtering (multi-source, single-item list, combined with exclude, backward compat with string).

## How to Test

1. Create a session with `source="tui"` (desktop app session) and one with `source="cli"`
2. Run `/resume` in a CLI session — both sessions should appear
3. Run `pytest tests/test_hermes_state.py -k "TestListSessionsRichSourceList" -v` — all 4 new tests pass
4. Run `pytest tests/test_hermes_state.py -k "list_sessions_rich or ListSessionsRich" -v` — all 26 tests pass (22 existing + 4 new)

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `hermes_state.py::list_sessions_rich` (source filter), `hermes_cli/session_listing.py::query_session_listing`, `cli.py::_list_recent_sessions`
- Blast radius: LOW — extends existing parameter type, backward compatible with string source
- Related patterns: `exclude_sources` already uses SQL `NOT IN` clause; this mirrors that pattern for the inclusion filter
