### PR TITLE
fix(ui): provide pulsing fallback for working sessions on reduced-motion

### DIFF
--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -628,10 +628,18 @@
   --arc-duration: 3.27s;
 }
 
-@media (prefers-reduced-motion: reduce) {
-  .arc-border::before {
-    animation: none;
-  }
+/* Add a subtle pulse animation for reduced-motion users to indicate working state */
+@keyframes arc-pulse-opacity {
+  0% { opacity: 1; }
+  50% { opacity: 0.3; }
+  100% { opacity: 1; }
+}
+
+@media (prefers-reduced-motion: reduce) { 
+  .arc-border::before { 
+    /* Replace motion with opacity change so it's clearly active but not spinning */
+    animation: arc-pulse-opacity 2s ease-in-out infinite; 
+  } 
 }
 
 /* No focus rings, anywhere. Kills the native outline plus Tailwind's


### PR DESCRIPTION
**Description:**
Resolves the accessibility/UI issue mentioned in #43611 (and potentially others) where active/working sessions appear completely static on Windows Desktop if `prefers-reduced-motion` is triggered.

**What changed:**
- Replaced `animation: none;` with a gentle opacity pulse (`arc-pulse-opacity`) inside the `@media (prefers-reduced-motion: reduce)` block for `.arc-border::before`.

**Why it matters:**
When a Windows machine (or Electron wrapper) respects reduced motion, the `arc-border` animation correctly stops spinning to prevent motion sickness. However, stripping the animation entirely makes the "working" state indistinguishable from a standard "selected/idle" row. This fix provides a safe, non-spatial opacity transition so users can tell at a glance that the agent is still actively processing, without violating accessibility motion guidelines.