### PR TITLE
fix(cron): use fallback_providers entry model instead of primary model (#47781)

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -1559,6 +1559,11 @@ def _run_job_impl(job: dict) -> tuple[bool, str, str, Optional[str]]:
                     if entry.get("api_key"):
                         fb_kwargs["explicit_api_key"] = entry["api_key"]
                     runtime = resolve_runtime_provider(**fb_kwargs)
+                    # Use the fallback entry's model if specified, instead of
+                    # keeping the primary model (which the fallback provider
+                    # may not serve).  See #47781.
+                    if entry.get("model"):
+                        model = entry["model"]
                     logger.info("Job '%s': fallback resolved to %s", job_id, runtime.get("provider"))
                     break
                 except Exception as fb_exc:


### PR DESCRIPTION
Fixes #47781. When a cron job's primary provider fails auth and the scheduler falls back to fallback_providers, the model was still the primary model name (e.g. gpt-5.5). The fallback provider would then receive a request for the wrong model. The fix extracts the model from the fallback_providers entry when available.