### PR TITLE
feat(skills): per-skill background review protection

### DIFF
--- a/agent/background_review.py
+++ b/agent/background_review.py
@@ -23,7 +23,7 @@ import json
 import logging
 import os
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Set
 
 from agent.thread_scoped_output import thread_scoped_silence
 
@@ -1172,6 +1172,46 @@ def _run_review_in_thread(
             except Exception:
                 pass
 
+            # Per-skill protection: read the config list and set the
+            # threadlocal so skill_manage refuses writes to protected
+            # skills during the review fork.
+            _protected_names: Set[str] = set()
+            _protection_parse_failed = False
+            try:
+                from hermes_cli.config import load_config, cfg_get
+                _cfg = load_config()
+                _raw_protected = cfg_get(_cfg, "skills", "review_protected", default=[])
+                if isinstance(_raw_protected, str):
+                    import json as _json
+                    _raw_protected = _json.loads(_raw_protected)
+                if isinstance(_raw_protected, list):
+                    _protected_names = {
+                        str(n).strip() for n in _raw_protected if str(n).strip()
+                    }
+                elif _raw_protected is None or _raw_protected == []:
+                    # Absent or empty — no protection (default).
+                    pass
+                else:
+                    # Explicit non-list, non-None value (e.g. scalar, dict) — malformed.
+                    _protection_parse_failed = True
+            except Exception:
+                _protection_parse_failed = True
+
+            if _protection_parse_failed:
+                logger.warning(
+                    "Failed to parse skills.review_protected config; "
+                    "blocking all skill writes for this review pass"
+                )
+
+            from tools.skill_manager_tool import (
+                set_review_protected_skills,
+                clear_review_protected_skills,
+            )
+            if _protection_parse_failed:
+                set_review_protected_skills({"*"})
+            else:
+                set_review_protected_skills(_protected_names or None)
+
             try:
                 # Routed to a different model -> replay a digest (cache is cold
                 # on that model anyway, so minimise cold-written tokens). Same
@@ -1205,6 +1245,7 @@ def _run_review_in_thread(
                 # next live turn. Runs on both the success and exception
                 # path (this whole block is inside the try/finally above).
                 _unregister_review_agent(review_agent)
+                clear_review_protected_skills()
 
             # Snapshot review actions before teardown. close() is allowed to
             # clean per-session state, but the user-visible self-improvement

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -928,6 +928,13 @@ skills:
   #   - ~/.agents/skills
   #   - /home/shared/team-skills
 
+  # Protect specific skills from automated modification during background
+  # self-improvement review. The review fork will not be able to patch,
+  # edit, or delete any skill listed here. Foreground turns are unaffected.
+  # review_protected:
+  #   - my-important-skill
+  #   - project-conventions
+
 # =============================================================================
 # Agent Behavior
 # =============================================================================

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -2019,6 +2019,10 @@ DEFAULT_CONFIG = {
         # and single-mutation `hermes curator rollback <entry-id>`.
         # Telemetry, never a gate: ledger failures cannot block a mutation.
         "ledger": True,
+        # Per-skill protection from the background self-improvement review
+        # fork. Skills named here cannot be modified by skill_manage during
+        # background review turns — only during foreground (normal) turns.
+        "review_protected": [],
     },
 
     # Curator — background skill maintenance.

--- a/tests/run_agent/test_background_review.py
+++ b/tests/run_agent/test_background_review.py
@@ -457,3 +457,164 @@ def test_skill_patch_off_silent_verbose_shows_diff():
     )
     assert len(verbose) == 1
     assert "demo" in verbose[0] and "→" in verbose[0]
+
+
+# ---------------------------------------------------------------------------
+# Lifecycle tests: config parsing → set/clear thread-local protection
+# Exercises the config-to-guard path that _run_review_in_thread uses.
+# ---------------------------------------------------------------------------
+
+def _parse_protection_config(raw_value):
+    """Replicate the config parsing logic from _run_review_in_thread."""
+    import json as _json
+
+    protected_names = set()
+    parse_failed = False
+
+    _raw = raw_value
+    if isinstance(_raw, str):
+        try:
+            _raw = _json.loads(_raw)
+        except _json.JSONDecodeError:
+            parse_failed = True
+            _raw = None
+    if isinstance(_raw, list):
+        protected_names = {str(n).strip() for n in _raw if str(n).strip()}
+    elif _raw is None or _raw == []:
+        pass
+    else:
+        parse_failed = True
+
+    return protected_names, parse_failed
+
+
+class TestReviewProtectedConfigParsing:
+    """Test config parsing logic that drives the protection lifecycle."""
+
+    def test_yaml_list(self):
+        names, failed = _parse_protection_config(["skill-a", "skill-b"])
+        assert not failed
+        assert names == {"skill-a", "skill-b"}
+
+    def test_json_array_string(self):
+        names, failed = _parse_protection_config('["skill-a", "skill-b"]')
+        assert not failed
+        assert names == {"skill-a", "skill-b"}
+
+    def test_empty_list(self):
+        names, failed = _parse_protection_config([])
+        assert not failed
+        assert names == set()
+
+    def test_none_value(self):
+        names, failed = _parse_protection_config(None)
+        assert not failed
+        assert names == set()
+
+    def test_whitespace_trimmed(self):
+        names, failed = _parse_protection_config(["  spaced  "])
+        assert not failed
+        assert names == {"spaced"}
+
+    def test_scalar_string_malformed(self):
+        names, failed = _parse_protection_config("my-skill")
+        assert failed
+
+    def test_dict_malformed(self):
+        names, failed = _parse_protection_config({"key": "value"})
+        assert failed
+
+    def test_int_malformed(self):
+        names, failed = _parse_protection_config(42)
+        assert failed
+
+    def test_invalid_json_string(self):
+        names, failed = _parse_protection_config('not json')
+        assert failed
+
+
+class TestReviewProtectedLifecycle:
+    """Test the set/clear lifecycle as _run_review_in_thread uses it."""
+
+    def test_protection_set_then_cleared(self):
+        """Simulate: config loads, set is called, review runs, clear in finally."""
+        from tools.skill_manager_tool import (
+            set_review_protected_skills,
+            clear_review_protected_skills,
+            _review_protected_guard,
+        )
+
+        clear_review_protected_skills()
+        # Simulate config load
+        names, failed = _parse_protection_config(["important-skill"])
+        assert not failed
+
+        try:
+            set_review_protected_skills(names or None)
+            # During review, writes are blocked
+            assert _review_protected_guard("patch", "important-skill") is not None
+        finally:
+            clear_review_protected_skills()
+
+        # After review, writes are allowed
+        assert _review_protected_guard("patch", "important-skill") is None
+
+    def test_fail_closed_on_malformed(self):
+        """Simulate: malformed config → deny-all → review runs → clear."""
+        from tools.skill_manager_tool import (
+            set_review_protected_skills,
+            clear_review_protected_skills,
+            _review_protected_guard,
+        )
+
+        clear_review_protected_skills()
+        names, failed = _parse_protection_config("my-skill")
+        assert failed
+
+        try:
+            set_review_protected_skills({"*"})
+            # During review, ALL writes blocked
+            assert _review_protected_guard("patch", "any") is not None
+            assert _review_protected_guard("edit", "other") is not None
+        finally:
+            clear_review_protected_skills()
+
+        assert _review_protected_guard("patch", "any") is None
+
+    def test_empty_config_no_protection(self):
+        """Simulate: empty config → no protection."""
+        from tools.skill_manager_tool import (
+            set_review_protected_skills,
+            clear_review_protected_skills,
+            _review_protected_guard,
+        )
+
+        clear_review_protected_skills()
+        names, failed = _parse_protection_config([])
+        assert not failed
+
+        try:
+            set_review_protected_skills(names or None)
+            assert _review_protected_guard("patch", "any") is None
+        finally:
+            clear_review_protected_skills()
+
+    def test_exception_during_review_still_cleans_up(self):
+        """Simulate: exception in run_conversation → finally clears protection."""
+        from tools.skill_manager_tool import (
+            set_review_protected_skills,
+            clear_review_protected_skills,
+            _review_protected_guard,
+        )
+
+        clear_review_protected_skills()
+
+        try:
+            set_review_protected_skills({"blocked-skill"})
+            raise RuntimeError("simulated review crash")
+        except RuntimeError:
+            pass
+        finally:
+            clear_review_protected_skills()
+
+        assert _review_protected_guard("patch", "blocked-skill") is None

--- a/tests/tools/test_skill_manager_tool.py
+++ b/tests/tools/test_skill_manager_tool.py
@@ -19,6 +19,9 @@ from tools.skill_manager_tool import (
     _write_file,
     _remove_file,
     skill_manage,
+    set_review_protected_skills,
+    clear_review_protected_skills,
+    _review_protected_guard,
 )
 from agent.skill_utils import (
     extract_skill_description,
@@ -947,3 +950,162 @@ class TestCuratorConsolidationDeleteGuard:
             assert allowed["success"] is True, allowed
 
         _reset_background_review_read_marks()
+
+
+# ---------------------------------------------------------------------------
+# Background review protection (_review_protected_guard)
+# ---------------------------------------------------------------------------
+
+class TestReviewProtectedGuard:
+    """Tests for the per-skill background review protection guard."""
+
+    def setup_method(self):
+        clear_review_protected_skills()
+
+    def teardown_method(self):
+        clear_review_protected_skills()
+
+    def test_guard_returns_none_when_threadlocal_unset(self):
+        """No protection when the threadlocal is not set (foreground turns)."""
+        assert _review_protected_guard("patch", "any-skill") is None
+        assert _review_protected_guard("delete", "any-skill") is None
+
+    def test_guard_blocks_patch_on_protected_skill(self):
+        set_review_protected_skills({"my-skill"})
+        result = _review_protected_guard("patch", "my-skill")
+        assert result is not None
+        assert "protected" in result
+
+    def test_guard_blocks_edit_on_protected_skill(self):
+        set_review_protected_skills({"my-skill"})
+        assert _review_protected_guard("edit", "my-skill") is not None
+
+    def test_guard_blocks_delete_on_protected_skill(self):
+        set_review_protected_skills({"my-skill"})
+        assert _review_protected_guard("delete", "my-skill") is not None
+
+    def test_guard_blocks_write_file_on_protected_skill(self):
+        set_review_protected_skills({"my-skill"})
+        assert _review_protected_guard("write_file", "my-skill") is not None
+
+    def test_guard_blocks_remove_file_on_protected_skill(self):
+        set_review_protected_skills({"my-skill"})
+        assert _review_protected_guard("remove_file", "my-skill") is not None
+
+    def test_guard_blocks_create_on_protected_skill(self):
+        set_review_protected_skills({"my-skill"})
+        assert _review_protected_guard("create", "my-skill") is not None
+
+    def test_guard_allows_unprotected_skill(self):
+        """A skill NOT in the protected list is allowed."""
+        set_review_protected_skills({"other-skill"})
+        assert _review_protected_guard("patch", "my-skill") is None
+
+    def test_guard_empty_set_allows_all(self):
+        """Empty protection set = no protection (back-compat)."""
+        set_review_protected_skills(set())
+        assert _review_protected_guard("patch", "any") is None
+
+    def test_guard_read_actions_pass_through(self):
+        """Read-only actions (view, list) are never blocked."""
+        set_review_protected_skills({"my-skill"})
+        assert _review_protected_guard("view", "my-skill") is None
+        assert _review_protected_guard("list", "my-skill") is None
+
+
+class TestReviewProtectedDispatch:
+    """Integration: skill_manage respects the guard end-to-end."""
+
+    def setup_method(self):
+        clear_review_protected_skills()
+
+    def teardown_method(self):
+        clear_review_protected_skills()
+
+    def test_protected_skill_patch_blocked_via_skill_manage(self, tmp_path):
+        """skill_manage(action='patch') on a protected skill returns error."""
+        with _skill_dir(tmp_path):
+            _create_skill("test-protected", VALID_SKILL_CONTENT)
+            set_review_protected_skills({"test-protected"})
+            result_json = skill_manage(
+                action="patch",
+                name="test-protected",
+                old_string="Step 1: Do the thing.",
+                new_string="Step 1: Do the NEW thing.",
+            )
+            result = json.loads(result_json)
+            assert result["success"] is False
+            assert "protected" in result["error"]
+
+    def test_unprotected_skill_patch_allowed_via_skill_manage(self, tmp_path):
+        """skill_manage(action='patch') on a non-protected skill succeeds."""
+        with _skill_dir(tmp_path):
+            _create_skill("test-free", VALID_SKILL_CONTENT)
+            set_review_protected_skills({"other-skill"})
+            result_json = skill_manage(
+                action="patch",
+                name="test-free",
+                old_string="Step 1: Do the thing.",
+                new_string="Step 1: Do the NEW thing.",
+            )
+            result = json.loads(result_json)
+            assert result["success"] is True
+
+    def test_foreground_patch_always_allowed(self, tmp_path):
+        """Without threadlocal set, patch works normally (foreground)."""
+        with _skill_dir(tmp_path):
+            _create_skill("test-foreground", VALID_SKILL_CONTENT)
+            clear_review_protected_skills()
+            result_json = skill_manage(
+                action="patch",
+                name="test-foreground",
+                old_string="Step 1: Do the thing.",
+                new_string="Step 1: Foreground change.",
+            )
+            result = json.loads(result_json)
+            assert result["success"] is True
+
+
+class TestReviewProtectedDenyAll:
+    """Tests for the fail-closed deny-all mode (config parse error)."""
+
+    def setup_method(self):
+        clear_review_protected_skills()
+
+    def teardown_method(self):
+        clear_review_protected_skills()
+
+    def test_deny_all_blocks_every_skill(self):
+        """Sentinel {"*"} blocks all write actions on any skill."""
+        set_review_protected_skills({"*"})
+        for action in ("patch", "edit", "delete", "create", "write_file", "remove_file"):
+            assert _review_protected_guard(action, "any-skill") is not None
+            assert _review_protected_guard(action, "other-skill") is not None
+
+    def test_deny_all_blocks_via_skill_manage(self, tmp_path):
+        """skill_manage on ANY skill is blocked when deny-all is active."""
+        with _skill_dir(tmp_path):
+            _create_skill("test-skill-a", VALID_SKILL_CONTENT)
+            set_review_protected_skills({"*"})
+            result_json = skill_manage(
+                action="patch",
+                name="test-skill-a",
+                old_string="Step 1: Do the thing.",
+                new_string="Step 1: Changed.",
+            )
+            result = json.loads(result_json)
+            assert result["success"] is False
+            assert "protected" in result["error"]
+
+    def test_deny_all_does_not_affect_reads(self):
+        """Read actions still pass through even in deny-all mode."""
+        set_review_protected_skills({"*"})
+        assert _review_protected_guard("view", "any") is None
+        assert _review_protected_guard("list", "any") is None
+
+    def test_deny_all_cleared_properly(self):
+        """Clearing deny-all restores normal write behavior."""
+        set_review_protected_skills({"*"})
+        assert _review_protected_guard("patch", "any") is not None
+        clear_review_protected_skills()
+        assert _review_protected_guard("patch", "any") is None

--- a/tools/skill_manager_tool.py
+++ b/tools/skill_manager_tool.py
@@ -37,8 +37,9 @@ import logging
 import re
 import shutil
 import contextvars as _ctxvars
+import threading
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Set, Tuple
 
 from hermes_constants import get_hermes_home, display_hermes_home
 from utils import atomic_write_text, is_truthy_value
@@ -269,6 +270,63 @@ def _validate_delete_target(skill_dir: Path) -> Optional[str]:
         f"Refusing to delete '{skill_dir}': path does not resolve inside any "
         f"known skills root."
     )
+
+
+_review_protected_skills = threading.local()
+
+
+def set_review_protected_skills(names: Optional[Set[str]]) -> None:
+    """Set the per-thread protected-skills list.
+
+    Only the background self-improvement review fork calls this.
+    Foreground threads never set it, so the guard is inert during
+    normal conversation.
+
+    Pass ``{"*"}`` to deny all skill writes (used when the protection
+    config is malformed and fail-closed behavior is required).
+    """
+    _review_protected_skills.names = names or None
+
+
+def clear_review_protected_skills() -> None:
+    """Clear the per-thread protected-skills list."""
+    _review_protected_skills.names = None
+
+
+# Actions that modify skill content — blocked for protected skills
+# during background review.  Read-only actions (skill_view, skills_list)
+# are separate tools and are never gated.
+_REVIEW_PROTECTED_ACTIONS = frozenset({
+    "create", "edit", "patch", "delete", "write_file", "remove_file",
+})
+
+# Sentinel that blocks ALL skill writes during review (used on config parse error).
+_REVIEW_DENY_ALL = frozenset({"*"})
+
+
+def _review_protected_guard(action: str, name: str) -> Optional[str]:
+    """Return a refusal message if this skill is protected during background review.
+
+    The guard fires only when the calling thread has set the protected list
+    via ``set_review_protected_skills()`` (i.e. the background review fork).
+    On the main conversation thread the threadlocal is never set, so all
+    writes pass through normally.
+    """
+    protected = getattr(_review_protected_skills, "names", None)
+    if not protected:
+        return None
+    if action not in _REVIEW_PROTECTED_ACTIONS:
+        return None
+    if protected == _REVIEW_DENY_ALL or name in protected:
+        logger.info(
+            "Background review blocked from %s on protected skill '%s'",
+            action, name,
+        )
+        return (
+            f"Skill '{name}' is protected from background self-improvement review. "
+            f"Use skill_manage in a foreground turn to modify it."
+        )
+    return None
 
 
 def _pinned_guard(name: str) -> Optional[str]:
@@ -1558,6 +1616,13 @@ def skill_manage(
 
     Returns JSON string with results.
     """
+    # Per-skill background review protection (config-driven).
+    # Runs before upstream's _background_review_preflight and the
+    # write-approval gate so protected skills are never staged.
+    _review_block = _review_protected_guard(action, name)
+    if _review_block:
+        return json.dumps({"success": False, "error": _review_block}, ensure_ascii=False)
+
     preflight = _background_review_preflight(action, name)
     if preflight is not None:
         return json.dumps(preflight, ensure_ascii=False)

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -669,6 +669,29 @@ skills:
 
 When on, skill writes are staged under `~/.hermes/pending/skills/` and reviewed with `/skills pending`, `/skills diff <id>`, `/skills approve <id>`, `/skills reject <id>` — from the CLI or any messaging platform. Toggle at runtime with `/skills approval on|off`. Memory has the same gate (`memory.write_approval`, below). Full walkthrough: [Gating agent skill writes](/user-guide/features/skills#gating-agent-skill-writes-skillswrite_approval).
 
+### Background review protection (`review_protected`)
+
+Prevent the per-turn self-improvement background review from modifying
+specific skills:
+
+```yaml
+skills:
+  review_protected:
+    - my-custom-skill
+    - project-workflow
+```
+
+Listed skills are blocked from all write actions during the per-turn review
+fork only — foreground turns are unaffected. Read actions (`list`, `view`)
+are always allowed. If the config value is malformed, all skill writes are
+blocked for that review pass (fail-closed).
+
+This is distinct from `write_approval` (which stages every write for human
+approval) and curator pinning (`hermes curator pin`, which is broader — it
+blocks all background-origin mutations and inactivity curation, and also
+prevents foreground deletion). Full description: [Protecting skills from
+background review](/user-guide/features/skills#protecting-skills-from-background-review-review_protected).
+
 ## Memory Configuration
 
 ```yaml

--- a/website/docs/user-guide/features/skills.md
+++ b/website/docs/user-guide/features/skills.md
@@ -564,6 +564,41 @@ in the pending JSON file). Memory writes have the same gate under
 > (dangerous-pattern heuristics), not an approval gate — the two are
 > independent. See [Guard on agent-created skill writes](/user-guide/configuration#guard-on-agent-created-skill-writes).
 
+### Protecting skills from background review (`review_protected`)
+
+The per-turn self-improvement background review can modify skills during its
+review pass. If you have skills you never want the review to touch — custom
+workflows, project-specific conventions, carefully tuned prompts — list them
+under `skills.review_protected`:
+
+```yaml
+skills:
+  review_protected:
+    - my-custom-skill
+    - project-workflow
+```
+
+When the background review fork starts, it reads this list into a thread-local
+set. Any write action (`create` / `edit` / `patch` / `delete` / `write_file` /
+`remove_file`) targeting a listed skill is blocked with a clear error returned
+to the review agent. Read actions (`list`, `view`) are unaffected. Foreground
+turns are never restricted — the protection applies only to the per-turn
+self-improvement review fork.
+
+If the config value is malformed (not a list or JSON-array string), all skill
+writes are blocked for that review pass (fail-closed) and a warning is logged.
+
+#### How this differs from other skill protection mechanisms
+
+| Mechanism | Scope | What it blocks |
+| --- | --- | --- |
+| `skills.review_protected` | Per-turn background review fork only | Write actions on named skills during review |
+| `hermes curator pin` | Broader — all background-origin writes + inactivity curator | Autonomous mutations and curation; also blocks foreground deletion (foreground edits still allowed) |
+| `skills.write_approval` | All skill writes (foreground + background) | Stages writes for human approval instead of blocking them outright |
+
+The read-before-write invariant (#55906) is a separate guard that prevents the
+review from patching any skill it has not loaded via `skill_view` first.
+
 ## Skills Hub
 
 Browse, search, install, and manage skills from online registries, `skills.sh`, direct well-known skill endpoints, and official optional skills.


### PR DESCRIPTION
## What does this PR do?

The background self-improvement review fork (`agent/background_review.py`) can call `skill_manage(action="patch"/"edit"/"delete"/etc.)` on **any** skill — including skills the user has carefully curated (e.g. custom workflow skills, project-specific conventions). There was no mechanism to protect specific skills from automated modification while still allowing the review to improve others.

This PR adds a **config-driven per-skill protection list** (`skills.review_protected`) that blocks write actions during background review only. Foreground turns are unaffected. Malformed config values trigger a fail-closed deny-all that blocks every skill write during that review pass.

**Relationship to #55906 (merged):** #55906 added a read-before-write invariant — the review fork must `skill_view` a skill before mutating it, closing the silent-corruption path in #55647. This PR is complementary, not competing:

- **#55906**: "read before you write" — prevents blind patches based on hallucinated content
- **This PR**: "do not touch these skills at all" — lets users opt out of automated modification entirely for specific skills

Both guards coexist in `skill_manage()`: `_review_protected_guard()` fires first (complete block), then the upstream read-before-write guard runs for unprotected skills.

## Related Issue

Related to #55647 (silent skill corruption), #55906 (read-before-write guard).

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- **`tools/skill_manager_tool.py`** — Thread-local `_review_protected_skills` set + `set_review_protected_skills()` / `clear_review_protected_skills()` helpers + `_review_protected_guard()` dispatched in `skill_manage()` before `_apply_skill_write_gate()`. Fail-closed deny-all sentinel (`{"*"}`) for malformed config.
- **`agent/background_review.py`** — Reads `skills.review_protected` from config, calls `set_review_protected_skills()` before review run, `clear_review_protected_skills()` in `finally` block. Type validation: non-list values (scalar, dict, int) trigger deny-all.
- **`hermes_cli/config_defaults.py`** — `DEFAULT_CONFIG` entry: `skills.review_protected: []`
- **`cli-config.yaml.example`** — Documented `review_protected` under `skills:` section
- **`tests/tools/test_skill_manager_tool.py`** — 17 new tests: `TestReviewProtectedGuard` (10) + `TestReviewProtectedDispatch` (3) + `TestReviewProtectedDenyAll` (4)
- **`tests/run_agent/test_background_review.py`** — 13 new tests: `TestReviewProtectedConfigParsing` (9) + `TestReviewProtectedLifecycle` (4)
- **`website/docs/user-guide/features/skills.md`** — "Protecting skills from background review" section + policy matrix table
- **`website/docs/user-guide/configuration.md`** — "Background review protection" section

## How to Test

1. Add protected skills to config: `skills.review_protected: ["my-important-skill"]`
2. Trigger a background review — verify `skill_manage(action="patch", name="my-important-skill")` is blocked
3. Verify unprotected skills can still be modified during review
4. Verify foreground `skill_manage` calls are unaffected
5. Set malformed config (e.g. `review_protected: 42`) — verify ALL skill writes are blocked during that review pass (fail-closed)
6. `pytest tests/tools/test_skill_manager_tool.py tests/run_agent/test_background_review.py -v` — all new tests pass

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu 24.04 (Linux 6.18.37)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (`docs/`, docstrings) — `skills.md`, `configuration.md`
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — N/A (thread-local, no platform-specific code)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A (no tool schema changes)
