### PR TITLE
fix: runtime footer uses gateway-resolved model, not cached agent attribute

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -14291,6 +14291,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         else:
             _status_thread_metadata = self._thread_metadata_for_source(source, event_message_id) if _progress_thread_id else None
 
+        # Captured by run_sync after model resolution; used by the runtime
+        # footer to report the gateway-resolved model rather than the (possibly
+        # stale) cached agent's model attribute (#fix-runtime-footer-model).
+        _resolved_turn_model = None
+
         def _status_callback_sync(event_type: str, message: str) -> None:
             if not _status_adapter or not _run_still_current():
                 return
@@ -14333,7 +14338,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # read *and* reassign the outer `_run_agent` parameter without
             # triggering an UnboundLocalError on the earlier read at
             # `_resolve_turn_agent_config(message, …)`.
-            nonlocal message
+            nonlocal message, _resolved_turn_model
 
             # session_key is now set via contextvars in _set_session_env()
             # (concurrency-safe). Keep os.environ as fallback for CLI/cron.
@@ -14366,6 +14371,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     session_key=session_key,
                     user_config=user_config,
                 )
+                _resolved_turn_model = model
                 logger.debug(
                     "run_agent resolved: model=%s provider=%s session=%s",
                     model, runtime_kwargs.get("provider"), session_key or "",
@@ -15159,7 +15165,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     "last_prompt_tokens": _last_prompt_toks,
                     "input_tokens": _input_toks,
                     "output_tokens": _output_toks,
-                    "model": _resolved_model,
+                    "model": _resolved_turn_model or _resolved_model,
                     "context_length": _context_length,
                 }
             
@@ -15258,7 +15264,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 "last_prompt_tokens": _last_prompt_toks,
                 "input_tokens": _input_toks,
                 "output_tokens": _output_toks,
-                "model": _resolved_model,
+                "model": _resolved_turn_model or _resolved_model,
                 "context_length": _context_length,
                 "session_id": effective_session_id,
                 "response_previewed": result.get("response_previewed", False),


### PR DESCRIPTION
## Summary

The `display.runtime_footer` feature renders a model/context/cwd status line on gateway responses. It reads the model from `agent_result["model"]`, which comes from the cached `AIAgent.model` attribute. When the session model override is cleared (session expiry, auto-reset, gateway restart), the footer silently reverts to `config.yaml`'s `model.default` even if the user explicitly switched models via `/model`.

## Root Cause

`_resolve_session_agent_runtime` at `gateway/run.py:2955` checks `_session_model_overrides` for the session's `/model` override. This in-memory dict can be cleared in three places:

| Line | Trigger |
|------|---------|
| 5709 | Session expiry watcher |
| 8297 | Auto-reset session boundary |
| 9142 | Compression exhaustion auto-reset |

When cleared, the next turn resolves back to `config.yaml`'s `model.default`. The agent cache signature includes the model — and since the override is gone, the signature matches the cached agent (built from the same default). The stale agent is reused, and the footer shows the config default instead of the user's chosen model.

## Fix

Capture the gateway-resolved model (`_resolved_turn_model`) in the `_run_agent` closure immediately after `_resolve_session_agent_runtime` returns, and prefer it over the agent's `.model` attribute when assembling the result dict.

Both result-assembly paths (the main path and the fallback/interrupt path) are updated.

**Changes:** 9 insertions / 3 deletions in `gateway/run.py`.

## What this fixes

- Footer correctly reflects the model the gateway resolved for this turn
- If the override is cleared, the footer shows the correct fallback (config default) rather than silently showing a stale cached agent's model
- No behavioral change to agent construction or model routing

## What this doesn't fix (deferred)

The session DB fallback — `/model` already persists the chosen model to the session DB (`slash_commands.py:1334`), but `_resolve_session_agent_runtime` doesn't read from it when the in-memory override is absent. This requires bridging `session_key` → `session_id` via SessionStore, which is a larger change. Filed as follow-up.

## Test Plan

- [ ] Verify runtime footer shows correct model after `/model` switch
- [ ] Verify footer shows config default after gateway restart (no override)
- [ ] Verify footer shows correct model after session expiry and resume
BODY 2>&1
