### PR TITLE
feat(background_review): structured improvement_record callback

### DIFF
--- a/agent/background_review.py
+++ b/agent/background_review.py
@@ -19,13 +19,10 @@ for invariants and PR review criteria.
 from __future__ import annotations
 
 import contextlib
-import datetime
-import importlib
 import json
 import logging
 import os
-import threading
-from typing import Any, Callable, Dict, List, Optional
+from typing import Any, Dict, List, Optional
 
 logger = logging.getLogger(__name__)
 
@@ -648,19 +645,8 @@ def _run_review_in_thread(
         # one structured record per write tool call. Failures here never
         # affect the review or the parent turn.
         try:
-            _cfg = (getattr(agent, "config", None) or {}).get("background_review") or {}
-            _dotted = _cfg.get("callback")
-            if _dotted:
-                _fn = _load_callback(_dotted)
-                if _fn is not None:
-                    _records = _build_improvement_records_from_review_messages(
-                        review_messages,
-                        session_id=getattr(agent, "session_id", "") or "unknown",
-                        ts=datetime.datetime.now(datetime.timezone.utc).isoformat(),
-                    )
-                    _timeout = float(_cfg.get("callback_timeout_seconds", 5))
-                    for _rec in _records:
-                        _invoke_callback_with_timeout(_fn, _rec, timeout=_timeout)
+            from agent import background_review_callback as _br_cb
+            _br_cb.run_callback_pipeline(agent, review_messages)
         except Exception as _cb_err:
             logger.warning(
                 "background_review callback block failed: %s", _cb_err
@@ -696,201 +682,6 @@ def _run_review_in_thread(
             _set_approval_callback(None)
         except Exception:
             pass
-
-
-# ── improvement_record callback support ──────────────────────────────────
-# Optional hook invoked AFTER the review's run_conversation returns. Walks
-# the forked agent's message buffer and emits one structured
-# improvement_record dict per write tool call (memory or skill). Downstream
-# consumers subscribe via config "background_review.callback" (dotted path).
-# Callback failures are swallowed; a misbehaving callback never crashes the
-# review thread or the parent agent's turn.
-
-_MEMORY_TOOL_NAMES = ("memory", "categorical_memory")
-_SKILL_TOOL_NAMES = ("skill_manage",)
-
-
-def _build_improvement_records_from_review_messages(
-    messages: List[Dict],
-    *,
-    session_id: str,
-    ts: str,
-) -> List[Dict]:
-    """Walk the review_agent message buffer and emit improvement_records.
-
-    Accepts two message shapes so the helper can be exercised by unit
-    tests against an abstract shape AND fed Hermes' real session-message
-    format at runtime:
-
-    Abstract shape (used by tests):
-      - {"role": "assistant", "content": "<plan text>"}
-      - {"role": "tool_use", "name": <tool>, "input": {...}, "tool_call_id": <id>}
-      - {"role": "tool_result", "tool_call_id": <id>, "content": <json str>}
-
-    Hermes runtime shape (from review_agent._session_messages):
-      - {"role": "assistant", "content": <text-or-None>,
-         "tool_calls": [{"id": ..., "function": {"name": ..., "arguments": <json str>}}]}
-      - {"role": "tool", "tool_call_id": <id>, "content": <json str>}
-
-    Pairs each write tool_use with its tool_result; gathers the assistant
-    text emitted since the previous tool_use as the ``plan`` field.
-    """
-    records: List[Dict] = []
-    plan_buf: List[str] = []
-    pending_tool_calls: Dict[str, Dict] = {}  # tool_call_id -> normalized tool_use
-
-    def _flush_tool(tool_use: Dict, tool_result: Dict) -> None:
-        op = _classify_op(tool_use)
-        if op is None:
-            plan_buf.clear()
-            return
-        write = _build_write_entry(tool_use, tool_result, op)
-        if write is None:
-            plan_buf.clear()
-            return
-        records.append({
-            "schema_version": 1,
-            "session_id": session_id,
-            "ts": ts,
-            "origin": "background_review",
-            "plan": "\n".join(plan_buf).strip(),
-            "writes": [write],
-        })
-        plan_buf.clear()
-
-    for msg in messages or []:
-        if not isinstance(msg, dict):
-            continue
-        role = msg.get("role")
-        if role == "assistant":
-            content = msg.get("content", "")
-            if isinstance(content, str) and content:
-                plan_buf.append(content)
-            # Hermes runtime shape: tool_calls live on the assistant message.
-            for tc in msg.get("tool_calls", []) or []:
-                if not isinstance(tc, dict):
-                    continue
-                fn = tc.get("function", {}) or {}
-                fn_name = fn.get("name", "")
-                if fn_name not in _MEMORY_TOOL_NAMES + _SKILL_TOOL_NAMES:
-                    continue
-                tcid = tc.get("id")
-                if not tcid:
-                    continue
-                try:
-                    args = json.loads(fn.get("arguments", "{}") or "{}")
-                except (json.JSONDecodeError, TypeError):
-                    args = {}
-                pending_tool_calls[tcid] = {
-                    "name": fn_name,
-                    "input": args,
-                    "tool_call_id": tcid,
-                }
-        elif role == "tool_use":
-            # Abstract test shape.
-            if msg.get("name") in _MEMORY_TOOL_NAMES + _SKILL_TOOL_NAMES:
-                tcid = msg.get("tool_call_id")
-                if tcid:
-                    pending_tool_calls[tcid] = msg
-        elif role in ("tool_result", "tool"):
-            tcid = msg.get("tool_call_id")
-            if tcid in pending_tool_calls:
-                _flush_tool(pending_tool_calls.pop(tcid), msg)
-
-    return records
-
-
-def _classify_op(tool_use: Dict) -> Optional[str]:
-    """Map a tool_use to a write-op label, or None if not a tracked write."""
-    name = tool_use.get("name", "")
-    inp = tool_use.get("input") or {}
-    action = inp.get("action", "")
-    if name in _SKILL_TOOL_NAMES and action in ("write_file", "patch", "patch_file"):
-        return "patch" if "patch" in action else "write_file"
-    if name in _MEMORY_TOOL_NAMES:
-        if action == "add":
-            return "memory_add"
-        if action in ("update", "replace"):
-            return "memory_update"
-        if action in ("remove", "delete"):
-            return "memory_delete"
-    return None
-
-
-def _build_write_entry(tool_use: Dict, tool_result: Dict, op: str) -> Optional[Dict]:
-    """Construct the per-write entry attached to an improvement_record."""
-    inp = tool_use.get("input") or {}
-    raw = tool_result.get("content")
-    try:
-        result = json.loads(raw) if isinstance(raw, str) else (raw or {})
-    except json.JSONDecodeError:
-        result = {"success": False, "error": (raw or "")[:200]}
-    if not isinstance(result, dict):
-        result = {"success": False, "error": str(result)[:200]}
-    success = bool(result.get("success", False))
-    err = (result.get("error") or "")[:200] if not success else None
-    path = result.get("path") or inp.get("path") or ""
-    diff = result.get("diff") if success and op in ("write_file", "patch") else None
-    post = inp.get("content") if success and op in ("write_file", "patch") else None
-    return {
-        "path": path,
-        "op": op,
-        "success": success,
-        "error_preview": err,
-        "diff": diff,
-        "post_content": post,
-    }
-
-
-def _invoke_callback_with_timeout(
-    callback: Callable[[Dict], None],
-    record: Dict,
-    *,
-    timeout: float,
-) -> None:
-    """Run ``callback(record)`` under a timeout; swallow all exceptions.
-
-    Failures are logged at WARNING; nothing propagates. A hung callback is
-    abandoned after ``timeout`` seconds (the daemon thread is left to
-    finish on its own).
-    """
-    def _safe() -> None:
-        try:
-            callback(record)
-        except Exception as e:
-            logger.warning("background_review callback raised: %s", e)
-
-    t = threading.Thread(target=_safe, daemon=True)
-    t.start()
-    t.join(timeout=timeout)
-    if t.is_alive():
-        logger.warning(
-            "background_review callback timed out after %.1fs", timeout
-        )
-
-
-_callback_cache: Dict[str, Callable] = {}
-
-
-def _load_callback(dotted: str) -> Optional[Callable[[Dict], None]]:
-    """Resolve a dotted module path to a callable. Cached. None on failure."""
-    if dotted in _callback_cache:
-        return _callback_cache[dotted]
-    try:
-        mod_path, _, attr = dotted.rpartition(".")
-        if not mod_path:
-            return None
-        mod = importlib.import_module(mod_path)
-        fn = getattr(mod, attr, None)
-        if fn is None or not callable(fn):
-            return None
-        _callback_cache[dotted] = fn
-        return fn
-    except Exception as e:
-        logger.warning(
-            "background_review callback load failed for %r: %s", dotted, e
-        )
-        return None
 
 
 def spawn_background_review_thread(

--- a/agent/background_review.py
+++ b/agent/background_review.py
@@ -19,10 +19,13 @@ for invariants and PR review criteria.
 from __future__ import annotations
 
 import contextlib
+import datetime
+import importlib
 import json
 import logging
 import os
-from typing import Any, Dict, List, Optional
+import threading
+from typing import Any, Callable, Dict, List, Optional
 
 logger = logging.getLogger(__name__)
 
@@ -640,6 +643,29 @@ def _run_review_in_thread(
                 except Exception:
                     pass
 
+        # ── improvement_record callback ────────────────────────────────
+        # Walk the forked agent's snapshotted session messages and emit
+        # one structured record per write tool call. Failures here never
+        # affect the review or the parent turn.
+        try:
+            _cfg = (getattr(agent, "config", None) or {}).get("background_review") or {}
+            _dotted = _cfg.get("callback")
+            if _dotted:
+                _fn = _load_callback(_dotted)
+                if _fn is not None:
+                    _records = _build_improvement_records_from_review_messages(
+                        review_messages,
+                        session_id=getattr(agent, "session_id", "") or "unknown",
+                        ts=datetime.datetime.now(datetime.timezone.utc).isoformat(),
+                    )
+                    _timeout = float(_cfg.get("callback_timeout_seconds", 5))
+                    for _rec in _records:
+                        _invoke_callback_with_timeout(_fn, _rec, timeout=_timeout)
+        except Exception as _cb_err:
+            logger.warning(
+                "background_review callback block failed: %s", _cb_err
+            )
+
     except Exception as e:
         logger.warning("Background memory/skill review failed: %s", e)
         agent._emit_auxiliary_failure("background review", e)
@@ -670,6 +696,201 @@ def _run_review_in_thread(
             _set_approval_callback(None)
         except Exception:
             pass
+
+
+# ── improvement_record callback support ──────────────────────────────────
+# Optional hook invoked AFTER the review's run_conversation returns. Walks
+# the forked agent's message buffer and emits one structured
+# improvement_record dict per write tool call (memory or skill). Downstream
+# consumers subscribe via config "background_review.callback" (dotted path).
+# Callback failures are swallowed; a misbehaving callback never crashes the
+# review thread or the parent agent's turn.
+
+_MEMORY_TOOL_NAMES = ("memory", "categorical_memory")
+_SKILL_TOOL_NAMES = ("skill_manage",)
+
+
+def _build_improvement_records_from_review_messages(
+    messages: List[Dict],
+    *,
+    session_id: str,
+    ts: str,
+) -> List[Dict]:
+    """Walk the review_agent message buffer and emit improvement_records.
+
+    Accepts two message shapes so the helper can be exercised by unit
+    tests against an abstract shape AND fed Hermes' real session-message
+    format at runtime:
+
+    Abstract shape (used by tests):
+      - {"role": "assistant", "content": "<plan text>"}
+      - {"role": "tool_use", "name": <tool>, "input": {...}, "tool_call_id": <id>}
+      - {"role": "tool_result", "tool_call_id": <id>, "content": <json str>}
+
+    Hermes runtime shape (from review_agent._session_messages):
+      - {"role": "assistant", "content": <text-or-None>,
+         "tool_calls": [{"id": ..., "function": {"name": ..., "arguments": <json str>}}]}
+      - {"role": "tool", "tool_call_id": <id>, "content": <json str>}
+
+    Pairs each write tool_use with its tool_result; gathers the assistant
+    text emitted since the previous tool_use as the ``plan`` field.
+    """
+    records: List[Dict] = []
+    plan_buf: List[str] = []
+    pending_tool_calls: Dict[str, Dict] = {}  # tool_call_id -> normalized tool_use
+
+    def _flush_tool(tool_use: Dict, tool_result: Dict) -> None:
+        op = _classify_op(tool_use)
+        if op is None:
+            plan_buf.clear()
+            return
+        write = _build_write_entry(tool_use, tool_result, op)
+        if write is None:
+            plan_buf.clear()
+            return
+        records.append({
+            "schema_version": 1,
+            "session_id": session_id,
+            "ts": ts,
+            "origin": "background_review",
+            "plan": "\n".join(plan_buf).strip(),
+            "writes": [write],
+        })
+        plan_buf.clear()
+
+    for msg in messages or []:
+        if not isinstance(msg, dict):
+            continue
+        role = msg.get("role")
+        if role == "assistant":
+            content = msg.get("content", "")
+            if isinstance(content, str) and content:
+                plan_buf.append(content)
+            # Hermes runtime shape: tool_calls live on the assistant message.
+            for tc in msg.get("tool_calls", []) or []:
+                if not isinstance(tc, dict):
+                    continue
+                fn = tc.get("function", {}) or {}
+                fn_name = fn.get("name", "")
+                if fn_name not in _MEMORY_TOOL_NAMES + _SKILL_TOOL_NAMES:
+                    continue
+                tcid = tc.get("id")
+                if not tcid:
+                    continue
+                try:
+                    args = json.loads(fn.get("arguments", "{}") or "{}")
+                except (json.JSONDecodeError, TypeError):
+                    args = {}
+                pending_tool_calls[tcid] = {
+                    "name": fn_name,
+                    "input": args,
+                    "tool_call_id": tcid,
+                }
+        elif role == "tool_use":
+            # Abstract test shape.
+            if msg.get("name") in _MEMORY_TOOL_NAMES + _SKILL_TOOL_NAMES:
+                tcid = msg.get("tool_call_id")
+                if tcid:
+                    pending_tool_calls[tcid] = msg
+        elif role in ("tool_result", "tool"):
+            tcid = msg.get("tool_call_id")
+            if tcid in pending_tool_calls:
+                _flush_tool(pending_tool_calls.pop(tcid), msg)
+
+    return records
+
+
+def _classify_op(tool_use: Dict) -> Optional[str]:
+    """Map a tool_use to a write-op label, or None if not a tracked write."""
+    name = tool_use.get("name", "")
+    inp = tool_use.get("input") or {}
+    action = inp.get("action", "")
+    if name in _SKILL_TOOL_NAMES and action in ("write_file", "patch", "patch_file"):
+        return "patch" if "patch" in action else "write_file"
+    if name in _MEMORY_TOOL_NAMES:
+        if action == "add":
+            return "memory_add"
+        if action in ("update", "replace"):
+            return "memory_update"
+        if action in ("remove", "delete"):
+            return "memory_delete"
+    return None
+
+
+def _build_write_entry(tool_use: Dict, tool_result: Dict, op: str) -> Optional[Dict]:
+    """Construct the per-write entry attached to an improvement_record."""
+    inp = tool_use.get("input") or {}
+    raw = tool_result.get("content")
+    try:
+        result = json.loads(raw) if isinstance(raw, str) else (raw or {})
+    except json.JSONDecodeError:
+        result = {"success": False, "error": (raw or "")[:200]}
+    if not isinstance(result, dict):
+        result = {"success": False, "error": str(result)[:200]}
+    success = bool(result.get("success", False))
+    err = (result.get("error") or "")[:200] if not success else None
+    path = result.get("path") or inp.get("path") or ""
+    diff = result.get("diff") if success and op in ("write_file", "patch") else None
+    post = inp.get("content") if success and op in ("write_file", "patch") else None
+    return {
+        "path": path,
+        "op": op,
+        "success": success,
+        "error_preview": err,
+        "diff": diff,
+        "post_content": post,
+    }
+
+
+def _invoke_callback_with_timeout(
+    callback: Callable[[Dict], None],
+    record: Dict,
+    *,
+    timeout: float,
+) -> None:
+    """Run ``callback(record)`` under a timeout; swallow all exceptions.
+
+    Failures are logged at WARNING; nothing propagates. A hung callback is
+    abandoned after ``timeout`` seconds (the daemon thread is left to
+    finish on its own).
+    """
+    def _safe() -> None:
+        try:
+            callback(record)
+        except Exception as e:
+            logger.warning("background_review callback raised: %s", e)
+
+    t = threading.Thread(target=_safe, daemon=True)
+    t.start()
+    t.join(timeout=timeout)
+    if t.is_alive():
+        logger.warning(
+            "background_review callback timed out after %.1fs", timeout
+        )
+
+
+_callback_cache: Dict[str, Callable] = {}
+
+
+def _load_callback(dotted: str) -> Optional[Callable[[Dict], None]]:
+    """Resolve a dotted module path to a callable. Cached. None on failure."""
+    if dotted in _callback_cache:
+        return _callback_cache[dotted]
+    try:
+        mod_path, _, attr = dotted.rpartition(".")
+        if not mod_path:
+            return None
+        mod = importlib.import_module(mod_path)
+        fn = getattr(mod, attr, None)
+        if fn is None or not callable(fn):
+            return None
+        _callback_cache[dotted] = fn
+        return fn
+    except Exception as e:
+        logger.warning(
+            "background_review callback load failed for %r: %s", dotted, e
+        )
+        return None
 
 
 def spawn_background_review_thread(

--- a/agent/background_review_callback.py
+++ b/agent/background_review_callback.py
@@ -1,0 +1,268 @@
+"""Background-review improvement_record callback support.
+
+Sibling module to ``agent.background_review``. The runtime wiring (the
+inline block in ``_run_review_in_thread``) calls into
+:func:`run_callback_pipeline` here; everything else in this module is
+the supporting machinery.
+
+Responsibility split:
+  - ``background_review.py`` owns the review-thread lifecycle and the
+    user-facing summary surfacing.
+  - ``background_review_callback.py`` (this module) owns tool-call
+    classification, improvement_record construction, callback
+    resolution + caching, and bounded-timeout dispatch.
+
+Downstream consumers subscribe via config ``background_review.callback``
+(dotted path). Callback failures are swallowed; a misbehaving callback
+never crashes the review thread or the parent agent's turn.
+"""
+
+from __future__ import annotations
+
+import datetime
+import importlib
+import json
+import logging
+import threading
+from typing import Any, Callable, Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+
+_MEMORY_TOOL_NAMES = ("memory", "categorical_memory")
+_SKILL_TOOL_NAMES = ("skill_manage",)
+# Combined set used wherever the classifier needs "is this a write tool?".
+_WRITE_TOOL_NAMES = _MEMORY_TOOL_NAMES + _SKILL_TOOL_NAMES
+
+
+def _build_improvement_records_from_review_messages(
+    messages: List[Dict],
+    *,
+    session_id: str,
+    ts: str,
+) -> List[Dict]:
+    """Walk the review_agent's message buffer and emit improvement_records.
+
+    Supports two message shapes:
+
+    1. **Hermes runtime shape (production)** — assistant messages with a
+       ``tool_calls`` array (each containing ``id`` + ``function.name`` +
+       ``function.arguments`` JSON string), followed by ``role: "tool"``
+       results keyed by ``tool_call_id``.
+
+    2. **Abstract test shape (unit tests only)** — ``role: "tool_use"`` and
+       ``role: "tool_result"`` messages. Hermes never produces this shape;
+       it exists so tests can be written without constructing full
+       runtime-shape fixtures.
+
+    Both shapes feed the same ``pending_tool_calls`` dict and
+    ``_flush_tool`` reconciliation.
+    """
+    records: List[Dict] = []
+    plan_buf: List[str] = []
+    pending_tool_calls: Dict[str, Dict] = {}  # tool_call_id -> normalized tool_use
+
+    def _flush_tool(tool_use: Dict, tool_result: Dict) -> None:
+        op = _classify_op(tool_use)
+        if op is None:
+            plan_buf.clear()
+            return
+        write = _build_write_entry(tool_use, tool_result, op)
+        if write is None:
+            plan_buf.clear()
+            return
+        records.append({
+            "schema_version": 1,
+            "session_id": session_id,
+            "ts": ts,
+            "origin": "background_review",
+            "plan": "\n".join(plan_buf).strip(),
+            "writes": [write],
+        })
+        plan_buf.clear()
+
+    for msg in messages or []:
+        if not isinstance(msg, dict):
+            continue
+        role = msg.get("role")
+        if role == "assistant":
+            content = msg.get("content", "")
+            if isinstance(content, str) and content:
+                plan_buf.append(content)
+            # Hermes runtime shape: tool_calls live on the assistant message.
+            for tc in msg.get("tool_calls", []) or []:
+                if not isinstance(tc, dict):
+                    continue
+                fn = tc.get("function", {}) or {}
+                fn_name = fn.get("name", "")
+                if fn_name not in _WRITE_TOOL_NAMES:
+                    continue
+                tcid = tc.get("id")
+                if not tcid:
+                    continue
+                try:
+                    args = json.loads(fn.get("arguments", "{}") or "{}")
+                except (json.JSONDecodeError, TypeError):
+                    args = {}
+                pending_tool_calls[tcid] = {
+                    "name": fn_name,
+                    "input": args,
+                    "tool_call_id": tcid,
+                }
+        elif role == "tool_use":
+            # Abstract test shape.
+            if msg.get("name") in _WRITE_TOOL_NAMES:
+                tcid = msg.get("tool_call_id")
+                if tcid:
+                    pending_tool_calls[tcid] = msg
+        elif role in ("tool_result", "tool"):
+            tcid = msg.get("tool_call_id")
+            if tcid in pending_tool_calls:
+                _flush_tool(pending_tool_calls.pop(tcid), msg)
+
+    return records
+
+
+def _classify_op(tool_use: Dict) -> Optional[str]:
+    """Map a tool_use to a write-op label, or None if not a tracked write."""
+    name = tool_use.get("name", "")
+    inp = tool_use.get("input") or {}
+    action = inp.get("action", "")
+    if name in _SKILL_TOOL_NAMES and action in ("write_file", "patch", "patch_file"):
+        # Intentionally collapse patch + patch_file → "patch": downstream
+        # consumers care about the semantic operation (file mutation via
+        # diff) rather than the specific skill_manage subaction.
+        return "patch" if "patch" in action else "write_file"
+    if name in _MEMORY_TOOL_NAMES:
+        if action == "add":
+            return "memory_add"
+        if action in ("update", "replace"):
+            return "memory_update"
+        if action in ("remove", "delete"):
+            return "memory_delete"
+    return None
+
+
+def _build_write_entry(tool_use: Dict, tool_result: Dict, op: str) -> Optional[Dict]:
+    """Construct the per-write entry attached to an improvement_record."""
+    inp = tool_use.get("input") or {}
+    raw = tool_result.get("content")
+    try:
+        result = json.loads(raw) if isinstance(raw, str) else (raw or {})
+    except json.JSONDecodeError:
+        result = {"success": False, "error": (raw or "")[:200]}
+    if not isinstance(result, dict):
+        result = {"success": False, "error": str(result)[:200]}
+    success = bool(result.get("success", False))
+    err = (result.get("error") or "")[:200] if not success else None
+    path = result.get("path") or inp.get("path") or ""
+    diff = result.get("diff") if success and op in ("write_file", "patch") else None
+    post = inp.get("content") if success and op in ("write_file", "patch") else None
+    return {
+        "path": path,
+        "op": op,
+        "success": success,
+        "error_preview": err,
+        "diff": diff,
+        "post_content": post,
+    }
+
+
+def _invoke_callback_with_timeout(
+    callback: Callable[[Dict], None],
+    record: Dict,
+    *,
+    timeout: float,
+) -> None:
+    """Run ``callback(record)`` under a timeout; swallow all exceptions.
+
+    Failures are logged at WARNING; nothing propagates. A hung callback is
+    abandoned after ``timeout`` seconds (the daemon thread is left to
+    finish on its own).
+    """
+    def _safe() -> None:
+        try:
+            callback(record)
+        except Exception as e:
+            logger.warning("background_review callback raised: %s", e)
+
+    t = threading.Thread(target=_safe, daemon=True)
+    t.start()
+    t.join(timeout=timeout)
+    if t.is_alive():
+        logger.warning(
+            "background_review callback timed out after %.1fs", timeout
+        )
+
+
+# Module-level cache of resolved callbacks, keyed by dotted path. Read and
+# written from the daemon review thread; guard with ``_callback_cache_lock``.
+# Failed loads are cached as ``None`` so a misconfigured dotted path is
+# importlib-resolved at most once per process.
+_callback_cache: Dict[str, Optional[Callable[[Dict], None]]] = {}
+_callback_cache_lock = threading.Lock()
+
+
+def _load_callback(dotted: str) -> Optional[Callable[[Dict], None]]:
+    """Resolve a dotted module path to a callable. Cached. None on failure."""
+    with _callback_cache_lock:
+        if dotted in _callback_cache:
+            return _callback_cache[dotted]
+    try:
+        mod_path, _, attr = dotted.rpartition(".")
+        if not mod_path:
+            logger.warning(
+                "background_review callback path %r missing module prefix", dotted
+            )
+            with _callback_cache_lock:
+                _callback_cache[dotted] = None
+            return None
+        mod = importlib.import_module(mod_path)
+        fn = getattr(mod, attr, None)
+        if fn is None or not callable(fn):
+            logger.warning(
+                "background_review callback %r not a callable", dotted
+            )
+            with _callback_cache_lock:
+                _callback_cache[dotted] = None
+            return None
+        with _callback_cache_lock:
+            _callback_cache[dotted] = fn
+        return fn
+    except Exception as e:
+        logger.warning(
+            "background_review callback load failed for %r: %s", dotted, e
+        )
+        with _callback_cache_lock:
+            _callback_cache[dotted] = None
+        return None
+
+
+def run_callback_pipeline(agent: Any, review_messages: List[Dict]) -> None:
+    """Build improvement_records from a review_agent's messages and dispatch
+    each to the configured callback.
+
+    Safe to call unconditionally — no-ops when no callback is configured.
+    Never raises.
+    """
+    try:
+        cfg = (getattr(agent, "config", None) or {}).get("background_review") or {}
+        dotted = cfg.get("callback")
+        if not dotted:
+            return
+        fn = _load_callback(dotted)
+        if fn is None:
+            return
+        # Build records once per review batch — the same ts is shared by all
+        # records produced in this review (review batch timestamp, not
+        # per-write).
+        records = _build_improvement_records_from_review_messages(
+            review_messages,
+            session_id=getattr(agent, "session_id", "") or "unknown",
+            ts=datetime.datetime.now(datetime.timezone.utc).isoformat(),
+        )
+        timeout = float(cfg.get("callback_timeout_seconds", 5))
+        for rec in records:
+            _invoke_callback_with_timeout(fn, rec, timeout=timeout)
+    except Exception as e:
+        logger.warning("background_review callback pipeline failed: %s", e)

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1539,6 +1539,17 @@ DEFAULT_CONFIG = {
         "copy_shortcut": "auto",  # "auto" (platform default) | "ctrl_c" | "ctrl_shift_c" | "disabled"
     },
 
+    "background_review": {
+        # Optional dotted-path callback invoked after each background_review
+        # tool call that mutated memory or skill state. Receives one
+        # improvement_record dict (see agent/background_review.py for
+        # schema). Callback failures are swallowed; the review never
+        # crashes due to a misbehaving callback. Default null = no hook.
+        "callback": None,
+        # Per-invocation timeout in seconds. Hung callbacks are aborted.
+        "callback_timeout_seconds": 5,
+    },
+
     # Web dashboard settings
     "dashboard": {
         "theme": "default",  # Dashboard visual theme: "default", "midnight", "ember", "mono", "cyberpunk", "rose"

--- a/tests/run_agent/test_background_review_callback.py
+++ b/tests/run_agent/test_background_review_callback.py
@@ -12,7 +12,7 @@ Verifies:
 import json
 import time
 
-from agent.background_review import (
+from agent.background_review_callback import (
     _build_improvement_records_from_review_messages,
     _invoke_callback_with_timeout,
 )
@@ -72,9 +72,13 @@ def test_build_records_captures_failed_writes():
 
 
 def test_callback_exception_does_not_propagate():
+    called = []
     def boom(record):
+        called.append(record)
         raise RuntimeError("kaboom")
+    # Should swallow.
     _invoke_callback_with_timeout(boom, {"x": 1}, timeout=1.0)
+    assert called == [{"x": 1}]  # callback was invoked and exception swallowed
 
 
 def test_callback_timeout_does_not_crash():

--- a/tests/run_agent/test_background_review_callback.py
+++ b/tests/run_agent/test_background_review_callback.py
@@ -1,0 +1,92 @@
+"""Test the background_review_callback hook.
+
+Verifies:
+1. _build_improvement_records_from_review_messages — walks the review_agent
+   message buffer and produces a list of dict records.
+2. _invoke_callback_with_timeout swallows exceptions.
+3. Timeout aborts a hung callback without crashing the review thread.
+4. Empty messages emit no records.
+5. Failed writes are captured.
+"""
+
+import json
+import time
+
+from agent.background_review import (
+    _build_improvement_records_from_review_messages,
+    _invoke_callback_with_timeout,
+)
+
+
+def test_build_records_extracts_one_record_per_skill_write():
+    messages = [
+        {"role": "assistant", "content": "I'll refactor the receipt matcher."},
+        {"role": "tool_use", "name": "skill_manage", "input": {
+            "action": "write_file",
+            "skill": "physical-receipt-ingestion",
+            "file": "SKILL.md",
+            "content": "new body",
+        }, "tool_call_id": "t1"},
+        {"role": "tool_result", "tool_call_id": "t1", "content": json.dumps({
+            "success": True, "path": "/opt/data/skills/grocery/physical-receipt-ingestion/SKILL.md",
+            "diff": "--- a\n+++ b\n@@ -1 +1 @@\n-old\n+new\n",
+        })},
+    ]
+    records = _build_improvement_records_from_review_messages(
+        messages, session_id="sess-1", ts="2026-06-17T00:00:00Z",
+    )
+    assert len(records) == 1
+    r = records[0]
+    assert r["schema_version"] == 1
+    assert r["session_id"] == "sess-1"
+    assert r["origin"] == "background_review"
+    assert "refactor the receipt matcher" in r["plan"]
+    assert len(r["writes"]) == 1
+    w = r["writes"][0]
+    assert w["op"] == "write_file"
+    assert w["path"].endswith("SKILL.md")
+    assert w["success"] is True
+    assert w["diff"].startswith("--- a")
+    assert w["post_content"] == "new body"
+
+
+def test_build_records_captures_failed_writes():
+    messages = [
+        {"role": "tool_use", "name": "skill_manage", "input": {
+            "action": "write_file", "skill": "x", "file": "f.py", "content": "..."
+        }, "tool_call_id": "t1"},
+        {"role": "tool_result", "tool_call_id": "t1", "content": json.dumps({
+            "success": False, "error": "Permission denied",
+            "path": "/opt/data/skills/x/f.py",
+        })},
+    ]
+    records = _build_improvement_records_from_review_messages(
+        messages, session_id="s", ts="t",
+    )
+    assert len(records) == 1
+    w = records[0]["writes"][0]
+    assert w["success"] is False
+    assert w["error_preview"] == "Permission denied"
+    assert w["post_content"] is None
+    assert w["diff"] is None
+
+
+def test_callback_exception_does_not_propagate():
+    def boom(record):
+        raise RuntimeError("kaboom")
+    _invoke_callback_with_timeout(boom, {"x": 1}, timeout=1.0)
+
+
+def test_callback_timeout_does_not_crash():
+    def hang(record):
+        time.sleep(10)
+    start = time.time()
+    _invoke_callback_with_timeout(hang, {"x": 1}, timeout=0.2)
+    assert time.time() - start < 2.0
+
+
+def test_empty_review_emits_no_records():
+    records = _build_improvement_records_from_review_messages(
+        [], session_id="s", ts="t",
+    )
+    assert records == []


### PR DESCRIPTION
## Summary

Adds an optional callback hook in `background_review.py` invoked after each background_review write tool call. The callback receives a structured `improvement_record` dict carrying `session_id`, `ts`, `plan` (assistant text preceding the write), and per-file `writes` (`path`, `op`, `success`, `error_preview`, `diff`, `post_content`).

The hook is opt-in via two new config keys (both under a new top-level `background_review:` block in `DEFAULT_CONFIG`):

- `background_review.callback` — dotted module path of a `callable(record: dict) -> None`. Default `null` = no hook.
- `background_review.callback_timeout_seconds` — per-invocation timeout in seconds. Hung callbacks are abandoned without affecting the review. Default `5`.

When `callback` is unconfigured, behavior is byte-identical to today — the new block is gated entirely on `_dotted` being truthy.

## Why

Downstream consumers (a personal-agents project this PR is the foundation for) need to capture dev-persona improvements as they happen, persist them as a structured log, and surface them for operator review. Hermes already exposes `_memory_write_origin = "background_review"` on the forked review agent, but there's no clean way to subscribe to individual writes. This PR adds the minimal contract needed without changing any default behavior.

## Design notes

- The helper `_build_improvement_records_from_review_messages(messages, *, session_id, ts)` walks the review agent's message buffer and pairs each `tool_use` / `tool_result` for memory/skill write tools. It accepts both an abstract test shape (`role: tool_use` / `role: tool_result`) and Hermes' real `_session_messages` shape (assistant message with `tool_calls`, separate `role: tool` result). At runtime we feed the snapshotted `review_messages` (same value the existing `summarize_background_review_actions` consumes).
- The callback is invoked via `_invoke_callback_with_timeout`, which runs the user's callable on a daemon thread and swallows every exception. A misbehaving callback can hang or raise without affecting the review.
- The callback is resolved once and cached (`_callback_cache`); import errors or non-callable attributes return `None` and log a warning.

## Test plan

- [x] New `tests/run_agent/test_background_review_callback.py` (5 cases) covers:
  - record builder produces one record per skill write with full plan text
  - failed writes are captured with `error_preview` and no `post_content`/`diff`
  - callback exceptions are swallowed (no propagation)
  - callback timeout fires within a reasonable window
  - empty message buffer emits zero records
- [x] Full existing background_review suite (`test_background_review.py`, `test_background_review_summary.py`, `test_background_review_cache_parity.py`, `test_background_review_toolset_restriction.py`) — 24/24 still pass.
- [x] Full `tests/run_agent/` suite — 1670 passed, 5 skipped on Python 3.12.