### PR TITLE
model-catalog: add MiniMax M2.7

### DIFF
--- a/website/static/api/model-catalog.json
+++ b/website/static/api/model-catalog.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "updated_at": "2026-06-13T08:41:46Z",
+  "updated_at": "2026-06-16T19:42:54Z",
   "metadata": {
     "source": "hermes-agent repo",
     "docs": "https://hermes-agent.nousresearch.com/docs/reference/model-catalog"
@@ -82,6 +82,10 @@
         },
         {
           "id": "moonshotai/kimi-k2.7-code",
+          "description": ""
+        },
+        {
+          "id": "minimax/minimax-m2.7",
           "description": ""
         },
         {
@@ -198,6 +202,9 @@
         },
         {
           "id": "moonshotai/kimi-k2.7-code"
+        },
+        {
+          "id": "minimax/minimax-m2.7"
         },
         {
           "id": "minimax/minimax-m3"


### PR DESCRIPTION
Adds `minimax/minimax-m2.7` to the curated model catalog for both OpenRouter and Nous providers.

M2.7 is already live on OpenRouter and working. Costs: $0.25/M input, $1.00/M output, $0.05/M cache read. 204,800 context window.

This is the same model family as the existing M3 entry — just filling the gap for users who want the more cost-effective M2.7 option.