### PR TITLE
fix(gateway): deduplicate user message persistence on transient failures

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -9202,14 +9202,29 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 # message so the next message can load a transcript that
                 # reflects what was said.  Skip the assistant error text since
                 # it's a gateway-generated hint, not model output. (#7100)
-                _user_entry = {"role": "user", "content": message_text, "timestamp": ts}
-                if event.message_id:
-                    _user_entry["message_id"] = str(event.message_id)
-                self.session_store.append_to_transcript(
-                    session_entry.session_id,
-                    _user_entry,
-                    skip_db=agent_persisted,
-                )
+                #
+                # Dedup guard: if the last entry in history is already this
+                # user message (same content + message_id), skip the write.
+                # Without this, retries of the same Telegram message after
+                # repeated transient failures stack duplicate user turns and
+                # the agent falls behind. (#47237)
+                _already_persisted = False
+                if history:
+                    _last = history[-1]
+                    if _last.get("role") == "user" and _last.get("content") == message_text:
+                        _last_mid = str(_last.get("message_id", ""))
+                        _curr_mid = str(event.message_id or "")
+                        if not _curr_mid or _last_mid == _curr_mid:
+                            _already_persisted = True
+                if not _already_persisted:
+                    _user_entry = {"role": "user", "content": message_text, "timestamp": ts}
+                    if event.message_id:
+                        _user_entry["message_id"] = str(event.message_id)
+                    self.session_store.append_to_transcript(
+                        session_entry.session_id,
+                        _user_entry,
+                        skip_db=agent_persisted,
+                    )
             else:
                 history_len = agent_result.get("history_offset", len(history))
                 new_messages = agent_messages[history_len:] if len(agent_messages) > history_len else []

--- a/tests/gateway/test_transient_failure_dedup.py
+++ b/tests/gateway/test_transient_failure_dedup.py
@@ -1,0 +1,112 @@
+"""Tests for transient-failure user-message dedup (#47237).
+
+When the gateway persists a user message after a transient provider failure
+(429, timeout, auth error), subsequent retries of the same message must NOT
+stack duplicate user turns in the transcript.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+
+def _dedup_should_skip(history, message_text, message_id=None):
+    """Replicate the dedup guard from _handle_message_with_agent (line ~9207).
+
+    Returns True when the persistence should be SKIPPED (message already
+    present as the last entry in history).
+    """
+    if not history:
+        return False
+    _last = history[-1]
+    if _last.get("role") == "user" and _last.get("content") == message_text:
+        _last_mid = str(_last.get("message_id", ""))
+        _curr_mid = str(message_id or "")
+        if not _curr_mid or _last_mid == _curr_mid:
+            return True
+    return False
+
+
+class TestTransientFailureDedup:
+    """Verify the dedup guard prevents stacking duplicate user turns."""
+
+    def test_empty_history_does_not_skip(self):
+        """First attempt: history is empty → must persist."""
+        assert _dedup_should_skip([], "Hello") is False
+
+    def test_same_content_at_end_skips(self):
+        """Second attempt: last history entry matches → skip."""
+        history = [
+            {"role": "user", "content": "Hello", "message_id": "m1"},
+        ]
+        assert _dedup_should_skip(history, "Hello", "m1") is True
+
+    def test_same_content_no_message_id_skips(self):
+        """When no message_id on either side, content match alone is enough."""
+        history = [
+            {"role": "user", "content": "Hello"},
+        ]
+        assert _dedup_should_skip(history, "Hello") is True
+
+    def test_different_content_does_not_skip(self):
+        """Different message content → must persist."""
+        history = [
+            {"role": "user", "content": "Hello", "message_id": "m1"},
+        ]
+        assert _dedup_should_skip(history, "World", "m2") is False
+
+    def test_different_message_id_does_not_skip(self):
+        """Same content but different message_id → distinct message, persist."""
+        history = [
+            {"role": "user", "content": "Hello", "message_id": "m1"},
+        ]
+        assert _dedup_should_skip(history, "Hello", "m2") is False
+
+    def test_last_entry_is_assistant_does_not_skip(self):
+        """Last entry is assistant → different message, must persist."""
+        history = [
+            {"role": "user", "content": "Hello", "message_id": "m1"},
+            {"role": "assistant", "content": "Hi there!"},
+        ]
+        assert _dedup_should_skip(history, "Hello", "m1") is False
+
+    def test_current_no_message_id_matches_any_last_mid(self):
+        """When current message has no id, match by content only."""
+        history = [
+            {"role": "user", "content": "Hello", "message_id": "m1"},
+        ]
+        assert _dedup_should_skip(history, "Hello", None) is True
+
+    def test_last_no_message_id_current_has_id_does_not_skip(self):
+        """Last has no id, current has id → can't confirm same message."""
+        history = [
+            {"role": "user", "content": "Hello"},
+        ]
+        # content matches but _last_mid="" != _curr_mid="m1"
+        # and _curr_mid is truthy → skip condition fails
+        assert _dedup_should_skip(history, "Hello", "m1") is False
+
+    def test_three_retries_only_first_persists(self):
+        """Simulate 3 retries: first persists, 2nd and 3rd are skipped."""
+        history = []
+
+        # First attempt: history empty → persist
+        assert _dedup_should_skip(history, "Hello", "m1") is False
+        history.append({"role": "user", "content": "Hello", "message_id": "m1"})
+
+        # Second attempt: history has the message → skip
+        assert _dedup_should_skip(history, "Hello", "m1") is True
+
+        # Third attempt: still skip (history unchanged)
+        assert _dedup_should_skip(history, "Hello", "m1") is True
+
+    def test_mixed_history_only_checks_last(self):
+        """Only the LAST entry matters — earlier duplicates don't affect."""
+        history = [
+            {"role": "user", "content": "Hello", "message_id": "m1"},
+            {"role": "assistant", "content": "Hi!"},
+            {"role": "user", "content": "Hello", "message_id": "m1"},
+        ]
+        # Last entry is user with same content+id → skip
+        assert _dedup_should_skip(history, "Hello", "m1") is True


### PR DESCRIPTION
## What does this PR do?

Adds a dedup guard to prevent stacking duplicate user messages in the transcript when the gateway retries after transient provider failures (429, timeout, auth error). Without this fix, the same Telegram message gets persisted multiple times, causing the agent to fall behind by 1-2 messages.

## Related Issue

Fixes #47237

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/run.py`: Added dedup check before `append_to_transcript` in the `agent_failed_early` branch — if the last entry in `history` already matches the current user message (same content + message_id), skip the persistence.
- `tests/gateway/test_transient_failure_dedup.py`: 10 unit tests covering empty history, matching/non-matching content, message_id comparison, three-retry scenario, and mixed history edge cases.

## How to Test

1. Configure a Telegram gateway session with a provider that intermittently returns 401/auth errors
2. Send a message while the provider is failing
3. Observe that after recovery, the transcript contains the user message exactly once (not 2-3 duplicates)
4. Run `pytest tests/gateway/test_transient_failure_dedup.py -v` — all 10 tests should pass

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `gateway/run.py` `_handle_message_with_agent` (line 9200 — `agent_failed_early` branch)
- Blast radius: LOW — dedup guard is additive, only affects transient-failure persistence path
- Related patterns: #7100 (original transient-failure persistence), #9893 (context-overflow skip)
