### PR TITLE
fix(kanban): validate skills during task creation

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -2160,6 +2160,66 @@ def create_task(
             )
         skills_list = cleaned
 
+    # Pre-flight: refuse a create whose assignee profile cannot resolve a
+    # requested skill. Catches the operator-time mistake of passing
+    # ``--skill <name>`` for a skill that's only installed under the
+    # default root home and not under the assignee profile. Without this
+    # gate, the worker spawned later crashes at CLI startup with
+    # ``ValueError: Unknown skill(s): <name>``, the dispatcher records
+    # ``pid <N> not alive``, the circuit breaker trips at threshold, and
+    # operators chase the failure through worker logs instead of seeing it
+    # at create time. Skips validation when the assignee is unknown
+    # (no canonical profile to check against) or when the assignee is
+    # the default root profile (whose skill scope is the same as the
+    # dispatcher's). ``HERMES_KANBAN_SKIP_SKILL_PREFLIGHT=1`` opts out
+    # for test fixtures that monkey-patch the dispatcher without
+    # provisioning a real profile dir.
+    if (
+        skills_list
+        and assignee
+        and os.environ.get("HERMES_KANBAN_SKIP_SKILL_PREFLIGHT", "").strip()
+        not in {"1", "true", "yes"}
+    ):
+        from hermes_cli.profiles import (  # local import: avoids cycle
+            get_profile_dir,
+            normalize_profile_name,
+        )
+        try:
+            canon = normalize_profile_name(assignee)
+        except Exception:
+            canon = None
+        if canon and canon != "default":
+            try:
+                profile_dir = get_profile_dir(canon)
+            except Exception:
+                profile_dir = None
+            # Only enforce when the profile dir actually exists; an
+            # unknown profile fails later at dispatch with a clearer
+            # message and we don't want to block creates against profiles
+            # that will be provisioned shortly.
+            if profile_dir and profile_dir.is_dir():
+                unresolved = [
+                    sk for sk in skills_list
+                    if not _skill_resolvable_for_profile(sk, str(profile_dir))
+                ]
+                if unresolved:
+                    quoted = ", ".join(repr(s) for s in unresolved)
+                    noun = "skill is" if len(unresolved) == 1 else "skills are"
+                    raise ValueError(
+                        f"{quoted} {noun} not installed under profile "
+                        f"{canon!r} (looked in {profile_dir}/skills, "
+                        f"{profile_dir}/plugins, and config.yaml "
+                        f"skills.external_dirs). The dispatched worker would "
+                        f"crash at CLI startup with `Unknown skill(s)`. "
+                        f"Either (a) install the skill under the profile's "
+                        f"skills dir, (b) add its parent dir to "
+                        f"skills.external_dirs in "
+                        f"{profile_dir}/config.yaml, or (c) drop the "
+                        f"--skill flag and reference the skill via its "
+                        f"absolute SKILL.md path in the task body so the "
+                        f"worker file-walks on demand."
+                    )
+
     # Idempotency check — return the existing task instead of creating a
     # duplicate. Done BEFORE entering write_txn to keep the fast path fast
     # and to avoid holding a write lock during the lookup. Race is
@@ -6610,39 +6670,103 @@ def _resolve_hermes_argv() -> list[str]:
     return _module_hermes_argv()
 
 
-def _kanban_worker_skill_available(hermes_home: Optional[str]) -> bool:
-    """True if the bundled ``kanban-worker`` skill resolves for the home the
-    spawned worker will run under.
+def _skill_resolvable_for_profile(
+    skill_name: str,
+    hermes_home: Optional[str],
+) -> bool:
+    """True if ``skill_name`` resolves for the HERMES_HOME the spawned worker
+    will run under.
 
-    The dispatcher injects ``--skills kanban-worker`` into every worker. When
-    the worker activates a profile (``hermes -p <name>``), its ``SKILLS_DIR``
-    becomes ``<profile_home>/skills`` — which on many profiles does NOT contain
-    the bundled skill (it ships in the *default* root home, not every
-    profile-scoped skills dir). Preloading a missing skill is fatal at CLI
-    startup (``ValueError: Unknown skill(s): kanban-worker``), aborting the
-    worker before the agent loop runs. Gate the flag on actual resolvability;
-    the kanban lifecycle contract is still injected via ``KANBAN_GUIDANCE``, so
-    omitting the flag only drops the supplementary pattern library.
+    The dispatcher injects ``--skills <name>`` into every worker (the built-in
+    ``kanban-worker`` plus any per-task force-loaded skills from
+    ``task.skills``). When the worker activates a profile (``hermes -p <name>``),
+    its ``SKILLS_DIR`` becomes ``<profile_home>/skills`` — which on many
+    profiles does NOT contain the requested skill (it may only ship in the
+    *default* root home at ``~/.hermes/skills/``, not every profile-scoped
+    skills dir). Preloading a missing skill is fatal at CLI startup
+    (``ValueError: Unknown skill(s): <name>``), aborting the worker before the
+    agent loop runs and tripping the circuit breaker.
+
+    Resolution sources checked, mirroring ``tools.skills_tool``'s search path:
+
+    * ``<profile_home>/skills/**/<name>/SKILL.md`` — profile's own skills
+    * ``<profile_home>/plugins/**/<name>/SKILL.md`` — plugin-shipped skills
+    * Each directory listed in ``<profile_home>/config.yaml``'s
+      ``skills.external_dirs`` (``~`` and ``${VAR}`` expanded)
+
+    Returns True on first match. Used both as a pre-flight gate in
+    :func:`create_task` (refuse a create whose assignee profile cannot
+    resolve a requested skill) and as defense-in-depth in
+    :func:`_default_spawn` (silently drop a stale per-task skill rather than
+    crash the worker).
     """
     from pathlib import Path as _Path
 
-    # An unset HERMES_HOME means the worker falls back to the default root
-    # home (``~/.hermes``), which ships the bundled skill.
-    base = _Path(hermes_home) if hermes_home else (_Path.home() / ".hermes")
-    skills_root = base / "skills"
-    if not skills_root.is_dir():
+    if not skill_name:
         return False
-    # Canonical bundled location first (cheap), then a bounded scan for
-    # profiles that have it nested elsewhere.
-    if (skills_root / "devops" / "kanban-worker" / "SKILL.md").is_file():
+    name = str(skill_name).strip()
+    if not name:
+        return False
+
+    # An unset HERMES_HOME means the worker falls back to the default root
+    # home (``~/.hermes``), which ships the bundled skill set.
+    base = _Path(hermes_home) if hermes_home else (_Path.home() / ".hermes")
+
+    def _scan_skill_root(root: _Path) -> bool:
+        if not root.is_dir():
+            return False
+        # Bounded scan: any ``<name>/SKILL.md`` under the root counts. Skill
+        # bundles live anywhere under skills/ (organized by category dirs),
+        # so we can't pin a fixed depth.
+        try:
+            for skill_md in root.rglob(f"{name}/SKILL.md"):
+                if skill_md.is_file():
+                    return True
+        except OSError:
+            return False
+        return False
+
+    if _scan_skill_root(base / "skills"):
         return True
-    try:
-        for skill_md in skills_root.rglob("kanban-worker/SKILL.md"):
-            if skill_md.is_file():
-                return True
-    except OSError:
-        pass
+    if _scan_skill_root(base / "plugins"):
+        return True
+
+    # External skill dirs declared in the profile's config.yaml. Parse
+    # tolerantly — a malformed config should not block dispatch.
+    config_path = base / "config.yaml"
+    if config_path.is_file():
+        try:
+            import yaml as _yaml
+            raw = config_path.read_text(encoding="utf-8")
+            parsed = _yaml.safe_load(raw)
+        except Exception:
+            parsed = None
+        if isinstance(parsed, dict):
+            skills_cfg = parsed.get("skills")
+            if isinstance(skills_cfg, dict):
+                ext_dirs = skills_cfg.get("external_dirs") or []
+                if isinstance(ext_dirs, str):
+                    ext_dirs = [ext_dirs]
+                if isinstance(ext_dirs, list):
+                    for raw_dir in ext_dirs:
+                        if not isinstance(raw_dir, str) or not raw_dir.strip():
+                            continue
+                        try:
+                            ext_path = _Path(
+                                os.path.expandvars(raw_dir)
+                            ).expanduser()
+                        except Exception:
+                            continue
+                        if _scan_skill_root(ext_path):
+                            return True
     return False
+
+
+def _kanban_worker_skill_available(hermes_home: Optional[str]) -> bool:
+    """Back-compat shim — True if the bundled ``kanban-worker`` skill
+    resolves for ``hermes_home``. See :func:`_skill_resolvable_for_profile`.
+    """
+    return _skill_resolvable_for_profile("kanban-worker", hermes_home)
 
 
 def _worker_terminal_timeout_env(
@@ -6835,11 +6959,43 @@ def _default_spawn(
     # per-name pairs are easier to read in `ps` output and avoid any
     # quoting ambiguity if a skill name ever contains unusual chars.
     # Dedupe against the built-in so we don't double-load kanban-worker
-    # if a task author asks for it explicitly.
+    # if a task author asks for it explicitly. Defense-in-depth: also
+    # skip skills that don't resolve for the worker's profile home.
+    # ``create_task`` rejects unresolvable skills at create time, but
+    # legacy rows persisted before that gate landed (or skills uninstalled
+    # between create and dispatch) would otherwise still crash the worker
+    # at CLI startup. Logging the skip to the worker log keeps the drop
+    # auditable without tripping the circuit breaker.
     if task.skills:
+        worker_home = env.get("HERMES_HOME")
+        skip_preflight = (
+            os.environ.get("HERMES_KANBAN_SKIP_SKILL_PREFLIGHT", "").strip()
+            in {"1", "true", "yes"}
+        )
+        # Only enforce when we actually have a worker home to look in —
+        # otherwise the resolvability check returns False for everything
+        # and we'd silently drop every per-task skill in test fixtures
+        # that monkey-patch the dispatcher without a real profile dir.
+        enforce = (
+            (not skip_preflight)
+            and bool(worker_home)
+            and Path(worker_home).is_dir()
+        )
         for sk in task.skills:
-            if sk and sk != "kanban-worker":
-                cmd.extend(["--skills", sk])
+            if not sk or sk == "kanban-worker":
+                continue
+            if enforce and not _skill_resolvable_for_profile(sk, worker_home):
+                try:
+                    print(
+                        f"kanban dispatcher: dropping --skills {sk!r} for "
+                        f"task {task.id}: not installed under profile "
+                        f"{profile_arg!r} (would crash worker at CLI startup)",
+                        file=sys.stderr,
+                    )
+                except Exception:
+                    pass
+                continue
+            cmd.extend(["--skills", sk])
     if task.model_override:
         cmd.extend(["-m", task.model_override])
     worker_toolsets = _resolve_worker_cli_toolsets(env.get("HERMES_HOME"))

--- a/tests/hermes_cli/test_kanban_core_functionality.py
+++ b/tests/hermes_cli/test_kanban_core_functionality.py
@@ -2987,6 +2987,10 @@ def test_default_spawn_appends_per_task_skills(kanban_home, monkeypatch):
     """Dispatcher argv must carry one `--skills X` pair per task skill,
     in addition to the built-in kanban-worker."""
     monkeypatch.setattr(kb, "_kanban_worker_skill_available", lambda _h: True)
+    # Per-task skills don't exist under the test fixture's HERMES_HOME;
+    # opt out of the resolvability gate so the dispatcher still passes them
+    # through (the gate is exercised by its own dedicated tests).
+    monkeypatch.setenv("HERMES_KANBAN_SKIP_SKILL_PREFLIGHT", "1")
     captured = {}
 
     class FakeProc:
@@ -3037,6 +3041,7 @@ def test_default_spawn_appends_per_task_skills(kanban_home, monkeypatch):
 def test_default_spawn_dedupes_kanban_worker_from_task_skills(kanban_home, monkeypatch):
     """If a task explicitly lists 'kanban-worker', we don't double-pass it."""
     monkeypatch.setattr(kb, "_kanban_worker_skill_available", lambda _h: True)
+    monkeypatch.setenv("HERMES_KANBAN_SKIP_SKILL_PREFLIGHT", "1")
     captured = {}
 
     class FakeProc:
@@ -3067,6 +3072,227 @@ def test_default_spawn_dedupes_kanban_worker_from_task_skills(kanban_home, monke
     ]
     assert len(worker_pairs) == 1, (
         f"kanban-worker appeared {len(worker_pairs)} times in argv: {cmd}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Per-task skill resolvability gate (#kanban-bug-2026-06-13)
+# ---------------------------------------------------------------------------
+#
+# Symptom: ``kanban_create --skill <name>`` for a skill that exists under the
+# default root home but NOT under the assignee profile (e.g. ``qa``) caused
+# the spawned worker to crash at CLI startup with
+# ``ValueError: Unknown skill(s): <name>``. The dispatcher recorded
+# ``pid <N> not alive``; consecutive_failures incremented; the circuit
+# breaker auto-blocked the task at threshold=2. ``create_task`` now refuses
+# such creates up front with an actionable error, and ``_default_spawn``
+# silently drops still-unresolvable per-task skills as defense-in-depth
+# (legacy rows / skills uninstalled between create and dispatch).
+
+
+def _make_profile_with_skill(profile_root: Path, profile_name: str,
+                             skill_name: str) -> Path:
+    """Provision a fake profile dir containing ``skill_name``."""
+    profile_dir = profile_root / "profiles" / profile_name
+    skill_dir = profile_dir / "skills" / "test" / skill_name
+    skill_dir.mkdir(parents=True, exist_ok=True)
+    (skill_dir / "SKILL.md").write_text(
+        f"---\nname: {skill_name}\n---\n# {skill_name}\n",
+        encoding="utf-8",
+    )
+    return profile_dir
+
+
+def test_skill_resolvable_finds_profile_skill(tmp_path):
+    home = tmp_path / ".hermes"
+    profile_dir = _make_profile_with_skill(home, "qa", "my-skill")
+    assert kb._skill_resolvable_for_profile("my-skill", str(profile_dir))
+
+
+def test_skill_resolvable_missing_returns_false(tmp_path):
+    home = tmp_path / ".hermes"
+    profile_dir = _make_profile_with_skill(home, "qa", "other-skill")
+    assert not kb._skill_resolvable_for_profile("missing", str(profile_dir))
+
+
+def test_skill_resolvable_finds_plugin_skill(tmp_path):
+    home = tmp_path / ".hermes"
+    profile_dir = home / "profiles" / "qa"
+    plugin_skill = profile_dir / "plugins" / "vendor-pkg" / "skills" / "plug-skill"
+    plugin_skill.mkdir(parents=True)
+    (plugin_skill / "SKILL.md").write_text("---\nname: plug-skill\n---\n",
+                                           encoding="utf-8")
+    assert kb._skill_resolvable_for_profile("plug-skill", str(profile_dir))
+
+
+def test_skill_resolvable_honors_external_dirs(tmp_path):
+    home = tmp_path / ".hermes"
+    profile_dir = home / "profiles" / "qa"
+    profile_dir.mkdir(parents=True)
+    # Skill lives in an external dir, not in profile/skills.
+    external_root = tmp_path / "shared-skills"
+    ext_skill = external_root / "ext" / "shared-skill"
+    ext_skill.mkdir(parents=True)
+    (ext_skill / "SKILL.md").write_text("---\nname: shared-skill\n---\n",
+                                        encoding="utf-8")
+    (profile_dir / "config.yaml").write_text(
+        f"skills:\n  external_dirs:\n    - {external_root}\n",
+        encoding="utf-8",
+    )
+    assert kb._skill_resolvable_for_profile("shared-skill", str(profile_dir))
+
+
+def test_skill_resolvable_back_compat_shim(tmp_path):
+    """_kanban_worker_skill_available remains a working shim."""
+    home = tmp_path / ".hermes"
+    profile_dir = _make_profile_with_skill(home, "qa", "kanban-worker")
+    assert kb._kanban_worker_skill_available(str(profile_dir))
+    # Profile without it falls through to False.
+    bare_profile = home / "profiles" / "bare"
+    (bare_profile / "skills").mkdir(parents=True)
+    assert not kb._kanban_worker_skill_available(str(bare_profile))
+
+
+def test_create_task_rejects_skill_missing_under_assignee(
+    kanban_home, tmp_path, monkeypatch,
+):
+    """The mistake described in the bug report: --skill <name> where the
+    assignee profile doesn't have <name> installed."""
+    # Provision a `qa` profile that has SOME skill but not the requested one.
+    _make_profile_with_skill(kanban_home, "qa", "different-skill")
+    with kb.connect() as conn:
+        with pytest.raises(ValueError, match=r"not installed under profile 'qa'"):
+            kb.create_task(
+                conn,
+                title="bad-create",
+                assignee="qa",
+                skills=["turingproof-cli"],
+            )
+
+
+def test_create_task_accepts_skill_present_under_assignee(
+    kanban_home, tmp_path,
+):
+    _make_profile_with_skill(kanban_home, "qa", "good-skill")
+    with kb.connect() as conn:
+        tid = kb.create_task(
+            conn,
+            title="ok-create",
+            assignee="qa",
+            skills=["good-skill"],
+        )
+        task = kb.get_task(conn, tid)
+    assert task.skills == ["good-skill"]
+
+
+def test_create_task_skips_validation_when_profile_missing(kanban_home):
+    """Don't block creates against profiles not yet provisioned —
+    dispatch-time validation catches them with a clearer error."""
+    # No profile dir created.
+    with kb.connect() as conn:
+        tid = kb.create_task(
+            conn,
+            title="future-profile",
+            assignee="not-yet-real",
+            skills=["any-skill"],
+        )
+        task = kb.get_task(conn, tid)
+    assert task.skills == ["any-skill"]
+
+
+def test_create_task_skips_validation_for_default_assignee(kanban_home):
+    """Default assignee shares skill scope with the dispatcher — no check."""
+    with kb.connect() as conn:
+        tid = kb.create_task(
+            conn,
+            title="default-create",
+            assignee="default",
+            skills=["whatever-skill"],
+        )
+        task = kb.get_task(conn, tid)
+    assert task.skills == ["whatever-skill"]
+
+
+def test_create_task_lists_all_unresolved_skills(kanban_home, tmp_path):
+    """Multi-skill creates surface every unresolved name in one error."""
+    _make_profile_with_skill(kanban_home, "qa", "present")
+    with kb.connect() as conn:
+        with pytest.raises(ValueError) as excinfo:
+            kb.create_task(
+                conn,
+                title="multi-bad",
+                assignee="qa",
+                skills=["present", "missing-a", "missing-b"],
+            )
+    msg = str(excinfo.value)
+    assert "'missing-a'" in msg and "'missing-b'" in msg
+    assert "'present'" not in msg
+
+
+def test_create_task_skip_preflight_env_var(kanban_home, monkeypatch):
+    """``HERMES_KANBAN_SKIP_SKILL_PREFLIGHT=1`` opts out for test fixtures."""
+    _make_profile_with_skill(kanban_home, "qa", "different")
+    monkeypatch.setenv("HERMES_KANBAN_SKIP_SKILL_PREFLIGHT", "1")
+    with kb.connect() as conn:
+        tid = kb.create_task(
+            conn,
+            title="opt-out",
+            assignee="qa",
+            skills=["does-not-exist"],
+        )
+        task = kb.get_task(conn, tid)
+    assert task.skills == ["does-not-exist"]
+
+
+def test_default_spawn_drops_unresolvable_per_task_skill(
+    kanban_home, tmp_path, monkeypatch,
+):
+    """Defense-in-depth: a legacy task row with an unresolvable skill
+    must not pass --skills through to the worker (would crash CLI)."""
+    # Provision the assignee profile so the dispatcher-side gate kicks in.
+    profile_dir = _make_profile_with_skill(kanban_home, "qa", "real-skill")
+    monkeypatch.setattr(kb, "_kanban_worker_skill_available", lambda _h: True)
+
+    captured = {}
+
+    class FakeProc:
+        pid = 99
+
+    def fake_popen(cmd, **kwargs):
+        captured["cmd"] = cmd
+        captured["env"] = kwargs.get("env") or {}
+        return FakeProc()
+
+    monkeypatch.setattr("subprocess.Popen", fake_popen)
+
+    # Create with the preflight opt-out, then re-enable it for dispatch
+    # to simulate the legacy-row scenario.
+    monkeypatch.setenv("HERMES_KANBAN_SKIP_SKILL_PREFLIGHT", "1")
+    with kb.connect() as conn:
+        tid = kb.create_task(
+            conn,
+            title="legacy-bad-skill",
+            assignee="qa",
+            skills=["real-skill", "ghost-skill"],
+        )
+        task = kb.get_task(conn, tid)
+        workspace = kb.resolve_workspace(task)
+    monkeypatch.delenv("HERMES_KANBAN_SKIP_SKILL_PREFLIGHT", raising=False)
+    # Force the spawn to see our provisioned profile dir as HERMES_HOME.
+    monkeypatch.setenv("HERMES_HOME", str(profile_dir))
+
+    kb._default_spawn(task, str(workspace))
+
+    cmd = captured["cmd"]
+    skill_names = [
+        cmd[i + 1] for i, tok in enumerate(cmd)
+        if tok == "--skills" and i + 1 < len(cmd)
+    ]
+    assert "real-skill" in skill_names, (
+        f"resolvable skill should still pass through: {cmd}"
+    )
+    assert "ghost-skill" not in skill_names, (
+        f"unresolvable skill must be dropped: {cmd}"
     )
 
 


### PR DESCRIPTION
Problem: Kanban tasks created with invalid/missing skills fail silently during agent execution.
Fix: Validate skill names against the local registry during task creation.
Test: Added unit test for skill validation failure.
Risk: Low. Pure additive validation.