### PR TITLE
fix(web): render multimodal session messages safely

### DIFF
--- a/tests/gateway/test_session_api.py
+++ b/tests/gateway/test_session_api.py
@@ -170,6 +170,26 @@ async def test_session_crud_and_message_history(adapter, session_db):
 
 
 @pytest.mark.asyncio
+async def test_session_messages_preserve_multimodal_content(adapter, session_db):
+    session_id = session_db.create_session("multimodal-history", "api_server")
+    content = [
+        {"type": "text", "text": "Please inspect this image."},
+        {"type": "image_url", "image_url": {"url": "data:image/png;base64,AAAA"}},
+    ]
+    session_db.append_message(session_id, "user", content)
+
+    app = _create_session_app(adapter)
+    async with TestClient(TestServer(app)) as cli:
+        messages_resp = await cli.get(f"/api/sessions/{session_id}/messages")
+        assert messages_resp.status == 200
+        messages = await messages_resp.json()
+
+    assert messages["object"] == "list"
+    assert messages["data"][0]["role"] == "user"
+    assert messages["data"][0]["content"] == content
+
+
+@pytest.mark.asyncio
 async def test_session_messages_follow_compression_tip(adapter, session_db):
     source_id = session_db.create_session("source-session", "api_server")
     session_db.append_message(source_id, "user", "before compression")

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1661,9 +1661,24 @@ export interface TelegramOnboardingApplyResponse {
   restart_error?: string;
 }
 
+export interface SessionMessageTextPart {
+  type: "text" | "input_text" | "output_text";
+  text: string;
+}
+
+export interface SessionMessageImagePart {
+  type: "image_url" | "input_image";
+  image_url: string | { url: string; detail?: string };
+}
+
+export type SessionMessageContentPart =
+  | SessionMessageTextPart
+  | SessionMessageImagePart
+  | Record<string, unknown>;
+
 export interface SessionMessage {
   role: "user" | "assistant" | "system" | "tool";
-  content: string | null;
+  content: string | SessionMessageContentPart[] | null;
   tool_calls?: Array<{
     id: string;
     function: { name: string; arguments: string };

--- a/web/src/pages/SessionsPage.tsx
+++ b/web/src/pages/SessionsPage.tsx
@@ -33,6 +33,7 @@ import { api } from "@/lib/api";
 import type {
   SessionInfo,
   SessionMessage,
+  SessionMessageContentPart,
   SessionSearchResult,
   SessionStoreStats,
   StatusResponse,
@@ -145,6 +146,53 @@ function ToolCallBlock({
       )}
     </div>
   );
+}
+
+function getMessageTextContent(content: SessionMessage["content"]): string {
+  if (typeof content === "string") return content;
+  if (!Array.isArray(content)) return "";
+
+  const parts: string[] = [];
+  for (const part of content) {
+    if (
+      part &&
+      typeof part === "object" &&
+      "type" in part &&
+      "text" in part &&
+      (part.type === "text" ||
+        part.type === "input_text" ||
+        part.type === "output_text") &&
+      typeof part.text === "string"
+    ) {
+      parts.push(part.text);
+    }
+  }
+  return parts.join("\n\n");
+}
+
+function getMessageImageUrls(content: SessionMessage["content"]): string[] {
+  if (!Array.isArray(content)) return [];
+
+  const urls: string[] = [];
+  for (const part of content) {
+    const url = getMessageImageUrl(part);
+    if (url) urls.push(url);
+  }
+  return urls;
+}
+
+function getMessageImageUrl(part: SessionMessageContentPart): string | null {
+  if (!part || typeof part !== "object" || !("type" in part)) return null;
+  if (part.type !== "image_url" && part.type !== "input_image") return null;
+
+  const raw =
+    typeof part.image_url === "string"
+      ? part.image_url
+      : part.image_url?.url;
+  if (typeof raw !== "string") return null;
+
+  const normalized = raw.trim();
+  return /^(https?:\/\/|data:image\/)/i.test(normalized) ? normalized : null;
 }
 
 // Context-compaction handoff blocks are persisted as ``role="user"`` or
@@ -288,11 +336,13 @@ function MessageBubble({
     : msg.tool_name
       ? `${t.sessions.roles.tool}: ${msg.tool_name}`
       : style.label;
+  const textContent = getMessageTextContent(msg.content);
+  const imageUrls = getMessageImageUrls(msg.content);
 
   // Check if any search term appears as a prefix of any word in content
   const isHit = (() => {
-    if (!highlight || !msg.content) return false;
-    const content = msg.content.toLowerCase();
+    if (!highlight || !textContent) return false;
+    const content = textContent.toLowerCase();
     const terms = highlight.toLowerCase().split(/\s+/).filter(Boolean);
     return terms.some((term) => content.includes(term));
   })();
@@ -319,14 +369,34 @@ function MessageBubble({
           </span>
         )}
       </div>
-      {msg.content &&
-        (msg.role === "system" ? (
-          <div className="text-sm text-foreground whitespace-pre-wrap leading-relaxed">
-            {msg.content}
-          </div>
-        ) : (
-          <Markdown content={msg.content} highlightTerms={highlightTerms} />
-        ))}
+      {(textContent || imageUrls.length > 0) && (
+        <div className="space-y-3">
+          {textContent &&
+            (msg.role === "system" ? (
+              <div className="text-sm text-foreground whitespace-pre-wrap leading-relaxed">
+                {textContent}
+              </div>
+            ) : (
+              <Markdown content={textContent} highlightTerms={highlightTerms} />
+            ))}
+          {imageUrls.map((url, index) => (
+            <a
+              key={`${msg.role}-image-${index}`}
+              href={url}
+              target="_blank"
+              rel="noreferrer"
+              className="block"
+            >
+              <img
+                src={url}
+                alt={`${label} image ${index + 1}`}
+                className="max-h-80 w-auto max-w-full rounded-md border border-border bg-background/40 object-contain"
+                loading="lazy"
+              />
+            </a>
+          ))}
+        </div>
+      )}
       {msg.tool_calls && msg.tool_calls.length > 0 && (
         <div className="mt-1">
           {msg.tool_calls.map((tc) => (


### PR DESCRIPTION
## Summary
- render session message text parts separately from image parts in the dashboard session viewer
- bypass the markdown renderer for `image_url` / `input_image` content so large data URIs render as images instead of recursive text
- cover `/api/sessions/{id}/messages` multimodal history with a regression test

Fixes #47498.

## Test plan
- `/Users/leongong/Desktop/LeonProjects/worktrees/hermes-agent/.base/.venv/bin/python -m pytest tests/gateway/test_session_api.py -q`
- `cd web && npm run typecheck`
- `git diff --check`
