### PR TITLE
fix(gateway): marshal send_message tool sends onto the adapter loop; deliver media in-process

### DIFF
--- a/tests/tools/test_send_via_adapter_media_and_loop.py
+++ b/tests/tools/test_send_via_adapter_media_and_loop.py
@@ -1,0 +1,428 @@
+"""Tests for the platform-agnostic gateway-send fixes in
+``tools.send_message_tool``:
+
+1. In-process media routing — ``_send_via_adapter`` must actually deliver media
+   through the live adapter's typed media methods (not silently drop it), with a
+   capability gate so non-overriding plugins never post a base placeholder.
+2. Cross-loop send marshaling — ``_await_on_adapter_loop`` must run the send on
+   the adapter's own (gateway) loop, fixing the production ``RuntimeError:
+   Timeout context manager should be used inside a task``.
+
+These use the real ``MattermostAdapter`` only as a convenient *concrete*
+file-capable adapter (it overrides the typed media methods); the code under
+test is platform-agnostic.
+"""
+import asyncio
+import threading
+from types import SimpleNamespace
+
+import pytest
+from unittest.mock import AsyncMock, patch
+
+from gateway.config import Platform, PlatformConfig
+from gateway.platforms.base import SendResult
+
+
+def _make_adapter():
+    """A real MattermostAdapter (concrete file-capable adapter) with mocked config."""
+    from plugins.platforms.mattermost.adapter import MattermostAdapter
+    config = PlatformConfig(
+        enabled=True,
+        token="test-token",
+        extra={"url": "https://mm.example.com"},
+    )
+    return MattermostAdapter(config)
+
+
+# ---------------------------------------------------------------------------
+# In-process media propagation through the live adapter path
+# ---------------------------------------------------------------------------
+
+class TestSendViaAdapterMediaPropagation:
+    """``_send_via_adapter``'s live in-process path must ACTUALLY deliver media,
+    not silently drop it. When a live adapter is present and media is present it
+    routes each canonical ``(path, is_voice)`` tuple through the adapter's typed
+    media methods (the same path ``cron.scheduler._send_media_via_adapter``
+    uses); text-only sends keep using the live ``adapter.send`` fast path."""
+
+    def _patch_runner(self, adapter):
+        """Patch gateway.run._gateway_runner_ref to return a runner exposing
+        ``adapters`` containing the given adapter for Platform.MATTERMOST."""
+        runner = SimpleNamespace(adapters={Platform.MATTERMOST: adapter})
+        import gateway.run as grun
+        return patch.object(grun, "_gateway_runner_ref", lambda: runner)
+
+    @pytest.mark.asyncio
+    async def test_media_actually_uploads_via_real_adapter(self, tmp_path):
+        """Drive the REAL MattermostAdapter delivery path with a canonical
+        ``[(path, False)]`` tuple, mocking only the network primitives
+        (``_upload_file`` / ``_api_post``). An upload MUST actually be
+        attempted — this is the empirical proof the tuple is not dropped."""
+        from tools.send_message_tool import _send_via_adapter
+
+        img = tmp_path / "pic.png"
+        img.write_bytes(b"\x89PNG\r\n\x1a\nfake")
+
+        adapter = _make_adapter()
+        adapter._upload_file = AsyncMock(return_value="file_id_1")
+        adapter._api_post = AsyncMock(return_value={"id": "post_1"})
+        adapter.send = AsyncMock(return_value=SendResult(success=True, message_id="text_post"))
+
+        pconfig = SimpleNamespace(token="tok", extra={"url": "https://mm.example.com"})
+        media = [(str(img), False)]
+
+        with self._patch_runner(adapter):
+            result = await _send_via_adapter(
+                Platform.MATTERMOST, pconfig, "chan_1", "see attached",
+                media_files=media,
+            )
+
+        assert result.get("success") is True
+        adapter._upload_file.assert_awaited_once()
+        up_args = adapter._upload_file.await_args
+        assert up_args.args[0] == "chan_1"  # channel_id
+        adapter._api_post.assert_awaited_once()
+        post_payload = adapter._api_post.await_args.args[1]
+        assert post_payload["channel_id"] == "chan_1"
+        assert post_payload["file_ids"] == ["file_id_1"]
+
+    @pytest.mark.asyncio
+    async def test_media_routes_to_document_for_non_image(self, tmp_path):
+        """A non-image file routes through ``send_document`` → ``_upload_file``
+        (still a real upload, proving extension-based dispatch works)."""
+        from tools.send_message_tool import _send_via_adapter
+
+        doc = tmp_path / "report.pdf"
+        doc.write_bytes(b"%PDF-1.4 fake")
+
+        adapter = _make_adapter()
+        adapter._upload_file = AsyncMock(return_value="file_pdf")
+        adapter._api_post = AsyncMock(return_value={"id": "post_pdf"})
+        adapter.send = AsyncMock(return_value=SendResult(success=True, message_id="t"))
+
+        pconfig = SimpleNamespace(token="tok", extra={"url": "https://mm.example.com"})
+
+        with self._patch_runner(adapter):
+            result = await _send_via_adapter(
+                Platform.MATTERMOST, pconfig, "chan_1", "doc", media_files=[(str(doc), False)],
+            )
+
+        assert result.get("success") is True
+        adapter._upload_file.assert_awaited_once()
+        assert adapter._api_post.await_args.args[1]["file_ids"] == ["file_pdf"]
+
+    @pytest.mark.asyncio
+    async def test_text_only_still_uses_live_adapter(self):
+        """Byte-identical text-only hot path: no media → live adapter.send,
+        and the media-dispatch helper is never touched."""
+        from tools.send_message_tool import _send_via_adapter
+
+        live_result = SimpleNamespace(success=True, message_id="live1", error=None)
+        live_adapter = SimpleNamespace(
+            send=AsyncMock(return_value=live_result),
+            send_image_file=AsyncMock(),
+            send_document=AsyncMock(),
+            send_voice=AsyncMock(),
+            send_video=AsyncMock(),
+        )
+
+        with self._patch_runner(live_adapter):
+            result = await _send_via_adapter(
+                Platform.MATTERMOST, SimpleNamespace(token="tok", extra={}),
+                "chan_1", "hello", media_files=None,
+            )
+
+        assert result.get("success") is True
+        assert result.get("message_id") == "live1"
+        live_adapter.send.assert_awaited_once()
+        live_adapter.send_image_file.assert_not_called()
+        live_adapter.send_document.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_non_overriding_adapter_does_not_post_placeholder(self, tmp_path):
+        """A file-capable plugin adapter that does NOT override the base media
+        methods (e.g. irc / ntfy / simplex) must NOT have media routed to the
+        BASE placeholder method on the in-process path.
+
+        The base ``send_image_file`` / ``send_document`` post a text placeholder
+        like ``📎 File: <local-path>`` via ``self.send`` — leaking a local
+        filesystem path into the channel. The capability gate must skip such
+        adapters entirely on this path, preserving the prior behavior."""
+        from gateway.platforms.base import BasePlatformAdapter
+        from tools.send_message_tool import _deliver_media_via_live_adapter
+
+        class _NonOverridingAdapter(BasePlatformAdapter):
+            def __init__(self):
+                self.platform = Platform.MATTERMOST
+                # Spy on the placeholder sink: the base media methods call
+                # self.send(...). It must never be invoked here.
+                self.send_calls = []
+
+            async def connect(self):
+                return True
+
+            async def disconnect(self):
+                return None
+
+            async def send(self, *args, **kwargs):
+                self.send_calls.append((args, kwargs))
+                return SimpleNamespace(success=True, message_id="x")
+
+            async def get_chat_info(self, chat_id):
+                return {}
+
+        adapter = _NonOverridingAdapter()
+
+        img = tmp_path / "pic.png"
+        img.write_bytes(b"\x89PNG\r\n\x1a\nfake")
+        doc = tmp_path / "report.pdf"
+        doc.write_bytes(b"%PDF-1.4 fake")
+
+        result = await _deliver_media_via_live_adapter(
+            adapter, Platform.MATTERMOST, "chan_1",
+            [(str(img), False), (str(doc), False)],
+        )
+
+        assert not (isinstance(result, dict) and result.get("error"))
+        assert adapter.send_calls == []
+
+    @pytest.mark.asyncio
+    async def test_overriding_adapter_still_delivers_media(self, tmp_path):
+        """The capability gate must NOT regress a genuinely file-capable adapter:
+        the real MattermostAdapter (which overrides the media methods) still
+        uploads its media via the in-process dispatch path."""
+        from tools.send_message_tool import _deliver_media_via_live_adapter
+
+        img = tmp_path / "pic.png"
+        img.write_bytes(b"\x89PNG\r\n\x1a\nfake")
+
+        adapter = _make_adapter()
+        adapter._upload_file = AsyncMock(return_value="file_id_1")
+        adapter._api_post = AsyncMock(return_value={"id": "post_1"})
+
+        result = await _deliver_media_via_live_adapter(
+            adapter, Platform.MATTERMOST, "chan_1", [(str(img), False)],
+        )
+
+        assert not (isinstance(result, dict) and result.get("error"))
+        adapter._upload_file.assert_awaited_once()
+        assert adapter._api_post.await_args.args[1]["file_ids"] == ["file_id_1"]
+
+    @pytest.mark.asyncio
+    async def test_media_falls_back_to_standalone_when_no_runner(self, tmp_path):
+        """With no live runner, media still flows through the standalone
+        sender carrying the canonical tuple unchanged (the out-of-process
+        cron path)."""
+        from tools.send_message_tool import _send_via_adapter
+
+        standalone = AsyncMock(return_value={"success": True, "message_id": "p3"})
+        entry = SimpleNamespace(standalone_sender_fn=standalone, max_message_length=4000)
+        pconfig = SimpleNamespace(token="tok", extra={})
+        media = [("/tmp/doc.pdf", False)]
+
+        import gateway.run as grun
+        with patch.object(grun, "_gateway_runner_ref", lambda: None), \
+             patch("gateway.platform_registry.platform_registry.get", return_value=entry):
+            result = await _send_via_adapter(
+                Platform.MATTERMOST, pconfig, "chan_1", "doc", media_files=media,
+            )
+
+        assert result.get("success") is True
+        standalone.assert_awaited_once()
+        assert standalone.await_args.kwargs.get("media_files") == media
+
+
+# ---------------------------------------------------------------------------
+# Cross-loop send dispatch — _await_on_adapter_loop marshaling
+# ---------------------------------------------------------------------------
+
+class TestSendViaAdapterLoopContext:
+    """Regression for the live failure ``Timeout context manager should be used
+    inside a task``.
+
+    A live adapter's aiohttp ``ClientSession`` is created on, and bound to, the
+    gateway event loop. The ``send_message`` tool, however, runs each send via
+    ``model_tools._run_async`` which — when already inside the gateway loop —
+    spins up a *fresh worker loop on a separate thread* and drives the send
+    coroutine there. A plain ``await adapter.send(...)`` then enters the
+    gateway-loop-bound session's timeout context manager while running on the
+    worker loop, where ``asyncio.current_task()`` of the session's loop is
+    ``None`` → aiohttp raises ``RuntimeError: Timeout context manager should be
+    used inside a task``.
+
+    These tests stand up a real second ('gateway') loop on its own thread,
+    create a real ``aiohttp.ClientSession`` bound to it, and drive the REAL
+    ``_send_via_adapter`` dispatch from a different worker loop — exactly the
+    production topology. They do NOT mock the async/timeout layer away."""
+
+    def _start_gateway_loop(self):
+        loop = asyncio.new_event_loop()
+        ready = threading.Event()
+
+        def _run():
+            asyncio.set_event_loop(loop)
+            loop.call_soon(ready.set)
+            loop.run_forever()
+
+        t = threading.Thread(target=_run, daemon=True)
+        t.start()
+        ready.wait(timeout=5)
+        return loop
+
+    def _stop_gateway_loop(self, loop):
+        loop.call_soon_threadsafe(loop.stop)
+
+    def _make_session_on(self, loop):
+        import aiohttp
+
+        async def _mk():
+            return aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(total=30))
+
+        return asyncio.run_coroutine_threadsafe(_mk(), loop).result(timeout=5)
+
+    def _close_session_on(self, session, loop):
+        async def _close():
+            await session.close()
+
+        try:
+            asyncio.run_coroutine_threadsafe(_close(), loop).result(timeout=5)
+        except Exception:
+            pass
+
+    def _run_in_worker_loop(self, coro_factory):
+        """Run ``coro_factory()`` on a fresh worker loop on a separate thread —
+        mirroring ``model_tools._run_async``'s in-gateway-loop branch."""
+        box = {}
+
+        def _worker():
+            wl = asyncio.new_event_loop()
+            asyncio.set_event_loop(wl)
+            try:
+                box["result"] = wl.run_until_complete(coro_factory())
+            except Exception as e:  # noqa: BLE001 — we assert on it
+                box["exc"] = e
+            finally:
+                wl.close()
+
+        t = threading.Thread(target=_worker)
+        t.start()
+        t.join(timeout=30)
+        return box
+
+    @pytest.mark.asyncio
+    async def test_text_send_marshals_onto_gateway_loop(self):
+        """Text-only channel send: the gateway-loop-bound session's timeout
+        context must be entered inside a task ON the gateway loop."""
+        import aiohttp
+        import gateway.run as grun
+        from tools import send_message_tool as smt
+
+        gw_loop = self._start_gateway_loop()
+        session = self._make_session_on(gw_loop)
+
+        class _SessionBoundAdapter:
+            platform = Platform.MATTERMOST
+
+            async def send(self, chat_id, content, metadata=None):
+                try:
+                    async with session.post(
+                        "http://127.0.0.1:1/unreachable",
+                        timeout=aiohttp.ClientTimeout(total=5),
+                    ) as resp:
+                        await resp.text()
+                except aiohttp.ClientError:
+                    return SendResult(success=True, message_id="text_ok")
+                return SendResult(success=True, message_id="text_ok")
+
+        runner = SimpleNamespace(
+            adapters={Platform.MATTERMOST: _SessionBoundAdapter()},
+            _gateway_loop=gw_loop,
+        )
+
+        try:
+            with patch.object(grun, "_gateway_runner_ref", lambda: runner):
+                box = self._run_in_worker_loop(
+                    lambda: smt._send_via_adapter(
+                        Platform.MATTERMOST,
+                        SimpleNamespace(token="t", extra={}),
+                        "chan_1",
+                        "hello channel",
+                    )
+                )
+        finally:
+            self._close_session_on(session, gw_loop)
+            self._stop_gateway_loop(gw_loop)
+
+        assert "exc" not in box, f"dispatch raised: {box.get('exc')!r}"
+        result = box.get("result")
+        assert isinstance(result, dict), f"unexpected result: {result!r}"
+        assert "Timeout context manager should be used inside a task" not in str(
+            result.get("error", "")
+        ), result
+        assert result.get("success") is True, result
+        assert result.get("message_id") == "text_ok"
+
+    @pytest.mark.asyncio
+    async def test_media_send_marshals_onto_gateway_loop(self, tmp_path):
+        """Media channel send: the typed media method (``send_image_file``) also
+        touches the gateway-loop-bound session and must be marshaled onto the
+        gateway loop, not awaited directly on the worker loop."""
+        import aiohttp
+        import gateway.run as grun
+        from tools import send_message_tool as smt
+
+        img = tmp_path / "pic.png"
+        img.write_bytes(b"\x89PNG\r\n\x1a\nfake")
+
+        gw_loop = self._start_gateway_loop()
+        session = self._make_session_on(gw_loop)
+
+        uploaded = []
+
+        class _SessionBoundAdapter:
+            platform = Platform.MATTERMOST
+
+            async def send(self, chat_id, content, metadata=None):
+                return SendResult(success=True, message_id="text_ok")
+
+            async def send_image_file(self, chat_id, image_path, metadata=None):
+                try:
+                    async with session.post(
+                        "http://127.0.0.1:1/unreachable",
+                        timeout=aiohttp.ClientTimeout(total=5),
+                    ) as resp:
+                        await resp.text()
+                except aiohttp.ClientError:
+                    uploaded.append(image_path)
+                    return SendResult(success=True, message_id="media_ok")
+                uploaded.append(image_path)
+                return SendResult(success=True, message_id="media_ok")
+
+        runner = SimpleNamespace(
+            adapters={Platform.MATTERMOST: _SessionBoundAdapter()},
+            _gateway_loop=gw_loop,
+        )
+
+        try:
+            with patch.object(grun, "_gateway_runner_ref", lambda: runner):
+                box = self._run_in_worker_loop(
+                    lambda: smt._send_via_adapter(
+                        Platform.MATTERMOST,
+                        SimpleNamespace(token="t", extra={}),
+                        "chan_1",
+                        "see attached",
+                        media_files=[(str(img), False)],
+                    )
+                )
+        finally:
+            self._close_session_on(session, gw_loop)
+            self._stop_gateway_loop(gw_loop)
+
+        assert "exc" not in box, f"dispatch raised: {box.get('exc')!r}"
+        result = box.get("result")
+        assert isinstance(result, dict), f"unexpected result: {result!r}"
+        assert "Timeout context manager should be used inside a task" not in str(
+            result.get("error", "")
+        ), result
+        assert result.get("success") is True, result
+        assert uploaded == [str(img)], "media upload was not actually attempted"

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -605,6 +605,140 @@ def _maybe_skip_cron_duplicate_send(platform_name: str, chat_id: str, thread_id:
     }
 
 
+# Media extension sets for live-adapter dispatch (mirrors cron.scheduler's
+# _send_media_via_adapter so in-process and cron deliveries route identically).
+_LIVE_VIDEO_EXTS = frozenset({'.mp4', '.mov', '.avi', '.mkv', '.webm', '.3gp'})
+_LIVE_IMAGE_EXTS = frozenset({'.jpg', '.jpeg', '.png', '.webp', '.gif'})
+
+
+async def _await_on_adapter_loop(runner, coro):
+    """Await ``coro`` on the loop the live adapter's I/O is bound to.
+
+    A connected adapter's network primitives (e.g. an ``aiohttp.ClientSession``)
+    are created on, and bound to, the gateway event loop. But the
+    ``send_message`` tool drives sends through ``model_tools._run_async``, which
+    — when already inside the gateway loop — runs the send coroutine on a
+    *fresh worker loop on a separate thread*. Awaiting ``adapter.send`` (or a
+    typed media method) directly there enters the gateway-loop-bound session's
+    timeout context from the wrong loop, where ``asyncio.current_task()`` is
+    ``None`` → aiohttp raises ``RuntimeError: Timeout context manager should be
+    used inside a task``.
+
+    When the runner exposes a *running* ``_gateway_loop`` that is NOT the loop
+    we are currently on, marshal the coroutine onto it via
+    ``asyncio.run_coroutine_threadsafe`` (leak-safe ``safe_schedule_threadsafe``)
+    and bridge the resulting ``concurrent.futures.Future`` back to the current
+    loop with ``asyncio.wrap_future`` — so the await is non-blocking and the
+    adapter I/O runs in a task on its own loop. This mirrors how
+    ``cron.scheduler._deliver_result`` marshals live-adapter sends onto the
+    gateway loop from its worker-thread tick.
+
+    When there is no distinct running gateway loop (the standalone/test path, or
+    the rare case where the tool already runs on the gateway loop), the
+    coroutine is awaited directly — byte-identical to the prior behavior.
+    """
+    gateway_loop = getattr(runner, "_gateway_loop", None)
+    try:
+        current_loop = asyncio.get_running_loop()
+    except RuntimeError:
+        current_loop = None
+
+    if (
+        gateway_loop is not None
+        and gateway_loop is not current_loop
+        and getattr(gateway_loop, "is_running", lambda: False)()
+    ):
+        from agent.async_utils import safe_schedule_threadsafe
+
+        future = safe_schedule_threadsafe(coro, gateway_loop)
+        if future is not None:
+            return await asyncio.wrap_future(future)
+        # Scheduling failed (loop closed mid-flight) — coro was closed by the
+        # helper; fall through to None so callers treat it as a no-op result.
+        return None
+
+    return await coro
+
+
+async def _deliver_media_via_live_adapter(adapter, platform, chat_id, media_files, *, metadata=None, runner=None):
+    """Upload canonical ``(path, is_voice)`` media tuples via a LIVE adapter.
+
+    This is the in-process mirror of ``cron.scheduler._send_media_via_adapter``:
+    it dispatches each file to the adapter's typed ``BasePlatformAdapter`` media
+    methods (``send_voice`` / ``send_image_file`` / ``send_video`` /
+    ``send_document``) by extension, which is the path cron uses (and which is
+    already proven against the canonical tuple format produced by
+    ``extract_media`` + ``filter_media_delivery_paths``).
+
+    Routing through these base methods keeps it generic — any file-capable
+    plugin adapter (Mattermost, google_chat, line, …) that overrides them gets
+    real delivery without a per-platform branch. Returns an error dict on the
+    first failure, or ``None`` if every file uploaded.
+
+    Capability gate: the ``BasePlatformAdapter`` defaults for these media
+    methods post a *text placeholder* (e.g. ``📎 File: <local-path>``) via
+    ``self.send``. For an adapter that does NOT override a given method, calling
+    it would leak a local filesystem path into the channel — an unintended
+    behavior change for plugins unrelated to file delivery (irc, ntfy, simplex,
+    …). So a method is only invoked when the adapter genuinely overrides it
+    (``type(adapter).<m> is not BasePlatformAdapter.<m>``); otherwise the file
+    is skipped on this in-process path, preserving the prior behavior (where
+    ``_send_via_adapter`` sent text only and never posted a placeholder).
+    """
+    from pathlib import Path
+    from gateway.platforms.base import BasePlatformAdapter, should_send_media_as_audio
+
+    def _overrides(method_name: str) -> bool:
+        """True iff ``adapter`` genuinely overrides the named base media method
+        (i.e. is file-capable for it), rather than inheriting the placeholder-
+        posting default from ``BasePlatformAdapter``."""
+        return getattr(type(adapter), method_name, None) is not getattr(
+            BasePlatformAdapter, method_name, None
+        )
+
+    media_files = BasePlatformAdapter.filter_media_delivery_paths(media_files)
+    last_result = None
+    for media_path, is_voice in media_files:
+        ext = Path(media_path).suffix.lower()
+        route_platform = getattr(adapter, "platform", None) or platform
+        try:
+            # Each typed media method touches the adapter's loop-bound network
+            # session, so it must run in the adapter's loop/task context (not
+            # the worker loop the send_message tool may be driving us on).
+            if should_send_media_as_audio(route_platform, ext, is_voice=is_voice):
+                if not _overrides("send_voice"):
+                    continue
+                result = await _await_on_adapter_loop(
+                    runner, adapter.send_voice(chat_id=chat_id, audio_path=media_path, metadata=metadata)
+                )
+            elif ext in _LIVE_VIDEO_EXTS:
+                if not _overrides("send_video"):
+                    continue
+                result = await _await_on_adapter_loop(
+                    runner, adapter.send_video(chat_id=chat_id, video_path=media_path, metadata=metadata)
+                )
+            elif ext in _LIVE_IMAGE_EXTS:
+                if not _overrides("send_image_file"):
+                    continue
+                result = await _await_on_adapter_loop(
+                    runner, adapter.send_image_file(chat_id=chat_id, image_path=media_path, metadata=metadata)
+                )
+            else:
+                if not _overrides("send_document"):
+                    continue
+                result = await _await_on_adapter_loop(
+                    runner, adapter.send_document(chat_id=chat_id, file_path=media_path, metadata=metadata)
+                )
+        except asyncio.CancelledError:
+            raise
+        except Exception as e:
+            return {"error": f"Adapter media send failed for {media_path}: {e}"}
+        if result is not None and not getattr(result, "success", True):
+            return {"error": f"Adapter media send failed for {media_path}: {getattr(result, 'error', 'unknown')}"}
+        last_result = result
+    return last_result
+
+
 async def _send_via_adapter(
     platform,
     pconfig,
@@ -640,22 +774,50 @@ async def _send_via_adapter(
         except Exception:
             adapter = None
         if adapter is not None:
-            try:
-                metadata = {}
-                if thread_id:
-                    metadata["thread_id"] = thread_id
-                if platform_name == "ntfy" and chat_id:
-                    metadata["publish_topic"] = chat_id
-                if not metadata:
-                    metadata = None
-                result = await adapter.send(chat_id=chat_id, content=chunk, metadata=metadata)
-            except asyncio.CancelledError:
-                raise
-            except Exception as e:
-                return {"error": f"Plugin platform send failed: {e}"}
-            if result.success:
-                return {"success": True, "message_id": result.message_id}
-            return {"error": f"Adapter send failed: {result.error}"}
+            metadata = {}
+            if thread_id:
+                metadata["thread_id"] = thread_id
+            if platform_name == "ntfy" and chat_id:
+                metadata["publish_topic"] = chat_id
+            if not metadata:
+                metadata = None
+            # 1. Text body (if any) via the live adapter.send fast path. Marshal
+            #    onto the adapter's own loop so its loop-bound network session's
+            #    timeout context is entered inside a task on the right loop (the
+            #    send_message tool may be driving us on a worker loop — see
+            #    _await_on_adapter_loop).
+            message_id = None
+            if chunk and chunk.strip():
+                try:
+                    result = await _await_on_adapter_loop(
+                        runner, adapter.send(chat_id=chat_id, content=chunk, metadata=metadata)
+                    )
+                except asyncio.CancelledError:
+                    raise
+                except Exception as e:
+                    return {"error": f"Plugin platform send failed: {e}"}
+                # _await_on_adapter_loop returns None if the gateway loop closed
+                # mid-send (scheduling failed). Guard symmetrically to the media
+                # branch below so we don't AttributeError on result.success.
+                if result is None:
+                    return {"error": "Adapter send failed: gateway loop unavailable"}
+                if not result.success:
+                    return {"error": f"Adapter send failed: {result.error}"}
+                message_id = result.message_id
+            # 2. Media (if any) via the adapter's typed media methods — the same
+            #    live path cron uses, which handles canonical (path, is_voice)
+            #    tuples correctly. This is what makes attachments actually deliver.
+            #    Pass the runner so each typed media call is likewise marshaled
+            #    onto the adapter's loop.
+            if media_files:
+                media_err = await _deliver_media_via_live_adapter(
+                    adapter, platform, chat_id, media_files, metadata=metadata, runner=runner
+                )
+                if isinstance(media_err, dict) and media_err.get("error"):
+                    return media_err
+                if message_id is None and media_err is not None:
+                    message_id = getattr(media_err, "message_id", None)
+            return {"success": True, "message_id": message_id}
 
     entry = None
     try:
@@ -883,11 +1045,45 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
             last_result = result
         return last_result
 
+    # --- Plugin platforms with file support (e.g. Mattermost) ---
+    # Plugin platforms register a ``standalone_sender_fn`` (proof of file
+    # support). When attachments are present, route every chunk through
+    # ``_send_via_adapter``, which delivers media via the LIVE adapter's typed
+    # media methods when the gateway is in-process (the cron live path) and via
+    # the standalone sender out-of-process — instead of falling into the "media
+    # omitted" path below. This is generic — any plugin whose PlatformEntry
+    # exposes a standalone sender gets media delivery without a per-platform
+    # branch here.
+    if media_files:
+        plugin_entry = None
+        try:
+            from gateway.platform_registry import platform_registry
+            plugin_entry = platform_registry.get(platform.value)
+        except Exception:
+            plugin_entry = None
+        if plugin_entry is not None and plugin_entry.standalone_sender_fn is not None:
+            last_result = None
+            for i, chunk in enumerate(chunks):
+                is_last = (i == len(chunks) - 1)
+                result = await _send_via_adapter(
+                    platform,
+                    pconfig,
+                    chat_id,
+                    chunk,
+                    thread_id=thread_id,
+                    media_files=media_files if is_last else None,
+                    force_document=force_document,
+                )
+                if isinstance(result, dict) and result.get("error"):
+                    return result
+                last_result = result
+            return last_result
+
     # --- Non-media platforms ---
     if media_files and not message.strip():
         return {
             "error": (
-                f"send_message MEDIA delivery is currently only supported for telegram, discord, matrix, weixin, signal, yuanbao and feishu; "
+                f"send_message MEDIA delivery is currently only supported for telegram, discord, matrix, weixin, signal, yuanbao and feishu, and file-capable plugin platforms; "
                 f"target {platform.value} had only media attachments"
             )
         }
@@ -895,7 +1091,7 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
     if media_files:
         warning = (
             f"MEDIA attachments were omitted for {platform.value}; "
-            "native send_message media delivery is currently only supported for telegram, discord, matrix, weixin, signal, yuanbao and feishu"
+            "native send_message media delivery is currently only supported for telegram, discord, matrix, weixin, signal, yuanbao and feishu, and file-capable plugin platforms"
         )
 
     last_result = None


### PR DESCRIPTION
## Problem
**Cross-loop send crash (the real bug).** A connected adapter's `aiohttp.ClientSession` is
created on, and bound to, the gateway event loop. But the `send_message` tool drives sends
through `model_tools._run_async`, which — when already inside the gateway loop — runs the
send coroutine on a *fresh worker loop on a separate thread*. A plain
`await adapter.send(...)` there enters the gateway-loop-bound session's timeout context from
the wrong loop, where `asyncio.current_task()` is `None`, so aiohttp raises
`RuntimeError: Timeout context manager should be used inside a task` and the send fails. This
reproduces against any connected plugin adapter that owns a loop-bound aiohttp session.

**In-process media silently dropped.** The live `adapter.send(chat_id, content, metadata)`
contract carries no media, so routing attachments through it alone drops them on the
in-process path.

## Change
- `_await_on_adapter_loop(runner, coro)`: when the runner exposes a *running* `_gateway_loop`
  distinct from the current loop, marshal the coroutine onto it via the leak-safe
  `safe_schedule_threadsafe` and bridge the `concurrent.futures.Future` back with
  `asyncio.wrap_future` (still a non-blocking await). With no distinct running gateway loop
  (standalone/test, or already on the gateway loop) the coroutine is awaited directly —
  byte-identical to prior behavior. This mirrors how `cron.scheduler._deliver_result` already
  marshals live sends onto the gateway loop from its worker-thread tick.
- `_deliver_media_via_live_adapter`: the in-process mirror of
  `cron.scheduler._send_media_via_adapter` — dispatch each canonical `(path, is_voice)` tuple
  to the adapter's typed media methods (`send_voice`/`send_image_file`/`send_video`/
  `send_document`) by extension. **Capability-gated**: a method is invoked only when the
  adapter genuinely overrides it (`type(adapter).<m> is not BasePlatformAdapter.<m>`), so
  non-overriding plugins (irc/ntfy/simplex/…) are skipped instead of posting the base
  `📎 File: <local-path>` placeholder that would leak a local path — preserving prior behavior.
- `_send_via_adapter` rewired to marshal the text send and every typed media call onto the
  adapter loop; `_send_to_platform` routes any plugin exposing a `standalone_sender_fn`
  through this path (live in-process, standalone out-of-process). Text-only hot path unchanged.
- The text result is guarded against a `None` marshaling result (gateway loop closed
  mid-send), symmetric to the media branch, to avoid an `AttributeError` in that race.

## Testing
`python -m pytest tests/tools/test_send_via_adapter_media_and_loop.py` → **8 passed**. The two
cross-loop tests are **not** mocked at the async/timeout layer: they stand up a real second
("gateway") event loop on its own thread, create a real `aiohttp.ClientSession` bound to it,
and drive the real `_send_via_adapter` from a different worker loop — the production topology —
asserting the `Timeout context manager…` error does not surface for both text and media sends.
Other tests prove media is actually uploaded (not dropped), non-overriding adapters never post
a placeholder, the text-only path is untouched, and the no-runner standalone fallback carries
the tuple unchanged. Regression: `test_managed_media_gateways.py`, `test_signal_media.py` pass.

## Generic, not vendor-specific
Touches only `tools/send_message_tool.py` and a new test. No platform branch — routing is by
`BasePlatformAdapter` capability and file extension; the fix benefits every file-capable plugin
adapter and every connected adapter with a loop-bound session. Tests use the real
`MattermostAdapter` only as a convenient *concrete* file-capable adapter.
