### PR TITLE
fix(conversation): prevent stale prefix cache on cwd or runtime surfa…

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -446,6 +446,20 @@ def _stored_prompt_matches_runtime(agent, prompt: str) -> bool:
     if stored_provider and current_provider and stored_provider != current_provider:
         return False
 
+    # Detect cwd drift: if the stored prompt was built in a different working
+    # directory, reuse would silently inject a stale path into the prefix cache.
+    stored_cwd = line_value("Current working directory")
+    if stored_cwd:
+        import os as _os
+        if stored_cwd != _os.getcwd():
+            return False
+
+    # Detect runtime surface drift: desktop GUI vs non-desktop.
+    has_desktop_marker = "Runtime surface: you're running inside the Hermes desktop GUI app." in prompt
+    in_desktop = (os.environ.get("HERMES_DESKTOP", "").strip().lower() in {"1", "true", "yes"})
+    if has_desktop_marker != in_desktop:
+        return False
+
     return True
 
 

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -38,6 +38,7 @@ from agent.turn_context import (
     reanchor_current_turn_user_idx,
 )
 from agent.turn_retry_state import TurnRetryState
+from agent.runtime_cwd import resolve_agent_cwd
 from agent.message_sanitization import (
     close_interrupted_tool_sequence,
     _repair_tool_call_arguments,
@@ -448,16 +449,20 @@ def _stored_prompt_matches_runtime(agent, prompt: str) -> bool:
 
     # Detect cwd drift: if the stored prompt was built in a different working
     # directory, reuse would silently inject a stale path into the prefix cache.
+    # Compare against resolve_agent_cwd() — the SAME resolver used to build the
+    # prompt — so gateway/TUI sessions that set TERMINAL_CWD are not falsely
+    # rejected (they would always differ from the launch dir's os.getcwd()).
     stored_cwd = line_value("Current working directory")
     if stored_cwd:
-        import os as _os
-        if stored_cwd != _os.getcwd():
+        if stored_cwd != str(resolve_agent_cwd()):
             return False
 
-    # Detect runtime surface drift: desktop GUI vs non-desktop.
-    has_desktop_marker = "Runtime surface: you're running inside the Hermes desktop GUI app." in prompt
-    in_desktop = (os.environ.get("HERMES_DESKTOP", "").strip().lower() in {"1", "true", "yes"})
-    if has_desktop_marker != in_desktop:
+    # Detect runtime-surface drift: the stored prompt records which platform it
+    # was built for (e.g. "desktop" vs "cli"). Reusing a desktop-built prompt on
+    # a terminal session (or vice versa) would inject the wrong runtime hints.
+    stored_platform = line_value("Platform")
+    current_platform = str(getattr(agent, "platform", "") or "").strip()
+    if stored_platform and current_platform and stored_platform != current_platform:
         return False
 
     return True

--- a/agent/system_prompt.py
+++ b/agent/system_prompt.py
@@ -515,6 +515,8 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
         timestamp_line += f"\nModel: {agent.model}"
     if agent.provider:
         timestamp_line += f"\nProvider: {agent.provider}"
+    if agent.platform:
+        timestamp_line += f"\nPlatform: {agent.platform}"
     volatile_parts.append(timestamp_line)
 
     return {

--- a/tests/run_agent/test_compression_persistence.py
+++ b/tests/run_agent/test_compression_persistence.py
@@ -387,6 +387,47 @@ class TestStoredPromptCwdDrift:
             "Expected True when stored platform matches the current platform"
         )
 
+    def test_stored_prompt_fresh_when_terminal_cwd_matches(self):
+        """Gateway: stored cwd equals TERMINAL_CWD -> reuse via resolve_agent_cwd.
+
+        The gateway sets TERMINAL_CWD to the configured project dir, which differs
+        from the process launch dir (os.getcwd()). Reuse must key off
+        resolve_agent_cwd(), not os.getcwd(), or every gateway turn would falsely
+        rebuild the system prompt.
+        """
+        from unittest.mock import patch
+        from agent.conversation_loop import _stored_prompt_matches_runtime
+
+        agent = self._make_agent()
+        with tempfile.TemporaryDirectory() as term_cwd:
+            stored_prompt = (
+                f"Current working directory: {term_cwd}\n"
+                "Model: test/model\n"
+                "Provider: openrouter\n"
+            )
+            with patch.dict(os.environ, {"TERMINAL_CWD": term_cwd}):
+                assert _stored_prompt_matches_runtime(agent, stored_prompt) is True, (
+                    "Expected True when stored cwd equals TERMINAL_CWD "
+                    "(gateway launch dir differs from configured cwd)"
+                )
+
+    def test_stored_prompt_stale_when_terminal_cwd_differs(self):
+        """Gateway: stored cwd differs from TERMINAL_CWD -> rebuild."""
+        from unittest.mock import patch
+        from agent.conversation_loop import _stored_prompt_matches_runtime
+
+        agent = self._make_agent()
+        with tempfile.TemporaryDirectory() as term_cwd, tempfile.TemporaryDirectory() as other_cwd:
+            stored_prompt = (
+                f"Current working directory: {other_cwd}\n"
+                "Model: test/model\n"
+                "Provider: openrouter\n"
+            )
+            with patch.dict(os.environ, {"TERMINAL_CWD": term_cwd}):
+                assert _stored_prompt_matches_runtime(agent, stored_prompt) is False, (
+                    "Expected False when stored cwd differs from TERMINAL_CWD"
+                )
+
     def test_built_prompt_contains_platform_line(self):
         """The built system prompt must carry a Platform: line so drift detection works."""
         import tempfile

--- a/tests/run_agent/test_compression_persistence.py
+++ b/tests/run_agent/test_compression_persistence.py
@@ -357,19 +357,61 @@ class TestStoredPromptCwdDrift:
             )
 
     def test_stored_prompt_stale_when_runtime_surface_differs(self):
-        """Desktop GUI marker in stored prompt must not be reused when running in terminal."""
-        from unittest.mock import patch
+        """A stored prompt built for a different platform must not be reused."""
         from agent.conversation_loop import _stored_prompt_matches_runtime
 
-        agent = self._make_agent()
         stored_prompt = (
-            "Runtime surface: you're running inside the Hermes desktop GUI app.\n"
+            "Platform: desktop\n"
             "Model: test/model\n"
             "Provider: openrouter\n"
         )
+        agent = self._make_agent()
+        agent.platform = "cli"
+        assert _stored_prompt_matches_runtime(agent, stored_prompt) is False, (
+            "Expected False when stored prompt is for 'desktop' but the "
+            "current session runs on 'cli'"
+        )
 
-        # Current runtime is terminal/CLI: no desktop marker.
-        with patch.dict(os.environ, {"HERMES_DESKTOP": ""}, clear=False):
-            assert _stored_prompt_matches_runtime(agent, stored_prompt) is False, (
-                "Expected False when stored prompt claims desktop but HERMES_DESKTOP is unset"
+    def test_stored_prompt_fresh_when_platform_matches(self):
+        """Matching platform allows prompt reuse."""
+        from agent.conversation_loop import _stored_prompt_matches_runtime
+
+        agent = self._make_agent()
+        agent.platform = "desktop"
+        stored_prompt = (
+            "Platform: desktop\n"
+            "Model: test/model\n"
+            "Provider: openrouter\n"
+        )
+        assert _stored_prompt_matches_runtime(agent, stored_prompt) is True, (
+            "Expected True when stored platform matches the current platform"
+        )
+
+    def test_built_prompt_contains_platform_line(self):
+        """The built system prompt must carry a Platform: line so drift detection works."""
+        import tempfile
+        from pathlib import Path
+        from unittest.mock import patch
+        from hermes_state import SessionDB
+        from run_agent import AIAgent
+        from agent.system_prompt import build_system_prompt_parts
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db = SessionDB(db_path=Path(tmpdir) / "test.db")
+            with patch.dict(os.environ, {"OPENROUTER_API_KEY": "test-key"}):
+                agent = AIAgent(
+                    api_key="test-key",
+                    base_url="https://openrouter.ai/api/v1",
+                    model="test/model",
+                    provider="openrouter",
+                    quiet_mode=True,
+                    session_db=db,
+                    session_id="platform-test",
+                    skip_context_files=True,
+                    skip_memory=True,
+                )
+            agent.platform = "cli"
+            parts = build_system_prompt_parts(agent)
+            assert "Platform: cli" in parts["volatile"], (
+                "Built prompt missing 'Platform: cli' — drift detection cannot read it"
             )

--- a/tests/run_agent/test_compression_persistence.py
+++ b/tests/run_agent/test_compression_persistence.py
@@ -307,3 +307,51 @@ class TestGatewayHistoryOffsetAfterSplit:
         assert len(new_messages) == 0, (
             "Expected 0 messages with stale offset=200 (demonstrates the bug)"
         )
+
+
+class TestStoredPromptCwdDrift:
+    """Verify that stored system prompts are rejected when cwd changed."""
+
+    def _make_agent(self, model="test/model", provider="openrouter"):
+        class _Agent:
+            pass
+
+        agent = _Agent()
+        agent.model = model
+        agent.provider = provider
+        return agent
+
+    def test_stored_prompt_stale_when_cwd_differs(self):
+        """Different cwd should force a prompt rebuild."""
+        from unittest.mock import patch
+        from agent.conversation_loop import _stored_prompt_matches_runtime
+
+        agent = self._make_agent()
+        stored_prompt = (
+            "Current working directory: /project/old\n"
+            "Model: test/model\n"
+            "Provider: openrouter\n"
+        )
+
+        with patch("os.getcwd", return_value="/project/new"):
+            assert _stored_prompt_matches_runtime(agent, stored_prompt) is False, (
+                "Expected False when stored cwd differs from current cwd"
+            )
+
+    def test_stored_prompt_fresh_when_cwd_matches(self):
+        """Matching cwd should allow prompt reuse."""
+        from unittest.mock import patch
+        from agent.conversation_loop import _stored_prompt_matches_runtime
+
+        agent = self._make_agent()
+        current_cwd = "/project/current"
+        stored_prompt = (
+            f"Current working directory: {current_cwd}\n"
+            "Model: test/model\n"
+            "Provider: openrouter\n"
+        )
+
+        with patch("os.getcwd", return_value=current_cwd):
+            assert _stored_prompt_matches_runtime(agent, stored_prompt) is True, (
+                "Expected True when stored cwd matches current cwd"
+            )

--- a/tests/run_agent/test_compression_persistence.py
+++ b/tests/run_agent/test_compression_persistence.py
@@ -355,3 +355,21 @@ class TestStoredPromptCwdDrift:
             assert _stored_prompt_matches_runtime(agent, stored_prompt) is True, (
                 "Expected True when stored cwd matches current cwd"
             )
+
+    def test_stored_prompt_stale_when_runtime_surface_differs(self):
+        """Desktop GUI marker in stored prompt must not be reused when running in terminal."""
+        from unittest.mock import patch
+        from agent.conversation_loop import _stored_prompt_matches_runtime
+
+        agent = self._make_agent()
+        stored_prompt = (
+            "Runtime surface: you're running inside the Hermes desktop GUI app.\n"
+            "Model: test/model\n"
+            "Provider: openrouter\n"
+        )
+
+        # Current runtime is terminal/CLI: no desktop marker.
+        with patch.dict(os.environ, {"HERMES_DESKTOP": ""}, clear=False):
+            assert _stored_prompt_matches_runtime(agent, stored_prompt) is False, (
+                "Expected False when stored prompt claims desktop but HERMES_DESKTOP is unset"
+            )


### PR DESCRIPTION
## Summary
Extends `_stored_prompt_matches_runtime()` to detect cwd and runtime
surface drift in the stored system prompt, preventing a stale prefix
cache hit when the session is resumed from a different working directory
or runtime environment.

---

## Root cause
`_stored_prompt_matches_runtime()` in `agent/conversation_loop.py`
compared only the `Model:` and `Provider:` lines from the stored system
prompt against the current runtime. If the working directory or runtime
surface (desktop GUI vs terminal) had changed since the prompt was
built, the function still returned `True` and the stale prompt was
reused as a valid prefix cache entry.

On the gateway path this caused a silent correctness issue: after a
compression chain where the tip session was built in a different
directory or environment, `/resume` would load the tip's system prompt
and treat it as cache-valid even though it contained a stale
`Current working directory:` path or an incorrect runtime surface.
The prefix cache stayed warm but the downstream agent received
a wrong working directory and could construct incorrect absolute paths
or target the wrong environment. The CLI path is unaffected because
`os.getcwd()` is stable within a single hermes process; the drift only
manifests on the gateway path after compression chains.

---

## Behavioral change
Before: `_stored_prompt_matches_runtime()` returned `True` as long as
`Model:` and `Provider:` matched, regardless of cwd or runtime surface
drift. A stale prompt could silently be reused as a valid prefix cache
entry, keeping cache warm but injecting incorrect environment state.

After: two additional checks are performed. If the stored prompt
contains a `Current working directory:` line that differs from
`resolve_agent_cwd()`, the function returns `False` and triggers a
rebuild. If the stored `Platform:` line differs from `agent.platform`,
the function also returns `False`. Both checks are skipped when the
respective marker is absent from the stored prompt, preserving backward
compatibility with legacy prompts.

---

## What changed
**`agent/conversation_loop.py`**: added cwd drift detection and runtime
surface drift detection to `_stored_prompt_matches_runtime()`. The cwd
check compares the `Current working directory:` line against
`resolve_agent_cwd()` — the same resolver used to build the prompt —
so gateway and TUI sessions that set `TERMINAL_CWD` are not falsely
rejected. The runtime surface check compares the stored `Platform:`
line against `agent.platform` instead of the removed `Runtime surface:`
marker (removed in `ac6dd598a`).

**`agent/system_prompt.py`**: added emission of `Platform: {agent.platform}`
in the volatile tier alongside `Model:` and `Provider:`, so
`_stored_prompt_matches_runtime()` has a real value to read.

**`tests/run_agent/test_compression_persistence.py`**: updated
`TestStoredPromptCwdDrift`. Added `test_stored_prompt_fresh_when_terminal_cwd_matches`
and `test_stored_prompt_stale_when_terminal_cwd_differs` covering the
gateway path where `TERMINAL_CWD` differs from the process launch dir.
Updated `test_stored_prompt_stale_when_runtime_surface_differs` and
added `test_stored_prompt_fresh_when_platform_matches` for the new
`Platform:` mechanism. Added `test_built_prompt_contains_platform_line`
using a real `AIAgent` to verify that `build_system_prompt_parts()`
emits `Platform: cli` in the volatile tier.

---

## What is NOT changed
- `_build_system_prompt` unchanged
- Session DB schema unchanged
- `Model:` and `Provider:` staleness checks unchanged
- Gateway and CLI paths where cwd is stable are unaffected: the check
  is a no-op when stored and current cwd match
- Existing compression persistence tests pass