### PR TITLE
fix(hindsight): preserve embedded daemon model config

### DIFF
--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -453,6 +453,14 @@ def _load_simple_env(path) -> dict[str, str]:
     return values
 
 
+_EMBEDDED_PROFILE_ENV_CONFIG_KEYS = {
+    "embeddings_provider": "HINDSIGHT_API_EMBEDDINGS_PROVIDER",
+    "embeddings_local_model": "HINDSIGHT_API_EMBEDDINGS_LOCAL_MODEL",
+    "reranker_provider": "HINDSIGHT_API_RERANKER_PROVIDER",
+    "reranker_local_model": "HINDSIGHT_API_RERANKER_LOCAL_MODEL",
+}
+
+
 def _build_embedded_profile_env(config: dict[str, Any], *, llm_api_key: str | None = None) -> dict[str, str]:
     """Build the profile-scoped env file that standalone hindsight-embed consumes."""
     current_key = llm_api_key
@@ -478,6 +486,16 @@ def _build_embedded_profile_env(config: dict[str, Any], *, llm_api_key: str | No
     }
     if current_base_url:
         env_values["HINDSIGHT_API_LLM_BASE_URL"] = str(current_base_url)
+
+    for config_key, env_key in _EMBEDDED_PROFILE_ENV_CONFIG_KEYS.items():
+        value = config.get(config_key)
+        if value is not None and value != "":
+            env_values[env_key] = str(value)
+
+    # Preserve advanced daemon settings if users configure raw Hindsight env keys.
+    for key, value in config.items():
+        if key.startswith("HINDSIGHT_") and value is not None and value != "":
+            env_values[key] = str(value)
 
     idle_timeout = (
         config.get("idle_timeout")

--- a/tests/plugins/memory/test_hindsight_provider.py
+++ b/tests/plugins/memory/test_hindsight_provider.py
@@ -348,6 +348,30 @@ class TestConfig:
 
         assert env["HINDSIGHT_EMBED_DAEMON_IDLE_TIMEOUT"] == "42"
 
+    def test_embedded_profile_env_preserves_embedding_and_reranker_config(self):
+        env = _build_embedded_profile_env({
+            "llm_provider": "openai",
+            "llm_model": "gpt-4o-mini",
+            "embeddings_provider": "local",
+            "embeddings_local_model": "BAAI/bge-m3",
+            "reranker_provider": "local",
+            "reranker_local_model": "BAAI/bge-reranker-v2-m3",
+        })
+
+        assert env["HINDSIGHT_API_EMBEDDINGS_PROVIDER"] == "local"
+        assert env["HINDSIGHT_API_EMBEDDINGS_LOCAL_MODEL"] == "BAAI/bge-m3"
+        assert env["HINDSIGHT_API_RERANKER_PROVIDER"] == "local"
+        assert env["HINDSIGHT_API_RERANKER_LOCAL_MODEL"] == "BAAI/bge-reranker-v2-m3"
+
+    def test_embedded_profile_env_preserves_raw_hindsight_config(self):
+        env = _build_embedded_profile_env({
+            "llm_provider": "openai",
+            "llm_model": "gpt-4o-mini",
+            "HINDSIGHT_API_EMBEDDINGS_LOCAL_FORCE_CPU": "true",
+        })
+
+        assert env["HINDSIGHT_API_EMBEDDINGS_LOCAL_FORCE_CPU"] == "true"
+
     def test_get_client_passes_idle_timeout_to_hindsight_embedded(self, monkeypatch):
         captured = {}
 


### PR DESCRIPTION
## Summary
- Preserve Hindsight embedded daemon embedding/reranker config when materializing the profile env file.
- Allow raw `HINDSIGHT_*` daemon settings from the plugin config to survive env materialization.
- Add regression coverage for BGE-M3/reranker settings and raw Hindsight env passthrough.

## Test Plan
- `uv run ruff check plugins/memory/hindsight/__init__.py tests/plugins/memory/test_hindsight_provider.py`
- `uv run --extra dev pytest tests/plugins/memory/test_hindsight_provider.py -q -o 'addopts='`

## Context
Without this, a local embedded Hindsight setup with a populated 1024-dimensional BGE-M3 bank can have `~/.hindsight/profiles/<profile>.env` rewritten without the configured embedding/reranker settings. The daemon then falls back to the 384-dimensional defaults and fails startup with an embedding dimension mismatch.
