### PR TITLE
feat(desktop): add answer navigation jump pill

### DIFF
--- a/apps/desktop/src/app/chat/scroll-to-bottom-button.test.tsx
+++ b/apps/desktop/src/app/chat/scroll-to-bottom-button.test.tsx
@@ -3,7 +3,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import { clearAllPrompts, setApprovalRequest } from '@/store/prompts'
 import { $activeSessionId } from '@/store/session'
-import { onScrollToBottomRequest, resetThreadScroll, setThreadAtBottom } from '@/store/thread-scroll'
+import { onScrollToBottomRequest, resetThreadScroll, setThreadAtBottom, setThreadJumpState } from '@/store/thread-scroll'
 
 import { ScrollToBottomButton } from './scroll-to-bottom-button'
 
@@ -51,6 +51,15 @@ describe('ScrollToBottomButton', () => {
 
     // Parked at bottom → control hidden, so it can't claim "approval needed".
     expect(screen.queryByRole('button')).toBeNull()
+  })
+
+  it('keeps answer navigation label when an approval is pending but still in view', () => {
+    pendingApproval()
+    setThreadJumpState({ target: 'answer-start', visible: true })
+    render(<ScrollToBottomButton />)
+
+    expect(screen.getByRole('button', { name: 'Answer start' })).toBeTruthy()
+    expect(screen.queryByText('Approval needed')).toBeNull()
   })
 
   it('re-arms sticky-bottom on click', () => {

--- a/apps/desktop/src/app/chat/scroll-to-bottom-button.tsx
+++ b/apps/desktop/src/app/chat/scroll-to-bottom-button.tsx
@@ -6,22 +6,24 @@ import { useI18n } from '@/i18n'
 import { triggerHaptic } from '@/lib/haptics'
 import { cn } from '@/lib/utils'
 import { $approvalRequest } from '@/store/prompts'
-import { $threadJumpButtonVisible, requestScrollToBottom } from '@/store/thread-scroll'
+import { $threadJumpState, $threadScrolledUp, requestThreadJump, type ThreadJumpTarget } from '@/store/thread-scroll'
 
 /**
- * Floating "jump to bottom" control. Sits centered just above the composer,
+ * Floating thread navigation control. Sits centered just above the composer,
  * clearing the out-of-flow status stack via the same measured-height CSS vars
  * the thread's bottom clearance uses (`--composer-measured-height` +
  * `--status-stack-measured-height`), so it never overlaps the queue / subagent
- * / background cards. Visible only while the user has scrolled meaningfully
- * away from the bottom; clicking re-arms sticky-bottom and pins the viewport.
+ * / background cards.
+ *
+ * Default behavior still supports the old bottom jump. For long latest answers,
+ * the thread viewport promotes the same pill to `Answer start` when the user is
+ * below the start, then flips it to `Answer end` when the user is already near
+ * the top of that answer. One control, no second sticky header.
  *
  * When the turn is BLOCKED on an approval, this same control morphs into an
  * "Approval needed" pill — the only response surface is the inline Run/Reject
  * bar on the parked tool row, which is always the bottom-most content, so the
- * existing scroll-to-bottom action lands the user right on it. One control, no
- * collision, no second scroll path (native scrollIntoView would scroll
- * overflow:hidden ancestors that can't scroll back and wreck the layout).
+ * bottom action lands the user right on it.
  *
  * Enter/exit motion lives in styles.css under `.thread-jump-button` — a
  * directional scale (contract in from 1.1, contract out to 0.9) keyed off
@@ -30,12 +32,16 @@ import { $threadJumpButtonVisible, requestScrollToBottom } from '@/store/thread-
  */
 export function ScrollToBottomButton() {
   const { t } = useI18n()
-  const visible = useStore($threadJumpButtonVisible)
+  const jump = useStore($threadJumpState)
+  const scrolledUp = useStore($threadScrolledUp)
   const request = useStore($approvalRequest)
+  const answerJumpVisible = jump.visible
+  const visible = scrolledUp || answerJumpVisible
   // Scrolled away while an approval is pending → the inline Run/Reject bar is
   // below the fold. Relabel so the user knows the session needs them, not just
   // that there's more to read.
-  const approval = visible && Boolean(request)
+  const approval = scrolledUp && Boolean(request)
+  const target: ThreadJumpTarget = approval ? 'bottom' : answerJumpVisible ? jump.target : 'bottom'
   const hasShownRef = useRef(false)
 
   if (visible) {
@@ -43,7 +49,16 @@ export function ScrollToBottomButton() {
   }
 
   const state = visible ? 'in' : hasShownRef.current ? 'out' : 'idle'
-  const label = approval ? t.assistant.approval.jumpToApproval : t.assistant.thread.scrollToBottom
+
+  const label = approval
+    ? t.assistant.approval.jumpToApproval
+    : target === 'answer-start'
+      ? t.assistant.thread.answerStart
+      : target === 'answer-end'
+        ? t.assistant.thread.answerEnd
+        : t.assistant.thread.scrollToBottom
+
+  const showText = approval || target !== 'bottom'
 
   return (
     <button
@@ -51,15 +66,21 @@ export function ScrollToBottomButton() {
       aria-label={label}
       className={cn(
         'thread-jump-button absolute left-1/2 z-20 grid place-items-center backdrop-blur-[0.75rem] [-webkit-backdrop-filter:blur(0.75rem)]',
-        approval
-          ? 'h-8 grid-flow-col gap-1.5 rounded-full border border-primary/40 bg-(--composer-fill) px-3 text-primary hover:bg-primary/10'
+        showText
+          ? cn(
+              'h-8 grid-flow-col gap-1.5 rounded-full border bg-(--composer-fill) px-3 text-xs font-medium shadow-sm',
+              approval
+                ? 'border-primary/40 text-primary hover:bg-primary/10'
+                : 'border-[color-mix(in_srgb,var(--dt-ring)_28%,var(--ui-stroke-secondary))] text-foreground/85 hover:bg-[color-mix(in_srgb,var(--dt-ring)_8%,var(--composer-fill))] hover:text-foreground'
+            )
           : 'size-8 rounded-full border border-border/65 bg-(--composer-fill) text-muted-foreground hover:text-foreground',
         !visible && 'pointer-events-none'
       )}
       data-state={state}
+      data-target={target}
       onClick={() => {
         triggerHaptic('selection')
-        requestScrollToBottom()
+        requestThreadJump(target)
       }}
       style={{
         bottom: 'calc(var(--composer-measured-height) + var(--status-stack-measured-height) + 0.625rem)'
@@ -67,8 +88,8 @@ export function ScrollToBottomButton() {
       tabIndex={visible ? 0 : -1}
       type="button"
     >
-      <Codicon name="arrow-down" size={approval ? '0.875rem' : '1rem'} />
-      {approval && <span className="text-xs font-medium">{label}</span>}
+      <Codicon name={target === 'answer-start' ? 'arrow-up' : 'arrow-down'} size={showText ? '0.875rem' : '1rem'} />
+      {showText && <span>{label}</span>}
     </button>
   )
 }

--- a/apps/desktop/src/components/assistant-ui/thread-list.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread-list.tsx
@@ -1,7 +1,7 @@
 import { ThreadPrimitive, useAuiEvent, useAuiState } from '@assistant-ui/react'
 import {
-  type CSSProperties,
   type ComponentProps,
+  type CSSProperties,
   type FC,
   memo,
   type ReactNode,
@@ -16,11 +16,15 @@ import { useStickToBottom } from 'use-stick-to-bottom'
 import { useI18n } from '@/i18n'
 import { cn } from '@/lib/utils'
 import {
-  onScrollToBottomRequest,
+  DEFAULT_THREAD_JUMP_STATE,
+  latestAnswerJumpState,
   onThreadEditClose,
   onThreadEditOpen,
+  onThreadJumpRequest,
   resetThreadScroll,
-  setThreadAtBottom
+  setThreadAtBottom,
+  setThreadJumpState,
+  type ThreadJumpTarget
 } from '@/store/thread-scroll'
 import { isSecondaryWindow } from '@/store/windows'
 
@@ -89,6 +93,42 @@ function buildGroups(signature: string): MessageGroup[] {
   return groups
 }
 
+const LATEST_ASSISTANT_SELECTOR = '[data-slot="aui_assistant-message-root"]'
+
+function latestAssistantMessage(viewport: HTMLElement): HTMLElement | null {
+  const messages = viewport.querySelectorAll<HTMLElement>(LATEST_ASSISTANT_SELECTOR)
+
+  return messages.length > 0 ? messages.item(messages.length - 1) : null
+}
+
+function latestAssistantGeometry(viewport: HTMLElement, answer: HTMLElement) {
+  const viewportRect = viewport.getBoundingClientRect()
+  const answerRect = answer.getBoundingClientRect()
+  const rectTop = answerRect.top - viewportRect.top + viewport.scrollTop
+
+  return {
+    answerHeight: answerRect.height || answer.offsetHeight,
+    answerTop: Number.isFinite(rectTop) ? rectTop : answer.offsetTop,
+    clientHeight: viewport.clientHeight,
+    scrollTop: viewport.scrollTop
+  }
+}
+
+function scrollTopForAnswerTarget(viewport: HTMLElement, answer: HTMLElement, target: ThreadJumpTarget): number | null {
+  if (target === 'bottom') {
+    return null
+  }
+
+  const { answerHeight, answerTop } = latestAssistantGeometry(viewport, answer)
+  const maxScrollTop = Math.max(0, viewport.scrollHeight - viewport.clientHeight)
+
+  if (target === 'answer-start') {
+    return Math.max(0, Math.min(answerTop - 16, maxScrollTop))
+  }
+
+  return Math.max(0, Math.min(answerTop + answerHeight - viewport.clientHeight + 16, maxScrollTop))
+}
+
 const ThreadMessageListInner: FC<ThreadMessageListProps> = ({
   clampToComposer,
   components,
@@ -145,15 +185,111 @@ const ThreadMessageListInner: FC<ThreadMessageListProps> = ({
   // sticky user bubble falls back to its ~4px default and slides under the OS
   // traffic lights.
   const secondaryTitlebarGap = 'calc(var(--titlebar-height) + 0.75rem)'
+
   const threadContentTopPad = secondaryWindow
     ? 'pt-[calc(var(--titlebar-height)+0.75rem)]'
     : 'pt-[calc(var(--titlebar-height)-0.5rem)]'
 
+  const updateLatestAnswerJumpState = useCallback(() => {
+    const viewport = scrollRef.current
+
+    if (!viewport) {
+      setThreadJumpState(DEFAULT_THREAD_JUMP_STATE)
+
+      return
+    }
+
+    const latestAnswer = latestAssistantMessage(viewport)
+
+    if (!latestAnswer) {
+      setThreadJumpState(DEFAULT_THREAD_JUMP_STATE)
+
+      return
+    }
+
+    setThreadJumpState(latestAnswerJumpState(latestAssistantGeometry(viewport, latestAnswer)))
+  }, [scrollRef])
+
   useEffect(() => setThreadAtBottom(isAtBottom), [isAtBottom])
   useEffect(() => () => resetThreadScroll(), [])
 
-  // Floating jump button (outside this subtree) → return to the bottom.
-  useEffect(() => onScrollToBottomRequest(() => void scrollToBottom()), [scrollToBottom])
+  // Keep the floating jump pill synced with the latest assistant answer's
+  // geometry. ResizeObserver catches streaming/layout growth; scroll catches the
+  // top/end flip as the user moves through the answer.
+  useEffect(() => {
+    const viewport = scrollRef.current
+
+    if (!viewport) {
+      setThreadJumpState(DEFAULT_THREAD_JUMP_STATE)
+
+      return
+    }
+
+    let rafId = 0
+
+    const scheduleUpdate = () => {
+      cancelAnimationFrame(rafId)
+      rafId = requestAnimationFrame(updateLatestAnswerJumpState)
+    }
+
+    scheduleUpdate()
+    viewport.addEventListener('scroll', scheduleUpdate, { passive: true })
+
+    let resizeObserver: ResizeObserver | null = null
+
+    if (typeof ResizeObserver !== 'undefined') {
+      resizeObserver = new ResizeObserver(scheduleUpdate)
+      resizeObserver.observe(viewport)
+
+      const content = viewport.querySelector<HTMLElement>('[data-slot="aui_thread-content"]')
+
+      if (content) {
+        resizeObserver.observe(content)
+      }
+    }
+
+    return () => {
+      cancelAnimationFrame(rafId)
+      viewport.removeEventListener('scroll', scheduleUpdate)
+      resizeObserver?.disconnect()
+    }
+  }, [messageSignature, renderBudget, scrollRef, updateLatestAnswerJumpState])
+
+  const handleThreadJump = useCallback(
+    (target: ThreadJumpTarget) => {
+      const viewport = scrollRef.current
+
+      if (!viewport || target === 'bottom') {
+        void scrollToBottom()
+
+        return
+      }
+
+      const latestAnswer = latestAssistantMessage(viewport)
+      const scrollTop = latestAnswer ? scrollTopForAnswerTarget(viewport, latestAnswer, target) : null
+
+      if (scrollTop == null) {
+        void scrollToBottom()
+
+        return
+      }
+
+      stopScroll()
+
+      if (typeof viewport.scrollTo === 'function') {
+        viewport.scrollTo({ behavior: 'smooth', top: scrollTop })
+      } else {
+        viewport.scrollTop = scrollTop
+      }
+
+      requestAnimationFrame(updateLatestAnswerJumpState)
+      window.setTimeout(updateLatestAnswerJumpState, 260)
+    },
+    [scrollRef, scrollToBottom, stopScroll, updateLatestAnswerJumpState]
+  )
+
+  // Floating jump button (outside this subtree) → latest answer start/end or bottom.
+  useEffect(() => onThreadJumpRequest(handleThreadJump), [handleThreadJump])
 
   const endEditHold = useCallback(() => {
     scrollRef.current?.removeAttribute('data-editing')

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -1739,6 +1739,8 @@ export const en: Translations = {
       readAloud: 'Read aloud',
       editMessage: 'Edit message',
       scrollToBottom: 'Scroll to bottom',
+      answerStart: 'Answer start',
+      answerEnd: 'Answer end',
       stop: 'Stop',
       restorePrevious: 'Restore previous checkpoint',
       restoreCheckpoint: 'Restore checkpoint',

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -1379,6 +1379,8 @@ export interface Translations {
       readAloud: string
       editMessage: string
       scrollToBottom: string
+      answerStart: string
+      answerEnd: string
       stop: string
       restorePrevious: string
       restoreCheckpoint: string

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -1918,6 +1918,8 @@ export const zh: Translations = {
       readAloud: '朗读',
       editMessage: '编辑消息',
       scrollToBottom: '滚动到底部',
+      answerStart: '答案开头',
+      answerEnd: '答案结尾',
       stop: '停止',
       restorePrevious: '恢复上一个检查点',
       restoreCheckpoint: '恢复检查点',

--- a/apps/desktop/src/store/thread-scroll.test.ts
+++ b/apps/desktop/src/store/thread-scroll.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest'
+
+import { DEFAULT_THREAD_JUMP_STATE, latestAnswerJumpState } from './thread-scroll'
+
+describe('latestAnswerJumpState', () => {
+  it('hides the jump pill for short answers', () => {
+    expect(
+      latestAnswerJumpState({
+        answerHeight: 300,
+        answerTop: 100,
+        clientHeight: 700,
+        scrollTop: 700
+      })
+    ).toEqual(DEFAULT_THREAD_JUMP_STATE)
+  })
+
+  it('jumps up to the answer start when parked near the bottom of a long answer', () => {
+    expect(
+      latestAnswerJumpState({
+        answerHeight: 1800,
+        answerTop: 240,
+        clientHeight: 700,
+        scrollTop: 1340
+      })
+    ).toEqual({ target: 'answer-start', visible: true })
+  })
+
+  it('jumps down to the answer end when already near the answer start', () => {
+    expect(
+      latestAnswerJumpState({
+        answerHeight: 1800,
+        answerTop: 240,
+        clientHeight: 700,
+        scrollTop: 300
+      })
+    ).toEqual({ target: 'answer-end', visible: true })
+  })
+
+  it('treats invalid geometry as hidden instead of producing a broken target', () => {
+    expect(
+      latestAnswerJumpState({
+        answerHeight: Number.NaN,
+        answerTop: 240,
+        clientHeight: 700,
+        scrollTop: 300
+      })
+    ).toEqual(DEFAULT_THREAD_JUMP_STATE)
+  })
+})

--- a/apps/desktop/src/store/thread-scroll.ts
+++ b/apps/desktop/src/store/thread-scroll.ts
@@ -5,10 +5,37 @@ import { atom, type WritableAtom } from 'nanostores'
 // subtree, so ThreadMessageList mirrors it into these atoms for the composer,
 // status stack, and floating jump button — all of which render OUTSIDE the thread.
 //
-// `$threadScrolledUp` dims the composer / status stack; `$threadJumpButtonVisible`
-// shows the floating jump control. Both track `!isAtBottom` today, but stay
-// separate so their thresholds can diverge again without touching consumers.
+// `$threadScrolledUp` dims the composer / status stack. `$threadJumpState`
+// describes the single floating navigation pill: legacy bottom jump, latest
+// answer start, or latest answer end. Keeping them separate lets the pill stay
+// visible at the bottom of a long answer without pretending the thread is
+// scrolled up.
 export const $threadScrolledUp = atom(false)
+
+export type ThreadJumpTarget = 'answer-end' | 'answer-start' | 'bottom'
+
+export interface ThreadJumpState {
+  target: ThreadJumpTarget
+  visible: boolean
+}
+
+export interface LatestAnswerJumpGeometry {
+  answerHeight: number
+  answerTop: number
+  clientHeight: number
+  scrollTop: number
+}
+
+export const DEFAULT_THREAD_JUMP_STATE: ThreadJumpState = { target: 'bottom', visible: false }
+
+const ANSWER_JUMP_MIN_HEIGHT_PX = 420
+const ANSWER_JUMP_MIN_VIEWPORT_RATIO = 0.95
+const ANSWER_JUMP_NEAR_START_PX = 120
+
+export const $threadJumpState = atom<ThreadJumpState>(DEFAULT_THREAD_JUMP_STATE)
+
+// Back-compat surface for any remaining consumers that only care about
+// visibility. New code should prefer `$threadJumpState`.
 export const $threadJumpButtonVisible = atom(false)
 
 // Skip no-op writes so subscribers don't churn on every scroll tick.
@@ -21,25 +48,78 @@ const setter = (target: WritableAtom<boolean>) => (value: boolean) => {
 const setScrolledUp = setter($threadScrolledUp)
 const setJumpButtonVisible = setter($threadJumpButtonVisible)
 
-export const setThreadAtBottom = (isAtBottom: boolean) => {
-  setScrolledUp(!isAtBottom)
-  setJumpButtonVisible(!isAtBottom)
+function syncJumpButtonVisible() {
+  setJumpButtonVisible($threadScrolledUp.get() || $threadJumpState.get().visible)
 }
 
-export const resetThreadScroll = () => setThreadAtBottom(true)
+export function latestAnswerJumpState(geometry: LatestAnswerJumpGeometry): ThreadJumpState {
+  const { answerHeight, answerTop, clientHeight, scrollTop } = geometry
+
+  if (
+    !Number.isFinite(answerHeight) ||
+    !Number.isFinite(answerTop) ||
+    !Number.isFinite(clientHeight) ||
+    !Number.isFinite(scrollTop) ||
+    answerHeight <= 0 ||
+    clientHeight <= 0
+  ) {
+    return DEFAULT_THREAD_JUMP_STATE
+  }
+
+  const usefulHeight = Math.max(ANSWER_JUMP_MIN_HEIGHT_PX, clientHeight * ANSWER_JUMP_MIN_VIEWPORT_RATIO)
+
+  if (answerHeight < usefulHeight) {
+    return DEFAULT_THREAD_JUMP_STATE
+  }
+
+  return {
+    target: scrollTop <= answerTop + ANSWER_JUMP_NEAR_START_PX ? 'answer-end' : 'answer-start',
+    visible: true
+  }
+}
+
+export const setThreadAtBottom = (isAtBottom: boolean) => {
+  setScrolledUp(!isAtBottom)
+  syncJumpButtonVisible()
+}
+
+export const setThreadJumpState = (state: ThreadJumpState) => {
+  const current = $threadJumpState.get()
+
+  if (current.visible !== state.visible || current.target !== state.target) {
+    $threadJumpState.set(state)
+  }
+
+  syncJumpButtonVisible()
+}
+
+export const resetThreadScroll = () => {
+  setThreadAtBottom(true)
+  setThreadJumpState(DEFAULT_THREAD_JUMP_STATE)
+}
 
 // Cross-component bridge: the jump button lives by the composer, the viewport's
-// `scrollToBottom` lives inside the thread. The bridge registers a handler; the
+// scroll owner lives inside the thread. The bridge registers a handler; the
 // button fires it. Mirrors the composer focus/insert emitter pattern.
-const handlers = new Set<() => void>()
+const handlers = new Set<(target: ThreadJumpTarget) => void>()
 
-export const onScrollToBottomRequest = (handler: () => void) => {
+export const onThreadJumpRequest = (handler: (target: ThreadJumpTarget) => void) => {
   handlers.add(handler)
 
   return () => void handlers.delete(handler)
 }
 
-export const requestScrollToBottom = () => handlers.forEach(handler => handler())
+export const requestThreadJump = (target = $threadJumpState.get().target) => handlers.forEach(handler => handler(target))
+
+// Legacy aliases for the old bottom-only control.
+export const onScrollToBottomRequest = (handler: () => void) =>
+  onThreadJumpRequest(target => {
+    if (target === 'bottom') {
+      handler()
+    }
+  })
+
+export const requestScrollToBottom = () => requestThreadJump('bottom')
 
 // Inline edit grows a sticky human bubble. Fire on pointerdown so the viewport
 // escapes stick-to-bottom before focus/layout; close clears the edit flag when

--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -907,6 +907,24 @@ canvas {
    prompt doesn't dominate the viewport. The clamp lifts only in the edit
    composer; expanding on read-only :focus-within ran on mousedown (before the
    swap) and fought stick-to-bottom when parked at the bottom. */
+.composer-human-message {
+  border-color: color-mix(in srgb, var(--dt-ring) 28%, var(--ui-stroke-tertiary)) !important;
+  background: color-mix(in srgb, var(--dt-user-bubble) 92%, var(--dt-ring) 8%) !important;
+  box-shadow:
+    inset 0 0.0625rem 0 color-mix(in srgb, #fff 8%, transparent),
+    0 0 0 0.0625rem color-mix(in srgb, var(--dt-ring) 12%, transparent),
+    0 0.75rem 1.75rem -1.25rem color-mix(in srgb, var(--dt-ring) 24%, transparent);
+}
+
+.composer-human-message:hover,
+.composer-human-message:focus-visible {
+  border-color: color-mix(in srgb, var(--dt-ring) 42%, var(--ui-stroke-secondary)) !important;
+  box-shadow:
+    inset 0 0.0625rem 0 color-mix(in srgb, #fff 10%, transparent),
+    0 0 0 0.0625rem color-mix(in srgb, var(--dt-ring) 18%, transparent),
+    0 0.875rem 2rem -1.2rem color-mix(in srgb, var(--dt-ring) 30%, transparent);
+}
+
 .sticky-human-clamp {
   cursor: pointer;
   max-height: calc(4 * var(--human-msg-line-height) * var(--conversation-text-font-size) + 0.15rem);


### PR DESCRIPTION
## Summary
- Add a contextual floating answer navigation pill for long latest assistant responses.
- Keep the legacy scroll-to-bottom and pending-approval jump behavior intact.
- Add a subtle outline/accent treatment to user prompt bubbles so prompts are easier to find while scanning a long thread.

## Behavior
- Shows `Answer start` when the latest assistant response is meaningfully taller than the viewport and the reader is below its start.
- Flips to `Answer end` when the reader is near the start of that latest response.
- Hides for short responses.
- Keeps pending approval labeling limited to the actual scrolled-away state so approvals already in view are not mislabeled.

## Verification
- `npm run test:ui -- src/app/chat/scroll-to-bottom-button.test.tsx src/store/thread-scroll.test.ts`
- `npm run typecheck`
- `npx eslint src/store/thread-scroll.ts src/store/thread-scroll.test.ts src/components/assistant-ui/thread-list.tsx src/app/chat/scroll-to-bottom-button.tsx src/app/chat/scroll-to-bottom-button.test.tsx src/i18n/types.ts src/i18n/en.ts src/i18n/zh.ts`
- `npm run build`
- Independent read-only code review passed after two regression fixes.
