### PR TITLE
docs: add missing Prerequisites/How to Run sections to SKILL.md template

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -412,6 +412,12 @@ Brief intro.
 ## When to Use
 Trigger conditions — when should the agent load this skill?
 
+## Prerequisites
+Env vars, install steps, MCP setup, API key sourcing.
+
+## How to Run
+Canonical invocation through the `terminal` tool.
+
 ## Quick Reference
 Table of common commands or API calls.
 


### PR DESCRIPTION
## Summary
- The SKILL.md template example in `CONTRIBUTING.md` was missing the `## Prerequisites` and `## How to Run` sections.
- The "modern section order" guidance immediately below the template (section 5) lists both as required sections, so the template was inconsistent with the documented spec it is meant to illustrate.

## Test plan
- Docs-only change; no code or tests affected.
- Verified the template now matches the section order listed under "SKILL.md body uses the modern section order."
