### PR TITLE
fix(dashboard): add WebSocket auto-reconnect with exponential backoff

### DIFF
--- a/web/src/components/ChatSidebar.tsx
+++ b/web/src/components/ChatSidebar.tsx
@@ -19,6 +19,10 @@
  *      ties this listener to the same chat tab's PTY child — see
  *      `ChatPage.tsx` for where the id is generated.
  *
+ * Both WebSockets auto-reconnect on unexpected close (gateway restart,
+ * network drop) with exponential backoff (1s → 2s → 4s → ... → 30s cap,
+ * max 15 attempts). Auth tickets are re-minted on each attempt.
+ *
  * Best-effort throughout: WS failures show in the badge / banner, the
  * terminal pane keeps working unimpaired.
  */
@@ -50,12 +54,18 @@ interface RpcEnvelope {
 
 const TOOL_LIMIT = 20;
 
+// ── Events-feed reconnect constants ──────────────────────────────────
+const EVENTS_RECONNECT_BASE_MS = 1_000;
+const EVENTS_RECONNECT_MAX_MS = 30_000;
+const EVENTS_MAX_RECONNECT_ATTEMPTS = 15;
+
 const STATE_LABEL: Record<ConnectionState, string> = {
   idle: "idle",
   connecting: "connecting",
   open: "live",
   closed: "closed",
   error: "error",
+  reconnecting: "reconnecting",
 };
 
 const STATE_TONE: Record<
@@ -67,6 +77,7 @@ const STATE_TONE: Record<
   open: "success",
   closed: "secondary",
   error: "destructive",
+  reconnecting: "warning",
 };
 
 interface ChatSidebarProps {
@@ -110,6 +121,12 @@ export function ChatSidebar({ channel, profile, className }: ChatSidebarProps) {
     setVersion((v) => v + 1);
   }, [scopeKey]);
 
+  // ── JSON-RPC sidecar (GatewayClient → /api/ws) ───────────────────
+  //
+  // GatewayClient now auto-reconnects on unexpected close. When it
+  // reconnects, it re-mints auth and re-establishes the connection.
+  // We listen for state transitions to re-create the sidecar session
+  // after a successful reconnect.
   useEffect(() => {
     let cancelled = false;
     setSessionId(null);
@@ -133,6 +150,23 @@ export function ChatSidebar({ channel, profile, className }: ChatSidebarProps) {
       if (message) {
         setError(message);
       }
+    });
+
+    // After a successful reconnect, re-create the sidecar session.
+    // The old session was reaped by the gateway when the WS dropped.
+    const offReconnected = gw.onState((s) => {
+      if (s !== "open" || cancelled) return;
+      gw.request<{ session_id: string }>("session.create", {
+        close_on_disconnect: true,
+        ...(profile ? { profile } : {}),
+      })
+        .then((created) => {
+          if (cancelled || !created?.session_id) return;
+          setSessionId(created.session_id);
+        })
+        .catch(() => {
+          /* best-effort — banner already shows connection state */
+        });
     });
 
     // Adopt whichever session the gateway hands us. session.create on the
@@ -167,146 +201,245 @@ export function ChatSidebar({ channel, profile, className }: ChatSidebarProps) {
       offState();
       offSessionInfo();
       offError();
+      offReconnected();
       gw.close();
     };
     // `profile` is read from render; scope changes bump `version` → new `gw`.
   }, [gw]);
 
-  // Event subscriber WebSocket — receives the rebroadcast of every
-  // dispatcher emit from the PTY child's gateway.  See /api/pub +
-  // /api/events in hermes_cli/web_server.py for the broadcast hop.
+  // ── Event subscriber WebSocket (/api/events?channel=…) ───────────
   //
-  // Failures (auth/loopback rejection, server too old to expose the
-  // endpoint, transient drops) surface in the same banner as the
-  // JSON-RPC sidecar so the sidebar matches its documented best-effort
-  // UX and the user always has a reconnect affordance.
+  // Auto-reconnects on unexpected close with exponential backoff.
+  // Auth tickets are re-minted on each attempt (single-use, TTL=30s).
   useEffect(() => {
     if (!channel) {
       return;
     }
-    // In loopback mode the legacy ?token=<session> path is fine; in gated
-    // mode we have to mint a single-use ticket from the cookie. The IIFE
-    // keeps the outer effect synchronous so its ``return cleanup`` stays
-    // at the top level; the local ``ws`` is hoisted to a closed-over
-    // binding the cleanup reads via ``wsRef``.
+
     let unmounting = false;
     let ws: WebSocket | null = null;
-    void (async () => {
-      const [authName, authValue] = await buildWsAuthParam();
-      if (!authValue || unmounting) {
+    let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+    let reconnectAttempts = 0;
+    let activeWsGeneration = 0; // tracks which WS "generation" is current
+
+    function surface(msg: string) {
+      if (!unmounting) setError(msg);
+    }
+
+    function clearReconnectBanner() {
+      if (!unmounting) setError(null);
+    }
+
+    function scheduleReconnect() {
+      if (unmounting) return;
+      if (reconnectAttempts >= EVENTS_MAX_RECONNECT_ATTEMPTS) {
+        surface(
+          `events feed: gave up after ${EVENTS_MAX_RECONNECT_ATTEMPTS} reconnect attempts — reload the page`,
+        );
         return;
       }
-      const proto = window.location.protocol === "https:" ? "wss:" : "ws:";
-      const qs = new URLSearchParams({ [authName]: authValue, channel });
-      ws = new WebSocket(
-        `${proto}//${window.location.host}${HERMES_BASE_PATH}/api/events?${qs.toString()}`,
+
+      const delay = Math.min(
+        EVENTS_RECONNECT_BASE_MS * 2 ** reconnectAttempts,
+        EVENTS_RECONNECT_MAX_MS,
+      );
+      reconnectAttempts++;
+
+      console.log(
+        `[events] reconnecting in ${delay}ms (attempt ${reconnectAttempts}/${EVENTS_MAX_RECONNECT_ATTEMPTS})`,
       );
 
-      // `unmounting` suppresses the banner during cleanup — `ws.close()`
-      // from the effect's return fires a close event with code 1005 that
-      // would otherwise look like an unexpected drop.
-      const DISCONNECTED = "events feed disconnected — tool calls may not appear";
-      const surface = (msg: string) => !unmounting && setError(msg);
+      reconnectTimer = setTimeout(() => {
+        reconnectTimer = null;
+        connectEvents();
+      }, delay);
+    }
 
-      ws.addEventListener("error", () => surface(DISCONNECTED));
+    async function connectEvents() {
+      if (unmounting) return;
 
-      ws.addEventListener("close", (ev) => {
-        if (ev.code === 4401 || ev.code === 4403) {
-          surface(`events feed rejected (${ev.code}) — reload the page`);
-        } else if (ev.code !== 1000) {
-          surface(DISCONNECTED);
+      const generation = ++activeWsGeneration;
+
+      // Tear down old socket
+      if (ws) {
+        const old = ws;
+        ws = null;
+        try {
+          old.close();
+        } catch {
+          /* ignore */
         }
-      });
-
-      ws.addEventListener("message", (ev) => {
-      let frame: RpcEnvelope;
+      }
 
       try {
-        frame = JSON.parse(ev.data);
-      } catch {
-        return;
-      }
+        const [authName, authValue] = await buildWsAuthParam();
+        if (!authValue || unmounting) return;
 
-      if (frame.method !== "event" || !frame.params) {
-        return;
-      }
+        // Stale: a newer connectEvents call has started
+        if (generation !== activeWsGeneration) return;
 
-      const { type, payload } = frame.params;
-
-      if (type === "tool.start") {
-        const p = payload as
-          | { tool_id?: string; name?: string; context?: string }
-          | undefined;
-        const toolId = p?.tool_id;
-
-        if (!toolId) {
-          return;
-        }
-
-        setTools((prev) =>
-          [
-            ...prev,
-            {
-              kind: "tool" as const,
-              id: `tool-${toolId}-${prev.length}`,
-              tool_id: toolId,
-              name: p?.name ?? "tool",
-              context: p?.context,
-              status: "running" as const,
-              startedAt: Date.now(),
-            },
-          ].slice(-TOOL_LIMIT),
+        const proto =
+          window.location.protocol === "https:" ? "wss:" : "ws:";
+        const qs = new URLSearchParams({ [authName]: authValue, channel });
+        const socket = new WebSocket(
+          `${proto}//${window.location.host}${HERMES_BASE_PATH}/api/events?${qs.toString()}`,
         );
-      } else if (type === "tool.progress") {
-        const p = payload as
-          | { name?: string; preview?: string }
-          | undefined;
+        ws = socket;
 
-        if (!p?.name || !p.preview) {
-          return;
-        }
+        socket.addEventListener("error", () => {
+          // Don't surface banner immediately — the close event follows
+          // and handles reconnect logic there.
+        });
 
-        setTools((prev) =>
-          prev.map((t) =>
-            t.status === "running" && t.name === p.name
-              ? { ...t, preview: p.preview }
-              : t,
-          ),
-        );
-      } else if (type === "tool.complete") {
-        const p = payload as
-          | {
-              tool_id?: string;
-              summary?: string;
-              error?: string;
-              inline_diff?: string;
+        socket.addEventListener("close", (ev) => {
+          // Stale socket from a superseded generation — ignore
+          if (socket !== ws) return;
+
+          if (ev.code === 4401 || ev.code === 4403) {
+            // Auth rejection — don't retry, user must reload
+            surface(
+              `events feed rejected (${ev.code}) — reload the page`,
+            );
+            return;
+          }
+
+          if (ev.code === 1000) {
+            // Clean close (unmount or explicit close) — no reconnect
+            return;
+          }
+
+          // Unexpected close — auto-reconnect
+          console.log(
+            `[events] WebSocket closed (code=${ev.code}), scheduling reconnect`,
+          );
+          scheduleReconnect();
+        });
+
+        socket.addEventListener("message", (ev) => {
+          let frame: RpcEnvelope;
+
+          try {
+            frame = JSON.parse(ev.data);
+          } catch {
+            return;
+          }
+
+          if (frame.method !== "event" || !frame.params) {
+            return;
+          }
+
+          const { type, payload } = frame.params;
+
+          if (type === "tool.start") {
+            const p = payload as
+              | { tool_id?: string; name?: string; context?: string }
+              | undefined;
+            const toolId = p?.tool_id;
+
+            if (!toolId) {
+              return;
             }
-          | undefined;
 
-        if (!p?.tool_id) {
-          return;
-        }
+            setTools((prev) =>
+              [
+                ...prev,
+                {
+                  kind: "tool" as const,
+                  id: `tool-${toolId}-${prev.length}`,
+                  tool_id: toolId,
+                  name: p?.name ?? "tool",
+                  context: p?.context,
+                  status: "running" as const,
+                  startedAt: Date.now(),
+                },
+              ].slice(-TOOL_LIMIT),
+            );
+          } else if (type === "tool.progress") {
+            const p = payload as
+              | { name?: string; preview?: string }
+              | undefined;
 
-        setTools((prev) =>
-          prev.map((t) =>
-            t.tool_id === p.tool_id
-              ? {
-                  ...t,
-                  status: p.error ? "error" : "done",
-                  summary: p.summary,
-                  error: p.error,
-                  inline_diff: p.inline_diff,
-                  completedAt: Date.now(),
+            if (!p?.name || !p.preview) {
+              return;
+            }
+
+            setTools((prev) =>
+              prev.map((t) =>
+                t.status === "running" && t.name === p.name
+                  ? { ...t, preview: p.preview }
+                  : t,
+              ),
+            );
+          } else if (type === "tool.complete") {
+            const p = payload as
+              | {
+                  tool_id?: string;
+                  summary?: string;
+                  error?: string;
+                  inline_diff?: string;
                 }
-              : t,
-          ),
-        );
+              | undefined;
+
+            if (!p?.tool_id) {
+              return;
+            }
+
+            setTools((prev) =>
+              prev.map((t) =>
+                t.tool_id === p.tool_id
+                  ? {
+                      ...t,
+                      status: p.error ? "error" : "done",
+                      summary: p.summary,
+                      error: p.error,
+                      inline_diff: p.inline_diff,
+                      completedAt: Date.now(),
+                    }
+                  : t,
+              ),
+            );
+          }
+        });
+
+        // Wait for open
+        await new Promise<void>((resolve, reject) => {
+          const onOpen = () => {
+            socket.removeEventListener("error", onError);
+            resolve();
+          };
+          const onError = () => {
+            socket.removeEventListener("open", onOpen);
+            reject(new Error("events WebSocket connection failed"));
+          };
+          socket.addEventListener("open", onOpen, { once: true });
+          socket.addEventListener("error", onError, { once: true });
+        });
+
+        // Stale: a newer connectEvents call started while we were awaiting
+        if (generation !== activeWsGeneration) return;
+
+        // Success — reset backoff and clear any stale error banner
+        reconnectAttempts = 0;
+        clearReconnectBanner();
+        console.log("[events] connected successfully");
+      } catch {
+        // Connection failed — schedule reconnect (unless unmounting or superseded)
+        if (!unmounting && generation === activeWsGeneration) {
+          scheduleReconnect();
+        }
       }
-      });
-    })();
+    }
+
+    // Initial connect
+    connectEvents();
 
     return () => {
       unmounting = true;
+      activeWsGeneration++; // invalidate any in-flight reconnect
+      if (reconnectTimer) {
+        clearTimeout(reconnectTimer);
+        reconnectTimer = null;
+      }
       ws?.close();
     };
   }, [channel, version]);
@@ -364,7 +497,6 @@ export function ChatSidebar({ channel, profile, className }: ChatSidebarProps) {
       {banner && (
         <Card className="flex items-start gap-2 border-destructive/40 bg-destructive/5 px-3 py-2 text-xs">
           <AlertCircle className="mt-0.5 h-3.5 w-3.5 shrink-0 text-destructive" />
-
           <div className="min-w-0 flex-1">
             <div className="wrap-break-word text-destructive">{banner}</div>
 

--- a/web/src/lib/gatewayClient.ts
+++ b/web/src/lib/gatewayClient.ts
@@ -11,6 +11,12 @@
  *   const { session_id } = await gw.request<{ session_id: string }>("session.create")
  *   gw.on("message.delta", (ev) => console.log(ev.payload?.text))
  *   await gw.request("prompt.submit", { session_id, text: "hi" })
+ *
+ * Auto-reconnect: when the WebSocket closes unexpectedly (gateway restart,
+ * network drop), the client automatically reconnects with exponential backoff
+ * (1s → 2s → 4s → 8s → 16s → 30s cap). Reconnection stops after
+ * MAX_RECONNECT_ATTEMPTS failures or when `close()` is called explicitly.
+ * On successful reconnect the backoff resets and pending state is preserved.
  */
 
 import { HERMES_BASE_PATH, getWsTicket } from "@/lib/api";
@@ -49,7 +55,8 @@ export type ConnectionState =
   | "connecting"
   | "open"
   | "closed"
-  | "error";
+  | "error"
+  | "reconnecting";
 
 interface Pending {
   resolve: (v: unknown) => void;
@@ -62,6 +69,11 @@ const DEFAULT_REQUEST_TIMEOUT_MS = 120_000;
 /** Wildcard listener key: subscribe to every event regardless of type. */
 const ANY = "*";
 
+// ── Reconnect constants ──────────────────────────────────────────────
+const RECONNECT_BASE_MS = 1_000;
+const RECONNECT_MAX_MS = 30_000;
+const MAX_RECONNECT_ATTEMPTS = 15;
+
 export class GatewayClient {
   private ws: WebSocket | null = null;
   private reqId = 0;
@@ -69,6 +81,11 @@ export class GatewayClient {
   private listeners = new Map<string, Set<(ev: GatewayEvent) => void>>();
   private _state: ConnectionState = "idle";
   private stateListeners = new Set<(s: ConnectionState) => void>();
+
+  // ── Reconnect state ──────────────────────────────────────────────
+  private _reconnectAttempts = 0;
+  private _reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+  private _explicitlyClosed = false;
 
   get state(): ConnectionState {
     return this._state;
@@ -150,20 +167,45 @@ export class GatewayClient {
       }
     });
 
-    ws.addEventListener("close", () => {
-      this.setState("closed");
+    ws.addEventListener("close", (ev) => {
+      // Ignore close events from a superseded socket (reconnect created a
+      // new WS before the old one finished closing).
+      if (ws !== this.ws) return;
+
       this.rejectAllPending(new Error("WebSocket closed"));
+
+      // Explicit close() — don't reconnect
+      if (this._explicitlyClosed) {
+        this.setState("closed");
+        return;
+      }
+
+      // Auth rejection / protocol error — don't retry (user must reload)
+      if (ev.code === 4401 || ev.code === 4403 || ev.code === 4408) {
+        this.setState("error");
+        return;
+      }
+
+      // Unexpected close — attempt reconnect
+      this.scheduleReconnect();
     });
 
     await new Promise<void>((resolve, reject) => {
       const onOpen = () => {
         ws.removeEventListener("error", onError);
+        // Successful connect — reset backoff
+        this._reconnectAttempts = 0;
         this.setState("open");
         resolve();
       };
       const onError = () => {
         ws.removeEventListener("open", onOpen);
-        this.setState("error");
+        // Connection failed — attempt reconnect (unless explicitly closed)
+        if (!this._explicitlyClosed) {
+          this.scheduleReconnect();
+        } else {
+          this.setState("error");
+        }
         reject(new Error("WebSocket connection failed"));
       };
       ws.addEventListener("open", onOpen, { once: true });
@@ -172,8 +214,79 @@ export class GatewayClient {
   }
 
   close() {
+    this._explicitlyClosed = true;
+    this.cancelReconnect();
     this.ws?.close();
     this.ws = null;
+    this.setState("closed");
+  }
+
+  /** Reset explicit-close flag so future connect() calls work. */
+  reset() {
+    this._explicitlyClosed = false;
+    this._reconnectAttempts = 0;
+    this.cancelReconnect();
+  }
+
+  // ── Reconnect logic ──────────────────────────────────────────────
+
+  private scheduleReconnect() {
+    if (this._explicitlyClosed) return;
+    if (this._reconnectAttempts >= MAX_RECONNECT_ATTEMPTS) {
+      console.warn(
+        `[gateway] reconnect gave up after ${MAX_RECONNECT_ATTEMPTS} attempts`,
+      );
+      this.setState("error");
+      return;
+    }
+
+    this.setState("reconnecting");
+
+    // Exponential backoff: 1s, 2s, 4s, 8s, 16s, 30s cap
+    const delay = Math.min(
+      RECONNECT_BASE_MS * 2 ** this._reconnectAttempts,
+      RECONNECT_MAX_MS,
+    );
+    this._reconnectAttempts++;
+
+    console.log(
+      `[gateway] reconnecting in ${delay}ms (attempt ${this._reconnectAttempts}/${MAX_RECONNECT_ATTEMPTS})`,
+    );
+
+    this._reconnectTimer = setTimeout(() => {
+      this._reconnectTimer = null;
+      this.reconnect();
+    }, delay);
+  }
+
+  private cancelReconnect() {
+    if (this._reconnectTimer) {
+      clearTimeout(this._reconnectTimer);
+      this._reconnectTimer = null;
+    }
+  }
+
+  private async reconnect() {
+    if (this._explicitlyClosed) return;
+
+    // Tear down stale socket
+    if (this.ws) {
+      const old = this.ws;
+      this.ws = null;
+      try {
+        old.close();
+      } catch {
+        /* ignore */
+      }
+    }
+
+    try {
+      // Re-mint auth (single-use tickets expire; session tokens are stable)
+      await this.connect();
+      console.log("[gateway] reconnected successfully");
+    } catch {
+      // connect() already called scheduleReconnect() on failure
+    }
   }
 
   private dispatch(msg: Record<string, unknown>) {
@@ -194,7 +307,6 @@ export class GatewayClient {
 
     const params = (msg.params ?? {}) as GatewayEvent;
     if (typeof params.type !== "string") return;
-
     for (const cb of this.listeners.get(params.type) ?? []) cb(params);
     for (const cb of this.listeners.get(ANY) ?? []) cb(params);
   }


### PR DESCRIPTION
## Problem

When the gateway restarts (e.g. after `hermes update`), all WebSocket connections in the dashboard are severed by the OS. The dashboard had **no retry logic** — the only recovery was a manual 'reconnect' button in the sidebar or a hard page refresh, which loses all progress (terminal state, tool call history, etc.).

This is a common pain point: any gateway restart (updates, crashes, config changes) forces users to manually refresh the page.

## Solution

Add automatic reconnection with exponential backoff to **both** WebSocket connections in the dashboard:

### 1. JSON-RPC sidecar (`GatewayClient` → `/api/ws`)

- On unexpected close (non-auth-rejection), reconnects with exponential backoff
- Backoff: 1s → 2s → 4s → 8s → 16s → 30s cap, max 15 attempts
- Auth tickets re-minted on each attempt (single-use, TTL=30s)
- On successful reconnect, sidecar session is automatically re-created (`session.create`)
- Explicit `close()` still works as before (no reconnect triggered)
- Auth rejection (4401/4403/4408) doesn't retry — user must reload
- New `reconnecting` state in `ConnectionState` union

### 2. Events feed (raw WebSocket → `/api/events`)

- Same backoff strategy with generation-counter invalidation
- Auth re-minted via `buildWsAuthParam()` on each attempt  
- Error banner auto-clears on successful reconnect
- Stale sockets from superseded reconnect attempts are ignored
- Max 15 attempts before giving up with clear user message

## Files Changed

- `web/src/lib/gatewayClient.ts` — Core reconnect logic for JSON-RPC client
- `web/src/components/ChatSidebar.tsx` — Events feed reconnect + sidecar session re-creation

## Backward Compatibility

- No breaking API changes
- `ConnectionState` gains a new union member (`reconnecting`) — all consumers handle it gracefully via existing `STATE_LABEL` and `STATE_TONE` maps
- Manual reconnect button still works (bumps version counter)
- `close()` behavior unchanged (explicit close = no reconnect)

## Testing

- Build passes: `tsc -b && vite build` — zero errors
- Dashboard verified serving updated bundle
- WebSocket endpoint responding correctly (403 = auth-protected, correct behavior)