### PR TITLE
test(skills): isolate HOME in openclaw migration tests

### DIFF
--- a/tests/skills/test_openclaw_migration.py
+++ b/tests/skills/test_openclaw_migration.py
@@ -5,6 +5,22 @@ import json
 import sys
 from pathlib import Path
 
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def isolate_home(tmp_path_factory, monkeypatch):
+    """Keep the migrator from escaping into the real ~/.agents/skills tree.
+
+    migrate_shared_skills() scans ``Path.home() / ".agents" / "skills"`` directly,
+    which on a developer machine can hold gigabytes of skills and makes the
+    execute=True cases copy them into tmp_path (200s+ per test, non-reproducible).
+    """
+    fake_home = tmp_path_factory.mktemp("home")
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: fake_home))
+    monkeypatch.setenv("HOME", str(fake_home))
+    monkeypatch.setenv("USERPROFILE", str(fake_home))
+
 
 SCRIPT_PATH = (
     Path(__file__).resolve().parents[2]
@@ -689,6 +705,31 @@ def test_shared_skills_migrated(tmp_path: Path):
     )
     report = migrator.migrate()
     imported = target / "skills" / mod.SKILL_CATEGORY_DIRNAME / "my-shared-skill" / "SKILL.md"
+    assert imported.exists()
+
+
+def test_personal_skills_migrated(tmp_path: Path):
+    """Personal skills under ~/.agents/skills/ are migrated (home is isolated)."""
+    mod = load_module()
+    personal_root = Path.home() / ".agents" / "skills" / "personal-skill"
+    personal_root.mkdir(parents=True)
+    (personal_root / "SKILL.md").write_text(
+        "---\nname: personal-skill\ndescription: personal\n---\n\nbody\n",
+        encoding="utf-8",
+    )
+
+    source = tmp_path / ".openclaw"
+    source.mkdir()
+    target = tmp_path / ".hermes"
+    target.mkdir()
+
+    migrator = mod.Migrator(
+        source_root=source, target_root=target, execute=True,
+        workspace_target=None, overwrite=False, migrate_secrets=False, output_dir=None,
+        selected_options={"shared-skills"},
+    )
+    migrator.migrate()
+    imported = target / "skills" / mod.SKILL_CATEGORY_DIRNAME / "personal-skill" / "SKILL.md"
     assert imported.exists()
 
 


### PR DESCRIPTION
## What & Why

`migrate_shared_skills()` in `optional-skills/migration/openclaw-migration/scripts/openclaw_to_hermes.py` scans `Path.home() / ".agents" / "skills"` directly as one of its skill sources. The existing tests isolate `source_root`/`target_root` via `tmp_path`, but this one source path escaped the sandbox and pointed at the developer's **real** `~/.agents/skills` tree.

On a real machine that directory can be large (in my case ~45k files / 1.3 GB), so every `execute=True` test that ran the full migration did a real `shutil.copytree` of it into `tmp_path`. Effects:

- 5 tests took **170–200s each**; the whole file took **~16 minutes** and was being SIGKILL'd by the 140s-per-file CI timeout.
- Results were **non-reproducible** — they depended on whatever skills happened to live in the runner's HOME. On a clean CI HOME the branch silently didn't execute at all.

### Fix

- Add an `autouse` fixture `isolate_home` that redirects `Path.home()` (and `HOME`/`USERPROFILE` as a fallback) to a temp directory, so the migrator can never reach into the real user tree.
- Add `test_personal_skills_migrated` to actually cover the `~/.agents/skills` (personal-skills) branch of `migrate_shared_skills()` — previously this branch was executed by accident but never asserted.

No production code changed; this is a tests-only change.

## How to test

```
pytest tests/skills/test_openclaw_migration.py -v
```

- Before: 41 passed in ~945s (0:15:45), with 5 cases at 170–200s each.
- After: 42 passed in ~1.3s.

## Platforms tested

- macOS (Apple Silicon), Python 3.11.11, pytest 9.0.2.
- The fixture also patches `HOME`/`USERPROFILE` so the isolation holds on Windows; the migrator code itself is unchanged.
