### PR TITLE
fix(desktop): keep clarify visible in silent tool mode

### DIFF
--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -1598,6 +1598,58 @@ def _session(agent=None, **extra):
     }
 
 
+def test_clarify_lifecycle_emits_when_tool_progress_off(monkeypatch):
+    """Blocking clarify prompts must stay visible even in silent tool mode."""
+    emitted = []
+
+    monkeypatch.setattr(
+        server,
+        "_emit",
+        lambda event, sid, payload=None: emitted.append((event, sid, payload)),
+    )
+    server._sessions["sid"] = _session(tool_progress_mode="off")
+    try:
+        server._on_tool_start(
+            "sid",
+            "tc-clarify",
+            "clarify",
+            {"question": "Pick one", "choices": ["A", "B"]},
+        )
+        server._on_tool_complete(
+            "sid",
+            "tc-clarify",
+            "clarify",
+            {"question": "Pick one", "choices": ["A", "B"]},
+            '{"user_response":"A"}',
+        )
+    finally:
+        server._sessions.pop("sid", None)
+
+    assert [event for event, _, _ in emitted] == ["tool.start", "tool.complete"]
+    assert emitted[0][2]["name"] == "clarify"
+    assert emitted[0][2]["tool_id"] == "tc-clarify"
+    assert emitted[1][2]["result"] == {"user_response": "A"}
+
+
+def test_non_blocking_tool_lifecycle_stays_hidden_when_tool_progress_off(monkeypatch):
+    """The clarify exception must not turn silent mode back on globally."""
+    emitted = []
+
+    monkeypatch.setattr(
+        server,
+        "_emit",
+        lambda event, sid, payload=None: emitted.append((event, sid, payload)),
+    )
+    server._sessions["sid"] = _session(tool_progress_mode="off")
+    try:
+        server._on_tool_start("sid", "tc-read", "read_file", {"path": "README.md"})
+        server._on_tool_complete("sid", "tc-read", "read_file", {"path": "README.md"}, "contents")
+    finally:
+        server._sessions.pop("sid", None)
+
+    assert emitted == []
+
+
 def test_session_close_commits_memory_and_fires_finalize_hook(monkeypatch):
     calls = {"hooks": []}
 

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -2021,6 +2021,21 @@ def _tool_progress_enabled(sid: str) -> bool:
     return _session_tool_progress_mode(sid) != "off"
 
 
+_BLOCKING_PROMPT_TOOLS = {"clarify"}
+
+
+def _should_emit_tool_lifecycle(sid: str, name: str | None) -> bool:
+    """Whether desktop/TUI clients need a live tool row for this call.
+
+    ``display.tool_progress=off`` suppresses ordinary tool progress, but tools
+    that block on user input still need their pending row rendered.  The
+    desktop clarify UI mounts from the ``clarify`` tool-call row while the
+    request id arrives separately via ``clarify.request``; hiding that row makes
+    the agent wait until timeout with no visible choices.
+    """
+    return _tool_progress_enabled(sid) or name in _BLOCKING_PROMPT_TOOLS
+
+
 def _restart_slash_worker(sid: str, session: dict):
     worker = session.get("slash_worker")
     if worker:
@@ -2733,7 +2748,7 @@ def _on_tool_start(sid: str, tool_call_id: str, name: str, args: dict):
         except Exception:
             pass
         session.setdefault("tool_started_at", {})[tool_call_id] = time.time()
-    if _tool_progress_enabled(sid):
+    if _should_emit_tool_lifecycle(sid, name):
         payload = {
             "tool_id": tool_call_id,
             "name": name,
@@ -2791,7 +2806,7 @@ def _on_tool_complete(sid: str, tool_call_id: str, name: str, args: dict, result
             payload["inline_diff"] = "\n".join(rendered)
     except Exception:
         pass
-    if _tool_progress_enabled(sid) or payload.get("inline_diff"):
+    if _should_emit_tool_lifecycle(sid, name) or payload.get("inline_diff"):
         _emit("tool.complete", sid, payload)
 
 


### PR DESCRIPTION
## Summary
- Emit `clarify` tool lifecycle events even when `display.tool_progress` is `off`, so the Desktop inline clarify UI has a pending tool row to mount on.
- Keep ordinary tool lifecycle events hidden in silent mode.
- Add regression coverage for both the clarify exception and the non-blocking silent-mode invariant.

## Test Plan
- `python -m pytest tests/test_tui_gateway_server.py::test_clarify_lifecycle_emits_when_tool_progress_off tests/test_tui_gateway_server.py::test_non_blocking_tool_lifecycle_stays_hidden_when_tool_progress_off -q`
- `python -m py_compile tui_gateway/server.py tests/test_tui_gateway_server.py`
- `git diff --check`

## Notes
- I also ran `scripts/run_tests.sh tests/test_tui_gateway_server.py`; the new tests passed, but the file run hit an unrelated local environment failure in `test_browser_manage_connect_default_local_reports_launch_hint` where the expected “No supported Chromium-family browser executable was found” launch-hint line was not present.
