### PR TITLE
fix(desktop): yield cron ownership to running gateway

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -112,15 +112,35 @@ def _start_desktop_cron_ticker(stop_event: "threading.Event", interval: int = 60
     a user creates in the app would never fire. We run a minimal ticker here
     (no live adapters; delivery falls back to the per-platform send path).
 
-    Cross-process safe: ``cron.scheduler.tick`` takes the ``cron/.tick.lock``
-    file lock, so this never double-fires alongside a real gateway on the same
-    HERMES_HOME — whichever process grabs the lock first wins the tick.
+    If a real gateway is already running for this HERMES_HOME, the desktop
+    ticker must stand down. Some macOS TCC permissions (Calendar/EventKit in
+    particular) are attached to the process context that wins the cron lock.
+    Letting the dashboard race the gateway can make cron jobs run from a
+    different, unauthorized requester even though the gateway can run them.
     """
     from cron.scheduler import tick as cron_tick
 
     _log.info("Desktop cron ticker started (interval=%ds)", interval)
+    skipped_for_gateway = False
     # Tick once up front (catches jobs due at launch), then on the interval.
     while not stop_event.is_set():
+        try:
+            gateway_pid = get_running_pid(cleanup_stale=True)
+        except Exception as e:
+            gateway_pid = None
+            _log.debug("Desktop cron gateway probe failed: %s", e)
+
+        if gateway_pid is not None and gateway_pid != os.getpid():
+            if not skipped_for_gateway:
+                _log.info(
+                    "Desktop cron ticker standing down; gateway PID %s owns cron",
+                    gateway_pid,
+                )
+                skipped_for_gateway = True
+            stop_event.wait(interval)
+            continue
+
+        skipped_for_gateway = False
         try:
             cron_tick(verbose=False, sync=False)
         except Exception as e:

--- a/tests/hermes_cli/test_desktop_cron_ticker.py
+++ b/tests/hermes_cli/test_desktop_cron_ticker.py
@@ -1,0 +1,50 @@
+import logging
+from typing import Any, cast
+
+import cron.scheduler as cron_scheduler
+import hermes_cli.web_server as web_server
+
+
+class OneTickStopEvent:
+    """Stop after one ticker iteration."""
+
+    def __init__(self):
+        self.waits = []
+
+    def is_set(self):
+        return bool(self.waits)
+
+    def wait(self, interval):
+        self.waits.append(interval)
+        return True
+
+
+def test_desktop_cron_ticker_stands_down_when_gateway_owns_cron(monkeypatch, caplog):
+    tick_calls = []
+    monkeypatch.setattr(web_server, "get_running_pid", lambda cleanup_stale=True: 4242)
+    monkeypatch.setattr(cron_scheduler, "tick", lambda **kwargs: tick_calls.append(kwargs))
+
+    caplog.set_level(logging.INFO, logger="hermes_cli.web_server")
+    stop_event = OneTickStopEvent()
+
+    web_server._start_desktop_cron_ticker(cast(Any, stop_event), interval=0)
+
+    assert tick_calls == []
+    assert stop_event.waits == [0]
+    assert "Desktop cron ticker standing down; gateway PID 4242 owns cron" in caplog.text
+
+
+def test_desktop_cron_ticker_runs_when_no_gateway_owns_cron(monkeypatch):
+    tick_calls = []
+    monkeypatch.setattr(web_server, "get_running_pid", lambda cleanup_stale=True: None)
+    monkeypatch.setattr(
+        cron_scheduler,
+        "tick",
+        lambda *, verbose, sync: tick_calls.append({"verbose": verbose, "sync": sync}),
+    )
+    stop_event = OneTickStopEvent()
+
+    web_server._start_desktop_cron_ticker(cast(Any, stop_event), interval=0)
+
+    assert tick_calls == [{"verbose": False, "sync": False}]
+    assert stop_event.waits == [0]


### PR DESCRIPTION
## Summary

- make the desktop dashboard cron ticker stand down when a real gateway PID is already running for the same Hermes home
- preserve desktop-created cron jobs when no gateway is running
- add regression coverage for both ownership paths

## Why

The desktop dashboard and the messaging gateway can both run the cron scheduler. The scheduler lock prevents double-firing, but whichever process wins the lock becomes the effective requester for jobs with OS-scoped permissions.

On macOS, Calendar/EventKit TCC permissions are attached to the requesting process/app context. If the desktop dashboard wins the cron lock while the gateway is running, a Calendar-backed cron job can run under the desktop app requester instead of the already-authorized gateway requester and fail with Calendar/EventKit authorization errors.

## Test plan

```bash
PYTHONPATH="$PWD" python -m pytest tests/hermes_cli/test_desktop_cron_ticker.py -q -o 'addopts='
```

Result:

```text
2 passed
```
