### PR TITLE
fix(gateway): preserve restart notification marker for retry on reconnect

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -5945,6 +5945,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         )
                         logger.info("✓ %s reconnected successfully", platform.value)
 
+                        # A platform that came back after startup may have a
+                        # pending restart notification that was deferred because
+                        # the adapter wasn't connected yet.  Retry it now.
+                        await self._send_restart_notification()
+
                         # Rebuild channel directory with the new adapter
                         try:
                             from gateway.channel_directory import build_channel_directory
@@ -11859,9 +11864,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
             platform = Platform(platform_str)
             adapter = self.adapters.get(platform)
+            # adapter not connected yet is a TRANSIENT condition — the
+            # reconnect watcher may bring it back.  Leave the marker file
+            # in place so a later retry can deliver the notification.
             if not adapter:
                 logger.debug(
-                    "Restart notification skipped: %s adapter not connected",
+                    "Restart notification deferred: %s adapter not connected",
                     platform_str,
                 )
                 return None
@@ -11872,6 +11880,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     "Restart notification suppressed: %s has gateway_restart_notification=false",
                     platform_str,
                 )
+                notify_path.unlink(missing_ok=True)
                 return None
 
             metadata = self._thread_metadata_for_target(
@@ -11898,6 +11907,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     chat_id,
                     getattr(result, "error", "send returned success=False"),
                 )
+                # Delivery failed but not necessarily transient (e.g. chat
+                # deleted).  Consume the marker so we don't retry forever.
+                notify_path.unlink(missing_ok=True)
                 return None
 
             logger.info(
@@ -11905,12 +11917,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 platform_str,
                 chat_id,
             )
+            notify_path.unlink(missing_ok=True)
             return str(platform_str), str(chat_id), str(thread_id) if thread_id else None
         except Exception as e:
             logger.warning("Restart notification failed: %s", e)
+            # Transient error — leave marker for retry on reconnect
             return None
-        finally:
-            notify_path.unlink(missing_ok=True)
 
     async def _send_home_channel_startup_notifications(
         self,

--- a/tests/gateway/test_restart_notification.py
+++ b/tests/gateway/test_restart_notification.py
@@ -442,8 +442,8 @@ async def test_send_restart_notification_noop_when_no_file(tmp_path, monkeypatch
 
 
 @pytest.mark.asyncio
-async def test_send_restart_notification_skips_when_adapter_missing(tmp_path, monkeypatch):
-    """If the requester's platform isn't connected, clean up without crashing."""
+async def test_send_restart_notification_defers_when_adapter_missing(tmp_path, monkeypatch):
+    """If the requester's platform isn't connected, defer — leave marker for retry on reconnect."""
     monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
 
     notify_path = tmp_path / ".restart_notify.json"
@@ -456,15 +456,15 @@ async def test_send_restart_notification_skips_when_adapter_missing(tmp_path, mo
 
     await runner._send_restart_notification()
 
-    # File cleaned up even though we couldn't send
-    assert not notify_path.exists()
+    # File preserved — await retry when discord reconnects
+    assert notify_path.exists()
 
 
 @pytest.mark.asyncio
-async def test_send_restart_notification_cleans_up_on_send_failure(
+async def test_send_restart_notification_defers_on_send_exception(
     tmp_path, monkeypatch
 ):
-    """If the adapter.send() raises, the file is still cleaned up."""
+    """If adapter.send() raises (transient error), preserve marker for retry on reconnect."""
     monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
 
     notify_path = tmp_path / ".restart_notify.json"
@@ -478,9 +478,9 @@ async def test_send_restart_notification_cleans_up_on_send_failure(
 
     delivered_target = await runner._send_restart_notification()
 
-    # File cleaned up even though send raised.
+    # File preserved — transient error, will retry on reconnect
     assert delivered_target is None
-    assert not notify_path.exists()
+    assert notify_path.exists()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Problem

When a platform's WebSocket connection fails on the first attempt after gateway restart (e.g., rate-limiting from the platform server), the "Gateway restarted successfully" notification is permanently lost.

**Root cause**: `_send_restart_notification()` unconditionally deletes the `.restart_notify.json` marker file in a `finally` block — even when the platform adapter is not yet connected and the notification cannot be sent. When the reconnection watcher later brings the platform back online, the marker file is already gone.

Observed on Feishu (30s timeout on first WebSocket connect after `/restart`), but affects all WebSocket-based platforms.

## Fix

Two targeted changes in `gateway/run.py`:

1. **`_send_restart_notification`**: Only unlink the marker on definitive outcomes (successful delivery, `gateway_restart_notification=false`, or `SendResult(success=False)`). Leave it in place when the adapter is absent (transient — reconnect watcher will bring it back) or when `adapter.send()` raises an exception (transient network error).

2. **`_platform_reconnect_watcher`**: After successfully reconnecting a platform, call `_send_restart_notification()` to deliver any deferred notification.

## Test changes

- `test_send_restart_notification_skips_when_adapter_missing` → renamed to `...defers_when_adapter_missing`, now asserts file persists
- `test_send_restart_notification_cleans_up_on_send_failure` → renamed to `...defers_on_send_exception`, now asserts file persists on transient errors
- All 27 existing tests pass

## Scope

Minimal — does not change the API, does not affect the success path. Only changes what happens in two failure modes that were silently dropping the notification.