### PR TITLE
feat(xai): default to grok-build-0.1

### DIFF
--- a/hermes_cli/model_setup_flows.py
+++ b/hermes_cli/model_setup_flows.py
@@ -517,7 +517,7 @@ def _model_flow_xai_oauth(_config, current_model="", *, args=None):
         pass
 
     models = list(_PROVIDER_MODELS.get("xai-oauth") or _PROVIDER_MODELS.get("xai") or [])
-    selected = _prompt_model_selection(models, current_model=current_model or (models[0] if models else "grok-4.3"))
+    selected = _prompt_model_selection(models, current_model=current_model or (models[0] if models else "grok-build-0.1"))
     if selected:
         _save_model_choice(selected)
         _update_config_for_provider("xai-oauth", base_url)

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -109,6 +109,7 @@ def _codex_curated_models() -> list[str]:
 # (grok-4, grok-4-0709, grok-4-fast{,-reasoning,-non-reasoning},
 #  grok-4-1-fast{,-reasoning,-non-reasoning}, grok-code-fast-1 → grok-4.3).
 _XAI_STATIC_FALLBACK: list[str] = [
+    "grok-build-0.1",
     "grok-4.3",
     "grok-4.20-0309-reasoning",
     "grok-4.20-0309-non-reasoning",
@@ -116,7 +117,7 @@ _XAI_STATIC_FALLBACK: list[str] = [
 ]
 
 
-_XAI_TOP_MODEL = "grok-4.3"
+_XAI_TOP_MODEL = "grok-build-0.1"
 
 
 def _xai_promote_top(ids: list[str]) -> list[str]:

--- a/plugins/web/xai/provider.py
+++ b/plugins/web/xai/provider.py
@@ -19,7 +19,7 @@ Optional knobs (under ``web.xai`` in ``config.yaml``)::
 
     web:
       xai:
-        model: "grok-4.3"             # reasoning model required by web_search
+        model: "grok-build-0.1"       # reasoning model required by web_search
         allowed_domains: ["x.ai"]     # max 5 — mutually exclusive with excluded_domains
         excluded_domains: ["bad.com"] # max 5 — mutually exclusive with allowed_domains
         timeout: 90                   # seconds (default 90)

--- a/plugins/web/xai/provider.py
+++ b/plugins/web/xai/provider.py
@@ -46,7 +46,7 @@ from tools.xai_http import (
 
 logger = logging.getLogger(__name__)
 
-DEFAULT_MODEL = "grok-4.3"
+DEFAULT_MODEL = "grok-build-0.1"
 DEFAULT_TIMEOUT = 90
 _MAX_DOMAIN_FILTERS = 5  # xAI hard cap on allowed_domains / excluded_domains
 

--- a/website/docs/guides/xai-grok-oauth.md
+++ b/website/docs/guides/xai-grok-oauth.md
@@ -22,7 +22,7 @@ The same OAuth bearer token is also reused by every direct-to-xAI surface in Her
 | Display name | xAI Grok OAuth (SuperGrok / X Premium+) |
 | Auth type | Browser OAuth 2.0 PKCE (loopback callback) |
 | Transport | xAI Responses API (`codex_responses`) |
-| Default model | `grok-4.3` |
+| Default model | `grok-build-0.1` |
 | Endpoint | `https://api.x.ai/v1` |
 | Auth server | `https://accounts.x.ai` |
 | Requires env var | No (`XAI_API_KEY` is **not** used for this provider) |
@@ -47,7 +47,7 @@ hermes model
 # → Select "xAI Grok OAuth (SuperGrok / X Premium+)" from the provider list
 # → Hermes opens your browser to accounts.x.ai
 # → Approve access in the browser
-# → Pick a model (grok-4.3 is at the top)
+# → Pick a model (grok-build-0.1 is at the top)
 # → Start chatting
 
 hermes
@@ -116,13 +116,13 @@ The `◆ Auth Providers` section will show the current state of every provider, 
 ```bash
 hermes model
 # → Select "xAI Grok OAuth (SuperGrok / X Premium+)"
-# → Pick from the model list (grok-4.3 is pinned to the top)
+# → Pick from the model list (grok-build-0.1 is pinned to the top)
 ```
 
 Or set the model directly:
 
 ```bash
-hermes config set model.default grok-4.3
+hermes config set model.default grok-build-0.1
 hermes config set model.provider xai-oauth
 ```
 
@@ -132,7 +132,7 @@ After login, `~/.hermes/config.yaml` will contain:
 
 ```yaml
 model:
-  default: grok-4.3
+  default: grok-build-0.1
   provider: xai-oauth
   base_url: https://api.x.ai/v1
 ```
@@ -176,7 +176,8 @@ The `x_search` toolset auto-enables whenever xAI credentials (a SuperGrok / X Pr
 
 | Tool | Model | Notes |
 |------|-------|-------|
-| Chat | `grok-4.3` | Default; auto-selected when you log in via OAuth |
+| Chat | `grok-build-0.1` | Default; auto-selected when you log in via OAuth |
+| Chat | `grok-4.3` | Previous default |
 | Chat | `grok-4.20-0309-reasoning` | Reasoning variant |
 | Chat | `grok-4.20-0309-non-reasoning` | Non-reasoning variant |
 | Chat | `grok-4.20-multi-agent-0309` | Multi-agent variant |
@@ -186,7 +187,7 @@ The `x_search` toolset auto-enables whenever xAI credentials (a SuperGrok / X Pr
 | Video | `grok-imagine-video-1.5-preview` | Image-to-video; dated alias `grok-imagine-video-1.5-2026-05-30` |
 | TTS | (default voice) | xAI `/v1/tts` endpoint |
 
-The chat catalog is derived live from the on-disk `models.dev` cache; new xAI releases appear automatically once that cache refreshes. `grok-4.3` is always pinned to the top of the list.
+The chat catalog is derived live from the on-disk `models.dev` cache; new xAI releases appear automatically once that cache refreshes. `grok-build-0.1` is always pinned to the top of the list.
 
 ## Environment Variables
 

--- a/website/docs/user-guide/features/web-search.md
+++ b/website/docs/user-guide/features/web-search.md
@@ -305,7 +305,7 @@ web:
 web:
   backend: "xai"
   xai:
-    model: grok-4.3              # reasoning model required by web_search (default)
+    model: grok-build-0.1        # reasoning model required by web_search (default)
     allowed_domains:             # optional, max 5 — mutex with excluded_domains
       - arxiv.org
     excluded_domains:            # optional, max 5

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/guides/xai-grok-oauth.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/guides/xai-grok-oauth.md
@@ -22,7 +22,7 @@ Hermes Agent 通过基于浏览器的 OAuth 登录流程支持 xAI Grok，认证
 | 显示名称 | xAI Grok OAuth (SuperGrok / X Premium+) |
 | 认证类型 | 浏览器 OAuth 2.0 PKCE（回环回调） |
 | 传输层 | xAI Responses API（`codex_responses`） |
-| 默认模型 | `grok-4.3` |
+| 默认模型 | `grok-build-0.1` |
 | 端点 | `https://api.x.ai/v1` |
 | 认证服务器 | `https://accounts.x.ai` |
 | 需要环境变量 | 否（此 provider 不使用 `XAI_API_KEY`） |
@@ -47,7 +47,7 @@ hermes model
 # → 从 provider 列表中选择 "xAI Grok OAuth (SuperGrok / X Premium+)"
 # → Hermes 在浏览器中打开 accounts.x.ai
 # → 在浏览器中批准访问
-# → 选择模型（grok-4.3 在列表顶部）
+# → 选择模型（grok-build-0.1 在列表顶部）
 # → 开始对话
 
 hermes
@@ -114,13 +114,13 @@ hermes doctor
 ```bash
 hermes model
 # → 选择 "xAI Grok OAuth (SuperGrok / X Premium+)"
-# → 从模型列表中选择（grok-4.3 固定在顶部）
+# → 从模型列表中选择（grok-build-0.1 固定在顶部）
 ```
 
 或直接设置模型：
 
 ```bash
-hermes config set model.default grok-4.3
+hermes config set model.default grok-build-0.1
 hermes config set model.provider xai-oauth
 ```
 
@@ -130,7 +130,7 @@ hermes config set model.provider xai-oauth
 
 ```yaml
 model:
-  default: grok-4.3
+  default: grok-build-0.1
   provider: xai-oauth
   base_url: https://api.x.ai/v1
 ```
@@ -174,7 +174,8 @@ hermes tools
 
 | 工具 | 模型 | 说明 |
 |------|-------|-------|
-| 对话 | `grok-4.3` | 默认；通过 OAuth 登录时自动选择 |
+| 对话 | `grok-build-0.1` | 默认；通过 OAuth 登录时自动选择 |
+| 对话 | `grok-4.3` | 之前的默认 |
 | 对话 | `grok-4.20-0309-reasoning` | 推理变体 |
 | 对话 | `grok-4.20-0309-non-reasoning` | 非推理变体 |
 | 对话 | `grok-4.20-multi-agent-0309` | 多 agent 变体 |
@@ -184,7 +185,7 @@ hermes tools
 | 视频 | `grok-imagine-video-1.5-preview` | 图像转视频；日期别名 `grok-imagine-video-1.5-2026-05-30` |
 | TTS | （默认音色） | xAI `/v1/tts` 端点 |
 
-对话模型目录从磁盘上的 `models.dev` 缓存实时获取；缓存刷新后，新的 xAI 模型会自动出现。`grok-4.3` 始终固定在列表顶部。
+对话模型目录从磁盘上的 `models.dev` 缓存实时获取；缓存刷新后，新的 xAI 模型会自动出现。`grok-build-0.1` 始终固定在列表顶部。
 
 ## 环境变量
 

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/features/web-search.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/features/web-search.md
@@ -305,7 +305,7 @@ web:
 web:
   backend: "xai"
   xai:
-    model: grok-4.3              # web_search 所需的推理模型（默认）
+    model: grok-build-0.1        # web_search 所需的推理模型（默认）
     allowed_domains:             # 可选，最多 5 个——与 excluded_domains 互斥
       - arxiv.org
     excluded_domains:            # 可选，最多 5 个


### PR DESCRIPTION
## What does this PR do?

Switches the default model for the xAI / Grok provider from `grok-4.3` to `grok-build-0.1`. This is the model selected by default when no model is explicitly configured for the xAI / Grok provider, and the default model the xAI web-search backend uses when `web.xai.model` is unset.

`grok-build-0.1` is already recognized by the model metadata (`agent/model_metadata.py` maps the `grok-build` prefix to a context length), so no new model definition is required and `grok-4.3` remains a selectable option.

## Related Issue

N/A — no related issue.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/models.py`: set `_XAI_TOP_MODEL` to `grok-build-0.1` (pins it to the top of the curated xAI list returned by `get_default_model_for_provider` for `xai` / `xai-oauth`) and add `grok-build-0.1` as the first entry of `_XAI_STATIC_FALLBACK` (the offline / fresh-install fallback). `grok-4.3` is kept in the list.
- `plugins/web/xai/provider.py`: set `DEFAULT_MODEL` to `grok-build-0.1` for the xAI web-search backend, and update the config example in the module docstring.
- `hermes_cli/model_setup_flows.py`: update the xAI OAuth model-picker's hardcoded fallback default to `grok-build-0.1`.
- Docs: update the default-model references in `website/docs/guides/xai-grok-oauth.md`, `website/docs/user-guide/features/web-search.md`, and their zh-Hans translations. `grok-4.3` is retained in the model tables as the previous default. The Nous Portal / OpenRouter aggregator catalog (`nous-portal.md`, `model-catalog.json`) still lists `grok-4.3` and is intentionally left unchanged.

## How to Test

1. With no xAI model configured, run `hermes model`, choose the xAI / Grok provider, and confirm `grok-build-0.1` is at the top and selected as the default.
2. `python -c "from hermes_cli.models import get_default_model_for_provider; print(get_default_model_for_provider('xai'))"` prints `grok-build-0.1`.
3. With `web.xai.model` unset, confirm the xAI web-search backend issues requests with model `grok-build-0.1` (the `DEFAULT_MODEL` in `plugins/web/xai/provider.py`).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (a literal default-value assertion would be a change-detector test, which `AGENTS.md` advises against)
- [ ] I've tested on my platform

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — xAI Grok OAuth guide + web-search docs (EN + zh-Hans) and the web provider docstring; the Nous/OpenRouter aggregator catalog still lists grok-4.3 and is intentionally left
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A (no config keys changed)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) — N/A (pure constant change, no OS-specific code)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A (no schema change)

## Screenshots / Logs

N/A


## Infographic

![default-model-swap-grok-build](https://v3b.fal.media/files/b/0a9e8f82/BS4J0qfUTp_vtd4A7k3Oo_xlo6orH7.png)
