### PR TITLE
fix(matrix): await inbound sync handlers

### DIFF
--- a/gateway/platforms/matrix.py
+++ b/gateway/platforms/matrix.py
@@ -1406,9 +1406,21 @@ class MatrixAdapter(BasePlatformAdapter):
         # Without this the INVITE handler below never fires.
         client.add_dispatcher(MembershipEventDispatcher)
 
-        client.add_event_handler(EventType.ROOM_MESSAGE, self._on_room_message)
-        client.add_event_handler(EventType.REACTION, self._on_reaction)
-        client.add_event_handler(IntEvt.INVITE, self._on_invite)
+        client.add_event_handler(
+            EventType.ROOM_MESSAGE,
+            self._on_room_message,
+            wait_sync=True,
+        )
+        client.add_event_handler(
+            EventType.REACTION,
+            self._on_reaction,
+            wait_sync=True,
+        )
+        client.add_event_handler(
+            IntEvt.INVITE,
+            self._on_invite,
+            wait_sync=True,
+        )
 
         # Initial sync to catch up, then start background sync.
         self._startup_ts = time.time()

--- a/tests/gateway/test_matrix.py
+++ b/tests/gateway/test_matrix.py
@@ -2589,13 +2589,20 @@ class TestMatrixEncryptedEventHandler:
                     with patch.object(adapter, "_sync_loop", AsyncMock(return_value=None)):
                         assert await adapter.connect() is True
 
-        # Verify event handlers were registered.
-        # In mautrix the order is: add_event_handler(EventType, callback)
+        # Verify inbound event handlers were registered as sync-awaited
+        # callbacks. mautrix only returns waited handler tasks from
+        # handle_sync(), so background-only handlers leave _dispatch_sync()
+        # without a completion point for Hermes' Matrix intake.
         handler_calls = mock_client.add_event_handler.call_args_list
-        registered_types = [call.args[0] for call in handler_calls]
+        waited_types = {
+            str(call.args[0])
+            for call in handler_calls
+            if call.kwargs.get("wait_sync") is True
+        }
 
-        # Should have registered handlers for ROOM_MESSAGE, REACTION, INVITE
-        assert len(handler_calls) >= 3
+        assert "m.room.message" in waited_types
+        assert "m.reaction" in waited_types
+        assert "internal.invite" in waited_types
 
         await adapter.disconnect()
 


### PR DESCRIPTION
## What does this PR do?

Registers the Matrix room message, reaction, and invite handlers with mautrix's `wait_sync=True` option.

Hermes calls `handle_sync()` through `_dispatch_sync()`, and mautrix only returns handler tasks for callbacks registered as sync-awaited handlers. Without that option, inbound Matrix callbacks can run only as background tasks, leaving Hermes without a completion point for message intake on the Tuwunel/mautrix migration path.

## Related Issue

Fixes #46142

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)
- [ ] New skill (bundled or hub)

## Changes Made

- `gateway/platforms/matrix.py`: set `wait_sync=True` for room message, reaction, and invite event handlers.
- `tests/gateway/test_matrix.py`: assert those inbound handler registrations are sync-awaited so `_dispatch_sync()` can await the tasks returned by mautrix.

## How to Test

1. `scripts/run_tests.sh tests/gateway/test_matrix.py -- -q -k test_connect_registers_encrypted_event_handler_when_encryption_on` -> `1 passed`
2. `scripts/run_tests.sh tests/gateway/test_matrix.py -- -q` -> `230 passed`
3. `codex --disable plugins review --uncommitted` -> clean, no accepted/actionable findings reported

Full `pytest tests/ -q` was not run locally; this patch is limited to the Matrix gateway path and the focused Matrix gateway suite passed through the repository test wrapper.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11 with the repository `scripts/run_tests.sh` wrapper

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) - N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys - N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows - N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) - no platform-specific behavior changed
- [x] I've updated tool descriptions/schemas if I changed tool behavior - N/A

## Screenshots / Logs

Focused verification:

```text
scripts/run_tests.sh tests/gateway/test_matrix.py -- -q -k test_connect_registers_encrypted_event_handler_when_encryption_on
1 passed

scripts/run_tests.sh tests/gateway/test_matrix.py -- -q
230 passed
```