### PR TITLE
fix(install): clear venv python locks on Windows

### DIFF
--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -214,6 +214,35 @@ function Show-NpmCertHint {
     return $true
 }
 
+# Stop python.exe/pythonw.exe only when they are still executing from the old
+# venv's Scripts\ directory. This avoids clobbering unrelated system Pythons
+# while releasing loaded .pyd DLL locks before Remove-Item venv.
+function Stop-VenvPythonProcesses {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$VenvDir,
+        [int]$ExcludePid = 0
+    )
+
+    $scriptsDir = [System.IO.Path]::GetFullPath((Join-Path $VenvDir "Scripts"))
+    $scriptsPrefix = $scriptsDir.TrimEnd('\') + '\'
+    $pythonProcs = Get-CimInstance -ClassName Win32_Process `
+        -Filter "Name = 'python.exe' OR Name = 'pythonw.exe'" `
+        -ErrorAction SilentlyContinue |
+        Where-Object {
+            $_.ProcessId -ne $ExcludePid -and
+            $_.ExecutablePath -and
+            ([System.IO.Path]::GetFullPath($_.ExecutablePath) -like "$scriptsPrefix*")
+        }
+
+    if (@($pythonProcs).Count -eq 0) { return }
+
+    Write-Info "Stopping python processes still running from the old venv..."
+    foreach ($proc in $pythonProcs) {
+        Stop-Process -Id $proc.ProcessId -Force -ErrorAction SilentlyContinue
+    }
+}
+
 # --- Ensure-mode helpers ---
 
 function Resolve-NpmCmd {
@@ -1432,12 +1461,15 @@ function Install-Venv {
     if (Test-Path "venv") {
         Write-Info "Virtual environment already exists, recreating..."
         # On Windows, native Python extensions (e.g. _bcrypt.pyd) are loaded as
-        # DLLs by any running hermes process. Windows denies deletion of loaded
-        # DLLs, so kill any hermes.exe tree before removing the venv.
+        # DLLs by any running hermes.exe / pythonw.exe from that same venv.
+        # Windows denies deletion of loaded DLLs, so stop both the launcher
+        # tree and any leftover python(.w) interpreters rooted in venv\Scripts.
         if ($env:OS -eq "Windows_NT") {
             $myPid = $PID
+            $venvDir = Join-Path $InstallDir "venv"
             Write-Info "Stopping any running hermes processes before recreating venv..."
             & taskkill /F /T /IM hermes.exe /FI "PID ne $myPid" 2>$null | Out-Null
+            Stop-VenvPythonProcesses -VenvDir $venvDir -ExcludePid $myPid
             Start-Sleep -Milliseconds 800
         }
         Remove-Item -Recurse -Force "venv"

--- a/tests/test_install_unmerged_index.py
+++ b/tests/test_install_unmerged_index.py
@@ -134,6 +134,25 @@ def test_install_ps1_clears_unmerged_index_before_stash() -> None:
     assert idx_reset < idx_stash, "`git reset` must run before `git stash push`"
 
 
+def test_install_ps1_stops_venv_python_processes_before_removing_venv() -> None:
+    """The Windows venv-recreate path must also stop leftover python(.w)
+    interpreters rooted in the old venv before Remove-Item deletes it."""
+    text = INSTALL_PS1.read_text()
+    assert "function Stop-VenvPythonProcesses" in text, (
+        "install.ps1 must define a helper that targets venv-bound python processes"
+    )
+    assert "Name = 'python.exe' OR Name = 'pythonw.exe'" in text, (
+        "the helper must target both python.exe and pythonw.exe"
+    )
+    idx_taskkill = text.index("& taskkill /F /T /IM hermes.exe")
+    idx_stop_python = text.index("Stop-VenvPythonProcesses -VenvDir $venvDir")
+    idx_remove_venv = text.index('Remove-Item -Recurse -Force "venv"')
+    assert idx_taskkill < idx_stop_python < idx_remove_venv, (
+        "venv-bound python processes must be stopped after hermes.exe and before "
+        "the venv directory is deleted"
+    )
+
+
 def test_install_sh_clears_unmerged_index_before_stash_source_order() -> None:
     """Same ordering contract for install.sh's source."""
     text = INSTALL_SH.read_text()


### PR DESCRIPTION
## Summary
- stop `python.exe` and `pythonw.exe` only when they are still running from the old `venv\Scripts` directory during venv recreation
- keep the existing `hermes.exe` taskkill path and run the python cleanup before `Remove-Item venv`
- add a regression test that locks this install.ps1 ordering contract

## Testing
- `git diff --check`
- `python3 -m pytest tests/test_install_unmerged_index.py -q`
- `uv run --frozen ruff check tests/test_install_unmerged_index.py`

Closes #47557
