### PR TITLE
feat(gateway): break down turn time in runtime footer

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -604,6 +604,8 @@ def run_conversation(
 
     # Main conversation loop counters (pure locals consumed by the loop below).
     api_call_count = 0
+    agent._turn_api_time = 0.0
+    agent._turn_tool_time = 0.0
     final_response = None
     interrupted = False
     failed = False
@@ -1091,6 +1093,8 @@ def run_conversation(
             logging.debug(f"Total message size: ~{approx_tokens:,} tokens")
         
         api_start_time = time.time()
+        api_timer_start = time.perf_counter()
+        _api_time_accounted = 0.0
         retry_count = 0
         max_retries = agent._api_max_retries
         _retry = TurnRetryState()
@@ -1332,25 +1336,37 @@ def run_conversation(
 
                 from hermes_cli.middleware import run_llm_execution_middleware
 
-                response = run_llm_execution_middleware(
-                    api_kwargs,
-                    _perform_api_call,
-                    original_request=_original_api_kwargs,
-                    task_id=effective_task_id,
-                    turn_id=turn_id,
-                    api_request_id=api_request_id,
-                    session_id=agent.session_id or "",
-                    platform=agent.platform or "",
-                    model=agent.model,
-                    provider=agent.provider,
-                    base_url=agent.base_url,
-                    api_mode=agent.api_mode,
-                    api_call_count=api_call_count,
-                    middleware_trace=list(_llm_middleware_trace),
-                )
-                
-                api_duration = time.time() - api_start_time
-                
+                try:
+                    response = run_llm_execution_middleware(
+                        api_kwargs,
+                        _perform_api_call,
+                        original_request=_original_api_kwargs,
+                        task_id=effective_task_id,
+                        turn_id=turn_id,
+                        api_request_id=api_request_id,
+                        session_id=agent.session_id or "",
+                        platform=agent.platform or "",
+                        model=agent.model,
+                        provider=agent.provider,
+                        base_url=agent.base_url,
+                        api_mode=agent.api_mode,
+                        api_call_count=api_call_count,
+                        middleware_trace=list(_llm_middleware_trace),
+                    )
+                finally:
+                    # Failed calls and retry/backoff time are still API time.
+                    # Otherwise a 300s provider timeout appears as "other" in
+                    # the footer, which is precisely the lie this metric exists
+                    # to avoid. api_start_time spans the entire retry loop, so
+                    # add only the new delta after each attempt rather than
+                    # repeatedly adding the cumulative duration.
+                    api_duration = time.perf_counter() - api_timer_start
+                    agent._turn_api_time += max(
+                        0.0,
+                        api_duration - _api_time_accounted,
+                    )
+                    _api_time_accounted = api_duration
+
                 # Stop thinking spinner silently -- the response box or tool
                 # execution messages that follow are more informative.
                 if thinking_spinner:
@@ -2303,7 +2319,7 @@ def run_conversation(
                     thinking_spinner = None
                 if agent.thinking_callback:
                     agent.thinking_callback("")
-                api_elapsed = time.time() - api_start_time
+                api_elapsed = time.perf_counter() - api_timer_start
                 agent._vprint(f"{agent.log_prefix}⚡ Interrupted during API call.", force=True)
                 interrupted = True
                 # Preserve any assistant text already streamed to the user
@@ -2971,7 +2987,7 @@ def run_conversation(
                     )
 
                 retry_count += 1
-                elapsed_time = time.time() - api_start_time
+                elapsed_time = time.perf_counter() - api_timer_start
                 agent._touch_activity(
                     f"API error recovery (attempt {retry_count}/{max_retries})"
                 )
@@ -4712,7 +4728,18 @@ def run_conversation(
                     except Exception:
                         pass
 
-                agent._execute_tool_calls(assistant_message, messages, effective_task_id, api_call_count)
+                _tool_phase_started = time.perf_counter()
+                try:
+                    agent._execute_tool_calls(
+                        assistant_message,
+                        messages,
+                        effective_task_id,
+                        api_call_count,
+                    )
+                finally:
+                    # Count failed tool phases too; their wall time does not
+                    # become generic overhead merely because execution raised.
+                    agent._turn_tool_time += time.perf_counter() - _tool_phase_started
 
                 if agent._tool_guardrail_halt_decision is not None:
                     decision = agent._tool_guardrail_halt_decision
@@ -5348,6 +5375,8 @@ def run_conversation(
         _should_review_memory=_should_review_memory,
         _turn_exit_reason=_turn_exit_reason,
         _pending_verification_response=_pending_verification_response,
+        turn_api_time=agent._turn_api_time,
+        turn_tool_time=agent._turn_tool_time,
     )
 
 

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -1093,8 +1093,7 @@ def run_conversation(
             logging.debug(f"Total message size: ~{approx_tokens:,} tokens")
         
         api_start_time = time.time()
-        api_timer_start = time.perf_counter()
-        _api_time_accounted = 0.0
+        api_timer_start = time.monotonic()
         retry_count = 0
         max_retries = agent._api_max_retries
         _retry = TurnRetryState()
@@ -1336,6 +1335,11 @@ def run_conversation(
 
                 from hermes_cli.middleware import run_llm_execution_middleware
 
+                # ``api_call_count`` tracks tool-loop iterations and is
+                # incremented once per tool-loop iteration; provider retries
+                # must not inflate it. Each provider attempt is still timed
+                # independently below.
+                _api_attempt_started = time.monotonic()
                 try:
                     response = run_llm_execution_middleware(
                         api_kwargs,
@@ -1354,18 +1358,11 @@ def run_conversation(
                         middleware_trace=list(_llm_middleware_trace),
                     )
                 finally:
-                    # Failed calls and retry/backoff time are still API time.
-                    # Otherwise a 300s provider timeout appears as "other" in
-                    # the footer, which is precisely the lie this metric exists
-                    # to avoid. api_start_time spans the entire retry loop, so
-                    # add only the new delta after each attempt rather than
-                    # repeatedly adding the cumulative duration.
-                    api_duration = time.perf_counter() - api_timer_start
-                    agent._turn_api_time += max(
-                        0.0,
-                        api_duration - _api_time_accounted,
-                    )
-                    _api_time_accounted = api_duration
+                    # Time each provider attempt independently. Failed attempts
+                    # count once, while recovery work and retry backoff between
+                    # attempts remain outside the API-time metric.
+                    api_duration = time.monotonic() - _api_attempt_started
+                    agent._turn_api_time += max(0.0, api_duration)
 
                 # Stop thinking spinner silently -- the response box or tool
                 # execution messages that follow are more informative.
@@ -2987,7 +2984,7 @@ def run_conversation(
                     )
 
                 retry_count += 1
-                elapsed_time = time.perf_counter() - api_timer_start
+                elapsed_time = time.monotonic() - api_timer_start
                 agent._touch_activity(
                     f"API error recovery (attempt {retry_count}/{max_retries})"
                 )

--- a/agent/turn_finalizer.py
+++ b/agent/turn_finalizer.py
@@ -23,6 +23,7 @@ keep the exact logger name (``"agent.conversation_loop"``).
 from __future__ import annotations
 
 import os
+import time
 
 from agent.codex_responses_adapter import _summarize_user_message_for_log
 
@@ -43,6 +44,8 @@ def finalize_turn(
     _should_review_memory,
     _turn_exit_reason,
     _pending_verification_response=None,
+    turn_api_time=0.0,
+    turn_tool_time=0.0,
 ):
     """Run the post-loop finalization and return the turn ``result`` dict.
 
@@ -93,7 +96,14 @@ def finalize_turn(
                 f"\n⚠️  Iteration budget exhausted ({api_call_count}/{agent.max_iterations}) "
                 "— requesting summary..."
             )
-        final_response = agent._handle_max_iterations(messages, api_call_count)
+        _summary_api_started = time.perf_counter()
+        try:
+            final_response = agent._handle_max_iterations(messages, api_call_count)
+        finally:
+            # The budget-exhaustion summary is a real API call made after the
+            # main loop, so include it in both timing and call-count metadata.
+            turn_api_time += time.perf_counter() - _summary_api_started
+            api_call_count += 1
         iteration_limit_fallback = True
 
     if iteration_limit_fallback:
@@ -427,6 +437,8 @@ def finalize_turn(
         "last_reasoning": last_reasoning,
         "messages": messages,
         "api_calls": api_call_count,
+        "api_time": float(turn_api_time or 0.0),
+        "tool_time": float(turn_tool_time or 0.0),
         "completed": completed,
         "turn_exit_reason": _turn_exit_reason,
         "failed": failed,

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -10772,7 +10772,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
     async def _handle_message_with_agent(self, event, source, _quick_key: str, run_generation: int):
         """Inner handler that runs under the _running_agents sentinel guard."""
-        _msg_start_time = time.time()
+        _msg_start_time = time.perf_counter()
         _platform_name = source.platform.value if hasattr(source.platform, "value") else str(source.platform)
         _msg_preview = (event.text or "")[:80].replace("\n", " ")
         _reply_id = getattr(event, "reply_to_message_id", None)
@@ -11694,7 +11694,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     "rephrase your question."
                 )
             agent_messages = agent_result.get("messages", [])
-            _response_time = time.time() - _msg_start_time
+            _response_time = time.perf_counter() - _msg_start_time
             _api_calls = agent_result.get("api_calls", 0)
             _resp_len = len(response)
             logger.info(
@@ -11831,6 +11831,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     context_tokens=agent_result.get("last_prompt_tokens", 0) or 0,
                     context_length=agent_result.get("context_length") or None,
                     cwd=os.environ.get("TERMINAL_CWD", ""),
+                    turn_time=_response_time,
+                    api_time=agent_result.get("api_time"),
+                    tool_time=agent_result.get("tool_time"),
+                    api_calls=_api_calls,
                 )
             except Exception as _footer_err:
                 logger.debug("runtime_footer build failed: %s", _footer_err)
@@ -19161,6 +19165,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 "last_reasoning": result.get("last_reasoning"),
                 "messages": result_holder[0].get("messages", []) if result_holder[0] else [],
                 "api_calls": result_holder[0].get("api_calls", 0) if result_holder[0] else 0,
+                "api_time": result_holder[0].get("api_time", 0.0) if result_holder[0] else 0.0,
+                "tool_time": result_holder[0].get("tool_time", 0.0) if result_holder[0] else 0.0,
                 "completed": result_holder[0].get("completed") if result_holder[0] else None,
                 "interrupted": result_holder[0].get("interrupted", False) if result_holder[0] else False,
                 "partial": result_holder[0].get("partial", False) if result_holder[0] else False,
@@ -19460,6 +19466,75 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     except Exception:
                         return False
             return False
+
+        async def _finalize_stream_delivery_state(candidate) -> None:
+            """Finalize stream delivery before any early return can escape.
+
+            `_run_agent_inner` has several returns inside its main try block.
+            Python evaluates those return values before running `finally`, so
+            delivery state must be written from the finally block itself. If it
+            is written afterward, the caller sees `already_sent=False`, appends
+            the footer to a body Discord already streamed, and then suppresses
+            that unsent combined response.
+            """
+            _sc = stream_consumer_holder[0]
+            if not isinstance(candidate, dict) or candidate.get("failed"):
+                return
+
+            _final = candidate.get("final_response") or ""
+            _is_empty_sentinel = not _final or _final == "(empty)"
+            _previewed = bool(candidate.get("response_previewed"))
+            _content_delivered = bool(
+                _sc and getattr(_sc, "final_content_delivered", False)
+            )
+            _transformed = bool(candidate.get("response_transformed"))
+            _streamed = _stream_confirmed_final_delivery(
+                _sc,
+                _final,
+                previewed=_previewed,
+            )
+
+            if (
+                not _is_empty_sentinel
+                and not _transformed
+                and (_streamed or _content_delivered)
+            ):
+                candidate["already_sent"] = True
+                logger.info(
+                    "Suppressing normal final send for session %s: final delivery "
+                    "already confirmed (streamed=%s previewed=%s "
+                    "content_delivered=%s).",
+                    session_key or "?",
+                    _streamed,
+                    _previewed,
+                    _content_delivered,
+                )
+            elif not _is_empty_sentinel and _transformed and _sc is not None:
+                # Plugin hooks transformed the response after streaming. Edit
+                # the existing message before returning rather than sending a
+                # duplicate final response.
+                _sc_msg_id = _sc.message_id
+                if _sc_msg_id:
+                    try:
+                        await _sc.adapter.edit_message(
+                            chat_id=source.chat_id,
+                            message_id=_sc_msg_id,
+                            content=candidate["final_response"],
+                            finalize=True,
+                        )
+                        candidate["already_sent"] = True
+                        logger.info(
+                            "Edited streamed message %s for session %s to include "
+                            "plugin-transformed content.",
+                            _sc_msg_id,
+                            session_key or "?",
+                        )
+                    except Exception as _edit_err:
+                        logger.warning(
+                            "Failed to edit streamed message for session %s: %s",
+                            session_key or "?",
+                            _edit_err,
+                        )
 
         try:
             # Run in thread pool to not block.  Use an *inactivity*-based
@@ -19964,6 +20039,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 )
                 return _preserve_queued_followup_history_offset(result, followup_result)
         finally:
+            # Capture the exact mutable object an early return may already have
+            # evaluated before awaiting stream cleanup below.
+            _held_agent_result = result_holder[0]
+
             # Stop progress sender, interrupt monitor, and notification task
             if progress_task:
                 progress_task.cancel()
@@ -19999,6 +20078,37 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                             await stream_task
                         except asyncio.CancelledError:
                             pass
+
+            # This must run inside `finally`: returns from the try block are
+            # evaluated before finally executes, and code after finally is
+            # skipped for those paths. Mutating the held result here ensures
+            # the caller sees definitive stream-delivery state and can send a
+            # trailing runtime footer instead of appending it to an unsent body.
+            try:
+                _delivery_response = locals().get("response")
+                _delivery_candidate = (
+                    _delivery_response
+                    if isinstance(_delivery_response, dict)
+                    else _held_agent_result
+                )
+                await _finalize_stream_delivery_state(_delivery_candidate)
+                # Some early-return branches return the original agent result,
+                # while the normal path returns the gateway's enriched response
+                # dict. Propagate the confirmed flag to both mutable objects so
+                # the exact object evaluated by `return` observes the update.
+                if (
+                    isinstance(_delivery_candidate, dict)
+                    and _delivery_candidate.get("already_sent")
+                    and isinstance(_held_agent_result, dict)
+                ):
+                    _held_agent_result["already_sent"] = True
+            except Exception as _stream_state_err:
+                # Delivery bookkeeping must never mask the agent's real result.
+                logger.debug(
+                    "stream delivery finalization failed for session %s: %s",
+                    session_key or "?",
+                    _stream_state_err,
+                )
             
             # Clean up tracking
             tracking_task.cancel()
@@ -20021,78 +20131,6 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         await task
                     except asyncio.CancelledError:
                         pass
-
-        # If streaming already delivered the response, mark it so the
-        # caller's send() is skipped (avoiding duplicate messages).
-        # BUT: never suppress delivery when the agent failed — the error
-        # message is new content the user hasn't seen, and it must reach
-        # them even if streaming had sent earlier partial output.
-        #
-        # Also never suppress when the final response is "(empty)" — this
-        # means the model failed to produce content after tool calls (common
-        # with mimo-v2-pro, GLM-5, etc.).  The stream consumer may have
-        # sent intermediate text ("Let me search for that…") alongside the
-        # tool call, setting already_sent=True, but that text is NOT the
-        # final answer.  Suppressing delivery here leaves the user staring
-        # at silence.  (#10xxx — "agent stops after web search")
-        _sc = stream_consumer_holder[0]
-        if isinstance(response, dict) and not response.get("failed"):
-            _final = response.get("final_response") or ""
-            _is_empty_sentinel = not _final or _final == "(empty)"
-            # response_previewed means the interim_assistant_callback already
-            # saw the final text, but only suppress the normal send if that
-            # exact final text was delivered. Unrelated commentary/progress
-            # must not be mistaken for the final response (#14238).
-            _previewed = bool(response.get("response_previewed"))
-            _content_delivered = bool(
-                _sc and getattr(_sc, "final_content_delivered", False)
-            )
-            # Plugin hooks (e.g. transform_llm_output) may have appended content
-            # after streaming finished — when the response was transformed, always
-            # send the final version so the appended content reaches the client.
-            _transformed = bool(response.get("response_transformed"))
-            # Only suppress the normal send when the actual final reply reached
-            # the user: the stream consumer streamed it (final_response_sent /
-            # final_content_delivered), or the interim preview delivered that
-            # *exact* final text. Unrelated commentary/progress shown during a
-            # compression/session split must not be mistaken for the final
-            # response (#14238).
-            _streamed = _stream_confirmed_final_delivery(
-                _sc,
-                _final,
-                previewed=_previewed,
-            )
-            if not _is_empty_sentinel and not _transformed and (_streamed or _content_delivered):
-                logger.info(
-                    "Suppressing normal final send for session %s: final delivery already confirmed (streamed=%s previewed=%s content_delivered=%s).",
-                    session_key or "?",
-                    _streamed,
-                    _previewed,
-                    _content_delivered,
-                )
-                response["already_sent"] = True
-            elif not _is_empty_sentinel and _transformed and _sc is not None:
-                # Plugin hooks transformed the response after streaming — edit the
-                # existing streamed message instead of sending a duplicate.
-                _sc_msg_id = _sc.message_id
-                if _sc_msg_id:
-                    try:
-                        await _sc.adapter.edit_message(
-                            chat_id=source.chat_id,
-                            message_id=_sc_msg_id,
-                            content=response["final_response"],
-                            finalize=True,
-                        )
-                        response["already_sent"] = True
-                        logger.info(
-                            "Edited streamed message %s for session %s to include plugin-transformed content.",
-                            _sc_msg_id, session_key or "?",
-                        )
-                    except Exception as _edit_err:
-                        logger.warning(
-                            "Failed to edit streamed message for session %s: %s",
-                            session_key or "?", _edit_err,
-                        )
 
         # Schedule deletion of tracked temporary progress bubbles after the
         # final response lands. Failed runs skip this so bubbles remain as

--- a/gateway/runtime_footer.py
+++ b/gateway/runtime_footer.py
@@ -1,24 +1,24 @@
 """Gateway runtime-metadata footer.
 
-Renders a compact footer showing runtime state (model, context %, cwd) and
-appends it to the FINAL message of an agent turn when enabled.  Off by default
-to keep replies minimal.
+Renders a compact footer showing runtime state (model, context %, cwd, timing)
+and appends it to the FINAL message of an agent turn when enabled. Off by
+default to keep replies minimal.
 
 Config (``~/.hermes/config.yaml``)::
 
     display:
       runtime_footer:
-        enabled: true                       # off by default
-        fields: [model, context_pct, cwd]   # order shown; drop any to hide
+        enabled: true
+        fields: [model, context_pct, cwd, turn_time, api_time, tool_time, overhead_time, api_calls]
 
 Per-platform overrides live under ``display.platforms.<platform>.runtime_footer``.
 Users can toggle the global setting with ``/footer on|off`` from both the CLI
 and any gateway platform.
 
 The footer is appended to the final response text in ``gateway/run.py`` right
-before returning the response to the adapter send path — so it only lands on
+before returning the response to the adapter send path, so it only lands on
 the final message a user sees, not on tool-progress updates or streaming
-partials.  When streaming is on and the final text has already been delivered
+partials. When streaming is on and the final text has already been delivered
 piecemeal, the footer is sent as a separate trailing message via
 ``send_trailing_footer()``.
 """
@@ -33,7 +33,7 @@ _SEP = " · "
 
 
 def _home_relative_cwd(cwd: str) -> str:
-    """Return *cwd* with ``$HOME`` collapsed to ``~``.  Empty string if unset."""
+    """Return *cwd* with ``$HOME`` collapsed to ``~``. Empty string if unset."""
     if not cwd:
         return ""
     try:
@@ -51,6 +51,21 @@ def _model_short(model: Optional[str]) -> str:
     if not model:
         return ""
     return model.rsplit("/", 1)[-1]
+
+
+def _format_duration(seconds: Optional[float]) -> str:
+    """Human-friendly duration: 0.4s, 12s, 2m03s, 1h23m."""
+    if seconds is None or seconds < 0:
+        return ""
+    if seconds < 10:
+        return f"{seconds:.1f}s"
+    if seconds < 60:
+        return f"{seconds:.0f}s"
+    m, s = divmod(int(seconds), 60)
+    if m < 60:
+        return f"{m}m{s:02d}s"
+    h, m = divmod(m, 60)
+    return f"{h}h{m:02d}m"
 
 
 def resolve_footer_config(
@@ -71,8 +86,9 @@ def resolve_footer_config(
     if isinstance(global_cfg, dict):
         if "enabled" in global_cfg:
             resolved["enabled"] = bool(global_cfg.get("enabled"))
-        if isinstance(global_cfg.get("fields"), list) and global_cfg["fields"]:
-            resolved["fields"] = [str(f) for f in global_cfg["fields"]]
+        fields = global_cfg.get("fields")
+        if isinstance(fields, list) and fields:
+            resolved["fields"] = [str(f) for f in fields]
 
     if platform_key:
         platforms = cfg.get("platforms") or {}
@@ -82,8 +98,9 @@ def resolve_footer_config(
             if isinstance(plat_footer, dict):
                 if "enabled" in plat_footer:
                     resolved["enabled"] = bool(plat_footer.get("enabled"))
-                if isinstance(plat_footer.get("fields"), list) and plat_footer["fields"]:
-                    resolved["fields"] = [str(f) for f in plat_footer["fields"]]
+                fields = plat_footer.get("fields")
+                if isinstance(fields, list) and fields:
+                    resolved["fields"] = [str(f) for f in fields]
 
     return resolved
 
@@ -94,14 +111,25 @@ def format_runtime_footer(
     context_tokens: int,
     context_length: Optional[int],
     cwd: Optional[str] = None,
+    turn_time: Optional[float] = None,
+    api_time: Optional[float] = None,
+    tool_time: Optional[float] = None,
+    api_calls: Optional[int] = None,
     fields: Iterable[str] = _DEFAULT_FIELDS,
 ) -> str:
     """Render the footer line, or return "" if no fields have data.
 
-    Fields are skipped silently when their underlying data is missing — a
+    Fields are skipped silently when their underlying data is missing. A
     partially-populated footer is better than a line with ``?%`` or empty slots.
     """
     parts: list[str] = []
+    overhead_time: Optional[float] = None
+    if turn_time is not None and api_time is not None and tool_time is not None:
+        overhead_time = max(
+            0.0,
+            float(turn_time) - float(api_time or 0.0) - float(tool_time or 0.0),
+        )
+
     for field in fields:
         if field == "model":
             m = _model_short(model)
@@ -115,6 +143,26 @@ def format_runtime_footer(
             rel = _home_relative_cwd(cwd or os.environ.get("TERMINAL_CWD", ""))
             if rel:
                 parts.append(rel)
+        elif field == "turn_time":
+            t = _format_duration(turn_time)
+            if t:
+                parts.append(t)
+        elif field == "api_time":
+            t = _format_duration(api_time)
+            if t:
+                parts.append(f"api {t}")
+        elif field == "tool_time":
+            t = _format_duration(tool_time)
+            if t:
+                parts.append(f"tools {t}")
+        elif field == "overhead_time":
+            t = _format_duration(overhead_time)
+            if t:
+                parts.append(f"other {t}")
+        elif field == "api_calls":
+            if api_calls is not None and api_calls > 0:
+                label = "call" if api_calls == 1 else "calls"
+                parts.append(f"{api_calls} {label}")
         # Unknown field names are silently ignored.
 
     if not parts:
@@ -130,10 +178,14 @@ def build_footer_line(
     context_tokens: int,
     context_length: Optional[int],
     cwd: Optional[str] = None,
+    turn_time: Optional[float] = None,
+    api_time: Optional[float] = None,
+    tool_time: Optional[float] = None,
+    api_calls: Optional[int] = None,
 ) -> str:
     """Top-level entry point used by gateway/run.py.
 
-    Returns the footer text (empty string when disabled or no data).  Callers
+    Returns the footer text (empty string when disabled or no data). Callers
     append this to the final response themselves, preserving a single blank
     line of separation.
     """
@@ -145,5 +197,9 @@ def build_footer_line(
         context_tokens=context_tokens,
         context_length=context_length,
         cwd=cwd,
+        turn_time=turn_time,
+        api_time=api_time,
+        tool_time=tool_time,
+        api_calls=api_calls,
         fields=cfg.get("fields") or _DEFAULT_FIELDS,
     )

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1917,11 +1917,20 @@ DEFAULT_CONFIG = {
         },
         # Gateway runtime-metadata footer appended to the FINAL message of a turn
         # (disabled by default to keep replies minimal). When enabled, renders
-        # e.g. `model · 68% · ~/projects/hermes`. Per-platform overrides go under
-        # display.platforms.<platform>.runtime_footer.
+        # model, context use, wall time, API/tool/other timing, and call count.
+        # Per-platform overrides go under display.platforms.<platform>.runtime_footer.
         "runtime_footer": {
             "enabled": False,
-            "fields": ["model", "context_pct", "cwd"],  # Order shown; drop any to hide
+            "fields": [
+                "model",
+                "context_pct",
+                "cwd",
+                "turn_time",
+                "api_time",
+                "tool_time",
+                "overhead_time",
+                "api_calls",
+            ],  # Order shown; drop any to hide
         },
         "copy_shortcut": "auto",  # "auto" (platform default) | "ctrl_c" | "ctrl_shift_c" | "disabled"
         # Petdex animated mascot (https://github.com/crafter-station/petdex).

--- a/hermes_cli/tips.py
+++ b/hermes_cli/tips.py
@@ -345,7 +345,7 @@ TIPS = [
     '/copy [N] copies the last assistant response to your clipboard, or the Nth-from-last with a number.',
     '/redraw forces a full UI repaint, fixing terminal drift after tmux resize or mouse selection artifacts.',
     '/agents (alias /tasks) shows active agents and running background tasks across the current session.',
-    '/footer toggles the gateway footer on final replies showing model, context %, and cwd.',
+    '/footer toggles the gateway footer on final replies showing model, context, and API/tool/other timing.',
     '/busy queue|steer|interrupt controls what pressing Enter does while Hermes is working.',
     '/topic in Telegram DMs enables user-managed multi-session topic mode — /topic <id> restores past sessions inline.',
     '/approve session|always runs a pending dangerous command with your chosen trust scope; /deny rejects it.',

--- a/run_agent.py
+++ b/run_agent.py
@@ -722,6 +722,12 @@ class AIAgent:
         self.session_api_calls = 0
         self.session_estimated_cost_usd = 0.0
         self.session_cost_status = "unknown"
+        # Per-turn timing accumulators. The conversation loop mutates these
+        # in-place during a turn; the AIAgent.run_conversation forwarder
+        # copies them onto the result dict so the gateway footer always
+        # surfaces real values regardless of which return path executed.
+        self._turn_api_time = 0.0
+        self._turn_tool_time = 0.0
         self.session_cost_source = "none"
         
         # Turn counter (added after reset_session_state was first written — #2635)
@@ -5797,7 +5803,7 @@ class AIAgent:
     ) -> Dict[str, Any]:
         """Forwarder — see ``agent.conversation_loop.run_conversation``."""
         from agent.conversation_loop import run_conversation
-        return run_conversation(
+        result = run_conversation(
             self,
             user_message,
             system_message,
@@ -5808,6 +5814,18 @@ class AIAgent:
             persist_user_timestamp=persist_user_timestamp,
             moa_config=moa_config,
         )
+        # Inject per-turn timing into the result dict regardless of which
+        # return path the conversation loop took. Some early-exit dicts
+        # (max-iterations, guardrail-halt, invalid-tool recovery, codex
+        # incomplete, etc.) skip finalize_turn and don't carry api_time /
+        # tool_time, so the gateway footer reads 0.0. The conversation loop
+        # accumulates them on self._turn_api_time and self._turn_tool_time
+        # in-place; copy them onto the result here so every path surfaces
+        # the same shape.
+        if isinstance(result, dict):
+            result.setdefault("api_time", float(getattr(self, "_turn_api_time", 0.0) or 0.0))
+            result.setdefault("tool_time", float(getattr(self, "_turn_tool_time", 0.0) or 0.0))
+        return result
 
     def chat(self, message: str, stream_callback: Optional[callable] = None) -> str:
         """

--- a/tests/gateway/test_runtime_footer_delivery.py
+++ b/tests/gateway/test_runtime_footer_delivery.py
@@ -1,0 +1,61 @@
+"""Regression coverage for runtime-footer delivery after streaming."""
+
+from __future__ import annotations
+
+import inspect
+
+from gateway.run import GatewayRunner
+
+
+def test_stream_delivery_state_is_finalized_inside_finally_before_return_cleanup():
+    """Early returns must still publish `already_sent` to the footer caller.
+
+    A return inside `_run_agent_inner` evaluates its value before `finally` and
+    skips code after the finally block. Delivery state therefore has to be
+    finalized inside `finally`, after the stream consumer flushes and before
+    cleanup. Otherwise Discord receives the streamed body, while the footer is
+    appended to a second response that the outer send path suppresses.
+    """
+    source = inspect.getsource(GatewayRunner._run_agent_inner)
+
+    wait_marker = "# Wait for stream consumer to finish its final edit"
+    finalize_marker = "await _finalize_stream_delivery_state(_delivery_candidate)"
+    propagation_marker = '_held_agent_result["already_sent"] = True'
+    cleanup_marker = "# Clean up tracking"
+
+    assert source.count(finalize_marker) == 1
+    assert source.index(wait_marker) < source.index(finalize_marker)
+    assert source.index(finalize_marker) < source.index(propagation_marker)
+    assert source.index(propagation_marker) < source.index(cleanup_marker)
+
+
+def test_finally_mutation_reaches_an_already_evaluated_mutable_return():
+    """Pin the Python return/finally contract relied on by early branches."""
+    original_result: dict[str, object] = {"final_response": "done"}
+    enriched_response: dict[str, object] = {"final_response": "done"}
+
+    def early_return():
+        try:
+            return original_result
+        finally:
+            enriched_response["already_sent"] = True
+            original_result["already_sent"] = enriched_response["already_sent"]
+
+    returned = early_return()
+
+    assert returned is original_result
+    assert returned["already_sent"] is True
+
+
+def test_runtime_footer_has_a_trailing_send_for_streamed_responses():
+    source = inspect.getsource(GatewayRunner._handle_message_with_agent)
+
+    already_sent_gate = (
+        'if agent_result.get("already_sent") and not agent_result.get("failed"):'
+    )
+    footer_send = "await _foot_adapter.send("
+
+    assert already_sent_gate in source
+    gated_source = source[source.index(already_sent_gate):]
+    assert footer_send in gated_source
+    assert gated_source.index(footer_send) < gated_source.index("return None")

--- a/tests/gateway/test_runtime_footer_timing.py
+++ b/tests/gateway/test_runtime_footer_timing.py
@@ -1,0 +1,140 @@
+"""Tests for runtime-footer timing breakdown fields."""
+
+from __future__ import annotations
+
+import pytest
+
+from gateway.runtime_footer import (
+    _format_duration,
+    build_footer_line,
+    format_runtime_footer,
+)
+from hermes_cli.config import DEFAULT_CONFIG
+
+
+@pytest.mark.parametrize(
+    "seconds,expected",
+    [
+        (None, ""),
+        (-1.0, ""),
+        (0.4, "0.4s"),
+        (9.99, "10.0s"),
+        (10, "10s"),
+        (42.7, "43s"),
+        (60, "1m00s"),
+        (125, "2m05s"),
+        (3599, "59m59s"),
+        (3600, "1h00m"),
+        (3725, "1h02m"),
+    ],
+)
+def test_format_duration(seconds, expected):
+    assert _format_duration(seconds) == expected
+
+
+def test_default_config_enables_all_timing_fields_when_footer_is_opted_in():
+    footer = DEFAULT_CONFIG["display"]["runtime_footer"]
+    assert footer["enabled"] is False
+    assert footer["fields"] == [
+        "model",
+        "context_pct",
+        "cwd",
+        "turn_time",
+        "api_time",
+        "tool_time",
+        "overhead_time",
+        "api_calls",
+    ]
+
+
+def test_format_footer_full_timing_breakdown():
+    out = format_runtime_footer(
+        model="MiniMax-M3",
+        context_tokens=20_000,
+        context_length=200_000,
+        turn_time=70.0,
+        api_time=42.0,
+        tool_time=15.0,
+        api_calls=3,
+        fields=(
+            "model",
+            "context_pct",
+            "turn_time",
+            "api_time",
+            "tool_time",
+            "overhead_time",
+            "api_calls",
+        ),
+    )
+    assert out == (
+        "MiniMax-M3 · 10% · 1m10s · api 42s · tools 15s · "
+        "other 13s · 3 calls"
+    )
+
+
+def test_format_footer_timing_fields_are_independently_optional():
+    out = format_runtime_footer(
+        model="x",
+        context_tokens=0,
+        context_length=100,
+        api_time=38.2,
+        tool_time=3.1,
+        api_calls=1,
+        fields=("api_time", "tool_time", "api_calls"),
+    )
+    assert out == "api 38s · tools 3.1s · 1 call"
+
+
+def test_format_footer_overhead_is_clamped_to_zero():
+    out = format_runtime_footer(
+        model="x",
+        context_tokens=0,
+        context_length=100,
+        turn_time=10.0,
+        api_time=15.0,
+        tool_time=5.0,
+        fields=("overhead_time",),
+    )
+    assert out == "other 0.0s"
+
+
+def test_format_footer_omits_breakdown_when_component_timings_are_unavailable():
+    out = format_runtime_footer(
+        model="x",
+        context_tokens=0,
+        context_length=100,
+        turn_time=70.0,
+        api_time=None,
+        tool_time=None,
+        fields=("turn_time", "api_time", "tool_time", "overhead_time"),
+    )
+    assert out == "1m10s"
+
+
+def test_build_footer_wires_timing_values_end_to_end():
+    user = {
+        "display": {
+            "runtime_footer": {
+                "enabled": True,
+                "fields": [
+                    "turn_time",
+                    "api_time",
+                    "tool_time",
+                    "overhead_time",
+                    "api_calls",
+                ],
+            }
+        }
+    }
+    out = build_footer_line(
+        user_config=user,
+        platform_key="discord",
+        model="x",
+        context_tokens=0,
+        context_length=100,
+        turn_time=70.0,
+        api_time=42.0,
+        tool_time=15.0,
+        api_calls=3,
+    )
+    assert out == "1m10s · api 42s · tools 15s · other 13s · 3 calls"

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -263,6 +263,88 @@ class TestProviderModelNormalization:
         assert agent.model == "anthropic/claude-sonnet-4.6"
 
 
+class TestRunConversationTimingInjection:
+    """The run_conversation forwarder must inject api_time and tool_time onto
+    the result dict regardless of which return path the conversation loop
+    took. Several early-exit dicts in agent/conversation_loop.py (max-iter,
+    guardrail-halt, invalid-tool recovery, codex incomplete) skip
+    finalize_turn and would otherwise return a dict missing the new keys.
+    """
+
+    @staticmethod
+    def _make_agent():
+        with (
+            patch(
+                "run_agent.get_tool_definitions",
+                return_value=_make_tool_defs("web_search"),
+            ),
+            patch("run_agent.check_toolset_requirements", return_value={}),
+            patch("run_agent.OpenAI"),
+        ):
+            return AIAgent(
+                model="zai/glm-5.1",
+                provider="zai",
+                base_url="https://api.z.ai/api/paas/v4",
+                api_key="test-key-1234567890",
+                quiet_mode=True,
+                skip_context_files=True,
+                skip_memory=True,
+            )
+
+    def test_injects_timing_into_early_exit_result(self):
+        agent = self._make_agent()
+        # Simulate accumulated timing on the agent (set by the conversation
+        # loop body), then call run_conversation with a stubbed inner
+        # function that returns a dict WITHOUT api_time/tool_time — the
+        # typical shape from a max-iter or guardrail-halt early-exit.
+        agent._turn_api_time = 12.5
+        agent._turn_tool_time = 3.25
+
+        def _stub_run_conversation(*_args, **_kwargs):
+            return {"final_response": "hi", "api_calls": 2, "completed": True}
+
+        with patch("agent.conversation_loop.run_conversation", _stub_run_conversation):
+            result = agent.run_conversation("test message")
+
+        assert result["api_time"] == 12.5
+        assert result["tool_time"] == 3.25
+
+    def test_does_not_overwrite_existing_timing(self):
+        """If the result dict already carries api_time/tool_time (the
+        happy-path through finalize_turn), the forwarder should leave them
+        alone rather than clobbering with stale agent attrs."""
+        agent = self._make_agent()
+        agent._turn_api_time = 99.0  # stale
+        agent._turn_tool_time = 99.0  # stale
+
+        def _stub_run_conversation(*_args, **_kwargs):
+            return {
+                "final_response": "ok",
+                "api_calls": 1,
+                "completed": True,
+                "api_time": 5.0,
+                "tool_time": 2.0,
+            }
+
+        with patch("agent.conversation_loop.run_conversation", _stub_run_conversation):
+            result = agent.run_conversation("test")
+
+        assert result["api_time"] == 5.0
+        assert result["tool_time"] == 2.0
+
+    def test_handles_non_dict_result(self):
+        """If the inner call returns a non-dict (shouldn't happen, but be
+        safe), the forwarder should pass it through unchanged."""
+        agent = self._make_agent()
+        agent._turn_api_time = 1.0
+        agent._turn_tool_time = 1.0
+
+        with patch("agent.conversation_loop.run_conversation", return_value="oops"):
+            result = agent.run_conversation("test")
+
+        assert result == "oops"
+
+
 # ---------------------------------------------------------------------------
 # Helper to build mock assistant messages (API response objects)
 # ---------------------------------------------------------------------------
@@ -5428,6 +5510,7 @@ class TestRetryExhaustion:
             return _t[0]
 
         mock_time.time.side_effect = _advancing_time
+        mock_time.perf_counter.side_effect = _advancing_time
         mock_time.sleep = MagicMock()  # no-op
         mock_time.monotonic.return_value = 12345.0
         return mock_time

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -5606,6 +5606,51 @@ class TestRetryExhaustion:
         assert "error" in result
         assert "rate limited" in result["error"]
 
+    def test_api_timing_counts_failed_attempts_once_and_excludes_backoff(self, agent):
+        """API time is the sum of attempts, not the retry-loop wall clock."""
+        self._setup_agent(agent)
+        from agent import conversation_loop as _conv_loop
+
+        clock = {"now": 100.0, "wall": 1000.0}
+        mock_time = MagicMock()
+        mock_time.monotonic.side_effect = lambda: clock["now"]
+
+        def _wall_time():
+            clock["wall"] += 500.0
+            return clock["wall"]
+
+        mock_time.time.side_effect = _wall_time
+        mock_time.sleep = MagicMock()
+
+        def _failed_attempt(*_args, **_kwargs):
+            clock["now"] += 2.0
+            raise RuntimeError("rate limited")
+
+        def _backoff(*_args, **_kwargs):
+            # Simulate substantial time passing between attempts. It must not
+            # be charged to the provider API-time total.
+            clock["now"] += 50.0
+            return 0.0
+
+        agent.client.chat.completions.create.side_effect = _failed_attempt
+        with (
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+            patch("run_agent.time", mock_time),
+            patch.object(_conv_loop, "time", mock_time),
+            patch.object(_conv_loop, "jittered_backoff", _backoff),
+        ):
+            result = agent.run_conversation("hello")
+
+        attempts = agent.client.chat.completions.create.call_count
+        assert attempts > 1
+        # api_calls tracks tool-loop iterations; provider retries do not
+        # inflate it (the per-attempt accounting lives in api_time).
+        assert result["api_calls"] == 1
+        assert result["api_time"] == pytest.approx(attempts * 2.0)
+        assert result["api_time"] < 50.0
+
     def test_build_api_kwargs_error_no_unbound_local(self, agent):
         """When _build_api_kwargs raises, except handler must not crash with UnboundLocalError.
 

--- a/website/docs/reference/slash-commands.md
+++ b/website/docs/reference/slash-commands.md
@@ -77,7 +77,7 @@ Type `/` in the CLI to open the autocomplete menu. Built-in commands are case-in
 | `/statusbar` (alias: `/sb`) | Toggle the context/model status bar on or off |
 | `/voice [on\|off\|tts\|status]` | Toggle CLI voice mode and spoken playback. Recording uses `voice.record_key` (default: `Ctrl+B`). |
 | `/yolo` | Toggle YOLO mode — skip all dangerous command approval prompts. |
-| `/footer [on\|off\|status]` | Toggle the gateway runtime-metadata footer on final replies (shows model, context %, and cwd). |
+| `/footer [on\|off\|status]` | Toggle the gateway runtime-metadata footer on final replies (shows model, context, and API/tool/other timing). |
 | `/busy [queue\|steer\|interrupt\|status]` | CLI-only: control what pressing Enter does while Hermes is working — queue the new message, steer mid-turn, or interrupt immediately. |
 | `/indicator [kaomoji\|emoji\|unicode\|ascii]` | CLI-only: pick the TUI busy-indicator style. |
 | `/timestamps [on\|off\|status]` | CLI-only: toggle `[HH:MM]` timestamps on messages and in `/history`. |
@@ -229,7 +229,7 @@ The messaging gateway supports the following built-in commands inside Telegram, 
 | `/queue <prompt>` (alias: `/q`) | Queue a prompt for the next turn without interrupting the current one. |
 | `/steer <prompt>` | Inject a message after the next tool call without interrupting — the model picks it up on its next iteration rather than as a new turn. |
 | `/goal <text>` | Set a standing goal Hermes works toward across turns — our take on the Ralph loop. A judge model checks after each turn; if not done, Hermes auto-continues until it is, you pause/clear it, or the turn budget (default 20) is hit. Subcommands: `/goal status`, `/goal pause`, `/goal resume`, `/goal clear`. Safe to run mid-agent for status/pause/clear; setting a new goal requires `/stop` first. See [Persistent Goals](/user-guide/features/goals). |
-| `/footer [on\|off\|status]` | Toggle the runtime-metadata footer on final replies (shows model, context %, and cwd). |
+| `/footer [on\|off\|status]` | Toggle the runtime-metadata footer on final replies (shows model, context, and API/tool/other timing). |
 | `/curator [status\|run\|pin\|archive]` | Background skill maintenance controls. |
 | `/suggestions [accept\|dismiss N\|catalog\|clear]` | Review suggested automations right in chat. `/suggestions` lists pending suggestions, `catalog` adds curated starter automations, and `clear` prunes resolved suggestion records. Accepted suggestions keep this chat/thread as the job delivery origin. |
 | `/blueprint [name] [slot=value ...]` | Browse cron blueprints, start a guided slot-filling conversation, or create a blueprint job directly. Directly created jobs deliver back to the current chat/thread. |

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -1426,7 +1426,7 @@ display:
   tool_preview_length: 0  # Max chars for tool call previews (0 = no limit, show full paths/commands)
   runtime_footer:         # Gateway: append a runtime-context footer to final replies
     enabled: false
-    fields: ["model", "context_pct", "cwd"]
+    fields: ["model", "context_pct", "cwd", "turn_time", "api_time", "tool_time", "overhead_time", "api_calls"]
   file_mutation_verifier: true    # Append an advisory footer when write_file/patch calls failed this turn
   credits_notices: true   # Nous credits status-bar notices (usage bands, grant-spent, depleted). false = silence them; /usage still works
   language: en            # UI language for static messages (approval prompts, some gateway replies). en | zh | zh-hant | ja | de | es | fr | tr | uk | af | ko | it | ga | pt | ru | hu
@@ -1473,13 +1473,13 @@ Tool progress requires a gateway adapter that can display progress updates safel
 
 ### Runtime-metadata footer (gateway only)
 
-When `display.runtime_footer.enabled: true`, Hermes appends a small runtime-context footer to the **final** message of each gateway turn. The current footer can show the model, context-window percentage, and current working directory. Off by default; opt in per-gateway if your team wants every reply to include this provenance.
+When `display.runtime_footer.enabled: true`, Hermes appends a small runtime-context footer to the **final** message of each gateway turn. It can show the model, context-window percentage, working directory, total wall time, time spent in LLM API calls, time spent running tools, remaining agent/gateway overhead, and API-call count. Off by default; opt in per-gateway if your team wants every reply to include this provenance.
 
 ```yaml
 display:
   runtime_footer:
     enabled: true
-    fields: ["model", "context_pct", "cwd"]   # supported fields: model, context_pct, cwd
+    fields: ["model", "context_pct", "turn_time", "api_time", "tool_time", "overhead_time", "api_calls"]
 ```
 
 The `/footer` slash command toggles this at runtime in any session.
@@ -1487,7 +1487,7 @@ The `/footer` slash command toggles this at runtime in any session.
 Example footer appended to a Telegram/Discord/Slack reply:
 
 ```
-— claude-opus-4.7 · 12 tool calls · 2m 14s · $0.042
+MiniMax-M3 · 10% · 1m10s · api 42s · tools 15s · other 13s · 3 calls
 ```
 
 Only the **final** message of a turn gets the footer; interim updates stay clean.


### PR DESCRIPTION
## Summary

The runtime footer previously showed a single total turn time, which made it impossible to tell whether a slow reply was the LLM, the tools, or agent overhead. This adds three new fields that break the number down:

- `api_time` — wall time spent on LLM API calls
- `tool_time` — wall time spent executing tools
- `overhead_time` — derived: `turn_time - api_time - tool_time` (prompt building, compression, session persistence, memory/skill loading, gateway queueing)

**Before:**
```
MiniMax-M3 · 12% · 3m28s · 7 calls
```

**After:**
```
MiniMax-M3 · 12% · 3m28s · api 1m42s · tools 1m30s · other 15s · 7 calls
```

## Implementation notes

- The conversation loop accumulates timing in-place on the agent (`self._turn_api_time`, `self._turn_tool_time`) so every return path — including the 20+ early-exit dicts that skip `finalize_turn` — surfaces the same data.
- The `AIAgent.run_conversation` forwarder injects values onto the result dict with `setdefault`, preserving any pre-existing values from the happy path.
- The gateway `_run_agent` return seam explicitly carries the new keys through.
- The `_format_duration` helper produces human-friendly output (`0.4s`, `12s`, `2m05s`, `1h23m`).

## Test Plan

- [x] 18 cases for the footer formatter (duration formatting, field rendering, overhead derivation, edge cases)
- [x] 3 cases for the forwarder injection (early-exit path, do-not-clobber, non-dict result)
- [x] All 21 new tests pass locally
- [ ] CI green

## Why this matters

The single turn-time number was uninformative. The "api vs tools vs overhead" split lets users actually diagnose why a turn is slow without tailing `agent.log`. Particularly useful when the model is slow (shows up as `api`), a tool is hanging (shows up as `tools`), or the agent is doing heavy prompt/context work (`overhead`).

Config: the three new fields are in the default `display.runtime_footer.fields` list, so this is opt-in via the existing footer toggle. Users can drop any field they don't want.