### PR TITLE
fix(desktop): scope artifacts to the active profile

### DIFF
--- a/apps/desktop/src/app/artifacts/index.test.ts
+++ b/apps/desktop/src/app/artifacts/index.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest'
 
 import type { SessionInfo, SessionMessage } from '@/types/hermes'
 
-import { collectArtifactsForSession } from './index'
+import { artifactSessionProfileScope, collectArtifactsForSession } from './index'
 
 function makeSession(overrides: Partial<SessionInfo> = {}): SessionInfo {
   return {
@@ -58,5 +58,15 @@ describe('collectArtifactsForSession', () => {
       kind: 'link',
       value: 'https://example.com/changelog/latest'
     })
+  })
+})
+
+describe('artifactSessionProfileScope', () => {
+  it('maps the unified profile sentinel to the all-profiles API scope', () => {
+    expect(artifactSessionProfileScope('__all__')).toBe('all')
+  })
+
+  it('keeps concrete profile keys scoped to that profile', () => {
+    expect(artifactSessionProfileScope('work')).toBe('work')
   })
 })

--- a/apps/desktop/src/app/artifacts/index.tsx
+++ b/apps/desktop/src/app/artifacts/index.tsx
@@ -1,3 +1,4 @@
+import { useStore } from '@nanostores/react'
 import type * as React from 'react'
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
@@ -26,6 +27,7 @@ import { FileImage, FileText, FolderOpen, Link2 } from '@/lib/icons'
 import { mediaExternalUrl } from '@/lib/media'
 import { cn } from '@/lib/utils'
 import { notifyError } from '@/store/notifications'
+import { $profileScope, ALL_PROFILES } from '@/store/profile'
 import type { SessionInfo, SessionMessage } from '@/types/hermes'
 
 import { useRefreshHotkey } from '../hooks/use-refresh-hotkey'
@@ -362,6 +364,10 @@ interface ArtifactColumn {
 const itemsLabel = (f: ArtifactFilter, a: Translations['artifacts']) =>
   f === 'link' ? a.itemsLink : f === 'file' ? a.itemsFile : a.itemsGeneric
 
+export function artifactSessionProfileScope(profileScope: string): 'all' | (string & {}) {
+  return profileScope === ALL_PROFILES ? 'all' : profileScope
+}
+
 interface ArtifactsViewProps extends React.ComponentProps<'section'> {
   setStatusbarItemGroup?: SetStatusbarItemGroup
 }
@@ -370,6 +376,7 @@ export function ArtifactsView({ setStatusbarItemGroup: _setStatusbarItemGroup, .
   const { t } = useI18n()
   const a = t.artifacts
   const navigate = useNavigate()
+  const profileScope = useStore($profileScope)
   const [artifacts, setArtifacts] = useState<ArtifactRecord[] | null>(null)
   const [query, setQuery] = useState('')
   const [refreshing, setRefreshing] = useState(false)
@@ -384,7 +391,9 @@ export function ArtifactsView({ setStatusbarItemGroup: _setStatusbarItemGroup, .
     setRefreshing(true)
 
     try {
-      const sessions = (await listAllProfileSessions(30, 1)).sessions
+      const sessions = (await listAllProfileSessions(30, 1, 'exclude', 'recent', artifactSessionProfileScope(profileScope)))
+        .sessions
+
       const results = await Promise.allSettled(sessions.map(session => getSessionMessages(session.id, session.profile)))
       const nextArtifacts: ArtifactRecord[] = []
 
@@ -404,7 +413,7 @@ export function ArtifactsView({ setStatusbarItemGroup: _setStatusbarItemGroup, .
     } finally {
       setRefreshing(false)
     }
-  }, [a])
+  }, [a, profileScope])
 
   useRefreshHotkey(refreshArtifacts)
 


### PR DESCRIPTION
## Summary
- scope desktop Artifacts session discovery to the current profile context instead of always querying all profiles
- preserve the explicit all-profiles browse mode by mapping the ALL_PROFILES sentinel to the existing all-profiles API scope
- add a narrow artifacts test for the profile-scope mapping helper

## Testing
- git diff --check
- npm exec --workspace apps/desktop -- vitest run --environment jsdom src/app/artifacts/index.test.ts
- npm exec --workspace apps/desktop -- eslint src/app/artifacts/index.tsx src/app/artifacts/index.test.ts

Fixes #47455