### PR TITLE
fix(cli): fall back to on-disk MemoryStore when agent store unavailable

### DIFF
--- a/hermes_cli/cli_commands_mixin.py
+++ b/hermes_cli/cli_commands_mixin.py
@@ -1407,6 +1407,14 @@ class CLICommandsMixin:
         parts = cmd.strip().split()
         args = parts[1:] if len(parts) > 1 else []
         store = getattr(self.agent, "_memory_store", None) if getattr(self, "agent", None) else None
+        if store is None:
+            # The TUI slash-worker and other contexts may not have a live
+            # agent with an initialized memory store.  Fall back to a fresh
+            # on-disk store (same approach as the messaging-gateway handler)
+            # so /memory approve works from every surface.  (#47363)
+            from tools.memory_tool import MemoryStore
+            store = MemoryStore()
+            store.load_from_disk()
         out = handle_pending_subcommand(
             wa.MEMORY, args,
             memory_store=store,

--- a/tests/hermes_cli/test_memory_command_fallback_store.py
+++ b/tests/hermes_cli/test_memory_command_fallback_store.py
@@ -1,0 +1,81 @@
+"""Test that _handle_memory_command falls back to a fresh MemoryStore when
+the agent does not have one (e.g., TUI slash-worker context).  Fixes #47363.
+"""
+
+import io
+import os
+import tempfile
+import shutil
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+@pytest.fixture
+def hermes_home(monkeypatch):
+    d = tempfile.mkdtemp(prefix="hermes_mem_cmd_")
+    home = os.path.join(d, ".hermes")
+    os.makedirs(home)
+    monkeypatch.setenv("HERMES_HOME", home)
+    # Create minimal MEMORY.md so MemoryStore.load_from_disk() succeeds
+    with open(os.path.join(home, "MEMORY.md"), "w") as f:
+        f.write("- test entry\n")
+    yield home
+    shutil.rmtree(d, ignore_errors=True)
+
+
+def test_memory_command_falls_back_to_disk_store(hermes_home, monkeypatch):
+    """When self.agent is None (TUI slash-worker), _handle_memory_command
+    should construct a MemoryStore from disk rather than passing None."""
+    from hermes_cli.cli_commands_mixin import CLICommandsMixin
+
+    # Build a minimal mixin instance with no agent
+    obj = object.__new__(CLICommandsMixin)
+    obj.agent = None
+
+    # Patch handle_pending_subcommand to capture what store is passed
+    captured = {}
+
+    def fake_handle(subsystem, args, memory_store=None, set_mode_fn=None):
+        captured["store"] = memory_store
+        captured["subsystem"] = subsystem
+        return "ok"
+
+    with patch(
+        "hermes_cli.write_approval_commands.handle_pending_subcommand",
+        side_effect=fake_handle,
+    ):
+        # Redirect stdout since the method prints
+        with patch("builtins.print"):
+            obj._handle_memory_command("/memory pending")
+
+    # The store should NOT be None — it should be a MemoryStore loaded from disk
+    assert captured["store"] is not None
+    assert hasattr(captured["store"], "memory_entries")
+
+
+def test_memory_command_uses_agent_store_when_available(hermes_home, monkeypatch):
+    """When self.agent._memory_store exists, use it directly."""
+    from hermes_cli.cli_commands_mixin import CLICommandsMixin
+
+    obj = object.__new__(CLICommandsMixin)
+    mock_store = MagicMock()
+    mock_agent = MagicMock()
+    mock_agent._memory_store = mock_store
+    obj.agent = mock_agent
+
+    captured = {}
+
+    def fake_handle(subsystem, args, memory_store=None, set_mode_fn=None):
+        captured["store"] = memory_store
+        return "ok"
+
+    with patch(
+        "hermes_cli.write_approval_commands.handle_pending_subcommand",
+        side_effect=fake_handle,
+    ):
+        with patch("builtins.print"):
+            obj._handle_memory_command("/memory pending")
+
+    # Should use the agent's existing store
+    assert captured["store"] is mock_store


### PR DESCRIPTION
## Problem

When `/memory approve` (or any `/memory` subcommand) is run from the TUI slash-worker or dashboard chat, the `HermesCLI` instance has no agent with an initialized `_memory_store`. The code passes `None` to `handle_pending_subcommand()`, which causes every approval to fail with:

```
Failed:
  <id>: memory store unavailable
```

Pending entries pile up in `~/.hermes/pending/memory/` and can never be approved from the TUI surface.

## Root Cause

In `hermes_cli/cli_commands_mixin.py`, `_handle_memory_command()` only tries to get the store from `self.agent._memory_store`. In the TUI slash-worker context (`tui_gateway/slash_worker.py`), the agent either isn't built or is initialized without a memory store (`skip_memory=True`), so the store is always `None`.

Meanwhile, the messaging-gateway handler (`gateway/slash_commands.py:2194`) constructs a fresh `MemoryStore()` and calls `load_from_disk()` — which works correctly.

## Fix

Mirror the gateway's approach: when `self.agent._memory_store` is unavailable, construct a fresh on-disk store instead of passing `None`. The store persists to the same `MEMORY.md` / `USER.md`, so a fresh instance is safe.

## Tests

Added `tests/hermes_cli/test_memory_command_fallback_store.py` with two test cases:
- Verifies fallback to disk-loaded store when agent has no store
- Verifies existing agent store is used when available

Fixes #47363