### PR TITLE
fix(security): sandbox tool isolation bypass — distinguish None from explicit empty/non-overlapping enabled_tools

### DIFF
--- a/tests/tools/test_code_execution.py
+++ b/tests/tools/test_code_execution.py
@@ -45,6 +45,7 @@ from tools.code_execution_tool import (
     EXECUTE_CODE_SCHEMA,
     _TOOL_DOC_LINES,
     _execute_remote,
+    _resolve_sandbox_tools,
 )
 
 
@@ -137,6 +138,26 @@ class TestHermesToolsGeneration(unittest.TestCase):
         src = generate_hermes_tools_module(["terminal"], transport="file")
         self.assertIn("_seq_lock = threading.Lock()", src)
         self.assertIn("with _seq_lock:", src)
+
+
+class TestSandboxToolResolution(unittest.TestCase):
+    def test_none_preserves_legacy_full_access(self):
+        self.assertEqual(_resolve_sandbox_tools(None), SANDBOX_ALLOWED_TOOLS)
+
+    def test_empty_list_is_authoritative(self):
+        self.assertEqual(_resolve_sandbox_tools([]), frozenset())
+
+    def test_nonoverlapping_tools_do_not_expand_access(self):
+        self.assertEqual(
+            _resolve_sandbox_tools(["execute_code", "vision_analyze"]),
+            frozenset(),
+        )
+
+    def test_intersection_only_exposes_session_allowed_tools(self):
+        self.assertEqual(
+            _resolve_sandbox_tools(["execute_code", "terminal", "read_file"]),
+            frozenset({"terminal", "read_file"}),
+        )
 
 
 class TestExecuteCodeRemoteTempDir(unittest.TestCase):
@@ -816,8 +837,8 @@ class TestExecuteCodeEdgeCases(unittest.TestCase):
         self.assertIn("all imports ok", result["output"])
 
     @unittest.skipIf(sys.platform == "win32", "UDS not available on Windows")
-    def test_empty_enabled_tools_uses_all(self):
-        """When enabled_tools is [] (empty), all sandbox tools should be available."""
+    def test_empty_enabled_tools_blocks_all_sandbox_tools(self):
+        """An explicit empty session tool list must not widen sandbox access."""
         code = (
             "from hermes_tools import terminal, web_search\n"
             "print('imports ok')\n"
@@ -826,13 +847,17 @@ class TestExecuteCodeEdgeCases(unittest.TestCase):
                     return_value=json.dumps({"ok": True})):
             result = json.loads(execute_code(code, task_id="test-empty",
                                              enabled_tools=[]))
-        self.assertEqual(result["status"], "success")
-        self.assertIn("imports ok", result["output"])
+        self.assertEqual(result["status"], "error")
+        error_text = result.get("error", "")
+        output_text = result.get("output", "")
+        self.assertTrue(
+            "ImportError" in error_text or "ImportError" in output_text,
+            f"Expected ImportError, got error={error_text!r} output={output_text!r}",
+        )
 
     @unittest.skipIf(sys.platform == "win32", "UDS not available on Windows")
-    def test_nonoverlapping_tools_fallback(self):
-        """When enabled_tools has no overlap with SANDBOX_ALLOWED_TOOLS,
-        should fall back to all allowed tools."""
+    def test_nonoverlapping_tools_do_not_fallback(self):
+        """A non-overlapping explicit policy must not restore sandbox tools."""
         code = (
             "from hermes_tools import terminal\n"
             "print('fallback ok')\n"
@@ -843,8 +868,34 @@ class TestExecuteCodeEdgeCases(unittest.TestCase):
                 code, task_id="test-nonoverlap",
                 enabled_tools=["vision_analyze", "browser_snapshot"],
             ))
-        self.assertEqual(result["status"], "success")
-        self.assertIn("fallback ok", result["output"])
+        self.assertEqual(result["status"], "error")
+        error_text = result.get("error", "")
+        output_text = result.get("output", "")
+        self.assertTrue(
+            "ImportError" in error_text or "ImportError" in output_text,
+            f"Expected ImportError, got error={error_text!r} output={output_text!r}",
+        )
+
+    @unittest.skipIf(sys.platform == "win32", "UDS not available on Windows")
+    def test_execute_code_only_session_cannot_regain_terminal(self):
+        """Real policy: execute_code-only session must not expose terminal."""
+        code = (
+            "from hermes_tools import terminal\n"
+            "print('terminal regained')\n"
+        )
+        with patch("model_tools.handle_function_call",
+                    return_value=json.dumps({"ok": True})):
+            result = json.loads(execute_code(
+                code, task_id="test-execute-code-only",
+                enabled_tools=["execute_code"],
+            ))
+        self.assertEqual(result["status"], "error")
+        error_text = result.get("error", "")
+        output_text = result.get("output", "")
+        self.assertTrue(
+            "ImportError" in error_text or "ImportError" in output_text,
+            f"Expected ImportError, got error={error_text!r} output={output_text!r}",
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/tools/code_execution_tool.py
+++ b/tools/code_execution_tool.py
@@ -204,6 +204,24 @@ def check_sandbox_requirements() -> bool:
     return True
 
 
+def _resolve_sandbox_tools(enabled_tools: list[str] | None) -> frozenset[str]:
+    """Resolve the exact tool set exposed inside execute_code.
+
+    Security boundary:
+    - ``enabled_tools is None`` means the caller did not provide session tool
+      context, so we preserve the historical fallback to all sandbox tools.
+    - Any explicit list, including an empty list or a non-overlapping list,
+      is treated as authoritative session policy and must not widen access.
+
+    Returns:
+        frozenset of tool names the sandbox is allowed to call.
+
+    """
+    if enabled_tools is None:
+        return SANDBOX_ALLOWED_TOOLS
+    return frozenset(SANDBOX_ALLOWED_TOOLS & set(enabled_tools))
+
+
 # ---------------------------------------------------------------------------
 # hermes_tools.py code generator
 # ---------------------------------------------------------------------------
@@ -890,10 +908,7 @@ def _execute_remote(
     timeout = _cfg.get("timeout", DEFAULT_TIMEOUT)
     max_tool_calls = _cfg.get("max_tool_calls", DEFAULT_MAX_TOOL_CALLS)
 
-    session_tools = set(enabled_tools) if enabled_tools else set()
-    sandbox_tools = frozenset(SANDBOX_ALLOWED_TOOLS & session_tools)
-    if not sandbox_tools:
-        sandbox_tools = SANDBOX_ALLOWED_TOOLS
+    sandbox_tools = _resolve_sandbox_tools(enabled_tools)
 
     effective_task_id = task_id or "default"
     env, env_type = _get_or_create_env(effective_task_id)
@@ -1133,11 +1148,7 @@ def execute_code(
     max_tool_calls = _cfg.get("max_tool_calls", DEFAULT_MAX_TOOL_CALLS)
 
     # Determine which tools the sandbox can call
-    session_tools = set(enabled_tools) if enabled_tools else set()
-    sandbox_tools = frozenset(SANDBOX_ALLOWED_TOOLS & session_tools)
-
-    if not sandbox_tools:
-        sandbox_tools = SANDBOX_ALLOWED_TOOLS
+    sandbox_tools = _resolve_sandbox_tools(enabled_tools)
 
     # --- Set up temp directory with hermes_tools.py and script.py ---
     tmpdir = tempfile.mkdtemp(prefix="hermes_sandbox_")


### PR DESCRIPTION
## Summary

Closes the sandbox tool isolation bypass described in #6614.

### Bug
`tools/code_execution_tool.py` — both `_execute_remote` and `execute_code` had:
```python
session_tools = set(enabled_tools) if enabled_tools else set()
sandbox_tools = frozenset(SANDBOX_ALLOWED_TOOLS & session_tools)
if not sandbox_tools:
    sandbox_tools = SANDBOX_ALLOWED_TOOLS  # BYPASS
```
`if not sandbox_tools` fires when `enabled_tools` is falsy (None, `[]`) OR when the intersection is empty. A session restricted to `["execute_code"]` silently regains terminal, file ops, and web access inside the sandbox.

### Fix
Adds `_resolve_sandbox_tools()` that distinguishes `None` (legacy fallback) from an explicit list (authoritative, no widening). Replaces both call sites.

### Tests
4 unit tests for `_resolve_sandbox_tools` + 3 integration tests verifying the behavior change end-to-end. All 7 pass.

### Credit
Original fix by @WAXLYY. This is a rebase onto current `main` with the reviewer's feedback incorporated.