### PR TITLE
Redact secrets in desktop tool transcripts

### DIFF
--- a/apps/desktop/src/components/assistant-ui/tool/fallback-model.test.ts
+++ b/apps/desktop/src/components/assistant-ui/tool/fallback-model.test.ts
@@ -9,6 +9,7 @@ import {
   inlineDiffFromResult,
   MAX_TOOL_RENDER_CHARS,
   prettyJson,
+  toolCopyPayload,
   type ToolPart
 } from './fallback-model'
 
@@ -413,5 +414,32 @@ describe('prettyJson caps serialized result size', () => {
 describe('countDiffLineStats', () => {
   it('counts added and removed lines', () => {
     expect(countDiffLineStats(`--- a/x\n+++ b/x\n@@\n-old\n+new\n context\n+another`)).toEqual({ added: 2, removed: 1 })
+  })
+})
+
+describe('buildToolView secret redaction', () => {
+  it('redacts token-shaped values from terminal display and copy payloads', () => {
+    const fakeToken = 'fake_plex_token_for_tool_card_123456789'
+
+    const tool = part({
+      args: {
+        command: `PLEX_TOKEN='${fakeToken}' curl 'http://localhost:32400/library?X-Plex-Token=${fakeToken}'`
+      },
+      result: {
+        output: `Authorization: Bearer ${fakeToken}`,
+        stderr: `token=${fakeToken}`,
+        stdout: `http://localhost:32400/status?X-Plex-Token=${fakeToken}`
+      },
+      toolName: 'terminal'
+    })
+
+    const view = buildToolView(tool, '')
+    const copy = toolCopyPayload(tool, view)
+    const rendered = JSON.stringify({ view, copy })
+
+    expect(rendered).not.toContain(fakeToken)
+    expect(view.title).toContain('[REDACTED]')
+    expect(view.detail).toContain('[REDACTED]')
+    expect(copy.text).toContain('[REDACTED]')
   })
 })

--- a/apps/desktop/src/components/assistant-ui/tool/fallback-model/index.ts
+++ b/apps/desktop/src/components/assistant-ui/tool/fallback-model/index.ts
@@ -1,5 +1,6 @@
 import { type ToolTitleKey, translateNow } from '@/i18n'
 import { normalizeExternalUrl } from '@/lib/external-link'
+import { redactSensitiveValue } from '@/lib/secret-redaction'
 import { summarizeShellCommand } from '@/lib/summarize-command'
 import { capitalize, normalize } from '@/lib/text'
 import { extractToolErrorMessage, formatToolResultSummary } from '@/lib/tool-result-summary'
@@ -1182,8 +1183,8 @@ export function toolCopyPayload(part: ToolPart, view: ToolView): { label: string
     generic: translateNow('common.copy')
   }
 
-  const args = parseMaybeObject(part.args)
-  const result = parseMaybeObject(part.result)
+  const args = parseMaybeObject(redactSensitiveValue(part.args))
+  const result = parseMaybeObject(redactSensitiveValue(part.result))
   const detail = view.detail.trim()
   const hasSubstantialOutput = detail.length > 16
 
@@ -1391,23 +1392,29 @@ function dynamicTitle(
 }
 
 export function buildToolView(part: ToolPart, inlineDiff: string): ToolView {
-  const argsRecord = parseMaybeObject(part.args)
-  const resultRecord = parseMaybeObject(part.result)
+  const safePart: ToolPart = {
+    ...part,
+    args: redactSensitiveValue(part.args),
+    result: redactSensitiveValue(part.result)
+  }
+
+  const argsRecord = parseMaybeObject(safePart.args)
+  const resultRecord = parseMaybeObject(safePart.result)
   const meta = toolMeta(part.toolName)
-  const status = toolStatus(part, resultRecord)
-  const error = toolErrorText(part, resultRecord)
-  const baseTitle = part.result === undefined ? meta.pending : meta.done
+  const status = toolStatus(safePart, resultRecord)
+  const error = toolErrorText(safePart, resultRecord)
+  const baseTitle = safePart.result === undefined ? meta.pending : meta.done
 
   const titleParts = dynamicTitle(
-    part,
+    safePart,
     argsRecord,
     resultRecord,
-    titlePartsFromAction(baseTitle, part.result === undefined ? meta.pendingAction : undefined)
+    titlePartsFromAction(baseTitle, safePart.result === undefined ? meta.pendingAction : undefined)
   )
 
   const title = titleParts.title
   const titleEnriched = title !== baseTitle
-  const baseSubtitle = error || toolSubtitle(part, argsRecord, resultRecord)
+  const baseSubtitle = error || toolSubtitle(safePart, argsRecord, resultRecord)
 
   const keepSubtitleWithTitle =
     part.toolName === 'terminal' ||
@@ -1415,7 +1422,7 @@ export function buildToolView(part: ToolPart, inlineDiff: string): ToolView {
     (isFileEditTool(part.toolName) && Boolean(baseSubtitle.trim()))
 
   const subtitle = titleEnriched && !error && !keepSubtitleWithTitle ? '' : baseSubtitle
-  const detailBody = stripDividerLines(toolDetailText(part, argsRecord, resultRecord))
+  const detailBody = stripDividerLines(toolDetailText(safePart, argsRecord, resultRecord))
 
   const detail = error
     ? [error, detailBody]
@@ -1425,14 +1432,14 @@ export function buildToolView(part: ToolPart, inlineDiff: string): ToolView {
     : detailBody
 
   const searchHits =
-    part.toolName === 'web_search' && status !== 'error' ? extractSearchResults(part.result) : undefined
+    safePart.toolName === 'web_search' && status !== 'error' ? extractSearchResults(safePart.result) : undefined
 
   const searchQuery =
     part.toolName === 'web_search'
       ? firstStringField(argsRecord, ['search_term', 'query']) || contextValue(argsRecord)
       : ''
 
-  const resultCount = status === 'error' ? null : toolResultCount(part, argsRecord, resultRecord)
+  const resultCount = status === 'error' ? null : toolResultCount(safePart, argsRecord, resultRecord)
 
   // For shell/code tools we surface stdout and stderr as separate labeled
   // streams in the renderer. Many CLIs use stderr for informational

--- a/apps/desktop/src/lib/chat-messages.test.ts
+++ b/apps/desktop/src/lib/chat-messages.test.ts
@@ -995,6 +995,70 @@ describe('upsertToolPart', () => {
       summary: 'Did 1 search in 0.5s'
     })
   })
+
+  it('redacts token-shaped values from live tool args and results', () => {
+    const fakeToken = 'fake_plex_token_for_live_tool_123456789'
+
+    const completed = upsertToolPart(
+      [],
+      {
+        args: {
+          command: `PLEX_TOKEN='${fakeToken}' curl 'http://localhost:32400/library?X-Plex-Token=${fakeToken}'`
+        },
+        name: 'terminal',
+        result: {
+          stdout: `connected with Authorization: Bearer ${fakeToken}`,
+          output: `http://localhost:32400/status?X-Plex-Token=${fakeToken}`
+        },
+        tool_id: 'terminal-secret'
+      },
+      'complete'
+    )
+
+    const serialized = JSON.stringify(completed)
+
+    expect(serialized).not.toContain(fakeToken)
+    expect(serialized).toContain('[REDACTED]')
+  })
+
+  it('redacts token-shaped values from stored tool calls and tool results', () => {
+    const fakeToken = 'fake_plex_token_for_stored_tool_123456789'
+
+    const messages = toChatMessages([
+      {
+        role: 'assistant',
+        content: `running TOKEN=${fakeToken}`,
+        reasoning: `checking X-Plex-Token=${fakeToken}`,
+        timestamp: 1,
+        tool_calls: [
+          {
+            id: 'tc-secret',
+            function: {
+              name: 'terminal',
+              arguments: JSON.stringify({
+                command: `TOKEN=${fakeToken} curl 'http://localhost:32400/library?X-Plex-Token=${fakeToken}'`
+              })
+            }
+          }
+        ]
+      },
+      {
+        role: 'tool',
+        tool_call_id: 'tc-secret',
+        tool_name: 'terminal',
+        content: JSON.stringify({
+          stdout: `Authorization: Bearer ${fakeToken}`,
+          output: `PLEX_TOKEN=${fakeToken}`
+        }),
+        timestamp: 2
+      }
+    ])
+
+    const serialized = JSON.stringify(messages)
+
+    expect(serialized).not.toContain(fakeToken)
+    expect(serialized).toContain('[REDACTED]')
+  })
 })
 
 describe('mergeFinalAssistantText', () => {

--- a/apps/desktop/src/lib/chat-messages.ts
+++ b/apps/desktop/src/lib/chat-messages.ts
@@ -4,6 +4,7 @@ import { type BillingBlock, skillInvocationText } from '@hermes/shared'
 import { extractImageRefs } from '@/lib/embedded-images'
 import { dedupeGeneratedImageEchoesInParts } from '@/lib/generated-images'
 import { mediaDisplayLabel, mediaMarkdownHref } from '@/lib/media'
+import { redactSensitiveText, redactSensitiveValue } from '@/lib/secret-redaction'
 import { normalize } from '@/lib/text'
 import { parseTodos } from '@/lib/todos'
 import type { SessionMessage, UsageStats } from '@/types/hermes'
@@ -119,7 +120,7 @@ export function textPart(text: string): ChatMessagePart {
 }
 
 export function reasoningPart(text: string): ChatMessagePart {
-  return { type: 'reasoning', text }
+  return { type: 'reasoning', text: redactSensitiveText(text) }
 }
 
 const MEDIA_LINE_RE = /(^|\n)[\t ]*[`"']?MEDIA:\s*(?<line>`[^`\n]+`|"[^"\n]+"|'[^'\n]+'|\S+)[`"']?[\t ]*(\n|$)/g
@@ -151,7 +152,7 @@ export function renderMediaTags(text: string): string {
 }
 
 export function assistantTextPart(text: string): ChatMessagePart {
-  return textPart(renderMediaTags(text))
+  return textPart(renderMediaTags(redactSensitiveText(text)))
 }
 
 export function chatMessageText(message: ChatMessage): string {
@@ -298,7 +299,7 @@ function displayContentForMessage(role: SessionMessage['role'], content: unknown
   const textContent = textFromUnknown(content)
 
   if (role !== 'user') {
-    return textContent
+    return redactSensitiveText(textContent)
   }
 
   // A `/skill` turn is stored expanded (the whole skill body). Current
@@ -397,7 +398,11 @@ function appendStreamPart(
     const part = next[i]
 
     if (part.type === type) {
-      next[i] = { ...part, text: `${(part as { text: string }).text}${delta}` } as ChatMessagePart
+      const nextText = `${(part as { text: string }).text}${delta}`
+      next[i] = {
+        ...part,
+        text: type === 'reasoning' ? redactSensitiveText(nextText) : nextText
+      } as ChatMessagePart
 
       return { index: i, parts: next }
     }
@@ -431,12 +436,11 @@ export function appendAssistantTextPart(parts: ChatMessagePart[], delta: string)
   const mayContainMedia =
     delta.includes('MEDIA:') || delta.includes('DIA:') || delta.includes('EDIA:') || delta.includes('IA:')
 
-  if (mayContainMedia || part.text.includes('MEDIA:')) {
-    const rendered = renderMediaTags(part.text)
+  const redacted = redactSensitiveText(part.text)
+  const rendered = mayContainMedia || redacted.includes('MEDIA:') ? renderMediaTags(redacted) : redacted
 
-    if (rendered !== part.text) {
-      next[index] = { ...part, text: rendered }
-    }
+  if (rendered !== part.text) {
+    next[index] = { ...part, text: rendered }
   }
 
   return next
@@ -610,13 +614,13 @@ function toolArgs(payload: GatewayEventPayload | undefined, prevArgs?: unknown):
   const prev = parseMaybeJsonObject(prevArgs)
   const eventArgs = liveToolArgs(payload)
 
-  return {
+  return redactSensitiveValue({
     ...prev,
     ...eventArgs,
     ...(payload?.context ? { context: payload.context } : {}),
     ...(payload?.preview ? { preview: payload.preview } : {}),
     ...carryTodos(payload, prevArgs)
-  }
+  }) as Record<string, unknown>
 }
 
 function toolResult(
@@ -626,7 +630,7 @@ function toolResult(
 ): Record<string, unknown> {
   const parsedResult = parseMaybeJsonObject(payload?.result)
 
-  return {
+  return redactSensitiveValue({
     ...parsedResult,
     ...(payload?.inline_diff ? { inline_diff: payload.inline_diff } : {}),
     ...(payload?.summary ? { summary: payload.summary } : {}),
@@ -635,7 +639,7 @@ function toolResult(
     ...(payload?.duration_s !== undefined ? { duration_s: payload.duration_s } : {}),
     ...carryTodos(payload, prevResult, prevArgs),
     ...(payload?.error ? { error: payload.error } : {})
-  }
+  }) as Record<string, unknown>
 }
 
 export function upsertToolPart(
@@ -735,7 +739,7 @@ function liveToolArgs(payload: GatewayEventPayload | undefined): Record<string, 
 
 function parseStoredToolResult(content: unknown): unknown {
   if (content && typeof content === 'object') {
-    return content
+    return redactSensitiveValue(content)
   }
 
   const textContent = textFromUnknown(content)
@@ -745,9 +749,9 @@ function parseStoredToolResult(content: unknown): unknown {
   }
 
   try {
-    return JSON.parse(textContent)
+    return redactSensitiveValue(JSON.parse(textContent))
   } catch {
-    return textContent
+    return redactSensitiveText(textContent)
   }
 }
 
@@ -760,7 +764,10 @@ function toolPartFromStoredCall(call: unknown, fallbackIndex: number): ChatMessa
     row.name || row.tool_name || fn?.name || (recordFromUnknown(row.input)?.name as string | undefined) || 'tool'
   )
 
-  const args = firstNonEmptyObject(fn?.arguments, row.arguments, row.args, row.input)
+  const args = redactSensitiveValue(firstNonEmptyObject(fn?.arguments, row.arguments, row.args, row.input)) as Record<
+    string,
+    unknown
+  >
 
   return {
     type: 'tool-call',
@@ -836,7 +843,7 @@ function applyStoredToolResultToParts(parts: ChatMessagePart[], toolMessage: Ses
 
 function storedToolMessagePart(toolMessage: SessionMessage, fallbackIndex: number): ChatMessagePart {
   const name = toolMessage.tool_name || toolMessage.name || 'tool'
-  const context = textFromUnknown(toolMessage.context || toolMessage.text || toolMessage.content || '')
+  const context = redactSensitiveText(textFromUnknown(toolMessage.context || toolMessage.text || toolMessage.content || ''))
   const args = context ? { context } : {}
 
   return {

--- a/apps/desktop/src/lib/secret-redaction.test.ts
+++ b/apps/desktop/src/lib/secret-redaction.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest'
+
+import { redactSensitiveText, redactSensitiveValue } from './secret-redaction'
+
+const FAKE_TOKEN = 'fake_plex_token_for_regression_123456789'
+
+describe('secret redaction', () => {
+  it('redacts Plex URL tokens in shell commands', () => {
+    const text = `curl 'http://localhost:32400/library/sections?X-Plex-Token=${FAKE_TOKEN}'`
+    const redacted = redactSensitiveText(text)
+
+    expect(redacted).not.toContain(FAKE_TOKEN)
+    expect(redacted).toContain('X-Plex-Token=[REDACTED]')
+  })
+
+  it('redacts env assignments and bearer headers', () => {
+    const text = `PLEX_TOKEN='${FAKE_TOKEN}' curl -H "Authorization: Bearer ${FAKE_TOKEN}" http://localhost`
+    const redacted = redactSensitiveText(text)
+
+    expect(redacted).not.toContain(FAKE_TOKEN)
+    expect(redacted).toContain("PLEX_TOKEN='[REDACTED]'")
+    expect(redacted).toContain('Authorization: Bearer [REDACTED]')
+  })
+
+  it('redacts nested structured values', () => {
+    const redacted = redactSensitiveValue({
+      command: `TOKEN=${FAKE_TOKEN} python /tmp/check.py`,
+      nested: {
+        token: FAKE_TOKEN,
+        url: `http://localhost:32400/?X-Plex-Token=${FAKE_TOKEN}`
+      }
+    })
+
+    expect(JSON.stringify(redacted)).not.toContain(FAKE_TOKEN)
+    expect(redacted).toMatchObject({
+      command: 'TOKEN=[REDACTED] python /tmp/check.py',
+      nested: {
+        token: '[REDACTED]',
+        url: 'http://localhost:32400/?X-Plex-Token=[REDACTED]'
+      }
+    })
+  })
+})

--- a/apps/desktop/src/lib/secret-redaction.ts
+++ b/apps/desktop/src/lib/secret-redaction.ts
@@ -1,0 +1,72 @@
+const REDACTED = '[REDACTED]'
+
+const SENSITIVE_KEY_RE =
+  /(?:^|[_-])(?:api[_-]?key|auth|authorization|bearer|cookie|password|passwd|private[_-]?key|refresh[_-]?token|secret|session|token)(?:$|[_-])/i
+
+const NAMED_SECRET_RE =
+  /(?:X-Plex-Token|Plex-Token|PLEX_TOKEN|[A-Z0-9_]*(?:TOKEN|SECRET|PASSWORD|PASSWD|API_KEY|ACCESS_KEY|PRIVATE_KEY|AUTH)[A-Z0-9_]*|api[_-]?key|apikey|access[_-]?token|refresh[_-]?token|password|secret|token)/i
+
+const QUERY_SECRET_RE =
+  /([?&](?:X-Plex-Token|Plex-Token|api[_-]?key|apikey|access[_-]?token|refresh[_-]?token|password|secret|token)=)([^&\s"'`<>)]*)/gi
+
+const BEARER_SECRET_RE = /\b(Authorization\s*:\s*Bearer\s+)([A-Za-z0-9._~+/-]+=*)/gi
+
+const JSON_SECRET_RE =
+  /((["'])(?:X-Plex-Token|Plex-Token|[A-Za-z0-9_]*(?:token|secret|password|passwd|api[_-]?key|access[_-]?key|private[_-]?key|auth)[A-Za-z0-9_]*|api[_-]?key|apikey|access[_-]?token|refresh[_-]?token|password|secret)\2\s*:\s*)(["'])([^"']+)(\3)/gi
+
+const ASSIGNMENT_SECRET_RE =
+  /(\b(?:X-Plex-Token|Plex-Token|[A-Za-z0-9_]*(?:TOKEN|SECRET|PASSWORD|PASSWD|API[_-]?KEY|ACCESS[_-]?KEY|PRIVATE[_-]?KEY)[A-Za-z0-9_]*|api[_-]?key|apikey|access[_-]?token|refresh[_-]?token|password|secret|token)\b\s*[:=]\s*)(["']?)([^\s"'`;&|)]+)/gi
+
+function isSensitiveKey(key: string): boolean {
+  return NAMED_SECRET_RE.test(key) || SENSITIVE_KEY_RE.test(key)
+}
+
+export function redactSensitiveText(value: string): string {
+  if (!value) {
+    return value
+  }
+
+  return value
+    .replace(QUERY_SECRET_RE, (_match, prefix: string) => `${prefix}${REDACTED}`)
+    .replace(BEARER_SECRET_RE, (_match, prefix: string) => `${prefix}${REDACTED}`)
+    .replace(JSON_SECRET_RE, (_match, prefix: string, _keyQuote: string, valueQuote: string, _secret: string) => {
+      return `${prefix}${valueQuote}${REDACTED}${valueQuote}`
+    })
+    .replace(ASSIGNMENT_SECRET_RE, (_match, prefix: string, quote: string) => `${prefix}${quote}${REDACTED}`)
+}
+
+function redactUnknown(value: unknown, seen: WeakSet<object>): unknown {
+  if (typeof value === 'string') {
+    return redactSensitiveText(value)
+  }
+
+  if (value === null || value === undefined || typeof value !== 'object') {
+    return value
+  }
+
+  if (seen.has(value)) {
+    return '[Circular]'
+  }
+
+  seen.add(value)
+
+  if (Array.isArray(value)) {
+    return value.map(item => redactUnknown(item, seen))
+  }
+
+  if (value instanceof Date) {
+    return value
+  }
+
+  const next: Record<string, unknown> = {}
+
+  for (const [key, rowValue] of Object.entries(value as Record<string, unknown>)) {
+    next[key] = isSensitiveKey(key) ? REDACTED : redactUnknown(rowValue, seen)
+  }
+
+  return next
+}
+
+export function redactSensitiveValue<T>(value: T): T {
+  return redactUnknown(value, new WeakSet()) as T
+}

--- a/apps/desktop/src/lib/tool-result-summary.ts
+++ b/apps/desktop/src/lib/tool-result-summary.ts
@@ -1,6 +1,7 @@
 // Heuristic JSON → human summary for tool results. Default view; technical
 // mode still gets the raw JSON section.
 
+import { redactSensitiveText } from '@/lib/secret-redaction'
 import { capitalize, normalize } from '@/lib/text'
 
 const WRAPPER_KEYS = ['data', 'result', 'output', 'response', 'payload'] as const
@@ -63,13 +64,13 @@ const titleCase = (k: string) =>
 const pluralize = (n: number, noun: string) => `${n} ${noun}${n === 1 ? '' : 's'}`
 
 function clipInline(value: string, max = 180): string {
-  const c = value.replace(/\s+/g, ' ').trim()
+  const c = redactSensitiveText(value).replace(/\s+/g, ' ').trim()
 
   return c.length > max ? `${c.slice(0, max - 1)}…` : c
 }
 
 function clipBlock(value: string, maxChars = 1800, maxLines = 18): string {
-  const t = value.trim()
+  const t = redactSensitiveText(value).trim()
 
   if (!t) {
     return ''


### PR DESCRIPTION
## Summary

- add a shared desktop redaction helper for token-shaped strings and structured values
- redact assistant text/reasoning plus live and stored tool args/results before transcript rendering
- redact tool-card display, raw JSON, stdout/stderr, summaries, and copy payloads as a second defense layer

## Verification

- `npm exec vitest run src/lib/secret-redaction.test.ts src/lib/chat-messages.test.ts src/components/assistant-ui/tool-fallback-model.test.ts --environment jsdom`
- `npm exec eslint src/lib/secret-redaction.ts src/lib/secret-redaction.test.ts src/lib/chat-messages.ts src/lib/chat-messages.test.ts src/components/assistant-ui/tool-fallback-model.ts src/components/assistant-ui/tool-fallback-model.test.ts`
- `npm --prefix apps/desktop run typecheck`
- `npm --prefix apps/desktop run build`

## Notes

- Regression tests use only fake token values.
- Full desktop lint still has unrelated pre-existing errors outside the touched files; the focused touched-file lint is clean.
