### PR TITLE
fix(discord): protect text batch dicts with async lock

### DIFF
--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -638,6 +638,7 @@ class DiscordAdapter(BasePlatformAdapter):
         self._text_batch_split_delay_seconds = float(os.getenv("HERMES_DISCORD_TEXT_BATCH_SPLIT_DELAY_SECONDS", "2.0"))
         self._pending_text_batches: Dict[str, MessageEvent] = {}
         self._pending_text_batch_tasks: Dict[str, asyncio.Task] = {}
+        self._text_batch_lock = asyncio.Lock()
         self._voice_text_channels: Dict[int, int] = {}  # guild_id -> text_channel_id
         self._voice_sources: Dict[int, Dict[str, Any]] = {}  # guild_id -> linked text channel source metadata
         self._voice_timeout_tasks: Dict[int, asyncio.Task] = {}  # guild_id -> timeout task
@@ -5287,7 +5288,7 @@ class DiscordAdapter(BasePlatformAdapter):
         # Only batch plain text messages — commands, media, etc. dispatch
         # immediately since they won't be split by the Discord client.
         if msg_type == MessageType.TEXT and self._text_batch_delay_seconds > 0:
-            self._enqueue_text_event(event)
+            await self._enqueue_text_event(event)
         else:
             await self.handle_message(event)
 
@@ -5304,33 +5305,37 @@ class DiscordAdapter(BasePlatformAdapter):
             thread_sessions_per_user=self.config.extra.get("thread_sessions_per_user", False),
         )
 
-    def _enqueue_text_event(self, event: MessageEvent) -> None:
+    async def _enqueue_text_event(self, event: MessageEvent) -> None:
         """Buffer a text event and reset the flush timer.
 
         When Discord splits a long user message at 2000 chars, the chunks
         arrive within a few hundred milliseconds.  This merges them into
         a single event before dispatching.
-        """
-        key = self._text_batch_key(event)
-        existing = self._pending_text_batches.get(key)
-        chunk_len = len(event.text or "")
-        if existing is None:
-            event._last_chunk_len = chunk_len  # type: ignore[attr-defined]
-            self._pending_text_batches[key] = event
-        else:
-            if event.text:
-                existing.text = f"{existing.text}\n{event.text}" if existing.text else event.text
-            existing._last_chunk_len = chunk_len  # type: ignore[attr-defined]
-            if event.media_urls:
-                existing.media_urls.extend(event.media_urls)
-                existing.media_types.extend(event.media_types)
 
-        prior_task = self._pending_text_batch_tasks.get(key)
-        if prior_task and not prior_task.done():
-            prior_task.cancel()
-        self._pending_text_batch_tasks[key] = asyncio.create_task(
-            self._flush_text_batch(key)
-        )
+        Protected by ``_text_batch_lock`` so two concurrent on_message
+        events from different channels don't race on the dict operations.
+        """
+        async with self._text_batch_lock:
+            key = self._text_batch_key(event)
+            existing = self._pending_text_batches.get(key)
+            chunk_len = len(event.text or "")
+            if existing is None:
+                event._last_chunk_len = chunk_len  # type: ignore[attr-defined]
+                self._pending_text_batches[key] = event
+            else:
+                if event.text:
+                    existing.text = f"{existing.text}\n{event.text}" if existing.text else event.text
+                existing._last_chunk_len = chunk_len  # type: ignore[attr-defined]
+                if event.media_urls:
+                    existing.media_urls.extend(event.media_urls)
+                    existing.media_types.extend(event.media_types)
+
+            prior_task = self._pending_text_batch_tasks.get(key)
+            if prior_task and not prior_task.done():
+                prior_task.cancel()
+            self._pending_text_batch_tasks[key] = asyncio.create_task(
+                self._flush_text_batch(key)
+            )
 
     async def _flush_text_batch(self, key: str) -> None:
         """Wait for the quiet period then dispatch the aggregated text.

--- a/tests/gateway/test_discord_text_batch_race.py
+++ b/tests/gateway/test_discord_text_batch_race.py
@@ -1,0 +1,144 @@
+"""Test: concurrent on_message events don't race on text batch dicts.
+
+When Discord splits a long user message at 2000 chars, chunks arrive as
+concurrent on_message events. _enqueue_text_event mutates
+_pending_text_batches and _pending_text_batch_tasks dicts — without a
+lock, two concurrent calls can corrupt the dicts (lost update on
+existing.text, double task creation).
+
+Uses asyncio.gather to simulate two near-simultaneous text events
+with the same batch key.
+"""
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from gateway.config import PlatformConfig
+from gateway.platforms.base import MessageEvent, MessageType
+
+
+@pytest.mark.asyncio
+async def test_concurrent_enqueue_text_events_do_not_race():
+    """Two text events with same batch key: the merge wins, no corruption."""
+
+    from plugins.platforms.discord.adapter import DiscordAdapter
+
+    # Build a minimal adapter — enough to exercise _enqueue_text_event
+    adapter = object.__new__(DiscordAdapter)
+    adapter._platform = "discord"
+    adapter.config = PlatformConfig(enabled=True, token="t")
+    adapter._ready_event = asyncio.Event()
+    adapter._allowed_user_ids = set()
+    adapter._allowed_role_ids = set()
+    adapter._voice_clients = {}
+    adapter._voice_locks = {}
+    adapter._voice_text_channels = {}
+    adapter._voice_sources = {}
+    adapter._voice_timeout_tasks = {}
+    adapter._voice_receivers = {}
+    adapter._voice_listen_tasks = {}
+    adapter._voice_input_callback = None
+    adapter._on_voice_disconnect = None
+    adapter._voice_output_callback = None
+    adapter._loop = asyncio.get_event_loop()
+    adapter._text_batch_delay_seconds = 0.6
+    adapter._text_batch_split_delay_seconds = 2.0
+    adapter._pending_text_batches = {}
+    adapter._pending_text_batch_tasks = {}
+    adapter._text_batch_lock = asyncio.Lock()
+    adapter._threads = MagicMock()
+
+    # Mock _text_batch_key to return same key for both events
+    adapter._text_batch_key = MagicMock(return_value="session:test:123")
+
+    # Mock handle_message to not actually run
+    adapter.handle_message = AsyncMock()
+
+    # Build two events with same key (simulating Discord split)
+    source = MagicMock()
+    source.platform = "discord"
+    source.channel_id = "123"
+
+    event1 = MessageEvent(
+        source=source,
+        text="First chunk of a long message that",
+        message_type=MessageType.TEXT,
+    )
+    event2 = MessageEvent(
+        source=source,
+        text=" continues here",
+        message_type=MessageType.TEXT,
+    )
+
+    # Fire both concurrently — like two near-simultaneous on_message
+    await asyncio.gather(
+        adapter._enqueue_text_event(event1),
+        adapter._enqueue_text_event(event2),
+    )
+
+    # After gather, exactly one batch should be pending (merged)
+    assert len(adapter._pending_text_batches) == 1
+    merged = adapter._pending_text_batches.get("session:test:123")
+    assert merged is not None
+    assert merged.text == "First chunk of a long message that\n continues here"
+
+    # Exactly one flush task should exist
+    assert len(adapter._pending_text_batch_tasks) == 1
+    task = adapter._pending_text_batch_tasks["session:test:123"]
+    assert not task.done()
+
+
+@pytest.mark.asyncio
+async def test_concurrent_events_different_keys_no_interference():
+    """Events from different sessions don't interfere under lock."""
+
+    from plugins.platforms.discord.adapter import DiscordAdapter
+
+    # Same minimal adapter setup
+    adapter = object.__new__(DiscordAdapter)
+    adapter._platform = "discord"
+    adapter.config = PlatformConfig(enabled=True, token="t")
+    adapter._ready_event = asyncio.Event()
+    adapter._allowed_user_ids = set()
+    adapter._allowed_role_ids = set()
+    adapter._voice_clients = {}
+    adapter._voice_locks = {}
+    adapter._voice_text_channels = {}
+    adapter._voice_sources = {}
+    adapter._voice_timeout_tasks = {}
+    adapter._voice_receivers = {}
+    adapter._voice_listen_tasks = {}
+    adapter._voice_input_callback = None
+    adapter._on_voice_disconnect = None
+    adapter._voice_output_callback = None
+    adapter._loop = asyncio.get_event_loop()
+    adapter._text_batch_delay_seconds = 0.6
+    adapter._text_batch_split_delay_seconds = 2.0
+    adapter._pending_text_batches = {}
+    adapter._pending_text_batch_tasks = {}
+    adapter._text_batch_lock = asyncio.Lock()
+    adapter._threads = MagicMock()
+
+    # Each event gets its own session key
+    adapter._text_batch_key = MagicMock(side_effect=lambda e: f"session:{e.source.channel_id}")
+
+    adapter.handle_message = AsyncMock()
+
+    src1 = MagicMock(platform="discord", channel_id="1")
+    src2 = MagicMock(platform="discord", channel_id="2")
+
+    ev1 = MessageEvent(source=src1, text="hello from ch1", message_type=MessageType.TEXT)
+    ev2 = MessageEvent(source=src2, text="hello from ch2", message_type=MessageType.TEXT)
+
+    await asyncio.gather(
+        adapter._enqueue_text_event(ev1),
+        adapter._enqueue_text_event(ev2),
+    )
+
+    assert len(adapter._pending_text_batches) == 2
+    assert adapter._pending_text_batches["session:1"].text == "hello from ch1"
+    assert adapter._pending_text_batches["session:2"].text == "hello from ch2"
+    assert len(adapter._pending_text_batch_tasks) == 2


### PR DESCRIPTION
When two on_message events arrive concurrently (Discord splits at 2000 chars from different channels), the fire-and-forget sync call races on _pending_text_batches and _pending_text_batch_tasks dicts.

Changes:
1. Add self._text_batch_lock = asyncio.Lock() in __init__
2. Change caller to await self._enqueue_text_event(event)
3. Make _enqueue_text_event → async def with body under async with self._text_batch_lock

Tests: 2 new asyncio tests covering concurrent same-key merge and concurrent different-key isolation.