### PR TITLE
fix: call LCM engine.ingest() every turn for WebUI sessions

### DIFF
--- a/agent/turn_context.py
+++ b/agent/turn_context.py
@@ -245,6 +245,28 @@ def build_turn_context(
             exc_info=True,
         )
 
+    # ── Ingest messages to durable store every turn ──
+    # Short conversations (especially WebUI) never hit compression threshold
+    # and never expire like Telegram sessions, so ingest unconditionally.
+    _ce = getattr(agent, "context_compressor", None)
+    if _ce is not None and hasattr(_ce, "ingest"):
+        try:
+            _ce.ingest(messages)
+            logger.debug(
+                "Per-turn ingest completed for session=%s msgs=%d",
+                getattr(_ce, "_session_id", "") or "(none)",
+                len(messages),
+            )
+        except Exception as _ingest_err:
+            logger.warning("Per-turn ingest failed for session=%s: %s",
+                           getattr(_ce, "_session_id", "") or "(none)", _ingest_err)
+    else:
+        logger.debug(
+            "Per-turn ingest skipped: context_compressor=%s has_ingest=%s",
+            type(_ce).__name__ if _ce else None,
+            hasattr(_ce, "ingest") if _ce else False,
+        )
+
     # ── Preflight context compression ──
     if (
         agent.compression_enabled


### PR DESCRIPTION
## Problem

WebUI sessions never expire (browser keeps them alive) and short conversations never hit the compression threshold. Since LCM only ingests on compression or session-end, **WebUI messages from short conversations never reach LCM** — making them invisible to journal crons, cross-session search, and memory providers.

Telegram sessions work because the gateway has a session expiry loop that eventually fires `shutdown_memory_provider()` -> `context_compressor.on_session_end()` -> `_ingest_messages()`. WebUI has no equivalent.

## Fix

Add a duck-typed call to `context_compressor.ingest(messages)` in `turn_context.py` before the preflight compression block. This runs unconditionally for every turn.

- Uses `hasattr(_ce, "ingest")` so non-LCM engines (built-in `ContextCompressor`) skip gracefully
- Uses existing `_ingest_messages` cursor — no duplicates when `compress()` runs later the same turn
- Zero extra LLM calls — `_ingest_messages()` is pure SQLite writes

## Companion PR

Requires [stephenschoettler/hermes-lcm#260](https://github.com/stephenschoettler/hermes-lcm/pull/260) which adds the `ingest()` method to the LCM engine. That PR is backward-compatible — `ingest()` simply won't exist on older LCM versions and the `hasattr` guard handles it.

## Testing

Verified live on a running Hermes instance with LCM v0.17.0:
- Cron jobs triggered per-turn ingest after gateway restart
- New `store_id` 76965 and 76966 landed in LCM with unique timestamps
- Log confirmed: `Per-turn ingest OK: session=cron_... msgs=1 cursor=1`