### PR TITLE
fix(gateway): polling-liveness + event-loop watchdogs for Telegram silent-offline

### DIFF
--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -14,6 +14,7 @@ import json
 import logging
 import os
 import tempfile
+import time
 import html as _html
 import re
 from datetime import datetime, timezone
@@ -513,6 +514,13 @@ class TelegramAdapter(BasePlatformAdapter):
         # Tracks status bubbles owned by this adapter so subsequent calls with the
         # same key edit the same message instead of appending new ones (#30045).
         self._status_message_ids: Dict[tuple, str] = {}
+        # Polling-liveness watchdog.
+        # _last_successful_poll_at is updated on every inbound update (text,
+        # command, callback, media) — the only observable proof that the
+        # getUpdates loop is alive.  Set to None at init so the watchdog
+        # starts the clock only after connect() succeeds.
+        self._last_successful_poll_at: Optional[float] = None
+        self._poll_liveness_watchdog_task: Optional[asyncio.Task] = None
 
     def _notification_kwargs(
         self, metadata: Optional[Dict[str, Any]]
@@ -1406,6 +1414,87 @@ class TelegramAdapter(BasePlatformAdapter):
                 self.name, exc_info=True,
             )
 
+    def _refresh_poll_liveness(self) -> None:
+        """Record that the getUpdates poll loop delivered an update right now.
+
+        Call this at the top of every inbound-update handler (text, command,
+        callback query, media).  Each call is observable proof that the long-poll
+        loop made a successful round trip — the watchdog uses this timestamp to
+        detect the "process alive, loop dead" failure mode.
+        """
+        self._last_successful_poll_at = time.monotonic()
+
+    async def _start_poll_liveness_watchdog(self) -> None:
+        """Background task: force a full poller reconnect when liveness expires.
+
+        Reads ``HERMES_POLL_LIVENESS_TIMEOUT`` (bridged from config.yaml
+        ``agent.gateway_poll_liveness_timeout``; default 300s; 0 = disabled).
+
+        If no inbound update arrives within the timeout window AND
+        ``Updater.running`` is True (the poller claims to be alive), we treat
+        the poller as wedged and force a full teardown + reconnect via
+        ``_handle_polling_network_error`` — the same path used for real network
+        errors.  This is intentionally NOT a soft resume; the whole point is
+        to close the stale httpx slot and re-open it.
+
+        The watchdog sleeps in a tight-ish loop (checking every POLL_INTERVAL
+        seconds) so it reacts quickly without busy-spinning.
+        """
+        try:
+            timeout = float(os.getenv("HERMES_POLL_LIVENESS_TIMEOUT", "300") or "300")
+        except (TypeError, ValueError):
+            timeout = 300.0
+        if timeout <= 0:
+            logger.debug("[%s] Poll-liveness watchdog disabled (timeout=0)", self.name)
+            return
+
+        POLL_INTERVAL = 30.0  # how often the watchdog checks the timestamp
+
+        logger.debug(
+            "[%s] Poll-liveness watchdog started (timeout=%.0fs, check_interval=%.0fs)",
+            self.name, timeout, POLL_INTERVAL,
+        )
+        # Seed the timestamp so we don't fire immediately at startup before
+        # the first message has had a chance to arrive.
+        self._last_successful_poll_at = time.monotonic()
+
+        while True:
+            await asyncio.sleep(POLL_INTERVAL)
+
+            if self.has_fatal_error:
+                # Adapter is shutting down — don't add noise.
+                return
+
+            # Only watchdog in polling mode; webhooks don't use getUpdates.
+            if self._webhook_mode:
+                return
+
+            # If the updater isn't running there's already a reconnect in flight
+            # (error callback fired) — let it handle it.
+            if not (self._app and self._app.updater and self._app.updater.running):
+                continue
+
+            last = self._last_successful_poll_at
+            if last is None:
+                continue
+            age = time.monotonic() - last
+            if age < timeout:
+                continue
+
+            # Liveness expired — the poller claims to be running but no update
+            # has been delivered in `timeout` seconds.  Force a full reconnect.
+            logger.warning(
+                "[%s] Poll liveness timeout: no update received for %.0fs "
+                "(threshold %.0fs) — forcing full poller reconnect",
+                self.name, age, timeout,
+            )
+            # Reset the timestamp so we don't immediately re-fire while the
+            # reconnect is in progress.
+            self._last_successful_poll_at = time.monotonic()
+            await self._handle_polling_network_error(
+                RuntimeError(f"Poll liveness timeout ({age:.0f}s > {timeout:.0f}s)")
+            )
+
     async def _handle_polling_network_error(self, error: Exception) -> None:
         """Reconnect polling after a transient network interruption.
 
@@ -1461,7 +1550,8 @@ class TelegramAdapter(BasePlatformAdapter):
                 error_callback=self._polling_error_callback_ref,
             )
             logger.info(
-                "[%s] Telegram polling resumed after network error (attempt %d)",
+                "[%s] Telegram polling reconnect initiated (attempt %d) — "
+                "awaiting first getUpdates cycle to confirm liveness",
                 self.name, attempt,
             )
             self._polling_network_error_count = 0
@@ -1525,6 +1615,10 @@ class TelegramAdapter(BasePlatformAdapter):
         try:
             await asyncio.wait_for(self._app.bot.get_me(), PROBE_TIMEOUT)
             self._send_path_degraded = False
+            logger.info(
+                "[%s] Telegram polling confirmed alive %ds after reconnect (getMe() OK)",
+                self.name, HEARTBEAT_PROBE_DELAY,
+            )
         except Exception as probe_err:
             logger.warning(
                 "[%s] Polling heartbeat probe failed %ds after reconnect: %s",
@@ -1588,7 +1682,8 @@ class TelegramAdapter(BasePlatformAdapter):
                     error_callback=self._polling_error_callback_ref,
                 )
                 logger.info(
-                    "[%s] Telegram polling resumed after conflict retry %d/%d",
+                    "[%s] Telegram polling reconnect initiated after conflict retry %d/%d — "
+                    "awaiting first getUpdates cycle to confirm liveness",
                     self.name, self._polling_conflict_count, MAX_CONFLICT_RETRIES,
                 )
                 self._polling_conflict_count = 0  # reset counter on success
@@ -2189,6 +2284,14 @@ class TelegramAdapter(BasePlatformAdapter):
                     drop_pending_updates=True,
                     error_callback=_polling_error_callback,
                 )
+                # Start the polling-liveness watchdog as a background asyncio
+                # task.  It detects the "process alive, poller dead" failure
+                # mode and forces a full reconnect when the getUpdates loop
+                # silently stops delivering updates.
+                watchdog = asyncio.ensure_future(self._start_poll_liveness_watchdog())
+                self._poll_liveness_watchdog_task = watchdog
+                self._background_tasks.add(watchdog)
+                watchdog.add_done_callback(self._background_tasks.discard)
             
             # Register bot commands so Telegram shows a hint menu when users type /
             # List is derived from the central COMMAND_REGISTRY — adding a new
@@ -2259,6 +2362,15 @@ class TelegramAdapter(BasePlatformAdapter):
 
     async def disconnect(self) -> None:
         """Stop polling/webhook, cancel pending album flushes, and disconnect."""
+        # Cancel the polling-liveness watchdog so it doesn't fire during shutdown.
+        if self._poll_liveness_watchdog_task and not self._poll_liveness_watchdog_task.done():
+            self._poll_liveness_watchdog_task.cancel()
+            try:
+                await self._poll_liveness_watchdog_task
+            except (asyncio.CancelledError, Exception):
+                pass
+        self._poll_liveness_watchdog_task = None
+
         pending_media_group_tasks = list(self._media_group_tasks.values())
         for task in pending_media_group_tasks:
             task.cancel()
@@ -3869,6 +3981,7 @@ class TelegramAdapter(BasePlatformAdapter):
         self, update: "Update", context: "ContextTypes.DEFAULT_TYPE"
     ) -> None:
         """Handle inline keyboard button clicks."""
+        self._refresh_poll_liveness()
         query = update.callback_query
         if not query or not query.data:
             return
@@ -5896,6 +6009,7 @@ class TelegramAdapter(BasePlatformAdapter):
         rapid successive text messages from the same user/chat and aggregate
         them into a single MessageEvent before dispatching.
         """
+        self._refresh_poll_liveness()
         msg = self._effective_update_message(update)
         if not msg or not msg.text:
             return
@@ -5913,6 +6027,7 @@ class TelegramAdapter(BasePlatformAdapter):
 
     async def _handle_command(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
         """Handle incoming command messages."""
+        self._refresh_poll_liveness()
         msg = self._effective_update_message(update)
         if not msg or not msg.text:
             return
@@ -5928,6 +6043,7 @@ class TelegramAdapter(BasePlatformAdapter):
 
     async def _handle_location_message(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
         """Handle incoming location/venue pin messages."""
+        self._refresh_poll_liveness()
         msg = self._effective_update_message(update)
         if not msg:
             return
@@ -6111,6 +6227,7 @@ class TelegramAdapter(BasePlatformAdapter):
 
     async def _handle_media_message(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
         """Handle incoming media messages, downloading images to local cache."""
+        self._refresh_poll_liveness()
         if not update.message:
             return
         if not self._should_process_message(update.message):

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1293,6 +1293,14 @@ if _config_path.exists():
                 os.environ["HERMES_AUTO_CONTINUE_FRESHNESS"] = str(
                     _agent_cfg["gateway_auto_continue_freshness"]
                 )
+            if "gateway_poll_liveness_timeout" in _agent_cfg:
+                os.environ["HERMES_POLL_LIVENESS_TIMEOUT"] = str(
+                    _agent_cfg["gateway_poll_liveness_timeout"]
+                )
+            if "gateway_loop_liveness_timeout" in _agent_cfg:
+                os.environ["HERMES_LOOP_LIVENESS_TIMEOUT"] = str(
+                    _agent_cfg["gateway_loop_liveness_timeout"]
+                )
         _display_cfg = _cfg.get("display", {})
         if _display_cfg and isinstance(_display_cfg, dict):
             if "busy_input_mode" in _display_cfg:
@@ -16332,6 +16340,22 @@ def _start_cron_ticker(stop_event: threading.Event, adapters=None, loop=None, in
     CHANNEL_DIR_EVERY = 5    # ticks — every 5 minutes
     PASTE_SWEEP_EVERY = 60   # ticks — once per hour
     CURATOR_EVERY = 60       # ticks — poll hourly (inner gate handles the real cadence)
+    # Event-loop liveness probe — every N ticks (default 5 ticks = 5 min)
+    LOOP_PROBE_EVERY = 5
+
+    # Read the loop-liveness timeout from env (bridged from config.yaml
+    # agent.gateway_loop_liveness_timeout at gateway startup; 0 = disabled).
+    def _float_env_ticker(name: str, default: float) -> float:
+        try:
+            return float(os.getenv(name, str(default)))
+        except (TypeError, ValueError):
+            return default
+
+    loop_liveness_timeout = _float_env_ticker("HERMES_LOOP_LIVENESS_TIMEOUT", 600.0)
+    _last_loop_probe_ok: float = time.monotonic()
+
+    async def _loop_noop() -> None:
+        """Trivial coroutine used to probe asyncio event-loop responsiveness."""
 
     logger.info("Cron ticker started (interval=%ds)", interval)
     tick_count = 0
@@ -16400,6 +16424,37 @@ def _start_cron_ticker(stop_event: threading.Event, adapters=None, loop=None, in
                 )
             except Exception as e:
                 logger.debug("Curator tick error: %s", e)
+
+        # ── Event-loop liveness probe ──────────────────────────────────────
+        # Submit a trivial no-op coroutine to the asyncio event loop and wait
+        # for it to complete.  If it doesn't finish within
+        # HERMES_LOOP_LIVENESS_TIMEOUT (from config.yaml
+        # agent.gateway_loop_liveness_timeout), the loop is stalled.
+        # First breach → WARNING.  Second breach (2x timeout elapsed since
+        # last good probe) → hard ERROR + os._exit(1) so the service manager
+        # (launchd / systemd) can restart the gateway.
+        if loop_liveness_timeout > 0 and tick_count % LOOP_PROBE_EVERY == 0 and loop is not None:
+            try:
+                probe_fut = asyncio.run_coroutine_threadsafe(_loop_noop(), loop)
+                probe_fut.result(timeout=min(loop_liveness_timeout, 30))
+                _last_loop_probe_ok = time.monotonic()
+            except Exception as _probe_err:
+                stall_duration = time.monotonic() - _last_loop_probe_ok
+                if stall_duration >= loop_liveness_timeout * 2:
+                    logger.error(
+                        "Event-loop liveness: asyncio loop unresponsive for %.0fs "
+                        "(threshold %.0fs) — forcing hard restart. Error: %s",
+                        stall_duration, loop_liveness_timeout, _probe_err,
+                    )
+                    # os._exit bypasses atexit/cleanup handlers intentionally:
+                    # the loop is stalled, so we can't run async shutdown anyway.
+                    os._exit(1)  # noqa: SLF001
+                else:
+                    logger.warning(
+                        "Event-loop liveness: asyncio loop unresponsive for %.0fs "
+                        "(will force restart at %.0fs). Error: %s",
+                        stall_duration, loop_liveness_timeout * 2, _probe_err,
+                    )
 
         stop_event.wait(timeout=interval)
     logger.info("Cron ticker stopped")

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -930,6 +930,21 @@ DEFAULT_CONFIG = {
         # only controls how inbound user images are presented.
         "image_input_mode": "auto",
         "disabled_toolsets": [],
+        # Polling-liveness watchdog: if no successful getUpdates cycle completes
+        # within this window (seconds), the watchdog forces a full poller
+        # teardown + fresh reconnect (not a soft resume).  0 = disabled.
+        # Default 300s (5 min) — chosen to be generous enough to avoid false
+        # positives during normal long-poll timeouts (Telegram's timeout is 10s
+        # but a healthy cycle is ~10-30s), but tight enough to catch the
+        # "process alive, loop dead" failure mode before it runs for hours.
+        "gateway_poll_liveness_timeout": 300,
+        # Event-loop liveness watchdog: the cron ticker periodically submits a
+        # no-op coroutine to the asyncio loop and waits for it to complete.  If
+        # it doesn't complete within this window (seconds), the loop is
+        # considered stalled and the gateway logs a hard WARNING.  If the stall
+        # persists for 2x this timeout the process exits with code 1 so the
+        # service manager can restart it.  0 = disabled.
+        "gateway_loop_liveness_timeout": 600,
     },
     
     "terminal": {

--- a/tests/gateway/test_telegram_poll_liveness.py
+++ b/tests/gateway/test_telegram_poll_liveness.py
@@ -1,0 +1,355 @@
+"""
+Tests for the Telegram polling-liveness watchdog.
+
+The watchdog detects the "process alive, poller dead" failure mode:
+the Updater reports running=True but the getUpdates loop silently stopped
+delivering updates (observed on 2026-06-16 after transient network errors).
+
+When the liveness timestamp hasn't been refreshed for longer than the
+configured timeout AND updater.running is True, the watchdog fires
+_handle_polling_network_error — a full teardown + reconnect, NOT a soft
+resume.
+
+Tests also cover:
+- _refresh_poll_liveness updates the timestamp
+- watchdog exits cleanly when disabled (timeout=0)
+- watchdog does NOT fire when adapter is shutting down (has_fatal_error)
+- watchdog does NOT fire in webhook mode
+- watchdog does NOT fire when updater isn't running (reconnect already in flight)
+- misleading "polling resumed" log message is replaced (verifies new wording)
+"""
+from __future__ import annotations
+
+import asyncio
+import sys
+import time
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from gateway.config import PlatformConfig
+
+
+def _ensure_telegram_mock():
+    if "telegram" in sys.modules and hasattr(sys.modules["telegram"], "__file__"):
+        return
+
+    telegram_mod = MagicMock()
+    telegram_mod.ext.ContextTypes.DEFAULT_TYPE = type(None)
+    telegram_mod.constants.ParseMode.MARKDOWN_V2 = "MarkdownV2"
+    telegram_mod.constants.ChatType.GROUP = "group"
+    telegram_mod.constants.ChatType.SUPERGROUP = "supergroup"
+    telegram_mod.constants.ChatType.CHANNEL = "channel"
+    telegram_mod.constants.ChatType.PRIVATE = "private"
+
+    for name in ("telegram", "telegram.ext", "telegram.constants", "telegram.request"):
+        sys.modules.setdefault(name, telegram_mod)
+
+
+_ensure_telegram_mock()
+
+from gateway.platforms.telegram import TelegramAdapter  # noqa: E402
+
+
+@pytest.fixture(autouse=True)
+def _no_auto_discovery(monkeypatch):
+    """Disable DoH auto-discovery so connect() uses the plain builder chain."""
+    async def _noop():
+        return []
+    monkeypatch.setattr("gateway.platforms.telegram.discover_fallback_ips", _noop)
+
+
+def _make_adapter() -> TelegramAdapter:
+    return TelegramAdapter(PlatformConfig(enabled=True, token="test-token"))
+
+
+def _make_running_app():
+    mock_updater = MagicMock()
+    mock_updater.running = True
+    mock_updater.stop = AsyncMock()
+    mock_updater.start_polling = AsyncMock()
+
+    mock_app = MagicMock()
+    mock_app.updater = mock_updater
+    return mock_app
+
+
+# ── _refresh_poll_liveness ─────────────────────────────────────────────────
+
+def test_refresh_poll_liveness_updates_timestamp():
+    """_refresh_poll_liveness should set _last_successful_poll_at to now."""
+    adapter = _make_adapter()
+    before = time.monotonic()
+    adapter._refresh_poll_liveness()
+    after = time.monotonic()
+
+    assert adapter._last_successful_poll_at is not None
+    assert before <= adapter._last_successful_poll_at <= after
+
+
+def test_refresh_poll_liveness_idempotent():
+    """Multiple calls to _refresh_poll_liveness always advance the timestamp."""
+    adapter = _make_adapter()
+    adapter._refresh_poll_liveness()
+    t1 = adapter._last_successful_poll_at
+    # Tiny sleep so monotonic clock can advance
+    time.sleep(0.01)
+    adapter._refresh_poll_liveness()
+    t2 = adapter._last_successful_poll_at
+
+    assert t2 is not None and t1 is not None
+    assert t2 >= t1
+
+
+# ── Watchdog disabled ──────────────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_watchdog_disabled_when_timeout_zero(monkeypatch):
+    """Watchdog returns immediately without any sleeps when timeout=0."""
+    monkeypatch.setenv("HERMES_POLL_LIVENESS_TIMEOUT", "0")
+    adapter = _make_adapter()
+
+    sleep_calls = []
+    async def _fake_sleep(t):
+        sleep_calls.append(t)
+
+    with patch("asyncio.sleep", side_effect=_fake_sleep):
+        await adapter._start_poll_liveness_watchdog()
+
+    assert sleep_calls == [], "Watchdog must not sleep when disabled"
+
+
+# ── Watchdog fires on timeout ──────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_watchdog_fires_reconnect_on_liveness_timeout(monkeypatch):
+    """
+    When the liveness timestamp is older than the timeout AND the updater is
+    running, the watchdog must call _handle_polling_network_error (full
+    teardown+reconnect path).
+
+    The watchdog seeds self._last_successful_poll_at at startup via
+    time.monotonic(), so we mock time.monotonic to return T0 for the seed
+    and T0 + 200 for the age check (200s >> 60s timeout).
+    """
+    monkeypatch.setenv("HERMES_POLL_LIVENESS_TIMEOUT", "60")
+    adapter = _make_adapter()
+    adapter._app = _make_running_app()
+    adapter._webhook_mode = False
+
+    # Mock time.monotonic so the watchdog sees an expired timestamp:
+    # call 1 = seed (T0), all subsequent = T0 + 200 (well past 60s timeout).
+    T0 = 1_000_000.0
+    call_count = 0
+
+    def _mock_monotonic() -> float:
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            return T0  # watchdog seeds _last_successful_poll_at = T0
+        return T0 + 200.0  # age = 200s > 60s timeout
+
+    reconnect_calls: list = []
+
+    async def _fake_reconnect(err):
+        reconnect_calls.append(err)
+
+    adapter._handle_polling_network_error = _fake_reconnect  # type: ignore[method-assign]
+
+    # Let the watchdog run one full check cycle then stop
+    sleep_count = 0
+
+    async def _controlled_sleep(t):
+        nonlocal sleep_count
+        sleep_count += 1
+        if sleep_count >= 2:
+            raise StopAsyncIteration("stop after one cycle")
+
+    with patch("gateway.platforms.telegram.time.monotonic", side_effect=_mock_monotonic):
+        with patch("asyncio.sleep", side_effect=_controlled_sleep):
+            with pytest.raises(StopAsyncIteration):
+                await adapter._start_poll_liveness_watchdog()
+
+    assert len(reconnect_calls) == 1, (
+        f"Expected exactly 1 reconnect call, got {len(reconnect_calls)}"
+    )
+    err_msg = str(reconnect_calls[0])
+    assert "liveness timeout" in err_msg.lower() or "Poll liveness" in err_msg
+
+
+@pytest.mark.asyncio
+async def test_watchdog_does_not_fire_when_liveness_fresh(monkeypatch):
+    """
+    When the liveness timestamp is recent (within the timeout window), the
+    watchdog must NOT fire a reconnect.
+    """
+    monkeypatch.setenv("HERMES_POLL_LIVENESS_TIMEOUT", "300")
+    adapter = _make_adapter()
+    adapter._app = _make_running_app()
+    adapter._webhook_mode = False
+
+    # Fresh timestamp — should not trigger
+    adapter._last_successful_poll_at = time.monotonic()
+
+    reconnect_calls: list = []
+
+    async def _fake_reconnect(err):
+        reconnect_calls.append(err)
+
+    adapter._handle_polling_network_error = _fake_reconnect  # type: ignore[method-assign]
+
+    sleep_count = 0
+
+    async def _controlled_sleep(t):
+        nonlocal sleep_count
+        sleep_count += 1
+        if sleep_count >= 2:
+            raise StopAsyncIteration("stop after one cycle")
+
+    with patch("asyncio.sleep", side_effect=_controlled_sleep):
+        with pytest.raises(StopAsyncIteration):
+            await adapter._start_poll_liveness_watchdog()
+
+    assert reconnect_calls == [], "Watchdog must not fire when liveness is fresh"
+
+
+# ── Guard conditions ───────────────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_watchdog_exits_on_fatal_error(monkeypatch):
+    """
+    When has_fatal_error is True (adapter shutting down), the watchdog must
+    return without triggering a reconnect.
+
+    The watchdog returns after the first sleep when fatal_error is set — so
+    we let it run to natural completion (no StopAsyncIteration needed).
+    """
+    monkeypatch.setenv("HERMES_POLL_LIVENESS_TIMEOUT", "60")
+    adapter = _make_adapter()
+    adapter._app = _make_running_app()
+    adapter._webhook_mode = False
+
+    # Simulate fatal error already set
+    adapter._set_fatal_error("test", "simulated fatal", retryable=False)
+
+    reconnect_calls: list = []
+
+    async def _fake_reconnect(err):
+        reconnect_calls.append(err)
+
+    adapter._handle_polling_network_error = _fake_reconnect  # type: ignore[method-assign]
+
+    # Watchdog sleeps once then returns when it sees has_fatal_error=True.
+    # We allow that one sleep so the function completes naturally.
+    async def _noop_sleep(t):
+        pass
+
+    with patch("asyncio.sleep", side_effect=_noop_sleep):
+        await adapter._start_poll_liveness_watchdog()
+
+    assert reconnect_calls == [], (
+        "Watchdog must not fire reconnect when adapter has a fatal error"
+    )
+
+
+@pytest.mark.asyncio
+async def test_watchdog_skips_in_webhook_mode(monkeypatch):
+    """
+    Webhook mode doesn't use getUpdates — watchdog must return without
+    triggering a reconnect.
+
+    The watchdog returns after the first sleep when _webhook_mode is True.
+    """
+    monkeypatch.setenv("HERMES_POLL_LIVENESS_TIMEOUT", "60")
+    adapter = _make_adapter()
+    adapter._app = _make_running_app()
+    adapter._webhook_mode = True
+
+    reconnect_calls: list = []
+
+    async def _fake_reconnect(err):
+        reconnect_calls.append(err)
+
+    adapter._handle_polling_network_error = _fake_reconnect  # type: ignore[method-assign]
+
+    # Watchdog sleeps once then returns when it sees _webhook_mode=True.
+    async def _noop_sleep(t):
+        pass
+
+    with patch("asyncio.sleep", side_effect=_noop_sleep):
+        await adapter._start_poll_liveness_watchdog()
+
+    assert reconnect_calls == [], (
+        "Watchdog must not fire reconnect in webhook mode"
+    )
+
+
+@pytest.mark.asyncio
+async def test_watchdog_skips_when_updater_not_running(monkeypatch):
+    """
+    When updater.running is False, a reconnect is already in flight via the
+    error callback path — watchdog must not double-trigger.
+    """
+    monkeypatch.setenv("HERMES_POLL_LIVENESS_TIMEOUT", "60")
+    adapter = _make_adapter()
+
+    mock_updater = MagicMock()
+    mock_updater.running = False  # updater is stopped / reconnect in flight
+    mock_app = MagicMock()
+    mock_app.updater = mock_updater
+    adapter._app = mock_app
+    adapter._webhook_mode = False
+    adapter._last_successful_poll_at = time.monotonic() - 120  # expired
+
+    reconnect_calls: list = []
+
+    async def _fake_reconnect(err):
+        reconnect_calls.append(err)
+
+    adapter._handle_polling_network_error = _fake_reconnect  # type: ignore[method-assign]
+
+    sleep_count = 0
+
+    async def _controlled_sleep(t):
+        nonlocal sleep_count
+        sleep_count += 1
+        if sleep_count >= 2:
+            raise StopAsyncIteration("stop")
+
+    with patch("asyncio.sleep", side_effect=_controlled_sleep):
+        with pytest.raises(StopAsyncIteration):
+            await adapter._start_poll_liveness_watchdog()
+
+    assert reconnect_calls == [], (
+        "Watchdog must not fire when updater.running is False (reconnect already in flight)"
+    )
+
+
+# ── Log message accuracy ───────────────────────────────────────────────────
+
+def test_reconnect_log_message_wording():
+    """
+    The 'polling resumed' log message must be replaced with 'reconnect
+    initiated — awaiting first getUpdates cycle to confirm liveness' so that
+    the message accurately reflects what has (and hasn't) happened.
+
+    Regression guard: the OLD wording said 'Telegram polling resumed after
+    network error' which was misleading — start_polling() returning doesn't
+    mean the long-poll loop is actually alive.
+    """
+    import inspect
+    import gateway.platforms.telegram as tg_module
+
+    source = inspect.getsource(tg_module)
+
+    old_misleading_phrase = "polling resumed after network error"
+    assert old_misleading_phrase not in source, (
+        f"Misleading log phrase '{old_misleading_phrase}' still present in telegram.py — "
+        "it should be replaced with wording that reflects the reconnect is only initiated, "
+        "not confirmed"
+    )
+
+    new_accurate_phrase = "reconnect initiated"
+    assert new_accurate_phrase in source, (
+        f"Expected accurate log phrase '{new_accurate_phrase}' in telegram.py"
+    )


### PR DESCRIPTION
## Problem

All three Hermes agent gateways (default/Archie, cto/Alexey, Pepper) went
silently unresponsive on Telegram on 2026-06-16. In each case:
- Process stayed ALIVE (2.5–6h uptime, ~0% CPU)
- User messages reached Telegram (single-check delivered) but never appeared in gateway logs
- Gateway log showed 'telegram connected' / 'polling resumed' but NO further inbound for hours
- In Archie's case the cron ticker (60s interval) also went silent for 2.5h (asyncio event loop stall)

**Root cause:** Transient network errors (httpx.ReadError ~09:59, Bad Gateway/TimedOut ~10:28–10:33) triggered the reconnect path. The reconnect path logged 'Telegram polling resumed after network error' but the long-poll loop was actually dead afterwards. The 'resumed' log fired when start_polling() returned, not when getUpdates actually resumed.

**Recovery complexity:** A soft gateway restart is NOT enough — the old hung poller holds Telegram's getUpdates slot open server-side, causing HTTP 409 Conflict on the new instance. Only a full STOP + confirm-dead + START clears it.

## Changes

### polling-liveness watchdog (telegram.py)
-  — called at the top of every inbound-update handler (text, command, callback, media, location) to track the last time getUpdates actually delivered
-  — background asyncio task that forces a full teardown+reconnect (not a soft resume) when no update has been received for  seconds while  is True
  - Guards: skips in webhook mode, skips when updater.running=False (reconnect already in flight), exits on fatal error
- Launched alongside polling at connect(); cancelled cleanly at disconnect()
- Fix misleading log: 'polling resumed after network error' → 'reconnect initiated — awaiting first getUpdates cycle to confirm liveness'
- Add confirmation log when getMe() probe succeeds post-reconnect

### event-loop liveness probe (run.py)
- Added to : every 5 ticks (5 min), submits a no-op coroutine to the asyncio event loop and waits up to 30s
- First breach → WARNING; second breach (≥2x timeout elapsed) → ERROR + os._exit(1) so launchd/systemd can restart
- Controlled by  env var (default 600s, 0=disabled)
- Bridge  from config.yaml → env var at startup (was missing; loop_liveness was already bridged)

### config.py
- Add  and  to DEFAULT_CONFIG agent section
- Settings in config.yaml under `agent:`, NOT .env

## Tests
9 new tests in `tests/gateway/test_telegram_poll_liveness.py`:
- _refresh_poll_liveness updates timestamp correctly
- Watchdog disabled when timeout=0
- Watchdog fires reconnect on liveness timeout (mocks time.monotonic)
- Watchdog does NOT fire when liveness is fresh
- Watchdog exits on fatal error without reconnect
- Watchdog skips in webhook mode
- Watchdog skips when updater.running=False
- Regression guard on log message wording