### PR TITLE
fix(tools): isolate atomic write errexit

### DIFF
--- a/tests/tools/test_file_operations.py
+++ b/tests/tools/test_file_operations.py
@@ -563,6 +563,19 @@ class TestSearchFilesFallbackHiddenPaths:
         assert set(result.files) == {str(visible_file), str(visible_nested_file)}
 
 
+class TestShellFileOpsAtomicWrite:
+    def test_atomic_write_wraps_errexit_in_subshell(self, mock_env):
+        """Atomic writes use errexit without leaking it into wrapper shells."""
+        ops = ShellFileOperations(mock_env)
+
+        result = ops._atomic_write("/tmp/test.txt", "hello\n")
+
+        assert result.exit_code == 0
+        command = mock_env.execute.call_args.args[0]
+        assert command.startswith("( set -e; ")
+        assert command.endswith("trap - EXIT )")
+
+
 class TestShellFileOpsWriteDenied:
     def test_write_file_denied_path(self, file_ops):
         result = file_ops.write_file("~/.ssh/authorized_keys", "evil key")

--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -885,7 +885,7 @@ class ShellFileOperations(FileOperations):
         #    successful mv (the temp no longer exists by then).
         #  - we `cat >` the temp, then `mv -f` it over the target.
         script = (
-            "set -e; "
+            "( set -e; "
             f"d={q_parent}; t={q_path}; "
             'tmp="$(mktemp -p "$d" ' + tmpl + ' 2>/dev/null '
             '|| mktemp "$d/.hermes-tmp.$$.XXXXXX" 2>/dev/null '
@@ -899,7 +899,7 @@ class ShellFileOperations(FileOperations):
             "fi; "
             'cat > "$tmp"; '
             'mv -f "$tmp" "$t"; '
-            "trap - EXIT"
+            "trap - EXIT )"
         )
         return self._exec(script, stdin_data=content)
 


### PR DESCRIPTION
## Summary
- wrap the shell atomic-write script's `set -e` in a subshell so `errexit` cannot leak into the wrapper shell used by the terminal environment
- add regression coverage for the generated `_atomic_write()` command shape

## Why
`ShellFileOperations._atomic_write()` intentionally enables `set -e` for its temp-file/rename script. In persistent shell wrappers, that setting should stay local to the atomic-write snippet; otherwise later wrapper bookkeeping can be converted into a false failure if a benign command returns non-zero.

## Duplicate check
Before opening, I checked current open PRs for this exact issue:
- `"atomic_write" "trap"` — no results
- `errexit` — no results
- `"ShellFileOperations" "atomic"` — only unrelated patch/Slack PRs

## Test plan
- `python -m pytest tests/tools/test_file_operations.py::TestShellFileOpsAtomicWrite::test_atomic_write_wraps_errexit_in_subshell -q -o 'addopts='`
- `python -m pytest tests/tools/test_file_operations.py -q -o 'addopts='`
- `git diff --check`
- `python -m py_compile tools/file_operations.py tests/tools/test_file_operations.py`
