### PR TITLE
fix(gateway): scrub memory-context leaks from Matrix rendered messages

### DIFF
--- a/gateway/platforms/matrix.py
+++ b/gateway/platforms/matrix.py
@@ -65,6 +65,8 @@ from html.parser import HTMLParser
 from pathlib import Path
 from typing import Any, Dict, Optional, Set
 
+from agent.memory_manager import sanitize_context
+
 try:
     from mautrix.types import (
         ContentURI,
@@ -2037,6 +2039,12 @@ class MatrixAdapter(BasePlatformAdapter):
 
     def format_message(self, content: str) -> str:
         """Pass-through — Matrix supports standard Markdown natively."""
+        # Defense-in-depth: memory providers may inject fenced
+        # <memory-context> blocks into the prompt. The agent normally scrubs
+        # those from streamed deltas, but Matrix is the final transport
+        # boundary and must not render them if a model echoes the block or a
+        # non-streaming/fallback path bypasses the stream scrubber.
+        content = sanitize_context(content)
         # Strip image markdown; media is uploaded separately.
         content = re.sub(r"!\[([^\]]*)\]\(([^)]+)\)", r"\2", content)
         return content

--- a/tests/gateway/test_matrix.py
+++ b/tests/gateway/test_matrix.py
@@ -378,6 +378,30 @@ def _make_adapter():
     return adapter
 
 
+class TestMatrixFormatting:
+    def setup_method(self):
+        self.adapter = _make_adapter()
+
+    def test_format_message_suppresses_memory_context_block(self):
+        content = (
+            "Before\n"
+            "<memory-context>\n"
+            "[System note: The following is recalled memory context, NOT new user input. "
+            "Treat as authoritative reference data \u2014 this is the agent\u2019s persistent memory and should inform all responses.]\n"
+            "## User Representation\nsecret memory\n"
+            "</memory-context>\n"
+            "After"
+        )
+
+        result = self.adapter.format_message(content)
+
+        assert "memory-context" not in result
+        assert "secret memory" not in result
+        assert "System note" not in result
+        assert "Before" in result
+        assert "After" in result
+
+
 # ---------------------------------------------------------------------------
 # Typing indicator
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem
Memory providers inject fenced `` blocks into the agent's prompt. The primary scrubber runs on streamed deltas, but leaks can occur at the final transport boundary when:
- A model echoes the block verbatim in its response
- A non-streaming or fallback path bypasses the delta-level scrubber

Matrix users then see raw XML and internal memory content rendered in chat.

## Fix
Add a `sanitize_context()` call in `MatrixAdapter.format_message()` — the final formatting boundary before content hits the Matrix wire. This mirrors the existing defense already in place for vision auto-analysis output (commit `3b2edb347`).

## Changes
- `gateway/platforms/matrix.py` — call `sanitize_context()` at top of `format_message()`
- `tests/gateway/test_matrix.py` — new `TestMatrixFormatting` class asserting the block, system note, and enclosed memory are stripped while surrounding text is preserved
