### PR TITLE
fix(kanban): sweep deferred scratch parent on archive_task

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -4628,6 +4628,11 @@ def archive_task(conn: sqlite3.Connection, task_id: str) -> bool:
     # Promote newly-unblocked dependents immediately instead of waiting
     # for a later dispatcher tick.
     recompute_ready(conn)
+    # Archiving a child task transitions it to a terminal state, which may
+    # unblock a scratch parent that deferred its own cleanup (#33774). Mirror
+    # the complete_task path: clean up this task's own scratch workspace and
+    # sweep any parent whose deferred cleanup is now unblocked.
+    _cleanup_workspace(conn, task_id)
     return True
 
 

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -2736,6 +2736,33 @@ def test_unlink_tasks_triggers_recompute_ready(kanban_home):
         )
 
 
+def test_archive_child_sweeps_deferred_scratch_parent(kanban_home):
+    """Archiving a child task must sweep a deferred scratch-workspace parent.
+
+    Regression for the gap where ``archive_task`` never called
+    ``_cleanup_workspace`` / ``_try_cleanup_parent_workspaces``, leaving the
+    parent's scratch dir stranded when a child is archived instead of
+    completed via ``complete_task``.
+    """
+    with kb.connect() as conn:
+        parent = kb.create_task(conn, title="scratch parent")
+        child = kb.create_task(conn, title="child task")
+        kb.link_tasks(conn, parent, child)
+        p_task = kb.get_task(conn, parent)
+        parent_ws = kb.resolve_workspace(p_task)
+        kb.set_workspace_path(conn, parent, parent_ws)
+
+        kb.complete_task(conn, parent, result="handoff")
+        assert parent_ws.exists(), "cleanup must be deferred while child is active"
+
+        kb.archive_task(conn, child)
+
+    assert not parent_ws.exists(), (
+        "archiving the last active child must trigger the deferred parent "
+        "scratch workspace cleanup"
+    )
+
+
 def test_archive_task_triggers_recompute_ready_for_dependents(kanban_home):
     """Archiving a parent must immediately unblock its children.
 


### PR DESCRIPTION
## Problem

`archive_task()` transitions a child task to the terminal `archived` state but never calls `_cleanup_workspace()` or `_try_cleanup_parent_workspaces()`.

When a scratch-workspace parent completes while a child is still active, cleanup is **deferred** (added in #33774). That deferred cleanup is only triggered when a child transitions to a terminal state *via `complete_task`*. If a user archives the child instead — e.g. a stuck/blocked child being manually dismissed — the parent's scratch temp directory leaks and is never removed.

**Reproduction:**
1. Create a `scratch`-workspace parent task + child task (linked)
2. `complete_task` the parent → cleanup deferred (child still active)
3. `archive_task` the child → parent scratch dir persists forever

## Fix

Call `_cleanup_workspace(conn, task_id)` at the end of `archive_task()`, after the DB write and `recompute_ready`. This mirrors the `complete_task` path and handles two cases:

- If the archived task itself has a `scratch` workspace, that directory is removed (containment-guarded as usual).
- `_try_cleanup_parent_workspaces` is then called, triggering deferred parent cleanup if all siblings are now terminal.

## Tests

Added `test_archive_child_sweeps_deferred_scratch_parent` — creates parent+child, completes the parent (deferred), archives the child, asserts the parent scratch dir is cleaned up.

Full `test_kanban_db.py` suite: **215 passed**.

## Related

- Original deferred-cleanup PR: #33774 / `9405cd081`
- Non-scratch child sibling fix: `76f01780f` (follow-up that added the parent sweep for `dir`/`worktree` children completing via `complete_task`)
- This PR closes the same gap for children reaching terminal state via `archive_task`

## Checklist

- [x] Root cause identified (`archive_task` skips `_cleanup_workspace`)
- [x] Fix adds `_cleanup_workspace` call matching `complete_task` pattern
- [x] Regression test added
- [x] All 215 kanban tests pass