### PR TITLE
fix(state): handle missing trigram tokenizer without crashing SessionDB

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -772,21 +772,42 @@ class SessionDB:
     @staticmethod
     def _is_fts5_unavailable_error(exc: sqlite3.OperationalError) -> bool:
         err = str(exc).lower()
-        return "no such module" in err and "fts5" in err
+        if "no such module" in err and "fts5" in err:
+            return True
+        if "no such tokenizer" in err:
+            return True
+        return False
 
-    def _warn_fts5_unavailable(self, exc: sqlite3.OperationalError) -> None:
-        self._fts_enabled = False
+    @staticmethod
+    def _is_trigram_only_error(exc: sqlite3.OperationalError) -> bool:
+        """Return True if the error is specifically about the trigram tokenizer
+        being unavailable (not a wholesale FTS5 absence)."""
+        err = str(exc).lower()
+        return "no such tokenizer" in err
+
+    def _warn_fts5_unavailable(self, exc: sqlite3.OperationalError, *, trigram_only: bool = False) -> None:
+        if not trigram_only:
+            self._fts_enabled = False
         if self._fts_unavailable_warned:
             return
         self._fts_unavailable_warned = True
-        logger.warning(
-            "SQLite FTS5 unavailable for %s; full-text session search "
-            "disabled. Run `hermes update` to rebuild the venv with a "
-            "current Python (managed uv guarantees FTS5). "
-            "(underlying error: %s)",
-            self.db_path,
-            exc,
-        )
+        if trigram_only:
+            logger.warning(
+                "SQLite trigram tokenizer unavailable for %s; "
+                "CJK/substring search will fall back to LIKE. "
+                "(underlying error: %s)",
+                self.db_path,
+                exc,
+            )
+        else:
+            logger.warning(
+                "SQLite FTS5 unavailable for %s; full-text session search "
+                "disabled. Run `hermes update` to rebuild the venv with a "
+                "current Python (managed uv guarantees FTS5). "
+                "(underlying error: %s)",
+                self.db_path,
+                exc,
+            )
 
     def _sqlite_supports_fts5(self, cursor: sqlite3.Cursor) -> bool:
         try:
@@ -796,7 +817,7 @@ class SessionDB:
         except sqlite3.OperationalError as exc:
             if not self._is_fts5_unavailable_error(exc):
                 raise
-            self._warn_fts5_unavailable(exc)
+            self._warn_fts5_unavailable(exc, trigram_only=self._is_trigram_only_error(exc))
             return False
 
     @staticmethod
@@ -844,7 +865,7 @@ class SessionDB:
             return True
         except sqlite3.OperationalError as exc:
             if self._is_fts5_unavailable_error(exc):
-                self._warn_fts5_unavailable(exc)
+                self._warn_fts5_unavailable(exc, trigram_only=self._is_trigram_only_error(exc))
                 return None
             if "no such table" in str(exc).lower():
                 return False
@@ -868,7 +889,7 @@ class SessionDB:
         except sqlite3.OperationalError as exc:
             if not self._is_fts5_unavailable_error(exc):
                 raise
-            self._warn_fts5_unavailable(exc)
+            self._warn_fts5_unavailable(exc, trigram_only=self._is_trigram_only_error(exc))
             return False
 
     def _execute_write(self, fn: Callable[[sqlite3.Connection], T]) -> T:
@@ -1166,7 +1187,7 @@ class SessionDB:
                         except sqlite3.OperationalError as exc:
                             if not self._is_fts5_unavailable_error(exc):
                                 raise
-                            self._warn_fts5_unavailable(exc)
+                            self._warn_fts5_unavailable(exc, trigram_only=self._is_trigram_only_error(exc))
                             fts5_available = False
                             fts_migrations_complete = False
                             break

--- a/tests/test_sessiondb_trigram_fallback.py
+++ b/tests/test_sessiondb_trigram_fallback.py
@@ -1,0 +1,74 @@
+"""Test that SessionDB gracefully handles missing trigram tokenizer.
+
+Regression test for https://github.com/NousResearch/hermes-agent/issues/47002
+"""
+
+import sqlite3
+from unittest.mock import patch
+
+import pytest
+
+from hermes_state import SessionDB
+
+
+class _NoTrigramCursor(sqlite3.Cursor):
+    """A cursor that rejects trigram DDL, simulating SQLite without the tokenizer."""
+
+    def executescript(self, sql_script):
+        if "tokenize='trigram'" in sql_script:
+            raise sqlite3.OperationalError("no such tokenizer: trigram")
+        return super().executescript(sql_script)
+
+
+def test_is_fts5_unavailable_error_matches_trigram():
+    """_is_fts5_unavailable_error should match 'no such tokenizer' errors."""
+    exc = sqlite3.OperationalError("no such tokenizer: trigram")
+    assert SessionDB._is_fts5_unavailable_error(exc) is True
+
+
+def test_is_fts5_unavailable_error_matches_no_module():
+    """_is_fts5_unavailable_error should still match 'no such module: fts5'."""
+    exc = sqlite3.OperationalError("no such module: fts5")
+    assert SessionDB._is_fts5_unavailable_error(exc) is True
+
+
+def test_is_fts5_unavailable_error_rejects_other():
+    """_is_fts5_unavailable_error should not match unrelated errors."""
+    exc = sqlite3.OperationalError("table already exists")
+    assert SessionDB._is_fts5_unavailable_error(exc) is False
+
+
+def test_is_trigram_only_error():
+    """_is_trigram_only_error should distinguish tokenizer-specific errors."""
+    trigram_exc = sqlite3.OperationalError("no such tokenizer: trigram")
+    module_exc = sqlite3.OperationalError("no such module: fts5")
+
+    assert SessionDB._is_trigram_only_error(trigram_exc) is True
+    assert SessionDB._is_trigram_only_error(module_exc) is False
+
+
+def test_sessiondb_init_survives_no_trigram(tmp_path):
+    """SessionDB.__init__ should not crash when trigram tokenizer is absent.
+
+    The base FTS5 table should still work; only trigram search falls back to LIKE.
+    """
+    db_path = tmp_path / "test_sessions.db"
+
+    # Patch sqlite3.Cursor to reject trigram DDL
+    original_cursor = sqlite3.Connection.cursor
+
+    def _patched_cursor(self, *args, **kwargs):
+        return _NoTrigramCursor(self)
+
+    with patch.object(sqlite3.Connection, "cursor", _patched_cursor):
+        # This should NOT raise — the trigram failure is caught gracefully
+        try:
+            db = SessionDB(str(db_path))
+            # Base FTS should still be enabled
+            assert db._fts_enabled is True
+        except sqlite3.OperationalError as exc:
+            if "no such tokenizer" in str(exc):
+                pytest.fail(
+                    f"SessionDB.__init__ crashed on missing trigram tokenizer: {exc}"
+                )
+            raise


### PR DESCRIPTION
## What

Gracefully handle SQLite builds that have FTS5 but lack the optional `trigram` tokenizer.

## Why

Since v0.16.0, `SessionDB.__init__()` crashes on SQLite builds that ship FTS5 without the trigram tokenizer (e.g. SQLite 3.26, stripped distros). The error `"no such tokenizer: trigram"` propagates out of `_ensure_fts_schema` because `_is_fts5_unavailable_error` only matches `"no such module.*fts5"`.

Additionally, when a trigram-only failure occurs, `_warn_fts5_unavailable` incorrectly disables ALL FTS search (`_fts_enabled = False`) even though the base FTS5 table was created successfully.

## How

1. Extended `_is_fts5_unavailable_error` to also match `"no such tokenizer"` errors
2. Added `_is_trigram_only_error` to distinguish tokenizer-specific failures
3. `_warn_fts5_unavailable` now accepts a `trigram_only` flag — when True, it logs a CJK/substring fallback warning without disabling base FTS5
4. All call sites pass the distinction through

## Testing

Added `tests/test_sessiondb_trigram_fallback.py` with:
- Unit tests for the error matcher functions
- Integration test confirming SessionDB initializes successfully when trigram is unavailable
- Confirms base FTS5 remains enabled after trigram-only failure

Fixes #47002