### PR TITLE
fix(whatsapp): strip custom mention_patterns wake words from group message body

### DIFF
--- a/gateway/platforms/whatsapp_common.py
+++ b/gateway/platforms/whatsapp_common.py
@@ -262,6 +262,15 @@ class WhatsAppBehaviorMixin:
                 cleaned = re.sub(
                     rf"@{re.escape(bare_id)}\b[,:\-]*\s*", "", cleaned
                 )
+        # Also strip the first occurrence of each custom mention_patterns
+        # wake word (e.g. "(?i)@andy\\b").  The same patterns that gate group
+        # messages should be removed from the body so the wake word does not
+        # leak into the agent prompt.  Use count=1 to keep the replacement
+        # bounded — only remove the leading/standalone occurrence, not
+        # arbitrary in-content matches.  (Closes #47493)
+        if self._mention_patterns:
+            for pattern in self._mention_patterns:
+                cleaned = pattern.sub("", cleaned, count=1)
         return cleaned.strip() or text
 
     def _should_process_message(self, data: Dict[str, Any]) -> bool:


### PR DESCRIPTION
## Problem
In WhatsApp group chats, a custom wake word configured via `mention_patterns` (e.g. `(?i)@andy\b`) gates which messages the agent responds to, but it was **never stripped from the message body** before reaching the agent. Only the bot's real JID `@mention` was removed.

## Root Cause
`_clean_bot_mention_text()` in `whatsapp_common.py` only consulted `_bot_ids_from_message()` (the bot's JID) and never consulted `self._mention_patterns`. So the gate and the body-cleaner used two different notions of "the bot's name".

## Fix
After stripping JID mentions, also strip the first match of each custom `mention_patterns` using `pattern.sub("", text, count=1)`. The `count=1` keeps the replacement bounded — only the leading/standalone wake-word occurrence is removed, not arbitrary in-content matches.

The gate (`_message_matches_mention_patterns`) and the cleaner (`_clean_bot_mention_text`) now agree on what "addressing the bot" means.

## Testing
- All 26 existing tests in `test_whatsapp_group_gating.py` pass
- Change is +9 lines in a single file

Closes #47493