### PR TITLE
test(tui): accept macOS browser launch fallback hint

### DIFF
--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -6068,7 +6068,10 @@ def test_browser_manage_connect_default_local_reports_launch_hint(monkeypatch):
         == "Chromium-family browser isn't running with remote debugging — attempting to launch..."
     )
     assert any(
-        "No supported Chromium-family browser executable was found" in line
+        (
+            "No supported Chromium-family browser executable was found" in line
+            or "Start a Chromium-family browser with remote debugging" in line
+        )
         for line in resp["result"]["messages"]
     )
     assert any(


### PR DESCRIPTION
## Summary
- Allow the TUI browser-connect launch-hint test to accept the macOS `open -a "Google Chrome"` fallback hint.

## Why
`manual_chrome_debug_command()` intentionally returns a macOS `open -a` command even when no executable candidate path is discovered. The test currently only accepts the "No supported Chromium-family browser executable" branch, so it fails on macOS despite the user-facing fallback being valid.

## Test plan
- `./.venv/bin/python -m pytest tests/test_tui_gateway_server.py::test_browser_manage_connect_default_local_reports_launch_hint -o 'addopts=' -q -vv`
- `./.venv/bin/python -m pytest tests/test_tui_gateway_server.py -o 'addopts=' -q`
