### PR TITLE
fix(wecom): improve reconnection logging with attempt counts (#47572)

### DIFF
--- a/gateway/platforms/wecom.py
+++ b/gateway/platforms/wecom.py
@@ -340,15 +340,16 @@ class WeComAdapter(BasePlatformAdapter):
 
                 delay = RECONNECT_BACKOFF[min(backoff_idx, len(RECONNECT_BACKOFF) - 1)]
                 backoff_idx += 1
+                logger.info("[%s] Reconnecting in %ds (attempt %d)...", self.name, delay, backoff_idx)
                 await asyncio.sleep(delay)
 
                 try:
                     await self._open_connection()
                     backoff_idx = 0
                     self._mark_connected()
-                    logger.info("[%s] Reconnected", self.name)
+                    logger.info("[%s] Reconnected successfully", self.name)
                 except Exception as reconnect_exc:
-                    logger.warning("[%s] Reconnect failed: %s", self.name, reconnect_exc)
+                    logger.warning("[%s] Reconnect attempt %d failed: %s", self.name, backoff_idx, reconnect_exc)
 
     async def _read_events(self) -> None:
         """Read websocket frames until the connection closes."""


### PR DESCRIPTION
Fixes #47572. WeCom WebSocket reconnection now logs the backoff delay and attempt number before sleeping, and includes the attempt count in failure messages. This makes reconnection state visible in logs instead of appearing as silent gaps.