### PR TITLE
fix: guard float(env var) casts in platform adapters against ValueError

### DIFF
--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -433,7 +433,10 @@ class TelegramAdapter(BasePlatformAdapter):
         self._rich_draft_disabled: bool = False
         # Buffer rapid/album photo updates so Telegram image bursts are handled
         # as a single MessageEvent instead of self-interrupting multiple turns.
-        self._media_batch_delay_seconds = float(os.getenv("HERMES_TELEGRAM_MEDIA_BATCH_DELAY_SECONDS", "0.8"))
+        self._media_batch_delay_seconds = self._env_float_clamped(
+            "HERMES_TELEGRAM_MEDIA_BATCH_DELAY_SECONDS", 0.8,
+            min_value=0.08, max_value=5.0,
+        )
         self._pending_photo_batches: Dict[str, MessageEvent] = {}
         self._pending_photo_batch_tasks: Dict[str, asyncio.Task] = {}
         self._media_group_events: Dict[str, MessageEvent] = {}

--- a/gateway/platforms/wecom.py
+++ b/gateway/platforms/wecom.py
@@ -186,8 +186,14 @@ class WeComAdapter(BasePlatformAdapter):
 
         # Text batching: merge rapid successive messages (Telegram-style).
         # WeCom clients split long messages around 4000 chars.
-        self._text_batch_delay_seconds = float(os.getenv("HERMES_WECOM_TEXT_BATCH_DELAY_SECONDS", "0.6"))
-        self._text_batch_split_delay_seconds = float(os.getenv("HERMES_WECOM_TEXT_BATCH_SPLIT_DELAY_SECONDS", "2.0"))
+        try:
+            self._text_batch_delay_seconds = float(os.getenv("HERMES_WECOM_TEXT_BATCH_DELAY_SECONDS", "0.6"))
+        except (ValueError, TypeError):
+            self._text_batch_delay_seconds = 0.6
+        try:
+            self._text_batch_split_delay_seconds = float(os.getenv("HERMES_WECOM_TEXT_BATCH_SPLIT_DELAY_SECONDS", "2.0"))
+        except (ValueError, TypeError):
+            self._text_batch_split_delay_seconds = 2.0
         self._pending_text_batches: Dict[str, MessageEvent] = {}
         self._pending_text_batch_tasks: Dict[str, asyncio.Task] = {}
         self._device_id = uuid.uuid4().hex

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -634,8 +634,14 @@ class DiscordAdapter(BasePlatformAdapter):
         self._voice_clients: Dict[int, Any] = {}  # guild_id -> VoiceClient
         self._voice_locks: Dict[int, asyncio.Lock] = {}  # guild_id -> serialize join/leave
         # Text batching: merge rapid successive messages (Telegram-style)
-        self._text_batch_delay_seconds = float(os.getenv("HERMES_DISCORD_TEXT_BATCH_DELAY_SECONDS", "0.6"))
-        self._text_batch_split_delay_seconds = float(os.getenv("HERMES_DISCORD_TEXT_BATCH_SPLIT_DELAY_SECONDS", "2.0"))
+        try:
+            self._text_batch_delay_seconds = float(os.getenv("HERMES_DISCORD_TEXT_BATCH_DELAY_SECONDS", "0.6"))
+        except (ValueError, TypeError):
+            self._text_batch_delay_seconds = 0.6
+        try:
+            self._text_batch_split_delay_seconds = float(os.getenv("HERMES_DISCORD_TEXT_BATCH_SPLIT_DELAY_SECONDS", "2.0"))
+        except (ValueError, TypeError):
+            self._text_batch_split_delay_seconds = 2.0
         self._pending_text_batches: Dict[str, MessageEvent] = {}
         self._pending_text_batch_tasks: Dict[str, asyncio.Task] = {}
         self._voice_text_channels: Dict[int, int] = {}  # guild_id -> text_channel_id


### PR DESCRIPTION
## Bug

Bare `float(os.getenv(...))` calls in platform adapter `__init__` methods crash the gateway when an env var contains a non-numeric string (e.g. a typo like `abc` instead of `0.6`). A single bad env var value takes down the entire gateway with an unhandled `ValueError`.

**Affected env vars:**
- `HERMES_DISCORD_TEXT_BATCH_DELAY_SECONDS` (discord/adapter.py:637)
- `HERMES_DISCORD_TEXT_BATCH_SPLIT_DELAY_SECONDS` (discord/adapter.py:638)
- `HERMES_TELEGRAM_MEDIA_BATCH_DELAY_SECONDS` (telegram.py:436)
- `HERMES_WECOM_TEXT_BATCH_DELAY_SECONDS` (wecom.py:189)
- `HERMES_WECOM_TEXT_BATCH_SPLIT_DELAY_SECONDS` (wecom.py:190)

## Fix

- **telegram.py**: Reused existing `_env_float_clamped` helper (already handles ValueError/TypeError)
- **discord/adapter.py** and **wecom.py**: Added inline `try/except (ValueError, TypeError)` with fallback to default values

This matches the defensive pattern already used throughout the codebase (e.g. `_safe_float_env` in `chat_completion_helpers.py`, `_env_float_clamped` in `telegram.py`).

**Files changed:** 3
**Lines added:** 20, **Lines removed:** 5

## Verification

```bash
python3 -m py_compile gateway/platforms/telegram.py
python3 -m py_compile plugins/platforms/discord/adapter.py
python3 -m py_compile gateway/platforms/wecom.py
```

All three files compile successfully.