### PR TITLE
test: neutralize webbrowser during tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -556,6 +556,27 @@ def pytest_configure(config):  # noqa: D401 — pytest hook
 
 
 @pytest.fixture(autouse=True)
+def _neutralize_webbrowser(monkeypatch):
+    """Prevent tests from opening a real browser or OAuth window.
+
+    Tests that need to assert browser-launch behavior can still install their
+    own monkeypatch; this fixture only supplies the hermetic default.
+    """
+    import webbrowser as _webbrowser
+
+    opened: list[object] = []
+
+    def _record(url=None, *args, **kwargs):
+        opened.append(url)
+        return True
+
+    for name in ("open", "open_new", "open_new_tab"):
+        monkeypatch.setattr(_webbrowser, name, _record, raising=False)
+
+    yield opened
+
+
+@pytest.fixture(autouse=True)
 def _live_system_guard(request, monkeypatch):
     """Block real os.kill / systemctl / gateway-pid scans during tests.
 

--- a/tests/test_webbrowser_guard.py
+++ b/tests/test_webbrowser_guard.py
@@ -1,0 +1,20 @@
+"""Tests for the global webbrowser hermeticity guard."""
+
+import webbrowser
+
+
+def test_webbrowser_open_is_neutralized_by_default():
+    assert webbrowser.open("https://auth.x.ai/oauth2/authorize") is True
+
+
+def test_tests_can_override_webbrowser_open(monkeypatch):
+    opened = []
+
+    def fake_open(url, *args, **kwargs):
+        opened.append(url)
+        return False
+
+    monkeypatch.setattr(webbrowser, "open", fake_open)
+
+    assert webbrowser.open("https://example.test/login") is False
+    assert opened == ["https://example.test/login"]

--- a/tests/test_webbrowser_guard.py
+++ b/tests/test_webbrowser_guard.py
@@ -2,9 +2,18 @@
 
 import webbrowser
 
+import pytest
 
-def test_webbrowser_open_is_neutralized_by_default():
-    assert webbrowser.open("https://auth.x.ai/oauth2/authorize") is True
+
+@pytest.mark.parametrize("method_name", ("open", "open_new", "open_new_tab"))
+def test_webbrowser_methods_are_neutralized_by_default(
+    _neutralize_webbrowser,
+    method_name,
+):
+    url = "https://auth.x.ai/oauth2/authorize"
+
+    assert getattr(webbrowser, method_name)(url) is True
+    assert _neutralize_webbrowser == [url]
 
 
 def test_tests_can_override_webbrowser_open(monkeypatch):


### PR DESCRIPTION
## Summary
- Add a global autouse fixture that stubs webbrowser.open/open_new/open_new_tab during tests.
- Add regression coverage proving the default guard is active and individual tests can still override it.

## Notes
- This addresses the browser/OAuth half of #35404. The Anthropic Keychain half appears already covered on current main by the local no_keychain fixture in tests/agent/test_anthropic_adapter.py, so this PR avoids duplicating that fix.

## Tests
- scripts/run_tests.sh tests/test_webbrowser_guard.py tests/hermes_cli/test_auth_manual_paste.py
- .venv/bin/ruff check tests/conftest.py tests/test_webbrowser_guard.py

Refs #35404