### PR TITLE
fix(agent): persistent retry on transient failures for long-horizon agents

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1236,6 +1236,18 @@ def init_agent(
         _api_retries = 3
     agent._api_max_retries = _api_retries
 
+    # Persistent retry for long-horizon / unattended agents (#35230, #25689).
+    # When enabled, transient failures keep retrying past api_max_retries
+    # instead of surfacing a failed turn.  Deterministic / authorization
+    # errors are never made persistent (see AIAgent._should_persist_retry).
+    agent._api_retry_persistent = bool(_agent_section.get("api_retry_persistent", False))
+    try:
+        _persist_cap = int(_agent_section.get("api_retry_persistent_max_elapsed_seconds", 0) or 0)
+        _persist_cap = max(_persist_cap, 0)  # 0 = no time limit
+    except (TypeError, ValueError):
+        _persist_cap = 0
+    agent._api_retry_persistent_max_elapsed_seconds = _persist_cap
+
     # Initialize context compressor for automatic context management
     # Compresses conversation when approaching model's context limit
     # Configuration via config.yaml (compression section)

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -871,6 +871,8 @@ def run_conversation(
         api_start_time = time.time()
         retry_count = 0
         max_retries = agent._api_max_retries
+        # Wall-clock anchor for persistent-retry's optional time cap (#35230).
+        _persistent_retry_started_at = api_start_time
         _retry = TurnRetryState()
         max_compression_attempts = 3
 
@@ -1222,16 +1224,11 @@ def run_conversation(
                     # upstream server error, or malformed response.
                     retry_count += 1
                     
-                    # Eager fallback: empty/malformed responses are a common
-                    # rate-limit symptom.  Switch to fallback immediately
-                    # rather than retrying with extended backoff.
-                    if agent._fallback_index < len(agent._fallback_chain):
-                        agent._buffer_status("⚠️ Empty/malformed response — switching to fallback...")
-                    if agent._try_activate_fallback():
-                        retry_count = 0
-                        compression_attempts = 0
-                        _retry.primary_recovery_attempted = False
-                        continue
+                    # Empty/malformed responses can still be transient.
+                    # Keep them on the same provider and let the normal
+                    # invalid-response retry/backoff path decide when to
+                    # fall back.
+                    agent._buffer_vprint("⚠️ Empty/malformed response — retrying...")
 
                     # Check for error field in response (some providers include this)
                     error_msg = "Unknown"
@@ -1303,18 +1300,43 @@ def run_conversation(
                             compression_attempts = 0
                             _retry.primary_recovery_attempted = False
                             continue
-                        # Terminal — flush buffered retry trace so user sees what happened.
-                        agent._flush_status_buffer()
-                        agent._emit_status(f"❌ Max retries ({max_retries}) exceeded for invalid responses. Giving up.")
-                        logger.error(f"{agent.log_prefix}Invalid API response after {max_retries} retries.")
-                        agent._persist_session(messages, conversation_history)
-                        return {
-                            "messages": messages,
-                            "completed": False,
-                            "api_calls": api_call_count,
-                            "error": f"Invalid API response after {max_retries} retries: {_failure_hint}",
-                            "failed": True  # Mark as failure for filtering
-                        }
+                        # Persistent retry (#35230): empty/malformed/invalid
+                        # responses are transient.  If the user opted into
+                        # long-horizon persistence and the time valve hasn't
+                        # tripped, reset the counter and keep retrying with
+                        # backoff rather than giving up.  The jittered backoff
+                        # below still runs on the next loop iteration.
+                        if (
+                            agent._should_persist_retry("invalid_response")
+                            and not agent._persistent_retry_time_exhausted(_persistent_retry_started_at)
+                        ):
+                            agent._buffer_status(
+                                f"⏳ Persistent retry — invalid responses after {max_retries} "
+                                f"attempts; continuing to retry ({_failure_hint})..."
+                            )
+                            logger.warning(
+                                "%sPersistent retry engaged for invalid responses — "
+                                "continuing instead of failing the turn.",
+                                agent.log_prefix,
+                            )
+                            retry_count = 0
+                            compression_attempts = 0
+                            _retry.primary_recovery_attempted = False
+                            # Fall through to the shared backoff+sleep below so
+                            # we don't hammer the provider with zero delay.
+                        else:
+                            # Terminal — flush buffered retry trace so user sees what happened.
+                            agent._flush_status_buffer()
+                            agent._emit_status(f"❌ Max retries ({max_retries}) exceeded for invalid responses. Giving up.")
+                            logger.error(f"{agent.log_prefix}Invalid API response after {max_retries} retries.")
+                            agent._persist_session(messages, conversation_history)
+                            return {
+                                "messages": messages,
+                                "completed": False,
+                                "api_calls": api_call_count,
+                                "error": f"Invalid API response after {max_retries} retries: {_failure_hint}",
+                                "failed": True  # Mark as failure for filtering
+                            }
                     
                     # Backoff before retry — jittered exponential: 5s base, 120s cap
                     wait_time = jittered_backoff(retry_count, base_delay=5.0, max_delay=120.0)
@@ -3294,6 +3316,61 @@ def run_conversation(
                         compression_attempts = 0
                         _retry.primary_recovery_attempted = False
                         continue
+                    # Persistent retry safety net (#35230, #25689): the fallback
+                    # chain is exhausted (or none is configured) but this is a
+                    # TRANSIENT failure (overloaded / rate-limit / usage- or
+                    # concurrent-limit / 5xx / timeout / unclassifiable) and the
+                    # user opted into long-horizon persistence.  Instead of
+                    # failing the turn, back off and keep retrying the current
+                    # provider — indefinitely, unless the optional wall-clock
+                    # safety valve has been reached.  Authorization, billing,
+                    # bad-request, content-policy and model-not-found never reach
+                    # here as persistent (see _should_persist_retry), so this
+                    # cannot hang on an error that retrying won't fix.
+                    if (
+                        agent._should_persist_retry(classified.reason)
+                        and not agent._persistent_retry_time_exhausted(_persistent_retry_started_at)
+                    ):
+                        _persist_wait = jittered_backoff(
+                            min(retry_count, max_retries), base_delay=2.0, max_delay=60.0
+                        )
+                        agent._buffer_status(
+                            f"⏳ Persistent retry ({classified.reason.value}) — provider still "
+                            f"failing after {max_retries} attempts; retrying in {_persist_wait:.0f}s..."
+                        )
+                        logger.warning(
+                            "%sPersistent retry engaged (reason=%s) — retrying in %.1fs "
+                            "instead of failing the turn.",
+                            agent.log_prefix, classified.reason.value, _persist_wait,
+                        )
+                        _persist_sleep_end = time.time() + _persist_wait
+                        _persist_touch = 0
+                        while time.time() < _persist_sleep_end:
+                            if agent._interrupt_requested:
+                                agent._vprint(
+                                    f"{agent.log_prefix}⚡ Interrupt during persistent retry wait, aborting.",
+                                    force=True,
+                                )
+                                agent._persist_session(messages, conversation_history)
+                                agent.clear_interrupt()
+                                return {
+                                    "final_response": "Operation interrupted during persistent retry.",
+                                    "messages": messages,
+                                    "api_calls": api_call_count,
+                                    "completed": False,
+                                    "interrupted": True,
+                                }
+                            time.sleep(0.2)
+                            _persist_touch += 1
+                            if _persist_touch % 150 == 0:  # ~30s
+                                agent._touch_activity(
+                                    f"persistent retry backoff ({classified.reason.value}), "
+                                    f"{int(_persist_sleep_end - time.time())}s remaining"
+                                )
+                        retry_count = 0
+                        compression_attempts = 0
+                        _retry.primary_recovery_attempted = False
+                        continue
                     # Terminal — flush buffered retry/fallback trace.
                     agent._flush_status_buffer()
                     _final_summary = agent._summarize_api_error(api_error)
@@ -4168,8 +4245,8 @@ def run_conversation(
                         continue
 
                     # ── Empty response retry ──────────────────────
-                    # Model returned nothing usable.  Retry up to 3
-                    # times before attempting fallback.  This covers
+                    # Model returned nothing usable.  Retry (default up
+                    # to 3 times) before attempting fallback.  This covers
                     # both truly empty responses (no content, no
                     # reasoning) AND reasoning-only responses after
                     # prefill exhaustion — models like mimo-v2-pro
@@ -4183,17 +4260,66 @@ def run_conversation(
                         _has_structured
                         and agent._thinking_prefill_retries >= 2
                     )
-                    if _truly_empty and (not _has_structured or _prefill_exhausted) and agent._empty_content_retries < 3:
+                    # Persistent retry (#35230, #25689): when the user opts into
+                    # long-horizon persistence, empty responses keep retrying
+                    # past the hardcoded 3-attempt cap (subject to the optional
+                    # wall-clock valve) instead of degrading to "(empty)".
+                    _empty_persist = (
+                        agent._should_persist_retry("invalid_response")
+                        and not agent._persistent_retry_time_exhausted(_persistent_retry_started_at)
+                    )
+                    _empty_budget_ok = agent._empty_content_retries < 3 or _empty_persist
+                    if _truly_empty and (not _has_structured or _prefill_exhausted) and _empty_budget_ok:
                         agent._empty_content_retries += 1
                         logger.warning(
                             "Empty response (no content or reasoning) — "
-                            "retry %d/3 (model=%s)",
-                            agent._empty_content_retries, agent.model,
+                            "retry %d%s (model=%s)",
+                            agent._empty_content_retries,
+                            "" if _empty_persist else "/3",
+                            agent.model,
                         )
                         agent._buffer_status(
                             f"⚠️ Empty response from model — retrying "
-                            f"({agent._empty_content_retries}/3)"
+                            f"({agent._empty_content_retries}"
+                            f"{'' if _empty_persist else '/3'})"
                         )
+                        # Backoff before the empty-response retry (#35230).
+                        # The previous code used a bare `continue` with zero
+                        # delay, firing all retries back-to-back within seconds
+                        # and wasting API calls.  Use the same jittered backoff
+                        # as the API-error path, interrupt-aware so the user can
+                        # still abort.  Cap the growth term so unbounded
+                        # persistent retries don't all sleep at the 60s ceiling
+                        # immediately — they ramp like the bounded path.
+                        _empty_wait = jittered_backoff(
+                            min(agent._empty_content_retries, 6),
+                            base_delay=2.0,
+                            max_delay=60.0,
+                        )
+                        _empty_sleep_end = time.time() + _empty_wait
+                        _empty_touch = 0
+                        while time.time() < _empty_sleep_end:
+                            if agent._interrupt_requested:
+                                agent._vprint(
+                                    f"{agent.log_prefix}⚡ Interrupt during empty-response retry wait, aborting.",
+                                    force=True,
+                                )
+                                agent._persist_session(messages, conversation_history)
+                                agent.clear_interrupt()
+                                return {
+                                    "final_response": "Operation interrupted during empty-response retry.",
+                                    "messages": messages,
+                                    "api_calls": api_call_count,
+                                    "completed": False,
+                                    "interrupted": True,
+                                }
+                            time.sleep(0.2)
+                            _empty_touch += 1
+                            if _empty_touch % 150 == 0:  # ~30s
+                                agent._touch_activity(
+                                    f"empty-response retry backoff "
+                                    f"({int(_empty_sleep_end - time.time())}s remaining)"
+                                )
                         continue
 
                     # ── Exhausted retries — try fallback provider ──

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -840,6 +840,22 @@ DEFAULT_CONFIG = {
         # on flaky primaries; raise it if you prefer to tolerate longer
         # provider hiccups on a single provider.
         "api_max_retries": 3,
+        # Persistent retry for long-horizon / unattended agents.  When True,
+        # transient provider failures (overloaded 5xx/503/529, rate limits,
+        # timeouts, empty/malformed responses, usage/concurrent-limit throttles)
+        # keep retrying with backoff INSTEAD of giving up after
+        # ``api_max_retries`` attempts — so a flaky or overloaded provider
+        # eventually succeeds rather than failing the turn.  Authorization and
+        # other deterministic errors (401/403 auth, 402 billing, 400 bad
+        # request, content-policy blocks, model-not-found) are NEVER made
+        # persistent — those will not fix themselves by retrying.  Default
+        # False preserves the legacy bounded behavior.  See #35230, #25689.
+        "api_retry_persistent": False,
+        # Safety valve for persistent retry: maximum wall-clock seconds a single
+        # turn may spend retrying a transient failure before it finally gives
+        # up.  0 means no time limit (retry forever).  Only consulted when
+        # ``api_retry_persistent`` is True.
+        "api_retry_persistent_max_elapsed_seconds": 0,
         "service_tier": "",
         # Tool-use enforcement: injects system prompt guidance that tells the
         # model to actually call tools instead of describing intended actions.

--- a/run_agent.py
+++ b/run_agent.py
@@ -4252,7 +4252,56 @@ class AIAgent:
         index = getattr(self, "_fallback_index", 0)
         return index < len(chain)
 
-    # ── Per-turn primary restoration ─────────────────────────────────────
+    # ── Persistent retry for long-horizon agents (#35230, #25689) ────────
+
+    # Transient failure reasons that persistent retry is allowed to loop on
+    # indefinitely.  Deliberately excludes every deterministic / authorization
+    # failure: a 401/403 (auth), 402 (billing), 400 (format_error /
+    # bad request), content-policy block, and model-not-found will NOT fix
+    # themselves by retrying, so making them persistent would just hang the
+    # turn forever against a wall.  These are exactly the reasons the classifier
+    # already marks ``retryable=True`` for a *bounded* loop — persistent mode
+    # only changes how long we keep at them.  Usage-limit and concurrent-limit
+    # throttles surface as ``rate_limit`` (see error_classifier), so they are
+    # covered here.
+    _PERSISTENT_RETRY_REASONS = frozenset({
+        "overloaded",
+        "rate_limit",
+        "server_error",
+        "timeout",
+        "unknown",
+        "invalid_response",
+    })
+
+    def _should_persist_retry(self, reason: "str | FailoverReason | None") -> bool:
+        """Whether a transient failure should retry past ``api_max_retries``.
+
+        Returns True only when persistent retry is enabled in config AND the
+        failure ``reason`` is a transient one (provider overloaded, rate/usage/
+        concurrent limit, 5xx, timeout, empty/malformed response, or an
+        unclassifiable hiccup).  Authorization, billing, bad-request, and
+        content-policy failures always return False so the turn still fails
+        fast on errors that retrying cannot fix.
+        """
+        if not getattr(self, "_api_retry_persistent", False):
+            return False
+        if reason is None:
+            return False
+        reason_value = getattr(reason, "value", reason)
+        return str(reason_value) in self._PERSISTENT_RETRY_REASONS
+
+    def _persistent_retry_time_exhausted(self, started_at: float) -> bool:
+        """Whether persistent retry has exceeded its wall-clock safety valve.
+
+        ``api_retry_persistent_max_elapsed_seconds`` of 0 means retry forever;
+        any positive value caps the total time a single turn may spend in
+        persistent retry before it finally gives up.
+        """
+        cap = getattr(self, "_api_retry_persistent_max_elapsed_seconds", 0) or 0
+        if cap <= 0:
+            return False
+        import time as _time
+        return (_time.time() - started_at) >= cap
 
     def _restore_primary_runtime(self) -> bool:
         """Forwarder — see ``agent.agent_runtime_helpers.restore_primary_runtime``."""

--- a/tests/run_agent/test_persistent_retry.py
+++ b/tests/run_agent/test_persistent_retry.py
@@ -1,0 +1,122 @@
+"""Tests for persistent retry on transient provider failures.
+
+Covers the long-horizon / unattended-agent retry behavior added for #35230
+and #25689: when ``agent.api_retry_persistent`` is enabled, transient
+failures (overloaded, rate/usage/concurrent limits, 5xx, timeouts, empty/
+malformed responses) keep retrying past ``api_max_retries`` with backoff,
+while authorization and other deterministic errors still fail fast.
+"""
+import time
+from unittest.mock import patch
+
+from run_agent import AIAgent
+from agent.error_classifier import FailoverReason
+
+
+def _make_agent(persistent=None, max_elapsed=None):
+    cfg = {"agent": {}}
+    if persistent is not None:
+        cfg["agent"]["api_retry_persistent"] = persistent
+    if max_elapsed is not None:
+        cfg["agent"]["api_retry_persistent_max_elapsed_seconds"] = max_elapsed
+
+    with patch("run_agent.OpenAI"), \
+         patch("hermes_cli.config.load_config", return_value=cfg):
+        return AIAgent(
+            api_key="test-key",
+            base_url="https://openrouter.ai/api/v1",
+            model="test/model",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+
+
+# ── Config surface ──────────────────────────────────────────────────────
+
+def test_persistent_retry_defaults_off():
+    agent = _make_agent()
+    assert agent._api_retry_persistent is False
+    assert agent._api_retry_persistent_max_elapsed_seconds == 0
+
+
+def test_persistent_retry_honors_config():
+    agent = _make_agent(persistent=True)
+    assert agent._api_retry_persistent is True
+
+
+def test_persistent_retry_max_elapsed_parsed():
+    agent = _make_agent(persistent=True, max_elapsed=3600)
+    assert agent._api_retry_persistent_max_elapsed_seconds == 3600
+
+
+def test_persistent_retry_max_elapsed_clamps_negative_to_zero():
+    agent = _make_agent(persistent=True, max_elapsed=-10)
+    assert agent._api_retry_persistent_max_elapsed_seconds == 0
+
+
+def test_persistent_retry_max_elapsed_invalid_falls_back_to_zero():
+    agent = _make_agent(persistent=True, max_elapsed="not-a-number")
+    assert agent._api_retry_persistent_max_elapsed_seconds == 0
+
+
+# ── _should_persist_retry: transient vs deterministic ───────────────────
+
+def test_should_persist_retry_false_when_disabled():
+    agent = _make_agent(persistent=False)
+    assert agent._should_persist_retry(FailoverReason.overloaded) is False
+    assert agent._should_persist_retry(FailoverReason.rate_limit) is False
+
+
+def test_should_persist_retry_true_for_transient_reasons():
+    agent = _make_agent(persistent=True)
+    # Provider-side / throttle / transport reasons should persist.
+    for reason in (
+        FailoverReason.overloaded,
+        FailoverReason.rate_limit,    # also covers usage- and concurrent-limit throttles
+        FailoverReason.server_error,
+        FailoverReason.timeout,
+        FailoverReason.unknown,
+    ):
+        assert agent._should_persist_retry(reason) is True, reason
+    # The invalid/empty-response sentinel is passed as a bare string.
+    assert agent._should_persist_retry("invalid_response") is True
+
+
+def test_should_persist_retry_false_for_authorization_and_deterministic():
+    agent = _make_agent(persistent=True)
+    # These never fix themselves by retrying — must fail fast.
+    for reason in (
+        FailoverReason.auth,
+        FailoverReason.auth_permanent,
+        FailoverReason.billing,
+        FailoverReason.format_error,
+        FailoverReason.content_policy_blocked,
+        FailoverReason.model_not_found,
+        FailoverReason.provider_policy_blocked,
+        FailoverReason.context_overflow,
+    ):
+        assert agent._should_persist_retry(reason) is False, reason
+
+
+def test_should_persist_retry_handles_none():
+    agent = _make_agent(persistent=True)
+    assert agent._should_persist_retry(None) is False
+
+
+# ── _persistent_retry_time_exhausted: the safety valve ──────────────────
+
+def test_time_exhausted_false_when_no_cap():
+    agent = _make_agent(persistent=True, max_elapsed=0)
+    # Even an ancient start time never exhausts when cap is 0 (retry forever).
+    assert agent._persistent_retry_time_exhausted(time.time() - 10_000) is False
+
+
+def test_time_exhausted_true_once_cap_exceeded():
+    agent = _make_agent(persistent=True, max_elapsed=60)
+    assert agent._persistent_retry_time_exhausted(time.time() - 120) is True
+
+
+def test_time_exhausted_false_within_cap():
+    agent = _make_agent(persistent=True, max_elapsed=600)
+    assert agent._persistent_retry_time_exhausted(time.time() - 5) is False


### PR DESCRIPTION
## Problem

Long-running / unattended agents fail a turn when the provider has a **transient** problem, even though retrying would eventually succeed. This is painful for long-horizon agents (e.g. a Z.AI GLM agent driving a multi-hour task) where the user is fine waiting as long as it keeps retrying.

Three separate ceilings caused premature failure:

1. **API-error retry loop** (`conversation_loop.py` ~3275) gives up after `api_max_retries` even when the failure is transient (overloaded `503`/`529`, `5xx`, rate/usage/concurrent-limit throttles, timeouts) and no fallback chain is configured.
2. **Invalid/empty/malformed-response path** (~1294) fails the turn after `api_max_retries`.
3. **Post-response empty-content path** (~4263) is hardcoded to 3 retries **and** used a bare `continue` with zero backoff — firing all retries back-to-back within seconds (this is exactly #35230).

## Fix

Adds an **opt-in** `agent.api_retry_persistent` mode. When enabled, transient failures keep retrying with jittered backoff instead of failing the turn, bounded only by an optional `agent.api_retry_persistent_max_elapsed_seconds` wall-clock valve (`0` = retry forever).

**Authorization and other deterministic errors are never made persistent** — `401/403` auth, `402` billing, `400` bad request, content-policy blocks, and model-not-found all still fail fast, because retrying cannot fix them. The allow-list (`_should_persist_retry`) is intentionally restricted to the reasons the classifier already marks `retryable=True`: `overloaded`, `rate_limit` (which also covers usage- and concurrent-limit throttles), `server_error`, `timeout`, `unknown`, and the `invalid_response`/empty sentinel.

Independently, the empty-content path's **missing backoff is fixed for all users** (#35230), not just persistent mode: the bare `continue` is replaced with the same interrupt-aware jittered backoff used by the API-error path.

Defaults preserve existing bounded behavior (`api_retry_persistent: false`).

## Changes

- `hermes_cli/config.py` — new config keys + inline docs
- `agent/agent_init.py` — load the new fields onto the agent
- `run_agent.py` — `_should_persist_retry()` + `_persistent_retry_time_exhausted()` helpers
- `agent/conversation_loop.py` — wire persistence into all three retry ceilings; add backoff to the empty-content path; also stop the empty/malformed invalid-response path from short-circuiting to fallback before the retry budget is spent
- `tests/run_agent/test_persistent_retry.py` — config parsing + decision-logic coverage (transient persists, auth/billing/format fail fast, time valve)

## Testing

- New: `tests/run_agent/test_persistent_retry.py` (12 cases)
- Regression: `test_error_classifier`, `test_turn_retry_state`, `test_empty_response_recovery_persistence`, `test_provider_fallback`, `test_retry_status_buffer`, `test_jsondecodeerror_retryable`, `test_nous_429_fallback_reentry`, `test_empty_model_fallback`, `test_empty_model_recovery`, `test_api_max_retries_config`, `test_turn_completion_explainer` — **all green (259 passed)**

Addresses #35230 (empty-response backoff) and the long-horizon retry gap also seen in #25689.

Written by Zephyr (AI Assistant)
