### PR TITLE
fix(compose): replace literal ~/.hermes bind mount with explicit HERMES_DATA_DIR

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,8 +4,10 @@
 # Usage:
 #   HERMES_UID=$(id -u) HERMES_GID=$(id -g) docker compose up -d
 #
-# Set HERMES_UID / HERMES_GID to the host user that owns ~/.hermes so
-# files created inside the container stay readable/writable on the host.
+# Set HERMES_UID / HERMES_GID to the host user that owns the data
+# directory (defaults to ${HOME}/.hermes) so files created inside the
+# container stay readable/writable on the host. Override the path with
+# HERMES_DATA_DIR=/custom/path if ${HOME}/.hermes is not what you want.
 # The s6-overlay stage2 hook remaps the internal `hermes` user to these
 # values via usermod/groupmod; each supervised service then drops to that
 # user via `s6-setuidgid`.
@@ -34,7 +36,7 @@ services:
     restart: unless-stopped
     network_mode: host
     volumes:
-      - ~/.hermes:/opt/data
+      - ${HERMES_DATA_DIR:-${HOME}/.hermes}:/opt/data
     environment:
       - HERMES_UID=${HERMES_UID:-10000}
       - HERMES_GID=${HERMES_GID:-10000}
@@ -52,7 +54,7 @@ services:
       # Google Chat — uncomment and fill in to enable the Google Chat gateway.
       # See website/docs/user-guide/messaging/google_chat.md for the full setup.
       # The SA JSON path must point to a file mounted into the container —
-      # add a volume entry above (e.g. ``- ~/.hermes/google-chat-sa.json:/secrets/google-chat-sa.json:ro``)
+      # add a volume entry above (e.g. ``- ${HERMES_DATA_DIR:-${HOME}/.hermes}/google-chat-sa.json:/secrets/google-chat-sa.json:ro``)
       # then set GOOGLE_CHAT_SERVICE_ACCOUNT_JSON to that mount path.
       # - GOOGLE_CHAT_PROJECT_ID=${GOOGLE_CHAT_PROJECT_ID}
       # - GOOGLE_CHAT_SUBSCRIPTION_NAME=${GOOGLE_CHAT_SUBSCRIPTION_NAME}
@@ -68,7 +70,7 @@ services:
     depends_on:
       - gateway
     volumes:
-      - ~/.hermes:/opt/data
+      - ${HERMES_DATA_DIR:-${HOME}/.hermes}:/opt/data
     environment:
       - HERMES_UID=${HERMES_UID:-10000}
       - HERMES_GID=${HERMES_GID:-10000}


### PR DESCRIPTION
## What does this PR do?

Fix `docker-compose.yml` so the gateway and dashboard bind-mount the user's actual `~/.hermes` directory instead of docker daemon's `/root/.hermes`.

The compose template currently uses a literal `~/.hermes:/opt/data` source path. Docker compose does not perform shell-style tilde expansion, so the docker daemon (running as root on most hosts) interprets the string as a literal path and bind-mounts `/root/.hermes` on the host — which is empty on a typical Linux install. The container then starts cleanly with an empty `/opt/data`: no `auth.json`, no `state.db`, no history.

This bit me when running `docker compose up -d` as a non-root user with data at `/home/admin/.hermes`: the new container silently got an empty `/opt/data`, lost access to 120MB of session history, and the dashboard reported a "fresh install" state. The fix is to use `${HERMES_DATA_DIR:-${HOME}/.hermes}` so `${HOME}` (read from the invoking shell) resolves to the right path, with an explicit `HERMES_DATA_DIR` override for users with custom layouts.

## Related Issue

- Symptom description in commit body
- Cross-references: see `project-hermes-bind-mount.md` in the operator's runbook

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `docker-compose.yml`
  - gateway `volumes`: `- ~/.hermes:/opt/data` → `- ${HERMES_DATA_DIR:-${HOME}/.hermes}:/opt/data`
  - dashboard `volumes`: same change
  - inline google-chat SA-JSON example: updated to match
  - header comment: documents the `HERMES_DATA_DIR` override

- No code or schema changes — only docker-compose template.

## Reproduction

On a host where the user data lives at `/home/admin/.hermes`:

```bash
docker compose up -d
docker exec hermes sh -c 'ls /opt/data/auth.json'
# ls: cannot access '/opt/data/auth.json': No such file or directory
docker exec hermes sh -c 'ls -la /opt/data | head'
# drwxr-xr-x ... (empty /opt/data, freshly created from /root/.hermes)
```

After applying this patch and re-running:

```bash
docker compose up -d
docker exec hermes sh -c 'ls /opt/data/auth.json /opt/data/state.db'
# /opt/data/auth.json
# /opt/data/state.db
```

## Test plan

- [x] `docker compose -f docker-compose.yml config --services` parses cleanly on Linux
- [x] Source path resolves to `$HOME/.hermes` (verified on `/root` host → `/root/.hermes`)
- [x] Manual override: `HERMES_DATA_DIR=/custom/path docker compose config` shows `/custom/path`
- [x] Existing user with `/home/admin/.hermes` runs `docker compose up -d` (HOME=/home/admin) → bind mount lands on the correct directory, no data loss
- [x] Windows compose file (`docker-compose.windows.yml`) unaffected — still uses `${USERPROFILE}/.hermes`

## Documentation & Housekeeping

- [x] I've updated relevant documentation — header comment in docker-compose.yml now explains the override
- [x] I've considered cross-platform impact (Windows, macOS) — Windows compose uses `${USERPROFILE}` and is untouched; macOS hosts work the same as Linux (both set `${HOME}` correctly)
- [x] No new config keys, no CLI changes, no test additions needed (compose-template-only change)

## Screenshots / Logs

Before (current upstream behavior on a host with data at `/home/admin/.hermes`):

```
$ docker exec hermes sh -c 'ls /opt/data/auth.json /opt/data/state.db'
ls: cannot access '/opt/data/auth.json': No such file or directory
ls: cannot access '/opt/data/state.db': No such file or directory

$ docker inspect hermes --format '{{ .Mounts }}'
[{bind /root/.hermes /opt/data ...}]
```

After:

```
$ docker exec hermes sh -c 'ls /opt/data/auth.json /opt/data/state.db'
/opt/data/auth.json
/opt/data/state.db

$ docker inspect hermes --format '{{ .Mounts }}'
[{bind /home/admin/.hermes /opt/data ...}]
```