### PR TITLE
feat(telegram): generic script-button dispatcher via config

### DIFF
--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -522,25 +522,40 @@ class TelegramAdapter(BasePlatformAdapter):
     def _load_button_handlers(self) -> None:
         """Load script-button handlers from platforms.telegram.extra.button_handlers.
 
-        Each entry maps a prefix (used in callback data) to a handler config::
+        ``button_handlers`` is a LIST of handler entries; each entry carries a
+        ``prefix`` (used in callback data), a ``script`` path, and an
+        ``actions`` map of verb → label::
 
             button_handlers:
-              news_action:
+              - prefix: na
                 script: ~/.hermes/scripts/news_action_button_handler.py
-                prefix: na
                 actions:
                   st: Story
-                  x: 𝕏
+                  x: "𝕏"
 
-        On dispatch a callback ``na:st:42`` matches prefix ``na``, looks up
-        handler ``news_action``, extracts verb ``st`` and arg ``42``, and
-        spawns ``script --action st --action-id 42``.
+        On dispatch a callback ``na:st:42`` matches prefix ``na``, extracts
+        verb ``st`` and arg ``42``, and spawns
+        ``script --action st --action-id 42``. Entries without a ``prefix`` are
+        skipped with a warning.
+
+        Built-in callback prefixes take precedence and must be avoided. The
+        bare model-picker tokens ``mb`` and ``mx`` match without a trailing
+        colon, so any prefix starting with ``mb`` or ``mx`` (e.g. ``mboard``)
+        is silently shadowed by the model picker; such entries are skipped
+        with a warning.
         """
         raw: List[Dict[str, Any]] = self.config.extra.get("button_handlers", [])
         for entry in raw:
             prefix = entry.get("prefix")
             if not prefix:
                 logger.warning("[%s] button_handler missing 'prefix', skipping: %s", self.name, entry)
+                continue
+            if prefix.startswith(("mb", "mx")):
+                logger.warning(
+                    "[%s] button_handler prefix %r is shadowed by the built-in "
+                    "model picker (mb/mx), skipping",
+                    self.name, prefix,
+                )
                 continue
             self._button_handlers[prefix] = entry
 
@@ -4005,29 +4020,6 @@ class TelegramAdapter(BasePlatformAdapter):
                 await self._handle_model_picker_callback(query, data, chat_id)
             return
 
-        # --- Generic script-button callbacks (<prefix>:<verb>:<arg>) ---
-        for prefix, handler in self._button_handlers.items():
-            if data.startswith(prefix + ":"):
-                parts = data.split(":", 2)
-                if len(parts) == 3:
-                    verb, arg = parts[1], parts[2]
-                    # reply_to and thread from the prompt message that carries
-                    # the button keyboard
-                    prompt_message_id = getattr(query.message, "reply_to_message", None)
-                    prompt_message_id = getattr(prompt_message_id, "message_id", None)
-                    asyncio.create_task(
-                        self._run_script_button(
-                            handler,
-                            verb,
-                            arg,
-                            str(query_chat_id),
-                            reply_to_message_id=str(prompt_message_id) if prompt_message_id is not None else None,
-                            thread_id=str(query_thread_id) if query_thread_id is not None else None,
-                        )
-                    )
-                    await query.answer()
-                return
-
         # --- Gmail-triage callbacks (gt:verb:arg) ---
         if data.startswith("gt:"):
             await self._handle_gmail_triage_callback(
@@ -4314,6 +4306,52 @@ class TelegramAdapter(BasePlatformAdapter):
                         "Telegram clarify button: resolve_gateway_clarify returned False (id=%s)",
                         clarify_id,
                     )
+            return
+
+        # --- Generic script-button callbacks (<prefix>:<verb>:<arg>) ---
+        # Placed AFTER all built-in prefix handlers so those always take
+        # precedence — a configured prefix can never shadow gt:/ea:/sc:/cl:/etc.
+        for prefix, handler in self._button_handlers.items():
+            if not data.startswith(prefix + ":"):
+                continue
+            parts = data.split(":", 2)
+            if len(parts) != 3:
+                # Malformed callback data: still answer to clear the spinner.
+                await query.answer()
+                return
+            verb, arg = parts[1], parts[2]
+            # Only authorized users may spawn handler scripts.
+            caller_id = str(getattr(query.from_user, "id", ""))
+            if not self._is_callback_user_authorized(
+                caller_id,
+                chat_id=query_chat_id,
+                chat_type=str(query_chat_type) if query_chat_type is not None else None,
+                thread_id=str(query_thread_id) if query_thread_id is not None else None,
+                user_name=query_user_name,
+            ):
+                await query.answer(text="⛔ You are not authorized to use this action.")
+                return
+            # Verb allow-list: only dispatch verbs the handler declares.
+            if verb not in handler.get("actions", {}):
+                await query.answer(text="Unknown action.")
+                return
+            # reply_to and thread from the prompt message that carries the
+            # button keyboard.
+            prompt_message_id = getattr(query.message, "reply_to_message", None)
+            prompt_message_id = getattr(prompt_message_id, "message_id", None)
+            task = asyncio.create_task(
+                self._run_script_button(
+                    handler,
+                    verb,
+                    arg,
+                    str(query_chat_id),
+                    reply_to_message_id=str(prompt_message_id) if prompt_message_id is not None else None,
+                    thread_id=str(query_thread_id) if query_thread_id is not None else None,
+                )
+            )
+            self._background_tasks.add(task)
+            task.add_done_callback(self._background_tasks.discard)
+            await query.answer()
             return
 
         # --- Update prompt callbacks ---

--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -513,6 +513,36 @@ class TelegramAdapter(BasePlatformAdapter):
         # Tracks status bubbles owned by this adapter so subsequent calls with the
         # same key edit the same message instead of appending new ones (#30045).
         self._status_message_ids: Dict[tuple, str] = {}
+        # DM Topics config from extra.dm_topics
+        self._dm_topics_config: List[Dict[str, Any]] = self.config.extra.get("dm_topics", [])
+        # Generic script-button handlers: prefix → {script, actions: {verb → label}}
+        self._button_handlers: Dict[str, dict] = {}
+        self._load_button_handlers()
+
+    def _load_button_handlers(self) -> None:
+        """Load script-button handlers from platforms.telegram.extra.button_handlers.
+
+        Each entry maps a prefix (used in callback data) to a handler config::
+
+            button_handlers:
+              news_action:
+                script: ~/.hermes/scripts/news_action_button_handler.py
+                prefix: na
+                actions:
+                  st: Story
+                  x: 𝕏
+
+        On dispatch a callback ``na:st:42`` matches prefix ``na``, looks up
+        handler ``news_action``, extracts verb ``st`` and arg ``42``, and
+        spawns ``script --action st --action-id 42``.
+        """
+        raw: List[Dict[str, Any]] = self.config.extra.get("button_handlers", [])
+        for entry in raw:
+            prefix = entry.get("prefix")
+            if not prefix:
+                logger.warning("[%s] button_handler missing 'prefix', skipping: %s", self.name, entry)
+                continue
+            self._button_handlers[prefix] = entry
 
     def _notification_kwargs(
         self, metadata: Optional[Dict[str, Any]]
@@ -3873,6 +3903,86 @@ class TelegramAdapter(BasePlatformAdapter):
             # Catch-all (e.g. page counter button "mx:noop")
             await query.answer()
 
+    async def _run_script_button(
+        self,
+        handler: dict,
+        verb: str,
+        arg: str,
+        chat_id: str,
+        reply_to_message_id: Optional[str] = None,
+        thread_id: Optional[str] = None,
+    ) -> None:
+        """Run a generic script-button handler out-of-band.
+
+        ``handler`` is the button_handlers entry from config, e.g.::
+
+            {
+              "script": "~/.hermes/scripts/news_action_button_handler.py",
+              "actions": {"st": "Story", "x": "𝕏", ...}
+            }
+
+        The script receives at least: ``--action <verb> --action-id <arg>``.
+        Additional per-dispatch context (chat_id, thread, reply_to) is always
+        appended so the script can route its reply correctly.
+        """
+        script = os.path.expanduser(handler.get("script", ""))
+        if not script:
+            logger.error("[%s] script-button handler has no script path: %s", self.name, handler)
+            return
+
+        actions: dict = handler.get("actions", {})
+        label = actions.get(verb, verb)
+
+        cmd = [
+            sys.executable,
+            script,
+            "--action",
+            verb,
+            "--action-id",
+            arg,
+            "--chat-id",
+            str(chat_id),
+        ]
+        if reply_to_message_id is not None:
+            cmd.extend(["--reply-to-message-id", str(reply_to_message_id)])
+        if thread_id is not None:
+            cmd.extend(["--thread-id", str(thread_id)])
+
+        try:
+            proc = await asyncio.create_subprocess_exec(
+                *cmd,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+            )
+            stdout, stderr = await proc.communicate()
+            if proc.returncode != 0:
+                err = (stderr or stdout or b"").decode("utf-8", errors="replace")[-1800:]
+                logger.error("[%s] script-button %s failed (%s %s): %s", self.name, label, verb, arg, err)
+                if self._bot:
+                    await self._send_message_with_thread_fallback(
+                        chat_id=int(chat_id),
+                        text=f"⚠️ {label} failed for `{arg}`:\n\n{err}",
+                        parse_mode=None,
+                        reply_to_message_id=int(reply_to_message_id) if reply_to_message_id else None,
+                        **({"message_thread_id": int(thread_id)} if thread_id else {}),
+                    )
+                return
+            out = stdout.decode("utf-8", errors="replace").strip()
+            logger.info("[%s] script-button %s completed (%s %s): %s", self.name, label, verb, arg, out)
+        except Exception as exc:
+            logger.error("[%s] script-button %s crashed (%s %s): %s", self.name, label, verb, arg, exc, exc_info=True)
+            if self._bot:
+                try:
+                    await self._send_message_with_thread_fallback(
+                        chat_id=int(chat_id),
+                        text=f"⚠️ {label} crashed for `{arg}`: {exc}",
+                        parse_mode=None,
+                        reply_to_message_id=int(reply_to_message_id) if reply_to_message_id else None,
+                        **({"message_thread_id": int(thread_id)} if thread_id else {}),
+                    )
+                except Exception:
+                    pass
+
     async def _handle_callback_query(
         self, update: "Update", context: "ContextTypes.DEFAULT_TYPE"
     ) -> None:
@@ -3894,6 +4004,29 @@ class TelegramAdapter(BasePlatformAdapter):
             if chat_id:
                 await self._handle_model_picker_callback(query, data, chat_id)
             return
+
+        # --- Generic script-button callbacks (<prefix>:<verb>:<arg>) ---
+        for prefix, handler in self._button_handlers.items():
+            if data.startswith(prefix + ":"):
+                parts = data.split(":", 2)
+                if len(parts) == 3:
+                    verb, arg = parts[1], parts[2]
+                    # reply_to and thread from the prompt message that carries
+                    # the button keyboard
+                    prompt_message_id = getattr(query.message, "reply_to_message", None)
+                    prompt_message_id = getattr(prompt_message_id, "message_id", None)
+                    asyncio.create_task(
+                        self._run_script_button(
+                            handler,
+                            verb,
+                            arg,
+                            str(query_chat_id),
+                            reply_to_message_id=str(prompt_message_id) if prompt_message_id is not None else None,
+                            thread_id=str(query_thread_id) if query_thread_id is not None else None,
+                        )
+                    )
+                    await query.answer()
+                return
 
         # --- Gmail-triage callbacks (gt:verb:arg) ---
         if data.startswith("gt:"):

--- a/tests/gateway/test_telegram_script_button.py
+++ b/tests/gateway/test_telegram_script_button.py
@@ -1,0 +1,395 @@
+"""Tests for the generic script-button dispatcher on the Telegram adapter.
+
+Covers _load_button_handlers registration, the _handle_callback_query dispatch
+(authorization gate, verb allow-list, precedence vs built-in prefixes, spinner
+on malformed data) and _run_script_button subprocess error handling.
+"""
+
+import asyncio
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+_repo = str(Path(__file__).resolve().parents[2])
+if _repo not in sys.path:
+    sys.path.insert(0, _repo)
+
+
+def _ensure_telegram_mock():
+    if "telegram" in sys.modules and hasattr(sys.modules["telegram"], "__file__"):
+        return
+    mod = MagicMock()
+    mod.ext.ContextTypes.DEFAULT_TYPE = type(None)
+    mod.constants.ParseMode.MARKDOWN = "Markdown"
+    mod.constants.ParseMode.MARKDOWN_V2 = "MarkdownV2"
+    mod.constants.ParseMode.HTML = "HTML"
+    mod.constants.ChatType.PRIVATE = "private"
+    mod.constants.ChatType.GROUP = "group"
+    mod.constants.ChatType.SUPERGROUP = "supergroup"
+    mod.constants.ChatType.CHANNEL = "channel"
+    mod.error.NetworkError = type("NetworkError", (OSError,), {})
+    mod.error.TimedOut = type("TimedOut", (OSError,), {})
+    mod.error.BadRequest = type("BadRequest", (Exception,), {})
+    for name in ("telegram", "telegram.ext", "telegram.constants", "telegram.request"):
+        sys.modules.setdefault(name, mod)
+    sys.modules.setdefault("telegram.error", mod.error)
+
+
+_ensure_telegram_mock()
+
+from gateway.platforms.telegram import TelegramAdapter
+from gateway.config import PlatformConfig
+
+
+_HANDLERS = [
+    {
+        "prefix": "na",
+        "script": "~/.hermes/scripts/news_action_button_handler.py",
+        "actions": {"st": "Story", "x": "𝕏"},
+    },
+    {
+        "prefix": "wx",
+        "script": "/opt/scripts/weather.py",
+        "actions": {"fc": "Forecast"},
+    },
+]
+
+
+def _make_adapter(handlers=None):
+    extra = {}
+    if handlers is not None:
+        extra["button_handlers"] = handlers
+    config = PlatformConfig(enabled=True, token="test-token", extra=extra)
+    adapter = TelegramAdapter(config)
+    adapter._bot = AsyncMock()
+    adapter._app = MagicMock()
+    # Authorization defers to the runner via _message_handler; with no handler
+    # set, _is_callback_user_authorized falls back to TELEGRAM_ALLOWED_USERS.
+    adapter._message_handler = None
+    return adapter
+
+
+def _make_query(data, *, user_id="123", chat_id=100, chat_type="private",
+                thread_id=None, reply_to_id=None):
+    chat = SimpleNamespace(type=chat_type)
+    reply_to = (
+        SimpleNamespace(message_id=reply_to_id) if reply_to_id is not None else None
+    )
+    message = SimpleNamespace(
+        chat_id=chat_id,
+        chat=chat,
+        message_thread_id=thread_id,
+        reply_to_message=reply_to,
+        message_id=999,
+    )
+    query = SimpleNamespace(
+        data=data,
+        from_user=SimpleNamespace(id=user_id, first_name="Tester"),
+        message=message,
+        answer=AsyncMock(),
+        edit_message_text=AsyncMock(),
+    )
+    return query
+
+
+def _make_update(query):
+    return SimpleNamespace(callback_query=query)
+
+
+# --------------------------------------------------------------------------
+# _load_button_handlers
+# --------------------------------------------------------------------------
+
+class TestLoadButtonHandlers:
+
+    def test_two_handlers_registered_by_prefix(self):
+        adapter = _make_adapter(_HANDLERS)
+        assert set(adapter._button_handlers) == {"na", "wx"}
+        assert adapter._button_handlers["na"]["script"].endswith(
+            "news_action_button_handler.py"
+        )
+
+    def test_entry_missing_prefix_is_skipped(self, caplog):
+        handlers = [
+            {"script": "/x.py", "actions": {"a": "A"}},  # no prefix
+            {"prefix": "ok", "script": "/y.py", "actions": {"b": "B"}},
+        ]
+        with caplog.at_level("WARNING"):
+            adapter = _make_adapter(handlers)
+        assert set(adapter._button_handlers) == {"ok"}
+        assert any(
+            "missing" in r.message and "prefix" in r.message
+            for r in caplog.records
+        )
+
+    def test_model_picker_shadowed_prefix_is_skipped(self, caplog):
+        """A configured prefix shadowed by the bare model-picker tokens
+        (mb/mx) is dropped with a warning, since it could never fire."""
+        handlers = [
+            {"prefix": "mboard", "script": "/x.py", "actions": {"a": "A"}},
+            {"prefix": "mx", "script": "/y.py", "actions": {"b": "B"}},
+            {"prefix": "ok", "script": "/z.py", "actions": {"c": "C"}},
+        ]
+        with caplog.at_level("WARNING"):
+            adapter = _make_adapter(handlers)
+        assert set(adapter._button_handlers) == {"ok"}
+        assert any("shadowed" in r.message for r in caplog.records)
+
+    def test_absent_config_no_handlers(self):
+        adapter = _make_adapter(None)
+        assert adapter._button_handlers == {}
+
+    def test_empty_config_no_handlers(self):
+        adapter = _make_adapter([])
+        assert adapter._button_handlers == {}
+
+
+# --------------------------------------------------------------------------
+# dispatch via _handle_callback_query
+# --------------------------------------------------------------------------
+
+def _patch_subprocess(monkeypatch, returncode=0, stdout=b"ok", stderr=b""):
+    """Patch asyncio.create_subprocess_exec; return (mock, captured_argv)."""
+    captured = {}
+    proc = MagicMock()
+    proc.returncode = returncode
+    proc.communicate = AsyncMock(return_value=(stdout, stderr))
+
+    async def fake_exec(*argv, **kwargs):
+        captured["argv"] = list(argv)
+        return proc
+
+    mock = AsyncMock(side_effect=fake_exec)
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", mock)
+    return mock, captured
+
+
+class TestDispatch:
+
+    @pytest.mark.asyncio
+    async def test_authorized_known_verb_spawns_subprocess(self, monkeypatch):
+        monkeypatch.setenv("TELEGRAM_ALLOWED_USERS", "123")
+        adapter = _make_adapter(_HANDLERS)
+        adapter._send_message_with_thread_fallback = AsyncMock()
+        mock, captured = _patch_subprocess(monkeypatch)
+        query = _make_query("na:st:42", user_id="123")
+
+        await adapter._handle_callback_query(_make_update(query), None)
+        # Drain the GC-safe task created by the dispatcher.
+        await asyncio.gather(*list(adapter._background_tasks))
+
+        assert mock.await_count == 1
+        argv = captured["argv"]
+        assert argv[0] == sys.executable
+        assert argv[1].endswith("news_action_button_handler.py")
+        assert "--action" in argv and argv[argv.index("--action") + 1] == "st"
+        assert "--action-id" in argv and argv[argv.index("--action-id") + 1] == "42"
+        assert "--chat-id" in argv and argv[argv.index("--chat-id") + 1] == "100"
+        query.answer.assert_awaited()
+        # Spinner-clear answer carries no error text on success.
+        assert query.answer.await_args.kwargs.get("text") is None
+        # A successful run sends no warning message.
+        adapter._send_message_with_thread_fallback.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_reply_to_and_thread_appended_when_present(self, monkeypatch):
+        monkeypatch.setenv("TELEGRAM_ALLOWED_USERS", "123")
+        adapter = _make_adapter(_HANDLERS)
+        _, captured = _patch_subprocess(monkeypatch)
+        query = _make_query(
+            "na:st:42", user_id="123", chat_type="supergroup",
+            thread_id=7, reply_to_id=55,
+        )
+
+        await adapter._handle_callback_query(_make_update(query), None)
+        await asyncio.gather(*list(adapter._background_tasks))
+
+        argv = captured["argv"]
+        assert argv[argv.index("--reply-to-message-id") + 1] == "55"
+        assert argv[argv.index("--thread-id") + 1] == "7"
+
+    @pytest.mark.asyncio
+    async def test_arg_with_embedded_colons_preserved(self, monkeypatch):
+        """split(":", 2) keeps colons in the arg as a single argv element."""
+        monkeypatch.setenv("TELEGRAM_ALLOWED_USERS", "123")
+        adapter = _make_adapter(_HANDLERS)
+        _, captured = _patch_subprocess(monkeypatch)
+        query = _make_query("na:st:a:b", user_id="123")
+
+        await adapter._handle_callback_query(_make_update(query), None)
+        await asyncio.gather(*list(adapter._background_tasks))
+
+        argv = captured["argv"]
+        assert argv[argv.index("--action") + 1] == "st"
+        assert argv[argv.index("--action-id") + 1] == "a:b"
+
+    @pytest.mark.asyncio
+    async def test_reply_to_and_thread_omitted_when_absent(self, monkeypatch):
+        monkeypatch.setenv("TELEGRAM_ALLOWED_USERS", "123")
+        adapter = _make_adapter(_HANDLERS)
+        _, captured = _patch_subprocess(monkeypatch)
+        query = _make_query("na:st:42", user_id="123")  # no thread, no reply_to
+
+        await adapter._handle_callback_query(_make_update(query), None)
+        await asyncio.gather(*list(adapter._background_tasks))
+
+        argv = captured["argv"]
+        assert "--reply-to-message-id" not in argv
+        assert "--thread-id" not in argv
+
+    @pytest.mark.asyncio
+    async def test_unauthorized_user_does_not_spawn(self, monkeypatch):
+        monkeypatch.setenv("TELEGRAM_ALLOWED_USERS", "999")
+        adapter = _make_adapter(_HANDLERS)
+        mock, _ = _patch_subprocess(monkeypatch)
+        query = _make_query("na:st:42", user_id="123")  # not allowed
+
+        await adapter._handle_callback_query(_make_update(query), None)
+
+        assert mock.await_count == 0
+        assert adapter._background_tasks == set()
+        query.answer.assert_awaited_once()
+        text = query.answer.await_args.kwargs.get("text", "")
+        assert "not authorized" in text.lower()
+
+    @pytest.mark.asyncio
+    async def test_unknown_verb_does_not_spawn(self, monkeypatch):
+        monkeypatch.setenv("TELEGRAM_ALLOWED_USERS", "123")
+        adapter = _make_adapter(_HANDLERS)
+        mock, _ = _patch_subprocess(monkeypatch)
+        query = _make_query("na:bogus:42", user_id="123")  # verb not in actions
+
+        await adapter._handle_callback_query(_make_update(query), None)
+
+        assert mock.await_count == 0
+        assert adapter._background_tasks == set()
+        query.answer.assert_awaited_once()
+        assert query.answer.await_args.kwargs.get("text") == "Unknown action."
+
+    @pytest.mark.asyncio
+    async def test_malformed_data_answers_without_spawn(self, monkeypatch):
+        monkeypatch.setenv("TELEGRAM_ALLOWED_USERS", "123")
+        adapter = _make_adapter(_HANDLERS)
+        mock, _ = _patch_subprocess(monkeypatch)
+        query = _make_query("na:onlytwo", user_id="123")  # split -> 2 parts
+
+        await adapter._handle_callback_query(_make_update(query), None)
+
+        assert mock.await_count == 0
+        assert adapter._background_tasks == set()
+        query.answer.assert_awaited_once()
+        # Malformed data clears the spinner with a bare answer (no error text).
+        assert query.answer.await_args.kwargs.get("text") is None
+
+    @pytest.mark.asyncio
+    async def test_builtin_prefix_gt_takes_precedence(self, monkeypatch):
+        """A configured prefix that startswith-collides with gt: must route
+        to the built-in gmail-triage handler, not the generic script path."""
+        monkeypatch.setenv("TELEGRAM_ALLOWED_USERS", "123")
+        handlers = [
+            {"prefix": "gt", "script": "/evil.py", "actions": {"send": "Send"}},
+        ]
+        adapter = _make_adapter(handlers)
+        mock, _ = _patch_subprocess(monkeypatch)
+        triage = AsyncMock()
+        adapter._handle_gmail_triage_callback = triage
+        query = _make_query("gt:send:42", user_id="123")
+
+        await adapter._handle_callback_query(_make_update(query), None)
+
+        assert mock.await_count == 0
+        assert adapter._background_tasks == set()
+        triage.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "prefix, data",
+        [
+            ("ea", "ea:once:42"),
+            ("sc", "sc:y:42"),
+        ],
+    )
+    async def test_builtin_prefix_precedence_no_generic_spawn(
+        self, monkeypatch, prefix, data
+    ):
+        """Configured prefixes that startswith-collide with other built-ins
+        (ea:/sc:) are handled by those built-ins, never the generic loop.
+
+        The generic dispatcher is the only path that spawns a subprocess /
+        registers a background task, so the absence of both proves the
+        built-in branch ran instead."""
+        monkeypatch.setenv("TELEGRAM_ALLOWED_USERS", "123")
+        handlers = [
+            {"prefix": prefix, "script": "/evil.py", "actions": {"once": "X", "y": "Y"}},
+        ]
+        adapter = _make_adapter(handlers)
+        mock, _ = _patch_subprocess(monkeypatch)
+        query = _make_query(data, user_id="123")
+
+        await adapter._handle_callback_query(_make_update(query), None)
+
+        assert mock.await_count == 0
+        assert adapter._background_tasks == set()
+
+
+# --------------------------------------------------------------------------
+# _run_script_button
+# --------------------------------------------------------------------------
+
+class TestRunScriptButton:
+
+    @pytest.mark.asyncio
+    async def test_nonzero_returncode_sends_warning(self, monkeypatch):
+        adapter = _make_adapter(_HANDLERS)
+        adapter._send_message_with_thread_fallback = AsyncMock()
+        _patch_subprocess(monkeypatch, returncode=2, stdout=b"", stderr=b"boom")
+
+        await adapter._run_script_button(
+            _HANDLERS[0], "st", "42", "100",
+            reply_to_message_id="55", thread_id="7",
+        )
+
+        adapter._send_message_with_thread_fallback.assert_awaited_once()
+        kwargs = adapter._send_message_with_thread_fallback.await_args.kwargs
+        text = kwargs["text"]
+        assert "⚠️" in text
+        assert "boom" in text
+        # The mapped action label is rendered, not the raw verb.
+        assert "Story" in text
+        # Routing kwargs are int-converted and plumbed through correctly.
+        assert kwargs["chat_id"] == 100
+        assert kwargs["reply_to_message_id"] == 55
+        assert kwargs["message_thread_id"] == 7
+        assert kwargs["parse_mode"] is None
+
+    @pytest.mark.asyncio
+    async def test_exception_sends_crash_warning_no_raise(self, monkeypatch):
+        adapter = _make_adapter(_HANDLERS)
+        adapter._send_message_with_thread_fallback = AsyncMock()
+
+        async def boom(*a, **k):
+            raise RuntimeError("kaboom")
+
+        monkeypatch.setattr(asyncio, "create_subprocess_exec", boom)
+
+        # Must not raise.
+        await adapter._run_script_button(_HANDLERS[0], "st", "42", "100")
+
+        adapter._send_message_with_thread_fallback.assert_awaited_once()
+        text = adapter._send_message_with_thread_fallback.await_args.kwargs["text"]
+        assert "⚠️" in text
+        assert "kaboom" in text
+
+    @pytest.mark.asyncio
+    async def test_missing_script_returns_early(self, monkeypatch):
+        adapter = _make_adapter(_HANDLERS)
+        mock, _ = _patch_subprocess(monkeypatch)
+
+        await adapter._run_script_button(
+            {"actions": {"st": "Story"}}, "st", "42", "100",
+        )
+
+        assert mock.await_count == 0


### PR DESCRIPTION
Replaces the earlier Pipebrief-specific news-action handler with a **generic, configurable script-button dispatcher** that any Hermes feature can use without code changes.

## What changed

- Added `_load_button_handlers()` and `_run_script_button()` to `TelegramAdapter`
- Both are driven by a new `platforms.telegram.extra.button_handlers` config list

## Config format

```yaml
platforms:
  telegram:
    extra:
      button_handlers:
        - prefix: na
          script: ~/.hermes/scripts/news_action_button_handler.py
          actions:
            st: Story
            x: "𝕏"
            li: LinkedIn
            tw: Takeaway
            rs: Research
        - prefix: wx
          script: ~/.hermes/scripts/weather_button.py
          actions:
            now: Current weather
            fc: Forecast
```

A callback `na:st:42` matches prefix `na`, extracts verb `st` and arg `42`, and spawns:

```
python ~/.hermes/scripts/news_action_button_handler.py \
    --action st --action-id 42 --chat-id <id>
```

Labels in the `actions` map are used for logging and error messages.

## Adding a new button type

**Zero code changes.** Just add one config entry + write the script. The script receives at least:

- `--action <verb>`
- `--action-id <arg>`
- `--chat-id <id>`
- `--reply-to-message-id <id>` (optional)
- `--thread-id <id>` (optional)

The script prints its result to stdout; stderr is captured for error messages.

## Alternative considered

Option A (convention-over-config via `hx_<name>.py` filenames) was rejected — it makes the label map harder to discover and doesn't integrate as cleanly with the existing Gmail-triage dispatch pattern.
