### PR TITLE
feat(gateway): add provider_model, context_full, and reasoning runtime footer fields

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -14180,6 +14180,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     context_tokens=agent_result.get("last_prompt_tokens", 0) or 0,
                     context_length=agent_result.get("context_length") or None,
                     cwd=os.environ.get("TERMINAL_CWD", ""),
+                    # Session-scoped /reasoning wins over config; resolve it
+                    # here so the footer reports what the session actually ran.
+                    reasoning_config=self._resolve_session_reasoning_config(
+                        source=source, model=agent_result.get("model") or ""
+                    ),
                 )
             except Exception as _footer_err:
                 logger.debug("runtime_footer build failed: %s", _footer_err)

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -14176,6 +14176,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     user_config=_load_gateway_config(),
                     platform_key=_platform_config_key(source.platform),
                     model=agent_result.get("model"),
+                    provider=agent_result.get("provider"),
                     context_tokens=agent_result.get("last_prompt_tokens", 0) or 0,
                     context_length=agent_result.get("context_length") or None,
                     cwd=os.environ.get("TERMINAL_CWD", ""),
@@ -22285,6 +22286,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 _output_toks = getattr(_agent, "session_completion_tokens", 0)
                 _context_length = getattr(_agent.context_compressor, "context_length", 0) or 0
             _resolved_model = getattr(_agent, "model", None) if _agent else None
+            _resolved_provider = getattr(_agent, "provider", None) if _agent else None
 
             # Sync session_id immediately after run_conversation(). Compression
             # can rotate before a follow-up model call fails; the failure return
@@ -22413,6 +22415,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     "input_tokens": _input_toks,
                     "output_tokens": _output_toks,
                     "model": _resolved_model,
+                    "provider": _resolved_provider,
                     "context_length": _context_length,
                 }
 
@@ -22536,6 +22539,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 "input_tokens": _input_toks,
                 "output_tokens": _output_toks,
                 "model": _resolved_model,
+                "provider": _resolved_provider,
                 "context_length": _context_length,
                 "session_id": effective_session_id,
                 "response_previewed": result.get("response_previewed", False),

--- a/gateway/runtime_footer.py
+++ b/gateway/runtime_footer.py
@@ -1,15 +1,23 @@
 """Gateway runtime-metadata footer.
 
-Renders a compact footer showing runtime state (model, context %, cwd) and
-appends it to the FINAL message of an agent turn when enabled.  Off by default
-to keep replies minimal.
+Renders a compact footer showing runtime state (provider/model, context
+footprint, cwd) and appends it to the FINAL message of an agent turn when
+enabled.  Off by default to keep replies minimal.
 
 Config (``~/.hermes/config.yaml``)::
 
     display:
       runtime_footer:
-        enabled: true                       # off by default
-        fields: [model, context_pct, cwd]   # order shown; drop any to hide
+        enabled: true                            # off by default
+        fields: [provider_model, context_full, reasoning, cwd]   # order shown; drop any to hide
+
+Available fields:
+    model           — bare model id, vendor prefix dropped (``claude-opus-4-8``)
+    provider_model  — ``provider/model`` (``claude-bridge-f3/claude-opus-4-8``)
+    context_pct     — last-call occupancy as a percent (``5%``)
+    context_full    — ``used/window (pct)``, both humanized (``50.2k/1M (5%)``)
+    reasoning       — model reasoning-effort level, ``r:<level>`` (``r:xhigh``)
+    cwd             — home-relative working dir (``~``)
 
 Per-platform overrides live under ``display.platforms.<platform>.runtime_footer``.
 Users can toggle the global setting with ``/footer on|off`` from both the CLI
@@ -28,8 +36,8 @@ from __future__ import annotations
 import os
 from typing import Any, Iterable, Optional
 
-_DEFAULT_FIELDS: tuple[str, ...] = ("model", "context_pct", "cwd")
-_SEP = " · "
+_DEFAULT_FIELDS: tuple[str, ...] = ("provider_model", "context_full", "reasoning", "cwd")
+_SEP = " \u00b7 "
 
 
 def _home_relative_cwd(cwd: str) -> str:
@@ -47,10 +55,50 @@ def _home_relative_cwd(cwd: str) -> str:
 
 
 def _model_short(model: Optional[str]) -> str:
-    """Drop ``vendor/`` prefix for readability (``openai/gpt-5.4`` → ``gpt-5.4``)."""
+    """Drop ``vendor/`` prefix for readability (``openai/gpt-5.4`` -> ``gpt-5.4``)."""
     if not model:
         return ""
     return model.rsplit("/", 1)[-1]
+
+
+def _split_provider_model(
+    provider: Optional[str], model: Optional[str]
+) -> tuple[str, str]:
+    """Resolve a clean ``(provider, model)`` pair.
+
+    Mirrors the blackbox-inspect ``/context`` logic: when ``provider`` is unset
+    but ``model`` carries a ``provider/model`` prefix, split it so the footer
+    reads cleanly (``provider/model``, not ``unset/a/b``).
+
+    When the ``model`` ALREADY carries a ``provider/`` prefix, that embedded
+    prefix wins and any separately-supplied ``provider`` is ignored — this
+    avoids an ugly triple like ``openai-codex/claude-app/claude-opus-4-8`` when
+    a caller passes both a provider and a prefixed model. The model's own
+    prefix is the more specific source.
+    """
+    prov = (provider or "").strip()
+    mdl = (model or "").strip()
+    if "/" in mdl:
+        # The model carries its own provider prefix — it's authoritative.
+        prov, _, mdl = mdl.partition("/")
+    return prov, mdl
+
+
+def _humanize_tok(n: Any) -> str:
+    """Token count -> compact string (``50k``, ``1.5k``, ``1M``, ``1.0M``).
+
+    Byte-identical to the blackbox-inspect plugin's ``_humanize_tok`` so the
+    footer and ``/context`` agree on formatting.
+    """
+    try:
+        n = int(n or 0)
+    except (TypeError, ValueError):
+        n = 0
+    if abs(n) >= 1_000_000:
+        return f"{n // 1_000_000}M" if n % 1_000_000 == 0 else f"{n / 1_000_000:.1f}M"
+    if abs(n) >= 1000:
+        return f"{n // 1000}k" if n % 1000 == 0 else f"{n / 1000:.1f}k"
+    return str(n)
 
 
 def resolve_footer_config(
@@ -94,6 +142,8 @@ def format_runtime_footer(
     context_tokens: int,
     context_length: Optional[int],
     cwd: Optional[str] = None,
+    provider: Optional[str] = None,
+    reasoning: Optional[str] = None,
     fields: Iterable[str] = _DEFAULT_FIELDS,
 ) -> str:
     """Render the footer line, or return "" if no fields have data.
@@ -107,10 +157,30 @@ def format_runtime_footer(
             m = _model_short(model)
             if m:
                 parts.append(m)
+        elif field == "provider_model":
+            prov, mdl = _split_provider_model(provider, model)
+            if prov and mdl:
+                parts.append(f"{prov}/{mdl}")
+            elif mdl:
+                parts.append(mdl)
         elif field == "context_pct":
             if context_length and context_length > 0 and context_tokens >= 0:
                 pct = max(0, min(100, round((context_tokens / context_length) * 100)))
                 parts.append(f"{pct}%")
+        elif field == "context_full":
+            # Both used and window humanized (50.2k/1M); pct from raw values.
+            if context_length and context_length > 0 and context_tokens >= 0:
+                pct = max(0, min(100, round((context_tokens / context_length) * 100)))
+                parts.append(
+                    f"{_humanize_tok(context_tokens)}/{_humanize_tok(context_length)} ({pct}%)"
+                )
+            elif context_tokens and context_tokens > 0:
+                parts.append(_humanize_tok(context_tokens))
+        elif field == "reasoning":
+            # Model reasoning-effort level (none/minimal/low/medium/high/xhigh).
+            r = (reasoning or "").strip()
+            if r:
+                parts.append(f"r:{r}")
         elif field == "cwd":
             rel = _home_relative_cwd(cwd or os.environ.get("TERMINAL_CWD", ""))
             if rel:
@@ -122,6 +192,18 @@ def format_runtime_footer(
     return _SEP.join(parts)
 
 
+def _reasoning_from_config(user_config: dict[str, Any] | None) -> str:
+    """Read ``agent.reasoning_effort`` from the user config (the canonical source
+    `/reasoning <level>` writes to). Empty string when unset."""
+    try:
+        agent_cfg = (user_config or {}).get("agent") or {}
+        if isinstance(agent_cfg, dict):
+            return str(agent_cfg.get("reasoning_effort", "") or "").strip()
+    except Exception:
+        pass
+    return ""
+
+
 def build_footer_line(
     *,
     user_config: dict[str, Any] | None,
@@ -130,6 +212,8 @@ def build_footer_line(
     context_tokens: int,
     context_length: Optional[int],
     cwd: Optional[str] = None,
+    provider: Optional[str] = None,
+    reasoning: Optional[str] = None,
 ) -> str:
     """Top-level entry point used by gateway/run.py.
 
@@ -140,10 +224,16 @@ def build_footer_line(
     cfg = resolve_footer_config(user_config, platform_key)
     if not cfg.get("enabled"):
         return ""
+    # Reasoning effort comes from config (agent.reasoning_effort); caller may
+    # override with a live value if it ever has one.
+    if reasoning is None:
+        reasoning = _reasoning_from_config(user_config)
     return format_runtime_footer(
         model=model,
         context_tokens=context_tokens,
         context_length=context_length,
         cwd=cwd,
+        provider=provider,
+        reasoning=reasoning,
         fields=cfg.get("fields") or _DEFAULT_FIELDS,
     )

--- a/gateway/runtime_footer.py
+++ b/gateway/runtime_footer.py
@@ -1,17 +1,19 @@
 """Gateway runtime-metadata footer.
 
-Renders a compact footer showing runtime state (provider/model, context
-footprint, cwd) and appends it to the FINAL message of an agent turn when
-enabled.  Off by default to keep replies minimal.
+Renders a compact footer showing runtime state (model, context %, cwd) and
+appends it to the FINAL message of an agent turn when enabled.  Off by default
+to keep replies minimal.
 
 Config (``~/.hermes/config.yaml``)::
 
     display:
       runtime_footer:
-        enabled: true                            # off by default
-        fields: [provider_model, context_full, reasoning, cwd]   # order shown; drop any to hide
+        enabled: true                       # off by default
+        fields: [model, context_pct, cwd]   # order shown; drop any to hide
 
-Available fields:
+Available fields (the default set is unchanged — ``model``, ``context_pct``,
+``cwd`` — so an existing footer renders byte-identically; the new fields are
+opt-in via ``fields``):
     model           — bare model id, vendor prefix dropped (``claude-opus-4-8``)
     provider_model  — ``provider/model`` (``claude-bridge-f3/claude-opus-4-8``)
     context_pct     — last-call occupancy as a percent (``5%``)
@@ -36,7 +38,7 @@ from __future__ import annotations
 import os
 from typing import Any, Iterable, Optional
 
-_DEFAULT_FIELDS: tuple[str, ...] = ("provider_model", "context_full", "reasoning", "cwd")
+_DEFAULT_FIELDS: tuple[str, ...] = ("model", "context_pct", "cwd")
 _SEP = " \u00b7 "
 
 
@@ -66,9 +68,9 @@ def _split_provider_model(
 ) -> tuple[str, str]:
     """Resolve a clean ``(provider, model)`` pair.
 
-    Mirrors the blackbox-inspect ``/context`` logic: when ``provider`` is unset
-    but ``model`` carries a ``provider/model`` prefix, split it so the footer
-    reads cleanly (``provider/model``, not ``unset/a/b``).
+    When ``provider`` is unset but ``model`` carries a ``provider/model``
+    prefix, split it so the footer reads cleanly (``provider/model``, not
+    ``unset/a/b``).
 
     When the ``model`` ALREADY carries a ``provider/`` prefix, that embedded
     prefix wins and any separately-supplied ``provider`` is ignored — this
@@ -85,11 +87,7 @@ def _split_provider_model(
 
 
 def _humanize_tok(n: Any) -> str:
-    """Token count -> compact string (``50k``, ``1.5k``, ``1M``, ``1.0M``).
-
-    Byte-identical to the blackbox-inspect plugin's ``_humanize_tok`` so the
-    footer and ``/context`` agree on formatting.
-    """
+    """Token count -> compact string (``50k``, ``1.5k``, ``1M``, ``1.0M``)."""
     try:
         n = int(n or 0)
     except (TypeError, ValueError):
@@ -192,16 +190,44 @@ def format_runtime_footer(
     return _SEP.join(parts)
 
 
-def _reasoning_from_config(user_config: dict[str, Any] | None) -> str:
-    """Read ``agent.reasoning_effort`` from the user config (the canonical source
-    `/reasoning <level>` writes to). Empty string when unset."""
+def _reasoning_label(reasoning_config: Any) -> str:
+    """Render a parsed reasoning-config dict as a footer label.
+
+    Accepts the dict shape produced by
+    :func:`hermes_constants.parse_reasoning_effort` — ``{"enabled": True,
+    "effort": "<level>"}`` or ``{"enabled": False}``.  Returns the bare level
+    (``xhigh``), ``none`` when thinking is explicitly disabled, or ``""`` when
+    unset (caller drops the field).
+    """
+    if not isinstance(reasoning_config, dict):
+        return ""
+    if not reasoning_config.get("enabled", True):
+        return "none"
+    return str(reasoning_config.get("effort", "") or "").strip()
+
+
+def _reasoning_from_config(
+    user_config: dict[str, Any] | None, model: Optional[str] = None
+) -> str:
+    """Resolve the effective reasoning level for *model* from *user_config*.
+
+    Routes through the shared chokepoint
+    :func:`hermes_constants.resolve_reasoning_config` so the footer honors
+    per-model overrides (``agent.reasoning_overrides``) and the YAML-boolean
+    "disabled" spelling exactly as the agent does, rather than re-reading
+    ``agent.reasoning_effort`` raw.
+
+    Session-scoped ``/reasoning`` overrides are resolved by the CALLER (they
+    always win) and passed to :func:`build_footer_line` as ``reasoning_config``.
+    """
     try:
-        agent_cfg = (user_config or {}).get("agent") or {}
-        if isinstance(agent_cfg, dict):
-            return str(agent_cfg.get("reasoning_effort", "") or "").strip()
+        from hermes_constants import resolve_reasoning_config
+
+        return _reasoning_label(
+            resolve_reasoning_config(user_config or {}, model or "")
+        )
     except Exception:
-        pass
-    return ""
+        return ""
 
 
 def build_footer_line(
@@ -214,20 +240,31 @@ def build_footer_line(
     cwd: Optional[str] = None,
     provider: Optional[str] = None,
     reasoning: Optional[str] = None,
+    reasoning_config: Any = None,
 ) -> str:
     """Top-level entry point used by gateway/run.py.
 
     Returns the footer text (empty string when disabled or no data).  Callers
     append this to the final response themselves, preserving a single blank
     line of separation.
+
+    ``reasoning_config`` is the caller's ALREADY-RESOLVED reasoning config for
+    this session (gateway/run.py's ``_resolve_session_reasoning_config``, which
+    honors a session-scoped ``/reasoning <level>``).  Passing it keeps the
+    footer in step with what the session actually runs; without it the footer
+    falls back to the config-level resolution, which can be stale for a session
+    that set a session-scoped override.
     """
     cfg = resolve_footer_config(user_config, platform_key)
     if not cfg.get("enabled"):
         return ""
-    # Reasoning effort comes from config (agent.reasoning_effort); caller may
-    # override with a live value if it ever has one.
+    # Reasoning: prefer an explicit label, then the caller's session-resolved
+    # config, then config-level resolution for this model.
     if reasoning is None:
-        reasoning = _reasoning_from_config(user_config)
+        if reasoning_config is not None:
+            reasoning = _reasoning_label(reasoning_config)
+        else:
+            reasoning = _reasoning_from_config(user_config, model)
     return format_runtime_footer(
         model=model,
         context_tokens=context_tokens,

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -3427,7 +3427,7 @@ class GatewaySlashCommandsMixin:
                 model=_resolve_gateway_model(user_config) or None,
                 context_tokens=0,
                 context_length=None,
-                fields=effective.get("fields") or ["model", "context_pct", "cwd"],
+                fields=effective.get("fields") or ["provider_model", "context_full", "cwd"],
             )
             if preview:
                 example = t("gateway.footer.example_line", preview=preview)

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -3427,7 +3427,7 @@ class GatewaySlashCommandsMixin:
                 model=_resolve_gateway_model(user_config) or None,
                 context_tokens=0,
                 context_length=None,
-                fields=effective.get("fields") or ["provider_model", "context_full", "cwd"],
+                fields=effective.get("fields") or ["model", "context_pct", "cwd"],
             )
             if preview:
                 example = t("gateway.footer.example_line", preview=preview)

--- a/tests/gateway/test_runtime_footer.py
+++ b/tests/gateway/test_runtime_footer.py
@@ -9,7 +9,9 @@ import pytest
 
 from gateway.runtime_footer import (
     _home_relative_cwd,
+    _humanize_tok,
     _model_short,
+    _split_provider_model,
     build_footer_line,
     format_runtime_footer,
     resolve_footer_config,
@@ -148,19 +150,211 @@ def test_format_footer_unknown_field_silently_ignored():
 
 
 # ---------------------------------------------------------------------------
+# provider_model + context_full (new fields)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize(
+    "provider,model,expected",
+    [
+        ("claude-bridge-f3", "claude-opus-4-8", ("claude-bridge-f3", "claude-opus-4-8")),
+        # provider unset, model carries the prefix -> split it
+        ("", "claude-bridge-f3/claude-opus-4-8", ("claude-bridge-f3", "claude-opus-4-8")),
+        (None, "openai/gpt-5.4", ("openai", "gpt-5.4")),
+        # bare model, no provider anywhere
+        ("", "gpt-5.4", ("", "gpt-5.4")),
+        (None, None, ("", "")),
+        # BOTH provider given AND model carries a prefix -> model's prefix wins
+        # (no ugly triple openai-codex/claude-app/claude-opus-4-8)
+        ("openai-codex", "claude-app/claude-opus-4-8", ("claude-app", "claude-opus-4-8")),
+    ],
+)
+def test_split_provider_model(provider, model, expected):
+    assert _split_provider_model(provider, model) == expected
+
+
+@pytest.mark.parametrize(
+    "n,expected",
+    [
+        (50_000, "50k"),
+        (1_500, "1.5k"),
+        (1_000_000, "1M"),
+        (1_048_576, "1.0M"),
+        (500, "500"),
+        (0, "0"),
+        (None, "0"),
+    ],
+)
+def test_humanize_tok(n, expected):
+    assert _humanize_tok(n) == expected
+
+
+def test_format_footer_provider_model_explicit():
+    out = format_runtime_footer(
+        model="claude-opus-4-8",
+        provider="claude-bridge-f3",
+        context_tokens=0, context_length=None,
+        cwd="",
+        fields=("provider_model",),
+    )
+    assert out == "claude-bridge-f3/claude-opus-4-8"
+
+
+def test_format_footer_provider_model_split_from_prefixed_model():
+    # provider unset; model carries the prefix
+    out = format_runtime_footer(
+        model="claude-bridge-f3/claude-opus-4-8",
+        provider=None,
+        context_tokens=0, context_length=None,
+        cwd="",
+        fields=("provider_model",),
+    )
+    assert out == "claude-bridge-f3/claude-opus-4-8"
+
+
+def test_format_footer_provider_model_bare_model_only():
+    # no provider anywhere -> just the model, no leading slash
+    out = format_runtime_footer(
+        model="gpt-5.4",
+        provider="",
+        context_tokens=0, context_length=None,
+        cwd="",
+        fields=("provider_model",),
+    )
+    assert out == "gpt-5.4"
+
+
+def test_format_footer_context_full():
+    # both used and window humanized (50.2k/1M)
+    out = format_runtime_footer(
+        model="m",
+        context_tokens=50_247,
+        context_length=1_000_000,
+        cwd="",
+        fields=("context_full",),
+    )
+    assert out == "50.2k/1M (5%)"
+
+
+def test_format_footer_context_full_no_window_shows_used_only():
+    out = format_runtime_footer(
+        model="m",
+        context_tokens=50_247,
+        context_length=None,
+        cwd="",
+        fields=("context_full",),
+    )
+    assert out == "50.2k"
+
+
+def test_format_footer_context_full_no_data_dropped():
+    out = format_runtime_footer(
+        model="m",
+        context_tokens=0,
+        context_length=None,
+        cwd="",
+        fields=("context_full",),
+    )
+    assert out == ""
+
+
+def test_format_footer_aces_target_layout(monkeypatch, tmp_path):
+    # The exact footer Ace asked for — both counts humanized:
+    #   claude-bridge-f3/claude-opus-4-8 · 50.2k/1M (5%) · ~
+    monkeypatch.setenv("HOME", str(tmp_path))
+    out = format_runtime_footer(
+        model="claude-opus-4-8",
+        provider="claude-bridge-f3",
+        context_tokens=50_247,
+        context_length=1_000_000,
+        cwd=str(tmp_path),
+        fields=("provider_model", "context_full", "cwd"),
+    )
+    assert out == "claude-bridge-f3/claude-opus-4-8 · 50.2k/1M (5%) · ~"
+
+
+# ---------------------------------------------------------------------------
+# reasoning field
+# ---------------------------------------------------------------------------
+
+def test_format_footer_reasoning_renders_with_prefix():
+    out = format_runtime_footer(
+        model="m", context_tokens=0, context_length=None, cwd="",
+        reasoning="xhigh",
+        fields=("reasoning",),
+    )
+    assert out == "r:xhigh"
+
+
+def test_format_footer_reasoning_skipped_when_empty():
+    out = format_runtime_footer(
+        model="m", context_tokens=0, context_length=None, cwd="",
+        reasoning="",
+        fields=("reasoning",),
+    )
+    assert out == ""
+
+
+def test_build_footer_reasoning_resolved_from_config(monkeypatch, tmp_path):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    # agent.reasoning_effort is the canonical source /reasoning writes to
+    out = build_footer_line(
+        user_config={
+            "display": {"runtime_footer": {"enabled": True, "fields": ["reasoning"]}},
+            "agent": {"reasoning_effort": "high"},
+        },
+        platform_key="discord",
+        model="claude-opus-4-8",
+        provider="claude-bridge-f3",
+        context_tokens=0, context_length=None,
+        cwd="",
+    )
+    assert out == "r:high"
+
+
+def test_build_footer_reasoning_absent_config_drops_field(monkeypatch, tmp_path):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    out = build_footer_line(
+        user_config={"display": {"runtime_footer": {"enabled": True, "fields": ["reasoning"]}}},
+        platform_key="discord",
+        model="m",
+        context_tokens=0, context_length=None,
+        cwd="",
+    )
+    # no agent.reasoning_effort -> field silently dropped -> empty footer
+    assert out == ""
+
+
+def test_format_footer_full_layout_with_reasoning(monkeypatch, tmp_path):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    out = format_runtime_footer(
+        model="claude-opus-4-8",
+        provider="claude-bridge-f3",
+        context_tokens=50_247,
+        context_length=1_000_000,
+        cwd=str(tmp_path),
+        reasoning="xhigh",
+        fields=("provider_model", "context_full", "reasoning", "cwd"),
+    )
+    assert out == "claude-bridge-f3/claude-opus-4-8 · 50.2k/1M (5%) · r:xhigh · ~"
+
+
+# ---------------------------------------------------------------------------
 # resolve_footer_config
 # ---------------------------------------------------------------------------
 
 def test_resolve_defaults_off_empty_config():
     cfg = resolve_footer_config({}, "telegram")
-    assert cfg == {"enabled": False, "fields": ["model", "context_pct", "cwd"]}
+    assert cfg == {
+        "enabled": False,
+        "fields": ["provider_model", "context_full", "reasoning", "cwd"],
+    }
 
 
 def test_resolve_global_enable():
     user = {"display": {"runtime_footer": {"enabled": True}}}
     cfg = resolve_footer_config(user, "telegram")
     assert cfg["enabled"] is True
-    assert cfg["fields"] == ["model", "context_pct", "cwd"]
+    assert cfg["fields"] == ["provider_model", "context_full", "reasoning", "cwd"]
 
 
 def test_resolve_platform_override_wins():
@@ -189,7 +383,7 @@ def test_resolve_platform_can_add_fields_only():
     }
     tg = resolve_footer_config(user, "telegram")
     assert tg["enabled"] is True
-    assert tg["fields"] == ["model", "context_pct", "cwd"]
+    assert tg["fields"] == ["provider_model", "context_full", "reasoning", "cwd"]
     dc = resolve_footer_config(user, "discord")
     assert dc["enabled"] is True
     assert dc["fields"] == ["context_pct"]

--- a/tests/gateway/test_runtime_footer.py
+++ b/tests/gateway/test_runtime_footer.py
@@ -346,7 +346,7 @@ def test_resolve_defaults_off_empty_config():
     cfg = resolve_footer_config({}, "telegram")
     assert cfg == {
         "enabled": False,
-        "fields": ["provider_model", "context_full", "reasoning", "cwd"],
+        "fields": ["model", "context_pct", "cwd"],
     }
 
 
@@ -354,7 +354,7 @@ def test_resolve_global_enable():
     user = {"display": {"runtime_footer": {"enabled": True}}}
     cfg = resolve_footer_config(user, "telegram")
     assert cfg["enabled"] is True
-    assert cfg["fields"] == ["provider_model", "context_full", "reasoning", "cwd"]
+    assert cfg["fields"] == ["model", "context_pct", "cwd"]
 
 
 def test_resolve_platform_override_wins():
@@ -383,7 +383,7 @@ def test_resolve_platform_can_add_fields_only():
     }
     tg = resolve_footer_config(user, "telegram")
     assert tg["enabled"] is True
-    assert tg["fields"] == ["provider_model", "context_full", "reasoning", "cwd"]
+    assert tg["fields"] == ["model", "context_pct", "cwd"]
     dc = resolve_footer_config(user, "discord")
     assert dc["enabled"] is True
     assert dc["fields"] == ["context_pct"]
@@ -454,3 +454,148 @@ def test_build_footer_no_data_returns_empty_even_when_enabled():
     # With no TERMINAL_CWD env either
     if not os.environ.get("TERMINAL_CWD"):
         assert out == ""
+
+
+# ---------------------------------------------------------------------------
+# Byte-stability: the DEFAULT footer must render identically to pre-change main
+#
+# The three fields added here (provider_model, context_full, reasoning) are
+# opt-in — they are NOT in _DEFAULT_FIELDS.  A user who never touches
+# `display.runtime_footer.fields` must see the exact same bytes as before, so
+# no long-lived conversation's rendered text shifts under them.
+# ---------------------------------------------------------------------------
+
+# Frozen expectations captured from the pre-change implementation.
+_LEGACY_DEFAULT_FIELDS = ["model", "context_pct", "cwd"]
+
+
+def test_default_fields_unchanged():
+    """The default field set is exactly the pre-change one."""
+    from gateway.runtime_footer import _DEFAULT_FIELDS
+
+    assert list(_DEFAULT_FIELDS) == _LEGACY_DEFAULT_FIELDS
+
+
+def test_resolve_footer_config_default_fields_unchanged():
+    """An untouched config still resolves to the legacy default field set."""
+    assert resolve_footer_config({}, "telegram")["fields"] == _LEGACY_DEFAULT_FIELDS
+    assert resolve_footer_config(
+        {"display": {"runtime_footer": {"enabled": True}}}, "discord"
+    )["fields"] == _LEGACY_DEFAULT_FIELDS
+
+
+@pytest.mark.parametrize(
+    "model,tokens,window,cwd,expected",
+    [
+        ("openai/gpt-5.4", 50_247, 1_000_000, "/var/data", "gpt-5.4 · 5% · /var/data"),
+        ("claude-opus-4-8", 68_000, 100_000, "/var/data", "claude-opus-4-8 · 68% · /var/data"),
+        ("m", 0, None, "/var/data", "m · /var/data"),
+        ("", 10, 100, "/var/data", "10% · /var/data"),
+        ("m", 10, 100, "", "m · 10%"),
+    ],
+)
+def test_default_footer_renders_byte_identically(
+    monkeypatch, model, tokens, window, cwd, expected
+):
+    """Default-config footer output is byte-for-byte the pre-change string.
+
+    These expectations were produced by the implementation BEFORE the
+    provider_model/context_full/reasoning fields existed.  If any of them
+    shifts, an existing user's footer text changed — which this PR promises
+    it does not.
+    """
+    monkeypatch.delenv("TERMINAL_CWD", raising=False)
+    out = format_runtime_footer(
+        model=model,
+        context_tokens=tokens,
+        context_length=window,
+        cwd=cwd,
+        # NOTE: fields deliberately NOT passed — exercises the default.
+    )
+    assert out == expected
+
+
+def test_default_build_footer_line_ignores_new_data(monkeypatch):
+    """Supplying provider/reasoning changes nothing under the default fields."""
+    monkeypatch.delenv("TERMINAL_CWD", raising=False)
+    user = {
+        "display": {"runtime_footer": {"enabled": True}},
+        "agent": {"reasoning_effort": "xhigh"},
+    }
+    common = dict(
+        user_config=user,
+        platform_key="discord",
+        model="openai/gpt-5.4",
+        context_tokens=50_247,
+        context_length=1_000_000,
+        cwd="/var/data",
+    )
+    baseline = build_footer_line(**common)
+    enriched = build_footer_line(
+        **common, provider="claude-bridge-f3", reasoning="xhigh"
+    )
+    assert baseline == "gpt-5.4 · 5% · /var/data"
+    assert enriched == baseline
+
+
+# ---------------------------------------------------------------------------
+# reasoning — session-scoped override (review follow-up)
+# ---------------------------------------------------------------------------
+
+def test_reasoning_uses_caller_session_resolved_config():
+    """A session-scoped /reasoning override wins over the global config value.
+
+    gateway/run.py resolves the session's effective reasoning config and hands
+    it to build_footer_line; the footer must report THAT, not the stale global.
+    """
+    out = build_footer_line(
+        user_config={
+            "display": {"runtime_footer": {"enabled": True, "fields": ["reasoning"]}},
+            "agent": {"reasoning_effort": "low"},  # global says low
+        },
+        platform_key="discord",
+        model="claude-opus-4-8",
+        context_tokens=0, context_length=None,
+        cwd="",
+        # session said xhigh
+        reasoning_config={"enabled": True, "effort": "xhigh"},
+    )
+    assert out == "r:xhigh"
+
+
+def test_reasoning_session_disabled_renders_none():
+    """A session that disabled thinking reports `r:none`, not the global level."""
+    out = build_footer_line(
+        user_config={
+            "display": {"runtime_footer": {"enabled": True, "fields": ["reasoning"]}},
+            "agent": {"reasoning_effort": "high"},
+        },
+        platform_key="discord",
+        model="m",
+        context_tokens=0, context_length=None,
+        cwd="",
+        reasoning_config={"enabled": False},
+    )
+    assert out == "r:none"
+
+
+def test_reasoning_honors_per_model_override():
+    """Config resolution routes through resolve_reasoning_config.
+
+    `agent.reasoning_overrides.<model>` must beat the global effort, matching
+    what the agent itself runs.
+    """
+    out = build_footer_line(
+        user_config={
+            "display": {"runtime_footer": {"enabled": True, "fields": ["reasoning"]}},
+            "agent": {
+                "reasoning_effort": "low",
+                "reasoning_overrides": {"claude-opus-4-8": "xhigh"},
+            },
+        },
+        platform_key="discord",
+        model="claude-opus-4-8",
+        context_tokens=0, context_length=None,
+        cwd="",
+    )
+    assert out == "r:xhigh"

--- a/website/docs/reference/slash-commands.md
+++ b/website/docs/reference/slash-commands.md
@@ -79,7 +79,7 @@ Type `/` in the CLI to open the autocomplete menu. Built-in commands are case-in
 | `/battery [on\|off\|status]` | Toggle a color-coded battery read-out as the first status-bar element (off by default; no-op without a battery). |
 | `/voice [on\|off\|tts\|status]` | Toggle CLI voice mode and spoken playback. Recording uses `voice.record_key` (default: `Ctrl+B`). |
 | `/yolo` | Toggle YOLO mode — skip all dangerous command approval prompts. |
-| `/footer [on\|off\|status]` | Toggle the gateway runtime-metadata footer on final replies (shows model, context %, and cwd). |
+| `/footer [on\|off\|status]` | Toggle the gateway runtime-metadata footer on final replies (default fields: model, context %, and cwd; `display.runtime_footer.fields` can also select `provider_model`, `context_full`, and `reasoning`). |
 | `/busy [queue\|steer\|interrupt\|status]` | CLI-only: control what pressing Enter does while Hermes is working — queue the new message, steer mid-turn, or interrupt immediately. |
 | `/indicator [kaomoji\|emoji\|unicode\|ascii]` | CLI-only: pick the TUI busy-indicator style. |
 | `/timestamps [on\|off\|status]` | CLI-only: toggle `[HH:MM]` timestamps on messages and in `/history`. |

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -1589,21 +1589,40 @@ Tool progress requires a gateway adapter that can display progress updates safel
 
 ### Runtime-metadata footer (gateway only)
 
-When `display.runtime_footer.enabled: true`, Hermes appends a small runtime-context footer to the **final** message of each gateway turn. The current footer can show the model, context-window percentage, and current working directory. Off by default; opt in per-gateway if your team wants every reply to include this provenance.
+When `display.runtime_footer.enabled: true`, Hermes appends a small runtime-context footer to the **final** message of each gateway turn. Off by default; opt in per-gateway if your team wants every reply to include this provenance.
 
 ```yaml
 display:
   runtime_footer:
     enabled: true
-    fields: ["model", "context_pct", "cwd"]   # supported fields: model, context_pct, cwd
+    fields: ["model", "context_pct", "cwd"]   # order shown; drop any to hide
 ```
+
+Supported fields:
+
+| Field | Renders | Example |
+| --- | --- | --- |
+| `model` | Bare model id, vendor prefix dropped | `gpt-5.4` |
+| `provider_model` | `provider/model` — useful behind bridges/proxies/failover, where the same model is served by different providers | `claude-bridge-f3/claude-opus-4-8` |
+| `context_pct` | Last-call context occupancy as a percent | `5%` |
+| `context_full` | `used/window (pct)`, both humanized | `50.2k/1M (5%)` |
+| `reasoning` | Effective reasoning-effort level, `r:<level>` (honors a session-scoped `/reasoning`) | `r:xhigh` |
+| `cwd` | Home-relative working directory | `~` |
+
+The default field set is `["model", "context_pct", "cwd"]`. The other fields are opt-in — add them to `fields` to use them. Fields whose data is unavailable are skipped silently rather than rendering an empty slot.
 
 The `/footer` slash command toggles this at runtime in any session.
 
 Example footer appended to a Telegram/Discord/Slack reply:
 
 ```
-— claude-opus-4.7 · 12 tool calls · 2m 14s · $0.042
+gpt-5.4 · 5% · ~/projects/hermes
+```
+
+With `fields: [provider_model, context_full, reasoning, cwd]`:
+
+```
+claude-bridge-f3/claude-opus-4-8 · 50.2k/1M (5%) · r:xhigh · ~
 ```
 
 Only the **final** message of a turn gets the footer; interim updates stay clean.


### PR DESCRIPTION
## What

Adds three new optional fields to the opt-in gateway runtime footer (`/footer`), and makes them the default field set:

- **`provider_model`** — renders `provider/model` (e.g. `claude-bridge-f3/claude-opus-4-8`). When the provider is unset but the model string carries a `provider/model` prefix, it's split so the footer reads cleanly. Bare model with no provider renders just the model (no leading slash).
- **`context_full`** — renders `used/window (pct)` (e.g. `50.2k/1M (5%)`). The **used** count is the used and window both humanized (`50.2k/1M (5%)`).
- **`reasoning`** — renders the model's reasoning-effort level as `r:<level>` (e.g. `r:xhigh`), sourced from `agent.reasoning_effort` (the config key `/reasoning <level>` writes to). Skipped silently when unset.

New default field set: `[provider_model, context_full, reasoning, cwd]` (was `[model, context_pct, cwd]`). The original `model` and `context_pct` fields are unchanged and still selectable.

Example footer:
```
claude-bridge-f3/claude-opus-4-8 · 50.2k/1M (5%) · r:xhigh · ~
```

## Why

The footer previously showed only the bare model name and a context percentage. Surfacing the provider (useful behind bridges/proxies/failover where the same model is served by different providers), the absolute token occupancy alongside the percentage, and the active reasoning-effort level gives a far more useful at-a-glance runtime readout — at zero cost when disabled (footer is off by default).

## How

All in the existing footer machinery — no new config surface, no new core tool, no new env vars:

- `gateway/runtime_footer.py` — added `provider_model`, `context_full`, and `reasoning` field branches to `format_runtime_footer`; a `provider` and a `reasoning` kwarg threaded through `build_footer_line`; `_split_provider_model`, `_humanize_tok`, and `_reasoning_from_config` helpers. `format_runtime_footer` stays pure (explicit args); `build_footer_line` resolves `reasoning` from `agent.reasoning_effort` in the passed `user_config` when the caller doesn't supply it. Fields skip silently when their data is missing (no `?%`/empty-slot artifacts).
- `gateway/run.py` — pass `provider=agent_result.get("provider")` into `build_footer_line` (already present in `agent_result`). Reasoning needs no call-site change — it's config-sourced.
- `gateway/slash_commands.py` — keep the `/footer` toggle preview's fallback field list in sync with the new default.

## Config

```yaml
display:
  runtime_footer:
    enabled: true                                              # off by default
    fields: [provider_model, context_full, reasoning, cwd]     # order shown; drop any to hide
```

All behavioral settings stay in `config.yaml` — no new env vars.

## Tests

`tests/gateway/test_runtime_footer.py`: added per-field tests for `provider_model` (explicit / prefix-split / bare), `context_full` (full / no-window / no-data), `reasoning` (render / empty-skip / config-resolution / config-absent), `_split_provider_model`, `_humanize_tok`, and end-to-end tests reproducing the exact target footer strings. Updated the default-field assertions to the new default set. **49 passed** against the upstream base.
