### PR TITLE
fix: strip internal message metadata before LLM calls

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -2085,6 +2085,18 @@ def sanitize_api_messages(messages: List[Dict[str, Any]]) -> List[Dict[str, Any]
             "Pre-call sanitizer: added %d stub tool result(s)",
             len(missing_results),
         )
+    # Strip internal bookkeeping keys that are not valid OpenAI message fields.
+    # The gateway stamps inbound messages with the platform event time and
+    # hermes_state re-hydrates these from state.db; strict OpenAI-compatible
+    # endpoints reject them with a non-retryable HTTP 400 (e.g. "Extra inputs are
+    # not permitted, field: 'messages[N].timestamp'").
+    _NON_API_KEYS = ("timestamp", "observed", "platform_message_id")
+    messages = [
+        {k: v for k, v in m.items() if k not in _NON_API_KEYS}
+        if isinstance(m, dict)
+        else m
+        for m in messages
+    ]
     return messages
 
 

--- a/tests/run_agent/test_agent_guardrails.py
+++ b/tests/run_agent/test_agent_guardrails.py
@@ -97,6 +97,31 @@ class TestSanitizeApiMessages:
         out = AIAgent._sanitize_api_messages(msgs)
         assert out == msgs
 
+    def test_strips_non_api_metadata_keys(self):
+        # The gateway stamps inbound messages with the platform event time and
+        # state.db restore re-hydrates timestamp/observed/platform_message_id.
+        # These are not valid OpenAI message fields; strict OpenAI-compatible
+        # endpoints reject them with a non-retryable HTTP 400.
+        msgs = [
+            {"role": "system", "content": "sys"},
+            {
+                "role": "user",
+                "content": "hi",
+                "timestamp": 1781703996.0,
+                "observed": True,
+                "platform_message_id": "abc123",
+            },
+        ]
+        out = AIAgent._sanitize_api_messages(msgs)
+        assert out[-1] == {"role": "user", "content": "hi"}
+        for key in ("timestamp", "observed", "platform_message_id"):
+            assert all(key not in m for m in out)
+
+    def test_strip_does_not_mutate_input(self):
+        user = {"role": "user", "content": "hi", "timestamp": 1.0}
+        AIAgent._sanitize_api_messages([user])
+        assert user["timestamp"] == 1.0
+
     def test_sdk_object_tool_calls(self):
         tc_obj = types.SimpleNamespace(id="c6", function=types.SimpleNamespace(
             name="terminal", arguments="{}"


### PR DESCRIPTION
The gateway stamps inbound messages with the platform event time (run_agent.py)
  and hermes_state re-hydrates timestamp/observed/platform_message_id from state.db.
  These leak into the chat-completions payload; strict OpenAI-compatible endpoints
  (e.g. OpenCode Zen) reject them with a non-retryable HTTP 400
  'Extra inputs are not permitted, field: messages[N].timestamp', breaking every
  turn. sanitize_api_messages() already normalizes messages pre-call, so strip the
  non-API bookkeeping keys there.

## What does this PR do?

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->



## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Fixes #

## Type of Change

<!-- Check the one that applies. -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- 

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. 
2. 
3. 

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [ ] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

<!-- Only fill this out if you're adding a skill. Delete this section otherwise. -->

- [ ] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [ ] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

