### PR TITLE
fix(openai): model-aware api_mode for direct api.openai.com (GPT-4.1/4o use Chat Completions)

### DIFF
--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -957,7 +957,7 @@ def switch_model(
         elif target_provider == "custom" and current_base_url:
             api_key = current_api_key
             base_url = current_base_url
-            api_mode = determine_api_mode(target_provider, base_url)
+            api_mode = determine_api_mode(target_provider, base_url, new_model)
         else:
             try:
                 runtime = resolve_runtime_provider(
@@ -1089,7 +1089,7 @@ def switch_model(
 
     # --- Determine api_mode if not already set ---
     if not api_mode:
-        api_mode = determine_api_mode(target_provider, base_url)
+        api_mode = determine_api_mode(target_provider, base_url, new_model)
 
     # OpenCode base URLs end with /v1 for OpenAI-compatible models, but the
     # Anthropic SDK prepends its own /v1/messages to the base_url.  Strip the

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -3264,6 +3264,40 @@ def azure_foundry_model_api_mode(model_name: Optional[str]) -> Optional[str]:
     return None
 
 
+def openai_model_api_mode(model_name: Optional[str]) -> Optional[str]:
+    """Infer the api_mode for a direct ``api.openai.com`` model.
+
+    OpenAI serves two wire protocols on the same host and they are NOT
+    interchangeable per model:
+
+    * Reasoning families (GPT-5.x, o1/o3/o4, codex) require the Responses
+      API (``codex_responses``).  ``/chat/completions`` 400s on these.
+    * Chat models (GPT-4.1, GPT-4o, GPT-4 Turbo, GPT-3.5, …) require
+      Chat Completions.  The Responses API rejects them with HTTP 400
+      ("Encrypted content is not supported with this model").
+
+    Hardcoding ``api.openai.com → codex_responses`` (the prior behaviour)
+    therefore broke every non-reasoning OpenAI model.  This mirrors
+    ``azure_foundry_model_api_mode`` — Azure Foundry hosts the same OpenAI
+    families, so the Responses-only prefix set is identical.
+
+    Returns ``None`` for an unknown/empty model so callers preserve their
+    existing default (api.openai.com historically defaulted to the
+    Responses API, which is correct for the GPT-5.x family Hermes ships as
+    the ``openai-api`` default).
+    """
+    raw = str(model_name or "").strip().lower()
+    if not raw:
+        return None
+    # Strip any vendor/ prefix a user may have copied from OpenRouter / Copilot.
+    if "/" in raw:
+        raw = raw.rsplit("/", 1)[-1]
+    for prefix in _AZURE_FOUNDRY_RESPONSES_PREFIXES:
+        if raw.startswith(prefix):
+            return "codex_responses"
+    return "chat_completions"
+
+
 def normalize_opencode_model_id(provider_id: Optional[str], model_id: Optional[str]) -> str:
     """Normalize OpenCode config IDs to the bare model slug used in API requests."""
     provider = normalize_provider(provider_id)

--- a/hermes_cli/providers.py
+++ b/hermes_cli/providers.py
@@ -499,14 +499,21 @@ def is_aggregator(provider: str) -> bool:
     return pdef.is_aggregator if pdef else False
 
 
-def determine_api_mode(provider: str, base_url: str = "") -> str:
+def determine_api_mode(provider: str, base_url: str = "", model: str = "") -> str:
     """Determine the API mode (wire protocol) for a provider/endpoint.
 
     Resolution order:
       1. Known provider → transport → TRANSPORT_TO_API_MODE.
       2. URL heuristics for unknown / custom providers.
       3. Default: 'chat_completions'.
+
+    ``model`` disambiguates api.openai.com, which serves reasoning families
+    (GPT-5.x, o-series, codex) on the Responses API and chat families
+    (GPT-4.1, GPT-4o, …) on Chat Completions. Omitting it preserves the
+    historical Responses-API default for that host.
     """
+    from hermes_cli.models import openai_model_api_mode
+
     pdef = get_provider(provider)
     if pdef is not None:
         # Even for known providers, check URL heuristics for special endpoints
@@ -518,7 +525,7 @@ def determine_api_mode(provider: str, base_url: str = "") -> str:
             if url_lower.endswith("/anthropic") or "api.anthropic.com" in url_lower:
                 return "anthropic_messages"
             if "api.openai.com" in url_lower:
-                return "codex_responses"
+                return openai_model_api_mode(model) or "codex_responses"
         return TRANSPORT_TO_API_MODE.get(pdef.transport, "chat_completions")
 
     # Direct provider checks for providers not in HERMES_OVERLAYS
@@ -534,7 +541,7 @@ def determine_api_mode(provider: str, base_url: str = "") -> str:
         if hostname == "api.kimi.com" and "/coding" in url_lower:
             return "anthropic_messages"
         if hostname == "api.openai.com":
-            return "codex_responses"
+            return openai_model_api_mode(model) or "codex_responses"
         if hostname.startswith("bedrock-runtime.") and base_url_host_matches(base_url, "amazonaws.com"):
             return "bedrock_converse"
 

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -74,11 +74,14 @@ def _config_base_url_trustworthy_for_bare_custom(cfg_base_url: str, cfg_provider
     return _loopback_hostname(base_url_hostname(bu))
 
 
-def _detect_api_mode_for_url(base_url: str) -> Optional[str]:
+def _detect_api_mode_for_url(base_url: str, model: Optional[str] = None) -> Optional[str]:
     """Auto-detect api_mode from the resolved base URL.
 
-    - Direct api.openai.com endpoints need the Responses API for GPT-5.x
-      tool calls with reasoning (chat/completions returns 400).
+    - Direct api.openai.com endpoints serve reasoning families (GPT-5.x,
+      o1/o3/o4, codex) on the Responses API and chat families (GPT-4.1,
+      GPT-4o, …) on Chat Completions — the two are NOT interchangeable per
+      model. ``model`` selects the right one via ``openai_model_api_mode``;
+      when ``model`` is unknown we keep the historical Responses default.
     - Third-party Anthropic-compatible gateways (MiniMax, Zhipu GLM,
       LiteLLM proxies, etc.) conventionally expose the native Anthropic
       protocol under a ``/anthropic`` suffix — treat those as
@@ -93,7 +96,9 @@ def _detect_api_mode_for_url(base_url: str) -> Optional[str]:
     if hostname == "api.x.ai":
         return "codex_responses"
     if hostname == "api.openai.com":
-        return "codex_responses"
+        from hermes_cli.models import openai_model_api_mode
+
+        return openai_model_api_mode(model) or "codex_responses"
     path = urlparse(normalized).path.rstrip("/")
     if path.endswith("/anthropic") or path.endswith("/anthropic/v1"):
         return "anthropic_messages"
@@ -395,9 +400,9 @@ def _resolve_runtime_from_pool_entry(
             api_mode = configured_mode
         else:
             # Auto-detect Anthropic-compatible endpoints (/anthropic suffix,
-            # Kimi /coding, api.openai.com → codex_responses, api.x.ai →
-            # codex_responses).
-            detected = _detect_api_mode_for_url(base_url)
+            # Kimi /coding, api.openai.com → model-aware Responses/Chat,
+            # api.x.ai → codex_responses).
+            detected = _detect_api_mode_for_url(base_url, effective_model)
             if detected:
                 api_mode = detected
 
@@ -852,6 +857,7 @@ def _resolve_openrouter_runtime(
     requested_provider: str,
     explicit_api_key: Optional[str] = None,
     explicit_base_url: Optional[str] = None,
+    target_model: Optional[str] = None,
 ) -> Dict[str, Any]:
     model_cfg = _get_model_config()
     cfg_base_url = model_cfg.get("base_url") if isinstance(model_cfg.get("base_url"), str) else ""
@@ -979,7 +985,7 @@ def _resolve_openrouter_runtime(
     return {
         "provider": effective_provider,
         "api_mode": _parse_api_mode(model_cfg.get("api_mode"))
-        or _detect_api_mode_for_url(base_url)
+        or _detect_api_mode_for_url(base_url, target_model or model_cfg.get("default", ""))
         or "chat_completions",
         "base_url": base_url,
         "api_key": api_key,
@@ -1163,6 +1169,7 @@ def _resolve_explicit_runtime(
     model_cfg: Dict[str, Any],
     explicit_api_key: Optional[str] = None,
     explicit_base_url: Optional[str] = None,
+    target_model: Optional[str] = None,
 ) -> Optional[Dict[str, Any]]:
     explicit_api_key = str(explicit_api_key or "").strip()
     explicit_base_url = str(explicit_base_url or "").strip().rstrip("/")
@@ -1291,8 +1298,11 @@ def _resolve_explicit_runtime(
                 api_mode = configured_mode
             else:
                 # Auto-detect from URL (Anthropic /anthropic suffix,
-                # api.openai.com → Responses, Kimi /coding, etc.).
-                detected = _detect_api_mode_for_url(base_url)
+                # api.openai.com → model-aware Responses/Chat, Kimi /coding,
+                # etc.).
+                detected = _detect_api_mode_for_url(
+                    base_url, target_model or model_cfg.get("default", "")
+                )
                 if detected:
                     api_mode = detected
 
@@ -1383,6 +1393,7 @@ def resolve_runtime_provider(
         model_cfg=model_cfg,
         explicit_api_key=explicit_api_key,
         explicit_base_url=explicit_base_url,
+        target_model=target_model,
     )
     if explicit_runtime:
         return explicit_runtime
@@ -1746,8 +1757,11 @@ def resolve_runtime_provider(
             else:
                 # Auto-detect Anthropic-compatible endpoints by URL convention
                 # (e.g. https://api.minimax.io/anthropic, https://dashscope.../anthropic)
-                # plus api.openai.com → codex_responses and api.x.ai → codex_responses.
-                detected = _detect_api_mode_for_url(base_url)
+                # plus api.openai.com → model-aware Responses/Chat and
+                # api.x.ai → codex_responses.
+                detected = _detect_api_mode_for_url(
+                    base_url, target_model or model_cfg.get("default", "")
+                )
                 if detected:
                     api_mode = detected
         # Strip trailing /v1 for OpenCode Anthropic models (see comment above).
@@ -1766,6 +1780,7 @@ def resolve_runtime_provider(
         requested_provider=requested_provider,
         explicit_api_key=explicit_api_key,
         explicit_base_url=explicit_base_url,
+        target_model=target_model,
     )
     runtime["requested_provider"] = requested_provider
     return runtime

--- a/tests/hermes_cli/test_api_key_providers.py
+++ b/tests/hermes_cli/test_api_key_providers.py
@@ -669,6 +669,45 @@ class TestRuntimeProviderResolution:
         assert result["provider"] == "copilot"
         assert result["api_mode"] == "codex_responses"
 
+    def test_runtime_openai_api_chat_model_uses_chat_completions(self, monkeypatch):
+        """Regression: --provider openai-api -m gpt-4.1 forced codex_responses,
+        and the Responses API 400s chat models ("Encrypted content is not
+        supported with this model"). It must resolve to chat_completions."""
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-openai-test")
+        monkeypatch.setattr(
+            "hermes_cli.runtime_provider._get_model_config",
+            lambda: {"provider": "openai-api", "default": "gpt-5.5"},
+        )
+        from hermes_cli.runtime_provider import resolve_runtime_provider
+        result = resolve_runtime_provider(requested="openai-api", target_model="gpt-4.1")
+        assert result["provider"] == "openai-api"
+        assert result["api_mode"] == "chat_completions"
+        assert result["base_url"] == "https://api.openai.com/v1"
+        assert result["api_key"] == "sk-openai-test"
+
+    def test_runtime_openai_api_reasoning_model_uses_codex_responses(self, monkeypatch):
+        """GPT-5.x / o-series remain on the Responses API — they require it."""
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-openai-test")
+        monkeypatch.setattr(
+            "hermes_cli.runtime_provider._get_model_config",
+            lambda: {"provider": "openai-api", "default": "gpt-4.1"},
+        )
+        from hermes_cli.runtime_provider import resolve_runtime_provider
+        for model in ("gpt-5.5", "o4-mini"):
+            result = resolve_runtime_provider(requested="openai-api", target_model=model)
+            assert result["api_mode"] == "codex_responses", model
+
+    def test_runtime_openai_api_defaults_to_config_model(self, monkeypatch):
+        """With no target_model, the config default model selects the api_mode."""
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-openai-test")
+        monkeypatch.setattr(
+            "hermes_cli.runtime_provider._get_model_config",
+            lambda: {"provider": "openai-api", "default": "gpt-4o"},
+        )
+        from hermes_cli.runtime_provider import resolve_runtime_provider
+        result = resolve_runtime_provider(requested="openai-api")
+        assert result["api_mode"] == "chat_completions"
+
     def test_runtime_copilot_acp_uses_process_runtime(self, monkeypatch):
         monkeypatch.setattr("hermes_cli.auth.shutil.which", lambda command: f"/usr/local/bin/{command}")
         monkeypatch.setenv("HERMES_COPILOT_ACP_ARGS", "--acp --stdio --debug")

--- a/tests/hermes_cli/test_detect_api_mode_for_url.py
+++ b/tests/hermes_cli/test_detect_api_mode_for_url.py
@@ -14,11 +14,13 @@ future update to the detection logic lives in one place.
 
 from __future__ import annotations
 
+from hermes_cli.models import openai_model_api_mode
 from hermes_cli.runtime_provider import _detect_api_mode_for_url
 
 
 class TestCodexResponsesDetection:
     def test_openai_api_returns_codex_responses(self):
+        # No model supplied → historical Responses-API default is preserved.
         assert _detect_api_mode_for_url("https://api.openai.com/v1") == "codex_responses"
 
     def test_xai_api_returns_codex_responses(self):
@@ -66,6 +68,48 @@ class TestAnthropicMessagesDetection:
         # The helper requires ``/anthropic`` as the path SUFFIX, not anywhere.
         # Protects against false positives on e.g. /anthropic/v1/models.
         assert _detect_api_mode_for_url("https://api.example.com/anthropic/v1/models") is None
+
+
+class TestOpenAIModelAwareDetection:
+    """api.openai.com serves reasoning families on the Responses API and chat
+    families on Chat Completions — the helper must pick per-model when a model
+    is known (regression: GPT-4.1 / GPT-4o 400'd on the forced Responses API).
+    """
+
+    def test_chat_model_uses_chat_completions(self):
+        assert _detect_api_mode_for_url("https://api.openai.com/v1", "gpt-4.1") == "chat_completions"
+
+    def test_gpt_4o_uses_chat_completions(self):
+        assert _detect_api_mode_for_url("https://api.openai.com/v1", "gpt-4o") == "chat_completions"
+
+    def test_reasoning_model_uses_codex_responses(self):
+        assert _detect_api_mode_for_url("https://api.openai.com/v1", "gpt-5.5") == "codex_responses"
+
+    def test_o_series_uses_codex_responses(self):
+        assert _detect_api_mode_for_url("https://api.openai.com/v1", "o4-mini") == "codex_responses"
+
+    def test_unknown_model_preserves_responses_default(self):
+        assert _detect_api_mode_for_url("https://api.openai.com/v1", "") == "codex_responses"
+
+
+class TestOpenAIModelApiMode:
+    """Unit coverage for the shared hermes_cli.models.openai_model_api_mode helper."""
+
+    def test_gpt_chat_families_are_chat_completions(self):
+        for model in ("gpt-4.1", "gpt-4o", "gpt-4o-mini", "gpt-4-turbo", "gpt-3.5-turbo"):
+            assert openai_model_api_mode(model) == "chat_completions", model
+
+    def test_reasoning_families_are_codex_responses(self):
+        for model in ("gpt-5", "gpt-5.5", "gpt-5.5-pro", "o1", "o1-preview", "o3-mini", "o4-mini", "codex-mini"):
+            assert openai_model_api_mode(model) == "codex_responses", model
+
+    def test_vendor_prefix_is_stripped(self):
+        assert openai_model_api_mode("openai/gpt-4.1") == "chat_completions"
+        assert openai_model_api_mode("openai/gpt-5.5") == "codex_responses"
+
+    def test_unknown_or_empty_returns_none(self):
+        assert openai_model_api_mode("") is None
+        assert openai_model_api_mode(None) is None
 
 
 class TestDefaultCase:

--- a/tests/hermes_cli/test_determine_api_mode_hostname.py
+++ b/tests/hermes_cli/test_determine_api_mode_hostname.py
@@ -12,6 +12,25 @@ from __future__ import annotations
 from hermes_cli.providers import determine_api_mode
 
 
+class TestOpenAIModelAware:
+    """api.openai.com is model-dependent: reasoning families → Responses API,
+    chat families → Chat Completions. Threading the model fixes GPT-4.1/GPT-4o
+    which 400'd on the previously-forced Responses API.
+    """
+
+    def test_chat_model_is_chat_completions(self):
+        assert determine_api_mode("openai-api", "https://api.openai.com/v1", "gpt-4.1") == "chat_completions"
+
+    def test_reasoning_model_is_codex_responses(self):
+        assert determine_api_mode("openai-api", "https://api.openai.com/v1", "gpt-5.5") == "codex_responses"
+
+    def test_o_series_is_codex_responses(self):
+        assert determine_api_mode("openai-api", "https://api.openai.com/v1", "o4-mini") == "codex_responses"
+
+    def test_no_model_preserves_responses_default(self):
+        assert determine_api_mode("openai-api", "https://api.openai.com/v1") == "codex_responses"
+
+
 class TestOpenAIHostHardening:
     def test_native_openai_url_is_codex_responses(self):
         assert determine_api_mode("", "https://api.openai.com/v1") == "codex_responses"


### PR DESCRIPTION
## Problem

Direct OpenAI access (the built-in `openai-api` provider, and any
`api.openai.com` base URL) is hardcoded to the Responses API
(`codex_responses`) for **every** model. The Responses API rejects
non-reasoning chat models, so they're currently unusable via Hermes:

- `gpt-4.1`, `gpt-4o` → **HTTP 400 "Encrypted content is not supported with this model"** (this is the `include: ["reasoning.encrypted_content"]` parameter the Responses path sends — see #23450)
- other GPT-4.x / GPT-3.5 chat models → same class of failure

Reasoning families (GPT-5.x, o1/o3/o4, codex) genuinely **require** the
Responses API, so a single transport per host can't be correct — it has
to be chosen per model.

### Repro

```bash
hermes chat -q "hi" -Q --provider openai-api -m gpt-4.1 --source tool --max-turns 2
# → 400 "Encrypted content is not supported with this model"
```

## Fix

Hermes already solves this exact problem per-model for other providers —
`azure_foundry_model_api_mode` (Azure Foundry) and `copilot_model_api_mode`
(Copilot) both return the Responses API only for GPT-5+/o-series and Chat
Completions otherwise. This PR gives the **direct OpenAI** path the same
treatment:

- Add `openai_model_api_mode(model)` in `hermes_cli/models.py`. It reuses the
  existing `_AZURE_FOUNDRY_RESPONSES_PREFIXES` set (Azure Foundry hosts the
  same OpenAI families, so the Responses-only prefixes are identical):
  reasoning families → `codex_responses`, chat families → `chat_completions`,
  unknown/empty → `None`.
- Thread the effective model through the two api_mode-governing helpers and
  their OpenAI-resolving callers:
  - `runtime_provider._detect_api_mode_for_url(base_url, model)` — pool,
    explicit, env-key, and openrouter resolution paths.
  - `providers.determine_api_mode(provider, base_url, model)` — used by the
    `/model` switch path in `model_switch.py`.

### Behavior

| model | before | after |
| --- | --- | --- |
| `gpt-4.1`, `gpt-4o`, `gpt-4-turbo`, `gpt-3.5*` | `codex_responses` (400) | **`chat_completions`** ✅ |
| `gpt-5`, `gpt-5.5`, `o1/o3/o4`, `codex*` | `codex_responses` | `codex_responses` (unchanged) |
| unknown / no model | `codex_responses` | `codex_responses` (unchanged) |

The unknown-model case preserves the historical Responses-API default, so
the `gpt-5.x` family Hermes ships as the `openai-api` default keeps working
exactly as before. An explicit `model.api_mode` / custom-provider override
still wins.

Note: `o4-mini`'s separate "organization must be verified to generate
reasoning summaries" error is an OpenAI account-level setting, not a
transport bug — o4-mini correctly stays on the Responses API here.

## Tests

```bash
python -m pytest \
  tests/hermes_cli/test_detect_api_mode_for_url.py \
  tests/hermes_cli/test_determine_api_mode_hostname.py \
  tests/hermes_cli/test_api_key_providers.py \
  tests/hermes_cli/test_runtime_provider_resolution.py \
  tests/hermes_cli/test_user_providers_model_switch.py \
  tests/cli/test_cli_provider_resolution.py -q
# 387 passed
```

New coverage: `openai_model_api_mode` units, model-aware
`_detect_api_mode_for_url` / `determine_api_mode`, and an end-to-end
`resolve_runtime_provider(requested="openai-api", target_model=…)` test
asserting `gpt-4.1` → `chat_completions` while `gpt-5.5` / `o4-mini` stay
`codex_responses`.

Fixes #23450