### PR TITLE
chore(deps): temporarily disable Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -28,7 +28,9 @@ updates:
     schedule:
       interval: "weekly"
       day: "monday"
-    open-pull-requests-limit: 5
+    # Temporarily disabled while we investigate duplicate Dependabot PRs
+    # triggered by PR-check automation. Restore to 5 once the approach is fixed.
+    open-pull-requests-limit: 0
     labels:
       - "dependencies"
       - "github-actions"


### PR DESCRIPTION
## Summary
- Temporarily set Dependabot's GitHub Actions update PR limit to 0
- Leave the existing configuration in place with a comment so it can be restored once the duplicate-PR interaction with PR-check automation is understood

## Validation
- Parsed .github/dependabot.yml with Python/YAML and confirmed open-pull-requests-limit is 0
