### PR TITLE
fix(auth): serialize concurrent xAI OAuth write-through to global root

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -951,6 +951,7 @@ def _auth_lock_path() -> Path:
 
 
 _auth_lock_holder = threading.local()
+_global_root_lock_holder = threading.local()
 
 
 @contextmanager
@@ -4037,14 +4038,20 @@ def _write_through_xai_oauth_to_global_root(state: Dict[str, Any]) -> None:
             except Exception:
                 return
     try:
-        if global_path.exists():
-            global_store = _load_auth_store(global_path)
-        else:
-            global_store = {}
-        if not isinstance(global_store, dict):
-            return
-        _store_provider_state(global_store, "xai-oauth", dict(state), set_active=False)
-        _save_auth_store(global_store, global_path)
+        with _file_lock(
+            global_path.with_suffix(".lock"),
+            _global_root_lock_holder,
+            AUTH_LOCK_TIMEOUT_SECONDS,
+            "Timed out waiting for global root auth store lock",
+        ):
+            if global_path.exists():
+                global_store = _load_auth_store(global_path)
+            else:
+                global_store = {}
+            if not isinstance(global_store, dict):
+                return
+            _store_provider_state(global_store, "xai-oauth", dict(state), set_active=False)
+            _save_auth_store(global_store, global_path)
     except Exception as exc:  # pragma: no cover - best effort
         logger.debug("xAI OAuth: write-through to global root failed: %s", exc)
 

--- a/tests/hermes_cli/test_xai_oauth_writethrough.py
+++ b/tests/hermes_cli/test_xai_oauth_writethrough.py
@@ -14,6 +14,7 @@ boundary, so they exercise the actual atomic write path.
 """
 
 import json
+import threading
 
 import pytest
 
@@ -167,3 +168,64 @@ def test_write_through_failure_does_not_break_profile_save(profile_and_root, mon
 
     profile = _read_store(profile_path)
     assert profile["providers"]["xai-oauth"]["tokens"]["refresh_token"] == "r"
+
+
+def test_concurrent_write_through_does_not_lose_second_token(profile_and_root):
+    """Concurrent write-throughs must serialize; final root holds one complete token set."""
+    profile_path, root_path = profile_and_root
+    _write_store(profile_path, {"version": 1, "providers": {}})
+    _write_store(
+        root_path,
+        {
+            "version": 1,
+            "providers": {
+                "xai-oauth": {
+                    "tokens": {"access_token": "old-access", "refresh_token": "old-refresh"}
+                }
+            },
+        },
+    )
+
+    state_a = {
+        "tokens": {"access_token": "token-A-access", "refresh_token": "token-A-refresh"},
+        "auth_mode": "oauth_pkce",
+    }
+    state_b = {
+        "tokens": {"access_token": "token-B-access", "refresh_token": "token-B-refresh"},
+        "auth_mode": "oauth_pkce",
+    }
+
+    errors = []
+    barrier = threading.Barrier(2)
+
+    def write_a():
+        try:
+            barrier.wait()
+            auth._write_through_xai_oauth_to_global_root(state_a)
+        except Exception as exc:
+            errors.append(exc)
+
+    def write_b():
+        try:
+            barrier.wait()
+            auth._write_through_xai_oauth_to_global_root(state_b)
+        except Exception as exc:
+            errors.append(exc)
+
+    t1 = threading.Thread(target=write_a)
+    t2 = threading.Thread(target=write_b)
+    t1.start()
+    t2.start()
+    t1.join()
+    t2.join()
+
+    assert not errors, f"Threads raised exceptions: {errors}"
+
+    root = _read_store(root_path)
+    final_tokens = root["providers"]["xai-oauth"]["tokens"]
+
+    token_a = {"access_token": "token-A-access", "refresh_token": "token-A-refresh"}
+    token_b = {"access_token": "token-B-access", "refresh_token": "token-B-refresh"}
+    assert final_tokens == token_a or final_tokens == token_b, (
+        f"Expected one complete token set (A or B), got corrupted mix: {final_tokens}"
+    )


### PR DESCRIPTION
## What does this PR do?

`_write_through_xai_oauth_to_global_root()` syncs a freshly-refreshed xAI OAuth token set from a profile store back to the global root `auth.json`. The function held the **profile-scoped** file lock while doing so, but performed the read-modify-write on the **global** `auth.json` without acquiring any lock on that file.

When two profiles refresh their xAI tokens concurrently:
1. Profile A and Profile B each read the global `auth.json` (both see `refresh_token_old`)
2. Profile A writes `refresh_token_A` → global file
3. Profile B writes `refresh_token_B` → global file (**overwrites A's token**)
4. Profile A's in-memory state has `refresh_token_A` but the file now has `refresh_token_B`
5. Next refresh attempt by Profile A: `invalid_grant` → forced re-authentication

## Related Issue

Adjacent to the already-fixed concurrent refresh race in #10147 / #15120 (Nous OAuth). Same class of bug, new code path.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] 🔒 Security fix

## Changes Made

- **`hermes_cli/auth.py`**: Added `_global_root_lock_holder = threading.local()` (separate from `_auth_lock_holder` to prevent `_file_lock`'s reentrancy depth counter from silently skipping the global lock when called from within a profile lock). Wrapped the entire read-modify-write in `_write_through_xai_oauth_to_global_root()` inside `_file_lock(global_path.with_suffix(".lock"), _global_root_lock_holder, AUTH_LOCK_TIMEOUT_SECONDS, ...)`, matching the `.lock` sidecar convention used by `_auth_lock_path()`.

- **`tests/hermes_cli/test_xai_oauth_writethrough.py`**: Added `test_concurrent_write_through_does_not_lose_second_token` — fires two threads simultaneously via `threading.Barrier(2)`, asserts the final global `auth.json` holds exactly one complete token set (not a corrupted mix of `access_token` from A and `refresh_token` from B).

## How to Test

```
pytest tests/hermes_cli/test_xai_oauth_writethrough.py -v
```

All 5 tests pass.

## Checklist

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11 + WSL2 Ubuntu