### PR TITLE
fix(gateway): parse Feishu interactive cards and stop truncating log …

### DIFF
--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -262,6 +262,8 @@ FALLBACK_POST_TEXT = "[Rich text message]"
 FALLBACK_FORWARD_TEXT = "[Merged forward message]"
 FALLBACK_SHARE_CHAT_TEXT = "[Shared chat]"
 FALLBACK_INTERACTIVE_TEXT = "[Interactive message]"
+# Max card body lines to surface; rich alert cards exceed a dozen.
+_INTERACTIVE_CARD_MAX_LINES = 60
 FALLBACK_IMAGE_TEXT = "[Image]"
 FALLBACK_ATTACHMENT_TEXT = "[Attachment]"
 # ---------------------------------------------------------------------------
@@ -279,8 +281,6 @@ _SUPPORTED_CARD_TEXT_KEYS = (
     "text",
     "content",
     "label",
-    "value",
-    "name",
     "summary",
     "subtitle",
     "description",
@@ -883,6 +883,22 @@ def _load_feishu_payload(raw_content: str) -> Dict[str, Any]:
     return parsed if isinstance(parsed, dict) else {"content": parsed}
 
 
+def _parse_card_user_dsl(payload: Any) -> Optional[Dict[str, Any]]:
+    """Return the parsed schema-2.0 card embedded in a `user_dsl` JSON string,
+    or None when absent/unparseable. CardKit 2.0 webhook events carry the real
+    card here while top-level `elements` is a lossy old-client fallback."""
+    if not isinstance(payload, dict):
+        return None
+    raw = payload.get("user_dsl")
+    if not isinstance(raw, str) or not raw.strip():
+        return None
+    try:
+        parsed = json.loads(raw)
+    except (json.JSONDecodeError, TypeError):
+        return None
+    return parsed if isinstance(parsed, dict) else None
+
+
 def _normalize_merge_forward_message(payload: Dict[str, Any]) -> FeishuNormalizedMessage:
     title = _first_non_empty_text(
         payload.get("title"),
@@ -934,6 +950,15 @@ def _normalize_share_chat_message(payload: Dict[str, Any]) -> FeishuNormalizedMe
 
 def _normalize_interactive_message(message_type: str, payload: Dict[str, Any]) -> FeishuNormalizedMessage:
     card_payload = payload.get("card") if isinstance(payload.get("card"), dict) else payload
+    # CardKit 2.0 dual-publish: Feishu ships the real schema-2.0 card as a JSON
+    # string in `user_dsl`, alongside a lossy flattened `elements`/`title`
+    # fallback for older clients. The fallback's `{tag:"text"}` nodes are
+    # dropped by the rich-block gate in _collect_text_segments, so without
+    # parsing user_dsl we only ever recover the header title. Prefer the
+    # user_dsl card (its body uses markdown/div nodes we already extract).
+    dsl_card = _parse_card_user_dsl(payload) or _parse_card_user_dsl(card_payload)
+    if dsl_card is not None:
+        card_payload = dsl_card
     title = _first_non_empty_text(
         _find_header_title(card_payload),
         payload.get("title"),
@@ -951,7 +976,10 @@ def _normalize_interactive_message(message_type: str, payload: Dict[str, Any]) -
     if actions:
         lines.append(f"Actions: {', '.join(actions)}")
 
-    text_content = "\n".join(lines[:12]).strip() or FALLBACK_INTERACTIVE_TEXT
+    # Cap generously: rich alert cards legitimately run well past a dozen
+    # lines (header + fields + table + links + button). The old limit of 12
+    # silently truncated the trailing links/buttons.
+    text_content = "\n".join(lines[:_INTERACTIVE_CARD_MAX_LINES]).strip() or FALLBACK_INTERACTIVE_TEXT
     return FeishuNormalizedMessage(
         raw_type=message_type,
         text_content=text_content,
@@ -1005,8 +1033,54 @@ def _collect_forward_entries(payload: Dict[str, Any]) -> List[str]:
 
 def _collect_card_lines(payload: Any) -> List[str]:
     lines = _collect_text_segments(payload, in_rich_block=False)
-    normalized = [_normalize_feishu_text(line) for line in lines]
+    normalized = [_flatten_markdown_links(_normalize_feishu_text(line)) for line in lines]
     return _unique_lines([line for line in normalized if line])
+
+
+def _flatten_markdown_links(text: str) -> str:
+    """Rewrite markdown links ``[label](url)`` to a bare ``label: url`` form.
+
+    Card download links often carry literal parens (e.g. a build number like
+    ``report_v1.2.3(456).zip``). Wrapped in markdown ``[label](url)`` — or,
+    worse, percent-encoded to dodge the link delimiters — models tend to
+    misread the URL as malformed/truncated and either reconstruct a wrong
+    filename or refuse it. A bare labelled URL is the most reliable thing for
+    the agent to read and reproduce verbatim, and Feishu still auto-links it
+    on output.
+
+    The destination is delimited by balanced parens (CommonMark): we scan from
+    each ``](`` tracking paren depth to find the real closing paren, so an
+    inner ``(456)`` is kept as part of the URL rather than mistaken for the
+    link's end.
+    """
+    if "](" not in text:
+        return text
+    result: List[str] = []
+    pos = 0
+    for m in re.finditer(r"\[([^\]]*)\]\(", text):
+        if m.start() < pos:
+            continue
+        label = m.group(1).strip()
+        url_start = m.end()
+        depth = 1
+        j = url_start
+        while j < len(text):
+            ch = text[j]
+            if ch == "(":
+                depth += 1
+            elif ch == ")":
+                depth -= 1
+                if depth == 0:
+                    break
+            j += 1
+        if depth != 0:  # unbalanced — leave this link untouched
+            continue
+        url = text[url_start:j].strip()
+        result.append(text[pos:m.start()])
+        result.append(f"{label}: {url}" if label else url)
+        pos = j + 1  # skip past the closing ')'
+    result.append(text[pos:])
+    return "".join(result)
 
 
 def _collect_action_labels(payload: Any) -> List[str]:
@@ -1017,11 +1091,15 @@ def _collect_action_labels(payload: Any) -> List[str]:
         tag = str(item.get("tag", "") or item.get("type", "")).strip().lower()
         if tag not in {"button", "select_static", "overflow", "date_picker", "picker"}:
             continue
+        # Display label lives in `text` (a string in v1, or {"content": ...}
+        # in schema 2.0) or `label`. Never fall back to `name`/`value` — those
+        # are the control's internal id / callback payload (e.g.
+        # "Button_m6vy7xom"), not human-readable text.
+        text_field = item.get("text")
         label = _first_non_empty_text(
-            item.get("text"),
-            item.get("name"),
-            item.get("value"),
-            _find_first_text(item, keys=("text", "content", "name", "value")),
+            text_field.get("content") if isinstance(text_field, dict) else text_field,
+            item.get("label"),
+            _find_first_text(item, keys=("content", "text", "label")),
         )
         if label:
             labels.append(label)
@@ -1065,7 +1143,14 @@ def _collect_text_segments(value: Any, *, in_rich_block: bool) -> List[str]:
     for key, item in value.items():
         if key in _SKIP_TEXT_KEYS:
             continue
-        segments.extend(_collect_text_segments(item, in_rich_block=next_in_rich_block))
+        # Only descend into nested structures. Text strings are harvested
+        # exclusively via the _SUPPORTED_CARD_TEXT_KEYS allowlist above;
+        # recursing into bare string fields here would scoop up layout/style
+        # metadata (element_id, "left", "weighted", "default", color names,
+        # button name/type, ...) the moment in_rich_block is set, flooding the
+        # output with noise and pushing real content past the line cap.
+        if isinstance(item, (dict, list)):
+            segments.extend(_collect_text_segments(item, in_rich_block=next_in_rich_block))
     return segments
 
 
@@ -4707,7 +4792,20 @@ class FeishuAdapter(BasePlatformAdapter):
     @staticmethod
     def _build_get_message_request(message_id: str) -> Any:
         if "GetMessageRequest" in globals():
-            return GetMessageRequest.builder().message_id(message_id).build()
+            request = GetMessageRequest.builder().message_id(message_id).build()
+            # Ask Feishu for the authoritative CardKit 2.0 card payload (incl.
+            # `user_dsl` / schema-2.0 DSL). Without this query param the GET
+            # message endpoint returns only the lossy v1 fallback — for v2
+            # cards that fallback is just an "upgrade your client" placeholder,
+            # so a fetched (quoted/parent) card loses all of its body content.
+            try:
+                queries = list(getattr(request, "queries", None) or [])
+                if not any(k == "card_msg_content_type" for k, _ in queries):
+                    queries.append(("card_msg_content_type", "user_card_content"))
+                request.queries = queries
+            except Exception:
+                logger.debug("[Feishu] could not set card_msg_content_type query", exc_info=True)
+            return request
         return SimpleNamespace(message_id=message_id)
 
     @staticmethod

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -8199,7 +8199,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # is referencing. History can contain the same or similar text
             # multiple times, and without an explicit pointer the agent has to
             # guess (or answer for both subjects). Token overhead is minimal.
-            reply_snippet = event.reply_to_text[:500]
+            # Cap generously: rich interactive cards (alert notifications with
+            # fields + table + several download links) run well past 500 chars,
+            # and a 500-char cut lands mid-URL — the agent then sees only a link
+            # prefix and (correctly) reports the URL as truncated. 4000 chars
+            # comfortably fits such cards while keeping token overhead minimal.
+            reply_snippet = event.reply_to_text[:4000]
             message_text = f'[Replying to: "{reply_snippet}"]\n\n{message_text}'
 
         if "@" in message_text:

--- a/tests/gateway/test_feishu.py
+++ b/tests/gateway/test_feishu.py
@@ -159,6 +159,253 @@ class TestFeishuMessageNormalization(unittest.TestCase):
             "Build Failed\nService: payments-api\nBranch: main\nView Logs\nRetry\nActions: View Logs, Retry",
         )
 
+    def test_normalize_interactive_card_extracts_body_from_user_dsl(self):
+        """CardKit 2.0 dual-publish: real content lives in the `user_dsl`
+        schema-2.0 string; the top-level `elements`/`title` are a lossy
+        fallback. Body must be extracted, not just the title.
+
+        Regression: a card only yielded the title because `user_dsl` was
+        never parsed and the fallback `{tag:text}` nodes were dropped by the
+        rich-block gate.
+        """
+        from gateway.platforms.feishu import normalize_feishu_message
+
+        user_dsl = {
+            "config": {},
+            "elements": [
+                {
+                    "background_style": "default",
+                    "columns": [
+                        {
+                            "tag": "column",
+                            "elements": [
+                                {"content": "<at id=all></at>", "tag": "markdown"},
+                                {"content": "**操作人员**：Alice", "tag": "markdown"},
+                                {"content": "**项目名称**：Demo App i18n", "tag": "markdown"},
+                                {"content": "**时间**：2026-06-09 10:11:20", "tag": "markdown"},
+                                {"content": "**结果**：成功", "tag": "markdown"},
+                                {"content": "**类型**：客户端", "tag": "markdown"},
+                                {"content": "**版本**：4.1.0", "tag": "markdown"},
+                                {"content": "**描述**：", "tag": "markdown"},
+                            ],
+                        }
+                    ],
+                    "tag": "column_set",
+                }
+            ],
+            "header": {
+                "template": "blue",
+                "title": {"content": "发布通知", "tag": "plain_text"},
+            },
+        }
+        raw_content = json.dumps(
+            {
+                "title": "发布通知",
+                "elements": [
+                    [
+                        {"tag": "text", "text": "@所有人"},
+                        {"tag": "text", "text": "操作人员"},
+                        {"tag": "text", "text": "：Alice"},
+                    ]
+                ],
+                "user_dsl": json.dumps(user_dsl, ensure_ascii=False),
+            },
+            ensure_ascii=False,
+        )
+
+        normalized = normalize_feishu_message(
+            message_type="interactive",
+            raw_content=raw_content,
+        )
+
+        self.assertEqual(normalized.relation_kind, "interactive")
+        text = normalized.text_content
+        self.assertIn("发布通知", text)
+        self.assertIn("Alice", text)
+        self.assertIn("Demo App i18n", text)
+        self.assertIn("成功", text)
+        self.assertIn("4.1.0", text)
+
+    def test_normalize_interactive_card_extracts_links_table_and_no_layout_noise(self):
+        """schema-2.0 card with nested columns, a markdown table, hyperlink
+        nodes and a button. Regression for two defects:
+          1. _collect_text_segments harvested layout/style scalars
+             (element_id, background_style, alignments, colors) as if text.
+          2. the 12-line cap truncated the bottom links/button.
+        """
+        from gateway.platforms.feishu import normalize_feishu_message
+
+        def md(content, eid):
+            return {
+                "content": content,
+                "element_id": eid,
+                "tag": "markdown",
+                "text_align": "left",
+                "background_style": "default",
+            }
+
+        user_dsl = {
+            "schema": "2.0",
+            "config": {"streaming_mode": False},
+            "header": {
+                "template": "red",
+                "title": {"content": "通知：示例标题，请及时查看", "tag": "plain_text"},
+            },
+            "body": {
+                "direction": "vertical",
+                "padding": "12px 12px 12px 12px",
+                "elements": [
+                    md("<font color='grey'>账号</font>\nuser@example.com", "_2"),
+                    {
+                        "tag": "column_set",
+                        "element_id": "_3",
+                        "flex_mode": "none",
+                        "horizontal_align": "left",
+                        "columns": [
+                            {
+                                "tag": "column",
+                                "element_id": "_8",
+                                "vertical_align": "top",
+                                "weight": 1,
+                                "width": "weighted",
+                                "elements": [md("<font color='grey'>环境</font>\nprod", "_9")],
+                            },
+                            {
+                                "tag": "column",
+                                "element_id": "_10",
+                                "width": "weighted",
+                                "elements": [md("<font color='grey'>实例ID</font>", "_13")],
+                            },
+                        ],
+                    },
+                    {"tag": "hr", "element_id": "_22"},
+                    md("\n| 组件 | 版本 |\n| --- | --- |\n| 核心 |  |\n| 客户端 | v3.3.0(33079) |\n", "_23"),
+                    md("[日志](https://res.example.com/app_log.zip)", "_30"),
+                    md("附加日志", "_35"),
+                    md("[统计](https://api.example.com/statistics)", "_43"),
+                    md("[详情](https://api.example.com/event_detail?id=125)", "_48"),
+                    {
+                        "tag": "column_set",
+                        "element_id": "_54",
+                        "columns": [
+                            {
+                                "tag": "column",
+                                "element_id": "_55",
+                                "width": "auto",
+                                "elements": [
+                                    {
+                                        "tag": "button",
+                                        "element_id": "_56",
+                                        "name": "Button_m6vy7xom",
+                                        "type": "primary",
+                                        "form_action_type": "submit",
+                                        "url": "https://api.example.com/event_detail?id=125",
+                                        "text": {"content": "去处理", "tag": "plain_text"},
+                                    }
+                                ],
+                            }
+                        ],
+                    },
+                ],
+            },
+        }
+        raw_content = json.dumps(
+            {
+                "title": "[Action Needed] Alert",
+                "elements": [[{"tag": "text", "text": "Upgrade to the latest app version"}]],
+                "user_dsl": json.dumps(user_dsl, ensure_ascii=False),
+            },
+            ensure_ascii=False,
+        )
+
+        normalized = normalize_feishu_message(
+            message_type="interactive",
+            raw_content=raw_content,
+        )
+        text = normalized.text_content
+
+        # Title + every meaningful line must survive (no 12-line truncation).
+        self.assertIn("通知：示例标题，请及时查看", text)
+        self.assertIn("user@example.com", text)
+        self.assertIn("v3.3.0(33079)", text)  # table cell
+        self.assertIn("https://res.example.com/app_log.zip", text)  # log link
+        self.assertIn("https://api.example.com/statistics", text)  # stats link
+        self.assertIn("https://api.example.com/event_detail?id=125", text)  # detail link
+        self.assertIn("去处理", text)  # button label
+
+        # Layout/style metadata must NOT leak in as text lines.
+        card_lines = text.split("\n")
+        for noise in ("_2", "_3", "_23", "_56", "weighted", "auto", "default", "primary", "submit", "Button_m6vy7xom"):
+            self.assertNotIn(noise, card_lines, f"layout noise leaked: {noise!r}")
+
+    def test_normalize_interactive_card_bare_schema_2_0_without_user_dsl(self):
+        """Fetched (quoted/parent) cards come back as the bare schema-2.0 DSL
+        ({"schema":"2.0","body":{...}}) with NO `user_dsl` wrapper — this is
+        what im.v1.message.get returns once card_msg_content_type is set.
+        Body + links must still be extracted. Regression for the group-@-quote
+        path where parent cards previously yielded only an upgrade placeholder.
+        """
+        from gateway.platforms.feishu import normalize_feishu_message
+
+        card = {
+            "schema": "2.0",
+            "config": {},
+            "header": {"template": "red", "title": {"content": "通知：示例消息", "tag": "plain_text"}},
+            "body": {
+                "direction": "vertical",
+                "elements": [
+                    {"content": "<font color='grey'>账号</font>\nuser@example.com", "element_id": "_2", "tag": "markdown"},
+                    {"content": "[日志](https://res.example.com/app.zip)", "element_id": "_30", "tag": "markdown"},
+                    {"content": "[详情](https://api.example.com/event?id=1)", "element_id": "_48", "tag": "markdown"},
+                ],
+            },
+        }
+        normalized = normalize_feishu_message(
+            message_type="interactive",
+            raw_content=json.dumps(card, ensure_ascii=False),
+        )
+        text = normalized.text_content
+        self.assertIn("通知：示例消息", text)
+        self.assertIn("user@example.com", text)
+        self.assertIn("https://res.example.com/app.zip", text)
+        self.assertIn("https://api.example.com/event?id=1", text)
+        self.assertNotIn("_2", text.split("\n"))
+
+    def test_normalize_interactive_card_flattens_links_to_bare_labelled_urls(self):
+        """Markdown links are flattened to a bare ``label: url`` form, keeping
+        the FULL literal URL (incl. parens from build numbers like
+        v3.3.0(33077)). Models misread percent-encoded / markdown-wrapped
+        URLs as truncated; a bare URL is reproduced verbatim and Feishu still
+        auto-links it.
+        """
+        from gateway.platforms.feishu import normalize_feishu_message
+
+        url = "https://res.example.com/log/report_v3.3.0(33077)_1779535092775.zip"
+        card = {
+            "schema": "2.0",
+            "header": {"title": {"content": "通知", "tag": "plain_text"}},
+            "body": {
+                "elements": [
+                    {"content": f"[日志]({url})", "tag": "markdown"},
+                    {"content": "[统计](https://api.example.com/stats?id=1)", "tag": "markdown"},
+                ]
+            },
+        }
+        normalized = normalize_feishu_message(
+            message_type="interactive",
+            raw_content=json.dumps(card, ensure_ascii=False),
+        )
+        text = normalized.text_content
+
+        # Flattened to "label: url" with the complete literal URL preserved.
+        self.assertIn(f"日志: {url}", text)
+        self.assertIn("统计: https://api.example.com/stats?id=1", text)
+        # No markdown link wrapper and no percent-encoding left behind.
+        self.assertNotIn("[日志](", text)
+        self.assertNotIn("%2833077%29", text)
+        # The full URL (including the trailing _...zip) survives intact.
+        self.assertIn("report_v3.3.0(33077)_1779535092775.zip", text)
+
 
 class TestFeishuAdapterMessaging(unittest.TestCase):
     @patch.dict(os.environ, {


### PR DESCRIPTION
## What does this PR do?

  Feishu interactive ("card") messages were being reduced to just their title,
  and long alert cards had their bottom log links/buttons silently truncated, so
  the agent received broken or missing download URLs.

  This PR makes the Feishu card normalizer extract the real card body and keep
  links intact:

  - Parses the CardKit 2.0 `user_dsl` payload (and bare `schema-2.0` cards),
    instead of stopping at the lossy top-level title.
  - Stops treating layout/style scalars (`element_id`, alignment, color) as body
    text inside rich blocks.
  - Raises the card body line cap (12 → 60) so links/buttons at the bottom of long
    alert cards survive.
  - Fetches messages with `card_msg_content_type=user_card_content`, fixing quoted
    in-group cards that previously yielded only an "upgrade your app" placeholder.
  - Flattens markdown links to a bare `label: url` form so models don't misread
    parenthesized/percent-encoded URLs (e.g. build numbers like `report_v1.2.3(456)`)
    as truncated.
  - Raises the quoted-message snippet injection cap (500 → 4000) in `run.py` — the
    root cause behind log URLs in long cards being cut so the model only saw the
    URL prefix.

  ## Related Issue

  Fixes #33090

  ## Type of Change

  - [x] 🐛 Bug fix (non-breaking change that fixes an issue)

  ## Changes Made

  - `gateway/platforms/feishu.py` — card normalization: parse `user_dsl` / bare
    schema-2.0, drop layout/style noise, raise body line cap 12 → 60, request
    `user_card_content`, flatten markdown links to `label: url`.
  - `gateway/run.py` — raise quoted-message snippet injection cap 500 → 4000.
  - `tests/gateway/test_feishu.py` — add card-normalization regression tests
    covering each of the above defects.

  ## How to Test

  1. Run the card-normalization regression tests:
     `pytest tests/gateway/test_feishu.py -k normalize_interactive_card -q`
     → all pass.
  2. Full file: `pytest tests/gateway/test_feishu.py -q`
     → 164 passed, 45 skipped.

  ## Checklist

  ### Code

  - [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(gateway):`)
  - [x] I searched for existing PRs to make sure this isn't a duplicate
  - [x] My PR contains **only** changes related to this fix
  - [x] I've added tests for my changes
  - [x] I've run `pytest tests/ -q` and all tests pass
  - [x] I've tested on my platform: macOS

  ### Documentation & Housekeeping

  - [x] I've updated relevant documentation (docstrings) — or N/A
  - [x] `cli-config.yaml.example` — N/A (no config keys changed)
  - [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A (no architecture/workflow change)
  - [x] Cross-platform impact — N/A (pure text-normalization logic)
  - [x] Tool descriptions/schemas — N/A