### PR TITLE
[codex] fix installer uv path quoting

### DIFF
--- a/.github/workflows/deploy-installer.yml
+++ b/.github/workflows/deploy-installer.yml
@@ -1,0 +1,25 @@
+name: Deploy Installer
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'scripts/install.sh'
+      - 'scripts/install.ps1'
+      - '.github/workflows/deploy-installer.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: installer-deploy
+  cancel-in-progress: false
+
+jobs:
+  deploy-vercel:
+    if: github.repository == 'NousResearch/hermes-agent'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger Vercel Deploy
+        run: curl -fsS -X POST "${{ secrets.VERCEL_DEPLOY_HOOK }}"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -502,7 +502,7 @@ install_uv() {
 
     if [ -x "$_managed_uv" ]; then
         UV_CMD="$_managed_uv"
-        UV_VERSION=$($UV_CMD --version 2>/dev/null)
+        UV_VERSION=$("$UV_CMD" --version 2>/dev/null)
         log_success "Managed uv found ($UV_VERSION)"
         return 0
     fi
@@ -538,7 +538,7 @@ install_uv() {
             exit 1
         fi
         rm -f "$_uv_install_log"
-        UV_VERSION=$($UV_CMD --version 2>/dev/null)
+        UV_VERSION=$("$UV_CMD" --version 2>/dev/null)
         log_success "Managed uv installed ($UV_VERSION)"
     else
         log_error "Failed to install uv"
@@ -1262,7 +1262,7 @@ setup_venv() {
     fi
 
     # uv creates the venv and pins the Python version in one step
-    $UV_CMD venv venv --python "$PYTHON_VERSION"
+    "$UV_CMD" venv venv --python "$PYTHON_VERSION"
 
     # Neutralize any inherited UV_PYTHON (e.g. UV_PYTHON=3.14 left in the
     # user's shell env). uv honours UV_PYTHON over an existing venv for the
@@ -1416,7 +1416,7 @@ install_deps() {
         #                  This respects the curation in pyproject.toml.
         # uv's own progress UI handles TTY detection and downgrades
         # gracefully when stdout/stderr aren't terminals.
-        if UV_PROJECT_ENVIRONMENT="$INSTALL_DIR/venv" $UV_CMD sync --extra all --locked; then
+        if UV_PROJECT_ENVIRONMENT="$INSTALL_DIR/venv" "$UV_CMD" sync --extra all --locked; then
             log_success "Main package installed (hash-verified via uv.lock)"
             log_success "All dependencies installed"
             return 0
@@ -1497,7 +1497,7 @@ PY
     install_tier() {
         local name="$1"; local spec="$2"
         log_info "Trying tier: $name ..."
-        if $UV_CMD pip install -e "$spec" 2>"$ALL_INSTALL_LOG"; then
+        if "$UV_CMD" pip install -e "$spec" 2>"$ALL_INSTALL_LOG"; then
             log_success "Main package installed ($name)"
             _installed=true
             _tier_name="$name"

--- a/setup-hermes.sh
+++ b/setup-hermes.sh
@@ -78,7 +78,7 @@ else
     fi
 
     if [ -n "$UV_CMD" ]; then
-        UV_VERSION=$($UV_CMD --version 2>/dev/null)
+        UV_VERSION=$("$UV_CMD" --version 2>/dev/null)
         echo -e "${GREEN}✓${NC} uv found ($UV_VERSION)"
     else
         echo -e "${CYAN}→${NC} Installing uv..."
@@ -106,7 +106,7 @@ else
 
             if [ -n "$UV_CMD" ]; then
                 rm -f "$_uv_log"
-                UV_VERSION=$($UV_CMD --version 2>/dev/null)
+                UV_VERSION=$("$UV_CMD" --version 2>/dev/null)
                 echo -e "${GREEN}✓${NC} uv installed ($UV_VERSION)"
             else
                 echo -e "${RED}✗${NC} uv installer reported success but binary not found. Add ~/.local/bin to PATH and retry."
@@ -149,14 +149,14 @@ if is_termux; then
         exit 1
     fi
 else
-    if $UV_CMD python find "$PYTHON_VERSION" &> /dev/null; then
-        PYTHON_PATH=$($UV_CMD python find "$PYTHON_VERSION")
+    if "$UV_CMD" python find "$PYTHON_VERSION" &> /dev/null; then
+        PYTHON_PATH=$("$UV_CMD" python find "$PYTHON_VERSION")
         PYTHON_FOUND_VERSION=$($PYTHON_PATH --version 2>/dev/null)
         echo -e "${GREEN}✓${NC} $PYTHON_FOUND_VERSION found"
     else
         echo -e "${CYAN}→${NC} Python $PYTHON_VERSION not found, installing via uv..."
-        $UV_CMD python install "$PYTHON_VERSION"
-        PYTHON_PATH=$($UV_CMD python find "$PYTHON_VERSION")
+        "$UV_CMD" python install "$PYTHON_VERSION"
+        PYTHON_PATH=$("$UV_CMD" python find "$PYTHON_VERSION")
         PYTHON_FOUND_VERSION=$($PYTHON_PATH --version 2>/dev/null)
         echo -e "${GREEN}✓${NC} $PYTHON_FOUND_VERSION installed"
     fi
@@ -177,7 +177,7 @@ if is_termux; then
     "$PYTHON_PATH" -m venv venv
     echo -e "${GREEN}✓${NC} venv created with stdlib venv"
 else
-    $UV_CMD venv venv --python "$PYTHON_VERSION"
+    "$UV_CMD" venv venv --python "$PYTHON_VERSION"
     echo -e "${GREEN}✓${NC} venv created (Python $PYTHON_VERSION)"
 fi
 
@@ -228,9 +228,9 @@ else
     done
     _SAFE_SPEC=".[$(IFS=,; echo "${_SAFE_EXTRAS[*]}")]"
     _try_install() {
-        $UV_CMD pip install -e ".[all]" \
-            || $UV_CMD pip install -e "$_SAFE_SPEC" \
-            || $UV_CMD pip install -e "."
+        "$UV_CMD" pip install -e ".[all]" \
+            || "$UV_CMD" pip install -e "$_SAFE_SPEC" \
+            || "$UV_CMD" pip install -e "."
     }
 
     if [ -f "uv.lock" ]; then
@@ -251,7 +251,7 @@ else
         # at first use.
         # Also: stream stderr through directly so the user sees uv's
         # progress UI instead of staring at a frozen prompt.
-        if UV_PROJECT_ENVIRONMENT="$SCRIPT_DIR/venv" $UV_CMD sync --extra all --locked; then
+        if UV_PROJECT_ENVIRONMENT="$SCRIPT_DIR/venv" "$UV_CMD" sync --extra all --locked; then
             echo -e "${GREEN}✓${NC} Dependencies installed (hash-verified via uv.lock)"
         else
             echo -e "${YELLOW}⚠${NC} Lockfile sync failed (see uv output above)."

--- a/tests/test_deploy_installer_workflow.py
+++ b/tests/test_deploy_installer_workflow.py
@@ -1,0 +1,20 @@
+"""Static guard for publishing public installer script updates."""
+
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+WORKFLOW = REPO_ROOT / ".github" / "workflows" / "deploy-installer.yml"
+
+
+def test_installer_changes_trigger_vercel_deploy() -> None:
+    text = WORKFLOW.read_text()
+
+    assert "name: Deploy Installer" in text
+    assert "workflow_dispatch:" in text
+    assert "branches: [main]" in text
+    assert "'scripts/install.sh'" in text
+    assert "'scripts/install.ps1'" in text
+    assert "github.repository == 'NousResearch/hermes-agent'" in text
+    assert "secrets.VERCEL_DEPLOY_HOOK" in text
+    assert "curl -fsS -X POST" in text

--- a/tests/test_install_sh_uv_path_spaces.py
+++ b/tests/test_install_sh_uv_path_spaces.py
@@ -1,0 +1,47 @@
+"""Regression coverage for installer-managed uv paths with spaces."""
+
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+INSTALL_SH = REPO_ROOT / "scripts" / "install.sh"
+SETUP_HERMES_SH = REPO_ROOT / "setup-hermes.sh"
+
+
+def _active_lines(path: Path) -> list[str]:
+    return [
+        line
+        for line in path.read_text().splitlines()
+        if line.strip() and not line.lstrip().startswith("#")
+    ]
+
+
+def test_install_script_quotes_uv_cmd_when_executing() -> None:
+    text = INSTALL_SH.read_text()
+
+    assert 'UV_VERSION=$("$UV_CMD" --version 2>/dev/null)' in text
+    assert '"$UV_CMD" venv venv --python "$PYTHON_VERSION"' in text
+    assert 'UV_PROJECT_ENVIRONMENT="$INSTALL_DIR/venv" "$UV_CMD" sync --extra all --locked' in text
+    assert 'if "$UV_CMD" pip install -e "$spec" 2>"$ALL_INSTALL_LOG"; then' in text
+
+    active = "\n".join(_active_lines(INSTALL_SH))
+    assert "$($UV_CMD " not in active
+    assert "\n    $UV_CMD " not in active
+    assert " $UV_CMD sync" not in active
+    assert "if $UV_CMD " not in active
+
+
+def test_setup_helper_quotes_uv_cmd_when_executing() -> None:
+    text = SETUP_HERMES_SH.read_text()
+
+    assert 'UV_VERSION=$("$UV_CMD" --version 2>/dev/null)' in text
+    assert 'if "$UV_CMD" python find "$PYTHON_VERSION" &> /dev/null; then' in text
+    assert 'PYTHON_PATH=$("$UV_CMD" python find "$PYTHON_VERSION")' in text
+    assert '"$UV_CMD" venv venv --python "$PYTHON_VERSION"' in text
+    assert 'UV_PROJECT_ENVIRONMENT="$SCRIPT_DIR/venv" "$UV_CMD" sync --extra all --locked' in text
+
+    active = "\n".join(_active_lines(SETUP_HERMES_SH))
+    assert "$($UV_CMD " not in active
+    assert "\n    $UV_CMD " not in active
+    assert " $UV_CMD sync" not in active
+    assert "if $UV_CMD " not in active


### PR DESCRIPTION
## Summary
- quote `UV_CMD` in the public installer when the managed uv binary is executed
- quote the same command path in the legacy `setup-hermes.sh` helper
- add regression coverage so installer-managed uv paths with spaces stay supported
- add a focused `Deploy Installer` workflow so future `scripts/install.sh` / `scripts/install.ps1` changes trigger the Vercel deploy hook after merge

## Root cause
The macOS agentic install readiness harness creates fresh paths with spaces. The public installer can install managed uv under `HERMES_HOME/bin`, but subsequent unquoted `$UV_CMD` command substitutions and executions split that path and fail before setup/OAuth begins.

The second operational issue is that installer-only changes do not obviously flow through the docs deploy path. The added installer deploy workflow makes the publish path explicit for installer script changes.

## Validation
- `bash -n scripts/install.sh setup-hermes.sh`
- Parsed `.github/workflows/deploy-installer.yml` with PyYAML `BaseLoader`
- `scripts/run_tests.sh tests/test_deploy_installer_workflow.py tests/test_install_sh_uv_path_spaces.py tests/test_install_sh_pythonpath_sanitization.py tests/test_install_sh_setup_wizard_tty_probe.py tests/test_install_sh_browser_install.py tests/test_install_no_initial_commit.py`
- local fresh-install rehearsal with isolated `HOME`, isolated `HERMES_HOME`, and install paths containing spaces: `bash scripts/install.sh --skip-setup --skip-browser --hermes-home "$tmp/Hermes Home" --dir "$tmp/Hermes Install"`
- PR-raw staging install over HTTPS from this branch, with isolated `HOME`, isolated `HERMES_HOME`, install paths containing spaces, and a temporary per-command Git `insteadOf` config so the installer cloned `codex/agentic-installer-uv-path-spaces`; result `PR_RAW_INSTALL_RC=0`, `hermes` binary present, installed checkout `2646110`

## Operator note
This PR is the current blocker for the public macOS agentic readiness gate. After merge, the new installer deploy workflow should trigger the Vercel hook for this installer-changing commit. If GitHub does not run the new workflow on the merge commit, a maintainer can run:

```bash
gh workflow run deploy-installer.yml --repo NousResearch/hermes-agent --ref main
```

Then verify the public artifact no longer contains unquoted `UV_CMD` executions:

```bash
curl -fsSL https://hermes-agent.nousresearch.com/install.sh | rg 'UV_VERSION=\$\(\$UV_CMD|\$UV_CMD venv| \$UV_CMD sync|if \$UV_CMD pip'
```

Expected result: no matches.
