### PR TITLE
docs(hooks): document manual shell hook allowlisting

### DIFF
--- a/website/docs/user-guide/features/hooks.md
+++ b/website/docs/user-guide/features/hooks.md
@@ -1313,6 +1313,23 @@ Non-TTY runs (gateway, cron, CI) need one of these three — otherwise any newly
 
 **Script edits are silently trusted.** The allowlist keys on the exact command string, not the script's hash, so editing the script on disk does not invalidate consent. `hermes hooks doctor` flags mtime drift so you can spot edits and decide whether to re-approve.
 
+#### Manual allowlisting
+
+Manual allowlisting is useful for non-TTY or service-account deployments where an operator cannot answer the first-use prompt interactively. The allowlist file is `~/.hermes/shell-hooks-allowlist.json`, and the expected format is an `approvals` array. Each approval records the hook `event` and the exact `command` string:
+
+```json
+{
+  "approvals": [
+    {
+      "event": "post_llm_call",
+      "command": "/home/hermes/.hermes/hooks/my-hook.py"
+    }
+  ]
+}
+```
+
+The command string must match the configured hook command exactly. A path-keyed object with a `sha256` field is not the expected format and will not approve the hook. Verify manual entries with `hermes hooks list`.
+
 ### The `hermes hooks` CLI
 
 | Command | What it does |


### PR DESCRIPTION
## Summary

- Adds a manual allowlisting note for `~/.hermes/shell-hooks-allowlist.json`.
- Documents the expected `approvals` array format with `event` and `command`.
- Notes that path-keyed `sha256` entries do not approve hooks and suggests verifying with `hermes hooks list`.

## Validation

- `git diff --check -- website/docs/user-guide/features/hooks.md`

Docs-only change; runtime behavior is unchanged.

References #31482
