### PR TITLE
fix(cli): skip bool coercion for string-typed config keys

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -6295,15 +6295,33 @@ def set_config_value(key: str, value: str):
     # _set_nested which preserves list-typed nodes; before #17876 the
     # inline navigation here silently overwrote lists with dicts.
 
-    # Convert value to appropriate type
-    if value.lower() in {'true', 'yes', 'on'}:
-        value = True
-    elif value.lower() in {'false', 'no', 'off'}:
-        value = False
-    elif value.isdigit():
-        value = int(value)
-    elif value.replace('.', '', 1).isdigit():
-        value = float(value)
+    # Convert value to appropriate type.
+    # Skip bool/int/float coercion when the target key's default value in
+    # DEFAULT_CONFIG is a string — otherwise tokens like ``off``/``on`` that
+    # are valid string enum members get silently rewritten as Python booleans.
+    # See: https://github.com/NousResearch/hermes-agent/issues/47515
+    _default_is_str = False
+    try:
+        _dk = DEFAULT_CONFIG
+        for _seg in key.split("."):
+            if isinstance(_dk, dict):
+                _dk = _dk.get(_seg)
+            else:
+                _dk = None
+                break
+        _default_is_str = isinstance(_dk, str)
+    except Exception:
+        pass
+
+    if not _default_is_str:
+        if value.lower() in {'true', 'yes', 'on'}:
+            value = True
+        elif value.lower() in {'false', 'no', 'off'}:
+            value = False
+        elif value.isdigit():
+            value = int(value)
+        elif value.replace('.', '', 1).isdigit():
+            value = float(value)
 
     _set_nested(user_config, key, value)
     


### PR DESCRIPTION
## Summary
- `hermes config set` silently coerced the literal strings `off`/`on`/`yes`/`no`/`true`/`false` to Python booleans regardless of the target key's type in `DEFAULT_CONFIG`.
- This corrupted any setting whose schema declares a string-typed enum containing one of those tokens — e.g. `hermes config set approvals.mode off` wrote `mode: false` instead of `mode: 'off'`.
- Fix: look up the key in `DEFAULT_CONFIG` before coercing; when the default value is a string, preserve the user's literal value as-is.

## Test Plan
- [ ] `hermes config set approvals.mode off` → verify `config.yaml` contains `mode: 'off'` (not `mode: false`)
- [ ] `hermes config set approvals.mode manual` → still works as string
- [ ] `hermes config set agent.max_turns 10` → still coerces to int
- [ ] `hermes config set some.new.bool.key true` → still coerces to bool (key not in DEFAULT_CONFIG)

Fixes #47515
