### PR TITLE
feat(desktop): add Photon iMessage section to sidebar

### DIFF
--- a/apps/desktop/src/app/messaging/platform-icon.tsx
+++ b/apps/desktop/src/app/messaging/platform-icon.tsx
@@ -17,6 +17,22 @@ import type { ComponentType, SVGProps } from 'react'
 import { Globe, Link as LinkIcon, MessageSquareText } from '@/lib/icons'
 import { cn } from '@/lib/utils'
 
+// ---------------------------------------------------------------------------
+// Photon brand icon — three diagonal rounded bars (the Photon logo mark).
+// Rendered at ~14 px inside the PlatformAvatar so the bars are kept thick
+// enough to stay legible. At small sizes the bars blend into a distinctive
+// silhouette; the wide triangular spacing preserves the logo's identity.
+// ---------------------------------------------------------------------------
+function PhotonIcon(props: React.SVGProps<SVGSVGElement>) {
+  return (
+    <svg fill="currentColor" viewBox="0 0 24 24" {...props}>
+      <rect height="10" rx="1.25" transform="rotate(15 14 7.5)" width="2.5" x="12.75" y="2.5" />
+      <rect height="10" rx="1.25" transform="rotate(15 8 13)" width="2.5" x="6.75" y="8" />
+      <rect height="10" rx="1.25" transform="rotate(15 16 18)" width="2.5" x="14.75" y="13" />
+    </svg>
+  )
+}
+
 // We render simpleicons.org brand glyphs for platforms whose owners publish a
 // usable mark (telegram, discord, matrix, ...). A few brands — Slack, Dingtalk,
 // Feishu, WeCom — have been removed from Simple Icons at the brand owner's
@@ -44,6 +60,7 @@ const PLATFORM_ICONS: Record<string, PlatformIconSpec> = {
   signal: { Icon: SiSignal, color: '#3A76F0', kind: 'brand' },
   whatsapp: { Icon: SiWhatsapp, color: '#25D366', kind: 'brand' },
   bluebubbles: { Icon: SiApple, color: '#0BD318', kind: 'brand' },
+  photon: { Icon: PhotonIcon, color: '#6366F1', kind: 'brand' },
   homeassistant: { Icon: SiHomeassistant, color: '#18BCF2', kind: 'brand' },
   email: { Icon: SiGmail, color: '#EA4335', kind: 'brand' },
   sms: { Icon: MessageSquareText, color: '#F43F5E', kind: 'generic' },

--- a/apps/desktop/src/lib/session-source.test.ts
+++ b/apps/desktop/src/lib/session-source.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  MESSAGING_SESSION_SOURCE_IDS,
+  isMessagingSource,
+  sessionSourceSearchTerms
+} from './session-source'
+
+// Regression guard for #46761 / PR #47395: Photon (iMessage) must keep its own
+// sidebar section. refreshMessagingSessions() filters rows through
+// isMessagingSource(), so this entry is the sole condition that keeps Photon
+// sessions out of generic recents. A silent removal would regress the feature
+// with no test failure — these asserts pin the contract.
+describe('photon messaging source registration', () => {
+  it('treats photon as a messaging source (own sidebar section)', () => {
+    expect(isMessagingSource('photon')).toBe(true)
+  })
+
+  it('is case/space insensitive on the source id', () => {
+    expect(isMessagingSource('PHOTON')).toBe(true)
+    expect(isMessagingSource('  photon ')).toBe(true)
+  })
+
+  it('exposes the iMessage/messages search aliases so Photon sessions are findable', () => {
+    const terms = sessionSourceSearchTerms('photon')
+    expect(terms).toContain('imessage')
+    expect(terms).toContain('messages')
+  })
+
+  it('is registered in the messaging source id list', () => {
+    expect(MESSAGING_SESSION_SOURCE_IDS).toContain('photon')
+  })
+
+  it('does not flag local/CLI-ish sources as messaging (guard sanity)', () => {
+    expect(isMessagingSource('cli')).toBe(false)
+    expect(isMessagingSource(null)).toBe(false)
+    expect(isMessagingSource(undefined)).toBe(false)
+  })
+})

--- a/apps/desktop/src/lib/session-source.ts
+++ b/apps/desktop/src/lib/session-source.ts
@@ -10,6 +10,7 @@ const SOURCE_LABELS: Record<string, string> = {
   local: 'Local',
   matrix: 'Matrix',
   mattermost: 'Mattermost',
+  photon: 'Photon',
   qqbot: 'QQ',
   signal: 'Signal',
   slack: 'Slack',
@@ -24,6 +25,7 @@ const SOURCE_LABELS: Record<string, string> = {
 
 const SOURCE_ALIASES: Record<string, string[]> = {
   bluebubbles: ['apple messages', 'imessage'],
+  photon: ['imessage', 'messages'],
   cli: ['terminal'],
   desktop: ['app', 'gui'],
   local: ['machine'],
@@ -53,6 +55,7 @@ export const MESSAGING_SESSION_SOURCE_IDS = [
   'signal',
   'whatsapp',
   'bluebubbles',
+  'photon',
   'homeassistant',
   'email',
   'sms',


### PR DESCRIPTION
## Summary

Register **Photon** (the built-in iMessage platform adapter) as a first-class messaging platform in the Hermes Desktop sidebar, matching the treatment Discord, Telegram, and other platforms already receive.

Closes #46761

## What changed

### `apps/desktop/src/lib/session-source.ts`
- Add `photon: 'Photon'` to `SOURCE_LABELS`
- Add `photon: ['imessage', 'messages']` to `SOURCE_ALIASES`
- Add `'photon'` to `MESSAGING_SESSION_SOURCE_IDS`

### `apps/desktop/src/app/messaging/platform-icon.tsx`
- Add `PhotonIcon` component — inline SVG of the official Photon brand mark (three diagonal rounded bars)
- Register `photon: { Icon: PhotonIcon, color: '#6366F1', kind: 'brand' }` in `PLATFORM_ICONS`

## Visual

| Before | After |
|--------|-------|
| Photon sessions mixed into generic SESSIONS list | Dedicated `PHOTON` section with brand icon, unread badge, session count |

## Testing

The sidebar platform sections are data-driven — once `photon` appears in `MESSAGING_SESSION_SOURCE_IDS`, any session with `source: "photon"` is automatically grouped into its own section with the Photon brand icon. The backend already registers as `name: "photon"` (see `plugins/platforms/photon/adapter.py` line 1486).

Tested by:
- ✅ Verified key alignment: frontend `'photon'` ↔ backend `name="photon"`
- ✅ SVG renders correctly at 14px (PlatformAvatar `size-3.5`) and 40px
- ✅ No regressions: additive changes only, follows existing platform patterns