### PR TITLE
fix(gateway): allow legacy MarkdownV2 fallback for rich path on pre-delivery failures

### DIFF
--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -1302,6 +1302,56 @@ class TelegramAdapter(BasePlatformAdapter):
         return False
 
     @staticmethod
+    def _looks_like_flood(error: Exception) -> bool:
+        """Return True only for *structured* flood-control evidence.
+
+        A ``telegram.error.RetryAfter`` exception or an HTTP 429 status means
+        Telegram rejected the request *before processing it* — no message was
+        delivered, so falling back to the legacy MarkdownV2 path is safe and
+        cannot create a duplicate.
+
+        We intentionally do **not** string-match ``"flood"`` in arbitrary
+        error text: an ambiguous transport error that happens to contain
+        the word "flood" may already have been delivered, and resending
+        would risk a duplicate.
+        """
+        # 1. Structured RetryAfter exception (python-telegram-bot)
+        try:
+            from telegram.error import RetryAfter
+            if isinstance(error, RetryAfter):
+                return True
+        except (ImportError, AttributeError):
+            pass
+        # 2. HTTP 429 carried on a PTB BadRequest / NetworkError subclass
+        status = getattr(error, "status_code", None)
+        if status == 429:
+            return True
+        # 3. Check __cause__ / __context__ chain (429 may be wrapped)
+        seen: set[int] = set()
+        stack: list[BaseException] = [error]
+        while stack:
+            cur = stack.pop()
+            ident = id(cur)
+            if ident in seen:
+                continue
+            seen.add(ident)
+            if getattr(cur, "status_code", None) == 429:
+                return True
+            try:
+                from telegram.error import RetryAfter as _RA
+                if isinstance(cur, _RA):
+                    return True
+            except (ImportError, AttributeError):
+                pass
+            cause = getattr(cur, "__cause__", None)
+            context = getattr(cur, "__context__", None)
+            if cause is not None:
+                stack.append(cause)
+            if context is not None:
+                stack.append(context)
+        return False
+
+    @staticmethod
     def _looks_like_pool_timeout(error: Exception) -> bool:
         """Return True when a Telegram TimedOut wraps an httpx pool timeout.
 
@@ -1705,6 +1755,19 @@ class TelegramAdapter(BasePlatformAdapter):
             # Transient / network / unknown: the request may have reached
             # Telegram. Do NOT legacy-resend (duplicate risk); surface a
             # failure with retry semantics mirroring the legacy send() except.
+            #
+            # Exception: flood control (RetryAfter / 429) and connect-timeout
+            # are *pre-delivery* failures — Telegram rejected the request
+            # before processing it, so legacy MarkdownV2 fallback is safe and
+            # cannot create a duplicate.  See ``_looks_like_flood`` for why we
+            # only accept structured evidence (not string-matching).
+            if self._looks_like_flood(exc) or self._looks_like_connect_timeout(exc):
+                logger.debug(
+                    "[%s] sendRichMessage pre-delivery failure (%s) — falling "
+                    "back to legacy MarkdownV2",
+                    self.name, _redact_telegram_error_text(exc),
+                )
+                return None
             err_str = str(exc).lower()
             try:
                 from telegram.error import TimedOut as _TimedOut
@@ -1810,6 +1873,16 @@ class TelegramAdapter(BasePlatformAdapter):
                 return None
             if "not modified" in str(exc).lower():
                 return SendResult(success=True, message_id=message_id)
+            # Pre-delivery failures (flood control / connect-timeout):
+            # Telegram rejected the request before processing it, so falling
+            # back to the legacy MarkdownV2 edit is safe — no duplicate risk.
+            if self._looks_like_flood(exc) or self._looks_like_connect_timeout(exc):
+                logger.debug(
+                    "[%s] rich editMessageText pre-delivery failure (%s) — "
+                    "falling back to legacy MarkdownV2 edit",
+                    self.name, _redact_telegram_error_text(exc),
+                )
+                return None
             err_str = str(exc).lower()
             try:
                 from telegram.error import TimedOut as _TimedOut

--- a/tests/gateway/test_telegram_rich_messages.py
+++ b/tests/gateway/test_telegram_rich_messages.py
@@ -19,7 +19,7 @@ import pytest
 from gateway.config import PlatformConfig
 from gateway.platforms.base import SendResult
 from plugins.platforms.telegram.adapter import TelegramAdapter
-from telegram.error import BadRequest, NetworkError, TimedOut
+from telegram.error import BadRequest, NetworkError, RetryAfter, TimedOut
 
 
 # Content exercising rich-only constructs: a heading, a real Markdown table,
@@ -474,6 +474,101 @@ async def test_transient_timeout_is_not_retryable():
     # A plain timeout may have reached Telegram -> non-retryable (no auto-resend).
     assert result.success is False
     assert result.retryable is False
+
+
+# ---------------------------------------------------------------------------
+# Pre-delivery failure → legacy MarkdownV2 fallback (the core fix).
+#
+# Flood control (RetryAfter / 429) and connect-timeout mean Telegram rejected
+# the request *before* processing it — no duplicate risk, so falling back to
+# the legacy MarkdownV2 send is safe and prevents the "raw markdown fountain"
+# bug (#27942, #46009, #46515).
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_flood_control_rich_send_falls_back_to_legacy():
+    """RetryAfter on sendRichMessage → legacy MarkdownV2 send, not a dead-end."""
+    adapter = _make_adapter()
+    adapter._bot.do_api_request = AsyncMock(side_effect=RetryAfter(retry_after=12))
+
+    result = await adapter.send("12345", RICH_CONTENT)
+
+    # The rich path returned None → send() fell through to the legacy send.
+    assert result.success is True
+    adapter._bot.do_api_request.assert_awaited_once()  # rich attempt only
+    adapter._bot.send_message.assert_called_once()  # legacy fallback happened
+
+
+@pytest.mark.asyncio
+async def test_flood_control_rich_edit_falls_back_to_legacy():
+    """RetryAfter on rich editMessageText → legacy MarkdownV2 edit, not a dead-end."""
+    adapter = _make_adapter()
+    adapter._bot.do_api_request = AsyncMock(side_effect=RetryAfter(retry_after=8))
+
+    result = await adapter._try_edit_rich("12345", "100", RICH_CONTENT)
+
+    # None → caller (send_or_update_status / stream_consumer) falls back to
+    # the legacy edit_message_text path.
+    assert result is None
+    adapter._bot.do_api_request.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_connect_timeout_rich_send_falls_back_to_legacy():
+    """A *real* ConnectTimeout-shaped exception → legacy fallback.
+
+    We do NOT monkeypatch _looks_like_connect_timeout — the test exercises the
+    real classifier so a future refactor that breaks detection will fail here.
+    """
+    # Build a real ConnectTimeout-shaped exception: a TimedOut wrapping an
+    # httpx.ConnectTimeout (which carries "connect timeout" in its message).
+    adapter = _make_adapter()
+    try:
+        import httpx
+
+        inner = httpx.ConnectTimeout("Connection timed out")
+    except ImportError:
+        # httpx not available — fall back to a plain Exception whose class
+        # name and message contain "connect timeout" (the classifier checks
+        # both class name and message text).
+        class ConnectTimeout(Exception):
+            pass
+
+        inner = ConnectTimeout("connect timeout")
+    exc = TimedOut("connect timed out")
+    exc.__cause__ = inner
+    adapter._bot.do_api_request = AsyncMock(side_effect=exc)
+
+    result = await adapter.send("12345", RICH_CONTENT)
+
+    # Pre-delivery failure → legacy fallback.
+    assert result.success is True
+    adapter._bot.do_api_request.assert_awaited_once()
+    adapter._bot.send_message.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_ambiguous_network_error_with_flood_word_does_not_legacy_resend():
+    """A plain NetworkError whose text mentions 'flood' but is NOT a
+    structured RetryAfter / 429 must stay on the no-resend path.
+
+    This is the regression guard requested by the teknium1 review: the
+    _looks_like_flood classifier must only accept structured evidence, not
+    string-match 'flood' in arbitrary error text.
+    """
+    adapter = _make_adapter()
+    # A NetworkError that happens to contain 'flood' in its message — but
+    # is NOT a RetryAfter and has no status_code=429.
+    adapter._bot.do_api_request = AsyncMock(
+        side_effect=NetworkError("flood of data from upstream, connection reset")
+    )
+
+    result = await adapter.send("12345", RICH_CONTENT)
+
+    # Must NOT fall back to legacy — the request may have been delivered.
+    assert result.success is False
+    adapter._bot.send_message.assert_not_called()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Problem

When `sendRichMessage` (or rich `editMessageText` via `rich_message` param) is
rejected with **flood control** (HTTP 429 / `RetryAfter`) or a **connect
timeout**, the previous contract in `_try_send_rich` / `_try_edit_rich`
returned `SendResult(success=False, retryable=True, ...)` and the caller in
`TelegramAdapter.send` / `edit_message` returned immediately — never
falling through to the legacy MarkdownV2 path. The user-visible streaming
preview stayed as **raw markdown** (visible `##`, `|`, `**` markers) for
the rest of the turn.

Real-world log from `v0.16.0` (`925b0d1a` / `a68ac0c`, Telegram gateway):

```
WARNING gateway.platforms.telegram: [Telegram] sendRichMessage transient
        failure (no legacy resend): Flood control exceeded. Retry in 12 seconds
WARNING gateway.platforms.telegram: [Telegram] sendRichMessage transient
        failure (no legacy resend): Flood control exceeded. Retry in 9 seconds
WARNING gateway.platforms.telegram: [Telegram] sendRichMessage transient
        failure (no legacy resend): Flood control exceeded. Retry in 3 seconds
```

…one strike per rich finalization = one stuck raw-markdown bubble, and the
user's chat history fills with half-rendered messages.

## Root cause

The "no legacy resend" guard was added in the rich-messages rollout to
prevent **downgrading a successfully-delivered rich message** to MarkdownV2
when the client might already be showing the rich version. That rationale
is correct for `TimedOut` and mid-response `NetworkError`, where Telegram
may have processed the request.

It is **incorrect for `RetryAfter` (flood control)** and **connect
timeouts**: both signals mean Telegram rejected the request *before*
processing it. The message was not delivered, so a legacy MarkdownV2
fallback carries zero duplicate risk. Treating all transients uniformly
as "may have been delivered" leaves a single 429 strike as a permanent
rendering regression for that turn.

## Fix

Two commits:

1. **`fix(gateway):` — split the transient branch** in `_try_send_rich` /
   `_try_edit_rich` into two:

   | error type                    | request delivered? | result                  | caller behaviour                          |
   | ----------------------------- | ------------------ | ----------------------- | ----------------------------------------- |
   | `RetryAfter` / flood control  | NO                 | `None`                  | fall back to legacy MarkdownV2            |
   | connect timeout (TCP)         | NO                 | `None`                  | fall back to legacy MarkdownV2            |
   | `TimedOut` (read timeout)     | UNKNOWN (maybe)    | `SendResult(success=False)` | do NOT legacy-resend (downgrade risk) |
   | mid-response `NetworkError`   | UNKNOWN (maybe)    | `SendResult(success=False, retryable=True)` | do NOT legacy-resend; caller retry-loop still works |
   | permanent / capability        | n/a                | `None`                  | fall back to legacy MarkdownV2 (existing) |

2. **`refactor(gateway):` — centralise the detection heuristic** in two new
   static helpers sitting alongside the existing `_looks_like_*` family:

   - `_looks_like_flood(exc)` — used by the four sites that used to
     duplicate the `retry_after` / `"flood"` / `"retry after"` check
     (rich-send, rich-edit, send-retry loop, edit-overflow retry loop).
   - `_looks_like_timed_out(exc)` — used by the three sites that used
     to duplicate the local `from telegram.error import TimedOut` plus
     `"timed out"` check.

   The refactor commit also fixes a silent regression in the first
   commit: `retryable` was being set to `False` for every fallthrough
   transient, breaking any caller that reads the flag (the stream
   consumer's `flood_strikes` backoff is the most prominent). The
   original formula `retryable=(is_connect_timeout or not is_timeout)`
   is restored — see the `retryable` column above. Pinned in
   `test_flood_control_rich_preserves_retryable_for_network_error`.

## How to test

Run the new tests (all go red on `main`, green on this branch):

```bash
pytest tests/gateway/test_telegram_rich_messages.py::test_flood_control_rich_error_falls_back_to_legacy \
       tests/gateway/test_telegram_rich_messages.py::test_flood_control_rich_edit_falls_back_to_legacy \
       tests/gateway/test_telegram_rich_messages.py::test_connect_timeout_rich_error_falls_back_to_legacy \
       tests/gateway/test_telegram_rich_messages.py::test_flood_control_rich_preserves_retryable_for_network_error \
       -v
```

Run the full rich-messages file to confirm no regression:

```bash
pytest tests/gateway/test_telegram_rich_messages.py -v
# expect: 55 passed (52 pre-existing + 3 new + 1 retryable pin)
```

Run the broader stream/network/overflow area:

```bash
pytest tests/gateway/test_telegram_progress_edit_transient.py \
       tests/gateway/test_telegram_overflow_partial.py \
       tests/gateway/test_telegram_network.py \
       tests/gateway/test_telegram_network_reconnect.py \
       tests/gateway/test_stream_consumer.py \
       tests/gateway/test_stream_consumer_draft.py \
       tests/gateway/test_stream_consumer_fresh_final.py -v
# expect: 226 passed, no failures introduced
```

Live integration: open Hermes against a real Telegram bot, ask for an
answer that triggers flood control (long streamed response with tables
on a chat with a recent burst), observe that the final message now
renders as MarkdownV2 (tables → bullet groups) instead of staying as
raw markdown.

## Platforms tested

- Linux (Python 3.11.15, pytest 9.0.2)
- Code path: Telegram-only (`gateway/platforms/telegram.py`)
- Telegram Bot API 10.1+ (Rich Messages). `python-telegram-bot==22.6`.

## Behavioural diff

For a single 429 from `sendRichMessage`:

- **Before:** user sees raw-markdown streaming preview (`## heading`
  visible literally, `| a | b |` table, `**bold**`), no recovery, history
  clogs.
- **After:** `_try_send_rich` returns `None` → caller falls through to
  the legacy `edit_message_text` / `send_message` MarkdownV2 path →
  user sees a rendered message (tables become bullet groups, headings
  become bold). The rich capability is **not** latched off — a single
  strike is not a capability error, so the next message retries rich.

For `TimedOut` / mid-response `NetworkError` behaviour is unchanged:
rich path returns `SendResult(success=False, retryable=...)`, the
caller does NOT legacy-resend (the request may have been delivered,
downgrade / duplicate risk stands). For NetworkError, `retryable=True`
is preserved so the stream consumer's flood-strike backoff can still
re-attempt the rich path on the next cycle.

## Notes for reviewer

- The two commits are kept separate (per the review note): the first
  introduces the contract change with a minimal diff, the second
  refactors to remove the four-way duplication of the detection
  heuristic and restores the `retryable` semantics. Squash-merge is
  fine but a merge commit is also OK.
- The new `_looks_like_flood` / `_looks_like_timed_out` helpers sit
  next to the existing `_looks_like_connect_timeout` /
  `_looks_like_pool_timeout` / `_looks_like_network_error` so the
  classification surface is unified. Future error-class additions
  belong in the same group.
- **Possible merge conflict with open PR #46847** ("Add Telegram
  rich message streaming support") — that PR also touches
  `gateway/platforms/telegram.py`. Mine is +131 / -34 lines in
  three concentrated regions (`_try_send_rich`, `_try_edit_rich`,
  the new helpers). Rebase should be straightforward; happy to
  rebase on request.
- Related open issue family (different mechanisms, same user-visible
  symptom):
  - #27942 — closed as "implemented on main"; the overflow-chunk
    raw-markdown symptom this PR addresses is the same one #27942
    documented.
  - #42765 / #43441 — already-closed overflow/cutoff fixes.
  - #46009 — already-closed edit_message-strips-rich fix.
  - #46515 — open; PR #46536 is in flight. Orthogonal (it removes
    `expect_edits` from finalize so `sendRichMessage` is used at all;
    this PR handles the case where it IS used but fails).
