### PR TITLE
fix(curator): skip prune during rollback safety snapshot

### DIFF
--- a/agent/curator_backup.py
+++ b/agent/curator_backup.py
@@ -208,13 +208,17 @@ def _write_manifest(dest: Path, reason: str, archive_path: Path,
     )
 
 
-def snapshot_skills(reason: str = "manual") -> Optional[Path]:
+def snapshot_skills(reason: str = "manual", *, skip_prune: bool = False) -> Optional[Path]:
     """Create a tar.gz snapshot of ``~/.hermes/skills/`` and prune old ones.
 
     Returns the snapshot directory path, or ``None`` if the snapshot was
     skipped (backup disabled, skills dir missing, or an IO error occurred —
     in which case we log at debug and return None so the curator never
     aborts a pass because of a backup failure).
+
+    When *skip_prune* is True the post-snapshot prune step is skipped.
+    This is used by ``rollback()`` so the safety snapshot it takes before
+    restoring does not delete the very snapshot being restored.
     """
     if not is_enabled():
         logger.debug("Curator backup disabled by config; skipping snapshot")
@@ -276,7 +280,8 @@ def snapshot_skills(reason: str = "manual") -> Optional[Path]:
             pass
         return None
 
-    _prune_old(keep=get_keep())
+    if not skip_prune:
+        _prune_old(keep=get_keep())
     logger.info("Curator snapshot created: %s (%s)", snap_id, reason)
     return dest
 
@@ -564,7 +569,7 @@ def rollback(backup_id: Optional[str] = None) -> Tuple[bool, str, Optional[Path]
     # out before touching anything — otherwise a failed extract could leave
     # the user with no skills.
     try:
-        snapshot_skills(reason=f"pre-rollback to {target.name}")
+        snapshot_skills(reason=f"pre-rollback to {target.name}", skip_prune=True)
     except Exception as e:
         return (False, f"pre-rollback safety snapshot failed: {e}", None)
 

--- a/tests/agent/test_curator_backup.py
+++ b/tests/agent/test_curator_backup.py
@@ -592,3 +592,35 @@ def test_restore_cron_skill_links_standalone(backup_env):
     assert report["restored"][0]["to"]["skills"] == ["narrow-a", "narrow-b"]
     assert len(report["skipped_missing"]) == 1
     assert report["skipped_missing"][0]["job_id"] == "job-gone"
+
+
+def test_rollback_to_oldest_snapshot_at_keep_limit(backup_env, monkeypatch):
+    """Regression test for #47612: rollback to the oldest snapshot must
+    succeed even when the backups directory is at the keep limit.
+
+    Before the fix, the safety snapshot taken by rollback() triggered
+    _prune_old(), which deleted the very snapshot being restored.
+    """
+    cb = backup_env["cb"]
+    skills = backup_env["skills"]
+    keep = 3
+    monkeypatch.setattr(cb, "get_keep", lambda: keep)
+
+    # Create `keep` snapshots with distinct skills to fill to capacity.
+    ids = [f"2026-06-0{i+1}T00-00-00Z" for i in range(keep)]
+    for i, fid in enumerate(ids):
+        _write_skill(skills, f"skill-{i}")
+        monkeypatch.setattr(cb, "_utc_id", lambda now=None, _f=fid: _f)
+        cb.snapshot_skills(reason=f"snapshot-{i}")
+
+    # Verify we're at capacity
+    remaining = sorted(p.name for p in (skills / ".curator_backups").iterdir()
+                       if not p.name.startswith("."))
+    assert len(remaining) == keep, f"expected {keep} snapshots, got {remaining}"
+
+    # The oldest snapshot is the first one — rollback to it.
+    oldest_id = ids[0]
+    ok, msg, target = cb.rollback(backup_id=oldest_id)
+    assert ok, f"rollback to oldest snapshot failed: {msg}"
+    assert target is not None
+    assert target.name == oldest_id


### PR DESCRIPTION
## What does this PR do?

Fixes a bug where `hermes curator rollback` to the oldest snapshot fails and permanently deletes that snapshot. The safety snapshot taken before restoring triggers `_prune_old()`, which deletes the rollback target when the backups directory is at capacity.

## Related Issue

Fixes #47612

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/curator_backup.py`: Add `skip_prune` keyword parameter to `snapshot_skills()` and use it from `rollback()` so the safety snapshot does not trigger pruning of the target snapshot.
- `tests/agent/test_curator_backup.py`: Add regression test `test_rollback_to_oldest_snapshot_at_keep_limit` that reproduces the exact scenario (fill to keep limit, rollback to oldest → succeeds).

## How to Test

1. `python -m pytest tests/agent/test_curator_backup.py::test_rollback_to_oldest_snapshot_at_keep_limit -q` — regression test passes
2. `python -m pytest tests/agent/test_curator_backup.py -q` — all 26 tests pass (no regressions)
3. Manual: fill curator backups to keep limit, run `hermes curator rollback --id <oldest>`, verify it succeeds instead of failing with "snapshot extract failed"

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A (pure file/timestamp logic, OS-independent)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `agent/curator_backup.py` (`snapshot_skills`, `_prune_old`, `rollback`)
- Blast radius: LOW — `skip_prune` is keyword-only with default `False`, all existing callers unchanged
- Related patterns: `_prune_old` sorts snapshots lexicographically and deletes beyond `keep` count; the safety snapshot from `rollback()` was inadvertently pushing the count past the limit
