### PR TITLE
fix(gateway): queue media attachments in steer mode

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -5546,8 +5546,16 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         steered = False
         if effective_mode == "steer":
             steer_text = (event.text or "").strip()
+            has_media = bool(getattr(event, "media_urls", None))
+            if has_media:
+                # ``AIAgent.steer()`` is text-only.  Steering a document/photo
+                # event would inject the caption while discarding cached media
+                # paths on the MessageEvent.  Queue the full event instead so
+                # the normal dequeue path preserves attachment metadata.
+                effective_mode = "queue"
             can_steer = (
-                steer_text
+                effective_mode == "steer"
+                and steer_text
                 and running_agent is not None
                 and running_agent is not _AGENT_PENDING_SENTINEL
                 and hasattr(running_agent, "steer")

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -9677,6 +9677,20 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 self._queue_or_replace_pending_event(_quick_key, event)
                 return None
             if self._busy_input_mode == "steer":
+                # ``AIAgent.steer()`` is text-only.  A media-bearing event
+                # (e.g. a cached PDF/document/audio clip) would inject its
+                # caption while discarding the cached media paths on the
+                # MessageEvent.  Queue the full event instead so the normal
+                # dequeue path preserves attachment metadata.  PHOTO bursts
+                # are already queued above, so this catches documents/audio/
+                # video that would otherwise reach steer().
+                if bool(getattr(event, "media_urls", None)):
+                    logger.debug(
+                        "PRIORITY steer demoted to queue for media event, session %s",
+                        _quick_key,
+                    )
+                    self._queue_or_replace_pending_event(_quick_key, event)
+                    return None
                 # Steer mode: inject text into the running agent mid-run via
                 # agent.steer().  Falls back to queue semantics if the payload
                 # is empty, the agent lacks steer(), or steer() rejects.

--- a/tests/gateway/test_busy_session_ack.py
+++ b/tests/gateway/test_busy_session_ack.py
@@ -393,6 +393,44 @@ class TestBusySessionAck:
         adapter._send_with_retry.assert_not_called()
 
     @pytest.mark.asyncio
+    async def test_steer_mode_queues_media_events_to_preserve_attachments(self):
+        """Media-bearing events must queue because agent.steer() is text-only.
+
+        The queue path routes through _queue_or_replace_pending_event (the FIFO
+        infrastructure), so assert on the observable outcome: the full event —
+        with its media_urls/media_types intact — lands in the pending slot and
+        agent.steer() is never called.
+        """
+        runner, sentinel = _make_runner()
+        runner._busy_input_mode = "steer"
+        adapter = _make_adapter()
+
+        event = _make_event(text="please read this pdf")
+        event.message_type = MessageType.DOCUMENT
+        event.media_urls = ["/tmp/cached.pdf"]
+        event.media_types = ["application/pdf"]
+        sk = build_session_key(event.source)
+        runner.adapters[event.source.platform] = adapter
+
+        agent = MagicMock()
+        agent.steer = MagicMock(return_value=True)
+        runner._running_agents[sk] = agent
+
+        await runner._handle_active_session_busy_message(event, sk)
+
+        agent.steer.assert_not_called()
+        agent.interrupt.assert_not_called()
+        # Full event queued with attachment metadata intact.
+        assert adapter._pending_messages[sk] is event
+        assert adapter._pending_messages[sk].media_urls == ["/tmp/cached.pdf"]
+        assert adapter._pending_messages[sk].media_types == ["application/pdf"]
+
+        call_kwargs = adapter._send_with_retry.call_args
+        content = call_kwargs.kwargs.get("content") or call_kwargs[1].get("content", "")
+        assert "Queued for the next turn" in content
+        assert "Steered" not in content
+
+    @pytest.mark.asyncio
     async def test_steer_mode_falls_back_to_queue_when_agent_rejects(self):
         """If agent.steer() returns False, fall back to queue behavior."""
         runner, sentinel = _make_runner()

--- a/tests/gateway/test_busy_session_ack.py
+++ b/tests/gateway/test_busy_session_ack.py
@@ -431,6 +431,41 @@ class TestBusySessionAck:
         assert "Steered" not in content
 
     @pytest.mark.asyncio
+    async def test_priority_steer_queues_media_events_to_preserve_attachments(self):
+        """PRIORITY steer path (_handle_message) must queue media-bearing events.
+
+        The independent PRIORITY steer branch also calls agent.steer(), which is
+        text-only, so a document/audio event would lose its cached media paths
+        unless it queues the full event instead of steering.
+        """
+        from gateway.run import GatewayRunner
+
+        runner, _sentinel = _make_runner()
+        runner._busy_input_mode = "steer"
+        adapter = _make_adapter()
+
+        event = _make_event(text="please read this pdf")
+        event.message_type = MessageType.DOCUMENT
+        event.media_urls = ["/tmp/cached.pdf"]
+        event.media_types = ["application/pdf"]
+        sk = build_session_key(event.source)
+        runner.adapters[event.source.platform] = adapter
+
+        agent = MagicMock()
+        agent.steer = MagicMock(return_value=True)
+        runner._running_agents[sk] = agent
+
+        result = await GatewayRunner._handle_message(runner, event)
+
+        assert result is None
+        agent.steer.assert_not_called()
+        agent.interrupt.assert_not_called()
+        # Full event queued with attachment metadata intact.
+        assert adapter._pending_messages[sk] is event
+        assert adapter._pending_messages[sk].media_urls == ["/tmp/cached.pdf"]
+        assert adapter._pending_messages[sk].media_types == ["application/pdf"]
+
+    @pytest.mark.asyncio
     async def test_steer_mode_falls_back_to_queue_when_agent_rejects(self):
         """If agent.steer() returns False, fall back to queue behavior."""
         runner, sentinel = _make_runner()


### PR DESCRIPTION
## What
- Queue media-bearing busy-session messages instead of routing them through text-only steer mode.
- Preserve the full MessageEvent for PDFs/documents/images/audio so cached attachment metadata survives to the normal next-turn processing path.
- Add a regression test covering steer mode with a document attachment.

## Why
When gateway busy input mode is set to steer, incoming messages were passed to AIAgent.steer(event.text). That API only accepts text, so a Discord message with a cached PDF/document attachment could be acknowledged as steered while silently dropping event.media_urls/event.media_types.

## How to test
- python scripts/check-windows-footguns.py --diff main
- scripts/run_tests.sh tests/gateway/test_busy_session_ack.py

## Platforms tested
- Linux

## Manual testing
- Discord live E2E not run; behavior is covered by the targeted regression test.