### PR TITLE
fix: preserve goals across compression session rotation

### DIFF
--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -554,6 +554,18 @@ def compress_context(
                     agent._session_db.set_session_title(agent.session_id, new_title)
                 except (ValueError, Exception) as e:
                     logger.debug("Could not propagate title on compression: %s", e)
+            # Migrate durable goal/objective state across the rotation. The goal
+            # is keyed ``goal:<session_id>`` and GoalManager does a flat lookup
+            # with no lineage fallback, so without this copy the objective reads
+            # None on the child session (and on /resume, which redirects to the
+            # child). The helper copies — not moves — and never raises, so a
+            # migration failure can never abort the compression split.
+            try:
+                from hermes_cli.goals import migrate_goal
+
+                migrate_goal(old_session_id, agent.session_id)
+            except Exception as e:
+                logger.warning("Could not migrate goal across compression rotation: %s", e)
             agent._session_db.update_system_prompt(agent.session_id, new_system_prompt)
             # Reset flush cursor — new session starts with no messages written
             agent._last_flushed_db_idx = 0

--- a/hermes_cli/goals.py
+++ b/hermes_cli/goals.py
@@ -279,6 +279,38 @@ def clear_goal(session_id: str) -> None:
     save_goal(session_id, state)
 
 
+def migrate_goal(old_session_id: str, new_session_id: str) -> bool:
+    """Copy durable goal state from one session id to another.
+
+    Used at the compression session-rotation boundary: compression ends the
+    active session and forks a child (new ``session_id``), but the goal is
+    keyed ``goal:<session_id>`` and GoalManager does a flat lookup with no
+    lineage fallback — so without this copy the objective reads None on the
+    child (and on /resume, which redirects to the child).
+
+    Copy, not move: the parent row is left intact for audit. Never overwrites
+    a goal the child already has. Returns True iff a goal was copied. Never
+    raises — a migration failure must not abort the compression split.
+    """
+    if not old_session_id or not new_session_id or old_session_id == new_session_id:
+        return False
+    db = _get_session_db()
+    if db is None:
+        return False
+    try:
+        raw = db.get_meta(_meta_key(old_session_id))
+        if not raw:
+            return False
+        if db.get_meta(_meta_key(new_session_id)):
+            return False  # child already has a goal — don't clobber it
+        db.set_meta(_meta_key(new_session_id), raw)
+        return True
+    except Exception as exc:
+        logger.warning("GoalManager: goal migration %s -> %s failed: %s",
+                       old_session_id, new_session_id, exc)
+        return False
+
+
 # ──────────────────────────────────────────────────────────────────────
 # Judge
 # ──────────────────────────────────────────────────────────────────────

--- a/tests/hermes_cli/test_goals.py
+++ b/tests/hermes_cli/test_goals.py
@@ -737,3 +737,69 @@ class TestStatusLineSubgoalCount:
         mgr.add_subgoal("b")
         line = mgr.status_line()
         assert "2 subgoals" in line
+
+
+class TestGoalSurvivesCompressionRotation:
+    """Regression: objective=None after a long/compressed turn.
+
+    Context compression ends the active session and forks a child session
+    (linked via ``parent_session_id``); the new messages land in the child,
+    and ``/resume`` redirects to that child via
+    ``SessionDB.resolve_resume_session_id``. The goal was saved under the
+    parent's id (``goal:<parent>``), but ``get_meta`` is a flat lookup with no
+    lineage fallback — so the resumed (child) session's GoalManager reads None.
+
+    The fix migrates the durable goal A -> B at the rotation boundary
+    (``hermes_cli.goals.migrate_goal``, called from
+    ``agent.conversation_compression.compress_context``), keeping the flat
+    GoalManager lookup unchanged. These tests pin that invariant.
+    """
+
+    def test_goal_survives_session_rotation_and_resume_redirect(self, hermes_home):
+        from hermes_state import SessionDB
+        from hermes_cli.goals import GoalManager, migrate_goal
+
+        parent, child = "rot-parent", "rot-child"
+        db = SessionDB()
+
+        # 1. Parent session.
+        db.create_session(parent, source="cli")
+
+        # 2. Set a goal on the parent — persisted under "goal:<parent>".
+        GoalManager(parent).set("finish the migration")
+        assert GoalManager(parent).has_goal() is True  # baseline sanity
+
+        # 3. Simulate the compression rotation as compress_context performs it:
+        #    end the parent, fork the child with parent_session_id, land a
+        #    message in the child (so it holds the conversation), and migrate
+        #    the durable goal via the same helper the rotation calls.
+        db.end_session(parent, "compression")
+        db.create_session(child, source="cli", parent_session_id=parent)
+        db.append_message(child, role="assistant", content="...summary...")
+        migrate_goal(parent, child)
+
+        # 4. Resume of the parent redirects forward to the child with messages.
+        assert db.resolve_resume_session_id(parent) == child
+
+        # 5. The objective must still resolve for the resumed (child) session.
+        mgr = GoalManager(child)
+        assert mgr.has_goal() is True, "objective lost across compression rotation"
+        assert mgr.state is not None
+        assert mgr.state.goal == "finish the migration"
+
+    def test_migrate_goal_does_not_overwrite_existing_child_goal(self, hermes_home):
+        """Copy semantics must never clobber a goal the child already has."""
+        from hermes_cli.goals import GoalManager, migrate_goal
+
+        GoalManager("ovr-parent").set("parent goal")
+        GoalManager("ovr-child").set("child goal")
+
+        assert migrate_goal("ovr-parent", "ovr-child") is False
+        assert GoalManager("ovr-child").state.goal == "child goal"
+
+    def test_migrate_goal_noop_when_no_source_goal(self, hermes_home):
+        """No source goal → nothing copied, returns False, no crash."""
+        from hermes_cli.goals import GoalManager, migrate_goal
+
+        assert migrate_goal("noop-parent", "noop-child") is False
+        assert GoalManager("noop-child").has_goal() is False

--- a/tests/run_agent/test_compression_persistence.py
+++ b/tests/run_agent/test_compression_persistence.py
@@ -198,3 +198,88 @@ class TestGatewayHistoryOffsetAfterSplit:
         assert len(new_messages) == 0, (
             "Expected 0 messages with stale offset=200 (demonstrates the bug)"
         )
+
+
+# ---------------------------------------------------------------------------
+# Part 3: Durable goal/objective survives the compression session rotation
+# ---------------------------------------------------------------------------
+
+def test_compression_rotation_migrates_goal(tmp_path, monkeypatch):
+    """compress_context must migrate the durable goal across session rotation.
+
+    Drives the real rotation path (summarizer stubbed so no model call fires).
+    Fails if agent/conversation_compression.py stops calling migrate_goal during
+    rotation: the spy records no call AND the goal no longer resolves under the
+    rotated (child) session id.
+    """
+    from pathlib import Path
+
+    import hermes_cli.goals as goals
+    from hermes_cli.goals import GoalManager
+    from hermes_state import SessionDB
+    from agent import conversation_compression
+
+    # Isolated HERMES_HOME so the agent's session rows and the goal store
+    # resolve to the same on-disk DB (as they do in production).
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    goals._DB_CACHE.clear()
+
+    db = SessionDB()
+    old_sid = "rotate-old"
+    db.create_session(session_id=old_sid, source="test")
+
+    with patch.dict(os.environ, {"OPENROUTER_API_KEY": "test-key"}):
+        from run_agent import AIAgent
+        agent = AIAgent(
+            api_key="test-key",
+            base_url="https://openrouter.ai/api/v1",
+            model="test/model",
+            quiet_mode=True,
+            session_db=db,
+            session_id=old_sid,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+
+    # Standing goal on the pre-rotation session.
+    GoalManager(old_sid).set("survive the rotation")
+
+    # Reach the rotation block without any model work: feasibility marked
+    # done and the summariser stubbed to a usable (non-aborted) summary.
+    agent._compression_feasibility_checked = True
+    agent.context_compressor.compress = lambda *a, **k: [
+        {"role": "user", "content": "[CONTEXT COMPACTION] summary"}
+    ]
+    agent.context_compressor._last_compress_aborted = False
+    agent.context_compressor._last_summary_error = None
+    agent.context_compressor._last_aux_model_failure_model = None
+
+    # Spy on migrate_goal while still performing the real copy. The rotation
+    # block does a local ``from hermes_cli.goals import migrate_goal``, so
+    # patching the module attribute is picked up at call time.
+    real_migrate = goals.migrate_goal
+    calls = []
+
+    def _spy(old, new):
+        calls.append((old, new))
+        return real_migrate(old, new)
+
+    monkeypatch.setattr(goals, "migrate_goal", _spy)
+
+    messages = [
+        {"role": "user", "content": "hi"},
+        {"role": "assistant", "content": "yo"},
+    ]
+    conversation_compression.compress_context(agent, messages, "sys")
+
+    new_sid = agent.session_id
+    assert new_sid != old_sid, "session rotation did not occur"
+    assert calls == [(old_sid, new_sid)], (
+        f"compress_context did not call migrate_goal(old, new) during rotation: {calls}"
+    )
+    # Observable effect: the objective now resolves under the rotated id.
+    assert GoalManager(new_sid).state is not None
+    assert GoalManager(new_sid).state.goal == "survive the rotation"


### PR DESCRIPTION
Context compression ends the active session and forks a child session (new session_id, linked via parent_session_id); /resume then redirects to that child. The goal/objective is keyed goal:<session_id> in state_meta and GoalManager does a flat lookup with no lineage fallback, so the objective read None on the child session after a long/compressed turn (and on resume).

Add migrate_goal(old, new) and call it at the rotation boundary in compress_context. Copy (not move), never overwrites an existing child goal, never raises — a migration failure can't abort the compression split. Flat GoalManager lookup and resume semantics are unchanged.

Tests: goal survives rotation + resume redirect, no-overwrite and no-source no-op invariants, and a focused test that compress_context actually calls migrate_goal during rotation.

Related to #[15000](https://github.com/NousResearch/hermes-agent/issues/15000): that issue covers compression-created child session chains for message history; this handles another session-scoped state affected by the same rotation.

Fixes #

Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

Changes Made

- hermes_cli/goals.py — new module-level migrate_goal(old_session_id, new_session_id) helper beside save_goal/clear_goal. Copy semantics; returns True only when a goal is copied; skips if source absent, if old == new, or if the child already has a goal; swallows + logs errors (never raises).
- agent/conversation_compression.py — call migrate_goal(old_session_id, agent.session_id) at the session-rotation boundary in compress_context (right after the title is propagated to the child), guarded so a migration failure can't abort the compaction split.
- tests/hermes_cli/test_goals.py — TestGoalSurvivesCompressionRotation: goal survives rotation + resume redirect, no-overwrite invariant, no-source no-op invariant.
- tests/run_agent/test_compression_persistence.py — test_compression_rotation_migrates_goal: drives the real compress_context rotation path (summarizer stubbed, no model call) and asserts migrate_goal(old, new) is invoked and the goal resolves under the rotated id.

How to Test

1. Run the targeted suites: venv/bin/pytest tests/hermes_cli/test_goals.py tests/run_agent/test_compression_persistence.py → 60 passed.
2. Regression proof (objective loss): on main, test_goal_survives_session_rotation_and_resume_redirect fails at GoalManager(child).has_goal() (objective lost across compression rotation); with this fix it passes.
3. Guard proof (fix is load-bearing): temporarily neutralize the migrate_goal(...) call in compress_context → test_compression_rotation_migrates_goal fails (spy records no call); restore → passes.
4. Manual: set a /goal, force a long turn that triggers compaction (or /compress), then /resume — the objective is still active under the rotated session instead of reading None.

Checklist

Code

- [x] I've read the Contributing Guide (https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow Conventional Commits (https://www.conventionalcommits.org/) (fix(scope):, feat(scope):, etc.)
- [x] I searched for existing PRs (https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix/feature (no unrelated commits)
- [x] I've run pytest tests/ -q and all tests pass <!-- ran the two affected suites (60 passed); full suite not run -->
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: <!-- e.g. Ubuntu 24.04 -->

Local platform: Debian GNU/Linux on x86_64, Python 3.11.15.


Documentation & Housekeeping

- [x] I've updated relevant documentation (README, docs/, docstrings) — or N/A <!-- N/A: behavior-preserving fix; new helper is self-documented -->
- [x] I've updated cli-config.yaml.example if I added/changed config keys — or N/A <!-- N/A: no config keys -->
- [x] I've updated CONTRIBUTING.md or AGENTS.md if I changed architecture or workflows — or N/A <!-- N/A -->
- [x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide (https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A <!-- N/A: pure SQLite state_meta copy -->
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A <!-- N/A -->