### PR TITLE
fix: custom_providers models cleared by dedup in build_models_payload

### DIFF
--- a/hermes_cli/inventory.py
+++ b/hermes_cli/inventory.py
@@ -179,6 +179,14 @@ def build_models_payload(
         if user_models:
             for row in rows:
                 slug = row.get("slug", "")
+                # Skip user-defined providers — their models should never be
+                # filtered by this dedup (they ARE the de-duplication target,
+                # not the subject). Without this guard, custom_providers
+                # entries that is_aggregator considers aggregators (like any
+                # custom:* gateway) get ALL their models removed because every
+                # model ID they serve is also in user_models.
+                if row.get("is_user_defined"):
+                    continue
                 if not _is_aggregator(slug):
                     continue
                 original = row.get("models") or []


### PR DESCRIPTION
build_models_payload() collects all model IDs from user-defined providers into user_models set, then filters them out of rows where is_aggregator() returns True. Since is_aggregator() returns True for all custom:* slugs, every custom_providers entry has its model list filtered to zero because every model it serves is also in user_models.

Skip user-defined rows in the dedup loop — they are the de-duplication target, not the subject. Built-in aggregators (like OpenRouter) are still filtered, while custom_providers entries retain their discovered models.