### PR TITLE
fix(desktop): clean profile dialog backend errors

### DIFF
--- a/apps/desktop/src/app/profiles/create-profile-dialog.tsx
+++ b/apps/desktop/src/app/profiles/create-profile-dialog.tsx
@@ -8,15 +8,11 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@
 import { Textarea } from '@/components/ui/textarea'
 import { createProfile, updateProfileSoul } from '@/hermes'
 import { useI18n } from '@/i18n'
+import { formatBackendError } from '@/lib/format-error'
 import { AlertTriangle } from '@/lib/icons'
+import { isValidProfileName, profileNameHint } from '@/lib/profile-names'
 import { cn } from '@/lib/utils'
 import type { ProfileInfo } from '@/types/hermes'
-
-const PROFILE_NAME_RE = /^[a-z0-9][a-z0-9_-]{0,63}$/
-
-export function isValidProfileName(name: string): boolean {
-  return PROFILE_NAME_RE.test(name.trim())
-}
 
 // Self-contained create flow (name + clone toggle + optional SOUL.md). Owns the
 // createProfile/updateProfileSoul calls so every caller just refreshes/selects
@@ -54,13 +50,14 @@ export function CreateProfileDialog({
 
   const trimmed = name.trim()
   const invalid = trimmed !== '' && !isValidProfileName(trimmed)
+  const nameHelp = profileNameHint(trimmed, p)
   const busy = status === 'saving' || status === 'done'
 
   async function handleSubmit(event: React.FormEvent) {
     event.preventDefault()
 
     if (!trimmed || invalid) {
-      setError(invalid ? p.invalidName(p.nameHint) : p.nameRequired)
+      setError(invalid ? p.invalidName(nameHelp) : p.nameRequired)
 
       return
     }
@@ -80,7 +77,7 @@ export function CreateProfileDialog({
       window.setTimeout(onClose, 800)
     } catch (err) {
       setStatus('idle')
-      setError(err instanceof Error ? err.message : p.failedCreate)
+      setError(formatBackendError(err, p.failedCreate))
     }
   }
 
@@ -106,7 +103,7 @@ export function CreateProfileDialog({
               value={name}
             />
             <p className={cn('text-[0.66rem] leading-4', invalid ? 'text-destructive' : 'text-muted-foreground')}>
-              {p.nameHint}
+              {nameHelp}
             </p>
           </div>
 

--- a/apps/desktop/src/app/profiles/index.tsx
+++ b/apps/desktop/src/app/profiles/index.tsx
@@ -25,19 +25,15 @@ import {
   updateProfileSoul
 } from '@/hermes'
 import { useI18n } from '@/i18n'
+import { formatBackendError } from '@/lib/format-error'
 import { AlertTriangle, Pencil, Save, Terminal, Trash2, Users } from '@/lib/icons'
+import { isValidProfileName, profileNameHint } from '@/lib/profile-names'
 import { cn } from '@/lib/utils'
 import { notify, notifyError } from '@/store/notifications'
 
 import { useRefreshHotkey } from '../hooks/use-refresh-hotkey'
 import { OverlayMain, OverlayNewButton, OverlaySidebar, OverlaySplitLayout } from '../overlays/overlay-split-layout'
 import { OverlayView } from '../overlays/overlay-view'
-
-const PROFILE_NAME_RE = /^[a-z0-9][a-z0-9_-]{0,63}$/
-
-function isValidProfileName(name: string): boolean {
-  return PROFILE_NAME_RE.test(name.trim())
-}
 
 interface ProfilesViewProps {
   onClose: () => void
@@ -87,7 +83,7 @@ export function ProfilesView({ onClose }: ProfilesViewProps) {
       const trimmed = name.trim()
 
       if (!isValidProfileName(trimmed)) {
-        throw new Error(p.nameHint)
+        throw new Error(profileNameHint(trimmed, p))
       }
 
       await createProfile({ name: trimmed, clone_from: cloneFrom })
@@ -107,7 +103,7 @@ export function ProfilesView({ onClose }: ProfilesViewProps) {
       }
 
       if (!isValidProfileName(target)) {
-        throw new Error(p.nameHint)
+        throw new Error(profileNameHint(target, p))
       }
 
       await renameProfile(from, target)
@@ -483,12 +479,13 @@ function CreateProfileDialog({
 
   const trimmed = name.trim()
   const invalid = trimmed !== '' && !isValidProfileName(trimmed)
+  const nameHelp = profileNameHint(trimmed, p)
 
   async function handleSubmit(event: React.FormEvent) {
     event.preventDefault()
 
     if (!trimmed || invalid) {
-      setError(invalid ? p.invalidName(p.nameHint) : p.nameRequired)
+      setError(invalid ? p.invalidName(nameHelp) : p.nameRequired)
 
       return
     }
@@ -500,7 +497,7 @@ function CreateProfileDialog({
       await onCreate(trimmed, cloneFrom)
       onClose()
     } catch (err) {
-      setError(err instanceof Error ? err.message : p.failedCreate)
+      setError(formatBackendError(err, p.failedCreate))
     } finally {
       setSaving(false)
     }
@@ -528,7 +525,7 @@ function CreateProfileDialog({
               value={name}
             />
             <p className={cn('text-[0.66rem] leading-4', invalid ? 'text-destructive' : 'text-muted-foreground')}>
-              {p.nameHint}
+              {nameHelp}
             </p>
           </div>
 
@@ -603,6 +600,7 @@ function RenameProfileDialog({
   const trimmed = name.trim()
   const unchanged = trimmed === currentName
   const invalid = trimmed !== '' && !unchanged && !isValidProfileName(trimmed)
+  const nameHelp = profileNameHint(trimmed, p)
 
   async function handleSubmit(event: React.FormEvent) {
     event.preventDefault()
@@ -614,7 +612,7 @@ function RenameProfileDialog({
     }
 
     if (!trimmed || invalid) {
-      setError(invalid ? p.invalidName(p.nameHint) : p.nameRequired)
+      setError(invalid ? p.invalidName(nameHelp) : p.nameRequired)
 
       return
     }
@@ -625,7 +623,7 @@ function RenameProfileDialog({
     try {
       await onRename(trimmed)
     } catch (err) {
-      setError(err instanceof Error ? err.message : p.failedRename)
+      setError(formatBackendError(err, p.failedRename))
     } finally {
       setSaving(false)
     }
@@ -656,7 +654,7 @@ function RenameProfileDialog({
               value={name}
             />
             <p className={cn('text-[0.66rem] leading-4', invalid ? 'text-destructive' : 'text-muted-foreground')}>
-              {p.nameHint}
+              {nameHelp}
             </p>
           </div>
 

--- a/apps/desktop/src/app/profiles/rename-profile-dialog.tsx
+++ b/apps/desktop/src/app/profiles/rename-profile-dialog.tsx
@@ -6,10 +6,10 @@ import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, D
 import { Input } from '@/components/ui/input'
 import { renameProfile } from '@/hermes'
 import { useI18n } from '@/i18n'
+import { formatBackendError } from '@/lib/format-error'
 import { AlertTriangle } from '@/lib/icons'
+import { isValidProfileName, profileNameHint } from '@/lib/profile-names'
 import { cn } from '@/lib/utils'
-
-import { isValidProfileName } from './create-profile-dialog'
 
 // Self-contained rename (owns the renameProfile call) so every caller just
 // reacts via onRenamed. Unchanged name is a no-op close.
@@ -43,6 +43,7 @@ export function RenameProfileDialog({
   const trimmed = name.trim()
   const unchanged = trimmed === currentName
   const invalid = trimmed !== '' && !unchanged && !isValidProfileName(trimmed)
+  const nameHelp = profileNameHint(trimmed, p)
   const busy = status === 'saving' || status === 'done'
 
   async function handleSubmit(event: React.FormEvent) {
@@ -55,7 +56,7 @@ export function RenameProfileDialog({
     }
 
     if (!trimmed || invalid) {
-      setError(invalid ? p.invalidName(p.nameHint) : p.nameRequired)
+      setError(invalid ? p.invalidName(nameHelp) : p.nameRequired)
 
       return
     }
@@ -70,7 +71,7 @@ export function RenameProfileDialog({
       window.setTimeout(onClose, 800)
     } catch (err) {
       setStatus('idle')
-      setError(err instanceof Error ? err.message : p.failedRename)
+      setError(formatBackendError(err, p.failedRename))
     }
   }
 
@@ -99,7 +100,7 @@ export function RenameProfileDialog({
               value={name}
             />
             <p className={cn('text-[0.66rem] leading-4', invalid ? 'text-destructive' : 'text-muted-foreground')}>
-              {p.nameHint}
+              {nameHelp}
             </p>
           </div>
 

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions.ts
@@ -23,6 +23,7 @@ import {
   isDesktopSlashCommand,
   resolveDesktopCommand
 } from '@/lib/desktop-slash-commands'
+import { formatBackendError } from '@/lib/format-error'
 import { triggerHaptic } from '@/lib/haptics'
 import { setMutableRef } from '@/lib/mutable-ref'
 import { isProviderSetupErrorMessage } from '@/lib/provider-setup-errors'
@@ -104,12 +105,6 @@ function isProviderSetupError(error: unknown) {
   const message = error instanceof Error ? error.message : String(error)
 
   return isProviderSetupErrorMessage(message)
-}
-
-function inlineErrorMessage(error: unknown, fallback: string): string {
-  const raw = error instanceof Error ? error.message : typeof error === 'string' ? error : fallback
-
-  return (raw.match(/Error invoking remote method '[^']+': Error: (.+)$/)?.[1] ?? raw).replace(/^Error:\s*/, '').trim()
 }
 
 function isSessionNotFoundError(error: unknown): boolean {
@@ -746,7 +741,7 @@ export function usePromptActions({
           return false
         }
 
-        const message = inlineErrorMessage(err, copy.promptFailed)
+        const message = formatBackendError(err, copy.promptFailed)
 
         updateSessionState(sessionId, state => ({
           ...state,
@@ -817,7 +812,7 @@ export function usePromptActions({
           session_id: sid
         })
       } catch (err) {
-        return { error: inlineErrorMessage(err, copy.handoff.failed(target)), ok: false }
+        return { error: formatBackendError(err, copy.handoff.failed(target)), ok: false }
       }
 
       const deadline = Date.now() + 60_000

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -926,6 +926,7 @@ export const en: Translations = {
   profiles: {
     close: 'Close profiles',
     nameHint: 'Lowercase letters, digits, hyphens, and underscores. Must start with a letter or digit.',
+    reservedNameHint: 'This name is reserved. Choose a different profile name.',
     title: 'Profiles',
     count: count => `${count} ${count === 1 ? 'profile' : 'profiles'}`,
     loading: 'Loading profiles...',

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -1053,6 +1053,7 @@ export const ja = defineLocale({
   profiles: {
     close: 'プロファイルを閉じる',
     nameHint: '小文字、数字、ハイフン、アンダースコア。文字または数字で始める必要があります。',
+    reservedNameHint: 'この名前は予約済みです。別のプロファイル名を選んでください。',
     title: 'プロファイル',
     count: count => `${count} プロファイル`,
     loading: 'プロファイルを読み込み中...',

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -699,6 +699,7 @@ export interface Translations {
   profiles: {
     close: string
     nameHint: string
+    reservedNameHint: string
     title: string
     count: (count: number) => string
     loading: string

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -1010,6 +1010,7 @@ export const zhHant = defineLocale({
   profiles: {
     close: '關閉設定檔',
     nameHint: '小寫字母、數字、連字號和底線。必須以字母或數字開頭。',
+    reservedNameHint: '此名稱為保留名稱。請選擇其他設定檔名稱。',
     title: '設定檔',
     count: count => `${count} 個設定檔`,
     loading: '正在載入設定檔…',

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -1114,6 +1114,7 @@ export const zh: Translations = {
   profiles: {
     close: '关闭配置档案',
     nameHint: '小写字母、数字、连字符和下划线。必须以字母或数字开头。',
+    reservedNameHint: '该名称为保留名称。请选择其他配置档案名称。',
     title: '配置档案',
     count: count => `${count} 个配置档案`,
     loading: '正在加载配置档案…',

--- a/apps/desktop/src/lib/format-error.test.ts
+++ b/apps/desktop/src/lib/format-error.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest'
+
+import { formatBackendError } from './format-error'
+
+describe('formatBackendError', () => {
+  it('unwraps Electron IPC and FastAPI detail envelopes', () => {
+    const error = new Error(
+      'Error invoking remote method \'hermes:api\': Error: 400: {"detail":"Profile name \'test\' is reserved"}'
+    )
+
+    expect(formatBackendError(error, 'Failed')).toBe("Profile name 'test' is reserved")
+  })
+
+  it('unwraps plain HTTP JSON error messages', () => {
+    expect(formatBackendError('400: {"detail":"No profile named coder"}', 'Failed')).toBe('No profile named coder')
+  })
+
+  it('keeps normal error messages readable', () => {
+    expect(formatBackendError(new Error('Error: Something failed'), 'Failed')).toBe('Something failed')
+  })
+
+  it('falls back for non-string errors', () => {
+    expect(formatBackendError({ error: 'hidden' }, 'Failed')).toBe('Failed')
+  })
+})

--- a/apps/desktop/src/lib/format-error.ts
+++ b/apps/desktop/src/lib/format-error.ts
@@ -1,0 +1,69 @@
+const IPC_REMOTE_ERROR_RE = /^Error invoking remote method '[^']+': Error: (.+)$/s
+const HTTP_ERROR_RE = /^\d{3}:\s*(.+)$/s
+
+function rawErrorMessage(error: unknown, fallback: string): string {
+  if (error instanceof Error) {
+    return error.message
+  }
+
+  if (typeof error === 'string') {
+    return error
+  }
+
+  return fallback
+}
+
+function cleanErrorText(value: string): string {
+  return value.replace(/^Error:\s*/, '').trim()
+}
+
+function detailToString(detail: unknown): null | string {
+  if (typeof detail === 'string') {
+    return detail
+  }
+
+  if (Array.isArray(detail)) {
+    const messages = detail
+      .map(item => {
+        if (typeof item === 'string') {
+          return item
+        }
+
+        if (item && typeof item === 'object' && 'msg' in item && typeof item.msg === 'string') {
+          return item.msg
+        }
+
+        return null
+      })
+      .filter((item): item is string => Boolean(item))
+
+    return messages.length > 0 ? messages.join('\n') : null
+  }
+
+  return null
+}
+
+function parseJsonDetail(value: string): null | string {
+  try {
+    const parsed = JSON.parse(value) as unknown
+
+    if (parsed && typeof parsed === 'object' && 'detail' in parsed) {
+      return detailToString(parsed.detail)
+    }
+  } catch {
+    return null
+  }
+
+  return null
+}
+
+export function formatBackendError(error: unknown, fallback: string): string {
+  const raw = rawErrorMessage(error, fallback)
+  const withoutIpc = raw.match(IPC_REMOTE_ERROR_RE)?.[1] ?? raw
+  const cleaned = cleanErrorText(withoutIpc)
+  const payload = cleaned.match(HTTP_ERROR_RE)?.[1] ?? cleaned
+  const detail = parseJsonDetail(payload)
+  const formatted = cleanErrorText(detail ?? cleaned)
+
+  return formatted || fallback
+}

--- a/apps/desktop/src/lib/profile-names.test.ts
+++ b/apps/desktop/src/lib/profile-names.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest'
+
+import { isReservedProfileName, isValidProfileName, profileNameHint } from './profile-names'
+
+const copy = {
+  nameHint: 'syntax hint',
+  reservedNameHint: 'reserved hint'
+}
+
+describe('profile name validation', () => {
+  it('accepts valid profile names', () => {
+    expect(isValidProfileName('coder')).toBe(true)
+    expect(isValidProfileName('team-agent_2')).toBe(true)
+  })
+
+  it('rejects backend reserved names', () => {
+    expect(isReservedProfileName('test')).toBe(true)
+    expect(isReservedProfileName(' sudo ')).toBe(true)
+    expect(isValidProfileName('test')).toBe(false)
+  })
+
+  it('uses reserved-name help only for syntactically valid reserved names', () => {
+    expect(profileNameHint('test', copy)).toBe('reserved hint')
+    expect(profileNameHint('Test', copy)).toBe('syntax hint')
+  })
+})

--- a/apps/desktop/src/lib/profile-names.ts
+++ b/apps/desktop/src/lib/profile-names.ts
@@ -1,0 +1,32 @@
+const PROFILE_NAME_RE = /^[a-z0-9][a-z0-9_-]{0,63}$/
+
+const RESERVED_PROFILE_NAMES = new Set(['hermes', 'default', 'test', 'tmp', 'root', 'sudo'])
+
+interface ProfileNameCopy {
+  nameHint: string
+  reservedNameHint: string
+}
+
+export function hasProfileNameSyntax(name: string): boolean {
+  return PROFILE_NAME_RE.test(name.trim())
+}
+
+export function isReservedProfileName(name: string): boolean {
+  return RESERVED_PROFILE_NAMES.has(name.trim().toLowerCase())
+}
+
+export function isValidProfileName(name: string): boolean {
+  const trimmed = name.trim()
+
+  return hasProfileNameSyntax(trimmed) && !isReservedProfileName(trimmed)
+}
+
+export function profileNameHint(name: string, copy: ProfileNameCopy): string {
+  const trimmed = name.trim()
+
+  if (hasProfileNameSyntax(trimmed) && isReservedProfileName(trimmed)) {
+    return copy.reservedNameHint
+  }
+
+  return copy.nameHint
+}

--- a/apps/desktop/src/store/notifications.ts
+++ b/apps/desktop/src/store/notifications.ts
@@ -1,6 +1,7 @@
 import { atom } from 'nanostores'
 
 import { translateNow } from '@/i18n'
+import { formatBackendError } from '@/lib/format-error'
 
 export type NotificationKind = 'error' | 'warning' | 'info' | 'success'
 
@@ -42,10 +43,6 @@ function defaultDuration(kind: NotificationKind) {
   }
 
   return 5_000
-}
-
-function cleanErrorText(value: string) {
-  return value.replace(/^Error:\s*/, '').trim()
 }
 
 const ERROR_SUMMARIES: { test: (msg: string) => boolean; summarize: (msg: string) => string }[] = [
@@ -91,10 +88,7 @@ function summarizeErrorMessage(message: string, fallback: string) {
 }
 
 function readableError(error: unknown, fallback: string): { message: string; detail?: string } {
-  const raw = error instanceof Error ? error.message : typeof error === 'string' ? error : fallback
-  const unwrapped = raw.match(/Error invoking remote method '[^']+': Error: (.+)$/)?.[1] ?? raw
-  const cleaned = cleanErrorText(unwrapped)
-  const detail = cleaned.match(/"detail"\s*:\s*"([^"]+)"/)?.[1] ?? cleaned
+  const detail = formatBackendError(error, fallback)
   const summary = summarizeErrorMessage(detail, fallback)
 
   return { message: summary, detail: detail === summary ? undefined : detail }


### PR DESCRIPTION
## Summary
- pre-validate reserved profile names in the desktop create/rename flows
- unwrap Electron IPC and FastAPI detail envelopes before showing backend errors
- share profile-name validation and backend-error formatting across desktop call sites

Fixes #47549

## Tests
- npm --workspace apps/desktop run test:ui -- src/lib/format-error.test.ts src/lib/profile-names.test.ts src/app/session/hooks/use-prompt-actions.test.tsx
- npm --workspace apps/desktop run typecheck