### PR TITLE
fix(update): honor skip gateway restart env

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -9345,6 +9345,24 @@ def _cmd_update_impl(args, gateway_mode: bool):
             except OSError:
                 pass
 
+        _truthy_env_values = {"1", "true", "yes", "on"}
+        _skip_gateway_restart_env = None
+        for _env_name in (
+            "HERMES_SKIP_GATEWAY_RESTART",
+            "HERMES_UPDATE_SKIP_GATEWAY_RESTART",
+        ):
+            if str(os.environ.get(_env_name, "")).strip().lower() in _truthy_env_values:
+                _skip_gateway_restart_env = _env_name
+                break
+        if _skip_gateway_restart_env:
+            print()
+            print(
+                "  ℹ Skipping inline gateway restart "
+                f"({_skip_gateway_restart_env} is set)."
+            )
+            print("    Restart the gateway later to pick up the updated code.")
+            return
+
         # Auto-restart ALL gateways after update.
         # The code update (git pull) is shared across all profiles, so every
         # running gateway needs restarting to pick up the new code.

--- a/tests/hermes_cli/test_cmd_update.py
+++ b/tests/hermes_cli/test_cmd_update.py
@@ -203,6 +203,33 @@ class TestCmdUpdateBranchFallback:
         captured = capsys.readouterr()
         assert "Already up to date!" in captured.out
 
+    @pytest.mark.parametrize(
+        "env_name",
+        ["HERMES_SKIP_GATEWAY_RESTART", "HERMES_UPDATE_SKIP_GATEWAY_RESTART"],
+    )
+    @patch("shutil.which", return_value=None)
+    @patch("subprocess.run")
+    def test_update_skip_gateway_restart_env_honored(
+        self, mock_run, _mock_which, mock_args, capsys, monkeypatch, env_name
+    ):
+        """Skip-restart env vars let gateway-hosted cron finish delivery."""
+        mock_run.side_effect = _make_run_side_effect(
+            branch="main", verify_ok=True, commit_count="1"
+        )
+        monkeypatch.setenv(env_name, "1")
+
+        cmd_update(mock_args)
+
+        out = capsys.readouterr().out
+        assert "Skipping inline gateway restart" in out
+        assert env_name in out
+        commands = [" ".join(str(a) for a in c.args[0]) for c in mock_run.call_args_list]
+        gateway_restart_probes = [
+            c for c in commands
+            if "hermes-gateway" in c and ("list-units" in c or "restart" in c)
+        ]
+        assert gateway_restart_probes == []
+
     @patch("shutil.which")
     @patch("subprocess.run")
     def test_update_refreshes_repo_and_tui_node_dependencies(


### PR DESCRIPTION
## Summary
- honor `HERMES_UPDATE_SKIP_GATEWAY_RESTART` in `hermes update` before the automatic gateway restart phase
- let gateway-hosted cron/update wrappers finish report generation and delivery before scheduling their own delayed restart
- add a regression test that the env flag skips gateway restart discovery/restart calls

## Why
When `hermes update` runs from inside `hermes-gateway.service` (for example via a gateway-hosted cron job), the automatic post-update gateway restart can kill the same scheduler/reporter process before cron metadata and Telegram/Discord delivery are persisted. Existing wrappers can set `HERMES_UPDATE_SKIP_GATEWAY_RESTART=1`, but the update command needs to honor it before entering the restart path.

## Tests
- `python -m py_compile hermes_cli/main.py tests/hermes_cli/test_cmd_update.py`
- `python -m pytest tests/hermes_cli/test_cmd_update.py::TestCmdUpdateBranchFallback::test_update_skip_gateway_restart_env_honored -q -o 'addopts='`\n