### PR TITLE
fix(kanban-dashboard): archiving a board must stick (flag, not a dir move that auto-resurrects)

### DIFF
--- a/plugins/kanban/dashboard/plugin_api.py
+++ b/plugins/kanban/dashboard/plugin_api.py
@@ -1990,6 +1990,7 @@ class RenameBoardBody(BaseModel):
     description: Optional[str] = None
     icon: Optional[str] = None
     color: Optional[str] = None
+    archived: Optional[bool] = None
 
 
 def _board_counts(slug: str) -> dict[str, int]:
@@ -2058,17 +2059,36 @@ def rename_board(slug: str, payload: RenameBoardBody):
         description=payload.description,
         icon=payload.icon,
         color=payload.color,
+        archived=payload.archived,
     )
     return {"board": meta}
 
 
 @router.delete("/boards/{slug}")
 def delete_board(slug: str, delete: bool = Query(False, description="Hard-delete instead of archive")):
-    """Archive (default) or hard-delete a board."""
+    """Archive (default) or hard-delete a board.
+
+    Archive is a REVERSIBLE metadata flag (``archived=true``) that hides the
+    board from the picker (it reappears under "Show archived" and is undone via
+    PATCH ``archived=false``). It deliberately does NOT move the board
+    directory: a moved board is auto-re-created the next time any read (e.g. the
+    dashboard polling the still-selected board) calls ``connect()`` /
+    ``init_db()``, so the board would reappear despite being "archived". Keeping
+    the directory in place and flagging it archived is what ``include_archived``
+    / the "Show archived" toggle already expect. Hard-delete (``?delete=true``)
+    removes the board outright.
+    """
     try:
-        res = kanban_db.remove_board(slug, archive=not delete)
+        normed = kanban_db._normalize_board_slug(slug)
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc))
+    if not normed or not kanban_db.board_exists(normed):
+        raise HTTPException(status_code=404, detail=f"board {slug!r} does not exist")
+    if delete:
+        res = kanban_db.remove_board(normed, archive=False)
+    else:
+        kanban_db.write_board_metadata(normed, archived=True)
+        res = {"slug": normed, "action": "archived"}
     return {"result": res, "current": kanban_db.get_current_board()}
 
 

--- a/tests/plugins/test_kanban_dashboard_plugin.py
+++ b/tests/plugins/test_kanban_dashboard_plugin.py
@@ -2252,3 +2252,45 @@ def test_dashboard_failed_card_highlight_class_exists():
     assert "hermes-kanban-card--failed" in js
     assert "hermes-kanban-card--failed" in css
     assert "failedIds" in js
+
+
+# ---------------------------------------------------------------------------
+# Archiving a board must be a sticky, reversible flag — not a directory move
+# that auto-resurrects on the next read. Regression for: archived board keeps
+# reappearing in the picker.
+# ---------------------------------------------------------------------------
+
+
+def test_archive_board_is_sticky_flag_and_survives_reads(client):
+    # create a board
+    r = client.post("/api/plugins/kanban/boards", json={"slug": "toarchive", "name": "To Archive"})
+    assert r.status_code == 200
+
+    # archive it (the dashboard "Archive" action: DELETE ?delete=false)
+    r = client.delete("/api/plugins/kanban/boards/toarchive")
+    assert r.status_code == 200
+    assert r.json()["result"].get("action") == "archived"
+
+    # hidden from the default picker, visible only under "Show archived"
+    picker = {b["slug"] for b in client.get("/api/plugins/kanban/boards").json()["boards"]}
+    assert "toarchive" not in picker
+    witharch = {b["slug"]: b for b in client.get("/api/plugins/kanban/boards?include_archived=true").json()["boards"]}
+    assert witharch.get("toarchive", {}).get("archived") is True
+
+    # reading the board (as the dashboard does when it's the selected board)
+    # must NOT resurrect it as a fresh un-archived board
+    assert client.get("/api/plugins/kanban/board?board=toarchive").status_code == 200
+    picker_after = {b["slug"] for b in client.get("/api/plugins/kanban/boards").json()["boards"]}
+    assert "toarchive" not in picker_after  # still archived after a read
+
+    # un-archive via PATCH archived=false brings it back
+    r = client.patch("/api/plugins/kanban/boards/toarchive", json={"archived": False})
+    assert r.status_code == 200
+    assert "toarchive" in {b["slug"] for b in client.get("/api/plugins/kanban/boards").json()["boards"]}
+
+
+def test_hard_delete_board_still_removes(client):
+    client.post("/api/plugins/kanban/boards", json={"slug": "todelete", "name": "To Delete"})
+    r = client.delete("/api/plugins/kanban/boards/todelete?delete=true")
+    assert r.status_code == 200
+    assert "todelete" not in {b["slug"] for b in client.get("/api/plugins/kanban/boards?include_archived=true").json()["boards"]}


### PR DESCRIPTION
## Problem

Archiving a board from the dashboard didn't stick — the board kept reappearing in the picker. `delete_board` (DELETE `/boards/{slug}?delete=false`) called `remove_board(archive=True)`, which **moves** the board directory to `boards/_archived/<slug>-<ts>/`. But the board's slug is still referenced by the UI (it's the selected board), and the very next read — `GET /board` → `_conn()` → `init_db()`/`connect()` — **auto-recreates** an empty board at that slug. So "archive" produced an endless move→resurrect loop (observed: 3 `_archived/<slug>-*` copies plus a live dir again within seconds).

The move approach also never integrated with the **"Show archived"** toggle: `list_boards` only scans `boards/`, not `boards/_archived/`, so a moved board wasn't visible even with `include_archived=true`.

## Fix

Archiving is now a **reversible metadata flag** that the picker already understands:

- `DELETE /boards/{slug}` (archive, `delete=false`) → sets `archived=true` via `write_board_metadata` and **leaves the directory in place**. `list_boards(include_archived=False)` already filters it out of the picker; "Show archived" reveals it. Because the dir stays, `init_db()`/`connect()` on a later read find the existing archived board instead of creating a fresh one — so the archive **sticks**.
- `PATCH /boards/{slug}` now accepts `archived` (un-archive = `archived:false`).
- `DELETE /boards/{slug}?delete=true` (hard-delete) still removes the board outright.

## Tests

Added to `tests/plugins/test_kanban_dashboard_plugin.py`:
- archiving hides the board from the default picker, shows it under `include_archived=true` with `archived:true`, **survives a `GET /board` read without resurrecting**, and un-archives via `PATCH archived:false`;
- hard-delete still removes the board.

Full plugin suite: **97 passed**.

## Compatibility

Additive: `RenameBoardBody` gains an optional `archived` field; the archive action changes from a directory move to a metadata flag (no data moved/lost; reversible). Hard-delete behavior is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)