### PR TITLE
fix(desktop): keep streaming painting in unfocused secondary chat windows

### DIFF
--- a/apps/desktop/electron/main.cjs
+++ b/apps/desktop/electron/main.cjs
@@ -28,6 +28,7 @@ const { detectRemoteDisplay, isWindowsBinaryPathInWsl, isWslEnvironment } = requ
 const { runBootstrap } = require('./bootstrap-runner.cjs')
 const {
   buildSessionWindowUrl,
+  chatWindowWebPreferences,
   createSessionWindowRegistry,
   SESSION_WINDOW_MIN_HEIGHT,
   SESSION_WINDOW_MIN_WIDTH
@@ -5106,14 +5107,7 @@ function spawnSecondaryWindow({ sessionId, watch, newSession } = {}) {
     // themes/context.tsx, so the window appears already themed.
     show: false,
     backgroundColor: getWindowBackgroundColor(),
-    webPreferences: {
-      preload: path.join(__dirname, 'preload.cjs'),
-      contextIsolation: true,
-      webviewTag: true,
-      sandbox: true,
-      nodeIntegration: false,
-      devTools: true
-    }
+    webPreferences: chatWindowWebPreferences(path.join(__dirname, 'preload.cjs'))
   })
 
   if (IS_MAC) {
@@ -5180,23 +5174,11 @@ function createWindow() {
     // material before the renderer paints the app theme. See createSessionWindow.
     show: false,
     backgroundColor: getWindowBackgroundColor(),
-    webPreferences: {
-      preload: path.join(__dirname, 'preload.cjs'),
-      contextIsolation: true,
-      webviewTag: true,
-      sandbox: true,
-      nodeIntegration: false,
-      devTools: true,
-      // Keep timers + requestAnimationFrame running at full speed when the
-      // window is blurred/occluded. The chat transcript streams to the screen
-      // through a requestAnimationFrame-gated flush (useSessionStateCache),
-      // so with Chromium's default background throttling the live answer
-      // stalls whenever this window isn't focused (e.g. you switch to your
-      // editor mid-turn, or open detached devtools) and only appears once you
-      // refocus or refresh. A streaming chat app must render in the
-      // background, so opt out — matching the secondary windows above.
-      backgroundThrottling: false
-    }
+    // Shared with the secondary session windows (chatWindowWebPreferences) so
+    // both keep `backgroundThrottling: false` — the chat transcript streams via
+    // a requestAnimationFrame-gated flush that Chromium pauses for blurred
+    // windows, stalling the live answer until refocus. See session-windows.cjs.
+    webPreferences: chatWindowWebPreferences(path.join(__dirname, 'preload.cjs'))
   })
 
   if (IS_MAC) {

--- a/apps/desktop/electron/session-windows.cjs
+++ b/apps/desktop/electron/session-windows.cjs
@@ -10,6 +10,29 @@ const { pathToFileURL } = require('node:url')
 const SESSION_WINDOW_MIN_WIDTH = 420
 const SESSION_WINDOW_MIN_HEIGHT = 620
 
+// Shared webPreferences for every window that renders the chat transcript — the
+// primary window AND the secondary session windows. Keeping it in one place is
+// the whole point: the two BrowserWindow definitions in main.cjs used to be
+// hand-copied, and the secondary windows silently lost `backgroundThrottling:
+// false`, so a streamed answer stalled until the window regained focus.
+//
+// `backgroundThrottling: false` is load-bearing: the transcript streams to the
+// screen through a requestAnimationFrame-gated flush, which Chromium pauses for
+// blurred/occluded windows. A streaming chat app must keep painting in the
+// background, so every chat window opts out. The preload path is injected
+// because it depends on the Electron entry's __dirname.
+function chatWindowWebPreferences(preloadPath) {
+  return {
+    preload: preloadPath,
+    contextIsolation: true,
+    webviewTag: true,
+    sandbox: true,
+    nodeIntegration: false,
+    devTools: true,
+    backgroundThrottling: false
+  }
+}
+
 // Build the renderer URL for a secondary window. The renderer uses a
 // HashRouter, so the session route lives after the '#'. The `?win=secondary`
 // flag MUST sit in the query string BEFORE the '#': anything after the '#' is
@@ -94,6 +117,7 @@ function createSessionWindowRegistry() {
 
 module.exports = {
   buildSessionWindowUrl,
+  chatWindowWebPreferences,
   createSessionWindowRegistry,
   SESSION_WINDOW_MIN_HEIGHT,
   SESSION_WINDOW_MIN_WIDTH

--- a/apps/desktop/electron/session-windows.test.cjs
+++ b/apps/desktop/electron/session-windows.test.cjs
@@ -1,7 +1,11 @@
 const assert = require('node:assert/strict')
 const test = require('node:test')
 
-const { buildSessionWindowUrl, createSessionWindowRegistry } = require('./session-windows.cjs')
+const {
+  buildSessionWindowUrl,
+  chatWindowWebPreferences,
+  createSessionWindowRegistry
+} = require('./session-windows.cjs')
 
 // A minimal fake BrowserWindow: tracks listeners + destroyed state and lets a
 // test fire the 'closed' event, mirroring the slice of the Electron API the
@@ -174,4 +178,22 @@ test('registry trims the session id before keying', () => {
   registry.openOrFocus('  s1  ', () => win)
 
   assert.equal(registry.has('s1'), true)
+})
+
+test('chatWindowWebPreferences disables background throttling so streaming paints while blurred', () => {
+  // Regression: secondary session windows used to omit this flag, so a streamed
+  // answer stalled until the window regained focus (Chromium pauses the
+  // requestAnimationFrame-gated transcript flush for backgrounded windows).
+  const prefs = chatWindowWebPreferences('/tmp/preload.cjs')
+
+  assert.equal(prefs.backgroundThrottling, false)
+})
+
+test('chatWindowWebPreferences passes the preload path through and keeps the hardened defaults', () => {
+  const prefs = chatWindowWebPreferences('/some/preload.cjs')
+
+  assert.equal(prefs.preload, '/some/preload.cjs')
+  assert.equal(prefs.contextIsolation, true)
+  assert.equal(prefs.sandbox, true)
+  assert.equal(prefs.nodeIntegration, false)
 })


### PR DESCRIPTION
## Problem

In Hermes Desktop, the final LLM response **doesn't stream/render while the window is unfocused** (tabbed out). Tool calls, API completion, and side-effects all run in the background, but the answer text only paints once the window regains focus. Reported on Windows 11.

Root cause: the chat transcript streams to screen through a **requestAnimationFrame-gated flush**, and Chromium pauses rAF (and clamps timers) for blurred/occluded renderers. The **primary** window already opts out via `webPreferences.backgroundThrottling: false` (plus the process-level `disable-renderer-backgrounding` / `disable-backgrounding-occluded-windows` / `disable-background-timer-throttling` switches). But the **secondary "session windows"** — the cmd-click pop-out, new-session, and subagent-watch windows in `spawnSecondaryWindow()` — hand-copied their `webPreferences` and silently dropped `backgroundThrottling: false`:

```js
// apps/desktop/electron/main.cjs — spawnSecondaryWindow (before)
webPreferences: {
  preload: path.join(__dirname, 'preload.cjs'),
  contextIsolation: true,
  webviewTag: true,
  sandbox: true,
  nodeIntegration: false,
  devTools: true
  // ← no backgroundThrottling: false
}
```

So a streamed answer in any secondary chat window stalls until the window is refocused. The primary window's own comment even claimed it was *"matching the secondary windows above"* — which was no longer true.

## Fix

Hoist the chat-window `webPreferences` into a **single shared factory** `chatWindowWebPreferences(preloadPath)` in `session-windows.cjs` (the existing Electron-free, unit-testable module) and use it for **both** the primary `createWindow()` and the secondary `spawnSecondaryWindow()`. Now both windows always agree, including `backgroundThrottling: false`, and they can never drift on this flag again.

Net diff is small and mostly de-duplication.

## Tests

`apps/desktop/electron/session-windows.test.cjs` (run with `node --test`):
- `chatWindowWebPreferences` sets `backgroundThrottling: false` (streaming paints while blurred)
- it passes the preload path through and keeps the hardened defaults (`contextIsolation`, `sandbox`, `nodeIntegration: false`)

All 14 tests pass.