### PR TITLE
feat(gateway): make agent cache idle TTL configurable

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -716,6 +716,11 @@ agent:
   # window on /restart, and keep it well under systemd's TimeoutStopSec.
   # restart_drain_timeout: 0
 
+  # Idle TTL for cached gateway agents between messages (seconds).
+  # Increase for long-lived messaging threads; set to 0 to disable idle eviction.
+  # The hard cache size cap still applies.
+  # cache_idle_ttl_seconds: 3600
+
   # Max app-level retry attempts for API errors (connection drops, provider
   # timeouts, 5xx, etc.) before the agent surfaces the failure. Lower this
   # to 1 if you use fallback providers and want fast failover on flaky

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -30,6 +30,7 @@ import dataclasses
 import inspect
 import json
 import logging
+import math
 import os
 import re
 import shlex
@@ -56,7 +57,7 @@ from agent.account_usage import fetch_account_usage, render_account_usage_lines
 from agent.async_utils import consume_detached_task_result, safe_schedule_threadsafe
 from agent.conversation_loop import INTERRUPT_WAITING_FOR_MODEL_PREFIX
 from agent.i18n import t
-from hermes_cli.config import cfg_get
+from hermes_cli.config import cfg_get, load_config
 from hermes_cli.fallback_config import get_fallback_chain
 
 # --- Agent cache tuning ---------------------------------------------------
@@ -2001,6 +2002,57 @@ def _own_policy_open_startup_violation(config) -> Optional[str]:
     return None
 
 
+def _resolve_agent_cache_idle_ttl_secs(config: Optional[Dict[str, Any]] = None) -> float:
+    """Return the configured agent-cache idle TTL in seconds.
+
+    ``0`` disables idle eviction. Missing, negative, non-finite, or non-numeric
+    values keep the historical one-hour default so a bad config cannot
+    accidentally disable cache cleanup for long-lived gateways.
+    """
+    cfg = config
+    if cfg is None:
+        try:
+            cfg = load_config()
+        except Exception:
+            cfg = {}
+
+    raw = cfg_get(
+        cfg,
+        "agent",
+        "cache_idle_ttl_seconds",
+        default=_AGENT_CACHE_IDLE_TTL_SECS,
+    )
+    if raw is False:
+        return 0.0
+    if raw is True:
+        return _AGENT_CACHE_IDLE_TTL_SECS
+
+    try:
+        ttl = float(raw)
+    except (TypeError, ValueError):
+        logger.warning(
+            "Ignoring invalid agent.cache_idle_ttl_seconds=%r; using default %.0fs",
+            raw,
+            _AGENT_CACHE_IDLE_TTL_SECS,
+        )
+        return _AGENT_CACHE_IDLE_TTL_SECS
+    if not math.isfinite(ttl):
+        logger.warning(
+            "Ignoring non-finite agent.cache_idle_ttl_seconds=%r; using default %.0fs",
+            raw,
+            _AGENT_CACHE_IDLE_TTL_SECS,
+        )
+        return _AGENT_CACHE_IDLE_TTL_SECS
+    if ttl < 0:
+        logger.warning(
+            "Ignoring negative agent.cache_idle_ttl_seconds=%r; using default %.0fs",
+            raw,
+            _AGENT_CACHE_IDLE_TTL_SECS,
+        )
+        return _AGENT_CACHE_IDLE_TTL_SECS
+    return ttl
+
+
 # Sentinel placed into _running_agents immediately when a session starts
 # processing, *before* any await.  Prevents a second message for the same
 # session from bypassing the "already running" guard during the async gap
@@ -3102,6 +3154,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         self._busy_input_mode = self._load_busy_input_mode()
         self._busy_text_mode = self._load_busy_text_mode()
         self._restart_drain_timeout = self._load_restart_drain_timeout()
+        self._agent_cache_idle_ttl_secs = _resolve_agent_cache_idle_ttl_secs()
         self._provider_routing = self._load_provider_routing()
         self._fallback_model = self._load_fallback_model()
 
@@ -18251,7 +18304,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 ).start()
 
     def _sweep_idle_cached_agents(self) -> int:
-        """Evict cached agents whose AIAgent has been idle > _AGENT_CACHE_IDLE_TTL_SECS.
+        """Evict cached agents whose AIAgent has been idle past the configured TTL.
 
         Safe to call from the session expiry watcher without holding the
         cache lock — acquires it internally.  Returns the number of entries
@@ -18264,6 +18317,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         _cache = getattr(self, "_agent_cache", None)
         _lock = getattr(self, "_agent_cache_lock", None)
         if _cache is None or _lock is None:
+            return 0
+        idle_ttl_secs = float(
+            getattr(self, "_agent_cache_idle_ttl_secs", _AGENT_CACHE_IDLE_TTL_SECS)
+        )
+        if idle_ttl_secs <= 0:
             return 0
         now = time.time()
         to_evict: List[tuple] = []
@@ -18282,7 +18340,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 last_activity = getattr(agent, "_last_activity_ts", None)
                 if last_activity is None:
                     continue
-                if (now - last_activity) > _AGENT_CACHE_IDLE_TTL_SECS:
+                if (now - last_activity) > idle_ttl_secs:
                     # Check whether the session has actually expired in the
                     # session store.  If it hasn't (e.g. daily-reset mode
                     # where the reset fires hours after the user's last

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1031,6 +1031,9 @@ DEFAULT_CONFIG = {
         # Set a positive value in config.yaml only if you explicitly want a
         # grace window on /restart (and keep it well under TimeoutStopSec).
         "restart_drain_timeout": 0,
+        # Idle TTL for cached gateway agents between messages.  0 disables
+        # idle eviction; the hard cache size cap still applies.
+        "cache_idle_ttl_seconds": 3600,
         # Max app-level retry attempts for API errors (connection drops,
         # provider timeouts, 5xx, etc.) before the agent surfaces the
         # failure.  The OpenAI SDK already does its own low-level retries

--- a/tests/gateway/test_agent_cache.py
+++ b/tests/gateway/test_agent_cache.py
@@ -781,12 +781,71 @@ class TestAgentCacheBoundedGrowth:
         assert "stale" not in runner._agent_cache
         assert "fresh" in runner._agent_cache
 
+    def test_idle_ttl_sweep_can_be_disabled(self):
+        """agent.cache_idle_ttl_seconds=0 disables idle eviction."""
+        runner = self._bounded_runner()
+        runner._agent_cache_idle_ttl_secs = 0
+        runner._cleanup_agent_resources = MagicMock()
+
+        import time as _t
+        stale = self._fake_agent(last_activity=_t.time() - 10.0)
+        runner._agent_cache["stale"] = (stale, "sig")
+
+        assert runner._sweep_idle_cached_agents() == 0
+        assert "stale" in runner._agent_cache
+        runner._cleanup_agent_resources.assert_not_called()
+
+    def test_idle_ttl_sweep_uses_runner_configured_ttl(self):
+        """The runner's configured TTL controls stale cache eviction."""
+        runner = self._bounded_runner()
+        runner._agent_cache_idle_ttl_secs = 60.0
+        runner._cleanup_agent_resources = MagicMock()
+
+        import time as _t
+        fresh = self._fake_agent(last_activity=_t.time() - 30.0)
+        stale = self._fake_agent(last_activity=_t.time() - 90.0)
+        runner._agent_cache["fresh"] = (fresh, "s1")
+        runner._agent_cache["stale"] = (stale, "s2")
+
+        assert runner._sweep_idle_cached_agents() == 1
+        assert "fresh" in runner._agent_cache
+        assert "stale" not in runner._agent_cache
+
+    def test_agent_cache_idle_ttl_config_parser(self, monkeypatch):
+        """TTL config accepts 0/positive values and falls back on invalid input."""
+        from gateway import run as gw_run
+
+        assert gw_run._resolve_agent_cache_idle_ttl_secs({
+            "agent": {"cache_idle_ttl_seconds": 0}
+        }) == 0.0
+        assert gw_run._resolve_agent_cache_idle_ttl_secs({
+            "agent": {"cache_idle_ttl_seconds": "7200"}
+        }) == 7200.0
+        assert gw_run._resolve_agent_cache_idle_ttl_secs({
+            "agent": {"cache_idle_ttl_seconds": -1}
+        }) == gw_run._AGENT_CACHE_IDLE_TTL_SECS
+        assert gw_run._resolve_agent_cache_idle_ttl_secs({
+            "agent": {"cache_idle_ttl_seconds": "not-a-number"}
+        }) == gw_run._AGENT_CACHE_IDLE_TTL_SECS
+        for raw in ("nan", "NaN", "inf", "-inf", float("nan"), float("inf")):
+            assert gw_run._resolve_agent_cache_idle_ttl_secs({
+                "agent": {"cache_idle_ttl_seconds": raw}
+            }) == gw_run._AGENT_CACHE_IDLE_TTL_SECS
+
+        monkeypatch.setattr(
+            gw_run,
+            "load_config",
+            lambda: {"agent": {"cache_idle_ttl_seconds": 123}},
+        )
+        assert gw_run._resolve_agent_cache_idle_ttl_secs() == 123.0
+
     def test_idle_sweep_skips_agents_without_activity_ts(self, monkeypatch):
         """Agents missing _last_activity_ts are left alone (defensive)."""
         from gateway import run as gw_run
 
         monkeypatch.setattr(gw_run, "_AGENT_CACHE_IDLE_TTL_SECS", 0.01)
         runner = self._bounded_runner()
+        runner._agent_cache_idle_ttl_secs = 0.01
         runner._cleanup_agent_resources = MagicMock()
 
         no_ts = MagicMock(spec=[])  # no _last_activity_ts attribute
@@ -807,6 +866,7 @@ class TestAgentCacheBoundedGrowth:
 
         monkeypatch.setattr(gw_run, "_AGENT_CACHE_IDLE_TTL_SECS", 0.01)
         runner = self._bounded_runner()
+        runner._agent_cache_idle_ttl_secs = 0.01
         runner._cleanup_agent_resources = MagicMock()
 
         import time as _t
@@ -833,6 +893,7 @@ class TestAgentCacheBoundedGrowth:
 
         monkeypatch.setattr(gw_run, "_AGENT_CACHE_IDLE_TTL_SECS", 0.01)
         runner = self._bounded_runner()
+        runner._agent_cache_idle_ttl_secs = 0.01
         runner._cleanup_agent_resources = MagicMock()
 
         import time as _t

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -838,12 +838,15 @@ Instead, when the budget is actually exhausted (90/90), Hermes injects one messa
 ```yaml
 agent:
   max_turns: 90                # Max iterations per conversation turn (default: 90)
+  cache_idle_ttl_seconds: 3600 # Evict idle cached gateway agents after 1h; 0 disables idle eviction
   api_max_retries: 3           # Retries per provider before fallback engages (default: 3)
 ```
 
 When the iteration budget is fully exhausted, the CLI shows a notification to the user: `⚠ Iteration budget reached (90/90) — response may be incomplete`.
 
 `agent.api_max_retries` controls how many times Hermes retries a provider API call on transient errors (rate limits, connection drops, 5xx) **before** fallback-provider switching engages. The default is `3` — four attempts total. If you have [fallback providers](/user-guide/features/fallback-providers) configured and want to fail over faster, drop this to `0` so the first transient error on your primary immediately hands off to the fallback instead of churning retries against the flaky endpoint.
+
+`agent.cache_idle_ttl_seconds` controls how long gateway sessions keep an idle in-memory agent between messages. The default is `3600` seconds. Set it higher for long-lived messaging threads that should preserve conversation context across breaks, or set it to `0` to disable idle eviction entirely. The hard cache size cap still applies, so disabling idle TTL does not make the cache unbounded.
 
 ## Standing Goals (`/goal`)
 


### PR DESCRIPTION
## What does this PR do?

Adds `agent.cache_idle_ttl_seconds` so gateway users can tune how long idle in-memory agents remain cached between messages.

The default remains `3600` seconds, preserving the existing one-hour eviction behavior. Setting the value to `0` disables idle eviction for long-lived messaging threads, while the existing hard cache size cap still bounds growth.

This is related to, but not a duplicate of, #31856. That PR changes when the idle sweep may evict agents relative to session expiry. This PR adds an explicit user-facing TTL setting for deployments that need a different idle retention window.

Fixes #47730

## Related Issue

Fixes #47730

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [x] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Added `agent.cache_idle_ttl_seconds` to `DEFAULT_CONFIG`.
- Resolved the gateway agent-cache idle TTL from config at `GatewayRunner` startup.
- Treated `0`/`false` as idle eviction disabled while falling back to the historical default for invalid or negative values.
- Updated `cli-config.yaml.example` and `website/docs/user-guide/configuration.md`.
- Added agent-cache tests for disabled TTL, configured TTL, and invalid config fallback.

## How to Test

1. Set `agent.cache_idle_ttl_seconds: 0` and start the gateway. Idle cached agents are no longer evicted by the idle TTL sweep.
2. Set a positive value such as `agent.cache_idle_ttl_seconds: 7200` and restart the gateway. Idle eviction uses that configured TTL.
3. Leave the key unset. The gateway keeps the existing 3600-second behavior.

Validation run:

- DGX Spark Linux: `scripts/run_tests.sh tests/gateway/test_config_env_bridge_authority.py tests/gateway/test_agent_cache.py` -> 77 passed.
- DGX Spark Linux: `~/.hermes/hermes-agent/venv/bin/python -m ruff check gateway/run.py hermes_cli/config.py tests/gateway/test_agent_cache.py` -> passed.
- DGX Spark Linux: `git diff --check origin/main...fix/47730-agent-cache-idle-ttl` -> passed after rebase.
- Windows: `.\\.venv\\Scripts\\python -m pytest tests\\gateway\\test_agent_cache.py -q` -> 71 passed.
- Windows: `.\\.venv\\Scripts\\python -m ruff check gateway\\run.py hermes_cli\\config.py tests\\gateway\\test_agent_cache.py` -> passed.

Broader gateway sweep:

- `scripts/run_tests.sh tests/gateway` reached 6905 passed, 6 failed in `tests/gateway/test_matrix_voice.py`.
- The same Matrix voice failures reproduce on clean `origin/main`, so they are pre-existing and unrelated to this branch.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this feature
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows local and DGX Spark Linux

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

Not applicable. This is a gateway configuration behavior change covered by tests.
