### PR TITLE
fix(agent): preserve multimodal user content through crash-resilience persist

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -1483,7 +1483,15 @@ class AIAgent:
         if 0 <= idx < len(messages):
             msg = messages[idx]
             if isinstance(msg, dict) and msg.get("role") == "user":
-                if override is not None:
+                # Text-only call paths may pass a synthetic API-facing prompt
+                # and a cleaner transcript string separately. Multimodal
+                # turns, however, keep image/audio blocks in the live
+                # messages list that is still used for the API request after
+                # early crash-resilience persistence. Do not replace those
+                # blocks with the text-only persistence override before the
+                # model call is built. The paired timestamp override still
+                # applies — it is metadata, not content.
+                if override is not None and not isinstance(msg.get("content"), list):
                     msg["content"] = override
                 if timestamp is not None:
                     msg["timestamp"] = timestamp

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -243,6 +243,7 @@ AUTHOR_MAP = {
     "32869278+dusterbloom@users.noreply.github.com": "dusterbloom",
     "189737461+basilalshukaili@users.noreply.github.com": "basilalshukaili",
     "liuhao1024@users.noreply.github.com": "liuhao1024",
+    "Rivuza@users.noreply.github.com": "Rivuza",
     "annguyenNous@users.noreply.github.com": "annguyenNous",
     "285874597+annguyenNous@users.noreply.github.com": "annguyenNous",
     "kylekahraman@users.noreply.github.com": "kylekahraman",

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -75,6 +75,33 @@ def agent():
         return a
 
 
+def test_persist_user_message_override_rewrites_text_turns(agent):
+    messages = [{"role": "user", "content": "API-only synthetic prefix\nhello"}]
+    agent._persist_user_message_idx = 0
+    agent._persist_user_message_override = "hello"
+
+    agent._apply_persist_user_message_override(messages)
+
+    assert messages == [{"role": "user", "content": "hello"}]
+
+
+def test_persist_user_message_override_preserves_multimodal_turns(agent):
+    multimodal_content = [
+        {"type": "text", "text": "What color is this?"},
+        {
+            "type": "image_url",
+            "image_url": {"url": "data:image/png;base64,AAAA"},
+        },
+    ]
+    messages = [{"role": "user", "content": multimodal_content}]
+    agent._persist_user_message_idx = 0
+    agent._persist_user_message_override = "What color is this? [Image attachment]"
+
+    agent._apply_persist_user_message_override(messages)
+
+    assert messages == [{"role": "user", "content": multimodal_content}]
+
+
 @pytest.fixture()
 def agent_with_memory_tool():
     """Agent whose valid_tool_names includes 'memory'."""


### PR DESCRIPTION
## Summary
Images attached to a user turn now survive to the model call instead of being silently dropped before the API request is built.

Root cause: `_apply_persist_user_message_override` unconditionally overwrote the current-turn user message `content` with the text-only persist string. `build_turn_context` runs a crash-resilience persist of the inbound turn **before the first API call**, on the same `messages` list the request is later built from — so a multimodal `[text, image_url]` user turn got clobbered to plain text, and the image was gone end-to-end. This hits every provider regardless of vision support: ACP `session/prompt` image blocks (#44242) and **Telegram native-vision image attachments** alike.

## Changes
- `run_agent.py`: skip the content override when the user message content is a multimodal list; the paired timestamp override still applies (it's metadata, not content).
- `tests/run_agent/test_run_agent.py`: regression tests for the multimodal-preserved and text-rewritten paths.
- `scripts/release.py`: AUTHOR_MAP entry for the salvaged contributor.

## Validation
| case | before | after |
|---|---|---|
| multimodal turn + text persist override | `content` → plain string, image dropped | `content` list preserved, image survives, timestamp written |
| text turn + persist override | clean string written | clean string written (unchanged) |
| multimodal + timestamp-only | n/a | list intact, timestamp written |

Targeted suite: `tests/run_agent/test_run_agent.py -k "persist_user_message or persist_session"` → 5 passed. E2E against the real method confirms all three cases.

## Credit
Salvaged from #44249 by @Rivuza (authorship preserved via rebase-merge). #44247 by @liuhao1024 submitted the same one-line fix first — both contributors credited. Adapted the guard so it doesn't regress the timestamp-metadata write that landed after both PRs were filed. Closes #44242.

## Infographic
![Multimodal persist fix](https://v3b.fal.media/files/b/0a9eab11/nMwn2lv_3EABvOu7oKDcw_4TjXNVyo.png)
