### PR TITLE
[codex] fix Telegram topic quote metadata

### DIFF
--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -27,6 +27,10 @@ try:
         from telegram import LinkPreviewOptions
     except ImportError:
         LinkPreviewOptions = None
+    try:
+        from telegram import ReplyParameters
+    except ImportError:
+        ReplyParameters = None
     from telegram.ext import (
         Application,
         CommandHandler,
@@ -45,6 +49,7 @@ except ImportError:
     Message = Any
     InlineKeyboardButton = Any
     InlineKeyboardMarkup = Any
+    ReplyParameters = Any
     LinkPreviewOptions = None
     Application = Any
     CommandHandler = Any
@@ -194,6 +199,33 @@ def _strip_mdv2(text: str) -> str:
     # Remove MarkdownV2 spoiler markers (||text|| → text)
     cleaned = re.sub(r'\|\|([^|]+)\|\|', r'\1', cleaned)
     return cleaned
+
+
+_TELEGRAM_UNSUPPORTED_MESSAGE_PLACEHOLDER = (
+    "This message is not supported in your version of Telegram. "
+    "Please update to the latest version."
+)
+
+
+def _is_telegram_unsupported_placeholder(text: Optional[str]) -> bool:
+    """True when Telegram supplied its generic unsupported-message placeholder.
+
+    Telegram can expose this placeholder through Bot API reply context when a
+    user replies to a message type the client/API cannot render. Treating it as
+    real quoted text causes Hermes to inject it into the agent prompt as
+    `[Replying to: ...]`, so Eve appears to parrot the placeholder.
+    """
+    return bool(text and text.strip() == _TELEGRAM_UNSUPPORTED_MESSAGE_PLACEHOLDER)
+
+
+def _telegram_reply_quote_text(text: Optional[str], limit: int = 256) -> Optional[str]:
+    """Return a compact explicit Telegram quote, or None for unusable text."""
+    if not text or _is_telegram_unsupported_placeholder(text):
+        return None
+    compact = re.sub(r"\s+", " ", str(text)).strip()
+    if not compact:
+        return None
+    return compact[:limit]
 
 
 # ---------------------------------------------------------------------------
@@ -594,6 +626,46 @@ class TelegramAdapter(BasePlatformAdapter):
         reply_to = metadata.get("telegram_reply_to_message_id")
         return int(reply_to) if reply_to is not None else None
 
+    @classmethod
+    def _metadata_reply_quote(cls, metadata: Optional[Dict[str, Any]]) -> Optional[str]:
+        if not metadata:
+            return None
+        return _telegram_reply_quote_text(metadata.get("telegram_reply_quote"))
+
+    @classmethod
+    def _metadata_explicit_quote_reply_to(
+        cls,
+        metadata: Optional[Dict[str, Any]],
+    ) -> Optional[int]:
+        if not cls._metadata_reply_quote(metadata):
+            return None
+        return cls._metadata_reply_to_message_id(metadata)
+
+    @classmethod
+    def _reply_parameters_for_send(
+        cls,
+        reply_to_message_id: Optional[int],
+        metadata: Optional[Dict[str, Any]],
+    ) -> Optional[Any]:
+        if reply_to_message_id is None or ReplyParameters is None:
+            return None
+        quote = cls._metadata_reply_quote(metadata)
+        if not quote:
+            return None
+        return ReplyParameters(message_id=reply_to_message_id, quote=quote)
+
+    @classmethod
+    def _reply_parameters_payload(
+        cls,
+        reply_to_message_id: int,
+        metadata: Optional[Dict[str, Any]],
+    ) -> Dict[str, Any]:
+        payload: Dict[str, Any] = {"message_id": reply_to_message_id}
+        quote = cls._metadata_reply_quote(metadata)
+        if quote:
+            payload["quote"] = quote
+        return payload
+
     @staticmethod
     def _looks_like_private_chat_id(chat_id: str) -> bool:
         try:
@@ -641,6 +713,9 @@ class TelegramAdapter(BasePlatformAdapter):
             if reply_to_mode == "off":
                 return None
             return cls._metadata_reply_to_message_id(metadata)
+        explicit_quote_reply_to = cls._metadata_explicit_quote_reply_to(metadata)
+        if explicit_quote_reply_to is not None:
+            return explicit_quote_reply_to
         return None
 
     @classmethod
@@ -1013,11 +1088,19 @@ class TelegramAdapter(BasePlatformAdapter):
         case so the legacy path stays the single source of the refuse result.
         """
         metadata_reply_to = self._metadata_reply_to_message_id(metadata)
+        metadata_reply_quote = self._metadata_reply_quote(metadata)
         private_dm_topic_send = self._is_private_dm_topic_send(chat_id, thread_id, metadata)
+        dm_topic_explicit_quote_reply = (
+            private_dm_topic_send
+            and self._reply_to_mode == "off"
+            and metadata_reply_to is not None
+            and bool(metadata_reply_quote)
+        )
         dm_topic_reply_to_off = (
             private_dm_topic_send
             and self._reply_to_mode == "off"
             and bool(metadata and metadata.get("telegram_dm_topic_reply_fallback"))
+            and not dm_topic_explicit_quote_reply
         )
         reply_to_source = reply_to or (
             str(metadata_reply_to)
@@ -1025,9 +1108,15 @@ class TelegramAdapter(BasePlatformAdapter):
             else None
         )
         if private_dm_topic_send:
-            should_thread = reply_to_source is not None and self._reply_to_mode != "off"
+            should_thread = reply_to_source is not None and (
+                self._reply_to_mode != "off" or dm_topic_explicit_quote_reply
+            )
         else:
-            should_thread = self._should_thread_reply(reply_to_source, 0)
+            explicit_quote_reply = False
+            if reply_to_source is None and metadata_reply_to is not None and metadata_reply_quote:
+                reply_to_source = str(metadata_reply_to)
+                explicit_quote_reply = True
+            should_thread = explicit_quote_reply or self._should_thread_reply(reply_to_source, 0)
         reply_to_id = int(reply_to_source) if should_thread and reply_to_source else None
         if private_dm_topic_send and reply_to_id is None and not dm_topic_reply_to_off:
             # Refusing to send outside the requested DM topic — defer to the
@@ -1075,7 +1164,7 @@ class TelegramAdapter(BasePlatformAdapter):
             # object), NOT the legacy reply_to_message_id scalar. Unknown
             # params are silently ignored by the Bot API, so the scalar would
             # quietly drop the reply anchor instead of erroring.
-            payload["reply_parameters"] = {"message_id": reply_to_id}
+            payload["reply_parameters"] = self._reply_parameters_payload(reply_to_id, metadata)
 
         try:
             msg = await self._bot.do_api_request(
@@ -2194,7 +2283,15 @@ class TelegramAdapter(BasePlatformAdapter):
             for i, chunk in enumerate(chunks):
                 retried_thread_not_found = False
                 metadata_reply_to = self._metadata_reply_to_message_id(metadata)
+                metadata_reply_quote = self._metadata_reply_quote(metadata)
                 private_dm_topic_send = self._is_private_dm_topic_send(chat_id, thread_id, metadata)
+                dm_topic_explicit_quote_reply = (
+                    private_dm_topic_send
+                    and self._reply_to_mode == "off"
+                    and metadata_reply_to is not None
+                    and bool(metadata_reply_quote)
+                    and i == 0
+                )
                 # reply_to_mode="off" on the existing telegram_dm_topic_reply_fallback path
                 # is an explicit user opt-in to "message_thread_id alone is enough" (PR #23994
                 # / commit 21a15b671). Honor it — don't fail loud just because the anchor was
@@ -2204,6 +2301,7 @@ class TelegramAdapter(BasePlatformAdapter):
                     private_dm_topic_send
                     and self._reply_to_mode == "off"
                     and bool(metadata and metadata.get("telegram_dm_topic_reply_fallback"))
+                    and not dm_topic_explicit_quote_reply
                 )
                 reply_to_source = reply_to or (
                     str(metadata_reply_to) if private_dm_topic_send and metadata_reply_to is not None else None
@@ -2211,10 +2309,22 @@ class TelegramAdapter(BasePlatformAdapter):
                 if private_dm_topic_send:
                     should_thread = (
                         reply_to_source is not None
-                        and self._reply_to_mode != "off"
+                        and (
+                            self._reply_to_mode != "off"
+                            or dm_topic_explicit_quote_reply
+                        )
                     )
                 else:
-                    should_thread = self._should_thread_reply(reply_to_source, i)
+                    explicit_quote_reply = False
+                    if (
+                        reply_to_source is None
+                        and metadata_reply_to is not None
+                        and metadata_reply_quote
+                        and i == 0
+                    ):
+                        reply_to_source = str(metadata_reply_to)
+                        explicit_quote_reply = True
+                    should_thread = explicit_quote_reply or self._should_thread_reply(reply_to_source, i)
                 reply_to_id = int(reply_to_source) if should_thread and reply_to_source else None
                 if private_dm_topic_send and reply_to_id is None and not dm_topic_reply_to_off:
                     return SendResult(
@@ -2233,6 +2343,7 @@ class TelegramAdapter(BasePlatformAdapter):
                     thread_kwargs = dict(thread_kwargs)
                     thread_kwargs["message_thread_id"] = None
                 effective_thread_id = thread_kwargs.get("message_thread_id")
+                reply_parameters = self._reply_parameters_for_send(reply_to_id, metadata)
 
                 msg = None
                 for _send_attempt in range(3):
@@ -2243,7 +2354,8 @@ class TelegramAdapter(BasePlatformAdapter):
                                 chat_id=int(chat_id),
                                 text=chunk,
                                 parse_mode=ParseMode.MARKDOWN_V2,
-                                reply_to_message_id=reply_to_id,
+                                reply_to_message_id=None if reply_parameters else reply_to_id,
+                                reply_parameters=reply_parameters,
                                 **thread_kwargs,
                                 **self._link_preview_kwargs(),
                                 **self._notification_kwargs(metadata),
@@ -2257,7 +2369,8 @@ class TelegramAdapter(BasePlatformAdapter):
                                     chat_id=int(chat_id),
                                     text=plain_chunk,
                                     parse_mode=None,
-                                    reply_to_message_id=reply_to_id,
+                                    reply_to_message_id=None if reply_parameters else reply_to_id,
+                                    reply_parameters=reply_parameters,
                                     **thread_kwargs,
                                     **self._link_preview_kwargs(),
                                     **self._notification_kwargs(metadata),
@@ -2319,6 +2432,7 @@ class TelegramAdapter(BasePlatformAdapter):
                                     self.name, send_err,
                                 )
                                 reply_to_id = None
+                                reply_parameters = None
                                 if metadata and metadata.get("telegram_dm_topic_reply_fallback"):
                                     thread_kwargs = {}
                                     effective_thread_id = None
@@ -6348,6 +6462,12 @@ class TelegramAdapter(BasePlatformAdapter):
             chat_type = "group"
         elif telegram_chat_type == "channel":
             chat_type = "channel"
+        elif str(getattr(chat, "id", "")).startswith("-"):
+            # Defensive fallback for tests/mocks and unusual PTB enum string
+            # forms. Telegram groups/supergroups use negative chat ids; never
+            # treat those as private DMs just because the type could not be
+            # normalized.
+            chat_type = "group"
 
         # Resolve Telegram topic name and skill binding.
         # Only preserve message_thread_id when Telegram marks the message as
@@ -6448,6 +6568,14 @@ class TelegramAdapter(BasePlatformAdapter):
                     or message.reply_to_message.caption
                     or None
                 )
+            if _is_telegram_unsupported_placeholder(reply_to_text):
+                logger.debug(
+                    "[Telegram] Dropping unsupported-message placeholder from reply context "
+                    "for message %s replying to %s",
+                    getattr(message, "message_id", None),
+                    reply_to_id,
+                )
+                reply_to_text = None
 
         # Per-channel/topic ephemeral prompt
         from gateway.platforms.base import resolve_channel_prompt

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -67,6 +67,14 @@ _AGENT_CACHE_IDLE_TTL_SECS = 3600.0  # evict agents idle for >1h
 _PLATFORM_CONNECT_TIMEOUT_SECS_DEFAULT = 30.0
 _ADAPTER_DISCONNECT_TIMEOUT_SECS_DEFAULT = 5.0
 _TELEGRAM_COMMAND_MENTION_RE = re.compile(r"(?<![\w:/])/([A-Za-z0-9][A-Za-z0-9_-]*)")
+_TELEGRAM_UNSUPPORTED_MESSAGE_PLACEHOLDER = (
+    "This message is not supported in your version of Telegram. "
+    "Please update to the latest version."
+)
+
+
+def _is_telegram_unsupported_message_placeholder(text: Optional[str]) -> bool:
+    return bool(text and str(text).strip() == _TELEGRAM_UNSUPPORTED_MESSAGE_PLACEHOLDER)
 
 _TELEGRAM_NOISY_STATUS_RE = re.compile(
     r"("  # transient/auxiliary status that should stay in logs, not Telegram chat
@@ -3676,7 +3684,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 return True
 
             reply_anchor = self._reply_anchor_for_event(event)
-            thread_meta = self._thread_metadata_for_source(event.source, reply_anchor)
+            thread_meta = self._thread_metadata_for_source(event.source, reply_anchor, event.text)
             if self._queue_during_drain_enabled():
                 self._queue_or_replace_pending_event(session_key, event)
                 message = f"⏳ Gateway {self._status_action_gerund()} — queued for the next turn after it comes back."
@@ -3882,7 +3890,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             logger.debug("Failed to apply busy-input onboarding hint: %s", _onb_err)
 
         reply_anchor = self._reply_anchor_for_event(event)
-        thread_meta = self._thread_metadata_for_source(event.source, reply_anchor)
+        thread_meta = self._thread_metadata_for_source(event.source, reply_anchor, event.text)
         try:
             await adapter._send_with_retry(
                 chat_id=event.source.chat_id,
@@ -7807,14 +7815,24 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 context_note = _build_document_context_note(display_name, agent_path, mtype)
                 message_text = f"{context_note}\n\n{message_text}"
 
-        if getattr(event, "reply_to_text", None) and event.reply_to_message_id:
+        reply_to_text = getattr(event, "reply_to_text", None)
+        if _is_telegram_unsupported_message_placeholder(reply_to_text):
+            logger.debug(
+                "Dropping Telegram unsupported-message placeholder before prompt injection "
+                "for message %s replying to %s",
+                getattr(event, "message_id", None),
+                getattr(event, "reply_to_message_id", None),
+            )
+            reply_to_text = None
+
+        if reply_to_text and event.reply_to_message_id:
             # Always inject the reply-to pointer — even when the quoted text
             # already appears in history. The prefix isn't deduplication, it's
             # disambiguation: it tells the agent *which* prior message the user
             # is referencing. History can contain the same or similar text
             # multiple times, and without an explicit pointer the agent has to
             # guess (or answer for both subjects). Token overhead is minimal.
-            reply_snippet = event.reply_to_text[:500]
+            reply_snippet = reply_to_text[:500]
             message_text = f'[Replying to: "{reply_snippet}"]\n\n{message_text}'
 
         if "@" in message_text:
@@ -9907,7 +9925,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 await adapter.play_in_voice_channel(guild_id, actual_path)
             elif adapter and hasattr(adapter, "send_voice"):
                 reply_anchor = self._reply_anchor_for_event(event)
-                thread_meta = self._thread_metadata_for_source(event.source, reply_anchor)
+                thread_meta = self._thread_metadata_for_source(event.source, reply_anchor, event.text)
                 # Mark the auto voice reply as notify-worthy.  Mirrors the
                 # final-text path in gateway/platforms/base.py which sets
                 # ``notify=True`` so platform adapters that gate push
@@ -9973,7 +9991,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             local_files, _ = adapter.extract_local_files(cleaned)
             local_files = BasePlatformAdapter.filter_local_delivery_paths(local_files)
 
-            _thread_meta = self._thread_metadata_for_source(event.source, self._reply_anchor_for_event(event))
+            _thread_meta = self._thread_metadata_for_source(event.source, self._reply_anchor_for_event(event), event.text)
 
             _VIDEO_EXTS = {'.mp4', '.mov', '.avi', '.mkv', '.webm', '.3gp'}
             _IMAGE_EXTS = {'.jpg', '.jpeg', '.png', '.webp', '.gif'}
@@ -10079,7 +10097,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             logger.warning("No adapter for platform %s in background task %s", source.platform, task_id)
             return
 
-        _thread_metadata = self._thread_metadata_for_source(source, event_message_id)
+        _thread_metadata = self._thread_metadata_for_source(source, event_message_id, message_text)
 
         try:
             user_config = _load_gateway_config()
@@ -10993,6 +11011,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         self,
         source,
         reply_to_message_id: Optional[str] = None,
+        reply_quote_text: Optional[str] = None,
     ) -> Optional[Dict[str, Any]]:
         """Build the metadata dict platforms need for thread-aware replies."""
         return self._thread_metadata_for_target(
@@ -11001,6 +11020,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             getattr(source, "thread_id", None),
             chat_type=getattr(source, "chat_type", None),
             reply_to_message_id=reply_to_message_id or getattr(source, "message_id", None),
+            reply_quote_text=reply_quote_text,
         )
 
     def _thread_metadata_for_target(
@@ -11011,6 +11031,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         *,
         chat_type: Optional[str] = None,
         reply_to_message_id: Optional[str] = None,
+        reply_quote_text: Optional[str] = None,
         adapter: Optional[Any] = None,
     ) -> Optional[Dict[str, Any]]:
         """Build thread metadata for synthetic sends that only have routing state."""
@@ -11033,6 +11054,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 metadata["direct_messages_topic_id"] = tid
             if reply_to_message_id is not None:
                 metadata["telegram_reply_to_message_id"] = str(reply_to_message_id)
+            if reply_quote_text:
+                metadata["telegram_reply_quote"] = str(reply_quote_text)
+        elif platform == Platform.TELEGRAM and reply_quote_text:
+            if reply_to_message_id is not None:
+                metadata["telegram_reply_to_message_id"] = str(reply_to_message_id)
+                metadata["telegram_reply_quote"] = str(reply_quote_text)
         return metadata
 
     @staticmethod
@@ -12891,7 +12918,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             else bool(_plat_streaming)
         )
 
-        _thread_metadata: Optional[Dict[str, Any]] = self._thread_metadata_for_source(source, event_message_id)
+        _thread_metadata: Optional[Dict[str, Any]] = self._thread_metadata_for_source(source, event_message_id, message)
 
         if _streaming_enabled:
             try:
@@ -13442,7 +13469,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         else:
             _progress_thread_id = source.thread_id
         _progress_metadata = (
-            self._thread_metadata_for_source(source, event_message_id)
+            self._thread_metadata_for_source(source, event_message_id, message)
             if _progress_thread_id == source.thread_id
             else {"thread_id": _progress_thread_id}
         ) if _progress_thread_id else None

--- a/tests/gateway/test_reply_to_injection.py
+++ b/tests/gateway/test_reply_to_injection.py
@@ -137,6 +137,29 @@ async def test_no_prefix_when_reply_to_text_is_empty():
 
 
 @pytest.mark.asyncio
+async def test_telegram_unsupported_placeholder_not_injected():
+    runner = _make_runner()
+    source = _source()
+    event = MessageEvent(
+        text="Can this live in Drive?",
+        source=source,
+        reply_to_message_id="42",
+        reply_to_text=(
+            "This message is not supported in your version of Telegram. "
+            "Please update to the latest version."
+        ),
+    )
+
+    result = await runner._prepare_inbound_message_text(
+        event=event,
+        source=source,
+        history=[],
+    )
+
+    assert result == "Can this live in Drive?"
+
+
+@pytest.mark.asyncio
 async def test_reply_snippet_truncated_to_500_chars():
     runner = _make_runner()
     source = _source()
@@ -157,3 +180,28 @@ async def test_reply_snippet_truncated_to_500_chars():
     assert result is not None
     assert result.startswith('[Replying to: "' + "x" * 500 + '"]')
     assert "x" * 501 not in result
+
+
+def test_telegram_group_topic_metadata_keeps_trigger_quote():
+    runner = _make_runner()
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="-100123",
+        chat_name="Eve Engineering",
+        chat_type="group",
+        user_name="Alice",
+        thread_id="20197",
+        message_id="463",
+    )
+
+    metadata = runner._thread_metadata_for_source(
+        source,
+        reply_to_message_id=None,
+        reply_quote_text="Can this live in Drive?",
+    )
+
+    assert metadata == {
+        "thread_id": "20197",
+        "telegram_reply_to_message_id": "463",
+        "telegram_reply_quote": "Can this live in Drive?",
+    }

--- a/tests/gateway/test_telegram_reply_quote.py
+++ b/tests/gateway/test_telegram_reply_quote.py
@@ -26,6 +26,7 @@ def _ensure_telegram_mock():
     telegram_mod.constants.ChatType.SUPERGROUP = "supergroup"
     telegram_mod.constants.ChatType.CHANNEL = "channel"
     telegram_mod.constants.ChatType.PRIVATE = "private"
+    telegram_mod.ChatType = telegram_mod.constants.ChatType
 
     for name in ("telegram", "telegram.ext", "telegram.constants", "telegram.request"):
         sys.modules.setdefault(name, telegram_mod)
@@ -126,6 +127,26 @@ def test_caption_fallback_when_no_quote_and_no_text():
     event = adapter._build_message_event(msg, MessageType.TEXT)
 
     assert event.reply_to_text == "Photo caption from earlier"
+
+
+def test_unsupported_placeholder_is_not_used_as_reply_to_text():
+    """Telegram's unsupported-message placeholder is routing metadata, not quote context."""
+    from gateway.platforms.base import MessageType
+
+    adapter = _make_adapter()
+    msg = _make_message(
+        text="what did I ask?",
+        reply_to_text=(
+            "This message is not supported in your version of Telegram. "
+            "Please update to the latest version."
+        ),
+        quote_text=None,
+    )
+
+    event = adapter._build_message_event(msg, MessageType.TEXT)
+
+    assert event.reply_to_message_id == "42"
+    assert event.reply_to_text is None
 
 
 def test_empty_quote_text_falls_back_to_full_reply():

--- a/tests/gateway/test_telegram_thread_fallback.py
+++ b/tests/gateway/test_telegram_thread_fallback.py
@@ -68,6 +68,13 @@ class _FakeInputMediaPhoto:
         self.kwargs = kwargs
 
 
+class _FakeReplyParameters:
+    def __init__(self, message_id, quote=None, **kwargs):
+        self.message_id = message_id
+        self.quote = quote
+        self.kwargs = kwargs
+
+
 _fake_telegram = types.ModuleType("telegram")
 _fake_telegram.Update = object
 _fake_telegram.Bot = object
@@ -75,6 +82,7 @@ _fake_telegram.Message = object
 _fake_telegram.InlineKeyboardButton = _FakeInlineKeyboardButton
 _fake_telegram.InlineKeyboardMarkup = _FakeInlineKeyboardMarkup
 _fake_telegram.InputMediaPhoto = _FakeInputMediaPhoto
+_fake_telegram.ReplyParameters = _FakeReplyParameters
 _fake_telegram_error = types.ModuleType("telegram.error")
 _fake_telegram_error.NetworkError = FakeNetworkError
 _fake_telegram_error.BadRequest = FakeBadRequest
@@ -566,6 +574,7 @@ async def test_gateway_runner_busy_ack_replies_to_triggering_message_for_telegra
         "telegram_dm_topic_reply_fallback": True,
         "direct_messages_topic_id": "20197",
         "telegram_reply_to_message_id": "463",
+        "telegram_reply_quote": "busy follow-up",
     }
 
 
@@ -624,6 +633,75 @@ async def test_send_uses_reply_anchor_when_direct_topic_fallback_metadata_exists
     assert call_log[0]["reply_to_message_id"] == 462
     assert call_log[0]["message_thread_id"] == 20197
     assert "direct_messages_topic_id" not in call_log[0]
+
+
+@pytest.mark.asyncio
+async def test_send_uses_explicit_quote_for_dm_topic_when_reply_to_mode_off(monkeypatch):
+    """reply_to_mode=off should not let Telegram infer an unsupported preview."""
+    from gateway.platforms import telegram as telegram_mod
+
+    monkeypatch.setattr(telegram_mod, "ReplyParameters", _FakeReplyParameters)
+    adapter = _make_adapter()
+    adapter._reply_to_mode = "off"
+    call_log = []
+
+    async def mock_send_message(**kwargs):
+        call_log.append(kwargs)
+        return SimpleNamespace(message_id=777)
+
+    adapter._bot = SimpleNamespace(send_message=mock_send_message)
+
+    result = await adapter.send(
+        chat_id="123",
+        content="test message",
+        metadata={
+            "thread_id": "20197",
+            "telegram_dm_topic_reply_fallback": True,
+            "direct_messages_topic_id": "20197",
+            "telegram_reply_to_message_id": "462",
+            "telegram_reply_quote": "what did I ask Eve to do?",
+        },
+    )
+
+    assert result.success is True
+    assert call_log[0]["reply_to_message_id"] is None
+    assert call_log[0]["message_thread_id"] == 20197
+    assert call_log[0]["reply_parameters"].message_id == 462
+    assert call_log[0]["reply_parameters"].quote == "what did I ask Eve to do?"
+    assert "direct_messages_topic_id" not in call_log[0]
+
+
+@pytest.mark.asyncio
+async def test_send_uses_explicit_quote_for_group_topic(monkeypatch):
+    """Forum-topic sends should quote the triggering user message, not the topic seed."""
+    from gateway.platforms import telegram as telegram_mod
+
+    monkeypatch.setattr(telegram_mod, "ReplyParameters", _FakeReplyParameters)
+    adapter = _make_adapter()
+    adapter._reply_to_mode = "off"
+    call_log = []
+
+    async def mock_send_message(**kwargs):
+        call_log.append(kwargs)
+        return SimpleNamespace(message_id=777)
+
+    adapter._bot = SimpleNamespace(send_message=mock_send_message)
+
+    result = await adapter.send(
+        chat_id="-100123",
+        content="test message",
+        metadata={
+            "thread_id": "20197",
+            "telegram_reply_to_message_id": "463",
+            "telegram_reply_quote": "Can this live in Drive?",
+        },
+    )
+
+    assert result.success is True
+    assert call_log[0]["reply_to_message_id"] is None
+    assert call_log[0]["message_thread_id"] == 20197
+    assert call_log[0]["reply_parameters"].message_id == 463
+    assert call_log[0]["reply_parameters"].quote == "Can this live in Drive?"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- Preserve the triggering Telegram user message text in topic reply metadata.
- Use explicit Telegram `ReplyParameters.quote` for topic replies when Hermes has the trigger id and trigger text.
- Drop Telegram's generic unsupported-message placeholder from both adapter extraction and common inbound prompt preparation.
- Cover DM-topic and forum/group-topic routing in focused gateway tests.

## Root Cause

Telegram topic routing can expose `message_thread_id` values that identify a topic service/seed message rather than the actual user prompt. When Hermes lets Telegram infer the visible quote target, clients can render the wrong quoted message, including a topic-created service message or Telegram's generic unsupported-message placeholder.

## Impact

Topic replies now quote the actual triggering user request when Hermes has enough metadata, while ordinary `reply_to_mode=off` behavior remains unchanged for sends that do not carry explicit quote metadata.

## Validation

- `/home/rj/.hermes/hermes-agent/venv/bin/python -m pytest tests/gateway/test_reply_to_injection.py tests/gateway/test_telegram_thread_fallback.py tests/gateway/test_telegram_reply_quote.py tests/gateway/test_telegram_reply_mode.py`
- Result: `100 passed`
