### PR TITLE
fix(docs): document xz-utils and curl as Linux prerequisites

### DIFF
--- a/website/docs/getting-started/installation.md
+++ b/website/docs/getting-started/installation.md
@@ -81,7 +81,7 @@ That logs you in, sets Nous as your provider, and turns on the Tool Gateway in o
 
 ## Prerequisites
 
-**Installer:** On non-Windows platforms, the only prerequisite is **Git**. The installer automatically handles everything else:
+**Installer:** On non-Windows platforms, the only prerequisites are **Git**, **curl**, and **xz-utils** (on Linux). The installer automatically handles everything else:
 
 - **uv** (fast Python package manager)
 - **Python 3.11** (via uv, no sudo needed)


### PR DESCRIPTION
## Summary

The installation docs say "the only prerequisite is Git", but the installer:
1. Downloads Node.js as a `.tar.xz` archive — requires `xz-utils` to decompress on Linux
2. Uses `curl` for the install command itself

On a fresh Debian/fresh Linux VM, `tar` fails with `xz: Cannot exec: No such file or directory` because `xz-utils` is not installed.

## Changes
- `website/docs/getting-started/installation.md`: Updated prerequisites line to mention `curl` and `xz-utils` (on Linux)

## Related Issue
Closes #47033