### PR TITLE
Add grok-composer-2.5-fast to xAI OAuth model picker

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -275,6 +275,7 @@ DEFAULT_CONTEXT_LENGTHS = {
     # via a custom provider. Values sourced from models.dev (2026-04).
     # Keys use substring matching (longest-first), so e.g. "grok-4.20"
     # matches "grok-4.20-0309-reasoning" / "-non-reasoning" / "-multi-agent-0309".
+    "grok-composer": 200000,    # grok-composer-2.5-fast (Grok Build CLI)
     "grok-build": 256000,       # grok-build-0.1
     "grok-code-fast": 256000,   # grok-code-fast-1
     "grok-2-vision": 8192,      # grok-2-vision, -1212, -latest

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -117,6 +117,11 @@ _XAI_STATIC_FALLBACK: list[str] = [
     "grok-4.20-multi-agent-0309",
 ]
 
+# Callable via xAI OAuth but omitted from models.dev and /v1/models listings.
+_XAI_CURATED_EXTRAS: list[str] = [
+    "grok-composer-2.5-fast",
+]
+
 
 _XAI_TOP_MODEL = "grok-build-0.1"
 
@@ -126,6 +131,18 @@ def _xai_promote_top(ids: list[str]) -> list[str]:
     if _XAI_TOP_MODEL in ids:
         return [_XAI_TOP_MODEL] + [m for m in ids if m != _XAI_TOP_MODEL]
     return ids
+
+
+def _xai_merge_curated_extras(ids: list[str]) -> list[str]:
+    """Append Hermes-curated xAI models that are missing from models.dev."""
+    out = list(ids)
+    for extra in _XAI_CURATED_EXTRAS:
+        if extra in out:
+            continue
+        # Keep the headline model pinned; slot extras immediately after it.
+        insert_at = 1 if out and out[0] == _XAI_TOP_MODEL else len(out)
+        out.insert(insert_at, extra)
+    return out
 
 
 def _xai_curated_models() -> list[str]:
@@ -147,12 +164,12 @@ def _xai_curated_models() -> list[str]:
         if isinstance(models, dict) and models:
             ids = [mid for mid in models.keys() if isinstance(mid, str)]
             if ids:
-                return _xai_promote_top(sorted(ids))
+                return _xai_merge_curated_extras(_xai_promote_top(sorted(ids)))
     except Exception:
         # Any failure (missing file, malformed JSON, import error)
         # falls through to the static list.
         pass
-    return list(_XAI_STATIC_FALLBACK)
+    return _xai_merge_curated_extras(list(_XAI_STATIC_FALLBACK))
 
 
 _PROVIDER_MODELS: dict[str, list[str]] = {

--- a/tests/hermes_cli/test_xai_curated_models.py
+++ b/tests/hermes_cli/test_xai_curated_models.py
@@ -1,0 +1,14 @@
+"""Regression tests for xAI curated model list (OAuth picker)."""
+
+from hermes_cli.models import _PROVIDER_MODELS, provider_model_ids
+
+
+def test_xai_oauth_includes_grok_composer_2_5_fast():
+    models = provider_model_ids("xai-oauth")
+    assert "grok-composer-2.5-fast" in models
+
+
+def test_grok_composer_slots_after_grok_build():
+    models = _PROVIDER_MODELS["xai-oauth"]
+    assert models[0] == "grok-build-0.1"
+    assert models[1] == "grok-composer-2.5-fast"


### PR DESCRIPTION
## What

Adds `grok-composer-2.5-fast` to the xAI Grok OAuth model catalog shown in `hermes model`.

## Why

The model works over xAI OAuth (`api.x.ai/v1`) but is omitted from both the models.dev cache and xAI's `/v1/models` listing, so Hermes never surfaced it in the picker. Users had to type it manually via "Enter custom model name" even though it is callable with the same OAuth credentials as `grok-build-0.1`.

## Changes

- `hermes_cli/models.py`: introduce `_XAI_CURATED_EXTRAS` and merge logic so unlisted-but-callable models are injected into the xAI OAuth picker (slotted immediately after `grok-build-0.1`).
- `agent/model_metadata.py`: add a 200k context fallback for `grok-composer-*`.
- `tests/hermes_cli/test_xai_curated_models.py`: regression tests for list membership and ordering.

## How to test

1. Sign in with xAI OAuth: `hermes auth add xai-oauth`
2. Run `hermes model` → xAI Grok → xAI Grok OAuth (SuperGrok / Premium+)
3. Confirm `grok-composer-2.5-fast` appears directly under `grok-build-0.1`
4. Select it and run a one-shot: `hermes -z "say hi" -m grok-composer-2.5-fast --provider xai-oauth`

```bash
scripts/run_tests.sh tests/hermes_cli/test_xai_curated_models.py
```

## Platforms tested

Linux (CachyOS)