### PR TITLE
fix(telegram): expose group chat ID in context prompt for media routing

### DIFF
--- a/gateway/session.py
+++ b/gateway/session.py
@@ -391,6 +391,23 @@ def build_session_context_prompt(
             "their user_id). Your normal reply is delivered to the group you "
             "are responding in."
         )
+    elif context.source.platform == Platform.TELEGRAM:
+        src = context.source
+        if src.chat_type in ("group", "channel") or (
+            src.chat_id and str(src.chat_id).startswith("-")
+        ):
+            _tg_chat_id = _hash_chat_id(src.chat_id) if redact_pii else src.chat_id
+            _tg_chat_name = src.chat_name or _tg_chat_id
+            lines.append("")
+            lines.append(f"**Telegram current chat:** {_tg_chat_name} (ID: `{_tg_chat_id}`)")
+            lines.append(
+                f"  - To deliver files/media **into this group**, "
+                f"use `send_message('telegram:{_tg_chat_id}', ...)`. "
+                "Prefer this over the home channel when the user made the request here."
+            )
+            if src.thread_id:
+                _tg_thread_id = _hash_chat_id(src.thread_id) if redact_pii else src.thread_id
+                lines.append(f"  - Thread ID: `{_tg_thread_id}` (pass as `thread_id` for threaded replies)")
 
     # Connected platforms
     platforms_list = ["local (files on this machine)"]


### PR DESCRIPTION
## Problem

When the bot is @mentioned in a Telegram group, \`build_session_context_prompt\` only shows the group by name ("group: my-group") — no numeric chat ID. The agent sees the home channel's ID listed explicitly under **Home Channels** and calls \`send_message("telegram:HOME_ID", ...)\`, routing media to the owner's private channel instead of the group.

Text responses route correctly (via the adapter's reply logic), but \`send_message\` calls with an explicit \`telegram:ID\` bypass the session-context fallback added in the Bug 2 fix.

## Fix

Add a Telegram-specific IDs block for group/channel sources (matching the existing Discord and Matrix pattern). When the session source is a group or channel, the context prompt now includes:

\`\`\`
**Telegram current chat:** my-group (ID: \`-1001234567890\`)
  - To deliver files/media **into this group**, use \`send_message('telegram:-1001234567890', ...)\`. Prefer this over the home channel when the user made the request here.
\`\`\`

This gives the agent a directly-usable target string for the current chat, so it can choose the group over the home channel when responding to an @mention with media.

## Test

1. @mention the bot in a Telegram group and request a music download
2. Verify the audio file arrives in the group chat, not the home/private channel

🤖 Generated with [Claude Code](https://claude.com/claude-code)