### PR TITLE
feat(catalog): add govee-mcp optional MCP entry

### DIFF
--- a/optional-mcps/govee/manifest.yaml
+++ b/optional-mcps/govee/manifest.yaml
@@ -18,7 +18,7 @@ transport:
 install:
   type: git
   url: https://github.com/evefromwayback/govee-mcp.git
-  ref: v0.2.0            # pinned release tag
+  ref: v0.2.1            # pinned release tag
   bootstrap:
     - "python3 -m venv .venv"
     - ".venv/bin/pip install ."

--- a/optional-mcps/govee/manifest.yaml
+++ b/optional-mcps/govee/manifest.yaml
@@ -5,9 +5,13 @@
 manifest_version: 1
 
 name: govee
-description: Control Govee smart lights and devices (LAN-first, cloud fallback) over stdio.
+description: Control Govee smart lights and devices (LAN-first, cloud fallback) over stdio. macOS/Linux only.
 source: https://github.com/evefromwayback/govee-mcp
 
+# POSIX-only entry: the launch command and bootstrap below use .venv/bin paths
+# and python3, which do not exist on native Windows. The manifest schema has no
+# per-platform fields today, so this entry is constrained to macOS/Linux rather
+# than claiming platform neutrality. Windows users can run it under WSL.
 transport:
   type: stdio
   command: "${INSTALL_DIR}/.venv/bin/python"
@@ -18,7 +22,7 @@ transport:
 install:
   type: git
   url: https://github.com/evefromwayback/govee-mcp.git
-  ref: v0.2.1            # pinned release tag
+  ref: 9847417047eba8e3149c0f84daa28627853e3349   # v0.2.1
   bootstrap:
     - "python3 -m venv .venv"
     - ".venv/bin/pip install ."
@@ -50,4 +54,5 @@ post_install: |
   govee-mcp controls your own Govee devices. Provide a Govee Developer API key for
   cloud control and for any device without LAN control; LAN-capable lights also work
   locally with no key. The free Govee API is for non-commercial use only.
+  This entry supports macOS and Linux only (Windows via WSL).
   Start a new Hermes session to load the tools.

--- a/optional-mcps/govee/manifest.yaml
+++ b/optional-mcps/govee/manifest.yaml
@@ -1,0 +1,53 @@
+# Nous-approved MCP catalog entry.
+# Presence in this directory = approval. Merged via PR review.
+#
+# Schema version 1.
+manifest_version: 1
+
+name: govee
+description: Control Govee smart lights and devices (LAN-first, cloud fallback) over stdio.
+source: https://github.com/evefromwayback/govee-mcp
+
+transport:
+  type: stdio
+  command: "${INSTALL_DIR}/.venv/bin/python"
+  args:
+    - "-m"
+    - "govee_mcp"
+
+install:
+  type: git
+  url: https://github.com/evefromwayback/govee-mcp.git
+  ref: v0.2.0            # pinned release tag
+  bootstrap:
+    - "python3 -m venv .venv"
+    - ".venv/bin/pip install ."
+
+auth:
+  type: api_key
+  env:
+    - name: GOVEE_API_KEY
+      prompt: "Govee Developer API key (Govee Home app: Profile > About Us > Apply for API Key). Leave blank for LAN-only control."
+      required: false
+      secret: true
+
+tools:
+  default_enabled:
+    - list_devices
+    - list_groups
+    - get_device_state
+    - refresh
+    - list_scenes
+    - set_power
+    - set_brightness
+    - set_color
+    - set_color_temp
+    - set_scene
+    - create_group
+    - delete_group
+
+post_install: |
+  govee-mcp controls your own Govee devices. Provide a Govee Developer API key for
+  cloud control and for any device without LAN control; LAN-capable lights also work
+  locally with no key. The free Govee API is for non-commercial use only.
+  Start a new Hermes session to load the tools.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -304,6 +304,7 @@ locales = ["locales/*.yaml"]
 # entry; tests/test_packaging_metadata.py enforces an entry per optional-mcps/<name>.
 "optional-mcps/linear" = ["optional-mcps/linear/manifest.yaml"]
 "optional-mcps/n8n" = ["optional-mcps/n8n/manifest.yaml"]
+"optional-mcps/govee" = ["optional-mcps/govee/manifest.yaml"]
 
 [tool.setuptools.package-data]
 hermes_cli = ["web_dist/**/*", "tui_dist/**/*", "scripts/install.sh", "scripts/install.ps1"]


### PR DESCRIPTION
## What does this PR do?
Adds a new Nous catalog entry for **govee-mcp**, an MCP server that lets Hermes control Govee smart lights and devices. It gives users a one-command install (`hermes mcp install official/govee`) for local light/device control — LAN-first with automatic cloud fallback, multi-device discovery, groups, scenes, and state read-back.
This approach mirrors the existing `n8n` entry: a git-installed stdio server pinned to a release tag with a venv + pip bootstrap, and `api_key` auth where the key is optional (LAN-only control needs none). The package is already published on PyPI (`govee-mcp`) and listed in the official MCP registry, so the manifest just points Hermes at vetted, versioned artifacts.

## Related Issue
N/A — new catalog entry, no existing issue.
## Type of Change
- [x] ✨ New feature (non-breaking change that adds functionality)
## Changes Made
- Added `optional-mcps/govee/manifest.yaml` — a new Nous catalog entry for **govee-mcp**, an MCP server for Govee smart lights and devices.
- LAN-first with cloud fallback; multi-device discovery, groups, scenes, and state read-back.
- stdio transport; git install pinned to tag `v0.2.1` with a venv + pip bootstrap.
- `GOVEE_API_KEY` is optional (LAN-only control works with no key). The free Govee Developer API is non-commercial use only.
- Manifest mirrors the existing `n8n` entry's structure (stdio + git install + `api_key` auth).
- No changes to Hermes code; this is a metadata-only catalog addition.
## How to Test
1. `hermes mcp install official/govee` (clones the repo at `v0.2.1`, creates a venv, pip installs).
2. When prompted, leave `GOVEE_API_KEY` blank for LAN-only, or paste a Govee Developer API key for cloud control.
3. Start a new Hermes session and run: `List my Govee devices` → calls `list_devices`. With a device present, `Turn off <device name>` exercises `set_power`.
## Checklist
### Code
- [x] I've read the Contributing Guide
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this feature (single manifest file)
- [ ] I've run `pytest tests/ -q` and all tests pass — N/A (no Hermes code changed; the govee-mcp package's own suite of 37 tests passes in its repo)
- [ ] I've added tests for my changes — N/A (metadata-only manifest)
- [x] I've tested on my platform: macOS (Apple Silicon)
### Documentation & Housekeeping
- [x] I've updated relevant documentation — N/A (catalog manifest is self-documenting via comments + `post_install`)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture — N/A
- [x] I've considered cross-platform impact — N/A (manifest is platform-agnostic; install uses `python3 -m venv`)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A