### PR TITLE
fix(install): reject HERMES_HOME paths with spaces early (#47822)

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -2039,6 +2039,22 @@ postinstall_mode() {
 main() {
     print_banner
 
+    # Validate HERMES_HOME path does not contain spaces.
+    # Python's venv module writes shebangs (e.g. #!/path/to/python) without
+    # quoting, so any space in HERMES_HOME propagates into broken entry-point
+    # scripts and launchers that silently fail with "No such file or directory".
+    if [[ "$HERMES_HOME" == *" "* ]]; then
+        log_error "HERMES_HOME must not contain spaces."
+        log_error "  Current value: $HERMES_HOME"
+        log_error ""
+        log_error "Remediation:"
+        log_error "  1. Move or create a HERMES_HOME at a path without spaces:"
+        log_error "       export HERMES_HOME=~/.hermes"
+        log_error "  2. Re-run the installer:"
+        log_error "       curl -fsSL https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scripts/install.sh | bash"
+        exit 1
+    fi
+
     detect_os
     resolve_install_layout
     install_uv


### PR DESCRIPTION
Fixes #47822. Add validation at the start of install.sh to reject HERMES_HOME paths containing spaces. Paths with spaces break Python venv entrypoints and launch scripts, so the installer now exits early with a clear remediation message instead of failing cryptically later.