### PR TITLE
fix(config): avoid pinned Claude default in install template

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -6,9 +6,13 @@
 # Model Configuration
 # =============================================================================
 model:
-  # Default model to use (can be overridden with --model flag)
+  # Default model to use (can be overridden with --model flag).
+  # Leave empty until you pick an authenticated provider/model with:
+  #   hermes setup model
+  # or:
+  #   hermes model
   # Both "default" and "model" work as the key name here.
-  default: "anthropic/claude-opus-4.6"
+  default: ""
   
   # Inference provider selection:
   #   "auto"         - Auto-detect from credentials (default)
@@ -110,7 +114,7 @@ model:
 #   anthropic:
 #     request_timeout_seconds: 30    # Fast-fail cloud requests
 #     models:
-#       claude-opus-4.6:
+#       claude-opus-4.8:
 #         timeout_seconds: 600       # Longer timeout for extended-thinking Opus calls
 #   openai-codex:
 #     models:

--- a/tests/hermes_cli/test_config_template.py
+++ b/tests/hermes_cli/test_config_template.py
@@ -1,0 +1,18 @@
+"""Regression tests for the install-time config template."""
+
+from pathlib import Path
+
+import yaml
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_cli_config_template_leaves_model_selection_to_setup():
+    """Fresh installs copy this template directly into config.yaml."""
+    template_path = REPO_ROOT / "cli-config.yaml.example"
+    config = yaml.safe_load(template_path.read_text(encoding="utf-8"))
+
+    model_config = config["model"]
+    default_model = model_config.get("default") or model_config.get("model") or ""
+    assert default_model == ""


### PR DESCRIPTION
## Summary

- leave `model.default` empty in `cli-config.yaml.example` so fresh installs do not preselect an unauthenticated provider/model
- point users at `hermes setup model` / `hermes model` for explicit provider and model selection
- update the nearby Anthropic timeout example from Opus 4.6 to Opus 4.8
- add a regression test for the install-time config template

## Why

`scripts/install.sh` copies `cli-config.yaml.example` directly into `~/.hermes/config.yaml` on first install. Because the template pinned `anthropic/claude-opus-4.6`, a fresh install could show Claude Opus 4.6 as the default model even when Anthropic / Claude Code auth was not configured.

This PR keeps the install template aligned with the existing built-in `DEFAULT_CONFIG` behavior: no default chat model is selected until setup or the model picker chooses one.

Closes #47735.

## Test plan

```text
venv/bin/python -m pytest tests/hermes_cli/test_config_template.py tests/hermes_cli/test_setup_noninteractive.py tests/hermes_cli/test_config.py
```

Result: 108 passed.