### PR TITLE
[codex] Preserve agent continuity across cache and compression paths

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -890,13 +890,20 @@ def _read_claude_code_credentials_from_keychain() -> Optional[Dict[str, Any]]:
         logger.debug("Keychain: no entry found for 'Claude Code-credentials'")
         return None
 
-    raw = result.stdout.strip()
+    stdout = getattr(result, "stdout", "")
+    if isinstance(stdout, bytes):
+        stdout = stdout.decode("utf-8", errors="replace")
+    elif not isinstance(stdout, str):
+        logger.debug("Keychain: credentials payload is not text")
+        return None
+
+    raw = stdout.strip()
     if not raw:
         return None
 
     try:
         data = json.loads(raw)
-    except json.JSONDecodeError:
+    except (json.JSONDecodeError, TypeError):
         logger.debug("Keychain: credentials payload is not valid JSON")
         return None
 

--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -287,6 +287,7 @@ def compress_context(
     task_id: str = "default",
     focus_topic: Optional[str] = None,
     force: bool = False,
+    conversation_history: Optional[list] = None,
 ) -> Tuple[list, str]:
     """Compress conversation context and split the session in SQLite.
 
@@ -512,6 +513,19 @@ def compress_context(
             old_title = agent._session_db.get_session_title(agent.session_id)
             # Trigger memory extraction on the old session before it rotates.
             agent.commit_memory_session(messages)
+            # Persist this turn's unflushed tail before ending the old session.
+            # Compression callers that have the pre-turn history pass it in so
+            # identity-based flush can skip already persisted rows.  Fallback to
+            # the old session's current DB row count for manual/direct callers.
+            if hasattr(agent, "_flush_messages_to_session_db"):
+                flush_history = conversation_history
+                if flush_history is None:
+                    try:
+                        persisted_count = len(agent._session_db.get_messages(agent.session_id))
+                    except Exception:
+                        persisted_count = 0
+                    flush_history = messages[:min(persisted_count, len(messages))]
+                agent._flush_messages_to_session_db(messages, flush_history)
             agent._session_db.end_session(agent.session_id, "compression")
             old_session_id = agent.session_id
             agent.session_id = f"{datetime.now().strftime('%Y%m%d_%H%M%S')}_{uuid.uuid4().hex[:6]}"

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -2741,6 +2741,7 @@ def run_conversation(
                             messages, system_message,
                             approx_tokens=approx_tokens,
                             task_id=effective_task_id,
+                            conversation_history=conversation_history,
                         )
                         # Compression created a new session — clear history
                         # so _flush_messages_to_session_db writes compressed
@@ -2917,6 +2918,7 @@ def run_conversation(
                     messages, active_system_prompt = agent._compress_context(
                         messages, system_message, approx_tokens=approx_tokens,
                         task_id=effective_task_id,
+                        conversation_history=conversation_history,
                     )
                     # Compression created a new session — clear history
                     # so _flush_messages_to_session_db writes compressed
@@ -3073,6 +3075,7 @@ def run_conversation(
                     messages, active_system_prompt = agent._compress_context(
                         messages, system_message, approx_tokens=approx_tokens,
                         task_id=effective_task_id,
+                        conversation_history=conversation_history,
                     )
                     # Compression created a new session — clear history
                     # so _flush_messages_to_session_db writes compressed
@@ -4028,6 +4031,7 @@ def run_conversation(
                         messages, system_message,
                         approx_tokens=agent.context_compressor.last_prompt_tokens,
                         task_id=effective_task_id,
+                        conversation_history=conversation_history,
                     )
                     # Compression created a new session — clear history so
                     # _flush_messages_to_session_db writes compressed messages

--- a/agent/transports/anthropic.py
+++ b/agent/transports/anthropic.py
@@ -4,10 +4,136 @@ Delegates to the existing adapter functions in agent/anthropic_adapter.py.
 This transport owns format conversion and normalization — NOT client lifecycle.
 """
 
-from typing import Any, Dict, List, Optional
+import html
+import json
+import re
+from typing import Any, Dict, List, Optional, Tuple
 
 from agent.transports.base import ProviderTransport
-from agent.transports.types import NormalizedResponse
+from agent.transports.types import NormalizedResponse, ToolCall
+
+
+_NAME_ATTR_RE = re.compile(r"""\bname\s*=\s*(?P<quote>["'])(?P<name>.*?)(?P=quote)""", re.IGNORECASE)
+_TEXT_INVOKE_RE = re.compile(
+    r"""<(?:[A-Za-z_][\w.-]*:)?(?P<tag>invoke|function)\b(?P<attrs>[^>]*)>"""
+    r"""(?P<body>.*?)"""
+    r"""</(?:[A-Za-z_][\w.-]*:)?(?P=tag)>""",
+    re.DOTALL | re.IGNORECASE,
+)
+_TEXT_PARAMETER_RE = re.compile(
+    r"""<(?:[A-Za-z_][\w.-]*:)?parameter\b(?P<attrs>[^>]*)>"""
+    r"""(?P<value>.*?)"""
+    r"""</(?:[A-Za-z_][\w.-]*:)?parameter>""",
+    re.DOTALL | re.IGNORECASE,
+)
+_TEXT_JSON_TOOL_RE = re.compile(
+    r"""<(?P<tag>tool_call|function_call)\b[^>]*>(?P<body>.*?)</(?P=tag)>""",
+    re.DOTALL | re.IGNORECASE,
+)
+_TEXT_JSON_TOOL_LIST_RE = re.compile(
+    r"""<(?P<tag>tool_calls|function_calls)\b[^>]*>(?P<body>.*?)</(?P=tag)>""",
+    re.DOTALL | re.IGNORECASE,
+)
+
+
+def _parse_text_tool_value(raw: str) -> Any:
+    value = html.unescape(raw).strip()
+    try:
+        return json.loads(value)
+    except (json.JSONDecodeError, TypeError, ValueError):
+        return value
+
+
+def _extract_attr_name(attrs: str) -> Optional[str]:
+    match = _NAME_ATTR_RE.search(attrs or "")
+    if not match:
+        return None
+    name = html.unescape(match.group("name")).strip()
+    return name or None
+
+
+def _tool_call_from_text_invoke(match: re.Match[str], index: int) -> Optional[ToolCall]:
+    name = _extract_attr_name(match.group("attrs"))
+    if not name:
+        return None
+
+    arguments: Dict[str, Any] = {}
+    for param in _TEXT_PARAMETER_RE.finditer(match.group("body") or ""):
+        param_name = _extract_attr_name(param.group("attrs"))
+        if not param_name:
+            continue
+        arguments[param_name] = _parse_text_tool_value(param.group("value"))
+
+    return ToolCall(
+        id=f"toolu_text_{index}",
+        name=name,
+        arguments=json.dumps(arguments, ensure_ascii=False),
+    )
+
+
+def _tool_calls_from_json_payload(payload: Any, start_index: int) -> List[ToolCall]:
+    if isinstance(payload, dict):
+        entries = [payload]
+    elif isinstance(payload, list):
+        entries = [entry for entry in payload if isinstance(entry, dict)]
+    else:
+        return []
+
+    calls: List[ToolCall] = []
+    for entry in entries:
+        name = entry.get("name")
+        if not isinstance(name, str) or not name.strip():
+            continue
+        arguments = entry.get("arguments", entry.get("input", {}))
+        if isinstance(arguments, str):
+            try:
+                arguments = json.loads(arguments)
+            except (json.JSONDecodeError, TypeError, ValueError):
+                arguments = {}
+        if not isinstance(arguments, dict):
+            arguments = {}
+        calls.append(
+            ToolCall(
+                id=str(entry.get("id") or f"toolu_text_{start_index + len(calls)}"),
+                name=name.strip(),
+                arguments=json.dumps(arguments, ensure_ascii=False),
+            )
+        )
+    return calls
+
+
+def _salvage_text_tool_calls(text: str) -> Tuple[List[ToolCall], str]:
+    """Promote complete tool-call markup leaked into Anthropic text blocks."""
+    if not text:
+        return [], text
+
+    tool_calls: List[ToolCall] = []
+
+    def _replace_invoke(match: re.Match[str]) -> str:
+        tool_call = _tool_call_from_text_invoke(match, len(tool_calls) + 1)
+        if not tool_call:
+            return match.group(0)
+        tool_calls.append(tool_call)
+        return ""
+
+    stripped = _TEXT_INVOKE_RE.sub(_replace_invoke, text)
+
+    def _replace_json(match: re.Match[str]) -> str:
+        try:
+            payload = json.loads(match.group("body").strip())
+        except (json.JSONDecodeError, TypeError, ValueError):
+            return match.group(0)
+        calls = _tool_calls_from_json_payload(payload, len(tool_calls) + 1)
+        if not calls:
+            return match.group(0)
+        tool_calls.extend(calls)
+        return ""
+
+    stripped = _TEXT_JSON_TOOL_RE.sub(_replace_json, stripped)
+    stripped = _TEXT_JSON_TOOL_LIST_RE.sub(_replace_json, stripped)
+    stripped = re.sub(r"[ \t]+\n", "\n", stripped)
+    stripped = re.sub(r"\n{3,}", "\n\n", stripped).strip()
+    return tool_calls, stripped
 
 
 class AnthropicTransport(ProviderTransport):
@@ -83,9 +209,7 @@ class AnthropicTransport(ProviderTransport):
         Parses content blocks (text, thinking, tool_use), maps stop_reason
         to OpenAI finish_reason, and collects reasoning_details in provider_data.
         """
-        import json
         from agent.anthropic_adapter import _to_plain_data, _sanitize_replay_block
-        from agent.transports.types import ToolCall
 
         strip_tool_prefix = kwargs.get("strip_tool_prefix", False)
         _MCP_PREFIX = "mcp_"
@@ -152,6 +276,13 @@ class AnthropicTransport(ProviderTransport):
                 )
 
         finish_reason = self._STOP_REASON_MAP.get(response.stop_reason, "stop")
+        content = "\n".join(text_parts) if text_parts else None
+        if not tool_calls and content:
+            salvaged_tool_calls, stripped_content = _salvage_text_tool_calls(content)
+            if salvaged_tool_calls:
+                tool_calls.extend(salvaged_tool_calls)
+                content = stripped_content or None
+                finish_reason = "tool_calls"
 
         provider_data = {}
         if reasoning_details:
@@ -175,7 +306,7 @@ class AnthropicTransport(ProviderTransport):
             provider_data["anthropic_content_blocks"] = ordered_blocks
 
         return NormalizedResponse(
-            content="\n".join(text_parts) if text_parts else None,
+            content=content,
             tool_calls=tool_calls or None,
             finish_reason=finish_reason,
             reasoning="\n\n".join(reasoning_parts) if reasoning_parts else None,

--- a/agent/transports/codex.py
+++ b/agent/transports/codex.py
@@ -218,10 +218,26 @@ class ResponsesApiTransport(ProviderTransport):
             kwargs.pop("timeout", None)
 
         if is_codex_backend:
-            # chatgpt.com/backend-api/codex rejects body-level
-            # ``extra_headers`` with HTTP 400. Correlation/cache routing for
-            # this backend must not be sent through the Responses payload.
-            kwargs.pop("extra_headers", None)
+            # chatgpt.com/backend-api/codex uses stable request-level
+            # correlation headers as part of its cache routing.  These are
+            # OpenAI SDK request options, not JSON body fields; removing them
+            # collapses prefix-cache hits for long-lived Codex sessions.
+            prompt_cache_key = kwargs.get("prompt_cache_key")
+            cache_scope_id = str(prompt_cache_key or session_id or "").strip()
+            if cache_scope_id:
+                existing_extra_headers = kwargs.get("extra_headers")
+                merged_extra_headers: Dict[str, str] = {}
+                if isinstance(existing_extra_headers, dict):
+                    merged_extra_headers.update(
+                        {
+                            str(key): str(value)
+                            for key, value in existing_extra_headers.items()
+                            if key and value is not None
+                        }
+                    )
+                merged_extra_headers["session_id"] = cache_scope_id
+                merged_extra_headers["x-client-request-id"] = cache_scope_id
+                kwargs["extra_headers"] = merged_extra_headers
 
         max_tokens = params.get("max_tokens")
         if max_tokens is not None and not is_codex_backend:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -16916,7 +16916,7 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
         _loop = asyncio.get_running_loop()
         await _loop.run_in_executor(None, discover_mcp_tools)
     except Exception as e:
-        logger.debug("MCP tool discovery failed: %s", e)
+        logger.warning("MCP tool discovery failed: %s", e, exc_info=True)
 
     # Start the gateway
     success = await runner.start()

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -3725,6 +3725,78 @@ def _set_nested(config, dotted_key: str, value):
         current[last] = value
 
 
+_CONFIG_DEFAULT_MISSING = object()
+_CONFIG_BOOL_TRUE = {"true", "yes", "on", "1"}
+_CONFIG_BOOL_FALSE = {"false", "no", "off", "0"}
+
+
+def _default_config_value_for_key(dotted_key: str) -> Any:
+    current: Any = DEFAULT_CONFIG
+    for part in dotted_key.split("."):
+        if isinstance(current, dict):
+            if part not in current:
+                return _CONFIG_DEFAULT_MISSING
+            current = current[part]
+            continue
+        if isinstance(current, list):
+            try:
+                idx = int(part)
+            except (TypeError, ValueError):
+                return _CONFIG_DEFAULT_MISSING
+            if idx < 0 or idx >= len(current):
+                return _CONFIG_DEFAULT_MISSING
+            current = current[idx]
+            continue
+        return _CONFIG_DEFAULT_MISSING
+    return current
+
+
+def _coerce_config_set_value(key: str, value: str) -> Any:
+    """Coerce ``hermes config set`` values only when the key's type is known.
+
+    The old global ``on/off`` heuristic corrupted string enums such as
+    ``approvals.mode=off``.  Keep numeric convenience for unknown extension
+    keys, but reserve boolean word parsing for keys whose default is boolean.
+    """
+    if not isinstance(value, str):
+        return value
+
+    default_value = _default_config_value_for_key(key)
+    stripped = value.strip()
+    lowered = stripped.lower()
+
+    if isinstance(default_value, bool):
+        if lowered in _CONFIG_BOOL_TRUE:
+            return True
+        if lowered in _CONFIG_BOOL_FALSE:
+            return False
+        return value
+
+    if isinstance(default_value, int) and not isinstance(default_value, bool):
+        try:
+            return int(stripped)
+        except ValueError:
+            return value
+
+    if isinstance(default_value, float):
+        try:
+            return float(stripped)
+        except ValueError:
+            return value
+
+    if default_value is _CONFIG_DEFAULT_MISSING or default_value is None:
+        try:
+            return int(stripped)
+        except ValueError:
+            pass
+        try:
+            return float(stripped)
+        except ValueError:
+            return value
+
+    return value
+
+
 def get_missing_config_fields() -> List[Dict[str, Any]]:
     """
     Check which config fields are missing or outdated (recursive).
@@ -6295,15 +6367,7 @@ def set_config_value(key: str, value: str):
     # _set_nested which preserves list-typed nodes; before #17876 the
     # inline navigation here silently overwrote lists with dicts.
 
-    # Convert value to appropriate type
-    if value.lower() in {'true', 'yes', 'on'}:
-        value = True
-    elif value.lower() in {'false', 'no', 'off'}:
-        value = False
-    elif value.isdigit():
-        value = int(value)
-    elif value.replace('.', '', 1).isdigit():
-        value = float(value)
+    value = _coerce_config_set_value(key, value)
 
     _set_nested(user_config, key, value)
     

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -10984,7 +10984,7 @@ def cmd_dashboard(args):
             thread_name="dashboard-mcp-discovery",
         )
     except Exception:
-        logger.debug(
+        logger.warning(
             "Background MCP tool discovery failed at dashboard startup",
             exc_info=True,
         )
@@ -11225,7 +11225,7 @@ def _prepare_agent_startup(args) -> None:
                 thread_name="cli-mcp-discovery",
             )
         except Exception:
-            logger.debug(
+            logger.warning(
                 "Background MCP tool discovery failed at CLI startup",
                 exc_info=True,
             )
@@ -11238,7 +11238,7 @@ def _prepare_agent_startup(args) -> None:
 
             discover_mcp_tools()
         except Exception:
-            logger.debug(
+            logger.warning(
                 "MCP tool discovery failed at CLI startup",
                 exc_info=True,
             )

--- a/hermes_cli/mcp_startup.py
+++ b/hermes_cli/mcp_startup.py
@@ -8,6 +8,7 @@ from typing import Optional
 _mcp_discovery_lock = threading.Lock()
 _mcp_discovery_started = False
 _mcp_discovery_thread: Optional[threading.Thread] = None
+DEFAULT_MCP_DISCOVERY_WAIT_SECONDS = 6.0
 
 
 def _has_configured_mcp_servers() -> bool:
@@ -40,7 +41,7 @@ def start_background_mcp_discovery(*, logger, thread_name: str) -> None:
 
                 discover_mcp_tools()
             except Exception:
-                logger.debug("Background MCP tool discovery failed", exc_info=True)
+                logger.warning("Background MCP tool discovery failed", exc_info=True)
 
         thread = threading.Thread(
             target=_discover,
@@ -51,7 +52,7 @@ def start_background_mcp_discovery(*, logger, thread_name: str) -> None:
         thread.start()
 
 
-def wait_for_mcp_discovery(timeout: float = 0.75) -> None:
+def wait_for_mcp_discovery(timeout: float = DEFAULT_MCP_DISCOVERY_WAIT_SECONDS) -> None:
     """Briefly wait for background MCP discovery before the first tool snapshot."""
     thread = _mcp_discovery_thread
     if thread is None or not thread.is_alive():

--- a/run_agent.py
+++ b/run_agent.py
@@ -5061,7 +5061,7 @@ class AIAgent:
         """
         return self.api_mode != "codex_responses"
 
-    def _compress_context(self, messages: list, system_message: str, *, approx_tokens: int = None, task_id: str = "default", focus_topic: str = None, force: bool = False) -> tuple:
+    def _compress_context(self, messages: list, system_message: str, *, approx_tokens: int = None, task_id: str = "default", focus_topic: str = None, force: bool = False, conversation_history: list = None) -> tuple:
         """Forwarder — see ``agent.conversation_compression.compress_context``.
 
         ``force=True`` is passed by the manual ``/compress`` slash command
@@ -5073,7 +5073,7 @@ class AIAgent:
         return compress_context(
             self, messages, system_message,
             approx_tokens=approx_tokens, task_id=task_id, focus_topic=focus_topic,
-            force=force,
+            force=force, conversation_history=conversation_history,
         )
 
     def _set_tool_guardrail_halt(self, decision: ToolGuardrailDecision) -> None:

--- a/tests/agent/transports/test_codex_transport.py
+++ b/tests/agent/transports/test_codex_transport.py
@@ -155,7 +155,7 @@ class TestCodexBuildKwargs:
         )
         assert "max_output_tokens" not in kw
 
-    def test_codex_backend_does_not_set_extra_headers(self, transport):
+    def test_codex_backend_sets_cache_routing_headers(self, transport):
         messages = [{"role": "user", "content": "Hi"}]
 
         kw = transport.build_kwargs(
@@ -166,9 +166,15 @@ class TestCodexBuildKwargs:
             is_codex_backend=True,
         )
 
-        assert "extra_headers" not in kw
+        assert kw.get("prompt_cache_key") == "conv-codex-1"
+        assert kw.get("extra_headers") == {
+            "session_id": "conv-codex-1",
+            "x-client-request-id": "conv-codex-1",
+        }
 
-    def test_codex_backend_strips_caller_extra_headers(self, transport):
+    def test_codex_backend_preserves_caller_headers_and_adds_cache_routing(
+        self, transport
+    ):
         messages = [{"role": "user", "content": "Hi"}]
 
         kw = transport.build_kwargs(
@@ -180,7 +186,12 @@ class TestCodexBuildKwargs:
             request_overrides={"extra_headers": {"x-test": "1"}},
         )
 
-        assert "extra_headers" not in kw
+        assert kw.get("prompt_cache_key") == "conv-codex-1"
+        assert kw.get("extra_headers") == {
+            "x-test": "1",
+            "session_id": "conv-codex-1",
+            "x-client-request-id": "conv-codex-1",
+        }
 
     def test_non_codex_responses_preserves_caller_extra_headers(self, transport):
         messages = [{"role": "user", "content": "Hi"}]

--- a/tests/agent/transports/test_transport.py
+++ b/tests/agent/transports/test_transport.py
@@ -202,6 +202,64 @@ class TestAnthropicTransport:
         assert tc.id == "toolu_123"
         assert '"command"' in tc.arguments
 
+    def test_normalize_response_salvages_text_invoke_tool_call(self, transport):
+        """Complete invoke markup in a text block should execute as a tool call."""
+        r = SimpleNamespace(
+            content=[
+                SimpleNamespace(
+                    type="text",
+                    text=(
+                        "Let me inspect that.\n"
+                        '<invoke name="read_file">\n'
+                        '  <parameter name="path">"/tmp/example.txt"</parameter>\n'
+                        '  <parameter name="offset">61</parameter>\n'
+                        '  <parameter name="include_hidden">true</parameter>\n'
+                        "</invoke>\n"
+                        "I will use the result next."
+                    ),
+                ),
+            ],
+            stop_reason="end_turn",
+            usage=SimpleNamespace(input_tokens=10, output_tokens=20),
+            model="claude-sonnet-4-6",
+        )
+
+        nr = transport.normalize_response(r)
+
+        assert nr.finish_reason == "tool_calls"
+        assert len(nr.tool_calls) == 1
+        tc = nr.tool_calls[0]
+        assert tc.name == "read_file"
+        assert '"path": "/tmp/example.txt"' in tc.arguments
+        assert '"offset": 61' in tc.arguments
+        assert '"include_hidden": true' in tc.arguments
+        assert "<invoke" not in (nr.content or "")
+        assert "read_file" not in (nr.content or "")
+        assert "Let me inspect that." in (nr.content or "")
+
+    def test_normalize_response_ignores_incomplete_text_invoke(self, transport):
+        """Partial invoke markup must remain visible text, not an executable call."""
+        r = SimpleNamespace(
+            content=[
+                SimpleNamespace(
+                    type="text",
+                    text=(
+                        '<invoke name="read_file">\n'
+                        '  <parameter name="path">"/tmp/example.txt"</parameter>\n'
+                    ),
+                ),
+            ],
+            stop_reason="end_turn",
+            usage=SimpleNamespace(input_tokens=10, output_tokens=20),
+            model="claude-sonnet-4-6",
+        )
+
+        nr = transport.normalize_response(r)
+
+        assert nr.finish_reason == "stop"
+        assert nr.tool_calls is None
+        assert "<invoke" in (nr.content or "")
+
     def test_normalize_response_thinking(self, transport):
         """Test normalization preserves thinking content."""
         r = SimpleNamespace(

--- a/tests/hermes_cli/test_mcp_startup.py
+++ b/tests/hermes_cli/test_mcp_startup.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 from argparse import Namespace
+import inspect
+import logging
 import sys
 import threading
 import time
@@ -86,6 +88,43 @@ def test_prepare_agent_startup_backgrounds_blocking_mcp_for_chat(monkeypatch):
         assert mcp_startup._mcp_discovery_thread.is_alive()
     finally:
         stop.set()
+
+
+def test_wait_for_mcp_discovery_default_covers_slow_local_servers():
+    """The default wait should cover reachable MCP servers that take ~6s."""
+    default_timeout = inspect.signature(
+        mcp_startup.wait_for_mcp_discovery
+    ).parameters["timeout"].default
+    assert default_timeout >= 6.0
+
+
+def test_background_mcp_discovery_failure_logs_warning(monkeypatch, caplog):
+    def _raise_discover():
+        raise RuntimeError("mcp boom")
+
+    monkeypatch.setitem(
+        sys.modules,
+        "hermes_cli.config",
+        types.SimpleNamespace(
+            read_raw_config=lambda: {"mcp_servers": {"demo": {"command": "demo"}}},
+        ),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "tools.mcp_tool",
+        types.SimpleNamespace(discover_mcp_tools=_raise_discover),
+    )
+
+    logger = logging.getLogger("test.mcp_startup")
+    with caplog.at_level(logging.WARNING, logger=logger.name):
+        mcp_startup.start_background_mcp_discovery(
+            logger=logger,
+            thread_name="test-mcp-discovery-failure",
+        )
+        assert mcp_startup._mcp_discovery_thread is not None
+        mcp_startup._mcp_discovery_thread.join(timeout=1.0)
+
+    assert "Background MCP tool discovery failed" in caplog.text
 
 
 def test_prepare_agent_startup_skips_mcp_bootstrap_for_tui_chat(monkeypatch):

--- a/tests/hermes_cli/test_set_config_value.py
+++ b/tests/hermes_cli/test_set_config_value.py
@@ -5,6 +5,7 @@ import os
 from unittest.mock import patch
 
 import pytest
+import yaml
 
 from hermes_cli.config import set_config_value, config_command
 
@@ -123,6 +124,20 @@ class TestConfigYamlRouting:
             "TERMINAL_DOCKER_MOUNT_CWD_TO_WORKSPACE=true" in env_content
             or "TERMINAL_DOCKER_MOUNT_CWD_TO_WORKSPACE=True" in env_content
         )
+
+    def test_string_enum_off_stays_string(self, _isolated_hermes_home):
+        """String enum values like approvals.mode=off must not become False."""
+        set_config_value("approvals.mode", "off")
+        reloaded = yaml.safe_load(_read_config(_isolated_hermes_home))
+        assert reloaded["approvals"]["mode"] == "off"
+
+    def test_unknown_on_off_values_stay_strings(self, _isolated_hermes_home):
+        """Unknown config keys must not guess that enum-looking strings are bools."""
+        set_config_value("custom_feature.mode", "on")
+        set_config_value("custom_feature.other_mode", "off")
+        reloaded = yaml.safe_load(_read_config(_isolated_hermes_home))
+        assert reloaded["custom_feature"]["mode"] == "on"
+        assert reloaded["custom_feature"]["other_mode"] == "off"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/run_agent/test_compression_boundary_hook.py
+++ b/tests/run_agent/test_compression_boundary_hook.py
@@ -90,6 +90,60 @@ class TestCompressionBoundaryHook:
             assert call.kwargs.get("old_session_id") == original_sid, \
                 f"Expected old_session_id={original_sid!r}, got {call.kwargs!r}"
 
+    def test_old_session_messages_flushed_before_end_session(self):
+        """Compression must persist the old turn before closing its DB session."""
+        from hermes_state import SessionDB
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db = SessionDB(db_path=Path(tmpdir) / "test.db")
+            agent = self._make_agent(db)
+
+            compressor = MagicMock()
+            compressor.compress.return_value = [
+                {"role": "user", "content": "[CONTEXT COMPACTION] summary"},
+                {"role": "user", "content": "tail question"},
+            ]
+            compressor.compression_count = 1
+            compressor.last_prompt_tokens = 0
+            compressor.last_completion_tokens = 0
+            compressor._last_summary_error = None
+            compressor._last_compress_aborted = False
+            agent.context_compressor = compressor
+
+            messages = [
+                {"role": "user", "content": "unflushed question"},
+                {"role": "assistant", "content": "unflushed answer"},
+            ]
+            original_sid = agent.session_id
+            events = []
+
+            real_flush = agent._flush_messages_to_session_db
+
+            def _spy_flush(flush_messages, conversation_history=None):
+                events.append(("flush", agent.session_id))
+                return real_flush(flush_messages, conversation_history)
+
+            real_end_session = db.end_session
+
+            def _spy_end_session(session_id, end_reason=None):
+                events.append(("end_session", session_id))
+                return real_end_session(session_id, end_reason)
+
+            agent._flush_messages_to_session_db = _spy_flush
+            db.end_session = _spy_end_session
+
+            agent._compress_context(messages, "sys", approx_tokens=10_000)
+
+            assert events[:2] == [
+                ("flush", original_sid),
+                ("end_session", original_sid),
+            ]
+            rows = db.get_messages(original_sid)
+            assert [row["content"] for row in rows] == [
+                "unflushed question",
+                "unflushed answer",
+            ]
+
     def test_no_hook_when_no_session_db(self):
         """Without session_db, session_id does not rotate and the hook is not fired."""
         from run_agent import AIAgent

--- a/tests/run_agent/test_run_agent_codex_responses.py
+++ b/tests/run_agent/test_run_agent_codex_responses.py
@@ -308,6 +308,10 @@ def test_build_api_kwargs_codex(monkeypatch):
     assert kwargs["parallel_tool_calls"] is True
     assert isinstance(kwargs["prompt_cache_key"], str)
     assert len(kwargs["prompt_cache_key"]) > 0
+    assert kwargs.get("extra_headers") == {
+        "session_id": kwargs["prompt_cache_key"],
+        "x-client-request-id": kwargs["prompt_cache_key"],
+    }
     # ``timeout`` is now wired from ``_resolved_api_call_timeout`` (default 1800s)
     # so per-provider ``request_timeout_seconds`` actually reaches the SDK.
     assert isinstance(kwargs.get("timeout"), float)

--- a/tests/tui_gateway/test_wait_for_mcp_discovery.py
+++ b/tests/tui_gateway/test_wait_for_mcp_discovery.py
@@ -7,6 +7,7 @@ discovery thread before building — bounded, so a dead server can't re-introduc
 the startup hang, and a no-op once discovery has finished.
 """
 
+import inspect
 import threading
 import time
 
@@ -28,6 +29,14 @@ def test_no_thread_is_noop():
         assert time.monotonic() - start < 0.1
     finally:
         _restore_thread_slot(saved)
+
+
+def test_default_wait_covers_slow_local_servers():
+    """Default first-snapshot wait should cover MCP discovery around 6 seconds."""
+    default_timeout = inspect.signature(
+        entry.wait_for_mcp_discovery
+    ).parameters["timeout"].default
+    assert default_timeout >= 6.0
 
 
 def test_already_finished_thread_is_noop():

--- a/tui_gateway/entry.py
+++ b/tui_gateway/entry.py
@@ -27,6 +27,7 @@ logger = logging.getLogger(__name__)
 # agent build briefly joins this so already-spawning fast servers land before
 # the agent snapshots its tool list (see wait_for_mcp_discovery).
 _mcp_discovery_thread = None
+DEFAULT_MCP_DISCOVERY_WAIT_SECONDS = 6.0
 
 
 def _install_sidecar_publisher() -> None:
@@ -192,7 +193,7 @@ def _log_exit(reason: str) -> None:
     print(f"[gateway-exit] {reason}", file=sys.stderr, flush=True)
 
 
-def wait_for_mcp_discovery(timeout: float = 0.75) -> None:
+def wait_for_mcp_discovery(timeout: float = DEFAULT_MCP_DISCOVERY_WAIT_SECONDS) -> None:
     """Briefly block until background MCP discovery finishes, up to ``timeout``.
 
     MCP discovery runs in a daemon thread spawned at startup (see main()) so a


### PR DESCRIPTION
## Summary

This PR tightens several continuity boundaries in the agent runtime:

- Preserve Codex backend cache routing by sending request-level `session_id` and `x-client-request-id` headers for stable prompt-cache keys.
- Flush the current conversation tail before compression rotates the session, so session persistence and memory extraction do not drop the active turn.
- Recover complete tool-call markup emitted as Anthropic text into normalized tool calls.
- Coerce `hermes config set` values based on the known default type, avoiding boolean coercion for string enums such as `approvals.mode=off`.
- Wait briefly for in-flight MCP discovery before agent construction and log MCP discovery failures with actionable warning context.
- Handle non-text macOS keychain stdout defensively when reading Claude Code credentials.

## Validation

- `git diff --check`
- `.venv/bin/python -m pytest tests/hermes_cli/test_set_config_value.py tests/hermes_cli/test_mcp_startup.py tests/tui_gateway/test_wait_for_mcp_discovery.py -q`  
  `45 passed`
- `.venv/bin/python -m pytest tests/agent/transports/test_codex_transport.py tests/agent/transports/test_transport.py -q`  
  `80 passed, 1 warning`
- `.venv/bin/python -m pytest tests/run_agent/test_compression_boundary_hook.py tests/run_agent/test_compression_persistence.py -q`  
  `13 passed, 1 warning`
- Live Codex cache probe with request-level session headers: second request reported `cached_tokens=5376`.

## Full-suite note

I also ran `scripts/run_tests.sh` after creating a local `.venv`. The run completed with `30975 passed`, `57 failed`, and `4` per-file timeouts. I did not treat that as a green full-suite because the failures were traced to local environment and runner constraints:

- local DNS maps `github.com`, `example.com`, and `cdn.discordapp.com` to `198.18.0.x`, triggering SSRF protections in browser/web/Discord/Matrix tests;
- `wecom` optional extra was missing initially; installing it made `tests/gateway/test_wecom_callback.py` pass;
- macOS lacks Linux `systemctl` / user D-Bus for systemd tests;
- `/tmp` resolves to `/private/tmp` on macOS;
- the per-file runner timeout is 140s while slow files pass individually, e.g. `tests/run_agent/test_run_agent.py` passed standalone in 322s.
