### PR TITLE
ci(pypi): validate distributions before upload

### DIFF
--- a/.github/workflows/upload_to_pypi.yml
+++ b/.github/workflows/upload_to_pypi.yml
@@ -80,6 +80,9 @@ jobs:
       - name: Build wheel and sdist
         run: uv build --sdist --wheel
 
+      - name: Validate distribution metadata
+        run: uvx twine==6.2.0 check dist/*
+
       - name: Upload distribution artifacts
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:


### PR DESCRIPTION
## What does this PR do?

Adds a `twine check` metadata validation step to the PyPI publish workflow after building the wheel and sdist and before uploading them as release artifacts.

This gives the release workflow a small fail-fast gate for malformed package metadata, broken long descriptions, or distribution metadata issues before the artifacts are passed to the publish/sign jobs.

## Related Issue

No specific issue found. This is a release-safety hardening change discovered from the public workflow state.

## Type of Change

- [x] CI / release safety

## Changes Made

- `.github/workflows/upload_to_pypi.yml`
  - Adds `uvx twine==6.2.0 check dist/*` immediately after `uv build --sdist --wheel`.

## Duplicate Checks

Checked immediately before submission:

- `twine check dist upload_to_pypi`
- `validate distributions before upload PyPI`
- `Publish to PyPI test typecheck release`

Result: no exact duplicate PR found.

## How to Test

Validated locally:

```bash
git diff --check
rm -rf dist
uv build --sdist --wheel
uvx twine==6.2.0 check dist/*
```

Results:

```text
Successfully built dist/hermes_agent-0.18.2.tar.gz
Successfully built dist/hermes_agent-0.18.2-py3-none-any.whl
Checking dist/hermes_agent-0.18.2-py3-none-any.whl: PASSED
Checking dist/hermes_agent-0.18.2.tar.gz: PASSED
```

The refreshed branch is rebuilt from current upstream `main`; its current CI status is reported in this PR’s checks.

## Risk

Low. This only adds a metadata validation step to the release workflow. It does not change runtime code or package contents. The only expected behavior change is that invalid package distributions fail before upload/publish.

## Checklist

- [x] Focused, small diff
- [x] Regression/docs validation added or not applicable
- [x] Duplicate checks completed
- [x] Validation passed
- [x] Maintainer edits enabled