### PR TITLE
fix(qwen): preserve tool result strings

### DIFF
--- a/plugins/model-providers/qwen-oauth/__init__.py
+++ b/plugins/model-providers/qwen-oauth/__init__.py
@@ -24,6 +24,8 @@ class QwenProfile(ProviderProfile):
         for msg in prepared:
             if not isinstance(msg, dict):
                 continue
+            if msg.get("role") == "tool":
+                continue
             content = msg.get("content")
             if isinstance(content, str):
                 msg["content"] = [{"type": "text", "text": content}]

--- a/run_agent.py
+++ b/run_agent.py
@@ -4728,6 +4728,8 @@ class AIAgent:
         for msg in prepared:
             if not isinstance(msg, dict):
                 continue
+            if msg.get("role") == "tool":
+                continue
             content = msg.get("content")
             if isinstance(content, str):
                 msg["content"] = [{"type": "text", "text": content}]
@@ -4760,6 +4762,8 @@ class AIAgent:
 
         for msg in messages:
             if not isinstance(msg, dict):
+                continue
+            if msg.get("role") == "tool":
                 continue
             content = msg.get("content")
             if isinstance(content, str):

--- a/tests/providers/test_profile_wiring.py
+++ b/tests/providers/test_profile_wiring.py
@@ -229,6 +229,28 @@ class TestQwenProfileParity:
         assert isinstance(out_msgs[1]["content"], list)
         assert out_msgs[1]["content"][0] == {"type": "text", "text": "hello"}
 
+    def test_tool_message_strings_remain_plain_strings(self, transport):
+        msgs = [
+            {"role": "assistant", "content": "", "tool_calls": [{"id": "call_1"}]},
+            {"role": "tool", "tool_call_id": "call_1", "content": "{\"ok\": true}"},
+        ]
+        profile = transport.build_kwargs(
+            model="qwen3.5",
+            messages=msgs,
+            tools=None,
+            provider_profile=get_provider_profile("qwen"),
+        )
+        legacy = transport.build_kwargs(
+            model="qwen3.5",
+            messages=msgs,
+            tools=None,
+            provider_profile=get_provider_profile("qwen-oauth"),
+        )
+        assert profile["messages"][0]["content"] == [{"type": "text", "text": ""}]
+        assert legacy["messages"][0]["content"] == [{"type": "text", "text": ""}]
+        assert profile["messages"][1]["content"] == "{\"ok\": true}"
+        assert legacy["messages"][1]["content"] == "{\"ok\": true}"
+
 
 class TestDeveloperRoleParity:
     """Developer role swap must work on BOTH legacy and profile paths."""

--- a/tests/providers/test_provider_profiles.py
+++ b/tests/providers/test_provider_profiles.py
@@ -464,6 +464,16 @@ class TestQwenProfile:
         assert isinstance(result[1]["content"], list)
         assert result[1]["content"][0]["text"] == "hello"
 
+    def test_prepare_messages_preserves_tool_message_strings(self):
+        p = get_provider_profile("qwen-oauth")
+        msgs = [
+            {"role": "assistant", "content": "", "tool_calls": [{"id": "call_1"}]},
+            {"role": "tool", "tool_call_id": "call_1", "content": "{\"ok\": true}"},
+        ]
+        result = p.prepare_messages(msgs)
+        assert result[0]["content"] == [{"type": "text", "text": ""}]
+        assert result[1]["content"] == "{\"ok\": true}"
+
     def test_metadata_top_level(self):
         p = get_provider_profile("qwen-oauth")
         meta = {"sessionId": "s123", "promptId": "p456"}

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -1770,6 +1770,18 @@ class TestBuildApiKwargs:
         assert user_content[0] == {"type": "text", "text": "hello"}
         assert user_content[1] == {"type": "text", "text": "world"}
 
+    def test_qwen_portal_preserves_tool_message_strings(self, agent):
+        agent.provider = "qwen-oauth"
+        agent.base_url = "https://portal.qwen.ai/v1"
+        agent._base_url_lower = agent.base_url.lower()
+        messages = [
+            {"role": "assistant", "content": "", "tool_calls": [{"id": "call_1"}]},
+            {"role": "tool", "tool_call_id": "call_1", "content": "{\"ok\": true}"},
+        ]
+        kwargs = agent._build_api_kwargs(messages)
+        assert kwargs["messages"][0]["content"] == [{"type": "text", "text": ""}]
+        assert kwargs["messages"][1]["content"] == "{\"ok\": true}"
+
     def test_qwen_portal_no_system_message(self, agent):
         agent.provider = "qwen-oauth"
         agent.base_url = "https://portal.qwen.ai/v1"


### PR DESCRIPTION
## Summary
- keep `role="tool"` Qwen Portal messages as plain strings during message normalization
- keep the legacy `run_agent.py` Qwen path in sync with the provider profile behavior
- add regression coverage for provider profile, transport wiring, and `_build_api_kwargs()`

## Testing
- `python -m pytest tests/providers/test_provider_profiles.py tests/providers/test_profile_wiring.py tests/run_agent/test_run_agent.py -k 'qwen_portal or prepare_messages or TestQwenProfileParity'`\n- `ruff check plugins/model-providers/qwen-oauth/__init__.py run_agent.py tests/providers/test_provider_profiles.py tests/providers/test_profile_wiring.py tests/run_agent/test_run_agent.py`\n- `git diff --check HEAD^ HEAD`\n\nFixes #47590