### PR TITLE
fix(windows): prefer Git Bash before PATH bash

### DIFF
--- a/tests/tools/test_local_find_bash.py
+++ b/tests/tools/test_local_find_bash.py
@@ -1,0 +1,50 @@
+import os
+
+from tools.environments import local
+
+
+def _windows_bash_env(monkeypatch, existing_paths, path_bash=None):
+    monkeypatch.setattr(local, "_IS_WINDOWS", True)
+    monkeypatch.delenv("HERMES_GIT_BASH_PATH", raising=False)
+    monkeypatch.setenv("LOCALAPPDATA", "/local")
+    monkeypatch.setenv("ProgramFiles", "/pf")
+    monkeypatch.setenv("ProgramFiles(x86)", "/pf86")
+    monkeypatch.setattr(local.os.path, "isfile", lambda path: path in existing_paths)
+    monkeypatch.setattr(local.shutil, "which", lambda name: path_bash if name == "bash" else None)
+
+
+def test_find_bash_prefers_system_git_for_windows_before_path_wsl(monkeypatch):
+    system_git = os.path.join("/pf", "Git", "bin", "bash.exe")
+    wsl_bash = os.path.join("/windows", "system32", "bash.exe")
+
+    _windows_bash_env(monkeypatch, {system_git}, path_bash=wsl_bash)
+
+    assert local._find_bash() == system_git
+
+
+def test_find_bash_keeps_explicit_env_override_first(monkeypatch):
+    custom = os.path.join("/custom", "bash.exe")
+    portable_git = os.path.join("/local", "hermes", "git", "bin", "bash.exe")
+    system_git = os.path.join("/pf", "Git", "bin", "bash.exe")
+
+    _windows_bash_env(monkeypatch, {custom, portable_git, system_git}, path_bash="/windows/system32/bash.exe")
+    monkeypatch.setenv("HERMES_GIT_BASH_PATH", custom)
+
+    assert local._find_bash() == custom
+
+
+def test_find_bash_keeps_hermes_portable_git_before_system_git(monkeypatch):
+    portable_git = os.path.join("/local", "hermes", "git", "bin", "bash.exe")
+    system_git = os.path.join("/pf", "Git", "bin", "bash.exe")
+
+    _windows_bash_env(monkeypatch, {portable_git, system_git}, path_bash="/windows/system32/bash.exe")
+
+    assert local._find_bash() == portable_git
+
+
+def test_find_bash_uses_path_bash_as_last_resort(monkeypatch):
+    path_bash = os.path.join("/other", "bash.exe")
+
+    _windows_bash_env(monkeypatch, set(), path_bash=path_bash)
+
+    assert local._find_bash() == path_bash

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -267,10 +267,9 @@ def _find_bash() -> str:
             if os.path.isfile(candidate):
                 return candidate
 
-    found = shutil.which("bash")
-    if found:
-        return found
-
+    # Prefer known Git-for-Windows installs before PATH. On native Windows,
+    # PATH often contains C:\Windows\System32\bash.exe, the WSL launcher; using
+    # it for the local backend sends Windows paths into Linux and breaks cwd.
     for candidate in (
         os.path.join(os.environ.get("ProgramFiles", r"C:\Program Files"), "Git", "bin", "bash.exe"),
         os.path.join(os.environ.get("ProgramFiles(x86)", r"C:\Program Files (x86)"), "Git", "bin", "bash.exe"),
@@ -278,6 +277,10 @@ def _find_bash() -> str:
     ):
         if candidate and os.path.isfile(candidate):
             return candidate
+
+    found = shutil.which("bash")
+    if found:
+        return found
 
     raise RuntimeError(
         "Git Bash not found. Hermes Agent requires Git for Windows on Windows.\n"


### PR DESCRIPTION
## Summary

- move known Git-for-Windows install paths ahead of the generic `shutil.which("bash")` fallback in `_find_bash()`
- keep the existing higher priorities intact: `HERMES_GIT_BASH_PATH` first, then Hermes-managed PortableGit/MinGit
- add regression coverage for the native Windows case where PATH resolves `bash` to the WSL launcher while `ProgramFiles\Git\bin\bash.exe` exists

Fixes #47837.

## Related PRs

This is narrower than #35675 and #38092:

- #35675 overlaps in the Windows bash area, but also changes cwd/file-operation behavior and does not narrowly restore ProgramFiles Git before PATH for #47837.
- #38092 adds more package-manager Git paths and is complementary; it does not move the existing known Git-for-Windows candidates before `shutil.which("bash")`.

## Testing

- `$HOME/.hermes/hermes-agent/venv/bin/python -m pytest tests/tools/test_local_find_bash.py -q`
- `$HOME/.hermes/hermes-agent/venv/bin/python -m pytest tests/tools/test_local_env_cwd_recovery.py tests/tools/test_local_env_blocklist.py tests/tools/test_local_find_bash.py -q`
- `$HOME/.hermes/hermes-agent/venv/bin/python -m compileall -q tools/environments/local.py tests/tools/test_local_find_bash.py`
- `git diff --check`

## Review

A read-only subagent review found no blocking issues and confirmed this is an independent narrow fix for #47837, not a duplicate of #35675/#38092.
