### PR TITLE
Keep dashboard chat alive across reconnects

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -10110,6 +10110,29 @@ else:
 _RESIZE_RE = re.compile(rb"\x1b\[RESIZE:(\d+);(\d+)\]")
 _PTY_READ_CHUNK_TIMEOUT = 0.2
 _VALID_CHANNEL_RE = re.compile(r"^[A-Za-z0-9._-]{1,128}$")
+
+# -- Reconnectable PTY bridge pool ------------------------------------------
+#
+# When the browser WebSocket drops (lid close, network blip, sleep/wake),
+# we keep the PTY child (hermes --tui) alive so a reconnect within the
+# grace window picks up where it left off.  Entries are keyed by the
+# channel id from the query string and auto-evicted after a timeout.
+
+@dataclass
+class _ReconnectableBridge:
+    bridge: Any
+    timer: Any
+
+
+_reconnectable_bridges: dict[str, _ReconnectableBridge] = {}
+_reconnectable_bridges_lock = threading.Lock()
+_BRIDGE_RECONNECT_TIMEOUT_S = 3600
+
+# 1005 means the peer supplied no close status; 1006 is an abnormal closure.
+# Both can represent a sleeping browser. Intentional browser teardown sends
+# 1000 explicitly and closes the child immediately.
+_WS_KEEP_BRIDGE_CODES = frozenset({1005, 1006})
+
 # Starlette's TestClient reports the peer as "testclient"; treat it as
 # loopback so tests don't need to rewrite request scope.
 _LOOPBACK_HOSTS = frozenset({"127.0.0.1", "::1", "localhost", "testclient"})
@@ -10503,6 +10526,53 @@ async def _broadcast_event(app: Any, channel: str, payload: str) -> None:
             _log.warning("broadcast send failed for subscriber on %s", channel, exc_info=True)
 
 
+def _expire_reconnectable_bridge(channel: str, expected_bridge: Any) -> None:
+    """Close a parked bridge only if it is still this channel's entry."""
+    with _reconnectable_bridges_lock:
+        entry = _reconnectable_bridges.get(channel)
+        if entry is None or entry.bridge is not expected_bridge:
+            return
+        _reconnectable_bridges.pop(channel, None)
+
+    expected_bridge.close()
+
+
+def _park_reconnectable_bridge(channel: str, bridge: Any) -> None:
+    """Park ``bridge`` for a later browser reconnect."""
+    timer = threading.Timer(
+        _BRIDGE_RECONNECT_TIMEOUT_S,
+        _expire_reconnectable_bridge,
+        args=[channel, bridge],
+    )
+    timer.daemon = True
+    entry = _ReconnectableBridge(bridge=bridge, timer=timer)
+
+    with _reconnectable_bridges_lock:
+        previous = _reconnectable_bridges.get(channel)
+        _reconnectable_bridges[channel] = entry
+
+    if previous is not None:
+        previous.timer.cancel()
+        previous.bridge.close()
+    timer.start()
+
+
+def _take_reconnectable_bridge(channel: str) -> Any | None:
+    """Return the channel's live parked bridge, if one remains."""
+    with _reconnectable_bridges_lock:
+        entry = _reconnectable_bridges.pop(channel, None)
+
+    if entry is None:
+        return None
+
+    entry.timer.cancel()
+    if entry.bridge.is_alive():
+        return entry.bridge
+
+    entry.bridge.close()
+    return None
+
+
 def _channel_or_close_code(ws: WebSocket) -> Optional[str]:
     """Return the channel id from the query string or None if invalid."""
     channel = ws.query_params.get("channel", "")
@@ -10575,38 +10645,55 @@ async def pty_ws(ws: WebSocket) -> None:
         await ws.close(code=1011)
         return
 
-    # --- spawn PTY ------------------------------------------------------
+    # --- spawn or reclaim PTY -------------------------------------------
     resume = ws.query_params.get("resume") or None
     profile = ws.query_params.get("profile") or None
     channel = _channel_or_close_code(ws)
     sidecar_url = _build_sidecar_url(channel) if channel else None
 
-    try:
-        argv, cwd, env = _resolve_chat_argv(
-            resume=resume, sidecar_url=sidecar_url, profile=profile
-        )
-    except HTTPException as exc:
-        # Unknown/invalid profile from _resolve_profile_dir.
-        await ws.send_text(f"\r\n\x1b[31mChat unavailable: {exc.detail}\x1b[0m\r\n")
-        await ws.close(code=1011)
-        return
-    except SystemExit as exc:
-        # _make_tui_argv calls sys.exit(1) when node/npm is missing.
-        await ws.send_text(f"\r\n\x1b[31mChat unavailable: {exc}\x1b[0m\r\n")
-        await ws.close(code=1011)
-        return
+    bridge: PtyBridge | None = None
 
+    # If this channel has a live bridge from a previous WS session,
+    # reclaim it instead of spawning a new TUI child.  This lets the
+    # browser reconnect after a lid-close or network blip without
+    # losing the running agent session.
+    if channel:
+        bridge = _take_reconnectable_bridge(channel)
+        if bridge is not None:
+            _log.info(
+                "pty reclaimed bridge channel=%s peer=%s",
+                channel,
+                peer,
+            )
 
-    try:
-        bridge = PtyBridge.spawn(argv, cwd=cwd, env=env)
-    except PtyUnavailableError as exc:
-        await ws.send_text(f"\r\n\x1b[31mChat unavailable: {exc}\x1b[0m\r\n")
-        await ws.close(code=1011)
-        return
-    except (FileNotFoundError, OSError) as exc:
-        await ws.send_text(f"\r\n\x1b[31mChat failed to start: {exc}\x1b[0m\r\n")
-        await ws.close(code=1011)
-        return
+    if bridge is None:
+        try:
+            argv, cwd, env = _resolve_chat_argv(
+                resume=resume, sidecar_url=sidecar_url, profile=profile
+            )
+        except HTTPException as exc:
+            # Unknown/invalid profile from _resolve_profile_dir.
+            await ws.send_text(f"\r\n\x1b[31mChat unavailable: {exc.detail}\x1b[0m\r\n")
+            await ws.close(code=1011)
+            return
+        except SystemExit as exc:
+            # _make_tui_argv calls sys.exit(1) when node/npm is missing.
+            await ws.send_text(f"\r\n\x1b[31mChat unavailable: {exc}\x1b[0m\r\n")
+            await ws.close(code=1011)
+            return
+
+        try:
+            bridge = PtyBridge.spawn(argv, cwd=cwd, env=env)
+        except PtyUnavailableError as exc:
+            await ws.send_text(f"\r\n\x1b[31mChat unavailable: {exc}\x1b[0m\r\n")
+            await ws.close(code=1011)
+            return
+        except (FileNotFoundError, OSError) as exc:
+            await ws.send_text(f"\r\n\x1b[31mChat failed to start: {exc}\x1b[0m\r\n")
+            await ws.close(code=1011)
+            return
+
+    assert bridge is not None
 
     loop = asyncio.get_running_loop()
 
@@ -10629,11 +10716,13 @@ async def pty_ws(ws: WebSocket) -> None:
     reader_task = asyncio.create_task(pump_pty_to_ws())
 
     # --- writer loop: WebSocket → PTY master ----------------------------
+    close_code: int | None = None
     try:
         while True:
             msg = await ws.receive()
             msg_type = msg.get("type")
             if msg_type == "websocket.disconnect":
+                close_code = msg.get("code", 1005)
                 break
             raw = msg.get("bytes")
             if raw is None:
@@ -10651,15 +10740,28 @@ async def pty_ws(ws: WebSocket) -> None:
                 continue
 
             bridge.write(raw)
-    except WebSocketDisconnect:
-        pass
+    except WebSocketDisconnect as exc:
+        close_code = getattr(exc, "code", 1005)
     finally:
         reader_task.cancel()
         try:
             await reader_task
         except (asyncio.CancelledError, Exception):
             pass
-        bridge.close()
+
+        # On abnormal WS closure (network drop, lid close, sleep) keep
+        # the PTY child alive in the reconnect pool so a new browser WS
+        # within the grace window reclaims it.  Normal close (user closed
+        # tab) and auth/refusal codes tear down immediately.
+        if channel and close_code in _WS_KEEP_BRIDGE_CODES:
+            _log.info(
+                "pty keeping bridge alive for reconnect channel=%s "
+                "close_code=%s timeout=%ss",
+                channel, close_code, _BRIDGE_RECONNECT_TIMEOUT_S,
+            )
+            _park_reconnectable_bridge(channel, bridge)
+        else:
+            bridge.close()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -4849,6 +4849,93 @@ skip_on_windows = pytest.mark.skipif(
 )
 
 
+class _FakeReconnectBridge:
+    def __init__(self, *, alive=True):
+        self.alive = alive
+        self.closed = False
+
+    def is_alive(self):
+        return self.alive
+
+    def close(self):
+        self.closed = True
+
+
+class _FakeReconnectTimer:
+    def __init__(self, interval, callback, args):
+        self.interval = interval
+        self.callback = callback
+        self.args = args
+        self.cancelled = False
+
+    def start(self):
+        return None
+
+    def cancel(self):
+        self.cancelled = True
+
+    def fire(self):
+        self.callback(*self.args)
+
+
+@skip_on_windows
+class TestReconnectablePtyBridgePool:
+    @pytest.fixture(autouse=True)
+    def _reset_pool(self, monkeypatch):
+        import hermes_cli.web_server as ws
+
+        self.ws = ws
+        self.timers = []
+
+        def fake_timer(interval, callback, args):
+            timer = _FakeReconnectTimer(interval, callback, args)
+            self.timers.append(timer)
+            return timer
+
+        monkeypatch.setattr(ws.threading, "Timer", fake_timer)
+        with ws._reconnectable_bridges_lock:
+            ws._reconnectable_bridges.clear()
+        yield
+        with ws._reconnectable_bridges_lock:
+            entries = list(ws._reconnectable_bridges.values())
+            ws._reconnectable_bridges.clear()
+        for entry in entries:
+            entry.timer.cancel()
+            entry.bridge.close()
+
+    def test_reclaims_live_bridge_and_cancels_expiry(self):
+        bridge = _FakeReconnectBridge()
+
+        self.ws._park_reconnectable_bridge("channel-1", bridge)
+        timer = self.ws._reconnectable_bridges["channel-1"].timer
+
+        assert self.ws._take_reconnectable_bridge("channel-1") is bridge
+        assert timer.cancelled is True
+        assert bridge.closed is False
+        assert "channel-1" not in self.ws._reconnectable_bridges
+
+    def test_dead_bridge_is_closed_instead_of_reclaimed(self):
+        bridge = _FakeReconnectBridge(alive=False)
+
+        self.ws._park_reconnectable_bridge("channel-2", bridge)
+
+        assert self.ws._take_reconnectable_bridge("channel-2") is None
+        assert bridge.closed is True
+
+    def test_stale_expiry_cannot_close_replacement_bridge(self):
+        first = _FakeReconnectBridge()
+        replacement = _FakeReconnectBridge()
+
+        self.ws._park_reconnectable_bridge("channel-3", first)
+        stale_timer = self.timers[-1]
+        self.ws._park_reconnectable_bridge("channel-3", replacement)
+        stale_timer.fire()
+
+        assert first.closed is True
+        assert replacement.closed is False
+        assert self.ws._take_reconnectable_bridge("channel-3") is replacement
+
+
 @skip_on_windows
 class TestPtyWebSocket:
     @pytest.fixture(autouse=True)
@@ -5005,6 +5092,41 @@ class TestPtyWebSocket:
                 if b"round-trip-payload" in buf:
                     break
             assert b"round-trip-payload" in buf
+
+    def test_abnormal_disconnect_reclaims_same_pty(self, monkeypatch):
+        monkeypatch.setattr(
+            self.ws_module,
+            "_resolve_chat_argv",
+            lambda resume=None, sidecar_url=None, profile=None: (["/bin/cat"], None, None),
+        )
+        real_spawn = self.ws_module.PtyBridge.spawn
+        spawned = []
+
+        def tracking_spawn(cls, *args, **kwargs):
+            bridge = real_spawn(*args, **kwargs)
+            spawned.append(bridge)
+            return bridge
+
+        monkeypatch.setattr(
+            self.ws_module.PtyBridge,
+            "spawn",
+            classmethod(tracking_spawn),
+        )
+
+        url = self._url(channel="sleep-wake-channel")
+        with self.client.websocket_connect(url) as conn:
+            conn.send_bytes(b"before-sleep\n")
+            assert b"before-sleep" in conn.receive_bytes()
+            conn.close(code=1006)
+
+        assert "sleep-wake-channel" in self.ws_module._reconnectable_bridges
+
+        with self.client.websocket_connect(url) as conn:
+            conn.send_bytes(b"after-wake\n")
+            assert b"after-wake" in conn.receive_bytes()
+
+        assert len(spawned) == 1
+        assert "sleep-wake-channel" not in self.ws_module._reconnectable_bridges
 
     def test_resize_escape_is_forwarded(self, monkeypatch):
         # Resize escape gets intercepted and applied via TIOCSWINSZ, then the

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -152,13 +152,14 @@ _SLASH_WORKER_TIMEOUT_S = max(5.0, _slash_timeout)
 # lingers forever — one leaked python process per refresh (#38591 fallout).
 # After this grace window, an orphaned (transport-detached, not-running) WS
 # session is reaped: its _SlashWorker is closed and the session finalized.
-# Set to 0 to disable (park forever, pre-fix behaviour).
+# Set to 0 to disable (park forever).  Default bumped to 3600s (1h)
+# so laptop sleep/wake doesn't orphan a session.
 try:
     _ws_orphan_reap_grace = float(
-        os.environ.get("HERMES_TUI_WS_ORPHAN_REAP_GRACE_S") or "20"
+        os.environ.get("HERMES_TUI_WS_ORPHAN_REAP_GRACE_S") or "3600"
     )
 except (ValueError, TypeError):
-    _ws_orphan_reap_grace = 20.0
+    _ws_orphan_reap_grace = 3600.0
 _WS_ORPHAN_REAP_GRACE_S = max(0.0, _ws_orphan_reap_grace)
 _DETAIL_SECTION_NAMES = ("thinking", "tools", "subagents", "activity")
 _DETAIL_MODES = frozenset({"hidden", "collapsed", "expanded"})

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -583,81 +583,139 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
     let unmounting = false;
     let onDataDisposable: { dispose(): void } | null = null;
     let onResizeDisposable: { dispose(): void } | null = null;
+    let reconnectAttempts = 0;
+    let reconnectTimer: number | null = null;
+    let hasConnected = false;
     void (async () => {
-      const authParam = await buildWsAuthParam();
-      if (unmounting) return;
-      const url = buildWsUrl(authParam, resumeParam, channel, scopedProfile);
-      const ws = new WebSocket(url);
-      ws.binaryType = "arraybuffer";
-      wsRef.current = ws;
+      const maxReconnectAttempts = 20;
+      const reconnectBaseDelayMs = 1000;
+      const reconnectMaxDelayMs = 30000;
 
-    ws.onopen = () => {
-      setBanner(null);
-      // Send the initial RESIZE immediately so Ink has *a* size to lay
-      // out against on its first paint.  The double-rAF block above will
-      // follow up with the authoritative measurement — at worst Ink
-      // reflows once after the PTY boots, which is imperceptible.
-      ws.send(`\x1b[RESIZE:${term.cols};${term.rows}]`);
-    };
+      function scheduleReconnect(termRef_: Terminal, closeCode: number): void {
+        if (unmounting || reconnectTimer !== null) return;
+        if (reconnectAttempts >= maxReconnectAttempts) {
+          termRef_.write(
+            `\r\n\x1b[90m[session ended (code ${closeCode}) — max reconnection attempts reached]\x1b[0m\r\n`,
+          );
+          return;
+        }
 
-    ws.onmessage = (ev) => {
-      if (typeof ev.data === "string") {
-        term.write(ev.data);
-      } else {
-        term.write(new Uint8Array(ev.data as ArrayBuffer));
+        const attemptIndex = reconnectAttempts;
+        reconnectAttempts += 1;
+        const delay = Math.min(
+          reconnectBaseDelayMs * Math.pow(2, attemptIndex),
+          reconnectMaxDelayMs,
+        );
+        const jitteredDelay = delay * (0.8 + Math.random() * 0.4);
+        const delaySeconds = Math.max(1, Math.round(jitteredDelay / 1000));
+        termRef_.write(
+          `\r\n\x1b[90m[connection lost, reconnecting in ${delaySeconds}s (attempt ${reconnectAttempts}/${maxReconnectAttempts})]\x1b[0m\r\n`,
+        );
+        reconnectTimer = window.setTimeout(() => {
+          reconnectTimer = null;
+          void connectWs(termRef_);
+        }, jitteredDelay);
       }
-    };
 
-    ws.onclose = (ev) => {
-      wsRef.current = null;
-      if (unmounting) {
-        return;
+      async function connectWs(termRef_: Terminal): Promise<void> {
+        try {
+          const authParam = await buildWsAuthParam();
+          if (unmounting) return;
+          const url = buildWsUrl(authParam, resumeParam, channel, scopedProfile);
+          const newWs = new WebSocket(url);
+          newWs.binaryType = "arraybuffer";
+          wsRef.current = newWs;
+          wireWsHandlers(newWs, termRef_);
+        } catch (error) {
+          if (unmounting) return;
+          console.warn("[chat] PTY WebSocket connection attempt failed", error);
+          scheduleReconnect(termRef_, 1006);
+        }
       }
-      // Surface the real cause to the browser console on every close so a
-      // "chat won't connect" report can be diagnosed without server access.
-      // The server sends a machine-parseable reason on every rejection (see
-      // pty_ws in web_server.py); echo it verbatim alongside the close code.
-      const why = ev.reason ? ` reason=${ev.reason}` : "";
-      console.warn(`[chat] PTY WebSocket closed code=${ev.code}${why}`);
-      if (ev.code === 4401) {
-        setBanner(
-          ev.reason
-            ? `Auth failed (${ev.reason}). Reload to refresh the session.`
-            : "Auth failed. Reload the page to refresh the session token.",
-        );
-        return;
+
+      function wireWsHandlers(targetWs: WebSocket, termRef_: Terminal): void {
+        targetWs.onopen = () => {
+          if (unmounting || wsRef.current !== targetWs) {
+            targetWs.close(1000, "stale connection");
+            return;
+          }
+
+          const wasReconnect = hasConnected;
+          hasConnected = true;
+          reconnectAttempts = 0;
+          setBanner(null);
+          targetWs.send(`\x1b[RESIZE:${termRef_.cols};${termRef_.rows}]`);
+          if (wasReconnect) {
+            termRef_.write(`\r\n\x1b[90m[reconnected]\x1b[0m\r\n`);
+          }
+          termRef_.focus();
+        };
+
+        targetWs.onmessage = (ev) => {
+          if (typeof ev.data === "string") {
+            termRef_.write(ev.data);
+          } else {
+            termRef_.write(new Uint8Array(ev.data as ArrayBuffer));
+          }
+        };
+
+        targetWs.onclose = (ev) => {
+          if (wsRef.current === targetWs) {
+            wsRef.current = null;
+          }
+          if (unmounting) {
+            return;
+          }
+          const why = ev.reason ? ` reason=${ev.reason}` : "";
+          console.warn(`[chat] PTY WebSocket closed code=${ev.code}${why}`);
+          if (ev.code === 4401) {
+            setBanner(
+              ev.reason
+                ? `Auth failed (${ev.reason}). Reload to refresh the session.`
+                : "Auth failed. Reload the page to refresh the session token.",
+            );
+            return;
+          }
+          if (ev.code === 4403) {
+            setBanner(
+              ev.reason
+                ? `Refused: ${ev.reason}.`
+                : "Refused: request host/origin doesn't match the dashboard.",
+            );
+            return;
+          }
+          if (ev.code === 4404) {
+            setBanner(
+              "Embedded chat is disabled on this server (start it with --tui).",
+            );
+            return;
+          }
+          if (ev.code === 4408) {
+            setBanner(
+              ev.reason
+                ? `Refused: ${ev.reason}.`
+                : "Refused: your client isn't permitted (server bound to localhost only).",
+            );
+            return;
+          }
+          if (ev.code === 1011) {
+            return;
+          }
+
+          // No-status and abnormal closures cover sleep/wake and network loss.
+          // The server parks the PTY child under this tab's stable channel id.
+          if (ev.code === 1006 || ev.code === 1005) {
+            scheduleReconnect(termRef_, ev.code);
+            return;
+          }
+          termRef_.write(
+            `\r\n\x1b[90m[session ended (code ${ev.code})]\x1b[0m\r\n`,
+          );
+        };
       }
-      if (ev.code === 4403) {
-        // Host/Origin mismatch (DNS-rebinding guard).
-        setBanner(
-          ev.reason
-            ? `Refused: ${ev.reason}.`
-            : "Refused: request host/origin doesn't match the dashboard.",
-        );
-        return;
-      }
-      if (ev.code === 4404) {
-        setBanner(
-          "Embedded chat is disabled on this server (start it with --tui).",
-        );
-        return;
-      }
-      if (ev.code === 4408) {
-        setBanner(
-          ev.reason
-            ? `Refused: ${ev.reason}.`
-            : "Refused: your client isn't permitted (server bound to localhost only).",
-        );
-        return;
-      }
-      if (ev.code === 1011) {
-        // Server already wrote an ANSI error frame.
-        return;
-      }
-      term.write(
-        `\r\n\x1b[90m[session ended (code ${ev.code})]\x1b[0m\r\n`,
-      );
-    };
+
+      // --- initial connection ---
+      await connectWs(term);
 
     // Keystrokes → PTY.
     //
@@ -676,18 +734,18 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
       // eslint-disable-next-line no-control-regex -- intentional ESC byte in xterm SGR mouse report parser
       const SGR_MOUSE_RE = /^\x1b\[<(\d+);(\d+);(\d+)([Mm])$/;
       onDataDisposable = term.onData((data) => {
-        if (ws.readyState !== WebSocket.OPEN) return;
+        if (wsRef.current?.readyState !== WebSocket.OPEN) return;
 
         if (SGR_MOUSE_RE.test(data)) {
           return;
         }
 
-        ws.send(data);
+        wsRef.current?.send(data);
       });
 
       onResizeDisposable = term.onResize(({ cols, rows }) => {
-        if (ws.readyState === WebSocket.OPEN) {
-          ws.send(`\x1b[RESIZE:${cols};${rows}]`);
+        if (wsRef.current?.readyState === WebSocket.OPEN) {
+          wsRef.current?.send(`\x1b[RESIZE:${cols};${rows}]`);
         }
       });
     })();
@@ -709,12 +767,16 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
       if (hostSyncRaf) cancelAnimationFrame(hostSyncRaf);
       if (settleRaf1) cancelAnimationFrame(settleRaf1);
       if (settleRaf2) cancelAnimationFrame(settleRaf2);
+      if (reconnectTimer !== null) {
+        clearTimeout(reconnectTimer);
+        reconnectTimer = null;
+      }
       // Phase 5.3: ``ws`` is local to the IIFE that opens it (the gated-mode
       // ticket fetch makes the open async). The cleanup runs at the outer
       // effect's top level so it can't reach into that scope — close via
       // the ref instead. ``?.`` covers the race where unmount fires before
       // the ticket fetch resolves and ``wsRef.current`` was never assigned.
-      wsRef.current?.close();
+      wsRef.current?.close(1000, "page unmounted");
       wsRef.current = null;
       term.dispose();
       termRef.current = null;


### PR DESCRIPTION
## Summary

Keep the dashboard chat session alive across transient browser WebSocket disconnects, such as laptop sleep/wake or network loss.

This changes `/api/pty` ownership so an abnormal WebSocket close parks the PTY bridge for a bounded reconnect window instead of immediately closing the `hermes --tui` child. The browser chat tab now retries the PTY WebSocket with bounded exponential backoff and reuses the same stable channel id, so reconnecting can reclaim the running TUI session and its history.

## Details

- Add a reconnectable PTY bridge pool keyed by chat channel id.
- Reclaim a parked PTY bridge on reconnect instead of spawning a fresh child.
- Keep abnormal/no-status WebSocket closes (`1006`/`1005`) alive for reconnect, while intentional page teardown (`1000`) still closes normally.
- Wait for `WebSocket.onopen` before sending resize data or announcing reconnect success.
- Extend regression coverage for abnormal disconnect/reclaim behavior.
- Relax TUI gateway orphan reaping so short sleep/wake gaps do not discard active sessions too aggressively.

## Validation

- `python3 -m py_compile hermes_cli/web_server.py tui_gateway/server.py`
- `git diff --cached --check`
- `/Users/ljubomir/hermes-agent-macbook2/.venv/bin/python -m pytest tests/hermes_cli/test_web_server.py -k 'reconnectable or TestPtyWebSocket' -q`
- `/Users/ljubomir/hermes-agent-macbook2/.venv/bin/python -m pytest tests/test_tui_gateway_server.py -k ws_orphan_reap -q`
- `/Users/ljubomir/hermes-agent-macbook2/.venv/bin/python -m ruff check hermes_cli/web_server.py tests/hermes_cli/test_web_server.py tui_gateway/server.py`
- `npm --workspace web run typecheck`
- `npm --workspace web run build`
- `npm --workspace web exec eslint -- src/pages/ChatPage.tsx` completed with warnings only; no errors.
