### PR TITLE
Fix TUI bare custom provider session routing

### DIFF
--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -58,6 +58,45 @@ def test_session_create_rejects_at_active_session_limit(monkeypatch, tmp_path):
         reset_hermes_home_override(token)
 
 
+def test_session_create_normalizes_bare_custom_provider(monkeypatch, tmp_path):
+    for session in list(server._sessions.values()):
+        server._teardown_session(session)
+    server._sessions.clear()
+    server._cfg_cache = None
+    server._cfg_mtime = None
+    server._cfg_path = None
+
+    monkeypatch.setattr(server, "_start_agent_build", lambda *args, **kwargs: None)
+    monkeypatch.setattr(server, "_completion_cwd", lambda params=None: str(tmp_path))
+    monkeypatch.setattr(
+        server,
+        "_configured_model_provider_for_profile",
+        lambda profile_home=None: "custom:herstory-api",
+    )
+
+    try:
+        resp = server._methods["session.create"](
+            "r1",
+            {
+                "cols": 80,
+                "model": "claude-sonnet-4-6",
+                "provider": "custom",
+            },
+        )
+
+        assert "result" in resp
+        sid = resp["result"]["session_id"]
+        assert resp["result"]["info"]["provider"] == "custom:herstory-api"
+        assert server._sessions[sid]["model_override"] == {
+            "model": "claude-sonnet-4-6",
+            "provider": "custom:herstory-api",
+        }
+    finally:
+        for session in list(server._sessions.values()):
+            server._teardown_session(session)
+        server._sessions.clear()
+
+
 def test_session_context_uses_session_cwd(monkeypatch, tmp_path):
     """Desktop/TUI sessions must pin the agent cwd per session.
 
@@ -1143,6 +1182,14 @@ def test_stored_session_runtime_overrides_skips_bare_billing_provider():
     assert "provider_override" not in ov
     assert ov["model_override"]["provider"] is None
 
+    # Bare model_config.provider is also only a runtime class unless a base_url
+    # is present for the custom-provider identity repair path.
+    ov = server._stored_session_runtime_overrides(
+        {"model": "my-model", "model_config": {"provider": "custom"}}
+    )
+    assert "provider_override" not in ov
+    assert ov["model_override"]["provider"] is None
+
     for bare in ("auto", "openrouter", "custom"):
         ov = server._stored_session_runtime_overrides({"model": "m", "billing_provider": bare})
         assert "provider_override" not in ov
@@ -1923,6 +1970,34 @@ def test_ensure_session_db_row_persists_session_model_override(monkeypatch):
     assert row["model_config"]["provider"] == "openrouter"
     assert row["model_config"]["reasoning_config"] == {"effort": "high"}
     assert row["model_config"]["service_tier"] == "priority"
+
+
+def test_ensure_session_db_row_normalizes_bare_custom_provider(monkeypatch):
+    created = []
+
+    class _FakeDB:
+        def create_session(self, key, source=None, model=None, model_config=None, cwd=None):
+            created.append({"key": key, "model": model, "model_config": model_config})
+
+    monkeypatch.setattr(server, "_get_db", lambda: _FakeDB())
+    monkeypatch.setattr(server, "_resolve_model", lambda: "global/default")
+    monkeypatch.setattr(
+        server,
+        "_configured_model_provider_for_profile",
+        lambda profile_home=None: "custom:herstory-api",
+    )
+
+    server._ensure_session_db_row(
+        {
+            "session_key": "k1",
+            "model_override": {"model": "claude-sonnet-4-6", "provider": "custom"},
+        }
+    )
+
+    assert len(created) == 1
+    row = created[0]
+    assert row["model"] == "claude-sonnet-4-6"
+    assert row["model_config"]["provider"] == "custom:herstory-api"
 
 
 def test_ensure_session_db_row_no_override_uses_global(monkeypatch):
@@ -6717,6 +6792,40 @@ def test_make_agent_uses_session_runtime_overrides(monkeypatch):
     assert mock_agent.call_args.kwargs["provider"] == "openai-codex"
     assert mock_agent.call_args.kwargs["reasoning_config"] == {"enabled": True, "effort": "high"}
     assert mock_agent.call_args.kwargs["service_tier"] == "priority"
+
+
+def test_make_agent_ignores_bare_custom_override_without_base_url(monkeypatch):
+    _setup_make_agent_mocks(monkeypatch, {})
+    resolved = {}
+
+    def fake_resolve_runtime_provider(requested=None, target_model=None):
+        resolved["requested"] = requested
+        resolved["target_model"] = target_model
+        return {
+            "provider": "custom",
+            "base_url": "https://configured.example/v1",
+            "api_key": "not-secret",
+            "api_mode": "chat_completions",
+            "command": None,
+            "args": None,
+            "credential_pool": None,
+        }
+
+    monkeypatch.setattr(
+        "hermes_cli.runtime_provider.resolve_runtime_provider",
+        fake_resolve_runtime_provider,
+    )
+
+    with patch("run_agent.AIAgent") as mock_agent:
+        server._make_agent(
+            "sid1",
+            "key1",
+            model_override={"model": "claude-sonnet-4-6", "provider": "custom"},
+        )
+
+    assert resolved == {"requested": None, "target_model": "claude-sonnet-4-6"}
+    assert mock_agent.call_args.kwargs["provider"] == "custom"
+    assert mock_agent.call_args.kwargs["base_url"] == "https://configured.example/v1"
 
 
 def test_make_agent_handles_null_agent_config(monkeypatch):

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -1205,14 +1205,19 @@ def _ensure_session_db_row(session: dict) -> None:
     override = override if isinstance(override, dict) else {}
     row_model = str(override.get("model") or "").strip() or _resolve_model()
     model_config: dict = {}
+    normalized_provider = _normalize_bare_custom_provider(
+        override.get("provider"),
+        profile_home=profile_home,
+    )
     for src_key, cfg_key in (
         ("model", "model"),
-        ("provider", "provider"),
         ("base_url", "base_url"),
         ("api_mode", "api_mode"),
     ):
         if val := override.get(src_key):
             model_config[cfg_key] = str(val)
+    if normalized_provider:
+        model_config["provider"] = normalized_provider
     if (reasoning := session.get("create_reasoning_override")) is not None:
         model_config["reasoning_config"] = reasoning
     if tier := session.get("create_service_tier_override"):
@@ -1491,6 +1496,35 @@ def _config_model_target() -> tuple[str, str]:
     return model, provider
 
 
+def _configured_model_provider_for_profile(profile_home: str | None = None) -> str:
+    home_token = None
+    try:
+        if profile_home:
+            home_token = set_hermes_home_override(profile_home)
+        _model, provider = _config_model_target()
+        return provider
+    finally:
+        if home_token is not None:
+            reset_hermes_home_override(home_token)
+
+
+def _normalize_bare_custom_provider(
+    provider: str | None,
+    *,
+    profile_home: str | None = None,
+) -> str | None:
+    normalized = str(provider or "").strip()
+    if not normalized:
+        return None
+    if normalized.lower() != "custom":
+        return normalized
+
+    configured = _configured_model_provider_for_profile(profile_home)
+    if configured.lower().startswith("custom:"):
+        return configured
+    return None
+
+
 def _resolve_startup_runtime() -> tuple[str, str | None]:
     model = _resolve_model()
     explicit_provider = os.environ.get("HERMES_TUI_PROVIDER", "").strip()
@@ -1563,13 +1597,19 @@ def _stored_session_runtime_overrides(row: dict | None) -> dict:
     # Only restore an explicit provider; otherwise leave it unset so resume falls back to
     # the configured default, matching the working CLI path.
     explicit_provider = str(model_config.get("provider") or "").strip()
+    base_url = str(model_config.get("base_url") or "").strip()
+    if explicit_provider.lower() == "custom" and not base_url:
+        # Bare ``custom`` is a billing/runtime class, not a recoverable endpoint
+        # identity. Without a base_url we cannot map it back to ``custom:<name>``,
+        # so let the profile config resolve the provider instead of falling back
+        # through the generic custom/OpenRouter path.
+        explicit_provider = ""
     billing_provider = str(
         model_config.get("billing_provider") or row.get("billing_provider") or ""
     ).strip()
     provider = explicit_provider
     if not provider and billing_provider.lower() not in _BARE_BILLING_PROVIDERS:
         provider = billing_provider
-    base_url = str(model_config.get("base_url") or "").strip()
     api_mode = str(model_config.get("api_mode") or "").strip()
     reasoning_config = model_config.get("reasoning_config")
     service_tier = str(model_config.get("service_tier") or "").strip()
@@ -3465,6 +3505,11 @@ def _make_agent(
         override_api_mode = model_override.get("api_mode")
         resolve_kwargs = {}
         if (
+            str(requested_provider or "").strip().lower() == "custom"
+            and not override_base_url
+        ):
+            requested_provider = None
+        if (
             override_base_url
             and str(requested_provider or "").strip().lower() == "custom"
         ):
@@ -4015,8 +4060,12 @@ def _(rid, params: dict) -> dict:
     # for a new chat can't mutate the profile default. provider is optional
     # (resolved at build).
     create_model = str(params.get("model") or "").strip()
+    create_provider = _normalize_bare_custom_provider(
+        params.get("provider"),
+        profile_home=str(profile_home) if profile_home is not None else None,
+    )
     session_model_override = (
-        {"model": create_model, "provider": str(params.get("provider") or "").strip() or None}
+        {"model": create_model, "provider": create_provider}
         if create_model
         else None
     )


### PR DESCRIPTION
## Summary

Fixes a Desktop/TUI session routing bug where a named custom provider can be collapsed to the bare provider value `custom`, then restored as if `custom` were a complete provider identity.

This is the issue described in #47714: Desktop/TUI chats stopped responding while the same profile still worked through the Feishu/message gateway and CLI. The working paths resolved the configured custom endpoint correctly, while affected Desktop/TUI sessions persisted runtime metadata like:

```json
{"model":"claude-sonnet-4-6","provider":"custom"}
```

with no `base_url`. On rebuild/resume, that bare `custom` value was treated as an explicit provider override and could fall through to the generic custom/OpenRouter path instead of resolving the profile's configured named custom provider.

## Background and investigation

The failure was reproducible from local logs/state with this pattern:

- Desktop/TUI sessions stored `model_config.provider = "custom"` without `base_url`.
- Feishu gateway sessions in the same profile resolved the correct custom endpoint and continued responding.
- Previously repaired session rows could work temporarily, but new Desktop/TUI sessions could regress because the bad value was written during session creation / first DB persistence.

The relevant paths are:

- `session.create` builds a per-session `model_override` from Desktop composer params before the agent is built.
- `_ensure_session_db_row()` persists that override into `model_config` on the first prompt.
- `_stored_session_runtime_overrides()` restores `model_config.provider` as an explicit runtime override on resume.
- `_make_agent()` passes the restored override to `resolve_runtime_provider()`.

Existing repair logic already handled `provider="custom"` when a `base_url` is also available, because the endpoint can be mapped back to `custom:<name>`. The missing case was `provider="custom"` without `base_url`: there is no durable identity to recover, so it should not be treated as a routable session provider.

## Fix

This patch keeps the change scoped to the TUI/Desktop gateway layer rather than changing global provider resolution semantics.

- Normalize bare `custom` during `session.create` using the active profile config. If the profile provider is `custom:<name>`, the session override stores that canonical identity instead of bare `custom`.
- Apply the same normalization when `_ensure_session_db_row()` writes the first session row, so `model_config.provider` does not persist the lossy value.
- Treat historical `model_config.provider == "custom"` with no `base_url` as non-routable during resume, allowing the profile config to resolve the provider.
- Add a defensive guard in `_make_agent()` so any in-memory override with bare `custom` and no `base_url` is not passed through as an explicit runtime provider.
- Preserve the existing `custom + base_url` repair behavior, including round-tripping named custom providers from endpoint URL.

## Expected result

After this change:

- New Desktop/TUI chats using a named custom provider should persist `custom:<name>` instead of bare `custom`.
- Existing broken rows that only have `provider="custom"` and no `base_url` should fall back to the profile's configured provider instead of drifting to a generic custom/OpenRouter route.
- Sessions that legitimately have `provider="custom"` plus a `base_url` continue using the existing repair/direct-alias path.
- No API keys are persisted or copied into session metadata.

## Tests

Passed:

```bash
venv/bin/python -m pytest -q tests/test_tui_gateway_server.py -k 'bare_custom or normalizes_bare_custom or stored_session_runtime_overrides_skips_bare_billing_provider or make_agent_uses_session_runtime_overrides'
# 5 passed, 275 deselected

venv/bin/python -m pytest -q tests/tui_gateway/test_custom_provider_session_persistence.py tests/tui_gateway/test_make_agent_provider.py
# 18 passed

python3 -m py_compile tui_gateway/server.py tests/test_tui_gateway_server.py
git diff --check -- tui_gateway/server.py tests/test_tui_gateway_server.py
```

Also ran the full `tests/test_tui_gateway_server.py`; the custom-provider related coverage passed, with one unrelated existing failure in `test_browser_manage_connect_default_local_reports_launch_hint` around browser launch hint text.
