### PR TITLE
fix: parenthesize or-expressions before slice truncation

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -726,7 +726,7 @@ def create_job(
     label_source = (prompt_text or (normalized_skills[0] if normalized_skills else None) or (normalized_script if normalized_no_agent else None)) or "cron job"
     job = {
         "id": job_id,
-        "name": name or label_source[:50].strip(),
+        "name": (name or label_source)[:50].strip(),
         "prompt": prompt_text,
         "skills": normalized_skills,
         "skill": normalized_skills[0] if normalized_skills else None,

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -1564,7 +1564,7 @@ class GatewaySlashCommandsMixin:
             lines.append(t("gateway.personality.none_option"))
             for name, prompt in personalities.items():
                 if isinstance(prompt, dict):
-                    preview = prompt.get("description") or prompt.get("system_prompt", "")[:50]
+                    preview = (prompt.get("description") or prompt.get("system_prompt", ""))[:50]
                 else:
                     preview = prompt[:50] + "..." if len(prompt) > 50 else prompt
                 lines.append(t("gateway.personality.item", name=name, preview=preview))

--- a/hermes_cli/cli_commands_mixin.py
+++ b/hermes_cli/cli_commands_mixin.py
@@ -1031,7 +1031,7 @@ class CLICommandsMixin:
             print(f"  {'none':<12} - (no personality overlay)")
             for name, prompt in self.personalities.items():
                 if isinstance(prompt, dict):
-                    preview = prompt.get("description") or prompt.get("system_prompt", "")[:50]
+                    preview = (prompt.get("description") or prompt.get("system_prompt", ""))[:50]
                 else:
                     preview = str(prompt)[:50]
                 print(f"  {name:<12} - {preview}")

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -1737,7 +1737,7 @@ class SlashCommandCompleter(Completer):
             for name, prompt in personalities.items():
                 if name.startswith(sub_lower) and name != sub_lower:
                     if isinstance(prompt, dict):
-                        meta = prompt.get("description") or prompt.get("system_prompt", "")[:50]
+                        meta = (prompt.get("description") or prompt.get("system_prompt", ""))[:50]
                     else:
                         meta = str(prompt)[:50]
                     yield Completion(

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -429,7 +429,7 @@ def _format_job(job: Dict[str, Any]) -> Dict[str, Any]:
     prompt = str(job.get("prompt") or "")
     skills = _canonical_skills(job.get("skill"), job.get("skills"))
     job_id = str(job.get("id") or "unknown")
-    name = str(job.get("name") or prompt[:50] or (skills[0] if skills else "") or job_id or "cron job")
+    name = str((job.get("name") or prompt or (skills[0] if skills else "") or job_id or "cron job")[:50])
     result = {
         "job_id": job_id,
         "name": name,


### PR DESCRIPTION
## Bug

Python's `[:N]` (slice) binds tighter than `or`. In expressions like `x or y[:50]`, only `y` is truncated — a long `x` passes through unbounded, breaking display layouts.

This is the same class of bug fixed in PRs #20050 and #32347, but 5 locations were missed.

## Affected locations

| File | Line | Impact |
|------|------|--------|
| `tools/cronjob_tools.py` | 432 | Long custom job names display untruncated in job list |
| `cron/jobs.py` | 729 | Long names stored untruncated in cron DB |
| `hermes_cli/cli_commands_mixin.py` | 1034 | Long personality description overflows `/personality` list |
| `hermes_cli/commands.py` | 1740 | Same overflow in autocomplete |
| `gateway/slash_commands.py` | 1567 | Same overflow in gateway `/personality` |

## Fix

Parenthesize so truncation applies to the resolved value:
```python
# Before (only y truncated):
name = x or y[:50]
# After (resolved value truncated):
name = (x or y)[:50]
```

**Files changed:** 5
**Lines changed:** 5 (one per location)