### PR TITLE
fix(agent): warn when memory.provider is misconfigured

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1144,7 +1144,7 @@ def init_agent(
 
             if _mem_provider_name and _mem_provider_name.strip():
                 from agent.memory_manager import MemoryManager as _MemoryManager
-                from plugins.memory import load_memory_provider as _load_mem
+                from plugins.memory import load_memory_provider as _load_mem, discover_memory_providers
                 agent._memory_manager = _MemoryManager()
                 _mp = _load_mem(_mem_provider_name)
                 if _mp and _mp.is_available():
@@ -1194,7 +1194,18 @@ def init_agent(
                     agent._memory_manager.initialize_all(**_init_kwargs)
                     _ra().logger.info("Memory provider '%s' activated", _mem_provider_name)
                 else:
-                    _ra().logger.debug("Memory provider '%s' not found or not available", _mem_provider_name)
+                    # Warn at WARNING (not DEBUG) so operators see misconfig.
+                    # List known providers to help the user self-diagnose.
+                    # See: https://github.com/NousResearch/hermes-agent/issues/47650
+                    try:
+                        _known = [n for n, _d, _a in discover_memory_providers()]
+                    except Exception:
+                        _known = []
+                    _hint = f" Known providers: {', '.join(_known)}" if _known else ""
+                    _ra().logger.warning(
+                        "Memory provider '%s' not found or not available.%s",
+                        _mem_provider_name, _hint,
+                    )
                     agent._memory_manager = None
         except Exception as _mpe:
             _ra().logger.warning("Memory provider plugin init failed: %s", _mpe)


### PR DESCRIPTION
## Summary
`memory.provider` accepted any string without validation. When set to an LLM provider name (e.g. `lm-studio`) instead of a memory provider, the failure was logged at `logger.debug()` — invisible at default log level. Users lost cross-session memory with no indication.

Change the log level to `logger.warning()` and include the list of known memory providers from `discover_memory_providers()` so operators can self-diagnose.

## Test Plan
- [ ] Set `memory.provider: lm-studio` in config.yaml
- [ ] Start Hermes — verify WARNING log shows "Memory provider 'lm-studio' not found" with list of known providers
- [ ] Set `memory.provider: honcho` (valid) — verify INFO log shows "activated"

Fixes #47650
