### PR TITLE
fix(desktop): retry profile model refresh

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-model-controls.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-model-controls.test.tsx
@@ -59,6 +59,7 @@ function Harness({
 
 describe('useModelControls', () => {
   beforeEach(() => {
+    vi.clearAllMocks()
     $activeSessionId.set(null)
     setCurrentModel('')
     setCurrentProvider('')
@@ -67,6 +68,7 @@ describe('useModelControls', () => {
   afterEach(() => {
     cleanup()
     vi.restoreAllMocks()
+    vi.useRealTimers()
     $activeSessionId.set(null)
     setCurrentModel('')
     setCurrentProvider('')
@@ -194,5 +196,66 @@ describe('useModelControls', () => {
     // A profile swap forces a reseed to the new profile's default.
     await result.current.refreshCurrentModel(true)
     expect($currentModel.get()).toBe('openai/gpt-5.5')
+  })
+
+  it('retries forced profile-default refreshes after a transient backend miss', async () => {
+    vi.useFakeTimers()
+    vi.mocked(getGlobalModelInfo).mockRejectedValueOnce(new Error('backend not ready')).mockResolvedValueOnce({
+      model: 'anthropic/claude-sonnet-4.6',
+      provider: 'anthropic'
+    })
+
+    const { result } = renderHook(() =>
+      useModelControls({
+        activeSessionId: null,
+        queryClient: new QueryClient(),
+        requestGateway: vi.fn()
+      })
+    )
+
+    const pending = result.current.refreshCurrentModel(true)
+
+    await vi.advanceTimersByTimeAsync(250)
+    await pending
+
+    expect(getGlobalModelInfo).toHaveBeenCalledTimes(2)
+    expect($currentModel.get()).toBe('anthropic/claude-sonnet-4.6')
+    expect($currentProvider.get()).toBe('anthropic')
+  })
+
+  it('keeps the latest forced profile-default refresh from being clobbered', async () => {
+    let resolveFirst!: (value: { model: string; provider: string }) => void
+    let resolveSecond!: (value: { model: string; provider: string }) => void
+    const first = new Promise<{ model: string; provider: string }>(resolve => {
+      resolveFirst = resolve
+    })
+    const second = new Promise<{ model: string; provider: string }>(resolve => {
+      resolveSecond = resolve
+    })
+
+    vi.mocked(getGlobalModelInfo).mockReturnValueOnce(first).mockReturnValueOnce(second)
+
+    const { result } = renderHook(() =>
+      useModelControls({
+        activeSessionId: null,
+        queryClient: new QueryClient(),
+        requestGateway: vi.fn()
+      })
+    )
+
+    const staleRefresh = result.current.refreshCurrentModel(true)
+    const latestRefresh = result.current.refreshCurrentModel(true)
+
+    resolveSecond({ model: 'current-profile-model', provider: 'current-provider' })
+    await latestRefresh
+
+    expect($currentModel.get()).toBe('current-profile-model')
+    expect($currentProvider.get()).toBe('current-provider')
+
+    resolveFirst({ model: 'stale-profile-model', provider: 'stale-provider' })
+    await staleRefresh
+
+    expect($currentModel.get()).toBe('current-profile-model')
+    expect($currentProvider.get()).toBe('current-provider')
   })
 })

--- a/apps/desktop/src/app/session/hooks/use-model-controls.ts
+++ b/apps/desktop/src/app/session/hooks/use-model-controls.ts
@@ -1,5 +1,5 @@
 import { type QueryClient } from '@tanstack/react-query'
-import { useCallback } from 'react'
+import { useCallback, useRef } from 'react'
 
 import { getGlobalModelInfo } from '@/hermes'
 import { useI18n } from '@/i18n'
@@ -24,9 +24,16 @@ interface ModelControlsOptions {
   requestGateway: <T = unknown>(method: string, params?: Record<string, unknown>) => Promise<T>
 }
 
+const FORCED_MODEL_REFRESH_RETRY_DELAYS_MS = [250, 750, 2_000]
+
+function delay(ms: number): Promise<void> {
+  return new Promise(resolve => window.setTimeout(resolve, ms))
+}
+
 export function useModelControls({ activeSessionId, queryClient, requestGateway }: ModelControlsOptions) {
   const { t } = useI18n()
   const copy = t.desktop
+  const refreshRunRef = useRef(0)
 
   const updateModelOptionsCache = useCallback(
     (provider: string, model: string, includeGlobal: boolean) => {
@@ -47,7 +54,10 @@ export function useModelControls({ activeSessionId, queryClient, requestGateway 
   // $currentModel) survives the lifecycle refreshes that fire on boot / fresh
   // draft / session events. A live session owns the footer, so skip entirely.
   const refreshCurrentModel = useCallback(async (force = false) => {
-    try {
+    const runId = force ? ++refreshRunRef.current : refreshRunRef.current
+    const retryDelays = force ? FORCED_MODEL_REFRESH_RETRY_DELAYS_MS : []
+
+    for (let attempt = 0; ; attempt += 1) {
       if ($activeSessionId.get()) {
         return
       }
@@ -56,21 +66,38 @@ export function useModelControls({ activeSessionId, queryClient, requestGateway 
         return
       }
 
-      const result = await getGlobalModelInfo()
+      try {
+        const result = await getGlobalModelInfo()
 
-      if ($activeSessionId.get() || (!force && $currentModel.get())) {
+        if (runId !== refreshRunRef.current) {
+          return
+        }
+
+        if ($activeSessionId.get() || (!force && $currentModel.get())) {
+          return
+        }
+
+        if (typeof result.model === 'string') {
+          setCurrentModel(result.model)
+        }
+
+        if (typeof result.provider === 'string') {
+          setCurrentProvider(result.provider)
+        }
+
         return
-      }
+      } catch {
+        if (runId !== refreshRunRef.current) {
+          return
+        }
 
-      if (typeof result.model === 'string') {
-        setCurrentModel(result.model)
-      }
+        const retryDelay = retryDelays[attempt]
+        if (retryDelay === undefined) {
+          return
+        }
 
-      if (typeof result.provider === 'string') {
-        setCurrentProvider(result.provider)
+        await delay(retryDelay)
       }
-    } catch {
-      // The delayed session.info event still updates this once the agent is ready.
     }
   }, [])
 


### PR DESCRIPTION
## Summary
- retry forced profile-default model refreshes when the desktop backend is briefly unavailable
- ignore stale refresh results so rapid profile switches cannot clobber the current model pill
- add regression coverage for transient failures and latest-refresh-wins ordering

Fixes #47524

## Tests
- npm --workspace apps/desktop run test:ui -- src/app/session/hooks/use-model-controls.test.tsx
- npm --workspace apps/desktop run typecheck