### PR TITLE
fix(agent): detect modern Azure OpenAI services.ai.azure.com URLs (#47666)

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -841,12 +841,15 @@ class AIAgent:
         does NOT support the Responses API — gpt-5.x models are served
         on the regular ``/chat/completions`` path — so routing decisions
         must treat Azure separately from direct OpenAI.
+
+        Modern Azure OpenAI resources (post-2024) use
+        ``{resource}.services.ai.azure.com`` endpoints.
         """
         if base_url is not None:
             url = str(base_url).lower()
         else:
             url = getattr(self, "_base_url_lower", "") or ""
-        return "openai.azure.com" in url
+        return "openai.azure.com" in url or "ai.azure.com" in url
 
     def _is_github_copilot_url(self, base_url: str = None) -> bool:
         """Return True when a base URL targets GitHub Copilot's OpenAI-compatible API."""


### PR DESCRIPTION
Fixes #47666. The _is_azure_openai_url function now also detects modern Azure OpenAI endpoints using services.ai.azure.com, in addition to the legacy openai.azure.com format.