### PR TITLE
fix(stt/tts): guard against null config subsections crashing with AttributeError

### DIFF
--- a/tools/transcription_tools.py
+++ b/tools/transcription_tools.py
@@ -1129,7 +1129,7 @@ def _transcribe_local(file_path: str, model_name: str) -> Dict[str, Any]:
 
         # Language: config.yaml (stt.local.language) > env var > auto-detect.
         _forced_lang = (
-            _load_stt_config().get("local", {}).get("language")
+            (_load_stt_config().get("local", {}) or {}).get("language")
             or os.getenv(LOCAL_STT_LANGUAGE_ENV)
             or None
         )
@@ -1212,7 +1212,7 @@ def _transcribe_local_command(file_path: str, model_name: str) -> Dict[str, Any]
 
     # Language: config.yaml (stt.local.language) > env var > "en" default.
     language = (
-        _load_stt_config().get("local", {}).get("language")
+        (_load_stt_config().get("local", {}) or {}).get("language")
         or os.getenv(LOCAL_STT_LANGUAGE_ENV)
         or DEFAULT_LOCAL_STT_LANGUAGE
     )
@@ -1541,7 +1541,7 @@ def _transcribe_elevenlabs(file_path: str, model_name: str) -> Dict[str, Any]:
         return {"success": False, "transcript": "", "error": "ELEVENLABS_API_KEY not set"}
 
     stt_config = _load_stt_config()
-    elevenlabs_config = stt_config.get("elevenlabs", {})
+    elevenlabs_config = stt_config.get("elevenlabs", {}) or {}
     base_url = str(
         elevenlabs_config.get("base_url")
         or get_env_value("ELEVENLABS_STT_BASE_URL")
@@ -1656,14 +1656,14 @@ def transcribe_audio(file_path: str, model: Optional[str] = None) -> Dict[str, A
     provider = _get_provider(stt_config)
 
     if provider == "local":
-        local_cfg = stt_config.get("local", {})
+        local_cfg = stt_config.get("local", {}) or {}
         model_name = _normalize_local_model(
             model or local_cfg.get("model", DEFAULT_LOCAL_MODEL)
         )
         return _transcribe_local(file_path, model_name)
 
     if provider == "local_command":
-        local_cfg = stt_config.get("local", {})
+        local_cfg = stt_config.get("local", {}) or {}
         model_name = _normalize_local_command_model(
             model or local_cfg.get("model", DEFAULT_LOCAL_MODEL)
         )
@@ -1674,12 +1674,12 @@ def transcribe_audio(file_path: str, model: Optional[str] = None) -> Dict[str, A
         return _transcribe_groq(file_path, model_name)
 
     if provider == "openai":
-        openai_cfg = stt_config.get("openai", {})
+        openai_cfg = stt_config.get("openai", {}) or {}
         model_name = model or openai_cfg.get("model", DEFAULT_STT_MODEL)
         return _transcribe_openai(file_path, model_name)
 
     if provider == "mistral":
-        mistral_cfg = stt_config.get("mistral", {})
+        mistral_cfg = stt_config.get("mistral", {}) or {}
         model_name = model or mistral_cfg.get("model", DEFAULT_MISTRAL_STT_MODEL)
         return _transcribe_mistral(file_path, model_name)
 
@@ -1689,7 +1689,7 @@ def transcribe_audio(file_path: str, model: Optional[str] = None) -> Dict[str, A
         return _transcribe_xai(file_path, model_name)
 
     if provider == "elevenlabs":
-        elevenlabs_cfg = stt_config.get("elevenlabs", {})
+        elevenlabs_cfg = stt_config.get("elevenlabs", {}) or {}
         model_name = model or elevenlabs_cfg.get("model_id", DEFAULT_ELEVENLABS_STT_MODEL)
         return _transcribe_elevenlabs(file_path, model_name)
 
@@ -1753,7 +1753,7 @@ def transcribe_audio(file_path: str, model: Optional[str] = None) -> Dict[str, A
 def _resolve_openai_audio_client_config() -> tuple[str, str]:
     """Return direct OpenAI audio config or a managed gateway fallback."""
     stt_config = _load_stt_config()
-    openai_cfg = stt_config.get("openai", {})
+    openai_cfg = stt_config.get("openai", {}) or {}
     cfg_api_key = openai_cfg.get("api_key", "")
     cfg_base_url = openai_cfg.get("base_url", "")
     if cfg_api_key:

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -935,7 +935,7 @@ async def _generate_edge_tts(text: str, output_path: str, tts_config: Dict[str, 
         Path to the saved audio file.
     """
     _edge_tts = _import_edge_tts()
-    edge_config = tts_config.get("edge", {})
+    edge_config = tts_config.get("edge", {}) or {}
     voice = edge_config.get("voice", DEFAULT_EDGE_VOICE)
     speed = float(edge_config.get("speed", tts_config.get("speed", 1.0)))
 


### PR DESCRIPTION
## Description

Fixes #47318

When `stt.local` or `tts.edge` is explicitly set to `null` in `config.yaml` (which happens by default on a fresh `--voice` setup), `stt_config.get("local", {})` returns `None` instead of `{}` because YAML preserves the key with a null value. The subsequent chained `.get("model")` call crashes with `AttributeError: "NoneType" object has no attribute "get"`.

## Fix

Apply the defensive `(x or {})` pattern to every config subsection access via `.get("xxx", {})` in `tools/transcription_tools.py` and `tools/tts_tool.py`. This covers:

- `local` (STT, both `_transcribe_local` and `_transcribe_local_command` call paths)
- `edge` (TTS)
- `openai` (STT, both inline and `_resolve_openai_audio_client_config`)
- `mistral` (STT)
- `elevenlabs` (STT, both inline and `_transcribe_elevenlabs`)

## Testing

Reproduced the crash by setting `stt.local: null` in config.yaml. With the fix, the code falls back to an empty dict and uses defaults.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)