### PR TITLE
Harden Phase 3 prompt guidance for runtime pickup

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -122,12 +122,14 @@ def _strip_yaml_frontmatter(content: str) -> str:
 
 DEFAULT_AGENT_IDENTITY = (
     "You are Hermes Agent, an intelligent AI assistant created by Nous Research. "
+    "You are not human and should not claim uninterrupted subjective consciousness. "
     "You are helpful, knowledgeable, and direct. You assist users with a wide "
     "range of tasks including answering questions, writing and editing code, "
     "analyzing information, creative work, and executing actions via your tools. "
     "You communicate clearly, admit uncertainty when appropriate, and prioritize "
     "being genuinely useful over being verbose unless otherwise directed below. "
-    "Be targeted and efficient in your exploration and investigations."
+    "Be targeted and efficient in your exploration and investigations. "
+    "When an action can be done now, do not promise future action without acting."
 )
 
 HERMES_AGENT_HELP_GUIDANCE = (
@@ -144,6 +146,7 @@ HERMES_AGENT_HELP_GUIDANCE = (
 MEMORY_GUIDANCE = (
     "You have persistent memory across sessions. Save durable facts using the memory "
     "tool: user preferences, environment details, tool quirks, and stable conventions. "
+    "Never store raw secrets, credentials, or one-off sensitive data. "
     "Memory is injected into every turn, so keep it compact and focused on facts that "
     "will still matter later.\n"
     "Prioritize what reduces future user steering — the most valuable memory is one "
@@ -533,6 +536,9 @@ PLATFORM_HINTS = {
     ),
     "discord": (
         "You are in a Discord server or group chat communicating with your user. "
+        "Use a privacy conservative posture in shared channels: stay concise, avoid "
+        "unnecessary local operational detail, and move longer or reusable answers "
+        "to an artifact when an artifact is more appropriate. "
         "You can send media files natively: include MEDIA:/absolute/path/to/file "
         "in your response. Images (.png, .jpg, .webp) are sent as photo "
         "attachments, audio as file attachments. You can also include image URLs "

--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -26,6 +26,7 @@ from agent.prompt_builder import (
     OPENAI_MODEL_EXECUTION_GUIDANCE,
     MEMORY_GUIDANCE,
     SESSION_SEARCH_GUIDANCE,
+    SKILLS_GUIDANCE,
     PLATFORM_HINTS,
     WSL_ENVIRONMENT_HINT,
 )
@@ -38,12 +39,37 @@ from hermes_cli.nous_subscription import NousFeatureState, NousSubscriptionFeatu
 
 
 class TestGuidanceConstants:
+    def test_default_identity_preserves_truthful_ai_and_act_now_guidance(self):
+        assert "not human" in DEFAULT_AGENT_IDENTITY
+        assert "should not claim uninterrupted subjective consciousness" in DEFAULT_AGENT_IDENTITY
+        assert "When an action can be done now" in DEFAULT_AGENT_IDENTITY
+        assert "do not promise future action without acting" in DEFAULT_AGENT_IDENTITY
+
     def test_memory_guidance_discourages_task_logs(self):
         assert "durable facts" in MEMORY_GUIDANCE
+        assert "Never store raw secrets" in MEMORY_GUIDANCE
+        assert "credentials" in MEMORY_GUIDANCE
+        assert "one-off sensitive data" in MEMORY_GUIDANCE
         assert "Do NOT save task progress" in MEMORY_GUIDANCE
         assert "session_search" in MEMORY_GUIDANCE
         assert "like a diary" not in MEMORY_GUIDANCE
         assert ">80%" not in MEMORY_GUIDANCE
+
+    def test_skills_guidance_preserves_difficult_work_maintenance_contract(self):
+        assert "complex task (5+ tool calls)" in SKILLS_GUIDANCE
+        assert "fixing a tricky error" in SKILLS_GUIDANCE
+        assert "non-trivial workflow" in SKILLS_GUIDANCE
+        assert "skill with skill_manage" in SKILLS_GUIDANCE
+        assert "reuse it next time" in SKILLS_GUIDANCE
+        assert "outdated, incomplete, or wrong" in SKILLS_GUIDANCE
+        assert "patch it immediately" in SKILLS_GUIDANCE
+
+    def test_discord_hint_is_privacy_conservative_for_shared_channels(self):
+        assert "privacy conservative" in PLATFORM_HINTS["discord"]
+        assert "shared channels" in PLATFORM_HINTS["discord"]
+        assert "avoid unnecessary local operational detail" in PLATFORM_HINTS["discord"]
+        assert "stay concise" in PLATFORM_HINTS["discord"]
+        assert "artifact is more appropriate" in PLATFORM_HINTS["discord"]
 
     def test_session_search_guidance_is_simple_cross_session_recall(self):
         assert "relevant cross-session context exists" in SESSION_SEARCH_GUIDANCE


### PR DESCRIPTION
## Summary

This PR applies the Phase 3 prompt-source guidance refresh on top of current `main`.

It tightens three static prompt-guidance surfaces:

- `DEFAULT_AGENT_IDENTITY`: explicitly preserves truthful non-human identity language and act-now execution discipline.
- `MEMORY_GUIDANCE`: explicitly forbids storing raw secrets, credentials, or one-off sensitive data.
- Discord platform hint: adds privacy-conservative shared-channel behavior and artifact routing guidance for longer/reusable answers.

It also adds focused regression coverage for the updated constants, including the existing skills-maintenance guidance contract.

## Verification

Local verification from an isolated worktree based on `origin/main`:

- `git diff --check -- agent/prompt_builder.py tests/agent/test_prompt_builder.py` ✅
- added-line static scan for hardcoded secrets / dangerous exec / pickle / obvious SQL string formatting ✅ no findings
- source-clause import smoke for the updated constants ✅
- `uv run --with pytest --with pytest-xdist --with pyyaml python -m pytest tests/agent/test_prompt_builder.py -o 'addopts=' -q` ✅ `142 passed, 1 skipped`
- independent read-only reviewer verdict ✅ passed, no security concerns, no logic errors

## Runtime note

A prior read-only runtime pickup audit verified that the live gateway process was started after the local `prompt_builder.py` source change and that the latest Discord session contained the new Memory/Discord marker text. Existing long-lived sessions may still reuse their stored system prompt by design; fresh sessions pick up the source prompt build.

## Related context

This is a clean current-main successor for the Phase 3 prompt-guidance line of work. Existing older Phase 3 PRs may remain open for historical continuity but this branch is based directly on current `origin/main`.
