### PR TITLE
test: isolate auxiliary health cache in main-first tests

### DIFF
--- a/tests/agent/test_auxiliary_main_first.py
+++ b/tests/agent/test_auxiliary_main_first.py
@@ -13,7 +13,18 @@ runs when the main provider has no working client.
 
 from __future__ import annotations
 
+import pytest
 from unittest.mock import MagicMock, patch
+
+
+@pytest.fixture(autouse=True)
+def reset_aux_unhealthy_cache():
+    """Keep tests isolated from the process-wide auxiliary health cache."""
+    from agent.auxiliary_client import _reset_aux_unhealthy_cache
+
+    _reset_aux_unhealthy_cache()
+    yield
+    _reset_aux_unhealthy_cache()
 
 
 


### PR DESCRIPTION
## Problem

`tests/agent/test_auxiliary_main_first.py` tests share a process-wide auxiliary health cache (`_aux_unhealthy_until` and `_aux_unhealthy_logged_at` module-level dicts in `agent/auxiliary_client.py`). When one test marks a provider as unhealthy, the flag persists into subsequent tests, making them order-dependent and prone to flaky failures.

## Fix

Add a `pytest.fixture(autouse=True)` that calls `_reset_aux_unhealthy_cache()` before and after each test, ensuring clean isolation.

## Test

All 18 tests in the file pass.