### PR TITLE
feat: add delayed gateway meta cleanup

### DIFF
--- a/gateway/display_config.py
+++ b/gateway/display_config.py
@@ -47,6 +47,17 @@ _GLOBAL_DEFAULTS: dict[str, Any] = {
     # live, just cleaned up after success so the chat doesn't fill up with
     # stale breadcrumbs. Failed runs leave bubbles in place as breadcrumbs.
     "cleanup_progress": False,
+    # Optional retention policy for cleanup_progress. 0 preserves legacy
+    # post-delivery cleanup; >0 waits for this much session inactivity before
+    # deleting the collected meta bubbles.
+    "cleanup_progress_idle_seconds": 0,
+    # Optional exchange-count trigger. 0 disables; N deletes collected meta
+    # bubbles after N successful cleanup-tracked turns even if the idle timer
+    # has not elapsed.
+    "cleanup_progress_max_exchanges": 0,
+    # Reset/new-session trigger. When cleanup_progress is enabled, a reset
+    # flushes any pending collected meta bubbles immediately by default.
+    "cleanup_progress_on_reset": True,
 }
 
 # ---------------------------------------------------------------------------
@@ -235,16 +246,21 @@ def _normalise(setting: str, value: Any) -> Any:
         if isinstance(value, str):
             return value.lower() in {"true", "1", "yes", "on"}
         return bool(value)
-    if setting == "cleanup_progress":
+    if setting in {"cleanup_progress", "cleanup_progress_on_reset"}:
         if isinstance(value, str):
             return value.lower() in {"true", "1", "yes", "on"}
         return bool(value)
     if setting == "tool_progress_grouping":
         val = str(value).lower()
         return val if val in ("accumulate", "separate") else "accumulate"
-    if setting == "tool_preview_length":
+    if setting in {"tool_preview_length", "cleanup_progress_max_exchanges"}:
         try:
-            return int(value)
+            return max(0, int(value))
         except (TypeError, ValueError):
             return 0
+    if setting == "cleanup_progress_idle_seconds":
+        try:
+            return max(0.0, float(value))
+        except (TypeError, ValueError):
+            return 0.0
     return value

--- a/gateway/display_config.py
+++ b/gateway/display_config.py
@@ -51,9 +51,11 @@ _GLOBAL_DEFAULTS: dict[str, Any] = {
     # post-delivery cleanup; >0 waits for this much session inactivity before
     # deleting the collected meta bubbles.
     "cleanup_progress_idle_seconds": 0,
-    # Optional exchange-count trigger. 0 disables; N deletes collected meta
-    # bubbles after N successful cleanup-tracked turns even if the idle timer
-    # has not elapsed.
+    # Optional exchange-count trigger. 0 disables. When set to N, the Nth
+    # successful cleanup-tracked turn deletes collected meta bubbles
+    # immediately, independent of cleanup_progress_idle_seconds. Use this as
+    # a hard transcript-noise ceiling when long active conversations should
+    # not wait for the idle timer before cleanup.
     "cleanup_progress_max_exchanges": 0,
     # Reset/new-session trigger. When cleanup_progress is enabled, a reset
     # flushes any pending collected meta bubbles immediately by default.

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2330,6 +2330,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # cannot grow unbounded over a long-running gateway lifetime.
         self._session_sources: "OrderedDict[str, SessionSource]" = OrderedDict()
         self._session_sources_max = 512
+        # Per-session delayed cleanup for Telegram/gateway meta bubbles.
+        # ``cleanup_progress_idle_seconds`` lets us collect tool/status noise
+        # across a burst of turns and delete it only after the conversation
+        # goes quiet, rather than making the transcript jump while the user is
+        # actively interacting.
+        self._meta_cleanup_pending: Dict[str, Dict[str, Any]] = {}
 
         # Cache AIAgent instances per session to preserve prompt caching.
         # Without this, a new AIAgent is created per message, rebuilding the
@@ -4143,6 +4149,240 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             logger.debug("Failed to send busy-ack: %s", e)
 
         return True
+
+    def _pause_meta_cleanup_for_session(self, session_key: Optional[str]) -> None:
+        """Pause any idle cleanup timer while a fresh turn is running."""
+        if not session_key:
+            return
+        pending = getattr(self, "_meta_cleanup_pending", None)
+        if not isinstance(pending, dict):
+            return
+        entry = pending.get(session_key)
+        if not entry:
+            return
+        fut = entry.get("future")
+        if fut is not None:
+            try:
+                fut.cancel()
+            except Exception:
+                pass
+            entry["future"] = None
+        entry["paused"] = True
+
+    def _resume_paused_meta_cleanup_for_session(
+        self,
+        session_key: Optional[str],
+        *,
+        loop: asyncio.AbstractEventLoop,
+        idle_seconds: float = 0.0,
+        max_exchanges: int = 0,
+    ) -> None:
+        """Re-arm a paused idle cleanup even when the next turn has no bubbles."""
+        if not session_key:
+            return
+        pending = getattr(self, "_meta_cleanup_pending", None)
+        if not isinstance(pending, dict):
+            return
+        entry = pending.get(session_key)
+        if not entry or not entry.get("ids") or entry.get("future") is not None:
+            return
+        try:
+            idle_delay = max(0.0, float(idle_seconds or 0.0))
+        except Exception:
+            idle_delay = 0.0
+        try:
+            exchange_limit = max(0, int(max_exchanges or 0))
+        except Exception:
+            exchange_limit = 0
+        if exchange_limit and int(entry.get("exchanges") or 0) < exchange_limit and idle_delay <= 0:
+            entry["paused"] = False
+            return
+        delay = 0.0 if exchange_limit and int(entry.get("exchanges") or 0) >= exchange_limit else idle_delay
+        entry["token"] = int(entry.get("token") or 0) + 1
+        token = entry["token"]
+        entry["paused"] = False
+
+        async def _delete_when_current() -> None:
+            try:
+                if delay > 0:
+                    await asyncio.sleep(delay)
+                current = pending.get(session_key)
+                if not current or current.get("token") != token:
+                    return
+                pending.pop(session_key, None)
+                delete_adapter = current.get("adapter")
+                delete_chat_id = current.get("chat_id")
+                delete_ids = list(current.get("ids") or [])
+                for mid in delete_ids:
+                    try:
+                        await delete_adapter.delete_message(delete_chat_id, mid)
+                    except Exception:
+                        pass
+            except asyncio.CancelledError:
+                raise
+            except Exception as exc:
+                logger.debug("Meta message cleanup failed for %s: %s", session_key, exc)
+
+        entry["future"] = safe_schedule_threadsafe(
+            _delete_when_current(),
+            loop,
+            logger=logger,
+            log_message="Meta message cleanup scheduling error",
+        )
+
+    async def _flush_meta_cleanup_for_session(
+        self,
+        session_key: Optional[str],
+        *,
+        platform_key: str = "",
+        force: bool = False,
+    ) -> None:
+        """Immediately delete any pending meta bubbles for a reset session."""
+        if not session_key:
+            return
+        if not force:
+            try:
+                user_config = _load_gateway_config()
+            except Exception:
+                user_config = {}
+            try:
+                from gateway.display_config import resolve_display_setting
+                if not bool(
+                    resolve_display_setting(
+                        user_config,
+                        platform_key,
+                        "cleanup_progress_on_reset",
+                        True,
+                    )
+                ):
+                    return
+            except Exception:
+                pass
+        pending = getattr(self, "_meta_cleanup_pending", None)
+        if not isinstance(pending, dict):
+            return
+        entry = pending.pop(session_key, None)
+        if not entry:
+            return
+        fut = entry.get("future")
+        if fut is not None:
+            try:
+                fut.cancel()
+            except Exception:
+                pass
+        adapter = entry.get("adapter")
+        chat_id = entry.get("chat_id")
+        if adapter is None or not chat_id:
+            return
+        for mid in list(entry.get("ids") or []):
+            try:
+                await adapter.delete_message(chat_id, str(mid))
+            except Exception:
+                pass
+
+    def _schedule_meta_message_cleanup(
+        self,
+        *,
+        session_key: Optional[str],
+        chat_id: str,
+        adapter: Any,
+        message_ids: List[str],
+        loop: asyncio.AbstractEventLoop,
+        idle_seconds: float = 0.0,
+        max_exchanges: int = 0,
+    ) -> None:
+        """Delete accumulated gateway meta messages after idle/turn thresholds.
+
+        This powers Telegram history condensation: progress/status bubbles are
+        useful live, but become transcript barnacles after the final answer.
+        We only delete bot-owned messages that were explicitly tracked by the
+        cleanup_progress path; user messages and final assistant answers are
+        never touched.
+        """
+        if not session_key or not message_ids or adapter is None:
+            return
+        if type(adapter).delete_message is BasePlatformAdapter.delete_message:
+            return
+
+        pending = getattr(self, "_meta_cleanup_pending", None)
+        if not isinstance(pending, dict):
+            pending = {}
+            self._meta_cleanup_pending = pending
+
+        entry = pending.setdefault(
+            session_key,
+            {
+                "chat_id": chat_id,
+                "adapter": adapter,
+                "ids": [],
+                "exchanges": 0,
+                "future": None,
+                "token": 0,
+            },
+        )
+        entry["chat_id"] = chat_id
+        entry["adapter"] = adapter
+        ids = entry.setdefault("ids", [])
+        seen = set(str(mid) for mid in ids)
+        for mid in message_ids:
+            smid = str(mid)
+            if smid and smid not in seen:
+                ids.append(smid)
+                seen.add(smid)
+        entry["exchanges"] = int(entry.get("exchanges") or 0) + 1
+        entry["token"] = int(entry.get("token") or 0) + 1
+
+        old_future = entry.get("future")
+        if old_future is not None:
+            try:
+                old_future.cancel()
+            except Exception:
+                pass
+
+        try:
+            idle_delay = max(0.0, float(idle_seconds or 0.0))
+        except Exception:
+            idle_delay = 0.0
+        try:
+            exchange_limit = max(0, int(max_exchanges or 0))
+        except Exception:
+            exchange_limit = 0
+        if exchange_limit and entry["exchanges"] < exchange_limit and idle_delay <= 0:
+            # Exchange-count-only mode: retain the accumulated ids until the
+            # Nth successful cleanup-tracked turn. With no idle delay there
+            # is intentionally no timer to schedule yet.
+            entry["future"] = None
+            return
+        delay = 0.0 if exchange_limit and entry["exchanges"] >= exchange_limit else idle_delay
+        token = entry["token"]
+
+        async def _delete_when_current() -> None:
+            try:
+                if delay > 0:
+                    await asyncio.sleep(delay)
+                current = pending.get(session_key)
+                if not current or current.get("token") != token:
+                    return
+                pending.pop(session_key, None)
+                delete_adapter = current.get("adapter")
+                delete_chat_id = current.get("chat_id")
+                delete_ids = list(current.get("ids") or [])
+                for mid in delete_ids:
+                    try:
+                        await delete_adapter.delete_message(delete_chat_id, mid)
+                    except Exception:
+                        pass
+            except asyncio.CancelledError:
+                raise
+            except Exception as exc:
+                logger.debug("Meta message cleanup failed for %s: %s", session_key, exc)
+
+        entry["future"] = safe_schedule_threadsafe(
+            _delete_when_current(),
+            loop,
+            logger=logger,
+            log_message="Meta message cleanup scheduling error",
+        )
 
     async def _drain_active_agents(self, timeout: float) -> tuple[Dict[str, Any], bool]:
         snapshot = self._snapshot_running_agents()
@@ -13891,6 +14131,30 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         _cleanup_progress = bool(
             resolve_display_setting(user_config, platform_key, "cleanup_progress")
         )
+        try:
+            _cleanup_idle_seconds = float(
+                resolve_display_setting(
+                    user_config,
+                    platform_key,
+                    "cleanup_progress_idle_seconds",
+                    0,
+                ) or 0
+            )
+        except Exception:
+            _cleanup_idle_seconds = 0.0
+        try:
+            _cleanup_max_exchanges = int(
+                resolve_display_setting(
+                    user_config,
+                    platform_key,
+                    "cleanup_progress_max_exchanges",
+                    0,
+                ) or 0
+            )
+        except Exception:
+            _cleanup_max_exchanges = 0
+        if _cleanup_progress and session_key and (_cleanup_idle_seconds > 0 or _cleanup_max_exchanges > 0):
+            self._pause_meta_cleanup_for_session(session_key)
         _cleanup_adapter = self.adapters.get(source.platform) if _cleanup_progress else None
         if _cleanup_adapter is not None and (
             type(_cleanup_adapter).delete_message is BasePlatformAdapter.delete_message
@@ -16309,10 +16573,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         if (
             _cleanup_progress
             and _cleanup_adapter is not None
-            and _cleanup_msg_ids
             and session_key
             and isinstance(response, dict)
-            and not response.get("failed")
             and hasattr(_cleanup_adapter, "register_post_delivery_callback")
         ):
             _ids_snapshot = list(_cleanup_msg_ids)
@@ -16321,29 +16583,43 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             _loop_snapshot = asyncio.get_running_loop()
 
             def _cleanup_temp_bubbles() -> None:
-                async def _delete_all() -> None:
-                    for _mid in _ids_snapshot:
-                        try:
-                            await _adapter_snapshot.delete_message(
-                                _chat_id_snapshot, _mid
-                            )
-                        except Exception:
-                            pass
                 try:
-                    safe_schedule_threadsafe(
-                        _delete_all(), _loop_snapshot,
-                        logger=logger,
-                        log_message="Temp bubble cleanup scheduling error",
-                    )
+                    if _ids_snapshot and not response.get("failed"):
+                        self._schedule_meta_message_cleanup(
+                            session_key=session_key,
+                            chat_id=_chat_id_snapshot,
+                            adapter=_adapter_snapshot,
+                            message_ids=_ids_snapshot,
+                            loop=_loop_snapshot,
+                            idle_seconds=_cleanup_idle_seconds,
+                            max_exchanges=_cleanup_max_exchanges,
+                        )
+                    else:
+                        self._resume_paused_meta_cleanup_for_session(
+                            session_key,
+                            loop=_loop_snapshot,
+                            idle_seconds=_cleanup_idle_seconds,
+                            max_exchanges=_cleanup_max_exchanges,
+                        )
                 except Exception:
                     pass
 
             try:
-                _cleanup_adapter.register_post_delivery_callback(
-                    session_key,
-                    _cleanup_temp_bubbles,
-                    generation=run_generation,
-                )
+                _should_register_cleanup = bool(_ids_snapshot and not response.get("failed"))
+                if not _should_register_cleanup:
+                    _pending = getattr(self, "_meta_cleanup_pending", {})
+                    _pending_entry = _pending.get(session_key) if isinstance(_pending, dict) else None
+                    _should_register_cleanup = bool(
+                        _pending_entry
+                        and _pending_entry.get("ids")
+                        and _pending_entry.get("future") is None
+                    )
+                if _should_register_cleanup:
+                    _cleanup_adapter.register_post_delivery_callback(
+                        session_key,
+                        _cleanup_temp_bubbles,
+                        generation=run_generation,
+                    )
             except Exception as _rpe:
                 logger.debug("Post-delivery cleanup registration failed: %s", _rpe)
 

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -67,6 +67,12 @@ class GatewaySlashCommandsMixin:
         
         # Get existing session key
         session_key = self._session_key_for_source(source)
+        if hasattr(self, "_flush_meta_cleanup_for_session"):
+            flush_meta_cleanup = getattr(self, "_flush_meta_cleanup_for_session")
+            await flush_meta_cleanup(
+                session_key,
+                platform_key=source.platform.value if source.platform else "",
+            )
         self._invalidate_session_run_generation(session_key, reason="session_reset")
         # Evict the running-agent slot now that the generation is bumped. The
         # in-flight run's own guarded release (run_generation=old) will return

--- a/tests/gateway/test_display_config.py
+++ b/tests/gateway/test_display_config.py
@@ -451,6 +451,54 @@ class TestCleanupProgress:
             }
             assert resolve_display_setting(config, "telegram", "cleanup_progress") is True, val
 
+    def test_delayed_cleanup_defaults(self):
+        """Delayed cleanup knobs default to legacy immediate-cleanup behavior."""
+        from gateway.display_config import resolve_display_setting
+
+        assert resolve_display_setting({}, "telegram", "cleanup_progress_idle_seconds") == 0
+        assert resolve_display_setting({}, "telegram", "cleanup_progress_max_exchanges") == 0
+        assert resolve_display_setting({}, "telegram", "cleanup_progress_on_reset") is True
+
+    def test_delayed_cleanup_overrides_normalise(self):
+        from gateway.display_config import resolve_display_setting
+
+        config = {
+            "display": {
+                "cleanup_progress_idle_seconds": "60",
+                "cleanup_progress_max_exchanges": "10",
+                "platforms": {
+                    "telegram": {
+                        "cleanup_progress_idle_seconds": "300.5",
+                        "cleanup_progress_max_exchanges": "5",
+                        "cleanup_progress_on_reset": "off",
+                    }
+                },
+            }
+        }
+
+        assert resolve_display_setting(config, "telegram", "cleanup_progress_idle_seconds") == 300.5
+        assert resolve_display_setting(config, "telegram", "cleanup_progress_max_exchanges") == 5
+        assert resolve_display_setting(config, "telegram", "cleanup_progress_on_reset") is False
+        assert resolve_display_setting(config, "discord", "cleanup_progress_idle_seconds") == 60.0
+        assert resolve_display_setting(config, "discord", "cleanup_progress_max_exchanges") == 10
+
+    def test_delayed_cleanup_invalid_values_clamp(self):
+        from gateway.display_config import resolve_display_setting
+
+        config = {
+            "display": {
+                "platforms": {
+                    "telegram": {
+                        "cleanup_progress_idle_seconds": "nope",
+                        "cleanup_progress_max_exchanges": -4,
+                    }
+                }
+            }
+        }
+
+        assert resolve_display_setting(config, "telegram", "cleanup_progress_idle_seconds") == 0.0
+        assert resolve_display_setting(config, "telegram", "cleanup_progress_max_exchanges") == 0
+
 
 class TestToolProgressGrouping:
     """resolve_display_setting() for the tool_progress_grouping knob."""

--- a/tests/gateway/test_run_cleanup_progress.py
+++ b/tests/gateway/test_run_cleanup_progress.py
@@ -365,3 +365,272 @@ async def test_cleanup_chains_with_existing_callback(monkeypatch, tmp_path):
     # deletes at least one progress bubble.
     assert pre_existing_fired == [True]
     assert len(adapter.deleted) >= 1
+
+
+@pytest.mark.asyncio
+async def test_cleanup_idle_seconds_delays_deletion_until_quiet():
+    """An idle cleanup window keeps progress bubbles visible briefly, then
+    deletes them after the configured quiet period."""
+    from gateway.run import GatewayRunner
+
+    adapter = CleanupCaptureAdapter()
+    runner = object.__new__(GatewayRunner)
+    loop = asyncio.get_running_loop()
+
+    runner._schedule_meta_message_cleanup(
+        session_key="agent:main:telegram:dm:42",
+        chat_id="42",
+        adapter=adapter,
+        message_ids=["m1", "m2"],
+        loop=loop,
+        idle_seconds=0.05,
+        max_exchanges=0,
+    )
+
+    await asyncio.sleep(0)
+    assert adapter.deleted == []
+
+    for _ in range(20):
+        await asyncio.sleep(0.01)
+        if len(adapter.deleted) == 2:
+            break
+
+    assert adapter.deleted == [
+        {"chat_id": "42", "message_id": "m1"},
+        {"chat_id": "42", "message_id": "m2"},
+    ]
+
+
+@pytest.mark.asyncio
+async def test_cleanup_accumulates_until_exchange_threshold():
+    """A max-exchanges threshold deletes accumulated meta bubbles before the
+    idle timer elapses."""
+    from gateway.run import GatewayRunner
+
+    adapter = CleanupCaptureAdapter()
+    runner = object.__new__(GatewayRunner)
+    loop = asyncio.get_running_loop()
+    session_key = "agent:main:telegram:dm:42"
+
+    runner._schedule_meta_message_cleanup(
+        session_key=session_key,
+        chat_id="42",
+        adapter=adapter,
+        message_ids=["m1"],
+        loop=loop,
+        idle_seconds=60,
+        max_exchanges=2,
+    )
+    await asyncio.sleep(0)
+    assert adapter.deleted == []
+
+    runner._schedule_meta_message_cleanup(
+        session_key=session_key,
+        chat_id="42",
+        adapter=adapter,
+        message_ids=["m2", "m1"],
+        loop=loop,
+        idle_seconds=60,
+        max_exchanges=2,
+    )
+
+    for _ in range(20):
+        await asyncio.sleep(0.01)
+        if len(adapter.deleted) == 2:
+            break
+
+    # m1 is not duplicated when the second turn reports it again.
+    assert adapter.deleted == [
+        {"chat_id": "42", "message_id": "m1"},
+        {"chat_id": "42", "message_id": "m2"},
+    ]
+
+
+@pytest.mark.asyncio
+async def test_cleanup_pause_cancels_pending_idle_delete():
+    """Starting a new turn pauses the idle cleanup timer so it cannot delete
+    historical meta bubbles while the user is actively interacting."""
+    from gateway.run import GatewayRunner
+
+    adapter = CleanupCaptureAdapter()
+    runner = object.__new__(GatewayRunner)
+    loop = asyncio.get_running_loop()
+    session_key = "agent:main:telegram:dm:42"
+
+    runner._schedule_meta_message_cleanup(
+        session_key=session_key,
+        chat_id="42",
+        adapter=adapter,
+        message_ids=["m1"],
+        loop=loop,
+        idle_seconds=0.05,
+        max_exchanges=0,
+    )
+    runner._pause_meta_cleanup_for_session(session_key)
+
+    await asyncio.sleep(0.08)
+    assert adapter.deleted == []
+
+    runner._schedule_meta_message_cleanup(
+        session_key=session_key,
+        chat_id="42",
+        adapter=adapter,
+        message_ids=["m2"],
+        loop=loop,
+        idle_seconds=0,
+        max_exchanges=0,
+    )
+    for _ in range(20):
+        await asyncio.sleep(0.01)
+        if len(adapter.deleted) == 2:
+            break
+
+    assert adapter.deleted == [
+        {"chat_id": "42", "message_id": "m1"},
+        {"chat_id": "42", "message_id": "m2"},
+    ]
+
+
+@pytest.mark.asyncio
+async def test_cleanup_resume_rearms_paused_idle_delete_without_new_ids():
+    """A progress-free follow-up turn should not strand previously tracked ids."""
+    from gateway.run import GatewayRunner
+
+    adapter = CleanupCaptureAdapter()
+    runner = object.__new__(GatewayRunner)
+    loop = asyncio.get_running_loop()
+    session_key = "agent:main:telegram:dm:42"
+
+    runner._schedule_meta_message_cleanup(
+        session_key=session_key,
+        chat_id="42",
+        adapter=adapter,
+        message_ids=["m1"],
+        loop=loop,
+        idle_seconds=60,
+        max_exchanges=0,
+    )
+    runner._pause_meta_cleanup_for_session(session_key)
+    runner._resume_paused_meta_cleanup_for_session(
+        session_key,
+        loop=loop,
+        idle_seconds=0.01,
+        max_exchanges=0,
+    )
+
+    for _ in range(20):
+        await asyncio.sleep(0.01)
+        if adapter.deleted:
+            break
+
+    assert adapter.deleted == [{"chat_id": "42", "message_id": "m1"}]
+    assert getattr(runner, "_meta_cleanup_pending", {}) == {}
+
+
+@pytest.mark.asyncio
+async def test_cleanup_flushes_on_session_reset():
+    """A session reset/new command deletes pending idle-cleanup meta bubbles
+    immediately instead of leaving them to linger."""
+    from gateway.run import GatewayRunner
+
+    adapter = CleanupCaptureAdapter()
+    runner = object.__new__(GatewayRunner)
+    loop = asyncio.get_running_loop()
+    session_key = "agent:main:telegram:dm:42"
+
+    runner._schedule_meta_message_cleanup(
+        session_key=session_key,
+        chat_id="42",
+        adapter=adapter,
+        message_ids=["m1", "m2"],
+        loop=loop,
+        idle_seconds=60,
+        max_exchanges=0,
+    )
+
+    await runner._flush_meta_cleanup_for_session(session_key)
+
+    assert adapter.deleted == [
+        {"chat_id": "42", "message_id": "m1"},
+        {"chat_id": "42", "message_id": "m2"},
+    ]
+    assert getattr(runner, "_meta_cleanup_pending", {}) == {}
+
+
+@pytest.mark.asyncio
+async def test_cleanup_reset_flush_respects_config(monkeypatch):
+    """cleanup_progress_on_reset=false leaves pending idle cleanup intact."""
+    from gateway import run as gateway_run
+    from gateway.run import GatewayRunner
+
+    adapter = CleanupCaptureAdapter()
+    runner = object.__new__(GatewayRunner)
+    loop = asyncio.get_running_loop()
+    session_key = "agent:main:telegram:dm:42"
+
+    runner._schedule_meta_message_cleanup(
+        session_key=session_key,
+        chat_id="42",
+        adapter=adapter,
+        message_ids=["m1"],
+        loop=loop,
+        idle_seconds=60,
+        max_exchanges=0,
+    )
+    monkeypatch.setattr(
+        gateway_run,
+        "_load_gateway_config",
+        lambda: {
+            "display": {
+                "platforms": {"telegram": {"cleanup_progress_on_reset": False}}
+            }
+        },
+    )
+
+    await runner._flush_meta_cleanup_for_session(session_key, platform_key="telegram")
+
+    assert adapter.deleted == []
+    assert session_key in getattr(runner, "_meta_cleanup_pending", {})
+
+
+@pytest.mark.asyncio
+async def test_cleanup_exchange_threshold_without_idle_waits_until_limit():
+    """Exchange-count-only mode should not fall back to legacy immediate cleanup."""
+    from gateway.run import GatewayRunner
+
+    adapter = CleanupCaptureAdapter()
+    runner = object.__new__(GatewayRunner)
+    loop = asyncio.get_running_loop()
+    session_key = "agent:main:telegram:dm:42"
+
+    runner._schedule_meta_message_cleanup(
+        session_key=session_key,
+        chat_id="42",
+        adapter=adapter,
+        message_ids=["m1"],
+        loop=loop,
+        idle_seconds=0,
+        max_exchanges=2,
+    )
+    await asyncio.sleep(0.03)
+    assert adapter.deleted == []
+    assert session_key in getattr(runner, "_meta_cleanup_pending", {})
+
+    runner._schedule_meta_message_cleanup(
+        session_key=session_key,
+        chat_id="42",
+        adapter=adapter,
+        message_ids=["m2"],
+        loop=loop,
+        idle_seconds=0,
+        max_exchanges=2,
+    )
+    for _ in range(20):
+        await asyncio.sleep(0.01)
+        if len(adapter.deleted) == 2:
+            break
+
+    assert adapter.deleted == [
+        {"chat_id": "42", "message_id": "m1"},
+        {"chat_id": "42", "message_id": "m2"},
+    ]

--- a/tests/gateway/test_session_model_reset.py
+++ b/tests/gateway/test_session_model_reset.py
@@ -33,6 +33,7 @@ def _make_runner():
     )
     adapter = MagicMock()
     adapter.send = AsyncMock()
+    adapter.delete_message = AsyncMock(return_value=True)
     runner.adapters = {Platform.TELEGRAM: adapter}
     runner._voice_mode = {}
     runner.hooks = SimpleNamespace(emit=AsyncMock(), loaded_hooks=False)
@@ -139,3 +140,25 @@ async def test_new_command_only_clears_own_session():
     assert other_key in runner._session_reasoning_overrides
     assert session_key not in runner._pending_model_notes
     assert other_key in runner._pending_model_notes
+
+
+@pytest.mark.asyncio
+async def test_new_command_flushes_pending_meta_cleanup_for_idle_session():
+    """Cold /new must honor cleanup_progress_on_reset for delayed meta bubbles."""
+    runner = _make_runner()
+    source = _make_source()
+    session_key = build_session_key(source)
+    adapter = runner.adapters[Platform.TELEGRAM]
+    runner._meta_cleanup_pending = {
+        session_key: {
+            "adapter": adapter,
+            "chat_id": source.chat_id,
+            "ids": ["progress-1"],
+            "future": None,
+        }
+    }
+
+    await runner._handle_reset_command(_make_event("/new"))
+
+    getattr(adapter.delete_message, "assert_awaited_once_with")(source.chat_id, "progress-1")
+    assert runner._meta_cleanup_pending == {}


### PR DESCRIPTION
## Summary
- add opt-in delayed cleanup for gateway meta/progress bubbles on deletion-capable platforms
- support idle-window cleanup, exchange-count cleanup, and reset-boundary flushes via per-platform display config
- preserve existing default behavior and skip adapters that do not implement `delete_message`
- keep deletion scoped to tracked bot-owned meta messages; user messages and final assistant answers are never deleted

Closes #47858

## Configuration
```yaml
display:
  platforms:
    telegram:
      cleanup_progress: true
      cleanup_progress_idle_seconds: 300
      cleanup_progress_max_exchanges: 0
      cleanup_progress_on_reset: true
```

## Tests
- `python -m pytest tests/gateway/test_run_cleanup_progress.py tests/gateway/test_display_config.py tests/gateway/test_session_model_reset.py tests/gateway/test_post_delivery_callback_chaining.py tests/gateway/test_ephemeral_reply.py tests/gateway/test_telegram_progress_edit_transient.py -q -o 'addopts='`
  - Result: 104 passed

## Review
- Codex review: approved; no actionable regressions identified after reset-path wiring and delayed cleanup edge-case checks.
