### PR TITLE
fix(gemini): omit synthetic maxOutputTokens for Gemma auxiliary calls

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -3377,8 +3377,6 @@ def _to_async_client(sync_client, model: str, is_vision: bool = False):
     header so the request is routed to Copilot's vision-capable
     infrastructure (otherwise vision payloads silently time out).
     """
-    from openai import AsyncOpenAI
-
     if isinstance(sync_client, CodexAuxiliaryClient):
         return AsyncCodexAuxiliaryClient(sync_client), model
     if isinstance(sync_client, AnthropicAuxiliaryClient):
@@ -3396,6 +3394,8 @@ def _to_async_client(sync_client, model: str, is_vision: bool = False):
             return sync_client, model
     except ImportError:
         pass
+
+    from openai import AsyncOpenAI
 
     async_kwargs = {
         "api_key": sync_client.api_key,
@@ -4848,6 +4848,12 @@ def _resolve_task_provider_model(
         cfg_provider, cfg_base_url = _expand_direct_api_alias(cfg_provider, cfg_base_url)
 
     if base_url:
+        # Keep an explicit non-auto provider paired with its explicit base_url.
+        # This matches the config-path behavior below and lets provider-specific
+        # transports (for example native Gemini) still activate when the caller
+        # intentionally overrides the endpoint.
+        if provider and provider not in {"auto", "custom"}:
+            return provider, resolved_model, base_url, api_key, resolved_api_mode
         return "custom", resolved_model, base_url, api_key, resolved_api_mode
     if provider:
         return provider, resolved_model, base_url, api_key, resolved_api_mode
@@ -5092,14 +5098,24 @@ def _build_call_kwargs(
         # models reject it entirely with error 1210). Omitting it sidesteps all of
         # those wire-format quirks at once.
         #
-        # The one exception is the Anthropic Messages wire (MiniMax and any
-        # ``/anthropic`` endpoint reached through the OpenAI SDK wrapper), where
-        # max_tokens is a MANDATORY field — omitting it is a hard 400. Keep it only
-        # there.
+        # Keep the caller's explicit cap only on transports that need Hermes to
+        # forward it as-is:
+        # - Anthropic Messages wire, where max_tokens is mandatory.
+        # - Native Gemini, where GeminiNativeClient translates max_tokens to
+        #   generationConfig.maxOutputTokens for the native REST API.
         _effective_base = base_url or (
             _current_custom_base_url() if provider == "custom" else ""
         )
-        if _is_anthropic_compat_endpoint(provider, _effective_base):
+        _normalized_provider = _normalize_aux_provider(provider)
+        _is_native_gemini = False
+        if _normalized_provider == "gemini":
+            try:
+                from agent.gemini_native_adapter import is_native_gemini_base_url
+
+                _is_native_gemini = is_native_gemini_base_url(_effective_base)
+            except Exception:
+                _is_native_gemini = False
+        if _is_anthropic_compat_endpoint(provider, _effective_base) or _is_native_gemini:
             kwargs["max_tokens"] = max_tokens
 
     if tools:
@@ -5620,9 +5636,15 @@ def call_llm(
             # warning so the operator knows aux task is about to fail.
             # (#26882) The error itself is re-raised below.
             logger.warning(
-                "Auxiliary %s: %s on %s and all fallbacks exhausted "
-                "(fallback_chain + main agent model). Raising original error.",
-                task or "call", reason, resolved_provider,
+                "Auxiliary %s: %s on provider=%s model=%s failed with %s: %s "
+                "and all fallbacks exhausted (fallback_chain + main agent model). "
+                "Raising original error.",
+                task or "call",
+                reason,
+                resolved_provider,
+                final_model or resolved_model or "default",
+                type(first_err).__name__,
+                " ".join(str(first_err).split())[:240],
             )
         # Connection/timeout errors leave the cached client poisoned (closed
         # httpx transport, half-read stream, dead async loop).  Drop it from
@@ -6067,9 +6089,15 @@ async def async_call_llm(
                     await async_fb.chat.completions.create(**fb_kwargs), task)
             # All fallback layers exhausted — warn before re-raising. (#26882)
             logger.warning(
-                "Auxiliary %s (async): %s on %s and all fallbacks exhausted "
-                "(fallback_chain + main agent model). Raising original error.",
-                task or "call", reason, resolved_provider,
+                "Auxiliary %s (async): %s on provider=%s model=%s failed with %s: %s "
+                "and all fallbacks exhausted (fallback_chain + main agent model). "
+                "Raising original error.",
+                task or "call",
+                reason,
+                resolved_provider,
+                final_model or resolved_model or "default",
+                type(first_err).__name__,
+                " ".join(str(first_err).split())[:240],
             )
         # Mirror the sync path: drop poisoned clients on connection/timeout
         # so the next aux call rebuilds.  See issue #23432.

--- a/agent/gemini_native_adapter.py
+++ b/agent/gemini_native_adapter.py
@@ -51,6 +51,30 @@ def bare_gemini_model_id(model: str) -> str:
     return name
 
 
+def gemini_resource_path(model: str) -> str:
+    """Return the native Gemini resource path for a model or resource id."""
+    normalized = bare_gemini_model_id(model).strip()
+    lowered = normalized.lower()
+    if lowered.startswith("models/") or lowered.startswith("tunedmodels/"):
+        return normalized
+    return f"models/{normalized}"
+
+
+def _gemini_resource_basename(model: str) -> str:
+    normalized = bare_gemini_model_id(model).strip()
+    lowered = normalized.lower()
+    for prefix in ("models/", "tunedmodels/"):
+        if lowered.startswith(prefix):
+            return normalized.split("/", 1)[1].strip() or normalized
+    return normalized
+
+
+def is_gemma_family_model(model: str) -> bool:
+    """Return True when the normalized Gemini model id is in the Gemma family."""
+    normalized = _gemini_resource_basename(model).strip().lower()
+    return normalized.startswith("gemma-")
+
+
 def is_native_gemini_base_url(base_url: str) -> bool:
     """Return True when the endpoint speaks Gemini's native REST API."""
     normalized = str(base_url or "").strip().rstrip("/").lower()
@@ -86,7 +110,8 @@ def probe_gemini_tier(
     if normalized_base.lower().endswith("/openai"):
         normalized_base = normalized_base[: -len("/openai")]
 
-    url = f"{normalized_base}/models/{model}:generateContent"
+    resource_path = gemini_resource_path(model)
+    url = f"{normalized_base}/{resource_path}:generateContent"
     payload = {
         "contents": [{"role": "user", "parts": [{"text": "hi"}]}],
         "generationConfig": {"maxOutputTokens": 1},
@@ -404,6 +429,7 @@ def _normalize_thinking_config(config: Any) -> Optional[Dict[str, Any]]:
 
 def build_gemini_request(
     *,
+    model: str = "",
     messages: List[Dict[str, Any]],
     tools: Any = None,
     tool_choice: Any = None,
@@ -431,7 +457,7 @@ def build_gemini_request(
         generation_config["temperature"] = temperature
     if max_tokens is not None:
         generation_config["maxOutputTokens"] = max_tokens
-    else:
+    elif not is_gemma_family_model(model):
         # Gemini's native generateContent does NOT treat an omitted
         # maxOutputTokens as "use the model's full output budget" — it applies
         # a low internal default and the model stops early with
@@ -439,9 +465,12 @@ def build_gemini_request(
         # then retries 3× and refuses the incomplete call). Every current
         # Gemini text model (2.5 + 3.x, flash / flash-lite / pro) caps at
         # 65,535 output tokens, so default to that ceiling when the caller
-        # passes None ("unlimited"). See the OpenAI-compat path where omitting
-        # the field genuinely means full budget — that assumption does not
-        # hold on the native API.
+        # passes None ("unlimited"). Gemma models on the same native endpoint
+        # are the exception: when Hermes routes an explicit Gemma model and the
+        # caller omitted max_tokens, leave maxOutputTokens unset so Gemini uses
+        # Gemma's own native default behavior. See the OpenAI-compat path where
+        # omitting the field genuinely means full budget — that assumption does
+        # not hold for Gemini-family models on the native API.
         generation_config["maxOutputTokens"] = GEMINI_DEFAULT_MAX_OUTPUT_TOKENS
     if top_p is not None:
         generation_config["topP"] = top_p
@@ -914,6 +943,7 @@ class GeminiNativeClient:
             thinking_config = extra_body.get("thinking_config") or extra_body.get("thinkingConfig")
 
         request = build_gemini_request(
+            model=model or "",
             messages=messages or [],
             tools=tools,
             tool_choice=tool_choice,
@@ -924,11 +954,11 @@ class GeminiNativeClient:
             thinking_config=thinking_config,
         )
 
-        model = bare_gemini_model_id(model)
+        resource_path = gemini_resource_path(model)
         if stream:
-            return self._stream_completion(model=model, request=request, timeout=timeout)
+            return self._stream_completion(model=resource_path, request=request, timeout=timeout)
 
-        url = f"{self.base_url}/models/{model}:generateContent"
+        url = f"{self.base_url}/{resource_path}:generateContent"
         response = self._http.post(url, json=request, headers=self._headers(), timeout=timeout)
         if response.status_code != 200:
             raise gemini_http_error(response)
@@ -941,10 +971,10 @@ class GeminiNativeClient:
                 status_code=response.status_code,
                 response=response,
             ) from exc
-        return translate_gemini_response(payload, model=model)
+        return translate_gemini_response(payload, model=resource_path)
 
     def _stream_completion(self, *, model: str, request: Dict[str, Any], timeout: Any = None) -> Iterator[_GeminiStreamChunk]:
-        url = f"{self.base_url}/models/{model}:streamGenerateContent?alt=sse"
+        url = f"{self.base_url}/{model}:streamGenerateContent?alt=sse"
         stream_headers = dict(self._headers())
         stream_headers["Accept"] = "text/event-stream"
 

--- a/cron/scripts/classify_items.py
+++ b/cron/scripts/classify_items.py
@@ -132,10 +132,14 @@ def _parse_scores(content: str, n_items: int) -> Dict[int, Dict[str, Any]]:
             return {}
     out: Dict[int, Dict[str, Any]] = {}
     if isinstance(arr, list):
-        for obj in arr:
+        for position, obj in enumerate(arr):
             if not isinstance(obj, dict):
                 continue
             idx = obj.get("index")
+            if idx is None:
+                if 0 <= position < n_items:
+                    out[position] = obj
+                continue
             if isinstance(idx, int) and 0 <= idx < n_items:
                 out[idx] = obj
     return out

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -38,6 +38,52 @@ def _jwt_with_claims(claims: dict) -> str:
     return f"{header}.{payload}.sig"
 
 
+def _gemini_text_payload(text: str) -> dict:
+    return {
+        "candidates": [
+            {
+                "content": {"parts": [{"text": text}]},
+                "finishReason": "STOP",
+            }
+        ],
+        "usageMetadata": {
+            "promptTokenCount": 1,
+            "candidatesTokenCount": 1,
+            "totalTokenCount": 2,
+        },
+    }
+
+
+class _RecordingGeminiHTTP:
+    def __init__(self, text: str = "ok"):
+        self.text = text
+        self.requests = []
+
+    def post(self, url, json=None, headers=None, timeout=None):
+        self.requests.append(
+            {
+                "url": url,
+                "json": json,
+                "headers": headers,
+                "timeout": timeout,
+            }
+        )
+        response = MagicMock()
+        response.status_code = 200
+        response.json.return_value = _gemini_text_payload(self.text)
+        return response
+
+    def close(self):
+        return None
+
+
+def _clear_aux_client_cache():
+    import agent.auxiliary_client as aux_mod
+
+    with aux_mod._client_cache_lock:
+        aux_mod._client_cache.clear()
+
+
 @pytest.fixture(autouse=True)
 def _clean_env(monkeypatch):
     """Strip provider env vars so each test starts clean."""
@@ -144,6 +190,117 @@ class TestBuildCallKwargsMaxTokens:
         )
         assert kwargs["max_tokens"] == 1234
         assert "max_completion_tokens" not in kwargs
+
+    def test_keeps_max_tokens_on_native_gemini(self):
+        from agent.auxiliary_client import _build_call_kwargs
+
+        kwargs = _build_call_kwargs(
+            provider="gemini",
+            model="gemma-4-31b-it",
+            messages=[{"role": "user", "content": "hi"}],
+            max_tokens=1234,
+            base_url="https://generativelanguage.googleapis.com/v1beta",
+        )
+        assert kwargs["max_tokens"] == 1234
+        assert "max_completion_tokens" not in kwargs
+
+
+class TestGeminiNativeAuxiliaryTaskRoutes:
+    def test_all_auxiliary_task_configs_share_gemma_no_default_cap_behavior(self, monkeypatch):
+        from hermes_cli.config import DEFAULT_CONFIG
+        from hermes_cli.plugins import PluginContext, PluginManager, PluginManifest
+
+        recorder = _RecordingGeminiHTTP()
+        monkeypatch.setattr(
+            "agent.gemini_native_adapter.httpx.Client",
+            lambda *args, **kwargs: recorder,
+        )
+        monkeypatch.setenv("GEMINI_API_KEY", "AIza-env-test")
+        _clear_aux_client_cache()
+
+        plugin_manager = PluginManager()
+        plugin_manager._discovered = True
+        plugin_ctx = PluginContext(PluginManifest(name="future_plugin"), plugin_manager)
+        plugin_ctx.register_auxiliary_task(
+            key="future_task",
+            display_name="Future task",
+            description="future auxiliary route",
+            defaults={
+                "provider": "gemini",
+                "model": "gemma-4-26b-a4b-it",
+                "base_url": "https://generativelanguage.googleapis.com/v1beta",
+                "timeout": 61,
+            },
+        )
+        monkeypatch.setattr(
+            "hermes_cli.plugins.get_plugin_auxiliary_tasks",
+            lambda: sorted(plugin_manager._aux_tasks.values(), key=lambda entry: entry["key"]),
+        )
+
+        ordered_tasks = list(DEFAULT_CONFIG["auxiliary"].keys()) + ["goal_judge", "future_task"]
+        gemma_models = ("gemma-4-31b-it", "gemma-4-26b-a4b-it")
+        config = {"auxiliary": {}}
+        for idx, task in enumerate(ordered_tasks):
+            if task == "future_task":
+                config["auxiliary"][task] = {"timeout": 75}
+                continue
+            config["auxiliary"][task] = {
+                "provider": "gemini",
+                "model": gemma_models[idx % len(gemma_models)],
+                "base_url": "https://generativelanguage.googleapis.com/v1beta",
+                "timeout": 30 + idx,
+            }
+        monkeypatch.setattr("hermes_cli.config.load_config", lambda: config)
+
+        for task in ordered_tasks:
+            client, model = get_text_auxiliary_client(task)
+            assert client is not None
+            assert model
+
+            client.chat.completions.create(
+                model=model,
+                messages=[{"role": "user", "content": f"hello from {task}"}],
+            )
+
+            request = recorder.requests[-1]
+            assert request["url"].endswith(f"/models/{model}:generateContent")
+            assert "maxOutputTokens" not in request["json"].get("generationConfig", {})
+
+    def test_explicit_auxiliary_api_key_still_uses_native_gemini_adapter(self, monkeypatch):
+        recorder = _RecordingGeminiHTTP()
+        monkeypatch.setattr(
+            "agent.gemini_native_adapter.httpx.Client",
+            lambda *args, **kwargs: recorder,
+        )
+        monkeypatch.delenv("GEMINI_API_KEY", raising=False)
+        monkeypatch.delenv("GOOGLE_API_KEY", raising=False)
+        _clear_aux_client_cache()
+
+        monkeypatch.setattr(
+            "hermes_cli.config.load_config",
+            lambda: {
+                "auxiliary": {
+                    "compression": {
+                        "provider": "gemini",
+                        "model": "gemma-4-31b-it",
+                        "api_key": "AIza-explicit-config",
+                    }
+                }
+            },
+        )
+
+        client, model = get_text_auxiliary_client("compression")
+        assert client is not None
+
+        client.chat.completions.create(
+            model=model,
+            messages=[{"role": "user", "content": "hello"}],
+            max_tokens=4096,
+        )
+
+        request = recorder.requests[-1]
+        assert request["headers"]["x-goog-api-key"] == "AIza-explicit-config"
+        assert request["json"]["generationConfig"]["maxOutputTokens"] == 4096
 
 
 class TestNousTagsScoping:
@@ -1764,9 +1921,14 @@ class TestAuxiliaryFallbackLayering:
                     messages=[{"role": "user", "content": "hello"}],
                 )
 
-        assert any(
-            "all fallbacks exhausted" in r.message for r in caplog.records
-        ), f"Expected exhaustion warning, got: {[r.message for r in caplog.records]}"
+        messages = [r.message for r in caplog.records]
+        assert any("all fallbacks exhausted" in message for message in messages), (
+            f"Expected exhaustion warning, got: {messages}"
+        )
+        exhaustion = next(message for message in messages if "all fallbacks exhausted" in message)
+        assert "provider=zai" in exhaustion
+        assert "model=glm-4v-flash" in exhaustion
+        assert "Exception: Payment Required" in exhaustion
 
 
 class TestTryMainAgentModelFallback:

--- a/tests/agent/test_auxiliary_config_bridge.py
+++ b/tests/agent/test_auxiliary_config_bridge.py
@@ -5,6 +5,7 @@ Also tests the vision_tools and browser_tool model override env vars.
 """
 
 import os
+import re
 import sys
 from pathlib import Path
 from unittest.mock import patch, MagicMock
@@ -63,6 +64,20 @@ def _run_auxiliary_bridge(config_dict, monkeypatch):
                 os.environ[env_map["base_url"]] = base_url
             if api_key:
                 os.environ[env_map["api_key"]] = api_key
+
+
+def _repo_source(*parts: str) -> str:
+    path = Path(__file__).parent.parent.parent.joinpath(*parts)
+    return path.read_text(encoding="utf-8")
+
+
+def _extract_ts_aux_task_keys(*parts: str) -> tuple[str, ...]:
+    source = _repo_source(*parts)
+    if "const AUX_TASKS" in source:
+        source = source.split("const AUX_TASKS", 1)[1]
+    if "] as const" in source:
+        source = source.split("] as const", 1)[0]
+    return tuple(re.findall(r"key:\s*['\"]([^'\"]+)['\"]", source))
 
 
 # ── Config bridging tests ────────────────────────────────────────────────────
@@ -285,6 +300,64 @@ class TestDefaultConfigShape:
         assert "model" in web
         assert web["provider"] == "auto"
         assert web["model"] == ""
+
+
+class TestAuxiliaryInventoryParity:
+    """Characterize the current aux task inventories without forcing them equal."""
+
+    def test_auxiliary_inventories_match_their_current_contracts(self):
+        from hermes_cli.config import DEFAULT_CONFIG
+        from hermes_cli.main import _AUX_TASKS
+        from hermes_cli.web_server import _AUX_TASK_SLOTS
+
+        config_keys = tuple(DEFAULT_CONFIG["auxiliary"].keys())
+        cli_keys = tuple(key for key, _, _ in _AUX_TASKS)
+        web_api_keys = tuple(_AUX_TASK_SLOTS)
+        web_frontend_keys = _extract_ts_aux_task_keys("web", "src", "pages", "ModelsPage.tsx")
+        desktop_keys = _extract_ts_aux_task_keys(
+            "apps", "desktop", "src", "app", "settings", "model-settings.tsx"
+        )
+
+        assert set(cli_keys) == set(config_keys) - {"monitor"}
+        assert set(web_api_keys) == set(config_keys) - {"monitor", "tts_audio_tags"}
+        assert web_frontend_keys == web_api_keys
+
+        assert set(desktop_keys).issubset(set(web_api_keys))
+        assert set(desktop_keys) != set(web_api_keys)
+        assert "triage_specifier" not in desktop_keys
+        assert "kanban_decomposer" not in desktop_keys
+        assert "profile_describer" not in desktop_keys
+
+        assert "tts_audio_tags" in config_keys
+        assert "tts_audio_tags" in cli_keys
+        assert "tts_audio_tags" not in web_api_keys
+        assert "monitor" in config_keys
+        assert "monitor" not in cli_keys
+        assert "monitor" not in web_api_keys
+
+    def test_goal_judge_is_hidden_manual_route_not_picker_inventory(self):
+        from hermes_cli.config import DEFAULT_CONFIG
+        from hermes_cli.main import _AUX_TASKS
+        from hermes_cli.web_server import _AUX_TASK_SLOTS
+
+        config_keys = tuple(DEFAULT_CONFIG["auxiliary"].keys())
+        cli_keys = tuple(key for key, _, _ in _AUX_TASKS)
+        web_api_keys = tuple(_AUX_TASK_SLOTS)
+        web_frontend_keys = _extract_ts_aux_task_keys("web", "src", "pages", "ModelsPage.tsx")
+        desktop_keys = _extract_ts_aux_task_keys(
+            "apps", "desktop", "src", "app", "settings", "model-settings.tsx"
+        )
+
+        assert "goal_judge" not in config_keys
+        assert "goal_judge" not in cli_keys
+        assert "goal_judge" not in web_api_keys
+        assert "goal_judge" not in web_frontend_keys
+        assert "goal_judge" not in desktop_keys
+
+        goals_doc = _repo_source("website", "docs", "user-guide", "features", "goals.md")
+        goals_source = _repo_source("hermes_cli", "goals.py")
+        assert "goal_judge" in goals_doc
+        assert 'get_text_auxiliary_client("goal_judge")' in goals_source
 
 
 # ── CLI defaults parity ─────────────────────────────────────────────────────

--- a/tests/agent/test_curator.py
+++ b/tests/agent/test_curator.py
@@ -904,6 +904,25 @@ def test_review_runtime_strips_blank_aux_credentials(curator_env):
     assert binding.explicit_base_url is None
 
 
+def test_review_runtime_accepts_explicit_gemma_auxiliary_slot(curator_env):
+    curator = curator_env["curator"]
+    cfg = {
+        "model": {"provider": "openrouter", "default": "openai/gpt-5.5"},
+        "auxiliary": {
+            "curator": {
+                "provider": "gemini",
+                "model": "gemma-4-31b-it",
+                "base_url": "https://generativelanguage.googleapis.com/v1beta",
+            },
+        },
+    }
+
+    binding = curator._resolve_review_runtime(cfg)
+    assert binding.provider == "gemini"
+    assert binding.model == "gemma-4-31b-it"
+    assert binding.explicit_base_url == "https://generativelanguage.googleapis.com/v1beta"
+
+
 def test_review_runtime_ignores_auxiliary_credentials_when_using_main(curator_env):
     """Falling through to main model must not pick up stray auxiliary.curator secrets."""
     curator = curator_env["curator"]

--- a/tests/agent/test_gemini_native_adapter.py
+++ b/tests/agent/test_gemini_native_adapter.py
@@ -211,7 +211,48 @@ def test_bare_gemini_model_id_strips_only_self_prefix(model, expected):
     assert bare_gemini_model_id(model) == expected
 
 
-def test_native_client_strips_self_prefix_from_model_url(monkeypatch):
+@pytest.mark.parametrize("model, expected", [
+    ("gemini-2.0-flash", "models/gemini-2.0-flash"),
+    ("models/gemini-x", "models/gemini-x"),
+    ("tunedModels/my-tune", "tunedModels/my-tune"),
+])
+def test_gemini_resource_path_preserves_native_resource_names(model, expected):
+    from agent.gemini_native_adapter import gemini_resource_path
+
+    assert gemini_resource_path(model) == expected
+
+
+@pytest.mark.parametrize(
+    "model",
+    [
+        "gemma-4-31b-it",
+        "google/gemma-4-31b-it",
+        "gemini/gemma-4-26b-a4b-it",
+        "models/gemma-4-31b-it",
+    ],
+)
+def test_is_gemma_family_model_normalizes_native_adapter_prefixes(model):
+    from agent.gemini_native_adapter import is_gemma_family_model
+
+    assert is_gemma_family_model(model) is True
+
+
+def test_is_gemma_family_model_rejects_non_gemma_models():
+    from agent.gemini_native_adapter import is_gemma_family_model
+
+    assert is_gemma_family_model("gemini-2.5-flash") is False
+    assert is_gemma_family_model("tunedModels/my-tune") is False
+
+
+@pytest.mark.parametrize(
+    "model, expected_suffix",
+    [
+        ("google/gemini-2.0-flash", "/models/gemini-2.0-flash:generateContent"),
+        ("models/gemini-x", "/models/gemini-x:generateContent"),
+        ("tunedModels/my-tune", "/tunedModels/my-tune:generateContent"),
+    ],
+)
+def test_native_client_builds_resource_aware_model_url(monkeypatch, model, expected_suffix):
     from agent.gemini_native_adapter import GeminiNativeClient
 
     recorded = {}
@@ -230,11 +271,54 @@ def test_native_client_strips_self_prefix_from_model_url(monkeypatch):
     monkeypatch.setattr("agent.gemini_native_adapter.httpx.Client", lambda *a, **k: DummyHTTP())
     client = GeminiNativeClient(api_key="AIza-test", base_url="https://generativelanguage.googleapis.com/v1beta")
     client.chat.completions.create(
-        model="google/gemini-2.0-flash",
+        model=model,
         messages=[{"role": "user", "content": "Hello"}],
     )
 
-    assert recorded["url"] == "https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent"
+    assert recorded["url"].endswith(expected_suffix)
+
+
+def test_native_stream_completion_preserves_tuned_model_resource_path(monkeypatch):
+    from agent.gemini_native_adapter import GeminiNativeClient
+
+    recorded = {}
+
+    class DummyStreamResponse:
+        status_code = 200
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc_val, exc_tb):
+            return False
+
+        def iter_text(self):
+            yield "data: [DONE]\n"
+
+    class DummyHTTP:
+        def stream(self, method, url, json=None, headers=None, timeout=None):
+            recorded["method"] = method
+            recorded["url"] = url
+            recorded["json"] = json
+            recorded["headers"] = headers
+            return DummyStreamResponse()
+
+        def close(self):
+            return None
+
+    monkeypatch.setattr("agent.gemini_native_adapter.httpx.Client", lambda *a, **k: DummyHTTP())
+    client = GeminiNativeClient(api_key="AIza-test", base_url="https://generativelanguage.googleapis.com/v1beta")
+
+    list(
+        client.chat.completions.create(
+            model="tunedModels/my-tune",
+            messages=[{"role": "user", "content": "Hello"}],
+            stream=True,
+        )
+    )
+
+    assert recorded["method"] == "POST"
+    assert recorded["url"].endswith("/tunedModels/my-tune:streamGenerateContent?alt=sse")
 
 
 def test_native_http_error_keeps_status_and_retry_after():
@@ -399,12 +483,44 @@ def test_max_tokens_none_defaults_to_gemini_output_ceiling():
         GEMINI_DEFAULT_MAX_OUTPUT_TOKENS,
     )
 
-    req = build_gemini_request(messages=[{"role": "user", "content": "hi"}], max_tokens=None)
+    req = build_gemini_request(
+        model="gemini-2.5-flash",
+        messages=[{"role": "user", "content": "hi"}],
+        max_tokens=None,
+    )
     assert req["generationConfig"]["maxOutputTokens"] == GEMINI_DEFAULT_MAX_OUTPUT_TOKENS == 65535
 
 
-def test_explicit_max_tokens_is_respected():
+@pytest.mark.parametrize("model", ["gemma-4-31b-it", "gemini-2.5-flash"])
+def test_explicit_max_tokens_is_respected(model):
     from agent.gemini_native_adapter import build_gemini_request
 
-    req = build_gemini_request(messages=[{"role": "user", "content": "hi"}], max_tokens=4096)
+    req = build_gemini_request(
+        model=model,
+        messages=[{"role": "user", "content": "hi"}],
+        max_tokens=4096,
+    )
     assert req["generationConfig"]["maxOutputTokens"] == 4096
+
+
+@pytest.mark.parametrize("model", ["gemma-4-31b-it", "gemma-4-26b-a4b-it"])
+def test_gemma_omits_synthetic_default_max_output_tokens(model):
+    from agent.gemini_native_adapter import build_gemini_request
+
+    req = build_gemini_request(
+        model=model,
+        messages=[{"role": "user", "content": "hi"}],
+        max_tokens=None,
+    )
+    assert "maxOutputTokens" not in req.get("generationConfig", {})
+
+
+def test_future_gemma_family_omits_synthetic_default_max_output_tokens():
+    from agent.gemini_native_adapter import build_gemini_request
+
+    req = build_gemini_request(
+        model="gemma-5-preview",
+        messages=[{"role": "user", "content": "hi"}],
+        max_tokens=None,
+    )
+    assert "maxOutputTokens" not in req.get("generationConfig", {})

--- a/tests/cron/test_classify_items.py
+++ b/tests/cron/test_classify_items.py
@@ -1,0 +1,258 @@
+"""Tests for cron/scripts/classify_items.py."""
+
+from __future__ import annotations
+
+import io
+import json as jsonlib
+import sys
+from unittest.mock import MagicMock
+
+
+def test_monitor_classifier_gemma_config_preserves_explicit_max_output_tokens(
+    monkeypatch, capsys
+):
+    import agent.auxiliary_client as aux_mod
+    from cron.scripts import classify_items
+
+    recorded = {}
+
+    class DummyHTTP:
+        def post(self, url, json=None, headers=None, timeout=None):
+            recorded["url"] = url
+            recorded["json"] = json
+            recorded["headers"] = headers
+            response = MagicMock()
+            response.status_code = 200
+            response.json.return_value = {
+                "candidates": [
+                    {
+                        "content": {
+                            "parts": [
+                                {
+                                    "text": jsonlib.dumps(
+                                        [
+                                            {
+                                                "index": 0,
+                                                "score": 9,
+                                                "reason": "reply today",
+                                            }
+                                        ]
+                                    )
+                                }
+                            ]
+                        },
+                        "finishReason": "STOP",
+                    }
+                ],
+                "usageMetadata": {
+                    "promptTokenCount": 1,
+                    "candidatesTokenCount": 1,
+                    "totalTokenCount": 2,
+                },
+            }
+            return response
+
+        def close(self):
+            return None
+
+    monkeypatch.setattr(
+        "agent.gemini_native_adapter.httpx.Client",
+        lambda *args, **kwargs: DummyHTTP(),
+    )
+    monkeypatch.setenv("GEMINI_API_KEY", "AIza-monitor-test")
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config",
+        lambda: {
+            "auxiliary": {
+                "monitor": {
+                    "provider": "gemini",
+                    "model": "gemma-4-31b-it",
+                    "base_url": "https://generativelanguage.googleapis.com/v1beta",
+                }
+            }
+        },
+    )
+    with aux_mod._client_cache_lock:
+        aux_mod._client_cache.clear()
+
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "classify_items.py",
+            "--criteria",
+            "Urgent if it needs a reply today.",
+            "--threshold",
+            "7",
+            "--format",
+            "json",
+        ],
+    )
+    monkeypatch.setattr(
+        sys,
+        "stdin",
+        io.StringIO(
+            jsonlib.dumps(
+                [
+                    {
+                        "id": "msg-1",
+                        "title": "Need a reply",
+                        "text": "Please get back to me today.",
+                    }
+                ]
+            )
+        ),
+    )
+
+    rc = classify_items.main()
+    stdout = capsys.readouterr().out
+    surfaced = jsonlib.loads(stdout)
+
+    assert rc == 0
+    assert surfaced[0]["id"] == "msg-1"
+    assert recorded["url"].endswith("/models/gemma-4-31b-it:generateContent")
+    assert recorded["json"]["generationConfig"]["maxOutputTokens"] == 1024
+
+
+def test_parse_scores_keeps_explicit_index_behavior():
+    from cron.scripts.classify_items import _parse_scores
+
+    scores = _parse_scores(
+        '[{"index": 0, "score": 9, "reason": "reply today"}]',
+        1,
+    )
+
+    assert scores == {0: {"index": 0, "score": 9, "reason": "reply today"}}
+
+
+def test_parse_scores_falls_back_to_array_position_when_index_is_omitted():
+    from cron.scripts.classify_items import _parse_scores
+
+    scores = _parse_scores(
+        '[{"score": 9, "reason": "reply today"}]',
+        1,
+    )
+
+    assert scores == {0: {"score": 9, "reason": "reply today"}}
+
+
+def test_parse_scores_ignores_out_of_range_explicit_index_without_positional_fallback():
+    from cron.scripts.classify_items import _parse_scores
+
+    scores = _parse_scores(
+        '[{"index": 4, "score": 9, "reason": "wrong item"}]',
+        1,
+    )
+
+    assert scores == {}
+
+
+def test_monitor_classifier_same_order_array_without_index_surfaces_above_threshold(
+    monkeypatch, capsys
+):
+    from cron.scripts import classify_items
+
+    def fake_call_llm(**kwargs):
+        assert kwargs["task"] == "monitor"
+        assert kwargs["max_tokens"] == 1024
+        return MagicMock(
+            choices=[
+                MagicMock(
+                    message=MagicMock(
+                        content='[{"score": 9, "reason": "reply today"}]'
+                    )
+                )
+            ]
+        )
+
+    monkeypatch.setattr("agent.auxiliary_client.call_llm", fake_call_llm)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "classify_items.py",
+            "--criteria",
+            "Urgent if it needs a reply today.",
+            "--threshold",
+            "7",
+            "--format",
+            "json",
+        ],
+    )
+    monkeypatch.setattr(
+        sys,
+        "stdin",
+        io.StringIO(
+            jsonlib.dumps(
+                [
+                    {
+                        "id": "msg-1",
+                        "title": "Need a reply",
+                        "text": "Please get back to me today.",
+                    }
+                ]
+            )
+        ),
+    )
+
+    rc = classify_items.main()
+    stdout = capsys.readouterr().out
+    surfaced = jsonlib.loads(stdout)
+
+    assert rc == 0
+    assert surfaced[0]["id"] == "msg-1"
+    assert surfaced[0]["score"] == 9
+    assert surfaced[0]["reason"] == "reply today"
+
+
+def test_monitor_classifier_below_threshold_reply_stays_silent(monkeypatch, capsys):
+    from cron.scripts import classify_items
+
+    def fake_call_llm(**kwargs):
+        assert kwargs["task"] == "monitor"
+        assert kwargs["max_tokens"] == 1024
+        return MagicMock(
+            choices=[
+                MagicMock(
+                    message=MagicMock(
+                        content='[{"score": 1, "reason": "ignore"}]'
+                    )
+                )
+            ]
+        )
+
+    monkeypatch.setattr("agent.auxiliary_client.call_llm", fake_call_llm)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "classify_items.py",
+            "--criteria",
+            "Urgent if it needs a reply today.",
+            "--threshold",
+            "7",
+            "--format",
+            "json",
+        ],
+    )
+    monkeypatch.setattr(
+        sys,
+        "stdin",
+        io.StringIO(
+            jsonlib.dumps(
+                [
+                    {
+                        "id": "msg-1",
+                        "title": "Need a reply",
+                        "text": "Please get back to me today.",
+                    }
+                ]
+            )
+        ),
+    )
+
+    rc = classify_items.main()
+    captured = capsys.readouterr()
+
+    assert rc == 0
+    assert captured.out == ""

--- a/tests/hermes_cli/test_gemini_provider.py
+++ b/tests/hermes_cli/test_gemini_provider.py
@@ -338,7 +338,7 @@ class TestGeminiModelsDev:
                 "models": {
                     "gemini-2.5-pro": {},
                     "gemma-4-31b-it": {},
-                    "gemma-3-27b-it": {},
+                    "gemma-4-26b-a4b-it": {},
                     "gemini-1.5-pro": {},
                     "gemini-2.0-flash": {},
                 }
@@ -351,6 +351,6 @@ class TestGeminiModelsDev:
 
         assert "gemini-2.5-pro" in result
         assert "gemma-4-31b-it" not in result
-        assert "gemma-3-27b-it" not in result
+        assert "gemma-4-26b-a4b-it" not in result
         assert "gemini-1.5-pro" not in result
         assert "gemini-2.0-flash" not in result

--- a/tests/hermes_cli/test_goals.py
+++ b/tests/hermes_cli/test_goals.py
@@ -175,6 +175,71 @@ class TestJudgeGoal:
         assert verdict == "continue"
         assert reason == "not yet"
 
+    def test_goal_judge_gemma_config_preserves_explicit_max_output_tokens(self, monkeypatch):
+        from hermes_cli import goals
+        import agent.auxiliary_client as aux_mod
+
+        recorded = {}
+
+        class DummyHTTP:
+            def post(self, url, json=None, headers=None, timeout=None):
+                recorded["url"] = url
+                recorded["json"] = json
+                recorded["headers"] = headers
+                response = MagicMock()
+                response.status_code = 200
+                response.json.return_value = {
+                    "candidates": [
+                        {
+                            "content": {
+                                "parts": [
+                                    {"text": '{"done": false, "reason": "not yet"}'}
+                                ]
+                            },
+                            "finishReason": "STOP",
+                        }
+                    ],
+                    "usageMetadata": {
+                        "promptTokenCount": 1,
+                        "candidatesTokenCount": 1,
+                        "totalTokenCount": 2,
+                    },
+                }
+                return response
+
+            def close(self):
+                return None
+
+        monkeypatch.setattr(
+            "agent.gemini_native_adapter.httpx.Client",
+            lambda *args, **kwargs: DummyHTTP(),
+        )
+        monkeypatch.setenv("GEMINI_API_KEY", "AIza-goal-test")
+        monkeypatch.setattr(
+            "hermes_cli.config.load_config",
+            lambda: {
+                "auxiliary": {
+                    "goal_judge": {
+                        "provider": "gemini",
+                        "model": "gemma-4-31b-it",
+                        "base_url": "https://generativelanguage.googleapis.com/v1beta",
+                        "max_tokens": 2048,
+                    }
+                }
+            },
+        )
+        with aux_mod._client_cache_lock:
+            aux_mod._client_cache.clear()
+
+        verdict, reason, parse_failed = goals.judge_goal("goal", "agent response")
+
+        assert verdict == "continue"
+        assert reason == "not yet"
+        assert parse_failed is False
+        assert recorded["url"].endswith("/models/gemma-4-31b-it:generateContent")
+        assert recorded["json"]["generationConfig"]["maxOutputTokens"] == 2048
+        assert goals._goal_judge_max_tokens() == 2048
+
 
 # ──────────────────────────────────────────────────────────────────────
 # GoalManager lifecycle + persistence

--- a/tests/hermes_cli/test_kanban_decompose.py
+++ b/tests/hermes_cli/test_kanban_decompose.py
@@ -148,6 +148,89 @@ def test_decompose_fanout_false_assigns_default_when_unassigned(kanban_home):
     assert task.assignee == "fallback"
 
 
+def test_decompose_task_gemma_config_preserves_explicit_max_output_tokens(
+    kanban_home, monkeypatch
+):
+    import agent.auxiliary_client as aux_mod
+
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="just one thing", triage=True)
+
+    recorded = {}
+
+    class DummyHTTP:
+        def post(self, url, json=None, headers=None, timeout=None):
+            recorded["url"] = url
+            recorded["json"] = json
+            recorded["headers"] = headers
+            response = MagicMock()
+            response.status_code = 200
+            response.json.return_value = {
+                "candidates": [
+                    {
+                        "content": {
+                            "parts": [
+                                {
+                                    "text": jsonlib.dumps(
+                                        {
+                                            "fanout": False,
+                                            "rationale": "single unit",
+                                            "title": "Tightened title",
+                                            "body": "**Goal**\nDo the thing.",
+                                        }
+                                    )
+                                }
+                            ]
+                        },
+                        "finishReason": "STOP",
+                    }
+                ],
+                "usageMetadata": {
+                    "promptTokenCount": 1,
+                    "candidatesTokenCount": 1,
+                    "totalTokenCount": 2,
+                },
+            }
+            return response
+
+        def close(self):
+            return None
+
+    monkeypatch.setattr(
+        "agent.gemini_native_adapter.httpx.Client",
+        lambda *args, **kwargs: DummyHTTP(),
+    )
+    monkeypatch.setenv("GEMINI_API_KEY", "AIza-decompose-test")
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config",
+        lambda: {
+            "auxiliary": {
+                "kanban_decomposer": {
+                    "provider": "gemini",
+                    "model": "gemma-4-31b-it",
+                    "base_url": "https://generativelanguage.googleapis.com/v1beta",
+                }
+            },
+            "kanban": {"default_assignee": "fallback"},
+        },
+    )
+    with aux_mod._client_cache_lock:
+        aux_mod._client_cache.clear()
+
+    patches = _patch_list_profiles(["orchestrator", "fallback"])
+    for p in patches:
+        p.start()
+    try:
+        outcome = decomp.decompose_task(tid, author="me")
+    finally:
+        for p in patches:
+            p.stop()
+
+    assert outcome.ok is True
+    assert recorded["url"].endswith("/models/gemma-4-31b-it:generateContent")
+    assert recorded["json"]["generationConfig"]["maxOutputTokens"] == 4000
+
+
 def test_decompose_fanout_false_preserves_existing_assignee(kanban_home):
     with kb.connect() as conn:
         tid = kb.create_task(

--- a/tests/hermes_cli/test_kanban_specify.py
+++ b/tests/hermes_cli/test_kanban_specify.py
@@ -112,6 +112,82 @@ def test_specify_task_happy_path(kanban_home):
     assert "**Goal**" in (task.body or "")
 
 
+def test_specify_task_gemma_config_preserves_explicit_max_output_tokens(
+    kanban_home, monkeypatch
+):
+    import agent.auxiliary_client as aux_mod
+
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="rough", triage=True)
+
+    recorded = {}
+
+    class DummyHTTP:
+        def post(self, url, json=None, headers=None, timeout=None):
+            recorded["url"] = url
+            recorded["json"] = json
+            recorded["headers"] = headers
+            response = MagicMock()
+            response.status_code = 200
+            response.json.return_value = {
+                "candidates": [
+                    {
+                        "content": {
+                            "parts": [
+                                {
+                                    "text": jsonlib.dumps(
+                                        {
+                                            "title": "Refined rough",
+                                            "body": "**Goal**\nA concrete goal.",
+                                        }
+                                    )
+                                }
+                            ]
+                        },
+                        "finishReason": "STOP",
+                    }
+                ],
+                "usageMetadata": {
+                    "promptTokenCount": 1,
+                    "candidatesTokenCount": 1,
+                    "totalTokenCount": 2,
+                },
+            }
+            return response
+
+        def close(self):
+            return None
+
+    monkeypatch.setattr(
+        "agent.gemini_native_adapter.httpx.Client",
+        lambda *args, **kwargs: DummyHTTP(),
+    )
+    monkeypatch.setenv("GEMINI_API_KEY", "AIza-specify-test")
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config",
+        lambda: {
+            "auxiliary": {
+                "triage_specifier": {
+                    "provider": "gemini",
+                    "model": "gemma-4-31b-it",
+                    "base_url": "https://generativelanguage.googleapis.com/v1beta",
+                }
+            }
+        },
+    )
+    with aux_mod._client_cache_lock:
+        aux_mod._client_cache.clear()
+
+    outcome = spec.specify_task(tid, author="ace")
+
+    assert outcome.ok is True
+    assert recorded["url"].endswith("/models/gemma-4-31b-it:generateContent")
+    assert (
+        recorded["json"]["generationConfig"]["maxOutputTokens"]
+        == spec.HERMES_KANBAN_SPECIFY_MAX_TOKENS
+    )
+
+
 def test_specify_task_falls_back_to_body_only_on_bad_json(kanban_home):
     with kb.connect() as conn:
         tid = kb.create_task(conn, title="keep title", triage=True)

--- a/tests/hermes_cli/test_plugin_auxiliary_tasks.py
+++ b/tests/hermes_cli/test_plugin_auxiliary_tasks.py
@@ -308,6 +308,43 @@ def test_get_auxiliary_task_config_layers_plugin_defaults(
     assert resolved["provider"] == "auto"
 
 
+def test_get_auxiliary_task_config_preserves_plugin_gemma_defaults(
+    tmp_path, monkeypatch, patched_manager
+):
+    from pathlib import Path
+    from hermes_cli.config import load_config, save_config
+    from agent.auxiliary_client import _get_auxiliary_task_config
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    (tmp_path / ".hermes").mkdir(exist_ok=True)
+
+    manifest = PluginManifest(name="plug")
+    ctx = PluginContext(manifest, patched_manager)
+    ctx.register_auxiliary_task(
+        key="future_task",
+        display_name="Future task",
+        description="x",
+        defaults={
+            "provider": "gemini",
+            "model": "gemma-4-26b-a4b-it",
+            "base_url": "https://generativelanguage.googleapis.com/v1beta",
+            "timeout": 61,
+        },
+    )
+
+    cfg = load_config()
+    aux = cfg.setdefault("auxiliary", {})
+    aux["future_task"] = {"timeout": 75}
+    save_config(cfg)
+
+    resolved = _get_auxiliary_task_config("future_task")
+    assert resolved["provider"] == "gemini"
+    assert resolved["model"] == "gemma-4-26b-a4b-it"
+    assert resolved["base_url"] == "https://generativelanguage.googleapis.com/v1beta"
+    assert resolved["timeout"] == 75
+
+
 def test_get_auxiliary_task_config_user_config_wins_over_plugin_defaults(
     tmp_path, monkeypatch, patched_manager
 ):

--- a/tests/hermes_cli/test_profile_describer.py
+++ b/tests/hermes_cli/test_profile_describer.py
@@ -112,6 +112,76 @@ def test_describer_writes_description_with_auto_true(profile_env, monkeypatch):
     assert meta["description_auto"] is True
 
 
+def test_describer_gemma_config_preserves_explicit_max_output_tokens(
+    profile_env, monkeypatch
+):
+    import agent.auxiliary_client as aux_mod
+
+    recorded = {}
+
+    class DummyHTTP:
+        def post(self, url, json=None, headers=None, timeout=None):
+            recorded["url"] = url
+            recorded["json"] = json
+            recorded["headers"] = headers
+            response = MagicMock()
+            response.status_code = 200
+            response.json.return_value = {
+                "candidates": [
+                    {
+                        "content": {
+                            "parts": [
+                                {
+                                    "text": jsonlib.dumps(
+                                        {"description": "writes Python codebases"}
+                                    )
+                                }
+                            ]
+                        },
+                        "finishReason": "STOP",
+                    }
+                ],
+                "usageMetadata": {
+                    "promptTokenCount": 1,
+                    "candidatesTokenCount": 1,
+                    "totalTokenCount": 2,
+                },
+            }
+            return response
+
+        def close(self):
+            return None
+
+    monkeypatch.setattr(
+        "agent.gemini_native_adapter.httpx.Client",
+        lambda *args, **kwargs: DummyHTTP(),
+    )
+    monkeypatch.setenv("GEMINI_API_KEY", "AIza-profile-test")
+    monkeypatch.setattr(profiles_mod, "profile_exists", lambda n: n == "myprof")
+    monkeypatch.setattr(profiles_mod, "normalize_profile_name", lambda n: n)
+    monkeypatch.setattr(profiles_mod, "get_profile_dir", lambda n: profile_env)
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config",
+        lambda: {
+            "auxiliary": {
+                "profile_describer": {
+                    "provider": "gemini",
+                    "model": "gemma-4-31b-it",
+                    "base_url": "https://generativelanguage.googleapis.com/v1beta",
+                }
+            }
+        },
+    )
+    with aux_mod._client_cache_lock:
+        aux_mod._client_cache.clear()
+
+    outcome = describer.describe_profile("myprof")
+
+    assert outcome.ok is True
+    assert recorded["url"].endswith("/models/gemma-4-31b-it:generateContent")
+    assert recorded["json"]["generationConfig"]["maxOutputTokens"] == 400
+
+
 def test_describer_refuses_to_overwrite_user_authored(profile_env, monkeypatch):
     profiles_mod.write_profile_meta(
         profile_env, description="curated", description_auto=False,

--- a/tests/tools/test_tts_gemini.py
+++ b/tests/tools/test_tts_gemini.py
@@ -367,6 +367,7 @@ class TestGenerateGeminiTts:
         mock_call_llm.assert_called_once()
         call_kwargs = mock_call_llm.call_args.kwargs
         assert call_kwargs["task"] == "tts_audio_tags"
+        assert "max_tokens" not in call_kwargs
         assert "Audio tags are inline square-bracket modifiers" in call_kwargs["messages"][0]["content"]
         assert "Style: Warm and amused." in call_kwargs["messages"][1]["content"]
         assert "Hi there." in call_kwargs["messages"][1]["content"]

--- a/tests/tools/test_vision_tools.py
+++ b/tests/tools/test_vision_tools.py
@@ -426,6 +426,71 @@ class TestVisionConfig:
         assert mock_llm.await_args.kwargs["temperature"] == 0.1
         assert mock_llm.await_args.kwargs["timeout"] == 120.0
 
+    @pytest.mark.asyncio
+    async def test_vision_gemma_config_preserves_explicit_max_output_tokens(
+        self, tmp_path, monkeypatch
+    ):
+        import agent.auxiliary_client as aux_mod
+
+        img = tmp_path / "test.png"
+        img.write_bytes(b"\x89PNG\r\n\x1a\n" + b"\x00" * 8)
+        recorded = {}
+
+        class DummyHTTP:
+            def post(self, url, json=None, headers=None, timeout=None):
+                recorded["url"] = url
+                recorded["json"] = json
+                recorded["headers"] = headers
+                response = MagicMock()
+                response.status_code = 200
+                response.json.return_value = {
+                    "candidates": [
+                        {
+                            "content": {"parts": [{"text": "Gemma vision analysis"}]},
+                            "finishReason": "STOP",
+                        }
+                    ],
+                    "usageMetadata": {
+                        "promptTokenCount": 1,
+                        "candidatesTokenCount": 1,
+                        "totalTokenCount": 2,
+                    },
+                }
+                return response
+
+            def close(self):
+                return None
+
+        monkeypatch.setattr(
+            "agent.gemini_native_adapter.httpx.Client",
+            lambda *args, **kwargs: DummyHTTP(),
+        )
+        monkeypatch.setenv("GEMINI_API_KEY", "AIza-vision-test")
+        monkeypatch.setattr(
+            "hermes_cli.config.load_config",
+            lambda: {
+                "auxiliary": {
+                    "vision": {
+                        "provider": "gemini",
+                        "model": "gemma-4-26b-a4b-it",
+                        "base_url": "https://generativelanguage.googleapis.com/v1beta",
+                    }
+                }
+            },
+        )
+        with aux_mod._client_cache_lock:
+            aux_mod._client_cache.clear()
+
+        with patch(
+            "tools.vision_tools._image_to_base64_data_url",
+            return_value="data:image/png;base64,abc",
+        ):
+            result = json.loads(await vision_analyze_tool(str(img), "describe this"))
+
+        assert result["success"] is True
+        assert recorded["url"].endswith("/models/gemma-4-26b-a4b-it:generateContent")
+        assert recorded["json"]["generationConfig"]["maxOutputTokens"] == 2000
+
 
 class TestVisionSafetyGuards:
     @pytest.mark.asyncio


### PR DESCRIPTION
## What does this PR do?

Fixes the native Gemini auxiliary path for Gemma-family models when the caller did not explicitly set `max_tokens`.

Before this change, Hermes synthesized `generationConfig.maxOutputTokens` defaults for native Gemini auxiliary calls, and Gemma-family models reject that synthetic field unless the caller explicitly asks for a cap. This PR removes the synthetic default only for the native Gemini Gemma path, preserves explicit cap forwarding, keeps generic OpenAI-compatible and Anthropic-compatible routing unchanged, and adds a positional fallback in `cron/scripts/classify_items.py` so same-order monitor outputs like `[{"score": 10}]` are not dropped when the model omits `index`.

This preserves the intentional decision not to expose Gemma models in generic model discovery.

## Related Issue

No exact public issue matched this bug during search.

Related PRs: #40844, #40175

## Type of Change

- [x] Bug fix (non-breaking change that fixes incorrect behavior)
- [x] Tests (adding or improving test coverage)

## Changes Made

- `agent/gemini_native_adapter.py`: omit synthetic `maxOutputTokens` only when the auxiliary call targets a Gemma-family model through the native Gemini adapter and the caller did not pass an explicit `max_tokens`; keep explicit cap forwarding and non-Gemma defaults intact.
- `agent/auxiliary_client.py`: preserve endpoint-agnostic explicit-cap forwarding into the adapter without adding Gemma-specific branching to generic OpenAI-compatible or Anthropic-compatible transports.
- `cron/scripts/classify_items.py`: add a same-order positional fallback so monitor outputs without `index` still map back to the input item list.
- Added regression coverage across native Gemini adapter behavior, auxiliary client routing, CLI auxiliary tasks, vision/TTS paths, curator, goals/kanban/profile flows, and the monitor parser fallback.

## Why this approach?

The bug belongs at the native Gemini adapter boundary, not in generic chat-completions routing. That keeps OpenAI-compatible and Anthropic-compatible auxiliary transports stable while fixing the Gemma-specific incompatibility where it actually occurs.

## How to Test

1. Run the required narrow wrapper suite:

   ```bash
   scripts/run_tests.sh -j 8 tests/agent/test_gemini_native_adapter.py tests/agent/test_auxiliary_client.py tests/agent/test_auxiliary_config_bridge.py tests/tools/test_vision_tools.py tests/tools/test_tts_gemini.py tests/hermes_cli/test_gemini_provider.py tests/hermes_cli/test_goals.py tests/hermes_cli/test_kanban_specify.py tests/hermes_cli/test_kanban_decompose.py tests/hermes_cli/test_profile_describer.py tests/agent/test_curator.py tests/hermes_cli/test_plugin_auxiliary_tasks.py tests/cron/test_suggestions.py tests/cron/test_classify_items.py -- --tb=short
   ```

   Result on this branch: `619 passed, 0 failed`.

2. Run the focused dashboard/API compatibility smokes:

   ```bash
   scripts/run_tests.sh tests/hermes_cli/test_web_server_profile_unification.py tests/hermes_cli/test_aux_config.py -- --tb=short -q -k "auxiliary_read_scoped_matches_write_target or auxiliary_unknown_profile_404 or select_provider_and_model_dispatches_to_aux_menu or leave_unchanged_replaces_cancel_label"
   ```

   Result on this branch: `4 passed, 0 failed`.

3. Optional current-main baseline disclosure runs:

   ```bash
   scripts/run_tests.sh tests/agent tests/tools tests/hermes_cli tests/cron -- --tb=short
   scripts/run_tests.sh
   ```

   These still fail in untouched current-main areas listed below.

Note: on this Windows host, a first narrow-suite rerun with the default `-j 32` worker fan-out hit the wrapper's 140-second per-file kill on `tests/agent/test_auxiliary_client.py`, `tests/hermes_cli/test_gemini_provider.py`, and `tests/tools/test_vision_tools.py`. Each file passed in isolated wrapper reruns, and the aggregate rerun passed cleanly with bounded parallelism.

## Platforms Tested

- Windows 11 / PowerShell / local Hermes install
- Windows-footgun lint: python3 scripts/check-windows-footguns.py <16 changed files> -> No Windows footguns found (16 file(s) scanned).
- POSIX not re-run in this contributor environment

## Surfaces Tested

- CLI: artifact-backed local Hermes session `20260616_145207_88435d`
- Direct internal Python diagnostic invocations: artifact-backed in the same session
- Dashboard/API: automated-only evidence from the focused wrapper smokes above
- TUI: not re-run in this thread
- Desktop settings: not re-run in this thread
- Messaging/channel entrypoints: not re-run in this thread

## Backend Families Checked

- Native Gemini target path: covered by the narrow wrapper suite plus the artifact-backed Hermes session above
- OpenAI-compatible auxiliary transports: automated-only evidence from `tests/agent/test_auxiliary_client.py`
- Anthropic-wire auxiliary transports: automated-only evidence from `tests/agent/test_auxiliary_client.py`

## Current-main baseline blockers

Affected-area and full-suite wrapper runs still fail on untouched current-main areas in the clean implementation worktree. Representative failures recorded during those runs:

- `tests/agent/test_anthropic_output_field_leak.py`: `cannot import name '_sanitize_replay_block' from 'agent.anthropic_adapter'`
- `tests/hermes_cli/test_xai_provider_labels.py`: expected `xAI`, got `xai`
- `tests/tools/test_checkpoint_manager.py`: existing GPG config assertion failures
- `tests/tools/test_managed_browserbase_and_modal.py`: `No module named 'agent.credential_persistence'`
- existing per-file 140-second harness kills in untouched areas such as `tests/agent/test_auxiliary_client.py`, `tests/agent/test_codex_cloudflare_headers.py`, and `tests/hermes_cli/test_web_server.py`
- full-wrapper runs also hit untouched failures including `tests/cli/test_cli_approval_ui.py`, `tests/gateway/test_matrix_voice.py`, `tests/run_agent/test_real_interrupt_subagent.py`, `tests/skills/test_openclaw_migration.py`, `tests/tools/test_subprocess_stdin_guard.py`, and `tests/tools/test_voice_mode.py`

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [ ] I've run `pytest tests/ -q` and all tests pass
  The current contributing guide requires `scripts/run_tests.sh` as the canonical evidence, and the broad/full wrapper runs still expose unrelated current-main baseline failures listed above.
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11 / PowerShell / local Hermes install

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact per the compatibility guide
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A


