### PR TITLE
fix(docs): document curl, xz-utils, and g++ as Linux prerequisites

### DIFF
--- a/website/docs/getting-started/installation.md
+++ b/website/docs/getting-started/installation.md
@@ -81,7 +81,7 @@ That logs you in, sets Nous as your provider, and turns on the Tool Gateway in o
 
 ## Prerequisites
 
-**Installer:** On non-Windows platforms, the only prerequisite is **Git**. The installer automatically handles everything else:
+**Installer:** On non-Windows platforms, the only prerequisite is **Git**. On Linux, also make sure `curl` and `xz-utils` are available (the installer downloads Node.js as a `.tar.xz` archive). The desktop app additionally requires `g++` (or `build-essential` on Debian/Ubuntu) to compile native modules. The installer automatically handles everything else:
 
 - **uv** (fast Python package manager)
 - **Python 3.11** (via uv, no sudo needed)
@@ -90,7 +90,7 @@ That logs you in, sets Nous as your provider, and turns on the Tool Gateway in o
 - **ffmpeg** (audio format conversion for TTS)
 
 :::info
-You do **not** need to install Python, Node.js, ripgrep, or ffmpeg manually. The installer detects what's missing and installs it for you. Just make sure `git` is available (`git --version`).
+You do **not** need to install Python, Node.js, ripgrep, or ffmpeg manually. The installer detects what's missing and installs it for you. Just make sure `git` is available (`git --version`). On Linux, ensure `curl` and `xz-utils` are installed (`sudo apt install curl xz-utils` on Debian/Ubuntu). For the desktop app, also install `build-essential` (`sudo apt install build-essential`).
 :::
 
 :::tip Nix users


### PR DESCRIPTION
## Summary

The installation docs say "the only prerequisite is Git", but:
1. On Linux, the installer downloads Node.js as a `.tar.xz` archive — requires `curl` and `xz-utils` to decompress
2. The desktop app requires `g++` (`build-essential` on Debian/Ubuntu) to compile native modules

On a fresh Linux VM without these packages, the Node.js extraction fails with `xz: Cannot exec: No such file or directory`.

## Changes
- `website/docs/getting-started/installation.md`: Updated prerequisites section to mention `curl`, `xz-utils` (Linux), and `g++`/`build-essential` (desktop app)
- Updated the info box with concrete install commands for Debian/Ubuntu users

## Related
Supersedes #47037 — reopened with maintainer-requested g++ addition.