### PR TITLE
feat(auth): share openai-codex OAuth token across profiles via shared store

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -3532,6 +3532,11 @@ def _save_codex_tokens(tokens: Dict[str, str], last_refresh: str = None, label: 
             previous_singleton_tokens=previous_singleton_tokens,
         )
         _save_auth_store(auth_store)
+    # Publish the freshly saved singleton token to the cross-profile shared
+    # store so sibling Hermes profiles can recover it after a refresh_token
+    # rotation instead of 401'ing. Best-effort; runs outside the auth-store
+    # lock and preserves the auth-then-shared lock ordering invariant.
+    _write_shared_codex_state(tokens, last_refresh)
 
 
 def _recover_codex_tokens_from_cli(reason: str) -> Optional[Dict[str, str]]:
@@ -3707,9 +3712,10 @@ def _refresh_codex_auth_tokens(
         # we never self-heal those and re-raise unchanged.
         if not getattr(exc, "relogin_required", False):
             raise
-        imported = _recover_codex_tokens_from_cli(
-            f"refresh_token rejected: {getattr(exc, 'code', None) or 'auth_error'}"
-        )
+        reason = f"refresh_token rejected: {getattr(exc, 'code', None) or 'auth_error'}"
+        # Prefer a sibling Hermes profile's freshly rotated token (shared store)
+        # before falling back to the Codex CLI store (~/.codex).
+        imported = _recover_codex_tokens_from_shared(reason) or _recover_codex_tokens_from_cli(reason)
         if not imported:
             raise
         return imported
@@ -3783,7 +3789,8 @@ def resolve_codex_runtime_credentials(
             "codex_auth_missing_refresh_token",
             "codex_auth_invalid_shape",
         }:
-            imported = _recover_codex_tokens_from_cli(str(getattr(exc, "code", None) or "auth_error"))
+            _reason = str(getattr(exc, "code", None) or "auth_error")
+            imported = _recover_codex_tokens_from_shared(_reason) or _recover_codex_tokens_from_cli(_reason)
             if imported:
                 data = {"tokens": imported, "last_refresh": imported.get("last_refresh")}
             else:
@@ -4618,8 +4625,8 @@ NOUS_SHARED_STORE_FILENAME = "nous_auth.json"
 _nous_shared_lock_holder = threading.local()
 
 
-def _nous_shared_auth_dir() -> Path:
-    """Resolve the directory that holds the shared Nous token store.
+def _shared_auth_dir() -> Path:
+    """Resolve the directory that holds cross-profile shared OAuth stores.
 
     Honors ``HERMES_SHARED_AUTH_DIR`` so tests can redirect it to a tmp
     path without touching the real user's home. Defaults to
@@ -4636,6 +4643,11 @@ def _nous_shared_auth_dir() -> Path:
         return Path(override).expanduser()
     from hermes_constants import get_default_hermes_root
     return get_default_hermes_root() / "shared"
+
+
+def _nous_shared_auth_dir() -> Path:
+    """Directory for the shared Nous token store. See :func:`_shared_auth_dir`."""
+    return _shared_auth_dir()
 
 
 def _nous_shared_store_path() -> Path:
@@ -5022,6 +5034,208 @@ def _try_import_shared_nous_state(
         return None
 
     return refreshed
+
+
+# -----------------------------------------------------------------------------
+# Shared cross-profile Codex (openai-codex) OAuth store
+#
+# Mirrors the shared Nous store above and the xAI global-root write-through
+# (#43589): Hermes keeps a per-profile openai-codex singleton token, but OAuth
+# refresh_tokens are single-use. When one gateway (e.g. the default profile)
+# refreshes, it rotates the shared ChatGPT/Codex account token, so sibling
+# profiles (e.g. a separate ``--profile`` gateway) holding the old refresh
+# token start failing with relogin-required 401s until a manual re-auth.
+#
+# This store lets sibling profiles recover the freshly rotated token from a
+# single shared file written on every singleton save, instead of bouncing to
+# device-code. It complements the existing ~/.codex/auth.json self-heal (which
+# only recovers tokens the *Codex CLI* rotated): the shared store additionally
+# recovers tokens a *sibling Hermes profile* rotated, which Hermes does not
+# write back to ~/.codex (see #12360).
+#
+# Only the singleton openai-codex token is shared. Independent accounts added
+# via ``hermes auth add openai-codex`` live in the credential pool and never
+# flow through ``_save_codex_tokens``, so they are never published here
+# (regression guard for #39236).
+# -----------------------------------------------------------------------------
+
+CODEX_SHARED_STORE_FILENAME = "codex_auth.json"
+_codex_shared_lock_holder = threading.local()
+
+
+def _codex_shared_store_path() -> Path:
+    path = _shared_auth_dir() / CODEX_SHARED_STORE_FILENAME
+    # Seat belt: refuse to touch the real user's shared store under pytest
+    # unless HERMES_SHARED_AUTH_DIR is redirected to a tmp_path (mirrors the
+    # _nous_shared_store_path guard).
+    if os.environ.get("PYTEST_CURRENT_TEST"):
+        from hermes_constants import get_default_hermes_root
+        real_home_shared = (
+            get_default_hermes_root() / "shared" / CODEX_SHARED_STORE_FILENAME
+        ).resolve(strict=False)
+        try:
+            resolved = path.resolve(strict=False)
+        except Exception:
+            resolved = path
+        if resolved == real_home_shared:
+            raise RuntimeError(
+                f"Refusing to touch real user shared Codex auth store during test run: "
+                f"{path}. Set HERMES_SHARED_AUTH_DIR to a tmp_path in your test fixture."
+            )
+    return path
+
+
+@contextmanager
+def _codex_shared_store_lock(timeout_seconds: float = AUTH_LOCK_TIMEOUT_SECONDS):
+    """Cross-profile lock for the shared Codex OAuth store.
+
+    Lock ordering invariant: if both this and ``_auth_store_lock`` need to be
+    held, acquire ``_auth_store_lock`` FIRST. All codex paths follow this.
+    """
+    try:
+        lock_path = _codex_shared_store_path().with_suffix(".lock")
+    except RuntimeError:
+        # No HERMES_HOME yet (pre-setup): fall through without locking.
+        yield
+        return
+    with _file_lock(
+        lock_path,
+        _codex_shared_lock_holder,
+        timeout_seconds,
+        "Timed out waiting for shared Codex auth lock",
+    ):
+        yield
+
+
+def _write_shared_codex_state(
+    tokens: Dict[str, Any], last_refresh: Optional[str] = None
+) -> None:
+    """Publish the singleton Codex OAuth token pair to the shared store.
+
+    Best-effort: any failure is swallowed after logging. The per-profile
+    auth.json remains the source of truth.
+    """
+    if not isinstance(tokens, dict):
+        return
+    access_token = str(tokens.get("access_token", "") or "").strip()
+    refresh_token = str(tokens.get("refresh_token", "") or "").strip()
+    if not access_token or not refresh_token:
+        # No refresh_token = nothing worth sharing across profiles.
+        return
+    shared = {
+        "_schema": 1,
+        "access_token": access_token,
+        "refresh_token": refresh_token,
+        "last_refresh": last_refresh,
+        "updated_at": datetime.now(timezone.utc).isoformat(),
+    }
+    try:
+        with _codex_shared_store_lock():
+            path = _codex_shared_store_path()
+            path.parent.mkdir(parents=True, exist_ok=True)
+            # secure_parent_dir refuses to chmod / or top-level dirs (#25821).
+            secure_parent_dir(path)
+            tmp = path.with_name(f"{path.name}.tmp.{os.getpid()}.{uuid.uuid4().hex}")
+            # Create with 0o600 atomically via os.open(O_EXCL) — closes the
+            # TOCTOU window where write_text() + post-write chmod briefly
+            # exposed the refresh_token at process umask. See #19673, #21148.
+            fd = os.open(
+                str(tmp),
+                os.O_WRONLY | os.O_CREAT | os.O_EXCL,
+                stat.S_IRUSR | stat.S_IWUSR,
+            )
+            try:
+                with os.fdopen(fd, "w", encoding="utf-8") as fh:
+                    fh.write(json.dumps(shared, indent=2, sort_keys=True))
+                    fh.flush()
+                    os.fsync(fh.fileno())
+                os.replace(tmp, path)
+            finally:
+                try:
+                    if tmp.exists():
+                        tmp.unlink()
+                except OSError:
+                    pass
+        _oauth_trace(
+            "codex_shared_store_written",
+            path=str(path),
+            refresh_token_fp=_token_fingerprint(refresh_token),
+        )
+    except Exception as exc:
+        logger.debug("Failed to write shared Codex auth store: %s", exc)
+
+
+def _read_shared_codex_state() -> Optional[Dict[str, Any]]:
+    """Return the shared Codex OAuth state if present and well-formed, else None."""
+    try:
+        path = _codex_shared_store_path()
+    except RuntimeError:
+        # Test seat belt tripped — treat as missing.
+        return None
+    if not path.is_file():
+        return None
+    try:
+        payload = json.loads(path.read_text())
+    except (OSError, ValueError) as exc:
+        logger.debug("Shared Codex auth store at %s is unreadable: %s", path, exc)
+        return None
+    if not isinstance(payload, dict):
+        return None
+    access_token = payload.get("access_token")
+    refresh_token = payload.get("refresh_token")
+    if not (isinstance(access_token, str) and access_token.strip()):
+        return None
+    if not (isinstance(refresh_token, str) and refresh_token.strip()):
+        return None
+    return payload
+
+
+def _clear_shared_codex_state(reason: str) -> None:
+    """Remove the shared Codex OAuth store after a terminal token failure."""
+    try:
+        with _codex_shared_store_lock():
+            path = _codex_shared_store_path()
+            try:
+                path.unlink()
+            except FileNotFoundError:
+                pass
+        _oauth_trace("codex_shared_store_cleared", reason=reason)
+    except Exception as exc:
+        logger.debug("Failed to clear shared Codex auth store: %s", exc)
+
+
+def _recover_codex_tokens_from_shared(reason: str) -> Optional[Dict[str, str]]:
+    """Adopt a still-valid Codex token pair published by a sibling Hermes profile.
+
+    Cross-profile counterpart to ``_recover_codex_tokens_from_cli``: when one
+    profile refreshes openai-codex it rotates the single-use refresh_token, so
+    sibling profiles holding the old copy 401. They recover the freshly rotated
+    token here instead of forcing a device-code re-login.
+
+    Only adopts a shared token whose access_token is still valid; an expiring
+    shared token is skipped so the caller falls through to the Codex CLI store
+    (~/.codex) or device-code. Best-effort; never raises.
+    """
+    try:
+        with _codex_shared_store_lock():
+            shared = _read_shared_codex_state()
+        if not shared:
+            return None
+        access_token = str(shared.get("access_token", "") or "").strip()
+        refresh_token = str(shared.get("refresh_token", "") or "").strip()
+        if not access_token or not refresh_token:
+            return None
+        # Skip an expiring shared token so the caller can fall through to the
+        # Codex CLI store / device-code rather than adopt a soon-dead token.
+        if _codex_access_token_is_expiring(access_token, 0):
+            return None
+        tokens = {"access_token": access_token, "refresh_token": refresh_token}
+        logger.info("Codex auth recovered from shared store (%s).", reason)
+        _save_codex_tokens(tokens, last_refresh=shared.get("last_refresh"))
+        return dict(tokens)
+    except Exception as exc:
+        logger.debug("Shared Codex import failed: %s", exc)
+        return None
 
 
 def _refresh_access_token(

--- a/tests/hermes_cli/test_auth_codex_shared_store.py
+++ b/tests/hermes_cli/test_auth_codex_shared_store.py
@@ -1,0 +1,178 @@
+"""Tests for the shared cross-profile Codex (openai-codex) OAuth store.
+
+Hermes keeps a per-profile openai-codex singleton token, but OAuth
+refresh_tokens are single-use. When one gateway (e.g. the default profile)
+refreshes it rotates the shared ChatGPT/Codex account token, so a sibling
+profile (e.g. a separate ``--profile`` gateway) holding the old refresh token
+401s until a manual re-auth.
+
+The shared store (``<hermes-root>/shared/codex_auth.json``) is written on every
+singleton save so sibling profiles can recover the freshly rotated token
+instead of bouncing to device-code. It complements — does not replace — the
+existing ``~/.codex/auth.json`` self-heal (which only recovers tokens the Codex
+CLI rotated; Hermes does not write back to ~/.codex, see #12360).
+"""
+
+import base64
+import json
+import time
+
+import pytest
+
+import hermes_cli.auth as auth
+from hermes_cli.auth import (
+    AuthError,
+    _read_shared_codex_state,
+    _recover_codex_tokens_from_shared,
+    _refresh_codex_auth_tokens,
+    _write_shared_codex_state,
+)
+
+
+@pytest.fixture
+def shared_store_env(tmp_path, monkeypatch):
+    """Redirect HERMES_SHARED_AUTH_DIR to a tmp_path.
+
+    Required for every test that exercises the shared Codex store — the
+    in-auth.py seat belt refuses to touch the real user's shared store under
+    pytest, so tests that forget this fixture fail loudly instead of
+    corrupting real state.
+    """
+    shared_dir = tmp_path / "shared"
+    monkeypatch.setenv("HERMES_SHARED_AUTH_DIR", str(shared_dir))
+    return shared_dir
+
+
+def _expired_jwt() -> str:
+    """A minimal JWT whose exp is in the past (so it reads as expiring)."""
+    def b64(obj):
+        raw = json.dumps(obj).encode("utf-8")
+        return base64.urlsafe_b64encode(raw).rstrip(b"=").decode("ascii")
+
+    header = b64({"alg": "none", "typ": "JWT"})
+    payload = b64({"exp": int(time.time()) - 3600})
+    return f"{header}.{payload}.sig"
+
+
+# ── store read/write primitives ──────────────────────────────────────────────
+
+def test_shared_write_and_read_roundtrip(shared_store_env):
+    _write_shared_codex_state(
+        {"access_token": "access-1", "refresh_token": "refresh-1"},
+        last_refresh="2026-06-16T00:00:00Z",
+    )
+    out = _read_shared_codex_state()
+    assert out is not None
+    assert out["access_token"] == "access-1"
+    assert out["refresh_token"] == "refresh-1"
+    assert out["last_refresh"] == "2026-06-16T00:00:00Z"
+
+
+def test_shared_write_skips_without_refresh_token(shared_store_env):
+    _write_shared_codex_state({"access_token": "access-only"})
+    assert _read_shared_codex_state() is None
+
+
+def test_shared_read_missing_returns_none(shared_store_env):
+    assert _read_shared_codex_state() is None
+
+
+def test_shared_read_malformed_returns_none(shared_store_env):
+    shared_store_env.mkdir(parents=True, exist_ok=True)
+    (shared_store_env / "codex_auth.json").write_text("{ not json")
+    assert _read_shared_codex_state() is None
+
+
+def test_shared_file_is_owner_only(shared_store_env):
+    import os
+    import stat as stat_mod
+
+    _write_shared_codex_state(
+        {"access_token": "access-1", "refresh_token": "refresh-1"}
+    )
+    path = shared_store_env / "codex_auth.json"
+    assert path.is_file()
+    if os.name != "nt":
+        mode = stat_mod.S_IMODE(path.stat().st_mode)
+        assert mode == 0o600
+
+
+# ── write-through hook on _save_codex_tokens ─────────────────────────────────
+
+def test_save_codex_tokens_publishes_to_shared(shared_store_env):
+    # HERMES_HOME is redirected to a tmp dir by the autouse conftest fixture,
+    # so this writes a real per-profile auth.json under the test root.
+    auth._save_codex_tokens(
+        {"access_token": "saved-access", "refresh_token": "saved-refresh"}
+    )
+    shared = _read_shared_codex_state()
+    assert shared is not None
+    assert shared["access_token"] == "saved-access"
+    assert shared["refresh_token"] == "saved-refresh"
+
+
+# ── recovery from the shared store ───────────────────────────────────────────
+
+def test_recover_from_shared_adopts_valid_token(shared_store_env, monkeypatch):
+    saved = {}
+    monkeypatch.setattr(auth, "_save_codex_tokens", lambda t, *a, **k: saved.update(t))
+    _write_shared_codex_state(
+        {"access_token": "fresh-access", "refresh_token": "fresh-refresh"}
+    )
+
+    out = _recover_codex_tokens_from_shared("test")
+
+    assert out == {"access_token": "fresh-access", "refresh_token": "fresh-refresh"}
+    # adopted token was persisted into the per-profile store
+    assert saved["access_token"] == "fresh-access"
+
+
+def test_recover_from_shared_returns_none_when_empty(shared_store_env):
+    assert _recover_codex_tokens_from_shared("test") is None
+
+
+def test_recover_from_shared_skips_expiring_token(shared_store_env, monkeypatch):
+    save_spy = {"n": 0}
+    monkeypatch.setattr(auth, "_save_codex_tokens", lambda *a, **k: save_spy.__setitem__("n", save_spy["n"] + 1))
+    # An expiring access_token must NOT be adopted — caller should fall through
+    # to the Codex CLI store / device-code instead of taking a soon-dead token.
+    _write_shared_codex_state(
+        {"access_token": _expired_jwt(), "refresh_token": "refresh-x"}
+    )
+
+    assert _recover_codex_tokens_from_shared("test") is None
+    assert save_spy["n"] == 0
+
+
+# ── integration: refresh prefers shared store over the Codex CLI store ───────
+
+def test_refresh_prefers_shared_over_cli(shared_store_env, monkeypatch):
+    """On a relogin-required refresh failure, a valid sibling-published token in
+    the shared store is adopted before falling back to ~/.codex."""
+    cli_calls = {"n": 0}
+
+    def _rejected(*_a, **_k):
+        raise AuthError(
+            "refresh token reused",
+            provider="openai-codex",
+            code="refresh_token_reused",
+            relogin_required=True,
+        )
+
+    def _cli_spy():
+        cli_calls["n"] += 1
+        return {"access_token": "cli-access", "refresh_token": "cli-refresh"}
+
+    monkeypatch.setattr(auth, "refresh_codex_oauth_pure", _rejected)
+    monkeypatch.setattr(auth, "_import_codex_cli_tokens", _cli_spy)
+    monkeypatch.setattr(auth, "_save_codex_tokens", lambda *a, **k: None)
+    _write_shared_codex_state(
+        {"access_token": "sibling-access", "refresh_token": "sibling-refresh"}
+    )
+
+    out = _refresh_codex_auth_tokens(
+        {"access_token": "stale-access", "refresh_token": "stale-refresh"}, 20.0
+    )
+
+    assert out["access_token"] == "sibling-access"
+    assert cli_calls["n"] == 0  # shared store satisfied the recovery; ~/.codex untouched


### PR DESCRIPTION
## Problem

Hermes keeps a **per-profile** `openai-codex` singleton token, but OAuth `refresh_token`s are **single-use**. When one gateway (e.g. the default profile) refreshes, it rotates the shared ChatGPT/Codex account token, so a **sibling profile** (e.g. a separate `--profile` gateway such as a dedicated assistant) that still holds the old refresh token starts failing with relogin-required 401s until a manual re-auth.

The existing `~/.codex/auth.json` self-heal only recovers tokens the **Codex CLI** rotated. It does **not** cover the case where a *sibling Hermes profile* rotated the token, because Hermes deliberately does not write back to `~/.codex` (#12360). With two gateways on the same account (default + a profile gateway), they rotate each other's tokens and intermittently 401.

## Fix

Mirror the patterns already used for **Nous** (shared store) and **xAI** (global-root write-through, #43589), now for `openai-codex`:

- **Write-through**: publish the singleton token to `<hermes-root>/shared/codex_auth.json` on every `_save_codex_tokens`, atomically (`O_EXCL`, `0o600`) under a cross-profile lock.
- **Recover**: on a relogin-required refresh failure, prefer a still-valid sibling-published token from the shared store **before** falling back to the Codex CLI store (`~/.codex`). An expiring shared token is skipped so the caller still falls through.

The shared dir resolution (`HERMES_SHARED_AUTH_DIR` → `<hermes-root>/shared/`) is factored into `_shared_auth_dir()` and reused by the existing Nous helper.

## Safety / scope

- **Only the singleton token is shared.** Independent accounts added via `hermes auth add openai-codex` live in the credential pool and never flow through `_save_codex_tokens`, so they are never published (regression guard for #39236).
- Lock-ordering invariant preserved: `_auth_store_lock` is always acquired before the shared-store lock.
- Best-effort: shared-store write/read failures are swallowed; the per-profile `auth.json` remains the source of truth.
- Same TOCTOU-safe atomic write + `0o600` perms as the Nous/xAI stores (#19673, #21148).

## Tests

New `tests/hermes_cli/test_auth_codex_shared_store.py` (10 tests, all passing):

- write/read roundtrip; write skips without refresh_token; read returns `None` on missing/malformed; owner-only file perms
- `_save_codex_tokens` publishes to the shared store
- recovery adopts a valid token, returns `None` when empty, and **skips an expiring token**
- integration: a relogin-required refresh prefers the shared store over `~/.codex`

Existing codex/nous auth suites pass unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
