### PR TITLE
fix(tui_gateway): interrupt async delegations on TUI shutdown

### DIFF
--- a/tests/test_tui_gateway_shutdown_delegation.py
+++ b/tests/test_tui_gateway_shutdown_delegation.py
@@ -1,0 +1,43 @@
+"""Regression test: TUI gateway shutdown calls interrupt_all().
+
+Before the fix, `_shutdown_sessions` only closed open WS sessions but never
+signalled running async delegations to stop.  CLI and gateway both call
+`tools.async_delegation.interrupt_all()` on shutdown; the TUI path was the
+only entry point that didn't, leaving background delegations running as
+orphaned daemon threads until the process exited.
+"""
+
+from unittest.mock import MagicMock, patch
+
+from tui_gateway import server
+
+
+def test_shutdown_sessions_calls_interrupt_all():
+    """_shutdown_sessions must call interrupt_all before closing sessions."""
+    interrupt_mock = MagicMock(return_value=0)
+
+    with patch("tui_gateway.server._sessions_lock"), \
+         patch.dict("tui_gateway.server._sessions", {}), \
+         patch("tools.async_delegation.interrupt_all", interrupt_mock):
+        server._shutdown_sessions()
+
+    interrupt_mock.assert_called_once_with(reason="tui_shutdown")
+
+
+def test_shutdown_sessions_interrupt_error_does_not_prevent_close():
+    """If interrupt_all raises, session close still runs."""
+    closed = []
+
+    def _fake_close(sid, *, end_reason):
+        closed.append(sid)
+
+    with patch("tui_gateway.server._sessions_lock"), \
+         patch.dict("tui_gateway.server._sessions", {"sid1": {}, "sid2": {}}), \
+         patch("tui_gateway.server._close_session_by_id", side_effect=_fake_close), \
+         patch(
+             "tools.async_delegation.interrupt_all",
+             side_effect=RuntimeError("boom"),
+         ):
+        server._shutdown_sessions()
+
+    assert set(closed) == {"sid1", "sid2"}

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -574,6 +574,11 @@ def _close_sessions_for_transport(
 
 
 def _shutdown_sessions() -> None:
+    try:
+        from tools.async_delegation import interrupt_all
+        interrupt_all(reason="tui_shutdown")
+    except Exception:
+        pass
     with _sessions_lock:
         sids = list(_sessions)
     for sid in sids:


### PR DESCRIPTION
## Summary

`_shutdown_sessions()` in `tui_gateway/server.py` (registered via `atexit`) closes open WebSocket sessions but never calls `tools.async_delegation.interrupt_all()`.

Both other shutdown paths already do this:
- **CLI** — `cli.py:981-984`
- **Gateway** — `gateway/run.py:6043-6051`

The TUI was the only entry point that didn't, leaving running background delegations as orphaned daemon threads that keep burning tokens with no one listening until the process exits hard.

## Fix

Add the same `try/except` guard before the session-close loop:

```python
def _shutdown_sessions() -> None:
    try:
        from tools.async_delegation import interrupt_all
        interrupt_all(reason="tui_shutdown")
    except Exception:
        pass
    with _sessions_lock:
        sids = list(_sessions)
    for sid in sids:
        _close_session_by_id(sid, end_reason="tui_shutdown")
```

## Tests

New file `tests/test_tui_gateway_shutdown_delegation.py`:

| Test | What it checks |
|---|---|
| `test_shutdown_sessions_calls_interrupt_all` | `interrupt_all(reason="tui_shutdown")` is called on shutdown |
| `test_shutdown_sessions_interrupt_error_does_not_prevent_close` | If `interrupt_all` raises, session close still runs for all sessions |

## Checklist

- [x] Mirrors the pattern already used in `cli.py` and `gateway/run.py`
- [x] `try/except Exception: pass` guard ensures backward compat if `async_delegation` module is absent
- [x] Both tests pass
- [x] No changes to public API