### PR TITLE
fix(run_agent): repair repeated tool names and duplicated JSON args (#6841)

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -1922,6 +1922,39 @@ def invoke_tool(agent, function_name: str, function_args: dict, effective_task_i
 
 
 
+def _collapse_repeated_text(value: str) -> str:
+    """Collapse an exact double-repeated string into a single copy.
+
+    Conservative helper for tool-name repair (#6841). Two observed
+    patterns:
+
+    - ``"skills_listskills_list"`` -> ``"skills_list"`` (no separator)
+    - ``"skills_list skills_list"`` -> ``"skills_list"`` (whitespace separator)
+
+    Returns ``value`` unchanged if no clean half-repeat is found. A
+    half-repeat is only collapsed when the two halves are byte-equal
+    (after stripping leading/trailing whitespace) and the result is
+    non-empty. Triple/quadruple repeats are not handled here — they
+    are not observed in production and a recursive ``len/2`` check on
+    an odd-length string would be ambiguous. The caller is expected
+    to fall through to fuzzy match for those cases.
+    """
+    if not isinstance(value, str):
+        return value
+    text = value.strip()
+    if not text:
+        return text
+    n = len(text)
+    if n % 2 == 0:
+        half = n // 2
+        if text[:half] == text[half:]:
+            return text[:half]
+    parts = text.split()
+    if len(parts) >= 2 and all(p == parts[0] for p in parts[1:]):
+        return parts[0]
+    return text
+
+
 def repair_tool_call(agent, tool_name: str) -> str | None:
     """Attempt to repair a mismatched tool name before aborting.
 
@@ -1936,10 +1969,16 @@ def repair_tool_call(agent, tool_name: str) -> str | None:
        Claude-style models sometimes tack on (TodoTool_tool ->
        TodoTool -> Todo -> todo). Applied twice so double-tacked
        suffixes like ``TodoTool_tool`` reduce all the way.
-    5. Fuzzy match (difflib, cutoff=0.7).
+    5. Collapse exact repeated tool names (#6841 — e.g.
+       ``skills_listskills_list`` -> ``skills_list``). Runs after
+       normalization so case/separator variants collapse correctly
+       (e.g. ``SKILLS_LISTSKILLS_LIST`` -> ``skills_list``).
+    6. Fuzzy match (difflib, cutoff=0.7).
 
     See #14784 for the original reports (TodoTool_tool, Patch_tool,
     BrowserClick_tool were all returning "Unknown tool" before).
+    See #6841 for the repeated-name reports (skills_listskills_list,
+    session_searchsession_search, web_searchweb_search).
 
     Returns the repaired name if found in valid_tool_names, else None.
     """
@@ -2004,6 +2043,16 @@ def repair_tool_call(agent, tool_name: str) -> str | None:
                 extra.add(_camel_snake(stripped))
         cands |= extra
 
+    # Collapse exact repeated tool names (#6841). Apply on the
+    # normalized form so the most common case (already-valid
+    # snake_case name duplicated) is caught without a separate
+    # case-folding pass.
+    collapsed = _collapse_repeated_text(normalized)
+    if collapsed != normalized:
+        cands.add(collapsed)
+        cands.add(_collapse_repeated_text(lowered))
+        cands.add(_collapse_repeated_text(tool_name))
+
     for c in cands:
         if c and c in agent.valid_tool_names:
             return c
@@ -2014,7 +2063,6 @@ def repair_tool_call(agent, tool_name: str) -> str | None:
         return matches[0]
 
     return None
-
 
 
 def sanitize_api_messages(messages: List[Dict[str, Any]]) -> List[Dict[str, Any]]:

--- a/agent/message_sanitization.py
+++ b/agent/message_sanitization.py
@@ -182,6 +182,65 @@ def _escape_invalid_chars_in_json_strings(raw: str) -> str:
     return "".join(out)
 
 
+def _collapse_repeated_json_objects(raw_args: str) -> str | None:
+    """Collapse exact-repeated adjacent JSON object payloads into one.
+
+    Some model/provider combinations emit a single JSON object payload
+    repeated back-to-back without a separator, e.g.
+    ``{"a":1}{"a":1}`` or
+    ``{"name":"x","file_path":""}{"name":"x","file_path":""}``.
+    The standard ``json.loads`` parser raises ``Extra data`` on the
+    second payload, so the call is rejected.
+
+    The helper is conservative:
+
+    - All payloads must be objects (``dict``) — repeated arrays/scalars
+      are not collapsed (those are usually the result of truncated
+      streaming output, not duplicated emission, and the existing
+      trailing-comma / unclosed-bracket repair stages handle them).
+    - All payloads must be byte-identical JSON object substrings. Two
+      objects that parse to the same dict but were serialized
+      differently (for example with a different key order) are not
+      collapsed.
+    - The first valid object is returned as compact JSON.
+
+    Returns ``None`` for any input that cannot be safely collapsed —
+    the caller should fall through to the existing repair stages.
+    Returns ``None`` for any non-string input.
+    """
+    if not isinstance(raw_args, str):
+        return None
+    text = raw_args.strip()
+    if not text:
+        return None
+    decoder = json.JSONDecoder()
+    pos = 0
+    payloads = []
+    raw_payloads = []
+    while pos < len(text):
+        while pos < len(text) and text[pos].isspace():
+            pos += 1
+        if pos >= len(text):
+            break
+        try:
+            start = pos
+            obj, end = decoder.raw_decode(text, pos)
+        except json.JSONDecodeError:
+            return None
+        payloads.append(obj)
+        raw_payloads.append(text[start:end])
+        pos = end
+    if len(payloads) < 2:
+        return None
+    first = payloads[0]
+    if not isinstance(first, dict):
+        return None
+    first_raw = raw_payloads[0]
+    if any(raw != first_raw for raw in raw_payloads[1:]):
+        return None
+    return json.dumps(first, separators=(",", ":"))
+
+
 def _repair_tool_call_arguments(raw_args: str, tool_name: str = "?") -> str:
     """Attempt to repair malformed tool_call argument JSON.
 
@@ -202,6 +261,21 @@ def _repair_tool_call_arguments(raw_args: str, tool_name: str = "?") -> str:
     if raw_stripped == "None":
         logger.warning("Sanitized Python-None tool_call arguments for %s", tool_name)
         return "{}"
+
+    # Repair pass 0a: collapsed repeated adjacent JSON objects
+    # (#6841 — e.g. ``{"a":1}{"a":1}`` or a real-world tool payload
+    # like ``{"name":"reddit-saas-idea-miner","file_path":""}`` repeated
+    # three times back-to-back). This runs before the unescaped-control
+    # pass because the unescaped-control pass reserialises the parsed
+    # object and would silently drop the duplicated payloads if the
+    # single-object form parsed successfully.
+    collapsed = _collapse_repeated_json_objects(raw_stripped)
+    if collapsed is not None:
+        logger.warning(
+            "Auto-repaired duplicated JSON arguments for %s: %s -> %s",
+            tool_name, raw_stripped[:80], collapsed[:80],
+        )
+        return collapsed
 
     # Repair pass 0: llama.cpp backends sometimes emit literal control
     # characters (tabs, newlines) inside JSON string values. json.loads

--- a/tests/run_agent/test_6841_repeated_tool_call_repair.py
+++ b/tests/run_agent/test_6841_repeated_tool_call_repair.py
@@ -1,0 +1,218 @@
+"""Regression tests for issue #6841 — repeated tool-name and duplicated
+JSON-argument repair.
+
+The agent loop in ``run_agent.py`` receives malformed tool-call payloads
+from certain model/provider combinations. Two corruption modes appear:
+
+1. **Repeated tool names** — the tool name is duplicated back-to-back, e.g.
+   ``skills_listskills_list``. The current ``_repair_tool_call`` pipeline
+   rejects these as "Unknown tool" because the repeated form is not in
+   ``valid_tool_names``.
+
+2. **Duplicated adjacent JSON arguments** — multiple identical JSON object
+   payloads are concatenated without a separator, e.g.
+   ``{"category":"research"}{"category":"research"}``. ``json.loads`` raises
+   ``Extra data`` and the call is rejected.
+
+Both are real, observed patterns (per the issue body) and break the
+generic tool-call path on otherwise-valid models.
+
+These tests guard the conservative repair pipeline:
+- Repeated tool names are collapsed only when the result is a valid tool.
+- Mismatched duplicated JSON payloads are still rejected (no silent merge).
+- Single, non-duplicated inputs are untouched.
+"""
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+
+import pytest
+
+from run_agent import AIAgent
+
+
+VALID = {
+    "skills_list",
+    "session_search",
+    "skill_view",
+    "web_search",
+    "execute_code",
+    "read_file",
+    "write_file",
+    "terminal",
+    "patch",
+    "browser_click",
+    "todo",
+}
+
+
+@pytest.fixture
+def repair():
+    """Bind ``_repair_tool_call`` to a stub agent with our VALID set."""
+    stub = SimpleNamespace(valid_tool_names=VALID)
+    return AIAgent._repair_tool_call.__get__(stub, AIAgent)
+
+
+class TestRepeatedToolNameRepair:
+    """L1 from LAYERS.md — repeated tool names collapse to a valid tool."""
+
+    @pytest.mark.parametrize(
+        "repeated,expected",
+        [
+            ("skills_listskills_list", "skills_list"),
+            ("session_searchsession_search", "session_search"),
+            ("skill_viewskill_view", "skill_view"),
+            ("web_searchweb_search", "web_search"),
+            ("execute_codeexecute_code", "execute_code"),
+        ],
+    )
+    def test_collapse_double_repeated_name(self, repair, repeated, expected):
+        """Issue body example: exact double-repeat of a valid tool name."""
+        assert repair(repeated) == expected
+
+    def test_collapse_triple_repeated_name(self, repair):
+        """Issue body example: three back-to-back identical JSON
+        payloads. Tool-name analog: ``foobar`` repeated three times
+        cannot be collapsed (the result is ``foo``, not in VALID). But
+        ``write_file`` repeated 1.5x is not valid either; the conservative
+        pipeline must NOT guess. Verify that ``foo`` is the only safe
+        output for an odd-length string and the fuzzy match fallback
+        runs. Since ``foo`` is not in VALID, expect ``None``."""
+        # 'foofoofoo' has len 9, not cleanly divisible; pipeline should
+        # not silently invent a tool. Falls through to fuzzy match —
+        # 'foofoofoo' has zero close matches at 0.7 cutoff.
+        assert repair("foofoofoo") is None
+
+    def test_collapse_repeated_does_not_match_unrelated_tool(self, repair):
+        """Half of ``abcdefabcdef`` is ``abcdef`` — not in VALID. Pipeline
+        must not claim a fuzzy match for an obviously unrelated string."""
+        assert repair("abcdefabcdef") is None
+
+    def test_collapse_preserves_existing_lowercase_repair(self, repair):
+        """If the input has case issues AND a repeat, lowercase first,
+        then collapse. ``SKILLS_LISTSKILLS_LIST`` -> ``skills_list``."""
+        assert repair("SKILLS_LISTSKILLS_LIST") == "skills_list"
+
+    def test_repeat_does_not_break_existing_dash_to_underscore(self, repair):
+        """Existing dash-to-underscore path must keep working alongside
+        the new collapse step."""
+        assert repair("write-file") == "write_file"
+
+
+class TestDuplicatedJsonArgsRepair:
+    """L2 from LAYERS.md — duplicated adjacent JSON payloads collapse."""
+
+    def test_exact_double_payload_collapses(self):
+        from run_agent import _repair_tool_call_arguments
+        result = _repair_tool_call_arguments(
+            '{"category":"research"}{"category":"research"}', "t"
+        )
+        assert json.loads(result) == {"category": "research"}
+
+    def test_exact_triple_payload_collapses(self):
+        from run_agent import _repair_tool_call_arguments
+        result = _repair_tool_call_arguments(
+            '{"a":1}{"a":1}{"a":1}', "t"
+        )
+        assert json.loads(result) == {"a": 1}
+
+    def test_nested_payload_double_collapses(self):
+        """Real-world case from issue body: nested object with
+        string-typed fields and an empty string value, repeated three
+        times back-to-back."""
+        from run_agent import _repair_tool_call_arguments
+        raw = (
+            '{"name":"reddit-saas-idea-miner","file_path":""}'
+            '{"name":"reddit-saas-idea-miner","file_path":""}'
+            '{"name":"reddit-saas-idea-miner","file_path":""}'
+        )
+        result = _repair_tool_call_arguments(raw, "t")
+        assert json.loads(result) == {
+            "name": "reddit-saas-idea-miner",
+            "file_path": "",
+        }
+
+    def test_mismatched_payloads_not_collapsed(self):
+        """Different keys/values back-to-back must not be silently
+        merged. The conservative pipeline's job here is to *not
+        invent* a combined object. The actual returned value may be:
+
+        - the first object (if the existing repair stages leave it
+          alone), or
+        - ``{}`` (the last-resort fallback), or
+        - any other single-object form the existing stages produce.
+
+        What it MUST NOT do is silently invent ``{"a": 1, "b": 2}``
+        or any other merged shape — that would corrupt the call."""
+        from run_agent import _repair_tool_call_arguments
+        result = _repair_tool_call_arguments('{"a":1}{"b":2}', "t")
+        parsed = json.loads(result)
+        assert parsed != {"a": 1, "b": 2}, (
+            f"Mismatched payloads were silently merged: {parsed!r}"
+        )
+        # The result must always be a valid JSON object (the existing
+        # contract — every repair result is a string that round-trips
+        # through json.loads).
+        assert isinstance(parsed, dict)
+
+    def test_semantically_equal_but_not_byte_identical_payloads_not_collapsed(self):
+        """Edge E2: equality of parsed dicts is not enough. The issue
+        asks for byte-identical repeated payloads, so differently serialized
+        objects must fall through to the existing safe-repair path."""
+        from agent.message_sanitization import _collapse_repeated_json_objects
+
+        raw = '{"a":1,"b":2}{"b":2,"a":1}'
+        assert _collapse_repeated_json_objects(raw) is None
+
+    def test_single_object_unchanged(self):
+        """Single, valid JSON object must not be touched."""
+        from run_agent import _repair_tool_call_arguments
+        result = _repair_tool_call_arguments('{"a": 1}', "t")
+        assert json.loads(result) == {"a": 1}
+
+    def test_empty_string_still_returns_empty_object(self):
+        """Edge E1: pre-existing contract must hold."""
+        from run_agent import _repair_tool_call_arguments
+        assert _repair_tool_call_arguments("", "t") == "{}"
+
+    def test_none_type_still_returns_empty_object(self):
+        """Edge E1: pre-existing contract must hold."""
+        from run_agent import _repair_tool_call_arguments
+        assert _repair_tool_call_arguments(None, "t") == "{}"
+
+    def test_non_object_payloads_not_collapsed(self):
+        """Number/array/bool payloads must not be subject to the
+        same collapse. ``[1,2][1,2]`` is a corrupted array; the
+        conservative pipeline should leave it for the existing
+        trailing-comma / unclosed-bracket repair stages to handle
+        (or fail safely) — but it MUST NOT invent a merged array."""
+        from run_agent import _repair_tool_call_arguments
+        result = _repair_tool_call_arguments("[1,2][1,2]", "t")
+        # Must parse to a valid JSON value of some kind.
+        parsed = json.loads(result)
+        # Acceptable: first array [1,2], or any repaired form. Must
+        # not equal a silently-merged [1,2,1,2].
+        assert parsed != [1, 2, 1, 2], (
+            f"Array payloads were silently concatenated: {parsed!r}"
+        )
+
+
+class TestRepairProducesValidJson:
+    """Every repair result MUST round-trip through ``json.loads`` —
+    either before (no fix) or after (fix applied)."""
+
+    @pytest.mark.parametrize(
+        "raw",
+        [
+            '{"a":1}{"a":1}',
+            '{"a":1}{"a":1}{"a":1}',
+            '{"name":"x","file_path":""}{"name":"x","file_path":""}',
+            '{"x":1}{"y":2}',  # mismatched — must not silently merge
+        ],
+    )
+    def test_repair_output_is_valid_json(self, raw):
+        from run_agent import _repair_tool_call_arguments
+        result = _repair_tool_call_arguments(raw, "t")
+        # The result must always be parseable JSON.
+        json.loads(result)


### PR DESCRIPTION
## Summary

Fixes #6841 by repairing two observed model/tool-call corruption patterns in the existing production repair paths:

- collapses exact double-repeated tool names only when the collapsed value is an actual registered tool name (for example `skills_listskills_list` → `skills_list`)
- collapses duplicated adjacent JSON object argument payloads only when every repeated payload substring is byte-identical and parses as an object (for example `{"a":1}{"a":1}` → `{"a":1}`)

The repair is conservative: mismatched payloads, non-object payloads, single valid objects, empty/`None` arguments, unrelated repeated strings, and invalid collapsed tool names fall through to the existing safe paths.

## Reviewer improvement pass

During automated review, I tightened the JSON duplicate repair from parsed-dict equality to byte-identical JSON substring equality and added a regression test for semantically equal but differently serialized objects (`{"a":1,"b":2}{"b":2,"a":1}`), which must not be collapsed.

## Competing PR analysis

Open PR #7159 attempts the same issue, but it is stale and contaminated against current `main`: its diff edits the old monolithic `run_agent.py`, removes unrelated current fields/behaviour such as `service_tier`, `request_overrides`, `suppress_status_output`, quiet tool-message logic, and local-provider stream timeout handling, and does not target the current extracted repair modules. This PR is based on fresh upstream `main`, keeps the change in the current extracted helper modules, and includes focused regression coverage.

## Verification

- RED proof on raw upstream/main: new regression suite collected 21 tests; 9–10 failed without the production fix for repeated tool names and duplicated JSON arguments.
- With fix before review: `tests/run_agent/test_6841_repeated_tool_call_repair.py`, `tests/run_agent/test_repair_tool_call_arguments.py`, `tests/run_agent/test_repair_tool_call_name.py`, and `tests/run_agent/test_message_sequence_repair.py` passed.
- After reviewer improvement + rebase:
  - `/Users/evinova-self/.hermes/hermes-agent/venv/bin/python3 -m pytest tests/run_agent/test_6841_repeated_tool_call_repair.py tests/run_agent/test_repair_tool_call_arguments.py tests/run_agent/test_repair_tool_call_name.py tests/run_agent/test_message_sequence_repair.py -q -o "addopts=" --tb=short`
  - Result: `88 passed, 1 warning in 0.65s`

Auto-published by Moonsong via Path B automated pipeline.
