### PR TITLE
feat: add Kanban task reasoning overrides

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -3205,6 +3205,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
         api_key: str = None,
         base_url: str = None,
         max_turns: int = None,
+        reasoning: str = None,
         verbose: Optional[bool] = None,
         compact: bool = False,
         resume: str = None,
@@ -3427,9 +3428,10 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
             _resolve_prefill_messages_file(CLI_CONFIG)
         )
         
-        # Reasoning config (OpenRouter reasoning effort level)
+        # Reasoning config (OpenRouter reasoning effort level). CLI override
+        # wins over config for this process only.
         self.reasoning_config = _parse_reasoning_config(
-            CLI_CONFIG["agent"].get("reasoning_effort", "")
+            reasoning if reasoning is not None else CLI_CONFIG["agent"].get("reasoning_effort", "")
         )
         self.service_tier = _parse_service_tier_config(
             CLI_CONFIG["agent"].get("service_tier", "")
@@ -13495,6 +13497,7 @@ def main(
     api_key: str = None,
     base_url: str = None,
     max_turns: int = None,
+    reasoning: str = None,
     verbose: Optional[bool] = None,
     quiet: bool = False,
     compact: bool = False,
@@ -13523,6 +13526,7 @@ def main(
         api_key: API key for authentication
         base_url: Base URL for the API
         max_turns: Maximum tool-calling iterations (default: 60)
+        reasoning: Reasoning effort override for this process
         verbose: Enable verbose logging
         compact: Use compact display mode
         list_tools: List available tools and exit
@@ -13633,6 +13637,7 @@ def main(
         api_key=api_key,
         base_url=base_url,
         max_turns=max_turns,
+        reasoning=reasoning,
         verbose=verbose,
         compact=compact,
         resume=resume,

--- a/hermes_cli/_parser.py
+++ b/hermes_cli/_parser.py
@@ -127,6 +127,15 @@ def build_top_level_parser():
     )
     _inherited_flag(
         parser,
+        "--reasoning",
+        default=None,
+        help=(
+            "Reasoning effort override for this invocation "
+            "(none, minimal, low, medium, high, xhigh). Applies to -z/--oneshot and --tui."
+        ),
+    )
+    _inherited_flag(
+        parser,
         "--provider",
         default=None,
         help=(
@@ -265,6 +274,12 @@ def build_top_level_parser():
     )
     chat_parser.add_argument(
         "-t", "--toolsets", help="Comma-separated toolsets to enable"
+    )
+    _inherited_flag(
+        chat_parser,
+        "--reasoning",
+        default=argparse.SUPPRESS,
+        help="Reasoning effort override (none, minimal, low, medium, high, xhigh)",
     )
     _inherited_flag(
         chat_parser,

--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -75,6 +75,7 @@ def _task_to_dict(t: kb.Task) -> dict[str, Any]:
         "completed_at": t.completed_at,
         "result": t.result,
         "skills": list(t.skills) if t.skills else [],
+        "reasoning_override": t.reasoning_override,
         "max_retries": t.max_retries,
         "session_id": t.session_id,
         "workflow_template_id": t.workflow_template_id,
@@ -333,6 +334,9 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
                                "(repeatable). Appended to the built-in "
                                "kanban-worker skill. Example: "
                                "--skill translation --skill github-code-review")
+    p_create.add_argument("--reasoning", default=None, dest="reasoning_override",
+                          help="Per-task reasoning effort override: "
+                               "none, minimal, low, medium, high, or xhigh")
     p_create.add_argument("--max-retries", type=int, default=None,
                           metavar="N",
                           help="Per-task override for the consecutive-failure "
@@ -1342,6 +1346,7 @@ def _cmd_create(args: argparse.Namespace) -> int:
             idempotency_key=getattr(args, "idempotency_key", None),
             max_runtime_seconds=max_runtime,
             skills=getattr(args, "skills", None) or None,
+            reasoning_override=getattr(args, "reasoning_override", None),
             max_retries=max_retries,
             goal_mode=bool(getattr(args, "goal_mode", False)),
             goal_max_turns=getattr(args, "goal_max_turns", None),
@@ -1519,6 +1524,8 @@ def _cmd_show(args: argparse.Namespace) -> int:
         print(f"  skills:    {', '.join(task.skills)}")
     if task.model_override:
         print(f"  model:     {task.model_override}")
+    if task.reasoning_override:
+        print(f"  reasoning: {task.reasoning_override}")
     # Effective retry threshold. Show the per-task override if set,
     # otherwise the dispatcher's resolved value from config (or the
     # default if config doesn't set it either). Helps operators see

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -774,6 +774,10 @@ class Task:
     # list = explicitly no extra skills.
     skills: Optional[list] = None
     model_override: Optional[str] = None
+    # Per-task reasoning effort override. When set, the dispatcher passes
+    # ``--reasoning <level>`` to the worker CLI, overriding the profile's
+    # configured ``agent.reasoning_effort`` for this run.
+    reasoning_override: Optional[str] = None
     # Per-task override for the consecutive-failure circuit breaker.
     # The value is the failure count at which the breaker trips — e.g.
     # ``max_retries=1`` blocks on the first failure (zero retries),
@@ -864,6 +868,11 @@ class Task:
             ),
             skills=skills_value,
             model_override=row["model_override"] if "model_override" in keys and row["model_override"] else None,
+            reasoning_override=(
+                row["reasoning_override"]
+                if "reasoning_override" in keys and row["reasoning_override"]
+                else None
+            ),
             max_retries=(
                 row["max_retries"] if "max_retries" in keys else None
             ),
@@ -1016,6 +1025,10 @@ CREATE TABLE IF NOT EXISTS tasks (
     -- to the worker, overriding the profile's default model. NULL = use
     -- the profile default.
     model_override       TEXT,
+    -- Per-task reasoning effort override. When set, the dispatcher passes
+    -- --reasoning <level> to the worker, overriding agent.reasoning_effort
+    -- for this task only. NULL = use the profile default.
+    reasoning_override   TEXT,
     -- Per-task override for the consecutive-failure circuit breaker.
     -- The value is the failure count at which the breaker trips — e.g.
     -- ``max_retries=1`` blocks on the first failure. NULL (the common
@@ -1668,7 +1681,12 @@ def _migrate_add_optional_columns(conn: sqlite3.Connection) -> None:
         _add_column_if_missing(conn, "tasks", "max_retries", "max_retries INTEGER")
 
     if "model_override" not in cols:
-        conn.execute("ALTER TABLE tasks ADD COLUMN model_override TEXT")
+        _add_column_if_missing(conn, "tasks", "model_override", "model_override TEXT")
+
+    if "reasoning_override" not in cols:
+        _add_column_if_missing(
+            conn, "tasks", "reasoning_override", "reasoning_override TEXT"
+        )
 
     if "goal_mode" not in cols:
         # Ralph-style goal loop toggle for the dispatched worker. 0 (the
@@ -2066,6 +2084,7 @@ def create_task(
     idempotency_key: Optional[str] = None,
     max_runtime_seconds: Optional[int] = None,
     skills: Optional[Iterable[str]] = None,
+    reasoning_override: Optional[str] = None,
     max_retries: Optional[int] = None,
     goal_mode: bool = False,
     goal_max_turns: Optional[int] = None,
@@ -2114,6 +2133,14 @@ def create_task(
     if branch_name and workspace_kind != "worktree":
         raise ValueError("branch_name is only valid for worktree workspaces")
     parents = tuple(p for p in parents if p)
+    if reasoning_override is not None:
+        from hermes_constants import parse_reasoning_effort
+
+        reasoning_override = str(reasoning_override).strip().lower() or None
+        if reasoning_override and parse_reasoning_effort(reasoning_override) is None:
+            raise ValueError(
+                "reasoning_override must be one of none, minimal, low, medium, high, xhigh"
+            )
 
     # Normalise + validate skills: strip whitespace, drop empties, dedupe
     # (preserving order). Refuse commas inside a single name so we don't
@@ -2236,8 +2263,9 @@ def create_task(
                         id, title, body, assignee, status, priority,
                         created_by, created_at, workspace_kind, workspace_path,
                         branch_name, tenant, idempotency_key, max_runtime_seconds,
-                        skills, max_retries, goal_mode, goal_max_turns, session_id
-                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                        skills, reasoning_override, max_retries, goal_mode,
+                        goal_max_turns, session_id
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                     """,
                     (
                         task_id,
@@ -2255,6 +2283,7 @@ def create_task(
                         idempotency_key,
                         int(max_runtime_seconds) if max_runtime_seconds is not None else None,
                         json.dumps(skills_list) if skills_list is not None else None,
+                        reasoning_override,
                         int(max_retries) if max_retries is not None else None,
                         1 if goal_mode else 0,
                         int(goal_max_turns) if goal_max_turns is not None else None,
@@ -2277,6 +2306,7 @@ def create_task(
                         "tenant": tenant,
                         "branch_name": branch_name,
                         "skills": list(skills_list) if skills_list else None,
+                        "reasoning_override": reasoning_override,
                         "goal_mode": bool(goal_mode) or None,
                     },
                 )
@@ -6842,6 +6872,8 @@ def _default_spawn(
                 cmd.extend(["--skills", sk])
     if task.model_override:
         cmd.extend(["-m", task.model_override])
+    if task.reasoning_override:
+        cmd.extend(["--reasoning", task.reasoning_override])
     worker_toolsets = _resolve_worker_cli_toolsets(env.get("HERMES_HOME"))
     if worker_toolsets:
         cmd.extend(["--toolsets", ",".join(worker_toolsets)])

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -391,6 +391,7 @@ def _apply_profile_override() -> None:
     value_flags = {
         "-z", "--oneshot",
         "-m", "--model",
+        "--reasoning",
         "--provider",
         "-t", "--toolsets",
         "-r", "--resume",
@@ -1916,6 +1917,7 @@ def _launch_tui(
     checkpoints: bool = False,
     pass_session_id: bool = False,
     max_turns: Optional[int] = None,
+    reasoning: Optional[str] = None,
     accept_hooks: bool = False,
 ):
     """Replace current process with the TUI."""
@@ -1995,6 +1997,8 @@ def _launch_tui(
         env["HERMES_TUI_PASS_SESSION_ID"] = "1"
     if max_turns is not None:
         env["HERMES_TUI_MAX_TURNS"] = str(max_turns)
+    if reasoning:
+        env["HERMES_TUI_REASONING"] = str(reasoning)
     if verbose:
         env["HERMES_TUI_TOOL_PROGRESS"] = "verbose"
     elif quiet:
@@ -2294,6 +2298,7 @@ def cmd_chat(args):
             checkpoints=getattr(args, "checkpoints", False),
             pass_session_id=getattr(args, "pass_session_id", False),
             max_turns=getattr(args, "max_turns", None),
+            reasoning=getattr(args, "reasoning", None),
             accept_hooks=getattr(args, "accept_hooks", False),
         )
 
@@ -2315,6 +2320,7 @@ def cmd_chat(args):
         "checkpoints": getattr(args, "checkpoints", False),
         "pass_session_id": getattr(args, "pass_session_id", False),
         "max_turns": getattr(args, "max_turns", None),
+        "reasoning": getattr(args, "reasoning", None),
         "ignore_rules": getattr(args, "ignore_rules", False) or getattr(args, "safe_mode", False),
         "ignore_user_config": getattr(args, "ignore_user_config", False) or getattr(args, "safe_mode", False),
         "compact": getattr(args, "compact", False),

--- a/tests/hermes_cli/test_argparse_flag_propagation.py
+++ b/tests/hermes_cli/test_argparse_flag_propagation.py
@@ -109,6 +109,60 @@ class TestChatVerboseArg:
         assert "verbose" not in captured
 
 
+class TestReasoningArg:
+    """Verify --reasoning mirrors -m as both a top-level and chat flag."""
+
+    def test_reasoning_before_chat_is_preserved(self):
+        from hermes_cli._parser import build_top_level_parser
+
+        parser, _subparsers, _chat_parser = build_top_level_parser()
+        args = parser.parse_args(["--reasoning", "high", "chat", "-q", "hello"])
+
+        assert args.reasoning == "high"
+        assert args.query == "hello"
+
+    def test_reasoning_after_chat_sets_attribute(self):
+        from hermes_cli._parser import build_top_level_parser
+
+        parser, _subparsers, _chat_parser = build_top_level_parser()
+        args = parser.parse_args(["chat", "--reasoning", "high", "-q", "hello"])
+
+        assert args.reasoning == "high"
+        assert args.query == "hello"
+
+    def test_cmd_chat_forwards_top_level_reasoning(self, monkeypatch):
+        import types
+        import sys
+
+        import hermes_cli.main as main_mod
+        from hermes_cli._parser import build_top_level_parser
+
+        parser, _subparsers, chat_parser = build_top_level_parser()
+        chat_parser.set_defaults(func=main_mod.cmd_chat)
+        args = parser.parse_args(["--reasoning", "high", "chat", "-q", "hello"])
+        captured = {}
+        fake_cli = types.ModuleType("cli")
+
+        def fake_main(**kwargs):
+            captured.update(kwargs)
+
+        setattr(fake_cli, "main", fake_main)
+        fake_banner = types.ModuleType("hermes_cli.banner")
+        setattr(fake_banner, "prefetch_update_check", lambda: None)
+        fake_skills_sync = types.ModuleType("tools.skills_sync")
+        setattr(fake_skills_sync, "sync_skills", lambda quiet=True: None)
+
+        monkeypatch.setitem(sys.modules, "cli", fake_cli)
+        monkeypatch.setitem(sys.modules, "hermes_cli.banner", fake_banner)
+        monkeypatch.setitem(sys.modules, "tools.skills_sync", fake_skills_sync)
+        monkeypatch.setattr(main_mod, "_has_any_provider_configured", lambda: True)
+        monkeypatch.setattr(main_mod, "_pin_kanban_board_env", lambda: None)
+
+        main_mod.cmd_chat(args)
+
+        assert captured["reasoning"] == "high"
+
+
 class TestYoloEnvVar:
     """Verify --yolo sets HERMES_YOLO_MODE regardless of flag position.
 

--- a/tests/hermes_cli/test_kanban_reasoning_override.py
+++ b/tests/hermes_cli/test_kanban_reasoning_override.py
@@ -1,0 +1,118 @@
+"""Tests for per-task Kanban reasoning overrides."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from hermes_cli import kanban as kc
+from hermes_cli import kanban_db as kb
+
+
+@pytest.fixture
+def kanban_home(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    kb.init_db()
+    return home
+
+
+def test_create_task_stores_reasoning_override(kanban_home):
+    with kb.connect() as conn:
+        tid = kb.create_task(
+            conn,
+            title="needs deeper thought",
+            assignee="dante",
+            reasoning_override="high",
+        )
+        task = kb.get_task(conn, tid)
+
+    assert task.reasoning_override == "high"
+
+
+def test_run_slash_create_reasoning_override_is_visible_in_json_and_show(kanban_home):
+    out = kc.run_slash(
+        "create 'needs deeper thought' --assignee dante --reasoning high --json"
+    )
+    payload = json.loads(out)
+
+    assert payload["reasoning_override"] == "high"
+
+    show = kc.run_slash(f"show {payload['id']}")
+    assert "reasoning: high" in show
+
+
+def test_default_spawn_passes_reasoning_override_to_worker_cli(monkeypatch, tmp_path):
+    root = tmp_path / ".hermes"
+    profile = root / "profiles" / "dante"
+    profile.mkdir(parents=True)
+    profile.joinpath("config.yaml").write_text("toolsets:\n  - hermes-cli\n", encoding="utf-8")
+    root.joinpath("config.yaml").write_text("toolsets:\n  - kanban\n", encoding="utf-8")
+    monkeypatch.setenv("HERMES_HOME", str(root))
+    monkeypatch.setattr(kb, "_resolve_hermes_argv", lambda: ["hermes"])
+
+    captured = {}
+
+    class FakeProc:
+        pid = 4242
+
+    def fake_popen(cmd, *args, **kwargs):
+        captured["cmd"] = list(cmd)
+        return FakeProc()
+
+    monkeypatch.setattr(subprocess, "Popen", fake_popen)
+
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    task = kb.Task(
+        id="t_reasoning",
+        title="reasoning task",
+        body=None,
+        assignee="dante",
+        status="running",
+        priority=0,
+        created_by="test",
+        created_at=1,
+        started_at=None,
+        completed_at=None,
+        workspace_kind="dir",
+        workspace_path=None,
+        claim_lock="lock",
+        claim_expires=None,
+        tenant=None,
+        current_run_id=7,
+        reasoning_override="high",
+    )
+
+    pid = kb._default_spawn(task, str(workspace))
+
+    assert pid == 4242
+    assert "--reasoning" in captured["cmd"]
+    assert captured["cmd"][captured["cmd"].index("--reasoning") + 1] == "high"
+
+
+def test_kanban_create_tool_accepts_reasoning_override(kanban_home, monkeypatch):
+    monkeypatch.setenv("HERMES_KANBAN_TASK", "t_parent")
+    monkeypatch.setenv("HERMES_PROFILE", "wren")
+
+    from tools import kanban_tools
+
+    result = json.loads(
+        kanban_tools._handle_create(
+            {
+                "title": "review carefully",
+                "assignee": "dante",
+                "reasoning_override": "high",
+            }
+        )
+    )
+
+    assert result["ok"] is True
+    with kb.connect() as conn:
+        task = kb.get_task(conn, result["task_id"])
+    assert task.reasoning_override == "high"

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -325,6 +325,7 @@ def _task_summary_dict(kb, conn, task) -> dict[str, Any]:
         "completed_at": task.completed_at,
         "current_run_id": task.current_run_id,
         "model_override": task.model_override,
+        "reasoning_override": task.reasoning_override,
         "parents": parents,
         "children": children,
         "parent_count": len(parents),
@@ -370,6 +371,7 @@ def _handle_show(args: dict, **kw) -> str:
                     "result": t.result,
                     "current_run_id": t.current_run_id,
                     "model_override": t.model_override,
+                    "reasoning_override": t.reasoning_override,
                 }
 
             def _run_dict(r):
@@ -809,6 +811,7 @@ def _handle_create(args: dict, **kw) -> str:
                     if max_runtime_seconds is not None else None
                 ),
                 skills=skills,
+                reasoning_override=args.get("reasoning_override"),
                 goal_mode=goal_mode,
                 goal_max_turns=(
                     int(goal_max_turns) if goal_max_turns is not None else None
@@ -1275,6 +1278,15 @@ KANBAN_CREATE_SCHEMA = {
                     "task, ['github-code-review'] for a reviewer task. "
                     "The names must match skills installed on the "
                     "assignee's profile."
+                ),
+            },
+            "reasoning_override": {
+                "type": "string",
+                "enum": ["none", "minimal", "low", "medium", "high", "xhigh"],
+                "description": (
+                    "Optional per-task reasoning effort override passed to "
+                    "the dispatched worker. Omit to use the assignee "
+                    "profile's configured agent.reasoning_effort."
                 ),
             },
             "goal_mode": {


### PR DESCRIPTION
## Summary

Adds per-task reasoning effort overrides for Hermes Kanban workers.

- stores an optional `reasoning_override` on Kanban tasks
- accepts `--reasoning` on `hermes kanban create` and `/kanban create`
- exposes `reasoning_override` on the `kanban_create` tool
- dispatches workers with a top-level `--reasoning <level>` CLI flag, mirroring `-m/--model`, instead of adding a non-secret `HERMES_*` env var
- threads top-level `hermes --reasoning ...` through chat/TUI invocation paths

## Verification

- `python -m pytest tests/hermes_cli/test_kanban_reasoning_override.py tests/hermes_cli/test_argparse_flag_propagation.py -o 'addopts=' -q` → 24 passed
- parser smoke: top-level `--reasoning` before `chat`, chat-level `--reasoning`, and `-z/--oneshot` parsing all preserve the requested effort
- CLI help smoke: `python -m hermes_cli.main --reasoning high --version` and `python -m hermes_cli.main chat --reasoning high --help`

I also ran `python -m pytest tests/hermes_cli/test_kanban*.py -o 'addopts=' -q`; it currently reports 659 passed / 10 failed. The failing cases pass when run as the isolated failing subset, so this appears to be pre-existing order/global-state coupling in the broader Kanban suite rather than this patch. The failures are in crash/reap/decompose tests unrelated to the reasoning override path.
