### PR TITLE
fix(desktop): remount chat runtime on profile switch to prevent stack overflow

### DIFF
--- a/apps/desktop/src/app/chat/index.tsx
+++ b/apps/desktop/src/app/chat/index.tsx
@@ -24,7 +24,7 @@ import { useIncrementalExternalStoreRuntime } from '@/lib/incremental-external-s
 import { cn } from '@/lib/utils'
 import type { ComposerAttachment } from '@/store/composer'
 import { $pinnedSessionIds } from '@/store/layout'
-import { $gatewaySwapTarget } from '@/store/profile'
+import { $activeGatewayProfile, $gatewaySwapTarget } from '@/store/profile'
 import {
   $activeSessionId,
   $awaitingResponse,
@@ -293,6 +293,7 @@ export function ChatView({
   const freshDraftReady = useStore($freshDraftReady)
   const gatewayState = useStore($gatewayState)
   const gatewaySwapTarget = useStore($gatewaySwapTarget)
+  const activeGatewayProfile = useStore($activeGatewayProfile)
   const gatewayOpen = gatewayState === 'open'
   const introPersonality = useStore($introPersonality)
   const introSeed = useStore($introSeed)
@@ -434,6 +435,7 @@ export function ChatView({
       <PromptOverlays />
 
       <ChatRuntimeBoundary
+        key={`${activeGatewayProfile}:${threadKey}`}
         busy={busy}
         onCancel={onCancel}
         onEdit={onEdit}


### PR DESCRIPTION
## Problem

Switching gateway profiles in Hermes Desktop intermittently crashes the renderer with **"Something broke in the interface — Maximum call stack size exceeded"**.

## Root cause

`ChatRuntimeBoundary` builds an assistant-ui `MessageRepository` via `ExportedMessageRepository.fromBranchableArray`, but the boundary never remounts across a profile switch, so the **same repository instance is reused**. When the active profile changes, the retained message nodes from the previous profile are incrementally relinked against the new profile's nodes whose `parentId` chains disagree — driving an **unguarded recursion** in the repository relink and overflowing the stack.

## Fix

Key `ChatRuntimeBoundary` on the active gateway profile in addition to the existing thread key:

```tsx
<ChatRuntimeBoundary key={`${activeGatewayProfile}:${threadKey}`} … />
```

This forces a fresh runtime + repository per profile, so no cross-profile relink can occur. Three lines: import `$activeGatewayProfile`, subscribe to it, and add it to the boundary `key`.

## Test

Switch between gateway profiles that each have existing chat threads — previously crashed on switch, now renders a clean runtime each time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)