### PR TITLE
fix(gateway): avoid duplicate threaded provider errors

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -5039,6 +5039,13 @@ class TurnRunner:
         ctx = self._ctx
         if not ctx._status_adapter or not ctx._run_still_current():
             return
+        _raw_status_text = _redact_gateway_user_facing_secrets(str(message or ""))
+        _provider_error_status_reply = None
+        if (
+            _gateway_platform_value(ctx.source.platform) == "telegram"
+            and _looks_like_gateway_provider_error(_raw_status_text)
+        ):
+            _provider_error_status_reply = _gateway_provider_error_reply(_raw_status_text)
         prepared_message = _prepare_gateway_status_message(
             ctx.source.platform,
             event_type,
@@ -5060,6 +5067,11 @@ class TurnRunner:
         )
         if _fut is None:
             return
+        if (
+            _provider_error_status_reply
+            and prepared_message == _provider_error_status_reply
+        ):
+            ctx._provider_error_status_futures.append((prepared_message, _fut))
         if ctx._cleanup_progress:
             def _track_status_id(fut) -> None:
                 try:
@@ -20302,7 +20314,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # content the user hasn't seen (streaming only sent earlier
             # partial output before the failure).  Without this guard,
             # users see the agent "stop responding without explanation."
-            if agent_result.get("already_sent") and not agent_result.get("failed"):
+            _already_visible_provider_error = bool(
+                agent_result.get("status_provider_error_delivered")
+            )
+            if agent_result.get("already_sent") and (
+                not agent_result.get("failed") or _already_visible_provider_error
+            ):
                 if response:
                     _media_adapter = self._adapter_for_source(source)
                     if _media_adapter:
@@ -28402,6 +28419,31 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
         _notify_task = asyncio.create_task(_notify_long_running())
 
+        async def _provider_error_status_already_delivered(final_text: str) -> bool:
+            if not turn_ctx._provider_error_status_futures or not final_text:
+                return False
+            if _gateway_platform_value(source.platform) != "telegram":
+                return False
+            final_reply = _sanitize_gateway_final_response(source.platform, final_text)
+            for status_reply, fut in list(turn_ctx._provider_error_status_futures):
+                if status_reply != final_reply:
+                    continue
+                try:
+                    if not fut.done():
+                        result = await asyncio.wait_for(
+                            asyncio.wrap_future(fut),
+                            timeout=2.0,
+                        )
+                    else:
+                        result = fut.result()
+                except asyncio.TimeoutError:
+                    continue
+                except Exception:
+                    continue
+                if getattr(result, "success", False):
+                    return True
+            return False
+
         def _stream_confirmed_final_delivery(
             consumer,
             final_text: str,
@@ -29199,6 +29241,16 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # final answer.  Suppressing delivery here leaves the user staring
         # at silence.  (#10xxx — "agent stops after web search")
         _sc = stream_consumer_holder[0]
+        if isinstance(response, dict):
+            _provider_error_final = response.get("final_response") or ""
+            if await _provider_error_status_already_delivered(_provider_error_final):
+                logger.info(
+                    "Suppressing normal final send for session %s: provider error already delivered as threaded status.",
+                    session_key or "?",
+                )
+                response["already_sent"] = True
+                response["status_provider_error_delivered"] = True
+
         if isinstance(response, dict) and not response.get("failed"):
             _final = response.get("final_response") or ""
             _is_empty_sentinel = not _final or _final == "(empty)"

--- a/gateway/turn_context.py
+++ b/gateway/turn_context.py
@@ -143,3 +143,7 @@ class TurnContext:
     _native_slack_task_cards: bool = False
     native_tool_start_callback: Optional[Callable] = None
     native_tool_complete_callback: Optional[Callable] = None
+
+    # Provider-error status send futures, tracked so the final-response path
+    # can avoid sending the same sanitized error a second time.
+    _provider_error_status_futures: List[tuple] = field(default_factory=list)

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -902,9 +902,10 @@ class TelegramAdapter(BasePlatformAdapter):
         # "all"       — every message triggers a push notification (legacy
         #               behavior; opt-in via display.platforms.telegram.notifications).
         self._notifications_mode: str = "important"
-        # send_or_update_status() bookkeeping: {(chat_id, status_key) -> bot message_id}
-        # Tracks status bubbles owned by this adapter so subsequent calls with the
-        # same key edit the same message instead of appending new ones (#30045).
+        # send_or_update_status() bookkeeping:
+        # {(chat_id, status_key, thread_id, dm_topic_id) -> bot message_id}
+        # Tracks status bubbles so subsequent calls with the same key and routing
+        # context edit the same message instead of appending new ones (#30045).
         self._status_message_ids: Dict[tuple, str] = {}
         # Last truncated mid-stream preview delivered per (chat_id, message_id).
         # Once an oversized streaming edit saturates at the 4096 preview cap,
@@ -914,6 +915,9 @@ class TelegramAdapter(BasePlatformAdapter):
         # penalties, hanging final delivery). Dedup here so a saturated preview
         # goes quiet until finalize. Bounded: entries are dropped on finalize.
         self._last_overflow_preview: Dict[tuple, str] = {}
+        # Per-key locks so concurrent send_or_update_status calls for the same
+        # routing key are serialized.
+        self._status_locks: Dict[tuple, "asyncio.Lock"] = {}
         # Background task that runs post-connect housekeeping (command-menu
         # registration + DM-topic setup) off the connect path so a slow Bot
         # API call (e.g. a set_my_commands stall for certain tokens) cannot
@@ -5460,22 +5464,35 @@ class TelegramAdapter(BasePlatformAdapter):
         subsequent calls with the same (chat_id, status_key) edit that same
         message in place. If the edit fails (message deleted, too old, etc.)
         we drop the cached id and send fresh.
+
+        Concurrent calls with the same routing key are serialized via a
+        per-key asyncio.Lock.
         """
-        key = (str(chat_id), str(status_key))
-        cached_id = self._status_message_ids.get(key)
-        if cached_id is not None:
-            result = await self.edit_message(
-                chat_id, cached_id, content, finalize=True, metadata=metadata,
-            )
-            if result.success:
-                if result.message_id:
-                    self._status_message_ids[key] = str(result.message_id)
-                return result
-            # Edit failed — clear the cached id and fall through to a fresh send.
-            self._status_message_ids.pop(key, None)
-        result = await self.send(chat_id, content, metadata=metadata)
-        if result.success and result.message_id:
-            self._status_message_ids[key] = str(result.message_id)
+        key = (
+            str(chat_id),
+            str(status_key),
+            self._metadata_thread_id(metadata),
+            self._metadata_direct_messages_topic_id(metadata),
+        )
+        lock = self._status_locks.get(key)
+        if lock is None:
+            lock = asyncio.Lock()
+            self._status_locks[key] = lock
+        async with lock:
+            cached_id = self._status_message_ids.get(key)
+            if cached_id is not None:
+                result = await self.edit_message(
+                    chat_id, cached_id, content, finalize=True, metadata=metadata,
+                )
+                if result.success:
+                    if result.message_id:
+                        self._status_message_ids[key] = str(result.message_id)
+                    return result
+                # Edit failed — clear the cached id and fall through to a fresh send.
+                self._status_message_ids.pop(key, None)
+            result = await self.send(chat_id, content, metadata=metadata)
+            if result.success and result.message_id:
+                self._status_message_ids[key] = str(result.message_id)
         return result
 
     async def edit_message(

--- a/tests/gateway/test_gateway_silence_tokens.py
+++ b/tests/gateway/test_gateway_silence_tokens.py
@@ -195,3 +195,49 @@ async def test_agent_end_hook_includes_model_and_provider(monkeypatch, tmp_path)
     )
     assert end_context["model"] == "gpt-5.6-terra"
     assert end_context["provider"] == "openai-codex"
+
+
+@pytest.mark.asyncio
+async def test_failed_already_sent_without_provider_status_is_still_delivered(monkeypatch, tmp_path):
+    """Ordinary failed-agent replies must not be hidden just because already_sent is true."""
+    runner = _runner(monkeypatch, tmp_path)
+    runner._run_agent = AsyncMock(return_value={
+        "final_response": "Error: tool crashed",
+        "messages": [],
+        "tools": [],
+        "history_offset": 0,
+        "last_prompt_tokens": 0,
+        "api_calls": 1,
+        "failed": True,
+        "already_sent": True,
+    })
+
+    response = await runner._handle_message_with_agent(
+        _event(), _source(), "agent:main:telegram:group:-1001:12345", 1
+    )
+
+    assert response == "Error: tool crashed"
+
+
+@pytest.mark.asyncio
+async def test_failed_provider_error_with_flag_set_suppresses_duplicate_final(monkeypatch, tmp_path):
+    """When status_provider_error_delivered is set on a failed result, the final
+    duplicate is suppressed because the threaded status path already showed it."""
+    runner = _runner(monkeypatch, tmp_path)
+    runner._run_agent = AsyncMock(return_value={
+        "final_response": "Error code: 429 - rate limited after 10 retries",
+        "messages": [],
+        "tools": [],
+        "history_offset": 0,
+        "last_prompt_tokens": 0,
+        "api_calls": 1,
+        "failed": True,
+        "already_sent": True,
+        "status_provider_error_delivered": True,
+    })
+
+    response = await runner._handle_message_with_agent(
+        _event(), _source(), "agent:main:telegram:group:-1001:12345", 1
+    )
+
+    assert response is None

--- a/tests/gateway/test_telegram_status_update.py
+++ b/tests/gateway/test_telegram_status_update.py
@@ -5,6 +5,9 @@ The status-update path must:
   2. Edit that same message on subsequent calls with the same key.
   3. Fall back to sending fresh when the cached message edit fails.
   4. Keep distinct keys independent (no cross-talk).
+  5. Keep distinct Telegram thread/topic ids independent (no cross-talk).
+  6. Edit in place within the same thread/topic.
+  7. Serialize concurrent calls with the same routing key.
 """
 
 from __future__ import annotations
@@ -18,6 +21,10 @@ import pytest
 
 from gateway.config import PlatformConfig
 from gateway.platforms.base import SendResult
+
+
+def _status_key(chat_id: str, status_key: str, thread_id=None, dm_topic_id=None):
+    return (chat_id, status_key, thread_id, dm_topic_id)
 
 
 def _install_fake_telegram(monkeypatch):
@@ -68,7 +75,6 @@ def adapter(monkeypatch):
 
     a = TelegramAdapter(PlatformConfig(enabled=True, token="fake-token"))
     a._bot = MagicMock()
-    # Patch send / edit_message so tests can drive them directly.
     a.send = AsyncMock()
     a.edit_message = AsyncMock()
     return a
@@ -76,7 +82,6 @@ def adapter(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_first_call_sends_and_caches_message_id(adapter):
-    """First call for a (chat, key) pair must send and remember the id."""
     adapter.send.return_value = SendResult(success=True, message_id="100")
 
     result = await adapter.send_or_update_status("chat-1", "lifecycle", "starting")
@@ -85,12 +90,47 @@ async def test_first_call_sends_and_caches_message_id(adapter):
     assert result.message_id == "100"
     adapter.send.assert_awaited_once()
     adapter.edit_message.assert_not_awaited()
-    assert adapter._status_message_ids[("chat-1", "lifecycle")] == "100"
+    assert adapter._status_message_ids[_status_key("chat-1", "lifecycle")] == "100"
+
+
+@pytest.mark.asyncio
+async def test_second_call_edits_in_place(adapter):
+    adapter.send.return_value = SendResult(success=True, message_id="100")
+    adapter.edit_message.return_value = SendResult(success=True, message_id="100")
+
+    await adapter.send_or_update_status("chat-1", "lifecycle", "step 1")
+    await adapter.send_or_update_status("chat-1", "lifecycle", "step 2")
+
+    adapter.send.assert_awaited_once()
+    adapter.edit_message.assert_awaited_once()
+    args, kwargs = adapter.edit_message.call_args
+    assert args[0] == "chat-1"
+    assert args[1] == "100"
+    assert args[2] == "step 2"
+
+
+@pytest.mark.asyncio
+async def test_edit_failure_falls_back_to_fresh_send(adapter):
+    adapter.send.side_effect = [
+        SendResult(success=True, message_id="100"),
+        SendResult(success=True, message_id="200"),
+    ]
+    adapter.edit_message.return_value = SendResult(
+        success=False, error="Bad Request: message to edit not found",
+    )
+
+    await adapter.send_or_update_status("chat-1", "lifecycle", "step 1")
+    result = await adapter.send_or_update_status("chat-1", "lifecycle", "step 2")
+
+    assert result.success is True
+    assert result.message_id == "200"
+    assert adapter.send.await_count == 2
+    assert adapter.edit_message.await_count == 1
+    assert adapter._status_message_ids[_status_key("chat-1", "lifecycle")] == "200"
 
 
 @pytest.mark.asyncio
 async def test_distinct_status_keys_do_not_collide(adapter):
-    """A different status_key gets its own message; the original isn't touched."""
     adapter.send.side_effect = [
         SendResult(success=True, message_id="100"),
         SendResult(success=True, message_id="200"),
@@ -101,7 +141,123 @@ async def test_distinct_status_keys_do_not_collide(adapter):
 
     assert adapter.send.await_count == 2
     adapter.edit_message.assert_not_awaited()
-    assert adapter._status_message_ids[("chat-1", "lifecycle")] == "100"
-    assert adapter._status_message_ids[("chat-1", "model-switch")] == "200"
+    assert adapter._status_message_ids[_status_key("chat-1", "lifecycle")] == "100"
+    assert adapter._status_message_ids[_status_key("chat-1", "model-switch")] == "200"
 
 
+@pytest.mark.asyncio
+async def test_distinct_chat_ids_do_not_collide(adapter):
+    adapter.send.side_effect = [
+        SendResult(success=True, message_id="100"),
+        SendResult(success=True, message_id="200"),
+    ]
+
+    await adapter.send_or_update_status("chat-1", "lifecycle", "first")
+    await adapter.send_or_update_status("chat-2", "lifecycle", "second")
+
+    assert adapter.send.await_count == 2
+    adapter.edit_message.assert_not_awaited()
+    assert adapter._status_message_ids[_status_key("chat-1", "lifecycle")] == "100"
+    assert adapter._status_message_ids[_status_key("chat-2", "lifecycle")] == "200"
+
+
+@pytest.mark.asyncio
+async def test_distinct_thread_ids_do_not_collide(adapter):
+    adapter.send.side_effect = [
+        SendResult(success=True, message_id="100"),
+        SendResult(success=True, message_id="200"),
+    ]
+
+    await adapter.send_or_update_status(
+        "chat-1", "provider-error", "rate limited",
+        metadata={"thread_id": "11"},
+    )
+    await adapter.send_or_update_status(
+        "chat-1", "provider-error", "rate limited",
+        metadata={"thread_id": "22"},
+    )
+
+    assert adapter.send.await_count == 2
+    adapter.edit_message.assert_not_awaited()
+    assert adapter._status_message_ids[_status_key("chat-1", "provider-error", "11")] == "100"
+    assert adapter._status_message_ids[_status_key("chat-1", "provider-error", "22")] == "200"
+
+
+@pytest.mark.asyncio
+async def test_same_thread_id_edits_in_place(adapter):
+    adapter.send.return_value = SendResult(success=True, message_id="100")
+    adapter.edit_message.return_value = SendResult(success=True, message_id="100")
+
+    await adapter.send_or_update_status(
+        "chat-1", "provider-error", "rate limited",
+        metadata={"thread_id": "11"},
+    )
+    await adapter.send_or_update_status(
+        "chat-1", "provider-error", "still rate limited",
+        metadata={"thread_id": "11"},
+    )
+
+    adapter.send.assert_awaited_once()
+    adapter.edit_message.assert_awaited_once()
+    args, kwargs = adapter.edit_message.call_args
+    assert args[0] == "chat-1"
+    assert args[1] == "100"
+    assert args[2] == "still rate limited"
+    assert kwargs["metadata"] == {"thread_id": "11"}
+
+
+@pytest.mark.asyncio
+async def test_distinct_dm_topic_ids_do_not_collide(adapter):
+    adapter.send.side_effect = [
+        SendResult(success=True, message_id="100"),
+        SendResult(success=True, message_id="200"),
+    ]
+
+    await adapter.send_or_update_status(
+        "chat-1", "lifecycle", "starting",
+        metadata={"direct_messages_topic_id": "7"},
+    )
+    await adapter.send_or_update_status(
+        "chat-1", "lifecycle", "step 2",
+        metadata={"direct_messages_topic_id": "9"},
+    )
+
+    assert adapter.send.await_count == 2
+    adapter.edit_message.assert_not_awaited()
+    assert adapter._status_message_ids[_status_key("chat-1", "lifecycle", None, "7")] == "100"
+    assert adapter._status_message_ids[_status_key("chat-1", "lifecycle", None, "9")] == "200"
+
+
+@pytest.mark.asyncio
+async def test_concurrent_same_key_is_serialized(adapter):
+    import asyncio as _asyncio
+
+    send_started = _asyncio.Event()
+    release_send = _asyncio.Event()
+
+    async def slow_send(*args, **kwargs):
+        send_started.set()
+        await release_send.wait()
+        return SendResult(success=True, message_id="100")
+
+    adapter.send = AsyncMock(side_effect=slow_send)
+    adapter.edit_message.return_value = SendResult(success=True, message_id="100")
+
+    first = _asyncio.create_task(
+        adapter.send_or_update_status("chat-1", "lifecycle", "call A")
+    )
+    await send_started.wait()
+
+    second = _asyncio.create_task(
+        adapter.send_or_update_status("chat-1", "lifecycle", "call B")
+    )
+    await _asyncio.sleep(0.01)
+
+    assert not second.done(), "second call should be blocked waiting for the lock"
+    assert adapter.send.await_count == 1, "exactly one send should be in-flight"
+
+    release_send.set()
+    await _asyncio.gather(first, second)
+
+    assert adapter.send.await_count == 1
+    assert adapter.edit_message.await_count == 1


### PR DESCRIPTION
## What does this PR do?

Provider/API failures can reach the user twice on Telegram: once via the threaded status callback, again via the final sanitized response. This PR suppresses the duplicate by tracking the status delivery future — the final send is skipped only when the threaded status was delivered. If the status send fails or times out, the final response still goes through.

Also fixes `send_or_update_status()` so its cache key includes `thread_id` and `dm_topic_id`, preventing status bubbles from one topic editing a bubble in another. Adds per-key `asyncio.Lock` to serialize concurrent calls with the same routing key.

## Related Issue

N/A — found while investigating duplicate Telegram provider error messages.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- **`gateway/turn_context.py`**
  - Add `_provider_error_status_futures: List[tuple]` field to `TurnContext`.
- **`gateway/run.py`**
  - `TurnRunner._status_callback_sync`: detect provider errors, append matching send futures to `ctx._provider_error_status_futures`.
  - `_provider_error_status_already_delivered()` — awaits matching future (2s timeout), returns True on confirmed delivery.
  - Final-response suppression: skip only if threaded status delivery succeeded; on failure/timeout, normal delivery path runs.
  - `already_sent` guard: allow `failed + status_provider_error_delivered` (ordinary failures always delivered).
- **`plugins/platforms/telegram/adapter.py`**
  - `send_or_update_status()` cache key: `(chat_id, status_key)` → `(chat_id, status_key, thread_id, dm_topic_id)`.
  - `_status_locks: Dict[tuple, asyncio.Lock]` — per-key lock for concurrent-call serialization.
- **`tests/gateway/test_telegram_status_update.py`**
  - Thread isolation, DM-topic isolation, edit-in-place within same topic.
  - `test_concurrent_same_key_is_serialized` — event-gated async verifying two concurrent calls serialize.
- **`tests/gateway/test_gateway_silence_tokens.py`**
  - Ordinary failed responses delivered even when `already_sent=True`.
  - `status_provider_error_delivered=True` suppresses duplicate final send.

## How to Test

1. Run targeted tests:

   ```shell
   python -m pytest tests/gateway/test_telegram_status_update.py tests/gateway/test_gateway_silence_tokens.py -q
   ```

   Result: `18 passed`

2. Compile changed files:

   ```shell
   python -m py_compile gateway/run.py gateway/turn_context.py plugins/platforms/telegram/adapter.py
   ```

3. Whitespace:

   ```shell
   git diff --check
   ```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Linux

### Documentation & Housekeeping

- [x] N/A (no config keys, architecture docs, or tool schemas changed)

