### PR TITLE
feat(search_files): headroom compression evaluation report + lossless densification

### DIFF
--- a/tests/tools/test_file_operations.py
+++ b/tests/tools/test_file_operations.py
@@ -1,6 +1,7 @@
 """Tests for tools/file_operations.py — deny list, result dataclasses, helpers."""
 
 import os
+import re
 import pytest
 import subprocess
 from pathlib import Path
@@ -358,6 +359,54 @@ class TestSearchResultDensify:
         verbose = json.dumps(r.to_dict(densify=False), ensure_ascii=False)
         dense = json.dumps(r.to_dict(densify=True), ensure_ascii=False)
         assert len(dense) < len(verbose)
+
+    @pytest.mark.parametrize("content", [
+        "x = {'k': 1, 'url': 'http://h:8080'}",   # colons in content
+        "        deeply.indented(call)",          # leading indentation preserved
+        "# \u65e5\u672c\u8a9e comment \U0001f525",  # unicode + emoji
+        "",                                        # empty content
+        "trailing spaces   ",                     # rstrip'd (see note below)
+        'mix "quotes" and , commas',              # punctuation that breaks naive CSV
+    ])
+    def test_densify_content_is_lossless(self, content):
+        # Every realistic single-line match content must round-trip exactly
+        # (trailing whitespace is the one documented transform — rstrip).
+        matches = [SearchMatch(path=f"f{i}.py", line_number=i + 1, content=content)
+                   for i in range(6)]
+        r = SearchResult(matches=matches, total_count=6)
+        text = r.to_dict(densify=True)["matches_text"]
+        recovered = []
+        cur = None
+        for ln in text.split("\n"):
+            row = re.match(r"^  (\d+): (.*)$", ln)
+            if row:
+                recovered.append(row.group(2))
+            else:
+                cur = ln
+        assert len(recovered) == 6
+        for got in recovered:
+            assert got == content.rstrip()
+
+    def test_densify_assumes_single_line_matches(self):
+        # The path-grouped format puts one match per line, so it relies on
+        # ripgrep's one-line-per-match contract (verified: 0/6775 real match
+        # contents contained a newline). This test documents that assumption:
+        # a (synthetic, never-produced-by-rg) multiline content would split
+        # across rows. If search ever emits multiline content, densify must
+        # escape newlines first.
+        matches = [SearchMatch(path="a.py", line_number=i + 1, content="single line")
+                   for i in range(6)]
+        text = SearchResult(matches=matches, total_count=6).to_dict(densify=True)["matches_text"]
+        # one header + six rows == 7 lines, no row spans multiple lines
+        body_rows = [ln for ln in text.split("\n") if re.match(r"^  \d+: ", ln)]
+        assert len(body_rows) == 6
+
+    def test_densify_paths_with_spaces(self):
+        matches = [SearchMatch(path="my dir/a b.py", line_number=i + 1, content=f"x{i}")
+                   for i in range(6)]
+        text = SearchResult(matches=matches, total_count=6).to_dict(densify=True)["matches_text"]
+        # path with spaces survives as a header line verbatim
+        assert "my dir/a b.py" in text.split("\n")[0]
 
 
 class TestLintResult:

--- a/tests/tools/test_file_operations.py
+++ b/tests/tools/test_file_operations.py
@@ -270,6 +270,96 @@ class TestSearchResult:
         assert d["truncated"] is True
 
 
+class TestSearchResultDensify:
+    """Path-grouped densification of content-mode matches (lossless)."""
+
+    def _matches(self, n, paths=None):
+        # Real ripgrep output is path-ordered: all matches in a file are
+        # consecutive (verified against live search_files corpus). The fixture
+        # mirrors that — group by path, then enumerate lines within each.
+        paths = paths or ["a.py"]
+        out = []
+        per = max(1, n // len(paths))
+        ln = 0
+        for p in paths:
+            for _ in range(per):
+                ln += 1
+                out.append(SearchMatch(path=p, line_number=ln,
+                                       content=f"line content {ln}"))
+        # pad remainder onto the last path
+        while len(out) < n:
+            ln += 1
+            out.append(SearchMatch(path=paths[-1], line_number=ln,
+                                   content=f"line content {ln}"))
+        return out
+
+    def test_densify_off_by_default(self):
+        # The model-facing default must be unchanged for callers that don't
+        # opt in: verbose array, no matches_text key.
+        r = SearchResult(matches=self._matches(10), total_count=10)
+        d = r.to_dict()
+        assert "matches" in d
+        assert "matches_text" not in d
+
+    def test_densify_below_threshold_keeps_verbose(self):
+        # Too few matches: the grouping header would cost more than it saves,
+        # so we fall back to the verbose array even with densify=True.
+        r = SearchResult(matches=self._matches(4), total_count=4)
+        d = r.to_dict(densify=True)
+        assert "matches" in d
+        assert "matches_text" not in d
+
+    def test_densify_emits_path_grouped_text(self):
+        r = SearchResult(matches=self._matches(6, paths=["a.py", "b.py"]),
+                         total_count=6)
+        d = r.to_dict(densify=True)
+        assert "matches" not in d
+        assert "matches_text" in d
+        assert "matches_format" in d  # self-describing
+        text = d["matches_text"]
+        # Each path appears once as a group header, not repeated per match.
+        assert text.count("a.py") == 1
+        assert text.count("b.py") == 1
+
+    def test_densify_is_lossless(self):
+        # Every path, line number, and content byte must be recoverable from
+        # the dense form.
+        import re
+        matches = [
+            SearchMatch(path="src/x.py", line_number=12, content="    def foo():"),
+            SearchMatch(path="src/x.py", line_number=45, content="        return bar"),
+            SearchMatch(path="src/y.py", line_number=3, content="import os"),
+            SearchMatch(path="src/y.py", line_number=99, content="x = 1  # tail"),
+            SearchMatch(path="src/z.py", line_number=7, content="class Z:"),
+        ]
+        r = SearchResult(matches=matches, total_count=5)
+        text = r.to_dict(densify=True)["matches_text"]
+        # Reconstruct (path, line, content) triples from the grouped text.
+        recovered = []
+        cur = None
+        for ln in text.split("\n"):
+            row = re.match(r"^  (\d+): (.*)$", ln)
+            if row:
+                recovered.append((cur, int(row.group(1)), row.group(2)))
+            else:
+                cur = ln
+        assert len(recovered) == 5
+        for orig, rec in zip(matches, recovered):
+            assert rec[0] == orig.path
+            assert rec[1] == orig.line_number
+            # content is rstrip'd in the dense form; originals here have no
+            # trailing whitespace, so they must match exactly.
+            assert rec[2] == orig.content
+
+    def test_densify_smaller_than_verbose(self):
+        import json
+        matches = self._matches(40, paths=["pkg/module_one.py", "pkg/module_two.py"])
+        r = SearchResult(matches=matches, total_count=40)
+        verbose = json.dumps(r.to_dict(densify=False), ensure_ascii=False)
+        dense = json.dumps(r.to_dict(densify=True), ensure_ascii=False)
+        assert len(dense) < len(verbose)
+
+
 class TestLintResult:
     def test_skipped(self):
         r = LintResult(skipped=True, message="No linter for .md files")

--- a/tests/tools/test_read_loop_detection.py
+++ b/tests/tools/test_read_loop_detection.py
@@ -46,7 +46,7 @@ class _FakeSearchResult:
     def __init__(self):
         self.matches = []
 
-    def to_dict(self):
+    def to_dict(self, densify=False):
         return {"matches": [{"file": "test.py", "line": 1, "text": "match"}]}
 
 

--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -30,7 +30,7 @@ import re
 import difflib
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
-from typing import Optional, List, Dict, Any
+from typing import Optional, List, Dict, Any, ClassVar
 from pathlib import Path
 from tools.binary_extensions import BINARY_EXTENSIONS
 
@@ -244,13 +244,56 @@ class SearchResult:
     limit_reason: Optional[str] = None
     error: Optional[str] = None
     
-    def to_dict(self) -> dict:
+    # Densify content-mode matches into a path-grouped text block above this
+    # many matches. Below it, the verbose array is already compact enough that
+    # the path-grouping header costs more than it saves.
+    _DENSIFY_MIN_MATCHES: ClassVar[int] = 5
+
+    def _densify_matches(self) -> Optional[str]:
+        """Render content-mode matches as a compact, path-grouped text block.
+
+        The verbose form repeats the ``{"path","line","content"}`` keys and the
+        full path string for every match. This groups consecutive matches by
+        path (path printed once, then ``  <line>: <content>`` rows), which is
+        lossless — every path, line number, and content byte is preserved — and
+        readable by the model without any decode step.
+
+        Returns ``None`` when densification is not worthwhile (too few matches),
+        so the caller falls back to the verbose array.
+        """
+        if len(self.matches) < self._DENSIFY_MIN_MATCHES:
+            return None
+        # ripgrep emits matches path-ordered (all hits in a file are
+        # consecutive), so grouping on path change collapses each file to a
+        # single header without reordering results.
+        lines: list[str] = []
+        current_path: Optional[str] = None
+        for m in self.matches:
+            if m.path != current_path:
+                lines.append(m.path)
+                current_path = m.path
+            # rstrip trailing whitespace only; leading indentation in code is
+            # meaningful and preserved verbatim after the "<line>: " prefix.
+            lines.append(f"  {m.line_number}: {m.content.rstrip()}")
+        return "\n".join(lines)
+
+    def to_dict(self, densify: bool = False) -> dict:
         result: dict[str, object] = {"total_count": self.total_count}
         if self.matches:
-            result["matches"] = [
-                {"path": m.path, "line": m.line_number, "content": m.content}
-                for m in self.matches
-            ]
+            dense = self._densify_matches() if densify else None
+            if dense is not None:
+                # Self-describing: the format key tells the model how to read
+                # the block so it never has to guess the shape.
+                result["matches_format"] = (
+                    "path-grouped: each file path on its own line, followed by "
+                    "indented '<line>: <content>' rows for matches in that file"
+                )
+                result["matches_text"] = dense
+            else:
+                result["matches"] = [
+                    {"path": m.path, "line": m.line_number, "content": m.content}
+                    for m in self.matches
+                ]
         if self.files:
             result["files"] = self.files
         if self.counts:

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -1478,7 +1478,7 @@ def search_tool(pattern: str, target: str = "content", path: str = ".",
             for m in result.matches:
                 if hasattr(m, 'content') and m.content:
                     m.content = redact_sensitive_text(m.content, code_file=True)
-        result_dict = result.to_dict()
+        result_dict = result.to_dict(densify=True)
 
         if count >= 3:
             result_dict["_warning"] = (


### PR DESCRIPTION
# Headroom evaluation + the one improvement worth shipping

This PR began as an evaluation of [chopratejas/headroom](https://github.com/chopratejas/headroom) ("Compress tool outputs, logs, files, and RAG chunks before they reach the LLM. 60–95% fewer tokens, same answers") as a context-compression layer for Hermes. This description is the **evaluation report first** — what we tested, what we measured, what we concluded — and then the one concrete improvement that came out of it (which is the code change in this PR).

**TL;DR:** Headroom's big advertised numbers come from a remove-and-retrieve mechanism (CCR) that is *net-negative* for an agent that reads its own tool outputs, and its genuinely-lossless densification fires on ~6% of real Hermes traffic for **0.34% net savings** — not worth a heavyweight dependency that also fights our prompt-cache and summarization invariants. But the evaluation surfaced one real, free win: **`search_files` JSON is densifiable losslessly for ~58% fewer tokens with zero dependencies**, which beats headroom on its own best case. That's what we shipped.

---

## 1. What headroom is (and what we evaluated)

Headroom is several things; the README leads with "60–95% fewer tokens." Per the task scope ("primarily the compression stuff, not the other features") we evaluated **only the compression path**:

- `headroom.compress(messages)` library API → `CompressResult` (messages, tokens_before/after/saved, transforms_applied)
- **SmartCrusher** — JSON array → compact CSV+schema (lossless densification)
- **diff compressor** — structural diff compaction (lossless)
- **CCR (Compress-Cache-Retrieve)** — replaces large content with a `<<ccr:HASH>>` marker, stashes the original in a local store, agent retrieves on demand
- **ML Kompress** (prose compression) — probed, then disabled (`kompress_model="disabled"`) for the lossless measurements

**Not evaluated** (explicitly out of scope): `proxy`, `wrap`, MCP server, `headroom learn`, cross-agent memory, output-token reduction, relevance/embedding subsystems.

## 2. How we tested it

1. Installed `headroom-ai[code]` into an isolated venv; verified `compress()` round-trips.
2. Built a `transform_tool_result` plugin (compress each tool result before it enters context) and a `headroom_retrieve` tool against the in-process compression store.
3. Ran it **live through a real Hermes agent** (CLI, multi-turn, real tool calls).
4. Benchmarked against **real Hermes transcripts** pulled from the session DB (up to 3,000 tool outputs), measuring per-tool-type savings, CCR-marker emission, losslessness, and the Hermes invariants (role alternation, tool-pair integrity, wire-safe message keys, prompt-cache).

## 3. What we found

### Finding A — Headroom has two mechanisms that behave very differently here

| mechanism | what it does | verdict for Hermes |
|---|---|---|
| **SmartCrusher / diff** | densifies structured content losslessly (JSON→CSV+schema) | useful but rarely fires |
| **CCR** | *removes* content, leaves `<<ccr:HASH>>`, caches original for retrieval | net-negative for a coding agent |

### Finding B — CCR retrieval works correctly… and that's exactly why it's net-negative

We verified the loop functions before judging it: **12/12** then **10/10** CCR markers from real transcripts round-tripped to their exact originals in-process. In a live run the agent autonomously recognized markers and called `headroom_retrieve` (once with a relevance query) and produced correct summaries.

The problem is structural: the agent **retrieves the data right back because it needs it**, putting the content in context twice (marker + retrieved blob) — *more* tokens than no compression. CCR is built for compressing conversation history the model has moved past (proxy world), not live tool results a coding agent is actively using. It also (a) can't be fully disabled in the library path — opaque-string CCR always emits — and (b) duplicates/fights Hermes' own summarization compressor (`agent/context_compressor.py`).

### Finding C — Lossless-only net savings on real traffic: 0.34%

Gating to lossless-only (reject anything that emits a CCR marker → no retrieval tax, no fidelity loss), measured on a 3,000-output real corpus:

| metric | value |
|---|--:|
| net corpus token savings | **0.34%** |
| firing rate | 6.2% of large outputs |
| read_file / skill_view / patch / terminal (the token bulk) | **~0%** — exceed CCR threshold or no-op |
| only meaningful winner | `search_files` |

By tool type (`kept` = lossless densification survived the no-retrieval gate):

| tool | n | kept | ccr_skip | when-kept reduction | corpus tokens |
|---|--:|--:|--:|--:|--:|
| terminal | 1149 | 4 | 704 | 39% | 2,261,761 |
| read_file | 815 | 0 | 571 | — | 1,471,138 |
| skill_view | 138 | 0 | 90 | — | 1,229,742 |
| search_files | 501 | 135 | 257 | 14% | 1,505,117 |
| patch | 233 | 0 | 202 | — | 138,641 |
| web_search | 24 | 24 | 0 | 13% | 16,529 |

### Finding D — Where lossless densification *does* fire (content-type breakdown)

Single-message compression by content type (ML Kompress disabled, markers counted):

| content type | reduction | CCR markers | transform |
|---|--:|--:|---|
| array JSON | 62.5% | 0 | smart_crusher (lossless) |
| git diff | 64.8% | 0 | diff (lossless) |
| prose | 0% | 0 | noop |
| code | 0% | 0 | noop |

Lossless densification only fires on *structured* content below the opaque-CCR size threshold. The large reference content in real traffic (39 KB skill files, 25 KB diffs) crosses that threshold and gets a CCR marker instead — which is what collapses the net to 0.34%.

### Finding E — Losslessness, where it applies, is real — but NOT unconditional

SmartCrusher's JSON→CSV+schema is semantically lossless on most shapes: a 200-record array compressed to `[200]{id:int,meta.owner:string,score:float,status:string,tags:json}` + CSV rows, **all 200 rows / ids 0–199 recovered** (43% reduction, 0 markers). An adversarial edge-case battery confirmed it handles cases that break naive CSV:

| edge case | result |
|---|---|
| embedded commas / quotes / newlines | ✓ CSV-quoted, exact |
| unicode + emoji (café, 日本語, 🔥) | ✓ byte-exact |
| leading zeros (`"00000"`) | ✓ typed `string`, no int coercion |
| big ints / float precision | ✓ exact |
| nested objects | ✓ flattened to `meta.k` + `meta.deep:json` |
| whitespace-only strings | ✓ preserved |
| mixed types per key | ✓ typed `json` |
| **`null` vs `""` (empty string)** | **✗ both collapse to an empty cell — LOSSY** |

The defect is real and reproducible: `compress([{v: null}])` and `compress([{v: ""}])` produce identical output (schema `v:string?`, empty cell either way). A query like *"how many rows have a null value"* is **unanswerable** from the dense form when nulls and empty strings coexist — which contradicts the project's "same answers" tagline. It is narrow (only bites when the null/empty distinction is semantically load-bearing), but it means headroom's densification is **not unconditionally lossless** — another reason not to route arbitrary tool output through it blind.

### Caveat — the live A/B was too noisy to claim a net session number

A treatment-vs-control run on an identical 5-step audit showed lower raw input tokens (3,305 vs 5,198) but divergent `cache_read`/`cache_write` between the two processes. A single run pair can't control prompt-cache state, so **the reliable measurement is the per-output corpus run, not a live session delta.** Reported for honesty, not as a savings claim.

## 4. Conclusions

- **CCR → reject.** Net-negative for an agent that reads its outputs; can't be disabled in-library; fights our summarizer. Works correctly — that's not the issue.
- **Headroom as a dependency → reject.** ~0.3% net on real traffic, and it would add `litellm` + `tiktoken` + `tree-sitter` + `ast-grep-cli` + ~15 transitive deps, while conflicting with prompt-cache and summarization invariants. Its densification is also not unconditionally lossless (null vs empty-string collision, Finding E). The cost/benefit is upside-down.
- **The idea worth porting → lossless densification of the one shape that actually compresses.** Headroom proved structured tool output (JSON/diff) densifies losslessly. Hermes' single biggest such shape is `search_files` content output — and we don't need headroom to capture it.

## 5. What's worth porting / what we can improve

The evaluation's one actionable result: **`search_files` content results repeat the `{path,line,content}` JSON keys and the full path string for every match.** A ~40-line native densifier groups them and elides the repetition — **lossless, zero dependencies, and it beats headroom on this exact shape: 57.8% vs headroom's gated 2.5%** (headroom keeps tripping its own CCR threshold and skipping these outputs).

That native densifier is the code change in this PR.

Future improvements the evaluation suggests but this PR does **not** do (deliberately scoped out):
- Apply the same path-grouping idea to other structured JSON tool outputs if a shape with comparable repetition + volume shows up (none did in the corpus besides search_files).
- Diff-output compaction (headroom's diff compressor hit ~65% lossless) — `patch` results are small in our corpus (138 K tokens total), so not worth it yet.

---

## 6. The change in this PR

`search_files` content results now ship in a compact path-grouped form instead of a verbose JSON array.

- `tools/file_operations.py`: `SearchResult.to_dict(densify=False)` gains an opt-in path-grouped renderer. Consecutive same-path matches collapse to one path header + indented `<line>: <content>` rows. Self-describing via a `matches_format` key. Gated at `>=5` matches. Default `densify=False` keeps existing callers byte-identical.
- `tools/file_tools.py`: `_handle_search_files` opts into `densify=True` (content mode only).
- `tests/tools/test_file_operations.py`: `TestSearchResultDensify` — off-by-default, threshold gate, path-grouping, **losslessness** + an adversarial edge-case battery (colons, indentation, unicode/emoji, empty content, trailing whitespace, quotes+commas, paths with spaces), and an explicit one-line-per-match invariant. Dense<verbose size.
- `tests/tools/test_read_loop_detection.py`: sibling test's `_FakeSearchResult.to_dict()` updated to mirror the new signature.

Before / after on a real result:

```jsonc
// before (verbose array — keys + path repeated per match)
{"total_count": 20, "matches": [
  {"path": "./tests/agent/test_context_engine.py", "line": 37, "content": "    def compress(self, ..."},
  {"path": "./tests/agent/test_context_engine.py", "line": 91, "content": "        return messages"},
  ...]}

// after (path-grouped — path once, keys elided)
{"total_count": 20,
 "matches_format": "path-grouped: each file path on its own line, followed by indented '<line>: <content>' rows for matches in that file",
 "matches_text": "./tests/agent/test_context_engine.py\n  37:     def compress(self, ...\n  91:         return messages\n..."}
```

### Validation

| | Result |
|---|---|
| New tests | `TestSearchResultDensify` — 6 cases, all pass |
| Regression | `test_file_operations.py` + `test_file_tools.py` + 3 search suites = **155 passed** |
| Live E2E | `_handle_search_files` against this repo → densified, lossless, parseable |
| Backward compat | `to_dict()` (no arg) unchanged — verified by pre-existing `TestSearchResult` |
| CI | full matrix green, `mergeStateStatus: CLEAN` |

| token-impact metric (422 real `search_files` content outputs) | value |
|---|--:|
| densification fires | **97%** of content outputs |
| corpus tokens | 679,967 → 286,648 |
| **reduction** | **57.8%** |
| when it fires | mean 52.9% · median 54.8% · max 74.1% |

Losslessness: every path, line number, and content byte recoverable from `matches_text` (only trailing whitespace `rstrip`'d; leading indentation preserved verbatim). The format puts one match per line, which is safe because ripgrep emits exactly one line per match — verified: **0 of 6,775** real match contents contained a newline. Unlike headroom's SmartCrusher, there is no null/empty ambiguity here: `search_files` content cells are always strings. A multi-turn live audit produced **byte-identical answers** with vs without densification (identical match counts and file rankings across 5 searches).

## Infographic

![search_files densification](https://v3b.fal.media/files/b/0a9ea8be/CyQmLVjuFMpr_48LP9dwX_ngl3dqOK.png)

