### PR TITLE
feat(telegram): topic-to-profile routing for forum topics

### DIFF
--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -491,6 +491,23 @@ class TelegramAdapter(BasePlatformAdapter):
         # Tracks status bubbles owned by this adapter so subsequent calls with the
         # same key edit the same message instead of appending new ones (#30045).
         self._status_message_ids: Dict[tuple, str] = {}
+        # Topic-to-profile routing: dispatch messages from specific forum
+        # topics to a different Hermes profile (model, skills, memory, SOUL).
+        # Config: telegram.topic_profiles:
+        #   - match: {chat_id: "-100...", thread_id: "2460"}
+        #     profile: "fitness"
+        self._topic_profiles: Dict[tuple, str] = {}
+        _tp_cfg = self.config.extra.get("topic_profiles")
+        if isinstance(_tp_cfg, list):
+            for entry in _tp_cfg:
+                if not isinstance(entry, dict):
+                    continue
+                match = entry.get("match", {}) or {}
+                chat_id = str(match.get("chat_id", ""))
+                thread_id = str(match.get("thread_id", ""))
+                profile = str(entry.get("profile", "")).strip()
+                if chat_id and profile:
+                    self._topic_profiles[(chat_id, thread_id)] = profile
 
     def _notification_kwargs(
         self, metadata: Optional[Dict[str, Any]]
@@ -506,6 +523,41 @@ class TelegramAdapter(BasePlatformAdapter):
         if (metadata or {}).get("notify"):
             return {}
         return {"disable_notification": True}
+
+    def _resolve_topic_profile(self, msg):
+        """Resolve target profile for a message based on topic_profiles routing.
+
+        Checks the message's chat_id + message_thread_id against the
+        configured topic_profiles routing table.  Returns the target
+        profile name on match, or None to use the default profile.
+        """
+        if not self._topic_profiles or not msg:
+            return None
+        chat_id = str(getattr(getattr(msg, "chat", None), "id", "") or "")
+        thread_id = str(
+            getattr(msg, "message_thread_id", None) or ""
+        )
+        # Exact match first: chat_id + thread_id
+        profile = self._topic_profiles.get((chat_id, thread_id))
+        if profile:
+            return profile
+        # Fallback: chat_id + empty thread_id (messages without thread_id)
+        if thread_id:
+            profile = self._topic_profiles.get((chat_id, ""))
+            if profile:
+                return profile
+        return None
+
+    def _apply_topic_profile_routing(self, event, msg):
+        """Apply topic-to-profile routing to a MessageEvent.
+
+        Calls _resolve_topic_profile and attaches the target profile to
+        the event.  The gateway runner detects this attribute and loads
+        the target profile config for the session.
+        """
+        profile = self._resolve_topic_profile(msg)
+        if profile:
+            event.source.routing_profile = profile
 
     def _is_callback_user_authorized(
         self,
@@ -5093,6 +5145,7 @@ class TelegramAdapter(BasePlatformAdapter):
         event = self._build_message_event(msg, MessageType.COMMAND, update_id=update.update_id)
         event.text = self._clean_bot_trigger_text(event.text)
         event = self._apply_telegram_group_observe_attribution(event)
+        self._apply_topic_profile_routing(event, msg)
         await self.handle_message(event)
 
     async def _handle_location_message(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
@@ -5133,6 +5186,7 @@ class TelegramAdapter(BasePlatformAdapter):
         event = self._build_message_event(msg, MessageType.LOCATION, update_id=update.update_id)
         event.text = "\n".join(parts)
         event = self._apply_telegram_group_observe_attribution(event)
+        self._apply_topic_profile_routing(event, msg)
         await self.handle_message(event)
 
     # ------------------------------------------------------------------
@@ -5334,6 +5388,7 @@ class TelegramAdapter(BasePlatformAdapter):
         # Apply observe attribution after caption is set; sticker is handled above
         # because _handle_sticker overwrites event.text with its vision description.
         event = self._apply_telegram_group_observe_attribution(event)
+        self._apply_topic_profile_routing(event, msg)
 
         # Download photo to local image cache so the vision tool can access it
         # even after Telegram's ephemeral file URLs expire (~1 hour).

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1534,6 +1534,25 @@ def _load_gateway_config() -> dict:
     return {}
 
 
+def _load_profile_config(profile_name: str) -> dict:
+    """Load a specific Hermes profile config.yaml.
+
+    Returns the parsed config dict or {} on error.  Used by
+    topic-to-profile routing to load the target profile model,
+    tools, and skills during agent creation.
+    """
+    profile_home = get_hermes_home().parent / profile_name
+    config_path = profile_home / "config.yaml"
+    try:
+        if config_path.exists():
+            import yaml
+            with open(config_path, "r", encoding="utf-8") as f:
+                return yaml.safe_load(f) or {}
+    except Exception:
+        logger.debug("Could not load profile config from %s", config_path)
+    return {}
+
+
 def _load_gateway_runtime_config() -> dict:
     """Load gateway config for runtime reads, expanding supported ``${VAR}`` refs.
 
@@ -16654,6 +16673,11 @@ class GatewayRunner:
             return self._is_session_run_current(session_key, run_generation)
         
         user_config = _load_gateway_config()
+        # Topic-to-profile routing: override config with target profile
+        if getattr(source, "routing_profile", None):
+            profile_cfg = _load_profile_config(source.routing_profile)
+            if profile_cfg:
+                user_config = profile_cfg
         platform_key = _platform_config_key(source.platform)
 
         from hermes_cli.tools_config import _get_platform_tools

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -84,6 +84,7 @@ class SessionSource:
     user_id: Optional[str] = None
     user_name: Optional[str] = None
     thread_id: Optional[str] = None  # For forum topics, Discord threads, etc.
+    routing_profile: Optional[str] = None  # Target Hermes profile for topic-to-profile routing
     chat_topic: Optional[str] = None  # Channel topic/description (Discord, Slack)
     user_id_alt: Optional[str] = None  # Platform-specific stable alt ID (Signal UUID, Feishu union_id)
     chat_id_alt: Optional[str] = None  # Signal group internal ID


### PR DESCRIPTION
## Summary

Dispatch messages from specific Telegram forum topics (threads) to different Hermes profiles — each with its own model, skills, memory, and SOUL. Single bot, multiple specialist agents.

**Related:** #4321, #10143

## Changes (3 files, +80 lines)

- **`session.py`** — Added `routing_profile: Optional[str]` field to `SessionSource`
- **`telegram.py`** — `_topic_profiles` dict from `config.extra.topic_profiles`; `_resolve_topic_profile()` matches `(chat_id, thread_id)` with empty-thread-id fallback; `_apply_topic_profile_routing()` called before `handle_message` for text, location, and photo/sticker/vision messages
- **`run.py`** — `_load_profile_config()` reads a named profile's `config.yaml`; overrides user config when `routing_profile` is set on the event source

## Config format

```yaml
telegram:
  topic_profiles:
    - match: {chat_id: "-1001234567890", thread_id: "2460"}
      profile: "fitness"
```

## Behavior

- Exact match: `chat_id` + `thread_id` → target profile
- Fallback: `chat_id` + empty `thread_id` (messages without thread_id)
- No match: keeps current behavior (default profile)
- Target profile gets its own model, tools, skills, memory, and SOUL.md

## Testing

Tested live on a production instance — fitness forum topic routes to fitness profile, yielding profile-scoped responses.