### PR TITLE
fix(kanban): restrict selected dashboard dispatches

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -6035,6 +6035,7 @@ def dispatch_once(
     board: Optional[str] = None,
     default_assignee: Optional[str] = None,
     max_in_progress_per_profile: Optional[int] = None,
+    selected_task_ids: Optional[list[str]] = None,
 ) -> DispatchResult:
     """Run one dispatcher tick.
 
@@ -6063,6 +6064,9 @@ def dispatch_once(
     ``spawn_fn`` defaults to ``_default_spawn``. Tests pass a stub.
     ``board`` pins workspace/log/db resolution for this tick to a specific
     board. When omitted, the current-board resolution chain is used.
+    ``selected_task_ids`` is a closed-world operator fence: when provided,
+    only those task ids are considered for ready/review spawning. Extra ready
+    tasks are not fallback candidates even if capacity remains.
     """
     # Reap zombie children from previously spawned workers. See
     # reap_worker_zombies() for the full rationale.
@@ -6108,11 +6112,25 @@ def dispatch_once(
             ).fetchone()[0]
         )
 
+    selected_order: Optional[dict[str, int]] = None
+    selected_set: Optional[set[str]] = None
+    if selected_task_ids is not None:
+        selected_order = {}
+        for raw_id in selected_task_ids:
+            tid = str(raw_id or "").strip()
+            if tid and tid not in selected_order:
+                selected_order[tid] = len(selected_order)
+        selected_set = set(selected_order.keys())
+
     ready_rows = conn.execute(
         "SELECT id, assignee FROM tasks "
         "WHERE status = 'ready' AND claim_lock IS NULL "
         "ORDER BY priority DESC, created_at ASC"
     ).fetchall()
+    if selected_set is not None:
+        ready_rows = [row for row in ready_rows if row["id"] in selected_set]
+        _selected_order = selected_order or {}
+        ready_rows.sort(key=lambda row: _selected_order.get(row["id"], 10**9))
     # Honour kanban.max_in_progress: if the board already has enough running
     # tasks, skip spawning this tick so slow workers (local LLMs,
     # resource-constrained hosts) can finish what they have before more tasks
@@ -6349,6 +6367,10 @@ def dispatch_once(
         "WHERE status = 'review' AND claim_lock IS NULL "
         "ORDER BY priority DESC, created_at ASC"
     ).fetchall()
+    if selected_set is not None:
+        review_rows = [row for row in review_rows if row["id"] in selected_set]
+        _selected_order = selected_order or {}
+        review_rows.sort(key=lambda row: _selected_order.get(row["id"], 10**9))
     for row in review_rows:
         if max_spawn is not None and running_count + spawned >= max_spawn:
             break

--- a/plugins/kanban/dashboard/dist/index.js
+++ b/plugins/kanban/dashboard/dist/index.js
@@ -1013,7 +1013,13 @@
           laneByProfile, setLaneByProfile,
           search, setSearch,
           onNudgeDispatch: function () {
-            SDK.fetchJSON(withBoard(`${API}/dispatch?max=8`, board), { method: "POST" })
+            const ids = Array.from(selectedIds);
+            const options = { method: "POST" };
+            if (ids.length > 0) {
+              options.headers = { "Content-Type": "application/json" };
+              options.body = JSON.stringify({ taskIds: ids });
+            }
+            SDK.fetchJSON(withBoard(`${API}/dispatch?max=8`, board), options)
               .then(loadBoard)
               .catch(function (e) { setError(String(e.message || e)); });
           },

--- a/plugins/kanban/dashboard/plugin_api.py
+++ b/plugins/kanban/dashboard/plugin_api.py
@@ -38,6 +38,7 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+import re
 import sqlite3
 import time
 from dataclasses import asdict
@@ -1951,23 +1952,59 @@ def get_task_log(
 # Dispatch nudge (optional quick-path so the UI doesn't wait 60 s)
 # ---------------------------------------------------------------------------
 
+class DispatchBody(BaseModel):
+    # Accept both JS-style and Python-style keys so dashboard bundles,
+    # curl probes, and future CLI adapters can share the endpoint.
+    taskIds: list[str] = Field(default_factory=list)
+    task_ids: list[str] = Field(default_factory=list)
+
+
+def _parse_task_ids(raw: Optional[str]) -> list[str]:
+    if not raw or not isinstance(raw, str):
+        return []
+    seen: set[str] = set()
+    out: list[str] = []
+    for item in re.split(r"[\s,]+", raw):
+        tid = item.strip()
+        if tid and tid not in seen:
+            seen.add(tid)
+            out.append(tid)
+    return out
+
 @router.post("/dispatch")
 def dispatch(
+    payload: Optional[DispatchBody] = None,
     dry_run: bool = Query(False),
     max_n: int = Query(8, alias="max"),
     board: Optional[str] = Query(None),
+    task_ids: Optional[str] = Query(None),
 ):
     board = _resolve_board(board)
+    query_task_ids = task_ids if isinstance(task_ids, str) else None
+    selected_was_requested = payload is not None or query_task_ids is not None
+    selected_task_ids = _parse_task_ids(query_task_ids)
+    if payload is not None:
+        for raw_id in [*payload.taskIds, *payload.task_ids]:
+            tid = str(raw_id or "").strip()
+            if tid and tid not in selected_task_ids:
+                selected_task_ids.append(tid)
     conn = _conn(board=board)
     try:
         result = kanban_db.dispatch_once(
-            conn, dry_run=dry_run, max_spawn=max_n, board=board,
+            conn,
+            dry_run=dry_run,
+            max_spawn=max_n,
+            board=board,
+            selected_task_ids=selected_task_ids if selected_was_requested else None,
         )
         # DispatchResult is a dataclass.
         try:
-            return asdict(result)
+            body: dict[str, Any] = asdict(result)
         except TypeError:
-            return {"result": str(result)}
+            body = {"result": str(result)}
+        body["selectedOnly"] = selected_was_requested
+        body["selectedTaskIds"] = selected_task_ids
+        return body
     finally:
         conn.close()
 

--- a/tests/hermes_cli/test_kanban_dispatch_selected.py
+++ b/tests/hermes_cli/test_kanban_dispatch_selected.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+import os
+import sys
+import tempfile
+
+import pytest
+
+
+@pytest.fixture()
+def isolated_kanban_home_with_profiles(monkeypatch):
+    test_home = tempfile.mkdtemp(prefix="kanban_selected_dispatch_test_")
+    for prof in ("alpha", "beta", "default"):
+        os.makedirs(os.path.join(test_home, "profiles", prof), exist_ok=True)
+    monkeypatch.setenv("HERMES_HOME", test_home)
+    for mod in list(sys.modules.keys()):
+        if mod.startswith("hermes_cli") or mod.startswith("hermes_state") or mod == "hermes_constants":
+            del sys.modules[mod]
+    from hermes_cli import kanban_db
+    yield kanban_db
+
+
+def _fake_spawn(*args, **kwargs):
+    return 12345
+
+
+def test_dispatch_once_selected_task_ids_only_spawns_requested_ready_tasks(isolated_kanban_home_with_profiles):
+    """Manual dashboard nudge with selected rows is closed-world.
+
+    Even with extra ready tasks and a larger max_spawn cap, dispatch_once must
+    only consider the operator-selected task IDs.
+    """
+    kb = isolated_kanban_home_with_profiles
+    with kb.connect_closing() as conn:
+        kb.create_board(slug="default", name="Test")
+        unselected_early = kb.create_task(conn, title="unselected early", assignee="alpha", priority=10)
+        selected_one = kb.create_task(conn, title="selected one", assignee="alpha", priority=1)
+        selected_two = kb.create_task(conn, title="selected two", assignee="beta", priority=1)
+        unselected_late = kb.create_task(conn, title="unselected late", assignee="beta", priority=9)
+
+    with kb.connect_closing() as conn:
+        res = kb.dispatch_once(
+            conn,
+            spawn_fn=_fake_spawn,
+            dry_run=True,
+            max_spawn=8,
+            selected_task_ids=[selected_one, selected_two],
+        )
+
+    assert [tid for tid, _assignee, _workspace in res.spawned] == [selected_one, selected_two]
+    assert unselected_early not in [tid for tid, _assignee, _workspace in res.spawned]
+    assert unselected_late not in [tid for tid, _assignee, _workspace in res.spawned]
+
+
+def test_dispatch_once_selected_task_ids_do_not_fallback_when_selected_is_unspawnable(isolated_kanban_home_with_profiles):
+    """If a selected task cannot spawn, unselected ready tasks are not substitutes."""
+    kb = isolated_kanban_home_with_profiles
+    with kb.connect_closing() as conn:
+        kb.create_board(slug="default", name="Test")
+        selected_unassigned = kb.create_task(conn, title="selected unassigned", assignee=None, priority=10)
+        unselected_spawnable = kb.create_task(conn, title="unselected spawnable", assignee="alpha", priority=1)
+
+    with kb.connect_closing() as conn:
+        res = kb.dispatch_once(
+            conn,
+            spawn_fn=_fake_spawn,
+            dry_run=True,
+            max_spawn=8,
+            selected_task_ids=[selected_unassigned],
+        )
+
+    assert res.spawned == []
+    assert selected_unassigned in res.skipped_unassigned
+    assert unselected_spawnable not in res.skipped_unassigned

--- a/tests/plugins/test_kanban_dashboard_dispatch_selected.py
+++ b/tests/plugins/test_kanban_dashboard_dispatch_selected.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+
+def test_dashboard_dispatch_passes_selected_task_ids_to_dispatch_once(monkeypatch):
+    from plugins.kanban.dashboard import plugin_api
+    from hermes_cli import kanban_db
+
+    captured = {}
+
+    class FakeConn:
+        def close(self):
+            captured['closed'] = True
+
+    monkeypatch.setattr(plugin_api, '_resolve_board', lambda board: board)
+    monkeypatch.setattr(plugin_api, '_conn', lambda board=None: FakeConn())
+
+    def fake_dispatch_once(conn, **kwargs):
+        captured.update(kwargs)
+        return kanban_db.DispatchResult(spawned=[('t_selected_1', 'alpha', '')])
+
+    monkeypatch.setattr(plugin_api.kanban_db, 'dispatch_once', fake_dispatch_once)
+
+    result = plugin_api.dispatch(
+        payload=plugin_api.DispatchBody(taskIds=['t_selected_1', 't_selected_2']),
+        dry_run=True,
+        max_n=8,
+        board='north-star',
+    )
+
+    assert captured['selected_task_ids'] == ['t_selected_1', 't_selected_2']
+    assert captured['dry_run'] is True
+    assert captured['max_spawn'] == 8
+    assert captured['board'] == 'north-star'
+    assert captured['closed'] is True
+    assert result['selectedOnly'] is True
+    assert result['selectedTaskIds'] == ['t_selected_1', 't_selected_2']
+
+
+def test_dashboard_dispatch_without_selection_preserves_generic_nudge(monkeypatch):
+    from plugins.kanban.dashboard import plugin_api
+    from hermes_cli import kanban_db
+
+    captured = {}
+
+    class FakeConn:
+        def close(self):
+            pass
+
+    monkeypatch.setattr(plugin_api, '_resolve_board', lambda board: board)
+    monkeypatch.setattr(plugin_api, '_conn', lambda board=None: FakeConn())
+
+    def fake_dispatch_once(conn, **kwargs):
+        captured.update(kwargs)
+        return kanban_db.DispatchResult()
+
+    monkeypatch.setattr(plugin_api.kanban_db, 'dispatch_once', fake_dispatch_once)
+
+    result = plugin_api.dispatch(payload=None, dry_run=False, max_n=8, board='north-star')
+
+    assert captured['selected_task_ids'] is None
+    assert result['selectedOnly'] is False
+    assert result['selectedTaskIds'] == []


### PR DESCRIPTION
## Summary
- Treat dashboard-selected task IDs as a closed-world dispatch allowlist.
- Send checked Kanban rows from the dashboard nudge action to the dispatch API.
- Preserve generic nudge behavior when no rows are selected.

## Test plan
- [x] `./venv/bin/python -m pytest tests/hermes_cli/test_kanban_per_profile_cap.py tests/hermes_cli/test_kanban_cli_dispatch_passthrough.py tests/hermes_cli/test_kanban_dispatch_selected.py tests/plugins/test_kanban_dashboard_dispatch_selected.py -q -o 'addopts='`
- [x] `./venv/bin/python -m py_compile hermes_cli/kanban_db.py plugins/kanban/dashboard/plugin_api.py`
- [x] `node --check plugins/kanban/dashboard/dist/index.js`

🤖 Generated with [Claude Code](https://claude.com/claude-code)