### PR TITLE
fix(tools): use errors=replace for browser subprocess output reads (#47456)

### DIFF
--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -924,7 +924,7 @@ def _run_chrome_fallback_command(
             proc.wait()
             return {"success": False, "error": f"Chrome fallback '{cmd}' timed out"}
         try:
-            with open(stdout_path, "r", encoding="utf-8") as f:
+            with open(stdout_path, "r", encoding="utf-8", errors="replace") as f:
                 stdout = f.read().strip()
             if stdout:
                 return json.loads(stdout.split("\n")[-1])
@@ -2110,9 +2110,9 @@ def _run_browser_command(
             result = {"success": False, "error": f"Command timed out after {timeout} seconds"}
             # Fall through to fallback check below
         else:
-            with open(stdout_path, "r", encoding="utf-8") as f:
+            with open(stdout_path, "r", encoding="utf-8", errors="replace") as f:
                 stdout = f.read()
-            with open(stderr_path, "r", encoding="utf-8") as f:
+            with open(stderr_path, "r", encoding="utf-8", errors="replace") as f:
                 stderr = f.read()
             returncode = proc.returncode
 


### PR DESCRIPTION
Fixes #47456. On Windows systems with non-UTF-8 locale (e.g. GBK/CJK), browser subprocess output containing system-encoded characters caused UnicodeDecodeError when reading temp files with hardcoded encoding=utf-8. Added errors=replace to gracefully handle encoding mismatches instead of crashing.