### PR TITLE
feat(desktop): profile badge and active-status indicator in sidebar

### DIFF
--- a/.plans/feat-sidebar-profile-badge-active-status.md
+++ b/.plans/feat-sidebar-profile-badge-active-status.md
@@ -1,0 +1,89 @@
+# feat(desktop): profile badge + active-status indicator in session sidebar
+
+## What
+
+Adds two visual indicators to each session row in the Hermes Desktop left sidebar,
+making it easy to tell at a glance **which profile** a session belongs to and
+**whether it is actively running**:
+
+### 1. Profile badge (All-profiles view only)
+
+A compact, color-coded chip appears between the status dot and the session title
+whenever the sidebar is in "All-profiles" mode (the fan-out view that shows
+every profile's sessions together).
+
+```
+● W  Fix auth bug                  🟢
+  G  Q3 planning doc
+● P  Research vacation spots
+```
+
+- Each named profile gets a **deterministic color** derived from its name (same
+  palette as the profile-rail squares in the sidebar footer).
+- The chip shows the profile's **first character** in uppercase.
+- Hovering reveals a tooltip: `Profile: work`.
+- Default/root profile sessions show **no badge** (they're clearly marked in
+  the group header when browsing all profiles, and always unambiguous in the
+  scoped view).
+- In single-profile or scoped-to-one-profile mode the badge is entirely hidden,
+  so existing users see **zero visual change**.
+
+### 2. Active status indicator (already present, documented here)
+
+The status dot (`SidebarRowDot`) was already implemented and covers:
+- **Idle**: small gray dot
+- **Needs user input**: amber steady dot with a quest-glow ring
+- **Running**: accent-colored pulsing dot + arc-border on the row
+
+This PR does not modify the status indicator — it documents that the feature
+request for "active status" is already covered by the existing dot system.
+
+## Why
+
+When browsing sessions across multiple profiles in the "All profiles" view, the
+list reads as a flat sequence with no visual grouping cue at the row level.
+The profile group headers tell you which group you're currently inside, but once
+the list is long and groups collapse, individual rows lose their profile context.
+A per-row badge restores instant glanceability without adding noise to single-
+or scoped-profile views.
+
+## Files changed
+
+| File | Change |
+|---|---|
+| `apps/desktop/src/app/chat/sidebar/session-row.tsx` | `ProfileBadge` component + `showProfileBadge` prop on `SidebarSessionRow` |
+| `apps/desktop/src/app/chat/sidebar/index.tsx` | `showProfileBadge` added to `SidebarSessionsSectionProps`; passed to search and pinned sections when `showAllProfiles` is true |
+| `apps/desktop/src/app/chat/sidebar/virtual-session-list.tsx` | `showProfileBadge` threaded through the virtual + sortable rows |
+| `apps/desktop/src/i18n/en.ts` | `sidebar.row.profileBadge` i18n key |
+
+## Design decisions
+
+- **Badge only in All-profiles view.** In the scoped view the rail square and
+  group header already provide full context. Adding a badge there would be
+  redundant and noisy for the common case.
+- **Chip, not full label.** A 1-character chip with color is the minimum
+  sufficient disambiguator — long profile names would steal width from the
+  session title on narrow sidebars.
+- **Same color source as the rail.** `profileColor()` + `profileColorSoft()`
+  are reused unchanged so badge color always matches the rail square for the
+  same profile. No new color logic.
+- **Default profile = no badge.** The "default" key intentionally returns
+  `null` from `profileColor()`, matching the existing no-color-for-default
+  convention throughout the UI.
+
+## How to verify
+
+1. Create two or more profiles (`+` in the sidebar rail).
+2. Start at least one session under each profile.
+3. Click the **layers icon** (Show all profiles) in the rail footer.
+4. Sessions from named profiles now show a small colored chip (first letter)
+   between the status dot and the title.
+5. Hover a chip → tooltip reads "Profile: <name>".
+6. Scoped back to one profile (click its square) → badges gone.
+7. Running sessions still show the accent pulsing dot; sessions waiting on input
+   show the amber quest-glow dot — no regression.
+
+## Platforms
+
+- Desktop GUI only (this feature is `comp/tui` + `comp/desktop`).
+- No gateway / CLI changes.

--- a/apps/desktop/src/app/chat/sidebar/index.tsx
+++ b/apps/desktop/src/app/chat/sidebar/index.tsx
@@ -907,6 +907,7 @@ export function ChatSidebar({
                 pinned={false}
                 rootClassName="min-h-32 flex-1 overflow-hidden p-0"
                 sessions={searchResults}
+                showProfileBadge={showAllProfiles}
                 workingSessionIdSet={workingSessionIdSet}
               />
             )}
@@ -928,6 +929,7 @@ export function ChatSidebar({
                 pinned
                 rootClassName="shrink-0 p-0 pb-1"
                 sessions={pinnedSessions}
+                showProfileBadge={showAllProfiles}
                 sortable={pinnedSessions.length > 1}
                 workingSessionIdSet={workingSessionIdSet}
               />
@@ -1193,6 +1195,8 @@ interface SidebarSessionsSectionProps {
   onReorderParents?: (ids: string[]) => void
   onReorderWorktree?: (parentId: string, ids: string[]) => void
   dndSensors?: ReturnType<typeof useSensors>
+  /** Show a color-coded profile badge on each row. For pinned & search in All-profiles view. */
+  showProfileBadge?: boolean
 }
 
 function SidebarSessionsSection({
@@ -1222,7 +1226,8 @@ function SidebarSessionsSection({
   onReorderSessions,
   onReorderParents,
   onReorderWorktree,
-  dndSensors
+  dndSensors,
+  showProfileBadge = false
 }: SidebarSessionsSectionProps) {
   const hasTreeSessions = Boolean(tree?.some(parent => parent.sessionCount > 0))
   const hasGroupedSessions = Boolean(groups?.some(group => group.sessions.length > 0))
@@ -1240,7 +1245,8 @@ function SidebarSessionsSection({
       onDelete: () => onDeleteSession(session.id),
       onPin: () => onTogglePin(sessionPinId(session)),
       onResume: () => onResumeSession(session.id),
-      session
+      session,
+      showProfileBadge
     }
 
     return draggable ? (
@@ -1304,6 +1310,7 @@ function SidebarSessionsSection({
         onTogglePin={onTogglePin}
         pinned={pinned}
         sessions={sessions}
+        showProfileBadge={showProfileBadge}
         sortable={sessionsDraggable}
         workingSessionIdSet={workingSessionIdSet}
       />

--- a/apps/desktop/src/app/chat/sidebar/session-row.tsx
+++ b/apps/desktop/src/app/chat/sidebar/session-row.tsx
@@ -10,6 +10,7 @@ import type { SessionInfo } from '@/hermes'
 import { type Translations, useI18n } from '@/i18n'
 import { sessionTitle } from '@/lib/chat-runtime'
 import { triggerHaptic } from '@/lib/haptics'
+import { profileColor, profileColorSoft } from '@/lib/profile-color'
 import { handoffOriginSource, sessionSourceLabel } from '@/lib/session-source'
 import { cn } from '@/lib/utils'
 import { $attentionSessionIds } from '@/store/session'
@@ -26,6 +27,8 @@ interface SidebarSessionRowProps extends React.ComponentProps<'div'> {
   onDelete: () => void
   onPin: () => void
   onResume: () => void
+  /** Show a profile-colored badge next to the dot. Only in the All-profiles flat view. */
+  showProfileBadge?: boolean
   reorderable?: boolean
   dragging?: boolean
   dragHandleProps?: React.HTMLAttributes<HTMLElement>
@@ -58,6 +61,7 @@ export function SidebarSessionRow({
   onDelete,
   onPin,
   onResume,
+  showProfileBadge = false,
   reorderable = false,
   dragging = false,
   dragHandleProps,
@@ -203,6 +207,9 @@ export function SidebarSessionRow({
               />
             </Tip>
           ) : null}
+          {showProfileBadge && session.profile && (
+            <ProfileBadge profile={session.profile} />
+          )}
           <span className="min-w-0 flex-1 truncate text-[0.8125rem] font-normal text-(--ui-text-secondary) group-hover:text-foreground group-data-[working=true]:text-foreground/90">
             {title}
           </span>
@@ -237,6 +244,42 @@ export function SidebarSessionRow({
     </SessionContextMenu>
   )
 }
+
+// ---------------------------------------------------------------------------
+// Profile badge — shown per-row only in the All-profiles flat view
+// ---------------------------------------------------------------------------
+
+function ProfileBadge({ profile }: { profile: null | string | undefined }) {
+  const { t } = useI18n()
+  const key = (profile ?? '').trim()
+
+  if (!key || key === 'default') {
+    return null
+  }
+
+  const color = profileColor(key)
+  const initial = key.replace(/[^a-z0-9]/gi, '').charAt(0).toUpperCase() || '?'
+  const label = t.sidebar.row.profileBadge(key)
+
+  return (
+    <Tip label={label}>
+      <span
+        aria-label={label}
+        className="shrink-0 select-none rounded-[3px] px-1 py-px text-[0.5625rem] font-semibold uppercase leading-none"
+        style={{
+          backgroundColor: color ? profileColorSoft(color, 22) : 'color-mix(in srgb, currentColor 10%, transparent)',
+          color: color ?? undefined
+        }}
+      >
+        {initial}
+      </span>
+    </Tip>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Dot status indicator
+// ---------------------------------------------------------------------------
 
 function SidebarRowDot({
   isWorking,

--- a/apps/desktop/src/app/chat/sidebar/virtual-session-list.tsx
+++ b/apps/desktop/src/app/chat/sidebar/virtual-session-list.tsx
@@ -28,6 +28,7 @@ interface VirtualSessionListProps {
   onTogglePin: (sessionId: string) => void
   pinned: boolean
   sessions: SessionInfo[]
+  showProfileBadge?: boolean
   sortable: boolean
   workingSessionIdSet: Set<string>
 }
@@ -44,6 +45,7 @@ export const VirtualSessionList: FC<VirtualSessionListProps> = ({
   onTogglePin,
   pinned,
   sessions,
+  showProfileBadge = false,
   sortable,
   workingSessionIdSet
 }) => {
@@ -88,6 +90,7 @@ export const VirtualSessionList: FC<VirtualSessionListProps> = ({
         measureRef={virtualizer.measureElement}
         rowProps={commonProps}
         session={session}
+        showProfileBadge={showProfileBadge}
       />
     ) : (
       <SidebarSessionRow
@@ -96,6 +99,7 @@ export const VirtualSessionList: FC<VirtualSessionListProps> = ({
         key={session.id}
         ref={virtualizer.measureElement}
         session={session}
+        showProfileBadge={showProfileBadge}
       />
     )
   })
@@ -117,9 +121,10 @@ interface VirtualSortableRowProps {
   measureRef: (node: Element | null) => void
   rowProps: SessionRowCommonProps
   session: SessionInfo
+  showProfileBadge?: boolean
 }
 
-function VirtualSortableRow({ index, measureRef, rowProps, session }: VirtualSortableRowProps) {
+function VirtualSortableRow({ index, measureRef, rowProps, session, showProfileBadge = false }: VirtualSortableRowProps) {
   const { attributes, isDragging, listeners, setNodeRef, transform, transition } = useSortable({ id: session.id })
 
   // Merge dnd-kit's setNodeRef with the virtualizer's measureElement so
@@ -142,6 +147,7 @@ function VirtualSortableRow({ index, measureRef, rowProps, session }: VirtualSor
       ref={refMerged}
       reorderable
       session={session}
+      showProfileBadge={showProfileBadge}
       style={{ transform: CSS.Transform.toString(transform), transition }}
     />
   )

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -1194,7 +1194,8 @@ export const en: Translations = {
       ageNow: 'now',
       ageDay: 'd',
       ageHour: 'h',
-      ageMin: 'm'
+      ageMin: 'm',
+      profileBadge: (name: string) => `Profile: ${name}`
     }
   },
 

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -1323,7 +1323,8 @@ export const ja = defineLocale({
       ageNow: 'たった今',
       ageDay: '日',
       ageHour: '時間',
-      ageMin: '分'
+      ageMin: '分',
+      profileBadge: (name: string) => `プロファイル：${name}`
     }
   },
 

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -923,6 +923,7 @@ export interface Translations {
       ageDay: string
       ageHour: string
       ageMin: string
+      profileBadge: (name: string) => string
     }
   }
 

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -1277,7 +1277,8 @@ export const zhHant = defineLocale({
       ageNow: '剛才',
       ageDay: '天',
       ageHour: '時',
-      ageMin: '分'
+      ageMin: '分',
+      profileBadge: (name: string) => `設定檔：${name}`
     }
   },
 

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -1381,7 +1381,8 @@ export const zh: Translations = {
       ageNow: '刚刚',
       ageDay: '天',
       ageHour: '时',
-      ageMin: '分'
+      ageMin: '分',
+      profileBadge: (name: string) => `配置档案：${name}`
     }
   },
 


### PR DESCRIPTION
When the sidebar is in All-profiles mode, each session row now shows a compact, color-coded profile badge (first letter of the profile name) between the status dot and the session title.  The badge uses the same deterministic color from profileColor() that the sidebar rail squares already use, so the same profile always reads the same color.

Hovering the badge shows a tooltip: Profile: <name>.  The default profile produces no badge (consistent with its neutral rail treatment).

In single-profile or scoped-to-one-profile mode the badge is completely absent, so existing users see zero visual change.

The active-status dot (SidebarRowDot) already covered the 'running', 'needs input', and 'idle' states; no changes to that component.

Files changed:
- session-row.tsx: ProfileBadge component + showProfileBadge prop
- index.tsx: prop wired through SidebarSessionsSectionProps; passed to search-results and pinned sections when showAllProfiles is true
- virtual-session-list.tsx: prop threaded to virtual and sortable rows
- i18n/en.ts: sidebar.row.profileBadge key

Closes #feat/sidebar-profile-badge-active-status

## What does this PR do?

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->



## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Fixes #

## Type of Change

<!-- Check the one that applies. -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- 

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. 
2. 
3. 

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [ ] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

<!-- Only fill this out if you're adding a skill. Delete this section otherwise. -->

- [ ] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [ ] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

