### PR TITLE
feat(delegation): allow provider/model overrides

### DIFF
--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -69,6 +69,8 @@ class TestDelegateRequirements(unittest.TestCase):
         self.assertIn("tasks", props)
         self.assertIn("context", props)
         self.assertIn("toolsets", props)
+        self.assertIn("provider", props)
+        self.assertIn("model", props)
         # max_iterations is intentionally NOT exposed to the model — it's
         # config-authoritative via delegation.max_iterations so users get
         # predictable budgets.
@@ -1395,6 +1397,52 @@ class TestDelegationProviderIntegration(unittest.TestCase):
                 self.assertEqual(call.kwargs.get("override_base_url"), "https://openrouter.ai/api/v1")
                 self.assertEqual(call.kwargs.get("override_api_key"), "sk-or-batch")
                 self.assertEqual(call.kwargs.get("override_api_mode"), "chat_completions")
+
+    @patch("tools.delegate_tool._load_config")
+    @patch("tools.delegate_tool._resolve_delegation_credentials")
+    def test_call_provider_model_override_reaches_resolver_and_child(
+        self, mock_creds, mock_cfg
+    ):
+        """delegate_task(provider=..., model=...) overrides config for this call."""
+        mock_cfg.return_value = {
+            "max_iterations": 45,
+            "model": "configured-model",
+            "provider": "configured-provider",
+        }
+        mock_creds.return_value = {
+            "model": "call-model",
+            "provider": "call-provider",
+            "base_url": "https://example.test/v1",
+            "api_key": "***",
+            "api_mode": "chat_completions",
+        }
+        parent = _make_mock_parent(depth=0)
+
+        with (
+            patch("tools.delegate_tool._build_child_agent") as mock_build,
+            patch("tools.delegate_tool._run_single_child") as mock_run,
+        ):
+            mock_child = MagicMock()
+            mock_build.return_value = mock_child
+            mock_run.return_value = {
+                "task_index": 0, "status": "completed",
+                "summary": "Done", "api_calls": 1, "duration_seconds": 1.0
+            }
+
+            delegate_task(
+                goal="Per-call provider routing",
+                provider="call-provider",
+                model="call-model",
+                parent_agent=parent,
+            )
+
+            resolved_cfg = mock_creds.call_args.args[0]
+            self.assertEqual(resolved_cfg["provider"], "call-provider")
+            self.assertEqual(resolved_cfg["model"], "call-model")
+            _, kwargs = mock_build.call_args
+            self.assertEqual(kwargs.get("model"), "call-model")
+            self.assertEqual(kwargs.get("override_provider"), "call-provider")
+            self.assertEqual(kwargs.get("override_base_url"), "https://example.test/v1")
 
     @patch("tools.delegate_tool._load_config")
     @patch("tools.delegate_tool._resolve_delegation_credentials")

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -2068,6 +2068,8 @@ def delegate_task(
     toolsets: Optional[List[str]] = None,
     tasks: Optional[List[Dict[str, Any]]] = None,
     max_iterations: Optional[int] = None,
+    provider: Optional[str] = None,
+    model: Optional[str] = None,
     acp_command: Optional[str] = None,
     acp_args: Optional[List[str]] = None,
     role: Optional[str] = None,
@@ -2133,8 +2135,15 @@ def delegate_task(
             }
         )
 
-    # Load config
-    cfg = _load_config()
+    # Load config. Per-call provider/model overrides are intentionally
+    # narrow: they reuse the existing delegation credential resolver and only
+    # affect this delegate_task invocation. Omitted values preserve the
+    # configured delegation defaults / parent inheritance behavior.
+    cfg = dict(_load_config())
+    if provider is not None:
+        cfg["provider"] = str(provider).strip()
+    if model is not None:
+        cfg["model"] = str(model).strip()
     default_max_iter = cfg.get("max_iterations", DEFAULT_MAX_ITERATIONS)
     # Model-supplied max_iterations is ignored — the config value is authoritative
     # so users get predictable budgets. The kwarg is retained for internal callers
@@ -3055,6 +3064,23 @@ DELEGATE_TASK_SCHEMA = {
                 "enum": ["leaf", "orchestrator"],
                 "description": "(rebuilt at get_definitions() time)",
             },
+            "provider": {
+                "type": "string",
+                "description": (
+                    "Provider override for child agents. When set, resolves credentials "
+                    "via the configured Hermes provider of this name (same path as "
+                    "delegation.provider) and applies only to this delegate_task call. "
+                    "Omit to use delegation.provider or inherit the parent provider."
+                ),
+            },
+            "model": {
+                "type": "string",
+                "description": (
+                    "Model override for child agents. When provider is also set, this "
+                    "is passed to that provider resolver; when provider is omitted, "
+                    "the child uses this model with the inherited provider credentials."
+                ),
+            },
             "background": {
                 "type": "boolean",
                 "description": (
@@ -3114,6 +3140,8 @@ registry.register(
         toolsets=args.get("toolsets"),
         tasks=args.get("tasks"),
         max_iterations=args.get("max_iterations"),
+        provider=args.get("provider"),
+        model=args.get("model"),
         acp_command=args.get("acp_command"),
         acp_args=args.get("acp_args"),
         role=args.get("role"),


### PR DESCRIPTION
## Summary
- add native delegate_task(provider=..., model=...) schema/handler support
- route per-call provider/model overrides through existing delegation credential resolver
- cover schema exposure and routing behavior in delegate tests

## Tests
- python3 -m py_compile tools/delegate_tool.py tests/tools/test_delegate.py
- uv run --with pytest pytest tests/tools/test_delegate.py -q
- uv run --with ruff ruff check tools/delegate_tool.py tests/tools/test_delegate.py