### PR TITLE
feat(memory): discover plugins in subdirectories for pip-installed packages

### DIFF
--- a/plugins/memory/__init__.py
+++ b/plugins/memory/__init__.py
@@ -71,33 +71,39 @@ def _get_user_plugins_dir() -> Optional[Path]:
         return None
 
 
-def _is_memory_provider_dir(path: Path) -> bool:
-    """Heuristic: does *path* look like a memory provider plugin?
-
-    Checks for ``register_memory_provider`` or ``MemoryProvider`` in the
-    ``__init__.py`` source.  Cheap text scan — no import needed.
-
-    Pip-installed packages often put their module in a subdirectory
-    (e.g. plugins/mimir/hermes_mimir/__init__.py instead of
-    plugins/mimir/__init__.py).  Probe subdirectories when the root
-    ``__init__.py`` is missing.
-    """
-    init_file = path / "__init__.py"
-    if not init_file.exists():
-        for sub in sorted(path.iterdir()):
-            if not sub.is_dir() or sub.name.startswith("."):
-                continue
-            sub_init = sub / "__init__.py"
-            if sub_init.exists():
-                init_file = sub_init
-                break
-        else:
-            return False
+def _source_looks_like_memory_provider(init_file: Path) -> bool:
+    """Return whether an initializer advertises a memory-provider entry point."""
     try:
         source = init_file.read_text(errors="replace", encoding="utf-8")[:8192]
         return "register_memory_provider" in source or "MemoryProvider" in source
     except Exception:
         return False
+
+
+def _resolve_package_entry(path: Path) -> Optional[Tuple[Path, Path]]:
+    """Return ``(initializer, package_dir)`` for a memory-provider package.
+
+    A pip-installed plugin may place its package below the advertised plugin
+    directory.  Only descend into a subdirectory when its initializer actually
+    advertises a memory provider; vendored packages must not win by sort order.
+    """
+    init_file = path / "__init__.py"
+    if init_file.exists() and _source_looks_like_memory_provider(init_file):
+        return init_file, path
+
+    if not init_file.exists():
+        for sub in sorted(path.iterdir()):
+            if not sub.is_dir() or sub.name.startswith("."):
+                continue
+            sub_init = sub / "__init__.py"
+            if sub_init.exists() and _source_looks_like_memory_provider(sub_init):
+                return sub_init, sub
+    return None
+
+
+def _is_memory_provider_dir(path: Path) -> bool:
+    """Return whether *path* contains a memory-provider package."""
+    return _resolve_package_entry(path) is not None
 
 
 def _iter_provider_dirs() -> List[Tuple[str, Path]]:
@@ -241,25 +247,10 @@ def _load_provider_from_dir(provider_dir: Path) -> Optional["MemoryProvider"]:
     # collide with bundled providers in sys.modules.
     _is_bundled = _MEMORY_PLUGINS_DIR in provider_dir.parents or provider_dir.parent == _MEMORY_PLUGINS_DIR
     module_name = f"plugins.memory.{name}" if _is_bundled else f"{_USER_NAMESPACE}.{name}"
-    init_file = provider_dir / "__init__.py"
-
-    # Pip-installed packages often put their module in a subdirectory
-    # (e.g. plugins/mimir/hermes_mimir/__init__.py instead of
-    # plugins/mimir/__init__.py).  Probe subdirectories when the root
-    # __init__.py is missing.
-    if not init_file.exists():
-        for sub in sorted(provider_dir.iterdir()):
-            if not sub.is_dir() or sub.name.startswith("."):
-                continue
-            sub_init = sub / "__init__.py"
-            if sub_init.exists():
-                init_file = sub_init
-                # submodule_search_locations should include the subdirectory
-                # so relative imports inside the plugin resolve correctly
-                provider_dir = sub
-                break
-        else:
-            return None
+    entry = _resolve_package_entry(provider_dir)
+    if entry is None:
+        return None
+    init_file, provider_dir = entry
 
     # Check if already loaded.  A synthetic package shell registered by
     # discover_plugin_cli_commands() for relative-import support has no

--- a/plugins/memory/__init__.py
+++ b/plugins/memory/__init__.py
@@ -76,10 +76,23 @@ def _is_memory_provider_dir(path: Path) -> bool:
 
     Checks for ``register_memory_provider`` or ``MemoryProvider`` in the
     ``__init__.py`` source.  Cheap text scan — no import needed.
+
+    Pip-installed packages often put their module in a subdirectory
+    (e.g. plugins/mimir/hermes_mimir/__init__.py instead of
+    plugins/mimir/__init__.py).  Probe subdirectories when the root
+    ``__init__.py`` is missing.
     """
     init_file = path / "__init__.py"
     if not init_file.exists():
-        return False
+        for sub in sorted(path.iterdir()):
+            if not sub.is_dir() or sub.name.startswith("."):
+                continue
+            sub_init = sub / "__init__.py"
+            if sub_init.exists():
+                init_file = sub_init
+                break
+        else:
+            return False
     try:
         source = init_file.read_text(errors="replace", encoding="utf-8")[:8192]
         return "register_memory_provider" in source or "MemoryProvider" in source
@@ -230,8 +243,23 @@ def _load_provider_from_dir(provider_dir: Path) -> Optional["MemoryProvider"]:
     module_name = f"plugins.memory.{name}" if _is_bundled else f"{_USER_NAMESPACE}.{name}"
     init_file = provider_dir / "__init__.py"
 
+    # Pip-installed packages often put their module in a subdirectory
+    # (e.g. plugins/mimir/hermes_mimir/__init__.py instead of
+    # plugins/mimir/__init__.py).  Probe subdirectories when the root
+    # __init__.py is missing.
     if not init_file.exists():
-        return None
+        for sub in sorted(provider_dir.iterdir()):
+            if not sub.is_dir() or sub.name.startswith("."):
+                continue
+            sub_init = sub / "__init__.py"
+            if sub_init.exists():
+                init_file = sub_init
+                # submodule_search_locations should include the subdirectory
+                # so relative imports inside the plugin resolve correctly
+                provider_dir = sub
+                break
+        else:
+            return None
 
     # Check if already loaded.  A synthetic package shell registered by
     # discover_plugin_cli_commands() for relative-import support has no

--- a/tests/agent/test_memory_provider.py
+++ b/tests/agent/test_memory_provider.py
@@ -665,6 +665,42 @@ class TestUserInstalledProviderDiscovery:
         assert p is not None
         assert p.name == "nestedimpl"
 
+    def test_rootless_provider_skips_non_provider_subpackage(self, tmp_path, monkeypatch):
+        """Rootless packages resolve the subdirectory that defines a provider."""
+        from plugins.memory import (
+            discover_memory_providers,
+            find_provider_dir,
+            list_memory_provider_names,
+            load_memory_provider,
+        )
+        plugin_dir = tmp_path / "plugins" / "mimir"
+        (plugin_dir / "aaa_vendor").mkdir(parents=True)
+        (plugin_dir / "aaa_vendor" / "__init__.py").write_text("VALUE = 1\n")
+        impl_dir = plugin_dir / "hermes_mimir"
+        impl_dir.mkdir()
+        (impl_dir / "__init__.py").write_text(
+            "from agent.memory_provider import MemoryProvider\n"
+            "class MimirProvider(MemoryProvider):\n"
+            "    @property\n"
+            "    def name(self): return 'mimir'\n"
+            "    def is_available(self): return True\n"
+            "    def initialize(self, **kw): pass\n"
+            "    def sync_turn(self, *a, **kw): pass\n"
+            "    def get_tool_schemas(self): return []\n"
+            "    def handle_tool_call(self, *a, **kw): return '{}'\n"
+        )
+        monkeypatch.setattr(
+            "plugins.memory._get_user_plugins_dir",
+            lambda: tmp_path / "plugins",
+        )
+
+        assert find_provider_dir("mimir") == plugin_dir
+        assert "mimir" in list_memory_provider_names()
+        assert dict((name, available) for name, _desc, available in discover_memory_providers())["mimir"]
+        provider = load_memory_provider("mimir")
+        assert provider is not None
+        assert provider.name == "mimir"
+
 
 class TestUserInstalledProviderCli:
     """CLI commands of user-installed providers must be discoverable.


### PR DESCRIPTION
## Summary

Pip-installed memory provider packages typically place their Python module in a subdirectory (e.g. `plugins/mimir/hermes_mimir/__init__.py`) rather than directly in the plugin root. Hermes previously required `__init__.py` at the plugin directory root, forcing users to manually copy or symlink files.

## Changes

Extend `_load_provider_from_dir()` in `plugins/memory/__init__.py` to probe immediate subdirectories when the root `__init__.py` is missing. The first subdirectory containing `__init__.py` is used as the module source, with `submodule_search_locations` pointed at the subdirectory so relative imports resolve correctly.

## Before

```
plugins/mimir/
  hermes_mimir/       ← pip install puts module here
    __init__.py        ← plugin code
  pyproject.toml
  
→ Hermes looks for plugins/mimir/__init__.py → NOT FOUND → silent failure
```

## After

```
plugins/mimir/
  hermes_mimir/       ← Hermes probes subdirectories, finds this
    __init__.py        ← loaded as the plugin module ✓
  pyproject.toml
```

Closes #47651