### PR TITLE
fix(gateway): validate user authorization before auto-resume

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -4854,6 +4854,27 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 )
                 continue
 
+            # Validate the session owner against the current allowlist
+            # before auto-resuming. A session created before
+            # TELEGRAM_ALLOWED_USERS (or equivalent) was configured, or
+            # before the owner was removed from it, must not silently
+            # receive a full agent response on gateway restart just
+            # because it has a resume-pending marker (issue #23778).
+            try:
+                if not self._is_user_authorized(source):
+                    logger.warning(
+                        "Skipping auto-resume for %s: session owner is no "
+                        "longer authorized under the current allowlist",
+                        entry.session_key,
+                    )
+                    continue
+            except Exception as exc:
+                logger.warning(
+                    "Skipping auto-resume for %s: authorization check failed: %s",
+                    entry.session_key, exc,
+                )
+                continue
+
             # Claim the session slot *before* spawning the task so that an
             # inbound message arriving between task creation and the task's
             # first await (where _process_message_background sets the real


### PR DESCRIPTION
Clean rebase of #23800 onto current main (egilewski flagged a merge conflict in gateway/run.py on the old branch).

## Problem

Auto-resume of restart-interrupted sessions bypassed auth checks. The session owner was never validated against TELEGRAM_ALLOWED_USERS before the synthetic resume event was dispatched (issue #23778).

## Fix

Check _is_user_authorized() for the session owner before scheduling auto-resume. Unauthorized sessions are skipped with a warning log.

Fixes #23778 (partial - auto-resume auth bypass)