### PR TITLE
fix(gateway): evict and delete a live session instead of refusing with 4023

### DIFF
--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -5177,9 +5177,13 @@ def test_session_delete_returns_db_unavailable_when_no_db(monkeypatch):
     assert "state.db unavailable" in resp["error"]["message"]
 
 
-def test_session_delete_refuses_active_session(monkeypatch):
-    """Cannot delete a session currently bound to a live TUI session."""
+def test_session_delete_evicts_then_deletes_active_session(monkeypatch):
+    """A session currently bound to a live TUI session is evicted (torn down
+    out of the live set) and THEN deleted on disk — no longer refused with
+    4023.  The live row is keyed off the STORED id (``session_key``), so the
+    handler must resolve it through the key, not the runtime ``sid``."""
     called: list[str] = []
+    torn_down: list[str] = []
 
     class _DB:
         def delete_session(self, sid, sessions_dir=None):
@@ -5187,6 +5191,94 @@ def test_session_delete_refuses_active_session(monkeypatch):
             return True
 
     monkeypatch.setattr(server, "_get_db", lambda: _DB())
+    # Reuse the stock teardown helper, but stub it so the test stays focused on
+    # the delete handler's evict-then-delete contract rather than agent close.
+    monkeypatch.setattr(
+        server,
+        "_close_session_by_id",
+        lambda sid, **kw: (torn_down.append(sid) or True),
+    )
+    # Runtime sid ("live") differs from the stored id ("key-live").
+    monkeypatch.setitem(server._sessions, "live", {"session_key": "key-live"})
+    try:
+        resp = server.handle_request(
+            {
+                "id": "1",
+                "method": "session.delete",
+                "params": {"session_id": "key-live"},
+            }
+        )
+    finally:
+        server._sessions.pop("live", None)
+
+    assert "result" in resp, resp
+    assert resp["result"] == {"deleted": "key-live", "evicted": True}
+    # Eviction tore down the live row by its runtime sid, then the on-disk row
+    # was deleted by the stored id.
+    assert torn_down == ["live"], "live runtime must be torn down before delete"
+    assert called == ["key-live"], "delete_session must run after eviction"
+
+
+def test_session_delete_interrupts_active_running_session(monkeypatch):
+    """Deleting a session that is mid-turn first interrupts the agent and
+    releases its pending prompts (mirrors session.interrupt) so a
+    deleted-while-streaming session never leaks a spending runtime."""
+    events: list[str] = []
+
+    class _Agent:
+        def interrupt(self):
+            events.append("interrupt")
+
+    class _DB:
+        def delete_session(self, sid, sessions_dir=None):
+            events.append("delete")
+            return True
+
+    monkeypatch.setattr(server, "_get_db", lambda: _DB())
+    monkeypatch.setattr(
+        server, "_close_session_by_id", lambda sid, **kw: events.append("teardown") or True
+    )
+    monkeypatch.setattr(
+        server, "_clear_pending", lambda sid=None: events.append("clear_pending")
+    )
+    monkeypatch.setitem(
+        server._sessions,
+        "live",
+        {"session_key": "key-run", "running": True, "agent": _Agent()},
+    )
+    try:
+        resp = server.handle_request(
+            {
+                "id": "1",
+                "method": "session.delete",
+                "params": {"session_id": "key-run"},
+            }
+        )
+    finally:
+        server._sessions.pop("live", None)
+
+    assert "result" in resp, resp
+    assert resp["result"] == {"deleted": "key-run", "evicted": True}
+    # interrupt + clear_pending happen BEFORE the teardown; the on-disk delete
+    # happens last.
+    assert events == ["interrupt", "clear_pending", "teardown", "delete"], events
+
+
+def test_session_delete_returns_4023_when_eviction_raises(monkeypatch):
+    """If the eviction teardown itself raises, the delete is refused with the
+    legacy 4023 code rather than deleting a half-torn-down session — and the
+    on-disk delete never runs."""
+
+    class _DB:
+        def delete_session(self, *a, **kw):
+            raise AssertionError("delete must not run when eviction fails")
+
+    monkeypatch.setattr(server, "_get_db", lambda: _DB())
+
+    def _boom(sid, **kw):
+        raise RuntimeError("agent close hung")
+
+    monkeypatch.setattr(server, "_close_session_by_id", _boom)
     monkeypatch.setitem(server._sessions, "live", {"session_key": "key-live"})
     try:
         resp = server.handle_request(
@@ -5201,8 +5293,8 @@ def test_session_delete_refuses_active_session(monkeypatch):
 
     assert "error" in resp
     assert resp["error"]["code"] == 4023
-    assert "active session" in resp["error"]["message"]
-    assert called == [], "delete_session must not be called for active sessions"
+    assert "could not evict active session" in resp["error"]["message"]
+    assert "agent close hung" in resp["error"]["message"]
 
 
 def test_session_delete_fails_closed_when_active_snapshot_raises(monkeypatch):
@@ -5263,7 +5355,8 @@ def test_session_delete_propagates_db_exception(monkeypatch):
 
 
 def test_session_delete_success_returns_deleted_id(monkeypatch):
-    """Happy path — DB delete succeeds, response carries the deleted id
+    """Happy path — DB delete succeeds for a NON-active session, response
+    carries the deleted id (with ``evicted: False`` since nothing was live)
     and the on-disk sessions dir is forwarded so transcript files get
     cleaned up alongside the row."""
     captured: dict = {}
@@ -5281,7 +5374,7 @@ def test_session_delete_success_returns_deleted_id(monkeypatch):
     )
 
     assert "result" in resp, resp
-    assert resp["result"] == {"deleted": "old-1"}
+    assert resp["result"] == {"deleted": "old-1", "evicted": False}
     assert captured["sid"] == "old-1"
     # sessions_dir must be forwarded so transcript files get cleaned up
     # too — not just the SQLite row.  The autouse _isolate_hermes_home

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -4720,11 +4720,20 @@ def _(rid, params: dict) -> dict:
     """Delete a stored session and its on-disk transcript files.
 
     Used by the TUI resume picker (``d`` key) so users can prune old
-    sessions without dropping to the CLI.  Refuses to delete a session
-    that is currently active in this gateway process — those rows are
-    still being written to and removing them out from under the live
-    agent corrupts message ordering and trips FK constraints when the
-    next message append flushes.
+    sessions without dropping to the CLI.  A session the user has open is
+    registered LIVE in this gateway process (``session.resume`` →
+    ``_init_session``), so the old "refuse any active session" guard made
+    delete reliably fail for anything currently open.  Instead of refusing,
+    we AUTO-EVICT the live row first, then delete the on-disk state.
+
+    Eviction is scoped to the single ``target`` session — other live rows are
+    never touched — and reuses the SAME teardown idiom as ``session.close``
+    (``_close_session_by_id``: pop under the resume/sessions locks +
+    ``_teardown_session``).  When the target is mid-turn we first interrupt the
+    agent and release any pending prompts/approvals (mirroring
+    ``session.interrupt``) so a deleted-while-streaming session never leaks a
+    spending runtime.  If the eviction teardown itself raises we refuse with
+    ``4023`` rather than delete a half-torn-down session.
     """
     target = params.get("session_id", "")
     if not target:
@@ -4732,29 +4741,68 @@ def _(rid, params: dict) -> dict:
     db = _get_db()
     if db is None:
         return _db_unavailable_error(rid, code=5036)
-    # Block deletion of any session currently bound to a live TUI session
-    # in this process.  The picker hides the active session anyway, but a
-    # racing caller could still target it.  Snapshot via ``list(...)``
-    # because ``_sessions`` is mutated by concurrent RPCs on the thread
-    # pool — iterating the dict directly can raise ``RuntimeError:
-    # dictionary changed size during iteration``.  If even the snapshot
-    # raises, fail closed (refuse the delete) rather than fail open.
+    # Snapshot the live table to learn whether ``target`` is currently bound to
+    # a live TUI session in this process.  Snapshot via ``list(...)`` because
+    # ``_sessions`` is mutated by concurrent RPCs on the thread pool — iterating
+    # the dict directly can raise ``RuntimeError: dictionary changed size during
+    # iteration``.  If even the snapshot raises, fail closed (refuse the delete)
+    # rather than fall through and delete blind.
     try:
         with _sessions_lock:
-            snapshot = list(_sessions.values())
+            snapshot = list(_sessions.items())
     except Exception as e:
         return _err(rid, 5036, f"could not enumerate active sessions: {e}")
-    active = {s.get("session_key") for s in snapshot if s.get("session_key")}
-    if target in active:
-        return _err(rid, 4023, "cannot delete an active session")
+
+    # ``session.delete`` keys on the STORED id (``session_key``), not the
+    # runtime ``sid``.  Resolve the live row through the key — never via
+    # ``_sessions.get(target)`` (which is keyed by ``sid``).
+    live: tuple[str, dict] | None = None
+    for sid, session in snapshot:
+        if session.get("_finalized"):
+            continue
+        if str(session.get("session_key") or "") == target:
+            live = (sid, session)
+            break
+
+    evicted = False
+    if live is not None:
+        live_sid, live_session = live
+        try:
+            if live_session.get("running"):
+                # Mid-turn: stop the spending runtime BEFORE evicting so a
+                # deleted-while-streaming session never leaks an orphaned
+                # agent.  Mirrors ``session.interrupt`` (interrupt + release
+                # pending prompts/approvals), scoped to this session only.
+                agent = live_session.get("agent")
+                if agent is not None and hasattr(agent, "interrupt"):
+                    agent.interrupt()
+                _clear_pending(live_sid)
+                try:
+                    from tools.approval import resolve_gateway_approval
+
+                    resolve_gateway_approval(target, "deny", resolve_all=True)
+                except Exception:
+                    pass
+            # Tear down via the same stock idiom as ``session.close``: serialize
+            # against the WS-orphan reaper under ``_session_resume_lock`` and let
+            # ``_close_session_by_id`` do the single idempotent pop+teardown.
+            with _session_resume_lock:
+                _close_session_by_id(live_sid, end_reason="tui_delete")
+            evicted = True
+        except Exception as e:
+            # Eviction teardown failed — refuse rather than delete a
+            # half-torn-down session.  ``4023`` is preserved for this fallback.
+            return _err(rid, 4023, f"could not evict active session: {e}")
+
     sessions_dir = get_hermes_home() / "sessions"
     try:
         deleted = db.delete_session(target, sessions_dir=sessions_dir)
     except Exception as e:
         return _err(rid, 5036, f"delete failed: {e}")
-    if not deleted:
+    if not deleted and not evicted:
+        # No on-disk row AND no live row existed — genuinely not found.
         return _err(rid, 4007, "session not found")
-    return _ok(rid, {"deleted": target})
+    return _ok(rid, {"deleted": target, "evicted": evicted})
 
 
 @method("session.title")


### PR DESCRIPTION
## What does this PR do?

`session.delete` refused to delete any session that was live in the gateway
process, returning error `4023 "cannot delete an active session"`. Root cause:
resuming a session registers it LIVE in this process (`session.resume` →
`_init_session`), so the "refuse any active session" guard made delete reliably
fail from the TUI resume picker (`d` key) — and from any client — for anything the
user currently had open. There was no in-process way to prune an open session.

This changes the handler to **evict-then-delete**: if the target stored session is
live, tear it down cleanly first, then delete it on disk. Eviction reuses the
gateway's existing teardown idiom (`_close_session_by_id` under
`_session_resume_lock` — the same path `session.close` uses), so no new teardown
logic is introduced. When the target is mid-turn, the agent is interrupted and its
pending prompts/approvals released first (mirroring `session.interrupt`) so a
deleted-while-streaming session never leaks a spending runtime. `4023` is kept only
as the fallback when the eviction teardown itself raises.

The change is additive/behavioral and fully self-contained — no new hooks, event
observers, module-level registries, or config keys.

## Related Issue

N/A

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tui_gateway/server.py` — `session.delete` handler: resolve the live runtime by
  its stored id (`session_key`); if found, interrupt + release pending
  prompts/approvals when mid-turn, then tear it down via
  `_close_session_by_id(..., end_reason="tui_delete")` under
  `_session_resume_lock`, then `db.delete_session(...)`. Returns
  `{"deleted": target, "evicted": <bool>}`. `4023` preserved only as the
  eviction-teardown-failure fallback. The fail-closed `5036` snapshot path is
  unchanged.
- `tests/test_tui_gateway_server.py` — repurposed the old "refuses active session"
  test and added coverage: active session now evicts-then-deletes
  (`evicted: true`); mid-turn session interrupts + clears pending before teardown;
  teardown raising still returns `4023`; non-active happy path returns
  `evicted: false`.

## How to Test

1. Start the gateway and resume a session so it is live in-process.
2. Call `session.delete` with that session's `session_id` (its stored key).
3. Confirm it returns `{"deleted": <id>, "evicted": true}` and the session is gone
   from the live set and from `/resume` (previously this returned `4023`).
4. Repeat against a session that is NOT live: returns `{"deleted": <id>,
   "evicted": false}`, unchanged behavior.
5. Run the suite: `scripts/run_tests.sh tests/test_tui_gateway_server.py`
   (the `session.delete` tests under `-k session_delete` all pass).

## Checklist

- [x] My commit messages follow Conventional Commits (`fix(gateway):`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [x] I've added tests and the `session.delete` suite passes (the one unrelated
      browser-detection failure is pre-existing on `main` and environment-dependent)
- [x] I've tested on my platform (macOS); `check-windows-footguns.py` is clean
- [x] `session.delete` now also returns `evicted` in its result (noted for clients)
