### PR TITLE
fix(dashboard): skip dangling symlinks in file browser instead of returning 500

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -1330,6 +1330,8 @@ def _managed_file_entry(policy: ManagedFilesPolicy, target: Path) -> Dict[str, A
     try:
         st = resolved.stat()
     except OSError as exc:
+        if target.is_symlink():
+            raise HTTPException(status_code=404, detail=f"Dangling symlink: {target.name}")
         raise HTTPException(status_code=500, detail=f"Could not stat path: {exc}")
 
     is_dir = resolved.is_dir()
@@ -1370,7 +1372,13 @@ async def list_managed_files(request: Request, path: Optional[str] = None):
         raise HTTPException(status_code=400, detail="Path is not a directory")
 
     try:
-        entries = [_managed_file_entry(policy, child) for child in target.iterdir()]
+        entries = []
+        for child in target.iterdir():
+            try:
+                entries.append(_managed_file_entry(policy, child))
+            except HTTPException:
+                # Skip entries that can't be stat'd (e.g. dangling symlinks)
+                continue
     except PermissionError:
         raise HTTPException(status_code=403, detail="Directory is not readable")
     except OSError as exc:

--- a/tests/hermes_cli/test_web_server_files.py
+++ b/tests/hermes_cli/test_web_server_files.py
@@ -331,3 +331,39 @@ def test_hosted_policy_locks_to_opt_data(monkeypatch):
 
     assert str(policy.locked_root) == "/opt/data"
     assert policy.can_change_path is False
+
+
+def test_directory_listing_skips_dangling_symlinks(forced_files_client):
+    """Dangling symlinks should be silently skipped in directory listings."""
+    client, root = forced_files_client
+    root.mkdir(parents=True, exist_ok=True)
+
+    # Create a valid file
+    valid = root / "valid.txt"
+    valid.write_text("hello")
+
+    # Create a dangling symlink
+    broken = root / "broken_link"
+    broken.symlink_to("/nonexistent/target/path")
+
+    resp = client.get("/api/files", params={"path": str(root)})
+    assert resp.status_code == 200
+    names = [e["name"] for e in resp.json()["entries"]]
+    assert "valid.txt" in names
+    assert "broken_link" not in names
+
+
+def test_direct_access_to_dangling_symlink_returns_404(forced_files_client):
+    """Accessing a dangling symlink directly should return 404, not 500."""
+    client, root = forced_files_client
+    root.mkdir(parents=True, exist_ok=True)
+
+    broken = root / "broken_link"
+    broken.symlink_to("/nonexistent/target/path")
+
+    resp = client.get(
+        "/api/files/read",
+        params={"path": str(broken)},
+    )
+    assert resp.status_code == 404
+    assert resp.status_code == 404  # exists() returns False for dangling symlinks


### PR DESCRIPTION
## What does this PR do?

Fixes the dashboard file browser returning HTTP 500 when a directory contains dangling (broken) symlinks. Broken symlinks are now silently skipped in directory listings, and direct access returns 404 instead of 500.

## Related Issue

Fixes #47154

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/web_server.py`: In `_managed_file_entry()`, added `target.is_symlink()` check on `OSError` from `resolved.stat()` — dangling symlinks now raise 404 instead of 500. In `list_managed_files()`, changed list comprehension to individual loop that catches `HTTPException` per entry, so one broken symlink doesn't crash the entire directory listing.
- `tests/hermes_cli/test_web_server_files.py`: Added `test_directory_listing_skips_dangling_symlinks` (valid file still appears, broken link skipped) and `test_direct_access_to_dangling_symlink_returns_404` (direct access returns 404).

## How to Test

1. Create a dangling symlink: `ln -s /nonexistent/target ~/broken-link`
2. Open the Hermes Dashboard file browser and navigate to the directory containing the broken symlink
3. Verify the directory listing loads successfully with the broken symlink omitted
4. Verify direct access to the symlink path returns 404

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation and Housekeeping

- [x] I've updated relevant documentation (README, docs, docstrings) — or N/A
- [x] I've updated cli-config.yaml.example if I added/changed config keys — or N/A
- [x] I've updated CONTRIBUTING.md or AGENTS.md if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

GitNexus unavailable — grep-based fallback used.
- Checked: `hermes_cli/web_server.py` — `_managed_file_entry()`, `list_managed_files()`
- Blast radius: LOW — two functions in a single file, no control flow changes elsewhere
- Related patterns: `OSError` handling in stat calls, HTTPException re-raise
