### PR TITLE
fix(desktop): stage local file refs before prompt submit

### DIFF
--- a/apps/desktop/electron/hardening.cjs
+++ b/apps/desktop/electron/hardening.cjs
@@ -4,7 +4,7 @@ const path = require('node:path')
 const { fileURLToPath } = require('node:url')
 
 const DEFAULT_FETCH_TIMEOUT_MS = 15_000
-const DATA_URL_READ_MAX_BYTES = 16 * 1024 * 1024
+const DATA_URL_READ_MAX_BYTES = 128 * 1024 * 1024
 const TEXT_PREVIEW_SOURCE_MAX_BYTES = 64 * 1024 * 1024
 
 const SAFE_ENV_SUFFIXES = new Set(['dist', 'example', 'sample', 'template'])

--- a/apps/desktop/electron/hardening.test.cjs
+++ b/apps/desktop/electron/hardening.test.cjs
@@ -6,6 +6,7 @@ const test = require('node:test')
 const { pathToFileURL } = require('node:url')
 
 const {
+  DATA_URL_READ_MAX_BYTES,
   DEFAULT_FETCH_TIMEOUT_MS,
   encryptDesktopSecret,
   resolveDirectoryForIpc,
@@ -21,6 +22,10 @@ async function rejectsWithCode(promise, code) {
     return true
   })
 }
+
+test('data-url file reads allow large site-plan PDFs up to 128 MB', () => {
+  assert.equal(DATA_URL_READ_MAX_BYTES, 128 * 1024 * 1024)
+})
 
 test('resolveTimeoutMs falls back to defaults and accepts overrides', () => {
   assert.equal(resolveTimeoutMs(undefined), DEFAULT_FETCH_TIMEOUT_MS)

--- a/apps/desktop/electron/main.cjs
+++ b/apps/desktop/electron/main.cjs
@@ -600,7 +600,7 @@ app.setAboutPanelOptions({
 
 // Custom scheme for streaming local media (video/audio) into the renderer.
 // Reading large media through `readFileDataUrl` failed: it base64-loads the
-// whole file into memory and is hard-capped at DATA_URL_READ_MAX_BYTES (16 MB),
+// whole file into memory and is hard-capped at DATA_URL_READ_MAX_BYTES (128 MB),
 // so any non-trivial video silently refused to load. Streaming via a protocol
 // handler removes the size cap and gives the <video> element seekable,
 // range-aware playback. Must be registered before the app is ready.

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions.test.tsx
@@ -655,16 +655,11 @@ describe('usePromptActions file attachment sync', () => {
     })
   })
 
-  it('passes a path-less @file: ref straight through (no path = nothing to upload)', async () => {
-    // Submit-layer contract: only attachments that carry a `path` are upload
-    // candidates. A path-less ref (an @-mention/context ref or pasted text)
-    // has no bytes to send, so syncAttachments leaves it untouched and the ref
-    // reaches the gateway as-is — correct for workspace-relative refs.
-    //
-    // The MahmoudR drag-drop bug (a Finder PDF that became a local-path text
-    // ref in remote mode) is fixed upstream at the DROP layer: OS drops now
-    // carry a path and route through the upload pipeline instead of becoming a
-    // path-less inline ref. See partitionDroppedFiles in use-composer-actions.
+  it('recovers a local path from a path-less @file ref and submits the staged workspace ref', async () => {
+    // Some Desktop paths can lose ComposerAttachment.path and leave only a
+    // pre-rendered @file:/Users/... ref. Submitting that raw path hits the
+    // backend workspace guard, so submit-time sync must recover obvious local
+    // filesystem paths and route them through file.attach.
     $connection.set({ mode: 'remote' } as never)
     const readFileDataUrl = vi.fn(async () => 'data:application/pdf;base64,JVBERi0=')
     Object.defineProperty(window, 'hermesDesktop', {
@@ -683,6 +678,14 @@ describe('usePromptActions file attachment sync', () => {
     const calls: { method: string; params?: Record<string, unknown> }[] = []
     const requestGateway = vi.fn(async (method: string, params?: Record<string, unknown>) => {
       calls.push({ method, params })
+      if (method === 'file.attach') {
+        return {
+          attached: true,
+          path: '/remote/work/.hermes/desktop-attachments/DEVIS_signed.pdf',
+          ref_text: '@file:.hermes/desktop-attachments/DEVIS_signed.pdf',
+          uploaded: true
+        } as never
+      }
       return {} as never
     })
 
@@ -692,10 +695,50 @@ describe('usePromptActions file attachment sync', () => {
     const ok = await handle!.submitText('read this file', { attachments: [pathlessRef] })
 
     expect(ok).toBe(true)
-    // No path → no file.attach, no byte read: the ref passes through unchanged.
+    expect(calls.map(c => c.method)).toEqual(['file.attach', 'prompt.submit'])
+    expect(readFileDataUrl).toHaveBeenCalledWith('/Users/mahmoud/Downloads/DEVIS_signed.pdf')
+    expect(calls[0]?.params).toMatchObject({
+      session_id: RUNTIME_SESSION_ID,
+      path: '/Users/mahmoud/Downloads/DEVIS_signed.pdf',
+      name: 'DEVIS_signed.pdf',
+      data_url: 'data:application/pdf;base64,JVBERi0='
+    })
+    expect(calls[1]?.params).toEqual({
+      session_id: RUNTIME_SESSION_ID,
+      text: '@file:.hermes/desktop-attachments/DEVIS_signed.pdf\n\nread this file'
+    })
+  })
+
+  it('passes a path-less workspace-relative @file ref straight through', async () => {
+    $connection.set({ mode: 'remote' } as never)
+    const readFileDataUrl = vi.fn(async () => 'data:application/pdf;base64,JVBERi0=')
+    Object.defineProperty(window, 'hermesDesktop', {
+      configurable: true,
+      value: { readFileDataUrl }
+    })
+
+    const pathlessRef: ComposerAttachment = {
+      id: 'file:workspace',
+      kind: 'file',
+      label: 'report.pdf',
+      refText: '@file:`docs/report.pdf`'
+    }
+
+    const calls: { method: string; params?: Record<string, unknown> }[] = []
+    const requestGateway = vi.fn(async (method: string, params?: Record<string, unknown>) => {
+      calls.push({ method, params })
+      return {} as never
+    })
+
+    let handle: HarnessHandle | null = null
+    render(<Harness onReady={h => (handle = h)} refreshSessions={async () => undefined} requestGateway={requestGateway} />)
+
+    const ok = await handle!.submitText('read this file', { attachments: [pathlessRef] })
+
+    expect(ok).toBe(true)
     expect(calls.map(c => c.method)).toEqual(['prompt.submit'])
     expect(readFileDataUrl).not.toHaveBeenCalled()
-    expect(calls[0]?.params?.text).toContain('@file:`/Users/mahmoud/Downloads/DEVIS_signed.pdf`')
+    expect(calls[0]?.params?.text).toContain('@file:`docs/report.pdf`')
   })
 
   it('passes the path directly via file.attach in local mode (no byte upload)', async () => {
@@ -1016,14 +1059,14 @@ describe('uploadComposerAttachment remote read failures', () => {
     vi.restoreAllMocks()
   })
 
-  it('turns the raw 16MB IPC cap error into a friendly remote-gateway message', async () => {
+  it('turns the raw data-url IPC cap error into a friendly remote-gateway message', async () => {
     // electron/hardening.cjs rejects the readFileDataUrl IPC with this exact
     // shape when a file exceeds DATA_URL_READ_MAX_BYTES.
     Object.defineProperty(window, 'hermesDesktop', {
       configurable: true,
       value: {
         readFileDataUrl: vi.fn(async () => {
-          throw new Error('File preview failed: file is too large (20971520 bytes; limit 16777216 bytes).')
+          throw new Error('File preview failed: file is too large (150994944 bytes; limit 134217728 bytes).')
         })
       }
     })
@@ -1035,7 +1078,7 @@ describe('uploadComposerAttachment remote read failures', () => {
         { id: 'file:big', kind: 'file', label: 'huge.csv', path: '/abs/huge.csv' },
         { remote: true, requestGateway, sessionId: RUNTIME_SESSION_ID }
       )
-    ).rejects.toThrow('huge.csv is too large to upload to the remote gateway (max 16 MB).')
+    ).rejects.toThrow('huge.csv is too large to upload to the remote gateway (max 128 MB).')
 
     // The cap is hit before any gateway round-trip.
     expect(requestGateway).not.toHaveBeenCalled()

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions.ts
@@ -188,8 +188,38 @@ async function readFileDataUrlForAttach(filePath: string): Promise<string | null
   return dataUrl || null
 }
 
+const FILE_REF_RE = /^@file:(`[^`\n]+`|"[^"\n]+"|'[^'\n]+'|\S+)$/
+
+function unwrapContextRefValue(raw: string): string {
+  if (raw.length >= 2) {
+    const head = raw[0]
+    const tail = raw[raw.length - 1]
+
+    if ((head === '`' && tail === '`') || (head === '"' && tail === '"') || (head === "'" && tail === "'")) {
+      return raw.slice(1, -1)
+    }
+  }
+
+  return raw.replace(/[,.;!?]+$/, '').trim()
+}
+
+function isLikelyLocalFilesystemPath(value: string): boolean {
+  return value.startsWith('/') || value.startsWith('~/') || /^[A-Za-z]:[\\/]/.test(value) || value.startsWith('\\\\')
+}
+
+/**
+ * Recover local filesystem paths from pre-rendered @file refs that lost their
+ * attachment.path metadata. Workspace-relative refs intentionally return ''.
+ */
+function localFilePathFromRefText(refText?: string): string {
+  const match = (refText || '').trim().match(FILE_REF_RE)
+  const value = match ? unwrapContextRefValue(match[1] || '') : ''
+
+  return value && isLikelyLocalFilesystemPath(value) ? value : ''
+}
+
 // The readFileDataUrl IPC base64-loads the whole file into memory and is
-// hard-capped (DATA_URL_READ_MAX_BYTES, 16 MB) in electron/hardening.cjs, which
+// hard-capped (DATA_URL_READ_MAX_BYTES, 128 MB) in electron/hardening.cjs, which
 // rejects with a raw "file is too large (N bytes; limit M bytes)" string. In
 // remote mode every attachment's bytes go through that read, so a big file
 // surfaces that internal message verbatim in the failure toast. Translate it
@@ -445,6 +475,19 @@ export function usePromptActions({
 
       for (const original of attachments) {
         let attachment = original
+
+        if (!attachment.path && attachment.kind === 'file') {
+          const recoveredPath = localFilePathFromRefText(attachment.refText)
+
+          if (recoveredPath) {
+            attachment = {
+              ...attachment,
+              detail: attachment.detail || recoveredPath,
+              label: attachment.label || pathLabel(recoveredPath),
+              path: recoveredPath
+            }
+          }
+        }
 
         // Join a drop-time eager upload still in flight for this attachment
         // before deciding anything — otherwise submit and the eager task both


### PR DESCRIPTION
## Summary

Fixes a Desktop attachment path-loss case where a selected/dropped local file could reach the agent as a raw absolute `@file:/Users/...` reference instead of being staged into the Hermes workspace first.

This PR makes Desktop recover obvious local filesystem paths from path-less `@file:` refs at submit time, route them through the existing `file.attach` upload/staging pipeline, and submit the workspace-safe staged ref (`@file:.hermes/desktop-attachments/...`) to the backend.

## Issue

Desktop has two relevant attachment shapes:

1. A real attachment object with `path` metadata.
   - This can be uploaded/staged before prompt submit.
2. A pre-rendered text/context ref such as `@file:`/Users/.../file.pdf`` with no `attachment.path` metadata.
   - Before this fix, submit-time sync treated this as “nothing to upload” and passed the ref through unchanged.

That second shape breaks remote Desktop usage:

- The path is usually on the client machine, not on the gateway/backend host.
- Even if the string reaches Hermes, backend context preprocessing correctly rejects raw absolute host paths that are outside the workspace.
- The agent then sees an unusable context warning instead of a readable attachment, so PDFs/documents cannot be extracted or rendered.

In practice this showed up as files being submitted as raw `/Users/.../Downloads/...` paths instead of staged `.hermes/desktop-attachments/...` paths.

## Root cause

The submit-layer file sync only uploaded attachments that already had `attachment.path` set. If a local file selection/drop lost that metadata but kept a rendered `@file:` ref, Desktop had enough information to identify the local path, but did not recover it before submitting.

The backend guard was not the bug; it is correct to block arbitrary absolute paths. Desktop needed to upload/stage the file before prompt submit.

## Fix

- Add parsing for single-file `@file:` refs in `use-prompt-actions.ts`.
- Unwrap backtick, single-quote, or double-quote wrapped values.
- Detect likely local filesystem paths:
  - POSIX absolute paths (`/Users/...`)
  - home-relative paths (`~/...`)
  - Windows drive paths (`C:\...` / `C:/...`)
  - UNC paths (`\\server\share\...`)
- If a path-less file attachment contains one of those refs, reconstruct `attachment.path` before the normal upload flow runs.
- Preserve workspace-relative path-less refs (`@file:docs/report.pdf`, etc.) as pass-through; those are already valid context refs and should not be uploaded.
- Keep the existing `file.attach` contract as the staging mechanism, so prompt text receives the backend-returned `ref_text` rather than the raw local path.
- Raise the Electron `readFileDataUrl` cap from 16 MB to 128 MB so practical remote uploads such as site-plan PDFs can be read and sent to `file.attach`.
- Update the size-limit error text and hardening tests to match the new 128 MB cap.

## Behavior after the fix

For a remote Desktop client submitting a local PDF whose metadata was reduced to:

```text
@file:`/Users/example/Downloads/site-plan.pdf`
```

Desktop now:

1. Recovers `/Users/example/Downloads/site-plan.pdf` from the ref.
2. Reads the file bytes through the Electron bridge.
3. Calls `file.attach` with the path, filename, session id, and `data_url`.
4. Receives a staged backend ref such as:

```text
@file:.hermes/desktop-attachments/site-plan.pdf
```

5. Submits that staged ref in the prompt.

The agent can then open/extract/render the file from the backend workspace.

## Verification

Automated checks run locally:

```bash
cd apps/desktop
npm run test:ui -- --run src/app/session/hooks/use-prompt-actions.test.tsx
# 33 tests passed

npm run typecheck
# passed

cd ../..
node --test apps/desktop/electron/hardening.test.cjs
# 13 tests passed

./venv/bin/python -m pytest tests/test_tui_gateway_server.py -k 'file_attach' -q
# 5 passed, 272 deselected
```

Manual end-to-end verification with a rebuilt/copied Desktop app:

- Image attachment test: the agent could see and describe the attached floor-plan image.
- PDF attachment test: a 9.2 MB AutoCAD A1 site-plan PDF arrived as:

```text
@file:.hermes/desktop-attachments/<filename>.pdf
```

rather than a raw `/Users/...` path.

Backend/tool verification for that PDF:

- File existed on the backend under `.hermes/desktop-attachments/`.
- `file` identified it as `PDF document, version 1.7`.
- `pdfinfo` reported:
  - 1 page
  - A1-sized page
  - not encrypted
  - AutoCAD-produced PDF metadata
- PyMuPDF opened it successfully.
- Text extraction returned ~18k characters.
- Rendering the page to PNG succeeded.
- The agent could read the title block and describe the site-plan contents.

That confirms the fix works for the original failure mode: the uploaded document is no longer stranded as an unreadable client-local path; it is staged into the backend workspace and usable by Hermes tools.

## Notes for reviewers

- This does not weaken backend workspace path validation.
- Workspace-relative `@file:` refs remain pass-through.
- The local-path recovery only applies to obvious filesystem paths, not arbitrary context refs.
- The 128 MB `readFileDataUrl` cap is still bounded; it only raises the practical ceiling for document uploads that must cross a remote Desktop/client boundary.
