### PR TITLE
fix: prevent rollback from pruning the target snapshot before extraction

### DIFF
--- a/agent/curator_backup.py
+++ b/agent/curator_backup.py
@@ -208,13 +208,17 @@ def _write_manifest(dest: Path, reason: str, archive_path: Path,
     )
 
 
-def snapshot_skills(reason: str = "manual") -> Optional[Path]:
+def snapshot_skills(reason: str = "manual", *, prune: bool = True) -> Optional[Path]:
     """Create a tar.gz snapshot of ``~/.hermes/skills/`` and prune old ones.
 
     Returns the snapshot directory path, or ``None`` if the snapshot was
     skipped (backup disabled, skills dir missing, or an IO error occurred —
     in which case we log at debug and return None so the curator never
     aborts a pass because of a backup failure).
+
+    *prune* controls whether old snapshots are deleted according to the
+    ``keep`` limit.  Callers that need the snapshot set to remain stable
+    (e.g. ``rollback()`` taking a safety snapshot) should pass ``prune=False``.
     """
     if not is_enabled():
         logger.debug("Curator backup disabled by config; skipping snapshot")
@@ -276,7 +280,8 @@ def snapshot_skills(reason: str = "manual") -> Optional[Path]:
             pass
         return None
 
-    _prune_old(keep=get_keep())
+    if prune:
+        _prune_old(keep=get_keep())
     logger.info("Curator snapshot created: %s (%s)", snap_id, reason)
     return dest
 
@@ -564,7 +569,7 @@ def rollback(backup_id: Optional[str] = None) -> Tuple[bool, str, Optional[Path]
     # out before touching anything — otherwise a failed extract could leave
     # the user with no skills.
     try:
-        snapshot_skills(reason=f"pre-rollback to {target.name}")
+        snapshot_skills(reason=f"pre-rollback to {target.name}", prune=False)
     except Exception as e:
         return (False, f"pre-rollback safety snapshot failed: {e}", None)
 

--- a/tests/agent/test_curator_backup.py
+++ b/tests/agent/test_curator_backup.py
@@ -592,3 +592,33 @@ def test_restore_cron_skill_links_standalone(backup_env):
     assert report["restored"][0]["to"]["skills"] == ["narrow-a", "narrow-b"]
     assert len(report["skipped_missing"]) == 1
     assert report["skipped_missing"][0]["job_id"] == "job-gone"
+
+
+def test_rollback_oldest_snapshot_not_deleted(backup_env, monkeypatch):
+    """Regression for issue #47612: rolling back to the oldest snapshot
+    when the backup directory is already at the keep limit must NOT delete
+    that oldest snapshot. The safety snapshot taken inside rollback() should
+    not trigger a prune that removes the target snapshot before extraction."""
+    cb = backup_env["cb"]
+    skills = backup_env["skills"]
+    _write_skill(skills, "alpha")
+    monkeypatch.setattr(cb, "get_keep", lambda: 5)
+
+    # Create exactly 5 snapshots (the steady state at keep=5). All 5 exist.
+    ids = [f"2026-05-0{i}T00-00-00Z" for i in range(1, 6)]
+    for i, fid in enumerate(ids):
+        monkeypatch.setattr(cb, "_utc_id", lambda now=None, _f=fid: _f)
+        cb.snapshot_skills(reason=f"n{i}")
+
+    oldest_id = ids[0]  # 2026-05-01T00-00-00Z
+    assert cb._resolve_backup(oldest_id) is not None
+
+    # Rollback to the oldest snapshot
+    ok, msg, _ = cb.rollback(backup_id=oldest_id)
+    assert ok, f"rollback failed: {msg}"
+
+    # The oldest snapshot must still be present (prune should not have
+    # removed it before extraction).
+    assert cb._resolve_backup(oldest_id) is not None, (
+        f"oldest snapshot {oldest_id} was deleted during rollback"
+    )


### PR DESCRIPTION
Fixes NousResearch/hermes-agent#47612

## Problem

When `rollback()` takes a safety snapshot before extracting the target snapshot, it calls `snapshot_skills()`, which unconditionally prunes old snapshots according to the configured limit. If the backups directory is already at the keep limit (default 5), the safety snapshot is the newest one, so the oldest snapshot — which is the rollback target — falls outside the window and is deleted before it can be opened.

## Root Cause

In `rollback()`, the safety snapshot taken via `snapshot_skills()` ends by calling `_prune_old_snapshots()`. That prune keeps the newest snapshots and deletes the rest, with no awareness of the rollback target.

## Fix

Add an optional `prune` keyword argument to `snapshot_skills()` (defaults to `True` for backward compatibility). Pass `prune=False` from `rollback()` when taking the pre-rollback safety snapshot, so the existing snapshot set remains stable during the operation. After the rollback succeeds, normal pruning resumes on subsequent calls.

## Changes

- `agent/curator_backup.py`
  - `snapshot_skills()` — new `prune` parameter
  - `rollback()` — passes `prune=False` to the safety snapshot
- `tests/agent/test_curator_backup.py`
  - Added regression test `test_rollback_oldest_snapshot_not_deleted`

## Impact

Restoring any listed snapshot now succeeds and leaves that snapshot in place. Rollback no longer accidentally destroys the very snapshot it is trying to restore.
