### PR TITLE
fix(delegation): forward background flag to delegate task

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -5140,6 +5140,7 @@ class AIAgent:
             acp_command=function_args.get("acp_command"),
             acp_args=function_args.get("acp_args"),
             role=function_args.get("role"),
+            background=function_args.get("background"),
             parent_agent=self,
         )
 

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -97,6 +97,22 @@ def agent_with_memory_tool():
         return a
 
 
+def test_dispatch_delegate_task_forwards_background_flag(agent):
+    """AIAgent's delegate_task dispatch must preserve async background requests."""
+    with patch("tools.delegate_tool.delegate_task", return_value="ok") as mock_delegate:
+        assert agent._dispatch_delegate_task(
+            {
+                "goal": "slow background task",
+                "context": "context",
+                "toolsets": ["web"],
+                "role": "leaf",
+                "background": True,
+            }
+        ) == "ok"
+
+    assert mock_delegate.call_args.kwargs["background"] is True
+
+
 def test_aiagent_reuses_existing_errors_log_handler():
     """Repeated AIAgent init should not accumulate duplicate errors.log handlers."""
     root_logger = logging.getLogger()


### PR DESCRIPTION
## Summary
- forward the delegate_task background flag through AIAgent._dispatch_delegate_task
- add a regression test covering async background delegation dispatch

## Test Plan
- uv run --with pytest python -m pytest tests/run_agent/test_run_agent.py::test_dispatch_delegate_task_forwards_background_flag -q -o 'addopts='
- uv run python -m py_compile run_agent.py tests/run_agent/test_run_agent.py
- uv run --with pytest python -m pytest tests/tools/test_async_delegation.py -q -o 'addopts='

## Notes
Before this fix, model/tool calls that included background=true were silently dispatched synchronously because the flag was dropped at the AIAgent forwarding layer.