### PR TITLE
fix(delegation): support daemon async workers on Python 3.14

### DIFF
--- a/tools/async_delegation.py
+++ b/tools/async_delegation.py
@@ -42,7 +42,7 @@ import time
 import uuid
 import weakref
 from concurrent.futures import ThreadPoolExecutor
-from concurrent.futures.thread import _worker
+from concurrent.futures.thread import _threads_queues, _worker
 from typing import Any, Callable, Dict, List, Optional
 
 logger = logging.getLogger(__name__)
@@ -67,19 +67,31 @@ class _DaemonThreadPoolExecutor(ThreadPoolExecutor):
         num_threads = len(self._threads)
         if num_threads < self._max_workers:
             thread_name = "%s_%d" % (self._thread_name_prefix or self, num_threads)
-            t = threading.Thread(
-                name=thread_name,
-                target=_worker,
-                args=(
+            worker_args: tuple[Any, ...]
+            if hasattr(self, "_create_worker_context"):
+                # Python 3.14 changed ThreadPoolExecutor worker internals from
+                # (queue, initializer, initargs) to a WorkerContext object.
+                worker_args = (
+                    weakref.ref(self, weakref_cb),
+                    self._create_worker_context(),
+                    self._work_queue,
+                )
+            else:
+                worker_args = (
                     weakref.ref(self, weakref_cb),
                     self._work_queue,
                     self._initializer,
                     self._initargs,
-                ),
+                )
+            t = threading.Thread(
+                name=thread_name,
+                target=_worker,
+                args=worker_args,
                 daemon=True,
             )
             t.start()
             self._threads.add(t)
+            _threads_queues[t] = self._work_queue  # type: ignore[index]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR do?

Makes background `delegate_task(background=true)` compatible with Python 3.14 by adapting the daemon `ThreadPoolExecutor` worker bootstrap to Python's new `WorkerContext`-based private `_worker` signature.

Without this, async delegation can dispatch but the daemon worker thread fails before running the child task on Python 3.14.

## Related Issue

No linked GitHub issue. Runtime reproduction: Python 3.14 changed `concurrent.futures.thread._worker` internals from `(executor_ref, work_queue, initializer, initargs)` to `(executor_ref, ctx, work_queue)`.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tools/async_delegation.py`
  - Detects Python 3.14's `_create_worker_context()` path when spawning daemon executor workers.
  - Preserves the older worker argument shape for Python versions before that change.
  - Registers daemon worker threads in `_threads_queues`, matching stdlib executor bookkeeping.

## How to Test

1. Run focused validation:
   ```bash
   scripts/run_tests.sh tests/tools/test_async_delegation.py -- -q --tb=short
   ```
   Result:
   ```text
   17 tests passed
   ```

2. Run direct focused validation:
   ```bash
   python -m pytest tests/tools/test_async_delegation.py -q --tb=short -o addopts=''
   ```
   Result:
   ```text
   17 passed, 1 warning in 2.10s
   ```

3. Compile and diff hygiene:
   ```bash
   python -m py_compile tools/async_delegation.py
   git diff --check origin/main...HEAD
   ```
   Result:
   ```text
   passed
   ```

## Validation Status

- Focused regression tests: passing.
- Broader suite: not run; scoped one-file compatibility fix.
- GitHub checks: pending.
- Full-suite checklist is intentionally unchecked because this is a narrow Python 3.14 async-delegation compatibility fix and focused async delegation coverage passed locally.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (existing async delegation tests cover this runtime path on Python 3.14; no new test file added)
- [x] I've tested on my platform: Arch Linux, Python 3.14.5

### Documentation and Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior or N/A

## For New Skills

N/A.

## Screenshots / Logs

```text
Python 3.14.5
scripts/run_tests.sh tests/tools/test_async_delegation.py -- -q --tb=short
17 tests passed

python -m pytest tests/tools/test_async_delegation.py -q --tb=short -o addopts=''
17 passed, 1 warning in 2.10s
```
