### PR TITLE
fix(desktop): render preview markers as cards

### DIFF
--- a/apps/desktop/src/components/assistant-ui/markdown-text.preview.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/markdown-text.preview.test.tsx
@@ -1,0 +1,43 @@
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { $previewTarget } from '@/store/preview'
+
+import { MarkdownTextContent } from './markdown-text'
+
+const marker = '[Preview: report.html](#preview/%2Ftmp%2Fhermes-preview%2Freport.html)'
+
+const target = '/tmp/hermes-preview/report.html'
+
+afterEach(() => {
+  cleanup()
+  $previewTarget.set(null)
+})
+
+describe('MarkdownTextContent preview markers', () => {
+  it('renders #preview markdown links as native preview cards and opens the in-app preview', async () => {
+    render(<MarkdownTextContent isRunning={false} text={marker} />)
+
+    const button = await screen.findByRole('button', { name: /open preview/i })
+    expect(screen.getByText('report.html')).toBeTruthy()
+
+    fireEvent.click(button)
+
+    await waitFor(() => {
+      expect($previewTarget.get()).toMatchObject({
+        path: target,
+        previewKind: 'html',
+        renderMode: 'preview',
+        source: target,
+        url: `file://${target}`
+      })
+    })
+  })
+
+  it('defers preview cards while text is still streaming', () => {
+    render(<MarkdownTextContent isRunning={true} text={marker} />)
+
+    expect(screen.queryByRole('button', { name: /open preview/i })).toBeNull()
+    expect($previewTarget.get()).toBeNull()
+  })
+})

--- a/apps/desktop/src/components/assistant-ui/markdown-text.tsx
+++ b/apps/desktop/src/components/assistant-ui/markdown-text.tsx
@@ -35,7 +35,7 @@ import {
   mediaPathFromMarkdownHref,
   mediaStreamUrl
 } from '@/lib/media'
-import { previewTargetFromMarkdownHref } from '@/lib/preview-targets'
+import { extractPreviewTargets, previewTargetFromMarkdownHref, stripPreviewTargets } from '@/lib/preview-targets'
 import { tailBoundedRemend } from '@/lib/remend-tail'
 import { cn } from '@/lib/utils'
 
@@ -558,28 +558,63 @@ function MarkdownTextSurface({ containerClassName, containerProps }: MarkdownTex
   )
 }
 
+function PreviewMarkerCards({ targets }: { targets: string[] }) {
+  if (targets.length === 0) {
+    return null
+  }
+
+  return (
+    <div className="mt-3 flex flex-wrap gap-2">
+      {targets.map(target => (
+        <PreviewAttachment key={target} source="explicit-link" target={target} />
+      ))}
+    </div>
+  )
+}
+
+function usePreviewMarkdown(text: string, isRunning: boolean) {
+  return useMemo(() => {
+    const targets = extractPreviewTargets(text)
+
+    return {
+      displayText: targets.length > 0 ? stripPreviewTargets(text) : text,
+      targets: isRunning ? [] : targets
+    }
+  }, [isRunning, text])
+}
+
 interface MarkdownTextContentProps extends MarkdownTextSurfaceProps {
   isRunning: boolean
   text: string
 }
 
 export function MarkdownTextContent({ isRunning, text, ...surfaceProps }: MarkdownTextContentProps) {
+  const { displayText, targets } = usePreviewMarkdown(text, isRunning)
+
   return (
-    <TextMessagePartProvider isRunning={isRunning} text={text}>
+    <TextMessagePartProvider isRunning={isRunning} text={displayText}>
       <SmoothStreamingText>
         <DeferStreamingText>
           <MarkdownTextSurface {...surfaceProps} />
         </DeferStreamingText>
       </SmoothStreamingText>
+      <PreviewMarkerCards targets={targets} />
     </TextMessagePartProvider>
   )
 }
 
 const MarkdownTextImpl = () => {
+  const { text, status } = useMessagePartText()
+  const isRunning = status.type === 'running'
+  const { displayText, targets } = usePreviewMarkdown(text, isRunning)
+
   return (
-    <DeferStreamingText>
-      <MarkdownTextSurface />
-    </DeferStreamingText>
+    <TextMessagePartProvider isRunning={isRunning} text={displayText}>
+      <DeferStreamingText>
+        <MarkdownTextSurface />
+      </DeferStreamingText>
+      <PreviewMarkerCards targets={targets} />
+    </TextMessagePartProvider>
   )
 }
 


### PR DESCRIPTION
## Summary
- Render explicit `#preview/...` markdown markers as native Desktop preview cards before Streamdown can sanitize hash-only links.
- Strip preview markers from normal markdown output and render `PreviewAttachment` separately after streaming completes.
- Add regression coverage for opening the preview card and for hiding cards while text is still streaming.

## Verification
- `npm run test:ui -- src/components/assistant-ui/markdown-text.preview.test.tsx src/lib/preview-targets.test.ts src/lib/external-link.test.tsx src/app/session/hooks/use-preview-routing.test.tsx src/store/preview.test.ts` - 28 passed
- `npx eslint src/components/assistant-ui/markdown-text.tsx src/components/assistant-ui/markdown-text.preview.test.tsx`
- `npm run typecheck`
- `npm run build`

## Notes
This fixes the Desktop path where valid preview markers like `[Preview: report.html](#preview/%2Ftmp%2Freport.html)` failed to materialize as the in-app Preview card/button.
