### PR TITLE
feat(slack): render clarify choices as Block Kit buttons

### DIFF
--- a/gateway/platforms/slack.py
+++ b/gateway/platforms/slack.py
@@ -963,6 +963,16 @@ class SlackAdapter(BasePlatformAdapter):
             ):
                 self._app.action(_action_id)(self._handle_slash_confirm_action)
 
+            # Register Block Kit action handlers for clarify buttons / select.
+            # A regex matcher (Bolt's documented app.action(re.compile(...))
+            # support) covers hermes_clarify_<n>, _other, and _select without a
+            # fixed id list — so arbitrary button counts register cleanly. The
+            # Slack 5-per-row UI cap still applies, so send_clarify keeps the
+            # static_select fallback for long choice lists.
+            self._app.action(_re.compile(r"^hermes_clarify_(?:\d+|other|select)$"))(
+                self._handle_clarify_action
+            )
+
             # Register plugin-provided Block Kit action handlers.
             #
             # Plugins call ``ctx.register_slack_action_handler(action_id, cb)``
@@ -3023,6 +3033,150 @@ class SlackAdapter(BasePlatformAdapter):
             logger.error("[Slack] send_slash_confirm failed: %s", e, exc_info=True)
             return SendResult(success=False, error=str(e))
 
+    # Inline buttons cap: Slack allows max 5 elements per actions block, so we
+    # reserve one slot for the trailing "Other" button and switch to a single
+    # static_select once the choice list exceeds this.
+    _CLARIFY_BUTTON_LIMIT = 4
+
+    async def send_clarify(
+        self,
+        chat_id: str,
+        question: str,
+        choices: Optional[list],
+        clarify_id: str,
+        session_key: str,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> SendResult:
+        """Render the clarify tool's question as Block Kit buttons.
+
+        Multi-choice: a section block + an actions block with one button per
+        choice plus a trailing "✏️ Other" button. Button clicks resolve via
+        ``tools.clarify_gateway.resolve_gateway_clarify``; "Other" flips the
+        entry into text-capture mode via ``mark_awaiting_text`` so the existing
+        gateway text-intercept captures the next in-thread message. Choice lists
+        longer than the Slack 5-per-row action cap render a single
+        ``static_select`` instead of buttons.
+
+        Open-ended (no choices): a plain section block; the gateway
+        text-intercept resolves the next message — no buttons. Mirrors the
+        Discord/Telegram ``send_clarify`` overrides; no base or gateway changes.
+        """
+        if not self._app:
+            return SendResult(success=False, error="Not connected")
+
+        try:
+            thread_ts = self._resolve_thread_ts(None, metadata)
+            clean = [str(c).strip() for c in (choices or []) if c and str(c).strip()]
+
+            # ---- open-ended: no buttons, rely on the text-intercept ----
+            if not clean:
+                # Mirror send_exec_approval's structure: an emoji + bold role
+                # title on the first line, then the actual content beneath it.
+                # Budget the question against Slack's 3000-char section-block cap
+                # (same guard as send_exec_approval) so a long question never
+                # trips invalid_blocks and silently drops the whole send.
+                header = f":question: *Clarification Needed*\n{question[:2900]}"
+                blocks = [
+                    {
+                        "type": "section",
+                        "text": {"type": "mrkdwn", "text": header},
+                    }
+                ]
+                kwargs: Dict[str, Any] = {
+                    "channel": chat_id,
+                    "text": f"❓ Clarification needed: {question[:120]}",
+                    "blocks": blocks,
+                }
+                if thread_ts:
+                    kwargs["thread_ts"] = thread_ts
+                result = await self._get_client(chat_id).chat_postMessage(**kwargs)
+                return SendResult(
+                    success=True, message_id=result.get("ts", ""), raw_response=result
+                )
+
+            # ---- multi-choice ----
+            # Same two-part structure as send_exec_approval: bold role title,
+            # then the question on its own line.
+            header = f":question: *Clarification Needed*\n{question[:2900]}"
+            section = {
+                "type": "section",
+                "text": {"type": "mrkdwn", "text": header},
+            }
+
+            if len(clean) <= self._CLARIFY_BUTTON_LIMIT:
+                elements: List[Dict[str, Any]] = [
+                    {
+                        "type": "button",
+                        # Encode the choice index in value so the handler can
+                        # round-trip the canonical choice text from the clarify
+                        # entry (mirror Discord) rather than trusting the label.
+                        # Buttons are tappable, so no numeric prefix is needed —
+                        # the label is just the choice text (cap at Slack's 75).
+                        "text": {
+                            "type": "plain_text",
+                            "text": c[:75],
+                        },
+                        "action_id": f"hermes_clarify_{i}",
+                        "value": f"{clarify_id}|{i}",
+                    }
+                    for i, c in enumerate(clean)
+                ]
+                elements.append(
+                    {
+                        "type": "button",
+                        "text": {"type": "plain_text", "text": "✏️ Other"},
+                        "action_id": "hermes_clarify_other",
+                        "value": f"{clarify_id}|other",
+                    }
+                )
+                actions = {"type": "actions", "elements": elements}
+            else:
+                actions = self._clarify_select_block(clean, clarify_id)
+
+            kwargs = {
+                "channel": chat_id,
+                "text": f"❓ {question[:120]}",
+                "blocks": [section, actions],
+            }
+            if thread_ts:
+                kwargs["thread_ts"] = thread_ts
+            result = await self._get_client(chat_id).chat_postMessage(**kwargs)
+            return SendResult(
+                success=True, message_id=result.get("ts", ""), raw_response=result
+            )
+        except Exception as e:
+            logger.error("[Slack] send_clarify failed: %s", e, exc_info=True)
+            return SendResult(success=False, error=str(e))
+
+    def _clarify_select_block(
+        self, choices: List[str], clarify_id: str
+    ) -> Dict[str, Any]:
+        """Build a static_select actions block for clarify prompts.
+
+        Slack actions blocks cap at 5 buttons, so choice lists longer than
+        ``_CLARIFY_BUTTON_LIMIT`` render as a single select menu. Each option's
+        value carries ``clarify_id|index`` exactly like the button path.
+        """
+        options = [
+            {
+                "text": {"type": "plain_text", "text": c[:75]},
+                "value": f"{clarify_id}|{i}",
+            }
+            # Slack caps a static_select at 100 options.
+            for i, c in enumerate(choices[:100])
+        ]
+        return {
+            "type": "actions",
+            "elements": [
+                {
+                    "type": "static_select",
+                    "action_id": "hermes_clarify_select",
+                    "placeholder": {"type": "plain_text", "text": "Pick an answer…"},
+                    "options": options,
+                }
+            ],
+        }
+
     def _is_interactive_user_authorized(
         self,
         user_id: str,
@@ -3300,6 +3454,136 @@ class SlackAdapter(BasePlatformAdapter):
             )
 
         # (approval state already consumed by atomic pop above)
+
+    async def _handle_clarify_action(self, ack, body, action) -> None:
+        """Handle a clarify button / select click from Block Kit.
+
+        Numeric click → resolve_gateway_clarify with the canonical choice text
+        round-tripped from the clarify entry (mirror Discord — never trust the
+        button label). "Other" → mark_awaiting_text so the existing gateway
+        text-intercept captures the user's next in-thread message. Auth reuses
+        the fail-closed _is_interactive_user_authorized boundary.
+        """
+        await ack()
+
+        action_id = action.get("action_id", "")
+        # static_select carries the chosen option under selected_option.
+        if action_id == "hermes_clarify_select":
+            value = (action.get("selected_option") or {}).get("value", "")
+        else:
+            value = action.get("value", "")
+
+        message = body.get("message", {})
+        msg_ts = message.get("ts", "")
+        channel_id = body.get("channel", {}).get("id", "")
+        user_name = body.get("user", {}).get("name", "unknown")
+        user_id = body.get("user", {}).get("id", "")
+
+        if not self._is_interactive_user_authorized(
+            user_id,
+            channel_id=channel_id,
+            user_name=user_name,
+        ):
+            logger.warning(
+                "[Slack] Unauthorized clarify click by %s (%s) - ignoring",
+                user_name,
+                user_id,
+            )
+            return
+
+        if "|" not in value:
+            logger.warning("[Slack] Malformed clarify value: %s", value)
+            return
+        clarify_id, idx_token = value.split("|", 1)
+
+        from tools import clarify_gateway as _clarify_mod
+
+        # ---- "Other" → text-capture mode ----
+        if idx_token == "other":
+            _clarify_mod.mark_awaiting_text(clarify_id)
+            await self._update_clarify_message(
+                channel_id,
+                msg_ts,
+                message,
+                f"✏️ {user_name} chose to type a custom answer — reply in-thread.",
+            )
+            return
+
+        # ---- numeric choice → resolve immediately ----
+        # Default to the raw index token, then upgrade to the canonical choice
+        # text round-tripped from the entry (mirror Discord; never trust the
+        # button label). The fallback only survives if the entry vanished (race).
+        #
+        # send_clarify renders buttons against a *filtered* choice list (empties
+        # and whitespace dropped), so the encoded index is into that filtered
+        # view — re-derive the SAME filter here before indexing, otherwise a
+        # dirty input list desyncs the two index spaces and resolves the wrong
+        # (or an empty) choice.
+        resolved_text: str = idx_token
+        try:
+            idx = int(idx_token)
+            entry = _clarify_mod._entries.get(clarify_id)  # type: ignore[attr-defined]
+            entry_choices = entry.choices if entry else None
+            clean_choices = [
+                str(c).strip()
+                for c in (entry_choices or [])
+                if c and str(c).strip()
+            ]
+            if clean_choices and 0 <= idx < len(clean_choices):
+                resolved_text = clean_choices[idx]
+        except Exception:
+            pass
+
+        await self._update_clarify_message(
+            channel_id,
+            msg_ts,
+            message,
+            f"✅ Answered by {user_name}: {resolved_text}",
+        )
+
+        try:
+            ok = _clarify_mod.resolve_gateway_clarify(clarify_id, resolved_text)
+            logger.info(
+                "Slack clarify resolved (id=%s, choice=%r, user=%s, ok=%s)",
+                clarify_id,
+                resolved_text,
+                user_name,
+                ok,
+            )
+        except Exception as exc:
+            logger.error(
+                "Slack clarify resolve failed (id=%s): %s",
+                clarify_id,
+                exc,
+                exc_info=True,
+            )
+
+    async def _update_clarify_message(
+        self, channel_id, msg_ts, message, footer
+    ) -> None:
+        """Rewrite the clarify prompt in place: keep the question, drop the
+        buttons, and append a context footer naming who answered (single-use)."""
+        original = ""
+        for b in message.get("blocks", []):
+            if b.get("type") == "section":
+                original = b.get("text", {}).get("text", "")
+                break
+        updated = [
+            {
+                "type": "section",
+                "text": {"type": "mrkdwn", "text": original or "Clarify prompt"},
+            },
+            {
+                "type": "context",
+                "elements": [{"type": "mrkdwn", "text": footer}],
+            },
+        ]
+        try:
+            await self._get_client(channel_id).chat_update(
+                channel=channel_id, ts=msg_ts, text=footer, blocks=updated
+            )
+        except Exception as e:
+            logger.warning("[Slack] Failed to update clarify message: %s", e)
 
     # ----- Thread context fetching -----
 

--- a/tests/gateway/test_slack_clarify_buttons.py
+++ b/tests/gateway/test_slack_clarify_buttons.py
@@ -1,0 +1,493 @@
+"""Tests for Slack clarify Block Kit button rendering and resolution.
+
+Slack counterpart to tests/gateway/test_discord_clarify_buttons.py and
+test_telegram_clarify_buttons.py for the ``send_clarify`` override.
+
+Slack renders clarify via Block Kit ``actions`` blocks (buttons, or a
+``static_select`` for long choice lists) and dispatches clicks through
+``_handle_clarify_action``. The auth + resolution path mirrors the other
+adapters:
+
+  · numeric choice → resolve_gateway_clarify(clarify_id, canonical_text)
+  · "Other" button → mark_awaiting_text(clarify_id) so the text-intercept
+    captures the next in-thread message
+  · unauthorized / malformed → ignored, no resolve, no message rewrite
+"""
+
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Ensure the repo root is importable
+# ---------------------------------------------------------------------------
+_repo = str(Path(__file__).resolve().parents[2])
+if _repo not in sys.path:
+    sys.path.insert(0, _repo)
+
+
+# ---------------------------------------------------------------------------
+# Minimal Slack SDK mock so SlackAdapter can be imported (mirrors
+# test_slack_approval_buttons.py)
+# ---------------------------------------------------------------------------
+def _ensure_slack_mock():
+    """Wire up the minimal mocks required to import SlackAdapter."""
+    if "slack_bolt" in sys.modules:
+        return
+    slack_bolt = MagicMock()
+    slack_bolt.async_app.AsyncApp = MagicMock
+    sys.modules["slack_bolt"] = slack_bolt
+    sys.modules["slack_bolt.async_app"] = slack_bolt.async_app
+    handler_mod = MagicMock()
+    handler_mod.AsyncSocketModeHandler = MagicMock
+    sys.modules["slack_bolt.adapter"] = MagicMock()
+    sys.modules["slack_bolt.adapter.socket_mode"] = MagicMock()
+    sys.modules["slack_bolt.adapter.socket_mode.async_handler"] = handler_mod
+    sdk_mod = MagicMock()
+    sdk_mod.web = MagicMock()
+    sdk_mod.web.async_client = MagicMock()
+    sdk_mod.web.async_client.AsyncWebClient = MagicMock
+    sys.modules["slack_sdk"] = sdk_mod
+    sys.modules["slack_sdk.web"] = sdk_mod.web
+    sys.modules["slack_sdk.web.async_client"] = sdk_mod.web.async_client
+
+
+_ensure_slack_mock()
+
+from gateway.platforms.slack import SlackAdapter  # noqa: E402
+from gateway.config import PlatformConfig  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+def _make_adapter():
+    """Create a SlackAdapter with mocked internals (mirror approval tests)."""
+    config = PlatformConfig(enabled=True, token="***")
+    adapter = SlackAdapter(config)
+    adapter._app = MagicMock()
+    adapter._bot_user_id = "U_BOT"
+    adapter._team_clients = {"T1": AsyncMock()}
+    adapter._team_bot_user_ids = {"T1": "U_BOT"}
+    adapter._channel_team = {"C1": "T1"}
+    return adapter
+
+
+class _AuthRunner:
+    def __init__(self, auth_fn=None):
+        self._auth_fn = auth_fn or (lambda _source: True)
+        self.seen_sources = []
+
+    async def handle(self, event):
+        return None
+
+    def _is_user_authorized(self, source):
+        self.seen_sources.append(source)
+        return self._auth_fn(source)
+
+
+def _attach_auth_runner(adapter, auth_fn=None):
+    runner = _AuthRunner(auth_fn=auth_fn)
+    adapter.set_message_handler(runner.handle)
+    return runner
+
+
+def _clear_clarify_state():
+    from tools import clarify_gateway as cm
+
+    with cm._lock:
+        cm._entries.clear()
+        cm._session_index.clear()
+        cm._notify_cbs.clear()
+
+
+def _click_body(*, msg_ts="111.222",
+                section_text=":question: *Clarification Needed*\nPick a color",
+                user_name="norbert", user_id="U_NORBERT"):
+    """A Block Kit action body as Bolt delivers it to the handler."""
+    return {
+        "message": {
+            "ts": msg_ts,
+            "blocks": [
+                {"type": "section",
+                 "text": {"type": "mrkdwn", "text": section_text}},
+                {"type": "actions", "elements": []},
+            ],
+        },
+        "channel": {"id": "C1"},
+        "user": {"name": user_name, "id": user_id},
+    }
+
+
+# ===========================================================================
+# send_clarify — block rendering
+# ===========================================================================
+
+class TestSlackSendClarify:
+    def setup_method(self):
+        _clear_clarify_state()
+
+    @pytest.mark.asyncio
+    async def test_multi_choice_renders_buttons_with_encoded_values(self):
+        adapter = _make_adapter()
+        client = adapter._team_clients["T1"]
+        client.chat_postMessage = AsyncMock(return_value={"ts": "1.1"})
+
+        result = await adapter.send_clarify(
+            chat_id="C1",
+            question="Pick a color",
+            choices=["red", "green", "blue"],
+            clarify_id="cidM",
+            session_key="sk-M",
+        )
+
+        assert result.success is True
+        assert result.message_id == "1.1"
+        client.chat_postMessage.assert_called_once()
+        blocks = client.chat_postMessage.call_args[1]["blocks"]
+        assert len(blocks) == 2
+        assert blocks[0]["type"] == "section"
+        section_text = blocks[0]["text"]["text"]
+        # Mirrors send_exec_approval: bold role title, then the question beneath.
+        assert "*Clarification Needed*" in section_text
+        assert "Pick a color" in section_text
+        assert blocks[1]["type"] == "actions"
+        elements = blocks[1]["elements"]
+        # 3 choice buttons + 1 Other
+        assert len(elements) == 4
+        assert [e["action_id"] for e in elements] == [
+            "hermes_clarify_0",
+            "hermes_clarify_1",
+            "hermes_clarify_2",
+            "hermes_clarify_other",
+        ]
+        # Values encode clarify_id|idx (and |other for the trailing button)
+        assert elements[0]["value"] == "cidM|0"
+        assert elements[1]["value"] == "cidM|1"
+        assert elements[2]["value"] == "cidM|2"
+        assert elements[3]["value"] == "cidM|other"
+        # Button labels are the bare choice text — no numeric prefix (tappable,
+        # so the "1./2." numbering from the text fallback is dropped).
+        assert elements[0]["text"]["text"] == "red"
+        assert elements[1]["text"]["text"] == "green"
+        assert "Other" in elements[3]["text"]["text"]
+
+    @pytest.mark.asyncio
+    async def test_open_ended_renders_section_only_no_actions(self):
+        adapter = _make_adapter()
+        client = adapter._team_clients["T1"]
+        client.chat_postMessage = AsyncMock(return_value={"ts": "2.2"})
+
+        result = await adapter.send_clarify(
+            chat_id="C1",
+            question="What is your name?",
+            choices=None,
+            clarify_id="cidOE",
+            session_key="sk-OE",
+        )
+
+        assert result.success is True
+        blocks = client.chat_postMessage.call_args[1]["blocks"]
+        # Open-ended → section only, NO actions block (text-intercept resolves)
+        assert len(blocks) == 1
+        assert blocks[0]["type"] == "section"
+        assert all(b["type"] != "actions" for b in blocks)
+
+    @pytest.mark.asyncio
+    async def test_many_choices_degrade_to_static_select(self):
+        adapter = _make_adapter()
+        client = adapter._team_clients["T1"]
+        client.chat_postMessage = AsyncMock(return_value={"ts": "3.3"})
+
+        choices = [f"opt-{i}" for i in range(8)]  # > _CLARIFY_BUTTON_LIMIT (4)
+        await adapter.send_clarify(
+            chat_id="C1",
+            question="Pick one",
+            choices=choices,
+            clarify_id="cidS",
+            session_key="sk-S",
+        )
+
+        blocks = client.chat_postMessage.call_args[1]["blocks"]
+        actions = blocks[1]
+        assert actions["type"] == "actions"
+        element = actions["elements"][0]
+        assert element["type"] == "static_select"
+        assert element["action_id"] == "hermes_clarify_select"
+        # One option per choice, each value-encoded clarify_id|idx
+        assert len(element["options"]) == 8
+        assert element["options"][0]["value"] == "cidS|0"
+        assert element["options"][7]["value"] == "cidS|7"
+
+    @pytest.mark.asyncio
+    async def test_long_question_stays_under_section_cap(self):
+        adapter = _make_adapter()
+        client = adapter._team_clients["T1"]
+        client.chat_postMessage = AsyncMock(return_value={"ts": "4.4"})
+
+        await adapter.send_clarify(
+            chat_id="C1",
+            question="Q" * 3000,
+            choices=["a", "b"],
+            clarify_id="cidL",
+            session_key="sk-L",
+        )
+
+        blocks = client.chat_postMessage.call_args[1]["blocks"]
+        section_text = blocks[0]["text"]["text"]
+        # Must stay under Slack's 3000-char section-block cap (no invalid_blocks)
+        assert len(section_text) <= 3000
+
+    @pytest.mark.asyncio
+    async def test_thread_ts_from_metadata_posts_in_thread(self):
+        adapter = _make_adapter()
+        client = adapter._team_clients["T1"]
+        client.chat_postMessage = AsyncMock(return_value={"ts": "5.5"})
+
+        await adapter.send_clarify(
+            chat_id="C1",
+            question="Pick",
+            choices=["a"],
+            clarify_id="cidT",
+            session_key="sk-T",
+            metadata={"thread_id": "9999.0000"},
+        )
+
+        assert client.chat_postMessage.call_args[1].get("thread_ts") == "9999.0000"
+
+    @pytest.mark.asyncio
+    async def test_not_connected_returns_failure(self):
+        adapter = _make_adapter()
+        adapter._app = None
+        result = await adapter.send_clarify(
+            chat_id="C1",
+            question="?",
+            choices=["a"],
+            clarify_id="cidNC",
+            session_key="sk-NC",
+        )
+        assert result.success is False
+        assert "Not connected" in (result.error or "")
+
+
+# ===========================================================================
+# _handle_clarify_action — numeric resolve
+# ===========================================================================
+
+class TestSlackClarifyResolve:
+    def setup_method(self):
+        _clear_clarify_state()
+
+    @pytest.mark.asyncio
+    async def test_numeric_click_resolves_with_canonical_choice_text(self):
+        from tools import clarify_gateway as cm
+
+        cm.register("cidA", "sk-A", "Pick", ["red", "green", "blue"])
+
+        adapter = _make_adapter()
+        _attach_auth_runner(adapter)
+        client = adapter._team_clients["T1"]
+        client.chat_update = AsyncMock()
+
+        ack = AsyncMock()
+        body = _click_body()
+        action = {"action_id": "hermes_clarify_1", "value": "cidA|1"}
+
+        await adapter._handle_clarify_action(ack, body, action)
+
+        ack.assert_called_once()
+        # Resolved through the clarify primitive with the canonical text,
+        # not the button label.
+        with cm._lock:
+            entry = cm._entries.get("cidA")
+        assert entry is not None
+        assert entry.response == "green"
+        assert entry.event.is_set()
+        # Message rewritten with "Answered by" footer
+        client.chat_update.assert_called_once()
+        update_kwargs = client.chat_update.call_args[1]
+        assert "Answered by norbert" in update_kwargs["text"]
+        assert "green" in update_kwargs["text"]
+
+    @pytest.mark.asyncio
+    async def test_static_select_uses_selected_option_value(self):
+        from tools import clarify_gateway as cm
+
+        cm.register("cidSel", "sk-Sel", "Pick", [f"opt-{i}" for i in range(8)])
+
+        adapter = _make_adapter()
+        _attach_auth_runner(adapter)
+        client = adapter._team_clients["T1"]
+        client.chat_update = AsyncMock()
+
+        ack = AsyncMock()
+        body = _click_body()
+        # static_select carries the chosen value under selected_option, not value
+        action = {
+            "action_id": "hermes_clarify_select",
+            "selected_option": {"value": "cidSel|5"},
+        }
+
+        await adapter._handle_clarify_action(ack, body, action)
+
+        with cm._lock:
+            entry = cm._entries.get("cidSel")
+        assert entry is not None
+        assert entry.response == "opt-5"
+        assert entry.event.is_set()
+
+    @pytest.mark.asyncio
+    async def test_numeric_click_falls_back_to_index_when_entry_missing(self):
+        """If the entry vanished (race/stale prompt), resolve with the raw
+        index token rather than crashing."""
+        adapter = _make_adapter()
+        _attach_auth_runner(adapter)
+        client = adapter._team_clients["T1"]
+        client.chat_update = AsyncMock()
+
+        ack = AsyncMock()
+        body = _click_body()
+        action = {"action_id": "hermes_clarify_0", "value": "cidGone|0"}
+
+        # No cm.register() — entry intentionally absent. Must not raise.
+        await adapter._handle_clarify_action(ack, body, action)
+
+        ack.assert_called_once()
+        # Footer falls back to the raw token
+        update_kwargs = client.chat_update.call_args[1]
+        assert "Answered by norbert" in update_kwargs["text"]
+
+    @pytest.mark.asyncio
+    async def test_dirty_choices_index_stays_aligned_with_rendered_buttons(self):
+        """Regression: send_clarify filters empty/whitespace choices before
+        rendering, so the encoded button index is into the FILTERED list. The
+        handler must apply the identical filter to entry.choices before
+        indexing — otherwise a dirty input list desyncs the two index spaces
+        and resolves the wrong (or empty) value.
+
+        Entry stores the raw list ["", "  ", "real-choice", None]; the rendered
+        button for the only real choice carries index 0 (filtered view). Clicking
+        it must resolve to "real-choice", not entry.choices[0] == "".
+        """
+        from tools import clarify_gateway as cm
+
+        # Deliberately dirty input (empties, whitespace, None) — build at runtime
+        # so the static type checker doesn't reject the intentional None.
+        dirty_choices = ["", "  ", "real-choice", None]
+        cm.register("cidDirty", "sk-Dirty", "Pick", dirty_choices)
+
+        adapter = _make_adapter()
+        _attach_auth_runner(adapter)
+        client = adapter._team_clients["T1"]
+        client.chat_update = AsyncMock()
+
+        ack = AsyncMock()
+        body = _click_body()
+        # send_clarify would render "real-choice" as button index 0.
+        action = {"action_id": "hermes_clarify_0", "value": "cidDirty|0"}
+
+        await adapter._handle_clarify_action(ack, body, action)
+
+        with cm._lock:
+            entry = cm._entries.get("cidDirty")
+        assert entry is not None
+        assert entry.response == "real-choice"
+        assert entry.event.is_set()
+        assert "real-choice" in client.chat_update.call_args[1]["text"]
+
+
+# ===========================================================================
+# _handle_clarify_action — "Other" → text-capture
+# ===========================================================================
+
+class TestSlackClarifyOther:
+    def setup_method(self):
+        _clear_clarify_state()
+
+    @pytest.mark.asyncio
+    async def test_other_flips_entry_to_awaiting_text_no_resolve(self):
+        from tools import clarify_gateway as cm
+
+        cm.register("cidD", "sk-D", "Pick", ["x", "y"])
+
+        adapter = _make_adapter()
+        _attach_auth_runner(adapter)
+        client = adapter._team_clients["T1"]
+        client.chat_update = AsyncMock()
+
+        ack = AsyncMock()
+        body = _click_body()
+        action = {"action_id": "hermes_clarify_other", "value": "cidD|other"}
+
+        await adapter._handle_clarify_action(ack, body, action)
+
+        # Entry flipped to awaiting_text, still pending (not resolved)
+        pending = cm.get_pending_for_session("sk-D")
+        assert pending is not None
+        assert pending.clarify_id == "cidD"
+        assert pending.awaiting_text is True
+        with cm._lock:
+            entry = cm._entries.get("cidD")
+        assert entry is not None
+        assert not entry.event.is_set()
+        # Message rewritten to prompt for the typed answer
+        client.chat_update.assert_called_once()
+        assert "type a custom answer" in client.chat_update.call_args[1]["text"]
+
+
+# ===========================================================================
+# _handle_clarify_action — auth + safety
+# ===========================================================================
+
+class TestSlackClarifyAuthSafety:
+    def setup_method(self):
+        _clear_clarify_state()
+
+    @pytest.mark.asyncio
+    async def test_unauthorized_click_ignored_no_resolve_no_update(self):
+        from tools import clarify_gateway as cm
+
+        cm.register("cidU", "sk-U", "Pick", ["x"])
+
+        adapter = _make_adapter()
+        # Auth runner denies everyone
+        _attach_auth_runner(adapter, auth_fn=lambda _s: False)
+        client = adapter._team_clients["T1"]
+        client.chat_update = AsyncMock()
+
+        ack = AsyncMock()
+        body = _click_body(user_name="mallory", user_id="U_ATTACKER")
+        action = {"action_id": "hermes_clarify_0", "value": "cidU|0"}
+
+        await adapter._handle_clarify_action(ack, body, action)
+
+        # Acked (so Slack doesn't retry) but no resolve, no message rewrite
+        ack.assert_called_once()
+        client.chat_update.assert_not_called()
+        with cm._lock:
+            entry = cm._entries.get("cidU")
+        assert entry is not None
+        assert not entry.event.is_set()
+
+    @pytest.mark.asyncio
+    async def test_malformed_value_no_crash_no_resolve(self):
+        adapter = _make_adapter()
+        _attach_auth_runner(adapter)
+        client = adapter._team_clients["T1"]
+        client.chat_update = AsyncMock()
+
+        ack = AsyncMock()
+        body = _click_body()
+        # No "|" separator
+        action = {"action_id": "hermes_clarify_0", "value": "garbage-no-pipe"}
+
+        with patch(
+            "tools.clarify_gateway.resolve_gateway_clarify"
+        ) as mock_resolve:
+            await adapter._handle_clarify_action(ack, body, action)
+
+        ack.assert_called_once()
+        mock_resolve.assert_not_called()
+        client.chat_update.assert_not_called()


### PR DESCRIPTION
## What does this PR do?

Brings Slack to parity with Telegram/Discord/WhatsApp on the clarify tool's interactive UX. Overrides `BasePlatformAdapter.send_clarify` on `SlackAdapter` to render Block Kit buttons when choices are present, reusing the same Block Kit + inbound-action + auth infrastructure that already powers `send_exec_approval` and `send_slash_confirm`. Today Slack inherits the numbered-text fallback; this gives it native one-tap answers. No `base.py` / gateway `clarify_callback` changes — mirrors how the Discord version shipped (commit `1dca6a6`).

The card structure deliberately matches `send_exec_approval`: an emoji + bold "Clarification Needed" title with the question on its own line beneath it, then clean choice buttons (no numeric prefixes, since they're tappable).

## Related Issue

Fixes #47529

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `gateway/platforms/slack.py`: add `SlackAdapter.send_clarify` — `section` (exec-approval-style title + question) + `actions` blocks, one button per choice + "✏️ Other", `static_select` fallback for >4 choices, 3000-char section-block budget, in-thread posting.
- `gateway/platforms/slack.py`: add `_handle_clarify_action` inbound handler — fail-closed auth, value decode (`clarify_id|idx`), numeric → `resolve_gateway_clarify` with the canonical entry text (the handler re-applies `send_clarify`'s empty/whitespace filter before indexing so dirty choice lists stay aligned), "Other" → `mark_awaiting_text`; message rewrite + context footer on resolve.
- `gateway/platforms/slack.py`: register the clarify `action_id`s via a regex matcher (`^hermes_clarify_(?:\d+|other|select)$`) alongside the existing approval handlers.
- `tests/gateway/test_slack_clarify_buttons.py`: new test module (13 cases).

## How to Test

1. `scripts/run_tests.sh tests/gateway/test_slack_clarify_buttons.py` (per-file isolated runner — the repo's intended entrypoint; 13/13 pass).
2. Live: trigger a clarify with choices in a Slack DM/channel → buttons render with the "Clarification Needed" header; click one → prompt updates with "✅ Answered by …", agent unblocks with that choice. Click "Other" → reply in-thread → that text resolves the clarify.
3. Open-ended clarify (no choices) → plain text prompt, next message resolves.
4. `git diff --check`

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`feat(scope):`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this feature (no unrelated commits)
- [x] I've run the test suite and all tests related to this change pass — `scripts/run_tests.sh` (the repo's per-file isolated runner) is green for the new module and the Slack gateway suites (`test_slack.py` 196/196, `test_slack_approval_buttons.py` 26/26). Note: a flat `pytest tests/ -q` over the whole tree currently reports pre-existing failures on `main` (e.g. `tests/gateway/test_slack_mention.py`, `tests/website/*`) that reproduce identically on a clean `origin/main` checkout with this branch absent — they are unrelated to this change and appear to be an artifact of running ~10k tests in one process rather than per-file. Happy to adjust if the maintainers prefer a different gate.
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS (live Slack workspace via Bolt Socket Mode — buttons render, tap resolves, "Other" → text capture, unauthorized clicks rejected)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (docstrings on the new methods) — or N/A
- [x] `cli-config.yaml.example` — N/A (no new config keys)
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A (no architecture change; per-adapter `send_clarify` override is the existing documented pattern)
- [x] Cross-platform impact — N/A (Slack-only; no OS-specific code)
- [x] tool descriptions/schemas — N/A (clarify tool contract unchanged; only Slack rendering)

## Screenshots / Logs

Block Kit payload the new `send_clarify` emits for a 3-choice prompt (captured from the actual method):

```json
{
  "blocks": [
    {"type": "section", "text": {"type": "mrkdwn",
      "text": ":question: *Clarification Needed*\nWhich deploy target should I use?"}},
    {"type": "actions", "elements": [
      {"type": "button", "text": {"type": "plain_text", "text": "staging"},    "action_id": "hermes_clarify_0", "value": "<id>|0"},
      {"type": "button", "text": {"type": "plain_text", "text": "production"}, "action_id": "hermes_clarify_1", "value": "<id>|1"},
      {"type": "button", "text": {"type": "plain_text", "text": "canary"},     "action_id": "hermes_clarify_2", "value": "<id>|2"},
      {"type": "button", "text": {"type": "plain_text", "text": "✏️ Other"},   "action_id": "hermes_clarify_other", "value": "<id>|other"}
    ]}
  ]
}
```

On resolve, the message is rewritten to drop the buttons and append a context line: `✅ Answered by <user>: <choice>`. Verified live in a Slack workspace.
