### PR TITLE
feat: inject frequently-used file paths into system prompt

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -1187,17 +1187,17 @@ def build_frequent_files_hints() -> str:
     from hermes_constants import (
         get_hermes_home,
         get_skills_dir,
-        get_memory_dir,
         get_env_path,
     )
 
     home = get_hermes_home()
+    memory_dir = home / "memories"
     lines: list[str] = []
 
     # ── Standard paths (always present in a healthy Hermes install) ──
     standard_paths = [
-        ("Memory store", get_memory_dir() / "MEMORY.md"),
-        ("User profile", get_memory_dir() / "USER.md"),
+        ("Memory store", memory_dir / "MEMORY.md"),
+        ("User profile", memory_dir / "USER.md"),
         ("Identity", home / "SOUL.md"),
         ("Configuration", home / "config.yaml"),
         ("Skills directory", get_skills_dir()),

--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -1169,6 +1169,70 @@ def build_environment_hints() -> str:
     return "\n\n".join(hints)
 
 
+
+def build_frequent_files_hints() -> str:
+    """Return a list of frequently-used file paths for the system prompt.
+
+    The LLM often wastes iterations searching for files it should already
+    know the location of (MEMORY.md, config.yaml, etc.).  Injecting their
+    absolute paths into the system prompt eliminates these search rounds.
+
+    Standard paths are derived from ``hermes_constants`` helpers.  Users can
+    add their own entries via ``config.yaml`` ``agent.frequent_files``
+    (a list of file/directory paths).
+
+    Missing paths are silently skipped (debug-logged) so the list is always
+    valid regardless of profile layout.
+    """
+    from hermes_constants import (
+        get_hermes_home,
+        get_skills_dir,
+        get_memory_dir,
+        get_env_path,
+    )
+
+    home = get_hermes_home()
+    lines: list[str] = []
+
+    # ── Standard paths (always present in a healthy Hermes install) ──
+    standard_paths = [
+        ("Memory store", get_memory_dir() / "MEMORY.md"),
+        ("User profile", get_memory_dir() / "USER.md"),
+        ("Identity", home / "SOUL.md"),
+        ("Configuration", home / "config.yaml"),
+        ("Skills directory", get_skills_dir()),
+        ("Environment", get_env_path()),
+        ("Sessions DB", home / "sessions.db"),
+    ]
+
+    found = []
+    for label, path in standard_paths:
+        if path.exists():
+            found.append(f"- {label}: {path}")
+        else:
+            logger.debug("frequent_files: standard path missing: %s", path)
+
+    # ── User-configured paths from config.yaml ──
+    try:
+        from hermes_cli.config import get_config
+        cfg = get_config()
+        user_paths = (cfg.get("agent", {}) or {}).get("frequent_files", [])
+    except Exception:
+        user_paths = []
+
+    for raw in user_paths:
+        p = Path(raw).expanduser()
+        if p.exists():
+            found.append(f"- {p.name}: {p}")
+        else:
+            logger.debug("frequent_files: user path missing: %s", raw)
+
+    if not found:
+        return ""
+
+    return "## Frequent File Paths\n" + "\n".join(found)
+
+
 CONTEXT_FILE_MAX_CHARS = 20_000
 CONTEXT_TRUNCATE_HEAD_RATIO = 0.7
 CONTEXT_TRUNCATE_TAIL_RATIO = 0.2

--- a/agent/system_prompt.py
+++ b/agent/system_prompt.py
@@ -310,6 +310,13 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
     if _env_hints:
         stable_parts.append(_env_hints)
 
+    # Frequently-used file paths so the model doesn't waste iterations
+    # searching for MEMORY.md, config.yaml, etc.  Small (~100 tokens)
+    # but saves many search iterations per session.
+    _freq_files = _r.build_frequent_files_hints()
+    if _freq_files:
+        stable_parts.append(_freq_files)
+
     # Coding posture (base Hermes, any interactive coding surface in a code
     # workspace — see agent/coding_context.py). The operating brief + the live
     # git/workspace snapshot are built once here and cached for the session;

--- a/run_agent.py
+++ b/run_agent.py
@@ -163,6 +163,7 @@ from agent.prompt_builder import (  # noqa: F401  # re-exported via _ra() / mock
     build_environment_hints,
     build_nous_subscription_prompt,
     load_soul_md,
+    build_frequent_files_hints,
 )
 from agent.process_bootstrap import _get_proxy_from_env  # noqa: F401
 from agent.message_sanitization import (  # noqa: F401


### PR DESCRIPTION
## Summary

Adds a **Frequent File Paths** section to the stable system prompt tier, listing absolute paths to commonly accessed files so the model does not waste iterations searching for them.

### Problem

The LLM frequently wastes iterations using `search_files`, `find`, or `execute_code` to locate files it should already know the location of (MEMORY.md, config.yaml, skills directory, etc.). This:
- Burns iteration budget on boilerplate discovery
- Adds latency to every session
- Increases false-positive risk in loop detection (repeated search calls)

### Solution

Inject a small (~100 token) section into the system prompt:

```
## Frequent File Paths
- Memory store: /home/user/.hermes/memories/MEMORY.md
- User profile: /home/user/.hermes/memories/USER.md
- Identity: /home/user/.hermes/SOUL.md
- Configuration: /home/user/.hermes/config.yaml
- Skills directory: /home/user/.hermes/skills/
- Environment: /home/user/.hermes/.env
- Sessions DB: /home/user/.hermes/sessions.db
```

### User-configurable paths

Users can add their own frequently accessed files via `config.yaml`:

```yaml
agent:
  frequent_files:
    - ~/projects/my-app/README.md
    - ~/notes/todo.md
```

Missing paths are silently skipped (debug-logged).

### Changes
- `agent/prompt_builder.py`: New `build_frequent_files_hints()` function
- `agent/system_prompt.py`: Call `build_frequent_files_hints()` in stable tier

Closes #47778. Replaces #47784 (closed due to branch contamination, now rebased clean).