### PR TITLE
fix(utils): honor env_bool default when the variable is unset

### DIFF
--- a/tests/test_utils_env_helpers.py
+++ b/tests/test_utils_env_helpers.py
@@ -1,0 +1,47 @@
+"""Tests for the env_int / env_bool environment-variable helpers."""
+
+from utils import env_bool, env_int
+
+
+def test_env_int_parses_valid_integer(monkeypatch):
+    monkeypatch.setenv("HERMES_TEST_INT", "42")
+    assert env_int("HERMES_TEST_INT") == 42
+
+
+def test_env_int_strips_whitespace(monkeypatch):
+    monkeypatch.setenv("HERMES_TEST_INT", "  123  ")
+    assert env_int("HERMES_TEST_INT") == 123
+
+
+def test_env_int_falls_back_on_invalid(monkeypatch):
+    monkeypatch.setenv("HERMES_TEST_INT", "not_a_number")
+    assert env_int("HERMES_TEST_INT", 7) == 7
+
+
+def test_env_int_falls_back_when_unset(monkeypatch):
+    monkeypatch.delenv("HERMES_TEST_INT", raising=False)
+    assert env_int("HERMES_TEST_INT", 5) == 5
+
+
+def test_env_bool_reads_truthy_strings(monkeypatch):
+    monkeypatch.setenv("HERMES_TEST_BOOL", "YeS")
+    assert env_bool("HERMES_TEST_BOOL") is True
+
+    monkeypatch.setenv("HERMES_TEST_BOOL", "off")
+    assert env_bool("HERMES_TEST_BOOL") is False
+
+
+def test_env_bool_honors_default_when_unset(monkeypatch):
+    monkeypatch.delenv("HERMES_TEST_BOOL", raising=False)
+    assert env_bool("HERMES_TEST_BOOL", default=True) is True
+    assert env_bool("HERMES_TEST_BOOL", default=False) is False
+
+
+def test_env_bool_honors_default_when_empty(monkeypatch):
+    monkeypatch.setenv("HERMES_TEST_BOOL", "   ")
+    assert env_bool("HERMES_TEST_BOOL", default=True) is True
+
+
+def test_env_bool_set_value_overrides_default(monkeypatch):
+    monkeypatch.setenv("HERMES_TEST_BOOL", "false")
+    assert env_bool("HERMES_TEST_BOOL", default=True) is False

--- a/utils.py
+++ b/utils.py
@@ -324,8 +324,11 @@ def env_int(key: str, default: int = 0) -> int:
 
 
 def env_bool(key: str, default: bool = False) -> bool:
-    """Read an environment variable as a boolean."""
-    return is_truthy_value(os.getenv(key, ""), default=default)
+    """Read an environment variable as a boolean, with fallback."""
+    raw = os.getenv(key, "").strip()
+    if not raw:
+        return default
+    return is_truthy_value(raw, default=default)
 
 
 # ─── Proxy Helpers ────────────────────────────────────────────────────────────


### PR DESCRIPTION
`env_bool(key, default=...)` was ignoring its `default` whenever the environment variable was missing or blank.

The cause: it passed `os.getenv(key, "")` to `is_truthy_value`, which only falls back to the default for `None`. An empty string — what an unset or blank var produces — is just treated as falsey, so `env_bool("SOMETHING", default=True)` returned `False` when `SOMETHING` wasn't set.

The fix mirrors the sibling `env_int` helper right above it: if the raw value is empty after stripping, return the default; otherwise parse it. I also added tests for `env_int` and `env_bool`, including the unset/blank cases that were broken (they fail before this change and pass after).

**How to test:** `scripts/run_tests.sh tests/test_utils_env_helpers.py`

Tested on macOS.