### PR TITLE
test(tui): cover render bridge fallbacks

### DIFF
--- a/tests/tui_gateway/test_render.py
+++ b/tests/tui_gateway/test_render.py
@@ -1,11 +1,12 @@
 """Tests for tui_gateway.render — rendering bridge fallback behavior."""
 
-from unittest.mock import MagicMock, patch
+from types import ModuleType
+from unittest.mock import patch
 
 from tui_gateway.render import make_stream_renderer, render_diff, render_message
 
 
-def _stub_rich(mock_mod):
+def _stub_rich(mock_mod: ModuleType):
     return patch.dict("sys.modules", {"agent.rich_output": mock_mod})
 
 
@@ -21,7 +22,31 @@ def test_render_message_none_without_module():
         assert render_message("hello") is None
 
 
+def test_render_message_falls_back_for_legacy_signature():
+    mod = ModuleType("agent.rich_output")
+
+    def format_response(text):
+        return text.upper()
+
+    setattr(mod, "format_response", format_response)
+
+    with _stub_rich(mod):
+        assert render_message("hello", cols=42) == "HELLO"
+
+
 # ── render_diff / make_stream_renderer ───────────────────────────────
+
+
+def test_render_diff_falls_back_for_legacy_signature():
+    mod = ModuleType("agent.rich_output")
+
+    def legacy_render_diff(text):
+        return f"legacy:{text}"
+
+    setattr(mod, "render_diff", legacy_render_diff)
+
+    with _stub_rich(mod):
+        assert render_diff("patch", cols=120) == "legacy:patch"
 
 
 def test_stream_renderer_none_without_module():
@@ -29,3 +54,13 @@ def test_stream_renderer_none_without_module():
         assert make_stream_renderer() is None
 
 
+def test_stream_renderer_falls_back_for_legacy_signature():
+    mod = ModuleType("agent.rich_output")
+
+    class StreamingRenderer:
+        pass
+
+    setattr(mod, "StreamingRenderer", StreamingRenderer)
+
+    with _stub_rich(mod):
+        assert isinstance(make_stream_renderer(cols=132), StreamingRenderer)


### PR DESCRIPTION
This adds focused coverage for the three legacy renderer fallbacks in `tui_gateway/render.py`.

Each legacy fixture leaves out `cols` entirely. Python raises the real compatibility `TypeError` on the first call, then the retry without `cols` succeeds.

I kept the smaller test file from current `main` instead of restoring the broader mock-heavy coverage removed by the recent test cleanup.

I ran `scripts/run_tests.sh tests/tui_gateway/test_render.py -q`, which passed all 5 tests. Ruff, formatting, ty, and `git diff --check` also pass.

Closes #36613