### PR TITLE
fix(agent): show full file path in context file truncation warning

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -1510,14 +1510,20 @@ def build_nous_subscription_prompt(valid_tool_names: "set[str] | None" = None) -
 # Context files (SOUL.md, AGENTS.md, .cursorrules)
 # =========================================================================
 
-def _truncate_content(content: str, filename: str, max_chars: Optional[int] = None) -> str:
+def _truncate_content(
+    content: str,
+    filename: str,
+    max_chars: Optional[int] = None,
+    file_path: Optional[str] = None,
+) -> str:
     """Head/tail truncation with a marker in the middle."""
     if max_chars is None:
         max_chars = _get_context_file_max_chars()
     if len(content) <= max_chars:
         return content
+    display_name = file_path or filename
     msg = (
-        f"⚠️  Context file {filename} TRUNCATED: "
+        f"⚠️  Context file {display_name} TRUNCATED: "
         f"{len(content)} chars exceeds limit of {max_chars} — "
         f"increase context_file_max_chars or trim the file!"
     )
@@ -1552,7 +1558,7 @@ def load_soul_md() -> Optional[str]:
         if not content:
             return None
         content = _scan_context_content(content, "SOUL.md")
-        content = _truncate_content(content, "SOUL.md")
+        content = _truncate_content(content, "SOUL.md", file_path=str(soul_path))
         return content
     except Exception as e:
         logger.debug("Could not read SOUL.md from %s: %s", soul_path, e)
@@ -1576,7 +1582,7 @@ def _load_hermes_md(cwd_path: Path) -> str:
             pass
         content = _scan_context_content(content, rel)
         result = f"## {rel}\n\n{content}"
-        return _truncate_content(result, ".hermes.md")
+        return _truncate_content(result, ".hermes.md", file_path=str(hermes_md_path))
     except Exception as e:
         logger.debug("Could not read %s: %s", hermes_md_path, e)
         return ""
@@ -1592,7 +1598,7 @@ def _load_agents_md(cwd_path: Path) -> str:
                 if content:
                     content = _scan_context_content(content, name)
                     result = f"## {name}\n\n{content}"
-                    return _truncate_content(result, "AGENTS.md")
+                    return _truncate_content(result, "AGENTS.md", file_path=str(candidate))
             except Exception as e:
                 logger.debug("Could not read %s: %s", candidate, e)
     return ""
@@ -1608,7 +1614,7 @@ def _load_claude_md(cwd_path: Path) -> str:
                 if content:
                     content = _scan_context_content(content, name)
                     result = f"## {name}\n\n{content}"
-                    return _truncate_content(result, "CLAUDE.md")
+                    return _truncate_content(result, "CLAUDE.md", file_path=str(candidate))
             except Exception as e:
                 logger.debug("Could not read %s: %s", candidate, e)
     return ""
@@ -1641,7 +1647,9 @@ def _load_cursorrules(cwd_path: Path) -> str:
 
     if not cursorrules_content:
         return ""
-    return _truncate_content(cursorrules_content, ".cursorrules")
+    return _truncate_content(
+        cursorrules_content, ".cursorrules", file_path=str(cursorrules_file)
+    )
 
 
 def build_context_files_prompt(cwd: Optional[str] = None, skip_soul: bool = False) -> str:

--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -218,6 +218,52 @@ class TestTruncateContent:
         assert len(parent_warnings) == 1
         assert "parent.md" in parent_warnings[0]
 
+    def test_file_path_included_in_warning(self, monkeypatch):
+        """When file_path is provided, the warning shows the full path."""
+        def fake_load_config():
+            return {"context_file_max_chars": 120}
+
+        monkeypatch.setattr("hermes_cli.config.load_config", fake_load_config)
+        content = "x" * 180
+
+        _truncate_content(
+            content, "AGENTS.md", file_path="/home/user/.hermes/hermes-agent/AGENTS.md"
+        )
+
+        warnings = drain_truncation_warnings()
+        assert len(warnings) == 1
+        assert "/home/user/.hermes/hermes-agent/AGENTS.md" in warnings[0]
+        assert "AGENTS.md TRUNCATED" in warnings[0]
+
+    def test_file_path_in_marker(self, monkeypatch):
+        """When file_path is provided, the in-content marker still uses filename."""
+        def fake_load_config():
+            return {"context_file_max_chars": 120}
+
+        monkeypatch.setattr("hermes_cli.config.load_config", fake_load_config)
+        content = "x" * 180
+
+        result = _truncate_content(
+            content, "AGENTS.md", file_path="/some/path/AGENTS.md"
+        )
+
+        # The in-content marker uses filename (not file_path) for brevity
+        assert "truncated agents.md" in result.lower()
+
+    def test_file_path_none_uses_filename(self, monkeypatch):
+        """When file_path is None, the warning falls back to filename."""
+        def fake_load_config():
+            return {"context_file_max_chars": 120}
+
+        monkeypatch.setattr("hermes_cli.config.load_config", fake_load_config)
+        content = "x" * 180
+
+        _truncate_content(content, "fallback.md")
+
+        warnings = drain_truncation_warnings()
+        assert len(warnings) == 1
+        assert "fallback.md" in warnings[0]
+
 
 # =========================================================================
 # _parse_skill_file — single-pass skill file reading


### PR DESCRIPTION
## What does this PR do?

Adds the full file path to the context file truncation warning message. When a context file (AGENTS.md, CLAUDE.md, .hermes.md, .cursorrules, SOUL.md) exceeds `context_file_max_chars`, the warning now shows the complete path (e.g. `/home/user/.hermes/hermes-agent/AGENTS.md`) instead of just the filename (`AGENTS.md`).

## Related Issue

Fixes #47753

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/prompt_builder.py`: Added optional `file_path` parameter to `_truncate_content()`; when provided, the warning message uses the full path. Updated all 5 callers (`load_soul_md`, `_load_hermes_md`, `_load_agents_md`, `_load_claude_md`, `_load_cursorrules`) to pass the resolved file path.
- `tests/agent/test_prompt_builder.py`: Added 3 tests for the `file_path` parameter — full path in warning, filename preserved in marker, fallback to filename when `file_path` is None.

## How to Test

1. Run `python -m pytest tests/agent/test_prompt_builder.py -q` — all 142 tests pass (including 3 new ones)
2. Set `context_file_max_chars: 120` in config.yaml
3. Place a large AGENTS.md in any project directory
4. Start `hermes chat` from that directory
5. Verify the warning shows the full path: `⚠️  Context file /path/to/AGENTS.md TRUNCATED: ...`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

⚠️ GitNexus unavailable — grep-based fallback used.
- Checked: `agent/prompt_builder.py` (`_truncate_content`, `load_soul_md`, `_load_hermes_md`, `_load_agents_md`, `_load_claude_md`, `_load_cursorrules`)
- Blast radius: LOW — additive parameter with backward-compatible default (`None`)
- Related patterns: `_get_context_file_max_chars()` config reader, `_record_truncation_warning()` context-scoped accumulator
