### PR TITLE
fix(gateway): clean stale stream previews after resend

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -1883,6 +1883,13 @@ class BasePlatformAdapter(ABC):
         # deliveries generation-aware and avoid stale runs clearing callbacks
         # registered by a fresher run for the same session.
         self._post_delivery_callbacks: Dict[str, Any] = {}
+        # Streamed preview messages that an upcoming final re-send will
+        # supersede.  Keyed by chat_id; registered by GatewayRunner when
+        # streaming could not confirm final delivery (e.g. the finalize
+        # edit hit flood control) and the normal final send must run.
+        # Consumed after that send succeeds; the stale previews are
+        # deleted so the user doesn't see a duplicate copy of the answer.
+        self._stale_stream_previews: Dict[str, list] = {}
         self._expected_cancelled_tasks: set[asyncio.Task] = set()
         self._busy_session_handler: Optional[Callable[[MessageEvent, str], Awaitable[bool]]] = None
         # Auto-TTS on voice input: ``_auto_tts_default`` is the global default
@@ -3335,6 +3342,38 @@ class BasePlatformAdapter(ABC):
         else:
             self._post_delivery_callbacks[session_key] = (int(generation), callback)
 
+    def register_stale_stream_preview(self, chat_id, message_ids) -> None:
+        """Remember streamed preview messages superseded by the next final send.
+
+        GatewayRunner calls this when the stream consumer could not confirm
+        final delivery (finalize edit failed, typically flood control) and
+        the normal final-send path will re-send the full response.  After
+        that send succeeds, ``_delete_stale_stream_preview`` removes these
+        messages so the user doesn't see the stuck raw preview AND the
+        fresh copy.  If the re-send fails, the previews are left in place
+        (they may be the only copy of the content the user has) and the
+        registration is dropped at the end of the processing cycle.
+        """
+        ids = [str(m) for m in (message_ids or []) if m and str(m) != "__no_edit__"]
+        if ids:
+            self._stale_stream_previews[str(chat_id)] = ids
+
+    async def _delete_stale_stream_preview(self, chat_id) -> None:
+        ids = self._stale_stream_previews.pop(str(chat_id), None)
+        if not ids:
+            return
+        delete_fn = getattr(self, "delete_message", None)
+        if not callable(delete_fn):
+            return
+        for mid in ids:
+            try:
+                await delete_fn(str(chat_id), mid)
+            except Exception:
+                logger.debug(
+                    "[%s] stale stream preview delete failed (%s)",
+                    self.name, mid, exc_info=True,
+                )
+
     def pop_post_delivery_callback(
         self,
         session_key: str,
@@ -4343,6 +4382,14 @@ class BasePlatformAdapter(ABC):
                     )
                     _record_delivery(result)
 
+                    # The fresh copy landed — remove any streamed preview
+                    # messages it supersedes (registered by GatewayRunner
+                    # when streaming couldn't confirm final delivery).
+                    if result.success:
+                        await self._delete_stale_stream_preview(
+                            event.source.chat_id
+                        )
+
                     # Schedule auto-deletion of system-notice replies.
                     # Detached so the handler returns immediately; errors
                     # (permission denied, message too old) are swallowed.
@@ -4596,6 +4643,11 @@ class BasePlatformAdapter(ABC):
                         )
                 except (asyncio.TimeoutError, Exception):
                     pass
+            # Drop any unconsumed stale-preview registration for this chat:
+            # the final send didn't happen or didn't succeed, so the preview
+            # must stay (it may be the only copy of the content). Without this
+            # drain, a later turn's send would delete it.
+            self._stale_stream_previews.pop(str(event.source.chat_id), None)
             # Some adapters keep platform-level typing tasks.  If callback
             # work or a late refresh recreated one, make one final bounded stop
             # before releasing the session guard.

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -16184,6 +16184,34 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                             "Failed to edit streamed message for session %s: %s",
                             session_key or "?", _edit_err,
                         )
+            elif not _is_empty_sentinel and _sc is not None:
+                # Streaming sent a preview but could not confirm final
+                # delivery (e.g. the finalize edit hit flood control), so
+                # the adapter's normal final-send path will re-send the
+                # full response.  Register the streamed preview messages
+                # for deletion after that send succeeds; otherwise the
+                # user sees the stuck raw preview AND the fresh copy
+                # (duplicate-answer bug, 2026-06-12 Telegram).
+                _preview_ids = list(
+                    getattr(_sc, "segment_message_ids", None) or []
+                )
+                _sc_adapter = getattr(_sc, "adapter", None)
+                if _preview_ids and hasattr(
+                    _sc_adapter, "register_stale_stream_preview"
+                ):
+                    try:
+                        _sc_adapter.register_stale_stream_preview(
+                            source.chat_id, _preview_ids
+                        )
+                        logger.info(
+                            "Registered %d stale stream preview message(s) for "
+                            "cleanup after final re-send (session %s).",
+                            len(_preview_ids), session_key or "?",
+                        )
+                    except Exception:
+                        logger.debug(
+                            "Stale preview registration failed", exc_info=True,
+                        )
 
         # Schedule deletion of tracked temporary progress bubbles after the
         # final response lands. Failed runs skip this so bubbles remain as

--- a/gateway/stream_consumer.py
+++ b/gateway/stream_consumer.py
@@ -242,6 +242,21 @@ class GatewayStreamConsumer:
         the subsequent cosmetic edit (cursor removal) failed."""
         return self._final_content_delivered
 
+    @property
+    def segment_message_ids(self) -> list:
+        """IDs of the platform messages holding the current segment's text.
+
+        After the consumer exits, this is the streamed copy of the final
+        answer.  If the gateway re-sends the response because delivery was
+        not confirmed, these messages become stale duplicates to delete."""
+        return list(self._preview_message_ids)
+
+    def _record_segment_message(self, *message_ids) -> None:
+        for mid in message_ids:
+            if not mid:
+                continue
+            self._track_preview_id(str(mid))
+
     async def _edit_message(
         self,
         *,
@@ -295,6 +310,7 @@ class GatewayStreamConsumer:
             return
         self._message_id = None
         self._message_created_ts = None
+        self._preview_message_ids = set()
         self._accumulated = ""
         self._last_sent_text = ""
         self._fallback_final_send = False
@@ -950,6 +966,7 @@ class GatewayStreamConsumer:
             sent_any_chunk = True
             last_successful_chunk = chunk
             last_message_id = result.message_id or last_message_id
+            self._record_segment_message(result.message_id)
             # Each fallback chunk is a fresh platform message — notify
             # so any stale tool-progress bubble gets closed off.
             self._notify_new_message()
@@ -1304,6 +1321,7 @@ class GatewayStreamConsumer:
         self._preview_message_ids = set()
         if new_message_id:
             self._message_id = new_message_id
+            self._track_preview_id(new_message_id)
             self._message_created_ts = time.monotonic()
         else:
             # Send succeeded but platform didn't return an id — treat the
@@ -1452,6 +1470,10 @@ class GatewayStreamConsumer:
                         # ``getattr`` with default keeps backwards compat with
                         # SimpleNamespace mocks in tests that pre-date the field.
                         _continuation_ids = getattr(result, "continuation_message_ids", ()) or ()
+                        self._record_segment_message(*_continuation_ids)
+                        self._record_segment_message(
+                            getattr(result, "message_id", None)
+                        )
                         if (
                             _continuation_ids
                             and result.message_id
@@ -1570,6 +1592,14 @@ class GatewayStreamConsumer:
                 if result.success:
                     if result.message_id:
                         self._message_id = result.message_id
+                        self._record_segment_message(result.message_id)
+                        # A long first send may have been split into several
+                        # platform messages — track them all as preview state.
+                        _raw = getattr(result, "raw_response", None)
+                        if isinstance(_raw, dict):
+                            self._record_segment_message(
+                                *(_raw.get("message_ids") or ())
+                            )
                         # Track when the preview first became visible to
                         # the user so fresh-final logic can detect stale
                         # preview timestamps on long-running responses.

--- a/tests/gateway/test_stale_stream_preview_cleanup.py
+++ b/tests/gateway/test_stale_stream_preview_cleanup.py
@@ -1,0 +1,86 @@
+"""Stale streamed-preview cleanup after a gateway final re-send.
+
+Regression tests for the 2026-06-12 Telegram duplicate-answer bug: the
+finalize edit hit flood control, the gateway re-sent the full response,
+and the raw streamed preview (asterisks + cursor) was left on screen
+alongside the fresh copy.
+
+GatewayRunner registers the preview message ids via
+``register_stale_stream_preview``; the adapter deletes them only after a
+successful final send and drops unconsumed registrations otherwise.
+"""
+
+import asyncio
+
+import pytest
+
+from gateway.config import Platform, PlatformConfig
+from gateway.platforms.base import BasePlatformAdapter, SendResult
+
+
+class StubAdapter(BasePlatformAdapter):
+    """Minimal concrete adapter with delete tracking."""
+
+    def __init__(self):
+        super().__init__(PlatformConfig(enabled=True, token="fake"), Platform.DISCORD)
+        self.deleted = []
+
+    async def connect(self):
+        return True
+
+    async def disconnect(self):
+        pass
+
+    async def send(self, chat_id, content, reply_to=None, metadata=None):
+        return SendResult(success=True, message_id="msg1")
+
+    async def send_typing(self, chat_id, metadata=None):
+        pass
+
+    async def get_chat_info(self, chat_id):
+        return {"id": chat_id}
+
+    async def delete_message(self, chat_id, message_id):
+        self.deleted.append((str(chat_id), str(message_id)))
+        return True
+
+
+def test_register_filters_sentinel_and_empty_ids():
+    adapter = StubAdapter()
+    adapter.register_stale_stream_preview("c1", ["10", None, "__no_edit__", "11"])
+    assert adapter._stale_stream_previews == {"c1": ["10", "11"]}
+
+
+def test_register_with_no_usable_ids_is_a_noop():
+    adapter = StubAdapter()
+    adapter.register_stale_stream_preview("c1", [None, "__no_edit__"])
+    assert adapter._stale_stream_previews == {}
+
+
+def test_delete_consumes_registration_and_deletes_all():
+    adapter = StubAdapter()
+    adapter.register_stale_stream_preview("c1", ["10", "11"])
+    asyncio.run(adapter._delete_stale_stream_preview("c1"))
+    assert adapter.deleted == [("c1", "10"), ("c1", "11")]
+    assert adapter._stale_stream_previews == {}
+
+
+def test_delete_without_registration_is_a_noop():
+    adapter = StubAdapter()
+    asyncio.run(adapter._delete_stale_stream_preview("c1"))
+    assert adapter.deleted == []
+
+
+def test_delete_survives_platform_errors():
+    adapter = StubAdapter()
+
+    async def _failing_delete(chat_id, message_id):
+        adapter.deleted.append((str(chat_id), str(message_id)))
+        raise RuntimeError("message too old")
+
+    adapter.delete_message = _failing_delete
+    adapter.register_stale_stream_preview("c1", ["10", "11"])
+    asyncio.run(adapter._delete_stale_stream_preview("c1"))
+    # Both deletes attempted despite the first raising; registry drained.
+    assert adapter.deleted == [("c1", "10"), ("c1", "11")]
+    assert adapter._stale_stream_previews == {}


### PR DESCRIPTION
## Summary
- track streamed preview message ids through `GatewayStreamConsumer` so the gateway can identify previews left behind by a failed finalize edit
- register those preview ids when final streaming delivery is not confirmed and the normal final-send path will resend the answer
- delete the stale previews only after the fresh final send succeeds, and drain stale registrations when it does not

## Tests
- `python3 -m pytest tests/gateway/test_stale_stream_preview_cleanup.py tests/gateway/test_duplicate_reply_suppression.py -q`
  - 29 passed
- `python3 -m pytest tests/gateway/test_stream_consumer.py tests/gateway/test_stale_stream_preview_cleanup.py -q`
  - 97 passed, 1 skipped