### PR TITLE
feat: add adversarial-debate optional skill

### DIFF
--- a/optional-skills/software-development/adversarial-debate/SKILL.md
+++ b/optional-skills/software-development/adversarial-debate/SKILL.md
@@ -1,0 +1,218 @@
+---
+name: adversarial-debate
+description: "Synchronous 4-agent adversarial debate with DQI scoring."
+version: 1.0.0
+author: Ramiz Mehran (ramizmehran) <ramiz@example.com>
+license: MIT
+platforms: [linux, macos]
+metadata:
+  hermes:
+    tags: [debate, multi-agent, decision-quality, consensus, cross-examination]
+    related_skills: [team-of-thoughts, kanban-orchestrator]
+    config:
+      delegation.max_concurrent_children: 4
+---
+
+# Adversarial Debate
+
+Orchestrate a synchronous 3-round adversarial debate among Clio, Hephaestus, Solon, and Talaria using `delegate_task`. Agents produce structured JSON claims with evidence types, rebut each other by claim ID, and converge to a weighted Decision Quality Index (DQI).
+
+**Core principle:** Structured cross-examination beats distributed monologue. Agents must defend, concede, or rebut by evidence — not opinion.
+
+## When to Use
+
+Use this skill when:
+- A decision has significant irreversible consequences (one-way door)
+- There are ≥2 plausible approaches with strong trade-offs
+- A previous kanban ToT produced weak or conflicting synthesis
+- The user explicitly asks for "full team debate", "adversarial review", or "cross-examine this"
+
+For routine feature design, low-risk bug fixes, and deliverable validation, use the kanban ToT (`team-of-thoughts` skill) instead.
+
+## Prerequisites
+
+| Requirement | Minimum | Notes |
+|-------------|---------|-------|
+| `delegation.max_concurrent_children` | 4 | In `config.yaml` — needed for parallel agent spawn |
+| `delegation.child_timeout_seconds` | 600 | Per-agent timeout for each round |
+| Hermes profiles | clio, hephaestus, solon, talaria | Must exist and be operational |
+| `delegate_task` tool | Available | Included in all platform toolsets |
+
+## How to Run
+
+### From agent prompt (primary path)
+
+Load this skill, then follow the Procedure below. You (Hermes/Default) serve as debate moderator: spawn agents via `delegate_task`, collect outputs, calculate DQI, produce synthesis.
+
+### From CLI (debugging / test)
+
+```bash
+~/.hermes/skills/adversarial-debate/scripts/debate-orchestrator.sh \
+  --topic "Topic" \
+  --context-file /tmp/context.md \
+  --format rca
+```
+
+## Quick Reference
+
+```
+Setup → Round 1 (4 parallel agents, opening statements)
+      → Round 2 (4 parallel agents, cross-examination by claim ID)
+      → DQI calculation → if DQI < 0.6 → Round 3 (convergence)
+      → Weighted synthesis → kanban root card
+```
+
+DQI formula per claim: `confidence × evidence_multiplier × rebuttal_status`
+  - evidence: direct=1.0, inferred=0.7, speculative=0.4
+  - rebuttal: unrebutted=1.0, conceded=0.7, unresolved=0.5
+
+## Procedure
+
+### 1. Setup
+
+1. Inform the user the debate is starting.
+2. Create workspace: `/tmp/hermes-debate-<timestamp>/` with `round-1/`, `round-2/`, `round-3/` subdirectories.
+3. Write the context file including topic, format (`rca` or `feature`), project root, background, and success criteria.
+4. Create a kanban root card for tracking:
+   ```bash
+   hermes kanban create "Debate: <topic>" --triage --body "$(cat context)"
+   ```
+5. Initialize the transcript:
+   ```bash
+   echo '{"debate_id":"debate-<ts>","topic":"<topic>","format":"<rca|feature>","rounds":[],"dqi":null}' > transcript.json
+   ```
+
+### 2. Round 1 — Opening Statements
+
+Read the Round 1 template from `templates/round-1-opening.md`. Render placeholders with the actual topic, format, and agent name. Spawn all 4 agents in parallel via `delegate_task`:
+
+```python
+for agent in ["clio", "hephaestus", "solon", "talaria"]:
+    delegate_task(
+        subagent_type="general",
+        description=f"Adversarial debate Round 1 — {agent}",
+        prompt=rendered_round1_prompt(agent, topic, context)
+    )
+```
+
+Each agent returns structured JSON with claims, evidence citations, confidence (0–100), and evidence strength (`direct` | `inferred` | `speculative`).
+
+On timeout or malformed JSON, record `{"agent":"<name>","error":"timeout|parse_error"}` and continue.
+
+Append all 4 outputs to the transcript.
+
+### 3. Round 2 — Cross-Examination
+
+Render the Round 2 template from `templates/round-2-cross-examination.md`. Append the full transcript JSON to each prompt so agents see every other agent's claims.
+
+Each agent MUST:
+- Rebut ≥1 specific claim from another agent by `claim.id`
+- Update their confidence (may increase or decrease)
+- Set `position_changed: true/false`
+
+Spawn all 4 in parallel. Collect outputs, append to transcript.
+
+### 4. DQI Calculation
+
+After Round 2, run the DQI formula using all claims from the latest round:
+
+```python
+evidence_mult = {"direct": 1.0, "inferred": 0.7, "speculative": 0.4}
+rebuttal_mult = {"unrebutted": 1.0, "conceded": 0.7, "unresolved": 0.5}
+
+weights = []
+for claim in all_claims:
+    c = claim["confidence"] / 100
+    e = evidence_mult.get(claim["evidence_strength"], 0.4)
+    r = rebuttal_mult.get(claim.get("rebuttal_status", "unrebutted"), 1.0)
+    weights.append(c * e * r)
+
+dqi = sum(weights) / len(weights) if weights else 0.0
+```
+
+| DQI | Action |
+|-----|--------|
+| ≥ 0.8 | Skip Round 3. Proceed to adjudication. |
+| 0.6 – 0.8 | Skip Round 3. Flag tensions in synthesis. |
+| < 0.6 | Enter Round 3 — Convergence. |
+
+Also count position changes: ≥2 agents changed position signals healthy convergence. 0 changes signals entrenched positions — note in synthesis.
+
+### 5. Round 3 — Convergence (only if DQI < 0.6)
+
+Render the Round 3 template from `templates/round-3-convergence.md`. Include the full transcript and a list of unresolved disagreements (claims defended in Round 2).
+
+Each agent MUST end with one of:
+- **accept** — full agreement
+- **conditional_accept** — accept if condition is met
+- **minority_report** — maintain dissenting position with rationale
+
+Spawn all 4 in parallel. Collect outputs. Recalculate DQI with Round 3 claims included.
+
+### 6. Adjudication
+
+Build the synthesis JSON:
+
+```python
+synthesis = {
+    "debate_id": "...",
+    "topic": "...",
+    "rounds_completed": 2 or 3,
+    "dqi": <float>,
+    "dqi_assessment": "high" | "moderate" | "low",
+    "consensus_claims": [unrebutted or conceded claims],
+    "tensions": [defended claims with split positions],
+    "minority_reports": [agents who filed minority reports],
+    "execute_automatically": dqi >= 0.8 and no minority reports
+}
+```
+
+Post the synthesis to the kanban root card:
+```bash
+hermes kanban comment <root_card_id> "$(cat synthesis.json)"
+hermes kanban complete <root_card_id> --summary "DQI: <score>"
+```
+
+Report to the user:
+- Debate complete, DQI score and assessment
+- Whether auto-execute or human review needed
+- Any minority reports or tensions
+
+## Pitfalls
+
+### Agent returns malformed JSON
+Try `jq` parse first. On failure, extract JSON block via regex `/```json\n([\s\S]*?)\n```/`. On complete failure, treat as `confidence: 0, evidence_strength: speculative`.
+
+### Agent times out (≥600s)
+Continue with remaining 3 agents. Note the missing agent in synthesis. Recalculate DQI without their claims. If ≥2 agents fail, abort and inform the user.
+
+### False consensus (DQI > 0.9 after Round 1)
+May indicate groupthink. Optionally inject an adversarial probe round where each agent argues AGAINST their initial position before proceeding to Round 2.
+
+### Cross-profile project contamination
+Include in the context file:
+```markdown
+**WORKING DIRECTORY:** /home/user/projects/your-project
+**DO NOT** analyze files outside this directory.
+```
+
+### Round 2 rebuttals target wrong claim IDs
+The prompt enforces claim ID format (`<agent>-claim-<N>`) but agents may hallucinate IDs. Validate: if a rebuttal targets a non-existent ID, log it but skip weighting.
+
+## Verification
+
+After a debate completes, verify:
+1. All agent JSON files exist and parse: `ls round-*/<agent>.json`
+2. Round 2 rebuttals cite valid claim IDs (check transcript)
+3. DQI was calculated with the correct formula
+4. Synthesis includes consensus claims, tensions, and minority reports
+5. Kanban root card has the synthesis comment
+
+For a dry-run test without real agents, call the orchestrator script with a small context and inspect the output:
+```bash
+~/.hermes/skills/adversarial-debate/scripts/debate-orchestrator.sh \
+  --topic "Dry run test" \
+  --context-file <(echo "## Test context") \
+  --format feature \
+  --max-rounds 1
+```

--- a/optional-skills/software-development/adversarial-debate/references/DQI-FORMULA.md
+++ b/optional-skills/software-development/adversarial-debate/references/DQI-FORMULA.md
@@ -1,0 +1,40 @@
+# Decision Quality Index (DQI)
+
+## Formula
+
+```
+For each claim:
+  weight = confidence × evidence_multiplier × rebuttal_multiplier
+
+DQI = sum(weights) / count(weights)
+```
+
+### Evidence multipliers
+
+| Strength     | Multiplier |
+|--------------|------------|
+| direct       | 1.0        |
+| inferred     | 0.7        |
+| speculative  | 0.4        |
+
+### Rebuttal multipliers
+
+| Status      | Multiplier |
+|-------------|------------|
+| unrebutted  | 1.0        |
+| conceded    | 0.7        |
+| unresolved  | 0.5        |
+
+## Thresholds
+
+| DQI Range     | Assessment | Action                           |
+|---------------|------------|----------------------------------|
+| ≥ 0.8         | high       | Auto-execute (no minority report)|
+| 0.6 – 0.8     | moderate   | Human review flagged             |
+| < 0.6         | low        | Round 3 convergence required     |
+
+## Notes
+
+- Position changes (Round 2) do not enter the DQI formula directly but signal healthy debate.
+- If an agent produces no claims (timeout or error), they contribute zero weight, lowering DQI.
+- DQI ≥ 0.9 after Round 1 warrants a groupthink check — optionally inject adversarial probe round.

--- a/optional-skills/software-development/adversarial-debate/scripts/debate-orchestrator.sh
+++ b/optional-skills/software-development/adversarial-debate/scripts/debate-orchestrator.sh
@@ -1,0 +1,227 @@
+#!/usr/bin/env bash
+# debate-orchestrator.sh — CLI entry point for adversarial debates
+#
+# Installed by the adversarial-debate optional skill.
+# Usage:
+#   debate-orchestrator.sh --topic "..." --context-file <path> --format <rca|feature>
+#
+# This script provides a bash-level interface to the adversarial debate
+# protocol. It is intended for testing and CLI invocation. The primary
+# path is to load the skill in Hermes and follow the SKILL.md procedure.
+
+set -euo pipefail
+
+SKILL_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+TIMESTAMP=$(date +%s)
+DEBATE_ID="debate-${TIMESTAMP}"
+WORKSPACE="/tmp/hermes-debate-${DEBATE_ID}"
+TRANSCRIPT_FILE="${WORKSPACE}/transcript.json"
+SYNTHESIS_FILE="${WORKSPACE}/synthesis.json"
+AGENTS=("clio" "hephaestus" "solon" "talaria")
+MAX_ROUNDS=3
+DQI_THRESHOLD=0.6
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --topic) TOPIC="$2"; shift 2 ;;
+    --context-file) CONTEXT_FILE="$2"; shift 2 ;;
+    --format) FORMAT="$2"; shift 2 ;;
+    --max-rounds) MAX_ROUNDS="$2"; shift 2 ;;
+    --dqi-threshold) DQI_THRESHOLD="$2"; shift 2 ;;
+    *) echo "Unknown: $1"; exit 1 ;;
+  esac
+done
+
+: "${TOPIC:?--topic required}"
+: "${CONTEXT_FILE:?--context-file required}"
+: "${FORMAT:?--format required (rca|feature)}"
+
+echo "[debate] Starting: $TOPIC (format=$FORMAT, max_rounds=$MAX_ROUNDS)"
+
+mkdir -p "${WORKSPACE}/round-1" "${WORKSPACE}/round-2" "${WORKSPACE}/round-3"
+cp "$CONTEXT_FILE" "${WORKSPACE}/context.md"
+echo "{\"debate_id\":\"${DEBATE_ID}\",\"topic\":\"${TOPIC}\",\"format\":\"${FORMAT}\",\"rounds\":[],\"dqi\":null}" > "$TRANSCRIPT_FILE"
+
+spawn_agent() {
+  local agent="$1" round="$2" prompt_file="$3"
+  local output_file="${WORKSPACE}/round-${round}/${agent}.json"
+  local full_prompt
+  full_prompt=$(cat "$prompt_file")
+  full_prompt="${full_prompt//\{\{TOPIC\}\}/${TOPIC}}"
+  full_prompt="${full_prompt//\{\{FORMAT\}\}/${FORMAT}}"
+  full_prompt="${full_prompt//\{\{AGENT\}\}/${agent}}"
+  full_prompt="${full_prompt//\{\{ROUND\}\}/${round}}"
+
+  if [[ "$round" -gt 1 ]]; then
+    full_prompt+="\n\n## Prior Rounds Transcript\n\`\`\`json\n$(cat "$TRANSCRIPT_FILE")\n\`\`\`"
+  fi
+
+  echo "$full_prompt" > "${WORKSPACE}/round-${round}/${agent}-prompt.md"
+
+  hermes delegate-task \
+    --profile "$agent" \
+    --prompt "$(cat "${WORKSPACE}/round-${round}/${agent}-prompt.md")" \
+    --output-format json \
+    --timeout 600 \
+    2>"${WORKSPACE}/round-${round}/${agent}-stderr.log" \
+    > "$output_file" || {
+      local ec=$?
+      echo "{\"agent\":\"${agent}\",\"round\":${round},\"error\":\"exit_code_${ec}\",\"claims\":[]}" > "$output_file"
+    }
+  echo "[debate] ${agent} Round ${round} complete"
+}
+
+update_transcript() {
+  local round="$1"
+  python3 -c "
+import json
+with open('${TRANSCRIPT_FILE}') as f:
+    t = json.load(f)
+outputs = []
+for agent in ['clio', 'hephaestus', 'solon', 'talaria']:
+    f = '${WORKSPACE}/round-${round}/' + agent + '.json'
+    try:
+        with open(f) as fh:
+            outputs.append({'agent': agent, 'output': json.load(fh)})
+    except (FileNotFoundError, json.JSONDecodeError):
+        outputs.append({'agent': agent, 'output': {'error': 'missing', 'claims': []}})
+t['rounds'].append({'round': ${round}, 'outputs': outputs})
+with open('${TRANSCRIPT_FILE}', 'w') as f:
+    json.dump(t, f, indent=2)
+"
+}
+
+produce_synthesis() {
+  python3 << 'PYEOF'
+import json, os
+workspace = os.environ.get('WORKSPACE', '')
+with open(f'{workspace}/transcript.json') as f:
+    t = json.load(f)
+
+rounds_completed = len(t['rounds'])
+position_changes = sum(
+    1 for r in t['rounds']
+    for output in r.get('outputs', [])
+    if output.get('output', {}).get('position_changed')
+)
+
+consensus = []
+tensions = []
+minority_reports = []
+
+for r in t['rounds']:
+    for output in r.get('outputs', []):
+        o = output.get('output', {})
+        if r['round'] >= 3 and o.get('resolution') == 'minority_report':
+            minority_reports.append({
+                'agent': output['agent'],
+                'position': o.get('position', ''),
+                'rationale': o.get('minority_report', '')
+            })
+        for claim in o.get('claims', []):
+            rs = claim.get('rebuttal_status', 'unrebutted')
+            if rs in ('unrebutted', 'conceded'):
+                consensus.append(claim)
+            elif rs == 'defended':
+                tensions.append(claim)
+
+dqi = t.get('dqi', 0.0)
+synthesis = {
+    'debate_id': t['debate_id'],
+    'topic': t['topic'],
+    'format': t['format'],
+    'rounds_completed': rounds_completed,
+    'dqi': dqi,
+    'dqi_assessment': 'high' if dqi >= 0.8 else ('moderate' if dqi >= 0.6 else 'low'),
+    'position_changes': position_changes,
+    'consensus_claims': [{'id': c['id'], 'statement': c['statement']} for c in consensus],
+    'tensions': [{'id': c['id'], 'statement': c['statement']} for c in tensions],
+    'minority_reports': minority_reports,
+    'execute_automatically': dqi >= 0.8 and len(minority_reports) == 0
+}
+with open(f'{workspace}/synthesis.json', 'w') as f:
+    json.dump(synthesis, f, indent=2)
+print(json.dumps(synthesis, indent=2))
+PYEOF
+}
+
+# ── Main sequence ─────────────────────────────────────────────────────
+echo "[debate] Round 1 — Opening Statements"
+for agent in "${AGENTS[@]}"; do
+  spawn_agent "$agent" 1 "${SKILL_DIR}/templates/round-1-opening.md" &
+done
+wait
+update_transcript 1
+
+echo "[debate] Round 2 — Cross-Examination"
+for agent in "${AGENTS[@]}"; do
+  spawn_agent "$agent" 2 "${SKILL_DIR}/templates/round-2-cross-examination.md" &
+done
+wait
+update_transcript 2
+
+DQI_DATA=$(ROUND_NUM=2 WORKSPACE="$WORKSPACE" python3 -c "
+import json, os
+
+workspace = os.environ['WORKSPACE']
+round_num = int(os.environ.get('ROUND_NUM', '2'))
+
+with open(f'{workspace}/transcript.json') as f:
+    transcript = json.load(f)
+
+evidence_mult = {'direct': 1.0, 'inferred': 0.7, 'speculative': 0.4}
+rebuttal_mult = {'unrebutted': 1.0, 'conceded': 0.7, 'unresolved': 0.5}
+
+all_weights = []
+for r in transcript.get('rounds', []):
+    if r['round'] == round_num:
+        for output in r['outputs']:
+            for claim in output.get('output', {}).get('claims', []):
+                conf = claim.get('confidence', 50) / 100.0
+                ev = evidence_mult.get(claim.get('evidence_strength', 'speculative'), 0.4)
+                rb = rebuttal_mult.get(claim.get('rebuttal_status', 'unrebutted'), 1.0)
+                all_weights.append(conf * ev * rb)
+
+dqi = sum(all_weights) / len(all_weights) if all_weights else 0.0
+print(json.dumps({'dqi': round(dqi, 3), 'claim_count': len(all_weights)}))
+")
+DQI=$(echo "$DQI_DATA" | python3 -c "import sys,json; print(json.load(sys.stdin)['dqi'])")
+echo "[debate] DQI after Round 2: $DQI"
+
+python3 -c "import json; t=json.load(open('${TRANSCRIPT_FILE}')); t['dqi']=${DQI}; json.dump(t, open('${TRANSCRIPT_FILE}','w'), indent=2)"
+
+if (( $(echo "$DQI < $DQI_THRESHOLD" | bc -l) )) && [[ "$MAX_ROUNDS" -ge 3 ]]; then
+  echo "[debate] DQI < threshold — Round 3: Convergence"
+  for agent in "${AGENTS[@]}"; do
+    spawn_agent "$agent" 3 "${SKILL_DIR}/templates/round-3-convergence.md" &
+  done
+  wait
+  update_transcript 3
+  DQI_DATA=$(ROUND_NUM=3 WORKSPACE="$WORKSPACE" python3 -c "
+import json, os
+workspace = os.environ['WORKSPACE']
+with open(f'{workspace}/transcript.json') as f:
+    transcript = json.load(f)
+evidence_mult = {'direct': 1.0, 'inferred': 0.7, 'speculative': 0.4}
+rebuttal_mult = {'unrebutted': 1.0, 'conceded': 0.7, 'unresolved': 0.5}
+all_weights = []
+for r in transcript.get('rounds', []):
+    if r['round'] == 3:
+        for output in r['outputs']:
+            for claim in output.get('output', {}).get('claims', []):
+                conf = claim.get('confidence', 50) / 100.0
+                ev = evidence_mult.get(claim.get('evidence_strength', 'speculative'), 0.4)
+                rb = rebuttal_mult.get(claim.get('rebuttal_status', 'unrebutted'), 1.0)
+                all_weights.append(conf * ev * rb)
+dqi = sum(all_weights) / len(all_weights) if all_weights else 0.0
+print(json.dumps({'dqi': round(dqi, 3)}))
+")
+  DQI=$(echo "$DQI_DATA" | python3 -c "import sys,json; print(json.load(sys.stdin)['dqi'])")
+  echo "[debate] DQI after Round 3: $DQI"
+fi
+
+echo "[debate] Producing synthesis"
+produce_synthesis
+
+echo "[debate] Complete. Synthesis: $SYNTHESIS_FILE"
+echo "[debate] DQI: $DQI"

--- a/optional-skills/software-development/adversarial-debate/templates/round-1-opening.md
+++ b/optional-skills/software-development/adversarial-debate/templates/round-1-opening.md
@@ -1,0 +1,50 @@
+# Adversarial Debate — Round 1: Opening Statement
+
+You are **{{AGENT}}** participating in a structured adversarial debate.
+
+## Topic
+
+{{TOPIC}}
+
+## Format
+
+{{FORMAT}}
+
+## Instructions
+
+Construct your opening statement with the following strict JSON schema. Output ONLY valid JSON — no markdown, no commentary.
+
+```json
+{
+  "agent": "{{AGENT}}",
+  "round": 1,
+  "position": "<FOR | AGAINST | CONDITIONAL>",
+  "position_changed": false,
+  "claims": [
+    {
+      "id": "{{AGENT}}-claim-1",
+      "statement": "Short, falsifiable claim",
+      "evidence": "What evidence supports this claim",
+      "evidence_strength": "direct|inferred|speculative",
+      "confidence": 75
+    }
+  ],
+  "minority_report": null,
+  "resolution": null
+}
+```
+
+### Claim Rules
+
+1. Each claim must be **falsifiable** — capable of being proven wrong by evidence.
+2. At most 5 claims per agent per round.
+3. `evidence_strength`:
+   - `direct` = you have explicit data, code, docs, or test results
+   - `inferred` = derived from existing evidence but not directly cited
+   - `speculative` = logical reasoning without supporting data
+4. `confidence` = integer 0–100 representing how sure you are.
+5. Claims are indexed sequentially as `{{AGENT}}-claim-1` through `{{AGENT}}-claim-N` for cross-referencing in Round 2.
+
+### Context
+
+{{CONTEXT}}

--- a/optional-skills/software-development/adversarial-debate/templates/round-2-cross-examination.md
+++ b/optional-skills/software-development/adversarial-debate/templates/round-2-cross-examination.md
@@ -1,0 +1,68 @@
+# Adversarial Debate — Round 2: Cross-Examination
+
+You are **{{AGENT}}**. The full transcript from Round 1 is included below.
+
+## Instructions
+
+Read every claim from every other agent. For each claim you disagree with or find unsupported:
+
+1. **Rebutt** — cite the claim ID and explain why it is wrong, incomplete, or speculative.
+2. **Concede** — acknowledge claims by other agents that are well-supported.
+3. **Update your confidence** — may increase, decrease, or stay the same.
+4. **Optionally change position** — if evidence compels it, set `position_changed: true`.
+
+Output ONLY valid JSON following this schema:
+
+```json
+{
+  "agent": "{{AGENT}}",
+  "round": 2,
+  "position": "<FOR | AGAINST | CONDITIONAL>",
+  "position_changed": true,
+  "claims": [
+    {
+      "id": "{{AGENT}}-claim-1",
+      "statement": "Updated claim (keep original or refine)",
+      "evidence": "Same or updated evidence",
+      "evidence_strength": "direct|inferred|speculative",
+      "confidence": 80,
+      "rebuttal_status": "unrebutted|conceded|defended",
+      "rebuttal_of": null,
+      "rebuttal_notes": null
+    },
+    {
+      "id": "{{AGENT}}-claim-2",
+      "statement": "A new or refined claim",
+      "evidence": "Evidence",
+      "evidence_strength": "direct",
+      "confidence": 90,
+      "rebuttal_status": "unrebutted",
+      "rebuttal_of": "clio-claim-3",
+      "rebuttal_notes": "Clio's claim ignores the latency overhead of ..."
+    }
+  ],
+  "minority_report": null,
+  "resolution": null
+}
+```
+
+### Rebuttal Rules
+
+- `rebuttal_of` = the claim ID you are rebutting (or `null` for original claims).
+- `rebuttal_status`:
+  - `unrebutted` — this is your own claim that no one has challenged
+  - `conceded` — you accept another agent's rebuttal and lower your confidence
+  - `defended` — you maintain your position despite the rebuttal
+- Rebuttals MUST target valid claim IDs from Round 1 (format: `<agent>-claim-<N>`).
+
+### Context
+
+{{CONTEXT}}
+
+---
+
+## Prior Rounds Transcript
+
+```json
+{{TRANSCRIPT}}
+```

--- a/optional-skills/software-development/adversarial-debate/templates/round-3-convergence.md
+++ b/optional-skills/software-development/adversarial-debate/templates/round-3-convergence.md
@@ -1,0 +1,48 @@
+# Adversarial Debate — Round 3: Convergence
+
+You are **{{AGENT}}**. This is the final round. The DQI after Round 2 was below threshold — there are still unresolved disagreements.
+
+## Instructions
+
+Review all unresolved tensions (claims that were defended in Round 2). You MUST end with one of:
+
+- **accept** — you agree with the consensus path forward
+- **conditional_accept** — you accept if a specific condition is met
+- **minority_report** — you maintain your dissenting position with a written rationale
+
+Output ONLY valid JSON:
+
+```json
+{
+  "agent": "{{AGENT}}",
+  "round": 3,
+  "position": "<FOR | AGAINST | CONDITIONAL>",
+  "position_changed": true,
+  "claims": [
+    {
+      "id": "{{AGENT}}-claim-1",
+      "statement": "Refined final position",
+      "evidence": "Summary of best evidence",
+      "evidence_strength": "direct|inferred|speculative",
+      "confidence": 85,
+      "rebuttal_status": "unrebutted|conceded|defended",
+      "rebuttal_of": null,
+      "rebuttal_notes": null
+    }
+  ],
+  "minority_report": "<only if resolution=minority_report>",
+  "resolution": "accept|conditional_accept|minority_report"
+}
+```
+
+### Context
+
+{{CONTEXT}}
+
+---
+
+## Prior Rounds Transcript
+
+```json
+{{TRANSCRIPT}}
+```

--- a/optional-skills/software-development/adversarial-debate/templates/synthesis-schema.json
+++ b/optional-skills/software-development/adversarial-debate/templates/synthesis-schema.json
@@ -1,0 +1,53 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Adversarial Debate Synthesis",
+  "type": "object",
+  "required": [
+    "debate_id", "topic", "format",
+    "rounds_completed", "dqi", "dqi_assessment",
+    "position_changes",
+    "consensus_claims", "tensions",
+    "minority_reports", "execute_automatically"
+  ],
+  "properties": {
+    "debate_id": { "type": "string", "pattern": "^debate-\\d+$" },
+    "topic": { "type": "string" },
+    "format": { "type": "string", "enum": ["rca", "feature"] },
+    "rounds_completed": { "type": "integer", "minimum": 1, "maximum": 3 },
+    "dqi": { "type": "number", "minimum": 0, "maximum": 1 },
+    "dqi_assessment": { "type": "string", "enum": ["high", "moderate", "low"] },
+    "position_changes": { "type": "integer", "minimum": 0, "maximum": 4 },
+    "consensus_claims": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "id": { "type": "string" },
+          "statement": { "type": "string" }
+        }
+      }
+    },
+    "tensions": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "id": { "type": "string" },
+          "statement": { "type": "string" }
+        }
+      }
+    },
+    "minority_reports": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "agent": { "type": "string" },
+          "position": { "type": "string" },
+          "rationale": { "type": "string" }
+        }
+      }
+    },
+    "execute_automatically": { "type": "boolean" }
+  }
+}

--- a/tests/skills/test_adversarial_debate_skill.py
+++ b/tests/skills/test_adversarial_debate_skill.py
@@ -1,0 +1,169 @@
+"""
+Smoke tests for the adversarial-debate optional skill.
+
+Verifies:
+  - SKILL.md frontmatter conforms to hardline format (description ≤60 chars)
+  - All template files exist and contain valid JSON schemas
+  - Template JSON is parseable and matches the expected schema
+  - DQI calculation is deterministic and correct
+"""
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+import pytest
+import yaml
+
+SKILL_DIR = (
+    Path(__file__).resolve().parents[2]
+    / "optional-skills"
+    / "software-development"
+    / "adversarial-debate"
+)
+
+
+@pytest.fixture(scope="module")
+def frontmatter() -> dict:
+    src = (SKILL_DIR / "SKILL.md").read_text()
+    m = re.search(r"^---\n(.*?)\n---", src, re.DOTALL)
+    assert m, "SKILL.md missing YAML frontmatter"
+    return yaml.safe_load(m.group(1))
+
+
+# ── Frontmatter checks ────────────────────────────────────────────────
+
+
+def test_skill_dir_exists() -> None:
+    assert SKILL_DIR.is_dir()
+
+
+def test_skill_md_present() -> None:
+    assert (SKILL_DIR / "SKILL.md").is_file()
+
+
+def test_description_under_60_chars(frontmatter) -> None:
+    desc = frontmatter["description"]
+    assert len(desc) <= 60, f"description is {len(desc)} chars (hardline ≤60): {desc!r}"
+
+
+def test_version_present(frontmatter) -> None:
+    assert "version" in frontmatter, "missing version"
+
+
+def test_author_present(frontmatter) -> None:
+    assert "author" in frontmatter, "missing author"
+
+
+def test_license_is_mit(frontmatter) -> None:
+    assert frontmatter.get("license") == "MIT"
+
+
+def test_platforms_defined(frontmatter) -> None:
+    assert "platforms" in frontmatter
+    assert isinstance(frontmatter["platforms"], list)
+    assert len(frontmatter["platforms"]) > 0
+
+
+def test_hermes_metadata_tags(frontmatter) -> None:
+    meta = frontmatter.get("metadata", {}).get("hermes", {})
+    assert "tags" in meta, "missing metadata.hermes.tags"
+    assert isinstance(meta["tags"], list)
+    assert len(meta["tags"]) >= 3
+
+
+def test_hermes_metadata_related_skills(frontmatter) -> None:
+    meta = frontmatter.get("metadata", {}).get("hermes", {})
+    assert "related_skills" in meta, "missing metadata.hermes.related_skills"
+
+
+# ── File existence checks ─────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "rel_path",
+    [
+        "templates/round-1-opening.md",
+        "templates/round-2-cross-examination.md",
+        "templates/round-3-convergence.md",
+        "templates/synthesis-schema.json",
+        "scripts/debate-orchestrator.sh",
+    ],
+)
+def test_required_file_exists(rel_path: str) -> None:
+    assert (SKILL_DIR / rel_path).is_file(), f"missing: {rel_path}"
+
+
+# ── JSON schema validation ────────────────────────────────────────────
+
+
+def test_synthesis_schema_is_valid_json() -> None:
+    path = SKILL_DIR / "templates" / "synthesis-schema.json"
+    schema = json.loads(path.read_text())
+    assert "$schema" in schema
+    assert "properties" in schema
+    assert "required" in schema
+
+
+def test_synthesis_schema_required_fields() -> None:
+    path = SKILL_DIR / "templates" / "synthesis-schema.json"
+    schema = json.loads(path.read_text())
+    required = set(schema["required"])
+    expected = {
+        "debate_id", "topic", "format",
+        "rounds_completed", "dqi", "dqi_assessment",
+        "position_changes",
+        "consensus_claims", "tensions",
+        "minority_reports", "execute_automatically",
+    }
+    missing = expected - required
+    assert not missing, f"Schema missing required fields: {missing}"
+
+
+# ── DQI calculation correctness ───────────────────────────────────────
+
+
+def _calculate_dqi(claims: list[dict]) -> float:
+    evidence_mult = {"direct": 1.0, "inferred": 0.7, "speculative": 0.4}
+    rebuttal_mult = {"unrebutted": 1.0, "conceded": 0.7, "unresolved": 0.5}
+    weights = []
+    for c in claims:
+        conf = c.get("confidence", 50) / 100.0
+        ev = evidence_mult.get(c.get("evidence_strength", "speculative"), 0.4)
+        rb = rebuttal_mult.get(c.get("rebuttal_status", "unrebutted"), 1.0)
+        weights.append(conf * ev * rb)
+    return sum(weights) / len(weights) if weights else 0.0
+
+
+def test_dqi_all_direct_unrebutted() -> None:
+    claims = [
+        {"confidence": 90, "evidence_strength": "direct", "rebuttal_status": "unrebutted"},
+        {"confidence": 80, "evidence_strength": "direct", "rebuttal_status": "unrebutted"},
+    ]
+    dqi = _calculate_dqi(claims)
+    expected = (0.9 * 1.0 * 1.0 + 0.8 * 1.0 * 1.0) / 2
+    assert dqi == pytest.approx(expected)
+
+
+def test_dqi_mixed_evidence_rebuttals() -> None:
+    claims = [
+        {"confidence": 100, "evidence_strength": "direct", "rebuttal_status": "unrebutted"},
+        {"confidence": 50, "evidence_strength": "speculative", "rebuttal_status": "conceded"},
+    ]
+    dqi = _calculate_dqi(claims)
+    expected = (1.0 * 1.0 * 1.0 + 0.5 * 0.4 * 0.7) / 2
+    assert dqi == pytest.approx(expected)
+
+
+def test_dqi_all_speculative_defended() -> None:
+    claims = [
+        {"confidence": 70, "evidence_strength": "speculative", "rebuttal_status": "defended"},
+    ]
+    dqi = _calculate_dqi(claims)
+    expected = 0.7 * 0.4 * 1.0  # defended = unrebutted in this model
+    assert dqi == pytest.approx(expected)
+
+
+def test_dqi_empty_claims() -> None:
+    assert _calculate_dqi([]) == 0.0


### PR DESCRIPTION
## Summary

Adds a new optional skill: **adversarial-debate** — a synchronous 4-agent adversarial debate protocol with Decision Quality Index (DQI) scoring.

## What it does

Orchestrates 3 rounds of structured cross-examination among Clio, Hephaestus, Solon, and Talaria. Agents produce JSON claims with evidence types (`direct`/`inferred`/`speculative`), rebut each other by claim ID, and converge to a weighted DQI.

### Files

| Path | Purpose |
|------|---------|
| `optional-skills/software-development/adversarial-debate/SKILL.md` | Agent-facing 6-step orchestration instructions |
| `scripts/debate-orchestrator.sh` | CLI entry point for testing/debugging |
| `templates/round-1-opening.md` | Round 1: opening statements |
| `templates/round-2-cross-examination.md` | Round 2: cross-examination by claim ID |
| `templates/round-3-convergence.md` | Round 3: convergence (minority report support) |
| `templates/synthesis-schema.json` | Output schema for the final synthesis |
| `references/DQI-FORMULA.md` | DQI calculation reference |
| `tests/skills/test_adversarial_debate_skill.py` | 20 smoke tests |

## Quality

- Description: 56 chars (hardline ≤60 ✓)
- Frontmatter: `version`, `author`, `license: MIT`, `platforms: [linux, macos]`, `metadata.hermes.*`
- Section order per dev guide ✓
- All 20 tests pass