### PR TITLE
fix: serialize gateway replace startup

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -16322,12 +16322,20 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
     # allow concurrent instances without tripping this guard.
     from gateway.status import (
         acquire_gateway_runtime_lock,
+        acquire_gateway_startup_lock,
         get_running_pid,
         get_process_start_time,
         release_gateway_runtime_lock,
+        release_gateway_startup_lock,
         remove_pid_file,
         terminate_pid,
     )
+    if not acquire_gateway_startup_lock():
+        logger.error(
+            "Another gateway startup/replacement is already in progress. Exiting."
+        )
+        return False
+
     existing_pid = get_running_pid()
     if existing_pid is not None and existing_pid != os.getpid():
         if replace:
@@ -16362,6 +16370,7 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
                     clear_takeover_marker()
                 except Exception:
                     pass
+                release_gateway_startup_lock()
                 return False
             # Wait up to 10 seconds for the old process to exit.
             # ``os.kill(pid, 0)`` on Windows is NOT a no-op — use the
@@ -16408,6 +16417,7 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
                         clear_takeover_marker()
                     except Exception:
                         pass
+                    release_gateway_startup_lock()
                     return False
             remove_pid_file()
             # remove_pid_file() is a no-op when the PID doesn't match.
@@ -16449,6 +16459,7 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
                 f"   or 'hermes gateway stop' to kill it first.\n"
                 f"   Or use 'hermes gateway run --replace' to auto-replace.\n"
             )
+            release_gateway_startup_lock()
             return False
 
     # Sync bundled skills on gateway start (fast -- skips unchanged)
@@ -16653,20 +16664,24 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
             "Another gateway instance (PID %d) started during our startup. "
             "Exiting to avoid double-running.", _current_pid
         )
+        release_gateway_startup_lock()
         return False
     if not acquire_gateway_runtime_lock():
         logger.error(
             "Gateway runtime lock is already held by another instance. Exiting."
         )
+        release_gateway_startup_lock()
         return False
     try:
         write_pid_file()
     except FileExistsError:
         release_gateway_runtime_lock()
+        release_gateway_startup_lock()
         logger.error(
             "PID file race lost to another gateway instance. Exiting."
         )
         return False
+    release_gateway_startup_lock()
     atexit.register(remove_pid_file)
     atexit.register(release_gateway_runtime_lock)
 

--- a/gateway/status.py
+++ b/gateway/status.py
@@ -34,7 +34,9 @@ _LOCKS_DIRNAME = "gateway-locks"
 _IS_WINDOWS = sys.platform == "win32"
 _UNSET = object()
 _GATEWAY_LOCK_FILENAME = "gateway.lock"
+_STARTUP_LOCK_FILENAME = "gateway-startup.lock"
 _gateway_lock_handle = None
+_startup_lock_handle = None
 # Windows byte-range locks are mandatory for other readers. Lock a byte well
 # past the JSON payload so runtime status / PID readers can still read the file
 # while another process holds the mutual-exclusion lock.
@@ -450,6 +452,47 @@ def release_gateway_runtime_lock() -> None:
     if handle is None:
         return
     _gateway_lock_handle = None
+    _release_file_lock(handle)
+    try:
+        handle.close()
+    except OSError:
+        pass
+
+
+def _get_startup_lock_path() -> Path:
+    return get_hermes_home() / _STARTUP_LOCK_FILENAME
+
+
+def acquire_gateway_startup_lock() -> bool:
+    """Serialize gateway startup and --replace handoff for one profile.
+
+    Runtime locks are held by the long-lived gateway process, so a replacer
+    cannot take that lock until the old process exits. This short-lived lock is
+    held only by CLI startup/replacement code to prevent concurrent --replace
+    launchers from all killing the same old gateway and racing to claim the PID
+    file on Windows.
+    """
+    global _startup_lock_handle
+    if _startup_lock_handle is not None:
+        return True
+
+    path = _get_startup_lock_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    handle = open(path, "a+", encoding="utf-8")
+    if not _try_acquire_file_lock(handle):
+        handle.close()
+        return False
+    _startup_lock_handle = handle
+    return True
+
+
+def release_gateway_startup_lock() -> None:
+    """Release the short-lived gateway startup lock when owned."""
+    global _startup_lock_handle
+    handle = _startup_lock_handle
+    if handle is None:
+        return
+    _startup_lock_handle = None
     _release_file_lock(handle)
     try:
         handle.close()

--- a/tests/gateway/test_gateway_startup_lock.py
+++ b/tests/gateway/test_gateway_startup_lock.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+import sys
+import types
+
+import pytest
+
+
+def _install_gateway_run_import_stubs(monkeypatch):
+    account_usage = types.ModuleType("agent.account_usage")
+    account_usage.fetch_account_usage = lambda *args, **kwargs: None
+    account_usage.render_account_usage_lines = lambda *args, **kwargs: []
+    monkeypatch.setitem(sys.modules, "agent.account_usage", account_usage)
+
+
+def test_gateway_startup_lock_is_exclusive(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    import gateway.status as status
+
+    assert status.acquire_gateway_startup_lock() is True
+    assert status.acquire_gateway_startup_lock() is True
+
+    lock_path = tmp_path / "gateway-startup.lock"
+    competing_handle = open(lock_path, "a+", encoding="utf-8")
+    try:
+        assert status._try_acquire_file_lock(competing_handle) is False
+    finally:
+        competing_handle.close()
+
+    status.release_gateway_startup_lock()
+    assert status.acquire_gateway_startup_lock() is True
+    status.release_gateway_startup_lock()
+
+
+@pytest.mark.asyncio
+async def test_start_gateway_exits_when_startup_lock_is_busy(monkeypatch):
+    _install_gateway_run_import_stubs(monkeypatch)
+    import gateway.run as run
+
+    calls: list[str] = []
+
+    monkeypatch.setattr(
+        "gateway.status.acquire_gateway_startup_lock",
+        lambda: calls.append("startup_lock") or False,
+    )
+    monkeypatch.setattr(
+        "gateway.status.acquire_gateway_runtime_lock",
+        lambda: calls.append("runtime_lock") or True,
+    )
+    monkeypatch.setattr(run, "sync_skills", lambda quiet=True: None, raising=False)
+
+    assert await run.start_gateway(replace=True) is False
+    assert calls == ["startup_lock"]
+
+
+@pytest.mark.asyncio
+async def test_start_gateway_releases_startup_lock_after_pid_claim(monkeypatch):
+    _install_gateway_run_import_stubs(monkeypatch)
+    import gateway.run as run
+
+    calls: list[str] = []
+
+    class FakeRunner:
+        should_exit_cleanly = True
+        should_exit_with_failure = False
+        exit_reason = None
+        adapters = {}
+        _signal_initiated_shutdown = False
+
+        def __init__(self, config):
+            calls.append("runner_init")
+
+        async def start(self):
+            calls.append("runner_start")
+            return True
+
+    monkeypatch.setattr("gateway.status.acquire_gateway_startup_lock", lambda: calls.append("startup_lock") or True)
+    monkeypatch.setattr("gateway.status.release_gateway_startup_lock", lambda: calls.append("release_startup"))
+    monkeypatch.setattr("gateway.status.get_running_pid", lambda: None)
+    monkeypatch.setattr("gateway.status.acquire_gateway_runtime_lock", lambda: calls.append("runtime_lock") or True)
+    monkeypatch.setattr("gateway.status.write_pid_file", lambda: calls.append("write_pid"))
+    monkeypatch.setattr(run, "GatewayRunner", FakeRunner)
+    monkeypatch.setattr(run, "sync_skills", lambda quiet=True: None, raising=False)
+    monkeypatch.setattr("hermes_logging.setup_logging", lambda **kwargs: None)
+    monkeypatch.setattr("tools.mcp_tool.discover_mcp_tools", lambda: None)
+    monkeypatch.setattr(run, "_ensure_windows_gateway_venv_imports", lambda: None)
+
+    assert await run.start_gateway(replace=True) is True
+    assert calls.index("write_pid") < calls.index("release_startup")
+    assert calls.index("release_startup") < calls.index("runner_start")
+    assert "runtime_lock" in calls


### PR DESCRIPTION
Fixes #47189

## Summary
- Add a short-lived per-profile gateway startup lock to serialize gateway run --replace handoffs.
- Release the startup lock after the replacement process claims the runtime lock and PID file.
- Add regression tests.

## Test Plan
- python -m pytest tests/hermes_cli/test_gateway.py tests/hermes_cli/test_gateway_windows.py tests/gateway/test_gateway_startup_lock.py -q -o addopts=