### PR TITLE
fix(tui): force true color depth and harden skin loading

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -10820,7 +10820,9 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
         style_dict = dict(getattr(self, "_tui_style_base", {}) or {})
         try:
             from hermes_cli.skin_engine import get_prompt_toolkit_style_overrides
-            style_dict.update(get_prompt_toolkit_style_overrides())
+            overrides = get_prompt_toolkit_style_overrides()
+            if overrides:
+                style_dict.update(overrides)
         except Exception:
             pass
         # Light-mode remap on the style strings.  Each value is a pt
@@ -12801,14 +12803,16 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
             'voice-status-recording': 'bg:#1a1a2e #FF4444 bold',
         }
         style = PTStyle.from_dict(self._build_tui_style_dict())
-        
+
         # Create the application
+        from prompt_toolkit.output.color_depth import ColorDepth
         app = Application(
             layout=layout,
             key_bindings=kb,
             style=style,
             full_screen=False,
             mouse_support=False,
+            color_depth=ColorDepth.TRUE_COLOR,
             # The status bar contains wall-clock read-outs (live prompt elapsed
             # and idle-since-last-turn). Once a turn finishes there may be no
             # further events to invalidate the app, so prompt_toolkit would keep

--- a/hermes_cli/skin_engine.py
+++ b/hermes_cli/skin_engine.py
@@ -774,11 +774,18 @@ def get_active_skin() -> SkinConfig:
     return _active_skin
 
 
-def set_active_skin(name: str) -> SkinConfig:
-    """Switch the active skin. Returns the new SkinConfig."""
+def set_active_skin(name) -> SkinConfig:
+    """Switch the active skin. Returns the new SkinConfig.
+
+    Accepts either a skin name (str) or an already-loaded SkinConfig.
+    """
     global _active_skin, _active_skin_name
-    _active_skin_name = name
-    _active_skin = load_skin(name)
+    if isinstance(name, SkinConfig):
+        _active_skin = name
+        _active_skin_name = name.name
+    else:
+        _active_skin_name = str(name)
+        _active_skin = load_skin(str(name))
     return _active_skin
 
 
@@ -852,7 +859,15 @@ def get_prompt_toolkit_style_overrides() -> Dict[str, str]:
     try:
         skin = get_active_skin()
     except Exception:
-        return {}
+        # If the active skin is broken, try to reload from config
+        try:
+            from hermes_cli.config import load_config
+            cfg = load_config()
+            display = cfg.get("display") or {}
+            skin_name = display.get("skin", "default") if isinstance(display, dict) else "default"
+            skin = set_active_skin(skin_name)
+        except Exception:
+            return {}
 
     # Input/prompt: leave unset by default so the typed text inherits
     # the terminal's foreground color (readable in both light and dark


### PR DESCRIPTION
## Problem

When a terminal emulator has a color scheme with an ANSI palette (e.g. Catppuccin Frappé in WezTerm), prompt_toolkit may fall back to ANSI indexed colors instead of using the explicit `bg:#XXXXXX` RGB values defined in skin overrides. This causes TUI chrome colors (status bar, completion menu, voice status) to be replaced by the terminal's ANSI palette colors, making skins appear different depending on the active terminal theme.

**Reproduction:** Set `color_scheme = 'Catppuccin Frappe'` in WezTerm config. The Hermes status bar background renders as peach `#ef9f76` (an ANSI index from the Frappé palette) instead of the skin-defined color. Switching to a terminal theme without an ANSI palette makes the skin render correctly.

## Root Cause

prompt_toolkit auto-detects color depth but can incorrectly choose `ANSI_COLORS_ONLY` or `DEPTH_8_BIT` even when `$COLORTERM=truecolor`. When this happens, all `bg:#XXXXXX` style strings are mapped to the nearest ANSI palette color.

## Fix

1. **Force true color** — Pass `color_depth=ColorDepth.TRUE_COLOR` to the prompt_toolkit `Application()` constructor. This forces 24-bit RGB output regardless of terminal detection heuristics, making skin colors invariant across different terminal themes.

2. **Harden `set_active_skin()`** — Accept `SkinConfig` objects alongside string names. Some internal code paths pass already-loaded configs, which previously caused `OSError: File name too long`.

3. **Retry skin reload on failure** — In `get_prompt_toolkit_style_overrides()`, attempt to reload the skin from config when `get_active_skin()` fails, instead of silently returning an empty dict.

4. **Guard against empty overrides** — Check that overrides dict is non-empty before calling `style_dict.update()`.

## Testing

Verified with WezTerm + Catppuccin Frappé where `color_scheme` defines a full ANSI palette. Before: status bar rendered as `#ef9f76`. After: skin colors render correctly regardless of terminal color scheme. Also verified that builtin skins (slate, charizard) continue to work as expected.