### PR TITLE
fix(bluebubbles): dedup inbound webhook events

### DIFF
--- a/gateway/platforms/bluebubbles.py
+++ b/gateway/platforms/bluebubbles.py
@@ -13,6 +13,7 @@ import json
 import logging
 import os
 import re
+import time
 import uuid
 from collections import OrderedDict
 from datetime import datetime
@@ -71,6 +72,8 @@ _PHONE_RE = re.compile(r"\+?\d{7,15}")
 _EMAIL_RE = re.compile(r"[\w.+-]+@[\w-]+\.[\w.]+")
 
 _GUID_CACHE_SIZE = 500  # LRU cap for resolved chat-GUID lookups
+_MESSAGE_GUID_DEDUP_TTL_SECONDS = 60.0
+_MESSAGE_GUID_DEDUP_CACHE_SIZE = 1000
 
 
 def _redact(text: str) -> str:
@@ -150,6 +153,7 @@ class BlueBubblesAdapter(BasePlatformAdapter):
         self._private_api_enabled: Optional[bool] = None
         self._helper_connected: bool = False
         self._guid_cache: OrderedDict[str, str] = OrderedDict()
+        self._recent_message_guids: OrderedDict[str, float] = OrderedDict()
 
     # ------------------------------------------------------------------
     # API helpers
@@ -860,6 +864,30 @@ class BlueBubblesAdapter(BasePlatformAdapter):
                 return candidate.strip()
         return None
 
+    def _is_duplicate_message_guid(
+        self,
+        msg_guid: Optional[str],
+        now: Optional[float] = None,
+    ) -> bool:
+        """Track recently seen inbound iMessage GUIDs."""
+        if not msg_guid:
+            return False
+        now = time.monotonic() if now is None else now
+        expired = [
+            guid
+            for guid, seen_at in self._recent_message_guids.items()
+            if now - seen_at > _MESSAGE_GUID_DEDUP_TTL_SECONDS
+        ]
+        for guid in expired:
+            self._recent_message_guids.pop(guid, None)
+        if msg_guid in self._recent_message_guids:
+            self._recent_message_guids.move_to_end(msg_guid)
+            return True
+        self._recent_message_guids[msg_guid] = now
+        while len(self._recent_message_guids) > _MESSAGE_GUID_DEDUP_CACHE_SIZE:
+            self._recent_message_guids.popitem(last=False)
+        return False
+
     async def _handle_webhook(self, request):
         from aiohttp import web
 
@@ -912,6 +940,19 @@ class BlueBubblesAdapter(BasePlatformAdapter):
             **_TAPBACK_ADDED,
             **_TAPBACK_REMOVED,
         }:
+            return web.Response(text="ok")
+
+        msg_guid = self._value(
+            record.get("guid"),
+            record.get("messageGuid"),
+            record.get("originalGuid"),
+        )
+        if self._is_duplicate_message_guid(msg_guid):
+            logger.debug(
+                "[bluebubbles] dropping duplicate webhook for guid %s (event=%s)",
+                _redact(msg_guid or ""),
+                event_type or "<none>",
+            )
             return web.Response(text="ok")
 
         text = (

--- a/tests/gateway/test_bluebubbles.py
+++ b/tests/gateway/test_bluebubbles.py
@@ -263,6 +263,81 @@ class TestBlueBubblesMentionGating:
         assert [event.text for event in handled] == ["hello from a dm"]
 
 
+class TestBlueBubblesWebhookDedup:
+    @pytest.mark.asyncio
+    async def test_duplicate_message_guid_is_acknowledged_and_skipped(self, monkeypatch):
+        adapter = _make_adapter(monkeypatch, send_read_receipts=False)
+        handled = []
+
+        async def fake_handle_message(event):
+            handled.append(event)
+
+        monkeypatch.setattr(adapter, "handle_message", fake_handle_message)
+        payload = {
+            "type": "new-message",
+            "data": {
+                "guid": "message-guid-1",
+                "text": "hello once",
+                "handle": {"address": "user@example.com"},
+                "isFromMe": False,
+                "chatGuid": "iMessage;-;user@example.com",
+                "chatIdentifier": "user@example.com",
+            },
+        }
+
+        first = await adapter._handle_webhook(_FakeBlueBubblesRequest(payload))
+        duplicate = await adapter._handle_webhook(_FakeBlueBubblesRequest({
+            **payload,
+            "type": "updated-message",
+        }))
+        await asyncio.sleep(0)
+
+        assert first.status == 200
+        assert duplicate.status == 200
+        assert [event.text for event in handled] == ["hello once"]
+
+    @pytest.mark.asyncio
+    async def test_distinct_message_guids_in_same_chat_are_dispatched(self, monkeypatch):
+        adapter = _make_adapter(monkeypatch, send_read_receipts=False)
+        handled = []
+
+        async def fake_handle_message(event):
+            handled.append(event)
+
+        monkeypatch.setattr(adapter, "handle_message", fake_handle_message)
+        base = {
+            "type": "new-message",
+            "data": {
+                "text": "hello",
+                "handle": {"address": "user@example.com"},
+                "isFromMe": False,
+                "chatGuid": "iMessage;-;user@example.com",
+                "chatIdentifier": "user@example.com",
+            },
+        }
+
+        first = await adapter._handle_webhook(_FakeBlueBubblesRequest({
+            **base,
+            "data": {**base["data"], "guid": "message-guid-1", "text": "first"},
+        }))
+        second = await adapter._handle_webhook(_FakeBlueBubblesRequest({
+            **base,
+            "data": {**base["data"], "guid": "message-guid-2", "text": "second"},
+        }))
+        await asyncio.sleep(0)
+
+        assert first.status == 200
+        assert second.status == 200
+        assert [event.text for event in handled] == ["first", "second"]
+
+    def test_message_guid_dedup_expires_after_ttl(self, monkeypatch):
+        adapter = _make_adapter(monkeypatch)
+
+        assert adapter._is_duplicate_message_guid("message-guid-1", now=100.0) is False
+        assert adapter._is_duplicate_message_guid("message-guid-1", now=101.0) is True
+        assert adapter._is_duplicate_message_guid("message-guid-1", now=161.1) is False
+
+
 class TestBlueBubblesWebhookParsing:
     def test_webhook_prefers_chat_guid_over_message_guid(self, monkeypatch):
         adapter = _make_adapter(monkeypatch)


### PR DESCRIPTION
## What does this PR do?

BlueBubbles can deliver more than one webhook for the same inbound iMessage, especially a `new-message` followed by an `updated-message` for the same message GUID. Without an idempotency guard, Hermes processes those duplicate webhooks as separate inbound turns and can send multiple agent replies for one user message.

This adds a small in-memory LRU/TTL guard keyed by the extracted message record GUID and acknowledges duplicates without dispatching them to the agent. It intentionally does not dedup on top-level `payload.guid`, because current BlueBubbles payload handling may use that field as a chat GUID.

## Related Issue

Supersedes the dedup portion of #11654. In that PR, a maintainer specifically asked for the de-dup fix, but the branch also bundled unrelated BlueBubbles voice-memo send changes.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/platforms/bluebubbles.py`: track recently seen inbound message GUIDs and skip duplicate webhook events within a 60-second TTL.
- `tests/gateway/test_bluebubbles.py`: add regression coverage for duplicate GUID suppression, distinct same-chat messages, and TTL expiry.

## How to Test

1. Send a BlueBubbles webhook with `data.guid=message-guid-1`; Hermes dispatches one inbound event.
2. Send a second webhook for the same `data.guid`; Hermes acknowledges it with `200 OK` and does not dispatch another event.
3. Send a different `data.guid` in the same chat; Hermes dispatches it normally.

Local verification:

```bash
scripts/run_tests.sh tests/gateway/test_bluebubbles.py
uv tool run ruff check gateway/platforms/bluebubbles.py tests/gateway/test_bluebubbles.py
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the focused gateway tests with `scripts/run_tests.sh` and they pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.3.1

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Not applicable; this is webhook handling behavior covered by tests.
