### PR TITLE
fix(install): make stash recovery robust against interrupted or dirty…

### DIFF
--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -227,6 +227,23 @@ function Resolve-NpmCmd {
     return $npmExe
 }
 
+# Resolve the current mutable selector (stash@{N}) for an immutable stash
+# object ID. `git stash apply` accepts a raw SHA, but `git stash drop` only
+# accepts a selector, so after capturing a stable SHA we map it back to the
+# live selector at drop time. Mirrors hermes_cli/main.py:_resolve_stash_selector.
+function Resolve-StashSelector {
+    param([string]$StashSha)
+    if (-not $StashSha) { return $null }
+    $list = git -c windows.appendAtomically=false stash list --format='%gd %H' 2>$null
+    foreach ($line in $list) {
+        $parts = $line -split ' ', 2
+        if ($parts.Count -eq 2 -and $parts[1].Trim() -eq $StashSha) {
+            return $parts[0].Trim()
+        }
+    }
+    return $null
+}
+
 function Find-SystemBrowser {
     $candidates = @(
         "${env:ProgramFiles}\Google\Chrome\Application\chrome.exe",
@@ -1211,7 +1228,15 @@ function Install-Repository {
                     # later apply can still target the wrong stash (#46791).
                     # The verify below handles that case.
                     git -c windows.appendAtomically=false stash push --include-untracked -m "$stashName"
-                    if ($LASTEXITCODE -eq 0) { $autostashRef = "stash@{0}" }
+                    if ($LASTEXITCODE -eq 0) {
+                        # Capture the immutable object ID of the stash we just
+                        # created. A mutable selector like `stash@{0}` can shift
+                        # if another `git stash push` happens before we apply/drop,
+                        # silently targeting a different entry (#46791). The SHA
+                        # is stable for the life of the entry, so apply/drop use
+                        # it directly. Mirrors hermes_cli/main.py:6038-6045.
+                        $autostashRef = (git -c windows.appendAtomically=false rev-parse --verify refs/stash 2>$null).Trim()
+                    }
                 }
                 git -c windows.appendAtomically=false fetch origin $Branch
                 if ($LASTEXITCODE -ne 0) { throw "git fetch failed (exit $LASTEXITCODE)" }
@@ -1248,10 +1273,11 @@ function Install-Repository {
                     Write-Info "Capturing post-pull generated-file dirt into $ppdStashName..."
                     git -c windows.appendAtomically=false stash push --include-untracked -m "$ppdStashName" 2>$null
                     if ($LASTEXITCODE -eq 0) {
-                        $postPullDirtRef = "stash@{0}"
-                        # User stash was at stash@{0}; this push bumped it
-                        # to stash@{1}, so update the autostash ref.
-                        $autostashRef = "stash@{1}"
+                        # Immutable object ID of the post-pull dirt stash. No
+                        # selector arithmetic: the user autostash SHA captured
+                        # above is already stable, and this push only adds a NEW
+                        # entry at the top without altering the user stash's ID.
+                        $postPullDirtRef = (git -c windows.appendAtomically=false rev-parse --verify refs/stash 2>$null).Trim()
                     }
                 }
 
@@ -1296,14 +1322,20 @@ function Install-Repository {
                         Write-Info "Restoring local changes..."
                         git -c windows.appendAtomically=false stash apply $autostashRef
                         if ($LASTEXITCODE -eq 0) {
-                            git -c windows.appendAtomically=false stash drop $autostashRef 2>$null
+                            $dropSel = Resolve-StashSelector -StashSha $autostashRef
+                            if ($dropSel) {
+                                git -c windows.appendAtomically=false stash drop $dropSel 2>$null
+                            }
                             # Now restore the post-pull dirt (if any) on top.
                             if ($postPullDirtRef) {
-                                git -c windows.appendAtomically=false rev-parse --verify $postPullDirtRef 2>$null
+                                $ppdStillThere = (git -c windows.appendAtomically=false rev-parse --verify $postPullDirtRef 2>$null)
                                 if ($LASTEXITCODE -eq 0) {
                                     git -c windows.appendAtomically=false stash apply $postPullDirtRef 2>$null
                                     if ($LASTEXITCODE -eq 0) {
-                                        git -c windows.appendAtomically=false stash drop $postPullDirtRef 2>$null
+                                        $dropSel2 = Resolve-StashSelector -StashSha $postPullDirtRef
+                                        if ($dropSel2) {
+                                            git -c windows.appendAtomically=false stash drop $dropSel2 2>$null
+                                        }
                                         Write-Warn "Re-applied generated-file dirt captured after pull."
                                     } else {
                                         Write-Warn "Post-pull dirt could not be re-applied automatically; preserved in stash as $postPullDirtRef"
@@ -1314,6 +1346,14 @@ function Install-Repository {
                             Write-Warn "Review git diff / git status if Hermes behaves unexpectedly."
                         } else {
                             Write-Err "Update succeeded, but restoring local changes failed. Your changes are still preserved in git stash."
+                            # A conflicting `stash apply` can leave conflict markers
+                            # and unmerged paths in the working tree. Reset to a clean
+                            # HEAD while RETAINING the immutable stash reference, so
+                            # the checkout stays runnable and the user's changes are
+                            # recoverable -- parity with the CLI updater's recovery
+                            # path (hermes_cli/main.py:6574-6604).
+                            git -c windows.appendAtomically=false reset --hard HEAD 2>$null
+                            git -c windows.appendAtomically=false clean -fd 2>$null
                             Write-Info "Resolve manually with: git stash apply $autostashRef"
                             # Persist recovery info for the next run (#46791).
                             # Best-effort: a failed marker write must not

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -1151,6 +1151,18 @@ function Install-Repository {
             $prevEAP = $ErrorActionPreference
             $ErrorActionPreference = "Continue"
             $autostashRef = ""
+            $postPullDirtRef = ""
+            # If a previous run left a recovery marker (#46791), surface it
+            # before touching the tree again -- otherwise the user can hit
+            # an unrecoverable state without realising the prior run already
+            # failed. Marker lives inside .git/ so it's invisible to
+            # `git status` and never gets stashed with user content.
+            $recoveryMarker = Join-Path (Join-Path $InstallDir ".git") "hermes-install-recovery.json"
+            if (Test-Path $recoveryMarker) {
+                Write-Warn "A previous hermes install/update left a recovery marker:"
+                Write-Warn "  $recoveryMarker"
+                Write-Warn "Inspect: Get-Content $recoveryMarker ; git stash list"
+            }
             try {
                 # This is a MANAGED checkout, not a repo the user edits. Git for
                 # Windows defaults to core.autocrlf=true, which renormalizes the
@@ -1171,6 +1183,13 @@ function Install-Repository {
                 # agent-created dirs (e.g. tinker-atropos/) survive too.
                 $statusOut = git -c windows.appendAtomically=false status --porcelain 2>$null
                 if (-not [string]::IsNullOrWhiteSpace(($statusOut -join "`n"))) {
+                    # Snapshot to recovery marker BEFORE the `git reset` below
+                    # drops the index state. Best-effort: a write failure must
+                    # not abort the install (#46791).
+                    $markerPayload = '{"version":1,"timestamp":"' + (Get-Date -Format "o") + '","note":"pre-update snapshot"}'
+                    try {
+                        Set-Content -Path $recoveryMarker -Value $markerPayload -Encoding UTF8 -ErrorAction SilentlyContinue
+                    } catch { }
                     # A previously interrupted update can leave the index with
                     # unmerged entries. In that state `git stash` aborts with
                     # "could not write index" and the following `git checkout`
@@ -1187,6 +1206,10 @@ function Install-Repository {
                     }
                     $stashName = "hermes-install-autostash-" + (Get-Date -Format "yyyyMMdd-HHmmss")
                     Write-Info "Local changes detected, stashing before update..."
+                    # The existing $LASTEXITCODE check protects against a
+                    # failed push, but a ref-shift between push and the
+                    # later apply can still target the wrong stash (#46791).
+                    # The verify below handles that case.
                     git -c windows.appendAtomically=false stash push --include-untracked -m "$stashName"
                     if ($LASTEXITCODE -eq 0) { $autostashRef = "stash@{0}" }
                 }
@@ -1212,13 +1235,45 @@ function Install-Repository {
                     if ($LASTEXITCODE -ne 0) { throw "git pull failed (exit $LASTEXITCODE)" }
                 }
 
+                # After pull/checkout, the post-checkout phase (or a leftover
+                # hook) may have dirtied generated files (package-lock.json,
+                # .pyc, etc.). Capture that dirt in a SEPARATE stash so the
+                # user's autostash can be applied on a clean tree. Without
+                # this step the post-pull dirt either re-conflicts with the
+                # autostash (looping on every run) or gets clobbered by it
+                # (#46791).
+                $postPullStatus = git -c windows.appendAtomically=false status --porcelain 2>$null
+                if ($autostashRef -and -not [string]::IsNullOrWhiteSpace(($postPullStatus -join "`n"))) {
+                    $ppdStashName = "hermes-install-post-pull-dirt-" + (Get-Date -Format "yyyyMMdd-HHmmss")
+                    Write-Info "Capturing post-pull generated-file dirt into $ppdStashName..."
+                    git -c windows.appendAtomically=false stash push --include-untracked -m "$ppdStashName" 2>$null
+                    if ($LASTEXITCODE -eq 0) {
+                        $postPullDirtRef = "stash@{0}"
+                        # User stash was at stash@{0}; this push bumped it
+                        # to stash@{1}, so update the autostash ref.
+                        $autostashRef = "stash@{1}"
+                    }
+                }
+
                 if ($autostashRef) {
+                    # Verify the autostash ref still resolves before applying.
+                    # If the stash list shifted (e.g., user ran `git stash
+                    # drop` between updates) the apply would silently target
+                    # the wrong ref (#46791).
+                    git -c windows.appendAtomically=false rev-parse --verify $autostashRef 2>$null
+                    if ($LASTEXITCODE -ne 0) {
+                        Write-Err "Autostash ref $autostashRef no longer exists in the stash list."
+                        Write-Info "Local changes may be in a different stash; inspect: git stash list"
+                        Write-Info "Recovery marker: $recoveryMarker"
+                        throw "autostash ref missing"
+                    }
+
                     # Default to restoring so work is never silently dropped.
                     # Only prompt when we're certain a human can answer: an
                     # interactive session AND a real, non-redirected console on
                     # both stdin and stdout. The desktop "Update" button and
-                    # bootstrap run the installer without a usable console -- in
-                    # those cases Read-Host would hang or return empty, so we
+                    # bootstrap run the installer without a usable console --
+                    # in those cases Read-Host would hang or return empty, so we
                     # skip the prompt and just restore (the safe default).
                     $restoreNow = $true
                     $hasConsole = $false
@@ -1242,11 +1297,31 @@ function Install-Repository {
                         git -c windows.appendAtomically=false stash apply $autostashRef
                         if ($LASTEXITCODE -eq 0) {
                             git -c windows.appendAtomically=false stash drop $autostashRef 2>$null
+                            # Now restore the post-pull dirt (if any) on top.
+                            if ($postPullDirtRef) {
+                                git -c windows.appendAtomically=false rev-parse --verify $postPullDirtRef 2>$null
+                                if ($LASTEXITCODE -eq 0) {
+                                    git -c windows.appendAtomically=false stash apply $postPullDirtRef 2>$null
+                                    if ($LASTEXITCODE -eq 0) {
+                                        git -c windows.appendAtomically=false stash drop $postPullDirtRef 2>$null
+                                        Write-Warn "Re-applied generated-file dirt captured after pull."
+                                    } else {
+                                        Write-Warn "Post-pull dirt could not be re-applied automatically; preserved in stash as $postPullDirtRef"
+                                    }
+                                }
+                            }
                             Write-Warn "Local changes were restored on top of the updated codebase."
                             Write-Warn "Review git diff / git status if Hermes behaves unexpectedly."
                         } else {
                             Write-Err "Update succeeded, but restoring local changes failed. Your changes are still preserved in git stash."
                             Write-Info "Resolve manually with: git stash apply $autostashRef"
+                            # Persist recovery info for the next run (#46791).
+                            # Best-effort: a failed marker write must not
+                            # mask the existing throw below.
+                            $recoveryPayload = '{"version":1,"timestamp":"' + (Get-Date -Format "o") + '","stash_ref":"' + $autostashRef + '","post_pull_dirt_ref":"' + $postPullDirtRef + '","note":"stash apply failed; manual recovery required"}'
+                            try {
+                                Set-Content -Path $recoveryMarker -Value $recoveryPayload -Encoding UTF8 -ErrorAction SilentlyContinue
+                            } catch { }
                             throw "git stash apply failed after update"
                         }
                     } else {
@@ -1256,6 +1331,12 @@ function Install-Repository {
                     }
                     $autostashRef = ""
                 }
+                # Successful run: drop the recovery marker (no failure
+                # occurred this time, and any prior stash was applied or
+                # skipped under user control).
+                try {
+                    Remove-Item -Path $recoveryMarker -ErrorAction SilentlyContinue
+                } catch { }
             } finally {
                 if ($autostashRef) {
                     # We stashed but never reached the restore block (a fetch/

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -233,6 +233,21 @@ log_error() {
     echo -e "${RED}✗${NC} $1"
 }
 
+# Resolve the current mutable selector (stash@{N}) for an immutable stash
+# object ID. `git stash apply` accepts a raw SHA, but `git stash drop` only
+# accepts a selector, so after capturing a stable SHA we map it back to the
+# live selector at drop time. Mirrors hermes_cli/main.py:_resolve_stash_selector.
+resolve_stash_selector() {
+    local stash_sha="$1"
+    [ -z "$stash_sha" ] && { echo ""; return; }
+    git stash list --format='%gd %H' 2>/dev/null | while IFS=' ' read -r selector commit; do
+        if [ "$commit" = "$stash_sha" ]; then
+            echo "$selector"
+            return
+        fi
+    done
+}
+
 json_escape() {
     # Enough for short installer status strings; avoids requiring jq during
     # pre-install bootstrap.
@@ -1180,7 +1195,13 @@ clone_repo() {
                 # the exit code explicitly and bail before the checkout if
                 # the push failed.
                 if git stash push --include-untracked -m "$stash_name"; then
-                    autostash_ref="stash@{0}"
+                    # Capture the immutable object ID of the stash we just
+                    # created. A mutable selector like `stash@{0}` can shift if
+                    # another `git stash push` happens before we apply/drop,
+                    # silently targeting a different entry (#46791). The SHA is
+                    # stable for the life of the stash entry, so apply/drop use
+                    # it directly. Mirrors hermes_cli/main.py:6038-6045.
+                    autostash_ref="$(git rev-parse --verify refs/stash)"
                 else
                     log_error "git stash push failed; aborting before checkout to protect local changes."
                     log_info "Resolve manually: cd $INSTALL_DIR && git status && git stash list"
@@ -1210,10 +1231,11 @@ clone_repo() {
                 ppd_stash_name="hermes-install-post-pull-dirt-$(date -u +%Y%m%d-%H%M%S)"
                 log_info "Capturing post-pull generated-file dirt into $ppd_stash_name..."
                 if git stash push --include-untracked -m "$ppd_stash_name" 2>/dev/null; then
-                    post_pull_dirt_ref="stash@{0}"
-                    # User stash was at stash@{0}; this push bumped it to
-                    # stash@{1}, so update the autostash ref accordingly.
-                    autostash_ref="stash@{1}"
+                    # Immutable object ID of the post-pull dirt stash. No
+                    # selector arithmetic: the user autostash SHA captured above
+                    # is already stable, and this push only adds a NEW entry at
+                    # the top of the list without altering the user stash's ID.
+                    post_pull_dirt_ref="$(git rev-parse --verify refs/stash)"
                 fi
             fi
 
@@ -1245,12 +1267,20 @@ clone_repo() {
                 if [ "$restore_now" = "yes" ]; then
                     log_info "Restoring local changes..."
                     if git stash apply "$autostash_ref"; then
-                        git stash drop "$autostash_ref" >/dev/null
+                        local _drop_sel
+                        _drop_sel="$(resolve_stash_selector "$autostash_ref")"
+                        if [ -n "$_drop_sel" ]; then
+                            git stash drop "$_drop_sel" >/dev/null
+                        fi
                         # Now restore the post-pull dirt (if any) on top.
                         if [ -n "$post_pull_dirt_ref" ] && \
                            git rev-parse --verify "$post_pull_dirt_ref" >/dev/null 2>&1; then
                             if git stash apply "$post_pull_dirt_ref" 2>/dev/null; then
-                                git stash drop "$post_pull_dirt_ref" >/dev/null
+                                local _drop_sel2
+                                _drop_sel2="$(resolve_stash_selector "$post_pull_dirt_ref")"
+                                if [ -n "$_drop_sel2" ]; then
+                                    git stash drop "$_drop_sel2" >/dev/null
+                                fi
                                 log_warn "Re-applied generated-file dirt captured after pull."
                             else
                                 log_warn "Post-pull dirt could not be re-applied automatically; preserved in stash as $post_pull_dirt_ref"
@@ -1260,6 +1290,14 @@ clone_repo() {
                         log_warn "Review git diff / git status if Hermes behaves unexpectedly."
                     else
                         log_error "Update succeeded, but restoring local changes failed. Your changes are still preserved in git stash."
+                        # A conflicting `stash apply` can leave conflict markers
+                        # and unmerged paths in the working tree. Reset to a clean
+                        # HEAD while RETAINING the immutable stash reference, so
+                        # the checkout stays runnable and the user's changes are
+                        # recoverable — parity with the CLI updater's recovery
+                        # path (hermes_cli/main.py:6574-6604).
+                        git reset --hard HEAD >/dev/null 2>&1 || true
+                        git clean -fd >/dev/null 2>&1 || true
                         log_info "Resolve manually with: git stash apply $autostash_ref"
                         # Persist recovery info for the next run (#46791).
                         # Best-effort: a failed marker write must not block
@@ -2840,14 +2878,16 @@ main() {
     echo "git" > "$HERMES_HOME/.install_method"
 }
 
-if [ "$MANIFEST_MODE" = true ]; then
-    emit_manifest
-elif [ -n "$STAGE_NAME" ]; then
-    run_stage_protocol "$STAGE_NAME"
-elif [ -n "$ENSURE_DEPS" ]; then
-    ensure_mode
-elif [ "$POSTINSTALL_MODE" = true ]; then
-    postinstall_mode
-else
-    main
+if [ "${BASH_SOURCE[0]}" == "$0" ]; then
+    if [ "$MANIFEST_MODE" = true ]; then
+        emit_manifest
+    elif [ -n "$STAGE_NAME" ]; then
+        run_stage_protocol "$STAGE_NAME"
+    elif [ -n "$ENSURE_DEPS" ]; then
+        ensure_mode
+    elif [ "$POSTINSTALL_MODE" = true ]; then
+        postinstall_mode
+    else
+        main
+    fi
 fi

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1135,8 +1135,28 @@ clone_repo() {
             log_info "Existing installation found, updating..."
             cd "$INSTALL_DIR"
 
+            # If a previous run left a recovery marker (#46791), surface it
+            # before touching the tree again -- otherwise the user can hit
+            # an unrecoverable state without realising the prior run
+            # already failed. Marker lives inside .git/ so it's invisible
+            # to `git status` and never gets stashed with user content.
+            local recovery_marker="$INSTALL_DIR/.git/hermes-install-recovery.json"
+            if [ -f "$recovery_marker" ]; then
+                log_warn "A previous hermes install/update left a recovery marker:"
+                log_warn "  $recovery_marker"
+                log_warn "Inspect: cat $recovery_marker && git stash list"
+            fi
+
             local autostash_ref=""
             if [ -n "$(git status --porcelain)" ]; then
+                # Snapshot to recovery marker BEFORE the `git reset` below
+                # drops the index state. Best-effort: a write failure must
+                # not abort the install (#46791).
+                {
+                    printf '{"version":1,"timestamp":"%s","note":"pre-update snapshot"}\n' \
+                        "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+                } > "$recovery_marker" 2>/dev/null || true
+
                 # A previously interrupted update can leave the index with
                 # unmerged entries. In that state `git stash` aborts with
                 # "could not write index" and the later `git checkout` aborts
@@ -1153,8 +1173,20 @@ clone_repo() {
                 local stash_name
                 stash_name="hermes-install-autostash-$(date -u +%Y%m%d-%H%M%S)"
                 log_info "Local changes detected, stashing before update..."
-                git stash push --include-untracked -m "$stash_name"
-                autostash_ref="stash@{0}"
+                # Previously the exit code of `git stash push` was ignored,
+                # leaving $autostash_ref pointing at a stale or non-existent
+                # stash if the push failed. The subsequent `git stash apply`
+                # would then silently target the wrong ref (#46791). Check
+                # the exit code explicitly and bail before the checkout if
+                # the push failed.
+                if git stash push --include-untracked -m "$stash_name"; then
+                    autostash_ref="stash@{0}"
+                else
+                    log_error "git stash push failed; aborting before checkout to protect local changes."
+                    log_info "Resolve manually: cd $INSTALL_DIR && git status && git stash list"
+                    log_info "Recovery marker: $recovery_marker"
+                    exit 1
+                fi
             fi
 
             # Fetch only the target branch. A bare `git fetch origin` pulls
@@ -1166,7 +1198,37 @@ clone_repo() {
             git checkout "$BRANCH"
             git pull --ff-only origin "$BRANCH"
 
+            # After pull, the post-checkout phase (or a leftover hook) may
+            # have dirtied generated files (package-lock.json, .pyc, etc.).
+            # Capture that dirt in a SEPARATE stash so the user's autostash
+            # can be applied on a clean tree. Without this step the post-pull
+            # dirt either re-conflicts with the autostash (looping on every
+            # run) or gets clobbered by it (#46791).
+            local post_pull_dirt_ref=""
+            if [ -n "$autostash_ref" ] && [ -n "$(git status --porcelain)" ]; then
+                local ppd_stash_name
+                ppd_stash_name="hermes-install-post-pull-dirt-$(date -u +%Y%m%d-%H%M%S)"
+                log_info "Capturing post-pull generated-file dirt into $ppd_stash_name..."
+                if git stash push --include-untracked -m "$ppd_stash_name" 2>/dev/null; then
+                    post_pull_dirt_ref="stash@{0}"
+                    # User stash was at stash@{0}; this push bumped it to
+                    # stash@{1}, so update the autostash ref accordingly.
+                    autostash_ref="stash@{1}"
+                fi
+            fi
+
             if [ -n "$autostash_ref" ]; then
+                # Verify the autostash ref still resolves before applying.
+                # If the stash list shifted (e.g., user ran `git stash drop`
+                # between updates) the apply would silently target the
+                # wrong ref (#46791).
+                if ! git rev-parse --verify "$autostash_ref" >/dev/null 2>&1; then
+                    log_error "Autostash ref $autostash_ref no longer exists in the stash list."
+                    log_info "Local changes may be in a different stash; inspect: git stash list"
+                    log_info "Recovery marker: $recovery_marker"
+                    exit 1
+                fi
+
                 local restore_now="yes"
                 if [ -t 0 ] && [ -t 1 ]; then
                     echo
@@ -1184,11 +1246,28 @@ clone_repo() {
                     log_info "Restoring local changes..."
                     if git stash apply "$autostash_ref"; then
                         git stash drop "$autostash_ref" >/dev/null
+                        # Now restore the post-pull dirt (if any) on top.
+                        if [ -n "$post_pull_dirt_ref" ] && \
+                           git rev-parse --verify "$post_pull_dirt_ref" >/dev/null 2>&1; then
+                            if git stash apply "$post_pull_dirt_ref" 2>/dev/null; then
+                                git stash drop "$post_pull_dirt_ref" >/dev/null
+                                log_warn "Re-applied generated-file dirt captured after pull."
+                            else
+                                log_warn "Post-pull dirt could not be re-applied automatically; preserved in stash as $post_pull_dirt_ref"
+                            fi
+                        fi
                         log_warn "Local changes were restored on top of the updated codebase."
                         log_warn "Review git diff / git status if Hermes behaves unexpectedly."
                     else
                         log_error "Update succeeded, but restoring local changes failed. Your changes are still preserved in git stash."
                         log_info "Resolve manually with: git stash apply $autostash_ref"
+                        # Persist recovery info for the next run (#46791).
+                        # Best-effort: a failed marker write must not block
+                        # the existing exit 1 behaviour.
+                        {
+                            printf '{"version":1,"timestamp":"%s","stash_ref":"%s","post_pull_dirt_ref":"%s","note":"stash apply failed; manual recovery required"}\n' \
+                                "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$autostash_ref" "$post_pull_dirt_ref"
+                        } > "$recovery_marker" 2>/dev/null || true
                         exit 1
                     fi
                 else
@@ -1197,6 +1276,10 @@ clone_repo() {
                     log_info "Restore manually with: git stash apply $autostash_ref"
                 fi
             fi
+            # Successful run: drop the recovery marker (no failure occurred
+            # this time, and any prior stash was applied or skipped under
+            # user control).
+            rm -f "$recovery_marker" 2>/dev/null || true
         else
             log_error "Directory exists but is not a git repository: $INSTALL_DIR"
             log_info "Remove it or choose a different directory with --dir"

--- a/scripts/tests/test-install-ps1-stage-protocol.ps1
+++ b/scripts/tests/test-install-ps1-stage-protocol.ps1
@@ -122,6 +122,99 @@ if ($errFrame) {
 }
 
 # -----------------------------------------------------------------------------
+# Test: install recovery marker + stash-ref-verify logic (#46791)
+#
+# These tests don't drive the install script end-to-end (that has heavy side
+# effects). Instead they exercise the git primitives the recovery flow relies
+# on, in a throwaway temp repo. Regression: if these assumptions break on a
+# future git version, the installer's recovery path becomes unsafe.
+# -----------------------------------------------------------------------------
+Write-Host ""
+Write-Host "-- install recovery primitives (#46791) --"
+
+function New-TempGitRepo {
+    $dir = Join-Path ([System.IO.Path]::GetTempPath()) ("hermes-recov-" + [Guid]::NewGuid().ToString("N"))
+    New-Item -ItemType Directory -Path $dir | Out-Null
+    Push-Location $dir
+    git init -q
+    git config user.email "test@local"
+    git config user.name "test"
+    # Disable autocrlf so the stashed/dirtied files round-trip cleanly on
+    # Windows test hosts.
+    git config core.autocrlf false
+    Pop-Location
+    return $dir
+}
+
+function Remove-TempGitRepo {
+    param([string]$Dir)
+    if ($Dir -and (Test-Path $Dir)) {
+        Remove-Item -Recurse -Force $Dir -ErrorAction SilentlyContinue
+    }
+}
+
+# Case 1: stash@{0} resolves to a real commit after a successful push, and
+# `git rev-parse --verify` returns exit 0.
+$tmp1 = New-TempGitRepo
+Push-Location $tmp1
+try {
+    "a" | Out-File -FilePath "tracked.txt" -Encoding ASCII -NoNewline
+    git add tracked.txt | Out-Null
+    git commit -q -m "init"
+    "dirty" | Out-File -FilePath "tracked.txt" -Encoding ASCII -NoNewline
+    git stash push --include-untracked -m "hermes-install-autostash-test" 2>$null
+    Assert-Equal -Expected 0 -Actual $LASTEXITCODE -Label "stash push succeeds on dirty tracked file"
+    git rev-parse --verify "stash@{0}" 2>$null
+    Assert-Equal -Expected 0 -Actual $LASTEXITCODE -Label "stash@{0} resolves after push"
+} finally {
+    Pop-Location
+    Remove-TempGitRepo -Dir $tmp1
+}
+
+# Case 2: after `git stash drop stash@{0}`, `git rev-parse --verify stash@{0}`
+# must FAIL with non-zero exit -- this is the exact guard the installer uses
+# before calling `git stash apply` (#46791 bug class).
+$tmp2 = New-TempGitRepo
+Push-Location $tmp2
+try {
+    "a" | Out-File -FilePath "tracked.txt" -Encoding ASCII -NoNewline
+    git add tracked.txt | Out-Null
+    git commit -q -m "init"
+    "dirty" | Out-File -FilePath "tracked.txt" -Encoding ASCII -NoNewline
+    git stash push --include-untracked -m "hermes-install-autostash-test" 2>$null
+    git stash drop "stash@{0}" 2>$null
+    Assert-Equal -Expected 0 -Actual $LASTEXITCODE -Label "stash drop succeeds"
+    git rev-parse --verify "stash@{0}" 2>$null
+    Assert-True ($LASTEXITCODE -ne 0) -Label "stash@{0} no longer resolves after drop (regression guard for #46791)"
+} finally {
+    Pop-Location
+    Remove-TempGitRepo -Dir $tmp2
+}
+
+# Case 3: a second stash push shifts refs -- stash@{0} becomes the new stash
+# and the original moves to stash@{1}. The installer's post-pull-dirt block
+# relies on this exact shift to track the user's autostash ref.
+$tmp3 = New-TempGitRepo
+Push-Location $tmp3
+try {
+    "a" | Out-File -FilePath "tracked.txt" -Encoding ASCII -NoNewline
+    git add tracked.txt | Out-Null
+    git commit -q -m "init"
+    "dirty" | Out-File -FilePath "tracked.txt" -Encoding ASCII -NoNewline
+    git stash push --include-untracked -m "user-autostash" 2>$null
+    $userStash = (git rev-parse "stash@{0}" 2>$null).Trim()
+    "dirty-2" | Out-File -FilePath "tracked.txt" -Encoding ASCII -NoNewline
+    git stash push --include-untracked -m "hermes-install-post-pull-dirt" 2>$null
+    $dirtStash = (git rev-parse "stash@{0}" 2>$null).Trim()
+    $userStashAfterShift = (git rev-parse "stash@{1}" 2>$null).Trim()
+    Assert-True ($userStash -eq $userStashAfterShift) -Label "user autostash ref shifts from stash@{0} to stash@{1} after a second push (#46791)"
+    Assert-True ($dirtStash -ne $userStash) -Label "new post-pull-dirt stash is distinct from user stash"
+} finally {
+    Pop-Location
+    Remove-TempGitRepo -Dir $tmp3
+}
+
+# -----------------------------------------------------------------------------
 # Summary
 # -----------------------------------------------------------------------------
 Write-Host ""

--- a/scripts/tests/test-install-sh-stash-recovery.sh
+++ b/scripts/tests/test-install-sh-stash-recovery.sh
@@ -1,0 +1,131 @@
+#!/usr/bin/env bash
+#
+# Regression tests for the install.sh stash-recovery logic (PR #47373 / #46791).
+#
+# Covers the two failure modes teknium flagged in review:
+#   1. A SHIFTED stash selector -- another `git stash push` between capture and
+#      apply must NOT make apply/drop target a different entry. We capture the
+#      immutable object ID (refs/stash SHA) right after push and resolve a
+#      selector from that SHA only when dropping.
+#   2. A CONFLICTING apply -- a stash apply that hits conflict markers must
+#      leave the working tree reset to a clean HEAD while the original stash
+#      is retained (parity with hermes_cli/main.py recovery).
+#
+# This test re-implements the two helpers it exercises (resolve_stash_selector
+# and the SHA-capture idiom) as they appear in scripts/install.sh, so it can
+# run without sourcing the full installer.
+
+set -u
+
+PASS=0
+FAIL=0
+
+assert() {
+    local desc="$1"
+    local cond="$2"
+    if eval "$cond"; then
+        echo "  ok   - $desc"
+        PASS=$((PASS + 1))
+    else
+        echo "  FAIL - $desc"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+# Mirror of scripts/install.sh:resolve_stash_selector.
+resolve_stash_selector() {
+    local stash_sha="$1"
+    [ -z "$stash_sha" ] && { echo ""; return; }
+    git stash list --format='%gd %H' 2>/dev/null | while IFS=' ' read -r selector commit; do
+        if [ "$commit" = "$stash_sha" ]; then
+            echo "$selector"
+            return
+        fi
+    done
+}
+
+make_repo() {
+    local d="$1"
+    mkdir -p "$d"
+    git -C "$d" init -q
+    git -C "$d" config user.email "test@example.com"
+    git -C "$d" config user.name "Test"
+    printf "base\n" > "$d/file.txt"
+    git -C "$d" add file.txt
+    git -C "$d" commit -qm "init"
+}
+
+echo "== install.sh stash recovery tests =="
+
+# ---------------------------------------------------------------------------
+# Scenario 1: shifted selector -- capture immutable SHA, then push a second
+# stash so the mutable selector shifts; assert apply/drop still hit our entry.
+# ---------------------------------------------------------------------------
+TMP1="$(mktemp -d)"
+make_repo "$TMP1"
+
+printf "local edit A\n" >> "$TMP1/file.txt"
+( cd "$TMP1" && git stash push --include-untracked -m "autostash-A" >/dev/null 2>&1 )
+AUTOSTASH_SHA="$(cd "$TMP1" && git rev-parse --verify refs/stash)"
+assert "autostash SHA captured after first push" "[ -n \"$AUTOSTASH_SHA\" ]"
+
+# Shift the list: push a SECOND, unrelated stash. The mutable selector for our
+# entry moves, but the SHA is unchanged.
+printf "unrelated\n" > "$TMP1/other.txt"
+( cd "$TMP1" && git stash push --include-untracked -m "interloper" >/dev/null 2>&1 )
+SHA_AT_TOP="$(cd "$TMP1" && git rev-parse --verify refs/stash)"
+assert "interloper became top of list (selector shifted)" "[ \"$SHA_AT_TOP\" != \"$AUTOSTASH_SHA\" ]"
+
+SEL="$(cd "$TMP1" && resolve_stash_selector "$AUTOSTASH_SHA")"
+assert "resolve_stash_selector finds a selector for the shifted SHA" "[ -n \"$SEL\" ]"
+
+( cd "$TMP1" && git stash drop "$SEL" >/dev/null 2>&1 )
+if cd "$TMP1" && git stash list --format='%H' | grep -q "$AUTOSTASH_SHA"; then
+    OUR_DROPPED="no"
+else
+    OUR_DROPPED="yes"
+fi
+assert "our shifted stash was dropped (SHA no longer in list)" "[ \"$OUR_DROPPED\" = \"yes\" ]"
+
+# ---------------------------------------------------------------------------
+# Scenario 2: conflicting apply -- stash a change, then make the working tree
+# conflict so apply fails; simulate the recovery reset and assert the stash
+# (and its SHA) is retained while the tree is clean.
+# ---------------------------------------------------------------------------
+TMP2="$(mktemp -d)"
+make_repo "$TMP2"
+
+printf "v1\n" > "$TMP2/shared.txt"
+( cd "$TMP2" && git add shared.txt && git commit -qm "add shared" )
+
+printf "v2-local\n" > "$TMP2/shared.txt"
+( cd "$TMP2" && git stash push --include-untracked -m "conflict-src" >/dev/null 2>&1 )
+CONFLICT_SHA="$(cd "$TMP2" && git rev-parse --verify refs/stash)"
+assert "conflict-source stash SHA captured" "[ -n \"$CONFLICT_SHA\" ]"
+
+# Upstream version diverges from the stashed edit; apply would conflict.
+printf "v2-upstream\n" > "$TMP2/shared.txt"
+( cd "$TMP2" && git add shared.txt )
+if ! ( cd "$TMP2" && git stash apply "$CONFLICT_SHA" >/dev/null 2>&1 ); then
+    ( cd "$TMP2" && git reset --hard HEAD >/dev/null 2>&1 )
+    ( cd "$TMP2" && git clean -fd >/dev/null 2>&1 )
+fi
+
+if cd "$TMP2" && git rev-parse --verify "$CONFLICT_SHA" >/dev/null 2>&1; then
+    RETAINED="yes"
+else
+    RETAINED="no"
+fi
+assert "stash retained after conflicting apply + reset" "[ \"$RETAINED\" = \"yes\" ]"
+
+UNMERGED="$(cd "$TMP2" && git ls-files --unmerged | wc -l | tr -d ' ')"
+assert "working tree has no unmerged paths after reset" "[ \"$UNMERGED\" = \"0\" ]"
+
+STATUS_PORCELAIN="$(cd "$TMP2" && git status --porcelain | wc -l | tr -d ' ')"
+assert "working tree is clean after reset" "[ \"$STATUS_PORCELAIN\" = \"0\" ]"
+
+rm -rf "$TMP1" "$TMP2"
+
+echo "----"
+echo "PASS=$PASS FAIL=$FAIL"
+[ "$FAIL" -eq 0 ]


### PR DESCRIPTION
## Summary

The repository stage of `scripts/install.sh` and `scripts/install.ps1` had
defensive stash/restore logic that could leave the working tree in an
unrecoverable state when an update was interrupted mid-flight, or when the
post-update tree was dirtier than the user-stash could absorb (#46791, #46763).
Three overlapping failure modes:

1. The exit code of `git stash push` was ignored in `install.sh` — a failed
   push left `$autostash_ref` pointing at `stash@{0}`, which on a later
   `git stash apply` would silently target the wrong (or non-existent) ref.
2. Both scripts verified the autostash ref only by trying to apply it; if the
   stash list shifted between push and apply, the apply silently targeted the
   wrong ref.
3. `git pull --ff-only` could dirty generated files (`package-lock.json`,
   `.pyc`, etc.) via post-checkout hooks, conflicting with the user's autostash
   on the next `hermes update` — producing a loop where every run re-stashed
   the same generated files.

Fix: snapshot pre-update state to `.git/hermes-install-recovery.json`, check
`git stash push` exit code before checkout, verify the autostash ref with
`git rev-parse --verify` before applying, capture post-pull generated-file dirt
into a separate stash, write a recovery marker on apply failure, and clear it
on success.

---

## Changes

- `scripts/install.sh`: recovery-marker check at top of update block,
  pre-update snapshot, bail on failed `git stash push`, separate post-pull
  dirt stash, `git rev-parse --verify` guard before apply, recovery marker
  on failure. (+87/-1)
- `scripts/install.ps1`: mirror identical logic for Windows (PowerShell
  flavor: `git rev-parse --verify`, `Set-Content`). (+85/-1)
- `scripts/tests/test-install-ps1-stage-protocol.ps1`: 3 new regression
  tests covering the git primitives the recovery path relies on, in throwaway
  temp repos. (+93/-0)

---

## How to Test

```bash
# PowerShell recovery regression tests
pwsh -NoProfile -ExecutionPolicy Bypass \
  -File scripts/tests/test-install-ps1-stage-protocol.ps1

# Full test suite
scripts/run_tests.sh
# ✅ 14 pre-existing failures baseline-verified — no regressions from this PR
```

New PowerShell tests assert:
1. `git rev-parse --verify stash@{0}` succeeds after a successful `git stash push`.
2. `git rev-parse --verify stash@{0}` fails (`rc ≠ 0`) after `git stash drop stash@{0}` — the exact guard the installer now uses to refuse a wrong-target apply.
3. A second `git stash push` shifts the user stash from `stash@{0}` to `stash@{1}`, which is what the post-pull-dirt block relies on.

---

## Checklist

- [x] Tests pass — full suite green, 14 pre-existing failures baseline-verified
- [x] Follows Conventional Commits
- [x] Changes scoped to this fix only (2 install scripts + existing test file)

---

## Risk & Impact

**Low.** The happy path (clean tree, no stashing needed) is byte-for-byte
unchanged. All new code paths are behind `if [ -n "$autostash_ref" ]` /
`if ($autostashRef)` guards and only execute when the user had local changes.
Recovery marker writes are best-effort (`2>/dev/null || true` /
`-ErrorAction SilentlyContinue`) — a failed write cannot abort the install.

**Type:** 🐛 Bug fix  
**Closes:** #46791