### PR TITLE
fix(model): clear stale base URL on provider switch

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -1478,6 +1478,7 @@ def switch_model(agent, new_model, new_provider, api_key='', base_url='', api_mo
 
     old_model = agent.model
     old_provider = agent.provider
+    provider_changed = (new_provider or "").strip().lower() != (old_provider or "").strip().lower()
 
     # ── Snapshot all fields the swap+rebuild can mutate ──
     # If the rebuild raises (bad API key, network error, build_anthropic_client
@@ -1520,13 +1521,14 @@ def switch_model(agent, new_model, new_provider, api_key='', base_url='', api_mo
         # ── Swap core runtime fields ──
         agent.model = new_model
         agent.provider = new_provider
-        # Use new base_url when provided; only fall back to current when the
-        # new provider genuinely has no endpoint (e.g. native SDK providers).
-        # Without this guard the old provider's URL (e.g. Ollama's localhost
-        # address) would persist silently after switching to a cloud provider
-        # that returns an empty base_url string.
+        # Use the new base_url when provided. When switching providers without
+        # one, clear the old endpoint so a native/provider-routed target is not
+        # paired with the previous provider's URL. Same-provider switches keep
+        # the existing endpoint for custom/local model changes.
         if base_url:
             agent.base_url = base_url
+        elif provider_changed:
+            agent.base_url = ""
         agent.api_mode = api_mode
         # Invalidate transport cache — new api_mode may need a different transport
         if hasattr(agent, "_transport_cache"):
@@ -1564,7 +1566,10 @@ def switch_model(agent, new_model, new_provider, api_key='', base_url='', api_mo
 
             agent.api_key = effective_key
             agent._anthropic_api_key = effective_key
-            agent._anthropic_base_url = base_url or getattr(agent, "_anthropic_base_url", None)
+            agent._anthropic_base_url = (
+                base_url
+                or (None if provider_changed else getattr(agent, "_anthropic_base_url", None))
+            )
             agent._anthropic_client = build_anthropic_client(
                 effective_key, agent._anthropic_base_url,
                 timeout=get_provider_request_timeout(agent.provider, agent.model),

--- a/tests/run_agent/test_switch_model_rollback.py
+++ b/tests/run_agent/test_switch_model_rollback.py
@@ -202,3 +202,37 @@ def test_successful_switch_still_works_after_rollback_refactor():
     assert agent.provider == "openrouter"
     assert agent.api_key == "or-key-new"
     assert agent.client is new_client
+
+
+def test_provider_switch_without_base_url_drops_previous_endpoint():
+    """Switching providers must not pair the new model with the old endpoint."""
+    agent = _make_agent_openrouter()
+    agent.model = "gpt-5.1-codex"
+    agent.provider = "copilot"
+    agent.base_url = "https://api.githubcopilot.com"
+    agent.api_key = "copilot-key-original"
+    agent._client_kwargs = {
+        "api_key": "copilot-key-original",
+        "base_url": "https://api.githubcopilot.com",
+    }
+
+    with (
+        patch("agent.anthropic_adapter.build_anthropic_client", return_value=MagicMock()) as build_client,
+        patch("agent.anthropic_adapter.resolve_anthropic_token", return_value="sk-ant-resolved"),
+        patch("agent.anthropic_adapter._is_oauth_token", return_value=False),
+        patch("hermes_cli.timeouts.get_provider_request_timeout", return_value=None),
+    ):
+        agent.switch_model(
+            new_model="claude-opus-4.8",
+            new_provider="anthropic",
+            api_key="sk-ant-new",
+            base_url="",
+            api_mode="anthropic_messages",
+        )
+
+    assert agent.model == "claude-opus-4.8"
+    assert agent.provider == "anthropic"
+    assert agent.base_url == ""
+    assert agent._primary_runtime["base_url"] == ""
+    assert agent._anthropic_base_url is None
+    build_client.assert_called_once_with("sk-ant-new", None, timeout=None)


### PR DESCRIPTION
When a live model switch moves to a provider that does not pass a new `base_url`, the in-place agent kept the previous endpoint. That can leave the new provider/model paired with the old provider URL on the next turn.

This clears the old `base_url` only when the provider changes. Same-provider switches still keep their endpoint for custom/local model changes, and the Anthropic runtime snapshot no longer inherits a previous provider URL when no new one is provided.

Closes #47828

Checked with:
- `python -m pytest tests/run_agent/test_primary_runtime_restore.py tests/run_agent/test_switch_model_rollback.py -q`
- `python -m ruff check agent/agent_runtime_helpers.py tests/run_agent/test_switch_model_rollback.py`
- `git diff --check`