### PR TITLE
feat: add context and runtime governors

### DIFF
--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -433,6 +433,30 @@ def compress_context(
             except Exception as _rel_err:
                 logger.debug("compression lock release failed: %s", _rel_err)
 
+    # Best-effort plugin hook for deterministic handoffs/checkpoints before
+    # the transcript is summarized or dropped.  Return values are ignored;
+    # plugin failures must never block compression.  Fire after acquiring the
+    # compression lock so concurrent paths do not race duplicate handoffs.
+    try:
+        from hermes_cli.plugins import invoke_hook as _invoke_hook
+        import os as _os
+        _invoke_hook(
+            "pre_context_compress",
+            session_id=getattr(agent, "session_id", None),
+            task_id=task_id,
+            cwd=_os.getcwd(),
+            model=getattr(agent, "model", None),
+            platform=getattr(agent, "platform", None),
+            approx_tokens=approx_tokens,
+            message_count=len(messages),
+            context_length=getattr(agent.context_compressor, "context_length", None),
+            threshold_tokens=getattr(agent.context_compressor, "threshold_tokens", None),
+            compression_count=getattr(agent.context_compressor, "compression_count", 0),
+            focus_topic=focus_topic,
+        )
+    except Exception as _hook_err:
+        logger.debug("pre_context_compress hook failed: %s", _hook_err)
+
     # Notify external memory provider before compression discards context
     if agent._memory_manager:
         try:

--- a/hermes_cli/context_governor.py
+++ b/hermes_cli/context_governor.py
@@ -1,0 +1,876 @@
+"""Deterministic context handoff/checkpoint writer for Hermes.
+
+This module is intentionally cheap and local-only: no model calls, bounded
+SQLite reads, bounded git commands, and best-effort failure behavior for the
+compression hook path.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import shlex
+import sqlite3
+import subprocess
+import tempfile
+import time
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Iterable
+
+from hermes_constants import get_hermes_home
+
+_MAX_GIT_LINES = 80
+_MAX_DB_ROWS = 80
+_MAX_FIELD_CHARS = 2_000
+_GIT_TIMEOUT_SECS = 1.5
+_VERIFY_RE = re.compile(
+    r"\b("
+    r"pytest|python\s+-m\s+pytest|uv\s+run.*pytest|npm\s+(?:test|run\s+(?:test|build|typecheck|lint))|"
+    r"node\s+--test|pnpm\s+(?:test|build|lint)|yarn\s+(?:test|build|lint)|"
+    r"ruff|mypy|pyright|tsc|vite\s+build|cargo\s+test|go\s+test|swift\s+test"
+    r")\b",
+    re.IGNORECASE,
+)
+
+
+@dataclass(frozen=True)
+class HandoffResult:
+    ok: bool
+    path: Path
+    repo_local: bool
+    error: str | None = None
+
+
+def create_handoff(
+    *,
+    cwd: str | os.PathLike[str] | None = None,
+    session_id: str | None = None,
+    task_goal: str | None = None,
+    reason: str = "manual",
+    now: datetime | None = None,
+    state_db_path: str | os.PathLike[str] | None = None,
+    hook_payload: dict[str, Any] | None = None,
+) -> HandoffResult:
+    """Write a deterministic handoff markdown file and return its location.
+
+    Repo work writes ``CURRENT.md`` at the git root. Non-repo work falls back to
+    ``$HERMES_HOME/handoffs/<timestamp>-<session>.md``. Exceptions are captured
+    in the returned result so compression callers can stay best-effort.
+    """
+    timestamp = _coerce_now(now)
+    workdir = _resolve_cwd(cwd)
+    db_path = Path(state_db_path) if state_db_path is not None else get_hermes_home() / "state.db"
+    payload = hook_payload or {}
+
+    try:
+        repo_root = _git_repo_root(workdir)
+        repo_local = repo_root is not None
+        target = repo_root / "CURRENT.md" if repo_root else _global_handoff_path(timestamp, session_id)
+
+        git_info = _collect_git_info(repo_root) if repo_root else _empty_git_info()
+        session_hints = _collect_session_hints(db_path, session_id)
+        effective_goal = _first_nonempty(task_goal, session_hints.get("goal"), payload.get("goal"))
+        verification_hints = _dedupe([*session_hints.get("verification_commands", []), *_payload_commands(payload)])
+
+        content = _render_handoff(
+            timestamp=timestamp,
+            session_id=session_id,
+            cwd=workdir,
+            repo_root=repo_root,
+            repo_local=repo_local,
+            reason=reason,
+            task_goal=effective_goal,
+            git_info=git_info,
+            verification_hints=verification_hints,
+            hook_payload=payload,
+        )
+        _atomic_write(target, content)
+        return HandoffResult(ok=True, path=target, repo_local=repo_local)
+    except Exception as exc:  # best-effort contract for compression hook callers
+        fallback = _global_handoff_path(timestamp, session_id)
+        return HandoffResult(ok=False, path=fallback, repo_local=False, error=f"{type(exc).__name__}: {exc}")
+
+
+def pre_context_compress_handoff(**kwargs: Any) -> HandoffResult:
+    """Hook callback for ``pre_context_compress``.
+
+    Never raises: compression must continue even if checkpointing fails.
+    """
+    try:
+        return create_handoff(
+            cwd=kwargs.get("cwd"),
+            session_id=kwargs.get("session_id"),
+            task_goal=kwargs.get("task_goal") or kwargs.get("goal"),
+            reason="pre_context_compress",
+            hook_payload=kwargs,
+        )
+    except Exception as exc:  # defensive belt-and-suspenders
+        return HandoffResult(
+            ok=False,
+            path=_global_handoff_path(_coerce_now(None), kwargs.get("session_id")),
+            repo_local=False,
+            error=f"{type(exc).__name__}: {exc}",
+        )
+
+
+def find_latest_handoff(*, cwd: str | os.PathLike[str] | None = None, hermes_home: Path | None = None) -> Path | None:
+    """Return the best latest handoff for this workspace.
+
+    Repo-local ``CURRENT.md`` wins when present because it is the source of
+    truth for that checkout. Otherwise use the newest global handoff file.
+    """
+    workdir = _resolve_cwd(cwd)
+    repo_root = _git_repo_root(workdir)
+    if repo_root:
+        current = repo_root / "CURRENT.md"
+        if current.exists():
+            return current
+    home = hermes_home or get_hermes_home()
+    handoff_dir = home / "handoffs"
+    try:
+        candidates = [p for p in handoff_dir.glob("*.md") if p.is_file()]
+    except Exception:
+        candidates = []
+    if not candidates:
+        return None
+    return max(candidates, key=lambda p: p.stat().st_mtime)
+
+
+def get_context_status(
+    *,
+    cwd: str | os.PathLike[str] | None = None,
+    state_db_path: str | os.PathLike[str] | None = None,
+) -> dict[str, Any]:
+    """Return deterministic non-UI Context Governor status for Spend Watch style surfaces."""
+    workdir = _resolve_cwd(cwd)
+    repo_root = _git_repo_root(workdir)
+    latest = find_latest_handoff(cwd=workdir)
+    db_path = Path(state_db_path) if state_db_path is not None else get_hermes_home() / "state.db"
+    burn = get_context_burn_summary(state_db_path=db_path)
+
+    git_info = _collect_git_info(repo_root) if repo_root else _empty_git_info()
+    changed_files = git_info.get("changed_files") or []
+    latest_mtime = _safe_mtime(latest)
+    changed_newer = False
+    if repo_root and changed_files:
+        for rel in changed_files:
+            if rel == "CURRENT.md":
+                continue
+            candidate = repo_root / rel
+            mtime = _safe_mtime(candidate)
+            if latest_mtime is None or (mtime is not None and mtime > latest_mtime):
+                changed_newer = True
+                break
+
+    high_burn = burn.get("avg_tokens_per_api_call", 0) >= 75_000 or burn.get("cache_read_percent", 0) >= 85.0
+    handoff_recommended = bool(changed_newer or high_burn or (changed_files and latest is None))
+    fresh_safe = bool(latest is not None and not changed_newer)
+    if latest is None:
+        reason = "no handoff found"
+    elif changed_newer:
+        reason = "changed files newer than latest handoff"
+    elif high_burn:
+        reason = "latest handoff exists; high context burn suggests fresh session is reasonable"
+    else:
+        reason = "latest handoff is current enough for deterministic resume"
+
+    return {
+        "cwd": str(workdir),
+        "repo_root": str(repo_root) if repo_root else None,
+        "latest_handoff_path": str(latest) if latest else None,
+        "handoff_recommended": handoff_recommended,
+        "fresh_session_safe": fresh_safe,
+        "fresh_session_reason": reason,
+        "git_status_summary": git_info.get("status_summary"),
+        "changed_files": changed_files,
+        "context_burn": burn,
+    }
+
+
+def get_context_burn_summary(
+    *,
+    state_db_path: str | os.PathLike[str] | None = None,
+    days: int = 1,
+) -> dict[str, Any]:
+    db_path = Path(state_db_path) if state_db_path is not None else get_hermes_home() / "state.db"
+    if not db_path.exists():
+        return _empty_burn_summary(days)
+    since = time.time() - max(days, 1) * 86_400
+    try:
+        conn = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True, timeout=0.5)
+        conn.row_factory = sqlite3.Row
+        try:
+            row = conn.execute(
+                """
+                SELECT
+                    COUNT(*) AS session_count,
+                    COALESCE(SUM(input_tokens), 0) AS input_tokens,
+                    COALESCE(SUM(output_tokens), 0) AS output_tokens,
+                    COALESCE(SUM(cache_read_tokens), 0) AS cache_read_tokens,
+                    COALESCE(SUM(cache_write_tokens), 0) AS cache_write_tokens,
+                    COALESCE(SUM(reasoning_tokens), 0) AS reasoning_tokens,
+                    COALESCE(SUM(api_call_count), 0) AS api_call_count
+                FROM sessions
+                WHERE started_at >= ?
+                """,
+                (since,),
+            ).fetchone()
+        finally:
+            conn.close()
+    except Exception:
+        return _empty_burn_summary(days)
+    total = int(row["input_tokens"] or 0) + int(row["output_tokens"] or 0) + int(row["cache_read_tokens"] or 0) + int(row["cache_write_tokens"] or 0) + int(row["reasoning_tokens"] or 0)
+    api_calls = int(row["api_call_count"] or 0)
+    cache_read = int(row["cache_read_tokens"] or 0)
+    return {
+        "days": days,
+        "session_count": int(row["session_count"] or 0),
+        "total_tokens": total,
+        "api_call_count": api_calls,
+        "avg_tokens_per_api_call": round(total / api_calls, 2) if api_calls else 0,
+        "cache_read_percent": round((cache_read / total) * 100, 2) if total else 0,
+    }
+
+
+def build_fresh_session_prompt(handoff_path: str | os.PathLike[str]) -> str:
+    path = Path(handoff_path).expanduser()
+    next_task = _extract_next_session_prompt(path)
+    return (
+        "[Hermes Context Governor fresh-session handoff]\n"
+        f"Read this handoff file first: {path}\n\n"
+        f"{next_task}\n\n"
+        "Continue from the handoff, inspect git status before editing, preserve build quality, "
+        "run relevant verification, and write/update a receipt with proof."
+    )
+
+
+def build_fresh_session_command(handoff_path: str | os.PathLike[str]) -> str:
+    prompt = build_fresh_session_prompt(handoff_path)
+    return f"hermes chat -q {shlex.quote(prompt)}"
+
+
+def get_quality_report(
+    *,
+    state_db_path: str | os.PathLike[str] | None = None,
+    days: int = 30,
+) -> dict[str, Any]:
+    """Compare fresh-from-handoff sessions against monster sessions.
+
+    This is v4's deterministic baseline: no outcome claims beyond what state.db
+    can show cheaply. Verification failures and user corrections are heuristic
+    counters from recent message text.
+    """
+    db_path = Path(state_db_path) if state_db_path is not None else get_hermes_home() / "state.db"
+    if not db_path.exists():
+        return {"days": days, "handoff_sessions": _empty_quality_bucket(), "monster_sessions": _empty_quality_bucket()}
+    since = time.time() - max(days, 1) * 86_400
+    try:
+        conn = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True, timeout=0.5)
+        conn.row_factory = sqlite3.Row
+        try:
+            sessions = conn.execute(
+                """
+                SELECT id, started_at, ended_at, input_tokens, output_tokens,
+                       cache_read_tokens, cache_write_tokens, reasoning_tokens, api_call_count
+                FROM sessions
+                WHERE started_at >= ?
+                """,
+                (since,),
+            ).fetchall()
+            messages = conn.execute(
+                """
+                SELECT session_id, role, content, tool_name
+                FROM messages
+                WHERE session_id IN (SELECT id FROM sessions WHERE started_at >= ?)
+                  AND COALESCE(active, 1) = 1
+                ORDER BY id ASC
+                """,
+                (since,),
+            ).fetchall()
+        finally:
+            conn.close()
+    except Exception:
+        return {"days": days, "handoff_sessions": _empty_quality_bucket(), "monster_sessions": _empty_quality_bucket()}
+
+    by_session: dict[str, list[sqlite3.Row]] = {}
+    for msg in messages:
+        by_session.setdefault(msg["session_id"], []).append(msg)
+
+    handoff_rows = []
+    monster_rows = []
+    for session in sessions:
+        sid = session["id"]
+        session_messages = by_session.get(sid, [])
+        total = _session_total_tokens(session)
+        api_calls = int(session["api_call_count"] or 0)
+        avg = total / api_calls if api_calls else 0
+        first_user = next((_plain_text(m["content"]) or "" for m in session_messages if m["role"] == "user"), "")
+        is_handoff = "Hermes Context Governor fresh-session handoff" in first_user or "Context Governor fresh-session handoff" in first_user
+        enriched = {"session": session, "messages": session_messages}
+        if is_handoff:
+            handoff_rows.append(enriched)
+        elif avg >= 75_000 or total >= 250_000:
+            monster_rows.append(enriched)
+    return {
+        "days": days,
+        "handoff_sessions": _quality_bucket(handoff_rows),
+        "monster_sessions": _quality_bucket(monster_rows),
+    }
+
+
+def checkpoint_command(raw_args: str = "") -> str:
+    """In-session slash command handler for ``/checkpoint``."""
+    parts = raw_args.strip().split()
+    verb = parts[0].lower() if parts else "create"
+    if verb == "status":
+        return _format_status(get_context_status())
+    if verb == "latest":
+        latest = find_latest_handoff()
+        return str(latest) if latest else "No handoff found."
+    if verb == "launch":
+        latest = find_latest_handoff()
+        return build_fresh_session_command(latest) if latest else "No handoff found to launch from."
+    if verb == "quality":
+        return _format_quality_report(get_quality_report())
+
+    goal = raw_args.strip() or None
+    result = create_handoff(task_goal=goal, reason="slash_checkpoint")
+    if result.ok:
+        scope = "repo" if result.repo_local else "global"
+        return f"✓ Checkpoint written ({scope}): {result.path}"
+    return f"⚠ Checkpoint failed: {result.error} (intended path: {result.path})"
+
+
+def setup_cli(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument("args", nargs="*", help="create goal text, or one of: status, latest, launch, quality")
+    parser.add_argument("--cwd", default=None, help="Directory to inspect (default: current working directory)")
+    parser.add_argument("--session-id", default=None, help="Session id to record and inspect in state.db")
+    parser.add_argument("--state-db", default=None, help="Path to Hermes state.db for cheap recent hints")
+    parser.add_argument("--reason", default="cli_checkpoint", help="Reason label written to the handoff")
+    parser.add_argument("--path", default=None, help="Explicit handoff path for launch")
+    parser.add_argument("--execute", action="store_true", help="For launch: execute `hermes chat -q ...` instead of printing it")
+    parser.add_argument("--days", type=int, default=30, help="For quality: lookback window in days")
+    parser.set_defaults(func=cli_main)
+
+
+def cli_main(args: argparse.Namespace) -> int:
+    tokens = list(getattr(args, "args", []) or [])
+    verb = tokens[0].lower() if tokens else "create"
+    db_path = getattr(args, "state_db", None)
+    cwd = getattr(args, "cwd", None)
+    if verb == "status":
+        print(_format_status(get_context_status(cwd=cwd, state_db_path=db_path)))
+        return 0
+    if verb == "latest":
+        latest = find_latest_handoff(cwd=cwd)
+        if latest:
+            print(latest)
+            return 0
+        print("No handoff found.")
+        return 1
+    if verb == "launch":
+        handoff_value = getattr(args, "path", None) or find_latest_handoff(cwd=cwd)
+        if not handoff_value:
+            print("No handoff found to launch from.")
+            return 1
+        handoff = Path(handoff_value)
+        if not handoff.exists():
+            print("No handoff found to launch from.")
+            return 1
+        command = build_fresh_session_command(handoff)
+        if getattr(args, "execute", False):
+            return subprocess.run(["hermes", "chat", "-q", build_fresh_session_prompt(handoff)]).returncode
+        print(command)
+        return 0
+    if verb == "quality":
+        print(_format_quality_report(get_quality_report(state_db_path=db_path, days=getattr(args, "days", 30))))
+        return 0
+
+    goal = " ".join(tokens).strip() or None
+    result = create_handoff(
+        cwd=cwd,
+        session_id=getattr(args, "session_id", None),
+        task_goal=goal,
+        reason=getattr(args, "reason", "cli_checkpoint"),
+        state_db_path=db_path,
+    )
+    if result.ok:
+        scope = "repo-local" if result.repo_local else "global"
+        print(f"Checkpoint written ({scope}): {result.path}")
+        return 0
+    print(f"Checkpoint failed: {result.error} (intended path: {result.path})")
+    return 1
+
+
+def _coerce_now(now: datetime | None) -> datetime:
+    if now is None:
+        return datetime.now(timezone.utc)
+    if now.tzinfo is None:
+        return now.replace(tzinfo=timezone.utc)
+    return now.astimezone(timezone.utc)
+
+
+def _resolve_cwd(cwd: str | os.PathLike[str] | None) -> Path:
+    path = Path(cwd or os.getcwd()).expanduser()
+    try:
+        return path.resolve()
+    except Exception:
+        return path.absolute()
+
+
+def _run_git(repo_or_cwd: Path, *args: str) -> str | None:
+    try:
+        proc = subprocess.run(
+            ["git", "-C", str(repo_or_cwd), *args],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            timeout=_GIT_TIMEOUT_SECS,
+            check=False,
+        )
+    except Exception:
+        return None
+    if proc.returncode != 0:
+        return None
+    return proc.stdout.strip()
+
+
+def _git_repo_root(cwd: Path) -> Path | None:
+    out = _run_git(cwd, "rev-parse", "--show-toplevel")
+    if not out:
+        return None
+    try:
+        return Path(out).resolve()
+    except Exception:
+        return Path(out)
+
+
+def _collect_git_info(repo_root: Path) -> dict[str, Any]:
+    branch = _run_git(repo_root, "branch", "--show-current") or _run_git(repo_root, "rev-parse", "--abbrev-ref", "HEAD") or "unknown"
+    status = _bounded_lines(_run_git(repo_root, "status", "--short") or "")
+    changed = []
+    for line in status:
+        # porcelain v1 normally uses two status columns plus a separator, but
+        # older/custom git output can collapse the separator for staged-only
+        # paths ("M path"). Prefer the porcelain slice when present; otherwise
+        # split on whitespace so we do not drop the first path character.
+        if len(line) >= 3 and line[2].isspace():
+            path = line[3:]
+        else:
+            parts = line.split(maxsplit=1)
+            path = parts[1] if len(parts) == 2 else line
+        if " -> " in path:
+            path = path.split(" -> ", 1)[1]
+        if path:
+            changed.append(path)
+    summary = "clean" if not status else f"{len(status)} changed path(s) shown"
+    return {
+        "branch": branch,
+        "status_summary": summary,
+        "status_lines": status,
+        "changed_files": _dedupe(changed)[:_MAX_GIT_LINES],
+    }
+
+
+def _empty_git_info() -> dict[str, Any]:
+    return {"branch": "(not a git repo)", "status_summary": "not a git repo", "status_lines": [], "changed_files": []}
+
+
+def _collect_session_hints(db_path: Path, session_id: str | None) -> dict[str, Any]:
+    if not session_id or not db_path.exists():
+        return {"goal": None, "verification_commands": []}
+    uri = f"file:{db_path}?mode=ro"
+    try:
+        conn = sqlite3.connect(uri, uri=True, timeout=0.5)
+        conn.row_factory = sqlite3.Row
+        try:
+            rows = conn.execute(
+                """
+                SELECT role, content, tool_calls, tool_name
+                FROM messages
+                WHERE session_id = ? AND COALESCE(active, 1) = 1
+                ORDER BY id DESC
+                LIMIT ?
+                """,
+                (session_id, _MAX_DB_ROWS),
+            ).fetchall()
+        finally:
+            conn.close()
+    except Exception:
+        return {"goal": None, "verification_commands": []}
+
+    goal = None
+    commands: list[str] = []
+    for row in reversed(rows):
+        role = row["role"]
+        content = _plain_text(row["content"])
+        if role == "user" and content and not content.lstrip().startswith("/"):
+            goal = _truncate(content.replace("\n", " "), 240)
+        commands.extend(_commands_from_tool_calls(row["tool_calls"]))
+        if row["tool_name"] == "terminal":
+            commands.extend(_commands_from_text(content))
+    return {"goal": goal, "verification_commands": _dedupe([c for c in commands if _VERIFY_RE.search(c)])[:8]}
+
+
+def _commands_from_tool_calls(raw: Any) -> list[str]:
+    if not raw:
+        return []
+    try:
+        calls = json.loads(raw) if isinstance(raw, str) else raw
+    except Exception:
+        return []
+    if isinstance(calls, dict):
+        calls = [calls]
+    if not isinstance(calls, list):
+        return []
+    found: list[str] = []
+    for call in calls:
+        if not isinstance(call, dict):
+            continue
+        fn = call.get("function") if isinstance(call.get("function"), dict) else call
+        name = fn.get("name") if isinstance(fn, dict) else None
+        if name != "terminal":
+            continue
+        args = fn.get("arguments") if isinstance(fn, dict) else None
+        if isinstance(args, str):
+            try:
+                args = json.loads(args)
+            except Exception:
+                continue
+        if isinstance(args, dict) and isinstance(args.get("command"), str):
+            found.append(_truncate(args["command"].strip(), 300))
+    return found
+
+
+def _commands_from_text(text: str | None) -> list[str]:
+    if not text:
+        return []
+    commands: list[str] = []
+    for line in text.splitlines():
+        stripped = line.strip()
+        if _VERIFY_RE.search(stripped):
+            commands.append(_truncate(stripped, 300))
+    return commands
+
+
+def _payload_commands(payload: dict[str, Any]) -> list[str]:
+    hints = payload.get("verification_commands") or payload.get("verification_hints") or []
+    if isinstance(hints, str):
+        hints = [hints]
+    if not isinstance(hints, Iterable):
+        return []
+    return [_truncate(str(x), 300) for x in hints if str(x).strip()]
+
+
+def _render_handoff(
+    *,
+    timestamp: datetime,
+    session_id: str | None,
+    cwd: Path,
+    repo_root: Path | None,
+    repo_local: bool,
+    reason: str,
+    task_goal: str | None,
+    git_info: dict[str, Any],
+    verification_hints: list[str],
+    hook_payload: dict[str, Any],
+) -> str:
+    ts = timestamp.isoformat().replace("+00:00", "Z")
+    repo_display = f"`{repo_root}`" if repo_root else "`(not detected)`"
+    changed_files = git_info.get("changed_files") or []
+    status_lines = git_info.get("status_lines") or []
+    payload_lines = _format_hook_payload(hook_payload)
+
+    lines = [
+        "# CURRENT — Hermes Context Governor Handoff",
+        "",
+        "This file is deterministic local state written before/around context loss. It contains no LLM analysis by default.",
+        "",
+        "## Snapshot",
+        f"- Timestamp: `{ts}`",
+        f"- Session ID: `{session_id or '(unknown)'}`",
+        f"- CWD: `{cwd}`",
+        f"- Repo root: {repo_display}",
+        f"- Scope: {'repo-local CURRENT.md' if repo_local else 'global fallback'}",
+        f"- Reason: {reason}",
+        "",
+        "## Current task / goal",
+        _truncate(task_goal, _MAX_FIELD_CHARS) if task_goal else "(not available — start by reading git status and recent receipts)",
+        "",
+        "## Git state",
+        f"- Branch: `{git_info.get('branch', 'unknown')}`",
+        f"- Status summary: {git_info.get('status_summary', 'unknown')}",
+        "",
+        "### Changed files",
+    ]
+    if changed_files:
+        lines.extend(f"- `{path}`" for path in changed_files)
+    else:
+        lines.append("- (none detected)")
+    lines.extend(["", "### `git status --short` (bounded)"])
+    if status_lines:
+        lines.append("```text")
+        lines.extend(status_lines)
+        lines.append("```")
+    else:
+        lines.append("```text\n(clean or unavailable)\n```")
+
+    lines.extend(["", "## Recent verification command hints"])
+    if verification_hints:
+        lines.extend(f"- `{cmd}`" for cmd in verification_hints)
+    else:
+        lines.append("- (none cheaply discovered)")
+
+    if payload_lines:
+        lines.extend(["", "## Compression trigger payload (bounded)"])
+        lines.extend(payload_lines)
+
+    lines.extend([
+        "",
+        "## Next-session prompt",
+        "```text",
+        "Resume this Hermes work from this handoff. Read CURRENT.md (or this global handoff) first, inspect git status, then continue the current task without assuming prior chat context. Preserve build quality: verify changed files, run the relevant focused tests/build commands, and write a receipt with proof before declaring success.",
+        "```",
+        "",
+    ])
+    return "\n".join(lines)
+
+
+def _format_hook_payload(payload: dict[str, Any]) -> list[str]:
+    keep = [
+        "task_id",
+        "platform",
+        "model",
+        "approx_tokens",
+        "message_count",
+        "context_length",
+        "threshold_tokens",
+        "compression_count",
+        "focus_topic",
+    ]
+    lines = []
+    for key in keep:
+        if key in payload and payload[key] is not None:
+            lines.append(f"- {key}: `{_truncate(str(payload[key]), 240)}`")
+    return lines
+
+
+def _global_handoff_path(timestamp: datetime, session_id: str | None) -> Path:
+    stamp = timestamp.strftime("%Y%m%dT%H%M%SZ")
+    suffix = _safe_slug(session_id or "no-session")
+    return get_hermes_home() / "handoffs" / f"{stamp}-{suffix}.md"
+
+
+def _atomic_write(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp_name = tempfile.mkstemp(prefix=f".{path.name}.", suffix=".tmp", dir=str(path.parent))
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as fh:
+            fh.write(content)
+            fh.flush()
+            os.fsync(fh.fileno())
+        os.replace(tmp_name, path)
+    finally:
+        try:
+            if os.path.exists(tmp_name):
+                os.unlink(tmp_name)
+        except Exception:
+            pass
+
+
+def _bounded_lines(text: str) -> list[str]:
+    lines = text.splitlines()[:_MAX_GIT_LINES]
+    return [_truncate(line, 500) for line in lines]
+
+
+def _plain_text(value: Any) -> str | None:
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        return _truncate(str(value), _MAX_FIELD_CHARS)
+    stripped = value.strip()
+    if not stripped:
+        return None
+    if stripped.startswith("[") or stripped.startswith("{"):
+        try:
+            parsed = json.loads(stripped)
+            if isinstance(parsed, str):
+                return parsed
+            if isinstance(parsed, list):
+                parts = []
+                for item in parsed:
+                    if isinstance(item, dict) and isinstance(item.get("text"), str):
+                        parts.append(item["text"])
+                    elif isinstance(item, str):
+                        parts.append(item)
+                if parts:
+                    return _truncate(" ".join(parts), _MAX_FIELD_CHARS)
+        except Exception:
+            pass
+    return _truncate(stripped, _MAX_FIELD_CHARS)
+
+
+def _truncate(value: Any, limit: int) -> str:
+    text = "" if value is None else str(value)
+    if len(text) <= limit:
+        return text
+    return text[: max(0, limit - 1)] + "…"
+
+
+def _dedupe(items: Iterable[str]) -> list[str]:
+    seen: set[str] = set()
+    out: list[str] = []
+    for item in items:
+        text = str(item).strip()
+        if not text or text in seen:
+            continue
+        seen.add(text)
+        out.append(text)
+    return out
+
+
+def _first_nonempty(*values: Any) -> str | None:
+    for value in values:
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    return None
+
+
+def _safe_mtime(path: Path | None) -> float | None:
+    if path is None:
+        return None
+    try:
+        return path.stat().st_mtime
+    except Exception:
+        return None
+
+
+def _empty_burn_summary(days: int) -> dict[str, Any]:
+    return {
+        "days": days,
+        "session_count": 0,
+        "total_tokens": 0,
+        "api_call_count": 0,
+        "avg_tokens_per_api_call": 0,
+        "cache_read_percent": 0,
+    }
+
+
+def _extract_next_session_prompt(path: Path) -> str:
+    default = "Resume from the latest Context Governor handoff."
+    try:
+        text = path.read_text(encoding="utf-8")
+    except Exception:
+        return default
+    marker = "## Next-session prompt"
+    idx = text.find(marker)
+    if idx < 0:
+        return default
+    tail = text[idx + len(marker):]
+    match = re.search(r"```(?:text)?\s*(.*?)```", tail, re.DOTALL | re.IGNORECASE)
+    if match:
+        return _truncate(match.group(1).strip(), 2_000) or default
+    lines = [line.strip() for line in tail.splitlines() if line.strip()]
+    return _truncate(" ".join(lines[:6]), 2_000) or default
+
+
+def _session_total_tokens(session: sqlite3.Row | dict[str, Any]) -> int:
+    total = 0
+    for key in ("input_tokens", "output_tokens", "cache_read_tokens", "cache_write_tokens", "reasoning_tokens"):
+        try:
+            total += int(session[key] or 0)
+        except Exception:
+            pass
+    return total
+
+
+def _empty_quality_bucket() -> dict[str, Any]:
+    return {
+        "session_count": 0,
+        "total_tokens": 0,
+        "api_call_count": 0,
+        "avg_tokens_per_api_call": 0,
+        "cache_read_percent": 0,
+        "verification_failure_markers": 0,
+        "user_correction_markers": 0,
+        "avg_elapsed_minutes": 0,
+    }
+
+
+def _quality_bucket(rows: list[dict[str, Any]]) -> dict[str, Any]:
+    if not rows:
+        return _empty_quality_bucket()
+    total_tokens = 0
+    cache_read = 0
+    api_calls = 0
+    elapsed_minutes: list[float] = []
+    verification_failures = 0
+    corrections = 0
+    for item in rows:
+        session = item["session"]
+        messages = item["messages"]
+        total_tokens += _session_total_tokens(session)
+        cache_read += int(session["cache_read_tokens"] or 0)
+        api_calls += int(session["api_call_count"] or 0)
+        started = float(session["started_at"] or 0)
+        ended = float(session["ended_at"] or 0) if session["ended_at"] is not None else started
+        if ended >= started and started > 0:
+            elapsed_minutes.append((ended - started) / 60)
+        for msg in messages:
+            text = (_plain_text(msg["content"]) or "").lower()
+            if msg["tool_name"] == "terminal" and any(token in text for token in ("failed", "error", "traceback", "exit_code")):
+                verification_failures += 1
+            if msg["role"] == "user" and any(token in text for token in ("actually", "not what", "wrong", "fix that", "you missed")):
+                corrections += 1
+    return {
+        "session_count": len(rows),
+        "total_tokens": total_tokens,
+        "api_call_count": api_calls,
+        "avg_tokens_per_api_call": round(total_tokens / api_calls, 2) if api_calls else 0,
+        "cache_read_percent": round((cache_read / total_tokens) * 100, 2) if total_tokens else 0,
+        "verification_failure_markers": verification_failures,
+        "user_correction_markers": corrections,
+        "avg_elapsed_minutes": round(sum(elapsed_minutes) / len(elapsed_minutes), 2) if elapsed_minutes else 0,
+    }
+
+
+def _format_status(status: dict[str, Any]) -> str:
+    burn = status.get("context_burn") or {}
+    return "\n".join([
+        "Context Governor status",
+        f"latest_handoff_path: {status.get('latest_handoff_path') or '(none)'}",
+        f"handoff_recommended: {status.get('handoff_recommended')}",
+        f"fresh_session_safe: {status.get('fresh_session_safe')}",
+        f"fresh_session_reason: {status.get('fresh_session_reason')}",
+        f"avg_tokens_per_api_call_1d: {burn.get('avg_tokens_per_api_call', 0)}",
+        f"cache_read_percent_1d: {burn.get('cache_read_percent', 0)}",
+        f"git_status_summary: {status.get('git_status_summary')}",
+    ])
+
+
+def _format_quality_report(report: dict[str, Any]) -> str:
+    handoff = report.get("handoff_sessions") or {}
+    monster = report.get("monster_sessions") or {}
+    return "\n".join([
+        f"Context Governor quality report ({report.get('days')}d)",
+        "handoff_sessions:",
+        f"  sessions: {handoff.get('session_count', 0)}",
+        f"  avg_tokens_per_api_call: {handoff.get('avg_tokens_per_api_call', 0)}",
+        f"  verification_failure_markers: {handoff.get('verification_failure_markers', 0)}",
+        f"  user_correction_markers: {handoff.get('user_correction_markers', 0)}",
+        "monster_sessions:",
+        f"  sessions: {monster.get('session_count', 0)}",
+        f"  avg_tokens_per_api_call: {monster.get('avg_tokens_per_api_call', 0)}",
+        f"  verification_failure_markers: {monster.get('verification_failure_markers', 0)}",
+        f"  user_correction_markers: {monster.get('user_correction_markers', 0)}",
+    ])
+
+
+def _safe_slug(value: str) -> str:
+    slug = re.sub(r"[^A-Za-z0-9_.-]+", "-", value.strip())
+    slug = slug.strip(".-")
+    return slug[:80] or "handoff"

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -139,6 +139,10 @@ VALID_HOOKS: Set[str] = {
     "pre_api_request",
     "post_api_request",
     "api_request_error",
+    # Observer hook fired immediately before context compression mutates the
+    # in-memory transcript. Plugins must treat this as best-effort only:
+    # return values are ignored and callback failures must not block compression.
+    "pre_context_compress",
     "on_session_start",
     "on_session_end",
     "on_session_finalize",

--- a/hermes_cli/runtime_governor.py
+++ b/hermes_cli/runtime_governor.py
@@ -1,0 +1,588 @@
+"""Deterministic observe-only Runtime Governor for Hermes.
+
+The Runtime Governor reports runtime waste smells from the local session store.
+It is intentionally backend-only, model-free, and side-effect free: no UI, no
+policy enforcement, no cost claims when provider telemetry is missing.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sqlite3
+import time
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any, Iterable
+
+from hermes_constants import get_hermes_home
+
+_RECEIPT_RE = re.compile(r"\b(receipts?|receipt-tagged|proof\s+notes?)\b", re.IGNORECASE)
+_DOCS_RE = re.compile(r"\b(readme|handoff|current\.md|\.md\b|docs?|documentation)\b", re.IGNORECASE)
+_WRITE_RE = re.compile(r"\b(write|wrote|save|saved|create|created|append|render|rendered)\b", re.IGNORECASE)
+_READ_RE = re.compile(r"\b(read|opened|cat|full\s+read|read_file|readback|read\s+back)\b", re.IGNORECASE)
+_SUMMARIZE_RE = re.compile(r"\b(summarize|summarise|summary|final\s+response|restate|recap)\b", re.IGNORECASE)
+_DONE_RE = re.compile(r"\b(done|build passed|tests? passed|complete|completed|receipt)\b", re.IGNORECASE)
+
+_DEFAULT_TOP_N = 10
+
+
+@dataclass(frozen=True)
+class RuntimeGovernorConfig:
+    """Deterministic thresholds for observe-only runtime classification."""
+
+    high_api_calls_per_session: int = 50
+    high_non_cache_tokens_per_session: int = 250_000
+    high_gross_tokens_per_session: int = 5_000_000
+    high_receipt_readback_mentions: int = 3
+    high_receipt_write_mentions: int = 3
+    excessive_finalization_calls: int = 3
+    high_same_file_read_count: int = 3
+    long_session_api_calls: int = 80
+    max_human_receipt_lines: int = 80
+
+
+def generate_runtime_report(
+    *,
+    state_db_path: str | Path | None = None,
+    days: int = 30,
+    now: float | None = None,
+    source: str | None = None,
+    config: RuntimeGovernorConfig | None = None,
+) -> dict[str, Any]:
+    """Generate an observe-only Runtime Governor report from a Hermes state DB.
+
+    The returned dict is structured for tests/automation. Use
+    :func:`format_runtime_report` for a lean terminal rendering.
+    """
+
+    cfg = config or RuntimeGovernorConfig()
+    timestamp = float(now if now is not None else time.time())
+    db_path = Path(state_db_path) if state_db_path is not None else get_hermes_home() / "state.db"
+    empty = _empty_report(days=days, generated_at=timestamp, db_path=db_path, config=cfg, source=source)
+    if not db_path.exists():
+        empty["warnings"].append(f"state DB not found: {db_path}")
+        return empty
+
+    try:
+        conn = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True, timeout=1.0)
+        conn.row_factory = sqlite3.Row
+    except sqlite3.Error as exc:
+        empty["warnings"].append(f"could not open state DB read-only: {type(exc).__name__}: {exc}")
+        return empty
+
+    try:
+        sessions = _fetch_sessions(conn, since=timestamp - max(days, 1) * 86_400, source=source)
+        messages_by_session = _fetch_messages_by_session(
+            conn,
+            [str(s.get("session_id")) for s in sessions],
+            since=timestamp - max(days, 1) * 86_400,
+        )
+    finally:
+        conn.close()
+
+    report = _build_report(
+        sessions=sessions,
+        messages_by_session=messages_by_session,
+        days=days,
+        generated_at=timestamp,
+        db_path=db_path,
+        cfg=cfg,
+        source=source,
+    )
+    return report
+
+
+def format_runtime_report(report: dict[str, Any]) -> str:
+    """Render a concise human-readable observe-only report."""
+
+    totals = report.get("totals", {})
+    cost = report.get("cost", {})
+    receipt = report.get("receipt_overhead", {})
+    lines = [
+        f"Runtime Governor observe-only report ({report.get('days')}d)",
+        f"DB: {report.get('db_path')}",
+        "",
+        "Totals:",
+        f"- Sessions: {totals.get('sessions', 0)}",
+        f"- API calls: {totals.get('api_calls', 0)}",
+        f"- Gross context tokens: {totals.get('gross_context_tokens', 0)}",
+        f"- Non-cache-ish tokens: {totals.get('non_cache_tokens', 0)}",
+    ]
+    if not cost.get("reliable", False):
+        lines.append("- Cost telemetry unreliable/missing; no dollar spend claims made.")
+    else:
+        lines.append(f"- Recorded cost: ${cost.get('recorded_cost_usd', 0.0):.4f}")
+
+    lines.extend(
+        [
+            "",
+            "Receipt/docs overhead heuristics:",
+            f"- Receipt-tagged sessions: {receipt.get('receipt_tagged_sessions', 0)} (upper bound, not marginal receipt spend)",
+            f"- Docs-or-receipt-tagged sessions: {receipt.get('docs_or_receipt_tagged_sessions', 0)} (broad upper bound)",
+            f"- Receipt write-ish mentions: {receipt.get('write_mentions', 0)}",
+            f"- Receipt read-ish mentions: {receipt.get('read_mentions', 0)}",
+            f"- Suspected write/read/summarize loops: {receipt.get('suspected_loops', 0)}",
+        ]
+    )
+
+    estimates = receipt.get("avoidable_token_estimates", {})
+    if estimates:
+        lines.extend(
+            [
+                "- Avoidable-token estimate range:",
+                f"  - conservative: {estimates.get('conservative', 0)}",
+                f"  - plausible: {estimates.get('plausible', 0)}",
+                f"  - aggressive: {estimates.get('aggressive', 0)}",
+            ]
+        )
+
+    recommendations = report.get("recommendations") or []
+    if recommendations:
+        lines.extend(["", "Recommendations:"])
+        for item in recommendations[:8]:
+            lines.append(f"- [{item.get('confidence', 'unknown')}] {item.get('recommendation')}")
+
+    warnings = report.get("warnings") or []
+    if warnings:
+        lines.extend(["", "Warnings:"])
+        for warning in warnings:
+            lines.append(f"- {warning}")
+
+    return "\n".join(lines)
+
+
+def _build_report(
+    *,
+    sessions: list[dict[str, Any]],
+    messages_by_session: dict[str, list[dict[str, Any]]],
+    days: int,
+    generated_at: float,
+    db_path: Path,
+    cfg: RuntimeGovernorConfig,
+    source: str | None,
+) -> dict[str, Any]:
+    totals = _compute_totals(sessions)
+    cost = _compute_cost(sessions)
+    per_session = [_analyze_session(session, messages_by_session.get(session["session_id"], []), cfg) for session in sessions]
+    receipt = _compute_receipt_overhead(per_session, totals)
+    outliers = _compute_outliers(per_session)
+    recommendations = _compute_recommendations(per_session, receipt, cost, cfg)
+
+    report = _empty_report(days=days, generated_at=generated_at, db_path=db_path, config=cfg, source=source)
+    report.update(
+        {
+            "totals": totals,
+            "cost": cost,
+            "receipt_overhead": receipt,
+            "outliers": outliers,
+            "runtime_smells": _compute_runtime_smells(per_session, cfg),
+            "recommendations": recommendations,
+            "session_count_analyzed": len(per_session),
+        }
+    )
+    if not cost["reliable"]:
+        report["warnings"].append("cost telemetry unreliable/missing; cost fields are zero, null, or sparse")
+    return report
+
+
+def _empty_report(
+    *,
+    days: int,
+    generated_at: float,
+    db_path: Path,
+    config: RuntimeGovernorConfig,
+    source: str | None,
+) -> dict[str, Any]:
+    return {
+        "mode": "observe",
+        "days": days,
+        "source_filter": source,
+        "generated_at": generated_at,
+        "db_path": str(db_path),
+        "config": asdict(config),
+        "totals": {
+            "sessions": 0,
+            "api_calls": 0,
+            "gross_context_tokens": 0,
+            "non_cache_tokens": 0,
+            "output_tokens": 0,
+            "cache_read_tokens": 0,
+            "cache_write_tokens": 0,
+            "reasoning_tokens": 0,
+        },
+        "cost": {"reliable": False, "recorded_cost_usd": 0.0, "sessions_with_cost": 0},
+        "receipt_overhead": {
+            "receipt_tagged_sessions": 0,
+            "docs_or_receipt_tagged_sessions": 0,
+            "write_mentions": 0,
+            "read_mentions": 0,
+            "suspected_loops": 0,
+            "avoidable_token_estimates": {"conservative": 0, "plausible": 0, "aggressive": 0},
+        },
+        "outliers": {"by_api_calls": [], "by_non_cache_tokens": [], "by_gross_context_tokens": []},
+        "runtime_smells": {},
+        "recommendations": [],
+        "warnings": [],
+        "session_count_analyzed": 0,
+    }
+
+
+def _fetch_sessions(conn: sqlite3.Connection, *, since: float, source: str | None) -> list[dict[str, Any]]:
+    if not _table_exists(conn, "sessions"):
+        return []
+    cols = _columns(conn, "sessions")
+    required = {"id", "started_at"}
+    if not required.issubset(cols):
+        return []
+
+    select_exprs = [
+        _select_col(cols, "id", alias="session_id", text=True),
+        _select_col(cols, "source", text=True),
+        _select_col(cols, "title", text=True),
+        _select_col(cols, "started_at"),
+        _select_col(cols, "input_tokens"),
+        _select_col(cols, "output_tokens"),
+        _select_col(cols, "cache_read_tokens"),
+        _select_col(cols, "cache_write_tokens"),
+        _select_col(cols, "reasoning_tokens"),
+        _select_col(cols, "api_call_count"),
+        _select_col(cols, "estimated_cost_usd"),
+        _select_col(cols, "actual_cost_usd"),
+    ]
+    sql = f"SELECT {', '.join(select_exprs)} FROM sessions WHERE started_at >= ?"
+    params: list[Any] = [since]
+    if source and "source" in cols:
+        sql += " AND source = ?"
+        params.append(source)
+    sql += " ORDER BY started_at DESC"
+    rows = conn.execute(sql, params).fetchall()
+    return [_normalize_session(dict(row)) for row in rows]
+
+
+def _fetch_messages_by_session(
+    conn: sqlite3.Connection,
+    session_ids: list[str],
+    *,
+    since: float,
+) -> dict[str, list[dict[str, Any]]]:
+    if not session_ids or not _table_exists(conn, "messages"):
+        return {}
+    cols = _columns(conn, "messages")
+    if "session_id" not in cols:
+        return {}
+    select_exprs = [
+        _select_col(cols, "session_id", text=True),
+        _select_col(cols, "role", text=True),
+        _select_col(cols, "content", text=True),
+        _select_col(cols, "tool_name", text=True),
+        _select_col(cols, "timestamp"),
+    ]
+    placeholders = ",".join("?" for _ in session_ids)
+    sql = f"SELECT {', '.join(select_exprs)} FROM messages WHERE session_id IN ({placeholders})"
+    params: list[Any] = list(session_ids)
+    if "timestamp" in cols:
+        sql += " AND timestamp >= ?"
+        params.append(since)
+    sql += " ORDER BY session_id, timestamp"
+    rows = conn.execute(sql, params).fetchall()
+    by_session: dict[str, list[dict[str, Any]]] = {sid: [] for sid in session_ids}
+    for row in rows:
+        data = dict(row)
+        by_session.setdefault(str(data.get("session_id")), []).append(data)
+    return by_session
+
+
+def _normalize_session(row: dict[str, Any]) -> dict[str, Any]:
+    normalized = dict(row)
+    for key in (
+        "started_at",
+        "input_tokens",
+        "output_tokens",
+        "cache_read_tokens",
+        "cache_write_tokens",
+        "reasoning_tokens",
+        "api_call_count",
+    ):
+        normalized[key] = int(normalized.get(key) or 0)
+    for key in ("estimated_cost_usd", "actual_cost_usd"):
+        value = normalized.get(key)
+        normalized[key] = float(value) if value not in (None, "") else None
+    normalized["session_id"] = str(normalized.get("session_id") or "")
+    return normalized
+
+
+def _analyze_session(
+    session: dict[str, Any],
+    messages: list[dict[str, Any]],
+    cfg: RuntimeGovernorConfig,
+) -> dict[str, Any]:
+    texts = [_message_text(m) for m in messages]
+    receipt_matches = [text for text in texts if _RECEIPT_RE.search(text)]
+    docs_matches = [text for text in texts if _DOCS_RE.search(text)]
+    write_mentions = sum(1 for text in receipt_matches if _WRITE_RE.search(text))
+    read_mentions = sum(1 for text in receipt_matches if _READ_RE.search(text))
+    summarize_mentions = sum(1 for text in receipt_matches if _SUMMARIZE_RE.search(text))
+    suspected_loop = _has_ordered_loop(texts)
+    non_cache_tokens = _non_cache_tokens(session)
+    gross_context_tokens = _gross_context_tokens(session)
+    api_calls = int(session.get("api_call_count") or 0)
+    finalization_churn = _finalization_churn(messages, cfg)
+
+    return {
+        "session_id": session.get("session_id"),
+        "title": session.get("title"),
+        "source": session.get("source"),
+        "started_at": session.get("started_at"),
+        "api_calls": api_calls,
+        "gross_context_tokens": gross_context_tokens,
+        "non_cache_tokens": non_cache_tokens,
+        "receipt_tagged": bool(receipt_matches),
+        "docs_or_receipt_tagged": bool(receipt_matches or docs_matches),
+        "receipt_mentions": len(receipt_matches),
+        "write_mentions": write_mentions,
+        "read_mentions": read_mentions,
+        "summarize_mentions": summarize_mentions,
+        "suspected_receipt_loop": suspected_loop,
+        "finalization_churn": finalization_churn,
+        "high_api_calls": api_calls >= cfg.high_api_calls_per_session,
+        "high_non_cache_tokens": non_cache_tokens >= cfg.high_non_cache_tokens_per_session,
+        "high_gross_context_tokens": gross_context_tokens >= cfg.high_gross_tokens_per_session,
+    }
+
+
+def _compute_totals(sessions: list[dict[str, Any]]) -> dict[str, int]:
+    totals = {
+        "sessions": len(sessions),
+        "api_calls": sum(int(s.get("api_call_count") or 0) for s in sessions),
+        "gross_context_tokens": sum(_gross_context_tokens(s) for s in sessions),
+        "non_cache_tokens": sum(_non_cache_tokens(s) for s in sessions),
+        "output_tokens": sum(int(s.get("output_tokens") or 0) for s in sessions),
+        "cache_read_tokens": sum(int(s.get("cache_read_tokens") or 0) for s in sessions),
+        "cache_write_tokens": sum(int(s.get("cache_write_tokens") or 0) for s in sessions),
+        "reasoning_tokens": sum(int(s.get("reasoning_tokens") or 0) for s in sessions),
+    }
+    return totals
+
+
+def _compute_cost(sessions: list[dict[str, Any]]) -> dict[str, Any]:
+    cost_values = [_session_recorded_cost(s) for s in sessions]
+    sessions_with_cost = sum(1 for value in cost_values if value > 0)
+    recorded_cost = sum(cost_values)
+    reliable = bool(sessions and recorded_cost > 0 and sessions_with_cost / len(sessions) >= 0.5)
+    return {
+        "reliable": reliable,
+        "recorded_cost_usd": recorded_cost,
+        "sessions_with_cost": sessions_with_cost,
+        "sessions_total": len(sessions),
+    }
+
+
+def _session_recorded_cost(session: dict[str, Any]) -> float:
+    value = session.get("actual_cost_usd")
+    if value is None:
+        value = session.get("estimated_cost_usd")
+    if value in (None, ""):
+        return 0.0
+    return float(value)
+
+
+
+def _compute_receipt_overhead(per_session: list[dict[str, Any]], totals: dict[str, int]) -> dict[str, Any]:
+    receipt_sessions = [s for s in per_session if s["receipt_tagged"]]
+    loop_sessions = [s for s in per_session if s["suspected_receipt_loop"]]
+    write_mentions = sum(int(s["write_mentions"]) for s in per_session)
+    read_mentions = sum(int(s["read_mentions"]) for s in per_session)
+    avg_non_cache_per_call = 0
+    if totals["api_calls"] > 0:
+        avg_non_cache_per_call = max(1, int(totals["non_cache_tokens"] / totals["api_calls"]))
+    loop_basis = max(len(loop_sessions), 0)
+    return {
+        "receipt_tagged_sessions": len(receipt_sessions),
+        "docs_or_receipt_tagged_sessions": sum(1 for s in per_session if s["docs_or_receipt_tagged"]),
+        "write_mentions": write_mentions,
+        "read_mentions": read_mentions,
+        "summarize_mentions": sum(int(s["summarize_mentions"]) for s in per_session),
+        "suspected_loops": loop_basis,
+        "receipt_tagged_upper_bound": {
+            "api_calls": sum(int(s["api_calls"]) for s in receipt_sessions),
+            "gross_context_tokens": sum(int(s["gross_context_tokens"]) for s in receipt_sessions),
+            "non_cache_tokens": sum(int(s["non_cache_tokens"]) for s in receipt_sessions),
+        },
+        "avoidable_token_estimates": {
+            "conservative": loop_basis * avg_non_cache_per_call,
+            "plausible": loop_basis * avg_non_cache_per_call * 2,
+            "aggressive": loop_basis * avg_non_cache_per_call * 3,
+        },
+    }
+
+
+def _compute_outliers(per_session: list[dict[str, Any]]) -> dict[str, list[dict[str, Any]]]:
+    return {
+        "by_api_calls": _top_sessions(per_session, "api_calls"),
+        "by_non_cache_tokens": _top_sessions(per_session, "non_cache_tokens"),
+        "by_gross_context_tokens": _top_sessions(per_session, "gross_context_tokens"),
+    }
+
+
+def _compute_runtime_smells(per_session: list[dict[str, Any]], cfg: RuntimeGovernorConfig) -> dict[str, Any]:
+    return {
+        "high_api_call_sessions": [s["session_id"] for s in per_session if s["high_api_calls"]],
+        "high_non_cache_token_sessions": [s["session_id"] for s in per_session if s["high_non_cache_tokens"]],
+        "high_gross_context_sessions": [s["session_id"] for s in per_session if s["high_gross_context_tokens"]],
+        "receipt_readback_sessions": [s["session_id"] for s in per_session if s["write_mentions"] and s["read_mentions"]],
+        "finalization_churn_sessions": [s["session_id"] for s in per_session if s["finalization_churn"]],
+    }
+
+
+def _compute_recommendations(
+    per_session: list[dict[str, Any]],
+    receipt: dict[str, Any],
+    cost: dict[str, Any],
+    cfg: RuntimeGovernorConfig,
+) -> list[dict[str, str]]:
+    recommendations: list[dict[str, str]] = []
+    if not cost.get("reliable"):
+        recommendations.append(
+            {
+                "confidence": "high",
+                "recommendation": "Treat cost as unavailable until per-call provider telemetry is populated; report token/API-call bounds instead of dollars.",
+            }
+        )
+    if receipt.get("suspected_loops", 0) > 0:
+        recommendations.append(
+            {
+                "confidence": "high",
+                "recommendation": "Replace receipt write/read/summarize loops with structured ledger rendering plus stat/checksum/excerpt verification.",
+            }
+        )
+    elif receipt.get("write_mentions", 0) and receipt.get("read_mentions", 0):
+        recommendations.append(
+            {
+                "confidence": "medium",
+                "recommendation": "Receipt readback should use stat/checksum/excerpt instead of full markdown reads.",
+            }
+        )
+    if any(s["high_api_calls"] and s["receipt_tagged"] for s in per_session):
+        recommendations.append(
+            {
+                "confidence": "medium",
+                "recommendation": "High-call receipt-tagged sessions should enter lean finalization: receipt path plus key proof only.",
+            }
+        )
+    if any(s["high_non_cache_tokens"] and s["receipt_tagged"] for s in per_session):
+        recommendations.append(
+            {
+                "confidence": "medium",
+                "recommendation": "Under high non-cache token pressure, render receipts from structured evidence rather than asking the main session to synthesize prose.",
+            }
+        )
+    return recommendations
+
+
+def _top_sessions(per_session: list[dict[str, Any]], key: str) -> list[dict[str, Any]]:
+    rows = sorted(per_session, key=lambda s: int(s.get(key) or 0), reverse=True)
+    trimmed = []
+    for row in rows[:_DEFAULT_TOP_N]:
+        trimmed.append(
+            {
+                "session_id": row.get("session_id"),
+                "title": row.get("title"),
+                "api_calls": row.get("api_calls"),
+                "gross_context_tokens": row.get("gross_context_tokens"),
+                "non_cache_tokens": row.get("non_cache_tokens"),
+                "receipt_tagged": row.get("receipt_tagged"),
+            }
+        )
+    return trimmed
+
+
+def _non_cache_tokens(session: dict[str, Any]) -> int:
+    return (
+        int(session.get("input_tokens") or 0)
+        + int(session.get("output_tokens") or 0)
+        + int(session.get("cache_write_tokens") or 0)
+        + int(session.get("reasoning_tokens") or 0)
+    )
+
+
+def _gross_context_tokens(session: dict[str, Any]) -> int:
+    return (
+        int(session.get("input_tokens") or 0)
+        + int(session.get("output_tokens") or 0)
+        + int(session.get("cache_read_tokens") or 0)
+        + int(session.get("cache_write_tokens") or 0)
+        + int(session.get("reasoning_tokens") or 0)
+    )
+
+
+def _has_ordered_loop(texts: Iterable[str]) -> bool:
+    state = 0
+    for text in texts:
+        if not _RECEIPT_RE.search(text):
+            continue
+        if state == 0 and _WRITE_RE.search(text):
+            state = 1
+        elif state == 1 and _READ_RE.search(text):
+            state = 2
+        elif state == 2 and _SUMMARIZE_RE.search(text):
+            return True
+    return False
+
+
+def _finalization_churn(messages: list[dict[str, Any]], cfg: RuntimeGovernorConfig) -> bool:
+    done_index = None
+    for idx, msg in enumerate(messages):
+        if _DONE_RE.search(_message_text(msg)):
+            done_index = idx
+            break
+    if done_index is None:
+        return False
+    remaining_assistant = sum(1 for msg in messages[done_index + 1 :] if (msg.get("role") or "") == "assistant")
+    return remaining_assistant >= cfg.excessive_finalization_calls
+
+
+def _message_text(message: dict[str, Any]) -> str:
+    pieces = [str(message.get("content") or "")]
+    tool_name = message.get("tool_name")
+    if tool_name:
+        pieces.append(str(tool_name))
+    return " ".join(pieces)
+
+
+def _table_exists(conn: sqlite3.Connection, table: str) -> bool:
+    row = conn.execute("SELECT name FROM sqlite_master WHERE type='table' AND name=?", (table,)).fetchone()
+    return row is not None
+
+
+def _columns(conn: sqlite3.Connection, table: str) -> set[str]:
+    return {str(row[1]) for row in conn.execute(f"PRAGMA table_info({table})").fetchall()}
+
+
+def _select_col(cols: set[str], name: str, *, alias: str | None = None, text: bool = False) -> str:
+    out = alias or name
+    if name in cols:
+        return f"{name} AS {out}" if out != name else name
+    default = "''" if text else "0"
+    return f"{default} AS {out}"
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Hermes Runtime Governor observe-only report")
+    parser.add_argument("--days", type=int, default=30)
+    parser.add_argument("--state-db", type=Path, default=None)
+    parser.add_argument("--source", default=None)
+    parser.add_argument("--json", action="store_true", help="Emit structured JSON instead of text")
+    args = parser.parse_args(argv)
+
+    report = generate_runtime_report(state_db_path=args.state_db, days=args.days, source=args.source)
+    if args.json:
+        print(json.dumps(report, indent=2, sort_keys=True))
+    else:
+        print(format_runtime_report(report))
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/plugins/context_governor/__init__.py
+++ b/plugins/context_governor/__init__.py
@@ -1,0 +1,30 @@
+"""Context Governor bundled plugin."""
+
+from __future__ import annotations
+
+
+def register(ctx):
+    from hermes_cli.context_governor import (
+        checkpoint_command,
+        cli_main,
+        pre_context_compress_handoff,
+        setup_cli,
+    )
+
+    ctx.register_hook("pre_context_compress", pre_context_compress_handoff)
+    ctx.register_command(
+        "checkpoint",
+        checkpoint_command,
+        description="Write a deterministic handoff/checkpoint for the current Hermes session",
+        args_hint="[current task/goal]",
+    )
+    ctx.register_cli_command(
+        "checkpoint",
+        help="Write a deterministic Hermes handoff/checkpoint",
+        setup_fn=setup_cli,
+        handler_fn=cli_main,
+        description=(
+            "Writes repo-local CURRENT.md when --cwd/current directory is inside a git repo; "
+            "otherwise writes under $HERMES_HOME/handoffs/. No model call is made."
+        ),
+    )

--- a/plugins/context_governor/plugin.yaml
+++ b/plugins/context_governor/plugin.yaml
@@ -1,0 +1,9 @@
+name: context-governor
+version: 0.1.0
+description: "Deterministic context handoff/checkpoint writer. Auto-writes repo-local CURRENT.md before context compression and exposes /checkpoint + hermes checkpoint."
+author: Hermes Agent
+kind: backend
+provides_hooks:
+  - pre_context_compress
+provides_commands:
+  - checkpoint

--- a/tests/hermes_cli/test_context_governor.py
+++ b/tests/hermes_cli/test_context_governor.py
@@ -1,0 +1,223 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from pathlib import Path
+import subprocess
+
+
+def _git(repo: Path, *args: str) -> None:
+    subprocess.run(["git", "-C", str(repo), *args], check=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
+
+
+def test_repo_handoff_writes_current_md_with_bounded_git_state(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "home"))
+    from hermes_cli.context_governor import create_handoff
+
+    repo = tmp_path / "repo"
+    subdir = repo / "pkg"
+    subdir.mkdir(parents=True)
+    _git(repo, "init")
+    tracked = repo / "app.py"
+    tracked.write_text("print('hello')\n", encoding="utf-8")
+    _git(repo, "add", "app.py")
+    tracked.write_text("print('changed')\n", encoding="utf-8")
+    (repo / "new.txt").write_text("new\n", encoding="utf-8")
+
+    result = create_handoff(
+        cwd=subdir,
+        session_id="sess-123",
+        task_goal="Build Context Governor",
+        reason="manual-test",
+        now=datetime(2026, 6, 17, 12, 30, tzinfo=timezone.utc),
+        state_db_path=tmp_path / "missing-state.db",
+    )
+
+    assert result.ok
+    assert result.path == repo / "CURRENT.md"
+    content = result.path.read_text(encoding="utf-8")
+    assert "# CURRENT — Hermes Context Governor Handoff" in content
+    assert "- Session ID: `sess-123`" in content
+    assert f"- CWD: `{subdir}`" in content
+    assert f"- Repo root: `{repo}`" in content
+    assert "- Reason: manual-test" in content
+    assert "Build Context Governor" in content
+    assert "app.py" in content
+    assert "new.txt" in content
+    assert "Resume this Hermes work" in content
+
+
+def test_non_repo_handoff_uses_global_fallback(tmp_path, monkeypatch):
+    home = tmp_path / "home"
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    from hermes_cli.context_governor import create_handoff
+
+    work = tmp_path / "not-a-repo"
+    work.mkdir()
+    result = create_handoff(
+        cwd=work,
+        session_id="sess/global",
+        task_goal=None,
+        now=datetime(2026, 6, 17, 12, 31, tzinfo=timezone.utc),
+        state_db_path=tmp_path / "missing.db",
+    )
+
+    assert result.ok
+    assert result.path.parent == home / "handoffs"
+    assert result.path.name.endswith("sess-global.md")
+    content = result.path.read_text(encoding="utf-8")
+    assert "- Repo root: `(not detected)`" in content
+    assert f"- CWD: `{work}`" in content
+
+
+def test_session_db_hints_extract_goal_and_verification_commands(tmp_path, monkeypatch):
+    home = tmp_path / "home"
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    from hermes_state import SessionDB
+    from hermes_cli.context_governor import create_handoff
+
+    db_path = tmp_path / "state.db"
+    db = SessionDB(db_path=db_path)
+    db.create_session("sess-hints", source="cli")
+    db.append_message("sess-hints", "user", "Build the backend handoff writer")
+    db.append_message(
+        "sess-hints",
+        "assistant",
+        "running tests",
+        tool_calls=[{"function": {"name": "terminal", "arguments": '{"command":"python -m pytest tests/hermes_cli/test_context_governor.py -q"}'}}],
+    )
+    db.append_message("sess-hints", "tool", '{"output":"passed"}', tool_name="terminal")
+    db.close()
+
+    work = tmp_path / "work"
+    work.mkdir()
+    result = create_handoff(
+        cwd=work,
+        session_id="sess-hints",
+        now=datetime(2026, 6, 17, 12, 32, tzinfo=timezone.utc),
+        state_db_path=db_path,
+    )
+
+    content = result.path.read_text(encoding="utf-8")
+    assert "Build the backend handoff writer" in content
+    assert "python -m pytest tests/hermes_cli/test_context_governor.py -q" in content
+
+
+def test_git_status_parser_keeps_first_character_for_staged_paths(monkeypatch, tmp_path):
+    from hermes_cli import context_governor
+
+    def fake_git(_repo, *args):
+        if args == ("branch", "--show-current"):
+            return "main"
+        if args == ("status", "--short"):
+            return "M gateway/platforms/telegram.py\n M tools/web_tools.py"
+        return None
+
+    monkeypatch.setattr(context_governor, "_run_git", fake_git)
+
+    info = context_governor._collect_git_info(tmp_path)
+
+    assert "gateway/platforms/telegram.py" in info["changed_files"]
+    assert "ateway/platforms/telegram.py" not in info["changed_files"]
+    assert "tools/web_tools.py" in info["changed_files"]
+
+
+def test_latest_handoff_prefers_repo_current_over_global(tmp_path, monkeypatch):
+    home = tmp_path / "home"
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    from hermes_cli.context_governor import find_latest_handoff
+
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(repo, "init")
+    current = repo / "CURRENT.md"
+    current.write_text("# CURRENT\n", encoding="utf-8")
+    global_dir = home / "handoffs"
+    global_dir.mkdir(parents=True)
+    global_handoff = global_dir / "20990101T000000Z-other.md"
+    global_handoff.write_text("global\n", encoding="utf-8")
+
+    latest = find_latest_handoff(cwd=repo)
+
+    assert latest == current
+
+
+def test_context_status_marks_dirty_repo_with_stale_handoff_unsafe(tmp_path, monkeypatch):
+    home = tmp_path / "home"
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    from hermes_cli.context_governor import get_context_status
+
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(repo, "init")
+    current = repo / "CURRENT.md"
+    current.write_text("old handoff\n", encoding="utf-8")
+    changed = repo / "work.py"
+    changed.write_text("new work\n", encoding="utf-8")
+
+    status = get_context_status(cwd=repo, state_db_path=tmp_path / "missing.db")
+
+    assert status["latest_handoff_path"] == str(current)
+    assert status["handoff_recommended"] is True
+    assert status["fresh_session_safe"] is False
+    assert "changed files newer than latest handoff" in status["fresh_session_reason"]
+
+
+def test_fresh_session_prompt_and_command_are_shell_safe(tmp_path):
+    from hermes_cli.context_governor import build_fresh_session_prompt, build_fresh_session_command
+
+    handoff = tmp_path / "handoff `weird` $(rm -rf nope).md"
+    handoff.write_text("## Next-session prompt\n```text\nContinue safely.\n```\n", encoding="utf-8")
+
+    prompt = build_fresh_session_prompt(handoff)
+    command = build_fresh_session_command(handoff)
+
+    assert str(handoff) in prompt
+    assert "Continue safely." in prompt
+    assert "hermes chat -q" in command
+    assert "$(rm -rf nope)" in command
+    assert "'" in command  # shell-quoted, not raw executable interpolation
+
+
+def test_quality_report_compares_handoff_sessions_to_monster_sessions(tmp_path, monkeypatch):
+    home = tmp_path / "home"
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    from hermes_state import SessionDB
+    from hermes_cli.context_governor import get_quality_report
+
+    db_path = tmp_path / "state.db"
+    db = SessionDB(db_path=db_path)
+    db.create_session("monster", source="cli")
+    db.append_message("monster", "user", "continue giant session")
+    db.update_token_counts("monster", input_tokens=100_000, output_tokens=5_000, cache_read_tokens=400_000, api_call_count=5, absolute=True)
+    db.create_session("handoff", source="cli")
+    db.append_message("handoff", "user", "[Hermes Context Governor fresh-session handoff] Read /tmp/CURRENT.md and continue")
+    db.update_token_counts("handoff", input_tokens=20_000, output_tokens=3_000, cache_read_tokens=40_000, api_call_count=4, absolute=True)
+    db.close()
+
+    report = get_quality_report(state_db_path=db_path, days=30)
+
+    assert report["handoff_sessions"]["session_count"] == 1
+    assert report["monster_sessions"]["session_count"] == 1
+    assert report["handoff_sessions"]["avg_tokens_per_api_call"] < report["monster_sessions"]["avg_tokens_per_api_call"]
+
+
+def test_context_governor_plugin_registers_hook_and_checkpoint_command(monkeypatch):
+    from plugins.context_governor import register
+
+    calls = []
+
+    class FakeContext:
+        def register_hook(self, name, callback):
+            calls.append(("hook", name, callback))
+
+        def register_command(self, name, handler, description="", args_hint=""):
+            calls.append(("command", name, handler, description, args_hint))
+
+        def register_cli_command(self, name, help, setup_fn, handler_fn=None, description=""):
+            calls.append(("cli", name, setup_fn, handler_fn, help, description))
+
+    register(FakeContext())
+
+    assert any(kind == "hook" and name == "pre_context_compress" for kind, name, *_ in calls)
+    assert any(kind == "command" and name == "checkpoint" for kind, name, *_ in calls)
+    assert any(kind == "cli" and name == "checkpoint" for kind, name, *_ in calls)

--- a/tests/hermes_cli/test_runtime_governor.py
+++ b/tests/hermes_cli/test_runtime_governor.py
@@ -1,0 +1,202 @@
+import sqlite3
+import time
+
+from hermes_cli.runtime_governor import generate_runtime_report, format_runtime_report
+
+
+def _create_db(path, *, minimal=False):
+    conn = sqlite3.connect(path)
+    if minimal:
+        conn.execute(
+            """
+            CREATE TABLE sessions (
+                id TEXT PRIMARY KEY,
+                source TEXT NOT NULL,
+                started_at REAL NOT NULL
+            )
+            """
+        )
+        conn.execute(
+            """
+            CREATE TABLE messages (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                session_id TEXT NOT NULL,
+                role TEXT NOT NULL,
+                content TEXT,
+                timestamp REAL NOT NULL
+            )
+            """
+        )
+    else:
+        conn.execute(
+            """
+            CREATE TABLE sessions (
+                id TEXT PRIMARY KEY,
+                source TEXT NOT NULL,
+                started_at REAL NOT NULL,
+                title TEXT,
+                input_tokens INTEGER DEFAULT 0,
+                output_tokens INTEGER DEFAULT 0,
+                cache_read_tokens INTEGER DEFAULT 0,
+                cache_write_tokens INTEGER DEFAULT 0,
+                reasoning_tokens INTEGER DEFAULT 0,
+                api_call_count INTEGER DEFAULT 0,
+                estimated_cost_usd REAL,
+                actual_cost_usd REAL
+            )
+            """
+        )
+        conn.execute(
+            """
+            CREATE TABLE messages (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                session_id TEXT NOT NULL,
+                role TEXT NOT NULL,
+                content TEXT,
+                tool_name TEXT,
+                timestamp REAL NOT NULL
+            )
+            """
+        )
+    conn.commit()
+    return conn
+
+
+def _add_session(conn, session_id, now, *, started_days_ago=1, input_tokens=0, output_tokens=0,
+                 cache_read_tokens=0, cache_write_tokens=0, reasoning_tokens=0,
+                 api_call_count=0, estimated_cost_usd=None, actual_cost_usd=None,
+                 title=None):
+    conn.execute(
+        """
+        INSERT INTO sessions (
+            id, source, started_at, title, input_tokens, output_tokens,
+            cache_read_tokens, cache_write_tokens, reasoning_tokens, api_call_count,
+            estimated_cost_usd, actual_cost_usd
+        ) VALUES (?, 'cli', ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        (
+            session_id,
+            now - started_days_ago * 86400,
+            title,
+            input_tokens,
+            output_tokens,
+            cache_read_tokens,
+            cache_write_tokens,
+            reasoning_tokens,
+            api_call_count,
+            estimated_cost_usd,
+            actual_cost_usd,
+        ),
+    )
+
+
+def _add_message(conn, session_id, content, *, role="assistant", offset=0, tool_name=None):
+    conn.execute(
+        "INSERT INTO messages (session_id, role, content, tool_name, timestamp) VALUES (?, ?, ?, ?, ?)",
+        (session_id, role, content, tool_name, time.time() + offset),
+    )
+
+
+def test_missing_cost_fields_are_marked_unreliable_and_not_reported_as_spend(tmp_path):
+    db_path = tmp_path / "state.db"
+    conn = _create_db(db_path)
+    now = time.time()
+    _add_session(
+        conn,
+        "s1",
+        now,
+        input_tokens=100_000,
+        output_tokens=20_000,
+        cache_read_tokens=1_000_000,
+        api_call_count=12,
+        estimated_cost_usd=0.0,
+        actual_cost_usd=None,
+    )
+    conn.commit()
+    conn.close()
+
+    report = generate_runtime_report(state_db_path=db_path, days=30, now=now)
+    rendered = format_runtime_report(report)
+
+    assert report["cost"]["reliable"] is False
+    assert report["totals"]["sessions"] == 1
+    assert "cost telemetry unreliable" in rendered.lower()
+    assert "receipt spend is" not in rendered.lower()
+
+
+def test_receipt_tagged_sessions_are_upper_bounds_and_loops_are_flagged(tmp_path):
+    db_path = tmp_path / "state.db"
+    conn = _create_db(db_path)
+    now = time.time()
+    _add_session(
+        conn,
+        "receipt_loop",
+        now,
+        input_tokens=60_000,
+        output_tokens=10_000,
+        cache_read_tokens=500_000,
+        cache_write_tokens=5_000,
+        api_call_count=9,
+        title="receipt finalization churn",
+    )
+    _add_message(conn, "receipt_loop", "Write the receipt to .hermes/receipts/r.md", offset=1)
+    _add_message(conn, "receipt_loop", "Read the receipt back with read_file", offset=2)
+    _add_message(conn, "receipt_loop", "Summarize the receipt again for the final response", offset=3)
+    conn.commit()
+    conn.close()
+
+    report = generate_runtime_report(state_db_path=db_path, days=30, now=now)
+    rendered = format_runtime_report(report)
+
+    assert report["receipt_overhead"]["receipt_tagged_sessions"] == 1
+    assert report["receipt_overhead"]["suspected_loops"] == 1
+    assert report["receipt_overhead"]["write_mentions"] == 1
+    assert report["receipt_overhead"]["read_mentions"] == 1
+    assert "upper bound" in rendered.lower()
+    assert "write/read/summarize" in rendered.lower()
+
+
+def test_schema_tolerance_with_minimal_tables(tmp_path):
+    db_path = tmp_path / "state.db"
+    conn = _create_db(db_path, minimal=True)
+    now = time.time()
+    conn.execute("INSERT INTO sessions (id, source, started_at) VALUES ('minimal', 'cli', ?)", (now,))
+    conn.execute(
+        "INSERT INTO messages (session_id, role, content, timestamp) VALUES ('minimal', 'assistant', 'No receipt here', ?)",
+        (now,),
+    )
+    conn.commit()
+    conn.close()
+
+    report = generate_runtime_report(state_db_path=db_path, days=1, now=now)
+
+    assert report["totals"]["sessions"] == 1
+    assert report["totals"]["api_calls"] == 0
+    assert report["cost"]["reliable"] is False
+
+
+def test_outlier_sessions_and_policy_recommendations_are_deterministic(tmp_path):
+    db_path = tmp_path / "state.db"
+    conn = _create_db(db_path)
+    now = time.time()
+    _add_session(conn, "normal", now, input_tokens=1_000, output_tokens=500, api_call_count=2)
+    _add_session(
+        conn,
+        "burner",
+        now,
+        input_tokens=300_000,
+        output_tokens=50_000,
+        cache_read_tokens=2_000_000,
+        cache_write_tokens=25_000,
+        api_call_count=75,
+    )
+    _add_message(conn, "burner", "Saved final receipt", offset=1)
+    _add_message(conn, "burner", "Read the full receipt again", offset=2)
+    conn.commit()
+    conn.close()
+
+    report = generate_runtime_report(state_db_path=db_path, days=30, now=now)
+
+    assert report["outliers"]["by_api_calls"][0]["session_id"] == "burner"
+    assert report["recommendations"]
+    assert any("stat/checksum/excerpt" in item["recommendation"] for item in report["recommendations"])

--- a/tests/run_agent/test_compression_boundary_hook.py
+++ b/tests/run_agent/test_compression_boundary_hook.py
@@ -160,6 +160,77 @@ class TestCompressionBoundaryHook:
             assert compressed
             assert agent.session_id != original_sid
 
+    def test_pre_context_compress_plugin_hook_fires_before_compress(self):
+        """Plugins can checkpoint state immediately before compression mutates messages."""
+        from hermes_state import SessionDB
+
+        seen = []
+
+        def _hook(name, **kwargs):
+            seen.append((name, kwargs))
+            return []
+
+        with tempfile.TemporaryDirectory() as tmpdir, patch(
+            "hermes_cli.plugins.invoke_hook", side_effect=_hook
+        ):
+            db = SessionDB(db_path=Path(tmpdir) / "test.db")
+            agent = self._make_agent(db)
+
+            compressor = MagicMock()
+            compressor.compress.return_value = [{"role": "user", "content": "summary"}]
+            compressor.compression_count = 0
+            compressor.last_prompt_tokens = 0
+            compressor.last_completion_tokens = 0
+            compressor.context_length = 200_000
+            compressor.threshold_tokens = 196_000
+            compressor._last_summary_error = None
+            compressor._last_compress_aborted = False
+            agent.context_compressor = compressor
+
+            messages = [{"role": "user", "content": "m"}]
+            agent._compress_context(messages, "sys", approx_tokens=123_456, task_id="task-1")
+
+        assert seen, "pre_context_compress hook was not invoked"
+        hook_name, payload = seen[0]
+        assert hook_name == "pre_context_compress"
+        assert payload["session_id"] == "original-session"
+        assert payload["task_id"] == "task-1"
+        assert payload["approx_tokens"] == 123_456
+        assert payload["message_count"] == 1
+        assert payload["context_length"] == 200_000
+        assert payload["threshold_tokens"] == 196_000
+        compressor.compress.assert_called_once_with(messages, current_tokens=123_456, focus_topic=None, force=False)
+
+    def test_pre_context_compress_plugin_hook_failure_does_not_break_compression(self):
+        """The hook is observer-only; plugin failures must not block compression."""
+        from hermes_state import SessionDB
+
+        def _hook(_name, **_kwargs):
+            raise RuntimeError("plugin exploded")
+
+        with tempfile.TemporaryDirectory() as tmpdir, patch(
+            "hermes_cli.plugins.invoke_hook", side_effect=_hook
+        ):
+            db = SessionDB(db_path=Path(tmpdir) / "test.db")
+            agent = self._make_agent(db)
+
+            compressor = MagicMock()
+            compressor.compress.return_value = [{"role": "user", "content": "summary"}]
+            compressor.compression_count = 0
+            compressor.last_prompt_tokens = 0
+            compressor.last_completion_tokens = 0
+            compressor.context_length = 200_000
+            compressor.threshold_tokens = 196_000
+            compressor._last_summary_error = None
+            compressor._last_compress_aborted = False
+            agent.context_compressor = compressor
+
+            compressed, _prompt = agent._compress_context(
+                [{"role": "user", "content": "m"}], "sys", approx_tokens=100
+            )
+
+        assert compressed == [{"role": "user", "content": "summary"}]
+
 
 class TestSessionCompressEvent:
     """The session:compress event_callback fires after a compression split."""


### PR DESCRIPTION
## Summary
- add pre-context-compression observer hook for deterministic handoffs before compaction
- add backend Context Governor checkpoint/handoff module and plugin command
- add backend Runtime Governor observe-only report for token/API-call/receipt churn analysis

## Tests
- uv run --with pytest python -m pytest tests/run_agent/test_compression_boundary_hook.py tests/hermes_cli/test_context_governor.py tests/hermes_cli/test_runtime_governor.py tests/agent/test_insights.py -q -o 'addopts='

## Notes
- backend-only; no Multiview/UI
- observe-only Runtime Governor; no enforcement
- cost telemetry is explicitly marked unreliable when provider cost fields are missing
