### PR TITLE
fix(memory): surface provider misconfiguration at WARNING instead of silent DEBUG

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1641,6 +1641,12 @@ def init_agent(
                 _mp = _load_mem(_mem_provider_name)
                 if _mp and _mp.is_available():
                     agent._memory_manager.add_provider(_mp)
+                elif _mp is not None:
+                    logger.warning(
+                        "memory.provider '%s' loaded but not available — "
+                        "check the provider name and its dependencies",
+                        _mem_provider_name,
+                    )
                 if agent._memory_manager.providers:
                     _init_kwargs = {
                         "session_id": agent.session_id,

--- a/plugins/memory/__init__.py
+++ b/plugins/memory/__init__.py
@@ -202,7 +202,7 @@ def load_memory_provider(name: str) -> Optional["MemoryProvider"]:
     """
     provider_dir = find_provider_dir(name)
     if not provider_dir:
-        logger.debug("Memory provider '%s' not found in bundled or user plugins", name)
+        logger.warning("Memory provider '%s' not found in bundled or user plugins", name)
         return None
 
     try:


### PR DESCRIPTION
## Summary

When `memory.provider` is set to an unrecognized value (e.g. an LLM provider name like `deepseek`), `load_memory_provider()` logs the failure at `DEBUG` level — invisible at the default `WARNING` log level. The agent silently skips memory provider initialization with no indication of misconfiguration.

## Changes

1. **`plugins/memory/__init__.py`**: Elevate `'provider not found'` log from `DEBUG` to `WARNING` in `load_memory_provider()`
2. **`agent/agent_init.py`**: Add a `WARNING` log when a named provider is loaded but `is_available()` returns `False`, so users see the failure even if a stale/empty plugin directory exists

## Before

```python
# plugins/memory/__init__.py
logger.debug("Memory provider '%s' not found in bundled or user plugins", name)
# → silent at default WARNING level
```

## After

```python
logger.warning("Memory provider '%s' not found in bundled or user plugins", name)
# → visible at default WARNING level
```

Closes #47650