### PR TITLE
fix(webhook): preserve home channel threads for bare delivery targets

### DIFF
--- a/gateway/platforms/webhook.py
+++ b/gateway/platforms/webhook.py
@@ -949,9 +949,10 @@ class WebhookAdapter(BasePlatformAdapter):
                 error=f"Platform {platform_name} not connected",
             )
 
-        # Use home channel if no specific chat_id in deliver_extra
+        # Use home channel if no specific chat_id in deliver_extra.
         extra = delivery.get("deliver_extra", {})
         chat_id = extra.get("chat_id", "")
+        home = None
         if not chat_id:
             home = self.gateway_runner.config.get_home_channel(target_platform)
             if home:
@@ -962,10 +963,29 @@ class WebhookAdapter(BasePlatformAdapter):
                     error=f"No chat_id or home channel for {platform_name}",
                 )
 
-        # Pass thread_id from deliver_extra so Telegram forum topics work
+        # Pass thread_id from deliver_extra so Telegram forum topics work.
+        # If the target falls back to a thread-aware home channel, preserve
+        # that thread too so bare webhook targets behave like cron/startup
+        # delivery targets.
         metadata = None
         thread_id = extra.get("message_thread_id") or extra.get("thread_id")
         if thread_id:
             metadata = {"thread_id": thread_id}
+        elif home is not None:
+            home_thread_id = getattr(home, "thread_id", None)
+            if home_thread_id is not None and str(home_thread_id) != "":
+                metadata_builder = getattr(
+                    type(self.gateway_runner), "_thread_metadata_for_target", None
+                )
+                if callable(metadata_builder):
+                    metadata = metadata_builder(
+                        self.gateway_runner,
+                        target_platform,
+                        chat_id,
+                        home_thread_id,
+                        adapter=adapter,
+                    )
+                if metadata is None:
+                    metadata = {"thread_id": home_thread_id}
 
         return await adapter.send(chat_id, content, metadata=metadata)

--- a/tests/gateway/test_webhook_adapter.py
+++ b/tests/gateway/test_webhook_adapter.py
@@ -27,7 +27,7 @@ import pytest
 from aiohttp import web
 from aiohttp.test_utils import TestClient, TestServer
 
-from gateway.config import Platform, PlatformConfig
+from gateway.config import HomeChannel, Platform, PlatformConfig
 from gateway.platforms.base import SendResult
 from gateway.platforms.webhook import (
     WebhookAdapter,
@@ -1007,6 +1007,100 @@ class TestDeliverCrossPlatformThreadId:
         await adapter._deliver_cross_platform("telegram", "hello", delivery)
         mock_target.send.assert_awaited_once_with(
             "12345", "hello", metadata=None
+        )
+
+    @pytest.mark.asyncio
+    async def test_home_channel_thread_id_used_when_chat_id_missing(self):
+        """Bare platform delivery preserves the configured home channel thread."""
+        adapter, mock_target = self._setup_adapter_with_mock_target()
+        adapter.gateway_runner.config.get_home_channel.return_value = HomeChannel(
+            platform=Platform.TELEGRAM,
+            chat_id="home-chat",
+            name="Ops Topic",
+            thread_id="home-topic",
+        )
+        delivery = {"deliver_extra": {}}
+
+        await adapter._deliver_cross_platform("telegram", "hello", delivery)
+
+        mock_target.send.assert_awaited_once_with(
+            "home-chat", "hello", metadata={"thread_id": "home-topic"}
+        )
+
+    @pytest.mark.asyncio
+    async def test_deliver_extra_thread_id_overrides_home_thread_id(self):
+        """Explicit webhook thread_id wins over the home channel thread_id."""
+        adapter, mock_target = self._setup_adapter_with_mock_target()
+        adapter.gateway_runner.config.get_home_channel.return_value = HomeChannel(
+            platform=Platform.TELEGRAM,
+            chat_id="home-chat",
+            name="Ops Topic",
+            thread_id="home-topic",
+        )
+        delivery = {"deliver_extra": {"thread_id": "explicit-topic"}}
+
+        await adapter._deliver_cross_platform("telegram", "hello", delivery)
+
+        mock_target.send.assert_awaited_once_with(
+            "home-chat", "hello", metadata={"thread_id": "explicit-topic"}
+        )
+
+    @pytest.mark.asyncio
+    async def test_home_channel_thread_metadata_uses_runner_builder(self):
+        """Home fallback uses gateway metadata so Telegram DM topics keep routing keys."""
+        adapter = _make_adapter()
+        mock_target = AsyncMock()
+        mock_target.send = AsyncMock(return_value=SendResult(success=True))
+        calls = {}
+
+        class RunnerWithMetadataBuilder:
+            def __init__(self):
+                self.adapters = {Platform.TELEGRAM: mock_target}
+                self.config = MagicMock()
+                self.config.get_home_channel.return_value = HomeChannel(
+                    platform=Platform.TELEGRAM,
+                    chat_id="home-chat",
+                    name="Ops Topic",
+                    thread_id="777",
+                )
+
+            def _thread_metadata_for_target(
+                self,
+                platform,
+                chat_id,
+                thread_id,
+                *,
+                adapter=None,
+                chat_type=None,
+                reply_to_message_id=None,
+            ):
+                calls["target"] = (platform, chat_id, thread_id, adapter)
+                return {
+                    "thread_id": thread_id,
+                    "telegram_dm_topic_reply_fallback": True,
+                    "direct_messages_topic_id": thread_id,
+                }
+
+        adapter.gateway_runner = RunnerWithMetadataBuilder()
+
+        await adapter._deliver_cross_platform(
+            "telegram", "hello", {"deliver_extra": {}}
+        )
+
+        assert calls["target"] == (
+            Platform.TELEGRAM,
+            "home-chat",
+            "777",
+            mock_target,
+        )
+        mock_target.send.assert_awaited_once_with(
+            "home-chat",
+            "hello",
+            metadata={
+                "thread_id": "777",
+                "telegram_dm_topic_reply_fallback": True,
+                "direct_messages_topic_id": "777",
+            },
         )
 
 

--- a/tests/gateway/test_webhook_deliver_only.py
+++ b/tests/gateway/test_webhook_deliver_only.py
@@ -21,7 +21,7 @@ import pytest
 from aiohttp import web
 from aiohttp.test_utils import TestClient, TestServer
 
-from gateway.config import Platform, PlatformConfig
+from gateway.config import HomeChannel, Platform, PlatformConfig
 from gateway.platforms.base import MessageEvent, SendResult
 from gateway.platforms.webhook import WebhookAdapter, _INSECURE_NO_AUTH
 
@@ -118,6 +118,42 @@ class TestDeliverOnlyBypassesAgent:
         chat_id_arg, content_arg = call_args.args[0], call_args.args[1]
         assert chat_id_arg == "12345"
         assert content_arg == "alice matched with bob!"
+
+    @pytest.mark.asyncio
+    async def test_home_channel_thread_id_used_when_chat_id_missing(self):
+        """deliver_only bare platform targets preserve the home channel thread."""
+        routes = {
+            "ops-alert": {
+                "secret": _INSECURE_NO_AUTH,
+                "deliver": "telegram",
+                "deliver_only": True,
+                "deliver_extra": {},
+                "prompt": "Build {build.number}: {build.status}",
+            }
+        }
+        adapter = _make_adapter(routes)
+        mock_target = _wire_mock_target(adapter)
+        adapter.gateway_runner.config.get_home_channel.return_value = HomeChannel(
+            platform=Platform.TELEGRAM,
+            chat_id="home-chat",
+            name="Ops Topic",
+            thread_id="home-topic",
+        )
+        app = _create_app(adapter)
+
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post(
+                "/webhooks/ops-alert",
+                json={"build": {"number": 77, "status": "FAILED"}},
+                headers={"X-GitHub-Delivery": "d-home-topic-1"},
+            )
+            assert resp.status == 200
+
+        mock_target.send.assert_awaited_once_with(
+            "home-chat",
+            "Build 77: FAILED",
+            metadata={"thread_id": "home-topic"},
+        )
 
     @pytest.mark.asyncio
     async def test_template_rendering_works(self):


### PR DESCRIPTION
## Summary

Webhook cross-platform delivery now preserves the configured home channel thread/topic when a route uses a bare platform target such as `deliver: telegram` or `deliver: discord` without an explicit `deliver_extra.chat_id`.

## Root cause

`WebhookAdapter._deliver_cross_platform()` fell back to `config.get_home_channel()` when `deliver_extra.chat_id` was missing, but only copied `home.chat_id`. Any stored `home.thread_id` was dropped, so thread-aware home channels could receive webhook responses in the parent/root conversation instead of the topic/thread where `/sethome` was configured.

Cron and gateway startup/shutdown notifications already preserve this home-channel thread metadata, so webhook delivery was inconsistent with the rest of gateway delivery.

## Changes

- Preserve `home.thread_id` when webhook delivery falls back to a configured home channel.
- Reuse the gateway thread metadata builder when available so Telegram DM/topic routing keeps its platform-specific metadata.
- Keep explicit `deliver_extra.thread_id` / `message_thread_id` precedence over the home channel thread.
- Add regression coverage for cross-platform delivery and the HTTP `deliver_only` webhook path.

## Validation

- `python -m pytest tests/gateway/test_webhook_adapter.py tests/gateway/test_webhook_deliver_only.py -q` — 86 passed
- `python -m pytest tests/gateway/test_restart_notification.py::test_send_home_channel_startup_notification_preserves_thread_metadata -q` — passed
- `python -m pytest tests/gateway/test_gateway_shutdown.py -q` — 17 passed
- `python -m pytest tests/cron/test_scheduler.py::TestResolveDeliveryTarget::test_bare_platform_delivery_preserves_home_thread_id -q` — passed
- `python -m pytest tests/gateway/test_webhook_integration.py -q` — 4 passed
- `ruff check gateway/platforms/webhook.py tests/gateway/test_webhook_adapter.py tests/gateway/test_webhook_deliver_only.py` — passed
- `python -m compileall gateway/platforms/webhook.py tests/gateway/test_webhook_adapter.py tests/gateway/test_webhook_deliver_only.py` — passed