### PR TITLE
chore: add mise toolchain config

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -1,0 +1,14 @@
+[tools]
+python = "3.11.14"
+node = "24.15.0"
+npm = "11.13.0"
+uv = "0.11.7"
+
+[env]
+UV_PYTHON = "3.11.14"
+
+[tasks.test-tool-budget]
+run = "python -m pytest tests/tools/test_tool_result_storage.py -q -o 'addopts='"
+
+[tasks.test-lsp-lifecycle]
+run = "python -m pytest tests/agent/lsp/test_client_e2e.py tests/agent/lsp/test_service.py -q -o 'addopts='"


### PR DESCRIPTION
## Summary
- add `mise.toml` for Hermes dev toolchain migration
- pin Python 3.11.14, Node 24.15.0, npm 11.13.0, and uv 0.11.7 to match the currently verified host setup
- add small mise tasks for the recently touched tool-budget and LSP lifecycle test slices

## Verification
- `mise install`
- `mise exec -- python --version` → Python 3.11.14
- `mise exec -- node --version` → v24.15.0
- `mise exec -- npm --version` → 11.13.0
- `mise exec -- uv --version` → uv 0.11.7
