### PR TITLE
feat(agent): make API retry backoff timing configurable

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -20,6 +20,7 @@ preserved.
 from __future__ import annotations
 
 import logging
+import math
 import os
 import re
 import sys
@@ -1539,6 +1540,30 @@ def init_agent(
     except (TypeError, ValueError):
         _api_retries = 3
     agent._api_max_retries = _api_retries
+
+    # Backoff timing for API retries. Keep Retry-After's ceiling separate: its
+    # 600s default covers provider quota reset windows while ordinary retries
+    # retain their legacy 2s base / 60s cap.
+    def _positive_finite_delay(key, default):
+        try:
+            raw_value = _agent_section.get(key, default)
+            if isinstance(raw_value, bool):
+                raise ValueError
+            value = float(raw_value)
+            if not math.isfinite(value) or value <= 0:
+                raise ValueError
+            return value
+        except (TypeError, ValueError):
+            return default
+
+    agent._retry_base_delay = _positive_finite_delay("retry_base_delay", 2.0)
+    agent._retry_max_delay = max(
+        agent._retry_base_delay,
+        _positive_finite_delay("retry_max_delay", 60.0),
+    )
+    agent._retry_after_max_delay = _positive_finite_delay(
+        "retry_after_max_delay", 600.0,
+    )
 
     # Initialize context compressor for automatic context management
     # Compresses conversation when approaching model's context limit

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 import json
 import logging
+import math
 import os
 import random
 import re
@@ -1592,8 +1593,12 @@ def run_conversation(
                             "failed": True  # Mark as failure for filtering
                         }
                     
-                    # Backoff before retry — jittered exponential: 5s base, 120s cap
-                    wait_time = jittered_backoff(retry_count, base_delay=5.0, max_delay=120.0)
+                    # Backoff before retry — jittered exponential (configurable)
+                    wait_time = jittered_backoff(
+                        retry_count,
+                        base_delay=agent._retry_base_delay,
+                        max_delay=agent._retry_max_delay,
+                    )
                     agent._buffer_vprint(f"⏳ Retrying in {wait_time:.1f}s ({_failure_hint})...")
                     logger.warning(f"Invalid API response (retry {retry_count}/{max_retries}): {', '.join(error_details)} | Provider: {provider_name}")
                     
@@ -4176,10 +4181,19 @@ def run_conversation(
                                 # retry before the actual reset window and re-trip the
                                 # limit. 600s covers all realistic provider reset
                                 # windows while still rejecting pathological values. (#26293)
-                                _retry_after = min(float(_ra_raw), 600)
+                                _parsed_retry_after = float(_ra_raw)
+                                if math.isfinite(_parsed_retry_after) and _parsed_retry_after > 0:
+                                    _retry_after = min(
+                                        _parsed_retry_after,
+                                        agent._retry_after_max_delay,
+                                    )
                             except (TypeError, ValueError):
                                 pass
-                wait_time = _retry_after if _retry_after else jittered_backoff(retry_count, base_delay=2.0, max_delay=60.0)
+                wait_time = _retry_after if _retry_after else jittered_backoff(
+                    retry_count,
+                    base_delay=agent._retry_base_delay,
+                    max_delay=agent._retry_max_delay,
+                )
                 _backoff_policy = None
                 if (is_rate_limited or _is_zai_coding_overload) and not _retry_after:
                     wait_time, _backoff_policy = adaptive_rate_limit_backoff(
@@ -4204,6 +4218,7 @@ def run_conversation(
                         agent._emit_status(_rate_limit_status)
                     else:
                         agent._buffer_status(_rate_limit_status)
+
                 else:
                     agent._buffer_status(f"⏳ Retrying in {wait_time:.1f}s (attempt {retry_count}/{max_retries})...")
                 logger.warning(

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1018,6 +1018,14 @@ DEFAULT_CONFIG = {
         # on flaky primaries; raise it if you prefer to tolerate longer
         # provider hiccups on a single provider.
         "api_max_retries": 3,
+        # Base delay (seconds) for the first API retry backoff. Default 2s.
+        "retry_base_delay": 2.0,
+        # Maximum delay (seconds) for API retry backoff. Default 60s.
+        # Raise this (e.g. 300) on flaky connections to tolerate longer outages.
+        "retry_max_delay": 60.0,
+        # Separate Retry-After ceiling. The 600s default accommodates provider
+        # quota reset windows (including Anthropic Tier 1).
+        "retry_after_max_delay": 600.0,
         "service_tier": "",
         # Tool-use enforcement: injects system prompt guidance that tells the
         # model to actually call tools instead of describing intended actions.

--- a/tests/run_agent/test_api_max_retries_config.py
+++ b/tests/run_agent/test_api_max_retries_config.py
@@ -1,23 +1,25 @@
-"""Tests for agent.api_max_retries config surface.
-
-Closes #11616 — make the hardcoded ``max_retries = 3`` in the agent's API
-retry loop user-configurable so fallback-provider setups can fail over
-faster on flaky primaries instead of burning ~3x180s on the same stall.
-"""
+"""Tests for the agent API retry configuration surface."""
 from unittest.mock import patch
 
 from run_agent import AIAgent
 
 
-def _make_agent(api_max_retries=None):
-    """Build an AIAgent with a mocked config.load_config that returns a
-    config tree containing the given agent.api_max_retries (or default)."""
+def _make_agent(
+    api_max_retries=None,
+    retry_base_delay=None,
+    retry_max_delay=None,
+    retry_after_max_delay=None,
+):
     cfg = {"agent": {}}
-    if api_max_retries is not None:
-        cfg["agent"]["api_max_retries"] = api_max_retries
+    values = {
+        "api_max_retries": api_max_retries,
+        "retry_base_delay": retry_base_delay,
+        "retry_max_delay": retry_max_delay,
+        "retry_after_max_delay": retry_after_max_delay,
+    }
+    cfg["agent"].update({key: value for key, value in values.items() if value is not None})
 
-    with patch("run_agent.OpenAI"), \
-         patch("hermes_cli.config.load_config", return_value=cfg):
+    with patch("run_agent.OpenAI"), patch("hermes_cli.config.load_config", return_value=cfg):
         return AIAgent(
             api_key="test-key",
             base_url="https://openrouter.ai/api/v1",
@@ -29,37 +31,63 @@ def _make_agent(api_max_retries=None):
 
 
 def test_default_api_max_retries_is_three():
-    """No config override → legacy default of 3 retries preserved."""
+    assert _make_agent()._api_max_retries == 3
+
+
+def test_default_api_retry_delays_preserve_legacy_values():
     agent = _make_agent()
-    assert agent._api_max_retries == 3
+    assert agent._retry_base_delay == 2.0
+    assert agent._retry_max_delay == 60.0
+    assert agent._retry_after_max_delay == 600.0
+
+
+def test_api_retry_delays_honor_config_override():
+    agent = _make_agent(
+        retry_base_delay=5,
+        retry_max_delay=300,
+        retry_after_max_delay=900,
+    )
+    assert agent._retry_base_delay == 5.0
+    assert agent._retry_max_delay == 300.0
+    assert agent._retry_after_max_delay == 900.0
+
+
+def test_api_retry_delays_reject_non_finite_and_non_positive_values():
+    agent = _make_agent(
+        retry_base_delay=float("nan"),
+        retry_max_delay=0,
+        retry_after_max_delay=float("inf"),
+    )
+    assert agent._retry_base_delay == 2.0
+    assert agent._retry_max_delay == 60.0
+    assert agent._retry_after_max_delay == 600.0
+
+    boolean_agent = _make_agent(
+        retry_base_delay=True,
+        retry_max_delay=False,
+        retry_after_max_delay=True,
+    )
+    assert boolean_agent._retry_base_delay == 2.0
+    assert boolean_agent._retry_max_delay == 60.0
+    assert boolean_agent._retry_after_max_delay == 600.0
+
+
+def test_api_retry_max_delay_is_never_below_base_delay():
+    agent = _make_agent(retry_base_delay=30, retry_max_delay=5)
+    assert agent._retry_base_delay == 30.0
+    assert agent._retry_max_delay == 30.0
 
 
 def test_api_max_retries_honors_config_override():
-    """Setting agent.api_max_retries in config propagates to the agent."""
-    agent = _make_agent(api_max_retries=1)
-    assert agent._api_max_retries == 1
-
-    agent2 = _make_agent(api_max_retries=5)
-    assert agent2._api_max_retries == 5
+    assert _make_agent(api_max_retries=1)._api_max_retries == 1
+    assert _make_agent(api_max_retries=5)._api_max_retries == 5
 
 
 def test_api_max_retries_clamps_below_one_to_one():
-    """0 or negative values would disable the retry loop entirely
-    (the ``while retry_count < max_retries`` guard would never execute),
-    so clamp to 1 = single attempt, no retry."""
-    agent = _make_agent(api_max_retries=0)
-    assert agent._api_max_retries == 1
-
-    agent2 = _make_agent(api_max_retries=-3)
-    assert agent2._api_max_retries == 1
+    assert _make_agent(api_max_retries=0)._api_max_retries == 1
+    assert _make_agent(api_max_retries=-3)._api_max_retries == 1
 
 
 def test_api_max_retries_falls_back_on_invalid_value():
-    """Garbage values in config don't crash agent init — fall back to 3."""
-    agent = _make_agent(api_max_retries="not-a-number")
-    assert agent._api_max_retries == 3
-
-    agent2 = _make_agent(api_max_retries=None)
-    # None with dict.get default fires → default(3), then int(None) raises
-    # TypeError → except branch sets to 3.
-    assert agent2._api_max_retries == 3
+    assert _make_agent(api_max_retries="not-a-number")._api_max_retries == 3
+    assert _make_agent(api_max_retries=None)._api_max_retries == 3

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -2548,14 +2548,19 @@ class TestRetryAfterCap:
     Retry-After header up to a 600s ceiling (was 120s, which retried before
     Tier-1 reset windows of ~171s and re-tripped the limit)."""
 
-    def _drive_once(self, agent, retry_after_value):
-        """Raise one 429 carrying ``Retry-After`` and capture the wait the loop
-        chose. Interrupt during the backoff sleep so the test doesn't actually
-        wait, and return the status string that reports the wait time."""
+    def _drive_once(self, agent, retry_after_value, *, zai_overload=False):
+        """Raise one 429 and capture the wait selected by the real loop."""
 
         class _RateLimitError(Exception):
             status_code = 429
-            response = SimpleNamespace(headers={"retry-after": str(retry_after_value)})
+            response = SimpleNamespace(headers=(
+                {} if retry_after_value is None
+                else {"retry-after": str(retry_after_value)}
+            ))
+            body = (
+                {"error": {"code": 1305, "message": "temporarily overloaded"}}
+                if zai_overload else None
+            )
 
             def __str__(self):
                 return "Error code: 429 - Rate limit exceeded."
@@ -2564,6 +2569,9 @@ class TestRetryAfterCap:
             raise _RateLimitError()
 
         agent._interruptible_api_call = _fake_api_call
+        if zai_overload:
+            agent.base_url = "https://api.z.ai/api/coding/paas/v4"
+            agent.model = "glm-5.2"
         agent._persist_session = lambda *args, **kwargs: None
         agent._save_trajectory = lambda *args, **kwargs: None
 
@@ -2591,6 +2599,45 @@ class TestRetryAfterCap:
         # 900s exceeds the ceiling → clamped to 600s, not the old 120s.
         status = self._drive_once(agent, 900)
         assert "Waiting 600.0s" in status
+
+    def test_configured_retry_after_cap_is_used_by_loop(self, agent):
+        agent._retry_after_max_delay = 240.0
+        status = self._drive_once(agent, 900)
+        assert "Waiting 240.0s" in status
+
+    def test_missing_retry_after_uses_configured_exception_backoff(self, agent):
+        from agent import conversation_loop as _conv_loop
+
+        agent._retry_base_delay = 7.0
+        agent._retry_max_delay = 80.0
+        with patch.object(_conv_loop, "jittered_backoff", return_value=17.0) as backoff:
+            status = self._drive_once(agent, None)
+
+        assert "Waiting 17.0s" in status
+        backoff.assert_called_once_with(1, base_delay=7.0, max_delay=80.0)
+
+    def test_invalid_retry_after_uses_configured_exception_backoff(self, agent):
+        from agent import conversation_loop as _conv_loop
+
+        agent._retry_base_delay = 11.0
+        agent._retry_max_delay = 110.0
+        with patch.object(_conv_loop, "jittered_backoff", return_value=21.0) as backoff:
+            status = self._drive_once(agent, float("nan"))
+
+        assert "Waiting 21.0s" in status
+        backoff.assert_called_once_with(1, base_delay=11.0, max_delay=110.0)
+
+    def test_provider_adaptive_backoff_wraps_configured_default(self, agent):
+        from agent import conversation_loop as _conv_loop
+
+        agent._retry_base_delay = 9.0
+        agent._retry_max_delay = 90.0
+        with patch.object(_conv_loop, "jittered_backoff", return_value=19.0) as backoff:
+            status = self._drive_once(agent, None, zai_overload=True)
+
+        assert "Waiting 19.0s" in status
+        assert "Z.AI Coding overload short retry" in status
+        backoff.assert_called_once_with(1, base_delay=9.0, max_delay=90.0)
 
 
 class TestConcurrentToolExecution:
@@ -5822,7 +5869,7 @@ class TestRetryExhaustion:
             patch.object(agent, "_cleanup_task_resources"),
             patch("run_agent.time", self._make_fast_time_mock()),
             patch.object(_conv_loop, "time", self._make_fast_time_mock()),
-            patch.object(_conv_loop, "jittered_backoff", lambda *a, **k: 0.0),
+            patch.object(_conv_loop, "jittered_backoff", return_value=0.0) as backoff,
         ):
             result = agent.run_conversation("hello")
         assert result.get("completed") is False, (
@@ -5832,6 +5879,10 @@ class TestRetryExhaustion:
         assert "error" in result
         assert "Invalid API response" in result["error"]
         assert result.get("final_response") == result["error"]
+        assert backoff.call_args.kwargs == {
+            "base_delay": agent._retry_base_delay,
+            "max_delay": agent._retry_max_delay,
+        }
 
     def test_content_filter_refusal_surfaced_not_retried(self, agent):
         """A model refusal must be surfaced immediately, NOT laundered into


### PR DESCRIPTION
## Summary
- add agent.retry_base_delay and agent.retry_max_delay config knobs
- use the configured backoff timings in both API retry paths
- cap Retry-After headers with agent.retry_max_delay instead of a hardcoded 120s
- extend existing api_max_retries config tests for the new retry delay knobs

## Why
Users on unstable connections can raise api_max_retries plus retry_max_delay to ride through multi-minute outages instead of failing after the current short hardcoded retry window.

Defaults preserve the existing connection-error behavior: 2s base delay and 60s max delay.

## Test Plan
- python -m pytest tests/run_agent/test_api_max_retries_config.py -q -o 'addopts='