### PR TITLE
fix(tools): add IPv4 fallback and port-465 support to standalone email send

### DIFF
--- a/plugins/platforms/email/adapter.py
+++ b/plugins/platforms/email/adapter.py
@@ -971,11 +971,33 @@ async def _standalone_send(
         msg["Subject"] = "Hermes Agent"
         msg["Date"] = formatdate(localtime=True)
 
-        server = smtplib.SMTP(smtp_host, smtp_port)
-        server.starttls(context=_ssl.create_default_context())
-        server.login(address, password)
-        server.send_message(msg)
-        server.quit()
+        ctx = _ssl.create_default_context()
+
+        def _connect(*, ipv4_only: bool = False) -> smtplib.SMTP:
+            smtp_cls = _IPv4SMTP if ipv4_only else smtplib.SMTP
+            smtp_ssl_cls = _IPv4SMTP_SSL if ipv4_only else smtplib.SMTP_SSL
+            if smtp_port == 465:
+                return smtp_ssl_cls(smtp_host, smtp_port, timeout=SMTP_CONNECT_TIMEOUT, context=ctx)
+            client = smtp_cls(smtp_host, smtp_port, timeout=SMTP_CONNECT_TIMEOUT)
+            try:
+                client.starttls(context=ctx)
+            except Exception:
+                client.close()
+                raise
+            return client
+
+        try:
+            server = _connect()
+        except (socket.timeout, TimeoutError, ConnectionError, OSError) as exc:
+            if isinstance(exc, _ssl.SSLError):
+                raise
+            server = _connect(ipv4_only=True)
+
+        try:
+            server.login(address, password)
+            server.send_message(msg)
+        finally:
+            server.quit()
         return {"success": True, "platform": "email", "chat_id": chat_id}
     except Exception as e:
         try:

--- a/tests/gateway/test_email.py
+++ b/tests/gateway/test_email.py
@@ -1482,5 +1482,92 @@ class TestConnectionConfigResolution(unittest.TestCase):
             self.assertTrue(check_email_requirements())
 
 
+class TestStandaloneSendSmtp(unittest.TestCase):
+    """Test _standalone_send() IPv4 fallback and port-465 support."""
+
+    def test_port_587_uses_starttls(self):
+        """Non-465 ports must use SMTP + STARTTLS, not SMTP_SSL."""
+        import asyncio
+        from unittest.mock import MagicMock, patch
+
+        mock_client = MagicMock()
+
+        with patch.dict(os.environ, {
+            "EMAIL_ADDRESS": "a@test.com", "EMAIL_PASSWORD": "pw",
+            "EMAIL_SMTP_HOST": "smtp.test.com", "EMAIL_SMTP_PORT": "587",
+        }):
+            with patch("smtplib.SMTP", return_value=mock_client) as mock_smtp, \
+                 patch("smtplib.SMTP_SSL") as mock_ssl:
+                from plugins.platforms.email.adapter import _standalone_send
+                pconfig = MagicMock()
+                pconfig.extra = {}
+                result = asyncio.run(_standalone_send(pconfig, "b@test.com", "hi"))
+
+        mock_smtp.assert_called_once()
+        mock_client.starttls.assert_called_once()
+        mock_ssl.assert_not_called()
+        self.assertTrue(result.get("success"))
+
+    def test_port_465_uses_smtp_ssl(self):
+        """Port 465 must use SMTP_SSL (implicit TLS), not SMTP + STARTTLS."""
+        import asyncio
+
+        mock_ssl_client = MagicMock()
+
+        with patch.dict(os.environ, {
+            "EMAIL_ADDRESS": "a@test.com", "EMAIL_PASSWORD": "pw",
+            "EMAIL_SMTP_HOST": "smtp.test.com", "EMAIL_SMTP_PORT": "465",
+        }):
+            with patch("smtplib.SMTP") as mock_smtp, \
+                 patch("smtplib.SMTP_SSL", return_value=mock_ssl_client):
+                from plugins.platforms.email.adapter import _standalone_send
+                pconfig = MagicMock()
+                pconfig.extra = {}
+                result = asyncio.run(_standalone_send(pconfig, "b@test.com", "hi"))
+
+        mock_smtp.assert_not_called()
+        self.assertTrue(result.get("success"))
+
+    def test_ipv4_fallback_on_timeout(self):
+        """Connection timeout triggers IPv4-only retry."""
+        import asyncio
+        import socket as _socket
+        from plugins.platforms.email import adapter as email_mod
+
+        mock_client = MagicMock()
+
+        with patch.dict(os.environ, {
+            "EMAIL_ADDRESS": "a@test.com", "EMAIL_PASSWORD": "pw",
+            "EMAIL_SMTP_HOST": "smtp.test.com", "EMAIL_SMTP_PORT": "587",
+        }):
+            with patch("smtplib.SMTP", side_effect=_socket.timeout("timed out")), \
+                 patch.object(email_mod, "_IPv4SMTP", return_value=mock_client):
+                pconfig = MagicMock()
+                pconfig.extra = {}
+                result = asyncio.run(email_mod._standalone_send(pconfig, "b@test.com", "hi"))
+
+        mock_client.starttls.assert_called_once()
+        self.assertTrue(result.get("success"))
+
+    def test_ssl_error_not_retried(self):
+        """TLS verification failure must not trigger IPv4 fallback."""
+        import asyncio
+        import ssl as _ssl
+        from plugins.platforms.email import adapter as email_mod
+
+        with patch.dict(os.environ, {
+            "EMAIL_ADDRESS": "a@test.com", "EMAIL_PASSWORD": "pw",
+            "EMAIL_SMTP_HOST": "smtp.test.com", "EMAIL_SMTP_PORT": "587",
+        }):
+            with patch("smtplib.SMTP", side_effect=_ssl.SSLError("cert verify")), \
+                 patch.object(email_mod, "_IPv4SMTP") as mock_ipv4:
+                pconfig = MagicMock()
+                pconfig.extra = {}
+                result = asyncio.run(email_mod._standalone_send(pconfig, "b@test.com", "hi"))
+
+        mock_ipv4.assert_not_called()
+        self.assertIn("error", result)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

- `_standalone_send` in `plugins/platforms/email/adapter.py` (the out-of-process one-shot SMTP path) still uses raw `smtplib.SMTP` + `starttls()`, ignoring port 465 (implicit TLS via `SMTP_SSL`) and lacking the IPv4 fallback that `EmailAdapter._connect_smtp` already provides for the adapter class.
- On dual-stack hosts where the IPv6 address returned by DNS is unreachable, the standalone send hangs until socket timeout. On port 465 servers (implicit TLS), the `starttls()` call fails because the server expects TLS from the start.

## Fix

Mirror the adapter's `_connect_smtp` pattern inside `_standalone_send`: port 465 uses `SMTP_SSL`, other ports use `SMTP` + `STARTTLS`, and connection-level failures (timeout, unreachable) retry through `_IPv4SMTP` / `_IPv4SMTP_SSL`. TLS verification errors are not retried.

## Validation

- `pytest tests/gateway/test_email.py -x -q` → **77 passed**
- New tests: `TestStandaloneSendSmtp` (port 587 STARTTLS, port 465 SMTP_SSL, IPv4 fallback on timeout, SSL error not retried)

## Test plan

- [x] `test_port_587_uses_starttls` — non-465 ports use SMTP + STARTTLS
- [x] `test_port_465_uses_smtp_ssl` — port 465 uses SMTP_SSL (implicit TLS)
- [x] `test_ipv4_fallback_on_timeout` — connection timeout triggers IPv4-only retry
- [x] `test_ssl_error_not_retried` — TLS verification failure does not trigger fallback