### PR TITLE
fix: show Codex gpt-5.5 auto-raise notice once

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -27,7 +27,7 @@ import threading
 import time
 import uuid
 from datetime import datetime
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, cast
 from urllib.parse import urlparse, parse_qs, urlunparse
 
 from agent.context_compressor import ContextCompressor
@@ -84,6 +84,27 @@ def _build_codex_gpt55_autoraise_notice(autoraise: Dict[str, float]) -> str:
         f"summarizing.\n"
         f"  Opt back out: hermes config set compression.codex_gpt55_autoraise false"
     )
+
+
+def _codex_gpt55_autoraise_notice_seen(config: Dict[str, Any]) -> bool:
+    """Return True if the Codex gpt-5.5 auto-raise notice was already shown."""
+    try:
+        from agent.onboarding import CODEX_GPT55_AUTORAISE_FLAG, is_seen
+
+        return is_seen(config, CODEX_GPT55_AUTORAISE_FLAG)
+    except Exception:
+        return False
+
+
+def _mark_codex_gpt55_autoraise_notice_seen() -> bool:
+    """Best-effort persistence for the Codex gpt-5.5 auto-raise notice."""
+    try:
+        from agent.onboarding import CODEX_GPT55_AUTORAISE_FLAG, mark_seen
+        from hermes_cli.config import get_config_path
+
+        return mark_seen(get_config_path(), CODEX_GPT55_AUTORAISE_FLAG)
+    except Exception:
+        return False
 
 
 def _normalized_custom_base_url(value: Any) -> str:
@@ -1650,29 +1671,48 @@ def init_agent(
             agent._ollama_num_ctx,
         )
 
+    # Check immediately so CLI users see the warning at startup.
+    # Gateway status_callback is not yet wired, so any warning is stored
+    # in _compression_warning and replayed in the first run_conversation().
+    agent._compression_warning = None
+    agent._compression_warning_seen_flag = None
+    agent._compression_warning_config_path = None
+
+    # First-touch notice when the Codex gpt-5.5 autoraise kicked in. Persist it
+    # under onboarding.seen so the useful default stays enabled without
+    # announcing itself on every new session.
+    _autoraise = getattr(agent, "_compression_threshold_autoraised", None)
+    _autoraise_notice = (
+        cast(Dict[str, float], _autoraise) if isinstance(_autoraise, dict) else None
+    )
+    _show_autoraise_notice = bool(
+        _autoraise_notice is not None
+        and compression_enabled
+        and not _codex_gpt55_autoraise_notice_seen(_agent_cfg)
+    )
+
     if not agent.quiet_mode:
         if compression_enabled:
             print(f"📊 Context limit: {agent.context_compressor.context_length:,} tokens (compress at {int(compression_threshold*100)}% = {agent.context_compressor.threshold_tokens:,})")
         else:
             print(f"📊 Context limit: {agent.context_compressor.context_length:,} tokens (auto-compression disabled)")
-        # One-time notice when the Codex gpt-5.5 autoraise kicked in, with the
-        # exact opt-back-out command. Printed inline at startup for CLI users;
-        # gateway users get the same text replayed via _compression_warning on
-        # turn 1 (set below, after the warning slot is initialized).
-        _autoraise = getattr(agent, "_compression_threshold_autoraised", None)
-        if _autoraise and compression_enabled:
-            print(_build_codex_gpt55_autoraise_notice(_autoraise))
+        if _show_autoraise_notice and _autoraise_notice is not None:
+            print(_build_codex_gpt55_autoraise_notice(_autoraise_notice))
+            _mark_codex_gpt55_autoraise_notice_seen()
 
-    # Check immediately so CLI users see the warning at startup.
-    # Gateway status_callback is not yet wired, so any warning is stored
-    # in _compression_warning and replayed in the first run_conversation().
-    agent._compression_warning = None
     # Gateway parity for the Codex gpt-5.5 autoraise notice: the startup print
     # above only reaches the CLI, so stash the same text here to be replayed
     # through status_callback on the first turn (Telegram/Discord/Slack/etc.).
-    _autoraise = getattr(agent, "_compression_threshold_autoraised", None)
-    if _autoraise and compression_enabled:
-        agent._compression_warning = _build_codex_gpt55_autoraise_notice(_autoraise)
+    if _show_autoraise_notice and _autoraise_notice is not None:
+        agent._compression_warning = _build_codex_gpt55_autoraise_notice(_autoraise_notice)
+        try:
+            from agent.onboarding import CODEX_GPT55_AUTORAISE_FLAG
+            from hermes_cli.config import get_config_path
+
+            agent._compression_warning_seen_flag = CODEX_GPT55_AUTORAISE_FLAG
+            agent._compression_warning_config_path = get_config_path()
+        except Exception:
+            pass
     # Lazy feasibility check: deferred to the first turn that approaches the
     # compression threshold. Running it eagerly here costs ~400ms cold (network
     # probe of the auxiliary provider chain + /models lookup) on every agent

--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -271,11 +271,32 @@ def replay_compression_warning(agent: Any) -> None:
     warning.
     """
     msg = getattr(agent, "_compression_warning", None)
-    if msg and agent.status_callback:
+    if not msg:
+        return
+
+    delivered = False
+    if agent.status_callback:
         try:
             agent.status_callback("lifecycle", msg)
+            delivered = True
         except Exception:
             pass
+
+    # Some compression notices are first-touch onboarding, not recurring
+    # health warnings. Mark those only after an actual delivery so quiet CLI
+    # one-shots do not consume the notice unseen.
+    flag = getattr(agent, "_compression_warning_seen_flag", None)
+    config_path = getattr(agent, "_compression_warning_config_path", None)
+    if delivered and flag and config_path:
+        try:
+            from agent.onboarding import mark_seen
+
+            mark_seen(Path(config_path), str(flag))
+        except Exception:
+            pass
+    if flag:
+        agent._compression_warning_seen_flag = None
+        agent._compression_warning_config_path = None
 
 
 def compress_context(

--- a/agent/onboarding.py
+++ b/agent/onboarding.py
@@ -27,6 +27,7 @@ BUSY_INPUT_FLAG = "busy_input_prompt"
 TOOL_PROGRESS_FLAG = "tool_progress_prompt"
 OPENCLAW_RESIDUE_FLAG = "openclaw_residue_cleanup"
 PROFILE_BUILD_FLAG = "profile_build_offered"
+CODEX_GPT55_AUTORAISE_FLAG = "codex_gpt55_autoraise_notice"
 
 
 # -------------------------------------------------------------------------
@@ -240,6 +241,7 @@ __all__ = [
     "TOOL_PROGRESS_FLAG",
     "OPENCLAW_RESIDUE_FLAG",
     "PROFILE_BUILD_FLAG",
+    "CODEX_GPT55_AUTORAISE_FLAG",
     "busy_input_hint_gateway",
     "busy_input_hint_cli",
     "tool_progress_hint_gateway",

--- a/tests/agent/test_onboarding.py
+++ b/tests/agent/test_onboarding.py
@@ -4,8 +4,10 @@ from __future__ import annotations
 
 import yaml
 
+from agent.agent_init import _codex_gpt55_autoraise_notice_seen
 from agent.onboarding import (
     BUSY_INPUT_FLAG,
+    CODEX_GPT55_AUTORAISE_FLAG,
     OPENCLAW_RESIDUE_FLAG,
     TOOL_PROGRESS_FLAG,
     busy_input_hint_cli,
@@ -43,6 +45,11 @@ class TestIsSeen:
     def test_other_flags_isolated(self):
         cfg = {"onboarding": {"seen": {BUSY_INPUT_FLAG: True}}}
         assert is_seen(cfg, TOOL_PROGRESS_FLAG) is False
+
+    def test_codex_gpt55_autoraise_notice_seen_helper(self):
+        cfg = {"onboarding": {"seen": {CODEX_GPT55_AUTORAISE_FLAG: True}}}
+        assert _codex_gpt55_autoraise_notice_seen(cfg) is True
+        assert _codex_gpt55_autoraise_notice_seen({}) is False
 
 
 class TestMarkSeen:

--- a/tests/run_agent/test_compression_feasibility.py
+++ b/tests/run_agent/test_compression_feasibility.py
@@ -11,9 +11,11 @@ Two-phase design:
 from unittest.mock import MagicMock, patch
 
 import pytest
+import yaml
 
 from run_agent import AIAgent
 from agent.context_compressor import ContextCompressor
+from agent.onboarding import CODEX_GPT55_AUTORAISE_FLAG
 
 
 @pytest.fixture(autouse=True)
@@ -437,6 +439,44 @@ def test_replay_without_callback_is_noop():
 
     # Should not raise
     agent._replay_compression_warning()
+
+
+def test_replay_marks_first_touch_compression_notice_seen(tmp_path):
+    """Gateway replay persists first-touch notices after actual delivery."""
+    cfg_path = tmp_path / "config.yaml"
+    cfg_path.write_text("compression:\n  threshold: 0.5\n", encoding="utf-8")
+    agent = _make_agent()
+    setattr(agent, "_compression_warning", "Codex gpt-5.5 auto-raise notice")
+    setattr(agent, "_compression_warning_seen_flag", CODEX_GPT55_AUTORAISE_FLAG)
+    setattr(agent, "_compression_warning_config_path", cfg_path)
+    callback_events = []
+    setattr(agent, "status_callback", lambda ev, msg: callback_events.append((ev, msg)))
+
+    agent._replay_compression_warning()
+
+    assert callback_events == [("lifecycle", "Codex gpt-5.5 auto-raise notice")]
+    loaded = yaml.safe_load(cfg_path.read_text(encoding="utf-8"))
+    assert loaded["onboarding"]["seen"][CODEX_GPT55_AUTORAISE_FLAG] is True
+    assert getattr(agent, "_compression_warning_seen_flag") is None
+    assert getattr(agent, "_compression_warning_config_path") is None
+
+
+def test_replay_does_not_mark_first_touch_notice_without_delivery(tmp_path):
+    """Quiet/no-callback runs must not consume a notice the user never saw."""
+    cfg_path = tmp_path / "config.yaml"
+    cfg_path.write_text("compression:\n  threshold: 0.5\n", encoding="utf-8")
+    agent = _make_agent()
+    setattr(agent, "_compression_warning", "Codex gpt-5.5 auto-raise notice")
+    setattr(agent, "_compression_warning_seen_flag", CODEX_GPT55_AUTORAISE_FLAG)
+    setattr(agent, "_compression_warning_config_path", cfg_path)
+    setattr(agent, "status_callback", None)
+
+    agent._replay_compression_warning()
+
+    loaded = yaml.safe_load(cfg_path.read_text(encoding="utf-8"))
+    assert loaded == {"compression": {"threshold": 0.5}}
+    assert getattr(agent, "_compression_warning_seen_flag") is None
+    assert getattr(agent, "_compression_warning_config_path") is None
 
 
 @patch("agent.model_metadata.get_model_context_length", return_value=80_000)


### PR DESCRIPTION
## Summary
- persist the Codex gpt-5.5 compaction auto-raise notice in onboarding.seen after it is actually delivered
- skip the notice on later sessions while keeping compression.codex_gpt55_autoraise enabled
- keep quiet/no-callback runs from consuming the notice unseen

## Tests
- uv run --extra dev python -m pytest tests/agent/test_arcee_trinity_overrides.py tests/agent/test_onboarding.py tests/run_agent/test_compression_feasibility.py -q -o 'addopts='
- uv run --extra dev ruff check agent/agent_init.py agent/conversation_compression.py agent/onboarding.py tests/agent/test_onboarding.py tests/run_agent/test_compression_feasibility.py

Assisted-by: vasyl