### PR TITLE
fix(gateway): flatten multimodal content to text in observed group context

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -712,6 +712,44 @@ def _message_timestamps_enabled(user_config: Optional[dict]) -> bool:
     return bool(mt)
 
 
+
+def _flatten_content_to_text(content: Any) -> str:
+    """Extract text from content that may be a multimodal parts list.
+
+    Observed-group-context is text-only by design (injected as a plain-string
+    prefix via ``_wrap_current_message_with_observed_context``).  When the
+    stored ``content`` is a list of parts (e.g. ``[{"type": "text", ...},
+    {"type": "image_url", ...}]``) produced by the image-routing pipeline,
+    ``str()``-ing it yields an unusable Python repr.  This helper extracts
+    the human-readable text and appends a media placeholder so the model
+    knows an attachment was present.
+
+    See issue #47415.
+    """
+    if isinstance(content, str):
+        return content.strip()
+    if isinstance(content, list):
+        text_parts: list[str] = []
+        media_count = 0
+        for part in content:
+            if not isinstance(part, dict):
+                continue
+            ptype = part.get("type", "")
+            if ptype == "text":
+                t = part.get("text", "")
+                if t:
+                    text_parts.append(t)
+            elif ptype == "image_url":
+                media_count += 1
+            elif ptype in ("image", "video", "audio", "file"):
+                media_count += 1
+        result = " ".join(text_parts).strip()
+        if media_count:
+            label = f"[{media_count} image(s) attached]" if media_count > 1 else "[image attached]"
+            result = f"{result} {label}" if result else label
+        return result or str(content).strip()
+    return str(content).strip()
+
 def _build_gateway_agent_history(
     history: List[Dict[str, Any]],
     *,
@@ -759,7 +797,7 @@ def _build_gateway_agent_history(
         if inject_timestamps and role == "user" and isinstance(content, str):
             content = _render_msg_ts(content, msg.get("timestamp"), tz=_msg_tz)
         if separate_observed_context and msg.get("observed") and role == "user" and content:
-            observed_group_context.append(str(content).strip())
+            observed_group_context.append(_flatten_content_to_text(content))
             continue
 
         # Rich agent messages (tool_calls, tool results) must be passed through

--- a/tests/gateway/test_telegram_group_gating.py
+++ b/tests/gateway/test_telegram_group_gating.py
@@ -1209,3 +1209,98 @@ def test_unmentioned_unsupported_document_observed_without_caching(monkeypatch):
         assert "unsupported" in message["content"].lower()
 
     asyncio.run(_run())
+
+
+def test_observed_group_context_flattens_multimodal_content_to_text():
+    """Observed group photos must be represented as text, not Python repr.
+
+    Regression test for #47415: when an observed group message contains
+    multimodal content (text + image_url parts), str() produced an unusable
+    Python repr.  The fix extracts text parts and appends an image placeholder.
+    """
+    from gateway.run import (
+        _build_gateway_agent_history,
+        _wrap_current_message_with_observed_context,
+    )
+
+    history = [
+        {
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "[Alice|111] here's the desk sheet"},
+                {"type": "image_url", "image_url": {"url": "data:image/png;base64,AAAA"}},
+            ],
+            "observed": True,
+        },
+        {
+            "role": "user",
+            "content": "[Bob|222] what was in that image?",
+            "observed": True,
+        },
+    ]
+
+    agent_history, observed_context = _build_gateway_agent_history(
+        history,
+        channel_prompt="observed Telegram group context",
+    )
+
+    # The image message must NOT contain Python repr
+    assert "image_url" not in observed_context
+    assert "{'type'" not in observed_context
+    # Must contain the text caption and an image placeholder
+    assert "desk sheet" in observed_context
+    assert "[image attached]" in observed_context
+    # The plain text message must still be present
+    assert "what was in that image?" in observed_context
+
+
+def test_observed_group_context_handles_image_only_no_text():
+    """An observed group image with no caption should still produce a placeholder."""
+    from gateway.run import (
+        _build_gateway_agent_history,
+    )
+
+    history = [
+        {
+            "role": "user",
+            "content": [
+                {"type": "image_url", "image_url": {"url": "data:image/png;base64,BBBB"}},
+            ],
+            "observed": True,
+        },
+    ]
+
+    _, observed_context = _build_gateway_agent_history(
+        history,
+        channel_prompt="observed Telegram group context",
+    )
+
+    assert observed_context == "[image attached]"
+    assert "image_url" not in observed_context
+
+
+def test_observed_group_context_handles_multiple_images():
+    """Multiple images in one observed message produce a count placeholder."""
+    from gateway.run import (
+        _build_gateway_agent_history,
+    )
+
+    history = [
+        {
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "[Alice|111] batch upload"},
+                {"type": "image_url", "image_url": {"url": "data:image/png;base64,CCC"}},
+                {"type": "image_url", "image_url": {"url": "data:image/png;base64,DDD"}},
+            ],
+            "observed": True,
+        },
+    ]
+
+    _, observed_context = _build_gateway_agent_history(
+        history,
+        channel_prompt="observed Telegram group context",
+    )
+
+    assert "[2 image(s) attached]" in observed_context
+    assert "batch upload" in observed_context


### PR DESCRIPTION
## What does this PR do?

Fixes observed Telegram group context mangling multimodal content (text + image_url parts) into an unusable Python repr string. When a group photo was sent without @mention, `str(content)` produced `[{'type': 'text', ...}, {'type': 'image_url', ...}]` instead of the caption text, breaking the model's ability to see the image context.

## Related Issue

Fixes #47415

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/run.py`: Add `_flatten_content_to_text()` helper that extracts text parts from multimodal content lists and appends an `[image attached]` placeholder. Replace `str(content).strip()` in the observed-group-context path with the new helper.
- `tests/gateway/test_telegram_group_gating.py`: Add 3 regression tests covering multimodal content flattening, image-only messages, and multiple images in one message.

## How to Test

1. Enable `observe_unmentioned_group_messages` in Telegram config
2. Send a photo to a group **without** mentioning the bot
3. Later @mention the bot and ask about the image
4. The model should see the caption text + `[image attached]` placeholder instead of a Python repr dump
5. Run: `python -m pytest tests/gateway/test_telegram_group_gating.py -q -k "flatten_multimodal or image_only_no_text or multiple_images"`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `_build_gateway_agent_history` (observed context path, line 797)
- Blast radius: LOW — single call site, `_flatten_content_to_text` falls back to `str()` for non-list content
- Related patterns: `str(content)` coercion in `api_server.py:192` (separate path, not affected)
