### PR TITLE
feat(delegate): run delegated tasks in Hermes profiles

### DIFF
--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -359,6 +359,53 @@ class TestDelegateTask(unittest.TestCase):
             ["terminal", "file"],
         )
 
+    @patch("tools.delegate_tool._resolve_profile_delegate_env")
+    @patch("tools.delegate_tool._run_profile_delegate")
+    def test_profile_background_registered_handler_returns_before_runner_finishes(
+        self, mock_run_profile, mock_profile_env
+    ):
+        from tools import async_delegation
+
+        async_delegation._reset_for_tests()
+        mock_profile_env.return_value = ("qa", "/tmp/hermes/profiles/qa")
+        runner_started = threading.Event()
+        release_runner = threading.Event()
+
+        def slow_profile_runner(**kwargs):
+            runner_started.set()
+            release_runner.wait(timeout=5)
+            return {"task_index": 0, "status": "completed", "summary": "ok"}
+
+        mock_run_profile.side_effect = slow_profile_runner
+        parent = _make_mock_parent()
+        entry = delegate_mod.registry.get_entry("delegate_task")
+        assert entry is not None
+
+        try:
+            start = time.monotonic()
+            raw = entry.handler(
+                {
+                    "goal": "Review later",
+                    "toolsets": ["terminal", "file"],
+                    "profile": "qa",
+                    "background": True,
+                },
+                parent_agent=parent,
+            )
+            elapsed = time.monotonic() - start
+            result = json.loads(raw)
+
+            self.assertEqual(result["status"], "dispatched")
+            self.assertIn("delegation_id", result)
+            self.assertEqual(result["profile"], "qa")
+            self.assertLess(elapsed, 0.5)
+            self.assertTrue(runner_started.wait(timeout=1))
+            self.assertEqual(async_delegation.active_count(), 1)
+        finally:
+            release_runner.set()
+            time.sleep(0.05)
+            async_delegation._reset_for_tests()
+
     def test_profile_batch_rejects_mixed_profile_and_in_process_tasks(self):
         parent = _make_mock_parent()
         result = json.loads(

--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -16,6 +16,8 @@ import time
 import unittest
 from unittest.mock import MagicMock, patch
 
+import tools.delegate_tool as delegate_mod
+
 from tools.delegate_tool import (
     DELEGATE_BLOCKED_TOOLS,
     DELEGATE_TASK_SCHEMA,
@@ -69,6 +71,8 @@ class TestDelegateRequirements(unittest.TestCase):
         self.assertIn("tasks", props)
         self.assertIn("context", props)
         self.assertIn("toolsets", props)
+        self.assertIn("profile", props)
+        self.assertIn("profile", props["tasks"]["items"]["properties"])
         # max_iterations is intentionally NOT exposed to the model — it's
         # config-authoritative via delegation.max_iterations so users get
         # predictable budgets.
@@ -215,6 +219,214 @@ class TestDelegateTask(unittest.TestCase):
         self.assertEqual(result["results"][0]["summary"], "Result A")
         self.assertEqual(result["results"][1]["summary"], "Result B")
         self.assertIn("total_duration_seconds", result)
+
+    @patch("tools.delegate_tool._resolve_profile_delegate_env")
+    @patch("tools.delegate_tool._resolve_profile_delegate_argv")
+    @patch("tools.delegate_tool.subprocess.Popen")
+    def test_profile_task_mode_spawns_profile_subprocess(self, mock_popen, mock_argv, mock_profile_env):
+        captured = {}
+        mock_profile_env.return_value = ("qa", "/tmp/hermes/profiles/qa")
+        mock_argv.return_value = ["hermes"]
+
+        class FakeProc:
+            pid = 1234
+            returncode = 0
+
+            def communicate(self, timeout=None):
+                captured["timeout"] = timeout
+                return "profile result\n", ""
+
+            def poll(self):
+                return self.returncode
+
+        def fake_popen(cmd, **kwargs):
+            captured["cmd"] = list(cmd)
+            captured["env"] = dict(kwargs["env"])
+            captured["stdin"] = kwargs["stdin"]
+            return FakeProc()
+
+        mock_popen.side_effect = fake_popen
+        parent = _make_mock_parent()
+        result = json.loads(
+            delegate_task(
+                goal="Review this diff",
+                context="base=main",
+                profile="QA",
+                parent_agent=parent,
+            )
+        )
+
+        self.assertEqual(result["results"][0]["status"], "completed")
+        self.assertEqual(result["results"][0]["summary"], "profile result")
+        self.assertEqual(result["results"][0]["profile"], "qa")
+        self.assertEqual(captured["env"]["HERMES_HOME"], "/tmp/hermes/profiles/qa")
+        self.assertEqual(captured["env"]["HERMES_PROFILE"], "qa")
+        self.assertEqual(captured["cmd"][:4], ["hermes", "-p", "qa", "--accept-hooks"])
+        self.assertIn("-z", captured["cmd"])
+        prompt = captured["cmd"][captured["cmd"].index("-z") + 1]
+        self.assertIn("Review this diff", prompt)
+        self.assertIn("base=main", prompt)
+        mock_profile_env.assert_called_with("QA")
+
+    @patch("tools.delegate_tool._resolve_profile_delegate_env")
+    @patch("tools.delegate_tool._resolve_profile_delegate_argv")
+    @patch("tools.delegate_tool.subprocess.Popen")
+    def test_profile_task_mode_reports_subprocess_failure(self, mock_popen, mock_argv, mock_profile_env):
+        mock_profile_env.return_value = ("qa", "/tmp/hermes/profiles/qa")
+        mock_argv.return_value = ["hermes"]
+
+        class FakeProc:
+            pid = 1234
+            returncode = 7
+
+            def communicate(self, timeout=None):
+                return "partial", "boom"
+
+            def poll(self):
+                return self.returncode
+
+        mock_popen.return_value = FakeProc()
+        parent = _make_mock_parent()
+        result = json.loads(delegate_task(goal="Do it", profile="qa", parent_agent=parent))
+
+        entry = result["results"][0]
+        self.assertEqual(entry["status"], "error")
+        self.assertEqual(entry["summary"], "partial")
+        self.assertEqual(entry["error"], "boom")
+        self.assertEqual(entry["exit_code"], 7)
+
+    @patch("tools.delegate_tool._resolve_profile_delegate_env")
+    @patch("tools.async_delegation.dispatch_async_delegation")
+    @patch("tools.delegate_tool._run_profile_delegate")
+    def test_profile_background_dispatches_without_building_child_agent(
+        self, mock_run_profile, mock_dispatch, mock_profile_env
+    ):
+        mock_profile_env.return_value = ("qa", "/tmp/hermes/profiles/qa")
+        mock_run_profile.return_value = {"task_index": 0, "status": "completed", "summary": "ok"}
+        mock_dispatch.return_value = {"status": "dispatched", "delegation_id": "deleg_123"}
+        parent = _make_mock_parent()
+        result = json.loads(
+            delegate_task(goal="Review later", profile="qa", background=True, parent_agent=parent)
+        )
+
+        self.assertEqual(result["status"], "dispatched")
+        self.assertEqual(result["delegation_id"], "deleg_123")
+        self.assertEqual(result["profile"], "qa")
+        kwargs = mock_dispatch.call_args.kwargs
+        self.assertEqual(kwargs["model"], "profile:qa")
+        self.assertTrue(callable(kwargs["runner"]))
+        self.assertTrue(callable(kwargs["interrupt_fn"]))
+
+        runner_result = kwargs["runner"]()
+        self.assertEqual(runner_result["status"], "completed")
+        mock_profile_env.assert_called_once_with("qa")
+        mock_run_profile.assert_called_once()
+        self.assertEqual(
+            mock_run_profile.call_args.kwargs["resolved_profile"],
+            ("qa", "/tmp/hermes/profiles/qa"),
+        )
+
+    def test_profile_batch_rejects_mixed_profile_and_in_process_tasks(self):
+        parent = _make_mock_parent()
+        result = json.loads(
+            delegate_task(
+                tasks=[{"goal": "QA", "profile": "qa"}, {"goal": "Plain"}],
+                parent_agent=parent,
+            )
+        )
+
+        self.assertIn("error", result)
+        self.assertIn("cannot mix profile and in-process tasks", result["error"])
+
+    def test_profile_background_rejects_batch(self):
+        parent = _make_mock_parent()
+        result = json.loads(
+            delegate_task(
+                tasks=[{"goal": "A", "profile": "qa"}, {"goal": "B", "profile": "qa"}],
+                background=True,
+                parent_agent=parent,
+            )
+        )
+
+        self.assertIn("error", result)
+        self.assertIn("background=true", result["error"])
+        self.assertIn("single-task", result["error"])
+
+    @patch("tools.delegate_tool._resolve_profile_delegate_env")
+    @patch("tools.delegate_tool._resolve_profile_delegate_argv")
+    @patch("tools.delegate_tool._terminate_profile_delegate_process")
+    @patch("tools.delegate_tool.subprocess.Popen")
+    def test_profile_delegate_terminates_subprocess_on_base_exception(
+        self, mock_popen, mock_terminate, mock_argv, mock_profile_env
+    ):
+        mock_profile_env.return_value = ("qa", "/tmp/hermes/profiles/qa")
+        mock_argv.return_value = ["hermes"]
+        proc_holder = {}
+
+        class FakeProc:
+            pid = 1234
+            returncode = None
+
+            def communicate(self, timeout=None):
+                raise KeyboardInterrupt()
+
+            def poll(self):
+                return None
+
+        fake_proc = FakeProc()
+        mock_popen.return_value = fake_proc
+
+        with self.assertRaises(KeyboardInterrupt):
+            delegate_mod._run_profile_delegate(
+                task_index=0,
+                goal="Review",
+                context=None,
+                profile="qa",
+                timeout_seconds=60,
+                proc_holder=proc_holder,
+            )
+
+        mock_terminate.assert_called_once_with(fake_proc)
+        self.assertEqual(proc_holder, {})
+
+    @patch("tools.delegate_tool._terminate_profile_delegate_process")
+    @patch("tools.delegate_tool.as_completed", side_effect=KeyboardInterrupt)
+    def test_profile_batch_terminates_in_flight_subprocesses_on_interrupt(
+        self, mock_as_completed, mock_terminate
+    ):
+        fake_procs = [MagicMock(name="proc0"), MagicMock(name="proc1")]
+
+        class FakeExecutor:
+            def __init__(self, *args, **kwargs):
+                self.submits = []
+                self.shutdown_calls = []
+
+            def submit(self, fn, **kwargs):
+                idx = kwargs["task_index"]
+                kwargs["proc_holder"]["proc"] = fake_procs[idx]
+                self.submits.append((fn, kwargs))
+                return MagicMock(name=f"future{idx}")
+
+            def shutdown(self, **kwargs):
+                self.shutdown_calls.append(kwargs)
+
+        fake_executor = FakeExecutor()
+        tasks = [{"goal": "A", "profile": "qa"}, {"goal": "B", "profile": "qa"}]
+
+        with patch("tools.delegate_tool.ThreadPoolExecutor", return_value=fake_executor):
+            with self.assertRaises(KeyboardInterrupt):
+                delegate_mod._run_profile_delegates(
+                    task_list=tasks,
+                    top_profile=None,
+                    max_children=2,
+                    timeout_seconds=60,
+                )
+
+        self.assertEqual([call.args[0] for call in mock_terminate.call_args_list], fake_procs)
+        self.assertEqual(
+            fake_executor.shutdown_calls,
+            [{"wait": False, "cancel_futures": True}],
+        )
 
     @patch("tools.delegate_tool._run_single_child")
     def test_batch_mode_accepts_json_string_tasks(self, mock_run):

--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -418,7 +418,9 @@ class TestDelegateTask(unittest.TestCase):
         self.assertIn("error", result)
         self.assertIn("cannot mix profile and in-process tasks", result["error"])
 
-    def test_profile_background_rejects_batch(self):
+    @patch("tools.async_delegation.dispatch_async_delegation_batch")
+    def test_profile_background_batch_dispatches_as_one_async_unit(self, mock_dispatch):
+        mock_dispatch.return_value = {"status": "dispatched", "delegation_id": "deleg_batch"}
         parent = _make_mock_parent()
         result = json.loads(
             delegate_task(
@@ -428,9 +430,14 @@ class TestDelegateTask(unittest.TestCase):
             )
         )
 
-        self.assertIn("error", result)
-        self.assertIn("background=true", result["error"])
-        self.assertIn("single-task", result["error"])
+        self.assertEqual(result["status"], "dispatched")
+        self.assertEqual(result["delegation_id"], "deleg_batch")
+        self.assertEqual(result["count"], 2)
+        kwargs = mock_dispatch.call_args.kwargs
+        self.assertEqual(kwargs["goals"], ["A", "B"])
+        self.assertEqual(kwargs["model"], "profile:batch")
+        self.assertTrue(callable(kwargs["runner"]))
+        self.assertTrue(callable(kwargs["interrupt_fn"]))
 
     @patch("tools.delegate_tool._resolve_profile_delegate_env")
     @patch("tools.delegate_tool._resolve_profile_delegate_argv")

--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -161,6 +161,22 @@ class TestStripBlockedTools(unittest.TestCase):
         self.assertEqual(result, [])
 
 
+class TestProfileDelegateToolsets(unittest.TestCase):
+    def test_profile_delegate_toolsets_arg_joins_requested_toolsets(self):
+        self.assertEqual(
+            delegate_mod._profile_delegate_toolsets_arg(["terminal", "file"]),
+            "terminal,file",
+        )
+
+    def test_profile_delegate_toolsets_arg_omits_empty_values(self):
+        self.assertIsNone(delegate_mod._profile_delegate_toolsets_arg(None))
+        self.assertIsNone(delegate_mod._profile_delegate_toolsets_arg([]))
+        self.assertEqual(
+            delegate_mod._profile_delegate_toolsets_arg(["terminal", "", " file "]),
+            "terminal,file",
+        )
+
+
 class TestDelegateTask(unittest.TestCase):
     def test_no_parent_agent(self):
         result = json.loads(delegate_task(goal="test"))
@@ -251,6 +267,7 @@ class TestDelegateTask(unittest.TestCase):
             delegate_task(
                 goal="Review this diff",
                 context="base=main",
+                toolsets=["terminal", "file"],
                 profile="QA",
                 parent_agent=parent,
             )
@@ -262,6 +279,12 @@ class TestDelegateTask(unittest.TestCase):
         self.assertEqual(captured["env"]["HERMES_HOME"], "/tmp/hermes/profiles/qa")
         self.assertEqual(captured["env"]["HERMES_PROFILE"], "qa")
         self.assertEqual(captured["cmd"][:4], ["hermes", "-p", "qa", "--accept-hooks"])
+        self.assertIn("-t", captured["cmd"])
+        self.assertEqual(
+            captured["cmd"][captured["cmd"].index("-t") + 1],
+            "terminal,file",
+        )
+        self.assertLess(captured["cmd"].index("-t"), captured["cmd"].index("-z"))
         self.assertIn("-z", captured["cmd"])
         prompt = captured["cmd"][captured["cmd"].index("-z") + 1]
         self.assertIn("Review this diff", prompt)
@@ -306,7 +329,13 @@ class TestDelegateTask(unittest.TestCase):
         mock_dispatch.return_value = {"status": "dispatched", "delegation_id": "deleg_123"}
         parent = _make_mock_parent()
         result = json.loads(
-            delegate_task(goal="Review later", profile="qa", background=True, parent_agent=parent)
+            delegate_task(
+                goal="Review later",
+                toolsets=["terminal", "file"],
+                profile="qa",
+                background=True,
+                parent_agent=parent,
+            )
         )
 
         self.assertEqual(result["status"], "dispatched")
@@ -324,6 +353,10 @@ class TestDelegateTask(unittest.TestCase):
         self.assertEqual(
             mock_run_profile.call_args.kwargs["resolved_profile"],
             ("qa", "/tmp/hermes/profiles/qa"),
+        )
+        self.assertEqual(
+            mock_run_profile.call_args.kwargs["toolsets"],
+            ["terminal", "file"],
         )
 
     def test_profile_batch_rejects_mixed_profile_and_in_process_tasks(self):
@@ -381,6 +414,7 @@ class TestDelegateTask(unittest.TestCase):
                 task_index=0,
                 goal="Review",
                 context=None,
+                toolsets=None,
                 profile="qa",
                 timeout_seconds=60,
                 proc_holder=proc_holder,
@@ -418,6 +452,7 @@ class TestDelegateTask(unittest.TestCase):
                 delegate_mod._run_profile_delegates(
                     task_list=tasks,
                     top_profile=None,
+                    top_toolsets=None,
                     max_children=2,
                     timeout_seconds=60,
                 )

--- a/tools/async_delegation.py
+++ b/tools/async_delegation.py
@@ -174,8 +174,10 @@ def dispatch_async_delegation(
         worker thread won't carry the contextvar. Used to route the
         completion back to the originating session.
     runner
-        Zero-arg callable that builds + runs the child and returns the same
-        result dict ``_run_single_child`` produces. Runs on the worker thread.
+        Zero-arg callable that runs the delegated work and returns a result
+        dict for the completion block. In-process children return the
+        ``_run_single_child`` shape; custom runners may add fields such as
+        profile subprocess metadata. Runs on the worker thread.
     interrupt_fn
         Optional callable to signal the child to stop (used on shutdown /
         explicit cancel).

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -2213,6 +2213,8 @@ def _run_profile_delegate(
             "duration_seconds": round(time.monotonic() - start, 2),
         }
     except Exception as exc:
+        if proc is not None:
+            _terminate_profile_delegate_process(proc)
         return {
             "task_index": task_index,
             "status": "error",

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -22,11 +22,15 @@ import logging
 
 logger = logging.getLogger(__name__)
 import os
+import signal
+import subprocess
+import sys
 import threading
 import time
 from concurrent.futures import (
     ThreadPoolExecutor,
     TimeoutError as FuturesTimeoutError,
+    as_completed,
 )
 from typing import Any, Dict, List, Optional
 
@@ -2039,6 +2043,270 @@ def _run_single_child(
             logger.debug("Failed to close child agent after delegation")
 
 
+
+_PROFILE_DELEGATE_TIMEOUT_SECONDS = 600
+_PROFILE_DELEGATE_MAX_STDERR_CHARS = 4000
+
+
+def _resolve_profile_delegate_env(profile: str) -> tuple[str, str]:
+    """Return ``(canonical_profile, HERMES_HOME)`` for a profile delegate."""
+    from hermes_cli.profiles import normalize_profile_name, resolve_profile_env
+
+    canon = normalize_profile_name(profile)
+    return canon, resolve_profile_env(canon)
+
+
+def _resolve_profile_delegate_argv() -> list[str]:
+    """Resolve the Hermes CLI invocation for a profile delegate subprocess."""
+    import shutil
+
+    env_bin = (os.environ.get("HERMES_BIN") or "").strip()
+    if env_bin:
+        return [env_bin]
+    hermes_bin = shutil.which("hermes")
+    if hermes_bin:
+        return [hermes_bin]
+    return [sys.executable, "-m", "hermes_cli.main"]
+
+
+def _profile_delegate_prompt(goal: str, context: Optional[str]) -> str:
+    parts = [
+        "You are running as a Hermes profile delegated by another Hermes agent.",
+        "Use your own profile configuration, tools, skills, memory, and context.",
+        "Return only the final answer the parent agent should receive; the parent will not see intermediate output.",
+        "",
+        "TASK:",
+        goal.strip(),
+    ]
+    if context and str(context).strip():
+        parts.extend(["", "CONTEXT:", str(context).strip()])
+    return "\n".join(parts)
+
+
+def _profile_delegate_timeout_seconds(cfg: dict) -> int:
+    try:
+        return max(
+            1,
+            int(cfg.get("profile_timeout_seconds", _PROFILE_DELEGATE_TIMEOUT_SECONDS)),
+        )
+    except (TypeError, ValueError):
+        return _PROFILE_DELEGATE_TIMEOUT_SECONDS
+
+
+def _terminate_profile_delegate_process(proc: subprocess.Popen) -> None:
+    if proc.poll() is not None:
+        return
+    try:
+        if os.name == "nt":
+            proc.terminate()
+        else:
+            os.killpg(proc.pid, signal.SIGTERM)  # windows-footgun: ok -- guarded by os.name
+    except Exception:
+        try:
+            if os.name == "nt":
+                proc.kill()
+            else:
+                os.killpg(  # windows-footgun: ok -- guarded by os.name
+                    proc.pid,
+                    getattr(signal, "SIGKILL", signal.SIGTERM),
+                )
+        except Exception:
+            try:
+                proc.kill()
+            except Exception:
+                pass
+
+
+def _run_profile_delegate(
+    *,
+    task_index: int,
+    goal: str,
+    context: Optional[str],
+    profile: str,
+    timeout_seconds: int,
+    proc_holder: Optional[Dict[str, subprocess.Popen]] = None,
+    resolved_profile: Optional[tuple[str, str]] = None,
+) -> Dict[str, Any]:
+    """Run one delegated task in a fresh ``hermes -p <profile> -z`` process."""
+    start = time.monotonic()
+    if resolved_profile is None:
+        try:
+            canon, hermes_home = _resolve_profile_delegate_env(profile)
+        except Exception as exc:
+            return {
+                "task_index": task_index,
+                "status": "error",
+                "summary": None,
+                "error": str(exc),
+                "profile": str(profile),
+                "api_calls": 0,
+                "duration_seconds": round(time.monotonic() - start, 2),
+            }
+    else:
+        canon, hermes_home = resolved_profile
+
+    env = dict(os.environ)
+    env["HERMES_HOME"] = hermes_home
+    env["HERMES_PROFILE"] = canon
+
+    cwd = os.environ.get("TERMINAL_CWD") or os.getcwd()
+    if not os.path.isdir(cwd):
+        cwd = os.getcwd()
+
+    cmd = [
+        *_resolve_profile_delegate_argv(),
+        "-p",
+        canon,
+        "--accept-hooks",
+        "-z",
+        _profile_delegate_prompt(goal, context),
+    ]
+
+    proc: Optional[subprocess.Popen] = None
+    try:
+        proc = subprocess.Popen(
+            cmd,
+            cwd=cwd,
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            env=env,
+            start_new_session=(os.name != "nt"),
+            creationflags=getattr(subprocess, "CREATE_NO_WINDOW", 0) if os.name == "nt" else 0,
+        )
+        if proc_holder is not None:
+            proc_holder["proc"] = proc
+        stdout, stderr = proc.communicate(timeout=timeout_seconds)
+    except subprocess.TimeoutExpired:
+        if proc is not None:
+            _terminate_profile_delegate_process(proc)
+            try:
+                stdout, stderr = proc.communicate(timeout=5)
+            except Exception:
+                stdout, stderr = "", ""
+        else:
+            stdout, stderr = "", ""
+        return {
+            "task_index": task_index,
+            "status": "timed_out",
+            "summary": (stdout or "").strip() or None,
+            "error": f"Profile delegate '{canon}' timed out after {timeout_seconds}s.",
+            "profile": canon,
+            "exit_code": None,
+            "api_calls": 0,
+            "duration_seconds": round(time.monotonic() - start, 2),
+        }
+    except Exception as exc:
+        return {
+            "task_index": task_index,
+            "status": "error",
+            "summary": None,
+            "error": f"{type(exc).__name__}: {exc}",
+            "profile": canon,
+            "api_calls": 0,
+            "duration_seconds": round(time.monotonic() - start, 2),
+        }
+    except BaseException:
+        if proc is not None:
+            _terminate_profile_delegate_process(proc)
+        raise
+    finally:
+        if proc_holder is not None:
+            proc_holder.pop("proc", None)
+
+    summary = (stdout or "").strip()
+    stderr_text = (stderr or "").strip()
+    result: Dict[str, Any] = {
+        "task_index": task_index,
+        "status": "completed" if proc.returncode == 0 else "error",
+        "summary": summary or None,
+        "profile": canon,
+        "exit_code": proc.returncode,
+        "api_calls": 0,
+        "duration_seconds": round(time.monotonic() - start, 2),
+    }
+    if proc.returncode != 0:
+        result["error"] = stderr_text[:_PROFILE_DELEGATE_MAX_STDERR_CHARS] or f"Profile delegate exited with code {proc.returncode}."
+    elif stderr_text:
+        result["stderr"] = stderr_text[:_PROFILE_DELEGATE_MAX_STDERR_CHARS]
+    return result
+
+
+def _run_profile_delegates(
+    *,
+    task_list: List[Dict[str, Any]],
+    top_profile: Optional[str],
+    max_children: int,
+    timeout_seconds: int,
+) -> List[Dict[str, Any]]:
+    specs: list[tuple[int, Dict[str, Any], str]] = []
+    for i, task in enumerate(task_list):
+        profile = (task.get("profile") or top_profile or "").strip()
+        if not profile:
+            raise ValueError(
+                "profile-backed batch cannot mix profile and in-process tasks; "
+                "set a top-level profile or a profile on every task."
+            )
+        specs.append((i, task, profile))
+
+    if len(specs) == 1:
+        i, task, profile = specs[0]
+        return [
+            _run_profile_delegate(
+                task_index=i,
+                goal=task["goal"],
+                context=task.get("context"),
+                profile=profile,
+                timeout_seconds=timeout_seconds,
+            )
+        ]
+
+    results: list[Dict[str, Any]] = []
+    proc_holders: dict[int, Dict[str, subprocess.Popen]] = {i: {} for i, _, _ in specs}
+    executor = ThreadPoolExecutor(max_workers=max_children)
+    try:
+        futures = {
+            executor.submit(
+                _run_profile_delegate,
+                task_index=i,
+                goal=task["goal"],
+                context=task.get("context"),
+                profile=profile,
+                timeout_seconds=timeout_seconds,
+                proc_holder=proc_holders[i],
+            ): i
+            for i, task, profile in specs
+        }
+        for future in as_completed(futures):
+            try:
+                results.append(future.result())
+            except Exception as exc:
+                results.append(
+                    {
+                        "task_index": futures[future],
+                        "status": "error",
+                        "summary": None,
+                        "error": f"{type(exc).__name__}: {exc}",
+                        "api_calls": 0,
+                        "duration_seconds": 0,
+                    }
+                )
+    except BaseException:
+        for holder in proc_holders.values():
+            proc = holder.get("proc")
+            if proc is not None:
+                _terminate_profile_delegate_process(proc)
+        executor.shutdown(wait=False, cancel_futures=True)
+        raise
+    else:
+        executor.shutdown(wait=True)
+    results.sort(key=lambda r: r["task_index"])
+    return results
+
+
 def _recover_tasks_from_json_string(
     tasks: Any,
 ) -> tuple[Optional[List[Dict[str, Any]]], Optional[str]]:
@@ -2072,6 +2340,7 @@ def delegate_task(
     acp_args: Optional[List[str]] = None,
     role: Optional[str] = None,
     background: Optional[bool] = None,
+    profile: Optional[str] = None,
     parent_agent=None,
 ) -> str:
     """
@@ -2143,16 +2412,6 @@ def delegate_task(
         )
     effective_max_iter = default_max_iter
 
-    # Resolve delegation credentials (provider:model pair).
-    # When delegation.provider is configured, this resolves the full credential
-    # bundle (base_url, api_key, api_mode) via the same runtime provider system
-    # used by CLI/gateway startup.  When unconfigured, returns None values so
-    # children inherit from the parent.
-    try:
-        creds = _resolve_delegation_credentials(cfg, parent_agent)
-    except ValueError as exc:
-        return tool_error(str(exc))
-
     # Normalize to task list
     max_children = _get_max_concurrent_children()
     recovered_tasks, tasks_error = _recover_tasks_from_json_string(tasks)
@@ -2172,9 +2431,10 @@ def delegate_task(
             )
         task_list = tasks
     elif goal and isinstance(goal, str) and goal.strip():
-        task_list = [
-            {"goal": goal, "context": context, "toolsets": toolsets, "role": top_role}
-        ]
+        task = {"goal": goal, "context": context, "toolsets": toolsets, "role": top_role}
+        if profile:
+            task["profile"] = profile
+        task_list = [task]
     else:
         return tool_error("Provide either 'goal' (single task) or 'tasks' (batch).")
 
@@ -2193,7 +2453,99 @@ def delegate_task(
     overall_start = time.monotonic()
     results = []
 
+    profile_requested = bool(profile) or any(t.get("profile") for t in task_list)
+    if profile_requested:
+        if acp_command or acp_args or any(t.get("acp_command") or t.get("acp_args") for t in task_list):
+            return tool_error(
+                "profile-backed delegation runs Hermes profiles via `hermes -p <profile>`; "
+                "ACP command overrides are only supported by in-process subagents."
+            )
+        timeout_seconds = _profile_delegate_timeout_seconds(cfg)
+        if background:
+            if len(task_list) != 1:
+                return tool_error("background=true with profile is single-task only.")
+            from tools.async_delegation import dispatch_async_delegation
+            from tools.approval import get_current_session_key
+
+            task = task_list[0]
+            task_profile = (task.get("profile") or profile or "").strip()
+            if not task_profile:
+                return tool_error("profile-backed delegation requires a profile.")
+            try:
+                canon_profile, hermes_home = _resolve_profile_delegate_env(task_profile)
+            except Exception as exc:
+                return tool_error(str(exc))
+            proc_holder: Dict[str, subprocess.Popen] = {}
+
+            def _async_runner() -> Dict[str, Any]:
+                return _run_profile_delegate(
+                    task_index=0,
+                    goal=task["goal"],
+                    context=task.get("context"),
+                    profile=canon_profile,
+                    timeout_seconds=timeout_seconds,
+                    proc_holder=proc_holder,
+                    resolved_profile=(canon_profile, hermes_home),
+                )
+
+            def _async_interrupt() -> None:
+                proc = proc_holder.get("proc")
+                if proc is not None:
+                    _terminate_profile_delegate_process(proc)
+
+            dispatch = dispatch_async_delegation(
+                goal=task["goal"],
+                context=task.get("context"),
+                toolsets=task.get("toolsets") or toolsets,
+                role=_normalize_role(task.get("role") or top_role),
+                model=f"profile:{canon_profile}",
+                session_key=get_current_session_key(default=""),
+                runner=_async_runner,
+                interrupt_fn=_async_interrupt,
+                max_async_children=_get_max_async_children(),
+            )
+            if dispatch.get("status") == "dispatched":
+                return json.dumps(
+                    {
+                        "status": "dispatched",
+                        "delegation_id": dispatch["delegation_id"],
+                        "goal": task["goal"],
+                        "profile": canon_profile,
+                        "mode": "background",
+                        "note": (
+                            "Profile delegate is running in the background. "
+                            "The result will re-enter the conversation as a new message when it finishes. "
+                            "Do not wait or poll — just continue."
+                        ),
+                    },
+                    ensure_ascii=False,
+                )
+            return tool_error(dispatch.get("error", "Async profile delegation could not be scheduled."))
+        try:
+            profile_results = _run_profile_delegates(
+                task_list=task_list,
+                top_profile=profile,
+                max_children=max_children,
+                timeout_seconds=timeout_seconds,
+            )
+        except ValueError as exc:
+            return tool_error(str(exc))
+        return json.dumps(
+            {
+                "results": profile_results,
+                "total_duration_seconds": round(time.monotonic() - overall_start, 2),
+            },
+            ensure_ascii=False,
+        )
+
     n_tasks = len(task_list)
+    # Resolve delegation credentials (provider:model pair). Profile-backed
+    # delegates returned above; only in-process children need this bundle.
+    try:
+        creds = _resolve_delegation_credentials(cfg, parent_agent)
+    except ValueError as exc:
+        return tool_error(str(exc))
+
     # Track goal labels for progress display (truncated for readability)
     task_labels = [t["goal"][:40] for t in task_list]
 
@@ -3056,6 +3408,14 @@ DELEGATE_TASK_SCHEMA = {
                             "enum": ["leaf", "orchestrator"],
                             "description": "Per-task role override. See top-level 'role' for semantics.",
                         },
+                        "profile": {
+                            "type": "string",
+                            "description": (
+                                "Hermes profile to run this task in. Profile-backed tasks run in a fresh "
+                                "`hermes -p <profile> -z ...` subprocess and load that profile's config, "
+                                "skills, memory, and tools instead of using an in-process child agent."
+                            ),
+                        },
                     },
                     "required": ["goal"],
                 },
@@ -3068,6 +3428,15 @@ DELEGATE_TASK_SCHEMA = {
                 "type": "string",
                 "enum": ["leaf", "orchestrator"],
                 "description": "(rebuilt at get_definitions() time)",
+            },
+            "profile": {
+                "type": "string",
+                "description": (
+                    "Run the delegated task in a named Hermes profile. This uses a fresh "
+                    "`hermes -p <profile> -z ...` subprocess so the target profile loads its own "
+                    "HERMES_HOME, config, .env, skills, memory, and tool settings. Omit for the "
+                    "existing in-process subagent path."
+                ),
             },
             "background": {
                 "type": "boolean",
@@ -3143,6 +3512,7 @@ registry.register(
         acp_args=args.get("acp_args"),
         role=args.get("role"),
         background=_model_background_value(args, kw.get("parent_agent")),
+        profile=args.get("profile"),
         parent_agent=kw.get("parent_agent"),
     ),
     check_fn=check_delegate_requirements,

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -2093,6 +2093,16 @@ def _profile_delegate_timeout_seconds(cfg: dict) -> int:
         return _PROFILE_DELEGATE_TIMEOUT_SECONDS
 
 
+def _profile_delegate_toolsets_arg(toolsets: Optional[List[str]]) -> Optional[str]:
+    """Return a comma-separated ``--toolsets`` value for profile delegates."""
+    if not toolsets:
+        return None
+    cleaned = [str(toolset).strip() for toolset in toolsets if str(toolset).strip()]
+    if not cleaned:
+        return None
+    return ",".join(cleaned)
+
+
 def _terminate_profile_delegate_process(proc: subprocess.Popen) -> None:
     if proc.poll() is not None:
         return
@@ -2122,6 +2132,7 @@ def _run_profile_delegate(
     task_index: int,
     goal: str,
     context: Optional[str],
+    toolsets: Optional[List[str]],
     profile: str,
     timeout_seconds: int,
     proc_holder: Optional[Dict[str, subprocess.Popen]] = None,
@@ -2158,9 +2169,11 @@ def _run_profile_delegate(
         "-p",
         canon,
         "--accept-hooks",
-        "-z",
-        _profile_delegate_prompt(goal, context),
     ]
+    toolsets_arg = _profile_delegate_toolsets_arg(toolsets)
+    if toolsets_arg:
+        cmd.extend(["-t", toolsets_arg])
+    cmd.extend(["-z", _profile_delegate_prompt(goal, context)])
 
     proc: Optional[subprocess.Popen] = None
     try:
@@ -2239,6 +2252,7 @@ def _run_profile_delegates(
     *,
     task_list: List[Dict[str, Any]],
     top_profile: Optional[str],
+    top_toolsets: Optional[List[str]],
     max_children: int,
     timeout_seconds: int,
 ) -> List[Dict[str, Any]]:
@@ -2259,6 +2273,7 @@ def _run_profile_delegates(
                 task_index=i,
                 goal=task["goal"],
                 context=task.get("context"),
+                toolsets=task.get("toolsets") or top_toolsets,
                 profile=profile,
                 timeout_seconds=timeout_seconds,
             )
@@ -2274,6 +2289,7 @@ def _run_profile_delegates(
                 task_index=i,
                 goal=task["goal"],
                 context=task.get("context"),
+                toolsets=task.get("toolsets") or top_toolsets,
                 profile=profile,
                 timeout_seconds=timeout_seconds,
                 proc_holder=proc_holders[i],
@@ -2482,6 +2498,7 @@ def delegate_task(
                     task_index=0,
                     goal=task["goal"],
                     context=task.get("context"),
+                    toolsets=task.get("toolsets") or toolsets,
                     profile=canon_profile,
                     timeout_seconds=timeout_seconds,
                     proc_holder=proc_holder,
@@ -2525,6 +2542,7 @@ def delegate_task(
             profile_results = _run_profile_delegates(
                 task_list=task_list,
                 top_profile=profile,
+                top_toolsets=toolsets,
                 max_children=max_children,
                 timeout_seconds=timeout_seconds,
             )

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -2103,6 +2103,26 @@ def _profile_delegate_toolsets_arg(toolsets: Optional[List[str]]) -> Optional[st
     return ",".join(cleaned)
 
 
+def _profile_task_toolsets(
+    task: Dict[str, Any], top_toolsets: Optional[List[str]]
+) -> Optional[List[str]]:
+    raw = task.get("toolsets")
+    return raw if isinstance(raw, list) else top_toolsets
+
+
+def _profile_task_context(task: Dict[str, Any]) -> Optional[str]:
+    raw = task.get("context")
+    return str(raw) if raw is not None else None
+
+
+def _profile_task_goal(task: Dict[str, Any]) -> str:
+    return str(task["goal"])
+
+
+def _profile_task_name(task: Dict[str, Any], top_profile: Optional[str]) -> str:
+    return str(task.get("profile") or top_profile or "").strip()
+
+
 def _terminate_profile_delegate_process(proc: subprocess.Popen) -> None:
     if proc.poll() is not None:
         return
@@ -2257,10 +2277,11 @@ def _run_profile_delegates(
     top_toolsets: Optional[List[str]],
     max_children: int,
     timeout_seconds: int,
+    proc_holders: Optional[dict[int, Dict[str, subprocess.Popen]]] = None,
 ) -> List[Dict[str, Any]]:
     specs: list[tuple[int, Dict[str, Any], str]] = []
     for i, task in enumerate(task_list):
-        profile = (task.get("profile") or top_profile or "").strip()
+        profile = _profile_task_name(task, top_profile)
         if not profile:
             raise ValueError(
                 "profile-backed batch cannot mix profile and in-process tasks; "
@@ -2268,33 +2289,35 @@ def _run_profile_delegates(
             )
         specs.append((i, task, profile))
 
+    holders = proc_holders or {i: {} for i, _, _ in specs}
+
     if len(specs) == 1:
         i, task, profile = specs[0]
         return [
             _run_profile_delegate(
                 task_index=i,
-                goal=task["goal"],
-                context=task.get("context"),
-                toolsets=task.get("toolsets") or top_toolsets,
+                goal=_profile_task_goal(task),
+                context=_profile_task_context(task),
+                toolsets=_profile_task_toolsets(task, top_toolsets),
                 profile=profile,
                 timeout_seconds=timeout_seconds,
+                proc_holder=holders[i],
             )
         ]
 
     results: list[Dict[str, Any]] = []
-    proc_holders: dict[int, Dict[str, subprocess.Popen]] = {i: {} for i, _, _ in specs}
     executor = ThreadPoolExecutor(max_workers=max_children)
     try:
         futures = {
             executor.submit(
                 _run_profile_delegate,
                 task_index=i,
-                goal=task["goal"],
-                context=task.get("context"),
-                toolsets=task.get("toolsets") or top_toolsets,
+                goal=_profile_task_goal(task),
+                context=_profile_task_context(task),
+                toolsets=_profile_task_toolsets(task, top_toolsets),
                 profile=profile,
                 timeout_seconds=timeout_seconds,
-                proc_holder=proc_holders[i],
+                proc_holder=holders[i],
             ): i
             for i, task, profile in specs
         }
@@ -2313,7 +2336,7 @@ def _run_profile_delegates(
                     }
                 )
     except BaseException:
-        for holder in proc_holders.values():
+        for holder in holders.values():
             proc = holder.get("proc")
             if proc is not None:
                 _terminate_profile_delegate_process(proc)
@@ -2480,66 +2503,139 @@ def delegate_task(
             )
         timeout_seconds = _profile_delegate_timeout_seconds(cfg)
         if background:
-            if len(task_list) != 1:
-                return tool_error("background=true with profile is single-task only.")
-            from tools.async_delegation import dispatch_async_delegation
-            from tools.approval import get_current_session_key
+            if len(task_list) == 1:
+                from tools.async_delegation import dispatch_async_delegation
+                from tools.approval import get_current_session_key
 
-            task = task_list[0]
-            task_profile = (task.get("profile") or profile or "").strip()
-            if not task_profile:
-                return tool_error("profile-backed delegation requires a profile.")
-            try:
-                canon_profile, hermes_home = _resolve_profile_delegate_env(task_profile)
-            except Exception as exc:
-                return tool_error(str(exc))
-            proc_holder: Dict[str, subprocess.Popen] = {}
+                task = task_list[0]
+                task_goal = _profile_task_goal(task)
+                task_context = _profile_task_context(task)
+                task_toolsets = _profile_task_toolsets(task, toolsets)
+                task_profile = _profile_task_name(task, profile)
+                if not task_profile:
+                    return tool_error("profile-backed delegation requires a profile.")
+                try:
+                    canon_profile, hermes_home = _resolve_profile_delegate_env(task_profile)
+                except Exception as exc:
+                    return tool_error(str(exc))
+                proc_holder: Dict[str, subprocess.Popen] = {}
 
-            def _async_runner() -> Dict[str, Any]:
-                return _run_profile_delegate(
-                    task_index=0,
-                    goal=task["goal"],
-                    context=task.get("context"),
-                    toolsets=task.get("toolsets") or toolsets,
-                    profile=canon_profile,
-                    timeout_seconds=timeout_seconds,
-                    proc_holder=proc_holder,
-                    resolved_profile=(canon_profile, hermes_home),
+                def _async_runner() -> Dict[str, Any]:
+                    return _run_profile_delegate(
+                        task_index=0,
+                        goal=task_goal,
+                        context=task_context,
+                        toolsets=task_toolsets,
+                        profile=canon_profile,
+                        timeout_seconds=timeout_seconds,
+                        proc_holder=proc_holder,
+                        resolved_profile=(canon_profile, hermes_home),
+                    )
+
+                def _async_interrupt() -> None:
+                    proc = proc_holder.get("proc")
+                    if proc is not None:
+                        _terminate_profile_delegate_process(proc)
+
+                dispatch = dispatch_async_delegation(
+                    goal=task_goal,
+                    context=task_context,
+                    toolsets=task_toolsets,
+                    role=_normalize_role(str(task.get("role") or top_role)),
+                    model=f"profile:{canon_profile}",
+                    session_key=get_current_session_key(default=""),
+                    runner=_async_runner,
+                    interrupt_fn=_async_interrupt,
+                    max_async_children=_get_max_async_children(),
                 )
-
-            def _async_interrupt() -> None:
-                proc = proc_holder.get("proc")
-                if proc is not None:
-                    _terminate_profile_delegate_process(proc)
-
-            dispatch = dispatch_async_delegation(
-                goal=task["goal"],
-                context=task.get("context"),
-                toolsets=task.get("toolsets") or toolsets,
-                role=_normalize_role(task.get("role") or top_role),
-                model=f"profile:{canon_profile}",
-                session_key=get_current_session_key(default=""),
-                runner=_async_runner,
-                interrupt_fn=_async_interrupt,
-                max_async_children=_get_max_async_children(),
-            )
-            if dispatch.get("status") == "dispatched":
-                return json.dumps(
-                    {
-                        "status": "dispatched",
-                        "delegation_id": dispatch["delegation_id"],
-                        "goal": task["goal"],
-                        "profile": canon_profile,
-                        "mode": "background",
-                        "note": (
-                            "Profile delegate is running in the background. "
-                            "The result will re-enter the conversation as a new message when it finishes. "
-                            "Do not wait or poll — just continue."
-                        ),
-                    },
-                    ensure_ascii=False,
+                if dispatch.get("status") == "dispatched":
+                    return json.dumps(
+                        {
+                            "status": "dispatched",
+                            "delegation_id": dispatch["delegation_id"],
+                            "goal": task_goal,
+                            "profile": canon_profile,
+                            "mode": "background",
+                            "note": (
+                                "Profile delegate is running in the background. "
+                                "The result will re-enter the conversation as a new message when it finishes. "
+                                "Do not wait or poll — just continue."
+                            ),
+                        },
+                        ensure_ascii=False,
+                    )
+                logger.info(
+                    "delegate_task: async profile pool rejected single task (%s); running synchronously.",
+                    dispatch.get("error", "rejected"),
                 )
-            return tool_error(dispatch.get("error", "Async profile delegation could not be scheduled."))
+            else:
+                from tools.async_delegation import dispatch_async_delegation_batch
+                from tools.approval import get_current_session_key
+
+                for task in task_list:
+                    if not _profile_task_name(task, profile):
+                        return tool_error(
+                            "profile-backed batch cannot mix profile and in-process tasks; "
+                            "set a top-level profile or a profile on every task."
+                        )
+
+                proc_holders: dict[int, Dict[str, subprocess.Popen]] = {
+                    i: {} for i in range(len(task_list))
+                }
+
+                def _profile_batch_runner() -> Dict[str, Any]:
+                    profile_results = _run_profile_delegates(
+                        task_list=task_list,
+                        top_profile=profile,
+                        top_toolsets=toolsets,
+                        max_children=max_children,
+                        timeout_seconds=timeout_seconds,
+                        proc_holders=proc_holders,
+                    )
+                    return {
+                        "results": profile_results,
+                        "total_duration_seconds": round(time.monotonic() - overall_start, 2),
+                    }
+
+                def _profile_batch_interrupt() -> None:
+                    for holder in proc_holders.values():
+                        proc = holder.get("proc")
+                        if proc is not None:
+                            _terminate_profile_delegate_process(proc)
+
+                _goals = [_profile_task_goal(t) for t in task_list]
+                dispatch = dispatch_async_delegation_batch(
+                    goals=_goals,
+                    context=context,
+                    toolsets=toolsets,
+                    role=top_role,
+                    model=f"profile:{profile.strip()}" if profile else "profile:batch",
+                    session_key=get_current_session_key(default=""),
+                    runner=_profile_batch_runner,
+                    interrupt_fn=_profile_batch_interrupt,
+                    max_async_children=_get_max_async_children(),
+                )
+                if dispatch.get("status") == "dispatched":
+                    return json.dumps(
+                        {
+                            "status": "dispatched",
+                            "mode": "background",
+                            "count": len(_goals),
+                            "delegation_id": dispatch["delegation_id"],
+                            "goals": _goals,
+                            "profile": profile or "per-task",
+                            "note": (
+                                f"{len(_goals)} profile delegates are running in parallel in the background. "
+                                "Their consolidated results will re-enter the conversation when all finish. "
+                                "Do not wait or poll — just continue."
+                            ),
+                        },
+                        ensure_ascii=False,
+                    )
+                logger.info(
+                    "delegate_task: async profile pool rejected batch (%s); running synchronously.",
+                    dispatch.get("error", "rejected"),
+                )
         try:
             profile_results = _run_profile_delegates(
                 task_list=task_list,

--- a/website/docs/user-guide/features/delegation.md
+++ b/website/docs/user-guide/features/delegation.md
@@ -18,6 +18,22 @@ delegate_task(
 )
 ```
 
+## Profile-Backed Delegation
+
+Use `profile` when the delegated work should run as a real Hermes profile with its own `HERMES_HOME`, config, `.env`, skills, memory, and tool settings. This path launches a fresh `hermes -p <profile> -z ...` subprocess instead of mutating the parent process into another profile.
+
+```python
+delegate_task(
+    goal="Review this PR as the QA profile",
+    context="Base branch: main. Focus on regressions and missing tests.",
+    profile="qa"
+)
+```
+
+Profile-backed delegation is intentionally lighter than Kanban: the result returns to the current `delegate_task` call (or re-enters the chat when `background=True`) and no durable task-board state is created. Use Kanban when the work needs durable assignment, retries, dependencies, or human-visible task state.
+
+For batch calls, profile-backed delegation is all-or-nothing: provide a top-level `profile` for the whole batch, or set `profile` on every task. You cannot mix real-profile subprocess tasks with ordinary in-process subagents in one `tasks` array.
+
 ## Parallel Batch
 
 Up to 3 concurrent subagents by default (configurable, no hard ceiling):

--- a/website/docs/user-guide/features/delegation.md
+++ b/website/docs/user-guide/features/delegation.md
@@ -37,6 +37,15 @@ Profile-backed delegation is intentionally lighter than Kanban: the result retur
 
 For batch calls, profile-backed delegation is all-or-nothing: provide a top-level `profile` for the whole batch, or set `profile` on every task. You cannot mix real-profile subprocess tasks with ordinary in-process subagents in one `tasks` array.
 
+You can tune the profile subprocess timeout via `config.yaml` under the `delegation` section:
+
+```yaml
+delegation:
+  profile_timeout_seconds: 600
+```
+
+If not configured, the default is 600 seconds. Setting it to `null` or a non-positive value keeps the default.
+
 ## Parallel Batch
 
 Up to 3 concurrent subagents by default (configurable, no hard ceiling):

--- a/website/docs/user-guide/features/delegation.md
+++ b/website/docs/user-guide/features/delegation.md
@@ -26,9 +26,12 @@ Use `profile` when the delegated work should run as a real Hermes profile with i
 delegate_task(
     goal="Review this PR as the QA profile",
     context="Base branch: main. Focus on regressions and missing tests.",
-    profile="qa"
+    profile="qa",
+    toolsets=["terminal", "file"],
 )
 ```
+
+When `toolsets` is provided with `profile`, Hermes passes it through to the profile subprocess as `--toolsets` / `-t`. The target profile still supplies its identity, config, credentials, memory, and other profile-local settings, but the delegated run only exposes the requested tools for that task. Omitting `toolsets` preserves the profile's normal default tool configuration.
 
 Profile-backed delegation is intentionally lighter than Kanban: the result returns to the current `delegate_task` call (or re-enters the chat when `background=True`) and no durable task-board state is created. Use Kanban when the work needs durable assignment, retries, dependencies, or human-visible task state.
 


### PR DESCRIPTION
## Summary

Adds a narrow `delegate_task(profile=...)` path that runs delegated work in a real Hermes profile subprocess:

- `profile="qa"` launches `hermes -p qa --accept-hooks -z <prompt>` instead of mutating the parent process or building an in-process child.
- The target profile loads its own `HERMES_HOME`, config, `.env`, skills, memory, and tool settings.
- Existing `toolsets=[...]` narrowing is passed through to the subprocess as `-t`, e.g. `-t terminal,file`.
- Existing `background=True` support works for profile delegates and returns an immediate `delegation_id` while the profile subprocess runs in the async delegation registry.
- Batch calls are supported only when every task resolves to a profile-backed delegate; mixed profile/in-process batches are rejected clearly.

## Why

The current in-process subagent path is useful for cheap parallel subtasks, but it does not exercise a named Hermes profile's actual identity/config/tool/memory environment. Some workflows need a real specialist profile without the durability and board overhead of Kanban.

This keeps the first slice intentionally small: reuse the existing `delegate_task` surface and existing async completion rail, while adding only the minimum profile subprocess runner and tests/docs for its contract.

## Non-goals / follow-ups

This PR does **not** add:

- durable delegation jobs or a new job-management tool family;
- list/poll/cancel handles beyond the existing async completion path;
- read-only QA/review enforcement;
- stale-head/work-id validation metadata;
- compact async completion envelopes;
- skill/memory/context whitelisting controls.

Those are useful follow-ups, but they are separate orchestration/API questions. This PR is just the first reusable profile-backed delegation primitive.

## Overlap with existing PRs

Related prior work exists, notably #11169 and #15785. This PR is deliberately narrower:

- unlike #11169, it does not try to route through profile-backed ACP child construction or change ACP/runtime metadata behavior;
- unlike #15785, it does not introduce a file-backed async job subsystem or new delegate job tools.

The goal here is a smaller reviewable slice: `delegate_task(profile=...)` as a subprocess-backed profile invocation, plus passthrough of the already-existing `toolsets` and `background` controls.

## Verification

On a clean worktree from `origin/main`, cherry-picked this branch and ran:

- `uv run --extra dev pytest tests/tools/test_delegate.py -q` → `150 passed`
- `uv run ruff check tools/delegate_tool.py tests/tools/test_delegate.py` → passed
- `git diff --check` → passed

Additional downstream dogfood used this path for profile-backed implementation + QA/review lanes with `background=True` and narrowed `toolsets`; the parent received immediate delegation IDs and later async completions, then verified exact heads/checks before acting.