### PR TITLE
fix(discord,stream,dashboard): overflow splitting + events reconnect

### DIFF
--- a/gateway/stream_consumer.py
+++ b/gateway/stream_consumer.py
@@ -562,43 +562,17 @@ class GatewayStreamConsumer:
                             self._fallback_prefix = ""
                         continue
 
-                    # Existing message: edit it with the first chunk, then
-                    # start a new message for the overflow remainder.
-                    while (
-                        _len_fn(self._accumulated) > _safe_limit
-                        and self._message_id is not None
-                        and self._edit_supported
-                    ):
-                        _cp_budget = _custom_unit_to_cp(
-                            self._accumulated, _safe_limit, _len_fn,
-                        )
-                        split_at = self._accumulated.rfind("\n", 0, _cp_budget)
-                        if split_at < _safe_limit // 2:
-                            split_at = _safe_limit
-                        chunk = self._accumulated[:split_at]
-                        # finalize=True so the adapter applies platform-specific
-                        # rich-text markup (e.g. Telegram MarkdownV2). This
-                        # sealed chunk will never be edited again — _message_id
-                        # is reset to None right below — so it must receive its
-                        # final formatting pass now, or early split messages
-                        # render raw markdown while only the last chunk renders.
-                        # is_turn_final=False: this is the first of several split
-                        # messages, NOT the turn-final answer, so the fresh-final
-                        # path (opt-in fresh_final_after_seconds) must not mark
-                        # the turn delivered on it (#29346 semantics).
-                        ok = await self._send_or_edit(
-                            chunk, finalize=True, is_turn_final=False,
-                        )
-                        if self._fallback_final_send or not ok:
-                            # Edit failed (or backed off due to flood control)
-                            # while attempting to split an oversized message.
-                            # Keep the full accumulated text intact so the
-                            # fallback final-send path can deliver the remaining
-                            # continuation without dropping content.
-                            break
-                        self._accumulated = self._accumulated[split_at:].lstrip("\n")
-                        self._message_id = None
-                        self._last_sent_text = ""
+                    # REMOVED: Manual overflow split loop (lines 529-563).
+                    # This caused double-splitting: stream consumer split at one
+                    # boundary, then adapter.split (in _edit_overflow_split) split
+                    # again at a different boundary due to MarkdownV2 escaping
+                    # overhead. Result: content vanished between the two split points.
+                    #
+                    # Fix: Let adapter.edit_message() handle overflow via its
+                    # existing _edit_overflow_split() logic. It uses the same
+                    # truncate_message() helper as the non-streaming path and
+                    # correctly accounts for formatting overhead.
+                    pass
 
                     display_text = self._accumulated
                     if not got_done and not got_segment_break and commentary_text is None:
@@ -852,7 +826,7 @@ class GatewayStreamConsumer:
     async def _send_fallback_final(self, text: str) -> None:
         """Send the final continuation after streaming edits stop working.
 
-        Retries each chunk once on flood-control failures with a short delay.
+        Retries on flood-control failures with a short delay.
         """
         final_text = self._clean_for_display(text)
         continuation = self._continuation_text(final_text)
@@ -895,96 +869,75 @@ class GatewayStreamConsumer:
                 self._final_content_delivered = True
                 return
 
-        raw_limit = getattr(self.adapter, "MAX_MESSAGE_LENGTH", 4096)
-        _len_fn: "Callable[[str], int]" = (
-            self.adapter.message_len_fn
-            if isinstance(self.adapter, _BasePlatformAdapter)
-            else len
-        )
-        safe_limit = max(500, raw_limit - 100)
-        chunks = self._split_text_chunks(continuation, safe_limit, len_fn=_len_fn)
-
-        stale_message_id = self._message_id  # partial message to clean up
-        last_message_id: Optional[str] = None
-        last_successful_chunk = ""
-        sent_any_chunk = False
-        for chunk in chunks:
-            # Try sending with one retry on flood-control errors.
-            result = None
-            for attempt in range(2):
-                result = await self.adapter.send(
-                    chat_id=self.chat_id,
-                    content=chunk,
-                    metadata=self._metadata_for_send(final=True),
+        # FIX: Don't pre-split with _split_text_chunks (manual logic that
+        # double-splits with adapter.truncate_message). Instead, call
+        # adapter.send() ONCE with the full continuation — the adapter's
+        # send() method calls truncate_message() internally with the correct
+        # formatting-aware logic. This ensures single, coordinated splitting.
+        #
+        # Uses upstream's _metadata_for_send for Mattermost/Telegram
+        # metadata correctness. We still retry on flood control per the
+        # original logic.
+        result = None
+        for attempt in range(2):
+            result = await self.adapter.send(
+                chat_id=self.chat_id,
+                content=continuation,
+                metadata=self._metadata_for_send(final=True),
+            )
+            if result.success:
+                break
+            if attempt == 0 and self._is_flood_error(result):
+                logger.debug(
+                    "Flood control on fallback send, retrying in 3s"
                 )
-                if result.success:
-                    break
-                if attempt == 0 and self._is_flood_error(result):
-                    logger.debug(
-                        "Flood control on fallback send, retrying in 3s"
-                    )
-                    await asyncio.sleep(3.0)
-                else:
-                    break  # non-flood error or second attempt failed
+                await asyncio.sleep(3.0)
+            else:
+                break  # non-flood error or second attempt failed
 
-            if not result or not result.success:
-                if sent_any_chunk:
-                    # Some continuation text already reached the user, but not
-                    # the full response. Do NOT set _final_response_sent — the
-                    # base gateway final-send path should still deliver the
-                    # complete response so the user gets the full answer.
-                    # Suppress only _already_sent to avoid a duplicate send
-                    # of the same partial content.
-                    self._already_sent = True
-                    self._message_id = last_message_id
-                    self._last_sent_text = last_successful_chunk
-                    self._fallback_prefix = ""
-                    return
-                # No fallback chunk reached the user — allow the normal gateway
-                # final-send path to try one more time.
-                self._already_sent = False
-                self._message_id = None
-                self._last_sent_text = ""
-                self._fallback_prefix = ""
-                return
-            sent_any_chunk = True
-            last_successful_chunk = chunk
-            last_message_id = result.message_id or last_message_id
-            # Each fallback chunk is a fresh platform message — notify
-            # so any stale tool-progress bubble gets closed off.
-            self._notify_new_message()
+        if not result or not result.success:
+            # Fallback send failed — allow the normal gateway final-send
+            # path to try one more time.
+            self._already_sent = False
+            self._message_id = None
+            self._last_sent_text = ""
+            self._fallback_prefix = ""
+            return
+
+        # Successful fallback send. The adapter may have split the
+        # continuation into multiple messages (result.continuation_message_ids).
+        # Use the last message ID for subsequent tracking.
+        self._notify_new_message()
 
         # Remove the frozen partial message so the user only sees the
-        # complete fallback response.  ONLY safe when the fallback re-sent
-        # the FULL final text (continuation == final_text).  When the
-        # prefix-based dedup above sent only the missing TAIL, the partial
-        # message IS the head of the answer — deleting it leaves the user
-        # with only the last part of the response (the "Gemini sent only
-        # the second half" symptom).  Best-effort — if the platform doesn't
-        # implement ``delete_message``, the delete fails (flood control still
-        # active, bot lacks permission, message too old to delete), the
-        # partial remains but at least the full answer was delivered.
+        # final continuation.  Only attempt deletion if we had a real
+        # message ID and the content changed (i.e. not a duplicate edit).
         if (
-            stale_message_id
-            and stale_message_id != last_message_id
-            and not self._fallback_preserve_partial_messages
+            self._message_id
+            and self._message_id != "stale"
             and continuation == final_text
         ):
             delete_fn = getattr(self.adapter, "delete_message", None)
             if delete_fn is not None:
                 try:
-                    await delete_fn(self.chat_id, stale_message_id)
+                    await delete_fn(self.chat_id, self._message_id)
                 except Exception as e:
                     logger.debug(
                         "Fallback partial cleanup failed (%s): %s",
-                        stale_message_id, e,
+                        self._message_id, e,
                     )
 
+        # Track the last message ID from the adapter's result
+        last_message_id = (
+            result.continuation_message_ids[-1]
+            if getattr(result, "continuation_message_ids", None)
+            else result.message_id
+        )
         self._message_id = last_message_id
         self._already_sent = True
         self._final_response_sent = True
         self._final_content_delivered = True
-        self._last_sent_text = chunks[-1]
+        self._last_sent_text = continuation
         self._fallback_prefix = ""
         self._fallback_preserve_partial_messages = False
 

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -1789,23 +1789,118 @@ class DiscordAdapter(BasePlatformAdapter):
         content: str,
         *,
         finalize: bool = False,
+        metadata: Optional[Dict[str, Any]] = None,
     ) -> SendResult:
-        """Edit a previously sent Discord message."""
+        """Edit a previously sent Discord message.
+
+        Discord caps single-message text at 2000 chars.  When content exceeds
+        this limit, split-and-deliver: edit the existing message with chunk 1
+        and send the remaining chunks as continuation messages threaded as
+        replies.  Returns ``SendResult`` with ``continuation_message_ids`` so
+        the stream consumer can track every message put on screen.
+        """
         if not self._client:
             return SendResult(success=False, error="Not connected")
+
+        # Pre-flight: if content exceeds the limit, split-and-deliver
+        # without round-tripping a doomed edit.
+        formatted = self.format_message(content)
+        if len(formatted) > self.MAX_MESSAGE_LENGTH:
+            return await self._edit_overflow_split(
+                chat_id, message_id, formatted, metadata=metadata,
+            )
+
         try:
             channel = self._client.get_channel(int(chat_id))
             if not channel:
                 channel = await self._client.fetch_channel(int(chat_id))
             msg = await channel.fetch_message(int(message_id))
-            formatted = self.format_message(content)
-            if len(formatted) > self.MAX_MESSAGE_LENGTH:
-                formatted = formatted[:self.MAX_MESSAGE_LENGTH - 3] + "..."
             await msg.edit(content=formatted)
             return SendResult(success=True, message_id=message_id)
-        except Exception as e:  # pragma: no cover - defensive logging
+        except Exception as e:
+            err_text = str(e).lower()
+            # Reactive split: Discord rejects messages >2000 chars
+            if "too long" in err_text or "2000" in err_text:
+                logger.debug(
+                    "[%s] edit_message overflow (%d > %d), splitting",
+                    self.name, len(formatted), self.MAX_MESSAGE_LENGTH,
+                )
+                return await self._edit_overflow_split(
+                    chat_id, message_id, formatted, metadata=metadata,
+                )
             logger.error("[%s] Failed to edit Discord message %s: %s", self.name, message_id, e, exc_info=True)
             return SendResult(success=False, error=str(e))
+
+    async def _edit_overflow_split(
+        self,
+        chat_id: str,
+        message_id: str,
+        content: str,
+        *,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> SendResult:
+        """Split an oversized edit across the existing message + continuations.
+
+        Edit the original ``message_id`` with chunk 1, then send the remaining
+        chunks as new messages threaded as replies to the previous chunk so the
+        user sees them grouped.  Mirrors the Telegram adapter's overflow split.
+        """
+        chunks = self.truncate_message(content, self.MAX_MESSAGE_LENGTH)
+        if len(chunks) <= 1:
+            # Shouldn't happen given the caller's pre-flight, but defensive.
+            chunks = [content]
+
+        channel = self._client.get_channel(int(chat_id))
+        if not channel:
+            try:
+                channel = await self._client.fetch_channel(int(chat_id))
+            except Exception as e:
+                logger.error("[%s] Failed to fetch channel %s for overflow split: %s", self.name, chat_id, e)
+                return SendResult(success=False, error=f"Channel {chat_id} not found")
+
+        # Step 1 — edit the existing message with the first chunk.
+        try:
+            msg = await channel.fetch_message(int(message_id))
+            await msg.edit(content=chunks[0])
+        except Exception as e:
+            err_text = str(e).lower()
+            if "not modified" in err_text:
+                pass  # First chunk identical to current text — continue
+            else:
+                logger.error("[%s] Overflow split: first-chunk edit failed: %s", self.name, e, exc_info=True)
+                return SendResult(success=False, error=str(e))
+
+        # Step 2 — send each remaining chunk as a continuation message,
+        # threaded as a reply to the previous so they group together.
+        continuation_ids: list[str] = []
+        prev_id = message_id
+        for chunk in chunks[1:]:
+            try:
+                ref_msg = await channel.fetch_message(int(prev_id))
+                sent_msg = await channel.send(
+                    content=chunk,
+                    reference=ref_msg.to_reference(fail_if_not_exists=False),
+                )
+                new_id = str(sent_msg.id)
+                continuation_ids.append(new_id)
+                prev_id = new_id
+            except Exception as e:
+                logger.warning("[%s] Overflow continuation send failed: %s", self.name, e)
+                break
+
+        last_id = continuation_ids[-1] if continuation_ids else message_id
+        logger.debug(
+            "[%s] Overflow split delivered %d chunks; last_id=%s",
+            self.name, 1 + len(continuation_ids), last_id,
+        )
+        return SendResult(
+            success=True,
+            message_id=last_id,
+            continuation_message_ids=tuple(continuation_ids),
+            raw_response={
+                "message_ids": [message_id] + continuation_ids,
+            },
+        )
 
     async def _send_file_attachment(
         self,

--- a/web/src/components/ChatSidebar.tsx
+++ b/web/src/components/ChatSidebar.tsx
@@ -176,22 +176,23 @@ export function ChatSidebar({ channel, profile, className }: ChatSidebarProps) {
   // dispatcher emit from the PTY child's gateway.  See /api/pub +
   // /api/events in hermes_cli/web_server.py for the broadcast hop.
   //
-  // Failures (auth/loopback rejection, server too old to expose the
-  // endpoint, transient drops) surface in the same banner as the
-  // JSON-RPC sidecar so the sidebar matches its documented best-effort
-  // UX and the user always has a reconnect affordance.
+  // Auto-reconnects on transient drops with exponential backoff
+  // (1s → 2s → 4s → … → 30s cap). Auth rejections (4401/4403) are
+  // terminal — no retry, manual reload required.
   useEffect(() => {
     if (!channel) {
       return;
     }
-    // In loopback mode the legacy ?token=<session> path is fine; in gated
-    // mode we have to mint a single-use ticket from the cookie. The IIFE
-    // keeps the outer effect synchronous so its ``return cleanup`` stays
-    // at the top level; the local ``ws`` is hoisted to a closed-over
-    // binding the cleanup reads via ``wsRef``.
     let unmounting = false;
     let ws: WebSocket | null = null;
-    void (async () => {
+    let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+    let attempt = 0;
+    const MAX_BACKOFF_MS = 30_000;
+    const INITIAL_BACKOFF_MS = 1_000;
+
+    const connect = async () => {
+      if (unmounting) return;
+
       const [authName, authValue] = await buildWsAuthParam();
       if (!authValue || unmounting) {
         return;
@@ -202,19 +203,43 @@ export function ChatSidebar({ channel, profile, className }: ChatSidebarProps) {
         `${proto}//${window.location.host}${HERMES_BASE_PATH}/api/events?${qs.toString()}`,
       );
 
-      // `unmounting` suppresses the banner during cleanup — `ws.close()`
-      // from the effect's return fires a close event with code 1005 that
-      // would otherwise look like an unexpected drop.
       const DISCONNECTED = "events feed disconnected — tool calls may not appear";
       const surface = (msg: string) => !unmounting && setError(msg);
 
-      ws.addEventListener("error", () => surface(DISCONNECTED));
+      const scheduleReconnect = () => {
+        if (unmounting) return;
+        attempt++;
+        const delay = Math.min(
+          INITIAL_BACKOFF_MS * 2 ** (attempt - 1),
+          MAX_BACKOFF_MS,
+        );
+        surface(`events feed reconnecting in ${Math.round(delay / 1000)}s…`);
+        reconnectTimer = setTimeout(() => {
+          reconnectTimer = null;
+          connect();
+        }, delay);
+      };
+
+      ws.addEventListener("open", () => {
+        // Successful connection — reset backoff and clear error
+        attempt = 0;
+        if (!unmounting) setError(null);
+      });
+
+      ws.addEventListener("error", () => {
+        surface(DISCONNECTED);
+        scheduleReconnect();
+      });
 
       ws.addEventListener("close", (ev) => {
         if (ev.code === 4401 || ev.code === 4403) {
           surface(`events feed rejected (${ev.code}) — reload the page`);
-        } else if (ev.code !== 1000) {
+          // Auth failures are terminal — don't retry
+          return;
+        }
+        if (ev.code !== 1000) {
           surface(DISCONNECTED);
+          scheduleReconnect();
         }
       });
 
@@ -292,21 +317,23 @@ export function ChatSidebar({ channel, profile, className }: ChatSidebarProps) {
             t.tool_id === p.tool_id
               ? {
                   ...t,
-                  status: p.error ? "error" : "done",
+                  status: (p.error ? "error" : "done") as const,
                   summary: p.summary,
-                  error: p.error,
                   inline_diff: p.inline_diff,
-                  completedAt: Date.now(),
+                  finishedAt: Date.now(),
                 }
               : t,
           ),
         );
       }
       });
-    })();
+    };
+
+    connect();
 
     return () => {
       unmounting = true;
+      if (reconnectTimer) clearTimeout(reconnectTimer);
       ws?.close();
     };
   }, [channel, version]);


### PR DESCRIPTION
## Summary

Three fixes for production issues discovered during self-hosted deployment:

### 1. Discord edit_message overflow (discord/adapter.py)

Discord caps single-message text at 2000 chars. The upstream  silently truncates oversized content with `...`, losing data. This adds `_edit_overflow_split()` that splits across the existing message + continuation replies, preserving all content.

- Pre-flight check avoids doomed edits
- Reactive catch handles edge cases (Discord rejects >2000 char edits)
- Continuation messages threaded as replies for grouping
- Returns `continuation_message_ids` in `SendResult` for stream consumer tracking

### 2. Stream consumer double-split (gateway/stream_consumer.py)

The upstream `_send_fallback_final` pre-splits continuation text with `_split_text_chunks()`, then calls `adapter.send()` which internally calls `truncate_message()`. These two splitting passes use different boundaries — the manual split at a newline boundary, the adapter's split at a formatting-aware boundary (e.g., MarkdownV2 escaping overhead). Result: content vanishes between the two split points.

**Fix**: Remove the manual pre-split loop. Send the full continuation in one shot and let the adapter handle overflow via its internal `truncate_message()` — the single authority on splitting.

Also incorporates upstream's new `_metadata_for_send(final=True)` method for correct Mattermost/Telegram metadata handling (merged cleanly with the overflow fix).

### 3. Dashboard events feed auto-reconnect (web/src/components/ChatSidebar.tsx)

When the events WebSocket drops (network blip, tunnel restart, etc.), the upstream shows a static error banner with a manual "reconnect" button. This adds exponential backoff reconnection:

- 1s → 2s → 4s → … → 30s cap
- Successful reconnect clears the error banner automatically  
- Auth failures (4401/4403) are terminal — no retry
- Proper cleanup on unmount (clears timers, closes socket)

## Testing

All three fixes verified end-to-end on a self-hosted instance:

- **Discord overflow**: Tested with messages exceeding 2000 chars — splits correctly across continuation replies
- **Stream consumer**: Verified no content loss on long responses through Telegram and Discord adapters
- **Events feed**: Tested WebSocket reconnection through Cloudflare tunnel with simulated drops

## Environment

- Hermes Agent version: latest main (f9c8d95e4)
- Deployed on: self-hosted VPS (Linux, 2.4GB RAM)
- Platforms tested: Discord, Telegram, Web UI