### PR TITLE
fix(desktop): structured Fallback Models editor + out-of-catalog model visibility

### DIFF
--- a/apps/desktop/src/app/settings/config-settings.tsx
+++ b/apps/desktop/src/app/settings/config-settings.tsx
@@ -19,6 +19,7 @@ import { notify, notifyError } from '@/store/notifications'
 import type { ConfigFieldSchema, HermesConfigRecord } from '@/types/hermes'
 
 import { CONTROL_TEXT, EMPTY_SELECT_VALUE, FIELD_DESCRIPTIONS, FIELD_LABELS, SECTIONS } from './constants'
+import { FallbackModelsField } from './fallback-models-field'
 import { fieldCopyForSchemaKey } from './field-copy'
 import { enumOptionsFor, getNested, prettyName, setNested } from './helpers'
 import { ModelSettings } from './model-settings'
@@ -66,6 +67,13 @@ function ConfigField({
   const row = (action: ReactNode, wide = false) => (
     <ListRow action={action} description={description} title={label} wide={wide} />
   )
+
+  // `fallback_providers` is a list of {provider, model} objects; the generic
+  // `list` branch below would stringify them to "[object Object]". Render the
+  // dedicated structured editor instead.
+  if (schemaKey === 'fallback_providers') {
+    return row(<FallbackModelsField onChange={onChange} value={value} />, true)
+  }
 
   if (schema.type === 'boolean') {
     return row(

--- a/apps/desktop/src/app/settings/fallback-models-field.test.tsx
+++ b/apps/desktop/src/app/settings/fallback-models-field.test.tsx
@@ -1,0 +1,87 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
+
+// Radix Select calls scrollIntoView / pointer-capture APIs jsdom lacks.
+beforeAll(() => {
+  Element.prototype.scrollIntoView = vi.fn()
+  Element.prototype.hasPointerCapture = vi.fn(() => false)
+  Element.prototype.releasePointerCapture = vi.fn()
+})
+
+const getGlobalModelOptions = vi.fn()
+
+vi.mock('@/hermes', () => ({
+  getGlobalModelOptions: () => getGlobalModelOptions()
+}))
+
+beforeEach(() => {
+  getGlobalModelOptions.mockResolvedValue({
+    providers: [
+      { name: 'GitHub Copilot', slug: 'copilot', models: ['gpt-5-mini', 'gpt-5.4-mini'] },
+      { name: 'OpenAI Codex', slug: 'openai-codex', models: ['gpt-5.4-mini'] },
+      { name: 'Nous', slug: 'nous', models: ['hermes-4'] }
+    ]
+  })
+})
+
+afterEach(() => {
+  cleanup()
+  vi.clearAllMocks()
+})
+
+async function renderField(value: unknown, onChange = vi.fn()) {
+  const { FallbackModelsField } = await import('./fallback-models-field')
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+
+  render(
+    <QueryClientProvider client={client}>
+      <FallbackModelsField onChange={onChange} value={value} />
+    </QueryClientProvider>
+  )
+
+  return onChange
+}
+
+const CHAIN = [
+  { provider: 'copilot', model: 'gpt-5-mini' },
+  { provider: 'openai-codex', model: 'gpt-5.4-mini' }
+]
+
+describe('FallbackModelsField', () => {
+  it('renders each {provider, model} entry as its own row (never "[object Object]")', async () => {
+    await renderField(CHAIN)
+
+    // One Remove control per entry proves the object list became rows — the old
+    // generic `list` input stringified the array to "[object Object]".
+    expect(screen.getAllByLabelText('Remove')).toHaveLength(2)
+    expect(screen.getByText('Add fallback')).toBeTruthy()
+    expect(screen.queryByText(/\[object Object\]/)).toBeNull()
+    await waitFor(() => expect(getGlobalModelOptions).toHaveBeenCalled())
+  })
+
+  it('removing a row emits the remaining entries', async () => {
+    const onChange = await renderField(CHAIN)
+
+    fireEvent.click(screen.getAllByLabelText('Remove')[0])
+
+    expect(onChange.mock.calls.at(-1)?.[0]).toEqual([{ provider: 'openai-codex', model: 'gpt-5.4-mini' }])
+  })
+
+  it('adding a blank row does not persist a partial entry', async () => {
+    const onChange = await renderField(CHAIN)
+
+    fireEvent.click(screen.getByText('Add fallback'))
+
+    // The new empty row stays in the UI but only complete pairs are emitted.
+    expect(onChange.mock.calls.at(-1)?.[0]).toEqual(CHAIN)
+    expect(screen.getAllByLabelText('Remove')).toHaveLength(3)
+  })
+
+  it('shows an empty-state hint when there are no fallbacks', async () => {
+    await renderField([])
+
+    expect(screen.getByText(/No fallback models/)).toBeTruthy()
+    expect(screen.queryAllByLabelText('Remove')).toHaveLength(0)
+  })
+})

--- a/apps/desktop/src/app/settings/fallback-models-field.tsx
+++ b/apps/desktop/src/app/settings/fallback-models-field.tsx
@@ -1,0 +1,137 @@
+import { useQuery } from '@tanstack/react-query'
+import { useState } from 'react'
+
+import { Button } from '@/components/ui/button'
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
+import { getGlobalModelOptions } from '@/hermes'
+import { useI18n } from '@/i18n'
+import { Plus, X } from '@/lib/icons'
+import { cn } from '@/lib/utils'
+
+import { CONTROL_TEXT } from './constants'
+
+interface FallbackEntry {
+  provider: string
+  model: string
+}
+
+// Normalize the raw config value (`fallback_providers`: a list of
+// `{provider, model}` dicts) into editor rows. Defensive against legacy string
+// entries ("provider/model") so the editor never crashes on odd data.
+function normalizeEntries(value: unknown): FallbackEntry[] {
+  if (!Array.isArray(value)) {
+    return []
+  }
+
+  return value.map(item => {
+    if (item && typeof item === 'object') {
+      const record = item as Record<string, unknown>
+
+      return { provider: String(record.provider ?? ''), model: String(record.model ?? '') }
+    }
+
+    if (typeof item === 'string') {
+      const slash = item.indexOf('/')
+
+      return slash > 0 ? { provider: item.slice(0, slash), model: item.slice(slash + 1) } : { provider: '', model: item }
+    }
+
+    return { provider: '', model: '' }
+  })
+}
+
+/**
+ * Structured editor for the top-level `fallback_providers` config list — a
+ * chain of `{provider, model}` pairs tried in order when the default model
+ * fails. Replaces the generic comma-string `list` input, which stringified the
+ * objects to "[object Object], [object Object]".
+ *
+ * Mirrors the Auxiliary Models picker in `model-settings.tsx`: provider + model
+ * selects sourced from `getGlobalModelOptions()`. Half-filled rows are kept in
+ * local state and only complete pairs are emitted upward, so the config
+ * autosave never persists a partial `{provider, model: ''}`.
+ */
+export function FallbackModelsField({
+  value,
+  onChange
+}: {
+  value: unknown
+  onChange: (next: FallbackEntry[]) => void
+}) {
+  const { t } = useI18n()
+  const m = t.settings.model
+
+  const modelOptions = useQuery({
+    queryKey: ['model-options', 'global'],
+    queryFn: () => getGlobalModelOptions()
+  })
+
+  const providers = (modelOptions.data?.providers ?? []).filter(provider => provider.slug)
+
+  const [rows, setRows] = useState<FallbackEntry[]>(() => normalizeEntries(value))
+
+  const commit = (next: FallbackEntry[]) => {
+    setRows(next)
+    onChange(next.filter(entry => entry.provider && entry.model))
+  }
+
+  const updateRow = (index: number, patch: Partial<FallbackEntry>) =>
+    commit(rows.map((entry, i) => (i === index ? { ...entry, ...patch } : entry)))
+
+  return (
+    <div className="grid w-full gap-1.5">
+      {rows.length === 0 && <p className="text-xs text-muted-foreground">{m.fallbackEmpty}</p>}
+      {rows.map((entry, index) => {
+        const providerRow = providers.find(provider => provider.slug === entry.provider)
+        const catalog = providerRow?.models ?? []
+        // Keep an out-of-catalog model selectable so an existing custom
+        // provider/model renders instead of showing a blank box.
+        const modelItems = entry.model && !catalog.includes(entry.model) ? [entry.model, ...catalog] : catalog
+
+        return (
+          <div className="flex flex-wrap items-center gap-2" key={index}>
+            <span className="w-4 shrink-0 text-center font-mono text-[0.7rem] text-muted-foreground">{index + 1}</span>
+            <Select onValueChange={provider => updateRow(index, { provider, model: '' })} value={entry.provider}>
+              <SelectTrigger className={cn('min-w-36', CONTROL_TEXT)}>
+                <SelectValue placeholder={m.provider} />
+              </SelectTrigger>
+              <SelectContent>
+                {providers.map(provider => (
+                  <SelectItem key={provider.slug} value={provider.slug}>
+                    {provider.name}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+            <Select onValueChange={model => updateRow(index, { model })} value={entry.model}>
+              <SelectTrigger className={cn('min-w-52 flex-1', CONTROL_TEXT)}>
+                <SelectValue placeholder={m.model} />
+              </SelectTrigger>
+              <SelectContent>
+                {modelItems.map(model => (
+                  <SelectItem key={model} value={model}>
+                    {model}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+            <Button
+              aria-label={t.common.remove}
+              onClick={() => commit(rows.filter((_, i) => i !== index))}
+              size="icon-xs"
+              variant="ghost"
+            >
+              <X className="size-3.5" />
+            </Button>
+          </div>
+        )
+      })}
+      <div>
+        <Button onClick={() => commit([...rows, { provider: '', model: '' }])} size="sm" variant="textStrong">
+          <Plus className="size-3.5" />
+          {m.fallbackAdd}
+        </Button>
+      </div>
+    </div>
+  )
+}

--- a/apps/desktop/src/app/settings/model-settings.tsx
+++ b/apps/desktop/src/app/settings/model-settings.tsx
@@ -167,6 +167,18 @@ export function ModelSettings({ onMainModelChanged }: ModelSettingsProps) {
 
   const selectedProviderModels = selectedProviderRow?.models ?? []
 
+  // Show the current model even when it isn't in the provider's advertised
+  // catalog (e.g. a custom/overridden id like a Nous-proxied OpenAI model) —
+  // otherwise Radix Select renders a blank box for a value with no matching
+  // item, hiding what's actually configured.
+  const modelSelectItems =
+    selectedModel && !selectedProviderModels.includes(selectedModel)
+      ? [selectedModel, ...selectedProviderModels]
+      : selectedProviderModels
+
+  const currentModelMissing =
+    !!selectedModel && selectedProviderModels.length > 0 && !selectedProviderModels.includes(selectedModel)
+
   // An unconfigured provider was picked: no credentials yet, so there are no
   // models to choose. `api_key` providers can be activated inline (paste key);
   // OAuth / external flows hand off to the onboarding sign-in.
@@ -181,6 +193,15 @@ export function ModelSettings({ onMainModelChanged }: ModelSettingsProps) {
   const auxDraftProviderModels = useMemo(
     () => providers.find(provider => provider.slug === auxDraft.provider)?.models ?? [],
     [auxDraft.provider, providers]
+  )
+
+  // Same out-of-catalog guard as the main model select (see modelSelectItems).
+  const auxDraftModelItems = useMemo(
+    () =>
+      auxDraft.model && !auxDraftProviderModels.includes(auxDraft.model)
+        ? [auxDraft.model, ...auxDraftProviderModels]
+        : auxDraftProviderModels,
+    [auxDraft.model, auxDraftProviderModels]
   )
 
   const auxiliaryTaskLabel = useCallback((key: string) => m.tasks[key]?.label ?? key, [m.tasks])
@@ -467,7 +488,7 @@ export function ModelSettings({ onMainModelChanged }: ModelSettingsProps) {
                   <SelectValue placeholder={m.model} />
                 </SelectTrigger>
                 <SelectContent>
-                  {(selectedProviderModels.length ? selectedProviderModels : []).map(model => (
+                  {modelSelectItems.map(model => (
                     <SelectItem key={model} value={model}>
                       {model}
                     </SelectItem>
@@ -485,6 +506,14 @@ export function ModelSettings({ onMainModelChanged }: ModelSettingsProps) {
             </>
           )}
         </div>
+        {currentModelMissing && (
+          <p className="mt-2 flex items-center gap-1.5 text-xs text-amber-600 dark:text-amber-400">
+            <AlertTriangle className="size-3.5 shrink-0" />
+            <span>
+              <span className="font-mono">{selectedModel}</span> {m.notInCatalog}
+            </span>
+          </p>
+        )}
         {needsSetup && !setupIsApiKey && (
           <p className="mt-2 text-xs text-muted-foreground">
             {selectedProviderRow?.auth_type === 'api_key'
@@ -619,7 +648,7 @@ export function ModelSettings({ onMainModelChanged }: ModelSettingsProps) {
                           <SelectValue placeholder={m.model} />
                         </SelectTrigger>
                         <SelectContent>
-                          {(auxDraftProviderModels.length ? auxDraftProviderModels : []).map(model => (
+                          {auxDraftModelItems.map(model => (
                             <SelectItem key={model} value={model}>
                               {model}
                             </SelectItem>

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -549,6 +549,9 @@ export const en: Translations = {
       change: 'Change',
       autoUseMain: 'auto · use main model',
       providerDefault: '(provider default)',
+      fallbackAdd: 'Add fallback',
+      fallbackEmpty: 'No fallback models — the default model is used unless it fails.',
+      notInCatalog: "isn't in this provider's model list — calls may fall back to a backup.",
       tasks: {
         vision: { label: 'Vision', hint: 'Image analysis' },
         web_extract: { label: 'Web extract', hint: 'Page summarization' },

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -441,6 +441,9 @@ export interface Translations {
       change: string
       autoUseMain: string
       providerDefault: string
+      fallbackAdd: string
+      fallbackEmpty: string
+      notInCatalog: string
       tasks: Record<string, AuxTaskCopy>
     }
     providers: {

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -744,6 +744,9 @@ export const zh: Translations = {
       change: '更改',
       autoUseMain: '自动 · 使用主模型',
       providerDefault: '(提供方默认)',
+      fallbackAdd: '添加备用模型',
+      fallbackEmpty: '未配置备用模型 — 默认模型失败时才会使用备用模型。',
+      notInCatalog: '不在该提供方的模型列表中 — 调用可能回退到备用模型。',
       tasks: {
         vision: { label: '视觉', hint: '图片分析' },
         web_extract: { label: '网页提取', hint: '页面总结' },


### PR DESCRIPTION
## Problem

In **Settings → Model**, two things were confusing or broken:

1. **Fallback Models rendered `[object Object], [object Object]`.** `fallback_providers` is a list of `{provider, model}` objects, but it was shown through the generic `list` config field, which does `value.join(', ')` and stringifies each object.
2. **The model box was blank** whenever the configured model wasn't in the selected provider's advertised catalog — e.g. a Nous‑proxied `openai/*` id, an LM Studio / custom‑endpoint model, or any overridden id. Radix `<Select>` renders nothing for a value with no matching item, so the page hid what was actually configured.

Both surfaced from a real case where a primary model was misconfigured (a provider/model mismatch that 404'd and silently fell back) and the UI gave no usable signal about what was set or why.

## Changes

- **New `FallbackModelsField`** — a structured provider + model row editor (add / remove) for `fallback_providers`, sourced from the same `getGlobalModelOptions()` the composer model picker uses. `ConfigField` renders it for that key instead of the generic `list` input. Half‑filled rows are kept in local state so the config autosave never persists a partial `{provider, model: ''}`, and an out‑of‑catalog model stays selectable so existing custom entries still render.
- **Out‑of‑catalog model visibility** — the main (and auxiliary) model `<Select>` now includes the current value as a selectable item even when it isn't in the provider's catalog, and shows a ⚠ note when the configured model isn't in the catalog, so the user knows calls may fall back.
- **i18n** — `settings.model.{fallbackAdd, fallbackEmpty, notInCatalog}` (en + zh; ja / zh‑hant fall back to English via `defineLocale`).
- **Tests** — `fallback-models-field.test.tsx`: each entry renders as its own row (never `[object Object]`), removing a row emits the remaining entries, adding a blank row never persists a partial pair, and the empty‑state hint.

**Old**
<img width="896" height="75" alt="Screenshot 2026-06-16 at 10 25 40 PM" src="https://github.com/user-attachments/assets/eb5defa5-87ca-4cef-b811-66fcd7f89edf" />


**New**
<img width="1568" height="502" alt="screenshot2" src="https://github.com/user-attachments/assets/f7c36790-d641-41bf-9fb3-dcd7c28d90ec" />


## Verification

- `npm run typecheck` and `eslint` clean on the changed files (the two remaining `react-hooks/exhaustive-deps` warnings in `config-settings.tsx` are pre‑existing in untouched `useEffect`s).
- `vitest` — the 4 new `fallback-models-field` tests pass. `model-settings.test.tsx` is unchanged by this PR; its one failing case fails identically on `main` (pre‑existing, unrelated).

## Follow-up (not in this PR)

A **"running on a fallback" banner**: when the default model is failing and the agent is silently serving from the `fallback_providers` chain, surface it (e.g. *"Default `nous/…` unavailable — running `copilot/…`"*). Doing this correctly needs a backend `fallback_activated` signal on `session.info` — a pure effective‑vs‑configured comparison would false‑positive on intentional per‑session model switches — plus making the agent's self‑report name the effective model. Tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
