### PR TITLE
feat(delegation): per-agent model assignment for delegate_task

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -952,10 +952,36 @@ delegation:
                                               # The parent TUI owns stdin, so blocking would deadlock; non-interactive resolution is required.
                                               # Both choices emit a logger.warning audit line. Flip to true only for cron/batch pipelines.
   # inherit_mcp_toolsets: true                # When explicit child toolsets are narrowed, also keep the parent's MCP toolsets (default: true). Set false for strict intersection.
-  # model: "google/gemini-3-flash-preview"    # Override model for subagents (empty = inherit parent)
-  # provider: "openrouter"                    # Override provider for subagents (empty = inherit parent)
+  # model: "google/gemini-3-flash-preview"    # Default model for subagents (empty = inherit parent)
+  # provider: "openrouter"                    # Default provider for subagents (empty = inherit parent)
   #                                           # Resolves full credentials (base_url, api_key) automatically.
   #                                           # Supported: openrouter, nous, zai, kimi-coding, minimax
+  # ---------------------------------------------------------------------------
+  # Per-subagent model assignment (assign DIFFERENT models to DIFFERENT subagents)
+  # ---------------------------------------------------------------------------
+  # `model`/`provider` above are the single default applied to every subagent.
+  # To give distinct subagents distinct models there are two mechanisms:
+  #
+  #   1. Runtime (agent-chosen): the orchestrating agent passes a per-task
+  #      `model` (and optionally `provider`) in a delegate_task batch — e.g.
+  #      task A -> a capable model, task B -> a small model. No config needed.
+  #
+  #   2. Human-config (operator-assigned): define NAMED model profiles here and
+  #      have the agent reference them per task by `model_profile`. You control
+  #      which model each profile maps to; the agent only picks the profile by
+  #      intent. A bare profile value is shorthand for {model: "<id>"}.
+  #
+  # A per-task model that omits provider/base_url runs on the SAME endpoint as
+  # the active delegation/parent credentials (just a different model id) — ideal
+  # for several models served from one provider (e.g. NVIDIA NIM). Set provider
+  # or base_url in a profile to route a subagent to a different provider.
+  #
+  # models:
+  #   research:  { model: "nvidia/nemotron-3-super-120b-a12b" }   # capable
+  #   summarize: { model: "nvidia/nemotron-3-nano-30b-a3b" }        # small/fast
+  #   cheap:     { model: "google/gemini-3-flash-preview", provider: "openrouter" }  # cross-provider
+  #   # shorthand string form (model id only):
+  #   draft: "nvidia/nemotron-3-nano-30b-a3b"
 
 # =============================================================================
 # Honcho Integration (Cross-Session User Modeling)

--- a/run_agent.py
+++ b/run_agent.py
@@ -5237,6 +5237,9 @@ class AIAgent:
             acp_args=function_args.get("acp_args"),
             role=function_args.get("role"),
             background=(not _is_subagent),
+            model=function_args.get("model"),
+            provider=function_args.get("provider"),
+            model_profile=function_args.get("model_profile"),
             parent_agent=self,
         )
 

--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -32,6 +32,8 @@ from tools.delegate_tool import (
     _strip_blocked_tools,
     _resolve_child_credential_pool,
     _resolve_delegation_credentials,
+    _normalize_model_profiles,
+    _resolve_task_credentials,
 )
 
 
@@ -2793,6 +2795,458 @@ class TestFallbackModelInheritance(unittest.TestCase):
 
         _, kwargs = MockAgent.call_args
         self.assertIsNone(kwargs["fallback_model"])
+
+
+# A NIM-style global credential bundle: two models served from one endpoint.
+# Mirrors what _resolve_delegation_credentials returns for a direct base_url.
+_NIM_GLOBAL_CREDS = {
+    "model": "nvidia/nemotron-3-nano-30b-a3b",
+    "provider": "custom",
+    "base_url": "https://nim.example/v1",
+    "api_key": "nim-key",
+    "api_mode": "chat_completions",
+}
+_EMPTY_CREDS = {
+    "model": None,
+    "provider": None,
+    "base_url": None,
+    "api_key": None,
+    "api_mode": None,
+}
+_SUPER = "nvidia/nemotron-3-super-120b-a12b"
+_NANO = "nvidia/nemotron-3-nano-30b-a3b"
+
+
+class TestModelProfileNormalization(unittest.TestCase):
+    """Unit tests for _normalize_model_profiles (delegation.models parsing)."""
+
+    def test_mapping_form(self):
+        cfg = {"models": {"research": {"model": _SUPER, "provider": "nvidia"}}}
+        out = _normalize_model_profiles(cfg)
+        self.assertEqual(out["research"]["model"], _SUPER)
+        self.assertEqual(out["research"]["provider"], "nvidia")
+
+    def test_string_shorthand_expands_to_model(self):
+        cfg = {"models": {"summarize": _NANO}}
+        out = _normalize_model_profiles(cfg)
+        self.assertEqual(out, {"summarize": {"model": _NANO}})
+
+    def test_invalid_shapes_skipped(self):
+        cfg = {"models": {"good": _NANO, "bad": 123, "": "x", "obj": {"model": "y"}}}
+        out = _normalize_model_profiles(cfg)
+        self.assertEqual(set(out), {"good", "obj"})
+
+    def test_no_models_key_returns_empty(self):
+        self.assertEqual(_normalize_model_profiles({}), {})
+        self.assertEqual(_normalize_model_profiles({"models": "nonsense"}), {})
+
+
+class TestResolveTaskCredentials(unittest.TestCase):
+    """Unit tests for per-task model/provider/profile credential resolution."""
+
+    def test_model_only_swap_keeps_global_endpoint(self):
+        """A bare per-task model keeps the global endpoint/key — same NIM
+        endpoint, different model (the motivating multi-specialty case)."""
+        r = _resolve_task_credentials(
+            task={"goal": "x", "model": _SUPER},
+            top_model=None, top_provider=None, top_profile=None,
+            global_creds=_NIM_GLOBAL_CREDS, cfg={}, parent_agent=None,
+        )
+        self.assertEqual(r["model"], _SUPER)
+        self.assertEqual(r["base_url"], _NIM_GLOBAL_CREDS["base_url"])
+        self.assertEqual(r["api_key"], _NIM_GLOBAL_CREDS["api_key"])
+        self.assertEqual(r["provider"], _NIM_GLOBAL_CREDS["provider"])
+
+    def test_no_override_returns_global_bundle_unchanged(self):
+        r = _resolve_task_credentials(
+            task={"goal": "x"},
+            top_model=None, top_provider=None, top_profile=None,
+            global_creds=_NIM_GLOBAL_CREDS, cfg={}, parent_agent=None,
+        )
+        self.assertEqual(r, _NIM_GLOBAL_CREDS)
+
+    def test_model_only_with_empty_global_defers_to_parent(self):
+        """With no global delegation config, a per-task model swaps the model
+        but leaves credentials None so _build_child_agent inherits the parent's
+        endpoint/key — the runtime fallback path."""
+        r = _resolve_task_credentials(
+            task={"goal": "x", "model": _SUPER},
+            top_model=None, top_provider=None, top_profile=None,
+            global_creds=_EMPTY_CREDS, cfg={}, parent_agent=None,
+        )
+        self.assertEqual(r["model"], _SUPER)
+        self.assertIsNone(r["provider"])
+        self.assertIsNone(r["base_url"])
+        self.assertIsNone(r["api_key"])
+
+    def test_profile_mapping_form(self):
+        cfg = {"models": {"research": {"model": _SUPER}}}
+        r = _resolve_task_credentials(
+            task={"goal": "x", "model_profile": "research"},
+            top_model=None, top_provider=None, top_profile=None,
+            global_creds=_NIM_GLOBAL_CREDS, cfg=cfg, parent_agent=None,
+        )
+        self.assertEqual(r["model"], _SUPER)
+        self.assertEqual(r["base_url"], _NIM_GLOBAL_CREDS["base_url"])
+
+    def test_profile_string_form(self):
+        cfg = {"models": {"summarize": _NANO}}
+        r = _resolve_task_credentials(
+            task={"goal": "x", "model_profile": "summarize"},
+            top_model=None, top_provider=None, top_profile=None,
+            global_creds=_NIM_GLOBAL_CREDS, cfg=cfg, parent_agent=None,
+        )
+        self.assertEqual(r["model"], _NANO)
+
+    def test_precedence_task_beats_top_beats_profile(self):
+        cfg = {"models": {"research": {"model": _SUPER}}}
+        # explicit per-task model wins over top-level and profile
+        r = _resolve_task_credentials(
+            task={"goal": "x", "model": "explicit-win"},
+            top_model="top-model", top_provider=None, top_profile="research",
+            global_creds=_NIM_GLOBAL_CREDS, cfg=cfg, parent_agent=None,
+        )
+        self.assertEqual(r["model"], "explicit-win")
+        # top-level beats profile when no per-task model
+        r = _resolve_task_credentials(
+            task={"goal": "x"},
+            top_model="top-model", top_provider=None, top_profile="research",
+            global_creds=_NIM_GLOBAL_CREDS, cfg=cfg, parent_agent=None,
+        )
+        self.assertEqual(r["model"], "top-model")
+
+    def test_unknown_profile_raises_valueerror(self):
+        cfg = {"models": {"research": {"model": _SUPER}}}
+        with self.assertRaises(ValueError) as ctx:
+            _resolve_task_credentials(
+                task={"goal": "x", "model_profile": "nope"},
+                top_model=None, top_provider=None, top_profile=None,
+                global_creds=_NIM_GLOBAL_CREDS, cfg=cfg, parent_agent=None,
+            )
+        msg = str(ctx.exception)
+        self.assertIn("nope", msg)
+        self.assertIn("research", msg)  # lists available profiles
+
+    @patch("tools.delegate_tool._resolve_delegation_credentials")
+    def test_provider_override_triggers_full_resolution(self, mock_resolve):
+        """A per-task provider re-resolves the full bundle via the same path
+        the global delegation.provider uses (cross-provider per task)."""
+        mock_resolve.return_value = {
+            "model": "google/gemini-3-flash-preview",
+            "provider": "openrouter",
+            "base_url": "https://openrouter.ai/api/v1",
+            "api_key": "sk-or",
+            "api_mode": "chat_completions",
+        }
+        r = _resolve_task_credentials(
+            task={"goal": "x", "provider": "openrouter", "model": "google/gemini-3-flash-preview"},
+            top_model=None, top_provider=None, top_profile=None,
+            global_creds=_NIM_GLOBAL_CREDS, cfg={}, parent_agent=None,
+        )
+        mock_resolve.assert_called_once()
+        synthetic_cfg = mock_resolve.call_args[0][0]
+        self.assertEqual(synthetic_cfg["provider"], "openrouter")
+        self.assertEqual(synthetic_cfg["model"], "google/gemini-3-flash-preview")
+        self.assertEqual(r["base_url"], "https://openrouter.ai/api/v1")
+        self.assertEqual(r["provider"], "openrouter")
+
+
+class TestPerTaskModelAssignment(unittest.TestCase):
+    """Integration: delegate_task assigns distinct models to distinct children.
+
+    Both halves of the requirement:
+      * runtime  — orchestrator passes per-task `model`
+      * human-config — operator defines delegation.models profiles
+    Each child is built with its own resolved credential bundle.
+    """
+
+    @patch("tools.delegate_tool._load_config", return_value={})
+    @patch("tools.delegate_tool._resolve_delegation_credentials")
+    @patch("tools.delegate_tool._run_single_child")
+    @patch("tools.delegate_tool._build_child_agent")
+    def test_runtime_batch_per_task_models(self, mock_build, mock_run, mock_creds, mock_cfg):
+        """task A -> super, task B -> nano in one batch."""
+        mock_creds.return_value = dict(_NIM_GLOBAL_CREDS)
+        mock_run.return_value = {
+            "task_index": 0, "status": "completed", "summary": "ok",
+            "api_calls": 1, "duration_seconds": 1.0,
+        }
+        mock_build.return_value = MagicMock()
+        parent = _make_mock_parent()
+
+        delegate_task(
+            tasks=[
+                {"goal": "deep research", "model": _SUPER},
+                {"goal": "quick summary", "model": _NANO},
+            ],
+            parent_agent=parent,
+        )
+
+        self.assertEqual(mock_build.call_count, 2)
+        models = [c.kwargs["model"] for c in mock_build.call_args_list]
+        self.assertEqual(models, [_SUPER, _NANO])
+        # Same endpoint, different model: the global base_url/api_key ride along.
+        for call in mock_build.call_args_list:
+            self.assertEqual(call.kwargs["override_base_url"], _NIM_GLOBAL_CREDS["base_url"])
+            self.assertEqual(call.kwargs["override_api_key"], _NIM_GLOBAL_CREDS["api_key"])
+
+    @patch("tools.delegate_tool._load_config")
+    @patch("tools.delegate_tool._resolve_delegation_credentials")
+    @patch("tools.delegate_tool._run_single_child")
+    @patch("tools.delegate_tool._build_child_agent")
+    def test_human_config_model_profiles(self, mock_build, mock_run, mock_creds, mock_cfg):
+        """Operator pre-assigns models via delegation.models; tasks reference
+        them by profile name."""
+        mock_cfg.return_value = {
+            "models": {
+                "research": {"model": _SUPER},
+                "summarize": {"model": _NANO},
+            }
+        }
+        mock_creds.return_value = dict(_NIM_GLOBAL_CREDS)
+        mock_run.return_value = {
+            "task_index": 0, "status": "completed", "summary": "ok",
+            "api_calls": 1, "duration_seconds": 1.0,
+        }
+        mock_build.return_value = MagicMock()
+        parent = _make_mock_parent()
+
+        delegate_task(
+            tasks=[
+                {"goal": "investigate", "model_profile": "research"},
+                {"goal": "condense", "model_profile": "summarize"},
+            ],
+            parent_agent=parent,
+        )
+
+        models = [c.kwargs["model"] for c in mock_build.call_args_list]
+        self.assertEqual(models, [_SUPER, _NANO])
+
+    @patch("tools.delegate_tool._load_config", return_value={})
+    @patch("tools.delegate_tool._resolve_delegation_credentials")
+    @patch("tools.delegate_tool._run_single_child")
+    @patch("tools.delegate_tool._build_child_agent")
+    def test_single_task_top_level_model(self, mock_build, mock_run, mock_creds, mock_cfg):
+        mock_creds.return_value = dict(_EMPTY_CREDS)
+        mock_run.return_value = {
+            "task_index": 0, "status": "completed", "summary": "ok",
+            "api_calls": 1, "duration_seconds": 1.0,
+        }
+        mock_build.return_value = MagicMock()
+        parent = _make_mock_parent()
+
+        delegate_task(goal="research the thing", model=_SUPER, parent_agent=parent)
+
+        self.assertEqual(mock_build.call_args.kwargs["model"], _SUPER)
+
+    @patch("tools.delegate_tool._load_config", return_value={})
+    @patch("tools.delegate_tool._resolve_delegation_credentials")
+    @patch("tools.delegate_tool._run_single_child")
+    @patch("tools.delegate_tool._build_child_agent")
+    def test_no_model_falls_back_to_global_then_parent(self, mock_build, mock_run, mock_creds, mock_cfg):
+        """When no per-task/top-level model is given, the global delegation
+        model is used; when that is also empty, None is passed so
+        _build_child_agent inherits the parent's model."""
+        mock_run.return_value = {
+            "task_index": 0, "status": "completed", "summary": "ok",
+            "api_calls": 1, "duration_seconds": 1.0,
+        }
+        mock_build.return_value = MagicMock()
+        parent = _make_mock_parent()
+
+        # global default present
+        mock_creds.return_value = {**_EMPTY_CREDS, "model": "global-default"}
+        delegate_task(goal="x", parent_agent=parent)
+        self.assertEqual(mock_build.call_args.kwargs["model"], "global-default")
+
+        # no global model -> None passed (parent fallback happens downstream)
+        mock_build.reset_mock()
+        mock_creds.return_value = dict(_EMPTY_CREDS)
+        delegate_task(goal="x", parent_agent=parent)
+        self.assertIsNone(mock_build.call_args.kwargs["model"])
+
+    @patch("tools.delegate_tool._load_config")
+    @patch("tools.delegate_tool._resolve_delegation_credentials")
+    @patch("tools.delegate_tool._run_single_child")
+    @patch("tools.delegate_tool._build_child_agent")
+    def test_unknown_profile_errors_before_building_children(self, mock_build, mock_run, mock_creds, mock_cfg):
+        mock_cfg.return_value = {"models": {"research": {"model": _SUPER}}}
+        mock_creds.return_value = dict(_NIM_GLOBAL_CREDS)
+        parent = _make_mock_parent()
+
+        result = json.loads(
+            delegate_task(tasks=[{"goal": "x", "model_profile": "ghost"}], parent_agent=parent)
+        )
+        self.assertIn("error", result)
+        self.assertIn("ghost", result["error"])
+        self.assertIn("Task 0", result["error"])
+        mock_build.assert_not_called()
+        mock_run.assert_not_called()
+
+
+class TestPerTaskModelSchemaAndDispatch(unittest.TestCase):
+    """Schema exposure + run_agent dispatch forwarding for the new fields."""
+
+    def test_schema_exposes_model_fields_both_levels(self):
+        props = DELEGATE_TASK_SCHEMA["parameters"]["properties"]
+        for field in ("model", "provider", "model_profile"):
+            self.assertIn(field, props, f"top-level '{field}' missing from schema")
+        task_props = props["tasks"]["items"]["properties"]
+        for field in ("model", "provider", "model_profile"):
+            self.assertIn(field, task_props, f"per-task '{field}' missing from schema")
+
+    def test_dispatch_forwards_model_fields(self):
+        """_dispatch_delegate_task threads the new fields through to
+        delegate_task (run_agent.py is the single call site)."""
+        from run_agent import AIAgent
+
+        with patch("tools.delegate_tool.delegate_task") as mock_dt:
+            mock_dt.return_value = "{}"
+            sentinel_parent = object()
+            AIAgent._dispatch_delegate_task(
+                sentinel_parent,
+                {
+                    "goal": "x",
+                    "model": "m1",
+                    "provider": "openrouter",
+                    "model_profile": "research",
+                },
+            )
+            _, kwargs = mock_dt.call_args
+            self.assertEqual(kwargs["model"], "m1")
+            self.assertEqual(kwargs["provider"], "openrouter")
+            self.assertEqual(kwargs["model_profile"], "research")
+            self.assertIs(kwargs["parent_agent"], sentinel_parent)
+
+
+class TestExplicitOverrideSuppressesFallback(unittest.TestCase):
+    """An explicit per-sub-agent model override must NOT inherit the parent's
+    fallback chain. Otherwise an error on the explicitly-chosen model would
+    silently fail the child over to the parent's fallback model, overriding the
+    caller's explicit choice. With no override, today's inherit behavior is
+    preserved (global delegation.model and parent-model cases unaffected).
+    """
+
+    _CHAIN = [{"provider": "openrouter", "model": "gpt-4o-mini", "api_key": "sk-or-x"}]
+
+    def _parent_with_chain(self):
+        parent = _make_mock_parent()
+        parent._fallback_chain = list(self._CHAIN)
+        return parent
+
+    # ── unit: _build_child_agent honors the flag ───────────────────────────
+    def test_build_child_explicit_override_suppresses_fallback(self):
+        parent = self._parent_with_chain()
+        with patch("run_agent.AIAgent") as MockAgent:
+            MockAgent.return_value = MagicMock()
+            _build_child_agent(
+                task_index=0, goal="g", context=None, toolsets=None,
+                model="explicit/model", max_iterations=10, task_count=1,
+                parent_agent=parent, explicit_model_override=True,
+            )
+            _, kwargs = MockAgent.call_args
+            self.assertIsNone(kwargs["fallback_model"])
+
+    def test_build_child_no_override_inherits_fallback(self):
+        parent = self._parent_with_chain()
+        with patch("run_agent.AIAgent") as MockAgent:
+            MockAgent.return_value = MagicMock()
+            _build_child_agent(
+                task_index=0, goal="g", context=None, toolsets=None,
+                model=None, max_iterations=10, task_count=1,
+                parent_agent=parent,  # explicit_model_override defaults to False
+            )
+            _, kwargs = MockAgent.call_args
+            self.assertEqual(kwargs["fallback_model"], self._CHAIN)
+
+    # ── integration: delegate_task wires explicitness per task ──────────────
+    @patch("tools.delegate_tool._load_config", return_value={})
+    @patch("tools.delegate_tool._resolve_delegation_credentials")
+    @patch("tools.delegate_tool._run_single_child")
+    def test_per_task_model_suppresses_only_overridden_child(self, mock_run, mock_creds, mock_cfg):
+        """In one batch: the explicit-model child loses the fallback chain; the
+        non-override child still inherits it."""
+        mock_creds.return_value = dict(_EMPTY_CREDS)
+        mock_run.return_value = {
+            "task_index": 0, "status": "completed", "summary": "ok",
+            "api_calls": 1, "duration_seconds": 1.0,
+        }
+        parent = self._parent_with_chain()
+        with patch("run_agent.AIAgent") as MockAgent:
+            MockAgent.return_value = MagicMock()
+            delegate_task(
+                tasks=[
+                    {"goal": "explicit", "model": _SUPER},
+                    {"goal": "inherit"},  # no override
+                ],
+                parent_agent=parent,
+            )
+            fb = [c.kwargs["fallback_model"] for c in MockAgent.call_args_list]
+            self.assertIsNone(fb[0])               # explicit override → suppressed
+            self.assertEqual(fb[1], self._CHAIN)   # no override → inherited
+
+    @patch("tools.delegate_tool._load_config")
+    @patch("tools.delegate_tool._resolve_delegation_credentials")
+    @patch("tools.delegate_tool._run_single_child")
+    def test_provider_and_profile_overrides_suppress_fallback(self, mock_run, mock_creds, mock_cfg):
+        """provider and model_profile count as explicit overrides too."""
+        mock_cfg.return_value = {"models": {"research": {"model": _SUPER}}}
+        mock_creds.return_value = {
+            "model": _SUPER, "provider": "openrouter",
+            "base_url": "https://openrouter.ai/api/v1",
+            "api_key": "sk", "api_mode": "chat_completions",
+        }
+        mock_run.return_value = {
+            "task_index": 0, "status": "completed", "summary": "ok",
+            "api_calls": 1, "duration_seconds": 1.0,
+        }
+        parent = self._parent_with_chain()
+        with patch("run_agent.AIAgent") as MockAgent:
+            MockAgent.return_value = MagicMock()
+            delegate_task(
+                tasks=[
+                    {"goal": "by-provider", "provider": "openrouter"},
+                    {"goal": "by-profile", "model_profile": "research"},
+                ],
+                parent_agent=parent,
+            )
+            fb = [c.kwargs["fallback_model"] for c in MockAgent.call_args_list]
+            self.assertIsNone(fb[0])  # provider override
+            self.assertIsNone(fb[1])  # model_profile override
+
+    @patch("tools.delegate_tool._load_config", return_value={})
+    @patch("tools.delegate_tool._resolve_delegation_credentials")
+    @patch("tools.delegate_tool._run_single_child")
+    def test_single_task_top_level_model_suppresses_fallback(self, mock_run, mock_creds, mock_cfg):
+        mock_creds.return_value = dict(_EMPTY_CREDS)
+        mock_run.return_value = {
+            "task_index": 0, "status": "completed", "summary": "ok",
+            "api_calls": 1, "duration_seconds": 1.0,
+        }
+        parent = self._parent_with_chain()
+        with patch("run_agent.AIAgent") as MockAgent:
+            MockAgent.return_value = MagicMock()
+            delegate_task(goal="single", model=_SUPER, parent_agent=parent)
+            _, kwargs = MockAgent.call_args
+            self.assertIsNone(kwargs["fallback_model"])
+
+    @patch("tools.delegate_tool._load_config", return_value={})
+    @patch("tools.delegate_tool._resolve_delegation_credentials")
+    @patch("tools.delegate_tool._run_single_child")
+    def test_no_override_preserves_parent_fallback(self, mock_run, mock_creds, mock_cfg):
+        """Global delegation.model (no per-task override) keeps today's
+        inherit behavior."""
+        mock_creds.return_value = {**_EMPTY_CREDS, "model": "global-default"}
+        mock_run.return_value = {
+            "task_index": 0, "status": "completed", "summary": "ok",
+            "api_calls": 1, "duration_seconds": 1.0,
+        }
+        parent = self._parent_with_chain()
+        with patch("run_agent.AIAgent") as MockAgent:
+            MockAgent.return_value = MagicMock()
+            delegate_task(goal="single", parent_agent=parent)
+            _, kwargs = MockAgent.call_args
+            self.assertEqual(kwargs["fallback_model"], self._CHAIN)
 
 
 if __name__ == "__main__":

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -990,6 +990,10 @@ def _build_child_agent(
     # 'leaf' (default) cannot; 'orchestrator' retains the delegation
     # toolset subject to depth/kill-switch bounds applied below.
     role: str = "leaf",
+    # True when the caller explicitly chose this child's model (per-task or
+    # top-level model/provider/model_profile). Suppresses the parent fallback
+    # chain so the explicit model can't be silently swapped — see below.
+    explicit_model_override: bool = False,
 ):
     """
     Build a child AIAgent on the main thread (thread-safe construction).
@@ -1184,7 +1188,20 @@ def _build_child_agent(
     # from rate-limits and credential exhaustion exactly like the top-level
     # agent does.  _fallback_chain is a list accepted by AIAgent's
     # fallback_model parameter (which handles both list and dict forms).
-    parent_fallback = getattr(parent_agent, "_fallback_chain", None) or None
+    #
+    # EXCEPTION — explicit model override: when the caller explicitly chose
+    # this child's model (per-task/top-level model/provider/model_profile),
+    # suppress the parent fallback chain. Otherwise an error on the
+    # explicitly-chosen model would silently fail the child over to the
+    # PARENT's fallback model, overriding the caller's explicit choice without
+    # their knowledge. An explicit override must be honored or fail loudly —
+    # never silently swapped. (No override → today's inherit behavior, so the
+    # global delegation.model and parent-model cases are unaffected.)
+    parent_fallback = (
+        None
+        if explicit_model_override
+        else (getattr(parent_agent, "_fallback_chain", None) or None)
+    )
 
     # Inherit the parent's OpenRouter provider-preference filters by default
     # (so subagents routed to the same provider honour the same routing
@@ -2072,6 +2089,9 @@ def delegate_task(
     acp_args: Optional[List[str]] = None,
     role: Optional[str] = None,
     background: Optional[bool] = None,
+    model: Optional[str] = None,
+    provider: Optional[str] = None,
+    model_profile: Optional[str] = None,
     parent_agent=None,
 ) -> str:
     """
@@ -2085,6 +2105,14 @@ def delegate_task(
     'leaf' (default) cannot; 'orchestrator' retains the delegation
     toolset and can spawn its own workers, bounded by
     delegation.max_spawn_depth.  Per-task role beats the top-level one.
+
+    Per-agent model assignment: 'model'/'provider'/'model_profile' select the
+    model for the spawned subagent(s). In batch mode each task may set its own
+    'model'/'provider'/'model_profile', so distinct subagents in one workflow
+    run on distinct models. Per-task values beat the top-level args, which beat
+    a named profile (delegation.models.<name>), which beats the global
+    delegation.model, which beats the parent's model. Omit them all to keep the
+    existing global-default + parent-fallback behavior unchanged.
 
     Returns JSON with results array, one entry per task.
     """
@@ -2190,6 +2218,50 @@ def delegate_task(
         if not task.get("goal", "").strip():
             return tool_error(f"Task {i} is missing a 'goal'.")
 
+    # Resolve per-task credentials UP FRONT so a bad model_profile or
+    # unresolvable provider fails before any child agent is constructed —
+    # otherwise we'd leak half-built children (registered for interrupt
+    # propagation, holding tool resources) on an early return. Each entry is
+    # a full credential bundle; the model-only case keeps the global bundle
+    # and just swaps the model (see _resolve_task_credentials).
+    #
+    # task_explicit_list[i] records whether the CALLER explicitly chose this
+    # child's model — via a per-task or top-level model/provider/model_profile.
+    # When true, the parent's fallback chain is suppressed for that child (see
+    # _build_child_agent) so an error on the chosen model can't silently fail
+    # over to the parent's fallback model. The global delegation.model/provider
+    # is NOT an explicit per-task override and keeps today's fallback behavior.
+    task_creds_list: List[Dict[str, Any]] = []
+    task_explicit_list: List[bool] = []
+    for i, t in enumerate(task_list):
+        task_explicit_list.append(
+            any(
+                str(v or "").strip()
+                for v in (
+                    t.get("model"),
+                    t.get("provider"),
+                    t.get("model_profile"),
+                    model,
+                    provider,
+                    model_profile,
+                )
+            )
+        )
+        try:
+            task_creds_list.append(
+                _resolve_task_credentials(
+                    task=t,
+                    top_model=model,
+                    top_provider=provider,
+                    top_profile=model_profile,
+                    global_creds=creds,
+                    cfg=cfg,
+                    parent_agent=parent_agent,
+                )
+            )
+        except ValueError as exc:
+            return tool_error(f"Task {i}: {exc}")
+
     overall_start = time.monotonic()
     results = []
 
@@ -2214,28 +2286,33 @@ def delegate_task(
             # Per-task role beats top-level; normalise again so unknown
             # per-task values warn and degrade to leaf uniformly.
             effective_role = _normalize_role(t.get("role") or top_role)
+            # Per-task credential bundle (model/provider/profile override of the
+            # global creds) resolved in the pre-pass above. Falls back to the
+            # global bundle, then to parent inheritance inside _build_child_agent.
+            task_creds = task_creds_list[i]
             child = _build_child_agent(
                 task_index=i,
                 goal=t["goal"],
                 context=t.get("context"),
                 toolsets=t.get("toolsets") or toolsets,
-                model=creds["model"],
+                model=task_creds["model"],
                 max_iterations=effective_max_iter,
                 task_count=n_tasks,
                 parent_agent=parent_agent,
-                override_provider=creds["provider"],
-                override_base_url=creds["base_url"],
-                override_api_key=creds["api_key"],
-                override_api_mode=creds["api_mode"],
+                override_provider=task_creds["provider"],
+                override_base_url=task_creds["base_url"],
+                override_api_key=task_creds["api_key"],
+                override_api_mode=task_creds["api_mode"],
                 override_acp_command=t.get("acp_command")
                 or acp_command
-                or creds.get("command"),
+                or task_creds.get("command"),
                 override_acp_args=(
                     task_acp_args
                     if task_acp_args is not None
-                    else (acp_args if acp_args is not None else creds.get("args"))
+                    else (acp_args if acp_args is not None else task_creds.get("args"))
                 ),
                 role=effective_role,
+                explicit_model_override=task_explicit_list[i],
             )
             # Override with correct parent tool names (before child construction mutated global)
             child._delegate_saved_tool_names = _parent_tool_names
@@ -2799,6 +2876,151 @@ def _resolve_delegation_credentials(cfg: dict, parent_agent) -> dict:
     }
 
 
+def _normalize_model_profiles(cfg: dict) -> Dict[str, Dict[str, Any]]:
+    """Return ``delegation.models`` as a ``name -> profile-dict`` mapping.
+
+    ``delegation.models`` lets a human pre-assign distinct models to distinct
+    kinds of subagent (the human-config half of per-agent model assignment).
+    Each profile may carry a full or partial credential bundle — the same keys
+    ``_resolve_delegation_credentials`` understands::
+
+        delegation:
+          models:
+            research:  {model: "nvidia/nemotron-3-super-120b-a12b"}
+            summarize: {model: "nvidia/nemotron-3-nano-8b-v1"}
+            # cross-provider profile (optional):
+            cheap:     {model: "google/gemini-3-flash-preview", provider: "openrouter"}
+
+    A bare string value is shorthand for ``{"model": "<string>"}``::
+
+        delegation:
+          models:
+            summarize: "nvidia/nemotron-3-nano-8b-v1"
+
+    Invalid shapes are skipped with a warning rather than raising, so one bad
+    profile entry never breaks every delegation.
+    """
+    raw = cfg.get("models")
+    if not isinstance(raw, dict):
+        return {}
+    out: Dict[str, Dict[str, Any]] = {}
+    for name, val in raw.items():
+        key = str(name).strip()
+        if not key:
+            continue
+        if isinstance(val, str):
+            model_id = val.strip()
+            if model_id:
+                out[key] = {"model": model_id}
+        elif isinstance(val, dict):
+            out[key] = dict(val)
+        else:
+            logger.warning(
+                "delegation.models['%s'] must be a model-id string or a "
+                "mapping of credential fields; got %s — skipping",
+                key,
+                type(val).__name__,
+            )
+    return out
+
+
+def _resolve_task_credentials(
+    *,
+    task: Dict[str, Any],
+    top_model: Optional[str],
+    top_provider: Optional[str],
+    top_profile: Optional[str],
+    global_creds: Dict[str, Any],
+    cfg: dict,
+    parent_agent,
+) -> Dict[str, Any]:
+    """Resolve the effective credential bundle for ONE delegated task.
+
+    This is the core of per-agent model assignment: it layers per-task model /
+    provider / profile overrides on top of the single global delegation bundle
+    so distinct subagents in one workflow can run on distinct models.
+
+    Precedence (highest first):
+      1. Explicit per-task ``model`` / ``provider`` fields.
+      2. Top-level ``model`` / ``provider`` args (the single-task choice, and
+         the batch default for tasks that don't set their own).
+      3. Named ``model_profile`` -> ``delegation.models.<name>`` (human-config).
+      4. Global delegation creds (``delegation.model`` / ``provider`` / ...).
+      5. Parent-agent inheritance (applied later in ``_build_child_agent``,
+         where ``effective_model = model or parent_agent.model`` etc.).
+
+    Returns a dict with the same shape as ``_resolve_delegation_credentials``:
+    ``{model, provider, base_url, api_key, api_mode[, command, args]}``.
+
+    Two resolution paths:
+
+    * **Model-only swap** (no provider/base_url override): keep the global
+      credential bundle untouched and only replace the model id. This is the
+      common, motivating case — several models served from one endpoint (e.g.
+      two NVIDIA NIM models behind a single ``base_url``/``api_key``). It also
+      covers the pure-parent case: with no global delegation config the bundle
+      is all-``None`` except the swapped model, so the child runs the chosen
+      model on the parent's own provider/base_url/api_key.
+    * **Credential re-resolution** (a provider or direct ``base_url`` is given,
+      via the per-task field or a profile): resolve a fresh bundle through the
+      very same ``_resolve_delegation_credentials`` path the global config uses,
+      so a per-task model can also live on a different provider.
+
+    Raises ``ValueError`` with a task-scoped message on profile/provider
+    failure (caught by the caller, surfaced as a tool error citing the task).
+    """
+    # 1. Resolve the named profile (lowest of the explicit override layers).
+    profile_name = (task.get("model_profile") or top_profile or "").strip() or None
+    profile: Dict[str, Any] = {}
+    if profile_name:
+        profiles = _normalize_model_profiles(cfg)
+        if profile_name not in profiles:
+            available = ", ".join(sorted(profiles)) or "(none configured)"
+            raise ValueError(
+                f"unknown delegation model_profile '{profile_name}'. Define it "
+                f"under delegation.models in config.yaml. Available profiles: "
+                f"{available}."
+            )
+        profile = profiles[profile_name]
+
+    # 2. Collapse the override layers (explicit per-task > top-level > profile).
+    def _pick(*candidates: Any) -> Optional[str]:
+        for c in candidates:
+            text = str(c or "").strip()
+            if text:
+                return text
+        return None
+
+    model_override = _pick(task.get("model"), top_model, profile.get("model"))
+    provider_override = _pick(task.get("provider"), top_provider, profile.get("provider"))
+    base_url_override = _pick(profile.get("base_url"))
+    api_key_override = _pick(profile.get("api_key"))
+    api_mode_override = _pick(task.get("api_mode"), profile.get("api_mode"))
+
+    # 3a. No credential-routing override → keep the global bundle, swap model.
+    if not provider_override and not base_url_override:
+        merged = dict(global_creds)
+        if model_override:
+            merged["model"] = model_override
+        if api_mode_override:
+            merged["api_mode"] = api_mode_override
+        if api_key_override:
+            merged["api_key"] = api_key_override
+        return merged
+
+    # 3b. Provider or direct endpoint given → resolve a full bundle the same
+    # way the global delegation config does (handles base_url auto-detection,
+    # built-in provider credential lookup, ACP command/args, etc.).
+    task_cfg = {
+        "model": model_override,
+        "provider": provider_override,
+        "base_url": base_url_override,
+        "api_key": api_key_override,
+        "api_mode": api_mode_override,
+    }
+    return _resolve_delegation_credentials(task_cfg, parent_agent)
+
+
 def _load_config() -> dict:
     """Load delegation config from CLI_CONFIG or persistent config.
 
@@ -3051,6 +3273,42 @@ DELEGATE_TASK_SCHEMA = {
                     "['terminal', 'file', 'web'] for full-stack tasks."
                 ),
             },
+            "model": {
+                "type": "string",
+                "description": (
+                    "Model override for the spawned subagent (single-task mode), "
+                    "and the default model for any batch task that doesn't set its "
+                    "own. A bare model id (e.g. 'nvidia/nemotron-3-nano-8b-v1') "
+                    "runs the child on that model using the active "
+                    "delegation/parent credentials — same endpoint, different "
+                    "model. For per-subagent differences in a batch, prefer "
+                    "setting 'model' inside each tasks[] item. Omit to use "
+                    "delegation.model from config, then the parent's model."
+                ),
+            },
+            "provider": {
+                "type": "string",
+                "description": (
+                    "Optional provider override for the subagent(s) (e.g. "
+                    "'openrouter', 'nous'). Resolves that provider's base_url / "
+                    "api_key automatically, the same way delegation.provider does. "
+                    "Only needed when the chosen model lives on a DIFFERENT "
+                    "provider than the active credentials; for a same-endpoint "
+                    "model swap just set 'model'."
+                ),
+            },
+            "model_profile": {
+                "type": "string",
+                "description": (
+                    "Name of an operator-defined model profile under "
+                    "delegation.models in config.yaml (human-assigned). Lets an "
+                    "operator pin specific models to specific subagent kinds (e.g. "
+                    "'research' -> a capable model, 'summarize' -> a small model) "
+                    "while you only choose the profile by intent. Explicit "
+                    "'model'/'provider' override the profile. Per-task "
+                    "'model_profile' inside tasks[] beats this top-level one."
+                ),
+            },
             "tasks": {
                 "type": "array",
                 "items": {
@@ -3065,6 +3323,41 @@ DELEGATE_TASK_SCHEMA = {
                             "type": "array",
                             "items": {"type": "string"},
                             "description": f"Toolsets for this specific task. Available: {_TOOLSET_LIST_STR}. Use 'web' for network access, 'terminal' for shell, 'browser' for web interaction.",
+                        },
+                        "model": {
+                            "type": "string",
+                            "description": (
+                                "Per-task model override — assign THIS subagent a "
+                                "specific model so different tasks in the batch run "
+                                "on different models (e.g. a capable model for a "
+                                "research task, a small fast model for a summarize "
+                                "task). A bare model id runs the child on that model "
+                                "using the active delegation/parent credentials "
+                                "(same endpoint, different model). Omit to inherit "
+                                "the top-level model, then delegation.model, then "
+                                "the parent's model."
+                            ),
+                        },
+                        "provider": {
+                            "type": "string",
+                            "description": (
+                                "Per-task provider override (e.g. 'openrouter', "
+                                "'nous'). Only needed when this task's model lives "
+                                "on a DIFFERENT provider than the active "
+                                "credentials; for a same-endpoint model swap set "
+                                "only 'model'. Resolves the provider's base_url / "
+                                "api_key automatically."
+                            ),
+                        },
+                        "model_profile": {
+                            "type": "string",
+                            "description": (
+                                "Name of an operator-defined model profile under "
+                                "delegation.models in config.yaml (e.g. 'research', "
+                                "'summarize'). Lets a human pin which model each kind "
+                                "of subagent uses while you pick the profile by "
+                                "intent. Explicit 'model'/'provider' override it."
+                            ),
                         },
                         "acp_command": {
                             "type": "string",
@@ -3171,6 +3464,9 @@ registry.register(
         acp_args=args.get("acp_args"),
         role=args.get("role"),
         background=_model_background_value(args, kw.get("parent_agent")),
+        model=args.get("model"),
+        provider=args.get("provider"),
+        model_profile=args.get("model_profile"),
         parent_agent=kw.get("parent_agent"),
     ),
     check_fn=check_delegate_requirements,

--- a/website/docs/user-guide/features/delegation.md
+++ b/website/docs/user-guide/features/delegation.md
@@ -131,7 +131,7 @@ Single-task delegation runs directly without thread pool overhead.
 
 ## Model Override
 
-You can configure a different model for subagents via `config.yaml` — useful for delegating simple tasks to cheaper/faster models:
+You can configure a different model for **all** subagents via `config.yaml` — useful for delegating simple tasks to cheaper/faster models:
 
 ```yaml
 # In ~/.hermes/config.yaml
@@ -141,6 +141,95 @@ delegation:
 ```
 
 If omitted, subagents use the same model as the parent.
+
+## Per-Agent Model Assignment
+
+`delegation.model` sets **one** model for every subagent. When a workflow needs
+**different models for different subagents** — for example a capable model for a
+"research" subagent and a small/fast model for a "summarize" subagent — there are
+two complementary mechanisms. Both preserve the global default and parent fallback:
+when no per-task model is given, a subagent uses `delegation.model`, then the
+parent's model, exactly as before.
+
+### 1. Runtime — the agent assigns models per task
+
+The orchestrating agent can set a `model` (and optionally `provider`) on each task
+in a `delegate_task` batch, with no configuration required:
+
+```python
+delegate_task(tasks=[
+    {
+        "goal": "Research the state of WebAssembly in 2025",
+        "toolsets": ["web"],
+        "model": "nvidia/nemotron-3-super-120b-a12b",   # capable model
+    },
+    {
+        "goal": "Summarize the research into 5 bullet points",
+        "model": "nvidia/nemotron-3-nano-30b-a3b",         # small, fast model
+    },
+])
+```
+
+A bare `model` id runs that subagent on the **same endpoint** as the active
+delegation/parent credentials — only the model id changes. This is the common case
+when several models are served from one provider (e.g. NVIDIA NIM). To route a task
+to a *different* provider, also set `provider` (resolves that provider's base URL and
+API key automatically, like `delegation.provider`).
+
+`model`/`provider` also work at the top level for single-task delegation, and act as
+the default for any batch task that doesn't set its own.
+
+### 2. Human-config — operator pre-assigns models via named profiles
+
+An operator can pin specific models to specific *kinds* of subagent in `config.yaml`
+under `delegation.models`, then have the agent reference them per task by name with
+`model_profile`. The operator controls which model each profile maps to; the agent
+only chooses the profile by intent:
+
+```yaml
+# In ~/.hermes/config.yaml
+delegation:
+  model: "nvidia/nemotron-3-nano-30b-a3b"   # global default (fallback)
+  base_url: "https://your-nim-endpoint/v1"
+  api_key: "..."                           # or rely on the parent's key
+  models:
+    research:  { model: "nvidia/nemotron-3-super-120b-a12b" }   # capable
+    summarize: { model: "nvidia/nemotron-3-nano-30b-a3b" }        # small/fast
+    cheap:     { model: "google/gemini-3-flash-preview", provider: "openrouter" }  # cross-provider
+    draft: "nvidia/nemotron-3-nano-30b-a3b"  # shorthand: bare string == {model: "<id>"}
+```
+
+```python
+delegate_task(tasks=[
+    {"goal": "Investigate the failing integration test", "model_profile": "research"},
+    {"goal": "Write a one-paragraph summary of the findings", "model_profile": "summarize"},
+])
+```
+
+A profile may carry just a `model`, or a full credential bundle (`model`, `provider`,
+`base_url`, `api_key`, `api_mode`) when the subagent should run on a different
+provider. Referencing an undefined profile returns a tool error listing the available
+profile names (no subagent is spawned).
+
+### Precedence
+
+For each task, the effective model/provider is resolved highest-first:
+
+1. Explicit per-task `model` / `provider`
+2. Top-level `model` / `provider` arguments to `delegate_task`
+3. Named `model_profile` → `delegation.models.<name>`
+4. Global `delegation.model` / `delegation.provider`
+5. The parent agent's model (inherited)
+
+Each subagent's **resolved** model is recorded in the delegation result (the `model`
+field of each result entry) and in the `/agents` overlay, so you can confirm which
+child ran which model.
+
+When you give a sub-agent an **explicit** model (a per-task or top-level
+`model` / `provider` / `model_profile`), that child does **not** inherit the parent's
+fallback-model chain. An explicit choice is honored or fails loudly — it is never
+silently swapped for the parent's fallback model on an error. Sub-agents that take no
+override keep the parent's fallback chain as before.
 
 ## Toolset Selection Tips
 
@@ -271,9 +360,12 @@ delegation:
   # max_concurrent_children: 3              # Parallel children per batch (default: 3)
   # max_spawn_depth: 1                      # Tree depth (floor 1, no ceiling, default 1 = flat). Raise to 2 to allow orchestrator children to spawn leaves; 3+ for deeper trees.
   # orchestrator_enabled: true              # Disable to force all children to leaf role.
-  model: "google/gemini-3-flash-preview"             # Optional provider/model override
+  model: "google/gemini-3-flash-preview"             # Optional default provider/model override
   provider: "openrouter"                             # Optional built-in provider
   api_mode: anthropic_messages                       # optional; auto-detected from base_url for anthropic_messages endpoints
+  models:                                            # Optional: per-subagent model profiles (see "Per-Agent Model Assignment")
+    research:  { model: "nvidia/nemotron-3-super-120b-a12b" }
+    summarize: { model: "nvidia/nemotron-3-nano-30b-a3b" }
 
 # Or use a direct custom endpoint instead of provider:
 delegation:


### PR DESCRIPTION
## What does this PR do?

Lets distinct sub-agents in a single `delegate_task` workflow run on **different models**. Today `delegation.model` sets one model for every sub-agent; this adds per-sub-agent selection, assignable two ways:

- **Runtime (agent-chosen):** the orchestrating agent sets a per-task `model` (and optionally `provider`) in a `delegate_task` batch — e.g. a capable model for a research task, a small/fast model for a summarize task.
- **Human-config (operator-assigned):** named profiles under `delegation.models` that the agent references per task via `model_profile`; the operator controls which model each profile maps to.

The global `delegation.model` default and parent-model fallback are preserved when nothing per-task is given, so existing behavior is unchanged. A per-task model with no provider/base_url runs on the **same endpoint** as the active credentials (just a different model id — the common case for several models served by one provider); a per-task `provider`/profile re-resolves a full credential bundle for cross-provider routing.

This is specifically per-sub-agent model assignment — not a task-complexity router or a quality/cost routing layer.

### Explicit-override fallback safety

When a sub-agent is given an **explicit** model (a per-task or top-level `model` / `provider` / `model_profile`), it no longer inherits the **parent's fallback-model chain**. Previously the child always inherited it, so an error on the explicitly-chosen model (rate limit, 5xx, …) would silently fail the child over to the *parent's* fallback model — overriding the model the caller explicitly requested, with no signal. The parent's chain is also tuned for the parent's model, so applying it to a child deliberately put on a different model was mismatched anyway. An explicit override is now honored or fails loudly; it is never silently swapped. Sub-agents with **no** override keep the parent's fallback chain exactly as before.

This guard was **inspired by #23649**, which implements the same explicit-override fallback suppression; the implementation here is self-contained.

## Related Issue

Related: #23649 (sibling PR — explicit-override fallback suppression; inspired the fallback guard here, not closed by this PR).

Fixes #<!-- add issue number if one exists -->

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `tools/delegate_tool.py`: add `_normalize_model_profiles()` and `_resolve_task_credentials()`; resolve per-task credentials up front (model-only swap keeps the global bundle; provider/base_url re-resolves via the existing `_resolve_delegation_credentials` path); build each child with its own bundle; add `model`/`provider`/`model_profile` params + schema fields (top-level and per-task) + registry handler wiring.
- `tools/delegate_tool.py`: add `explicit_model_override` to `_build_child_agent` and suppress the parent fallback chain when set; `delegate_task` computes per-task explicitness (any per-task/top-level `model`/`provider`/`model_profile`) and threads it through for both single-task and batch.
- `run_agent.py`: forward `model`/`provider`/`model_profile` through `_dispatch_delegate_task`.
- `DELEGATE_TASK_SCHEMA`: add `model`/`provider`/`model_profile` at top level and per-task.
- `tests/tools/test_delegate.py`: 25 new tests — both assignment paths, precedence, global-then-parent fallback, unknown-profile error, dispatch forwarding, and explicit-override fallback suppression (all forms, single-task and batch). Mocked; no network.
- `website/docs/user-guide/features/delegation.md` and `cli-config.yaml.example`: document `delegation.models` profiles, per-task `model`/`provider`/`model_profile`, and the explicit-override fallback behavior.

## How to Test

Automated (no network — external calls mocked):

```bash
pytest tests/tools/test_delegate.py tests/tools/test_async_delegation.py -q   # 182 passed
```

Manual end-to-end (validated live against NVIDIA NIM with two models on one endpoint):

1. **Human-config:** define `delegation.models` profiles (`research` → capable model, `summarize` → small model); delegate a 2-task batch tagging each task with `model_profile`. Each child's resolved `model` (in the `delegate_task` result JSON / `/agents` overlay) matches its profile.
2. **Runtime:** delegate a 2-task batch with explicit per-task `model` (A → capable, B → small). Each child reports its assigned model.
3. **Fallback:** omit per-task model → child uses `delegation.model`; remove that too → child inherits the parent's model.
4. **Explicit-override fallback safety:** set a non-empty fallback chain on the parent, delegate a task with an explicit per-task `model`, and confirm the child is built with `fallback_model=None` (no silent failover); a sibling no-override task in the same batch still inherits the chain.

The pass signal is the recorded per-child `model`, observable via `./hermes chat -v` (the `Result:` tool block) or the `/agents` overlay.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`feat(delegation): …`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this feature
- [x] I've run the delegation test suite and all tests pass (182 passed)
- [x] I've added tests for my changes
- [ ] I've tested on my platform: <!-- e.g. Ubuntu 24.04 -->

### Documentation & Housekeeping

- [x] I've updated relevant documentation (`website/docs/.../delegation.md`)
- [x] I've updated `cli-config.yaml.example` (new `delegation.models` key)
- [x] I've updated tool descriptions/schemas (`DELEGATE_TASK_SCHEMA` gains `model`/`provider`/`model_profile`)
- [x] I've considered cross-platform impact — N/A (no platform-specific code)
- [x] I've updated `CONTRIBUTING.md`/`AGENTS.md` — N/A (no architecture/workflow change)
