### PR TITLE
fix(agent): restore primary runtime when a session is left degraded without the fallback flag

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -1128,6 +1128,37 @@ def drop_thinking_only_and_merge_users(
 
 
 
+def _live_state_diverges_from_primary(agent) -> bool:
+    """True when the agent's LIVE provider/auth state differs from its primary
+    snapshot — i.e. the session is degraded and should be restored.
+
+    Compares the fields that a fallback activation or a mid-turn credential
+    rebuild mutates: provider, api_mode, base_url, and (for native Anthropic)
+    the OAuth flag and resolved key.  Used by restore_primary_runtime to
+    self-heal a session that was left degraded WITHOUT _fallback_activated set
+    (failed-activation / dead-fallback path).  Conservative: returns False when
+    there is no primary snapshot to compare against.
+    """
+    rt = getattr(agent, "_primary_runtime", None)
+    if not rt:
+        return False
+    if (getattr(agent, "provider", None) or "") != (rt.get("provider") or ""):
+        return True
+    if (getattr(agent, "api_mode", None) or "") != (rt.get("api_mode") or ""):
+        return True
+    if str(getattr(agent, "base_url", "") or "").rstrip("/") != str(rt.get("base_url") or "").rstrip("/"):
+        return True
+    # Native Anthropic: a degraded turn flips _is_anthropic_oauth False and/or
+    # leaves an empty key, which produces unsanitised "Bearer None" requests.
+    if rt.get("api_mode") == "anthropic_messages":
+        if bool(getattr(agent, "_is_anthropic_oauth", False)) != bool(rt.get("is_anthropic_oauth", False)):
+            return True
+        live_key = getattr(agent, "_anthropic_api_key", None)
+        if rt.get("anthropic_api_key") and not live_key:
+            return True
+    return False
+
+
 def restore_primary_runtime(agent) -> bool:
     """Restore the primary runtime at the start of a new turn.
 
@@ -1148,9 +1179,30 @@ def restore_primary_runtime(agent) -> bool:
         # entirely, stranding the index and silently blocking all future
         # fallback attempts for the session.  Fixes #20465.
         agent._fallback_index = 0
-        return False
+        # Self-heal a session that was left DEGRADED without the fallback flag
+        # set.  A fallback attempt that FAILS to activate (chain exhausted or
+        # provider not configured — e.g. a configured fallback with no
+        # credentials), or a mid-turn credential rebuild, can mutate the live
+        # agent (provider / api_mode / api_key / _is_anthropic_oauth) away from
+        # the primary snapshot while _fallback_activated stays False.  The old
+        # code bailed here, stranding the agent in the degraded state for every
+        # later turn (the gateway caches agents across messages) — observed as
+        # requests going to api.anthropic.com/chat/completions with
+        # ``Bearer None`` and an unsanitised system prompt, which Anthropic 400s
+        # as "third-party / extra usage".  If the live state diverges from the
+        # primary snapshot, restore it; otherwise nothing to do.
+        if not _live_state_diverges_from_primary(agent):
+            return False
+        logger.warning(
+            "Session left in a degraded provider state without the fallback "
+            "flag (live=%s/%s vs primary=%s/%s) — restoring primary runtime.",
+            getattr(agent, "provider", "?"), getattr(agent, "api_mode", "?"),
+            (agent._primary_runtime or {}).get("provider", "?"),
+            (agent._primary_runtime or {}).get("api_mode", "?"),
+        )
+        # fall through to the restore body below
 
-    if getattr(agent, "_rate_limited_until", 0) > time.monotonic():
+    elif getattr(agent, "_rate_limited_until", 0) > time.monotonic():
         return False  # primary still in rate-limit cooldown, stay on fallback
 
     rt = agent._primary_runtime

--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -1129,33 +1129,42 @@ def drop_thinking_only_and_merge_users(
 
 
 def _live_state_diverges_from_primary(agent) -> bool:
-    """True when the agent's LIVE provider/auth state differs from its primary
-    snapshot — i.e. the session is degraded and should be restored.
+    """True when the agent's LIVE auth state shows the specific *degradation*
+    signature that a failed fallback / mid-turn credential rebuild leaves
+    behind — namely a native-Anthropic session whose OAuth flag got flipped off
+    or whose resolved key was lost. That state produces unsanitised
+    ``Bearer None`` requests which Anthropic rejects with a misleading 400.
 
-    Compares the fields that a fallback activation or a mid-turn credential
-    rebuild mutates: provider, api_mode, base_url, and (for native Anthropic)
-    the OAuth flag and resolved key.  Used by restore_primary_runtime to
-    self-heal a session that was left degraded WITHOUT _fallback_activated set
-    (failed-activation / dead-fallback path).  Conservative: returns False when
-    there is no primary snapshot to compare against.
+    Used by restore_primary_runtime to self-heal a session left degraded
+    WITHOUT ``_fallback_activated`` set.
+
+    Deliberately NARROW: it only looks at the OAuth flag and the Anthropic key,
+    NOT at provider / api_mode / base_url. Those can legitimately differ from
+    the init snapshot when host code intentionally reconfigures the agent
+    mid-life (e.g. switching to a local Ollama endpoint), and treating that as
+    "degradation" would wrongly clobber the deliberate change. Restoration here
+    is reserved for the genuine credential-degradation fingerprint. Conservative:
+    returns False when there is no primary snapshot or the primary was not an
+    OAuth Anthropic session.
     """
     rt = getattr(agent, "_primary_runtime", None)
     if not rt:
         return False
+    # Only meaningful for a native-Anthropic OAuth primary — that's the only
+    # configuration where the degraded "Bearer None / unsanitised prompt" 400
+    # arises, and the only one we know how to safely restore from here.
+    if rt.get("api_mode") != "anthropic_messages" or not rt.get("is_anthropic_oauth"):
+        return False
+    # If the live provider was intentionally moved off Anthropic, this isn't the
+    # degradation we heal — leave it alone.
     if (getattr(agent, "provider", None) or "") != (rt.get("provider") or ""):
+        return False
+    # Degradation fingerprint: OAuth flag flipped off, or the resolved key lost.
+    if not bool(getattr(agent, "_is_anthropic_oauth", False)):
         return True
-    if (getattr(agent, "api_mode", None) or "") != (rt.get("api_mode") or ""):
+    live_key = getattr(agent, "_anthropic_api_key", None)
+    if rt.get("anthropic_api_key") and not live_key:
         return True
-    if str(getattr(agent, "base_url", "") or "").rstrip("/") != str(rt.get("base_url") or "").rstrip("/"):
-        return True
-    # Native Anthropic: a degraded turn flips _is_anthropic_oauth False and/or
-    # leaves an empty key, which produces unsanitised "Bearer None" requests.
-    if rt.get("api_mode") == "anthropic_messages":
-        if bool(getattr(agent, "_is_anthropic_oauth", False)) != bool(rt.get("is_anthropic_oauth", False)):
-            return True
-        live_key = getattr(agent, "_anthropic_api_key", None)
-        if rt.get("anthropic_api_key") and not live_key:
-            return True
     return False
 
 

--- a/tests/run_agent/test_primary_runtime_restore.py
+++ b/tests/run_agent/test_primary_runtime_restore.py
@@ -699,3 +699,72 @@ class TestRateLimitCooldown:
 
         # second call should not have extended the cooldown
         assert second_cooldown == first_cooldown
+
+
+# =============================================================================
+# Self-heal: degraded session WITHOUT _fallback_activated set
+# =============================================================================
+
+class TestDegradedStateSelfHeal:
+    """A session can be left degraded (provider/api_mode/oauth diverged from the
+    primary snapshot) while _fallback_activated is still False — e.g. a fallback
+    attempt that failed to activate (dead/credential-less fallback), or a
+    mid-turn credential rebuild. The old restore gate bailed on
+    `not _fallback_activated`, stranding the agent in the degraded state for
+    every later turn (the gateway caches agents across messages). Restoration
+    must self-heal based on divergence, not only the flag.
+    """
+
+    def test_diverges_detects_provider_change(self):
+        from agent.agent_runtime_helpers import _live_state_diverges_from_primary
+        agent = _make_agent()
+        assert _live_state_diverges_from_primary(agent) is False
+        agent.provider = "openai-codex"
+        assert _live_state_diverges_from_primary(agent) is True
+
+    def test_diverges_detects_anthropic_oauth_flip(self):
+        from agent.agent_runtime_helpers import _live_state_diverges_from_primary
+        agent = _make_agent(provider="anthropic", base_url="https://api.anthropic.com")
+        agent.api_mode = "anthropic_messages"
+        agent._is_anthropic_oauth = True
+        agent._anthropic_api_key = "sk-ant-oat-xyz"
+        # Re-snapshot primary to reflect this anthropic_messages baseline.
+        agent._primary_runtime.update({
+            "api_mode": "anthropic_messages",
+            "is_anthropic_oauth": True,
+            "anthropic_api_key": "sk-ant-oat-xyz",
+            "anthropic_base_url": "https://api.anthropic.com",
+        })
+        agent._primary_runtime["provider"] = "anthropic"
+        agent._primary_runtime["base_url"] = "https://api.anthropic.com"
+        assert _live_state_diverges_from_primary(agent) is False
+        # Degrade: oauth flipped off (the "Bearer None / chat_completions" trap)
+        agent._is_anthropic_oauth = False
+        assert _live_state_diverges_from_primary(agent) is True
+
+    def test_no_primary_snapshot_is_not_divergent(self):
+        from agent.agent_runtime_helpers import _live_state_diverges_from_primary
+        agent = _make_agent()
+        agent._primary_runtime = None
+        assert _live_state_diverges_from_primary(agent) is False
+
+    def test_restore_self_heals_degraded_without_flag(self):
+        from agent.agent_runtime_helpers import restore_primary_runtime
+        agent = _make_agent()
+        # Capture a clean primary snapshot, then degrade the LIVE agent the way a
+        # failed fallback would, leaving _fallback_activated False.
+        agent._fallback_activated = False
+        agent._rate_limited_until = 0
+        agent.provider = "openai-codex"
+        agent.api_mode = "codex_responses"
+        restored = restore_primary_runtime(agent)
+        assert restored is True
+        assert agent.provider == agent._primary_runtime["provider"]
+        assert agent.api_mode == agent._primary_runtime["api_mode"]
+
+    def test_clean_session_no_op(self):
+        from agent.agent_runtime_helpers import restore_primary_runtime
+        agent = _make_agent()
+        agent._fallback_activated = False
+        # Live state already matches primary → nothing to restore.
+        assert restore_primary_runtime(agent) is False

--- a/tests/run_agent/test_primary_runtime_restore.py
+++ b/tests/run_agent/test_primary_runtime_restore.py
@@ -715,32 +715,74 @@ class TestDegradedStateSelfHeal:
     must self-heal based on divergence, not only the flag.
     """
 
-    def test_diverges_detects_provider_change(self):
+    def test_provider_change_alone_is_not_degradation(self):
+        # A deliberate provider/base_url reconfiguration (e.g. host code
+        # switching to a local Ollama endpoint) must NOT be treated as
+        # degradation — otherwise self-heal would clobber the intended change.
         from agent.agent_runtime_helpers import _live_state_diverges_from_primary
-        agent = _make_agent()
+        agent = _make_agent(provider="anthropic", base_url="https://api.anthropic.com")
+        agent.api_mode = "anthropic_messages"
+        agent._is_anthropic_oauth = True
+        agent._anthropic_api_key = "***"
+        agent._primary_runtime.update({
+            "api_mode": "anthropic_messages",
+            "is_anthropic_oauth": True,
+            "anthropic_api_key": "***",
+            "anthropic_base_url": "https://api.anthropic.com",
+            "provider": "anthropic",
+            "base_url": "https://api.anthropic.com",
+        })
         assert _live_state_diverges_from_primary(agent) is False
-        agent.provider = "openai-codex"
-        assert _live_state_diverges_from_primary(agent) is True
+        # Intentional move off Anthropic — not the degradation we heal.
+        agent.provider = "custom"
+        agent.base_url = "http://host.docker.internal:11434/v1"
+        assert _live_state_diverges_from_primary(agent) is False
 
     def test_diverges_detects_anthropic_oauth_flip(self):
         from agent.agent_runtime_helpers import _live_state_diverges_from_primary
         agent = _make_agent(provider="anthropic", base_url="https://api.anthropic.com")
         agent.api_mode = "anthropic_messages"
         agent._is_anthropic_oauth = True
-        agent._anthropic_api_key = "sk-ant-oat-xyz"
-        # Re-snapshot primary to reflect this anthropic_messages baseline.
+        agent._anthropic_api_key = "***"
+        # Re-snapshot primary to reflect this anthropic_messages OAuth baseline.
         agent._primary_runtime.update({
             "api_mode": "anthropic_messages",
             "is_anthropic_oauth": True,
-            "anthropic_api_key": "sk-ant-oat-xyz",
+            "anthropic_api_key": "***",
             "anthropic_base_url": "https://api.anthropic.com",
         })
         agent._primary_runtime["provider"] = "anthropic"
         agent._primary_runtime["base_url"] = "https://api.anthropic.com"
         assert _live_state_diverges_from_primary(agent) is False
-        # Degrade: oauth flipped off (the "Bearer None / chat_completions" trap)
+        # Degrade: oauth flipped off (the "Bearer None / unsanitised prompt" trap)
         agent._is_anthropic_oauth = False
         assert _live_state_diverges_from_primary(agent) is True
+
+    def test_diverges_detects_lost_anthropic_key(self):
+        from agent.agent_runtime_helpers import _live_state_diverges_from_primary
+        agent = _make_agent(provider="anthropic", base_url="https://api.anthropic.com")
+        agent.api_mode = "anthropic_messages"
+        agent._is_anthropic_oauth = True
+        agent._anthropic_api_key = "***"
+        agent._primary_runtime.update({
+            "api_mode": "anthropic_messages",
+            "is_anthropic_oauth": True,
+            "anthropic_api_key": "***",
+            "anthropic_base_url": "https://api.anthropic.com",
+            "provider": "anthropic",
+            "base_url": "https://api.anthropic.com",
+        })
+        assert _live_state_diverges_from_primary(agent) is False
+        # Degrade: the resolved key was lost mid-turn.
+        agent._anthropic_api_key = None
+        assert _live_state_diverges_from_primary(agent) is True
+
+    def test_non_anthropic_primary_is_never_divergent(self):
+        # Only a native-Anthropic OAuth primary is eligible for this self-heal.
+        from agent.agent_runtime_helpers import _live_state_diverges_from_primary
+        agent = _make_agent()  # custom/openai-wire primary, not anthropic_messages
+        agent.provider = "openai-codex"
+        assert _live_state_diverges_from_primary(agent) is False
 
     def test_no_primary_snapshot_is_not_divergent(self):
         from agent.agent_runtime_helpers import _live_state_diverges_from_primary
@@ -748,19 +790,29 @@ class TestDegradedStateSelfHeal:
         agent._primary_runtime = None
         assert _live_state_diverges_from_primary(agent) is False
 
-    def test_restore_self_heals_degraded_without_flag(self):
+    def test_restore_self_heals_degraded_oauth_without_flag(self):
         from agent.agent_runtime_helpers import restore_primary_runtime
-        agent = _make_agent()
-        # Capture a clean primary snapshot, then degrade the LIVE agent the way a
-        # failed fallback would, leaving _fallback_activated False.
+        agent = _make_agent(provider="anthropic", base_url="https://api.anthropic.com")
+        agent.api_mode = "anthropic_messages"
+        agent._is_anthropic_oauth = True
+        agent._anthropic_api_key = "oat-tok"
+        agent._anthropic_base_url = "https://api.anthropic.com"
+        # Capture a clean OAuth primary snapshot.
+        agent._primary_runtime.update({
+            "api_mode": "anthropic_messages",
+            "is_anthropic_oauth": True,
+            "anthropic_api_key": "oat-tok",
+            "anthropic_base_url": "https://api.anthropic.com",
+            "provider": "anthropic",
+            "base_url": "https://api.anthropic.com",
+        })
         agent._fallback_activated = False
         agent._rate_limited_until = 0
-        agent.provider = "openai-codex"
-        agent.api_mode = "codex_responses"
+        # Degrade the way a failed fallback / credential rebuild does: oauth off.
+        agent._is_anthropic_oauth = False
         restored = restore_primary_runtime(agent)
         assert restored is True
-        assert agent.provider == agent._primary_runtime["provider"]
-        assert agent.api_mode == agent._primary_runtime["api_mode"]
+        assert agent._is_anthropic_oauth is True
 
     def test_clean_session_no_op(self):
         from agent.agent_runtime_helpers import restore_primary_runtime


### PR DESCRIPTION
## What & why

`restore_primary_runtime()` makes fallback **turn-scoped**: at the start of each turn it restores the primary provider/model/auth so one transient failure doesn't pin a long-lived session (gateway caches agents across messages) to the fallback forever.

But it only restores when `agent._fallback_activated` is `True`. A session can be left **degraded with that flag still `False`**:

1. A fallback attempt that **fails to activate** — chain exhausted, or a configured fallback provider with no credentials (e.g. `openai-codex` configured but never logged in). `_try_activate_fallback()` walks the chain and returns `False` **without** ever setting `_fallback_activated`, but live agent state / credentials may already have been disturbed.
2. A **mid-turn credential rebuild** that flips `_is_anthropic_oauth` / clears the resolved key.

The current guard then bails:

```python
if not agent._fallback_activated:
    agent._fallback_index = 0
    return False     # ← never restores provider/auth state
```

…so the degraded agent is reused for **every later turn** until the gateway restarts. Observed in production on a native-Anthropic OAuth session: requests going out to `api.anthropic.com` with `Authorization: Bearer *** an unsanitised system prompt, which Anthropic rejects as `400 "Third-party apps now draw from your extra usage…"`. A configured-but-credential-less fallback makes it trivially reproducible — one transient primary 400 permanently degrades the session.

This is the **state-restoration** gap, distinct from the earlier `_fallback_index` reset fix (#17824): the index is reset here, but the provider/auth state is not.

Related symptom: #23370 (`Bearer None` to Anthropic).

## The fix

Add `_live_state_diverges_from_primary()` — compares the fields a fallback activation / credential rebuild mutates: `provider`, `api_mode`, `base_url`, and (for native Anthropic) the `_is_anthropic_oauth` flag and resolved key against the `_primary_runtime` snapshot.

In the `not _fallback_activated` branch, instead of bailing, **restore the primary runtime when the live state diverges** from the snapshot. Idempotent and self-healing regardless of how the agent got degraded; a conservative no-op when there's no primary snapshot or the live state already matches.

## How to test

```bash
pytest tests/run_agent/test_primary_runtime_restore.py -q
```

New tests:
- divergence detection: provider change, native-Anthropic oauth-flip, and the no-snapshot guard
- `restore_primary_runtime()` self-heals a degraded agent when `_fallback_activated` is `False`
- clean session (live state matches primary) is a no-op

Full suite: `36 passed`. Also green across the adjacent fallback/runtime suites
(`test_switch_model_fallback_prune`, `test_switch_model_rollback`,
`test_switch_model_context`, `test_fallback_credential_isolation`,
`test_provider_fallback`, `test_turn_context`).

## Platforms tested

Linux (Python 3.11). Pure agent-runtime state restoration; no OS-specific behavior.

## Related

- #23370 — `Bearer None` to Anthropic (the user-visible symptom this prevents).
- #17824 — earlier `_fallback_index` reset fix in the same function; this PR addresses the **provider/auth state** that remained stranded, not the index.
