### PR TITLE
fix(state): order replayed conversation by id, not timestamp

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -2877,6 +2877,13 @@ class SessionDB:
         By default only active messages are returned. Pass
         ``include_inactive=True`` to load soft-deleted (rewound) rows
         as well. See :meth:`rewind_to_message`.
+
+        Ordered by AUTOINCREMENT id (true insertion order), not timestamp:
+        see c03acca50 / #25774. ``timestamp`` is not monotonic across a
+        multi-tool turn, and platform-supplied timestamps can be skewed, so
+        ordering by it can place a tool result before the assistant tool_call
+        that produced it and break the tool-call/tool-response adjacency the
+        provider requires (HTTP 400 on resume). Mirrors :meth:`get_messages`.
         """
         session_ids = [session_id]
         if include_ancestors:
@@ -2890,7 +2897,7 @@ class SessionDB:
                 "finish_reason, reasoning, reasoning_content, reasoning_details, "
                 "codex_reasoning_items, codex_message_items, platform_message_id, observed, timestamp "
                 f"FROM messages WHERE session_id IN ({placeholders})"
-                f"{active_clause} ORDER BY timestamp, id",
+                f"{active_clause} ORDER BY id",
                 tuple(session_ids),
             ).fetchall()
 

--- a/tests/hermes_state/test_replay_ordering.py
+++ b/tests/hermes_state/test_replay_ordering.py
@@ -1,0 +1,68 @@
+"""Regression test for get_messages_as_conversation ordering.
+
+A non-monotonic clock (WSL2 / NTP step) or a skewed platform-supplied
+timestamp can stamp a tool result earlier than the assistant tool_call that
+produced it. Ordering the replayed conversation by timestamp then places the
+tool message before its assistant message, breaking the tool_call/tool_response
+adjacency the provider requires and causing an HTTP 400 on resume.
+
+PR #25774 (commit c03acca50) fixed exactly this by ordering message readers by
+AUTOINCREMENT id instead of timestamp. It was later reintroduced on this replay
+path by bd7fc8fdc ("inject stable human-readable message timestamps"), which is
+what this test guards against.
+"""
+import pytest
+
+from hermes_state import SessionDB
+
+
+@pytest.fixture
+def db(tmp_path):
+    return SessionDB(tmp_path / "state.db")
+
+
+def test_replay_orders_by_id_not_timestamp(db):
+    """A tool result stamped earlier than its assistant tool_call must still
+    replay immediately after that assistant message (insertion order)."""
+    sid = "s1"
+    db.create_session(sid, source="cli")
+
+    base = 1_000_000.0
+    # Insertion order: user -> assistant(tool_calls) -> tool result.
+    # Timestamps are deliberately NON-monotonic: the tool result (base + 1) is
+    # stamped BEFORE the assistant message (base + 2) that called it, simulating
+    # a clock regression between two appends within one multi-tool turn.
+    db.append_message(sid, role="user", content="run the tool", timestamp=base)
+    db.append_message(
+        sid,
+        role="assistant",
+        content="",
+        tool_calls=[
+            {"id": "call_1", "type": "function",
+             "function": {"name": "x", "arguments": "{}"}}
+        ],
+        timestamp=base + 2,
+    )
+    db.append_message(
+        sid,
+        role="tool",
+        content="tool output",
+        tool_call_id="call_1",
+        tool_name="x",
+        timestamp=base + 1,
+    )
+
+    conv = db.get_messages_as_conversation(sid)
+    roles = [m["role"] for m in conv]
+
+    # Must be insertion order. ORDER BY timestamp would yield
+    # ["user", "tool", "assistant"] and orphan the tool result.
+    assert roles == ["user", "assistant", "tool"], (
+        f"replay reordered by timestamp instead of id: {roles}"
+    )
+
+    # The assistant tool_call must be immediately followed by its tool result.
+    assert conv[1].get("tool_calls"), "assistant tool_calls missing from replay"
+    assert conv[1]["tool_calls"][0]["id"] == "call_1"
+    assert conv[2]["role"] == "tool"
+    assert conv[2]["tool_call_id"] == "call_1"


### PR DESCRIPTION
## What does this PR do?

`SessionDB.get_messages_as_conversation` restores a session's history for the LLM on resume. It ordered messages by `timestamp, id`. `timestamp` is not monotonic across a single multi-tool turn: on WSL2 or after an NTP step `time.time()` can move backwards between two `append_message` calls, and platform-supplied timestamps can be skewed. When a tool result is stamped earlier than the assistant message that called it, ordering by timestamp places the tool message before its assistant message. That breaks the tool_call/tool_response adjacency the provider requires and returns HTTP 400 on resume.

PR #25774 (commit c03acca5) fixed exactly this for both message readers by ordering on AUTOINCREMENT id (true insertion order). The later timestamp-injection feature (bd7fc8fd) reintroduced `ORDER BY timestamp, id` on this replay path only; the sibling `get_messages` still orders by id and documents the rationale. This restores id ordering on the replay path. Timestamps remain in the returned rows for display, so the human-readable-timestamp feature is unaffected.

## Related Issue

Self-found regression, no existing issue. The offending change is isolated to this one method (see commit `bd7fc8fd`), and the sibling `get_messages` already documents the correct ordering, so this is a direct restore of the `#25774` invariant on the replay path.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_state.py`: `get_messages_as_conversation` now orders by `id` instead of `timestamp, id`, and the docstring documents the rationale (mirrors `get_messages`).
- `tests/hermes_state/test_replay_ordering.py`: regression test that appends a tool result with a timestamp earlier than its assistant tool_call and asserts the replay preserves insertion order and tool adjacency.

## How to Test

1. On current `main`, append a `user` message, an `assistant` message with a tool_call (timestamp T+2), then the `tool` result (timestamp T+1, i.e. earlier). `get_messages_as_conversation` returns `[user, tool, assistant]`, orphaning the tool result before its assistant tool_call (provider 400 on the next turn).
2. With this change it returns `[user, assistant, tool]` (insertion order, adjacency preserved).
3. Automated: `pytest tests/hermes_state/test_replay_ordering.py -q` passes on this branch and fails on `main`.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(state):`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I ran the SessionDB/state suites (`pytest tests/hermes_state/` plus the root `test_hermes_state*` files and the gateway `test_undo_command` consumer): all pass. CI runs the full `tests/`.
- [x] I've added tests for my changes
- [x] I've tested on my platform: Ubuntu 24.04 (Linux)

### Documentation & Housekeeping

- [x] Updated the method docstring; no other docs affected
- [x] N/A: no config keys added or changed
- [x] N/A: no architecture or workflow change
- [x] Considered cross-platform impact: this specifically fixes a WSL2 / clock-regression failure on resume
- [x] N/A: no tool descriptions or schemas changed
