### PR TITLE
fix(cli): resolve Python 3.11 `TypeError` in `shutil.rmtree` during profile deletion

### DIFF
--- a/hermes_cli/profiles.py
+++ b/hermes_cli/profiles.py
@@ -1193,9 +1193,11 @@ def delete_profile(name: str, yes: bool = False) -> Path:
                 raise
 
         # ``onexc`` was added in 3.12; fall back to ``onerror`` on 3.11.
-        try:
+        import sys
+    
+        if sys.version_info >= (3, 12):
             shutil.rmtree(profile_dir, onexc=_make_writable)
-        except TypeError:
+        else:
             shutil.rmtree(profile_dir, onerror=_make_writable)
         print(f"✓ Removed {profile_dir}")
     except Exception as e:


### PR DESCRIPTION
**Description:**
Partially addresses #47368 (Bug 1: `delete_profile()` calls `shutil.rmtree()` with a Python 3.12-only kwarg).

**What changed:**
- Replaced the failing `try/except` block with an explicit `sys.version_info` check in `hermes_cli/profiles.py`.
- Uses `onexc` for Python 3.12+ and falls back cleanly to `onerror` for Python 3.11 and below.

**Why it matters:**
Hermes ships on CPython 3.11.13, meaning the `onexc` keyword argument in `shutil.rmtree` constantly triggers a `TypeError` before falling back to `onerror`. This PR makes the deletion branch strictly version-correct, eliminating the initial exception and cleanly bridging compatibility across Python versions. 
*(Note: This is step 1 of fixing #47368. The backend termination sequence still needs to be addressed separately to resolve the `Errno 66` lock).*