### PR TITLE
fix(gateway): preserve interrupt session routing

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -8254,6 +8254,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 pass
         return source
 
+    def _cache_session_source_if_absent(self, session_key: str, source) -> None:
+        if self._get_cached_session_source(session_key) is None:
+            self._cache_session_source(session_key, source)
+
     async def _handle_message_with_agent(self, event, source, _quick_key: str, run_generation: int):
         """Inner handler that runs under the _running_agents sentinel guard."""
         _msg_start_time = time.time()
@@ -8285,7 +8289,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
         session_entry = self.session_store.get_or_create_session(source)
         session_key = session_entry.session_key
-        self._cache_session_source(session_key, source)
+        self._cache_session_source_if_absent(session_key, source)
         if self._is_telegram_topic_lane(source):
             try:
                 binding = self._session_db.get_telegram_topic_binding(
@@ -11397,6 +11401,22 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             reply_to_message_id=reply_to_message_id or getattr(source, "message_id", None),
         )
 
+    def _thread_metadata_for_session_source(
+        self,
+        session_key: Optional[str],
+        source,
+        reply_to_message_id: Optional[str] = None,
+    ) -> Optional[Dict[str, Any]]:
+        metadata = self._thread_metadata_for_source(source, reply_to_message_id)
+        if metadata is not None:
+            return metadata
+
+        cached_source = self._get_cached_session_source(session_key or "")
+        if cached_source is None:
+            return None
+
+        return self._thread_metadata_for_source(cached_source, reply_to_message_id)
+
     def _thread_metadata_for_target(
         self,
         platform: Optional[Platform],
@@ -13409,7 +13429,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             else bool(_plat_streaming)
         )
 
-        _thread_metadata: Optional[Dict[str, Any]] = self._thread_metadata_for_source(source, event_message_id)
+        _thread_metadata: Optional[Dict[str, Any]] = self._thread_metadata_for_session_source(
+            session_key,
+            source,
+            event_message_id,
+        )
 
         if _streaming_enabled:
             try:
@@ -14394,7 +14418,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 "reply_to_message_id": event_message_id,
             }
         else:
-            _status_thread_metadata = self._thread_metadata_for_source(source, event_message_id) if _progress_thread_id else None
+            _status_thread_metadata = self._thread_metadata_for_session_source(
+                session_key,
+                source,
+                event_message_id,
+            )
 
         def _status_callback_sync(event_type: str, message: str) -> None:
             if not _status_adapter or not _run_still_current():

--- a/tests/gateway/test_session_source_cache.py
+++ b/tests/gateway/test_session_source_cache.py
@@ -1,0 +1,99 @@
+from collections import OrderedDict
+
+from gateway.config import Platform
+from gateway.run import GatewayRunner
+from gateway.session import SessionSource, build_session_key
+
+
+def _runner() -> GatewayRunner:
+    runner = object.__new__(GatewayRunner)
+    runner._session_sources = OrderedDict()
+    runner._session_sources_max = 512
+    return runner
+
+
+def _source(thread_id: str | None, message_id: str = "msg-1") -> SessionSource:
+    return SessionSource(
+        platform=Platform.MATTERMOST,
+        chat_id="channel-1",
+        chat_type="channel",
+        user_id="user-1",
+        thread_id=thread_id,
+        message_id=message_id,
+    )
+
+
+def _telegram_topic_source(thread_id: str | None) -> SessionSource:
+    return SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="-1001",
+        chat_type="group",
+        user_id="user-1",
+        thread_id=thread_id,
+        message_id="telegram-msg",
+    )
+
+
+def test_cache_session_source_if_absent_preserves_original_thread_source():
+    runner = _runner()
+
+    original = _source("thread-root", "thread-msg")
+    interrupting = _source(None, "channel-msg")
+    session_key = build_session_key(original)
+
+    assert build_session_key(interrupting) != session_key
+
+    runner._cache_session_source_if_absent(session_key, original)
+    runner._cache_session_source_if_absent(session_key, interrupting)
+
+    cached = runner._get_cached_session_source(session_key)
+    assert cached is not None
+    assert cached.thread_id == "thread-root"
+    assert cached.message_id == "thread-msg"
+
+
+def test_thread_metadata_for_session_source_falls_back_to_cached_thread():
+    runner = _runner()
+    session_key = build_session_key(_source("thread-root"))
+
+    runner._cache_session_source_if_absent(session_key, _source("thread-root"))
+
+    metadata = runner._thread_metadata_for_session_source(
+        session_key,
+        _source(None, "channel-msg"),
+        reply_to_message_id="channel-msg",
+    )
+
+    assert metadata == {"thread_id": "thread-root"}
+
+
+def test_thread_metadata_for_session_source_prefers_current_thread():
+    runner = _runner()
+    session_key = build_session_key(_source("thread-root"))
+
+    runner._cache_session_source_if_absent(session_key, _source("thread-root"))
+
+    metadata = runner._thread_metadata_for_session_source(
+        session_key,
+        _source("current-thread"),
+        reply_to_message_id="current-msg",
+    )
+
+    assert metadata == {"thread_id": "current-thread"}
+
+
+def test_thread_metadata_for_session_source_falls_back_to_cached_telegram_topic():
+    runner = _runner()
+    session_key = build_session_key(_telegram_topic_source("topic-42"))
+
+    runner._cache_session_source_if_absent(
+        session_key,
+        _telegram_topic_source("topic-42"),
+    )
+
+    metadata = runner._thread_metadata_for_session_source(
+        session_key,
+        _telegram_topic_source(None),
+    )
+
+    assert metadata == {"thread_id": "topic-42"}


### PR DESCRIPTION
## Summary
Preserve the cached source for a gateway session when a pending or interrupting event is replayed under the original session key, so streaming and status sends can keep Mattermost/Telegram thread routing instead of falling back to the flat channel.

## Changes
- keep the first cached `SessionSource` for an active session instead of replacing it during replayed follow-ups
- add `_thread_metadata_for_session_source()` so current-source thread metadata still wins, while missing metadata falls back to the cached session source
- add regression coverage for Mattermost thread fallback, current-thread precedence, and Telegram topic fallback

Fixes #47445.

## Validation
- `uv sync --frozen --extra dev --extra messaging`
- `uv run scripts/run_tests.sh tests/gateway/test_session_source_cache.py tests/gateway/test_mattermost.py tests/gateway/test_stream_consumer_thread_routing.py -- --tb=long` (71 passed)
- `uv run ruff check gateway/run.py tests/gateway/test_session_source_cache.py`
- `uv run ty check tests/gateway/test_session_source_cache.py`
- `git diff --check`
- `git diff --check origin/main...HEAD`
