### PR TITLE
fix(compressor): strip _multimodal tool-result images after compress()

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -468,6 +468,53 @@ def _strip_historical_media(messages: List[Dict[str, Any]]) -> List[Dict[str, An
     return result if changed else messages
 
 
+def _strip_all_multimodal_tool_results(messages: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    """Replace ``_multimodal`` image payloads in tool results with their text summaries.
+
+    ``browser_vision`` and ``computer_use`` return screenshots inside a
+    ``_multimodal`` envelope::
+
+        {"_multimodal": True, "content": [...base64...], "text_summary": "..."}
+
+    Each screenshot can be several megabytes.  After :meth:`compress` assembles
+    the compressed message list, the model has already seen and responded to
+    every tool result in the conversation.  The base64 payload is therefore
+    redundant — it carries no information the model has not already processed,
+    but it inflates every subsequent API request's byte size.  Providers impose
+    hard limits on request body size (not token count), so even when the token
+    estimate is within limits a session with a handful of browser_vision calls
+    can produce HTTP 413 errors that survive every compression pass.
+
+    Replaces each ``_multimodal`` envelope with its ``text_summary`` string so
+    the model retains a readable description of what the screenshot showed.
+    Only called inside :meth:`compress` after the final message list is
+    assembled, guaranteeing the model will have seen the screenshot before it
+    is stripped.
+
+    Shallow copies only; input is never mutated.
+    """
+    if not messages:
+        return messages
+
+    result: List[Dict[str, Any]] = []
+    changed = False
+    for msg in messages:
+        if not isinstance(msg, dict) or msg.get("role") != "tool":
+            result.append(msg)
+            continue
+        content = msg.get("content")
+        if isinstance(content, dict) and content.get("_multimodal"):
+            summary = content.get("text_summary") or "[screenshot removed to save context]"
+            new_msg = msg.copy()
+            new_msg["content"] = f"[screenshot removed] {summary[:200]}"
+            result.append(new_msg)
+            changed = True
+        else:
+            result.append(msg)
+
+    return result if changed else messages
+
+
 def _summarize_tool_result(tool_name: str, tool_args: str, tool_content: str) -> str:
     """Create an informative 1-line summary of a tool call + result.
 
@@ -2394,12 +2441,17 @@ This compaction should PRIORITISE preserving all information related to the focu
 
         compressed = self._sanitize_tool_pairs(compressed)
 
-        # Replace image parts in all compressed messages before the newest
-        # image-bearing user turn with a short text placeholder. Without
-        # this, tail messages keep their original multi-MB base-64 image
-        # payloads forever, which can push every subsequent API request
-        # past the provider's body-size limit and wedge the session.
-        # Port of Kilo-Org/kilocode#9434.
+        # Strip _multimodal base64 from all tool results (browser_vision /
+        # computer_use screenshots).  After compression the model has already
+        # analyzed and responded to every tool result, so the base64 is
+        # redundant.  Provider payload limits are based on byte size, not
+        # token count, so a handful of screenshots can produce HTTP 413 errors
+        # even when the token estimate is within bounds.  text_summary is
+        # preserved so the model can still reference what the screenshot showed.
+        compressed = _strip_all_multimodal_tool_results(compressed)
+
+        # Replace image parts in older user messages with a short text
+        # placeholder.  Port of Kilo-Org/kilocode#9434.
         compressed = _strip_historical_media(compressed)
 
         new_estimate = estimate_messages_tokens_rough(compressed)

--- a/tests/agent/test_context_compressor.py
+++ b/tests/agent/test_context_compressor.py
@@ -2264,3 +2264,111 @@ class TestPreflightSentinelGuard:
         compressor.last_prompt_tokens = 50_000
         result = self._seed(compressor.last_prompt_tokens, 10_000)
         assert result == 50_000
+
+
+class TestStripAllMultimodalToolResults:
+    """_strip_all_multimodal_tool_results strips every _multimodal tool result.
+
+    browser_vision and computer_use return screenshots as ``_multimodal`` envelopes.
+    After compression the model has already responded to each of them, so the
+    base64 payload is pure waste.  Providers enforce byte-size limits (not token
+    limits), so even a token-lean conversation can produce HTTP 413 when a handful
+    of multi-MB screenshots survive in the compressed message list.
+
+    The key difference from the anchor-based user-image stripping: ALL tool-result
+    envelopes are stripped — including the most recent one — because the model will
+    always have seen and responded to them before compress() runs.
+    """
+
+    def _make_multimodal_envelope(self, summary: str = "screenshot of page") -> dict:
+        return {
+            "_multimodal": True,
+            "content": [
+                {"type": "text", "text": "Image loaded into your context."},
+                {"type": "image_url", "image_url": {"url": "data:image/png;base64,AAAA" + "x" * 1000}},
+            ],
+            "text_summary": summary,
+            "meta": {"size_bytes": 1024},
+        }
+
+    def test_single_multimodal_tool_result_stripped(self):
+        """Even the only tool result is stripped — no anchor exception."""
+        from agent.context_compressor import _strip_all_multimodal_tool_results
+
+        messages = [
+            {"role": "user", "content": "screenshot please"},
+            {"role": "assistant", "content": "", "tool_calls": [{"id": "c1"}]},
+            {"role": "tool", "content": self._make_multimodal_envelope("login page"), "tool_call_id": "c1"},
+            {"role": "assistant", "content": "I see the login form."},
+        ]
+
+        result = _strip_all_multimodal_tool_results(messages)
+
+        assert result[2]["content"] == "[screenshot removed] login page"
+        assert result[0] is messages[0]
+        assert result[3] is messages[3]
+
+    def test_all_multimodal_tool_results_stripped(self):
+        """Every _multimodal tool result in the list is stripped, not just older ones."""
+        from agent.context_compressor import _strip_all_multimodal_tool_results
+
+        messages = [
+            {"role": "user", "content": "take two screenshots"},
+            {"role": "assistant", "content": "", "tool_calls": [{"id": "c1"}]},
+            {"role": "tool", "content": self._make_multimodal_envelope("first"), "tool_call_id": "c1"},
+            {"role": "assistant", "content": "I see the first page."},
+            {"role": "user", "content": "now the second"},
+            {"role": "assistant", "content": "", "tool_calls": [{"id": "c2"}]},
+            {"role": "tool", "content": self._make_multimodal_envelope("second"), "tool_call_id": "c2"},
+            {"role": "assistant", "content": "I see the second page."},
+        ]
+
+        result = _strip_all_multimodal_tool_results(messages)
+
+        assert result[2]["content"] == "[screenshot removed] first"
+        assert result[6]["content"] == "[screenshot removed] second"
+
+    def test_text_summary_used_as_replacement(self):
+        """Stripped content uses text_summary from the envelope."""
+        from agent.context_compressor import _strip_all_multimodal_tool_results
+
+        envelope = self._make_multimodal_envelope("a dashboard with 3 charts")
+        messages = [
+            {"role": "tool", "content": envelope, "tool_call_id": "c1"},
+        ]
+        result = _strip_all_multimodal_tool_results(messages)
+        assert result[0]["content"] == "[screenshot removed] a dashboard with 3 charts"
+
+    def test_fallback_when_no_text_summary(self):
+        """Falls back to generic placeholder when text_summary is absent."""
+        from agent.context_compressor import _strip_all_multimodal_tool_results
+
+        envelope = {"_multimodal": True, "content": [{"type": "image_url", "image_url": {"url": "data:image/png;base64,AAA"}}]}
+        messages = [
+            {"role": "tool", "content": envelope, "tool_call_id": "c1"},
+        ]
+        result = _strip_all_multimodal_tool_results(messages)
+        assert result[0]["content"] == "[screenshot removed] [screenshot removed to save context]"
+
+    def test_non_multimodal_tool_results_unchanged(self):
+        """Plain string tool results are not touched."""
+        from agent.context_compressor import _strip_all_multimodal_tool_results
+
+        messages = [
+            {"role": "tool", "content": "exit code 0", "tool_call_id": "c1"},
+            {"role": "tool", "content": [{"type": "text", "text": "plain list"}], "tool_call_id": "c2"},
+        ]
+        result = _strip_all_multimodal_tool_results(messages)
+        assert result is messages
+
+    def test_user_and_assistant_messages_unchanged(self):
+        """Only tool messages are inspected; user/assistant messages pass through."""
+        from agent.context_compressor import _strip_all_multimodal_tool_results
+
+        img_content = [{"type": "image_url", "image_url": {"url": "data:image/png;base64,USR"}}]
+        messages = [
+            {"role": "user", "content": img_content},
+            {"role": "assistant", "content": "described it"},
+        ]
+        result = _strip_all_multimodal_tool_results(messages)
+        assert result is messages


### PR DESCRIPTION
## Problem

`browser_vision` and `computer_use` return screenshots as a `_multimodal` envelope:

```python
{"_multimodal": True, "content": [...base64...], "text_summary": "..."}
```

Each screenshot can be several megabytes. `_strip_historical_media` only stripped user-attached images, so `_multimodal` tool results accumulated across turns and inflated every subsequent API request payload.

Providers enforce limits on **byte size**, not token count. Sessions with a handful of `browser_vision` calls produced HTTP 413 errors that survived every compression pass even when the token estimate was well within the model's context limit (issue #47339: 101 → 13 messages, still 413).

## Fix

Add `_strip_all_multimodal_tool_results()`, called inside `compress()` after `_sanitize_tool_pairs()` and before `_strip_historical_media()`.

It replaces every `_multimodal` envelope with its `text_summary` string:

```
{"_multimodal": True, "content": [...3MB base64...], "text_summary": "login page with a form"}
→ "[screenshot removed] login page with a form"
```

**Why it's safe to strip all of them (including the most recent):** `compress()` only runs between turns, never mid-turn. By the time compression triggers, the model always has an assistant response for every tool result in the conversation — the base64 has already been processed and retaining it serves no purpose.

## Tests

6 new tests in `TestStripAllMultimodalToolResults`:
- single envelope stripped (no anchor exception)
- all envelopes stripped across multiple calls
- `text_summary` used as replacement text
- fallback placeholder when `text_summary` absent
- non-`_multimodal` tool results unchanged
- user/assistant messages unchanged

All 102 tests pass.

Fixes #47339.