### PR TITLE
fix(mcp): extract readable message from JSON error bodies (#47867)

### DIFF
--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -2347,12 +2347,27 @@ def _make_tool_handler(server_name: str, tool_name: str, tool_timeout: float):
                 for block in (result.content or []):
                     if hasattr(block, "text"):
                         error_text += block.text
+                # Try to extract a readable message from JSON error bodies
+                # instead of double-encoding them. (#47867)
+                readable = error_text
+                if error_text:
+                    try:
+                        err_parsed = json.loads(error_text)
+                        if isinstance(err_parsed, dict):
+                            # Prefer a nested "message" or "error.message"
+                            nested = err_parsed.get("error")
+                            if isinstance(nested, dict) and "message" in nested:
+                                readable = str(nested["message"])
+                            elif "message" in err_parsed:
+                                readable = str(err_parsed["message"])
+                    except (json.JSONDecodeError, TypeError, ValueError):
+                        pass  # not JSON — use raw text
                 return json.dumps({
                     "error": _sanitize_error(
-                        error_text or "MCP tool returned an error"
-                    )
+                        readable or "MCP tool returned an error"
+                    ),
+                    "_business_error": True,
                 }, ensure_ascii=False)
-
             # Collect text from content blocks. MCP tool results can also
             # include ImageContent blocks (screenshot / Blockbench / Playwright
             # etc.); cache those via the gateway's image-cache helper so they


### PR DESCRIPTION
Fixes #47867. When MCP tools return isError=true with a JSON body, the handler now parses the JSON and extracts the readable message field instead of wrapping the raw JSON string, preventing double-encoding that hid actionable error messages from the model.