### PR TITLE
feat(dashboard-auth): configurable id_token_leeway for self-hosted OIDC

### DIFF
--- a/plugins/dashboard_auth/self_hosted/__init__.py
+++ b/plugins/dashboard_auth/self_hosted/__init__.py
@@ -50,11 +50,13 @@ same precedence convention as the ``nous`` plugin)::
           issuer: https://auth.example.com/application/o/hermes/   # required
           client_id: hermes-dashboard                              # required
           scopes: "openid profile email"                           # optional
+          id_token_leeway: 0                                        # optional; seconds of clock-skew tolerance
 
     # Environment overrides (Docker/Fly secret injection)
     HERMES_DASHBOARD_OIDC_ISSUER
     HERMES_DASHBOARD_OIDC_CLIENT_ID
-    HERMES_DASHBOARD_OIDC_SCOPES        # optional; defaults to "openid profile email"
+    HERMES_DASHBOARD_OIDC_SCOPES          # optional; defaults to "openid profile email"
+    HERMES_DASHBOARD_OIDC_ID_TOKEN_LEEWAY # optional seconds; clock-skew tolerance for exp/nbf/iat (default 0)
 
 Skip reasons: when the plugin loads but can't register (missing issuer /
 client_id), it writes a human-readable reason to the module-level
@@ -172,6 +174,7 @@ class SelfHostedOIDCProvider(DashboardAuthProvider):
         issuer: str,
         client_id: str,
         scopes: str = _DEFAULT_SCOPES,
+        id_token_leeway: float = 0.0,
     ) -> None:
         if not issuer:
             raise ValueError("issuer is required")
@@ -186,6 +189,13 @@ class SelfHostedOIDCProvider(DashboardAuthProvider):
         _require_https_or_loopback(self._issuer, field="issuer")
         self._client_id = client_id
         self._scopes = scopes.strip() or _DEFAULT_SCOPES
+        # Clock-skew tolerance (seconds) applied to the ID token's exp/nbf/iat
+        # checks. Default 0 keeps the strict behaviour; operators whose verifier
+        # and IDP clocks can drift (containers / VMs without tight time-sync)
+        # set a small value (RFC 7519 §4.1.4-4.1.6 allow "some small leeway,
+        # usually no more than a few minutes, to account for clock skew").
+        # Negative values are clamped to 0.
+        self._id_token_leeway = max(0.0, float(id_token_leeway))
 
         # Discovery + JWKS are lazily resolved on first use so plugin
         # registration never makes a network call (the IDP may be down at
@@ -510,6 +520,7 @@ class SelfHostedOIDCProvider(DashboardAuthProvider):
                 algorithms=list(_ALLOWED_ID_TOKEN_ALGS),
                 audience=self._client_id,
                 issuer=disco["issuer"],
+                leeway=self._id_token_leeway,
                 options={"require": ["exp", "iat", "aud", "iss", "sub"]},
             )
         except jwt.ExpiredSignatureError as exc:
@@ -673,6 +684,28 @@ def _resolve_setting(env_var: str, cfg_value: Any) -> str:
     return str(cfg_value or "").strip()
 
 
+def _resolve_leeway(env_var: str, cfg_value: Any) -> float:
+    """Resolve a non-negative seconds value with env-wins-config precedence.
+
+    Reuses :func:`_resolve_setting`'s precedence, then parses to a float.
+    Unparseable or negative input falls back to ``0.0`` (strict, no leeway) so
+    a typo can never *widen* the verification window — it only ever loses the
+    operator's intended tolerance, which fails closed.
+    """
+    raw = _resolve_setting(env_var, cfg_value)
+    if not raw:
+        return 0.0
+    try:
+        return max(0.0, float(raw))
+    except (TypeError, ValueError):
+        logger.warning(
+            "dashboard-auth-self-hosted: ignoring invalid id_token_leeway %r "
+            "(expected seconds); using 0",
+            raw,
+        )
+        return 0.0
+
+
 def register(ctx) -> None:
     """Plugin entry — called by the plugin loader at startup.
 
@@ -701,6 +734,9 @@ def register(ctx) -> None:
         _resolve_setting("HERMES_DASHBOARD_OIDC_SCOPES", oidc_cfg.get("scopes"))
         or _DEFAULT_SCOPES
     )
+    id_token_leeway = _resolve_leeway(
+        "HERMES_DASHBOARD_OIDC_ID_TOKEN_LEEWAY", oidc_cfg.get("id_token_leeway")
+    )
 
     if not issuer or not client_id:
         LAST_SKIP_REASON = (
@@ -717,7 +753,10 @@ def register(ctx) -> None:
 
     try:
         provider = SelfHostedOIDCProvider(
-            issuer=issuer, client_id=client_id, scopes=scopes
+            issuer=issuer,
+            client_id=client_id,
+            scopes=scopes,
+            id_token_leeway=id_token_leeway,
         )
     except (ValueError, ProviderError) as exc:
         LAST_SKIP_REASON = (
@@ -729,8 +768,9 @@ def register(ctx) -> None:
     ctx.register_dashboard_auth_provider(provider)
     logger.info(
         "dashboard-auth-self-hosted: registered provider "
-        "(issuer=%s, client_id=%s, scopes=%r)",
+        "(issuer=%s, client_id=%s, scopes=%r, id_token_leeway=%s)",
         issuer,
         client_id,
         scopes,
+        id_token_leeway,
     )

--- a/tests/plugins/dashboard_auth/test_self_hosted_provider.py
+++ b/tests/plugins/dashboard_auth/test_self_hosted_provider.py
@@ -99,6 +99,7 @@ def _mint_id_token(
     groups: Any = None,
     org_id: str | None = None,
     ttl_seconds: int = 900,
+    iat_offset: int = 0,
     extra_claims: Dict[str, Any] | None = None,
 ) -> str:
     now = int(time.time())
@@ -106,7 +107,7 @@ def _mint_id_token(
         "iss": iss,
         "aud": aud,
         "sub": sub,
-        "iat": now,
+        "iat": now + iat_offset,
         "exp": now + ttl_seconds,
     }
     if email is not None:
@@ -127,11 +128,15 @@ def _mint_id_token(
     )
 
 
-def _make_provider(rsa_keypair, *, scopes: str | None = None):
+def _make_provider(
+    rsa_keypair, *, scopes: str | None = None, id_token_leeway: float | None = None
+):
     """Construct a provider with discovery + JWKS stubbed (no network)."""
     kwargs: Dict[str, Any] = {"issuer": _ISSUER, "client_id": _CLIENT_ID}
     if scopes is not None:
         kwargs["scopes"] = scopes
+    if id_token_leeway is not None:
+        kwargs["id_token_leeway"] = id_token_leeway
     p = oidc_plugin.SelfHostedOIDCProvider(**kwargs)
     # Pre-seed discovery so nothing hits the network.
     p._discovery = dict(_DISCOVERY_DOC)
@@ -210,6 +215,22 @@ class TestConstruction:
             issuer=_ISSUER, client_id=_CLIENT_ID, scopes="   "
         )
         assert p._scopes == "openid profile email"
+
+    def test_default_leeway_is_zero(self):
+        p = oidc_plugin.SelfHostedOIDCProvider(issuer=_ISSUER, client_id=_CLIENT_ID)
+        assert p._id_token_leeway == 0.0
+
+    def test_custom_leeway_stored(self):
+        p = oidc_plugin.SelfHostedOIDCProvider(
+            issuer=_ISSUER, client_id=_CLIENT_ID, id_token_leeway=60
+        )
+        assert p._id_token_leeway == 60.0
+
+    def test_negative_leeway_clamped_to_zero(self):
+        p = oidc_plugin.SelfHostedOIDCProvider(
+            issuer=_ISSUER, client_id=_CLIENT_ID, id_token_leeway=-5
+        )
+        assert p._id_token_leeway == 0.0
 
 
 # ---------------------------------------------------------------------------
@@ -643,6 +664,28 @@ class TestVerifySession:
         with pytest.raises(ProviderError, match="JWKS"):
             provider.verify_session(access_token=token)
 
+    def test_future_iat_rejected_without_leeway(self, provider, rsa_keypair):
+        # Default leeway=0: an iat slightly in the future (clock skew between
+        # issuer and verifier) raises ImmatureSignatureError -> ProviderError.
+        token = _mint_id_token(rsa_keypair, iat_offset=30)
+        with pytest.raises(ProviderError, match="verification failed"):
+            provider.verify_session(access_token=token)
+
+    def test_future_iat_accepted_within_leeway(self, rsa_keypair):
+        # With leeway >= the skew, the same future-iat token verifies.
+        provider = _make_provider(rsa_keypair, id_token_leeway=60)
+        token = _mint_id_token(rsa_keypair, iat_offset=30)
+        session = provider.verify_session(access_token=token)
+        assert session is not None
+        assert session.user_id == "usr_abc"
+
+    def test_future_iat_beyond_leeway_still_rejected(self, rsa_keypair):
+        # Leeway bounds tolerance: skew larger than the leeway still fails.
+        provider = _make_provider(rsa_keypair, id_token_leeway=60)
+        token = _mint_id_token(rsa_keypair, iat_offset=120)
+        with pytest.raises(ProviderError, match="verification failed"):
+            provider.verify_session(access_token=token)
+
 
 # ---------------------------------------------------------------------------
 # refresh_session + revoke_session
@@ -755,6 +798,7 @@ class TestPluginRegister:
             "HERMES_DASHBOARD_OIDC_ISSUER",
             "HERMES_DASHBOARD_OIDC_CLIENT_ID",
             "HERMES_DASHBOARD_OIDC_SCOPES",
+            "HERMES_DASHBOARD_OIDC_ID_TOKEN_LEEWAY",
         ):
             monkeypatch.delenv(var, raising=False)
 
@@ -795,7 +839,43 @@ class TestPluginRegister:
         assert registered._issuer == _ISSUER
         assert registered._client_id == _CLIENT_ID
         assert registered._scopes == "openid profile email"
+        assert registered._id_token_leeway == 0.0
         assert oidc_plugin.LAST_SKIP_REASON == ""
+
+    def test_leeway_from_env(self, patch_config, monkeypatch):
+        patch_config(None)
+        monkeypatch.setenv("HERMES_DASHBOARD_OIDC_ISSUER", _ISSUER)
+        monkeypatch.setenv("HERMES_DASHBOARD_OIDC_CLIENT_ID", _CLIENT_ID)
+        monkeypatch.setenv("HERMES_DASHBOARD_OIDC_ID_TOKEN_LEEWAY", "60")
+        ctx = MagicMock()
+        oidc_plugin.register(ctx)
+        registered = ctx.register_dashboard_auth_provider.call_args.args[0]
+        assert registered._id_token_leeway == 60.0
+
+    def test_leeway_from_config_yaml(self, patch_config):
+        patch_config(
+            {
+                "self_hosted": {
+                    "issuer": _ISSUER,
+                    "client_id": _CLIENT_ID,
+                    "id_token_leeway": 30,
+                }
+            }
+        )
+        ctx = MagicMock()
+        oidc_plugin.register(ctx)
+        registered = ctx.register_dashboard_auth_provider.call_args.args[0]
+        assert registered._id_token_leeway == 30.0
+
+    def test_invalid_leeway_falls_back_to_zero(self, patch_config, monkeypatch):
+        patch_config(None)
+        monkeypatch.setenv("HERMES_DASHBOARD_OIDC_ISSUER", _ISSUER)
+        monkeypatch.setenv("HERMES_DASHBOARD_OIDC_CLIENT_ID", _CLIENT_ID)
+        monkeypatch.setenv("HERMES_DASHBOARD_OIDC_ID_TOKEN_LEEWAY", "not-a-number")
+        ctx = MagicMock()
+        oidc_plugin.register(ctx)
+        registered = ctx.register_dashboard_auth_provider.call_args.args[0]
+        assert registered._id_token_leeway == 0.0
 
     def test_registers_from_config_yaml(self, patch_config):
         patch_config(


### PR DESCRIPTION
## What

Adds an optional, configurable `id_token_leeway` (seconds) to the self-hosted OIDC dashboard auth provider and passes it to PyJWT's `jwt.decode(..., leeway=...)`.

Fixes #47815.

## Why

`_verify_id_token` in `plugins/dashboard_auth/self_hosted/__init__.py` currently calls `jwt.decode(...)` without a `leeway` argument, so PyJWT's default `leeway=0` applies — **zero clock-skew tolerance**. Any clock skew between the IdP (issuer) and the host running the verifier makes login fail with `ImmatureSignatureError` ("The token is not yet valid (iat)"). This is easy to hit when the IdP and dashboard run on different hosts/VMs/containers without tightly synchronized clocks.

RFC 7519 explicitly allows verifiers a small leeway on the time-based claims (`exp` §4.1.4, `nbf` §4.1.5, `iat` §4.1.6: *"some small leeway, usually no more than a few minutes, to account for clock skew"*).

## How

- New constructor kwarg `id_token_leeway: float = 0.0` (clamped to `>= 0`), stored as `self._id_token_leeway` and passed to `jwt.decode`.
- New `_resolve_leeway(...)` reuses the existing `_resolve_setting` env-wins-config precedence, then parses to a non-negative float. Unparseable/negative input falls back to `0.0` (fail-closed — a typo can never *widen* the verification window).
- Resolved in `register()` from, mirroring the existing `scopes` surface:
  - `config.yaml`: `dashboard.oauth.self_hosted.id_token_leeway`
  - env: `HERMES_DASHBOARD_OIDC_ID_TOKEN_LEEWAY`
- Module docstring + the registered-provider log line updated.

**Default is `0`**, so this is a no-op behavior change for existing deployments. Operators whose verifier and IdP clocks can drift opt in to a small value (e.g. 30-60s).

## Tests

`tests/plugins/dashboard_auth/test_self_hosted_provider.py`:
- construction: default leeway is 0, custom value stored, negative clamped to 0;
- registration: leeway resolved from env and from config.yaml, invalid value falls back to 0;
- verification: a future-`iat` token is rejected with leeway 0, accepted within leeway, and still rejected beyond leeway.

All 74 tests in the suite pass locally (`uv run --frozen pytest tests/plugins/dashboard_auth/test_self_hosted_provider.py`).

## Notes

- `leeway` in PyJWT applies symmetrically to `exp`/`nbf`/`iat`; a small value extends the effective `exp` window by the same amount. With a few-seconds-to-a-minute value against typical ID-token lifetimes this is negligible, and PKCE + the short `exp` remain the primary controls.
- Kept the default at `0` for backwards-compat; happy to flip to a small non-zero default if you'd prefer the spec-aligned "leeway by default" stance.
