### PR TITLE
fix(codex): persist OAuth usage-limit cooldowns

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -649,6 +649,27 @@ class _CodexCompletionsAdapter:
         messages = kwargs.get("messages", [])
         model = kwargs.get("model", self._model)
 
+        try:
+            from agent.codex_rate_guard import (
+                codex_rate_limit_remaining,
+                format_remaining as _format_codex_remaining,
+            )
+
+            _remaining = codex_rate_limit_remaining(model=model)
+            if _remaining is not None and _remaining > 0:
+                err = RuntimeError(
+                    "Codex OAuth usage limit active — "
+                    f"resets in {_format_codex_remaining(_remaining)}"
+                )
+                setattr(err, "status_code", 429)
+                raise err
+        except RuntimeError:
+            raise
+        except Exception:
+            # Guard is best-effort only; never let its own state parsing break
+            # auxiliary work.
+            pass
+
         # Separate system/instructions from replayable conversation messages,
         # then route the rest through the SINGLE shared chat->Responses
         # converter used by the main agent transport
@@ -898,6 +919,12 @@ class _CodexCompletionsAdapter:
         except Exception as exc:
             if timed_out.is_set():
                 raise TimeoutError(_timeout_message()) from exc
+            try:
+                from agent.codex_rate_guard import record_codex_rate_limit_from_exception
+
+                record_codex_rate_limit_from_exception(exc, model=model)
+            except Exception:
+                pass
             logger.debug("Codex auxiliary Responses API call failed: %s", exc)
             raise
         finally:

--- a/agent/codex_rate_guard.py
+++ b/agent/codex_rate_guard.py
@@ -1,0 +1,302 @@
+"""Cross-session usage-limit guard for OpenAI Codex OAuth.
+
+Codex OAuth usage limits are account/plan windows, not per-process failures.
+When one Hermes session hits ``usage_limit_reached`` and other sessions keep
+retrying, every retry wastes allowance and can look like abusive traffic.  This
+guard records the reset time in ``$HERMES_HOME/rate_limits/codex.json`` so CLI,
+gateway, cron, and auxiliary calls can skip doomed requests until the window
+resets.
+
+This is deliberately *not* an evasion layer: it does not rotate IPs, accounts,
+or tokens.  It only honors reset/backoff signals and prevents retry storms for
+the single Codex OAuth account the user chose to use.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import tempfile
+import time
+from typing import Any, Mapping, Optional
+
+from utils import atomic_replace
+
+logger = logging.getLogger(__name__)
+
+_STATE_SUBDIR = "rate_limits"
+_STATE_FILENAME = "codex.json"
+_LANE_STATE_FILENAMES = {
+    "all": _STATE_FILENAME,
+    "standard": "codex-standard.json",
+    "spark": "codex-spark.json",
+}
+
+# Short Retry-After windows are usually transient transport/provider jitter.
+# Only trip the cross-session breaker for meaningful windows or explicit
+# Codex usage-limit payloads.
+_MIN_RESET_FOR_BREAKER_SECONDS = 60.0
+
+
+def _lane_for_model(model: Optional[str] = None) -> str:
+    """Return the Codex OAuth usage lane for *model*."""
+    if not model:
+        return "all"
+    return "spark" if "spark" in str(model).lower() else "standard"
+
+
+def _state_path(lane: str = "all") -> str:
+    """Return the path to the Codex rate-limit state file."""
+    try:
+        from hermes_constants import get_hermes_home
+
+        base = get_hermes_home()
+    except ImportError:
+        base = os.path.join(os.path.expanduser("~"), ".hermes")
+    filename = _LANE_STATE_FILENAMES.get(lane, _STATE_FILENAME)
+    return os.path.join(base, _STATE_SUBDIR, filename)
+
+
+def _coerce_float(value: Any) -> Optional[float]:
+    if value in {None, ""}:
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _parse_reset_at(value: Any, *, now: float) -> Optional[float]:
+    """Parse a reset timestamp or seconds-from-now value."""
+    parsed = _coerce_float(value)
+    if parsed is None:
+        return None
+    if parsed > now:
+        return parsed
+    if parsed > 0:
+        return now + parsed
+    return None
+
+
+def _headers_reset_at(headers: Optional[Mapping[str, str]], *, now: float) -> Optional[float]:
+    if not headers:
+        return None
+    lowered = {str(k).lower(): v for k, v in headers.items()}
+
+    # Prefer longer account windows when available.
+    for key in (
+        "x-ratelimit-reset-requests-1h",
+        "x-ratelimit-reset-tokens-1h",
+        "x-ratelimit-reset-requests",
+        "x-ratelimit-reset-tokens",
+        "retry-after",
+    ):
+        reset_at = _parse_reset_at(lowered.get(key), now=now)
+        if reset_at is not None:
+            return reset_at
+    return None
+
+
+def _context_reset_at(error_context: Optional[dict[str, Any]], *, now: float) -> Optional[float]:
+    if not isinstance(error_context, dict):
+        return None
+    for key in ("reset_at", "resets_at", "resets_in_seconds", "retry_after"):
+        reset_at = _parse_reset_at(error_context.get(key), now=now)
+        if reset_at is not None:
+            return reset_at
+    return None
+
+
+def is_codex_usage_limit_context(error_context: Optional[dict[str, Any]] = None) -> bool:
+    """Return True for Codex account/plan usage-limit payloads."""
+    if not isinstance(error_context, dict):
+        return False
+    reason = str(error_context.get("reason") or "").lower()
+    message = str(error_context.get("message") or "").lower()
+    combined = f"{reason} {message}"
+    return any(
+        needle in combined
+        for needle in (
+            "usage_limit_reached",
+            "usage limit reached",
+            "usage limit has been reached",
+            "agentic usage limit",
+        )
+    )
+
+
+def should_record_codex_rate_limit(
+    *,
+    headers: Optional[Mapping[str, str]] = None,
+    error_context: Optional[dict[str, Any]] = None,
+    now: Optional[float] = None,
+) -> bool:
+    """Decide whether a 429 should trip the cross-session breaker."""
+    now = time.time() if now is None else now
+    if is_codex_usage_limit_context(error_context):
+        return True
+    reset_at = _headers_reset_at(headers, now=now) or _context_reset_at(error_context, now=now)
+    return bool(reset_at and (reset_at - now) >= _MIN_RESET_FOR_BREAKER_SECONDS)
+
+
+def record_codex_rate_limit(
+    *,
+    headers: Optional[Mapping[str, str]] = None,
+    error_context: Optional[dict[str, Any]] = None,
+    model: Optional[str] = None,
+    default_cooldown: float = 4 * 3600.0,
+) -> Optional[float]:
+    """Record Codex OAuth as temporarily unavailable.
+
+    Returns the seconds remaining if a breaker was written, otherwise ``None``.
+    The guard records explicit Codex usage-limit errors even when no reset time
+    is present, using ``default_cooldown`` as a conservative fallback.
+    """
+    now = time.time()
+    if not should_record_codex_rate_limit(
+        headers=headers,
+        error_context=error_context,
+        now=now,
+    ):
+        return None
+
+    reset_at = (
+        _context_reset_at(error_context, now=now)
+        or _headers_reset_at(headers, now=now)
+        or (now + default_cooldown)
+    )
+    remaining = max(0.0, reset_at - now)
+
+    lane = _lane_for_model(model)
+    path = _state_path(lane)
+    try:
+        state_dir = os.path.dirname(path)
+        os.makedirs(state_dir, exist_ok=True)
+        state = {
+            "lane": lane,
+            "model": model,
+            "reset_at": reset_at,
+            "recorded_at": now,
+            "reset_seconds": remaining,
+            "reason": (error_context or {}).get("reason"),
+            "message": (error_context or {}).get("message"),
+        }
+        fd, tmp_path = tempfile.mkstemp(dir=state_dir, suffix=".tmp")
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as f:
+                json.dump(state, f)
+            atomic_replace(tmp_path, path)
+        except Exception:
+            try:
+                os.unlink(tmp_path)
+            except OSError:
+                pass
+            raise
+        logger.info(
+            "Codex OAuth usage guard recorded for %s lane: resets in %.0fs",
+            lane,
+            remaining,
+        )
+        return remaining
+    except Exception as exc:
+        logger.debug("Failed to write Codex rate-limit state: %s", exc)
+        return remaining
+
+
+def extract_error_context_from_exception(exc: BaseException) -> dict[str, Any]:
+    """Extract Codex usage-limit context from an SDK/API exception."""
+    context: dict[str, Any] = {}
+    body = getattr(exc, "body", None)
+    payload = None
+    if isinstance(body, dict):
+        payload = body.get("error") if isinstance(body.get("error"), dict) else body
+    if isinstance(payload, dict):
+        reason = payload.get("code") or payload.get("type") or payload.get("error")
+        if isinstance(reason, str) and reason.strip():
+            context["reason"] = reason.strip()
+        message = payload.get("message") or payload.get("error_description")
+        if isinstance(message, str) and message.strip():
+            context["message"] = message.strip()
+        for key in ("reset_at", "resets_at", "resets_in_seconds", "retry_after"):
+            if payload.get(key) not in {None, ""}:
+                context[key] = payload.get(key)
+    if "message" not in context:
+        raw = str(exc).strip()
+        if raw:
+            context["message"] = raw[:500]
+    return context
+
+
+def record_codex_rate_limit_from_exception(
+    exc: BaseException,
+    *,
+    model: Optional[str] = None,
+    default_cooldown: float = 4 * 3600.0,
+) -> Optional[float]:
+    """Extract headers/body from an exception and record a Codex breaker."""
+    response = getattr(exc, "response", None)
+    headers = getattr(response, "headers", None) if response is not None else None
+    return record_codex_rate_limit(
+        headers=headers,
+        error_context=extract_error_context_from_exception(exc),
+        model=model,
+        default_cooldown=default_cooldown,
+    )
+
+
+def _remaining_from_path(path: str) -> Optional[float]:
+    try:
+        with open(path, encoding="utf-8") as f:
+            state = json.load(f)
+        reset_at = float(state.get("reset_at", 0))
+        remaining = reset_at - time.time()
+        if remaining > 0:
+            return remaining
+        try:
+            os.unlink(path)
+        except OSError:
+            pass
+        return None
+    except (FileNotFoundError, json.JSONDecodeError, KeyError, TypeError, ValueError):
+        return None
+
+
+def codex_rate_limit_remaining(*, model: Optional[str] = None) -> Optional[float]:
+    """Return seconds until Codex OAuth reset, or ``None`` when available."""
+    # A global/unknown breaker applies to every Codex lane.
+    remaining = _remaining_from_path(_state_path("all"))
+    if remaining is not None:
+        return remaining
+    lane = _lane_for_model(model)
+    if lane == "all":
+        return None
+    return _remaining_from_path(_state_path(lane))
+
+
+def clear_codex_rate_limit(*, model: Optional[str] = None) -> None:
+    """Clear Codex guard state after a successful Codex request."""
+    lane = _lane_for_model(model)
+    paths = [_state_path("all")]
+    if lane != "all":
+        paths.append(_state_path(lane))
+    for path in paths:
+        try:
+            os.unlink(path)
+        except FileNotFoundError:
+            pass
+        except OSError as exc:
+            logger.debug("Failed to clear Codex rate-limit state %s: %s", path, exc)
+
+
+def format_remaining(seconds: float) -> str:
+    """Format seconds remaining into human-readable duration."""
+    s = max(0, int(seconds))
+    if s < 60:
+        return f"{s}s"
+    if s < 3600:
+        m, sec = divmod(s, 60)
+        return f"{m}m {sec}s" if sec else f"{m}m"
+    h, remainder = divmod(s, 3600)
+    m = remainder // 60
+    return f"{h}h {m}m" if m else f"{h}h"

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -914,6 +914,51 @@ def run_conversation(
         agent._current_api_request_id = api_request_id
 
         while retry_count < max_retries:
+            # ── OpenAI Codex OAuth usage-limit guard ───────────────────
+            # Codex OAuth plan limits are account/window based. If another
+            # Hermes session already recorded ``usage_limit_reached``, skip the
+            # API call instead of amplifying retries across CLI, gateway, cron,
+            # and auxiliary tasks.
+            if agent.provider == "openai-codex":
+                try:
+                    from agent.codex_rate_guard import (
+                        codex_rate_limit_remaining,
+                        format_remaining as _fmt_codex_remaining,
+                    )
+
+                    _codex_remaining = codex_rate_limit_remaining(model=agent.model)
+                    if _codex_remaining is not None and _codex_remaining > 0:
+                        _codex_msg = (
+                            "Codex OAuth usage limit active — "
+                            f"resets in {_fmt_codex_remaining(_codex_remaining)}."
+                        )
+                        agent._buffer_vprint(f"⏳ {_codex_msg} Trying fallback...")
+                        agent._buffer_status(f"⏳ {_codex_msg}")
+                        if agent._try_activate_fallback():
+                            retry_count = 0
+                            compression_attempts = 0
+                            _retry.primary_recovery_attempted = False
+                            continue
+                        agent._flush_status_buffer()
+                        agent._persist_session(messages, conversation_history)
+                        return {
+                            "final_response": (
+                                f"⏳ {_codex_msg}\n\n"
+                                "No voy a reintentar automáticamente porque "
+                                "cada intento fallido también puede consumir "
+                                "límite. Probá de nuevo después del reset."
+                            ),
+                            "messages": messages,
+                            "api_calls": api_call_count,
+                            "completed": False,
+                            "failed": True,
+                            "error": _codex_msg,
+                        }
+                except ImportError:
+                    pass
+                except Exception:
+                    pass  # Never let rate guard break the agent loop
+
             # ── Nous Portal rate limit guard ──────────────────────
             # If another session already recorded that Nous is rate-
             # limited, skip the API call entirely.  Each attempt
@@ -1922,6 +1967,13 @@ def run_conversation(
                         clear_nous_rate_limit()
                     except Exception:
                         pass
+                if agent.provider == "openai-codex":
+                    try:
+                        from agent.codex_rate_guard import clear_codex_rate_limit
+
+                        clear_codex_rate_limit(model=agent.model)
+                    except Exception:
+                        pass
                 agent._touch_activity(f"API call #{api_call_count} completed")
                 break  # Success, exit retry loop
 
@@ -2851,6 +2903,25 @@ def run_conversation(
                     # Upstream capacity 429: fall through to normal
                     # retry logic.  A different model (or the same
                     # model a moment later) will typically succeed.
+
+                if (
+                    is_rate_limited
+                    and agent.provider == "openai-codex"
+                    and classified.reason == FailoverReason.rate_limit
+                    and not recovered_with_pool
+                ):
+                    try:
+                        from agent.codex_rate_guard import record_codex_rate_limit
+
+                        _err_resp = getattr(api_error, "response", None)
+                        _err_hdrs = getattr(_err_resp, "headers", None) if _err_resp else None
+                        record_codex_rate_limit(
+                            headers=_err_hdrs,
+                            error_context=error_context,
+                            model=agent.model,
+                        )
+                    except Exception:
+                        pass
 
                 is_payload_too_large = (
                     classified.reason == FailoverReason.payload_too_large

--- a/tests/agent/test_codex_rate_guard.py
+++ b/tests/agent/test_codex_rate_guard.py
@@ -1,0 +1,138 @@
+"""Tests for agent/codex_rate_guard.py — Codex OAuth retry-storm breaker."""
+
+import json
+import os
+import time
+from types import SimpleNamespace
+
+import pytest
+
+
+@pytest.fixture
+def codex_guard_env(tmp_path, monkeypatch):
+    hermes_home = str(tmp_path / ".hermes")
+    os.makedirs(hermes_home, exist_ok=True)
+    monkeypatch.setenv("HERMES_HOME", hermes_home)
+    return hermes_home
+
+
+def test_records_explicit_usage_limit_with_resets_in_seconds(codex_guard_env):
+    from agent.codex_rate_guard import (
+        _state_path,
+        codex_rate_limit_remaining,
+        record_codex_rate_limit,
+    )
+
+    remaining = record_codex_rate_limit(
+        error_context={
+            "reason": "usage_limit_reached",
+            "message": "The usage limit has been reached",
+            "resets_in_seconds": 900,
+        }
+    )
+
+    assert remaining == pytest.approx(900, abs=2)
+    assert codex_rate_limit_remaining() == pytest.approx(900, abs=2)
+    with open(_state_path(), encoding="utf-8") as f:
+        state = json.load(f)
+    assert state["reason"] == "usage_limit_reached"
+
+
+def test_records_explicit_usage_limit_with_default_cooldown(codex_guard_env):
+    from agent.codex_rate_guard import codex_rate_limit_remaining, record_codex_rate_limit
+
+    remaining = record_codex_rate_limit(
+        error_context={
+            "reason": "usage_limit_reached",
+            "message": "The usage limit has been reached",
+        },
+        default_cooldown=120,
+    )
+
+    assert remaining == pytest.approx(120, abs=2)
+    assert codex_rate_limit_remaining() == pytest.approx(120, abs=2)
+
+
+def test_ignores_short_transient_retry_after(codex_guard_env):
+    from agent.codex_rate_guard import codex_rate_limit_remaining, record_codex_rate_limit
+
+    remaining = record_codex_rate_limit(headers={"Retry-After": "2.5"})
+
+    assert remaining is None
+    assert codex_rate_limit_remaining() is None
+
+
+def test_records_long_retry_after(codex_guard_env):
+    from agent.codex_rate_guard import codex_rate_limit_remaining, record_codex_rate_limit
+
+    remaining = record_codex_rate_limit(headers={"Retry-After": "180"})
+
+    assert remaining == pytest.approx(180, abs=2)
+    assert codex_rate_limit_remaining() == pytest.approx(180, abs=2)
+
+
+def test_expired_state_is_cleared(codex_guard_env):
+    from agent.codex_rate_guard import _state_path, codex_rate_limit_remaining
+
+    path = _state_path()
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    with open(path, "w", encoding="utf-8") as f:
+        json.dump({"reset_at": time.time() - 1}, f)
+
+    assert codex_rate_limit_remaining() is None
+    assert not os.path.exists(path)
+
+
+def test_extracts_context_from_sdk_exception_body(codex_guard_env):
+    from agent.codex_rate_guard import (
+        codex_rate_limit_remaining,
+        record_codex_rate_limit_from_exception,
+    )
+
+    class FakeSDKError(Exception):
+        body = {
+            "error": {
+                "type": "usage_limit_reached",
+                "message": "The usage limit has been reached",
+                "resets_in_seconds": 300,
+            }
+        }
+        response = SimpleNamespace(headers={})
+
+    remaining = record_codex_rate_limit_from_exception(FakeSDKError("rate limit"))
+
+    assert remaining == pytest.approx(300, abs=2)
+    assert codex_rate_limit_remaining() == pytest.approx(300, abs=2)
+
+
+def test_spark_and_standard_usage_limits_are_isolated(codex_guard_env):
+    from agent.codex_rate_guard import codex_rate_limit_remaining, record_codex_rate_limit
+
+    remaining = record_codex_rate_limit(
+        error_context={
+            "reason": "usage_limit_reached",
+            "message": "Spark usage limit reached",
+            "resets_in_seconds": 600,
+        },
+        model="gpt-5.3-codex-spark",
+    )
+
+    assert remaining == pytest.approx(600, abs=2)
+    assert codex_rate_limit_remaining(model="gpt-5.3-codex-spark") == pytest.approx(600, abs=2)
+    assert codex_rate_limit_remaining(model="gpt-5.5") is None
+
+
+def test_global_usage_limit_blocks_every_lane(codex_guard_env):
+    from agent.codex_rate_guard import codex_rate_limit_remaining, record_codex_rate_limit
+
+    remaining = record_codex_rate_limit(
+        error_context={
+            "reason": "usage_limit_reached",
+            "message": "Generic Codex usage limit reached",
+            "resets_in_seconds": 480,
+        }
+    )
+
+    assert remaining == pytest.approx(480, abs=2)
+    assert codex_rate_limit_remaining(model="gpt-5.3-codex-spark") == pytest.approx(480, abs=2)
+    assert codex_rate_limit_remaining(model="gpt-5.5") == pytest.approx(480, abs=2)


### PR DESCRIPTION
## Summary

This PR adds a small, best-effort cross-session usage-limit guard for the `openai-codex` OAuth provider.

When Codex OAuth returns an account/plan usage-limit response (for example `usage_limit_reached` with `resets_in_seconds`), Hermes currently treats that failure inside the active process/turn. Other concurrently running Hermes entry points — CLI sessions, gateway conversations, cron jobs, and auxiliary/compression calls — can still keep making doomed Codex requests until each one independently hits the same limit.

This change records the reset window under `HERMES_HOME/rate_limits/` and checks it before later Codex calls. That lets Hermes skip known-doomed requests until the provider window resets instead of amplifying retries across local processes.

## Why this is useful

- Codex OAuth usage limits are account-window limits, not just per-request or per-process failures.
- Hermes commonly runs multiple local entry points at the same time: gateway, CLI, cron, auxiliary clients, compression, etc.
- Persisting the reset window prevents repeated calls that cannot succeed until the same account window resets.
- The guard gives a clearer user-facing message (`Codex OAuth usage limit active — resets in ...`) and allows existing fallback handling to run where available.

## Scope / compatibility

- Scoped only to `provider == "openai-codex"`.
- Best-effort only: if the guard state cannot be read/written, existing behavior continues.
- Does not rotate accounts, tokens, IPs, or models.
- Does not add user-facing configuration or new required environment variables.
- Does not affect non-Codex providers.
- Successful Codex calls clear the persisted cooldown, so stale state does not keep blocking after the provider accepts requests again.
- Spark and standard Codex model lanes are isolated when the model name indicates Spark, while an unknown/global usage-limit state can still protect all Codex lanes.

## Implementation notes

- Adds `agent/codex_rate_guard.py` to parse reset signals from response headers or SDK error payloads.
- Checks the persisted guard before main-agent Codex calls and auxiliary Codex Responses calls.
- Records account-window usage limits from main-agent 429 classification and auxiliary exceptions.
- Stores state as small JSON files below `HERMES_HOME/rate_limits/` using existing atomic replacement utilities.

## Verification

Ran locally:

```bash
venv/bin/python -m pytest tests/agent/test_codex_rate_guard.py tests/hermes_cli/test_auth_codex_self_heal.py tests/hermes_cli/test_auth_commands.py -q -o 'addopts='
# 68 passed

venv/bin/python -m py_compile agent/codex_rate_guard.py agent/auxiliary_client.py agent/conversation_loop.py

git diff --check origin/main...HEAD

hermes --version
```

Also verified the branch is one commit ahead of `origin/main` with no merge-tree conflicts.
