### PR TITLE
Fix/langfuse chat completions trace scope

### DIFF
--- a/plugins/observability/langfuse/__init__.py
+++ b/plugins/observability/langfuse/__init__.py
@@ -219,7 +219,34 @@ def _get_langfuse() -> Optional[Langfuse]:
     return _LANGFUSE_CLIENT
 
 
-def _trace_key(task_id: str, session_id: str) -> str:
+def _trace_key(
+    task_id: str,
+    session_id: str,
+    *,
+    turn_id: str = "",
+    api_request_id: str = "",
+) -> str:
+    """Build a stable in-process trace scope key for one agent turn.
+
+    Older Hermes paths only expose ``task_id``/``session_id``. Newer paths
+    pass ``turn_id`` and ``api_request_id`` in LLM/tool hooks; when present,
+    they must scope trace state so concurrent requests sharing one task/session
+    never collide.
+    """
+    if turn_id:
+        if task_id:
+            return f"task:{task_id}:turn:{turn_id}"
+        if session_id:
+            return f"session:{session_id}:turn:{turn_id}"
+        return f"thread:{threading.get_ident()}:turn:{turn_id}"
+
+    if api_request_id:
+        if task_id:
+            return f"task:{task_id}:api:{api_request_id}"
+        if session_id:
+            return f"session:{session_id}:api:{api_request_id}"
+        return f"thread:{threading.get_ident()}:api:{api_request_id}"
+
     if task_id:
         return task_id
     if session_id:
@@ -563,12 +590,15 @@ def _usage_and_cost(response: Any, *, provider: str, api_mode: str, model: str, 
 
 
 def _start_root_trace(task_key: str, *, task_id: str, session_id: str, platform: str, provider: str, model: str,
-                      api_mode: str, messages: Any, client: Langfuse) -> TraceState:
+                      api_mode: str, messages: Any, client: Langfuse,
+                      turn_id: str = "", api_request_id: str = "") -> TraceState:
     trace_id = client.create_trace_id(seed=f"{session_id or 'sessionless'}::{task_id or task_key}")
     trace_input = _extract_last_user_message(messages)
     metadata = {
         "source": "hermes",
         "task_id": task_id,
+        "turn_id": turn_id,
+        "api_request_id": api_request_id,
         "platform": platform,
         "provider": provider,
         "model": model,
@@ -712,7 +742,8 @@ def _request_key(api_call_count: Any) -> str:
 def on_pre_llm_call(*, task_id: str = "", session_id: str = "", platform: str = "", model: str = "",
                     provider: str = "", base_url: str = "", api_mode: str = "",
                     api_call_count: int = 0, messages: Any = None, turn_type: str = "user",
-                    conversation_history: Any = None, user_message: Any = None, **_: Any) -> None:
+                    conversation_history: Any = None, user_message: Any = None,
+                    turn_id: str = "", api_request_id: str = "", **_: Any) -> None:
     # Older Hermes branches used pre_llm_call for request-scoped tracing and
     # passed the actual API messages. Current Hermes also has a turn-scoped
     # pre_llm_call used for context injection; tracing that hook creates an
@@ -729,7 +760,12 @@ def on_pre_llm_call(*, task_id: str = "", session_id: str = "", platform: str = 
     # pre_llm_call with API messages directly. Current Hermes fires
     # pre_llm_call for context injection (conversation_history/user_message,
     # no messages list) — tracing that would create orphan traces.
-    task_key = _trace_key(task_id, session_id)
+    task_key = _trace_key(
+        task_id,
+        session_id,
+        turn_id=turn_id,
+        api_request_id=api_request_id,
+    )
 
     with _STATE_LOCK:
         state = _TRACE_STATE.get(task_key)
@@ -744,6 +780,8 @@ def on_pre_llm_call(*, task_id: str = "", session_id: str = "", platform: str = 
                 api_mode=api_mode,
                 messages=messages,
                 client=client,
+                turn_id=turn_id,
+                api_request_id=api_request_id,
             )
             _TRACE_STATE[task_key] = state
         state.last_updated_at = time.time()
@@ -769,6 +807,8 @@ def on_pre_llm_request(
     max_tokens: Any = None,
     conversation_history: Any = None,
     user_message: Any = None,
+    turn_id: str = "",
+    api_request_id: str = "",
     **_: Any,
 ) -> None:
     client = _get_langfuse()
@@ -782,7 +822,12 @@ def on_pre_llm_request(
         user_message=user_message,
     )
 
-    task_key = _trace_key(task_id, session_id)
+    task_key = _trace_key(
+        task_id,
+        session_id,
+        turn_id=turn_id,
+        api_request_id=api_request_id,
+    )
     req_key = _request_key(api_call_count)
 
     with _STATE_LOCK:
@@ -798,6 +843,8 @@ def on_pre_llm_request(
                 api_mode=api_mode,
                 messages=input_messages,
                 client=client,
+                turn_id=turn_id,
+                api_request_id=api_request_id,
             )
             _TRACE_STATE[task_key] = state
         state.last_updated_at = time.time()
@@ -827,12 +874,18 @@ def on_post_llm_call(*, task_id: str = "", session_id: str = "", provider: str =
                      api_duration: float = 0.0, finish_reason: str = "",
                      usage: Any = None, assistant_content_chars: int = 0,
                      assistant_tool_call_count: int = 0, assistant_response: Any = None,
+                     turn_id: str = "", api_request_id: str = "",
                      **_: Any) -> None:
     client = _get_langfuse()
     if client is None:
         return
 
-    task_key = _trace_key(task_id, session_id)
+    task_key = _trace_key(
+        task_id,
+        session_id,
+        turn_id=turn_id,
+        api_request_id=api_request_id,
+    )
     req_key = _request_key(api_call_count)
 
     with _STATE_LOCK:
@@ -950,12 +1003,18 @@ def on_post_llm_call(*, task_id: str = "", session_id: str = "", provider: str =
 
 
 def on_pre_tool_call(*, tool_name: str = "", args: Any = None, task_id: str = "",
-                     session_id: str = "", tool_call_id: str = "", **_: Any) -> None:
+                     session_id: str = "", tool_call_id: str = "",
+                     turn_id: str = "", api_request_id: str = "", **_: Any) -> None:
     client = _get_langfuse()
     if client is None:
         return
 
-    task_key = _trace_key(task_id, session_id)
+    task_key = _trace_key(
+        task_id,
+        session_id,
+        turn_id=turn_id,
+        api_request_id=api_request_id,
+    )
 
     with _STATE_LOCK:
         state = _TRACE_STATE.get(task_key)
@@ -976,8 +1035,14 @@ def on_pre_tool_call(*, tool_name: str = "", args: Any = None, task_id: str = ""
 
 
 def on_post_tool_call(*, tool_name: str = "", args: Any = None, result: Any = None,
-                      task_id: str = "", session_id: str = "", tool_call_id: str = "", **_: Any) -> None:
-    task_key = _trace_key(task_id, session_id)
+                      task_id: str = "", session_id: str = "", tool_call_id: str = "",
+                      turn_id: str = "", api_request_id: str = "", **_: Any) -> None:
+    task_key = _trace_key(
+        task_id,
+        session_id,
+        turn_id=turn_id,
+        api_request_id=api_request_id,
+    )
     observation = None
 
     with _STATE_LOCK:

--- a/tests/plugins/test_langfuse_plugin.py
+++ b/tests/plugins/test_langfuse_plugin.py
@@ -205,6 +205,37 @@ class TestPayloadSanitization:
         }
 
 
+class TestTraceScopeKey:
+    def _fresh_plugin(self):
+        mod_name = "plugins.observability.langfuse"
+        sys.modules.pop(mod_name, None)
+        return importlib.import_module(mod_name)
+
+    def test_trace_key_scopes_by_turn_id_when_available(self):
+        plugin = self._fresh_plugin()
+
+        key_a = plugin._trace_key("task-1", "session-1", turn_id="turn-a")
+        key_b = plugin._trace_key("task-1", "session-1", turn_id="turn-b")
+
+        assert key_a != key_b
+        assert "turn:turn-a" in key_a
+        assert "turn:turn-b" in key_b
+
+    def test_trace_key_scopes_by_api_request_id_when_turn_missing(self):
+        plugin = self._fresh_plugin()
+
+        key_a = plugin._trace_key("task-1", "session-1", api_request_id="req-a")
+        key_b = plugin._trace_key("task-1", "session-1", api_request_id="req-b")
+
+        assert key_a != key_b
+        assert "api:req-a" in key_a
+        assert "api:req-b" in key_b
+
+    def test_trace_key_keeps_legacy_shape_without_turn_or_api_id(self):
+        plugin = self._fresh_plugin()
+        assert plugin._trace_key("task-1", "session-1") == "task-1"
+
+
 # ---------------------------------------------------------------------------
 # Placeholder-credential guard (#23823).
 #


### PR DESCRIPTION
## What does this PR do?

This PR fixes a Langfuse observability bug where traces can be dropped for v1/chat/completions requests when multiple turns or API requests share the same task/session scope.

Discord issue: https://discord.com/channels/1053877538025386074/1516762258166775819

Root cause:
- The plugin kept in-flight trace state under broad keys (task_id/session_id), which can collide across concurrent or near-concurrent requests in the same session.

Why this approach:
- Trace state is now scoped with turn_id first, then api_request_id as fallback, while preserving legacy behavior when neither is available.
- This removes key collisions without changing external APIs or requiring config changes.


## Related Issue

Fixes #

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Added request/turn-aware trace scoping helper and applied it in Langfuse hook paths:
  - plugins/observability/langfuse/__init__.py
- Updated pre/post LLM + tool hook state lookup to use the new scoped key strategy:
  - plugins/observability/langfuse/__init__.py
- Added regression tests for trace-key scoping behavior:
  - tests/plugins/test_langfuse_plugin.py

## How to Test

1. Reproduce on main:
   - Enable Langfuse plugin and run requests through v1/chat/completions in the same session/task context.
   - Observe intermittent missing traces due to state-key collisions.
2. Verify fix on this branch:
   - Repeat the same request pattern.
   - Confirm traces are emitted consistently (separate trace state per turn/api request).
3. Run regression tests:
   - scripts/run_tests.sh tests/plugins/test_langfuse_plugin.py -q

## Checklist

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (fix(scope):, feat(scope):, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run pytest tests/ -q and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, docs/, docstrings) or N/A
- [x] I've updated cli-config.yaml.example if I added/changed config keys or N/A
- [x] I've updated CONTRIBUTING.md or AGENTS.md if I changed architecture or workflows or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior or N/A

## For New Skills

- [ ] This skill is **broadly useful** to most users (if bundled) - see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [ ] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I've tested the skill end-to-end: hermes --toolsets skills -q "Use the X skill to do Y"

## Screenshots / Logs

- Compare view (2 commits, 2 files changed):
  https://github.com/NousResearch/hermes-agent/compare/main...infinitycrew39:hermes-agent:fix/langfuse-chat-completions-trace-scope?expand=1

- Test command status on local machine:
  - scripts/run_tests.sh tests/plugins/test_langfuse_plugin.py -q
  - Could not run because no local virtualenv was found (.venv/venv missing).
