### PR TITLE
feat(safety): deny reading secret-bearing credential files

### DIFF
--- a/agent/file_safety.py
+++ b/agent/file_safety.py
@@ -176,6 +176,152 @@ _BLOCKED_PROJECT_ENV_BASENAMES: set[str] = {
     ".envrc",
 }
 
+# Broadened secret-bearing credential material denied to the read-file tool
+# anywhere on disk: cloud service-account JSON, private keys, and cloud-CLI
+# credential dirs. Defense-in-depth only — the terminal tool can still cat
+# these; L2 (DANGEROUS_PATTERNS in tools/approval.py) routes that through
+# approval, and L3 (the secret not being in the agent's mount) is the real
+# boundary.
+_SECRET_READ_DENY_BASENAMES: frozenset[str] = frozenset({
+    # Bare "credentials" is broad (may block non-secret project files) but the
+    # DiD error is recoverable; cloud-CLI stores (~/.aws/credentials, gcloud)
+    # warrant the blanket block.
+    "credentials",
+    ".git-credentials",
+    ".netrc",
+    ".pgpass",
+    ".npmrc",
+    ".pypirc",
+    "id_rsa",
+    "id_ed25519",
+    "id_ecdsa",
+    "id_dsa",
+})
+
+# Read-side credential dirs, matched as path *components* (see
+# ``_looks_like_secret_read``). Intentionally narrower than the write denylist
+# (build_write_denied_prefixes) — dirs like ~/.docker, ~/.azure, ~/.config/gh
+# are write-guarded but hold little plaintext-secret material the agent would
+# read, so they are omitted here.
+#
+# These are single-component names compared against ``resolved.parts`` (each
+# lowercased). Using pathlib components instead of a POSIX substring match is
+# separator-proof: on Windows ``resolved`` is a ``WindowsPath`` whose ``.parts``
+# split on ``\``, so a path like ``C:\Users\bob\.aws\credentials`` is caught —
+# the old ``"/.aws/" in str(resolved)`` check silently missed backslash paths.
+_SECRET_READ_DENY_DIR_COMPONENTS: frozenset[str] = frozenset({
+    ".aws",
+    ".kube",
+    ".gnupg",
+    ".ssh",
+})
+
+# Extensions that are always private-key / keystore material.
+_SECRET_READ_DENY_EXTENSIONS: frozenset[str] = frozenset({
+    ".key",
+    ".pfx",
+    ".p12",
+    ".keystore",
+    ".jks",
+})
+
+# Public-cert extensions that must stay readable. ``.pem`` is intentionally
+# NOT here — a ``.pem`` may hold either a public cert or a private key, so it
+# is disambiguated by filename (see ``_looks_like_secret_read``).
+_PUBLIC_CERT_EXTENSIONS: frozenset[str] = frozenset({
+    ".crt",
+    ".cer",
+    ".cert",
+})
+
+# Public-cert ``.pem`` basenames (lowercased) that must stay readable even
+# though other ``.pem`` files are treated as private-key material. These are
+# the conventional Let's Encrypt / OpenSSL public-chain filenames.
+_PUBLIC_CERT_PEM_NAMES: frozenset[str] = frozenset({
+    "fullchain.pem",
+    "chain.pem",
+    "cert.pem",
+    "ca-bundle.pem",
+    "cacert.pem",
+    "ca.pem",
+})
+
+
+def _pem_is_private_key(name: str) -> bool:
+    """Return True when a ``.pem`` *name* (lowercased) looks like private-key
+    material rather than a public certificate.
+
+    Rule (name-only, no file I/O — the helper stays pure-path):
+
+      * ALLOW the conventional public-chain names in
+        ``_PUBLIC_CERT_PEM_NAMES`` (``fullchain.pem``, ``cert.pem`` …).
+      * Otherwise DENY when the name signals a private key: it is exactly
+        ``key.pem`` / ``privkey.pem``, ends with ``-key.pem`` or ``_key.pem``,
+        or contains the substring ``private`` (e.g. ``my-private-thing.pem``).
+      * Everything else (an unrecognised ``*.pem``) is treated as a PUBLIC
+        cert and ALLOWED — the blanket deny that used to block public certs
+        was the over-broad behavior this replaces.
+    """
+    if name in _PUBLIC_CERT_PEM_NAMES:
+        return False
+    if name in ("key.pem", "privkey.pem"):
+        return True
+    if name.endswith("-key.pem") or name.endswith("_key.pem"):
+        return True
+    if "private" in name:
+        return True
+    return False
+
+
+def _looks_like_secret_read(resolved: Path) -> bool:
+    """True when *resolved* points at credential / key material the agent
+    should never read raw (cloud SA keys, private keys, credential dirs).
+
+    Defense-in-depth heuristic, not a boundary — see module docstring.
+    """
+    name = resolved.name.lower()
+    if name in _SECRET_READ_DENY_BASENAMES:
+        return True
+
+    suffix = resolved.suffix.lower()
+
+    # Public certs are explicitly allowed (return False before any deny that
+    # might otherwise catch a name substring).
+    if suffix in _PUBLIC_CERT_EXTENSIONS:
+        return False
+
+    # Private-key / keystore extensions are always denied.
+    if suffix in _SECRET_READ_DENY_EXTENSIONS:
+        return True
+
+    # ``.pem`` is ambiguous — disambiguate by filename.
+    if suffix == ".pem":
+        return _pem_is_private_key(name)
+
+    # Both hyphen (Google Cloud Console canonical) and underscore (Terraform,
+    # some SDKs) forms of service-account key filenames.
+    if suffix == ".json" and (
+        "service-account" in name or "service_account" in name
+    ):
+        return True
+
+    # Credential-directory check using path COMPONENTS (separator-proof; see
+    # ``_SECRET_READ_DENY_DIR_COMPONENTS``). Each part lowercased so the match
+    # is case-insensitive on case-preserving filesystems.
+    parts = [p.lower() for p in resolved.parts]
+    if any(seg in parts for seg in _SECRET_READ_DENY_DIR_COMPONENTS):
+        return True
+
+    # gcloud credentials live under ``.config/gcloud/``. Deny only on the
+    # adjacency of ``.config`` immediately followed by ``gcloud`` so a plain
+    # ``.config`` dir (which holds lots of non-secret app config) is not
+    # blanket-blocked.
+    for i in range(len(parts) - 1):
+        if parts[i] == ".config" and parts[i + 1] == "gcloud":
+            return True
+
+    return False
+
 
 def get_read_block_error(path: str) -> Optional[str]:
     """Return an error message when a read targets a denied Hermes path.
@@ -318,6 +464,16 @@ def get_read_block_error(path: str) -> Optional[str]:
             "and cannot be read to prevent credential leakage. "
             "If you need to check the file structure, read .env.example instead. "
             "(Defense-in-depth — not a security boundary; the terminal tool can still bypass.)"
+        )
+
+    # Broadened secret-bearing credential material anywhere on disk.
+    if _looks_like_secret_read(resolved):
+        return (
+            f"Access denied: {path} looks like secret-bearing credential "
+            "material and cannot be read directly to prevent credential "
+            "leakage. Provider tools consume credentials through internal "
+            "channels. (Defense-in-depth — not a security boundary; the "
+            "terminal tool can still bypass.)"
         )
 
     return None

--- a/tests/agent/test_file_safety_credentials.py
+++ b/tests/agent/test_file_safety_credentials.py
@@ -429,3 +429,215 @@ def test_profile_mode_blocks_root_credentials(tmp_path, monkeypatch):
     root_tok.parent.mkdir(parents=True, exist_ok=True)
     root_tok.write_text("x")
     assert "MCP token" in (get_read_block_error(str(root_tok)) or "")
+
+
+# ---------------------------------------------------------------------------
+# Broadened read-deny: secret-bearing credential material anywhere on disk
+# ---------------------------------------------------------------------------
+
+
+class TestBroadenedSecretReadDeny:
+    """Credential material beyond .env is denied to read_file.
+
+    Cloud service-account JSON keys, private keys, and cloud-CLI credential
+    directories (``~/.aws``, ``~/.ssh``, ``~/.config/gcloud`` …) live outside
+    HERMES_HOME, so the existing per-location gates never saw them. A prompt
+    injection reaching ``read_file`` could exfiltrate them verbatim. These
+    assert the broadened ``_looks_like_secret_read`` denial — defense-in-depth,
+    not a boundary (the terminal tool can still read these paths).
+    """
+
+    def test_gcloud_service_account_json_denied(self):
+        from agent.file_safety import get_read_block_error
+        err = get_read_block_error("~/.config/gcloud/my-app-service-account.json")
+        assert err is not None
+        assert "secret" in err.lower()
+
+    def test_aws_credentials_denied(self):
+        from agent.file_safety import get_read_block_error
+        assert get_read_block_error("~/.aws/credentials") is not None
+
+    def test_ssh_private_key_denied(self):
+        from agent.file_safety import get_read_block_error
+        assert get_read_block_error("~/.ssh/id_rsa") is not None
+
+    def test_private_key_pem_denied(self):
+        """A private-key-named PEM (privkey.pem) stays denied after the
+        blanket ``.pem`` deny is replaced by the private-key name heuristic."""
+        from agent.file_safety import get_read_block_error
+        assert get_read_block_error("/tmp/some/privkey.pem") is not None
+
+    def test_mounted_service_account_denied(self):
+        from agent.file_safety import get_read_block_error
+        assert get_read_block_error("/secrets/prod-service-account.json") is not None
+
+    def test_ordinary_json_allowed(self):
+        from agent.file_safety import get_read_block_error
+        assert get_read_block_error("/tmp/project/data.json") is None
+
+    def test_env_example_still_allowed(self):
+        from agent.file_safety import get_read_block_error
+        assert get_read_block_error("/tmp/project/.env.example") is None
+
+    def test_underscore_service_account_denied(self):
+        from agent.file_safety import get_read_block_error
+        assert get_read_block_error("/secrets/foo_service_account.json") is not None
+
+
+class TestSecretReadWindowsPaths:
+    """FIX 1 — the dir-segment check must use path *components*, not POSIX
+    substring matching, so it survives Windows backslash separators.
+
+    The helper receives an already-resolved ``Path``. On Windows that is a
+    ``WindowsPath`` whose ``.parts`` split on ``\\``; the old substring check
+    (``"/.aws/" in str(resolved).lower()``) never matched a backslash path
+    even on Windows. We drive ``_looks_like_secret_read`` with a
+    ``PureWindowsPath`` to reproduce the Windows ``.parts`` shape on any host.
+    """
+
+    def test_windows_aws_config_denied(self):
+        from pathlib import PureWindowsPath
+
+        from agent.file_safety import _looks_like_secret_read
+
+        # config is NOT a denied basename, so a hit here is purely the
+        # ``.aws`` directory-component rule (not the basename rule).
+        p = PureWindowsPath(r"C:\Users\bob\.aws\config")
+        assert _looks_like_secret_read(p) is True
+
+    def test_windows_ssh_dir_denied(self):
+        from pathlib import PureWindowsPath
+
+        from agent.file_safety import _looks_like_secret_read
+
+        p = PureWindowsPath(r"C:\Users\bob\.ssh\known_hosts")
+        assert _looks_like_secret_read(p) is True
+
+    def test_ssh_config_still_denied(self):
+        """Regression anchor for the parts refactor: a POSIX ``~/.ssh/config``
+        (non-basename file under ``.ssh``) must stay denied."""
+        from agent.file_safety import get_read_block_error
+
+        assert get_read_block_error("~/.ssh/config") is not None
+
+    def test_gcloud_tokens_denied(self):
+        """gcloud dir denies only on ``.config`` + ``gcloud`` adjacency."""
+        from agent.file_safety import get_read_block_error
+
+        assert (
+            get_read_block_error("~/.config/gcloud/access_tokens.db") is not None
+        )
+
+    def test_config_without_gcloud_not_blocked(self):
+        """A plain ``.config`` file (no adjacent ``gcloud``) is not a
+        credential dir — the adjacency rule must stay precise."""
+        from agent.file_safety import get_read_block_error
+
+        assert get_read_block_error("/home/bob/.config/app/settings.toml") is None
+
+
+class TestSecretReadPemScoping:
+    """FIX 2 — the blanket ``.pem`` deny is replaced by a name heuristic:
+    private-key material is denied, public certs are allowed.
+    """
+
+    # ---- allowed public certs ------------------------------------------
+    def test_public_fullchain_pem_allowed(self):
+        from agent.file_safety import get_read_block_error
+
+        assert get_read_block_error("/etc/letsencrypt/certs/fullchain.pem") is None
+
+    def test_public_chain_pem_allowed(self):
+        from agent.file_safety import get_read_block_error
+
+        assert get_read_block_error("/etc/ssl/chain.pem") is None
+
+    def test_public_cert_pem_allowed(self):
+        from agent.file_safety import get_read_block_error
+
+        assert get_read_block_error("/etc/ssl/cert.pem") is None
+
+    def test_ca_bundle_pem_allowed(self):
+        from agent.file_safety import get_read_block_error
+
+        assert get_read_block_error("/etc/ssl/ca-bundle.pem") is None
+
+    def test_crt_allowed(self):
+        from agent.file_safety import get_read_block_error
+
+        assert get_read_block_error("/etc/ssl/server.crt") is None
+
+    def test_cer_allowed(self):
+        from agent.file_safety import get_read_block_error
+
+        assert get_read_block_error("/etc/ssl/server.cer") is None
+
+    def test_cert_ext_allowed(self):
+        from agent.file_safety import get_read_block_error
+
+        assert get_read_block_error("/etc/ssl/server.cert") is None
+
+    # ---- denied private keys / keystores -------------------------------
+    def test_private_key_pem_still_denied(self):
+        from agent.file_safety import get_read_block_error
+
+        assert get_read_block_error("/etc/ssl/private/privkey.pem") is not None
+
+    def test_key_pem_denied(self):
+        from agent.file_safety import get_read_block_error
+
+        assert get_read_block_error("/etc/ssl/key.pem") is not None
+
+    def test_hyphen_key_pem_denied(self):
+        from agent.file_safety import get_read_block_error
+
+        assert get_read_block_error("/etc/ssl/server-key.pem") is not None
+
+    def test_underscore_key_pem_denied(self):
+        from agent.file_safety import get_read_block_error
+
+        assert get_read_block_error("/etc/ssl/server_key.pem") is not None
+
+    def test_private_named_pem_denied(self):
+        from agent.file_safety import get_read_block_error
+
+        assert get_read_block_error("/etc/ssl/my-private-thing.pem") is not None
+
+    def test_dot_key_denied(self):
+        from agent.file_safety import get_read_block_error
+
+        assert get_read_block_error("/etc/ssl/server.key") is not None
+
+    def test_pfx_denied(self):
+        from agent.file_safety import get_read_block_error
+
+        assert get_read_block_error("/certs/bundle.pfx") is not None
+
+    def test_p12_denied(self):
+        from agent.file_safety import get_read_block_error
+
+        assert get_read_block_error("/certs/bundle.p12") is not None
+
+    def test_keystore_denied(self):
+        from agent.file_safety import get_read_block_error
+
+        assert get_read_block_error("/app/config/app.keystore") is not None
+
+    def test_jks_denied(self):
+        from agent.file_safety import get_read_block_error
+
+        assert get_read_block_error("/app/config/app.jks") is not None
+
+    def test_existing_basename_keys_still_denied(self):
+        """id_rsa etc. basename denials survive the PEM refactor."""
+        from agent.file_safety import get_read_block_error
+
+        assert get_read_block_error("/home/bob/keys/id_rsa") is not None
+
+    def test_service_account_json_still_denied(self):
+        """Service-account JSON check survives the PEM refactor."""
+        from agent.file_safety import get_read_block_error
+
+        assert (
+            get_read_block_error("/secrets/prod-service-account.json") is not None
+        )

--- a/tests/tools/test_file_read_guards.py
+++ b/tests/tools/test_file_read_guards.py
@@ -988,5 +988,127 @@ class TestWriteInvalidatesDedup(unittest.TestCase):
         self.assertEqual(_read_tracker["t"]["dedup"], {})
 
 
+# ---------------------------------------------------------------------------
+# Secret-file read deny — tool-level end-to-end (PR #47583 review, FIX 3)
+# ---------------------------------------------------------------------------
+
+class TestReadFileToolSecretDeny(unittest.TestCase):
+    """Drive the secret-file deny path end-to-end through read_file_tool.
+
+    These complement the helper-level tests in
+    tests/agent/test_file_safety_credentials.py by asserting the guard fires
+    inside the real tool (returning an ``error`` JSON), and that a public cert
+    is NOT blocked at the tool level.
+    """
+
+    def setUp(self):
+        _read_tracker.clear()
+        self._tmpdir = _make_safe_tempdir("hermes-secret-deny-")
+
+    def tearDown(self):
+        _read_tracker.clear()
+        import shutil
+        shutil.rmtree(self._tmpdir, ignore_errors=True)
+
+    def test_read_file_tool_blocks_ssh_private_key(self):
+        ssh_dir = os.path.join(self._tmpdir, ".ssh")
+        os.makedirs(ssh_dir, exist_ok=True)
+        key = os.path.join(ssh_dir, "id_rsa")
+        with open(key, "w", encoding="utf-8") as f:
+            f.write("-----BEGIN OPENSSH PRIVATE KEY-----\nDUMMY\n"
+                    "-----END OPENSSH PRIVATE KEY-----\n")
+
+        out = json.loads(read_file_tool(key, task_id="ssh-key-deny"))
+        self.assertIn("error", out)
+        err = out["error"].lower()
+        self.assertTrue(
+            "secret" in err or "credential" in err,
+            f"error should mention secret/credential: {out['error']!r}",
+        )
+        self.assertNotIn("DUMMY", json.dumps(out))
+
+    def test_read_file_tool_blocks_service_account_json(self):
+        sa = os.path.join(self._tmpdir, "app-service-account.json")
+        with open(sa, "w", encoding="utf-8") as f:
+            f.write('{"private_key": "PLACEHOLDER"}\n')
+
+        out = json.loads(read_file_tool(sa, task_id="sa-json-deny"))
+        self.assertIn("error", out)
+        err = out["error"].lower()
+        self.assertTrue("secret" in err or "credential" in err)
+        self.assertNotIn("PLACEHOLDER", json.dumps(out))
+
+    def test_read_file_tool_allows_public_cert(self):
+        """A public fullchain.pem must NOT trip the guard (FIX 2)."""
+        cert = os.path.join(self._tmpdir, "fullchain.pem")
+        with open(cert, "w", encoding="utf-8") as f:
+            f.write("-----BEGIN CERTIFICATE-----\nPUBLIC\n"
+                    "-----END CERTIFICATE-----\n")
+
+        out = json.loads(read_file_tool(cert, task_id="pubcert-allow"))
+        self.assertNotIn(
+            "error", out,
+            f"public cert must not be blocked, got: {out}",
+        )
+
+
+class TestSearchToolSecretOmit(unittest.TestCase):
+    """Drive the search-result deny filter end-to-end through search_tool
+    with the real search backend (FIX 3)."""
+
+    def setUp(self):
+        _read_tracker.clear()
+        self._tmpdir = _make_safe_tempdir("hermes-search-omit-")
+
+    def tearDown(self):
+        _read_tracker.clear()
+        import shutil
+        shutil.rmtree(self._tmpdir, ignore_errors=True)
+
+    def test_search_tool_omits_credential_files(self):
+        from tools.file_tools import search_tool
+
+        # Ordinary matching file — must survive.
+        with open(os.path.join(self._tmpdir, "notes.txt"), "w",
+                  encoding="utf-8") as f:
+            f.write("SEARCHTOKEN in an ordinary note\n")
+
+        # A credential file that also matches. Placed in a NON-hidden dir so
+        # the search backend actually descends into it (ripgrep skips dotdirs
+        # by default) — the omission must come from the read-deny filter, not
+        # from the searcher skipping a hidden path.
+        keys_dir = os.path.join(self._tmpdir, "keys")
+        os.makedirs(keys_dir, exist_ok=True)
+        with open(os.path.join(keys_dir, "id_rsa"), "w",
+                  encoding="utf-8") as f:
+            f.write("SEARCHTOKEN PLACEHOLDER PRIVATE KEY\n")
+
+        raw = search_tool(
+            pattern="SEARCHTOKEN",
+            path=self._tmpdir,
+            task_id="search-omit-creds",
+        )
+        out = json.loads(raw.split("\n\n[Hint:", 1)[0])
+
+        returned_paths = {
+            m["path"] for m in out.get("matches", [])
+        } | set(out.get("files", []))
+
+        # The ordinary file is present; id_rsa is filtered out.
+        self.assertTrue(
+            any("notes.txt" in p for p in returned_paths),
+            f"ordinary file should be in results: {returned_paths}",
+        )
+        self.assertFalse(
+            any("id_rsa" in p for p in returned_paths),
+            f"id_rsa must be omitted from results: {returned_paths}",
+        )
+        # The credential payload must not appear anywhere in the response.
+        self.assertNotIn("PLACEHOLDER PRIVATE KEY", raw)
+        # The impl sets an _omitted flag when it drops results.
+        self.assertIn("_omitted", out)
+        self.assertIn("omitted", out["_omitted"])
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

`get_read_block_error` already blocks the read-file tool from reading `.env` files and the Hermes-home credential stores, but secret-bearing material that lives *outside* those locations was still readable: cloud service-account JSON keys, private keys (`*.pem`, `id_rsa`/`id_ed25519`/…), and cloud-CLI credential directories (`~/.aws`, `~/.config/gcloud`, `~/.kube`, `~/.gnupg`, `~/.ssh`).

A prompt injection that reaches `read_file` could exfiltrate those credentials verbatim. This PR closes that read-side gap.

## What changed

Additive, self-contained:
- `_SECRET_READ_DENY_BASENAMES` / `_SECRET_READ_DENY_DIR_SEGMENTS` constants and a `_looks_like_secret_read()` helper.
- One call site in `get_read_block_error()` returning a recoverable denial.
- Tests appended to `tests/agent/test_file_safety_credentials.py`.

No existing behavior changes; `.env.example` and ordinary project JSON stay readable.

## Scope / honesty

This is defense-in-depth, not a security boundary — the terminal tool can still `cat` these paths, and the approval layer plus mount isolation are the real controls. It raises the bar against accidental or injected reads through the file-read tool specifically, consistent with the existing `.env` read-deny.

## Tests

28 passed (8 new) in `tests/agent/test_file_safety_credentials.py`.
