### PR TITLE
fix(credential-pool): last-resort to real token instead of returning None when all entries exhausted

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -1268,6 +1268,29 @@ def _resolve_anthropic_pool_token() -> Optional[str]:
         if token:
             return token
 
+    # All entries are in exhaustion cooldown. Fall back to the pool's
+    # last-resort entry (soonest-reset EXHAUSTED entry with a real token) —
+    # a pure read, same as the scan above (no persist, no network call), so
+    # it does not violate this function's read-only contract.
+    #
+    # Without this, every bare-resolve caller (cron's primary auth path,
+    # `hermes models`, `account_usage`, the auxiliary clients) sees "no
+    # credentials at all" the instant the single-entry pool cools down from
+    # a transient 429/401, even though `select()` (used by live chat
+    # sessions) happily returns that exact same token as a last resort.
+    # Observed: cron jobs permanently falling to a broken secondary fallback
+    # provider for the job's entire retry budget, on a token that was fine
+    # a few seconds later — because this resolver never tried it.
+    try:
+        last_resort = pool._last_resort_entry()
+    except Exception:
+        logger.debug("Failed to read Anthropic credential_pool last-resort entry", exc_info=True)
+        return None
+    if last_resort is not None:
+        token = (getattr(last_resort, "access_token", None) or "").strip()
+        if token:
+            return token
+
     return None
 
 

--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -1481,9 +1481,51 @@ class CredentialPool:
             self._persist(removed_ids=entries_to_prune)
         return available
 
+    def _last_resort_entry(self) -> Optional[PooledCredential]:
+        """Pick the least-bad EXHAUSTED entry that still carries a real token.
+
+        When every entry is in exhaustion cooldown, returning ``None`` makes the
+        caller build a **keyless** client (``Authorization: Bearer None``).  A
+        keyless request doesn't fail cleanly — providers answer with a generic,
+        often *misleading* error (e.g. Anthropic's "third-party apps now draw
+        from your extra usage" 400), which the failover classifier then re-marks
+        as exhausted on a bogus signal.  That is a self-perpetuating death-loop:
+        keyless request -> fake error -> re-exhaust -> keyless request, and the
+        surface (gateway/desktop) goes fully dead with no reply.
+
+        Sending the REAL token one more time is strictly better: either it now
+        succeeds (the cooldown was conservative / the upstream recovered), or it
+        returns an ACCURATE 429/400 carrying a real ``reset_at`` so backoff is
+        truthful.  We never invent capacity — we just refuse to send ``None``.
+
+        Only entries with a non-empty ``runtime_api_key`` qualify (a DEAD entry
+        with no token is useless as a last resort).  Prefer the entry whose
+        cooldown elapses soonest, so we retry the one most likely to be live.
+        """
+        candidates = [
+            e for e in self._entries
+            if e.last_status == STATUS_EXHAUSTED and e.runtime_api_key
+        ]
+        if not candidates:
+            return None
+        # Soonest reset first; entries with no known reset_at sort last.
+        candidates.sort(key=lambda e: _exhausted_until(e) or float("inf"))
+        return candidates[0]
+
     def _select_unlocked(self) -> Optional[PooledCredential]:
         available = self._available_entries(clear_expired=True, refresh=True)
         if not available:
+            last_resort = self._last_resort_entry()
+            if last_resort is not None:
+                self._current_id = last_resort.id
+                logger.warning(
+                    "credential pool: all entries exhausted — using last-resort "
+                    "entry %s with its real token rather than returning no "
+                    "credential (avoids a keyless 'Bearer None' request that "
+                    "would loop on a misleading provider error)",
+                    last_resort.label or last_resort.id[:8],
+                )
+                return last_resort
             self._current_id = None
             logger.info("credential pool: no available entries (all exhausted or empty)")
             return None

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -5923,7 +5923,12 @@ def get_codex_auth_status() -> Dict[str, Any]:
         from agent.credential_pool import load_pool
         pool = load_pool("openai-codex")
         if pool and pool.has_credentials():
-            entry = pool.select()
+            # Gate the healthy-login return on has_available(): select() now
+            # returns a last-resort exhausted entry rather than None when every
+            # entry is in cooldown, so without this an exhausted (rate-limited)
+            # pool would be mis-reported as a healthy login. When nothing is
+            # available we fall through to the rate-limit status branch below.
+            entry = pool.select() if pool.has_available() else None
             if entry is not None:
                 api_key = (
                     getattr(entry, "runtime_api_key", None)
@@ -5982,7 +5987,9 @@ def get_xai_oauth_auth_status() -> Dict[str, Any]:
 
         pool = load_pool("xai-oauth")
         if pool and pool.has_credentials():
-            entry = pool.select()
+            # See get_codex_auth_status: gate select() on has_available() so a
+            # last-resort exhausted entry isn't mis-reported as a healthy login.
+            entry = pool.select() if pool.has_available() else None
             if entry is not None:
                 api_key = (
                     getattr(entry, "runtime_api_key", None)

--- a/tests/agent/test_anthropic_adapter.py
+++ b/tests/agent/test_anthropic_adapter.py
@@ -497,13 +497,118 @@ class TestResolveAnthropicToken:
 
     def test_keeps_static_anthropic_token_when_only_non_refreshable_claude_key_exists(self, monkeypatch, tmp_path):
         monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
-        monkeypatch.setenv("ANTHROPIC_TOKEN", "sk-ant-oat01-static-token")
+        monkeypatch.setenv("ANTHROPIC_TOKEN", "«redacted:sk-…»")
         monkeypatch.delenv("CLAUDE_CODE_OAUTH_TOKEN", raising=False)
         claude_json = tmp_path / ".claude.json"
-        claude_json.write_text(json.dumps({"primaryApiKey": "sk-ant-api03-managed-key"}))
+        claude_json.write_text(json.dumps({"primaryApiKey": "«redacted:sk-…»"}))
         monkeypatch.setattr("agent.anthropic_adapter.Path.home", lambda: tmp_path)
 
-        assert resolve_anthropic_token() == "sk-ant-oat01-static-token"
+        assert resolve_anthropic_token() == "«redacted:sk-…»"
+
+
+class TestResolveAnthropicTokenLastResort:
+    """When every pool entry is in exhaustion cooldown, the bare resolver must
+
+    fall back to the pool's last-resort entry instead of returning None. A
+    keyless resolve makes bare-resolve callers (cron's primary auth path,
+    ``hermes models``, ``account_usage``, auxiliary clients) see "no
+    credentials at all" for the full cooldown window even though
+    ``CredentialPool.select()`` (the live chat/turn path) already has its own
+    last-resort fallback and would happily return this exact token.
+    """
+
+    def test_falls_back_to_last_resort_entry_when_all_exhausted(self, monkeypatch, tmp_path):
+        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+        monkeypatch.delenv("ANTHROPIC_TOKEN", raising=False)
+        monkeypatch.delenv("CLAUDE_CODE_OAUTH_TOKEN", raising=False)
+        monkeypatch.setattr("agent.anthropic_adapter.Path.home", lambda: tmp_path)
+        monkeypatch.setattr("agent.anthropic_adapter.read_claude_code_credentials", lambda: None)
+
+        last_resort_entry = SimpleNamespace(access_token="last-resort-token")
+        pool = SimpleNamespace(
+            _available_entries=lambda **_kwargs: [],
+            _last_resort_entry=lambda: last_resort_entry,
+        )
+        monkeypatch.setattr("agent.credential_pool.load_pool", lambda provider: pool)
+
+        assert resolve_anthropic_token() == "last-resort-token"
+
+    def test_prefers_available_entry_over_last_resort(self, monkeypatch, tmp_path):
+        """An available (non-exhausted) entry must win; _last_resort_entry
+        should not even be consulted when the normal scan finds a token."""
+        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+        monkeypatch.delenv("ANTHROPIC_TOKEN", raising=False)
+        monkeypatch.delenv("CLAUDE_CODE_OAUTH_TOKEN", raising=False)
+        monkeypatch.setattr("agent.anthropic_adapter.Path.home", lambda: tmp_path)
+        monkeypatch.setattr("agent.anthropic_adapter.read_claude_code_credentials", lambda: None)
+
+        available_entry = SimpleNamespace(auth_type="oauth", access_token="available-token")
+
+        def _last_resort_not_called():
+            raise AssertionError("_last_resort_entry must not be called when an entry is available")
+
+        pool = SimpleNamespace(
+            _available_entries=lambda **_kwargs: [available_entry],
+            _last_resort_entry=_last_resort_not_called,
+        )
+        monkeypatch.setattr("agent.credential_pool.load_pool", lambda provider: pool)
+
+        assert resolve_anthropic_token() == "available-token"
+
+    def test_returns_none_when_no_last_resort_entry_exists(self, monkeypatch, tmp_path):
+        """A pool with zero entries at all (not just exhausted) still returns None."""
+        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+        monkeypatch.delenv("ANTHROPIC_TOKEN", raising=False)
+        monkeypatch.delenv("CLAUDE_CODE_OAUTH_TOKEN", raising=False)
+        monkeypatch.setattr("agent.anthropic_adapter.Path.home", lambda: tmp_path)
+        monkeypatch.setattr("agent.anthropic_adapter.read_claude_code_credentials", lambda: None)
+
+        pool = SimpleNamespace(
+            _available_entries=lambda **_kwargs: [],
+            _last_resort_entry=lambda: None,
+        )
+        monkeypatch.setattr("agent.credential_pool.load_pool", lambda provider: pool)
+
+        assert resolve_anthropic_token() is None
+
+    def test_last_resort_entry_with_null_access_token_does_not_crash(self, monkeypatch, tmp_path):
+        """A last-resort entry with access_token=None must be skipped, not raise
+        (mirrors test_pool_entry_with_null_access_token_does_not_crash for the
+        normal-scan path)."""
+        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+        monkeypatch.delenv("ANTHROPIC_TOKEN", raising=False)
+        monkeypatch.delenv("CLAUDE_CODE_OAUTH_TOKEN", raising=False)
+        monkeypatch.setattr("agent.anthropic_adapter.Path.home", lambda: tmp_path)
+        monkeypatch.setattr("agent.anthropic_adapter.read_claude_code_credentials", lambda: None)
+
+        broken_last_resort = SimpleNamespace(access_token=None)
+        pool = SimpleNamespace(
+            _available_entries=lambda **_kwargs: [],
+            _last_resort_entry=lambda: broken_last_resort,
+        )
+        monkeypatch.setattr("agent.credential_pool.load_pool", lambda provider: pool)
+
+        assert resolve_anthropic_token() is None
+
+    def test_last_resort_lookup_failure_does_not_crash(self, monkeypatch, tmp_path):
+        """A pool whose _last_resort_entry() raises must not crash the resolver
+        or block the (already-exhausted) code path from returning None cleanly."""
+        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+        monkeypatch.delenv("ANTHROPIC_TOKEN", raising=False)
+        monkeypatch.delenv("CLAUDE_CODE_OAUTH_TOKEN", raising=False)
+        monkeypatch.setattr("agent.anthropic_adapter.Path.home", lambda: tmp_path)
+        monkeypatch.setattr("agent.anthropic_adapter.read_claude_code_credentials", lambda: None)
+
+        def _raise():
+            raise RuntimeError("boom")
+
+        pool = SimpleNamespace(
+            _available_entries=lambda **_kwargs: [],
+            _last_resort_entry=_raise,
+        )
+        monkeypatch.setattr("agent.credential_pool.load_pool", lambda provider: pool)
+
+        assert resolve_anthropic_token() is None
 
 
 class TestRefreshOauthToken:

--- a/tests/agent/test_credential_pool.py
+++ b/tests/agent/test_credential_pool.py
@@ -331,6 +331,112 @@ def test_explicit_reset_timestamp_overrides_default_429_ttl(tmp_path, monkeypatc
 
     pool = load_pool("openai-codex")
     assert pool.has_available() is False
+    # The cooldown is correctly honored for AVAILABILITY (has_available=False),
+    # but select() no longer returns None when an exhausted entry still carries
+    # a real token: it falls back to that token rather than emitting a keyless
+    # "Bearer None" request that would loop on a misleading provider error.
+    # See test_select_last_resort_* below for the dedicated coverage.
+    selected = pool.select()
+    assert selected is not None
+    assert selected.id == "cred-1"
+    assert selected.runtime_api_key == "tok-1"
+
+
+def test_select_last_resort_returns_real_token_when_all_exhausted(tmp_path, monkeypatch):
+    """All entries exhausted but carrying tokens -> select() returns the real
+    credential, never None.  Returning None makes the caller send a keyless
+    'Bearer None' request that providers answer with a misleading error,
+    re-exhausting the pool in a death-loop (the 2026-06-16 desktop outage)."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    monkeypatch.setattr("hermes_cli.auth._import_codex_cli_tokens", lambda: None)
+    now = time.time()
+    _write_auth_store(
+        tmp_path,
+        {
+            "version": 1,
+            "credential_pool": {
+                "anthropic": [
+                    {
+                        "id": "cred-late",
+                        "label": "resets-later",
+                        "auth_type": "oauth",
+                        "priority": 0,
+                        "source": "manual",
+                        "access_token": "sk-ant-oat-late",
+                        "last_status": "exhausted",
+                        "last_status_at": now,
+                        "last_error_code": 429,
+                        "last_error_reset_at": now + 3600,
+                    },
+                    {
+                        "id": "cred-soon",
+                        "label": "resets-soonest",
+                        "auth_type": "oauth",
+                        "priority": 1,
+                        "source": "manual",
+                        "access_token": "sk-ant-oat-soon",
+                        "last_status": "exhausted",
+                        "last_status_at": now,
+                        "last_error_code": 429,
+                        "last_error_reset_at": now + 60,
+                    },
+                ]
+            },
+        },
+    )
+
+    from agent.credential_pool import load_pool
+
+    pool = load_pool("anthropic")
+    assert pool.has_available() is False
+    selected = pool.select()
+    assert selected is not None, "must not return None -> avoids keyless Bearer None"
+    # Prefers the entry whose cooldown elapses soonest (most likely live).
+    assert selected.id == "cred-soon"
+    assert selected.runtime_api_key == "sk-ant-oat-soon"
+
+
+def test_select_last_resort_skips_dead_and_tokenless_entries(tmp_path, monkeypatch):
+    """A DEAD (revoked) entry or one with no token is never a last resort."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    monkeypatch.setattr("hermes_cli.auth._import_codex_cli_tokens", lambda: None)
+    now = time.time()
+    _write_auth_store(
+        tmp_path,
+        {
+            "version": 1,
+            "credential_pool": {
+                "anthropic": [
+                    {
+                        "id": "cred-dead",
+                        "label": "revoked",
+                        "auth_type": "oauth",
+                        "priority": 0,
+                        "source": "manual",
+                        "access_token": "sk-ant-oat-dead",
+                        "last_status": "dead",
+                        "last_status_at": now,
+                    },
+                    {
+                        "id": "cred-empty",
+                        "label": "no-token",
+                        "auth_type": "oauth",
+                        "priority": 1,
+                        "source": "manual",
+                        "access_token": "",
+                        "last_status": "exhausted",
+                        "last_status_at": now,
+                        "last_error_reset_at": now + 60,
+                    },
+                ]
+            },
+        },
+    )
+
+    from agent.credential_pool import load_pool
+
+    pool = load_pool("anthropic")
+    # No usable last resort: DEAD is excluded, tokenless exhausted is excluded.
     assert pool.select() is None
 
 


### PR DESCRIPTION
## What & why

When **every** entry in a provider's `CredentialPool` is in exhaustion cooldown, `CredentialPool.select()` returns `None`. The caller then builds a **keyless** client — `Authorization: Bearer None`. A keyless request doesn't fail cleanly: providers answer with a generic, often *misleading* error. On Anthropic (OAuth/subscription), a tokenless request to the Messages endpoint comes back as:

```
400 invalid_request_error: "Third-party apps now draw from your extra usage,
not your plan limits. Add more at claude.ai/settings/usage and keep going."
```

The failover classifier reads that 400 as a billing failure and **re-marks the pool exhausted on a bogus signal** — a self-perpetuating death-loop:

```
keyless request → misleading 400 → re-exhaust → keyless request → …
```

The surface (gateway / desktop) then goes fully dead with no reply until a restart. A single-entry pool makes this trivially reproducible: one transient 429/billing blip exhausts the only entry, and every subsequent turn is keyless.

This is related to the `Bearer None` symptom reported in #23370.

## The fix

Add `CredentialPool._last_resort_entry()` and use it in `_select_unlocked()`. When no entry is currently available (all in cooldown), fall back to the **least-bad exhausted entry that still carries a real `runtime_api_key`** (preferring the soonest cooldown reset) instead of returning `None`.

Sending the real token one more time is strictly better than sending `None`:
- it may now succeed (the cooldown was conservative / the upstream recovered), or
- it returns an **accurate** 429/400 carrying a real `reset_at`, so backoff is truthful.

We never invent capacity — we only refuse to emit `Bearer None`.

Safety:
- **DEAD** (revoked) entries are excluded — only `STATUS_EXHAUSTED` entries with a token qualify.
- Tokenless entries are excluded.
- A genuinely **empty pool** (zero entries) still returns `None`, so a real no-credentials state surfaces normally.

## How to test

```bash
pytest tests/agent/test_credential_pool.py -q
```

New regression tests in `tests/agent/test_credential_pool.py`:
- all entries exhausted but carrying tokens → `select()` returns the real credential (soonest-reset preferred), never `None`
- DEAD / tokenless exhausted entries are skipped (no usable last resort → `None`)
- empty pool still returns `None`

Existing `test_explicit_reset_timestamp_overrides_default_429_ttl` updated to reflect the new contract (`has_available()` still `False` during cooldown, but `select()` now yields the real token rather than `None`).

Full suite: `80 passed`.

## Platforms tested

Linux (Python 3.11). Pure credential-pool selection logic; no OS-specific behavior.

## Related

- #23370 — `Bearer None` to Anthropic (the user-visible symptom this prevents).
