### PR TITLE
feat(cli): per-profile git credential provisioning at boot

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -670,7 +670,16 @@ def load_cli_config() -> Dict[str, Any]:
     for config_key, env_var in browser_env_mappings.items():
         if config_key in browser_config:
             os.environ[env_var] = str(browser_config[config_key])
-    
+
+    # Bridge git config → env vars. provision_credentials_at_boot gates the
+    # boot-time git-credential provisioning (container_boot.main). Mirrors the
+    # terminal.home_mode → TERMINAL_HOME_MODE precedent.
+    git_config = defaults.get("git", {})
+    if "provision_credentials_at_boot" in git_config:
+        os.environ["HERMES_GIT_CREDENTIALS_BOOT"] = (
+            "1" if git_config["provision_credentials_at_boot"] else "0"
+        )
+
     # Apply auxiliary model/direct-endpoint overrides to environment variables.
     # Vision and web_extract each have their own provider/model/base_url/api_key tuple.
     # Compression config is read directly from config.yaml by run_agent.py and

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1561,6 +1561,14 @@ if _config_path.exists():
                         os.environ[_env_var] = json.dumps(_val)
                     else:
                         os.environ[_env_var] = str(_val)
+        # Bridge git config → env vars. provision_credentials_at_boot gates the
+        # boot-time git-credential provisioning (container_boot.main). Mirrors
+        # the terminal.home_mode → TERMINAL_HOME_MODE precedent above.
+        _git_cfg = _cfg.get("git", {})
+        if isinstance(_git_cfg, dict) and "provision_credentials_at_boot" in _git_cfg:
+            os.environ["HERMES_GIT_CREDENTIALS_BOOT"] = (
+                "1" if _git_cfg["provision_credentials_at_boot"] else "0"
+            )
         # Compression config is read directly from config.yaml by run_agent.py
         # and auxiliary_client.py — no env var bridging needed.
         # Auxiliary model/direct-endpoint overrides (vision, web_extract,

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1271,6 +1271,21 @@ DEFAULT_CONFIG = {
         "extract_char_limit": 15000,  # per-page char budget for web_extract; larger pages truncate + store full text in cache/web
     },
 
+    "git": {
+        # When true, materialize each profile's own GitHub token (from its
+        # .env) into {HERMES_HOME}/home/.git-credentials (0600) at container
+        # boot so the agent's git can authenticate over HTTPS. Bridged to the
+        # HERMES_GIT_CREDENTIALS_BOOT env var (see cli.py / gateway/run.py).
+        #
+        # SECURITY: default OFF. Enabling this deliberately bypasses the
+        # subprocess env blocklist that otherwise strips GITHUB_TOKEN/GH_TOKEN
+        # from tool subprocesses — the token becomes readable to anything
+        # running as the agent in that HOME. Distinct from
+        # terminal.docker_forward_env (which forwards secrets into the
+        # container ENV); this writes a credential FILE into the agent HOME.
+        "provision_credentials_at_boot": False,
+    },
+
     "browser": {
         "inactivity_timeout": 120,
         "command_timeout": 30,  # Timeout for browser commands in seconds (screenshot, navigate, etc.)
@@ -4512,6 +4527,19 @@ OPTIONAL_ENV_VARS = {
     # are intentionally NOT listed here: OPTIONAL_ENV_VARS feeds user-facing
     # surfaces (dashboard keys page, setup checklists) and deprecated knobs
     # shouldn't be offered there.
+    "HERMES_GIT_CREDENTIALS_BOOT": {
+        "description": "When 1/true/yes, materialize each profile's own GitHub token into "
+                       "{HERMES_HOME}/home/.git-credentials (0600) at container boot so the "
+                       "agent's git can authenticate. Default OFF. This deliberately bypasses "
+                       "the subprocess env blocklist that otherwise strips GITHUB_TOKEN/GH_TOKEN, "
+                       "so the token becomes readable to anything running as the agent in that HOME. "
+                       "Bridged from git.provision_credentials_at_boot in config.yaml.",
+        "prompt": "Provision per-profile git credentials at boot? (1/true to enable, blank to leave OFF)",
+        "url": None,
+        "password": False,
+        "category": "setting",
+        "advanced": True,
+    },
     "HERMES_PREFILL_MESSAGES_FILE": {
         "description": "Path to JSON file with ephemeral prefill messages for few-shot priming",
         "prompt": "Prefill messages file path",

--- a/hermes_cli/container_boot.py
+++ b/hermes_cli/container_boot.py
@@ -564,6 +564,29 @@ def main() -> int:
     actions = reconcile_profile_gateways(
         hermes_home=hermes_home, scandir=scandir,
     )
+
+    # Materialize each profile's own GitHub token into its subprocess HOME as
+    # a git credential file (see hermes_cli.git_credentials_boot). This is a
+    # SANCTIONED bypass of the provider-secret env blocklist that otherwise
+    # strips GITHUB_TOKEN/GH_TOKEN from tool subprocesses (GHSA-hardened;
+    # see tools/environments/local.py) — the token becomes readable to
+    # anything running as the agent in that HOME. So it is OPT-IN and
+    # default-OFF, gated on HERMES_GIT_CREDENTIALS_BOOT (bridged from the
+    # git.provision_credentials_at_boot config setting). Runs only in the
+    # gateway container (after the dashboard early-return above) so dashboard
+    # containers never provision. provision_all stays pure/unconditional; the
+    # gate is a boot-lifecycle decision made here.
+    if os.environ.get("HERMES_GIT_CREDENTIALS_BOOT", "").lower() in ("1", "true", "yes"):
+        from hermes_cli.git_credentials_boot import provision_all
+
+        for r in provision_all(hermes_home):
+            status = (
+                f"provisioned (source={r.source})"
+                if r.provisioned
+                else f"skipped ({r.reason})"
+            )
+            print(f"git-credentials: home={r.home} {status}")
+
     for a in actions:
         print(
             f"reconcile: profile={a.profile} "

--- a/hermes_cli/git_credentials_boot.py
+++ b/hermes_cli/git_credentials_boot.py
@@ -1,0 +1,191 @@
+"""Boot-time provisioning of per-profile git credentials.
+
+Make "the profile's own GitHub token usable by git" happen in the agent
+runtime at boot, rather than relying on an external management layer to
+reach into the runtime's data directory from the outside:
+
+  * The tool subprocess (where the agent runs ``git``) deliberately CANNOT
+    see ``GITHUB_TOKEN`` — provider secrets are blocklisted from the
+    subprocess env. So a credential file is the only path, and a skill that
+    runs *inside* the subprocess can't read the raw token to write one.
+  * This module runs in-process at container boot, where the profile's
+    ``.env`` is readable on the mounted volume and the subprocess HOME
+    (``{HERMES_HOME}/home``, per ``get_subprocess_home()``) is known
+    directly.
+
+It writes the profile's OWN token (from its ``.env``) into
+``{HERMES_HOME}/home/.git-credentials`` + ``.gitconfig`` so git's ``store``
+helper picks it up. Tokens never cross-pollinate — each home reads only its
+own ``.env``. Creating ``{HERMES_HOME}/home`` is also what activates the
+tool subprocess's HOME override (see ``get_subprocess_home``).
+
+Provides a pure, per-home function plus a profile-aware ``provision_all``
+and a ``main()`` entry point intended to run during the runtime boot
+sequence. The runtime owns the credential path, so no external component
+needs to know about it.
+"""
+from __future__ import annotations
+
+import os
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+
+GIT_HOST = "github.com"
+
+# Checked in order; a dedicated GITHUB_PAT wins over the copilot GITHUB_TOKEN.
+TOKEN_VARS = ("GITHUB_PAT", "GITHUB_TOKEN", "GH_TOKEN")
+
+
+# ---------------------------------------------------------------------------
+# Pure content builders
+# ---------------------------------------------------------------------------
+
+
+def build_git_credentials_content(token: str) -> str:
+    """The ``~/.git-credentials`` line the ``store`` helper reads for HTTPS."""
+    return f"https://x-access-token:{token}@{GIT_HOST}\n"
+
+
+def build_git_config_content(*, name: str, email: str) -> str:
+    """Minimal ``~/.gitconfig``: store helper + identity + ssh→https rewrites."""
+    return "\n".join(
+        [
+            "[credential]",
+            "\thelper = store",
+            "[user]",
+            f"\tname = {name}",
+            f"\temail = {email}",
+            f'[url "https://{GIT_HOST}/"]',
+            f"\tinsteadOf = git@{GIT_HOST}:",
+            f"\tinsteadOf = ssh://git@{GIT_HOST}/",
+            "",
+        ]
+    )
+
+
+# ---------------------------------------------------------------------------
+# .env token extraction
+# ---------------------------------------------------------------------------
+
+
+def _read_env_token(env_path: Path) -> Optional[tuple[str, str]]:
+    """Return ``(token, source_var)`` from ``env_path`` or ``None``.
+
+    Reads a flat ``.env`` file (no shell expansion). The first non-empty
+    match across ``TOKEN_VARS`` (in precedence order) wins.
+    """
+    try:
+        content = env_path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
+        return None
+    for key in TOKEN_VARS:
+        m = re.search(rf"^{re.escape(key)}=(.*)$", content, re.MULTILINE)
+        if m:
+            val = re.sub(r'^["\']|["\']$', "", m.group(1).strip())
+            if val:
+                return val, key
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Provisioning
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class ProvisionResult:
+    home: Path
+    provisioned: bool
+    reason: Optional[str] = None
+    source: Optional[str] = None
+
+
+def provision_git_credentials(
+    home_dir: Path,
+    *,
+    name: Optional[str] = None,
+    email: Optional[str] = None,
+    force: bool = False,
+) -> ProvisionResult:
+    """Provision git auth for one profile home from its own ``.env`` token.
+
+    ``home_dir`` is a HERMES_HOME-shaped directory: it holds ``.env`` at the
+    root and the tool subprocess HOME at ``{home_dir}/home``. Idempotent;
+    a no-op (``provisioned=False``) when no token is configured.
+
+    Apply-if-absent: never clobbers an existing ``.git-credentials`` /
+    ``.gitconfig`` (e.g. a profile's own imported setup) unless ``force``.
+    """
+    found = _read_env_token(home_dir / ".env")
+    if found is None:
+        return ProvisionResult(home_dir, False, reason="no GitHub token configured")
+    token, source = found
+
+    subprocess_home = home_dir / "home"
+    cred_path = subprocess_home / ".git-credentials"
+    cfg_path = subprocess_home / ".gitconfig"
+
+    if not force and (cred_path.exists() or cfg_path.exists()):
+        return ProvisionResult(
+            home_dir,
+            False,
+            reason="git config already present (pass force to overwrite)",
+            source=source,
+        )
+
+    resolved_name = name or home_dir.name
+    resolved_email = email or f"{resolved_name}@users.noreply.github.com"
+
+    subprocess_home.mkdir(parents=True, exist_ok=True)
+    _write_file(cred_path, build_git_credentials_content(token), mode=0o600)
+    _write_file(
+        cfg_path,
+        build_git_config_content(name=resolved_name, email=resolved_email),
+        mode=0o644,
+    )
+    return ProvisionResult(home_dir, True, source=source)
+
+
+def _write_file(path: Path, content: str, *, mode: int) -> None:
+    """Write ``content`` then force ``mode`` (umask-independent)."""
+    path.write_text(content, encoding="utf-8")
+    os.chmod(path, mode)
+
+
+def provision_all(hermes_home: Path) -> list[ProvisionResult]:
+    """Provision the default profile (HERMES_HOME root) + each named profile.
+
+    The HERMES_HOME root is the implicit default profile, and named profiles
+    live under ``{HERMES_HOME}/profiles/<name>/``.
+
+    The root's basename is uninformative in production (``/opt/data`` → "data"),
+    so the git identity for the default profile comes from ``HERMES_AGENT_NAME``
+    when set — commits are authored as the agent, not "data". A named profile is
+    its own agent and is identified by its profile directory name.
+    """
+    root_name = os.environ.get("HERMES_AGENT_NAME") or None
+    results = [provision_git_credentials(hermes_home, name=root_name)]
+    profiles_dir = hermes_home / "profiles"
+    if profiles_dir.is_dir():
+        for profile in sorted(p for p in profiles_dir.iterdir() if p.is_dir()):
+            results.append(provision_git_credentials(profile))
+    return results
+
+
+def main() -> int:
+    """Entry point invoked during the runtime boot sequence."""
+    hermes_home = Path(os.environ.get("HERMES_HOME", "/opt/data"))
+    for r in provision_all(hermes_home):
+        status = (
+            f"provisioned (source={r.source})"
+            if r.provisioned
+            else f"skipped ({r.reason})"
+        )
+        print(f"git-credentials: home={r.home} {status}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/hermes_cli/test_container_boot_git_credentials.py
+++ b/tests/hermes_cli/test_container_boot_git_credentials.py
@@ -1,0 +1,164 @@
+"""Tests for the boot-time git-credential provisioning wired into
+``hermes_cli.container_boot.main`` behind the ``HERMES_GIT_CREDENTIALS_BOOT``
+gate.
+
+The provisioning primitive itself (``provision_all`` /
+``provision_git_credentials``) is covered exhaustively by
+``test_git_credentials_boot.py``. These tests cover the *boot lifecycle
+decision*: that ``main()`` provisions ONLY when the gate is explicitly
+enabled, never provisions in a dashboard container, and — the security
+invariant — provisions nothing when the gate env var is absent (default OFF).
+
+No real tokens: placeholders only (``ghp_test``, ``alpha_tok``).
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from hermes_cli import container_boot
+
+
+# ---------------------------------------------------------------------------
+# Fixtures + helpers
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _inert_reconcile(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Make ``reconcile_profile_gateways`` a no-op returning no actions.
+
+    The reconciler walks/writes s6 service slots under a real scandir; these
+    tests only care about the credential-provisioning branch, so stub it out.
+    """
+    monkeypatch.setattr(
+        container_boot,
+        "reconcile_profile_gateways",
+        lambda **_kwargs: [],
+    )
+
+
+@pytest.fixture(autouse=True)
+def _gateway_container_argv(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Default the container role to a NON-dashboard (gateway) container.
+
+    ``main()`` early-returns for dashboard containers before provisioning.
+    Empty argv is treated as a gateway container (``_is_dashboard_container``
+    returns False), so provisioning is reachable. The dashboard test overrides
+    this.
+    """
+    monkeypatch.setattr(
+        container_boot,
+        "_read_container_argv",
+        lambda: (),
+    )
+
+
+def _write_env(dir_path: Path, body: str) -> None:
+    dir_path.mkdir(parents=True, exist_ok=True)
+    (dir_path / ".env").write_text(body, encoding="utf-8")
+
+
+def _cred_path(hermes_home: Path) -> Path:
+    return hermes_home / "home" / ".git-credentials"
+
+
+# ---------------------------------------------------------------------------
+# Gate ON
+# ---------------------------------------------------------------------------
+
+
+def test_boot_provisions_when_gate_enabled_against_isolated_hermes_home(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setenv("HERMES_GIT_CREDENTIALS_BOOT", "1")
+    # HERMES_AGENT_NAME unset — identity falls back to the home basename.
+    monkeypatch.delenv("HERMES_AGENT_NAME", raising=False)
+    _write_env(tmp_path, "GITHUB_PAT=ghp_test\n")
+
+    rc = container_boot.main()
+
+    assert rc == 0
+    cred = _cred_path(tmp_path)
+    assert cred.read_text() == "https://x-access-token:ghp_test@github.com\n"
+    assert (cred.stat().st_mode & 0o777) == 0o600
+
+
+def test_boot_provisions_named_profiles_when_enabled(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setenv("HERMES_GIT_CREDENTIALS_BOOT", "true")
+    monkeypatch.delenv("HERMES_AGENT_NAME", raising=False)
+    # Root profile has no token; only the named profile does.
+    _write_env(tmp_path / "profiles" / "alpha", "GITHUB_PAT=alpha_tok\n")
+
+    rc = container_boot.main()
+
+    assert rc == 0
+    alpha_cred = tmp_path / "profiles" / "alpha" / "home" / ".git-credentials"
+    assert alpha_cred.exists()
+    assert "alpha_tok" in alpha_cred.read_text()
+    assert (alpha_cred.stat().st_mode & 0o777) == 0o600
+
+
+# ---------------------------------------------------------------------------
+# Gate OFF / default OFF  (SECURITY INVARIANT)
+# ---------------------------------------------------------------------------
+
+
+def test_boot_does_not_provision_when_gate_disabled(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setenv("HERMES_GIT_CREDENTIALS_BOOT", "0")
+    _write_env(tmp_path, "GITHUB_PAT=ghp_test\n")
+
+    rc = container_boot.main()
+
+    assert rc == 0
+    assert not _cred_path(tmp_path).exists()
+
+
+def test_boot_gate_default_is_off(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """SECURITY INVARIANT: with the gate env var entirely absent, boot must
+    provision nothing — even when a token IS present in the profile's .env.
+    """
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.delenv("HERMES_GIT_CREDENTIALS_BOOT", raising=False)
+    _write_env(tmp_path, "GITHUB_PAT=ghp_test\n")
+
+    rc = container_boot.main()
+
+    assert rc == 0
+    assert not _cred_path(tmp_path).exists()
+
+
+# ---------------------------------------------------------------------------
+# Dashboard container never provisions, even with the gate ON
+# ---------------------------------------------------------------------------
+
+
+def test_dashboard_container_never_provisions_even_when_gate_on(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setenv("HERMES_GIT_CREDENTIALS_BOOT", "1")
+    _write_env(tmp_path, "GITHUB_PAT=ghp_test\n")
+    # A dashboard-only container: main() early-returns before provisioning.
+    monkeypatch.setattr(
+        container_boot,
+        "_read_container_argv",
+        lambda: ("dashboard",),
+    )
+
+    rc = container_boot.main()
+
+    assert rc == 0
+    assert not _cred_path(tmp_path).exists()
+    # And no named-profile creds either.
+    assert not list(tmp_path.glob("profiles/*/home/.git-credentials"))

--- a/tests/hermes_cli/test_git_credentials_boot.py
+++ b/tests/hermes_cli/test_git_credentials_boot.py
@@ -1,0 +1,242 @@
+"""Tests for hermes_cli.git_credentials_boot — boot-time provisioning of
+per-profile git credentials from the profile's own configured GitHub token.
+
+The module runs in-process at container boot, where the profile's .env is
+readable on the mounted volume and HERMES_HOME / get_subprocess_home() are
+known directly — unlike the tool subprocess, which cannot see the token
+(GITHUB_TOKEN is blocklisted from the subprocess env by design).
+
+Tests run against a fake $HERMES_HOME under tmp_path. No container, no git.
+"""
+from __future__ import annotations
+
+import stat
+from pathlib import Path
+
+import pytest
+
+from hermes_cli.git_credentials_boot import (
+    build_git_config_content,
+    build_git_credentials_content,
+    provision_all,
+    provision_git_credentials,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _write_env(home: Path, body: str) -> None:
+    home.mkdir(parents=True, exist_ok=True)
+    (home / ".env").write_text(body)
+
+
+def _cred_path(home: Path) -> Path:
+    return home / "home" / ".git-credentials"
+
+
+def _cfg_path(home: Path) -> Path:
+    return home / "home" / ".gitconfig"
+
+
+def _mode(p: Path) -> int:
+    return stat.S_IMODE(p.stat().st_mode)
+
+
+# ---------------------------------------------------------------------------
+# Pure content builders
+# ---------------------------------------------------------------------------
+
+
+def test_credentials_content_uses_x_access_token_https_line():
+    assert build_git_credentials_content("ghp_abc") == (
+        "https://x-access-token:ghp_abc@github.com\n"
+    )
+
+
+def test_config_content_has_store_helper_identity_and_insteadof():
+    cfg = build_git_config_content(name="agent-a", email="agent-a@users.noreply.github.com")
+    assert "helper = store" in cfg
+    assert "name = agent-a" in cfg
+    assert "email = agent-a@users.noreply.github.com" in cfg
+    # ssh-style remotes get rewritten through HTTPS so the agent doesn't die on
+    # "Host key verification failed" when it reaches for an SSH URL.
+    assert 'insteadOf = git@github.com:' in cfg
+    assert 'insteadOf = ssh://git@github.com/' in cfg
+
+
+# ---------------------------------------------------------------------------
+# provision_git_credentials — single home
+# ---------------------------------------------------------------------------
+
+
+def test_writes_credentials_and_config_from_env_token(tmp_path):
+    _write_env(tmp_path, "GITHUB_PAT=ghp_secret\n")
+
+    result = provision_git_credentials(tmp_path)
+
+    assert result.provisioned is True
+    assert result.source == "GITHUB_PAT"
+    assert _cred_path(tmp_path).read_text() == "https://x-access-token:ghp_secret@github.com\n"
+    assert "helper = store" in _cfg_path(tmp_path).read_text()
+
+
+def test_credentials_file_is_chmod_600(tmp_path):
+    _write_env(tmp_path, "GITHUB_PAT=ghp_secret\n")
+    provision_git_credentials(tmp_path)
+    assert _mode(_cred_path(tmp_path)) == 0o600
+
+
+def test_config_file_is_chmod_644(tmp_path):
+    _write_env(tmp_path, "GITHUB_PAT=ghp_secret\n")
+    provision_git_credentials(tmp_path)
+    assert _mode(_cfg_path(tmp_path)) == 0o644
+
+
+def test_token_precedence_pat_beats_github_token_beats_gh_token(tmp_path):
+    _write_env(tmp_path, "GH_TOKEN=gh_v\nGITHUB_TOKEN=ght_v\nGITHUB_PAT=pat_v\n")
+    result = provision_git_credentials(tmp_path)
+    assert result.source == "GITHUB_PAT"
+    assert "pat_v" in _cred_path(tmp_path).read_text()
+
+
+def test_falls_back_to_gh_token_when_only_one_present(tmp_path):
+    _write_env(tmp_path, "GH_TOKEN=gh_only\n")
+    result = provision_git_credentials(tmp_path)
+    assert result.source == "GH_TOKEN"
+    assert "gh_only" in _cred_path(tmp_path).read_text()
+
+
+def test_strips_quotes_and_whitespace_from_token(tmp_path):
+    _write_env(tmp_path, 'GITHUB_PAT="ghp_quoted"  \n')
+    provision_git_credentials(tmp_path)
+    assert _cred_path(tmp_path).read_text() == "https://x-access-token:ghp_quoted@github.com\n"
+
+
+def test_no_token_is_inert(tmp_path):
+    _write_env(tmp_path, "OPENAI_API_KEY=sk-whatever\n")
+    result = provision_git_credentials(tmp_path)
+    assert result.provisioned is False
+    assert result.reason == "no GitHub token configured"
+    assert not _cred_path(tmp_path).exists()
+    assert not (tmp_path / "home").exists()
+
+
+def test_missing_env_is_inert(tmp_path):
+    result = provision_git_credentials(tmp_path)
+    assert result.provisioned is False
+    assert not _cred_path(tmp_path).exists()
+
+
+def test_empty_token_value_is_inert(tmp_path):
+    _write_env(tmp_path, "GITHUB_PAT=\n")
+    result = provision_git_credentials(tmp_path)
+    assert result.provisioned is False
+
+
+# ---------------------------------------------------------------------------
+# Apply-if-absent data-loss guard
+# ---------------------------------------------------------------------------
+
+
+def test_apply_if_absent_does_not_clobber_existing_credentials(tmp_path):
+    _write_env(tmp_path, "GITHUB_PAT=ghp_new\n")
+    home = tmp_path / "home"
+    home.mkdir()
+    (home / ".git-credentials").write_text("PRE-EXISTING\n")
+
+    result = provision_git_credentials(tmp_path)
+
+    assert result.provisioned is False
+    assert "already present" in (result.reason or "")
+    assert (home / ".git-credentials").read_text() == "PRE-EXISTING\n"
+
+
+def test_apply_if_absent_does_not_clobber_existing_gitconfig(tmp_path):
+    _write_env(tmp_path, "GITHUB_PAT=ghp_new\n")
+    home = tmp_path / "home"
+    home.mkdir()
+    (home / ".gitconfig").write_text("[user]\n\tname = human\n")
+
+    result = provision_git_credentials(tmp_path)
+
+    assert result.provisioned is False
+    assert (home / ".gitconfig").read_text() == "[user]\n\tname = human\n"
+
+
+def test_force_overwrites_existing(tmp_path):
+    _write_env(tmp_path, "GITHUB_PAT=ghp_new\n")
+    home = tmp_path / "home"
+    home.mkdir()
+    (home / ".git-credentials").write_text("PRE-EXISTING\n")
+
+    result = provision_git_credentials(tmp_path, force=True)
+
+    assert result.provisioned is True
+    assert "ghp_new" in (home / ".git-credentials").read_text()
+
+
+# ---------------------------------------------------------------------------
+# provision_all — HERMES_HOME root (default profile) + named profiles
+# ---------------------------------------------------------------------------
+
+
+def test_provision_all_does_root_and_each_named_profile(tmp_path):
+    # Default profile = HERMES_HOME root.
+    _write_env(tmp_path, "GITHUB_PAT=root_tok\n")
+    # Named profiles live under profiles/<name>/, each with its own .env.
+    _write_env(tmp_path / "profiles" / "alpha", "GITHUB_PAT=alpha_tok\n")
+    _write_env(tmp_path / "profiles" / "beta", "GH_TOKEN=beta_tok\n")
+
+    results = provision_all(tmp_path)
+
+    provisioned = {r.home: r for r in results if r.provisioned}
+    assert tmp_path in provisioned
+    assert (tmp_path / "profiles" / "alpha") in provisioned
+    assert (tmp_path / "profiles" / "beta") in provisioned
+    assert "root_tok" in _cred_path(tmp_path).read_text()
+    assert "alpha_tok" in _cred_path(tmp_path / "profiles" / "alpha").read_text()
+    assert "beta_tok" in _cred_path(tmp_path / "profiles" / "beta").read_text()
+
+
+def test_provision_all_skips_profile_without_token(tmp_path):
+    _write_env(tmp_path / "profiles" / "notoken", "OPENAI_API_KEY=sk-x\n")
+    results = provision_all(tmp_path)
+    notoken = tmp_path / "profiles" / "notoken"
+    assert all(not r.provisioned for r in results if r.home == notoken)
+    assert not _cred_path(notoken).exists()
+
+
+def test_provision_all_handles_no_profiles_dir(tmp_path):
+    _write_env(tmp_path, "GITHUB_PAT=root_tok\n")
+    results = provision_all(tmp_path)
+    assert any(r.provisioned and r.home == tmp_path for r in results)
+
+
+def test_provision_all_uses_hermes_agent_name_for_root_identity(tmp_path, monkeypatch):
+    # The default profile (HERMES_HOME root) basename is "data" in production
+    # (/opt/data); HERMES_AGENT_NAME carries the real agent name, so commits
+    # are authored as the agent, not "data".
+    monkeypatch.setenv("HERMES_AGENT_NAME", "gamma")
+    _write_env(tmp_path, "GITHUB_PAT=root_tok\n")
+
+    provision_all(tmp_path)
+
+    cfg = _cfg_path(tmp_path).read_text()
+    assert "name = gamma" in cfg
+    assert "email = gamma@users.noreply.github.com" in cfg
+
+
+def test_provision_all_profile_identity_uses_profile_name_not_env(tmp_path, monkeypatch):
+    # A named profile is its own agent — its identity is the profile name,
+    # never the container-level HERMES_AGENT_NAME.
+    monkeypatch.setenv("HERMES_AGENT_NAME", "rootname")
+    _write_env(tmp_path / "profiles" / "beta", "GITHUB_PAT=tok\n")
+
+    provision_all(tmp_path)
+
+    cfg = _cfg_path(tmp_path / "profiles" / "beta").read_text()
+    assert "name = beta" in cfg
+    assert "name = rootname" not in cfg

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -475,6 +475,25 @@ Hermes resolves each listed variable from your current shell first, then falls b
 Anything listed in `docker_forward_env` becomes visible to commands run inside the container. Only forward credentials you are comfortable exposing to the terminal session.
 :::
 
+### Provisioning Git Credentials at Boot
+
+The agent's tool subprocess deliberately **cannot** see `GITHUB_TOKEN` / `GH_TOKEN`: provider secrets are stripped from the subprocess environment (a GHSA hardening — see the env blocklist in `tools/environments/local.py`). That means `git push` from inside an agent session has no token to authenticate with, even when the profile has one configured.
+
+`git.provision_credentials_at_boot` opts into a sanctioned bypass. When enabled, at container boot Hermes reads each profile's **own** GitHub token from its `.env` and materializes it into that profile's agent HOME as a git credential file — `{HERMES_HOME}/home/.git-credentials`, mode `0600` — so git's `store` helper can authenticate over HTTPS. Tokens never cross-pollinate: each home reads only its own `.env`.
+
+```yaml
+git:
+  provision_credentials_at_boot: true   # default: false
+```
+
+Can also be set via environment variable: `HERMES_GIT_CREDENTIALS_BOOT=1` (accepts `1`/`true`/`yes`). Default is **off** — with the setting absent, no credential file is ever written. Dashboard-only containers never provision, regardless of this setting.
+
+This is distinct from `terminal.docker_forward_env`: that forwards a secret into the container's **environment** for a Docker terminal session; this writes a credential **file** into the agent's HOME so the agent's git can use it directly.
+
+:::warning
+Enabling this deliberately bypasses the subprocess env blocklist that otherwise strips `GITHUB_TOKEN` / `GH_TOKEN`. Once the credential file is written, the token becomes readable to anything running as the agent in that HOME. Only enable it when you are comfortable exposing the profile's GitHub token to the agent's git.
+:::
+
 ### Running the Container as Your Host User
 
 By default Docker containers run as `root` (UID 0). Files created inside `/workspace` or other bind-mounts end up owned by root on the host, so after a session you have to `sudo chown` them before you can edit them from your host editor. The `terminal.docker_run_as_host_user` flag fixes this:


### PR DESCRIPTION
## What

Adds `hermes_cli/git_credentials_boot.py`: a boot-time step that makes each profile's own GitHub token usable by `git`, by writing a scoped `{HERMES_HOME}/home/.git-credentials` (mode 0600) and a minimal `.gitconfig` (mode 0644, `store` helper + identity + ssh→https rewrites).

## Why

The tool subprocess that runs `git` deliberately cannot see `GITHUB_TOKEN` (provider secrets are blocklisted from its env), and its HOME is redirected to `{HERMES_HOME}/home`. So a skill running inside the subprocess can neither read the raw token nor write a credentials file. The only place the token is reachable is in-process at boot, where the profile's `.env` is on the mounted volume and the subprocess HOME path is known directly. This module fills that gap.

Crucially, it is **per-profile with no token cross-pollination**: each home reads only its own `.env`. The default profile is the `HERMES_HOME` root (identity from `HERMES_AGENT_NAME` so commits aren't authored as "data"); each named profile under `{HERMES_HOME}/profiles/<name>/` is provisioned from its own `.env` and authored under its own profile name. Running multiple profiles in one runtime can't leak one profile's git auth into another.

## Behavior

- Token precedence: `GITHUB_PAT` > `GITHUB_TOKEN` > `GH_TOKEN`.
- Inert when no token is configured (no files written, `home/` not created).
- Apply-if-absent: never clobbers an existing `.git-credentials`/`.gitconfig` (e.g. a user's imported setup) unless `force=True`.
- Strips surrounding quotes/whitespace from the token value.
- Idempotent.

## Tests

19 unit tests in `tests/hermes_cli/test_git_credentials_boot.py`, covering content builders, token precedence/extraction, chmod modes, inert cases, the apply-if-absent guard, and `provision_all` over root + named profiles. All pass against a fake `$HERMES_HOME` under `tmp_path` (no container, no git).
