### PR TITLE
fix(tools): reap tar/ssh subprocesses on non-timeout errors in SSH bulk upload

### DIFF
--- a/tests/tools/test_ssh_bulk_upload.py
+++ b/tests/tools/test_ssh_bulk_upload.py
@@ -453,6 +453,43 @@ class TestSSHBulkUpload:
         mock_tar.kill.assert_called_once()
         mock_ssh.kill.assert_called_once()
 
+    def test_communicate_error_kills_both_processes(self, mock_env, tmp_path):
+        """A non-timeout error during communicate must still reap both procs.
+
+        Only subprocess.TimeoutExpired was handled, so a different failure mid
+        communicate (e.g. an OSError from a dropped control socket, or EINTR
+        from a signal) propagated without killing tar/ssh — leaking a zombie
+        pair per failed sync on a long-lived gateway.
+        """
+        f1 = tmp_path / "t.txt"
+        f1.write_text("t")
+        files = [(str(f1), "/home/testuser/.hermes/skills/t.txt")]
+
+        mock_tar = MagicMock()
+        mock_tar.stdout = MagicMock()
+        mock_tar.returncode = None
+        mock_tar.poll.return_value = None
+
+        mock_ssh = MagicMock()
+        mock_ssh.communicate.side_effect = OSError("Socket is not connected")
+        mock_ssh.returncode = None
+
+        def make_proc(cmd, **kwargs):
+            if cmd[0] == "tar":
+                return mock_tar
+            return mock_ssh
+
+        with patch.object(subprocess, "run",
+                          return_value=subprocess.CompletedProcess([], 0)), \
+             patch.object(subprocess, "Popen", side_effect=make_proc):
+            with pytest.raises(OSError, match="Socket is not connected"):
+                mock_env._ssh_bulk_upload(files)
+
+        mock_tar.kill.assert_called_once()
+        mock_ssh.kill.assert_called_once()
+        mock_tar.wait.assert_called_once()
+        mock_ssh.wait.assert_called_once()
+
 
 class TestSSHBulkUploadWiring:
     """Verify bulk_upload_fn is wired into FileSyncManager."""

--- a/tools/environments/ssh.py
+++ b/tools/environments/ssh.py
@@ -286,6 +286,19 @@ class SSHEnvironment(BaseEnvironment):
                 tar_proc.wait()
                 ssh_proc.wait()
                 raise RuntimeError("SSH bulk upload timed out")
+            except Exception:
+                # Any other failure (e.g. EINTR from a signal, or a dropped
+                # control socket) must still reap both children, or a
+                # long-lived gateway accumulates a zombie tar/ssh pair per
+                # failed sync. Mirror the timeout cleanup above.
+                for proc in (tar_proc, ssh_proc):
+                    try:
+                        proc.kill()
+                    except OSError:
+                        pass
+                tar_proc.wait()
+                ssh_proc.wait()
+                raise
 
             if tar_proc.returncode != 0:
                 raise RuntimeError(


### PR DESCRIPTION
## What does this PR do?

`_ssh_bulk_upload` in `tools/environments/ssh.py` pipes a local `tar c` through SSH into a remote `tar x`. The block that drives the transfer only handles `subprocess.TimeoutExpired`:

```python
try:
    _, ssh_stderr = ssh_proc.communicate(timeout=120)
    ...
except subprocess.TimeoutExpired:
    tar_proc.kill(); ssh_proc.kill(); tar_proc.wait(); ssh_proc.wait()
    raise RuntimeError("SSH bulk upload timed out")
```

Any *other* exception during `communicate()` propagates without killing or reaping either child: an `OSError` from a dropped ControlMaster socket or broken pipe, an `InterruptedError` (EINTR) when a signal reaches the gateway mid-sync, etc. On a long-lived gateway using the SSH backend, each failed sync then leaks a zombie `tar` + `ssh` pair, and their stderr pipes stay open. The `Popen`-failure path just above (lines ~266-269) already kills and waits `tar_proc`, so this is a gap in the same method, not a deliberate "best effort" choice.

This adds a general `except Exception:` clause that kills and waits both children, then re-raises the original error, mirroring the existing timeout cleanup. The happy path is unchanged: on success `communicate()` has already reaped both processes, so the handler never runs.

## Type of Change

- [x] 🐛 Bug fix (robustness / resource leak)

## Changes Made

- `tools/environments/ssh.py` — add an `except Exception:` handler after the existing `except subprocess.TimeoutExpired:` in `_ssh_bulk_upload` that reaps both subprocesses (`kill()` guarded against an already-dead process, then `wait()`) and re-raises.
- `tests/tools/test_ssh_bulk_upload.py` — add `test_communicate_error_kills_both_processes`: a non-timeout `OSError` raised during `communicate()` now kills and waits both procs and still propagates. Sits beside the existing `test_timeout_kills_both_processes`.

## How to Test

1. `python -m pytest tests/tools/test_ssh_bulk_upload.py::TestSSHBulkUpload::test_communicate_error_kills_both_processes -q` → passes.
2. Revert only the `ssh.py` change (keep the test) → it fails with `Expected 'kill' to have been called once. Called 0 times.`, demonstrating the leak.
3. `python -m pytest tests/tools/test_ssh_bulk_upload.py tests/tools/test_ssh_environment.py -q` → 36 passed, 11 skipped.

## Checklist

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(tools): ...`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've added a regression test
- [x] I've run the affected tests: 36 passed, 11 skipped
- [x] I've tested on my platform: Linux (Fedora), Python 3.14
- [x] Cross-platform: pure exception-handling / cleanup, no platform-specific code
