### PR TITLE
fix(gateway): scope /fast and /reasoning overrides to the session

### DIFF
--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -2348,7 +2348,11 @@ def test_config_set_fast_updates_live_agent_and_config(monkeypatch):
             "foo": "bar",
             "service_tier": "priority",
         }
-        assert ("agent.service_tier", "fast") in writes
+        # Session-scoped (with a session_id): the toggle updates the live agent
+        # and parks on the session's build-time override, but NEVER writes global
+        # config — a per-session /fast must not clobber the profile default.
+        assert writes == []
+        assert server._sessions["sid"]["create_service_tier_override"] == "priority"
         assert ("session.info", "sid", {"model": "x"}) in emits
 
         resp_normal = server.handle_request(
@@ -2361,7 +2365,8 @@ def test_config_set_fast_updates_live_agent_and_config(monkeypatch):
         assert resp_normal["result"]["value"] == "normal"
         assert agent.service_tier is None
         assert agent.request_overrides == {"foo": "bar"}
-        assert ("agent.service_tier", "normal") in writes
+        assert writes == []
+        assert server._sessions["sid"]["create_service_tier_override"] is None
     finally:
         server._sessions.pop("sid", None)
 

--- a/tests/tui_gateway/test_session_scoped_fast_reasoning.py
+++ b/tests/tui_gateway/test_session_scoped_fast_reasoning.py
@@ -1,0 +1,258 @@
+"""Session-scoping for the /fast and /reasoning gateway config handlers.
+
+``config.set`` for ``fast`` / ``reasoning`` used to write the user's GLOBAL
+config (``agent.service_tier`` / ``agent.reasoning_effort``) unconditionally,
+so toggling either for a single session clobbered the profile default. These
+toggles are session-scoped: with a ``session_id`` in scope the pick is parked
+on the session's existing ``create_service_tier_override`` /
+``create_reasoning_override`` (the same fields ``session.create`` seeds and
+``_start_agent_build`` applies at agent BUILD time, mirroring
+``model_override``) and global config is never touched.
+
+Without a ``session_id`` the global path is unchanged.
+"""
+
+from __future__ import annotations
+
+import yaml
+
+from hermes_constants import (
+    parse_reasoning_effort,
+    reset_hermes_home_override,
+    set_hermes_home_override,
+)
+from tui_gateway import server
+
+
+# A model that supports OpenAI Priority Processing.
+_OPENAI_FAST_MODEL = "gpt-5.4"
+
+
+class _FakeAgent:
+    """Minimal stand-in carrying just the runtime attrs the handlers touch."""
+
+    def __init__(self, model: str = _OPENAI_FAST_MODEL):
+        self.model = model
+        self.service_tier = None
+        self.request_overrides: dict = {}
+        self.reasoning_config = None
+
+
+def _home(tmp_path, monkeypatch, *, model: str = _OPENAI_FAST_MODEL) -> object:
+    """Pin a clean HERMES_HOME so global config reads/writes hit tmp_path.
+
+    ``_load_cfg`` honors the home override; ``_save_cfg`` writes to the module
+    ``_hermes_home``. Pin both, and reset the cfg cache so reads see fresh
+    state. Returns a token to pass to :func:`reset_hermes_home_override`.
+    """
+    home = tmp_path / ".hermes"
+    home.mkdir(exist_ok=True)
+    token = set_hermes_home_override(str(home))
+    monkeypatch.setattr(server, "_hermes_home", home)
+    monkeypatch.setattr(server, "_resolve_model", lambda: model)
+    server._cfg_cache = None
+    server._cfg_mtime = None
+    server._cfg_path = None
+    return token
+
+
+def _global_cfg(tmp_path) -> dict:
+    path = tmp_path / ".hermes" / "config.yaml"
+    if not path.exists():
+        return {}
+    return yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+
+
+# ── /fast ────────────────────────────────────────────────────────────────────
+
+
+def test_fast_without_session_writes_global(tmp_path, monkeypatch):
+    """No session_id -> global config path is unchanged."""
+    token = _home(tmp_path, monkeypatch)
+    try:
+        server._sessions.clear()
+        res = server._methods["config.set"]("r1", {"key": "fast", "value": "fast"})
+        assert res["result"]["value"] == "fast"
+        # Global config WAS written (legacy global path).
+        assert _global_cfg(tmp_path).get("agent", {}).get("service_tier") == "fast"
+    finally:
+        server._sessions.clear()
+        server._cfg_cache = server._cfg_mtime = server._cfg_path = None
+        reset_hermes_home_override(token)
+
+
+def test_fast_with_session_parks_override_and_skips_global(tmp_path, monkeypatch):
+    """With a session_id (no live agent yet) -> park the override, never write global."""
+    token = _home(tmp_path, monkeypatch)
+    try:
+        sid = "sid-fast"
+        server._sessions.clear()
+        server._sessions[sid] = {
+            "session_key": "k-fast",
+            "agent": None,
+            "create_service_tier_override": None,
+        }
+        res = server._methods["config.set"](
+            "r1", {"key": "fast", "value": "fast", "session_id": sid}
+        )
+        assert res["result"]["value"] == "fast"
+        # Parked on the session's existing build-time override field.
+        assert server._sessions[sid]["create_service_tier_override"] == "priority"
+        # Global config was NOT touched.
+        assert "service_tier" not in _global_cfg(tmp_path).get("agent", {})
+    finally:
+        server._sessions.clear()
+        server._cfg_cache = server._cfg_mtime = server._cfg_path = None
+        reset_hermes_home_override(token)
+
+
+def test_fast_normal_with_session_parks_none_and_skips_global(tmp_path, monkeypatch):
+    """Setting normal in a session parks None (no explicit pick) and skips global."""
+    token = _home(tmp_path, monkeypatch)
+    try:
+        sid = "sid-fast-off"
+        server._sessions.clear()
+        server._sessions[sid] = {
+            "session_key": "k",
+            "agent": None,
+            "create_service_tier_override": "priority",
+        }
+        res = server._methods["config.set"](
+            "r1", {"key": "fast", "value": "normal", "session_id": sid}
+        )
+        assert res["result"]["value"] == "normal"
+        assert server._sessions[sid]["create_service_tier_override"] is None
+        assert "service_tier" not in _global_cfg(tmp_path).get("agent", {})
+    finally:
+        server._sessions.clear()
+        server._cfg_cache = server._cfg_mtime = server._cfg_path = None
+        reset_hermes_home_override(token)
+
+
+def test_fast_with_live_agent_updates_agent_not_global(tmp_path, monkeypatch):
+    """A live agent is updated in place (service_tier + request_overrides); global untouched."""
+    token = _home(tmp_path, monkeypatch)
+    try:
+        sid = "sid-live"
+        agent = _FakeAgent(model=_OPENAI_FAST_MODEL)
+        server._sessions.clear()
+        server._sessions[sid] = {
+            "session_key": "k",
+            "agent": agent,
+            "create_service_tier_override": None,
+        }
+        monkeypatch.setattr(server, "_persist_live_session_runtime", lambda s: None)
+        monkeypatch.setattr(server, "_emit", lambda *a, **k: None)
+        monkeypatch.setattr(server, "_session_info", lambda a, s: {})
+        res = server._methods["config.set"](
+            "r1", {"key": "fast", "value": "fast", "session_id": sid}
+        )
+        assert res["result"]["value"] == "fast"
+        assert agent.service_tier == "priority"
+        assert agent.request_overrides == {"service_tier": "priority"}
+        assert server._sessions[sid]["create_service_tier_override"] == "priority"
+        assert "service_tier" not in _global_cfg(tmp_path).get("agent", {})
+    finally:
+        server._sessions.clear()
+        server._cfg_cache = server._cfg_mtime = server._cfg_path = None
+        reset_hermes_home_override(token)
+
+
+# ── /reasoning ───────────────────────────────────────────────────────────────
+
+
+def test_reasoning_without_session_writes_global(tmp_path, monkeypatch):
+    """No session_id -> global config path is unchanged."""
+    token = _home(tmp_path, monkeypatch)
+    try:
+        server._sessions.clear()
+        res = server._methods["config.set"](
+            "r1", {"key": "reasoning", "value": "high"}
+        )
+        assert res["result"]["value"] == "high"
+        assert _global_cfg(tmp_path).get("agent", {}).get("reasoning_effort") == "high"
+    finally:
+        server._sessions.clear()
+        server._cfg_cache = server._cfg_mtime = server._cfg_path = None
+        reset_hermes_home_override(token)
+
+
+def test_reasoning_with_session_parks_override_and_skips_global(tmp_path, monkeypatch):
+    """With a session_id (no live agent) -> park parsed override, never write global."""
+    token = _home(tmp_path, monkeypatch)
+    try:
+        sid = "sid-reason"
+        server._sessions.clear()
+        server._sessions[sid] = {
+            "session_key": "k",
+            "agent": None,
+            "create_reasoning_override": None,
+        }
+        res = server._methods["config.set"](
+            "r1", {"key": "reasoning", "value": "high", "session_id": sid}
+        )
+        assert res["result"]["value"] == "high"
+        assert server._sessions[sid]["create_reasoning_override"] == parse_reasoning_effort("high")
+        assert "reasoning_effort" not in _global_cfg(tmp_path).get("agent", {})
+    finally:
+        server._sessions.clear()
+        server._cfg_cache = server._cfg_mtime = server._cfg_path = None
+        reset_hermes_home_override(token)
+
+
+def test_reasoning_with_live_agent_updates_agent_not_global(tmp_path, monkeypatch):
+    """A live agent's reasoning_config is updated; global config untouched."""
+    token = _home(tmp_path, monkeypatch)
+    try:
+        sid = "sid-reason-live"
+        agent = _FakeAgent()
+        server._sessions.clear()
+        server._sessions[sid] = {
+            "session_key": "k",
+            "agent": agent,
+            "create_reasoning_override": None,
+        }
+        monkeypatch.setattr(server, "_persist_live_session_runtime", lambda s: None)
+        monkeypatch.setattr(server, "_emit", lambda *a, **k: None)
+        monkeypatch.setattr(server, "_session_info", lambda a, s: {})
+        res = server._methods["config.set"](
+            "r1", {"key": "reasoning", "value": "low", "session_id": sid}
+        )
+        assert res["result"]["value"] == "low"
+        assert agent.reasoning_config == parse_reasoning_effort("low")
+        assert server._sessions[sid]["create_reasoning_override"] == parse_reasoning_effort("low")
+        assert "reasoning_effort" not in _global_cfg(tmp_path).get("agent", {})
+    finally:
+        server._sessions.clear()
+        server._cfg_cache = server._cfg_mtime = server._cfg_path = None
+        reset_hermes_home_override(token)
+
+
+# ── config.get reads back the session pick ───────────────────────────────────
+
+
+def test_config_get_reflects_parked_session_overrides(tmp_path, monkeypatch):
+    """config.get fast/reasoning read the session's parked pick, not the global default."""
+    token = _home(tmp_path, monkeypatch)
+    try:
+        # Global default differs from the per-session pick.
+        server._write_config_key("agent.service_tier", "normal")
+        server._write_config_key("agent.reasoning_effort", "medium")
+        sid = "sid-get"
+        server._sessions.clear()
+        server._sessions[sid] = {
+            "session_key": "k",
+            "agent": None,
+            "create_service_tier_override": "priority",
+            "create_reasoning_override": parse_reasoning_effort("high"),
+        }
+        fast = server._methods["config.get"]("r1", {"key": "fast", "session_id": sid})
+        assert fast["result"]["value"] == "fast"
+        reasoning = server._methods["config.get"](
+            "r2", {"key": "reasoning", "session_id": sid}
+        )
+        assert reasoning["result"]["value"] == "high"
+    finally:
+        server._sessions.clear()
+        server._cfg_cache = server._cfg_mtime = server._cfg_path = None
+        reset_hermes_home_override(token)

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -7230,6 +7230,11 @@ def _(rid, params: dict) -> dict:
         agent = session.get("agent") if session else None
         if agent is not None:
             current_fast = getattr(agent, "service_tier", None) == "priority"
+        elif session and session.get("create_service_tier_override") is not None:
+            # Session-scoped: a value parked before the agent built is this
+            # session's state; status/toggle must reflect it, not the global
+            # default. ``None`` means "no explicit pick" — fall through.
+            current_fast = session.get("create_service_tier_override") == "priority"
         else:
             current_fast = _load_service_tier() == "priority"
 
@@ -7269,7 +7274,17 @@ def _(rid, params: dict) -> dict:
                     "fast mode is not available for this model",
                 )
 
-        _write_config_key("agent.service_tier", nv)
+        if not session:
+            _write_config_key("agent.service_tier", nv)
+        else:
+            # Session-scoped: never write global config. Park the pick on the
+            # session's existing ``create_service_tier_override`` (the same key
+            # session.create seeds and _start_agent_build applies at build time,
+            # mirroring ``model_override``). A pre-build value lands at build; a
+            # live agent is updated below.
+            session["create_service_tier_override"] = (
+                "priority" if nv == "fast" else None
+            )
         if agent is not None:
             agent.service_tier = "priority" if nv == "fast" else None
             current_overrides = dict(getattr(agent, "request_overrides", {}) or {})
@@ -7442,15 +7457,23 @@ def _(rid, params: dict) -> dict:
             parsed = parse_reasoning_effort(arg)
             if parsed is None:
                 return _err(rid, 4002, f"unknown reasoning value: {value}")
-            _write_config_key("agent.reasoning_effort", arg)
-            if session and session.get("agent") is not None:
-                session["agent"].reasoning_config = parsed
-                _persist_live_session_runtime(session)
-                _emit(
-                    "session.info",
-                    params.get("session_id", ""),
-                    _session_info(session["agent"], session),
-                )
+            if not session:
+                _write_config_key("agent.reasoning_effort", arg)
+            else:
+                # Session-scoped: never write global config. Park the pick on
+                # the session's existing ``create_reasoning_override`` (the same
+                # key session.create seeds and _start_agent_build applies at
+                # build time, mirroring ``model_override``). A pre-build value
+                # lands at build; a live agent is updated below.
+                session["create_reasoning_override"] = parsed
+                if session.get("agent") is not None:
+                    session["agent"].reasoning_config = parsed
+                    _persist_live_session_runtime(session)
+                    _emit(
+                        "session.info",
+                        params.get("session_id", ""),
+                        _session_info(session["agent"], session),
+                    )
             return _ok(rid, {"key": key, "value": arg})
         except Exception as e:
             return _err(rid, 5001, str(e))
@@ -7693,9 +7716,27 @@ def _(rid, params: dict) -> dict:
         )
     if key == "reasoning":
         cfg = _load_cfg()
-        effort = str(
-            (cfg.get("agent") or {}).get("reasoning_effort", "medium") or "medium"
-        )
+        # Prefer the session's own reasoning state (live agent, then a value
+        # parked before the agent built) over the global default — /reasoning
+        # is session-scoped, so config.get must read back the session's pick.
+        session = _sessions.get(params.get("session_id", ""))
+        reasoning_cfg = None
+        if session is not None:
+            agent = session.get("agent")
+            if agent is not None and getattr(agent, "reasoning_config", None):
+                reasoning_cfg = agent.reasoning_config
+            elif isinstance(session.get("create_reasoning_override"), dict):
+                reasoning_cfg = session.get("create_reasoning_override")
+        if isinstance(reasoning_cfg, dict):
+            effort = (
+                "none"
+                if reasoning_cfg.get("enabled") is False
+                else str(reasoning_cfg.get("effort") or "medium")
+            )
+        else:
+            effort = str(
+                (cfg.get("agent") or {}).get("reasoning_effort", "medium") or "medium"
+            )
         display = (
             "show"
             if bool((cfg.get("display") or {}).get("show_reasoning", False))
@@ -7703,18 +7744,15 @@ def _(rid, params: dict) -> dict:
         )
         return _ok(rid, {"value": effort, "display": display})
     if key == "fast":
-        return _ok(
-            rid,
-            {
-                "value": (
-                    "fast"
-                    if (session := _sessions.get(params.get("session_id", "")))
-                    and getattr(session.get("agent"), "service_tier", None)
-                    == "priority"
-                    else ("fast" if _load_service_tier() == "priority" else "normal")
-                ),
-            },
-        )
+        session = _sessions.get(params.get("session_id", ""))
+        if session and session.get("agent") is not None:
+            current_fast = getattr(session["agent"], "service_tier", None) == "priority"
+        elif session and session.get("create_service_tier_override") is not None:
+            # A value parked before the agent built is this session's state.
+            current_fast = session.get("create_service_tier_override") == "priority"
+        else:
+            current_fast = _load_service_tier() == "priority"
+        return _ok(rid, {"value": "fast" if current_fast else "normal"})
     if key == "busy":
         return _ok(rid, {"value": _load_busy_input_mode()})
     if key == "details_mode":


### PR DESCRIPTION
## What does this PR do?

`config.set` for `fast`/`reasoning` wrote the user's global config
(`agent.service_tier` / `agent.reasoning_effort`) unconditionally, so toggling
either for a single session clobbered the profile default that every other session
and the CLI/cron inherit.

Root cause: both branches called `_write_config_key(...)` with no per-session
guard, while the model path already scopes per-session via
`session["model_override"]`. These toggles are session-scoped: when a `session_id`
is in scope the pick is parked on the session's existing
`create_service_tier_override` / `create_reasoning_override` fields — the same
fields `session.create` seeds and `_start_agent_build` consumes at agent build
time, mirroring `model_override` — and global config is never touched. With no
`session_id` the global path is unchanged.

`config.get` for `fast`/`reasoning` now reads back the session's own pick (live
agent first, then a value parked before the agent built) instead of the global
default.

## Related Issue

N/A

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tui_gateway/server.py` — `config.set` fast/reasoning: when a `session_id` is in
  scope, park the pick on the session's `create_service_tier_override` /
  `create_reasoning_override` (no global write); with no `session_id`, the global
  path is unchanged; live agents are still updated in place. `config.get`
  fast/reasoning reads back the session's pick before the global default.
- `tests/tui_gateway/test_session_scoped_fast_reasoning.py` (new): 8 tests — no
  `session_id` → global path unchanged (fast + reasoning); with `session_id` →
  parks the override and leaves global untouched (fast + reasoning, pre-build and
  live-agent); `config.get` reflects the parked pick.
- `tests/test_tui_gateway_server.py`: updated the test that previously asserted the
  global clobber for a session-scoped toggle to assert the corrected behavior.

## How to Test

1. `scripts/run_tests.sh tests/tui_gateway/test_session_scoped_fast_reasoning.py`
   → 8 passed.
2. Manual: in one session run `/fast` (or `/reasoning high`); confirm the global
   `config.yaml` `agent.service_tier` / `agent.reasoning_effort` is unchanged and a
   sibling session keeps the profile default.

## Checklist

- [x] One logical change; no new env vars, hooks, registries, or observers
- [x] Override parked at `config.set`, applied at agent BUILD; prompt cache /
      toolset never rebuilt mid-conversation
- [x] Focused tests next to where fast/reasoning config is tested
- [x] `scripts/run_tests.sh` green (only a pre-existing env-dependent browser
      failure remains, also failing on clean `main`)
- [x] `check-windows-footguns.py` clean; Conventional Commit
