### PR TITLE
fix(gateway): handle Feishu merge_forward follow-ups

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -117,6 +117,10 @@ def _reply_anchor_for_event(event) -> str | None:
         # SlackAdapter._resolve_thread_ts() treat it as a thread anchor and
         # reply in a (nonexistent) thread anyway.
         return None
+    if getattr(event, "suppress_reply_anchor", False):
+        return None
+    if platform == "feishu" and _is_feishu_merge_forward_event(event):
+        return None
     if platform == "telegram" and thread_id and getattr(source, "chat_type", None) == "dm":
         # Reply to the triggering user message. Replying to Telegram's earlier
         # topic seed/anchor can render the bot response outside the active lane.
@@ -126,6 +130,29 @@ def _reply_anchor_for_event(event) -> str | None:
     if platform == "feishu" and thread_id and getattr(event, "reply_to_message_id", None):
         return getattr(event, "reply_to_message_id", None)
     return getattr(event, "message_id", None)
+
+
+def _is_feishu_merge_forward_event(event) -> bool:
+    raw = getattr(event, "raw_message", None)
+    raw_event = raw.get("event") if isinstance(raw, dict) else None
+    raw_message = raw.get("message") if isinstance(raw, dict) else None
+    candidates = [
+        getattr(getattr(raw, "event", None), "message", None),
+        raw_event.get("message") if isinstance(raw_event, dict) else None,
+        getattr(raw, "message", None),
+        raw_message,
+        raw,
+    ]
+    for candidate in candidates:
+        if candidate is None:
+            continue
+        if isinstance(candidate, dict):
+            message_type = candidate.get("message_type") or candidate.get("msg_type")
+        else:
+            message_type = getattr(candidate, "message_type", None) or getattr(candidate, "msg_type", None)
+        if str(message_type or "").strip().lower() == "merge_forward":
+            return True
+    return False
 
 
 def should_send_media_as_audio(platform, ext: str, is_voice: bool = False) -> bool:
@@ -1817,6 +1844,7 @@ class MessageEvent:
     # clarify resolvers) BEFORE normal dispatch; native adapters never set it
     # (their button callbacks resolve in-process).
     prompt_response: Optional[Dict[str, Any]] = None
+    suppress_reply_anchor: bool = False  # Send without platform-native reply anchoring.
     
     # Auto-loaded skill(s) for topic/channel bindings (e.g., Telegram DM Topics,
     # Discord channel_skill_bindings).  A single name or ordered list.
@@ -2208,6 +2236,8 @@ def merge_pending_message_event(
         ):
             if event.text:
                 existing.text = f"{existing.text}\n{event.text}" if existing.text else event.text
+            if getattr(event, "suppress_reply_anchor", False):
+                existing.suppress_reply_anchor = True
             return
 
     pending_messages[session_key] = event
@@ -4554,6 +4584,8 @@ class BasePlatformAdapter(ABC):
                 state.event.message_id = str(latest_message_id)
             if latest_anchor is not None and hasattr(state.event, "reply_to_message_id"):
                 state.event.reply_to_message_id = str(latest_anchor)
+            if getattr(event, "suppress_reply_anchor", False):
+                state.event.suppress_reply_anchor = True
             state.last_ts = now
 
         if state.task is not None and not state.task.done():

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -201,6 +201,11 @@ def _gateway_surface_passes_raw_text(platform: Any) -> bool:
     return _gateway_platform_value(platform) in _GATEWAY_RAW_TEXT_PLATFORMS
 
 
+_GATEWAY_BENIGN_STATUS_RE = re.compile(
+    r"codex\s+gpt-5\.5\s+caps\s+context.+auto-compaction\s+was\s+raised.+compression\.codex_gpt55_autoraise",
+    re.IGNORECASE | re.DOTALL,
+)
+
 _GATEWAY_PROVIDER_ERROR_RE = re.compile(
     r"("  # infrastructure/provider error preambles, not ordinary assistant prose
     r"api\s+(?:call\s+)?failed"
@@ -571,6 +576,8 @@ def _prepare_gateway_status_message(platform: Any, event_type: str, message: str
         return None
     if _gateway_surface_passes_raw_text(platform):
         return text
+    if event_type == "lifecycle" and _GATEWAY_BENIGN_STATUS_RE.search(text):
+        return None
 
     text = _redact_gateway_user_facing_secrets(text)
     if _TELEGRAM_NOISY_STATUS_RE.search(text):
@@ -6116,13 +6123,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             await adapter._send_with_retry(
                 chat_id=event.source.chat_id,
                 content=message,
-                reply_to=(
-                    reply_anchor
-                    if event.source.platform == Platform.TELEGRAM
-                    and event.source.chat_type == "dm"
-                    and event.source.thread_id
-                    else (None if event.source.platform == Platform.TELEGRAM and event.source.thread_id else event.message_id)
-                ),
+                reply_to=self._status_reply_to_for_event(event, reply_anchor),
                 metadata=thread_meta,
             )
             return True
@@ -6496,13 +6497,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             await adapter._send_with_retry(
                 chat_id=event.source.chat_id,
                 content=message,
-                reply_to=(
-                    reply_anchor
-                    if event.source.platform == Platform.TELEGRAM
-                    and event.source.chat_type == "dm"
-                    and event.source.thread_id
-                    else (None if event.source.platform == Platform.TELEGRAM and event.source.thread_id else event.message_id)
-                ),
+                reply_to=self._status_reply_to_for_event(event, reply_anchor),
                 metadata=thread_meta,
             )
         except Exception as e:
@@ -16853,6 +16848,22 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
     def _reply_anchor_for_event(event: MessageEvent) -> Optional[str]:
         """Return the platform-specific reply anchor for GatewayRunner sends."""
         return _reply_anchor_for_event(event)
+
+    @staticmethod
+    def _status_reply_to_for_event(event: MessageEvent, reply_anchor: Optional[str]) -> Optional[str]:
+        """Return the reply target for status/ack sends.
+
+        Telegram non-DM topics route by metadata only; other platforms should
+        use the normalized reply anchor so adapter-specific suppression (for
+        example Feishu merge_forward) is respected.
+        """
+        if (
+            event.source.platform == Platform.TELEGRAM
+            and event.source.thread_id
+            and event.source.chat_type != "dm"
+        ):
+            return None
+        return reply_anchor
 
 
     # ------------------------------------------------------------------

--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -268,6 +268,9 @@ _FEISHU_REACTION_FAILURE = "CrossMark"
 # delete-failures, not a capacity plan.
 _FEISHU_PROCESSING_REACTION_CACHE_SIZE = 1024
 _FEISHU_MESSAGE_TEXT_CACHE_SIZE = 512       # LRU cap for reply-context message text lookups
+_MERGE_FORWARD_MAX_ITEMS = 20
+_MERGE_FORWARD_MAX_DEPTH = 2
+_MERGE_FORWARD_MAX_CHARS = 8000
 
 # QR onboarding constants
 _ONBOARD_ACCOUNTS_URLS = {
@@ -1030,6 +1033,77 @@ def _collect_forward_entries(payload: Dict[str, Any]) -> List[str]:
     return _unique_lines(entries)
 
 
+def _read_feishu_field(value: Any, *names: str, default: Any = None) -> Any:
+    for name in names:
+        if isinstance(value, dict) and name in value:
+            return value.get(name)
+        if hasattr(value, name):
+            return getattr(value, name)
+    return default
+
+
+def _read_feishu_body_content(item: Any) -> str:
+    body = _read_feishu_field(item, "body")
+    content = _read_feishu_field(body, "content", default="")
+    return str(content or "")
+
+
+def _read_feishu_sender_label(item: Any) -> str:
+    sender = _read_feishu_field(item, "sender")
+    return _first_non_empty_text(
+        _read_feishu_field(sender, "sender_name", "name"),
+        _read_feishu_field(item, "sender_name", "user_name", "name"),
+        _read_feishu_field(sender, "id"),
+    )
+
+
+def _read_feishu_message_id(item: Any) -> str:
+    return str(_read_feishu_field(item, "message_id", default="") or "").strip()
+
+
+def _read_feishu_message_type(item: Any) -> str:
+    return str(_read_feishu_field(item, "msg_type", "message_type", default="") or "").strip().lower()
+
+
+def _read_feishu_parent_id(item: Any, fallback_root_id: str) -> str:
+    return str(
+        _read_feishu_field(item, "upper_message_id", "parent_id", "root_id", default="")
+        or fallback_root_id
+    ).strip()
+
+
+def _read_feishu_mentions(item: Any) -> Optional[Sequence[Any]]:
+    mentions = _read_feishu_field(item, "mentions")
+    return mentions if isinstance(mentions, (list, tuple)) else None
+
+
+def _forward_sort_key(item: Any) -> int:
+    raw = str(_read_feishu_field(item, "create_time", default="") or "").strip()
+    try:
+        parsed = int(float(raw))
+    except (TypeError, ValueError):
+        return 0
+    return parsed * 1000 if parsed < 1_000_000_000_000 else parsed
+
+
+def _format_forward_timestamp(value: Any) -> str:
+    raw = str(value or "").strip()
+    if not raw:
+        return ""
+    try:
+        parsed = int(float(raw))
+    except (TypeError, ValueError):
+        return ""
+    # Feishu message APIs may return seconds or milliseconds depending on
+    # endpoint/version; normalize both to local wall-clock time for readability.
+    if parsed < 1_000_000_000_000:
+        parsed *= 1000
+    try:
+        return datetime.fromtimestamp(parsed / 1000).strftime("%H:%M")
+    except (OSError, ValueError):
+        return ""
+
+
 def _collect_card_lines(payload: Any) -> List[str]:
     lines = _collect_text_segments(payload, in_rich_block=False)
     normalized = [_normalize_feishu_text(line) for line in lines]
@@ -1494,6 +1568,7 @@ class FeishuAdapter(BasePlatformAdapter):
         self._sent_message_id_order: List[str] = []  # LRU order for _sent_message_ids_to_chat
         self._chat_info_cache: Dict[str, Dict[str, Any]] = {}
         self._message_text_cache: "OrderedDict[str, Optional[str]]" = OrderedDict()
+        self._message_type_cache: "OrderedDict[str, str]" = OrderedDict()
         self._app_lock_identity: Optional[str] = None
         self._text_batch_state = FeishuBatchState()
         self._pending_text_batches = self._text_batch_state.events
@@ -3293,14 +3368,30 @@ class FeishuAdapter(BasePlatformAdapter):
             if hint:
                 text = f"{hint}\n\n{text}" if text else hint
 
-        thread_id = getattr(message, "thread_id", None) or getattr(message, "root_id", None) or None
-        reply_to_message_id = (
-            getattr(message, "parent_id", None)
-            or getattr(message, "upper_message_id", None)
-            or getattr(message, "root_id", None)
-            or None
-        )
+        is_merge_forward = str(getattr(message, "message_type", "") or "").strip().lower() == "merge_forward"
+        if is_merge_forward:
+            # Feishu surfaces merge_forward internals through root/parent fields.
+            # Reusing those as reply anchors makes Hermes replies render inside
+            # the merged-forward container instead of the active chat.
+            thread_id = None
+            reply_to_message_id = None
+            suppress_reply_anchor = True
+        else:
+            thread_id = getattr(message, "thread_id", None) or getattr(message, "root_id", None) or None
+            reply_to_message_id = (
+                getattr(message, "parent_id", None)
+                or getattr(message, "upper_message_id", None)
+                or getattr(message, "root_id", None)
+                or None
+            )
+            suppress_reply_anchor = False
         reply_to_text = await self._fetch_message_text(reply_to_message_id) if reply_to_message_id else None
+        if (
+            reply_to_message_id
+            and self._cached_message_type(reply_to_message_id) == "merge_forward"
+        ):
+            thread_id = None
+            suppress_reply_anchor = True
 
         sender_primary = (
             getattr(sender_id, "open_id", None)
@@ -3344,6 +3435,7 @@ class FeishuAdapter(BasePlatformAdapter):
             reply_to_message_id=reply_to_message_id,
             reply_to_text=reply_to_text,
             channel_prompt=self._resolve_channel_prompt(chat_id, thread_id or None),
+            suppress_reply_anchor=suppress_reply_anchor,
             timestamp=datetime.now(),
         )
         await self._dispatch_inbound_event(normalized)
@@ -3689,9 +3781,22 @@ class FeishuAdapter(BasePlatformAdapter):
     @staticmethod
     def _text_batch_is_compatible(existing: MessageEvent, incoming: MessageEvent) -> bool:
         """Only merge text events when reply/thread context is identical."""
+        if FeishuAdapter._is_merge_forward_followup(existing, incoming):
+            return True
         return (
             existing.reply_to_message_id == incoming.reply_to_message_id
             and existing.reply_to_text == incoming.reply_to_text
+            and existing.source.thread_id == incoming.source.thread_id
+        )
+
+    @staticmethod
+    def _is_merge_forward_followup(existing: MessageEvent, incoming: MessageEvent) -> bool:
+        """Treat a prompt replying to a just-arrived merge_forward as one turn."""
+        return bool(
+            getattr(existing, "suppress_reply_anchor", False)
+            and getattr(incoming, "suppress_reply_anchor", False)
+            and incoming.reply_to_message_id
+            and incoming.reply_to_message_id == existing.message_id
             and existing.source.thread_id == incoming.source.thread_id
         )
 
@@ -3730,6 +3835,8 @@ class FeishuAdapter(BasePlatformAdapter):
         existing.timestamp = event.timestamp
         if event.message_id:
             existing.message_id = event.message_id
+        if getattr(event, "suppress_reply_anchor", False):
+            existing.suppress_reply_anchor = True
         self._pending_text_batch_counts[key] = next_count
         self._schedule_text_batch_flush(key)
 
@@ -3805,6 +3912,10 @@ class FeishuAdapter(BasePlatformAdapter):
             mentions=getattr(message, "mentions", None),
             bot=self._bot_identity(),
         )
+        if message_id and self._should_expand_merge_forward(normalized):
+            expanded = await self._try_expand_merge_forward_with_bot(message_id)
+            if expanded:
+                normalized = expanded
         media_urls, media_types = await self._download_feishu_message_resources(
             message_id=message_id,
             normalized=normalized,
@@ -4231,9 +4342,10 @@ class FeishuAdapter(BasePlatformAdapter):
             items = getattr(getattr(response, "data", None), "items", None) or []
             parent = items[0] if items else None
             body = getattr(parent, "body", None)
-            msg_type = getattr(parent, "msg_type", "") or ""
+            msg_type = _read_feishu_message_type(parent)
             raw_content = getattr(body, "content", "") or ""
             parent_mentions = getattr(parent, "mentions", None) if parent else None
+            self._remember_message_type(message_id, msg_type)
             text = self._extract_text_from_raw_content(
                 msg_type=msg_type,
                 raw_content=raw_content,
@@ -4246,6 +4358,148 @@ class FeishuAdapter(BasePlatformAdapter):
         except Exception:
             logger.warning("[Feishu] Failed to fetch parent message %s", message_id, exc_info=True)
             return None
+
+    def _remember_message_type(self, message_id: str, msg_type: str) -> None:
+        if not message_id or not msg_type:
+            return
+        cache = getattr(self, "_message_type_cache", None)
+        if cache is None:
+            cache = OrderedDict()
+            self._message_type_cache = cache
+        cache[message_id] = str(msg_type or "").strip().lower()
+        cache.move_to_end(message_id)
+        while len(cache) > _FEISHU_MESSAGE_TEXT_CACHE_SIZE:
+            cache.popitem(last=False)
+
+    def _cached_message_type(self, message_id: str) -> Optional[str]:
+        cache = getattr(self, "_message_type_cache", None)
+        if cache is None or message_id not in cache:
+            return None
+        cache.move_to_end(message_id)
+        return cache[message_id]
+
+    async def _try_expand_merge_forward_with_bot(self, message_id: str) -> Optional[FeishuNormalizedMessage]:
+        if not getattr(self, "_client", None) or not message_id:
+            return None
+        try:
+            request = self._build_get_message_request(message_id)
+            response = await self._run_blocking(self._client.im.v1.message.get, request)
+            if not response or getattr(response, "success", lambda: False)() is False:
+                code = getattr(response, "code", "unknown")
+                msg = getattr(response, "msg", "message lookup failed")
+                logger.warning("[Feishu] Failed to expand merge_forward %s: [%s] %s", message_id, code, msg)
+                return self._merge_forward_expand_failure(f"[{code}] {msg}")
+            items = list(getattr(getattr(response, "data", None), "items", None) or [])
+            expanded = self._render_expanded_merge_forward(items, root_message_id=message_id)
+            if not expanded:
+                logger.warning("[Feishu] merge_forward %s expansion returned no children", message_id)
+                return self._merge_forward_expand_failure("empty")
+            return FeishuNormalizedMessage(
+                raw_type="merge_forward",
+                text_content=expanded,
+                relation_kind="merge_forward",
+                metadata={"expanded": True, "source": "bot"},
+            )
+        except Exception as exc:
+            logger.warning("[Feishu] Failed to expand merge_forward %s", message_id, exc_info=True)
+            return self._merge_forward_expand_failure(exc.__class__.__name__)
+
+    def _render_expanded_merge_forward(self, items: Sequence[Any], *, root_message_id: str) -> str:
+        if not items:
+            return ""
+        parent = items[0]
+        root_id = _read_feishu_message_id(parent) or root_message_id
+        children_by_parent: Dict[str, List[Any]] = {}
+        for item in items:
+            item_id = _read_feishu_message_id(item)
+            parent_id = _read_feishu_parent_id(item, root_id)
+            if item_id == root_id and parent_id == root_id:
+                continue
+            if item_id and parent_id == item_id:
+                parent_id = root_id
+            children_by_parent.setdefault(parent_id, []).append(item)
+
+        for children in children_by_parent.values():
+            children.sort(key=_forward_sort_key)
+
+        lines: List[str] = [FALLBACK_FORWARD_TEXT, ""]
+        count = 0
+        truncated = False
+
+        def render_children(parent_id: str, depth: int) -> List[str]:
+            nonlocal count, truncated
+            rendered: List[str] = []
+            if depth > _MERGE_FORWARD_MAX_DEPTH:
+                truncated = True
+                return rendered
+            for item in children_by_parent.get(parent_id, []):
+                if count >= _MERGE_FORWARD_MAX_ITEMS:
+                    truncated = True
+                    break
+                count += 1
+                sender = _read_feishu_sender_label(item) or "Unknown"
+                timestamp = _format_forward_timestamp(_read_feishu_field(item, "create_time"))
+                header = f"{count}. {sender}{f' {timestamp}' if timestamp else ''}"
+                body = self._render_forward_item_body(item, depth=depth)
+                if not body:
+                    body = f"[{_read_feishu_message_type(item) or 'message'}]"
+                indented = "\n".join(f"   {line}" for line in body.splitlines() if line.strip())
+                rendered.append(f"{header}\n{indented}")
+                child_id = _read_feishu_message_id(item)
+                if child_id and _read_feishu_message_type(item) == "merge_forward":
+                    rendered.extend(render_children(child_id, depth + 1))
+            return rendered
+
+        lines.extend(render_children(root_id, 0))
+        if truncated:
+            lines.append("... (truncated)")
+        rendered_text = "\n\n".join(part for part in lines if part).strip()
+        if len(rendered_text) > _MERGE_FORWARD_MAX_CHARS:
+            return rendered_text[:_MERGE_FORWARD_MAX_CHARS].rstrip() + "\n... (truncated)"
+        return rendered_text
+
+    def _render_forward_item_body(self, item: Any, *, depth: int) -> str:
+        msg_type = _read_feishu_message_type(item)
+        if msg_type == "merge_forward":
+            if depth >= _MERGE_FORWARD_MAX_DEPTH:
+                return FALLBACK_FORWARD_TEXT
+            title = self._extract_text_from_raw_content(
+                msg_type=msg_type,
+                raw_content=_read_feishu_body_content(item),
+                mentions=_read_feishu_mentions(item),
+            )
+            return title or FALLBACK_FORWARD_TEXT
+        text = self._extract_text_from_raw_content(
+            msg_type=msg_type,
+            raw_content=_read_feishu_body_content(item),
+            mentions=_read_feishu_mentions(item),
+        )
+        if text:
+            return text
+        if msg_type == "image":
+            return FALLBACK_IMAGE_TEXT
+        if msg_type in {"file", "audio", "media"}:
+            return FALLBACK_ATTACHMENT_TEXT
+        return ""
+
+    @staticmethod
+    def _merge_forward_expand_failure(reason: str) -> FeishuNormalizedMessage:
+        safe_reason = _normalize_feishu_text(str(reason or "unknown"))[:160] or "unknown"
+        return FeishuNormalizedMessage(
+            raw_type="merge_forward",
+            text_content=f"{FALLBACK_FORWARD_TEXT}\n(failed to expand: {safe_reason})",
+            relation_kind="merge_forward",
+            metadata={"expanded": False, "error": safe_reason},
+        )
+
+    @staticmethod
+    def _should_expand_merge_forward(normalized: FeishuNormalizedMessage) -> bool:
+        if normalized.raw_type != "merge_forward":
+            return False
+        metadata = normalized.metadata if isinstance(normalized.metadata, dict) else {}
+        entry_count = metadata.get("entry_count")
+        text = (normalized.text_content or "").strip()
+        return text == FALLBACK_FORWARD_TEXT or entry_count == 0
 
     def _extract_text_from_raw_content(
         self,

--- a/tests/gateway/test_busy_session_ack.py
+++ b/tests/gateway/test_busy_session_ack.py
@@ -260,6 +260,39 @@ class TestBusySessionAck:
         assert adapter._pending_messages[sk].media_urls == event.media_urls
 
     @pytest.mark.asyncio
+    async def test_feishu_busy_ack_respects_suppressed_reply_anchor(self):
+        """Feishu merge_forward follow-ups must not get status acks inside the card."""
+        runner, _sentinel = _make_runner()
+        runner._busy_input_mode = "interrupt"
+        adapter = _make_adapter("feishu")
+        source = SessionSource(
+            platform=Platform.FEISHU,
+            chat_id="oc_chat",
+            chat_type="dm",
+            user_id="ou_user",
+        )
+        event = MessageEvent(
+            text="能识别吗",
+            message_type=MessageType.TEXT,
+            source=source,
+            message_id="om_text",
+            suppress_reply_anchor=True,
+        )
+        sk = build_session_key(event.source)
+
+        agent = MagicMock()
+        agent.get_activity_summary.return_value = {"seconds_since_activity": 1.0}
+        runner._running_agents[sk] = agent
+        runner._running_agents_ts[sk] = time.time()
+        runner.adapters[event.source.platform] = adapter
+
+        await runner._handle_active_session_busy_message(event, sk)
+
+        adapter._send_with_retry.assert_called_once()
+        assert adapter._send_with_retry.call_args.kwargs["reply_to"] is None
+        agent.interrupt.assert_called_once_with("能识别吗")
+
+    @pytest.mark.asyncio
     async def test_queue_mode_suppresses_interrupt_and_updates_ack(self):
         """When busy_input_mode is 'queue', message is queued WITHOUT interrupt."""
         runner, sentinel = _make_runner()

--- a/tests/gateway/test_feishu.py
+++ b/tests/gateway/test_feishu.py
@@ -1396,6 +1396,163 @@ class TestAdapterBehavior(unittest.TestCase):
         self.assertEqual(media_types, [])
 
     @patch.dict(os.environ, {}, clear=True)
+    def test_extract_merge_forward_placeholder_expands_with_bot_fetch(self):
+        from gateway.config import PlatformConfig
+        from plugins.platforms.feishu.adapter import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+        adapter._client = Mock()
+        request = object()
+        adapter._build_get_message_request = Mock(return_value=request)
+        response = Mock()
+        response.success = Mock(return_value=True)
+        response.data = SimpleNamespace(
+            items=[
+                SimpleNamespace(
+                    message_id="om_merge_forward",
+                    msg_type="merge_forward",
+                    body=SimpleNamespace(content="{}"),
+                    create_time="1700000000000",
+                    sender=SimpleNamespace(id="ou_sender", name="Sender"),
+                ),
+                SimpleNamespace(
+                    message_id="om_child_1",
+                    upper_message_id="om_merge_forward",
+                    msg_type="text",
+                    body=SimpleNamespace(content=json.dumps({"text": "第一条内容"})),
+                    create_time="1700000001000",
+                    sender=SimpleNamespace(id="ou_alice", name="Alice"),
+                ),
+                SimpleNamespace(
+                    message_id="om_child_2",
+                    upper_message_id="om_merge_forward",
+                    msg_type="post",
+                    body=SimpleNamespace(
+                        content=json.dumps({"zh_cn": {"content": [[{"tag": "text", "text": "第二条富文本"}]]}})
+                    ),
+                    create_time="1700000002000",
+                    sender=SimpleNamespace(id="ou_bob", name="Bob"),
+                ),
+            ]
+        )
+        message_get = Mock()
+        adapter._client.im.v1.message.get = message_get
+        adapter._run_blocking = AsyncMock(return_value=response)
+        message = SimpleNamespace(
+            message_type="merge_forward",
+            content="{}",
+            message_id="om_merge_forward",
+        )
+
+        text, msg_type, media_urls, media_types, _mentions = asyncio.run(adapter._extract_message_content(message))
+
+        self.assertIn("[Merged forward message]", text)
+        self.assertIn("1. Alice", text)
+        self.assertIn("第一条内容", text)
+        self.assertIn("2. Bob", text)
+        self.assertIn("第二条富文本", text)
+        self.assertEqual(msg_type.value, "text")
+        self.assertEqual(media_urls, [])
+        self.assertEqual(media_types, [])
+        adapter._run_blocking.assert_awaited_once_with(message_get, request)
+        message_get.assert_not_called()
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_extract_merge_forward_expands_interactive_child_card(self):
+        from gateway.config import PlatformConfig
+        from plugins.platforms.feishu.adapter import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+        adapter._client = Mock()
+        adapter._build_get_message_request = Mock(return_value=object())
+        response = Mock()
+        response.success = Mock(return_value=True)
+        response.data = SimpleNamespace(
+            items=[
+                SimpleNamespace(
+                    message_id="om_merge_forward",
+                    msg_type="merge_forward",
+                    body=SimpleNamespace(content="{}"),
+                    create_time="1700000000000",
+                    sender=SimpleNamespace(id="ou_sender"),
+                ),
+                SimpleNamespace(
+                    message_id="om_card",
+                    upper_message_id="om_merge_forward",
+                    msg_type="interactive",
+                    body=SimpleNamespace(
+                        content=json.dumps(
+                            {
+                                "card": {
+                                    "header": {"title": {"tag": "plain_text", "content": "Approval"}},
+                                    "elements": [
+                                        {
+                                            "tag": "div",
+                                            "text": {"tag": "plain_text", "content": "Requester: Alice"},
+                                        },
+                                        {
+                                            "tag": "action",
+                                            "actions": [
+                                                {
+                                                    "tag": "button",
+                                                    "text": {"tag": "plain_text", "content": "Approve"},
+                                                }
+                                            ],
+                                        },
+                                    ],
+                                }
+                            }
+                        )
+                    ),
+                    create_time="1700000001000",
+                    sender=SimpleNamespace(id="ou_argos", name="Argos"),
+                ),
+            ]
+        )
+        adapter._client.im.v1.message.get = Mock(return_value=response)
+        message = SimpleNamespace(
+            message_type="merge_forward",
+            content="{}",
+            message_id="om_merge_forward",
+        )
+
+        text, msg_type, _media_urls, _media_types, _mentions = asyncio.run(adapter._extract_message_content(message))
+
+        self.assertIn("Argos", text)
+        self.assertIn("Approval", text)
+        self.assertIn("Requester: Alice", text)
+        self.assertIn("Actions: Approve", text)
+        self.assertEqual(msg_type.value, "text")
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_extract_merge_forward_fetch_failure_keeps_readable_fallback(self):
+        from gateway.config import PlatformConfig
+        from plugins.platforms.feishu.adapter import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+        adapter._client = Mock()
+        adapter._build_get_message_request = Mock(return_value=object())
+        response = Mock()
+        response.success = Mock(return_value=False)
+        response.code = 99991663
+        response.msg = "missing scope"
+        adapter._client.im.v1.message.get = Mock(return_value=response)
+        message = SimpleNamespace(
+            message_type="merge_forward",
+            content="{}",
+            message_id="om_merge_forward",
+        )
+
+        text, msg_type, media_urls, media_types, _mentions = asyncio.run(adapter._extract_message_content(message))
+
+        self.assertIn("[Merged forward message]", text)
+        self.assertIn("failed to expand", text)
+        self.assertIn("missing scope", text)
+        self.assertEqual(msg_type.value, "text")
+        self.assertEqual(media_urls, [])
+        self.assertEqual(media_types, [])
+
+    @patch.dict(os.environ, {}, clear=True)
     def test_extract_share_chat_message_as_text_summary(self):
         from gateway.config import PlatformConfig
         from plugins.platforms.feishu.adapter import FeishuAdapter
@@ -1807,6 +1964,70 @@ class TestAdapterBehavior(unittest.TestCase):
         event = adapter.handle_message.await_args.args[0]
         self.assertEqual(event.text, "A\nB")
         self.assertEqual(event.message_type, MessageType.TEXT)
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_text_batch_merges_merge_forward_with_followup_reply(self):
+        from gateway.config import PlatformConfig
+        from gateway.platforms.base import MessageEvent, MessageType
+        from plugins.platforms.feishu.adapter import FeishuAdapter
+        from gateway.session import SessionSource
+
+        adapter = FeishuAdapter(PlatformConfig())
+        adapter.handle_message = AsyncMock()
+        source = SessionSource(
+            platform=adapter.platform,
+            chat_id="oc_chat",
+            chat_name="Feishu DM",
+            chat_type="dm",
+            user_id="ou_user",
+            user_name="张三",
+        )
+
+        async def _sleep(_delay):
+            return None
+
+        async def _run() -> None:
+            with patch("plugins.platforms.feishu.adapter.asyncio.sleep", side_effect=_sleep):
+                await adapter._dispatch_inbound_event(
+                    MessageEvent(
+                        text="[Merged forward message]\n\n1. Alice\n   成本 ok 了",
+                        message_type=MessageType.TEXT,
+                        source=source,
+                        raw_message=SimpleNamespace(
+                            event=SimpleNamespace(
+                                message=SimpleNamespace(message_type="merge_forward")
+                            )
+                        ),
+                        message_id="om_merge",
+                        suppress_reply_anchor=True,
+                    )
+                )
+                await adapter._dispatch_inbound_event(
+                    MessageEvent(
+                        text="能识别吗",
+                        message_type=MessageType.TEXT,
+                        source=source,
+                        message_id="om_text",
+                        reply_to_message_id="om_merge",
+                        reply_to_text="[Merged forward message]\n\n1. Alice\n   成本 ok 了",
+                        suppress_reply_anchor=True,
+                    )
+                )
+                pending = list(adapter._pending_text_batch_tasks.values())
+                self.assertEqual(len(pending), 1)
+                await asyncio.gather(*pending, return_exceptions=True)
+
+        asyncio.run(_run())
+
+        adapter.handle_message.assert_awaited_once()
+        event = adapter.handle_message.await_args.args[0]
+        self.assertEqual(
+            event.text,
+            "[Merged forward message]\n\n1. Alice\n   成本 ok 了\n能识别吗",
+        )
+        self.assertEqual(event.message_id, "om_text")
+        self.assertIsNone(event.reply_to_message_id)
+        self.assertTrue(event.suppress_reply_anchor)
 
     @patch.dict(
         os.environ,
@@ -4780,6 +5001,7 @@ class TestFeishuProcessInboundMessage(unittest.TestCase):
         adapter._bot_name = "Hermes"
         adapter._download_feishu_message_resources = AsyncMock(return_value=([], []))
         adapter._fetch_message_text = AsyncMock(return_value=None)
+        adapter._message_type_cache = OrderedDict()
         adapter.get_chat_info = AsyncMock(return_value={"name": "Test Chat"})
         adapter._resolve_sender_profile = AsyncMock(
             return_value={"user_id": "u1", "user_name": "Alice", "user_id_alt": None}
@@ -5242,6 +5464,105 @@ class TestFeishuMentionEndToEnd(unittest.TestCase):
         # Body: leading @Hermes stripped, Alice preserved, trailing text intact.
         self.assertIn("@Alice review the spec with Alice", event.text)
         self.assertNotIn("@Hermes @Alice", event.text)
+
+    def test_merge_forward_does_not_inherit_thread_or_reply_anchor(self):
+        adapter = self._build_adapter()
+        message = SimpleNamespace(
+            content="{}",
+            message_type="merge_forward",
+            message_id="om_merge",
+            mentions=[],
+            chat_id="oc_chat",
+            parent_id="om_parent_inside_merge",
+            upper_message_id="om_upper_inside_merge",
+            root_id="om_root_inside_merge",
+            thread_id="omt_inside_merge",
+        )
+        asyncio.run(
+            adapter._process_inbound_message(
+                data=SimpleNamespace(event=SimpleNamespace(message=message)),
+                message=message,
+                sender_id=SimpleNamespace(open_id="ou_user", user_id=None, union_id=None),
+                chat_type="group",
+                message_id="om_merge",
+            )
+        )
+
+        adapter.build_source.assert_called_once()
+        self.assertIsNone(adapter.build_source.call_args.kwargs["thread_id"])
+        adapter._fetch_message_text.assert_not_awaited()
+        event = adapter._dispatch_inbound_event.call_args.args[0]
+        self.assertEqual(event.message_id, "om_merge")
+        self.assertIsNone(event.source.thread_id)
+        self.assertIsNone(event.reply_to_message_id)
+        self.assertIsNone(event.reply_to_text)
+        self.assertTrue(event.suppress_reply_anchor)
+
+    def test_text_reply_to_merge_forward_parent_suppresses_reply_anchor(self):
+        from gateway.platforms.base import _reply_anchor_for_event
+
+        adapter = self._build_adapter()
+
+        async def fetch_parent_text(message_id):
+            adapter._remember_message_type(message_id, "merge_forward")
+            return "[Merged forward message]\n\n1. Alice\n   hello"
+
+        adapter._fetch_message_text = AsyncMock(side_effect=fetch_parent_text)
+        message = SimpleNamespace(
+            content=json.dumps({"text": "你能理解这个消息吗"}),
+            message_type="text",
+            message_id="om_text",
+            mentions=[],
+            chat_id="oc_chat",
+            parent_id="om_merge",
+            upper_message_id=None,
+            root_id="om_merge",
+            thread_id="omt_inside_merge",
+        )
+        asyncio.run(
+            adapter._process_inbound_message(
+                data=SimpleNamespace(event=SimpleNamespace(message=message)),
+                message=message,
+                sender_id=SimpleNamespace(open_id="ou_user", user_id=None, union_id=None),
+                chat_type="group",
+                message_id="om_text",
+            )
+        )
+
+        adapter.build_source.assert_called_once()
+        self.assertIsNone(adapter.build_source.call_args.kwargs["thread_id"])
+        event = adapter._dispatch_inbound_event.call_args.args[0]
+        self.assertEqual(event.message_id, "om_text")
+        self.assertEqual(event.reply_to_message_id, "om_merge")
+        self.assertIn("[Merged forward message]", event.reply_to_text)
+        self.assertTrue(event.suppress_reply_anchor)
+        self.assertIsNone(_reply_anchor_for_event(event))
+
+    def test_reply_anchor_omits_feishu_merge_forward_message_id(self):
+        from gateway.config import Platform
+        from gateway.platforms.base import MessageEvent, MessageType, _reply_anchor_for_event
+
+        source = SimpleNamespace(platform=Platform.FEISHU, thread_id=None, chat_type="group")
+        raw_message = SimpleNamespace(message_type="merge_forward")
+        event = MessageEvent(
+            text="[Merged forward message]",
+            message_type=MessageType.TEXT,
+            source=source,
+            raw_message=SimpleNamespace(event=SimpleNamespace(message=raw_message)),
+            message_id="om_merge",
+        )
+
+        self.assertIsNone(_reply_anchor_for_event(event))
+
+        raw_text = SimpleNamespace(message_type="text")
+        normal_event = MessageEvent(
+            text="hello",
+            message_type=MessageType.TEXT,
+            source=source,
+            raw_message=SimpleNamespace(event=SimpleNamespace(message=raw_text)),
+            message_id="om_text",
+        )
+        self.assertEqual(_reply_anchor_for_event(normal_event), "om_text")
 
 
 class TestChatLockEviction(unittest.TestCase):

--- a/tests/gateway/test_telegram_noise_filter.py
+++ b/tests/gateway/test_telegram_noise_filter.py
@@ -263,6 +263,18 @@ def test_chat_gateways_drop_interrupt_sentinel(platform):
     assert _sanitize_gateway_final_response("local", sentinel) == sentinel
 
 
+def test_codex_gpt55_autoraise_notice_is_not_sent_to_gateway_chats():
+    """One-time local configuration notices should not appear as IM replies."""
+    message = (
+        "ℹ Codex gpt-5.5 caps context at 272K, so auto-compaction was raised "
+        "to 85% (from 50%) to use more of the window before summarizing.\n"
+        "  Opt back out: hermes config set compression.codex_gpt55_autoraise false"
+    )
+
+    assert _prepare_gateway_status_message(Platform.FEISHU, "lifecycle", message) is None
+    assert _prepare_gateway_status_message(Platform.DISCORD, "lifecycle", message) is None
+
+
 def test_telegram_status_sanitizes_raw_provider_security_errors():
     """Provider policy/security bodies should be replaced before chat delivery."""
     raw = (


### PR DESCRIPTION
## Summary
- expand Feishu merge_forward placeholders via bot-side message fetches with readable fallback
- keep merge_forward cards and follow-up prompts in one gateway turn, without replying inside the Feishu card
- suppress the Codex gpt-5.5 auto-raise lifecycle notice from messaging chats

## Tests
- ./scripts/run_tests.sh tests/gateway/test_feishu.py
- ./scripts/run_tests.sh tests/gateway/test_busy_session_ack.py tests/gateway/test_telegram_noise_filter.py
- git diff --check