### PR TITLE
fix(chat-completions): strip timestamp from messages before sending to strict providers

### DIFF
--- a/agent/transports/chat_completions.py
+++ b/agent/transports/chat_completions.py
@@ -172,6 +172,7 @@ class ChatCompletionsTransport(ProviderTransport):
                 "codex_reasoning_items" in msg
                 or "codex_message_items" in msg
                 or "tool_name" in msg
+                or "timestamp" in msg  # #47868 — strict providers reject this
             ):
                 needs_sanitize = True
                 break
@@ -201,6 +202,7 @@ class ChatCompletionsTransport(ProviderTransport):
             msg.pop("codex_reasoning_items", None)
             msg.pop("codex_message_items", None)
             msg.pop("tool_name", None)
+            msg.pop("timestamp", None)  # #47868 — leak into strict providers
             # Drop all Hermes-internal scaffolding markers (``_``-prefixed).
             # OpenAI's message schema has no ``_``-prefixed fields, so this
             # is safe and future-proofs against new markers being added.


### PR DESCRIPTION
## Summary

Per-message `timestamp` metadata injected by `_apply_persist_user_message_override` leaks into the Chat Completions payload sent to the provider. Strict OpenAI-compatible providers (e.g. Fireworks-backed endpoints like OpenCode Go `glm-5.2`) reject this schema-foreign field with HTTP 400:

```
Extra inputs are not permitted, field: \"messages[0].timestamp\"
```

## Root Cause

The `ChatCompletionsTransport.convert_messages` already strips known internal-only fields (`tool_name`, `_`-prefixed scaffolding keys, `codex_reasoning_items`, etc.) from messages before they reach the wire. The `timestamp` key was not in the strip list.

## Fix

Add `timestamp` to the sanitize check and to the pop-keys in `convert_messages`. This mirrors the existing pattern for `tool_name` and other internal-only fields.

## Testing

- Existing tests pass (the timestamp field is a Hermes-internal concern, not part of the API schema)
- The pattern is identical to the existing `tool_name` strip that was added for the same class of providers

Closes #47868