### PR TITLE
feat: add z-ai/glm-5.2 to OpenRouter and Nous model lists

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -61,6 +61,7 @@ OPENROUTER_MODELS: list[tuple[str, str]] = [
     # MiniMax
     ("minimax/minimax-m3",                     ""),
     # Z-AI
+    ("z-ai/glm-5.2",                           ""),
     ("z-ai/glm-5.1",                           ""),
     # Xiaomi
     ("xiaomi/mimo-v2.5-pro",                   ""),
@@ -182,6 +183,7 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
         # MiniMax
         "minimax/minimax-m3",
         # Z-AI
+        "z-ai/glm-5.2",
         "z-ai/glm-5.1",
         # Xiaomi
         "xiaomi/mimo-v2.5-pro",

--- a/website/static/api/model-catalog.json
+++ b/website/static/api/model-catalog.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "updated_at": "2026-06-13T08:41:46Z",
+  "updated_at": "2026-06-16T18:04:33Z",
   "metadata": {
     "source": "hermes-agent repo",
     "docs": "https://hermes-agent.nousresearch.com/docs/reference/model-catalog"
@@ -86,6 +86,10 @@
         },
         {
           "id": "minimax/minimax-m3",
+          "description": ""
+        },
+        {
+          "id": "z-ai/glm-5.2",
           "description": ""
         },
         {
@@ -201,6 +205,9 @@
         },
         {
           "id": "minimax/minimax-m3"
+        },
+        {
+          "id": "z-ai/glm-5.2"
         },
         {
           "id": "z-ai/glm-5.1"


### PR DESCRIPTION
Z.ai released **GLM 5.2** on 2026-06-15, available on OpenRouter: https://openrouter.ai/z-ai/glm-5.2

GLM-5.2 is Z.ai's flagship for long-horizon tasks, shipping a **1M-token context window** (up from 200K on GLM 5.1) with tool calling. Per the OpenRouter `/api/v1/models` API: text-only, `context_length` 1048576, `tools` supported. There is **no separate `-fast` variant** (unlike Opus 4.8).

### Context: most of GLM 5.2 already landed
The 1M context length (`agent/model_metadata.py`), the native `zai` picker entry (`_PROVIDER_MODELS["zai"]`), the setup wizard (`hermes_cli/setup.py`), and the Z.ai coding-plan auth entries (`hermes_cli/auth.py`) for `glm-5.2` are already on `main`. This PR fills the one remaining gap: the two **aggregator** surfaces where `z-ai/glm-5.1` appears but `z-ai/glm-5.2` did not — mirroring how Opus 4.8 was added to "the OpenRouter fallback snapshot and the Nous Portal curated list."

### Changes
- **`hermes_cli/models.py`** — add `z-ai/glm-5.2` to the OpenRouter fallback snapshot (`OPENROUTER_MODELS`) and the Nous curated list (`_PROVIDER_MODELS["nous"]`), newest flagship first. Live catalogs surface it automatically when reachable; the fallback lists matter when the manifest fetch fails.
- **`website/static/api/model-catalog.json`** — regenerated via `scripts/build_model_catalog.py` (not hand-edited) so the manifest stays in sync with the source lists; guarded by `tests/hermes_cli/test_model_catalog.py`.

### Verification
- `tests/hermes_cli/test_model_catalog.py` (28), `tests/agent/test_model_metadata.py` (105), `tests/hermes_cli/test_provider_live_curated_merge.py` (9) — **142 passed**.
- Runtime: confirmed `z-ai/glm-5.2` present in OpenRouter snapshot, Nous list, and zai native list; context resolves to 1,048,576.
- **Live API roundtrip** through OpenRouter:
  ```
  hermes chat -Q -q "Reply with exactly: TEST-OK and your model id." --model z-ai/glm-5.2 --provider openrouter
  → TEST-OK z-ai/glm-5.2
  ```

## Infographic

![glm-5.2-support](https://v3b.fal.media/files/b/0a9e8f0d/YPMP5BqA_scrfOwzWOPvh_XRmeL3Tx.png)
