### PR TITLE
fix(compressor): use time.monotonic() for duration measurement

### DIFF
--- a/trajectory_compressor.py
+++ b/trajectory_compressor.py
@@ -1062,7 +1062,7 @@ Write only the summary, starting with "[CONTEXT SUMMARY]:" prefix."""
         
         # Record start time
         self.aggregate_metrics.processing_start_time = datetime.now().isoformat()
-        start_time = time.time()
+        start_time = time.monotonic()
         
         # Find all JSONL files
         jsonl_files = sorted(input_dir.glob("*.jsonl"))
@@ -1237,7 +1237,7 @@ Write only the summary, starting with "[CONTEXT SUMMARY]:" prefix."""
         
         # Record end time
         self.aggregate_metrics.processing_end_time = datetime.now().isoformat()
-        self.aggregate_metrics.processing_duration_seconds = time.time() - start_time
+        self.aggregate_metrics.processing_duration_seconds = time.monotonic() - start_time
         
         # Print summary
         self._print_summary()


### PR DESCRIPTION
## Bug

`trajectory_compressor.py` uses `time.time()` for measuring processing duration (lines 1065, 1240). `time.time()` is the wall clock — subject to NTP adjustments, leap seconds, or manual clock changes. This can cause:

- Negative duration measurements (clock jumps backward)
- Wildly inflated durations (clock jumps forward)
- Incorrect `processing_duration_seconds` in aggregate metrics

Same pattern was fixed in PR #29561 for `agent/conversation_loop.py` and `agent/rate_limit_tracker.py`, but `trajectory_compressor.py` was missed.

## Fix

Replace `time.time()` with `time.monotonic()` — the correct clock for elapsed time intervals.

**Note:** `processing_start_time` and `processing_end_time` (lines 1064, 1239) correctly use `datetime.now().isoformat()` for wall-clock timestamps — those are display values, not duration measurements.

## Test plan
- [x] `py_compile` passes
- [x] `processing_start_time` / `processing_end_time` still use wall clock (datetime.now)
- [x] `processing_duration_seconds` uses monotonic clock