### PR TITLE
feat: add provider usage guard

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1098,6 +1098,18 @@ def init_agent(
     except Exception:
         _agent_cfg = {}
     try:
+        from agent.usage_guard import load_usage_guard_config
+        agent._usage_guard_config = load_usage_guard_config(_agent_cfg)
+        agent._usage_guard_last_decision = None
+        agent._usage_guard_last_notice_key = None
+        agent._usage_guard_safe_tool_names = None
+    except Exception as _ug_err:
+        _ra().logger.warning("Usage guard config ignored: %s", _ug_err)
+        agent._usage_guard_config = None
+        agent._usage_guard_last_decision = None
+        agent._usage_guard_last_notice_key = None
+        agent._usage_guard_safe_tool_names = None
+    try:
         agent._tool_guardrails = ToolCallGuardrailController(
             ToolCallGuardrailConfig.from_mapping(
                 _agent_cfg.get("tool_loop_guardrails", {})

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -1066,6 +1066,22 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
     if agent._fallback_index >= len(agent._fallback_chain):
         return False
 
+    try:
+        from agent.usage_guard import should_require_fallback_confirmation
+
+        _blocked, _message = should_require_fallback_confirmation(agent)
+    except Exception:
+        logger.debug("usage_guard: fallback confirmation check failed", exc_info=True)
+        _blocked, _message = False, ""
+    if _blocked:
+        if _message:
+            try:
+                agent._buffer_status(f"🛑 {_message}")
+            except Exception:
+                pass
+        logger.warning("Fallback blocked by usage_guard confirmation requirement")
+        return False
+
     fb = agent._fallback_chain[agent._fallback_index]
     agent._fallback_index += 1
     fb_provider = (fb.get("provider") or "").strip().lower()

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -34,6 +34,7 @@ from agent.iteration_budget import IterationBudget
 from agent.turn_context import build_turn_context
 from agent.turn_retry_state import TurnRetryState
 from agent.memory_manager import build_memory_context_block
+from agent.usage_guard import active_valid_tool_names
 from agent.message_sanitization import (
     _repair_tool_call_arguments,
     _sanitize_messages_non_ascii,
@@ -532,6 +533,7 @@ def run_conversation(
     current_turn_user_idx = _ctx.current_turn_user_idx
     _should_review_memory = _ctx.should_review_memory
     _plugin_user_context = _ctx.plugin_user_context
+    _usage_guard_context = _ctx.usage_guard_context
     _ext_prefetch_cache = _ctx.ext_prefetch_cache
 
     # Main conversation loop counters (pure locals consumed by the loop below).
@@ -726,6 +728,8 @@ def run_conversation(
                         _injections.append(_fenced)
                 if _plugin_user_context:
                     _injections.append(_plugin_user_context)
+                if _usage_guard_context:
+                    _injections.append(_usage_guard_context)
                 if _injections:
                     _base = api_msg.get("content", "")
                     if isinstance(_base, str):
@@ -3719,22 +3723,23 @@ def run_conversation(
                 
                 # Validate tool call names - detect model hallucinations
                 # Repair mismatched tool names before validating
+                _active_tool_names = active_valid_tool_names(agent)
                 for tc in assistant_message.tool_calls:
-                    if tc.function.name not in agent.valid_tool_names:
+                    if tc.function.name not in _active_tool_names:
                         repaired = agent._repair_tool_call(tc.function.name)
-                        if repaired:
+                        if repaired and repaired in _active_tool_names:
                             print(f"{agent.log_prefix}🔧 Auto-repaired tool name: '{tc.function.name}' -> '{repaired}'")
                             tc.function.name = repaired
                 invalid_tool_calls = [
                     tc.function.name for tc in assistant_message.tool_calls
-                    if tc.function.name not in agent.valid_tool_names
+                    if tc.function.name not in _active_tool_names
                 ]
                 if invalid_tool_calls:
                     # Track retries for invalid tool calls
                     agent._invalid_tool_retries += 1
 
                     # Return helpful error to model — model can agent-correct next turn
-                    available = ", ".join(sorted(agent.valid_tool_names))
+                    available = ", ".join(sorted(_active_tool_names))
                     invalid_name = invalid_tool_calls[0]
                     invalid_preview = invalid_name[:80] + "..." if len(invalid_name) > 80 else invalid_name
                     agent._buffer_vprint(f"⚠️  Unknown tool '{invalid_preview}' — sending error to model for agent-correction ({agent._invalid_tool_retries}/3)")
@@ -3756,7 +3761,7 @@ def run_conversation(
                     assistant_msg = agent._build_assistant_message(assistant_message, finish_reason)
                     messages.append(assistant_msg)
                     for tc in assistant_message.tool_calls:
-                        if tc.function.name not in agent.valid_tool_names:
+                        if tc.function.name not in _active_tool_names:
                             content = f"Tool '{tc.function.name}' does not exist. Available tools: {available}"
                         else:
                             content = "Skipped: another tool call in this turn used an invalid name. Please retry this tool call."

--- a/agent/turn_context.py
+++ b/agent/turn_context.py
@@ -57,6 +57,8 @@ class TurnContext:
     should_review_memory: bool = False
     # Context contributed by ``pre_llm_call`` plugins (appended to user message).
     plugin_user_context: str = ""
+    # Context contributed by usage guard threshold checks (appended to user message).
+    usage_guard_context: str = ""
     # External-memory prefetch result, reused across loop iterations.
     ext_prefetch_cache: str = ""
 
@@ -342,6 +344,16 @@ def build_turn_context(
     except Exception as exc:
         logger.warning("pre_llm_call hook failed: %s", exc)
 
+    # Usage guard: API-time-only context plus optional runtime safe-mode checks.
+    usage_guard_context = ""
+    try:
+        from agent.usage_guard import evaluate_usage_guard_for_turn
+
+        _usage_decision = evaluate_usage_guard_for_turn(agent)
+        usage_guard_context = _usage_decision.context or ""
+    except Exception as exc:
+        logger.warning("usage_guard check failed: %s", exc)
+
     # Per-turn file-mutation verifier state.
     agent._turn_failed_file_mutations = {}
 
@@ -386,5 +398,6 @@ def build_turn_context(
         current_turn_user_idx=current_turn_user_idx,
         should_review_memory=should_review_memory,
         plugin_user_context=plugin_user_context,
+        usage_guard_context=usage_guard_context,
         ext_prefetch_cache=ext_prefetch_cache,
     )

--- a/agent/usage_guard.py
+++ b/agent/usage_guard.py
@@ -1,0 +1,419 @@
+"""Usage-limit guardrails for provider-backed Hermes sessions.
+
+The guard is intentionally conservative: it never guesses hidden account state
+and it never silently changes model/provider routing.  When enabled for a
+provider with account-usage visibility, it emits threshold notices and injects a
+small API-time context block that tells the model to checkpoint or wind down.
+
+Important prompt-cache invariant: this module does *not* change the tool schema
+sent to the model mid-conversation.  In wind-down mode it only narrows runtime
+validation/dispatch to configured safe-mode toolsets, so the cached system
+prompt/tool prefix remains stable.
+"""
+
+from __future__ import annotations
+
+import logging
+import math
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any, Callable, Iterable, Optional
+
+from agent.account_usage import AccountUsageSnapshot, AccountUsageWindow, fetch_account_usage
+
+logger = logging.getLogger(__name__)
+
+
+class UsageGuardLevel(Enum):
+    NORMAL = "normal"
+    WARN = "warn"
+    BLOCK_NEW_LONG_TASKS = "block_new_long_tasks"
+    WIND_DOWN = "wind_down"
+
+
+@dataclass(frozen=True)
+class UsageGuardConfig:
+    enabled: bool = False
+    provider: str = "openai-codex"
+    warn_at_percent: float = 75.0
+    wind_down_at_percent: float = 90.0
+    block_new_long_tasks_at_percent: float = 85.0
+    fallback_requires_user_confirmation: bool = True
+    safe_mode_toolsets: tuple[str, ...] = ("file", "terminal", "messaging")
+
+
+@dataclass(frozen=True)
+class UsageGuardDecision:
+    config: UsageGuardConfig
+    level: UsageGuardLevel = UsageGuardLevel.NORMAL
+    used_percent: Optional[float] = None
+    window_label: str = ""
+    reset_at: Any = None
+    status: str = ""
+    context: str = ""
+
+    @property
+    def active(self) -> bool:
+        return self.level is not UsageGuardLevel.NORMAL
+
+    @property
+    def wind_down(self) -> bool:
+        return self.level is UsageGuardLevel.WIND_DOWN
+
+
+def _as_mapping(value: Any) -> dict[str, Any]:
+    return value if isinstance(value, dict) else {}
+
+
+def _as_bool(value: Any, default: bool) -> bool:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        text = value.strip().lower()
+        if text in {"true", "yes", "on", "1"}:
+            return True
+        if text in {"false", "no", "off", "0"}:
+            return False
+    return default
+
+
+def _as_percent(value: Any, default: float) -> float:
+    try:
+        number = float(value)
+    except (TypeError, ValueError):
+        return default
+    if not math.isfinite(number):
+        return default
+    return max(0.0, min(100.0, number))
+
+
+def _as_str_tuple(value: Any, default: Iterable[str]) -> tuple[str, ...]:
+    if isinstance(value, str):
+        parts = [part.strip() for part in value.split(",")]
+    elif isinstance(value, (list, tuple, set)):
+        parts = [str(part).strip() for part in value]
+    else:
+        parts = [str(part).strip() for part in default]
+    return tuple(part for part in parts if part)
+
+
+def load_usage_guard_config(config: Optional[dict[str, Any]] = None) -> UsageGuardConfig:
+    """Parse the root-level ``usage_guard`` block from ``config.yaml``.
+
+    ``config`` may be the whole Hermes config mapping or the usage_guard block
+    itself.  Invalid values are fail-soft and fall back to safe defaults.
+    """
+    cfg = _as_mapping(config)
+    raw = _as_mapping(cfg.get("usage_guard")) if "usage_guard" in cfg else cfg
+    defaults = UsageGuardConfig()
+    return UsageGuardConfig(
+        enabled=_as_bool(raw.get("enabled"), defaults.enabled),
+        provider=str(raw.get("provider") or defaults.provider).strip().lower(),
+        warn_at_percent=_as_percent(raw.get("warn_at_percent"), defaults.warn_at_percent),
+        wind_down_at_percent=_as_percent(raw.get("wind_down_at_percent"), defaults.wind_down_at_percent),
+        block_new_long_tasks_at_percent=_as_percent(
+            raw.get("block_new_long_tasks_at_percent"),
+            defaults.block_new_long_tasks_at_percent,
+        ),
+        fallback_requires_user_confirmation=_as_bool(
+            raw.get("fallback_requires_user_confirmation"),
+            defaults.fallback_requires_user_confirmation,
+        ),
+        safe_mode_toolsets=_as_str_tuple(
+            raw.get("safe_mode_toolsets"),
+            defaults.safe_mode_toolsets,
+        ),
+    )
+
+
+def _finite_used_percent(window: AccountUsageWindow) -> Optional[float]:
+    value = window.used_percent
+    if value is None:
+        return None
+    try:
+        number = float(value)
+    except (TypeError, ValueError):
+        return None
+    if not math.isfinite(number):
+        return None
+    return max(0.0, min(100.0, number))
+
+
+def _highest_usage_window(snapshot: Optional[AccountUsageSnapshot]) -> tuple[Optional[AccountUsageWindow], Optional[float]]:
+    if snapshot is None:
+        return None, None
+    best_window: Optional[AccountUsageWindow] = None
+    best_percent: Optional[float] = None
+    for window in snapshot.windows:
+        percent = _finite_used_percent(window)
+        if percent is None:
+            continue
+        if best_percent is None or percent > best_percent:
+            best_window = window
+            best_percent = percent
+    return best_window, best_percent
+
+
+def _level_for_percent(config: UsageGuardConfig, used_percent: Optional[float]) -> UsageGuardLevel:
+    if used_percent is None:
+        return UsageGuardLevel.NORMAL
+    if used_percent >= config.wind_down_at_percent:
+        return UsageGuardLevel.WIND_DOWN
+    if used_percent >= config.block_new_long_tasks_at_percent:
+        return UsageGuardLevel.BLOCK_NEW_LONG_TASKS
+    if used_percent >= config.warn_at_percent:
+        return UsageGuardLevel.WARN
+    return UsageGuardLevel.NORMAL
+
+
+def _format_reset_hint(window: Optional[AccountUsageWindow]) -> str:
+    if not window or not window.reset_at:
+        return ""
+    try:
+        local = window.reset_at.astimezone()
+        return f" Resets at {local.strftime('%Y-%m-%d %H:%M %Z')}."
+    except Exception:
+        return ""
+
+
+def _safe_toolsets_csv(config: UsageGuardConfig) -> str:
+    return ", ".join(config.safe_mode_toolsets) if config.safe_mode_toolsets else "none"
+
+
+def _status_for_decision(
+    config: UsageGuardConfig,
+    level: UsageGuardLevel,
+    window: Optional[AccountUsageWindow],
+    used: Optional[float],
+) -> str:
+    if level is UsageGuardLevel.NORMAL or used is None:
+        return ""
+    label = window.label if window else "account"
+    used_display = f"{used:.0f}%"
+    reset = _format_reset_hint(window)
+    if level is UsageGuardLevel.WIND_DOWN:
+        return (
+            f"🛑 Usage guard: {config.provider} {label} usage is {used_display}, "
+            f"at/above the {config.wind_down_at_percent:.0f}% wind-down threshold. "
+            f"Safe wind-down mode is active; runtime tool validation is limited to: "
+            f"{_safe_toolsets_csv(config)}.{reset}"
+        )
+    if level is UsageGuardLevel.BLOCK_NEW_LONG_TASKS:
+        return (
+            f"⚠️ Usage guard: {config.provider} {label} usage is {used_display}, "
+            f"at/above the {config.block_new_long_tasks_at_percent:.0f}% new-long-task block threshold. "
+            f"Avoid starting broad new work; checkpoint or ask before continuing.{reset}"
+        )
+    return (
+        f"⚠️ Usage guard: {config.provider} {label} usage is {used_display}, "
+        f"at/above the {config.warn_at_percent:.0f}% warning threshold.{reset}"
+    )
+
+
+def _context_for_decision(
+    config: UsageGuardConfig,
+    level: UsageGuardLevel,
+    window: Optional[AccountUsageWindow],
+    used: Optional[float],
+) -> str:
+    if level is UsageGuardLevel.NORMAL or used is None:
+        return ""
+    label = window.label if window else "account"
+    used_display = f"{used:.0f}%"
+    reset = _format_reset_hint(window)
+    common = (
+        "<usage-guard>\n"
+        f"Provider {config.provider} {label} usage is {used_display}."
+        f"{reset}\n"
+    )
+    if level is UsageGuardLevel.WIND_DOWN:
+        return (
+            common
+            + "Safe wind-down mode is active. Finish only a small, already-started, safe atomic step if needed. "
+            + "Do not start broad new work, new subagents, deployments, store submissions, DNS/payment/credential flows, "
+            + "or other high-autonomy side-effecting work. Checkpoint current state, summarize what is done and what remains, "
+            + "and ask the user before continuing after the reset or under a different provider. "
+            + f"Runtime tool validation is limited to these safe-mode toolsets: {_safe_toolsets_csv(config)}.\n"
+            + "</usage-guard>"
+        )
+    if level is UsageGuardLevel.BLOCK_NEW_LONG_TASKS:
+        return (
+            common
+            + "New-long-task block is active. Do not begin large multi-step work, new subagents, or long-running jobs. "
+            + "If the user's request is short and safe, proceed carefully; otherwise give a concise checkpoint and ask whether to wait for reset.\n"
+            + "</usage-guard>"
+        )
+    return (
+        common
+        + "Warning threshold is active. Continue normally only for bounded work; prefer concise progress, avoid avoidable exploration, "
+        + "and be ready to checkpoint if usage rises further.\n"
+        + "</usage-guard>"
+    )
+
+
+def evaluate_usage_guard(
+    config: UsageGuardConfig,
+    snapshot: Optional[AccountUsageSnapshot],
+) -> UsageGuardDecision:
+    if not config.enabled:
+        return UsageGuardDecision(config=config)
+    if snapshot is not None and snapshot.provider:
+        snapshot_provider = str(snapshot.provider).strip().lower()
+        if snapshot_provider and snapshot_provider != config.provider:
+            return UsageGuardDecision(config=config)
+    window, used = _highest_usage_window(snapshot)
+    level = _level_for_percent(config, used)
+    return UsageGuardDecision(
+        config=config,
+        level=level,
+        used_percent=used,
+        window_label=window.label if window else "",
+        reset_at=window.reset_at if window else None,
+        status=_status_for_decision(config, level, window, used),
+        context=_context_for_decision(config, level, window, used),
+    )
+
+
+def safe_tool_names_for_toolsets(toolsets: Iterable[str]) -> set[str]:
+    names: set[str] = set()
+    try:
+        from toolsets import resolve_toolset
+    except Exception:
+        return names
+    for toolset in toolsets:
+        try:
+            names.update(resolve_toolset(str(toolset)))
+        except Exception:
+            logger.debug("usage_guard: unknown safe_mode_toolset %r", toolset, exc_info=True)
+    return names
+
+
+def active_valid_tool_names(agent: Any) -> set[str]:
+    """Return valid tool names after runtime usage-guard restrictions.
+
+    This intentionally restricts validation/dispatch only; it does not change
+    the API tool schema and therefore preserves the prompt-cache prefix.
+    """
+    valid = set(getattr(agent, "valid_tool_names", None) or set())
+    allowed = getattr(agent, "_usage_guard_safe_tool_names", None)
+    if allowed is None:
+        return valid
+    return valid & set(allowed)
+
+
+def _agent_usage_guard_config(agent: Any) -> UsageGuardConfig:
+    cfg = getattr(agent, "_usage_guard_config", None)
+    if isinstance(cfg, UsageGuardConfig):
+        return cfg
+    try:
+        from hermes_cli.config import load_config
+
+        cfg = load_usage_guard_config(load_config())
+    except Exception:
+        cfg = UsageGuardConfig()
+    try:
+        agent._usage_guard_config = cfg
+    except Exception:
+        pass
+    return cfg
+
+
+def _provider_matches_agent(agent: Any, config: UsageGuardConfig) -> bool:
+    provider = str(getattr(agent, "provider", "") or "").strip().lower()
+    primary = str((getattr(agent, "_primary_runtime", None) or {}).get("provider") or "").strip().lower()
+    return config.provider in {provider, primary}
+
+
+def evaluate_usage_guard_for_turn(
+    agent: Any,
+    *,
+    fetcher: Callable[[str], Optional[AccountUsageSnapshot]] = fetch_account_usage,
+) -> UsageGuardDecision:
+    """Fetch account usage and arm per-turn guardrails on ``agent``.
+
+    This is fail-open by design. If the provider usage endpoint is unavailable,
+    normal work continues rather than inventing a quota state.
+    """
+    config = _agent_usage_guard_config(agent)
+    try:
+        agent._usage_guard_safe_tool_names = None
+    except Exception:
+        pass
+    if not config.enabled or not _provider_matches_agent(agent, config):
+        decision = UsageGuardDecision(config=config)
+        try:
+            agent._usage_guard_last_decision = decision
+        except Exception:
+            pass
+        return decision
+
+    snapshot: Optional[AccountUsageSnapshot]
+    try:
+        snapshot = fetcher(config.provider)
+    except Exception:
+        logger.debug("usage_guard: fetch failed for provider %s", config.provider, exc_info=True)
+        snapshot = None
+
+    decision = evaluate_usage_guard(config, snapshot)
+    try:
+        agent._usage_guard_last_decision = decision
+    except Exception:
+        pass
+
+    if decision.status:
+        notice_key = (decision.level.value, decision.window_label, round(decision.used_percent or 0))
+        if getattr(agent, "_usage_guard_last_notice_key", None) != notice_key:
+            try:
+                agent._emit_status(decision.status)
+            except Exception:
+                pass
+            try:
+                agent._usage_guard_last_notice_key = notice_key
+            except Exception:
+                pass
+
+    if decision.wind_down:
+        safe_names = safe_tool_names_for_toolsets(config.safe_mode_toolsets)
+        try:
+            agent._usage_guard_safe_tool_names = safe_names or set()
+        except Exception:
+            pass
+        budget = getattr(agent, "iteration_budget", None)
+        if budget is not None and hasattr(budget, "max_total"):
+            try:
+                budget.max_total = min(int(budget.max_total), 3)
+            except Exception:
+                pass
+
+    return decision
+
+
+def should_require_fallback_confirmation(agent: Any) -> tuple[bool, str]:
+    config = _agent_usage_guard_config(agent)
+    if not (config.enabled and config.fallback_requires_user_confirmation):
+        return False, ""
+    if getattr(agent, "_usage_guard_fallback_confirmed", False):
+        return False, ""
+    if not getattr(agent, "_fallback_chain", None):
+        return False, ""
+    if not _provider_matches_agent(agent, config):
+        return False, ""
+    message = (
+        f"Usage guard requires explicit user confirmation before switching from {config.provider} "
+        "to a fallback provider. Automatic fallback is blocked so the agent's judgment engine does not change silently. "
+        "Ask the user to confirm the provider/model switch, or wait for the primary provider reset."
+    )
+    return True, message
+
+
+__all__ = [
+    "UsageGuardConfig",
+    "UsageGuardDecision",
+    "UsageGuardLevel",
+    "active_valid_tool_names",
+    "evaluate_usage_guard",
+    "evaluate_usage_guard_for_turn",
+    "load_usage_guard_config",
+    "safe_tool_names_for_toolsets",
+    "should_require_fallback_confirmation",
+]

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -809,6 +809,19 @@ DEFAULT_CONFIG = {
     "model": "",
     "providers": {},
     "fallback_providers": [],
+    # Usage-limit guardrails for providers with account-window visibility.
+    # Disabled by default. When enabled, Hermes warns before quota exhaustion,
+    # discourages broad new work near configured thresholds, prompts safe
+    # wind-down, and can block silent fallback-provider switches.
+    "usage_guard": {
+        "enabled": False,
+        "provider": "openai-codex",
+        "warn_at_percent": 75,
+        "wind_down_at_percent": 90,
+        "block_new_long_tasks_at_percent": 85,
+        "fallback_requires_user_confirmation": True,
+        "safe_mode_toolsets": ["file", "terminal", "messaging"],
+    },
     "credential_pool_strategies": {},
     "toolsets": ["hermes-cli"],
     # Global active chat session cap across CLI, TUI/dashboard, and messaging.
@@ -4158,7 +4171,7 @@ def check_config_version() -> Tuple[int, int]:
 # Fields that are valid at root level of config.yaml
 _KNOWN_ROOT_KEYS = {
     "_config_version", "model", "providers", "fallback_model",
-    "fallback_providers", "credential_pool_strategies", "toolsets",
+    "fallback_providers", "usage_guard", "credential_pool_strategies", "toolsets",
     "agent", "terminal", "display", "compression", "delegation",
     "auxiliary", "custom_providers", "context", "memory", "gateway",
     "sessions", "streaming", "updates", "mcp_servers",

--- a/tests/test_usage_guard.py
+++ b/tests/test_usage_guard.py
@@ -1,0 +1,110 @@
+from datetime import datetime, timezone
+from types import SimpleNamespace
+
+from agent.account_usage import AccountUsageSnapshot, AccountUsageWindow
+from agent.usage_guard import (
+    UsageGuardConfig,
+    UsageGuardLevel,
+    active_valid_tool_names,
+    evaluate_usage_guard,
+    load_usage_guard_config,
+    should_require_fallback_confirmation,
+)
+
+
+def _snapshot(*windows):
+    return AccountUsageSnapshot(
+        provider="openai-codex",
+        source="usage_api",
+        fetched_at=datetime.now(timezone.utc),
+        windows=tuple(windows),
+    )
+
+
+def test_load_usage_guard_config_accepts_requested_schema():
+    cfg = load_usage_guard_config(
+        {
+            "usage_guard": {
+                "enabled": True,
+                "provider": "openai-codex",
+                "warn_at_percent": 75,
+                "wind_down_at_percent": 90,
+                "block_new_long_tasks_at_percent": 85,
+                "fallback_requires_user_confirmation": True,
+                "safe_mode_toolsets": ["file", "terminal", "messaging"],
+            }
+        }
+    )
+
+    assert cfg.enabled is True
+    assert cfg.provider == "openai-codex"
+    assert cfg.warn_at_percent == 75.0
+    assert cfg.block_new_long_tasks_at_percent == 85.0
+    assert cfg.wind_down_at_percent == 90.0
+    assert cfg.fallback_requires_user_confirmation is True
+    assert cfg.safe_mode_toolsets == ("file", "terminal", "messaging")
+
+
+def test_evaluate_usage_guard_uses_highest_account_window_for_wind_down():
+    cfg = UsageGuardConfig(
+        enabled=True,
+        provider="openai-codex",
+        warn_at_percent=75,
+        block_new_long_tasks_at_percent=85,
+        wind_down_at_percent=90,
+        fallback_requires_user_confirmation=True,
+        safe_mode_toolsets=("file", "terminal", "messaging"),
+    )
+    decision = evaluate_usage_guard(
+        cfg,
+        _snapshot(
+            AccountUsageWindow(label="Session", used_percent=72),
+            AccountUsageWindow(label="Weekly", used_percent=91),
+        ),
+    )
+
+    assert decision.level is UsageGuardLevel.WIND_DOWN
+    assert decision.used_percent == 91.0
+    assert decision.window_label == "Weekly"
+    assert "safe wind-down" in decision.context.lower()
+    assert "file, terminal, messaging" in decision.context
+
+
+def test_active_valid_tool_names_filters_to_safe_mode_toolsets_without_schema_mutation():
+    agent = SimpleNamespace(
+        tools=[
+            {"function": {"name": "terminal"}},
+            {"function": {"name": "patch"}},
+            {"function": {"name": "send_message"}},
+            {"function": {"name": "browser_navigate"}},
+        ],
+        valid_tool_names={"terminal", "patch", "send_message", "browser_navigate"},
+        _usage_guard_safe_tool_names={"terminal", "patch", "send_message"},
+    )
+
+    assert active_valid_tool_names(agent) == {"terminal", "patch", "send_message"}
+    assert [tool["function"]["name"] for tool in agent.tools] == [
+        "terminal",
+        "patch",
+        "send_message",
+        "browser_navigate",
+    ]
+
+
+def test_fallback_confirmation_required_blocks_automatic_primary_fallback():
+    agent = SimpleNamespace(
+        provider="openai-codex",
+        _primary_runtime={"provider": "openai-codex"},
+        _fallback_chain=[{"provider": "anthropic", "model": "claude-sonnet"}],
+        _usage_guard_config=UsageGuardConfig(
+            enabled=True,
+            provider="openai-codex",
+            fallback_requires_user_confirmation=True,
+        ),
+    )
+
+    should_block, message = should_require_fallback_confirmation(agent)
+
+    assert should_block is True
+    assert "explicit user confirmation" in message
+    assert "openai-codex" in message

--- a/website/docs/user-guide/features/fallback-providers.md
+++ b/website/docs/user-guide/features/fallback-providers.md
@@ -43,8 +43,35 @@ Each entry requires both `provider` and `model`. Entries missing either field ar
 `fallback_providers` (plural, list) is the current config shape and supports multiple fallbacks tried in order. `fallback_model` (singular) is the legacy single-fallback key — Hermes still honors it for back-compat, but `hermes fallback` writes the current `fallback_providers` key and migrates legacy config on write. When both are set, `fallback_providers` takes priority.
 :::
 
-### Supported Providers
+### Usage Guard: warning before quota exhaustion
 
+For subscription-style providers that expose account usage windows, such as
+`openai-codex`, you can opt into a usage guard that warns before exhaustion,
+discourages new long-running work near the limit, and prompts safe wind-down at
+high usage. It can also require explicit confirmation before Hermes switches to
+a configured fallback provider, so a long-running session does not silently
+continue under a different model family.
+
+```yaml
+usage_guard:
+  enabled: true
+  provider: openai-codex
+  warn_at_percent: 75
+  block_new_long_tasks_at_percent: 85
+  wind_down_at_percent: 90
+  fallback_requires_user_confirmation: true
+  safe_mode_toolsets:
+    - file
+    - terminal
+    - messaging
+```
+
+The guard is disabled by default. When enabled, Hermes checks usage once at the
+start of each user turn for the configured provider. Safe-mode toolsets are
+enforced at runtime during wind-down without changing the tool schema sent to
+the model mid-conversation, preserving prompt-cache stability.
+
+### Supported Providers
 | Provider | Value | Requirements |
 |----------|-------|-------------|
 | OpenRouter | `openrouter` | `OPENROUTER_API_KEY` |


### PR DESCRIPTION
## Summary

Adds an opt-in `usage_guard` policy for providers with account-usage visibility, initially targeting `openai-codex`.

The guard:

- parses a top-level `usage_guard:` config block
- checks account usage once at the start of each user turn when enabled
- emits threshold notices and API-time user-message context at warn / block-new-long-tasks / wind-down thresholds
- limits runtime tool validation to configured safe-mode toolsets during wind-down
- blocks silent fallback-provider activation when `fallback_requires_user_confirmation: true`
- documents the config under fallback providers

Default config is disabled:

```yaml
usage_guard:
  enabled: false
  provider: openai-codex
  warn_at_percent: 75
  wind_down_at_percent: 90
  block_new_long_tasks_at_percent: 85
  fallback_requires_user_confirmation: true
  safe_mode_toolsets:
    - file
    - terminal
    - messaging
```

## Design notes

- Preserves prompt-cache stability: the guard does **not** change the tool schema sent to the model mid-conversation.
- Safe-mode toolsets are enforced at runtime validation/dispatch during wind-down rather than by mutating schemas.
- Fails open if usage cannot be fetched, so provider/account telemetry outages do not block normal Hermes use.
- Uses existing `agent.account_usage` support instead of adding a new external integration.

Refs #45646.

## Tests

```text
python -m pytest -q tests/test_usage_guard.py tests/test_account_usage.py
8 passed in 0.18s

python -m py_compile agent/usage_guard.py agent/turn_context.py agent/conversation_loop.py agent/chat_completion_helpers.py agent/agent_init.py hermes_cli/config.py

python -m hermes_cli.main config check
exit 0

git diff --check
exit 0
```
