### PR TITLE
fix(agent): restore codex cache-affinity request headers

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -701,6 +701,13 @@ class _CodexCompletionsAdapter:
         # same behavior as the main agent's Codex transport.
         extra_body = kwargs.get("extra_body") or {}
         if isinstance(extra_body, dict):
+            request_headers = extra_body.get("_hermes_http_request_headers")
+            if isinstance(request_headers, dict) and request_headers:
+                resp_kwargs["_hermes_http_request_headers"] = {
+                    str(key): str(value)
+                    for key, value in request_headers.items()
+                    if key and value is not None
+                }
             reasoning_cfg = extra_body.get("reasoning")
             if isinstance(reasoning_cfg, dict):
                 if reasoning_cfg.get("enabled") is False:
@@ -835,13 +842,17 @@ class _CodexCompletionsAdapter:
 
             stream_kwargs = dict(resp_kwargs)
             stream_kwargs["stream"] = True
+            request_client = self._client
+            request_headers = stream_kwargs.pop("_hermes_http_request_headers", None)
+            if isinstance(request_headers, dict) and request_headers:
+                request_client = self._client.with_options(default_headers=request_headers)
 
             def _on_each_event(_event: Any) -> None:
                 # Re-check timeout/cancellation per event, matching the
                 # cadence the old in-line ``_check_cancelled()`` used.
                 _check_cancelled()
 
-            event_stream = self._client.responses.create(**stream_kwargs)
+            event_stream = request_client.responses.create(**stream_kwargs)
             try:
                 final = _consume_codex_event_stream(
                     event_stream,

--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -607,9 +607,13 @@ def run_codex_stream(agent, api_kwargs: dict, client: Any = None, on_first_delta
 
         stream_kwargs = dict(api_kwargs)
         stream_kwargs["stream"] = True
+        request_client = active_client
+        request_headers = stream_kwargs.pop("_hermes_http_request_headers", None)
+        if isinstance(request_headers, dict) and request_headers:
+            request_client = active_client.with_options(default_headers=request_headers)
 
         try:
-            event_stream = active_client.responses.create(**stream_kwargs)
+            event_stream = request_client.responses.create(**stream_kwargs)
         except (_httpx.RemoteProtocolError, _httpx.ReadTimeout, _httpx.ConnectError, ConnectionError) as exc:
             if attempt < max_stream_retries:
                 logger.debug(

--- a/agent/transports/codex.py
+++ b/agent/transports/codex.py
@@ -11,6 +11,9 @@ from agent.transports.base import ProviderTransport
 from agent.transports.types import NormalizedResponse, ToolCall
 
 
+CODEX_HTTP_REQUEST_HEADERS_KEY = "_hermes_http_request_headers"
+
+
 class ResponsesApiTransport(ProviderTransport):
     """Transport for api_mode='codex_responses'.
 
@@ -218,9 +221,19 @@ class ResponsesApiTransport(ProviderTransport):
             kwargs.pop("timeout", None)
 
         if is_codex_backend:
-            # chatgpt.com/backend-api/codex rejects body-level
-            # ``extra_headers`` with HTTP 400. Correlation/cache routing for
-            # this backend must not be sent through the Responses payload.
+            # chatgpt.com/backend-api/codex regressed badly on prompt-cache
+            # affinity once Hermes stopped sending the session correlation
+            # headers altogether. The backend still rejects caller-visible
+            # ``extra_headers`` here, so stash Hermes' own affinity headers on
+            # a private kwarg for the runtime to apply as real HTTP headers via
+            # ``client.with_options(default_headers=...)`` before the SDK call.
+            prompt_cache_key = kwargs.get("prompt_cache_key")
+            cache_scope_id = str(prompt_cache_key or session_id or "").strip()
+            if cache_scope_id:
+                kwargs[CODEX_HTTP_REQUEST_HEADERS_KEY] = {
+                    "session_id": cache_scope_id,
+                    "x-client-request-id": cache_scope_id,
+                }
             kwargs.pop("extra_headers", None)
 
         max_tokens = params.get("max_tokens")

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -30,6 +30,7 @@ from agent.auxiliary_client import (
     _resolve_xai_oauth_for_aux,
     _CodexCompletionsAdapter,
 )
+from agent.transports.codex import CODEX_HTTP_REQUEST_HEADERS_KEY
 
 
 def _jwt_with_claims(claims: dict) -> str:
@@ -3391,6 +3392,69 @@ class TestAuxiliaryClientPoisonedCacheEviction:
         finally:
             with _client_cache_lock:
                 _client_cache.clear()
+
+    def test_codex_adapter_promotes_affinity_headers_to_client_options(self):
+        captured = {}
+
+        class _FakeCreateStream:
+            def __iter__(self):
+                message_item = SimpleNamespace(
+                    type="message",
+                    role="assistant",
+                    status="completed",
+                    content=[SimpleNamespace(type="output_text", text="hi")],
+                )
+                return iter(
+                    [
+                        SimpleNamespace(type="response.created"),
+                        SimpleNamespace(type="response.output_item.done", item=message_item),
+                        SimpleNamespace(
+                            type="response.completed",
+                            response=SimpleNamespace(
+                                status="completed",
+                                id="resp_test",
+                                usage=SimpleNamespace(input_tokens=1, output_tokens=1, total_tokens=2),
+                            ),
+                        ),
+                    ]
+                )
+
+            def close(self):
+                pass
+
+        class _WrappedClient:
+            def __init__(self, headers):
+                self.responses = SimpleNamespace(create=self._create)
+                self._headers = headers
+
+            def _create(self, **kwargs):
+                captured["headers"] = dict(self._headers)
+                captured["kwargs"] = dict(kwargs)
+                return _FakeCreateStream()
+
+        class _BaseClient:
+            def with_options(self, **kwargs):
+                captured["with_options"] = dict(kwargs)
+                return _WrappedClient(kwargs.get("default_headers") or {})
+
+        adapter = _CodexCompletionsAdapter(_BaseClient(), "gpt-5.5")
+        response = adapter.create(
+            messages=[{"role": "user", "content": "hi"}],
+            extra_body={
+                CODEX_HTTP_REQUEST_HEADERS_KEY: {
+                    "session_id": "sess-aux-1",
+                    "x-client-request-id": "sess-aux-1",
+                }
+            },
+        )
+
+        assert captured["with_options"]["default_headers"] == {
+            "session_id": "sess-aux-1",
+            "x-client-request-id": "sess-aux-1",
+        }
+        assert CODEX_HTTP_REQUEST_HEADERS_KEY not in captured["kwargs"]
+        assert captured["kwargs"]["stream"] is True
+        assert response.choices[0].message.content == "hi"
 
     def test_call_llm_evicts_on_connection_error_with_explicit_provider(self):
         """Connection error on an explicit provider must drop the cached client.

--- a/tests/agent/transports/test_codex_transport.py
+++ b/tests/agent/transports/test_codex_transport.py
@@ -4,6 +4,7 @@ import json
 import pytest
 from types import SimpleNamespace
 
+from agent.transports.codex import CODEX_HTTP_REQUEST_HEADERS_KEY
 from agent.transports import get_transport
 from agent.transports.types import NormalizedResponse
 
@@ -155,7 +156,7 @@ class TestCodexBuildKwargs:
         )
         assert "max_output_tokens" not in kw
 
-    def test_codex_backend_does_not_set_extra_headers(self, transport):
+    def test_codex_backend_stashes_affinity_headers_out_of_band(self, transport):
         messages = [{"role": "user", "content": "Hi"}]
 
         kw = transport.build_kwargs(
@@ -167,6 +168,10 @@ class TestCodexBuildKwargs:
         )
 
         assert "extra_headers" not in kw
+        assert kw[CODEX_HTTP_REQUEST_HEADERS_KEY] == {
+            "session_id": "conv-codex-1",
+            "x-client-request-id": "conv-codex-1",
+        }
 
     def test_codex_backend_strips_caller_extra_headers(self, transport):
         messages = [{"role": "user", "content": "Hi"}]
@@ -181,6 +186,10 @@ class TestCodexBuildKwargs:
         )
 
         assert "extra_headers" not in kw
+        assert kw[CODEX_HTTP_REQUEST_HEADERS_KEY] == {
+            "session_id": "conv-codex-1",
+            "x-client-request-id": "conv-codex-1",
+        }
 
     def test_non_codex_responses_preserves_caller_extra_headers(self, transport):
         messages = [{"role": "user", "content": "Hi"}]

--- a/tests/run_agent/test_run_agent_codex_responses.py
+++ b/tests/run_agent/test_run_agent_codex_responses.py
@@ -4,6 +4,8 @@ from types import SimpleNamespace
 
 import pytest
 
+from agent.transports.codex import CODEX_HTTP_REQUEST_HEADERS_KEY
+
 
 sys.modules.setdefault("fire", types.SimpleNamespace(Fire=lambda *a, **k: None))
 sys.modules.setdefault("firecrawl", types.SimpleNamespace(Firecrawl=object))
@@ -688,6 +690,53 @@ def test_run_codex_stream_ignores_completed_response_with_null_output(monkeypatc
     assert response.status == "completed"
     assert response.output == [output_item]
     assert response.usage.total_tokens == 11
+
+
+def test_run_codex_stream_promotes_affinity_headers_to_client_options(monkeypatch):
+    agent = _build_agent(monkeypatch)
+    captured = {}
+
+    class _WrappedClient:
+        def __init__(self, headers):
+            self.responses = SimpleNamespace(create=self._create)
+            self._headers = headers
+
+        def _create(self, **kwargs):
+            captured["headers"] = dict(self._headers)
+            captured["kwargs"] = dict(kwargs)
+            return _FakeCreateStream(
+                [
+                    SimpleNamespace(type="response.created"),
+                    SimpleNamespace(
+                        type="response.completed",
+                        response=_codex_message_response("ok"),
+                    ),
+                ]
+            )
+
+    class _BaseClient:
+        def with_options(self, **kwargs):
+            captured["with_options"] = dict(kwargs)
+            return _WrappedClient(kwargs.get("default_headers") or {})
+
+    agent.client = _BaseClient()
+    response = agent._run_codex_stream(
+        {
+            **_codex_request_kwargs(),
+            CODEX_HTTP_REQUEST_HEADERS_KEY: {
+                "session_id": "sess-123",
+                "x-client-request-id": "sess-123",
+            },
+        }
+    )
+
+    assert captured["with_options"]["default_headers"] == {
+        "session_id": "sess-123",
+        "x-client-request-id": "sess-123",
+    }
+    assert CODEX_HTTP_REQUEST_HEADERS_KEY not in captured["kwargs"]
+    assert captured["kwargs"]["stream"] is True
+    assert response.status == "completed"
 
 
 def test_run_conversation_codex_plain_text(monkeypatch):


### PR DESCRIPTION
## What does this PR do?

Restores Hermes' Codex cache-affinity routing on `chatgpt.com/backend-api/codex` by carrying `session_id` / `x-client-request-id` as real HTTP request headers again, without reintroducing the backend-visible `extra_headers` payload shape that previously caused 400s.

## Related Issue

Fixes #47335

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/transports/codex.py`: stash Codex-only cache-affinity headers on a private internal kwarg instead of exposing them as `extra_headers` on the request payload.
- `agent/codex_runtime.py`: promote the private affinity headers into real per-request HTTP headers with `client.with_options(default_headers=...)` before `responses.create(stream=True)`.
- `agent/auxiliary_client.py`: mirror the same promotion path for auxiliary Codex Responses calls.
- `tests/agent/transports/test_codex_transport.py`: assert Codex affinity headers are preserved out-of-band while caller-visible `extra_headers` stay stripped.
- `tests/run_agent/test_run_agent_codex_responses.py`: assert the main stream runtime upgrades the private affinity headers into client request options.
- `tests/agent/test_auxiliary_client.py`: add the same runtime assertion for the auxiliary Codex adapter.

## What changed and why

The regression started when Hermes stopped sending Codex cache-affinity correlation headers entirely after `fix(codex): drop extra_headers for chatgpt.com backend`. `prompt_cache_key=session_id` remained, but the user report showed cache hit rate collapse on `openai-codex` / `gpt-5.5`. This patch keeps the request body clean for the ChatGPT Codex backend while still restoring the session correlation headers as true HTTP headers, which matches the issue's suspected failure mode without reviving the rejected payload field.

## How to Test

1. Run the covering subset with a writable Hermes home:
   `HERMES_HOME=$(mktemp -d) pytest tests/agent/transports/test_codex_transport.py tests/run_agent/test_run_agent_codex_responses.py::test_build_api_kwargs_codex tests/run_agent/test_run_agent_codex_responses.py::test_run_codex_stream_promotes_affinity_headers_to_client_options tests/agent/test_auxiliary_client.py -q -k 'codex_adapter_promotes_affinity_headers_to_client_options or test_build_api_kwargs_codex or test_run_codex_stream_promotes_affinity_headers_to_client_options or test_codex_backend_stashes_affinity_headers_out_of_band or test_codex_backend_strips_caller_extra_headers'`
2. Confirm the subset passes and that the runtime tests show `_hermes_http_request_headers` is removed from request kwargs and applied via `with_options(default_headers=...)`.
3. Run the repo-wide command:
   `HERMES_HOME=$(mktemp -d) /opt/homebrew/bin/timeout -k 30 480 sh -c 'pytest tests/ -q -x --timeout=60 "$@"' sh`
4. In this sandbox, step 3 stops early in unrelated collection at `tests/hermes_cli/test_dashboard_auth_401_reauth.py` because `fastapi` is unavailable; in a full dev environment it should continue past that point.
5. Run `python scripts/check-windows-footguns.py --diff "$(git merge-base origin/main HEAD)"` and `git diff --check`.

## What platforms tested on

- macOS 15 / darwin-arm64 (local sandbox)

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 / darwin-arm64

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Not applicable.

<!-- autocontrib:worker-id=issue-new-4e877c18 kind=pr-open -->