### PR TITLE
fix(terminal): check system Git paths before shutil.which on Windows (#47837)

### DIFF
--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -251,8 +251,6 @@ def _find_bash() -> str:
                 return candidate
 
     found = shutil.which("bash")
-    if found:
-        return found
 
     for candidate in (
         os.path.join(os.environ.get("ProgramFiles", r"C:\Program Files"), "Git", "bin", "bash.exe"),
@@ -261,6 +259,9 @@ def _find_bash() -> str:
     ):
         if candidate and os.path.isfile(candidate):
             return candidate
+
+    if found:
+        return found
 
     raise RuntimeError(
         "Git Bash not found. Hermes Agent requires Git for Windows on Windows.\n"


### PR DESCRIPTION
Fixes #47837.

On Native Windows with both Git for Windows and WSL installed, _find_bash() resolves to WSL's bash.exe instead of Git for Windows' bash.exe. This is because shutil.which("bash") on the system PATH returns WSL's bash.exe (C:\Windows\system32\bash.exe), which is checked before the Git-for-Windows paths.

The fix reorders the lookup: system Git-for-Windows paths (Program Files\Git\bin\bash.exe, etc.) are now checked before falling back to shutil.which("bash"). This ensures Git Bash (MSYS) is preferred over WSL bash when both are available.
