### PR TITLE
fix(mcp): extract message from JSON error bodies to prevent double-encoding

### DIFF
--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -2815,10 +2815,29 @@ def _make_tool_handler(server_name: str, tool_name: str, tool_timeout: float):
                 for block in (result.content or []):
                     if hasattr(block, "text"):
                         error_text += block.text
+                # Try to extract a human-readable message from JSON error
+                # bodies to avoid double-encoding (issue #47867).
+                display_text = error_text or "MCP tool returned an error"
+                if error_text:
+                    try:
+                        parsed = json.loads(error_text)
+                        if isinstance(parsed, dict):
+                            # Walk common nested shapes: error.message,
+                            # error.msg, message, msg, detail
+                            inner = parsed
+                            for key in ("error", "details"):
+                                if isinstance(inner.get(key), dict):
+                                    inner = inner[key]
+                            for key in ("message", "msg", "detail",
+                                        "description", "error"):
+                                val = inner.get(key)
+                                if isinstance(val, str) and val:
+                                    display_text = val
+                                    break
+                    except (json.JSONDecodeError, TypeError, AttributeError):
+                        pass
                 return json.dumps({
-                    "error": _sanitize_error(
-                        error_text or "MCP tool returned an error"
-                    )
+                    "error": _sanitize_error(display_text)
                 }, ensure_ascii=False)
 
             # Collect text from content blocks. MCP tool results can also


### PR DESCRIPTION
## Bug

When an MCP tool returns `isError: true` with a JSON body (e.g. `{"ok":false,"error":{"code":"...","message":"..."}}`), the handler wraps the entire JSON string as the error value, producing double-encoded JSON.

The model receives a raw JSON string instead of the readable error message.

## Fix

Parse `error_text` as JSON and walk common nested shapes (`error.message`, `message`, `msg`, `detail`, `description`) to extract the human-readable message. Falls back to raw text if JSON parsing fails.

Fixes #47867

## Test plan
- [x] `py_compile` passes
- [x] Plain text errors still returned as-is
- [x] Nested JSON errors extract the inner message
- [x] Non-JSON errors fall back to raw text