### PR TITLE
fix(whatsapp): strip configured mention_patterns wake-word from group body

### DIFF
--- a/gateway/platforms/whatsapp_common.py
+++ b/gateway/platforms/whatsapp_common.py
@@ -368,11 +368,53 @@ class WhatsAppBehaviorMixin:
                 return True
         return False
 
+    def _first_matching_mention_pattern(self, text: str):
+        """Return the first configured mention_patterns match, or None."""
+        if not text or not self._mention_patterns:
+            return None
+        for pattern in self._mention_patterns:
+            if pattern.search(text):
+                return pattern
+        return None
+
     def _message_matches_mention_patterns(self, data: Dict[str, Any]) -> bool:
-        if not self._mention_patterns:
-            return False
-        body = str(data.get("body") or "")
-        return any(pattern.search(body) for pattern in self._mention_patterns)
+        return self._first_matching_mention_pattern(str(data.get("body") or "")) is not None
+
+    def _admission_mention_pattern(self, data: Dict[str, Any]):
+        """Return the mention_patterns entry that admitted this group message.
+
+        Mirrors ``_should_process_message`` short-circuits: pattern cleanup is
+        only appropriate when the gate fell through to mention_patterns. A
+        JID/reply/command/free-response admission must leave ordinary text that
+        merely *looks* like a wake word alone.
+        """
+        if not data.get("isGroup"):
+            return None
+        chat_id = str(data.get("chatId") or "")
+        if chat_id in self._whatsapp_free_response_chats():
+            return None
+        if not self._whatsapp_require_mention():
+            return None
+        body = str(data.get("body") or "").strip()
+        if body.startswith("/"):
+            return None
+        if self._message_is_reply_to_bot(data):
+            return None
+        if self._message_mentions_bot(data):
+            return None
+        return self._first_matching_mention_pattern(body)
+
+    @staticmethod
+    def _strip_pattern_match(text: str, pattern) -> str:
+        """Remove the first match of ``pattern`` plus trailing separators."""
+        m = pattern.search(text)
+        if not m:
+            return text
+        end = m.end()
+        trailing = re.match(r"[,:\-]*\s*", text[end:])
+        if trailing:
+            end += trailing.end()
+        return text[: m.start()] + text[end:]
 
     def _clean_bot_mention_text(self, text: str, data: Dict[str, Any]) -> str:
         if not text:
@@ -385,21 +427,14 @@ class WhatsAppBehaviorMixin:
                 cleaned = re.sub(
                     rf"@{re.escape(bare_id)}\b[,:\-]*\s*", "", cleaned
                 )
-        # Strip the configured wake word(s) too — the same mention_patterns
-        # that admit the message in _message_matches_mention_patterns. Without
-        # this, a custom wake word like "@andy" gates the message but then
-        # leaks into the prompt verbatim (real JID @mentions, above, do not).
-        # Remove only the first match of each pattern (plus trailing
-        # separators) so arbitrary in-content matches aren't rewritten.
-        for pattern in self._mention_patterns:
-            m = pattern.search(cleaned)
-            if not m:
-                continue
-            end = m.end()
-            trailing = re.match(r"[,:\-]*\s*", cleaned[end:])
-            if trailing:
-                end += trailing.end()
-            cleaned = cleaned[: m.start()] + cleaned[end:]
+        # Only strip a wake word when mention_patterns was the admission
+        # cause. Evaluate against the original body (not post-JID-clean
+        # text) so a JID-admitted message that happens to contain a
+        # configured pattern as ordinary content keeps that content.
+        admission_data = {**data, "body": text}
+        admission_pattern = self._admission_mention_pattern(admission_data)
+        if admission_pattern is not None:
+            cleaned = self._strip_pattern_match(cleaned, admission_pattern)
         return cleaned.strip() or text
 
     def _should_process_message(self, data: Dict[str, Any]) -> bool:

--- a/gateway/platforms/whatsapp_common.py
+++ b/gateway/platforms/whatsapp_common.py
@@ -385,6 +385,21 @@ class WhatsAppBehaviorMixin:
                 cleaned = re.sub(
                     rf"@{re.escape(bare_id)}\b[,:\-]*\s*", "", cleaned
                 )
+        # Strip the configured wake word(s) too — the same mention_patterns
+        # that admit the message in _message_matches_mention_patterns. Without
+        # this, a custom wake word like "@andy" gates the message but then
+        # leaks into the prompt verbatim (real JID @mentions, above, do not).
+        # Remove only the first match of each pattern (plus trailing
+        # separators) so arbitrary in-content matches aren't rewritten.
+        for pattern in self._mention_patterns:
+            m = pattern.search(cleaned)
+            if not m:
+                continue
+            end = m.end()
+            trailing = re.match(r"[,:\-]*\s*", cleaned[end:])
+            if trailing:
+                end += trailing.end()
+            cleaned = cleaned[: m.start()] + cleaned[end:]
         return cleaned.strip() or text
 
     def _should_process_message(self, data: Dict[str, Any]) -> bool:

--- a/tests/gateway/test_whatsapp_group_gating.py
+++ b/tests/gateway/test_whatsapp_group_gating.py
@@ -230,3 +230,30 @@ def test_broadcast_filter_runs_before_allowlist():
     assert adapter._should_process_message(msg) is False
 
 
+# --- _clean_bot_mention_text: strip configured wake word from body (#47493) ---
+
+def test_mention_pattern_wake_word_stripped_from_body():
+    adapter = _make_adapter(require_mention=True, mention_patterns=[r"(?i)@andy\b"])
+    clean = adapter._clean_bot_mention_text
+    # Leading wake word, trailing punctuation, and mid-string occurrences.
+    assert clean("@andy show photos of Runi", {"botIds": []}) == "show photos of Runi"
+    assert clean("@andy, book a table at Andy's Diner", {"botIds": []}) == "book a table at Andy's Diner"
+    assert clean("hey @andy what's up", {"botIds": []}) == "hey what's up"
+
+
+def test_mention_pattern_only_body_is_preserved():
+    adapter = _make_adapter(require_mention=True, mention_patterns=[r"(?i)@andy\b"])
+    # A message that is only the wake word must not be blanked out.
+    assert adapter._clean_bot_mention_text("@andy", {"botIds": []}) == "@andy"
+
+
+def test_clean_bot_mention_noop_without_patterns():
+    adapter = _make_adapter(require_mention=True)  # no mention_patterns configured
+    assert adapter._clean_bot_mention_text("@andy hi", {"botIds": []}) == "@andy hi"
+
+
+def test_real_jid_mention_still_stripped_alongside_pattern():
+    adapter = _make_adapter(require_mention=True, mention_patterns=[r"(?i)@andy\b"])
+    data = {"botIds": ["12345@s.whatsapp.net"]}
+    assert adapter._clean_bot_mention_text("@12345 @andy ping", data) == "ping"
+

--- a/tests/gateway/test_whatsapp_group_gating.py
+++ b/tests/gateway/test_whatsapp_group_gating.py
@@ -233,27 +233,76 @@ def test_broadcast_filter_runs_before_allowlist():
 # --- _clean_bot_mention_text: strip configured wake word from body (#47493) ---
 
 def test_mention_pattern_wake_word_stripped_from_body():
-    adapter = _make_adapter(require_mention=True, mention_patterns=[r"(?i)@andy\b"])
+    adapter = _make_adapter(
+        require_mention=True, mention_patterns=[r"(?i)@andy\b"], group_policy="open"
+    )
     clean = adapter._clean_bot_mention_text
     # Leading wake word, trailing punctuation, and mid-string occurrences.
-    assert clean("@andy show photos of Runi", {"botIds": []}) == "show photos of Runi"
-    assert clean("@andy, book a table at Andy's Diner", {"botIds": []}) == "book a table at Andy's Diner"
-    assert clean("hey @andy what's up", {"botIds": []}) == "hey what's up"
+    # botIds empty so admission is pattern-only (not a JID mention).
+    assert clean("@andy show photos of Runi", _group_message("@andy show photos of Runi", botIds=[])) == (
+        "show photos of Runi"
+    )
+    assert clean(
+        "@andy, book a table at Andy's Diner",
+        _group_message("@andy, book a table at Andy's Diner", botIds=[]),
+    ) == "book a table at Andy's Diner"
+    assert clean("hey @andy what's up", _group_message("hey @andy what's up", botIds=[])) == (
+        "hey what's up"
+    )
 
 
 def test_mention_pattern_only_body_is_preserved():
-    adapter = _make_adapter(require_mention=True, mention_patterns=[r"(?i)@andy\b"])
+    adapter = _make_adapter(
+        require_mention=True, mention_patterns=[r"(?i)@andy\b"], group_policy="open"
+    )
     # A message that is only the wake word must not be blanked out.
-    assert adapter._clean_bot_mention_text("@andy", {"botIds": []}) == "@andy"
+    assert adapter._clean_bot_mention_text("@andy", _group_message("@andy", botIds=[])) == "@andy"
 
 
 def test_clean_bot_mention_noop_without_patterns():
-    adapter = _make_adapter(require_mention=True)  # no mention_patterns configured
-    assert adapter._clean_bot_mention_text("@andy hi", {"botIds": []}) == "@andy hi"
+    adapter = _make_adapter(require_mention=True, group_policy="open")
+    assert adapter._clean_bot_mention_text(
+        "@andy hi", _group_message("@andy hi", botIds=[])
+    ) == "@andy hi"
 
 
-def test_real_jid_mention_still_stripped_alongside_pattern():
-    adapter = _make_adapter(require_mention=True, mention_patterns=[r"(?i)@andy\b"])
-    data = {"botIds": ["12345@s.whatsapp.net"]}
-    assert adapter._clean_bot_mention_text("@12345 @andy ping", data) == "ping"
+def test_jid_mention_admission_keeps_ordinary_wake_word_text():
+    """JID-admitted messages must not strip configured pattern text as content."""
+    adapter = _make_adapter(
+        require_mention=True, mention_patterns=[r"(?i)@andy\b"], group_policy="open"
+    )
+    data = _group_message(
+        "@12345 tell @andy the photos are ready",
+        botIds=["12345@s.whatsapp.net"],
+    )
+    assert adapter._clean_bot_mention_text(
+        "@12345 tell @andy the photos are ready", data
+    ) == "tell @andy the photos are ready"
+
+
+def test_jid_mention_still_stripped_when_pattern_also_present():
+    adapter = _make_adapter(
+        require_mention=True, mention_patterns=[r"(?i)@andy\b"], group_policy="open"
+    )
+    data = _group_message("@12345 @andy ping", botIds=["12345@s.whatsapp.net"])
+    # Admitted via JID — strip @12345 only; leave @andy alone.
+    assert adapter._clean_bot_mention_text("@12345 @andy ping", data) == "@andy ping"
+
+
+def test_only_admitting_pattern_stripped_when_multiple_configured():
+    adapter = _make_adapter(
+        require_mention=True,
+        mention_patterns=[r"(?i)@andy\b", r"(?i)@bot\b"],
+        group_policy="open",
+    )
+    # @andy admits; @bot later in the message is ordinary content.
+    assert adapter._clean_bot_mention_text(
+        "@andy ping @bot later",
+        _group_message("@andy ping @bot later", botIds=[]),
+    ) == "ping @bot later"
+    # @bot alone admits — strip only that pattern.
+    assert adapter._clean_bot_mention_text(
+        "@bot status",
+        _group_message("@bot status", botIds=[]),
+    ) == "status"
 


### PR DESCRIPTION
## Problem

In WhatsApp **group** chats, a custom wake word configured via `mention_patterns` (e.g. `(?i)@andy\b`) is used to **gate** which messages the agent answers — but it is **never stripped from the message body**. Only the bot's real WhatsApp JID `@mention` is removed (`_clean_bot_mention_text`), so the wake word leaks into the prompt verbatim.

The gate (`_message_matches_mention_patterns`) and the body cleaner (`_clean_bot_mention_text`) used two different notions of "addressing the bot": the gate honored `mention_patterns`, the cleaner did not.

Mostly harmless, but it bites when the wake word resembles content:

> `@andy book a table at Andy's Diner for 7pm`

reaches the model as `@andy book a table at Andy's Diner...` — two "andy"s, one of which is just the wake word — nudging the model toward mis-parsing / "which Andy?".

## Fix

Make `_clean_bot_mention_text` also strip text matched by `self._mention_patterns`, reusing the same signal that admits the message. Bounded to the **first match per pattern** (plus trailing `[,:\-]*\s*`), so a broad user regex can't rewrite arbitrary in-content text, and the existing `cleaned.strip() or text` fallback keeps a wake-word-only message from being blanked out.

Lives in the shared `WhatsAppBehaviorMixin`, so both the Baileys (`whatsapp.py`) and Cloud (`whatsapp_cloud.py`) adapters are fixed.

## Behavior

| Incoming group body | Agent receives (after fix) |
|---|---|
| `@andy show photos of Runi` | `show photos of Runi` |
| `@andy, book a table at Andy's Diner` | `book a table at Andy's Diner` |
| `hey @andy what's up` | `hey what's up` |
| `@andy` (wake word only) | `@andy` (fallback — never blanked) |

## Tests

`tests/gateway/test_whatsapp_group_gating.py` — 4 new cases: strip in 3 positions, wake-word-only preserved, no-op when no `mention_patterns` configured (regression guard), and JID-mention stripping still works alongside the new loop. Full WhatsApp suite: 214/214 passing.

```
scripts/run_tests.sh tests/gateway/test_whatsapp_group_gating.py
```

## Verification beyond unit tests

Confirmed against the real inbound path: the WhatsApp bridge builds `body` from `conversation` / `extendedTextMessage.text` (the literal typed text, wake word inline) and ships `botIds` as the bot's own JID/LID — so the wake word lives only in `body` and is not otherwise removed.

Fixes #47493
