### PR TITLE
fix(agent): distinguish network unreachable from missing creds in provider init error

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -857,6 +857,20 @@ def init_agent(
                             _fb_resolved = True
                             break
                     if not _fb_resolved:
+                        # Check if the API key is actually present in the environment.
+                        # If it is, the resolution failure is likely a network/DNS issue
+                        # rather than a missing credential. This avoids misleading
+                        # "no API key" errors when the provider's endpoint is unreachable
+                        # (e.g., DNS outage, Tailscale down, proxy misconfiguration).
+                        _api_key_present = bool(os.getenv(_env_hint, "").strip())
+                        if _api_key_present:
+                            raise RuntimeError(
+                                f"Provider '{_explicit}' is set in config.yaml and "
+                                f"{_env_hint} is present in the environment, but the "
+                                f"provider could not be reached. Check your network "
+                                f"connection and DNS resolution, or switch to a "
+                                f"different provider with `hermes model`."
+                            )
                         raise RuntimeError(
                             f"Provider '{_explicit}' is set in config.yaml but no API key "
                             f"was found. Set the {_env_hint} environment "

--- a/tests/run_agent/test_init_fallback_network_error.py
+++ b/tests/run_agent/test_init_fallback_network_error.py
@@ -1,0 +1,43 @@
+"""Regression test for #47321: misleading "no API key" error when the
+provider endpoint is unreachable (e.g. DNS outage, Tailscale down).
+
+When the API key env var IS set but resolve_provider_client returns None
+because the endpoint can't be reached, the error should say "provider
+could not be reached" instead of "no API key was found"."""
+import os
+import pytest
+from unittest.mock import patch, MagicMock
+from run_agent import AIAgent
+
+
+def _make_tool_defs():
+    return [{"type": "function", "function": {"name": "web_search",
+             "description": "search", "parameters": {"type": "object", "properties": {}}}}]
+
+
+def test_init_raises_network_error_when_key_present_but_provider_unreachable():
+    """When the API key env var is set but resolve_provider_client returns
+    None (provider endpoint unreachable), the RuntimeError should say
+    'could not be reached', not 'no API key was found'."""
+    with patch.dict(os.environ, {"ALIBABA_CODING_PLAN_API_KEY": "sk-test-key-value-123456"}), \
+         patch("agent.auxiliary_client.resolve_provider_client", return_value=(None, None)), \
+         patch("run_agent.get_tool_definitions", return_value=_make_tool_defs()), \
+         patch("run_agent.check_toolset_requirements", return_value={}), \
+         patch("run_agent.OpenAI", return_value=MagicMock()):
+
+        with pytest.raises(RuntimeError) as excinfo:
+            AIAgent(
+                provider="alibaba-coding-plan",
+                model="qwen3.6-plus",
+                api_key=None,
+                base_url=None,
+                quiet_mode=True,
+                skip_context_files=True,
+                skip_memory=True,
+                fallback_model=None,
+            )
+        assert "could not be reached" in str(excinfo.value)
+        assert "ALIBABA_CODING_PLAN_API_KEY is present in the environment" in str(excinfo.value)
+        assert "Check your network" in str(excinfo.value)
+        # The old misleading error must NOT appear:
+        assert "no API key was found" not in str(excinfo.value)


### PR DESCRIPTION
## What does this PR do?

When `resolve_provider_client()` returns `None` during init-time fallback resolution, the error always said **"no API key was found"**. This was misleading when the API key was actually present in the environment but the provider endpoint was unreachable (e.g. DNS outage, Tailscale down, proxy misconfiguration).

## Related Issue

Fixes #47321

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/agent_init.py`: Before raising the "no API key" RuntimeError, check if the API key env var is actually set. If it is, raise a new error message saying the provider could not be reached (network/DNS issue) instead.

## How to Test

1. Set a provider API key in the environment (e.g. `export OLLAMA_API_KEY=sk-...`)
2. Make the provider endpoint unreachable (e.g. `iptables -A OUTPUT -d ollama.com -j DROP`)
3. Run `hermes` with that provider configured
4. **Before:** `RuntimeError: Provider 'ollama-cloud' is set in config.yaml but no API key was found.`
5. **After:** `RuntimeError: Provider 'ollama-cloud' is set in config.yaml and OLLAMA_API_KEY is present in the environment, but the provider could not be reached. Check your network connection and DNS resolution`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [x] I've added tests for my changes
- [x] I've tested on my platform: Linux