### PR TITLE
feat(dashboard): configurable hostname allowlist for tunnel/proxy setups

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1620,6 +1620,13 @@ DEFAULT_CONFIG = {
         # falls through to request reconstruction rather than breaking
         # the login flow.
         "public_url": "",
+        # Hostnames to additionally accept on loopback binds
+        # (127.0.0.1 / localhost) — useful for Cloudflare Tunnel and
+        # other reverse-proxy setups that forward WS connections to a
+        # loopback-bound dashboard with a non-loopback Host header.
+        # Each entry is matched case-insensitively.  Default empty list
+        # keeps the existing loopback-only behavior.
+        "allowed_external_hosts": [],
     },
 
     # Privacy settings

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -301,6 +301,36 @@ _LOOPBACK_HOST_VALUES: frozenset = frozenset({
 })
 
 
+def _get_allowed_external_hosts() -> frozenset:
+    """Hostnames from config that are additionally accepted on loopback binds.
+
+    Reads ``dashboard.allowed_external_hosts`` from config.yaml (case-
+    insensitively).  Returns an empty frozenset on any failure (missing
+    config, missing key, wrong type) so a misconfigured config never
+    breaks the Host header check.
+
+    The result is a module-level memo so config is only read once per
+    process — restart the dashboard to pick up config changes.
+    """
+    try:
+        from hermes_cli.config import load_config
+
+        cfg = load_config()
+        hosts: list = cfg.get("dashboard", {}).get(
+            "allowed_external_hosts", []
+        )
+        if isinstance(hosts, list) and all(
+            isinstance(h, str) for h in hosts
+        ):
+            return frozenset(h.lower() for h in hosts)
+    except Exception:
+        pass
+    return frozenset()
+
+
+_ALLOWED_EXTERNAL_HOSTS: frozenset = _get_allowed_external_hosts()
+
+
 def should_require_auth(host: str, allow_public: bool) -> bool:
     """Return True iff the dashboard OAuth auth gate must be active.
 
@@ -352,10 +382,10 @@ def _is_accepted_host(host_header: str, bound_host: str) -> bool:
     if bound_host in {"0.0.0.0", "::"}:
         return True
 
-    # Loopback bind: accept the loopback names
+    # Loopback bind: accept the loopback names AND configured external hosts
     bound_lc = bound_host.lower()
     if bound_lc in _LOOPBACK_HOST_VALUES:
-        return host_only in _LOOPBACK_HOST_VALUES
+        return host_only in _LOOPBACK_HOST_VALUES or host_only in _ALLOWED_EXTERNAL_HOSTS
 
     # Explicit non-loopback bind: require exact host match
     return host_only == bound_lc

--- a/tests/hermes_cli/test_dashboard_host_allowlist.py
+++ b/tests/hermes_cli/test_dashboard_host_allowlist.py
@@ -1,0 +1,16 @@
+"""Tests for dashboard hostname allowlist in _is_accepted_host."""
+import pytest
+from hermes_cli.web_server import _is_accepted_host
+
+
+def test_loopback_host_always_accepted():
+    assert _is_accepted_host("127.0.0.1:10000", "127.0.0.1") is True
+    assert _is_accepted_host("localhost:10000", "127.0.0.1") is True
+
+
+def test_unknown_host_rejected():
+    assert _is_accepted_host("evil.example.com:443", "127.0.0.1") is False
+
+
+def test_0_0_0_0_bind_accepts_any_host():
+    assert _is_accepted_host("anything.example.com:443", "0.0.0.0") is True


### PR DESCRIPTION
Adds `dashboard.allowed_external_hosts` config key (default `[]`) and
reads it in `_is_accepted_host()` so Cloudflare Tunnel and other
reverse-proxy setups can route WebSocket connections through loopback-
bound dashboards without triggering the Host header check.

## Problem
When the dashboard binds to loopback (127.0.0.1 — the default), it
rejects any Host header that isn't localhost/::1. This breaks reverse-
proxy setups (nginx, caddy, Cloudflare Tunnel) where the proxy
forwards WS connections with the external hostname as the Host header.

## Solution
A config key `dashboard.allowed_external_hosts` (list of hostnames,
case-insensitive, empty by default) that the Host header check also
accepts on loopback binds. Loopback names are always accepted
regardless.

## Changes
- `hermes_cli/config.py`: added `allowed_external_hosts: []` default
- `hermes_cli/web_server.py`: `_get_allowed_external_hosts()` + module-level memo, used in `_is_accepted_host`
- `tests/hermes_cli/test_dashboard_host_allowlist.py`: 3 tests

## Testing
```
pytest tests/hermes_cli/test_dashboard_host_allowlist.py -v -o 'addopts='
============================== 3 passed ==============================
```

## Usage
```yaml
dashboard:
  allowed_external_hosts:
    - hermes-gw.example.com
```