### PR TITLE
fix: remove logging.basicConfig() from library __init__ methods

### DIFF
--- a/mini_swe_runner.py
+++ b/mini_swe_runner.py
@@ -195,11 +195,6 @@ class MiniSWERunner:
         self.cwd = cwd
         
         # Setup logging
-        logging.basicConfig(
-            level=logging.DEBUG if verbose else logging.INFO,
-            format='%(asctime)s - %(levelname)s - %(message)s',
-            datefmt='%H:%M:%S'
-        )
         self.logger = logging.getLogger(__name__)
         
         # Initialize LLM client via centralized provider router.

--- a/trajectory_compressor.py
+++ b/trajectory_compressor.py
@@ -352,11 +352,6 @@ class TrajectoryCompressor:
         # Initialize OpenRouter client
         self._init_summarizer()
         
-        logging.basicConfig(
-            level=logging.INFO,
-            format='%(asctime)s - %(levelname)s - %(message)s',
-            datefmt='%H:%M:%S'
-        )
         self.logger = logging.getLogger(__name__)
     
     def _init_tokenizer(self):


### PR DESCRIPTION
## Bug

`logging.basicConfig()` in `trajectory_compressor.py` and `mini_swe_runner.py` hijacks the root logger when these classes are instantiated before the main app configures logging. This overrides the host application's logging setup (format, level, handlers).

`basicConfig()` is a no-op after the first call, but the ordering dependency makes it fragile. Entry points (`cli.py`, `gateway`) are responsible for root logger configuration.

## Fix

Remove `logging.basicConfig()` calls from both `__init__` methods, keeping only `self.logger = logging.getLogger(__name__)`.

**Files changed:** 2
**Lines removed:** 10

## Verification

```bash
python3 -m py_compile trajectory_compressor.py
python3 -m py_compile mini_swe_runner.py
```

Both files compile successfully.