### PR TITLE
fix: disable httpx proxy for Photon sidecar localhost connections

### DIFF
--- a/plugins/platforms/photon/adapter.py
+++ b/plugins/platforms/photon/adapter.py
@@ -327,7 +327,7 @@ class PhotonAdapter(BasePlatformAdapter):
             )
             return False
 
-        client = httpx.AsyncClient(timeout=30.0)
+        client = httpx.AsyncClient(timeout=30.0, trust_env=False)
         self._http_client = client
 
         # The sidecar holds the gRPC stream for BOTH directions, so it is
@@ -667,7 +667,7 @@ class PhotonAdapter(BasePlatformAdapter):
         if sys.platform == "win32":  # lsof/ps; orphaning is a POSIX-only path
             return
         try:
-            async with httpx.AsyncClient(timeout=2.0) as client:
+            async with httpx.AsyncClient(timeout=2.0, trust_env=False) as client:
                 await client.post(
                     f"http://{self._sidecar_bind}:{self._sidecar_port}/healthz",
                     headers={"X-Hermes-Sidecar-Token": self._sidecar_token},
@@ -747,7 +747,7 @@ class PhotonAdapter(BasePlatformAdapter):
         # Wait for /healthz to come up — give it up to 15s on cold start.
         deadline = time.time() + 15.0
         last_err: Optional[Exception] = None
-        async with httpx.AsyncClient(timeout=2.0) as client:
+        async with httpx.AsyncClient(timeout=2.0, trust_env=False) as client:
             while time.time() < deadline:
                 if self._sidecar_proc.poll() is not None:
                     raise RuntimeError(
@@ -1281,7 +1281,7 @@ class PhotonAdapter(BasePlatformAdapter):
         # _http_client directly — it always runs on the gateway's loop.
         url = f"http://{self._sidecar_bind}:{self._sidecar_port}{path}"
         headers = {"X-Hermes-Sidecar-Token": self._sidecar_token}
-        async with httpx.AsyncClient(timeout=30.0) as client:
+        async with httpx.AsyncClient(timeout=30.0, trust_env=False) as client:
             resp = await client.post(url, json=body, headers=headers)
         if resp.status_code != 200:
             raise RuntimeError(
@@ -1421,7 +1421,7 @@ async def _standalone_send(
     headers = {"X-Hermes-Sidecar-Token": token}
     last_message_id: Optional[str] = None
     try:
-        async with httpx.AsyncClient(timeout=30.0) as client:
+        async with httpx.AsyncClient(timeout=30.0, trust_env=False) as client:
             # 1. Text body first (if any), so it leads the conversation.
             if message:
                 send_body: Dict[str, Any] = {


### PR DESCRIPTION
## Summary

All Photon sidecar HTTP requests target `127.0.0.1` — they should never be routed through a system HTTP proxy. When `trust_env=True` (the default), httpx picks up macOS system proxy settings and routes localhost requests through the proxy.

## Bug

If the system proxy returns a spurious response (e.g. `502`), `_reap_stale_sidecar()` interprets it as "port in use by a non-sidecar process" and refuses to start the sidecar:

```
failed to start Photon sidecar: port 8789 is in use by another process
(pids: unknown, not a Photon sidecar)
```

The proxy intercepts the `/healthz` POST and returns 502 → code falls through to `_find_listener_pids()` → `lsof` correctly finds nothing → "pids: unknown" error.

## Fix

Set `trust_env=False` on all five `httpx.AsyncClient(...)` call sites in the Photon adapter so localhost sidecar communication bypasses the system proxy entirely.

## Reproduced & Tested

- macOS with system HTTP proxy at `127.0.0.1:7890`
- `trust_env=False` resolves the issue — Photon connects immediately