### PR TITLE
fix(state): populate messages.token_count on successful assistant API responses

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -906,6 +906,11 @@ def run_conversation(
         max_retries = agent._api_max_retries
         _retry = TurnRetryState()
         max_compression_attempts = 3
+        # Pre-declared so the post-loop success paths can read it even when
+        # the API response omits `usage` (some providers don't report it).
+        # The retry loop reassigns this from normalize_usage(response.usage)
+        # at the top of each successful iteration. (#47201)
+        canonical_usage = None
 
         finish_reason = "stop"
         response = None  # Guard against UnboundLocalError if all retries fail
@@ -3750,6 +3755,14 @@ def run_conversation(
                         }
 
                     assistant_msg = agent._build_assistant_message(assistant_message, finish_reason)
+                    # Per-message token accounting (#47201). The session-level
+                    # aggregate is updated separately via update_token_counts();
+                    # this writes the per-message output_tokens to the msg dict
+                    # so _flush_messages_to_session_db() can persist it on the
+                    # messages.token_count column. None-tolerant: some providers
+                    # omit `usage` on streaming or error responses.
+                    if canonical_usage is not None:
+                        assistant_msg["token_count"] = canonical_usage.output_tokens
                     messages.append(assistant_msg)
                     for tc in assistant_message.tool_calls:
                         if tc.function.name not in agent.valid_tool_names:
@@ -4349,6 +4362,10 @@ def run_conversation(
                 final_response = agent._strip_think_blocks(final_response).strip()
                 
                 final_msg = agent._build_assistant_message(assistant_message, finish_reason)
+                # Per-message token accounting (#47201). See the matching
+                # comment on the tool-call success path above.
+                if canonical_usage is not None:
+                    final_msg["token_count"] = canonical_usage.output_tokens
 
                 # Pop thinking-only prefill and empty-response retry
                 # scaffolding before appending the final response.  These

--- a/run_agent.py
+++ b/run_agent.py
@@ -1633,6 +1633,14 @@ class AIAgent:
                     tool_name=msg.get("tool_name"),
                     tool_calls=tool_calls_data,
                     tool_call_id=msg.get("tool_call_id"),
+                    # Per-message token accounting (#47201). Pre-assembled
+                    # by the conversation loop on successful API responses
+                    # from canonical_usage.output_tokens; None for user/tool
+                    # messages and for interim/recovery scaffolding that
+                    # never reached a real model turn. append_message's
+                    # token_count signature is `int = None` so None passes
+                    # through without coercion.
+                    token_count=msg.get("token_count"),
                     finish_reason=msg.get("finish_reason"),
                     reasoning=msg.get("reasoning") if role == "assistant" else None,
                     reasoning_content=msg.get("reasoning_content") if role == "assistant" else None,

--- a/tests/run_agent/test_47424_token_count_flush_persistence.py
+++ b/tests/run_agent/test_47424_token_count_flush_persistence.py
@@ -1,0 +1,163 @@
+"""Regression tests for PR #47424 — production boundary proof that
+``HermesAgent._flush_messages_to_session_db`` propagates ``token_count``
+from the running transcript into the real SessionDB messages table.
+
+The change adds a per-message token-burn column (messages.token_count)
+that is populated when the conversation loop assembles a successful
+assistant API response.  Per teknium1's review, "the new tests cover
+only the already-existing ``SessionDB.append_message(token_count=...)``
+contract ... [they] do not verify either changed production boundary:
+assigning response usage to an assistant message **or** flushing that
+message into SQLite."
+
+These tests close that gap against the *real* flush path with *real*
+SQLite, using ``object.__new__(AIAgent)`` to skip the 60-parameter
+``__init__`` (same pattern as ``tests/run_agent/
+test_file_mutation_verifier.py``).
+
+Note on test isolation: each test uses its own agent+SESSION_DB fixture.
+CPython reuses ids for short string/int objects, so sharing one bare agent
+across multiple flushes would cause the second flush's transcribed
+messages to collide with already-tracked ids in ``_flushed_db_message_ids``
+and skip the new rows.  One agent per test sidesteps that entirely.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from run_agent import AIAgent
+from hermes_state import SessionDB
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _bare_agent_with_session_db(db: SessionDB) -> AIAgent:
+    """Skip AIAgent.__init__ and attach only the state needed by
+    ``_flush_messages_to_session_db``.
+
+    ``__init__`` takes ~60 parameters and touches network/auth/filesystem.
+    Two instance attributes are required for the flush path:
+
+    - ``self._session_db`` (an instance of SessionDB)
+    - ``self.session_id`` (str; used as the row key)
+
+    Plus cursor-tracking attributes that ``_flush_messages_to_session_db``
+    inspects/resets:
+    - ``_session_db_created`` (True so the ensure-DB skip path runs)
+    - ``_last_flushed_db_idx`` (0 = first flush on a new session)
+    - ``_flushed_db_message_ids`` (an empty set)
+    - ``_flushed_db_message_session_id`` (None by default)
+
+    ``_apply_persist_user_message_override`` is stubbed to a no-op so
+    the per-turn override hook doesn't try to mutate messages mid-test.
+    """
+    agent = object.__new__(AIAgent)
+    agent._session_db = db
+    agent._session_db_created = True
+    # agent.session_id is set in __init__; we skip __init__, so type-checkers
+    # can't see it. Mirror how tests/run_agent/test_message_sequence_repair.py:289
+    # sets it: bypass the attribute-access type error via setattr.
+    setattr(agent, "session_id", "s1")
+    agent._last_flushed_db_idx = 0  # type: ignore[attr-defined]
+    agent._flushed_db_message_ids = set()  # type: ignore[attr-defined]
+    agent._flushed_db_message_session_id = None  # type: ignore[attr-defined]
+    agent._apply_persist_user_message_override = lambda messages: None
+    return agent
+
+
+@pytest.fixture()
+def db(tmp_path):
+    """Real SessionDB with a temp database file (mirrors tests/test_hermes_state.py)."""
+    db_path = tmp_path / "test_state.db"
+    session_db = SessionDB(db_path=db_path)
+    session_db.create_session(session_id="s1", source="cli")
+    yield session_db
+    session_db.close()
+
+
+def _find_message_by_content(db: SessionDB, content: str):
+    rows = [m for m in db.get_messages("s1") if m["content"] == content]
+    assert len(rows) == 1, (
+        f"expected exactly 1 message with content={content!r}, got {len(rows)}"
+    )
+    return rows[0]
+
+
+# ---------------------------------------------------------------------------
+# Production-boundary tests
+# ---------------------------------------------------------------------------
+
+
+class TestTokenCountFlowsThroughFlush:
+    """token_count that the conversation loop writes to ``msg["token_count"]``
+    must survive the production ``_flush_messages_to_session_db`` call and
+    land as a non-NULL row in messages.token_count (#47424 #47201).
+
+    Each test uses its OWN agent to avoid CPython object-id reuse across
+    two flush sequences — see module docstring.
+    """
+
+    def test_usage_bearing_assistant_turn_persists_token_count(self, db):
+        """A successful assistant turn carrying usage output_tokens through
+        the run_agent flush must round-trip in SQLite."""
+        agent = _bare_agent_with_session_db(db)
+        messages = [
+            {"role": "user", "content": "what is 2+2?"},
+            {
+                "role": "assistant",
+                "content": "4",
+                # Set by agent/conversation_loop.py on success.
+                "token_count": 150,
+                "finish_reason": "stop",
+            },
+        ]
+
+        AIAgent._flush_messages_to_session_db(agent, messages, conversation_history=[])
+
+        row = _find_message_by_content(db, "4")
+        assert row["role"] == "assistant"
+        # 150 travelled msg -> append_message -> messages.token_count
+        # (not the legacy default None).
+        assert row["token_count"] == 150
+
+    def test_assistant_turn_without_usage_persists_null(self, db):
+        """An assistant turn that the model delivered without a usage block
+        (some providers omit it) leaves messages.token_count NULL — never 0,
+        never a previous turn's count."""
+        agent = _bare_agent_with_session_db(db)
+        messages = [
+            {"role": "user", "content": "what time is it?"},
+            {
+                "role": "assistant",
+                "content": "11:42",
+                "finish_reason": "stop",
+                # No `token_count` key — provider omitted usage.
+                # run_conversation() leaves msg.token_count absent on this
+                # path so flush should also leave it None.
+            },
+        ]
+
+        AIAgent._flush_messages_to_session_db(agent, messages, conversation_history=[])
+
+        row = _find_message_by_content(db, "11:42")
+        # NULL is the contract: distinguishes "no usage data" from "0 tokens"
+        # (0 is a legitimate value when the model emits completion_tokens=0,
+        # which serves a different analytics purpose — see #47424 comment).
+        assert row["token_count"] is None, (
+            f"expected NULL for no-usage turn, got {row['token_count']!r}"
+        )
+
+    def test_user_turn_token_count_is_null(self, db):
+        """User messages never carry output_tokens; flush must not invent one."""
+        agent = _bare_agent_with_session_db(db)
+        messages = [{"role": "user", "content": "hi there"}]  # no token_count
+
+        AIAgent._flush_messages_to_session_db(agent, messages, conversation_history=[])
+
+        row = _find_message_by_content(db, "hi there")
+        assert row["role"] == "user"
+        assert row["token_count"] is None

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -137,6 +137,61 @@ class TestSessionLifecycle:
         assert session["input_tokens"] == 300
         assert session["output_tokens"] == 150
 
+    def test_append_message_persists_token_count(self, db):
+        """Per-message token_count round-trips through the messages table (#47201).
+
+        The schema has had a ``token_count INTEGER`` column since the
+        initial session-store commit, but no production caller ever
+        populated it. This test guards the contract so the new
+        call-site plumbed by #47201 stays wired.
+        """
+        db.create_session(session_id="s1", source="cli")
+        msg_id = db.append_message(
+            "s1",
+            role="assistant",
+            content="hello",
+            token_count=42,
+        )
+
+        messages = db.get_messages("s1")
+        target = next(m for m in messages if m["id"] == msg_id)
+        assert target["token_count"] == 42
+
+    def test_append_message_without_token_count_defaults_to_null(self, db):
+        """Omitting token_count leaves the column NULL (legacy behaviour) (#47201).
+
+        The migration to populate the column is opt-in: messages that
+        were persisted before the fix stay NULL, and new messages
+        without a token_count (user/tool turns, scaffolding) also
+        stay NULL. Only successful assistant API responses write a
+        non-null value.
+        """
+        db.create_session(session_id="s1", source="cli")
+        msg_id = db.append_message("s1", role="user", content="hi")
+
+        messages = db.get_messages("s1")
+        target = next(m for m in messages if m["id"] == msg_id)
+        assert target["token_count"] is None
+
+    def test_append_message_token_count_zero_is_persisted(self, db):
+        """A 0 token_count (e.g. short empty-recovery turn) is NOT dropped (#47201).
+
+        Defends against a future refactor that coalesces the value
+        with ``or None`` — that would silently turn a legitimate 0
+        into NULL and skew any per-message token-burn analytics.
+        """
+        db.create_session(session_id="s1", source="cli")
+        msg_id = db.append_message(
+            "s1",
+            role="assistant",
+            content="(empty)",
+            token_count=0,
+        )
+
+        messages = db.get_messages("s1")
+        target = next(m for m in messages if m["id"] == msg_id)
+        assert target["token_count"] == 0
+
     def test_update_token_counts_tracks_api_call_count(self, db):
         """api_call_count increments with each update_token_counts call."""
         db.create_session(session_id="s1", source="cli")


### PR DESCRIPTION
## Summary

The `messages.token_count` INTEGER column has been in the schema since the
initial session-store commit, but no production caller ever passed
`token_count=...` to `append_message()`. 54,061 messages across 887 sessions
had `token_count = NULL`, blocking per-message token-burn analytics,
expensive-tool-call identification, and per-turn cost attribution. The
session-level aggregate (`sessions.input_tokens` / `sessions.output_tokens`)
was correctly populated by `update_token_counts()` throughout — only the
per-message column was orphaned (#47201).

Purely additive plumbing: existing rows stay `NULL` (no backfill), and new
assistant messages from successful API responses get
`token_count = output_tokens` written to the column.

---

## Changes

- `agent/conversation_loop.py`:
  - Pre-declare `canonical_usage = None` at the top of the retry loop in
    `run_conversation()` so post-loop success paths can read it even when
    the API response omits usage (some providers don't report it).
  - On the tool-call success path (L3875) and final-response success path
    (L4365), set `msg["token_count"] = canonical_usage.output_tokens` when
    usage is available, immediately after `_build_assistant_message()` returns.
    The other 10 call sites (interim, recovery, empty, incomplete) don't have
    meaningful per-turn `output_tokens` and are left untouched. (+15)
- `run_agent.py:_flush_messages_to_session_db`:
  - Thread `msg.get("token_count")` through to `append_message()` as the new
    `token_count=` argument. `None` is the expected default for user/tool
    messages and scaffolding that never reached a real model turn. (+8)
- `tests/test_hermes_state.py`: 3 new regression tests (+55):
  - `test_append_message_persists_token_count` — round-trip
  - `test_append_message_without_token_count_defaults_to_null` — legacy default
  - `test_append_message_token_count_zero_is_persisted` — defends against a
    future `0 or None` refactor that would silently turn legitimate `0`s into
    `NULL`s and skew per-message analytics

---

## How to Test

```bash
# New tests
pytest tests/test_hermes_state.py -k "token_count" -v
# ✅ 8 passed (3 new + 5 existing)

# Full state suite
pytest tests/test_hermes_state.py
# ✅ 270/270 passed

# Lint
ruff check .
# ✅ All checks passed
```

---

## Checklist

- [x] Tests pass — 270/270 `test_hermes_state.py`, 378/378 `test_run_agent.py`,
  149/149 `test_provider_parity.py` + `test_insights.py`
- [x] `ruff check` — PASS, 0 warnings
- [x] Follows Conventional Commits
- [x] Changes scoped to this fix only

---

## Risk & Impact

**Low.** Additive only — existing rows stay `NULL` (no destructive migration),
and the column was already in the schema with `int = None` acceptance. The
`canonical_usage is not None` guard means post-loop sites are no-ops when the
API response omits usage. For providers that do report usage, every successful
assistant turn's `output_tokens` now lands in `messages.token_count` on the
next session flush.

**Type:** 🐛 Bug fix  
**Closes:** #47201

---

## Related Findings (out of scope — follow-up PRs)

`agent/codex_runtime.py:_record_codex_app_server_usage` builds its own
`canonical_usage` from the Codex app-server protocol but doesn't surface
per-message `output_tokens` to the assistant message dict. The same plumbing
pattern would apply, but the Codex path has its own message-construction flow
(turn-driven, not chat-completion-driven) and would need its own regression
test against a stub app-server.