### PR TITLE
perf(agent): cache subdirectory hint mtimes to prevent redundant re-injection

### DIFF
--- a/agent/subdirectory_hints.py
+++ b/agent/subdirectory_hints.py
@@ -23,6 +23,11 @@ from agent.prompt_builder import _scan_context_content
 
 logger = logging.getLogger(__name__)
 
+# Per-session mtime cache: path → last_seen_mtime.
+# Prevents re-injection of unchanged hint files when the same
+# directory is visited multiple times in a session.
+_mtime_cache: Dict[Path, float] = {}
+
 # Context files to look for in subdirectories, in priority order.
 # Same filenames as prompt_builder.py but we load ALL found (not first-wins)
 # since different subdirectories may use different conventions.
@@ -226,6 +231,21 @@ class SubdirectoryHintTracker:
                     continue
             except OSError:
                 continue
+
+            # Skip if mtime unchanged — prevents re-injection of
+            # identical content when the same directory is visited
+            # multiple times in a session.
+            try:
+                current_mtime = hint_path.stat().st_mtime
+                cached_mtime = _mtime_cache.get(hint_path)
+                if cached_mtime is not None and current_mtime <= cached_mtime:
+                    logger.debug("Skipping unchanged hint: %s", hint_path)
+                    found_hints.append((str(hint_path), ""))
+                    break
+                _mtime_cache[hint_path] = current_mtime
+            except OSError:
+                pass  # can't stat — load anyway
+
             try:
                 content = hint_path.read_text(encoding="utf-8").strip()
                 if not content:
@@ -258,6 +278,8 @@ class SubdirectoryHintTracker:
 
         sections = []
         for rel_path, content in found_hints:
+            if not content:
+                continue  # skipped due to mtime cache
             sections.append(
                 f"[Subdirectory context discovered: {rel_path}]\n{content}"
             )


### PR DESCRIPTION
## What

Adds a per-session mtime cache to `SubdirectoryHintTracker` to prevent redundant re-injection of subdirectory context files that haven't changed.

When the same directory is visited multiple times in a session (which happens frequently due to symlink resolution differences between `/home` and `/var/home`), hint files were re-read and re-injected into the system prompt even when their content was identical. This bloated the context and destabilized prompt caching.

## Changes (22 insertions, 0 deletions)

1. **Module-level `_mtime_cache: Dict[Path, float]`** — tracks last-seen mtime per hint file
2. **Mtime check** — before reading a hint file, `stat()` it. If mtime ≤ cached value, skip with a debug log and append an empty placeholder
3. **Empty content filter** — when building context sections, skip entries with empty content (from the mtime cache skip)

Graceful fallback: if `stat()` fails (OSError), the cache is bypassed and the file is loaded normally.

## Footprint

Rung 1 of the footprint ladder — extends existing code with zero new surface. No new config keys, no new env vars, no new tools.

## Testing

- `tests/agent/test_subdirectory_hints.py` — 25/25 pass
- `tests/agent/test_prompt_builder.py` — 135/135 pass
- `tests/agent/test_context_compressor.py` — 96/96 pass
- Tested on Linux (Fedora 44)