### PR TITLE
fix(model-picker): don't filter user-defined providers against themselves

### DIFF
--- a/hermes_cli/inventory.py
+++ b/hermes_cli/inventory.py
@@ -178,6 +178,15 @@ def build_models_payload(
                 user_models.update(m.lower() for m in (row.get("models") or []))
         if user_models:
             for row in rows:
+                # Never trim a user-defined row. It is the "more-specific"
+                # source that seeded user_models in the first place; filtering
+                # it against that set cancels it against its own catalog and
+                # zeroes the count. This bit named custom_providers whose slug
+                # (``custom:<name>``) classifies as an aggregator — e.g. a
+                # 9router endpoint showed "(0 models)" in the /model picker
+                # while ``hermes model`` (which skips this dedup) showed 437.
+                if row.get("is_user_defined"):
+                    continue
                 slug = row.get("slug", "")
                 if not _is_aggregator(slug):
                     continue

--- a/tests/hermes_cli/test_inventory.py
+++ b/tests/hermes_cli/test_inventory.py
@@ -606,3 +606,34 @@ def test_aggregator_dedup_multiple_user_providers():
     assert or_row["models"] == ["model-z"]
     assert or_row["total_models"] == 1
 
+
+def test_user_defined_custom_provider_not_filtered_against_itself():
+    """A user-defined provider whose slug classifies as an aggregator
+    (``custom:<name>``, e.g. a 9router endpoint) must NOT have its own
+    catalog filtered against ``user_models``.
+
+    Regression: ``is_aggregator()`` returns True for any ``custom:`` slug,
+    so the dedup loop trimmed the user-defined row against a set seeded
+    from its own models, zeroing the count. The picker showed
+    "9router.digitalbroadcast.id (0 models)" while ``hermes model``
+    (which skips this dedup path) showed the full 437.
+    """
+    rows = [
+        {
+            "slug": "custom:9router.digitalbroadcast.id",
+            "name": "9router.digitalbroadcast.id",
+            "models": ["kr/claude-opus-4.8", "ocg/glm-5", "ocg/kimi-k2.6"],
+            "total_models": 3,
+            "is_current": True,
+            "is_user_defined": True,
+            "source": "user-config",
+        },
+    ]
+    ctx = _empty_ctx()
+    with _list_auth_returning(rows):
+        payload = build_models_payload(ctx)
+
+    row = payload["providers"][0]
+    assert row["total_models"] == 3
+    assert row["models"] == ["kr/claude-opus-4.8", "ocg/glm-5", "ocg/kimi-k2.6"]
+


### PR DESCRIPTION
## Problem

The in-session `/model` picker shows a user-defined custom provider as **(0 models)** even though the endpoint is healthy and `hermes model` (the terminal picker) lists the full catalog.

Concretely: a `custom_providers` entry pointing at a 9router endpoint (slug `custom:9router.digitalbroadcast.id`, 437 models) rendered as `9router.digitalbroadcast.id (0 models)` in `/model`, while `hermes model` showed all 437.

## Root cause

`build_models_payload` (`hermes_cli/inventory.py`) runs an aggregator-dedup step (#45954) that removes models from built-in aggregator rows when they overlap with a user's more-specific provider:

```python
user_models = { all models from is_user_defined rows }
for row in rows:
    if not _is_aggregator(row["slug"]):
        continue
    row["models"] = [m for m in row["models"] if m.lower() not in user_models]
```

But `is_aggregator()` returns `True` for **any** `custom:<name>` slug:

```python
def is_aggregator(provider: str) -> bool:
    provider_norm = normalize_provider(provider or "")
    if provider_norm.startswith("custom:"):
        return True
    ...
```

So a user-defined custom provider is simultaneously:
1. seeding `user_models` with its own catalog (because `is_user_defined=True`), and
2. classified as an aggregator to be trimmed (because its slug starts with `custom:`).

The dedup then filters the provider's models against a set containing its own models → every model removed → `total_models = 0`.

`hermes model` doesn't hit this path — it calls `list_authenticated_providers` directly, which is why the terminal picker was correct (437) and only the in-session `/model` was wrong (0).

## Fix

Skip `is_user_defined` rows in the dedup loop. A user-defined row is the *more-specific* source the dedup exists to protect — it should never be the aggregator being trimmed.

```python
for row in rows:
    if row.get("is_user_defined"):
        continue
    slug = row.get("slug", "")
    if not _is_aggregator(slug):
        continue
    ...
```

## Tests

- Adds `test_user_defined_custom_provider_not_filtered_against_itself` (regression).
- All existing #45954 dedup tests still pass (they use built-in aggregator rows with `is_user_defined=False`, unaffected by this change).

```
$ python -m pytest tests/hermes_cli/test_inventory.py -o 'addopts=' -q
29 passed
```
