### PR TITLE
fix(agent): handle YAML null value in context_length_cache

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -916,7 +916,10 @@ def _load_context_cache() -> Dict[str, int]:
     try:
         with open(path, encoding="utf-8") as f:
             data = yaml.safe_load(f) or {}
-        return data.get("context_lengths", {})
+        # data.get("context_lengths", {}) returns None when the key exists
+        # with a YAML null value (e.g. "context_lengths:" with no value).
+        # Use "or {}" to handle both missing keys and null values. (#47135)
+        return data.get("context_lengths") or {}
     except Exception as e:
         logger.debug("Failed to load context length cache: %s", e)
         return {}


### PR DESCRIPTION
## Summary

`_load_context_cache()` in `agent/model_metadata.py` returns `None` when `context_length_cache.yaml` contains `context_lengths:` (no value), because YAML parses this as `{"context_lengths": None}` and `dict.get(key, default)` only returns the default when the key is **absent** — not when the value is `None`.

This causes `AttributeError: NoneType object has no attribute get` in every downstream caller (`get_cached_context_length`, `save_context_length`, `_invalidate_cached_context_length`), crashing the gateway entirely.

## Fix

```python
# Before:
return data.get("context_lengths", {})

# After:
return data.get("context_lengths") or {}
```

This handles both cases: key absent (returns `{}`) and key present with `None` value (returns `{}`).

## Related Issue

Closes #47135

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)