### PR TITLE
fix(gateway): log MCP discovery failures at WARNING (#47509)

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -18339,7 +18339,7 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
         _loop = asyncio.get_running_loop()
         await _loop.run_in_executor(None, discover_mcp_tools)
     except Exception as e:
-        logger.debug("MCP tool discovery failed: %s", e)
+        logger.warning("MCP tool discovery failed: %s", e)
 
     # Start the gateway
     success = await runner.start()


### PR DESCRIPTION
Fixes #47509. Changes MCP tool discovery failure logging from debug to warning level so failures are visible at the default INFO log level instead of being silently swallowed.