### PR TITLE
feat: add budget checkpoint continuation scaffolding

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -511,6 +511,30 @@ def init_agent(
     except Exception:
         pass
 
+    # Budget checkpointing scaffolding is dormant by default. When explicitly
+    # enabled in config.yaml, conversation_loop may request one structured,
+    # no-tools continuation packet before max-turn exhaustion.
+    agent._budget_checkpointing_enabled = False
+    agent._budget_checkpoint_warning_ratio = 0.75
+    agent._budget_checkpoint_checkpoint_ratio = 0.88
+    agent._budget_checkpoint_mode = "continuation_packet"
+    agent._budget_checkpoint_warning_emitted = False
+    agent._budget_checkpoint_emitted = False
+    try:
+        from hermes_cli.config import load_config as _load_budget_cfg
+
+        _budget_cfg = (
+            (_load_budget_cfg().get("agent") or {}).get("budget_checkpointing")
+            or {}
+        )
+        if isinstance(_budget_cfg, dict):
+            agent._budget_checkpointing_enabled = bool(_budget_cfg.get("enabled", False))
+            agent._budget_checkpoint_warning_ratio = float(_budget_cfg.get("warning_ratio", 0.75))
+            agent._budget_checkpoint_checkpoint_ratio = float(_budget_cfg.get("checkpoint_ratio", 0.88))
+            agent._budget_checkpoint_mode = str(_budget_cfg.get("mode", "continuation_packet") or "continuation_packet")
+    except Exception:
+        pass
+
     # Iteration budget: the LLM is only notified when it actually exhausts
     # the iteration budget (api_call_count >= max_iterations).  At that
     # point we inject ONE message, allow one final API call, and if the

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -1302,6 +1302,165 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
 
 
 
+_CONTINUATION_PACKET_FIELDS = [
+    "issue",
+    "lane",
+    "owner",
+    "task class",
+    "budget state",
+    "last completed phase",
+    "current phase",
+    "repo/worktree/branch",
+    "commit SHA",
+    "PR URL/state",
+    "merge state",
+    "package path",
+    "Drive target",
+    "Obsidian target",
+    "Linear state",
+    "validation",
+    "remaining actions",
+    "forbidden actions",
+    "do-not-repeat list",
+    "next safe resume packet",
+    "FGD-21 footer",
+]
+
+
+def _build_budget_checkpoint_request(
+    *,
+    api_call_count: int,
+    max_iterations: int,
+    budget_state: str = "checkpoint",
+    task_metadata: Optional[Dict[str, Any]] = None,
+) -> str:
+    """Build the dormant continuation-packet prompt for budget checkpoints."""
+    task_metadata = task_metadata or {}
+    metadata_lines = []
+    for key in ("issue", "lane", "owner", "task_class", "last_completed_phase", "current_phase"):
+        if task_metadata.get(key):
+            metadata_lines.append(f"- {key.replace('_', ' ')}: {task_metadata[key]}")
+    metadata_block = "\n".join(metadata_lines) if metadata_lines else "- none supplied; infer only from accepted conversation evidence"
+    fields = "\n".join(f"- {field}" for field in _CONTINUATION_PACKET_FIELDS)
+    return (
+        "Budget checkpoint threshold reached before iteration exhaustion. "
+        "Do not call tools. Return a structured CONTINUATION PACKET only; "
+        "do not provide a generic summary.\n\n"
+        f"Budget state: {budget_state} ({api_call_count}/{max_iterations} API/tool iterations).\n"
+        "Known task metadata:\n"
+        f"{metadata_block}\n\n"
+        "The continuation packet must preserve these fields exactly where known, "
+        "using 'unknown' when evidence is missing:\n"
+        f"{fields}\n\n"
+        "The FGD-21 footer must include Worker used, Worker suitable, "
+        "Jimmy review result, and Next handover type."
+    )
+
+
+def _build_no_tools_finalizer_messages(agent, messages: list) -> list:
+    """Prepare sanitized messages for a no-tools finalizer request."""
+    _needs_sanitize = agent._should_sanitize_tool_calls()
+    api_messages = []
+    for msg in messages:
+        api_msg = msg.copy()
+        agent._copy_reasoning_content_for_api(msg, api_msg)
+        for internal_field in ("reasoning", "finish_reason", "_thinking_prefill"):
+            api_msg.pop(internal_field, None)
+        for schema_foreign in ("tool_name", "codex_reasoning_items", "codex_message_items"):
+            api_msg.pop(schema_foreign, None)
+        for internal_key in [k for k in api_msg if isinstance(k, str) and k.startswith("_")]:
+            api_msg.pop(internal_key, None)
+        if _needs_sanitize:
+            agent._sanitize_tool_calls_for_strict_api(api_msg, model=agent.model)
+        api_messages.append(api_msg)
+
+    effective_system = agent._cached_system_prompt or ""
+    if agent.ephemeral_system_prompt:
+        effective_system = (effective_system + "\n\n" + agent.ephemeral_system_prompt).strip()
+    if effective_system:
+        api_messages = [{"role": "system", "content": effective_system}] + api_messages
+    if agent.prefill_messages:
+        sys_offset = 1 if effective_system else 0
+        for idx, pfm in enumerate(agent.prefill_messages):
+            api_messages.insert(sys_offset + idx, pfm.copy())
+
+    api_messages = agent._sanitize_api_messages(api_messages)
+    api_messages = agent._drop_thinking_only_and_merge_users(api_messages)
+    return api_messages
+
+
+def handle_budget_checkpoint(
+    agent,
+    messages: list,
+    api_call_count: int,
+    *,
+    budget_state: str = "checkpoint",
+    task_metadata: Optional[Dict[str, Any]] = None,
+) -> str:
+    """Request a structured no-tools continuation packet before exhaustion.
+
+    Dormant helper only: no production call site is wired in this gate.
+    """
+    checkpoint_request = _build_budget_checkpoint_request(
+        api_call_count=api_call_count,
+        max_iterations=agent.max_iterations,
+        budget_state=budget_state,
+        task_metadata=task_metadata,
+    )
+    messages.append({"role": "user", "content": checkpoint_request})
+
+    try:
+        api_messages = _build_no_tools_finalizer_messages(agent, messages)
+
+        if agent.api_mode == "codex_responses":
+            codex_kwargs = agent._build_api_kwargs(api_messages)
+            codex_kwargs.pop("tools", None)
+            checkpoint_response = agent._run_codex_stream(codex_kwargs)
+            checkpoint_result = agent._get_transport().normalize_response(checkpoint_response)
+            final_response = (checkpoint_result.content or "").strip()
+        elif agent.api_mode == "anthropic_messages":
+            transport = agent._get_transport()
+            ant_kwargs = transport.build_kwargs(
+                model=agent.model,
+                messages=api_messages,
+                tools=None,
+                max_tokens=agent.max_tokens,
+                reasoning_config=agent.reasoning_config,
+                is_oauth=agent._is_anthropic_oauth,
+                preserve_dots=agent._anthropic_preserve_dots(),
+            )
+            checkpoint_response = agent._anthropic_messages_create(ant_kwargs)
+            checkpoint_result = transport.normalize_response(
+                checkpoint_response,
+                strip_tool_prefix=agent._is_anthropic_oauth,
+            )
+            final_response = (checkpoint_result.content or "").strip()
+        else:
+            checkpoint_kwargs = {
+                "model": agent.model,
+                "messages": api_messages,
+            }
+            if agent.max_tokens is not None:
+                checkpoint_kwargs.update(agent._max_tokens_param(agent.max_tokens))
+            checkpoint_response = agent._ensure_primary_openai_client(
+                reason="budget_checkpoint_continuation"
+            ).chat.completions.create(**checkpoint_kwargs)
+            checkpoint_result = agent._get_transport().normalize_response(checkpoint_response)
+            final_response = (checkpoint_result.content or "").strip()
+
+        if final_response:
+            if "<think>" in final_response:
+                final_response = re.sub(r'<think>.*?</think>\s*', '', final_response, flags=re.DOTALL).strip()
+            if final_response:
+                messages.append({"role": "assistant", "content": final_response})
+                return final_response
+
+        return "Budget checkpoint reached, but no continuation packet was generated."
+    except Exception as e:
+        logger.warning(f"Failed to get budget checkpoint continuation response: {e}")
+        return f"Budget checkpoint reached but continuation packet generation failed. Error: {str(e)}"
+
+
 def handle_max_iterations(agent, messages: list, api_call_count: int) -> str:
     """Request a summary when max iterations are reached. Returns the final response text."""
     print(f"⚠️  Reached maximum iterations ({agent.max_iterations}). Requesting summary...")

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -27,6 +27,7 @@ import time
 import uuid
 from typing import Any, Dict, List, Optional
 
+from agent.chat_completion_helpers import handle_budget_checkpoint
 from agent.codex_responses_adapter import _summarize_user_message_for_log
 from agent.display import KawaiiSpinner
 from agent.error_classifier import FailoverReason, classify_api_error
@@ -549,6 +550,38 @@ def run_conversation(
             if not agent.quiet_mode:
                 agent._safe_print(f"\n⚠️  Iteration budget exhausted ({agent.iteration_budget.used}/{agent.iteration_budget.max_total} iterations used)")
             break
+
+        if getattr(agent, "_budget_checkpointing_enabled", False):
+            try:
+                _budget_state = agent.iteration_budget.threshold_state(
+                    warning_ratio=getattr(agent, "_budget_checkpoint_warning_ratio", 0.75),
+                    checkpoint_ratio=getattr(agent, "_budget_checkpoint_checkpoint_ratio", 0.88),
+                )
+            except Exception as _budget_err:
+                logger.debug("budget checkpoint threshold check failed: %s", _budget_err)
+                _budget_state = "normal"
+
+            if _budget_state == "warning" and not getattr(agent, "_budget_checkpoint_warning_emitted", False):
+                agent._budget_checkpoint_warning_emitted = True
+                agent._emit_status(
+                    f"⚠️ Budget checkpoint warning ({agent.iteration_budget.used}/{agent.iteration_budget.max_total})"
+                )
+            elif (
+                _budget_state == "checkpoint"
+                and getattr(agent, "_budget_checkpoint_mode", "continuation_packet") == "continuation_packet"
+                and not getattr(agent, "_budget_checkpoint_emitted", False)
+            ):
+                agent._budget_checkpoint_emitted = True
+                _turn_exit_reason = "budget_checkpoint"
+                failed = True
+                final_response = handle_budget_checkpoint(
+                    agent,
+                    messages,
+                    api_call_count,
+                    budget_state=_budget_state,
+                    task_metadata={},
+                )
+                break
 
         # Fire step_callback for gateway hooks (agent:step event)
         if agent.step_callback is not None:

--- a/agent/iteration_budget.py
+++ b/agent/iteration_budget.py
@@ -58,5 +58,41 @@ class IterationBudget:
         with self._lock:
             return max(0, self.max_total - self._used)
 
+    @property
+    def ratio_used(self) -> float:
+        """Fraction of the total iteration budget already consumed."""
+        with self._lock:
+            if self.max_total <= 0:
+                return 1.0
+            return min(1.0, self._used / self.max_total)
+
+    def threshold_state(
+        self,
+        *,
+        warning_ratio: float = 0.75,
+        checkpoint_ratio: float = 0.88,
+    ) -> str:
+        """Classify current budget pressure without changing runtime behavior.
+
+        Returns one of: ``normal``, ``warning``, ``checkpoint``, or
+        ``exhausted``. This is scaffolding for callers that may later choose to
+        emit warnings or continuation checkpoints; the helper itself has no side
+        effects.
+        """
+        if not (0 <= warning_ratio < checkpoint_ratio <= 1):
+            raise ValueError(
+                "warning_ratio must be >= 0 and less than checkpoint_ratio, "
+                "and checkpoint_ratio must be <= 1"
+            )
+
+        ratio = self.ratio_used
+        if ratio >= 1.0:
+            return "exhausted"
+        if ratio >= checkpoint_ratio:
+            return "checkpoint"
+        if ratio >= warning_ratio:
+            return "warning"
+        return "normal"
+
 
 __all__ = ["IterationBudget"]

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -816,6 +816,15 @@ DEFAULT_CONFIG = {
     "max_concurrent_sessions": None,
     "agent": {
         "max_turns": 90,
+        # Budget checkpointing scaffolding is disabled by default. Future
+        # gates may use these thresholds to emit continuation packets before
+        # max-turn exhaustion; this gate only records non-active defaults.
+        "budget_checkpointing": {
+            "enabled": False,
+            "warning_ratio": 0.75,
+            "checkpoint_ratio": 0.88,
+            "mode": "continuation_packet",
+        },
         # Inactivity timeout for gateway agent execution (seconds).
         # The agent can run indefinitely as long as it's actively calling
         # tools or receiving API responses.  Only fires when the agent has

--- a/tests/agent/test_budget_checkpoint_finalizer.py
+++ b/tests/agent/test_budget_checkpoint_finalizer.py
@@ -1,0 +1,167 @@
+from types import SimpleNamespace
+
+
+def test_handle_budget_checkpoint_requests_structured_packet_without_tools():
+    from agent.chat_completion_helpers import handle_budget_checkpoint
+
+    captured_kwargs = {}
+
+    class FakeCompletions:
+        def create(self, **kwargs):
+            captured_kwargs.update(kwargs)
+            return SimpleNamespace(choices=[SimpleNamespace(message=SimpleNamespace(content="CONTINUATION PACKET"))])
+
+    class FakeClient:
+        chat = SimpleNamespace(completions=FakeCompletions())
+
+    class FakeTransport:
+        def normalize_response(self, response, **kwargs):
+            return SimpleNamespace(content=response.choices[0].message.content)
+
+    class FakeAgent:
+        model = "test-model"
+        max_iterations = 30
+        api_mode = "chat_completions"
+        _cached_system_prompt = "You are helpful."
+        ephemeral_system_prompt = ""
+        prefill_messages = []
+        provider = "openrouter"
+        base_url = "https://openrouter.ai/api/v1"
+        _base_url_lower = "https://openrouter.ai/api/v1"
+        max_tokens = None
+        reasoning_config = None
+        providers_allowed = None
+        providers_ignored = None
+        providers_order = None
+        provider_sort = None
+        openrouter_min_coding_score = None
+        _is_anthropic_oauth = False
+
+        def _should_sanitize_tool_calls(self):
+            return False
+
+        def _copy_reasoning_content_for_api(self, msg, api_msg):
+            return None
+
+        def _sanitize_api_messages(self, messages):
+            return messages
+
+        def _drop_thinking_only_and_merge_users(self, messages):
+            return messages
+
+        def _supports_reasoning_extra_body(self):
+            return False
+
+        def _is_openrouter_url(self):
+            return True
+
+        def _max_tokens_param(self, max_tokens):
+            return {"max_tokens": max_tokens}
+
+        def _ensure_primary_openai_client(self, reason):
+            return FakeClient()
+
+        def _get_transport(self):
+            return FakeTransport()
+
+    messages = [{"role": "user", "content": "ship the issue"}]
+
+    result = handle_budget_checkpoint(
+        FakeAgent(),
+        messages,
+        api_call_count=27,
+        budget_state="checkpoint 27/30",
+        task_metadata={
+            "issue": "Hermes: Budget-aware full-flow delivery",
+            "lane": "FGDGHO / Wiring / Hermes",
+            "owner": "Jimmy",
+            "task_class": "full delivery",
+            "current_phase": "validation",
+        },
+    )
+
+    assert result == "CONTINUATION PACKET"
+    assert "tools" not in captured_kwargs
+
+    api_messages = captured_kwargs["messages"]
+    checkpoint_prompt = api_messages[-1]["content"]
+    assert "CONTINUATION PACKET" in checkpoint_prompt
+    assert "Do not call tools" in checkpoint_prompt
+    assert "issue" in checkpoint_prompt
+    assert "lane" in checkpoint_prompt
+    assert "owner" in checkpoint_prompt
+    assert "task class" in checkpoint_prompt
+    assert "budget state" in checkpoint_prompt
+    assert "last completed phase" in checkpoint_prompt
+    assert "current phase" in checkpoint_prompt
+    assert "repo/worktree/branch" in checkpoint_prompt
+    assert "commit SHA" in checkpoint_prompt
+    assert "PR URL/state" in checkpoint_prompt
+    assert "merge state" in checkpoint_prompt
+    assert "package path" in checkpoint_prompt
+    assert "Drive target" in checkpoint_prompt
+    assert "Obsidian target" in checkpoint_prompt
+    assert "Linear state" in checkpoint_prompt
+    assert "validation" in checkpoint_prompt
+    assert "remaining actions" in checkpoint_prompt
+    assert "forbidden actions" in checkpoint_prompt
+    assert "do-not-repeat list" in checkpoint_prompt
+    assert "next safe resume packet" in checkpoint_prompt
+    assert "FGD-21 footer" in checkpoint_prompt
+    assert "summarizing what you've found" not in checkpoint_prompt
+
+
+def test_handle_budget_checkpoint_strips_tools_from_codex_kwargs():
+    from agent.chat_completion_helpers import handle_budget_checkpoint
+
+    captured_kwargs = {}
+
+    class FakeTransport:
+        def normalize_response(self, response, **kwargs):
+            return SimpleNamespace(content="CODEX CONTINUATION")
+
+    class FakeAgent:
+        model = "test-model"
+        max_iterations = 30
+        api_mode = "codex_responses"
+        _cached_system_prompt = ""
+        ephemeral_system_prompt = ""
+        prefill_messages = []
+        provider = "openai-codex"
+        base_url = ""
+        _base_url_lower = ""
+        max_tokens = None
+        reasoning_config = None
+        providers_allowed = None
+        providers_ignored = None
+        providers_order = None
+        provider_sort = None
+        openrouter_min_coding_score = None
+        _is_anthropic_oauth = False
+
+        def _should_sanitize_tool_calls(self):
+            return False
+
+        def _copy_reasoning_content_for_api(self, msg, api_msg):
+            return None
+
+        def _sanitize_api_messages(self, messages):
+            return messages
+
+        def _drop_thinking_only_and_merge_users(self, messages):
+            return messages
+
+        def _build_api_kwargs(self, messages):
+            return {"input": messages, "tools": [{"name": "should_not_survive"}]}
+
+        def _run_codex_stream(self, kwargs):
+            captured_kwargs.update(kwargs)
+            return SimpleNamespace()
+
+        def _get_transport(self):
+            return FakeTransport()
+
+    result = handle_budget_checkpoint(FakeAgent(), [{"role": "user", "content": "work"}], 27)
+
+    assert result == "CODEX CONTINUATION"
+    assert "tools" not in captured_kwargs

--- a/tests/agent/test_budget_checkpoint_runtime.py
+++ b/tests/agent/test_budget_checkpoint_runtime.py
@@ -1,0 +1,133 @@
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from run_agent import AIAgent
+
+
+def _make_tool_defs(*names: str) -> list:
+    return [
+        {
+            "type": "function",
+            "function": {
+                "name": name,
+                "description": f"{name} tool",
+                "parameters": {"type": "object", "properties": {}},
+            },
+        }
+        for name in names
+    ]
+
+
+@pytest.fixture()
+def agent():
+    with (
+        patch("run_agent.get_tool_definitions", return_value=_make_tool_defs("web_search")),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI"),
+    ):
+        a = AIAgent(
+            api_key="test-key-1234567890",
+            base_url="https://openrouter.ai/api/v1",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+            max_iterations=4,
+        )
+        a.client = MagicMock()
+        a._cached_system_prompt = "You are helpful."
+        a._use_prompt_caching = False
+        a.tool_delay = 0
+        a.compression_enabled = False
+        a.save_trajectories = False
+        return a
+
+
+def _mock_response(*, content="", finish_reason="stop", tool_calls=None):
+    message = SimpleNamespace(content=content, tool_calls=tool_calls)
+    choice = SimpleNamespace(message=message, finish_reason=finish_reason)
+    return SimpleNamespace(choices=[choice], usage=None)
+
+
+def _mock_tool_call(call_id="call_1"):
+    return SimpleNamespace(
+        id=call_id,
+        type="function",
+        function=SimpleNamespace(name="web_search", arguments="{}"),
+    )
+
+
+def _run_without_persistence(agent, prompt="work"):
+    with (
+        patch.object(agent, "_persist_session"),
+        patch.object(agent, "_save_trajectory"),
+        patch.object(agent, "_cleanup_task_resources"),
+    ):
+        return agent.run_conversation(prompt)
+
+
+def test_budget_checkpoint_disabled_does_not_call_checkpoint_helper(agent, monkeypatch):
+    agent._budget_checkpointing_enabled = False
+    agent.client.chat.completions.create.side_effect = [
+        _mock_response(finish_reason="tool_calls", tool_calls=[_mock_tool_call("c1")]),
+        _mock_response(finish_reason="tool_calls", tool_calls=[_mock_tool_call("c2")]),
+        _mock_response(content="Done", finish_reason="stop"),
+    ]
+    checkpoint_calls = []
+
+    def fake_checkpoint(*args, **kwargs):
+        checkpoint_calls.append((args, kwargs))
+        return "SHOULD NOT RUN"
+
+    monkeypatch.setattr("agent.conversation_loop.handle_budget_checkpoint", fake_checkpoint)
+
+    with patch("run_agent.handle_function_call", return_value="search result"):
+        result = _run_without_persistence(agent)
+
+    assert result["final_response"] == "Done"
+    assert checkpoint_calls == []
+
+
+def test_budget_checkpoint_enabled_calls_helper_before_exhaustion(agent, monkeypatch):
+    agent._budget_checkpointing_enabled = True
+    agent._budget_checkpoint_warning_ratio = 0.25
+    agent._budget_checkpoint_checkpoint_ratio = 0.50
+    agent._budget_checkpoint_mode = "continuation_packet"
+    agent.client.chat.completions.create.side_effect = [
+        _mock_response(finish_reason="tool_calls", tool_calls=[_mock_tool_call("c1")]),
+        _mock_response(content="SHOULD NOT REACH SECOND API CALL", finish_reason="stop"),
+    ]
+    checkpoint_calls = []
+
+    def fake_checkpoint(agent_arg, messages, api_call_count, **kwargs):
+        checkpoint_calls.append((api_call_count, kwargs))
+        return "CONTINUATION PACKET"
+
+    monkeypatch.setattr("agent.conversation_loop.handle_budget_checkpoint", fake_checkpoint)
+
+    with patch("run_agent.handle_function_call", return_value="search result"):
+        result = _run_without_persistence(agent)
+
+    assert result["final_response"] == "CONTINUATION PACKET"
+    assert result["completed"] is False
+    assert result["turn_exit_reason"] == "budget_checkpoint"
+    assert checkpoint_calls == [(2, {"budget_state": "checkpoint", "task_metadata": {}})]
+    assert agent.client.chat.completions.create.call_count == 1
+
+
+def test_budget_checkpoint_disabled_preserves_max_iteration_summary(agent):
+    agent.max_iterations = 1
+    agent.iteration_budget.max_total = 1
+    agent._budget_checkpointing_enabled = False
+    agent.client.chat.completions.create.side_effect = [
+        _mock_response(finish_reason="tool_calls", tool_calls=[_mock_tool_call("c1")]),
+        _mock_response(content="Could not finish — budget exhausted.", finish_reason="stop"),
+    ]
+
+    with patch("run_agent.handle_function_call", return_value="search result"):
+        result = _run_without_persistence(agent)
+
+    assert result["completed"] is False
+    assert result["turn_exit_reason"].startswith("max_iterations_reached")
+    assert result["final_response"] == "Could not finish — budget exhausted."

--- a/tests/hermes_cli/test_config.py
+++ b/tests/hermes_cli/test_config.py
@@ -73,6 +73,19 @@ class TestLoadConfigDefaults:
             assert config["terminal"]["backend"] == "local"
             assert config["display"]["interim_assistant_messages"] is True
 
+    def test_budget_checkpointing_defaults_are_disabled(self, tmp_path):
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
+            config = load_config()
+            budget_cfg = config["agent"]["budget_checkpointing"]
+
+            assert budget_cfg == {
+                "enabled": False,
+                "warning_ratio": 0.75,
+                "checkpoint_ratio": 0.88,
+                "mode": "continuation_packet",
+            }
+            assert DEFAULT_CONFIG["agent"]["budget_checkpointing"] == budget_cfg
+
     def test_legacy_root_level_max_turns_migrates_to_agent_config(self, tmp_path):
         with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
             config_path = tmp_path / "config.yaml"

--- a/tests/run_agent/test_iteration_budget_race.py
+++ b/tests/run_agent/test_iteration_budget_race.py
@@ -104,3 +104,50 @@ def test_iteration_budget_remaining():
     assert budget.remaining == 2
     budget.refund()
     assert budget.remaining == 3
+
+
+def test_iteration_budget_ratio_used_tracks_consumed_fraction():
+    """ratio_used must report used/max_total without mutating budget state."""
+    from run_agent import IterationBudget
+
+    budget = IterationBudget(max_total=4)
+
+    assert budget.ratio_used == 0.0
+    budget.consume()
+    assert budget.ratio_used == 0.25
+    budget.consume()
+    budget.consume()
+    assert budget.ratio_used == 0.75
+    assert budget.used == 3
+
+
+def test_iteration_budget_threshold_state_reports_lifecycle_states():
+    """threshold_state must classify normal/warning/checkpoint/exhausted bands."""
+    from run_agent import IterationBudget
+
+    budget = IterationBudget(max_total=10)
+    assert budget.threshold_state(warning_ratio=0.75, checkpoint_ratio=0.9) == "normal"
+
+    for _ in range(7):
+        budget.consume()
+    assert budget.threshold_state(warning_ratio=0.75, checkpoint_ratio=0.9) == "normal"
+
+    budget.consume()
+    assert budget.threshold_state(warning_ratio=0.75, checkpoint_ratio=0.9) == "warning"
+
+    budget.consume()
+    assert budget.threshold_state(warning_ratio=0.75, checkpoint_ratio=0.9) == "checkpoint"
+
+    budget.consume()
+    assert budget.threshold_state(warning_ratio=0.75, checkpoint_ratio=0.9) == "exhausted"
+
+
+def test_iteration_budget_threshold_state_validates_ratios():
+    """threshold_state must reject invalid threshold ordering."""
+    from run_agent import IterationBudget
+
+    budget = IterationBudget(max_total=10)
+
+    import pytest
+    with pytest.raises(ValueError, match="warning_ratio"):
+        budget.threshold_state(warning_ratio=0.95, checkpoint_ratio=0.9)


### PR DESCRIPTION
Issue: Hermes budget-aware full-flow delivery and closeout-resume handling

Clean branch commit SHA: cd82e36abf4cce23371395b74925af23f8716454

Summary:
- IterationBudget threshold helpers
- disabled-by-default budget_checkpointing config
- dormant no-tools continuation packet finalizer
- runtime trigger wired only behind disabled feature flag

Validation results:
- python -m pytest tests/agent/test_budget_checkpoint_runtime.py tests/agent/test_budget_checkpoint_finalizer.py tests/run_agent/test_iteration_budget_race.py tests/hermes_cli/test_config.py::TestLoadConfigDefaults::test_budget_checkpointing_defaults_are_disabled -q — 14 passed, 1 warning
- python -m pytest tests/run_agent/test_run_agent.py::TestRunConversation tests/run_agent/test_run_agent.py::TestHandleMaxIterations -q — 48 passed, 1 warning
- python -m py_compile agent/conversation_loop.py agent/agent_init.py agent/chat_completion_helpers.py agent/iteration_budget.py hermes_cli/config.py tests/agent/test_budget_checkpoint_runtime.py tests/agent/test_budget_checkpoint_finalizer.py tests/run_agent/test_iteration_budget_race.py tests/hermes_cli/test_config.py — passed
- git diff --check origin/main...HEAD -- approved budget-checkpoint files — passed

Notes:
- checkpointing remains disabled by default
- no live/profile config mutation
- no gateway restart/smoke/deploy/merge
- no unrelated dirty worktree files included