### PR TITLE
fix(cli): include TUI sessions in /resume listing

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -5792,7 +5792,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
 
             return query_session_listing(
                 self._session_db,
-                source="cli",
+                source=["cli", "tui"],
                 current_session_id=self.session_id,
                 include_all_sources=False,
                 include_unnamed=True,

--- a/hermes_cli/session_listing.py
+++ b/hermes_cli/session_listing.py
@@ -36,7 +36,7 @@ def parse_session_listing_args(raw_args: str) -> tuple[bool, bool, str]:
 def query_session_listing(
     session_db: Any,
     *,
-    source: str | None,
+    source: str | list[str] | None,
     current_session_id: str | None = None,
     include_all_sources: bool = False,
     include_unnamed: bool = False,

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -1979,7 +1979,7 @@ class SessionDB:
 
     def list_sessions_rich(
         self,
-        source: str = None,
+        source: str | list[str] | tuple[str, ...] | None = None,
         exclude_sources: List[str] = None,
         limit: int = 20,
         offset: int = 0,
@@ -2039,9 +2039,14 @@ class SessionDB:
             where_clauses.append(_LISTABLE_CHILD_SQL)
             where_clauses.append(f"{_delegate_from_json('s.model_config')} IS NULL")
 
-        if source:
-            where_clauses.append("s.source = ?")
-            params.append(source)
+        if source is not None:
+            if isinstance(source, (list, tuple)):
+                placeholders = ",".join("?" for _ in source)
+                where_clauses.append(f"s.source IN ({placeholders})")
+                params.extend(source)
+            else:
+                where_clauses.append("s.source = ?")
+                params.append(source)
         if exclude_sources:
             placeholders = ",".join("?" for _ in exclude_sources)
             where_clauses.append(f"s.source NOT IN ({placeholders})")


### PR DESCRIPTION
## What does this PR do?

Fixes `/resume` not listing desktop-app TUI sessions. The command filtered by `source="cli"`, which excluded `source="tui"` sessions created by the Electron desktop app.

## Related Issue

Closes #47214

## Changes (3 files, +11/-6)

1. **`hermes_state.py`** — `list_sessions_rich()` now accepts `source` as `str | list[str] | tuple[str, ...]`. When a list is passed, it uses a SQL `IN` clause instead of an equality filter.
2. **`cli.py`** — `_list_recent_sessions()` passes `source=["cli", "tui"]` so both local interactive session types appear in `/resume`.
3. **`hermes_cli/session_listing.py`** — Updated the `query_session_listing()` type hint for the `source` parameter.

## Testing

All 18 existing `TestListSessionsRich` tests pass. All 15 CLI resume command tests pass.