### PR TITLE
feat: add result budgets and reap LSP children

### DIFF
--- a/agent/lsp/client.py
+++ b/agent/lsp/client.py
@@ -44,6 +44,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import os
+import signal
 import sys
 from pathlib import Path
 from typing import Any, Awaitable, Callable, Dict, List, Optional, Set
@@ -262,6 +263,13 @@ class LSPClient:
         if sys.platform == "win32":
             cmd = self._win_wrap_cmd(cmd)
 
+        create_kwargs: Dict[str, Any] = {}
+        if sys.platform != "win32":
+            # Put each language server in its own process group so shutdown can
+            # reap helper grandchildren (tsserver, pyright node children, etc.)
+            # instead of leaving orphaned long-lived processes under the gateway.
+            create_kwargs["start_new_session"] = True
+
         try:
             self._proc = await asyncio.create_subprocess_exec(
                 cmd[0],
@@ -271,6 +279,7 @@ class LSPClient:
                 stderr=asyncio.subprocess.PIPE,
                 env=env,
                 cwd=self._cwd,
+                **create_kwargs,
             )
         except FileNotFoundError as e:
             raise LSPProtocolError(
@@ -442,12 +451,21 @@ class LSPClient:
             return
         if proc.returncode is None:
             try:
-                proc.terminate()
+                if sys.platform != "win32":
+                    try:
+                        os.killpg(proc.pid, signal.SIGTERM)
+                    except ProcessLookupError:
+                        pass
+                else:
+                    proc.terminate()
                 try:
                     await asyncio.wait_for(proc.wait(), timeout=SHUTDOWN_GRACE)
                 except asyncio.TimeoutError:
                     try:
-                        proc.kill()
+                        if sys.platform != "win32":
+                            os.killpg(proc.pid, signal.SIGKILL)
+                        else:
+                            proc.kill()
                         await proc.wait()
                     except ProcessLookupError:
                         pass

--- a/agent/lsp/manager.py
+++ b/agent/lsp/manager.py
@@ -204,6 +204,7 @@ class LSPService:
         enabled = bool(lsp_cfg.get("enabled", True))
         wait_mode = lsp_cfg.get("wait_mode", "document")
         wait_timeout = float(lsp_cfg.get("wait_timeout", DIAGNOSTICS_DOCUMENT_WAIT))
+        idle_timeout = float(lsp_cfg.get("idle_timeout", DEFAULT_IDLE_TIMEOUT))
         install_strategy = lsp_cfg.get("install_strategy", "auto")
         servers_cfg = lsp_cfg.get("servers") or {}
         disabled = []
@@ -235,6 +236,7 @@ class LSPService:
             env_overrides=env_overrides,
             init_overrides=init_overrides,
             disabled_servers=disabled,
+            idle_timeout=idle_timeout,
         )
 
     # ------------------------------------------------------------------
@@ -485,6 +487,7 @@ class LSPService:
         return list(client.diagnostics_for(file_path))
 
     async def _get_or_spawn(self, file_path: str) -> Optional[LSPClient]:
+        await self._reap_idle_clients()
         srv = find_server_for_file(file_path)
         if srv is None:
             return None
@@ -566,6 +569,23 @@ class LSPService:
             with self._state_lock:
                 self._spawning.pop(key, None)
 
+    async def _reap_idle_clients(self) -> None:
+        """Shutdown LSP clients that have been idle past the configured TTL."""
+        if self._idle_timeout <= 0:
+            return
+        now = time.time()
+        expired: list[tuple[tuple[str, str], LSPClient]] = []
+        with self._state_lock:
+            for key, client in list(self._clients.items()):
+                last = self._last_used.get(key, now)
+                if now - last > self._idle_timeout or not client.is_running:
+                    expired.append((key, client))
+                    self._clients.pop(key, None)
+                    self._last_used.pop(key, None)
+        if expired:
+            logger.info("Reaping %d idle LSP client(s)", len(expired))
+            await asyncio.gather(*(client.shutdown() for _, client in expired), return_exceptions=True)
+
     async def _shutdown_async(self) -> None:
         with self._state_lock:
             clients = list(self._clients.values())
@@ -598,6 +618,7 @@ class LSPService:
             "enabled": self._enabled,
             "wait_mode": self._wait_mode,
             "wait_timeout": self._wait_timeout,
+            "idle_timeout": self._idle_timeout,
             "install_strategy": self._install_strategy,
             "clients": clients,
             "broken": broken,

--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -43,6 +43,7 @@ from tools.thread_context import propagate_context_to_thread
 from tools.tool_result_storage import (
     maybe_persist_tool_result,
     enforce_turn_budget,
+    load_budget_config,
 )
 
 logger = logging.getLogger(__name__)
@@ -720,11 +721,13 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
             except Exception as cb_err:
                 logging.debug(f"Tool complete callback error: {cb_err}")
 
+        _budget_config = load_budget_config()
         function_result = maybe_persist_tool_result(
             content=function_result,
             tool_name=name,
             tool_use_id=tc.id,
             env=get_active_env(effective_task_id),
+            config=_budget_config,
         ) if not _is_multimodal_tool_result(function_result) else function_result
 
         subdir_hints = agent._subdirectory_hints.check_tool_call(name, args)
@@ -756,7 +759,11 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
     num_tools = len(parsed_calls)
     if num_tools > 0:
         turn_tool_msgs = messages[-num_tools:]
-        enforce_turn_budget(turn_tool_msgs, env=get_active_env(effective_task_id))
+        enforce_turn_budget(
+            turn_tool_msgs,
+            env=get_active_env(effective_task_id),
+            config=load_budget_config(),
+        )
 
     # ── /steer injection ──────────────────────────────────────────────
     # Append any pending user steer text to the last tool result so the
@@ -1358,11 +1365,13 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
             except Exception as cb_err:
                 logging.debug(f"Tool complete callback error: {cb_err}")
 
+        _budget_config = load_budget_config()
         function_result = maybe_persist_tool_result(
             content=function_result,
             tool_name=function_name,
             tool_use_id=tool_call.id,
             env=get_active_env(effective_task_id),
+            config=_budget_config,
         ) if not _is_multimodal_tool_result(function_result) else function_result
 
         # Discover subdirectory context files from tool arguments
@@ -1411,7 +1420,11 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
     # ── Per-turn aggregate budget enforcement ─────────────────────────
     num_tools_seq = len(assistant_message.tool_calls)
     if num_tools_seq > 0:
-        enforce_turn_budget(messages[-num_tools_seq:], env=get_active_env(effective_task_id))
+        enforce_turn_budget(
+            messages[-num_tools_seq:],
+            env=get_active_env(effective_task_id),
+            config=load_budget_config(),
+        )
 
     # ── /steer injection ──────────────────────────────────────────────
     # See _execute_tool_calls_parallel for the rationale. Same hook,

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2190,6 +2190,15 @@ DEFAULT_CONFIG = {
             # Hard upper bound the model can request via ``limit``. Range 1..50.
             "max_search_limit": 20,
         },
+        # Generic tool-result headroom gate. Oversized outputs are saved to
+        # the active environment's temp dir and the model receives a compact
+        # preview + read_file instructions instead of the full payload.
+        "result_budget": {
+            "default_result_size": 100_000,
+            "turn_budget": 200_000,
+            "preview_size": 1_500,
+            "tool_overrides": {},
+        },
     },
 
     # Logging — controls file logging to ~/.hermes/logs/.
@@ -2416,6 +2425,11 @@ DEFAULT_CONFIG = {
         # workspace-wide diagnostics (slower).
         "wait_mode": "document",
         "wait_timeout": 5.0,
+
+        # Reap language server clients that have not been touched for this
+        # many seconds. Keeps long-lived gateway sessions from accumulating
+        # tsserver/pyright/gopls children across unrelated projects.
+        "idle_timeout": 600,
 
         # How to handle missing server binaries.
         # ``"auto"`` — try to install via npm/go/pip into

--- a/tests/agent/lsp/test_client_e2e.py
+++ b/tests/agent/lsp/test_client_e2e.py
@@ -11,6 +11,7 @@ import asyncio
 import os
 import sys
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
@@ -29,6 +30,37 @@ def _client(workspace: Path, script: str = "clean") -> LSPClient:
         env=env,
         cwd=str(workspace),
     )
+
+
+@pytest.mark.asyncio
+async def test_client_spawn_uses_own_process_group_on_posix(monkeypatch, tmp_path: Path):
+    """LSP children must be group-owned so shutdown can reap helpers."""
+    captured = {}
+
+    async def fake_create_subprocess_exec(*cmd, **kwargs):
+        captured["cmd"] = cmd
+        captured["kwargs"] = kwargs
+        return SimpleNamespace(
+            stdin=SimpleNamespace(is_closing=lambda: False),
+            stdout=SimpleNamespace(),
+            stderr=SimpleNamespace(),
+            returncode=None,
+            pid=123456,
+        )
+
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_create_subprocess_exec)
+    client = _client(tmp_path, "clean")
+    await client._spawn()
+    try:
+        if sys.platform != "win32":
+            assert captured["kwargs"].get("start_new_session") is True
+        else:
+            assert "start_new_session" not in captured["kwargs"]
+    finally:
+        if client._reader_task is not None:
+            client._reader_task.cancel()
+        if client._stderr_task is not None:
+            client._stderr_task.cancel()
 
 
 @pytest.mark.asyncio

--- a/tests/agent/lsp/test_service.py
+++ b/tests/agent/lsp/test_service.py
@@ -171,6 +171,7 @@ def test_service_status_includes_clients(mock_pyright):
         svc.get_diagnostics_sync(str(f))
         info = svc.get_status()
         assert info["enabled"] is True
+        assert info["idle_timeout"] == 600
         assert any(c["server_id"] == "pyright" for c in info["clients"])
     finally:
         svc.shutdown()

--- a/tests/tools/test_tool_result_storage.py
+++ b/tests/tools/test_tool_result_storage.py
@@ -7,6 +7,7 @@ from tools.budget_config import (
     DEFAULT_RESULT_SIZE_CHARS,
     DEFAULT_PREVIEW_SIZE_CHARS,
     BudgetConfig,
+    budget_config_from_mapping,
 )
 from tools.tool_result_storage import (
     HEREDOC_MARKER,
@@ -62,6 +63,53 @@ class TestGeneratePreview:
         preview, has_more = generate_preview(text)
         assert preview == text
         assert has_more is False
+
+
+# ── BudgetConfig mapping loader ───────────────────────────────────────
+
+class TestBudgetConfigFromMapping:
+    def test_uses_nested_tool_result_budget_config(self):
+        cfg = budget_config_from_mapping({
+            "tools": {
+                "result_budget": {
+                    "default_result_size": 12_000,
+                    "turn_budget": 48_000,
+                    "preview_size": 900,
+                    "tool_overrides": {
+                        "terminal": 8_000,
+                        "mcp_smart_web_smartfetch": 6_000,
+                    },
+                },
+            },
+        })
+
+        assert cfg.default_result_size == 12_000
+        assert cfg.turn_budget == 48_000
+        assert cfg.preview_size == 900
+        assert cfg.tool_overrides == {
+            "terminal": 8_000,
+            "mcp_smart_web_smartfetch": 6_000,
+        }
+
+    def test_invalid_values_fall_back_to_safe_defaults(self):
+        cfg = budget_config_from_mapping({
+            "tools": {
+                "result_budget": {
+                    "default_result_size": -1,
+                    "turn_budget": "bad",
+                    "preview_size": 0,
+                    "tool_overrides": {"terminal": -50, "read_file": 1_000},
+                },
+            },
+        })
+
+        assert cfg.default_result_size == DEFAULT_RESULT_SIZE_CHARS
+        assert cfg.turn_budget > 0
+        assert cfg.preview_size == DEFAULT_PREVIEW_SIZE_CHARS
+        # read_file remains pinned by BudgetConfig.resolve_threshold; the
+        # loader should also ignore invalid non-positive overrides.
+        assert cfg.tool_overrides == {"read_file": 1_000}
+        assert cfg.resolve_threshold("read_file") == float("inf")
 
 
 # ── _heredoc_marker ───────────────────────────────────────────────────

--- a/tools/budget_config.py
+++ b/tools/budget_config.py
@@ -4,7 +4,7 @@ Per-tool resolution: pinned > config overrides > registry > default.
 """
 
 from dataclasses import dataclass, field
-from typing import Dict
+from typing import Any, Dict
 
 # Tools whose thresholds must never be overridden.
 # read_file=inf prevents infinite persist->read->persist loops.
@@ -45,6 +45,63 @@ class BudgetConfig:
             return self.tool_overrides[tool_name]
         from tools.registry import registry
         return registry.get_max_result_size(tool_name, default=self.default_result_size)
+
+
+def _positive_int(value: Any, default: int) -> int:
+    """Return ``value`` as a positive int, else ``default``."""
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        return default
+    return parsed if parsed > 0 else default
+
+
+def budget_config_from_mapping(config: dict[str, Any] | None) -> BudgetConfig:
+    """Build tool-result budget settings from ``config.yaml`` data.
+
+    User-facing config lives at::
+
+        tools:
+          result_budget:
+            default_result_size: 50000
+            turn_budget: 120000
+            preview_size: 1500
+            tool_overrides:
+              terminal: 25000
+
+    Invalid values are ignored so a typo cannot disable persistence. Pinned
+    thresholds such as ``read_file`` still win at ``resolve_threshold`` time.
+    """
+    root = config or {}
+    section = ((root.get("tools") or {}).get("result_budget") or {})
+    if not isinstance(section, dict):
+        section = {}
+
+    overrides_raw = section.get("tool_overrides") or {}
+    overrides: Dict[str, int] = {}
+    if isinstance(overrides_raw, dict):
+        for name, value in overrides_raw.items():
+            if not isinstance(name, str) or not name:
+                continue
+            try:
+                parsed = int(value)
+            except (TypeError, ValueError):
+                continue
+            if parsed > 0:
+                overrides[name] = parsed
+
+    return BudgetConfig(
+        default_result_size=_positive_int(
+            section.get("default_result_size"), DEFAULT_RESULT_SIZE_CHARS,
+        ),
+        turn_budget=_positive_int(
+            section.get("turn_budget"), DEFAULT_TURN_BUDGET_CHARS,
+        ),
+        preview_size=_positive_int(
+            section.get("preview_size"), DEFAULT_PREVIEW_SIZE_CHARS,
+        ),
+        tool_overrides=overrides,
+    )
 
 
 # Default config -- matches current hardcoded behavior exactly.

--- a/tools/tool_result_storage.py
+++ b/tools/tool_result_storage.py
@@ -31,6 +31,7 @@ from tools.budget_config import (
     DEFAULT_PREVIEW_SIZE_CHARS,
     BudgetConfig,
     DEFAULT_BUDGET,
+    budget_config_from_mapping,
 )
 
 logger = logging.getLogger(__name__)
@@ -39,6 +40,16 @@ PERSISTED_OUTPUT_CLOSING_TAG = "</persisted-output>"
 STORAGE_DIR = "/tmp/hermes-results"
 HEREDOC_MARKER = "HERMES_PERSIST_EOF"
 _BUDGET_TOOL_NAME = "__budget_enforcement__"
+
+
+def load_budget_config() -> BudgetConfig:
+    """Load tool-result budget policy from config.yaml, fail-open to defaults."""
+    try:
+        from hermes_cli.config import load_config
+        return budget_config_from_mapping(load_config())
+    except Exception as exc:
+        logger.debug("Could not load tool result budget config: %s", exc)
+        return DEFAULT_BUDGET
 
 
 def _resolve_storage_dir(env) -> str:


### PR DESCRIPTION
## Summary
- make Hermes tool-result budgets configurable via `tools.result_budget`
- load that budget in both sequential and parallel tool execution before persisting oversized results
- add LSP process lifecycle hardening: language servers start in their own POSIX process group and shutdown kills the group so helper children do not leak
- add configurable `lsp.idle_timeout` and reap idle/dead LSP clients before spawning more

## Verification
- `python -m pytest tests/tools/test_tool_result_storage.py tests/agent/lsp/test_client_e2e.py tests/agent/lsp/test_service.py -q -o 'addopts='`
