### PR TITLE
fix(wecom): bound reconnect attempts and log retries

### DIFF
--- a/gateway/platforms/wecom.py
+++ b/gateway/platforms/wecom.py
@@ -92,6 +92,7 @@ CONNECT_TIMEOUT_SECONDS = 20.0
 REQUEST_TIMEOUT_SECONDS = 15.0
 HEARTBEAT_INTERVAL_SECONDS = 30.0
 RECONNECT_BACKOFF = [2, 5, 10, 30, 60]
+RECONNECT_ATTEMPT_TIMEOUT_SECONDS = CONNECT_TIMEOUT_SECONDS * 2
 
 DEDUP_MAX_SIZE = 1000
 
@@ -347,16 +348,40 @@ class WeComAdapter(BasePlatformAdapter):
                 self._fail_pending_responses(RuntimeError("WeCom connection interrupted"))
 
                 delay = RECONNECT_BACKOFF[min(backoff_idx, len(RECONNECT_BACKOFF) - 1)]
-                backoff_idx += 1
-                await asyncio.sleep(delay)
-
-                try:
-                    await self._open_connection()
+                attempt = backoff_idx + 1
+                if await self._reconnect_once(delay=delay, attempt=attempt):
                     backoff_idx = 0
-                    self._mark_connected()
-                    logger.info("[%s] Reconnected", self.name)
-                except Exception as reconnect_exc:
-                    logger.warning("[%s] Reconnect failed: %s", self.name, reconnect_exc)
+                else:
+                    backoff_idx += 1
+
+    async def _reconnect_once(self, *, delay: float, attempt: int) -> bool:
+        """Reconnect once with bounded timing and explicit observability."""
+        logger.info("[%s] Reconnecting in %ss (attempt %d)", self.name, delay, attempt)
+        await asyncio.sleep(delay)
+        if not self._running:
+            return False
+        try:
+            await asyncio.wait_for(
+                self._open_connection(),
+                timeout=RECONNECT_ATTEMPT_TIMEOUT_SECONDS,
+            )
+        except asyncio.CancelledError:
+            raise
+        except asyncio.TimeoutError:
+            logger.warning(
+                "[%s] Reconnect failed: timed out after %.1fs",
+                self.name,
+                RECONNECT_ATTEMPT_TIMEOUT_SECONDS,
+                exc_info=True,
+            )
+            return False
+        except Exception as reconnect_exc:
+            logger.warning("[%s] Reconnect failed: %s", self.name, reconnect_exc, exc_info=True)
+            return False
+
+        self._mark_connected()
+        logger.info("[%s] Reconnected", self.name)
+        return True
 
     async def _read_events(self) -> None:
         """Read websocket frames until the connection closes."""

--- a/tests/gateway/test_wecom.py
+++ b/tests/gateway/test_wecom.py
@@ -122,6 +122,47 @@ class TestWeComConnect:
         assert adapter.fatal_error_code == "wecom_connect_error"
         assert "invalid secret" in (adapter.fatal_error_message or "")
 
+    @pytest.mark.asyncio
+    async def test_reconnect_once_logs_attempt_and_success(self):
+        from gateway.platforms.wecom import WeComAdapter
+
+        adapter = WeComAdapter(PlatformConfig(enabled=True))
+        adapter._running = True
+        adapter._open_connection = AsyncMock()
+        adapter._mark_connected = MagicMock()
+
+        with patch("gateway.platforms.wecom.logger") as mock_logger:
+            success = await adapter._reconnect_once(delay=0, attempt=3)
+
+        assert success is True
+        adapter._open_connection.assert_awaited_once()
+        adapter._mark_connected.assert_called_once_with()
+        assert mock_logger.info.call_args_list[0].args == ("[%s] Reconnecting in %ss (attempt %d)", adapter.name, 0, 3)
+        assert mock_logger.info.call_args_list[1].args == ("[%s] Reconnected", adapter.name)
+
+    @pytest.mark.asyncio
+    async def test_reconnect_once_times_out_and_logs_warning(self, monkeypatch):
+        import gateway.platforms.wecom as wecom_module
+        from gateway.platforms.wecom import WeComAdapter
+
+        adapter = WeComAdapter(PlatformConfig(enabled=True))
+        adapter._running = True
+
+        async def _hang_forever():
+            await asyncio.sleep(1)
+
+        adapter._open_connection = _hang_forever
+
+        monkeypatch.setattr(wecom_module, "RECONNECT_ATTEMPT_TIMEOUT_SECONDS", 0.01)
+        with patch("gateway.platforms.wecom.logger") as mock_logger:
+            success = await adapter._reconnect_once(delay=0, attempt=1)
+
+        assert success is False
+        mock_logger.warning.assert_called_once()
+        warning_args = mock_logger.warning.call_args.args
+        assert warning_args[:3] == ("[%s] Reconnect failed: timed out after %.1fs", adapter.name, 0.01)
+        assert mock_logger.warning.call_args.kwargs["exc_info"] is True
+
 
 class TestWeComQrScan:
     @patch("gateway.platforms.wecom.time")


### PR DESCRIPTION
## Summary
- add a dedicated WeCom reconnect helper that logs each retry attempt before sleeping
- bound each reconnect attempt with an outer timeout so stalled reconnects become explicit warnings
- cover successful and timed-out reconnects in `tests/gateway/test_wecom.py`

## Testing
- pytest -q tests/gateway/test_wecom.py
- uv run --frozen ruff check gateway/platforms/wecom.py tests/gateway/test_wecom.py
- git diff --check

Fixes #47572