### PR TITLE
feat(memory): add opt-in context_id scoping for per-channel/tenant memory isolation

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1381,10 +1381,26 @@ def init_agent(
             agent._user_profile_enabled = mem_config.get("user_profile_enabled", False)
             agent._memory_nudge_interval = int(mem_config.get("nudge_interval", 10))
             if agent._memory_enabled or agent._user_profile_enabled:
-                from tools.memory_tool import MemoryStore
+                from tools.memory_tool import MemoryStore, derive_context_id
+                # Per-context scoping (gateway/messaging only). Off by default;
+                # when enabled we partition memory by platform:chat_type:chat_id
+                # so a fact learned in one DM/group is isolated from others. The
+                # interactive CLI has no chat_id, so derive_context_id → None
+                # and the store stays unscoped regardless of the flag.
+                _context_id = None
+                _include_global = False
+                if mem_config.get("context_scoping_enabled", False):
+                    _context_id = derive_context_id(
+                        getattr(agent, "platform", None),
+                        getattr(agent, "_chat_type", None),
+                        getattr(agent, "_chat_id", None),
+                    )
+                    _include_global = bool(mem_config.get("include_global_in_scoped", False))
                 agent._memory_store = MemoryStore(
                     memory_char_limit=mem_config.get("memory_char_limit", 2200),
                     user_char_limit=mem_config.get("user_char_limit", 1375),
+                    context_id=_context_id,
+                    include_global=_include_global,
                 )
                 agent._memory_store.load_from_disk()
         except Exception:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2438,6 +2438,26 @@ def _resolve_gateway_model(config: dict | None = None) -> str:
     return ""
 
 
+def _context_id_for_source(source) -> Optional[str]:
+    """Derive the per-context memory id for a ``SessionSource``, or None.
+
+    Scopes EVERY chat type (DMs included) and platform-qualifies the id so the
+    same chat_id can't leak memory across platforms or between a DM and a
+    group. Returns None when there is no chat_id (routes to unscoped/global
+    memory). Delegates to the single-sourced ``derive_context_id`` so the
+    gateway and ``agent_init`` compute identical ids.
+    """
+    from tools.memory_tool import derive_context_id
+
+    platform = getattr(source, "platform", None)
+    platform_str = getattr(platform, "value", None) or (str(platform) if platform else None)
+    return derive_context_id(
+        platform_str,
+        getattr(source, "chat_type", None),
+        getattr(source, "chat_id", None),
+    )
+
+
 def _channel_override_lookup_keys(
     chat_id: str,
     *,

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2225,6 +2225,17 @@ DEFAULT_CONFIG = {
         "write_approval": False,
         "memory_char_limit": 2200,   # ~800 tokens at 2.75 chars/token
         "user_char_limit": 1375,     # ~500 tokens at 2.75 chars/token
+        # Per-context memory scoping (gateway only). When True, memory in a
+        # messaging chat is partitioned to contexts/{platform:chat_type:chat_id}/
+        # so a fact learned in one DM or group is not readable in another.
+        # Default False = today's behavior (single shared memory). No effect on
+        # the interactive CLI, which is always unscoped.
+        "context_scoping_enabled": False,
+        # When scoping is on, whether a scoped context ALSO reads the shared
+        # global MEMORY.md/USER.md as a read-only layer. Default False keeps
+        # scoped contexts fully isolated; True lets them see (but never edit)
+        # global facts.
+        "include_global_in_scoped": False,
         # External memory provider plugin (empty = built-in only).
         # Set to a provider name to activate: "openviking", "mem0",
         # "hindsight", "holographic", "retaindb", "byterover".

--- a/tests/gateway/test_context_id_derivation.py
+++ b/tests/gateway/test_context_id_derivation.py
@@ -1,0 +1,137 @@
+"""Tests for gateway per-context memory id derivation.
+
+`_context_id_for_source` turns a messaging SessionSource into the context id
+used to partition memory. The guarantees under test:
+
+  - Every chat type is scoped, DMs included (fixes the leak where DMs were
+    left unscoped and shared one global memory).
+  - Ids are platform-qualified, so the same raw chat_id on two platforms — or
+    the same id used for a DM and a group — never collide.
+  - No chat_id ⇒ None ⇒ unscoped/global memory (interactive CLI, no-chat).
+  - Path-unsafe chat_ids are sanitized by MemoryStore and stay under contexts/.
+
+Uses the real Platform enum plus a lightweight fake source; no real chat ids.
+"""
+
+import sys
+from dataclasses import dataclass
+from typing import Optional
+
+import pytest
+
+from gateway.run import _context_id_for_source
+from gateway.config import Platform
+from tools.memory_tool import MemoryStore, derive_context_id
+
+# Patch get_memory_dir on the exact module object MemoryStore came from, not by
+# dotted string: tests/tools/test_memory_tool_import_fallback.py reimports
+# tools.memory_tool, so a later sys.modules entry can be a different object.
+_MEM_MOD = sys.modules[MemoryStore.__module__]
+
+
+@dataclass
+class FakeSource:
+    """Minimal stand-in for gateway SessionSource: only the attributes the
+    derivation reads."""
+    platform: object
+    chat_type: str
+    chat_id: Optional[str]
+
+
+def test_dm_is_scoped():
+    """A DM is scoped (non-None) — the leak this fixes was DMs going unscoped."""
+    cid = _context_id_for_source(FakeSource(Platform.TELEGRAM, "dm", "u1"))
+    assert cid is not None
+    assert cid == "telegram:dm:u1"
+
+
+def test_group_is_scoped():
+    cid = _context_id_for_source(FakeSource(Platform.TELEGRAM, "group", "123"))
+    assert cid == "telegram:group:123"
+
+
+def test_no_chat_id_is_unscoped():
+    """Missing chat_id ⇒ None ⇒ global/unscoped memory."""
+    assert _context_id_for_source(FakeSource(Platform.LOCAL, "dm", None)) is None
+    assert _context_id_for_source(FakeSource(Platform.LOCAL, "dm", "")) is None
+
+
+def test_platform_qualified_ids_dont_collide():
+    """Same chat_id '123' as a group on TELEGRAM vs SLACK → distinct ids."""
+    tg = _context_id_for_source(FakeSource(Platform.TELEGRAM, "group", "123"))
+    sl = _context_id_for_source(FakeSource(Platform.SLACK, "group", "123"))
+    assert tg != sl
+    assert tg == "telegram:group:123"
+    assert sl == "slack:group:123"
+
+
+def test_dm_and_group_same_chat_id_distinct():
+    """Same chat_id '123' as a DM vs a group → distinct ids (no cross-type leak)."""
+    dm = _context_id_for_source(FakeSource(Platform.TELEGRAM, "dm", "123"))
+    grp = _context_id_for_source(FakeSource(Platform.TELEGRAM, "group", "123"))
+    assert dm != grp
+
+
+def test_string_platform_supported():
+    """A plugin platform passed as a bare string (no .value) still derives."""
+    cid = _context_id_for_source(FakeSource("irc", "group", "42"))
+    assert cid == "irc:group:42"
+
+
+def test_context_id_path_safe(tmp_path, monkeypatch):
+    """A chat_id containing path-traversal sequences is sanitized by the store
+    and stays under contexts/ — never escapes the memories dir."""
+    monkeypatch.setattr(_MEM_MOD, "get_memory_dir", lambda: tmp_path)
+
+    cid = _context_id_for_source(FakeSource(Platform.SLACK, "group", "../../etc/x"))
+    assert cid is not None
+
+    store = MemoryStore(context_id=cid)
+    store.load_from_disk()
+    store.add("memory", "trapped")
+
+    # No escape outside the memories tree.
+    assert not (tmp_path.parent.parent / "etc" / "x" / "MEMORY.md").exists()
+    # The scoped file lives under contexts/.
+    contexts = tmp_path / "contexts"
+    assert contexts.exists()
+    written = list(contexts.rglob("MEMORY.md"))
+    assert written, "expected a scoped MEMORY.md under contexts/"
+    for p in written:
+        assert contexts in p.parents
+
+
+class TestLiveDerivationPath:
+    """agent/agent_init.py is the LIVE construction site: it calls
+    tools.memory_tool.derive_context_id directly with the agent's stored
+    platform string / chat_type / chat_id (the gateway threads these onto the
+    agent). These tests exercise that shared core so the wired path — not only
+    the gateway-typed _context_id_for_source adapter — is covered, and assert
+    the two entry points agree."""
+
+    def test_derive_context_id_matches_source_helper(self):
+        """The bare-string core and the SessionSource adapter agree, so the
+        gateway and agent_init compute identical ids."""
+        via_core = derive_context_id("telegram", "dm", "u1")
+        via_source = _context_id_for_source(FakeSource(Platform.TELEGRAM, "dm", "u1"))
+        assert via_core == via_source == "telegram:dm:u1"
+
+    def test_cli_like_source_is_unscoped(self):
+        """The interactive CLI passes platform='cli' with no chat_id → None,
+        so a scoped store is never built even if scoping is enabled."""
+        assert derive_context_id("cli", None, None) is None
+        assert derive_context_id("cli", "dm", "") is None
+
+    def test_dm_scoped_via_core(self):
+        assert derive_context_id("slack", "dm", "u9") == "slack:dm:u9"
+
+
+def test_derivation_matches_stored_context_id(tmp_path, monkeypatch):
+    """The colon-delimited id resolves to a single directory under contexts/
+    (the ':' separators are kept verbatim, not treated as path boundaries)."""
+    monkeypatch.setattr(_MEM_MOD, "get_memory_dir", lambda: tmp_path)
+    cid = _context_id_for_source(FakeSource(Platform.TELEGRAM, "dm", "u1"))
+    store = MemoryStore(context_id=cid)
+    store.load_from_disk()
+    store.add("memory", "hi")
+    assert (tmp_path / "contexts" / "telegram:dm:u1" / "MEMORY.md").exists()

--- a/tests/tools/test_memory_scoping.py
+++ b/tests/tools/test_memory_scoping.py
@@ -1,0 +1,361 @@
+"""Tests for opt-in context_id memory partitioning in MemoryStore.
+
+Partition model (per target ∈ {memory, user}):
+  - Global files:  <memories>/MEMORY.md, USER.md  (unchanged, backward compatible)
+  - Scoped files:  <memories>/contexts/{context_id}/MEMORY.md, USER.md
+
+Guarantees under test:
+  - A scoped file on disk contains ONLY scoped entries — global facts are
+    never copied into it (the core isolation bug this partition model fixes).
+  - Global is an OPT-IN, READ-ONLY layer: include_global defaults False. The
+    default scoped read view is scoped-only.
+  - Every mutation path (add / replace / remove / apply_batch) refuses to
+    mutate a global entry from a scoped context, for BOTH targets.
+  - Global membership is decided by set-membership against the global
+    partition, per target (index-free) — different global counts in MEMORY vs
+    USER never cross-guard.
+  - Migration: a scoped file that wrongly contains a global entry (old buggy
+    write-back) is healed on load.
+  - Feature disabled (context_id=None) ⇒ behavior identical to flat upstream.
+
+No real PII: fixtures use "u1", "123", and synthetic facts only.
+"""
+
+import sys
+
+import pytest
+
+from tools.memory_tool import MemoryStore, ENTRY_DELIMITER
+
+# Patch get_memory_dir on the exact module object MemoryStore was defined in,
+# not by dotted string. tests/tools/test_memory_tool_import_fallback.py deletes
+# and re-imports tools.memory_tool, so a later ``sys.modules["tools.memory_tool"]``
+# can be a different module object than the one holding this class's methods.
+# Resolving via the class keeps the patch pointed at the right globals.
+_MEM_MOD = sys.modules[MemoryStore.__module__]
+
+
+@pytest.fixture
+def mem_dir(tmp_path, monkeypatch):
+    """Patch get_memory_dir to a temp dir; return the dir."""
+    monkeypatch.setattr(_MEM_MOD, "get_memory_dir", lambda: tmp_path)
+    return tmp_path
+
+
+def _parse(path):
+    """Parse a memory file on disk into its list of entries."""
+    if not path.exists():
+        return []
+    raw = path.read_text(encoding="utf-8")
+    if not raw.strip():
+        return []
+    return [e.strip() for e in raw.split(ENTRY_DELIMITER) if e.strip()]
+
+
+def _global_path(mem_dir, target):
+    return mem_dir / ("USER.md" if target == "user" else "MEMORY.md")
+
+
+def _scoped_path(mem_dir, context_id, target):
+    return mem_dir / "contexts" / context_id / ("USER.md" if target == "user" else "MEMORY.md")
+
+
+# =========================================================================
+# Scoped writes never leak global entries into the scoped file
+# =========================================================================
+
+class TestScopedWriteDoesNotCopyGlobal:
+    def test_scoped_add_does_not_copy_global_into_scoped_file(self, mem_dir):
+        """Global MEMORY.md has 'global fact'; a scoped add writes ONLY the
+        scoped fact into the scoped file — never the global one."""
+        _global_path(mem_dir, "memory").write_text("global fact")
+
+        store = MemoryStore(context_id="grp-1")
+        store.load_from_disk()
+        result = store.add("memory", "scoped fact")
+        assert result["success"] is True
+
+        scoped_file = _scoped_path(mem_dir, "grp-1", "memory")
+        assert _parse(scoped_file) == ["scoped fact"]
+        # Global file untouched.
+        assert _parse(_global_path(mem_dir, "memory")) == ["global fact"]
+
+    def test_scoped_add_of_global_fact_is_noop_not_copy(self, mem_dir):
+        """Adding text that already exists globally is a no-op — it is NOT
+        copied into the scoped partition (which load-time healing would strip
+        anyway), even with include_global=False."""
+        _global_path(mem_dir, "memory").write_text("global fact")
+
+        store = MemoryStore(context_id="grp-1")  # include_global=False
+        store.load_from_disk()
+        result = store.add("memory", "global fact")
+        assert result["success"] is True  # idempotent no-op
+
+        # Scoped file must not have been created with the global entry in it.
+        scoped_file = _scoped_path(mem_dir, "grp-1", "memory")
+        assert _parse(scoped_file) == []
+        assert _parse(_global_path(mem_dir, "memory")) == ["global fact"]
+
+    def test_scoped_add_user_does_not_copy_global_user(self, mem_dir):
+        """Same guarantee for the USER.md target."""
+        _global_path(mem_dir, "user").write_text("global user pref")
+
+        store = MemoryStore(context_id="grp-1")
+        store.load_from_disk()
+        result = store.add("user", "scoped user pref")
+        assert result["success"] is True
+
+        scoped_file = _scoped_path(mem_dir, "grp-1", "user")
+        assert _parse(scoped_file) == ["scoped user pref"]
+        assert _parse(_global_path(mem_dir, "user")) == ["global user pref"]
+
+
+# =========================================================================
+# Read view: global is opt-in
+# =========================================================================
+
+class TestReadViewOptInGlobal:
+    def test_scoped_read_excludes_global_by_default(self, mem_dir):
+        """include_global=False (default): read view is scoped-only."""
+        _global_path(mem_dir, "memory").write_text("global fact")
+        _scoped_path(mem_dir, "grp-1", "memory").parent.mkdir(parents=True, exist_ok=True)
+        _scoped_path(mem_dir, "grp-1", "memory").write_text("scoped fact")
+
+        store = MemoryStore(context_id="grp-1")
+        store.load_from_disk()
+
+        assert "scoped fact" in store.memory_entries
+        assert "global fact" not in store.memory_entries
+
+    def test_scoped_read_includes_global_when_opted_in(self, mem_dir):
+        """include_global=True: read view = global + scoped (global first)."""
+        _global_path(mem_dir, "memory").write_text("global fact")
+        _scoped_path(mem_dir, "grp-1", "memory").parent.mkdir(parents=True, exist_ok=True)
+        _scoped_path(mem_dir, "grp-1", "memory").write_text("scoped fact")
+
+        store = MemoryStore(context_id="grp-1", include_global=True)
+        store.load_from_disk()
+
+        assert "global fact" in store.memory_entries
+        assert "scoped fact" in store.memory_entries
+        # Global first.
+        assert store.memory_entries.index("global fact") < store.memory_entries.index("scoped fact")
+
+    def test_unscoped_read_is_global_only(self, mem_dir):
+        """context_id=None: read view = global only (today's behavior)."""
+        _global_path(mem_dir, "memory").write_text("global fact")
+        store = MemoryStore()
+        store.load_from_disk()
+        assert store.memory_entries == ["global fact"]
+
+
+# =========================================================================
+# Mutation guards: global is read-only from a scoped context
+# =========================================================================
+
+class TestGlobalReadOnlyFromScope:
+    def test_replace_global_entry_from_scope_refused(self, mem_dir):
+        """Scoped store, include_global=True: replacing a global entry is
+        refused (global is read-only from a scoped context)."""
+        _global_path(mem_dir, "memory").write_text("the sky is blue")
+
+        store = MemoryStore(context_id="grp-1", include_global=True)
+        store.load_from_disk()
+        result = store.replace("memory", "sky is blue", "sky is green")
+
+        assert result["success"] is False
+        err = result["error"].lower()
+        assert "global" in err
+        # Nothing written to the scoped file; global unchanged.
+        assert not _scoped_path(mem_dir, "grp-1", "memory").exists() or \
+            "sky is green" not in _parse(_scoped_path(mem_dir, "grp-1", "memory"))
+        assert _parse(_global_path(mem_dir, "memory")) == ["the sky is blue"]
+
+    def test_remove_global_entry_from_scope_refused(self, mem_dir):
+        """Removing a global entry from a scoped context is refused."""
+        _global_path(mem_dir, "memory").write_text("the sky is blue")
+
+        store = MemoryStore(context_id="grp-1", include_global=True)
+        store.load_from_disk()
+        result = store.remove("memory", "sky is blue")
+
+        assert result["success"] is False
+        assert "global" in result["error"].lower()
+        assert _parse(_global_path(mem_dir, "memory")) == ["the sky is blue"]
+
+    def test_replace_global_user_entry_from_scope_refused(self, mem_dir):
+        """Per-target: the same refusal holds for the USER.md target."""
+        _global_path(mem_dir, "user").write_text("user likes tea")
+
+        store = MemoryStore(context_id="grp-1", include_global=True)
+        store.load_from_disk()
+        result = store.replace("user", "likes tea", "likes coffee")
+
+        assert result["success"] is False
+        assert "global" in result["error"].lower()
+        assert _parse(_global_path(mem_dir, "user")) == ["user likes tea"]
+
+    def test_replace_scoped_entry_from_scope_allowed(self, mem_dir):
+        """Positive control: a scoped entry CAN be replaced from its scope."""
+        store = MemoryStore(context_id="grp-1", include_global=True)
+        store.load_from_disk()
+        store.add("memory", "scoped original")
+        result = store.replace("memory", "scoped original", "scoped updated")
+
+        assert result["success"] is True
+        assert _parse(_scoped_path(mem_dir, "grp-1", "memory")) == ["scoped updated"]
+
+
+# =========================================================================
+# apply_batch is partition-aware
+# =========================================================================
+
+class TestApplyBatchPartitioning:
+    def test_apply_batch_scoped_does_not_copy_global(self, mem_dir):
+        """A batch of scoped ops leaves the global file untouched and writes
+        no global entries into the scoped file."""
+        _global_path(mem_dir, "memory").write_text("global fact")
+
+        store = MemoryStore(context_id="grp-1", include_global=True)
+        store.load_from_disk()
+        result = store.apply_batch("memory", [
+            {"action": "add", "content": "scoped a"},
+            {"action": "add", "content": "scoped b"},
+        ])
+        assert result["success"] is True
+
+        assert _parse(_scoped_path(mem_dir, "grp-1", "memory")) == ["scoped a", "scoped b"]
+        assert _parse(_global_path(mem_dir, "memory")) == ["global fact"]
+
+    def test_apply_batch_refuses_global_mutation_from_scope(self, mem_dir):
+        """A batch containing a replace/remove that targets a global entry is
+        refused whole — nothing is written (all-or-nothing)."""
+        _global_path(mem_dir, "memory").write_text("global fact")
+
+        store = MemoryStore(context_id="grp-1", include_global=True)
+        store.load_from_disk()
+        result = store.apply_batch("memory", [
+            {"action": "add", "content": "scoped a"},
+            {"action": "replace", "old_text": "global fact", "content": "hacked"},
+        ])
+        assert result["success"] is False
+        assert "global" in result["error"].lower()
+
+        # All-or-nothing: neither op committed.
+        assert not _scoped_path(mem_dir, "grp-1", "memory").exists() or \
+            _parse(_scoped_path(mem_dir, "grp-1", "memory")) == []
+        assert _parse(_global_path(mem_dir, "memory")) == ["global fact"]
+
+    def test_apply_batch_refuses_global_remove_from_scope(self, mem_dir):
+        """Batch remove of a global entry from a scoped context is refused."""
+        _global_path(mem_dir, "memory").write_text("global fact")
+
+        store = MemoryStore(context_id="grp-1", include_global=True)
+        store.load_from_disk()
+        result = store.apply_batch("memory", [
+            {"action": "remove", "old_text": "global fact"},
+        ])
+        assert result["success"] is False
+        assert "global" in result["error"].lower()
+        assert _parse(_global_path(mem_dir, "memory")) == ["global fact"]
+
+
+# =========================================================================
+# Global membership is per-target (no cross-guard)
+# =========================================================================
+
+class TestGlobalMembershipPerTarget:
+    def test_global_membership_is_per_target(self, mem_dir):
+        """Different global contents in MEMORY vs USER don't cross-guard:
+        a scoped entry in one target must remain mutable even when the OTHER
+        target's global partition is larger."""
+        # MEMORY global has two entries; USER global has none.
+        _global_path(mem_dir, "memory").write_text(
+            "mem global 1" + ENTRY_DELIMITER + "mem global 2"
+        )
+
+        store = MemoryStore(context_id="grp-1", include_global=True)
+        store.load_from_disk()
+
+        # A scoped USER add + replace must succeed — USER has no global entries,
+        # so an index-based guard borrowing MEMORY's count would wrongly block.
+        store.add("user", "scoped user entry")
+        result = store.replace("user", "scoped user entry", "scoped user updated")
+        assert result["success"] is True
+        assert _parse(_scoped_path(mem_dir, "grp-1", "user")) == ["scoped user updated"]
+
+        # And a scoped MEMORY entry (positioned AFTER the 2 globals in the read
+        # view) is still mutable.
+        store.add("memory", "scoped mem entry")
+        result2 = store.replace("memory", "scoped mem entry", "scoped mem updated")
+        assert result2["success"] is True
+        assert "scoped mem updated" in _parse(_scoped_path(mem_dir, "grp-1", "memory"))
+
+
+# =========================================================================
+# Migration / self-healing of old buggy scoped files
+# =========================================================================
+
+class TestMigrationDedup:
+    def test_migration_dedups_preexisting_global_in_scoped_file(self, mem_dir):
+        """A scoped file that wrongly contains a global entry (from the old
+        buggy write-back) is healed on load: the read view doesn't double-show
+        it, and after any scoped write the scoped partition no longer holds
+        the global entry."""
+        _global_path(mem_dir, "memory").write_text("global fact")
+        # Old bug: scoped file has BOTH the global fact and a real scoped fact.
+        scoped_file = _scoped_path(mem_dir, "grp-1", "memory")
+        scoped_file.parent.mkdir(parents=True, exist_ok=True)
+        scoped_file.write_text("global fact" + ENTRY_DELIMITER + "real scoped fact")
+
+        store = MemoryStore(context_id="grp-1", include_global=True)
+        store.load_from_disk()
+
+        # Read view shows the global fact exactly once, plus the scoped fact.
+        assert store.memory_entries.count("global fact") == 1
+        assert "real scoped fact" in store.memory_entries
+
+        # The scoped partition no longer holds the global entry.
+        store.add("memory", "another scoped fact")
+        on_disk = _parse(scoped_file)
+        assert "global fact" not in on_disk
+        assert "real scoped fact" in on_disk
+        assert "another scoped fact" in on_disk
+
+
+# =========================================================================
+# Feature disabled == flat upstream behavior
+# =========================================================================
+
+class TestFeatureDisabledMatchesFlat:
+    def test_feature_disabled_matches_flat_behavior(self, mem_dir):
+        """context_id=None behaves exactly like flat upstream: writes land in
+        the global file, no contexts/ directory is ever created."""
+        store = MemoryStore()
+        store.load_from_disk()
+        store.add("memory", "flat fact")
+        store.add("user", "flat pref")
+
+        assert _parse(_global_path(mem_dir, "memory")) == ["flat fact"]
+        assert _parse(_global_path(mem_dir, "user")) == ["flat pref"]
+        assert not (mem_dir / "contexts").exists()
+
+        # Fresh store reads it straight back.
+        store2 = MemoryStore()
+        store2.load_from_disk()
+        assert store2.memory_entries == ["flat fact"]
+        assert store2.user_entries == ["flat pref"]
+
+    def test_empty_context_id_is_none(self, mem_dir):
+        """Empty-string context_id sanitizes to None (unscoped)."""
+        store = MemoryStore(context_id="")
+        assert store.context_id is None
+
+    def test_context_id_path_traversal_sanitized(self, mem_dir):
+        """Path traversal in context_id can't escape contexts/."""
+        store = MemoryStore(context_id="../../etc/passwd")
+        store.load_from_disk()
+        store.add("memory", "trapped")
+        # Nothing written outside the temp memory dir tree.
+        assert not (mem_dir.parent.parent / "etc" / "passwd" / "MEMORY.md").exists()
+        assert (mem_dir / "contexts").exists()

--- a/tools/memory_tool.py
+++ b/tools/memory_tool.py
@@ -80,6 +80,28 @@ def _scan_memory_content(content: str) -> Optional[str]:
     return _first_threat_message(content, scope="strict")
 
 
+def derive_context_id(platform: Optional[str], chat_type: Optional[str],
+                      chat_id: Optional[str]) -> Optional[str]:
+    """Build a memory context id from a messaging source, or None if unscopable.
+
+    Scopes EVERY chat type (including DMs) and qualifies by platform so the
+    same raw chat_id on two platforms — or the same id used for a DM and a
+    group — never collide:
+
+        f"{platform}:{chat_type}:{chat_id}"
+
+    Returns None when ``chat_id`` is empty/None, which routes memory to the
+    unscoped global store (the interactive-CLI and no-chat case). The
+    ``MemoryStore`` sanitizer maps any residual path-unsafe characters to ``_``
+    so the derived id always stays under contexts/.
+    """
+    if not chat_id:
+        return None
+    plat = platform if platform else "unknown"
+    ctype = chat_type if chat_type else "chat"
+    return f"{plat}:{ctype}:{chat_id}"
+
+
 def _drift_error(path: "Path", bak_path: str) -> Dict[str, Any]:
     """Build the error dict returned when external drift is detected.
 
@@ -127,11 +149,37 @@ class MemoryStore:
     # turn to budget exhaustion and suppress the user's reply (issue #42405).
     _MAX_CONSOLIDATION_FAILURES_PER_TURN = 3
 
-    def __init__(self, memory_char_limit: int = 2200, user_char_limit: int = 1375):
+    def __init__(self, memory_char_limit: int = 2200, user_char_limit: int = 1375,
+                 context_id: Optional[str] = None, include_global: bool = False):
+        # ``memory_entries`` / ``user_entries`` are the DERIVED read view (what
+        # the system prompt, ``read``, and success responses show). They are
+        # never persisted as one blob. The two partitions below are the source
+        # of truth and are written to their own files independently.
         self.memory_entries: List[str] = []
         self.user_entries: List[str] = []
         self.memory_char_limit = memory_char_limit
         self.user_char_limit = user_char_limit
+        # Partition state (per target). Global is the shared, backward-compatible
+        # layer; scoped is per-context and isolated. Keeping them separate is
+        # what guarantees a scoped file only ever holds scoped entries.
+        self._global_entries: Dict[str, List[str]] = {"memory": [], "user": []}
+        self._scoped_entries: Dict[str, List[str]] = {"memory": [], "user": []}
+        # Sanitize context_id: treat empty/falsy as None; replace path
+        # separators and parent-ref sequences so chat IDs from any platform
+        # can't escape the contexts/ directory via path traversal. The gateway
+        # emits ``{platform}:{chat_type}:{chat_id}`` — ``:`` is kept verbatim
+        # (safe on every supported filesystem and used only as a within-name
+        # separator, not a directory boundary).
+        if context_id:
+            safe_id = str(context_id).replace("/", "_").replace("\\", "_").replace("..", "_")
+            self.context_id: Optional[str] = safe_id or None
+        else:
+            self.context_id = None
+        # Opt-in, read-only global layer for scoped stores. Default OFF: a
+        # scoped store's read view is scoped-only unless the operator turns
+        # this on. Ignored (no effect) for unscoped stores, which are always
+        # global-only.
+        self.include_global = bool(include_global)
         # Frozen snapshot for system prompt -- set once at load_from_disk()
         self._system_prompt_snapshot: Dict[str, str] = {"memory": "", "user": ""}
         # Per-turn counter of failed at-capacity consolidation attempts; reset
@@ -185,12 +233,11 @@ class MemoryStore:
         mem_dir = get_memory_dir()
         mem_dir.mkdir(parents=True, exist_ok=True)
 
-        self.memory_entries = self._read_file(mem_dir / "MEMORY.md")
-        self.user_entries = self._read_file(mem_dir / "USER.md")
-
-        # Deduplicate entries (preserves order, keeps first occurrence)
-        self.memory_entries = list(dict.fromkeys(self.memory_entries))
-        self.user_entries = list(dict.fromkeys(self.user_entries))
+        # Load each target's partitions from disk and derive the read view.
+        for target in ("memory", "user"):
+            self._load_partitions(target)
+        self.memory_entries = self._derive_view("memory")
+        self.user_entries = self._derive_view("user")
 
         # Sanitize entries for the system-prompt snapshot only.  Live state
         # (memory_entries / user_entries) keeps the raw text so the user
@@ -278,38 +325,146 @@ class MemoryStore:
             fd.close()
 
     @staticmethod
-    def _path_for(target: str) -> Path:
+    def _global_path_for(target: str) -> Path:
+        """Return the global (unscoped) file for a target — always at the
+        memories-dir root, backward compatible."""
         mem_dir = get_memory_dir()
         if target == "user":
             return mem_dir / "USER.md"
         return mem_dir / "MEMORY.md"
 
+    def _scoped_path_for(self, target: str) -> Path:
+        """Return the scoped file for a target under contexts/{context_id}/.
+
+        Only meaningful when ``context_id`` is set.
+        """
+        mem_dir = get_memory_dir()
+        base = mem_dir / "contexts" / str(self.context_id)
+        if target == "user":
+            return base / "USER.md"
+        return base / "MEMORY.md"
+
+    def _path_for(self, target: str) -> Path:
+        """Return the file this store MUTATES for a target.
+
+        Unscoped (context_id=None) → the global file (backward compatible).
+        Scoped → the scoped file. Global files are never mutated from a scoped
+        store, so a scoped store's write path is always the scoped file.
+        """
+        if self.context_id is None:
+            return self._global_path_for(target)
+        return self._scoped_path_for(target)
+
+    # -- Partition load / derive --
+
+    def _load_partitions(self, target: str) -> None:
+        """Load the global and scoped partitions for ``target`` from disk into
+        ``_global_entries`` / ``_scoped_entries`` (deduplicated within each).
+
+        Migration / self-healing: when a scoped file wrongly contains an entry
+        that also exists in the global partition (from the old buggy write-back
+        that copied the merged list into the scoped file), that entry is
+        dropped from the scoped partition here. The scoped partition holds ONLY
+        genuinely-scoped entries; global stays the single source of truth for
+        shared facts.
+        """
+        global_entries = list(dict.fromkeys(self._read_file(self._global_path_for(target))))
+        self._global_entries[target] = global_entries
+
+        if self.context_id is None:
+            self._scoped_entries[target] = []
+            return
+
+        scoped_raw = list(dict.fromkeys(self._read_file(self._scoped_path_for(target))))
+        global_set = set(global_entries)
+        # Heal old data: never keep a global entry inside the scoped partition.
+        self._scoped_entries[target] = [e for e in scoped_raw if e not in global_set]
+
+    def _derive_view(self, target: str) -> List[str]:
+        """Return the merged READ view for ``target`` from the partitions.
+
+        - Unscoped store: global only (today's behavior).
+        - Scoped, include_global=False (default): scoped only.
+        - Scoped, include_global=True: global first, then scoped, deduped.
+        """
+        scoped = self._scoped_entries.get(target, [])
+        if self.context_id is None:
+            return list(self._global_entries.get(target, []))
+        if not self.include_global:
+            return list(scoped)
+        merged = list(self._global_entries.get(target, [])) + list(scoped)
+        return list(dict.fromkeys(merged))
+
+    def _project_view(self, target: str, writable: List[str]) -> List[str]:
+        """Derive the read view that WOULD result from a candidate writable
+        partition, without committing it. Used for budget checks.
+
+        Mirrors ``_derive_view`` but substitutes ``writable`` for the stored
+        partition this store mutates.
+        """
+        if self.context_id is None:
+            return list(writable)
+        if not self.include_global:
+            return list(writable)
+        merged = list(self._global_entries.get(target, [])) + list(writable)
+        return list(dict.fromkeys(merged))
+
+    def _is_global_entry(self, target: str, entry: str) -> bool:
+        """True if ``entry`` belongs to the global partition for ``target``.
+
+        Set-membership against the global partition — per-target and
+        index-free, so a scoped mutation is judged only against that target's
+        own global entries (no cross-target guarding).
+        """
+        return entry in set(self._global_entries.get(target, []))
+
+    _GLOBAL_READONLY_MSG = (
+        "Cannot modify a global entry from a scoped context — global memory is "
+        "read-only here. Edit it from an unscoped (global) session instead."
+    )
+
+    def _reject_global_mutation(self, target: str, entry: str) -> Optional[Dict[str, Any]]:
+        """Return a refusal dict if ``entry`` is a global entry and this store
+        is scoped; otherwise None (mutation may proceed).
+        """
+        if self.context_id is not None and self._is_global_entry(target, entry):
+            return {"success": False, "error": self._GLOBAL_READONLY_MSG}
+        return None
+
     def _reload_target(self, target: str, *, skip_drift: bool = False) -> Optional[str]:
-        """Re-read entries from disk into in-memory state.
+        """Re-read the target's partitions from disk into in-memory state.
 
         Called under file lock to get the latest state before mutating.
-        Returns the backup path if external drift was detected (the on-disk
-        file contains content that wouldn't round-trip through our
-        parser/serializer, OR an entry larger than the store's char limit).
-        When drift is detected the caller must abort the mutation —
-        flushing would discard the un-roundtrippable content.
-        Returns None on clean reload.
+        Returns the backup path if external drift was detected on the SCOPED
+        file (the file this store writes), or None on clean reload. The global
+        file is read-only from every store, so drift detection only applies to
+        the write path.
 
         When *skip_drift* is True the round-trip / entry-size check is
         bypassed.  Used by the ``add`` action which appends without
         rewriting, so existing content is never clobbered.
+
+        Rebuilds both partitions and the derived read view so the mutation
+        methods below see a fresh, healed picture.
         """
-        path = self._path_for(target)
         bak = None if skip_drift else self._detect_external_drift(target)
-        fresh = self._read_file(path)
-        fresh = list(dict.fromkeys(fresh))  # deduplicate
-        self._set_entries(target, fresh)
+        self._load_partitions(target)
+        self._set_entries(target, self._derive_view(target))
         return bak
 
     def save_to_disk(self, target: str):
-        """Persist entries to the appropriate file. Called after every mutation."""
-        get_memory_dir().mkdir(parents=True, exist_ok=True)
-        self._write_file(self._path_for(target), self._entries_for(target))
+        """Persist the mutated partition to its own file.
+
+        Scoped store → writes ONLY the scoped file, and ONLY the scoped
+        partition (never the merged read view — that would leak global entries
+        into the scoped file). Unscoped store → writes the global file.
+        """
+        path = self._path_for(target)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        if self.context_id is None:
+            self._write_file(path, self._global_entries[target])
+        else:
+            self._write_file(path, self._scoped_entries[target])
 
     def _entries_for(self, target: str) -> List[str]:
         if target == "user":
@@ -321,6 +476,26 @@ class MemoryStore:
             self.user_entries = entries
         else:
             self.memory_entries = entries
+
+    def _writable_entries(self, target: str) -> List[str]:
+        """Return a COPY of the partition this store may mutate for ``target``.
+
+        Scoped store → the scoped partition; unscoped store → the global
+        partition. Mutations operate on this copy and commit via
+        ``_commit_writable`` so the merged read view is never written back to
+        a partition file.
+        """
+        if self.context_id is None:
+            return list(self._global_entries[target])
+        return list(self._scoped_entries[target])
+
+    def _commit_writable(self, target: str, entries: List[str]) -> None:
+        """Store the mutated partition and re-derive the read view."""
+        if self.context_id is None:
+            self._global_entries[target] = entries
+        else:
+            self._scoped_entries[target] = entries
+        self._set_entries(target, self._derive_view(target))
 
     def _char_count(self, target: str) -> int:
         entries = self._entries_for(target)
@@ -353,16 +528,25 @@ class MemoryStore:
             # would discard un-roundtrippable content (issue #26045).
             self._reload_target(target, skip_drift=True)
 
-            entries = self._entries_for(target)
+            # Duplicate check is against the READ view AND the global partition.
+            # Consulting the global partition even when include_global is False
+            # keeps a scoped store from shadowing a global fact with a
+            # redundant scoped copy — such a copy would be silently stripped by
+            # the load-time healing (_load_partitions), so the "add" would not
+            # survive a reload. Treating it as an existing entry is correct and
+            # never copies a global entry into the scoped file.
+            view = self._entries_for(target)
             limit = self._char_limit(target)
-
-            # Reject exact duplicates
-            if content in entries:
+            if content in view or self._is_global_entry(target, content):
                 return self._success_response(target, "Entry already exists (no duplicate added).")
 
-            # Calculate what the new total would be
-            new_entries = entries + [content]
-            new_total = len(ENTRY_DELIMITER.join(new_entries))
+            # Append to the WRITABLE partition (scoped for a scoped store).
+            writable = self._writable_entries(target)
+            new_writable = writable + [content]
+
+            # Budget is measured against the resulting READ view.
+            projected = self._project_view(target, new_writable)
+            new_total = len(ENTRY_DELIMITER.join(projected))
 
             if new_total > limit:
                 current = self._char_count(target)
@@ -375,12 +559,11 @@ class MemoryStore:
                         f"shorter ones or 'remove' stale or less important entries (see "
                         f"current_entries below), then retry this add — all in this turn."
                     ),
-                    "current_entries": entries,
+                    "current_entries": view,
                     "usage": f"{current:,}/{limit:,}",
                 })
 
-            entries.append(content)
-            self._set_entries(target, entries)
+            self._commit_writable(target, new_writable)
             self.save_to_disk(target)
 
         return self._success_response(target, "Entry added.")
@@ -426,13 +609,26 @@ class MemoryStore:
                     }
                 # All identical -- safe to replace just the first
 
-            idx = matches[0][0]
+            matched_text = matches[0][1]
+
+            # Guard: a global entry is read-only from a scoped context. The
+            # scoped store only writes the scoped file, so mutating a global
+            # entry here would silently be lost on the next reload — refuse.
+            guard = self._reject_global_mutation(target, matched_text)
+            if guard is not None:
+                return guard
+
             limit = self._char_limit(target)
 
-            # Check that replacement doesn't blow the budget
-            test_entries = entries.copy()
-            test_entries[idx] = new_content
-            new_total = len(ENTRY_DELIMITER.join(test_entries))
+            # Locate the entry in the WRITABLE partition (it is scoped, since
+            # the guard above ruled out a global match for a scoped store).
+            writable = self._writable_entries(target)
+            w_idx = writable.index(matched_text)
+            writable[w_idx] = new_content
+
+            # Budget against the resulting READ view.
+            projected = self._project_view(target, writable)
+            new_total = len(ENTRY_DELIMITER.join(projected))
 
             if new_total > limit:
                 current = self._char_count(target)
@@ -448,8 +644,7 @@ class MemoryStore:
                     "usage": f"{current:,}/{limit:,}",
                 })
 
-            entries[idx] = new_content
-            self._set_entries(target, entries)
+            self._commit_writable(target, writable)
             self.save_to_disk(target)
 
         return self._success_response(target, "Entry replaced.")
@@ -487,9 +682,16 @@ class MemoryStore:
                     }
                 # All identical -- safe to remove just the first
 
-            idx = matches[0][0]
-            entries.pop(idx)
-            self._set_entries(target, entries)
+            matched_text = matches[0][1]
+
+            # Guard: refuse to remove a global entry from a scoped context.
+            guard = self._reject_global_mutation(target, matched_text)
+            if guard is not None:
+                return guard
+
+            writable = self._writable_entries(target)
+            writable.pop(writable.index(matched_text))
+            self._commit_writable(target, writable)
             self.save_to_disk(target)
 
         return self._success_response(target, "Entry removed.")
@@ -525,8 +727,15 @@ class MemoryStore:
             if bak:
                 return _drift_error(self._path_for(target), bak)
 
-            # Work on a copy; only commit if the whole batch validates.
-            working: List[str] = list(self._entries_for(target))
+            # Work on a copy of the WRITABLE partition (scoped for a scoped
+            # store); only commit if the whole batch validates. Global entries
+            # are read-only here, so ``working`` never contains them and
+            # replace/remove that resolve to a global entry are refused before
+            # any change is applied.
+            working: List[str] = self._writable_entries(target)
+            # The set the model "sees" for match/idempotency, including the
+            # read-only global layer when opted in.
+            view = self._entries_for(target)
             limit = self._char_limit(target)
 
             for i, op in enumerate(operations):
@@ -539,8 +748,12 @@ class MemoryStore:
                 if act == "add":
                     if not content:
                         return self._batch_error(target, f"{pos}: content is required.")
-                    if content in working:
-                        continue  # idempotent -- skip duplicate, don't fail the batch
+                    # Idempotent against the working set, the read view, AND the
+                    # global partition (even when include_global is off) — a
+                    # scoped store never shadows a global fact with a redundant
+                    # scoped copy that load-time healing would later strip.
+                    if content in working or content in view or self._is_global_entry(target, content):
+                        continue
                     working.append(content)
 
                 elif act == "replace":
@@ -551,6 +764,14 @@ class MemoryStore:
                             target,
                             f"{pos}: content is required (use action='remove' to delete).",
                         )
+                    # Refuse a batch that targets a global entry from a scope,
+                    # even if that entry isn't in the writable partition — the
+                    # guard is against the read view (issue: apply_batch arrived
+                    # unguarded from upstream).
+                    if self.context_id is not None and any(
+                        self._is_global_entry(target, e) for e in view if old_text in e
+                    ):
+                        return self._batch_error(target, f"{pos}: {self._GLOBAL_READONLY_MSG}")
                     matches = [j for j, e in enumerate(working) if old_text in e]
                     if not matches:
                         return self._batch_error(target, f"{pos}: no entry matched '{old_text}'.")
@@ -564,6 +785,10 @@ class MemoryStore:
                 elif act == "remove":
                     if not old_text:
                         return self._batch_error(target, f"{pos}: old_text is required.")
+                    if self.context_id is not None and any(
+                        self._is_global_entry(target, e) for e in view if old_text in e
+                    ):
+                        return self._batch_error(target, f"{pos}: {self._GLOBAL_READONLY_MSG}")
                     matches = [j for j, e in enumerate(working) if old_text in e]
                     if not matches:
                         return self._batch_error(target, f"{pos}: no entry matched '{old_text}'.")
@@ -580,8 +805,9 @@ class MemoryStore:
                         f"{pos}: unknown action. Use add, replace, or remove.",
                     )
 
-            # Budget check against the FINAL state only.
-            new_total = len(ENTRY_DELIMITER.join(working)) if working else 0
+            # Budget check against the FINAL read view only.
+            projected = self._project_view(target, working)
+            new_total = len(ENTRY_DELIMITER.join(projected)) if projected else 0
             if new_total > limit:
                 current = self._char_count(target)
                 return self._consolidation_failure({
@@ -595,8 +821,8 @@ class MemoryStore:
                     "usage": f"{current:,}/{limit:,}",
                 })
 
-            # Commit.
-            self._set_entries(target, working)
+            # Commit the scoped partition only.
+            self._commit_writable(target, working)
             self.save_to_disk(target)
 
         return self._success_response(target, f"Applied {len(operations)} operation(s).")


### PR DESCRIPTION
Addresses #34352.

## What

Adds an opaque `context_id` parameter to `MemoryStore` that routes memory **writes** into per-context subdirectories (`memories/contexts/{context_id}/`). **Reads** merge global entries plus the context-scoped entries, so an agent keeps its shared/global memory while gaining a per-channel (Telegram/Signal chat, tenant, etc.) private slice. The gateway derives the `context_id` from the message source via a single `_context_id_for_source()` helper in `GatewayRunner`.

## Why

Today all memory lands in one flat store. For agents serving multiple channels/tenants from one process, that leaks state across contexts. `context_id` gives lightweight isolation without standing up a second store backend — directly addressing the memory-isolation sub-problem in #34352.

## Backward compatibility

Fully backward compatible. `context_id=None` (and empty string, which is treated as `None`) preserves the exact existing single-tenant layout and behavior — no migration, no path changes for current users. The feature is purely additive and opt-in.

## Safety

- `context_id` is sanitized in `MemoryStore.__init__` (path separators and parent-ref sequences stripped) so untrusted chat IDs cannot traverse out of `contexts/`.
- `replace()` / `remove()` from a scoped context cannot mutate or delete **global** entries (tracked via `_global_entry_count`); they return an error instead.

## Tests

New `tests/tools/test_memory_scoping.py` — 18 tests covering scoped vs global routing, global+scoped read merge, `context_id=None`/empty fallback, path-traversal sanitization, and replace/remove protection of global entries from a scoped context. All 18 pass.
