### PR TITLE
fix(config): restore env keys removed during update

### DIFF
--- a/hermes_cli/backup.py
+++ b/hermes_cli/backup.py
@@ -11,6 +11,7 @@ HERMES_HOME root.
 import json
 import logging
 import os
+import re
 import shutil
 import sqlite3
 import sys
@@ -691,6 +692,8 @@ def restore_quick_snapshot(
 # Relative path of the cron job database inside HERMES_HOME. Kept in sync with
 # the entry in ``_QUICK_STATE_FILES`` and with ``cron/jobs.py``'s ``JOBS_FILE``.
 _CRON_JOBS_REL = "cron/jobs.json"
+_ENV_FILE_REL = ".env"
+_ENV_ASSIGNMENT_RE = re.compile(r"^\s*(?:export\s+)?([A-Za-z_][A-Za-z0-9_]*)\s*=")
 
 
 def _count_cron_jobs(path: Path) -> Optional[int]:
@@ -785,6 +788,111 @@ def restore_cron_jobs_if_emptied(
         snapshot_id,
     )
     return {"restored": True, "job_count": snap_count, "snapshot_id": snapshot_id}
+
+
+def _read_env_key_lines(path: Path) -> Optional[Dict[str, str]]:
+    """Return the first assignment line for each env key in ``path``.
+
+    ``None`` means the file could not be read and callers should avoid acting.
+    Comments, blank lines, and malformed lines are ignored. The line text is
+    preserved verbatim except for the trailing newline so recovery can append
+    the user's original value without reformatting or expanding secrets.
+    """
+    if not path.exists():
+        return {}
+    if not path.is_file():
+        return None
+    try:
+        lines = path.read_text(encoding="utf-8").splitlines()
+    except (OSError, UnicodeDecodeError):
+        return None
+
+    key_lines: Dict[str, str] = {}
+    for line in lines:
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        match = _ENV_ASSIGNMENT_RE.match(line)
+        if not match:
+            continue
+        key = match.group(1)
+        key_lines.setdefault(key, line)
+    return key_lines
+
+
+def restore_env_keys_if_removed(
+    snapshot_id: str,
+    hermes_home: Optional[Path] = None,
+) -> Optional[Dict[str, Any]]:
+    """Restore env assignments that disappeared during ``hermes update``.
+
+    Issue #26804 showed update/config-migration paths can drop user-owned
+    ``.env`` keys while leaving a valid but incomplete file. The pre-update
+    quick snapshot already captures ``.env``; this safety net compares key
+    presence after migration and appends any assignments that existed before
+    the update but are now missing. Existing live keys always win, so rotated
+    or intentionally changed values are not overwritten.
+
+    Returns:
+        ``None`` when no action was taken. On restore, returns
+        ``{"restored": True, "key_count": N, "keys": [...], "snapshot_id": ...}``.
+    """
+    if not snapshot_id:
+        return None
+
+    home = hermes_home or get_hermes_home()
+    live_path = home / _ENV_FILE_REL
+    snap_path = _quick_snapshot_root(home) / snapshot_id / _ENV_FILE_REL
+
+    snapshot_keys = _read_env_key_lines(snap_path)
+    if not snapshot_keys:
+        return None
+
+    live_keys = _read_env_key_lines(live_path)
+    if live_keys is None:
+        return None
+
+    missing_keys = [key for key in snapshot_keys if key not in live_keys]
+    if not missing_keys:
+        return None
+
+    try:
+        live_text = live_path.read_text(encoding="utf-8") if live_path.exists() else ""
+    except (OSError, UnicodeDecodeError):
+        return None
+
+    additions = [snapshot_keys[key] for key in missing_keys]
+    updated_text = live_text
+    if updated_text and not updated_text.endswith("\n"):
+        updated_text += "\n"
+    updated_text += "\n".join(additions) + "\n"
+
+    try:
+        live_path.parent.mkdir(parents=True, exist_ok=True)
+        live_path.write_text(updated_text, encoding="utf-8")
+        try:
+            live_path.chmod(0o600)
+        except OSError:
+            pass
+    except (OSError, PermissionError) as exc:
+        logger.error(
+            ".env keys were removed during update but auto-restore failed: %s",
+            exc,
+        )
+        return None
+
+    logger.warning(
+        "Restored %d .env key(s) from pre-update snapshot %s: %s",
+        len(missing_keys),
+        snapshot_id,
+        ", ".join(missing_keys),
+    )
+    return {
+        "restored": True,
+        "key_count": len(missing_keys),
+        "keys": missing_keys,
+        "snapshot_id": snapshot_id,
+    }
 
 
 def _prune_quick_snapshots(root: Path, keep: int = _QUICK_DEFAULT_KEEP) -> int:

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -9156,7 +9156,10 @@ def _cmd_update_impl(args, gateway_mode: bool):
         # job (issue #34600). If the live file is now empty while the
         # pre-update snapshot held jobs, restore it and warn loudly.
         try:
-            from hermes_cli.backup import restore_cron_jobs_if_emptied
+            from hermes_cli.backup import (
+                restore_cron_jobs_if_emptied,
+                restore_env_keys_if_removed,
+            )
 
             cron_restore = restore_cron_jobs_if_emptied(pre_update_snapshot_id)
             if cron_restore:
@@ -9166,9 +9169,23 @@ def _cmd_update_impl(args, gateway_mode: bool):
                     f"restored {cron_restore['job_count']} job(s) from "
                     f"pre-update snapshot {cron_restore['snapshot_id']}."
                 )
+            env_restore = restore_env_keys_if_removed(pre_update_snapshot_id)
+            if env_restore:
+                restored_keys = env_restore.get("keys") or []
+                shown = ", ".join(restored_keys[:8])
+                if len(restored_keys) > 8:
+                    shown += f", … and {len(restored_keys) - 8} more"
+                print()
+                print(
+                    "  ⚠️  .env lost "
+                    f"{env_restore['key_count']} key(s) during this update — "
+                    f"restored from pre-update snapshot {env_restore['snapshot_id']}."
+                )
+                if shown:
+                    print(f"     Restored keys: {shown}")
         except Exception as exc:
-            # Never let the cron safety net break an otherwise-good update.
-            logger.debug("Cron jobs auto-restore check failed: %s", exc)
+            # Never let the config/state safety nets break an otherwise-good update.
+            logger.debug("Post-update config/state auto-restore check failed: %s", exc)
 
         print()
         print("✓ Update complete!")

--- a/tests/hermes_cli/test_backup.py
+++ b/tests/hermes_cli/test_backup.py
@@ -1888,3 +1888,76 @@ class TestRestoreCronJobsIfEmptied:
         result = restore_cron_jobs_if_emptied(snap_id, hermes_home=hermes_home)
         assert result is not None
         assert result["job_count"] == 2
+
+
+# ---------------------------------------------------------------------------
+# .env auto-restore after update/config migration loss (issue #26804)
+# ---------------------------------------------------------------------------
+
+class TestRestoreEnvKeysIfRemoved:
+    """`hermes update` snapshots `.env` before migration. If the migration
+    drops user-owned keys, the post-update safety net should merge them back
+    from the pre-update snapshot while keeping current/live values authoritative
+    for keys that still exist."""
+
+    def _make_snapshot(self, hermes_home: Path, label="pre-update"):
+        from hermes_cli.backup import create_quick_snapshot
+        return create_quick_snapshot(label=label, hermes_home=hermes_home, keep=5)
+
+    def test_restores_missing_user_env_keys_from_pre_update_snapshot(self, tmp_path):
+        from hermes_cli.backup import restore_env_keys_if_removed
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        env_path = hermes_home / ".env"
+        env_path.write_text(
+            "OPENROUTER_API_KEY=sk-live\n"
+            "TELEGRAM_BOT_TOKEN=12345:abc\n"
+            "DEEPSEEK_API_KEY=ds-old\n",
+            encoding="utf-8",
+        )
+        snap_id = self._make_snapshot(hermes_home)
+        assert snap_id
+
+        # Simulate a post-update template rewrite that kept only a known key.
+        env_path.write_text("OPENROUTER_API_KEY=sk-rotated\n", encoding="utf-8")
+
+        result = restore_env_keys_if_removed(snap_id, hermes_home=hermes_home)
+
+        assert result is not None
+        assert result["restored"] is True
+        assert result["key_count"] == 2
+        assert result["keys"] == ["TELEGRAM_BOT_TOKEN", "DEEPSEEK_API_KEY"]
+        assert result["snapshot_id"] == snap_id
+
+        saved = env_path.read_text(encoding="utf-8")
+        assert "OPENROUTER_API_KEY=sk-rotated" in saved
+        assert "TELEGRAM_BOT_TOKEN=12345:abc" in saved
+        assert "DEEPSEEK_API_KEY=ds-old" in saved
+        assert "OPENROUTER_API_KEY=sk-live" not in saved
+
+    def test_noop_when_live_env_still_has_snapshot_keys(self, tmp_path):
+        from hermes_cli.backup import restore_env_keys_if_removed
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        env_path = hermes_home / ".env"
+        env_path.write_text(
+            "OPENROUTER_API_KEY=sk-live\n"
+            "TELEGRAM_BOT_TOKEN=12345:abc\n",
+            encoding="utf-8",
+        )
+        snap_id = self._make_snapshot(hermes_home)
+
+        assert restore_env_keys_if_removed(snap_id, hermes_home=hermes_home) is None
+        assert env_path.read_text(encoding="utf-8") == (
+            "OPENROUTER_API_KEY=sk-live\n"
+            "TELEGRAM_BOT_TOKEN=12345:abc\n"
+        )
+
+    def test_noop_without_pre_update_snapshot(self, tmp_path):
+        from hermes_cli.backup import restore_env_keys_if_removed
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        (hermes_home / ".env").write_text("OPENROUTER_API_KEY=sk-live\n", encoding="utf-8")
+
+        assert restore_env_keys_if_removed(None, hermes_home=hermes_home) is None
+        assert restore_env_keys_if_removed("", hermes_home=hermes_home) is None


### PR DESCRIPTION
## What changed

Adds a post-update safety net for `.env` loss during `hermes update` / config migration.

`hermes update` already creates a pre-update quick snapshot of critical state. This PR uses that snapshot after migration to detect when `.env` assignments were removed and merges only the missing keys back into the live `.env`.

Existing live values remain authoritative. If a key survived the update, the snapshot copy is not used, so rotated or intentionally changed values are not overwritten.

## Why

Issue #26804 reported update-time loss of user-owned `.env` keys. PR #26807 addresses one sanitizer-specific path. This PR adds the broader recovery layer requested in the issue discussion: when update/config migration still leaves `.env` valid but missing keys, Hermes restores the missing assignments automatically from the pre-update snapshot and prints a concise summary of restored key names.

## Behavior

- Compares pre-update snapshot `.env` with the live `.env` after config migration.
- Appends assignments that existed before the update and are missing afterward.
- Keeps existing live values first, so current values win for shared keys.
- Leaves unreadable/malformed non-file `.env` states untouched instead of masking a different corruption mode.
- Keeps the existing cron job auto-restore safety net intact.

## Validation

```bash
uv run pytest tests/hermes_cli/test_backup.py::TestRestoreEnvKeysIfRemoved tests/hermes_cli/test_backup.py::TestRestoreCronJobsIfEmptied -q
# 9 passed

scripts/run_tests.sh tests/hermes_cli/test_backup.py
# 113 tests passed

scripts/run_tests.sh tests/hermes_cli/test_config.py tests/hermes_cli/test_env_sanitize_on_load.py
# 103 tests passed

uv run python -m py_compile hermes_cli/backup.py hermes_cli/main.py

uv run ruff check hermes_cli/backup.py hermes_cli/main.py tests/hermes_cli/test_backup.py
# All checks passed
```

Related: #26804
