### PR TITLE
fix(supermemory): lazy-install SDK on first use like honcho/hindsight

### DIFF
--- a/plugins/memory/supermemory/__init__.py
+++ b/plugins/memory/supermemory/__init__.py
@@ -263,6 +263,16 @@ def _is_trivial_message(text: str) -> bool:
 
 class _SupermemoryClient:
     def __init__(self, api_key: str, timeout: float, container_tag: str, search_mode: str = "hybrid"):
+        # Lazy-install the SDK on first use, mirroring honcho/hindsight. Without
+        # this the provider degrades silently to inactive whenever the wheel is
+        # absent (e.g. after a bare `uv sync` that prunes the optional extra).
+        try:
+            from tools.lazy_deps import ensure as _lazy_ensure
+            _lazy_ensure("memory.supermemory", prompt=False)
+        except ImportError:
+            pass
+        except Exception as _e:
+            raise ImportError(str(_e))
         from supermemory import Supermemory
 
         self._api_key = api_key

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -135,6 +135,12 @@ edge-tts = ["edge-tts==7.2.7"]
 modal = ["modal==1.3.4"]
 daytona = ["daytona==0.155.0"]
 hindsight = ["hindsight-client==0.6.1"]
+# Supermemory memory provider SDK. Like honcho/hindsight this is an opt-in
+# memory backend, so it stays out of [all] (it must lazy-install / be
+# explicitly selected, never break a fresh default install). The plugin's
+# session-ingest path uses the REST API directly, but search/recall/save/
+# forget/profile go through this SDK — without it those degrade silently.
+supermemory = ["supermemory==3.46.0"]
 dev = ["debugpy==1.8.20", "pytest==9.0.2", "pytest-asyncio==1.3.0", "mcp==1.26.0", "starlette==1.0.1", "ty==0.0.21", "ruff==0.15.10", "setuptools==81.0.0"]  # starlette: CVE-2026-48710; setuptools: latest <82 (torch >=2.11 caps setuptools<82)
 messaging = ["python-telegram-bot[webhooks]==22.6", "discord.py[voice]==2.7.1", "aiohttp==3.13.4", "brotlicffi==1.2.0.1", "slack-bolt==1.27.0", "slack-sdk==3.40.1", "qrcode==7.4.2"]  # aiohttp: CVE-2026-34513/34518/34519/34520/34525
 cron = []  # croniter is now a core dependency; this extra kept for back-compat

--- a/tools/lazy_deps.py
+++ b/tools/lazy_deps.py
@@ -119,6 +119,7 @@ LAZY_DEPS: dict[str, tuple[str, ...]] = {
     # ─── Memory providers ──────────────────────────────────────────────────
     "memory.honcho": ("honcho-ai==2.0.1",),
     "memory.hindsight": ("hindsight-client==0.6.1",),
+    "memory.supermemory": ("supermemory==3.46.0",),
 
     # ─── Messaging platforms (lazy-installable on demand) ──────────────────
     "platform.telegram": ("python-telegram-bot[webhooks]==22.6",),

--- a/uv.lock
+++ b/uv.lock
@@ -1564,6 +1564,9 @@ slack = [
 sms = [
     { name = "aiohttp" },
 ]
+supermemory = [
+    { name = "supermemory" },
+]
 teams = [
     { name = "aiohttp" },
     { name = "microsoft-teams-apps" },
@@ -1716,6 +1719,7 @@ requires-dist = [
     { name = "starlette", marker = "extra == 'dev'", specifier = "==1.0.1" },
     { name = "starlette", marker = "extra == 'mcp'", specifier = "==1.0.1" },
     { name = "starlette", marker = "extra == 'web'", specifier = "==1.0.1" },
+    { name = "supermemory", marker = "extra == 'supermemory'", specifier = "==3.46.0" },
     { name = "tenacity", specifier = "==9.1.4" },
     { name = "ty", marker = "extra == 'dev'", specifier = "==0.0.21" },
     { name = "tzdata", marker = "sys_platform == 'win32'", specifier = "==2025.3" },
@@ -1725,7 +1729,7 @@ requires-dist = [
     { name = "websockets", specifier = "==15.0.1" },
     { name = "youtube-transcript-api", marker = "extra == 'youtube'", specifier = "==1.2.4" },
 ]
-provides-extras = ["anthropic", "exa", "firecrawl", "parallel-web", "fal", "edge-tts", "modal", "daytona", "hindsight", "dev", "messaging", "cron", "slack", "matrix", "wecom", "cli", "tts-premium", "voice", "pty", "honcho", "vision", "mcp", "nemo-relay", "homeassistant", "sms", "teams", "computer-use", "acp", "mistral", "bedrock", "azure-identity", "termux", "termux-all", "dingtalk", "feishu", "google", "youtube", "web", "all"]
+provides-extras = ["anthropic", "exa", "firecrawl", "parallel-web", "fal", "edge-tts", "modal", "daytona", "hindsight", "supermemory", "dev", "messaging", "cron", "slack", "matrix", "wecom", "cli", "tts-premium", "voice", "pty", "honcho", "vision", "mcp", "nemo-relay", "homeassistant", "sms", "teams", "computer-use", "acp", "mistral", "bedrock", "azure-identity", "termux", "termux-all", "dingtalk", "feishu", "google", "youtube", "web", "all"]
 
 [[package]]
 name = "hf-xet"
@@ -3771,6 +3775,23 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/08/a3/84e821cc54b4ab50ae6dbc6ac3800a651b65ec35f045cc73785380654057/starlette-1.0.1.tar.gz", hash = "sha256:512399c5f1de7fac99c88572212ded9ddeddef2fb32afa82d724000e88b38f4f", size = 2659596, upload-time = "2026-05-21T21:58:58.433Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ec/e1/b2df4bc09a1e51ff664c1e17018a4274b42e5e9352e4a478ea540512dc88/starlette-1.0.1-py3-none-any.whl", hash = "sha256:7c0e69b2ee1c848bd54669d908500117a3ee13de603a21427e5c6fc1adf98dcd", size = 72802, upload-time = "2026-05-21T21:58:56.551Z" },
+]
+
+[[package]]
+name = "supermemory"
+version = "3.46.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "distro" },
+    { name = "httpx" },
+    { name = "pydantic" },
+    { name = "sniffio" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/24/09/73aa7df138823250ad529ceed4f1f3f8197a51dcfa6134ced556d91e03ea/supermemory-3.46.0.tar.gz", hash = "sha256:d1257ca92571840e535ed955d2b4c6fab97df6d13f9fd6e74a9fe19fe923ea49", size = 173431, upload-time = "2026-06-08T19:29:36.036Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d7/07/74e517149275ece59607f74eaaa88e943dd579bde4c03c857b7eda973cfc/supermemory-3.46.0-py3-none-any.whl", hash = "sha256:2bd474c1dcd8b7d51aaf7303a9794a66bf18cc3dcd6e87fbdccc5b89c97734b1", size = 154435, upload-time = "2026-06-08T19:29:34.746Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Problem

The `supermemory` memory provider is the only built-in memory backend with **no** `LAZY_DEPS` entry and **no** pyproject extra. Its SDK import (`from supermemory import Supermemory` in `_SupermemoryClient.__init__`) is declared nowhere, so on any install that doesn't happen to have the wheel, the provider degrades **silently**:

- `_SupermemoryClient.__init__` raises `ModuleNotFoundError`
- `MemoryProvider.initialize()` swallows it into a logged warning + `self._active = False`
- the session-ingest path (REST `POST /v4/conversations`) keeps working, so conversations still get archived…
- …but `search` / `recall` / `save` / `forget` / `profile` (all SDK-backed) silently no-op, with no user-facing hint that the backend is inactive.

honcho and hindsight — the comparable opt-in memory providers — both ship a pyproject extra **and** a `LAZY_DEPS` entry, and self-install on first use. supermemory was just missing this wiring.

## Fix

Align supermemory with the honcho/hindsight convention:

- **pyproject.toml**: add a `supermemory = ["supermemory==3.46.0"]` extra, kept out of `[all]` per the opt-in-memory-backend policy; regenerate `uv.lock`.
- **tools/lazy_deps.py**: add `"memory.supermemory": ("supermemory==3.46.0",)` to `LAZY_DEPS`.
- **plugins/memory/supermemory/__init__.py**: call `ensure("memory.supermemory", prompt=False)` before the SDK import in `_SupermemoryClient.__init__`, mirroring `plugins/memory/hindsight`.

Exact-pinned to match the no-ranges dependency policy; the `LAZY_DEPS` pin and the pyproject extra pin are kept in lockstep.

## Tests

`tests/tools/test_lazy_deps.py`, `tests/test_packaging_metadata.py`, `tests/test_project_metadata.py` all pass (81 tests). Self-heal verified end-to-end locally: uninstall the wheel → first provider init → `ensure` reinstalls it → SDK search succeeds.