### PR TITLE
fix(auth): use platform.claude.com for OAuth login token exchange

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -1251,7 +1251,7 @@ def run_oauth_setup_token() -> Optional[str]:
 # Stores credentials in ~/.hermes/.anthropic_oauth.json (our own file).
 
 _OAUTH_CLIENT_ID = "9d1c250a-e61b-44d9-88ed-5944d1962f5e"
-_OAUTH_TOKEN_URL = "https://console.anthropic.com/v1/oauth/token"
+_OAUTH_TOKEN_URL = "https://platform.claude.com/v1/oauth/token"
 _OAUTH_REDIRECT_URI = "https://console.anthropic.com/oauth/code/callback"
 _OAUTH_SCOPES = "org:create_api_key user:profile user:inference"
 _HERMES_OAUTH_FILE = get_hermes_home() / ".anthropic_oauth.json"


### PR DESCRIPTION
**Problem**

The Hermes-native PKCE login flow posts the authorization-code → token exchange to:

```python
_OAUTH_TOKEN_URL = "https://console.anthropic.com/v1/oauth/token"
```

That endpoint now returns **HTTP 404** — Anthropic migrated the OAuth token endpoint to `platform.claude.com`. As a result, `hermes auth add anthropic` fails with:

```
Token exchange failed: HTTP Error 404 / did not return credentials
```

**Why this is a bug (login/refresh asymmetry)**

The *refresh* path already migrated — `refresh_anthropic_oauth_pure` tries `https://platform.claude.com/v1/oauth/token` first, with the old console URL only as a fallback:

```python
token_endpoints = [
    "https://platform.claude.com/v1/oauth/token",
    "https://console.anthropic.com/v1/oauth/token",
]
```

Only the *login* path (`_OAUTH_TOKEN_URL`) was missed, so login and refresh now point at different endpoints — login at the dead one.

**Fix**

Point the login token exchange at the same endpoint the refresh path already uses (one line). `_OAUTH_REDIRECT_URI` is intentionally left unchanged — the `console.anthropic.com/oauth/code/callback` redirect is still the registered callback for the OAuth client and authorizes correctly (matches Claude Code's own flow).

**Testing**

With this change, `hermes auth add anthropic` completes the code→token exchange and stores credentials; the Anthropic OAuth serving path works. Validated on a live deployment.
