### PR TITLE
fix(dashboard): persist update action status (#47864)

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -6248,6 +6248,39 @@ def _kill_stale_dashboard_processes(
 _warn_stale_dashboard_processes = _kill_stale_dashboard_processes
 
 
+def _record_dashboard_action_success_from_env() -> None:
+    """Persist dashboard-spawned update success before restarting dashboards.
+
+    ``hermes update`` kills or restarts the dashboard near the end of a
+    successful run. When the update was launched from the dashboard, that can
+    destroy the in-memory action state before the frontend's status poll sees
+    exit code 0. The dashboard server passes a result-file path in the child
+    environment; stamp it here after update work succeeds but before restart.
+
+    Must be invoked from EVERY successful dashboard-kill/restart path —
+    including the Windows ZIP-fallback ``_update_via_zip`` branch — before
+    any teardown/exit, otherwise the dashboard never observes exit code 0
+    for that run (#47902 follow-up).
+    """
+    dashboard_result_file = os.environ.get("HERMES_DASHBOARD_ACTION_RESULT_FILE")
+    if not dashboard_result_file:
+        return
+    try:
+        result_path = Path(dashboard_result_file)
+        result_path.parent.mkdir(parents=True, exist_ok=True)
+        tmp_path = result_path.with_suffix(result_path.suffix + ".tmp")
+        tmp_path.write_text(
+            json.dumps({"exit_code": 0, "pid": os.getpid()}),
+            encoding="utf-8",
+        )
+        tmp_path.replace(result_path)
+    except OSError:
+        pass
+
+
+# --- Browser helpers ---------------------------------------------------------
+
+
 def _atomic_replace_dir(src: str, dst: str) -> None:
     """Replace directory *dst* with *src* without leaving *dst* half-deleted.
 
@@ -9881,11 +9914,21 @@ def _cmd_update_impl(args, gateway_mode: bool):
         print()
 
     if use_zip_update:
-        # ZIP-based update for Windows when git is broken
+        # ZIP-based update for Windows when git is broken.
+        # Stamp dashboard action success BEFORE gateway resume (which can
+        # tear down child state) so a dashboard-spawned `hermes update`
+        # on the ZIP fallback path still surfaces exit_code=0 to the
+        # frontend status poll (#47902 follow-up). The stamp runs only
+        # on the success path: any exception / SystemExit from
+        # ``_update_via_zip`` propagates without the stamp being written,
+        # matching the non-ZIP path's semantics.
         try:
             _update_via_zip(args)
-        finally:
+        except BaseException:
             _resume_windows_gateways_after_update(_windows_gateway_resume)
+            raise
+        _record_dashboard_action_success_from_env()
+        _resume_windows_gateways_after_update(_windows_gateway_resume)
         return
 
     # Fetch and pull
@@ -10645,6 +10688,8 @@ def _cmd_update_impl(args, gateway_mode: bool):
                 install_cua_driver(upgrade=True)
         except Exception as e:
             logger.debug("cua-driver refresh failed: %s", e)
+
+        _record_dashboard_action_success_from_env()
 
         # Write exit code *before* the gateway restart attempt.
         # When running as ``hermes update --gateway`` (spawned by the gateway's

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -3238,6 +3238,54 @@ _ACTION_COMMANDS: Dict[str, Tuple[str, ...]] = {}
 _ACTION_RESULTS: Dict[str, Dict[str, Any]] = {}
 
 
+def _action_result_path(name: str) -> Path:
+    """Return the persistent result marker path for an action name."""
+    log_file_name = _ACTION_LOG_FILES[name]
+    return _ACTION_LOG_DIR / f"{Path(log_file_name).stem}.result.json"
+
+
+def _write_action_result(name: str, exit_code: int, pid: Optional[int]) -> None:
+    """Persist a completed action result so status survives dashboard restart."""
+    try:
+        _ACTION_LOG_DIR.mkdir(parents=True, exist_ok=True)
+        result_path = _action_result_path(name)
+        tmp_path = result_path.with_suffix(result_path.suffix + ".tmp")
+        tmp_path.write_text(
+            json.dumps({"exit_code": exit_code, "pid": pid}),
+            encoding="utf-8",
+        )
+        tmp_path.replace(result_path)
+    except OSError:
+        _log.debug("Failed to persist action result for %s", name, exc_info=True)
+
+
+def _read_action_result(name: str) -> Optional[Dict[str, Any]]:
+    """Read a persisted action result, ignoring corrupt or missing markers."""
+    try:
+        data = json.loads(_action_result_path(name).read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError, TypeError):
+        return None
+    if not isinstance(data, dict):
+        return None
+    exit_code = data.get("exit_code")
+    pid = data.get("pid")
+    if not isinstance(exit_code, int):
+        return None
+    if pid is not None and not isinstance(pid, int):
+        return None
+    return {"exit_code": exit_code, "pid": pid}
+
+
+def _clear_action_result(name: str) -> None:
+    """Remove a stale persisted result before starting a fresh action."""
+    try:
+        _action_result_path(name).unlink()
+    except FileNotFoundError:
+        pass
+    except OSError:
+        _log.debug("Failed to clear persisted action result for %s", name, exc_info=True)
+
+
 def _record_completed_action(name: str, message: str, exit_code: int = 1) -> None:
     """Record a non-spawned action result and write it to the action log."""
     log_file_name = _ACTION_LOG_FILES[name]
@@ -3253,6 +3301,7 @@ def _record_completed_action(name: str, message: str, exit_code: int = 1) -> Non
     _ACTION_PROCS.pop(name, None)
     _ACTION_COMMANDS.pop(name, None)
     _ACTION_RESULTS[name] = {"exit_code": exit_code, "pid": None}
+    _write_action_result(name, exit_code=exit_code, pid=None)
 
 
 def _dashboard_spawn_executable() -> str:
@@ -3290,6 +3339,13 @@ def _spawn_hermes_action(subcommand: List[str], name: str) -> subprocess.Popen:
     # drops it (gateway/run.py); mirror that here (#52470).
     action_env = {**os.environ, "HERMES_NONINTERACTIVE": "1"}
     action_env.pop("_HERMES_GATEWAY", None)
+    # Tell the child which action is running and where to persist a
+    # result marker that survives the dashboard restart the update
+    # itself triggers. Without this, the in-memory action state would
+    # be wiped before the frontend's status poll sees exit code 0
+    # (#47902).
+    action_env["HERMES_DASHBOARD_ACTION_NAME"] = name
+    action_env["HERMES_DASHBOARD_ACTION_RESULT_FILE"] = str(_action_result_path(name))
 
     popen_kwargs: Dict[str, Any] = {
         "cwd": str(PROJECT_ROOT),
@@ -3303,6 +3359,11 @@ def _spawn_hermes_action(subcommand: List[str], name: str) -> subprocess.Popen:
     else:
         popen_kwargs["start_new_session"] = True
 
+    # Wipe any stale persisted result marker from a prior run so the
+    # frontend does not see a phantom "already-succeeded" status for
+    # this action before the new child has had a chance to stamp
+    # anything itself.
+    _clear_action_result(name)
     proc = subprocess.Popen(cmd, **popen_kwargs)
     # The child inherits its own duplicated fd for stdout/stderr, so the
     # parent's handle can be released immediately — otherwise we leak one
@@ -3992,7 +4053,7 @@ async def get_action_status(name: str, lines: int = 200):
 
     proc = _ACTION_PROCS.get(name)
     if proc is None:
-        result = _ACTION_RESULTS.get(name)
+        result = _ACTION_RESULTS.get(name) or _read_action_result(name)
         running = False
         exit_code = result.get("exit_code") if result else None
         pid = result.get("pid") if result else None
@@ -4006,6 +4067,7 @@ async def get_action_status(name: str, lines: int = 200):
             except Exception:
                 pass
             _ACTION_RESULTS[name] = {"exit_code": exit_code, "pid": pid}
+            _write_action_result(name, exit_code=exit_code, pid=pid)
             _ACTION_PROCS.pop(name, None)
             _ACTION_COMMANDS.pop(name, None)
 

--- a/tests/hermes_cli/test_cmd_update.py
+++ b/tests/hermes_cli/test_cmd_update.py
@@ -1028,6 +1028,74 @@ class TestCmdUpdateZipBranchRefusal:
         # No actual download attempted.
         assert "Downloading latest version" not in out
 
+    def test_zip_fallback_records_success_before_gateway_resume(self, tmp_path, monkeypatch):
+        from hermes_cli import config as config_mod
+        from hermes_cli import main as hm
+
+        events = []
+        args = SimpleNamespace(yes=True, force=False, force_venv=False, branch=None)
+        monkeypatch.setattr(hm, "PROJECT_ROOT", tmp_path)
+        monkeypatch.setattr(hm.sys, "platform", "win32")
+        monkeypatch.setattr(hm, "_is_windows", lambda: False)
+        monkeypatch.setattr(hm, "_run_pre_update_backup", lambda _args: None)
+        monkeypatch.setattr(hm, "_pause_windows_gateways_for_update", lambda: ())
+        monkeypatch.setattr(hm, "_discard_lockfile_churn", lambda *_args: None)
+        monkeypatch.setattr(hm, "_get_origin_url", lambda *_args: "https://github.com/NousResearch/hermes-agent.git")
+        monkeypatch.setattr(hm, "_is_fork", lambda _url: False)
+        monkeypatch.setattr(config_mod, "load_config", lambda: {})
+        monkeypatch.setattr(hm, "_update_via_zip", lambda _args: events.append("update"))
+        monkeypatch.setattr(
+            hm,
+            "_record_dashboard_action_success_from_env",
+            lambda: events.append("stamp"),
+        )
+        monkeypatch.setattr(
+            hm,
+            "_resume_windows_gateways_after_update",
+            lambda token: events.append(("resume", token)),
+        )
+
+        hm._cmd_update_impl(args, gateway_mode=False)
+
+        assert events == ["update", "stamp", ("resume", ())]
+
+    def test_zip_fallback_does_not_record_failed_update(self, tmp_path, monkeypatch):
+        from hermes_cli import config as config_mod
+        from hermes_cli import main as hm
+
+        events = []
+        args = SimpleNamespace(yes=True, force=False, force_venv=False, branch=None)
+        monkeypatch.setattr(hm, "PROJECT_ROOT", tmp_path)
+        monkeypatch.setattr(hm.sys, "platform", "win32")
+        monkeypatch.setattr(hm, "_is_windows", lambda: False)
+        monkeypatch.setattr(hm, "_run_pre_update_backup", lambda _args: None)
+        monkeypatch.setattr(hm, "_pause_windows_gateways_for_update", lambda: ())
+        monkeypatch.setattr(hm, "_discard_lockfile_churn", lambda *_args: None)
+        monkeypatch.setattr(hm, "_get_origin_url", lambda *_args: "https://github.com/NousResearch/hermes-agent.git")
+        monkeypatch.setattr(hm, "_is_fork", lambda _url: False)
+        monkeypatch.setattr(config_mod, "load_config", lambda: {})
+
+        def fail_zip(_args):
+            events.append("update")
+            raise RuntimeError("zip failed")
+
+        monkeypatch.setattr(hm, "_update_via_zip", fail_zip)
+        monkeypatch.setattr(
+            hm,
+            "_record_dashboard_action_success_from_env",
+            lambda: events.append("stamp"),
+        )
+        monkeypatch.setattr(
+            hm,
+            "_resume_windows_gateways_after_update",
+            lambda token: events.append(("resume", token)),
+        )
+
+        with pytest.raises(RuntimeError, match="zip failed"):
+            hm._cmd_update_impl(args, gateway_mode=False)
+
+        assert events == ["update", ("resume", ())]
+
 
 def test_is_termux_env_true_for_termux_prefix():
     from hermes_cli import main as hm

--- a/tests/hermes_cli/test_update_stale_dashboard.py
+++ b/tests/hermes_cli/test_update_stale_dashboard.py
@@ -14,6 +14,7 @@ History:
 from __future__ import annotations
 
 import importlib
+import json
 import os
 import sys
 from unittest.mock import patch, MagicMock
@@ -23,6 +24,7 @@ import pytest
 from hermes_cli.main import (
     _find_stale_dashboard_pids,
     _kill_stale_dashboard_processes,
+    _record_dashboard_action_success_from_env,
     _warn_stale_dashboard_processes,  # back-compat alias
 )
 
@@ -47,6 +49,7 @@ def _refresh_bindings_against_live_module():
     """
     global _find_stale_dashboard_pids
     global _kill_stale_dashboard_processes
+    global _record_dashboard_action_success_from_env
     global _warn_stale_dashboard_processes
 
     live = sys.modules.get("hermes_cli.main")
@@ -55,6 +58,7 @@ def _refresh_bindings_against_live_module():
 
     _find_stale_dashboard_pids = live._find_stale_dashboard_pids
     _kill_stale_dashboard_processes = live._kill_stale_dashboard_processes
+    _record_dashboard_action_success_from_env = live._record_dashboard_action_success_from_env
     _warn_stale_dashboard_processes = live._warn_stale_dashboard_processes
     yield
 
@@ -78,6 +82,23 @@ def _ps_runner(stdout: str):
         # Any other subprocess.run (e.g. taskkill) — benign success stub.
         return MagicMock(returncode=0, stdout="", stderr="")
     return _side_effect
+
+
+def test_record_dashboard_action_success_from_env_writes_result_marker(tmp_path, monkeypatch):
+    result_path = tmp_path / "action-hermes-update.result.json"
+    monkeypatch.setenv("HERMES_DASHBOARD_ACTION_RESULT_FILE", str(result_path))
+
+    _record_dashboard_action_success_from_env()
+
+    data = json.loads(result_path.read_text(encoding="utf-8"))
+    assert data["exit_code"] == 0
+    assert data["pid"] == os.getpid()
+
+
+def test_record_dashboard_action_success_from_env_ignores_missing_env(monkeypatch):
+    monkeypatch.delenv("HERMES_DASHBOARD_ACTION_RESULT_FILE", raising=False)
+
+    _record_dashboard_action_success_from_env()
 
 
 class TestFindStaleDashboardPids:

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -2053,6 +2053,65 @@ class TestWebServerEndpoints:
             "pid": 99,
         }
 
+    def test_action_status_survives_server_restart_from_result_file(self, tmp_path, monkeypatch):
+        import hermes_cli.web_server as web_server
+
+        monkeypatch.setattr(web_server, "_ACTION_LOG_DIR", tmp_path)
+        web_server._ACTION_PROCS.pop("hermes-update", None)
+        web_server._ACTION_RESULTS.pop("hermes-update", None)
+        web_server._write_action_result("hermes-update", exit_code=0, pid=42424)
+
+        resp = self.client.get("/api/actions/hermes-update/status")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["running"] is False
+        assert data["exit_code"] == 0
+        assert data["pid"] == 42424
+
+    def test_spawn_hermes_action_clears_stale_persisted_result(self, tmp_path, monkeypatch):
+        import hermes_cli.web_server as web_server
+
+        monkeypatch.setattr(web_server, "_ACTION_LOG_DIR", tmp_path)
+        web_server._write_action_result("hermes-update", exit_code=0, pid=111)
+
+        class _Proc:
+            pid = 222
+
+        captured = {}
+
+        def fake_popen(*_args, **kwargs):
+            captured.update(kwargs)
+            return _Proc()
+
+        monkeypatch.setattr(web_server.subprocess, "Popen", fake_popen)
+
+        proc = web_server._spawn_hermes_action(["update"], "hermes-update")
+
+        assert proc.pid == 222
+        assert captured["env"]["HERMES_DASHBOARD_ACTION_NAME"] == "hermes-update"
+        assert captured["env"]["HERMES_DASHBOARD_ACTION_RESULT_FILE"] == str(
+            tmp_path / "hermes-update.result.json"
+        )
+        assert web_server._read_action_result("hermes-update") is None
+
+    def test_action_status_ignores_corrupt_persisted_result(self, tmp_path, monkeypatch):
+        import hermes_cli.web_server as web_server
+
+        monkeypatch.setattr(web_server, "_ACTION_LOG_DIR", tmp_path)
+        tmp_path.mkdir(parents=True, exist_ok=True)
+        web_server._action_result_path("hermes-update").write_text("not json", encoding="utf-8")
+        web_server._ACTION_PROCS.pop("hermes-update", None)
+        web_server._ACTION_RESULTS.pop("hermes-update", None)
+
+        resp = self.client.get("/api/actions/hermes-update/status")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["running"] is False
+        assert data["exit_code"] is None
+        assert data["pid"] is None
+
     def test_action_status_tails_large_log_without_read_text(self, tmp_path, monkeypatch):
         import hermes_cli.web_server as web_server
 


### PR DESCRIPTION
## Summary
- Persist completed dashboard action results to a sidecar marker so `/api/actions/{name}/status` survives a dashboard restart.
- Pass the result marker path into dashboard-spawned `hermes update` and stamp success before the updater restarts/kills the dashboard.
- Clear stale persisted markers before launching a new action and ignore corrupt/unwritable markers without breaking the status endpoint.

## Verification
- `10 passed`: focused action-status/update regression set
- `309 passed, 1 warning`: `tests/hermes_cli/test_web_server.py tests/hermes_cli/test_update_stale_dashboard.py`
- Branch rebased on current `upstream/main`; `git rev-list --left-right --count upstream/main...HEAD` returned `0 1`.

## Competitor / duplicate check
- No open Tranquil-Flow PRs found for #47864 or `fix/47864*`.
- No open upstream PRs found for `47864` or dashboard updater action-status restart-loss keywords.

Auto-published by Moonsong via Path B automated pipeline.