### PR TITLE
Fix: Telegram send_message should retry on timeout errors

### DIFF
--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -97,8 +97,11 @@ def _telegram_retry_delay(exc: Exception, attempt: int) -> float | None:
             return 1.0
 
     text = str(exc).lower()
+    # Telegram timeout errors should also retry (previously returned None as
+    # non-retryable, which caused messages to be lost on transient timeouts).
+    # Aligns with the 502/503/504 retry logic above.
     if "timed out" in text or "timeout" in text:
-        return None
+        return float(2 ** attempt)
     if (
         "bad gateway" in text
         or "502" in text


### PR DESCRIPTION
## 問題

`_telegram_retry_delay` 函式對 **timeout 錯誤視為不可重試**（return None），導致 Telegram 偶發 timeout 時訊息直接丟失。

## 修復

對齊 502/503/504 邏輯，timeout 也用指數退避重試（2/4/8 秒）。

## 影響範圍

- 所有用 `send_message` 工具發 Telegram 的場景
- 特別是 cron job 排程的訊息（無人工介入修復）
- 訊息丟失且無 fallback 機制

## 修復驗證

KAKACO 已在本機 patch 驗證有效：
- 修復前：Telegram 偶發 timeout → 訊息丟失
- 修復後：3 次指數退避（2/4/8 秒）→ 大幅提升送達率

## Diff

```diff
--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -97,8 +97,11 @@ def _telegram_retry_delay(exc: Exception, attempt: int) -> float | None:
             return 1.0
 
     text = str(exc).lower()
+    # Telegram timeout errors should also retry (previously returned None as
+    # non-retryable, which caused messages to be lost on transient timeouts).
+    # Aligns with the 502/503/504 retry logic above.
     if "timed out" in text or "timeout" in text:
-        return None
+        return float(2 ** attempt)
     if (
         "bad gateway" in text
         or "502" in text
```

## 對應 Issue

Fixes #47229

## 環境

- hermes-agent: M3 (含 5 層 fallback 機制)
- 影響版本：所有 timeout 視為不可重試的版本
