### PR TITLE
fix(anthropic): OAuth login token exchange falls back to platform.claude.com (console 404)

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -1251,7 +1251,10 @@ def run_oauth_setup_token() -> Optional[str]:
 # Stores credentials in ~/.hermes/.anthropic_oauth.json (our own file).
 
 _OAUTH_CLIENT_ID = "9d1c250a-e61b-44d9-88ed-5944d1962f5e"
-_OAUTH_TOKEN_URL = "https://console.anthropic.com/v1/oauth/token"
+_OAUTH_TOKEN_URLS = [
+    "https://platform.claude.com/v1/oauth/token",
+    "https://console.anthropic.com/v1/oauth/token",
+]
 _OAUTH_REDIRECT_URI = "https://console.anthropic.com/oauth/code/callback"
 _OAUTH_SCOPES = "org:create_api_key user:profile user:inference"
 _HERMES_OAUTH_FILE = get_hermes_home() / ".anthropic_oauth.json"
@@ -1349,18 +1352,26 @@ def run_hermes_oauth_login_pure() -> Optional[Dict[str, Any]]:
             "code_verifier": verifier,
         }).encode()
 
-        req = urllib.request.Request(
-            _OAUTH_TOKEN_URL,
-            data=exchange_data,
-            headers={
-                "Content-Type": "application/json",
-                "User-Agent": f"claude-cli/{_get_claude_code_version()} (external, cli)",
-            },
-            method="POST",
-        )
+        last_error = None
+        for endpoint in _OAUTH_TOKEN_URLS:
+            req = urllib.request.Request(
+                endpoint,
+                data=exchange_data,
+                headers={
+                    "Content-Type": "application/json",
+                    "User-Agent": f"claude-cli/{_get_claude_code_version()} (external, cli)",
+                },
+                method="POST",
+            )
 
-        with urllib.request.urlopen(req, timeout=15) as resp:
-            result = json.loads(resp.read().decode())
+            try:
+                with urllib.request.urlopen(req, timeout=15) as resp:
+                    result = json.loads(resp.read().decode())
+                break
+            except Exception as exc:
+                last_error = exc
+        else:
+            raise last_error or RuntimeError("OAuth token exchange failed")
     except Exception as e:
         print(f"Token exchange failed: {e}")
         return None


### PR DESCRIPTION
## Problem

The interactive Hermes OAuth login flow (`run_hermes_oauth_login_pure()`) hard-codes a single token-exchange endpoint:

```python
_OAUTH_TOKEN_URL = "https://console.anthropic.com/v1/oauth/token"
```

That endpoint now returns **HTTP 404 Not Found**, so `hermes auth add anthropic --type oauth` fails the PKCE code exchange with `Token exchange failed: HTTP Error 404: Not Found`. Because each attempt consumes the user's one-time PKCE challenge, every failure forces another full browser authorize round-trip — there is no way to complete a subscription OAuth login on current builds.

## Root cause

The **refresh** path in the same file already migrated to the new endpoint and tries both with a fallback loop:

```python
# refresh (already correct)
_TOKEN_URLS = [
    "https://platform.claude.com/v1/oauth/token",
    "https://console.anthropic.com/v1/oauth/token",
]
```

Only the **login** path was left on the stale console-only constant. This is the same bug class, just an un-migrated sibling call site.

## Fix

Symmetrize login with refresh: introduce `_OAUTH_TOKEN_URLS` (platform primary, console fallback) and loop the exchange over both, breaking on first success and re-raising the last error if all fail. No behavior change when the primary endpoint works; restores login when console 404s.

## Verification

```
./venv/bin/python -c "import agent.anthropic_adapter as a; print(a._OAUTH_TOKEN_URLS)"
# ['https://platform.claude.com/v1/oauth/token', 'https://console.anthropic.com/v1/oauth/token']

hermes auth add anthropic --type oauth --label claude-max-sub   # completes; cred lands in pool
hermes auth list                                                # #1 oauth ← active, api_key #2 fallback
```

Tested live against a Claude Max subscription: login now completes on the platform endpoint and the pooled OAuth credential takes precedence over the API key.
