### PR TITLE
fix(cli) + feat(gateway): custom-endpoint model autocorrect + interactive suggestion buttons

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -2559,6 +2559,35 @@ class BasePlatformAdapter(ABC):
             metadata=metadata,
         )
 
+    async def send_model_suggestions(
+        self,
+        chat_id: str,
+        message: str,
+        suggestions: list,
+        suggest_id: str,
+        session_key: str,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> SendResult:
+        """Send a model-suggestion prompt with one inline button per suggestion.
+
+        Called after a successful model switch where the requested model wasn't
+        found in the provider's listing but close matches exist.  Each button
+        lets the user re-switch to the suggested model with one click.
+
+        Button callbacks MUST resolve via
+        ``tools.slash_confirm.resolve(session_key, suggest_id, choice)``
+        where ``choice`` is the suggested model ID string.
+
+        The default implementation falls back to a plain text message with
+        the suggestions listed inline — adapters with button UIs (Telegram,
+        Discord) SHOULD override this for a richer UX.
+        """
+        return await self.send(
+            chat_id=chat_id,
+            content=message,
+            metadata=metadata,
+        )
+
     async def send_private_notice(
         self,
         chat_id: str,

--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -495,6 +495,10 @@ class TelegramAdapter(BasePlatformAdapter):
         # Slash-confirm button state: confirm_id → session_key (for /reload-mcp
         # and any other slash-confirm prompts; see GatewayRunner._request_slash_confirm).
         self._slash_confirm_state: Dict[str, str] = {}
+        # Model-suggestion button state: suggest_id → list of model IDs.
+        # Used by /model when the requested model isn't in the provider's
+        # listing but close matches exist (see send_model_suggestions).
+        self._model_suggestion_state: Dict[str, list] = {}
         # Clarify button state: clarify_id → session_key (for the clarify tool's
         # multiple-choice prompts; see GatewayRunner clarify_callback wiring).
         self._clarify_state: Dict[str, str] = {}
@@ -3200,6 +3204,72 @@ class TelegramAdapter(BasePlatformAdapter):
             logger.warning("[%s] send_slash_confirm failed: %s", self.name, e)
             return SendResult(success=False, error=str(e))
 
+    async def send_model_suggestions(
+        self,
+        chat_id: str,
+        message: str,
+        suggestions: list,
+        suggest_id: str,
+        session_key: str,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> SendResult:
+        """Render a model-suggestion prompt with one inline button per suggestion."""
+        if not self._bot:
+            return SendResult(success=False, error="Not connected")
+
+        try:
+            preview = self.format_message(
+                message if len(message) <= 3800 else message[:3800] + "..."
+            )
+
+            # Build one button per suggestion. Telegram caps callback_data at
+            # 64 bytes, so use short indices and store the mapping server-side.
+            rows = []
+            for idx, model_id in enumerate(suggestions):
+                # Button label: show the short name (after last '/')
+                short = model_id.split("/")[-1] if "/" in model_id else model_id
+                # Truncate to Telegram's 64-byte button label limit
+                if len(short) > 60:
+                    short = short[:57] + "..."
+                rows.append([
+                    InlineKeyboardButton(
+                        short,
+                        callback_data=f"msug:{suggest_id}:{idx}",
+                    )
+                ])
+
+            keyboard = InlineKeyboardMarkup(rows)
+
+            thread_id = self._metadata_thread_id(metadata)
+            kwargs: Dict[str, Any] = {
+                "chat_id": int(chat_id),
+                "text": preview,
+                "parse_mode": ParseMode.MARKDOWN_V2,
+                "reply_markup": keyboard,
+                **self._link_preview_kwargs(),
+            }
+            reply_to_id = self._reply_to_message_id_for_send(None, metadata, reply_to_mode=self._reply_to_mode)
+            kwargs["reply_to_message_id"] = reply_to_id
+            kwargs.update(
+                self._thread_kwargs_for_send(
+                    chat_id,
+                    thread_id,
+                    metadata,
+                    reply_to_message_id=reply_to_id,
+                    reply_to_mode=self._reply_to_mode
+                )
+            )
+
+            msg = await self._send_message_with_thread_fallback(**kwargs)
+            # Store the suggestion list so the callback handler can resolve
+            # the index to a model ID.
+            self._slash_confirm_state[suggest_id] = session_key
+            self._model_suggestion_state[suggest_id] = suggestions
+            return SendResult(success=True, message_id=str(msg.message_id))
+        except Exception as e:
+            logger.warning("[%s] send_model_suggestions failed: %s", self.name, e)
+            return SendResult(success=False, error=str(e))
+
     async def send_clarify(
         self,
         chat_id: str,
@@ -3949,6 +4019,69 @@ class TelegramAdapter(BasePlatformAdapter):
                         await self._send_message_with_thread_fallback(**send_kwargs)
                 except Exception as exc:
                     logger.error("[%s] slash-confirm callback failed: %s", self.name, exc, exc_info=True)
+            return
+
+        # --- Model-suggestion callbacks (msug:suggest_id:idx) ---
+        if data.startswith("msug:"):
+            parts = data.split(":", 2)
+            if len(parts) == 3:
+                suggest_id = parts[1]
+                idx_str = parts[2]
+
+                caller_id = str(getattr(query.from_user, "id", ""))
+                if not self._is_callback_user_authorized(
+                    caller_id,
+                    chat_id=query_chat_id,
+                    chat_type=str(query_chat_type) if query_chat_type is not None else None,
+                    thread_id=str(query_thread_id) if query_thread_id is not None else None,
+                    user_name=query_user_name,
+                ):
+                    await query.answer(text="⛔ You are not authorized to answer this prompt.")
+                    return
+
+                suggestions = self._model_suggestion_state.pop(suggest_id, None)
+                session_key = self._slash_confirm_state.pop(suggest_id, None)
+                if not suggestions or not session_key:
+                    await query.answer(text="This prompt has already been resolved.")
+                    return
+
+                try:
+                    idx = int(idx_str)
+                    chosen_model = suggestions[idx]
+                except (ValueError, IndexError):
+                    await query.answer(text="Invalid selection.")
+                    return
+
+                short = chosen_model.split("/")[-1] if "/" in chosen_model else chosen_model
+                user_display = getattr(query.from_user, "first_name", "User")
+                await query.answer(text=f"Switching to {short}…")
+
+                try:
+                    await query.edit_message_text(
+                        text=self.format_message(f"🔄 {user_display} selected `{short}`"),
+                        parse_mode=ParseMode.MARKDOWN_V2,
+                        reply_markup=None,
+                    )
+                except Exception:
+                    pass
+
+                # Resolve via the slash_confirm module — the gateway registered
+                # a handler that re-runs switch_model with the chosen model.
+                try:
+                    from tools import slash_confirm as _slash_confirm_mod
+                    result_text = await _slash_confirm_mod.resolve(
+                        session_key, suggest_id, chosen_model,
+                    )
+                    if result_text and query.message:
+                        send_kwargs: Dict[str, Any] = {
+                            "chat_id": int(query.message.chat_id),
+                            "text": self.format_message(result_text),
+                            "parse_mode": ParseMode.MARKDOWN_V2,
+                            **self._link_preview_kwargs(),
+                        }
+                        await self._send_message_with_thread_fallback(**send_kwargs)
+                except Exception as exc:
+                    logger.error("[%s] model-suggestion callback failed: %s", self.name, exc, exc_info=True)
             return
 
         # --- Clarify callbacks (cl:clarify_id:idx | cl:clarify_id:other) ---

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -1494,7 +1494,179 @@ class GatewaySlashCommandsMixin:
                 handler=_on_cost_confirm,
             )
 
-        return await _finish_switch()
+        confirm_text = await _finish_switch()
+
+        # --- Model suggestions: if the model wasn't in the provider's listing
+        # but close matches exist, send inline buttons so the user can
+        # one-click switch to a suggested model. ---
+        if result.suggestions:
+            try:
+                import itertools as _itertools
+                _suggest_counter = getattr(self, "_model_suggest_counter", None)
+                if _suggest_counter is None:
+                    _suggest_counter = _itertools.count(1)
+                    self._model_suggest_counter = _suggest_counter
+                suggest_id = f"{next(_suggest_counter)}"
+
+                # Build a short prompt for the suggestion buttons
+                short_requested = result.new_model.split("/")[-1] if "/" in result.new_model else result.new_model
+                suggest_msg = (
+                    f"💡 `{short_requested}` wasn't found in the model listing. "
+                    f"Click a similar model to switch:"
+                )
+
+                # The handler re-runs switch_model with the chosen suggestion.
+                # It captures the current switch context so the re-switch
+                # uses the same provider/credentials.
+                _provider = result.target_provider
+                _base_url = result.base_url
+                _api_key = result.api_key
+                _api_mode = result.api_mode
+                _persist_global = persist_global
+                _explicit_provider = explicit_provider
+                _user_provs = user_provs
+                _custom_provs = custom_provs
+                _current_model = result.new_model
+                _current_provider = result.target_provider
+                _current_base_url = result.base_url
+                _current_api_key = result.api_key
+                _session_key = session_key
+                _source = source
+                _event = event
+
+                async def _on_suggestion_click(chosen_model: str) -> str:
+                    """Re-run the model switch with the clicked suggestion."""
+                    inner_result = _switch_model(
+                        raw_input=chosen_model,
+                        current_provider=_current_provider,
+                        current_model=_current_model,
+                        current_base_url=_current_base_url,
+                        current_api_key=_current_api_key,
+                        is_global=_persist_global,
+                        explicit_provider=_explicit_provider,
+                        user_providers=_user_provs,
+                        custom_providers=_custom_provs,
+                    )
+                    if not inner_result.success:
+                        return t(
+                            "gateway.model.error_prefix",
+                            error=inner_result.error_message,
+                        )
+
+                    # Apply the switch (same logic as _finish_switch but
+                    # without the suggestion round — avoids infinite loops
+                    # since the suggested model should be in the listing).
+                    _cache_lock2 = getattr(self, "_agent_cache_lock", None)
+                    _cache2 = getattr(self, "_agent_cache", None)
+                    if _cache_lock2 and _cache2 is not None:
+                        with _cache_lock2:
+                            _ce = _cache2.get(_session_key)
+                        if _ce and _ce[0] is not None:
+                            try:
+                                _ce[0].switch_model(
+                                    new_model=inner_result.new_model,
+                                    new_provider=inner_result.target_provider,
+                                    api_key=inner_result.api_key,
+                                    base_url=inner_result.base_url,
+                                    api_mode=inner_result.api_mode,
+                                )
+                            except Exception as exc:
+                                logger.warning("Suggestion switch failed: %s", exc)
+
+                    # Persist to session DB
+                    _sess_db = getattr(self, "_session_db", None)
+                    if _sess_db is not None:
+                        try:
+                            _sess_entry = self.session_store.get_or_create_session(_source)
+                            _sess_db.update_session_model(
+                                _sess_entry.session_id, inner_result.new_model
+                            )
+                        except Exception:
+                            pass
+
+                    # Model note
+                    if not hasattr(self, "_pending_model_notes"):
+                        self._pending_model_notes = {}
+                    self._pending_model_notes[_session_key] = (
+                        f"[Note: model was just switched from {_current_model} to "
+                        f"{inner_result.new_model} via "
+                        f"{inner_result.provider_label or inner_result.target_provider}. "
+                        f"Adjust your self-identification accordingly.]"
+                    )
+
+                    # Session override
+                    self._session_model_overrides[_session_key] = {
+                        "model": inner_result.new_model,
+                        "provider": inner_result.target_provider,
+                        "api_key": inner_result.api_key,
+                        "base_url": inner_result.base_url,
+                        "api_mode": inner_result.api_mode,
+                    }
+                    self._evict_cached_agent(_session_key)
+
+                    # Persist to config if --global
+                    if _persist_global:
+                        try:
+                            if config_path.exists():
+                                with open(config_path, encoding="utf-8") as f:
+                                    cfg2 = yaml.safe_load(f) or {}
+                            else:
+                                cfg2 = {}
+                            raw_model2 = cfg2.get("model")
+                            if isinstance(raw_model2, dict):
+                                model_cfg2 = raw_model2
+                            elif isinstance(raw_model2, str) and raw_model2.strip():
+                                model_cfg2 = {"default": raw_model2.strip()}
+                                cfg2["model"] = model_cfg2
+                            else:
+                                model_cfg2 = {}
+                                cfg2["model"] = model_cfg2
+                            model_cfg2["default"] = inner_result.new_model
+                            model_cfg2["provider"] = inner_result.target_provider
+                            if inner_result.base_url:
+                                model_cfg2["base_url"] = inner_result.base_url
+                            from hermes_cli.config import save_config
+                            save_config(cfg2)
+                        except Exception as e:
+                            logger.warning("Failed to persist suggestion switch: %s", e)
+
+                    # Build confirmation
+                    plabel = inner_result.provider_label or inner_result.target_provider
+                    lines2 = [t("gateway.model.switched", model=inner_result.new_model)]
+                    lines2.append(t("gateway.model.provider_label", provider=plabel))
+                    if inner_result.warning_message:
+                        lines2.append(t("gateway.model.warning_prefix", warning=inner_result.warning_message))
+                    if _persist_global:
+                        lines2.append(t("gateway.model.saved_global"))
+                    else:
+                        lines2.append(t("gateway.model.session_only_hint"))
+                    return "\n".join(lines2)
+
+                from tools import slash_confirm as _slash_confirm_mod
+                _slash_confirm_mod.register(
+                    session_key, suggest_id, "model", _on_suggestion_click,
+                )
+
+                adapter = self.adapters.get(source.platform)
+                _metadata = self._thread_metadata_for_source(
+                    source, self._reply_anchor_for_event(event),
+                )
+                if adapter is not None:
+                    try:
+                        button_result = await adapter.send_model_suggestions(
+                            chat_id=source.chat_id,
+                            message=suggest_msg,
+                            suggestions=result.suggestions,
+                            suggest_id=suggest_id,
+                            session_key=session_key,
+                            metadata=_metadata,
+                        )
+                    except Exception as exc:
+                        logger.debug("send_model_suggestions failed: %s", exc)
+            except Exception as exc:
+                logger.debug("Model suggestion buttons failed: %s", exc)
+
+        return confirm_text
 
     async def _handle_codex_runtime_command(self, event: MessageEvent) -> str:
         """Handle /codex-runtime command in the gateway.

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -290,6 +290,7 @@ class ModelSwitchResult:
     api_mode: str = ""
     error_message: str = ""
     warning_message: str = ""
+    suggestions: list = None
     provider_label: str = ""
     resolved_via_alias: str = ""
     capabilities: Optional[ModelCapabilities] = None
@@ -1113,13 +1114,16 @@ def switch_model(
     # --- Get full model info from models.dev ---
     model_info = get_model_info(target_provider, new_model)
 
-    # --- Collect warnings ---
+    # --- Collect warnings + suggestions ---
     warnings: list[str] = []
     if validation.get("message"):
         warnings.append(validation["message"])
     hermes_warn = _check_hermes_model_warning(new_model)
     if hermes_warn:
         warnings.append(hermes_warn)
+
+    # Suggestions from validation (close matches when model wasn't in listing)
+    suggestions = validation.get("suggestions") or []
 
     # --- Build result ---
     return ModelSwitchResult(
@@ -1131,6 +1135,7 @@ def switch_model(
         base_url=base_url,
         api_mode=api_mode,
         warning_message=" | ".join(warnings) if warnings else "",
+        suggestions=suggestions if suggestions else None,
         provider_label=provider_label,
         resolved_via_alias=resolved_alias,
         capabilities=capabilities,

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -3708,6 +3708,7 @@ def validate_requested_model(
                 "persist": True,
                 "recognized": False,
                 "message": message,
+                "suggestions": suggestions,
             }
 
         message = (

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -3669,8 +3669,15 @@ def validate_requested_model(
                     "message": None,
                 }
 
-            # Auto-correct if the top match is very similar (e.g. typo)
-            auto = get_close_matches(requested_for_lookup, api_models, n=1, cutoff=0.9)
+            # Auto-correct if the top match is very similar (e.g. typo).
+            # For explicit full model IDs (containing '/'), require an exact
+            # match. Custom endpoints often omit new or aliased models from their
+            # /models listing, so silently rewriting a full path to a different
+            # model is more dangerous than accepting it with a warning below.
+            auto_cutoff = 1.0 if "/" in requested_for_lookup else 0.9
+            auto = get_close_matches(
+                requested_for_lookup, api_models, n=1, cutoff=auto_cutoff
+            )
             if auto:
                 return {
                     "accepted": True,

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -4546,6 +4546,53 @@ class DiscordAdapter(BasePlatformAdapter):
         except Exception as e:
             return SendResult(success=False, error=str(e))
 
+    async def send_model_suggestions(
+        self,
+        chat_id: str,
+        message: str,
+        suggestions: list,
+        suggest_id: str,
+        session_key: str,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> SendResult:
+        """Send a model-suggestion prompt with one Discord button per suggestion."""
+        if not self._client or not DISCORD_AVAILABLE:
+            return SendResult(success=False, error="Not connected")
+
+        try:
+            target_id = chat_id
+            if metadata and metadata.get("thread_id"):
+                target_id = metadata["thread_id"]
+
+            channel = self._client.get_channel(int(target_id))
+            if not channel:
+                channel = await self._client.fetch_channel(int(target_id))
+
+            max_desc = 4088
+            body = message if len(message) <= max_desc else message[: max_desc - 3] + "..."
+            embed = discord.Embed(
+                title="💡 Similar models found",
+                description=body,
+                color=discord.Color.blurple(),
+            )
+
+            # Discord allows up to 5 buttons per row, 5 rows = 25 total.
+            clean_suggestions = [str(s) for s in suggestions[:25]]
+            view = ModelSuggestionView(
+                suggestions=clean_suggestions,
+                session_key=session_key,
+                suggest_id=suggest_id,
+                allowed_user_ids=self._allowed_user_ids,
+                allowed_role_ids=self._allowed_role_ids,
+            )
+
+            msg = await channel.send(embed=embed, view=view)
+            view._message = msg
+            return SendResult(success=True, message_id=str(msg.id))
+        except Exception as e:
+            logger.warning("[%s] send_model_suggestions failed: %s", self.name, e)
+            return SendResult(success=False, error=str(e))
+
     async def send_clarify(
         self,
         chat_id: str,
@@ -5671,6 +5718,101 @@ def _define_discord_view_classes() -> None:
             for child in self.children:
                 child.disabled = True
             # Visually update the Discord message so buttons appear disabled.
+            msg = getattr(self, '_message', None)
+            if msg:
+                try:
+                    embed = msg.embeds[0] if msg.embeds else None
+                    if embed:
+                        embed.color = discord.Color.greyple()
+                        embed.set_footer(text="⏱ Prompt expired — no action taken")
+                    await msg.edit(embed=embed, view=self)
+                except Exception:
+                    pass
+
+    class ModelSuggestionView(discord.ui.View):
+        """One-button-per-suggestion view for model switch suggestions.
+
+        Used after a /model switch where the requested model wasn't found in
+        the provider's listing but close matches exist.  Each button shows the
+        short model name; clicking resolves via ``tools.slash_confirm.resolve``
+        with the full model ID as the choice, which runs the handler the
+        gateway registered (re-runs switch_model with the suggested model).
+        """
+
+        def __init__(
+            self,
+            suggestions: list,
+            session_key: str,
+            suggest_id: str,
+            allowed_user_ids: set,
+            allowed_role_ids: Optional[set] = None,
+        ):
+            super().__init__(timeout=300)
+            self.session_key = session_key
+            self.suggest_id = suggest_id
+            self.allowed_user_ids = allowed_user_ids
+            self.allowed_role_ids = allowed_role_ids or set()
+            self.resolved = False
+            self.suggestions = suggestions
+
+            for idx, model_id in enumerate(suggestions):
+                short = model_id.split("/")[-1] if "/" in model_id else model_id
+                if len(short) > 80:
+                    short = short[:77] + "..."
+                button = discord.ui.Button(
+                    label=short,
+                    style=discord.ButtonStyle.secondary,
+                    custom_id=f"msug:{suggest_id}:{idx}",
+                )
+                button.callback = self._make_callback(idx, model_id)
+                self.add_item(button)
+
+        def _make_callback(self, idx: int, model_id: str):
+            async def _callback(interaction: discord.Interaction):
+                if self.resolved:
+                    await interaction.response.send_message(
+                        "This prompt has already been resolved.", ephemeral=True,
+                    )
+                    return
+                if not _component_check_auth(
+                    interaction, self.allowed_user_ids, self.allowed_role_ids,
+                ):
+                    await interaction.response.send_message(
+                        "You're not authorized to answer this prompt.", ephemeral=True,
+                    )
+                    return
+
+                self.resolved = True
+                short = model_id.split("/")[-1] if "/" in model_id else model_id
+
+                embed = interaction.message.embeds[0] if interaction.message.embeds else None
+                if embed:
+                    embed.color = discord.Color.green()
+                    embed.set_footer(text=f"Switching to {short} by {interaction.user.display_name}")
+                for child in self.children:
+                    child.disabled = True
+                await interaction.response.edit_message(embed=embed, view=self)
+
+                try:
+                    from tools import slash_confirm as _slash_confirm_mod
+                    result_text = await _slash_confirm_mod.resolve(
+                        self.session_key, self.suggest_id, model_id,
+                    )
+                    if result_text:
+                        await interaction.followup.send(result_text)
+                    logger.info(
+                        "Discord model-suggestion resolved for session %s "
+                        "(model=%s, user=%s)",
+                        self.session_key, model_id, interaction.user.display_name,
+                    )
+                except Exception as exc:
+                    logger.error("Discord model-suggestion resolve failed: %s", exc, exc_info=True)
+            return _callback
+
+        async def on_timeout(self):
+            self.resolved = True
+            for child in self.children:
+                child.disabled = True
             msg = getattr(self, '_message', None)
             if msg:
                 try:

--- a/tests/hermes_cli/test_model_validation.py
+++ b/tests/hermes_cli/test_model_validation.py
@@ -577,6 +577,25 @@ class TestValidateApiNotFound:
         assert result.get("corrected_model") is None
         assert "not found" in result["message"]
 
+    def test_custom_endpoint_full_model_id_not_autocorrected(self):
+        """Full custom-endpoint IDs (with '/') should not be rewritten to a close match.
+
+        Providers like Fireworks may omit newer or aliased models from their
+        /v1/models listing even though the inference endpoint accepts them.
+        Auto-correcting a full path to a sibling model (e.g. glm-5p2 -> glm-5p1)
+        is more harmful than accepting it with a warning.
+        """
+        result = _validate(
+            "accounts/fireworks/models/glm-5p2",
+            provider="custom",
+            api_models=["accounts/fireworks/models/glm-5p1"],
+            base_url="https://api.fireworks.ai/inference/v1",
+        )
+        assert result["accepted"] is True
+        assert result["persist"] is True
+        assert result.get("corrected_model") is None
+        assert "not found" in result["message"].lower() or "note" in result["message"].lower()
+
 
 # -- validate — API unreachable — soft-accept via catalog or warning --------
 


### PR DESCRIPTION
## Summary

This PR contains two related changes that fix a real bug when switching to models on custom endpoints (e.g. Fireworks AI) that are valid for inference but not returned by the provider's `/v1/models` listing.

### 1. fix(cli): don't autocorrect full custom-endpoint model IDs

**The bug:** When a user runs `/model accounts/fireworks/models/glm-5p2`, Hermes probes the provider's `/v1/models`, does not find `glm-5p2` (Fireworks only lists `glm-5p1` in the per-account endpoint), and `get_close_matches()` with a 0.9 cutoff silently rewrites the request to `glm-5p1` because the two strings are ~97% similar. The user gets a misleading warning: `Auto-corrected accounts/fireworks/models/glm-5p2 → accounts/fireworks/models/glm-5p1`.

**The fix:** In `validate_requested_model()`, the custom-endpoint validation path now requires an exact match (cutoff=1.0) for model IDs that contain `/`. This prevents silent downgrades on full paths while still allowing typo autocorrection for bare short names (e.g. `gpt-4o` → `gpt-4o-2024-08-06`).

**Why a different approach from PR #13692:** PR #13692 raises the global cutoff to 0.98, which fixes the `kimi-k2p6` → `kimi-k2p5` symptom but still permits silent rewrites on any sufficiently similar string. The fix here is narrower: exact-match-only for full paths on custom endpoints, preserving the typo-correction feature for the 99% case.

### 2. feat(gateway): interactive suggestion buttons for unlisted models

When the model switch succeeds but the requested model wasn't in the provider's listing, the gateway now sends native inline buttons so the user can one-click switch to a close match instead of reading a wall of text and re-typing.

**What it looks like on Telegram (verified live):**

Running `/model accounts/fireworks/models/glm-5p2` returns a confirmation message with a warning, followed by a second message: "💡 `glm-5p2` wasn't found in the model listing. Click a similar model to switch:" with inline buttons `glm-5p1`, `kimi-k2p6`, `kimi-k2p5`.

**Architecture:**

| Component | Change |
|-----------|--------|
| `hermes_cli/models.py` | `validate_requested_model()` returns `suggestions` as a structured list in `recognized=False` and unreachable-listing branches |
| `hermes_cli/model_switch.py` | `ModelSwitchResult` gains `suggestions` field; `switch_model()` wires it through |
| `gateway/platforms/base.py` | New `send_model_suggestions()` stub on `BasePlatformAdapter` |
| `gateway/platforms/telegram.py` | `send_model_suggestions()` with `InlineKeyboardMarkup` (one button per suggestion, short model name as label). Callback prefix `msug:<id>:<idx>`. New `ModelSuggestionView` callback handler alongside existing `sc:` and `cl:` handlers. |
| `plugins/platforms/discord/adapter.py` | `ModelSuggestionView` (`discord.ui.View` with dynamically generated buttons) + `send_model_suggestions()` implementation |
| `gateway/slash_commands.py` | After `_finish_switch()`, if `result.suggestions` is non-empty, registers a `tools.slash_confirm` handler and sends buttons via the platform adapter. The callback handler re-runs `switch_model()` with the chosen model and applies the full session/config update. |

**Why not just show the suggestion text?** The warning message already lists similar models in plain text, but:
1. The user has to read the warning, understand the model naming convention, and re-type the correct one.
2. On mobile, copy-pasting from a warning message is awkward.
3. The buttons reuse the existing `tools.slash_confirm` registration/resolution primitive, so no new state machine is introduced.

**Security:** All button callbacks call the same `_is_callback_user_authorized` / `_component_check_auth` checks used by existing slash-confirm and clarify buttons. Unauthorized clicks get a friendly "not authorized" ephemeral reply.

**Tests:** 380 passed across `test_model_validation`, `test_cli_provider_resolution`, `test_minimax_model_validation`, and `test_tui_gateway_server`.

---

Fixes silent autocorrect of `glm-5p2` → `glm-5p1` on Fireworks custom endpoints. Complements PR #13692 with a more targeted fix plus an interactive UX improvement.
