### PR TITLE
Scope Responses API conversation names by session key

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -1293,6 +1293,24 @@ class APIServerAdapter(BasePlatformAdapter):
 
         return raw, None
 
+    @staticmethod
+    def _conversation_store_key(
+        conversation: Optional[str],
+        gateway_session_key: Optional[str],
+    ) -> Optional[str]:
+        """Return the storage key for a conversation name.
+
+        Conversation names stay global for callers without a session key.
+        When a session key is present, scope the conversation name to that
+        key so another client can't reuse the same name to chain into a
+        different client's history.
+        """
+        if not conversation:
+            return None
+        if not gateway_session_key:
+            return conversation
+        return f"{gateway_session_key}\x1f{conversation}"
+
     # ------------------------------------------------------------------
     # Session DB helper
     # ------------------------------------------------------------------
@@ -2884,7 +2902,10 @@ class APIServerAdapter(BasePlatformAdapter):
                 "session_id": session_id,
             })
             if conversation:
-                self._response_store.set_conversation(conversation, response_id)
+                self._response_store.set_conversation(
+                    self._conversation_store_key(conversation, gateway_session_key),
+                    response_id,
+                )
 
         def _persist_incomplete_if_needed() -> None:
             """Persist an ``incomplete`` snapshot if no terminal one was written.
@@ -3391,7 +3412,9 @@ class APIServerAdapter(BasePlatformAdapter):
 
         # Resolve conversation name to latest response_id
         if conversation:
-            previous_response_id = self._response_store.get_conversation(conversation)
+            previous_response_id = self._response_store.get_conversation(
+                self._conversation_store_key(conversation, gateway_session_key)
+            )
             # No error if conversation doesn't exist yet — it's a new conversation
 
         # Normalize input to message list
@@ -3634,7 +3657,10 @@ class APIServerAdapter(BasePlatformAdapter):
             # Update conversation mapping so the next request with the same
             # conversation name automatically chains to this response
             if conversation:
-                self._response_store.set_conversation(conversation, response_id)
+                self._response_store.set_conversation(
+                    self._conversation_store_key(conversation, gateway_session_key),
+                    response_id,
+                )
 
         response_headers = {"X-Hermes-Session-Id": session_id}
         if gateway_session_key:

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -3497,6 +3497,46 @@ class TestConversationParameter:
                 assert adapter._response_store.get_conversation("conv-a") != adapter._response_store.get_conversation("conv-b")
 
     @pytest.mark.asyncio
+    async def test_conversation_names_are_scoped_by_session_key(self, auth_adapter):
+        """The same conversation name should not chain across different session keys."""
+        app = _create_app(auth_adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(auth_adapter, "_run_agent", new_callable=AsyncMock) as mock_run:
+                mock_run.return_value = (
+                    {"final_response": "Key A first", "messages": [], "api_calls": 1},
+                    {"input_tokens": 10, "output_tokens": 5, "total_tokens": 15},
+                )
+                await cli.post(
+                    "/v1/responses",
+                    headers={
+                        "Authorization": "Bearer sk-secret",
+                        "X-Hermes-Session-Key": "channel-a",
+                    },
+                    json={"input": "hello", "conversation": "shared-room"},
+                )
+
+                mock_run.return_value = (
+                    {"final_response": "Key B first", "messages": [], "api_calls": 1},
+                    {"input_tokens": 10, "output_tokens": 5, "total_tokens": 15},
+                )
+                await cli.post(
+                    "/v1/responses",
+                    headers={
+                        "Authorization": "Bearer sk-secret",
+                        "X-Hermes-Session-Key": "channel-b",
+                    },
+                    json={"input": "hello", "conversation": "shared-room"},
+                )
+
+                assert mock_run.call_count == 2
+                second_call = mock_run.call_args_list[1]
+                history = second_call.kwargs.get(
+                    "conversation_history",
+                    second_call[1].get("conversation_history", []) if len(second_call) > 1 else [],
+                )
+                assert history == []
+
+    @pytest.mark.asyncio
     async def test_conversation_store_false_no_mapping(self, adapter):
         """If store=false, conversation mapping is not updated."""
         app = _create_app(adapter)


### PR DESCRIPTION
## Summary

This scopes Responses API `conversation` chaining to `X-Hermes-Session-Key` when the header is present. Previously, conversation names were global, so two different clients using the same conversation name could chain into each other's stored response history.

## Why

`X-Hermes-Session-Key` is the long-term memory boundary. If two clients use the same conversation name under different keys, the server should keep those chains isolated instead of reusing the latest response ID from another key.

## Changes

- Namespace the stored conversation lookup key with the active session key when present.
- Preserve the existing global behavior for callers that do not send a session key.
- Add a regression test proving the same conversation name stays isolated across two different session keys.

## Tests

```text
python -m pytest tests/gateway/test_api_server.py -k "conversation_names_are_scoped_by_session_key or separate_conversations_are_isolated or conversation_chains_automatically" -q
3 passed, 155 deselected, 3 warnings in 2.49s
```
