### PR TITLE
fix(desktop): render local markdown image paths via media pipeline

### DIFF
--- a/apps/desktop/src/components/assistant-ui/markdown-text.tsx
+++ b/apps/desktop/src/components/assistant-ui/markdown-text.tsx
@@ -33,6 +33,7 @@ import {
   mediaKind,
   mediaName,
   mediaPathFromMarkdownHref,
+  mediaPathFromMarkdownImageSrc,
   mediaStreamUrl
 } from '@/lib/media'
 import { previewTargetFromMarkdownHref } from '@/lib/preview-targets'
@@ -176,7 +177,7 @@ function MediaAttachment({ path }: { path: string }) {
   if (kind === 'image' && src) {
     return (
       <span className="block">
-        <MarkdownImage alt={name} src={src} />
+        <ImagePreview alt={name} src={src} />
       </span>
     )
   }
@@ -272,7 +273,7 @@ function MarkdownLink({ children, className, href, ...props }: ComponentProps<'a
   )
 }
 
-function MarkdownImage({ className, src, alt, ...props }: ComponentProps<'img'>) {
+function ImagePreview({ className, src, alt, ...props }: ComponentProps<'img'>) {
   return (
     <ZoomableImage
       alt={alt}
@@ -286,6 +287,16 @@ function MarkdownImage({ className, src, alt, ...props }: ComponentProps<'img'>)
       {...props}
     />
   )
+}
+
+function MarkdownImage({ className, src, alt, ...props }: ComponentProps<'img'>) {
+  const mediaPath = mediaPathFromMarkdownImageSrc(src)
+
+  if (mediaPath) {
+    return <MediaAttachment path={mediaPath} />
+  }
+
+  return <ImagePreview alt={alt} className={className} src={src} {...props} />
 }
 
 // Steady character-reveal for streaming text: decouples visible cadence from

--- a/apps/desktop/src/lib/media.remote.test.ts
+++ b/apps/desktop/src/lib/media.remote.test.ts
@@ -2,7 +2,13 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { $connection } from '@/store/session'
 
-import { filePathFromMediaPath, gatewayMediaDataUrl, isRemoteGateway, mediaExternalUrl } from './media'
+import {
+  filePathFromMediaPath,
+  gatewayMediaDataUrl,
+  isRemoteGateway,
+  mediaExternalUrl,
+  mediaPathFromMarkdownImageSrc
+} from './media'
 
 describe('isRemoteGateway', () => {
   afterEach(() => {
@@ -32,6 +38,27 @@ describe('filePathFromMediaPath', () => {
 
   it('decodes a file:// URL with encoded characters', () => {
     expect(filePathFromMediaPath('file:///tmp/a%20b.png')).toBe('/tmp/a b.png')
+  })
+})
+
+describe('mediaPathFromMarkdownImageSrc', () => {
+  it('routes gateway-local markdown image paths through the media pipeline', () => {
+    expect(mediaPathFromMarkdownImageSrc('/home/u/Documents/monday-artifacts/chart.png')).toBe(
+      '/home/u/Documents/monday-artifacts/chart.png'
+    )
+    expect(mediaPathFromMarkdownImageSrc('~/Documents/monday-artifacts/chart.png')).toBe(
+      '~/Documents/monday-artifacts/chart.png'
+    )
+    expect(mediaPathFromMarkdownImageSrc('file:///tmp/a%20b.png')).toBe('file:///tmp/a%20b.png')
+    expect(mediaPathFromMarkdownImageSrc('#media:%2Ftmp%2Fa%20b.png')).toBe('/tmp/a b.png')
+  })
+
+  it('leaves fetchable and relative image sources on the normal image renderer', () => {
+    expect(mediaPathFromMarkdownImageSrc('https://example.com/a.png')).toBeNull()
+    expect(mediaPathFromMarkdownImageSrc('data:image/png;base64,AAAA')).toBeNull()
+    expect(mediaPathFromMarkdownImageSrc('//cdn.example.com/a.png')).toBeNull()
+    expect(mediaPathFromMarkdownImageSrc('assets/chart.png')).toBeNull()
+    expect(mediaPathFromMarkdownImageSrc(undefined)).toBeNull()
   })
 })
 
@@ -86,5 +113,38 @@ describe('gatewayMediaDataUrl', () => {
     expect(api).toHaveBeenCalledWith({
       path: '/api/media?path=%2Fhome%2Fu%2F.hermes%2Fimages%2Fa%20b.png'
     })
+  })
+
+  it('falls back to managed file reads for images outside dedicated media roots', async () => {
+    api.mockRejectedValueOnce(new Error('403: {"detail":"Path outside media roots"}'))
+    api.mockResolvedValueOnce({ data_url: 'data:image/png;base64,b3V0c2lkZQ==' })
+
+    const url = await gatewayMediaDataUrl('/home/u/Documents/monday-artifacts/a b.png')
+
+    expect(url).toBe('data:image/png;base64,b3V0c2lkZQ==')
+    expect(api).toHaveBeenNthCalledWith(1, {
+      path: '/api/media?path=%2Fhome%2Fu%2FDocuments%2Fmonday-artifacts%2Fa%20b.png'
+    })
+    expect(api).toHaveBeenNthCalledWith(2, {
+      path: '/api/files/read?path=%2Fhome%2Fu%2FDocuments%2Fmonday-artifacts%2Fa%20b.png'
+    })
+  })
+
+  it('does not fall back to managed file reads for auth or non-media failures', async () => {
+    api.mockRejectedValueOnce(new Error('401: {"detail":"Invalid session token"}'))
+
+    await expect(gatewayMediaDataUrl('/home/u/Documents/monday-artifacts/a.png')).rejects.toThrow(
+      'Invalid session token'
+    )
+    expect(api).toHaveBeenCalledTimes(1)
+  })
+
+  it('rejects fallback payloads that are not image data URLs', async () => {
+    api.mockRejectedValueOnce(new Error('403: {"detail":"Path outside media roots"}'))
+    api.mockResolvedValueOnce({ data_url: 'data:text/plain;base64,c2VjcmV0' })
+
+    await expect(gatewayMediaDataUrl('/home/u/Documents/monday-artifacts/a.png')).rejects.toThrow(
+      'Expected image data'
+    )
   })
 })

--- a/apps/desktop/src/lib/media.ts
+++ b/apps/desktop/src/lib/media.ts
@@ -96,6 +96,24 @@ export function mediaPathFromMarkdownHref(href?: string): string | null {
   }
 }
 
+export function mediaPathFromMarkdownImageSrc(src?: string): string | null {
+  if (!src) {
+    return null
+  }
+
+  const mediaPath = mediaPathFromMarkdownHref(src)
+
+  if (mediaPath) {
+    return mediaPath
+  }
+
+  if (/^(?:https?|data):/i.test(src) || src.startsWith('//')) {
+    return null
+  }
+
+  return /^(?:file:|~\/|\/|[A-Za-z]:[\\/])/.test(src) ? src : null
+}
+
 export function filePathFromMediaPath(path: string): string {
   if (!path.startsWith('file:')) {
     return path
@@ -114,18 +132,49 @@ export function isRemoteGateway(): boolean {
   return $connection.get()?.mode === 'remote'
 }
 
+function assertImageDataUrl(dataUrl: string): string {
+  if (!/^data:image\/[a-z0-9.+-]+;base64,/i.test(dataUrl)) {
+    throw new Error('Expected image data from gateway media endpoint')
+  }
+
+  return dataUrl
+}
+
+function isPathOutsideMediaRootsError(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error || '')
+
+  return /^403\b/.test(message) && message.includes('Path outside media roots')
+}
+
 // Fetch a gateway-local image as a data URL via the authenticated REST bridge.
 // Used in remote mode where readFileDataUrl (which reads THIS machine's disk)
 // can't see files the agent wrote on the gateway. Requires the gateway to
 // expose GET /api/media (hermes_cli/web_server.py).
 export async function gatewayMediaDataUrl(path: string): Promise<string> {
   const file = filePathFromMediaPath(path)
+  const encodedPath = encodeURIComponent(file)
 
-  const result = await window.hermesDesktop!.api<{ data_url: string }>({
-    path: `/api/media?path=${encodeURIComponent(file)}`
-  })
+  if (mediaKind(file) !== 'image') {
+    throw new Error('Expected image media path')
+  }
 
-  return result.data_url
+  try {
+    const result = await window.hermesDesktop!.api<{ data_url: string }>({
+      path: `/api/media?path=${encodedPath}`
+    })
+
+    return assertImageDataUrl(result.data_url)
+  } catch (error) {
+    if (!isPathOutsideMediaRootsError(error)) {
+      throw error
+    }
+
+    const result = await window.hermesDesktop!.api<{ data_url: string }>({
+      path: `/api/files/read?path=${encodedPath}`
+    })
+
+    return assertImageDataUrl(result.data_url)
+  }
 }
 
 export function mediaDisplayLabel(path: string): string {


### PR DESCRIPTION
## Summary
- Route local-looking markdown image `src` values through the Desktop media attachment pipeline instead of rendering them as raw browser image URLs.
- Let remote Desktop fetch gateway-local image previews via `/api/media`, with a narrow fallback to `/api/files/read` only for image paths rejected as outside dedicated media roots.
- Preserve normal rendering for fetchable `http(s)`, `data:`, protocol-relative, and relative image sources.
- Avoid recursive image rendering by using a shared `ImagePreview` component after media paths are resolved.

## Test plan
- `cd apps/desktop && npx vitest run --environment jsdom src/lib/media.remote.test.ts src/lib/chat-messages.test.ts`
- `cd apps/desktop && npm run typecheck`
- `cd apps/desktop && npx eslint src/lib/media.ts src/lib/media.remote.test.ts src/components/assistant-ui/markdown-text.tsx`
- `git diff --check -- apps/desktop/src/lib/media.ts apps/desktop/src/lib/media.remote.test.ts apps/desktop/src/components/assistant-ui/markdown-text.tsx`

## Notes
This fixes Desktop Remote sessions where assistant markdown includes a gateway-local absolute image path such as `/home/.../chart.png`; those paths are valid on the Hermes gateway host but broken as raw `<img src>` values in the Desktop renderer.
