### PR TITLE
feat(skills): add wiki-search — semantic vector search for markdown wikis

### DIFF
--- a/optional-skills/research/wiki-search/SKILL.md
+++ b/optional-skills/research/wiki-search/SKILL.md
@@ -1,0 +1,60 @@
+---
+name: wiki-search
+description: Search markdown wikis semantically with local Ollama.
+version: 1.1.0
+author: PINKIIILQWQ (@PINKIIILQWQ) + Hermes Agent
+license: MIT
+platforms: [linux, macos, windows]
+metadata:
+  hermes:
+    tags: [wiki, search, semantic-search, markdown, ollama]
+    related_skills: [llm-wiki, qmd]
+---
+
+# Wiki Search
+
+Search Markdown wikis by meaning with local Ollama embeddings. The skill keeps
+each index isolated by canonical wiki root, embedding model, and cache schema,
+and falls back to keyword search when Ollama is unavailable.
+
+## Commands
+
+```bash
+python3 scripts/wiki-search --wiki ~/wiki index
+python3 scripts/wiki-search --wiki ~/wiki reindex
+python3 scripts/wiki-search --wiki ~/wiki --hybrid "photography composition"
+python3 scripts/wiki-search --wiki ~/wiki --status
+python3 scripts/wiki-search --wiki ~/wiki --clean
+```
+
+Use `--model <name>` to select an embedding model and `--json` for stable,
+machine-readable output. JSON search responses have `schema_version`, `command`,
+`wiki`, `model`, `mode`, `fallback`, and `results` fields.
+
+```python
+result = json.loads(subprocess.run(
+    ["python3", "scripts/wiki-search", "--json", "--wiki", wiki, "question"],
+    check=True,
+    capture_output=True,
+    text=True,
+).stdout)
+for item in result["results"]:
+    print(item["file"], item["heading"])
+```
+
+## Prerequisites
+
+Ollama is optional. For semantic results, install it and pull an embedding model:
+
+```bash
+ollama pull all-minilm
+```
+
+Without Ollama, `wiki-search` returns keyword matches instead of failing.
+
+## Index Behavior
+
+Indexes live beneath `~/.cache/wiki-search/v1/` in a namespace derived from the
+resolved wiki root and exact model name. Changing a model creates a separate
+index. Deleted Markdown files are pruned at the next index run. A corrupted or
+incompatible index is rebuilt rather than mixing vector dimensions.

--- a/optional-skills/research/wiki-search/scripts/wiki-search
+++ b/optional-skills/research/wiki-search/scripts/wiki-search
@@ -1,0 +1,6 @@
+#!/usr/bin/env python3
+from wiki_search import main
+
+
+if __name__ == "__main__":
+    main()

--- a/optional-skills/research/wiki-search/scripts/wiki_search.py
+++ b/optional-skills/research/wiki-search/scripts/wiki_search.py
@@ -1,0 +1,448 @@
+"""Semantic and keyword search for Markdown wikis using optional Ollama embeddings."""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import re
+import sys
+import urllib.error
+import urllib.request
+from pathlib import Path
+from typing import Any
+
+
+CACHE_SCHEMA_VERSION = 1
+SECTION_MIN_CHARS = 20
+DEFAULT_MODEL = "all-minilm"
+
+
+def log(message: str) -> None:
+    print(f"[wiki-search] {message}", file=sys.stderr)
+
+
+def ollama_embed(text: str, model: str) -> list[float] | None:
+    """Request a local embedding, returning ``None`` when Ollama is unavailable."""
+    payload = json.dumps({"model": model, "prompt": text}).encode("utf-8")
+    ollama_url = os.environ.get("OLLAMA_URL", "http://localhost:11434").rstrip("/")
+    request = urllib.request.Request(
+        f"{ollama_url}/api/embeddings",
+        data=payload,
+        headers={"Content-Type": "application/json"},
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=30) as response:
+            embedding = json.loads(response.read())["embedding"]
+    except (KeyError, OSError, ValueError, urllib.error.HTTPError, urllib.error.URLError):
+        return None
+    if not isinstance(embedding, list) or not all(isinstance(value, (int, float)) for value in embedding):
+        return None
+    return [float(value) for value in embedding]
+
+
+def _identity(root: Path, model: str) -> dict[str, object]:
+    return {
+        "root": str(root.expanduser().resolve()),
+        "model": model,
+        "schema": CACHE_SCHEMA_VERSION,
+    }
+
+
+def index_path(cache_dir: Path, root: Path, model: str) -> Path:
+    """Return the index path unique to one canonical root, model, and schema."""
+    encoded = json.dumps(_identity(root, model), sort_keys=True).encode("utf-8")
+    digest = hashlib.sha256(encoded).hexdigest()
+    return cache_dir / f"v{CACHE_SCHEMA_VERSION}" / digest / "index.json"
+
+
+def fresh_index(root: Path, model: str) -> dict[str, object]:
+    """Create an empty, validated index for one root and embedding model."""
+    return {"metadata": {**_identity(root, model), "dimension": None}, "files": {}}
+
+
+def _is_valid_index(index: object, root: Path, model: str) -> bool:
+    if not isinstance(index, dict) or not isinstance(index.get("files"), dict):
+        return False
+    metadata = index.get("metadata")
+    if not isinstance(metadata, dict):
+        return False
+    identity = _identity(root, model)
+    if any(metadata.get(key) != value for key, value in identity.items()):
+        return False
+    dimension = metadata.get("dimension")
+    if dimension is not None and (not isinstance(dimension, int) or dimension <= 0):
+        return False
+    for file_info in index["files"].values():
+        if not isinstance(file_info, dict) or not isinstance(file_info.get("sections", []), list):
+            return False
+        for section in file_info.get("sections", []):
+            if not isinstance(section, dict):
+                return False
+            embedding = section.get("embedding")
+            if embedding is None:
+                continue
+            if (
+                dimension is None
+                or not isinstance(embedding, list)
+                or len(embedding) != dimension
+                or not all(isinstance(value, (int, float)) for value in embedding)
+            ):
+                return False
+    return True
+
+
+def load_index(cache_dir: Path, root: Path, model: str) -> dict[str, object]:
+    """Load only a matching, current-schema index; otherwise start clean."""
+    path = index_path(cache_dir, root, model)
+    try:
+        loaded = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return fresh_index(root, model)
+    return loaded if _is_valid_index(loaded, root, model) else fresh_index(root, model)
+
+
+def save_index(cache_dir: Path, root: Path, model: str, index: dict[str, object]) -> Path:
+    """Persist a validated index in its isolated namespace."""
+    if not _is_valid_index(index, root, model):
+        raise ValueError("refusing to save an index with incompatible metadata")
+    path = index_path(cache_dir, root, model)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(index, ensure_ascii=False, indent=2, sort_keys=True), encoding="utf-8"
+    )
+    return path
+
+
+def _without_frontmatter(text: str) -> str:
+    return re.sub(r"\A---\s*\n.*?\n---\s*\n?", "", text, count=1, flags=re.DOTALL)
+
+
+def parse_md_sections(text: str) -> list[dict[str, object]]:
+    """Split Markdown into meaningful heading sections."""
+    sections: list[dict[str, object]] = []
+    heading = ""
+    level = 0
+    lines: list[str] = []
+
+    def flush() -> None:
+        content = "\n".join(lines).strip()
+        if len(content) < SECTION_MIN_CHARS:
+            return
+        sections.append(
+            {
+                "heading": heading,
+                "level": level,
+                "content": content,
+                "slug": hashlib.sha256(content.encode("utf-8")).hexdigest()[:12],
+            }
+        )
+
+    for line in _without_frontmatter(text).splitlines():
+        match = re.match(r"^(#{1,6})\s+(.+)$", line)
+        if match:
+            flush()
+            lines = []
+            level = len(match.group(1))
+            heading = match.group(2).strip()
+        else:
+            lines.append(line)
+    flush()
+    return sections
+
+
+def extract_title(text: str, fallback: str) -> str:
+    """Use the first H1 title when present, otherwise use the file stem."""
+    match = re.search(r"^#\s+(.+)$", _without_frontmatter(text), re.MULTILINE)
+    return match.group(1).strip() if match else fallback
+
+
+def _file_changed(info: object, path: Path, force: bool) -> bool:
+    if force or not isinstance(info, dict):
+        return True
+    stat = path.stat()
+    return info.get("mtime_ns") != stat.st_mtime_ns or info.get("size") != stat.st_size
+
+
+def _index_file(path: Path, relative_path: str, index: dict[str, Any], model: str) -> dict[str, object] | None:
+    text = path.read_text(encoding="utf-8", errors="replace")
+    sections = parse_md_sections(text)
+    if not sections:
+        return None
+    metadata = index["metadata"]
+    dimension = metadata["dimension"]
+    embedded_sections: list[dict[str, object]] = []
+    for section in sections:
+        query_text = str(section["content"])
+        if section["heading"]:
+            query_text = f"{section['heading']}: {query_text}"
+        embedding = ollama_embed(query_text[:2000], model)
+        if embedding is not None:
+            if dimension is None:
+                dimension = len(embedding)
+                metadata["dimension"] = dimension
+            if len(embedding) != dimension:
+                log(f"incompatible embedding dimension for {relative_path}; keeping keyword-only")
+                embedding = None
+        embedded_sections.append({**section, "embedding": embedding})
+    stat = path.stat()
+    return {
+        "title": extract_title(text, path.stem),
+        "mtime_ns": stat.st_mtime_ns,
+        "size": stat.st_size,
+        "sections": embedded_sections,
+    }
+
+
+def cmd_index(
+    wiki_path: str | Path,
+    *,
+    model: str,
+    cache_dir: Path,
+    force: bool = False,
+) -> dict[str, object]:
+    """Create or incrementally update the isolated index for one Markdown wiki."""
+    root = Path(wiki_path).expanduser().resolve()
+    if not root.is_dir():
+        raise FileNotFoundError(f"wiki path does not exist: {root}")
+    index: dict[str, Any] = load_index(cache_dir, root, model)
+    markdown_files = [
+        path for path in sorted(root.rglob("*.md")) if not path.relative_to(root).parts[0] == "raw"
+    ]
+    present_paths = {str(path.relative_to(root)) for path in markdown_files}
+    files: dict[str, Any] = index["files"]
+    removed = sum(1 for relative_path in list(files) if relative_path not in present_paths)
+    for relative_path in list(files):
+        if relative_path not in present_paths:
+            del files[relative_path]
+
+    indexed = 0
+    skipped = 0
+    for path in markdown_files:
+        relative_path = str(path.relative_to(root))
+        if not _file_changed(files.get(relative_path), path, force):
+            skipped += 1
+            continue
+        entry = _index_file(path, relative_path, index, model)
+        if entry is None:
+            files.pop(relative_path, None)
+        else:
+            files[relative_path] = entry
+            indexed += 1
+
+    save_index(cache_dir, root, model, index)
+    sections = sum(len(file_info["sections"]) for file_info in files.values())
+    return {
+        "command": "index",
+        "wiki": str(root),
+        "model": model,
+        "indexed": indexed,
+        "skipped": skipped,
+        "removed": removed,
+        "files": len(files),
+        "sections": sections,
+    }
+
+
+def cosine_similarity(a: list[float], b: list[float]) -> float | None:
+    """Return cosine similarity only when two non-zero vectors are compatible."""
+    if not a or len(a) != len(b):
+        return None
+    dot_product = sum(left * right for left, right in zip(a, b))
+    left_norm = sum(value * value for value in a) ** 0.5
+    right_norm = sum(value * value for value in b) ** 0.5
+    if left_norm == 0 or right_norm == 0:
+        return None
+    return dot_product / (left_norm * right_norm)
+
+
+def _result(relative_path: str, file_info: dict[str, Any], section: dict[str, Any], score: float) -> dict[str, object]:
+    return {
+        "file": relative_path,
+        "title": file_info.get("title", Path(relative_path).stem),
+        "heading": section.get("heading", ""),
+        "content": str(section.get("content", ""))[:300],
+        "score": score,
+    }
+
+
+def semantic_search(query: str, index: dict[str, Any], model: str, top_k: int = 10) -> tuple[list[dict[str, object]], bool]:
+    """Return semantic candidates plus whether a query embedding was available."""
+    query_embedding = ollama_embed(query, model)
+    if query_embedding is None:
+        return [], False
+    expected_dimension = index["metadata"].get("dimension")
+    if expected_dimension is not None and len(query_embedding) != expected_dimension:
+        log("query embedding dimension does not match the index; using keywords")
+        return [], False
+    results: list[dict[str, object]] = []
+    for relative_path, file_info in index["files"].items():
+        for section in file_info.get("sections", []):
+            embedding = section.get("embedding")
+            if not isinstance(embedding, list):
+                continue
+            score = cosine_similarity(query_embedding, embedding)
+            if score is not None:
+                results.append(_result(relative_path, file_info, section, score))
+    results.sort(key=lambda result: float(result["score"]), reverse=True)
+    return results[:top_k], True
+
+
+def keyword_search(query: str, index: dict[str, Any], top_k: int = 10) -> list[dict[str, object]]:
+    """Return simple case-insensitive keyword candidates without external services."""
+    terms = [term for term in query.lower().split() if term]
+    if not terms:
+        return []
+    results: list[dict[str, object]] = []
+    for relative_path, file_info in index["files"].items():
+        for section in file_info.get("sections", []):
+            content = str(section.get("content", ""))
+            matches = sum(term in content.lower() for term in terms)
+            if matches:
+                results.append(_result(relative_path, file_info, section, matches / len(terms)))
+    results.sort(key=lambda result: float(result["score"]), reverse=True)
+    return results[:top_k]
+
+
+def hybrid_search(
+    semantic_results: list[dict[str, object]], keyword_results: list[dict[str, object]], top_k: int = 10
+) -> list[dict[str, object]]:
+    """Fuse semantic and keyword rankings using reciprocal-rank fusion."""
+    scores: dict[tuple[str, str, str], float] = {}
+    results: dict[tuple[str, str, str], dict[str, object]] = {}
+    for ranking in (semantic_results, keyword_results):
+        for rank, item in enumerate(ranking, start=1):
+            key = (str(item["file"]), str(item["heading"]), str(item["content"]))
+            scores[key] = scores.get(key, 0.0) + 1 / (60 + rank)
+            results.setdefault(key, item)
+    combined = [{**item, "score": scores[key]} for key, item in results.items()]
+    combined.sort(key=lambda result: float(result["score"]), reverse=True)
+    return combined[:top_k]
+
+
+def cmd_search(
+    query: str,
+    wiki_path: str | Path,
+    *,
+    model: str,
+    cache_dir: Path,
+    mode: str = "semantic",
+    top_k: int = 10,
+) -> dict[str, object]:
+    """Search exactly the index belonging to ``wiki_path`` and ``model``."""
+    root = Path(wiki_path).expanduser().resolve()
+    index: dict[str, Any] = load_index(cache_dir, root, model)
+    semantic_results, semantic_available = semantic_search(query, index, model, top_k)
+    keyword_results = keyword_search(query, index, top_k)
+    if mode == "hybrid":
+        results = hybrid_search(semantic_results, keyword_results, top_k)
+        fallback = "semantic" if semantic_available else "keyword"
+    elif semantic_results:
+        results = semantic_results
+        fallback = "semantic"
+    else:
+        results = keyword_results
+        fallback = "keyword"
+    return {
+        "command": "search",
+        "wiki": str(root),
+        "model": model,
+        "mode": mode,
+        "fallback": fallback,
+        "results": results,
+    }
+
+
+def cmd_clean(wiki_path: str | Path, *, model: str, cache_dir: Path) -> dict[str, object]:
+    """Remove only the index namespace selected by root and model."""
+    root = Path(wiki_path).expanduser().resolve()
+    path = index_path(cache_dir, root, model)
+    existed = path.exists()
+    if existed:
+        path.unlink()
+    return {"command": "clean", "wiki": str(root), "model": model, "removed": existed}
+
+
+def cmd_status(wiki_path: str | Path, *, model: str, cache_dir: Path) -> dict[str, object]:
+    """Report the selected index without touching another wiki's cache."""
+    root = Path(wiki_path).expanduser().resolve()
+    index: dict[str, Any] = load_index(cache_dir, root, model)
+    files: dict[str, Any] = index["files"]
+    return {
+        "command": "status",
+        "wiki": str(root),
+        "model": model,
+        "index": str(index_path(cache_dir, root, model)),
+        "files": len(files),
+        "sections": sum(len(file_info.get("sections", [])) for file_info in files.values()),
+        "dimension": index["metadata"]["dimension"],
+    }
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Semantic search for Markdown wikis using local Ollama.")
+    parser.add_argument("--wiki", default=os.environ.get("WIKI_PATH", "~/wiki"), help="Markdown wiki directory")
+    parser.add_argument("--model", default=os.environ.get("WIKI_EMBED_MODEL", DEFAULT_MODEL), help="Ollama embedding model")
+    parser.add_argument("--top-k", type=int, default=10, help="Maximum results to return")
+    parser.add_argument("--hybrid", action="store_true", help="Fuse semantic and keyword rankings")
+    parser.add_argument("--json", action="store_true", help="Emit stable machine-readable JSON")
+    parser.add_argument("--status", action="store_true", help="Show index metadata")
+    parser.add_argument("--reindex", action="store_true", help="Force a complete reindex")
+    parser.add_argument("--clean", action="store_true", help="Delete only this root/model index")
+    parser.add_argument("query", nargs="*", help="index, reindex, status, clean, or a search query")
+    return parser
+
+
+def emit(payload: dict[str, object], json_mode: bool) -> None:
+    """Emit the versioned API response or a concise human-readable equivalent."""
+    versioned = {"schema_version": 1, **payload}
+    if json_mode:
+        print(json.dumps(versioned, ensure_ascii=False, sort_keys=True))
+        return
+    command = str(payload["command"])
+    if command == "search":
+        results = payload["results"]
+        if not results:
+            print("No relevant results found.")
+            return
+        print(f"{len(results)} results ({payload['fallback']} search):")
+        for number, item in enumerate(results, start=1):
+            print(f"{number}. {item['file']} — {item['heading']}")
+        return
+    print(json.dumps(versioned, ensure_ascii=False, indent=2, sort_keys=True))
+
+
+def main() -> None:
+    """Run the command-line interface."""
+    args = build_parser().parse_args()
+    cache_dir = Path(os.environ.get("WIKI_SEARCH_CACHE_DIR", "~/.cache/wiki-search")).expanduser()
+    positional_command = args.query[0] if args.query else ""
+    try:
+        if args.clean or positional_command == "clean":
+            payload = cmd_clean(args.wiki, model=args.model, cache_dir=cache_dir)
+        elif args.status or positional_command == "status":
+            payload = cmd_status(args.wiki, model=args.model, cache_dir=cache_dir)
+        elif args.reindex or positional_command == "reindex":
+            payload = cmd_index(args.wiki, model=args.model, cache_dir=cache_dir, force=True)
+        elif positional_command == "index":
+            payload = cmd_index(args.wiki, model=args.model, cache_dir=cache_dir)
+        elif args.query:
+            mode = "hybrid" if args.hybrid else "semantic"
+            payload = cmd_search(
+                " ".join(args.query),
+                args.wiki,
+                model=args.model,
+                cache_dir=cache_dir,
+                mode=mode,
+                top_k=args.top_k,
+            )
+        else:
+            build_parser().print_help()
+            return
+    except (FileNotFoundError, ValueError) as error:
+        if args.json:
+            print(json.dumps({"schema_version": 1, "error": str(error)}, ensure_ascii=False))
+        else:
+            print(f"Error: {error}", file=sys.stderr)
+        raise SystemExit(2) from error
+    emit(payload, args.json)

--- a/optional-skills/research/wiki-search/scripts/wiki_search.py
+++ b/optional-skills/research/wiki-search/scripts/wiki_search.py
@@ -18,6 +18,10 @@ SECTION_MIN_CHARS = 20
 DEFAULT_MODEL = "all-minilm"
 
 
+class PersistedEmbeddingDimensionChanged(Exception):
+    """A reindex observed a new embedding dimension for an existing namespace."""
+
+
 def log(message: str) -> None:
     print(f"[wiki-search] {message}", file=sys.stderr)
 
@@ -164,7 +168,14 @@ def _file_changed(info: object, path: Path, force: bool) -> bool:
     return info.get("mtime_ns") != stat.st_mtime_ns or info.get("size") != stat.st_size
 
 
-def _index_file(path: Path, relative_path: str, index: dict[str, Any], model: str) -> dict[str, object] | None:
+def _index_file(
+    path: Path,
+    relative_path: str,
+    index: dict[str, Any],
+    model: str,
+    *,
+    rebuild_on_dimension_change: bool = False,
+) -> dict[str, object] | None:
     text = path.read_text(encoding="utf-8", errors="replace")
     sections = parse_md_sections(text)
     if not sections:
@@ -182,6 +193,8 @@ def _index_file(path: Path, relative_path: str, index: dict[str, Any], model: st
                 dimension = len(embedding)
                 metadata["dimension"] = dimension
             if len(embedding) != dimension:
+                if rebuild_on_dimension_change:
+                    raise PersistedEmbeddingDimensionChanged
                 log(f"incompatible embedding dimension for {relative_path}; keeping keyword-only")
                 embedding = None
         embedded_sections.append({**section, "embedding": embedding})
@@ -209,26 +222,42 @@ def cmd_index(
     markdown_files = [
         path for path in sorted(root.rglob("*.md")) if not path.relative_to(root).parts[0] == "raw"
     ]
-    present_paths = {str(path.relative_to(root)) for path in markdown_files}
-    files: dict[str, Any] = index["files"]
-    removed = sum(1 for relative_path in list(files) if relative_path not in present_paths)
-    for relative_path in list(files):
-        if relative_path not in present_paths:
-            del files[relative_path]
+    rebuild_on_dimension_change = index["metadata"]["dimension"] is not None
+    while True:
+        present_paths = {str(path.relative_to(root)) for path in markdown_files}
+        files: dict[str, Any] = index["files"]
+        removed = sum(1 for relative_path in list(files) if relative_path not in present_paths)
+        for relative_path in list(files):
+            if relative_path not in present_paths:
+                del files[relative_path]
 
-    indexed = 0
-    skipped = 0
-    for path in markdown_files:
-        relative_path = str(path.relative_to(root))
-        if not _file_changed(files.get(relative_path), path, force):
-            skipped += 1
+        indexed = 0
+        skipped = 0
+        try:
+            for path in markdown_files:
+                relative_path = str(path.relative_to(root))
+                if not _file_changed(files.get(relative_path), path, force):
+                    skipped += 1
+                    continue
+                entry = _index_file(
+                    path,
+                    relative_path,
+                    index,
+                    model,
+                    rebuild_on_dimension_change=rebuild_on_dimension_change,
+                )
+                if entry is None:
+                    files.pop(relative_path, None)
+                else:
+                    files[relative_path] = entry
+                    indexed += 1
+        except PersistedEmbeddingDimensionChanged:
+            log("embedding dimension changed; rebuilding this index namespace")
+            index = fresh_index(root, model)
+            rebuild_on_dimension_change = False
+            force = True
             continue
-        entry = _index_file(path, relative_path, index, model)
-        if entry is None:
-            files.pop(relative_path, None)
-        else:
-            files[relative_path] = entry
-            indexed += 1
+        break
 
     save_index(cache_dir, root, model, index)
     sections = sum(len(file_info["sections"]) for file_info in files.values())

--- a/tests/skills/test_wiki_search_skill.py
+++ b/tests/skills/test_wiki_search_skill.py
@@ -1,0 +1,270 @@
+"""Hermetic regression tests for the optional wiki-search skill."""
+from __future__ import annotations
+
+import ast
+import importlib.util
+import json
+import re
+import sys
+import urllib.error
+from pathlib import Path
+
+import pytest
+import yaml
+
+
+SKILL_DIR = (
+    Path(__file__).resolve().parents[2]
+    / "optional-skills"
+    / "research"
+    / "wiki-search"
+)
+SCRIPT_PATH = SKILL_DIR / "scripts" / "wiki_search.py"
+
+
+@pytest.fixture(scope="module")
+def frontmatter() -> dict:
+    source = (SKILL_DIR / "SKILL.md").read_text(encoding="utf-8")
+    match = re.search(r"^---\n(.*?)\n---", source, re.DOTALL)
+    assert match, "SKILL.md missing YAML frontmatter"
+    return yaml.safe_load(match.group(1))
+
+
+def test_skill_metadata_and_python_source_are_compliant(frontmatter: dict) -> None:
+    assert SKILL_DIR.is_dir()
+    assert frontmatter["name"] == "wiki-search"
+    assert len(frontmatter["description"]) <= 60
+    assert frontmatter["description"].endswith(".")
+    assert "PINKIIILQWQ" in frontmatter["author"]
+    assert frontmatter["license"] == "MIT"
+    ast.parse(SCRIPT_PATH.read_text(encoding="utf-8"))
+
+
+def load_module():
+    spec = importlib.util.spec_from_file_location("wiki_search", SCRIPT_PATH)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_cache_namespace_isolated_by_root_and_model(tmp_path: Path) -> None:
+    module = load_module()
+    cache_dir = tmp_path / "cache"
+    root_a = tmp_path / "wiki-a"
+    root_b = tmp_path / "wiki-b"
+    root_a.mkdir()
+    root_b.mkdir()
+
+    path_a = module.index_path(cache_dir, root_a, "all-minilm")
+    path_b = module.index_path(cache_dir, root_b, "all-minilm")
+    path_other_model = module.index_path(cache_dir, root_a, "nomic-embed-text")
+
+    assert path_a != path_b
+    assert path_a != path_other_model
+
+    index_a = module.fresh_index(root_a, "all-minilm")
+    index_a["files"] = {"only-a.md": {"sections": []}}
+    module.save_index(cache_dir, root_a, "all-minilm", index_a)
+
+    index_b = module.fresh_index(root_b, "all-minilm")
+    index_b["files"] = {"only-b.md": {"sections": []}}
+    module.save_index(cache_dir, root_b, "all-minilm", index_b)
+
+    assert set(module.load_index(cache_dir, root_a, "all-minilm")["files"]) == {"only-a.md"}
+    assert set(module.load_index(cache_dir, root_b, "all-minilm")["files"]) == {"only-b.md"}
+
+
+def test_load_index_discards_incompatible_metadata(tmp_path: Path) -> None:
+    module = load_module()
+    cache_dir = tmp_path / "cache"
+    root = tmp_path / "wiki"
+    root.mkdir()
+    path = module.index_path(cache_dir, root, "all-minilm")
+    path.parent.mkdir(parents=True)
+    path.write_text(
+        json.dumps(
+            {
+                "metadata": {
+                    "schema": module.CACHE_SCHEMA_VERSION,
+                    "root": str(root.resolve()),
+                    "model": "nomic-embed-text",
+                    "dimension": 768,
+                },
+                "files": {"stale.md": {"sections": []}},
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    loaded = module.load_index(cache_dir, root, "all-minilm")
+
+    assert loaded["files"] == {}
+    assert loaded["metadata"]["model"] == "all-minilm"
+    assert loaded["metadata"]["dimension"] is None
+
+
+def test_load_index_discards_stored_vectors_with_the_wrong_dimension(tmp_path: Path) -> None:
+    module = load_module()
+    cache_dir = tmp_path / "cache"
+    root = tmp_path / "wiki"
+    root.mkdir()
+    corrupt = module.fresh_index(root, "all-minilm")
+    corrupt["metadata"]["dimension"] = 2
+    corrupt["files"] = {
+        "wrong.md": {
+            "sections": [
+                {"heading": "Wrong", "content": "A corrupt vector entry.", "embedding": [1.0, 0.0, 0.0]}
+            ]
+        }
+    }
+    path = module.index_path(cache_dir, root, "all-minilm")
+    path.parent.mkdir(parents=True)
+    path.write_text(json.dumps(corrupt), encoding="utf-8")
+
+    loaded = module.load_index(cache_dir, root, "all-minilm")
+
+    assert loaded["files"] == {}
+    assert loaded["metadata"]["dimension"] is None
+
+
+def test_indexing_prunes_deleted_markdown_files(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    module = load_module()
+    cache_dir = tmp_path / "cache"
+    root = tmp_path / "wiki"
+    root.mkdir()
+    (root / "one.md").write_text("# One\n\nUseful content for the first page.", encoding="utf-8")
+    gone = root / "gone.md"
+    gone.write_text("# Gone\n\nUseful content for the deleted page.", encoding="utf-8")
+    monkeypatch.setattr(module, "ollama_embed", lambda text, model: [1.0, 0.0])
+
+    module.cmd_index(root, model="all-minilm", cache_dir=cache_dir)
+    gone.unlink()
+    module.cmd_index(root, model="all-minilm", cache_dir=cache_dir)
+
+    index = module.load_index(cache_dir, root, "all-minilm")
+    assert set(index["files"]) == {"one.md"}
+
+
+def test_indexing_rejects_sections_with_incompatible_vector_dimension(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    module = load_module()
+    cache_dir = tmp_path / "cache"
+    root = tmp_path / "wiki"
+    root.mkdir()
+    (root / "two.md").write_text(
+        "# Two\n\nFirst section has useful content.\n\n## Three\n\nSecond section has useful content.",
+        encoding="utf-8",
+    )
+    vectors = iter(([1.0, 0.0], [1.0, 0.0, 0.0]))
+    monkeypatch.setattr(module, "ollama_embed", lambda text, model: next(vectors))
+
+    module.cmd_index(root, model="all-minilm", cache_dir=cache_dir)
+
+    index = module.load_index(cache_dir, root, "all-minilm")
+    sections = index["files"]["two.md"]["sections"]
+    assert index["metadata"]["dimension"] == 2
+    assert sections[0]["embedding"] == [1.0, 0.0]
+    assert sections[1]["embedding"] is None
+
+
+def test_cosine_similarity_rejects_mismatched_vectors_and_ollama_errors(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module = load_module()
+    monkeypatch.setattr(
+        module.urllib.request,
+        "urlopen",
+        lambda *args, **kwargs: (_ for _ in ()).throw(urllib.error.URLError("offline")),
+    )
+
+    assert module.cosine_similarity([1.0, 0.0], [1.0, 0.0, 0.0]) is None
+    assert module.ollama_embed("query", "all-minilm") is None
+
+
+def test_ollama_embed_honors_configured_endpoint(monkeypatch: pytest.MonkeyPatch) -> None:
+    module = load_module()
+    requested_urls: list[str] = []
+
+    class Response:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            return False
+
+        def read(self) -> bytes:
+            return b'{"embedding": [1, 0]}'
+
+    def fake_urlopen(request, timeout):
+        requested_urls.append(request.full_url)
+        return Response()
+
+    monkeypatch.setenv("OLLAMA_URL", "http://ollama.example:11434/")
+    monkeypatch.setattr(module.urllib.request, "urlopen", fake_urlopen)
+
+    assert module.ollama_embed("query", "all-minilm") == [1.0, 0.0]
+    assert requested_urls == ["http://ollama.example:11434/api/embeddings"]
+
+
+def test_search_falls_back_to_keyword_results_when_embedding_is_unavailable(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    module = load_module()
+    cache_dir = tmp_path / "cache"
+    root = tmp_path / "wiki"
+    root.mkdir()
+    index = module.fresh_index(root, "all-minilm")
+    index["files"] = {
+        "notes.md": {
+            "title": "Notes",
+            "sections": [
+                {
+                    "heading": "Useful note",
+                    "content": "The green comet appears only in winter.",
+                    "embedding": None,
+                }
+            ],
+        }
+    }
+    module.save_index(cache_dir, root, "all-minilm", index)
+    monkeypatch.setattr(module, "ollama_embed", lambda text, model: None)
+
+    result = module.cmd_search(
+        "green comet", root, model="all-minilm", cache_dir=cache_dir, mode="semantic"
+    )
+
+    assert result["fallback"] == "keyword"
+    assert [item["file"] for item in result["results"]] == ["notes.md"]
+
+
+def test_json_cli_emits_a_stable_search_schema(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    module = load_module()
+    cache_dir = tmp_path / "cache"
+    root = tmp_path / "wiki"
+    root.mkdir()
+    index = module.fresh_index(root, "all-minilm")
+    index["files"] = {
+        "notes.md": {
+            "title": "Notes",
+            "sections": [
+                {"heading": "Useful note", "content": "The green comet appears in winter.", "embedding": None}
+            ],
+        }
+    }
+    module.save_index(cache_dir, root, "all-minilm", index)
+    monkeypatch.setenv("WIKI_SEARCH_CACHE_DIR", str(cache_dir))
+    monkeypatch.setattr(module, "ollama_embed", lambda text, model: None)
+    monkeypatch.setattr(sys, "argv", ["wiki-search", "--json", "--wiki", str(root), "green comet"])
+
+    module.main()
+
+    payload = json.loads(capsys.readouterr().out)
+    assert set(payload) == {"schema_version", "command", "wiki", "model", "mode", "fallback", "results"}
+    assert payload["schema_version"] == 1
+    assert payload["command"] == "search"
+    assert payload["fallback"] == "keyword"
+    assert payload["results"][0]["file"] == "notes.md"

--- a/tests/skills/test_wiki_search_skill.py
+++ b/tests/skills/test_wiki_search_skill.py
@@ -169,6 +169,31 @@ def test_indexing_rejects_sections_with_incompatible_vector_dimension(
     assert sections[1]["embedding"] is None
 
 
+def test_reindex_rebuilds_a_persisted_namespace_after_embedding_dimension_change(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    module = load_module()
+    cache_dir = tmp_path / "cache"
+    root = tmp_path / "wiki"
+    root.mkdir()
+    (root / "entry.md").write_text("# Entry\n\nA durable note that is long enough to embed.", encoding="utf-8")
+
+    monkeypatch.setattr(module, "ollama_embed", lambda text, model: [1.0, 0.0])
+    module.cmd_index(root, model="all-minilm", cache_dir=cache_dir)
+
+    monkeypatch.setattr(module, "ollama_embed", lambda text, model: [1.0, 0.0, 0.0])
+    module.cmd_index(root, model="all-minilm", cache_dir=cache_dir, force=True)
+
+    rebuilt = module.load_index(cache_dir, root, "all-minilm")
+    embedding = rebuilt["files"]["entry.md"]["sections"][0]["embedding"]
+
+    assert rebuilt["metadata"]["dimension"] == 3
+    assert embedding == [1.0, 0.0, 0.0]
+    results, semantic_available = module.semantic_search("durable note", rebuilt, "all-minilm")
+    assert semantic_available is True
+    assert results[0]["file"] == "entry.md"
+
+
 def test_cosine_similarity_rejects_mismatched_vectors_and_ollama_errors(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## Motivation

The `llm-wiki` skill (Karpathy's LLM Wiki pattern) provides structured markdown knowledge bases but only supports keyword search. As wikis grow, users need to find content by **meaning**, not just exact terms — e.g., "why did xiaos fail with CreditsError" should find the model-switch solution page without matching any of those keywords exactly.

This PR adds semantic search as a companion skill, using local resources already present in most Hermes setups.

## Dependency Choice

Semantic search requires **ollama** with an embedding model (`all-minilm`, 45MB). When ollama is unavailable, the tool **gracefully degrades** to keyword-only search — no crash, no error.

| Approach | Verdict |
|----------|---------|
| sqlite-vec (core PR #44093) | ❌ Not merged yet, requires C extension |
| sentence-transformers | ❌ ~500MB pip install per user |
| API-based LLM provider | ❌ Pay-per-token, slow |
| **ollama (chosen)** | ✅ Many users already have it; 45MB model; no API cost |

The core agent is adding sqlite-vec for session_search ([PR #44093](https://github.com/NousResearch/hermes-agent/pull/44093)). Once merged, wiki-search may adopt the same provider chain — but ollama is the most practical option that works today.

## Design Decisions

- **Section-level indexing** (by `##`/`###` headings) gives finer granularity than whole-file embeddings
- **RRF hybrid search** fuses vector similarity with keyword match counts — catches both semantic nuance and exact terminology
- **Graceful degradation** — when ollama is not running, `semantic_search()` returns `[]` and `cmd_search()` falls back to keyword search
- **JSON storage** — simple, debuggable, human-readable. No database. Suitable for wikis under 500 files

## Changes

| File | Purpose |
|------|---------|
| `skills/research/wiki-search/SKILL.md` | Skill definition: triggers, dependency rationale, CLI reference |
| `skills/research/wiki-search/scripts/wiki-search` | Python CLI (450+ lines): indexing engine + 3 search modes |

No existing files modified.

## Testing

Manual verification on a real 7-file wiki:

- `wiki-search --status` — ✅ ollama health check, index stats correct
- `wiki-search index` — ✅ indexes 7 files / 37 sections in ~20s
- `wiki-search "xiaos CreditsError"` — ✅ top result (62%): `solutions/xiaos-model-switch.md`
- `wiki-search --hybrid "profile config not working"` — ✅ RRF fusion returns correct mix
- Graceful degradation — ✅ verified: stopping ollama, search falls back to keyword with warning

## Breaking Changes

**None.**

## Related

- [PR #44093](https://github.com/NousResearch/hermes-agent/pull/44093) — Core agent sqlite-vec session search (complementary; targets conversation history, not wikis)
- `skills/research/llm-wiki` — The wiki skill this enhances

## Checklist

- [x] New code has no TODO/FIXME markers
- [x] Documentation included in SKILL.md (dependency rationale, CLI usage, pitfalls, verification)
- [x] No existing code modified
- [x] Breaking changes: explicitly none
- [x] Graceful fallback path tested (ollama absent → keyword-only)