### PR TITLE
fix(browser): decode subprocess output resiliently on non-UTF-8 locales

### DIFF
--- a/tests/tools/test_browser_encoding.py
+++ b/tests/tools/test_browser_encoding.py
@@ -41,3 +41,22 @@ def test_read_subprocess_text_plain_utf8_unaffected(tmp_path):
     p.write_text("正常 UTF-8 텍스트 ✓", encoding="utf-8")
     out = bt._read_subprocess_text(str(p))
     assert out == "正常 UTF-8 텍스트 ✓"
+
+
+@pytest.mark.parametrize(
+    "raw",
+    [
+        pytest.param(b"line1\r\nline2\r\n", id="crlf"),
+        pytest.param(b"line1\rline2\r", id="lone_cr"),
+        pytest.param(b"a\r\nb \xb2\xbb\rc", id="mixed_crlf_cr_non_utf8"),
+    ],
+)
+def test_read_subprocess_text_preserves_newline_bytes(tmp_path, raw):
+    # Text mode defaults to universal-newline translation (newline=None), which
+    # rewrites \r\n and lone \r to \n and would break the lossless round-trip
+    # the docstring promises (the Windows non-UTF-8 case this targets). The read
+    # must preserve the raw CR/CRLF bytes verbatim.
+    p = tmp_path / "out.txt"
+    p.write_bytes(raw)
+    out = bt._read_subprocess_text(str(p))
+    assert out.encode("utf-8", errors="surrogateescape") == raw

--- a/tests/tools/test_browser_encoding.py
+++ b/tests/tools/test_browser_encoding.py
@@ -1,0 +1,43 @@
+"""Regression tests for #47456: browser subprocess output must decode
+resiliently on non-UTF-8 system locales (GBK/Shift-JIS/EUC-KR) instead of
+raising UnicodeDecodeError."""
+
+import pytest
+
+import tools.browser_tool as bt
+
+
+# Bytes that are INVALID UTF-8 but valid in common Windows system locales.
+#   0xb2 0xbb  -> GBK    (the exact lead byte 0xb2 from the issue's traceback)
+#   0x82 0xa0  -> Shift-JIS (Japanese)
+#   0xb0 0xa1  -> EUC-KR  (Korean)
+_NON_UTF8 = [
+    pytest.param(b"\xb2\xbb", id="gbk"),
+    pytest.param(b"\x82\xa0", id="shift_jis"),
+    pytest.param(b"\xb0\xa1", id="euc_kr"),
+]
+
+
+@pytest.mark.parametrize("raw", _NON_UTF8)
+def test_read_subprocess_text_never_raises_on_non_utf8(tmp_path, raw):
+    p = tmp_path / "out.txt"
+    p.write_bytes(b'{"ok": true} ' + raw)
+    # Must not raise (the bug raised UnicodeDecodeError here).
+    out = bt._read_subprocess_text(str(p))
+    assert '{"ok": true}' in out
+
+
+def test_read_subprocess_text_roundtrips_bytes_losslessly(tmp_path):
+    # surrogateescape preserves the original bytes (reversible), unlike replace.
+    p = tmp_path / "out.txt"
+    raw = b"hello \xb2\xbb world"
+    p.write_bytes(raw)
+    out = bt._read_subprocess_text(str(p))
+    assert out.encode("utf-8", errors="surrogateescape") == raw
+
+
+def test_read_subprocess_text_plain_utf8_unaffected(tmp_path):
+    p = tmp_path / "out.txt"
+    p.write_text("正常 UTF-8 텍스트 ✓", encoding="utf-8")
+    out = bt._read_subprocess_text(str(p))
+    assert out == "正常 UTF-8 텍스트 ✓"

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -141,8 +141,13 @@ def _read_subprocess_text(path: str) -> str:
     tool non-functional (#47456). Decode with ``errors="surrogateescape"`` so
     arbitrary bytes round-trip losslessly and the call never raises; the
     ASCII/UTF-8 JSON control payload downstream is unaffected.
+
+    ``newline=""`` disables universal-newline translation so CR/CRLF bytes are
+    preserved verbatim — without it, text mode rewrites ``\r\n``/``\r`` to
+    ``\n``, which would break the lossless round-trip the docstring promises
+    (notably on Windows, the exact platform this resilient decode targets).
     """
-    with open(path, "r", encoding="utf-8", errors="surrogateescape") as f:
+    with open(path, "r", encoding="utf-8", errors="surrogateescape", newline="") as f:
         return f.read()
 
 

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -131,6 +131,21 @@ _SANE_PATH_DIRS = (
 _SANE_PATH = os.pathsep.join(_SANE_PATH_DIRS)
 
 
+def _read_subprocess_text(path: str) -> str:
+    """Read a browser subprocess's stdout/stderr temp file as text.
+
+    Browser child processes (Chrome, the agent-browser CLI) emit output in the
+    OS *system* locale, which on non-UTF-8 Windows installs (GBK / Shift-JIS /
+    EUC-KR) is not valid UTF-8. Decoding such bytes with a hardcoded
+    ``encoding="utf-8"`` raises ``UnicodeDecodeError`` and makes every browser
+    tool non-functional (#47456). Decode with ``errors="surrogateescape"`` so
+    arbitrary bytes round-trip losslessly and the call never raises; the
+    ASCII/UTF-8 JSON control payload downstream is unaffected.
+    """
+    with open(path, "r", encoding="utf-8", errors="surrogateescape") as f:
+        return f.read()
+
+
 @functools.lru_cache(maxsize=1)
 def _discover_homebrew_node_dirs() -> tuple[str, ...]:
     """Find Homebrew versioned Node.js bin directories (e.g. node@20, node@24).
@@ -924,8 +939,7 @@ def _run_chrome_fallback_command(
             proc.wait()
             return {"success": False, "error": f"Chrome fallback '{cmd}' timed out"}
         try:
-            with open(stdout_path, "r", encoding="utf-8") as f:
-                stdout = f.read().strip()
+            stdout = _read_subprocess_text(stdout_path).strip()
             if stdout:
                 return json.loads(stdout.split("\n")[-1])
         except Exception as exc:
@@ -2110,10 +2124,8 @@ def _run_browser_command(
             result = {"success": False, "error": f"Command timed out after {timeout} seconds"}
             # Fall through to fallback check below
         else:
-            with open(stdout_path, "r", encoding="utf-8") as f:
-                stdout = f.read()
-            with open(stderr_path, "r", encoding="utf-8") as f:
-                stderr = f.read()
+            stdout = _read_subprocess_text(stdout_path)
+            stderr = _read_subprocess_text(stderr_path)
             returncode = proc.returncode
 
             # Clean up temp files (best-effort)


### PR DESCRIPTION
## What does this PR do?

`browser_tool.py` reads browser subprocess stdout/stderr temp files with a hardcoded `encoding="utf-8"`. On Windows installs with a non-UTF-8 system locale (Chinese GBK, Japanese Shift-JIS, Korean EUC-KR), the browser child process emits output in that locale, so the read raises `UnicodeDecodeError` (`'utf-8' codec can't decode byte 0xb2 ...`) and makes `browser_navigate` and every other browser tool non-functional.

This routes all browser-subprocess output reads through a single `_read_subprocess_text()` helper that decodes with `errors="surrogateescape"`, so non-UTF-8 bytes round-trip losslessly and the read never raises. The ASCII/UTF-8 JSON control payload is unaffected.

## Related Issue

Fixes #47456

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/browser_tool.py`: added `_read_subprocess_text(path)` helper (utf-8 + `errors="surrogateescape"`).
- Routed all three browser-subprocess output reads through it: the Chrome-fallback `_run_chrome_fallback_command` stdout read (one site) and the main `_run_browser_command` stdout+stderr reads (two sites). The issue cited only the main-run sites; the Chrome-fallback path has the identical hardcoded-utf-8 read and the same crash, so this PR covers all three at the same root cause rather than leaving the fallback path reachable.
- `tests/tools/test_browser_encoding.py`: new parametrized regression test with GBK / Shift-JIS / EUC-KR byte cases proving the read no longer raises, a lossless-round-trip assertion, and a plain-UTF-8 regression guard.

Out of scope (left as-is, correctly): the file's other utf-8 opens read Hermes-written pid/config files and the kernel `/proc/1/cgroup`, which are guaranteed ASCII/UTF-8.

## How to Test

1. `uv run --with pytest --with pytest-xdist --with pytest-asyncio python3 -m pytest tests/tools/test_browser_encoding.py -v`
2. Fail-before/pass-after was verified: reverting the helper body to the strict `encoding="utf-8"` reproduces the issue's exact `UnicodeDecodeError: 'utf-8' codec can't decode byte 0xb2`; restoring `errors="surrogateescape"` makes all cases pass while the plain-UTF-8 case stays green throughout.
3. Adjacent `tests/tools/test_browser_hardening.py` + `tests/tools/test_browser_cleanup.py` still pass (30 tests).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the focused suite for the touched code and it passes (the new file plus adjacent browser tests)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS (the fix is locale-decode logic, verifiable headlessly)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Contract Protected

- **Invariant:** reading browser-subprocess stdout/stderr never raises `UnicodeDecodeError`; arbitrary (non-UTF-8) bytes are preserved losslessly.
- **Known-bad inputs covered:** GBK (`0xb2 0xbb`, the issue's exact lead byte), Shift-JIS (`0x82 0xa0`), EUC-KR (`0xb0 0xa1`).
- **Future-input coverage:** any byte sequence — `surrogateescape` maps every undecodable byte to a surrogate, so no byte value can raise.
- **Negative case:** plain UTF-8 (`正常 UTF-8 텍스트 ✓`) decodes unchanged (no lossy substitution).