### PR TITLE
FGD-199: add clean Agent Floor live-pulse backend

### DIFF
--- a/gateway/live_pulse.py
+++ b/gateway/live_pulse.py
@@ -1,0 +1,255 @@
+"""Non-secret Hermes gateway live pulse for Mission Control / Agent Floor.
+
+This module exports metadata only: counts, redacted session identity, state,
+elapsed time, model/provider labels, and process counts. It never writes chat
+content, user prompts, tool output, command text, logs, credentials, raw
+session keys, or approval payloads.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Callable, Mapping
+
+try:
+    from hermes_cli.config import get_hermes_home
+except Exception:  # pragma: no cover - defensive fallback for isolated imports
+    def get_hermes_home() -> Path:  # type: ignore[no-redef]
+        return Path.home() / ".hermes"
+
+
+PULSE_PATH = get_hermes_home() / "tools" / "agent_floor" / "hermes_live_pulse.json"
+HEARTBEAT_INTERVAL_SECONDS = 30
+INTERRUPTION_SIGNALS = {
+    "safe_to_message",
+    "caution_active_workflow",
+    "do_not_interrupt",
+    "unknown",
+}
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def _hash_session_key(session_key: str) -> str:
+    if not session_key:
+        return ""
+    return hashlib.sha256(session_key.encode("utf-8", errors="replace")).hexdigest()[:16]
+
+
+def _safe_str(value: Any, max_len: int = 96) -> str:
+    text = "" if value is None else str(value)
+    text = " ".join(text.split())
+    if len(text) <= max_len:
+        return text
+    return text[: max(0, max_len - 1)] + "…"
+
+
+def _agent_activity(agent: Any) -> dict[str, Any]:
+    if not agent or not hasattr(agent, "get_activity_summary"):
+        return {}
+    try:
+        activity = agent.get_activity_summary() or {}
+    except Exception:
+        return {}
+    current_tool = activity.get("current_tool")
+    current_phase = activity.get("last_activity_desc") or current_tool or "running"
+    return {
+        "current_phase": _safe_str(current_phase),
+        "current_tool": _safe_str(current_tool, 64) if current_tool else None,
+        "api_call_count": activity.get("api_call_count"),
+        "max_iterations": activity.get("max_iterations"),
+        "seconds_since_activity": activity.get("seconds_since_activity"),
+    }
+
+
+def _pending_approval_counts(pending_approvals: Mapping[str, Any] | None) -> dict[str, int]:
+    counts: dict[str, int] = {}
+    if not pending_approvals:
+        return counts
+    for session_key, approval in pending_approvals.items():
+        if not session_key:
+            continue
+        if isinstance(approval, (list, tuple, set)):
+            counts[str(session_key)] = len(approval)
+        elif isinstance(approval, Mapping) and approval.get("items") and isinstance(approval.get("items"), list):
+            counts[str(session_key)] = len(approval.get("items") or [])
+        else:
+            counts[str(session_key)] = 1
+    return counts
+
+
+def classify_background_process(proc: Mapping[str, Any]) -> tuple[str, bool, str]:
+    """Classify process-registry rows without exposing command text.
+
+    Only session-linked or non-default task-linked running processes are treated
+    as interrupt-sensitive. Unscoped long-lived helpers stay visible but do not
+    pin Agent Floor to caution forever.
+    """
+    has_session_key = bool(proc.get("has_session_key"))
+    task_id = _safe_str(proc.get("task_id"), 64) if proc.get("task_id") else ""
+    has_meaningful_task_id = bool(task_id and task_id != "default")
+    detached = bool(proc.get("detached"))
+    uptime = int(proc.get("uptime_seconds") or 0)
+
+    if detached:
+        return "detached_or_recovered_process", False, "detached recovered process; visible warning only"
+    if not has_meaningful_task_id and uptime >= 300:
+        return "default_long_lived_helper", False, "default/unscoped helper older than five minutes; not interrupt-sensitive"
+    if has_session_key or has_meaningful_task_id:
+        return "active_background_work", True, "linked to an active Hermes session or non-default task"
+    return "unscoped_recent_background_process", False, "unscoped recent process; visible warning only"
+
+
+def _process_rows() -> list[dict[str, Any]]:
+    try:
+        from tools.process_registry import process_registry
+
+        rows: list[dict[str, Any]] = []
+        for proc in process_registry.list_sessions():
+            if proc.get("status") != "running":
+                continue
+            classification, interrupt_sensitive, reason = classify_background_process(proc)
+            task_id = _safe_str(proc.get("task_id"), 64) if proc.get("task_id") else None
+            rows.append(
+                {
+                    "process_id": _safe_str(proc.get("session_id"), 48),
+                    "state": "background_running",
+                    "classification": classification,
+                    "interrupt_sensitive": interrupt_sensitive,
+                    "classification_reason": reason,
+                    "elapsed_seconds": int(proc.get("uptime_seconds") or 0),
+                    "session_linked": bool(proc.get("has_session_key")),
+                    "task_id": task_id,
+                    "pid_scope": _safe_str(proc.get("pid_scope"), 24) if proc.get("pid_scope") else None,
+                    "detached": bool(proc.get("detached")),
+                }
+            )
+        return rows
+    except Exception:
+        return []
+
+
+def build_live_pulse(
+    *,
+    running_agents: Mapping[str, Any] | None = None,
+    running_started: Mapping[str, float] | None = None,
+    pending_sentinel: Any = None,
+    background_tasks: set[Any] | None = None,
+    pending_approvals: Mapping[str, Any] | None = None,
+    session_platform_resolver: Callable[[str], str] | None = None,
+) -> dict[str, Any]:
+    now = time.time()
+    running_agents = running_agents or {}
+    running_started = running_started or {}
+    approval_counts = _pending_approval_counts(pending_approvals)
+    pending_approval_total = sum(int(v or 0) for v in approval_counts.values())
+
+    sessions: list[dict[str, Any]] = []
+    active_agent_turns = 0
+    starting_turns = 0
+
+    for session_key, agent in running_agents.items():
+        session_key = str(session_key)
+        started = float(running_started.get(session_key, now) or now)
+        is_starting = agent is pending_sentinel
+        pending_count = int(approval_counts.get(session_key, 0) or 0)
+        if is_starting:
+            starting_turns += 1
+            state = "starting"
+            risk = "caution_active_workflow"
+        elif pending_count:
+            active_agent_turns += 1
+            state = "waiting_human_approval"
+            risk = "safe_to_message"
+        else:
+            active_agent_turns += 1
+            state = "running"
+            risk = "caution_active_workflow"
+
+        platform = "unknown"
+        if session_platform_resolver:
+            try:
+                platform = _safe_str(session_platform_resolver(session_key), 32) or "unknown"
+            except Exception:
+                platform = "unknown"
+
+        row = {
+            "session_key_hash": _hash_session_key(session_key),
+            "session_id": "" if is_starting else _safe_str(getattr(agent, "session_id", ""), 64),
+            "platform": platform,
+            "state": state,
+            "elapsed_seconds": max(0, int(now - started)),
+            "model": "" if is_starting else _safe_str(getattr(agent, "model", ""), 96),
+            "provider": "" if is_starting else _safe_str(getattr(agent, "provider", ""), 64),
+            "current_phase": "starting" if is_starting else "running",
+            "current_tool": None,
+            "pending_approval_count": pending_count,
+            "interruption_risk": risk,
+        }
+        if not is_starting:
+            row.update(_agent_activity(agent))
+        sessions.append(row)
+
+    running_processes = _process_rows()
+    interrupt_sensitive_process_count = len([p for p in running_processes if p.get("interrupt_sensitive")])
+    helper_process_count = len(running_processes) - interrupt_sensitive_process_count
+    async_job_count = len([t for t in (background_tasks or set()) if hasattr(t, "done") and not t.done()])
+
+    if any(row.get("interruption_risk") == "do_not_interrupt" for row in sessions):
+        signal = "do_not_interrupt"
+        reason = "A live Hermes session reports do-not-interrupt risk."
+    elif active_agent_turns or starting_turns or interrupt_sensitive_process_count or async_job_count:
+        signal = "caution_active_workflow"
+        reason = "Hermes gateway reports active turn/startup/background activity."
+    elif pending_approval_total:
+        signal = "safe_to_message"
+        reason = "Hermes is waiting on human approval; messaging is unlikely to interrupt active execution."
+    elif helper_process_count:
+        signal = "safe_to_message"
+        reason = "Fresh gateway pulse shows no active turns or interrupt-sensitive background work; non-interrupting background helper present."
+    else:
+        signal = "safe_to_message"
+        reason = "Fresh gateway pulse shows no active turns, approvals, async jobs, or background processes."
+
+    return {
+        "schema_version": "hermes-live-pulse-v1",
+        "generated_at": _now_iso(),
+        "profile": os.getenv("HERMES_PROFILE") or "jimmy",
+        "gateway": {"running": True, "pid": os.getpid()},
+        "summary": {
+            "active_agent_turns": active_agent_turns,
+            "starting_turns": starting_turns,
+            "pending_approval_count": pending_approval_total,
+            "running_background_process_count": interrupt_sensitive_process_count,
+            "background_process_total_count": len(running_processes),
+            "background_helper_process_count": helper_process_count,
+            "async_job_count": async_job_count,
+            "interruption_signal": signal,
+            "interruption_reason": reason,
+        },
+        "sessions": sessions,
+        "running_background_processes": running_processes,
+        "source_limits": [
+            "No chat content included",
+            "No raw user prompt included",
+            "No raw tool output included",
+            "No sensitive command text included",
+            "No approval payload included",
+            "No logs, databases, caches, browser profiles, tokens, or credentials inspected",
+        ],
+    }
+
+
+def write_live_pulse(**kwargs: Any) -> dict[str, Any]:
+    pulse = build_live_pulse(**kwargs)
+    PULSE_PATH.parent.mkdir(parents=True, exist_ok=True)
+    tmp = PULSE_PATH.with_suffix(".json.tmp")
+    tmp.write_text(json.dumps(pulse, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+    tmp.replace(PULSE_PATH)
+    return pulse

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2355,6 +2355,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
         # Track background tasks to prevent garbage collection mid-execution
         self._background_tasks: set = set()
+        # Agent Floor live-pulse heartbeat is observability-only and is not
+        # counted in _background_tasks, otherwise the heartbeat would make the
+        # gateway look perpetually busy.
+        self._agent_floor_live_pulse_heartbeat_task: Optional[asyncio.Task] = None
 
 
     def _wire_teams_pipeline_runtime(self) -> None:
@@ -3116,6 +3120,54 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
     def _running_agent_count(self) -> int:
         return len(self._running_agents)
+
+    def _write_agent_floor_live_pulse(self) -> None:
+        """Best-effort non-secret live pulse for Mission Control / Agent Floor."""
+        try:
+            from gateway.live_pulse import write_live_pulse
+
+            write_live_pulse(
+                running_agents=getattr(self, "_running_agents", {}) or {},
+                running_started=getattr(self, "_running_agents_ts", {}) or {},
+                pending_sentinel=_AGENT_PENDING_SENTINEL,
+                background_tasks=getattr(self, "_background_tasks", set()) or set(),
+                pending_approvals=getattr(self, "_pending_approvals", {}) or {},
+                session_platform_resolver=lambda key: key.split(":", 1)[0] if key else "unknown",
+            )
+        except Exception:
+            logger.debug("Failed to write Agent Floor live pulse", exc_info=True)
+
+    async def _agent_floor_live_pulse_heartbeat(self) -> None:
+        """Keep Agent Floor's non-secret live pulse fresh while gateway runs."""
+        try:
+            from gateway.live_pulse import HEARTBEAT_INTERVAL_SECONDS
+        except Exception:
+            HEARTBEAT_INTERVAL_SECONDS = 30
+
+        while self._running:
+            self._write_agent_floor_live_pulse()
+            try:
+                await asyncio.sleep(HEARTBEAT_INTERVAL_SECONDS)
+            except asyncio.CancelledError:
+                raise
+            except Exception:
+                await asyncio.sleep(30)
+
+    def _start_agent_floor_live_pulse_heartbeat(self) -> None:
+        task = getattr(self, "_agent_floor_live_pulse_heartbeat_task", None)
+        if task is not None and not task.done():
+            return
+        task = asyncio.create_task(self._agent_floor_live_pulse_heartbeat())
+        self._agent_floor_live_pulse_heartbeat_task = task
+        task.add_done_callback(
+            lambda done: setattr(self, "_agent_floor_live_pulse_heartbeat_task", None)
+        )
+
+    def _stop_agent_floor_live_pulse_heartbeat(self) -> None:
+        task = getattr(self, "_agent_floor_live_pulse_heartbeat_task", None)
+        if task is not None and not task.done():
+            task.cancel()
+        self._agent_floor_live_pulse_heartbeat_task = None
 
     def _status_action_label(self) -> str:
         return "restart" if self._restart_requested else "shutdown"
@@ -5242,6 +5294,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
         self._running = True
         self._update_runtime_status("running")
+        self._start_agent_floor_live_pulse_heartbeat()
         
         # Emit gateway:startup hook
         hook_count = len(self.hooks.loaded_hooks)
@@ -6182,6 +6235,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     continue
                 _task.cancel()
             self._background_tasks.clear()
+            self._stop_agent_floor_live_pulse_heartbeat()
 
             self.adapters.clear()
             for _session_key in list(self._running_agents):
@@ -12671,6 +12725,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         self._running_agents_ts.pop(session_key, None)
         if hasattr(self, "_busy_ack_ts"):
             self._busy_ack_ts.pop(session_key, None)
+        self._write_agent_floor_live_pulse()
         return True
 
     def _clear_session_boundary_security_state(self, session_key: str) -> None:
@@ -15172,6 +15227,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 )
                 return
             self._running_agents[session_key] = agent_holder[0]
+            self._write_agent_floor_live_pulse()
             if self._draining:
                 self._update_runtime_status("draining")
         

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -544,6 +544,20 @@ class GatewaySlashCommandsMixin:
             if hasattr(t, "done") and not t.done()
         ]
 
+        try:
+            from gateway.live_pulse import write_live_pulse
+
+            write_live_pulse(
+                running_agents=running_agents,
+                running_started=running_started,
+                pending_sentinel=_AGENT_PENDING_SENTINEL,
+                background_tasks=set(background_tasks),
+                pending_approvals=getattr(self, "_pending_approvals", {}) or {},
+                session_platform_resolver=lambda key: key.split(":", 1)[0] if key else "unknown",
+            )
+        except Exception:
+            logger.debug("Failed to write Agent Floor live pulse from /agents", exc_info=True)
+
         lines = [
             t("gateway.agents.header"),
             "",

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -1284,6 +1284,7 @@ class ProcessRegistry:
             all_sessions = list(self._running.values()) + list(self._finished.values())
 
         all_sessions = [self._refresh_detached_session(s) for s in all_sessions]
+        all_sessions = [s for s in all_sessions if s is not None]
 
         if task_id:
             all_sessions = [s for s in all_sessions if s.task_id == task_id]
@@ -1299,6 +1300,13 @@ class ProcessRegistry:
                 "uptime_seconds": int(time.time() - s.started_at),
                 "status": "exited" if s.exited else "running",
                 "output_preview": s.output_buffer[-200:] if s.output_buffer else "",
+                # Non-secret lifecycle metadata used by observability surfaces.
+                # Do not expose raw session_key here; callers that need identity
+                # should use the boolean linkage signal only or derive their own
+                # redacted/hash value from in-memory state they already own.
+                "task_id": s.task_id,
+                "has_session_key": bool(s.session_key),
+                "pid_scope": s.pid_scope,
             }
             if s.exited:
                 entry["exit_code"] = s.exit_code


### PR DESCRIPTION
Issue: FGD-199

Clean replacement for PR #46322.

Commit SHA: 0cdf37a9e006ef2e596ffe933ae1e76b858fd920

Summary:
- Adds a non-secret Agent Floor / Mission Control live-pulse backend writer.
- Publishes active gateway/session pulse metadata without chat content, prompts, raw tool output, command text, logs, credentials, tokens, raw session keys, or approval payloads.
- Wires best-effort gateway heartbeat refresh, active-session pulse refresh, /agents pulse refresh, and additive process metadata for non-secret classification.

Files changed:
- gateway/live_pulse.py
- gateway/run.py
- gateway/slash_commands.py
- tools/process_registry.py

Validation results:
- python3 -m py_compile gateway/live_pulse.py gateway/run.py gateway/slash_commands.py tools/process_registry.py: passed
- uv run pytest tests/gateway/test_status_command.py::test_agents_command_reports_active_agents_and_processes tests/gateway/test_status_command.py::test_tasks_alias_routes_to_agents_command tests/tools/test_process_registry.py -q: 71 passed
- uv run python live-pulse smoke validation: passed
- git diff --check origin/main: passed
- forbidden-risky-removal scan: no matches

Safety / exclusions:
- tools/approval.py is not touched.
- Approval guard removals are excluded.
- Process completion-event behavior is preserved.
- Gateway replay/interruption/cache behavior removals are excluded.
- /credits removal is excluded.
- No deploy, restart, smoke test, or merge is included.