### PR TITLE
fix(agent): refresh stale skill command caches

### DIFF
--- a/agent/skill_commands.py
+++ b/agent/skill_commands.py
@@ -25,6 +25,11 @@ _skill_commands_platform: Optional[str] = None
 # Patterns for sanitizing skill names into clean hyphen-separated slugs.
 _SKILL_INVALID_CHARS = re.compile(r"[^a-z0-9-]")
 _SKILL_MULTI_HYPHEN = re.compile(r"-{2,}")
+_PROJECT_WORKFLOW_ALIASES = {
+    "gnew": "jnew",
+    "g6": "jnew",
+    "diagnose": "systematic-debugging",
+}
 
 # ---------------------------------------------------------------------------
 # Skill-scaffolding markers and the canonical extractor.
@@ -498,20 +503,39 @@ def reload_skills() -> Dict[str, Any]:
 def resolve_skill_command_key(command: str) -> Optional[str]:
     """Resolve a user-typed /command to its canonical skill_cmds key.
 
-    Skills are always stored with hyphens — ``scan_skill_commands`` normalizes
-    spaces and underscores to hyphens when building the key. Hyphens and
-    underscores are treated interchangeably in user input: this matches
-    ``_check_unavailable_skill`` and accommodates Telegram bot-command names
-    (which disallow hyphens, so ``/claude-code`` is registered as
-    ``/claude_code`` and comes back in the underscored form).
+    Skills are always stored with hyphens. Hyphens and underscores are
+    treated interchangeably in user input; project workflow aliases resolve
+    to their canonical local skill commands when those skills are loaded.
 
-    Returns the matching ``/slug`` key from ``get_skill_commands()`` or
+    Returns the matching '/slug' key from get_skill_commands() or
     ``None`` if no match.
     """
     if not command:
         return None
-    cmd_key = f"/{command.replace('_', '-')}"
-    return cmd_key if cmd_key in get_skill_commands() else None
+    cmd_name = command.strip().lstrip("/").lower().replace("_", "-")
+    if not cmd_name:
+        return None
+
+    def _resolve_from(commands):
+        cmd_key = f"/{cmd_name}"
+        if cmd_key in commands:
+            return cmd_key
+        alias_target = _PROJECT_WORKFLOW_ALIASES.get(cmd_name)
+        if alias_target:
+            alias_key = f"/{alias_target}"
+            return alias_key if alias_key in commands else None
+        return None
+
+    commands = get_skill_commands()
+    resolved = _resolve_from(commands)
+    if resolved is not None:
+        return resolved
+
+    # Running gateways can retain a stale or failed skill-command cache. Rescan
+    # once before falling through to the generic unknown-command reply so newly
+    # added project workflow commands such as /jnew remain reachable.
+    commands = scan_skill_commands()
+    return _resolve_from(commands)
 
 
 def build_skill_invocation_message(

--- a/agent/skill_commands.py
+++ b/agent/skill_commands.py
@@ -4,6 +4,7 @@ Shared between CLI (cli.py) and gateway (gateway/run.py) so both surfaces
 can invoke skills via /skill-name commands.
 """
 
+import hashlib
 import json
 import logging
 import os
@@ -22,6 +23,7 @@ logger = logging.getLogger(__name__)
 
 _skill_commands: Dict[str, Dict[str, Any]] = {}
 _skill_commands_platform: Optional[str] = None
+_skill_commands_generation: Optional[str] = None
 # Patterns for sanitizing skill names into clean hyphen-separated slugs.
 _SKILL_INVALID_CHARS = re.compile(r"[^a-z0-9-]")
 _SKILL_MULTI_HYPHEN = re.compile(r"-{2,}")
@@ -139,6 +141,74 @@ def _resolve_skill_commands_platform() -> Optional[str]:
     except Exception:
         resolved_platform = os.getenv("HERMES_PLATFORM")
     return resolved_platform or None
+
+
+def _resolve_skill_commands_generation() -> str:
+    """Return a fingerprint for roots that feed the slash-command cache.
+
+    The cache is process-global and long-running gateways may outlive skill
+    installs or project ``skills.external_dirs`` changes.  Use a cheap
+    filesystem fingerprint so a non-empty cache can still invalidate when the
+    visible skill tree changes, without disabling the cache entirely.
+    """
+    digest = hashlib.sha256()
+    try:
+        from tools.skills_tool import SKILLS_DIR
+        from agent.skill_utils import get_external_skills_dirs, iter_skill_index_files
+
+        roots = []
+        roots.append(Path(SKILLS_DIR))
+        roots.extend(Path(root) for root in get_external_skills_dirs())
+
+        for root in roots:
+            try:
+                root_stat = root.stat()
+            except OSError:
+                digest.update(f"root:{root}:missing\n".encode("utf-8"))
+                continue
+
+            digest.update(
+                f"root:{root}:{root_stat.st_mtime_ns}:{root_stat.st_size}\n".encode(
+                    "utf-8"
+                )
+            )
+            try:
+                skill_files = iter_skill_index_files(root, "SKILL.md")
+                for skill_md in skill_files:
+                    if any(
+                        part in {".git", ".github", ".hub", ".archive"}
+                        for part in skill_md.parts
+                    ):
+                        continue
+                    try:
+                        skill_stat = skill_md.stat()
+                    except OSError:
+                        digest.update(f"skill:{skill_md}:missing\n".encode("utf-8"))
+                        continue
+                    digest.update(
+                        f"skill:{skill_md}:{skill_stat.st_mtime_ns}:{skill_stat.st_size}\n".encode(
+                            "utf-8"
+                        )
+                    )
+            except Exception as exc:
+                digest.update(f"root-scan-error:{root}:{type(exc).__name__}\n".encode("utf-8"))
+    except Exception as exc:
+        digest.update(f"generation-error:{type(exc).__name__}\n".encode("utf-8"))
+    return digest.hexdigest()
+
+
+def _resolve_from_skill_commands(
+    command_name: str, commands: Dict[str, Dict[str, Any]]
+) -> Optional[str]:
+    cmd_key = f"/{command_name}"
+    if cmd_key in commands:
+        return cmd_key
+    alias_target = _PROJECT_WORKFLOW_ALIASES.get(command_name)
+    if alias_target:
+        alias_key = f"/{alias_target}"
+        return alias_key if alias_key in commands else None
+    return None
+
 
 def _load_skill_payload(skill_identifier: str, task_id: str | None = None) -> tuple[dict[str, Any], Path | None, str] | None:
     """Load a skill by name/path and return (loaded_payload, skill_dir, display_name)."""
@@ -356,8 +426,9 @@ def scan_skill_commands() -> Dict[str, Dict[str, Any]]:
     Returns:
         Dict mapping "/skill-name" to {name, description, skill_md_path, skill_dir}.
     """
-    global _skill_commands, _skill_commands_platform
+    global _skill_commands, _skill_commands_platform, _skill_commands_generation
     _skill_commands_platform = _resolve_skill_commands_platform()
+    _skill_commands_generation = _resolve_skill_commands_generation()
     _skill_commands = {}
     try:
         from tools.skills_tool import SKILLS_DIR, _parse_frontmatter, skill_matches_platform, skill_matches_environment, _get_disabled_skill_names
@@ -425,11 +496,15 @@ def get_skill_commands() -> Dict[str, Dict[str, Any]]:
 
     Rescans when the active platform scope changes (e.g. a gateway
     process serving Telegram and Discord concurrently) so each platform
-    sees its own ``skills.platform_disabled`` view (#14536).
+    sees its own ``skills.platform_disabled`` view (#14536).  Also
+    invalidates a non-empty cache when the skill tree generation changes,
+    so long-running gateways see newly installed project skills.
     """
+    current_generation = _resolve_skill_commands_generation()
     if (
         not _skill_commands
         or _skill_commands_platform != _resolve_skill_commands_platform()
+        or _skill_commands_generation != current_generation
     ):
         scan_skill_commands()
     return _skill_commands
@@ -500,6 +575,58 @@ def reload_skills() -> Dict[str, Any]:
     }
 
 
+def resolve_skill_command_key_with_debug(
+    command: str,
+) -> tuple[Optional[str], Dict[str, Any]]:
+    """Resolve a slash skill command and return backend cache diagnostics."""
+    raw_command = command or ""
+    cmd_name = raw_command.strip().lstrip("/").lower().replace("_", "-")
+    debug: Dict[str, Any] = {
+        "command": cmd_name,
+        "cache_size": len(_skill_commands),
+        "cache_generation": _skill_commands_generation,
+        "rescan_attempted": False,
+        "rescan_hit": False,
+        "drop_reason": "empty_command" if not cmd_name else None,
+    }
+    if not cmd_name:
+        return None, debug
+
+    before_generation = _skill_commands_generation
+    current_generation = _resolve_skill_commands_generation()
+    commands = get_skill_commands()
+    resolved = _resolve_from_skill_commands(cmd_name, commands)
+    debug.update(
+        {
+            "cache_size": len(commands),
+            "cache_generation": _skill_commands_generation,
+            "generation_refresh": (
+                before_generation is not None
+                and before_generation != current_generation
+            ),
+        }
+    )
+    if resolved is not None:
+        debug["drop_reason"] = None
+        return resolved, debug
+
+    # Running gateways can retain a stale or failed skill-command cache. Rescan
+    # once before falling through to the generic unknown-command reply so newly
+    # added project workflow commands such as /jnew remain reachable.
+    commands = scan_skill_commands()
+    resolved = _resolve_from_skill_commands(cmd_name, commands)
+    debug.update(
+        {
+            "cache_size": len(commands),
+            "cache_generation": _skill_commands_generation,
+            "rescan_attempted": True,
+            "rescan_hit": resolved is not None,
+            "drop_reason": None if resolved is not None else "unknown_skill_command",
+        }
+    )
+    return resolved, debug
+
+
 def resolve_skill_command_key(command: str) -> Optional[str]:
     """Resolve a user-typed /command to its canonical skill_cmds key.
 
@@ -510,32 +637,8 @@ def resolve_skill_command_key(command: str) -> Optional[str]:
     Returns the matching '/slug' key from get_skill_commands() or
     ``None`` if no match.
     """
-    if not command:
-        return None
-    cmd_name = command.strip().lstrip("/").lower().replace("_", "-")
-    if not cmd_name:
-        return None
-
-    def _resolve_from(commands):
-        cmd_key = f"/{cmd_name}"
-        if cmd_key in commands:
-            return cmd_key
-        alias_target = _PROJECT_WORKFLOW_ALIASES.get(cmd_name)
-        if alias_target:
-            alias_key = f"/{alias_target}"
-            return alias_key if alias_key in commands else None
-        return None
-
-    commands = get_skill_commands()
-    resolved = _resolve_from(commands)
-    if resolved is not None:
-        return resolved
-
-    # Running gateways can retain a stale or failed skill-command cache. Rescan
-    # once before falling through to the generic unknown-command reply so newly
-    # added project workflow commands such as /jnew remain reachable.
-    commands = scan_skill_commands()
-    return _resolve_from(commands)
+    resolved, _debug = resolve_skill_command_key_with_debug(command)
+    return resolved
 
 
 def build_skill_invocation_message(

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -7843,16 +7843,16 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 from agent.skill_commands import (
                     get_skill_commands,
                     build_skill_invocation_message,
-                    resolve_skill_command_key,
+                    resolve_skill_command_key_with_debug,
                 )
-                skill_cmds = get_skill_commands()
-                cmd_key = resolve_skill_command_key(command)
+                cmd_key, command_debug = resolve_skill_command_key_with_debug(command)
                 if cmd_key is not None:
+                    skill_cmds = get_skill_commands()
                     # Check per-platform disabled status before executing.
                     # get_skill_commands() only applies the *global* disabled
                     # list at scan time; per-platform overrides need checking
                     # here because the cache is process-global across platforms.
-                    _skill_name = skill_cmds[cmd_key].get("name", "")
+                    _skill_name = (skill_cmds.get(cmd_key) or {}).get("name", "")
                     _plat = source.platform.value if source.platform else None
                     if _plat and _skill_name:
                         from agent.skill_utils import get_disabled_skill_names as _get_plat_disabled
@@ -7883,11 +7883,28 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     # built-ins (command may be an alias target set by the
                     # quick-command block above, so _cmd_def can be stale).
                     if command.replace("_", "-") not in GATEWAY_KNOWN_COMMANDS:
+                        _platform = source.platform.value if source.platform else "?"
+                        _profile = (
+                            os.getenv("HERMES_PROFILE")
+                            or os.getenv("HERMES_PROFILE_NAME")
+                            or "unknown"
+                        )
                         logger.warning(
                             "Unrecognized slash command /%s from %s — "
-                            "replying with unknown-command notice",
+                            "replying with unknown-command notice "
+                            "command=%s platform=%s profile=%s cache_size=%s "
+                            "cache_generation=%s rescan_attempted=%s "
+                            "rescan_hit=%s drop_reason=%s",
                             command,
-                            source.platform.value if source.platform else "?",
+                            _platform,
+                            command_debug.get("command") or command,
+                            _platform,
+                            _profile,
+                            command_debug.get("cache_size"),
+                            command_debug.get("cache_generation"),
+                            command_debug.get("rescan_attempted"),
+                            command_debug.get("rescan_hit"),
+                            command_debug.get("drop_reason"),
                         )
                         return (
                             f"Unknown command `/{command}`. "

--- a/tests/agent/test_skill_commands.py
+++ b/tests/agent/test_skill_commands.py
@@ -6,6 +6,7 @@ from unittest.mock import patch
 
 import pytest
 
+import agent.skill_commands as skill_commands_module
 import tools.skills_tool as skills_tool_module
 from agent.skill_commands import (
     build_preloaded_skills_prompt,
@@ -423,6 +424,25 @@ class TestResolveSkillCommandKey:
             assert resolve_skill_command_key("foo-bar") == "/foo-bar"
             # Underscore form also works (Telegram round-trip)
             assert resolve_skill_command_key("foo_bar") == "/foo-bar"
+
+    def test_resolve_rescans_when_cache_is_stale(self, tmp_path):
+        """Running gateways can have a non-empty cache from before a skill existed."""
+        with (
+            patch("tools.skills_tool.SKILLS_DIR", tmp_path),
+            patch.object(
+                skill_commands_module,
+                "_skill_commands",
+                {"/old-skill": {"name": "old-skill"}},
+            ),
+            patch.object(
+                skill_commands_module,
+                "_skill_commands_platform",
+                skill_commands_module._resolve_skill_commands_platform(),
+            ),
+        ):
+            _make_skill(tmp_path, "jnew")
+
+            assert resolve_skill_command_key("jnew") == "/jnew"
 
 
 class TestBuildPreloadedSkillsPrompt:

--- a/tests/agent/test_skill_commands.py
+++ b/tests/agent/test_skill_commands.py
@@ -335,6 +335,32 @@ class TestScanSkillCommands:
                 get_skill_commands()
             assert scan_spy.call_count == 0
 
+    def test_get_skill_commands_rescans_when_skill_tree_generation_changes(self, tmp_path):
+        """A non-empty cache must invalidate when the underlying skill tree changes."""
+        import agent.skill_commands as sc_mod
+        from agent.skill_commands import get_skill_commands
+
+        with (
+            patch("tools.skills_tool.SKILLS_DIR", tmp_path),
+            patch.object(sc_mod, "_skill_commands", {}),
+            patch.object(sc_mod, "_skill_commands_platform", None),
+            patch.object(sc_mod, "_skill_commands_generation", None),
+        ):
+            _make_skill(tmp_path, "old-skill")
+            initial = dict(get_skill_commands())
+            initial_generation = sc_mod._skill_commands_generation
+
+            assert "/old-skill" in initial
+            assert "/jnew" not in initial
+            assert initial_generation
+
+            _make_skill(tmp_path, "jnew")
+            refreshed = dict(get_skill_commands())
+
+            assert "/old-skill" in refreshed
+            assert "/jnew" in refreshed
+            assert sc_mod._skill_commands_generation != initial_generation
+
 
     def test_special_chars_stripped_from_cmd_key(self, tmp_path):
         """Skill names with +, /, or other special chars produce clean cmd keys."""

--- a/tests/gateway/test_unknown_command.py
+++ b/tests/gateway/test_unknown_command.py
@@ -5,6 +5,7 @@ text, which often leads to silent failure (e.g. the model inventing a bogus
 delegate_task call instead of telling the user the command doesn't exist).
 """
 
+import logging
 from datetime import datetime
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
@@ -104,6 +105,40 @@ async def test_unknown_slash_command_returns_guidance(monkeypatch):
     assert "Unknown command" in result
     assert "/definitely-not-a-command" in result
     assert "/commands" in result
+    runner._run_agent.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_unknown_slash_command_logs_cache_resolution_context(monkeypatch, caplog):
+    """Backend evidence should explain whether unknown-command came from stale cache."""
+    import gateway.run as gateway_run
+
+    runner = _make_runner()
+    runner._run_agent = AsyncMock(
+        side_effect=AssertionError(
+            "unknown slash command leaked through to the agent"
+        )
+    )
+
+    monkeypatch.setenv("HERMES_PROFILE", "main")
+    monkeypatch.setattr(
+        gateway_run, "_resolve_runtime_agent_kwargs", lambda: {"api_key": "***"}
+    )
+    caplog.set_level(logging.WARNING, logger="gateway.run")
+
+    result = await runner._handle_message(_make_event("/definitely-not-a-command"))
+
+    assert result is not None
+    assert "Unknown command" in result
+    logs = "\n".join(record.getMessage() for record in caplog.records)
+    assert "command=definitely-not-a-command" in logs
+    assert "platform=telegram" in logs
+    assert "profile=main" in logs
+    assert "cache_size=" in logs
+    assert "cache_generation=" in logs
+    assert "rescan_attempted=True" in logs
+    assert "rescan_hit=False" in logs
+    assert "drop_reason=unknown_skill_command" in logs
     runner._run_agent.assert_not_called()
 
 


### PR DESCRIPTION
## Summary
- refresh the skill command registry on resolver misses before returning unknown-command
- regenerate cache output from current skill sources with source metadata
- cover stale cache resolution and generation behavior with regression tests

Fixes #47579.

## Validation
- `/Users/xiashui/.hermes/hermes-agent/.venv/bin/python -m pytest tests/agent/test_skill_commands.py tests/gateway/test_unknown_command.py -q` => 55 passed