### PR TITLE
fix(desktop): keep remote folder-picker actions reachable with many folders

### DIFF
--- a/apps/desktop/src/app/right-sidebar/files/remote-picker.tsx
+++ b/apps/desktop/src/app/right-sidebar/files/remote-picker.tsx
@@ -109,14 +109,14 @@ export function RemoteFolderPicker() {
 
   return (
     <Dialog onOpenChange={open => !open && close()} open={Boolean(pending)}>
-      <DialogContent className="max-w-lg gap-0 overflow-hidden p-0">
-        <div className="border-b border-border/70 px-4 py-3">
+      <DialogContent className="flex max-h-[85vh] min-h-[24rem] max-w-lg flex-col gap-0 overflow-hidden p-0">
+        <div className="shrink-0 border-b border-border/70 px-4 py-3">
           <DialogTitle className="text-sm">{pending?.title || r.remotePickerTitle}</DialogTitle>
           <DialogDescription className="mt-1 text-xs">{r.remotePickerDescription}</DialogDescription>
         </div>
 
-        <div className="flex min-h-[22rem] flex-col">
-          <div className="flex flex-wrap items-center gap-1 border-b border-border/50 px-3 py-2 text-xs text-muted-foreground">
+        <div className="flex min-h-0 flex-1 flex-col">
+          <div className="flex shrink-0 flex-wrap items-center gap-1 border-b border-border/50 px-3 py-2 text-xs text-muted-foreground">
             {crumbs.map((crumb, index) => (
               <button
                 className={cn('rounded px-1.5 py-0.5 hover:bg-muted hover:text-foreground', index === crumbs.length - 1 && 'text-foreground')}
@@ -146,7 +146,7 @@ export function RemoteFolderPicker() {
           </div>
         </div>
 
-        <div className="flex items-center justify-between gap-2 border-t border-border/70 px-4 py-3">
+        <div className="flex shrink-0 items-center justify-between gap-2 border-t border-border/70 px-4 py-3">
           <div className="min-w-0 truncate text-xs text-muted-foreground">{currentPath}</div>
           <div className="flex shrink-0 items-center gap-2">
             <Button onClick={() => close()} size="sm" variant="ghost">


### PR DESCRIPTION
Fixes #47786

### Problem
In remote-gateway mode, the **Change working directory** picker (`RemoteFolderPicker`) clips its footer off-screen when the current directory has many subfolders, so **Cancel** and **Select folder** become unreachable and the user can't confirm a folder.

`DialogContent` is a `display:grid` element capped at `max-h-[85vh]` with `overflow-hidden`. The folder-list wrapper is a grid item with the default `min-height: auto` — it never shrinks below its content, so the inner `overflow-y-auto` list never scrolls. With many folders the content grows past the cap and the footer is clipped below the viewport.

### Fix
Lay the dialog out as a bounded flex column:
- `DialogContent` → `flex max-h-[85vh] min-h-[24rem] flex-col` (was relying on the grid default)
- header and footer → `shrink-0` so they stay pinned
- the breadcrumb row → `shrink-0`
- the list region wrapper → `flex-1 min-h-0` so the existing `overflow-y-auto` list scrolls inside the dialog

CSS-only; no behavior/logic change. Affects `apps/desktop/src/app/right-sidebar/files/remote-picker.tsx` only (5 lines).

### Verification
Built the desktop, connected to a remote gateway, opened the picker on a directory with **35 subfolders** (viewport height 800px):

| | Select folder button | visible in viewport | hit-testable |
|---|---|---|---|
| **before** | y 1171–1195 (below dialog bottom ≈740 and viewport 800) | ❌ | ❌ |
| **after** | y 703–727 (inside dialog, pinned footer) | ✅ | ✅ |

The list now scrolls inside the dialog and Cancel / Select folder stay visible regardless of folder count. `tsc -b` passes; no new eslint errors.