### PR TITLE
fix(gateway): log MCP discovery failures at WARNING instead of DEBUG

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -16915,8 +16915,9 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
         from tools.mcp_tool import discover_mcp_tools
         _loop = asyncio.get_running_loop()
         await _loop.run_in_executor(None, discover_mcp_tools)
+        logger.info("MCP tool discovery completed successfully")
     except Exception as e:
-        logger.debug("MCP tool discovery failed: %s", e)
+        logger.warning("MCP tool discovery failed: %s", e)
 
     # Start the gateway
     success = await runner.start()


### PR DESCRIPTION
## Summary
When `discover_mcp_tools()` fails (missing `mcp` package, config parse error, connection timeout), the gateway starts with zero MCP tools registered and the operator has NO indication anything went wrong — the failure was logged at `logger.debug()` which is invisible at the default INFO level.

Change the failure log to `logger.warning()` and add a success log at `logger.info()` so operators can see MCP tool discovery status in gateway logs.

## Test Plan
- [ ] Configure `mcp_servers` in config.yaml but do NOT install the `mcp` package
- [ ] Start the gateway
- [ ] Verify gateway.log shows a WARNING about MCP tool discovery failure
- [ ] With `mcp` installed: verify gateway.log shows INFO about successful discovery

Fixes #47509
