### PR TITLE
feat(providers): support external-process client hooks

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -746,7 +746,7 @@ def init_agent(
                 client_kwargs = {"api_key": api_key, "base_url": base_url}
             if _provider_timeout is not None:
                 client_kwargs["timeout"] = _provider_timeout
-            if agent.provider == "copilot-acp":
+            if str(base_url or "").lower().startswith(("acp://", "acp+tcp://")):
                 client_kwargs["command"] = agent.acp_command
                 client_kwargs["args"] = agent.acp_args
             effective_base = base_url

--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -1362,6 +1362,37 @@ def create_openai_client(agent, client_kwargs: dict, *, reason: str, shared: boo
     client_kwargs = dict(client_kwargs)
     _validate_proxy_env_urls()
     _validate_base_url(client_kwargs.get("base_url"))
+    try:
+        from providers import get_provider_profile
+
+        profile = get_provider_profile(getattr(agent, "provider", "") or "")
+    except Exception:
+        profile = None
+    client_module = str(getattr(profile, "client_module", "") or "").strip()
+    client_class = str(getattr(profile, "client_class", "") or "").strip()
+    if client_module and client_class:
+        import importlib
+
+        module = importlib.import_module(client_module)
+        cls = getattr(module, client_class)
+        profile_kwargs = dict(client_kwargs)
+        if getattr(profile, "client_receives_agent_context", False):
+            profile_kwargs.setdefault("agent", agent)
+            hsid = getattr(agent, "session_id", None) or getattr(agent, "_session_id", None)
+            if hsid:
+                profile_kwargs.setdefault("hermes_session_id", str(hsid))
+            platform = getattr(agent, "platform", None)
+            if platform:
+                profile_kwargs.setdefault("platform", platform)
+        client = cls(**profile_kwargs)
+        _ra().logger.info(
+            "%s client created (%s, shared=%s) %s",
+            getattr(profile, "name", getattr(agent, "provider", "provider")),
+            reason,
+            shared,
+            agent._client_log_context(),
+        )
+        return client
     if agent.provider == "copilot-acp" or str(client_kwargs.get("base_url", "")).startswith("acp://copilot"):
         from agent.copilot_acp_client import CopilotACPClient
 

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -4016,6 +4016,44 @@ def resolve_provider_client(
             or _read_main_model(),
             provider,
         )
+        try:
+            from providers import get_provider_profile as _gpf_external_process
+
+            _profile = _gpf_external_process(provider)
+        except Exception:
+            _profile = None
+        _client_module = str(getattr(_profile, "client_module", "") or "").strip()
+        _client_class = str(getattr(_profile, "client_class", "") or "").strip()
+        if _client_module and _client_class:
+            api_key = str(creds.get("api_key", "")).strip()
+            base_url = str(creds.get("base_url", "")).strip()
+            command = str(creds.get("command", "")).strip() or None
+            args = list(creds.get("args") or [])
+            if not final_model:
+                logger.warning(
+                    "resolve_provider_client: %s requested but no model was provided or configured",
+                    provider,
+                )
+                return None, None
+            if not api_key or not base_url:
+                logger.warning(
+                    "resolve_provider_client: %s requested but external process credentials are incomplete",
+                    provider,
+                )
+                return None, None
+            import importlib
+
+            _module = importlib.import_module(_client_module)
+            _cls = getattr(_module, _client_class)
+            client = _cls(
+                api_key=api_key,
+                base_url=base_url,
+                command=command,
+                args=args,
+            )
+            logger.debug("resolve_provider_client: %s (%s)", provider, final_model)
+            return (_to_async_client(client, final_model, is_vision=is_vision) if async_mode
+                    else (client, final_model))
         if provider == "copilot-acp":
             api_key = str(creds.get("api_key", "")).strip()
             base_url = str(creds.get("base_url", "")).strip()

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -446,7 +446,7 @@ PROVIDER_REGISTRY: Dict[str, ProviderConfig] = {
     ),
 }
 
-# Auto-extend PROVIDER_REGISTRY with any api-key provider registered in
+# Auto-extend PROVIDER_REGISTRY with any api-key or external-process provider registered in
 # providers/ that is not already declared above.  New providers only need a
 # plugins/model-providers/<name>/ plugin — no edits to this file required.
 try:
@@ -454,7 +454,9 @@ try:
     for _pp in _list_providers_for_registry():
         if _pp.name in PROVIDER_REGISTRY:
             continue
-        if _pp.auth_type != "api_key" or not _pp.env_vars:
+        if _pp.auth_type not in {"api_key", "external_process"}:
+            continue
+        if _pp.auth_type == "api_key" and not _pp.env_vars:
             continue
         # Skip providers that need custom token resolution or are special-cased
         # in resolve_provider() (copilot/kimi/zai have bespoke token refresh;
@@ -468,7 +470,7 @@ try:
         PROVIDER_REGISTRY[_pp.name] = ProviderConfig(
             id=_pp.name,
             name=_pp.display_name or _pp.name,
-            auth_type="api_key",
+            auth_type=_pp.auth_type,
             inference_base_url=_pp.base_url,
             api_key_env_vars=_api_key_vars or _pp.env_vars,
             base_url_env_var=_base_url_var or "",
@@ -6111,23 +6113,67 @@ def get_api_key_provider_status(provider_id: str) -> Dict[str, Any]:
     }
 
 
+def _external_process_profile(provider_id: str):
+    """Return ProviderProfile metadata for an external-process provider."""
+    try:
+        from providers import get_provider_profile
+
+        profile = get_provider_profile(provider_id)
+    except Exception:
+        profile = None
+    if profile is not None and getattr(profile, "auth_type", "") == "external_process":
+        return profile
+    return None
+
+
+def _external_process_runtime_settings(provider_id: str, pconfig: ProviderConfig) -> Dict[str, Any]:
+    profile = _external_process_profile(provider_id) or _external_process_profile(pconfig.id)
+    is_copilot = provider_id == "copilot-acp" or pconfig.id == "copilot-acp"
+
+    command_env_vars = tuple(getattr(profile, "external_process_command_env_vars", ()) or ())
+    default_command = str(getattr(profile, "external_process_default_command", "") or "").strip()
+    args_env_var = str(getattr(profile, "external_process_args_env_var", "") or "").strip()
+    default_args = tuple(getattr(profile, "external_process_default_args", ()) or ())
+    api_key = str(getattr(profile, "external_process_api_key", "") or "").strip()
+    missing_hint = str(getattr(profile, "external_process_missing_command_hint", "") or "").strip()
+
+    if is_copilot:
+        command_env_vars = command_env_vars or ("HERMES_COPILOT_ACP_COMMAND", "COPILOT_CLI_PATH")
+        default_command = default_command or "copilot"
+        args_env_var = args_env_var or "HERMES_COPILOT_ACP_ARGS"
+        default_args = default_args or ("--acp", "--stdio")
+        api_key = api_key or "copilot-acp"
+        missing_hint = missing_hint or (
+            "Install GitHub Copilot CLI or set HERMES_COPILOT_ACP_COMMAND/COPILOT_CLI_PATH."
+        )
+
+    command = next((os.getenv(var, "").strip() for var in command_env_vars if os.getenv(var, "").strip()), "")
+    command = command or default_command
+    raw_args = os.getenv(args_env_var, "").strip() if args_env_var else ""
+    args = shlex.split(raw_args) if raw_args else list(default_args)
+    base_url = os.getenv(pconfig.base_url_env_var, "").strip() if pconfig.base_url_env_var else ""
+    if not base_url:
+        base_url = pconfig.inference_base_url
+
+    return {
+        "api_key": api_key or provider_id,
+        "base_url": base_url,
+        "command": command,
+        "args": args,
+        "missing_hint": missing_hint,
+    }
+
+
 def get_external_process_provider_status(provider_id: str) -> Dict[str, Any]:
     """Status snapshot for providers that run a local subprocess."""
     pconfig = PROVIDER_REGISTRY.get(provider_id)
     if not pconfig or pconfig.auth_type != "external_process":
         return {"configured": False}
 
-    command = (
-        os.getenv("HERMES_COPILOT_ACP_COMMAND", "").strip()
-        or os.getenv("COPILOT_CLI_PATH", "").strip()
-        or "copilot"
-    )
-    raw_args = os.getenv("HERMES_COPILOT_ACP_ARGS", "").strip()
-    args = shlex.split(raw_args) if raw_args else ["--acp", "--stdio"]
-    base_url = os.getenv(pconfig.base_url_env_var, "").strip() if pconfig.base_url_env_var else ""
-    if not base_url:
-        base_url = pconfig.inference_base_url
-
+    settings = _external_process_runtime_settings(provider_id, pconfig)
+    command = settings["command"]
+    args = settings["args"]
+    base_url = settings["base_url"]
     resolved_command = shutil.which(command) if command else None
     return {
         "configured": bool(resolved_command or base_url.startswith("acp+tcp://")),
@@ -6160,12 +6206,12 @@ def get_auth_status(provider_id: Optional[str] = None) -> Dict[str, Any]:
         return get_gemini_oauth_auth_status()
     if target == "minimax-oauth":
         return get_minimax_oauth_auth_status()
-    if target == "copilot-acp":
-        return get_external_process_provider_status(target)
     if target == "azure-foundry":
         return _get_azure_foundry_auth_status()
-    # API-key providers
     pconfig = PROVIDER_REGISTRY.get(target)
+    if pconfig and pconfig.auth_type == "external_process":
+        return get_external_process_provider_status(target)
+    # API-key providers
     if pconfig and pconfig.auth_type == "api_key":
         return get_api_key_provider_status(target)
     # AWS SDK providers (Bedrock) — check via boto3 credential chain
@@ -6310,29 +6356,23 @@ def resolve_external_process_provider_credentials(provider_id: str) -> Dict[str,
             code="invalid_provider",
         )
 
-    base_url = os.getenv(pconfig.base_url_env_var, "").strip() if pconfig.base_url_env_var else ""
-    if not base_url:
-        base_url = pconfig.inference_base_url
-
-    command = (
-        os.getenv("HERMES_COPILOT_ACP_COMMAND", "").strip()
-        or os.getenv("COPILOT_CLI_PATH", "").strip()
-        or "copilot"
-    )
-    raw_args = os.getenv("HERMES_COPILOT_ACP_ARGS", "").strip()
-    args = shlex.split(raw_args) if raw_args else ["--acp", "--stdio"]
+    settings = _external_process_runtime_settings(provider_id, pconfig)
+    base_url = settings["base_url"]
+    command = settings["command"]
+    args = settings["args"]
     resolved_command = shutil.which(command) if command else None
     if not resolved_command and not base_url.startswith("acp+tcp://"):
+        hint = settings.get("missing_hint") or f"Install the CLI for provider '{provider_id}' or configure its command env var."
         raise AuthError(
-            f"Could not find the Copilot CLI command '{command}'. "
-            "Install GitHub Copilot CLI or set HERMES_COPILOT_ACP_COMMAND/COPILOT_CLI_PATH.",
+            f"Could not find the external-process command '{command}' for provider '{provider_id}'. "
+            f"{hint}",
             provider=provider_id,
-            code="missing_copilot_cli",
+            code="missing_external_process_cli",
         )
 
     return {
         "provider": provider_id,
-        "api_key": "copilot-acp",
+        "api_key": settings["api_key"],
         "base_url": base_url.rstrip("/"),
         "command": resolved_command or command,
         "args": args,

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -1557,10 +1557,11 @@ def resolve_runtime_provider(
             logger.info("Google Gemini OAuth credentials failed; "
                         "falling through to next provider.")
 
-    if provider == "copilot-acp":
+    pconfig = PROVIDER_REGISTRY.get(provider)
+    if pconfig and pconfig.auth_type == "external_process":
         creds = resolve_external_process_provider_credentials(provider)
         return {
-            "provider": "copilot-acp",
+            "provider": provider,
             "api_mode": "chat_completions",
             "base_url": creds.get("base_url", "").rstrip("/"),
             "api_key": creds.get("api_key", ""),

--- a/providers/base.py
+++ b/providers/base.py
@@ -83,6 +83,22 @@ class ProviderProfile:
 
     # ── Client-level quirks (set once at client construction) ─
     default_headers: dict[str, str] = field(default_factory=dict)
+    # Optional OpenAI-compatible client implementation for providers that do
+    # not use the stock OpenAI SDK client. The module/class are imported lazily
+    # by agent runtime construction.
+    client_module: str = ""
+    client_class: str = ""
+    client_receives_agent_context: bool = False
+
+    # External-process provider metadata. Used when auth_type is
+    # "external_process" so out-of-tree provider plugins can declare command
+    # resolution without adding provider-specific branches to core.
+    external_process_api_key: str = ""
+    external_process_command_env_vars: tuple = ()
+    external_process_default_command: str = ""
+    external_process_args_env_var: str = ""
+    external_process_default_args: tuple = ()
+    external_process_missing_command_hint: str = ""
 
     # ── Request-level quirks ─────────────────────────────────
     # Temperature: None = use caller's default, OMIT_TEMPERATURE = don't send

--- a/tests/run_agent/test_external_process_provider_hooks.py
+++ b/tests/run_agent/test_external_process_provider_hooks.py
@@ -1,0 +1,131 @@
+import sys
+import types
+
+from providers.base import ProviderProfile
+
+
+def test_create_openai_client_uses_external_process_profile_client(monkeypatch):
+    from agent.agent_runtime_helpers import create_openai_client
+
+    calls = {}
+    module = types.ModuleType("fake_external_client")
+
+    class FakeExternalClient:
+        def __init__(self, **kwargs):
+            calls.update(kwargs)
+
+    module.FakeExternalClient = FakeExternalClient
+    monkeypatch.setitem(sys.modules, "fake_external_client", module)
+
+    profile = ProviderProfile(
+        name="fake-acp",
+        auth_type="external_process",
+        base_url="acp://fake",
+        client_module="fake_external_client",
+        client_class="FakeExternalClient",
+        client_receives_agent_context=True,
+    )
+    monkeypatch.setattr(
+        "providers.get_provider_profile",
+        lambda name: profile if name == "fake-acp" else None,
+    )
+
+    agent = types.SimpleNamespace(
+        provider="fake-acp",
+        session_id="session-123",
+        platform="telegram",
+        _client_log_context=lambda: "ctx",
+    )
+
+    client = create_openai_client(
+        agent,
+        {"api_key": "fake-key", "base_url": "acp://fake", "command": "fake"},
+        reason="test",
+        shared=False,
+    )
+
+    assert isinstance(client, FakeExternalClient)
+    assert calls["api_key"] == "fake-key"
+    assert calls["base_url"] == "acp://fake"
+    assert calls["command"] == "fake"
+    assert calls["agent"] is agent
+    assert calls["hermes_session_id"] == "session-123"
+    assert calls["platform"] == "telegram"
+
+
+def test_external_process_credentials_use_provider_profile(monkeypatch):
+    from hermes_cli import auth
+
+    profile = ProviderProfile(
+        name="fake-acp",
+        auth_type="external_process",
+        base_url="acp://fake",
+        external_process_api_key="fake-acp",
+        external_process_command_env_vars=("FAKE_ACP_COMMAND",),
+        external_process_default_command="fake-cli",
+        external_process_args_env_var="FAKE_ACP_ARGS",
+        external_process_default_args=("--acp", "--stdio"),
+    )
+    monkeypatch.setattr(
+        "providers.get_provider_profile",
+        lambda name: profile if name == "fake-acp" else None,
+    )
+    monkeypatch.setitem(
+        auth.PROVIDER_REGISTRY,
+        "fake-acp",
+        auth.ProviderConfig(
+            id="fake-acp",
+            name="Fake ACP",
+            auth_type="external_process",
+            inference_base_url="acp://fake",
+            base_url_env_var="FAKE_ACP_BASE_URL",
+        ),
+    )
+    monkeypatch.setenv("FAKE_ACP_COMMAND", "fake-bin")
+    monkeypatch.setenv("FAKE_ACP_ARGS", "--stdio --debug")
+    monkeypatch.setattr(auth.shutil, "which", lambda command: f"/bin/{command}")
+
+    creds = auth.resolve_external_process_provider_credentials("fake-acp")
+
+    assert creds["provider"] == "fake-acp"
+    assert creds["api_key"] == "fake-acp"
+    assert creds["base_url"] == "acp://fake"
+    assert creds["command"] == "/bin/fake-bin"
+    assert creds["args"] == ["--stdio", "--debug"]
+
+
+def test_runtime_provider_resolves_generic_external_process(monkeypatch):
+    from hermes_cli import runtime_provider
+    from hermes_cli.auth import ProviderConfig
+
+    monkeypatch.setitem(
+        runtime_provider.PROVIDER_REGISTRY,
+        "fake-acp",
+        ProviderConfig(
+            id="fake-acp",
+            name="Fake ACP",
+            auth_type="external_process",
+            inference_base_url="acp://fake",
+        ),
+    )
+    monkeypatch.setattr(
+        runtime_provider,
+        "resolve_external_process_provider_credentials",
+        lambda provider: {
+            "provider": provider,
+            "api_key": "fake-acp",
+            "base_url": "acp://fake",
+            "command": "/bin/fake",
+            "args": ["--acp"],
+            "source": "process",
+        },
+    )
+
+    resolved = runtime_provider.resolve_runtime_provider(requested="fake-acp")
+
+    assert resolved["provider"] == "fake-acp"
+    assert resolved["api_mode"] == "chat_completions"
+    assert resolved["base_url"] == "acp://fake"
+    assert resolved["api_key"] == "fake-acp"
+    assert resolved["command"] == "/bin/fake"
+    assert resolved["args"] == ["--acp"]


### PR DESCRIPTION
## Summary
- add optional ProviderProfile metadata for external-process client construction
- allow provider profiles to declare command/env/args defaults for local subprocess-backed providers
- route runtime, auth, main client creation, and auxiliary client creation through profile metadata before falling back to built-in Copilot ACP handling

## Why
This makes subprocess-backed model providers installable as out-of-tree provider plugins instead of requiring provider-specific branches in Hermes core. The immediate use case is moving a local Claude Code ACP provider out of the fork.

## Tests
- `.venv/bin/python -m pytest tests/run_agent/test_external_process_provider_hooks.py -q`
  - 3 passed
- `.venv/bin/python -m pytest tests/hermes_cli/test_api_key_providers.py tests/run_agent/test_run_agent.py::test_aiagent_uses_copilot_acp_client tests/agent/test_copilot_acp_client.py -q`
  - 173 passed