### PR TITLE
fix(slack): route /debug via /hermes to restore Telegram-parity

### DIFF
--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -1053,7 +1053,8 @@ _SLACK_PRIORITY_ALIASES = ("btw", "bg")
 # the telegram-parity test reads it so an entry here is a deliberate
 # "Slack-via-/hermes" decision, not a silent clamp.
 #   - credits: the billing/top-up surface; reached via /hermes credits on Slack.
-_SLACK_VIA_HERMES_ONLY = frozenset({"credits"})
+#   - debug: the log/report upload surface; reached via /hermes debug on Slack.
+_SLACK_VIA_HERMES_ONLY = frozenset({"credits", "debug"})
 
 
 def _sanitize_slack_name(raw: str) -> str:


### PR DESCRIPTION
## Summary
Restores Telegram↔Slack slash-command parity, which is currently red on `main`. `/debug` (added in #—, "add /debug slash command for all platforms") pushed the Slack native-slash registry past Slack's 50-command cap, so it got clamped out of the native list — present on Telegram, absent from Slack, and in neither exclusion set — failing `test_telegram_parity`.

Fix: add `debug` to `_SLACK_VIA_HERMES_ONLY`, the exact treatment `credits` already gets. `/debug` stays native on CLI, TUI, Telegram, and Discord, and remains reachable on Slack via `/hermes debug`.

## Root cause
Slack caps apps at 50 slash commands. `slack_native_slashes()` clamps to that ceiling; whichever command sorts last gets dropped. `debug` was the casualty. The parity test exists precisely to make this loud rather than a silent drop — the fix is to curate the via-`/hermes` list, not to suppress the test.

## Changes
- `hermes_cli/commands.py`: `_SLACK_VIA_HERMES_ONLY = {"credits"}` → `{"credits", "debug"}` + a one-line comment documenting why.

## Validation
- `tests/hermes_cli/test_commands.py`: 156 passed (was 1 failed: `test_telegram_parity`).

## Infographic

![slack-debug-parity-gits-cyberscape](https://v3b.fal.media/files/b/0a9e877c/f9vZsK5LS2AwoTIuLp0YL_wwMV5dn6.png)
