### PR TITLE
feat(whatsapp): use adaptive text batch delays

### DIFF
--- a/plugins/platforms/whatsapp/adapter.py
+++ b/plugins/platforms/whatsapp/adapter.py
@@ -1380,6 +1380,10 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
 
     # ── Text debounce batching ──────────────────────────────────────
 
+    _TEXT_BATCH_FAST_LEN = 320
+    _TEXT_BATCH_FAST_DELAY_S = 0.18
+    _TEXT_BATCH_SHORT_LEN = 1024
+    _TEXT_BATCH_SHORT_DELAY_S = 0.24
     _SPLIT_THRESHOLD = 6000  # WhatsApp supports ~65K chars; generous threshold
 
     def _text_batch_key(self, event: MessageEvent) -> str:
@@ -1426,8 +1430,17 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
         try:
             pending = self._pending_text_batches.get(key)
             last_len = getattr(pending, "_last_chunk_len", 0) if pending else 0
+            total_len = len(pending.text or "") if pending else 0
             if last_len >= self._SPLIT_THRESHOLD:
                 delay = self._text_batch_split_delay_seconds
+            elif total_len <= self._TEXT_BATCH_FAST_LEN:
+                delay = min(
+                    self._text_batch_delay_seconds, self._TEXT_BATCH_FAST_DELAY_S
+                )
+            elif total_len <= self._TEXT_BATCH_SHORT_LEN:
+                delay = min(
+                    self._text_batch_delay_seconds, self._TEXT_BATCH_SHORT_DELAY_S
+                )
             else:
                 delay = self._text_batch_delay_seconds
             await asyncio.sleep(delay)

--- a/tests/gateway/test_whatsapp_text_batching.py
+++ b/tests/gateway/test_whatsapp_text_batching.py
@@ -9,11 +9,12 @@ Batch delays are read from ``config.extra`` (config.yaml), not env vars.
 """
 
 import asyncio
+from unittest.mock import AsyncMock
 
 from gateway.config import Platform, PlatformConfig
 from gateway.platforms.base import MessageEvent, MessageType
-from plugins.platforms.whatsapp.adapter import WhatsAppAdapter
 from gateway.session import SessionSource
+from plugins.platforms.whatsapp.adapter import WhatsAppAdapter
 
 
 def _make_adapter(**extra):
@@ -51,3 +52,117 @@ def test_invalid_config_value_falls_back_to_default():
     assert adapter._text_batch_split_delay_seconds == 10.0
 
 
+async def _flush_with_recorded_delay(
+    monkeypatch, adapter, event, *, last_chunk_len=None
+):
+    sleeps = []
+
+    async def fake_sleep(delay):
+        sleeps.append(delay)
+
+    monkeypatch.setattr("plugins.platforms.whatsapp.adapter.asyncio.sleep", fake_sleep)
+    adapter.handle_message = AsyncMock()
+    key = adapter._text_batch_key(event)
+    event._last_chunk_len = (  # type: ignore[attr-defined]
+        len(event.text or "") if last_chunk_len is None else last_chunk_len
+    )
+    adapter._pending_text_batches[key] = event
+
+    await adapter._flush_text_batch(key)
+
+    adapter.handle_message.assert_awaited_once_with(event)
+    return sleeps
+
+
+def test_adaptive_batch_tiers_are_ordered():
+    assert WhatsAppAdapter._TEXT_BATCH_FAST_LEN < WhatsAppAdapter._TEXT_BATCH_SHORT_LEN
+    assert (
+        WhatsAppAdapter._TEXT_BATCH_FAST_DELAY_S
+        < WhatsAppAdapter._TEXT_BATCH_SHORT_DELAY_S
+    )
+    assert WhatsAppAdapter._TEXT_BATCH_FAST_DELAY_S > 0
+    assert WhatsAppAdapter._TEXT_BATCH_SHORT_DELAY_S > 0
+
+
+def test_fast_text_batch_uses_fast_delay(monkeypatch):
+    adapter = _make_adapter(text_batch_delay_seconds=5.0)
+
+    async def _drive():
+        sleeps = await _flush_with_recorded_delay(
+            monkeypatch, adapter, _event("f" * 320)
+        )
+        assert sleeps == [0.18]
+
+    asyncio.run(_drive())
+
+
+def test_medium_text_batch_uses_short_delay(monkeypatch):
+    adapter = _make_adapter(text_batch_delay_seconds=5.0)
+
+    async def _drive():
+        sleeps = await _flush_with_recorded_delay(
+            monkeypatch, adapter, _event("m" * 1024)
+        )
+        assert sleeps == [0.24]
+
+    asyncio.run(_drive())
+
+
+def test_tier_uses_total_batch_length_not_latest_chunk(monkeypatch):
+    adapter = _make_adapter(text_batch_delay_seconds=5.0)
+
+    async def _drive():
+        sleeps = await _flush_with_recorded_delay(
+            monkeypatch,
+            adapter,
+            _event("m" * 321),
+            last_chunk_len=1,
+        )
+        assert sleeps == [0.24]
+
+    asyncio.run(_drive())
+
+
+def test_configured_delay_caps_adaptive_tiers(monkeypatch):
+    adapter = _make_adapter(text_batch_delay_seconds=0.1)
+
+    async def _drive():
+        fast_sleeps = await _flush_with_recorded_delay(
+            monkeypatch, adapter, _event("fast")
+        )
+        medium_sleeps = await _flush_with_recorded_delay(
+            monkeypatch, adapter, _event("m" * 321)
+        )
+        assert fast_sleeps == [0.1]
+        assert medium_sleeps == [0.1]
+
+    asyncio.run(_drive())
+
+
+def test_long_text_batch_uses_configured_delay(monkeypatch):
+    adapter = _make_adapter(text_batch_delay_seconds=0.5)
+
+    async def _drive():
+        sleeps = await _flush_with_recorded_delay(
+            monkeypatch, adapter, _event("l" * 1025)
+        )
+        assert sleeps == [0.5]
+
+    asyncio.run(_drive())
+
+
+def test_split_threshold_uses_configured_split_delay(monkeypatch):
+    adapter = _make_adapter(
+        text_batch_delay_seconds=0.5,
+        text_batch_split_delay_seconds=1.5,
+    )
+
+    async def _drive():
+        sleeps = await _flush_with_recorded_delay(
+            monkeypatch,
+            adapter,
+            _event("s" * WhatsAppAdapter._SPLIT_THRESHOLD),
+        )
+        assert sleeps == [1.5]
+
+    asyncio.run(_drive())


### PR DESCRIPTION
## Summary

Port Telegram-style adaptive incoming text-batch delay tiers to the current WhatsApp plugin adapter.

WhatsApp already batches rapid incoming text messages before dispatching them to the agent. This keeps short and medium batches responsive while retaining the longer configured quiet window for large or split-prone input.

## Changes

- Add adaptive delay tiers in `plugins/platforms/whatsapp/adapter.py`:
  - total pending text up to 320 characters: cap at `0.18s`
  - total pending text up to 1,024 characters: cap at `0.24s`
  - longer text: use `text_batch_delay_seconds`
  - latest chunk at the split threshold: use `text_batch_split_delay_seconds`
- Keep existing WhatsApp defaults and config semantics unchanged.
- Add focused tests against the plugin adapter for tier ordering, fast/medium batches, operator caps, long batches, and split-threshold behavior.

## Why

This aligns WhatsApp ingress batching with Telegram's adaptive behavior without introducing profile-specific logic or changing operator-controlled caps.

## Validation

```text
26 passed  — focused and adjacent text-batching suites
125 passed — complete tests/gateway/test_whatsapp*.py suite
Ruff passed
Python compile check passed
git diff --check passed
```

The complete WhatsApp run emitted one existing `AsyncMock` cleanup warning from an unchanged test/import path; the focused suites were clean.
