### PR TITLE
fix: normalize OpenCode Go pool base URLs

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -3979,6 +3979,25 @@ class AIAgent:
         runtime_key = getattr(entry, "runtime_api_key", None) or getattr(entry, "access_token", "")
         runtime_base = getattr(entry, "runtime_base_url", None) or getattr(entry, "base_url", None) or self.base_url
 
+        # OpenCode Go exposes both OpenAI-compatible and Anthropic-compatible
+        # surfaces under the same provider.  Credential pool entries persist a
+        # provider-level base_url, but the correct runtime URL depends on the
+        # active model's API mode:
+        # - chat_completions: OpenAI client appends /chat/completions, so the
+        #   base URL must include /v1.
+        # - anthropic_messages: Anthropic client appends /v1/messages, so the
+        #   base URL must NOT include /v1.
+        # Normalize on rotation so a credential used by one model family cannot
+        # poison retries for the other model family.
+        if self.provider == "opencode-go" and isinstance(runtime_base, str):
+            raw_runtime_base = runtime_base.rstrip("/")
+            if self.api_mode == "anthropic_messages" and raw_runtime_base.endswith("/v1"):
+                runtime_base = raw_runtime_base[:-3]
+            elif self.api_mode != "anthropic_messages" and not raw_runtime_base.endswith("/v1"):
+                runtime_base = raw_runtime_base + "/v1"
+            else:
+                runtime_base = raw_runtime_base
+
         if self.api_mode == "anthropic_messages":
             from agent.anthropic_adapter import build_anthropic_client, _is_oauth_token
 

--- a/tests/agent/test_credential_pool_routing.py
+++ b/tests/agent/test_credential_pool_routing.py
@@ -12,6 +12,67 @@ from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 
+class TestOpenCodeGoCredentialBaseUrlNormalization:
+    """OpenCode Go pool rotation must preserve the endpoint shape for the active API mode."""
+
+    def _make_agent(self, *, api_mode="chat_completions", base_url="https://opencode.ai/zen/go/v1"):
+        from run_agent import AIAgent
+
+        with patch.object(AIAgent, "__init__", lambda self, **kw: None):
+            agent = AIAgent()
+
+        agent.provider = "opencode-go"
+        agent.model = "glm-5.2"
+        agent.api_mode = api_mode
+        agent.base_url = base_url
+        agent.api_key = "old-key"
+        agent._client_kwargs = {}
+        agent._apply_client_headers_for_base_url = MagicMock()
+        agent._replace_primary_openai_client = MagicMock()
+        agent._anthropic_client = MagicMock()
+        agent._anthropic_api_key = "old-key"
+        agent._anthropic_base_url = base_url
+        agent._is_anthropic_oauth = False
+        return agent
+
+    def test_chat_completions_rotation_adds_v1_to_stripped_opencode_go_base_url(self):
+        """GLM/Kimi/MiMo-style OpenCode Go models must retry against /v1/chat/completions."""
+        entry = SimpleNamespace(
+            runtime_api_key="new-key",
+            access_token="new-key",
+            runtime_base_url="https://opencode.ai/zen/go",
+            base_url="https://opencode.ai/zen/go",
+        )
+        agent = self._make_agent(api_mode="chat_completions", base_url="https://opencode.ai/zen/go")
+
+        agent._swap_credential(entry)
+
+        assert agent.base_url == "https://opencode.ai/zen/go/v1"
+        assert agent._client_kwargs["base_url"] == "https://opencode.ai/zen/go/v1"
+        agent._replace_primary_openai_client.assert_called_once_with(reason="credential_rotation")
+
+    def test_anthropic_rotation_strips_v1_from_opencode_go_base_url(self):
+        """MiniMax/Claude-style OpenCode Go models must not build /v1/v1/messages."""
+        entry = SimpleNamespace(
+            runtime_api_key="new-key",
+            access_token="new-key",
+            runtime_base_url="https://opencode.ai/zen/go/v1",
+            base_url="https://opencode.ai/zen/go/v1",
+        )
+        agent = self._make_agent(api_mode="anthropic_messages", base_url="https://opencode.ai/zen/go/v1")
+        agent.model = "minimax-m2.7"
+
+        with patch("agent.anthropic_adapter.build_anthropic_client") as build_client:
+            build_client.return_value = MagicMock()
+            agent._swap_credential(entry)
+
+        assert agent.base_url == "https://opencode.ai/zen/go"
+        assert agent._anthropic_base_url == "https://opencode.ai/zen/go"
+        build_client.assert_called_once()
+        assert build_client.call_args.args[:2] == ("new-key", "https://opencode.ai/zen/go")
+
+
+
 # ---------------------------------------------------------------------------
 # 1. CLI _resolve_turn_agent_config includes credential_pool
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Normalize OpenCode Go credential-pool base URLs during credential rotation based on the active model API mode.
- Ensure OpenAI-compatible chat-completions models such as GLM/Kimi/MiMo retry against `/v1`.
- Ensure Anthropic-compatible messages models retry against the stripped provider root, avoiding `/v1/v1/messages`.
- Add regression coverage for both endpoint families.

## Why this PR is needed
OpenCode Go exposes multiple API surfaces through the same Hermes provider:

- Chat-completions models use an OpenAI-compatible client, which appends `/chat/completions`. These requests require the provider base URL to include `/v1`.
- Anthropic-style message models use the Anthropic client, which appends `/v1/messages`. These requests require the provider base URL to *not* include `/v1`.

Credential-pool entries persist a provider-level base URL. During failover, a credential that was stored with the URL shape for one model family can be reused while the active session is using the other model family. Before this change, `_swap_credential()` copied that persisted URL directly into the runtime client, so endpoint shape could become wrong after rotation.

The real failure mode this fixes:

1. A chat-completions model such as `glm-5.2` or `kimi-k2.6` is active through `opencode-go`.
2. The current credential fails due to quota/billing/rate-limit exhaustion.
3. Credential-pool rotation selects another OpenCode Go credential whose persisted base URL is the stripped Anthropic-style provider root: `https://opencode.ai/zen/go`.
4. Hermes retries with the OpenAI-compatible client against `https://opencode.ai/zen/go/chat/completions` instead of `https://opencode.ai/zen/go/v1/chat/completions`.
5. The retry fails even though the backup credential itself is valid.

This makes failover unreliable specifically for OpenCode Go because the correct base URL is not credential-global; it depends on the active model's `api_mode`.

## Implementation
`AIAgent._swap_credential()` now normalizes OpenCode Go runtime base URLs after selecting a credential and before rebuilding the client:

- `api_mode == "anthropic_messages"`: strip a trailing `/v1`.
- all other OpenCode Go modes: ensure a trailing `/v1`.

This keeps the persisted pool entry flexible while ensuring the runtime client always receives the endpoint shape expected by the active model family.

## Test Plan
- `python -m pytest tests/agent/test_credential_pool_routing.py::TestOpenCodeGoCredentialBaseUrlNormalization -q`
  - verified the new regression tests fail before the implementation and pass after it
- `python -m pytest tests/agent/test_credential_pool_routing.py tests/agent/test_credential_pool.py -q`
  - `90 passed`
- `python -m ruff check run_agent.py tests/agent/test_credential_pool_routing.py`
  - passed; ruff reported one pre-existing warning about an invalid `# noqa` directive on `run_agent.py:94`
- `python -m py_compile run_agent.py tests/agent/test_credential_pool_routing.py`
  - passed
