### PR TITLE
feat(voice): real-time voice conversation platform (Daily + Deepgram Flux + Cartesia)

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -171,6 +171,38 @@ model:
 # Choose ONE of the following terminal configurations by uncommenting it.
 # The terminal tool executes commands in the specified environment.
 
+# =============================================================================
+# Voice model (the voice modality's dedicated model)
+# =============================================================================
+# A top-level sibling to `model:` and `fallback_model:`. Real-time voice turns
+# are latency-critical, so they can run on a faster, non-reasoning model while
+# the main model stays whatever you set above. Absent / empty / provider: auto
+# all mean voice rides the main model. Used by the voice platform plugin.
+#
+# voice_model:
+#   provider: groq
+#   model: meta-llama/llama-4-scout-17b-16e-instruct
+
+# =============================================================================
+# Voice platform plugin (realtime voice calls — plugins/platforms/voice)
+# =============================================================================
+# Joins a Daily (WebRTC) room, transcribes with Deepgram Flux (streaming STT +
+# turn detection), and speaks with Cartesia (streaming TTS), with in-process
+# barge-in. Enabled when its three keys are present:
+#   DAILY_API_KEY, DEEPGRAM_API_KEY, CARTESIA_API_KEY   (set in .env)
+# Plus a model for voice turns (voice_model: above, or the main model).
+#
+# platforms:
+#   voice:
+#     extra:
+#       cartesia_voice_id: ""        # Cartesia voice id (or CARTESIA_VOICE_ID)
+#       cartesia_model: sonic-3.5
+#       eot_threshold: 0.7           # Flux end-of-turn confidence
+#       eager_eot_threshold: 0.5     # Flux eager (speculative) end-of-turn
+#       allow_interruptions: true    # barge-in on the caller speaking
+#       tts_speed: ""                # optional Cartesia speed (e.g. 1.0)
+#       greeting_prompt: ""          # optional: how the agent opens the call
+
 # -----------------------------------------------------------------------------
 # OPTION 1: Local execution (default)
 # Commands run directly on your machine in the current directory

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1572,6 +1572,90 @@ def _try_resolve_fallback_provider() -> dict | None:
     return None
 
 
+def _read_voice_model_cfg() -> dict | None:
+    """Read the top-level ``voice_model:`` slot from config.yaml.
+
+    Returns the mapping only when it names a real provider+model; an absent
+    slot, an empty model, or ``provider: auto`` all mean "voice rides the main
+    model" and return None.
+    """
+    try:
+        import yaml as _y
+        cfg_path = _hermes_home / "config.yaml"
+        if not cfg_path.exists():
+            return None
+        with open(cfg_path, encoding="utf-8") as _f:
+            cfg = _y.safe_load(_f) or {}
+        vm = cfg.get("voice_model")
+        if not isinstance(vm, dict) or not vm.get("model"):
+            return None
+        if str(vm.get("provider") or "").strip().lower() in ("", "auto"):
+            return None
+        return vm
+    except Exception:
+        return None
+
+
+def _voice_model_name() -> str | None:
+    """The configured ``voice_model`` slot's model name (telemetry/logging),
+    or None when voice uses the main model."""
+    vm = _read_voice_model_cfg()
+    return (vm or {}).get("model") or None
+
+
+def _resolve_voice_runtime_kwargs() -> dict | None:
+    """Resolve the ``voice_model:`` slot — a dedicated top-level model for the
+    real-time voice modality, a sibling to ``model:`` (main) and
+    ``fallback_model:``.
+
+    Voice is a full agentic turn (tools, memory, the iteration loop) delivered
+    in a latency-critical spoken modality, so it gets its own first-class slot
+    rather than a per-platform override. Returns AIAgent runtime kwargs
+    (endpoint/key/provider/api_mode + ``model``) when the slot is configured,
+    or None when it is unset / ``auto`` (caller uses the main model).
+
+    Mirrors :func:`_try_resolve_fallback_provider`.
+    """
+    from hermes_cli.runtime_provider import resolve_runtime_provider
+
+    vm = _read_voice_model_cfg()
+    if vm is None:
+        return None
+    try:
+        explicit_api_key = vm.get("api_key")
+        if not explicit_api_key:
+            key_env = str(vm.get("key_env") or vm.get("api_key_env") or "").strip()
+            if key_env:
+                explicit_api_key = os.getenv(key_env, "").strip() or None
+        runtime = resolve_runtime_provider(
+            requested=vm.get("provider"),
+            explicit_base_url=vm.get("base_url"),
+            explicit_api_key=explicit_api_key,
+            target_model=vm.get("model"),
+        )
+    except Exception as exc:
+        logger.warning(
+            "voice_model resolution failed (%s); falling back to the main model",
+            exc,
+        )
+        return None
+    logger.info(
+        "Voice model resolved: %s model=%s",
+        vm.get("provider") or runtime.get("provider"),
+        vm.get("model"),
+    )
+    return {
+        "api_key": runtime.get("api_key"),
+        "base_url": runtime.get("base_url"),
+        "provider": runtime.get("provider"),
+        "api_mode": runtime.get("api_mode"),
+        "command": runtime.get("command"),
+        "args": list(runtime.get("args") or []),
+        "credential_pool": runtime.get("credential_pool"),
+        "model": vm.get("model"),
+    }
+
+
 def _build_media_placeholder(event) -> str:
     """Build a text placeholder for media-only events so they aren't dropped.
 

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -4130,7 +4130,7 @@ def check_config_version() -> Tuple[int, int]:
 
 # Fields that are valid at root level of config.yaml
 _KNOWN_ROOT_KEYS = {
-    "_config_version", "model", "providers", "fallback_model",
+    "_config_version", "model", "providers", "fallback_model", "voice_model",
     "fallback_providers", "credential_pool_strategies", "toolsets",
     "agent", "terminal", "display", "compression", "delegation",
     "auxiliary", "custom_providers", "context", "memory", "gateway",
@@ -4275,6 +4275,34 @@ def validate_config_structure(config: Optional[Dict[str, Any]] = None) -> List["
             "fallback_model appears inside custom_providers instead of at root level",
             "Move fallback_model to the top level of config.yaml (no indentation)",
         ))
+
+    # ── voice_model: top-level dict (provider + model) for the voice modality ──
+    # A sibling to model:/fallback_model:. Absent / empty / provider: auto all
+    # mean voice turns ride the main model.
+    vm = config.get("voice_model")
+    if vm is not None:
+        if not isinstance(vm, dict):
+            issues.append(ConfigIssue(
+                "error",
+                f"voice_model should be a dict with 'provider' and 'model', got {type(vm).__name__}",
+                "Change to:\n"
+                "  voice_model:\n"
+                "    provider: groq\n"
+                "    model: meta-llama/llama-4-scout-17b-16e-instruct",
+            ))
+        elif vm:
+            if not vm.get("provider"):
+                issues.append(ConfigIssue(
+                    "warning",
+                    "voice_model is missing 'provider' field — voice will use the main model",
+                    "Add: provider: groq (or another provider)",
+                ))
+            if not vm.get("model"):
+                issues.append(ConfigIssue(
+                    "warning",
+                    "voice_model is missing 'model' field — voice will use the main model",
+                    "Add: model: <model-name>",
+                ))
 
     # ── model section: should exist when custom_providers is configured ──
     model_cfg = config.get("model")

--- a/plugins/platforms/voice/__init__.py
+++ b/plugins/platforms/voice/__init__.py
@@ -1,0 +1,3 @@
+from .adapter import register
+
+__all__ = ["register"]

--- a/plugins/platforms/voice/adapter.py
+++ b/plugins/platforms/voice/adapter.py
@@ -50,16 +50,16 @@ def _voice_modules():
     try:
         import cartesia_tts
         import daily_transport
-        import deepgram_flux_stt
+        import stt as stt_mod
         import turn_loop
     except ImportError:
         from . import (
             cartesia_tts,
             daily_transport,
-            deepgram_flux_stt,
             turn_loop,
         )
-    return (daily_transport, turn_loop, cartesia_tts, deepgram_flux_stt)
+        from . import stt as stt_mod
+    return (daily_transport, turn_loop, cartesia_tts, stt_mod)
 
 
 def _daily_available() -> bool:
@@ -181,31 +181,30 @@ class VoiceAdapter(BasePlatformAdapter):
         return True
 
     async def _start_call(self, room_url: str, token: str) -> None:
-        daily_transport, turn_loop, cartesia_tts, deepgram_flux_stt = _voice_modules()
+        daily_transport, turn_loop, cartesia_tts, stt_mod = _voice_modules()
         async with self._call_lock:
             if self._active_call is not None:
                 await self._end_call_locked("replaced-by-new-call")
             loop = asyncio.get_running_loop()
             extra = self.config.extra or {}
 
-            # STT: Deepgram Flux — streaming ASR + model-integrated turn
-            # detection (start/eager-end/resumed/end-of-turn events the turn
-            # loop reacts to). Inbound caller audio is 24 kHz; Flux resamples
-            # 24k->16k internally.
-            dg_key = os.getenv("DEEPGRAM_API_KEY", "").strip()
-            if not dg_key:
-                raise RuntimeError("DEEPGRAM_API_KEY is not set")
-            stt = deepgram_flux_stt.DeepgramFluxSTT(
-                dg_key,
+            # STT: streaming ASR + model-integrated turn detection
+            # (start/eager-end/resumed/end-of-turn events the turn loop reacts
+            # to). Deepgram Flux is the default; the make_stt factory is the
+            # seam so another provider (e.g. Cartesia Ink-2) can be A/B'd
+            # behind the same port. Inbound caller audio is at the Daily
+            # SPEAKER_RATE; each adapter handles its own rate (Flux resamples
+            # 24k->16k internally; Ink-2 accepts the native rate). The factory
+            # resolves the provider's API key and raises if it's missing.
+            stt_provider = (extra.get("stt_provider")
+                            or "deepgram_flux").strip().lower()
+            stt = stt_mod.make_stt(
+                stt_provider,
                 input_rate=daily_transport.SPEAKER_RATE,
-                eot_threshold=_resolve_float_extra(
-                    extra, "eot_threshold",
-                    deepgram_flux_stt.DEFAULT_EOT_THRESHOLD),
-                eager_eot_threshold=_resolve_float_extra(
-                    extra, "eager_eot_threshold",
-                    deepgram_flux_stt.DEFAULT_EAGER_EOT_THRESHOLD),
+                extra=extra,
             )
             await stt.start()
+            logger.info("voice: STT provider=%s", stt.provider)
 
             async def on_audio_in(pcm: bytes) -> None:
                 await stt.send_audio(pcm)
@@ -345,6 +344,7 @@ class VoiceAdapter(BasePlatformAdapter):
             "room_url": call.get("room_url"),
             "call_s": round(time.monotonic() - call["started_at"], 1),
             "asr_seconds_est": round(call["stt"].asr_seconds_est, 1),
+            "stt_provider": call["stt"].provider,
         }
         # Durable + WARNING-level emit: this is the per-call cost record; it
         # must survive log levels/rotation on the agent volume.

--- a/plugins/platforms/voice/adapter.py
+++ b/plugins/platforms/voice/adapter.py
@@ -1,0 +1,410 @@
+"""Voice platform plugin — realtime Daily (WebRTC) voice calls.
+
+Structural template: plugins/platforms/ntfy/adapter.py.
+Turn orchestration lives in turn_loop.py; this module owns plugin
+registration, requirement checks, and the adapter lifecycle.
+
+Standalone mode: this agent holds DAILY_API_KEY, creates its own private
+Daily room + a single-use meeting token at connect time, joins immediately,
+and logs the room URL for the owner to share. caller == owner.
+
+Opinionated stack: Deepgram Flux (streaming STT + model-integrated turn
+detection), Cartesia (streaming TTS, default — the per-turn TTS is built
+behind a factory so another provider can be slotted in), and the agent's
+voice_model: for generation.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import time
+from typing import Any, Dict, Optional, Tuple
+
+from gateway.config import Platform, PlatformConfig
+from gateway.platforms.base import (
+    BasePlatformAdapter,
+    SendResult,
+)
+
+logger = logging.getLogger(__name__)
+
+DAILY_API = "https://api.daily.co/v1"
+STANDALONE_ROOM_TTL_S = 3600
+
+# Call watchdog: an abandoned call — tab closed, or the room expired and
+# ejected the agent — would otherwise leave the billable STT stream running.
+# The watchdog tears the call down when humans are gone, the call ended
+# remotely, or a hard age cap is hit.
+DEFAULT_IDLE_TEARDOWN_S = 60.0   # extra.idle_teardown_s
+DEFAULT_MAX_CALL_S = 1800.0      # extra.max_call_s
+WATCHDOG_POLL_S = 0.5
+
+
+def _voice_modules():
+    """Sibling voice modules via the discord dual-import pattern
+    (plugins/platforms/discord/adapter.py:1991-1993): flat import for the
+    test loader, relative import for the production package
+    (hermes_plugins.platforms__voice)."""
+    try:
+        import cartesia_tts
+        import daily_transport
+        import deepgram_flux_stt
+        import turn_loop
+    except ImportError:
+        from . import (
+            cartesia_tts,
+            daily_transport,
+            deepgram_flux_stt,
+            turn_loop,
+        )
+    return (daily_transport, turn_loop, cartesia_tts, deepgram_flux_stt)
+
+
+def _daily_available() -> bool:
+    try:
+        import daily  # noqa: F401
+        return True
+    except ImportError:
+        return False
+
+
+def _websockets_available() -> bool:
+    try:
+        import websockets  # noqa: F401
+        return True
+    except ImportError:
+        return False
+
+
+def check_requirements() -> bool:
+    """Deps importable + the three call keys present (cheap env read, no
+    config load): Daily (transport), Deepgram (Flux STT), Cartesia (TTS)."""
+    if not _daily_available() or not _websockets_available():
+        return False
+    return bool(
+        os.getenv("DAILY_API_KEY", "").strip()
+        and os.getenv("DEEPGRAM_API_KEY", "").strip()
+        and os.getenv("CARTESIA_API_KEY", "").strip()
+    )
+
+
+def _resolve_float_extra(extra: Dict[str, Any], key: str, default: float) -> float:
+    raw = extra.get(key)
+    if raw is None or (isinstance(raw, str) and not raw.strip()):
+        return default
+    try:
+        return float(raw)
+    except (TypeError, ValueError):
+        logger.warning("voice: invalid %s=%r; using default %s",
+                       key, raw, default)
+        return default
+
+
+def _resolve_opt_float_extra(extra: Dict[str, Any], key: str) -> Optional[float]:
+    """Like _resolve_float_extra but returns None (not a default) when unset —
+    so a Cartesia generation_config field is only sent when the user set it."""
+    raw = extra.get(key)
+    if raw is None or (isinstance(raw, str) and not raw.strip()):
+        return None
+    try:
+        return float(raw)
+    except (TypeError, ValueError):
+        logger.warning("voice: invalid %s=%r; ignoring", key, raw)
+        return None
+
+
+def validate_config(config) -> bool:
+    return bool(os.getenv("DAILY_API_KEY", "").strip())
+
+
+def is_connected(config) -> bool:
+    return check_requirements() and validate_config(config)
+
+
+def register(ctx) -> None:
+    """Plugin entry point — called by the Hermes plugin system at startup."""
+    ctx.register_platform(
+        name="voice",
+        label="Voice",
+        adapter_factory=lambda cfg: VoiceAdapter(cfg),
+        check_fn=check_requirements,
+        validate_config=validate_config,
+        is_connected=is_connected,
+        required_env=["DAILY_API_KEY", "DEEPGRAM_API_KEY", "CARTESIA_API_KEY"],
+        install_hint='uv sync --extra voice-platform   # daily-python + websockets',
+        pii_safe=True,
+        emoji="📞",
+        allow_update_command=False,
+        platform_hint=(
+            "You are on a live voice call. Speak naturally and BRIEFLY — "
+            "1-3 short sentences per reply unless asked for detail. Never use "
+            "markdown, bullet lists, code blocks, or URLs; everything you "
+            "write is read aloud. If a tool call will take a while, say so "
+            "in a few words first."
+        ),
+    )
+
+
+class VoiceAdapter(BasePlatformAdapter):
+    """Daily-room voice call adapter (standalone mode).
+
+    This agent holds DAILY_API_KEY, creates its own private room + meeting
+    token via the Daily REST API at connect time, joins immediately, and logs
+    the room URL for the owner to share.
+
+    One active call at a time (daily-python virtual devices are process-level
+    singletons — see daily_transport.py).
+    """
+
+    def __init__(self, config: PlatformConfig):
+        platform = Platform("voice")
+        super().__init__(config=config, platform=platform)
+        self._call_lock = asyncio.Lock()
+        self._active_call: Optional[Dict[str, Any]] = None
+
+    async def connect(self) -> bool:
+        # Standalone: create our own private room + tokens, join immediately.
+        # The room is private, so the shareable URL must carry an owner token —
+        # the bare room URL alone cannot join a private room.
+        room_url, agent_token, share_url = await self._create_standalone_room()
+        await self._start_call(room_url, agent_token)
+        self._mark_connected()
+        # WARNING level so the URL is visible at the default gateway log level —
+        # this is how the owner discovers where to call. The token in the URL is
+        # the join permission (the room is private); share it only with people
+        # you want to reach your agent.
+        logger.warning(
+            "voice: standalone call ready — open this URL to talk to your "
+            "agent (keep the token private):\n    %s", share_url)
+        return True
+
+    async def _start_call(self, room_url: str, token: str) -> None:
+        daily_transport, turn_loop, cartesia_tts, deepgram_flux_stt = _voice_modules()
+        async with self._call_lock:
+            if self._active_call is not None:
+                await self._end_call_locked("replaced-by-new-call")
+            loop = asyncio.get_running_loop()
+            extra = self.config.extra or {}
+
+            # STT: Deepgram Flux — streaming ASR + model-integrated turn
+            # detection (start/eager-end/resumed/end-of-turn events the turn
+            # loop reacts to). Inbound caller audio is 24 kHz; Flux resamples
+            # 24k->16k internally.
+            dg_key = os.getenv("DEEPGRAM_API_KEY", "").strip()
+            if not dg_key:
+                raise RuntimeError("DEEPGRAM_API_KEY is not set")
+            stt = deepgram_flux_stt.DeepgramFluxSTT(
+                dg_key,
+                input_rate=daily_transport.SPEAKER_RATE,
+                eot_threshold=_resolve_float_extra(
+                    extra, "eot_threshold",
+                    deepgram_flux_stt.DEFAULT_EOT_THRESHOLD),
+                eager_eot_threshold=_resolve_float_extra(
+                    extra, "eager_eot_threshold",
+                    deepgram_flux_stt.DEFAULT_EAGER_EOT_THRESHOLD),
+            )
+            await stt.start()
+
+            async def on_audio_in(pcm: bytes) -> None:
+                await stt.send_audio(pcm)
+
+            transport = daily_transport.DailyTransport(loop, on_audio_in)
+            await transport.join(room_url, token)
+
+            # TTS: Cartesia (default). ONE persistent socket for the whole call
+            # (connect is too costly to pay per turn), opened here so turn 1 is
+            # fast. The per-turn tts_factory is the seam for another provider.
+            tts_provider = (extra.get("tts_provider") or "cartesia").strip().lower()
+            if tts_provider != "cartesia":
+                raise RuntimeError(
+                    f"unsupported tts_provider={tts_provider!r}; "
+                    "'cartesia' is the bundled provider")
+            cartesia_key = os.getenv("CARTESIA_API_KEY", "").strip()
+            if not cartesia_key:
+                raise RuntimeError("CARTESIA_API_KEY is not set")
+            cartesia_voice = (
+                extra.get("cartesia_voice_id")
+                or os.getenv("CARTESIA_VOICE_ID", "").strip()
+            )
+            tts_client = cartesia_tts.CartesiaTTSClient(
+                cartesia_key,
+                cartesia_voice,
+                model=extra.get("cartesia_model") or cartesia_tts.DEFAULT_MODEL,
+                speed=_resolve_opt_float_extra(extra, "tts_speed"),
+                volume=_resolve_opt_float_extra(extra, "tts_volume"),
+                emotion=(extra.get("tts_emotion") or None),
+            )
+            await tts_client.connect()
+            logger.info("voice: TTS provider=cartesia model=%s voice=%s",
+                        tts_client._model, cartesia_voice)
+
+            async def tts_factory(on_audio):
+                turn = tts_client.new_turn(on_audio)
+                await turn.open()
+                return turn
+
+            vloop = turn_loop.VoiceTurnLoop(
+                stt, tts_factory, transport, extra=extra)
+            task = asyncio.create_task(vloop.run())
+            self._active_call = {
+                "stt": stt, "transport": transport, "loop": vloop,
+                "task": task, "tts_client": tts_client,
+                "started_at": time.monotonic(), "room_url": room_url}
+            self._active_call["watchdog"] = asyncio.create_task(
+                self._call_watchdog(transport))
+            logger.info("voice: call started in %s", room_url)
+
+    async def _call_watchdog(self, transport) -> None:
+        """Tear the call down when it is no longer worth paying for:
+          - no human (remote) participant for extra.idle_teardown_s
+            (tab closed / never joined),
+          - the call ended remotely (room expired, agent ejected, fatal
+            client error),
+          - call age exceeds extra.max_call_s (hard cost cap).
+        Polls every WATCHDOG_POLL_S. asr_seconds_est in the teardown summary
+        makes the cost of every call auditable."""
+        extra = self.config.extra or {}
+        idle_teardown_s = _resolve_float_extra(
+            extra, "idle_teardown_s", DEFAULT_IDLE_TEARDOWN_S)
+        max_call_s = _resolve_float_extra(
+            extra, "max_call_s", DEFAULT_MAX_CALL_S)
+        idle_since: Optional[float] = None
+        while True:
+            await asyncio.sleep(WATCHDOG_POLL_S)
+            call = self._active_call
+            if call is None or call.get("transport") is not transport:
+                return
+            now = time.monotonic()
+            age_s = now - call["started_at"]
+            reason = None
+            abnormal = transport.abnormal_end
+            if abnormal is not None:
+                reason = "remote-end"
+                logger.warning(
+                    "voice: WATCHDOG teardown reason=%s detail=%r age_s=%.0f "
+                    "— call ended remotely (ejection/expiry/error)",
+                    reason, abnormal, age_s)
+            elif age_s >= max_call_s:
+                reason = "max-call-duration"
+                logger.warning(
+                    "voice: WATCHDOG teardown reason=%s age_s=%.0f "
+                    "max_call_s=%.0f — hard cost cap hit",
+                    reason, age_s, max_call_s)
+            elif transport.remote_participant_count == 0:
+                if idle_since is None:
+                    idle_since = now
+                elif now - idle_since >= idle_teardown_s:
+                    reason = "no-human-participants"
+                    logger.warning(
+                        "voice: WATCHDOG teardown reason=%s idle_s=%.0f "
+                        "idle_teardown_s=%.0f age_s=%.0f — caller gone "
+                        "(tab closed / never joined)",
+                        reason, now - idle_since, idle_teardown_s, age_s)
+            else:
+                idle_since = None
+            if reason is not None:
+                await self._end_call(reason)
+                return
+
+    async def _end_call(self, reason: str) -> None:
+        async with self._call_lock:
+            await self._end_call_locked(reason)
+
+    async def _end_call_locked(self, reason: str) -> None:
+        call = self._active_call
+        if call is None:
+            return
+        self._active_call = None
+        # FIRST: kill the billable keep-alive feed. Every await below can take
+        # real time, and the keep-alive must not pump paid STT audio while the
+        # call winds down.
+        call["transport"].begin_teardown()
+        watchdog = call.get("watchdog")
+        if watchdog is not None and watchdog is not asyncio.current_task():
+            watchdog.cancel()
+            try:
+                await watchdog
+            except (asyncio.CancelledError, Exception):
+                pass
+        await call["loop"].stop()
+        call["task"].cancel()
+        try:
+            await call["task"]
+        except (asyncio.CancelledError, Exception):
+            pass
+        await call["stt"].stop()
+        tts_client = call.get("tts_client")
+        if tts_client is not None:
+            await tts_client.close()
+        await call["transport"].leave()
+        summary = {
+            "event": "voice_call_teardown",
+            "reason": reason,
+            "room_url": call.get("room_url"),
+            "call_s": round(time.monotonic() - call["started_at"], 1),
+            "asr_seconds_est": round(call["stt"].asr_seconds_est, 1),
+        }
+        # Durable + WARNING-level emit: this is the per-call cost record; it
+        # must survive log levels/rotation on the agent volume.
+        (_, turn_loop, _, _) = _voice_modules()
+        turn_loop.emit_telemetry(summary)
+        logger.info("voice: call ended reason=%s", reason)
+
+    async def _create_standalone_room(self) -> Tuple[str, str, str]:
+        """Create a private room + two short-lived meeting tokens: one the agent
+        joins with, and one embedded in the shareable URL so the owner can join
+        the private room (the bare URL cannot). Returns
+        (room_url, agent_token, share_url)."""
+        import httpx
+
+        daily_key = os.environ["DAILY_API_KEY"]
+        headers = {"Authorization": f"Bearer {daily_key}"}
+        exp = int(time.time()) + STANDALONE_ROOM_TTL_S
+        async with httpx.AsyncClient(timeout=15.0) as client:
+            room_resp = await client.post(
+                f"{DAILY_API}/rooms", headers=headers,
+                json={"privacy": "private", "properties": {"exp": exp}},
+            )
+            room_resp.raise_for_status()
+            room = room_resp.json()
+
+            async def _mint_token(is_owner: bool) -> str:
+                resp = await client.post(
+                    f"{DAILY_API}/meeting-tokens", headers=headers,
+                    json={"properties": {"room_name": room["name"],
+                                         "is_owner": is_owner, "exp": exp}},
+                )
+                resp.raise_for_status()
+                return resp.json()["token"]
+
+            agent_token = await _mint_token(False)
+            human_token = await _mint_token(True)
+        share_url = f"{room['url']}?t={human_token}"
+        return room["url"], agent_token, share_url
+
+    async def disconnect(self) -> None:
+        await self._end_call("adapter-disconnect")
+
+    async def send(self, chat_id, content, reply_to=None, metadata=None) -> SendResult:
+        """Out-of-band sends (cron etc.): speak if a call is live.
+
+        The gateway never routes normal chat through this adapter (the turn
+        loop owns the conversation), but the abstract method must exist
+        (base.py:2257). Honest failure beats a hidden queue.
+        """
+        call = self._active_call
+        if call is None:
+            return SendResult(success=False, error="no active voice call")
+        tts = call["loop"]._tts
+        if tts is None:
+            return SendResult(
+                success=False,
+                error="agent not mid-utterance; queueing not supported in v0",
+            )
+        await tts.send_text(content)
+        return SendResult(success=True, message_id="voice")
+
+    async def get_chat_info(self, chat_id: str) -> Dict[str, Any]:
+        return {"name": "Voice Call", "type": "dm"}

--- a/plugins/platforms/voice/cartesia_ink_stt.py
+++ b/plugins/platforms/voice/cartesia_ink_stt.py
@@ -12,12 +12,17 @@ Input: raw s16le mono PCM at the call's native rate. Unlike Flux (which we
 resample 24k->16k), Ink-2 accepts the declared sample_rate directly, so we send
 the inbound mic audio AS-IS and just declare its rate in the URL — no resample.
 
-IMPORTANT — wire schema is ASSUMED, not yet verified live. The turn-event JSON
-field names (transcript / confidence / words), the exact ``type`` strings, and
-whether eager-end needs an opt-in query param are not confirmed. Every such
-assumption is isolated in ``_normalize_ink_message`` and the URL builder behind
-``# VERIFY-AGAINST-LIVE-API:`` comments, so a first live call can correct them
-in one place without touching the turn loop.
+Wire schema VERIFIED live 2026-06-16 (probe against the real socket):
+  {"type":"connected","request_id":...}                       -> ignored ack
+  {"type":"turn.start","turn_id":"1","request_id":...}
+  {"type":"turn.update","transcript":"Hi, I'm","turn_id":"1",...}   (cumulative)
+  {"type":"turn.eager_end","transcript":"...","turn_id":"1",...}
+  {"type":"turn.resume","turn_id":"1",...}                     (no transcript)
+  {"type":"turn.end","transcript":"...","turn_id":"1",...}     (final)
+Transcript lives in ``transcript``; the id field is ``turn_id`` (string);
+there is no ``confidence`` or per-word list; eager-end fires by default (no
+opt-in param). Connection params + ``Authorization: Bearer`` + ``Cartesia-Version``
+header are confirmed working.
 """
 
 from __future__ import annotations
@@ -39,9 +44,7 @@ WS_BASE = "wss://api.cartesia.ai/stt/turns/websocket"
 INK_MODEL = "ink-2"
 CARTESIA_VERSION = "2026-03-01"
 
-# VERIFY-AGAINST-LIVE-API: top-level message "type" -> normalized EV_*. These
-# turn.* strings are the assumed Realtime-turns event names; confirm against a
-# live socket capture and fix only this map if they differ.
+# Verified live 2026-06-16: top-level message "type" -> normalized EV_*.
 _INK_EVENT_MAP = {
     "turn.start": EV_START,
     "turn.update": EV_UPDATE,
@@ -59,34 +62,20 @@ def _normalize_ink_message(msg: Dict[str, Any]) -> Optional[Dict[str, Any]]:
     Yields the same shape Flux yields:
         {"event", "transcript", "confidence", "words", "turn_index"}
     """
-    raw_type = msg.get("type")
-    ev = _INK_EVENT_MAP.get(raw_type)
+    ev = _INK_EVENT_MAP.get(msg.get("type"))
     if ev is None:
-        # Non-turn frames (acks, metadata, errors) are surfaced by the caller;
-        # here we just drop anything that isn't a known turn event.
+        # Non-turn frames ("connected" ack, metadata, errors) are not turn
+        # events; the loop ignores them.
         return None
-    # VERIFY-AGAINST-LIVE-API: transcript field name. Try the most likely keys
-    # in order; Cartesia may use "text", "transcript", or "transcript_text".
-    transcript = (
-        msg.get("text")
-        or msg.get("transcript")
-        or msg.get("transcript_text")
-        or ""
-    )
-    # VERIFY-AGAINST-LIVE-API: confidence field name (assumed "confidence";
-    # Flux uses "end_of_turn_confidence"). Defaults to None if absent.
-    confidence = msg.get("confidence")
-    # VERIFY-AGAINST-LIVE-API: per-word timing list field name (assumed
-    # "words"). Defaults to [] if absent — the turn loop does not require it.
-    words = msg.get("words") or []
-    # VERIFY-AGAINST-LIVE-API: turn index field name (assumed "turn_index").
-    turn_index = msg.get("turn_index")
+    # Verified: transcript in "transcript"; id in "turn_id" (string). Ink-2
+    # sends no confidence or per-word list, so those stay None/[] (the turn
+    # loop does not require them) — kept for shape-parity with the Flux adapter.
     return {
         "event": ev,
-        "transcript": transcript or "",
-        "confidence": confidence,
-        "words": words,
-        "turn_index": turn_index,
+        "transcript": msg.get("transcript") or "",
+        "confidence": None,
+        "words": [],
+        "turn_index": msg.get("turn_id"),
     }
 
 
@@ -115,10 +104,8 @@ class CartesiaInkSTT:
         return self._asr_seconds
 
     def _url(self) -> str:
-        # VERIFY-AGAINST-LIVE-API: query params. This is the Realtime "Auto"
-        # endpoint (Cartesia owns turn detection). Whether turn.eager_end is
-        # emitted by default or needs an opt-in param (e.g. &eager_end=true) is
-        # NOT confirmed — add it here if eager events never arrive live.
+        # Realtime "Auto" endpoint (Cartesia owns turn detection). Verified
+        # live: these params connect and eager-end fires by default.
         return (
             f"{WS_BASE}?model={INK_MODEL}"
             f"&encoding=pcm_s16le&sample_rate={self._input_rate}"

--- a/plugins/platforms/voice/cartesia_ink_stt.py
+++ b/plugins/platforms/voice/cartesia_ink_stt.py
@@ -1,0 +1,213 @@
+"""Cartesia Ink-2 streaming STT — conversational ASR with model-integrated
+turn detection (the Realtime "Auto" turns websocket).
+
+Like Deepgram Flux, Ink-2 is a single model that does transcription AND
+turn-taking: Cartesia owns turn detection server-side and emits
+conversation-native turn events. This adapter normalizes those onto the same
+EV_* contract Flux uses, so the turn loop drives it identically — the seam
+exists so we can A/B Ink-2 against Flux on turn-taking + latency. Accuracy is
+out of scope here.
+
+Input: raw s16le mono PCM at the call's native rate. Unlike Flux (which we
+resample 24k->16k), Ink-2 accepts the declared sample_rate directly, so we send
+the inbound mic audio AS-IS and just declare its rate in the URL — no resample.
+
+IMPORTANT — wire schema is ASSUMED, not yet verified live. The turn-event JSON
+field names (transcript / confidence / words), the exact ``type`` strings, and
+whether eager-end needs an opt-in query param are not confirmed. Every such
+assumption is isolated in ``_normalize_ink_message`` and the URL builder behind
+``# VERIFY-AGAINST-LIVE-API:`` comments, so a first live call can correct them
+in one place without touching the turn loop.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+from typing import Any, AsyncIterator, Dict, Optional
+
+logger = logging.getLogger(__name__)
+
+# Canonical normalized event names live in stt.py (the port).
+try:
+    from stt import EV_EAGER_EOT, EV_END, EV_RESUMED, EV_START, EV_UPDATE
+except ImportError:
+    from .stt import EV_EAGER_EOT, EV_END, EV_RESUMED, EV_START, EV_UPDATE
+
+WS_BASE = "wss://api.cartesia.ai/stt/turns/websocket"
+INK_MODEL = "ink-2"
+CARTESIA_VERSION = "2026-03-01"
+
+# VERIFY-AGAINST-LIVE-API: top-level message "type" -> normalized EV_*. These
+# turn.* strings are the assumed Realtime-turns event names; confirm against a
+# live socket capture and fix only this map if they differ.
+_INK_EVENT_MAP = {
+    "turn.start": EV_START,
+    "turn.update": EV_UPDATE,
+    "turn.eager_end": EV_EAGER_EOT,
+    "turn.resume": EV_RESUMED,
+    "turn.end": EV_END,
+}
+
+
+def _normalize_ink_message(msg: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+    """Map a raw Ink-2 server message to the normalized turn event the loop
+    consumes, or None for messages we ignore. ALL wire-schema assumptions are
+    isolated here so a first live call corrects them in one place.
+
+    Yields the same shape Flux yields:
+        {"event", "transcript", "confidence", "words", "turn_index"}
+    """
+    raw_type = msg.get("type")
+    ev = _INK_EVENT_MAP.get(raw_type)
+    if ev is None:
+        # Non-turn frames (acks, metadata, errors) are surfaced by the caller;
+        # here we just drop anything that isn't a known turn event.
+        return None
+    # VERIFY-AGAINST-LIVE-API: transcript field name. Try the most likely keys
+    # in order; Cartesia may use "text", "transcript", or "transcript_text".
+    transcript = (
+        msg.get("text")
+        or msg.get("transcript")
+        or msg.get("transcript_text")
+        or ""
+    )
+    # VERIFY-AGAINST-LIVE-API: confidence field name (assumed "confidence";
+    # Flux uses "end_of_turn_confidence"). Defaults to None if absent.
+    confidence = msg.get("confidence")
+    # VERIFY-AGAINST-LIVE-API: per-word timing list field name (assumed
+    # "words"). Defaults to [] if absent — the turn loop does not require it.
+    words = msg.get("words") or []
+    # VERIFY-AGAINST-LIVE-API: turn index field name (assumed "turn_index").
+    turn_index = msg.get("turn_index")
+    return {
+        "event": ev,
+        "transcript": transcript or "",
+        "confidence": confidence,
+        "words": words,
+        "turn_index": turn_index,
+    }
+
+
+class CartesiaInkSTT:
+    """One Cartesia Ink-2 websocket for a call. ``events()`` yields normalized
+    turn events; ``send_audio`` streams the mic audio at its native rate (no
+    resample)."""
+
+    provider = "cartesia_ink"   # telemetry tag (the STT port surface)
+
+    def __init__(self, api_key: str, *, input_rate: int = 24000):
+        if not api_key:
+            raise ValueError("CARTESIA_API_KEY is required for Ink-2 STT")
+        self._api_key = api_key
+        self._input_rate = input_rate
+        self._ws = None
+        self._recv_task: Optional[asyncio.Task] = None
+        self._queue: "asyncio.Queue[Optional[Dict[str, Any]]]" = asyncio.Queue()
+        self._closed = False
+        self._asr_seconds = 0.0   # cost telemetry: audio seconds streamed
+
+    @property
+    def asr_seconds_est(self) -> float:
+        """Estimated seconds of audio sent to ASR (for the per-call cost
+        record)."""
+        return self._asr_seconds
+
+    def _url(self) -> str:
+        # VERIFY-AGAINST-LIVE-API: query params. This is the Realtime "Auto"
+        # endpoint (Cartesia owns turn detection). Whether turn.eager_end is
+        # emitted by default or needs an opt-in param (e.g. &eager_end=true) is
+        # NOT confirmed — add it here if eager events never arrive live.
+        return (
+            f"{WS_BASE}?model={INK_MODEL}"
+            f"&encoding=pcm_s16le&sample_rate={self._input_rate}"
+            f"&language=en"
+        )
+
+    async def start(self) -> None:
+        import websockets
+        self._ws = await websockets.connect(
+            self._url(),
+            additional_headers={
+                "Authorization": f"Bearer {self._api_key}",
+                "Cartesia-Version": CARTESIA_VERSION,
+            },
+            max_size=None, ping_interval=5, ping_timeout=10,
+        )
+        self._recv_task = asyncio.create_task(self._recv_loop(self._ws))
+        logger.info("voice/stt cartesia-ink: connected model=%s rate=%d",
+                    INK_MODEL, self._input_rate)
+
+    async def _recv_loop(self, ws) -> None:
+        try:
+            async for raw in ws:
+                msg = json.loads(raw)
+                norm = _normalize_ink_message(msg)
+                if norm is not None:
+                    await self._queue.put(norm)
+                # VERIFY-AGAINST-LIVE-API: error frame "type" string (assumed
+                # "error"). Log it so live debugging surfaces wire mismatches.
+                elif msg.get("type") in ("error", "Error"):
+                    logger.warning("voice/stt cartesia-ink: %s: %s",
+                                   msg.get("type"), msg)
+                # Acks / metadata / unknown turn-detection frames: informational.
+        except asyncio.CancelledError:
+            raise
+        except Exception as e:
+            if not self._closed:
+                logger.warning("voice/stt cartesia-ink: socket closed: %s", e)
+        finally:
+            await self._queue.put(None)   # unblock events()
+
+    async def send_audio(self, pcm: bytes) -> None:
+        if self._closed or self._ws is None:
+            return
+        self._asr_seconds += len(pcm) / 2 / self._input_rate   # s16le mono
+        try:
+            # Ink-2 accepts the declared sample_rate directly: send raw s16le
+            # binary frames at the native input rate (no resample).
+            await self._ws.send(pcm)
+        except Exception as e:
+            if not self._closed:
+                logger.warning("voice/stt cartesia-ink: send failed: %s", e)
+
+    async def events(self) -> AsyncIterator[Dict[str, Any]]:
+        """Yield normalized turn events until the stream ends."""
+        while True:
+            item = await self._queue.get()
+            if item is None:
+                return
+            yield item
+
+    async def configure(self, **kw: Any) -> None:
+        """No-op: Ink-2 turn detection is model-controlled (no eot/eager
+        thresholds yet), so there is nothing to tune mid-stream. Logged once at
+        INFO so a tuning attempt isn't silently swallowed."""
+        if not getattr(self, "_configure_warned", False):
+            self._configure_warned = True
+            logger.info(
+                "voice/stt cartesia-ink: configure() is a no-op — Ink-2 turn "
+                "detection is model-controlled (no tunable thresholds)")
+
+    async def stop(self) -> None:
+        self._closed = True
+        if self._ws is not None:
+            try:
+                # VERIFY-AGAINST-LIVE-API: close/finalize control message shape
+                # (assumed {"type":"close"}; Flux uses {"type":"CloseStream"}).
+                await self._ws.send(json.dumps({"type": "close"}))
+            except Exception:
+                pass
+        if self._recv_task is not None and not self._recv_task.done():
+            self._recv_task.cancel()
+            try:
+                await self._recv_task
+            except (asyncio.CancelledError, Exception):
+                pass
+        if self._ws is not None:
+            try:
+                await self._ws.close()
+            except Exception:
+                pass
+        self._ws = None

--- a/plugins/platforms/voice/cartesia_tts.py
+++ b/plugins/platforms/voice/cartesia_tts.py
@@ -1,0 +1,319 @@
+"""Cartesia streaming TTS over a PERSISTENT websocket.
+
+Why persistent (not one socket per turn): a fresh Cartesia websocket costs
+~600-1400ms to connect (TLS + handshake), measured live
+2026-06-13. Paying that per turn would dwarf the ~200-310ms synthesis
+latency. Cartesia's own guidance is to amortize connect across turns and use
+one ``context_id`` per utterance ("Live session (WebSocket)" is the
+recommended endpoint for streaming LLM tokens). So a single
+``CartesiaTTSClient`` holds the socket for the whole call and hands out a
+lightweight ``CartesiaTTSTurn`` per agent turn.
+
+Model: ``sonic-3.5`` (latest — "fastest, most natural", sub-90ms model
+latency). Output: 48 kHz s16le mono PCM to match the Daily transport exactly
+(no resampling). Managed buffering: sentences are sent with ``continue=true``
+ending in punctuation, so the model has enough context to start promptly; the
+turn closes with ``continue=false``. The turn loop's ``<flush>`` sentinel maps
+to Cartesia's native manual flush (``flush=true`` + empty transcript), never
+spoken as text.
+
+Barge-in: server-side cancel is unreliable (verified live — audio chunks keep
+arriving after a ``cancel``), so barge-in is CLIENT-SIDE: ``mute()`` drops
+audio immediately and ``context_id`` routing guarantees a finished/aborted
+turn's audio never reaches the transport.
+
+Wire facts verified live (2026-06-13): audio arrives as
+``{"type":"chunk","context_id":...,"data":"<base64 pcm>"}`` (the ``data``
+field, not the doc summary's ``audio``); turn ends with ``{"type":"done"}``;
+errors as ``{"type":"error","error":...}``. We read ``data`` first and fall
+back to ``audio`` defensively across API versions.
+
+Resilience: the websockets library answers ping/pong automatically; we set an
+explicit ping_interval so the socket survives silent gaps BETWEEN turns
+(Cartesia closes idle sockets). If the socket drops, the next send lazily
+reconnects.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import json
+import logging
+import time
+from typing import Any, Awaitable, Callable, Dict, Optional
+
+logger = logging.getLogger(__name__)
+
+WS_URL = "wss://api.cartesia.ai/tts/websocket"
+CARTESIA_VERSION = "2024-11-13"
+OUTPUT_SAMPLE_RATE = 48000          # matches the Daily transport (no resample)
+DEFAULT_MODEL = "sonic-3.5"
+FLUSH_SENTINEL = "<flush>"          # force-synth token the turn loop emits
+PING_INTERVAL_S = 15                # keep the socket alive across idle turn gaps
+PING_TIMEOUT_S = 15
+
+
+class CartesiaTTSClient:
+    """Persistent Cartesia websocket for one call.
+
+    One turn is active at a time (the turn loop guarantees this). A single
+    recv loop routes audio chunks to the active turn by ``context_id``;
+    chunks for a finished/barged-in context are dropped.
+    """
+
+    def __init__(
+        self,
+        api_key: str,
+        voice_id: str,
+        *,
+        model: str = DEFAULT_MODEL,
+        speed: Optional[float] = None,
+        volume: Optional[float] = None,
+        emotion: Optional[str] = None,
+        max_buffer_delay_ms: Optional[int] = None,
+    ):
+        if not api_key:
+            raise ValueError("CARTESIA_API_KEY is required for cartesia TTS")
+        if not voice_id:
+            raise ValueError("a Cartesia voice_id is required for cartesia TTS")
+        self._api_key = api_key
+        self._voice_id = voice_id
+        self._model = model or DEFAULT_MODEL
+        self._gen_cfg: Dict[str, Any] = {}
+        if speed is not None:
+            self._gen_cfg["speed"] = speed
+        if volume is not None:
+            self._gen_cfg["volume"] = volume
+        if emotion:
+            self._gen_cfg["emotion"] = emotion
+        self._max_buffer_delay_ms = max_buffer_delay_ms
+        self._ws = None
+        self._recv_task: Optional[asyncio.Task] = None
+        self._active: Optional["CartesiaTTSTurn"] = None
+        self._turn_seq = 0
+        self._reconnects = 0          # observability: socket drops this call
+
+    async def connect(self) -> None:
+        """Pre-pay the socket connect during call setup so turn 1 is fast."""
+        t0 = time.monotonic()
+        await self._ensure_connected()
+        logger.info("voice/tts cartesia: connected model=%s voice=%s in %dms",
+                    self._model, self._voice_id,
+                    int((time.monotonic() - t0) * 1000))
+
+    async def _ensure_connected(self) -> None:
+        if self._ws is not None and not getattr(self._ws, "closed", False):
+            return
+        import websockets
+        if self._ws is not None:
+            self._reconnects += 1
+            logger.warning("voice/tts cartesia: socket was closed; "
+                           "reconnecting (#%d this call)", self._reconnects)
+        url = f"{WS_URL}?api_key={self._api_key}&cartesia_version={CARTESIA_VERSION}"
+        self._ws = await websockets.connect(
+            url, max_size=None,
+            ping_interval=PING_INTERVAL_S, ping_timeout=PING_TIMEOUT_S,
+            close_timeout=2)
+        self._recv_task = asyncio.create_task(self._recv_loop(self._ws))
+
+    async def _recv_loop(self, ws) -> None:
+        try:
+            async for raw in ws:
+                msg = json.loads(raw)
+                mtype = msg.get("type")
+                active = self._active
+                if active is None or msg.get("context_id") != active.context_id:
+                    continue  # stale (previous/barged-in turn) — never forward
+                if mtype == "chunk":
+                    if not active._muted:
+                        data = msg.get("data") or msg.get("audio")
+                        if data:
+                            pcm = base64.b64decode(data)
+                            if active._first_audio_t is None:
+                                active._first_audio_t = time.monotonic()
+                            active._chunks += 1
+                            active._bytes += len(pcm)
+                            await active._on_audio(pcm)
+                elif mtype == "done":
+                    active._done.set()
+                elif mtype == "error":
+                    active._error = msg.get("error") or "error"
+                    logger.warning(
+                        "voice/tts cartesia: server error ctx=%s req=%s: %s",
+                        msg.get("context_id"), msg.get("request_id"),
+                        active._error)
+                    active._done.set()
+                elif mtype == "flush_done":
+                    pass  # context boundary marker; single-turn doesn't need it
+                # timestamps / word messages: not used here
+        except asyncio.CancelledError:
+            raise
+        except Exception as e:
+            logger.warning("voice/tts cartesia: recv loop ended: %s", e)
+        finally:
+            if self._active is not None:
+                # never let end() hang if the socket dropped mid-turn
+                self._active._done.set()
+            if self._ws is ws:
+                self._ws = None
+
+    def new_turn(
+        self, on_audio: Callable[[bytes], Awaitable[None]]
+    ) -> "CartesiaTTSTurn":
+        self._turn_seq += 1
+        return CartesiaTTSTurn(self, f"turn-{self._turn_seq}", on_audio)
+
+    def _request(self, context_id: str, transcript: str, cont: bool,
+                 flush: bool = False) -> Dict[str, Any]:
+        req: Dict[str, Any] = {
+            "model_id": self._model,
+            "transcript": transcript,
+            "voice": {"mode": "id", "id": self._voice_id},
+            "output_format": {
+                "container": "raw",
+                "encoding": "pcm_s16le",
+                "sample_rate": OUTPUT_SAMPLE_RATE,
+            },
+            "language": "en",
+            "context_id": context_id,
+            "continue": cont,
+        }
+        if flush:
+            req["flush"] = True
+        if self._gen_cfg:
+            req["generation_config"] = dict(self._gen_cfg)
+        if self._max_buffer_delay_ms is not None:
+            req["max_buffer_delay_ms"] = self._max_buffer_delay_ms
+        return req
+
+    async def _send(self, payload: Dict[str, Any]) -> None:
+        await self._ensure_connected()
+        await self._ws.send(json.dumps(payload))
+
+    async def close(self) -> None:
+        if self._recv_task is not None and not self._recv_task.done():
+            self._recv_task.cancel()
+            try:
+                await self._recv_task
+            except (asyncio.CancelledError, Exception):
+                pass
+        if self._ws is not None:
+            try:
+                await self._ws.close()
+            except Exception:
+                pass
+        self._ws = None
+        self._active = None
+
+
+class CartesiaTTSTurn:
+    """One agent turn on the client's shared socket. Interface the turn loop
+    expects: open / send_text / send_filler / end / mute / abort."""
+
+    def __init__(self, client: CartesiaTTSClient, context_id: str,
+                 on_audio: Callable[[bytes], Awaitable[None]]):
+        self._client = client
+        self.context_id = context_id
+        self._on_audio = on_audio
+        self._done = asyncio.Event()
+        self._muted = False
+        self._aborted = False
+        self.chars_sent = 0
+        # per-turn observability
+        self._first_send_t: Optional[float] = None
+        self._first_audio_t: Optional[float] = None
+        self._chunks = 0
+        self._bytes = 0
+        self._error: Optional[str] = None
+
+    async def open(self) -> None:
+        # Become the active turn; the socket is already connected (or lazily
+        # connects). Audio for this context_id now routes to our on_audio.
+        self._client._active = self
+        await self._client._ensure_connected()
+
+    async def send_text(self, text: str) -> None:
+        if self._aborted or not text:
+            return
+        if text.strip() == FLUSH_SENTINEL:
+            # <flush> sentinel -> Cartesia native manual flush. Never spoken.
+            # continue=true keeps the context open for more text.
+            try:
+                await self._client._send(
+                    self._client._request(self.context_id, "", True, flush=True))
+            except Exception:
+                pass
+            return
+        text = text.replace(FLUSH_SENTINEL, "").strip()
+        if not text:
+            return
+        if self._first_send_t is None:
+            self._first_send_t = time.monotonic()
+        self.chars_sent += len(text)
+        await self._client._send(
+            self._client._request(self.context_id, text, True))
+
+    async def send_filler(self, text: str) -> None:
+        """Filler utterance (tool-latency masking) + an immediate flush so it
+        is heard right away."""
+        if self._aborted or not text:
+            return
+        await self.send_text(text)
+        try:
+            await self._client._send(
+                self._client._request(self.context_id, "", True, flush=True))
+        except Exception:
+            pass
+
+    async def end(self) -> None:
+        """Close the context (continue=false flushes remaining audio) and wait
+        for the final ``done``. Callers wrap this in asyncio.wait_for."""
+        if self._aborted:
+            return
+        try:
+            await self._client._send(
+                self._client._request(self.context_id, "", False))
+        except Exception:
+            pass
+        try:
+            await self._done.wait()
+        finally:
+            self._log_turn()
+            if self._client._active is self:
+                self._client._active = None
+
+    def _log_turn(self) -> None:
+        ttfb = None
+        if self._first_send_t is not None and self._first_audio_t is not None:
+            ttfb = int((self._first_audio_t - self._first_send_t) * 1000)
+        audio_s = self._bytes / 2 / OUTPUT_SAMPLE_RATE
+        if self._error:
+            logger.warning(
+                "voice/tts cartesia: turn ctx=%s ERROR=%s chars=%d chunks=%d",
+                self.context_id, self._error, self.chars_sent, self._chunks)
+        else:
+            logger.info(
+                "voice/tts cartesia: turn ctx=%s ttfb=%sms chars=%d chunks=%d "
+                "audio=%.1fs", self.context_id,
+                ttfb if ttfb is not None else "-", self.chars_sent,
+                self._chunks, audio_s)
+
+    def mute(self) -> None:
+        """Synchronous barge-in step: stop forwarding audio IMMEDIATELY.
+        Callers clear the transport queue right after."""
+        self._muted = True
+
+    async def abort(self) -> None:
+        """Barge-in: drop pending audio (client-side) and best-effort tell the
+        server to stop (frees credits; not relied on — verified unreliable)."""
+        self._aborted = True
+        self._muted = True
+        try:
+            await self._client._send(
+                {"context_id": self.context_id, "cancel": True})
+        except Exception:
+            pass
+        self._done.set()
+        if self._client._active is self:
+            self._client._active = None

--- a/plugins/platforms/voice/daily_transport.py
+++ b/plugins/platforms/voice/daily_transport.py
@@ -1,0 +1,412 @@
+"""Daily WebRTC transport via daily-python virtual audio devices.
+
+Audio geometry (chosen to avoid resampling entirely — daily-python gives
+every virtual device its own sample_rate, verified against the installed
+SDK 0.29.1: Daily.create_microphone_device / create_speaker_device both
+take ``sample_rate``):
+  inbound  (caller -> STT): virtual SPEAKER device @ 24 kHz mono. Read 1920
+           frames (80 ms) per blocking read_frames() call; the device paces
+           reads at real time. Deepgram Flux resamples 24k->16k internally.
+  outbound (TTS -> caller): virtual MICROPHONE device @ 48 kHz mono — matches
+           Cartesia TTS output. Blocking write_frames() paces playback;
+           barge-in drains the local queue and stops writing.
+
+daily-python allows ONE active virtual speaker per process (and the
+upstream demos treat the mic the same way), so devices are process-level
+singletons and the adapter enforces a single active call.
+
+API facts verified against the installed daily-python 0.29.1 and the
+upstream demos (demos/audio/wav_audio_send.py, wav_audio_receive.py):
+  - Daily.init(worker_threads=2, log_level=...) — no args required.
+  - create_microphone_device(device_name, sample_rate=16000, channels=1,
+    non_blocking=False); same signature for create_speaker_device.
+  - CallClient(event_handler=None);
+    join(meeting_url, meeting_token=None, client_settings=None,
+         completion=None) — completion(JoinData, CallClientError);
+    leave(completion=None) — completion(CallClientError);
+    update_subscription_profiles(profile_settings, completion=None);
+    participants() — mapping keyed by participant id (the local
+    participant under the "local" key), each value carrying
+    {"id": ..., "info": {"isLocal": bool, ...}, ...}.
+  - daily.EventHandler — subclass and pass to CallClient(event_handler=);
+    callbacks are invoked on daily-python's internal event thread:
+      on_participant_joined(participant)        (remote participants)
+      on_participant_left(participant, reason)
+      on_call_state_updated(state)              ("joining"/"joined"/
+                                                 "leaving"/"left")
+      on_error(message)
+  - client_settings mic selection shape (wav_audio_send.py):
+    {"inputs": {"camera": False, "microphone":
+        {"isEnabled": True, "settings": {"deviceId": <name>}}}}
+  - VirtualMicrophoneDevice.write_frames(frames, completion=None) -> int;
+    VirtualSpeakerDevice.read_frames(num_frames, completion=None) ->
+    bytestring (empty when no frames were read).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import queue
+import threading
+import time
+from typing import Awaitable, Callable, Optional
+
+logger = logging.getLogger(__name__)
+
+MIC_DEVICE = "hermes-voice-mic"
+SPEAKER_DEVICE = "hermes-voice-speaker"
+MIC_RATE = 48000                # agent TTS output rate (Cartesia 48k)
+OUT_CHUNK_BYTES = 7680          # 80ms @ 48kHz s16le mono — barge-in flush granularity
+SPEAKER_RATE = 24000            # inbound caller rate (Flux STT resamples 24k->16k)
+IN_CHUNK_FRAMES = 1920          # 80 ms @ 24 kHz — one ASR chunk per read
+
+# Subscribe to participant microphones only (wav_audio_receive.py pattern);
+# video is never wanted on a voice call.
+_SUBSCRIPTION_PROFILES = {
+    "base": {"camera": "unsubscribed", "microphone": "subscribed"}
+}
+
+_init_lock = threading.Lock()
+_initialized = False
+_mic = None
+_speaker = None
+
+
+def _is_local_participant(key: str, participant: dict) -> bool:
+    """True for the agent's own entry in participants()/events. The local
+    participant appears under the "local" key in participants() and carries
+    info.isLocal in event payloads."""
+    if key == "local":
+        return True
+    info = participant.get("info") or {}
+    return bool(info.get("isLocal"))
+
+
+def _make_event_handler(transport: "DailyTransport"):
+    """EventHandler subclass wired to *transport* (deferred daily import so
+    the module stays importable without the SDK). Callbacks arrive on
+    daily-python's internal event thread — handlers must be thread-safe."""
+    from daily import EventHandler
+
+    class _TransportEvents(EventHandler):
+        def on_participant_joined(self, participant) -> None:
+            transport._on_participant_joined(participant)
+
+        def on_participant_left(self, participant, reason) -> None:
+            transport._on_participant_left(participant, reason)
+
+        def on_call_state_updated(self, state) -> None:
+            transport._on_call_state_updated(state)
+
+        def on_error(self, message) -> None:
+            transport._on_client_error(message)
+
+    return _TransportEvents()
+
+
+def _ensure_daily() -> None:
+    """Daily.init() + virtual device creation, once per process."""
+    global _initialized, _mic, _speaker
+    with _init_lock:
+        if _initialized:
+            return
+        from daily import Daily
+        Daily.init()
+        _mic = Daily.create_microphone_device(
+            MIC_DEVICE, sample_rate=MIC_RATE, channels=1)
+        _speaker = Daily.create_speaker_device(
+            SPEAKER_DEVICE, sample_rate=SPEAKER_RATE, channels=1)
+        Daily.select_speaker_device(SPEAKER_DEVICE)
+        _initialized = True
+
+
+class DailyTransport:
+    """One Daily call. on_audio_in(pcm) is scheduled onto *loop* for every
+    80 ms chunk of caller audio (s16le mono 24 kHz)."""
+
+    def __init__(
+        self,
+        loop: asyncio.AbstractEventLoop,
+        on_audio_in: Callable[[bytes], Awaitable[None]],
+    ):
+        self._loop = loop
+        self._on_audio_in = on_audio_in
+        self._client = None
+        self._running = False
+        self._reader: Optional[threading.Thread] = None
+        self._writer: Optional[threading.Thread] = None
+        self._keepalive: Optional[threading.Thread] = None
+        self._out_q: "queue.Queue[Optional[bytes]]" = queue.Queue()
+        self._joined = threading.Event()
+        self._join_error: Optional[str] = None
+        self._last_audio_in_t = 0.0
+        # Presence + lifecycle state for the adapter's call watchdog
+        # (ENG-555 cost leak: abandoned calls kept the billable ASR stream
+        # alive forever). Mutated from daily-python's event thread.
+        self._presence_lock = threading.Lock()
+        self._remote_ids: set = set()
+        self._leaving = False
+        self._abnormal_end: Optional[str] = None
+        # Teardown gate: set the moment teardown starts, BEFORE the call is
+        # left, so the DTX keep-alive stops feeding billable silence into
+        # the ASR stream immediately (the keep-alive thread must never
+        # outlive the call).
+        self._teardown = threading.Event()
+        # Telemetry write mark (notes §16 first_frame_written): the turn
+        # loop arms it at the start of a turn cycle; the writer thread
+        # stamps the first real frame write after arming.
+        self._first_write_t: Optional[float] = None
+        self._write_mark_armed = False
+
+    async def join(self, room_url: str, token: str, timeout: float = 15.0) -> None:
+        _ensure_daily()
+        from daily import CallClient
+        self._client = CallClient(event_handler=_make_event_handler(self))
+        self._client.update_subscription_profiles(_SUBSCRIPTION_PROFILES)
+
+        def _on_join(data, error):
+            self._join_error = str(error) if error else None
+            self._joined.set()
+
+        self._client.join(
+            room_url,
+            meeting_token=token,
+            client_settings={
+                "inputs": {
+                    "camera": False,
+                    "microphone": {
+                        "isEnabled": True,
+                        "settings": {"deviceId": MIC_DEVICE},
+                    },
+                }
+            },
+            completion=_on_join,
+        )
+        await self._loop.run_in_executor(None, self._joined.wait, timeout)
+        if not self._joined.is_set():
+            self._client.release()
+            self._client = None
+            raise RuntimeError(f"Daily join timed out after {timeout}s")
+        if self._join_error:
+            self._client.release()
+            self._client = None
+            raise RuntimeError(f"Daily join failed: {self._join_error}")
+        # Seed presence from the post-join roster: a human may already be
+        # waiting in the room when the agent joins (their joined event fired
+        # before our handler existed).
+        participants = self._client.participants()
+        with self._presence_lock:
+            for key, part in participants.items():
+                if not _is_local_participant(key, part):
+                    self._remote_ids.add(part.get("id") or key)
+        self._running = True
+        self._last_audio_in_t = time.monotonic()
+        self._reader = threading.Thread(
+            target=self._read_loop, name="voice-daily-reader", daemon=True)
+        self._writer = threading.Thread(
+            target=self._write_loop, name="voice-daily-writer", daemon=True)
+        self._keepalive = threading.Thread(
+            target=self._keepalive_loop, name="voice-daily-keepalive",
+            daemon=True)
+        self._reader.start()
+        self._writer.start()
+        self._keepalive.start()
+        logger.info("voice/daily: joined %s", room_url)
+
+    # -- presence + call-state events (daily-python event thread) ----------
+
+    def _on_participant_joined(self, participant) -> None:
+        if _is_local_participant("", participant or {}):
+            return
+        pid = (participant or {}).get("id")
+        if pid is None:
+            return
+        with self._presence_lock:
+            self._remote_ids.add(pid)
+            count = len(self._remote_ids)
+        logger.info("voice/daily: participant joined id=%s remote_count=%d",
+                    pid, count)
+
+    def _on_participant_left(self, participant, reason) -> None:
+        pid = (participant or {}).get("id")
+        with self._presence_lock:
+            self._remote_ids.discard(pid)
+            count = len(self._remote_ids)
+        logger.warning(
+            "voice/daily: participant left id=%s reason=%s remote_count=%d",
+            pid, reason, count)
+
+    def _on_call_state_updated(self, state) -> None:
+        logger.info("voice/daily: call state -> %s", state)
+        if state == "left" and not self._leaving:
+            # We did not initiate this: room expired / agent ejected /
+            # connection lost. The adapter watchdog tears the call down.
+            self._abnormal_end = "left"
+            logger.warning(
+                "voice/daily: call ended remotely (ejected/expired) — "
+                "flagging for teardown")
+
+    def _on_client_error(self, message) -> None:
+        self._abnormal_end = f"error: {message}"
+        logger.error("voice/daily: fatal client error: %s", message)
+
+    @property
+    def remote_participant_count(self) -> int:
+        """Remote (non-agent) participants currently in the room."""
+        with self._presence_lock:
+            return len(self._remote_ids)
+
+    @property
+    def abnormal_end(self) -> Optional[str]:
+        """Set when the call ended without us leaving: "left" (ejection /
+        room expiry) or "error: ..." (fatal client error). None while the
+        call is healthy."""
+        return self._abnormal_end
+
+    def _read_loop(self) -> None:
+        while self._running:
+            frames = _speaker.read_frames(IN_CHUNK_FRAMES)   # blocking 80 ms
+            if not frames:
+                # Empty reads happen at teardown / before audio flows; avoid
+                # a hot spin since only non-empty reads pace real time.
+                time.sleep(0.01)
+                continue
+            self._last_audio_in_t = time.monotonic()
+            asyncio.run_coroutine_threadsafe(self._on_audio_in(frames), self._loop)
+
+    def _keepalive_loop(self) -> None:
+        # WebRTC DTX: a silent caller stops sending packets entirely and
+        # read_frames() BLOCKS (it cannot be relied on to return empties at
+        # cadence). Streaming STT turn detection assumes a continuous
+        # timeline — Flux needs to SEE the post-speech silence to fire its
+        # end-of-turn, and a starved socket cannot deliver it. This thread
+        # feeds synthesized 80ms silence whenever real audio stops flowing.
+        # COST GUARD: this synthesized silence is BILLABLE STT input. The
+        # _teardown gate stops the feed the moment teardown starts — without
+        # it an abandoned call would keep the STT stream alive indefinitely.
+        silence = b"\x00" * (IN_CHUNK_FRAMES * 2)
+        while self._running and not self._teardown.is_set():
+            self._teardown.wait(0.08)
+            if not self._running or self._teardown.is_set():
+                return
+            if time.monotonic() - self._last_audio_in_t >= 0.16:
+                asyncio.run_coroutine_threadsafe(
+                    self._on_audio_in(silence), self._loop)
+
+    def _write_loop(self) -> None:
+        # WALL-CLOCK paced: write_frames sometimes returns faster than real
+        # time (Daily buffers internally — measured live 2026-06-12: the
+        # writer ran ~1.6s ahead on long replies, and barge-in's
+        # clear_output cannot claw audio back out of Daily's buffer, so the
+        # caller kept hearing the dead reply for that long). Never hand
+        # Daily chunk N+1 before chunk N's real-time due point: buffered
+        # audio is then capped at ~one 80ms chunk and barge-in cutoff stays
+        # bounded by the trigger latency, not the backlog.
+        burst_t0 = 0.0
+        burst_audio_s = 0.0
+        next_due = 0.0
+        while self._running:
+            try:
+                chunk = self._out_q.get(timeout=0.5)
+            except queue.Empty:
+                if burst_audio_s > 0.0:
+                    logger.info(
+                        "voice/daily: write burst ended audio_s=%.2f wall_s=%.2f",
+                        burst_audio_s, time.monotonic() - burst_t0)
+                    burst_audio_s = 0.0
+                continue
+            if chunk is None:
+                continue
+            now = time.monotonic()
+            if burst_audio_s == 0.0:
+                burst_t0 = now
+                next_due = now
+                logger.info("voice/daily: write burst started qsize=%d",
+                            self._out_q.qsize())
+            delay = next_due - now
+            if delay > 0:
+                time.sleep(delay)
+            elif delay < -0.5:
+                next_due = time.monotonic()   # writer fell behind; resync
+            t0 = time.monotonic()
+            if self._write_mark_armed:
+                self._write_mark_armed = False
+                self._first_write_t = t0
+            _mic.write_frames(chunk)
+            chunk_s = len(chunk) / 2.0 / MIC_RATE
+            next_due += chunk_s
+            burst_audio_s += chunk_s
+
+    async def send_audio(self, pcm: bytes) -> None:
+        """Queue agent speech (s16le mono 48 kHz) for the caller.
+
+        Split into <=80ms sub-chunks so the wall-clock writer caps Daily's
+        internal buffer tightly: barge-in's clear_output then leaves only
+        ~one 80ms chunk of unstoppable audio regardless of the TTS provider's
+        native chunk size (Cartesia emits ~190ms chunks)."""
+        if len(pcm) <= OUT_CHUNK_BYTES:
+            self._out_q.put(pcm)
+            return
+        for i in range(0, len(pcm), OUT_CHUNK_BYTES):
+            self._out_q.put(pcm[i:i + OUT_CHUNK_BYTES])
+
+    def reset_write_mark(self) -> None:
+        """Arm the first_frame_written telemetry mark for a new turn."""
+        self._first_write_t = None
+        self._write_mark_armed = True
+
+    @property
+    def first_write_t(self) -> Optional[float]:
+        """Monotonic time of the first frame written after the last
+        reset_write_mark(), or None if nothing was written yet."""
+        return self._first_write_t
+
+    def is_playing(self) -> bool:
+        """True while agent audio is still queued to play out to the caller.
+
+        The turn loop flips its state back to LISTENING as soon as the TTS has
+        FINISHED SENDING audio (tts.end() returns when the last chunk is
+        queued), but the wall-clock writer then plays that audio out over the
+        following seconds. Barge-in must fire during this tail too — otherwise
+        the caller hears the agent talk over them with no way to cut it."""
+        return not self._out_q.empty()
+
+    def clear_output(self) -> None:
+        """Barge-in: drop all queued (unplayed) agent audio."""
+        dropped = 0
+        try:
+            while True:
+                self._out_q.get_nowait()
+                dropped += 1
+        except queue.Empty:
+            pass
+        logger.info("voice/daily: cleared %d queued chunks", dropped)
+
+    def begin_teardown(self) -> None:
+        """Stop feeding billable keep-alive silence IMMEDIATELY. Called by
+        the adapter as the very first teardown step — before the turn loop,
+        STT, and transport are wound down (each of which can await) — so no
+        more ASR audio is paid for past this point."""
+        if not self._teardown.is_set():
+            self._teardown.set()
+            logger.info("voice/daily: teardown begun — keep-alive stopped")
+
+    async def leave(self) -> None:
+        self._teardown.set()
+        self._leaving = True
+        self._running = False
+        self.clear_output()
+        if self._client is not None:
+            done = threading.Event()
+            self._client.leave(completion=lambda _error: done.set())
+            await self._loop.run_in_executor(None, done.wait, 10.0)
+            self._client.release()
+            self._client = None
+        for worker in (self._reader, self._writer, self._keepalive):
+            if worker is not None and worker.is_alive():
+                await self._loop.run_in_executor(None, worker.join, 2.0)
+        self._reader = None
+        self._writer = None
+        self._keepalive = None
+        logger.info("voice/daily: left room")

--- a/plugins/platforms/voice/deepgram_flux_stt.py
+++ b/plugins/platforms/voice/deepgram_flux_stt.py
@@ -43,12 +43,13 @@ DEFAULT_EOT_THRESHOLD = 0.7
 DEFAULT_EAGER_EOT_THRESHOLD = 0.5
 DEFAULT_EOT_TIMEOUT_MS = 5000
 
-# Normalized event names the turn loop consumes (provider-agnostic).
-EV_START = "start_of_turn"
-EV_UPDATE = "update"
-EV_EAGER_EOT = "eager_end_of_turn"
-EV_RESUMED = "turn_resumed"
-EV_END = "end_of_turn"
+# Normalized event names the turn loop consumes (provider-agnostic). Their
+# canonical home is stt.py (the port); re-exported here so existing
+# `from deepgram_flux_stt import EV_*` imports keep working.
+try:
+    from stt import EV_EAGER_EOT, EV_END, EV_RESUMED, EV_START, EV_UPDATE
+except ImportError:
+    from .stt import EV_EAGER_EOT, EV_END, EV_RESUMED, EV_START, EV_UPDATE
 
 _FLUX_EVENT_MAP = {
     "StartOfTurn": EV_START,
@@ -116,6 +117,8 @@ def _resample_to_16k(pcm: bytes, in_rate: int) -> bytes:
 class DeepgramFluxSTT:
     """One Flux websocket for a call. ``events()`` yields normalized turn
     events; ``send_audio`` streams the (resampled) mic audio."""
+
+    provider = "deepgram_flux"   # telemetry tag (the STT port surface)
 
     def __init__(
         self,

--- a/plugins/platforms/voice/deepgram_flux_stt.py
+++ b/plugins/platforms/voice/deepgram_flux_stt.py
@@ -1,0 +1,254 @@
+"""Deepgram Flux streaming STT — conversational ASR with model-integrated
+turn detection (the /v2/listen websocket API).
+
+Flux is a single fused model that does transcription AND turn-taking. Instead
+of a separate ASR + VAD + end-of-turn-detection stack, Flux emits
+conversation-native events that the turn loop reacts to directly:
+
+  - StartOfTurn     -> the user began speaking (barge-in trigger)
+  - Update          -> incremental partial transcript (~every 250ms)
+  - EagerEndOfTurn  -> medium-confidence end (~150-250ms early) -> start the
+                       LLM speculatively
+  - TurnResumed     -> the user kept talking past the eager signal -> cancel
+                       the speculative response
+  - EndOfTurn       -> high-confidence end -> commit the turn (synthesize)
+
+Verified live 2026-06-14: every server message is ``{"type":"TurnInfo",
+"event":"StartOfTurn"|...,"transcript":...,"end_of_turn_confidence":...,
+"words":[...]}``; StartOfTurn carries a non-empty transcript; EagerEndOfTurn
+lands ~185ms before EndOfTurn.
+
+Input: linear16 @ 16 kHz mono. Our inbound mic is 24 kHz (the Daily ASR rate),
+so audio is resampled 24k->16k here (linear interpolation; the 24->16 ratio of
+speech-band audio tolerates it — confirmed accurate transcription live).
+
+Opinionated: Deepgram-only, no provider seam — Flux's model-integrated turn
+detection IS the architecture, not a swappable component.
+"""
+
+from __future__ import annotations
+
+import array
+import asyncio
+import json
+import logging
+from typing import Any, AsyncIterator, Dict, Optional
+
+logger = logging.getLogger(__name__)
+
+WS_BASE = "wss://api.deepgram.com/v2/listen"
+FLUX_MODEL = "flux-general-en"
+FLUX_RATE = 16000               # Flux input rate (linear16 mono)
+DEFAULT_EOT_THRESHOLD = 0.7
+DEFAULT_EAGER_EOT_THRESHOLD = 0.5
+DEFAULT_EOT_TIMEOUT_MS = 5000
+
+# Normalized event names the turn loop consumes (provider-agnostic).
+EV_START = "start_of_turn"
+EV_UPDATE = "update"
+EV_EAGER_EOT = "eager_end_of_turn"
+EV_RESUMED = "turn_resumed"
+EV_END = "end_of_turn"
+
+_FLUX_EVENT_MAP = {
+    "StartOfTurn": EV_START,
+    "Update": EV_UPDATE,
+    "EagerEndOfTurn": EV_EAGER_EOT,
+    "TurnResumed": EV_RESUMED,
+    "EndOfTurn": EV_END,
+}
+
+
+def _normalize_flux_message(msg: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+    """Map a raw Flux server message to the normalized turn event the loop
+    consumes, or None for non-TurnInfo / unknown-event messages (which the loop
+    ignores). Keeps the wire-format knowledge in one testable place."""
+    if msg.get("type") != "TurnInfo":
+        return None
+    ev = _FLUX_EVENT_MAP.get(msg.get("event"))
+    if ev is None:
+        return None
+    return {
+        "event": ev,
+        "transcript": msg.get("transcript") or "",
+        "confidence": msg.get("end_of_turn_confidence"),
+        "words": msg.get("words") or [],
+        "turn_index": msg.get("turn_index"),
+    }
+
+
+def _resample_to_16k(pcm: bytes, in_rate: int) -> bytes:
+    """Linear-interpolate s16le mono PCM from ``in_rate`` to 16 kHz.
+
+    Pure stdlib (no numpy): the inbound chunk is ~1920 samples per 80 ms, so a
+    plain interpolation loop is negligible and keeps the voice-platform extra to
+    just daily-python + websockets. Per-chunk (stateless): the sub-sample
+    boundary error is inaudible to an ASR model for 24k->16k speech-band audio.
+    Assumes a little-endian host (``array('h')``), which every Hermes target is.
+    """
+    if in_rate == FLUX_RATE:
+        return pcm
+    src = array.array("h")
+    src.frombytes(pcm)
+    n_in = len(src)
+    if n_in == 0:
+        return b""
+    n_out = max(1, int(round(n_in * FLUX_RATE / in_rate)))
+    out = array.array("h", bytes(2 * n_out))
+    if n_in == 1 or n_out == 1:
+        for i in range(n_out):
+            out[i] = src[0]
+        return out.tobytes()
+    # Map output index i -> source position, endpoints inclusive (i=0 -> 0,
+    # i=n_out-1 -> n_in-1), matching a linspace+interp resample.
+    step = (n_in - 1) / (n_out - 1)
+    for i in range(n_out):
+        pos = i * step
+        j = int(pos)
+        if j + 1 < n_in:
+            frac = pos - j
+            out[i] = int(src[j] + (src[j + 1] - src[j]) * frac)
+        else:
+            out[i] = src[j]
+    return out.tobytes()
+
+
+class DeepgramFluxSTT:
+    """One Flux websocket for a call. ``events()`` yields normalized turn
+    events; ``send_audio`` streams the (resampled) mic audio."""
+
+    def __init__(
+        self,
+        api_key: str,
+        *,
+        input_rate: int = 24000,
+        eot_threshold: float = DEFAULT_EOT_THRESHOLD,
+        eager_eot_threshold: float = DEFAULT_EAGER_EOT_THRESHOLD,
+        eot_timeout_ms: int = DEFAULT_EOT_TIMEOUT_MS,
+    ):
+        if not api_key:
+            raise ValueError("DEEPGRAM_API_KEY is required for Flux STT")
+        if eager_eot_threshold > eot_threshold:
+            # Flux rejects eager > eot; clamp so a misconfig can't 400 the call.
+            eager_eot_threshold = eot_threshold
+        self._api_key = api_key
+        self._input_rate = input_rate
+        self._eot_threshold = eot_threshold
+        self._eager_eot_threshold = eager_eot_threshold
+        self._eot_timeout_ms = eot_timeout_ms
+        self._ws = None
+        self._recv_task: Optional[asyncio.Task] = None
+        self._queue: "asyncio.Queue[Optional[Dict[str, Any]]]" = asyncio.Queue()
+        self._closed = False
+        self._asr_seconds = 0.0   # cost telemetry: audio seconds streamed
+
+    @property
+    def asr_seconds_est(self) -> float:
+        """Estimated seconds of audio sent to ASR (for the per-call cost
+        record)."""
+        return self._asr_seconds
+
+    def _url(self) -> str:
+        return (
+            f"{WS_BASE}?model={FLUX_MODEL}"
+            f"&encoding=linear16&sample_rate={FLUX_RATE}"
+            f"&eot_threshold={self._eot_threshold}"
+            f"&eager_eot_threshold={self._eager_eot_threshold}"
+            f"&eot_timeout_ms={self._eot_timeout_ms}"
+        )
+
+    async def start(self) -> None:
+        import websockets
+        self._ws = await websockets.connect(
+            self._url(),
+            additional_headers={"Authorization": f"Token {self._api_key}"},
+            max_size=None, ping_interval=5, ping_timeout=10,
+        )
+        self._recv_task = asyncio.create_task(self._recv_loop(self._ws))
+        logger.info("voice/stt flux: connected model=%s eot=%.2f eager=%.2f",
+                    FLUX_MODEL, self._eot_threshold, self._eager_eot_threshold)
+
+    async def _recv_loop(self, ws) -> None:
+        try:
+            async for raw in ws:
+                msg = json.loads(raw)
+                norm = _normalize_flux_message(msg)
+                if norm is not None:
+                    await self._queue.put(norm)
+                elif msg.get("type") in ("Error", "ConfigureFailure"):
+                    logger.warning("voice/stt flux: %s: %s",
+                                   msg.get("type"), msg)
+                # Connected / ConfigureSuccess / Metadata: informational
+        except asyncio.CancelledError:
+            raise
+        except Exception as e:
+            if not self._closed:
+                logger.warning("voice/stt flux: socket closed: %s", e)
+        finally:
+            await self._queue.put(None)   # unblock events()
+
+    async def send_audio(self, pcm: bytes) -> None:
+        if self._closed or self._ws is None:
+            return
+        self._asr_seconds += len(pcm) / 2 / self._input_rate   # s16le mono
+        try:
+            await self._ws.send(_resample_to_16k(pcm, self._input_rate))
+        except Exception as e:
+            if not self._closed:
+                logger.warning("voice/stt flux: send failed: %s", e)
+
+    async def events(self) -> AsyncIterator[Dict[str, Any]]:
+        """Yield normalized turn events until the stream ends."""
+        while True:
+            item = await self._queue.get()
+            if item is None:
+                return
+            yield item
+
+    async def configure(
+        self,
+        *,
+        eot_threshold: Optional[float] = None,
+        eager_eot_threshold: Optional[float] = None,
+        eot_timeout_ms: Optional[int] = None,
+    ) -> None:
+        """Update turn-detection thresholds mid-stream (no reconnect).
+        Omitted values keep their current setting."""
+        if self._ws is None:
+            return
+        th: Dict[str, Any] = {}
+        if eot_threshold is not None:
+            th["eot_threshold"] = eot_threshold
+            self._eot_threshold = eot_threshold
+        if eager_eot_threshold is not None:
+            th["eager_eot_threshold"] = eager_eot_threshold
+            self._eager_eot_threshold = eager_eot_threshold
+        if eot_timeout_ms is not None:
+            th["eot_timeout_ms"] = eot_timeout_ms
+            self._eot_timeout_ms = eot_timeout_ms
+        if not th:
+            return
+        try:
+            await self._ws.send(json.dumps({"type": "Configure", "thresholds": th}))
+        except Exception:
+            pass
+
+    async def stop(self) -> None:
+        self._closed = True
+        if self._ws is not None:
+            try:
+                await self._ws.send(json.dumps({"type": "CloseStream"}))
+            except Exception:
+                pass
+        if self._recv_task is not None and not self._recv_task.done():
+            self._recv_task.cancel()
+            try:
+                await self._recv_task
+            except (asyncio.CancelledError, Exception):
+                pass
+        if self._ws is not None:
+            try:
+                await self._ws.close()
+            except Exception:
+                pass
+        self._ws = None

--- a/plugins/platforms/voice/plugin.yaml
+++ b/plugins/platforms/voice/plugin.yaml
@@ -1,0 +1,32 @@
+name: voice-platform
+label: Voice
+kind: platform
+version: 0.1.0
+description: >
+  Realtime voice-call gateway adapter. Joins a Daily (WebRTC) room as a
+  participant, streams caller audio to Deepgram Flux (streaming STT with
+  model-integrated turn detection), runs one fresh agent turn per utterance
+  with token streaming, and speaks replies through Cartesia (streaming TTS)
+  with sentence-level latency and in-process barge-in.
+
+  Standalone mode: this agent holds DAILY_API_KEY and creates its own private
+  room + single-use meeting token at startup, then logs a shareable URL.
+author: Supernal Technology
+requires_env:
+  - name: DAILY_API_KEY
+    description: "Daily API key (WebRTC transport — agent creates its own room)"
+    prompt: "Daily API key"
+    password: true
+  - name: DEEPGRAM_API_KEY
+    description: "Deepgram API key (Flux streaming STT + turn detection)"
+    prompt: "Deepgram API key"
+    password: true
+  - name: CARTESIA_API_KEY
+    description: "Cartesia API key (streaming TTS)"
+    prompt: "Cartesia API key"
+    password: true
+optional_env:
+  - name: CARTESIA_VOICE_ID
+    description: "Cartesia TTS voice id (or set platforms.voice.extra.cartesia_voice_id)"
+    prompt: "Cartesia voice id (or empty for default)"
+    password: false

--- a/plugins/platforms/voice/stt.py
+++ b/plugins/platforms/voice/stt.py
@@ -1,0 +1,138 @@
+"""Streaming STT port + adapter factory (Ports & Adapters).
+
+The voice turn loop consumes a provider-agnostic stream of normalized turn
+events; this module defines that contract and the factory that builds a
+concrete adapter for it.
+
+The canonical home of the normalized event names is HERE — every adapter
+(``deepgram_flux_stt``, ``cartesia_ink_stt``) maps its provider-specific wire
+events onto these constants, and the turn loop branches only on these. They are
+re-exported by ``deepgram_flux_stt`` so existing imports keep working.
+
+  start_of_turn      -> the user began speaking (barge-in trigger)
+  update             -> incremental partial transcript
+  eager_end_of_turn  -> medium-confidence end -> start the agent speculatively
+  turn_resumed       -> the user kept talking past the eager signal -> cancel
+  end_of_turn        -> high-confidence end -> commit the turn
+
+Default provider is Deepgram Flux. Cartesia Ink-2 is a second adapter behind
+the same port for A/B comparison (turn-taking + latency); accuracy is out of
+scope for the seam.
+"""
+
+from __future__ import annotations
+
+from typing import Any, AsyncIterator, Dict, Protocol, runtime_checkable
+
+# Normalized event names the turn loop consumes (provider-agnostic). Canonical
+# home — adapters import these from here.
+EV_START = "start_of_turn"
+EV_UPDATE = "update"
+EV_EAGER_EOT = "eager_end_of_turn"
+EV_RESUMED = "turn_resumed"
+EV_END = "end_of_turn"
+
+
+@runtime_checkable
+class STT(Protocol):
+    """The streaming STT port. An adapter holds one provider websocket for a
+    call: ``send_audio`` streams mic PCM in, ``events()`` yields normalized turn
+    events out. ``provider`` tags telemetry for the A/B.
+
+    Normalized event shape (every yield):
+        {"event": <EV_*>, "transcript": str, "confidence": float | None,
+         "words": list, "turn_index": int | None}
+    """
+
+    #: Stable provider id used to tag telemetry (e.g. "deepgram_flux").
+    provider: str
+
+    @property
+    def asr_seconds_est(self) -> float:
+        """Estimated seconds of audio streamed to ASR (per-call cost record)."""
+        ...
+
+    async def start(self) -> None:
+        """Open the provider websocket and begin receiving."""
+        ...
+
+    async def send_audio(self, pcm: bytes) -> None:
+        """Stream one chunk of s16le mono PCM at the declared input rate."""
+        ...
+
+    def events(self) -> AsyncIterator[Dict[str, Any]]:
+        """Yield normalized turn events until the stream ends."""
+        ...
+
+    async def configure(self, **kw: Any) -> None:
+        """Update provider turn-detection settings mid-stream, if supported."""
+        ...
+
+    async def stop(self) -> None:
+        """Close the provider websocket and tear down."""
+        ...
+
+
+DEFAULT_STT_PROVIDER = "deepgram_flux"
+
+
+def make_stt(provider: str, *, input_rate: int, extra: Dict[str, Any]) -> STT:
+    """Build the STT adapter for ``provider``.
+
+    Resolves the provider's API key from the environment (``DEEPGRAM_API_KEY`` /
+    ``CARTESIA_API_KEY``), passes Flux its turn-detection thresholds from
+    ``extra``, and raises a clear error for an unknown provider. The adapter
+    constructors raise on a missing key, so a misconfigured provider fails fast.
+
+    Sibling modules are imported the discord dual-import way (flat for the test
+    loader, relative for the production ``hermes_plugins.platforms__voice``
+    package) so this works in both contexts.
+    """
+    import os
+
+    provider = (provider or DEFAULT_STT_PROVIDER).strip().lower()
+
+    if provider == "deepgram_flux":
+        try:
+            import deepgram_flux_stt
+        except ImportError:
+            from . import deepgram_flux_stt
+        dg_key = os.getenv("DEEPGRAM_API_KEY", "").strip()
+        if not dg_key:
+            raise RuntimeError("DEEPGRAM_API_KEY is not set")
+        return deepgram_flux_stt.DeepgramFluxSTT(
+            dg_key,
+            input_rate=input_rate,
+            eot_threshold=_float_extra(
+                extra, "eot_threshold",
+                deepgram_flux_stt.DEFAULT_EOT_THRESHOLD),
+            eager_eot_threshold=_float_extra(
+                extra, "eager_eot_threshold",
+                deepgram_flux_stt.DEFAULT_EAGER_EOT_THRESHOLD),
+        )
+
+    if provider == "cartesia_ink":
+        try:
+            import cartesia_ink_stt
+        except ImportError:
+            from . import cartesia_ink_stt
+        ck_key = os.getenv("CARTESIA_API_KEY", "").strip()
+        if not ck_key:
+            raise RuntimeError("CARTESIA_API_KEY is not set")
+        return cartesia_ink_stt.CartesiaInkSTT(ck_key, input_rate=input_rate)
+
+    raise RuntimeError(
+        f"unknown stt_provider={provider!r}; "
+        "supported: 'deepgram_flux' (default), 'cartesia_ink'")
+
+
+def _float_extra(extra: Dict[str, Any], key: str, default: float) -> float:
+    """Parse a float from extra, falling back to the default on missing/bad
+    input (no silent surprises — matches adapter._resolve_float_extra)."""
+    raw = (extra or {}).get(key)
+    if raw is None or (isinstance(raw, str) and not raw.strip()):
+        return default
+    try:
+        return float(raw)
+    except (TypeError, ValueError):
+        return default

--- a/plugins/platforms/voice/turn_loop.py
+++ b/plugins/platforms/voice/turn_loop.py
@@ -1,0 +1,770 @@
+"""Voice turn orchestrator.
+
+One VoiceTurnLoop per live call. Turn-taking is driven by Deepgram Flux —
+a single fused model that does transcription AND conversation-native turn
+detection — so the loop reacts to events rather than running its own VAD /
+endpoint model:
+
+  start_of_turn     -> the user began speaking. If the agent is thinking,
+                       speaking, or still has audio playing out, BARGE IN
+                       (cancel the in-flight agent turn + mute TTS + drain
+                       the transport). Otherwise pre-warm the next agent.
+  eager_end_of_turn -> medium-confidence end (~185ms early) -> start the
+                       agent speculatively on the transcript so far.
+  turn_resumed      -> the user kept talking past the eager signal -> cancel
+                       the speculative turn.
+  end_of_turn       -> high-confidence end -> start the turn (or, if an eager
+                       turn is already running, let it stand).
+
+Per turn, once started:
+  -> fresh AIAgent with stream_delta_callback (api_server pattern,
+     gateway/platforms/api_server.py:1604-1657 + 3510-3554)
+  -> deltas marshaled via loop.call_soon_threadsafe into an asyncio queue
+  -> sentence buffer streams words to the per-turn Cartesia TTS socket, which
+     synthesizes on sentence-final punctuation or an explicit <flush>
+  -> audio out through the transport.
+
+In-process barge-in is the differentiator: a barge-in calls agent.interrupt()
+(the same call as api_server.py:4091) and STOPS the LLM mid-generation, then
+mutes TTS and drains the transport. An external orchestrator can only mute the
+audio while the agent keeps generating server-side.
+
+The agent speaks first: run() executes a greeting turn before listening.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import concurrent.futures
+import json
+import logging
+import os
+import re
+import threading
+import time
+import uuid
+from typing import Any, Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+# Sentence-final punctuation: tracks how much UNSYNTHESIZED text the TTS server
+# is holding (it only synthesizes on [.!?] or an explicit <flush>); a long
+# punctuation-free stretch gets a forced flush on idle.
+_PUNCT_RE = re.compile(r"[.!?]")
+LONG_FLUSH_LEN = 100
+# If the first sentence hasn't reached sentence-final punctuation this long
+# after its first words went to TTS, force a <flush> once so audio starts
+# (prosody costs less than dead air on the first clause).
+FIRST_SENTENCE_FLUSH_S = 0.6
+TTS_END_TIMEOUT_S = 30.0
+# Bound on awaiting the executor-run agent after a turn ends (normally the
+# future is already done; after an interrupt a well-behaved agent returns
+# promptly). The thread itself cannot be killed, but the event loop must never
+# block on a generation that ignores its interrupt.
+RUN_FUTURE_TIMEOUT_S = 60.0
+
+DEFAULT_ALLOW_INTERRUPTIONS = True
+DEFAULT_GREETING_PROMPT = (
+    "(The user just joined a voice call with you. Greet them by voice in "
+    "one short, warm sentence and ask how you can help.)"
+)
+DEFAULT_FILLER_TEXT = "One moment."
+
+LISTENING, THINKING, SPEAKING = "listening", "thinking", "speaking"
+
+# Durable telemetry sink: the voice/telemetry JSON records are the per-call
+# audit trail (latency legs, billable ASR seconds), but log lines vanish at the
+# container's default log level and on rotation. Every record ALSO appends to a
+# JSONL file on the agent volume (/opt/data persists across restarts):
+#   docker exec <agent> tail /opt/data/voice-telemetry.jsonl
+# Fail-soft: an unwritable volume logs ONE warning and never raises into the
+# call path.
+TELEMETRY_SINK_PATH = "/opt/data/voice-telemetry.jsonl"
+_sink_warned = False
+
+
+def emit_telemetry(record: Dict[str, Any]) -> None:
+    """Emit one voice/telemetry record: log it at WARNING (visible at the
+    default container log level) and append it to the durable JSONL sink.
+    Open-append-close per record — a handful per call, and the record must be
+    on disk the moment the line is logged."""
+    global _sink_warned
+    line = json.dumps(record)
+    logger.warning("voice/telemetry %s", line)
+    try:
+        with open(TELEMETRY_SINK_PATH, "a", encoding="utf-8") as fh:
+            fh.write(line + "\n")
+    except OSError as exc:
+        if not _sink_warned:
+            _sink_warned = True
+            logger.warning(
+                "voice/telemetry sink unwritable (%s): %s — records stay "
+                "in the process logs only", TELEMETRY_SINK_PATH, exc)
+
+
+def _voice_model_name() -> Optional[str]:
+    """Model name from the top-level ``voice_model:`` slot, for telemetry.
+    None means voice turns ran on the main model."""
+    try:
+        from gateway.run import _voice_model_name as _core_voice_model_name
+        return _core_voice_model_name()
+    except Exception:
+        return None
+
+
+def _resolve_reasoning_override(extra: Dict[str, Any]) -> Optional[dict]:
+    """platforms.voice.extra.reasoning_effort overrides the gateway reasoning
+    effort for voice turns only: thinking tokens run before the first text
+    delta, straight on top of first-audio latency. None = gateway default."""
+    raw = (extra or {}).get("reasoning_effort")
+    if raw is None or not str(raw).strip():
+        return None
+    from hermes_constants import parse_reasoning_effort
+
+    parsed = parse_reasoning_effort(str(raw))
+    if parsed is None:
+        logger.warning("voice/turn: invalid reasoning_effort %r ignored", raw)
+    return parsed
+
+
+def _resolve_bool_extra(extra: Dict[str, Any], key: str, default: bool) -> bool:
+    raw = (extra or {}).get(key)
+    if raw is None:
+        return default
+    if isinstance(raw, bool):
+        return raw
+    if isinstance(raw, str):
+        s = raw.strip().lower()
+        if s in ("true", "1", "yes", "on"):
+            return True
+        if s in ("false", "0", "no", "off"):
+            return False
+    logger.warning("voice/turn: invalid %s %r ignored", key, raw)
+    return default
+
+
+def _resolve_max_iterations(extra: Dict[str, Any]) -> int:
+    """platforms.voice.extra.max_turns caps the per-utterance agent loop;
+    falls back to the api_server default (HERMES_MAX_ITERATIONS env, 90)."""
+    raw = extra.get("max_turns")
+    if raw is not None:
+        try:
+            return int(raw)
+        except (TypeError, ValueError):
+            logger.warning("voice/turn: invalid max_turns %r ignored", raw)
+    return int(os.getenv("HERMES_MAX_ITERATIONS", "90"))
+
+
+def _create_voice_agent(
+    session_id: str,
+    stream_delta_callback,
+    tool_progress_callback,
+    *,
+    extra: Optional[Dict[str, Any]] = None,
+):
+    """Fresh agent per turn — mirrors api_server._create_agent
+    (gateway/platforms/api_server.py:1029-1065) with platform='voice'.
+
+    The model comes from the dedicated ``voice_model:`` slot (a top-level
+    sibling to ``model:`` and ``fallback_model:``) when configured, otherwise
+    the main model. Voice is a full agentic turn delivered in a latency-critical
+    spoken modality, so it gets its own first-class model slot — not a
+    per-platform override.
+    """
+    from run_agent import AIAgent
+    from gateway.run import (
+        GatewayRunner,
+        _load_gateway_config,
+        _resolve_gateway_model,
+        _resolve_runtime_agent_kwargs,
+        _resolve_voice_runtime_kwargs,
+    )
+    from hermes_cli.tools_config import _get_platform_tools
+
+    user_config = _load_gateway_config()
+    runtime_kwargs = _resolve_runtime_agent_kwargs()
+    model = _resolve_gateway_model(user_config)
+    # The voice_model: slot overrides endpoint/key/provider/api_mode + model for
+    # voice turns. None = slot unset or `auto` -> use the main model.
+    voice_override = _resolve_voice_runtime_kwargs()
+    if voice_override is not None:
+        model = voice_override.pop("model")
+        runtime_kwargs = {**runtime_kwargs, **voice_override}
+    return AIAgent(
+        model=model,
+        **runtime_kwargs,
+        max_iterations=_resolve_max_iterations(extra or {}),
+        quiet_mode=True,
+        verbose_logging=False,
+        enabled_toolsets=sorted(_get_platform_tools(user_config, "voice")),
+        session_id=session_id,
+        platform="voice",
+        stream_delta_callback=stream_delta_callback,
+        tool_progress_callback=tool_progress_callback,
+        fallback_model=GatewayRunner._load_fallback_model(),
+        reasoning_config=(_resolve_reasoning_override(extra or {})
+                          or GatewayRunner._load_reasoning_config()),
+    )
+
+
+class VoiceTurnLoop:
+    def __init__(self, stt, tts_factory, transport, *, extra: Dict[str, Any]):
+        """tts_factory(on_audio) -> opened TTS turn (one per turn)."""
+        self._stt = stt
+        self._tts_factory = tts_factory
+        self._transport = transport
+        self._extra = extra or {}
+        self._greeting = self._extra.get("greeting_prompt") or DEFAULT_GREETING_PROMPT
+        self._filler = self._extra.get("filler_text") or DEFAULT_FILLER_TEXT
+        self._session_id = f"voice-{uuid.uuid4().hex[:12]}"
+        self._history: List[Dict[str, str]] = []
+        # Holds a barged-in user_message that was never heard, re-queued for
+        # the next turn so the caller's words are not lost.
+        self._pending_text: List[str] = []
+        self._state = LISTENING
+        self._allow_interruptions = _resolve_bool_extra(
+            self._extra, "allow_interruptions", DEFAULT_ALLOW_INTERRUPTIONS)
+        # Telemetry: one structured record per turn, emitted as a JSON log line
+        # when the turn ends; per-call summary on stop.
+        self._tel: Dict[str, Any] = {}
+        self._call_stats: List[Dict[str, Any]] = []
+        # Per-turn delta/tool sinks behind stable trampolines, so an agent can
+        # be CONSTRUCTED before its turn starts and still stream into the right
+        # turn's queue.
+        self._delta_sink = None
+        self._tool_sink = None
+        # Pre-constructed agent for the next turn (concurrent.futures.Future
+        # from run_in_executor), made while the user is still speaking.
+        self._spare_agent_future = None
+        # One-element list so the executor thread can publish the live agent for
+        # cross-thread interrupt (api_server agent_ref pattern, 3505-3508).
+        self._agent_ref: List[Optional[Any]] = [None]
+        # Per-turn interrupt latch: a barge-in landing while the executor thread
+        # is still CONSTRUCTING the agent (agent_ref[0] unset) must not be lost —
+        # _run checks it right after construction.
+        self._interrupt_latch: Optional[threading.Event] = None
+        self._tts = None
+        self._turn_task: Optional[asyncio.Task] = None
+        self._stopped = asyncio.Event()
+        # Timing instrumentation: per-turn sequence + reference timestamp. All
+        # voice/timing logs report ms since this reference.
+        self._turn_seq = 0
+        self._t_ref: Optional[float] = None
+
+    def _mark(self, leg: str, **fields: Any) -> None:
+        """INFO timing log: ms since the current turn's reference point."""
+        now = time.monotonic()
+        ref = self._t_ref if self._t_ref is not None else now
+        extra = "".join(f" {k}={v}" for k, v in fields.items())
+        logger.info("voice/timing turn=%d %s t=+%.0fms%s",
+                    self._turn_seq, leg, (now - ref) * 1000.0, extra)
+
+    # -- telemetry ----------------------------------------------------------
+
+    def _tel_open(self) -> None:
+        if not self._tel:
+            self._tel = {"opened_at": time.monotonic()}
+            reset = getattr(self._transport, "reset_write_mark", None)
+            if reset is not None:
+                reset()
+
+    def _tel_set(self, key: str, value: Any = None) -> None:
+        """Record a telemetry timestamp (default: now) or value. First write
+        wins — retries must not overwrite the first leg."""
+        self._tel_open()
+        self._tel.setdefault(key, time.monotonic() if value is None else value)
+
+    def _tel_emit(self, status: str) -> None:
+        """Emit the per-turn structured JSON log line and bank the record for
+        the per-call summary. All offsets are ms since speech_end (end of the
+        user's utterance)."""
+        tel, self._tel = self._tel, {}
+        if not tel:
+            return
+        speech_end = tel.get("speech_end") or tel.get("vad_end") \
+            or tel.get("opened_at")
+        first_written = getattr(self._transport, "first_write_t", None)
+
+        def off(t: Optional[float]) -> Optional[int]:
+            return None if t is None else int(round((t - speech_end) * 1000))
+
+        perceived = off(first_written)
+        substantive = off(tel.get("tts_first_audio"))
+        record = {
+            "event": "voice_turn",
+            "turn": self._turn_seq,
+            "status": status,
+            "eager_start": bool(tel.get("eager_start")),
+            "turn_detector": tel.get("turn_detector", "flux"),
+            "eot_reason": tel.get("eot_reason"),
+            "vad_end_ms": off(tel.get("vad_end")),
+            "agent_start_ms": off(tel.get("agent_start")),
+            "first_delta_ms": off(tel.get("first_delta")),
+            "first_sentence_ms": off(tel.get("first_sentence")),
+            "tts_first_audio_ms": substantive,
+            "first_frame_written_ms": perceived,
+            "totals": {
+                "perceived_first_audio_ms": perceived,
+                "substantive_first_audio_ms": substantive,
+                "turn_total_ms": off(time.monotonic()),
+            },
+        }
+        emit_telemetry(record)
+        self._call_stats.append(record)
+
+    def _emit_call_summary(self) -> None:
+        turns = [r for r in self._call_stats if r["vad_end_ms"] is not None]
+
+        def stats(key: str) -> Optional[Dict[str, int]]:
+            vals = sorted(r["totals"][key] for r in turns
+                          if r["totals"][key] is not None)
+            if not vals:
+                return None
+            return {"median": vals[len(vals) // 2],
+                    "p90": vals[min(len(vals) - 1, int(len(vals) * 0.9))],
+                    "n": len(vals)}
+
+        raw_effort = self._extra.get("reasoning_effort")
+        record = {
+            "event": "voice_call_summary",
+            "session": self._session_id,
+            "turns": len(turns),
+            "model_override": _voice_model_name(),
+            "reasoning_effort": (str(raw_effort).strip()
+                                 if raw_effort is not None
+                                 and str(raw_effort).strip()
+                                 else "gateway-default"),
+            "eager_starts": sum(1 for r in turns if r["eager_start"]),
+            "barge_ins": sum(1 for r in self._call_stats
+                             if r["status"] == "interrupted"),
+            "perceived_first_audio_ms": stats("perceived_first_audio_ms"),
+            "substantive_first_audio_ms": stats("substantive_first_audio_ms"),
+        }
+        emit_telemetry(record)
+
+    # -- agent plumbing -----------------------------------------------------
+
+    def _delta_tramp(self, delta: str) -> None:
+        sink = self._delta_sink
+        if sink is not None:
+            sink(delta)
+
+    def _tool_tramp(self, event_type, tool_name=None, preview=None,
+                    args=None, **kwargs) -> None:
+        sink = self._tool_sink
+        if sink is not None:
+            sink(event_type, tool_name=tool_name, preview=preview,
+                 args=args, **kwargs)
+
+    def _make_agent(self):
+        """Construct a turn agent (executor thread). Construction does not need
+        the user message, so it can run before the turn starts."""
+        return _create_voice_agent(
+            self._session_id, self._delta_tramp, self._tool_tramp,
+            extra=self._extra)
+
+    def _preconstruct_agent(self) -> "concurrent.futures.Future":
+        """Build the next turn's agent on a worker thread. Returns a concurrent
+        Future (thread-safe .result() from the turn executor)."""
+        fut: "concurrent.futures.Future" = concurrent.futures.Future()
+
+        def _build() -> None:
+            try:
+                fut.set_result(self._make_agent())
+            except BaseException as e:    # surface in the consuming turn
+                fut.set_exception(e)
+
+        threading.Thread(
+            target=_build, name="voice-agent-prewarm", daemon=True).start()
+        return fut
+
+    # -- main ---------------------------------------------------------------
+
+    async def run(self) -> None:
+        consumer = asyncio.create_task(self._consume_flux())
+        canned = self._extra.get("greeting_text")
+        if canned:
+            # Canned greeting: instant TTS, no LLM round-trip. The first real
+            # turn's agent is pre-warmed while the greeting plays.
+            self._spare_agent_future = self._preconstruct_agent()
+            self._turn_task = asyncio.create_task(self._speak_canned(canned))
+        else:
+            # Agent speaks first: greeting turn before listening.
+            self._start_turn(self._greeting, record_user=False)
+        await self._stopped.wait()
+        consumer.cancel()
+        try:
+            await consumer
+        except (asyncio.CancelledError, Exception):
+            pass
+
+    async def stop(self) -> None:
+        await self._barge_in()           # kill any in-flight turn
+        self._tel_emit("call-ended")
+        self._emit_call_summary()
+        self._stopped.set()
+
+    async def _speak_canned(self, text: str) -> None:
+        """Speak fixed text through TTS without an agent turn (greeting)."""
+        self._t_ref = time.monotonic()
+        self._mark("canned-greeting-start", chars=len(text))
+        self._state = SPEAKING
+        try:
+            self._tts = await self._tts_factory(self._transport.send_audio)
+            await self._tts.send_text(text)
+            await asyncio.wait_for(self._tts.end(), timeout=TTS_END_TIMEOUT_S)
+            self._history.append({"role": "assistant", "content": text})
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            logger.exception("voice/turn: canned greeting failed")
+        finally:
+            self._tts = None
+            if self._state != LISTENING:
+                self._state = LISTENING
+
+    # -- Flux turn pump -----------------------------------------------------
+
+    async def _consume_flux(self) -> None:
+        """Deepgram Flux turn path: the STT emits conversation-native events
+        (normalized to start_of_turn / eager_end_of_turn / turn_resumed /
+        end_of_turn) and we drive the turn directly. Our in-process barge-in
+        EXECUTION (cancel LLM + mute TTS + clear transport, via _barge_in) is
+        the differentiator; Flux just supplies the trigger. See
+        deepgram_flux_stt.py for the event names."""
+        eager_live = False
+        async for ev in self._stt.events():
+            kind = ev.get("event")
+            text = (ev.get("transcript") or "").strip()
+            if kind == "start_of_turn":
+                # Barge-in if the agent is thinking/speaking OR still has audio
+                # PLAYING OUT — state flips to LISTENING the instant the audio
+                # is queued, but the transport plays the tail for seconds after,
+                # during which the caller is still hearing the agent.
+                speaking = (self._state in (THINKING, SPEAKING)
+                            or self._transport.is_playing())
+                if speaking:
+                    if self._allow_interruptions:
+                        self._mark("flux-barge-in", state=self._state)
+                        await self._barge_in()
+                        eager_live = False
+                elif self._spare_agent_future is None:
+                    # Pre-warm the agent while the user speaks so construction
+                    # (~0.5s) is off the critical path by eager/end-of-turn.
+                    self._spare_agent_future = self._preconstruct_agent()
+            elif kind == "eager_end_of_turn":
+                if text and self._state == LISTENING:
+                    eager_live = True
+                    self._begin_flux_turn(text, eager=True, reason="eager")
+            elif kind == "turn_resumed":
+                if eager_live:
+                    self._mark("flux-turn-resumed")
+                    await self._barge_in()   # cancel the speculative turn
+                    eager_live = False
+            elif kind == "end_of_turn":
+                if eager_live:
+                    # The speculative turn is already running; Flux guarantees
+                    # the EndOfTurn transcript matches the eager one, so it
+                    # stands as-is.
+                    eager_live = False
+                elif text and self._state == LISTENING:
+                    self._begin_flux_turn(text, eager=False, reason="endpoint")
+            # "update": incremental partial transcripts — not needed here.
+
+    def _begin_flux_turn(self, text: str, *, eager: bool, reason: str) -> None:
+        """Open the per-turn telemetry record and start the agent for a
+        Flux-detected turn."""
+        self._turn_seq += 1
+        self._t_ref = time.monotonic()
+        self._tel_set("vad_end", self._t_ref)
+        self._tel["speech_end"] = self._t_ref
+        self._tel_set("turn_detector", "flux")
+        self._tel_set("eot_reason", reason)
+        if eager:
+            self._tel_set("eager_start", True)
+        self._mark("flux-turn-end", reason=reason, eager=eager)
+        agent_future = self._spare_agent_future
+        self._spare_agent_future = None
+        self._start_turn(text, record_user=True, agent_future=agent_future)
+
+    # -- agent turn ---------------------------------------------------------
+
+    def _start_turn(self, user_message: str, *, record_user: bool,
+                    agent_future=None) -> None:
+        self._state = THINKING
+        if self._t_ref is None:          # greeting turn has no vad-end
+            self._t_ref = time.monotonic()
+        self._mark("turn-start", chars=len(user_message))
+        # Fresh latch BEFORE the task exists so a barge-in can never land
+        # between turn creation and the executor publishing the agent.
+        self._interrupt_latch = threading.Event()
+        self._turn_task = asyncio.create_task(
+            self._execute_turn(user_message, record_user=record_user,
+                               agent_future=agent_future))
+
+    async def _execute_turn(self, user_message: str, *, record_user: bool,
+                            agent_future=None) -> None:
+        loop = asyncio.get_running_loop()
+        q: "asyncio.Queue[tuple]" = asyncio.Queue()
+        agent_ref = self._agent_ref
+        agent_ref[0] = None
+        interrupt_latch = self._interrupt_latch
+
+        # Threadsafe marshal — mirrors api_server._enqueue (1619-1631).
+        def _enqueue(item: tuple) -> None:
+            try:
+                running_loop = asyncio.get_running_loop()
+            except RuntimeError:
+                running_loop = None
+            try:
+                if running_loop is loop:
+                    q.put_nowait(item)
+                else:
+                    loop.call_soon_threadsafe(q.put_nowait, item)
+            except RuntimeError:
+                pass
+
+        # Mirrors api_server._delta (1633-1635).
+        first_delta_seen = threading.Event()
+
+        def _delta(delta: str) -> None:
+            if delta:
+                if not first_delta_seen.is_set():
+                    first_delta_seen.set()
+                    self._mark("first-delta")
+                    self._tel_set("first_delta")
+                _enqueue(("delta", delta))
+
+        # Signature mirrors api_server._tool_progress (1637).
+        def _tool_progress(event_type, tool_name=None, preview=None,
+                           args=None, **kwargs) -> None:
+            if event_type == "tool.started":
+                _enqueue(("tool", tool_name))
+
+        # Route the stable trampolines into THIS turn's queue. One live turn at
+        # a time, so plain assignment is safe.
+        self._delta_sink = _delta
+        self._tool_sink = _tool_progress
+
+        def _run():
+            # Executor body mirrors api_server._run_agent (3510-3554).
+            if agent_future is not None:
+                # Pre-constructed; bounded so a hung construction can never
+                # wedge the turn executor forever.
+                agent = agent_future.result(timeout=RUN_FUTURE_TIMEOUT_S)
+            else:
+                self._mark("agent-constructing")
+                agent = self._make_agent()
+            agent_ref[0] = agent
+            self._mark("agent-start")
+            self._tel_set("agent_start")
+            if interrupt_latch.is_set():
+                # A barge-in/stop landed while the agent was still being
+                # constructed: interrupt before the first iteration runs.
+                try:
+                    agent.interrupt("user barge-in (voice)")
+                except Exception:
+                    pass
+            try:
+                return agent.run_conversation(
+                    user_message=user_message,
+                    conversation_history=list(self._history),
+                    task_id=self._session_id,
+                )
+            finally:
+                _enqueue(("done", None))
+
+        run_future = loop.run_in_executor(None, _run)
+        # Pre-warm the NEXT turn's agent while this one runs: construction
+        # (~0.5s of config/toolset loading) drops off the critical path of every
+        # subsequent turn.
+        if self._spare_agent_future is None:
+            self._spare_agent_future = self._preconstruct_agent()
+
+        interrupted = False
+        first_audio_seen = False
+
+        async def _on_audio(pcm: bytes) -> None:
+            nonlocal first_audio_seen
+            if not first_audio_seen:
+                first_audio_seen = True
+                self._mark("first-tts-audio-chunk", bytes=len(pcm))
+                self._tel_set("tts_first_audio")
+            await self._transport.send_audio(pcm)
+
+        try:
+            self._tts = await self._tts_factory(_on_audio)
+            self._mark("tts-socket-open")
+            self._state = SPEAKING
+            await self._pump_deltas_to_tts(q)
+            try:
+                # end() blocks until the server's final audio; bounded wait.
+                await asyncio.wait_for(self._tts.end(), timeout=TTS_END_TIMEOUT_S)
+            except asyncio.TimeoutError:
+                logger.warning("voice/turn: tts end timed out; aborting socket")
+                await self._tts.abort()
+        except asyncio.CancelledError:
+            interrupted = True
+            raise
+        finally:
+            self._tts = None
+            if interrupted and agent_ref[0] is not None:
+                # The latch may have raced agent construction; now that the
+                # agent surely exists, re-issue the direct interrupt so the
+                # bounded await below resolves promptly.
+                try:
+                    agent_ref[0].interrupt("user barge-in (voice)")
+                except Exception:
+                    pass
+            try:
+                result = await asyncio.wait_for(
+                    run_future, timeout=RUN_FUTURE_TIMEOUT_S)
+            except asyncio.TimeoutError:
+                logger.error(
+                    "voice/turn: agent run did not finish within %.0fs after "
+                    "the turn ended; abandoning executor thread (it may still "
+                    "be running and burning tokens)", RUN_FUTURE_TIMEOUT_S)
+                result = None
+            except Exception:
+                logger.exception("voice/turn: agent run failed")
+                result = None
+            if result and isinstance(result, dict) and not interrupted:
+                final = result.get("final_response", "")
+                if record_user:
+                    self._history.append({"role": "user", "content": user_message})
+                if final:
+                    self._history.append({"role": "assistant", "content": final})
+            elif interrupted and record_user and not first_audio_seen:
+                # Barged in before the user heard ANY of the reply: their words
+                # must not vanish — feed them into the next turn.
+                self._pending_text.insert(0, user_message)
+            agent_ref[0] = None
+            self._delta_sink = None
+            self._tool_sink = None
+            if self._state != LISTENING:
+                self._state = LISTENING
+            self._tel_emit("interrupted" if interrupted else "ok")
+
+    async def _pump_deltas_to_tts(self, q: "asyncio.Queue[tuple]") -> None:
+        """Stream deltas to TTS at word granularity.
+
+        Cartesia synthesizes on sentence-final punctuation (or an explicit
+        <flush>), so forwarding words as they arrive lets audio start the moment
+        the model emits the first '.', instead of after the whole reply. Words
+        are never split across messages; ``buf`` holds at most one partial word.
+        ``unsynthesized`` tracks text the server is holding without a sentence
+        boundary — a long punctuation-free stretch is force-flushed on idle."""
+        buf = ""
+        unsynthesized = 0
+        filler_spoken = False
+        first_text_sent = False
+        first_send_t: Optional[float] = None
+        punct_ever = False
+        first_flush_done = False
+
+        def _mark_first_send(kind_: str, text: str) -> None:
+            nonlocal first_text_sent, first_send_t
+            if not first_text_sent:
+                first_text_sent = True
+                first_send_t = time.monotonic()
+                self._mark("first-text-to-tts", kind=kind_, chars=len(text))
+
+        async def _send(fragment: str, kind_: str) -> None:
+            nonlocal unsynthesized, punct_ever
+            if not fragment:
+                return
+            _mark_first_send(kind_, fragment)
+            await self._tts.send_text(fragment)
+            m = None
+            for m in _PUNCT_RE.finditer(fragment):
+                pass
+            if m is not None:
+                if not punct_ever:
+                    self._tel_set("first_sentence")
+                punct_ever = True
+                unsynthesized = len(fragment) - m.end()
+            else:
+                unsynthesized += len(fragment)
+
+        async def _maybe_first_flush() -> None:
+            # First-audio guard: if the model's first sentence is dragging on
+            # with no sentence-final punctuation, force one <flush> so the user
+            # hears SOMETHING (~350ms later) instead of dead air.
+            nonlocal first_flush_done, unsynthesized
+            if (first_send_t is not None and not punct_ever
+                    and not first_flush_done and unsynthesized > 0
+                    and time.monotonic() - first_send_t
+                    > FIRST_SENTENCE_FLUSH_S):
+                first_flush_done = True
+                self._mark("first-sentence-forced-flush", held_chars=unsynthesized)
+                self._tel_set("first_sentence")
+                await self._tts.send_text("<flush>")
+                unsynthesized = 0
+
+        while True:
+            try:
+                kind, payload = await asyncio.wait_for(q.get(), timeout=0.2)
+            except asyncio.TimeoutError:
+                await _maybe_first_flush()
+                if buf and len(buf) + unsynthesized > LONG_FLUSH_LEN:
+                    await _send(buf, "long-flush")
+                    buf = ""
+                if unsynthesized > LONG_FLUSH_LEN:
+                    await self._tts.send_text("<flush>")
+                    unsynthesized = 0
+                continue
+            if kind == "tool":
+                if not filler_spoken:
+                    filler_spoken = True
+                    _mark_first_send("filler", self._filler)
+                    await self._tts.send_filler(self._filler)
+            elif kind == "delta":
+                buf += payload
+                # Send everything up to the last whitespace (complete words);
+                # keep the trailing partial word.
+                cut = max(buf.rfind(" "), buf.rfind("\n"), buf.rfind("\t"))
+                if cut >= 0:
+                    await _send(buf[:cut + 1], "words")
+                    buf = buf[cut + 1:]
+                await _maybe_first_flush()
+            elif kind == "done":
+                if buf.strip():
+                    await _send(buf, "done-tail")
+                return
+
+    # -- barge-in -----------------------------------------------------------
+
+    async def _barge_in(self) -> None:
+        t0 = time.monotonic()
+        # Latch first: if the executor thread is still constructing the agent,
+        # _run picks this up right after construction and interrupts before the
+        # first iteration (the direct path below would miss it).
+        latch = self._interrupt_latch
+        if latch is not None:
+            latch.set()
+        agent = self._agent_ref[0]
+        if agent is not None:
+            try:
+                agent.interrupt("user barge-in (voice)")   # api_server.py:4091
+            except Exception:
+                pass
+        tts = self._tts
+        if tts is not None:
+            # Mute synchronously FIRST: no further TTS audio may reach the
+            # transport while abort()'s socket close is in flight.
+            tts.mute()
+        self._transport.clear_output()
+        logger.info("voice/timing barge-in audio-cleared in %.0fms",
+                    (time.monotonic() - t0) * 1000.0)
+        if tts is not None:
+            await tts.abort()
+        if self._turn_task is not None and not self._turn_task.done():
+            self._turn_task.cancel()
+            try:
+                await self._turn_task
+            except (asyncio.CancelledError, Exception):
+                pass
+        self._turn_task = None
+        self._state = LISTENING
+        logger.info("voice/turn: barge-in handled in %.0fms",
+                    (time.monotonic() - t0) * 1000.0)

--- a/plugins/platforms/voice/turn_loop.py
+++ b/plugins/platforms/voice/turn_loop.py
@@ -295,7 +295,8 @@ class VoiceTurnLoop:
             "turn": self._turn_seq,
             "status": status,
             "eager_start": bool(tel.get("eager_start")),
-            "turn_detector": tel.get("turn_detector", "flux"),
+            "turn_detector": tel.get("turn_detector", self._stt.provider),
+            "stt_provider": self._stt.provider,
             "eot_reason": tel.get("eot_reason"),
             "vad_end_ms": off(tel.get("vad_end")),
             "agent_start_ms": off(tel.get("agent_start")),
@@ -329,6 +330,7 @@ class VoiceTurnLoop:
             "event": "voice_call_summary",
             "session": self._session_id,
             "turns": len(turns),
+            "stt_provider": self._stt.provider,
             "model_override": _voice_model_name(),
             "reasoning_effort": (str(raw_effort).strip()
                                  if raw_effort is not None
@@ -478,7 +480,7 @@ class VoiceTurnLoop:
         self._t_ref = time.monotonic()
         self._tel_set("vad_end", self._t_ref)
         self._tel["speech_end"] = self._t_ref
-        self._tel_set("turn_detector", "flux")
+        self._tel_set("turn_detector", self._stt.provider)
         self._tel_set("eot_reason", reason)
         if eager:
             self._tel_set("eager_start", True)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -155,6 +155,13 @@ voice = [
   "sounddevice==0.5.5",
   "numpy==2.4.3",
 ]
+# Realtime voice platform plugin (plugins/platforms/voice): Daily WebRTC
+# transport + the Deepgram Flux / Cartesia streaming websocket clients.
+# Kept out of the base install — only needed to run live voice calls.
+voice-platform = [
+  "daily-python==0.29.1",
+  "websockets==15.0.1",  # >=14 for connect(additional_headers=...)
+]
 pty = [
   # Kept as a no-op back-compat alias — `ptyprocess` and `pywinpty` are now
   # in the main `dependencies` list (with the same platform markers), so

--- a/tests/gateway/test_voice_plugin.py
+++ b/tests/gateway/test_voice_plugin.py
@@ -448,15 +448,10 @@ def test_ink_normalize_resume_is_turn_resumed():
     assert out["event"] == "turn_resumed"
 
 
-def test_ink_normalize_transcript_field_fallbacks():
-    # transcript field name is assumed; defensive extraction tries text ->
-    # transcript -> transcript_text.
-    assert ink._normalize_ink_message(
-        {"type": "turn.end", "text": "hello"})["transcript"] == "hello"
+def test_ink_normalize_transcript_field():
+    # Verified live: the transcript lives in "transcript".
     assert ink._normalize_ink_message(
         {"type": "turn.end", "transcript": "hi there"})["transcript"] == "hi there"
-    assert ink._normalize_ink_message(
-        {"type": "turn.end", "transcript_text": "yo"})["transcript"] == "yo"
 
 
 def test_ink_normalize_defaults_missing_fields():
@@ -467,13 +462,15 @@ def test_ink_normalize_defaults_missing_fields():
     assert out["turn_index"] is None
 
 
-def test_ink_normalize_carries_optional_fields():
+def test_ink_normalize_carries_turn_id():
+    # Verified live: id field is "turn_id" (string); Ink-2 sends no confidence
+    # or per-word list, so those stay None/[] for shape-parity with Flux.
     out = ink._normalize_ink_message({
-        "type": "turn.update", "text": "partial",
-        "confidence": 0.42, "words": [{"w": "partial"}], "turn_index": 3})
-    assert out["confidence"] == 0.42
-    assert out["words"] == [{"w": "partial"}]
-    assert out["turn_index"] == 3
+        "type": "turn.update", "transcript": "partial", "turn_id": "3"})
+    assert out["transcript"] == "partial"
+    assert out["turn_index"] == "3"
+    assert out["confidence"] is None
+    assert out["words"] == []
 
 
 def test_ink_normalize_drops_unknown_types():

--- a/tests/gateway/test_voice_plugin.py
+++ b/tests/gateway/test_voice_plugin.py
@@ -1,0 +1,407 @@
+"""Fixture-driven unit tests for the voice platform plugin
+(plugins/platforms/voice/). No live network — Daily / Deepgram / Cartesia are
+all faked. Covers plugin registration + requirements, the Cartesia extra-config
+parsers, the Flux event -> turn/barge-in logic in the turn loop (the
+in-process barge-in is the plugin's whole point), and the 24k->16k resampler.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from gateway.config import PlatformConfig
+from tests.gateway._plugin_adapter_loader import load_plugin_adapter
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_VOICE_DIR = _REPO_ROOT / "plugins" / "platforms" / "voice"
+
+
+def _load_voice_module(name: str):
+    """Load a sibling voice module (turn_loop, deepgram_flux_stt) the same
+    isolated way load_plugin_adapter loads adapter.py — by explicit file path
+    under a unique module name, no sys.path mutation."""
+    mod_name = f"voice_mod_{name}"
+    cached = sys.modules.get(mod_name)
+    if cached is not None:
+        return cached
+    spec = importlib.util.spec_from_file_location(mod_name, _VOICE_DIR / f"{name}.py")
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[mod_name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+_adapter = load_plugin_adapter("voice")
+turn_loop = _load_voice_module("turn_loop")
+flux = _load_voice_module("deepgram_flux_stt")
+daily_transport = _load_voice_module("daily_transport")
+cartesia = _load_voice_module("cartesia_tts")
+
+
+# --------------------------------------------------------------------------- #
+# Fakes
+# --------------------------------------------------------------------------- #
+
+class _FakeFluxSTT:
+    """Yields a fixed list of normalized Flux events, then ends (so the
+    turn loop's `async for` over events() returns)."""
+
+    def __init__(self, events):
+        self._events = events
+
+    async def events(self):
+        for ev in self._events:
+            yield ev
+
+
+class _FakeTransport:
+    def __init__(self, playing: bool = False):
+        self._playing = playing
+        self.cleared = 0
+        self.first_write_t = None
+
+    def is_playing(self) -> bool:
+        return self._playing
+
+    def clear_output(self) -> None:
+        self.cleared += 1
+
+    def reset_write_mark(self) -> None:
+        pass
+
+    async def send_audio(self, pcm: bytes) -> None:
+        pass
+
+
+async def _noop_tts_factory(on_audio):  # never called: _start_turn is patched
+    raise AssertionError("tts_factory should not run in _consume_flux tests")
+
+
+def _make_loop(events, *, playing=False, extra=None):
+    return turn_loop.VoiceTurnLoop(
+        _FakeFluxSTT(events), _noop_tts_factory, _FakeTransport(playing=playing),
+        extra=extra or {})
+
+
+# --------------------------------------------------------------------------- #
+# Plugin registration + requirements
+# --------------------------------------------------------------------------- #
+
+def test_register_registers_voice_platform():
+    ctx = MagicMock()
+    _adapter.register(ctx)
+    ctx.register_platform.assert_called_once()
+    kwargs = ctx.register_platform.call_args.kwargs
+    assert kwargs["name"] == "voice"
+    assert kwargs["label"] == "Voice"
+    assert kwargs["required_env"] == [
+        "DAILY_API_KEY", "DEEPGRAM_API_KEY", "CARTESIA_API_KEY"]
+    assert kwargs["pii_safe"] is True
+    assert kwargs["allow_update_command"] is False
+    for fn in ("check_fn", "validate_config", "is_connected", "adapter_factory"):
+        assert callable(kwargs[fn])
+
+
+def test_adapter_factory_returns_voice_adapter():
+    ctx = MagicMock()
+    _adapter.register(ctx)
+    factory = ctx.register_platform.call_args.kwargs["adapter_factory"]
+    adapter = factory(PlatformConfig(enabled=True, extra={}))
+    assert isinstance(adapter, _adapter.VoiceAdapter)
+
+
+def test_check_requirements_needs_all_three_keys(monkeypatch):
+    monkeypatch.setattr(_adapter, "_daily_available", lambda: True)
+    monkeypatch.setattr(_adapter, "_websockets_available", lambda: True)
+    monkeypatch.setenv("DAILY_API_KEY", "dk")
+    monkeypatch.setenv("DEEPGRAM_API_KEY", "dg")
+    monkeypatch.delenv("CARTESIA_API_KEY", raising=False)
+    assert _adapter.check_requirements() is False
+    monkeypatch.setenv("CARTESIA_API_KEY", "ck")
+    assert _adapter.check_requirements() is True
+
+
+def test_check_requirements_false_without_deps(monkeypatch):
+    monkeypatch.setattr(_adapter, "_daily_available", lambda: False)
+    monkeypatch.setattr(_adapter, "_websockets_available", lambda: True)
+    monkeypatch.setenv("DAILY_API_KEY", "dk")
+    monkeypatch.setenv("DEEPGRAM_API_KEY", "dg")
+    monkeypatch.setenv("CARTESIA_API_KEY", "ck")
+    assert _adapter.check_requirements() is False
+
+
+def test_validate_config_requires_daily_key(monkeypatch):
+    cfg = PlatformConfig(enabled=True, extra={})
+    monkeypatch.delenv("DAILY_API_KEY", raising=False)
+    assert _adapter.validate_config(cfg) is False
+    monkeypatch.setenv("DAILY_API_KEY", "dk")
+    assert _adapter.validate_config(cfg) is True
+
+
+# --------------------------------------------------------------------------- #
+# Extra-config parsers
+# --------------------------------------------------------------------------- #
+
+def test_resolve_float_extra_default_and_parse():
+    assert _adapter._resolve_float_extra({}, "eot_threshold", 0.7) == 0.7
+    assert _adapter._resolve_float_extra({"eot_threshold": "0.5"}, "eot_threshold", 0.7) == 0.5
+    # garbage falls back to the default, never raises
+    assert _adapter._resolve_float_extra({"eot_threshold": "nope"}, "eot_threshold", 0.7) == 0.7
+
+
+def test_resolve_opt_float_extra_returns_none_when_unset():
+    assert _adapter._resolve_opt_float_extra({}, "tts_speed") is None
+    assert _adapter._resolve_opt_float_extra({"tts_speed": ""}, "tts_speed") is None
+    assert _adapter._resolve_opt_float_extra({"tts_speed": "1.2"}, "tts_speed") == 1.2
+
+
+# --------------------------------------------------------------------------- #
+# Flux event -> turn / barge-in logic (the moat)
+# --------------------------------------------------------------------------- #
+
+@pytest.mark.asyncio
+async def test_eager_then_end_starts_a_single_turn(monkeypatch):
+    loop = _make_loop([
+        {"event": "eager_end_of_turn", "transcript": "hello there"},
+        {"event": "end_of_turn", "transcript": "hello there"},
+    ])
+    started = []
+    monkeypatch.setattr(loop, "_start_turn",
+                        lambda text, **k: started.append(text))
+    await loop._consume_flux()
+    # Eager starts the turn; the matching end_of_turn lets it stand (no restart).
+    assert started == ["hello there"]
+
+
+@pytest.mark.asyncio
+async def test_end_of_turn_without_eager_starts_turn(monkeypatch):
+    loop = _make_loop([
+        {"event": "end_of_turn", "transcript": "what time is it"},
+    ])
+    started = []
+    monkeypatch.setattr(loop, "_start_turn",
+                        lambda text, **k: started.append(text))
+    await loop._consume_flux()
+    assert started == ["what time is it"]
+
+
+@pytest.mark.asyncio
+async def test_start_of_turn_barges_in_while_audio_playing(monkeypatch):
+    # State is LISTENING but the transport is still playing the agent's tail —
+    # barge-in must fire on that tail, which is the bug the is_playing() check
+    # fixes.
+    loop = _make_loop(
+        [{"event": "start_of_turn", "transcript": "wait"}], playing=True)
+    barged = []
+
+    async def _fake_barge():
+        barged.append(True)
+
+    monkeypatch.setattr(loop, "_barge_in", _fake_barge)
+    await loop._consume_flux()
+    assert barged == [True]
+
+
+@pytest.mark.asyncio
+async def test_start_of_turn_idle_does_not_barge(monkeypatch):
+    loop = _make_loop(
+        [{"event": "start_of_turn", "transcript": "hi"}], playing=False)
+    barged = []
+
+    async def _fake_barge():
+        barged.append(True)
+
+    monkeypatch.setattr(loop, "_barge_in", _fake_barge)
+    await loop._consume_flux()
+    assert barged == []   # nothing playing -> pre-warm, not barge
+
+
+@pytest.mark.asyncio
+async def test_start_of_turn_respects_allow_interruptions_false(monkeypatch):
+    loop = _make_loop(
+        [{"event": "start_of_turn", "transcript": "wait"}],
+        playing=True, extra={"allow_interruptions": False})
+    barged = []
+
+    async def _fake_barge():
+        barged.append(True)
+
+    monkeypatch.setattr(loop, "_barge_in", _fake_barge)
+    await loop._consume_flux()
+    assert barged == []
+
+
+@pytest.mark.asyncio
+async def test_turn_resumed_cancels_the_speculative_turn(monkeypatch):
+    loop = _make_loop([
+        {"event": "eager_end_of_turn", "transcript": "hello"},
+        {"event": "turn_resumed", "transcript": ""},
+    ])
+    monkeypatch.setattr(loop, "_start_turn", lambda text, **k: None)
+    barged = []
+
+    async def _fake_barge():
+        barged.append(True)
+
+    monkeypatch.setattr(loop, "_barge_in", _fake_barge)
+    await loop._consume_flux()
+    assert barged == [True]   # the user kept talking -> kill the eager turn
+
+
+def test_resolve_bool_extra():
+    assert turn_loop._resolve_bool_extra({}, "k", True) is True
+    assert turn_loop._resolve_bool_extra({"k": "false"}, "k", True) is False
+    assert turn_loop._resolve_bool_extra({"k": "on"}, "k", False) is True
+    assert turn_loop._resolve_bool_extra({"k": False}, "k", True) is False
+
+
+# --------------------------------------------------------------------------- #
+# Flux 24k -> 16k resampler (pure function)
+# --------------------------------------------------------------------------- #
+
+def test_resample_to_16k_reduces_sample_count():
+    pcm = bytes(2400 * 2)   # 2400 s16le samples @ 24k (silence)
+    out = flux._resample_to_16k(pcm, 24000)
+    # 24k -> 16k is a 2/3 ratio: 2400 -> 1600 samples (3200 bytes).
+    assert len(out) == 1600 * 2
+
+
+def test_resample_to_16k_interpolates_a_ramp():
+    import array
+    src = array.array("h", [0, 300, 600, 900])   # 4 samples
+    out = array.array("h")
+    out.frombytes(flux._resample_to_16k(src.tobytes(), 24000))
+    # 4 -> round(4*2/3)=3 samples, endpoints preserved, middle interpolated.
+    assert len(out) == 3
+    assert out[0] == 0 and out[-1] == 900
+    assert 0 < out[1] < 900
+
+
+def test_resample_to_16k_passthrough_at_16k():
+    pcm = b"\x01\x00\x02\x00\x03\x00"
+    assert flux._resample_to_16k(pcm, 16000) == pcm
+
+
+def test_resample_to_16k_empty():
+    assert flux._resample_to_16k(b"", 24000) == b""
+
+
+# --------------------------------------------------------------------------- #
+# Flux wire-message normalization (the event contract the turn loop consumes)
+# --------------------------------------------------------------------------- #
+
+def test_flux_normalize_start_of_turn():
+    out = flux._normalize_flux_message(
+        {"type": "TurnInfo", "event": "StartOfTurn", "transcript": "hi",
+         "end_of_turn_confidence": 0.2})
+    assert out["event"] == "start_of_turn"
+    assert out["transcript"] == "hi"
+    assert out["confidence"] == 0.2
+
+
+def test_flux_normalize_eager_and_end_events():
+    eager = flux._normalize_flux_message(
+        {"type": "TurnInfo", "event": "EagerEndOfTurn"})
+    end = flux._normalize_flux_message(
+        {"type": "TurnInfo", "event": "EndOfTurn"})
+    resumed = flux._normalize_flux_message(
+        {"type": "TurnInfo", "event": "TurnResumed"})
+    assert eager["event"] == "eager_end_of_turn"
+    assert end["event"] == "end_of_turn"
+    assert resumed["event"] == "turn_resumed"
+
+
+def test_flux_normalize_missing_transcript_becomes_empty():
+    out = flux._normalize_flux_message(
+        {"type": "TurnInfo", "event": "StartOfTurn", "transcript": None})
+    assert out["transcript"] == ""
+
+
+def test_flux_normalize_drops_unknown_and_non_turninfo():
+    assert flux._normalize_flux_message(
+        {"type": "TurnInfo", "event": "Bogus"}) is None
+    assert flux._normalize_flux_message({"type": "Metadata"}) is None
+    assert flux._normalize_flux_message({"type": "Connected"}) is None
+
+
+# --------------------------------------------------------------------------- #
+# Daily transport queue logic (the barge-in audio path — no SDK needed)
+# --------------------------------------------------------------------------- #
+
+async def _noop_audio_in(pcm: bytes) -> None:
+    pass
+
+
+@pytest.mark.asyncio
+async def test_transport_send_audio_splits_large_pcm():
+    import asyncio
+    t = daily_transport.DailyTransport(asyncio.get_running_loop(), _noop_audio_in)
+    big = bytes(daily_transport.OUT_CHUNK_BYTES * 3 + 100)
+    await t.send_audio(big)
+    sizes = []
+    while not t._out_q.empty():
+        sizes.append(len(t._out_q.get_nowait()))
+    assert len(sizes) == 4  # 3 full chunks + a 100-byte remainder
+    assert all(s <= daily_transport.OUT_CHUNK_BYTES for s in sizes)
+    assert sum(sizes) == len(big)
+
+
+@pytest.mark.asyncio
+async def test_transport_send_audio_small_stays_one_chunk():
+    import asyncio
+    t = daily_transport.DailyTransport(asyncio.get_running_loop(), _noop_audio_in)
+    await t.send_audio(b"\x00" * 200)
+    assert t._out_q.qsize() == 1
+
+
+@pytest.mark.asyncio
+async def test_transport_is_playing_and_clear_output():
+    import asyncio
+    t = daily_transport.DailyTransport(asyncio.get_running_loop(), _noop_audio_in)
+    assert t.is_playing() is False
+    await t.send_audio(b"\x00" * 200)
+    assert t.is_playing() is True
+    t.clear_output()                      # barge-in drops queued audio
+    assert t.is_playing() is False
+
+
+# --------------------------------------------------------------------------- #
+# Cartesia request builder (pure) + the <flush> mapping
+# --------------------------------------------------------------------------- #
+
+def test_cartesia_request_basic_payload():
+    c = cartesia.CartesiaTTSClient("k", "voice-1")
+    req = c._request("ctx-1", "hello there", True)
+    assert req["transcript"] == "hello there"
+    assert req["voice"] == {"mode": "id", "id": "voice-1"}
+    assert req["output_format"]["encoding"] == "pcm_s16le"
+    assert req["output_format"]["sample_rate"] == cartesia.OUTPUT_SAMPLE_RATE
+    assert req["context_id"] == "ctx-1"
+    assert req["continue"] is True
+    assert "flush" not in req
+    assert "generation_config" not in req
+
+
+def test_cartesia_request_flush_maps_to_flag():
+    c = cartesia.CartesiaTTSClient("k", "voice-1")
+    req = c._request("ctx-1", "", True, flush=True)
+    assert req["flush"] is True
+    assert req["transcript"] == ""
+
+
+def test_cartesia_request_carries_generation_config():
+    c = cartesia.CartesiaTTSClient("k", "voice-1", speed=1.2, emotion="calm")
+    req = c._request("ctx-1", "hi", False)
+    assert req["generation_config"] == {"speed": 1.2, "emotion": "calm"}
+    assert req["continue"] is False
+
+
+def test_cartesia_requires_a_voice_id():
+    with pytest.raises(ValueError):
+        cartesia.CartesiaTTSClient("k", "")

--- a/tests/gateway/test_voice_plugin.py
+++ b/tests/gateway/test_voice_plugin.py
@@ -22,9 +22,17 @@ _VOICE_DIR = _REPO_ROOT / "plugins" / "platforms" / "voice"
 
 
 def _load_voice_module(name: str):
-    """Load a sibling voice module (turn_loop, deepgram_flux_stt) the same
-    isolated way load_plugin_adapter loads adapter.py — by explicit file path
-    under a unique module name, no sys.path mutation."""
+    """Load a sibling voice module (turn_loop, deepgram_flux_stt, stt,
+    cartesia_ink_stt) the same isolated way load_plugin_adapter loads
+    adapter.py — by explicit file path under a unique module name, no sys.path
+    mutation.
+
+    Cross-sibling imports: deepgram_flux_stt / cartesia_ink_stt import EV_* from
+    the ``stt`` port via the discord dual-import (flat ``import stt`` in the test
+    loader, relative ``from .stt`` in the production package). To make the flat
+    ``import stt`` resolve under this isolated loader, each module is ALSO
+    registered under its bare flat name in sys.modules. Production is unaffected
+    (there the real package names apply)."""
     mod_name = f"voice_mod_{name}"
     cached = sys.modules.get(mod_name)
     if cached is not None:
@@ -33,13 +41,17 @@ def _load_voice_module(name: str):
     assert spec is not None and spec.loader is not None
     module = importlib.util.module_from_spec(spec)
     sys.modules[mod_name] = module
+    # Expose the bare flat name so a sibling's `import <name>` resolves here.
+    sys.modules[name] = module
     spec.loader.exec_module(module)
     return module
 
 
 _adapter = load_plugin_adapter("voice")
+stt_port = _load_voice_module("stt")
 turn_loop = _load_voice_module("turn_loop")
 flux = _load_voice_module("deepgram_flux_stt")
+ink = _load_voice_module("cartesia_ink_stt")
 daily_transport = _load_voice_module("daily_transport")
 cartesia = _load_voice_module("cartesia_tts")
 
@@ -51,6 +63,8 @@ cartesia = _load_voice_module("cartesia_tts")
 class _FakeFluxSTT:
     """Yields a fixed list of normalized Flux events, then ends (so the
     turn loop's `async for` over events() returns)."""
+
+    provider = "deepgram_flux"   # the STT port surface the turn loop tags
 
     def __init__(self, events):
         self._events = events
@@ -405,3 +419,141 @@ def test_cartesia_request_carries_generation_config():
 def test_cartesia_requires_a_voice_id():
     with pytest.raises(ValueError):
         cartesia.CartesiaTTSClient("k", "")
+
+
+# --------------------------------------------------------------------------- #
+# Cartesia Ink-2 wire-message normalization (the A/B adapter's event contract)
+# --------------------------------------------------------------------------- #
+
+def test_ink_normalize_maps_every_turn_event():
+    # The whole point of the seam: Ink-2's turn.* events normalize onto the
+    # SAME EV_* contract Flux produces, so the turn loop drives both identically.
+    cases = {
+        "turn.start": stt_port.EV_START,
+        "turn.update": stt_port.EV_UPDATE,
+        "turn.eager_end": stt_port.EV_EAGER_EOT,
+        "turn.resume": stt_port.EV_RESUMED,
+        "turn.end": stt_port.EV_END,
+    }
+    for raw_type, expected in cases.items():
+        out = ink._normalize_ink_message({"type": raw_type})
+        assert out is not None
+        assert out["event"] == expected
+
+
+def test_ink_normalize_resume_is_turn_resumed():
+    # Explicit: the resume event must map to turn_resumed so the loop cancels
+    # the speculative (eager) turn — the trickiest mapping to get right.
+    out = ink._normalize_ink_message({"type": "turn.resume"})
+    assert out["event"] == "turn_resumed"
+
+
+def test_ink_normalize_transcript_field_fallbacks():
+    # transcript field name is assumed; defensive extraction tries text ->
+    # transcript -> transcript_text.
+    assert ink._normalize_ink_message(
+        {"type": "turn.end", "text": "hello"})["transcript"] == "hello"
+    assert ink._normalize_ink_message(
+        {"type": "turn.end", "transcript": "hi there"})["transcript"] == "hi there"
+    assert ink._normalize_ink_message(
+        {"type": "turn.end", "transcript_text": "yo"})["transcript"] == "yo"
+
+
+def test_ink_normalize_defaults_missing_fields():
+    out = ink._normalize_ink_message({"type": "turn.start"})
+    assert out["transcript"] == ""
+    assert out["confidence"] is None
+    assert out["words"] == []
+    assert out["turn_index"] is None
+
+
+def test_ink_normalize_carries_optional_fields():
+    out = ink._normalize_ink_message({
+        "type": "turn.update", "text": "partial",
+        "confidence": 0.42, "words": [{"w": "partial"}], "turn_index": 3})
+    assert out["confidence"] == 0.42
+    assert out["words"] == [{"w": "partial"}]
+    assert out["turn_index"] == 3
+
+
+def test_ink_normalize_drops_unknown_types():
+    assert ink._normalize_ink_message({"type": "metadata"}) is None
+    assert ink._normalize_ink_message({"type": "error", "error": "x"}) is None
+    assert ink._normalize_ink_message({}) is None
+
+
+def test_ink_requires_api_key():
+    with pytest.raises(ValueError):
+        ink.CartesiaInkSTT("")
+
+
+# --------------------------------------------------------------------------- #
+# STT port surface + factory (both providers behind one seam)
+# --------------------------------------------------------------------------- #
+
+def test_both_providers_expose_provider_tag():
+    dg = flux.DeepgramFluxSTT("dg-key")
+    ck = ink.CartesiaInkSTT("ck-key")
+    assert dg.provider == "deepgram_flux"
+    assert ck.provider == "cartesia_ink"
+
+
+def test_both_providers_satisfy_the_port_surface():
+    dg = flux.DeepgramFluxSTT("dg-key")
+    ck = ink.CartesiaInkSTT("ck-key")
+    for obj in (dg, ck):
+        for attr in ("start", "send_audio", "events", "configure", "stop"):
+            assert callable(getattr(obj, attr))
+        assert isinstance(obj.asr_seconds_est, float)
+        assert isinstance(obj.provider, str)
+        # runtime_checkable Protocol: both adapters are STT instances.
+        assert isinstance(obj, stt_port.STT)
+
+
+def test_ev_constants_reexported_from_flux():
+    # Existing `from deepgram_flux_stt import EV_*` imports must keep working
+    # even though the canonical home moved to stt.py.
+    assert flux.EV_START == stt_port.EV_START == "start_of_turn"
+    assert flux.EV_RESUMED == stt_port.EV_RESUMED == "turn_resumed"
+    assert flux.EV_END == stt_port.EV_END == "end_of_turn"
+
+
+def test_make_stt_defaults_to_flux(monkeypatch):
+    monkeypatch.setenv("DEEPGRAM_API_KEY", "dg")
+    stt = stt_port.make_stt("deepgram_flux", input_rate=24000, extra={})
+    assert stt.provider == "deepgram_flux"
+
+
+def test_make_stt_builds_cartesia_ink(monkeypatch):
+    monkeypatch.setenv("CARTESIA_API_KEY", "ck")
+    stt = stt_port.make_stt("cartesia_ink", input_rate=24000, extra={})
+    assert stt.provider == "cartesia_ink"
+
+
+def test_make_stt_passes_flux_thresholds(monkeypatch):
+    monkeypatch.setenv("DEEPGRAM_API_KEY", "dg")
+    stt = stt_port.make_stt(
+        "deepgram_flux", input_rate=24000,
+        extra={"eot_threshold": "0.8", "eager_eot_threshold": "0.4"})
+    assert stt._eot_threshold == 0.8
+    assert stt._eager_eot_threshold == 0.4
+
+
+def test_make_stt_unknown_provider_raises(monkeypatch):
+    monkeypatch.setenv("DEEPGRAM_API_KEY", "dg")
+    with pytest.raises(RuntimeError, match="unknown stt_provider"):
+        stt_port.make_stt("whisper-x", input_rate=24000, extra={})
+
+
+def test_make_stt_missing_key_raises_clear(monkeypatch):
+    monkeypatch.delenv("CARTESIA_API_KEY", raising=False)
+    with pytest.raises(RuntimeError, match="CARTESIA_API_KEY is not set"):
+        stt_port.make_stt("cartesia_ink", input_rate=24000, extra={})
+
+
+@pytest.mark.asyncio
+async def test_ink_configure_is_noop():
+    ck = ink.CartesiaInkSTT("ck-key")
+    # No socket open; must not raise, and must do nothing harmful.
+    await ck.configure(eot_threshold=0.9)
+    await ck.configure()

--- a/tests/hermes_cli/test_config_validation.py
+++ b/tests/hermes_cli/test_config_validation.py
@@ -205,3 +205,40 @@ class TestConfigIssueDataclass:
         a = ConfigIssue("error", "msg", "hint")
         b = ConfigIssue("error", "msg", "hint")
         assert a == b
+
+
+class TestVoiceModelValidation:
+    """voice_model should be a top-level dict with provider + model
+    (the dedicated model slot for the voice modality)."""
+
+    def test_missing_provider(self):
+        issues = validate_config_structure({
+            "voice_model": {"model": "meta-llama/llama-4-scout-17b-16e-instruct"},
+        })
+        assert any("voice_model is missing 'provider'" in i.message for i in issues)
+
+    def test_missing_model(self):
+        issues = validate_config_structure({
+            "voice_model": {"provider": "groq"},
+        })
+        assert any("voice_model is missing 'model'" in i.message for i in issues)
+
+    def test_wrong_type_is_error(self):
+        issues = validate_config_structure({"voice_model": "groq/some-model"})
+        assert any(
+            i.severity == "error" and "voice_model should be a dict" in i.message
+            for i in issues)
+
+    def test_valid_voice_model(self):
+        issues = validate_config_structure({
+            "voice_model": {
+                "provider": "groq",
+                "model": "meta-llama/llama-4-scout-17b-16e-instruct",
+            },
+        })
+        vm_issues = [i for i in issues if "voice_model" in i.message]
+        assert vm_issues == []
+
+    def test_absent_voice_model_is_fine(self):
+        issues = validate_config_structure({"model": ""})
+        assert [i for i in issues if "voice_model" in i.message] == []

--- a/uv.lock
+++ b/uv.lock
@@ -761,6 +761,17 @@ wheels = [
 ]
 
 [[package]]
+name = "daily-python"
+version = "0.29.1"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e4/bb/cb99be4a63cd826d6de9f5feb399edb809b6240285204f4f727ad3fb0907/daily_python-0.29.1-cp37-abi3-macosx_10_15_x86_64.whl", hash = "sha256:96dd5cf04a786e00e47cdb15fe0e1ccbe29c3ff7bdca1a9d0566aaab950d9727", size = 13362191, upload-time = "2026-06-09T22:14:35.277Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/f1/5fe6c1adf502938da5164c5895734cdbc48fecb1c715b0df99e9155e1dbd/daily_python-0.29.1-cp37-abi3-macosx_11_0_arm64.whl", hash = "sha256:998940878c4a4539aa5588f2132debb474f3feee9afe04beda9bb03f225998e9", size = 11888238, upload-time = "2026-06-09T22:14:37.554Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/10/e02d145a272e56e8023782b74d6108680fcf09ae2e07cdc09ff5f44eaa1f/daily_python-0.29.1-cp37-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:e43265f6ec8b4b9e672b868eb0e9fead7b262f33173f3c08e8d4de4d55e7b3da", size = 13957031, upload-time = "2026-06-09T22:14:39.519Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/b8/5c360f0d1e28db8acdb3f01a03134d1a5b98966c0f78dfca6748efcae5e3/daily_python-0.29.1-cp37-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:7edac330712b6d4e3600fd31af7f6f0d180ab7dcad823b962039a6d9bbf5446f", size = 14493172, upload-time = "2026-06-09T22:14:41.313Z" },
+]
+
+[[package]]
 name = "darabonba-core"
 version = "1.0.5"
 source = { registry = "https://pypi.org/simple" }
@@ -1598,6 +1609,10 @@ voice = [
     { name = "numpy" },
     { name = "sounddevice" },
 ]
+voice-platform = [
+    { name = "daily-python" },
+    { name = "websockets" },
+]
 web = [
     { name = "fastapi" },
     { name = "starlette" },
@@ -1628,6 +1643,7 @@ requires-dist = [
     { name = "brotlicffi", marker = "extra == 'messaging'", specifier = "==1.2.0.1" },
     { name = "certifi", specifier = "==2026.5.20" },
     { name = "croniter", specifier = "==6.0.0" },
+    { name = "daily-python", marker = "extra == 'voice-platform'", specifier = "==0.29.1" },
     { name = "daytona", marker = "extra == 'daytona'", specifier = "==0.155.0" },
     { name = "debugpy", marker = "extra == 'dev'", specifier = "==1.8.20" },
     { name = "defusedxml", marker = "extra == 'wecom'", specifier = "==0.7.1" },
@@ -1723,9 +1739,10 @@ requires-dist = [
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.24.0,<1" },
     { name = "uvicorn", extras = ["standard"], marker = "extra == 'web'", specifier = "==0.41.0" },
     { name = "websockets", specifier = "==15.0.1" },
+    { name = "websockets", marker = "extra == 'voice-platform'", specifier = "==15.0.1" },
     { name = "youtube-transcript-api", marker = "extra == 'youtube'", specifier = "==1.2.4" },
 ]
-provides-extras = ["anthropic", "exa", "firecrawl", "parallel-web", "fal", "edge-tts", "modal", "daytona", "hindsight", "dev", "messaging", "cron", "slack", "matrix", "wecom", "cli", "tts-premium", "voice", "pty", "honcho", "vision", "mcp", "nemo-relay", "homeassistant", "sms", "teams", "computer-use", "acp", "mistral", "bedrock", "azure-identity", "termux", "termux-all", "dingtalk", "feishu", "google", "youtube", "web", "all"]
+provides-extras = ["anthropic", "exa", "firecrawl", "parallel-web", "fal", "edge-tts", "modal", "daytona", "hindsight", "dev", "messaging", "cron", "slack", "matrix", "wecom", "cli", "tts-premium", "voice", "voice-platform", "pty", "honcho", "vision", "mcp", "nemo-relay", "homeassistant", "sms", "teams", "computer-use", "acp", "mistral", "bedrock", "azure-identity", "termux", "termux-all", "dingtalk", "feishu", "google", "youtube", "web", "all"]
 
 [[package]]
 name = "hf-xet"

--- a/website/docs/user-guide/messaging/voice.md
+++ b/website/docs/user-guide/messaging/voice.md
@@ -1,0 +1,92 @@
+---
+title: "Voice"
+description: "Call your Hermes Agent over WebRTC — real-time, full-duplex voice"
+---
+
+# Voice Platform
+
+The voice platform turns your agent into something you can **call**. It joins a
+[Daily](https://daily.co) (WebRTC) room as a participant, listens with
+[Deepgram Flux](https://developers.deepgram.com/docs/flux) (streaming
+speech-to-text with model-integrated turn detection), thinks with your agent,
+and speaks back with [Cartesia](https://cartesia.ai) (streaming text-to-speech)
+— all in real time, with **in-process barge-in**: interrupting the agent cancels
+its actual generation, not just the audio.
+
+Unlike an external voice orchestrator that wraps the model as a black box, this
+loop runs *inside* the agent session — so a barge-in stops the LLM mid-thought,
+and voice shares the same agent, tools, and memory as every other channel.
+
+## What you need
+
+Install the optional dependencies:
+
+```bash
+uv sync --extra voice-platform   # daily-python + websockets
+```
+
+Set four keys in your `.env` (all three services have free tiers):
+
+| Key | Service | Used for |
+| --- | --- | --- |
+| `DAILY_API_KEY` | [Daily](https://dashboard.daily.co) | WebRTC transport (the agent mints its own room) |
+| `DEEPGRAM_API_KEY` | [Deepgram](https://console.deepgram.com) | Flux streaming STT + turn detection |
+| `CARTESIA_API_KEY` | [Cartesia](https://play.cartesia.ai) | streaming TTS |
+| a voice model key | your provider | generation (see `voice_model:` below) |
+
+## A faster model for voice (optional)
+
+Real-time voice is latency-critical, so you can point voice turns at a fast,
+non-reasoning model while your main model stays whatever you normally use. Add a
+top-level `voice_model:` block to `config.yaml` — a sibling to `model:` and
+`fallback_model:`:
+
+```yaml
+voice_model:
+  provider: groq
+  model: meta-llama/llama-4-scout-17b-16e-instruct
+```
+
+Leave it out (or set `provider: auto`) and voice rides your main model.
+
+## Configuration
+
+The plugin works with no extra config. To tune it, add a `platforms.voice.extra`
+block to `config.yaml`:
+
+```yaml
+platforms:
+  voice:
+    extra:
+      cartesia_voice_id: ""        # Cartesia voice id (or set CARTESIA_VOICE_ID)
+      cartesia_model: sonic-3.5
+      eot_threshold: 0.7           # Flux end-of-turn confidence (higher = waits longer)
+      eager_eot_threshold: 0.5     # Flux eager/speculative end-of-turn
+      allow_interruptions: true    # barge-in when the caller starts speaking
+      tts_speed: ""                # optional Cartesia speed (e.g. 1.0)
+      greeting_prompt: ""          # optional: how the agent opens the call
+```
+
+## Making a call
+
+With the keys set and the plugin enabled, start the gateway. The agent creates
+its own private Daily room, joins it, and **prints the join URL on startup** —
+watch the gateway output for:
+
+```
+voice: standalone call ready — open this URL to talk to your agent (keep the token private):
+    https://<you>.daily.co/<room>?t=<token>
+```
+
+Open that URL in a browser, allow the microphone, and talk. The room is private,
+so the URL carries a short-lived owner **token** — that token is the join
+permission, so share the URL only with people you want to reach your agent. The
+room is short-lived (~1 hour), and the agent ends the call automatically when the
+caller leaves, the room expires, or a maximum-duration cap is reached.
+
+## Notes
+
+- One active call per agent process (the WebRTC virtual audio devices are
+  process-level singletons).
+- Per-call cost telemetry (STT seconds, timing legs) is written to
+  `voice-telemetry.jsonl` on the agent's data volume.


### PR DESCRIPTION
Implements real-time WebRTC voice as a Hermes gateway **platform plugin** — peer to `plugins/platforms/telegram`, running **in-process with the agent session**, not as an external orchestrator. Addresses #35750 (Option C); posted there first per the discuss-before-PR convention.

## Why in-process
For one audio stream the loop is thin (STT in → flush on end-of-turn → stream tokens out through TTS → cancel on barge-in). What matters is *where* it lives:
- **Barge-in cancels generation.** Interrupting calls `agent.interrupt()` and stops the LLM mid-generation — not just muting audio. External harnesses (Pipecat / LiveKit Agents / Vapi) run the loop outside the agent and treat it as an LLM endpoint, so the model keeps generating server-side, out of sync with what was actually heard.
- **Tool-aware speech.** The loop sees the agent's tool events, so it can say "one sec, checking" while a tool runs instead of going silent.
- **Native channel, not a separate client.** Same agent, memory, and session whether you text it or call it.

No Pipecat/LiveKit dependency — one audio stream doesn't need an SFU or SIP routing on day one, and a dependency that size has to earn its place. Transports are adapters around the one loop, so a heavier transport can slot in later without touching it.

## Stack
- **Transport:** Daily (`daily-python`, BSD-2) — inexpensive, reliable WebRTC; per-device sample rates mean no resampling.
- **STT + turn-taking:** **Deepgram Flux** (shipping default). One fused model does transcription *and* conversation-native turn detection, emitting start / eager-end / resumed / end-of-turn events the loop reacts to directly — replacing a separate VAD, endpoint model, speculative-start, and energy barge-in.
- **TTS:** Cartesia, over one persistent socket per call (a fresh connect is ~0.6–1.4s; reuse keeps per-turn latency at synthesis time).

These are what's worked best after building a fair amount of voice; the model side stays swappable (below) so you're not locked to one provider.

## Pluggable STT (port + adapters)
STT is a small **port** (`stt.py`): a provider emits the normalized turn events the loop consumes. **Deepgram Flux is the default**; a **Cartesia Ink-2** adapter is included as a second, live-verified implementation, selected via `platforms.voice.extra.stt_provider`. The default stays opinionated — the seam just keeps it provider-flexible and ships a tested alternative. (I A/B'd the two live and they're basically dead even on turn-taking and latency, so the default is a wash either way.)

## `voice_model:` slot (maintainer input wanted)
A top-level `voice_model:` block, sibling to `model:` and `fallback_model:`. Real-time voice is latency-critical and you usually don't want a (possibly reasoning) main model answering a call, so this points voice turns at a fast model while the main model is unchanged. Unset / `auto` falls back to the main model, resolving through the same provider surface (mirrors `_try_resolve_fallback_provider`). I think a dedicated top-level slot is right — voice is a full agentic turn in a different modality, and `fallback_model` sets the sibling-slot precedent — but it touches core, so **I'd want a maintainer's read on whether it belongs at the top level or elsewhere.**

## Scope
A small first cut: browser-only WebRTC, no telephony/SIP yet. No frontend in the Hermes client — standalone mode creates its own private Daily room and prints the join URL on startup (the token in the URL is the join permission), which you open in a browser. Bare-bones, but it works today.

## Follow-ups (order open for discussion)
- A keyless, fully self-hosted harness (Pipecat SmallWebRTC or a raw aiortc peer + local STT/TTS → a no-API-key stack).
- SIP/PSTN trunking — the phone-like experience from the issue.

Opening as **draft** for maintainer review, especially on the `voice_model:` placement.
