### PR TITLE
fix: require confirmation before debug share uploads

### DIFF
--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -3638,8 +3638,14 @@ class GatewaySlashCommandsMixin:
         from hermes_cli.debug import (
             _capture_dump, collect_debug_report,
             upload_to_pastebin, _schedule_auto_delete,
-            _GATEWAY_PRIVACY_NOTICE, _best_effort_sweep_expired_pastes,
+            _GATEWAY_PRIVACY_NOTICE, _GATEWAY_DEBUG_CONFIRM_TEXT,
+            _best_effort_sweep_expired_pastes,
         )
+
+        args = event.get_command_args().strip().lower()
+        action = args.split()[0] if args else ""
+        if action not in {"confirm", "yes", "upload"}:
+            return "\n\n".join([_GATEWAY_PRIVACY_NOTICE, _GATEWAY_DEBUG_CONFIRM_TEXT])
 
         loop = asyncio.get_running_loop()
 

--- a/hermes_cli/debug.py
+++ b/hermes_cli/debug.py
@@ -197,7 +197,14 @@ _PRIVACY_NOTICE = """\
     contains conversation content, tool outputs, and file paths)
 
 Pastes auto-delete after 6 hours.
+
+Type UPLOAD to confirm, or rerun with --local to inspect without uploading.
 """
+
+_GATEWAY_DEBUG_CONFIRM_TEXT = (
+    "To upload the debug report, run `/debug confirm`. "
+    "Run `hermes debug share --local` on the host to inspect locally without uploading."
+)
 
 _GATEWAY_PRIVACY_NOTICE = (
     "⚠️ **Privacy notice:** This uploads system info + recent log tails "
@@ -691,6 +698,29 @@ def build_debug_share(
     )
 
 
+def _debug_upload_confirmed(args) -> bool:
+    """Return True only after explicit user confirmation for paste uploads."""
+    if getattr(args, "yes", False) or getattr(args, "confirm_upload", False):
+        return True
+    if not sys.stdin.isatty():
+        print(
+            "\nUpload cancelled: debug share uploads require explicit confirmation.\n"
+            "Run `hermes debug share --local` to inspect locally, or add `--yes` "
+            "after reviewing the privacy notice.",
+            file=sys.stderr,
+        )
+        return False
+    try:
+        response = input("Type UPLOAD to send this report to a public paste service: ")
+    except (EOFError, KeyboardInterrupt):
+        print("\nUpload cancelled.", file=sys.stderr)
+        return False
+    if response.strip() == "UPLOAD":
+        return True
+    print("\nUpload cancelled.", file=sys.stderr)
+    return False
+
+
 def run_debug_share(args):
     """Collect debug report + full logs, upload each, print URLs."""
     log_lines = getattr(args, "lines", 200)
@@ -741,6 +771,8 @@ def run_debug_share(args):
         return
 
     print(_PRIVACY_NOTICE)
+    if not _debug_upload_confirmed(args):
+        sys.exit(1)
     print("Collecting debug report...")
     print("Uploading...")
 

--- a/hermes_cli/subcommands/debug.py
+++ b/hermes_cli/subcommands/debug.py
@@ -64,6 +64,16 @@ Examples:
             "into the public paste service."
         ),
     )
+    share_parser.add_argument(
+        "--yes",
+        "--confirm-upload",
+        dest="yes",
+        action="store_true",
+        help=(
+            "Confirm that debug logs may be uploaded to a public paste service. "
+            "Required for non-interactive use."
+        ),
+    )
     delete_parser = debug_sub.add_parser(
         "delete",
         help="Delete a paste uploaded by 'hermes debug share'",

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -2049,6 +2049,9 @@ async def run_config_migrate():
 
 
 class DebugShareRequest(BaseModel):
+    # Uploads leave the machine and go to a public paste service. Dashboard
+    # callers must explicitly opt in so accidental button/API hits fail closed.
+    confirm_upload: bool = False
     # Redaction is ON by default — force-mode scrubs credential-shaped tokens
     # out of log content before it leaves the machine. The toggle exists so an
     # operator who knows the logs are clean can opt out for fuller fidelity.
@@ -2068,9 +2071,18 @@ async def run_debug_share_endpoint(body: DebugShareRequest | None = None):
     dashboard renders those as real, copyable links instead of scraping a log
     tail. Pastes auto-delete after 6 hours (handled inside the share core).
     """
-    from hermes_cli.debug import build_debug_share
+    from hermes_cli.debug import _PRIVACY_NOTICE, build_debug_share
 
     req = body or DebugShareRequest()
+    if not bool(req.confirm_upload):
+        raise HTTPException(
+            status_code=409,
+            detail={
+                "error": "debug_share_confirmation_required",
+                "message": "Debug share uploads may expose private data. Re-submit with confirm_upload=true after reviewing the privacy notice.",
+                "privacy_notice": _PRIVACY_NOTICE,
+            },
+        )
     try:
         result = await asyncio.to_thread(
             build_debug_share,

--- a/tests/gateway/test_debug_command.py
+++ b/tests/gateway/test_debug_command.py
@@ -30,10 +30,23 @@ def _make_runner():
 
 
 class TestHandleDebugCommand:
+
+    @pytest.mark.asyncio
+    async def test_debug_requires_confirmation_before_upload(self):
+        runner = _make_runner()
+        event = _make_event()
+
+        with patch("hermes_cli.debug.upload_to_pastebin") as mock_upload:
+            result = await runner._handle_debug_command(event)
+
+        mock_upload.assert_not_called()
+        assert "Privacy notice" in result
+        assert "/debug confirm" in result
+
     @pytest.mark.asyncio
     async def test_debug_sweeps_expired_pastes_before_upload(self):
         runner = _make_runner()
-        event = _make_event()
+        event = _make_event("/debug confirm")
 
         with patch("hermes_cli.debug._sweep_expired_pastes", return_value=(0, 0)) as mock_sweep, \
              patch("hermes_cli.debug._capture_dump", return_value="dump"), \
@@ -48,7 +61,7 @@ class TestHandleDebugCommand:
     @pytest.mark.asyncio
     async def test_debug_survives_sweep_failure(self):
         runner = _make_runner()
-        event = _make_event()
+        event = _make_event("/debug confirm")
 
         with patch("hermes_cli.debug._sweep_expired_pastes", side_effect=RuntimeError("offline")), \
              patch("hermes_cli.debug._capture_dump", return_value="dump"), \

--- a/tests/hermes_cli/test_dashboard_admin_endpoints.py
+++ b/tests/hermes_cli/test_dashboard_admin_endpoints.py
@@ -870,7 +870,10 @@ class TestDebugShareEndpoint:
         monkeypatch.setattr(dbg, "_best_effort_sweep_expired_pastes", lambda: None)
         monkeypatch.setattr("hermes_cli.dump.run_dump", lambda a: None)
 
-        r = self.client.post("/api/ops/debug-share", json={"redact": True})
+        r = self.client.post(
+            "/api/ops/debug-share",
+            json={"redact": True, "confirm_upload": True},
+        )
         assert r.status_code == 200
         body = r.json()
         assert body["ok"] is True
@@ -889,7 +892,10 @@ class TestDebugShareEndpoint:
         monkeypatch.setattr(dbg, "_best_effort_sweep_expired_pastes", lambda: None)
         monkeypatch.setattr("hermes_cli.dump.run_dump", lambda a: None)
 
-        r = self.client.post("/api/ops/debug-share", json={"redact": False})
+        r = self.client.post(
+            "/api/ops/debug-share",
+            json={"redact": False, "confirm_upload": True},
+        )
         assert r.status_code == 200
         assert r.json()["redacted"] is False
 
@@ -904,7 +910,7 @@ class TestDebugShareEndpoint:
         monkeypatch.setattr("hermes_cli.dump.run_dump", lambda a: None)
 
         # No JSON body at all — should default redact=True.
-        r = self.client.post("/api/ops/debug-share")
+        r = self.client.post("/api/ops/debug-share", json={"confirm_upload": True})
         assert r.status_code == 200
         assert r.json()["redacted"] is True
 
@@ -920,8 +926,31 @@ class TestDebugShareEndpoint:
         monkeypatch.setattr(dbg, "_best_effort_sweep_expired_pastes", lambda: None)
         monkeypatch.setattr("hermes_cli.dump.run_dump", lambda a: None)
 
-        r = self.client.post("/api/ops/debug-share", json={"redact": True})
+        r = self.client.post(
+            "/api/ops/debug-share",
+            json={"redact": True, "confirm_upload": True},
+        )
         assert r.status_code == 502
+
+
+    def test_requires_upload_confirmation_before_paste(self, monkeypatch):
+        import hermes_cli.debug as dbg
+
+        called = {"upload": False}
+
+        def _upload(content, expiry_days=7):
+            called["upload"] = True
+            return "https://paste.rs/x"
+
+        monkeypatch.setattr(dbg, "upload_to_pastebin", _upload)
+
+        r = self.client.post("/api/ops/debug-share", json={"redact": True})
+
+        assert r.status_code == 409
+        body = r.json()["detail"]
+        assert body["error"] == "debug_share_confirmation_required"
+        assert "public paste service" in body["privacy_notice"]
+        assert called["upload"] is False
 
     def test_requires_session_token(self):
         # Drop the token header and confirm the global auth gate rejects it.

--- a/tests/hermes_cli/test_debug.py
+++ b/tests/hermes_cli/test_debug.py
@@ -483,6 +483,67 @@ class TestCollectDebugReport:
 class TestRunDebugShare:
     """Test the run_debug_share CLI handler."""
 
+    def test_share_requires_confirmation_before_upload(self, hermes_home, capsys, monkeypatch):
+        """Non-interactive debug share fails closed before any paste upload."""
+        from hermes_cli.debug import run_debug_share
+
+        args = MagicMock()
+        args.lines = 50
+        args.expire = 7
+        args.local = False
+        args.yes = False
+        args.confirm_upload = False
+        monkeypatch.setattr("sys.stdin.isatty", lambda: False)
+
+        with patch("hermes_cli.debug.upload_to_pastebin") as mock_upload:
+            with pytest.raises(SystemExit) as exc_info:
+                run_debug_share(args)
+
+        assert exc_info.value.code == 1
+        mock_upload.assert_not_called()
+        captured = capsys.readouterr()
+        assert "public paste service" in captured.out
+        assert "require explicit confirmation" in captured.err
+
+    def test_share_prompt_requires_upload_word(self, hermes_home, capsys, monkeypatch):
+        """TTY prompt must receive the exact confirmation word before uploading."""
+        from hermes_cli.debug import run_debug_share
+
+        args = MagicMock()
+        args.lines = 50
+        args.expire = 7
+        args.local = False
+        args.yes = False
+        args.confirm_upload = False
+        monkeypatch.setattr("sys.stdin.isatty", lambda: True)
+        monkeypatch.setattr("builtins.input", lambda prompt="": "nope")
+
+        with patch("hermes_cli.debug.upload_to_pastebin") as mock_upload:
+            with pytest.raises(SystemExit) as exc_info:
+                run_debug_share(args)
+
+        assert exc_info.value.code == 1
+        mock_upload.assert_not_called()
+        assert "Upload cancelled" in capsys.readouterr().err
+
+    def test_share_yes_bypasses_prompt(self, hermes_home, capsys, monkeypatch):
+        """--yes is the explicit non-interactive confirmation path."""
+        from hermes_cli.debug import run_debug_share
+
+        args = MagicMock()
+        args.lines = 50
+        args.expire = 7
+        args.local = False
+        args.yes = True
+        monkeypatch.setattr("sys.stdin.isatty", lambda: False)
+
+        with patch("hermes_cli.dump.run_dump"), \
+             patch("hermes_cli.debug.upload_to_pastebin", return_value="https://paste.rs/ok"):
+            run_debug_share(args)
+
+        assert "https://paste.rs/ok" in capsys.readouterr().out
+
+
     def test_share_sweeps_expired_pastes(self, hermes_home, capsys):
         """Slash-command path should sweep old pending deletes before uploading."""
         from hermes_cli.debug import run_debug_share

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1092,13 +1092,18 @@ export const api = {
   runDump: () => fetchJSON<ActionResponse>("/api/ops/dump", { method: "POST" }),
   runConfigMigrate: () =>
     fetchJSON<ActionResponse>("/api/ops/config-migrate", { method: "POST" }),
-  runDebugShare: (opts?: { redact?: boolean; lines?: number }) =>
+  runDebugShare: (opts?: {
+    redact?: boolean;
+    lines?: number;
+    confirmUpload?: boolean;
+  }) =>
     fetchJSON<DebugShareResponse>("/api/ops/debug-share", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({
         redact: opts?.redact ?? true,
         lines: opts?.lines ?? 200,
+        confirm_upload: opts?.confirmUpload ?? false,
       }),
     }),
 

--- a/web/src/pages/SystemPage.tsx
+++ b/web/src/pages/SystemPage.tsx
@@ -363,10 +363,18 @@ export default function SystemPage() {
   );
 
   const runDebugShare = useCallback(async () => {
+    const confirmed = window.confirm(
+      "Upload a debug report to a public paste service?\n\n" +
+        "It may include conversation fragments, tool output, local paths, chat IDs, and system fingerprints. Use the local CLI path if you need to inspect it first.",
+    );
+    if (!confirmed) return;
     setSharing(true);
     setShareResult(null);
     try {
-      const res = await api.runDebugShare({ redact: shareRedact });
+      const res = await api.runDebugShare({
+        redact: shareRedact,
+        confirmUpload: true,
+      });
       setShareResult(res);
       const n = Object.keys(res.urls).length;
       showToast(


### PR DESCRIPTION
## Summary
- require explicit confirmation before `hermes debug share` uploads to paste services
- add `--yes` / `--confirm-upload` for deliberate non-interactive CLI uploads while keeping `--local` upload-free
- require `confirm_upload: true` on the dashboard debug-share API and wire the dashboard UI through a browser confirmation
- require `/debug confirm` (or `/debug yes` / `/debug upload`) before gateway paste upload

## Issue
Refs #22016

## Verification
- `python -m pytest tests/hermes_cli/test_debug.py tests/hermes_cli/test_dashboard_admin_endpoints.py tests/gateway/test_debug_command.py tests/hermes_cli/test_subcommands_batch.py -q -o 'addopts='` — 176 passed
- `npm run typecheck --workspace web`
- `git diff --check`
- `python -m compileall hermes_cli/debug.py hermes_cli/subcommands/debug.py hermes_cli/web_server.py gateway/slash_commands.py`

## Review
Codex review: no discrete introduced bug found after wiring CLI, gateway, dashboard API, and dashboard UI confirmation paths.
