### PR TITLE
feat(slack): make bot mention stripping configurable

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -943,6 +943,8 @@ def load_gateway_config() -> GatewayConfig:
                     bridged["reply_in_thread"] = platform_cfg["reply_in_thread"]
                 if "require_mention" in platform_cfg:
                     bridged["require_mention"] = platform_cfg["require_mention"]
+                if plat == Platform.SLACK and "strip_bot_mentions" in platform_cfg:
+                    bridged["strip_bot_mentions"] = platform_cfg["strip_bot_mentions"]
                 if plat == Platform.TELEGRAM and "allowed_chats" in platform_cfg:
                     bridged["allowed_chats"] = platform_cfg["allowed_chats"]
                 if plat == Platform.TELEGRAM and "group_allowed_chats" in platform_cfg:
@@ -1037,6 +1039,8 @@ def load_gateway_config() -> GatewayConfig:
                     os.environ["SLACK_REQUIRE_MENTION"] = str(slack_cfg["require_mention"]).lower()
                 if "strict_mention" in slack_cfg and not os.getenv("SLACK_STRICT_MENTION"):
                     os.environ["SLACK_STRICT_MENTION"] = str(slack_cfg["strict_mention"]).lower()
+                if "strip_bot_mentions" in slack_cfg and not os.getenv("SLACK_STRIP_BOT_MENTIONS"):
+                    os.environ["SLACK_STRIP_BOT_MENTIONS"] = str(slack_cfg["strip_bot_mentions"]).lower()
                 if "allow_bots" in slack_cfg and not os.getenv("SLACK_ALLOW_BOTS"):
                     os.environ["SLACK_ALLOW_BOTS"] = str(slack_cfg["allow_bots"]).lower()
                 frc = slack_cfg.get("free_response_channels")

--- a/gateway/platforms/slack.py
+++ b/gateway/platforms/slack.py
@@ -2522,9 +2522,10 @@ class SlackAdapter(BasePlatformAdapter):
                 ):
                     return
 
-        if is_mentioned:
+        if is_mentioned and self._slack_strip_bot_mentions():
             # Strip the bot mention from the text
             text = text.replace(f"<@{bot_uid}>", "").strip()
+        if is_mentioned:
             # Register this thread so all future messages auto-trigger the bot.
             # Skipped in strict mode: strict_mention=true bots must be
             # re-mentioned every turn, so remembering the thread would
@@ -3410,7 +3411,7 @@ class SlackAdapter(BasePlatformAdapter):
                     continue
 
                 # Strip bot mentions from context messages
-                if bot_uid:
+                if bot_uid and self._slack_strip_bot_mentions():
                     msg_text = msg_text.replace(f"<@{bot_uid}>", "").strip()
 
                 prefix = "[thread parent] " if is_parent else ""
@@ -3480,7 +3481,7 @@ class SlackAdapter(BasePlatformAdapter):
                 return ""
             bot_uid = self._team_bot_user_ids.get(team_id, self._bot_user_id)
             text = (parent.get("text") or "").strip()
-            if bot_uid:
+            if bot_uid and self._slack_strip_bot_mentions():
                 text = text.replace(f"<@{bot_uid}>", "").strip()
             return text
         except Exception as exc:  # pragma: no cover - defensive
@@ -3778,6 +3779,24 @@ class SlackAdapter(BasePlatformAdapter):
             "1",
             "yes",
             "on",
+        }
+
+    def _slack_strip_bot_mentions(self) -> bool:
+        """Return whether Slack bot mention tokens are removed from prompt text.
+
+        Defaults to True to preserve existing behavior. Explicit false values
+        keep the raw ``<@U...>`` tokens in current and fetched thread text.
+        """
+        configured = self.config.extra.get("strip_bot_mentions")
+        if configured is not None:
+            if isinstance(configured, str):
+                return configured.lower() not in {"false", "0", "no", "off"}
+            return bool(configured)
+        return os.getenv("SLACK_STRIP_BOT_MENTIONS", "true").lower() not in {
+            "false",
+            "0",
+            "no",
+            "off",
         }
 
     def _slack_free_response_channels(self) -> set:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -312,6 +312,7 @@ _HERMES_BEHAVIORAL_VARS = frozenset({
     # Force-clear on every test setup so the leak can't happen.
     "SLACK_REQUIRE_MENTION",
     "SLACK_STRICT_MENTION",
+    "SLACK_STRIP_BOT_MENTIONS",
     "SLACK_FREE_RESPONSE_CHANNELS",
     "SLACK_ALLOW_BOTS",
     "SLACK_REACTIONS",

--- a/tests/gateway/test_slack.py
+++ b/tests/gateway/test_slack.py
@@ -1802,6 +1802,21 @@ class TestMessageRouting:
         assert "<@U_BOT>" not in msg_event.text
 
     @pytest.mark.asyncio
+    async def test_channel_mention_preserves_bot_id_when_config_false(self, adapter):
+        """strip_bot_mentions=false keeps the mention token in MessageEvent text."""
+        adapter.config.extra["strip_bot_mentions"] = False
+        event = {
+            "text": "<@U_BOT> what's the weather?",
+            "user": "U_USER",
+            "channel": "C123",
+            "channel_type": "channel",
+            "ts": "1234567890.000001",
+        }
+        await adapter._handle_slack_message(event)
+        msg_event = adapter.handle_message.call_args[0][0]
+        assert msg_event.text == "<@U_BOT> what's the weather?"
+
+    @pytest.mark.asyncio
     async def test_bot_messages_ignored(self, adapter):
         """Messages from bots should be ignored."""
         event = {
@@ -3474,7 +3489,7 @@ class TestSlackReplyToText:
                     {
                         "ts": "1000.0",
                         "bot_id": "B_CRON",
-                        "text": "メール要約: 新着メール3件あります",
+                        "text": "<@U_BOT> メール要約: 新着メール3件あります",
                     },
                     {"ts": "1000.5", "user": "U_USER", "text": "詳細を教えて"},
                 ]
@@ -3505,6 +3520,45 @@ class TestSlackReplyToText:
         # gateway can inject it when not already in the session history.
         assert msg_event.reply_to_text is not None
         assert "メール要約" in msg_event.reply_to_text
+        assert "<@U_BOT>" not in msg_event.reply_to_text
+
+    @pytest.mark.asyncio
+    async def test_slack_reply_to_text_preserves_bot_mention_when_config_false(
+        self, adapter
+    ):
+        adapter.config.extra["strip_bot_mentions"] = False
+        adapter._channel_team = {}
+        adapter._team_bot_user_ids = {}
+
+        adapter._app.client.conversations_replies = AsyncMock(
+            return_value={
+                "messages": [
+                    {
+                        "ts": "1000.0",
+                        "bot_id": "B_CRON",
+                        "text": "<@U_BOT> Parent summary",
+                    },
+                    {"ts": "1000.5", "user": "U_USER", "text": "details"},
+                ]
+            }
+        )
+
+        event = {
+            "text": "details",
+            "user": "U_USER",
+            "channel": "D123",
+            "channel_type": "im",
+            "ts": "1000.5",
+            "thread_ts": "1000.0",
+        }
+
+        with patch.object(
+            adapter, "_resolve_user_name", new=AsyncMock(return_value="Alice")
+        ):
+            await adapter._handle_slack_message(event)
+
+        msg_event = adapter.handle_message.call_args[0][0]
+        assert msg_event.reply_to_text == "<@U_BOT> Parent summary"
 
     @pytest.mark.asyncio
     async def test_slack_reply_to_text_none_for_top_level_message(self, adapter):

--- a/tests/gateway/test_slack_approval_buttons.py
+++ b/tests/gateway/test_slack_approval_buttons.py
@@ -361,7 +361,7 @@ class TestSlackThreadContext:
         mock_client.conversations_replies = AsyncMock(return_value={
             "messages": [
                 {"ts": "1000.0", "user": "U1", "text": "This is the parent message"},
-                {"ts": "1000.1", "user": "U2", "text": "I think we should refactor"},
+                {"ts": "1000.1", "user": "U2", "text": "<@U_BOT> I think we should refactor"},
                 {"ts": "1000.2", "user": "U1", "text": "Good idea, <@U_BOT> what do you think?"},
             ]
         })
@@ -383,6 +383,31 @@ class TestSlackThreadContext:
         assert "what do you think" not in context
         # Bot mention should be stripped from context
         assert "<@U_BOT>" not in context
+
+    @pytest.mark.asyncio
+    async def test_fetch_thread_context_preserves_bot_mentions_when_config_false(self):
+        adapter = _make_adapter()
+        adapter.config.extra["strip_bot_mentions"] = False
+        mock_client = adapter._team_clients["T1"]
+        mock_client.conversations_replies = AsyncMock(return_value={
+            "messages": [
+                {"ts": "1000.0", "user": "U1", "text": "<@U_BOT> parent"},
+                {"ts": "1000.1", "user": "U2", "text": "prior <@U_BOT> reply"},
+                {"ts": "1000.2", "user": "U1", "text": "current <@U_BOT>"},
+            ]
+        })
+        adapter._user_name_cache = {"U1": "Alice", "U2": "Bob"}
+
+        context = await adapter._fetch_thread_context(
+            channel_id="C1",
+            thread_ts="1000.0",
+            current_ts="1000.2",
+            team_id="T1",
+        )
+
+        assert "[thread parent] Alice: <@U_BOT> parent" in context
+        assert "Bob: prior <@U_BOT> reply" in context
+        assert "current <@U_BOT>" not in context
 
     @pytest.mark.asyncio
     async def test_skips_bot_messages(self):
@@ -606,6 +631,39 @@ class TestSlackThreadContext:
         assert parent == "Parent summary"
         # No additional API call
         assert mock_client.conversations_replies.await_count == 1
+
+    @pytest.mark.asyncio
+    async def test_fetch_thread_parent_text_strips_bot_mention_by_default(self):
+        adapter = _make_adapter()
+        mock_client = adapter._team_clients["T1"]
+        mock_client.conversations_replies = AsyncMock(return_value={
+            "messages": [
+                {"ts": "1000.0", "user": "U1", "text": "<@U_BOT> Parent summary"},
+            ]
+        })
+
+        parent = await adapter._fetch_thread_parent_text(
+            channel_id="C1", thread_ts="1000.0", team_id="T1"
+        )
+
+        assert parent == "Parent summary"
+
+    @pytest.mark.asyncio
+    async def test_fetch_thread_parent_text_preserves_bot_mention_when_config_false(self):
+        adapter = _make_adapter()
+        adapter.config.extra["strip_bot_mentions"] = False
+        mock_client = adapter._team_clients["T1"]
+        mock_client.conversations_replies = AsyncMock(return_value={
+            "messages": [
+                {"ts": "1000.0", "user": "U1", "text": "<@U_BOT> Parent summary"},
+            ]
+        })
+
+        parent = await adapter._fetch_thread_parent_text(
+            channel_id="C1", thread_ts="1000.0", team_id="T1"
+        )
+
+        assert parent == "<@U_BOT> Parent summary"
 
 
 # ===========================================================================

--- a/tests/gateway/test_slack_mention.py
+++ b/tests/gateway/test_slack_mention.py
@@ -55,7 +55,13 @@ CHANNEL_ID = "C0AQWDLHY9M"
 OTHER_CHANNEL_ID = "C9999999999"
 
 
-def _make_adapter(require_mention=None, strict_mention=None, free_response_channels=None, allowed_channels=None):
+def _make_adapter(
+    require_mention=None,
+    strict_mention=None,
+    free_response_channels=None,
+    allowed_channels=None,
+    strip_bot_mentions=None,
+):
     extra = {}
     if require_mention is not None:
         extra["require_mention"] = require_mention
@@ -65,6 +71,8 @@ def _make_adapter(require_mention=None, strict_mention=None, free_response_chann
         extra["free_response_channels"] = free_response_channels
     if allowed_channels is not None:
         extra["allowed_channels"] = allowed_channels
+    if strip_bot_mentions is not None:
+        extra["strip_bot_mentions"] = strip_bot_mentions
 
     adapter = object.__new__(SlackAdapter)
     adapter.platform = Platform.SLACK
@@ -178,6 +186,32 @@ def test_strict_mention_env_var_fallback(monkeypatch):
     monkeypatch.setenv("SLACK_STRICT_MENTION", "true")
     adapter = _make_adapter()  # no config value -> falls back to env
     assert adapter._slack_strict_mention() is True
+
+
+# ---------------------------------------------------------------------------
+# Tests: _slack_strip_bot_mentions
+# ---------------------------------------------------------------------------
+
+def test_strip_bot_mentions_defaults_to_true(monkeypatch):
+    monkeypatch.delenv("SLACK_STRIP_BOT_MENTIONS", raising=False)
+    adapter = _make_adapter()
+    assert adapter._slack_strip_bot_mentions() is True
+
+
+def test_strip_bot_mentions_false():
+    adapter = _make_adapter(strip_bot_mentions=False)
+    assert adapter._slack_strip_bot_mentions() is False
+
+
+def test_strip_bot_mentions_string_off():
+    adapter = _make_adapter(strip_bot_mentions="off")
+    assert adapter._slack_strip_bot_mentions() is False
+
+
+def test_strip_bot_mentions_env_var_fallback(monkeypatch):
+    monkeypatch.setenv("SLACK_STRIP_BOT_MENTIONS", "false")
+    adapter = _make_adapter()
+    assert adapter._slack_strip_bot_mentions() is False
 
 
 # ---------------------------------------------------------------------------
@@ -514,6 +548,28 @@ def test_config_bridges_slack_strict_mention(monkeypatch, tmp_path):
     assert config is not None
     import os as _os
     assert _os.environ["SLACK_STRICT_MENTION"] == "true"
+
+
+def test_config_bridges_slack_strip_bot_mentions(monkeypatch, tmp_path):
+    from gateway.config import load_gateway_config
+
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir()
+    (hermes_home / "config.yaml").write_text(
+        "slack:\n"
+        "  strip_bot_mentions: false\n",
+        encoding="utf-8",
+    )
+
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.delenv("SLACK_STRIP_BOT_MENTIONS", raising=False)
+
+    config = load_gateway_config()
+
+    assert config is not None
+    assert config.platforms[Platform.SLACK].extra.get("strip_bot_mentions") is False
+    import os as _os
+    assert _os.environ["SLACK_STRIP_BOT_MENTIONS"] == "false"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- add Slack `strip_bot_mentions` config, defaulting to `true` to preserve existing behavior
- allow `strip_bot_mentions: false` to keep raw `<@U...>` bot mention tokens in current message text, fetched thread context, and thread-parent `reply_to_text`
- bridge the YAML setting into Slack platform extra config and `SLACK_STRIP_BOT_MENTIONS` env fallback

## Rationale / example scenario
In a shared Slack channel with two Hermes gateway profiles installed, a user might write:

```text
<@U_DEFAULT_HERMES> can you check the deployment?
```

while another Hermes bot/profile is also participating in the same thread. If the Slack adapter strips `<@U_DEFAULT_HERMES>` before the model sees the message, I only receive `can you check the deployment?`. That loses the key evidence for who was explicitly addressed.

An even more ambiguous case is a message that mentions one bot/profile but is addressed to another:

```text
<@U_DEFAULT_HERMES> can you check on <@U_OTHER_HERMES>'s deployment?
```

If the addressed mention is stripped, the model sees only `can you check on <@U_OTHER_HERMES>'s deployment?`. In a multi-bot thread, that can look like the remaining mentioned bot/profile is the intended addressee, even though the user was actually asking the default Hermes bot to inspect something belonging to the other profile.

Preserving the raw mention tokens when `strip_bot_mentions: false` gives the model the same routing clues Slack had at the adapter layer, so it can distinguish between:

- a request addressed to this bot;
- a request addressed to another Hermes profile;
- a request addressed to one bot about another bot/profile;
- a general thread reply that should not wake every bot that has prior context.

The default remains `true`, so existing single-bot workspaces keep the current cleaned-up prompt text unless they opt into preserving mentions.

## Test plan
- `python -m pytest tests/gateway/test_slack.py tests/gateway/test_slack_approval_buttons.py tests/gateway/test_slack_mention.py -q -o 'addopts='`
- `git diff --check`
- `python -m py_compile gateway/platforms/slack.py gateway/config.py tests/gateway/test_slack.py tests/gateway/test_slack_approval_buttons.py tests/gateway/test_slack_mention.py tests/conftest.py`
