### PR TITLE
docs(providers): clarify vllm qwen reasoning output

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -483,6 +483,10 @@ prompt_caching:
 #                           # reasoning controls:
 #                           # extra_body:
 #                           #   enable_thinking: false
+#                           # Some vLLM/Qwen deployments expect this nested:
+#                           # extra_body:
+#                           #   chat_template_kwargs:
+#                           #     enable_thinking: false
 
 # =============================================================================
 # Persistent Memory

--- a/website/docs/integrations/providers.md
+++ b/website/docs/integrations/providers.md
@@ -792,6 +792,8 @@ hermes model
 
 Supported parsers: `hermes` (Qwen 2.5, Hermes 2/3), `llama3_json` (Llama 3.x), `mistral`, `deepseek_v3`, `deepseek_v31`, `xlam`, `pythonic`. Without these flags, tool calls won't work — the model will output tool calls as text.
 
+**Qwen reasoning parsers:** Hermes preserves structured reasoning metadata such as `reasoning`, `reasoning_content`, and streamed reasoning deltas when OpenAI-compatible servers return them. That metadata is treated as reasoning/thinking trace data, not as a replacement for the assistant's visible answer. For Qwen reasoning models served by vLLM, make sure the final user-visible response still appears in `content`. If `--reasoning-parser qwen3` leaves `content` empty in your deployment, either disable that parser or pass a server-supported request option such as `chat_template_kwargs.enable_thinking: false` through `extra_body`.
+
 :::tip
 vLLM supports human-readable sizes: `--max-model-len 64k` (lowercase k = 1000, uppercase K = 1024).
 :::
@@ -1270,6 +1272,14 @@ Use the shape your server documents. For example, vLLM Gemma deployments and som
 extra_body:
   chat_template_kwargs:
     enable_thinking: true
+```
+
+For Qwen reasoning models served by vLLM, this same shape can be used to disable thinking when a reasoning parser separates all generated text into reasoning fields and leaves the assistant `content` empty:
+
+```yaml
+extra_body:
+  chat_template_kwargs:
+    enable_thinking: false
 ```
 
 The `hermes model` → Custom Endpoint wizard now prompts for `api_mode` explicitly and persists your answer to `config.yaml`. URL-based auto-detection (e.g. `/anthropic` paths → `anthropic_messages`) still happens as a fallback when the field is left blank.


### PR DESCRIPTION
## What does this PR do?

This PR documents the expected behavior for Qwen reasoning models served through OpenAI-compatible vLLM endpoints.

Hermes can preserve structured reasoning metadata such as `reasoning`, `reasoning_content`, and streamed reasoning deltas, but that metadata is treated as reasoning/thinking trace data. The assistant's user-visible answer should still be emitted in `content`.

For vLLM/Qwen deployments where `--reasoning-parser qwen3` leaves `content` empty, the docs now point users to two stable options:

- disable the reasoning parser for that deployment, or
- pass a server-supported request option such as `chat_template_kwargs.enable_thinking: false` through `extra_body`.

## Related Issue

Fixes #38360

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [x] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `website/docs/integrations/providers.md`
  - Clarifies how Hermes treats Qwen/vLLM reasoning-parser output.
  - Adds the `extra_body.chat_template_kwargs.enable_thinking: false` workaround for deployments that separate all generated text into reasoning fields.
- `cli-config.yaml.example`
  - Adds the nested vLLM/Qwen `extra_body` shape to the auxiliary-model comment example.

## How to Test

1. Read the vLLM provider section in `website/docs/integrations/providers.md`.
2. Confirm it explains that separated reasoning metadata is not a replacement for visible `content`.
3. Confirm the custom-provider `extra_body` section shows the nested `chat_template_kwargs.enable_thinking: false` shape.

Validation run:

- Local Windows:
  - `git diff --check`
- DGX Spark Linux:
  - `git diff --check`
  - `cd website && npm ci && npm run build`

Results:

- Diff check: passed
- Docusaurus build: passed
- Note: the docs build still reports existing broken link/anchor warnings elsewhere in the site; the build exits successfully and this PR does not add new links.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11 local diff check and DGX Spark Linux docs build

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — yes
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — comment-only example update
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — N/A, docs-only
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## For New Skills

N/A

## Screenshots / Logs

DGX Spark docs build:

```text
[SUCCESS] Generated static files in "build".
[SUCCESS] Generated static files in "build/zh-Hans".
```
