### PR TITLE
feat(mcp): raise default tool-call timeout 120s → 300s

### DIFF
--- a/tests/tools/test_mcp_tool.py
+++ b/tests/tools/test_mcp_tool.py
@@ -1884,7 +1884,7 @@ class TestConfigurableTimeouts:
 
         server = MCPServerTask("test_srv")
         assert server.tool_timeout == _DEFAULT_TOOL_TIMEOUT
-        assert server.tool_timeout == 120
+        assert server.tool_timeout == 300
 
     def test_custom_timeout(self):
         """Server with timeout=180 in config gets 180."""

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -17,7 +17,7 @@ Example config::
         command: "npx"
         args: ["-y", "@modelcontextprotocol/server-filesystem", "/tmp"]
         env: {}
-        timeout: 120         # per-tool-call timeout in seconds (default: 120)
+        timeout: 120         # per-tool-call timeout in seconds (default: 300)
         connect_timeout: 60  # initial connection timeout (default: 60)
       github:
         command: "npx"
@@ -258,7 +258,7 @@ if _MCP_AVAILABLE and not _MCP_MESSAGE_HANDLER_SUPPORTED:
 # Constants
 # ---------------------------------------------------------------------------
 
-_DEFAULT_TOOL_TIMEOUT = 120      # seconds for tool calls
+_DEFAULT_TOOL_TIMEOUT = 300      # seconds for tool calls
 _DEFAULT_CONNECT_TIMEOUT = 60    # seconds for initial connection per server
 _MAX_RECONNECT_RETRIES = 5
 _MAX_INITIAL_CONNECT_RETRIES = 3 # retries for the very first connection attempt

--- a/website/docs/reference/mcp-config-reference.md
+++ b/website/docs/reference/mcp-config-reference.md
@@ -54,8 +54,8 @@ mcp_servers:
 | `client_cert` | string or list | HTTP | mTLS client certificate. String = path to a PEM file containing cert + key. List `[cert, key]` = separate files. List `[cert, key, password]` = encrypted key |
 | `client_key` | string | HTTP | Path to the client private key, when `client_cert` is a string and the key is in a separate file |
 | `enabled` | bool | both | Skip the server entirely when false |
-| `timeout` | number | both | Tool call timeout |
-| `connect_timeout` | number | both | Initial connection timeout |
+| `timeout` | number | both | Tool call timeout in seconds (default: `300`) |
+| `connect_timeout` | number | both | Initial connection timeout in seconds (default: `60`) |
 | `supports_parallel_tool_calls` | bool | both | Allow tools from this server to run concurrently |
 | `tools` | mapping | both | Filtering and utility-tool policy |
 | `auth` | string | HTTP | Authentication method. Set to `oauth` to enable OAuth 2.1 with PKCE |


### PR DESCRIPTION
## Summary
MCP tools that legitimately run long (web fetches, sandboxed builds, deep-research servers) no longer fail spuriously at 120s — the default per-tool-call timeout is now 300s.

Ported from [openai/codex#28234](https://github.com/openai/codex/pull/28234), which raised Codex's default MCP tool timeout from 120 to 300 for the same reason. Hermes had the identical 120s default.

## Changes
- `tools/mcp_tool.py`: `_DEFAULT_TOOL_TIMEOUT` 120 → 300. The per-server `timeout:` config override is unchanged, so anyone who set an explicit value keeps it.
- `tests/tools/test_mcp_tool.py`: update `test_default_timeout` assertion.
- `website/docs/reference/mcp-config-reference.md`: document the `timeout`/`connect_timeout` defaults in the config table.

## Adaptation notes
Codex's PR also touched its Rust schema/config plumbing; in Hermes this is a single module-level constant consumed by `MCPServerTask`, so the port is one value plus the test and docs that referenced the old default. No behavior change for users with an explicit `timeout:` set.

## Validation
```
pytest tests/tools/test_mcp_tool.py -k 'Timeout or timeout'  → 5 passed
```