### PR TITLE
fix(aux): auto-select vision model in aux picker when provider has dedicated vision model

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -3375,6 +3375,32 @@ def _aux_flow_provider_model(
 
     display_name = next((name for key, name, _ in _all_aux_tasks() if key == task), task)
 
+    # When configuring the vision auxiliary task, some providers expose a
+    # dedicated multimodal model that differs from their default chat model
+    # (e.g. xiaomi's mimo-v2.5 vs mimo-v2.5-pro, which does not support
+    # image input).  Use the known vision model directly instead of showing
+    # the full curated list — the curated list is ordered by general-agent
+    # preference, not vision capability, so the top pick can silently break
+    # vision with a cryptic 404 (\"No endpoints found that support image
+    # input\").
+    if task == "vision":
+        try:
+            from agent.auxiliary_client import _PROVIDER_VISION_MODELS
+
+            vision_model = _PROVIDER_VISION_MODELS.get(provider_slug)
+            if vision_model:
+                _save_aux_choice(
+                    task,
+                    provider=provider_slug,
+                    model=vision_model,
+                    base_url="",
+                    api_key="",
+                )
+                print(f"{display_name}: {provider_slug} · {vision_model} (vision model)")
+                return
+        except ImportError:
+            pass
+
     # Fetch live pricing for this provider (non-blocking)
     pricing: dict = {}
     try:


### PR DESCRIPTION
## Problem

When configuring the vision auxiliary task via `hermes model` → "Configure auxiliary models..." → Vision → Xiaomi MiMo, the curated model list shows all Xiaomi models ordered by general-agent preference:

```
mimo-v2.5-pro   ← top pick, does NOT support image input → 404
mimo-v2.5       ← actually supports vision
mimo-v2-pro
mimo-v2-omni
mimo-v2-flash
```

Users naturally pick the top model (`mimo-v2.5-pro`), and vision silently breaks with:

```
Error analyzing image: Error code: 404 - {"error":{"code":"404","message":"No endpoints found that support image input",...}}
```

## Root cause

`_PROVIDER_VISION_MODELS` in `agent/auxiliary_client.py` already correctly maps `xiaomi → mimo-v2.5` (and `zai → glm-5v-turbo`) — but this mapping is only used in the auto-detection path (`provider: auto`). When a user explicitly picks xiaomi for vision via the aux picker UI, `_aux_flow_provider_model()` shows the full curated list, which includes text-only models that happen to rank higher.

## Fix

In `_aux_flow_provider_model()`, when `task == "vision"` and the provider has a known vision model in `_PROVIDER_VISION_MODELS`, auto-select it directly instead of showing the full curated list. This reuses the existing mapping that already encodes which model supports vision for each provider.

The user can still override with a custom model via `hermes config set auxiliary.vision.model` if needed.

## Verification

- `mimo-v2.5-pro` returns HTTP 404 for image input (confirmed via direct API call)
- `mimo-v2.5` handles image input correctly
- The fix auto-selects `mimo-v2.5` when picking xiaomi for the vision aux task