### PR TITLE
fix(agent): skip empty partial-stream assistant turns

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -2025,15 +2025,25 @@ def run_conversation(
                             )
                         if assistant_message is not None and not _trunc_has_tool_calls:
                             length_continue_retries += 1
-                            interim_msg = agent._build_assistant_message(assistant_message, finish_reason)
-                            messages.append(interim_msg)
+                            _is_partial_stream_stub = (
+                                getattr(response, "id", "") == PARTIAL_STREAM_STUB_ID
+                            )
+                            _trunc_content_empty = not bool(
+                                getattr(assistant_message, "content", None)
+                            )
+                            # Gemini rejects history containing an assistant
+                            # turn with neither content nor tool_calls. A
+                            # partial-stream-stub can legitimately have no
+                            # recoverable visible text after a network reset;
+                            # ask for continuation without poisoning the next
+                            # request payload with an empty assistant message.
+                            if not (_is_partial_stream_stub and _trunc_content_empty):
+                                interim_msg = agent._build_assistant_message(assistant_message, finish_reason)
+                                messages.append(interim_msg)
                             if assistant_message.content:
                                 truncated_response_parts.append(assistant_message.content)
 
                             if length_continue_retries < 4:
-                                _is_partial_stream_stub = (
-                                    getattr(response, "id", "") == PARTIAL_STREAM_STUB_ID
-                                )
                                 _dropped_tools = getattr(
                                     response, "_dropped_tool_names", None
                                 )

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -493,6 +493,29 @@ _CODEX_INCOMPLETE_NUDGE = (
     "you were planning).]"
 )
 
+def _append_continuation_user_message(
+    messages: List[Dict[str, Any]],
+    content: str,
+) -> None:
+    """Coalesce a continuation prompt with an adjacent user turn."""
+    if messages and isinstance(messages[-1], dict) and messages[-1].get("role") == "user":
+        previous = messages[-1]
+        previous_content = previous.get("content")
+        if isinstance(previous_content, str):
+            previous["content"] = (
+                f"{previous_content}\n\n{content}"
+                if previous_content and content
+                else (previous_content or content)
+            )
+            return
+        if isinstance(previous_content, list):
+            previous["content"] = [
+                *previous_content,
+                {"type": "text", "text": content},
+            ]
+            return
+    messages.append({"role": "user", "content": content})
+
 
 # Shared recovery hint appended to every content-policy refusal message. Both
 # the HTTP-200 refusal path (``finish_reason=content_filter``) and the
@@ -2071,11 +2094,16 @@ def run_conversation(
                                 _continue_content = _get_continuation_prompt(
                                     _is_partial_stream_stub, _dropped_tools
                                 )
-                                continue_msg = {
-                                    "role": "user",
-                                    "content": _continue_content,
-                                }
-                                messages.append(continue_msg)
+                                if _is_partial_stream_stub and _trunc_content_empty:
+                                    _append_continuation_user_message(
+                                        messages,
+                                        _continue_content,
+                                    )
+                                else:
+                                    messages.append({
+                                        "role": "user",
+                                        "content": _continue_content,
+                                    })
                                 agent._session_messages = messages
                                 _retry.restart_with_length_continuation = True
                                 break

--- a/tests/run_agent/test_partial_stream_finish_reason.py
+++ b/tests/run_agent/test_partial_stream_finish_reason.py
@@ -410,6 +410,59 @@ class TestConversationLoopPartialStreamContinuation:
         assert msgs[-1]["role"] == "user"
         assert "network error mid-stream" in (msgs[-1].get("content") or "")
 
+    def test_empty_partial_stream_stub_coalesces_multimodal_user_continuation(
+        self,
+        loop_agent,
+    ):
+        """The retry prompt must remain in the initial multimodal user turn."""
+        from tests.run_agent.test_run_agent import _mock_response, _mock_assistant_msg
+
+        partial_stub = SimpleNamespace(
+            id=PARTIAL_STREAM_STUB_ID,
+            model="test/model",
+            choices=[SimpleNamespace(
+                index=0,
+                message=_mock_assistant_msg(content=None),
+                finish_reason=FINISH_REASON_LENGTH,
+            )],
+            usage=None,
+        )
+        continuation = _mock_response(
+            content="Recovered multimodal answer.",
+            finish_reason="stop",
+        )
+        loop_agent.client.chat.completions.create.side_effect = [
+            partial_stub,
+            continuation,
+        ]
+        multimodal_prompt = [
+            {"type": "text", "text": "Describe this image."},
+            {
+                "type": "image_url",
+                "image_url": {"url": "data:image/png;base64,YWJj"},
+            },
+        ]
+
+        with (
+            patch.object(loop_agent, "_persist_session"),
+            patch.object(loop_agent, "_save_trajectory"),
+            patch.object(loop_agent, "_cleanup_task_resources"),
+            patch.object(loop_agent, "_model_supports_vision", return_value=True),
+        ):
+            result = loop_agent.run_conversation(multimodal_prompt)
+
+        assert result["completed"] is True
+        second_call_kwargs = loop_agent.client.chat.completions.create.call_args_list[1]
+        msgs = second_call_kwargs.kwargs.get("messages") or second_call_kwargs.args[0].get("messages")
+        assert not any(
+            first.get("role") == second.get("role") == "user"
+            for first, second in zip(msgs, msgs[1:])
+        ), msgs
+        final_user = next(m for m in reversed(msgs) if m.get("role") == "user")
+        assert isinstance(final_user["content"], list)
+        assert final_user["content"][-1]["type"] == "text"
+        assert "network error mid-stream" in final_user["content"][-1]["text"]
+
 
 class TestContentFilterStallActivatesFallback:
     """Regression for #32421: a provider output-layer content safety filter

--- a/tests/run_agent/test_partial_stream_finish_reason.py
+++ b/tests/run_agent/test_partial_stream_finish_reason.py
@@ -364,6 +364,53 @@ class TestConversationLoopPartialStreamContinuation:
         assert "forty-two" in result["final_response"]
 
 
+    def test_empty_partial_stream_stub_skips_empty_assistant_turn(self, loop_agent):
+        """Gemini rejects assistant messages with neither content nor
+        tool_calls. When a network reset leaves no recoverable text, the loop
+        should request continuation without appending an empty assistant turn."""
+
+        from tests.run_agent.test_run_agent import _mock_assistant_msg, _mock_response
+
+        partial_stub = SimpleNamespace(
+            id=PARTIAL_STREAM_STUB_ID,
+            model="test/model",
+            choices=[SimpleNamespace(
+                index=0,
+                message=_mock_assistant_msg(content=None),
+                finish_reason=FINISH_REASON_LENGTH,
+            )],
+            usage=None,
+        )
+        continuation = _mock_response(
+            content="Recovered answer.", finish_reason="stop",
+        )
+
+        loop_agent.client.chat.completions.create.side_effect = [
+            partial_stub, continuation,
+        ]
+
+        with (
+            patch.object(loop_agent, "_persist_session"),
+            patch.object(loop_agent, "_save_trajectory"),
+            patch.object(loop_agent, "_cleanup_task_resources"),
+        ):
+            result = loop_agent.run_conversation("ask me something")
+
+        assert result["completed"] is True
+        assert result["final_response"] == "Recovered answer."
+
+        second_call_kwargs = loop_agent.client.chat.completions.create.call_args_list[1]
+        msgs = second_call_kwargs.kwargs.get("messages") or second_call_kwargs.args[0].get("messages")
+        assert not any(
+            m.get("role") == "assistant"
+            and not (m.get("content") or "")
+            and not m.get("tool_calls")
+            for m in msgs
+        ), msgs
+        assert msgs[-1]["role"] == "user"
+        assert "network error mid-stream" in (msgs[-1].get("content") or "")
+
+
 class TestContentFilterStallActivatesFallback:
     """Regression for #32421: a provider output-layer content safety filter
     (e.g. MiniMax ``output new_sensitive (1027)``) terminates a streaming


### PR DESCRIPTION
## What does this PR do?

Skips appending an empty assistant history turn when a `PARTIAL_STREAM_STUB_ID` has no recoverable text and no tool calls. In that case the loop still asks the model to continue from the stream interruption, but it no longer sends a synthetic assistant message with neither `content` nor `tool_calls`.

This fixes a strict Chat Completions failure observed in production with Gemini through CLIProxyAPI:

```text
tool(result) -> assistant(content="") -> user(network-error continuation)
HTTP 400 INVALID_ARGUMENT: Request contains an invalid argument.
```

The bad message is created by Hermes' partial-stream recovery path before the request reaches the proxy. A proxy-side sanitizer could mask it, but Hermes has the semantic context to avoid adding the synthetic empty assistant turn at all.

## Related Issue

No separate issue filed. This is related to, but distinct from:

- #30963
- #31998
- #31583
- #31582

Those cover partial-stream continuation and empty assistant content with `tool_calls`; this PR covers the empty partial-stream-stub case with no recoverable text and no tool calls.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/conversation_loop.py`
  - Detect empty `PARTIAL_STREAM_STUB_ID` messages before building an interim assistant history row.
  - Preserve the existing continuation prompt and retry path.
  - Leave normal output-length truncation and non-empty partial-stream stubs unchanged.
- `tests/run_agent/test_partial_stream_finish_reason.py`
  - Add a regression test proving the second request contains no empty assistant turn and still continues successfully.

## How to Test

1. Reproduce with a partial-stream-stub response whose message has `content=None`, `tool_calls=None`, and `finish_reason="length"`.
2. Verify the continuation request ends with the existing network-error user prompt.
3. Verify the continuation request does not include an assistant message with empty content and no `tool_calls`.

Commands run:

```bash
/usr/local/lib/hermes-agent/venv/bin/python -m pytest -q -o addopts='' tests/run_agent/test_partial_stream_finish_reason.py
/usr/local/lib/hermes-agent/venv/bin/python -m py_compile agent/conversation_loop.py tests/run_agent/test_partial_stream_finish_reason.py
/usr/local/lib/hermes-agent/venv/bin/python -m ruff check agent/conversation_loop.py tests/run_agent/test_partial_stream_finish_reason.py
git diff --check
```

Results:

- `10 passed`
- `All checks passed!`
- `git diff --check` clean

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu 24.04

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Observed production failure shape, redacted:

```json
[
  {"role": "tool", "content": "..."},
  {"role": "assistant", "content": ""},
  {
    "role": "user",
    "content": "[System: The previous response was cut off by a network error mid-stream. Continue exactly where you left off. Do not restart or repeat prior text. Finish the answer directly.]"
  }
]
```

The upstream returned:

```json
{"error":{"code":400,"message":"Request contains an invalid argument.","status":"INVALID_ARGUMENT"}}
```
