### PR TITLE
feat(cli): show session token usage on model switch

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -6633,6 +6633,17 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
         _cprint(f"  ✓ Model switched: {result.new_model}")
         _cprint(f"    Provider: {provider_label}")
 
+        # Show session token usage at model switch
+        if self.agent is not None:
+            _in = getattr(self.agent, "session_input_tokens", 0) or 0
+            _out = getattr(self.agent, "session_output_tokens", 0) or 0
+            _total = getattr(self.agent, "session_total_tokens", 0) or 0
+            if _total > 0:
+                _cprint(
+                    f"    Session tokens so far: {_in:,} in / {_out:,} out"
+                    f" / {_total:,} total"
+                )
+
         # Context: always resolve via the provider-aware chain so Codex OAuth,
         # Copilot, and Nous-enforced caps win over the raw models.dev entry
         # (e.g. gpt-5.5 is 1.05M on openai but 272K on Codex OAuth).
@@ -6890,6 +6901,17 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
         provider_label = result.provider_label or result.target_provider
         _cprint(f"  ✓ Model switched: {result.new_model}")
         _cprint(f"    Provider: {provider_label}")
+
+        # Show session token usage at model switch
+        if self.agent is not None:
+            _in = getattr(self.agent, "session_input_tokens", 0) or 0
+            _out = getattr(self.agent, "session_output_tokens", 0) or 0
+            _total = getattr(self.agent, "session_total_tokens", 0) or 0
+            if _total > 0:
+                _cprint(
+                    f"    Session tokens so far: {_in:,} in / {_out:,} out"
+                    f" / {_total:,} total"
+                )
 
         # Context: always resolve via the provider-aware chain so Codex OAuth,
         # Copilot, and Nous-enforced caps win over the raw models.dev entry


### PR DESCRIPTION
## Summary

When the user switches model via `/model`, the confirmation block now includes accumulated session token counts alongside the existing provider / context / cost metadata:

```
  ✓ Model switched: claude-opus-4
    Provider: anthropic
    Session tokens so far: 12,345 in / 4,210 out / 16,555 total
    Context: 200,000 tokens
    ...
```

The line is suppressed when `total == 0` (i.e. a switch that happens before any API call is made) so a fresh session stays clean.

## What was changed

`cli.py` — both `_apply_model_switch_result` code paths (interactive TUI picker and direct `/model` command) get the same block reading `session_input_tokens`, `session_output_tokens`, `session_total_tokens` from `self.agent` via `getattr` (safe against older agent versions).

## Why

After `/model`, the user is context-switching to a potentially different provider/pricing tier. Knowing how many tokens were already spent on the previous model is directly useful for cost awareness and for deciding whether to start a fresh session.

## Test

No automated test added — the display path is covered by existing `/model` integration tests. Verified locally that:
- Switching after zero turns → no token line shown
- Switching mid-session → correct counts appear
