### PR TITLE
fix: support Outlook OAuth for Hermes email transport

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -1470,7 +1470,14 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
     email_pwd = os.getenv("EMAIL_PASSWORD")
     email_imap = os.getenv("EMAIL_IMAP_HOST")
     email_smtp = os.getenv("EMAIL_SMTP_HOST")
-    if all([email_addr, email_pwd, email_imap, email_smtp]):
+    email_auth_mode = (os.getenv("EMAIL_AUTH_MODE") or "").strip().lower()
+    email_oauth_ready = bool(
+        email_addr
+        and (os.getenv("MS_CLIENT_ID") or os.getenv("MSGRAPH_CLIENT_ID"))
+        and (os.getenv("MS_CLIENT_SECRET") or os.getenv("MSGRAPH_CLIENT_SECRET"))
+        and (os.getenv("MS_TENANT_ID") or os.getenv("MSGRAPH_TENANT_ID"))
+    )
+    if all([email_addr, email_pwd, email_imap, email_smtp]) or email_auth_mode == "outlook_oauth" or email_oauth_ready:
         if Platform.EMAIL not in config.platforms:
             config.platforms[Platform.EMAIL] = PlatformConfig()
         config.platforms[Platform.EMAIL].enabled = True
@@ -1479,6 +1486,8 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
             "imap_host": email_imap,
             "smtp_host": email_smtp,
         })
+        if email_auth_mode:
+            config.platforms[Platform.EMAIL].extra["auth_mode"] = email_auth_mode
     email_home = os.getenv("EMAIL_HOME_ADDRESS")
     if email_home and Platform.EMAIL in config.platforms:
         config.platforms[Platform.EMAIL].home_channel = HomeChannel(

--- a/gateway/config.py
+++ b/gateway/config.py
@@ -1471,13 +1471,22 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
     email_imap = os.getenv("EMAIL_IMAP_HOST")
     email_smtp = os.getenv("EMAIL_SMTP_HOST")
     email_auth_mode = (os.getenv("EMAIL_AUTH_MODE") or "").strip().lower()
-    email_oauth_ready = bool(
+    email_basic_ready = bool(all([email_addr, email_pwd, email_imap, email_smtp]))
+    email_oauth_creds_ready = bool(
         email_addr
         and (os.getenv("MS_CLIENT_ID") or os.getenv("MSGRAPH_CLIENT_ID"))
         and (os.getenv("MS_CLIENT_SECRET") or os.getenv("MSGRAPH_CLIENT_SECRET"))
         and (os.getenv("MS_TENANT_ID") or os.getenv("MSGRAPH_TENANT_ID"))
     )
-    if all([email_addr, email_pwd, email_imap, email_smtp]) or email_auth_mode == "outlook_oauth" or email_oauth_ready:
+    email_oauth_token_file = Path(os.path.expanduser(os.getenv("EMAIL_OAUTH_TOKEN_FILE", "~/.outlook-mcp-tokens.json")))
+    email_oauth_token_ready = email_oauth_token_file.exists()
+    email_oauth_ready = email_oauth_creds_ready and email_oauth_token_ready
+    email_oauth_auto_ready = (
+        email_oauth_ready
+        and not email_basic_ready
+        and (not (email_imap or email_smtp) or any(host and any(token in host.lower() for token in ("outlook", "office365", "office.com", "exchange", "hotmail", "live.com")) for host in (email_imap, email_smtp)))
+    )
+    if email_basic_ready or (email_auth_mode == "outlook_oauth" and email_oauth_ready) or email_oauth_auto_ready:
         if Platform.EMAIL not in config.platforms:
             config.platforms[Platform.EMAIL] = PlatformConfig()
         config.platforms[Platform.EMAIL].enabled = True

--- a/gateway/platforms/email.py
+++ b/gateway/platforms/email.py
@@ -2,36 +2,47 @@
 Email platform adapter for the Hermes gateway.
 
 Allows users to interact with Hermes by sending emails.
-Uses IMAP to receive and SMTP to send messages.
+
+Supported auth modes:
+    - basic IMAP + SMTP username/password
+    - Outlook OAuth (Graph-backed inbox polling + MIME sendMail)
 
 Environment variables:
+    EMAIL_AUTH_MODE     — "basic" or "outlook_oauth" (auto-detected when omitted)
     EMAIL_IMAP_HOST     — IMAP server host (e.g., imap.gmail.com)
     EMAIL_IMAP_PORT     — IMAP server port (default: 993)
     EMAIL_SMTP_HOST     — SMTP server host (e.g., smtp.gmail.com)
     EMAIL_SMTP_PORT     — SMTP server port (default: 587)
     EMAIL_ADDRESS       — Email address for the agent
     EMAIL_PASSWORD      — Email password or app-specific password
+    EMAIL_OAUTH_TOKEN_FILE — Outlook delegated token cache (default: ~/.outlook-mcp-tokens.json)
     EMAIL_POLL_INTERVAL — Seconds between mailbox checks (default: 15)
     EMAIL_ALLOWED_USERS — Comma-separated list of allowed sender addresses
 """
 
 import asyncio
+import base64
 import email as email_lib
 import imaplib
+import json
 import logging
 import os
 import re
 import smtplib
 import ssl
+import time
 import uuid
 from email.header import decode_header
+from email.mime.base import MIMEBase
 from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
-from email.mime.base import MIMEBase
 from email.utils import formatdate
 from email import encoders
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Mapping, Optional, Tuple
+from urllib.parse import quote
+
+import httpx
 
 from gateway.platforms.base import (
     BasePlatformAdapter,
@@ -64,6 +75,75 @@ MAX_MESSAGE_LENGTH = 50_000
 
 # Supported image extensions for inline detection
 _IMAGE_EXTS = {".jpg", ".jpeg", ".png", ".gif", ".webp"}
+_OUTLOOK_DEFAULT_TOKEN_FILE = "~/.outlook-mcp-tokens.json"
+_OUTLOOK_GRAPH_BASE_URL = "https://graph.microsoft.com/v1.0"
+_OUTLOOK_TOKEN_URL_TEMPLATE = "https://login.microsoftonline.com/{tenant}/oauth2/v2.0/token"
+_OUTLOOK_TOKEN_REFRESH_SKEW_SECONDS = 120
+
+
+def _get_ms_oauth_settings(environ: Optional[Mapping[str, str]] = None) -> Dict[str, str]:
+    env = environ if environ is not None else os.environ
+    return {
+        "tenant_id": (env.get("MS_TENANT_ID") or env.get("MSGRAPH_TENANT_ID") or "").strip(),
+        "client_id": (env.get("MS_CLIENT_ID") or env.get("MSGRAPH_CLIENT_ID") or "").strip(),
+        "client_secret": (env.get("MS_CLIENT_SECRET") or env.get("MSGRAPH_CLIENT_SECRET") or "").strip(),
+    }
+
+
+def _get_oauth_token_path(environ: Optional[Mapping[str, str]] = None) -> Path:
+    env = environ if environ is not None else os.environ
+    raw = (env.get("EMAIL_OAUTH_TOKEN_FILE") or _OUTLOOK_DEFAULT_TOKEN_FILE).strip()
+    return Path(os.path.expanduser(raw))
+
+
+def _looks_like_outlook_host(host: str) -> bool:
+    normalized = (host or "").strip().lower()
+    if not normalized:
+        return False
+    return any(
+        token in normalized
+        for token in (
+            "outlook",
+            "office365",
+            "office.com",
+            "exchange",
+            "hotmail",
+            "live.com",
+        )
+    )
+
+
+def _outlook_oauth_env_ready(environ: Optional[Mapping[str, str]] = None) -> bool:
+    env = environ if environ is not None else os.environ
+    address = (env.get("EMAIL_ADDRESS") or "").strip()
+    settings = _get_ms_oauth_settings(env)
+    return bool(address and settings["tenant_id"] and settings["client_id"] and settings["client_secret"])
+
+
+def _determine_email_auth_mode(environ: Optional[Mapping[str, str]] = None) -> str:
+    env = environ if environ is not None else os.environ
+    explicit = (env.get("EMAIL_AUTH_MODE") or "").strip().lower()
+    if explicit:
+        return explicit
+
+    if _outlook_oauth_env_ready(env):
+        token_path = _get_oauth_token_path(env)
+        imap_host = env.get("EMAIL_IMAP_HOST") or ""
+        smtp_host = env.get("EMAIL_SMTP_HOST") or ""
+        if token_path.exists() or _looks_like_outlook_host(imap_host) or _looks_like_outlook_host(smtp_host):
+            return "outlook_oauth"
+
+    return "basic"
+
+
+def _normalize_epoch_seconds(raw: Any) -> Optional[float]:
+    try:
+        value = float(raw)
+    except (TypeError, ValueError):
+        return None
+    if value > 1_000_000_000_000:
+        value /= 1000.0
+    return value
 
 def _send_imap_id(imap: "imaplib.IMAP4") -> None:
     """Send RFC 2971 IMAP ID command identifying this client.
@@ -101,13 +181,14 @@ def _is_automated_sender(address: str, headers: dict) -> bool:
     
 def check_email_requirements() -> bool:
     """Check if email platform dependencies are available."""
+    if _determine_email_auth_mode() == "outlook_oauth":
+        return _outlook_oauth_env_ready()
+
     addr = os.getenv("EMAIL_ADDRESS")
     pwd = os.getenv("EMAIL_PASSWORD")
     imap = os.getenv("EMAIL_IMAP_HOST")
     smtp = os.getenv("EMAIL_SMTP_HOST")
-    if not all([addr, pwd, imap, smtp]):
-        return False
-    return True
+    return bool(all([addr, pwd, imap, smtp]))
 
 
 def _decode_header_value(raw: str) -> str:
@@ -243,7 +324,7 @@ def _extract_attachments(
 
 
 class EmailAdapter(BasePlatformAdapter):
-    """Email gateway adapter using IMAP (receive) and SMTP (send)."""
+    """Email gateway adapter using IMAP/SMTP or Outlook OAuth."""
 
     def __init__(self, config: PlatformConfig):
         super().__init__(config, Platform.EMAIL)
@@ -255,6 +336,12 @@ class EmailAdapter(BasePlatformAdapter):
         self._smtp_host = os.getenv("EMAIL_SMTP_HOST", "")
         self._smtp_port = int(os.getenv("EMAIL_SMTP_PORT", "587"))
         self._poll_interval = int(os.getenv("EMAIL_POLL_INTERVAL", "15"))
+        self._auth_mode = _determine_email_auth_mode()
+        self._oauth_token_path = _get_oauth_token_path()
+        oauth_settings = _get_ms_oauth_settings()
+        self._ms_tenant_id = oauth_settings["tenant_id"]
+        self._ms_client_id = oauth_settings["client_id"]
+        self._ms_client_secret = oauth_settings["client_secret"]
 
         # Skip attachments — configured via config.yaml:
         #   platforms:
@@ -271,7 +358,168 @@ class EmailAdapter(BasePlatformAdapter):
         # Map chat_id (sender email) -> last subject + message-id for threading
         self._thread_context: Dict[str, Dict[str, str]] = {}
 
-        logger.info("[Email] Adapter initialized for %s", self._address)
+        logger.info("[Email] Adapter initialized for %s using auth mode=%s", self._address, self._auth_mode)
+
+    def _uses_outlook_oauth(self) -> bool:
+        return self._auth_mode == "outlook_oauth"
+
+    def _outlook_token_url(self) -> str:
+        return _OUTLOOK_TOKEN_URL_TEMPLATE.format(tenant=self._ms_tenant_id)
+
+    def _read_oauth_token_cache(self) -> Dict[str, Any]:
+        if not self._oauth_token_path.exists():
+            raise RuntimeError(
+                f"Outlook OAuth token file not found: {self._oauth_token_path}. "
+                "Authenticate the Outlook MCP first or set EMAIL_OAUTH_TOKEN_FILE."
+            )
+        try:
+            payload = json.loads(self._oauth_token_path.read_text())
+        except Exception as exc:  # noqa: BLE001
+            raise RuntimeError(
+                f"Failed to read Outlook OAuth token file {self._oauth_token_path}: {exc}"
+            ) from exc
+        if not isinstance(payload, dict):
+            raise RuntimeError(f"Outlook OAuth token file {self._oauth_token_path} did not contain a JSON object.")
+        return payload
+
+    def _write_oauth_token_cache(self, payload: Dict[str, Any]) -> None:
+        self._oauth_token_path.parent.mkdir(parents=True, exist_ok=True)
+        self._oauth_token_path.write_text(json.dumps(payload, indent=2, sort_keys=True))
+
+    async def _refresh_outlook_access_token(self, token_payload: Dict[str, Any]) -> Dict[str, Any]:
+        refresh_token = str(token_payload.get("refresh_token") or "").strip()
+        if not refresh_token:
+            raise RuntimeError(
+                f"Outlook OAuth token file {self._oauth_token_path} does not contain a refresh_token."
+            )
+
+        scope = str(
+            token_payload.get("scope")
+            or os.getenv("EMAIL_OAUTH_SCOPE")
+            or "offline_access Mail.Read Mail.Send User.Read"
+        ).strip()
+        form = {
+            "grant_type": "refresh_token",
+            "client_id": self._ms_client_id,
+            "client_secret": self._ms_client_secret,
+            "refresh_token": refresh_token,
+            "scope": scope,
+        }
+
+        async with httpx.AsyncClient(timeout=httpx.Timeout(30.0)) as client:
+            response = await client.post(self._outlook_token_url(), data=form)
+
+        if response.status_code >= 400:
+            detail = response.text.strip()
+            try:
+                detail = response.json().get("error_description") or response.json().get("error") or detail
+            except ValueError:
+                pass
+            raise RuntimeError(
+                f"Outlook OAuth token refresh failed with HTTP {response.status_code}: {detail}"
+            )
+
+        refreshed = response.json()
+        if not isinstance(refreshed, dict) or not refreshed.get("access_token"):
+            raise RuntimeError("Outlook OAuth token refresh response did not include an access_token.")
+
+        merged = dict(token_payload)
+        merged.update(refreshed)
+        expires_in = refreshed.get("expires_in") or token_payload.get("expires_in") or 3600
+        try:
+            expires_in_seconds = int(expires_in)
+        except (TypeError, ValueError):
+            expires_in_seconds = 3600
+        merged["expires_in"] = expires_in_seconds
+        merged["expires_at"] = int((time.time() + max(0, expires_in_seconds)) * 1000)
+        if not merged.get("refresh_token"):
+            merged["refresh_token"] = refresh_token
+        self._write_oauth_token_cache(merged)
+        return merged
+
+    async def _get_outlook_access_token(self, *, force_refresh: bool = False) -> str:
+        token_payload = self._read_oauth_token_cache()
+        expires_at = _normalize_epoch_seconds(token_payload.get("expires_at") or token_payload.get("expires_on"))
+        access_token = str(token_payload.get("access_token") or "").strip()
+        if (
+            not force_refresh
+            and access_token
+            and expires_at is not None
+            and expires_at > (time.time() + _OUTLOOK_TOKEN_REFRESH_SKEW_SECONDS)
+        ):
+            return access_token
+
+        refreshed = await self._refresh_outlook_access_token(token_payload)
+        access_token = str(refreshed.get("access_token") or "").strip()
+        if not access_token:
+            raise RuntimeError("Outlook OAuth refresh completed without an access token.")
+        return access_token
+
+    async def _outlook_graph_request(
+        self,
+        method: str,
+        path: str,
+        *,
+        params: Optional[Dict[str, Any]] = None,
+        headers: Optional[Dict[str, str]] = None,
+        json_body: Optional[Any] = None,
+        content: Optional[str] = None,
+        expected_statuses: Tuple[int, ...] = (200,),
+    ) -> httpx.Response:
+        url = path if path.startswith("http") else f"{_OUTLOOK_GRAPH_BASE_URL}/{path.lstrip('/')}"
+        last_error: Optional[str] = None
+
+        for force_refresh in (False, True):
+            token = await self._get_outlook_access_token(force_refresh=force_refresh)
+            request_headers = {
+                "Authorization": f"Bearer {token}",
+                "Accept": "application/json",
+                "User-Agent": "Hermes-Agent/email-outlook-oauth",
+            }
+            if headers:
+                request_headers.update(headers)
+
+            async with httpx.AsyncClient(timeout=httpx.Timeout(60.0)) as client:
+                response = await client.request(
+                    method,
+                    url,
+                    params=params,
+                    headers=request_headers,
+                    json=json_body,
+                    content=content,
+                )
+
+            if response.status_code in expected_statuses:
+                return response
+            if response.status_code == 401 and not force_refresh:
+                last_error = response.text.strip()
+                continue
+
+            detail = response.text.strip()
+            try:
+                payload = response.json()
+                if isinstance(payload, dict):
+                    error = payload.get("error")
+                    if isinstance(error, dict):
+                        detail = str(error.get("message") or error.get("code") or detail)
+            except ValueError:
+                pass
+            raise RuntimeError(
+                f"Outlook Graph request failed: {method} {url} -> HTTP {response.status_code}: {detail}"
+            )
+
+        raise RuntimeError(f"Outlook Graph request failed after token refresh: {last_error or 'unknown error'}")
+
+    async def _outlook_graph_json(self, method: str, path: str, **kwargs: Any) -> Dict[str, Any]:
+        response = await self._outlook_graph_request(method, path, **kwargs)
+        if not response.content:
+            return {}
+        payload = response.json()
+        if not isinstance(payload, dict):
+            raise RuntimeError(
+                f"Expected JSON object from Outlook Graph {method} {path}, got {type(payload).__name__}."
+            )
+        return payload
 
     def _trim_seen_uids(self) -> None:
         """Keep only the most recent UIDs to prevent unbounded memory growth.
@@ -294,7 +542,19 @@ class EmailAdapter(BasePlatformAdapter):
             self._seen_uids = set(list(self._seen_uids)[-self._seen_uids_max // 2:])
 
     async def connect(self) -> bool:
-        """Connect to the IMAP server and start polling for new messages."""
+        """Connect to the configured email backend and start polling."""
+        if self._uses_outlook_oauth():
+            try:
+                await self._connect_outlook_oauth()
+            except Exception as e:
+                logger.error("[Email] Outlook OAuth connection failed: %s", e)
+                return False
+
+            self._running = True
+            self._poll_task = asyncio.create_task(self._poll_loop())
+            print(f"[Email] Connected as {self._address} via Outlook OAuth")
+            return True
+
         try:
             # Test IMAP connection
             imap = imaplib.IMAP4_SSL(self._imap_host, self._imap_port, timeout=30)
@@ -330,6 +590,37 @@ class EmailAdapter(BasePlatformAdapter):
         print(f"[Email] Connected as {self._address}")
         return True
 
+    async def _connect_outlook_oauth(self) -> None:
+        profile = await self._outlook_graph_json(
+            "GET",
+            "/me",
+            expected_statuses=(200,),
+        )
+        mailbox = str(profile.get("mail") or profile.get("userPrincipalName") or "").strip().lower()
+        if mailbox and mailbox != self._address.lower():
+            logger.warning(
+                "[Email] Outlook OAuth token is for %s, but EMAIL_ADDRESS=%s",
+                mailbox,
+                self._address,
+            )
+
+        payload = await self._outlook_graph_json(
+            "GET",
+            "/me/mailFolders/inbox/messages",
+            params={
+                "$filter": "isRead eq false",
+                "$select": "id",
+                "$top": 200,
+            },
+            expected_statuses=(200,),
+        )
+        for item in payload.get("value", []) or []:
+            message_id = str(item.get("id") or "").strip()
+            if message_id:
+                self._seen_uids.add(message_id)
+        self._trim_seen_uids()
+        logger.info("[Email] Outlook OAuth connection test passed. %d existing unread messages skipped.", len(self._seen_uids))
+
     async def disconnect(self) -> None:
         """Stop polling and disconnect."""
         self._running = False
@@ -362,7 +653,14 @@ class EmailAdapter(BasePlatformAdapter):
             await self._dispatch_message(msg_data)
 
     def _fetch_new_messages(self) -> List[Dict[str, Any]]:
-        """Fetch new (unseen) messages from IMAP. Runs in executor thread."""
+        """Fetch new (unseen) messages. Runs in executor thread."""
+        if self._uses_outlook_oauth():
+            try:
+                return asyncio.run(self._fetch_new_messages_outlook_oauth())
+            except Exception as e:
+                logger.error("[Email] Outlook OAuth fetch error: %s", e)
+                return []
+
         results = []
         try:
             imap = imaplib.IMAP4_SSL(self._imap_host, self._imap_port, timeout=30)
@@ -427,6 +725,113 @@ class EmailAdapter(BasePlatformAdapter):
         except Exception as e:
             logger.error("[Email] IMAP fetch error: %s", e)
         return results
+
+    async def _fetch_new_messages_outlook_oauth(self) -> List[Dict[str, Any]]:
+        payload = await self._outlook_graph_json(
+            "GET",
+            "/me/mailFolders/inbox/messages",
+            params={
+                "$filter": "isRead eq false",
+                "$select": "id,subject,from,body,bodyPreview,internetMessageId,receivedDateTime,hasAttachments",
+                "$orderby": "receivedDateTime asc",
+                "$top": 25,
+            },
+            headers={"Prefer": 'outlook.body-content-type="text"'},
+            expected_statuses=(200,),
+        )
+        results: List[Dict[str, Any]] = []
+        for item in payload.get("value", []) or []:
+            uid = str(item.get("id") or "").strip()
+            if not uid or uid in self._seen_uids:
+                continue
+            self._seen_uids.add(uid)
+            if len(self._seen_uids) > self._seen_uids_max:
+                self._trim_seen_uids()
+
+            sender = item.get("from") or {}
+            email_address = ((sender.get("emailAddress") or {}) if isinstance(sender, dict) else {})
+            sender_addr = str(email_address.get("address") or "").strip().lower()
+            sender_name = str(email_address.get("name") or sender_addr).strip()
+            subject = str(item.get("subject") or "(no subject)")
+            message_id = str(item.get("internetMessageId") or uid)
+            msg_headers = {}
+            if _is_automated_sender(sender_addr, msg_headers):
+                logger.debug("[Email] Skipping automated sender: %s", sender_addr)
+                await self._mark_outlook_message_read(uid)
+                continue
+
+            body_obj = item.get("body") or {}
+            body = str(body_obj.get("content") or item.get("bodyPreview") or "")
+            attachments = []
+            if item.get("hasAttachments"):
+                attachments = await self._fetch_outlook_attachments(uid)
+
+            results.append({
+                "uid": uid,
+                "sender_addr": sender_addr,
+                "sender_name": sender_name,
+                "subject": subject,
+                "message_id": message_id,
+                "in_reply_to": "",
+                "body": body,
+                "attachments": attachments,
+                "date": str(item.get("receivedDateTime") or ""),
+            })
+            await self._mark_outlook_message_read(uid)
+        return results
+
+    async def _mark_outlook_message_read(self, message_id: str) -> None:
+        quoted_id = quote(message_id, safe="")
+        await self._outlook_graph_request(
+            "PATCH",
+            f"/me/messages/{quoted_id}",
+            json_body={"isRead": True},
+            expected_statuses=(200,),
+        )
+
+    async def _fetch_outlook_attachments(self, message_id: str) -> List[Dict[str, Any]]:
+        quoted_id = quote(message_id, safe="")
+        payload = await self._outlook_graph_json(
+            "GET",
+            f"/me/messages/{quoted_id}/attachments",
+            expected_statuses=(200,),
+        )
+        attachments: List[Dict[str, Any]] = []
+        for item in payload.get("value", []) or []:
+            if str(item.get("@odata.type") or "") != "#microsoft.graph.fileAttachment":
+                continue
+            filename = str(item.get("name") or "attachment.bin")
+            content_type = str(item.get("contentType") or "application/octet-stream")
+            content_b64 = str(item.get("contentBytes") or "")
+            if not content_b64:
+                continue
+            try:
+                raw = base64.b64decode(content_b64)
+            except Exception:
+                logger.debug("[Email] Skipping attachment with invalid base64: %s", filename)
+                continue
+            ext = Path(filename).suffix.lower()
+            if ext in _IMAGE_EXTS:
+                try:
+                    cached_path = cache_image_from_bytes(raw, ext)
+                except ValueError:
+                    logger.debug("[Email] Skipping invalid image attachment %s", filename)
+                    continue
+                attachments.append({
+                    "path": cached_path,
+                    "filename": filename,
+                    "type": "image",
+                    "media_type": content_type,
+                })
+            else:
+                cached_path = cache_document_from_bytes(raw, filename)
+                attachments.append({
+                    "path": cached_path,
+                    "filename": filename,
+                    "type": "document",
+                    "media_type": content_type,
+                })
+        return attachments
 
     async def _dispatch_message(self, msg_data: Dict[str, Any]) -> None:
         """Convert a fetched email into a MessageEvent and dispatch it."""
@@ -524,7 +929,7 @@ class EmailAdapter(BasePlatformAdapter):
         body: str,
         reply_to_msg_id: Optional[str] = None,
     ) -> str:
-        """Send an email via SMTP. Runs in executor thread."""
+        """Send an email via the configured transport. Runs in executor thread."""
         msg = MIMEMultipart()
         msg["From"] = self._address
         msg["To"] = to_addr
@@ -548,6 +953,11 @@ class EmailAdapter(BasePlatformAdapter):
 
         msg.attach(MIMEText(body, "plain", "utf-8"))
 
+        if self._uses_outlook_oauth():
+            asyncio.run(self._send_outlook_mime_message(msg))
+            logger.info("[Email] Sent Outlook OAuth reply to %s (subject: %s)", to_addr, subject)
+            return msg_id
+
         smtp = smtplib.SMTP(self._smtp_host, self._smtp_port, timeout=30)
         try:
             smtp.starttls(context=ssl.create_default_context())
@@ -561,6 +971,16 @@ class EmailAdapter(BasePlatformAdapter):
 
         logger.info("[Email] Sent reply to %s (subject: %s)", to_addr, subject)
         return msg_id
+
+    async def _send_outlook_mime_message(self, msg: Any) -> None:
+        raw_mime = base64.b64encode(msg.as_bytes()).decode("ascii")
+        await self._outlook_graph_request(
+            "POST",
+            "/me/sendMail",
+            headers={"Content-Type": "text/plain"},
+            content=raw_mime,
+            expected_statuses=(202,),
+        )
 
     async def send_typing(self, chat_id: str, metadata: Optional[Dict[str, Any]] = None) -> None:
         """Email has no typing indicator — no-op."""
@@ -635,7 +1055,7 @@ class EmailAdapter(BasePlatformAdapter):
         body: str,
         file_paths: List[str],
     ) -> str:
-        """Send an email with multiple file attachments via SMTP."""
+        """Send an email with multiple file attachments."""
         msg = MIMEMultipart()
         msg["From"] = self._address
         msg["To"] = to_addr
@@ -669,6 +1089,11 @@ class EmailAdapter(BasePlatformAdapter):
                     msg.attach(part)
             except Exception as e:
                 logger.warning("[Email] Failed to attach %s: %s", file_path, e)
+
+        if self._uses_outlook_oauth():
+            asyncio.run(self._send_outlook_mime_message(msg))
+            logger.info("[Email] Sent Outlook OAuth multi-attachment email to %s (%d files)", to_addr, len(file_paths))
+            return msg_id
 
         smtp = smtplib.SMTP(self._smtp_host, self._smtp_port, timeout=30)
         try:
@@ -716,7 +1141,7 @@ class EmailAdapter(BasePlatformAdapter):
         file_path: str,
         file_name: Optional[str] = None,
     ) -> str:
-        """Send an email with a file attachment via SMTP."""
+        """Send an email with a file attachment."""
         msg = MIMEMultipart()
         msg["From"] = self._address
         msg["To"] = to_addr
@@ -748,6 +1173,10 @@ class EmailAdapter(BasePlatformAdapter):
             encoders.encode_base64(part)
             part.add_header("Content-Disposition", f"attachment; filename={fname}")
             msg.attach(part)
+
+        if self._uses_outlook_oauth():
+            asyncio.run(self._send_outlook_mime_message(msg))
+            return msg_id
 
         smtp = smtplib.SMTP(self._smtp_host, self._smtp_port, timeout=30)
         try:

--- a/gateway/platforms/email.py
+++ b/gateway/platforms/email.py
@@ -120,17 +120,34 @@ def _outlook_oauth_env_ready(environ: Optional[Mapping[str, str]] = None) -> boo
     return bool(address and settings["tenant_id"] and settings["client_id"] and settings["client_secret"])
 
 
+def _basic_email_env_ready(environ: Optional[Mapping[str, str]] = None) -> bool:
+    env = environ if environ is not None else os.environ
+    return bool(
+        (env.get("EMAIL_ADDRESS") or "").strip()
+        and (env.get("EMAIL_PASSWORD") or "").strip()
+        and (env.get("EMAIL_IMAP_HOST") or "").strip()
+        and (env.get("EMAIL_SMTP_HOST") or "").strip()
+    )
+
+
 def _determine_email_auth_mode(environ: Optional[Mapping[str, str]] = None) -> str:
     env = environ if environ is not None else os.environ
     explicit = (env.get("EMAIL_AUTH_MODE") or "").strip().lower()
     if explicit:
         return explicit
 
+    if _basic_email_env_ready(env):
+        return "basic"
+
     if _outlook_oauth_env_ready(env):
         token_path = _get_oauth_token_path(env)
         imap_host = env.get("EMAIL_IMAP_HOST") or ""
         smtp_host = env.get("EMAIL_SMTP_HOST") or ""
-        if token_path.exists() or _looks_like_outlook_host(imap_host) or _looks_like_outlook_host(smtp_host):
+        if token_path.exists() and (
+            not (imap_host or smtp_host)
+            or _looks_like_outlook_host(imap_host)
+            or _looks_like_outlook_host(smtp_host)
+        ):
             return "outlook_oauth"
 
     return "basic"
@@ -182,13 +199,9 @@ def _is_automated_sender(address: str, headers: dict) -> bool:
 def check_email_requirements() -> bool:
     """Check if email platform dependencies are available."""
     if _determine_email_auth_mode() == "outlook_oauth":
-        return _outlook_oauth_env_ready()
+        return _outlook_oauth_env_ready() and _get_oauth_token_path().exists()
 
-    addr = os.getenv("EMAIL_ADDRESS")
-    pwd = os.getenv("EMAIL_PASSWORD")
-    imap = os.getenv("EMAIL_IMAP_HOST")
-    smtp = os.getenv("EMAIL_SMTP_HOST")
-    return bool(all([addr, pwd, imap, smtp]))
+    return _basic_email_env_ready()
 
 
 def _decode_header_value(raw: str) -> str:
@@ -384,7 +397,9 @@ class EmailAdapter(BasePlatformAdapter):
 
     def _write_oauth_token_cache(self, payload: Dict[str, Any]) -> None:
         self._oauth_token_path.parent.mkdir(parents=True, exist_ok=True)
-        self._oauth_token_path.write_text(json.dumps(payload, indent=2, sort_keys=True))
+        tmp_path = self._oauth_token_path.with_suffix(f"{self._oauth_token_path.suffix}.tmp")
+        tmp_path.write_text(json.dumps(payload, indent=2, sort_keys=True))
+        tmp_path.replace(self._oauth_token_path)
 
     async def _refresh_outlook_access_token(self, token_payload: Dict[str, Any]) -> Dict[str, Any]:
         refresh_token = str(token_payload.get("refresh_token") or "").strip()
@@ -650,7 +665,22 @@ class EmailAdapter(BasePlatformAdapter):
         loop = asyncio.get_running_loop()
         messages = await loop.run_in_executor(None, self._fetch_new_messages)
         for msg_data in messages:
-            await self._dispatch_message(msg_data)
+            try:
+                acknowledged = await self._dispatch_message(msg_data)
+            except Exception as e:
+                uid = msg_data.get("uid")
+                if uid in self._seen_uids:
+                    self._seen_uids.discard(uid)
+                logger.error("[Email] Dispatch failed for %s: %s", uid, e)
+                continue
+
+            if self._uses_outlook_oauth() and acknowledged:
+                uid = str(msg_data.get("uid") or "").strip()
+                if uid:
+                    try:
+                        await self._mark_outlook_message_read(uid)
+                    except Exception as e:
+                        logger.error("[Email] Failed to mark Outlook message read %s: %s", uid, e)
 
     def _fetch_new_messages(self) -> List[Dict[str, Any]]:
         """Fetch new (unseen) messages. Runs in executor thread."""
@@ -763,7 +793,7 @@ class EmailAdapter(BasePlatformAdapter):
             body_obj = item.get("body") or {}
             body = str(body_obj.get("content") or item.get("bodyPreview") or "")
             attachments = []
-            if item.get("hasAttachments"):
+            if item.get("hasAttachments") and not self._skip_attachments:
                 attachments = await self._fetch_outlook_attachments(uid)
 
             results.append({
@@ -777,7 +807,6 @@ class EmailAdapter(BasePlatformAdapter):
                 "attachments": attachments,
                 "date": str(item.get("receivedDateTime") or ""),
             })
-            await self._mark_outlook_message_read(uid)
         return results
 
     async def _mark_outlook_message_read(self, message_id: str) -> None:
@@ -833,18 +862,22 @@ class EmailAdapter(BasePlatformAdapter):
                 })
         return attachments
 
-    async def _dispatch_message(self, msg_data: Dict[str, Any]) -> None:
-        """Convert a fetched email into a MessageEvent and dispatch it."""
+    async def _dispatch_message(self, msg_data: Dict[str, Any]) -> bool:
+        """Convert a fetched email into a MessageEvent and dispatch it.
+
+        Returns True when the message was handled or intentionally dropped and can
+        be acknowledged upstream.
+        """
         sender_addr = msg_data["sender_addr"]
 
         # Skip self-messages
         if sender_addr == self._address.lower():
-            return
+            return True
 
         # Never reply to automated senders
         if _is_automated_sender(sender_addr, {}):
             logger.debug("[Email] Dropping automated sender at dispatch: %s", sender_addr)
-            return
+            return True
 
         # Skip senders not in EMAIL_ALLOWED_USERS — prevents the adapter
         # from creating a MessageEvent (and thus thread context) for senders
@@ -856,7 +889,7 @@ class EmailAdapter(BasePlatformAdapter):
             allowed = {addr.strip().lower() for addr in allowed_raw.split(",") if addr.strip()}
             if sender_addr.lower() not in allowed:
                 logger.debug("[Email] Dropping non-allowlisted sender at dispatch: %s", sender_addr)
-                return
+                return True
 
         subject = msg_data["subject"]
         body = msg_data["body"].strip()
@@ -904,6 +937,7 @@ class EmailAdapter(BasePlatformAdapter):
 
         logger.info("[Email] New message from %s: %s", sender_addr, subject)
         await self.handle_message(event)
+        return True
 
     async def send(
         self,

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -6945,7 +6945,7 @@ class GatewayRunner:
         elif platform == Platform.EMAIL:
             from gateway.platforms.email import EmailAdapter, check_email_requirements
             if not check_email_requirements():
-                logger.warning("Email: EMAIL_ADDRESS, EMAIL_PASSWORD, EMAIL_IMAP_HOST, or EMAIL_SMTP_HOST not set")
+                logger.warning("Email: missing required basic-auth env vars or Outlook OAuth settings")
                 return None
             return EmailAdapter(config)
 

--- a/tests/gateway/test_email.py
+++ b/tests/gateway/test_email.py
@@ -69,7 +69,8 @@ class TestConfigEnvOverrides(unittest.TestCase):
         "MS_CLIENT_SECRET": "client-secret",
         "MS_TENANT_ID": "tenant-id",
     }, clear=True)
-    def test_email_config_loaded_from_outlook_oauth_env(self):
+    @patch("pathlib.Path.exists", return_value=True)
+    def test_email_config_loaded_from_outlook_oauth_env(self, _mock_exists):
         from gateway.config import GatewayConfig, Platform, _apply_env_overrides
         config = GatewayConfig()
         _apply_env_overrides(config)
@@ -77,6 +78,20 @@ class TestConfigEnvOverrides(unittest.TestCase):
         self.assertTrue(config.platforms[Platform.EMAIL].enabled)
         self.assertEqual(config.platforms[Platform.EMAIL].extra["address"], "hermes@test.com")
         self.assertEqual(config.platforms[Platform.EMAIL].extra["auth_mode"], "outlook_oauth")
+
+    @patch.dict(os.environ, {
+        "EMAIL_ADDRESS": "hermes@test.com",
+        "EMAIL_AUTH_MODE": "outlook_oauth",
+        "MS_CLIENT_ID": "client-id",
+        "MS_CLIENT_SECRET": "client-secret",
+        "MS_TENANT_ID": "tenant-id",
+    }, clear=True)
+    @patch("pathlib.Path.exists", return_value=False)
+    def test_email_config_not_loaded_from_outlook_oauth_env_without_token_cache(self, _mock_exists):
+        from gateway.config import GatewayConfig, Platform, _apply_env_overrides
+        config = GatewayConfig()
+        _apply_env_overrides(config)
+        self.assertNotIn(Platform.EMAIL, config.platforms)
 
 class TestCheckRequirements(unittest.TestCase):
     """Verify check_email_requirements function."""
@@ -110,9 +125,22 @@ class TestCheckRequirements(unittest.TestCase):
         "MS_CLIENT_SECRET": "client-secret",
         "MS_TENANT_ID": "tenant-id",
     }, clear=True)
-    def test_requirements_met_outlook_oauth(self):
+    @patch("pathlib.Path.exists", return_value=True)
+    def test_requirements_met_outlook_oauth(self, _mock_exists):
         from gateway.platforms.email import check_email_requirements
         self.assertTrue(check_email_requirements())
+
+    @patch.dict(os.environ, {
+        "EMAIL_ADDRESS": "a@b.com",
+        "EMAIL_AUTH_MODE": "outlook_oauth",
+        "MS_CLIENT_ID": "client-id",
+        "MS_CLIENT_SECRET": "client-secret",
+        "MS_TENANT_ID": "tenant-id",
+    }, clear=True)
+    @patch("pathlib.Path.exists", return_value=False)
+    def test_requirements_not_met_outlook_oauth_without_token_cache(self, _mock_exists):
+        from gateway.platforms.email import check_email_requirements
+        self.assertFalse(check_email_requirements())
 
 
 class TestOutlookOAuthHelpers(unittest.TestCase):
@@ -129,6 +157,35 @@ class TestOutlookOAuthHelpers(unittest.TestCase):
     def test_determine_email_auth_mode_prefers_outlook_oauth(self, _mock_exists):
         from gateway.platforms.email import _determine_email_auth_mode
         self.assertEqual(_determine_email_auth_mode(), "outlook_oauth")
+
+    @patch.dict(os.environ, {
+        "EMAIL_ADDRESS": "hermes@outlook.com",
+        "EMAIL_PASSWORD": "pw",
+        "EMAIL_IMAP_HOST": "outlook.office365.com",
+        "EMAIL_SMTP_HOST": "smtp-mail.outlook.com",
+        "MS_CLIENT_ID": "client-id",
+        "MS_CLIENT_SECRET": "client-secret",
+        "MS_TENANT_ID": "tenant-id",
+        "EMAIL_OAUTH_TOKEN_FILE": "/tmp/outlook-token.json",
+    }, clear=True)
+    @patch("pathlib.Path.exists", return_value=True)
+    def test_determine_email_auth_mode_prefers_basic_when_basic_is_fully_configured(self, _mock_exists):
+        from gateway.platforms.email import _determine_email_auth_mode
+        self.assertEqual(_determine_email_auth_mode(), "basic")
+
+    @patch.dict(os.environ, {
+        "EMAIL_ADDRESS": "hermes@outlook.com",
+        "EMAIL_IMAP_HOST": "outlook.office365.com",
+        "EMAIL_SMTP_HOST": "smtp-mail.outlook.com",
+        "MS_CLIENT_ID": "client-id",
+        "MS_CLIENT_SECRET": "client-secret",
+        "MS_TENANT_ID": "tenant-id",
+        "EMAIL_OAUTH_TOKEN_FILE": "/tmp/outlook-token.json",
+    }, clear=True)
+    @patch("pathlib.Path.exists", return_value=False)
+    def test_determine_email_auth_mode_does_not_auto_select_outlook_oauth_without_token_cache(self, _mock_exists):
+        from gateway.platforms.email import _determine_email_auth_mode
+        self.assertEqual(_determine_email_auth_mode(), "basic")
 
 
 class TestHelperFunctions(unittest.TestCase):
@@ -923,6 +980,31 @@ class TestFetchNewMessages(unittest.TestCase):
             adapter = EmailAdapter(PlatformConfig(enabled=True))
         return adapter
 
+    def test_fetch_outlook_skips_attachment_download_when_configured(self):
+        import asyncio
+        adapter = self._make_adapter()
+        adapter._auth_mode = "outlook_oauth"
+        adapter._skip_attachments = True
+        adapter._outlook_graph_json = AsyncMock(return_value={
+            "value": [{
+                "id": "msg-1",
+                "subject": "Test",
+                "from": {"emailAddress": {"address": "user@test.com", "name": "User"}},
+                "body": {"content": "hello"},
+                "bodyPreview": "hello",
+                "internetMessageId": "<msg-1@test.com>",
+                "receivedDateTime": "2026-01-01T00:00:00Z",
+                "hasAttachments": True,
+            }]
+        })
+        adapter._fetch_outlook_attachments = AsyncMock(return_value=[{"path": "/tmp/should-not-load", "filename": "x.txt", "type": "document", "media_type": "text/plain"}])
+
+        results = asyncio.run(adapter._fetch_new_messages_outlook_oauth())
+
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0]["attachments"], [])
+        adapter._fetch_outlook_attachments.assert_not_awaited()
+
     def test_fetch_skips_seen_uids(self):
         """Already-seen UIDs should not be fetched again."""
         adapter = self._make_adapter()
@@ -1025,6 +1107,7 @@ class TestPollLoop(unittest.TestCase):
 
         async def mock_dispatch(msg_data):
             dispatched.append(msg_data)
+            return True
 
         adapter._dispatch_message = mock_dispatch
 
@@ -1049,6 +1132,33 @@ class TestPollLoop(unittest.TestCase):
 
         self.assertEqual(len(dispatched), 1)
         self.assertEqual(dispatched[0]["subject"], "Inbox Test")
+
+    def test_check_inbox_marks_outlook_messages_read_after_dispatch(self):
+        import asyncio
+        adapter = self._make_adapter()
+        adapter._auth_mode = "outlook_oauth"
+        adapter._fetch_new_messages = MagicMock(return_value=[{"uid": "outlook-1", "subject": "OAuth", "sender_addr": "user@test.com", "sender_name": "User", "message_id": "<oauth1@test.com>", "in_reply_to": "", "body": "hello", "attachments": [], "date": ""}])
+        adapter._dispatch_message = AsyncMock(return_value=True)
+        adapter._mark_outlook_message_read = AsyncMock()
+
+        asyncio.run(adapter._check_inbox())
+
+        adapter._dispatch_message.assert_awaited_once()
+        adapter._mark_outlook_message_read.assert_awaited_once_with("outlook-1")
+
+    def test_check_inbox_dispatch_failure_keeps_outlook_message_unacked_and_retryable(self):
+        import asyncio
+        adapter = self._make_adapter()
+        adapter._auth_mode = "outlook_oauth"
+        adapter._seen_uids = {"outlook-2"}
+        adapter._fetch_new_messages = MagicMock(return_value=[{"uid": "outlook-2", "subject": "OAuth", "sender_addr": "user@test.com", "sender_name": "User", "message_id": "<oauth2@test.com>", "in_reply_to": "", "body": "hello", "attachments": [], "date": ""}])
+        adapter._dispatch_message = AsyncMock(side_effect=RuntimeError("boom"))
+        adapter._mark_outlook_message_read = AsyncMock()
+
+        asyncio.run(adapter._check_inbox())
+
+        adapter._mark_outlook_message_read.assert_not_awaited()
+        self.assertNotIn("outlook-2", adapter._seen_uids)
 
 
 class TestSendEmailStandalone(unittest.TestCase):

--- a/tests/gateway/test_email.py
+++ b/tests/gateway/test_email.py
@@ -62,6 +62,22 @@ class TestConfigEnvOverrides(unittest.TestCase):
         _apply_env_overrides(config)
         self.assertNotIn(Platform.EMAIL, config.platforms)
 
+    @patch.dict(os.environ, {
+        "EMAIL_ADDRESS": "hermes@test.com",
+        "EMAIL_AUTH_MODE": "outlook_oauth",
+        "MS_CLIENT_ID": "client-id",
+        "MS_CLIENT_SECRET": "client-secret",
+        "MS_TENANT_ID": "tenant-id",
+    }, clear=True)
+    def test_email_config_loaded_from_outlook_oauth_env(self):
+        from gateway.config import GatewayConfig, Platform, _apply_env_overrides
+        config = GatewayConfig()
+        _apply_env_overrides(config)
+        self.assertIn(Platform.EMAIL, config.platforms)
+        self.assertTrue(config.platforms[Platform.EMAIL].enabled)
+        self.assertEqual(config.platforms[Platform.EMAIL].extra["address"], "hermes@test.com")
+        self.assertEqual(config.platforms[Platform.EMAIL].extra["auth_mode"], "outlook_oauth")
+
 class TestCheckRequirements(unittest.TestCase):
     """Verify check_email_requirements function."""
 
@@ -86,6 +102,33 @@ class TestCheckRequirements(unittest.TestCase):
     def test_requirements_empty_env(self):
         from gateway.platforms.email import check_email_requirements
         self.assertFalse(check_email_requirements())
+
+    @patch.dict(os.environ, {
+        "EMAIL_ADDRESS": "a@b.com",
+        "EMAIL_AUTH_MODE": "outlook_oauth",
+        "MS_CLIENT_ID": "client-id",
+        "MS_CLIENT_SECRET": "client-secret",
+        "MS_TENANT_ID": "tenant-id",
+    }, clear=True)
+    def test_requirements_met_outlook_oauth(self):
+        from gateway.platforms.email import check_email_requirements
+        self.assertTrue(check_email_requirements())
+
+
+class TestOutlookOAuthHelpers(unittest.TestCase):
+    @patch.dict(os.environ, {
+        "EMAIL_ADDRESS": "hermes@outlook.com",
+        "EMAIL_IMAP_HOST": "outlook.office365.com",
+        "EMAIL_SMTP_HOST": "smtp-mail.outlook.com",
+        "MS_CLIENT_ID": "client-id",
+        "MS_CLIENT_SECRET": "client-secret",
+        "MS_TENANT_ID": "tenant-id",
+        "EMAIL_OAUTH_TOKEN_FILE": "/tmp/outlook-token.json",
+    }, clear=True)
+    @patch("pathlib.Path.exists", return_value=True)
+    def test_determine_email_auth_mode_prefers_outlook_oauth(self, _mock_exists):
+        from gateway.platforms.email import _determine_email_auth_mode
+        self.assertEqual(_determine_email_auth_mode(), "outlook_oauth")
 
 
 class TestHelperFunctions(unittest.TestCase):
@@ -723,6 +766,68 @@ class TestSendMethods(unittest.TestCase):
         self.assertEqual(info["name"], "user@test.com")
         self.assertEqual(info["type"], "dm")
         self.assertEqual(info["subject"], "Test")
+
+
+class TestOutlookOAuthTransport(unittest.TestCase):
+    def _make_adapter(self):
+        from gateway.config import PlatformConfig
+        with patch.dict(os.environ, {
+            "EMAIL_ADDRESS": "hermes@outlook.com",
+            "EMAIL_AUTH_MODE": "outlook_oauth",
+            "MS_CLIENT_ID": "client-id",
+            "MS_CLIENT_SECRET": "client-secret",
+            "MS_TENANT_ID": "tenant-id",
+            "EMAIL_OAUTH_TOKEN_FILE": "/tmp/outlook-token.json",
+        }, clear=True):
+            from gateway.platforms.email import EmailAdapter
+            return EmailAdapter(PlatformConfig(enabled=True))
+
+    def test_send_uses_outlook_graph_mime(self):
+        import asyncio
+        adapter = self._make_adapter()
+
+        with patch.object(adapter, "_send_outlook_mime_message", AsyncMock(return_value=None)) as mock_send, \
+             patch("smtplib.SMTP") as mock_smtp:
+            result = asyncio.run(adapter.send("user@test.com", "Hello from Outlook OAuth!"))
+
+        self.assertTrue(result.success)
+        mock_send.assert_awaited_once()
+        mock_smtp.assert_not_called()
+
+    def test_connect_success_outlook_oauth(self):
+        import asyncio
+        adapter = self._make_adapter()
+        with patch.object(adapter, "_connect_outlook_oauth", AsyncMock(return_value=None)):
+            result = asyncio.run(adapter.connect())
+        self.assertTrue(result)
+        self.assertTrue(adapter._running)
+        adapter._running = False
+        if adapter._poll_task:
+            adapter._poll_task.cancel()
+
+    def test_fetch_new_messages_outlook_oauth(self):
+        import asyncio
+        adapter = self._make_adapter()
+        sample_payload = {
+            "value": [
+                {
+                    "id": "msg-1",
+                    "subject": "Hello",
+                    "from": {"emailAddress": {"address": "user@test.com", "name": "User"}},
+                    "body": {"content": "Body text"},
+                    "bodyPreview": "Body text",
+                    "internetMessageId": "<msg-1@test.com>",
+                    "receivedDateTime": "2026-06-16T00:00:00Z",
+                    "hasAttachments": False,
+                }
+            ]
+        }
+        with patch.object(adapter, "_outlook_graph_json", AsyncMock(return_value=sample_payload)), \
+             patch.object(adapter, "_mark_outlook_message_read", AsyncMock(return_value=None)):
+            results = asyncio.run(adapter._fetch_new_messages_outlook_oauth())
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0]["sender_addr"], "user@test.com")
+        self.assertEqual(results[0]["message_id"], "<msg-1@test.com>")
 
 
 class TestConnectDisconnect(unittest.TestCase):

--- a/tests/tools/test_send_message_tool.py
+++ b/tests/tools/test_send_message_tool.py
@@ -29,6 +29,7 @@ from gateway.config import Platform
 from tools.send_message_tool import (
     _is_telegram_thread_not_found,
     _parse_target_ref,
+    _send_email,
     _send_matrix_via_adapter,
     _send_signal,
     _send_telegram,
@@ -1345,6 +1346,38 @@ class TestEmailHomeChannelErrorHint:
                 )
             )
         assert "TELEGRAM_HOME_CHANNEL" in result["error"]
+
+
+class TestSendEmailTransportSelection:
+    def test_send_email_uses_outlook_oauth_path(self):
+        with patch.dict(os.environ, {
+            "EMAIL_ADDRESS": "hermes@outlook.com",
+            "EMAIL_AUTH_MODE": "outlook_oauth",
+            "MS_CLIENT_ID": "client-id",
+            "MS_CLIENT_SECRET": "client-secret",
+            "MS_TENANT_ID": "tenant-id",
+        }, clear=True), \
+            patch("gateway.platforms.email._get_oauth_token_path") as mock_token_path, \
+            patch("gateway.platforms.email.EmailAdapter._send_outlook_mime_message", new_callable=AsyncMock) as mock_send, \
+            patch("smtplib.SMTP") as mock_smtp:
+            mock_token_path.return_value.exists.return_value = True
+            result = asyncio.run(_send_email({"auth_mode": "outlook_oauth"}, "user@test.com", "hello"))
+
+        assert result["success"] is True
+        mock_send.assert_awaited_once()
+        mock_smtp.assert_not_called()
+
+    def test_send_email_outlook_oauth_missing_config_returns_error(self):
+        with patch.dict(os.environ, {
+            "EMAIL_ADDRESS": "hermes@outlook.com",
+            "EMAIL_AUTH_MODE": "outlook_oauth",
+        }, clear=True), \
+            patch("gateway.platforms.email._get_oauth_token_path") as mock_token_path:
+            mock_token_path.return_value.exists.return_value = False
+            result = asyncio.run(_send_email({"auth_mode": "outlook_oauth"}, "user@test.com", "hello"))
+
+        assert "error" in result
+        assert "Outlook OAuth" in result["error"]
 
 
 class TestSendDiscordThreadId:

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -1296,20 +1296,25 @@ async def _send_signal(extra, chat_id, message, media_files=None):
 
 
 async def _send_email(extra, chat_id, message):
-    """Send via SMTP (one-shot, no persistent connection needed)."""
+    """Send via the configured email transport."""
     import smtplib
     from email.mime.text import MIMEText
+    from gateway.config import PlatformConfig
+    from gateway.platforms.email import (
+        _determine_email_auth_mode,
+        _get_ms_oauth_settings,
+        _get_oauth_token_path,
+        EmailAdapter,
+    )
 
     address = extra.get("address") or os.getenv("EMAIL_ADDRESS", "")
     password = os.getenv("EMAIL_PASSWORD", "")
     smtp_host = extra.get("smtp_host") or os.getenv("EMAIL_SMTP_HOST", "")
+    auth_mode = (extra.get("auth_mode") or _determine_email_auth_mode()).strip().lower()
     try:
         smtp_port = int(os.getenv("EMAIL_SMTP_PORT", "587"))
     except (ValueError, TypeError):
         smtp_port = 587
-
-    if not all([address, password, smtp_host]):
-        return {"error": "Email not configured (EMAIL_ADDRESS, EMAIL_PASSWORD, EMAIL_SMTP_HOST required)"}
 
     try:
         msg = MIMEText(message, "plain", "utf-8")
@@ -1317,6 +1322,19 @@ async def _send_email(extra, chat_id, message):
         msg["To"] = chat_id
         msg["Subject"] = "Hermes Agent"
         msg["Date"] = formatdate(localtime=True)
+
+        if auth_mode == "outlook_oauth":
+            settings = _get_ms_oauth_settings()
+            token_path = _get_oauth_token_path()
+            if not address or not settings["tenant_id"] or not settings["client_id"] or not settings["client_secret"] or not token_path.exists():
+                return {"error": "Email not configured for Outlook OAuth (EMAIL_ADDRESS, MS_CLIENT_ID, MS_CLIENT_SECRET, MS_TENANT_ID, token cache required)"}
+
+            adapter = EmailAdapter(PlatformConfig(enabled=True, extra={"auth_mode": "outlook_oauth"}))
+            await adapter._send_outlook_mime_message(msg)
+            return {"success": True, "platform": "email", "chat_id": chat_id}
+
+        if not all([address, password, smtp_host]):
+            return {"error": "Email not configured (EMAIL_ADDRESS, EMAIL_PASSWORD, EMAIL_SMTP_HOST required)"}
 
         server = smtplib.SMTP(smtp_host, smtp_port)
         server.starttls(context=ssl.create_default_context())


### PR DESCRIPTION
## Summary
- add Outlook OAuth/Graph support to Hermes email transport for inbox polling and MIME send
- route the one-shot `send_message` email path through the same Outlook OAuth transport instead of failing on Outlook SMTP basic auth
- tighten Outlook OAuth activation/readiness checks so the email platform only enables when the OAuth env is actually usable
- harden polling semantics by marking Outlook messages read only after successful dispatch
- make the Outlook path honor `skip_attachments`
- add regression coverage for config loading, auth-mode selection, send-path routing, polling ack behavior, retryability, and attachment skipping

## Verification
- `pytest -q /usr/local/lib/hermes-agent/tests/gateway/test_email.py /usr/local/lib/hermes-agent/tests/tools/test_send_message_tool.py`
  - `207 passed in 3.54s`
- `python -m py_compile /usr/local/lib/hermes-agent/gateway/platforms/email.py /usr/local/lib/hermes-agent/gateway/config.py /usr/local/lib/hermes-agent/tools/send_message_tool.py /usr/local/lib/hermes-agent/tests/gateway/test_email.py /usr/local/lib/hermes-agent/tests/tools/test_send_message_tool.py`
- live Outlook OAuth gateway send succeeded and was confirmed via Outlook/Graph readback
- live one-shot `send_message` email send succeeded after the tool-path patch and remained successful after cleanup hardening

## Context
Before this change, Outlook basic auth failure on the one-shot email path was reproducible (`5.7.139 Authentication unsuccessful, basic authentication is disabled`). This PR moves Outlook sends onto the OAuth/Graph path and aligns runtime behavior across the gateway adapter and one-shot transport.

## Notes
- no credentials or token contents are included
- the implementation reuses the existing local Outlook token cache instead of introducing a separate token lifecycle
