### PR TITLE
fix(cli): parenthesize or-expression before [:50] slice in 3 locations

### DIFF
--- a/hermes_cli/cli_commands_mixin.py
+++ b/hermes_cli/cli_commands_mixin.py
@@ -1031,7 +1031,7 @@ class CLICommandsMixin:
             print(f"  {'none':<12} - (no personality overlay)")
             for name, prompt in self.personalities.items():
                 if isinstance(prompt, dict):
-                    preview = prompt.get("description") or prompt.get("system_prompt", "")[:50]
+                    preview = (prompt.get("description") or prompt.get("system_prompt", ""))[:50]
                 else:
                     preview = str(prompt)[:50]
                 print(f"  {name:<12} - {preview}")

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -1747,7 +1747,7 @@ class SlashCommandCompleter(Completer):
             for name, prompt in personalities.items():
                 if name.startswith(sub_lower) and name != sub_lower:
                     if isinstance(prompt, dict):
-                        meta = prompt.get("description") or prompt.get("system_prompt", "")[:50]
+                        meta = (prompt.get("description") or prompt.get("system_prompt", ""))[:50]
                     else:
                         meta = str(prompt)[:50]
                     yield Completion(

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -429,7 +429,7 @@ def _format_job(job: Dict[str, Any]) -> Dict[str, Any]:
     prompt = str(job.get("prompt") or "")
     skills = _canonical_skills(job.get("skill"), job.get("skills"))
     job_id = str(job.get("id") or "unknown")
-    name = str(job.get("name") or prompt[:50] or (skills[0] if skills else "") or job_id or "cron job")
+    name = str((job.get("name") or prompt)[:50] or (skills[0] if skills else "") or job_id or "cron job")
     result = {
         "job_id": job_id,
         "name": name,


### PR DESCRIPTION
## Bug

Python's slice operator `[:]` binds tighter than `or`, so `x or y[:50]` only truncates `y`, not the full expression. Long `description` values pass through untruncated, breaking personality list layout and cron job name display.

Same pattern fixed previously in PRs #20050, #32347, #32450 — these 3 locations were missed.

## Fix

Parenthesize: `(x or y)[:50]`

**Locations:**
- `tools/cronjob_tools.py:432` — cron job name display
- `hermes_cli/cli_commands_mixin.py:1034` — personality preview in `/mode` list
- `hermes_cli/commands.py:1750` — personality autocomplete

## Test plan
- [x] `py_compile` passes on all 3 files
- [x] Personality list with long descriptions displays truncated
- [x] Cron job name truncated to 50 chars