### PR TITLE
fix(agent): warn when memory.provider is unrecognized or unavailable

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1147,6 +1147,26 @@ def init_agent(
                 from plugins.memory import load_memory_provider as _load_mem
                 agent._memory_manager = _MemoryManager()
                 _mp = _load_mem(_mem_provider_name)
+                if _mp is None:
+                    # Provider name not found — warn with valid options
+                    try:
+                        from plugins.memory import discover_memory_providers as _discover_mp
+                        _valid = [n for n, _d, _a in _discover_mp()]
+                        _valid_str = ", ".join(sorted(_valid)) if _valid else "(none)"
+                    except Exception:
+                        _valid_str = "(discovery failed)"
+                    logger.warning(
+                        "memory.provider '%s' is not a recognized memory provider. "
+                        "Valid providers: %s. Falling back to built-in memory.",
+                        _mem_provider_name, _valid_str,
+                    )
+                elif not _mp.is_available():
+                    logger.warning(
+                        "memory.provider '%s' was found but is not available "
+                        "(missing credentials or dependencies). "
+                        "Falling back to built-in memory.",
+                        _mem_provider_name,
+                    )
                 if _mp and _mp.is_available():
                     agent._memory_manager.add_provider(_mp)
                 if agent._memory_manager.providers:

--- a/tests/run_agent/test_memory_provider_init.py
+++ b/tests/run_agent/test_memory_provider_init.py
@@ -1,5 +1,6 @@
 """Regression tests for memory provider selection during AIAgent init."""
 
+import logging
 from types import SimpleNamespace
 from unittest.mock import patch
 
@@ -132,3 +133,106 @@ def test_core_tool_names_rejected_from_memory_routing_table():
     assert "clarify" not in schema_names
     assert "delegate_task" not in schema_names
     assert "honcho_search" in schema_names
+
+
+def test_unknown_memory_provider_logs_warning_with_valid_options(caplog):
+    """Setting memory.provider to an unrecognized name should log a WARNING
+    listing valid providers, not fail silently (#47650)."""
+    cfg = {"memory": {"provider": "lm-studio"}, "agent": {}}
+
+    with (
+        patch("hermes_cli.config.load_config", return_value=cfg),
+        patch("plugins.memory.load_memory_provider", return_value=None),
+        patch(
+            "plugins.memory.discover_memory_providers",
+            return_value=[("builtin", "Built-in", True), ("honcho", "Honcho", False)],
+        ),
+        patch("agent.model_metadata.get_model_context_length", return_value=204_800),
+        patch("run_agent.get_tool_definitions", return_value=[]),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI"),
+    ):
+        from run_agent import AIAgent
+
+        with caplog.at_level(logging.WARNING, logger="agent.agent_init"):
+            agent = AIAgent(
+                api_key="test-key-1234567890",
+                base_url="https://openrouter.ai/api/v1",
+                quiet_mode=True,
+                skip_context_files=True,
+                skip_memory=False,
+            )
+
+    # Warning must mention the invalid name and list valid providers
+    warning_msgs = [r.message for r in caplog.records if r.levelno >= logging.WARNING]
+    assert any("lm-studio" in m and "builtin" in m and "honcho" in m for m in warning_msgs), (
+        f"Expected warning about 'lm-studio' with valid providers, got: {warning_msgs}"
+    )
+
+
+def test_unavailable_memory_provider_logs_warning(caplog):
+    """A known memory provider that reports is_available()=False should warn (#47650)."""
+
+    class UnavailableProvider:
+        name = "unavailable-mem"
+
+        def is_available(self):
+            return False
+
+    cfg = {"memory": {"provider": "unavailable-mem"}, "agent": {}}
+
+    with (
+        patch("hermes_cli.config.load_config", return_value=cfg),
+        patch("plugins.memory.load_memory_provider", return_value=UnavailableProvider()),
+        patch("agent.model_metadata.get_model_context_length", return_value=204_800),
+        patch("run_agent.get_tool_definitions", return_value=[]),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI"),
+    ):
+        from run_agent import AIAgent
+
+        with caplog.at_level(logging.WARNING, logger="agent.agent_init"):
+            agent = AIAgent(
+                api_key="test-key-1234567890",
+                base_url="https://openrouter.ai/api/v1",
+                quiet_mode=True,
+                skip_context_files=True,
+                skip_memory=False,
+            )
+
+    warning_msgs = [r.message for r in caplog.records if r.levelno >= logging.WARNING]
+    assert any("unavailable-mem" in m and "not available" in m for m in warning_msgs), (
+        f"Expected warning about 'unavailable-mem' not available, got: {warning_msgs}"
+    )
+
+
+def test_valid_memory_provider_no_warning(caplog):
+    """A valid, available memory provider should not trigger any validation warning (#47650)."""
+    cfg = {"memory": {"provider": "recording"}, "agent": {}}
+
+    with (
+        patch("hermes_cli.config.load_config", return_value=cfg),
+        patch("plugins.memory.load_memory_provider", return_value=RecordingMemoryProvider()),
+        patch("agent.model_metadata.get_model_context_length", return_value=204_800),
+        patch("run_agent.get_tool_definitions", return_value=[]),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI"),
+    ):
+        from run_agent import AIAgent
+
+        with caplog.at_level(logging.WARNING, logger="agent.agent_init"):
+            agent = AIAgent(
+                api_key="test-key-1234567890",
+                base_url="https://openrouter.ai/api/v1",
+                quiet_mode=True,
+                skip_context_files=True,
+                skip_memory=False,
+            )
+
+    # Valid provider should be activated, no validation warnings
+    assert agent._memory_manager is not None
+    assert len(agent._memory_manager.providers) > 0
+    warning_msgs = [r.message for r in caplog.records if r.levelno >= logging.WARNING]
+    assert not any("not a recognized" in m or "not available" in m for m in warning_msgs), (
+        f"Unexpected validation warning for valid provider: {warning_msgs}"
+    )


### PR DESCRIPTION
## What does this PR do?

Adds validation warnings when `memory.provider` is set to an unrecognized or unavailable value. Previously, invalid provider names (e.g. LLM provider names like `lm-studio`) were silently accepted, leaving users with no indication their memory system was broken.

## Related Issue

Fixes #47650

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/agent_init.py`: Added two warning paths after `load_memory_provider()` — one for unrecognized provider names (lists valid options from `discover_memory_providers()`), one for known providers that report `is_available()=False` (missing credentials/dependencies).
- `tests/run_agent/test_memory_provider_init.py`: Added 3 regression tests — unknown provider warning, unavailable provider warning, and valid provider no-warning.

## How to Test

1. Set `memory.provider: lm-studio` in config.yaml (an LLM provider, not a memory provider)
2. Start Hermes — verify a WARNING is logged: `memory.provider 'lm-studio' is not a recognized memory provider. Valid providers: builtin, honcho, ...`
3. Set `memory.provider: honcho` without Honcho credentials configured
4. Start Hermes — verify a WARNING is logged: `memory.provider 'honcho' was found but is not available`
5. Run `pytest tests/run_agent/test_memory_provider_init.py -q` — all 6 tests pass

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `agent/agent_init.py` (memory provider init path, lines 1138-1221)
- Blast radius: LOW — only adds warning log messages; no control flow changes for valid providers
- Related patterns: `load_memory_provider()` returns None for unknown names; `discover_memory_providers()` returns `(name, desc, available)` tuples
