### PR TITLE
fix: guard V4A Move File patch paths

### DIFF
--- a/tests/tools/test_cross_profile_guard.py
+++ b/tests/tools/test_cross_profile_guard.py
@@ -158,6 +158,23 @@ class TestPatchCrossProfileGuard:
         assert "cross-profile" in result["error"].lower()
         assert target.read_text() == original
 
+    def test_v4a_move_file_extracts_destination_for_guard(self, fake_hermes):
+        """Move File has a destination path that must not bypass guards."""
+        from tools.file_tools import patch_tool
+        source = "local-note.md"
+        target = fake_hermes["root"] / "skills" / "shared-skill" / "MOVED.md"
+        v4a = (
+            "*** Begin Patch\n"
+            f"*** Move File: {source} -> {target}\n"
+            "*** End Patch"
+        )
+        result_json = patch_tool(mode="patch", patch=v4a)
+        result = json.loads(result_json)
+        assert result.get("error"), f"V4A Move File destination must block: {result}"
+        lowered = result["error"].lower()
+        assert "cross-profile" in lowered or "sensitive" in lowered
+        assert not target.exists()
+
 
 # ---------------------------------------------------------------------------
 # skill_manage — error message naming other profile (item D)

--- a/tests/tools/test_file_tools.py
+++ b/tests/tools/test_file_tools.py
@@ -247,6 +247,54 @@ class TestPatchHandler:
         assert "error" in result
         assert "traversal" in result["error"].lower()
 
+    @patch("tools.file_tools._get_file_ops")
+    def test_patch_v4a_rejects_traversal_in_move_header(self, mock_get):
+        """Move File headers have two paths; both must pass V4A guards."""
+        from tools.file_tools import patch_tool
+        result = json.loads(patch_tool(
+            mode="patch",
+            patch=(
+                "*** Begin Patch\n"
+                "*** Move File: safe.py -> ../../../tmp/escaped.py\n"
+                "*** End Patch\n"
+            ),
+        ))
+        assert "error" in result
+        assert "traversal" in result["error"].lower()
+        mock_get.return_value.patch_v4a.assert_not_called()
+
+    @patch("tools.file_tools._get_file_ops")
+    def test_patch_v4a_guards_parser_accepted_no_space_header(self, mock_get):
+        """Guard extraction must accept the same header spacing as parser."""
+        from tools.file_tools import patch_tool
+        result = json.loads(patch_tool(
+            mode="patch",
+            patch=(
+                "*** Begin Patch\n"
+                "***Move File: safe.py -> ../../../tmp/escaped.py\n"
+                "*** End Patch\n"
+            ),
+        ))
+        assert "error" in result
+        assert "traversal" in result["error"].lower()
+        mock_get.return_value.patch_v4a.assert_not_called()
+
+    @patch("tools.file_tools._get_file_ops")
+    def test_patch_v4a_rejects_traversal_in_move_source(self, mock_get):
+        """Move File source paths are also destructive and must be guarded."""
+        from tools.file_tools import patch_tool
+        result = json.loads(patch_tool(
+            mode="patch",
+            patch=(
+                "*** Begin Patch\n"
+                "*** Move File: ../../../tmp/source.py -> safe.py\n"
+                "*** End Patch\n"
+            ),
+        ))
+        assert "error" in result
+        assert "traversal" in result["error"].lower()
+        mock_get.return_value.patch_v4a.assert_not_called()
+
 
 class TestSearchHandler:
     @patch("tools.file_tools._get_file_ops")

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -1272,8 +1272,12 @@ def patch_tool(mode: str = "replace", path: str = None, old_string: str = None,
     if mode == "patch" and patch:
         import re as _re
         from tools.path_security import has_traversal_component
-        for _m in _re.finditer(r'^\*\*\*\s+(?:Update|Add|Delete)\s+File:\s*(.+)$', patch, _re.MULTILINE):
-            v4a_path = _m.group(1).strip()
+        v4a_paths: list[str] = []
+        for _m in _re.finditer(r'^\*\*\*\s*(?:Update|Add|Delete)\s+File:\s*(.+)$', patch, _re.MULTILINE):
+            v4a_paths.append(_m.group(1).strip())
+        for _m in _re.finditer(r'^\*\*\*\s*Move\s+File:\s*(.+?)\s*->\s*(.+)$', patch, _re.MULTILINE):
+            v4a_paths.extend([_m.group(1).strip(), _m.group(2).strip()])
+        for v4a_path in v4a_paths:
             # V4A path headers come from patch CONTENT, not the explicit
             # ``path=`` arg — so they're more attacker-influenceable (skill
             # content, web extract, prompt injection). Reject ``..`` traversal
@@ -1286,7 +1290,8 @@ def patch_tool(mode: str = "replace", path: str = None, old_string: str = None,
                 return tool_error(
                     f"V4A patch header contains '..' traversal: {v4a_path!r}. "
                     "Use the agent's cwd-relative path (no '..') or an absolute "
-                    "path in '*** Update File:' / '*** Add File:' / '*** Delete File:' headers."
+                    "path in '*** Update File:' / '*** Add File:' / '*** Delete File:' / "
+                    "'*** Move File:' headers."
                 )
             _paths_to_check.append(v4a_path)
     for _p in _paths_to_check:


### PR DESCRIPTION
## Summary
- Extend V4A patch path extraction in \ to include \ headers.
- Validate both move source and destination paths before dispatching to \, so traversal, sensitive-path, cross-profile, and lock checks cover move operations too.
- Align guard extraction with the V4A parser's accepted optional whitespace after \, including \.

## Discovery / root cause
I found this by auditing file-tool path safety directly rather than working from an existing issue. The V4A parser accepts \ operations, but \ only extracted paths from \ headers before running the path guard pipeline. A \ header could therefore skip the preflight traversal/cross-profile/sensitive-path checks that other V4A operations receive.

Duplicate check: searched upstream issues for V4A/Move File/cross-profile patch variants and did not find an existing tracked issue for this specific bug.

## Behavior before
A patch like this reached \ instead of being rejected by the path guard:

\\\

The parser also accepts the no-space form \, while the old guard regex required whitespace after \.

## Behavior after
- \ source and destination paths are collected into the same guard list as \ paths.
- Parser-accepted no-space headers are guarded before \ runs.
- Traversal in either source or destination returns an error and does not invoke \.

## Test plan
- \......                                                                   [100%]
6 passed in 0.21s
  - Result: \
- Static added-line scan for hardcoded secrets, shell injection, eval/exec, pickle, and simple SQL string formatting: no findings.
- Independent reviewer pass: no blocking security or logic concerns after aligning the regex with parser spacing; added the reviewer-suggested source-path traversal regression test.