### PR TITLE
fix(agent): keep OpenRouter provider fallback on cooldown

### DIFF
--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -691,6 +691,7 @@ def classify_api_error(
 
     classified = _classify_by_message(
         error_msg, error_type,
+        provider=provider_lower,
         approx_tokens=approx_tokens,
         context_length=context_length,
         result_fn=_result,
@@ -1145,6 +1146,7 @@ def _classify_by_message(
     error_msg: str,
     error_type: str,
     *,
+    provider: str = "",
     approx_tokens: int,
     context_length: int,
     result_fn,
@@ -1257,6 +1259,20 @@ def _classify_by_message(
     # model response.
     if any(p in error_msg for p in _TIMEOUT_MESSAGE_PATTERNS):
         return result_fn(FailoverReason.timeout, retryable=True)
+
+    # OpenRouter sometimes wraps upstream provider failures as a status-less
+    # generic "Provider returned error". Specific inner messages from
+    # metadata.raw are appended to error_msg earlier and win above; when only
+    # the generic wrapper remains, treat it like a transient provider-side
+    # rate limit so fallback cooldown keeps the next turn off the failing
+    # primary path.
+    if provider == "openrouter" and "provider returned error" in error_msg:
+        return result_fn(
+            FailoverReason.rate_limit,
+            retryable=True,
+            should_rotate_credential=True,
+            should_fallback=True,
+        )
 
     return None
 

--- a/tests/agent/test_error_classifier.py
+++ b/tests/agent/test_error_classifier.py
@@ -1326,6 +1326,19 @@ class TestAdversarialEdgeCases:
         result = classify_api_error(e, provider="openrouter")
         assert result.reason == FailoverReason.rate_limit
 
+    def test_openrouter_provider_returned_error_without_status_is_rate_limit(self):
+        e = MockAPIError("Provider returned error")
+        result = classify_api_error(e, provider="openrouter")
+        assert result.reason == FailoverReason.rate_limit
+        assert result.retryable is True
+        assert result.should_rotate_credential is True
+        assert result.should_fallback is True
+
+    def test_generic_provider_returned_error_without_openrouter_stays_unknown(self):
+        e = MockAPIError("Provider returned error")
+        result = classify_api_error(e, provider="custom")
+        assert result.reason == FailoverReason.unknown
+
     def test_thinking_signature_via_openrouter(self):
         """Thinking signature errors proxied through OpenRouter must be caught."""
         e = MockAPIError(


### PR DESCRIPTION
## What does this PR do?

Classifies OpenRouter's status-less generic `Provider returned error` wrapper as a rate-limit style failover when no more specific inner provider message is available.

This fixes a fallback stickiness bug: the conversation loop already sets `_rate_limited_until` for `FailoverReason.rate_limit`, so the next turn stays on the fallback provider instead of immediately restoring the failing OpenRouter primary.

The matcher is intentionally narrow:

- it only applies when `provider="openrouter"`;
- it runs after more specific message patterns, so `metadata.raw` context overflow, model-not-found, auth, timeout, billing, and explicit rate-limit messages keep their existing classifications;
- non-OpenRouter generic `Provider returned error` messages still classify as `unknown`.

## Related Issue

Fixes #46856

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/error_classifier.py`: passes provider context into message classification and maps OpenRouter's generic status-less wrapper to `FailoverReason.rate_limit` only after more specific patterns fail.
- `tests/agent/test_error_classifier.py`: adds regression coverage for the OpenRouter wrapper and a guard that the same phrase from another provider remains `unknown`.

## How to Test

1. `uv sync --frozen --extra dev`
2. `uv run scripts/run_tests.sh tests/agent/test_error_classifier.py -- --tb=long`
3. `uv run scripts/run_tests.sh tests/run_agent/test_primary_runtime_restore.py -- -k cooldown --tb=long`
4. `uv run ruff check agent/error_classifier.py tests/agent/test_error_classifier.py`

Observed locally on macOS:

- `tests/agent/test_error_classifier.py`: 163 passed.
- `tests/run_agent/test_primary_runtime_restore.py -k cooldown`: 4 passed.
- Ruff passed for the touched files.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS, Python 3.11 via uv

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — no platform-specific code changed
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

Targeted test output:

```text
Discovered 1 test files (163 tests) under ['tests/agent/test_error_classifier.py']; running with -j 24
[100.0% |   163/163 | ✓163 | ✗  0] ✓ tests/agent/test_error_classifier.py (163✓, 4.6s)

Discovered 1 test files (4 tests) under ['tests/run_agent/test_primary_runtime_restore.py']; running with -j 24
[100.0% |     4/4 | ✓4 | ✗0] ✓ tests/run_agent/test_primary_runtime_restore.py (4✓, 17.9s)
```
