### PR TITLE
B-Prime mobile bridge + GitNexus code intelligence

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1405,6 +1405,9 @@ This repository is listed under GitNexus **group(s): tailscale-hermes** (see `~/
 
 ## CLI
 
+> **Note:** The `.claude/skills/gitnexus/` paths below are populated by `gitnexus setup` and
+> are not present in a clean clone. Run `gitnexus setup` once to install them locally.
+
 | Task | Read this skill file |
 |------|---------------------|
 | Understand architecture / "How does X work?" | `.claude/skills/gitnexus/gitnexus-exploring/SKILL.md` |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1367,3 +1367,51 @@ not the specific names.
 
 Reviewers should reject new change-detector tests; authors should convert
 them into invariants before re-requesting review.
+
+<!-- gitnexus:start -->
+# GitNexus — Code Intelligence
+
+This project is indexed by GitNexus as **hermes-agent** (131482 symbols, 238043 relationships, 300 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+
+> Index stale? Run `node .gitnexus/run.cjs analyze` from the project root — it auto-selects an available runner. No `.gitnexus/run.cjs` yet? `npx gitnexus analyze` (npm 11 crash → `npm i -g gitnexus`; #1939).
+
+## Always Do
+
+- **MUST run impact analysis before editing any symbol.** Before modifying a function, class, or method, run `impact({target: "symbolName", direction: "upstream"})` and report the blast radius (direct callers, affected processes, risk level) to the user.
+- **MUST run `detect_changes()` before committing** to verify your changes only affect expected symbols and execution flows. For regression review, compare against the default branch: `detect_changes({scope: "compare", base_ref: "main"})`.
+- **MUST warn the user** if impact analysis returns HIGH or CRITICAL risk before proceeding with edits.
+- When exploring unfamiliar code, use `query({query: "concept"})` to find execution flows instead of grepping. It returns process-grouped results ranked by relevance.
+- When you need full context on a specific symbol — callers, callees, which execution flows it participates in — use `context({name: "symbolName"})`.
+
+## Never Do
+
+- NEVER edit a function, class, or method without first running `impact` on it.
+- NEVER ignore HIGH or CRITICAL risk warnings from impact analysis.
+- NEVER rename symbols with find-and-replace — use `rename` which understands the call graph.
+- NEVER commit changes without running `detect_changes()` to check affected scope.
+
+## Resources
+
+| Resource | Use for |
+|----------|---------|
+| `gitnexus://repo/hermes-agent/context` | Codebase overview, check index freshness |
+| `gitnexus://repo/hermes-agent/clusters` | All functional areas |
+| `gitnexus://repo/hermes-agent/processes` | All execution flows |
+| `gitnexus://repo/hermes-agent/process/{name}` | Step-by-step execution trace |
+
+## Cross-Repo Groups
+
+This repository is listed under GitNexus **group(s): tailscale-hermes** (see `~/.gitnexus/groups/`). For cross-repo analysis, use MCP tools `impact`, `query`, and `context` with `repo` set to `@<groupName>` or `@<groupName>/<memberPath>` (paths match keys in that group’s `group.yaml`). Use `group_list` / `group_sync` for membership and sync. From the project root: `node .gitnexus/run.cjs group list`, `node .gitnexus/run.cjs group sync <name>`, `node .gitnexus/run.cjs group impact <name> --target <symbol> --repo <group-path>` (the `.gitnexus/run.cjs` path is repo-root-relative).
+
+## CLI
+
+| Task | Read this skill file |
+|------|---------------------|
+| Understand architecture / "How does X work?" | `.claude/skills/gitnexus/gitnexus-exploring/SKILL.md` |
+| Blast radius / "What breaks if I change X?" | `.claude/skills/gitnexus/gitnexus-impact-analysis/SKILL.md` |
+| Trace bugs / "Why is X failing?" | `.claude/skills/gitnexus/gitnexus-debugging/SKILL.md` |
+| Rename / extract / split / refactor | `.claude/skills/gitnexus/gitnexus-refactoring/SKILL.md` |
+| Tools, resources, schema reference | `.claude/skills/gitnexus/gitnexus-guide/SKILL.md` |
+| Index, status, clean, wiki CLI commands | `.claude/skills/gitnexus/gitnexus-cli/SKILL.md` |
+
+<!-- gitnexus:end -->

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,6 +35,9 @@ This repository is listed under GitNexus **group(s): tailscale-hermes** (see `~/
 
 ## CLI
 
+> **Note:** The `.claude/skills/gitnexus/` paths below are populated by `gitnexus setup` and
+> are not present in a clean clone. Run `gitnexus setup` once to install them locally.
+
 | Task | Read this skill file |
 |------|---------------------|
 | Understand architecture / "How does X work?" | `.claude/skills/gitnexus/gitnexus-exploring/SKILL.md` |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,47 @@
+<!-- gitnexus:start -->
+# GitNexus — Code Intelligence
+
+This project is indexed by GitNexus as **hermes-agent** (131482 symbols, 238043 relationships, 300 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+
+> Index stale? Run `node .gitnexus/run.cjs analyze` from the project root — it auto-selects an available runner. No `.gitnexus/run.cjs` yet? `npx gitnexus analyze` (npm 11 crash → `npm i -g gitnexus`; #1939).
+
+## Always Do
+
+- **MUST run impact analysis before editing any symbol.** Before modifying a function, class, or method, run `impact({target: "symbolName", direction: "upstream"})` and report the blast radius (direct callers, affected processes, risk level) to the user.
+- **MUST run `detect_changes()` before committing** to verify your changes only affect expected symbols and execution flows. For regression review, compare against the default branch: `detect_changes({scope: "compare", base_ref: "main"})`.
+- **MUST warn the user** if impact analysis returns HIGH or CRITICAL risk before proceeding with edits.
+- When exploring unfamiliar code, use `query({query: "concept"})` to find execution flows instead of grepping. It returns process-grouped results ranked by relevance.
+- When you need full context on a specific symbol — callers, callees, which execution flows it participates in — use `context({name: "symbolName"})`.
+
+## Never Do
+
+- NEVER edit a function, class, or method without first running `impact` on it.
+- NEVER ignore HIGH or CRITICAL risk warnings from impact analysis.
+- NEVER rename symbols with find-and-replace — use `rename` which understands the call graph.
+- NEVER commit changes without running `detect_changes()` to check affected scope.
+
+## Resources
+
+| Resource | Use for |
+|----------|---------|
+| `gitnexus://repo/hermes-agent/context` | Codebase overview, check index freshness |
+| `gitnexus://repo/hermes-agent/clusters` | All functional areas |
+| `gitnexus://repo/hermes-agent/processes` | All execution flows |
+| `gitnexus://repo/hermes-agent/process/{name}` | Step-by-step execution trace |
+
+## Cross-Repo Groups
+
+This repository is listed under GitNexus **group(s): tailscale-hermes** (see `~/.gitnexus/groups/`). For cross-repo analysis, use MCP tools `impact`, `query`, and `context` with `repo` set to `@<groupName>` or `@<groupName>/<memberPath>` (paths match keys in that group’s `group.yaml`). Use `group_list` / `group_sync` for membership and sync. From the project root: `node .gitnexus/run.cjs group list`, `node .gitnexus/run.cjs group sync <name>`, `node .gitnexus/run.cjs group impact <name> --target <symbol> --repo <group-path>` (the `.gitnexus/run.cjs` path is repo-root-relative).
+
+## CLI
+
+| Task | Read this skill file |
+|------|---------------------|
+| Understand architecture / "How does X work?" | `.claude/skills/gitnexus/gitnexus-exploring/SKILL.md` |
+| Blast radius / "What breaks if I change X?" | `.claude/skills/gitnexus/gitnexus-impact-analysis/SKILL.md` |
+| Trace bugs / "Why is X failing?" | `.claude/skills/gitnexus/gitnexus-debugging/SKILL.md` |
+| Rename / extract / split / refactor | `.claude/skills/gitnexus/gitnexus-refactoring/SKILL.md` |
+| Tools, resources, schema reference | `.claude/skills/gitnexus/gitnexus-guide/SKILL.md` |
+| Index, status, clean, wiki CLI commands | `.claude/skills/gitnexus/gitnexus-cli/SKILL.md` |
+
+<!-- gitnexus:end -->

--- a/hermes_cli/mobile_bridge.py
+++ b/hermes_cli/mobile_bridge.py
@@ -104,10 +104,15 @@ async def run_mobile_dashboard_chat_turn(
     agent_ref: list[Any] = [None]
 
     try:
+        server_history: List[Dict[str, Any]] = []
+        load_history = getattr(adapter, "_conversation_history_for_session", None)
+        if callable(load_history):
+            server_history = load_history(session_id) or []
+
         result, usage = await adapter._run_agent(
             user_message=user_message,
-            conversation_history=conversation_history or [],
-            ephemeral_system_prompt=system_message,
+            conversation_history=server_history,
+            ephemeral_system_prompt=None,
             session_id=session_id,
             gateway_session_key=gateway_session_key or session_id,
             agent_ref=agent_ref,

--- a/hermes_cli/mobile_bridge.py
+++ b/hermes_cli/mobile_bridge.py
@@ -1,0 +1,125 @@
+"""Minimal dashboard-auth mobile bridge helpers.
+
+This module intentionally does not revive the older ``/mobile-native`` route
+stack.  It provides a small BFF-style helper that can be called by the
+dashboard API after the existing dashboard auth middleware has accepted the
+request.
+"""
+from __future__ import annotations
+
+import inspect
+import logging
+from typing import Any, Callable, Dict, List, Optional
+
+
+_log = logging.getLogger(__name__)
+
+
+async def _maybe_await(value: Any) -> Any:
+    if inspect.isawaitable(value):
+        return await value
+    return value
+
+
+async def _best_effort_cleanup(label: str, cleanup: Callable[[], Any]) -> None:
+    try:
+        await _maybe_await(cleanup())
+    except Exception:
+        _log.debug("Mobile bridge cleanup failed: %s", label, exc_info=True)
+
+
+async def _release_agent_clients(agent: Any) -> None:
+    release_clients = getattr(agent, "release_clients", None)
+    if callable(release_clients):
+        await _best_effort_cleanup("agent.release_clients", release_clients)
+
+
+async def _disconnect_adapter(adapter: Any) -> None:
+    disconnect = getattr(adapter, "disconnect", None)
+    if callable(disconnect):
+        await _best_effort_cleanup("adapter.disconnect", disconnect)
+
+
+async def _close_adapter_session_db(adapter: Any) -> None:
+    session_db = getattr(adapter, "_session_db", None)
+    close = getattr(session_db, "close", None)
+    if callable(close):
+        await _best_effort_cleanup("adapter._session_db.close", close)
+
+
+def _default_adapter_factory() -> Any:
+    """Create an API-server adapter instance without starting an HTTP server."""
+    from gateway.config import PlatformConfig
+    from gateway.platforms.api_server import APIServerAdapter
+
+    return APIServerAdapter(PlatformConfig(enabled=True))
+
+
+def _redacted_mobile_response(
+    result: Any,
+    usage: Optional[Dict[str, Any]],
+    *,
+    fallback_session_id: str,
+) -> Dict[str, Any]:
+    if isinstance(result, dict):
+        session_id = result.get("session_id") or fallback_session_id
+        final_response = result.get("final_response") or ""
+    else:
+        session_id = fallback_session_id
+        final_response = ""
+
+    if not isinstance(final_response, str):
+        final_response = str(final_response)
+
+    return {
+        "object": "hermes.mobile.chat.completion",
+        "session_id": session_id,
+        "message": {
+            "role": "assistant",
+            "content_redacted": True,
+            "content_length": len(final_response),
+        },
+        "usage": usage or {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0},
+    }
+
+
+async def run_mobile_dashboard_chat_turn(
+    *,
+    session_id: str,
+    user_message: str,
+    conversation_history: Optional[List[Dict[str, Any]]] = None,
+    system_message: Optional[str] = None,
+    gateway_session_key: Optional[str] = None,
+    adapter_factory: Optional[Callable[[], Any]] = None,
+) -> Dict[str, Any]:
+    """Run one dashboard-auth mobile chat turn with soft cleanup only.
+
+    The owned adapter/agent lifetime is per call, but the cleanup boundary is
+    deliberately soft for the agent: call ``agent.release_clients()`` and never
+    call ``agent.close()`` or ``shutdown_memory_provider()``.  Adapter-owned
+    resources (notably ``ResponseStore``) are disconnected after the turn.
+    """
+    factory = adapter_factory or _default_adapter_factory
+    adapter = factory()
+    agent_ref: list[Any] = [None]
+
+    try:
+        result, usage = await adapter._run_agent(
+            user_message=user_message,
+            conversation_history=conversation_history or [],
+            ephemeral_system_prompt=system_message,
+            session_id=session_id,
+            gateway_session_key=gateway_session_key or session_id,
+            agent_ref=agent_ref,
+        )
+        return _redacted_mobile_response(
+            result,
+            usage,
+            fallback_session_id=session_id,
+        )
+    finally:
+        agent = agent_ref[0]
+        if agent is not None:
+            await _release_agent_clients(agent)
+        await _disconnect_adapter(adapter)
+        await _close_adapter_session_db(adapter)

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -6495,11 +6495,12 @@ async def mobile_dashboard_chat_endpoint(
         raise HTTPException(status_code=400, detail="message is required")
 
     gateway_session_key = _mobile_gateway_session_key(request, session_id)
+    # B-Prime mobile continuity is server-owned. Keep legacy request fields
+    # parse-compatible, but never trust client-supplied conversation_history or
+    # system_message; the bridge loads SessionDB history immediately before run.
     return await _run_mobile_dashboard_chat_turn(
         session_id=session_id,
         user_message=message,
-        conversation_history=body.conversation_history or [],
-        system_message=body.system_message,
         gateway_session_key=gateway_session_key,
     )
 

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -63,6 +63,7 @@ from hermes_cli.config import (
     redact_key,
 )
 from gateway.status import get_running_pid, read_runtime_status
+from hermes_cli.mobile_bridge import run_mobile_dashboard_chat_turn as _run_mobile_dashboard_chat_turn
 from utils import env_var_enabled
 
 try:
@@ -6456,6 +6457,51 @@ async def cancel_oauth_session(
 # Session detail endpoints
 # ---------------------------------------------------------------------------
 
+
+_MOBILE_GATEWAY_SESSION_KEY_MAX_LEN = 256
+
+
+def _mobile_gateway_session_key(request: Request, session_id: str) -> str:
+    raw = request.headers.get("X-Hermes-Session-Key", "").strip()
+    if not raw:
+        return session_id
+    if re.search(r"[\r\n\x00]", raw):
+        raise HTTPException(status_code=400, detail="Invalid session key")
+    if len(raw) > _MOBILE_GATEWAY_SESSION_KEY_MAX_LEN:
+        raise HTTPException(status_code=400, detail="Session key too long")
+    return raw
+
+
+class MobileDashboardChatRequest(BaseModel):
+    message: str
+    system_message: Optional[str] = None
+    conversation_history: Optional[List[Dict[str, Any]]] = None
+
+
+@app.post("/api/mobile/sessions/{session_id}/chat")
+async def mobile_dashboard_chat_endpoint(
+    session_id: str,
+    body: MobileDashboardChatRequest,
+    request: Request,
+):
+    """Authenticated dashboard BFF route for one mobile/native chat turn.
+
+    This route deliberately stays under ``/api`` so existing dashboard auth
+    middleware remains the trust boundary.  The helper returns a browser-safe
+    redacted envelope and owns the per-turn soft cleanup contract.
+    """
+    message = body.message.strip()
+    if not message:
+        raise HTTPException(status_code=400, detail="message is required")
+
+    gateway_session_key = _mobile_gateway_session_key(request, session_id)
+    return await _run_mobile_dashboard_chat_turn(
+        session_id=session_id,
+        user_message=message,
+        conversation_history=body.conversation_history or [],
+        system_message=body.system_message,
+        gateway_session_key=gateway_session_key,
+    )
 
 
 def _session_latest_descendant(session_id: str):

--- a/tests/hermes_cli/test_mobile_bridge_bprime.py
+++ b/tests/hermes_cli/test_mobile_bridge_bprime.py
@@ -74,7 +74,13 @@ def test_dashboard_mobile_chat_route_uses_existing_auth_and_redacts_response(
     session_id = "mobile-bprime-session"
     response = client.post(
         f"/api/mobile/sessions/{session_id}/chat",
-        json={"message": "hello from ipad", "system_message": "do not leak"},
+        json={
+            "message": "hello from ipad",
+            "system_message": "do not leak",
+            "conversation_history": [
+                {"role": "user", "content": "client fake history"},
+            ],
+        },
         headers={"X-Hermes-Session-Key": session_id},
     )
 
@@ -93,8 +99,9 @@ def test_dashboard_mobile_chat_route_uses_existing_auth_and_redacts_response(
     assert "Bearer " not in response.text
     assert calls["session_id"] == session_id
     assert calls["user_message"] == "hello from ipad"
-    assert calls["system_message"] == "do not leak"
     assert calls["gateway_session_key"] == session_id
+    assert "system_message" not in calls
+    assert "conversation_history" not in calls
 
 
 def test_dashboard_mobile_chat_route_validates_gateway_session_key(
@@ -157,6 +164,13 @@ async def test_mobile_turn_helper_soft_releases_agent_and_disconnects_owned_adap
             self.run_kwargs = None
             self.disconnect_calls = 0
 
+        def _conversation_history_for_session(self, session_id):
+            assert session_id == "mobile-bprime-session"
+            return [
+                {"role": "user", "content": "previous server turn"},
+                {"role": "assistant", "content": "previous server answer"},
+            ]
+
         async def _run_agent(self, **kwargs):
             self.run_kwargs = kwargs
             kwargs["agent_ref"][0] = self.agent
@@ -169,20 +183,23 @@ async def test_mobile_turn_helper_soft_releases_agent_and_disconnects_owned_adap
             self.disconnect_calls += 1
 
     adapter = FakeAdapter()
-    conversation_history = [{"role": "user", "content": "previous turn"}]
+    client_history = [{"role": "user", "content": "client fake turn"}]
 
     result = await run_mobile_dashboard_chat_turn(
         session_id="mobile-bprime-session",
         user_message="continue on ipad",
-        conversation_history=conversation_history,
-        system_message="short system prompt",
+        conversation_history=client_history,
+        system_message="client fake system prompt",
         gateway_session_key="mobile-bprime-session",
         adapter_factory=lambda: adapter,
     )
 
     assert adapter.run_kwargs["user_message"] == "continue on ipad"
-    assert adapter.run_kwargs["conversation_history"] == conversation_history
-    assert adapter.run_kwargs["ephemeral_system_prompt"] == "short system prompt"
+    assert adapter.run_kwargs["conversation_history"] == [
+        {"role": "user", "content": "previous server turn"},
+        {"role": "assistant", "content": "previous server answer"},
+    ]
+    assert adapter.run_kwargs["ephemeral_system_prompt"] is None
     assert adapter.run_kwargs["session_id"] == "mobile-bprime-session"
     assert adapter.run_kwargs["gateway_session_key"] == "mobile-bprime-session"
     assert adapter.agent.release_calls == 1
@@ -198,6 +215,72 @@ async def test_mobile_turn_helper_soft_releases_agent_and_disconnects_owned_adap
         "usage": {"input_tokens": 5, "output_tokens": 6, "total_tokens": 11},
     }
     assert "assistant secret body" not in str(result)
+
+
+@pytest.mark.asyncio
+async def test_mobile_turn_helper_second_turn_uses_prior_server_history():
+    run_mobile_dashboard_chat_turn = _load_mobile_turn_helper()
+
+    class FakeAgent:
+        async def release_clients(self):
+            return None
+
+        def close(self):  # pragma: no cover - must never be called
+            raise AssertionError("mobile per-turn cleanup must not call agent.close()")
+
+        def shutdown_memory_provider(self, *args, **kwargs):  # pragma: no cover - must never be called
+            raise AssertionError("mobile per-turn cleanup must not shutdown memory provider")
+
+    class FakeAdapter:
+        def __init__(self):
+            self.agent = FakeAgent()
+            self.histories = [
+                [],
+                [
+                    {"role": "user", "content": "BPRIME-GATE2-NONCE-test"},
+                    {"role": "assistant", "content": "Acknowledged: BPRIME-GATE2-NONCE-test"},
+                ],
+            ]
+            self.run_histories = []
+            self.disconnect_calls = 0
+
+        def _conversation_history_for_session(self, session_id):
+            assert session_id == "mobile-bprime-session"
+            return self.histories[len(self.run_histories)]
+
+        async def _run_agent(self, **kwargs):
+            kwargs["agent_ref"][0] = self.agent
+            self.run_histories.append(kwargs["conversation_history"])
+            final_response = "ack" if len(self.run_histories) == 1 else "BPRIME-GATE2-NONCE-test"
+            return (
+                {"final_response": final_response, "session_id": kwargs["session_id"]},
+                {"input_tokens": 1, "output_tokens": 1, "total_tokens": 2},
+            )
+
+        async def disconnect(self):
+            self.disconnect_calls += 1
+
+    adapter = FakeAdapter()
+
+    await run_mobile_dashboard_chat_turn(
+        session_id="mobile-bprime-session",
+        user_message="send nonce",
+        gateway_session_key="mobile-bprime-session",
+        adapter_factory=lambda: adapter,
+    )
+    await run_mobile_dashboard_chat_turn(
+        session_id="mobile-bprime-session",
+        user_message="what nonce did I send?",
+        gateway_session_key="mobile-bprime-session",
+        adapter_factory=lambda: adapter,
+    )
+
+    assert adapter.run_histories[0] == []
+    assert adapter.run_histories[1] == [
+        {"role": "user", "content": "BPRIME-GATE2-NONCE-test"},
+        {"role": "assistant", "content": "Acknowledged: BPRIME-GATE2-NONCE-test"},
+    ]
+    assert adapter.disconnect_calls == 2
 
 
 @pytest.mark.asyncio

--- a/tests/hermes_cli/test_mobile_bridge_bprime.py
+++ b/tests/hermes_cli/test_mobile_bridge_bprime.py
@@ -1,0 +1,261 @@
+"""B-prime mobile bridge TDD tests.
+
+These tests define the smaller current-baseline bridge contract before any
+production code is added:
+
+* mobile/native chat uses dashboard auth under ``/api/*`` instead of reviving
+  the old public ``/mobile-native`` namespace;
+* browser/mobile clients never receive the raw assistant body or API-server
+  bearer credentials;
+* the per-turn agent cleanup boundary is soft: ``release_clients()`` only,
+  never ``agent.close()`` or ``shutdown_memory_provider()``.
+"""
+from __future__ import annotations
+
+import pytest
+
+
+def _dashboard_client():
+    try:
+        from starlette.testclient import TestClient
+    except ImportError:
+        pytest.skip("fastapi/starlette not installed")
+
+    import hermes_state
+    from hermes_constants import get_hermes_home
+    from hermes_cli import web_server
+
+    client = TestClient(web_server.app)
+    client.headers[web_server._SESSION_HEADER_NAME] = web_server._SESSION_TOKEN
+    hermes_state.DEFAULT_DB_PATH = get_hermes_home() / "state.db"
+    return client, web_server
+
+
+def _load_mobile_turn_helper():
+    try:
+        from hermes_cli.mobile_bridge import run_mobile_dashboard_chat_turn
+    except ImportError as exc:  # Expected RED until the bridge module exists.
+        pytest.fail(f"B-prime mobile bridge helper is missing: {exc}")
+    return run_mobile_dashboard_chat_turn
+
+
+def test_mobile_bridge_routes_stay_behind_dashboard_auth_allowlist():
+    from hermes_cli.dashboard_auth.public_paths import PUBLIC_API_PATHS
+
+    assert "/api/mobile/sessions" not in PUBLIC_API_PATHS
+    assert "/api/mobile/sessions/{session_id}/chat" not in PUBLIC_API_PATHS
+    assert not any(path.startswith("/api/mobile") for path in PUBLIC_API_PATHS)
+
+
+def test_dashboard_mobile_chat_route_uses_existing_auth_and_redacts_response(
+    _isolate_hermes_home,
+    monkeypatch,
+):
+    client, web_server = _dashboard_client()
+    calls: dict[str, object] = {}
+
+    async def fake_turn(**kwargs):
+        calls.update(kwargs)
+        return {
+            "object": "hermes.mobile.chat.completion",
+            "session_id": kwargs["session_id"],
+            "message": {
+                "role": "assistant",
+                "content_redacted": True,
+                "content_length": len("assistant secret body"),
+            },
+            "usage": {"input_tokens": 3, "output_tokens": 4, "total_tokens": 7},
+        }
+
+    # The future route should call this helper. ``raising=False`` keeps this
+    # test RED as a route-missing 404 instead of failing during monkeypatch.
+    monkeypatch.setattr(web_server, "_run_mobile_dashboard_chat_turn", fake_turn, raising=False)
+
+    session_id = "mobile-bprime-session"
+    response = client.post(
+        f"/api/mobile/sessions/{session_id}/chat",
+        json={"message": "hello from ipad", "system_message": "do not leak"},
+        headers={"X-Hermes-Session-Key": session_id},
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["object"] == "hermes.mobile.chat.completion"
+    assert body["session_id"] == session_id
+    assert body["message"] == {
+        "role": "assistant",
+        "content_redacted": True,
+        "content_length": len("assistant secret body"),
+    }
+    assert "assistant secret body" not in response.text
+    assert "API_SERVER_KEY" not in response.text
+    assert "Authorization" not in response.text
+    assert "Bearer " not in response.text
+    assert calls["session_id"] == session_id
+    assert calls["user_message"] == "hello from ipad"
+    assert calls["system_message"] == "do not leak"
+    assert calls["gateway_session_key"] == session_id
+
+
+def test_dashboard_mobile_chat_route_validates_gateway_session_key(
+    _isolate_hermes_home,
+    monkeypatch,
+):
+    client, web_server = _dashboard_client()
+    calls: list[dict[str, object]] = []
+
+    async def fake_turn(**kwargs):
+        calls.append(kwargs)
+        return {
+            "object": "hermes.mobile.chat.completion",
+            "session_id": kwargs["session_id"],
+            "message": {"role": "assistant", "content_redacted": True, "content_length": 0},
+            "usage": {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0},
+        }
+
+    monkeypatch.setattr(web_server, "_run_mobile_dashboard_chat_turn", fake_turn, raising=False)
+
+    session_id = "mobile-bprime-session"
+    too_long = "x" * 257
+    rejected = client.post(
+        f"/api/mobile/sessions/{session_id}/chat",
+        json={"message": "hello"},
+        headers={"X-Hermes-Session-Key": too_long},
+    )
+    assert rejected.status_code == 400
+    assert calls == []
+
+    accepted = client.post(
+        f"/api/mobile/sessions/{session_id}/chat",
+        json={"message": "hello"},
+        headers={"X-Hermes-Session-Key": "  ipad-session-key  "},
+    )
+    assert accepted.status_code == 200
+    assert calls[0]["gateway_session_key"] == "ipad-session-key"
+
+
+@pytest.mark.asyncio
+async def test_mobile_turn_helper_soft_releases_agent_and_disconnects_owned_adapter():
+    run_mobile_dashboard_chat_turn = _load_mobile_turn_helper()
+
+    class FakeAgent:
+        def __init__(self):
+            self.release_calls = 0
+
+        async def release_clients(self):
+            self.release_calls += 1
+
+        def close(self):  # pragma: no cover - must never be called
+            raise AssertionError("mobile per-turn cleanup must not call agent.close()")
+
+        def shutdown_memory_provider(self, *args, **kwargs):  # pragma: no cover - must never be called
+            raise AssertionError("mobile per-turn cleanup must not shutdown memory provider")
+
+    class FakeAdapter:
+        def __init__(self):
+            self.agent = FakeAgent()
+            self.run_kwargs = None
+            self.disconnect_calls = 0
+
+        async def _run_agent(self, **kwargs):
+            self.run_kwargs = kwargs
+            kwargs["agent_ref"][0] = self.agent
+            return (
+                {"final_response": "assistant secret body", "session_id": kwargs["session_id"]},
+                {"input_tokens": 5, "output_tokens": 6, "total_tokens": 11},
+            )
+
+        async def disconnect(self):
+            self.disconnect_calls += 1
+
+    adapter = FakeAdapter()
+    conversation_history = [{"role": "user", "content": "previous turn"}]
+
+    result = await run_mobile_dashboard_chat_turn(
+        session_id="mobile-bprime-session",
+        user_message="continue on ipad",
+        conversation_history=conversation_history,
+        system_message="short system prompt",
+        gateway_session_key="mobile-bprime-session",
+        adapter_factory=lambda: adapter,
+    )
+
+    assert adapter.run_kwargs["user_message"] == "continue on ipad"
+    assert adapter.run_kwargs["conversation_history"] == conversation_history
+    assert adapter.run_kwargs["ephemeral_system_prompt"] == "short system prompt"
+    assert adapter.run_kwargs["session_id"] == "mobile-bprime-session"
+    assert adapter.run_kwargs["gateway_session_key"] == "mobile-bprime-session"
+    assert adapter.agent.release_calls == 1
+    assert adapter.disconnect_calls == 1
+    assert result == {
+        "object": "hermes.mobile.chat.completion",
+        "session_id": "mobile-bprime-session",
+        "message": {
+            "role": "assistant",
+            "content_redacted": True,
+            "content_length": len("assistant secret body"),
+        },
+        "usage": {"input_tokens": 5, "output_tokens": 6, "total_tokens": 11},
+    }
+    assert "assistant secret body" not in str(result)
+
+
+@pytest.mark.asyncio
+async def test_mobile_turn_helper_cleanup_survives_release_failure_and_closes_session_db():
+    run_mobile_dashboard_chat_turn = _load_mobile_turn_helper()
+
+    class FailingReleaseAgent:
+        def __init__(self):
+            self.release_calls = 0
+
+        async def release_clients(self):
+            self.release_calls += 1
+            raise RuntimeError("release failed")
+
+        def close(self):  # pragma: no cover - must never be called
+            raise AssertionError("mobile per-turn cleanup must not call agent.close()")
+
+        def shutdown_memory_provider(self, *args, **kwargs):  # pragma: no cover - must never be called
+            raise AssertionError("mobile per-turn cleanup must not shutdown memory provider")
+
+    class FakeSessionDB:
+        def __init__(self):
+            self.close_calls = 0
+
+        def close(self):
+            self.close_calls += 1
+
+    class FakeAdapter:
+        def __init__(self):
+            self.agent = FailingReleaseAgent()
+            self._session_db = FakeSessionDB()
+            self.disconnect_calls = 0
+
+        async def _run_agent(self, **kwargs):
+            kwargs["agent_ref"][0] = self.agent
+            return (
+                {"final_response": "assistant body", "session_id": kwargs["session_id"]},
+                {"input_tokens": 1, "output_tokens": 2, "total_tokens": 3},
+            )
+
+        async def disconnect(self):
+            self.disconnect_calls += 1
+
+    adapter = FakeAdapter()
+
+    result = await run_mobile_dashboard_chat_turn(
+        session_id="mobile-bprime-session",
+        user_message="continue on ipad",
+        gateway_session_key="mobile-bprime-session",
+        adapter_factory=lambda: adapter,
+    )
+
+    assert result["message"] == {
+        "role": "assistant",
+        "content_redacted": True,
+        "content_length": len("assistant body"),
+    }
+    assert adapter.agent.release_calls == 1
+    assert adapter.disconnect_calls == 1
+    assert adapter._session_db.close_calls == 1
+    assert "assistant body" not in str(result)


### PR DESCRIPTION
## Summary
- B-Prime mobile bridge: authenticated BFF bridge with `/api/mobile/` routes behind dashboard auth, server-owned history, response redaction
- Fix: stop trusting client-supplied conversation_history/system_message
- GitNexus code intelligence block in AGENTS.md and CLAUDE.md for shared operator graph-awareness
- Clarify that `.claude/skills/gitnexus/` paths are populated by `gitnexus setup`

## Test plan
- [ ] `pytest tests/hermes_cli/test_mobile_bridge_bprime.py` passes
- [ ] Dashboard auth gate confirmed for `/api/mobile/` routes
- [ ] `gitnexus status` shows up-to-date after clone + `gitnexus setup`

🤖 Generated with [Claude Code](https://claude.com/claude-code)