### PR TITLE
fix(gateway): handle malformed session entries without crashing on startup

### DIFF
--- a/gateway/session.py
+++ b/gateway/session.py
@@ -546,7 +546,7 @@ class SessionEntry:
     @classmethod
     def from_dict(cls, data: Dict[str, Any]) -> "SessionEntry":
         origin = None
-        if "origin" in data and data["origin"]:
+        if "origin" in data and isinstance(data["origin"], dict):
             origin = SessionSource.from_dict(data["origin"])
         
         platform = None
@@ -742,9 +742,12 @@ class SessionStore:
                     data = json.load(f)
                     for key, entry_data in data.items():
                         try:
+                            if not isinstance(entry_data, dict):
+                                continue
                             self._entries[key] = SessionEntry.from_dict(entry_data)
-                        except (ValueError, KeyError):
+                        except (ValueError, KeyError, TypeError):
                             # Skip entries with unknown/removed platform values
+                            # or malformed data (e.g. bool where dict expected)
                             continue
             except Exception as e:
                 print(f"[gateway] Warning: Failed to load sessions: {e}")


### PR DESCRIPTION
## What

Prevent `"argument of type bool is not iterable"` TypeError when loading sessions.json on gateway startup.

## Why

On every startup, sessions loading fails with this error when a session entry's `origin` field was stored as `True` (bool) rather than a dict object. This can happen from older serialization paths or corrupted state. The error is caught by the outer `except Exception`, but it prevents ALL sessions from loading — not just the malformed one.

## How

1. Check `isinstance(data["origin"], dict)` instead of bare truthiness check (`data["origin"]`)
2. Add `isinstance(entry_data, dict)` guard to skip non-dict entries entirely
3. Catch `TypeError` alongside `ValueError`/`KeyError` in the per-entry exception handler

This ensures individual malformed entries are skipped while valid sessions still load.

## Impact

- Gateway no longer emits the warning on every startup
- Valid sessions load even when some entries are corrupted
- No data loss — malformed entries are silently skipped (they were inaccessible anyway)

Fixes #46994