### PR TITLE
fix(desktop): guard preview webview protocols

### DIFF
--- a/apps/desktop/electron/main.cjs
+++ b/apps/desktop/electron/main.cjs
@@ -20,7 +20,6 @@ const crypto = require('node:crypto')
 const fs = require('node:fs')
 const http = require('node:http')
 const https = require('node:https')
-const net = require('node:net')
 const path = require('node:path')
 const { pathToFileURL } = require('node:url')
 const { execFileSync, spawn } = require('node:child_process')
@@ -38,6 +37,7 @@ const { adoptServedDashboardToken } = require('./dashboard-token.cjs')
 const { waitForDashboardPort } = require('./backend-ready.cjs')
 const { serializeJsonBody, setJsonRequestHeaders } = require('./oauth-net-request.cjs')
 const { fetchMarketplaceThemes, searchMarketplaceThemes } = require('./vscode-marketplace.cjs')
+const { guardPreviewWebContents } = require('./preview-navigation.cjs')
 const { buildDesktopBackendEnv, normalizeHermesHomeRoot } = require('./backend-env.cjs')
 const { readWindowsUserEnvVar } = require('./windows-user-env.cjs')
 const { readDirForIpc } = require('./fs-read-dir.cjs')
@@ -5067,6 +5067,9 @@ function wireCommonWindowHandlers(win) {
 
     event.preventDefault()
     openExternalUrl(url)
+  })
+  win.webContents.on('did-attach-webview', (_event, webContents) => {
+    guardPreviewWebContents(webContents, { openExternalUrl })
   })
 }
 

--- a/apps/desktop/electron/preview-navigation.cjs
+++ b/apps/desktop/electron/preview-navigation.cjs
@@ -1,0 +1,55 @@
+const PREVIEW_ALLOWED_PROTOCOLS = new Set(['http:', 'https:', 'file:', 'hermes-media:'])
+const PREVIEW_EXTERNAL_OPEN_PROTOCOLS = new Set(['http:', 'https:'])
+
+function parsePreviewUrl(rawUrl) {
+  try {
+    return new URL(String(rawUrl || '').trim())
+  } catch {
+    return null
+  }
+}
+
+function isAllowedPreviewNavigation(rawUrl) {
+  const parsed = parsePreviewUrl(rawUrl)
+
+  return Boolean(parsed && PREVIEW_ALLOWED_PROTOCOLS.has(parsed.protocol))
+}
+
+function isAllowedPreviewExternalOpen(rawUrl) {
+  const parsed = parsePreviewUrl(rawUrl)
+
+  return Boolean(parsed && PREVIEW_EXTERNAL_OPEN_PROTOCOLS.has(parsed.protocol))
+}
+
+function guardPreviewWebContents(webContents, { openExternalUrl } = {}) {
+  if (!webContents) {
+    return
+  }
+
+  const blockUnsafeNavigation = (event, url) => {
+    if (isAllowedPreviewNavigation(url)) {
+      return
+    }
+
+    event.preventDefault()
+  }
+
+  webContents.setWindowOpenHandler?.(details => {
+    if (isAllowedPreviewExternalOpen(details.url) && typeof openExternalUrl === 'function') {
+      openExternalUrl(details.url)
+    }
+
+    return { action: 'deny' }
+  })
+
+  webContents.on?.('will-navigate', blockUnsafeNavigation)
+  webContents.on?.('will-frame-navigate', blockUnsafeNavigation)
+  webContents.on?.('will-redirect', blockUnsafeNavigation)
+}
+
+module.exports = {
+  PREVIEW_ALLOWED_PROTOCOLS,
+  guardPreviewWebContents,
+  isAllowedPreviewExternalOpen,
+  isAllowedPreviewNavigation
+}

--- a/apps/desktop/electron/preview-navigation.test.cjs
+++ b/apps/desktop/electron/preview-navigation.test.cjs
@@ -1,0 +1,102 @@
+const test = require('node:test')
+const assert = require('node:assert/strict')
+
+const {
+  guardPreviewWebContents,
+  isAllowedPreviewExternalOpen,
+  isAllowedPreviewNavigation
+} = require('./preview-navigation.cjs')
+
+function fakeWebContents() {
+  const listeners = new Map()
+  let windowOpenHandler = null
+
+  return {
+    emit(name, ...args) {
+      listeners.get(name)?.(...args)
+    },
+    on(name, listener) {
+      listeners.set(name, listener)
+    },
+    setWindowOpenHandler(handler) {
+      windowOpenHandler = handler
+    },
+    windowOpen(url) {
+      return windowOpenHandler({ url })
+    }
+  }
+}
+
+test('isAllowedPreviewNavigation allows preview-safe schemes', () => {
+  assert.equal(isAllowedPreviewNavigation('https://example.com/page'), true)
+  assert.equal(isAllowedPreviewNavigation('http://localhost:5173'), true)
+  assert.equal(isAllowedPreviewNavigation('file:///tmp/demo.html'), true)
+  assert.equal(isAllowedPreviewNavigation('hermes-media://stream/%2Ftmp%2Fdemo.mp4'), true)
+})
+
+test('isAllowedPreviewNavigation rejects custom and executable schemes', () => {
+  assert.equal(isAllowedPreviewNavigation('bitbrowser://open?url=https%3A%2F%2Fexample.com'), false)
+  assert.equal(isAllowedPreviewNavigation('intent://scan/#Intent;scheme=zxing;end'), false)
+  assert.equal(isAllowedPreviewNavigation('javascript:alert(1)'), false)
+  assert.equal(isAllowedPreviewNavigation('data:text/html,<script>alert(1)</script>'), false)
+  assert.equal(isAllowedPreviewNavigation(''), false)
+})
+
+test('isAllowedPreviewExternalOpen only allows web URLs', () => {
+  assert.equal(isAllowedPreviewExternalOpen('https://example.com/page'), true)
+  assert.equal(isAllowedPreviewExternalOpen('http://example.com/page'), true)
+  assert.equal(isAllowedPreviewExternalOpen('file:///tmp/demo.html'), false)
+  assert.equal(isAllowedPreviewExternalOpen('hermes-media://stream/%2Ftmp%2Fdemo.mp4'), false)
+  assert.equal(isAllowedPreviewExternalOpen('bitbrowser://open'), false)
+})
+
+test('guardPreviewWebContents blocks custom-protocol guest navigation', () => {
+  const webContents = fakeWebContents()
+  let prevented = false
+
+  guardPreviewWebContents(webContents)
+  webContents.emit(
+    'will-navigate',
+    { preventDefault: () => (prevented = true) },
+    'bitbrowser://open?url=https%3A%2F%2Fexample.com'
+  )
+
+  assert.equal(prevented, true)
+})
+
+test('guardPreviewWebContents blocks custom-protocol guest redirects and frame navigations', () => {
+  const webContents = fakeWebContents()
+  const blocked = []
+
+  guardPreviewWebContents(webContents)
+  webContents.emit('will-redirect', { preventDefault: () => blocked.push('redirect') }, 'intent://scan')
+  webContents.emit('will-frame-navigate', { preventDefault: () => blocked.push('frame') }, 'bitbrowser://open')
+
+  assert.deepEqual(blocked, ['redirect', 'frame'])
+})
+
+test('guardPreviewWebContents leaves preview-safe guest navigation alone', () => {
+  const webContents = fakeWebContents()
+  let prevented = false
+
+  guardPreviewWebContents(webContents)
+  webContents.emit('will-navigate', { preventDefault: () => (prevented = true) }, 'https://example.com/next')
+
+  assert.equal(prevented, false)
+})
+
+test('guardPreviewWebContents denies webview new windows and opens http links externally', () => {
+  const webContents = fakeWebContents()
+  const opened = []
+
+  guardPreviewWebContents(webContents, {
+    openExternalUrl(url) {
+      opened.push(url)
+    }
+  })
+
+  assert.deepEqual(webContents.windowOpen('https://example.com/page'), { action: 'deny' })
+  assert.deepEqual(webContents.windowOpen('bitbrowser://open'), { action: 'deny' })
+  assert.deepEqual(webContents.windowOpen('file:///tmp/demo.html'), { action: 'deny' })
+  assert.deepEqual(opened, ['https://example.com/page'])
+})

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -37,7 +37,7 @@
     "test:desktop:nsis": "node scripts/test-desktop.mjs nsis",
     "test:desktop:existing": "node scripts/test-desktop.mjs existing",
     "test:desktop:fresh": "node scripts/test-desktop.mjs fresh",
-    "test:desktop:platforms": "node --test electron/bootstrap-platform.test.cjs electron/hardening.test.cjs electron/backend-env.test.cjs electron/backend-probes.test.cjs electron/bootstrap-runner.test.cjs electron/connection-config.test.cjs electron/dashboard-token.test.cjs electron/gateway-ws-probe.test.cjs electron/oauth-net-request.test.cjs electron/desktop-uninstall.test.cjs electron/session-windows.test.cjs electron/workspace-cwd.test.cjs electron/fs-read-dir.test.cjs electron/git-root.test.cjs electron/windows-child-process.test.cjs electron/update-remote.test.cjs electron/windows-user-env.test.cjs",
+    "test:desktop:platforms": "node --test electron/bootstrap-platform.test.cjs electron/hardening.test.cjs electron/backend-env.test.cjs electron/backend-probes.test.cjs electron/bootstrap-runner.test.cjs electron/connection-config.test.cjs electron/dashboard-token.test.cjs electron/gateway-ws-probe.test.cjs electron/oauth-net-request.test.cjs electron/desktop-uninstall.test.cjs electron/session-windows.test.cjs electron/workspace-cwd.test.cjs electron/fs-read-dir.test.cjs electron/git-root.test.cjs electron/windows-child-process.test.cjs electron/update-remote.test.cjs electron/windows-user-env.test.cjs electron/preview-navigation.test.cjs",
     "typecheck": "tsc -p . --noEmit",
     "lint": "eslint src/ electron/",
     "lint:fix": "eslint src/ electron/ --fix",


### PR DESCRIPTION
## Summary

- add a shared Electron guard for preview `<webview>` guest navigation
- block custom/executable schemes such as `bitbrowser://`, `intent://`, `javascript:`, and `data:` from preview navigations, frame navigations, redirects, and `window.open`
- keep in-webview preview navigation limited to `http:`, `https:`, `file:`, and `hermes-media:`, while only allowing `http(s)` new windows to leave via the existing `openExternalUrl` path
- wire the new guard into every desktop window through `did-attach-webview`

## Related

Addresses the custom-protocol-handler path in #47500.
Complements #41565: that PR gates remote URL preview auto-open; this PR handles a page that is already inside the preview webview trying to escape to a custom OS protocol.
Related to #41111, but this is not the background title/artifact download dialog path.

## Testing

- `node --test apps/desktop/electron/preview-navigation.test.cjs`
- `node --check apps/desktop/electron/main.cjs && node --check apps/desktop/electron/preview-navigation.cjs && node --check apps/desktop/electron/preview-navigation.test.cjs`
- `../../node_modules/.bin/eslint electron/main.cjs electron/preview-navigation.cjs electron/preview-navigation.test.cjs` (from `apps/desktop`)
- `../../node_modules/.bin/prettier --check electron/preview-navigation.cjs electron/preview-navigation.test.cjs package.json` (from `apps/desktop`)
- `npm run --workspace apps/desktop typecheck`
- `node --test electron/bootstrap-platform.test.cjs electron/hardening.test.cjs electron/backend-env.test.cjs electron/backend-probes.test.cjs electron/bootstrap-runner.test.cjs electron/connection-config.test.cjs electron/dashboard-token.test.cjs electron/gateway-ws-probe.test.cjs electron/oauth-net-request.test.cjs electron/desktop-uninstall.test.cjs electron/session-windows.test.cjs electron/workspace-cwd.test.cjs electron/fs-read-dir.test.cjs electron/git-root.test.cjs electron/update-remote.test.cjs electron/windows-user-env.test.cjs electron/preview-navigation.test.cjs` (from `apps/desktop`)

Note: `npm run --workspace apps/desktop test:desktop:platforms` still has an unrelated pre-existing failure in `electron/windows-child-process.test.cjs` on current `main` (`missing call site: execFileSync(pyExe`). The same platform suite without that pre-existing failing file passes with the new preview-navigation test included.
