### PR TITLE
fix(honcho): include file size in memo key to detect sub-second honch…

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -12770,16 +12770,19 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
     @classmethod
     def _extract_honcho_cache_busting_config(cls) -> dict[str, Any]:
-        """Extract Honcho identity keys, memoized by honcho.json mtime."""
+        """Extract Honcho identity keys, memoized by honcho.json mtime + size."""
         try:
             from plugins.memory.honcho.client import HonchoClientConfig, resolve_config_path
 
             path = resolve_config_path()
             try:
-                mtime_ns = path.stat().st_mtime_ns
+                st = path.stat()
+                mtime_ns = st.st_mtime_ns
+                file_size = st.st_size
             except OSError:
                 mtime_ns = None
-            memo_key = (str(path), mtime_ns)
+                file_size = None
+            memo_key = (str(path), mtime_ns, file_size)
             cached = cls._HONCHO_CACHE_BUSTING_MEMO.get(memo_key)
             if cached is not None:
                 return dict(cached)


### PR DESCRIPTION
## What does this PR do?

`_extract_honcho_cache_busting_config` memoized its result using `(path, mtime_ns)` as the cache key. On most filesystems, `mtime_ns` has 1-second granularity, so rapid consecutive writes to `honcho.json` within the same second would share an identical `mtime_ns`. The second call would then hit the stale cache and return the old configuration, causing `pinPeerName` flips to be ignored.

This PR adds `st_size` to the memoization key. When `pinPeerName` flips (`true` ↔ `false`), the serialized JSON changes length by one byte, ensuring the cache key changes even when `mtime_ns` remains identical. Since `st_size` is retrieved during the existing `path.stat()` call, there is no additional I/O cost.

## Related Issue

Fixes #47844

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Modified `gateway/run.py` in `_extract_honcho_cache_busting_config`: Included `st_size` in the `memo_key` tuple to ensure cache invalidation on file content changes that occur within the same second.

## How to Test

1. Run the specific test case that reproduces the race condition:
   `scripts/run_tests.sh tests/honcho_plugin/test_pin_peer_name.py::TestPinTransition::test_cache_busting_signature_reflects_pin_peer_name`
2. Verify that the test passes (it previously failed due to identical cache signatures).
3. Confirm all tests in the file pass: `scripts/run_tests.sh tests/honcho_plugin/test_pin_peer_name.py`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix/feature
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (this PR addresses an existing test failure)
- [x] I've tested on my platform: Ubuntu 22.04

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A
- [x] I've updated `cli-config.yaml.example` — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` — N/A
- [x] I've considered cross-platform impact — Yes, `path.stat()` is standard.
- [x] I've updated tool descriptions/schemas — N/A

## Screenshots / Logs

```text
[100.0% | 43/43 | ✓43 | ✗ 0] ✓ tests/honcho_plugin/test_pin_peer_name.py (43✓, 2.2s)