### PR TITLE
fix(agent): detect symlink cycles in iter_skill_index_files to prevent infinite recursion

### DIFF
--- a/agent/skill_utils.py
+++ b/agent/skill_utils.py
@@ -701,9 +701,19 @@ def iter_skill_index_files(skills_dir: Path, filename: str):
     scripts) can contain arbitrary markdown and even archived package
     ``SKILL.md`` files, but they are progressive-disclosure data loaded through
     ``skill_view(..., file_path=...)`` rather than active skill roots.
+
+    Symlink cycles (e.g. ``skills/productivity/productivity -> ..``) are
+    detected via a *visited* set of resolved real paths.  When a cycle is
+    encountered the branch is pruned instead of recursing infinitely.
     """
     matches = []
+    visited: set = set()
     for root, dirs, files in os.walk(skills_dir, followlinks=True):
+        real_root = Path(root).resolve()
+        if real_root in visited:
+            dirs[:] = []  # prune this branch — already traversed
+            continue
+        visited.add(real_root)
         has_skill_md = "SKILL.md" in files
         dirs[:] = [
             d

--- a/tests/agent/test_skill_utils.py
+++ b/tests/agent/test_skill_utils.py
@@ -215,7 +215,37 @@ def test_iter_skill_index_files_keeps_support_named_categories(tmp_path):
     assert is_excluded_skill_path(scripts_skill / "SKILL.md") is False
 
 
-# ── skill_matches_platform on Termux ──────────────────────────────────────
+def test_iter_skill_index_files_prunes_self_referencing_symlinks(tmp_path):
+    """Self-referencing symlinks must not cause infinite recursion.
+
+    Regression test for <https://github.com/NousResearch/hermes-agent/issues/47659>.
+    A symlink inside a skill directory that points back to its own parent
+    (e.g. ``productivity/productivity -> productivity/``) must be detected
+    as a cycle and pruned instead of recursing infinitely.
+    """
+    # Create a skill directory with a self-referencing symlink.
+    skill_dir = tmp_path / "productivity"
+    skill_dir.mkdir()
+    (skill_dir / "SKILL.md").write_text(
+        "---\nname: productivity\n---\n", encoding="utf-8"
+    )
+    # Symlink: productivity/productivity -> productivity/
+    (skill_dir / "productivity").symlink_to(skill_dir)
+
+    # Create a second skill without a cycle (control).
+    normal_skill = tmp_path / "research"
+    normal_skill.mkdir()
+    (normal_skill / "SKILL.md").write_text(
+        "---\nname: research\n---\n", encoding="utf-8"
+    )
+
+    found = list(iter_skill_index_files(tmp_path, "SKILL.md"))
+
+    # Each skill should appear exactly once — no duplicated entries from
+    # the cycle.
+    assert len(found) == 2
+    names = sorted(p.parent.name for p in found)
+    assert names == ["productivity", "research"]
 
 
 class TestSkillMatchesPlatformTermux:


### PR DESCRIPTION
## What does this PR do?

Adds symlink cycle detection to `iter_skill_index_files()` so that self-referencing symlinks inside skill directories (e.g. `skills/productivity/productivity -> productivity/`) are pruned instead of causing infinite recursion via `os.walk(followlinks=True)`.

Without this guard, self-referencing symlinks inflate the skills prompt from ~1K tokens to ~109K tokens, consuming most of the context window before any conversation starts.

## Related Issue

Fixes #47659

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/skill_utils.py`: Add a `visited` set of `Path.resolve()` real paths to `iter_skill_index_files()`. When `os.walk` revisits an already-seen directory (via symlink cycle), prune the branch by setting `dirs[:] = []`.
- `tests/agent/test_skill_utils.py`: Add `test_iter_skill_index_files_prunes_self_referencing_symlinks` — creates a self-referencing symlink inside a skill directory and verifies each skill appears exactly once (no duplicated entries from the cycle).

## How to Test

1. Create a skill directory with a self-referencing symlink:
   ```bash
   mkdir -p /tmp/test-skills/productivity
   echo -e "---\nname: productivity\n---\n" > /tmp/test-skills/productivity/SKILL.md
   ln -s /tmp/test-skills/productivity /tmp/test-skills/productivity/productivity
   ```
2. Run the test suite: `python -m pytest tests/agent/test_skill_utils.py::test_iter_skill_index_files_prunes_self_referencing_symlinks -v`
3. Verify the function returns exactly 2 entries (one per skill), not infinitely recursing.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — fix is pure Python stdlib (pathlib + os.walk), platform-agnostic
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `iter_skill_index_files` (callers: 5 in `agent/skill_utils.py`, `agent/prompt_builder.py`, `tools/skills_tool.py`, `agent/skill_commands.py`)
- Blast radius: LOW — pure guard addition, no behavioral change for non-cyclic directories
- Related patterns: `os.walk(followlinks=True)` cycle detection is a well-known Python pattern; the `visited` set of resolved paths is the standard approach
