### PR TITLE
fix(curator): protect external_dirs skills from curator LLM agent mutations

### DIFF
--- a/agent/curator.py
+++ b/agent/curator.py
@@ -358,6 +358,11 @@ CURATOR_REVIEW_PROMPT = (
     "Hard rules — do not violate:\n"
     "1. DO NOT touch bundled or hub-installed skills. The candidate list "
     "below is already filtered to agent-created skills only.\n"
+    "1b. DO NOT touch any skill that lives in a ``skills.external_dirs`` "
+    "directory — those skills are user-managed, often version-controlled, "
+    "and treated as externally owned. The candidate list below excludes "
+    "them, and attempting to reach them via ``terminal`` or ``skills_list`` "
+    "is forbidden.\n"
     "2. DO NOT delete any skill. Archiving (moving the skill's directory "
     "into ~/.hermes/skills/.archive/) is the maximum destructive action. "
     "Archives are recoverable; deletion is not.\n"
@@ -1400,6 +1405,15 @@ def _render_candidate_list() -> str:
             f"view={r.get('view_count', 0)}  "
             f"patches={r.get('patch_count', 0)}  "
             f"last_activity={r.get('last_activity_at') or 'never'}"
+        )
+    # GH-47688: note that external_dirs skills are excluded from the candidate list.
+    from agent.skill_utils import get_external_skills_dirs
+    ext_dirs = get_external_skills_dirs()
+    if ext_dirs:
+        dirs_str = ", ".join(str(d) for d in ext_dirs)
+        lines.append(
+            f"\nNote: skills in external_dirs ({dirs_str}) are not listed — "
+            "they are user-managed and excluded from curation."
         )
     return "\n".join(lines)
 

--- a/tools/skill_usage.py
+++ b/tools/skill_usage.py
@@ -428,6 +428,34 @@ def is_bundled(skill_name: str) -> bool:
     return skill_name in _read_bundled_manifest_names()
 
 
+def is_external_skill(skill_name: str) -> bool:
+    """Whether *skill_name* lives under a ``skills.external_dirs`` directory.
+
+    Skills in external dirs are user-managed, often version-controlled, and
+    MUST be treated as read-only by the curator — the curator must never
+    archive, consolidate, edit, or delete them in place.
+    """
+    from agent.skill_utils import get_external_skills_dirs, is_excluded_skill_path
+
+    external_dirs = get_external_skills_dirs()
+    if not external_dirs:
+        return False
+
+    for ext_dir in external_dirs:
+        for skill_md in ext_dir.rglob("SKILL.md"):
+            if is_excluded_skill_path(skill_md):
+                continue
+            try:
+                text = skill_md.read_text(encoding="utf-8", errors="replace")[:4000]
+                import re
+                m = re.search(r"^name:\s*(.+)$", text, re.MULTILINE)
+                if m and m.group(1).strip() == skill_name:
+                    return True
+            except OSError:
+                continue
+    return False
+
+
 def is_curation_eligible(skill_name: str) -> bool:
     """Whether the curator may track/archive *skill_name*.
 
@@ -436,6 +464,8 @@ def is_curation_eligible(skill_name: str) -> bool:
     NEVER eligible — they have an external upstream owner. Protected built-ins
     (``PROTECTED_BUILTIN_SKILLS``) are NEVER eligible regardless of any flag —
     they back load-bearing UX and must never be archived or consolidated.
+    Skills residing in ``skills.external_dirs`` are NEVER eligible — they are
+    user-managed and the curator must not touch them (see ``is_external_skill``).
     """
     if is_protected_builtin(skill_name):
         return False
@@ -443,6 +473,9 @@ def is_curation_eligible(skill_name: str) -> bool:
         return False
     if is_bundled(skill_name):
         return _prune_builtins_enabled()
+    # GH-47688: external_dirs skills are user-managed — curator must not touch them.
+    if is_external_skill(skill_name):
+        return False
     return True
 
 
@@ -685,6 +718,12 @@ def archive_skill(skill_name: str) -> Tuple[bool, str]:
             )
         if is_hub_installed(skill_name):
             return False, f"skill '{skill_name}' is hub-installed; never archive"
+        # GH-47688: external_dirs skills are user-managed — curator must not touch them.
+        if is_external_skill(skill_name):
+            return False, (
+                f"skill '{skill_name}' lives in skills.external_dirs and is "
+                "user-managed; the curator never archives external skills"
+            )
         return False, (
             f"skill '{skill_name}' is a bundled built-in; enable "
             "curator.prune_builtins to allow pruning it"


### PR DESCRIPTION
## Summary

The curator's LLM consolidation agent can discover and mutate skills living in `skills.external_dirs` via the `skills_list` and `terminal` tools, even though the automatic sweep path correctly ignores them. This causes recurring, silent data loss from user-managed (often version-controlled) skill directories.

## Changes

1. **`tools/skill_usage.py`**: Add `is_external_skill()` predicate that checks whether a skill name maps to a directory under any `skills.external_dirs` path.
2. **`tools/skill_usage.py`**: Gate `is_curation_eligible()` for external skills — they are now never eligible for curator operations.
3. **`tools/skill_usage.py`**: Add explicit refusal in `archive_skill()` with a clear error message when called on an external skill.
4. **`agent/curator.py`**: Add rule 1b to `CURATOR_REVIEW_PROMPT` forbidding the LLM agent from touching `external_dirs` skills, with an explicit prohibition against reaching them via `terminal` or `skills_list`.
5. **`agent/curator.py`**: Add a note in `_render_candidate_list()` informing the LLM that `external_dirs` skills exist but are excluded from curation.

## Test plan

- Verified compilation: `python3 -m py_compile tools/skill_usage.py` and `python3 -m py_compile agent/curator.py` both pass.
- Existing test suite should continue to pass since no existing behavior is changed for non-external skills — all new code paths are additive guards.

Closes #47688
