### PR TITLE
docs(agents): clarify background delegation durability

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -954,9 +954,10 @@ Enable/disable per platform via `hermes tools` (the curses UI) or the
 ## Delegation (`delegate_task`)
 
 `tools/delegate_tool.py` spawns a subagent with an isolated
-context + terminal session. Synchronous: the parent waits for the
-child's summary before continuing its own loop — if the parent is
-interrupted, the child is cancelled.
+context + terminal session. By default the parent waits for the
+child's summary before continuing its own loop. With `background=true`,
+Hermes returns a delegation id immediately and the result re-enters the
+conversation later through the async-delegation completion queue.
 
 Two shapes:
 
@@ -978,9 +979,9 @@ Key config knobs (under `delegation:` in `config.yaml`):
 `orchestrator_enabled`, `subagent_auto_approve`, `inherit_mcp_toolsets`,
 `max_iterations`.
 
-Synchronicity rule: delegate_task is **not** durable. For long-running
-work that must outlive the current turn, use `cronjob` or
-`terminal(background=True, notify_on_complete=True)` instead.
+Durability rule: background `delegate_task` is detached from the current
+turn but still process-local. For work that must survive process restart, use
+`cronjob` or `terminal(background=True, notify_on_complete=True)` instead.
 
 ---
 


### PR DESCRIPTION
## Summary

Clarifies the `delegate_task` guidance in `AGENTS.md` so it matches the behavior Hermes already has today:

- default `delegate_task` waits for the child summary before the parent continues
- `background=true` returns a delegation id immediately and completes later through the async-delegation completion queue
- background delegation is detached from the current turn but remains process-local, so restart-durable work should still use `cronjob` or `terminal(background=True, notify_on_complete=True)`

## Validation

- Reviewed the existing `tools/delegate_tool.py` background path that removes the child from the parent turn and hands it to async delegation.
- No automated tests run; this is an `AGENTS.md` documentation-only change.
