### PR TITLE
fix(clarify): put options in choices[] only, never enumerate in question text

### DIFF
--- a/tools/clarify_tool.py
+++ b/tools/clarify_tool.py
@@ -93,6 +93,12 @@ CLARIFY_SCHEMA = {
         "or types their own answer via a 5th 'Other' option.\n"
         "2. **Open-ended** — omit choices entirely. The user types a free-form "
         "response.\n\n"
+        "CRITICAL: when you are offering options, put each option ONLY in the "
+        "`choices` array — NEVER enumerate the options inside the `question` "
+        "text. The UI renders `choices` as selectable rows; options written "
+        "into the question string render as dead prose the user can't pick. "
+        "Right: question='Which deployment target?', choices=['staging', "
+        "'prod']. Wrong: question='Which target? 1) staging 2) prod', choices=[].\n\n"
         "Use this tool when:\n"
         "- The task is ambiguous and you need the user to choose an approach\n"
         "- You want post-task feedback ('How did that work out?')\n"
@@ -107,16 +113,22 @@ CLARIFY_SCHEMA = {
         "properties": {
             "question": {
                 "type": "string",
-                "description": "The question to present to the user.",
+                "description": (
+                    "The question itself, and ONLY the question (e.g. 'Which "
+                    "deployment target?'). Do NOT embed the answer options here "
+                    "— pass them as separate elements in `choices`."
+                ),
             },
             "choices": {
                 "type": "array",
                 "items": {"type": "string"},
                 "maxItems": MAX_CHOICES,
                 "description": (
-                    "Up to 4 answer choices. Omit this parameter entirely to "
-                    "ask an open-ended question. When provided, the UI "
-                    "automatically appends an 'Other (type your answer)' option."
+                    "REQUIRED whenever you are presenting selectable options: "
+                    "each distinct option is its own array element (up to 4). "
+                    "The UI renders these as pickable rows and auto-appends an "
+                    "'Other (type your answer)' option. Omit this parameter "
+                    "entirely ONLY for a genuinely open-ended free-text question."
                 ),
             },
         },


### PR DESCRIPTION

Tiny carve-out — docstring / schema-description only, no code change. Applies to
every interface, not just OpenTUI.

### What it does
Updates the `clarify` tool's description so the model puts selectable options in the
`choices[]` array (rendered as pickable rows) instead of enumerating them inside the
`question` string (where they render as dead prose the user can't pick).

### Commit
- `16e408f3` fix(clarify): docstring — put options in choices[] only, never enumerate in question text

File: `tools/clarify_tool.py` (every changed line is inside a `"description"` string).

Carve-out branch built + saved as patch: `fix/clarify-choices-docstring`
(cherry-picked clean off main, py-compile OK).

Parent: #TRACKER


Closes #47285 · part of #47281
