### PR TITLE
fix(acp): record runtime main provider to prevent auxiliary fallback …

### DIFF
--- a/acp_adapter/session.py
+++ b/acp_adapter/session.py
@@ -617,6 +617,26 @@ class SessionManager:
 
         _register_task_cwd(session_id, cwd)
         agent = AIAgent(**kwargs)
+        # Record the live runtime for auxiliary client resolution. The agent's
+        # provider/model/base_url/api_key are already set in kwargs but
+        # auxiliary_client._resolve_auto reads them from module-level globals
+        # (set_runtime_main) or from config.yaml via _read_main_provider() —
+        # neither reflects what we just resolved. Without this call, Step 1 of
+        # _resolve_auto (main provider + main model) silently skips the
+        # ACP-resolved provider and the fallback chain may construct a bare
+        # openai.OpenAI() client that leaks to api.openai.com. (#47638)
+        try:
+            from agent.auxiliary_client import set_runtime_main
+            set_runtime_main(
+                getattr(agent, "provider", "") or kwargs.get("provider", ""),
+                getattr(agent, "model", "") or kwargs.get("model", ""),
+                base_url=getattr(agent, "base_url", "") or kwargs.get("base_url", ""),
+                api_key=getattr(agent, "api_key", "") or kwargs.get("api_key", ""),
+                api_mode=getattr(agent, "api_mode", "") or kwargs.get("api_mode", ""),
+            )
+        except Exception:
+            logger.debug("ACP session: set_runtime_main failed", exc_info=True)
+
         # ACP stdio transport requires stdout to remain protocol-only JSON-RPC.
         # Route any incidental human-readable agent output to stderr instead.
         agent._print_fn = _acp_stderr_print

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -88,6 +88,28 @@ class _OpenAIProxy:
     __slots__ = ()
 
     def __call__(self, *args, **kwargs):
+        api_key = kwargs.get("api_key")
+        base_url = kwargs.get("base_url")
+        if isinstance(base_url, str) and base_url.strip():
+            try:
+                from urllib.parse import urlparse as _urlparse
+                host = _urlparse(base_url.strip()).hostname or ""
+            except Exception:
+                host = ""
+        else:
+            host = "api.openai.com"  # default SDK endpoint when no base_url
+        if host == "api.openai.com":
+            _key = (api_key or "").strip() if isinstance(api_key, str) else ""
+            if not _key or _key == "no-key-required":
+                logger.warning(
+                    "Constructing OpenAI client targeting %s with "
+                    "missing or placeholder api_key (%r). The auxiliary "
+                    "provider fallback chain could not resolve a working "
+                    "provider — this call will likely fail with HTTP 401. "
+                    "Set OPENAI_API_KEY or configure a non-OpenAI provider "
+                    "in config.yaml.",
+                    host, _key[:20],
+                )
         return _load_openai_cls()(*args, **kwargs)
 
     def __instancecheck__(self, obj):

--- a/plugins/image_gen/openai/__init__.py
+++ b/plugins/image_gen/openai/__init__.py
@@ -224,7 +224,7 @@ class OpenAIImageGenProvider(ImageGenProvider):
         }
 
         try:
-            client = openai.OpenAI()
+            client = openai.OpenAI(api_key=os.environ["OPENAI_API_KEY"])
             response = client.images.generate(**payload)
         except Exception as exc:
             logger.debug("OpenAI image generation failed", exc_info=True)


### PR DESCRIPTION
closes:#47638
Three defence layers for a class of bug where Hermes constructs an
`openai.OpenAI()` client targeting `api.openai.com` with a missing or
placeholder API key, resulting in a silent 401 from OpenAI.

**Root cause:** `acp_adapter/session.py` creates an `AIAgent` with the
correct provider/model/base_url/api_key in `kwargs`, but
`auxiliary_client._resolve_auto` reads these from `set_runtime_main()`
module-level globals. Without the call, Step 1 silently skips the
ACP-resolved provider and the fallback chain may construct a bare
`openai.OpenAI()` that leaks to api.openai.com with whatever key (or
placeholder) the environment provides.

**Fix 1 — `acp_adapter/session.py`:** Call `set_runtime_main()` right
after `AIAgent(**kwargs)` so Step 1 of `_resolve_auto` finds the
ACP-resolved provider (e.g. `minimax-cn`). This is the highest-impact
change — it prevents the entire fallback chain from running for ACP
child agents.

**Fix 2 — `agent/auxiliary_client.py:_OpenAIProxy`:** Defence in depth.
When the proxy constructs an `OpenAI` client that targets
`api.openai.com` (explicitly or by default) with a missing or
`"no-key-required"` placeholder key, log a warning pointing the user at
the fix. This catches any Hermes-internal code path that falls through
to the default OpenAI endpoint without a real credential.

**Fix 3 — `plugins/image_gen/openai/__init__.py`:** Pass
`api_key=os.environ["OPENAI_API_KEY"]` explicitly to `openai.OpenAI()`
instead of relying on the SDK's implicit env-var read. The existing
guard on line 191 already returns early when the env var is absent; this
makes the credential traceable in stack traces and logs.