### PR TITLE
skills: add coding-harness conductor skill

### DIFF
--- a/skills/software-development/coding-harness/SKILL.md
+++ b/skills/software-development/coding-harness/SKILL.md
@@ -1,0 +1,162 @@
+---
+name: coding-harness
+description: "Use when a coding task spans many steps, files, or a long session: imposes a phased execution loop, evidence-driven verification, and tracked falsifiable progress so long-horizon work doesn't drift, stall, or silently regress."
+version: 1.0.0
+author: Teddy Tennant
+license: MIT
+platforms: [linux, macos, windows]
+metadata:
+  hermes:
+    tags: [coding, long-horizon, harness, execution-loop, verification, orchestration, reliability]
+    related_skills: [plan, test-driven-development, systematic-debugging, requesting-code-review, subagent-driven-development]
+---
+
+# Coding Harness
+
+## Overview
+
+Long-horizon coding fails from **drift and unverified assumptions**, not from inability to
+write code. Over 50+ tool calls the agent forgets the original goal, acts on stale beliefs
+about the codebase, re-solves problems it already solved, and — worst — declares "done" on
+its own say-so when the build is actually broken.
+
+This skill is a **conductor**: it wraps a multi-step coding task in a structured loop, forces
+every increment to be proven against external reality, and keeps falsifiable state on disk so
+progress survives context compaction and interruptions. It trades a little raw speed for
+structure that holds up over a long session.
+
+The three pillars (adapted from agentic-harness-engineering / NexAU):
+
+1. **Structured execution loop** — discrete phases with explicit entry/exit criteria. You
+   always know which phase you are in and what proves you can leave it.
+2. **Evidence-driven verification** — the agent's belief that something works is never
+   sufficient. Only the *external* signal (build, test, lint, running the app) closes a step.
+3. **Falsifiable progress** — each increment records a prediction; the next verification keeps
+   it, reverts it, or marks it partial. No change is "trusted" until reality confirms it.
+
+This skill does NOT replace the per-phase skills — it orchestrates them. Defer to `plan` for
+planning, `test-driven-development` for the verify-first discipline, `systematic-debugging`
+when a verification fails, `requesting-code-review` for an independent verifier, and
+`subagent-driven-development` for delegation.
+
+## When to Use
+
+- The task spans **5+ distinct steps** or **multiple files / subsystems**.
+- It will run across a long session where context will fill and compact.
+- Correctness matters and "looks done" is not good enough (refactors, migrations, features
+  with tests, bug hunts across modules).
+- The user says things like "build X end-to-end", "migrate Y", "make Z reliable", or hands
+  you a multi-part spec.
+
+**Don't use for:** single-file edits, a one-line fix, a quick question, or anything finishable
+in under ~5 tool calls. The harness overhead is not worth it there.
+
+## The Execution Loop
+
+Work **one increment at a time** through these phases. Never skip VERIFY.
+
+| Phase | Action | Exit criterion |
+|-------|--------|----------------|
+| **SCOPE** | Restate the goal in your own words; list constraints, unknowns, success signals. Run the helper `init`. | Goal + done-definition written to state. |
+| **PLAN** | Break the goal into ordered, independently-verifiable increments. Use the `plan` skill. | An ordered increment list exists in state. |
+| **IMPLEMENT** | Take the next increment. Make the smallest change that could satisfy it. Record a prediction. | Code written; prediction recorded via `add-increment`. |
+| **VERIFY** | Run the *external* check for this increment (see verification-protocol). | Pass/fail/partial recorded via `record-verification`. |
+| **ATTRIBUTE** | Compare the result to the prediction. Verdict: keep / revert / partial. On fail → ROOT-CAUSE. | Verdict recorded; tree is in a known-good state. |
+| **ITERATE** | If increments remain, go to IMPLEMENT. If all done, do a final full-suite VERIFY and stop. | All increments kept; final verify green. |
+
+**ROOT-CAUSE (on VERIFY fail):** do not patch blindly. Switch to the `systematic-debugging`
+skill, find the actual cause, then either fix forward or revert the increment. A failed
+increment must return the tree to a known-good state before you move on.
+
+Full phase spec, transitions, and termination rules: `references/execution-loop.md`.
+
+## Harness State
+
+The loop's memory lives in `.hermes/coding-harness/state.json` in the workspace, managed by
+the helper script. It is the single source of truth that survives context compaction — re-read
+it (`status`) whenever you lose the thread or resume after an interruption.
+
+```bash
+HS="python3 skills/software-development/coding-harness/scripts/harness_state.py"
+# (use the absolute path to the script; it writes ./.hermes/coding-harness/state.json by default)
+
+$HS init "Migrate auth from sessions to JWT, all tests green"
+$HS add-increment "Add JWT issue/verify helpers" --predict "new unit tests pass" --risk "breaks existing session test"
+$HS record-verification ch_001 pass --note "pytest tests/auth -q: 14 passed"
+$HS status
+```
+
+State holds: the goal + done-definition, the ordered increment list, each increment's
+prediction / risk / verification result / verdict, and a running log. See
+`references/change-manifest.md` for the schema and a worked example.
+
+## Verification Protocol (the core discipline)
+
+**Never mark an increment done on self-report.** The single most common long-horizon failure
+is the agent believing it succeeded when the external test says otherwise. Always close the
+loop with a signal the agent does not author:
+
+- **Build / compile** — the command exits 0.
+- **Tests** — the relevant suite passes; for new behavior, write the test first (`test-driven-development`).
+- **Lint / typecheck** — clean (or no new findings vs. baseline).
+- **Run it** — for behavior the test suite can't cover, actually run the app/CLI and observe.
+
+Cross-check belief vs. reality: if you *expected* pass and got fail (or vice-versa), that gap
+is the most valuable signal in the loop — investigate it, don't paper over it.
+
+For high-stakes increments, spawn an **independent verifier subagent** (no agent should verify
+its own work) — defer to `requesting-code-review`. Full protocol and per-task-type proof
+standards: `references/verification-protocol.md`.
+
+## Falsifiable Progress
+
+Every increment is a hypothesis. When you `add-increment`, state `predicted_impact` (what
+should get better) and the at-risk regression (what might break). After VERIFY, the verdict is:
+
+- **keep** — prediction held; advance.
+- **revert** — change was ineffective or caused a regression; undo it, log the lesson.
+- **partial** — partially worked; refine and re-verify.
+
+This makes regressions visible immediately and stops the agent from accreting changes it can't
+account for. Verdicts are recorded in state and form the audit trail of the whole task.
+
+## Tool Orchestration
+
+- **Parallel vs. sequential:** independent read-only ops (reading several files, separate
+  greps) → fire concurrently in one turn. Edits/commands touching the **same path** → run
+  sequentially to avoid races (matches Hermes's own `tool_executor.py` heuristic). Never
+  parallelize two writes to the same file.
+- **Delegate** large, independent sub-investigations or fan-out work to subagents
+  (`subagent-driven-development`) — keep the main context focused on the loop, not on raw
+  search output.
+- **Context discipline:** before context fills, checkpoint to state (`add-increment` /
+  `status` capture progress) so a compaction can't lose the plan. Prefer running a command and
+  reading its summary over pasting huge outputs into context. This mirrors the compaction /
+  long-output middleware that keeps the AHE loop in a valid state.
+
+## Common Pitfalls
+
+1. **Declaring done without running anything.** "The code looks correct" is not verification.
+   Run the external check every time.
+2. **Skipping ATTRIBUTE.** If you don't compare result to prediction, silent regressions
+   accumulate. Record a verdict for every increment.
+3. **Big-bang increments.** A change that touches ten things can't be verified or reverted
+   cleanly. Keep increments small and independently checkable.
+4. **Patching a failing verify without root-causing.** Switch to `systematic-debugging`; a
+   symptom fix usually breaks something else.
+5. **Letting state go stale.** If `status` doesn't match the working tree, the harness is
+   lying to you. Update state as you go, not at the end.
+6. **Re-restating instead of resuming.** After a compaction, run `status` and continue — don't
+   re-plan from scratch and lose verified progress.
+7. **Using the harness for trivial tasks.** Overhead with no payoff. See "When to Use".
+
+## Verification Checklist
+
+- [ ] `init` run with a concrete, testable done-definition
+- [ ] Work proceeded one small increment at a time
+- [ ] Every increment has a recorded prediction AND an external verification result
+- [ ] Every VERIFY used a signal the agent did not author (build/test/lint/run)
+- [ ] Every failed verify was root-caused (not blind-patched) and the tree returned to green
+- [ ] Final full-suite verification passed
+- [ ] `status` matches the actual working tree at the end
+- [ ] High-stakes changes got an independent reviewer (`requesting-code-review`)

--- a/skills/software-development/coding-harness/SKILL.md
+++ b/skills/software-development/coding-harness/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: coding-harness
-description: "Use when a coding task spans many steps, files, or a long session: imposes a phased execution loop, evidence-driven verification, and tracked falsifiable progress so long-horizon work doesn't drift, stall, or silently regress."
+description: Run long multi-step work as verified increments.
 version: 1.0.0
-author: Teddy Tennant
+author: Teddy Tennant (@teddytennant)
 license: MIT
 platforms: [linux, macos, windows]
 metadata:
@@ -74,7 +74,8 @@ Full phase spec, transitions, and termination rules: `references/execution-loop.
 
 The loop's memory lives in `.hermes/coding-harness/state.json` in the workspace, managed by
 the helper script. It is the single source of truth that survives context compaction — re-read
-it (`status`) whenever you lose the thread or resume after an interruption.
+it (`status`) whenever you lose the thread or resume after an interruption. Drive the script
+with the `terminal` tool:
 
 ```bash
 HS="python3 skills/software-development/coding-harness/scripts/harness_state.py"
@@ -117,15 +118,19 @@ should get better) and the at-risk regression (what might break). After VERIFY, 
 - **revert** — change was ineffective or caused a regression; undo it, log the lesson.
 - **partial** — partially worked; refine and re-verify.
 
+Only a `pass` verification may end in `keep`. `record-verification` rejects `fail --verdict
+keep` (and `partial --verdict keep`), so a failed increment can never be counted as complete
+or dropped from the pending list — it stays next in line until it passes or is reverted.
+
 This makes regressions visible immediately and stops the agent from accreting changes it can't
 account for. Verdicts are recorded in state and form the audit trail of the whole task.
 
 ## Tool Orchestration
 
-- **Parallel vs. sequential:** independent read-only ops (reading several files, separate
-  greps) → fire concurrently in one turn. Edits/commands touching the **same path** → run
-  sequentially to avoid races (matches Hermes's own `tool_executor.py` heuristic). Never
-  parallelize two writes to the same file.
+- **Parallel vs. sequential:** independent read-only ops (several `read_file` calls, separate
+  `search_files` queries) → fire concurrently in one turn. `patch` / `terminal` calls touching
+  the **same path** → run sequentially to avoid races (matches Hermes's own
+  `tool_executor.py` heuristic). Never parallelize two writes to the same file.
 - **Delegate** large, independent sub-investigations or fan-out work to subagents
   (`subagent-driven-development`) — keep the main context focused on the loop, not on raw
   search output.

--- a/skills/software-development/coding-harness/references/change-manifest.md
+++ b/skills/software-development/coding-harness/references/change-manifest.md
@@ -1,0 +1,69 @@
+# Change Manifest — schema and worked example
+
+Every increment is a **falsifiable hypothesis**: it states up front what should improve and
+what might break, and the next verification renders a verdict. This is the agent-facing form of
+the agentic-harness-engineering Change Manifest (`references/HARNESS.md`). The
+`harness_state.py` helper persists this structure to `.hermes/coding-harness/state.json`; this
+file documents the shape so you can read/extend it directly when needed.
+
+## State file schema
+
+```json
+{
+  "manifest_version": "1.0",
+  "goal": "Migrate auth from sessions to JWT; all auth tests green and login still works",
+  "created_at": "<iso8601, stamped by the helper>",
+  "increments": [
+    {
+      "change_id": "ch_001",
+      "summary": "Add JWT issue/verify helpers in auth/jwt.py",
+      "predicted_impact": {
+        "expected": "new unit tests in tests/auth/test_jwt.py pass",
+        "at_risk": "tests/auth/test_session.py may break if it shares config"
+      },
+      "verification": {
+        "status": "pass",
+        "note": "pytest tests/auth -q -> 14 passed, 0 failed",
+        "verdict": "keep"
+      }
+    }
+  ],
+  "log": [
+    "<iso8601> init: goal set",
+    "<iso8601> add-increment ch_001: Add JWT issue/verify helpers",
+    "<iso8601> verify ch_001: pass (keep)"
+  ]
+}
+```
+
+## Field meanings
+
+| Field | Required | Meaning |
+|-------|----------|---------|
+| `goal` | ✅ | The falsifiable done-definition from SCOPE. |
+| `increments[].change_id` | ✅ | Auto-assigned `ch_NNN`. Use it in `record-verification`. |
+| `increments[].summary` | ✅ | What this increment changes (and where). |
+| `predicted_impact.expected` | ✅ | **What should get better** — the success signal. |
+| `predicted_impact.at_risk` | recommended | **What might break** — the regression to watch. |
+| `verification.status` | set at VERIFY | `pending` / `pass` / `fail` / `partial`. |
+| `verification.note` | recommended | The **actual command + outcome** (external proof). |
+| `verification.verdict` | set at ATTRIBUTE | `keep` / `revert` / `partial`. |
+
+## The three verdicts
+
+- **keep** — prediction held (or the change is sound and verified). Advance to the next
+  increment.
+- **revert** — ineffective or caused a regression. Undo the change so the tree returns to
+  known-good, and write the lesson into the log so you don't retry the same thing.
+- **partial** — partially worked. Refine the change and re-verify; do not advance on a partial.
+
+## Why falsifiable
+
+Forcing a prediction before implementing, then checking it, does three things:
+1. Surfaces regressions the moment they happen instead of at the end.
+2. Stops the agent accreting changes it can't account for ("why is this here?").
+3. Produces an audit trail (the `log`) that a fresh post-compaction context — or a human — can
+   replay to understand exactly what was tried and what reality said about it.
+
+A change you can't state a prediction for is a change you don't understand well enough to make.
+Break it down further.

--- a/skills/software-development/coding-harness/references/execution-loop.md
+++ b/skills/software-development/coding-harness/references/execution-loop.md
@@ -1,0 +1,101 @@
+# Execution Loop — full specification
+
+The loop is a small state machine. You are always in exactly one phase and you only leave it
+when its **exit criterion** is met. Adapted from the agentic-harness-engineering iteration loop
+(`evolve.py`), which runs snapshot → evaluate → analyze → root-cause → attribute → evolve →
+verify/commit each iteration. Here the same shape drives a single coding task.
+
+```
+        ┌─────────┐
+        │  SCOPE  │  goal + done-definition
+        └────┬────┘
+             v
+        ┌─────────┐
+        │  PLAN   │  ordered, independently-verifiable increments
+        └────┬────┘
+             v
+   ┌──> ┌───────────┐
+   │    │ IMPLEMENT │  smallest change for next increment + prediction
+   │    └────┬──────┘
+   │         v
+   │    ┌─────────┐
+   │    │ VERIFY  │  run the EXTERNAL check
+   │    └────┬────┘
+   │         v
+   │    ┌───────────┐      fail     ┌────────────┐
+   │    │ ATTRIBUTE │ ───────────>  │ ROOT-CAUSE │ (systematic-debugging)
+   │    └────┬──────┘               └─────┬──────┘
+   │         │ keep                       │ fix-forward / revert
+   │         v                            │
+   │    increments remain? ──yes──────────┘
+   │         │ no
+   │         v
+   │    ┌──────────────┐
+   └─no─│ FINAL VERIFY │  full suite green ?
+        └──────┬───────┘
+               │ yes
+               v
+             DONE
+```
+
+## Phase contracts
+
+### SCOPE
+- **Input:** the user's request.
+- **Do:** restate the goal in your own words. Enumerate constraints, unknowns, and the
+  concrete signals that will prove success (which tests, what behavior, what command exits 0).
+- **Exit:** `harness_state.py init "<done-definition>"` has been run. The done-definition must
+  be falsifiable — "all auth tests pass and login still works" not "auth is better".
+
+### PLAN
+- **Input:** the scoped goal.
+- **Do:** decompose into an ordered list of increments. Each increment must be independently
+  verifiable (you can prove it works without the later ones) and small enough to revert
+  cleanly. Use the `plan` skill for the decomposition discipline.
+- **Exit:** the ordered increment list is captured (in the plan artifact and/or as the intended
+  sequence you will feed to `add-increment`).
+
+### IMPLEMENT
+- **Input:** the next un-started increment.
+- **Do:** make the *smallest* change that could satisfy it. For new behavior, write the test
+  first (`test-driven-development`). Before/while editing, record the increment and its
+  prediction with `add-increment ... --predict ... --risk ...`.
+- **Exit:** code is written and the increment (with prediction) exists in state.
+
+### VERIFY
+- **Input:** the just-implemented increment.
+- **Do:** run the external check appropriate to it (see `verification-protocol.md`). Capture
+  the actual command and its result.
+- **Exit:** `record-verification <id> <pass|fail|partial> --note "<command + outcome>"`.
+
+### ATTRIBUTE
+- **Input:** the verification result + the recorded prediction.
+- **Do:** compare them. A surprise (predicted pass → got fail, or predicted regression →
+  didn't happen) is signal — note it. Assign a verdict: **keep** (advance), **revert** (undo,
+  log the lesson), **partial** (refine, re-verify).
+- **Exit:** verdict recorded and the working tree is in a known-good state (failing increments
+  are reverted or fixed before moving on).
+
+### ROOT-CAUSE (only on fail)
+- Switch to `systematic-debugging`. Find the actual cause before touching code again. Then
+  return to IMPLEMENT (fix forward) or revert the increment. Never blind-patch a failing check.
+
+### FINAL VERIFY
+- When no increments remain, run the **full** relevant suite (not just the last increment's
+  test) plus any end-to-end / run-the-app check. Drift between increments only shows up here.
+- **Exit:** full suite green → DONE. Any failure re-enters ROOT-CAUSE.
+
+## Termination rules
+
+Stop the loop when **any** of:
+- All increments are `keep` and FINAL VERIFY is green → success.
+- An increment is fundamentally blocked (missing access, ambiguous spec) → stop and ask the
+  user; record the blocker in state. Do not thrash.
+- You have reverted the same increment twice without progress → stop, summarize what you tried
+  (state log has it), and ask for direction. Repeated identical attempts are a loop, not work.
+
+## Resuming after compaction / interruption
+
+Run `status` first. It reprints the goal, the increment list with verdicts, and the log. Pick
+up at the first increment without a `keep` verdict. Do **not** re-plan from scratch — that
+discards verified progress.

--- a/skills/software-development/coding-harness/references/verification-protocol.md
+++ b/skills/software-development/coding-harness/references/verification-protocol.md
@@ -1,0 +1,63 @@
+# Verification Protocol
+
+The defining rule of this harness: **an increment is only done when a signal the agent did not
+author confirms it.** This is the agent-facing version of the agentic-harness-engineering
+`adb ask` step, where a separate verifier cross-references the agent's internal trace against
+the *external* test output to catch "the agent believed it succeeded when the verifier
+disagreed" (`evolve.py` `DEFAULT_DEBUG_QUERY_K1`).
+
+## What counts as proof, by task type
+
+| Task type | Acceptable proof | Not proof |
+|-----------|------------------|-----------|
+| Bug fix | A test that failed before and passes now | "I can see the bug is fixed" |
+| New feature | New tests pass + existing suite still green | The code reads correctly |
+| Refactor | Full existing suite green, behavior unchanged | "Pure refactor, can't break" |
+| Build/config | `build` / `compile` exits 0 on a clean tree | It built last time |
+| Performance | A measurement before vs. after | "This should be faster" |
+| CLI/UI behavior | Actually running it and observing output | The handler looks right |
+| Lint/types | Tool reports clean or no-new-findings vs. baseline | Eyeballing the diff |
+
+## The belief-vs-reality cross-check
+
+After every VERIFY, compare three things:
+1. What you **predicted** would happen (from `add-increment`).
+2. What you **believe** happened (your read of the change).
+3. What the **external signal actually reported**.
+
+When (3) disagrees with (1) or (2), that gap is the highest-value information in the loop:
+- Predicted pass, got fail → your model of the code is wrong. Root-cause before continuing.
+- Predicted fail/regression, got pass → either the risk wasn't real or the check didn't
+  exercise it. Confirm the check actually covers the at-risk path before trusting the pass.
+- "Looks done" but the suite is red → classic self-report failure. The suite wins, always.
+
+Record the actual command and its outcome in the verification note. Future-you (post-compaction)
+trusts the recorded external result, not a vague "passed".
+
+## Baseline awareness
+
+Before declaring a regression, know the baseline. If a test was already failing before your
+change, your increment didn't break it — capture the pre-change suite state once at SCOPE (or
+before the first risky increment) so VERIFY can distinguish *new* failures from pre-existing
+ones. Don't chase red that you didn't cause (but do note it).
+
+## Independent verifier subagent (high-stakes increments)
+
+For changes that are risky, security-relevant, or hard to test directly, do not rely on your
+own verification — **no agent should verify its own work** (the core principle of
+`requesting-code-review`). Spawn a fresh-context reviewer subagent and give it:
+
+- The diff / changed files.
+- The increment's stated goal and prediction.
+- The done-definition from state.
+- An instruction to run the build/tests itself and report pass/fail with evidence, and to
+  look specifically for the at-risk regression you recorded.
+
+Fresh context finds what the implementing context misses. Treat a reviewer "fail" as a real
+VERIFY fail → ROOT-CAUSE.
+
+## Final verification
+
+The per-increment checks can each pass while the whole is broken (integration drift). FINAL
+VERIFY runs the full suite + an end-to-end exercise of the feature. Only a green FINAL VERIFY
+closes the task.

--- a/skills/software-development/coding-harness/scripts/harness_state.py
+++ b/skills/software-development/coding-harness/scripts/harness_state.py
@@ -1,0 +1,255 @@
+#!/usr/bin/env python3
+"""harness_state.py — on-disk state for the coding-harness execution loop.
+
+Single source of truth for a long-horizon coding task: the goal/done-definition,
+the ordered list of increments (each a falsifiable hypothesis), and a running log.
+Survives context compaction — re-read with `status` whenever you lose the thread.
+
+Stdlib only. Cross-platform. The agent drives this via the `terminal` tool.
+
+Usage:
+    harness_state.py init "<done-definition>" [--force]
+    harness_state.py add-increment "<summary>" [--predict TEXT] [--risk TEXT]
+    harness_state.py record-verification <change_id> <pass|fail|partial>
+                         [--note TEXT] [--verdict keep|revert|partial]
+    harness_state.py status
+    harness_state.py --self-test
+
+State file defaults to ./.hermes/coding-harness/state.json
+(override with --state PATH or env CODING_HARNESS_STATE).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import tempfile
+from datetime import datetime, timezone
+from pathlib import Path
+
+MANIFEST_VERSION = "1.0"
+DEFAULT_REL_PATH = Path(".hermes") / "coding-harness" / "state.json"
+DEFAULT_VERDICT = {"pass": "keep", "fail": "revert", "partial": "partial"}
+
+
+def _now() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="seconds")
+
+
+def _state_path(args: argparse.Namespace) -> Path:
+    override = getattr(args, "state", None) or os.environ.get("CODING_HARNESS_STATE")
+    return Path(override) if override else DEFAULT_REL_PATH
+
+
+def _load(path: Path) -> dict:
+    if not path.exists():
+        sys.exit(
+            f"error: no state at {path}. Run `init` first "
+            f"(or pass --state / set CODING_HARNESS_STATE)."
+        )
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        sys.exit(f"error: cannot read state at {path}: {exc}")
+
+
+def _save(path: Path, state: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    # Atomic write: temp file in the same dir, then replace.
+    fd, tmp = tempfile.mkstemp(dir=str(path.parent), suffix=".tmp")
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as fh:
+            json.dump(state, fh, indent=2, ensure_ascii=False)
+            fh.write("\n")
+        os.replace(tmp, path)
+    except BaseException:
+        try:
+            os.unlink(tmp)
+        except OSError:
+            pass
+        raise
+
+
+def _next_change_id(state: dict) -> str:
+    return f"ch_{len(state['increments']) + 1:03d}"
+
+
+def _find(state: dict, change_id: str) -> dict:
+    for inc in state["increments"]:
+        if inc["change_id"] == change_id:
+            return inc
+    sys.exit(f"error: no increment {change_id!r} in state.")
+
+
+# --- commands -------------------------------------------------------------
+
+
+def cmd_init(args: argparse.Namespace) -> None:
+    path = _state_path(args)
+    if path.exists() and not args.force:
+        sys.exit(f"error: state already exists at {path}. Use --force to overwrite.")
+    state = {
+        "manifest_version": MANIFEST_VERSION,
+        "goal": args.goal,
+        "created_at": _now(),
+        "increments": [],
+        "log": [f"{_now()} init: goal set"],
+    }
+    _save(path, state)
+    print(f"initialized {path}\ngoal: {args.goal}")
+
+
+def cmd_add_increment(args: argparse.Namespace) -> None:
+    path = _state_path(args)
+    state = _load(path)
+    change_id = _next_change_id(state)
+    state["increments"].append(
+        {
+            "change_id": change_id,
+            "summary": args.summary,
+            "predicted_impact": {
+                "expected": args.predict or "",
+                "at_risk": args.risk or "",
+            },
+            "verification": {"status": "pending", "note": "", "verdict": ""},
+        }
+    )
+    state["log"].append(f"{_now()} add-increment {change_id}: {args.summary}")
+    _save(path, state)
+    print(change_id)
+
+
+def cmd_record_verification(args: argparse.Namespace) -> None:
+    path = _state_path(args)
+    state = _load(path)
+    inc = _find(state, args.change_id)
+    verdict = args.verdict or DEFAULT_VERDICT[args.status]
+    inc["verification"] = {
+        "status": args.status,
+        "note": args.note or "",
+        "verdict": verdict,
+    }
+    state["log"].append(
+        f"{_now()} verify {args.change_id}: {args.status} ({verdict})"
+    )
+    _save(path, state)
+    print(f"{args.change_id}: {args.status} -> {verdict}")
+
+
+def _render(state: dict) -> str:
+    lines = []
+    lines.append(f"GOAL: {state['goal']}")
+    lines.append(f"created: {state.get('created_at', '?')}")
+    incs = state["increments"]
+    done = sum(1 for i in incs if i["verification"]["verdict"] == "keep")
+    lines.append(f"increments: {len(incs)} ({done} kept)")
+    lines.append("")
+    for inc in incs:
+        v = inc["verification"]
+        status = v["status"] or "pending"
+        verdict = f" -> {v['verdict']}" if v["verdict"] else ""
+        lines.append(f"[{inc['change_id']}] {status}{verdict}  {inc['summary']}")
+        pi = inc["predicted_impact"]
+        if pi.get("expected"):
+            lines.append(f"    expect: {pi['expected']}")
+        if pi.get("at_risk"):
+            lines.append(f"    risk:   {pi['at_risk']}")
+        if v.get("note"):
+            lines.append(f"    proof:  {v['note']}")
+    pending = [i["change_id"] for i in incs if i["verification"]["verdict"] != "keep"]
+    lines.append("")
+    if pending:
+        lines.append(f"NEXT: resume at {pending[0]} (not yet kept)")
+    else:
+        lines.append("NEXT: all increments kept -> run FINAL VERIFY (full suite)")
+    return "\n".join(lines)
+
+
+def cmd_status(args: argparse.Namespace) -> None:
+    print(_render(_load(_state_path(args))))
+
+
+def cmd_self_test(_args: argparse.Namespace) -> None:
+    """Run a full init -> add -> verify -> status cycle in a temp dir."""
+    with tempfile.TemporaryDirectory() as tmp:
+        sp = Path(tmp) / "state.json"
+        ns = argparse.Namespace
+
+        cmd_init(ns(state=str(sp), goal="self-test goal", force=False))
+        assert sp.exists(), "init did not write state"
+
+        cmd_add_increment(
+            ns(state=str(sp), summary="first increment", predict="x passes", risk="y breaks")
+        )
+        state = json.loads(sp.read_text())
+        assert state["increments"][0]["change_id"] == "ch_001", "bad change_id"
+
+        cmd_record_verification(
+            ns(state=str(sp), change_id="ch_001", status="pass", note="ran tests", verdict=None)
+        )
+        state = json.loads(sp.read_text())
+        v = state["increments"][0]["verification"]
+        assert v["status"] == "pass" and v["verdict"] == "keep", "verdict not derived"
+        assert len(state["log"]) == 3, f"expected 3 log lines, got {len(state['log'])}"
+
+        out = _render(state)
+        assert "GOAL: self-test goal" in out
+        assert "[ch_001] pass -> keep" in out
+        assert "all increments kept" in out
+
+        # round-trip: reload is byte-stable
+        reloaded = json.loads(sp.read_text())
+        assert reloaded == state, "state not stable across reload"
+
+    print("self-test OK")
+
+
+# --- arg parsing ----------------------------------------------------------
+
+
+def build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    p.add_argument("--self-test", action="store_true", help="run an internal sanity cycle and exit")
+    p.add_argument("--state", help="path to state file (default ./.hermes/coding-harness/state.json)")
+    sub = p.add_subparsers(dest="command")
+
+    pi = sub.add_parser("init", help="create state with a done-definition")
+    pi.add_argument("goal")
+    pi.add_argument("--force", action="store_true", help="overwrite existing state")
+    pi.set_defaults(func=cmd_init)
+
+    pa = sub.add_parser("add-increment", help="append an increment (a falsifiable hypothesis)")
+    pa.add_argument("summary")
+    pa.add_argument("--predict", help="expected impact (success signal)")
+    pa.add_argument("--risk", help="at-risk regression to watch")
+    pa.set_defaults(func=cmd_add_increment)
+
+    pr = sub.add_parser("record-verification", help="record the external verification result")
+    pr.add_argument("change_id")
+    pr.add_argument("status", choices=["pass", "fail", "partial"])
+    pr.add_argument("--note", help="actual command + outcome (the external proof)")
+    pr.add_argument("--verdict", choices=["keep", "revert", "partial"], help="override derived verdict")
+    pr.set_defaults(func=cmd_record_verification)
+
+    ps = sub.add_parser("status", help="print goal, increments, and next step")
+    ps.set_defaults(func=cmd_status)
+
+    return p
+
+
+def main(argv: list[str] | None = None) -> None:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    if args.self_test:
+        cmd_self_test(args)
+        return
+    if not getattr(args, "command", None):
+        parser.print_help()
+        sys.exit(2)
+    args.func(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/software-development/coding-harness/scripts/harness_state.py
+++ b/skills/software-development/coding-harness/scripts/harness_state.py
@@ -15,6 +15,9 @@ Usage:
     harness_state.py status
     harness_state.py --self-test
 
+Only a `pass` verification may end in the `keep` verdict — a failed or partial
+increment stays pending until it passes or is reverted.
+
 State file defaults to ./.hermes/coding-harness/state.json
 (override with --state PATH or env CODING_HARNESS_STATE).
 """
@@ -32,6 +35,14 @@ from pathlib import Path
 MANIFEST_VERSION = "1.0"
 DEFAULT_REL_PATH = Path(".hermes") / "coding-harness" / "state.json"
 DEFAULT_VERDICT = {"pass": "keep", "fail": "revert", "partial": "partial"}
+# Only a passing verification may end in "keep" — that is what marks an increment
+# complete in _render(). A failed or partial increment stays pending until it passes
+# or is reverted, so a known-bad change can never be counted as done.
+ALLOWED_VERDICTS = {
+    "pass": ("keep", "partial", "revert"),
+    "fail": ("revert", "partial"),
+    "partial": ("partial", "revert"),
+}
 
 
 def _now() -> str:
@@ -126,6 +137,13 @@ def cmd_record_verification(args: argparse.Namespace) -> None:
     state = _load(path)
     inc = _find(state, args.change_id)
     verdict = args.verdict or DEFAULT_VERDICT[args.status]
+    allowed = ALLOWED_VERDICTS[args.status]
+    if verdict not in allowed:
+        sys.exit(
+            f"error: verdict {verdict!r} is not valid for status {args.status!r}. "
+            f"Allowed: {', '.join(allowed)}. Root-cause the failure and revert (or "
+            f"fix forward and re-verify) instead of keeping a known-bad increment."
+        )
     inc["verification"] = {
         "status": args.status,
         "note": args.note or "",
@@ -138,12 +156,22 @@ def cmd_record_verification(args: argparse.Namespace) -> None:
     print(f"{args.change_id}: {args.status} -> {verdict}")
 
 
+def _is_complete(inc: dict) -> bool:
+    """An increment counts as done only when reality agreed AND we kept it.
+
+    Checked here as well as at write time so a hand-edited state file cannot
+    smuggle a failed increment past the pending list.
+    """
+    v = inc["verification"]
+    return v.get("status") == "pass" and v.get("verdict") == "keep"
+
+
 def _render(state: dict) -> str:
     lines = []
     lines.append(f"GOAL: {state['goal']}")
     lines.append(f"created: {state.get('created_at', '?')}")
     incs = state["increments"]
-    done = sum(1 for i in incs if i["verification"]["verdict"] == "keep")
+    done = sum(1 for i in incs if _is_complete(i))
     lines.append(f"increments: {len(incs)} ({done} kept)")
     lines.append("")
     for inc in incs:
@@ -158,7 +186,7 @@ def _render(state: dict) -> str:
             lines.append(f"    risk:   {pi['at_risk']}")
         if v.get("note"):
             lines.append(f"    proof:  {v['note']}")
-    pending = [i["change_id"] for i in incs if i["verification"]["verdict"] != "keep"]
+    pending = [i["change_id"] for i in incs if not _is_complete(i)]
     lines.append("")
     if pending:
         lines.append(f"NEXT: resume at {pending[0]} (not yet kept)")
@@ -203,6 +231,26 @@ def cmd_self_test(_args: argparse.Namespace) -> None:
         reloaded = json.loads(sp.read_text())
         assert reloaded == state, "state not stable across reload"
 
+        # failure path: a failed increment must not be keepable, and must stay pending
+        cmd_add_increment(ns(state=str(sp), summary="second increment", predict=None, risk=None))
+        try:
+            cmd_record_verification(
+                ns(state=str(sp), change_id="ch_002", status="fail", note="", verdict="keep")
+            )
+        except SystemExit as exc:
+            assert "not valid for status" in str(exc), f"unexpected exit: {exc}"
+        else:  # pragma: no cover - guarded by the assert below
+            raise AssertionError("fail --verdict keep was accepted")
+
+        cmd_record_verification(
+            ns(state=str(sp), change_id="ch_002", status="fail", note="pytest: 1 failed", verdict=None)
+        )
+        state = json.loads(sp.read_text())
+        assert state["increments"][1]["verification"]["verdict"] == "revert", "fail should revert"
+        out = _render(state)
+        assert "increments: 2 (1 kept)" in out, out
+        assert "NEXT: resume at ch_002" in out, out
+
     print("self-test OK")
 
 
@@ -230,7 +278,11 @@ def build_parser() -> argparse.ArgumentParser:
     pr.add_argument("change_id")
     pr.add_argument("status", choices=["pass", "fail", "partial"])
     pr.add_argument("--note", help="actual command + outcome (the external proof)")
-    pr.add_argument("--verdict", choices=["keep", "revert", "partial"], help="override derived verdict")
+    pr.add_argument(
+        "--verdict",
+        choices=["keep", "revert", "partial"],
+        help="override derived verdict (only a `pass` may be kept)",
+    )
     pr.set_defaults(func=cmd_record_verification)
 
     ps = sub.add_parser("status", help="print goal, increments, and next step")

--- a/tests/skills/test_coding_harness_skill.py
+++ b/tests/skills/test_coding_harness_skill.py
@@ -1,0 +1,166 @@
+"""Tests for the coding-harness skill.
+
+Covers the hardline frontmatter rules for a shipped skill plus the harness
+state helper, including the invariant that a failed increment can never be
+recorded as kept (which is what marks an increment complete in `status`).
+"""
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+import re
+import sys
+from pathlib import Path
+
+import pytest
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SKILL_DIR = REPO_ROOT / "skills" / "software-development" / "coding-harness"
+SCRIPT_PATH = SKILL_DIR / "scripts" / "harness_state.py"
+
+
+@pytest.fixture(scope="module")
+def frontmatter() -> dict:
+    src = (SKILL_DIR / "SKILL.md").read_text(encoding="utf-8")
+    m = re.search(r"^---\n(.*?)\n---", src, re.DOTALL)
+    assert m, "SKILL.md missing YAML frontmatter"
+    return yaml.safe_load(m.group(1))
+
+
+@pytest.fixture(scope="module")
+def harness():
+    spec = importlib.util.spec_from_file_location("coding_harness_state", SCRIPT_PATH)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _ns(**kwargs) -> argparse.Namespace:
+    kwargs.setdefault("state", None)
+    return argparse.Namespace(**kwargs)
+
+
+@pytest.fixture()
+def state_file(tmp_path, harness) -> Path:
+    path = tmp_path / "state.json"
+    harness.cmd_init(_ns(state=str(path), goal="all tests green", force=False))
+    return path
+
+
+# --- frontmatter ----------------------------------------------------------
+
+
+def test_skill_dir_exists() -> None:
+    assert SKILL_DIR.is_dir(), f"missing skill dir: {SKILL_DIR}"
+
+
+def test_description_under_60_chars(frontmatter) -> None:
+    desc = frontmatter["description"]
+    assert len(desc) <= 60, f"description is {len(desc)} chars (hardline <=60): {desc!r}"
+    assert desc.endswith("."), f"description should end with a period: {desc!r}"
+
+
+def test_author_credits_contributor_with_handle(frontmatter) -> None:
+    author = frontmatter["author"]
+    assert "Teddy Tennant" in author, f"author should credit the contributor: {author!r}"
+    assert "@teddytennant" in author, f"author should carry the GitHub handle: {author!r}"
+
+
+def test_prose_names_native_hermes_tools() -> None:
+    """Shell utilities the agent already has wrapped must not headline the prose."""
+    body = (SKILL_DIR / "SKILL.md").read_text(encoding="utf-8")
+    prose = re.sub(r"```.*?```", "", body, flags=re.DOTALL)
+    assert not re.search(r"\bgreps?\b", prose), "use `search_files`, not grep, in prose"
+    assert "`search_files`" in prose
+    assert "`read_file`" in prose
+
+
+def test_shipped_reference_files_exist() -> None:
+    for name in ("execution-loop.md", "verification-protocol.md", "change-manifest.md"):
+        assert (SKILL_DIR / "references" / name).is_file(), f"missing reference: {name}"
+
+
+# --- harness_state helper -------------------------------------------------
+
+
+def test_init_then_add_increment_assigns_ids(harness, state_file) -> None:
+    harness.cmd_add_increment(
+        _ns(state=str(state_file), summary="add jwt helpers", predict="unit tests pass", risk="session test")
+    )
+    harness.cmd_add_increment(
+        _ns(state=str(state_file), summary="swap middleware", predict=None, risk=None)
+    )
+    state = json.loads(state_file.read_text(encoding="utf-8"))
+    assert [i["change_id"] for i in state["increments"]] == ["ch_001", "ch_002"]
+    assert state["increments"][0]["verification"]["status"] == "pending"
+
+
+def test_verdict_is_derived_from_status(harness, state_file) -> None:
+    harness.cmd_add_increment(_ns(state=str(state_file), summary="one", predict=None, risk=None))
+    harness.cmd_record_verification(
+        _ns(state=str(state_file), change_id="ch_001", status="pass", note="pytest -q: 14 passed", verdict=None)
+    )
+    state = json.loads(state_file.read_text(encoding="utf-8"))
+    assert state["increments"][0]["verification"]["verdict"] == "keep"
+
+
+@pytest.mark.parametrize("status", ["fail", "partial"])
+def test_non_passing_verification_cannot_be_kept(harness, state_file, status) -> None:
+    """Regression: `record-verification ch_001 fail --verdict keep` used to be accepted,
+    which let `status` count a known-broken increment as complete."""
+    harness.cmd_add_increment(_ns(state=str(state_file), summary="one", predict=None, risk=None))
+    with pytest.raises(SystemExit) as excinfo:
+        harness.cmd_record_verification(
+            _ns(state=str(state_file), change_id="ch_001", status=status, note="", verdict="keep")
+        )
+    assert "not valid for status" in str(excinfo.value)
+
+    state = json.loads(state_file.read_text(encoding="utf-8"))
+    assert state["increments"][0]["verification"]["status"] == "pending", "state must not be mutated"
+
+
+def test_failed_increment_stays_pending_in_status(harness, state_file) -> None:
+    harness.cmd_add_increment(_ns(state=str(state_file), summary="one", predict=None, risk=None))
+    harness.cmd_add_increment(_ns(state=str(state_file), summary="two", predict=None, risk=None))
+    harness.cmd_record_verification(
+        _ns(state=str(state_file), change_id="ch_001", status="pass", note="green", verdict=None)
+    )
+    harness.cmd_record_verification(
+        _ns(state=str(state_file), change_id="ch_002", status="fail", note="pytest -q: 1 failed", verdict=None)
+    )
+    out = harness._render(json.loads(state_file.read_text(encoding="utf-8")))
+    assert "increments: 2 (1 kept)" in out
+    assert "NEXT: resume at ch_002" in out
+
+
+def test_hand_edited_state_cannot_smuggle_a_failure_past_pending(harness, state_file) -> None:
+    """Defense in depth: `_render()` re-checks status, not just the verdict."""
+    harness.cmd_add_increment(_ns(state=str(state_file), summary="one", predict=None, risk=None))
+    state = json.loads(state_file.read_text(encoding="utf-8"))
+    state["increments"][0]["verification"] = {"status": "fail", "note": "", "verdict": "keep"}
+    out = harness._render(state)
+    assert "increments: 1 (0 kept)" in out
+    assert "NEXT: resume at ch_001" in out
+
+
+def test_init_refuses_to_clobber_without_force(harness, state_file) -> None:
+    with pytest.raises(SystemExit):
+        harness.cmd_init(_ns(state=str(state_file), goal="different goal", force=False))
+    harness.cmd_init(_ns(state=str(state_file), goal="different goal", force=True))
+    assert json.loads(state_file.read_text(encoding="utf-8"))["goal"] == "different goal"
+
+
+def test_record_verification_on_unknown_increment_errors(harness, state_file) -> None:
+    with pytest.raises(SystemExit):
+        harness.cmd_record_verification(
+            _ns(state=str(state_file), change_id="ch_999", status="pass", note="", verdict=None)
+        )
+
+
+def test_self_test_entrypoint_passes(harness, capsys) -> None:
+    harness.cmd_self_test(_ns())
+    assert "self-test OK" in capsys.readouterr().out


### PR DESCRIPTION
## What

Adds `coding-harness`, a *conductor* skill under `skills/software-development/` that makes the agent more reliable on long-horizon coding tasks (multi-step features, migrations, cross-module bug hunts) by imposing structure rather than relying on the model to hold everything in context.

## The three pillars

1. **Structured execution loop** — `SCOPE → PLAN → IMPLEMENT → VERIFY → ATTRIBUTE → ITERATE`, one small increment at a time, each phase with an explicit exit criterion.
2. **Evidence-driven verification** — every increment closes on an *external* signal (build/test/lint/run the app), never self-report. A belief-vs-reality cross-check catches the classic "agent thought it succeeded but the test disagreed" failure.
3. **Falsifiable progress** — each increment records a prediction + at-risk regression; the next verification yields keep/revert/partial, tracked on disk.

## Positioning

It orchestrates existing peers rather than duplicating them — `plan`, `test-driven-development`, `systematic-debugging`, `requesting-code-review`, `subagent-driven-development` — and adds what none of them do: the outer loop, cross-increment state, and the belief-vs-reality rule.

## Contents

- `SKILL.md` (~9k, peer-sized) + `references/{execution-loop,verification-protocol,change-manifest}.md`
- `scripts/harness_state.py` — stdlib-only CLI tracking goal/increments/verdicts at `.hermes/coding-harness/state.json`; `python3 scripts/harness_state.py --self-test` passes.

Frontmatter follows `hermes-agent-skill-authoring` conventions and the `skill_manager_tool.py` validator (name, description ≤1024 chars, ≤100k total).

Pattern adapted from agentic-harness-engineering / NexAU harness-evolution work.