### PR TITLE
fix(auxiliary): route minimax-oauth through AnthropicAuxiliaryClient

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -1957,6 +1957,84 @@ def _try_custom_endpoint() -> Tuple[Optional[Any], Optional[str]]:
     return _fallback_client, model
 
 
+def _build_minimax_oauth_aux_client(model: str) -> Tuple[Optional[Any], Optional[str]]:
+    """Build an AnthropicAuxiliaryClient for a MiniMax OAuth-authenticated session.
+
+    MiniMax exposes an Anthropic-Messages-compatible endpoint
+    (https://api.minimax.io/anthropic) via OAuth, so we use the native Anthropic
+    SDK wrapped in AnthropicAuxiliaryClient — same pattern as ``_try_anthropic``
+    but with the MiniMax OAuth token provider as the bearer source.
+
+    MiniMax issues short-lived access tokens (~15 min), so we pass a *callable*
+    token provider from ``build_minimax_oauth_token_provider()`` instead of a
+    static string. ``build_anthropic_client`` detects the callable and installs
+    the bearer-injecting httpx hook that mints a fresh token per request (or
+    re-uses the cached one if it still has enough lifetime left).
+
+    Returns ``(None, None)`` when the user has not authenticated with
+    MiniMax OAuth, or when the anthropic SDK is missing. The caller is
+    responsible for passing a model — pinning a default would silently rot
+    when MiniMax's accepted-model list drifts.
+    """
+    if not model:
+        logger.warning(
+            "Auxiliary client: minimax-oauth requested without a model; "
+            "pass model explicitly (auxiliary.<task>.model in config.yaml)."
+        )
+        return None, None
+    try:
+        from agent.anthropic_adapter import build_anthropic_client
+        from hermes_cli.auth import (
+            build_minimax_oauth_token_provider,
+            resolve_minimax_oauth_runtime_credentials,
+        )
+    except ImportError as exc:
+        logger.debug(
+            "Auxiliary client: minimax-oauth requested but anthropic adapter "
+            "or auth helpers not importable: %s", exc
+        )
+        return None, None
+
+    try:
+        creds = resolve_minimax_oauth_runtime_credentials(as_token_provider=True)
+    except Exception as exc:
+        logger.warning(
+            "Auxiliary client: minimax-oauth requested but no valid token "
+            "found (run: hermes model and select MiniMax OAuth): %s", exc
+        )
+        return None, None
+
+    token_provider = creds["api_key"]          # zero-arg callable
+    base_url = creds["base_url"].rstrip("/")
+    # The token provider IS already a callable from resolve_minimax_oauth_runtime_credentials
+    # when as_token_provider=True. Re-wrap defensively in case the helper's
+    # contract changes — build_minimax_oauth_token_provider always returns a
+    # fresh callable so the cost is one extra closure allocation.
+    if not callable(token_provider):
+        token_provider = build_minimax_oauth_token_provider()
+    try:
+        real_client = build_anthropic_client(token_provider, base_url)
+    except ImportError:
+        logger.warning(
+            "Auxiliary client: minimax-oauth requested but the anthropic "
+            "SDK is not installed — install with `pip install 'anthropic>=0.39.0'`"
+        )
+        return None, None
+
+    logger.debug(
+        "Auxiliary client: MiniMax OAuth (%s) at %s (per-request token provider)",
+        model, base_url,
+    )
+    # is_oauth=True is the safer default for MiniMax: even if the callable
+    # path is bypassed in some future change, the AnthropicAuxiliaryClient
+    # shim already strips the OAuth identity headers that would leak to
+    # MiniMax's third-party endpoint. See agent.anthropic_adapter for the
+    # third-party identity-injection guard.
+    return AnthropicAuxiliaryClient(
+        real_client, model, "oauth-callable", base_url, is_oauth=True,
+    ), model
+
+
 def _build_xai_oauth_aux_client(model: str) -> Tuple[Optional[Any], Optional[str]]:
     """Build a CodexAuxiliaryClient for an xAI Grok OAuth-authenticated session.
 
@@ -3677,6 +3755,31 @@ def resolve_provider_client(
         return (_to_async_client(client, final_model, is_vision=is_vision) if async_mode
                 else (client, final_model))
 
+    # ── MiniMax (OAuth · minimax.io) ─────────────────────────────────
+    # Same rationale as xAI Grok OAuth above: without an explicit branch,
+    # the generic ``oauth_external`` arm below would return ``(None, None)``,
+    # silently re-routing every auxiliary task (compression, web extract,
+    # session search, curator, title generation, vision, ...) to whichever
+    # Step-2 fallback the user has configured. For users on MiniMax OAuth —
+    # a third-party Anthropic-Messages-compatible endpoint with OAuth
+    # credentials — that would mean surprise DeepSeek / OpenRouter bills for
+    # side tasks they thought were running on their MiniMax subscription.
+    # MiniMax uses the Anthropic Messages wire, so we route through the
+    # same AnthropicAuxiliaryClient as native Anthropic — the only thing
+    # that differs is the auth source (MiniMax OAuth token provider).
+    if provider == "minimax-oauth":
+        client, default = _build_minimax_oauth_aux_client(model)
+        if client is None:
+            logger.warning(
+                "resolve_provider_client: minimax-oauth requested but no "
+                "valid MiniMax OAuth token found (run: hermes model and "
+                "select MiniMax (OAuth · minimax.io))"
+            )
+            return None, None
+        final_model = _normalize_resolved_model(model or default, provider)
+        return (_to_async_client(client, final_model, is_vision=is_vision) if async_mode
+                else (client, final_model))
+
     # ── Custom endpoint (OPENAI_BASE_URL + OPENAI_API_KEY) ───────────
     if provider == "custom":
         if explicit_base_url:
@@ -4081,14 +4184,23 @@ def resolve_provider_client(
         return (_to_async_client(client, final_model, is_vision=is_vision) if async_mode
                 else (client, final_model))
 
-    elif pconfig.auth_type in {"oauth_device_code", "oauth_external"}:
-        # OAuth providers — route through their specific try functions
+    elif pconfig.auth_type in {"oauth_device_code", "oauth_external", "oauth_minimax"}:
+        # OAuth providers — route through their specific try functions.
+        # ``oauth_minimax`` is a third-party OAuth (PKCE, portal-based) that
+        # uses the Anthropic Messages wire, so it lives in the same
+        # dispatch block as ``oauth_external``. The specific provider name
+        # check below (xai-oauth, minimax-oauth) handles routing to its
+        # own _build_*_aux_client — without that, the helper returns
+        # (None, None) and every auxiliary task silently leaks to the
+        # api-key fallback chain (DeepSeek, OpenRouter, ...).
         if provider == "nous":
             return resolve_provider_client("nous", model, async_mode)
         if provider == "openai-codex":
             return resolve_provider_client("openai-codex", model, async_mode)
         if provider == "xai-oauth":
             return resolve_provider_client("xai-oauth", model, async_mode)
+        if provider == "minimax-oauth":
+            return resolve_provider_client("minimax-oauth", model, async_mode)
         # Other OAuth providers not directly supported
         logger.warning("resolve_provider_client: OAuth provider %s not "
                        "directly supported, try 'auto'", provider)


### PR DESCRIPTION
# fix(auxiliary): route `minimax-oauth` through `AnthropicAuxiliaryClient`

## Bug

The `minimax-oauth` provider silently fails for every auxiliary task (`title_generation`, `vision`, `web_extract`, `compression`, `session_search`, `curator`, `mcp`, `skills_hub`, etc.) when it is the configured main provider.

`resolve_provider_client` (in `agent/auxiliary_client.py`) dispatches OAuth providers in two places:

1. The named-provider arms (around line 3610) handle `nous`, `openai-codex`, and `xai-oauth` — but **not** `minimax-oauth`.
2. The catch-all `elif pconfig.auth_type in {"oauth_device_code", "oauth_external"}:` (around line 4084) routes through `nous` / `openai-codex` / `xai-oauth` branches — but `minimax-oauth`'s `auth_type` is the string `"oauth_minimax"` (see `hermes_cli/auth.py:306`), which is **not** in that set.

Result: the catch-all falls through to `return None, None`. `call_llm` then drops to the `auto` chain, which finds `deepseek` or `openrouter` in the credential pool and silently uses them. The user sees the wrong model name in `hermes insights` and pays for tokens on a subscription they did not authorize for that route.

## Impact (before the fix)

Reproduction in `agent.log` on a fresh session:

```
WARNING agent.auxiliary_client: resolve_provider_client: unhandled auth_type oauth_minimax for minimax-oauth
INFO    agent.auxiliary_client: Auxiliary title_generation: using deepseek (deepseek-v4-pro) at https://api.deepseek.com/v1/
```

`hermes insights --days 7` on the reporter's local install (last 7 days, 96 sessions, 5,156 messages):

| Model            | Sessions | Tokens       | Share |
|------------------|----------|--------------|-------|
| deepseek-v4-pro  | 31       | 299,719,486  | **82 %** |
| MiniMax-M3       | 60       |  43,479,896  |  12 %  |
| minimax-m3       |  1       |  21,220,278  |   6 %  |

The user was paying for a MiniMax-M3 subscription and still got 82 % of their auxiliary-task tokens billed to DeepSeek.

## Root cause

`agent/auxiliary_client.py` `resolve_provider_client` line 4084:

```python
elif pconfig.auth_type in {"oauth_device_code", "oauth_external"}:
    # OAuth providers — route through their specific try functions
    if provider == "nous":
        return resolve_provider_client("nous", model, async_mode)
    if provider == "openai-codex":
        return resolve_provider_client("openai-codex", model, async_mode)
    if provider == "xai-oauth":
        return resolve_provider_client("xai-oauth", model, async_mode)
    # Other OAuth providers not directly supported
    logger.warning("resolve_provider_client: OAuth provider %s not "
                   "directly supported, try 'auto'", provider)
    return None, None
```

`minimax-oauth` is missing from the `if` chain AND its `auth_type` is not in the dispatch set, so it falls to the warning + `None` branch.

The main agent path (`agent/agent_init.py`) already handles `minimax-oauth` correctly — it installs a per-request token provider via `build_minimax_oauth_token_provider()` and uses `build_anthropic_client`, because MiniMax exposes an Anthropic-Messages-compatible endpoint. The auxiliary path just never got the same treatment.

## Fix

Three changes, all in `agent/auxiliary_client.py`:

### 1. New helper `_build_minimax_oauth_aux_client`

Mirrors `_build_xai_oauth_aux_client` and the pattern in `_try_anthropic`. Uses `resolve_minimax_oauth_runtime_credentials(as_token_provider=True)` to get a callable that mints a fresh bearer per request (MiniMax access tokens are short-lived, ~15 min), then wraps a native Anthropic client in `AnthropicAuxiliaryClient`.

### 2. New `minimax-oauth` branch in `resolve_provider_client`

Right after the `xai-oauth` block, with a warning message that mirrors the existing xai-oauth one.

### 3. Extend the dispatch set

```python
elif pconfig.auth_type in {"oauth_device_code", "oauth_external", "oauth_minimax"}:
    ...
    if provider == "minimax-oauth":
        return resolve_provider_client("minimax-oauth", model, async_mode)
```

## Verification

Local test on the reporter's installation, after applying the patch:

```text
$ python -c "
import sys, os
os.environ['HERMES_HOME'] = os.path.expanduser('~/.hermes')
sys.path.insert(0, os.path.expanduser('~/.hermes/hermes-agent'))
from agent.auxiliary_client import call_llm
r = call_llm(task='title_generation',
             messages=[{'role':'user','content':'قل OK فقط'}],
             max_tokens=10, timeout=30)
print(r.choices[0].message.content)
"
INFO agent.auxiliary_client: Auxiliary title_generation: using minimax-oauth (MiniMax-M3) at https://api.minimax.io/anthropic
INFO httpx: HTTP Request: POST https://api.minimax.io/anthropic/v1/messages "HTTP/1.1 200 OK"
OK
```

Sync and async clients both build successfully; `resolve_provider_client('auto', 'MiniMax-M3')` (the Step-1 main-provider fast-path used by `_resolve_auto`) now resolves to `AnthropicAuxiliaryClient` at the MiniMax inference URL instead of falling through to the api-key chain.

## Risk assessment

- **Touches a single file, 114 + / 2 −.** Pattern is identical to the existing `xai-oauth` branch, so reviewers can diff them side-by-side.
- **No new dependencies.** Uses the existing `anthropic` SDK, `AnthropicAuxiliaryClient`, and `build_minimax_oauth_token_provider` from `hermes_cli.auth`.
- **No behavior change for non-MiniMax users.** The new branch is gated on `provider == "minimax-oauth"`; the dispatch set change is additive.
- **Fails loud, not silent.** If the OAuth token is missing or invalid, the helper logs a clear warning ("run: hermes model and select MiniMax (OAuth · minimax.io)") and returns `(None, None)` — same shape as the existing xai-oauth arm.

## Out of scope (intentionally)

- Adding a similar branch for any other future third-party OAuth providers. Same pattern would apply — the reviewer can extend the dispatch set the same way.
- Cleaning up legacy `deepseek` / `openrouter` credentials from `auth.json`. That's a per-user hygiene step; the reporter already removed theirs locally with `hermes auth remove`.

## Reporter

Dr. Basim — MiniMax-M3 subscriber, noticed the leak in `hermes insights` and tracked it to `agent.log`.
