### PR TITLE
fix(memory): retry memory provider load once with 100ms delay to absorb startup race

### DIFF
--- a/plugins/memory/__init__.py
+++ b/plugins/memory/__init__.py
@@ -198,6 +198,15 @@ def load_memory_provider(name: str) -> Optional["MemoryProvider"]:
         provider = _load_provider_from_dir(provider_dir)
         if provider:
             return provider
+        # Retry once with a short delay — on cold starts the provider
+        # plugin's register() may not have completed yet (race between
+        # module exec and provider instance capture).  #47954
+        import time
+        time.sleep(0.1)
+        provider = _load_provider_from_dir(provider_dir)
+        if provider:
+            logger.debug("Memory provider '%s' loaded on retry", name)
+            return provider
         logger.warning("Memory provider '%s' loaded but no provider instance found", name)
         return None
     except Exception as e:


### PR DESCRIPTION
## Description

On cold starts with memory providers like honcho, `load_memory_provider()`
fires a WARNING less than 4ms before the provider actually registers,
due to a transient race between module exec and provider instance capture
in the collector pattern (\`_ProviderCollector\`).

This PR adds a single retry with a 100ms sleep — imperceptible on the
happy path and eliminates the spurious WARNING that appeared on every
session start.

## Changes

- **plugins/memory/__init__.py**: In `load_memory_provider()`, retry
  `_load_provider_from_dir()` once after 100ms if the first attempt
  returns no provider instance. Log at DEBUG if the retry succeeds;
  only warn if both attempts fail.

## Testing

- Existing tests continue to pass (logic is additive — existing path
  is unchanged on success)
- On cold start with honcho provider, the WARNING is no longer emitted

Closes #47954