### PR TITLE
fix(mcp): don't trip circuit breaker on business errors (isError)

### DIFF
--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -2861,11 +2861,22 @@ def _make_tool_handler(server_name: str, tool_name: str, tool_timeout: float):
 
         try:
             result = _call_once()
-            # Check if the MCP tool itself returned an error
+            # Check if the MCP tool itself returned an error.
+            #
+            # IMPORTANT: an "error" key in the JSON response comes from
+            # ``result.isError == true`` (the MCP protocol's business-error
+            # signal, see lines 2813-2822).  This is NOT a transport failure —
+            # the server is healthy and the model should retry with corrected
+            # arguments.  Bumping the circuit-breaker counter here would treat
+            # a validation error the same as a network outage (#47851).
+            #
+            # Only transport/auth failures (caught as exceptions in the outer
+            # ``except Exception`` block at line ~2876) should increment the
+            # error counter and trip the circuit breaker.
             try:
                 parsed = json.loads(result)
                 if "error" in parsed:
-                    _bump_server_error(server_name)
+                    _reset_server_error(server_name)  # business error — server healthy
                 else:
                     _reset_server_error(server_name)  # success — reset
             except (json.JSONDecodeError, TypeError):


### PR DESCRIPTION
## Problem

When an MCP tool returns `isError: true` with a business error message (e.g. validation failure, missing required field), the handler wraps it as `{"error": "..."}`. The circuit-breaker check at line ~2867 was treating this the same as a transport failure and calling `_bump_server_error()`, which caused the circuit breaker to trip after 3 consecutive business errors.

This blocks ALL tools on the server for ~60 seconds with a misleading message like:
`"MCP server 'waw' is unreachable after 3 consecutive failures"`

even though the server is perfectly healthy — the errors are just validation/business errors.

Refs: #47851

## Fix

Reset the error counter for JSON responses containing an `"error"` key instead of bumping it. Business errors mean the server is healthy — the model should retry with corrected arguments.

Transport/auth failures are still properly handled by the outer `except Exception` block (line ~2876), which still calls `_bump_server_error()`.

## Changes

- **tools/mcp_tool.py**: Changed `_bump_server_error(server_name)` to `_reset_server_error(server_name)` in the JSON error-check path, with explanatory comments referencing #47851