### PR TITLE
fix(gateway): flatten observed-group multimodal content to text

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -741,6 +741,41 @@ def _message_timestamps_enabled(user_config: Optional[dict]) -> bool:
     return bool(mt)
 
 
+def _flatten_observed_content(content: Any) -> str:
+    """Render an observed-group message's content as plain text.
+
+    Observed group chatter is replayed as a *text* prefix on the addressed turn
+    (see ``_wrap_current_message_with_observed_context``), so multimodal content
+    must be flattened to text. A photo arrives as a multimodal parts list
+    (``[{"type": "text", ...}, {"type": "image_url", ...}]``); calling
+    ``str()`` on that list yields a Python ``repr`` — corrupting the image and
+    polluting the context prefix with ``{'type': 'image_url', ...}`` noise. We
+    keep text parts verbatim and replace non-text parts (images, audio) with a
+    short placeholder so the model still knows an attachment was sent without
+    receiving a garbled blob.
+    """
+
+    if isinstance(content, str):
+        return content.strip()
+    if isinstance(content, list):
+        parts: List[str] = []
+        for part in content:
+            if not isinstance(part, dict):
+                parts.append(str(part))
+                continue
+            part_type = part.get("type")
+            if part_type == "text":
+                text = part.get("text", "")
+                if text:
+                    parts.append(text)
+            elif part_type == "image_url":
+                parts.append("[image attachment]")
+            elif part_type:
+                parts.append(f"[{part_type} attachment]")
+        return " ".join(parts).strip()
+    return str(content).strip()
+
+
 def _build_gateway_agent_history(
     history: List[Dict[str, Any]],
     *,
@@ -788,7 +823,7 @@ def _build_gateway_agent_history(
         if inject_timestamps and role == "user" and isinstance(content, str):
             content = _render_msg_ts(content, msg.get("timestamp"), tz=_msg_tz)
         if separate_observed_context and msg.get("observed") and role == "user" and content:
-            observed_group_context.append(str(content).strip())
+            observed_group_context.append(_flatten_observed_content(content))
             continue
 
         # Rich agent messages (tool_calls, tool results) must be passed through

--- a/tests/gateway/test_telegram_group_gating.py
+++ b/tests/gateway/test_telegram_group_gating.py
@@ -300,6 +300,45 @@ def test_observed_group_context_wraps_multimodal_current_message_without_mutatin
     assert wrapped[1] == original[1]
 
 
+def test_observed_group_context_flattens_multimodal_message_to_text():
+    """An observed group photo must not be str()-ed into a Python repr.
+
+    A photo sent without an @mention is stored as an observed multimodal
+    message (text part + image_url part). It is replayed as a *text* prefix,
+    so the image_url part must become a placeholder, never a stringified dict.
+    """
+    from gateway.run import (
+        _build_gateway_agent_history,
+        _wrap_current_message_with_observed_context,
+    )
+
+    history = [
+        {
+            "role": "user",
+            "observed": True,
+            "content": [
+                {"type": "text", "text": "[Alice|111]\nhere's the desk sheet"},
+                {"type": "image_url", "image_url": {"url": "data:image/png;base64,abc"}},
+            ],
+        },
+    ]
+
+    agent_history, observed_context = _build_gateway_agent_history(
+        history,
+        channel_prompt="observed Telegram group context",
+    )
+    api_message = _wrap_current_message_with_observed_context("[Bob|222]\ncambio", observed_context)
+
+    assert agent_history == []
+    # The text part survives; the image becomes a placeholder.
+    assert "here's the desk sheet" in api_message
+    assert "[image attachment]" in api_message
+    # The bug: the raw image_url dict must never leak into the prefix as a repr.
+    assert "image_url" not in api_message
+    assert "data:image/png" not in api_message
+    assert "{'type'" not in api_message
+
+
 def test_observed_group_context_replays_normally_without_telegram_prompt():
     from gateway.run import _build_gateway_agent_history
 


### PR DESCRIPTION
## What does this PR do?

Fixes a bug where a photo sent into a Telegram **group** without an `@bot` mention is dropped: the model never receives it and asks for a re-send.

Observed group chatter is replayed as a **text-only** prefix on the addressed turn (`_wrap_current_message_with_observed_context`), but `_build_gateway_agent_history` accumulated observed content with `str(content)`. For a photo, `content` is a multimodal parts list (`[{"type":"text"...}, {"type":"image_url"...}]`), so `str()` produced a Python `repr` — corrupting the image and polluting the prefix with `{'type': 'image_url', ...}` noise. Text-only messages were unaffected because `str(str)` is a no-op, which is why this only surfaced for unmentioned group photos.

The fix flattens observed content to text deliberately (the prefix can only carry text anyway): keep text parts, replace `image_url`/other parts with a short `[image attachment]` placeholder.

## Related Issue

Fixes #47415

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/run.py`: add `_flatten_observed_content(content)` and call it from `_build_gateway_agent_history` instead of `str(content)` in the observed-context branch.
- `tests/gateway/test_telegram_group_gating.py`: add `test_observed_group_context_flattens_multimodal_message_to_text` — asserts the text part survives, the image becomes `[image attachment]`, and no raw `image_url`/`data:` dict repr leaks into the prefix.

## How to Test

1. In a Telegram group with `observe_unmentioned_group_messages` enabled, send a photo **without** mentioning the bot.
2. Then prompt the bot — before this fix the image is unusable and the bot asks for a re-send; after, the caption + an `[image attachment]` placeholder appear in the observed context (and a re-send with `@bot` continues to work via the native path).
3. Unit: `pytest tests/gateway/test_telegram_group_gating.py -q`

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(gateway): ...`)
- [x] I searched for existing PRs/issues to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [ ] I've run `pytest tests/ -q` and all tests pass — see note below
- [x] I've added tests for my changes
- [x] I've tested on my platform: Debian 13 / Python 3.13.5

> Test note: `tests/gateway/test_telegram_group_gating.py` passes in full (46/46). The broader `tests/gateway` run was clean except pre-existing collection/failures in unrelated suites that need optional deps unavailable in my sandbox (`aiohttp` test utils for `test_api_server*`/`test_webhook*`; `test_whatsapp_cloud.py`, `test_ws_auth_retry.py`). None touch the changed code path.

### Documentation & Housekeeping

- [x] I've updated relevant documentation (docstrings) — the new helper is documented; no user-facing docs affected
- [x] N/A — no config keys changed
- [x] N/A — no architecture/workflow change
- [x] I've considered cross-platform impact — pure-Python string handling, no platform specifics
- [x] N/A — no tool behavior changed
