### PR TITLE
fix(anthropic): salvage text-embedded tool calls not promoted to tool_use

### DIFF
--- a/agent/transports/anthropic.py
+++ b/agent/transports/anthropic.py
@@ -4,10 +4,91 @@ Delegates to the existing adapter functions in agent/anthropic_adapter.py.
 This transport owns format conversion and normalization — NOT client lifecycle.
 """
 
-from typing import Any, Dict, List, Optional
+import re
+from typing import Any, Dict, List, Optional, Tuple
 
 from agent.transports.base import ProviderTransport
 from agent.transports.types import NormalizedResponse
+
+# ── Text-embedded tool-call salvage (issue: opus-4-8 antml: prefix drop) ──
+# Anthropic OAuth turns tool calls into structured ``tool_use`` blocks ONLY
+# when the model emits the namespaced ``antml:invoke`` markup correctly.
+# Some Claude builds (observed: opus-4-8) intermittently drop the ``antml:``
+# namespace prefix and emit a bare ``<invoke name="...">`` block instead.
+# The API can't recognise it, so it comes back as a plain ``text`` block with
+# ``stop_reason="end_turn"`` and NO ``tool_use`` — the agent loop then treats
+# the turn as a final answer and halts WITHOUT running the tool.
+#
+# These regexes recover a *complete* invoke block (closing tag required) from
+# assistant text so the transport can re-promote it to a real tool call.
+# Both the namespaced (``antml:invoke``) and bare (``invoke``) spellings are
+# matched, as are self-closing and value-bearing parameters.
+_SALVAGE_INVOKE_RE = re.compile(
+    r"<(?:antml:)?invoke\s+name\s*=\s*\"([^\"]+)\"\s*>(.*?)</(?:antml:)?invoke\s*>",
+    re.DOTALL | re.IGNORECASE,
+)
+_SALVAGE_PARAM_RE = re.compile(
+    r"<(?:antml:)?parameter\s+name\s*=\s*\"([^\"]+)\"\s*>(.*?)</(?:antml:)?parameter\s*>",
+    re.DOTALL | re.IGNORECASE,
+)
+
+
+def _coerce_salvaged_value(raw: str) -> Any:
+    """Best-effort type recovery for a text-extracted parameter value.
+
+    Structured ``tool_use`` blocks carry already-typed JSON (ints, bools,
+    lists). Text-embedded parameters are always strings, so we try
+    ``json.loads`` to mirror what the structured call would have contained
+    (``"61"`` -> ``61``, ``"true"`` -> ``True``, ``'{"a": 1}'`` -> dict).
+    Anything that isn't valid JSON (file paths, shell commands, prose) is
+    kept as the trimmed string — identical to how the model would pass it.
+    """
+    import json
+
+    s = raw.strip()
+    if s == "":
+        return ""
+    try:
+        return json.loads(s)
+    except (ValueError, TypeError):
+        return s
+
+
+def salvage_tool_calls_from_text(text: str) -> Tuple[List[Dict[str, Any]], str]:
+    """Recover bare ``<invoke>`` tool-call markup left in assistant text.
+
+    Returns ``(calls, cleaned_text)`` where ``calls`` is a list of
+    ``{"name": str, "arguments": {...}}`` dicts (empty when nothing is
+    salvageable) and ``cleaned_text`` is ``text`` with every salvaged
+    invoke block removed so the raw markup never reaches the user.
+
+    Only *complete* blocks (with a closing ``</invoke>``) are salvaged;
+    a truncated tail is left untouched so a half-streamed call is not
+    executed with partial arguments.
+    """
+    if not text or "invoke" not in text.lower():
+        return [], text
+
+    calls: List[Dict[str, Any]] = []
+
+    def _replace(match: "re.Match") -> str:
+        name = (match.group(1) or "").strip()
+        body = match.group(2) or ""
+        if not name:
+            # No tool name — leave the original markup in place.
+            return match.group(0)
+        args: Dict[str, Any] = {}
+        for pname, pval in _SALVAGE_PARAM_RE.findall(body):
+            key = (pname or "").strip()
+            if key:
+                args[key] = _coerce_salvaged_value(pval)
+        calls.append({"name": name, "arguments": args})
+        return ""
+
+    cleaned = _SALVAGE_INVOKE_RE.sub(_replace, text)
+    if not calls:
+        return [], text
+    return calls, cleaned.strip()
 
 
 class AnthropicTransport(ProviderTransport):
@@ -152,6 +233,31 @@ class AnthropicTransport(ProviderTransport):
                 )
 
         finish_reason = self._STOP_REASON_MAP.get(response.stop_reason, "stop")
+
+        # ── Salvage bare <invoke> markup the API failed to promote ──────────
+        # When a Claude build drops the ``antml:`` namespace prefix the API
+        # returns the tool call as plain text with no ``tool_use`` block and
+        # ``stop_reason="end_turn"``. Without recovery the agent loop halts
+        # WITHOUT running the tool. If we got no structured tool_calls but the
+        # text carries a complete invoke block, re-promote it to a real call
+        # and re-map the finish reason so the loop keeps executing. Skipped
+        # entirely when the turn already produced structured tool_calls (the
+        # healthy path) so well-formed turns pay nothing.
+        if not tool_calls and text_parts:
+            _joined = "\n".join(text_parts)
+            _salvaged, _cleaned = salvage_tool_calls_from_text(_joined)
+            if _salvaged:
+                import json as _json
+                for _sc in _salvaged:
+                    tool_calls.append(
+                        ToolCall(
+                            id=None,
+                            name=_sc["name"],
+                            arguments=_json.dumps(_sc.get("arguments", {})),
+                        )
+                    )
+                text_parts = [_cleaned] if _cleaned else []
+                finish_reason = self._STOP_REASON_MAP.get("tool_use", "tool_calls")
 
         provider_data = {}
         if reasoning_details:

--- a/tests/agent/transports/test_anthropic_invoke_salvage.py
+++ b/tests/agent/transports/test_anthropic_invoke_salvage.py
@@ -1,0 +1,232 @@
+"""Tests for AnthropicTransport bare-invoke tool-call salvage.
+
+Regression coverage for the opus-4-8 ``antml:`` namespace-drop bug:
+Anthropic OAuth promotes tool calls to structured ``tool_use`` blocks ONLY
+when the model emits the namespaced invoke markup. Some Claude builds
+intermittently drop the ``antml:`` prefix and emit a bare invoke block,
+which the API returns as a plain ``text`` block with
+``stop_reason="end_turn"`` and NO ``tool_use``. The agent loop then treats
+the turn as a final answer and halts WITHOUT running the tool (reproduced
+as round 2-A in the model-routing test matrix).
+
+``normalize_response`` now salvages a complete invoke block from assistant
+text, re-promotes it to a real ``ToolCall``, and re-maps the finish reason
+to ``tool_calls`` so the loop keeps executing.
+
+The markup tokens are assembled from ``_TOK`` fragments rather than written
+as literals, so the test source itself never carries raw invoke markup that
+a tool-call parser could accidentally grab.
+"""
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+
+import pytest
+
+from agent.transports import get_transport
+from agent.transports.types import NormalizedResponse
+from agent.transports.anthropic import (
+    salvage_tool_calls_from_text,
+    _coerce_salvaged_value,
+)
+
+
+# ── Markup token builders (avoid literal invoke markup in source) ────────
+_LT, _GT, _SL, _NS = "<", ">", "/", "antml:"
+
+
+def _inv(name, body, ns=False):
+    pre = _NS if ns else ""
+    return f"{_LT}{pre}invoke name=\"{name}\"{_GT}{body}{_LT}{_SL}{pre}invoke{_GT}"
+
+
+def _param(name, val, ns=False):
+    pre = _NS if ns else ""
+    return f"{_LT}{pre}parameter name=\"{name}\"{_GT}{val}{_LT}{_SL}{pre}parameter{_GT}"
+
+
+# ── Pure-function tests: salvage_tool_calls_from_text ────────────────────
+
+class TestSalvageFromText:
+
+    def test_bare_invoke_single_param(self):
+        text = "Reading the file now.\n" + _inv(
+            "read_file", _param("path", "/etc/os-release")
+        )
+        calls, cleaned = salvage_tool_calls_from_text(text)
+        assert len(calls) == 1
+        assert calls[0]["name"] == "read_file"
+        assert calls[0]["arguments"] == {"path": "/etc/os-release"}
+        assert "invoke" not in cleaned
+        assert "Reading the file now." in cleaned
+
+    def test_namespaced_invoke_also_salvaged(self):
+        text = _inv("terminal", _param("command", "ls -la", ns=True), ns=True)
+        calls, cleaned = salvage_tool_calls_from_text(text)
+        assert len(calls) == 1
+        assert calls[0]["name"] == "terminal"
+        assert calls[0]["arguments"] == {"command": "ls -la"}
+        assert cleaned == ""
+
+    def test_multiple_params_with_type_coercion(self):
+        body = (
+            _param("path", "/home/x/config.yaml")
+            + _param("offset", "61")
+            + _param("limit", "90")
+        )
+        text = _inv("read_file", body)
+        calls, _ = salvage_tool_calls_from_text(text)
+        assert calls[0]["arguments"] == {
+            "path": "/home/x/config.yaml",
+            "offset": 61,
+            "limit": 90,
+        }
+        # offset/limit must be real ints, mirroring a structured tool_use.
+        assert isinstance(calls[0]["arguments"]["offset"], int)
+
+    def test_multiple_invoke_blocks(self):
+        text = (
+            _inv("read_file", _param("path", "/a"))
+            + "\nand then\n"
+            + _inv("terminal", _param("command", "echo hi"))
+        )
+        calls, cleaned = salvage_tool_calls_from_text(text)
+        assert [c["name"] for c in calls] == ["read_file", "terminal"]
+        assert "and then" in cleaned
+
+    def test_no_markup_returns_text_unchanged(self):
+        text = "Just a normal answer, no tools here."
+        calls, cleaned = salvage_tool_calls_from_text(text)
+        assert calls == []
+        assert cleaned == text
+
+    def test_truncated_block_not_salvaged(self):
+        # Open tag with no closing </invoke> — must NOT execute a partial call.
+        text = "Working: " + _LT + "invoke name=\"terminal\"" + _GT + _param(
+            "command", "rm -rf /"
+        )
+        calls, cleaned = salvage_tool_calls_from_text(text)
+        assert calls == []
+        assert cleaned == text
+
+    def test_empty_param_value(self):
+        text = _inv("todo", _param("status", ""))
+        calls, _ = salvage_tool_calls_from_text(text)
+        assert calls[0]["arguments"] == {"status": ""}
+
+    def test_invoke_with_no_params(self):
+        text = _inv("session_search", "")
+        calls, _ = salvage_tool_calls_from_text(text)
+        assert calls == [{"name": "session_search", "arguments": {}}]
+
+
+# ── _coerce_salvaged_value ───────────────────────────────────────────────
+
+class TestCoerceSalvagedValue:
+
+    def test_int(self):
+        assert _coerce_salvaged_value("61") == 61
+
+    def test_bool(self):
+        assert _coerce_salvaged_value("true") is True
+
+    def test_json_object(self):
+        assert _coerce_salvaged_value('{"a": 1}') == {"a": 1}
+
+    def test_plain_path_string(self):
+        assert _coerce_salvaged_value("/etc/passwd") == "/etc/passwd"
+
+    def test_shell_command_string(self):
+        assert _coerce_salvaged_value("ls -la /tmp") == "ls -la /tmp"
+
+    def test_whitespace_trimmed(self):
+        assert _coerce_salvaged_value("  hello  ") == "hello"
+
+    def test_empty(self):
+        assert _coerce_salvaged_value("   ") == ""
+
+
+# ── End-to-end: normalize_response promotes salvaged calls ───────────────
+
+class TestNormalizeResponseSalvage:
+
+    @pytest.fixture
+    def transport(self):
+        import agent.transports.anthropic  # noqa: F401
+        return get_transport("anthropic_messages")
+
+    def test_bare_invoke_in_text_promoted_to_tool_call(self, transport):
+        """The core 2-A repro: end_turn + text-only invoke -> real tool call."""
+        leaked = "Let me read it.\n" + _inv(
+            "read_file", _param("path", "/etc/os-release")
+        )
+        r = SimpleNamespace(
+            content=[SimpleNamespace(type="text", text=leaked)],
+            stop_reason="end_turn",
+            usage=SimpleNamespace(input_tokens=10, output_tokens=5),
+            model="claude-opus-4-8",
+        )
+        nr = transport.normalize_response(r)
+        assert nr.tool_calls is not None
+        assert len(nr.tool_calls) == 1
+        tc = nr.tool_calls[0]
+        assert tc.name == "read_file"
+        assert json.loads(tc.arguments) == {"path": "/etc/os-release"}
+        # Finish reason re-mapped so the agent loop keeps going.
+        assert nr.finish_reason == "tool_calls"
+        # Raw markup scrubbed from user-visible content.
+        assert nr.content is None or "invoke" not in nr.content
+        assert nr.content is None or "Let me read it." in nr.content
+
+    def test_structured_tool_use_unaffected(self, transport):
+        """Healthy path: a real tool_use block is untouched by salvage."""
+        r = SimpleNamespace(
+            content=[
+                SimpleNamespace(
+                    type="tool_use", id="toolu_1", name="terminal",
+                    input={"command": "ls"},
+                ),
+            ],
+            stop_reason="tool_use",
+            usage=SimpleNamespace(input_tokens=10, output_tokens=20),
+            model="claude-opus-4-8",
+        )
+        nr = transport.normalize_response(r)
+        assert len(nr.tool_calls) == 1
+        assert nr.tool_calls[0].id == "toolu_1"
+        assert nr.finish_reason == "tool_calls"
+
+    def test_plain_text_answer_unaffected(self, transport):
+        """A genuine final text answer must NOT be mangled."""
+        r = SimpleNamespace(
+            content=[SimpleNamespace(type="text", text="The answer is 42.")],
+            stop_reason="end_turn",
+            usage=SimpleNamespace(input_tokens=10, output_tokens=5),
+            model="claude-opus-4-8",
+        )
+        nr = transport.normalize_response(r)
+        assert nr.tool_calls is None or nr.tool_calls == []
+        assert nr.content == "The answer is 42."
+        assert nr.finish_reason == "stop"
+
+    def test_salvage_skipped_when_structured_calls_present(self, transport):
+        """If the API already gave a tool_use, leftover text markup is left
+        as-is (we only salvage when there are zero structured calls)."""
+        leaked = "extra " + _inv("read_file", _param("path", "/x"))
+        r = SimpleNamespace(
+            content=[
+                SimpleNamespace(type="text", text=leaked),
+                SimpleNamespace(
+                    type="tool_use", id="toolu_9", name="terminal",
+                    input={"command": "pwd"},
+                ),
+            ],
+            stop_reason="tool_use",
+            usage=SimpleNamespace(input_tokens=5, output_tokens=5),
+            model="claude-opus-4-8",
+        )
+        nr = transport.normalize_response(r)
+        # Only the structured call survives; no salvage double-count.
+        assert len(nr.tool_calls) == 1
+        assert nr.tool_calls[0].name == "terminal"


### PR DESCRIPTION
## Summary

`AnthropicTransport.normalize_response()` only promotes tool calls from structured `tool_use` content blocks. When a complete tool-call (`invoke`) block lands in a **`text`** block instead of being promoted to `tool_use` by the serving layer, the method returns `tool_calls=None` / `finish_reason="stop"` and the agent loop halts **without executing the tool**.

This PR adds a defensive salvage path that recovers such embedded tool calls — the same "recover malformed provider tool data" philosophy as the existing VolcEngine workaround in `_repair_tool_call`, applied at the response-normalization layer.

Fixes #47472

## Changes

**`agent/transports/anthropic.py`**
- New module-level helper `salvage_tool_calls_from_text(text) -> (calls, cleaned_text)`: regex-extracts **complete** invoke blocks (namespaced and bare spellings both matched), recovers tool name + parameters, and returns the text with the markup stripped.
- New helper `_coerce_salvaged_value()`: `json.loads`-based type recovery so text-extracted params match a structured `tool_use` payload (`"61"`→`61`, `"true"`→`True`); non-JSON values kept as trimmed strings.
- `normalize_response()`: after collecting structured `tool_calls`, if there are **zero** of them but the joined text carries a complete invoke block, re-promote it to a real `ToolCall`, re-map `finish_reason` to `tool_calls`, and scrub the markup from user-visible content.

**`tests/agent/transports/test_anthropic_invoke_salvage.py`** (new, 19 tests)
- Pure-function coverage for `salvage_tool_calls_from_text` and `_coerce_salvaged_value`.
- End-to-end `normalize_response` coverage incl. a real `anthropic.types.TextBlock` smoke path.

## Safety / non-regression

- **Healthy path untouched**: salvage only fires when structured `tool_calls` is empty. A real `tool_use` block, or a genuine final text answer, is unaffected.
- **No partial execution**: only blocks with a closing tag are salvaged; a truncated streaming tail is left as text.
- **No double-count**: when the API already returned a structured call, leftover text markup is left as-is.
- Both streaming and non-streaming paths share `normalize_response`, so the fix covers both with one change.

## Test plan

```
python -m pytest tests/agent/transports/test_anthropic_invoke_salvage.py -q
# 19 passed

python -m pytest tests/agent/transports/ -q
# 351 passed  (no regressions)
```

- [x] New unit + integration tests pass
- [x] Full transport suite green (351 passed)
- [x] Verified against a real `anthropic.types.TextBlock` object
