### PR TITLE
fix(auxiliary): preserve named provider when base_url is passed (vision 401)

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -4848,6 +4848,17 @@ def _resolve_task_provider_model(
         cfg_provider, cfg_base_url = _expand_direct_api_alias(cfg_provider, cfg_base_url)
 
     if base_url:
+        # An explicit base_url normally forces an anonymous "custom" endpoint.
+        # But when the caller ALSO names a provider (e.g. a named custom
+        # provider like ``custom:9router-codex``, or ``openrouter``), keep that
+        # name so resolve_provider_client can resolve its declared credentials
+        # (``key_env`` / ``*_API_KEY``).  Collapsing to bare "custom" here would
+        # drop the key_env and fall back to the ``no-key-required`` placeholder
+        # → 401 on auth-required endpoints.  This mirrors the config-derived
+        # branch below (cfg_base_url + cfg_provider preserves cfg_provider).
+        prov_norm = (provider or "").strip().lower()
+        if prov_norm and prov_norm not in {"auto", "custom"}:
+            return provider, resolved_model, base_url, api_key, resolved_api_mode
         return "custom", resolved_model, base_url, api_key, resolved_api_mode
     if provider:
         return provider, resolved_model, base_url, api_key, resolved_api_mode

--- a/tests/agent/test_auxiliary_named_custom_providers.py
+++ b/tests/agent/test_auxiliary_named_custom_providers.py
@@ -491,3 +491,59 @@ class TestCustomProviderAliasCollision:
         assert isinstance(client, OpenAI)
         assert "override.example.com" in str(client.base_url)
         assert client.api_key == "override-key"
+
+
+class TestResolveTaskProviderModelBaseUrlPreservesNamedProvider:
+    """_resolve_task_provider_model must NOT collapse a named provider to bare
+    'custom' just because an explicit base_url is also supplied.
+
+    Regression for the auxiliary-vision 401: async_call_llm resolves the task
+    config (gets the provider's base_url) and passes that base_url back into
+    resolve_vision_provider_client, which re-runs _resolve_task_provider_model
+    with base_url set.  Forcing the provider to 'custom' there dropped the named
+    provider's key_env (e.g. NINEROUTER_KEY) → 'no-key-required' placeholder →
+    401 on every vision call, even though the main agent (same provider) worked.
+    """
+
+    def test_named_custom_provider_preserved_with_base_url(self):
+        from agent.auxiliary_client import _resolve_task_provider_model
+        prov, model, base, key, _mode = _resolve_task_provider_model(
+            task="vision",
+            provider="custom:9router-codex",
+            model="vertex/gemini-2.5-flash",
+            base_url="http://127.0.0.1:20128/v1",
+            api_key=None,
+        )
+        # The named provider must survive so its key_env can resolve downstream.
+        assert prov == "custom:9router-codex"
+        assert base == "http://127.0.0.1:20128/v1"
+        assert model == "vertex/gemini-2.5-flash"
+
+    def test_builtin_named_provider_preserved_with_base_url(self):
+        from agent.auxiliary_client import _resolve_task_provider_model
+        prov, _model, base, _key, _mode = _resolve_task_provider_model(
+            task="vision",
+            provider="openrouter",
+            base_url="https://openrouter.ai/api/v1",
+        )
+        assert prov == "openrouter"
+        assert base == "https://openrouter.ai/api/v1"
+
+    def test_anonymous_endpoint_still_collapses_to_custom(self):
+        """No provider (or literal 'custom'/'auto') + base_url → bare 'custom'."""
+        from agent.auxiliary_client import _resolve_task_provider_model
+        prov, _m, base, _k, _mode = _resolve_task_provider_model(
+            task="vision", base_url="http://localhost:1234/v1",
+        )
+        assert prov == "custom"
+        assert base == "http://localhost:1234/v1"
+
+        prov2, *_ = _resolve_task_provider_model(
+            task="vision", provider="custom", base_url="http://localhost:1234/v1",
+        )
+        assert prov2 == "custom"
+
+        prov3, *_ = _resolve_task_provider_model(
+            task="vision", provider="auto", base_url="http://localhost:1234/v1",
+        )
+        assert prov3 == "custom"


### PR DESCRIPTION
## What does this PR do?

`_resolve_task_provider_model()` force-collapsed the provider to the anonymous string `"custom"` whenever an explicit `base_url` was supplied — **even when the caller named a provider** (a named custom provider like `custom:9router-codex`, or a built-in aggregator like `openrouter`). Collapsing to bare `"custom"` discards the named provider, so `resolve_provider_client()` takes the anonymous-custom branch and cannot resolve the provider's declared `key_env` (e.g. `NINEROUTER_KEY`). It then falls back to the `"no-key-required"` placeholder and returns **HTTP 401 `invalid_api_key`** on every auth-required request.

This bites **auxiliary vision** specifically: `async_call_llm(task="vision")` resolves the task config (obtaining the provider's `base_url`), then passes that `base_url` back into `resolve_vision_provider_client()`, which re-runs `_resolve_task_provider_model()` with `base_url` set → the named provider is collapsed → 401 on every vision call, **even though the main agent loop (same provider) works fine**. That "main works, vision 401s" asymmetry is what made it hard to spot.

The fix makes the explicit-arg branch consistent with the existing config-derived branch a few lines below (`cfg_base_url` + `cfg_provider` already *preserves* `cfg_provider`).

## Related Issue

No existing issue. Symptom: auxiliary vision returns 401 `invalid_api_key` when `auxiliary.vision` points at a named custom provider that carries a `base_url` (the named provider's `key_env` is silently dropped).

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `agent/auxiliary_client.py` — in `_resolve_task_provider_model()`, when `base_url` is supplied **and** a non-anonymous provider is named (anything other than `""` / `"auto"` / `"custom"`), return the named provider instead of collapsing to `"custom"`, so its credentials resolve downstream. Anonymous endpoints (no provider, or literal `custom`/`auto`) still collapse to `"custom"` exactly as before.
- `tests/agent/test_auxiliary_named_custom_providers.py` — new class `TestResolveTaskProviderModelBaseUrlPreservesNamedProvider`: named-custom preserved with base_url, builtin-named (`openrouter`) preserved with base_url, and anonymous/`custom`/`auto` still collapse.

## How to Test

1. `pytest tests/agent/test_auxiliary_named_custom_providers.py -q` → all pass.
2. Proof of coverage: the two "preserved" tests **fail on `main`** (provider comes back as `"custom"`) and **pass with this change**.
3. Broader regression: `pytest tests/agent/test_auxiliary_client.py tests/agent/test_auxiliary_named_custom_providers.py tests/agent/test_auxiliary_transport_autodetect.py -q` → **277 passed**.
4. Real-world repro: configure `auxiliary.vision` with `provider: custom:<named>`, `model: <vision model>`, `base_url: <named provider's url>` where the named provider declares `key_env`. Before: every `vision_analyze` call → 401 `invalid_api_key`. After: resolves the key and returns a correct analysis.

## Checklist

### Code
- [x] I've read the Contributing Guide
- [x] Commit messages follow Conventional Commits (`fix(auxiliary): …`)
- [x] Searched existing PRs to avoid duplicates
- [x] PR contains only changes related to this fix
- [x] Ran `pytest` on the relevant suites and all pass (277 + the new class)
- [x] Added regression tests
- [x] Tested on platform: Ubuntu (Python 3.11)

### Documentation & Housekeeping
- [x] Docstring/inline comment added — README/docs N/A
- [x] `cli-config.yaml.example` — N/A (no new/changed config keys)
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A (no architecture/workflow change)
- [x] Cross-platform impact — N/A (pure provider-name resolution logic)
- [x] Tool descriptions/schemas — N/A
