### PR TITLE
fix(skills): refresh stale slash command cache on miss

### DIFF
--- a/agent/skill_commands.py
+++ b/agent/skill_commands.py
@@ -506,12 +506,26 @@ def resolve_skill_command_key(command: str) -> Optional[str]:
     ``/claude_code`` and comes back in the underscored form).
 
     Returns the matching ``/slug`` key from ``get_skill_commands()`` or
-    ``None`` if no match.
+    ``None`` if no match. When an existing same-platform cache misses, rescan
+    once before returning ``None`` so long-running gateway processes can pick
+    up newly added, removed, or renamed skills without a restart.
     """
     if not command:
         return None
     cmd_key = f"/{command.replace('_', '-')}"
-    return cmd_key if cmd_key in get_skill_commands() else None
+    current_platform = _resolve_skill_commands_platform()
+    had_current_cache = (
+        bool(_skill_commands)
+        and _skill_commands_platform == current_platform
+    )
+    commands = get_skill_commands()
+    if cmd_key in commands:
+        return cmd_key
+    if had_current_cache:
+        commands = scan_skill_commands()
+        if cmd_key in commands:
+            return cmd_key
+    return None
 
 
 def build_skill_invocation_message(

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -7848,6 +7848,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 skill_cmds = get_skill_commands()
                 cmd_key = resolve_skill_command_key(command)
                 if cmd_key is not None:
+                    skill_cmds = get_skill_commands()
                     # Check per-platform disabled status before executing.
                     # get_skill_commands() only applies the *global* disabled
                     # list at scan time; per-platform overrides need checking

--- a/tests/agent/test_skill_commands.py
+++ b/tests/agent/test_skill_commands.py
@@ -410,6 +410,28 @@ class TestResolveSkillCommandKey:
             assert resolve_skill_command_key("does_not_exist") is None
             assert resolve_skill_command_key("does-not-exist") is None
 
+    def test_miss_refreshes_stale_cache_from_current_skill_sources(self, tmp_path):
+        import agent.skill_commands as sc_mod
+        from agent.skill_commands import get_skill_commands
+
+        with (
+            patch("tools.skills_tool.SKILLS_DIR", tmp_path),
+            patch.object(sc_mod, "_skill_commands", {}),
+            patch.object(sc_mod, "_skill_commands_platform", None),
+        ):
+            old_skill = _make_skill(tmp_path, "old-skill")
+            scan_skill_commands()
+            assert "/old-skill" in get_skill_commands()
+
+            _make_skill(tmp_path, "new-skill")
+            old_skill.joinpath("SKILL.md").unlink()
+
+            assert resolve_skill_command_key("new-skill") == "/new-skill"
+
+            refreshed = get_skill_commands()
+            assert "/new-skill" in refreshed
+            assert "/old-skill" not in refreshed
+
     def test_empty_command_returns_none(self, tmp_path):
         with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
             scan_skill_commands()

--- a/tests/gateway/test_reload_skills_command.py
+++ b/tests/gateway/test_reload_skills_command.py
@@ -13,6 +13,7 @@ Verifies:
     message alternation must not be broken by a phantom user turn
 """
 
+import shutil
 from datetime import datetime
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
@@ -36,6 +37,15 @@ def _make_source() -> SessionSource:
 
 def _make_event(text: str) -> MessageEvent:
     return MessageEvent(text=text, source=_make_source(), message_id="m1")
+
+
+def _write_skill(skills_dir, name: str, description: str):
+    skill_dir = skills_dir / name
+    skill_dir.mkdir(parents=True, exist_ok=True)
+    (skill_dir / "SKILL.md").write_text(
+        f"---\nname: {name}\ndescription: {description}\n---\n\nRun {name}.\n"
+    )
+    return skill_dir
 
 
 def _make_runner():
@@ -71,8 +81,12 @@ def _make_runner():
     runner.session_store.rewrite_transcript = MagicMock()
     runner.session_store.update_session = MagicMock()
     runner._running_agents = {}
+    runner._running_agents_ts = {}
+    runner._active_session_leases = {}
+    runner._session_run_generation = {}
     runner._pending_messages = {}
     runner._pending_approvals = {}
+    runner._busy_ack_ts = {}
     runner._session_db = None
     runner._reasoning_config = None
     runner._provider_routing = {}
@@ -198,3 +212,38 @@ async def test_underscored_alias_not_flagged_unknown(monkeypatch):
     result = await runner._handle_message(_make_event("/reload_skills"))
     if result is not None:
         assert "Unknown command" not in result
+
+
+@pytest.mark.asyncio
+async def test_gateway_skill_command_miss_refreshes_stale_cache(monkeypatch, tmp_path):
+    """A long-running gateway should pick up newly added skills on command miss."""
+    import agent.skill_commands as skill_commands_mod
+    import agent.skill_utils as skill_utils_mod
+    import tools.skills_tool as skills_tool_mod
+    from gateway.run import GatewayRunner
+
+    monkeypatch.setattr(skills_tool_mod, "SKILLS_DIR", tmp_path, raising=False)
+    monkeypatch.setattr(skill_utils_mod, "get_external_skills_dirs", lambda: [])
+    monkeypatch.setattr(skills_tool_mod, "_get_disabled_skill_names", lambda: set())
+    monkeypatch.setattr(skill_commands_mod, "_skill_commands", {}, raising=False)
+    monkeypatch.setattr(skill_commands_mod, "_skill_commands_platform", None, raising=False)
+
+    old_skill = _write_skill(tmp_path, "old-skill", "old skill")
+    skill_commands_mod.scan_skill_commands()
+    assert "/old-skill" in skill_commands_mod.get_skill_commands()
+
+    shutil.rmtree(old_skill)
+    _write_skill(tmp_path, "new-skill", "fresh skill")
+
+    async def capture_agent_message(self, event, source, quick_key, generation):
+        return event.text
+
+    monkeypatch.setattr(GatewayRunner, "_handle_message_with_agent", capture_agent_message)
+
+    runner = _make_runner()
+    result = await runner._handle_message(_make_event("/new-skill use it"))
+
+    assert result is not None
+    assert 'The user has invoked the "new-skill" skill' in result
+    assert "The user has provided the following instruction alongside the skill invocation: use it" in result
+    assert "/old-skill" not in skill_commands_mod.get_skill_commands()


### PR DESCRIPTION
## Summary
- rescan skill slash commands once when same-platform cache misses
- make gateway reread the cache after resolver refreshes it
- cover both agent resolver behavior and the real gateway skill dispatch path

Fixes #47579

## Tests
- scripts/run_tests.sh tests/agent/test_skill_commands.py tests/gateway/test_reload_skills_command.py -- -q
- /Users/tushaokun/.hermes/hermes-agent/venv/bin/python -m pytest tests/gateway/test_max_concurrent_sessions.py::test_skill_command_that_would_start_agent_is_blocked_at_limit -q