### PR TITLE
fix(agent): detect modern services.ai.azure.com URLs as Azure OpenAI

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -1057,16 +1057,18 @@ class AIAgent:
 
         Azure OpenAI exposes an OpenAI-compatible endpoint at
         ``{resource}.openai.azure.com/openai/v1`` that accepts the
-        standard ``openai`` Python client.  Unlike api.openai.com it
-        does NOT support the Responses API — gpt-5.x models are served
-        on the regular ``/chat/completions`` path — so routing decisions
-        must treat Azure separately from direct OpenAI.
+        standard ``openai`` Python client.  Modern (post-2024) resources
+        also use ``{resource}.services.ai.azure.com``.  Unlike
+        api.openai.com, Azure does NOT support the Responses API —
+        gpt-5.x models are served on the regular ``/chat/completions``
+        path — so routing decisions must treat Azure separately from
+        direct OpenAI.
         """
         if base_url is not None:
             url = str(base_url).lower()
         else:
             url = getattr(self, "_base_url_lower", "") or ""
-        return "openai.azure.com" in url
+        return "openai.azure.com" in url or "ai.azure.com" in url
 
     def _is_github_copilot_url(self, base_url: str = None) -> bool:
         """Return True when a base URL targets GitHub Copilot's OpenAI-compatible API."""

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -5206,6 +5206,9 @@ class TestGpt5ApiModeRouting:
         # Path-embedded azure string should still detect — we're ~substring matching
         agent.base_url = "https://my-resource.openai.azure.com/openai/v1"
         assert agent._is_azure_openai_url() is True
+        # Modern (post-2024) Azure OpenAI resources use services.ai.azure.com
+        assert agent._is_azure_openai_url("https://my-resource.services.ai.azure.com/openai/v1") is True
+        assert agent._is_azure_openai_url("https://my-resource.services.ai.azure.com/") is True
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
`_is_azure_openai_url()` only checked for `openai.azure.com` in the URL. Modern (post-2024) Azure OpenAI resources use the pattern `{name}.services.ai.azure.com` which was not detected, causing Azure-specific routing to fail for gpt-5.x models served without `/v1/` prefix.

Extend the substring check to also match `ai.azure.com`.

## Test Plan
- [x] Added test cases for `services.ai.azure.com` URLs
- [x] Existing tests pass
- [ ] Verify with actual Azure OpenAI endpoint

Fixes #47666
