### PR TITLE
fix(agent): guard repeated skill reads

### DIFF
--- a/agent/tool_guardrails.py
+++ b/agent/tool_guardrails.py
@@ -24,6 +24,8 @@ IDEMPOTENT_TOOL_NAMES = frozenset(
         "web_search",
         "web_extract",
         "session_search",
+        "skill_view",
+        "skills_list",
         "browser_snapshot",
         "browser_console",
         "browser_get_images",

--- a/tests/agent/test_tool_guardrails.py
+++ b/tests/agent/test_tool_guardrails.py
@@ -119,6 +119,41 @@ def test_hard_stop_enabled_blocks_repeated_exact_failure_before_next_execution()
 
 
 
+def test_skill_read_tools_are_idempotent_and_block_repeated_identical_success_output():
+    cases = [
+        (
+            "skill_view",
+            {"name": "gui-agent-ml-operations"},
+            '{"success":true,"name":"gui-agent-ml-operations","content":"same"}',
+        ),
+        (
+            "skills_list",
+            {"category": "mlops"},
+            '{"success":true,"skills":[{"name":"gui-agent-ml-operations"}]}',
+        ),
+    ]
+
+    for tool_name, args, result in cases:
+        controller = ToolCallGuardrailController(
+            ToolCallGuardrailConfig(
+                hard_stop_enabled=True,
+                no_progress_warn_after=2,
+                no_progress_block_after=2,
+            )
+        )
+
+        assert controller.before_call(tool_name, args).action == "allow"
+        assert controller.after_call(tool_name, args, result, failed=False).action == "allow"
+        assert controller.before_call(tool_name, args).action == "allow"
+        warn = controller.after_call(tool_name, args, result, failed=False)
+        assert warn.action == "warn"
+        assert warn.code == "idempotent_no_progress_warning"
+
+        blocked = controller.before_call(tool_name, args)
+        assert blocked.action == "block"
+        assert blocked.code == "idempotent_no_progress_block"
+
+
 def test_mutating_or_unknown_tools_are_not_blocked_for_repeated_identical_success_output_by_default():
     controller = ToolCallGuardrailController(
         ToolCallGuardrailConfig(no_progress_warn_after=2, no_progress_block_after=2)


### PR DESCRIPTION
## Summary
- Treat `skill_view` and `skills_list` as idempotent read-only tools in the tool-loop guardrail.
- This lets the existing no-progress guardrail warn/block repeated identical skill loads instead of repeatedly adding large skill outputs to context.
- Add a regression test covering repeated `skill_view` output under hard-stop guardrails.

## Why
Large skill reads are read-only and can return identical content across repeated calls. When a model gets into a tool loop, repeatedly loading the same skill can rapidly inflate context and amplify provider/proxy instability. Classifying skill reads as idempotent lets the existing guardrail stop that loop without changing normal first-time skill loading behavior.

## Test Plan
- `python -m pytest tests/agent/test_tool_guardrails.py tests/run_agent/test_tool_call_guardrail_runtime.py -q`
