### PR TITLE
fix: guard STT/TTS config reads against YAML null values

### DIFF
--- a/tools/transcription_tools.py
+++ b/tools/transcription_tools.py
@@ -121,7 +121,7 @@ def _load_stt_config() -> dict:
     """Load the ``stt`` section from user config, falling back to defaults."""
     try:
         from hermes_cli.config import load_config
-        return load_config().get("stt", {})
+        return load_config().get("stt") or {}
     except Exception:
         return {}
 
@@ -1129,7 +1129,7 @@ def _transcribe_local(file_path: str, model_name: str) -> Dict[str, Any]:
 
         # Language: config.yaml (stt.local.language) > env var > auto-detect.
         _forced_lang = (
-            _load_stt_config().get("local", {}).get("language")
+            (_load_stt_config().get("local") or {}).get("language")
             or os.getenv(LOCAL_STT_LANGUAGE_ENV)
             or None
         )
@@ -1212,7 +1212,7 @@ def _transcribe_local_command(file_path: str, model_name: str) -> Dict[str, Any]
 
     # Language: config.yaml (stt.local.language) > env var > "en" default.
     language = (
-        _load_stt_config().get("local", {}).get("language")
+        (_load_stt_config().get("local") or {}).get("language")
         or os.getenv(LOCAL_STT_LANGUAGE_ENV)
         or DEFAULT_LOCAL_STT_LANGUAGE
     )
@@ -1446,7 +1446,7 @@ def _transcribe_xai(file_path: str, model_name: str) -> Dict[str, Any]:
         }
 
     stt_config = _load_stt_config()
-    xai_config = stt_config.get("xai", {})
+    xai_config = stt_config.get("xai") or {}
     base_url = str(
         xai_config.get("base_url")
         or get_env_value("XAI_STT_BASE_URL")
@@ -1493,7 +1493,7 @@ def _transcribe_xai(file_path: str, model_name: str) -> Dict[str, Any]:
             detail = ""
             try:
                 err_body = response.json()
-                detail = err_body.get("error", {}).get("message", "") or response.text[:300]
+                detail = (err_body.get("error") or {}).get("message", "") or response.text[:300]
             except Exception:
                 detail = response.text[:300]
             return {
@@ -1541,7 +1541,7 @@ def _transcribe_elevenlabs(file_path: str, model_name: str) -> Dict[str, Any]:
         return {"success": False, "transcript": "", "error": "ELEVENLABS_API_KEY not set"}
 
     stt_config = _load_stt_config()
-    elevenlabs_config = stt_config.get("elevenlabs", {})
+    elevenlabs_config = stt_config.get("elevenlabs") or {}
     base_url = str(
         elevenlabs_config.get("base_url")
         or get_env_value("ELEVENLABS_STT_BASE_URL")
@@ -1656,14 +1656,14 @@ def transcribe_audio(file_path: str, model: Optional[str] = None) -> Dict[str, A
     provider = _get_provider(stt_config)
 
     if provider == "local":
-        local_cfg = stt_config.get("local", {})
+        local_cfg = stt_config.get("local") or {}
         model_name = _normalize_local_model(
             model or local_cfg.get("model", DEFAULT_LOCAL_MODEL)
         )
         return _transcribe_local(file_path, model_name)
 
     if provider == "local_command":
-        local_cfg = stt_config.get("local", {})
+        local_cfg = stt_config.get("local") or {}
         model_name = _normalize_local_command_model(
             model or local_cfg.get("model", DEFAULT_LOCAL_MODEL)
         )
@@ -1674,12 +1674,12 @@ def transcribe_audio(file_path: str, model: Optional[str] = None) -> Dict[str, A
         return _transcribe_groq(file_path, model_name)
 
     if provider == "openai":
-        openai_cfg = stt_config.get("openai", {})
+        openai_cfg = stt_config.get("openai") or {}
         model_name = model or openai_cfg.get("model", DEFAULT_STT_MODEL)
         return _transcribe_openai(file_path, model_name)
 
     if provider == "mistral":
-        mistral_cfg = stt_config.get("mistral", {})
+        mistral_cfg = stt_config.get("mistral") or {}
         model_name = model or mistral_cfg.get("model", DEFAULT_MISTRAL_STT_MODEL)
         return _transcribe_mistral(file_path, model_name)
 
@@ -1689,7 +1689,7 @@ def transcribe_audio(file_path: str, model: Optional[str] = None) -> Dict[str, A
         return _transcribe_xai(file_path, model_name)
 
     if provider == "elevenlabs":
-        elevenlabs_cfg = stt_config.get("elevenlabs", {})
+        elevenlabs_cfg = stt_config.get("elevenlabs") or {}
         model_name = model or elevenlabs_cfg.get("model_id", DEFAULT_ELEVENLABS_STT_MODEL)
         return _transcribe_elevenlabs(file_path, model_name)
 
@@ -1753,7 +1753,7 @@ def transcribe_audio(file_path: str, model: Optional[str] = None) -> Dict[str, A
 def _resolve_openai_audio_client_config() -> tuple[str, str]:
     """Return direct OpenAI audio config or a managed gateway fallback."""
     stt_config = _load_stt_config()
-    openai_cfg = stt_config.get("openai", {})
+    openai_cfg = stt_config.get("openai") or {}
     cfg_api_key = openai_cfg.get("api_key", "")
     cfg_base_url = openai_cfg.get("base_url", "")
     if cfg_api_key:

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -328,7 +328,7 @@ def _load_tts_config() -> Dict[str, Any]:
     try:
         from hermes_cli.config import load_config
         config = load_config()
-        return config.get("tts", {})
+        return config.get("tts") or {}
     except ImportError:
         logger.debug("hermes_cli.config not available, using default TTS config")
         return {}
@@ -935,7 +935,7 @@ async def _generate_edge_tts(text: str, output_path: str, tts_config: Dict[str, 
         Path to the saved audio file.
     """
     _edge_tts = _import_edge_tts()
-    edge_config = tts_config.get("edge", {})
+    edge_config = tts_config.get("edge") or {}
     voice = edge_config.get("voice", DEFAULT_EDGE_VOICE)
     speed = float(edge_config.get("speed", tts_config.get("speed", 1.0)))
 
@@ -968,7 +968,7 @@ def _generate_elevenlabs(text: str, output_path: str, tts_config: Dict[str, Any]
     if not api_key:
         raise ValueError("ELEVENLABS_API_KEY not set. Get one at https://elevenlabs.io/")
 
-    el_config = tts_config.get("elevenlabs", {})
+    el_config = tts_config.get("elevenlabs") or {}
     voice_id = el_config.get("voice_id", DEFAULT_ELEVENLABS_VOICE_ID)
     model_id = el_config.get("model_id", DEFAULT_ELEVENLABS_MODEL_ID)
 
@@ -1012,7 +1012,7 @@ def _generate_openai_tts(text: str, output_path: str, tts_config: Dict[str, Any]
     """
     api_key, base_url = _resolve_openai_audio_client_config()
 
-    oai_config = tts_config.get("openai", {})
+    oai_config = tts_config.get("openai") or {}
     model = oai_config.get("model", DEFAULT_OPENAI_MODEL)
     voice = oai_config.get("voice", DEFAULT_OPENAI_VOICE)
     base_url = oai_config.get("base_url", base_url)
@@ -1126,7 +1126,7 @@ def _generate_xai_tts(text: str, output_path: str, tts_config: Dict[str, Any]) -
     if not api_key:
         raise ValueError("No xAI credentials found. Configure xAI OAuth in `hermes model` or set XAI_API_KEY.")
 
-    xai_config = tts_config.get("xai", {})
+    xai_config = tts_config.get("xai") or {}
     voice_id = str(xai_config.get("voice_id", DEFAULT_XAI_VOICE_ID)).strip() or DEFAULT_XAI_VOICE_ID
     language = str(xai_config.get("language", DEFAULT_XAI_LANGUAGE)).strip() or DEFAULT_XAI_LANGUAGE
     sample_rate = int(xai_config.get("sample_rate", DEFAULT_XAI_SAMPLE_RATE))
@@ -1207,7 +1207,7 @@ def _generate_minimax_tts(text: str, output_path: str, tts_config: Dict[str, Any
     if not api_key:
         raise ValueError("MINIMAX_API_KEY not set. Get one at https://platform.minimax.io/")
 
-    mm_config = tts_config.get("minimax", {})
+    mm_config = tts_config.get("minimax") or {}
     model = mm_config.get("model", DEFAULT_MINIMAX_MODEL)
     voice_id = mm_config.get("voice_id", DEFAULT_MINIMAX_VOICE_ID)
     base_url = mm_config.get("base_url", DEFAULT_MINIMAX_BASE_URL)
@@ -1271,14 +1271,14 @@ def _generate_minimax_tts(text: str, output_path: str, tts_config: Dict[str, Any
         # t2a_v2 returns JSON with hex-encoded audio
         response.raise_for_status()
         result = response.json()
-        base_resp = result.get("base_resp", {})
+        base_resp = result.get("base_resp") or {}
         status_code = base_resp.get("status_code", -1)
 
         if status_code != 0:
             status_msg = base_resp.get("status_msg", "unknown error")
             raise RuntimeError(f"MiniMax TTS API error (code {status_code}): {status_msg}")
 
-        hex_audio = result.get("data", {}).get("audio", "")
+        hex_audio = (result.get("data") or {}).get("audio", "")
         if not hex_audio:
             raise RuntimeError("MiniMax TTS returned empty audio data")
 
@@ -1299,7 +1299,7 @@ def _generate_minimax_tts(text: str, output_path: str, tts_config: Dict[str, Any
         # Fallback: try parsing as JSON
         try:
             result = response.json()
-            base_resp = result.get("base_resp", {})
+            base_resp = result.get("base_resp") or {}
             status_code = base_resp.get("status_code", -1)
             if status_code != 0:
                 status_msg = base_resp.get("status_msg", "unknown error")
@@ -1328,7 +1328,7 @@ def _generate_mistral_tts(text: str, output_path: str, tts_config: Dict[str, Any
     if not api_key:
         raise ValueError("MISTRAL_API_KEY not set. Get one at https://console.mistral.ai/")
 
-    mi_config = tts_config.get("mistral", {})
+    mi_config = tts_config.get("mistral") or {}
     model = mi_config.get("model", DEFAULT_MISTRAL_TTS_MODEL)
     voice_id = mi_config.get("voice_id") or DEFAULT_MISTRAL_TTS_VOICE_ID
 
@@ -1579,7 +1579,7 @@ def _generate_gemini_tts(text: str, output_path: str, tts_config: Dict[str, Any]
             "GEMINI_API_KEY not set. Get one at https://aistudio.google.com/app/apikey"
         )
 
-    raw_gemini_config = tts_config.get("gemini", {})
+    raw_gemini_config = tts_config.get("gemini") or {}
     gemini_config = raw_gemini_config if isinstance(raw_gemini_config, dict) else {}
     model = str(gemini_config.get("model", DEFAULT_GEMINI_TTS_MODEL)).strip() or DEFAULT_GEMINI_TTS_MODEL
     voice = str(gemini_config.get("voice", DEFAULT_GEMINI_TTS_VOICE)).strip() or DEFAULT_GEMINI_TTS_VOICE
@@ -1628,7 +1628,7 @@ def _generate_gemini_tts(text: str, output_path: str, tts_config: Dict[str, Any]
     if response.status_code != 200:
         # Surface the API error message when present
         try:
-            err = response.json().get("error", {})
+            err = response.json().get("error") or {}
             detail = err.get("message") or response.text[:300]
         except Exception:
             detail = response.text[:300]
@@ -1743,7 +1743,7 @@ def _generate_neutts(text: str, output_path: str, tts_config: Dict[str, Any]) ->
     """
     import sys
 
-    neutts_config = tts_config.get("neutts", {})
+    neutts_config = tts_config.get("neutts") or {}
     ref_audio = neutts_config.get("ref_audio", "") or _default_neutts_ref_audio()
     ref_text = neutts_config.get("ref_text", "") or _default_neutts_ref_text()
     model = neutts_config.get("model", "neuphonic/neutts-air-q4-gguf")
@@ -1881,7 +1881,7 @@ def _generate_piper_tts(text: str, output_path: str, tts_config: Dict[str, Any])
     PiperVoice = _import_piper()
     import wave
 
-    piper_config = tts_config.get("piper", {}) if isinstance(tts_config, dict) else {}
+    piper_config = tts_config.get("piper") or {} if isinstance(tts_config, dict) else {}
     voice_name = piper_config.get("voice") or DEFAULT_PIPER_VOICE
     download_dir = Path(piper_config.get("voices_dir") or _get_piper_voices_dir()).expanduser()
     download_dir.mkdir(parents=True, exist_ok=True)
@@ -1972,7 +1972,7 @@ def _generate_kittentts(text: str, output_path: str, tts_config: Dict[str, Any])
         Path to the saved audio file.
     """
     KittenTTS = _import_kittentts()
-    kt_config = tts_config.get("kittentts", {})
+    kt_config = tts_config.get("kittentts") or {}
     model_name = kt_config.get("model", DEFAULT_KITTENTTS_MODEL)
     voice = kt_config.get("voice", DEFAULT_KITTENTTS_VOICE)
     speed = kt_config.get("speed", 1.0)
@@ -2480,7 +2480,7 @@ def stream_tts_to_speaker(
         model_id = DEFAULT_ELEVENLABS_STREAMING_MODEL_ID
 
         tts_config = _load_tts_config()
-        el_config = tts_config.get("elevenlabs", {})
+        el_config = tts_config.get("elevenlabs") or {}
         voice_id = el_config.get("voice_id", voice_id)
         model_id = el_config.get("streaming_model_id",
                                  el_config.get("model_id", model_id))


### PR DESCRIPTION
## Bug

When `stt.local`, `tts.edge`, or any other config section is explicitly `null` in `config.yaml` (common after `hermes setup --voice`), `.get("key", {})` returns `None` (not `{}`) because the key exists with value `None`. Subsequent `.get()` calls crash with `AttributeError: 'NoneType' object has no attribute 'get'`.

**Reproduction:**
```yaml
# config.yaml after fresh 'hermes setup --voice'
stt:
  local: null
tts:
  edge: null
```
Then `/voice on` → `Transcription failed: 'NoneType' object has no attribute 'get'`

## Fix

Replace `.get("key", {})` with `.get("key") or {}` throughout `transcription_tools.py` and `tts_tool.py` (28 locations total).

For chained access, wrap in parentheses:
```python
# Before (crashes when value is None):
local_cfg = stt_config.get("local", {})
model = local_cfg.get("model", DEFAULT_MODEL)

# After (safe):
local_cfg = stt_config.get("local") or {}
model = local_cfg.get("model", DEFAULT_MODEL)

# Chained inline:
(stt_config.get("local") or {}).get("language")
```

**Files changed:** 2 (`tools/transcription_tools.py`, `tools/tts_tool.py`)
**Lines changed:** 28

Fixes #47318