### PR TITLE
fix(cron): fall back to standalone delivery when live adapter fails silently

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -771,12 +771,30 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                     if future is None:
                         adapter_ok = False
                     else:
+                        send_result = None
                         try:
                             send_result = future.result(timeout=60)
                         except TimeoutError:
                             future.cancel()
-                            raise
-                        if send_result and not getattr(send_result, "success", True):
+                            logger.warning(
+                                "Job '%s': live adapter send to %s:%s timed out, falling back to standalone",
+                                job["id"], platform_name, chat_id,
+                            )
+                            adapter_ok = False
+                        except Exception as send_exc:
+                            logger.warning(
+                                "Job '%s': live adapter send to %s:%s raised %s, falling back to standalone",
+                                job["id"], platform_name, chat_id, send_exc,
+                            )
+                            adapter_ok = False
+
+                        if adapter_ok and send_result is None:
+                            logger.warning(
+                                "Job '%s': live adapter send to %s:%s returned None, falling back to standalone",
+                                job["id"], platform_name, chat_id,
+                            )
+                            adapter_ok = False
+                        elif adapter_ok and not getattr(send_result, "success", True):
                             err = getattr(send_result, "error", "unknown")
                             logger.warning(
                                 "Job '%s': live adapter send to %s:%s failed (%s), falling back to standalone",


### PR DESCRIPTION
## What

Fix cron job output being silently dropped when the gateway has an active user session.

## Why

When a cron job completes while the user has an active conversation, the live adapter `send()` can return `None` or fail in a way that the scheduler still logs as "delivered". The message is permanently lost without any error or retry.

Root cause: the condition `if send_result and not getattr(send_result, "success", True)` evaluates to `False` when `send_result` is `None` (falsy), causing `adapter_ok` to remain `True`. The scheduler reports successful delivery when no message was actually sent.

## How

1. Initialize `send_result = None` before the try block
2. Catch ALL exceptions from `future.result()` (not just TimeoutError) — fall back to standalone
3. After successful `.result()`, explicitly check `send_result is None` → fall back
4. Guard the success/error field checks with `if adapter_ok` so they only run when no prior failure occurred
5. Log specific warnings for each failure mode (timeout, exception, None result)

The standalone fallback path runs in a fresh event loop on a dedicated thread, which is immune to the active-session contention that can cause the live adapter to silently fail.

## Testing

The fix is defensive — the standalone path is already proven reliable (it's the non-live-adapter fallback that works for E2EE-exempt platforms). The change ensures it activates when the live adapter misbehaves.

Fixes #47056