### PR TITLE
fix(telegram): handle media in active forum-topic sessions without re-mention

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -2592,6 +2592,12 @@ class BasePlatformAdapter(ABC):
     def __init__(self, config: PlatformConfig, platform: Platform):
         self.config = config
         self.platform = platform
+        # Profile namespace for adapters owned by the multi-profile gateway.
+        # The primary adapter leaves this unset and SessionStore falls back to
+        # the active profile. Secondary adapters are stamped by GatewayRunner
+        # before they connect so pre-dispatch routing checks can build the same
+        # profile-aware session key as the eventual message handler.
+        self._session_profile: Optional[str] = None
         self._message_handler: Optional[MessageHandler] = None
         # Optional gateway-supplied fan-out for platform-native emoji
         # reaction events (see ``set_reaction_handler``).
@@ -6149,6 +6155,8 @@ class BasePlatformAdapter(ABC):
                     "Profile resolution failed for %s/%s, defaulting to active profile",
                     self.platform, chat_id, exc_info=True,
                 )
+        if profile is None:
+            profile = getattr(self, "_session_profile", None)
 
         source = SessionSource(
             platform=self.platform,
@@ -6176,6 +6184,11 @@ class BasePlatformAdapter(ABC):
         # for this turn even when profile_routes selects a different runtime.
         source._transport_adapter_ref = weakref.ref(self)
         return source
+
+    def set_session_profile(self, profile_name: Optional[str]) -> None:
+        """Stamp the fallback profile namespace for this adapter's sources."""
+        normalized = str(profile_name or "").strip()
+        self._session_profile = normalized or None
     
     @abstractmethod
     async def get_chat_info(self, chat_id: str) -> Dict[str, Any]:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -10288,6 +10288,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         platform: Platform,
     ) -> None:
         """Install the profile-scoped handlers shared by startup and reconnect."""
+        adapter.set_session_profile(profile_name)
         adapter.set_message_handler(self._make_profile_message_handler(profile_name))
         adapter.set_fatal_error_handler(
             self._make_profile_fatal_error_handler(profile_name, platform)

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -8587,17 +8587,15 @@ class TelegramAdapter(BasePlatformAdapter):
         active topic conversation instead of being dropped by the mention gate.
 
         Only fires for real forum topic threads that already have a session, so
-        idle topics still need a mention to start. Builds the lookup key with
-        ``build_session_key`` using the same isolation flags the store used to
-        key the entry, so the lookup matches the stored key. Any failure returns
+        idle topics still need a mention to start. Builds the lookup key through
+        the session store's profile-aware generator, so isolation flags and
+        multiplexed profile namespaces match the stored key. Any failure returns
         False (mention still required).
         """
         store = getattr(self, "_session_store", None)
         if not store:
             return False
         try:
-            from gateway.session import SessionSource, build_session_key
-
             chat = getattr(message, "chat", None)
             chat_id = str(getattr(chat, "id", "") or "")
             if not chat_id:
@@ -8606,32 +8604,13 @@ class TelegramAdapter(BasePlatformAdapter):
             if not thread_id:
                 return False
             user = getattr(message, "from_user", None)
-            source = SessionSource(
-                platform=Platform.TELEGRAM,
+            source = self.build_source(
                 chat_id=chat_id,
                 chat_type="group",
                 user_id=str(user.id) if user is not None else None,
                 thread_id=thread_id,
             )
-            # Read isolation flags from the session store's own config, not the
-            # adapter's PlatformConfig.extra. The store keys entries via
-            # SessionStore._generate_session_key, which reads these flags from
-            # the gateway config it holds; using the same source keeps the
-            # lookup key aligned with the stored key when an operator changes
-            # group_sessions_per_user / thread_sessions_per_user. Mirrors
-            # SlackAdapter._has_active_session_for_thread.
-            store_cfg = getattr(store, "config", None)
-            group_per_user = (
-                getattr(store_cfg, "group_sessions_per_user", True) if store_cfg is not None else True
-            )
-            thread_per_user = (
-                getattr(store_cfg, "thread_sessions_per_user", False) if store_cfg is not None else False
-            )
-            session_key = build_session_key(
-                source,
-                group_sessions_per_user=group_per_user,
-                thread_sessions_per_user=thread_per_user,
-            )
+            session_key = store._generate_session_key(source)
             store._ensure_loaded()
             return session_key in store._entries
         except Exception:

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -8567,7 +8567,75 @@ class TelegramAdapter(BasePlatformAdapter):
         # _message_mentions_bot above — skip the redundant second call.
         if not self._telegram_guest_mode() and self._message_mentions_bot(message):
             return True
-        return self._message_matches_mention_patterns(message)
+        if self._message_matches_mention_patterns(message):
+            return True
+        # Ongoing conversation: a forum topic that already has an active
+        # session keeps accepting follow-up messages (text and media, even
+        # without a caption mention) so the conversation is not broken by a
+        # missing re-mention. Mirrors Slack thread behavior. Idle topics still
+        # require a mention to start, so the bot stays quiet on unrelated
+        # group chatter.
+        return self._forum_topic_has_active_session(message)
+
+    def _forum_topic_has_active_session(self, message: Message) -> bool:
+        """Return True when a group forum topic already has an active session.
+
+        Mirrors :meth:`SlackAdapter._has_active_session_for_thread`. Once a
+        session is running in a forum topic, follow-up messages in that topic
+        belong to the ongoing conversation and should be processed without a
+        fresh @mention. This is what lets an uncaptioned screenshot continue an
+        active topic conversation instead of being dropped by the mention gate.
+
+        Only fires for real forum topic threads that already have a session, so
+        idle topics still need a mention to start. Builds the lookup key with
+        ``build_session_key`` using the same isolation flags the store used to
+        key the entry, so the lookup matches the stored key. Any failure returns
+        False (mention still required).
+        """
+        store = getattr(self, "_session_store", None)
+        if not store:
+            return False
+        try:
+            from gateway.session import SessionSource, build_session_key
+
+            chat = getattr(message, "chat", None)
+            chat_id = str(getattr(chat, "id", "") or "")
+            if not chat_id:
+                return False
+            thread_id = self._effective_message_thread_id(message)
+            if not thread_id:
+                return False
+            user = getattr(message, "from_user", None)
+            source = SessionSource(
+                platform=Platform.TELEGRAM,
+                chat_id=chat_id,
+                chat_type="group",
+                user_id=str(user.id) if user is not None else None,
+                thread_id=thread_id,
+            )
+            # Read isolation flags from the session store's own config, not the
+            # adapter's PlatformConfig.extra. The store keys entries via
+            # SessionStore._generate_session_key, which reads these flags from
+            # the gateway config it holds; using the same source keeps the
+            # lookup key aligned with the stored key when an operator changes
+            # group_sessions_per_user / thread_sessions_per_user. Mirrors
+            # SlackAdapter._has_active_session_for_thread.
+            store_cfg = getattr(store, "config", None)
+            group_per_user = (
+                getattr(store_cfg, "group_sessions_per_user", True) if store_cfg is not None else True
+            )
+            thread_per_user = (
+                getattr(store_cfg, "thread_sessions_per_user", False) if store_cfg is not None else False
+            )
+            session_key = build_session_key(
+                source,
+                group_sessions_per_user=group_per_user,
+                thread_sessions_per_user=thread_per_user,
+            )
+            store._ensure_loaded()
+            return session_key in store._entries
+        except Exception:
+            return False
 
     async def _ensure_forum_commands(self, message) -> None:
         """Lazy-register bot commands for forum supergroups.

--- a/tests/gateway/test_multiplex_adapter_registry.py
+++ b/tests/gateway/test_multiplex_adapter_registry.py
@@ -1,8 +1,10 @@
 """Phase 3: secondary-profile adapter registry + same-token conflict detection."""
-import logging
 import asyncio
+import logging
 from contextlib import contextmanager
 from pathlib import Path
+from types import SimpleNamespace
+from typing import Any, cast
 from unittest.mock import AsyncMock
 
 import pytest
@@ -162,6 +164,9 @@ class _SecondaryRecoveryAdapter:
 
     async def disconnect(self):
         self.disconnected = True
+
+    def set_session_profile(self, profile_name):
+        self.session_profile = profile_name
 
     def set_message_handler(self, handler):
         self.message_handler = handler
@@ -586,6 +591,9 @@ class TestSecondaryProfileConfigHandling:
         class _DirectAdapter:
             platform = Platform.TELEGRAM
 
+            def set_session_profile(self, profile_name):
+                self.session_profile = profile_name
+
             def set_message_handler(self, handler):
                 self.message_handler = handler
 
@@ -660,6 +668,9 @@ class TestSecondaryProfileConfigHandling:
         class _RelayAdapter:
             platform = Platform.RELAY
 
+            def set_session_profile(self, profile_name):
+                self.session_profile = profile_name
+
             def set_message_handler(self, handler):
                 pass
 
@@ -716,6 +727,78 @@ class TestSecondaryProfileConfigHandling:
         assert connected == 1
         assert factory_calls == [Platform.RELAY]
         assert connect_calls == [(relay, Platform.RELAY)]
+
+    @pytest.mark.asyncio
+    async def test_secondary_telegram_profile_reaches_active_topic_lookup(self, monkeypatch):
+        """Production startup stamps the profile used by Telegram's pre-dispatch gate."""
+        from gateway.config import GatewayConfig, Platform, PlatformConfig
+        from gateway.session import build_session_key
+        from plugins.platforms.telegram.adapter import TelegramAdapter
+
+        profile_name = "reviewer"
+        platform_config = PlatformConfig(enabled=True, token="secondary-token")
+        adapter = TelegramAdapter(platform_config)
+
+        class _SessionStore:
+            config = SimpleNamespace(
+                group_sessions_per_user=True,
+                thread_sessions_per_user=False,
+                multiplex_profiles=True,
+            )
+
+            def __init__(self):
+                self._entries = set()
+
+            def _ensure_loaded(self):
+                return None
+
+            def _generate_session_key(self, source):
+                return build_session_key(
+                    source,
+                    group_sessions_per_user=self.config.group_sessions_per_user,
+                    thread_sessions_per_user=self.config.thread_sessions_per_user,
+                    profile=source.profile,
+                )
+
+        store = _SessionStore()
+        runner = GatewayRunner.__new__(GatewayRunner)
+        runner.config = GatewayConfig(multiplex_profiles=True)
+        runner._profile_adapters = {}
+        runner.session_store = cast(Any, store)
+        runner._busy_text_mode = "interrupt"
+        runner._connect_adapter_with_timeout = AsyncMock(return_value=True)
+        runner._is_user_authorized = lambda source: True
+
+        profile_cfg = GatewayConfig(multiplex_profiles=True)
+        profile_cfg.platforms = {Platform.TELEGRAM: platform_config}
+        monkeypatch.setattr("gateway.config.load_gateway_config", lambda: profile_cfg)
+        monkeypatch.setattr(runner, "_create_adapter", lambda _platform, _config: adapter)
+
+        connected = await runner._start_one_profile_adapters(profile_name, Path("/tmp/x"), {})
+
+        assert connected == 1
+        assert adapter._session_profile == profile_name
+        source = adapter.build_source(
+            chat_id="-1001234567890",
+            chat_type="group",
+            user_id="111",
+            thread_id="42",
+        )
+        assert source.profile == profile_name
+        store._entries.add(store._generate_session_key(source))
+
+        message = SimpleNamespace(
+            chat=SimpleNamespace(
+                id=-1001234567890,
+                type="supergroup",
+                title="Example Forum",
+                is_forum=True,
+            ),
+            from_user=SimpleNamespace(id=111),
+            message_thread_id=42,
+            is_topic_message=True,
+        )
+        assert adapter._forum_topic_has_active_session(message) is True
 
     @pytest.mark.asyncio
     async def test_secondary_same_config_token_is_refused(self, monkeypatch):

--- a/tests/gateway/test_telegram_forum_topic_media_routing.py
+++ b/tests/gateway/test_telegram_forum_topic_media_routing.py
@@ -1,0 +1,453 @@
+"""Regression tests for Telegram forum-topic media routing.
+
+These tests lock two invariants that together explain and fix the reported bug
+where photos and files sent to a bound group forum topic never reached the
+agent while plain text in the same topic worked:
+
+1. Routing symmetry: text, photos, and document/image files sent to the same
+   forum topic resolve the same ``thread_id`` and session key, so media always
+   routes to the same session as text in that topic.
+
+2. Active-session bypass: a forum topic that already has an active session
+   accepts follow-up messages (text and media, even without a caption mention)
+   without a fresh @mention, matching Slack thread behavior. Idle topics still
+   require a mention, so the bot stays quiet on unrelated group chatter.
+
+The mention gate, not the routing layer, was dropping uncaptioned media; these
+tests cover both the gate decision and the end-to-end media path.
+"""
+
+import sys
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from gateway.config import Platform, PlatformConfig
+from gateway.platforms.base import MessageType
+
+
+# ---------------------------------------------------------------------------
+# Mock the telegram package if it's not installed (mirrors test_telegram_documents)
+# ---------------------------------------------------------------------------
+
+def _ensure_telegram_mock():
+    if "telegram" in sys.modules and hasattr(sys.modules["telegram"], "__file__"):
+        return
+    telegram_mod = MagicMock()
+    telegram_mod.ext.ContextTypes.DEFAULT_TYPE = type(None)
+    telegram_mod.constants.ParseMode.MARKDOWN_V2 = "MarkdownV2"
+    telegram_mod.constants.ChatType.GROUP = "group"
+    telegram_mod.constants.ChatType.SUPERGROUP = "supergroup"
+    telegram_mod.constants.ChatType.CHANNEL = "channel"
+    telegram_mod.constants.ChatType.PRIVATE = "private"
+    for name in ("telegram", "telegram.ext", "telegram.constants", "telegram.request"):
+        sys.modules.setdefault(name, telegram_mod)
+
+
+_ensure_telegram_mock()
+
+from gateway.platforms.telegram import TelegramAdapter  # noqa: E402
+from gateway.session import SessionSource, build_session_key  # noqa: E402
+
+
+GROUP_ID = -1003917904618  # "D4J Powerhouse" supergroup id from the report
+TOPIC_ID = 14              # "Samson" forum topic id from the report
+OTHER_TOPIC_ID = 99
+BOT_USERNAME = "hermes_bot"
+
+
+# ---------------------------------------------------------------------------
+# Fakes / builders
+# ---------------------------------------------------------------------------
+
+class _FakeSessionStore:
+    """Minimal session store exposing the read surface the gate touches.
+
+    Carries a ``config`` with the session-isolation flags, mirroring the real
+    SessionStore: the gate reads these to build a lookup key that matches how
+    the store keyed the entry.
+    """
+
+    def __init__(self, keys=(), *, group_sessions_per_user=True, thread_sessions_per_user=False):
+        self._entries = set(keys)
+        self.ensure_loaded_called = False
+        self.config = SimpleNamespace(
+            group_sessions_per_user=group_sessions_per_user,
+            thread_sessions_per_user=thread_sessions_per_user,
+        )
+
+    def _ensure_loaded(self):
+        self.ensure_loaded_called = True
+
+
+class _RaisingSessionStore:
+    """Session store whose load step raises, to prove the gate fails safe."""
+
+    _entries: set = set()
+
+    def _ensure_loaded(self):
+        raise RuntimeError("store unavailable")
+
+
+def _make_adapter(*, require_mention=True, session_keys=(), session_store="fake"):
+    config = PlatformConfig(
+        enabled=True,
+        token="fake-token",
+        extra={
+            "require_mention": require_mention,
+            "allowed_topics": [],
+            "allowed_chats": [],
+            "group_allowed_chats": [],
+        },
+    )
+    adapter = TelegramAdapter(config)
+    adapter._bot = SimpleNamespace(id=999, username=BOT_USERNAME)
+    if session_store == "fake":
+        adapter._session_store = _FakeSessionStore(session_keys)
+    elif session_store == "raising":
+        adapter._session_store = _RaisingSessionStore()
+    else:
+        adapter._session_store = session_store
+    # The empty-allowlist callback auth path is fail-closed; bypass it so the
+    # trigger logic under test runs for fake senders.
+    adapter._is_callback_user_authorized = lambda user_id, **_kw: True
+    return adapter
+
+
+def _forum_message(
+    *,
+    text=None,
+    caption=None,
+    thread_id=TOPIC_ID,
+    chat_id=GROUP_ID,
+    from_user_id=111,
+    entities=None,
+    caption_entities=None,
+    message_id=42,
+):
+    """A message posted into a supergroup forum topic."""
+    return SimpleNamespace(
+        message_id=message_id,
+        text=text,
+        caption=caption,
+        entities=entities or [],
+        caption_entities=caption_entities or [],
+        message_thread_id=thread_id,
+        is_topic_message=thread_id is not None,
+        chat=SimpleNamespace(
+            id=chat_id,
+            type="supergroup",
+            title="D4J Powerhouse",
+            is_forum=True,
+        ),
+        from_user=SimpleNamespace(
+            id=from_user_id,
+            full_name="Alice Example",
+            first_name="Alice",
+        ),
+        reply_to_message=None,
+        quote=None,
+        date=None,
+    )
+
+
+def _dm_message(*, caption=None, from_user_id=111):
+    return SimpleNamespace(
+        message_id=43,
+        text=caption,
+        caption=caption,
+        entities=[],
+        caption_entities=[],
+        message_thread_id=None,
+        is_topic_message=False,
+        chat=SimpleNamespace(
+            id=from_user_id,
+            type="private",
+            title=None,
+            full_name="Alice Example",
+            is_forum=False,
+        ),
+        from_user=SimpleNamespace(
+            id=from_user_id,
+            full_name="Alice Example",
+            first_name="Alice",
+        ),
+        reply_to_message=None,
+        quote=None,
+        date=None,
+    )
+
+
+def _topic_session_key(
+    *,
+    thread_id=TOPIC_ID,
+    chat_id=GROUP_ID,
+    user_id=111,
+    group_sessions_per_user=True,
+    thread_sessions_per_user=False,
+):
+    """The session key the store would use for a forum-topic message.
+
+    Defaults match the store defaults; pass explicit flags to mirror a store
+    configured with non-default isolation.
+    """
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id=str(chat_id),
+        chat_type="group",
+        user_id=str(user_id),
+        thread_id=str(thread_id),
+    )
+    return build_session_key(
+        source,
+        group_sessions_per_user=group_sessions_per_user,
+        thread_sessions_per_user=thread_sessions_per_user,
+    )
+
+
+def _mention_entity(text, mention="@" + BOT_USERNAME):
+    offset = text.index(mention)
+    return SimpleNamespace(type="mention", offset=offset, length=len(mention))
+
+
+def _file_obj(data=b"image-bytes", file_path="photos/file.jpg"):
+    f = AsyncMock()
+    f.download_as_bytearray = AsyncMock(return_value=bytearray(data))
+    f.file_path = file_path
+    return f
+
+
+def _photo_size(file_obj=None):
+    return SimpleNamespace(get_file=AsyncMock(return_value=file_obj or _file_obj()))
+
+
+# ---------------------------------------------------------------------------
+# 1. Routing symmetry: text / photo / image-document resolve the same session
+# ---------------------------------------------------------------------------
+
+def test_text_photo_and_document_resolve_same_topic_thread_id():
+    adapter = _make_adapter()
+
+    text_event = adapter._build_message_event(_forum_message(text="hi"), MessageType.TEXT)
+    photo_event = adapter._build_message_event(_forum_message(caption=None), MessageType.PHOTO)
+    doc_event = adapter._build_message_event(_forum_message(caption="see file"), MessageType.DOCUMENT)
+
+    assert text_event.source.thread_id == str(TOPIC_ID)
+    assert photo_event.source.thread_id == str(TOPIC_ID)
+    assert doc_event.source.thread_id == str(TOPIC_ID)
+
+
+def test_text_photo_and_document_build_identical_session_key():
+    adapter = _make_adapter()
+
+    def key(event):
+        return build_session_key(
+            event.source,
+            group_sessions_per_user=adapter.config.extra.get("group_sessions_per_user", True),
+            thread_sessions_per_user=adapter.config.extra.get("thread_sessions_per_user", False),
+        )
+
+    text_key = key(adapter._build_message_event(_forum_message(text="hi"), MessageType.TEXT))
+    photo_key = key(adapter._build_message_event(_forum_message(), MessageType.PHOTO))
+    doc_key = key(adapter._build_message_event(_forum_message(caption="x"), MessageType.DOCUMENT))
+
+    assert text_key == photo_key == doc_key
+    # And it is the topic-scoped key, not the group-root key.
+    assert str(TOPIC_ID) in text_key
+
+
+def test_dm_photo_routes_to_dm_session_unchanged():
+    adapter = _make_adapter()
+    event = adapter._build_message_event(_dm_message(), MessageType.PHOTO)
+    assert event.source.chat_type == "dm"
+    assert event.source.thread_id is None
+
+
+# ---------------------------------------------------------------------------
+# 2. Forum-topic thread-id helper (single source of truth)
+# ---------------------------------------------------------------------------
+
+def test_forum_topic_thread_id_helper():
+    adapter = _make_adapter()
+    # Real forum topic message.
+    assert adapter._forum_topic_thread_id(_forum_message(text="hi"), "group") == str(TOPIC_ID)
+    # Forum group with no explicit topic falls back to the General topic.
+    no_topic = _forum_message(text="hi", thread_id=None)
+    assert adapter._forum_topic_thread_id(no_topic, "group") == adapter._GENERAL_TOPIC_THREAD_ID
+    # Plain (non-forum) group reply anchor is dropped.
+    plain = _forum_message(text="hi")
+    plain.is_topic_message = False
+    plain.chat.is_forum = False
+    assert adapter._forum_topic_thread_id(plain, "group") is None
+
+
+# ---------------------------------------------------------------------------
+# 3. Active-session bypass at the gate (the fix)
+# ---------------------------------------------------------------------------
+
+def test_uncaptioned_media_dropped_in_topic_without_active_session():
+    """Baseline: with require_mention and no active session, captionless media
+    is not processed (this is the reported drop)."""
+    adapter = _make_adapter(require_mention=True, session_keys=())
+    # No caption, no mention.
+    assert adapter._should_process_message(_forum_message(caption=None)) is False
+    assert adapter._should_process_message(_forum_message(text=None)) is False
+
+
+def test_uncaptioned_media_processed_when_topic_has_active_session():
+    adapter = _make_adapter(require_mention=True)
+    adapter._session_store = _FakeSessionStore({_topic_session_key()})
+
+    # Uncaptioned photo / document / text all pass once the topic has a session.
+    assert adapter._should_process_message(_forum_message(caption=None)) is True
+    assert adapter._should_process_message(_forum_message(text=None)) is True
+    assert adapter._session_store.ensure_loaded_called is True
+
+
+def test_active_session_bypass_is_scoped_to_the_matching_topic():
+    adapter = _make_adapter(require_mention=True)
+    # Only TOPIC_ID has an active session.
+    adapter._session_store = _FakeSessionStore({_topic_session_key()})
+
+    # A captionless message in a different topic is still dropped.
+    other = _forum_message(caption=None, thread_id=OTHER_TOPIC_ID)
+    assert adapter._should_process_message(other) is False
+
+
+def test_mention_still_processed_without_active_session():
+    """The active-session bypass is additive: an explicit mention still works
+    even when no session exists yet (starting a conversation)."""
+    adapter = _make_adapter(require_mention=True, session_keys=())
+    text = "hey @" + BOT_USERNAME + " look"
+    msg = _forum_message(text=text, entities=[_mention_entity(text)])
+    assert adapter._should_process_message(msg) is True
+
+
+def test_active_session_lookup_uses_store_config_isolation_flags():
+    """The lookup key must use the store's isolation flags, not the adapter's
+    PlatformConfig.extra (which never carries them). With
+    thread_sessions_per_user=True the store keys the entry WITH the user id, so
+    a gate that read the adapter extra (defaulting the flag to False) would
+    build a user-less key and miss the entry."""
+    adapter = _make_adapter(require_mention=True)
+    user_id = 111
+    keyed = _topic_session_key(user_id=user_id, thread_sessions_per_user=True)
+    adapter._session_store = _FakeSessionStore({keyed}, thread_sessions_per_user=True)
+
+    msg = _forum_message(caption=None, from_user_id=user_id)
+    assert adapter._should_process_message(msg) is True
+
+    # A different user's uncaptioned message is dropped: per-user keying means
+    # only the user with the active session bypasses the mention requirement.
+    other_user = _forum_message(caption=None, from_user_id=222)
+    assert adapter._should_process_message(other_user) is False
+
+
+def test_gate_fails_safe_when_session_store_missing_or_raising():
+    no_store = _make_adapter(require_mention=True, session_store=None)
+    assert no_store._should_process_message(_forum_message(caption=None)) is False
+
+    raising = _make_adapter(require_mention=True, session_store="raising")
+    assert raising._should_process_message(_forum_message(caption=None)) is False
+
+
+def test_active_session_helper_ignores_non_forum_group_messages():
+    adapter = _make_adapter(require_mention=True)
+    adapter._session_store = _FakeSessionStore({_topic_session_key()})
+    plain = _forum_message(caption=None)
+    plain.is_topic_message = False
+    plain.chat.is_forum = False
+    # No real topic thread -> helper returns False even if a key happens to exist.
+    assert adapter._forum_topic_has_active_session(plain) is False
+
+
+# ---------------------------------------------------------------------------
+# 4. End-to-end media path: caption preserved, attachment attached, topic kept
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_captioned_topic_photo_preserves_caption_and_attachment():
+    adapter = _make_adapter(require_mention=True)
+    # Caption mentions the bot so the message passes the gate on its own.
+    caption = "@" + BOT_USERNAME + " look at this"
+    msg = _forum_message(
+        caption=caption,
+        caption_entities=[_mention_entity(caption)],
+    )
+    msg.photo = [_photo_size()]
+    msg.video = msg.audio = msg.voice = msg.sticker = msg.document = None
+    msg.media_group_id = None
+    update = SimpleNamespace(message=msg, update_id=1)
+
+    captured = []
+    adapter._enqueue_photo_event = lambda key, event: captured.append((key, event))
+
+    with patch(
+        "gateway.platforms.telegram.cache_image_from_bytes",
+        return_value="/cache/user-photo.jpg",
+    ):
+        await adapter._handle_media_message(update, None)
+
+    assert captured, "captioned topic photo should be enqueued, not dropped"
+    _key, event = captured[0]
+    assert event.media_urls == ["/cache/user-photo.jpg"]
+    assert event.media_types == ["image/jpg"]
+    assert "look at this" in (event.text or "")
+    assert event.source.thread_id == str(TOPIC_ID)
+
+
+@pytest.mark.asyncio
+async def test_uncaptioned_topic_photo_reaches_pipeline_when_session_active():
+    adapter = _make_adapter(require_mention=True)
+    adapter._session_store = _FakeSessionStore({_topic_session_key()})
+
+    msg = _forum_message(caption=None)
+    msg.photo = [_photo_size()]
+    msg.video = msg.audio = msg.voice = msg.sticker = msg.document = None
+    msg.media_group_id = None
+    update = SimpleNamespace(message=msg, update_id=2)
+
+    captured = []
+    adapter._enqueue_photo_event = lambda key, event: captured.append((key, event))
+
+    with patch(
+        "gateway.platforms.telegram.cache_image_from_bytes",
+        return_value="/cache/user-photo.jpg",
+    ):
+        await adapter._handle_media_message(update, None)
+
+    assert captured, "uncaptioned photo in an active-session topic must not be dropped"
+    _key, event = captured[0]
+    assert event.media_urls == ["/cache/user-photo.jpg"]
+    assert event.source.thread_id == str(TOPIC_ID)
+
+
+# ---------------------------------------------------------------------------
+# 5. Album / media-group keeps the topic thread and coalesces into one event
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_topic_album_coalesces_into_one_event_keeping_thread():
+    adapter = _make_adapter(require_mention=True)
+    adapter.handle_message = AsyncMock()
+
+    ev1 = adapter._build_message_event(_forum_message(caption="album"), MessageType.PHOTO)
+    ev1.media_urls = ["/cache/a.jpg"]
+    ev1.media_types = ["image/jpg"]
+    ev2 = adapter._build_message_event(_forum_message(), MessageType.PHOTO)
+    ev2.media_urls = ["/cache/b.jpg"]
+    ev2.media_types = ["image/jpg"]
+
+    gid = "group-1"
+    await adapter._queue_media_group_event(gid, ev1)
+    await adapter._queue_media_group_event(gid, ev2)
+
+    merged = adapter._media_group_events[gid]
+    assert merged.media_urls == ["/cache/a.jpg", "/cache/b.jpg"]
+    assert merged.source.thread_id == str(TOPIC_ID)
+
+    # Cancel the pending flush task so the test does not leak a timer.
+    task = adapter._media_group_tasks.get(gid)
+    if task:
+        task.cancel()

--- a/tests/gateway/test_telegram_forum_topic_media_routing.py
+++ b/tests/gateway/test_telegram_forum_topic_media_routing.py
@@ -19,6 +19,7 @@ tests cover both the gate decision and the end-to-end media path.
 
 import sys
 from types import SimpleNamespace
+from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -51,8 +52,8 @@ from plugins.platforms.telegram.adapter import TelegramAdapter  # noqa: E402
 from gateway.session import SessionSource, build_session_key  # noqa: E402
 
 
-GROUP_ID = -1003917904618  # "D4J Powerhouse" supergroup id from the report
-TOPIC_ID = 14              # "Samson" forum topic id from the report
+GROUP_ID = -1001234567890
+TOPIC_ID = 42
 OTHER_TOPIC_ID = 99
 BOT_USERNAME = "hermes_bot"
 
@@ -69,16 +70,32 @@ class _FakeSessionStore:
     the store keyed the entry.
     """
 
-    def __init__(self, keys=(), *, group_sessions_per_user=True, thread_sessions_per_user=False):
+    def __init__(
+        self,
+        keys=(),
+        *,
+        group_sessions_per_user=True,
+        thread_sessions_per_user=False,
+        multiplex_profiles=False,
+    ):
         self._entries = set(keys)
         self.ensure_loaded_called = False
         self.config = SimpleNamespace(
             group_sessions_per_user=group_sessions_per_user,
             thread_sessions_per_user=thread_sessions_per_user,
+            multiplex_profiles=multiplex_profiles,
         )
 
     def _ensure_loaded(self):
         self.ensure_loaded_called = True
+
+    def _generate_session_key(self, source):
+        return build_session_key(
+            source,
+            group_sessions_per_user=self.config.group_sessions_per_user,
+            thread_sessions_per_user=self.config.thread_sessions_per_user,
+            profile=source.profile if self.config.multiplex_profiles else None,
+        )
 
 
 class _RaisingSessionStore:
@@ -90,7 +107,13 @@ class _RaisingSessionStore:
         raise RuntimeError("store unavailable")
 
 
-def _make_adapter(*, require_mention=True, session_keys=(), session_store="fake"):
+def _make_adapter(
+    *,
+    require_mention=True,
+    session_keys=(),
+    session_store: Any = "fake",
+    profile_name=None,
+):
     config = PlatformConfig(
         enabled=True,
         token="fake-token",
@@ -104,6 +127,7 @@ def _make_adapter(*, require_mention=True, session_keys=(), session_store="fake"
         },
     )
     adapter = TelegramAdapter(config)
+    adapter.set_session_profile(profile_name)
     adapter._bot = SimpleNamespace(id=999, username=BOT_USERNAME)
     if session_store == "fake":
         adapter._session_store = _FakeSessionStore(session_keys)
@@ -140,7 +164,7 @@ def _forum_message(
         chat=SimpleNamespace(
             id=chat_id,
             type="supergroup",
-            title="D4J Powerhouse",
+            title="Example Forum",
             is_forum=True,
         ),
         from_user=SimpleNamespace(
@@ -188,6 +212,7 @@ def _topic_session_key(
     user_id=111,
     group_sessions_per_user=True,
     thread_sessions_per_user=False,
+    profile=None,
 ):
     """The session key the store would use for a forum-topic message.
 
@@ -205,6 +230,7 @@ def _topic_session_key(
         source,
         group_sessions_per_user=group_sessions_per_user,
         thread_sessions_per_user=thread_sessions_per_user,
+        profile=profile,
     )
 
 
@@ -347,11 +373,9 @@ def test_mention_still_processed_without_active_session():
 
 
 def test_active_session_lookup_uses_store_config_isolation_flags():
-    """The lookup key must use the store's isolation flags, not the adapter's
-    PlatformConfig.extra (which never carries them). With
-    thread_sessions_per_user=True the store keys the entry WITH the user id, so
-    a gate that read the adapter extra (defaulting the flag to False) would
-    build a user-less key and miss the entry."""
+    """The lookup key must use the store's isolation flags. With
+    thread_sessions_per_user=True the store keys the entry with the user id, so
+    bypassing the store's key generator would risk missing the entry."""
     adapter = _make_adapter(require_mention=True)
     user_id = 111
     keyed = _topic_session_key(user_id=user_id, thread_sessions_per_user=True)
@@ -364,6 +388,21 @@ def test_active_session_lookup_uses_store_config_isolation_flags():
     # only the user with the active session bypasses the mention requirement.
     other_user = _forum_message(caption=None, from_user_id=222)
     assert adapter._should_process_message(other_user) is False
+
+
+def test_active_session_lookup_uses_multiplexed_profile_namespace():
+    profile_name = "support"
+    keyed = _topic_session_key(profile=profile_name)
+    store = _FakeSessionStore({keyed}, multiplex_profiles=True)
+    adapter = _make_adapter(
+        require_mention=True,
+        session_store=store,
+        profile_name=profile_name,
+    )
+
+    assert adapter._should_process_message(_forum_message(caption=None)) is True
+    event = adapter._build_message_event(_forum_message(text="follow-up"), MessageType.TEXT)
+    assert event.source.profile == profile_name
 
 
 def test_gate_fails_safe_when_session_store_missing_or_raising():

--- a/tests/gateway/test_telegram_forum_topic_media_routing.py
+++ b/tests/gateway/test_telegram_forum_topic_media_routing.py
@@ -47,7 +47,7 @@ def _ensure_telegram_mock():
 
 _ensure_telegram_mock()
 
-from gateway.platforms.telegram import TelegramAdapter  # noqa: E402
+from plugins.platforms.telegram.adapter import TelegramAdapter  # noqa: E402
 from gateway.session import SessionSource, build_session_key  # noqa: E402
 
 
@@ -96,6 +96,8 @@ def _make_adapter(*, require_mention=True, session_keys=(), session_store="fake"
         token="fake-token",
         extra={
             "require_mention": require_mention,
+            "free_response_chats": [],
+            "mention_patterns": [],
             "allowed_topics": [],
             "allowed_chats": [],
             "group_allowed_chats": [],
@@ -268,18 +270,18 @@ def test_dm_photo_routes_to_dm_session_unchanged():
 # 2. Forum-topic thread-id helper (single source of truth)
 # ---------------------------------------------------------------------------
 
-def test_forum_topic_thread_id_helper():
+def test_effective_message_thread_id_helper():
     adapter = _make_adapter()
     # Real forum topic message.
-    assert adapter._forum_topic_thread_id(_forum_message(text="hi"), "group") == str(TOPIC_ID)
+    assert adapter._effective_message_thread_id(_forum_message(text="hi")) == str(TOPIC_ID)
     # Forum group with no explicit topic falls back to the General topic.
     no_topic = _forum_message(text="hi", thread_id=None)
-    assert adapter._forum_topic_thread_id(no_topic, "group") == adapter._GENERAL_TOPIC_THREAD_ID
+    assert adapter._effective_message_thread_id(no_topic) == adapter._GENERAL_TOPIC_THREAD_ID
     # Plain (non-forum) group reply anchor is dropped.
     plain = _forum_message(text="hi")
     plain.is_topic_message = False
     plain.chat.is_forum = False
-    assert adapter._forum_topic_thread_id(plain, "group") is None
+    assert adapter._effective_message_thread_id(plain) is None
 
 
 # ---------------------------------------------------------------------------
@@ -303,6 +305,26 @@ def test_uncaptioned_media_processed_when_topic_has_active_session():
     assert adapter._should_process_message(_forum_message(caption=None)) is True
     assert adapter._should_process_message(_forum_message(text=None)) is True
     assert adapter._session_store.ensure_loaded_called is True
+
+
+def test_active_session_accepts_every_media_shape():
+    """The gate is media-type agnostic: once the topic has a session, a photo
+    with a plain caption (no mention), an uncaptioned photo, and a document all
+    pass. Without a session each is still dropped under require_mention."""
+    active = _make_adapter(require_mention=True)
+    active._session_store = _FakeSessionStore({_topic_session_key()})
+
+    captioned_photo = _forum_message(caption="here is the screenshot")
+    uncaptioned_photo = _forum_message(caption=None)
+    document = _forum_message(caption=None)  # a file is gated identically
+
+    assert active._should_process_message(captioned_photo) is True
+    assert active._should_process_message(uncaptioned_photo) is True
+    assert active._should_process_message(document) is True
+
+    idle = _make_adapter(require_mention=True, session_keys=())
+    assert idle._should_process_message(_forum_message(caption="here is the screenshot")) is False
+    assert idle._should_process_message(_forum_message(caption=None)) is False
 
 
 def test_active_session_bypass_is_scoped_to_the_matching_topic():
@@ -384,7 +406,7 @@ async def test_captioned_topic_photo_preserves_caption_and_attachment():
     adapter._enqueue_photo_event = lambda key, event: captured.append((key, event))
 
     with patch(
-        "gateway.platforms.telegram.cache_image_from_bytes",
+        "plugins.platforms.telegram.adapter.cache_image_from_bytes",
         return_value="/cache/user-photo.jpg",
     ):
         await adapter._handle_media_message(update, None)
@@ -412,7 +434,7 @@ async def test_uncaptioned_topic_photo_reaches_pipeline_when_session_active():
     adapter._enqueue_photo_event = lambda key, event: captured.append((key, event))
 
     with patch(
-        "gateway.platforms.telegram.cache_image_from_bytes",
+        "plugins.platforms.telegram.adapter.cache_image_from_bytes",
         return_value="/cache/user-photo.jpg",
     ):
         await adapter._handle_media_message(update, None)
@@ -420,6 +442,40 @@ async def test_uncaptioned_topic_photo_reaches_pipeline_when_session_active():
     assert captured, "uncaptioned photo in an active-session topic must not be dropped"
     _key, event = captured[0]
     assert event.media_urls == ["/cache/user-photo.jpg"]
+    assert event.source.thread_id == str(TOPIC_ID)
+
+
+@pytest.mark.asyncio
+async def test_uncaptioned_topic_document_reaches_pipeline_when_session_active():
+    adapter = _make_adapter(require_mention=True)
+    adapter._session_store = _FakeSessionStore({_topic_session_key()})
+    adapter.handle_message = AsyncMock()
+
+    file_obj = AsyncMock()
+    file_obj.download_as_bytearray = AsyncMock(return_value=bytearray(b"%PDF-1.4 ..."))
+    file_obj.file_path = "documents/report.pdf"
+    document = MagicMock()
+    document.file_name = "report.pdf"
+    document.mime_type = "application/pdf"
+    document.file_size = 2048
+    document.get_file = AsyncMock(return_value=file_obj)
+
+    msg = _forum_message(caption=None)
+    msg.photo = msg.video = msg.audio = msg.voice = msg.sticker = None
+    msg.document = document
+    msg.media_group_id = None
+    update = SimpleNamespace(message=msg, update_id=3)
+
+    with patch(
+        "plugins.platforms.telegram.adapter.cache_document_from_bytes",
+        return_value="/cache/report.pdf",
+    ):
+        await adapter._handle_media_message(update, None)
+
+    adapter.handle_message.assert_awaited_once()
+    event = adapter.handle_message.await_args.args[0]
+    assert event.media_urls == ["/cache/report.pdf"]
+    assert event.media_types == ["application/pdf"]
     assert event.source.thread_id == str(TOPIC_ID)
 
 

--- a/website/docs/user-guide/messaging/telegram.md
+++ b/website/docs/user-guide/messaging/telegram.md
@@ -537,6 +537,8 @@ Hermes Agent works in Telegram group chats with a few considerations:
   - `@botusername` mentions
   - `/command@botusername` (Telegram's bot-menu command form that includes the bot name)
   - matches for one of your configured regex wake words in `telegram.mention_patterns`
+  - follow-ups in a forum topic that already has an active session (see below)
+- Once a forum topic has an active session, follow-up messages in that topic are treated as part of the ongoing conversation and do not need a fresh mention, the same way Slack handles replies in an active thread. This applies to text and to media (photos, screenshots, and files), so an uncaptioned image continuing a conversation reaches the agent instead of being dropped by the mention gate. Starting a new topic conversation still needs a mention when `require_mention` is enabled, and `telegram.ignored_threads` still silences a topic entirely.
 - In groups with multiple Hermes bots, `telegram.exclusive_bot_mentions` keeps routing deterministic. When a message explicitly mentions one or more Telegram bot usernames, only the mentioned bot profiles process it; other Hermes bots ignore it before reply and wake-word fallbacks run. This is enabled by default.
 - Renaming the bot's `@username` in BotFather is picked up automatically — Hermes follows the new handle for mention routing without a gateway restart. Collectible (Fragment) usernames that don't end in `bot` are supported too.
 - Use `telegram.ignored_threads` to keep Hermes silent in specific Telegram forum topics, even when the group would otherwise allow free responses or mention-triggered replies


### PR DESCRIPTION
## What does this PR do?

In a Telegram group forum topic that already has an active session, media sent as a follow-up never reaches the agent: an uncaptioned photo, a photo with a plain caption, and a file sent as a document are all dropped, while plain text that mentions the bot works and private DM media works.

The routing layer is already symmetric: text, photos, and documents in a forum topic build the same `thread_id` and session key and dispatch through the same handler (verified, and now locked by tests). The drop happens earlier, at the group mention gate `_should_process_message` in `plugins/platforms/telegram/adapter.py`. For a `require_mention` group it returns True only on an `@mention`, a wake word, a reply to the bot, a free-response chat, or when mentions are disabled. The gate checks the caption too, so the only media that passes is media whose caption literally mentions the bot. A photo with a normal caption, an uncaptioned photo, and a document all fail and are dropped before any download (which matches the "no download event in the logs" symptom). DMs short-circuit that gate at its first line, which is why DM media always works.

This PR mirrors the mechanism Slack already uses for threads (`SlackAdapter._has_active_session_for_thread`): once a forum topic has an active session, follow-up messages in that topic belong to the ongoing conversation and are processed without a fresh mention. This applies to text and media alike. Idle topics still require a mention to start, so the bot stays quiet on unrelated group chatter, and per-user thread sessions still scope the bypass to the participant who has the active session.

## Related Issue

Related to #47415. That issue is a distinct, complementary bug: when `observe_unmentioned_group_messages` is on, an unmentioned group photo **is** downloaded and observed, then corrupted because `gateway/run.py` runs `str()` over the multimodal content list during observed-context replay. This PR does not touch that path. It addresses the case where the topic has an active session and the media is dropped at the mention gate before any download, so it never becomes a turn at all. In an active topic this fix turns the media into a real turn with the actual image attached, which also sidesteps the observed-context stringification for that case.

Related context: #46100 (media-group split), #13607 (General-topic messages can fail to reach Hermes while DMs work).

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `plugins/platforms/telegram/adapter.py`
  - Add `_forum_topic_has_active_session(message)`, mirroring `SlackAdapter._has_active_session_for_thread`: build the topic source and ask the session store's profile-aware key generator for the exact stored key. This preserves group/thread isolation flags and multiplexed profile namespaces. The lookup fails closed (mention still required) when the store is missing or raises.
  - Consult it in `_should_process_message` after the existing mention, reply, and wake-word checks and before the final return, so the active-session bypass runs only after the `allowed_topics`, `ignored_threads`, `allowed_chats`, and `exclusive_bot_mentions` hard gates.
  - Reuse the current-main `_effective_message_thread_id(message)` normalizer for both active-session gating and event routing, so General-topic fallback, real topic IDs, and ordinary reply anchors remain consistent.
- `gateway/platforms/base.py` and `gateway/run.py`: stamp secondary-profile adapters before connection and carry that namespace into inbound `SessionSource` objects. This lets pre-dispatch gates and the eventual message handler resolve the same multiplexed session key.
- `tests/gateway/test_telegram_forum_topic_media_routing.py` (new): routing symmetry across text, photo, and document in a forum topic; the active-session bypass and its topic, per-user, and multiplexed-profile scoping; store-config isolation; fail-safe behavior; caption and attachment preservation; album coalescing; synthetic-only fixture identifiers.
- `tests/gateway/test_multiplex_adapter_registry.py`: exercise the production secondary-adapter startup path and prove its profile stamp reaches both built sources and Telegram's active-topic lookup.
- `website/docs/user-guide/messaging/telegram.md`: document that an active forum-topic session accepts follow-up messages (including media) without a fresh mention, the same way Slack handles an active thread.

## How to Test

1. Configure a Telegram supergroup with forum topics and `require_mention: true`.
2. In a topic, mention the bot to start a session, let it reply.
3. Send a photo (with or without a caption) or a file as a document as a follow-up in that topic. Before this change it is dropped (no download in the gateway log). After this change it reaches the agent with the attachment.
4. Send an uncaptioned photo in a topic with no active session. It is still dropped (a mention is required to start).
5. Private DM media and mentioned or captioned media are unchanged.

Automated:

```text
pytest tests/gateway/test_telegram_forum_topic_media_routing.py tests/gateway/test_telegram_group_gating.py tests/gateway/test_multiplex_adapter_registry.py -q
# 80 passed
pytest tests/gateway/test_platform_base.py -q
# 178 passed
pytest tests/gateway/test_telegram_documents.py tests/gateway/test_telegram_topic_mode.py -q
# 89 passed
pytest tests/gateway/test_multiplex_*.py -q
# 71 passed
ruff check gateway/platforms/base.py gateway/run.py plugins/platforms/telegram/adapter.py tests/gateway/test_telegram_forum_topic_media_routing.py tests/gateway/test_multiplex_adapter_registry.py
# All checks passed
```

## Risks

- The bypass relaxes the mention requirement only for a topic that already has a session, and only after the hard allowlist and ignored-thread gates, so it cannot admit messages from non-allowlisted chats or silenced threads. Per-sender authorization is unchanged and still enforced downstream in the runner.
- With the default shared-thread session model, any participant in an active topic can continue it without a mention, matching the existing Slack thread behavior and the documented forum-topic session model.
- In multiplexed gateways, the pre-dispatch lookup uses the adapter's stamped profile and the session store's own key generator, preventing cross-profile collisions or misses.
- A `/stop`-suspended topic keeps a membership entry, so the next follow-up still bypasses the mention and starts a fresh session via the store's auto-reset, consistent with Slack's membership check.
- There is a narrow race if an uncaptioned follow-up arrives before the first turn has created the session entry. This matches the existing Slack behavior and is not addressed here.

## Checklist

### Code

- [x] My commit messages follow Conventional Commits (`fix(telegram): ...`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've run the relevant gateway tests and they pass
- [x] I've added tests for my changes

### Documentation & Housekeeping

- [x] I've updated relevant documentation (`website/docs/user-guide/messaging/telegram.md`)
- [x] No config keys added or changed (N/A `cli-config.yaml.example`)
- [x] No architecture or workflow change (N/A `CONTRIBUTING.md` / `AGENTS.md`)
- [x] Cross-platform impact considered: pure Python gateway logic, no platform-specific calls


