### PR TITLE
feat(gateway): add role-scoped session search

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -2851,7 +2851,9 @@ async def get_profiles_sessions(
 
 
 @app.get("/api/sessions/search")
-async def search_sessions(q: str = "", limit: int = 20, profile: Optional[str] = None):
+async def search_sessions(
+    q: str = "", limit: int = 20, scope: str = "all", profile: Optional[str] = None
+):
     """Search sessions by ID plus full-text message content using FTS5.
 
     Direct session-id matches are surfaced first, then FTS message-content
@@ -2861,9 +2863,27 @@ async def search_sessions(q: str = "", limit: int = 20, profile: Optional[str] =
     logical chat can own many ``sessions`` rows that all match the same query.
     Branches also use ``parent_session_id``, but they are real alternate
     conversations; don't collapse branch-specific hits back into the parent.
+
+    ``scope`` narrows by message role so the result list isn't dominated by
+    tool/structured noise:
+      - ``all`` (default): every role, plus direct session-id matches. This is
+        byte-identical to the historical behaviour.
+      - ``messages``: user + assistant prose only (excludes tool output).
+      - ``code``: tool messages only (command output / file contents /
+        structured results).
+    Any unrecognised value is treated as ``all``. A non-``all`` scope drops the
+    session-id match pass so the list stays a pure content-scoped result.
     """
     if not q or not q.strip():
         return {"results": []}
+    # Map the public scope name onto the db layer's role_filter. ``None`` means
+    # "no role filter" — the exact default search_messages already uses — so
+    # scope="all" (or any unknown value) leaves the query untouched.
+    scope_norm = (scope or "all").strip().lower()
+    role_filter = {
+        "messages": ["user", "assistant"],
+        "code": ["tool"],
+    }.get(scope_norm)  # None for "all"/unknown → unchanged behaviour
     try:
         db = _open_session_db_for_profile(profile)
         try:
@@ -2960,7 +2980,15 @@ async def search_sessions(q: str = "", limit: int = 20, profile: Optional[str] =
             # logs, or another Hermes surface. FTS can't find those unless the
             # id happens to appear in message text. search_sessions_by_id is
             # SQL-bounded, so this stays cheap even with thousands of sessions.
-            for row in db.search_sessions_by_id(q, limit=safe_limit, include_archived=True):
+            # Skipped for a narrowed scope (messages/code) so the list stays a
+            # pure content-scoped result; for the default scope this is the same
+            # pass as before.
+            id_rows = (
+                db.search_sessions_by_id(q, limit=safe_limit, include_archived=True)
+                if role_filter is None
+                else []
+            )
+            for row in id_rows:
                 sid = row.get("id")
                 preview = (row.get("preview") or "").strip()
                 snippet = preview or f"Session ID: {sid}"
@@ -2989,7 +3017,13 @@ async def search_sessions(q: str = "", limit: int = 20, profile: Optional[str] =
             # Over-fetch so lineage dedup can still surface `limit` distinct
             # conversations even when several hits collapse onto one root.
             fetch_limit = max(safe_limit * 5, 50)
-            matches = db.search_messages(query=prefix_query, limit=fetch_limit)
+            # Pass role_filter only when a scope is active, so the default
+            # (scope="all") path calls search_messages exactly as stock Hermes
+            # does — keeps this seam additive and the existing search tests green.
+            search_kwargs = {"query": prefix_query, "limit": fetch_limit}
+            if role_filter is not None:
+                search_kwargs["role_filter"] = role_filter
+            matches = db.search_messages(**search_kwargs)
 
             for m in matches:
                 if len(seen) >= safe_limit:

--- a/tests/hermes_cli/test_web_server_session_search.py
+++ b/tests/hermes_cli/test_web_server_session_search.py
@@ -88,3 +88,154 @@ def test_desktop_session_search_merges_id_matches_before_content_matches(monkeyp
             },
         ]
     }
+
+
+class _ScopeRecordingSessionDB:
+    """Fake that records how /api/sessions/search drives the db layer.
+
+    Captures whether the session-id pass ran and what ``role_filter`` reached
+    ``search_messages``, so the scope tests can assert on the wiring rather than
+    a particular result shape. Returns one user, one assistant and one tool hit
+    so a role-scoped query has something to narrow.
+    """
+
+    def __init__(self):
+        self.id_search_called = False
+        self.search_messages_kwargs = None
+
+    def search_sessions_by_id(self, query, limit=20, include_archived=True):
+        self.id_search_called = True
+        return [
+            {
+                "id": "id_hit",
+                "preview": "id preview",
+                "source": "cli",
+                "model": "claude",
+                "started_at": 10,
+            }
+        ]
+
+    def search_messages(self, query, limit=20, role_filter=None):
+        self.search_messages_kwargs = {
+            "query": query,
+            "limit": limit,
+            "role_filter": role_filter,
+        }
+        rows = [
+            {
+                "session_id": "user_session",
+                "snippet": "user hit",
+                "role": "user",
+                "source": "cli",
+                "model": "claude",
+                "session_started": 20,
+            },
+            {
+                "session_id": "assistant_session",
+                "snippet": "assistant hit",
+                "role": "assistant",
+                "source": "cli",
+                "model": "claude",
+                "session_started": 30,
+            },
+            {
+                "session_id": "tool_session",
+                "snippet": "tool hit",
+                "role": "tool",
+                "source": "cli",
+                "model": "claude",
+                "session_started": 40,
+            },
+        ]
+        # Mirror the db layer: when a role_filter is supplied, only rows with a
+        # matching role come back.
+        if role_filter is not None:
+            rows = [r for r in rows if r["role"] in role_filter]
+        return rows
+
+    def get_session(self, session_id):
+        return {"id": session_id, "parent_session_id": None}
+
+    def get_compression_tip(self, session_id):
+        return session_id
+
+    def close(self):
+        pass
+
+
+def test_session_search_scope_all_is_unchanged_default(monkeypatch):
+    """scope defaults to "all": id-pass runs and no role_filter is sent.
+
+    This is the byte-identical-to-stock path — search_messages is called with
+    exactly the kwargs the old handler used (no role_filter key).
+    """
+    fake = _ScopeRecordingSessionDB()
+    monkeypatch.setattr("hermes_state.SessionDB", lambda *a, **k: fake)
+
+    explicit = asyncio.run(web_server.search_sessions(q="docker", limit=10, scope="all"))
+    assert fake.id_search_called is True
+    assert fake.search_messages_kwargs["role_filter"] is None
+
+    fake_default = _ScopeRecordingSessionDB()
+    monkeypatch.setattr("hermes_state.SessionDB", lambda *a, **k: fake_default)
+    omitted = asyncio.run(web_server.search_sessions(q="docker", limit=10))
+
+    # Omitting scope and passing scope="all" produce the same result and the
+    # same db driving (id-pass on, role_filter off).
+    assert omitted == explicit
+    assert fake_default.id_search_called is True
+    assert fake_default.search_messages_kwargs["role_filter"] is None
+    # The id-match session leads (every role present in the result set).
+    roots = [r["lineage_root"] for r in explicit["results"]]
+    assert roots == ["id_hit", "user_session", "assistant_session", "tool_session"]
+
+
+def test_session_search_scope_messages_filters_to_prose(monkeypatch):
+    """scope="messages" → user+assistant role_filter and no session-id pass."""
+    fake = _ScopeRecordingSessionDB()
+    monkeypatch.setattr("hermes_state.SessionDB", lambda *a, **k: fake)
+
+    response = asyncio.run(
+        web_server.search_sessions(q="docker", limit=10, scope="messages")
+    )
+
+    assert fake.id_search_called is False
+    assert fake.search_messages_kwargs["role_filter"] == ["user", "assistant"]
+    roots = [r["lineage_root"] for r in response["results"]]
+    assert roots == ["user_session", "assistant_session"]
+    assert "id_hit" not in roots
+    assert "tool_session" not in roots
+
+
+def test_session_search_scope_code_filters_to_tool(monkeypatch):
+    """scope="code" → tool-only role_filter and no session-id pass."""
+    fake = _ScopeRecordingSessionDB()
+    monkeypatch.setattr("hermes_state.SessionDB", lambda *a, **k: fake)
+
+    response = asyncio.run(
+        web_server.search_sessions(q="docker", limit=10, scope="code")
+    )
+
+    assert fake.id_search_called is False
+    assert fake.search_messages_kwargs["role_filter"] == ["tool"]
+    roots = [r["lineage_root"] for r in response["results"]]
+    assert roots == ["tool_session"]
+
+
+def test_session_search_invalid_scope_falls_back_to_all(monkeypatch):
+    """An unrecognised scope is handled gracefully — treated as "all".
+
+    No error is raised; the id-pass runs and search_messages gets no
+    role_filter, exactly like scope="all".
+    """
+    fake = _ScopeRecordingSessionDB()
+    monkeypatch.setattr("hermes_state.SessionDB", lambda *a, **k: fake)
+
+    response = asyncio.run(
+        web_server.search_sessions(q="docker", limit=10, scope="bogus")
+    )
+
+    assert fake.id_search_called is True
+    assert fake.search_messages_kwargs["role_filter"] is None
+    roots = [r["lineage_root"] for r in response["results"]]
+    assert roots == ["id_hit", "user_session", "assistant_session", "tool_session"]


### PR DESCRIPTION
## What does this PR do?

Adds an optional `scope` query parameter to the dashboard session-search endpoint
(`GET /api/sessions/search`) so a caller can restrict matches by message role. It
maps a public scope name onto the db layer's existing `role_filter`:

- `all` (default) — every role, plus direct session-id matches. **Byte-identical
  to today's behaviour.**
- `messages` — user + assistant prose only (excludes tool output).
- `code` — tool messages only (command output / file contents / structured results).

Any unrecognised value is treated as `all`. A non-`all` scope also drops the
session-id match pass so the result list stays a pure content-scoped result.

## Related Issue

N/A

## Type of Change

- [x] ✨ New feature (additive, backward-compatible)

## Changes Made

- `hermes_cli/web_server.py`: added a `scope: str = "all"` query param to
  `search_sessions`; normalise it to a `role_filter`
  (`messages → ["user","assistant"]`, `code → ["tool"]`, everything else →
  `None`); skip the session-id pass when a scope is active; pass `role_filter` to
  `search_messages` **only** when a scope is active.
- `tests/hermes_cli/test_web_server_session_search.py`: 4 new tests covering the
  default (unchanged) path, both explicit scopes, and graceful fallback for an
  invalid scope.

No db-layer change: `SessionDB.search_messages` already accepts `role_filter`
(default `None` = unchanged). No new env vars, hooks, or registries.

## How to Test

1. `scripts/run_tests.sh tests/hermes_cli/test_web_server_session_search.py`
2. Manually against a running dashboard:
   - `GET /api/sessions/search?q=docker` and `?q=docker&scope=all` → identical results.
   - `?q=docker&scope=messages` → user/assistant hits only.
   - `?q=docker&scope=code` → tool-message hits only.
   - `?q=docker&scope=bogus` → behaves exactly like `all` (no error).

## Checklist

- [x] Default (`scope=all` / omitted) is byte-identical to current stock
- [x] One logical, additive change; no new env vars / hooks / observers / registries
- [x] Focused tests added (default-equivalence, explicit-scope, invalid-scope fallback)
- [x] `scripts/run_tests.sh` green for the changed file + surrounding suites
- [x] `check-windows-footguns.py` clean
- [x] Conventional Commit, imperative, no trailing period
