### PR TITLE
fix(copilot): don't seed a Copilot pool credential from a classic ghp_ GITHUB_TOKEN (#47708)

### DIFF
--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -2264,6 +2264,26 @@ def _seed_from_env(provider: str, entries: List[PooledCredential]) -> Tuple[bool
         token = _get_env_prefer_dotenv(env_var)
         if not token:
             continue
+        # A `GITHUB_TOKEN` is commonly present for unrelated reasons (gh CLI,
+        # GitHub MCP). If it's a classic `ghp_*` PAT it is rejected by the
+        # Copilot API on every request, so auto-enrolling it as a copilot
+        # credential creates a permanently-broken pool entry that burns a
+        # failover hop and 400s every turn (#47708). The dynamic resolver in
+        # _seed_from_singletons already skips classic PATs via
+        # resolve_copilot_token(); apply the same gate here so the env path
+        # never seeds an unusable token into the pool.
+        if provider == "copilot":
+            try:
+                from hermes_cli.copilot_auth import validate_copilot_token
+                _ok, _msg = validate_copilot_token(token)
+            except Exception:
+                _ok = True  # never block seeding on an import/validation error
+            if not _ok:
+                logger.warning(
+                    "Skipping Copilot credential auto-derived from %s: %s",
+                    env_var, _msg.splitlines()[0] if _msg else "unsupported token",
+                )
+                continue
         source = f"env:{env_var}"
         if _is_source_suppressed(provider, source):
             continue

--- a/tests/tools/test_credential_pool_env_fallback.py
+++ b/tests/tools/test_credential_pool_env_fallback.py
@@ -296,3 +296,50 @@ class TestAnthropicEnvAuthTypeClassification:
         _write_env_file(isolated_hermes_home, ANTHROPIC_API_KEY="sk-ant-api-fake-12345")
         entry = self._seed("ANTHROPIC_API_KEY", "sk-ant-api-fake-12345")
         assert entry.auth_type == AUTH_TYPE_API_KEY
+
+
+class TestCopilotGithubTokenSeedGuard:
+    """Issue #47708: a classic ``ghp_*`` GITHUB_TOKEN must not auto-enroll a
+    permanently-broken Copilot credential.
+
+    A ``GITHUB_TOKEN`` is commonly present for unrelated reasons (gh CLI,
+    GitHub MCP). Classic ``ghp_*`` PATs are rejected by the Copilot API on
+    every request, so ``_seed_from_env`` must not create a ``copilot`` pool
+    entry pointed at ``api.githubcopilot.com`` from one — otherwise failover
+    burns a hop and 400s every turn. Fine-grained (``github_pat_*``) and
+    device-flow (``gho_*``) tokens are still enrolled.
+    """
+
+    @pytest.fixture
+    def clean_github_env(self, isolated_hermes_home, monkeypatch):
+        for key in ("GITHUB_TOKEN", "GH_TOKEN", "COPILOT_GITHUB_TOKEN"):
+            monkeypatch.delenv(key, raising=False)
+        return isolated_hermes_home
+
+    def test_classic_ghp_token_is_not_seeded(self, clean_github_env, monkeypatch):
+        monkeypatch.setenv("GITHUB_TOKEN", "ghp_FAKEclassicPAT1234567890abcdef")
+        from agent.credential_pool import _seed_from_env
+        entries = []
+        changed, active_sources = _seed_from_env("copilot", entries)
+        assert changed is False
+        assert active_sources == set()
+        assert entries == []
+
+    def test_fine_grained_pat_is_seeded(self, clean_github_env, monkeypatch):
+        monkeypatch.setenv("GITHUB_TOKEN", "github_pat_FAKEfinegrained1234567890")
+        from agent.credential_pool import _seed_from_env
+        entries = []
+        changed, active_sources = _seed_from_env("copilot", entries)
+        assert changed is True
+        assert "env:GITHUB_TOKEN" in active_sources
+        assert len(entries) == 1
+        assert entries[0].base_url == "https://api.githubcopilot.com"
+
+    def test_oauth_gho_token_is_seeded(self, clean_github_env, monkeypatch):
+        monkeypatch.setenv("GITHUB_TOKEN", "gho_FAKEoauth1234567890")
+        from agent.credential_pool import _seed_from_env
+        entries = []
+        changed, active_sources = _seed_from_env("copilot", entries)
+        assert changed is True
+        assert "env:GITHUB_TOKEN" in active_sources
+        assert len(entries) == 1


### PR DESCRIPTION
## Summary

- A classic `ghp_*` `GITHUB_TOKEN` no longer auto-enrolls a permanently-broken `copilot` credential in the gateway pool.
- Fine-grained (`github_pat_*`) and device-flow (`gho_*`) tokens are still enrolled, so legitimate Copilot use is unaffected.

## Motivation

Closes #47708.

`_seed_from_env()` in `agent/credential_pool.py` iterates the `copilot` provider's `api_key_env_vars` (`COPILOT_GITHUB_TOKEN`, `GH_TOKEN`, `GITHUB_TOKEN`) and enrolls a credential pointed at `https://api.githubcopilot.com` **without validating the token type**. A `GITHUB_TOKEN` is commonly present for unrelated reasons (gh CLI, GitHub MCP, Bitwarden Secrets Manager). Classic `ghp_*` PATs are rejected by the Copilot API on every request (`Personal Access Tokens are not supported for this endpoint`), so the auto-derived entry is a permanently-broken fallback that gets tried (and 400s) on every failover — adding log noise and latency, and confusing users who reasonably ask "why is Copilot my fallback?" when they never set it up.

The dynamic resolver in `_seed_from_singletons()` already skips classic PATs via `resolve_copilot_token()`. The env-seed path did not.

## Fix

In `_seed_from_env()`, when `provider == "copilot"`, validate the token with the existing `hermes_cli.copilot_auth.validate_copilot_token()` and **skip-with-warning** on a classic `ghp_*` PAT before it ever enters the pool. The token-type is already detectable, so this gates the credential before creation rather than failing on every turn. Validation/import errors are fail-open (never block seeding).

This is the issue's first suggested fix ("Don't auto-derive a Copilot credential from classic `ghp_*` tokens"). Scope is `credential_pool.py` only and is distinct from the open `copilot_auth.py` prefix-validation PR (#13538) and the `web_server.py` PAT-validation PR (#40098) — neither touches the pool-seeding path.

## Verification

- `python3 -m pytest tests/tools/test_credential_pool_env_fallback.py` — 11 passed (incl. 3 new)
- `python3 -m pytest tests/agent/test_credential_pool.py tests/tools/test_credential_pool_env_fallback.py tests/hermes_cli/test_copilot_auth.py` — 114 passed
- `ruff check agent/credential_pool.py` — clean
- New regression tests assert `ghp_*` is skipped while `github_pat_*` / `gho_*` are seeded; they **fail without the fix** (the old path enrolled the `ghp_*` token).

## Real behavior proof

- **Behavior addressed:** a classic `ghp_*` `GITHUB_TOKEN` in the environment produced a `copilot` pool entry at `api.githubcopilot.com` that 400s on every failover.
- **Real environment:** Python 3.14, repo checkout on `fix/47708-copilot-ghp-pool-seed`; `COPILOT_GITHUB_TOKEN`/`GH_TOKEN` unset.
- **Captured output (real run on this branch):**

```
=== classic ghp_ token (should be SKIPPED) ===
Skipping Copilot credential auto-derived from GITHUB_TOKEN: Classic Personal
Access Tokens (ghp_*) are not supported by the Copilot API. ...
changed: False  sources: set()  entries: 0

=== fine-grained github_pat_ token (should be KEPT) ===
changed: True  sources: {'env:GITHUB_TOKEN'}  entries: 1
  ENTRY: env:GITHUB_TOKEN https://api.githubcopilot.com github_pat_

=== gho_ oauth token (should be KEPT) ===
changed: True  sources: {'env:GITHUB_TOKEN'}  entries: 1

=== non-copilot provider unaffected (deepseek) ===
changed: True  sources: {'env:DEEPSEEK_API_KEY'}  entries: 1
```

- **Regression test:** `tests/tools/test_credential_pool_env_fallback.py::TestCopilotGithubTokenSeedGuard` (`test_classic_ghp_token_is_not_seeded`, `test_fine_grained_pat_is_seeded`, `test_oauth_gho_token_is_seeded`).
- **What was NOT tested:** the issue's alternative suggestions (mark-unhealthy-on-first-401, opt-in flag) are not implemented — this PR takes the gate-before-enroll approach only.
