### PR TITLE
feat(gateway): add health probe aliases

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -1807,9 +1807,20 @@ class APIServerAdapter(BasePlatformAdapter):
         mirrors without starting a real aiohttp listener.
         """
         routes: List[tuple] = [
+            # Liveness endpoints: public, cheap, and intentionally do not run
+            # runtime readiness probes.
             ("GET", "/health", self._handle_health),
-            ("GET", "/health/detailed", self._handle_health_detailed),
+            ("GET", "/healthz", self._handle_health),
+            ("GET", "/livez", self._handle_health),
             ("GET", "/v1/health", self._handle_health),
+            ("GET", "/v1/healthz", self._handle_health),
+            ("GET", "/v1/livez", self._handle_health),
+            # Readiness endpoints: same authenticated rich contract as
+            # /health/detailed, because they report runtime readiness rather
+            # than simple process liveness.
+            ("GET", "/health/detailed", self._handle_health_detailed),
+            ("GET", "/readyz", self._handle_health_detailed),
+            ("GET", "/v1/readyz", self._handle_health_detailed),
             ("GET", "/v1/models", self._handle_models),
             ("GET", "/api/model/options", self._handle_model_options),
             ("GET", "/v1/capabilities", self._handle_capabilities),

--- a/gateway/platforms/webhook.py
+++ b/gateway/platforms/webhook.py
@@ -288,6 +288,8 @@ class WebhookAdapter(BasePlatformAdapter):
         # Content-Length and would otherwise bypass the header check below.
         app = web.Application(client_max_size=self._max_body_bytes)
         app.router.add_get("/health", self._handle_health)
+        app.router.add_get("/healthz", self._handle_health)
+        app.router.add_get("/livez", self._handle_health)
         app.router.add_post("/webhooks/{route_name}", self._handle_webhook)
         # Multi-profile multiplexing: a /p/<profile>/webhooks/<route> prefix
         # routes the inbound event to that profile. Same handler; the profile is

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -304,24 +304,15 @@ def _create_app(adapter: APIServerAdapter) -> web.Application:
     mws = [mw for mw in (cors_middleware, security_headers_middleware) if mw is not None]
     app = web.Application(middlewares=mws)
     app["api_server_adapter"] = adapter
-    app.router.add_get("/health", adapter._handle_health)
-    app.router.add_get("/health/detailed", adapter._handle_health_detailed)
-    app.router.add_get("/v1/health", adapter._handle_health)
-    app.router.add_get("/v1/models", adapter._handle_models)
-    app.router.add_get("/api/model/options", adapter._handle_model_options)
-    app.router.add_get("/v1/capabilities", adapter._handle_capabilities)
-    app.router.add_get("/v1/skills", adapter._handle_skills)
-    app.router.add_get("/v1/toolsets", adapter._handle_toolsets)
-    app.router.add_post("/api/sessions/{session_id}/chat", adapter._handle_session_chat)
-    app.router.add_post("/api/sessions/{session_id}/chat/stream", adapter._handle_session_chat_stream)
-    app.router.add_post("/v1/chat/completions", adapter._handle_chat_completions)
-    app.router.add_post("/v1/responses", adapter._handle_responses)
-    app.router.add_get("/v1/responses/{response_id}", adapter._handle_get_response)
-    app.router.add_delete("/v1/responses/{response_id}", adapter._handle_delete_response)
-    app.router.add_post(
-        "/api/platforms/{platform}/events",
-        adapter._handle_platform_event_callback,
-    )
+    for method, path, handler in adapter._http_route_table():
+        if method == "GET":
+            app.router.add_get(path, handler)
+        elif method == "POST":
+            app.router.add_post(path, handler)
+        elif method == "PATCH":
+            app.router.add_patch(path, handler)
+        elif method == "DELETE":
+            app.router.add_delete(path, handler)
     return app
 
 
@@ -432,6 +423,34 @@ class TestRunEventCallback:
 
 
 class TestHealthEndpoint:
+
+    def test_probe_aliases_registered_on_production_route_table(self, adapter):
+        routes = {(method, path, handler) for method, path, handler in adapter._http_route_table()}
+        for path in ("/health", "/healthz", "/livez", "/v1/health", "/v1/healthz", "/v1/livez"):
+            assert ("GET", path, adapter._handle_health) in routes
+        for path in ("/health/detailed", "/readyz", "/v1/readyz"):
+            assert ("GET", path, adapter._handle_health_detailed) in routes
+
+    @pytest.mark.asyncio
+    async def test_liveness_aliases_do_not_run_readiness_probes(self, adapter):
+        app = _create_app(adapter)
+        with patch("gateway.platforms.api_server.collect_runtime_readiness") as probe:
+            async with TestClient(TestServer(app)) as cli:
+                for path in ("/healthz", "/livez", "/v1/healthz", "/v1/livez"):
+                    resp = await cli.get(path)
+                    assert resp.status == 200
+                    assert (await resp.json())["status"] == "ok"
+        probe.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_readyz_alias_uses_authenticated_detailed_readiness(self, adapter):
+        app = _create_app(adapter)
+        with patch("gateway.platforms.api_server.collect_runtime_readiness", return_value={"status": "ok", "reason": "ready", "problems": []}) as probe:
+            async with TestClient(TestServer(app)) as cli:
+                resp = await cli.get("/readyz")
+                assert resp.status == 200
+        probe.assert_called_once()
+
     @pytest.mark.asyncio
     async def test_security_headers_present(self, adapter):
         """Responses should include basic security headers."""

--- a/tests/gateway/test_webhook_adapter.py
+++ b/tests/gateway/test_webhook_adapter.py
@@ -1002,3 +1002,49 @@ def test_route_profile_validation_fails_closed():
         assert WebhookAdapter._route_allows_profile(
             {"profile": malformed}, "worker"
         ) is False
+
+
+def test_webhook_health_aliases_registered_on_connect(monkeypatch):
+    from gateway.config import PlatformConfig
+    from gateway.platforms.webhook import WebhookAdapter
+
+    adapter = WebhookAdapter(PlatformConfig(enabled=True, extra={"routes": {}}))
+    registered = []
+
+    class FakeRouter:
+        def add_get(self, path, handler):
+            registered.append(("GET", path, handler))
+        def add_post(self, path, handler):
+            registered.append(("POST", path, handler))
+
+    class FakeApp:
+        router = FakeRouter()
+
+    class FakeRunner:
+        def __init__(self, app):
+            self.app = app
+        async def setup(self):
+            return None
+        async def cleanup(self):
+            return None
+
+    class FakeSite:
+        def __init__(self, runner, host, port, **kwargs):
+            self.runner = runner
+            self.host = host
+            self.port = port
+            self.kwargs = kwargs
+        async def start(self):
+            return None
+
+    monkeypatch.setattr("gateway.platforms.webhook.web.Application", lambda *a, **k: FakeApp())
+    monkeypatch.setattr("gateway.platforms.webhook.web.AppRunner", FakeRunner)
+    monkeypatch.setattr("gateway.platforms.webhook.web.TCPSite", FakeSite)
+
+    import asyncio
+    assert asyncio.run(adapter.connect()) is True
+    try:
+        for path in ("/health", "/healthz", "/livez"):
+            assert ("GET", path, adapter._handle_health) in registered
+    finally:
+        asyncio.run(adapter.disconnect())


### PR DESCRIPTION
## Summary
- add public liveness aliases for API server: `/healthz`, `/livez`, `/v1/healthz`, `/v1/livez`
- add authenticated readiness aliases for API server: `/readyz`, `/v1/readyz` reuse `/health/detailed`
- add public webhook liveness aliases: `/healthz`, `/livez`
- cover production API route table and webhook `connect()` registration

## Contract
- `/health`, `/healthz`, `/livez`, `/v1/health`, `/v1/healthz`, `/v1/livez`: liveness only, public, cheap, no readiness probes.
- `/health/detailed`, `/readyz`, `/v1/readyz`: detailed readiness, same authenticated contract as the existing detailed endpoint.

## Tests
- `python3 -m py_compile gateway/platforms/api_server.py gateway/platforms/webhook.py tests/gateway/test_api_server.py tests/gateway/test_webhook_adapter.py`
- `python3 -m pytest tests/gateway/test_api_server.py::TestHealthEndpoint tests/gateway/test_api_server.py::TestHealthDetailedEndpoint tests/gateway/test_webhook_adapter.py::test_webhook_health_aliases_registered_on_connect -q` → 9 passed
