### PR TITLE
fix: avoid stack overflow on large pasted images

### DIFF
--- a/apps/desktop/src/lib/embedded-images.test.ts
+++ b/apps/desktop/src/lib/embedded-images.test.ts
@@ -32,4 +32,12 @@ describe('extractEmbeddedImages', () => {
     expect(result.cleanedText).toBe('first  mid  tail')
     expect(result.images).toEqual([SAMPLE_PNG_DATA_URL, second])
   })
+
+  it('handles large pasted image data URLs without overflowing the JS stack', () => {
+    const largeImage = 'data:image/png;base64,' + 'A'.repeat(8 * 1024 * 1024)
+    const result = extractEmbeddedImages(`describe this ${largeImage}`)
+
+    expect(result.cleanedText).toBe('describe this')
+    expect(result.images).toEqual([largeImage])
+  })
 })

--- a/apps/desktop/src/lib/embedded-images.ts
+++ b/apps/desktop/src/lib/embedded-images.ts
@@ -1,5 +1,7 @@
-const EMBEDDED_IMAGE_RE =
-  /(\{\s*"type"\s*:\s*"image_url"\s*,\s*"image_url"\s*:\s*\{\s*"url"\s*:\s*")?(data:image\/[\w.+-]+;base64,[A-Za-z0-9+/=]{64,})("\s*\}\s*\})?/g
+const EMBEDDED_IMAGE_PREFIX_RE = /\{\s*"type"\s*:\s*"image_url"\s*,\s*"image_url"\s*:\s*\{\s*"url"\s*:\s*"$/
+const EMBEDDED_IMAGE_SUFFIX_RE = /^"\s*\}\s*\}/
+const DATA_IMAGE_PREFIX_RE = /^data:image\/[\w.+-]+;base64,/i
+const BASE64_CHAR_RE = /^[A-Za-z0-9+/=]$/
 
 const DATA_URL_RE = /^data:([\w./+-]+);base64,(.*)$/i
 
@@ -37,13 +39,67 @@ export function extractEmbeddedImages(text: string): EmbeddedImageExtraction {
   }
 
   const images: string[] = []
+  const cleanedParts: string[] = []
+  let cursor = 0
+  let searchFrom = 0
 
-  const cleanedText = text
-    .replace(EMBEDDED_IMAGE_RE, (_match, _open, dataUrl: string) => {
-      images.push(dataUrl)
+  while (searchFrom < text.length) {
+    const urlStart = text.indexOf('data:image/', searchFrom)
 
-      return ''
-    })
+    if (urlStart < 0) {
+      break
+    }
+
+    const candidate = text.slice(urlStart, Math.min(text.length, urlStart + 128))
+    const prefixMatch = DATA_IMAGE_PREFIX_RE.exec(candidate)
+
+    if (!prefixMatch) {
+      searchFrom = urlStart + 'data:image/'.length
+      continue
+    }
+
+    let urlEnd = urlStart + prefixMatch[0].length
+
+    while (urlEnd < text.length && BASE64_CHAR_RE.test(text[urlEnd])) {
+      urlEnd += 1
+    }
+
+    // Keep short / malformed data URLs inline. The renderer only lifts real
+    // embedded images; tiny strings are usually examples or partial input.
+    if (urlEnd - urlStart - prefixMatch[0].length < 64) {
+      searchFrom = urlEnd
+      continue
+    }
+
+    let matchStart = urlStart
+    let matchEnd = urlEnd
+    const before = text.slice(Math.max(cursor, urlStart - 128), urlStart)
+    const prefixEnvelope = EMBEDDED_IMAGE_PREFIX_RE.exec(before)
+
+    if (prefixEnvelope) {
+      matchStart = urlStart - prefixEnvelope[0].length
+    }
+
+    const suffixEnvelope = EMBEDDED_IMAGE_SUFFIX_RE.exec(text.slice(urlEnd, urlEnd + 32))
+
+    if (suffixEnvelope) {
+      matchEnd = urlEnd + suffixEnvelope[0].length
+    }
+
+    cleanedParts.push(text.slice(cursor, matchStart))
+    images.push(text.slice(urlStart, urlEnd))
+    cursor = matchEnd
+    searchFrom = matchEnd
+  }
+
+  if (images.length === 0) {
+    return { cleanedText: text, images: [] }
+  }
+
+  cleanedParts.push(text.slice(cursor))
+
+  const cleanedText = cleanedParts
+    .join('')
     .replace(/[ \t]+\n/g, '\n')
     .replace(/\n{3,}/g, '\n\n')
     .trim()


### PR DESCRIPTION
## Summary
- Replace the large embedded image extraction regex with an iterative scanner for `data:image/...;base64` URLs
- Preserve JSON `image_url` envelope cleanup while avoiding regex backtracking/stack overflow on large pasted images
- Add regression coverage with an 8 MB pasted image data URL

## Test Plan
- [x] `cd apps/desktop && npm run test:ui -- src/lib/embedded-images.test.ts`
- [x] `cd apps/desktop && npm run typecheck`
- [x] `cd apps/desktop && npm run build`

## Notes
- Reproduced locally from Hermes Desktop renderer crashes with `RangeError: Maximum call stack size exceeded` when rendering messages containing very large pasted image data URLs.
