### PR TITLE
fix(desktop): reclaim sidebar space when sessions collapse

### DIFF
--- a/apps/desktop/src/app/chat/sidebar/classes.test.ts
+++ b/apps/desktop/src/app/chat/sidebar/classes.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest'
+
+import { sidebarSessionsSectionRootClassName } from './classes'
+
+describe('sidebarSessionsSectionRootClassName', () => {
+  it('keeps the flexing recents layout while expanded', () => {
+    expect(
+      sidebarSessionsSectionRootClassName(
+        'min-h-32 flex-1 overflow-hidden p-0 compact:min-h-0 compact:flex-none compact:overflow-visible',
+        true
+      )
+    ).toBe('min-h-32 flex-1 overflow-hidden p-0 compact:min-h-0 compact:flex-none compact:overflow-visible')
+  })
+
+  it('reclaims sidebar space when a flexing sessions section is collapsed', () => {
+    const className = sidebarSessionsSectionRootClassName(
+      'min-h-32 flex-1 overflow-hidden p-0 compact:min-h-0 compact:flex-none compact:overflow-visible',
+      false
+    )
+
+    expect(className).toContain('min-h-0')
+    expect(className).toContain('flex-none')
+    expect(className).toContain('shrink-0')
+    expect(className).toContain('overflow-visible')
+    expect(className).toContain('p-0')
+    expect(className).not.toContain('min-h-32')
+    expect(className).not.toContain('flex-1')
+    expect(className).not.toContain('overflow-hidden')
+  })
+
+  it('keeps non-flex collapsed sections header-sized', () => {
+    const className = sidebarSessionsSectionRootClassName('shrink-0 p-0', false)
+
+    expect(className).toContain('shrink-0')
+    expect(className).toContain('p-0')
+    expect(className).toContain('flex-none')
+    expect(className).not.toContain('flex-1')
+    expect(className).not.toContain('min-h-32')
+  })
+})

--- a/apps/desktop/src/app/chat/sidebar/classes.ts
+++ b/apps/desktop/src/app/chat/sidebar/classes.ts
@@ -1,0 +1,5 @@
+import { cn } from '@/lib/utils'
+
+export function sidebarSessionsSectionRootClassName(rootClassName: string | undefined, open: boolean): string {
+  return cn(rootClassName, !open && 'min-h-0 flex-none shrink-0 overflow-visible')
+}

--- a/apps/desktop/src/app/chat/sidebar/index.tsx
+++ b/apps/desktop/src/app/chat/sidebar/index.tsx
@@ -99,6 +99,7 @@ import { type AppView, ARTIFACTS_ROUTE, MESSAGING_ROUTE, SKILLS_ROUTE } from '..
 import { SidebarPanelLabel } from '../../shell/sidebar-label'
 import type { SidebarNavItem } from '../../types'
 
+import { sidebarSessionsSectionRootClassName } from './classes'
 import { SidebarCronJobsSection } from './cron-jobs-section'
 import { SidebarLoadMoreRow } from './load-more-row'
 import { resolveManualSessionOrderIds } from './order'
@@ -1332,7 +1333,7 @@ function SidebarSessionsSection({
   const resolvedContentClassName = cn(contentClassName, flatVirtualized && 'overflow-y-visible')
 
   return (
-    <SidebarGroup className={rootClassName}>
+    <SidebarGroup className={sidebarSessionsSectionRootClassName(rootClassName, open)}>
       <SidebarSectionHeader
         action={headerAction}
         icon={labelIcon}


### PR DESCRIPTION
## Summary
- collapse sidebar session sections to header-sized roots when closed
- preserve expanded virtualized/compact layout classes
- add focused tests for flexing and non-flex section roots

Closes #46881

## Tests
- npm --workspace apps/desktop run test:ui -- src/app/chat/sidebar/classes.test.ts src/app/chat/sidebar/order.test.ts src/app/chat/sidebar/workspace-groups.test.ts
- npm --workspace apps/desktop run typecheck
- git diff --check