### PR TITLE
fix(models): add openrouter/fusion to model picker with router-model allowlist

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -72,6 +72,7 @@ OPENROUTER_MODELS: list[tuple[str, str]] = [
     # NVIDIA
     ("nvidia/nemotron-3-super-120b-a12b",      ""),
     # OpenRouter routers
+    ("openrouter/fusion",                      "multi-model deliberation with web search/fetch"),
     ("openrouter/pareto-code",                 "auto-routes to cheapest coder meeting openrouter.min_coding_score"),
     # Free tier
     ("openrouter/elephant-alpha",              "free"),
@@ -1306,15 +1307,25 @@ def _openrouter_model_supports_tools(item: Any) -> bool:
     so the picker doesn't silently empty for those users. Only hide models
     whose ``supported_parameters`` is an explicit list that omits ``tools``.
 
+    **OpenRouter routers are allowed even when they don't expose parameters.**
+    Router models such as ``openrouter/fusion`` and ``openrouter/pareto-code``
+    own their own routing/search behavior and may publish an empty
+    ``supported_parameters`` list while still being valid curated selections.
+
     Ported from Kilo-Org/kilocode#9068.
     """
     if not isinstance(item, dict):
+        return True
+    if str(item.get("id") or "") in _OPENROUTER_ROUTER_MODELS:
         return True
     params = item.get("supported_parameters")
     if not isinstance(params, list):
         # Field absent / malformed / None — be permissive.
         return True
     return "tools" in params
+
+
+_OPENROUTER_ROUTER_MODELS = {"openrouter/fusion", "openrouter/pareto-code"}
 
 
 def fetch_openrouter_models(

--- a/website/static/api/model-catalog.json
+++ b/website/static/api/model-catalog.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "updated_at": "2026-06-16T18:04:33Z",
+  "updated_at": "2026-06-16T22:33:14Z",
   "metadata": {
     "source": "hermes-agent repo",
     "docs": "https://hermes-agent.nousresearch.com/docs/reference/model-catalog"
@@ -111,6 +111,10 @@
         {
           "id": "nvidia/nemotron-3-super-120b-a12b",
           "description": ""
+        },
+        {
+          "id": "openrouter/fusion",
+          "description": "multi-model deliberation with web search/fetch"
         },
         {
           "id": "openrouter/pareto-code",


### PR DESCRIPTION
## Problem
`openrouter/fusion` is missing from the Hermes model picker (both CLI and desktop app).

## Root Cause
OpenRouter's Fusion model publishes an empty `supported_parameters: []` list. The `_openrouter_model_supports_tools()` function was filtering it out because an empty list doesn't contain `"tools"`.

## Fix
1. Add `openrouter/fusion` to `OPENROUTER_MODELS` static list
2. Introduce `_OPENROUTER_ROUTER_MODELS` allowlist for OpenRouter router models
3. Add a router-model bypass in `_openrouter_model_supports_tools()` so router models are never dropped by the live tool-support filter
4. Rebuild `website/static/api/model-catalog.json` (33 → 34 models)

Once deployed, the remote catalog at `hermes-agent.nousresearch.com/docs/api/model-catalog.json` will include `openrouter/fusion` and it will appear in the model picker.