### PR TITLE
fix(compressor): strip _multimodal tool-result images in _strip_historical_media

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -411,43 +411,83 @@ def _strip_images_from_content(content: Any) -> Any:
     return new_parts
 
 
+def _tool_result_has_media(content: Any) -> bool:
+    """True when a tool result's content carries image data that should be stripped.
+
+    Covers two shapes:
+    - ``_multimodal`` envelope dict: ``{"_multimodal": True, "content": [...]}``
+      returned by browser_vision / computer_use on the native-vision fast path.
+    - OpenAI-style list with image parts: ``[{"type": "image_url", ...}, ...]``
+    """
+    if isinstance(content, dict) and content.get("_multimodal"):
+        return True
+    if isinstance(content, list):
+        return _content_has_images(content)
+    return False
+
+
+def _strip_tool_result_media(msg: Dict[str, Any]) -> Dict[str, Any]:
+    """Return a shallow copy of a tool-result message with its image payload removed.
+
+    ``_multimodal`` envelopes are replaced with their ``text_summary`` string so
+    the model retains a readable description without the base-64 bulk.  List-style
+    multimodal content is stripped via ``_strip_image_parts_from_parts``.
+    """
+    content = msg.get("content")
+    new_msg = msg.copy()
+    if isinstance(content, dict) and content.get("_multimodal"):
+        summary = content.get("text_summary") or "[screenshot removed to save context]"
+        new_msg["content"] = f"[screenshot removed] {summary[:200]}"
+    elif isinstance(content, list):
+        stripped = _strip_image_parts_from_parts(content)
+        if stripped is not None:
+            new_msg["content"] = stripped
+    return new_msg
+
+
 def _strip_historical_media(messages: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
-    """Replace image parts in older messages with placeholder text.
+    """Replace image payloads in older messages with placeholder text.
 
-    The anchor is the *last* user message that has any image content. Every
-    message before that anchor gets its image parts replaced with a short
-    placeholder so the outgoing request stops re-shipping the same multi-MB
-    base-64 image blobs on every turn.
+    The anchor is the *last* message — user or tool result — that carries image
+    content.  Every message before that anchor has its image data replaced with a
+    short placeholder, stopping the outgoing request from re-shipping the same
+    multi-MB base-64 blobs on every turn.
 
-    If no user message carries images, the list is returned unchanged.
-    If the only user message with images is the very first one (nothing
-    earlier to strip), the list is returned unchanged.
+    Two image-bearing message shapes are handled:
+    - User messages with OpenAI-style multimodal content lists (e.g. attached
+      screenshots sent by the user).
+    - Tool result messages whose content is a ``_multimodal`` envelope
+      (``browser_vision`` / ``computer_use`` native-vision fast path) or an
+      OpenAI-style list.  These were previously invisible to the anchor search,
+      so a session that only used browser_vision never stripped any screenshots
+      and accumulated unbounded base-64 payload — causing HTTP 413 errors even
+      after multiple compression passes.
 
-    Shallow copies of touched messages only; input is never mutated.
-    Port of Kilo-Org/kilocode#9434 (adapted for the OpenAI-style message
-    shape the hermes compressor emits).
+    If no image-bearing message exists, or it is the very first message (nothing
+    earlier to strip), the list is returned unchanged.  Shallow copies of touched
+    messages only; input is never mutated.
+
+    Port of Kilo-Org/kilocode#9434 (adapted for hermes message shapes).
     """
     if not messages:
         return messages
 
-    # Find the newest user message that carries at least one image part.
-    # We anchor on image-bearing user messages (not all user messages) so
-    # a plain text follow-up after a big-image turn still strips the old
-    # image — matching the problem kilocode#9434 set out to solve.
+    # Find the newest message (user or tool result) that carries image content.
     anchor = -1
     for i in range(len(messages) - 1, -1, -1):
         msg = messages[i]
         if not isinstance(msg, dict):
             continue
-        if msg.get("role") != "user":
-            continue
-        if _content_has_images(msg.get("content")):
+        role = msg.get("role")
+        content = msg.get("content")
+        if role == "user" and _content_has_images(content):
+            anchor = i
+            break
+        if role == "tool" and _tool_result_has_media(content):
             anchor = i
             break
 
     if anchor <= 0:
-        # No image-bearing user message, or it's the very first message —
-        # nothing before it to strip.
         return messages
 
     changed = False
@@ -456,14 +496,18 @@ def _strip_historical_media(messages: List[Dict[str, Any]]) -> List[Dict[str, An
         if i >= anchor or not isinstance(msg, dict):
             result.append(msg)
             continue
+        role = msg.get("role")
         content = msg.get("content")
-        if not _content_has_images(content):
+        if role == "user" and _content_has_images(content):
+            new_msg = msg.copy()
+            new_msg["content"] = _strip_images_from_content(content)
+            result.append(new_msg)
+            changed = True
+        elif role == "tool" and _tool_result_has_media(content):
+            result.append(_strip_tool_result_media(msg))
+            changed = True
+        else:
             result.append(msg)
-            continue
-        new_msg = msg.copy()
-        new_msg["content"] = _strip_images_from_content(content)
-        result.append(new_msg)
-        changed = True
 
     return result if changed else messages
 

--- a/tests/agent/test_context_compressor.py
+++ b/tests/agent/test_context_compressor.py
@@ -2264,3 +2264,130 @@ class TestPreflightSentinelGuard:
         compressor.last_prompt_tokens = 50_000
         result = self._seed(compressor.last_prompt_tokens, 10_000)
         assert result == 50_000
+
+
+class TestStripHistoricalMediaToolResults:
+    """_strip_historical_media should strip images from tool results, not just user messages.
+
+    browser_vision and computer_use return ``_multimodal`` envelopes as tool results.
+    Without this fix those payloads survived every compression pass because the anchor
+    search only looked at user-role messages, so sessions with multiple browser_vision
+    calls accumulated multi-MB base-64 screenshots and always hit HTTP 413 errors.
+    """
+
+    def _make_multimodal_envelope(self, summary: str = "screenshot of page") -> dict:
+        return {
+            "_multimodal": True,
+            "content": [
+                {"type": "text", "text": "Image loaded into your context."},
+                {"type": "image_url", "image_url": {"url": "data:image/png;base64,AAAA" + "x" * 1000}},
+            ],
+            "text_summary": summary,
+            "meta": {"size_bytes": 1024},
+        }
+
+    def test_multimodal_tool_result_before_anchor_is_stripped(self):
+        from agent.context_compressor import _strip_historical_media
+
+        messages = [
+            {"role": "user", "content": "take a screenshot"},
+            {"role": "assistant", "content": "", "tool_calls": [{"id": "c1"}]},
+            {"role": "tool", "content": self._make_multimodal_envelope("first screenshot"), "tool_call_id": "c1"},
+            {"role": "assistant", "content": "I see the login page."},
+            {"role": "user", "content": "take another screenshot"},
+            {"role": "assistant", "content": "", "tool_calls": [{"id": "c2"}]},
+            {"role": "tool", "content": self._make_multimodal_envelope("second screenshot"), "tool_call_id": "c2"},
+            {"role": "assistant", "content": "I see a modal."},
+        ]
+
+        result = _strip_historical_media(messages)
+
+        # Oldest tool result (index 2) must be stripped — image payload gone, summary kept.
+        assert result[2]["content"] == "[screenshot removed] first screenshot"
+        # Most recent tool result (index 6) is the anchor — must be preserved verbatim.
+        assert result[6]["content"] == messages[6]["content"]
+        # Non-image messages must not be mutated.
+        assert result[0] is messages[0]
+        assert result[3] is messages[3]
+
+    def test_only_tool_result_images_no_user_images(self):
+        """No user message has images — anchor comes from the tool result."""
+        from agent.context_compressor import _strip_historical_media
+
+        messages = [
+            {"role": "user", "content": "browse the web"},
+            {"role": "assistant", "content": "", "tool_calls": [{"id": "c1"}]},
+            {"role": "tool", "content": self._make_multimodal_envelope("old screenshot"), "tool_call_id": "c1"},
+            {"role": "assistant", "content": "Done browsing."},
+            {"role": "user", "content": "take a fresh look"},
+            {"role": "assistant", "content": "", "tool_calls": [{"id": "c2"}]},
+            {"role": "tool", "content": self._make_multimodal_envelope("new screenshot"), "tool_call_id": "c2"},
+            {"role": "assistant", "content": "I see the updated page."},
+        ]
+
+        result = _strip_historical_media(messages)
+
+        assert result[2]["content"] == "[screenshot removed] old screenshot"
+        assert result[6]["content"] == messages[6]["content"]
+
+    def test_single_tool_result_not_stripped(self):
+        """Only one tool result with images — it is the anchor, nothing to strip."""
+        from agent.context_compressor import _strip_historical_media
+
+        messages = [
+            {"role": "user", "content": "screenshot please"},
+            {"role": "assistant", "content": "", "tool_calls": [{"id": "c1"}]},
+            {"role": "tool", "content": self._make_multimodal_envelope("only screenshot"), "tool_call_id": "c1"},
+            {"role": "assistant", "content": "Here you go."},
+        ]
+
+        result = _strip_historical_media(messages)
+        assert result is messages  # returned unchanged
+
+    def test_legacy_user_image_stripping_still_works(self):
+        """Existing behaviour: user-attached images before the anchor are stripped."""
+        from agent.context_compressor import _strip_historical_media, _is_image_part
+
+        img_part = {"type": "image_url", "image_url": {"url": "data:image/png;base64,OLD"}}
+        img_part2 = {"type": "image_url", "image_url": {"url": "data:image/png;base64,NEW"}}
+
+        messages = [
+            {"role": "user", "content": [img_part, {"type": "text", "text": "old image"}]},
+            {"role": "assistant", "content": "analysis of old"},
+            {"role": "user", "content": [img_part2, {"type": "text", "text": "new image"}]},
+            {"role": "assistant", "content": "analysis of new"},
+        ]
+
+        result = _strip_historical_media(messages)
+
+        # First user message: image stripped, text kept.
+        assert not any(_is_image_part(p) for p in result[0]["content"])
+        assert any(p.get("text") == "old image" for p in result[0]["content"] if isinstance(p, dict))
+        # Second user message (anchor): unchanged.
+        assert result[2]["content"] is messages[2]["content"]
+
+    def test_tool_result_list_style_images_stripped(self):
+        """OpenAI-style list content in tool results is also stripped."""
+        from agent.context_compressor import _strip_historical_media, _is_image_part
+
+        list_content = [
+            {"type": "text", "text": "vision result"},
+            {"type": "image_url", "image_url": {"url": "data:image/png;base64,SCREENSHOT"}},
+        ]
+
+        messages = [
+            {"role": "user", "content": "go"},
+            {"role": "assistant", "content": "", "tool_calls": [{"id": "c1"}]},
+            {"role": "tool", "content": list_content, "tool_call_id": "c1"},
+            {"role": "assistant", "content": "done"},
+            {"role": "user", "content": "more"},
+            {"role": "assistant", "content": "", "tool_calls": [{"id": "c2"}]},
+            {"role": "tool", "content": self._make_multimodal_envelope("new"), "tool_call_id": "c2"},
+            {"role": "assistant", "content": "done again"},
+        ]
+
+        result = _strip_historical_media(messages)
+
+        stripped_tool_content = result[2]["content"]
+        assert isinstance(stripped_tool_content, list)
+        assert not any(_is_image_part(p) for p in stripped_tool_content)


### PR DESCRIPTION
## Problem

`_strip_historical_media` only searched for image-bearing **user** messages when
selecting the anchor. Sessions driven by `browser_vision` or `computer_use`
(native-vision fast path) accumulate screenshots exclusively in **tool result**
messages as `_multimodal` envelopes — their user turns carry plain text. Because
the anchor search never matched those tool results, no base-64 payload was ever
stripped. After two compression passes (e.g. 101 → 13 messages) the screenshots
were still present in the tail, pushing the outgoing payload above the provider's
HTTP 413 limit even though the estimated token count looked safe. Reported in #47339.

## Fix

- Add `_tool_result_has_media()` to recognise `_multimodal` envelopes and
  OpenAI-style list content in tool-result messages.
- Add `_strip_tool_result_media()` to replace a `_multimodal` envelope with its
  `text_summary` string and to strip image parts from list-style tool results.
- Extend the anchor search in `_strip_historical_media` to also consider
  tool-result messages (user-image anchoring is preserved as-is).
- Strip tool-result images for all messages before the anchor alongside the
  existing user-image stripping.

## Tests

`TestStripHistoricalMediaToolResults` (5 cases):
- `_multimodal` envelope in tool result before anchor → stripped to `text_summary`
- Most-recent tool result (the anchor itself) → left untouched
- Only one screenshot in session → nothing stripped (no-op, returns original list)
- Legacy user-image stripping still works unchanged
- OpenAI-style list content in tool results → image parts stripped

```
uv run --frozen python -m pytest tests/agent/test_context_compressor.py -x -q
101 passed in 6.11s
```