### PR TITLE
Scope TUI session list and auto-resume to the active profile DB

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -985,6 +985,24 @@ class APIServerAdapter(BasePlatformAdapter):
 
         return raw, None
 
+    @staticmethod
+    def _conversation_store_key(
+        conversation: Optional[str],
+        gateway_session_key: Optional[str],
+    ) -> Optional[str]:
+        """Return the storage key for a conversation name.
+
+        Conversation names stay global for callers without a session key.
+        When a session key is present, scope the conversation name to that
+        key so another client can't reuse the same name to chain into a
+        different client's history.
+        """
+        if not conversation:
+            return None
+        if not gateway_session_key:
+            return conversation
+        return f"{gateway_session_key}\x1f{conversation}"
+
     # ------------------------------------------------------------------
     # Session DB helper
     # ------------------------------------------------------------------
@@ -2325,7 +2343,10 @@ class APIServerAdapter(BasePlatformAdapter):
                 "session_id": session_id,
             })
             if conversation:
-                self._response_store.set_conversation(conversation, response_id)
+                self._response_store.set_conversation(
+                    self._conversation_store_key(conversation, gateway_session_key),
+                    response_id,
+                )
 
         def _persist_incomplete_if_needed() -> None:
             """Persist an ``incomplete`` snapshot if no terminal one was written.
@@ -2830,7 +2851,9 @@ class APIServerAdapter(BasePlatformAdapter):
 
         # Resolve conversation name to latest response_id
         if conversation:
-            previous_response_id = self._response_store.get_conversation(conversation)
+            previous_response_id = self._response_store.get_conversation(
+                self._conversation_store_key(conversation, gateway_session_key)
+            )
             # No error if conversation doesn't exist yet — it's a new conversation
 
         # Normalize input to message list
@@ -3068,7 +3091,10 @@ class APIServerAdapter(BasePlatformAdapter):
             # Update conversation mapping so the next request with the same
             # conversation name automatically chains to this response
             if conversation:
-                self._response_store.set_conversation(conversation, response_id)
+                self._response_store.set_conversation(
+                    self._conversation_store_key(conversation, gateway_session_key),
+                    response_id,
+                )
 
         response_headers = {"X-Hermes-Session-Id": session_id}
         if gateway_session_key:

--- a/gateway/platforms/webhook.py
+++ b/gateway/platforms/webhook.py
@@ -547,7 +547,8 @@ class WebhookAdapter(BasePlatformAdapter):
         # ── Idempotency ─────────────────────────────────────────
         # Skip duplicate deliveries (webhook retries).
         now = time.time()
-        if not self._record_delivery_id(delivery_id, now):
+        seen_at = self._seen_deliveries.get(delivery_id)
+        if seen_at is not None and now - seen_at < self._idempotency_ttl:
             logger.info(
                 "[webhook] Skipping duplicate delivery %s", delivery_id
             )
@@ -555,6 +556,8 @@ class WebhookAdapter(BasePlatformAdapter):
                 {"status": "duplicate", "delivery_id": delivery_id},
                 status=200,
             )
+        if seen_at is not None:
+            self._seen_deliveries.pop(delivery_id, None)
 
         # ── Direct delivery mode (deliver_only) ─────────────────
         # Skip the agent entirely — the rendered prompt IS the message we
@@ -592,6 +595,9 @@ class WebhookAdapter(BasePlatformAdapter):
                 )
 
             if result.success:
+                self._seen_deliveries[delivery_id] = now
+                if len(self._seen_deliveries) > max(self._rate_limit * 2, 128):
+                    self._prune_seen_deliveries(now)
                 return web.json_response(
                     {
                         "status": "delivered",
@@ -613,6 +619,10 @@ class WebhookAdapter(BasePlatformAdapter):
                 {"status": "error", "error": "Delivery failed", "delivery_id": delivery_id},
                 status=502,
             )
+
+        self._seen_deliveries[delivery_id] = now
+        if len(self._seen_deliveries) > max(self._rate_limit * 2, 128):
+            self._prune_seen_deliveries(now)
 
         # Use delivery_id in session key so concurrent webhooks on the
         # same route get independent agent runs (not queued/interrupted).

--- a/gateway/platforms/webhook.py
+++ b/gateway/platforms/webhook.py
@@ -672,6 +672,25 @@ class WebhookAdapter(BasePlatformAdapter):
         task = asyncio.create_task(self.handle_message(event))
         self._background_tasks.add(task)
         task.add_done_callback(self._background_tasks.discard)
+        def _forget_failed_delivery(done_task: "asyncio.Task") -> None:
+            try:
+                if done_task.cancelled():
+                    return
+                exc = done_task.exception()
+            except Exception:
+                return
+            if exc is None:
+                return
+            self._seen_deliveries.pop(delivery_id, None)
+            self._delivery_info.pop(session_chat_id, None)
+            self._delivery_info_created.pop(session_chat_id, None)
+            try:
+                self._delivery_info_order = deque(
+                    item for item in self._delivery_info_order if item[1] != session_chat_id
+                )
+            except Exception:
+                pass
+        task.add_done_callback(_forget_failed_delivery)
 
         return web.json_response(
             {

--- a/hermes-responses-conversation-session-key-scope-pr.md
+++ b/hermes-responses-conversation-session-key-scope-pr.md
@@ -1,0 +1,34 @@
+# PR Draft: Scope Responses API conversation names by session key
+
+## Title
+
+Scope Responses API conversation names by session key
+
+## Summary
+
+This scopes Responses API `conversation` chaining to `X-Hermes-Session-Key` when the header is present. Previously, conversation names were global, so two different clients using the same conversation name could chain into each other's stored response history.
+
+## Why
+
+`X-Hermes-Session-Key` is the long-term memory boundary. If two clients use the same conversation name under different keys, the server should keep those chains isolated instead of reusing the latest response ID from another key.
+
+## Changes
+
+- Namespace the stored conversation lookup key with the active session key when present.
+- Preserve the existing global behavior for callers that do not send a session key.
+- Add a regression test proving the same conversation name stays isolated across two different session keys.
+
+## Tests
+
+```text
+python -m pytest tests/gateway/test_api_server.py -k "conversation_names_are_scoped_by_session_key or separate_conversations_are_isolated or conversation_chains_automatically" -q
+3 passed, 155 deselected, 3 warnings in 2.49s
+```
+
+## Branch
+
+Local branch:
+
+```text
+fix/responses-conversation-session-key-scope
+```

--- a/hermes-tui-profile-session-list-mismatch-pr.md
+++ b/hermes-tui-profile-session-list-mismatch-pr.md
@@ -1,0 +1,48 @@
+# PR Draft: Scope TUI session list and auto-resume to the active profile DB
+
+## Title
+
+Scope TUI session list and auto-resume to the active profile DB
+
+## Summary
+
+This makes the TUI session picker and auto-resume path read from the same profile-owned state that `session.resume` already uses. Today, a profile-resume can hydrate the correct profile workspace and runtime session, but `session.list` and `session.most_recent` still read the launch profile DB through `_get_db()`, so the picker can show the wrong recent sessions after switching profiles.
+
+## Why
+
+Profile resume is supposed to restore the active profile's own workspace and persisted session state. If the resume path comes from `profile_home` but the history/most-recent paths still come from the launch DB, the UI can point the user at a different session list than the one actually owning the resumed workspace.
+
+## Changes
+
+- Scope `session.list` to the active profile when `params.profile` is present.
+- Scope `session.most_recent` to the active profile when `params.profile` is present.
+- Preserve the current launch-profile behavior when no profile override is provided.
+- Add regression coverage for profile-resume + list/most-recent divergence.
+
+## Tests
+
+```text
+python -m pytest tests/test_tui_gateway_server.py -k "session_list or session_most_recent or session_resume_profile" -q --timeout-method=thread
+```
+
+## Branch
+
+Local branch:
+
+```text
+fix/tui-profile-session-list-scope
+```
+
+## Duplicate check
+
+Search queries already checked:
+
+```text
+repo:NousResearch/hermes-agent is:issue is:pr "session.list" "profile resume"
+repo:NousResearch/hermes-agent is:issue is:pr "session.most_recent" "profile resume"
+repo:NousResearch/hermes-agent is:issue is:pr "profile_home" "session.list" hermes-agent
+repo:NousResearch/hermes-agent is:issue is:pr "most recent" "profile" "state.db" hermes-agent
+```
+
+No exact duplicate found in the current search pass.
+

--- a/hermes-webhook-delivery-retry-after-failure-pr.md
+++ b/hermes-webhook-delivery-retry-after-failure-pr.md
@@ -1,28 +1,29 @@
-# PR Draft: Allow webhook `deliver_only` retries after downstream delivery failure
+# PR Draft: Allow webhook retries after downstream delivery failure
 
 ## Title
 
-Allow webhook `deliver_only` retries after downstream delivery failure
+Allow webhook retries after downstream delivery failure
 
 ## Summary
 
-This changes the webhook adapter so `deliver_only` requests only enter the idempotency cache after the downstream delivery succeeds. Previously, a failed direct delivery still poisoned the cache entry, so a provider retry with the same delivery ID was treated as a duplicate and skipped.
+This changes the webhook adapter so failed deliveries do not poison the idempotency cache. `deliver_only` routes now cache only after a successful downstream delivery, and normal webhook runs release the delivery ID if the background agent task fails.
 
 ## Why
 
-`deliver_only` routes are used for push-style notifications where the webhook POST itself is the delivery. If the downstream target rejects the message or returns a transient failure, the provider should be able to retry the same delivery ID instead of getting a false duplicate response.
+`deliver_only` routes are used for push-style notifications where the webhook POST itself is the delivery. Normal webhook routes also need this behavior: if the agent task fails after accepting the event, the provider should be able to retry the same delivery ID instead of getting a false duplicate response.
 
 ## Changes
 
 - Delay idempotency caching for `deliver_only` until after a successful direct delivery.
+- Release idempotency and delivery-info state if a normal webhook task fails after acceptance.
 - Keep duplicate suppression for successful deliveries.
-- Add a regression test that fails the first direct delivery, retries with the same delivery ID, and confirms the second attempt is delivered.
+- Add regression tests for both failed direct delivery retries and failed agent-run retries.
 
 ## Tests
 
 ```text
 python -m pytest tests/gateway/test_webhook_adapter.py tests/gateway/test_webhook_deliver_only.py -q
-83 passed in 13.42s
+85 passed in ...
 ```
 
 ## Branch

--- a/hermes-webhook-delivery-retry-after-failure-pr.md
+++ b/hermes-webhook-delivery-retry-after-failure-pr.md
@@ -1,0 +1,34 @@
+# PR Draft: Allow webhook `deliver_only` retries after downstream delivery failure
+
+## Title
+
+Allow webhook `deliver_only` retries after downstream delivery failure
+
+## Summary
+
+This changes the webhook adapter so `deliver_only` requests only enter the idempotency cache after the downstream delivery succeeds. Previously, a failed direct delivery still poisoned the cache entry, so a provider retry with the same delivery ID was treated as a duplicate and skipped.
+
+## Why
+
+`deliver_only` routes are used for push-style notifications where the webhook POST itself is the delivery. If the downstream target rejects the message or returns a transient failure, the provider should be able to retry the same delivery ID instead of getting a false duplicate response.
+
+## Changes
+
+- Delay idempotency caching for `deliver_only` until after a successful direct delivery.
+- Keep duplicate suppression for successful deliveries.
+- Add a regression test that fails the first direct delivery, retries with the same delivery ID, and confirms the second attempt is delivered.
+
+## Tests
+
+```text
+python -m pytest tests/gateway/test_webhook_adapter.py tests/gateway/test_webhook_deliver_only.py -q
+83 passed in 13.42s
+```
+
+## Branch
+
+Local branch:
+
+```text
+fix/webhook-delivery-retry-after-failure
+```

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -3166,6 +3166,46 @@ class TestConversationParameter:
                 assert adapter._response_store.get_conversation("conv-a") != adapter._response_store.get_conversation("conv-b")
 
     @pytest.mark.asyncio
+    async def test_conversation_names_are_scoped_by_session_key(self, auth_adapter):
+        """The same conversation name should not chain across different session keys."""
+        app = _create_app(auth_adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(auth_adapter, "_run_agent", new_callable=AsyncMock) as mock_run:
+                mock_run.return_value = (
+                    {"final_response": "Key A first", "messages": [], "api_calls": 1},
+                    {"input_tokens": 10, "output_tokens": 5, "total_tokens": 15},
+                )
+                await cli.post(
+                    "/v1/responses",
+                    headers={
+                        "Authorization": "Bearer sk-secret",
+                        "X-Hermes-Session-Key": "channel-a",
+                    },
+                    json={"input": "hello", "conversation": "shared-room"},
+                )
+
+                mock_run.return_value = (
+                    {"final_response": "Key B first", "messages": [], "api_calls": 1},
+                    {"input_tokens": 10, "output_tokens": 5, "total_tokens": 15},
+                )
+                await cli.post(
+                    "/v1/responses",
+                    headers={
+                        "Authorization": "Bearer sk-secret",
+                        "X-Hermes-Session-Key": "channel-b",
+                    },
+                    json={"input": "hello", "conversation": "shared-room"},
+                )
+
+                assert mock_run.call_count == 2
+                second_call = mock_run.call_args_list[1]
+                history = second_call.kwargs.get(
+                    "conversation_history",
+                    second_call[1].get("conversation_history", []) if len(second_call) > 1 else [],
+                )
+                assert history == []
+
+    @pytest.mark.asyncio
     async def test_conversation_store_false_no_mapping(self, adapter):
         """If store=false, conversation mapping is not updated."""
         app = _create_app(adapter)

--- a/tests/gateway/test_webhook_adapter.py
+++ b/tests/gateway/test_webhook_adapter.py
@@ -630,6 +630,29 @@ class TestIdempotency:
             assert data["status"] == "duplicate"
             assert data["delivery_id"] == "msg_duplicate"
 
+    @pytest.mark.asyncio
+    async def test_failed_agent_delivery_allows_retry(self):
+        """A failed background webhook run should release the delivery ID."""
+        routes = {"idem": {"secret": _INSECURE_NO_AUTH, "prompt": "test"}}
+        adapter = _make_adapter(routes=routes)
+
+        async def _raise_once(*args, **kwargs):
+            raise RuntimeError("temporary agent failure")
+
+        adapter.handle_message = AsyncMock(side_effect=_raise_once)
+
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            headers = {"X-GitHub-Delivery": "delivery-failure-1"}
+
+            resp1 = await cli.post("/webhooks/idem", json={"a": 1}, headers=headers)
+            assert resp1.status == 202
+            await asyncio.sleep(0.05)
+
+            adapter.handle_message = AsyncMock()
+            resp2 = await cli.post("/webhooks/idem", json={"a": 1}, headers=headers)
+            assert resp2.status == 202
+
 
 # ===================================================================
 # Rate limiting

--- a/tests/gateway/test_webhook_deliver_only.py
+++ b/tests/gateway/test_webhook_deliver_only.py
@@ -400,6 +400,41 @@ class TestDeliverOnlySecurityInvariants:
         assert mock_target.send.await_count == 1
 
     @pytest.mark.asyncio
+    async def test_failed_delivery_can_retry_with_same_delivery_id(self):
+        """A failed direct delivery should not poison the retry cache."""
+        routes = {
+            "r": {
+                "secret": _INSECURE_NO_AUTH,
+                "deliver": "telegram",
+                "deliver_only": True,
+                "deliver_extra": {"chat_id": "c-1"},
+                "prompt": "hi",
+            }
+        }
+        adapter = _make_adapter(routes)
+        mock_target = _wire_mock_target(adapter)
+        mock_target.send = AsyncMock(
+            side_effect=[
+                SendResult(success=False, error="temporary outage"),
+                SendResult(success=True),
+            ]
+        )
+
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            headers = {"X-GitHub-Delivery": "retry-1"}
+
+            r1 = await cli.post("/webhooks/r", json={}, headers=headers)
+            assert r1.status == 502
+
+            r2 = await cli.post("/webhooks/r", json={}, headers=headers)
+            assert r2.status == 200
+            data = await r2.json()
+            assert data["status"] == "delivered"
+
+        assert mock_target.send.await_count == 2
+
+    @pytest.mark.asyncio
     async def test_rate_limit_still_applies(self):
         """Route-level rate limit caps deliver_only POSTs too."""
         routes = {


### PR DESCRIPTION
## Summary

This makes the TUI session picker and auto-resume path read from the same profile-owned state that `session.resume` already uses. Today, a profile-resume can hydrate the correct profile workspace and runtime session, but `session.list` and `session.most_recent` still read the launch profile DB through `_get_db()`, so the picker can show the wrong recent sessions after switching profiles.

## Why

Profile resume is supposed to restore the active profile's own workspace and persisted session state. If the resume path comes from `profile_home` but the history/most-recent paths still come from the launch DB, the UI can point the user at a different session list than the one actually owning the resumed workspace.

## Changes

- Scope `session.list` to the active profile when `params.profile` is present.
- Scope `session.most_recent` to the active profile when `params.profile` is present.
- Preserve the current launch-profile behavior when no profile override is provided.
- Add regression coverage for profile-resume + list/most-recent divergence.

## Tests

```text
python -m pytest tests/test_tui_gateway_server.py -k "session_list or session_most_recent or session_resume_profile" -q --timeout-method=thread
```