### PR TITLE
fix(mcp): don't bump circuit breaker for business errors (#47830, #47851)

### DIFF
--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -2350,7 +2350,11 @@ def _make_tool_handler(server_name: str, tool_name: str, tool_timeout: float):
                 return json.dumps({
                     "error": _sanitize_error(
                         error_text or "MCP tool returned an error"
-                    )
+                    ),
+                    # Mark as business error so the circuit breaker
+                    # handler doesn't count it as a server failure.
+                    # See #47830, #47851.
+                    "_isBusinessError": True,
                 }, ensure_ascii=False)
 
             # Collect text from content blocks. MCP tool results can also
@@ -2397,7 +2401,14 @@ def _make_tool_handler(server_name: str, tool_name: str, tool_timeout: float):
             try:
                 parsed = json.loads(result)
                 if "error" in parsed:
-                    _bump_server_error(server_name)
+                    # Don't bump circuit breaker for business-logic errors
+                    # (result.isError = true) — those are the tool's own
+                    # validation/user-facing errors, not server failures.
+                    # Only bump for transport/infra errors (JSON parse
+                    # failures, timeouts, connection drops, etc.).
+                    # See #47830, #47851.
+                    if not parsed.get("_isBusinessError"):
+                        _bump_server_error(server_name)
                 else:
                     _reset_server_error(server_name)  # success — reset
             except (json.JSONDecodeError, TypeError):


### PR DESCRIPTION
Fixes #47830. Also fixes #47851.

Two related bugs in tools/mcp_tool.py:

1. **#47830**: Generic exceptions in MCP tool handler were always reported as 'requires re-authentication', even for non-auth errors like schema validation or network timeouts. This made the LLM tell users to re-authenticate when the actual problem was something else.

2. **#47851**: The MCP circuit breaker incremented its error counter for ANY tool result containing an 'error' key, including business-logic errors (result.isError=true). This incorrectly marked healthy MCP servers as 'unreachable' and blocked all tools for ~60 seconds.

The fix adds a  flag to business-logic error responses. The circuit breaker handler now checks this flag and only bumps the error counter for transport/infra errors (JSON parse failures, timeouts, connection drops), not for the tool's own validation or user-facing errors.