### PR TITLE
fix(cli): narrow model picker dedup to routing aggregators only

### DIFF
--- a/hermes_cli/inventory.py
+++ b/hermes_cli/inventory.py
@@ -157,21 +157,21 @@ def build_models_payload(
         max_models=max_models,
     )
 
-    # --- Deduplicate: remove models from aggregators that overlap with
-    # user-defined providers.  When a local proxy (e.g. litellm-proxy)
-    # serves a model whose name also appears in an aggregator's curated
-    # catalog, the picker would show the model under both providers.
-    # Selecting it from the aggregator row sets model.provider to the
-    # aggregator (e.g. openrouter) instead of the user's proxy — silently
-    # breaking the call.  Filtering at the payload level keeps the
-    # aggregator rows honest: they only show models the user can't get
-    # from a more-specific provider.  (#45954)
+    # --- Deduplicate: remove models from routing aggregators that overlap
+    # with user-defined providers.  When a local proxy (e.g. litellm-proxy)
+    # serves a model whose name also appears in a pure routing aggregator's
+    # catalog (e.g. openrouter), the picker would show the model under both
+    # providers.  Selecting it from the aggregator row sets model.provider
+    # to the aggregator instead of the user's proxy — silently breaking the
+    # call.  Only pure routing aggregators (dedup_on_overlap=True) are
+    # filtered; curated catalogs like opencode-go, huggingface, novita
+    # serve models directly and must NOT be filtered.  (#45954, #47704)
     try:
-        from hermes_cli.providers import is_aggregator as _is_aggregator
+        from hermes_cli.providers import is_overlap_dedup as _is_overlap_dedup
     except Exception:
-        _is_aggregator = None  # type: ignore[assignment]
+        _is_overlap_dedup = None  # type: ignore[assignment]
 
-    if _is_aggregator is not None:
+    if _is_overlap_dedup is not None:
         user_models: set[str] = set()
         for row in rows:
             if row.get("is_user_defined"):
@@ -179,15 +179,11 @@ def build_models_payload(
         if user_models:
             for row in rows:
                 # A user's own configured provider is never an "aggregator
-                # duplicate" of itself: user_models is built from these very
-                # rows, and is_aggregator() reports True for every custom:*
-                # slug.  Without this guard the dedup strips a user-defined
-                # custom provider's entire model list (all of it lives in
-                # user_models), emptying its picker row.
+                # duplicate" of itself.
                 if row.get("is_user_defined"):
                     continue
                 slug = row.get("slug", "")
-                if not _is_aggregator(slug):
+                if not _is_overlap_dedup(slug):
                     continue
                 original = row.get("models") or []
                 filtered = [m for m in original if m.lower() not in user_models]

--- a/hermes_cli/providers.py
+++ b/hermes_cli/providers.py
@@ -37,6 +37,7 @@ class HermesOverlay:
 
     transport: str = "openai_chat"        # openai_chat | anthropic_messages | codex_responses
     is_aggregator: bool = False
+    dedup_on_overlap: bool = False        # True only for pure routing aggregators (e.g. openrouter)
     auth_type: str = "api_key"            # api_key | oauth_device_code | oauth_external | external_process
     extra_env_vars: Tuple[str, ...] = ()  # env vars models.dev doesn't list
     base_url_override: str = ""           # override if models.dev URL is wrong/missing
@@ -47,6 +48,7 @@ HERMES_OVERLAYS: Dict[str, HermesOverlay] = {
     "openrouter": HermesOverlay(
         transport="openai_chat",
         is_aggregator=True,
+        dedup_on_overlap=True,
         base_url_env_var="OPENROUTER_BASE_URL",
     ),
     "nous": HermesOverlay(
@@ -228,6 +230,7 @@ class ProviderDef:
     base_url: str = ""
     base_url_env_var: str = ""
     is_aggregator: bool = False
+    dedup_on_overlap: bool = False
     auth_type: str = "api_key"
     doc: str = ""
     source: str = ""                      # "models.dev", "hermes", "user-config"
@@ -431,6 +434,7 @@ def get_provider(name: str) -> Optional[ProviderDef]:
         # Merge models.dev + overlay
         transport = overlay.transport if overlay else "openai_chat"
         is_agg = overlay.is_aggregator if overlay else False
+        dedup = overlay.dedup_on_overlap if overlay else False
         auth = overlay.auth_type if overlay else "api_key"
         base_url_env = overlay.base_url_env_var if overlay else ""
         base_url_override = overlay.base_url_override if overlay else ""
@@ -450,6 +454,7 @@ def get_provider(name: str) -> Optional[ProviderDef]:
             base_url=base_url_override or mdev_info.api,
             base_url_env_var=base_url_env,
             is_aggregator=is_agg,
+            dedup_on_overlap=dedup,
             auth_type=auth,
             doc=mdev_info.doc,
             source="models.dev",
@@ -465,6 +470,7 @@ def get_provider(name: str) -> Optional[ProviderDef]:
             base_url=overlay.base_url_override,
             base_url_env_var=overlay.base_url_env_var,
             is_aggregator=overlay.is_aggregator,
+            dedup_on_overlap=overlay.dedup_on_overlap,
             auth_type=overlay.auth_type,
             source="hermes",
         )
@@ -497,6 +503,21 @@ def is_aggregator(provider: str) -> bool:
         return True
     pdef = get_provider(provider_norm)
     return pdef.is_aggregator if pdef else False
+
+
+def is_overlap_dedup(provider: str) -> bool:
+    """Return True when the provider should be deduped against user-defined providers.
+
+    Only pure routing aggregators (e.g. openrouter) that silently remap
+    model.provider should be deduped.  Curated catalogs like opencode-go,
+    huggingface, novita serve models directly and must NOT be filtered.
+    See: https://github.com/NousResearch/hermes-agent/issues/47704
+    """
+    provider_norm = normalize_provider(provider or "")
+    if provider_norm.startswith("custom:"):
+        return False
+    pdef = get_provider(provider_norm)
+    return pdef.dedup_on_overlap if pdef else False
 
 
 def determine_api_mode(provider: str, base_url: str = "") -> str:


### PR DESCRIPTION
## Summary
The dedup logic in the model picker used `is_aggregator()` which was too broad — it removed models from ALL aggregators including curated catalogs like `opencode-go`, `huggingface`, and `novita` that serve models directly and should never be filtered.

Add a new `dedup_on_overlap` field to `HermesOverlay` (default `False`, only `True` on `openrouter`). Add `is_overlap_dedup()` function and update `inventory.py` to use it instead of `is_aggregator()`.

Fixes #47704