### PR TITLE
fix(signal): send recipient as string instead of list to avoid ClassCastException

### DIFF
--- a/gateway/platforms/signal.py
+++ b/gateway/platforms/signal.py
@@ -692,10 +692,25 @@ class SignalAdapter(BasePlatformAdapter):
             })
             if isinstance(contacts, list):
                 for contact in contacts:
-                    number = contact.get("number") if isinstance(contact, dict) else None
-                    service_id = self._extract_contact_uuid(contact, chat_id)
-                    if number and service_id:
-                        self._remember_recipient_identifiers(number, service_id)
+                    if not isinstance(contact, dict):
+                        continue
+                    number = contact.get("number")
+                    uuid_val = contact.get("uuid") or contact.get("serviceId")
+                    if not uuid_val or not _is_signal_service_id(str(uuid_val)):
+                        continue
+                    # Always populate cache from every contact — the caller's
+                    # chat_id might not match any single number exactly
+                    # (format differences, missing country code, etc.)
+                    if number and _looks_like_e164_number(str(number)):
+                        self._recipient_uuid_by_number[str(number)] = str(uuid_val)
+                        # Also cache partial variants so a truncated chat_id
+                        # (e.g. missing country code) still resolves
+                        raw = str(number).lstrip("+")
+                        if len(raw) > 10:
+                            raw = raw[-10:]
+                        self._recipient_uuid_by_number[raw] = str(uuid_val)
+                        self._recipient_uuid_by_number["1" + raw] = str(uuid_val)
+                        self._recipient_uuid_by_number["+1" + raw] = str(uuid_val)
 
             return self._recipient_uuid_by_number.get(chat_id, chat_id)
 
@@ -990,7 +1005,7 @@ class SignalAdapter(BasePlatformAdapter):
         if chat_id.startswith("group:"):
             params["groupId"] = chat_id[6:]
         else:
-            params["recipient"] = [await self._resolve_recipient(chat_id)]
+            params["recipient"] = await self._resolve_recipient(chat_id)
 
         result = await self._rpc("send", params)
 
@@ -1040,7 +1055,7 @@ class SignalAdapter(BasePlatformAdapter):
         if chat_id.startswith("group:"):
             params["groupId"] = chat_id[6:]
         else:
-            params["recipient"] = [await self._resolve_recipient(chat_id)]
+            params["recipient"] = await self._resolve_recipient(chat_id)
 
         fails = self._typing_failures.get(chat_id, 0)
         result = await self._rpc(
@@ -1140,7 +1155,7 @@ class SignalAdapter(BasePlatformAdapter):
         if chat_id.startswith("group:"):
             base_params["groupId"] = chat_id[6:]
         else:
-            base_params["recipient"] = [await self._resolve_recipient(chat_id)]
+            base_params["recipient"] = await self._resolve_recipient(chat_id)
 
         att_batches = [
             attachments[i:i + SIGNAL_MAX_ATTACHMENTS_PER_MSG]
@@ -1273,7 +1288,7 @@ class SignalAdapter(BasePlatformAdapter):
         if chat_id.startswith("group:"):
             params["groupId"] = chat_id[6:]
         else:
-            params["recipient"] = [await self._resolve_recipient(chat_id)]
+            params["recipient"] = await self._resolve_recipient(chat_id)
 
         result = await self._rpc("send", params)
         if result is not None:
@@ -1312,7 +1327,7 @@ class SignalAdapter(BasePlatformAdapter):
         if chat_id.startswith("group:"):
             params["groupId"] = chat_id[6:]
         else:
-            params["recipient"] = [await self._resolve_recipient(chat_id)]
+            params["recipient"] = await self._resolve_recipient(chat_id)
 
         result = await self._rpc("send", params)
         if result is not None:
@@ -1424,7 +1439,7 @@ class SignalAdapter(BasePlatformAdapter):
         if chat_id.startswith("group:"):
             params["groupId"] = chat_id[6:]
         else:
-            params["recipient"] = [chat_id]
+            params["recipient"] = chat_id
 
         result = await self._rpc("sendReaction", params)
         if result is not None:
@@ -1450,7 +1465,7 @@ class SignalAdapter(BasePlatformAdapter):
         if chat_id.startswith("group:"):
             params["groupId"] = chat_id[6:]
         else:
-            params["recipient"] = [chat_id]
+            params["recipient"] = chat_id
 
         result = await self._rpc("sendReaction", params)
         return result is not None

--- a/tests/gateway/test_signal.py
+++ b/tests/gateway/test_signal.py
@@ -402,7 +402,7 @@ class TestSignalSendImageFile:
         assert len(captured) == 1
         assert captured[0]["method"] == "send"
         assert captured[0]["params"]["account"] == adapter.account
-        assert captured[0]["params"]["recipient"] == ["+155****4567"]
+        assert captured[0]["params"]["recipient"] == "+155****4567"
         assert captured[0]["params"]["attachments"] == [str(img_path)]
         assert captured[0]["params"]["message"] == ""  # caption=None → ""
         # Typing indicator must be stopped before sending
@@ -496,7 +496,7 @@ class TestSignalRecipientResolution:
 
         assert result.success is True
         assert captured[0]["method"] == "send"
-        assert captured[0]["params"]["recipient"] == ["68680952-6d86-45bc-85e0-1a4d186d53ee"]
+        assert captured[0]["params"]["recipient"] == "68680952-6d86-45bc-85e0-1a4d186d53ee"
 
     @pytest.mark.asyncio
     async def test_send_looks_up_uuid_via_list_contacts(self, monkeypatch):
@@ -525,7 +525,7 @@ class TestSignalRecipientResolution:
         assert result.success is True
         assert captured[0]["method"] == "listContacts"
         assert captured[1]["method"] == "send"
-        assert captured[1]["params"]["recipient"] == ["68680952-6d86-45bc-85e0-1a4d186d53ee"]
+        assert captured[1]["params"]["recipient"] == "68680952-6d86-45bc-85e0-1a4d186d53ee"
 
     @pytest.mark.asyncio
     async def test_send_falls_back_to_phone_when_no_uuid_found(self, monkeypatch):
@@ -547,7 +547,7 @@ class TestSignalRecipientResolution:
         result = await adapter.send(chat_id="+15551230000", content="hello")
 
         assert result.success is True
-        assert captured[1]["params"]["recipient"] == ["+15551230000"]
+        assert captured[1]["params"]["recipient"] == "+15551230000"
 
     @pytest.mark.asyncio
     async def test_send_typing_uses_cached_uuid(self, monkeypatch):
@@ -565,7 +565,7 @@ class TestSignalRecipientResolution:
         await adapter.send_typing("+15551230000")
 
         assert captured[0]["method"] == "sendTyping"
-        assert captured[0]["params"]["recipient"] == ["68680952-6d86-45bc-85e0-1a4d186d53ee"]
+        assert captured[0]["params"]["recipient"] == "68680952-6d86-45bc-85e0-1a4d186d53ee"
 
 
 # ---------------------------------------------------------------------------
@@ -1513,7 +1513,7 @@ class TestSignalSendMultipleImages:
 
         assert len(captured) == 1
         params = captured[0]["params"]
-        assert params["recipient"] == ["+155****4567"]
+        assert params["recipient"] == "+155****4567"
         assert params["message"] == ""
         assert len(params["attachments"]) == 5
         # raise_on_rate_limit must be opted into so the retry loop sees 429s


### PR DESCRIPTION
## Problem

signal-cli JSON-RPC API expects `recipient` parameter as a plain string (UUID or E.164 phone number), but the adapter was wrapping it in a list `[UUID]`, causing a Java `ClassCastException` on every send attempt:

```
java.util.LinkedHashMap cannot be cast to java.lang.String
```

## Root Cause

In `gateway/platforms/signal.py`, multiple methods were constructing the RPC params like:

```python
params["recipient"] = [await self._resolve_recipient(chat_id)]
```

This sends `{"recipient": ["696c26d2-..."]}` to signal-cli, which throws a ClassCastException when it tries to cast the JSON array to a String.

## Fix

Changed all 7 occurrences to pass recipient as a string:

```python
params["recipient"] = await self._resolve_recipient(chat_id)
```

Affected methods:
- `send()`
- `send_typing()`
- `send_image_file()`
- `send_voice()`
- `send_video()`
- `send_reaction()`
- `remove_reaction()`

Also improved `_resolve_recipient()` to:
- Always populate number→UUID cache from `listContacts` (not just matching contacts)
- Store partial variants (last 10 digits, with/without country code) so contacts added by username or with different number formats still resolve correctly

## Testing

- Verified with live RPC calls against signal-cli daemon — sending to UUIDs works, sending to phone numbers returns `UNREGISTERED_FAILURE` as expected
- Updated 6 test assertions in `tests/gateway/test_signal.py` to match new string format
- All 108 tests in `test_signal.py` pass
- All 5 tests in `test_signal_media.py` pass

## Related

No existing issue tracked this specific bug. The 15 open `platform/signal` issues cover other problems (approval routing, group targets, health check endpoint mismatches with REST API Docker image, etc.).