### PR TITLE
feat(webhook): accept Standard Webhooks signatures

### DIFF
--- a/gateway/platforms/webhook.py
+++ b/gateway/platforms/webhook.py
@@ -662,7 +662,10 @@ class WebhookAdapter(BasePlatformAdapter):
             "X-GitHub-Delivery",
             request.headers.get(
                 "svix-id",
-                request.headers.get("X-Request-ID", str(int(time.time() * 1000))),
+                request.headers.get(
+                    "webhook-id",
+                    request.headers.get("X-Request-ID", str(int(time.time() * 1000))),
+                ),
             ),
         )
 
@@ -903,15 +906,17 @@ class WebhookAdapter(BasePlatformAdapter):
                 or request.headers.get(name.upper(), "")
             )
 
-        # Svix / AgentMail:
+        # Svix / AgentMail / Standard Webhooks:
         #   svix-id: msg_...
         #   svix-timestamp: unix seconds
         #   svix-signature: v1,<base64-hmac> [v1,<base64-hmac> ...]
+        # Standard Webhooks providers such as GitLab use the same signed
+        # content and v1 signature format with webhook-* header names.
         # Signed content is: "{id}.{timestamp}.{raw_body}".  Svix secrets
         # usually start with "whsec_" and the remainder is base64-encoded.
-        svix_id = _header("svix-id")
-        svix_timestamp = _header("svix-timestamp")
-        svix_signature = _header("svix-signature")
+        svix_id = _header("svix-id") or _header("webhook-id")
+        svix_timestamp = _header("svix-timestamp") or _header("webhook-timestamp")
+        svix_signature = _header("svix-signature") or _header("webhook-signature")
         if svix_id or svix_timestamp or svix_signature:
             return self._validate_svix_signature(
                 body=body,

--- a/tests/gateway/test_webhook_adapter.py
+++ b/tests/gateway/test_webhook_adapter.py
@@ -121,6 +121,15 @@ def _svix_signature(body: bytes, secret: str, msg_id: str, timestamp: str) -> st
     return "v1," + base64.b64encode(digest).decode()
 
 
+def _standard_webhook_signature(
+    body: bytes, secret: str, webhook_id: str, timestamp: str
+) -> str:
+    """Compute a Standard Webhooks v1 signature header for *body*."""
+    signed = webhook_id.encode() + b"." + timestamp.encode() + b"." + body
+    digest = hmac.new(secret.encode(), signed, hashlib.sha256).digest()
+    return "v1," + base64.b64encode(digest).decode()
+
+
 # ===================================================================
 # Signature validation
 # ===================================================================
@@ -355,6 +364,43 @@ class TestValidateSignature:
                 "svix-id": msg_id,
                 "svix-timestamp": timestamp,
                 "svix-signature": sig,
+            }
+        )
+        assert adapter._validate_signature(req, received_body, secret) is False
+
+    def test_validate_standard_webhooks_signature_valid(self):
+        """Valid Standard Webhooks headers are accepted."""
+        adapter = _make_adapter()
+        body = b'{"object_kind":"push"}'
+        secret = "gitlab-signing-secret"
+        webhook_id = "msg_gitlab_123"
+        timestamp = str(int(time.time()))
+        sig = _standard_webhook_signature(body, secret, webhook_id, timestamp)
+        req = _mock_request(
+            headers={
+                "webhook-id": webhook_id,
+                "webhook-timestamp": timestamp,
+                "webhook-signature": sig,
+            }
+        )
+        assert adapter._validate_signature(req, body, secret) is True
+
+    def test_validate_standard_webhooks_signature_wrong_body_rejects(self):
+        """Standard Webhooks signatures are bound to the exact raw body."""
+        adapter = _make_adapter()
+        signed_body = b'{"object_kind":"push"}'
+        received_body = b'{"object_kind":"merge_request"}'
+        secret = "gitlab-signing-secret"
+        webhook_id = "msg_gitlab_123"
+        timestamp = str(int(time.time()))
+        sig = _standard_webhook_signature(
+            signed_body, secret, webhook_id, timestamp
+        )
+        req = _mock_request(
+            headers={
+                "webhook-id": webhook_id,
+                "webhook-timestamp": timestamp,
+                "webhook-signature": sig,
             }
         )
         assert adapter._validate_signature(req, received_body, secret) is False
@@ -1048,6 +1094,25 @@ class TestIdempotency:
             data = await resp2.json()
             assert data["status"] == "duplicate"
             assert data["delivery_id"] == "msg_duplicate"
+
+    @pytest.mark.asyncio
+    async def test_webhook_id_used_as_delivery_id_for_deduplication(self):
+        """Standard Webhooks retries reuse webhook-id, so use it for dedupe."""
+        routes = {"idem": {"secret": _INSECURE_NO_AUTH, "prompt": "test"}}
+        adapter = _make_adapter(routes=routes)
+        adapter.handle_message = AsyncMock()
+
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            headers = {"webhook-id": "msg_standard_duplicate"}
+            resp1 = await cli.post("/webhooks/idem", json={"a": 1}, headers=headers)
+            assert resp1.status == 202
+
+            resp2 = await cli.post("/webhooks/idem", json={"a": 1}, headers=headers)
+            assert resp2.status == 200
+            data = await resp2.json()
+            assert data["status"] == "duplicate"
+            assert data["delivery_id"] == "msg_standard_duplicate"
 
 
 # ===================================================================

--- a/website/docs/user-guide/messaging/webhooks.md
+++ b/website/docs/user-guide/messaging/webhooks.md
@@ -455,6 +455,7 @@ The adapter validates incoming webhook signatures using the appropriate method f
 
 - **GitHub**: `X-Hub-Signature-256` header — HMAC-SHA256 hex digest prefixed with `sha256=`
 - **GitLab**: `X-Gitlab-Token` header — plain secret string match
+- **Standard Webhooks**: `webhook-id`, `webhook-timestamp`, and `webhook-signature` headers — signed content is `{id}.{timestamp}.{raw_body}` with a `v1,<base64-hmac-sha256>` signature
 - **Generic (V2, recommended)**: `X-Webhook-Signature-V2` + `X-Webhook-Timestamp` headers — HMAC-SHA256 hex digest of `<timestamp>.<body>`. The timestamp (Unix seconds) must be within ±300 seconds of the server clock, which prevents captured requests from being replayed later.
 - **Generic (V1, legacy)**: `X-Webhook-Signature` header — raw HMAC-SHA256 hex digest of the body only. Still accepted for backward compatibility, but it has no replay protection (a captured request replays indefinitely); the gateway logs a deprecation warning once per route. Switch senders to V2.
 
@@ -481,7 +482,7 @@ Requests exceeding the limit receive a `429 Too Many Requests` response.
 
 ### Idempotency
 
-Delivery IDs (from `X-GitHub-Delivery`, `X-Request-ID`, or a timestamp fallback) are cached for **1 hour**. Duplicate deliveries (e.g. webhook retries) are silently skipped with a `200` response, preventing duplicate agent runs.
+Delivery IDs (from `X-GitHub-Delivery`, `svix-id`, `webhook-id`, `X-Request-ID`, or a timestamp fallback) are cached for **1 hour**. Duplicate deliveries (e.g. webhook retries) are silently skipped with a `200` response, preventing duplicate agent runs.
 
 ### Body size limits
 
@@ -540,7 +541,7 @@ This is the same trust model that applies to everything the agent reads: web pag
 
 ### Duplicate responses
 
-- The idempotency cache should prevent this — check that the webhook source is sending a delivery ID header (`X-GitHub-Delivery` or `X-Request-ID`)
+- The idempotency cache should prevent this — check that the webhook source is sending a delivery ID header (`X-GitHub-Delivery`, `svix-id`, `webhook-id`, or `X-Request-ID`)
 - Delivery IDs are cached for 1 hour
 
 ### `gh` CLI errors (GitHub comment delivery)


### PR DESCRIPTION
## What does this PR do?

Adds Standard Webhooks header support to the generic webhook adapter so providers such as GitLab can authenticate with `webhook-id`, `webhook-timestamp`, and `webhook-signature`.

This reuses the existing Svix-compatible validator because the signed content and `v1,<base64-hmac-sha256>` format are the same: `{id}.{timestamp}.{raw_body}`. It also uses `webhook-id` as the delivery ID fallback so retries dedupe correctly.

Existing GitHub `X-Hub-Signature-256`, GitLab `X-Gitlab-Token`, Svix, and generic `X-Webhook-Signature` paths are preserved for requests that do not send Standard Webhooks headers. Requests that do send `webhook-id` are treated as Standard Webhooks requests and fail closed unless the required Standard Webhooks fields validate.

Fixes #47451

## Related Issue

Fixes #47451

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [x] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Accepted `webhook-id` as an alias for `svix-id`.
- Accepted `webhook-timestamp` as an alias for `svix-timestamp`.
- Accepted `webhook-signature` as an alias for `svix-signature`.
- Used `webhook-id` as the webhook delivery ID fallback for idempotency.
- Added tests for valid Standard Webhooks signatures, raw-body mismatch rejection, and `webhook-id` deduplication.
- Updated webhook security documentation.

## How to Test

1. Configure a webhook route with a shared secret.
2. Send a POST with `webhook-id`, `webhook-timestamp`, and `webhook-signature`.
3. The signature should validate when it signs `{id}.{timestamp}.{raw_body}` with HMAC-SHA256 and the route secret.
4. Reusing the same `webhook-id` should return the duplicate response on retry.

Validation run:

- DGX Spark Linux: `scripts/run_tests.sh tests/gateway/test_webhook_adapter.py tests/gateway/test_webhook_signature_rate_limit.py tests/gateway/test_webhook_integration.py` -> 78 passed.
- DGX Spark Linux: `~/.hermes/hermes-agent/venv/bin/python -m ruff check gateway/platforms/webhook.py tests/gateway/test_webhook_adapter.py` -> passed.
- DGX Spark Linux: `git diff --check origin/main...fix/47451-standard-webhook-signature` -> passed after rebase.
- Windows: `.\\.venv\\Scripts\\python -m pytest tests\\gateway\\test_webhook_adapter.py tests\\gateway\\test_webhook_signature_rate_limit.py tests\\gateway\\test_webhook_integration.py -q` -> 78 passed.
- Windows: `.\\.venv\\Scripts\\python -m ruff check gateway\\platforms\\webhook.py tests\\gateway\\test_webhook_adapter.py` -> passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this feature
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows local and DGX Spark Linux

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

Not applicable. This is a webhook signature validation change covered by tests.
