### PR TITLE
fix(browser): advertise browser_vision when main model supports vision natively (#47149)

### DIFF
--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -3733,7 +3733,7 @@ def check_browser_vision_requirements() -> bool:
     resolvable vision backend. Without the vision check, the tool stays in
     the model's tool list even when no vision provider is configured, then
     fails at call time with a cryptic provider-side error like
-    ``unknown variant `image_url`, expected `text``` (issue #31179).
+    ``unknown variant `image_url`, expected `text`` (issue #31179).
     """
     if not check_browser_requirements():
         return False
@@ -3741,7 +3741,23 @@ def check_browser_vision_requirements() -> bool:
         from tools.vision_tools import check_vision_requirements
     except ImportError:
         return False
-    return check_vision_requirements()
+    if check_vision_requirements():
+        return True
+    # The auxiliary resolver may not recognise the user's main provider
+    # (e.g. custom OAuth providers, local vLLM endpoints), even though
+    # the main model is itself vision-capable and images would work via
+    # the native fast path.  In that case the tool should still be
+    # advertised — otherwise it silently disappears (#47149).
+    try:
+        from agent.auxiliary_client import _main_model_supports_vision
+        from agent.auxiliary_client import _read_main_provider, _read_main_model
+        main_provider = _read_main_provider()
+        main_model = _read_main_model()
+        if main_provider and main_provider not in {"auto", ""}:
+            return _main_model_supports_vision(main_provider, main_model)
+    except Exception:
+        pass
+    return False
 
 
 # ============================================================================


### PR DESCRIPTION
Fixes #47149. check_browser_vision_requirements() only checked the auxiliary vision resolver, which doesn't recognize custom OAuth providers, local vLLM endpoints, or any provider not cataloged in models.dev. When the main model is itself vision-capable, browser_vision should still be advertised via the native fast path.

After the auxiliary resolver returns False, the fix now checks _main_model_supports_vision() on the active main provider. Unknown providers default to True, so custom providers with vision-capable models get the tool back.