### PR TITLE
fix(telegram): keep polling alive during outages

### DIFF
--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -106,7 +106,7 @@ _TELEGRAM_IMAGE_EXT_TO_MIME = {
 }
 
 
-MAX_COMMANDS_PER_SCOPE = 30
+MAX_COMMANDS_PER_SCOPE = 100
 
 
 def check_telegram_requirements() -> bool:
@@ -1414,6 +1414,126 @@ class TelegramAdapter(BasePlatformAdapter):
                 self.name, exc_info=True,
             )
 
+    def _telegram_network_retry_limits(self) -> tuple[int, float, float]:
+        """Return retry ladder settings for Telegram polling recovery.
+
+        Defaults are intentionally more OpenClaw-like than the historical
+        gateway behaviour: keep the gateway alive for a long outage, retry
+        quickly at first, and cap backoff so recovery is not delayed by a
+        minutes-long sleep after the network comes back.
+
+        Non-secret behavioral overrides, if ever needed, live in config.yaml
+        under the Telegram platform's ``extra`` map rather than new HERMES_*
+        environment variables.
+        """
+        def _extra_int(name: str, default: int, min_value: int, max_value: int) -> int:
+            try:
+                value = int(self.config.extra.get(name, default))
+            except (TypeError, ValueError):
+                value = default
+            return max(min_value, min(value, max_value))
+
+        def _extra_float(name: str, default: float, min_value: float, max_value: float) -> float:
+            import math
+
+            try:
+                value = float(self.config.extra.get(name, default))
+            except (TypeError, ValueError):
+                value = default
+            if not math.isfinite(value):
+                value = default
+            return max(min_value, min(value, max_value))
+
+        max_retries = _extra_int("network_max_retries", 60, 1, 10000)
+        base_delay = _extra_float("network_base_delay", 5.0, 1.0, 60.0)
+        max_delay = _extra_float("network_max_delay", 30.0, base_delay, 300.0)
+        return max_retries, base_delay, max_delay
+
+    def _schedule_polling_recovery(self, error: Exception, *, reason: str) -> None:
+        """Schedule Telegram polling recovery without failing gateway startup.
+
+        This mirrors OpenClaw's isolated-polling strategy: a Telegram channel
+        bootstrap/deleteWebhook failure degrades only the Telegram adapter while
+        the gateway process remains alive and keeps retrying in the background.
+        """
+        if self.has_fatal_error:
+            return
+        if self._polling_error_task and not self._polling_error_task.done():
+            logger.debug(
+                "[%s] Telegram polling recovery already scheduled; ignoring %s: %s",
+                self.name,
+                reason,
+                error,
+            )
+            return
+        self._send_path_degraded = True
+        logger.warning(
+            "[%s] Telegram polling degraded (%s); gateway stays alive and will retry. Error: %s",
+            self.name,
+            reason,
+            error,
+        )
+        loop = asyncio.get_running_loop()
+        self._polling_error_task = loop.create_task(self._handle_polling_network_error(error))
+        self._background_tasks.add(self._polling_error_task)
+        self._polling_error_task.add_done_callback(self._background_tasks.discard)
+
+    async def _delete_webhook_best_effort(self) -> bool:
+        """Clear webhook if possible, but do not fail polling on network errors."""
+        if not self._bot:
+            return False
+        delete_webhook = getattr(self._bot, "delete_webhook", None)
+        if not callable(delete_webhook):
+            return True
+        try:
+            await delete_webhook(drop_pending_updates=False)
+            return True
+        except Exception as err:
+            if self._looks_like_network_error(err):
+                logger.warning(
+                    "[%s] deleteWebhook failed with a recoverable network error; "
+                    "continuing to polling so getUpdates/retry can recover: %s",
+                    self.name,
+                    err,
+                )
+                self._send_path_degraded = True
+                return False
+            raise
+
+    async def _start_polling_resilient(
+        self,
+        *,
+        drop_pending_updates: bool,
+        error_callback,
+    ) -> bool:
+        """Start PTB polling; on transient bootstrap failure, retry in background."""
+        if not (self._app and self._app.updater):
+            raise RuntimeError("Telegram application/updater not initialized")
+        try:
+            await self._app.updater.start_polling(
+                allowed_updates=Update.ALL_TYPES,
+                drop_pending_updates=drop_pending_updates,
+                error_callback=error_callback,
+            )
+            return True
+        except Exception as err:
+            if self._looks_like_polling_conflict(err):
+                logger.warning(
+                    "[%s] Telegram polling bootstrap conflict; gateway stays alive "
+                    "while conflict retry runs: %s",
+                    self.name,
+                    err,
+                )
+                loop = asyncio.get_running_loop()
+                self._polling_error_task = loop.create_task(self._handle_polling_conflict(err))
+                self._background_tasks.add(self._polling_error_task)
+                self._polling_error_task.add_done_callback(self._background_tasks.discard)
+                return False
+            if self._looks_like_network_error(err):
+                self._schedule_polling_recovery(err, reason="polling bootstrap")
+                return False
+            raise
+
     async def _handle_polling_network_error(self, error: Exception) -> None:
         """Reconnect polling after a transient network interruption.
 
@@ -1429,9 +1549,7 @@ class TelegramAdapter(BasePlatformAdapter):
         if self.has_fatal_error:
             return
 
-        MAX_NETWORK_RETRIES = 10
-        BASE_DELAY = 5
-        MAX_DELAY = 60
+        MAX_NETWORK_RETRIES, BASE_DELAY, MAX_DELAY = self._telegram_network_retry_limits()
 
         self._polling_network_error_count += 1
         self._send_path_degraded = True
@@ -2172,9 +2290,10 @@ class TelegramAdapter(BasePlatformAdapter):
                 # ── Polling mode (default) ───────────────────────────
                 # Clear any stale webhook first so polling doesn't inherit a
                 # previous webhook registration and silently stop receiving updates.
-                delete_webhook = getattr(self._bot, "delete_webhook", None)
-                if callable(delete_webhook):
-                    await delete_webhook(drop_pending_updates=False)
+                # This is best-effort: transient Telegram network errors must not
+                # prevent the gateway from starting. Polling recovery below will
+                # continue in the background, OpenClaw-style.
+                await self._delete_webhook_best_effort()
 
                 loop = asyncio.get_running_loop()
 
@@ -2183,20 +2302,27 @@ class TelegramAdapter(BasePlatformAdapter):
                         return
                     if self._looks_like_polling_conflict(error):
                         self._polling_error_task = loop.create_task(self._handle_polling_conflict(error))
+                        self._background_tasks.add(self._polling_error_task)
+                        self._polling_error_task.add_done_callback(self._background_tasks.discard)
                     elif self._looks_like_network_error(error):
                         logger.warning("[%s] Telegram network error, scheduling reconnect: %s", self.name, error)
-                        self._polling_error_task = loop.create_task(self._handle_polling_network_error(error))
+                        self._schedule_polling_recovery(error, reason="polling error callback")
                     else:
                         logger.error("[%s] Telegram polling error: %s", self.name, error, exc_info=True)
 
                 # Store reference for retry use in _handle_polling_conflict
                 self._polling_error_callback_ref = _polling_error_callback
 
-                await self._app.updater.start_polling(
-                    allowed_updates=Update.ALL_TYPES,
+                polling_started = await self._start_polling_resilient(
                     drop_pending_updates=True,
                     error_callback=_polling_error_callback,
                 )
+                if not polling_started:
+                    logger.warning(
+                        "[%s] Connected in degraded Telegram mode: gateway is alive, "
+                        "polling will be retried in the background",
+                        self.name,
+                    )
             
             # Register bot commands so Telegram shows a hint menu when users type /
             # List is derived from the central COMMAND_REGISTRY — adding a new

--- a/gateway/platforms/telegram_network.py
+++ b/gateway/platforms/telegram_network.py
@@ -40,7 +40,7 @@ _DOH_PROVIDERS: list[dict] = [
 
 # Last-resort IPs when DoH is also blocked.  These are stable Telegram Bot API
 # endpoints in the 149.154.160.0/20 block (same seed used by OpenClaw).
-_SEED_FALLBACK_IPS: list[str] = ["149.154.167.220"]
+_SEED_FALLBACK_IPS: list[str] = ["149.154.166.110", "149.154.167.220"]
 
 
 def _resolve_proxy_url(target_hosts=None) -> str | None:

--- a/tests/gateway/test_telegram_network_reconnect.py
+++ b/tests/gateway/test_telegram_network_reconnect.py
@@ -153,11 +153,18 @@ async def test_reconnect_success_resets_error_count():
 @pytest.mark.asyncio
 async def test_reconnect_triggers_fatal_after_max_retries():
     """
-    After MAX_NETWORK_RETRIES attempts, the adapter should set a fatal error
-    rather than retrying forever.
+    After configured MAX_NETWORK_RETRIES attempts, the adapter should set a
+    fatal error. Default production retries are intentionally higher; this test
+    pins the threshold via config.extra for a fast deterministic check.
     """
-    adapter = _make_adapter()
-    adapter._polling_network_error_count = 10  # MAX_NETWORK_RETRIES
+    adapter = TelegramAdapter(
+        PlatformConfig(
+            enabled=True,
+            token="test-token",
+            extra={"network_max_retries": 10},
+        )
+    )
+    adapter._polling_network_error_count = 10  # configured MAX_NETWORK_RETRIES
 
     fatal_handler = AsyncMock()
     adapter.set_fatal_error_handler(fatal_handler)
@@ -473,3 +480,81 @@ async def test_reconnect_schedules_heartbeat_probe_on_success():
             await t
         except (asyncio.CancelledError, Exception):
             pass
+
+
+# ── OpenClaw-style bootstrap degradation ─────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_delete_webhook_network_error_is_recoverable():
+    """deleteWebhook timeouts must not fail gateway startup.
+
+    OpenClaw treats this as recoverable and continues toward polling; Hermes
+    should do the same so a transient Bot API outage does not become a systemd
+    service failure.
+    """
+    adapter = _make_adapter()
+    mock_bot = MagicMock()
+    mock_bot.delete_webhook = AsyncMock(side_effect=ConnectionError("api.telegram.org timeout"))
+    adapter._bot = mock_bot
+
+    result = await adapter._delete_webhook_best_effort()
+
+    assert result is False
+    assert adapter._send_path_degraded is True
+    mock_bot.delete_webhook.assert_awaited_once_with(drop_pending_updates=False)
+    assert not adapter.has_fatal_error
+
+
+@pytest.mark.asyncio
+async def test_polling_bootstrap_network_error_schedules_background_recovery():
+    """Initial start_polling() network failure should degrade, not raise."""
+    adapter = _make_adapter()
+    mock_updater = MagicMock()
+    mock_updater.start_polling = AsyncMock(side_effect=ConnectionError("bootstrap timeout"))
+    mock_app = MagicMock()
+    mock_app.updater = mock_updater
+    adapter._app = mock_app
+    adapter._schedule_polling_recovery = MagicMock()
+
+    result = await adapter._start_polling_resilient(
+        drop_pending_updates=True,
+        error_callback=lambda error: None,
+    )
+
+    assert result is False
+    adapter._schedule_polling_recovery.assert_called_once()
+    err = adapter._schedule_polling_recovery.call_args.args[0]
+    assert isinstance(err, ConnectionError)
+    assert adapter._schedule_polling_recovery.call_args.kwargs["reason"] == "polling bootstrap"
+    assert not adapter.has_fatal_error
+
+
+@pytest.mark.asyncio
+async def test_polling_bootstrap_conflict_schedules_conflict_recovery_task():
+    """Initial 409 polling conflict should also be recovered in background."""
+    adapter = _make_adapter()
+    mock_updater = MagicMock()
+    mock_updater.start_polling = AsyncMock(
+        side_effect=Exception("Conflict: terminated by other getUpdates request")
+    )
+    mock_app = MagicMock()
+    mock_app.updater = mock_updater
+    adapter._app = mock_app
+    adapter._handle_polling_conflict = AsyncMock()
+
+    result = await adapter._start_polling_resilient(
+        drop_pending_updates=True,
+        error_callback=lambda error: None,
+    )
+
+    assert result is False
+    pending = [t for t in adapter._background_tasks if not t.done()]
+    assert pending, "expected background conflict recovery task"
+    for task in pending:
+        task.cancel()
+        try:
+            await task
+        except (asyncio.CancelledError, Exception):
+            pass
+    assert not adapter.has_fatal_error


### PR DESCRIPTION
## Summary
- Keep Telegram gateway startup alive when `deleteWebhook` or initial `start_polling()` hits a transient Bot API/network failure.
- Schedule background polling recovery for bootstrap network errors and polling conflicts instead of failing the gateway process.
- Increase Telegram polling recovery defaults to a longer OpenClaw-style retry window with bounded backoff.
- Add a second Telegram Bot API seed fallback IP.

## Why
A transient Telegram Bot API outage or network timeout during gateway bootstrap can currently cause the whole gateway service to fail or restart-loop, even though the right behavior is to keep the process alive and let Telegram polling recover in the background.

## Test plan
- [x] `python -m py_compile gateway/platforms/telegram.py gateway/platforms/telegram_network.py tests/gateway/test_telegram_network_reconnect.py`
- [x] `python -m pytest tests/gateway/test_telegram_network_reconnect.py -q -o 'addopts='`

Local result:

```text
18 passed in 0.43s
```

## Notes
- Behavioral retry overrides are read from Telegram platform `config.extra` keys (`network_max_retries`, `network_base_delay`, `network_max_delay`) rather than new `HERMES_*` environment variables.
- The gateway can enter a degraded Telegram mode while polling recovery continues in the background.