### PR TITLE
feat: add team-of-thoughts optional skill

### DIFF
--- a/optional-skills/software-development/adversarial-debate/SKILL.md
+++ b/optional-skills/software-development/adversarial-debate/SKILL.md
@@ -1,0 +1,218 @@
+---
+name: adversarial-debate
+description: "Synchronous 4-agent adversarial debate with DQI scoring."
+version: 1.0.0
+author: Ramiz Mehran (ramizmehran) <ramiz@example.com>
+license: MIT
+platforms: [linux, macos]
+metadata:
+  hermes:
+    tags: [debate, multi-agent, decision-quality, consensus, cross-examination]
+    related_skills: [team-of-thoughts, kanban-orchestrator]
+    config:
+      delegation.max_concurrent_children: 4
+---
+
+# Adversarial Debate
+
+Orchestrate a synchronous 3-round adversarial debate among Clio, Hephaestus, Solon, and Talaria using `delegate_task`. Agents produce structured JSON claims with evidence types, rebut each other by claim ID, and converge to a weighted Decision Quality Index (DQI).
+
+**Core principle:** Structured cross-examination beats distributed monologue. Agents must defend, concede, or rebut by evidence — not opinion.
+
+## When to Use
+
+Use this skill when:
+- A decision has significant irreversible consequences (one-way door)
+- There are ≥2 plausible approaches with strong trade-offs
+- A previous kanban ToT produced weak or conflicting synthesis
+- The user explicitly asks for "full team debate", "adversarial review", or "cross-examine this"
+
+For routine feature design, low-risk bug fixes, and deliverable validation, use the kanban ToT (`team-of-thoughts` skill) instead.
+
+## Prerequisites
+
+| Requirement | Minimum | Notes |
+|-------------|---------|-------|
+| `delegation.max_concurrent_children` | 4 | In `config.yaml` — needed for parallel agent spawn |
+| `delegation.child_timeout_seconds` | 600 | Per-agent timeout for each round |
+| Hermes profiles | clio, hephaestus, solon, talaria | Must exist and be operational |
+| `delegate_task` tool | Available | Included in all platform toolsets |
+
+## How to Run
+
+### From agent prompt (primary path)
+
+Load this skill, then follow the Procedure below. You (Hermes/Default) serve as debate moderator: spawn agents via `delegate_task`, collect outputs, calculate DQI, produce synthesis.
+
+### From CLI (debugging / test)
+
+```bash
+~/.hermes/skills/adversarial-debate/scripts/debate-orchestrator.sh \
+  --topic "Topic" \
+  --context-file /tmp/context.md \
+  --format rca
+```
+
+## Quick Reference
+
+```
+Setup → Round 1 (4 parallel agents, opening statements)
+      → Round 2 (4 parallel agents, cross-examination by claim ID)
+      → DQI calculation → if DQI < 0.6 → Round 3 (convergence)
+      → Weighted synthesis → kanban root card
+```
+
+DQI formula per claim: `confidence × evidence_multiplier × rebuttal_status`
+  - evidence: direct=1.0, inferred=0.7, speculative=0.4
+  - rebuttal: unrebutted=1.0, conceded=0.7, unresolved=0.5
+
+## Procedure
+
+### 1. Setup
+
+1. Inform the user the debate is starting.
+2. Create workspace: `/tmp/hermes-debate-<timestamp>/` with `round-1/`, `round-2/`, `round-3/` subdirectories.
+3. Write the context file including topic, format (`rca` or `feature`), project root, background, and success criteria.
+4. Create a kanban root card for tracking:
+   ```bash
+   hermes kanban create "Debate: <topic>" --triage --body "$(cat context)"
+   ```
+5. Initialize the transcript:
+   ```bash
+   echo '{"debate_id":"debate-<ts>","topic":"<topic>","format":"<rca|feature>","rounds":[],"dqi":null}' > transcript.json
+   ```
+
+### 2. Round 1 — Opening Statements
+
+Read the Round 1 template from `templates/round-1-opening.md`. Render placeholders with the actual topic, format, and agent name. Spawn all 4 agents in parallel via `delegate_task`:
+
+```python
+for agent in ["clio", "hephaestus", "solon", "talaria"]:
+    delegate_task(
+        subagent_type="general",
+        description=f"Adversarial debate Round 1 — {agent}",
+        prompt=rendered_round1_prompt(agent, topic, context)
+    )
+```
+
+Each agent returns structured JSON with claims, evidence citations, confidence (0–100), and evidence strength (`direct` | `inferred` | `speculative`).
+
+On timeout or malformed JSON, record `{"agent":"<name>","error":"timeout|parse_error"}` and continue.
+
+Append all 4 outputs to the transcript.
+
+### 3. Round 2 — Cross-Examination
+
+Render the Round 2 template from `templates/round-2-cross-examination.md`. Append the full transcript JSON to each prompt so agents see every other agent's claims.
+
+Each agent MUST:
+- Rebut ≥1 specific claim from another agent by `claim.id`
+- Update their confidence (may increase or decrease)
+- Set `position_changed: true/false`
+
+Spawn all 4 in parallel. Collect outputs, append to transcript.
+
+### 4. DQI Calculation
+
+After Round 2, run the DQI formula using all claims from the latest round:
+
+```python
+evidence_mult = {"direct": 1.0, "inferred": 0.7, "speculative": 0.4}
+rebuttal_mult = {"unrebutted": 1.0, "conceded": 0.7, "unresolved": 0.5}
+
+weights = []
+for claim in all_claims:
+    c = claim["confidence"] / 100
+    e = evidence_mult.get(claim["evidence_strength"], 0.4)
+    r = rebuttal_mult.get(claim.get("rebuttal_status", "unrebutted"), 1.0)
+    weights.append(c * e * r)
+
+dqi = sum(weights) / len(weights) if weights else 0.0
+```
+
+| DQI | Action |
+|-----|--------|
+| ≥ 0.8 | Skip Round 3. Proceed to adjudication. |
+| 0.6 – 0.8 | Skip Round 3. Flag tensions in synthesis. |
+| < 0.6 | Enter Round 3 — Convergence. |
+
+Also count position changes: ≥2 agents changed position signals healthy convergence. 0 changes signals entrenched positions — note in synthesis.
+
+### 5. Round 3 — Convergence (only if DQI < 0.6)
+
+Render the Round 3 template from `templates/round-3-convergence.md`. Include the full transcript and a list of unresolved disagreements (claims defended in Round 2).
+
+Each agent MUST end with one of:
+- **accept** — full agreement
+- **conditional_accept** — accept if condition is met
+- **minority_report** — maintain dissenting position with rationale
+
+Spawn all 4 in parallel. Collect outputs. Recalculate DQI with Round 3 claims included.
+
+### 6. Adjudication
+
+Build the synthesis JSON:
+
+```python
+synthesis = {
+    "debate_id": "...",
+    "topic": "...",
+    "rounds_completed": 2 or 3,
+    "dqi": <float>,
+    "dqi_assessment": "high" | "moderate" | "low",
+    "consensus_claims": [unrebutted or conceded claims],
+    "tensions": [defended claims with split positions],
+    "minority_reports": [agents who filed minority reports],
+    "execute_automatically": dqi >= 0.8 and no minority reports
+}
+```
+
+Post the synthesis to the kanban root card:
+```bash
+hermes kanban comment <root_card_id> "$(cat synthesis.json)"
+hermes kanban complete <root_card_id> --summary "DQI: <score>"
+```
+
+Report to the user:
+- Debate complete, DQI score and assessment
+- Whether auto-execute or human review needed
+- Any minority reports or tensions
+
+## Pitfalls
+
+### Agent returns malformed JSON
+Try `jq` parse first. On failure, extract JSON block via regex `/```json\n([\s\S]*?)\n```/`. On complete failure, treat as `confidence: 0, evidence_strength: speculative`.
+
+### Agent times out (≥600s)
+Continue with remaining 3 agents. Note the missing agent in synthesis. Recalculate DQI without their claims. If ≥2 agents fail, abort and inform the user.
+
+### False consensus (DQI > 0.9 after Round 1)
+May indicate groupthink. Optionally inject an adversarial probe round where each agent argues AGAINST their initial position before proceeding to Round 2.
+
+### Cross-profile project contamination
+Include in the context file:
+```markdown
+**WORKING DIRECTORY:** /home/user/projects/your-project
+**DO NOT** analyze files outside this directory.
+```
+
+### Round 2 rebuttals target wrong claim IDs
+The prompt enforces claim ID format (`<agent>-claim-<N>`) but agents may hallucinate IDs. Validate: if a rebuttal targets a non-existent ID, log it but skip weighting.
+
+## Verification
+
+After a debate completes, verify:
+1. All agent JSON files exist and parse: `ls round-*/<agent>.json`
+2. Round 2 rebuttals cite valid claim IDs (check transcript)
+3. DQI was calculated with the correct formula
+4. Synthesis includes consensus claims, tensions, and minority reports
+5. Kanban root card has the synthesis comment
+
+For a dry-run test without real agents, call the orchestrator script with a small context and inspect the output:
+```bash
+~/.hermes/skills/adversarial-debate/scripts/debate-orchestrator.sh \
+  --topic "Dry run test" \
+  --context-file <(echo "## Test context") \
+  --format feature \
+  --max-rounds 1
+```

--- a/optional-skills/software-development/adversarial-debate/references/DQI-FORMULA.md
+++ b/optional-skills/software-development/adversarial-debate/references/DQI-FORMULA.md
@@ -1,0 +1,40 @@
+# Decision Quality Index (DQI)
+
+## Formula
+
+```
+For each claim:
+  weight = confidence × evidence_multiplier × rebuttal_multiplier
+
+DQI = sum(weights) / count(weights)
+```
+
+### Evidence multipliers
+
+| Strength     | Multiplier |
+|--------------|------------|
+| direct       | 1.0        |
+| inferred     | 0.7        |
+| speculative  | 0.4        |
+
+### Rebuttal multipliers
+
+| Status      | Multiplier |
+|-------------|------------|
+| unrebutted  | 1.0        |
+| conceded    | 0.7        |
+| unresolved  | 0.5        |
+
+## Thresholds
+
+| DQI Range     | Assessment | Action                           |
+|---------------|------------|----------------------------------|
+| ≥ 0.8         | high       | Auto-execute (no minority report)|
+| 0.6 – 0.8     | moderate   | Human review flagged             |
+| < 0.6         | low        | Round 3 convergence required     |
+
+## Notes
+
+- Position changes (Round 2) do not enter the DQI formula directly but signal healthy debate.
+- If an agent produces no claims (timeout or error), they contribute zero weight, lowering DQI.
+- DQI ≥ 0.9 after Round 1 warrants a groupthink check — optionally inject adversarial probe round.

--- a/optional-skills/software-development/adversarial-debate/scripts/debate-orchestrator.sh
+++ b/optional-skills/software-development/adversarial-debate/scripts/debate-orchestrator.sh
@@ -1,0 +1,227 @@
+#!/usr/bin/env bash
+# debate-orchestrator.sh — CLI entry point for adversarial debates
+#
+# Installed by the adversarial-debate optional skill.
+# Usage:
+#   debate-orchestrator.sh --topic "..." --context-file <path> --format <rca|feature>
+#
+# This script provides a bash-level interface to the adversarial debate
+# protocol. It is intended for testing and CLI invocation. The primary
+# path is to load the skill in Hermes and follow the SKILL.md procedure.
+
+set -euo pipefail
+
+SKILL_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+TIMESTAMP=$(date +%s)
+DEBATE_ID="debate-${TIMESTAMP}"
+WORKSPACE="/tmp/hermes-debate-${DEBATE_ID}"
+TRANSCRIPT_FILE="${WORKSPACE}/transcript.json"
+SYNTHESIS_FILE="${WORKSPACE}/synthesis.json"
+AGENTS=("clio" "hephaestus" "solon" "talaria")
+MAX_ROUNDS=3
+DQI_THRESHOLD=0.6
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --topic) TOPIC="$2"; shift 2 ;;
+    --context-file) CONTEXT_FILE="$2"; shift 2 ;;
+    --format) FORMAT="$2"; shift 2 ;;
+    --max-rounds) MAX_ROUNDS="$2"; shift 2 ;;
+    --dqi-threshold) DQI_THRESHOLD="$2"; shift 2 ;;
+    *) echo "Unknown: $1"; exit 1 ;;
+  esac
+done
+
+: "${TOPIC:?--topic required}"
+: "${CONTEXT_FILE:?--context-file required}"
+: "${FORMAT:?--format required (rca|feature)}"
+
+echo "[debate] Starting: $TOPIC (format=$FORMAT, max_rounds=$MAX_ROUNDS)"
+
+mkdir -p "${WORKSPACE}/round-1" "${WORKSPACE}/round-2" "${WORKSPACE}/round-3"
+cp "$CONTEXT_FILE" "${WORKSPACE}/context.md"
+echo "{\"debate_id\":\"${DEBATE_ID}\",\"topic\":\"${TOPIC}\",\"format\":\"${FORMAT}\",\"rounds\":[],\"dqi\":null}" > "$TRANSCRIPT_FILE"
+
+spawn_agent() {
+  local agent="$1" round="$2" prompt_file="$3"
+  local output_file="${WORKSPACE}/round-${round}/${agent}.json"
+  local full_prompt
+  full_prompt=$(cat "$prompt_file")
+  full_prompt="${full_prompt//\{\{TOPIC\}\}/${TOPIC}}"
+  full_prompt="${full_prompt//\{\{FORMAT\}\}/${FORMAT}}"
+  full_prompt="${full_prompt//\{\{AGENT\}\}/${agent}}"
+  full_prompt="${full_prompt//\{\{ROUND\}\}/${round}}"
+
+  if [[ "$round" -gt 1 ]]; then
+    full_prompt+="\n\n## Prior Rounds Transcript\n\`\`\`json\n$(cat "$TRANSCRIPT_FILE")\n\`\`\`"
+  fi
+
+  echo "$full_prompt" > "${WORKSPACE}/round-${round}/${agent}-prompt.md"
+
+  hermes delegate-task \
+    --profile "$agent" \
+    --prompt "$(cat "${WORKSPACE}/round-${round}/${agent}-prompt.md")" \
+    --output-format json \
+    --timeout 600 \
+    2>"${WORKSPACE}/round-${round}/${agent}-stderr.log" \
+    > "$output_file" || {
+      local ec=$?
+      echo "{\"agent\":\"${agent}\",\"round\":${round},\"error\":\"exit_code_${ec}\",\"claims\":[]}" > "$output_file"
+    }
+  echo "[debate] ${agent} Round ${round} complete"
+}
+
+update_transcript() {
+  local round="$1"
+  python3 -c "
+import json
+with open('${TRANSCRIPT_FILE}') as f:
+    t = json.load(f)
+outputs = []
+for agent in ['clio', 'hephaestus', 'solon', 'talaria']:
+    f = '${WORKSPACE}/round-${round}/' + agent + '.json'
+    try:
+        with open(f) as fh:
+            outputs.append({'agent': agent, 'output': json.load(fh)})
+    except (FileNotFoundError, json.JSONDecodeError):
+        outputs.append({'agent': agent, 'output': {'error': 'missing', 'claims': []}})
+t['rounds'].append({'round': ${round}, 'outputs': outputs})
+with open('${TRANSCRIPT_FILE}', 'w') as f:
+    json.dump(t, f, indent=2)
+"
+}
+
+produce_synthesis() {
+  python3 << 'PYEOF'
+import json, os
+workspace = os.environ.get('WORKSPACE', '')
+with open(f'{workspace}/transcript.json') as f:
+    t = json.load(f)
+
+rounds_completed = len(t['rounds'])
+position_changes = sum(
+    1 for r in t['rounds']
+    for output in r.get('outputs', [])
+    if output.get('output', {}).get('position_changed')
+)
+
+consensus = []
+tensions = []
+minority_reports = []
+
+for r in t['rounds']:
+    for output in r.get('outputs', []):
+        o = output.get('output', {})
+        if r['round'] >= 3 and o.get('resolution') == 'minority_report':
+            minority_reports.append({
+                'agent': output['agent'],
+                'position': o.get('position', ''),
+                'rationale': o.get('minority_report', '')
+            })
+        for claim in o.get('claims', []):
+            rs = claim.get('rebuttal_status', 'unrebutted')
+            if rs in ('unrebutted', 'conceded'):
+                consensus.append(claim)
+            elif rs == 'defended':
+                tensions.append(claim)
+
+dqi = t.get('dqi', 0.0)
+synthesis = {
+    'debate_id': t['debate_id'],
+    'topic': t['topic'],
+    'format': t['format'],
+    'rounds_completed': rounds_completed,
+    'dqi': dqi,
+    'dqi_assessment': 'high' if dqi >= 0.8 else ('moderate' if dqi >= 0.6 else 'low'),
+    'position_changes': position_changes,
+    'consensus_claims': [{'id': c['id'], 'statement': c['statement']} for c in consensus],
+    'tensions': [{'id': c['id'], 'statement': c['statement']} for c in tensions],
+    'minority_reports': minority_reports,
+    'execute_automatically': dqi >= 0.8 and len(minority_reports) == 0
+}
+with open(f'{workspace}/synthesis.json', 'w') as f:
+    json.dump(synthesis, f, indent=2)
+print(json.dumps(synthesis, indent=2))
+PYEOF
+}
+
+# ── Main sequence ─────────────────────────────────────────────────────
+echo "[debate] Round 1 — Opening Statements"
+for agent in "${AGENTS[@]}"; do
+  spawn_agent "$agent" 1 "${SKILL_DIR}/templates/round-1-opening.md" &
+done
+wait
+update_transcript 1
+
+echo "[debate] Round 2 — Cross-Examination"
+for agent in "${AGENTS[@]}"; do
+  spawn_agent "$agent" 2 "${SKILL_DIR}/templates/round-2-cross-examination.md" &
+done
+wait
+update_transcript 2
+
+DQI_DATA=$(ROUND_NUM=2 WORKSPACE="$WORKSPACE" python3 -c "
+import json, os
+
+workspace = os.environ['WORKSPACE']
+round_num = int(os.environ.get('ROUND_NUM', '2'))
+
+with open(f'{workspace}/transcript.json') as f:
+    transcript = json.load(f)
+
+evidence_mult = {'direct': 1.0, 'inferred': 0.7, 'speculative': 0.4}
+rebuttal_mult = {'unrebutted': 1.0, 'conceded': 0.7, 'unresolved': 0.5}
+
+all_weights = []
+for r in transcript.get('rounds', []):
+    if r['round'] == round_num:
+        for output in r['outputs']:
+            for claim in output.get('output', {}).get('claims', []):
+                conf = claim.get('confidence', 50) / 100.0
+                ev = evidence_mult.get(claim.get('evidence_strength', 'speculative'), 0.4)
+                rb = rebuttal_mult.get(claim.get('rebuttal_status', 'unrebutted'), 1.0)
+                all_weights.append(conf * ev * rb)
+
+dqi = sum(all_weights) / len(all_weights) if all_weights else 0.0
+print(json.dumps({'dqi': round(dqi, 3), 'claim_count': len(all_weights)}))
+")
+DQI=$(echo "$DQI_DATA" | python3 -c "import sys,json; print(json.load(sys.stdin)['dqi'])")
+echo "[debate] DQI after Round 2: $DQI"
+
+python3 -c "import json; t=json.load(open('${TRANSCRIPT_FILE}')); t['dqi']=${DQI}; json.dump(t, open('${TRANSCRIPT_FILE}','w'), indent=2)"
+
+if (( $(echo "$DQI < $DQI_THRESHOLD" | bc -l) )) && [[ "$MAX_ROUNDS" -ge 3 ]]; then
+  echo "[debate] DQI < threshold — Round 3: Convergence"
+  for agent in "${AGENTS[@]}"; do
+    spawn_agent "$agent" 3 "${SKILL_DIR}/templates/round-3-convergence.md" &
+  done
+  wait
+  update_transcript 3
+  DQI_DATA=$(ROUND_NUM=3 WORKSPACE="$WORKSPACE" python3 -c "
+import json, os
+workspace = os.environ['WORKSPACE']
+with open(f'{workspace}/transcript.json') as f:
+    transcript = json.load(f)
+evidence_mult = {'direct': 1.0, 'inferred': 0.7, 'speculative': 0.4}
+rebuttal_mult = {'unrebutted': 1.0, 'conceded': 0.7, 'unresolved': 0.5}
+all_weights = []
+for r in transcript.get('rounds', []):
+    if r['round'] == 3:
+        for output in r['outputs']:
+            for claim in output.get('output', {}).get('claims', []):
+                conf = claim.get('confidence', 50) / 100.0
+                ev = evidence_mult.get(claim.get('evidence_strength', 'speculative'), 0.4)
+                rb = rebuttal_mult.get(claim.get('rebuttal_status', 'unrebutted'), 1.0)
+                all_weights.append(conf * ev * rb)
+dqi = sum(all_weights) / len(all_weights) if all_weights else 0.0
+print(json.dumps({'dqi': round(dqi, 3)}))
+")
+  DQI=$(echo "$DQI_DATA" | python3 -c "import sys,json; print(json.load(sys.stdin)['dqi'])")
+  echo "[debate] DQI after Round 3: $DQI"
+fi
+
+echo "[debate] Producing synthesis"
+produce_synthesis
+
+echo "[debate] Complete. Synthesis: $SYNTHESIS_FILE"
+echo "[debate] DQI: $DQI"

--- a/optional-skills/software-development/adversarial-debate/templates/round-1-opening.md
+++ b/optional-skills/software-development/adversarial-debate/templates/round-1-opening.md
@@ -1,0 +1,50 @@
+# Adversarial Debate — Round 1: Opening Statement
+
+You are **{{AGENT}}** participating in a structured adversarial debate.
+
+## Topic
+
+{{TOPIC}}
+
+## Format
+
+{{FORMAT}}
+
+## Instructions
+
+Construct your opening statement with the following strict JSON schema. Output ONLY valid JSON — no markdown, no commentary.
+
+```json
+{
+  "agent": "{{AGENT}}",
+  "round": 1,
+  "position": "<FOR | AGAINST | CONDITIONAL>",
+  "position_changed": false,
+  "claims": [
+    {
+      "id": "{{AGENT}}-claim-1",
+      "statement": "Short, falsifiable claim",
+      "evidence": "What evidence supports this claim",
+      "evidence_strength": "direct|inferred|speculative",
+      "confidence": 75
+    }
+  ],
+  "minority_report": null,
+  "resolution": null
+}
+```
+
+### Claim Rules
+
+1. Each claim must be **falsifiable** — capable of being proven wrong by evidence.
+2. At most 5 claims per agent per round.
+3. `evidence_strength`:
+   - `direct` = you have explicit data, code, docs, or test results
+   - `inferred` = derived from existing evidence but not directly cited
+   - `speculative` = logical reasoning without supporting data
+4. `confidence` = integer 0–100 representing how sure you are.
+5. Claims are indexed sequentially as `{{AGENT}}-claim-1` through `{{AGENT}}-claim-N` for cross-referencing in Round 2.
+
+### Context
+
+{{CONTEXT}}

--- a/optional-skills/software-development/adversarial-debate/templates/round-2-cross-examination.md
+++ b/optional-skills/software-development/adversarial-debate/templates/round-2-cross-examination.md
@@ -1,0 +1,68 @@
+# Adversarial Debate — Round 2: Cross-Examination
+
+You are **{{AGENT}}**. The full transcript from Round 1 is included below.
+
+## Instructions
+
+Read every claim from every other agent. For each claim you disagree with or find unsupported:
+
+1. **Rebutt** — cite the claim ID and explain why it is wrong, incomplete, or speculative.
+2. **Concede** — acknowledge claims by other agents that are well-supported.
+3. **Update your confidence** — may increase, decrease, or stay the same.
+4. **Optionally change position** — if evidence compels it, set `position_changed: true`.
+
+Output ONLY valid JSON following this schema:
+
+```json
+{
+  "agent": "{{AGENT}}",
+  "round": 2,
+  "position": "<FOR | AGAINST | CONDITIONAL>",
+  "position_changed": true,
+  "claims": [
+    {
+      "id": "{{AGENT}}-claim-1",
+      "statement": "Updated claim (keep original or refine)",
+      "evidence": "Same or updated evidence",
+      "evidence_strength": "direct|inferred|speculative",
+      "confidence": 80,
+      "rebuttal_status": "unrebutted|conceded|defended",
+      "rebuttal_of": null,
+      "rebuttal_notes": null
+    },
+    {
+      "id": "{{AGENT}}-claim-2",
+      "statement": "A new or refined claim",
+      "evidence": "Evidence",
+      "evidence_strength": "direct",
+      "confidence": 90,
+      "rebuttal_status": "unrebutted",
+      "rebuttal_of": "clio-claim-3",
+      "rebuttal_notes": "Clio's claim ignores the latency overhead of ..."
+    }
+  ],
+  "minority_report": null,
+  "resolution": null
+}
+```
+
+### Rebuttal Rules
+
+- `rebuttal_of` = the claim ID you are rebutting (or `null` for original claims).
+- `rebuttal_status`:
+  - `unrebutted` — this is your own claim that no one has challenged
+  - `conceded` — you accept another agent's rebuttal and lower your confidence
+  - `defended` — you maintain your position despite the rebuttal
+- Rebuttals MUST target valid claim IDs from Round 1 (format: `<agent>-claim-<N>`).
+
+### Context
+
+{{CONTEXT}}
+
+---
+
+## Prior Rounds Transcript
+
+```json
+{{TRANSCRIPT}}
+```

--- a/optional-skills/software-development/adversarial-debate/templates/round-3-convergence.md
+++ b/optional-skills/software-development/adversarial-debate/templates/round-3-convergence.md
@@ -1,0 +1,48 @@
+# Adversarial Debate — Round 3: Convergence
+
+You are **{{AGENT}}**. This is the final round. The DQI after Round 2 was below threshold — there are still unresolved disagreements.
+
+## Instructions
+
+Review all unresolved tensions (claims that were defended in Round 2). You MUST end with one of:
+
+- **accept** — you agree with the consensus path forward
+- **conditional_accept** — you accept if a specific condition is met
+- **minority_report** — you maintain your dissenting position with a written rationale
+
+Output ONLY valid JSON:
+
+```json
+{
+  "agent": "{{AGENT}}",
+  "round": 3,
+  "position": "<FOR | AGAINST | CONDITIONAL>",
+  "position_changed": true,
+  "claims": [
+    {
+      "id": "{{AGENT}}-claim-1",
+      "statement": "Refined final position",
+      "evidence": "Summary of best evidence",
+      "evidence_strength": "direct|inferred|speculative",
+      "confidence": 85,
+      "rebuttal_status": "unrebutted|conceded|defended",
+      "rebuttal_of": null,
+      "rebuttal_notes": null
+    }
+  ],
+  "minority_report": "<only if resolution=minority_report>",
+  "resolution": "accept|conditional_accept|minority_report"
+}
+```
+
+### Context
+
+{{CONTEXT}}
+
+---
+
+## Prior Rounds Transcript
+
+```json
+{{TRANSCRIPT}}
+```

--- a/optional-skills/software-development/adversarial-debate/templates/synthesis-schema.json
+++ b/optional-skills/software-development/adversarial-debate/templates/synthesis-schema.json
@@ -1,0 +1,53 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Adversarial Debate Synthesis",
+  "type": "object",
+  "required": [
+    "debate_id", "topic", "format",
+    "rounds_completed", "dqi", "dqi_assessment",
+    "position_changes",
+    "consensus_claims", "tensions",
+    "minority_reports", "execute_automatically"
+  ],
+  "properties": {
+    "debate_id": { "type": "string", "pattern": "^debate-\\d+$" },
+    "topic": { "type": "string" },
+    "format": { "type": "string", "enum": ["rca", "feature"] },
+    "rounds_completed": { "type": "integer", "minimum": 1, "maximum": 3 },
+    "dqi": { "type": "number", "minimum": 0, "maximum": 1 },
+    "dqi_assessment": { "type": "string", "enum": ["high", "moderate", "low"] },
+    "position_changes": { "type": "integer", "minimum": 0, "maximum": 4 },
+    "consensus_claims": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "id": { "type": "string" },
+          "statement": { "type": "string" }
+        }
+      }
+    },
+    "tensions": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "id": { "type": "string" },
+          "statement": { "type": "string" }
+        }
+      }
+    },
+    "minority_reports": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "agent": { "type": "string" },
+          "position": { "type": "string" },
+          "rationale": { "type": "string" }
+        }
+      }
+    },
+    "execute_automatically": { "type": "boolean" }
+  }
+}

--- a/optional-skills/software-development/team-of-thoughts/SKILL.md
+++ b/optional-skills/software-development/team-of-thoughts/SKILL.md
@@ -1,0 +1,332 @@
+---
+name: team-of-thoughts
+description: "Kanban-based multi-agent deliberation for RCA and feature design."
+version: 1.0.0
+author: Ramiz Mehran (ramizmehran) <mehranramiz93@gmail.com>
+license: MIT
+platforms: [linux, macos]
+metadata:
+  hermes:
+    tags: [kanban, multi-agent, deliberation, rca, feature-design, squad]
+    related_skills: [adversarial-debate, kanban-orchestrator, subagent-driven-development]
+    config:
+      delegation.max_concurrent_children: 4
+---
+
+# Team of Thoughts
+
+Multi-turn kanban debate across 4 agents (Clio, Hephaestus, Solon, Talaria) to lock an RCA or feature plan before handing off to a coding CLI. The default protocol for medium-stakes decisions where structured async review is sufficient.
+
+**Core principle:** Async kanban comments beat synchronous chat for routine deliberation. Each agent works independently, then Hermes synthesizes. For high-stakes irreversible decisions, see the `adversarial-debate` skill instead.
+
+## When to Use
+
+- A non-trivial bug needs rigorous RCA before coding
+- A feature has ≥2 defensible designs
+- The user wants the Squad to research, debate, and lock a plan before any code is written
+- **Deliverable validation:** Docs, scripts, or configs produced need cross-validation before shipping
+- The user explicitly asks for "team review", "run through ToT", or "ask the squad"
+
+### When NOT to use (use adversarial-debate instead)
+
+- The outcome has significant irreversible consequences (one-way door)
+- A previous kanban ToT produced weak or conflicting synthesis
+- The user explicitly asks for "full team debate", "adversarial review", or "cross-examine this"
+
+### Protocol selector
+
+| User says | Stakes | Protocol |
+|-----------|--------|----------|
+| "run through ToT" / "ask the team" | Low-medium | Kanban ToT (this skill) |
+| "full team debate" / "adversarial review" | High | Adversarial Debate (`adversarial-debate` skill) |
+
+## Prerequisites
+
+| Requirement | Notes |
+|-------------|-------|
+| Kanban CLI (`hermes kanban`) | Available in all Hermes installations |
+| Agent profiles | clio, hephaestus, solon, talaria must exist |
+| `delegation.max_concurrent_children` | ≥3 for parallel dispatch |
+
+## How to Run
+
+Load this skill in Hermes. Follow the Procedure below to bootstrap kanban cards, dispatch agents, and synthesize. The `scripts/tot-start.sh` helper can automate card creation.
+
+```bash
+~/.hermes/skills/team-of-thoughts/scripts/tot-start.sh \
+  "Topic" "rca|feature" "/path/to/project" "<optional-parent-task-id>"
+```
+
+## Quick Reference
+
+```
+0. Set working directory
+1. Bootstrap board (create root + child cards)
+2. Hermes opens the debate comment
+3. Prepare child cards (assign, unlink, promote)
+4. Dispatch agents (parallel rounds)
+5. Agents post findings as kanban_comments on root card
+6. Synthesis — locked plan comment on root card
+7. Execution hand-off via coding CLI
+```
+
+## Procedure
+
+### 0. Set the working directory
+
+All kanban commands must run from the project directory being debated:
+
+```bash
+cd /path/to/project
+hermes kanban boards  # verify active board
+```
+
+### 1. Bootstrap the board
+
+Create or switch to the correct kanban board:
+
+```bash
+hermes kanban boards create <slug> --name "Display Name" --description "..." --switch
+```
+
+Create the root card with rich context (goal, evidence, current state):
+
+```bash
+ROOT=$(hermes kanban create "ToT: <Topic>" \
+  --triage \
+  --body "Full context here" \
+  --json 2>&1 | python3 -c "import sys,json; print(json.load(sys.stdin)['id'])")
+echo "ROOT=$ROOT"
+```
+
+Create 4 child cards — one per agent — with `--assignee` so the dispatcher auto-claims:
+
+```bash
+hermes kanban create "🏛️ Clio: <Topic>" \
+  --body "**PERSPECTIVE:** Clio the historian — research and evidence grounding.
+
+**GOAL:** Investigate <topic> with questions:
+1. What already exists?
+2. What are the relevant patterns/docs?
+3. What evidence supports each approach?
+
+Post full findings as **kanban_comment** on root card $ROOT before completing." \
+  --assignee clio
+
+hermes kanban create "🔨 Hephaestus: <Topic>" \
+  --body "**PERSPECTIVE:** Hephaestus the builder — feasibility and integration cost.
+
+**GOAL:** Evaluate <topic> for:
+1. Implementation complexity
+2. Integration cost with existing code
+3. Testability and risk factors
+
+Post full findings as **kanban_comment** on root card $ROOT before completing." \
+  --assignee hephaestus
+
+hermes kanban create "⚖️ Solon: <Topic>" \
+  --body "**PERSPECTIVE:** Solon the strategist — trade-off analysis.
+
+**GOAL:** Analyze <topic> for:
+1. Trade-offs between approaches
+2. Long-term maintenance impact
+3. Strategic alignment
+
+Post full findings as **kanban_comment** on root card $ROOT before completing." \
+  --assignee solon
+
+hermes kanban create "✉️ Talaria: <Topic>" \
+  --body "**PERSPECTIVE:** Talaria the messenger — mechanical and UX lens.
+
+**GOAL:** Review <topic> for:
+1. User-facing impact and edge cases
+2. Naming conventions and consistency
+3. Small-scope improvements
+
+Post full findings as **kanban_comment** on root card $ROOT before completing." \
+  --assignee talaria
+```
+
+Cards created with `--assignee` land in `ready` status — the dispatcher may auto-claim them. Run a dispatch to catch any stragglers.
+
+Do NOT include implementation instructions (file paths, function signatures) in debate card bodies. Research cards investigate — they do not code.
+
+### 2. Hermes opens the debate
+
+Move the root card from `triage` to `running`:
+
+```bash
+hermes kanban specify <root-id>
+hermes kanban claim <root-id>
+```
+
+If `specify` fails with an LLM error, use SQLite to move directly to `ready`:
+
+```bash
+python3 -c "
+import sqlite3
+db = sqlite3.connect('$HOME/.hermes/kanban/boards/<board>/kanban.db')
+db.execute(\"UPDATE tasks SET status='ready' WHERE id='<root-id>'\")
+db.commit()
+db.close()
+"
+hermes kanban claim <root-id>
+```
+
+Post the opening debate comment on the root card naming the topic, expected output, and round count (default 2):
+
+```bash
+hermes kanban comment <root-id> "## Opening — <Topic>
+
+**Format:** <rca|feature>
+**Rounds:** 2
+**Expected output:** Locked plan with rationale and rejected alternatives."
+```
+
+### 3. Prepare child cards for dispatch
+
+Assign each child card to its agent profile:
+
+```bash
+hermes kanban assign <child-clio-id> clio
+hermes kanban assign <child-hephaestus-id> hephaestus
+hermes kanban assign <child-solon-id> solon
+hermes kanban assign <child-talaria-id> talaria
+```
+
+Promote children to `ready` (use `--force` if parent link blocks):
+
+```bash
+hermes kanban promote --force <child-clio-id>
+hermes kanban promote --force <child-hephaestus-id>
+hermes kanban promote --force <child-solon-id>
+hermes kanban promote --force <child-talaria-id>
+```
+
+If parent-child links block the dispatcher (claim rejects with `parents_not_done`), remove them:
+
+```bash
+hermes kanban unlink <root-id> <child-clio-id>
+hermes kanban unlink <root-id> <child-hephaestus-id>
+hermes kanban unlink <root-id> <child-solon-id>
+hermes kanban unlink <root-id> <child-talaria-id>
+```
+
+### 4. Dispatch agents (parallel rounds)
+
+```bash
+hermes kanban dispatch --max 4
+```
+
+For each round, each agent:
+- Reads all prior comments on the root card
+- Posts one `kanban_comment` with `### Round <N> — <Agent>` and their analysis
+- Does NOT execute code — only debates
+
+Run 2 rounds minimum for non-trivial tasks.
+
+To run subsequent rounds, post a Round 2 challenge comment on the root card summarizing Round 1 findings, then create new child cards for Round 2.
+
+### 5. Synthesis
+
+After all rounds complete, read all agent comments and write the synthesis:
+
+```bash
+hermes kanban comment <root-id> "$(cat << 'SYNTHESIS'
+### Synthesis — Locked Plan
+
+**Decision:** <final approach>
+
+**Rationale:** <why this approach wins>
+
+**Rejected alternatives:**
+- <alternative 1>: <why rejected>
+- <alternative 2>: <why rejected>
+
+**Execution plan:**
+- [ ] Task 1: <description>
+- [ ] Task 2: <description>
+- [ ] Task 3: <description>
+
+**Dependencies:** <any ordering constraints>
+SYNTHESIS
+)"
+```
+
+Complete the root card:
+
+```bash
+hermes kanban complete <root-id> --summary "Synthesis posted"
+```
+
+### 6. Execution hand-off
+
+Two valid paths:
+
+**Path A — Execution card (complex multi-step):**
+
+```bash
+hermes kanban create "Execute: <Topic>" \
+  --assignee hephaestus \
+  --body "Use synthesis from root card $ROOT. Implement all tasks."
+```
+
+**Path B — Direct CLI dispatch (single well-scoped fix):**
+
+Write a self-contained executor prompt from the synthesis and dispatch via the active coding CLI:
+
+```bash
+codex exec --sandbox danger-full-access "Read /tmp/plan.md and implement all changes."
+```
+
+**Rule of thumb:** If the fix touches >3 files or multiple components, use Path A. If single-component with exact code already drafted, Path B is faster.
+
+## Pitfalls
+
+### Parent-child link blocks dispatcher claim
+Even with `promote --force`, child cards with `--parent` links are rejected by the dispatcher at claim time (`parents_not_done`). Remove the parent link with `hermes kanban unlink <root-id> <child-id>` before dispatching. The card remains parented in the DB for display; only the dispatcher block is lifted.
+
+### Cross-profile project context contamination
+Agents dispatched in different profiles may have `environment_hint` or `terminal.cwd` pointing to a different project. Include explicit project context in every child card body:
+
+```markdown
+**IMPORTANT — WORK IN THIS PROJECT:** /path/to/correct/project
+**DO NOT** work in /other/project — that is a different project.
+```
+
+### Agents may not post comments to root cards automatically
+The kanban-worker skill handles card lifecycle (claim → work → complete) but does not enforce posting findings as `kanban_comment`. Every child card body MUST end with an explicit instruction:
+
+```markdown
+Post your full findings as a **kanban_comment** on root card <ROOT_ID> before completing.
+```
+
+### Root cards with `--triage` avoid auto-assignment
+Without `--triage`, root cards can be auto-assigned by `kanban.default_assignee` to a debate agent — that agent then tries to execute instead of synthesize. Always create root cards with `--triage`.
+
+### Dispatcher "Spawned: 0" output is unreliable
+The stdout count may not reflect actual spawning. Verify with `ps aux | grep "hermes.*task"` and `hermes kanban ls | grep <child-id>`.
+
+### Large card body causes `create` to hang
+For bodies >3000 chars, use two-step bootstrap: create with short placeholder, then add context as a `kanban_comment`.
+
+### No task gets dispatched without debate
+This is Rule #0. Always run the full ToT review before dispatching execution cards. If kanban creation fails, solve the obstacle — do not fall back to raw `delegate_task` for investigations.
+
+## Verification
+
+After a ToT cycle completes, verify:
+1. All 4 agents posted `kanban_comment`s on the root card
+2. A `### Synthesis — Locked Plan` comment exists with rationale and rejected alternatives
+3. Child cards show `done` status
+4. Root card shows `done` or was explicitly completed
+
+## References
+
+- `templates/rca-deliberation.md` — template for RCA-style debate
+- `templates/feature-deliberation.md` — template for feature-design debate
+- `templates/execution-prompt.md` — template for executor hand-off
+- `scripts/tot-start.sh` — helper script for card creation
+- `references/kanban-db-workarounds.md` — SQLite tricks for card status
+- `references/profile-context-contamination.md` — detecting project context leaks
+- Related: `adversarial-debate` skill for high-stakes synchronous debate

--- a/optional-skills/software-development/team-of-thoughts/references/kanban-db-workarounds.md
+++ b/optional-skills/software-development/team-of-thoughts/references/kanban-db-workarounds.md
@@ -1,0 +1,102 @@
+# Kanban DB Workarounds
+
+> SQLite queries for when the kanban CLI's LLM-backed commands (specify, decompose) fail with `BadRequestError`.
+
+## DB location
+
+```bash
+~/.hermes/kanban/boards/<board-slug>/kanban.db
+```
+
+Find the active board slug with:
+```bash
+hermes kanban boards
+```
+
+## Common workarounds
+
+### Move triage cards to todo (when `specify` fails)
+
+```python
+python3 -c "
+import sqlite3
+db = sqlite3.connect('$HOME/.hermes/kanban/boards/<board-slug>/kanban.db')
+db.execute(\"UPDATE tasks SET status='todo' WHERE status='triage'\")
+db.commit()
+db.close()
+"
+```
+
+### Check all cards and their status
+
+```python
+python3 -c "
+import sqlite3
+db = sqlite3.connect('$HOME/.hermes/kanban/boards/<board-slug>/kanban.db')
+db.row_factory = sqlite3.Row
+rows = db.execute('SELECT id, title, status, assignee FROM tasks ORDER BY id').fetchall()
+for r in rows:
+    print(f'{r[\"id\"]} | {r[\"status\"]:8s} | {r[\"assignee\"] or \"-\":12s} | {r[\"title\"][:70]}')
+db.close()
+"
+```
+
+### Promote a card via DB (when promote CLI fails)
+
+```python
+python3 -c "
+import sqlite3
+db = sqlite3.connect('$HOME/.hermes/kanban/boards/<board-slug>/kanban.db')
+db.execute(\"UPDATE tasks SET status='ready' WHERE id='<card-id>'\")
+db.commit()
+db.close()
+"
+```
+
+## Schema notes (relevant columns)
+
+| Column | Type | Values |
+|--------|------|--------|
+| id | TEXT | `t_<hex>` — the task ID used in CLI commands |
+| title | TEXT | Card title |
+| status | TEXT | `triage`, `todo`, `ready`, `running`, `blocked`, `done`, `archived` |
+| assignee | TEXT | Profile name or null |
+| parent_id | TEXT | Null for root cards, `t_<hex>` for children |
+| body | TEXT | Card description / opening post |
+| created_at | INTEGER | Unix timestamp |
+| completed_at | INTEGER | Unix timestamp or null |
+| priority | INTEGER | 0-9 for tiebreaking |
+| claim_lock | TEXT | Lock owner identifier or null |
+| claim_expires | INTEGER | Unix timestamp or null |
+| worker_pid | INTEGER | PID of running worker process or null |
+| current_run_id | INTEGER | Active run ID or null |
+| consecutive_failures | INTEGER | Failure count (reset to 0 on success) |
+| last_failure_error | TEXT | Last error message or null |
+| started_at | INTEGER | Unix timestamp or null |
+
+## When to use these workarounds
+
+- **`hermes kanban specify` fails** → `BadRequestError` means the LLM behind it errored. Use the triage→todo DB update.
+- **`hermes kanban decompose` fails** → Same LLM error. Manually create child cards with `hermes kanban create --parent <id>` instead.
+- **`hermes kanban promote` blocks on dependency** → Use `--force` flag first (preferred). Only use DB update when `--force` also fails.
+- **Need bulk promote** → DB update is faster than 9 separate CLI calls for promoting multiple cards at once.
+
+### Reset stuck `running` cards (after killing worker processes)
+
+When you kill a kanban worker process (e.g. because it was using the wrong executor), the card stays in `running` status with stale lock/PID. There is no `hermes kanban release` command. Use this:
+
+```python
+python3 -c "
+import sqlite3
+db = sqlite3.connect('$HOME/.hermes/kanban/boards/<board-slug>/kanban.db')
+for card_id in ['<card-1>', '<card-2>']:
+    db.execute('''UPDATE tasks SET status='ready', claim_lock=NULL, claim_expires=NULL, worker_pid=NULL, current_run_id=NULL, started_at=NULL, consecutive_failures=0, last_failure_error=NULL WHERE id=?''', (card_id,))
+    print(f'Reset {card_id} to ready')
+db.commit()
+db.close()
+"
+```
+
+**When to use:** After `kill -9 <pid>` on a kanban worker, or when a card is stuck in `running` with no active process. Always verify with `ps aux | grep <pid>` that the process is truly dead before resetting.
+
+Do NOT use DB workarounds for anything that has a working CLI equivalent (create, archive, comment). Reserve them strictly for LLM-backed commands that fail, stuck cards, or bulk operations.

--- a/optional-skills/software-development/team-of-thoughts/references/profile-context-contamination.md
+++ b/optional-skills/software-development/team-of-thoughts/references/profile-context-contamination.md
@@ -1,0 +1,76 @@
+# Profile Context Contamination
+
+> How profile `environment_hint` / `terminal.cwd` settings cause debate agents to analyze the wrong project, and how to prevent it.
+
+## The problem
+
+Some Hermes profiles (especially `hephaestus` and `talaria`) carry an `environment_hint` in their `config.yaml` that tells the agent which project it works in. For example:
+
+```yaml
+# ~/.hermes/profiles/hephaestus/config.yaml
+agent:
+  environment_hint: |
+    DELEGATION RULE — ABSOLUTE AND NON-NEGOTIABLE:
+    You work in /path/to/project.
+```
+
+When the kanban dispatcher spawns a subagent in this profile, the `environment_hint` injects the wrong project path into the agent's system prompt. The agent reads files from the wrong project. The `clio` profile typically has no such hint and works correctly.
+
+## Symptoms
+
+| Symptom | Looks like | Real issue |
+|---------|-----------|------------|
+| Wrong stack mentioned | "Reviewed Hono + tRPC + Drizzle" | Target project uses Go + sqlx + PostgreSQL |
+| Wrong repo output | Execution cards with wrong `workspace: dir @` path | Agent thinks that is the current project |
+| "No X code exists" | "No <project> code exists in the repo" | Agent is looking at the wrong repo — the code actually exists |
+| Wrong framework bugs | "Add toast notifications for tRPC" | Target project uses REST/axios, not tRPC |
+
+## Detection
+
+Before dispatching debate agents, check which profiles have environment hints:
+
+```bash
+grep -l "environment_hint" ~/.hermes/profiles/*/config.yaml
+```
+
+For each profile found, check what project the hint points to:
+
+```bash
+grep -A5 "environment_hint" ~/.hermes/profiles/hephaestus/config.yaml
+grep -A5 "environment_hint" ~/.hermes/profiles/talaria/config.yaml
+```
+
+If the hint points to a different project than the one being debated, you need the override.
+
+## Fix
+
+Override the profile's `environment_hint` by embedding explicit project instructions in the child card body:
+
+```markdown
+**IMPORTANT — WORK IN THIS PROJECT:** /home/user/projects/correct-project
+**DO NOT** work in /other/project — that is a different project.
+
+**ACTIONS:**
+1. ... (all actions scoped to the correct project)
+```
+
+Place this at the very top of the card `--body`, before any role-specific instructions. The instruction overrides whatever `environment_hint` the profile injected.
+
+## Which profiles are affected
+
+| Profile | Usually affected? | Why |
+|---------|-----------------|-----|
+| `clio` | Rarely | Research profile, no delegation-rule hints; works on whatever the card tells it to |
+| `hephaestus` | Often | Orchestrator profile with project-specific delegation rules in `environment_hint` |
+| `talaria` | Often | Executor profile with project-specific delegation rules in `environment_hint` |
+
+## Permanent fix
+
+For dedicated single-project setups, update the profile's `environment_hint` to match the correct project:
+
+```bash
+hermes config set --profile hephaestus agent.environment_hint "DELEGATION RULE ..."
+hermes config set --profile talaria agent.environment_hint "... same ..."
+```
+
+For multi-project setups, the card-body override approach is the only option.

--- a/optional-skills/software-development/team-of-thoughts/scripts/tot-start.sh
+++ b/optional-skills/software-development/team-of-thoughts/scripts/tot-start.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+TITLE="${1:?usage: tot-start.sh <title> <rca|feature> <project-root> [parent-task-id]}"
+TYPE="${2:?usage: tot-start.sh <title> <rca|feature> <project-root> [parent-task-id]}"
+PROJECT_ROOT="${3:?usage: tot-start.sh <title> <rca|feature> <project-root> [parent-task-id]}"
+PARENT="${4:-}"
+
+BODY=$(printf 'Type: %s\nProject: %s' "$TYPE" "$PROJECT_ROOT")
+
+PARENT_ARGS=()
+if [[ -n "$PARENT" ]]; then
+  PARENT_ARGS=(--parent "$PARENT")
+fi
+
+ROOT_OUT=$(hermes kanban create "ToT: $TITLE" --assignee default --body "$BODY" --triage "${PARENT_ARGS[@]}")
+ROOT_ID=$(echo "$ROOT_OUT" | grep -oE 't_[a-f0-9]+')
+
+echo "Root card: $ROOT_ID"
+
+for role in clio hephaestus solon talaria; do
+  hermes kanban create \
+    "ToT debate — $role — $TITLE" \
+    --assignee "$role" \
+    --body "Participate in the Team-of-Thoughts debate on root card $ROOT_ID. Read all prior comments, then post one comment per round. No code." \
+    --parent "$ROOT_ID" >/dev/null
+  echo "Created $role debate card"
+done

--- a/optional-skills/software-development/team-of-thoughts/templates/execution-prompt.md
+++ b/optional-skills/software-development/team-of-thoughts/templates/execution-prompt.md
@@ -1,0 +1,27 @@
+# Locked Plan — Execute with {{EXECUTOR}}
+
+## Project root
+{{PROJECT_ROOT}}
+
+## Locked plan
+{{LOCKED_PLAN}}
+
+## Instructions
+
+You are implementing the locked plan above. This plan was debated and approved by a multi-agent team (Clio, Hephaestus, Talaria). Treat it as the authoritative specification.
+
+### Execution guidelines
+1. **Read the locked plan carefully** — every task item must be addressed.
+2. **Read existing code BEFORE writing** — check how auth, middleware, imports, and data access work in the current codebase.
+3. **Implement file by file** — make changes incrementally, not in one giant dump.
+4. **Build after every meaningful change** — run the project's build/compile command BEFORE committing.
+5. **Do not deviate from the plan** without explicit human approval.
+6. **If you hit an unexpected blocker**, document it clearly and continue with what you can.
+7. **Verify referenced symbols exist** — search first, then use.
+
+### Completion
+When done, produce a summary with:
+- Files changed (list each with what was done)
+- Tests run and their results
+- Any blockers or deviations from the plan
+- A confidence assessment: [DONE] / [PARTIAL] / [BLOCKED]

--- a/optional-skills/software-development/team-of-thoughts/templates/feature-deliberation.md
+++ b/optional-skills/software-development/team-of-thoughts/templates/feature-deliberation.md
@@ -1,0 +1,20 @@
+# Feature Deliberation: {{TITLE}}
+
+## Context
+{{ROOT_CARD_BODY}}
+
+## Your job
+You are part of a Team-of-Thoughts design debate. Do NOT write code. Post one `kanban_comment` per round.
+
+### Round {{ROUND}}
+- Argue for or against the leading design option.
+- Cite trade-offs: coupling, performance, operational cost, testing effort, external dependencies.
+- Propose concrete alternatives if you disagree.
+- Address the previous round's strongest objection.
+
+## Output format
+### Round {{ROUND}} — {{ROLE}}
+- Position:
+- Rationale:
+- Risks / mitigations:
+- Requested changes to emerging plan:

--- a/optional-skills/software-development/team-of-thoughts/templates/rca-deliberation.md
+++ b/optional-skills/software-development/team-of-thoughts/templates/rca-deliberation.md
@@ -1,0 +1,20 @@
+# RCA Deliberation: {{TITLE}}
+
+## Context
+{{ROOT_CARD_BODY}}
+
+## Your job
+You are part of a Team-of-Thoughts RCA. Do NOT write code. Post one `kanban_comment` per round.
+
+### Round {{ROUND}}
+- State what you believe is the most likely root cause (or rank candidates).
+- Cite concrete evidence: log lines, file paths, config values, external docs.
+- Flag what is still uncertain and what would falsify your hypothesis.
+- If another agent's prior round contradicts yours, address it directly.
+
+## Output format
+### Round {{ROUND}} — {{ROLE}}
+- Hypothesis:
+- Evidence:
+- Concerns / open questions:
+- Requested changes to emerging plan:

--- a/tests/skills/test_adversarial_debate_skill.py
+++ b/tests/skills/test_adversarial_debate_skill.py
@@ -1,0 +1,169 @@
+"""
+Smoke tests for the adversarial-debate optional skill.
+
+Verifies:
+  - SKILL.md frontmatter conforms to hardline format (description ≤60 chars)
+  - All template files exist and contain valid JSON schemas
+  - Template JSON is parseable and matches the expected schema
+  - DQI calculation is deterministic and correct
+"""
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+import pytest
+import yaml
+
+SKILL_DIR = (
+    Path(__file__).resolve().parents[2]
+    / "optional-skills"
+    / "software-development"
+    / "adversarial-debate"
+)
+
+
+@pytest.fixture(scope="module")
+def frontmatter() -> dict:
+    src = (SKILL_DIR / "SKILL.md").read_text()
+    m = re.search(r"^---\n(.*?)\n---", src, re.DOTALL)
+    assert m, "SKILL.md missing YAML frontmatter"
+    return yaml.safe_load(m.group(1))
+
+
+# ── Frontmatter checks ────────────────────────────────────────────────
+
+
+def test_skill_dir_exists() -> None:
+    assert SKILL_DIR.is_dir()
+
+
+def test_skill_md_present() -> None:
+    assert (SKILL_DIR / "SKILL.md").is_file()
+
+
+def test_description_under_60_chars(frontmatter) -> None:
+    desc = frontmatter["description"]
+    assert len(desc) <= 60, f"description is {len(desc)} chars (hardline ≤60): {desc!r}"
+
+
+def test_version_present(frontmatter) -> None:
+    assert "version" in frontmatter, "missing version"
+
+
+def test_author_present(frontmatter) -> None:
+    assert "author" in frontmatter, "missing author"
+
+
+def test_license_is_mit(frontmatter) -> None:
+    assert frontmatter.get("license") == "MIT"
+
+
+def test_platforms_defined(frontmatter) -> None:
+    assert "platforms" in frontmatter
+    assert isinstance(frontmatter["platforms"], list)
+    assert len(frontmatter["platforms"]) > 0
+
+
+def test_hermes_metadata_tags(frontmatter) -> None:
+    meta = frontmatter.get("metadata", {}).get("hermes", {})
+    assert "tags" in meta, "missing metadata.hermes.tags"
+    assert isinstance(meta["tags"], list)
+    assert len(meta["tags"]) >= 3
+
+
+def test_hermes_metadata_related_skills(frontmatter) -> None:
+    meta = frontmatter.get("metadata", {}).get("hermes", {})
+    assert "related_skills" in meta, "missing metadata.hermes.related_skills"
+
+
+# ── File existence checks ─────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "rel_path",
+    [
+        "templates/round-1-opening.md",
+        "templates/round-2-cross-examination.md",
+        "templates/round-3-convergence.md",
+        "templates/synthesis-schema.json",
+        "scripts/debate-orchestrator.sh",
+    ],
+)
+def test_required_file_exists(rel_path: str) -> None:
+    assert (SKILL_DIR / rel_path).is_file(), f"missing: {rel_path}"
+
+
+# ── JSON schema validation ────────────────────────────────────────────
+
+
+def test_synthesis_schema_is_valid_json() -> None:
+    path = SKILL_DIR / "templates" / "synthesis-schema.json"
+    schema = json.loads(path.read_text())
+    assert "$schema" in schema
+    assert "properties" in schema
+    assert "required" in schema
+
+
+def test_synthesis_schema_required_fields() -> None:
+    path = SKILL_DIR / "templates" / "synthesis-schema.json"
+    schema = json.loads(path.read_text())
+    required = set(schema["required"])
+    expected = {
+        "debate_id", "topic", "format",
+        "rounds_completed", "dqi", "dqi_assessment",
+        "position_changes",
+        "consensus_claims", "tensions",
+        "minority_reports", "execute_automatically",
+    }
+    missing = expected - required
+    assert not missing, f"Schema missing required fields: {missing}"
+
+
+# ── DQI calculation correctness ───────────────────────────────────────
+
+
+def _calculate_dqi(claims: list[dict]) -> float:
+    evidence_mult = {"direct": 1.0, "inferred": 0.7, "speculative": 0.4}
+    rebuttal_mult = {"unrebutted": 1.0, "conceded": 0.7, "unresolved": 0.5}
+    weights = []
+    for c in claims:
+        conf = c.get("confidence", 50) / 100.0
+        ev = evidence_mult.get(c.get("evidence_strength", "speculative"), 0.4)
+        rb = rebuttal_mult.get(c.get("rebuttal_status", "unrebutted"), 1.0)
+        weights.append(conf * ev * rb)
+    return sum(weights) / len(weights) if weights else 0.0
+
+
+def test_dqi_all_direct_unrebutted() -> None:
+    claims = [
+        {"confidence": 90, "evidence_strength": "direct", "rebuttal_status": "unrebutted"},
+        {"confidence": 80, "evidence_strength": "direct", "rebuttal_status": "unrebutted"},
+    ]
+    dqi = _calculate_dqi(claims)
+    expected = (0.9 * 1.0 * 1.0 + 0.8 * 1.0 * 1.0) / 2
+    assert dqi == pytest.approx(expected)
+
+
+def test_dqi_mixed_evidence_rebuttals() -> None:
+    claims = [
+        {"confidence": 100, "evidence_strength": "direct", "rebuttal_status": "unrebutted"},
+        {"confidence": 50, "evidence_strength": "speculative", "rebuttal_status": "conceded"},
+    ]
+    dqi = _calculate_dqi(claims)
+    expected = (1.0 * 1.0 * 1.0 + 0.5 * 0.4 * 0.7) / 2
+    assert dqi == pytest.approx(expected)
+
+
+def test_dqi_all_speculative_defended() -> None:
+    claims = [
+        {"confidence": 70, "evidence_strength": "speculative", "rebuttal_status": "defended"},
+    ]
+    dqi = _calculate_dqi(claims)
+    expected = 0.7 * 0.4 * 1.0  # defended = unrebutted in this model
+    assert dqi == pytest.approx(expected)
+
+
+def test_dqi_empty_claims() -> None:
+    assert _calculate_dqi([]) == 0.0


### PR DESCRIPTION
## Summary

Adds a new optional skill: **team-of-thoughts** — a kanban-based multi-agent deliberation protocol for RCA and feature design, using async kanban comments for structured agent review.

## What it does

Orchestrates a multi-turn kanban debate among Clio, Hephaestus, Solon, and Talaria to lock an RCA or feature plan before handing off to a coding CLI. The default protocol for medium-stakes decisions where structured async review is sufficient.

Pairs with the `adversarial-debate` skill (PR #47694): the SKILL.md includes a protocol selector table that routes low-medium stakes to kanban ToT and high-stakes to synchronous adversarial debate.

### Files

| Path | Purpose |
|------|---------|
| `SKILL.md` | Full orchestration workflow (bootstrap → debate → synthesis → execution) |
| `scripts/tot-start.sh` | CLI helper for card creation |
| `templates/rca-deliberation.md` | Template for RCA-style debate prompts |
| `templates/feature-deliberation.md` | Template for feature-design debate prompts |
| `templates/execution-prompt.md` | Template for executor hand-off |
| `references/kanban-db-workarounds.md` | SQLite workarounds for card status issues |
| `references/profile-context-contamination.md` | Detecting and preventing cross-project agent confusion |

## Quality

- Description: 55 chars (hardline ≤60 ✓)
- Frontmatter: `version`, `author`, `license: MIT`, `platforms: [linux, macos]`, `metadata.hermes.*`
- Section order per dev guide ✓
- General-purpose — all AutoGC-specific references cleaned before contribution
- References `adversarial-debate` as the high-stakes protocol alternative