### PR TITLE
fix(anthropic): salvage tool calls from text blocks when tool_use blocks missing

### DIFF
--- a/agent/transports/anthropic.py
+++ b/agent/transports/anthropic.py
@@ -4,10 +4,11 @@ Delegates to the existing adapter functions in agent/anthropic_adapter.py.
 This transport owns format conversion and normalization — NOT client lifecycle.
 """
 
+import re
 from typing import Any, Dict, List, Optional
 
 from agent.transports.base import ProviderTransport
-from agent.transports.types import NormalizedResponse
+from agent.transports.types import NormalizedResponse, ToolCall
 
 
 class AnthropicTransport(ProviderTransport):
@@ -16,6 +17,14 @@ class AnthropicTransport(ProviderTransport):
     Wraps the existing functions in anthropic_adapter.py behind the
     ProviderTransport ABC.  Each method delegates — no logic is duplicated.
     """
+
+    # Regex to match complete <invoke> blocks in text content.
+    # Matches: <invoke name="tool_name"><![CDATA[{"param": "value"}]]></invoke>
+    # The CDATA section is optional but commonly used by Anthropic.
+    _INVOKE_RE = re.compile(
+        r'<invoke\s+name="([^"]+)">(?:<!\[CDATA\[)?(.*?)(?:\]\]>)?</invoke>',
+        re.DOTALL
+    )
 
     @property
     def api_mode(self) -> str:
@@ -131,6 +140,20 @@ class AnthropicTransport(ProviderTransport):
         if reasoning_details:
             provider_data["reasoning_details"] = reasoning_details
 
+        # Salvage tool calls from text blocks if no structured tool_use blocks found
+        if not tool_calls:
+            joined_text = "\n".join(text_parts)
+            tool_calls = self._salvage_text_tool_calls(joined_text)
+            # If we salvaged tool calls, update finish_reason and clean text content
+            if tool_calls:
+                finish_reason = "tool_calls"
+                # Remove the invoke markup from text content
+                text_parts = [self._INVOKE_RE.sub("", t) for t in text_parts]
+
+        provider_data = {}
+        if reasoning_details:
+            provider_data["reasoning_details"] = reasoning_details
+
         return NormalizedResponse(
             content="\n".join(text_parts) if text_parts else None,
             tool_calls=tool_calls or None,
@@ -139,6 +162,35 @@ class AnthropicTransport(ProviderTransport):
             usage=None,
             provider_data=provider_data or None,
         )
+
+    @staticmethod
+    def _salvage_text_tool_calls(text: str) -> list:
+        """Recover tool calls emitted as text instead of tool_use blocks.
+
+        Safety properties:
+        - Only called when no structured tool_calls are present
+        - Only salvages complete blocks (requires closing </invoke> tag)
+        - Validates JSON parameters
+        - Returns empty list if no valid invoke blocks found
+        """
+        import json
+        from agent.transports.types import ToolCall
+
+        calls = []
+        for match in AnthropicTransport._INVOKE_RE.finditer(text):
+            name = match.group(1)
+            try:
+                # Validate that parameters are valid JSON
+                args = json.loads(match.group(2).strip())
+                calls.append(ToolCall(
+                    id=f"salvaged_{len(calls)}",
+                    name=name,
+                    arguments=json.dumps(args)
+                ))
+            except (json.JSONDecodeError, ValueError):
+                # Skip invalid JSON - don't execute malformed tool calls
+                continue
+        return calls
 
     def validate_response(self, response: Any) -> bool:
         """Check Anthropic response structure is valid.

--- a/tests/agent/transports/test_transport.py
+++ b/tests/agent/transports/test_transport.py
@@ -9,7 +9,7 @@ from agent.transports.types import NormalizedResponse, ToolCall, Usage
 from agent.transports import get_transport, register_transport, _REGISTRY
 
 
-# ── ABC contract tests ──────────────────────────────────────────────────
+# ── ABC contract tests ──────────────────────────────────────────────
 
 class TestProviderTransportABC:
     """Verify the ABC contract is enforceable."""
@@ -47,7 +47,7 @@ class TestProviderTransportABC:
         assert t.map_finish_reason("end_turn") == "end_turn"  # default passthrough
 
 
-# ── Registry tests ───────────────────────────────────────────────────────
+# ── Registry tests ────────────────────────────────────────────────
 
 class TestTransportRegistry:
 
@@ -88,7 +88,7 @@ class TestTransportRegistry:
         _REGISTRY.pop("dummy_test", None)
 
 
-# ── AnthropicTransport tests ────────────────────────────────────────────
+# ── AnthropicTransport tests ────────────────────────────────────────
 
 class TestAnthropicTransport:
 
@@ -107,7 +107,7 @@ class TestAnthropicTransport:
                 "name": "test_tool",
                 "description": "A test",
                 "parameters": {"type": "object", "properties": {}},
-            }
+            },
         }]
         result = transport.convert_tools(tools)
         assert len(result) == 1
@@ -233,3 +233,140 @@ class TestAnthropicTransport:
         assert system is not None
         # Messages should only have user
         assert len(msgs) >= 1
+
+    def test_normalize_response_text_with_invoke_salvage(self, transport):
+        """Test salvage of tool calls from text blocks when no tool_use blocks present."""
+        # Simulate Anthropic response where tool call is in text block as <invoke> markup
+        r = SimpleNamespace(
+            content=[
+                SimpleNamespace(
+                    type="text",
+                    text='I will now run the ls command:<invoke name="terminal"><![CDATA[{"command": "ls -la"}]]></invoke>'
+                ),
+            ],
+            stop_reason="end_turn",
+            usage=SimpleNamespace(input_tokens=10, output_tokens=20),
+            model="claude-sonnet-4-6",
+        )
+        nr = transport.normalize_response(r)
+        
+        # Should have salvaged the tool call from text
+        assert nr.finish_reason == "tool_calls"
+        assert nr.tool_calls is not None
+        assert len(nr.tool_calls) == 1
+        tc = nr.tool_calls[0]
+        assert tc.name == "terminal"
+        # Arguments should be valid JSON
+        assert '"command"' in tc.arguments
+        assert '"ls -la"' in tc.arguments
+        # Text content should be cleaned (invoke markup removed)
+        assert nr.content == "I will now run the ls command:"
+
+    def test_normalize_response_text_with_multiple_invoke_salvage(self, transport):
+        """Test salvage of multiple tool calls from text blocks."""
+        r = SimpleNamespace(
+            content=[
+                SimpleNamespace(
+                    type="text",
+                    text='First:<invoke name="terminal"><![CDATA[{"command": "ls"}]]></invoke> Then:<invoke name="read_file"><![CDATA[{"path": "/etc/passwd"}]]></invoke>'
+                ),
+            ],
+            stop_reason="end_turn",
+            usage=SimpleNamespace(input_tokens=10, output_tokens=30),
+            model="claude-sonnet-4-6",
+        )
+        nr = transport.normalize_response(r)
+        
+        # Should have salvaged both tool calls
+        assert nr.finish_reason == "tool_calls"
+        assert nr.tool_calls is not None
+        assert len(nr.tool_calls) == 2
+        
+        # First tool call
+        tc1 = nr.tool_calls[0]
+        assert tc1.name == "terminal"
+        assert '"command"' in tc1.arguments
+        assert '"ls"' in tc1.arguments
+        
+        # Second tool call
+        tc2 = nr.tool_calls[1]
+        assert tc2.name == "read_file"
+        assert '"path"' in tc2.arguments
+        assert '"/etc/passwd"' in tc2.arguments
+        
+        # Text content should be cleaned
+        assert nr.content == "First: Then:"
+
+    def test_normalize_response_text_with_invalid_invoke_no_salvage(self, transport):
+        """Test that invalid JSON in invoke block does not create tool calls."""
+        r = SimpleNamespace(
+            content=[
+                SimpleNamespace(
+                    type="text",
+                    text='Running command:<invoke name="terminal"><![CDATA[{invalid json: }]]></invoke>'
+                ),
+            ],
+            stop_reason="end_turn",
+            usage=SimpleNamespace(input_tokens=10, output_tokens=10),
+            model="claude-sonnet-4-6",
+        )
+        nr = transport.normalize_response(r)
+        
+        # Should NOT have salvaged tool call due to invalid JSON
+        assert nr.finish_reason == "stop"
+        assert nr.tool_calls is None or len(nr.tool_calls) == 0
+        # Text content should remain unchanged (no valid invoke blocks to remove)
+        assert nr.content == 'Running command:<invoke name="terminal"><![CDATA[{invalid json: }]]></invoke>'
+
+    def test_normalize_response_text_with_incomplete_invoke_no_salvage(self, transport):
+        """Test that incomplete invoke block (missing closing tag) does not create tool calls."""
+        r = SimpleNamespace(
+            content=[
+                SimpleNamespace(
+                    type="text",
+                    text='Running command:<invoke name="terminal"><![CDATA[{"command": "ls"}]]'
+                ),
+            ],
+            stop_reason="end_turn",
+            usage=SimpleNamespace(input_tokens=10, output_tokens=10),
+            model="claude-sonnet-4-6",
+        )
+        nr = transport.normalize_response(r)
+        
+        # Should NOT have salvaged tool call due to missing closing tag
+        assert nr.finish_reason == "stop"
+        assert nr.tool_calls is None or len(nr.tool_calls) == 0
+        # Text content should remain unchanged
+        assert nr.content == 'Running command:<invoke name="terminal"><![CDATA[{"command": "ls"}]]'
+
+    def test_normalize_response_prefers_tool_use_over_text(self, transport):
+        """Test that when both tool_use and text blocks with invoke are present, tool_use wins."""
+        r = SimpleNamespace(
+            content=[
+                SimpleNamespace(
+                    type="tool_use",
+                    id="toolu_123",
+                    name="terminal",
+                    input={"command": "ls -l"},
+                ),
+                SimpleNamespace(
+                    type="text",
+                    text='Alternative:<invoke name="read_file"><![CDATA[{"path": "/tmp/test"}]]></invoke>'
+                ),
+            ],
+            stop_reason="tool_use",
+            usage=SimpleNamespace(input_tokens=10, output_tokens=20),
+            model="claude-sonnet-4-6",
+        )
+        nr = transport.normalize_response(r)
+        
+        # Should use the structured tool_use block, not salvage from text
+        assert nr.finish_reason == "tool_calls"
+        assert len(nr.tool_calls) == 1
+        tc = nr.tool_calls[0]
+        assert tc.name == "terminal"
+        assert tc.id == "toolu_123"
+        assert '"command"' in tc.arguments
+        assert '"ls -l"' in tc.arguments
+        # Text content should be preserved (including the invoke markup since we didn't salvage)
+        assert nr.content == 'Alternative:<invoke name="read_file"><![CDATA[{"path": "/tmp/test"}]]></invoke>'


### PR DESCRIPTION
## Summary

When the Anthropic API returns tool calls as plain text markup (in `<invoke>` blocks) instead of structured `tool_use` blocks, the agent loop would halt without executing the tool. This adds a defensive salvage path in `normalize_response()` that:

- Only runs when no structured `tool_calls` are present
- Requires complete `<invoke>...</invoke>` blocks with closing tags
- Validates JSON parameters before creating `ToolCall` objects
- Strips the invoke markup from the text content
- Follows the same pattern as the existing VolcEngine fix

## Changes

- `agent/transports/anthropic.py`: Added `_INVOKE_RE` regex, `_salvage_text_tool_calls()` static method, and salvage logic in `normalize_response()`
- `tests/agent/transports/test_transport.py`: Added 5 comprehensive tests covering:
  - Single tool call salvage
  - Multiple tool calls in one text block
  - Invalid JSON in invoke block (skipped)
  - Incomplete invoke block without closing tag (skipped)
  - Structured tool_use takes precedence over text salvage

## Testing

All 28 transport tests pass, including the 5 new tests.

Fixes #47472