### PR TITLE
fix(provider): honor api_mode for named custom providers (#47719)

### DIFF
--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -215,7 +215,12 @@ def _provider_supports_explicit_api_mode(provider: Optional[str], configured_pro
     if not normalized_configured:
         return True
     if normalized_provider == "custom":
-        return normalized_configured == "custom" or normalized_configured.startswith("custom:")
+        if normalized_configured == "custom" or normalized_configured.startswith("custom:"):
+            return True
+        # Named custom providers (defined in the user's ``providers:`` block)
+        # are not in the built-in PROVIDER_REGISTRY, so honor their api_mode.
+        from hermes_cli.auth import PROVIDER_REGISTRY
+        return normalized_configured not in PROVIDER_REGISTRY
     return normalized_configured == normalized_provider
 
 


### PR DESCRIPTION
Fixes #47719. When the runtime provider is 'custom' and the configured provider is a named custom provider (defined in the user's providers: block) that is not in the built-in PROVIDER_REGISTRY, the explicit api_mode was silently discarded. This caused ~48% cache efficiency loss on providers like DeepSeek that support the Anthropic Messages protocol. The fix checks whether the configured_provider is a built-in before rejecting it.