### PR TITLE
fix: honor explicit web capability backends

### DIFF
--- a/tests/tools/test_web_providers_brave_free.py
+++ b/tests/tools/test_web_providers_brave_free.py
@@ -208,6 +208,14 @@ class TestBraveFreeBackendWiring:
         monkeypatch.setenv("BRAVE_SEARCH_API_KEY", "BSAkey123")
         assert web_tools._get_backend() == "brave-free"
 
+    def test_configured_capability_backend_routes_before_availability_check(self, monkeypatch):
+        from tools import web_tools
+        monkeypatch.setattr(web_tools, "_load_web_config", lambda: {"extract_backend": "plugin-extract"})
+        monkeypatch.setattr(web_tools, "_is_backend_available", lambda _backend: False)
+        monkeypatch.setattr(web_tools, "_get_backend", lambda: "fallback")
+
+        assert web_tools._get_capability_backend("extract") == "plugin-extract"
+
     def test_auto_detect_picks_brave_free_when_only_key_set(self, monkeypatch):
         from tools import web_tools
         monkeypatch.setattr(web_tools, "_load_web_config", lambda: {})

--- a/tools/web_tools.py
+++ b/tools/web_tools.py
@@ -204,12 +204,14 @@ def _get_extract_backend() -> str:
 def _get_capability_backend(capability: str) -> str:
     """Shared helper for per-capability backend selection.
 
-    Reads ``web.{capability}_backend`` from config; if set and available,
-    uses it. Otherwise falls through to the shared ``_get_backend()``.
+    Reads ``web.{capability}_backend`` from config. Explicit config wins even
+    before an availability check so plugin-provided backend names can route to
+    the registry and unavailable built-ins can surface precise setup errors.
+    Otherwise falls through to the shared ``_get_backend()`` auto-detection.
     """
     cfg = _load_web_config()
     specific = (cfg.get(f"{capability}_backend") or "").lower().strip()
-    if specific and _is_backend_available(specific):
+    if specific:
         return specific
     return _get_backend()
 


### PR DESCRIPTION
## Summary
- allow explicit per-capability web backend config to route before availability checks
- preserves plugin-provided backend names so registry/provider setup errors surface precisely

## Tests
- uv run --with pytest --with pytest-asyncio python -m pytest tests/tools/test_web_providers_brave_free.py tests/tools/test_web_tools_config.py tests/plugins/web/test_web_search_provider_plugins.py -q -o 'addopts='
