### PR TITLE
fix(gateway): preserve session source and thread metadata across cross-thread interrupts

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -8285,7 +8285,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
         session_entry = self.session_store.get_or_create_session(source)
         session_key = session_entry.session_key
-        self._cache_session_source(session_key, source)
+        # Preserve original session source on resume — don't let the
+        # interrupting message's metadata overwrite the cached source.
+        # (Fixes #47445: cross-thread interrupt loses thread_id.)
+        if not self._get_cached_session_source(session_key):
+            self._cache_session_source(session_key, source)
         if self._is_telegram_topic_lane(source):
             try:
                 binding = self._session_db.get_telegram_topic_binding(
@@ -13410,6 +13414,18 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         )
 
         _thread_metadata: Optional[Dict[str, Any]] = self._thread_metadata_for_source(source, event_message_id)
+        # On session resume after cross-thread interrupt, the current source
+        # may carry the interrupting message's metadata (thread_id=None on
+        # channel-level posts).  Fall back to the cached original session
+        # source so streamed responses route to the correct thread.
+        # (Fixes #47445.)
+        if _thread_metadata is None:
+            _cached_meta_source = self._get_cached_session_source(session_key)
+            if _cached_meta_source is not None:
+                _thread_metadata = self._thread_metadata_for_source(
+                    _cached_meta_source,
+                    event_message_id,
+                )
 
         if _streaming_enabled:
             try:


### PR DESCRIPTION
## Summary

Two related fixes for `gateway/run.py` that prevent session routing corruption when a running agent session is interrupted by an inbound message from a **different** thread or channel.

Closes #47445

## Problem

When Hermes is streaming a response in Thread A, and a new message arrives in Channel B (or Thread C), the gateway:

1. **Interrupts** the running agent
2. **Overwrites** `session_source` with the interrupting message's metadata
3. **Resumes** the session with wrong `thread_id`/`message_id`
4. Responses go to the **wrong destination** (or lose thread routing entirely)

## Changes

### Fix 1: Preserve original session source (`_handle_message_with_agent`)

Only cache the session source on first creation - do not overwrite it with the interrupting message's metadata on resume.

### Fix 2: Fall back to cached source for thread metadata (`_run_agent_via_proxy`)

When the interrupting message is a channel-level post (no thread_id), `_thread_metadata_for_source()` returns `None`. Fall back to the cached original session source to recover correct thread routing.

## Testing

Both patches can be verified on Mattermost with multi-thread workflows: 1. Start a conversation in Thread A (agent streaming) 2. Send a message from Channel B mid-stream 3. Verify the original session resumes with correct thread routing 4. Verify subsequent messages in Thread A still route to Thread A