### PR TITLE
[Proposal] Add ProviderProfile.build_client — let model-provider plugins supply a custom client

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -1873,6 +1873,19 @@ def create_openai_client(agent, client_kwargs: dict, *, reason: str, shared: boo
             agent._client_log_context(),
         )
         return client
+    _cc_base = str(client_kwargs.get("base_url", "") or "")
+    try:
+        from providers import build_custom_client
+        _cc = build_custom_client(
+            base_url=_cc_base, api_key=client_kwargs.get("api_key"), async_mode=False,
+            default_headers=client_kwargs.get("default_headers"),
+            timeout=client_kwargs.get("timeout"), http_client=client_kwargs.get("http_client"),
+        )
+    except Exception:
+        _cc = None
+    if _cc is not None:
+        _ra().logger.info("Custom native client created (%s, shared=%s) %s", reason, shared, agent._client_log_context())
+        return _cc
     if agent.provider == "gemini":
         from agent.gemini_native_adapter import GeminiNativeClient, is_native_gemini_base_url
 

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -1625,6 +1625,10 @@ def _maybe_wrap_anthropic(
     # Other specialized adapters we should never re-dispatch.
     if _safe_isinstance(client_obj, CodexAuxiliaryClient):
         return client_obj
+    # `is True` on purpose: a MagicMock (or any auto-attribute object) returns
+    # a truthy stand-in for missing attributes, which must not read as native.
+    if getattr(client_obj, "_hermes_native", False) is True:
+        return client_obj
     try:
         from agent.gemini_native_adapter import GeminiNativeClient
         if _safe_isinstance(client_obj, GeminiNativeClient):
@@ -1963,6 +1967,10 @@ def _resolve_api_key_provider() -> Tuple[Optional[OpenAI], Optional[str]]:
                 continue  # skip provider if we don't know a valid aux model
             logger.debug("Auxiliary text client: %s (%s) via pool", pconfig.name, model)
             if provider_id == "gemini":
+                from providers import build_custom_client
+                _cc = build_custom_client(base_url=base_url, api_key=api_key, async_mode=False)
+                if _cc is not None:
+                    return _cc, model
                 from agent.gemini_native_adapter import GeminiNativeClient, is_native_gemini_base_url
 
                 if is_native_gemini_base_url(base_url):
@@ -2003,6 +2011,10 @@ def _resolve_api_key_provider() -> Tuple[Optional[OpenAI], Optional[str]]:
             continue  # skip provider if we don't know a valid aux model
         logger.debug("Auxiliary text client: %s (%s)", pconfig.name, model)
         if provider_id == "gemini":
+            from providers import build_custom_client
+            _cc = build_custom_client(base_url=base_url, api_key=api_key, async_mode=False)
+            if _cc is not None:
+                return _cc, model
             from agent.gemini_native_adapter import GeminiNativeClient, is_native_gemini_base_url
 
             if is_native_gemini_base_url(base_url):
@@ -4593,6 +4605,8 @@ def _to_async_client(sync_client, model: str, is_vision: bool = False):
         return AsyncAnthropicAuxiliaryClient(sync_client), model
     if isinstance(sync_client, BedrockAuxiliaryClient):
         return AsyncBedrockAuxiliaryClient(sync_client), model
+    if getattr(sync_client, "_hermes_native", False) is True and hasattr(sync_client, "as_async_client"):
+        return sync_client.as_async_client(), model
     try:
         from agent.gemini_native_adapter import GeminiNativeClient, AsyncGeminiNativeClient
 
@@ -5189,6 +5203,11 @@ def resolve_provider_client(
         default_model = _get_aux_model_for_provider(provider)
         final_model = _normalize_resolved_model(model or default_model, provider)
 
+        from providers import build_custom_client
+        _cc = build_custom_client(base_url=base_url, api_key=api_key, async_mode=async_mode)
+        if _cc is not None:
+            logger.debug("resolve_provider_client(custom native): %s", final_model)
+            return _cc, final_model
         if provider == "gemini":
             from agent.gemini_native_adapter import GeminiNativeClient, is_native_gemini_base_url
 

--- a/providers/__init__.py
+++ b/providers/__init__.py
@@ -35,6 +35,7 @@ import importlib.util
 import logging
 import sys
 from pathlib import Path
+from typing import Any
 
 from providers.base import OMIT_TEMPERATURE, ProviderProfile  # noqa: F401
 
@@ -86,6 +87,29 @@ def list_providers() -> list[ProviderProfile]:
             seen.add(pid)
             result.append(profile)
     return result
+
+
+def build_custom_client(*, base_url: str, api_key: str | None = None,
+                        async_mode: bool = False, **context: Any):
+    """Ask each registered provider profile to supply a custom client for
+    *base_url*; return the first non-None, else None (→ stock OpenAI()).
+
+    Provider-agnostic: profiles that don't own *base_url* return None. This is
+    the generic dispatch the client-construction sites call before falling back
+    to stock construction."""
+    if not _discovered:
+        _discover_providers()
+    for profile in list_providers():
+        try:
+            client = profile.build_client(
+                base_url=base_url, api_key=api_key, async_mode=async_mode, **context
+            )
+        except Exception:
+            logger.debug("build_client(%s) raised", getattr(profile, "name", "?"), exc_info=True)
+            client = None
+        if client is not None:
+            return client
+    return None
 
 
 def _user_plugins_dir() -> Path | None:

--- a/providers/base.py
+++ b/providers/base.py
@@ -108,6 +108,17 @@ class ProviderProfile:
             return urlparse(self.base_url).hostname or ""
         return ""
 
+    def build_client(self, *, base_url: str, api_key: str | None = None,
+                     async_mode: bool = False, **context: Any):
+        """Return a custom OpenAI-SDK-shaped client for *base_url*, or None to
+        use the stock OpenAI()/AsyncOpenAI() construction.
+
+        The ONE seam that lets a provider plugin own client construction — what
+        the in-tree native clients hardcode today. Default None → every existing
+        provider keeps stock construction unchanged. async_mode=True should
+        return the async client form directly."""
+        return None
+
     def prepare_messages(self, messages: list[dict[str, Any]]) -> list[dict[str, Any]]:
         """Provider-specific message preprocessing.
 

--- a/tests/providers/test_build_client_seam.py
+++ b/tests/providers/test_build_client_seam.py
@@ -1,0 +1,117 @@
+"""Tests for the ProviderProfile.build_client seam.
+
+Covers the generic, provider-agnostic client-construction hook:
+  * ProviderProfile.build_client default returns None (stock OpenAI() path).
+  * build_custom_client() asks each registered profile and returns the first
+    non-None, else None.
+  * async_mode is forwarded; the owning profile decides the client form.
+  * a profile raising in build_client is skipped, not fatal.
+
+These assert the dispatch contract only — no real network/client construction.
+"""
+
+import pytest
+
+import providers as _pkg
+from providers import build_custom_client, register_provider
+from providers.base import ProviderProfile
+
+
+_OWNED_URL = "http://owned.local/v1"
+
+
+class _DummyClient:
+    """Stand-in for a provider's custom client (e.g. a native transport)."""
+
+    _hermes_native = True
+
+    def __init__(self, base_url):
+        self.base_url = base_url
+
+    def as_async_client(self):
+        return _DummyAsyncClient(self)
+
+
+class _DummyAsyncClient:
+    _hermes_native = True
+
+    def __init__(self, sync_client):
+        self._sync = sync_client
+
+
+class _DummyProfile(ProviderProfile):
+    """Owns exactly _OWNED_URL; supplies a custom client for it, None otherwise."""
+
+    def build_client(self, *, base_url, api_key=None, async_mode=False, **context):
+        if base_url != _OWNED_URL:
+            return None
+        client = _DummyClient(base_url)
+        return client.as_async_client() if async_mode else client
+
+
+class _RaisingProfile(ProviderProfile):
+    def build_client(self, *, base_url, api_key=None, async_mode=False, **context):
+        raise RuntimeError("boom")
+
+
+@pytest.fixture
+def isolated_registry():
+    """Swap in a registry we fully control; restore the real one afterward."""
+    saved_registry = dict(_pkg._REGISTRY)
+    saved_aliases = dict(_pkg._ALIASES)
+    saved_discovered = _pkg._discovered
+    _pkg._REGISTRY.clear()
+    _pkg._ALIASES.clear()
+    _pkg._discovered = True  # skip filesystem discovery; we register by hand
+    try:
+        yield
+    finally:
+        _pkg._REGISTRY.clear()
+        _pkg._REGISTRY.update(saved_registry)
+        _pkg._ALIASES.clear()
+        _pkg._ALIASES.update(saved_aliases)
+        _pkg._discovered = saved_discovered
+
+
+class TestBuildClientHook:
+    def test_default_returns_none(self):
+        """The base hook must default to None so existing providers are unchanged."""
+        profile = ProviderProfile(name="plain")
+        assert profile.build_client(base_url="http://anything/v1") is None
+        assert profile.build_client(base_url="http://anything/v1", async_mode=True) is None
+
+
+class TestBuildCustomClientDispatch:
+    def test_routes_to_owning_profile(self, isolated_registry):
+        register_provider(_DummyProfile(name="dummy-native"))
+        client = build_custom_client(base_url=_OWNED_URL, api_key="EMPTY")
+        assert client is not None
+        assert isinstance(client, _DummyClient)
+        assert getattr(client, "_hermes_native", False) is True
+
+    def test_returns_none_for_unowned_url(self, isolated_registry):
+        register_provider(_DummyProfile(name="dummy-native"))
+        assert build_custom_client(base_url="http://somewhere-else/v1") is None
+
+    def test_returns_none_with_no_profiles(self, isolated_registry):
+        assert build_custom_client(base_url=_OWNED_URL) is None
+
+    def test_async_mode_forwarded(self, isolated_registry):
+        register_provider(_DummyProfile(name="dummy-native"))
+        client = build_custom_client(base_url=_OWNED_URL, async_mode=True)
+        assert isinstance(client, _DummyAsyncClient)
+
+    def test_first_non_none_wins(self, isolated_registry):
+        # A non-owning profile is consulted first and returns None; the owning
+        # one is reached next. Both present → the one that claims the URL wins.
+        register_provider(ProviderProfile(name="declarative-only"))  # build_client → None
+        register_provider(_DummyProfile(name="dummy-native"))
+        client = build_custom_client(base_url=_OWNED_URL)
+        assert isinstance(client, _DummyClient)
+
+    def test_raising_profile_is_skipped(self, isolated_registry):
+        # A profile that raises must not abort dispatch; a later owner still wins.
+        register_provider(_RaisingProfile(name="raises"))
+        register_provider(_DummyProfile(name="dummy-native"))
+        client = build_custom_client(base_url=_OWNED_URL)
+        assert isinstance(client, _DummyClient)


### PR DESCRIPTION
## What does this PR do?

Adds **one generic, provider-agnostic seam** so a model-provider plugin can supply its own client.

`ProviderProfile` is declarative-only today — per `providers/base.py`: *"They do NOT own client
construction, credential rotation, or streaming."* So any provider needing a **custom client** (the
in-tree Gemini native client, or an out-of-tree native transport — in my case a Gemma
`/v1/completions` client that sidesteps the streaming chat tool-parser) must be **hardcoded at every
`OpenAI(...)` construction site** (6 of them). That can't be a plugin, so it forces a source patch
re-applied on every upgrade. This PR makes that expressible as a plugin, with **zero behavior change**
for existing providers (default path is untouched).

> ### ⚠️ Status & disclosure — please read
> - **This is a proposal / not-yet-battle-tested patch, not a guaranteed fix.** It solves a real
>   problem in my live deployment and works there, but it has **not** been exercised across the full
>   provider matrix, and the API shape is a suggestion — expect to change names/signatures. I'd rather
>   you shape the API than assume this is final.
> - **🤖 AI-assisted, human-directed.** This change + description were drafted with an AI assistant
>   (Anthropic Claude) under my direction and validated by me against a live Hermes deployment. Flagging
>   it openly — not hiding it — so you review with appropriate scrutiny. Authored under my name with a
>   `Co-Authored-By` trailer for the tool, per the "credit the human, tool secondary" guidance in
>   CONTRIBUTING.md.

## Related Issue

Discussion of the API: #47291

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)
- [x] ♻️ Refactor (no behavior change) — generalizes how native clients are wired

## Changes Made

- `providers/base.py` — new hook `ProviderProfile.build_client(*, base_url, api_key=None, async_mode=False, **context) -> client | None` (default `None` → stock `OpenAI()`).
- `providers/__init__.py` — `build_custom_client(...)`: ask each registered profile, return the first non-None, else `None`.
- `agent/auxiliary_client.py` (5 sites) + `agent/agent_runtime_helpers.py` (1 site) — call `build_custom_client(...)` before stock construction; the don't-redispatch guard and the sync→async wrap recognize a custom client by a duck-typed `_hermes_native` marker + `as_async_client()`, so **core needs no provider-specific import**.
- `tests/providers/test_build_client_seam.py` — covers the dispatch contract.

## How to Test

1. `pytest tests/providers/test_build_client_seam.py -q` — default hook returns `None`; dispatch routes an owned base_url to the profile's client; unowned/no-profile → `None`; `async_mode` forwarded; a raising profile is skipped.
2. Existing provider paths are unchanged because the default `build_client` returns `None` (stock construction).
3. (Real-world) Implement a plugin profile whose `build_client` returns a custom client for its base_url; confirm it's selected for that URL and not others.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`feat(providers): …`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this feature
- [x] I've run the full suite (`scripts/run_tests.sh`, 2026-07-20, Ubuntu aarch64 / Python 3.12, on the v2026.7.20 rebase): **43,774 passed, 3 failed** — all 3 failures are environment-specific (audio detection ×2, Copilot-ACP `$HOME` test) and fail identically on clean `main` in the same environment.
- [x] I've added tests for my changes (`tests/providers/test_build_client_seam.py`)
- [x] I've tested on my platform: Ubuntu (aarch64, DGX Spark) — live Hermes deployment

### Documentation & Housekeeping

- [x] Docstrings added on the new hook + helper
- [ ] `cli-config.yaml.example` — N/A (no config keys)
- [ ] `CONTRIBUTING.md`/`AGENTS.md` — this adds a provider hook; happy to document it if you want it merged (flagging as a possible follow-up rather than claiming done)
- [x] Cross-platform — pure Python, no platform-specific code
- [ ] Tool descriptions/schemas — N/A

## Design notes

- **Why a marker instead of more hooks:** the don't-redispatch guard and the async-wrap site need to
  recognize a custom client without re-running construction. Rather than per-provider hooks, a custom
  client sets `_hermes_native = True` and exposes `as_async_client()`. Checked by value, so it's robust
  to the client module being imported under a plugin's private module name.
- **Backward compatibility:** default `build_client` → `None`; `build_custom_client` → `None` when no
  profile claims the base_url. Every existing provider hits the unchanged stock path. Additions only.
- **Suggested follow-up (separate PR):** refactor the in-tree Gemini native client to register via
  `build_client` and drop its hardcoded branches — dogfoods the seam and removes the special-casing
  this generalizes.

## Example: a provider becomes a pure plugin

```python
# $HERMES_HOME/plugins/model-providers/my-native/__init__.py
from providers import register_provider
from providers.base import ProviderProfile
from .my_adapter import MyNativeClient, owns_base_url

class MyNativeProfile(ProviderProfile):
    def build_client(self, *, base_url, api_key=None, async_mode=False, **ctx):
        if not owns_base_url(base_url):
            return None
        c = MyNativeClient(base_url=base_url, api_key=api_key)
        return c.as_async_client() if async_mode else c

register_provider(MyNativeProfile(name="my-native", api_mode="chat_completions"))
```
No core edits — drop-in, survives upgrades.

