### PR TITLE
fix(inventory): keep user-defined custom providers in model dedup

### DIFF
--- a/hermes_cli/inventory.py
+++ b/hermes_cli/inventory.py
@@ -178,6 +178,14 @@ def build_models_payload(
                 user_models.update(m.lower() for m in (row.get("models") or []))
         if user_models:
             for row in rows:
+                # A user's own configured provider is never an "aggregator
+                # duplicate" of itself: user_models is built from these very
+                # rows, and is_aggregator() reports True for every custom:*
+                # slug.  Without this guard the dedup strips a user-defined
+                # custom provider's entire model list (all of it lives in
+                # user_models), emptying its picker row.
+                if row.get("is_user_defined"):
+                    continue
                 slug = row.get("slug", "")
                 if not _is_aggregator(slug):
                     continue

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -415,6 +415,7 @@ AUTHOR_MAP = {
     "154585401+LeonSGP43@users.noreply.github.com": "LeonSGP43",
     "cine.dreamer.one@gmail.com": "LeonSGP43",
     "david@nutricraft.ca": "cyb0rgk1tty",
+    "214562553+cyb0rgk1tty@users.noreply.github.com": "cyb0rgk1tty",
     "chris+dora@cmullins.io": "cmullins70",
     "zjtan1@gmail.com": "zeejaytan",
     "asslaenn5@gmail.com": "Aslaaen",

--- a/tests/hermes_cli/test_inventory.py
+++ b/tests/hermes_cli/test_inventory.py
@@ -606,3 +606,35 @@ def test_aggregator_dedup_multiple_user_providers():
     assert or_row["models"] == ["model-z"]
     assert or_row["total_models"] == 1
 
+
+def test_aggregator_dedup_does_not_empty_user_defined_custom_provider():
+    """A named custom provider has slug ``custom:<name>``, which makes it
+    *both* ``is_user_defined=True`` *and* ``is_aggregator()==True``
+    (is_aggregator reports True for every ``custom:*`` slug).  The dedup
+    must skip user-defined rows: their models populate ``user_models``, so
+    filtering them against that set would strip the row's entire catalog and
+    hide the provider from the picker.  Regression for the #45954 dedup
+    emptying ``custom:*`` providers (e.g. a local llama.cpp endpoint or an
+    Anthropic-compatible proxy)."""
+    rows = [
+        _user_provider_row("custom:my-proxy", ["my-model-a", "my-model-b"]),
+        _aggregator_row("openrouter", ["my-model-a", "other/model"]),
+    ]
+    ctx = _empty_ctx()
+    with _list_auth_returning(rows):
+        payload = build_models_payload(ctx)
+
+    proxy_row = next(
+        r for r in payload["providers"] if r["slug"] == "custom:my-proxy"
+    )
+    or_row = next(r for r in payload["providers"] if r["slug"] == "openrouter")
+
+    # The user's own custom provider keeps all of its models.
+    assert proxy_row["models"] == ["my-model-a", "my-model-b"]
+    assert proxy_row["total_models"] == 2
+
+    # A genuine aggregator is still deduped against the user's models.
+    assert "my-model-a" not in or_row["models"]
+    assert "other/model" in or_row["models"]
+    assert or_row["total_models"] == 1
+


### PR DESCRIPTION
## Summary
A user-defined `custom:*` provider no longer erases its own model list from the `/model` picker.

Root cause: the aggregator dedup (`inventory.py`) builds `user_models` from every `is_user_defined` row, then strips those model IDs from any row where `is_aggregator(slug)` is True. But `is_aggregator()` returns True for **every** `custom:*` slug (`providers.py:496`), so a named custom provider is simultaneously `is_user_defined=True` and an "aggregator" — the dedup filters its entire catalog (all of which lives in `user_models`) out of its own row, hiding it from the picker. This is the "custom provider can't see models anymore after updating" regression.

## Changes
- `hermes_cli/inventory.py`: skip `is_user_defined` rows during aggregator filtering. Genuine aggregators still get deduped against user models; a user's own provider never dedups against itself.
- `tests/hermes_cli/test_inventory.py`: regression test (custom provider keeps its models, real aggregator still deduped).
- `scripts/release.py`: AUTHOR_MAP entry for @cyb0rgk1tty's noreply email (CI author-gate).

## Validation
| | Before | After |
|---|---|---|
| `custom:my-llamacpp` models | `[]` (erased) | `[llama-3.3-70b, qwen-coder]` |
| `openrouter` overlapping model | stripped | stripped |
| `openrouter` unique model | kept | kept |

Targeted suite: `tests/hermes_cli/test_inventory.py` 29/29 pass. E2E verified with real imports.

Salvages #46921 by @cyb0rgk1tty — authorship preserved via cherry-pick.

## Infographic

![nous-mission-patch](https://v3b.fal.media/files/b/0a9e8f9b/RsY-IxpkRdCTJarFKpoeB_QyDbzc2P.png)
