### PR TITLE
fix(docker): supervised gateway uses --replace to take over stale holder (NS-505)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 *.pyc*
 __pycache__/
 .venv/
+.venv
 .vscode/
 .env
 .env.local

--- a/.venv
+++ b/.venv
@@ -1,0 +1,1 @@
+/home/ben/nous/hermes-agent/.venv

--- a/.venv
+++ b/.venv
@@ -1,1 +1,0 @@
-/home/ben/nous/hermes-agent/.venv

--- a/hermes_cli/service_manager.py
+++ b/hermes_cli/service_manager.py
@@ -684,10 +684,25 @@ class S6ServiceManager:
         # start`, etc. See `_gateway_command_inner` for the matching
         # guard.
         lines.append("export HERMES_S6_SUPERVISED_CHILD=1")
+        # ``--replace`` makes the supervised gateway authoritative for its
+        # profile's HERMES_HOME. Without it, a gateway started OUTSIDE s6
+        # (a stray ``hermes gateway run`` from a shell, an agent action, or
+        # the Open WebUI helper) grabs the per-HERMES_HOME PID lock first;
+        # the supervised slot then execs a bare ``gateway run``, hits the
+        # "Another gateway instance is already running" guard, exits
+        # non-zero, and s6 restarts it — a restart loop that floods the
+        # log and never binds (NS-505). ``--replace``
+        # instead reaps the stale holder (hardened takeover path: marker +
+        # SIGTERM→SIGKILL-with-confirmation + scoped-lock cleanup, see
+        # gateway/run.py) so s6 always wins. The HERMES_S6_SUPERVISED_CHILD
+        # sentinel above prevents the run→start→run redirect recursion.
+        # Each profile is scoped to its own HERMES_HOME and s6 guarantees a
+        # single supervised instance per slot, so there is no legitimate
+        # supervised sibling for ``--replace`` to clobber.
         if profile == "default":
-            gateway_cmd = "hermes gateway run"
+            gateway_cmd = "hermes gateway run --replace"
         else:
-            gateway_cmd = f"hermes -p {shlex.quote(profile)} gateway run"
+            gateway_cmd = f"hermes -p {shlex.quote(profile)} gateway run --replace"
         # Skip the drop when already non-root (setgroups() lacks CAP_SETGID →
         # s6 boot-loop).
         lines.append(f'[ "$(id -u)" = 0 ] || exec {gateway_cmd}')

--- a/tests/hermes_cli/test_service_manager.py
+++ b/tests/hermes_cli/test_service_manager.py
@@ -631,7 +631,46 @@ def test_render_run_script_resets_home_before_exec() -> None:
     run_text = S6ServiceManager._render_run_script("coder", {})
 
     assert "export HOME=/opt/data" in run_text
-    assert "exec s6-setuidgid hermes hermes -p coder gateway run" in run_text
+    assert "exec s6-setuidgid hermes hermes -p coder gateway run --replace" in run_text
+
+
+def test_render_run_script_uses_replace_to_take_over_stale_holder() -> None:
+    """NS-505: the supervised gateway must exec ``gateway run --replace``.
+
+    Without ``--replace`` a gateway started OUTSIDE s6 (a stray shell
+    ``hermes gateway run``, an agent action, the Open WebUI helper) holds
+    the per-HERMES_HOME PID lock; the supervised slot then execs a bare
+    ``gateway run``, hits the "Another gateway instance is already
+    running" guard, exits non-zero, and s6 restarts it — a restart loop
+    that never binds. ``--replace`` makes the supervised gateway reap the
+    stale holder and win, so s6 is authoritative for the slot.
+
+    Covers both the default (root HERMES_HOME, no ``-p``) and named-profile
+    render paths.
+    """
+    default_text = S6ServiceManager._render_run_script("default", {})
+    # Root profile: bare `hermes gateway run --replace` (no -p flag).
+    assert "hermes gateway run --replace" in default_text
+    assert "hermes -p default" not in default_text
+    # Every exec line that launches the gateway must carry --replace, so
+    # neither the non-root nor the privilege-drop branch can spin.
+    gateway_execs = [
+        line for line in default_text.splitlines()
+        if "gateway run" in line
+    ]
+    assert gateway_execs, "no gateway run exec line rendered"
+    assert all("--replace" in line for line in gateway_execs), (
+        f"a gateway run line is missing --replace: {gateway_execs}"
+    )
+
+    named_text = S6ServiceManager._render_run_script("coder", {})
+    named_execs = [
+        line for line in named_text.splitlines() if "gateway run" in line
+    ]
+    assert named_execs
+    assert all("--replace" in line for line in named_execs), (
+        f"a named-profile gateway run line is missing --replace: {named_execs}"
+    )
 
 
 def test_s6_register_rejects_invalid_profile_name(s6_scandir) -> None:


### PR DESCRIPTION
![NS-505 supervised gateway crash-loop fix](https://files.catbox.moe/ff426h.png)

## Summary

Inside the s6 container image the per-profile gateway service rendered a **bare** `hermes gateway run` (no `--replace`). When a gateway gets started **outside s6** — a stray shell `hermes gateway run`, an agent action, or the Open WebUI helper (`scripts/setup_open_webui.sh` does `nohup hermes gateway run &`) — it grabs the per-`HERMES_HOME` PID lock first. The supervised slot then execs the bare `gateway run`, hits the **"Another gateway instance is already running"** guard in `gateway/run.py`, exits non-zero, and s6 (a longrun with no backoff) restarts it — a restart loop that floods the log every ~12s and **never binds**. The container looks up but the gateway is permanently down, and dashboard-only users (no shell access) cannot recover.

The fix renders the supervised run script as `gateway run --replace` so **s6 is authoritative for its slot**: the supervised child reaps the stale holder via the already-hardened takeover path (takeover marker → `SIGTERM` → `SIGKILL`-with-confirmation → scoped-lock cleanup, all in `gateway/run.py`) and binds. This is exactly what the **systemd** service path already does (`_build_gateway_argv` emits `nohup hermes gateway run --replace`), and it matches the intent already documented in `_maybe_redirect_run_to_s6_supervision` ("when s6-supervise execs `hermes gateway run --replace` as a longrun…"). Until now the code and its own docstring disagreed.

## Reported via beta — NS-505

The user's `gateway.log` (hermes `v2026.6.5`, fly.io) is the smoking gun:

```
gateway:            running (manual process, pid 17907)
10:45:45 ERROR gateway.run: Another gateway instance is already running (PID 17907, HERMES_HOME=/opt/data) …
10:45:58 ERROR gateway.run: Another gateway instance is already running (PID 17907 …)
   … repeats every ~12s for the entire log …
```

PID 17907 is a **live** gateway started as a *manual process* (outside s6); the supervised slot keeps colliding with it and losing.

## Relationship to #46120 (merged) — this is the complementary half, not a duplicate

#46120 ("block duplicate foreground gateway runs earlier") cited this same debug report and PID 17907, and it is already on `main`. But it fixes the **non-supervised** side only:

- It adds `_guard_existing_gateway_process_conflict` / `_guard_supervised_gateway_conflict` preflights so a **shell/dashboard** duplicate `gateway run` fails *cheaply* (before expensive plugin discovery) instead of burning memory/CPU on a 1 GB instance.
- **Both guards self-suppress when `HERMES_S6_SUPERVISED_CHILD` is set** (`_running_under_gateway_supervisor()` → early return). The s6 supervised child is *exempt*, so it still falls through to `gateway/run.py`'s authoritative check and — without `--replace` — **still loops.**

I verified this at runtime: with `HERMES_S6_SUPERVISED_CHILD=1`, #46120's guards return early, and only this render-script change makes the supervised child take over. So #46120 reduced the *cost* of the loop on the shell side; this PR removes the loop on the supervised side. Together they close it on both sides.

## Why "always `--replace`" (and not adopt-or-replace detection)

Each profile's gateway is scoped to its own `HERMES_HOME`, and s6 guarantees a single supervised instance per service slot — so a *legitimately-supervised sibling* holding the same profile's lock cannot occur. Conditional "only replace if the holder isn't supervised" logic would guard a case that can't happen. The `--replace` takeover path is already hardened against the duplicate-gateway hazard (#19471). The `HERMES_S6_SUPERVISED_CHILD` sentinel continues to prevent the run→start→run redirect recursion.

## Changes

- **`hermes_cli/service_manager.py`** — `_render_run_script` now emits `gateway run --replace` for both the default (root `HERMES_HOME`, no `-p`) and named-profile paths, with a comment explaining the NS-505 loop. `container_boot.py` reuses this same renderer, so the boot-reconciler path is covered by the single change.
- **`tests/hermes_cli/test_service_manager.py`** — updates the existing render assertion and adds `test_render_run_script_uses_replace_to_take_over_stale_holder`, which asserts **every** gateway-run exec line (default + named profile, both the non-root and privilege-drop branches) carries `--replace`.

## Validation

| Check | Result |
|---|---|
| New regression test fails **without** the prod change, passes **with** it | ✅ confirmed (stash-and-rerun) |
| `pytest tests/hermes_cli/test_service_manager.py test_container_boot.py test_apply_profile_override.py` | 122 passed |
| `pytest tests/hermes_cli/test_gateway_s6_dispatch.py tests/gateway/test_status.py` | 86 passed |
| Rendered script eyeballed for default + named profile | ✅ both carry `--replace` |
| Runtime trace: supervised child exempt from #46120 guards → only this fix breaks the loop | ✅ confirmed |

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Note for reviewers

This is Docker/container-runtime behaviour by file (`_render_run_script`), but it changes how the supervised gateway process behaves and interacts with #46120's just-merged guards, so it's flagged for core review rather than a Docker-lane self-merge.

