### PR TITLE
fix(cli): end session in state.db on atexit cleanup

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -1068,6 +1068,24 @@ def _run_cleanup(*, notify_session_finalize: bool = True):
     # leaving a zombie CLI holding the terminal for minutes.
     _arm_exit_watchdog()
 
+    # Persist the session boundary before any best-effort teardown that can
+    # block on a subprocess, network client, or browser.  If the watchdog
+    # later force-exits a wedged cleanup, state.db must not retain a zombie
+    # session.  SessionDB keeps the first end reason, so normal close paths
+    # remain idempotent and retain their more specific reason.
+    try:
+        if _active_agent_ref and getattr(_active_agent_ref, "session_id", None):
+            session_db = getattr(_active_agent_ref, "_session_db", None)
+            if session_db is not None:
+                session_db.end_session(_active_agent_ref.session_id, "shutdown")
+    except Exception:
+        logger.debug(
+            "CLI cleanup end_session failed for session %s",
+            getattr(_active_agent_ref, "session_id", "<unknown>")
+            if _active_agent_ref else "<no-agent>",
+            exc_info=True,
+        )
+
     # Reset terminal input modes first, before the slower resource teardown
     # below (MCP / browser / memory shutdown can take seconds). On Ctrl+C the
     # user's terminal becomes usable immediately, and a later step raising

--- a/tests/cli/test_single_query_session_finalize.py
+++ b/tests/cli/test_single_query_session_finalize.py
@@ -1,8 +1,16 @@
+import os
+from pathlib import Path
+from tempfile import gettempdir
 from types import SimpleNamespace
 
 import pytest
 
+# The hermetic runner clears Windows home variables before this module imports
+# cli.py.  Supply a disposable platform default until pytest isolates HERMES_HOME.
+os.environ.setdefault("LOCALAPPDATA", str(Path(gettempdir()) / "hermes-test-localappdata"))
+
 import cli
+from hermes_state import SessionDB
 
 
 @pytest.fixture(autouse=True)
@@ -114,7 +122,12 @@ def test_finalize_single_query_signal_window_does_not_reemit_during_atexit(monke
     monkeypatch.setattr(cli, "_run_cleanup", original_run_cleanup)
     monkeypatch.setattr(cli, "_active_agent_ref", None)
     monkeypatch.setattr(cli, "_reset_terminal_input_modes_on_exit", lambda: None)
-    monkeypatch.setattr(cli, "_cleanup_all_terminals", lambda: None)
+    def assert_session_was_finalized_before_teardown():
+        session = db.get_session(session_id)
+        assert session["ended_at"] is not None
+        assert session["end_reason"] == "shutdown"
+
+    monkeypatch.setattr(cli, "_cleanup_all_terminals", assert_session_was_finalized_before_teardown)
     monkeypatch.setattr(cli, "_cleanup_all_browsers", lambda: None)
     monkeypatch.setattr("tools.mcp_tool.shutdown_mcp_servers", lambda: None)
     monkeypatch.setattr("agent.auxiliary_client.shutdown_cached_clients", lambda: None)
@@ -122,6 +135,38 @@ def test_finalize_single_query_signal_window_does_not_reemit_during_atexit(monke
     cli._run_cleanup()
 
     assert calls == [expected_finalize, ("release", {})]
+
+
+def test_run_cleanup_finalizes_real_state_db_session(monkeypatch, tmp_path):
+    """Cleanup persists the shutdown result in the session database."""
+    db_path = tmp_path / "state.db"
+    session_id = "one-shot-session"
+    db = SessionDB(db_path=db_path)
+    db.create_session(session_id, "cli")
+
+    monkeypatch.setattr(
+        cli,
+        "_active_agent_ref",
+        SimpleNamespace(session_id=session_id, _session_db=db),
+    )
+    monkeypatch.setattr(cli, "_arm_exit_watchdog", lambda **_kwargs: None)
+    monkeypatch.setattr(cli, "_reset_terminal_input_modes_on_exit", lambda: None)
+    monkeypatch.setattr(cli, "_cleanup_all_terminals", lambda: None)
+    monkeypatch.setattr(cli, "_cleanup_all_browsers", lambda: None)
+    monkeypatch.setattr("tools.async_delegation.interrupt_all", lambda **_kwargs: None)
+    monkeypatch.setattr("tools.mcp_tool.shutdown_mcp_servers", lambda: None)
+    monkeypatch.setattr("agent.auxiliary_client.shutdown_cached_clients", lambda: None)
+
+    cli._run_cleanup(notify_session_finalize=False)
+    db.close()
+
+    reopened = SessionDB(db_path=db_path)
+    try:
+        session = reopened.get_session(session_id)
+        assert session["ended_at"] is not None
+        assert session["end_reason"] == "shutdown"
+    finally:
+        reopened.close()
 
 
 def test_notify_single_query_session_finalize_uses_agent_session(monkeypatch):


### PR DESCRIPTION
Closes #47277 (CLI/TUI portion).

## Problem
Sessions created by the CLI/TUI were never marked as ended when the process exited via atexit (Ctrl+C, SIGTERM, SIGHUP). Only the clean /exit path at cli.py:13326 called end_session(). This caused zombie session accumulation — 12 out of 13 sessions in a real database had ended_at=NULL.

## Fix
Add an end_session('shutdown') call inside `_run_cleanup()`, the centralized atexit-registered cleanup function that fires on every exit path including signal handlers. The call is idempotent: end_session() only updates rows where ended_at IS NULL.

## Note
This is a partial fix for #47277 — it only addresses the CLI/TUI path. The WebUI PTY disconnect and Electron before-quit paths require separate changes (different code paths, different lifecycle).