### PR TITLE
fix(gateway): scope session recall to chat threads

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -1822,6 +1822,11 @@ def invoke_tool(agent, function_name: str, function_args: dict, effective_task_i
                     sort=next_args.get("sort"),
                     db=session_db,
                     current_session_id=agent.session_id,
+                    current_source=agent.platform or getattr(agent, "_platform", None),
+                    current_chat_type=getattr(agent, "_chat_type", None),
+                    current_chat_id=getattr(agent, "_chat_id", None),
+                    current_thread_id=getattr(agent, "_thread_id", None),
+                    current_session_key=getattr(agent, "_gateway_session_key", None),
                 ),
                 next_args,
             )

--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -598,6 +598,12 @@ def compress_context(
                         source=agent.platform or os.environ.get("HERMES_SESSION_SOURCE", "cli"),
                         model=agent.model,
                         model_config=agent._session_init_model_config,
+                        user_id=getattr(agent, "_user_id", None),
+                        user_id_alt=getattr(agent, "_user_id_alt", None),
+                        chat_type=getattr(agent, "_chat_type", None),
+                        chat_id=getattr(agent, "_chat_id", None),
+                        thread_id=getattr(agent, "_thread_id", None),
+                        session_key=getattr(agent, "_gateway_session_key", None),
                         parent_session_id=old_session_id,
                     )
                 except Exception as _cs_err:

--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -1021,6 +1021,11 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
                     sort=next_args.get("sort"),
                     db=session_db,
                     current_session_id=agent.session_id,
+                    current_source=agent.platform or getattr(agent, "_platform", None),
+                    current_chat_type=getattr(agent, "_chat_type", None),
+                    current_chat_id=getattr(agent, "_chat_id", None),
+                    current_thread_id=getattr(agent, "_thread_id", None),
+                    current_session_key=getattr(agent, "_gateway_session_key", None),
                 )
             function_result, function_args = _run_agent_tool_execution_middleware(
                 agent,

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -766,6 +766,23 @@ def build_session_key(
     return ":".join(key_parts)
 
 
+def session_db_scope_kwargs(
+    source: Optional[SessionSource],
+    session_key: Optional[str] = None,
+) -> Dict[str, Optional[str]]:
+    """Return SessionDB kwargs that preserve gateway chat/thread scope."""
+    if source is None:
+        return {}
+    return {
+        "user_id": str(source.user_id) if source.user_id is not None else None,
+        "user_id_alt": str(source.user_id_alt) if source.user_id_alt is not None else None,
+        "chat_type": str(source.chat_type) if source.chat_type is not None else None,
+        "chat_id": str(source.chat_id) if source.chat_id is not None else None,
+        "thread_id": str(source.thread_id) if source.thread_id is not None else None,
+        "session_key": str(session_key) if session_key is not None else None,
+    }
+
+
 class SessionStore:
     """
     Manages session storage and retrieval.
@@ -1056,7 +1073,7 @@ class SessionStore:
             db_create_kwargs = {
                 "session_id": session_id,
                 "source": source.platform.value,
-                "user_id": source.user_id,
+                **session_db_scope_kwargs(source, session_key),
             }
 
         # SQLite operations outside the lock
@@ -1282,7 +1299,7 @@ class SessionStore:
             db_create_kwargs = {
                 "session_id": session_id,
                 "source": old_entry.platform.value if old_entry.platform else "unknown",
-                "user_id": old_entry.origin.user_id if old_entry.origin else None,
+                **session_db_scope_kwargs(old_entry.origin, session_key),
             }
 
         if self._db and db_end_session_id:

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -33,7 +33,7 @@ from agent.account_usage import fetch_account_usage, render_account_usage_lines
 from agent.i18n import t
 from gateway.config import HomeChannel, Platform, PlatformConfig
 from gateway.platforms.base import EphemeralReply, MessageEvent, MessageType
-from gateway.session import SessionSource, build_session_key
+from gateway.session import SessionSource, build_session_key, session_db_scope_kwargs
 from hermes_cli.config import cfg_get, clear_model_endpoint_credentials
 from utils import (
     atomic_json_write,
@@ -2958,7 +2958,7 @@ class GatewaySlashCommandsMixin:
                 self._session_db.create_session(
                     session_id=session_id,
                     source=source.platform.value if source.platform else "unknown",
-                    user_id=source.user_id,
+                    **session_db_scope_kwargs(source, session_entry.session_key),
                 )
             except Exception:
                 pass  # Session might already exist, ignore errors
@@ -3255,6 +3255,7 @@ class GatewaySlashCommandsMixin:
                 source=source.platform.value if source.platform else "gateway",
                 model=(self.config.get("model", {}) or {}).get("default") if isinstance(self.config, dict) else None,
                 model_config={"_branched_from": parent_session_id},
+                **session_db_scope_kwargs(source, session_key),
                 parent_session_id=parent_session_id,
             )
         except Exception as e:

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -116,7 +116,7 @@ T = TypeVar("T")
 
 DEFAULT_DB_PATH = get_hermes_home() / "state.db"
 
-SCHEMA_VERSION = 16
+SCHEMA_VERSION = 17
 
 # ---------------------------------------------------------------------------
 # WAL-compatibility fallback
@@ -524,6 +524,11 @@ CREATE TABLE IF NOT EXISTS sessions (
     id TEXT PRIMARY KEY,
     source TEXT NOT NULL,
     user_id TEXT,
+    user_id_alt TEXT,
+    chat_type TEXT,
+    chat_id TEXT,
+    thread_id TEXT,
+    session_key TEXT,
     model TEXT,
     model_config TEXT,
     system_prompt TEXT,
@@ -606,6 +611,10 @@ CREATE INDEX IF NOT EXISTS idx_compression_locks_expires ON compression_locks(ex
 DEFERRED_INDEX_SQL = """
 CREATE INDEX IF NOT EXISTS idx_messages_session_active
     ON messages(session_id, active, timestamp);
+CREATE INDEX IF NOT EXISTS idx_sessions_gateway_scope
+    ON sessions(source, chat_type, chat_id, thread_id, started_at DESC);
+CREATE INDEX IF NOT EXISTS idx_sessions_session_key
+    ON sessions(session_key) WHERE session_key IS NOT NULL;
 """
 
 FTS_SQL = """
@@ -1353,19 +1362,32 @@ class SessionDB:
         model_config: Dict[str, Any] = None,
         system_prompt: str = None,
         user_id: str = None,
+        user_id_alt: str = None,
+        chat_type: str = None,
+        chat_id: str = None,
+        thread_id: str = None,
+        session_key: str = None,
         parent_session_id: str = None,
         cwd: str = None,
     ) -> None:
         """Shared INSERT OR IGNORE for session rows."""
         def _do(conn):
             conn.execute(
-                """INSERT OR IGNORE INTO sessions (id, source, user_id, model, model_config,
-                   system_prompt, parent_session_id, cwd, started_at)
-                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                """INSERT OR IGNORE INTO sessions (
+                   id, source, user_id, user_id_alt, chat_type, chat_id,
+                   thread_id, session_key, model, model_config, system_prompt,
+                   parent_session_id, cwd, started_at
+                   )
+                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
                 (
                     session_id,
                     source,
                     user_id,
+                    user_id_alt,
+                    chat_type,
+                    chat_id,
+                    thread_id,
+                    session_key,
                     model,
                     json.dumps(model_config) if model_config else None,
                     system_prompt,
@@ -2105,6 +2127,11 @@ class SessionDB:
     def list_sessions_rich(
         self,
         source: str = None,
+        chat_type_filter: str = None,
+        chat_id_filter: str = None,
+        thread_id_filter: str = None,
+        strict_thread_scope: bool = False,
+        session_key_filter: str = None,
         exclude_sources: List[str] = None,
         limit: int = 20,
         offset: int = 0,
@@ -2167,6 +2194,21 @@ class SessionDB:
         if source:
             where_clauses.append("s.source = ?")
             params.append(source)
+        if chat_type_filter:
+            where_clauses.append("s.chat_type = ?")
+            params.append(chat_type_filter)
+        if chat_id_filter:
+            where_clauses.append("s.chat_id = ?")
+            params.append(chat_id_filter)
+        if strict_thread_scope:
+            if thread_id_filter:
+                where_clauses.append("s.thread_id = ?")
+                params.append(thread_id_filter)
+            else:
+                where_clauses.append("(s.thread_id IS NULL OR s.thread_id = '')")
+        if session_key_filter:
+            where_clauses.append("s.session_key = ?")
+            params.append(session_key_filter)
         if exclude_sources:
             placeholders = ",".join("?" for _ in exclude_sources)
             where_clauses.append(f"s.source NOT IN ({placeholders})")
@@ -3468,6 +3510,11 @@ class SessionDB:
         query: str,
         source_filter: List[str] = None,
         exclude_sources: List[str] = None,
+        chat_type_filter: str = None,
+        chat_id_filter: str = None,
+        thread_id_filter: str = None,
+        strict_thread_scope: bool = False,
+        session_key_filter: str = None,
         role_filter: List[str] = None,
         limit: int = 20,
         offset: int = 0,
@@ -3540,6 +3587,23 @@ class SessionDB:
             # are hidden. See archive_and_compact() / #38763.
             where_clauses.append("(m.active = 1 OR m.compacted = 1)")
 
+        def add_session_scope_filters(clauses: List[str], values: List[Any]) -> None:
+            if chat_type_filter:
+                clauses.append("s.chat_type = ?")
+                values.append(chat_type_filter)
+            if chat_id_filter:
+                clauses.append("s.chat_id = ?")
+                values.append(chat_id_filter)
+            if strict_thread_scope:
+                if thread_id_filter:
+                    clauses.append("s.thread_id = ?")
+                    values.append(thread_id_filter)
+                else:
+                    clauses.append("(s.thread_id IS NULL OR s.thread_id = '')")
+            if session_key_filter:
+                clauses.append("s.session_key = ?")
+                values.append(session_key_filter)
+
         if source_filter is not None:
             source_placeholders = ",".join("?" for _ in source_filter)
             where_clauses.append(f"s.source IN ({source_placeholders})")
@@ -3549,6 +3613,8 @@ class SessionDB:
             exclude_placeholders = ",".join("?" for _ in exclude_sources)
             where_clauses.append(f"s.source NOT IN ({exclude_placeholders})")
             params.extend(exclude_sources)
+
+        add_session_scope_filters(where_clauses, params)
 
         if role_filter:
             role_placeholders = ",".join("?" for _ in role_filter)
@@ -3627,6 +3693,7 @@ class SessionDB:
                 if exclude_sources is not None:
                     tri_where.append(f"s.source NOT IN ({','.join('?' for _ in exclude_sources)})")
                     tri_params.extend(exclude_sources)
+                add_session_scope_filters(tri_where, tri_params)
                 if role_filter:
                     tri_where.append(f"m.role IN ({','.join('?' for _ in role_filter)})")
                     tri_params.extend(role_filter)
@@ -3684,6 +3751,7 @@ class SessionDB:
                 if exclude_sources is not None:
                     like_where.append(f"s.source NOT IN ({','.join('?' for _ in exclude_sources)})")
                     like_params.extend(exclude_sources)
+                add_session_scope_filters(like_where, like_params)
                 if role_filter:
                     like_where.append(f"m.role IN ({','.join('?' for _ in role_filter)})")
                     like_params.extend(role_filter)

--- a/run_agent.py
+++ b/run_agent.py
@@ -533,7 +533,12 @@ class AIAgent:
                 model=self.model,
                 model_config=self._session_init_model_config,
                 system_prompt=self._cached_system_prompt,
-                user_id=None,
+                user_id=getattr(self, "_user_id", None),
+                user_id_alt=getattr(self, "_user_id_alt", None),
+                chat_type=getattr(self, "_chat_type", None),
+                chat_id=getattr(self, "_chat_id", None),
+                thread_id=getattr(self, "_thread_id", None),
+                session_key=getattr(self, "_gateway_session_key", None),
                 parent_session_id=self._parent_session_id,
                 cwd=_launch_cwd_for_session(source),
             )

--- a/tests/gateway/test_session.py
+++ b/tests/gateway/test_session.py
@@ -500,6 +500,33 @@ class TestSenderPrefixWithBackfill:
         assert "[Alice] [Recent" not in result
 
 
+class TestSessionStoreScopeMetadata:
+    def test_get_or_create_session_persists_gateway_scope(self, tmp_path, monkeypatch):
+        import hermes_state
+
+        monkeypatch.setattr(hermes_state, "DEFAULT_DB_PATH", tmp_path / "state.db")
+        store = SessionStore(sessions_dir=tmp_path / "sessions", config=GatewayConfig())
+        source = SessionSource(
+            platform=Platform.TELEGRAM,
+            chat_id="-100",
+            chat_type="group",
+            user_id="user-1",
+            user_id_alt="alt-1",
+            thread_id="111",
+        )
+
+        entry = store.get_or_create_session(source)
+        session = store._db.get_session(entry.session_id)
+
+        assert session["source"] == "telegram"
+        assert session["user_id"] == "user-1"
+        assert session["user_id_alt"] == "alt-1"
+        assert session["chat_type"] == "group"
+        assert session["chat_id"] == "-100"
+        assert session["thread_id"] == "111"
+        assert session["session_key"] == entry.session_key
+
+
 class TestSessionStoreRewriteTranscript:
     """Regression: /retry and /undo must persist truncated history to DB."""
 

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -92,6 +92,26 @@ class TestSessionLifecycle:
         assert session["model"] == "test-model"
         assert session["ended_at"] is None
 
+    def test_create_session_persists_gateway_scope(self, db):
+        db.create_session(
+            session_id="s1",
+            source="telegram",
+            user_id="user-1",
+            user_id_alt="alt-1",
+            chat_type="group",
+            chat_id="-100",
+            thread_id="111",
+            session_key="agent:main:telegram:group:-100:111",
+        )
+
+        session = db.get_session("s1")
+        assert session["user_id"] == "user-1"
+        assert session["user_id_alt"] == "alt-1"
+        assert session["chat_type"] == "group"
+        assert session["chat_id"] == "-100"
+        assert session["thread_id"] == "111"
+        assert session["session_key"] == "agent:main:telegram:group:-100:111"
+
 
     def test_get_nonexistent_session(self, db):
         assert db.get_session("nonexistent") is None
@@ -2328,9 +2348,12 @@ class TestSchemaInit:
         conn.close()
 
         db = SessionDB(db_path=old_db)
-        cursor = db._conn.execute("PRAGMA table_info(sessions)")
-        columns = {row[1] for row in cursor.fetchall()}
-        assert {"chat_id", "chat_type", "thread_id", "session_key"}.isdisjoint(columns)
+        cursor = db._conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='table'"
+        )
+        tables = {row[0] for row in cursor.fetchall()}
+        assert "telegram_dm_topic_mode" not in tables
+        assert "telegram_dm_topic_bindings" not in tables
         db.close()
 
     def test_apply_telegram_topic_migration_creates_topic_tables_explicitly(self, tmp_path):

--- a/tests/tools/test_session_search.py
+++ b/tests/tools/test_session_search.py
@@ -58,6 +58,38 @@ def _seed_modpack_sessions(db):
     db._conn.commit()
 
 
+def _seed_gateway_session(
+    db,
+    session_id,
+    *,
+    chat_id,
+    thread_id=None,
+    text="shared needle",
+    source="telegram",
+    chat_type="group",
+    started_offset=0,
+):
+    now = int(time.time())
+    session_key = f"agent:main:{source}:{chat_type}:{chat_id}"
+    if thread_id:
+        session_key = f"{session_key}:{thread_id}"
+    db.create_session(
+        session_id,
+        source=source,
+        chat_type=chat_type,
+        chat_id=chat_id,
+        thread_id=thread_id,
+        session_key=session_key,
+    )
+    db._conn.execute(
+        "UPDATE sessions SET started_at = ?, title = ? WHERE id = ?",
+        (now + started_offset, f"Gateway {session_id}", session_id),
+    )
+    db.append_message(session_id, role="user", content=text)
+    db.append_message(session_id, role="assistant", content=f"ack {text}")
+    db._conn.commit()
+
+
 # =========================================================================
 # Schema invariants
 # =========================================================================
@@ -232,6 +264,151 @@ class TestDiscoverySort:
         # Should not error
         result = json.loads(session_search(query="modpack", sort="bogus", db=db))
         assert result["success"] is True
+
+
+class TestGatewayScope:
+    def test_discovery_scopes_to_current_gateway_thread(self, db):
+        _seed_gateway_session(
+            db,
+            "topic-a",
+            chat_id="-100",
+            thread_id="111",
+            text="deploy path lives in topic a",
+        )
+        _seed_gateway_session(
+            db,
+            "topic-b",
+            chat_id="-100",
+            thread_id="222",
+            text="deploy path lives in topic b",
+        )
+        _seed_gateway_session(
+            db,
+            "other-chat",
+            chat_id="-200",
+            thread_id="111",
+            text="deploy path lives in another chat",
+        )
+
+        result = json.loads(session_search(
+            query="deploy",
+            db=db,
+            current_source="telegram",
+            current_chat_type="group",
+            current_chat_id="-100",
+            current_thread_id="111",
+        ))
+
+        assert result["success"] is True
+        assert [r["session_id"] for r in result["results"]] == ["topic-a"]
+
+    def test_discovery_without_thread_does_not_recall_thread_sessions(self, db):
+        _seed_gateway_session(
+            db,
+            "root-chat",
+            chat_id="-100",
+            thread_id=None,
+            text="incident path in parent chat",
+        )
+        _seed_gateway_session(
+            db,
+            "topic-chat",
+            chat_id="-100",
+            thread_id="111",
+            text="incident path in forum topic",
+        )
+
+        result = json.loads(session_search(
+            query="incident",
+            db=db,
+            current_source="telegram",
+            current_chat_type="group",
+            current_chat_id="-100",
+        ))
+
+        assert result["success"] is True
+        assert [r["session_id"] for r in result["results"]] == ["root-chat"]
+
+    def test_cjk_like_discovery_keeps_gateway_scope(self, db):
+        _seed_gateway_session(
+            db,
+            "same-topic",
+            chat_id="-100",
+            thread_id="111",
+            text="路径在当前话题",
+        )
+        _seed_gateway_session(
+            db,
+            "other-topic",
+            chat_id="-100",
+            thread_id="222",
+            text="路径在其他话题",
+        )
+
+        result = json.loads(session_search(
+            query="路径",
+            db=db,
+            current_source="telegram",
+            current_chat_type="group",
+            current_chat_id="-100",
+            current_thread_id="111",
+        ))
+
+        assert result["success"] is True
+        assert [r["session_id"] for r in result["results"]] == ["same-topic"]
+
+    def test_browse_scopes_to_current_gateway_thread(self, db):
+        _seed_gateway_session(db, "topic-a-old", chat_id="-100", thread_id="111", started_offset=-20)
+        _seed_gateway_session(db, "topic-b-new", chat_id="-100", thread_id="222", started_offset=20)
+        _seed_gateway_session(db, "topic-a-new", chat_id="-100", thread_id="111", started_offset=40)
+
+        result = json.loads(session_search(
+            db=db,
+            current_source="telegram",
+            current_chat_type="group",
+            current_chat_id="-100",
+            current_thread_id="111",
+        ))
+
+        assert result["success"] is True
+        assert [r["session_id"] for r in result["results"]] == ["topic-a-new", "topic-a-old"]
+
+    def test_read_rejects_session_outside_gateway_scope(self, db):
+        _seed_gateway_session(db, "topic-a", chat_id="-100", thread_id="111")
+        _seed_gateway_session(db, "topic-b", chat_id="-100", thread_id="222")
+
+        result = json.loads(session_search(
+            session_id="topic-b",
+            db=db,
+            current_source="telegram",
+            current_chat_type="group",
+            current_chat_id="-100",
+            current_thread_id="111",
+        ))
+
+        assert result["success"] is False
+        assert "outside the current gateway chat/thread scope" in result["error"]
+
+    def test_scroll_rejects_session_outside_gateway_scope(self, db):
+        _seed_gateway_session(db, "topic-a", chat_id="-100", thread_id="111")
+        _seed_gateway_session(db, "topic-b", chat_id="-100", thread_id="222")
+        message_id = db._conn.execute(
+            "SELECT id FROM messages WHERE session_id = ? ORDER BY id LIMIT 1",
+            ("topic-b",),
+        ).fetchone()[0]
+
+        result = json.loads(session_search(
+            session_id="topic-b",
+            around_message_id=message_id,
+            db=db,
+            current_source="telegram",
+            current_chat_type="group",
+            current_chat_id="-100",
+            current_thread_id="111",
+        ))
+
+        assert result["success"] is False
+        assert "outside the current gateway chat/thread scope" in result["error"]
 
 
 class TestRoleFilter:

--- a/tools/session_search_tool.py
+++ b/tools/session_search_tool.py
@@ -40,6 +40,78 @@ from typing import Any, Dict, List, Optional, Union
 _HIDDEN_SESSION_SOURCES = ("subagent", "tool")
 
 
+def _clean_scope_value(value: Any, *, lower: bool = False) -> Optional[str]:
+    if value is None:
+        return None
+    text = str(value).strip()
+    if not text:
+        return None
+    return text.lower() if lower else text
+
+
+def _build_current_scope(
+    *,
+    current_source: str = None,
+    current_chat_type: str = None,
+    current_chat_id: str = None,
+    current_thread_id: str = None,
+    current_session_key: str = None,
+) -> Optional[Dict[str, str]]:
+    source = _clean_scope_value(current_source, lower=True)
+    chat_id = _clean_scope_value(current_chat_id)
+    if not source or not chat_id:
+        return None
+    return {
+        "source": source,
+        "chat_type": _clean_scope_value(current_chat_type, lower=True),
+        "chat_id": chat_id,
+        "thread_id": _clean_scope_value(current_thread_id),
+        "session_key": _clean_scope_value(current_session_key),
+    }
+
+
+def _session_matches_current_scope(
+    session_meta: Dict[str, Any],
+    current_scope: Optional[Dict[str, str]],
+) -> bool:
+    if not current_scope:
+        return True
+    if _clean_scope_value(session_meta.get("source"), lower=True) != current_scope["source"]:
+        return False
+    if current_scope.get("chat_type"):
+        if _clean_scope_value(session_meta.get("chat_type"), lower=True) != current_scope["chat_type"]:
+            return False
+    if _clean_scope_value(session_meta.get("chat_id")) != current_scope["chat_id"]:
+        return False
+    meta_thread = _clean_scope_value(session_meta.get("thread_id"))
+    current_thread = current_scope.get("thread_id")
+    if current_thread:
+        return meta_thread == current_thread
+    return meta_thread is None
+
+
+def _list_scope_kwargs(current_scope: Optional[Dict[str, str]]) -> Dict[str, Any]:
+    if not current_scope:
+        return {}
+    kwargs: Dict[str, Any] = {
+        "source": current_scope["source"],
+        "chat_type_filter": current_scope.get("chat_type"),
+        "chat_id_filter": current_scope["chat_id"],
+        "thread_id_filter": current_scope.get("thread_id"),
+        "strict_thread_scope": True,
+    }
+    return kwargs
+
+
+def _search_scope_kwargs(current_scope: Optional[Dict[str, str]]) -> Dict[str, Any]:
+    if not current_scope:
+        return {}
+    kwargs = _list_scope_kwargs(current_scope)
+    source = kwargs.pop("source")
+    kwargs["source_filter"] = [source]
+    return kwargs
+
+
 def _format_timestamp(ts: Union[int, float, str, None]) -> str:
     """Convert a Unix timestamp (float/int) or ISO string to a human-readable date.
 
@@ -175,7 +247,13 @@ def _locate_session_db(session_id: str):
     return None, None
 
 
-def _read_session(db, session_id: str, head: int = 20, tail: int = 10) -> str:
+def _read_session(
+    db,
+    session_id: str,
+    head: int = 20,
+    tail: int = 10,
+    current_scope: Optional[Dict[str, str]] = None,
+) -> str:
     """Read shape: dump a whole session by id (head + tail when large).
 
     Serves the linked-session case — the user dropped an @session reference and
@@ -190,6 +268,11 @@ def _read_session(db, session_id: str, head: int = 20, tail: int = 10) -> str:
         meta = {}
     if not meta:
         return tool_error(f"session_id not found: {session_id}", success=False)
+    if not _session_matches_current_scope(meta, current_scope):
+        return tool_error(
+            "session_id is outside the current gateway chat/thread scope",
+            success=False,
+        )
 
     try:
         rows = db.get_messages(session_id)
@@ -224,13 +307,19 @@ def _read_session(db, session_id: str, head: int = 20, tail: int = 10) -> str:
     return json.dumps(response, ensure_ascii=False)
 
 
-def _list_recent_sessions(db, limit: int, current_session_id: str = None) -> str:
+def _list_recent_sessions(
+    db,
+    limit: int,
+    current_session_id: str = None,
+    current_scope: Optional[Dict[str, str]] = None,
+) -> str:
     """Return metadata for the most recent sessions (no LLM calls, no FTS5)."""
     try:
         sessions = db.list_sessions_rich(
             limit=limit + 5,
             exclude_sources=list(_HIDDEN_SESSION_SOURCES),
             order_by_last_active=True,
+            **_list_scope_kwargs(current_scope),
         )  # fetch extra so we can skip current
 
         current_root = _resolve_to_parent(db, current_session_id) if current_session_id else None
@@ -273,6 +362,7 @@ def _scroll(
     around_message_id: int,
     window: int = 5,
     current_session_id: str = None,
+    current_scope: Optional[Dict[str, str]] = None,
 ) -> str:
     """Scroll shape: return a window of messages centered on an anchor.
 
@@ -316,6 +406,11 @@ def _scroll(
         session_meta = {}
     if not session_meta:
         return tool_error(f"session_id not found: {session_id}", success=False)
+    if not _session_matches_current_scope(session_meta, current_scope):
+        return tool_error(
+            "session_id is outside the current gateway chat/thread scope",
+            success=False,
+        )
 
     # Fetch the window
     try:
@@ -398,6 +493,7 @@ def _discover(
     limit: int,
     sort: Optional[str],
     current_session_id: str = None,
+    current_scope: Optional[Dict[str, str]] = None,
 ) -> str:
     """Discovery shape: FTS5 + anchored window + bookends per hit. Single call."""
     role_list = role_filter if role_filter else ["user", "assistant"]
@@ -410,6 +506,7 @@ def _discover(
             limit=50,  # widen so dedup-by-lineage can find distinct sessions
             offset=0,
             sort=sort,
+            **_search_scope_kwargs(current_scope),
         )
     except Exception as e:
         logging.error("FTS5 search failed: %s", e, exc_info=True)
@@ -498,6 +595,11 @@ def session_search(
     limit: int = 3,
     db=None,
     current_session_id: str = None,
+    current_source: str = None,
+    current_chat_type: str = None,
+    current_chat_id: str = None,
+    current_thread_id: str = None,
+    current_session_key: str = None,
     # Scroll shape
     session_id: str = None,
     around_message_id: int = None,
@@ -527,6 +629,14 @@ def session_search(
             from hermes_state import format_session_db_unavailable
             return tool_error(format_session_db_unavailable(), success=False)
 
+    current_scope = _build_current_scope(
+        current_source=current_source,
+        current_chat_type=current_chat_type,
+        current_chat_id=current_chat_id,
+        current_thread_id=current_thread_id,
+        current_session_key=current_session_key,
+    )
+
     # Normalise a raw `@session:<profile>/<id>` link value passed as session_id.
     # Session ids never contain "/", so a slash unambiguously means profile/id —
     # always strip the prefix off the id, and adopt the embedded profile only
@@ -550,6 +660,7 @@ def session_search(
         if profile_db is not None:
             db = profile_db
             current_session_id = None
+            current_scope = None
 
     # Scroll shape takes precedence — explicit anchor beats any query.
     if (isinstance(session_id, str) and session_id.strip()) and around_message_id is not None:
@@ -559,12 +670,13 @@ def session_search(
             around_message_id=around_message_id,
             window=window,
             current_session_id=current_session_id,
+            current_scope=current_scope,
         )
 
     # Read shape: a session_id with no anchor → dump the whole session.
     if isinstance(session_id, str) and session_id.strip():
         sid = session_id.strip()
-        result = _read_session(db, sid)
+        result = _read_session(db, sid, current_scope=current_scope)
         if json.loads(result).get("success"):
             return result
 
@@ -574,7 +686,7 @@ def session_search(
         located, owner = _locate_session_db(sid)
         if located is not None:
             try:
-                found = json.loads(_read_session(located, sid))
+                found = json.loads(_read_session(located, sid, current_scope=current_scope))
             finally:
                 located.close()
             if found.get("success"):
@@ -592,7 +704,7 @@ def session_search(
 
     # Browse shape: no query → recent sessions.
     if not query or not isinstance(query, str) or not query.strip():
-        return _list_recent_sessions(db, limit, current_session_id)
+        return _list_recent_sessions(db, limit, current_session_id, current_scope)
 
     # Parse role_filter
     role_list: Optional[List[str]] = None
@@ -613,6 +725,7 @@ def session_search(
         limit=limit,
         sort=sort_norm,
         current_session_id=current_session_id,
+        current_scope=current_scope,
     )
 
 
@@ -791,6 +904,11 @@ registry.register(
         profile=args.get("profile"),
         db=kw.get("db"),
         current_session_id=kw.get("current_session_id"),
+        current_source=kw.get("current_source"),
+        current_chat_type=kw.get("current_chat_type"),
+        current_chat_id=kw.get("current_chat_id"),
+        current_thread_id=kw.get("current_thread_id"),
+        current_session_key=kw.get("current_session_key"),
     ),
     check_fn=check_session_search_requirements,
     emoji="🔍",


### PR DESCRIPTION
## Summary
- Persist gateway chat/thread scope metadata on session rows, including resets, branches, and compression continuations.
- Apply the current gateway platform/chat/thread scope to session recall for browse, discovery, read, and scroll paths.
- Add regression coverage for cross-topic isolation, parent-chat isolation, CJK fallback search, direct read rejection, and gateway session-store metadata.

Fixes #35465.

## Testing
- `.\.venv\Scripts\python -m compileall -q hermes_state.py tools/session_search_tool.py agent/tool_executor.py agent/agent_runtime_helpers.py agent/conversation_compression.py run_agent.py gateway/session.py gateway/slash_commands.py`
- `.\.venv\Scripts\python -m pytest tests/tools/test_session_search.py tests/test_hermes_state.py tests/gateway/test_session.py -q` (401 passed)
- `.\.venv\Scripts\python -m pytest tests/agent/test_compression_logging_session_context.py tests/run_agent/test_session_id_env.py -q` (4 passed)
- `.\.venv\Scripts\python -m pytest --collect-only -q` (collection succeeded)
- `.\.venv\Scripts\python -m pytest -q` was attempted after preparing the Windows test environment; it exceeded the 15 minute local tool timeout after collection had already been verified.