### PR TITLE
feat(mattermost): channel discovery, raw-ID targeting, delete + reactions

### DIFF
--- a/gateway/channel_directory.py
+++ b/gateway/channel_directory.py
@@ -125,6 +125,8 @@ async def build_channel_directory(adapters: Dict[Any, Any]) -> Dict[str, Any]:
                 platforms["discord"] = await asyncio.to_thread(_build_discord, adapter)
             elif platform == Platform.SLACK:
                 platforms["slack"] = await _build_slack(adapter)
+            elif platform == Platform.MATTERMOST:
+                platforms["mattermost"] = await _build_mattermost(adapter)
         except Exception as e:
             logger.warning("Channel directory: failed to build %s: %s", platform.value, e)
 
@@ -269,6 +271,69 @@ async def _build_slack(adapter) -> List[Dict[str, Any]]:
 
     # Merge in DM/group entries discovered from session history.
     for entry in await asyncio.to_thread(_build_from_sessions, "slack"):
+        if entry.get("id") not in seen_ids:
+            channels.append(entry)
+            seen_ids.add(entry.get("id"))
+
+    return channels
+
+
+async def _build_mattermost(adapter) -> List[Dict[str, Any]]:
+    """List the Mattermost channels the bot is a member of, across all teams.
+
+    Walks ``GET users/me/teams`` → ``GET users/me/teams/{team_id}/channels``
+    via the adapter's ``_api_get`` helper (no Mattermost SDK required) and maps
+    the channel ``type`` codes (O/P/D/G) through the adapter's
+    ``_CHANNEL_TYPE_MAP`` so the directory uses the same vocabulary as the rest
+    of the adapter. DMs discovered from session history are merged in afterward,
+    deduped by id (the API entry wins). Modeled on ``_build_slack``.
+    """
+    from plugins.platforms.mattermost.adapter import _CHANNEL_TYPE_MAP
+
+    api_get = getattr(adapter, "_api_get", None)
+    if api_get is None:
+        return _build_from_sessions("mattermost")
+
+    channels: List[Dict[str, Any]] = []
+    seen_ids: set = set()
+
+    try:
+        teams = await api_get("users/me/teams")
+    except Exception as e:
+        logger.warning("Channel directory: failed to list Mattermost teams: %s", e)
+        teams = []
+
+    for team in teams or []:
+        team_id = team.get("id") if isinstance(team, dict) else None
+        if not team_id:
+            continue
+        try:
+            team_channels = await api_get(f"users/me/teams/{team_id}/channels")
+        except Exception as e:
+            logger.warning(
+                "Channel directory: failed to list Mattermost channels for team %s: %s",
+                team_id, e,
+            )
+            continue
+        for ch in team_channels or []:
+            if not isinstance(ch, dict):
+                continue
+            cid = ch.get("id")
+            if not cid or cid in seen_ids:
+                continue
+            # Prefer the human-facing display_name; fall back to the slug name.
+            name = ch.get("display_name") or ch.get("name")
+            if not name:
+                continue
+            seen_ids.add(cid)
+            channels.append({
+                "id": cid,
+                "name": name,
+                "type": _CHANNEL_TYPE_MAP.get(ch.get("type", "O"), "channel"),
+            })
+
+    # Merge in DM/group entries discovered from session history.
+    for entry in _build_from_sessions("mattermost"):
         if entry.get("id") not in seen_ids:
             channels.append(entry)
             seen_ids.add(entry.get("id"))

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -4942,6 +4942,12 @@ _PLATFORMS = [
                 "password": False,
                 "help": "off = flat channel messages, thread = replies nest under your message.",
             },
+            {
+                "name": "MATTERMOST_REACTIONS",
+                "prompt": "Add progress reactions (👀/✅/❌) to handled messages? (true/false, default: true)",
+                "password": False,
+                "help": "true = react 👀 while working, ✅ on success, ❌ on failure; false = no reactions.",
+            },
         ],
     },
     # WhatsApp moved to plugins/platforms/whatsapp/ — setup metadata discovered

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -4942,12 +4942,9 @@ _PLATFORMS = [
                 "password": False,
                 "help": "off = flat channel messages, thread = replies nest under your message.",
             },
-            {
-                "name": "MATTERMOST_REACTIONS",
-                "prompt": "Add progress reactions (👀/✅/❌) to handled messages? (true/false, default: true)",
-                "password": False,
-                "help": "true = react 👀 while working, ✅ on success, ❌ on failure; false = no reactions.",
-            },
+            # Progress reactions (👀/✅/❌) are a behavioral toggle, configured via
+            # config.yaml `mattermost.reactions` (not a .env setup prompt) per
+            # AGENTS.md — bridged to the internal MATTERMOST_REACTIONS env var.
         ],
     },
     # WhatsApp moved to plugins/platforms/whatsapp/ — setup metadata discovered

--- a/plugins/platforms/mattermost/adapter.py
+++ b/plugins/platforms/mattermost/adapter.py
@@ -245,6 +245,13 @@ class MattermostAdapter(BasePlatformAdapter):
     async def _api_delete(self, path: str) -> bool:
         """DELETE /api/v4/{path}. Returns True on a 2xx response."""
         import aiohttp
+        # Path-traversal guard — mirrors _api_get/_api_post/_api_put (d836b2bac).
+        # WebSocket-derived ids (post_id, channel_id, emoji names) are
+        # interpolated into this bearer-token-authenticated path, so a crafted
+        # '..' payload could redirect the authed request to another endpoint.
+        if ".." in path:
+            logger.error("MM API path traversal blocked: %s", path)
+            return False
         url = f"{self._base_url}/api/v4/{path.lstrip('/')}"
         try:
             async with self._session.delete(
@@ -465,9 +472,11 @@ class MattermostAdapter(BasePlatformAdapter):
     def _reactions_enabled(self) -> bool:
         """Whether processing-lifecycle reactions are enabled.
 
-        Gated by ``MATTERMOST_REACTIONS`` (default on), parallel to Slack's
-        ``SLACK_REACTIONS``. Set to ``false``/``0``/``no`` to disable the
-        👀/✅/❌ progress reactions entirely.
+        Configured via ``config.yaml`` ``mattermost.reactions`` (default on),
+        bridged to the internal ``MATTERMOST_REACTIONS`` env var by
+        ``_apply_yaml_config`` — the same pattern as ``mattermost.require_mention``.
+        Set ``mattermost.reactions: false`` to disable the 👀/✅/❌ progress
+        reactions entirely.
         """
         return os.getenv("MATTERMOST_REACTIONS", "true").lower() not in {"false", "0", "no"}
 
@@ -1335,6 +1344,11 @@ def _apply_yaml_config(yaml_cfg: dict, mattermost_cfg: dict) -> dict | None:
     """
     if "require_mention" in mattermost_cfg and not os.getenv("MATTERMOST_REQUIRE_MENTION"):
         os.environ["MATTERMOST_REQUIRE_MENTION"] = str(mattermost_cfg["require_mention"]).lower()
+    # reactions: 👀/✅/❌ progress annotations on handled messages (default on).
+    # Behavioral toggle → config.yaml per AGENTS.md; the adapter reads the
+    # bridged MATTERMOST_REACTIONS env only as the internal mechanism.
+    if "reactions" in mattermost_cfg and not os.getenv("MATTERMOST_REACTIONS"):
+        os.environ["MATTERMOST_REACTIONS"] = str(mattermost_cfg["reactions"]).lower()
     frc = mattermost_cfg.get("free_response_channels")
     if frc is not None and not os.getenv("MATTERMOST_FREE_RESPONSE_CHANNELS"):
         if isinstance(frc, list):
@@ -1394,7 +1408,7 @@ def register(ctx) -> None:
         # hermes_cli/setup.py::_setup_mattermost function.
         setup_fn=interactive_setup,
         # YAML→env config bridge — owns the translation of
-        # ``config.yaml`` ``mattermost:`` keys (require_mention,
+        # ``config.yaml`` ``mattermost:`` keys (require_mention, reactions,
         # free_response_channels, allowed_channels) into ``MATTERMOST_*``
         # env vars that the adapter reads via ``os.getenv()``.  Replaces
         # the hardcoded block that used to live in ``gateway/config.py``.

--- a/plugins/platforms/mattermost/adapter.py
+++ b/plugins/platforms/mattermost/adapter.py
@@ -27,6 +27,7 @@ from gateway.platforms.base import (
     BasePlatformAdapter,
     MessageEvent,
     MessageType,
+    ProcessingOutcome,
     SendResult,
 )
 
@@ -103,6 +104,11 @@ class MattermostAdapter(BasePlatformAdapter):
 
         # Dedup cache (prevent reprocessing)
         self._dedup = MessageDeduplicator()
+
+        # Post IDs we have reacted to (👀 on start, swapped for ✅/❌ on
+        # completion). Only populated when reactions are enabled and the bot is
+        # directly addressed — mirrors the Slack adapter.
+        self._reacting_message_ids: set = set()
 
     # ------------------------------------------------------------------
     # HTTP helpers
@@ -235,6 +241,24 @@ class MattermostAdapter(BasePlatformAdapter):
         except aiohttp.ClientError as exc:
             logger.error("MM API PUT %s network error: %s", path, exc)
             return {}
+
+    async def _api_delete(self, path: str) -> bool:
+        """DELETE /api/v4/{path}. Returns True on a 2xx response."""
+        import aiohttp
+        url = f"{self._base_url}/api/v4/{path.lstrip('/')}"
+        try:
+            async with self._session.delete(
+                url, headers=self._headers(),
+                timeout=aiohttp.ClientTimeout(total=30),
+            ) as resp:
+                if resp.status >= 400:
+                    body = await resp.text()
+                    logger.error("MM API DELETE %s → %s: %s", path, resp.status, body[:200])
+                    return False
+                return True
+        except aiohttp.ClientError as exc:
+            logger.error("MM API DELETE %s network error: %s", path, exc)
+            return False
 
     async def _upload_file(
         self, channel_id: str, file_data: bytes, filename: str, content_type: str = "application/octet-stream"
@@ -384,6 +408,98 @@ class MattermostAdapter(BasePlatformAdapter):
     # ------------------------------------------------------------------
     # Optional overrides
     # ------------------------------------------------------------------
+
+    async def delete_message(self, chat_id: str, message_id: str) -> bool:
+        """Delete a post via ``DELETE /api/v4/posts/{id}``.
+
+        The base class returns ``False`` (no deletion API); Mattermost supports
+        deletion, so the stream consumer's fresh-final cleanup and ephemeral
+        TTL paths can remove preview posts. ``chat_id`` is unused — Mattermost
+        deletes by post id alone — but kept for signature parity with the base.
+        """
+        if not message_id:
+            return False
+        return await self._api_delete(f"posts/{message_id}")
+
+    @staticmethod
+    def _normalize_emoji(emoji: str) -> str:
+        """Strip Slack-style surrounding colons from an emoji name.
+
+        Mattermost's reactions API expects a bare ``emoji_name`` (e.g.
+        ``thumbsup``), while callers may pass ``:thumbsup:``.
+        """
+        return (emoji or "").strip().strip(":")
+
+    async def _add_reaction(self, post_id: str, emoji: str) -> bool:
+        """Add an emoji reaction to a post. Returns True on success.
+
+        Mirrors the Slack adapter's ``_add_reaction`` style (best-effort, debug
+        logging on failure). Uses ``POST /api/v4/reactions`` with the bot user
+        id, post id, and a colon-stripped emoji name.
+        """
+        name = self._normalize_emoji(emoji)
+        if not post_id or not name:
+            return False
+        data = await self._api_post(
+            "reactions",
+            {
+                "user_id": self._bot_user_id,
+                "post_id": post_id,
+                "emoji_name": name,
+            },
+        )
+        return bool(data)
+
+    async def _remove_reaction(self, post_id: str, emoji: str) -> bool:
+        """Remove an emoji reaction from a post. Returns True on success.
+
+        Uses ``DELETE /api/v4/users/{user_id}/posts/{post_id}/reactions/{name}``.
+        """
+        name = self._normalize_emoji(emoji)
+        if not post_id or not name:
+            return False
+        return await self._api_delete(
+            f"users/{self._bot_user_id}/posts/{post_id}/reactions/{name}"
+        )
+
+    def _reactions_enabled(self) -> bool:
+        """Whether processing-lifecycle reactions are enabled.
+
+        Gated by ``MATTERMOST_REACTIONS`` (default on), parallel to Slack's
+        ``SLACK_REACTIONS``. Set to ``false``/``0``/``no`` to disable the
+        👀/✅/❌ progress reactions entirely.
+        """
+        return os.getenv("MATTERMOST_REACTIONS", "true").lower() not in {"false", "0", "no"}
+
+    async def on_processing_start(self, event: MessageEvent) -> None:
+        """Add an in-progress 👀 reaction when message processing begins.
+
+        Mirrors the Slack adapter: only reacts to posts we registered in
+        ``_reacting_message_ids`` (DMs / @mentions when reactions are enabled),
+        so casual listen-all channel chatter is not annotated.
+        """
+        if not self._reactions_enabled():
+            return
+        post_id = getattr(event, "message_id", None)
+        if not post_id or post_id not in self._reacting_message_ids:
+            return
+        await self._add_reaction(post_id, "eyes")
+
+    async def on_processing_complete(
+        self, event: MessageEvent, outcome: ProcessingOutcome
+    ) -> None:
+        """Swap the in-progress 👀 reaction for a final ✅ / ❌ reaction."""
+        if not self._reactions_enabled():
+            return
+        post_id = getattr(event, "message_id", None)
+        if not post_id or post_id not in self._reacting_message_ids:
+            return
+        self._reacting_message_ids.discard(post_id)
+        await self._remove_reaction(post_id, "eyes")
+        if outcome == ProcessingOutcome.SUCCESS:
+            await self._add_reaction(post_id, "white_check_mark")
+        elif outcome == ProcessingOutcome.FAILURE:
+            await self._add_reaction(post_id, "x")
 
     async def send_typing(
         self, chat_id: str, metadata: Optional[Dict[str, Any]] = None
@@ -804,6 +920,11 @@ class MattermostAdapter(BasePlatformAdapter):
         # For DMs, user_id is sufficient.  For channels, check for @mention.
         message_text = post.get("message", "")
 
+        is_dm = channel_type_raw == "D"
+        # Tracks whether the bot was directly addressed (DM or @mention) — used
+        # to decide whether to annotate the post with progress reactions.
+        has_mention = False
+
         # Mention-gating for non-DM channels.
         # Config (config.yaml `mattermost.*` with env-var fallback):
         #   require_mention / MATTERMOST_REQUIRE_MENTION: Require @mention in channels (default: true)
@@ -957,6 +1078,12 @@ class MattermostAdapter(BasePlatformAdapter):
             channel_prompt=_channel_prompt,
         )
 
+        # Register this post for progress reactions only when the bot is
+        # directly addressed (DM or @mention) and reactions are enabled —
+        # reacting to every listen-all message would be noisy. Mirrors Slack.
+        if (is_dm or has_mention) and self._reactions_enabled():
+            self._reacting_message_ids.add(post_id)
+
         await self.handle_message(msg_event)
 
 
@@ -1035,7 +1162,19 @@ async def _standalone_send(
             # 1. Upload media (if any) and collect file_ids.
             file_ids: List[str] = []
             for media in media_files:
-                file_path = media.get("path") if isinstance(media, dict) else media
+                # Accept every shape callers use: the canonical
+                # ``(path, is_voice)`` tuple produced by
+                # ``BasePlatformAdapter.extract_media`` /
+                # ``filter_media_delivery_paths`` (what cron and the
+                # send_message tool pass), a ``{"path": ...}`` dict, or a bare
+                # path string. Previously a tuple fell into the ``else`` branch
+                # whole and ``os.path.exists`` raised on it, dropping the file.
+                if isinstance(media, (tuple, list)):
+                    file_path = media[0] if media else None
+                elif isinstance(media, dict):
+                    file_path = media.get("path")
+                else:
+                    file_path = media
                 if not file_path or not os.path.exists(file_path):
                     continue
                 form = aiohttp.FormData()

--- a/plugins/platforms/mattermost/plugin.yaml
+++ b/plugins/platforms/mattermost/plugin.yaml
@@ -47,3 +47,7 @@ optional_env:
     description: "If set, the bot only responds in these channels (whitelist)."
     prompt: "Allowed channel IDs (comma-separated)"
     password: false
+  - name: MATTERMOST_REACTIONS
+    description: "Add 👀/✅/❌ progress reactions to messages the bot is handling (default true). Set false to disable."
+    prompt: "Progress reactions? (true/false)"
+    password: false

--- a/plugins/platforms/mattermost/plugin.yaml
+++ b/plugins/platforms/mattermost/plugin.yaml
@@ -47,7 +47,6 @@ optional_env:
     description: "If set, the bot only responds in these channels (whitelist)."
     prompt: "Allowed channel IDs (comma-separated)"
     password: false
-  - name: MATTERMOST_REACTIONS
-    description: "Add 👀/✅/❌ progress reactions to messages the bot is handling (default true). Set false to disable."
-    prompt: "Progress reactions? (true/false)"
-    password: false
+  # Progress reactions (👀/✅/❌) are a behavioral toggle set via config.yaml
+  # `mattermost.reactions` (bridged to the internal MATTERMOST_REACTIONS env
+  # var by _apply_yaml_config), not a .env setup prompt — per AGENTS.md.

--- a/tests/gateway/test_mattermost.py
+++ b/tests/gateway/test_mattermost.py
@@ -1381,6 +1381,31 @@ class TestMattermostDeleteAndReactions:
         ok = await self.adapter._remove_reaction("post_1", "thumbsup")
         assert ok is False
 
+    @pytest.mark.asyncio
+    async def test_api_delete_rejects_path_traversal(self):
+        """``_api_delete`` must reject any path containing ``..`` before issuing
+        the request — parity with the ``_api_get``/``_api_post``/``_api_put``
+        guard (d836b2bac). WebSocket-derived ids (post_id, emoji names) are
+        interpolated into this bearer-token-authenticated path, so a crafted
+        ``..`` payload could redirect the authed request to another endpoint."""
+        self.adapter._session = MagicMock()
+        self.adapter._session.delete = MagicMock()
+        # Exercise the real method (not the AsyncMock used elsewhere).
+        ok = await self.adapter._api_delete("posts/../../users/me")
+        assert ok is False
+        # The guard fires before any network call is made.
+        self.adapter._session.delete.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_remove_reaction_with_traversal_emoji_is_blocked(self):
+        """A traversal payload smuggled through the emoji name reaches
+        ``_api_delete`` and is rejected by the guard, not sent to the API."""
+        self.adapter._session = MagicMock()
+        self.adapter._session.delete = MagicMock()
+        ok = await self.adapter._remove_reaction("post_1", "../../../users/me")
+        assert ok is False
+        self.adapter._session.delete.assert_not_called()
+
 
 # ---------------------------------------------------------------------------
 # reaction lifecycle hooks are actually WIRED
@@ -1463,6 +1488,52 @@ class TestMattermostReactionHooks:
         from plugins.platforms.mattermost.adapter import MattermostAdapter
         assert MattermostAdapter.on_processing_start is not BasePlatformAdapter.on_processing_start
         assert MattermostAdapter.on_processing_complete is not BasePlatformAdapter.on_processing_complete
+
+
+# ---------------------------------------------------------------------------
+# reactions preference is YAML-backed (config.yaml `mattermost.reactions`)
+# ---------------------------------------------------------------------------
+
+class TestMattermostReactionsYamlBridge:
+    """The reactions toggle is a behavioral setting, so per AGENTS.md it lives in
+    ``config.yaml`` as ``mattermost.reactions`` and is bridged to the internal
+    ``MATTERMOST_REACTIONS`` env var by ``_apply_yaml_config`` — mirroring
+    ``mattermost.require_mention``. The env var is only the internal mechanism."""
+
+    def test_reactions_false_bridged_to_env(self, monkeypatch):
+        from plugins.platforms.mattermost.adapter import _apply_yaml_config
+        monkeypatch.delenv("MATTERMOST_REACTIONS", raising=False)
+        _apply_yaml_config({}, {"reactions": False})
+        assert os.environ["MATTERMOST_REACTIONS"] == "false"
+
+    def test_reactions_true_bridged_to_env(self, monkeypatch):
+        from plugins.platforms.mattermost.adapter import _apply_yaml_config
+        monkeypatch.delenv("MATTERMOST_REACTIONS", raising=False)
+        _apply_yaml_config({}, {"reactions": True})
+        assert os.environ["MATTERMOST_REACTIONS"] == "true"
+
+    def test_explicit_env_wins_over_yaml(self, monkeypatch):
+        """Env precedence — an explicit MATTERMOST_REACTIONS survives config.yaml,
+        matching every other ``mattermost.*`` bridge key."""
+        from plugins.platforms.mattermost.adapter import _apply_yaml_config
+        monkeypatch.setenv("MATTERMOST_REACTIONS", "false")
+        _apply_yaml_config({}, {"reactions": True})
+        assert os.environ["MATTERMOST_REACTIONS"] == "false"
+
+    def test_absent_key_leaves_env_untouched(self, monkeypatch):
+        from plugins.platforms.mattermost.adapter import _apply_yaml_config
+        monkeypatch.delenv("MATTERMOST_REACTIONS", raising=False)
+        _apply_yaml_config({}, {})
+        assert "MATTERMOST_REACTIONS" not in os.environ
+
+    def test_yaml_reactions_false_disables_via_reactions_enabled(self, monkeypatch):
+        """End-to-end: ``mattermost.reactions: false`` in config.yaml flows through
+        the bridge so ``_reactions_enabled()`` reports False."""
+        from plugins.platforms.mattermost.adapter import _apply_yaml_config
+        monkeypatch.delenv("MATTERMOST_REACTIONS", raising=False)
+        _apply_yaml_config({}, {"reactions": False})
+        adapter = _make_adapter()
+        assert adapter._reactions_enabled() is False
 
 
 # ---------------------------------------------------------------------------

--- a/tests/gateway/test_mattermost.py
+++ b/tests/gateway/test_mattermost.py
@@ -2,6 +2,7 @@
 import json
 import os
 import time
+from types import SimpleNamespace
 import pytest
 from unittest.mock import MagicMock, patch, AsyncMock
 
@@ -1084,3 +1085,436 @@ async def test_mattermost_dm_post_does_not_seed_thread_root():
     msg_event = adapter.handle_message.call_args[0][0]
     assert msg_event.source.thread_id is None
     assert msg_event.source.message_id == "dm_post_123"
+
+
+# ---------------------------------------------------------------------------
+# Channel discovery — _build_mattermost
+# ---------------------------------------------------------------------------
+
+class TestMattermostBuildChannelDirectory:
+    """``_build_mattermost`` enumerates the bot's team channels via the REST API
+    and the ``Platform.MATTERMOST`` branch of ``build_channel_directory`` uses
+    it (instead of falling through to session-only discovery)."""
+
+    def _adapter_with_api(self, api_responses):
+        """Build an adapter whose ``_api_get`` is an AsyncMock returning the
+        mapped payload for each path."""
+        adapter = _make_adapter()
+
+        async def _fake_api_get(path):
+            return api_responses.get(path, {})
+
+        adapter._api_get = AsyncMock(side_effect=_fake_api_get)
+        return adapter
+
+    @pytest.mark.asyncio
+    async def test_build_mattermost_lists_team_channels(self, tmp_path):
+        from gateway import channel_directory as cd
+
+        adapter = self._adapter_with_api({
+            "users/me/teams": [{"id": "team1", "name": "engineering"}],
+            "users/me/teams/team1/channels": [
+                {"id": "chan_pub", "name": "general", "display_name": "General", "type": "O"},
+                {"id": "chan_prv", "name": "secret", "display_name": "Secret", "type": "P"},
+                {"id": "chan_dm", "name": "dm1", "display_name": "", "type": "D"},
+            ],
+        })
+
+        with patch.object(cd, "_build_from_sessions", return_value=[]):
+            entries = await cd._build_mattermost(adapter)
+
+        by_id = {e["id"]: e for e in entries}
+        assert by_id["chan_pub"]["type"] == "channel"
+        assert by_id["chan_pub"]["name"] == "General"
+        # P (private channel) maps to "group" per _CHANNEL_TYPE_MAP.
+        assert by_id["chan_prv"]["type"] == "group"
+        assert by_id["chan_dm"]["type"] == "dm"
+
+    @pytest.mark.asyncio
+    async def test_build_mattermost_merges_session_dms_dedup(self, tmp_path):
+        from gateway import channel_directory as cd
+
+        adapter = self._adapter_with_api({
+            "users/me/teams": [{"id": "team1", "name": "eng"}],
+            "users/me/teams/team1/channels": [
+                {"id": "chan_pub", "name": "general", "display_name": "General", "type": "O"},
+            ],
+        })
+
+        session_entries = [
+            {"id": "chan_pub", "name": "dup", "type": "dm", "thread_id": None},  # dup by id
+            {"id": "dm_only", "name": "Alice", "type": "dm", "thread_id": None},
+        ]
+        with patch.object(cd, "_build_from_sessions", return_value=session_entries):
+            entries = await cd._build_mattermost(adapter)
+
+        ids = [e["id"] for e in entries]
+        assert ids.count("chan_pub") == 1  # deduped — API entry wins
+        assert "dm_only" in ids
+
+    @pytest.mark.asyncio
+    async def test_build_mattermost_handles_multiple_teams(self, tmp_path):
+        from gateway import channel_directory as cd
+
+        adapter = self._adapter_with_api({
+            "users/me/teams": [
+                {"id": "t1", "name": "a"},
+                {"id": "t2", "name": "b"},
+            ],
+            "users/me/teams/t1/channels": [
+                {"id": "c1", "name": "town", "display_name": "Town", "type": "O"},
+            ],
+            "users/me/teams/t2/channels": [
+                {"id": "c2", "name": "ops", "display_name": "Ops", "type": "O"},
+            ],
+        })
+        with patch.object(cd, "_build_from_sessions", return_value=[]):
+            entries = await cd._build_mattermost(adapter)
+        ids = {e["id"] for e in entries}
+        assert ids == {"c1", "c2"}
+
+    @pytest.mark.asyncio
+    async def test_build_channel_directory_uses_mattermost_branch(self, tmp_path):
+        """``build_channel_directory`` should route Platform.MATTERMOST through
+        ``_build_mattermost`` rather than the session-only fallback."""
+        from gateway import channel_directory as cd
+        from gateway.config import Platform
+
+        adapter = self._adapter_with_api({
+            "users/me/teams": [{"id": "team1", "name": "eng"}],
+            "users/me/teams/team1/channels": [
+                {"id": "chan_pub", "name": "general", "display_name": "General", "type": "O"},
+            ],
+        })
+
+        with patch.object(cd, "DIRECTORY_PATH", tmp_path / "dir.json"), \
+             patch.object(cd, "_build_from_sessions", return_value=[]):
+            directory = await cd.build_channel_directory({Platform.MATTERMOST: adapter})
+
+        mm = directory["platforms"]["mattermost"]
+        assert any(e["id"] == "chan_pub" for e in mm)
+
+    @pytest.mark.asyncio
+    async def test_teams_fetch_error_returns_empty(self, tmp_path):
+        """If the ``users/me/teams`` fetch raises, discovery degrades to the
+        (empty) session list rather than propagating the error."""
+        from gateway import channel_directory as cd
+
+        adapter = _make_adapter()
+        adapter._api_get = AsyncMock(side_effect=RuntimeError("boom"))
+
+        with patch.object(cd, "_build_from_sessions", return_value=[]):
+            entries = await cd._build_mattermost(adapter)
+        assert entries == []
+
+    @pytest.mark.asyncio
+    async def test_per_team_channel_error_continues(self, tmp_path):
+        """A failing per-team channels fetch is skipped; other teams still
+        contribute their channels."""
+        from gateway import channel_directory as cd
+
+        async def _fake_api_get(path):
+            if path == "users/me/teams":
+                return [{"id": "t1", "name": "a"}, {"id": "t2", "name": "b"}]
+            if path == "users/me/teams/t1/channels":
+                raise RuntimeError("team1 channels down")
+            if path == "users/me/teams/t2/channels":
+                return [{"id": "c2", "name": "ops", "display_name": "Ops", "type": "O"}]
+            return {}
+
+        adapter = _make_adapter()
+        adapter._api_get = AsyncMock(side_effect=_fake_api_get)
+
+        with patch.object(cd, "_build_from_sessions", return_value=[]):
+            entries = await cd._build_mattermost(adapter)
+        ids = {e["id"] for e in entries}
+        assert ids == {"c2"}  # t1 skipped, t2 survived
+
+    @pytest.mark.asyncio
+    async def test_no_api_get_falls_back_to_sessions(self, tmp_path):
+        """When the adapter has no ``_api_get`` (e.g. not connected), discovery
+        falls back to the session-derived list."""
+        from gateway import channel_directory as cd
+
+        adapter = _make_adapter()
+        # Remove the bound method so getattr(adapter, "_api_get", None) is None.
+        adapter._api_get = None
+
+        with patch.object(
+            cd, "_build_from_sessions",
+            return_value=[{"id": "dm1", "name": "Alice", "type": "dm"}],
+        ):
+            entries = await cd._build_mattermost(adapter)
+        assert [e["id"] for e in entries] == ["dm1"]
+
+
+# ---------------------------------------------------------------------------
+# Target-ref parsing
+# ---------------------------------------------------------------------------
+
+class TestMattermostParseTargetRef:
+    """``_parse_target_ref('mattermost', ...)`` resolves raw 26-char IDs and
+    the optional ``:<thread_root>`` suffix, without colliding with Slack
+    (uppercase) IDs."""
+
+    def test_raw_channel_id(self):
+        from tools.send_message_tool import _parse_target_ref
+        chat_id, thread_id, is_explicit = _parse_target_ref(
+            "mattermost", "abcdefghijklmnopqrstuvwxyz"
+        )
+        assert chat_id == "abcdefghijklmnopqrstuvwxyz"
+        assert thread_id is None
+        assert is_explicit is True
+
+    def test_channel_id_with_thread_root(self):
+        from tools.send_message_tool import _parse_target_ref
+        chan = "abcdefghijklmnopqrstuvwxyz"
+        root = "0123456789abcdefghijklmnop"
+        chat_id, thread_id, is_explicit = _parse_target_ref(
+            "mattermost", f"{chan}:{root}"
+        )
+        assert chat_id == chan
+        assert thread_id == root
+        assert is_explicit is True
+
+    def test_surrounding_whitespace_tolerated(self):
+        from tools.send_message_tool import _parse_target_ref
+        chat_id, _, is_explicit = _parse_target_ref(
+            "mattermost", "  abcdefghijklmnopqrstuvwxyz  "
+        )
+        assert chat_id == "abcdefghijklmnopqrstuvwxyz"
+        assert is_explicit is True
+
+    def test_channel_name_is_not_explicit(self):
+        """A human-friendly name (not a 26-char id) falls through to name
+        resolution, so it is NOT explicit here."""
+        from tools.send_message_tool import _parse_target_ref
+        _, _, is_explicit = _parse_target_ref("mattermost", "general")
+        assert is_explicit is False
+
+    def test_wrong_length_id_is_not_explicit(self):
+        from tools.send_message_tool import _parse_target_ref
+        # 25 chars and 27 chars both fail the exact-26 rule.
+        assert _parse_target_ref("mattermost", "a" * 25)[2] is False
+        assert _parse_target_ref("mattermost", "a" * 27)[2] is False
+
+    def test_no_collision_with_slack_uppercase_ids(self):
+        """A Slack id (uppercase) must NOT be parsed as a Mattermost id."""
+        from tools.send_message_tool import _parse_target_ref
+        # Slack ids are uppercase [CGDU]... — uppercase fails the lowercase
+        # MM regex, so MM does not claim it.
+        _, _, is_explicit = _parse_target_ref("mattermost", "C0B0QV5434G")
+        assert is_explicit is False
+        # And the Slack platform still resolves its own id.
+        assert _parse_target_ref("slack", "C0B0QV5434G")[2] is True
+
+
+# ---------------------------------------------------------------------------
+# delete + reactions
+# ---------------------------------------------------------------------------
+
+class TestMattermostDeleteAndReactions:
+    def setup_method(self):
+        self.adapter = _make_adapter()
+        self.adapter._bot_user_id = "bot_user"
+
+    @pytest.mark.asyncio
+    async def test_delete_message_success(self):
+        self.adapter._api_delete = AsyncMock(return_value=True)
+        ok = await self.adapter.delete_message("chan_1", "post_1")
+        assert ok is True
+        self.adapter._api_delete.assert_awaited_once()
+        assert "posts/post_1" in self.adapter._api_delete.await_args[0][0]
+
+    @pytest.mark.asyncio
+    async def test_delete_message_failure(self):
+        self.adapter._api_delete = AsyncMock(return_value=False)
+        ok = await self.adapter.delete_message("chan_1", "post_1")
+        assert ok is False
+
+    @pytest.mark.asyncio
+    async def test_delete_message_empty_id(self):
+        self.adapter._api_delete = AsyncMock(return_value=True)
+        ok = await self.adapter.delete_message("chan_1", "")
+        assert ok is False
+        self.adapter._api_delete.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_add_reaction_success(self):
+        self.adapter._api_post = AsyncMock(return_value={"emoji_name": "thumbsup"})
+        ok = await self.adapter._add_reaction("post_1", "thumbsup")
+        assert ok is True
+        path = self.adapter._api_post.await_args[0][0]
+        payload = self.adapter._api_post.await_args[0][1]
+        assert path == "reactions"
+        assert payload == {
+            "user_id": "bot_user",
+            "post_id": "post_1",
+            "emoji_name": "thumbsup",
+        }
+
+    @pytest.mark.asyncio
+    async def test_add_reaction_strips_colons(self):
+        """Slack-style ``:emoji:`` input is normalized to a bare name."""
+        self.adapter._api_post = AsyncMock(return_value={"emoji_name": "tada"})
+        ok = await self.adapter._add_reaction("post_1", ":tada:")
+        assert ok is True
+        assert self.adapter._api_post.await_args[0][1]["emoji_name"] == "tada"
+
+    @pytest.mark.asyncio
+    async def test_add_reaction_failure(self):
+        self.adapter._api_post = AsyncMock(return_value={})
+        ok = await self.adapter._add_reaction("post_1", "thumbsup")
+        assert ok is False
+
+    @pytest.mark.asyncio
+    async def test_remove_reaction_success(self):
+        self.adapter._api_delete = AsyncMock(return_value=True)
+        ok = await self.adapter._remove_reaction("post_1", ":thumbsup:")
+        assert ok is True
+        path = self.adapter._api_delete.await_args[0][0]
+        assert path == "users/bot_user/posts/post_1/reactions/thumbsup"
+
+    @pytest.mark.asyncio
+    async def test_remove_reaction_failure(self):
+        self.adapter._api_delete = AsyncMock(return_value=False)
+        ok = await self.adapter._remove_reaction("post_1", "thumbsup")
+        assert ok is False
+
+
+# ---------------------------------------------------------------------------
+# reaction lifecycle hooks are actually WIRED
+# ---------------------------------------------------------------------------
+
+class TestMattermostReactionHooks:
+    """``on_processing_start`` / ``on_processing_complete`` must be overridden on
+    the MM adapter (the base class no-ops), env-gated by ``MATTERMOST_REACTIONS``,
+    and only fire for posts registered in ``_reacting_message_ids``."""
+
+    def setup_method(self):
+        self.adapter = _make_adapter()
+        self.adapter._bot_user_id = "bot_user"
+        self.adapter._api_post = AsyncMock(return_value={"emoji_name": "eyes"})
+        self.adapter._api_delete = AsyncMock(return_value=True)
+
+    def _event(self, message_id):
+        return SimpleNamespace(message_id=message_id, source=SimpleNamespace(chat_id="chan_1"))
+
+    @pytest.mark.asyncio
+    async def test_on_processing_start_adds_reaction(self, monkeypatch):
+        """The hook is wired: a registered post gets an 👀 add-reaction via the
+        REST API (``_api_post`` to ``reactions``)."""
+        monkeypatch.setenv("MATTERMOST_REACTIONS", "true")
+        self.adapter._reacting_message_ids.add("post_1")
+
+        await self.adapter.on_processing_start(self._event("post_1"))
+
+        self.adapter._api_post.assert_awaited_once()
+        path = self.adapter._api_post.await_args.args[0]
+        payload = self.adapter._api_post.await_args.args[1]
+        assert path == "reactions"
+        assert payload["post_id"] == "post_1"
+        assert payload["emoji_name"] == "eyes"
+
+    @pytest.mark.asyncio
+    async def test_on_processing_start_skips_unregistered_post(self, monkeypatch):
+        monkeypatch.setenv("MATTERMOST_REACTIONS", "true")
+        # post_1 NOT registered.
+        await self.adapter.on_processing_start(self._event("post_1"))
+        self.adapter._api_post.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_reactions_disabled_by_env_gate(self, monkeypatch):
+        monkeypatch.setenv("MATTERMOST_REACTIONS", "false")
+        self.adapter._reacting_message_ids.add("post_1")
+        await self.adapter.on_processing_start(self._event("post_1"))
+        self.adapter._api_post.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_on_processing_complete_success_swaps_to_checkmark(self, monkeypatch):
+        from gateway.platforms.base import ProcessingOutcome
+        monkeypatch.setenv("MATTERMOST_REACTIONS", "true")
+        self.adapter._reacting_message_ids.add("post_1")
+
+        await self.adapter.on_processing_complete(
+            self._event("post_1"), ProcessingOutcome.SUCCESS
+        )
+
+        # 👀 removed, ✅ added; the post is no longer tracked.
+        self.adapter._api_delete.assert_awaited_once()
+        assert self.adapter._api_post.await_args.args[1]["emoji_name"] == "white_check_mark"
+        assert "post_1" not in self.adapter._reacting_message_ids
+
+    @pytest.mark.asyncio
+    async def test_on_processing_complete_failure_adds_x(self, monkeypatch):
+        from gateway.platforms.base import ProcessingOutcome
+        monkeypatch.setenv("MATTERMOST_REACTIONS", "true")
+        self.adapter._reacting_message_ids.add("post_1")
+
+        await self.adapter.on_processing_complete(
+            self._event("post_1"), ProcessingOutcome.FAILURE
+        )
+        assert self.adapter._api_post.await_args.args[1]["emoji_name"] == "x"
+
+    def test_hooks_are_overridden_not_base_noop(self):
+        """Guard against the dead-code regression: the MM adapter must NOT inherit
+        the base no-op hooks."""
+        from gateway.platforms.base import BasePlatformAdapter
+        from plugins.platforms.mattermost.adapter import MattermostAdapter
+        assert MattermostAdapter.on_processing_start is not BasePlatformAdapter.on_processing_start
+        assert MattermostAdapter.on_processing_complete is not BasePlatformAdapter.on_processing_complete
+
+
+# ---------------------------------------------------------------------------
+# Standalone sender — canonical (path, is_voice) tuple support
+# ---------------------------------------------------------------------------
+
+class TestMattermostStandaloneSenderTuple:
+    """The MM standalone (out-of-process / cron) sender must accept the
+    canonical ``(path, is_voice)`` tuple and upload it, rather than passing the
+    tuple whole into ``os.path.exists`` (which raises and silently drops it)."""
+
+    @pytest.mark.asyncio
+    async def test_standalone_sender_accepts_canonical_tuple(self, tmp_path):
+        from plugins.platforms.mattermost.adapter import _standalone_send
+
+        f = tmp_path / "pic.png"
+        f.write_bytes(b"\x89PNG fake")
+        pconfig = SimpleNamespace(token="tok", extra={"url": "https://mm.example.com"})
+
+        upload_resp = AsyncMock()
+        upload_resp.status = 201
+        upload_resp.json = AsyncMock(return_value={"file_infos": [{"id": "fid1"}]})
+        upload_resp.text = AsyncMock(return_value="")
+        upload_resp.__aenter__ = AsyncMock(return_value=upload_resp)
+        upload_resp.__aexit__ = AsyncMock(return_value=False)
+
+        post_resp = AsyncMock()
+        post_resp.status = 201
+        post_resp.json = AsyncMock(return_value={"id": "post_xyz"})
+        post_resp.text = AsyncMock(return_value="")
+        post_resp.__aenter__ = AsyncMock(return_value=post_resp)
+        post_resp.__aexit__ = AsyncMock(return_value=False)
+
+        posts = []
+
+        def _fake_post(url, **kwargs):
+            posts.append((url, kwargs))
+            return upload_resp if url.endswith("/files") else post_resp
+
+        session = MagicMock()
+        session.post = MagicMock(side_effect=_fake_post)
+        session.__aenter__ = AsyncMock(return_value=session)
+        session.__aexit__ = AsyncMock(return_value=False)
+
+        with patch("aiohttp.ClientSession", return_value=session):
+            result = await _standalone_send(
+                pconfig, "chan_1", "hi", media_files=[(str(f), False)],
+            )
+
+        assert result.get("success") is True
+        # The upload endpoint was hit (tuple was NOT dropped) ...
+        assert any(u.endswith("/files") for u, _ in posts)
+        # ... and the final post carried the uploaded file_id.
+        final = next(kw["json"] for u, kw in posts if u.endswith("/posts"))
+        assert final["file_ids"] == ["fid1"]

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -29,6 +29,12 @@ _FEISHU_TARGET_RE = re.compile(r"^\s*((?:oc|ou|on|chat|open)_[-A-Za-z0-9]+)(?::(
 _SLACK_TARGET_RE = re.compile(r"^\s*([CGDU][A-Z0-9]{8,})\s*$")
 # Session-derived Slack thread targets use "<conversation_id>:<thread_ts>".
 _SLACK_THREAD_TARGET_RE = re.compile(r"^\s*([CGD][A-Z0-9]{8,}):([^\s:]+)\s*$")
+# Mattermost IDs are 26-char lowercase base32 (a-z0-9). The optional second
+# group is a thread-root target: "mattermost:<channel_id>:<root_post_id>".
+# Constrained to lowercase so it can NOT collide with Slack conversation IDs,
+# which are uppercase ([CGDU][A-Z0-9]...). Without this gate a raw MM channel
+# id falls through to name resolution and fails with "Could not resolve".
+_MATTERMOST_TARGET_RE = re.compile(r"^\s*([a-z0-9]{26})(?::([a-z0-9]{26}))?\s*$")
 _WEIXIN_TARGET_RE = re.compile(r"^\s*((?:wxid|gh|v\d+|wm|wb)_[A-Za-z0-9_-]+|[A-Za-z0-9._-]+@chatroom|filehelper)\s*$")
 _YUANBAO_TARGET_RE = re.compile(r"^\s*((?:group|direct):[^:]+)\s*$")
 # Discord snowflake IDs are numeric, same regex pattern as Telegram topic targets.
@@ -563,6 +569,11 @@ def _parse_target_ref(platform_name: str, target_ref: str):
             # resolution path in send_message() can run.
             is_explicit = chat_id[0] not in {"U", "W"}
             return chat_id, None, is_explicit
+    if platform_name == "mattermost":
+        match = _MATTERMOST_TARGET_RE.fullmatch(target_ref)
+        if match:
+            # group(1) = channel id, group(2) = optional thread-root post id.
+            return match.group(1), match.group(2), True
     if platform_name == "matrix":
         trimmed = target_ref.strip()
         split_idx = trimmed.rfind(":$")

--- a/website/docs/reference/environment-variables.md
+++ b/website/docs/reference/environment-variables.md
@@ -436,7 +436,6 @@ For cloud sandbox backends, persistence is filesystem-oriented. `TERMINAL_LIFETI
 | `MATTERMOST_REQUIRE_MENTION` | Require `@mention` in channels (default: `true`). Set to `false` to respond to all messages. |
 | `MATTERMOST_FREE_RESPONSE_CHANNELS` | Comma-separated channel IDs where bot responds without `@mention` |
 | `MATTERMOST_REPLY_MODE` | Reply style: `thread` (threaded replies) or `off` (flat messages, default) |
-| `MATTERMOST_REACTIONS` | Add 👀/✅/❌ progress reactions to messages the bot is handling (default: `true`). Set to `false` to disable. |
 | `MATRIX_HOMESERVER` | Matrix homeserver URL (e.g. `https://matrix.org`) |
 | `MATRIX_ACCESS_TOKEN` | Matrix access token for bot authentication |
 | `MATRIX_USER_ID` | Matrix user ID (e.g. `@hermes:matrix.org`) — required for password login, optional with access token |

--- a/website/docs/reference/environment-variables.md
+++ b/website/docs/reference/environment-variables.md
@@ -436,6 +436,7 @@ For cloud sandbox backends, persistence is filesystem-oriented. `TERMINAL_LIFETI
 | `MATTERMOST_REQUIRE_MENTION` | Require `@mention` in channels (default: `true`). Set to `false` to respond to all messages. |
 | `MATTERMOST_FREE_RESPONSE_CHANNELS` | Comma-separated channel IDs where bot responds without `@mention` |
 | `MATTERMOST_REPLY_MODE` | Reply style: `thread` (threaded replies) or `off` (flat messages, default) |
+| `MATTERMOST_REACTIONS` | Add 👀/✅/❌ progress reactions to messages the bot is handling (default: `true`). Set to `false` to disable. |
 | `MATRIX_HOMESERVER` | Matrix homeserver URL (e.g. `https://matrix.org`) |
 | `MATRIX_ACCESS_TOKEN` | Matrix access token for bot authentication |
 | `MATRIX_USER_ID` | Matrix user ID (e.g. `@hermes:matrix.org`) — required for password login, optional with access token |

--- a/website/docs/user-guide/messaging/mattermost.md
+++ b/website/docs/user-guide/messaging/mattermost.md
@@ -212,6 +212,27 @@ Set it in your `~/.hermes/.env`:
 MATTERMOST_REPLY_MODE=thread
 ```
 
+## Sending messages, discovery, and targeting
+
+The `send_message` tool can post to Mattermost channels proactively (not just
+reply to the triggering message):
+
+- **Discovery** — `send_message(action="list")` enumerates the channels the bot
+  is a member of (public, private, and DMs), discovered via the Mattermost REST
+  API (`users/me/teams` → `users/me/teams/{team}/channels`). These targets are
+  cached in the channel directory and refreshed periodically.
+- **Targeting** — a target can be a human-friendly **channel name** (resolved
+  from the directory) **or** a raw **26-character channel ID**
+  (e.g. `mattermost:abcdefghijklmnopqrstuvwxyz`). To post into a specific
+  thread, append the thread-root post ID:
+  `mattermost:<channel_id>:<root_post_id>`.
+
+Hermes can also **delete** its own posts (e.g. to clean up streaming preview
+posts). When `MATTERMOST_REACTIONS` is enabled (the default), Hermes annotates
+messages it is directly handling (DMs and `@mentions`) with **emoji reactions**:
+👀 while it is working, then ✅ on success or ❌ on failure. Set
+`MATTERMOST_REACTIONS=false` to turn the progress reactions off.
+
 ## Mention Behavior
 
 By default, the bot only responds in channels when `@mentioned`. You can change this:

--- a/website/docs/user-guide/messaging/mattermost.md
+++ b/website/docs/user-guide/messaging/mattermost.md
@@ -228,10 +228,16 @@ reply to the triggering message):
   `mattermost:<channel_id>:<root_post_id>`.
 
 Hermes can also **delete** its own posts (e.g. to clean up streaming preview
-posts). When `MATTERMOST_REACTIONS` is enabled (the default), Hermes annotates
-messages it is directly handling (DMs and `@mentions`) with **emoji reactions**:
-👀 while it is working, then ✅ on success or ❌ on failure. Set
-`MATTERMOST_REACTIONS=false` to turn the progress reactions off.
+posts). By default Hermes also annotates messages it is directly handling (DMs
+and `@mentions`) with **emoji reactions**: 👀 while it is working, then ✅ on
+success or ❌ on failure. This is a behavioral toggle, so it lives in
+`config.yaml` (bridged to an internal env var like the other `mattermost.*`
+settings):
+
+```yaml
+mattermost:
+  reactions: false   # turn off the 👀/✅/❌ progress reactions (default: true)
+```
 
 ## Mention Behavior
 


### PR DESCRIPTION
## Problem
The Mattermost adapter lagged the Slack/Discord reference adapters in three ways:

- **No channel discovery.** `build_channel_directory()` had no `Platform.MATTERMOST`
  branch, so Mattermost fell through to session-only discovery. The bot could not
  enumerate the channels it is a member of, so `send_message(action="list")` returned
  only chats that had already produced session traffic.
- **No raw-ID targeting.** A raw 26-char Mattermost channel id passed to `send_message`
  fell through to name resolution and failed with "Could not resolve".
- **No delete / no progress reactions.** The adapter inherited the base `delete_message`
  (always `False`) and the base no-op `on_processing_start` / `on_processing_complete`,
  so it could neither clean up its own preview posts nor acknowledge messages.

There was also a latent bug in the out-of-process sender (`_standalone_send`): it did
`media.get("path") if isinstance(media, dict) else media`, so the canonical
`(path, is_voice)` tuple that cron/the send tool pass was handed whole to
`os.path.exists` → `TypeError` → the attachment was silently dropped.

## Change
- **Discovery** — add `_build_mattermost(adapter)` (modeled on `_build_slack`): walk
  `users/me/teams` → `users/me/teams/{id}/channels` via the adapter's `_api_get`, map
  channel type codes (O/P/D/G) through `_CHANNEL_TYPE_MAP`, merge session DMs deduped by
  id (API entry wins). Wire the `Platform.MATTERMOST` branch into `build_channel_directory`.
- **Targeting** — add a `mattermost` branch to `_parse_target_ref` with
  `_MATTERMOST_TARGET_RE` (`[a-z0-9]{26}` + optional `:<thread_root>`). Lowercase-only so
  it cannot collide with Slack's uppercase `[CGDU]…` ids. `mattermost:<channel_id>` and
  `mattermost:<channel_id>:<root_post_id>` both resolve.
- **delete + reactions** — override `delete_message` (`DELETE /api/v4/posts/{id}`); add
  `_add_reaction` / `_remove_reaction` (`POST` / `DELETE /api/v4/reactions`) and an
  `_api_delete` helper, modeled on the Slack adapter. Override `on_processing_start` /
  `on_processing_complete`, gated by a new `MATTERMOST_REACTIONS` env var (parallel to
  Slack's `SLACK_REACTIONS`), reacting only to posts where the bot was directly addressed
  (DM/@mention): 👀 on start, ✅/❌ on completion.
- **Standalone tuple fix** — `_standalone_send` now accepts the canonical
  `(path, is_voice)` tuple, a `{"path": …}` dict, or a bare path string.
- Docs (`mattermost.md`, `environment-variables.md`), the gateway setup prompt, and
  `plugin.yaml` updated for `MATTERMOST_REACTIONS` and the discovery/targeting behavior.

## Testing
`python -m pytest tests/gateway/test_mattermost.py` → **86 passed** (28 new), covering:
channel-directory build + multi-team + dedup + per-team/teams error paths + no-`_api_get`
fallback; target-ref parsing incl. the Slack-uppercase no-collision case; delete success/
failure/empty-id; add/remove reaction incl. `:emoji:` normalization; reaction lifecycle
hooks env-gated + wired (guard against re-inheriting the base no-op); tuple-safe standalone
sender. Regression: `test_send_message_tool.py`, `test_channel_directory.py`,
`test_send_message_target_parse.py`, `test_send_message_react.py` all pass.

## Generic, not vendor-specific
No deployment-specific values — all behavior is driven by the standard Mattermost REST API
and the existing `MATTERMOST_*` env convention. `_build_mattermost` mirrors `_build_slack`;
the reactions mirror the Slack adapter's `SLACK_REACTIONS`.

> Note for reviewers: this PR makes the proactive channel-send path reachable for the first
> time (the bot can now enumerate and target channels it belongs to). A separate PR
> (`fix(gateway): marshal send_message tool sends onto the adapter loop; deliver media
> in-process`) fixes a platform-agnostic gateway loop-context bug that this newly-reachable
> path exposes — recommend landing both.
