### PR TITLE
fix(agent): stop bg-review from sharing parent session_id (#47268)

### DIFF
--- a/agent/background_review.py
+++ b/agent/background_review.py
@@ -541,19 +541,24 @@ def _run_review_in_thread(
             # measured impact (~26% end-to-end cost reduction on
             # Sonnet 4.5).
             review_agent._cached_system_prompt = agent._cached_system_prompt
-            # Defensive: pin session_start + session_id to the
-            # parent's so any code path that re-renders parts of
-            # the system prompt (compression, plugin hooks) still
-            # produces byte-identical output. The cached-prompt
-            # assignment above already short-circuits the normal
-            # rebuild path, but these pins guarantee parity even
-            # if a future code path bypasses the cache.
+            # Pin session_start so any code path that re-renders parts of
+            # the system prompt (plugin hooks) still produces byte-identical
+            # output. The cached-prompt assignment above already
+            # short-circuits the normal rebuild path, but this pin
+            # guarantees parity even if a future code path bypasses the
+            # cache.
             review_agent.session_start = agent.session_start
-            review_agent.session_id = agent.session_id
-            # Never let the review fork compress. It shares the parent's
-            # session_id, so if it won a compression race it would rotate the
-            # parent into a NEW child that the gateway never adopts (the fork
-            # is single-lifecycle and dies right after this run_conversation).
+            # DO NOT share the parent's session_id.  The review agent
+            # writes its own messages (including denied-tool-call errors)
+            # during run_conversation.  If it used the parent's session_id,
+            # those error messages would land in the parent's session DB
+            # and the parent would see them in its conversation context,
+            # causing the model to decide the turn is "done" prematurely
+            # with abnormally short responses.  (issue #47268)
+            # Never let the review fork compress. It uses a separate
+            # session_id from the parent, so compressing would create
+            # a new child that the gateway never adopts (the fork is
+            # single-lifecycle and dies right after this run_conversation).
             # The foreground turn would then start from the stale parent and
             # compress it again, leaving the same parent with two sibling
             # children (issue #38727). Review also needs full context to

--- a/tests/run_agent/test_background_review_cache_parity.py
+++ b/tests/run_agent/test_background_review_cache_parity.py
@@ -131,20 +131,23 @@ def test_review_fork_inherits_parent_cached_system_prompt():
     )
 
 
-def test_review_fork_pins_session_start_and_session_id():
-    """Defensive complement to cached-system-prompt inheritance.
+def test_review_fork_pins_session_start_and_has_own_session_id():
+    """Review fork inherits session_start but uses its own session_id.
 
-    Even though ``_cached_system_prompt`` inheritance short-circuits the
-    normal rebuild path, pinning ``session_start`` and ``session_id`` to
-    the parent's guarantees byte-identical output from any code path that
-    re-renders parts of the system prompt (compression, plugin hooks).
+    ``session_start`` is pinned so any code path that re-renders parts of
+    the system prompt (plugin hooks) still produces byte-identical output.
+
+    However, ``session_id`` must NOT be shared with the parent -- the review
+    agent writes its own messages (including denied-tool-call errors) during
+    ``run_conversation``.  If it used the parent's session_id, those error
+    messages would land in the parent's session DB and the parent would see
+    them in its conversation context, causing the model to decide the turn
+    is "done" prematurely with abnormally short responses.  (issue #47268)
     """
     import run_agent
 
     agent = _make_agent_stub(run_agent.AIAgent)
-
     captured = {}
-
     class _Recorder:
         def __init__(self, *args, **kwargs):
             self._cached_system_prompt = None
@@ -158,6 +161,7 @@ def test_review_fork_pins_session_start_and_session_id():
             self.suppress_status_output = None
             self.session_start = None
             self.session_id = None
+            self._parent_session_id = None
 
         def run_conversation(self, *args, **kwargs):
             captured["session_start"] = self.session_start
@@ -179,12 +183,14 @@ def test_review_fork_pins_session_start_and_session_id():
         )
 
     assert captured.get("session_start") == agent.session_start, (
-        "Review fork did not inherit parent's session_start — "
+        "Review fork did not inherit parent's session_start -- "
         "system-prompt rebuild paths would diverge."
     )
-    assert captured.get("session_id") == agent.session_id, (
-        "Review fork did not inherit parent's session_id — "
-        "system-prompt rebuild paths would diverge."
+    # session_id must NOT be shared -- see issue #47268
+    assert captured.get("session_id") != agent.session_id, (
+        "Review fork shared parent's session_id -- denied tool call errors "
+        "would pollute the parent's session DB and cause premature turn "
+        "termination. (issue #47268)"
     )
 
 


### PR DESCRIPTION
Fixes #47268. Background review agent shared the parent's session_id, so its denied tool call errors were written to the parent's session DB. The parent then saw those errors in its context and terminated the turn early with very short responses (11-77 chars). Fixed by giving the bg-review agent its own session_id while keeping session_start pinned for prompt cache parity.