### PR TITLE
feat(prompt): scale context-file cap to model window + point agent at truncated file

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -958,13 +958,41 @@ CONTEXT_FILE_MAX_CHARS = 20_000
 CONTEXT_TRUNCATE_HEAD_RATIO = 0.7
 CONTEXT_TRUNCATE_TAIL_RATIO = 0.2
 
+# Dynamic-cap parameters (used when no explicit context_file_max_chars is set).
+# The cap scales with the model's context window so large-context models rarely
+# truncate a project doc, while small-context models stay at the historical
+# 20K floor. ~4 chars/token is the usual English heuristic; we spend a small
+# slice of the window on context files since they share the cached prefix with
+# the system prompt, tools, memory, and the whole conversation.
+_CONTEXT_FILE_CHARS_PER_TOKEN = 4
+_CONTEXT_FILE_WINDOW_FRACTION = 0.06
+_CONTEXT_FILE_DYNAMIC_CEILING = 500_000
 
-def _get_context_file_max_chars() -> int:
-    """Return the configured context-file truncation limit.
 
-    ``CONTEXT_FILE_MAX_CHARS`` remains the upstream-compatible default and
-    fallback. Users with larger context windows can raise
-    ``context_file_max_chars`` in config.yaml without patching Hermes.
+def _dynamic_context_file_max_chars(context_length: Optional[int]) -> int:
+    """Derive a char cap from the model's context window.
+
+    Returns at least ``CONTEXT_FILE_MAX_CHARS`` (the historical 20K floor) and
+    at most ``_CONTEXT_FILE_DYNAMIC_CEILING``. When ``context_length`` is
+    unknown/invalid, returns the flat default so behavior is unchanged.
+    """
+    if not isinstance(context_length, int) or context_length <= 0:
+        return CONTEXT_FILE_MAX_CHARS
+    budget = int(
+        context_length * _CONTEXT_FILE_CHARS_PER_TOKEN * _CONTEXT_FILE_WINDOW_FRACTION
+    )
+    return max(CONTEXT_FILE_MAX_CHARS, min(budget, _CONTEXT_FILE_DYNAMIC_CEILING))
+
+
+def _get_context_file_max_chars(context_length: Optional[int] = None) -> int:
+    """Return the context-file truncation limit.
+
+    Resolution order:
+      1. Explicit ``context_file_max_chars`` in config.yaml — user knows best,
+         always wins (including over the dynamic cap).
+      2. Dynamic cap derived from the model's ``context_length`` when provided
+         (scales the budget to the window; floor 20K, ceiling 500K).
+      3. ``CONTEXT_FILE_MAX_CHARS`` (20K) as the upstream-compatible fallback.
     """
     try:
         from hermes_cli.config import load_config
@@ -974,7 +1002,7 @@ def _get_context_file_max_chars() -> int:
             return int(val)
     except Exception as e:
         logger.debug("Could not read context_file_max_chars from config: %s", e)
-    return CONTEXT_FILE_MAX_CHARS
+    return _dynamic_context_file_max_chars(context_length)
 
 # Collect truncation warnings so the caller (run_agent) can surface them.
 # A ContextVar (not a module-global list) isolates accumulation per thread /
@@ -1510,16 +1538,30 @@ def build_nous_subscription_prompt(valid_tool_names: "set[str] | None" = None) -
 # Context files (SOUL.md, AGENTS.md, .cursorrules)
 # =========================================================================
 
-def _truncate_content(content: str, filename: str, max_chars: Optional[int] = None) -> str:
-    """Head/tail truncation with a marker in the middle."""
+def _truncate_content(
+    content: str,
+    filename: str,
+    max_chars: Optional[int] = None,
+    context_length: Optional[int] = None,
+    read_path: Optional[str] = None,
+) -> str:
+    """Head/tail truncation with a marker in the middle.
+
+    ``filename`` is the human label used in warnings. ``read_path`` is the
+    concrete path the agent should ``read_file`` to recover the full content
+    (defaults to ``filename`` when not supplied). ``context_length`` lets the
+    cap scale to the model's window when no explicit config override is set.
+    """
     if max_chars is None:
-        max_chars = _get_context_file_max_chars()
+        max_chars = _get_context_file_max_chars(context_length)
     if len(content) <= max_chars:
         return content
+    target = read_path or filename
     msg = (
         f"⚠️  Context file {filename} TRUNCATED: "
         f"{len(content)} chars exceeds limit of {max_chars} — "
-        f"increase context_file_max_chars or trim the file!"
+        f"trim the file, pin a larger context_file_max_chars, or use a "
+        f"larger-context model!"
     )
     logger.warning(msg)
     _record_truncation_warning(msg)
@@ -1527,11 +1569,16 @@ def _truncate_content(content: str, filename: str, max_chars: Optional[int] = No
     tail_chars = int(max_chars * CONTEXT_TRUNCATE_TAIL_RATIO)
     head = content[:head_chars]
     tail = content[-tail_chars:]
-    marker = f"\n\n[...truncated {filename}: kept {head_chars}+{tail_chars} of {len(content)} chars. Use file tools to read the full file.]\n\n"
+    marker = (
+        f"\n\n[...truncated {filename}: kept {head_chars}+{tail_chars} of "
+        f"{len(content)} chars. The middle is omitted — if you need the full "
+        f"instructions, read the complete file with the read_file tool: "
+        f"{target}]\n\n"
+    )
     return head + marker + tail
 
 
-def load_soul_md() -> Optional[str]:
+def load_soul_md(context_length: Optional[int] = None) -> Optional[str]:
     """Load SOUL.md from HERMES_HOME and return its content, or None.
 
     Used as the agent identity (slot #1 in the system prompt).  When this
@@ -1552,14 +1599,17 @@ def load_soul_md() -> Optional[str]:
         if not content:
             return None
         content = _scan_context_content(content, "SOUL.md")
-        content = _truncate_content(content, "SOUL.md")
+        content = _truncate_content(
+            content, "SOUL.md", context_length=context_length,
+            read_path=str(soul_path),
+        )
         return content
     except Exception as e:
         logger.debug("Could not read SOUL.md from %s: %s", soul_path, e)
         return None
 
 
-def _load_hermes_md(cwd_path: Path) -> str:
+def _load_hermes_md(cwd_path: Path, context_length: Optional[int] = None) -> str:
     """.hermes.md / HERMES.md — walk to git root."""
     hermes_md_path = _find_hermes_md(cwd_path)
     if not hermes_md_path:
@@ -1576,13 +1626,16 @@ def _load_hermes_md(cwd_path: Path) -> str:
             pass
         content = _scan_context_content(content, rel)
         result = f"## {rel}\n\n{content}"
-        return _truncate_content(result, ".hermes.md")
+        return _truncate_content(
+            result, ".hermes.md", context_length=context_length,
+            read_path=str(hermes_md_path),
+        )
     except Exception as e:
         logger.debug("Could not read %s: %s", hermes_md_path, e)
         return ""
 
 
-def _load_agents_md(cwd_path: Path) -> str:
+def _load_agents_md(cwd_path: Path, context_length: Optional[int] = None) -> str:
     """AGENTS.md — top-level only (no recursive walk)."""
     for name in ["AGENTS.md", "agents.md"]:
         candidate = cwd_path / name
@@ -1592,13 +1645,16 @@ def _load_agents_md(cwd_path: Path) -> str:
                 if content:
                     content = _scan_context_content(content, name)
                     result = f"## {name}\n\n{content}"
-                    return _truncate_content(result, "AGENTS.md")
+                    return _truncate_content(
+                        result, "AGENTS.md", context_length=context_length,
+                        read_path=str(candidate),
+                    )
             except Exception as e:
                 logger.debug("Could not read %s: %s", candidate, e)
     return ""
 
 
-def _load_claude_md(cwd_path: Path) -> str:
+def _load_claude_md(cwd_path: Path, context_length: Optional[int] = None) -> str:
     """CLAUDE.md / claude.md — cwd only."""
     for name in ["CLAUDE.md", "claude.md"]:
         candidate = cwd_path / name
@@ -1608,13 +1664,16 @@ def _load_claude_md(cwd_path: Path) -> str:
                 if content:
                     content = _scan_context_content(content, name)
                     result = f"## {name}\n\n{content}"
-                    return _truncate_content(result, "CLAUDE.md")
+                    return _truncate_content(
+                        result, "CLAUDE.md", context_length=context_length,
+                        read_path=str(candidate),
+                    )
             except Exception as e:
                 logger.debug("Could not read %s: %s", candidate, e)
     return ""
 
 
-def _load_cursorrules(cwd_path: Path) -> str:
+def _load_cursorrules(cwd_path: Path, context_length: Optional[int] = None) -> str:
     """.cursorrules + .cursor/rules/*.mdc — cwd only."""
     cursorrules_content = ""
     cursorrules_file = cwd_path / ".cursorrules"
@@ -1641,10 +1700,17 @@ def _load_cursorrules(cwd_path: Path) -> str:
 
     if not cursorrules_content:
         return ""
-    return _truncate_content(cursorrules_content, ".cursorrules")
+    return _truncate_content(
+        cursorrules_content, ".cursorrules", context_length=context_length,
+        read_path=str(cwd_path / ".cursorrules"),
+    )
 
 
-def build_context_files_prompt(cwd: Optional[str] = None, skip_soul: bool = False) -> str:
+def build_context_files_prompt(
+    cwd: Optional[str] = None,
+    skip_soul: bool = False,
+    context_length: Optional[int] = None,
+) -> str:
     """Discover and load context files for the system prompt.
 
     Priority (first found wins — only ONE project context type is loaded):
@@ -1654,7 +1720,11 @@ def build_context_files_prompt(cwd: Optional[str] = None, skip_soul: bool = Fals
       4. .cursorrules / .cursor/rules/*.mdc  (cwd only)
 
     SOUL.md from HERMES_HOME is independent and always included when present.
-    Each context source is capped at 20,000 chars.
+
+    Each context source is capped before injection. The cap defaults to the
+    model's context window (scaled — see ``_dynamic_context_file_max_chars``)
+    when *context_length* is provided, falling back to 20,000 chars otherwise.
+    An explicit ``context_file_max_chars`` in config.yaml always wins.
 
     When *skip_soul* is True, SOUL.md is not included here (it was already
     loaded via ``load_soul_md()`` for the identity slot).
@@ -1667,17 +1737,17 @@ def build_context_files_prompt(cwd: Optional[str] = None, skip_soul: bool = Fals
 
     # Priority-based project context: first match wins
     project_context = (
-        _load_hermes_md(cwd_path)
-        or _load_agents_md(cwd_path)
-        or _load_claude_md(cwd_path)
-        or _load_cursorrules(cwd_path)
+        _load_hermes_md(cwd_path, context_length)
+        or _load_agents_md(cwd_path, context_length)
+        or _load_claude_md(cwd_path, context_length)
+        or _load_cursorrules(cwd_path, context_length)
     )
     if project_context:
         sections.append(project_context)
 
     # SOUL.md from HERMES_HOME only — skip when already loaded as identity
     if not skip_soul:
-        soul_content = load_soul_md()
+        soul_content = load_soul_md(context_length)
         if soul_content:
             sections.append(soul_content)
 

--- a/agent/system_prompt.py
+++ b/agent/system_prompt.py
@@ -83,6 +83,17 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
     # we resolve through ``_ra()`` to honor those patches.
     _r = _ra()
 
+    # Resolve the model's context window once so context-file caps can scale
+    # to it (dynamic cap — see prompt_builder._dynamic_context_file_max_chars).
+    # None falls back to the historical flat default. This value is stable for
+    # the life of the conversation, so it does not threaten prompt caching.
+    _ctx_len: Optional[int] = None
+    _cc = getattr(agent, "context_compressor", None)
+    if _cc is not None:
+        _cc_len = getattr(_cc, "context_length", None)
+        if isinstance(_cc_len, int) and _cc_len > 0:
+            _ctx_len = _cc_len
+
     # ── Stable tier ────────────────────────────────────────────────
     stable_parts: List[str] = []
 
@@ -91,7 +102,7 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
     # cwd project instructions disabled.
     _soul_loaded = False
     if agent.load_soul_identity or not agent.skip_context_files:
-        _soul_content = _r.load_soul_md()
+        _soul_content = _r.load_soul_md(_ctx_len)
         if _soul_content:
             stable_parts.append(_soul_content)
             _soul_loaded = True
@@ -334,7 +345,8 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
         # dir — the user's real cwd there, but the install dir for the gateway
         # daemon, which is why the gateway sets TERMINAL_CWD.
         context_files_prompt = _r.build_context_files_prompt(
-            cwd=resolve_context_cwd(), skip_soul=_soul_loaded)
+            cwd=resolve_context_cwd(), skip_soul=_soul_loaded,
+            context_length=_ctx_len)
         if context_files_prompt:
             context_parts.append(context_files_prompt)
 

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1104,10 +1104,13 @@ DEFAULT_CONFIG = {
         "min_interval_hours": 24,
     },
 
-    # Maximum characters loaded from a single automatic context file such as
-    # SOUL.md, AGENTS.md, CLAUDE.md, .hermes.md, or .cursorrules before Hermes
-    # applies head/tail truncation. This is separate from read_file tool limits.
-    "context_file_max_chars": 20_000,
+    # Hard cap (chars) for a single automatic context file such as SOUL.md,
+    # AGENTS.md, CLAUDE.md, .hermes.md, or .cursorrules before Hermes applies
+    # head/tail truncation. ``null`` (the default) lets the cap scale with the
+    # model's context window (floor 20K, ceiling 500K) so large-context models
+    # rarely truncate a project doc. Set a positive integer to pin a fixed cap
+    # and override the dynamic behavior. Separate from read_file tool limits.
+    "context_file_max_chars": None,
 
     # Maximum characters returned by a single read_file call.  Reads that
     # exceed this are rejected with guidance to use offset+limit.

--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -19,6 +19,9 @@ from agent.prompt_builder import (
     build_nous_subscription_prompt,
     build_context_files_prompt,
     CONTEXT_FILE_MAX_CHARS,
+    _dynamic_context_file_max_chars,
+    _get_context_file_max_chars,
+    _CONTEXT_FILE_DYNAMIC_CEILING,
     DEFAULT_AGENT_IDENTITY,
     drain_truncation_warnings,
     TOOL_USE_ENFORCEMENT_GUIDANCE,
@@ -217,6 +220,71 @@ class TestTruncateContent:
         parent_warnings = drain_truncation_warnings()
         assert len(parent_warnings) == 1
         assert "parent.md" in parent_warnings[0]
+
+
+class TestDynamicContextFileCap:
+    """B — cap scales with the model's context window when not pinned.
+    C — truncation marker points the agent at the full file to read_file."""
+
+    @pytest.fixture(autouse=True)
+    def _no_explicit_config(self, monkeypatch):
+        # No explicit context_file_max_chars → dynamic path is eligible.
+        monkeypatch.setattr("hermes_cli.config.load_config", lambda: {})
+
+    def test_dynamic_floor_for_small_window(self):
+        # A small context window never drops below the historical 20K floor.
+        assert _dynamic_context_file_max_chars(8_000) == CONTEXT_FILE_MAX_CHARS
+
+    def test_dynamic_scales_above_floor_for_large_window(self):
+        # 200K-token window → ~48K (200000 * 4 * 0.06), well above the floor
+        # and above Codex's 32 KiB project_doc default.
+        cap = _dynamic_context_file_max_chars(200_000)
+        assert cap == 48_000
+        assert cap > CONTEXT_FILE_MAX_CHARS
+
+    def test_dynamic_respects_ceiling(self):
+        # An enormous window is clamped to the ceiling.
+        assert _dynamic_context_file_max_chars(100_000_000) == _CONTEXT_FILE_DYNAMIC_CEILING
+
+    def test_none_context_length_falls_back_to_flat_default(self):
+        assert _dynamic_context_file_max_chars(None) == CONTEXT_FILE_MAX_CHARS
+        assert _dynamic_context_file_max_chars(0) == CONTEXT_FILE_MAX_CHARS
+
+    def test_get_context_file_max_chars_uses_context_length(self):
+        # With no explicit config, the resolver derives the cap from context.
+        assert _get_context_file_max_chars(200_000) == 48_000
+        assert _get_context_file_max_chars(None) == CONTEXT_FILE_MAX_CHARS
+
+    def test_explicit_config_beats_dynamic(self, monkeypatch):
+        # An explicit value always wins, even when a big window is available.
+        monkeypatch.setattr(
+            "hermes_cli.config.load_config",
+            lambda: {"context_file_max_chars": 1_000},
+        )
+        assert _get_context_file_max_chars(200_000) == 1_000
+
+    def test_large_window_avoids_truncation_of_midsize_doc(self):
+        # A 30K-char AGENTS.md is truncated at the flat default but survives
+        # whole on a large-context model (dynamic cap ~48K).
+        content = "z" * 30_000
+        small = _truncate_content(content, "AGENTS.md", context_length=8_000)
+        big = _truncate_content(content, "AGENTS.md", context_length=200_000)
+        assert "truncated" in small.lower()
+        assert big == content
+
+    def test_marker_points_to_read_path(self):
+        content = "h" * 50_000
+        result = _truncate_content(
+            content, "AGENTS.md", context_length=8_000,
+            read_path="/proj/AGENTS.md",
+        )
+        assert "read_file" in result
+        assert "/proj/AGENTS.md" in result
+
+    def test_marker_defaults_to_filename_without_read_path(self):
+        result = _truncate_content("h" * 50_000, "AGENTS.md", context_length=8_000)
+        assert "read_file" in result
+        assert "AGENTS.md" in result
 
 
 # =========================================================================

--- a/tests/agent/test_system_prompt.py
+++ b/tests/agent/test_system_prompt.py
@@ -31,7 +31,7 @@ def _captured_context_cwd(agent):
     """The cwd build_system_prompt_parts hands to build_context_files_prompt."""
     captured = {}
 
-    def fake_context_files(cwd=None, skip_soul=False):
+    def fake_context_files(cwd=None, skip_soul=False, context_length=None):
         captured["cwd"] = cwd
         return ""
 


### PR DESCRIPTION
## Summary
Context files now scale their truncation cap to the model's context window instead of a flat 20K, and when truncation does happen the agent is told exactly which file to `read_file` for the rest.

The flat 20K cap on AGENTS.md / CLAUDE.md / .hermes.md / .cursorrules / SOUL.md predates large context windows and silently truncates real-world project docs. Among the harnesses we track, only Codex caps project docs at all (32 KiB); Claude Code, OpenCode, and Cline load them whole.

## Changes
- `agent/prompt_builder.py`: `_dynamic_context_file_max_chars()` — cap = `ctx_tokens × 4 × 0.06`, clamped to `[20K, 500K]`. `_get_context_file_max_chars()` resolution: explicit config → dynamic → 20K fallback. `context_length` + concrete `read_path` threaded through every loader into `_truncate_content`; truncation marker names the file and instructs `read_file`.
- `agent/system_prompt.py`: resolves `agent.context_compressor.context_length` once (stable for the conversation → prompt cache untouched) and passes it to the SOUL.md identity slot and the project-context slot.
- `hermes_cli/config.py`: default `context_file_max_chars` `20_000 → None` (dynamic by default; pin an integer to override).
- tests: 8 new cases (floor/scale/ceiling/None, explicit-override precedence, midsize-doc survival on large windows, read_file marker); updated one fixture signature.

## Behavior
| Model window | Cap | 60K AGENTS.md |
|---|---|---|
| 8K | 20K (floor) | truncated, marker → `read_file <path>` |
| 200K | 48K | truncated (>48K) |
| 400K | 96K | loaded whole |

Small-context models behave exactly as before. Explicit `context_file_max_chars` always wins. The system prompt stays byte-stable for the life of the conversation — caching invariant preserved.

## Validation
- 154 targeted tests + full `agent/` + `hermes_cli/` + `test_config` — 0 failures.
- E2E against a real 60K AGENTS.md in an isolated HERMES_HOME: small window truncates with the path-bearing marker, large window loads whole, byte-stable across repeat builds.

## Infographic

![dynamic-context-file-cap](https://v3b.fal.media/files/b/0a9ea813/QCIYsPbMm_H09cXeuprvW_tV9iSz1E.png)
