### PR TITLE
fix(agent): fall back to max_context_length in LM Studio probe

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -1346,6 +1346,12 @@ def _query_local_context_length(model: str, base_url: str, api_key: str = "") ->
                                 ctx = cfg.get("context_length")
                                 if ctx and isinstance(ctx, (int, float)):
                                     return int(ctx)
+                            # Fallback: model-level max_context_length (training
+                            # max, available even when the model is not loaded).
+                            # See: https://github.com/NousResearch/hermes-agent/issues/47678
+                            ctx = m.get("max_context_length")
+                            if ctx and isinstance(ctx, (int, float)):
+                                return int(ctx)
                             break
 
             # LM Studio / vLLM / llama.cpp: try /v1/models/{model}


### PR DESCRIPTION
## Summary
`_query_local_context_length()` only read `context_length` from loaded instances in LM Studio's `/api/v1/models` response. When the model is not loaded (JIT enabled, fresh server start, TTL unload), `loaded_instances` is `[]` and the probe returned `None`, falling through to hardcoded family defaults (e.g. 256K for gemma-4) which can be much larger than the actual runtime window.

Add a fallback to the model-level `max_context_length` field which is always present in the response regardless of load state.

## Test Plan
- [ ] Start LM Studio with JIT enabled, no model loaded
- [ ] Query `_query_local_context_length()` — should return `max_context_length` instead of `None`
- [ ] With model loaded — should still prefer loaded instance `context_length`

Fixes #47678
