### PR TITLE
fix(telegram): resolve replies to rich (sendRichMessage) messages

### DIFF
--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -1241,6 +1241,14 @@ class TelegramAdapter(BasePlatformAdapter):
                 message_id = (msg.get("result") or {}).get("message_id")
         else:
             message_id = getattr(msg, "message_id", None)
+        if message_id is not None:
+            # Telegram won't echo rich content in reply_to_message, so remember
+            # what we sent — replies to this message resolve via this index.
+            try:
+                from gateway import rich_sent_store
+                rich_sent_store.record(str(chat_id), str(message_id), content)
+            except Exception:
+                pass
         return SendResult(
             success=True,
             message_id=str(message_id) if message_id is not None else None,
@@ -6700,6 +6708,19 @@ class TelegramAdapter(BasePlatformAdapter):
                     or message.reply_to_message.caption
                     or None
                 )
+                if not reply_to_text:
+                    # Rich messages (sendRichMessage — the launchd briefings and
+                    # the gateway's own rich finals) are NOT echoed with their
+                    # content in reply_to_message; Telegram sends no text,
+                    # caption, or api_kwargs for them. Recover the text we sent
+                    # from our local send-time index, keyed by message id.
+                    try:
+                        from gateway import rich_sent_store
+                        reply_to_text = rich_sent_store.lookup(
+                            str(chat.id), reply_to_id
+                        )
+                    except Exception:
+                        reply_to_text = None
 
         # Per-channel/topic ephemeral prompt
         from gateway.platforms.base import resolve_channel_prompt

--- a/gateway/rich_sent_store.py
+++ b/gateway/rich_sent_store.py
@@ -1,0 +1,80 @@
+"""Local index of text we've sent via ``sendRichMessage`` (Bot API 10.1).
+
+Telegram does NOT echo a rich message's content back in ``reply_to_message``
+when a user replies to it (verified: ``.text``/``.caption`` empty,
+``.api_kwargs`` None). So replies to the launchd briefings / any rich send
+arrive with no quotable text and the agent is blind to what was referenced.
+
+Fix: remember ``message_id -> text`` at send time, look it up by
+``reply_to_id`` on inbound. This module is the single source of truth for that
+index.
+
+Best-effort and dependency-free: every operation swallows errors and degrades
+to a no-op / ``None`` so it can never break a send or an inbound message.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import time
+from typing import Optional
+
+_MAX_ENTRIES = 1000
+_MAX_TEXT_CHARS = 2000
+
+
+def _store_path() -> str:
+    home = os.environ.get("HERMES_HOME") or os.path.expanduser("~/.hermes")
+    return os.path.join(home, "state", "rich_sent_index.json")
+
+
+def _key(chat_id, message_id) -> str:
+    return f"{chat_id}:{message_id}"
+
+
+def record(chat_id, message_id, text: Optional[str]) -> None:
+    """Persist ``text`` for ``(chat_id, message_id)``. No-op on any failure."""
+    if not text or message_id is None or chat_id is None:
+        return
+    path = _store_path()
+    try:
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        try:
+            with open(path, "r", encoding="utf-8") as fh:
+                data = json.load(fh)
+            if not isinstance(data, dict):
+                data = {}
+        except (FileNotFoundError, ValueError):
+            data = {}
+        data[_key(chat_id, message_id)] = {
+            "t": text[:_MAX_TEXT_CHARS],
+            "ts": int(time.time()),
+        }
+        # Trim oldest by timestamp when over cap.
+        if len(data) > _MAX_ENTRIES:
+            for k, _ in sorted(
+                data.items(), key=lambda kv: kv[1].get("ts", 0)
+            )[: len(data) - _MAX_ENTRIES]:
+                data.pop(k, None)
+        tmp = f"{path}.tmp.{os.getpid()}"
+        with open(tmp, "w", encoding="utf-8") as fh:
+            json.dump(data, fh, ensure_ascii=False)
+        os.replace(tmp, path)  # atomic; tolerates concurrent writers racing
+    except Exception:
+        return
+
+
+def lookup(chat_id, message_id) -> Optional[str]:
+    """Return stored text for ``(chat_id, message_id)`` or ``None``."""
+    if message_id is None or chat_id is None:
+        return None
+    try:
+        with open(_store_path(), "r", encoding="utf-8") as fh:
+            data = json.load(fh)
+        entry = data.get(_key(chat_id, message_id))
+        if isinstance(entry, dict):
+            return entry.get("t") or None
+    except (FileNotFoundError, ValueError, AttributeError):
+        return None
+    return None

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -8259,10 +8259,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         _msg_start_time = time.time()
         _platform_name = source.platform.value if hasattr(source.platform, "value") else str(source.platform)
         _msg_preview = (event.text or "")[:80].replace("\n", " ")
+        _reply_id = getattr(event, "reply_to_message_id", None)
+        _reply_txt = (getattr(event, "reply_to_text", None) or "")[:80].replace("\n", " ")
         logger.info(
-            "inbound message: platform=%s user=%s chat=%s msg=%r",
+            "inbound message: platform=%s user=%s chat=%s msg=%r reply_to_id=%s reply_to_text=%r",
             _platform_name, source.user_name or source.user_id or "unknown",
-            source.chat_id or "unknown", _msg_preview,
+            source.chat_id or "unknown", _msg_preview, _reply_id, _reply_txt,
         )
 
         # Get or create session

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -91,6 +91,7 @@ AUTHOR_MAP = {
     "290859878+synapsesx@users.noreply.github.com": "synapsesx",
     "157689911+itsflownium@users.noreply.github.com": "itsflownium",
     "dirtyren@users.noreply.github.com": "dirtyren",
+    "stevenn.damatoo@gmail.com": "x1erra",
     "evansrory@gmail.com": "zimigit2020",
     "237263164+ft-ioxcs@users.noreply.github.com": "ft-ioxcs",
     "tharushkadinujaya05@gmail.com": "0xneobyte",

--- a/tests/gateway/test_telegram_rich_messages.py
+++ b/tests/gateway/test_telegram_rich_messages.py
@@ -756,3 +756,110 @@ async def test_finalize_edit_rich_over_markdownv2_limit_not_split():
     api_kwargs = _rich_edit_kwargs(adapter)
     assert api_kwargs["rich_message"]["markdown"] == big_table
     adapter._bot.edit_message_text.assert_not_called()
+
+
+# --------------------------------------------------------------------------
+# Rich-reply recovery (#47375): Telegram does not echo a sendRichMessage's
+# content in reply_to_message (.text/.caption empty, .api_kwargs None), so we
+# record message_id -> text at send time and recover it on inbound reply.
+# --------------------------------------------------------------------------
+
+
+def _reply_message(reply_to_id, *, reply_text=None, reply_caption=None, quote_text=None):
+    """Build a mock inbound reply Message for _build_message_event."""
+    replied = SimpleNamespace(
+        message_id=int(reply_to_id),
+        text=reply_text,
+        caption=reply_caption,
+    )
+    quote = SimpleNamespace(text=quote_text) if quote_text is not None else None
+    return SimpleNamespace(
+        message_id=999,
+        chat=SimpleNamespace(id=12345, type="private", title=None, full_name="U"),
+        from_user=SimpleNamespace(
+            id=42, username="u", first_name="U", last_name=None,
+            full_name="U", is_bot=False,
+        ),
+        text="what did this mean?",
+        caption=None,
+        reply_to_message=replied,
+        quote=quote,
+        message_thread_id=None,
+        is_topic_message=False,
+        entities=[],
+        date=None,
+    )
+
+
+@pytest.mark.asyncio
+async def test_rich_reply_records_and_recovers_text(monkeypatch, tmp_path):
+    """A reply to a rich-sent message resolves the original text via the index."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    from gateway.platforms.base import MessageType
+    from gateway import rich_sent_store
+
+    adapter = _make_adapter()
+
+    # _try_send_rich records (chat_id, message_id) -> content on a successful
+    # rich send. Drive that path directly so the test doesn't depend on send()
+    # gating heuristics (length, content shape) choosing the rich path.
+    adapter._bot.do_api_request = AsyncMock(
+        return_value=SimpleNamespace(message_id=678)
+    )
+    send_result = await adapter._try_send_rich(
+        "12345", "Your morning briefing: CI is green.", None, None,
+    )
+    assert send_result is not None and send_result.success is True
+    assert send_result.message_id == "678"
+    assert rich_sent_store.lookup("12345", "678") == "Your morning briefing: CI is green."
+
+    # Inbound reply carries NO text/caption (the rich-message blind spot).
+    event = adapter._build_message_event(
+        _reply_message("678"), MessageType.TEXT,
+    )
+    assert event.reply_to_message_id == "678"
+    assert event.reply_to_text == "Your morning briefing: CI is green."
+
+
+@pytest.mark.asyncio
+async def test_rich_reply_lookup_miss_leaves_text_none(monkeypatch, tmp_path):
+    """No recorded entry -> reply_to_text stays None, no crash."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    from gateway.platforms.base import MessageType
+
+    adapter = _make_adapter()
+    event = adapter._build_message_event(
+        _reply_message("404"), MessageType.TEXT,
+    )
+    assert event.reply_to_message_id == "404"
+    assert event.reply_to_text is None
+
+
+@pytest.mark.asyncio
+async def test_rich_reply_native_quote_wins_over_lookup(monkeypatch, tmp_path):
+    """A native partial quote takes precedence over the send-time index."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    from gateway.platforms.base import MessageType
+    from gateway import rich_sent_store
+
+    rich_sent_store.record("12345", "678", "full recorded body")
+    adapter = _make_adapter()
+    event = adapter._build_message_event(
+        _reply_message("678", quote_text="just this part"), MessageType.TEXT,
+    )
+    assert event.reply_to_text == "just this part"
+
+
+@pytest.mark.asyncio
+async def test_rich_reply_caption_wins_over_lookup(monkeypatch, tmp_path):
+    """When Telegram DOES echo a caption, it wins over the index fallback."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    from gateway.platforms.base import MessageType
+    from gateway import rich_sent_store
+
+    rich_sent_store.record("12345", "678", "recorded body")
+    adapter = _make_adapter()
+    event = adapter._build_message_event(
+        _reply_message("678", reply_caption="echoed caption"), MessageType.TEXT,
+    )
+    assert event.reply_to_text == "echoed caption"


### PR DESCRIPTION
## Summary
Replies to Telegram `sendRichMessage` messages now resolve their quoted text. Telegram does not echo a rich message's content back in `reply_to_message` (`.text`/`.caption` empty, `.api_kwargs` None), so replies to rich sends (scheduled briefings, the gateway's own rich finals) arrived with no quotable text and the `[Replying to: ...]` injection was skipped.

Salvage of #47375 by @x1erra, cherry-picked onto current main with authorship preserved.

## Changes
- `gateway/rich_sent_store.py` (new): best-effort JSON index at `state/rich_sent_index.json` mapping `chat_id:message_id -> text` (cap 1000, 2000-char text cap, atomic writes, fully no-throw).
- `gateway/platforms/telegram.py`: `_try_send_rich` records content on a successful send; the inbound reply extractor falls back to `rich_sent_store.lookup(...)` when `.text`/`.caption` are empty (after the native-quote check, so partial quotes still win).
- `gateway/run.py`: inbound `reply_to_id`/`reply_to_text` added to the message log line (diagnostic the author used to verify).
- `tests/gateway/test_telegram_rich_messages.py`: 4 regression tests — record+recover round trip, lookup miss, native quote precedence, echoed caption precedence.

## Salvage notes (vs original PR)
- **Dropped** the `gateway/run.py` reply-prefix rewrite. It changed the cross-platform `[Replying to: "..."]` prefix into a ~50-token anti-gaslighting instruction block, hitting every reply on every platform — out of scope for a telegram rich-reply fix and a permanent per-reply token cost. Kept the terse original.
- **Scrubbed** a docstring reference to `scripts/telegram/send_rich.py` (an out-of-repo cron sender, not part of this codebase).

## Validation
| | Before | After |
|---|---|---|
| Reply to rich send | `reply_to_text=''`, injection skipped | full sent text recovered |
| Reply to plain send | works | unchanged |
| `tests/gateway/test_telegram_rich_messages.py` | 51 | 55 passing |

Store E2E (isolated `HERMES_HOME`): round-trip, path, miss→None, None-arg no-op, empty-text skip, 2000-char cap, 1000-entry trim, corrupt-file recovery, str-key parity — all pass.

Closes #47375.

## Infographic

![rich-reply-recovery](https://v3b.fal.media/files/b/0a9e8fa2/J7UWt5FwF5UUDqneMKO5R_J0cUJmlW.png)
