### PR TITLE
fix(logging): elevate silent operational failures from DEBUG to WARNING

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -2945,7 +2945,7 @@ def run_job(
             job.get("id", "?"), _session_db_timeout,
         )
     except Exception as e:
-        logger.debug("Job '%s': SQLite session store not available: %s", job.get("id", "?"), e)
+        logger.warning("Job '%s': SQLite session store not available: %s", job.get("id", "?"), e)
 
     # Wake-gate: if this job has a pre-check script, run it BEFORE building
     # the prompt so a ``{"wakeAgent": false}`` response can short-circuit
@@ -3769,7 +3769,7 @@ def run_job(
                         _session_db, _final_cron_session_id, f"cron {job_id}"
                     )
             except (Exception, KeyboardInterrupt) as e:
-                logger.debug(
+                logger.warning(
                     "Job '%s': failed to set cron session title: %s", job_id, e
                 )
                 # Last-resort: never leave the session blank (#50535). Try the
@@ -3792,11 +3792,11 @@ def run_job(
                     _final_cron_session_id, "cron_complete"
                 )
             except (Exception, KeyboardInterrupt) as e:
-                logger.debug("Job '%s': failed to end session: %s", job_id, e)
+                logger.warning("Job '%s': failed to end session: %s", job_id, e)
             try:
                 _session_db.close()
             except (Exception, KeyboardInterrupt) as e:
-                logger.debug("Job '%s': failed to close SQLite session store: %s", job_id, e)
+                logger.warning("Job '%s': failed to close SQLite session store: %s", job_id, e)
         # Release subprocesses, terminal sandboxes, browser daemons, and the
         # main OpenAI/httpx client held by this ephemeral cron agent. Without
         # this, a gateway that ticks cron every N minutes leaks fds per job
@@ -3825,7 +3825,7 @@ def _teardown_cron_agent(agent, job_id: str) -> None:
         if agent is not None:
             agent.close()
     except (Exception, KeyboardInterrupt) as e:
-        logger.debug("Job '%s': failed to close agent resources: %s", job_id, e)
+        logger.warning("Job '%s': failed to close agent resources: %s", job_id, e)
     # Each cron run spins up a short-lived worker thread whose event loop
     # dies as soon as the ``ThreadPoolExecutor`` shuts down. Any async
     # httpx clients cached under that loop are now unusable — reap them
@@ -3834,7 +3834,7 @@ def _teardown_cron_agent(agent, job_id: str) -> None:
         from agent.auxiliary_client import cleanup_stale_async_clients
         cleanup_stale_async_clients()
     except Exception as e:
-        logger.debug("Job '%s': failed to reap stale auxiliary clients: %s", job_id, e)
+        logger.warning("Job '%s': failed to reap stale auxiliary clients: %s", job_id, e)
 
 
 def run_one_job(job: dict, *, adapters=None, loop=None, verbose: bool = False) -> bool:

--- a/gateway/channel_directory.py
+++ b/gateway/channel_directory.py
@@ -459,7 +459,7 @@ def _build_from_sessions_json(platform_name: str) -> List[Dict[str, str]]:
                 "thread_id": origin.get("thread_id"),
             })
     except Exception as e:
-        logger.debug("Channel directory: failed to read sessions for %s: %s", platform_name, e)
+        logger.warning("Channel directory: failed to read sessions for %s: %s", platform_name, e)
 
     return entries
 

--- a/gateway/config.py
+++ b/gateway/config.py
@@ -2659,7 +2659,7 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
                         ),
                     )
     except Exception as e:
-        logger.debug("Plugin platform enable pass failed: %s", e)
+        logger.warning("Plugin platform enable pass failed: %s", e)
 
     # Relay (generic connector-fronted platform, EXPERIMENTAL). Enabled when a
     # connector relay URL is configured via GATEWAY_RELAY_URL (env) or

--- a/gateway/memory_monitor.py
+++ b/gateway/memory_monitor.py
@@ -132,8 +132,8 @@ def _monitor_loop(stop_event: threading.Event, interval: float) -> None:
         try:
             log_memory_usage()
         except Exception as e:
-            # Never let the monitor crash the gateway; just log and carry on.
-            logger.debug("Memory monitor iteration failed: %s", e)
+            # Never let the monitor crash the gateway; log a warning so operators see it.
+            logger.warning("Memory monitor iteration failed: %s", e)
 
 
 def start_memory_monitoring(interval_seconds: float = 300.0) -> bool:

--- a/gateway/mirror.py
+++ b/gateway/mirror.py
@@ -200,7 +200,7 @@ def _append_to_sqlite(session_id: str, message: dict) -> None:
             content=message.get("content"),
         )
     except Exception as e:
-        logger.debug("Mirror SQLite write failed: %s", e)
+        logger.warning("Mirror SQLite write failed: %s", e)
     finally:
         if db is not None:
             db.close()

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -1913,7 +1913,7 @@ class APIServerAdapter(BasePlatformAdapter):
 
             return self._open_and_cache_session_db(get_hermes_home())
         except Exception as e:
-            logger.debug("SessionDB unavailable for API server: %s", e)
+            logger.warning("SessionDB unavailable for API server: %s", e)
             return None
 
     async def _ensure_session_db_async(self):
@@ -1943,7 +1943,7 @@ class APIServerAdapter(BasePlatformAdapter):
                     return cache[key]
                 return await asyncio.to_thread(self._open_and_cache_session_db, home)
         except Exception as e:
-            logger.debug("SessionDB unavailable for API server: %s", e)
+            logger.warning("SessionDB unavailable for API server: %s", e)
             return None
 
     # ------------------------------------------------------------------


### PR DESCRIPTION
Systematic pass through the gateway and cron subsystems to surface
genuine operational failures that were invisible at the default INFO
log level.  Each of these DEBUG calls indicated a real failure that
operators need to see:

**gateway/**
- `channel_directory`: session read failures (channels silently empty)
- `config`: plugin platform enable failures (config not applying)
- `memory_monitor`: monitoring iteration failures (silent degradation)
- `mirror`: SQLite write failures (data not persisted)
- `platforms/api_server`: SessionDB init failures (no session persistence)

**cron/**
- `scheduler`: SQLite store init failures, session title/end/close
  failures, agent resource close failures, auxiliary client reap
  failures — all previously invisible during scheduled job runs

None of these should crash the process, but all should be visible to
the operator so they can diagnose silent degradation.

Related: #47509 (same class of bug — MCP discovery failures at DEBUG)