### PR TITLE
fix(gateway): send every tool-progress event in separate grouping mode

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -14136,7 +14136,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
             progress_lines = []      # Accumulated tool lines for the CURRENT editable bubble
             progress_msg_id = None   # ID of the current progress message to edit
-            can_edit = progress_grouping != "separate"  # "separate" = one message per tool (pre-v0.9 behavior)
+            separate_grouping = progress_grouping == "separate"  # one message per tool (pre-v0.9 behavior)
+            can_edit = not separate_grouping  # also flips to False if an edit later fails (see below)
             _last_edit_ts = 0.0      # Throttle edits to avoid Telegram flood control
             _PROGRESS_EDIT_INTERVAL = 1.5  # Minimum seconds between edits
 
@@ -14319,14 +14320,25 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     # API calls to avoid hitting Telegram flood control.
                     # (grammY auto-retry pattern: proactively rate-limit
                     # instead of reacting to 429s.)
-                    _now = time.monotonic()
-                    _remaining = _PROGRESS_EDIT_INTERVAL - (_now - _last_edit_ts)
-                    if _remaining > 0:
-                        # Wait out the throttle interval, then loop back to
-                        # drain any additional queued messages before sending
-                        # a single batched edit.
-                        await asyncio.sleep(_remaining)
-                        continue
+                    #
+                    # Skip this only for configured "separate" grouping, where
+                    # each tool is its own message sent below: the batch-and-
+                    # continue tick would silently drop it, because nothing
+                    # re-sends the buffered line if no further event wakes the
+                    # loop (rapid tool bursts then lose per-tool progress). Those
+                    # are sent immediately; the post-send sleep still paces them.
+                    # Accumulate grouping keeps the throttle even after an edit
+                    # failure flips can_edit off, so the send fallback stays
+                    # flood-protected.
+                    if not separate_grouping:
+                        _now = time.monotonic()
+                        _remaining = _PROGRESS_EDIT_INTERVAL - (_now - _last_edit_ts)
+                        if _remaining > 0:
+                            # Wait out the throttle interval, then loop back to
+                            # drain any additional queued messages before sending
+                            # a single batched edit.
+                            await asyncio.sleep(_remaining)
+                            continue
 
                     if not _run_still_current():
                         return

--- a/gateway/run_turn_runner.py
+++ b/gateway/run_turn_runner.py
@@ -672,10 +672,13 @@ class TurnRunner:
                     # Throttle edits: batch rapid tool updates into fewer API calls (grammY pattern:
                     # proactively rate-limit rather than react to 429s). Loop back to drain further
                     # queued messages before sending a single batched edit.
-                    remaining = EDIT_INTERVAL - (time.monotonic() - last_edit_ts)
-                    if remaining > 0:
-                        await asyncio.sleep(remaining)
-                        continue
+                    # Separate grouping has no batched edit to flush a deferred line.
+                    # Keep accumulate throttling even after an edit failure disables editing.
+                    if ctx.progress_grouping != "separate":
+                        remaining = EDIT_INTERVAL - (time.monotonic() - last_edit_ts)
+                        if remaining > 0:
+                            await asyncio.sleep(remaining)
+                            continue
                     if not ctx._run_still_current():
                         return
                     if not await self._progress_send_or_edit(st, msg):

--- a/tests/gateway/test_run_progress_topics.py
+++ b/tests/gateway/test_run_progress_topics.py
@@ -294,6 +294,67 @@ async def test_run_agent_progress_stays_in_originating_topic(monkeypatch, tmp_pa
 
 
 @pytest.mark.asyncio
+async def test_separate_grouping_sends_each_tool_without_editing(monkeypatch, tmp_path):
+    """display.tool_progress_grouping="separate" must send one message per tool.
+
+    Rapid tool.started events (closer together than the edit throttle interval)
+    must each be delivered as their own message and the progress bubble must
+    never be edited. Regression for separate-mode bursts silently losing
+    per-tool progress, because the edit throttle's batch-and-continue tick only
+    makes sense for accumulate grouping (follow-up to #47228).
+    """
+    monkeypatch.setenv("HERMES_TOOL_PROGRESS_MODE", "all")
+
+    import yaml
+    (tmp_path / "config.yaml").write_text(
+        yaml.dump({"display": {"tool_progress_grouping": "separate"}}),
+        encoding="utf-8",
+    )
+
+    fake_dotenv = types.ModuleType("dotenv")
+    fake_dotenv.load_dotenv = lambda *args, **kwargs: None
+    monkeypatch.setitem(sys.modules, "dotenv", fake_dotenv)
+
+    fake_run_agent = types.ModuleType("run_agent")
+    fake_run_agent.AIAgent = FakeAgent
+    monkeypatch.setitem(sys.modules, "run_agent", fake_run_agent)
+    import tools.terminal_tool  # noqa: F401 - register terminal emoji for this fake-agent test
+
+    adapter = ProgressCaptureAdapter()
+    runner = _make_runner(adapter)
+    gateway_run = importlib.import_module("gateway.run")
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.setattr(gateway_run, "_resolve_runtime_agent_kwargs", lambda: {"api_key": "fake"})
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="-1001",
+        chat_type="group",
+        thread_id="17585",
+    )
+
+    result = await runner._run_agent(
+        message="hello",
+        context_prompt="",
+        history=[],
+        source=source,
+        session_id="sess-separate-grouping",
+        session_key="agent:main:telegram:group:-1001:17585",
+    )
+
+    assert result["final_response"] == "done"
+    # Separate grouping must never edit a shared bubble.
+    assert adapter.edits == []
+    # Both rapid tool.started events are delivered as their own messages — the
+    # second must not be dropped by the edit throttle (accumulate-only).
+    assert len(adapter.sent) == 2, f"expected one message per tool, got {adapter.sent}"
+    assert "pwd" in adapter.sent[0]["content"]
+    assert (
+        "example.com" in adapter.sent[1]["content"]
+        or "browser_navigate" in adapter.sent[1]["content"]
+    )
+
+
+@pytest.mark.asyncio
 async def test_run_agent_progress_edits_keep_originating_topic_metadata(monkeypatch, tmp_path):
     monkeypatch.setenv("HERMES_TOOL_PROGRESS_MODE", "all")
 

--- a/tests/gateway/test_run_progress_topics.py
+++ b/tests/gateway/test_run_progress_topics.py
@@ -1937,3 +1937,108 @@ class TestSlackReplyInThreadProgressRouting:
             event_message_id="evt-trigger-001",
             reply_in_thread=True,
         ) == "evt-trigger-001"
+
+
+@pytest.mark.asyncio
+async def test_separate_grouping_sends_each_tool_without_editing(monkeypatch, tmp_path):
+    """display.tool_progress_grouping="separate" must send one message per tool.
+
+    Rapid tool.started events (closer together than the edit throttle interval)
+    must each be delivered as their own message and the progress bubble must
+    never be edited. Regression for separate-mode bursts silently losing
+    per-tool progress, because the edit throttle's batch-and-continue tick only
+    makes sense for accumulate grouping (follow-up to #47228).
+    """
+    monkeypatch.setenv("HERMES_TOOL_PROGRESS_MODE", "all")
+
+    import yaml
+    (tmp_path / "config.yaml").write_text(
+        yaml.dump({"display": {"tool_progress_grouping": "separate"}}),
+        encoding="utf-8",
+    )
+
+    fake_dotenv = types.ModuleType("dotenv")
+    fake_dotenv.load_dotenv = lambda *args, **kwargs: None
+    monkeypatch.setitem(sys.modules, "dotenv", fake_dotenv)
+
+    fake_run_agent = types.ModuleType("run_agent")
+    fake_run_agent.AIAgent = FakeAgent
+    monkeypatch.setitem(sys.modules, "run_agent", fake_run_agent)
+    import tools.terminal_tool  # noqa: F401 - register terminal emoji for this fake-agent test
+
+    adapter = ProgressCaptureAdapter()
+    runner = _make_runner(adapter)
+    gateway_run = importlib.import_module("gateway.run")
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.setattr(gateway_run, "_resolve_runtime_agent_kwargs", lambda: {"api_key": "fake"})
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="-1001",
+        chat_type="group",
+        thread_id="17585",
+    )
+
+    result = await runner._run_agent(
+        message="hello",
+        context_prompt="",
+        history=[],
+        source=source,
+        session_id="sess-separate-grouping",
+        session_key="agent:main:telegram:group:-1001:17585",
+    )
+
+    assert result["final_response"] == "done"
+    # Separate grouping must never edit a shared bubble.
+    assert adapter.edits == []
+    # Both rapid tool.started events are delivered as their own messages — the
+    # second must not be dropped by the edit throttle (accumulate-only).
+    assert len(adapter.sent) == 2, f"expected one message per tool, got {adapter.sent}"
+    assert "pwd" in adapter.sent[0]["content"]
+    assert (
+        "example.com" in adapter.sent[1]["content"]
+        or "browser_navigate" in adapter.sent[1]["content"]
+    )
+
+
+@pytest.mark.asyncio
+async def test_accumulate_throttles_after_permanent_edit_failure(monkeypatch):
+    """Losing edit support must not turn accumulated progress into unpaced sends."""
+    import queue
+    import gateway.run_turn_runner as turn_runner_module
+    from gateway.run_turn_runner import TurnRunner
+    from gateway.turn_context import TurnContext
+
+    class FailingEditAdapter(ProgressCaptureAdapter):
+        async def edit_message(self, chat_id, message_id, content):
+            self.edits.append(content)
+            return SendResult(success=False, error="message to edit not found")
+
+    adapter = FailingEditAdapter()
+    clock = [100.0]
+    delays = []
+    active = [True]
+    pending = queue.Queue()
+    for line in ("first", "second", "third", "fourth"):
+        pending.put(line)
+
+    async def advance(delay):
+        delays.append(delay)
+        clock[0] += delay
+        if pending.empty():
+            active[0] = False
+
+    monkeypatch.setattr(turn_runner_module, "time", SimpleNamespace(monotonic=lambda: clock[0]))
+    monkeypatch.setattr(turn_runner_module, "asyncio", SimpleNamespace(
+        sleep=advance, CancelledError=asyncio.CancelledError,
+    ))
+    ctx = TurnContext(
+        source=SessionSource(platform=Platform.TELEGRAM, chat_id="test"),
+        progress_grouping="accumulate", progress_queue=pending,
+        _run_still_current=lambda: active[0],
+    )
+    turn = TurnRunner(SimpleNamespace(_adapter_for_source=lambda source: adapter), ctx)
+    await turn.send_progress_messages()
+
+    assert adapter.edits  # Exercise the real permanent-failure fallback.
+    assert len([delay for delay in delays if delay > 0.3]) == 2
+    assert all(item["content"] != "fourth" for item in adapter.sent)


### PR DESCRIPTION
Follow-up to #47228, which added `display.tool_progress_grouping = separate` (one message per tool, `can_edit = False`).

## Bug

In `separate` grouping the edit throttle in `send_progress_messages` still runs. A `tool.started` event arriving within the 1.5s `_PROGRESS_EDIT_INTERVAL` is appended to `progress_lines`, then the loop does `await asyncio.sleep(_remaining); continue` — expecting a later **batched edit** to flush the buffered line. But with editing disabled (`can_edit = False`) that batched edit never happens, and the separate-mode send path emits only the *current* line (`content=msg`). So a throttled event with no further event to wake the loop is **never sent**.

Net effect: under bursty multi-tool turns, `separate` mode silently drops exactly the extra per-tool visibility it advertises (and the cancellation drain is also `can_edit`-gated, so it doesn't recover them either).

## Fix

Gate the throttle on the configured grouping (`separate_grouping = progress_grouping == "separate"`) rather than `can_edit`. Separate-mode events are sent immediately (still paced by the existing post-send `sleep(0.3)`); accumulate grouping keeps the throttle **unchanged**, including the `can_edit = False` fallback after an edit failure — so its flood protection is preserved. The two states were previously conflated through `can_edit`.

```diff
-                    _now = time.monotonic()
-                    _remaining = _PROGRESS_EDIT_INTERVAL - (_now - _last_edit_ts)
-                    if _remaining > 0:
-                        await asyncio.sleep(_remaining)
-                        continue
+                    if not separate_grouping:
+                        _now = time.monotonic()
+                        _remaining = _PROGRESS_EDIT_INTERVAL - (_now - _last_edit_ts)
+                        if _remaining > 0:
+                            await asyncio.sleep(_remaining)
+                            continue
```

## Test

`tests/gateway/test_run_progress_topics.py::test_separate_grouping_sends_each_tool_without_editing` — drives the runner with `display.tool_progress_grouping = "separate"` and two rapid `tool.started` events, asserting both are delivered as their own messages and the bubble is never edited. Fails on the old throttle (second event dropped), passes with the fix.
