### PR TITLE
fix(gateway): respect config.yaml enabled: false for Feishu (#47804)

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -1562,9 +1562,14 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
     feishu_app_id = os.getenv("FEISHU_APP_ID")
     feishu_app_secret = os.getenv("FEISHU_APP_SECRET")
     if feishu_app_id and feishu_app_secret:
+        # Only force-enable if the platform wasn't explicitly disabled in config.yaml.
+        # An explicit `enabled: false` in config takes precedence over env vars.
+        # See #47804.
         if Platform.FEISHU not in config.platforms:
             config.platforms[Platform.FEISHU] = PlatformConfig()
-        config.platforms[Platform.FEISHU].enabled = True
+            config.platforms[Platform.FEISHU].enabled = True
+        elif config.platforms[Platform.FEISHU].enabled is not False:
+            config.platforms[Platform.FEISHU].enabled = True
         config.platforms[Platform.FEISHU].extra.update({
             "app_id": feishu_app_id,
             "app_secret": feishu_app_secret,

--- a/tests/gateway/test_feishu.py
+++ b/tests/gateway/test_feishu.py
@@ -77,6 +77,25 @@ class TestConfigEnvOverrides(unittest.TestCase):
 
         self.assertIn(Platform.FEISHU, config.get_connected_platforms())
 
+    @patch.dict(os.environ, {
+        "FEISHU_APP_ID": "cli_xxx",
+        "FEISHU_APP_SECRET": "secret_xxx",
+    }, clear=False)
+    def test_feishu_config_explicitly_disabled_not_overridden_by_env(self):
+        """Env vars should not force-enable Feishu when config.yaml has enabled: false.
+
+        Regression test for #47804.
+        """
+        from gateway.config import GatewayConfig, Platform, PlatformConfig, _apply_env_overrides
+
+        config = GatewayConfig()
+        # Simulate config.yaml having feishu.enabled: false
+        config.platforms[Platform.FEISHU] = PlatformConfig(enabled=False)
+        _apply_env_overrides(config)
+
+        # Platform should remain disabled despite FEISHU_APP_ID/SECRET env vars
+        self.assertFalse(config.platforms[Platform.FEISHU].enabled)
+
 
 class TestFeishuMessageNormalization(unittest.TestCase):
     def test_normalize_merge_forward_preserves_summary_lines(self):


### PR DESCRIPTION
Fixes #47804. When Feishu platform has enabled: false in config.yaml, environment variables FEISHU_APP_ID and FEISHU_APP_SECRET no longer force-enable it. The explicit config setting now takes precedence over env vars.