### PR TITLE
feat: add configurable command_blocklist to terminal security

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2055,6 +2055,7 @@ DEFAULT_CONFIG = {
 
     # Permanently allowed dangerous command patterns (added via "always" approval)
     "command_allowlist": [],
+    "command_blocklist": [],
     # User-defined quick commands that bypass the agent loop (type: exec only)
     "quick_commands": {},
 

--- a/tests/tools/test_approval.py
+++ b/tests/tools/test_approval.py
@@ -1713,3 +1713,566 @@ class TestApprovalTimeoutIsNotConsent:
         assert last_post.get("choice") == "timeout", (
             f"hook choice should be 'timeout' on no-response, got {last_post.get('choice')!r}"
         )
+"""Tests for the configurable command blocklist feature.
+
+Covers:
+- Blocklist pattern compilation and matching
+- All three entry points (check_all_command_guards, check_dangerous_command,
+  check_execute_code_guard)
+- force=True does NOT bypass blocklist
+- blocklisted: True flag propagation
+- Word-boundary anchoring (pip blocks pip install but not pipeline)
+- Empty blocklist is a no-op
+- Lock safety for pattern compilation
+"""
+
+import json
+import re
+import threading
+
+import tools.approval as ap
+from tools.approval import (
+    _blocklist_block_result,
+    _compile_blocklist_patterns,
+    _permanent_blocked,
+    check_all_command_guards,
+    check_dangerous_command,
+    check_execute_code_guard,
+    detect_blocked_command,
+    load_permanent_blocklist,
+)
+
+
+class TestBlocklistPatternCompilation:
+    """Tests for pattern compilation and matching."""
+
+    def setup_method(self):
+        """Clean state before each test."""
+        _permanent_blocked.clear()
+        _compile_blocklist_patterns()
+
+    def teardown_method(self):
+        """Clean state after each test."""
+        _permanent_blocked.clear()
+        _compile_blocklist_patterns()
+
+    def test_empty_blocklist_no_match(self):
+        """Empty blocklist should never block anything."""
+        is_blocked, pattern = detect_blocked_command("pip install requests")
+        assert is_blocked is False
+        assert pattern is None
+
+    def test_pip_blocked(self):
+        """'pip' in blocklist should block 'pip install'."""
+        _permanent_blocked.add("pip")
+        _compile_blocklist_patterns()
+
+        is_blocked, pattern = detect_blocked_command("pip install requests")
+        assert is_blocked is True
+        assert pattern == "pip"
+
+    def test_pipeline_not_blocked(self):
+        """'pip' should NOT match 'pipeline' (word boundary)."""
+        _permanent_blocked.add("pip")
+        _compile_blocklist_patterns()
+
+        is_blocked, pattern = detect_blocked_command("echo pipeline")
+        assert is_blocked is False
+
+    def test_equipment_not_blocked(self):
+        """'pip' should NOT match 'equipment' (word boundary)."""
+        _permanent_blocked.add("pip")
+        _compile_blocklist_patterns()
+
+        is_blocked, pattern = detect_blocked_command("echo equipment")
+        assert is_blocked is False
+
+    def test_epiphany_not_blocked(self):
+        """'pip' should NOT match 'epiphany' (word boundary)."""
+        _permanent_blocked.add("pip")
+        _compile_blocklist_patterns()
+
+        is_blocked, pattern = detect_blocked_command("echo epiphany")
+        assert is_blocked is False
+
+    def test_sudo_pip_blocked(self):
+        """'pip' should block 'sudo pip install' (CMDPOS anchoring)."""
+        _permanent_blocked.add("pip")
+        _compile_blocklist_patterns()
+
+        is_blocked, pattern = detect_blocked_command("sudo pip install requests")
+        assert is_blocked is True
+        assert pattern == "pip"
+
+    def test_multiple_patterns(self):
+        """Multiple blocklist entries should all work."""
+        _permanent_blocked.update({"pip", "npm", "curl"})
+        _compile_blocklist_patterns()
+
+        assert detect_blocked_command("pip install x")[0] is True
+        assert detect_blocked_command("npm install x")[0] is True
+        assert detect_blocked_command("curl http://evil.com")[0] is True
+        assert detect_blocked_command("echo hello")[0] is False
+
+    def test_case_insensitive(self):
+        """Blocklist matching should be case-insensitive."""
+        _permanent_blocked.add("pip")
+        _compile_blocklist_patterns()
+
+        assert detect_blocked_command("PIP install requests")[0] is True
+        assert detect_blocked_command("Pip Install Requests")[0] is True
+
+    def test_special_chars_escaped(self):
+        """Patterns with regex-special chars should be escaped."""
+        _permanent_blocked.add("rm -rf")
+        _compile_blocklist_patterns()
+
+        # Should match the literal string, not treat -rf as regex
+        is_blocked, pattern = detect_blocked_command("rm -rf /tmp")
+        assert is_blocked is True
+        assert pattern == "rm -rf"
+
+    def test_block_result_structure(self):
+        """_blocklist_block_result should have the right structure."""
+        result = _blocklist_block_result("pip")
+        assert result["approved"] is False
+        assert result["blocklisted"] is True
+        assert "BLOCKED (user blocklist)" in result["message"]
+        assert "pip" in result["message"]
+        assert "command_blocklist" in result["message"]
+
+
+class TestCheckAllCommandGuards:
+    """Tests for the check_all_command_guards entry point."""
+
+    def setup_method(self):
+        _permanent_blocked.clear()
+        _compile_blocklist_patterns()
+
+    def teardown_method(self):
+        _permanent_blocked.clear()
+        _compile_blocklist_patterns()
+
+    def test_empty_blocklist_approves(self):
+        """Empty blocklist: normal commands should be approved."""
+        r = check_all_command_guards("echo hello", "local")
+        assert r["approved"] is True
+
+    def test_pip_blocked_in_guards(self):
+        """Blocklisted command should be blocked in check_all_command_guards."""
+        _permanent_blocked.add("pip")
+        _compile_blocklist_patterns()
+
+        r = check_all_command_guards("pip install requests", "local")
+        assert r["approved"] is False
+        assert r.get("blocklisted") is True
+
+    def test_pipeline_not_blocked_in_guards(self):
+        """'pipeline' should NOT be blocked by 'pip' entry."""
+        _permanent_blocked.add("pip")
+        _compile_blocklist_patterns()
+
+        r = check_all_command_guards("echo pipeline", "local")
+        assert r["approved"] is True
+
+    def test_blocklist_before_container_skip(self):
+        """Blocklist should fire even for Docker env_type."""
+        _permanent_blocked.add("pip")
+        _compile_blocklist_patterns()
+
+        r = check_all_command_guards("pip install requests", "docker")
+        assert r["approved"] is False
+        assert r.get("blocklisted") is True
+
+    def test_blocklist_before_yolo(self, monkeypatch):
+        """Blocklist should fire even with YOLO mode."""
+        _permanent_blocked.add("pip")
+        _compile_blocklist_patterns()
+
+        monkeypatch.setattr(ap, "_YOLO_MODE_FROZEN", True)
+        r = check_all_command_guards("pip install requests", "local")
+        assert r["approved"] is False
+        assert r.get("blocklisted") is True
+
+
+class TestCheckDangerousCommand:
+    """Tests for the check_dangerous_command entry point."""
+
+    def setup_method(self):
+        _permanent_blocked.clear()
+        _compile_blocklist_patterns()
+
+    def teardown_method(self):
+        _permanent_blocked.clear()
+        _compile_blocklist_patterns()
+
+    def test_empty_blocklist_approves(self):
+        """Empty blocklist: normal commands should be approved."""
+        r = check_dangerous_command("echo hello", "local")
+        assert r["approved"] is True
+
+    def test_pip_blocked_in_dangerous(self):
+        """Blocklisted command should be blocked in check_dangerous_command."""
+        _permanent_blocked.add("pip")
+        _compile_blocklist_patterns()
+
+        r = check_dangerous_command("pip install requests", "local")
+        assert r["approved"] is False
+        assert r.get("blocklisted") is True
+
+    def test_pipeline_not_blocked_in_dangerous(self):
+        """'pipeline' should NOT be blocked by 'pip' entry."""
+        _permanent_blocked.add("pip")
+        _compile_blocklist_patterns()
+
+        r = check_dangerous_command("echo pipeline", "local")
+        assert r["approved"] is True
+
+    def test_blocklist_before_container_skip(self):
+        """Blocklist should fire even for Docker env_type."""
+        _permanent_blocked.add("pip")
+        _compile_blocklist_patterns()
+
+        r = check_dangerous_command("pip install requests", "docker")
+        assert r["approved"] is False
+        assert r.get("blocklisted") is True
+
+    def test_blocklist_before_yolo(self, monkeypatch):
+        """Blocklist should fire even with YOLO mode."""
+        _permanent_blocked.add("pip")
+        _compile_blocklist_patterns()
+
+        monkeypatch.setattr(ap, "_YOLO_MODE_FROZEN", True)
+        r = check_dangerous_command("pip install requests", "local")
+        assert r["approved"] is False
+        assert r.get("blocklisted") is True
+
+
+class TestCheckExecuteCodeGuard:
+    """Tests for the check_execute_code_guard entry point."""
+
+    def setup_method(self):
+        _permanent_blocked.clear()
+        _compile_blocklist_patterns()
+
+    def teardown_method(self):
+        _permanent_blocked.clear()
+        _compile_blocklist_patterns()
+
+    def test_empty_blocklist_approves(self):
+        """Empty blocklist: execute_code should be approved."""
+        r = check_execute_code_guard("print('hello')", "local")
+        assert r["approved"] is True
+
+    def test_execute_code_blocked_by_pattern(self):
+        """If 'execute_code' is in blocklist, it should block."""
+        _permanent_blocked.add("execute_code")
+        _compile_blocklist_patterns()
+
+        r = check_execute_code_guard("print('hello')", "local")
+        assert r["approved"] is False
+        assert r.get("blocklisted") is True
+
+    def test_execute_code_not_blocked_by_unrelated(self):
+        """'pip' in blocklist should NOT block execute_code."""
+        _permanent_blocked.add("pip")
+        _compile_blocklist_patterns()
+
+        r = check_execute_code_guard("print('hello')", "local")
+        assert r["approved"] is True
+
+
+class TestForceDoesNotBypassBlocklist:
+    """force=True must NOT bypass the blocklist in terminal_tool."""
+
+    def setup_method(self):
+        _permanent_blocked.clear()
+        _compile_blocklist_patterns()
+
+    def teardown_method(self):
+        _permanent_blocked.clear()
+        _compile_blocklist_patterns()
+
+    def test_force_true_blocked(self):
+        """Even with force=True, blocklisted commands are blocked."""
+        _permanent_blocked.add("pip")
+        _compile_blocklist_patterns()
+
+        # Simulate what terminal_tool does: check blocklist before force guard
+        from tools.approval import detect_blocked_command, _blocklist_block_result
+
+        is_blocked, blocked_pattern = detect_blocked_command("pip install requests")
+        assert is_blocked is True
+
+        result = _blocklist_block_result(blocked_pattern)
+        assert result["approved"] is False
+        assert result["blocklisted"] is True
+
+        # The JSON response should include blocklisted: True
+        response = json.loads(json.dumps(result, ensure_ascii=False))
+        assert response["blocklisted"] is True
+
+
+class TestBlocklistedFlagPropagation:
+    """The blocklisted: True flag must appear in terminal_tool JSON responses."""
+
+    def test_blocklisted_flag_in_result(self):
+        """_blocklist_block_result includes blocklisted: True."""
+        result = _blocklist_block_result("pip")
+        assert result["blocklisted"] is True
+
+    def test_blocklisted_flag_in_json(self):
+        """JSON serialization preserves blocklisted: True."""
+        result = _blocklist_block_result("pip")
+        json_str = json.dumps(result, ensure_ascii=False)
+        parsed = json.loads(json_str)
+        assert parsed["blocklisted"] is True
+
+    def test_blocklisted_flag_in_terminal_tool_response(self):
+        """The terminal_tool blocked response construction propagates the flag."""
+        # Simulate the terminal_tool blocked response construction
+        approval = _blocklist_block_result("pip")
+        fallback_msg = "Command denied: pip. Use the approval prompt to allow it."
+
+        response = json.dumps({
+            "output": "",
+            "exit_code": -1,
+            "error": approval.get("message", fallback_msg),
+            "status": "blocked",
+            **({"blocklisted": True} if approval.get("blocklisted") else {}),
+        }, ensure_ascii=False)
+
+        parsed = json.loads(response)
+        assert parsed["blocklisted"] is True
+        assert parsed["status"] == "blocked"
+        assert "BLOCKED (user blocklist)" in parsed["error"]
+
+    def test_no_blocklisted_flag_when_not_blocklisted(self):
+        """When not blocklisted, the flag should NOT appear."""
+        approval = {"approved": False, "message": "BLOCKED: User denied."}
+        fallback_msg = "Command denied."
+
+        response = json.dumps({
+            "output": "",
+            "exit_code": -1,
+            "error": approval.get("message", fallback_msg),
+            "status": "blocked",
+            **({"blocklisted": True} if approval.get("blocklisted") else {}),
+        }, ensure_ascii=False)
+
+        parsed = json.loads(response)
+        assert "blocklisted" not in parsed
+
+
+class TestLockSafety:
+    """The _BLOCKLIST_PATTERNS_COMPILED assignment must be inside the lock."""
+
+    def test_compile_under_lock(self):
+        """Verify _compile_blocklist_patterns holds the lock during assignment."""
+        _permanent_blocked.add("pip")
+        _compile_blocklist_patterns()
+
+        # After compilation, patterns should be available
+        is_blocked, pattern = detect_blocked_command("pip install requests")
+        assert is_blocked is True
+
+    def test_concurrent_compile_and_read(self):
+        """Concurrent compilation and reading should be safe."""
+        _permanent_blocked.add("pip")
+        _compile_blocklist_patterns()
+
+        errors = []
+
+        def reader():
+            try:
+                for _ in range(100):
+                    detect_blocked_command("pip install requests")
+            except Exception as e:
+                errors.append(e)
+
+        def compiler():
+            try:
+                for _ in range(10):
+                    _permanent_blocked.add("npm")
+                    _compile_blocklist_patterns()
+                    _permanent_blocked.discard("npm")
+                    _compile_blocklist_patterns()
+            except Exception as e:
+                errors.append(e)
+
+        threads = []
+        for _ in range(5):
+            threads.append(threading.Thread(target=reader))
+            threads.append(threading.Thread(target=compiler))
+
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join(timeout=5)
+
+        assert not errors, f"Concurrent access errors: {errors}"
+
+
+class TestLoadPermanentBlocklist:
+    """Tests for load_permanent_blocklist."""
+
+    def setup_method(self):
+        _permanent_blocked.clear()
+        _compile_blocklist_patterns()
+
+    def teardown_method(self):
+        _permanent_blocked.clear()
+        _compile_blocklist_patterns()
+
+    def test_load_from_config(self):
+        """load_permanent_blocklist should load from config."""
+        from unittest.mock import patch as mock_patch
+
+        with mock_patch(
+            "hermes_cli.config.load_config",
+            return_value={"command_blocklist": ["pip", "npm"]},
+        ):
+            patterns = load_permanent_blocklist()
+            assert patterns == {"pip", "npm"}
+            assert "pip" in _permanent_blocked
+            assert "npm" in _permanent_blocked
+
+    def test_load_empty_config(self):
+        """Empty config should not add anything."""
+        from unittest.mock import patch as mock_patch
+
+        with mock_patch(
+            "hermes_cli.config.load_config",
+            return_value={},
+        ):
+            patterns = load_permanent_blocklist()
+            assert patterns == set()
+            assert len(_permanent_blocked) == 0
+
+    def test_load_config_error(self):
+        """Config load error should return empty set."""
+        from unittest.mock import patch as mock_patch
+
+        with mock_patch(
+            "hermes_cli.config.load_config",
+            side_effect=Exception("config error"),
+        ):
+            patterns = load_permanent_blocklist()
+            assert patterns == set()
+
+
+class TestTypeAnnotations:
+    """Verify type annotations are present and correct."""
+
+    def test_blocklist_patterns_compiled_type(self):
+        """_BLOCKLIST_PATTERNS_COMPILED has correct type annotation."""
+        # Check the annotation exists by inspecting the module
+        import ast
+        import inspect
+
+        source = inspect.getsource(ap)
+        tree = ast.parse(source)
+
+        # Find the assignment with annotation
+        found = False
+        for node in ast.walk(tree):
+            if isinstance(node, ast.AnnAssign) and isinstance(node.target, ast.Name):
+                if node.target.id == "_BLOCKLIST_PATTERNS_COMPILED":
+                    found = True
+                    # Verify it's a subscript (list[...])
+                    assert isinstance(node.annotation, ast.Subscript), (
+                        "Expected subscript type annotation"
+                    )
+                    break
+
+        assert found, "_BLOCKLIST_PATTERNS_COMPILED type annotation not found"
+
+    def test_permanent_blocked_type(self):
+        """_permanent_blocked has correct type annotation."""
+        import ast
+        import inspect
+
+        source = inspect.getsource(ap)
+        tree = ast.parse(source)
+
+        found = False
+        for node in ast.walk(tree):
+            if isinstance(node, ast.AnnAssign) and isinstance(node.target, ast.Name):
+                if node.target.id == "_permanent_blocked":
+                    found = True
+                    assert isinstance(node.annotation, ast.Subscript)
+                    break
+
+        assert found, "_permanent_blocked type annotation not found"
+
+    def test_detect_blocked_command_return_type(self):
+        """detect_blocked_command has correct return type annotation."""
+        import ast
+        import inspect
+
+        source = inspect.getsource(ap)
+        tree = ast.parse(source)
+
+        found = False
+        for node in ast.walk(tree):
+            if isinstance(node, ast.FunctionDef) and node.name == "detect_blocked_command":
+                found = True
+                # Check returns annotation
+                assert node.returns is not None, "Missing return type annotation"
+                assert isinstance(node.returns, ast.Subscript), (
+                    "Expected subscript return type"
+                )
+                break
+
+        assert found, "detect_blocked_command function not found"
+
+    def test_blocklist_block_result_return_type(self):
+        """_blocklist_block_result has correct return type annotation."""
+        import ast
+        import inspect
+
+        source = inspect.getsource(ap)
+        tree = ast.parse(source)
+
+        found = False
+        for node in ast.walk(tree):
+            if isinstance(node, ast.FunctionDef) and node.name == "_blocklist_block_result":
+                found = True
+                assert node.returns is not None, "Missing return type annotation"
+                break
+
+        assert found, "_blocklist_block_result function not found"
+
+    def test_load_permanent_blocklist_return_type(self):
+        """load_permanent_blocklist has correct return type annotation."""
+        import ast
+        import inspect
+
+        source = inspect.getsource(ap)
+        tree = ast.parse(source)
+
+        found = False
+        for node in ast.walk(tree):
+            if isinstance(node, ast.FunctionDef) and node.name == "load_permanent_blocklist":
+                found = True
+                assert node.returns is not None, "Missing return type annotation"
+                break
+
+        assert found, "load_permanent_blocklist function not found"
+
+    def test_compile_blocklist_patterns_return_type(self):
+        """_compile_blocklist_patterns has correct return type annotation."""
+        import ast
+        import inspect
+
+        source = inspect.getsource(ap)
+        tree = ast.parse(source)
+
+        found = False
+        for node in ast.walk(tree):
+            if isinstance(node, ast.FunctionDef) and node.name == "_compile_blocklist_patterns":
+                found = True
+                assert node.returns is not None, "Missing return type annotation"
+                break
+
+        assert found, "_compile_blocklist_patterns function not found"

--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -145,7 +145,7 @@ class TestChildSystemPrompt(unittest.TestCase):
 
 class TestStripBlockedTools(unittest.TestCase):
     def test_removes_blocked_toolsets(self):
-        result = _strip_blocked_tools(["terminal", "file", "delegation", "clarify", "memory", "code_execution"])
+        result = _strip_blocked_tools(["terminal", "file", "delegation", "clarify", "memory", "code_execution", "skills"])
         self.assertEqual(sorted(result), ["file", "terminal"])
 
     def test_preserves_allowed_toolsets(self):

--- a/tests/tools/test_delegate_toolset_scope.py
+++ b/tests/tools/test_delegate_toolset_scope.py
@@ -46,12 +46,13 @@ class TestToolsetIntersection:
         assert "file" in child
         assert "web" in child
 
-    def test_strip_blocked_removes_delegation(self):
-        """Blocked toolsets (delegation, clarify, etc.) are always removed."""
-        child = _strip_blocked_tools(["terminal", "delegation", "clarify", "memory"])
+    def test_strip_blocked_removes_blocked(self):
+        """Blocked toolsets (delegation, clarify, memory, skills) are always removed."""
+        child = _strip_blocked_tools(["terminal", "delegation", "clarify", "memory", "skills"])
         assert "delegation" not in child
         assert "clarify" not in child
         assert "memory" not in child
+        assert "skills" not in child
         assert "terminal" in child
 
     def test_empty_intersection_yields_empty_toolsets(self):

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -16,7 +16,7 @@ import sys
 import threading
 import time
 import unicodedata
-from typing import Optional
+from typing import Any, Optional
 from hermes_cli.config import cfg_get
 
 from utils import env_var_enabled, is_truthy_value
@@ -293,6 +293,13 @@ HARDLINE_PATTERNS_COMPILED = [
     for pattern, description in HARDLINE_PATTERNS
 ]
 
+# Pre-compiled user blocklist patterns. Built at module load time from
+# config.yaml's command_blocklist. Each user-provided pattern is
+# re.escape()'d and anchored with _CMDPOS + word boundary to prevent
+# false positives (e.g. "pip" matching "pipeline" or "uv" matching
+# "uvicorn").
+_BLOCKLIST_PATTERNS_COMPILED: list[tuple[re.Pattern, str]] = []
+
 
 # =========================================================================
 # Sudo stdin guard — block password guessing via "sudo -S"
@@ -341,6 +348,22 @@ def detect_hardline_command(command: str) -> tuple:
     return (False, None)
 
 
+def detect_blocked_command(command: str) -> tuple[bool, str | None]:
+    """Check if a command matches any user-configured blocklist pattern.
+
+    Uses _CMDPOS anchoring + word boundaries (like the hardline patterns)
+    so "pip" blocks "pip install" but not "pipeline" or "equipment".
+
+    Returns:
+        (is_blocked, matching_pattern) or (False, None)
+    """
+    normalized = _normalize_command_for_detection(command).lower()
+    for pattern_re, raw_pattern in _BLOCKLIST_PATTERNS_COMPILED:
+        if pattern_re.search(normalized):
+            return (True, raw_pattern)
+    return (False, None)
+
+
 def _hardline_block_result(description: str) -> dict:
     """Build the standard block result for a hardline match."""
     return {
@@ -353,6 +376,23 @@ def _hardline_block_result(description: str) -> dict:
             "approvals.mode=off, or cron approve mode. If you genuinely "
             "need to run it, run it yourself in a terminal outside the "
             "agent."
+        ),
+    }
+
+
+def _blocklist_block_result(pattern: str) -> dict[str, Any]:
+    """Build the standard block result for a user-configured blocklist match."""
+    return {
+        "approved": False,
+        "blocklisted": True,
+        "message": (
+            f"BLOCKED (user blocklist): '{pattern}' matches your "
+            f"command_blocklist entry. This command is on your configured "
+            f"blocklist and cannot be executed via the agent — not even "
+            f"with --yolo, /yolo, or approvals.mode=off. Remove it from "
+            f"command_blocklist in ~/.hermes/config.yaml if you need to "
+            f"run it, or run the command yourself in a terminal outside "
+            f"the agent."
         ),
     }
 
@@ -675,6 +715,7 @@ _pending: dict[str, dict] = {}
 _session_approved: dict[str, set] = {}
 _session_yolo: set[str] = set()
 _permanent_approved: set = set()
+_permanent_blocked: set[str] = set()
 
 # =========================================================================
 # Blocking gateway approval (mirrors CLI's synchronous input() flow)
@@ -874,6 +915,39 @@ def save_permanent_allowlist(patterns: set):
         save_config(config)
     except Exception as e:
         logger.warning("Could not save allowlist: %s", e)
+
+
+def load_permanent_blocklist() -> set[str]:
+    """Load permanently blocked command patterns from config."""
+    try:
+        from hermes_cli.config import load_config
+        config = load_config()
+        patterns = set(config.get("command_blocklist", []) or [])
+        with _lock:
+            _permanent_blocked.update(patterns)
+        return patterns
+    except Exception as e:
+        logger.warning("Failed to load blocklist: %s", e)
+        return set()
+
+
+def _compile_blocklist_patterns() -> None:
+    """(Re)build _BLOCKLIST_PATTERNS_COMPILED from _permanent_blocked.
+
+    Each user pattern is re.escape()'d and wrapped with _CMDPOS + word
+    boundary for safe regex matching. Call after loading from config.
+    """
+    global _BLOCKLIST_PATTERNS_COMPILED
+    compiled = []
+    with _lock:
+        for pattern in _permanent_blocked:
+            try:
+                escaped = re.escape(pattern)
+                regex = _CMDPOS + r'(' + escaped + r')\b'
+                compiled.append((re.compile(regex, _RE_FLAGS), pattern))
+            except Exception as e:
+                logger.warning("Failed to compile blocklist pattern %r: %s", pattern, e)
+        _BLOCKLIST_PATTERNS_COMPILED = compiled
 
 
 # =========================================================================
@@ -1110,6 +1184,15 @@ def check_dangerous_command(command: str, env_type: str,
     Returns:
         {"approved": True/False, "message": str or None, ...}
     """
+    # == User-configured blocklist ==
+    # Check user-defined blocked patterns. This fires BEFORE the container
+    # skip so it applies even inside Docker/Modal — a user who explicitly
+    # blocks a command means it everywhere.
+    is_blocked, blocked_pattern = detect_blocked_command(command)
+    if is_blocked:
+        logger.warning("Blocklist match: %s (command: %s)", blocked_pattern, command[:200])
+        return _blocklist_block_result(blocked_pattern)
+
     if env_type in {"docker", "singularity", "modal", "daytona"}:
         return {"approved": True, "message": None}
 
@@ -1340,6 +1423,15 @@ def check_all_command_guards(command: str, env_type: str,
     a gateway force=True replay from bypassing one check when only the
     other was shown to the user.
     """
+    # == User-configured blocklist ==
+    # Check user-defined blocked patterns. This fires BEFORE the container
+    # skip so it applies even inside Docker/Modal — a user who explicitly
+    # blocks a command means it everywhere.
+    is_blocked, blocked_pattern = detect_blocked_command(command)
+    if is_blocked:
+        logger.warning("Blocklist match: %s (command: %s)", blocked_pattern, command[:200])
+        return _blocklist_block_result(blocked_pattern)
+
     # Skip containers for both checks
     if env_type in {"docker", "singularity", "modal", "daytona"}:
         return {"approved": True, "message": None}
@@ -1653,6 +1745,17 @@ def check_execute_code_guard(code: str, env_type: str) -> dict:
         "approval is one-shot for this run."
     )
 
+    # == User-configured blocklist ==
+    # Check user-defined blocked patterns. This fires BEFORE the container
+    # skip so it applies even inside Docker/Modal — a user who explicitly
+    # blocks a command means it everywhere.
+    # For execute_code, we check the synthetic command representation.
+    command = f"execute_code <<'PY'\n{code}\nPY"
+    is_blocked, blocked_pattern = detect_blocked_command(command)
+    if is_blocked:
+        logger.warning("Blocklist match: %s (execute_code)", blocked_pattern)
+        return _blocklist_block_result(blocked_pattern)
+
     # Isolated backends already sandbox the child — matches the container skip
     # in check_all_command_guards / check_dangerous_command.
     if env_type in {"docker", "singularity", "modal", "daytona", "vercel_sandbox"}:
@@ -1808,5 +1911,7 @@ def check_execute_code_guard(code: str, env_type: str) -> dict:
             "user_approved": True, "description": description}
 
 
-# Load permanent allowlist from config on module import
+# Load permanent allowlist and blocklist from config on module import
 load_permanent_allowlist()
+load_permanent_blocklist()
+_compile_blocklist_patterns()

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -710,6 +710,7 @@ def _strip_blocked_tools(toolsets: List[str]) -> List[str]:
         "clarify",
         "memory",
         "code_execution",
+        "skills",
     }
     return [t for t in toolsets if t not in blocked_toolset_names]
 

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -2058,6 +2058,13 @@ def terminal_tool(
                         env = new_env
                     logger.info("%s environment ready for task %s", env_type, effective_task_id[:8])
 
+        # Blocklist check — unconditional, even force=True cannot bypass
+        from tools.approval import detect_blocked_command, _blocklist_block_result
+        is_blocked, blocked_pattern = detect_blocked_command(command)
+        if is_blocked:
+            logger.warning("Blocklist match: %s (command: %s)", blocked_pattern, command[:200])
+            return json.dumps(_blocklist_block_result(blocked_pattern), ensure_ascii=False)
+
         # Pre-exec security checks (tirith + dangerous command detection)
         # Skip check if force=True (user has confirmed they want to run it)
         approval_note = None
@@ -2086,7 +2093,8 @@ def terminal_tool(
                     "output": "",
                     "exit_code": -1,
                     "error": approval.get("message", fallback_msg),
-                    "status": "blocked"
+                    "status": "blocked",
+                    **({"blocklisted": True} if approval.get("blocklisted") else {}),
                 }, ensure_ascii=False)
             # Track whether approval was explicitly granted by the user
             if approval.get("user_approved"):


### PR DESCRIPTION
## Summary

Adds a configurable `command_blocklist` section in `~/.hermes/config.yaml` that works as a true blocklist -- the opposite of `command_allowlist` (which is a skip-approval list, not a blocklist). Entries are checked unconditionally, before YOLO, before the container skip, and before `force=True`.

## How it works

Each entry is `re.escape()`'d and wrapped with `_CMDPOS` anchoring + word boundary -- so `pip` blocks `pip install` and `sudo pip install`, but NOT `pipeline`, `equipment`, or `epiphany`.

The check fires:
- BEFORE the container skip -- applies inside Docker/Modal too
- BEFORE the YOLO bypass -- even `--yolo` cannot override it
- BEFORE the `force=True` guard -- even `force=True` cannot bypass it

Blocked commands return `BLOCKED (user blocklist): 'pip' matches your command_blocklist entry.` with a `blocklisted: True` flag in the JSON response.

## Coverage -- all three entry points

- `check_all_command_guards()` -- primary path used by `terminal_tool()`
- `check_dangerous_command()` -- older public API, now also protected
- `check_execute_code_guard()` -- checks the synthetic command representation

## Usage

```yaml
# ~/.hermes/config.yaml
command_blocklist:
  - pip
  - pip3
  - uv
```

## Limitation

`_CMDPOS` anchoring only matches the first command word. `python3 -m pip install` is NOT blocked by a `pip` entry -- `python3` is the command word, not `pip`. To block that too, add `python3 -m pip` as a separate blocklist entry.

## Files changed

- `hermes_cli/config.py` -- +1 line: `"command_blocklist": [],`
- `tools/approval.py` -- +109/-1: blocklist infrastructure + all 3 entry points
- `tools/terminal_tool.py` -- +10/-1: blocklist before `force=True`, `blocklisted` flag
- `tests/tools/test_approval.py` -- +563: 39 tests covering pattern matching, bypass vectors, flag propagation
