### PR TITLE
fix(cron): don't crash on non-UTF-8/truncated script stdout

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -973,6 +973,8 @@ def _run_job_script(script_path: str) -> tuple[bool, str]:
             argv,
             capture_output=True,
             text=True,
+            encoding="utf-8",
+            errors="replace",
             timeout=script_timeout,
             cwd=str(path.parent),
             **popen_kwargs,


### PR DESCRIPTION
## Symptom

A cron job with a pre-run/data-collection `script` fails with:

```
Script execution failed: 'utf-8' codec can't decode byte 0xe2 in position 84: invalid continuation byte
```

even though the script itself ran fine. The error masks the real outcome (in my case a 120s timeout on a heavy script that does a git clone + install).

## Root cause

`cron/scheduler.py:_run_job_script` runs the script with:

```python
result = subprocess.run(argv, capture_output=True, text=True, timeout=script_timeout, cwd=...)
```

`text=True` decodes captured stdout as **strict** UTF-8. When the script emits a multibyte character (e.g. `⚠` = `e2 9a a0`, `→` = `e2 86 92`) and the captured buffer is cut mid-character — a pipe-buffer boundary, or the process killed mid-write on timeout — the bytes are truncated mid-codepoint and the strict decode raises `UnicodeDecodeError`. That propagates out of `subprocess.run` and is caught by the generic `except Exception` handler (line ~1004), surfacing as `Script execution failed: ...` and failing the whole job.

## Fix

Decode with `encoding='utf-8', errors='replace'` so a stray/truncated byte degrades to U+FFFD instead of taking down the run. Surgical 2-line change; fixes the whole class for every cron script, not just the one that tripped it.

## Repro (verbatim, current main)

```python
import subprocess, sys
script = r'import os; os.write(1, b"x"*84 + b"\xe2")'  # lone 0xe2 lead byte, clean exit
# BEFORE (text=True, strict):  raises UnicodeDecodeError: 'utf-8' codec can't decode byte 0xe2 in position 84
# AFTER  (text=True, errors='replace'): stdout = 'xxx...x\ufffd', no crash
subprocess.run([sys.executable, '-c', script], capture_output=True, text=True, timeout=5)
```

Confirmed on CPython 3.11.15: the BEFORE path reproduces the exact error string; `errors='replace'` recovers cleanly.