### PR TITLE
fix(memory): load package-style user plugins

### DIFF
--- a/plugins/memory/__init__.py
+++ b/plugins/memory/__init__.py
@@ -71,20 +71,67 @@ def _get_user_plugins_dir() -> Optional[Path]:
         return None
 
 
+def _init_declares_memory_provider(init_file: Path) -> bool:
+    """Cheap text scan for memory-provider registration code."""
+    try:
+        source = init_file.read_text(errors="replace")[:8192]
+        return "register_memory_provider" in source or "MemoryProvider" in source
+    except Exception:
+        return False
+
+
+def _memory_provider_init_file(path: Path) -> Optional[Path]:
+    """Return the provider package ``__init__.py`` for a plugin directory.
+
+    User-installed packages are often laid out like
+    ``$HERMES_HOME/plugins/mimir/hermes_mimir/__init__.py`` rather than putting
+    the implementation directly at ``plugins/mimir/__init__.py``. Keep the
+    original root-file behavior, then fall back to one immediate package
+    subdirectory that clearly declares a memory provider.
+    """
+    root_init = path / "__init__.py"
+    if root_init.exists() and _init_declares_memory_provider(root_init):
+        return root_init
+
+    normalized_name = path.name.replace("-", "_")
+    preferred = (
+        path.name,
+        normalized_name,
+        f"hermes_{normalized_name}",
+    )
+    seen: set[Path] = set()
+
+    for child_name in preferred:
+        candidate = path / child_name / "__init__.py"
+        seen.add(candidate)
+        if candidate.exists() and _init_declares_memory_provider(candidate):
+            return candidate
+
+    try:
+        children = sorted(path.iterdir(), key=lambda child: child.name)
+    except Exception:
+        return None
+
+    for child in children:
+        candidate = child / "__init__.py"
+        if (
+            candidate in seen
+            or not child.is_dir()
+            or child.name.startswith(("_", "."))
+        ):
+            continue
+        if candidate.exists() and _init_declares_memory_provider(candidate):
+            return candidate
+    return None
+
+
 def _is_memory_provider_dir(path: Path) -> bool:
     """Heuristic: does *path* look like a memory provider plugin?
 
     Checks for ``register_memory_provider`` or ``MemoryProvider`` in the
     ``__init__.py`` source.  Cheap text scan — no import needed.
     """
-    init_file = path / "__init__.py"
-    if not init_file.exists():
-        return False
-    try:
-        source = init_file.read_text(errors="replace")[:8192]
-        return "register_memory_provider" in source or "MemoryProvider" in source
-    except Exception:
-        return False
+    return _memory_provider_init_file(path) is not None
 
 
 def _iter_provider_dirs() -> List[Tuple[str, Path]]:
@@ -217,9 +264,9 @@ def _load_provider_from_dir(provider_dir: Path) -> Optional["MemoryProvider"]:
     # collide with bundled providers in sys.modules.
     _is_bundled = _MEMORY_PLUGINS_DIR in provider_dir.parents or provider_dir.parent == _MEMORY_PLUGINS_DIR
     module_name = f"plugins.memory.{name}" if _is_bundled else f"{_USER_NAMESPACE}.{name}"
-    init_file = provider_dir / "__init__.py"
+    init_file = _memory_provider_init_file(provider_dir)
 
-    if not init_file.exists():
+    if init_file is None:
         return None
 
     # Check if already loaded.  A synthetic package shell registered by
@@ -258,7 +305,7 @@ def _load_provider_from_dir(provider_dir: Path) -> Optional["MemoryProvider"]:
         # Now load the provider module
         spec = importlib.util.spec_from_file_location(
             module_name, str(init_file),
-            submodule_search_locations=[str(provider_dir)]
+            submodule_search_locations=[str(init_file.parent)]
         )
         if not spec:
             return None
@@ -268,7 +315,7 @@ def _load_provider_from_dir(provider_dir: Path) -> Optional["MemoryProvider"]:
 
         # Register submodules so relative imports work
         # e.g., "from .store import MemoryStore" in holographic plugin
-        for sub_file in provider_dir.glob("*.py"):
+        for sub_file in init_file.parent.glob("*.py"):
             if sub_file.name == "__init__.py":
                 continue
             sub_name = sub_file.stem

--- a/tests/agent/test_memory_provider.py
+++ b/tests/agent/test_memory_provider.py
@@ -606,6 +606,44 @@ class TestUserInstalledProviderDiscovery:
         assert p is not None
         assert p.name == "nestedimpl"
 
+    def test_load_user_plugin_from_package_subdir_without_root_init(
+        self, tmp_path, monkeypatch
+    ):
+        """Pip-style provider packages do not need a copied root __init__.py."""
+        from plugins.memory import discover_memory_providers, load_memory_provider
+
+        plugin_dir = tmp_path / "plugins" / "mimir"
+        package_dir = plugin_dir / "hermes_mimir"
+        package_dir.mkdir(parents=True)
+        (package_dir / "helper.py").write_text("PROVIDER_NAME = 'mimir'\n")
+        (package_dir / "__init__.py").write_text(
+            "from agent.memory_provider import MemoryProvider\n"
+            "from . import helper\n"
+            "class MyProvider(MemoryProvider):\n"
+            "    @property\n"
+            "    def name(self): return helper.PROVIDER_NAME\n"
+            "    def is_available(self): return True\n"
+            "    def initialize(self, **kw): pass\n"
+            "    def sync_turn(self, *a, **kw): pass\n"
+            "    def get_tool_schemas(self): return []\n"
+            "    def handle_tool_call(self, *a, **kw): return '{}'\n"
+        )
+        (plugin_dir / "plugin.yaml").write_text(
+            "name: mimir\ndescription: Pip package provider\n"
+        )
+        monkeypatch.setattr(
+            "plugins.memory._get_user_plugins_dir",
+            lambda: tmp_path / "plugins",
+        )
+
+        p = load_memory_provider("mimir")
+        assert p is not None
+        assert p.name == "mimir"
+
+        providers = discover_memory_providers()
+        matches = [row for row in providers if row[0] == "mimir"]
+        assert matches == [("mimir", "Pip package provider", True)]
+
 
 class TestUserInstalledProviderCli:
     """CLI commands of user-installed providers must be discoverable.


### PR DESCRIPTION
Memory provider discovery only accepted user plugins with `__init__.py` directly under `$HERMES_HOME/plugins/<name>`. Pip-style packages often keep the implementation under a package directory, for example `plugins/mimir/hermes_mimir/__init__.py`, so Hermes missed them unless users copied or symlinked a root file.

This keeps the existing root `__init__.py` path first, then falls back to an immediate package subdirectory that clearly declares a memory provider. The provider name still comes from the plugin folder, and `plugin.yaml` metadata stays at the folder root.

Closes #47651

Checked:
- `python -m pytest tests/agent/test_memory_provider.py -q`
- `python -m ruff check plugins/memory/__init__.py tests/agent/test_memory_provider.py`
- `git diff --check`