### PR TITLE
fix: context_from strips to ## Response only; [SILENT] prefix-only check

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -1109,6 +1109,12 @@ def _build_job_prompt(job: dict, prerun_script: Optional[tuple] = None) -> str:
                 if not output_files:
                     continue  # silent skip — no output yet
                 latest_output = output_files[0].read_text(encoding="utf-8").strip()
+                # Extract only the ## Response section to avoid injecting
+                # prompt/skill boilerplate that bloats downstream context.
+                _RESPONSE_MARKER = "\n## Response\n"
+                _resp_idx = latest_output.find(_RESPONSE_MARKER)
+                if _resp_idx != -1:
+                    latest_output = latest_output[_resp_idx + len(_RESPONSE_MARKER):].strip()
                 # Truncate to 8K characters to avoid prompt bloat
                 _MAX_CONTEXT_CHARS = 8000
                 if len(latest_output) > _MAX_CONTEXT_CHARS:
@@ -2061,7 +2067,7 @@ def tick(verbose: bool = True, adapters=None, loop=None, sync: bool = True) -> i
                 # responses: do not deliver a blank message, and let the
                 # empty-response guard below mark the run as a soft failure.
                 should_deliver = bool(deliver_content.strip())
-                if should_deliver and success and SILENT_MARKER in deliver_content.strip().upper():
+                if should_deliver and success and deliver_content.strip().upper().startswith(SILENT_MARKER):
                     logger.info("Job '%s': agent returned %s — skipping delivery", job["id"], SILENT_MARKER)
                     should_deliver = False
 


### PR DESCRIPTION
## Summary

Two surgical fixes to `cron/scheduler.py`:

### 1. `context_from` now extracts only the `## Response` section

**Problem:** When a job uses `context_from` to inject a preceding job's output, it reads the **entire** saved `.md` file — which includes the `## Prompt` section containing loaded skill content, model instructions, and other boilerplate. The 8K char cap then truncates this, meaning downstream jobs often receive skill/docs text instead of the actual response they need.

**Example:** A 5 AM Daily Brief output file is ~110K chars (mostly skill content in `## Prompt`). The actual response is ~2.5K chars. The 4 PM Delta report's `context_from` injection was getting 8K of skill boilerplate, not the morning brief response.

**Fix:** Strip everything before `## Response\n` before applying the 8K cap. If the marker is not found (e.g., no_agent script outputs that don't use the format), fall through to the existing behavior.

### 2. `[SILENT]` delivery suppression changed to prefix-only

**Problem:** The check `SILENT_MARKER in deliver_content.strip().upper()` is a substring match. If a response mentions `[SILENT]` anywhere in the body (e.g., explaining why it is NOT silent), delivery is incorrectly suppressed.

**Fix:** Changed to `deliver_content.strip().upper().startswith(SILENT_MARKER)`. The cron hint already instructs the agent to respond with *exactly* `[SILENT]` and nothing else, so prefix-only is the correct semantic.

## Validation

- Both changes compile clean (`py_compile`)
- `context_from` extraction verified against real output files: 110K chars → 2.5K chars (actual response)
- `[SILENT]` prefix check verified: `[SILENT]` suppresses; `## Report\n...mentioned [SILENT] in passing...` does not
- No changes to prompt construction, skill loading, delivery wrapping, or any other code path

## Risk

Very low. Both changes are 1-3 lines each, in well-scoped locations, with no new abstractions.