### PR TITLE
fix(skills): pass encoding="utf-8" on skills-hub file I/O

### DIFF
--- a/tests/tools/test_skills_hub_encoding.py
+++ b/tests/tools/test_skills_hub_encoding.py
@@ -1,0 +1,55 @@
+"""Encoding-safety guard for the Skills Hub file I/O.
+
+The hub state files (lock.json, taps.json, the skill-index caches) are written
+with ``json.dumps(..., ensure_ascii=False)`` and carry skill metadata that can
+contain emoji / CJK / accented text. ``Path.write_text()`` / ``Path.read_text()``
+without an explicit ``encoding=`` use the platform locale codec — ``cp1252`` /
+``GBK`` on Windows — which raises ``UnicodeEncodeError`` (or silently mojibakes)
+on that content, corrupting installs.
+
+``scripts/check-windows-footguns.py`` only flags the builtin ``open()`` and
+deliberately skips ``.write_text()`` / ``.read_text()`` method calls, so this
+guard covers that gap for the two skills-hub I/O modules. Mirrors the static
+AST checks in ``test_windows_compat.py``.
+"""
+
+import ast
+from pathlib import Path
+
+import pytest
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent
+
+# Modules that own the skills-hub state files and must round-trip non-ASCII.
+GUARDED_FILES = [
+    "tools/skills_hub.py",
+    "tools/skills_sync.py",
+]
+
+_TEXT_IO_METHODS = {"write_text", "read_text"}
+
+
+def _text_io_without_encoding(relpath: str) -> list[int]:
+    """Line numbers of Path.write_text/read_text calls missing encoding=."""
+    source = (PROJECT_ROOT / relpath).read_text(encoding="utf-8")
+    tree = ast.parse(source, filename=relpath)
+    missing = []
+    for node in ast.walk(tree):
+        if (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and node.func.attr in _TEXT_IO_METHODS
+            and not any(kw.arg == "encoding" for kw in node.keywords)
+        ):
+            missing.append(node.lineno)
+    return missing
+
+
+@pytest.mark.parametrize("relpath", GUARDED_FILES)
+def test_text_io_specifies_encoding(relpath):
+    missing = _text_io_without_encoding(relpath)
+    assert not missing, (
+        f"{relpath}: Path.write_text/read_text without encoding= at line(s) "
+        f"{missing}. Pass encoding='utf-8' — cp1252/GBK locales corrupt the "
+        f"non-ASCII skill metadata these hub files carry."
+    )

--- a/tools/skills_hub.py
+++ b/tools/skills_hub.py
@@ -921,7 +921,7 @@ class GitHubSource(SkillSource):
             stat = cache_file.stat()
             if time.time() - stat.st_mtime > INDEX_CACHE_TTL:
                 return None
-            return json.loads(cache_file.read_text())
+            return json.loads(cache_file.read_text(encoding="utf-8"))
         except (OSError, json.JSONDecodeError):
             return None
 
@@ -930,7 +930,7 @@ class GitHubSource(SkillSource):
         INDEX_CACHE_DIR.mkdir(parents=True, exist_ok=True)
         cache_file = INDEX_CACHE_DIR / f"{key}.json"
         try:
-            cache_file.write_text(json.dumps(data, ensure_ascii=False))
+            cache_file.write_text(json.dumps(data, ensure_ascii=False), encoding="utf-8")
         except OSError as e:
             logger.debug("Could not write cache: %s", e)
 
@@ -3104,7 +3104,7 @@ def _read_index_cache(key: str) -> Optional[Any]:
         stat = cache_file.stat()
         if time.time() - stat.st_mtime > INDEX_CACHE_TTL:
             return None
-        return json.loads(cache_file.read_text())
+        return json.loads(cache_file.read_text(encoding="utf-8"))
     except (OSError, json.JSONDecodeError):
         return None
 
@@ -3118,12 +3118,12 @@ def _write_index_cache(key: str, data: Any) -> None:
     ignore_file = HUB_DIR / ".ignore"
     if not ignore_file.exists():
         try:
-            ignore_file.write_text("# Exclude hub internals from search tools\n*\n")
+            ignore_file.write_text("# Exclude hub internals from search tools\n*\n", encoding="utf-8")
         except OSError:
             pass
     cache_file = INDEX_CACHE_DIR / f"{key}.json"
     try:
-        cache_file.write_text(json.dumps(data, ensure_ascii=False, default=str))
+        cache_file.write_text(json.dumps(data, ensure_ascii=False, default=str), encoding="utf-8")
     except OSError as e:
         logger.debug("Could not write cache: %s", e)
 
@@ -3157,13 +3157,13 @@ class HubLockFile:
         if not self.path.exists():
             return {"version": 1, "installed": {}}
         try:
-            return json.loads(self.path.read_text())
+            return json.loads(self.path.read_text(encoding="utf-8"))
         except (json.JSONDecodeError, OSError):
             return {"version": 1, "installed": {}}
 
     def save(self, data: dict) -> None:
         self.path.parent.mkdir(parents=True, exist_ok=True)
-        self.path.write_text(json.dumps(data, indent=2, ensure_ascii=False) + "\n")
+        self.path.write_text(json.dumps(data, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
 
     def record_install(
         self,
@@ -3229,14 +3229,14 @@ class TapsManager:
         if not self.path.exists():
             return []
         try:
-            data = json.loads(self.path.read_text())
+            data = json.loads(self.path.read_text(encoding="utf-8"))
             return data.get("taps", [])
         except (json.JSONDecodeError, OSError):
             return []
 
     def save(self, taps: List[dict]) -> None:
         self.path.parent.mkdir(parents=True, exist_ok=True)
-        self.path.write_text(json.dumps({"taps": taps}, indent=2) + "\n")
+        self.path.write_text(json.dumps({"taps": taps}, indent=2) + "\n", encoding="utf-8")
 
     def add(self, repo: str, path: str = "skills/") -> bool:
         """Add a tap. Returns False if already exists."""
@@ -3290,11 +3290,11 @@ def ensure_hub_dirs() -> None:
     QUARANTINE_DIR.mkdir(exist_ok=True)
     INDEX_CACHE_DIR.mkdir(exist_ok=True)
     if not LOCK_FILE.exists():
-        LOCK_FILE.write_text('{"version": 1, "installed": {}}\n')
+        LOCK_FILE.write_text('{"version": 1, "installed": {}}\n', encoding="utf-8")
     if not AUDIT_LOG.exists():
         AUDIT_LOG.touch()
     if not TAPS_FILE.exists():
-        TAPS_FILE.write_text('{"taps": []}\n')
+        TAPS_FILE.write_text('{"taps": []}\n', encoding="utf-8")
 
 
 def quarantine_bundle(bundle: SkillBundle) -> Path:
@@ -3538,7 +3538,7 @@ def _load_hermes_index() -> Optional[dict]:
         try:
             age = time.time() - HERMES_INDEX_CACHE_FILE.stat().st_mtime
             if age < HERMES_INDEX_TTL:
-                return json.loads(HERMES_INDEX_CACHE_FILE.read_text())
+                return json.loads(HERMES_INDEX_CACHE_FILE.read_text(encoding="utf-8"))
         except (OSError, json.JSONDecodeError):
             pass
 
@@ -3560,7 +3560,7 @@ def _load_hermes_index() -> Optional[dict]:
     # Cache locally
     try:
         HERMES_INDEX_CACHE_FILE.parent.mkdir(parents=True, exist_ok=True)
-        HERMES_INDEX_CACHE_FILE.write_text(json.dumps(data))
+        HERMES_INDEX_CACHE_FILE.write_text(json.dumps(data), encoding="utf-8")
     except OSError:
         pass
 
@@ -3571,7 +3571,7 @@ def _load_stale_index_cache() -> Optional[dict]:
     """Fall back to stale cache when the network fetch fails."""
     if HERMES_INDEX_CACHE_FILE.exists():
         try:
-            return json.loads(HERMES_INDEX_CACHE_FILE.read_text())
+            return json.loads(HERMES_INDEX_CACHE_FILE.read_text(encoding="utf-8"))
         except (OSError, json.JSONDecodeError):
             pass
     return None

--- a/tools/skills_sync.py
+++ b/tools/skills_sync.py
@@ -373,7 +373,7 @@ def _backfill_optional_provenance(quiet: bool = False) -> List[str]:
 
     lock_path = SKILLS_DIR / ".hub" / "lock.json"
     try:
-        data = json.loads(lock_path.read_text()) if lock_path.exists() else {"version": 1, "installed": {}}
+        data = json.loads(lock_path.read_text(encoding="utf-8")) if lock_path.exists() else {"version": 1, "installed": {}}
     except (json.JSONDecodeError, OSError):
         data = {"version": 1, "installed": {}}
     installed = data.setdefault("installed", {})


### PR DESCRIPTION
## What does this PR do?

`Path.write_text()` / `Path.read_text()` without an explicit `encoding=` use the platform locale codec: UTF-8 on Linux/macOS, but `cp1252` / `GBK` on Windows. The Skills Hub state files written by these two modules carry skill metadata that is routinely non-ASCII:

- `lock.json` (`HubLockFile`), `taps.json`, and the skill-index caches are written with `json.dumps(..., ensure_ascii=False)`, so emoji / CJK / accented characters in a skill's name or description are written as raw Unicode.
- On a non-UTF-8 Windows locale that `write_text` raises `UnicodeEncodeError: 'charmap' codec can't encode character ...`, and the install record is left missing or truncated. Reads mojibake symmetrically.

This adds `encoding="utf-8"` to every `write_text` / `read_text` call in `tools/skills_hub.py` and `tools/skills_sync.py`, making them deterministic on every platform. Several callsites in these same files already pass `encoding="utf-8"`; this brings the rest in line.

## Why CI didn't catch it

`scripts/check-windows-footguns.py` flags the builtin `open()` without `encoding=`, but it intentionally does **not** flag `Path.write_text()` / `Path.read_text()` (see the comment on the `open()` rule: it requires a start-of-identifier boundary before `open(` and skips method calls). So this whole class is invisible to the checker.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] Cross-platform compatibility (Windows)

## Changes Made

- `tools/skills_hub.py` — `encoding="utf-8"` on the 14 `read_text` / `write_text` calls for the index cache, the `.ignore` marker, `lock.json` (`HubLockFile`), `taps.json` (`TapsManager`), `ensure_hub_dirs()`, and the Hermes index cache.
- `tools/skills_sync.py` — `encoding="utf-8"` on the `lock.json` read in `_backfill_optional_provenance()`.
- `tests/tools/test_skills_hub_encoding.py` — static AST guard asserting every `write_text` / `read_text` in those two modules passes `encoding=`. Mirrors the static checks in `tests/tools/test_windows_compat.py`.

## Related

- #16440 (open since April, no activity since) proposes *atomic* writes for `lock.json` / `taps.json`, which is an orthogonal crash-safety concern and does not add `encoding=`. This PR is about text *encoding* and additionally covers the index caches and `skills_sync.py`, which #16440 does not touch. The two changes are independent.

## How to Test

1. `python -m pytest tests/tools/test_skills_hub_encoding.py -q` → passes.
2. Revert only the `tools/` changes (keep the test) → it fails, listing the unencoded callsites, demonstrating the gap.
3. `python -m pytest tests/tools/test_skills_hub.py tests/tools/test_skills_sync.py -q` → 202 passed.
4. `python scripts/check-windows-footguns.py tools/skills_hub.py tools/skills_sync.py` → clean.

## Checklist

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(skills): ...`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've added a regression test
- [x] I've run the affected tests (202 passed) and the new guard
- [x] I've tested on my platform: Linux (Fedora), Python 3.14
- [x] Cross-platform: the change makes `write_text` / `read_text` behavior identical on Windows, macOS, and Linux
