### PR TITLE
fix(agent): query LMStudio native API for context_length on remote instances

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -866,6 +866,57 @@ def fetch_endpoint_model_metadata(
                 except Exception:
                     pass
 
+            # Fallback: if models were found but none have context_length,
+            # try the LMStudio native /api/v1/models endpoint (works for
+            # remote LMStudio instances where is_local_endpoint() is False).
+            if cache and not any(
+                "context_length" in v for v in cache.values()
+            ):
+                try:
+                    if detect_local_server_type(
+                        normalized, api_key=api_key
+                    ) == "lm-studio":
+                        server_url = (
+                            normalized[:-3].rstrip("/")
+                            if normalized.endswith("/v1")
+                            else normalized
+                        )
+                        lm_resp = requests.get(
+                            server_url.rstrip("/") + "/api/v1/models",
+                            headers=headers,
+                            timeout=10,
+                            verify=_resolve_requests_verify(),
+                        )
+                        lm_resp.raise_for_status()
+                        lm_payload = lm_resp.json()
+                        for lm_model in lm_payload.get("models", []):
+                            if not isinstance(lm_model, dict):
+                                continue
+                            lm_id = (
+                                lm_model.get("key")
+                                or lm_model.get("id")
+                                or ""
+                            )
+                            for inst in (
+                                lm_model.get("loaded_instances") or []
+                            ):
+                                if not isinstance(inst, dict):
+                                    continue
+                                cfg = inst.get("config", {})
+                                ctx = (
+                                    cfg.get("context_length")
+                                    if isinstance(cfg, dict)
+                                    else None
+                                )
+                                if isinstance(ctx, int) and ctx > 0:
+                                    # Merge into matching cache entries
+                                    for alias_key, alias_entry in cache.items():
+                                        if alias_key == lm_id or alias_entry.get("name") == lm_id:
+                                            alias_entry.setdefault("context_length", ctx)
+                                    break
+                except Exception:
+                    pass  # best-effort; standard metadata is still usable
+
             _endpoint_model_metadata_cache[normalized] = cache
             _endpoint_model_metadata_cache_time[normalized] = time.time()
             return cache

--- a/tests/agent/test_model_metadata_local_ctx.py
+++ b/tests/agent/test_model_metadata_local_ctx.py
@@ -595,3 +595,119 @@ class TestGetModelContextLengthLocalFallback:
             result = get_model_context_length("unknown-xyz-model", "")
 
         mock_query.assert_not_called()
+
+
+class TestFetchEndpointModelMetadataRemoteLmStudioFallback:
+    """Remote LMStudio: native /api/v1/models fallback when standard path lacks context_length."""
+
+    def _make_resp(self, body):
+        resp = MagicMock()
+        resp.raise_for_status.return_value = None
+        resp.json.return_value = body
+        return resp
+
+    def test_remote_lmstudio_fallback_to_native_api(self):
+        """When standard /models returns no context_length, try LMStudio native API."""
+        from agent.model_metadata import fetch_endpoint_model_metadata
+
+        # Standard OpenAI /v1/models response (no context_length)
+        openai_resp = self._make_resp(
+            {
+                "data": [
+                    {
+                        "id": "qwen3.5-27b",
+                        "object": "model",
+                        "owned_by": "lm-studio",
+                    }
+                ]
+            }
+        )
+        # LMStudio native /api/v1/models response (has context_length)
+        native_resp = self._make_resp(
+            {
+                "models": [
+                    {
+                        "key": "qwen3.5-27b",
+                        "id": "qwen3.5-27b",
+                        "loaded_instances": [
+                            {"config": {"context_length": 131072}}
+                        ],
+                    }
+                ]
+            }
+        )
+
+        def mock_get(url, **kwargs):
+            if "/api/v1/models" in url:
+                return native_resp
+            return openai_resp
+
+        with patch("agent.model_metadata.is_local_endpoint", return_value=False), \
+             patch("agent.model_metadata.detect_local_server_type", return_value="lm-studio"), \
+             patch("agent.model_metadata.requests.get", side_effect=mock_get):
+            result = fetch_endpoint_model_metadata(
+                "https://remote-lmstudio:1234/v1",
+                api_key="test-key",
+                force_refresh=True,
+            )
+
+        assert "qwen3.5-27b" in result
+        assert result["qwen3.5-27b"]["context_length"] == 131072
+
+    def test_remote_non_lmstudio_no_fallback(self):
+        """When standard /models returns no context_length but server is not LMStudio, skip fallback."""
+        from agent.model_metadata import fetch_endpoint_model_metadata
+
+        openai_resp = self._make_resp(
+            {
+                "data": [
+                    {
+                        "id": "some-model",
+                        "object": "model",
+                        "owned_by": "openai",
+                    }
+                ]
+            }
+        )
+
+        with patch("agent.model_metadata.is_local_endpoint", return_value=False), \
+             patch("agent.model_metadata.detect_local_server_type", return_value=None), \
+             patch("agent.model_metadata.requests.get", return_value=openai_resp):
+            result = fetch_endpoint_model_metadata(
+                "https://remote-api:1234/v1",
+                api_key="test-key",
+                force_refresh=True,
+            )
+
+        assert "some-model" in result
+        assert "context_length" not in result["some-model"]
+
+    def test_standard_path_with_context_length_skips_fallback(self):
+        """When standard /models already returns context_length, skip LMStudio fallback."""
+        from agent.model_metadata import fetch_endpoint_model_metadata
+
+        openai_resp = self._make_resp(
+            {
+                "data": [
+                    {
+                        "id": "gpt-4",
+                        "object": "model",
+                        "owned_by": "openai",
+                        "context_length": 128000,
+                    }
+                ]
+            }
+        )
+
+        with patch("agent.model_metadata.is_local_endpoint", return_value=False), \
+             patch("agent.model_metadata.detect_local_server_type") as mock_detect, \
+             patch("agent.model_metadata.requests.get", return_value=openai_resp):
+            result = fetch_endpoint_model_metadata(
+                "https://api.openai.com/v1",
+                api_key="sk-test",
+                force_refresh=True,
+            )
+
+        # detect_local_server_type should NOT be called since context_length exists
+        mock_detect.assert_not_called()
+        assert result["gpt-4"]["context_length"] == 128000


### PR DESCRIPTION
## What does this PR do?

Adds a fallback to query LMStudio's native `/api/v1/models` endpoint for `context_length` metadata when the standard OpenAI-compatible `/v1/models` endpoint doesn't return it. This fixes context length detection for **remote** LMStudio instances.

## Related Issue

Fixes #47200

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/model_metadata.py`: After the standard `/models` query in `fetch_endpoint_model_metadata()`, if models were found but none have `context_length`, probe the LMStudio native `/api/v1/models` endpoint as a best-effort fallback and merge context_length into the cache.
- `tests/agent/test_model_metadata_local_ctx.py`: Added `TestFetchEndpointModelMetadataRemoteLmStudioFallback` with 3 tests covering the fallback, non-LMStudio skip, and early-exit when context_length already exists.

## How to Test

1. Configure a remote LMStudio instance (non-localhost, e.g. `192.168.1.x` or a public IP)
2. Set `model.base_url` to `http://<remote-ip>:1234/v1` in config.yaml
3. Start a session — `hermes` should now correctly detect the model's context length instead of falling back to 256K default
4. Run: `python -m pytest tests/agent/test_model_metadata_local_ctx.py::TestFetchEndpointModelMetadataRemoteLmStudioFallback -q`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation and Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- GitNexus unavailable — grep-based fallback used.
- Checked: `agent/model_metadata.py` `_fetch_endpoint_model_metadata`, `detect_local_server_type`, `is_local_endpoint`
- Blast radius: LOW — fallback is best-effort (wrapped in try/except), only triggers when standard path returns no context_length
- Related patterns: Local LMStudio fast path (lines 769-819) already handles the same extraction; this extends it to remote instances
