### PR TITLE
fix(cron): rebuild Anthropic client on stale stream instead of OpenAI client

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -2361,7 +2361,10 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
             # Rebuild the primary client too — its connection pool
             # may hold dead sockets from the same provider outage.
             try:
-                agent._replace_primary_openai_client(reason="stale_stream_pool_cleanup")
+                if getattr(agent, "api_mode", None) == "anthropic_messages":
+                    agent._rebuild_anthropic_client()
+                else:
+                    agent._replace_primary_openai_client(reason="stale_stream_pool_cleanup")
             except Exception:
                 pass
             # Reset the timer so we don't kill repeatedly while


### PR DESCRIPTION
## Summary

- When a stale stream is detected for `anthropic_messages` providers (e.g. `provider: anthropic`), the recovery path was calling `_replace_primary_openai_client()` — which fails with `"OPENAI_API_KEY not set"` and silently leaves the Anthropic SDK client in a broken state
- All subsequent reconnect attempts then hang indefinitely, eventually causing the cron job to hit its inactivity timeout
- Fix mirrors the existing interrupt-handler logic at line 2376–2378: call `_rebuild_anthropic_client()` when `api_mode == "anthropic_messages"`, otherwise fall back to the OpenAI client rebuild

## Test plan

- [ ] Trigger a cron job using `provider: anthropic` and confirm it completes successfully after a transient API stall
- [ ] Confirm non-Anthropic providers still use `_replace_primary_openai_client()` on stale stream

🤖 Generated with [Claude Code](https://claude.com/claude-code)