### PR TITLE
fix(install): keep Hermes-managed Node private instead of hijacking the user's node

### DIFF
--- a/hermes_cli/dep_ensure.py
+++ b/hermes_cli/dep_ensure.py
@@ -24,8 +24,45 @@ from pathlib import Path
 
 _IS_WINDOWS = platform.system() == "Windows"
 
+def _has_private_hermes_node() -> bool:
+    # Detection + the per-platform layout (node/bin on POSIX, node/ on the
+    # Windows portable zip) is owned by hermes_constants, which also mirrors the
+    # directory ordering used by the Electron main process. Defer to it instead
+    # of re-deriving the managed-Node path here.
+    from hermes_constants import find_hermes_node_executable
+    return find_hermes_node_executable("node") is not None
+
+
+def _prepend_private_hermes_node_bin() -> None:
+    # Only when the user has NO node on PATH: surface the managed copy for the
+    # rest of this process (and inherited children) without shadowing a
+    # user-managed node. Process-local PATH edit only — never touches shell
+    # config. Reuses with_hermes_node_path() so the prepend logic (both the
+    # node/ and node/bin layouts) stays single-sourced in hermes_constants.
+    if shutil.which("node") is not None:
+        return
+    from hermes_constants import iter_hermes_node_dirs, with_hermes_node_path
+    if not any(d.is_dir() for d in iter_hermes_node_dirs()):
+        return
+    os.environ["PATH"] = with_hermes_node_path()["PATH"]
+
+
+def _has_node_runtime() -> bool:
+    return shutil.which("node") is not None or _has_private_hermes_node()
+
+
+def _remove_legacy_node_symlinks() -> None:
+    try:
+        from hermes_constants import get_hermes_home
+        from hermes_cli.uninstall import remove_node_symlinks
+        remove_node_symlinks(get_hermes_home())
+    except Exception:
+        # Cleanup is best-effort. Dependency checks must remain fail-open.
+        pass
+
+
 _DEP_CHECKS = {
-    "node": lambda: shutil.which("node") is not None,
+    "node": _has_node_runtime,
     "browser": lambda: (
         shutil.which("agent-browser") is not None
         or _has_system_browser()
@@ -105,11 +142,15 @@ def ensure_dependency(
     interactive: bool = True,
 ) -> bool:
     """Ensure a non-Python dependency is available. Returns True if available."""
+    if dep in {"node", "browser"}:
+        _remove_legacy_node_symlinks()
     check = _DEP_CHECKS.get(dep)
     if check is None:
         # Unknown dep — don't silently forward to install script.
         return False
     if check():
+        if dep == "node":
+            _prepend_private_hermes_node_bin()
         return True
 
     script, shell = _find_install_script()
@@ -155,5 +196,8 @@ def ensure_dependency(
         return False
 
     if check:
-        return check()
+        ok = check()
+        if ok and dep == "node":
+            _prepend_private_hermes_node_bin()
+        return ok
     return True

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -1596,6 +1596,13 @@ def _ensure_tui_node() -> None:
     Idempotent no-op when node+npm are already discoverable. Set
     ``HERMES_SKIP_NODE_BOOTSTRAP=1`` to disable auto-install.
     """
+    hermes_home = os.environ.get("HERMES_HOME") or str(Path.home() / ".hermes")
+    try:
+        from hermes_cli.uninstall import remove_node_symlinks
+        remove_node_symlinks(Path(hermes_home))
+    except Exception:
+        pass
+
     if shutil.which("node") and shutil.which("npm"):
         return
     if os.environ.get("HERMES_SKIP_NODE_BOOTSTRAP"):
@@ -1605,7 +1612,6 @@ def _ensure_tui_node() -> None:
     if not helper.is_file():
         return
 
-    hermes_home = os.environ.get("HERMES_HOME") or str(Path.home() / ".hermes")
     try:
         # Helper writes logs to stderr; we ask bash to print `command -v node`
         # on stdout once ensure_node succeeds. Subshell PATH edits don't leak
@@ -1633,7 +1639,7 @@ def _ensure_tui_node() -> None:
     if resolved:
         extras.append(Path(resolved).resolve().parent)
 
-    extras.extend([Path(hermes_home) / "node" / "bin", Path.home() / ".local" / "bin"])
+    extras.append(Path(hermes_home) / "node" / "bin")
 
     for extra in extras:
         s = str(extra)
@@ -7754,8 +7760,26 @@ def _ensure_uv_for_termux(pip_cmd: list[str]) -> str | None:
     return resolve_uv() or shutil.which("uv")
 
 
+def _cleanup_legacy_node_symlinks() -> Path:
+    try:
+        from hermes_constants import get_hermes_home
+        from hermes_cli.uninstall import remove_node_symlinks
+
+        hermes_home = get_hermes_home()
+        remove_node_symlinks(hermes_home)
+    except Exception:
+        hermes_home = Path(os.environ.get("HERMES_HOME") or (Path.home() / ".hermes"))
+    return hermes_home
+
+
 def _update_node_dependencies() -> None:
     from hermes_constants import find_node_executable, with_hermes_node_path
+
+    # Older installs symlinked Hermes-managed node/npm/npx into PATH dirs
+    # (~/.local/bin etc.). Remove those legacy shims before resolving npm so a
+    # stale link can't win; find_node_executable() then prefers the managed
+    # copy and falls back to PATH. (Migration for the install-side fix.)
+    _cleanup_legacy_node_symlinks()
 
     npm = find_node_executable("npm")
     if not npm:
@@ -8737,6 +8761,11 @@ def _cmd_update_impl(args, gateway_mode: bool):
 
     print("⚕ Updating Hermes Agent...")
     print()
+
+    # Update is the common self-healing entrypoint for older installs. Clean up
+    # legacy Hermes-owned node/npm/npx PATH shims before any early return (for
+    # example the "Already up to date" path below).
+    _cleanup_legacy_node_symlinks()
 
     # On Windows, abort early if another hermes.exe is holding the venv shim
     # open. Continuing would result in a string of WinError 32 warnings and

--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -831,11 +831,15 @@ def _run_cua_driver_installer(label: str = "Installing", verbose: bool = True) -
 
 def _run_post_setup(post_setup_key: str):
     """Run post-setup hooks for tools that need extra installation steps."""
-    import shutil
+    from hermes_constants import find_node_executable, with_hermes_node_path
     if post_setup_key in {"agent_browser", "browserbase"}:
         node_modules = PROJECT_ROOT / "node_modules" / "agent-browser"
-        npm_bin = shutil.which("npm")
-        npx_bin = shutil.which("npx")
+        # Resolve Hermes-managed node tooling first so browser setup still works
+        # when the only Node is Hermes's private copy — after the installer
+        # stopped symlinking node/npm/npx onto PATH, a plain which() would miss
+        # it. Falls back to PATH for users with their own Node.
+        npm_bin = find_node_executable("npm")
+        npx_bin = find_node_executable("npx")
         # Step 1: install the agent-browser npm package into node_modules/
         if not node_modules.exists() and npm_bin:
             _print_info("    Installing Node.js dependencies for browser tools...")
@@ -849,7 +853,8 @@ def _run_post_setup(post_setup_key: str):
                 # only, avoiding the apps/* glob which would pull in
                 # apps/desktop (Electron + node-pty) unnecessarily. See #38772.
                 [npm_bin, "install", "--silent", "--workspaces=false"],
-                capture_output=True, text=True, cwd=str(PROJECT_ROOT)
+                capture_output=True, text=True, cwd=str(PROJECT_ROOT),
+                env=with_hermes_node_path(),
             )
             if result.returncode == 0:
                 _print_success("    Node.js dependencies installed")
@@ -925,6 +930,7 @@ def _run_post_setup(post_setup_key: str):
             result = subprocess.run(
                 install_cmd,
                 capture_output=True, text=True, cwd=str(PROJECT_ROOT), timeout=600,
+                env=with_hermes_node_path(),
             )
             if result.returncode == 0:
                 _print_success("    Chromium installed")
@@ -947,7 +953,7 @@ def _run_post_setup(post_setup_key: str):
 
     elif post_setup_key == "camofox":
         camofox_dir = PROJECT_ROOT / "node_modules" / "@askjo" / "camofox-browser"
-        _npm_bin = shutil.which("npm")
+        _npm_bin = find_node_executable("npm")
         if not camofox_dir.exists() and _npm_bin:
             _print_info("    Installing Camofox browser server...")
             import subprocess
@@ -955,7 +961,8 @@ def _run_post_setup(post_setup_key: str):
             result = subprocess.run(
                 # --workspaces=false avoids resolving apps/desktop. See #38772.
                 [_npm_bin, "install", "--silent", "--workspaces=false"],
-                capture_output=True, text=True, cwd=str(PROJECT_ROOT)
+                capture_output=True, text=True, cwd=str(PROJECT_ROOT),
+                env=with_hermes_node_path(),
             )
             if result.returncode == 0:
                 _print_success("    Camofox installed")
@@ -966,7 +973,7 @@ def _run_post_setup(post_setup_key: str):
             _print_info("      npx @askjo/camofox-browser")
             _print_info("    First run downloads the Camoufox engine (~300MB)")
             _print_info("    Or use Docker: docker run -p 9377:9377 -e CAMOFOX_PORT=9377 jo-inc/camofox-browser")
-        elif not shutil.which("npm"):
+        elif not find_node_executable("npm"):
             _print_warning("    Node.js not found. Install Camofox via Docker:")
             _print_info("      docker run -p 9377:9377 -e CAMOFOX_PORT=9377 jo-inc/camofox-browser")
 

--- a/hermes_cli/uninstall.py
+++ b/hermes_cli/uninstall.py
@@ -134,19 +134,18 @@ def _node_symlink_candidate_dirs() -> "list[Path]":
 def remove_node_symlinks(hermes_home: Path) -> list:
     """Remove the node/npm/npx symlinks the installer placed on PATH.
 
-    The POSIX installer (``scripts/install.sh`` / ``scripts/lib/node-bootstrap.sh``)
-    symlinks node/npm/npx into the same directory as the ``hermes`` command:
+    Older POSIX installers (``scripts/install.sh`` /
+    ``scripts/lib/node-bootstrap.sh``) symlinked node/npm/npx into the same
+    directory as the ``hermes`` command:
 
     - ``/usr/local/bin/`` on root FHS installs (Linux, uid 0)
     - ``$PREFIX/bin/`` on Termux
     - ``~/.local/bin/`` otherwise (the common non-root case)
 
-    We check all candidate directories so that uninstall works regardless of
-    how the install was done (e.g. a root FHS install that placed links in
-    ``/usr/local/bin``, or an older install that used ``~/.local/bin`` before
-    the FHS fix).  Only symlinks that resolve into this Hermes home's ``node``
-    directory are removed — links the user has repointed elsewhere (nvm, fnm,
-    etc.) are left untouched.
+    We check all legacy candidate directories so that uninstall and migration
+    clean up whichever layout created the links. Only symlinks that resolve
+    into this Hermes home's ``node`` directory are removed — links the user has
+    repointed elsewhere (nvm, fnm, etc.) are left untouched.
     """
     node_dir = (hermes_home / "node").resolve()
     removed = []

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -413,23 +413,64 @@ get_command_link_display_dir() {
     fi
 }
 
-# Point a Hermes-managed Node's `npm install -g` at a directory that is on
-# PATH. npm's default global prefix for a bundled Node is the Node dir itself,
-# so global package binaries land in $HERMES_HOME/node/bin — which is NOT on
-# PATH (only the command link dir is) and is wiped on every Node upgrade.
-# Redirecting the prefix to the link dir's parent makes global bins resolve to
-# the command link dir (node/npm/npx live there too, already on PATH) and
-# survive upgrades. Scoped to the managed Node via its prefix-local global
-# npmrc, so the user's other Node installs and their ~/.npmrc are untouched.
-# Hermes's own global installs pass an explicit --prefix and are unaffected.
+# Point a Hermes-managed Node's `npm install -g` at $HERMES_HOME/node. That
+# keeps global package shims self-contained under $HERMES_HOME/node/bin, which
+# Hermes already prepends for its subprocesses and dependency checks, instead
+# of placing node/npm/npx or npm-installed CLIs in ~/.local/bin where they can
+# shadow the user's own version manager. Scoped to the managed Node via its
+# prefix-local global npmrc, so the user's other Node installs and their ~/.npmrc
+# are untouched. Hermes's own global installs pass the same explicit --prefix.
 # Idempotent and a no-op when there is no Hermes-managed npm, so calling it on
 # every install run repairs pre-existing installs, not just fresh ones.
 configure_managed_node_npm_prefix() {
     [ -x "$HERMES_HOME/node/bin/npm" ] || return 0
-    local link_dir
-    link_dir="$(get_command_link_dir)"
     mkdir -p "$HERMES_HOME/node/etc"
-    printf 'prefix=%s\n' "$(dirname "$link_dir")" > "$HERMES_HOME/node/etc/npmrc"
+    printf 'prefix=%s\n' "$HERMES_HOME/node" > "$HERMES_HOME/node/etc/npmrc"
+}
+
+node_link_points_into_hermes_node() {
+    local link="$1"
+    [ -L "$link" ] || return 1
+
+    local target target_abs node_dir
+    target="$(readlink "$link" 2>/dev/null)" || return 1
+    case "$target" in
+        /*) target_abs="$target" ;;
+        *)  target_abs="$(dirname "$link")/$target" ;;
+    esac
+
+    node_dir="$HERMES_HOME/node"
+    case "$target_abs" in
+        "$node_dir"|"$node_dir"/*) return 0 ;;
+    esac
+
+    if [ -d "$node_dir" ] && [ -e "$target_abs" ]; then
+        local resolved_target resolved_node
+        resolved_target="$(cd "$(dirname "$target_abs")" 2>/dev/null && pwd -P)/$(basename "$target_abs")"
+        resolved_node="$(cd "$node_dir" 2>/dev/null && pwd -P)"
+        case "$resolved_target" in
+            "$resolved_node"|"$resolved_node"/*) return 0 ;;
+        esac
+    fi
+    return 1
+}
+
+remove_managed_node_path_symlinks() {
+    local dirs=("$HOME/.local/bin" "/usr/local/bin")
+    if is_termux && [ -n "${PREFIX:-}" ]; then
+        dirs+=("$PREFIX/bin")
+    fi
+
+    local dir name link
+    for dir in "${dirs[@]}"; do
+        [ -d "$dir" ] || continue
+        for name in node npm npx; do
+            link="$dir/$name"
+            if node_link_points_into_hermes_node "$link"; then
+                rm -f "$link" || true
+            fi
+        done
+    done
 }
 
 get_hermes_command_path() {
@@ -738,12 +779,70 @@ node_satisfies_build() {
     return 1
 }
 
+activate_node_bin_if_satisfies_build() {
+    local node_bin="$1"
+    local label="$2"
+    [ -x "$node_bin" ] || return 1
+    local version
+    version="$("$node_bin" --version 2>/dev/null)" || return 1
+    node_satisfies_build "$version" || return 1
+
+    local node_dir
+    node_dir="$(dirname "$node_bin")"
+    case ":$PATH:" in
+        *":$node_dir:"*) ;;
+        *) export PATH="$node_dir:$PATH" ;;
+    esac
+    log_success "Node.js $version found ($label)"
+    HAS_NODE=true
+    return 0
+}
+
+try_existing_nvm_node() {
+    local nvm_root="${NVM_DIR:-$HOME/.nvm}"
+    local node_bin
+    for node_bin in "$nvm_root"/versions/node/*/bin/node; do
+        [ -e "$node_bin" ] || continue
+        activate_node_bin_if_satisfies_build "$node_bin" "nvm" && return 0
+    done
+    return 1
+}
+
+try_existing_fnm_node() {
+    local fnm_root node_bin
+    for fnm_root in "${FNM_DIR:-$HOME/.local/share/fnm}" "$HOME/.fnm"; do
+        for node_bin in "$fnm_root"/node-versions/*/installation/bin/node "$fnm_root"/node-versions/*/bin/node; do
+            [ -e "$node_bin" ] || continue
+            activate_node_bin_if_satisfies_build "$node_bin" "fnm" && return 0
+        done
+    done
+
+    if command -v fnm >/dev/null 2>&1; then
+        eval "$(fnm env 2>/dev/null)" || true
+        if command -v node >/dev/null 2>&1 && node_satisfies_build "$(node --version)"; then
+            log_success "Node.js $(node --version) found (fnm)"
+            HAS_NODE=true
+            return 0
+        fi
+    fi
+    return 1
+}
+
+try_existing_volta_node() {
+    local volta_root="${VOLTA_HOME:-$HOME/.volta}"
+    activate_node_bin_if_satisfies_build "$volta_root/bin/node" "Volta"
+}
+
 check_node() {
     log_info "Checking Node.js (for browser tools)..."
 
-    # Repair pre-existing Hermes-managed installs where `npm install -g` lands
-    # off PATH. No-op when there's no managed Node, so this is safe to run on
-    # every install — including re-runs that skip the Node (re)install below.
+    # Migrate legacy installers that linked Hermes-managed node/npm/npx into
+    # ~/.local/bin, /usr/local/bin, or $PREFIX/bin. Only links into this
+    # HERMES_HOME are removed; user-managed binaries are left untouched.
+    remove_managed_node_path_symlinks
+
+    # Keep pre-existing Hermes-managed installs self-contained. No-op when
+    # there's no managed Node, so this is safe on every install.
     configure_managed_node_npm_prefix
 
     if command -v node &> /dev/null && node_satisfies_build "$(node --version)"; then
@@ -752,13 +851,14 @@ check_node() {
         return 0
     fi
 
-    # Prefer a Hermes-managed Node from a previous run over a too-old system one.
-    if [ -x "$HERMES_HOME/node/bin/node" ] && node_satisfies_build "$("$HERMES_HOME/node/bin/node" --version)"; then
-        export PATH="$HERMES_HOME/node/bin:$PATH"
-        log_success "Node.js $("$HERMES_HOME/node/bin/node" --version) found (Hermes-managed)"
-        HAS_NODE=true
-        return 0
-    fi
+    # Prefer explicit user version-manager installs over Hermes's private copy.
+    try_existing_fnm_node && return 0
+    try_existing_volta_node && return 0
+    try_existing_nvm_node && return 0
+
+    # Reuse Hermes's private Node only after user-managed installs have been
+    # checked, so a one-time fallback does not permanently win over nvm/fnm/Volta.
+    activate_node_bin_if_satisfies_build "$HERMES_HOME/node/bin/node" "Hermes-managed" && return 0
 
     if command -v node &> /dev/null; then
         log_warn "Node.js $(node --version) is too old for the desktop build (need ^20.19 or >=22.12) — installing Hermes-managed Node $NODE_VERSION LTS..."
@@ -860,20 +960,12 @@ install_node() {
         return 0
     fi
 
-    # Place into ~/.hermes/node/ and symlink binaries into the same bin dir
-    # the hermes command uses (get_command_link_dir): /usr/local/bin for root
-    # FHS installs, $PREFIX/bin on Termux, ~/.local/bin otherwise.
+    # Place into ~/.hermes/node/. The binaries stay private; install/check
+    # paths prepend $HERMES_HOME/node/bin only for Hermes subprocesses.
     rm -rf "$HERMES_HOME/node"
     mkdir -p "$HERMES_HOME"
     mv "$extracted_dir" "$HERMES_HOME/node"
     rm -rf "$tmp_dir"
-
-    local node_link_dir
-    node_link_dir="$(get_command_link_dir)"
-    mkdir -p "$node_link_dir"
-    ln -sf "$HERMES_HOME/node/bin/node" "$node_link_dir/node"
-    ln -sf "$HERMES_HOME/node/bin/npm"  "$node_link_dir/npm"
-    ln -sf "$HERMES_HOME/node/bin/npx"  "$node_link_dir/npx"
 
     configure_managed_node_npm_prefix
 

--- a/scripts/lib/node-bootstrap.sh
+++ b/scripts/lib/node-bootstrap.sh
@@ -44,30 +44,58 @@ _nb_is_termux() {
     [ -n "${TERMUX_VERSION:-}" ] || [[ "${PREFIX:-}" == *"com.termux/files/usr"* ]]
 }
 
-# Where to symlink node/npm/npx so they land on PATH.
-# Mirrors get_command_link_dir() from install.sh: root FHS → /usr/local/bin,
-# Termux → $PREFIX/bin, otherwise ~/.local/bin.
-_nb_get_link_dir() {
-    if _nb_is_termux && [ -n "${PREFIX:-}" ]; then
-        echo "$PREFIX/bin"
-    elif [ "$(id -u)" = 0 ] && [ "$(uname -s)" = "Linux" ]; then
-        echo "/usr/local/bin"
-    else
-        echo "$HOME/.local/bin"
-    fi
-}
-
-# Redirect a Hermes-managed Node's `npm install -g` to the command link dir
-# (already on PATH) instead of the default $HERMES_HOME/node/bin, which is off
-# PATH and wiped on every Node upgrade. Scoped to the managed Node via its
-# prefix-local global npmrc; the user's other Node installs / ~/.npmrc are
-# untouched. Idempotent no-op when there's no managed npm.
+# Redirect a Hermes-managed Node's `npm install -g` into $HERMES_HOME/node so
+# global bins stay self-contained under $HERMES_HOME/node/bin, which Hermes
+# already uses for its own subprocess PATH, instead of shadowing the user's
+# node/npm/npx in ~/.local/bin. Scoped to the managed Node via its prefix-local
+# global npmrc; the user's other Node installs / ~/.npmrc are untouched.
+# Idempotent no-op when there's no managed npm.
 _nb_configure_npm_prefix() {
     [ -x "$HERMES_HOME/node/bin/npm" ] || return 0
-    local _link_dir
-    _link_dir="$(_nb_get_link_dir)"
     mkdir -p "$HERMES_HOME/node/etc"
-    printf 'prefix=%s\n' "$(dirname "$_link_dir")" > "$HERMES_HOME/node/etc/npmrc"
+    printf 'prefix=%s\n' "$HERMES_HOME/node" > "$HERMES_HOME/node/etc/npmrc"
+}
+
+_nb_link_points_into_hermes_node() {
+    local _link="$1" _target _target_abs _node_dir
+    [ -L "$_link" ] || return 1
+    _target="$(readlink "$_link" 2>/dev/null)" || return 1
+    case "$_target" in
+        /*) _target_abs="$_target" ;;
+        *)  _target_abs="$(dirname "$_link")/$_target" ;;
+    esac
+
+    _node_dir="$HERMES_HOME/node"
+    case "$_target_abs" in
+        "$_node_dir"|"$_node_dir"/*) return 0 ;;
+    esac
+
+    if [ -d "$_node_dir" ] && [ -e "$_target_abs" ]; then
+        local _resolved_target _resolved_node
+        _resolved_target="$(cd "$(dirname "$_target_abs")" 2>/dev/null && pwd -P)/$(basename "$_target_abs")"
+        _resolved_node="$(cd "$_node_dir" 2>/dev/null && pwd -P)"
+        case "$_resolved_target" in
+            "$_resolved_node"|"$_resolved_node"/*) return 0 ;;
+        esac
+    fi
+    return 1
+}
+
+_nb_remove_legacy_node_links() {
+    local _dirs=() _dir _name _link
+    _dirs+=("$HOME/.local/bin")
+    [ -n "${PREFIX:-}" ] && _dirs+=("$PREFIX/bin")
+    _dirs+=("/usr/local/bin")
+
+    for _dir in "${_dirs[@]}"; do
+        [ -d "$_dir" ] || continue
+        for _name in node npm npx; do
+            _link="$_dir/$_name"
+            if _nb_link_points_into_hermes_node "$_link"; then
+                rm -f "$_link" || true
+            fi
+        done
+    done
 }
 
 _nb_node_major() {
@@ -79,6 +107,26 @@ _nb_node_major() {
 _nb_have_modern_node() {
     command -v node >/dev/null 2>&1 || return 1
     [ "$(_nb_node_major)" -ge "$HERMES_NODE_MIN_VERSION" ]
+}
+
+_nb_node_bin_major() {
+    local node_bin="$1" v
+    [ -x "$node_bin" ] || return 1
+    v=$("$node_bin" --version 2>/dev/null | sed 's/^v//' | cut -d. -f1)
+    [[ "$v" =~ ^[0-9]+$ ]] && echo "$v" || echo 0
+}
+
+_nb_activate_node_bin() {
+    local node_bin="$1" label="$2" major node_dir
+    major="$(_nb_node_bin_major "$node_bin")" || return 1
+    [ "$major" -ge "$HERMES_NODE_MIN_VERSION" ] || return 1
+    node_dir="$(dirname "$node_bin")"
+    case ":$PATH:" in
+        *":$node_dir:"*) ;;
+        *) export PATH="$node_dir:$PATH" ;;
+    esac
+    _nb_ok "Node $("$node_bin" --version) found ($label)"
+    return 0
 }
 
 # ---------------------------------------------------------------------------
@@ -116,6 +164,31 @@ _nb_try_nvm() {
     _nb_have_modern_node || return 1
     _nb_ok "Node $(node --version) activated via nvm"
     return 0
+}
+
+_nb_try_existing_nvm() {
+    local nvm_root="${NVM_DIR:-$HOME/.nvm}" node_bin
+    for node_bin in "$nvm_root"/versions/node/*/bin/node; do
+        [ -e "$node_bin" ] || continue
+        _nb_activate_node_bin "$node_bin" "nvm" && return 0
+    done
+    return 1
+}
+
+_nb_try_existing_fnm() {
+    local fnm_root node_bin
+    for fnm_root in "${FNM_DIR:-$HOME/.local/share/fnm}" "$HOME/.fnm"; do
+        for node_bin in "$fnm_root"/node-versions/*/installation/bin/node "$fnm_root"/node-versions/*/bin/node; do
+            [ -e "$node_bin" ] || continue
+            _nb_activate_node_bin "$node_bin" "fnm" && return 0
+        done
+    done
+    return 1
+}
+
+_nb_try_existing_volta() {
+    local volta_root="${VOLTA_HOME:-$HOME/.volta}"
+    _nb_activate_node_bin "$volta_root/bin/node" "Volta"
 }
 
 # ---------------------------------------------------------------------------
@@ -213,13 +286,6 @@ _nb_install_bundled_node() {
     mv "$extracted" "$HERMES_HOME/node"
     rm -rf "$tmp"
 
-    local _link_dir
-    _link_dir="$(_nb_get_link_dir)"
-    mkdir -p "$_link_dir"
-    ln -sf "$HERMES_HOME/node/bin/node" "$_link_dir/node"
-    ln -sf "$HERMES_HOME/node/bin/npm"  "$_link_dir/npm"
-    ln -sf "$HERMES_HOME/node/bin/npx"  "$_link_dir/npx"
-
     _nb_configure_npm_prefix
 
     export PATH="$HERMES_HOME/node/bin:$PATH"
@@ -236,8 +302,13 @@ _nb_install_bundled_node() {
 ensure_node() {
     HERMES_NODE_AVAILABLE=false
 
-    # Repair pre-existing managed installs where `npm install -g` lands off
-    # PATH. No-op when there's no managed Node, so it's safe to run first.
+    # Remove legacy node/npm/npx shims that older Hermes installers placed in
+    # ~/.local/bin or other command dirs. Only links into this HERMES_HOME are
+    # removed; user-managed nvm/fnm/Volta binaries are left untouched.
+    _nb_remove_legacy_node_links
+
+    # Keep pre-existing managed installs self-contained. No-op when there's no
+    # managed Node, so it's safe to run first.
     _nb_configure_npm_prefix
 
     if _nb_have_modern_node; then
@@ -245,6 +316,11 @@ ensure_node() {
         HERMES_NODE_AVAILABLE=true
         return 0
     fi
+
+    # Prefer explicit user version-manager installs over Hermes's private copy.
+    _nb_try_existing_fnm   && { HERMES_NODE_AVAILABLE=true; return 0; }
+    _nb_try_existing_volta && { HERMES_NODE_AVAILABLE=true; return 0; }
+    _nb_try_existing_nvm   && { HERMES_NODE_AVAILABLE=true; return 0; }
 
     if [ -x "$HERMES_HOME/node/bin/node" ]; then
         export PATH="$HERMES_HOME/node/bin:$PATH"

--- a/tests/hermes_cli/test_cmd_update.py
+++ b/tests/hermes_cli/test_cmd_update.py
@@ -1,6 +1,7 @@
 """Tests for cmd_update — branch fallback when remote branch doesn't exist."""
 
 import subprocess
+from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import patch
 
@@ -175,6 +176,33 @@ class TestCmdUpdateBranchFallback:
         commands = [" ".join(str(a) for a in c.args[0]) for c in mock_run.call_args_list]
         pull_cmds = [c for c in commands if "pull" in c]
         assert len(pull_cmds) == 0
+
+    @patch("shutil.which", return_value=None)
+    @patch("subprocess.run")
+    def test_update_already_up_to_date_migrates_legacy_node_symlinks(
+        self, mock_run, _mock_which, mock_args, tmp_path, monkeypatch
+    ):
+        mock_run.side_effect = _make_run_side_effect(
+            branch="main", verify_ok=True, commit_count="0"
+        )
+        monkeypatch.setattr(Path, "home", classmethod(lambda cls: tmp_path))
+        hermes_home = tmp_path / ".hermes"
+        node_bin = hermes_home / "node" / "bin"
+        local_bin = tmp_path / ".local" / "bin"
+        node_bin.mkdir(parents=True)
+        local_bin.mkdir(parents=True)
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        for name in ("node", "npm", "npx"):
+            binary = node_bin / name
+            binary.write_text("#!/bin/sh\n", encoding="utf-8")
+            binary.chmod(0o755)
+            (local_bin / name).symlink_to(binary)
+
+        cmd_update(mock_args)
+
+        for name in ("node", "npm", "npx"):
+            assert not (local_bin / name).is_symlink()
 
     @patch("shutil.which", return_value=None)
     @patch("subprocess.run")
@@ -802,6 +830,41 @@ def test_is_termux_env_false_for_non_termux_prefix():
     from hermes_cli import main as hm
 
     assert hm._is_termux_env({"PREFIX": "/usr/local"}) is False
+
+
+def test_update_node_dependencies_uses_private_hermes_npm_when_path_has_none(
+    tmp_path, monkeypatch
+):
+    """Update still refreshes Node deps after legacy node/npm PATH shims are gone."""
+    from hermes_cli import main as hm
+
+    project = tmp_path / "repo"
+    project.mkdir()
+    (project / "package.json").write_text("{}", encoding="utf-8")
+
+    hermes_home = tmp_path / ".hermes"
+    node_bin = hermes_home / "node" / "bin"
+    node_bin.mkdir(parents=True)
+    npm = node_bin / "npm"
+    npm.write_text("#!/bin/sh\n", encoding="utf-8")
+    npm.chmod(0o755)
+
+    calls = []
+
+    def fake_run_npm(npm_path, cwd, *, extra_args=(), capture_output=False, env=None):
+        calls.append((npm_path, Path(cwd), tuple(extra_args), capture_output, env))
+        return subprocess.CompletedProcess([npm_path], 0, stdout="", stderr="")
+
+    monkeypatch.setattr(hm, "PROJECT_ROOT", project)
+    monkeypatch.setattr(hm.shutil, "which", lambda _name: None)
+    monkeypatch.setattr("hermes_constants.get_hermes_home", lambda: hermes_home)
+    monkeypatch.setattr(hm, "_run_npm_install_deterministic", fake_run_npm)
+    monkeypatch.setattr(hm, "_nixos_build_env", lambda: None)
+
+    hm._update_node_dependencies()
+
+    assert [call[0] for call in calls] == [str(npm), str(npm)]
+    assert [call[1] for call in calls] == [project, project]
 
 
 def test_load_installable_optional_extras_supports_termux_group(tmp_path, monkeypatch):

--- a/tests/hermes_cli/test_dep_ensure.py
+++ b/tests/hermes_cli/test_dep_ensure.py
@@ -1,3 +1,4 @@
+import os
 from unittest.mock import patch
 
 
@@ -18,6 +19,60 @@ def test_ensure_dependency_returns_false_when_missing_noninteractive():
         with patch("hermes_cli.dep_ensure._find_install_script", return_value=(None, None)):
             result = ensure_dependency("node", interactive=False)
             assert result is False
+
+
+def test_ensure_dependency_accepts_private_hermes_node_when_not_on_path(tmp_path):
+    """Removing ~/.local/bin node/npm shims must not break lazy node ensure."""
+    from hermes_cli.dep_ensure import ensure_dependency
+
+    node_bin = tmp_path / "node" / "bin"
+    node_bin.mkdir(parents=True)
+    for name in ("node", "npm"):
+        binary = node_bin / name
+        binary.write_text("#!/bin/sh\n", encoding="utf-8")
+        binary.chmod(0o755)
+
+    with patch("hermes_cli.dep_ensure.shutil.which", return_value=None), \
+         patch("hermes_constants.get_hermes_home", return_value=tmp_path):
+        assert ensure_dependency("node", interactive=False) is True
+
+
+def test_ensure_dependency_does_not_prepend_private_node_over_user_node(
+    tmp_path, monkeypatch
+):
+    """A private Hermes runtime must not shadow a user-managed node already on PATH."""
+    from hermes_cli.dep_ensure import ensure_dependency
+
+    node_bin = tmp_path / "node" / "bin"
+    node_bin.mkdir(parents=True)
+    private_node = node_bin / "node"
+    private_node.write_text("#!/bin/sh\n", encoding="utf-8")
+    private_node.chmod(0o755)
+
+    monkeypatch.setenv("PATH", "/usr/local/bin:/usr/bin")
+    with patch("hermes_cli.dep_ensure.shutil.which", return_value="/usr/local/bin/node"), \
+         patch("hermes_constants.get_hermes_home", return_value=tmp_path):
+        assert ensure_dependency("node", interactive=False) is True
+
+    assert os.environ["PATH"] == "/usr/local/bin:/usr/bin"
+
+
+def test_has_private_hermes_node_windows_layout(tmp_path):
+    """The Windows portable zip puts node.exe in node/ (root), not node/bin/.
+
+    Detection now defers to hermes_constants.find_hermes_node_executable, which
+    keys the per-platform layout off sys.platform; the node/bin-vs-node ordering
+    itself is covered directly in tests/test_hermes_constants.py.
+    """
+    from hermes_cli.dep_ensure import _has_private_hermes_node
+
+    node_dir = tmp_path / "node"
+    node_dir.mkdir(parents=True)
+    (node_dir / "node.exe").write_text("", encoding="utf-8")
+
+    with patch("hermes_constants.sys.platform", "win32"), \
+         patch("hermes_constants.get_hermes_home", return_value=tmp_path):
+        assert _has_private_hermes_node() is True
 
 
 def test_find_install_script_from_checkout(tmp_path):

--- a/tests/hermes_cli/test_tools_config.py
+++ b/tests/hermes_cli/test_tools_config.py
@@ -1044,6 +1044,50 @@ def test_computer_use_post_setup_missing_override_does_not_accept_default_binary
     assert "curl" in seen
 
 
+def test_post_setup_browser_uses_managed_node_when_path_has_none(tmp_path, monkeypatch):
+    """`hermes setup` must install browser deps via the Hermes-managed Node even
+    when no node/npm is on PATH.
+
+    Regression: the installer no longer symlinks node/npm/npx into ~/.local/bin,
+    so a bare ``shutil.which("npm")`` returns None on a Hermes-private-node box
+    and the browser-tool install was silently skipped. ``_run_post_setup`` now
+    resolves via ``find_node_executable()`` and runs npm with
+    ``with_hermes_node_path()`` so the managed Node is reachable.
+    """
+    import os
+
+    from hermes_cli import tools_config
+
+    hermes_home = tmp_path / ".hermes"
+    node_bin = hermes_home / "node" / "bin"
+    node_bin.mkdir(parents=True)
+    for name in ("node", "npm", "npx"):
+        binary = node_bin / name
+        binary.write_text("#!/bin/sh\n", encoding="utf-8")
+        binary.chmod(0o755)
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    monkeypatch.setattr(tools_config, "PROJECT_ROOT", repo)
+
+    # No node/npm/npx on PATH — the private-node-only box. On the pre-fix code
+    # this made npm_bin None and skipped the install entirely.
+    with patch("shutil.which", return_value=None), \
+         patch("subprocess.run") as run:
+        run.return_value = SimpleNamespace(returncode=0, stdout="", stderr="")
+        # "browserbase" runs the npm install then returns before the Chromium
+        # step, so exactly one subprocess (the install) is expected.
+        tools_config._run_post_setup("browserbase")
+
+    run.assert_called_once()
+    cmd = run.call_args.args[0]
+    assert cmd[0] == str(node_bin / "npm")
+    assert cmd[1] == "install"
+    env_path = run.call_args.kwargs.get("env", {}).get("PATH", "")
+    assert str(node_bin) in env_path.split(os.pathsep)
+
+
 class TestImagegenBackendRegistry:
     """IMAGEGEN_BACKENDS tags drive the model picker flow in tools_config."""
 

--- a/tests/hermes_cli/test_tui_resume_flow.py
+++ b/tests/hermes_cli/test_tui_resume_flow.py
@@ -396,6 +396,40 @@ def test_termux_fast_cli_launch_version_skips_update_check(monkeypatch, main_mod
     assert captured == [False]
 
 
+def test_ensure_tui_node_prepends_private_node_without_local_bin(
+    tmp_path, monkeypatch, main_mod
+):
+    hermes_home = tmp_path / ".hermes"
+    node_bin = hermes_home / "node" / "bin"
+    local_bin = tmp_path / ".local" / "bin"
+    node_bin.mkdir(parents=True)
+    local_bin.mkdir(parents=True)
+
+    node = node_bin / "node"
+    node.write_text("#!/bin/sh\n", encoding="utf-8")
+    node.chmod(0o755)
+
+    import hermes_cli.uninstall as uninstall
+
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.setenv("PATH", "/usr/bin:/bin")
+    monkeypatch.setattr(uninstall, "remove_node_symlinks", lambda _home: [])
+    monkeypatch.setattr(main_mod.shutil, "which", lambda _name: None)
+    monkeypatch.setattr(
+        main_mod.subprocess,
+        "run",
+        lambda *args, **kwargs: main_mod.subprocess.CompletedProcess(
+            args[0], 0, stdout=f"{node}\n", stderr=""
+        ),
+    )
+
+    main_mod._ensure_tui_node()
+
+    path_entries = os.environ["PATH"].split(os.pathsep)
+    assert path_entries[0] == str(node_bin)
+    assert str(local_bin) not in path_entries
+
+
 def test_termux_ultrafast_version_runs_before_heavy_startup(
     monkeypatch, capsys, main_mod
 ):

--- a/tests/hermes_cli/test_uninstall_node_symlinks.py
+++ b/tests/hermes_cli/test_uninstall_node_symlinks.py
@@ -1,9 +1,9 @@
 """Tests for hermes_cli.uninstall.remove_node_symlinks.
 
-Regression for #34536: the POSIX installer drops node/npm/npx symlinks in
-~/.local/bin pointing into $HERMES_HOME/node and prepends ~/.local/bin to
-PATH, shadowing an existing nvm. Uninstall must remove those symlinks, but
-only when they still resolve into the Hermes-managed node dir.
+Regression for #34536: older POSIX installers dropped node/npm/npx symlinks in
+~/.local/bin pointing into $HERMES_HOME/node, shadowing an existing nvm.
+Uninstall and migration must remove those symlinks, but only when they still
+resolve into the Hermes-managed node dir.
 """
 
 import os

--- a/tests/test_install_sh_node_global_prefix.py
+++ b/tests/test_install_sh_node_global_prefix.py
@@ -1,17 +1,19 @@
-"""Regression tests for the Hermes-managed Node's npm global prefix.
+"""Regression tests for Hermes-managed Node PATH isolation.
 
 When the installer falls back to a bundled Node under ``$HERMES_HOME/node``,
-npm's default global prefix is that Node dir, so ``npm install -g <pkg>``
-drops the package binary in ``$HERMES_HOME/node/bin`` — which is NOT on PATH
-(only the command link dir is) and is wiped on every Node upgrade. Users then
-report "I can ``npm i -g`` but the package isn't usable on the command line".
-
-The fix redirects the bundled Node's global prefix to the command link dir's
-parent (so global bins land in the already-on-PATH link dir alongside
-node/npm/npx), scoped to the bundled Node via its prefix-local global npmrc.
+Hermes must keep node/npm/npx private. Older installers linked them into the
+command link dir (usually ``~/.local/bin``), which could shadow nvm/fnm/Volta.
+The managed npm prefix now stays inside ``$HERMES_HOME/node`` so npm global
+bins land in ``$HERMES_HOME/node/bin``: private to Hermes, but still visible to
+Hermes subprocess PATH construction and dependency detection. Startup migrates
+only legacy symlinks that still point into the current Hermes-managed Node.
 """
 
+import os
+import subprocess
+import textwrap
 from pathlib import Path
+from unittest.mock import patch
 
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
@@ -19,14 +21,33 @@ INSTALL_SH = REPO_ROOT / "scripts" / "install.sh"
 NODE_BOOTSTRAP = REPO_ROOT / "scripts" / "lib" / "node-bootstrap.sh"
 
 
-def test_install_sh_redirects_bundled_npm_global_prefix_to_link_dir() -> None:
+def test_install_sh_keeps_bundled_npm_global_prefix_inside_hermes_home() -> None:
     text = INSTALL_SH.read_text()
 
-    # The redirect must target the link dir's PARENT so global bins resolve to
-    # <parent>/bin == the command link dir (node/npm/npx live there and it is
-    # guaranteed on PATH by the installer's PATH setup).
+    # Hermes-managed npm must stay self-contained while still placing global
+    # package bins in a Hermes runtime PATH directory. $HERMES_HOME/node/bin is
+    # already used by install.sh --prefix installs and dep_ensure detection.
     assert "configure_managed_node_npm_prefix()" in text
-    assert 'printf \'prefix=%s\\n\' "$(dirname "$link_dir")" > "$HERMES_HOME/node/etc/npmrc"' in text
+    assert 'printf \'prefix=%s\\n\' "$HERMES_HOME/node" > "$HERMES_HOME/node/etc/npmrc"' in text
+    assert 'printf \'prefix=%s\\n\' "$(dirname "$link_dir")" > "$HERMES_HOME/node/etc/npmrc"' not in text
+
+
+def test_managed_npm_global_bin_is_a_hermes_runtime_detection_path(tmp_path) -> None:
+    """prefix=$HERMES_HOME/node makes npm -g bins visible to Hermes internals."""
+    from hermes_cli.dep_ensure import _has_hermes_agent_browser
+
+    managed_prefix = tmp_path / "node"
+    managed_global_bin = managed_prefix / "bin"
+    assert managed_global_bin == tmp_path / "node" / "bin"
+
+    managed_global_bin.mkdir(parents=True)
+    agent_browser = managed_global_bin / "agent-browser"
+    agent_browser.write_text("#!/bin/sh\n", encoding="utf-8")
+    agent_browser.chmod(0o755)
+
+    with patch("hermes_cli.dep_ensure._IS_WINDOWS", False), \
+         patch("hermes_constants.get_hermes_home", return_value=tmp_path):
+        assert _has_hermes_agent_browser() is True
 
 
 def test_install_sh_repairs_existing_managed_node_on_rerun() -> None:
@@ -42,14 +63,134 @@ def test_install_sh_repairs_existing_managed_node_on_rerun() -> None:
     assert '[ -x "$HERMES_HOME/node/bin/npm" ] || return 0' in text
 
 
-def test_node_bootstrap_redirects_bundled_npm_global_prefix_to_link_dir() -> None:
+def test_node_bootstrap_keeps_bundled_npm_global_prefix_inside_hermes_home() -> None:
     text = NODE_BOOTSTRAP.read_text()
 
     assert "_nb_configure_npm_prefix()" in text
-    assert 'printf \'prefix=%s\\n\' "$(dirname "$_link_dir")" > "$HERMES_HOME/node/etc/npmrc"' in text
+    assert 'printf \'prefix=%s\\n\' "$HERMES_HOME/node" > "$HERMES_HOME/node/etc/npmrc"' in text
+    assert 'printf \'prefix=%s\\n\' "$(dirname "$_link_dir")" > "$HERMES_HOME/node/etc/npmrc"' not in text
 
     # Runs at the top of ensure_node so existing managed installs are repaired
     # even when a modern Node is already present (early return path).
     ensure_node_body = text.split("ensure_node()", 1)[1]
     assert "_nb_configure_npm_prefix" in ensure_node_body
     assert '[ -x "$HERMES_HOME/node/bin/npm" ] || return 0' in text
+
+
+def test_installers_never_link_managed_node_tools_into_command_dir() -> None:
+    install_text = INSTALL_SH.read_text()
+    bootstrap_text = NODE_BOOTSTRAP.read_text()
+
+    forbidden = (
+        'ln -sf "$HERMES_HOME/node/bin/node"',
+        'ln -sf "$HERMES_HOME/node/bin/npm"',
+        'ln -sf "$HERMES_HOME/node/bin/npx"',
+    )
+    for snippet in forbidden:
+        assert snippet not in install_text
+        assert snippet not in bootstrap_text
+
+
+def test_node_bootstrap_migrates_only_hermes_owned_node_symlinks(tmp_path) -> None:
+    home = tmp_path / "home"
+    hermes_home = home / ".hermes"
+    local_bin = home / ".local" / "bin"
+    node_bin = hermes_home / "node" / "bin"
+    nvm_bin = home / ".nvm" / "versions" / "node" / "v22.12.0" / "bin"
+    node_bin.mkdir(parents=True)
+    local_bin.mkdir(parents=True)
+    nvm_bin.mkdir(parents=True)
+
+    for name in ("node", "npm", "npx"):
+        target = node_bin / name
+        target.write_text("#!/bin/sh\n", encoding="utf-8")
+        target.chmod(0o755)
+        (local_bin / name).symlink_to(target)
+
+    user_node = nvm_bin / "node"
+    user_node.write_text("#!/bin/sh\n", encoding="utf-8")
+    user_node.chmod(0o755)
+    user_link = local_bin / "user-node"
+    user_link.symlink_to(user_node)
+
+    script = textwrap.dedent(
+        f"""
+        source "{NODE_BOOTSTRAP}"
+        _nb_remove_legacy_node_links
+        for name in node npm npx; do
+            [ ! -e "{local_bin}/$name" ] && [ ! -L "{local_bin}/$name" ] || exit 10
+        done
+        [ -L "{user_link}" ] || exit 11
+        """
+    )
+    result = subprocess.run(
+        ["bash", "--noprofile", "--norc", "-c", script],
+        env={
+            "HOME": str(home),
+            "HERMES_HOME": str(hermes_home),
+            "PATH": os.environ.get("PATH", ""),
+        },
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr
+
+
+def test_node_bootstrap_prefers_existing_nvm_node_over_private_fallback(tmp_path) -> None:
+    home = tmp_path / "home"
+    hermes_home = home / ".hermes"
+    hermes_node_bin = hermes_home / "node" / "bin"
+    nvm_node_bin = home / ".nvm" / "versions" / "node" / "v22.20.0" / "bin"
+    hermes_node_bin.mkdir(parents=True)
+    nvm_node_bin.mkdir(parents=True)
+
+    for name in ("node", "npm"):
+        binary = hermes_node_bin / name
+        binary.write_text("#!/bin/sh\necho v22.12.0\n", encoding="utf-8")
+        binary.chmod(0o755)
+
+    nvm_node = nvm_node_bin / "node"
+    nvm_node.write_text("#!/bin/sh\necho v22.20.0\n", encoding="utf-8")
+    nvm_node.chmod(0o755)
+
+    script = textwrap.dedent(
+        f"""
+        source "{NODE_BOOTSTRAP}"
+        ensure_node >/tmp/hermes-bootstrap-prefers-nvm.out 2>/tmp/hermes-bootstrap-prefers-nvm.err
+        [ "$(command -v node)" = "{nvm_node}" ] || {{
+            command -v node
+            cat /tmp/hermes-bootstrap-prefers-nvm.err >&2
+            exit 12
+        }}
+        """
+    )
+    result = subprocess.run(
+        ["bash", "--noprofile", "--norc", "-c", script],
+        env={
+            "HOME": str(home),
+            "HERMES_HOME": str(hermes_home),
+            "PATH": "/usr/bin:/bin",
+        },
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr
+
+
+def test_install_sh_checks_user_version_managers_before_private_node() -> None:
+    text = INSTALL_SH.read_text()
+    check_node_body = text.split("check_node()", 1)[1].split("\ninstall_node()", 1)[0]
+
+    fnm_idx = check_node_body.index("try_existing_fnm_node")
+    volta_idx = check_node_body.index("try_existing_volta_node")
+    nvm_idx = check_node_body.index("try_existing_nvm_node")
+    private_idx = check_node_body.index('activate_node_bin_if_satisfies_build "$HERMES_HOME/node/bin/node"')
+
+    assert fnm_idx < private_idx
+    assert volta_idx < private_idx
+    assert nvm_idx < private_idx
+    assert '"${FNM_DIR:-$HOME/.local/share/fnm}"' in text
+    assert '${VOLTA_HOME:-$HOME/.volta}' in text
+    assert '${NVM_DIR:-$HOME/.nvm}' in text


### PR DESCRIPTION
## Update — rebased onto latest `main` (+ adopted shared helpers, + `hermes setup` fix)

This branch was ~580 commits behind `main`; it has been rebased onto current `main` and the overlap reconciled:

- **Resolved the one merge conflict** (`hermes_cli/main.py` `_update_node_dependencies`). Since this branch was cut, `main` independently introduced `hermes_constants.{find_node_executable, with_hermes_node_path, iter_hermes_node_dirs}` for managed-Node resolution. The Python side now uses those shared helpers instead of the hand-rolled per-platform path logic this PR originally added — `dep_ensure.py` no longer re-derives `$HERMES_HOME/node[/bin]`; it defers to `iter_hermes_node_dirs` / `find_hermes_node_executable` (which are kept in sync with `apps/desktop/electron/main.cjs`). The install-side fix and the legacy-shim migration are unchanged — the symlink hijack still exists on current `main`, so this fix is still needed.
- **`hermes setup` regression fix (new in this revision).** Removing the PATH symlinks exposed a pre-existing bare `shutil.which("npm"/"npx")` in `hermes_cli/tools_config.py::_run_post_setup`: on a machine whose only Node was the Hermes symlink, the post-setup browser/camofox install was silently skipped. It now resolves via `find_node_executable` and runs npm/npx with `env=with_hermes_node_path()` (mirroring the existing WhatsApp / web-build call sites in `main.py`). Added a regression test (`test_post_setup_browser_uses_managed_node_when_path_has_none`) that fails on the old code.
- **Tests:** all touched suites pass — `test_dep_ensure`, `test_cmd_update`, `test_tools_config`, `test_uninstall_node_symlinks`, `test_tui_resume_flow`, `test_install_sh_node_global_prefix`, `test_hermes_constants`.

### Deliberately out of scope (pre-existing, not introduced here)

Removing the PATH symlinks also exposes other pre-existing bare `shutil.which` / `command -v node` call sites that the symlinks were silently backstopping. These are **not** on the critical install / first-run / update path (which self-heals via `_ensure_tui_node` / `ensure_dependency` / the desktop PATH builder), so they are left for a separate follow-up:

- `apps/desktop/electron/backend-env.cjs` — Windows: omits the `node/` root from the spawned backend's PATH (pre-dates this PR).
- `hermes_cli/main.py` `_launch_tui` — copies `os.environ` *before* `_ensure_tui_node()` prepends `node/bin`, so the TUI child env can lack the managed dir.
- `hermes_cli/doctor.py` — diagnostic-only false "node not found" on a private-node box.
- `agent/lsp/install.py`, `plugins/platforms/photon/*` — opt-in flows.
- `try_existing_*` node probes pick the lexicographically-first version ≥ build floor rather than newest / `nvm default` (no `sort -V`).

---

## What does this PR do?

On POSIX, the installer makes Hermes's **bundled Node hijack the user's own Node**. `scripts/install.sh` (and the lazy `scripts/lib/node-bootstrap.sh`) symlink the managed `node`/`npm`/`npx` into `~/.local/bin` (or `/usr/local/bin` / `$PREFIX/bin`) and point the managed npm global prefix at the link dir's parent. Because `~/.local/bin` typically sits **ahead of a version manager's shims on PATH**, this silently shadows the user's `nvm`/`fnm`/`Volta` Node — and it **recurs on every install/update/lazy-ensure**, so removing the symlinks by hand doesn't stick.

This makes the managed Node **private to Hermes subprocesses** and migrates away the legacy shims, so Hermes stops competing for the user's `node` on PATH.

## Related Issue

No tracking issue — happy to open one if you'd like it linked.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- **`scripts/install.sh`, `scripts/lib/node-bootstrap.sh`** — stop symlinking `node`/`npm`/`npx` into command dirs on install. Set the managed npm global prefix to `$HERMES_HOME/node` (so `npm install -g` bins land in `$HERMES_HOME/node/bin`, which is already on Hermes's runtime PATH and matches the explicit `--prefix "$HERMES_HOME/node"` the installer already uses for agent-browser — rather than an off-PATH `$HERMES_HOME/bin`).
- **Migration** — `check_node` / `ensure_node` / `hermes update` / lazy `ensure_dependency` remove legacy `node`/`npm`/`npx` shims, but **only links that resolve into _this_ `$HERMES_HOME/node`**. Links the user repointed elsewhere (nvm/fnm/Volta) are left untouched (reuses `uninstall.remove_node_symlinks`).
- **Prefer the user's version manager** — `check_node`/`ensure_node` probe existing `fnm`/`Volta`/`nvm` Node before falling back to the private copy, so a one-time fallback never permanently wins over a version manager.
- **`hermes_cli/dep_ensure.py`, `hermes_cli/main.py`** — resolve `$HERMES_HOME/node/bin` for Hermes subprocesses without relying on a PATH symlink, and **never prepend the private Node when the user already has `node` on PATH**.
- **`hermes update` idempotency** — legacy shims are cleaned up even on the "Already up to date" early-return, so updates don't reintroduce the hijack.
- **Per-platform layout** — the managed-Node bin dir is `node/bin` on POSIX and `node/` for the Windows portable zip; the new `dep_ensure`/update helpers honor both.
- Tests added/updated across `tests/` for every behavior above.

## How to Test

Reproduction (POSIX):
1. With `nvm`/`fnm`/`Volta` providing `node` on PATH, run the installer (or `bash scripts/install.sh --ensure node`).
2. Before this PR: `~/.local/bin/{node,npm,npx}` get symlinked to the bundled Node and shadow the version manager (`readlink $(command -v node)` points into `$HERMES_HOME/node`); the symlinks come back after each `hermes update`.
3. After this PR: the version-manager Node stays in front; any legacy Hermes shims pointing into `$HERMES_HOME/node` are removed; user-repointed links are preserved.

Automated:
```bash
scripts/run_tests.sh \
  tests/test_install_sh_node_global_prefix.py \
  tests/hermes_cli/test_dep_ensure.py \
  tests/hermes_cli/test_cmd_update.py \
  tests/hermes_cli/test_uninstall_node_symlinks.py \
  tests/hermes_cli/test_tui_resume_flow.py
# 107 passed
```

Also verified with two temp-`HOME` sandboxes: `install.sh --ensure node` and `node-bootstrap ensure_node` both remove legacy `~/.local/bin` shims, prefer an existing nvm Node, and write `prefix=$HERMES_HOME/node`.

## Cross-platform note (install.sh ↔ install.ps1)

Per CONTRIBUTING rule #13 I checked `scripts/install.ps1`: **the POSIX bugs do not exist on Windows, so no equivalent ps1 change is needed for this fix.** install.ps1 *appends* `$HERMES_HOME\node` to the user PATH (it does not shadow a user's existing Node, which sits earlier on PATH) and already installs agent-browser with an explicit `--prefix "$HERMES_HOME\node"` (on PATH). The new Python helpers are made layout-correct for both platforms (Windows portable Node lives in `node\`, POSIX in `node/bin/`). Fully isolating the managed Node from the persistent Windows User PATH would be a separate, larger, Windows-tested change and is intentionally out of scope here.

One known non-blocking nit: `main.py:_ensure_tui_node` still appends `node/bin` literally, but that path is POSIX-only by construction (it's driven by `bash -c 'source node-bootstrap.sh'`) and guarded by `if extra.is_dir()`, so it is a harmless no-op on Windows. Happy to platformize it for consistency if preferred.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(install): ...`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [x] I've run the touched test files and they pass (107 passed)
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS (POSIX); Windows layout covered by unit tests, not run on a Windows host

### Documentation & Housekeeping

- [x] Documentation — N/A (behavior fix; comments updated in-place)
- [x] `cli-config.yaml.example` — N/A (no config keys changed)
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A (no workflow change)
- [x] Cross-platform impact considered — see note above
- [x] Tool descriptions/schemas — N/A

