### PR TITLE
fix(agent): detect modern services.ai.azure.com in _is_azure_openai_url()

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -1057,16 +1057,18 @@ class AIAgent:
 
         Azure OpenAI exposes an OpenAI-compatible endpoint at
         ``{resource}.openai.azure.com/openai/v1`` that accepts the
-        standard ``openai`` Python client.  Unlike api.openai.com it
-        does NOT support the Responses API — gpt-5.x models are served
-        on the regular ``/chat/completions`` path — so routing decisions
-        must treat Azure separately from direct OpenAI.
+        standard ``openai`` Python client.  Modern Azure OpenAI resources
+        (post-2024) also use ``{resource}.services.ai.azure.com``.
+        Unlike api.openai.com Azure does NOT support the Responses API —
+        gpt-5.x models are served on the regular ``/chat/completions``
+        path — so routing decisions must treat Azure separately from
+        direct OpenAI.
         """
         if base_url is not None:
             url = str(base_url).lower()
         else:
             url = getattr(self, "_base_url_lower", "") or ""
-        return "openai.azure.com" in url
+        return "openai.azure.com" in url or "ai.azure.com" in url
 
     def _is_github_copilot_url(self, base_url: str = None) -> bool:
         """Return True when a base URL targets GitHub Copilot's OpenAI-compatible API."""

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -5203,6 +5203,9 @@ class TestGpt5ApiModeRouting:
         assert agent._is_azure_openai_url("https://foo.openai.azure.com/openai/v1") is True
         assert agent._is_azure_openai_url("https://api.openai.com/v1") is False
         assert agent._is_azure_openai_url("https://openrouter.ai/api/v1") is False
+        # Modern Azure OpenAI resources use *.services.ai.azure.com
+        assert agent._is_azure_openai_url("https://my-resource.services.ai.azure.com/") is True
+        assert agent._is_azure_openai_url("https://my-resource.services.ai.azure.com/openai/v1") is True
         # Path-embedded azure string should still detect — we're ~substring matching
         agent.base_url = "https://my-resource.openai.azure.com/openai/v1"
         assert agent._is_azure_openai_url() is True


### PR DESCRIPTION
## What does this PR do?

Extends `_is_azure_openai_url()` to detect modern Azure OpenAI endpoints (`*.services.ai.azure.com`) in addition to the legacy `*.openai.azure.com` pattern. This ensures Azure-specific routing works correctly for post-2024 Azure OpenAI resources.

## Related Issue

Fixes #47666

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `run_agent.py`: Extended `_is_azure_openai_url()` substring check to also match `ai.azure.com`, covering modern `*.services.ai.azure.com` endpoints. Updated docstring to document both URL patterns.
- `tests/run_agent/test_run_agent.py`: Added assertions for `*.services.ai.azure.com` URLs in `test_is_azure_openai_url_detection`.

## How to Test

1. Run `pytest tests/run_agent/test_run_agent.py::TestGpt5ApiModeRouting -xvs` — all 4 tests should pass
2. Verify the new assertions: `services.ai.azure.com` URLs return `True`, legacy `openai.azure.com` still works, and non-Azure URLs still return `False`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `_is_azure_openai_url` (callers: 3 — `run_agent.py:1272`, `agent_init.py:385`, `chat_completion_helpers.py:1145`)
- Blast radius: LOW — substring match is additive, no existing URLs are affected
- Related patterns: Azure URL detection used in gpt-5.x API mode routing (`TestGpt5ApiModeRouting`)
