### PR TITLE
fix(gateway): bypass macOS system proxy for WebSocket connections on all WS platforms

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -379,6 +379,67 @@ def resolve_proxy_url(
     return detected
 
 
+def resolve_ws_proxy(
+    *,
+    platform_env_var: str | None = None,
+    target_host: str | None = None,
+) -> dict:
+    """Resolve proxy config for a ``websockets`` or ``aiohttp`` WebSocket connection.
+
+    On macOS, system-level proxies (Surge, ClashX, V2RayU, ShadowsocksX, etc.)
+    often break WebSocket ``CONNECT`` tunnels because the proxy software returns
+    non-standard or incomplete responses.  When a system proxy is detected but
+    the user has *not* explicitly configured a platform-specific WS proxy env
+    var, we force ``proxy=None`` (direct connect) rather than letting the
+    ``websockets`` library auto-detect and tunnel through the system proxy.
+
+    Check order:
+      0. ``platform_env_var`` (e.g. ``FEISHU_WS_PROXY``) — highest priority.
+         When set, the given proxy URL is used as-is.
+      1. The generic HTTPS_PROXY / HTTP_PROXY env vars.
+      2. macOS system proxy via ``scutil --proxy``.
+      3. If 2 returns something (system proxy active), we return
+         ``{"proxy": None}`` to force a direct connection, bypassing
+         the broken CONNECT tunnel.
+
+    ``target_host`` is passed to ``should_bypass_proxy`` for NO_PROXY matching.
+
+    Returns:
+      - ``{"proxy": "http://host:port"}`` — explicit proxy from platform env var
+      - ``{"proxy": None}`` — macOS system proxy detected; force direct connect
+      - ``{}`` — no proxy detected anywhere; let library decide
+    """
+    # 0. Platform-specific env var → use it explicitly
+    if platform_env_var:
+        value = (os.environ.get(platform_env_var) or "").strip()
+        if value:
+            if target_host and should_bypass_proxy(target_host):
+                return {}
+            return {"proxy": normalize_proxy_url(value)}
+
+    # 1. Generic proxy env vars → use them explicitly
+    for key in ("HTTPS_PROXY", "HTTP_PROXY", "ALL_PROXY",
+                "https_proxy", "http_proxy", "all_proxy"):
+        value = (os.environ.get(key) or "").strip()
+        if value:
+            if target_host and should_bypass_proxy(target_host):
+                return {}
+            return {"proxy": normalize_proxy_url(value)}
+
+    # 2. macOS system proxy → bypass for WebSocket
+    detected = _detect_macos_system_proxy()
+    if detected:
+        if target_host and should_bypass_proxy(target_host):
+            return {}
+        logger.info(
+            "System proxy detected (%s) — bypassing for WebSocket direct connect",
+            detected,
+        )
+        return {"proxy": None}
+
+    return {}
+
+
 def proxy_kwargs_for_bot(proxy_url: str | None) -> dict:
     """Build kwargs for ``commands.Bot()`` / ``discord.Client()`` with proxy.
 

--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -139,6 +139,7 @@ from gateway.platforms.base import (
     cache_image_from_url,
     cache_audio_from_bytes,
     cache_image_from_bytes,
+    resolve_ws_proxy,
 )
 from gateway.status import acquire_scoped_lock, release_scoped_lock
 from hermes_constants import get_hermes_home
@@ -1307,7 +1308,14 @@ def _run_official_feishu_ws_client(ws_client: Any, adapter: Any) -> None:
             kwargs["ping_interval"] = adapter._ws_ping_interval
         if adapter._ws_ping_timeout is not None and "ping_timeout" not in kwargs:
             kwargs["ping_timeout"] = adapter._ws_ping_timeout
-        return original_connect(*args, **kwargs)
+        # macOS 系统代理（Surge/Clash 等）会阻断 WebSocket CONNECT 隧道，
+        # 检测到系统代理时强制直连（proxy=None），避免 InvalidProxyMessage 错误。
+        # 用户可通过 FEISHU_WS_PROXY 环境变量显式指定代理。
+        if "proxy" not in kwargs:
+            ws_proxy = resolve_ws_proxy(platform_env_var="FEISHU_WS_PROXY")
+            if ws_proxy:
+                kwargs.update(ws_proxy)
+        return await original_connect(*args, **kwargs)
 
     def _configure_with_overrides(conf: Any) -> Any:
         if original_configure is None:

--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -1280,6 +1280,35 @@ def _strip_edge_self_mentions(
                 break
         else:
             return remaining
+def _detect_system_https_proxy() -> str | None:
+    """Detect system HTTP/HTTPS proxy for WebSocket connections.
+
+    Checks env vars first (http_proxy/HTTPS_PROXY), then macOS system proxy
+    preferences. Returns a proxy URL string like 'http://127.0.0.1:6152' or None.
+    """
+    for var in ("https_proxy", "HTTPS_PROXY", "http_proxy", "HTTP_PROXY"):
+        val = os.environ.get(var)
+        if val:
+            return val
+    try:
+        import subprocess
+        result = subprocess.run(
+            ["scutil", "--proxy"],
+            capture_output=True, text=True, timeout=5,
+        )
+        if result.returncode == 0:
+            import re
+            http_host = re.search(r'HTTPProxy\s*:\s*(\S+)', result.stdout)
+            http_port = re.search(r'HTTPPort\s*:\s*(\d+)', result.stdout)
+            https_host = re.search(r'HTTPSProxy\s*:\s*(\S+)', result.stdout)
+            https_port = re.search(r'HTTPSPort\s*:\s*(\d+)', result.stdout)
+            host = https_host.group(1) if https_host else (http_host.group(1) if http_host else None)
+            port = https_port.group(1) if https_port else (http_port.group(1) if http_port else None)
+            if host and port:
+                return f"http://{host}:{port}"
+    except Exception:
+        pass
+    return None
 
 
 def _run_official_feishu_ws_client(ws_client: Any, adapter: Any) -> None:
@@ -1308,9 +1337,10 @@ def _run_official_feishu_ws_client(ws_client: Any, adapter: Any) -> None:
             kwargs["ping_interval"] = adapter._ws_ping_interval
         if adapter._ws_ping_timeout is not None and "ping_timeout" not in kwargs:
             kwargs["ping_timeout"] = adapter._ws_ping_timeout
-        # macOS 系统代理（Surge/Clash 等）会阻断 WebSocket CONNECT 隧道，
-        # 检测到系统代理时强制直连（proxy=None），避免 InvalidProxyMessage 错误。
-        # 用户可通过 FEISHU_WS_PROXY 环境变量显式指定代理。
+        # Surge/Clash 等系统代理对 WebSocket CONNECT 隧道兼容性差，
+        # 检测到代理时强制 proxy=None 直连（websockets 默认 proxy=True
+        # 会通过 urllib.request.getproxies() 检测到系统代理然后走代理，
+        # 但系统代理软件可能返回非标准数据导致 InvalidProxyMessage）。
         if "proxy" not in kwargs:
             ws_proxy = resolve_ws_proxy(platform_env_var="FEISHU_WS_PROXY")
             if ws_proxy:

--- a/gateway/platforms/wecom.py
+++ b/gateway/platforms/wecom.py
@@ -67,6 +67,7 @@ from gateway.platforms.base import (
     SendResult,
     cache_document_from_bytes,
     cache_image_from_bytes,
+    resolve_ws_proxy,
 )
 
 logger = logging.getLogger(__name__)
@@ -281,11 +282,13 @@ class WeComAdapter(BasePlatformAdapter):
     async def _open_connection(self) -> None:
         """Open and authenticate a websocket connection."""
         await self._cleanup_ws()
-        self._session = aiohttp.ClientSession(trust_env=True)
+        ws_proxy = resolve_ws_proxy(platform_env_var="WECOM_WS_PROXY")
+        self._session = aiohttp.ClientSession(trust_env=not bool(ws_proxy))
         self._ws = await self._session.ws_connect(
             self._ws_url,
             heartbeat=HEARTBEAT_INTERVAL_SECONDS * 2,
             timeout=CONNECT_TIMEOUT_SECONDS,
+            **(ws_proxy or {}),
         )
 
         req_id = self._new_req_id("subscribe")

--- a/gateway/platforms/yuanbao.py
+++ b/gateway/platforms/yuanbao.py
@@ -59,6 +59,7 @@ from gateway.platforms.base import (
     cache_document_from_bytes,
     cache_image_from_bytes,
     cache_video_from_bytes,
+    resolve_ws_proxy,
 )
 from gateway.platforms.helpers import MessageDeduplicator
 from gateway.platforms.yuanbao_media import (
@@ -3311,12 +3312,14 @@ class ConnectionManager:
 
             # Step 2: Open WebSocket connection (disable built-in ping/pong)
             logger.info("[%s] Connecting to %s", adapter.name, adapter._ws_url)
+            ws_kwargs = resolve_ws_proxy(platform_env_var="YUANBAO_WS_PROXY")
             self._ws = await asyncio.wait_for(
                 websockets.connect(  # type: ignore[attr-defined]
                     adapter._ws_url,
                     ping_interval=None,
                     ping_timeout=None,
                     close_timeout=5,
+                    **ws_kwargs,
                 ),
                 timeout=CONNECT_TIMEOUT_SECONDS,
             )
@@ -3798,12 +3801,14 @@ class ConnectionManager:
                 if token_data.get("bot_id"):
                     adapter._bot_id = str(token_data["bot_id"])
 
+                ws_kwargs = resolve_ws_proxy(platform_env_var="YUANBAO_WS_PROXY")
                 self._ws = await asyncio.wait_for(
                     websockets.connect(  # type: ignore[attr-defined]
                         adapter._ws_url,
                         ping_interval=None,
                         ping_timeout=None,
                         close_timeout=5,
+                        **ws_kwargs,
                     ),
                     timeout=CONNECT_TIMEOUT_SECONDS,
                 )

--- a/plugins/platforms/homeassistant/adapter.py
+++ b/plugins/platforms/homeassistant/adapter.py
@@ -34,6 +34,7 @@ from gateway.platforms.base import (
     MessageEvent,
     MessageType,
     SendResult,
+    resolve_ws_proxy,
 )
 
 logger = logging.getLogger(__name__)
@@ -142,10 +143,15 @@ class HomeAssistantAdapter(BasePlatformAdapter):
         ws_url = self._hass_url.replace("https://", "wss://").replace("http://", "ws://")
         ws_url = f"{ws_url}/api/websocket"
 
+        ws_proxy = resolve_ws_proxy(platform_env_var="HASS_WS_PROXY")
         self._session = aiohttp.ClientSession(
-            timeout=aiohttp.ClientTimeout(total=30)
+            timeout=aiohttp.ClientTimeout(total=30),
+            trust_env=not bool(ws_proxy),
         )
-        self._ws = await self._session.ws_connect(ws_url, heartbeat=30, timeout=30)
+        self._ws = await self._session.ws_connect(
+            ws_url, heartbeat=30, timeout=30,
+            **(ws_proxy or {}),
+        )
 
         # Step 1: Receive auth_required
         msg = await self._ws.receive_json()

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -915,7 +915,7 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
         elif platform == Platform.DINGTALK:
             result = await _send_dingtalk(pconfig.extra, chat_id, chunk)
         elif platform == Platform.FEISHU:
-            result = await _send_feishu(pconfig, chat_id, chunk, thread_id=thread_id)
+            result = await _send_feishu(pconfig, chat_id, chunk, media_files=media_files, thread_id=thread_id)
         elif platform == Platform.WECOM:
             result = await _send_wecom(pconfig.extra, chat_id, chunk)
         elif platform == Platform.BLUEBUBBLES:


### PR DESCRIPTION
## Summary

Fixes WebSocket `CONNECT` tunnel failures on macOS when system proxies (Surge, ClashX, V2RayU, ShadowsocksX, etc.) are active. These proxies often return non-standard or incomplete responses that break the `websockets` and `aiohttp` libraries, causing `InvalidProxyMessage` or connection timeout errors.

## Root Cause

When a system proxy is detected, `websockets` and `aiohttp` auto-detect it via `urllib.request.getproxies()` and tunnel through it. However, macOS proxy software (Surge, Clash, etc.) often returns non-standard CONNECT responses that these libraries cannot parse, resulting in:
- `InvalidProxyMessage` errors
- Connection timeouts
- Intermittent WebSocket disconnects

## Solution

Added `resolve_ws_proxy()` function in `gateway/platforms/base.py` that:

1. **Checks platform-specific env var** (e.g., `FEISHU_WS_PROXY`) — highest priority, explicit override
2. **Checks generic proxy env vars** (`HTTPS_PROXY`, `HTTP_PROXY`, `ALL_PROXY`) — uses them explicitly if set
3. **Detects macOS system proxy** via `scutil --proxy` — if active but no explicit env var, forces `proxy=None` (direct connect) to bypass broken CONNECT tunnel
4. **Respects NO_PROXY/`should_bypass_proxy()`** — skips proxy logic for local/internal hosts

## Platform Integration

Integrated into all WebSocket-based platform adapters:
- **Feishu** (`FEISHU_WS_PROXY`)
- **WeCom** (`WECOM_WS_PROXY`)
- **Yuanbao** (`YUANBAO_WS_PROXY`)
- **Home Assistant** (`HASS_WS_PROXY`)

## Related Fixes
- `tools/send_message_tool.py`: Fixed Feishu media file sending (missing `media_files` parameter pass-through)

## Testing
- Tested with Surge/ClashX active — WebSocket connections now succeed via direct connect
- Tested with explicit `*_WS_PROXY` env var — proxy routing works as expected
- Tested with no proxy — normal behavior unchanged