### PR TITLE
fix(desktop): right-align user message bubbles

### DIFF
--- a/apps/desktop/src/components/assistant-ui/thread.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread.tsx
@@ -789,7 +789,7 @@ function StickyHumanMessageContainer({ attachments, children }: { attachments?: 
     // while attachments below it scroll away.
     <>
       <div
-        className="group/user-message sticky z-40 -mx-4 flex w-[calc(100%+2rem)] min-w-0 max-w-none flex-col items-stretch gap-0 self-end overflow-visible bg-(--ui-chat-surface-background) px-4 pb-(--conversation-turn-gap) pt-1"
+        className="group/user-message sticky z-40 -mx-4 flex w-[calc(100%+2rem)] min-w-0 max-w-none flex-col items-end gap-0 self-end overflow-visible bg-(--ui-chat-surface-background) px-4 pb-(--conversation-turn-gap) pt-1"
         data-role="user"
         data-slot="aui_user-message-root"
       >
@@ -982,7 +982,10 @@ const UserMessage: FC<{
           ) : null
         }
       >
-        <ActionBarPrimitive.Root className="relative w-full max-w-full" data-slot="aui_user-bubble-actions">
+        <ActionBarPrimitive.Root
+          className="relative ml-auto w-fit max-w-[min(76%,52rem)]"
+          data-slot="aui_user-bubble-actions"
+        >
           <div className="human-message-with-todos-wrapper flex w-full flex-col gap-0">
             <div className="relative w-full">
               {/* Always editable — clicking opens the edit composer even while a
@@ -1677,7 +1680,7 @@ const UserEditComposer: FC<UserEditComposerProps> = ({ cwd, gateway, sessionId }
     <ComposerPrimitive.Root className="contents" data-slot="aui_edit-composer-root">
       <StickyHumanMessageContainer>
         <div
-          className="composer-human-message-container human-execution-message-top relative flex w-full items-start rounded-md bg-(--ui-chat-surface-background)"
+          className="composer-human-message-container human-execution-message-top relative ml-auto flex w-full max-w-[min(76%,52rem)] items-start rounded-md bg-(--ui-chat-surface-background)"
           onBlur={handleEditBlur}
           onDragEnter={handleDragEnter}
           onDragLeave={handleDragLeave}

--- a/apps/desktop/src/components/assistant-ui/user-message-edit.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/user-message-edit.test.tsx
@@ -8,8 +8,8 @@ import { ExportedMessageRepository } from '@assistant-ui/core/internal'
 // bubbles) is not reproducible in jsdom — see USER_BUBBLE_BASE_CLASS's no-drag
 // carve-out in thread.tsx.
 import { AssistantRuntimeProvider, type ThreadMessage, useExternalStoreRuntime } from '@assistant-ui/react'
-import { fireEvent, render, screen, waitFor } from '@testing-library/react'
-import { describe, expect, it, vi } from 'vitest'
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import { useIncrementalExternalStoreRuntime } from '@/lib/incremental-external-store-runtime'
 
@@ -30,6 +30,8 @@ vi.stubGlobal('requestAnimationFrame', (callback: FrameRequestCallback) =>
 vi.stubGlobal('cancelAnimationFrame', (id: number) => window.clearTimeout(id))
 
 Element.prototype.scrollTo = function scrollTo() {}
+
+afterEach(() => cleanup())
 
 function stubOffsetDimension(
   prop: 'offsetHeight' | 'offsetWidth',
@@ -115,6 +117,19 @@ function StockHarness({ onEdit }: { onEdit: () => Promise<void> }) {
 }
 
 describe('click-to-edit user message', () => {
+  it('renders human prompts as a right-aligned, capped-width bubble', async () => {
+    const { container } = render(<StockHarness onEdit={async () => {}} />)
+
+    await screen.findByRole('button', { name: 'Edit message' })
+
+    const root = container.querySelector('[data-slot="aui_user-message-root"]')
+    const actionRoot = container.querySelector('[data-slot="aui_user-bubble-actions"]')
+
+    expect(root?.className).toContain('items-end')
+    expect(actionRoot?.className).toContain('ml-auto')
+    expect(actionRoot?.className).toContain('max-w-[min(76%,52rem)]')
+  })
+
   it('opens the edit composer with the incremental runtime', async () => {
     const { container } = render(<IncrementalHarness onEdit={async () => {}} />)
 


### PR DESCRIPTION
## Summary
- right-aligns user message bubbles in the desktop thread
- caps user bubble width so prompts wrap before the full chat edge
- keeps the inline edit composer aligned with the read-only bubble

## Test Plan
- npm run test:ui -- src/components/assistant-ui/user-message-edit.test.tsx
- npm run typecheck
- npm run pack