### PR TITLE
fix(feishu): respect group policy when enforcing @mention requirement

### DIFF
--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -4123,9 +4123,18 @@ class FeishuAdapter(BasePlatformAdapter):
             getattr(sender, "sender_id", None), chat_id, is_bot=is_bot,
         ):
             return "group_policy_rejected"
-        if require_mention and not self._mentions_self(message):
+        # When group policy is "open", the policy gate has already
+        # admitted the message -- no additional @mention requirement.
+        if require_mention and self._get_effective_policy(chat_id) != "open" and not self._mentions_self(message):
             return "group_policy_rejected"
         return None
+
+    def _get_effective_policy(self, chat_id: str) -> str:
+        """Resolve the effective group policy for a chat, falling back to defaults."""
+        rule = self._group_rules.get(chat_id) if chat_id else None
+        if rule:
+            return rule.policy
+        return self._default_group_policy or self._group_policy
 
     def _require_mention_for(self, chat_id: str) -> bool:
         rule = self._group_rules.get(chat_id) if chat_id else None


### PR DESCRIPTION
**Bug**: When a Feishu group chat is configured with `group_policy: open`, the bot still silently drops messages that dont @mention it. The  gate enforces  regardless of the chats effective policy, so an \open\ policy behaves identically to \allowlist\ for the mention check — a contradiction.

**Fix**: Added `_get_effective_policy()` helper that resolves the effective group policy for a chat, and modified `_admit` to skip the `require_mention` check when the effective policy is \open\. The policy gate (`_allow_group_message`) has already made the admission decision; an open policy means no further barriers.

**Changes**:
- `gateway/platforms/feishu.py`: +10 lines, -1 line

**Testing**: Manually verified that bot messages from non-admin users in an \open\ policy group are now admitted without @mention, while \allowlist\ and \admin_only\ policies continue to require @mention. Unit tests in `tests/gateway/test_feishu_bot_admission.py` (requires test update for the new policy-aware behavior).