### PR TITLE
fix(desktop): scope cron job calls by profile

### DIFF
--- a/apps/desktop/src/hermes.test.ts
+++ b/apps/desktop/src/hermes.test.ts
@@ -1,6 +1,10 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import {
+  createCronJob,
+  deleteCronJob,
+  getCronJob,
+  getCronJobRuns,
   getCronJobs,
   getGlobalModelInfo,
   getGlobalModelOptions,
@@ -10,7 +14,12 @@ import {
   getSessionMessages,
   getStatus,
   listAllProfileSessions,
-  listSessions
+  listSessions,
+  pauseCronJob,
+  resumeCronJob,
+  setApiRequestProfile,
+  triggerCronJob,
+  updateCronJob
 } from './hermes'
 import { refreshActiveProfile } from './store/profile'
 
@@ -33,6 +42,7 @@ describe('Hermes REST session helpers', () => {
   })
 
   afterEach(() => {
+    setApiRequestProfile(null)
     vi.restoreAllMocks()
     Reflect.deleteProperty(window, 'hermesDesktop')
   })
@@ -153,5 +163,66 @@ describe('Hermes REST session helpers', () => {
         path: '/api/model/options?refresh=1&include_unconfigured=1'
       })
     )
+  })
+
+  it('tags cron job reads and mutations with the active API profile', async () => {
+    setApiRequestProfile('worker_alpha')
+    api.mockResolvedValue({ runs: [] })
+
+    await getCronJobs()
+    await getCronJob('job 1')
+    await getCronJobRuns('job 1', 7)
+    await createCronJob({ name: 'Daily', prompt: 'say hi', schedule: '0 9 * * *' })
+    await updateCronJob('job 1', { enabled: false })
+    await pauseCronJob('job 1')
+    await resumeCronJob('job 1')
+    await triggerCronJob('job 1')
+    await deleteCronJob('job 1')
+
+    expect(api).toHaveBeenNthCalledWith(1, {
+      path: '/api/cron/jobs?profile=worker_alpha',
+      profile: 'worker_alpha',
+      timeoutMs: 60_000
+    })
+    expect(api).toHaveBeenNthCalledWith(2, {
+      path: '/api/cron/jobs/job%201?profile=worker_alpha',
+      profile: 'worker_alpha'
+    })
+    expect(api).toHaveBeenNthCalledWith(3, {
+      path: '/api/cron/jobs/job%201/runs?limit=7&profile=worker_alpha',
+      profile: 'worker_alpha'
+    })
+    expect(api).toHaveBeenNthCalledWith(4, {
+      path: '/api/cron/jobs?profile=worker_alpha',
+      method: 'POST',
+      body: { name: 'Daily', prompt: 'say hi', schedule: '0 9 * * *' },
+      profile: 'worker_alpha'
+    })
+    expect(api).toHaveBeenNthCalledWith(5, {
+      path: '/api/cron/jobs/job%201?profile=worker_alpha',
+      method: 'PUT',
+      body: { updates: { enabled: false } },
+      profile: 'worker_alpha'
+    })
+    expect(api).toHaveBeenNthCalledWith(6, {
+      path: '/api/cron/jobs/job%201/pause?profile=worker_alpha',
+      method: 'POST',
+      profile: 'worker_alpha'
+    })
+    expect(api).toHaveBeenNthCalledWith(7, {
+      path: '/api/cron/jobs/job%201/resume?profile=worker_alpha',
+      method: 'POST',
+      profile: 'worker_alpha'
+    })
+    expect(api).toHaveBeenNthCalledWith(8, {
+      path: '/api/cron/jobs/job%201/trigger?profile=worker_alpha',
+      method: 'POST',
+      profile: 'worker_alpha'
+    })
+    expect(api).toHaveBeenNthCalledWith(9, {
+      path: '/api/cron/jobs/job%201?profile=worker_alpha',
+      method: 'DELETE',
+      profile: 'worker_alpha'
+    })
   })
 })

--- a/apps/desktop/src/hermes.ts
+++ b/apps/desktop/src/hermes.ts
@@ -195,6 +195,15 @@ function profileScoped(): { profile?: string } {
   return _apiProfile ? { profile: _apiProfile } : {}
 }
 
+function profileScopedPath(path: string): string {
+  if (!_apiProfile) {
+    return path
+  }
+
+  const separator = path.includes('?') ? '&' : '?'
+  return `${path}${separator}profile=${encodeURIComponent(_apiProfile)}`
+}
+
 export async function listSessions(
   limit = 40,
   minMessages = 0,
@@ -750,20 +759,23 @@ export function testMessagingPlatform(platformId: string): Promise<MessagingPlat
 
 export function getCronJobs(): Promise<CronJob[]> {
   return window.hermesDesktop.api<CronJob[]>({
-    path: '/api/cron/jobs',
+    ...profileScoped(),
+    path: profileScopedPath('/api/cron/jobs'),
     timeoutMs: STARTUP_REQUEST_TIMEOUT_MS
   })
 }
 
 export function getCronJob(jobId: string): Promise<CronJob> {
   return window.hermesDesktop.api<CronJob>({
-    path: `/api/cron/jobs/${encodeURIComponent(jobId)}`
+    ...profileScoped(),
+    path: profileScopedPath(`/api/cron/jobs/${encodeURIComponent(jobId)}`)
   })
 }
 
 export async function getCronJobRuns(jobId: string, limit = 20): Promise<SessionInfo[]> {
   const { runs } = await window.hermesDesktop.api<{ runs: SessionInfo[] }>({
-    path: `/api/cron/jobs/${encodeURIComponent(jobId)}/runs?limit=${limit}`
+    ...profileScoped(),
+    path: profileScopedPath(`/api/cron/jobs/${encodeURIComponent(jobId)}/runs?limit=${limit}`)
   })
 
   return runs ?? []
@@ -771,7 +783,8 @@ export async function getCronJobRuns(jobId: string, limit = 20): Promise<Session
 
 export function createCronJob(body: CronJobCreatePayload): Promise<CronJob> {
   return window.hermesDesktop.api<CronJob>({
-    path: '/api/cron/jobs',
+    ...profileScoped(),
+    path: profileScopedPath('/api/cron/jobs'),
     method: 'POST',
     body
   })
@@ -779,7 +792,8 @@ export function createCronJob(body: CronJobCreatePayload): Promise<CronJob> {
 
 export function updateCronJob(jobId: string, updates: CronJobUpdates): Promise<CronJob> {
   return window.hermesDesktop.api<CronJob>({
-    path: `/api/cron/jobs/${encodeURIComponent(jobId)}`,
+    ...profileScoped(),
+    path: profileScopedPath(`/api/cron/jobs/${encodeURIComponent(jobId)}`),
     method: 'PUT',
     body: { updates }
   })
@@ -787,28 +801,32 @@ export function updateCronJob(jobId: string, updates: CronJobUpdates): Promise<C
 
 export function pauseCronJob(jobId: string): Promise<CronJob> {
   return window.hermesDesktop.api<CronJob>({
-    path: `/api/cron/jobs/${encodeURIComponent(jobId)}/pause`,
+    ...profileScoped(),
+    path: profileScopedPath(`/api/cron/jobs/${encodeURIComponent(jobId)}/pause`),
     method: 'POST'
   })
 }
 
 export function resumeCronJob(jobId: string): Promise<CronJob> {
   return window.hermesDesktop.api<CronJob>({
-    path: `/api/cron/jobs/${encodeURIComponent(jobId)}/resume`,
+    ...profileScoped(),
+    path: profileScopedPath(`/api/cron/jobs/${encodeURIComponent(jobId)}/resume`),
     method: 'POST'
   })
 }
 
 export function triggerCronJob(jobId: string): Promise<CronJob> {
   return window.hermesDesktop.api<CronJob>({
-    path: `/api/cron/jobs/${encodeURIComponent(jobId)}/trigger`,
+    ...profileScoped(),
+    path: profileScopedPath(`/api/cron/jobs/${encodeURIComponent(jobId)}/trigger`),
     method: 'POST'
   })
 }
 
 export function deleteCronJob(jobId: string): Promise<{ ok: boolean }> {
   return window.hermesDesktop.api<{ ok: boolean }>({
-    path: `/api/cron/jobs/${encodeURIComponent(jobId)}`,
+    ...profileScoped(),
+    path: profileScopedPath(`/api/cron/jobs/${encodeURIComponent(jobId)}`),
     method: 'DELETE'
   })
 }


### PR DESCRIPTION
## Summary

This scopes Desktop cron job REST helpers to the active API profile.

## Why

The backend cron endpoints are profile-aware, but the Desktop helpers did not pass the active API profile. In a multi-profile Desktop session, the Cron page could show or mutate jobs against the default/launch profile instead of the selected profile.

The most visible case is creating or editing a cron job while another profile is active: the UI appears to operate on that profile, but the request can land in the default profile's cron store.

## Changes

- Add `profileScoped()` to cron job list/detail/run-history helpers.
- Add `profileScoped()` to create/update/pause/resume/trigger/delete helpers.
- Add regression coverage proving all cron helper calls include the active API profile.

## Tests

```text
npm --workspace apps/desktop run test:ui -- src/hermes.test.ts
1 passed, 4 tests