### PR TITLE
fix(gateway): stop self-restart and resume replay loops

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -8380,7 +8380,36 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 exc,
             )
             return session_entry, None
-        if not history or len(history) < 4:
+        if not history:
+            logger.info(
+                "Resume-pending recovery: clearing stale marker for %s; "
+                "no active transcript rows remain for %s",
+                session_key,
+                session_entry.session_id,
+            )
+            try:
+                self.session_store.clear_resume_pending(session_key)
+            except Exception as exc:
+                logger.debug(
+                    "Resume-pending recovery: failed to clear stale marker for %s: %s",
+                    session_key,
+                    exc,
+                )
+            try:
+                self.session_store.update_session(session_key, last_prompt_tokens=0)
+            except Exception as exc:
+                logger.debug(
+                    "Resume-pending recovery: failed to reset prompt token count for %s: %s",
+                    session_key,
+                    exc,
+                )
+            session_entry.resume_pending = False
+            session_entry.resume_reason = None
+            session_entry.last_resume_marked_at = None
+            session_entry.last_prompt_tokens = 0
+            return session_entry, None
+
+        if len(history) < 4:
             return session_entry, None
 
         user_config: dict = {}

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1437,6 +1437,7 @@ from gateway.config import (
     load_gateway_config,
 )
 from gateway.session import (
+    SessionEntry,
     SessionStore,
     SessionSource,
     SessionContext,
@@ -2123,6 +2124,78 @@ def _should_clear_resume_pending_after_turn(agent_result: dict) -> bool:
     if agent_result.get("completed") is False:
         return False
     return True
+
+
+def _resume_pending_recovery_threshold_pct(user_config: Optional[dict]) -> float:
+    """Return the max context ratio safe for restart-recovery replay.
+
+    Normal gateway hygiene uses a high 85% threshold to avoid surprising
+    compression during ordinary long chats.  A ``resume_pending`` session is
+    different: a previous turn already failed or was interrupted, and replaying
+    a huge transcript can wedge the channel in the same failed turn forever.
+    Use the configured agent compression threshold, capped at 50%, so recovery
+    never feeds a transcript the agent itself would immediately compact.
+    """
+    threshold = 0.5
+    if isinstance(user_config, dict):
+        comp_cfg = user_config.get("compression", {})
+        if isinstance(comp_cfg, dict):
+            raw_threshold = comp_cfg.get("threshold", threshold)
+            try:
+                parsed = float(raw_threshold)
+            except (TypeError, ValueError):
+                parsed = threshold
+            if 0 < parsed < 1:
+                threshold = parsed
+    return min(threshold, 0.5)
+
+
+def _resume_pending_recovery_hard_message_limit(user_config: Optional[dict]) -> int:
+    """Return the message-count safety valve used for restart recovery."""
+    limit = 400
+    if isinstance(user_config, dict):
+        comp_cfg = user_config.get("compression", {})
+        if isinstance(comp_cfg, dict):
+            raw_limit = comp_cfg.get("hygiene_hard_message_limit")
+            if raw_limit is not None:
+                try:
+                    parsed = int(raw_limit)
+                except (TypeError, ValueError):
+                    parsed = limit
+                if parsed > 0:
+                    limit = parsed
+    return limit
+
+
+def _resume_pending_history_needs_clean_reset(
+    session_entry: Any,
+    history: list,
+    *,
+    context_length: int,
+    threshold_pct: float,
+    hard_message_limit: int,
+    estimated_tokens: int,
+) -> tuple[bool, int, str, int]:
+    """Decide whether a restart-recovery transcript is too large to replay."""
+    if not getattr(session_entry, "resume_pending", False):
+        return False, 0, "none", 0
+    if not history or len(history) < 4:
+        return False, 0, "none", 0
+
+    token_threshold = int(max(1, context_length) * threshold_pct)
+    stored_tokens = int(getattr(session_entry, "last_prompt_tokens", 0) or 0)
+    if stored_tokens > 0:
+        approx_tokens = stored_tokens
+        token_source = "actual"
+    else:
+        approx_tokens = int(estimated_tokens or 0)
+        token_source = "estimated"
+
+    needs_reset = (
+        approx_tokens >= token_threshold
+        or len(history) >= hard_message_limit
+    )
+    return needs_reset, approx_tokens, token_source, token_threshold
 
 
 def _preserve_queued_followup_history_offset(
@@ -8287,6 +8360,147 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 pass
         return source
 
+    def _reset_oversized_resume_pending_session(
+        self,
+        *,
+        source: SessionSource,
+        session_key: str,
+        session_entry: SessionEntry,
+    ) -> tuple[SessionEntry, Optional[str]]:
+        """Rotate poisoned restart-recovery sessions before agent startup."""
+        if not session_key or not getattr(session_entry, "resume_pending", False):
+            return session_entry, None
+
+        try:
+            history = self.session_store.load_transcript(session_entry.session_id)
+        except Exception as exc:
+            logger.debug(
+                "Resume-pending recovery: failed to load transcript for %s: %s",
+                session_entry.session_id,
+                exc,
+            )
+            return session_entry, None
+        if not history or len(history) < 4:
+            return session_entry, None
+
+        user_config: dict = {}
+        model = "anthropic/claude-sonnet-4.6"
+        provider = None
+        base_url = None
+        api_key = None
+        config_context_length = None
+        try:
+            loaded = _load_gateway_config()
+            if isinstance(loaded, dict):
+                user_config = loaded
+            model_cfg = user_config.get("model", {})
+            if isinstance(model_cfg, str):
+                model = model_cfg
+            elif isinstance(model_cfg, dict):
+                model = model_cfg.get("default") or model_cfg.get("model") or model
+                provider = model_cfg.get("provider") or None
+                base_url = model_cfg.get("base_url") or None
+                raw_context_length = model_cfg.get("context_length")
+                if raw_context_length is not None:
+                    try:
+                        config_context_length = int(raw_context_length)
+                    except (TypeError, ValueError):
+                        config_context_length = None
+        except Exception:
+            user_config = {}
+
+        try:
+            model, runtime = self._resolve_session_agent_runtime(
+                source=source,
+                session_key=session_key,
+                user_config=user_config,
+            )
+            provider = runtime.get("provider") or provider
+            base_url = runtime.get("base_url") or base_url
+            api_key = runtime.get("api_key") or api_key
+        except Exception:
+            pass
+
+        try:
+            from agent.model_metadata import (
+                estimate_messages_tokens_rough,
+                get_model_context_length,
+            )
+
+            context_length = get_model_context_length(
+                model,
+                base_url=base_url or "",
+                api_key=api_key or "",
+                config_context_length=config_context_length,
+                provider=provider or "",
+            )
+            estimated_tokens = estimate_messages_tokens_rough(history)
+        except Exception as exc:
+            logger.debug(
+                "Resume-pending recovery: token estimate failed for %s: %s",
+                session_entry.session_id,
+                exc,
+            )
+            return session_entry, None
+
+        threshold_pct = _resume_pending_recovery_threshold_pct(user_config)
+        hard_message_limit = _resume_pending_recovery_hard_message_limit(user_config)
+        needs_reset, approx_tokens, token_source, token_threshold = (
+            _resume_pending_history_needs_clean_reset(
+                session_entry,
+                history,
+                context_length=context_length,
+                threshold_pct=threshold_pct,
+                hard_message_limit=hard_message_limit,
+                estimated_tokens=estimated_tokens,
+            )
+        )
+        if not needs_reset:
+            return session_entry, None
+
+        logger.warning(
+            "Resume-pending recovery: auto-resetting oversized session %s "
+            "before agent run (%s messages, ~%s tokens %s; threshold=%s, "
+            "context=%s, recovery_pct=%s%%)",
+            session_entry.session_id,
+            len(history),
+            f"{approx_tokens:,}",
+            token_source,
+            f"{token_threshold:,}",
+            f"{context_length:,}",
+            int(threshold_pct * 100),
+        )
+
+        new_entry = self.session_store.reset_session(session_key)
+        if new_entry is None:
+            return session_entry, None
+
+        self._evict_cached_agent(session_key)
+        session_overrides = getattr(self, "_session_model_overrides", None)
+        if isinstance(session_overrides, dict):
+            session_overrides.pop(session_key, None)
+        try:
+            self._set_session_reasoning_override(session_key, None)
+        except Exception:
+            pass
+        pending_model_notes = getattr(self, "_pending_model_notes", None)
+        if isinstance(pending_model_notes, dict):
+            pending_model_notes.pop(session_key, None)
+        self._clear_session_boundary_security_state(session_key)
+        self._sync_telegram_topic_binding(
+            source,
+            new_entry,
+            reason="resume-pending-oversized-reset",
+        )
+
+        context_note = (
+            "[System note: The previous restart-recovery session was too large "
+            "to safely resume and was automatically reset before this turn. "
+            "This is a fresh conversation with no prior context; the old "
+            "transcript remains available in session history.]"
+        )
+        return new_entry, context_note
+
     async def _handle_message_with_agent(self, event, source, _quick_key: str, run_generation: int):
         """Inner handler that runs under the _running_agents sentinel guard."""
         _msg_start_time = time.time()
@@ -8375,6 +8589,14 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     self._record_telegram_topic_binding(source, session_entry)
                 except Exception:
                     logger.debug("Failed to record Telegram topic binding", exc_info=True)
+
+        session_entry, _resume_recovery_context_note = (
+            self._reset_oversized_resume_pending_session(
+                source=source,
+                session_key=session_key,
+                session_entry=session_entry,
+            )
+        )
         if getattr(session_entry, "was_auto_reset", False):
             # Treat auto-reset as a full conversation boundary — drop every
             # session-scoped transient state so the fresh session does not
@@ -8421,6 +8643,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
         # Build the context prompt to inject
         context_prompt = build_session_context_prompt(context, redact_pii=_redact_pii)
+        if _resume_recovery_context_note:
+            context_prompt = _resume_recovery_context_note + "\n\n" + context_prompt
         
         # If the previous session expired and was auto-reset, prepend a notice
         # so the agent knows this is a fresh conversation (not an intentional /reset).

--- a/tests/gateway/test_restart_resume_pending.py
+++ b/tests/gateway/test_restart_resume_pending.py
@@ -40,6 +40,8 @@ from gateway.run import (
     _coerce_gateway_timestamp,
     _is_fresh_gateway_interruption,
     _last_transcript_timestamp,
+    _resume_pending_history_needs_clean_reset,
+    _resume_pending_recovery_threshold_pct,
     _should_clear_resume_pending_after_turn,
 )
 from gateway.session import SessionEntry, SessionSource, SessionStore
@@ -69,6 +71,164 @@ def test_resume_pending_is_cleared_only_after_successful_turn():
     assert _should_clear_resume_pending_after_turn({"failed": True}) is False
     assert _should_clear_resume_pending_after_turn({"partial": True}) is False
     assert _should_clear_resume_pending_after_turn({"error": "boom"}) is False
+
+
+def test_resume_pending_recovery_uses_conservative_threshold():
+    """Restart recovery must not use the normal 85% hygiene threshold.
+
+    The incident transcript recorded ~329k prompt tokens on a 400k context
+    model.  That is below the ordinary 85% hygiene gate, but above the agent's
+    50% compression gate; replaying it after an incomplete recovery turn can
+    wedge the channel indefinitely.
+    """
+    assert _resume_pending_recovery_threshold_pct(
+        {"compression": {"threshold": 0.85}}
+    ) == 0.5
+    assert _resume_pending_recovery_threshold_pct(
+        {"compression": {"threshold": 0.35}}
+    ) == 0.35
+
+
+def test_resume_pending_329k_prompt_on_400k_context_needs_clean_reset():
+    now = datetime.now()
+    entry = SessionEntry(
+        session_key="agent:main:discord:group:1490826686294392893:492823160601837596",
+        session_id="20260616_234010_2675ef",
+        created_at=now,
+        updated_at=now,
+        resume_pending=True,
+        resume_reason="shutdown_timeout",
+        last_prompt_tokens=329_227,
+    )
+    history = [
+        {"role": "user", "content": "what happened", "timestamp": time.time()}
+        for _ in range(192)
+    ]
+
+    needs_reset, approx_tokens, token_source, token_threshold = (
+        _resume_pending_history_needs_clean_reset(
+            entry,
+            history,
+            context_length=400_000,
+            threshold_pct=0.5,
+            hard_message_limit=400,
+            estimated_tokens=10,
+        )
+    )
+
+    assert needs_reset is True
+    assert approx_tokens == 329_227
+    assert token_source == "actual"
+    assert token_threshold == 200_000
+
+
+def test_non_resume_pending_large_session_keeps_normal_hygiene_path():
+    now = datetime.now()
+    entry = SessionEntry(
+        session_key="agent:main:discord:group:1:2",
+        session_id="sid",
+        created_at=now,
+        updated_at=now,
+        resume_pending=False,
+        last_prompt_tokens=329_227,
+    )
+    history = [{"role": "user", "content": "x"} for _ in range(192)]
+
+    needs_reset, *_ = _resume_pending_history_needs_clean_reset(
+        entry,
+        history,
+        context_length=400_000,
+        threshold_pct=0.5,
+        hard_message_limit=400,
+        estimated_tokens=10,
+    )
+
+    assert needs_reset is False
+
+
+def test_oversized_resume_pending_session_rotates_before_agent_start(monkeypatch):
+    from gateway.run import GatewayRunner
+
+    now = datetime.now()
+    session_key = (
+        "agent:main:discord:group:1490826686294392893:492823160601837596"
+    )
+    old_entry = SessionEntry(
+        session_key=session_key,
+        session_id="20260616_234010_2675ef",
+        created_at=now,
+        updated_at=now,
+        platform=Platform.DISCORD,
+        chat_type="group",
+        resume_pending=True,
+        resume_reason="shutdown_timeout",
+        last_prompt_tokens=329_227,
+    )
+    new_entry = SessionEntry(
+        session_key=session_key,
+        session_id="20260617_020000_clean",
+        created_at=now,
+        updated_at=now,
+        platform=Platform.DISCORD,
+        chat_type="group",
+        is_fresh_reset=True,
+    )
+
+    runner = object.__new__(GatewayRunner)
+    runner.session_store = MagicMock()
+    runner.session_store.load_transcript.return_value = [
+        {"role": "user", "content": "what happened", "timestamp": time.time()}
+        for _ in range(192)
+    ]
+    runner.session_store.reset_session.return_value = new_entry
+    runner._session_model_overrides = {session_key: {"model": "old"}}
+    runner._pending_model_notes = {session_key: "stale note"}
+    runner._agent_cache = {}
+    runner._agent_cache_lock = None
+    runner._set_session_reasoning_override = MagicMock()
+    runner._clear_session_boundary_security_state = MagicMock()
+    runner._sync_telegram_topic_binding = MagicMock()
+    runner._resolve_session_agent_runtime = MagicMock(
+        return_value=("gpt-5.5", {"provider": "openai-codex"})
+    )
+
+    monkeypatch.setattr(
+        "gateway.run._load_gateway_config",
+        lambda: {
+            "model": {
+                "default": "gpt-5.5",
+                "provider": "openai-codex",
+                "context_length": 400_000,
+            },
+            "compression": {
+                "threshold": 0.5,
+                "hygiene_hard_message_limit": 400,
+            },
+        },
+    )
+    monkeypatch.setattr(
+        "agent.model_metadata.get_model_context_length",
+        lambda *_args, **_kwargs: 400_000,
+    )
+    monkeypatch.setattr(
+        "agent.model_metadata.estimate_messages_tokens_rough",
+        lambda _history: 10,
+    )
+
+    result_entry, context_note = runner._reset_oversized_resume_pending_session(
+        source=_make_source(platform=Platform.DISCORD, chat_id="492823160601837596"),
+        session_key=session_key,
+        session_entry=old_entry,
+    )
+
+    assert result_entry is new_entry
+    assert "automatically reset before this turn" in context_note
+    runner.session_store.reset_session.assert_called_once_with(session_key)
+    runner._set_session_reasoning_override.assert_called_once_with(session_key, None)
+    runner._clear_session_boundary_security_state.assert_called_once_with(session_key)
+    runner._sync_telegram_topic_binding.assert_called_once()
+    assert session_key not in runner._session_model_overrides
+    assert session_key not in runner._pending_model_notes
 
 
 def _make_source(platform=Platform.TELEGRAM, chat_id="123", user_id="u1"):

--- a/tests/gateway/test_restart_resume_pending.py
+++ b/tests/gateway/test_restart_resume_pending.py
@@ -231,6 +231,50 @@ def test_oversized_resume_pending_session_rotates_before_agent_start(monkeypatch
     assert session_key not in runner._pending_model_notes
 
 
+def test_resume_pending_empty_active_history_clears_stale_marker():
+    from gateway.run import GatewayRunner
+
+    now = datetime.now()
+    session_key = (
+        "agent:main:discord:group:1490826686294392893:492823160601837596"
+    )
+    entry = SessionEntry(
+        session_key=session_key,
+        session_id="20260616_234010_2675ef",
+        created_at=now,
+        updated_at=now,
+        platform=Platform.DISCORD,
+        chat_type="group",
+        resume_pending=True,
+        resume_reason="shutdown_timeout",
+        last_prompt_tokens=329_227,
+    )
+
+    runner = object.__new__(GatewayRunner)
+    runner.session_store = MagicMock()
+    runner.session_store.load_transcript.return_value = []
+    runner.session_store.clear_resume_pending.return_value = True
+
+    result_entry, context_note = runner._reset_oversized_resume_pending_session(
+        source=_make_source(platform=Platform.DISCORD, chat_id="492823160601837596"),
+        session_key=session_key,
+        session_entry=entry,
+    )
+
+    assert result_entry is entry
+    assert context_note is None
+    assert entry.resume_pending is False
+    assert entry.resume_reason is None
+    assert entry.last_resume_marked_at is None
+    assert entry.last_prompt_tokens == 0
+    runner.session_store.clear_resume_pending.assert_called_once_with(session_key)
+    runner.session_store.update_session.assert_called_once_with(
+        session_key,
+        last_prompt_tokens=0,
+    )
+    runner.session_store.reset_session.assert_not_called()
+
+
 def _make_source(platform=Platform.TELEGRAM, chat_id="123", user_id="u1"):
     return SessionSource(platform=platform, chat_id=chat_id, user_id=user_id)
 

--- a/tests/tools/test_approval.py
+++ b/tests/tools/test_approval.py
@@ -765,11 +765,12 @@ class TestPatternKeyUniqueness:
         _, key_delete, _ = detect_dangerous_command("find . -name '*.tmp' -delete")
         session = "test_find_collision"
         _clear_session(session)
-        approve_session(session, key_exec)
-        assert is_approved(session, key_exec) is True
-        assert is_approved(session, key_delete) is False, (
-            "approving find -exec rm should not auto-approve find -delete"
-        )
+        with mock_patch.object(approval_module, "_permanent_approved", set()):
+            approve_session(session, key_exec)
+            assert is_approved(session, key_exec) is True
+            assert is_approved(session, key_delete) is False, (
+                "approving find -exec rm should not auto-approve find -delete"
+            )
         _clear_session(session)
 
     def test_legacy_find_key_still_approves_find_exec(self):
@@ -884,6 +885,20 @@ class TestGatewayProtection:
         dangerous, key, desc = detect_dangerous_command(cmd)
         assert dangerous is True
         assert "stop/restart" in desc
+
+    def test_launchctl_kickstart_hermes_gateway_flagged(self):
+        """launchd kickstart can restart the macOS gateway and must be gated."""
+        cmd = "launchctl kickstart -k gui/501/ai.hermes.gateway"
+        dangerous, key, desc = detect_dangerous_command(cmd)
+        assert dangerous is True
+        assert "launchd hermes gateway lifecycle" in desc
+
+    def test_launchctl_unload_hermes_gateway_plist_flagged(self):
+        """launchd unload/remove variants are gateway lifecycle too."""
+        cmd = "launchctl unload ~/Library/LaunchAgents/ai.hermes.gateway.plist"
+        dangerous, key, desc = detect_dangerous_command(cmd)
+        assert dangerous is True
+        assert "launchd hermes gateway lifecycle" in desc
 
     def test_pkill_hermes_detected(self):
         """pkill targeting hermes/gateway processes must be caught."""

--- a/tests/tools/test_command_guards.py
+++ b/tests/tools/test_command_guards.py
@@ -8,6 +8,7 @@ import pytest
 import tools.approval as approval_module
 from tools.approval import (
     approve_session,
+    check_execute_code_guard,
     check_all_command_guards,
     is_approved,
     set_current_session_key,
@@ -72,6 +73,43 @@ class TestContainerSkip:
     def test_daytona_skips_both(self):
         result = check_all_command_guards("rm -rf /", "daytona")
         assert result["approved"] is True
+
+
+# ---------------------------------------------------------------------------
+# Gateway self-restart guard
+# ---------------------------------------------------------------------------
+
+class TestGatewaySelfRestartGuard:
+    def test_launchctl_kickstart_blocked_from_gateway_before_approval_mode(self):
+        os.environ["HERMES_GATEWAY_SESSION"] = "1"
+        with patch.object(approval_module, "_get_approval_mode", return_value="off"):
+            result = check_all_command_guards(
+                "launchctl kickstart -k gui/501/ai.hermes.gateway",
+                "local",
+            )
+
+        assert result["approved"] is False
+        assert result.get("hardline") is True
+        assert "gateway self-restart guard" in result["message"]
+
+    def test_launchctl_kickstart_not_hard_blocked_outside_gateway(self):
+        with patch.object(approval_module, "_get_approval_mode", return_value="off"):
+            result = check_all_command_guards(
+                "launchctl kickstart -k gui/501/ai.hermes.gateway",
+                "local",
+            )
+
+        assert result["approved"] is True
+
+    def test_execute_code_gateway_kickstart_blocked_before_approval_mode(self):
+        os.environ["HERMES_GATEWAY_SESSION"] = "1"
+        code = "import subprocess\nsubprocess.run(['launchctl', 'kickstart', '-k', 'gui/501/ai.hermes.gateway'])"
+        with patch.object(approval_module, "_get_approval_mode", return_value="off"):
+            result = check_execute_code_guard(code, "local")
+
+        assert result["approved"] is False
+        assert result.get("hardline") is True
+        assert "gateway self-restart guard" in result["message"]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/tools/test_terminal_task_cwd.py
+++ b/tests/tools/test_terminal_task_cwd.py
@@ -159,6 +159,44 @@ def test_background_command_prefers_live_env_cwd_over_init_time_cwd(monkeypatch)
     }]
 
 
+def test_gateway_self_restart_blocked_before_background_spawn(monkeypatch):
+    """Gateway sessions must not self-restart through terminal(background=True)."""
+
+    class FakeEnv:
+        env = {}
+        cwd = "/workspace/live"
+
+    class FakeRegistry:
+        pending_watchers = []
+
+        def spawn_local(self, **_kwargs):
+            raise AssertionError("blocked gateway restart must not spawn")
+
+    import tools.process_registry as process_registry_mod
+
+    task_id = "gateway-bg-self-restart"
+    monkeypatch.setenv("HERMES_GATEWAY_SESSION", "1")
+    monkeypatch.delenv("HERMES_CRON_SESSION", raising=False)
+    monkeypatch.setattr(terminal_tool, "_active_environments", {task_id: FakeEnv()})
+    monkeypatch.setattr(terminal_tool, "_last_activity", {})
+    monkeypatch.setattr(terminal_tool, "_task_env_overrides", {})
+    monkeypatch.setattr(terminal_tool, "_get_env_config", lambda: _minimal_terminal_config(cwd="/workspace/live"))
+    monkeypatch.setattr(terminal_tool, "_start_cleanup_thread", lambda: None)
+    monkeypatch.setattr(terminal_tool, "_resolve_container_task_id", lambda value: value or "default")
+    monkeypatch.setattr(process_registry_mod, "process_registry", FakeRegistry())
+
+    result = json.loads(
+        terminal_tool.terminal_tool(
+            command="launchctl kickstart -k gui/501/ai.hermes.gateway",
+            task_id=task_id,
+            background=True,
+        )
+    )
+
+    assert result["status"] == "blocked"
+    assert "gateway self-restart guard" in result["error"]
+
+
 def test_registering_cwd_override_updates_live_env_cwd(monkeypatch):
     """An ACP ``update_cwd`` (re-)registered mid-session must win over a
     previously ``cd``-ed live ``env.cwd``.

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -371,6 +371,40 @@ def _sudo_stdin_block_result(description: str) -> dict:
     }
 
 
+_GATEWAY_SELF_RESTART_RE = re.compile(
+    r'(?:'
+    r'\bhermes\s+gateway\s+(?:stop|restart)\b|'
+    r'\bhermes\s+update\b|'
+    r'\blaunchctl\b[^\n;`]*(?:kickstart|bootout|bootstrap|stop|remove|unload|load)\b'
+    r'[^\n;`]*\bai\.hermes\.gateway(?:\.plist)?\b|'
+    r'\bsystemctl\s+(?:--user\s+)?(?:stop|restart)\s+hermes-gateway(?:\.service)?\b'
+    r')',
+    _RE_FLAGS,
+)
+
+
+def _check_gateway_self_restart_guard(command: str) -> tuple:
+    """Detect Hermes gateway lifecycle commands from inside gateway sessions."""
+    normalized = _normalize_command_for_detection(command).lower()
+    if _GATEWAY_SELF_RESTART_RE.search(normalized):
+        return (True, "Hermes gateway lifecycle command from inside the gateway")
+    return (False, None)
+
+
+def _gateway_self_restart_block_result(description: str) -> dict:
+    """Build the block result for gateway self-restart attempts."""
+    return {
+        "approved": False,
+        "hardline": True,
+        "message": (
+            f"BLOCKED (gateway self-restart guard): {description}. "
+            "A running Hermes gateway session must not restart or kickstart "
+            "its own gateway process. Ask for an operator shell outside the "
+            "running gateway, then verify after that external restart."
+        ),
+    }
+
+
 # =========================================================================
 # Dangerous command patterns
 # =========================================================================
@@ -424,6 +458,7 @@ DANGEROUS_PATTERNS = [
     # terminates all running agents mid-work.
     (r'\bhermes\s+gateway\s+(stop|restart)\b', "stop/restart hermes gateway (kills running agents)"),
     (r'\bhermes\s+update\b', "hermes update (restarts gateway, kills running agents)"),
+    (r'\blaunchctl\b[^\n;`]*(kickstart|bootout|bootstrap|stop|remove|unload|load)\b[^\n;`]*\bai\.hermes\.gateway(\.plist)?\b', "launchd hermes gateway lifecycle (kills running agents)"),
     # Docker container lifecycle — any user with docker.sock mounted (a common
     # Docker Compose pattern) gives the agent the ability to restart/stop/kill
     # containers without approval.  These are agent-initiated lifecycle operations
@@ -1364,6 +1399,12 @@ def check_all_command_guards(command: str, env_type: str,
                        sudo_guess_desc, command[:200])
         return _sudo_stdin_block_result(sudo_guess_desc)
 
+    is_gateway_self_restart, gateway_self_restart_desc = _check_gateway_self_restart_guard(command)
+    if is_gateway_self_restart and _is_gateway_approval_context():
+        logger.warning("Gateway self-restart guard block: %s (command: %s)",
+                       gateway_self_restart_desc, command[:200])
+        return _gateway_self_restart_block_result(gateway_self_restart_desc)
+
     # --yolo or approvals.mode=off: bypass all approval prompts.
     # Gateway /yolo is session-scoped; CLI --yolo remains process-scoped.
     approval_mode = _get_approval_mode()
@@ -1658,12 +1699,18 @@ def check_execute_code_guard(code: str, env_type: str) -> dict:
     if env_type in {"docker", "singularity", "modal", "daytona", "vercel_sandbox"}:
         return {"approved": True, "message": None}
 
+    is_gateway = _is_gateway_approval_context()
+    is_gateway_self_restart, gateway_self_restart_desc = _check_gateway_self_restart_guard(code)
+    if is_gateway_self_restart and is_gateway:
+        logger.warning("Gateway self-restart guard block in execute_code: %s",
+                       gateway_self_restart_desc)
+        return _gateway_self_restart_block_result(gateway_self_restart_desc)
+
     # --yolo or approvals.mode=off: bypass (session- or process-scoped).
     approval_mode = _get_approval_mode()
     if _YOLO_MODE_FROZEN or is_current_session_yolo_enabled() or approval_mode == "off":
         return {"approved": True, "message": None}
 
-    is_gateway = _is_gateway_approval_context()
     is_ask = env_var_enabled("HERMES_EXEC_ASK")
 
     # Cron: no user is present to approve arbitrary code.


### PR DESCRIPTION
## What does this PR do?

Fixes two gateway stability failures from the same local incident:

1. A gateway-run agent could bypass the existing `hermes gateway restart` protection by shelling directly to the macOS launchd service:

   ```bash
   launchctl kickstart -k gui/501/ai.hermes.gateway
   ```

   That sent SIGTERM to the running gateway from inside an active turn.

2. After the interrupted turn, the affected Discord channel stayed broken because the session remained `resume_pending=True` while replaying an oversized transcript. The local incident had ~329k recorded prompt tokens on a configured 400k context model, below the old 85% gateway hygiene threshold but above the agent's 50% compression threshold. Incomplete turns did not clear `resume_pending`, so every real user message re-entered the same poisoned context.

This PR now blocks gateway self-restart commands from gateway/API sessions before `/yolo` or `approvals.mode=off`, and adds a pre-agent restart-recovery reset gate: oversized `resume_pending` sessions are rotated to a fresh active session before any model call. The old transcript is preserved in session history; it is not replayed into the current turn.

Related overlap: existing open PRs #7817, #33084, and #33562 also cover launchd gateway lifecycle commands in `DANGEROUS_PATTERNS`. This PR is stricter in gateway context because it hard-blocks before yolo/off approvals and also covers `execute_code` snippets.

## Related Issue

No public issue for the local incident. Related to the same launchd bypass class discussed in #7817, #33084, and #33562.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [x] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tools/approval.py` — adds `_check_gateway_self_restart_guard()` and blocks Hermes gateway lifecycle commands from gateway/API sessions before yolo or disabled approvals can bypass the approval layer.
- `tools/approval.py` — adds launchd `ai.hermes.gateway` lifecycle commands to `DANGEROUS_PATTERNS` for ordinary dangerous-command detection outside the hard-blocked gateway context.
- `tools/approval.py` — applies the same gateway self-restart guard to `check_execute_code_guard()` so Python snippets containing launchd gateway lifecycle calls are denied from gateway sessions before whole-script approval bypasses.
- `gateway/run.py` — adds a restart-recovery safety gate for `resume_pending` sessions whose transcript is already beyond the agent compression threshold, capped at 50% context. Those sessions are reset before agent startup, with session-boundary transient state cleared and Telegram topic bindings re-pointed when applicable.
- `tests/tools/test_approval.py` — covers launchd Hermes gateway lifecycle command detection and isolates the `find` approval-key regression test from host-local permanent allowlists.
- `tests/tools/test_command_guards.py` — covers terminal and `execute_code` gateway-session hard blocks, including the `approvals.mode=off` path.
- `tests/gateway/test_restart_resume_pending.py` — covers the exact 329k prompt / 400k context incident shape and verifies the oversized `resume_pending` session rotates before agent startup.

## How to Test

1. From a gateway-context guard path, verify `launchctl kickstart -k gui/501/ai.hermes.gateway` returns `approved: False` before approval mode/yolo handling.
2. Verify an `execute_code` snippet containing `subprocess.run(['launchctl', 'kickstart', '-k', 'gui/501/ai.hermes.gateway'])` is also blocked from a gateway session before whole-script approval bypasses.
3. Verify a `resume_pending` session with `last_prompt_tokens=329_227` and `context_length=400_000` resets before agent startup instead of replaying the transcript.
4. Run focused CI-parity wrapper tests:

   ```bash
   scripts/run_tests.sh tests/gateway/test_restart_resume_pending.py
   scripts/run_tests.sh tests/gateway/test_session_hygiene.py tests/tools/test_approval.py tests/tools/test_command_guards.py tests/hermes_cli/test_gateway_restart_loop.py
   ```

5. Run syntax/bytecode validation:

   ```bash
   venv/bin/python -m compileall -q gateway/run.py tools/approval.py
   ```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate; related PRs #7817, #33084, and #33562 are called out above
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass; not run locally because this draft targets gateway restart/recovery behavior and focused CI-parity wrapper tests were run instead
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.2

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A; no user-facing docs changed
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility); launchd detection is macOS-specific, existing systemd detection remains unchanged, and the restart-recovery reset gate is platform-neutral
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A; no model-facing tool schema changed

## For New Skills

N/A.

## Screenshots / Logs

Focused wrapper test results:

```text
=== Summary: 1 files, 77 tests passed, 0 failed (100% complete) in 18.0s (24 workers) ===
=== Summary: 4 files, 306 tests passed, 0 failed (100% complete) in 5.9s (24 workers) ===
```

Compile checks:

```bash
venv/bin/python -m compileall -q gateway/run.py tools/approval.py
```
