### PR TITLE
fix(model_metadata): parse slash-separated provider/model prefix in get_model_context_length

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -1663,9 +1663,23 @@ def get_model_context_length(
         except Exception:
             pass  # fall through to probing
 
-    # Normalise provider-prefixed model names (e.g. "local:model-name" →
-    # "model-name") so cache lookups and server queries use the bare ID that
-    # local servers actually know about.  Ollama "model:tag" colons are preserved.
+    # Normalise provider-prefixed model names — first handle slash-separated
+    # format (e.g. "opencode-go/qwen3.7-plus" → model="qwen3.7-plus",
+    # provider="opencode-go") so that both call forms return the same context
+    # length for the same model.  Without this, callers that pass a
+    # fully-qualified provider/model id as the model string get a different
+    # result from those passing the bare model + explicit provider param,
+    # because the unresolved prefixed string falls through to hardcoded
+    # catch-all entries (e.g. generic "qwen" → 131072) while the separated
+    # form reaches the correct provider-aware lookup.  See #47782.
+    if "/" in model and not provider:
+        slash_idx = model.index("/")
+        potential_provider = model[:slash_idx].strip().lower()
+        if potential_provider in _PROVIDER_PREFIXES:
+            provider = model[:slash_idx].strip()
+            model = model[slash_idx + 1:]
+    # Then handle colon-separated format (e.g. "local:my-model" → "my-model").
+    # Ollama "model:tag" colons (e.g. "qwen3.5:27b") are preserved.
     model = _strip_provider_prefix(model)
 
     # 1. Check persistent cache (model+provider)


### PR DESCRIPTION
## Summary

Fixes a bug where `get_model_context_length()` returns different context windows for the same model depending on whether the caller passes a bare model id (`"qwen3.7-plus"` with `provider="opencode-go"`) or a fully-qualified id (`"opencode-go/qwen3.7-plus"`).

The slash-separated provider prefix was not being recognized — only the colon-separated format (`"local:my-model"`) was handled by `_strip_provider_prefix`. This caused the prefixed string to fall through to hardcoded catch-all entries (e.g. generic "qwen" → 131072) instead of reaching the correct provider-aware lookup.

## Root Cause

`_strip_provider_prefix()` (line 87) only handles colon-separated `provider:model` format, but some callers pass slash-separated `provider/model` format. When that happens, the provider prefix is not stripped, the provider param stays empty, and the resolution falls through to the hardcoded `DEFAULT_CONTEXT_LENGTHS` where a generic substring match (e.g. "qwen" → 131072) returns the wrong value.

## Fix

Parses a recognized provider prefix before the slash in the model string and sets both `provider` and `model` accordingly before `_strip_provider_prefix` runs. The guard `not provider` ensures that an explicitly-passed provider param is never overridden by the parsed prefix.

## Testing

Verified that both call forms now return the same result:

```python
>>> get_model_context_length("opencode-go/qwen3.7-plus")
1000000
>>> get_model_context_length("qwen3.7-plus", provider="opencode-go")
1000000
```

Closes #47782