### PR TITLE
fix(acp): handle session/prompt completion when ACP server omits JSON-RPC response

### DIFF
--- a/agent/copilot_acp_client.py
+++ b/agent/copilot_acp_client.py
@@ -9,6 +9,7 @@ back into the minimal shape Hermes expects from an OpenAI client.
 from __future__ import annotations
 
 import json
+import logging
 import os
 import queue
 import re
@@ -23,6 +24,8 @@ from typing import Any
 
 from agent.file_safety import get_read_block_error, is_write_denied
 from agent.redact import redact_sensitive_text
+
+logger = logging.getLogger(__name__)
 
 ACP_MARKER_BASE_URL = "acp://copilot"
 _DEFAULT_TIMEOUT_SECONDS = 900.0
@@ -544,6 +547,31 @@ class CopilotACPClient:
                         f"Original error:\n{stderr_text}"
                     )
                 raise RuntimeError(f"Copilot ACP process exited early: {stderr_text}")
+
+            # ── Graceful fallback for session/prompt ───────────────────────
+            # Some ACP server implementations (including Claude Code's ACP)
+            # send all text chunks via session/update notifications and then
+            # exit cleanly WITHOUT sending a final JSON-RPC response.  When
+            # this happens for session/prompt and we have collected text,
+            # treat it as successful completion instead of raising TimeoutError.
+            if method == "session/prompt" and text_parts is not None:
+                combined = "".join(text_parts).strip()
+                if combined:
+                    logger.warning(
+                        "ACP %s completed via notification stream "
+                        "(no JSON-RPC response). process_exit=%s "
+                        "text=%d chars reasoning=%d parts",
+                        method,
+                        proc.poll() is not None,
+                        len(combined),
+                        len(reasoning_parts or []),
+                    )
+                    return {}
+                logger.info(
+                    "ACP %s produced no visible text — raising timeout.",
+                    method,
+                )
+
             raise TimeoutError(f"Timed out waiting for Copilot ACP response to {method}.")
 
         try:
@@ -620,6 +648,15 @@ class CopilotACPClient:
                 text_parts.append(chunk_text)
             elif kind == "agent_thought_chunk" and chunk_text and reasoning_parts is not None:
                 reasoning_parts.append(chunk_text)
+            elif kind not in ("agent_message_chunk", "agent_thought_chunk"):
+                # Log non-chunk session/update types so protocol quirks
+                # (e.g. user_message_chunk, usage_update, end_turn) are
+                # visible in the log even though they are safely consumed.
+                logger.log(
+                    logging.DEBUG if not chunk_text else logging.INFO,
+                    "ACP session/update type=%r text=%d chars",
+                    kind, len(chunk_text),
+                )
             return True
 
         if process.stdin is None:


### PR DESCRIPTION
## Problem

When using `claude --acp --stdio` (or any ACP backend), sending a message sometimes produces no response. Sending another message then returns the first message's result — a classic response misalignment.

## Root Cause

`CopilotACPClient._request()` communicates with the ACP server via a three-step handshake:
1. `initialize` (id=1)
2. `session/new` (id=2)
3. `session/prompt` (id=3)

Step 3 sends the prompt and the server streams back text chunks via `session/update` notifications, then should send a final JSON-RPC response with the matching id to signal completion.

Some ACP implementations (Claude Code ACP included) send all text chunks via `session/update` notifications and then **exit cleanly without sending the final JSON-RPC response**. In this case the `_request` while loop breaks because `proc.poll() is not None`, then unconditionally raises `TimeoutError` — even though the full response text was already collected in `text_parts`.

## Fix

1. **`_request` fallback**: when the while loop exits without finding a matching JSON-RPC response and we are in the `session/prompt` call, check whether `text_parts` has content. If so, return success with the collected text instead of raising `TimeoutError`. A warning is logged so the event is visible in diagnostics.

2. **`_handle_server_message` logging**: non-chunk `session/update` types (`user_message_chunk`, `usage_update`, `end_turn`, etc.) are now logged at DEBUG/INFO level instead of being silently consumed, making protocol quirks visible during troubleshooting.

## Verification

- All 7 existing `test_copilot_acp_client.py` tests pass
- Module-level `logger` added (file previously had no logging at all)
