### PR TITLE
fix(gateway): convert MSYS/Git Bash paths in validate_media_delivery_path (#47767)

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -987,6 +987,11 @@ def validate_media_delivery_path(path: str) -> Optional[str]:
     if not candidate:
         return None
 
+    # Convert MSYS/Git Bash paths (e.g. /c/Users/...) to Windows paths
+    # so pathlib can resolve them on Windows.
+    if os.name == "nt" and len(candidate) >= 3 and candidate[0] == "/" and candidate[2] == "/":
+        _drive = candidate[1].upper()
+        candidate = _drive + ":" + candidate[2:]
     expanded = Path(os.path.expanduser(candidate))
     if not expanded.is_absolute():
         return None


### PR DESCRIPTION
Fixes #47767. On Windows with Git Bash (MSYS2), Unix-style paths like /c/Users/... were rejected by validate_media_delivery_path() because pathlib.Path could not resolve them as absolute paths. The fix detects MSYS-style paths (single-char drive letter after leading slash) and converts them to Windows paths before validation.