### PR TITLE
fix(desktop): don't report false failure on a successful backend update

### DIFF
--- a/apps/desktop/src/store/updates.test.ts
+++ b/apps/desktop/src/store/updates.test.ts
@@ -197,11 +197,58 @@ describe('applyBackendUpdate recovery', () => {
     checkHermesUpdateSpy.mockRejectedValue(new Error('ECONNREFUSED'))
 
     const promise = applyBackendUpdate()
-    await vi.advanceTimersByTimeAsync(70000)
+    // Exhaust the full restart-confirm budget (RETURN_MAX_MS = 4 min) before asserting.
+    await vi.advanceTimersByTimeAsync(5 * 60 * 1000)
     const result = await promise
 
     expect(result.ok).toBe(false)
     expect($backendUpdateApply.get().stage).toBe('error')
+  })
+
+  it('keeps waiting through a long-running update instead of failing at the old ~45s cap', async () => {
+    updateHermesSpy.mockResolvedValue({ ok: true, name: 'update', pid: 1 })
+
+    // The dashboard stays up and the action keeps reporting `running` well past the old
+    // 30×1.5s≈45s budget, then the connection drops when the update restarts it.
+    let polls = 0
+    getActionStatusSpy.mockImplementation(async () => {
+      polls += 1
+
+      if (polls > 40) {
+        throw new Error('ECONNREFUSED')
+      }
+
+      return { name: 'update', running: true, exit_code: null, pid: 1, lines: [] }
+    })
+    checkHermesUpdateSpy.mockResolvedValue({ install_method: 'git', current_version: '0.16.0', behind: 0, update_available: false, can_apply: true, update_command: 'hermes update', message: null })
+
+    const promise = applyBackendUpdate()
+
+    // Past the old cap the overlay must still be applying — not an error.
+    await vi.advanceTimersByTimeAsync(50000)
+    expect($backendUpdateApply.get().stage).not.toBe('error')
+    expect($backendUpdateApply.get().applying).toBe(true)
+
+    // Let the action run on, drop the connection, and the backend come back current.
+    await vi.advanceTimersByTimeAsync(30000)
+    const result = await promise
+
+    expect(result.ok).toBe(true)
+    expect($backendUpdateApply.get().stage).toBe('idle')
+  })
+
+  it('reports failure only when the update action itself exits non-zero', async () => {
+    updateHermesSpy.mockResolvedValue({ ok: true, name: 'update', pid: 1 })
+    getActionStatusSpy.mockResolvedValue({ name: 'update', running: false, exit_code: 1, pid: 1, lines: [] })
+
+    const promise = applyBackendUpdate()
+    await vi.advanceTimersByTimeAsync(5000)
+    const result = await promise
+
+    expect(result.ok).toBe(false)
+    expect($backendUpdateApply.get().stage).toBe('error')
+    // A real action failure must not be masked by the restart-confirm path.
+    expect(checkHermesUpdateSpy).not.toHaveBeenCalled()
   })
 })
 

--- a/apps/desktop/src/store/updates.ts
+++ b/apps/desktop/src/store/updates.ts
@@ -305,18 +305,43 @@ export async function applyUpdates(opts: DesktopUpdateApplyOptions = {}): Promis
   }
 }
 
-const BACKEND_RETURN_POLL_MS = 1500
-const BACKEND_RETURN_MAX_ATTEMPTS = 40
+// `hermes update` runs git pull + uv sync + npm install + vite build, then drains and
+// restarts the gateway ("up to 195s") before finally tearing down the dashboard it is
+// serving us from. That routinely takes well over a minute, so these budgets are
+// generous on purpose: the old 30×1.5s≈45s poll cap expired mid-update and reported a
+// false failure while the update was still succeeding.
+const ACTION_POLL_MS = 1500
+// Upper bound on how long we watch the update action itself — only a guard against an
+// action that never terminates. Normal updates finish (or drop the connection on
+// restart) long before this.
+const ACTION_MAX_MS = 6 * 60 * 1000
+const RETURN_POLL_MS = 1500
+// How long we wait for the backend to come back AND report itself up to date after the
+// restart. Covers a cold dashboard boot plus any stale-keepalive socket recycling.
+const RETURN_MAX_MS = 4 * 60 * 1000
 
+/**
+ * Poll the backend after a restart until it's reachable AND reports that no update is
+ * available — i.e. the new code is live. We can't compare versions (the backend
+ * `__version__` only bumps on release commits, not per-commit), so `update_available
+ * === false` from a forced, cache-busted check is the authoritative "we're current"
+ * signal. A bare "the request didn't throw" is not enough: right after `hermes update`
+ * the dashboard is mid-restart and a reused-but-dead keepalive socket can answer late.
+ */
 async function waitForBackendReturn(): Promise<boolean> {
-  for (let attempt = 0; attempt < BACKEND_RETURN_MAX_ATTEMPTS; attempt += 1) {
-    await new Promise(resolve => globalThis.setTimeout(resolve, BACKEND_RETURN_POLL_MS))
-    try {
-      await checkHermesUpdate()
+  const deadline = Date.now() + RETURN_MAX_MS
 
-      return true
+  while (Date.now() < deadline) {
+    await new Promise(resolve => globalThis.setTimeout(resolve, RETURN_POLL_MS))
+
+    try {
+      const res = await checkHermesUpdate(true)
+
+      if (res.update_available === false) {
+        return true
+      }
     } catch {
-      continue
+      // Backend still restarting (connection refused / 5xx / timeout) — keep waiting.
     }
   }
 
@@ -360,44 +385,64 @@ export async function applyBackendUpdate(): Promise<DesktopUpdateApplyResult> {
 
     $backendUpdateApply.set({ ...IDLE, applying: true, stage: 'pull', message: translateNow('updates.applyStatus.pulling') })
 
+    const enterRestart = () =>
+      $backendUpdateApply.set({
+        ...$backendUpdateApply.get(),
+        applying: true,
+        stage: 'restart',
+        message: translateNow('updates.applyStatus.restarting')
+      })
+
+    const fail = (): DesktopUpdateApplyResult => {
+      $backendUpdateApply.set({
+        ...$backendUpdateApply.get(),
+        applying: false,
+        stage: 'error',
+        error: 'apply-failed',
+        message: translateNow('updates.applyStatus.failed')
+      })
+
+      return { ok: false, error: 'apply-failed', message: 'Backend update failed.' }
+    }
+
+    // Phase A — watch the update action until it terminates. A still-running action is
+    // NOT a failure: `hermes update` legitimately runs for minutes. We only leave on a
+    // terminal signal — the action exits, or the connection drops because the update
+    // tore down the dashboard we poll through for its restart.
+    const actionDeadline = Date.now() + ACTION_MAX_MS
     let last: Awaited<ReturnType<typeof getActionStatus>> | null = null
-    for (let attempt = 0; attempt < 30; attempt += 1) {
-      await new Promise(resolve => globalThis.setTimeout(resolve, 1500))
+
+    while (Date.now() < actionDeadline) {
+      await new Promise(resolve => globalThis.setTimeout(resolve, ACTION_POLL_MS))
+
       try {
         last = await getActionStatus(started.name, 200)
       } catch {
-        // The dashboard restarts mid-update, dropping this connection — expected, not a failure.
-        $backendUpdateApply.set({
-          ...$backendUpdateApply.get(),
-          applying: true,
-          stage: 'restart',
-          message: translateNow('updates.applyStatus.restarting')
-        })
+        // Connection dropped: the update reached its restart step, not a failure.
+        enterRestart()
 
         return finishBackendApply(await waitForBackendReturn())
       }
 
       if (last && !last.running) {
-        break
+        // The action exited. A non-zero exit is the one true failure here; exit 0 means
+        // confirm the backend comes back up to date (systemd-managed deploys restart it).
+        if ((last.exit_code ?? 1) !== 0) {
+          return fail()
+        }
+
+        enterRestart()
+
+        return finishBackendApply(await waitForBackendReturn())
       }
     }
 
-    const ok = !!last && (last.exit_code ?? 1) === 0
-    if (ok) {
-      $backendUpdateApply.set({ ...$backendUpdateApply.get(), applying: true, stage: 'restart', message: translateNow('updates.applyStatus.restarting') })
+    // The action never reported completion within ACTION_MAX_MS (a stuck update). Don't
+    // claim failure — hand off to the restart-confirm net, which either confirms the
+    // backend is current or reports it never came back.
+    enterRestart()
 
-      return finishBackendApply(await waitForBackendReturn())
-    }
-
-    $backendUpdateApply.set({
-      ...$backendUpdateApply.get(),
-      applying: false,
-      stage: 'error',
-      error: 'apply-failed',
-      message: translateNow('updates.applyStatus.failed')
-    })
-
-    return { ok: false, error: 'apply-failed', message: 'Backend update failed.' }
+    return finishBackendApply(await waitForBackendReturn())
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error)
     $backendUpdateApply.set({ ...$backendUpdateApply.get(), applying: false, stage: 'error', error: 'apply-failed', message })


### PR DESCRIPTION
Fixes #47359.

## What & why

In remote mode the backend update overlay showed **"Backend update failed."** ~45s in, even though `hermes update` was still running and went on to succeed (a relaunch always showed the new version). `applyBackendUpdate()` polled the update action for only `30 × 1.5s ≈ 45s`, then computed `ok = (exit_code ?? 1) === 0` on a still-running action (`exit_code` null) and surfaced a failure. Real updates (git pull + uv sync + npm install + vite build + gateway drain "up to 195s") routinely exceed that, so the toast fired on nearly every update.

## Change

Restructure the apply flow in `apps/desktop/src/store/updates.ts` into two phases:

- **Phase A — wait for the action to terminate.** A still-running action is never treated as failure (the cap is now only a generous safety guard, not a verdict). Terminal signals: the action exits, or the connection drops because the update tore down the dashboard it serves us from. Only a non-zero exit is a real failure.
- **Phase B — confirm the backend is back _and_ current.** `waitForBackendReturn()` now polls a forced `GET /api/hermes/update/check` until `update_available === false`, with a generous budget that tolerates a cold dashboard restart and stale-keepalive socket recycling. (We can't compare versions — backend `__version__` only bumps on release commits, not per-commit.)

No backend changes, no new i18n keys, no type changes. Reuses the existing `checkHermesUpdate` / `getActionStatus` / `finishBackendApply` plumbing.

## Tests

`apps/desktop/src/store/updates.test.ts`:
- new: keeps waiting through a long-running update instead of failing at the old ~45s cap (the reported bug)
- new: reports failure only when the action itself exits non-zero
- updated: the existing "never comes back" test now exhausts the longer confirm budget

```
npx vitest run --environment jsdom src/store/updates.test.ts   # 11 passed
npm run typecheck                                              # clean
npm run lint                                                   # 0 errors, no new warnings
```

## Out of scope (optional follow-up, noted in the issue)
Persist + expose the `hermes update` exit code from the dashboard (it already writes `~/.hermes/.update_exit_code`) so the client can confirm success deterministically rather than via `update_available`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
