### PR TITLE
fix(credential-pool): skip ghp_* PATs for copilot env seeding (#47708)

### DIFF
--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -1873,6 +1873,15 @@ def _seed_from_env(provider: str, entries: List[PooledCredential]) -> Tuple[bool
         token = _get_env_prefer_dotenv(env_var)
         if not token:
             continue
+        # Copilot rejects classic PATs (ghp_*) — skip them so a
+        # GITHUB_TOKEN / GH_TOKEN set for `gh` / git doesn't create a
+        # permanently-failing fallback in the credential pool.  (#47708)
+        if provider == "copilot" and token.startswith("ghp_"):
+            logger.debug(
+                "Skipping env:%s for copilot — classic PAT (ghp_*) is not supported",
+                env_var,
+            )
+            continue
         source = f"env:{env_var}"
         if _is_source_suppressed(provider, source):
             continue


### PR DESCRIPTION
Fixes #47708. Skip classic ghp_* PATs when seeding copilot credentials from GITHUB_TOKEN/GH_TOKEN env vars, since the Copilot API rejects them. This prevents a permanently-failing fallback entry in the credential pool.