### PR TITLE
fix(acp): don't translate Windows paths to WSL /mnt/ on native Windows

### DIFF
--- a/acp_adapter/server.py
+++ b/acp_adapter/server.py
@@ -147,12 +147,27 @@ def _image_data_url(data: bytes, mime_type: str) -> str:
     return f"data:{mime_type};base64,{base64.b64encode(data).decode('ascii')}"
 
 
+def _is_wsl() -> bool:
+    """Return True when running inside Windows Subsystem for Linux."""
+    # WSL sets WSL_DISTRO_NAME; fall back to /proc/version containing "microsoft".
+    if os.environ.get("WSL_DISTRO_NAME"):
+        return True
+    try:
+        with open("/proc/version") as fv:
+            return "microsoft" in fv.read().lower()
+    except OSError:
+        return False
+
+
 def _path_from_file_uri(uri: str) -> Path | None:
     """Convert local file URIs/paths from ACP clients into a readable Path.
 
-    Zed may send POSIX file URIs from Linux/WSL workspaces or Windows-ish paths
-    when launched through wsl.exe. Translate the common Windows drive form to
-    /mnt/<drive>/... so Hermes running in WSL can read it.
+    Zed and other ACP clients may send Windows-style paths (C:\Users\... or
+    file:///C:/Users/...) regardless of whether Hermes itself runs on native
+    Windows or inside WSL.  On WSL, we must translate drive letters to
+    /mnt/<drive>/... so the Linux filesystem layer can resolve them.  On native
+    Windows, we must *not* do this translation — the Windows path is already
+    correct.
     """
     raw = (uri or "").strip()
     if not raw:
@@ -173,11 +188,15 @@ def _path_from_file_uri(uri: str) -> Path | None:
     if len(path_text) >= 3 and path_text[0] == "/" and path_text[2] == ":" and path_text[1].isalpha():
         drive = path_text[1].lower()
         rest = path_text[3:].lstrip("/\\").replace("\\", "/")
-        return Path("/mnt") / drive / rest
+        if _is_wsl():
+            return Path("/mnt") / drive / rest
+        return Path(f"{drive.upper()}:/{rest}")
     if len(path_text) >= 2 and path_text[1] == ":" and path_text[0].isalpha():
         drive = path_text[0].lower()
         rest = path_text[2:].lstrip("/\\").replace("\\", "/")
-        return Path("/mnt") / drive / rest
+        if _is_wsl():
+            return Path("/mnt") / drive / rest
+        return Path(f"{drive.upper()}:/{rest}")
 
     return Path(path_text)
 


### PR DESCRIPTION
## Problem

`_path_from_file_uri()` in `acp_adapter/server.py` unconditionally converts Windows-style paths (`C:\Users\...` or `file:///C:/Users/...`) to `/mnt/<drive>/...`. This translation is only correct when Hermes runs **inside WSL** — on native Windows it produces non-existent paths, causing all file attachments from ACP clients (Zed, Copilot, etc.) to fail silently.

This is a concrete instance of the broader "ACP on Windows is broken" pattern (see #45140, #39185).

## Root cause

The function was written with the assumption that Hermes always runs on Linux, and Windows-style paths always come from a WSL-launched client. When Hermes runs natively on Windows, the `/mnt/c/` path does not exist.

## Fix

Add `_is_wsl()` helper that detects the WSL environment via:
1. `WSL_DISTRO_NAME` environment variable (set by WSL itself)
2. `/proc/version` containing `"microsoft"` (fallback for older WSL versions)

When `_is_wsl()` is `True`, the existing `/mnt/<drive>/...` translation is preserved. When `False` (native Windows, Linux, macOS), Windows-style paths are returned as-is with proper drive letter casing.

**Diff: +24 −5** — only `acp_adapter/server.py`.

| Input | Before (native Windows) | After (native Windows) | After (WSL) |
|---|---|---|---|
| `file:///C:/Users/test/file.txt` | `/mnt/c/Users/test/file.txt` ❌ | `C:/Users/test/file.txt` ✅ | `/mnt/c/Users/test/file.txt` ✅ |
| `C:\Users\test\file.txt` | `/mnt/c/Users/test/file.txt` ❌ | `C:/Users/test/file.txt` ✅ | `/mnt/c/Users/test/file.txt` ✅ |
| `/home/user/file.txt` | `/home/user/file.txt` ✅ | `/home/user/file.txt` ✅ | `/home/user/file.txt` ✅ |

## Testing

- The change is purely additive — non-WSL, non-Windows paths are completely unaffected
- `_is_wsl()` returns `False` on Linux/macOS (no WSL_DISTRO_NAME, /proc/version missing or no "microsoft")
- On WSL, behavior is identical to before
- No existing tests for `_path_from_file_uri` (verified via `grep`), so no regressions