### PR TITLE
fix(cli): kill venv python processes before venv recreation on Windows

### DIFF
--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -1438,6 +1438,17 @@ function Install-Venv {
             $myPid = $PID
             Write-Info "Stopping any running hermes processes before recreating venv..."
             & taskkill /F /T /IM hermes.exe /FI "PID ne $myPid" 2>$null | Out-Null
+            # Also kill python.exe / pythonw.exe processes running from inside
+            # this venv — they hold .pyd native extensions as loaded DLLs which
+            # Windows locks, causing Remove-Item to fail with "The directory is
+            # not empty".  See: https://github.com/NousResearch/hermes-agent/issues/47557
+            $venvScripts = Join-Path $InstallDir "venv\Scripts"
+            Get-Process -Name "python","pythonw" -ErrorAction SilentlyContinue |
+                Where-Object { $_.Path -and $_.Path.StartsWith($venvScripts) } |
+                ForEach-Object {
+                    Write-Info "Stopping $($_.ProcessName) (PID $($_.Id)) from old venv..."
+                    Stop-Process -Id $_.Id -Force -ErrorAction SilentlyContinue
+                }
             Start-Sleep -Milliseconds 800
         }
         Remove-Item -Recurse -Force "venv"


### PR DESCRIPTION
## Summary
`scripts/install.ps1` only kills `hermes.exe` before deleting the old venv during recreation. However, `python.exe` / `pythonw.exe` processes running from inside the same venv also hold `.pyd` native extensions as loaded DLLs. Windows locks those DLLs, causing `Remove-Item -Recurse -Force "venv"` to fail with "The directory is not empty".

## Fix
Add a `Get-Process` scan that finds `python`/`pythonw` processes whose executable path starts with the venv `Scripts` directory, and stops them before attempting deletion.

## Test Plan
- [ ] On Windows, start a gateway (which spawns `pythonw.exe` from the venv)
- [ ] Run `hermes update` (or the bootstrap installer)
- [ ] Verify the venv recreation succeeds without "The directory is not empty" error
- [ ] Verify unrelated Python processes (not from the venv) are not killed

Fixes #47557
