### PR TITLE
fix(plugins): retry memory provider load to avoid startup race warning

### DIFF
--- a/plugins/memory/__init__.py
+++ b/plugins/memory/__init__.py
@@ -198,6 +198,15 @@ def load_memory_provider(name: str) -> Optional["MemoryProvider"]:
         provider = _load_provider_from_dir(provider_dir)
         if provider:
             return provider
+        # The general plugin system may be concurrently registering this
+        # provider in a background task.  A single brief retry avoids a
+        # spurious WARNING on every cold start when the provider arrives
+        # milliseconds later.  (#47954)
+        import time
+        time.sleep(0.1)
+        provider = _load_provider_from_dir(provider_dir)
+        if provider:
+            return provider
         logger.warning("Memory provider '%s' loaded but no provider instance found", name)
         return None
     except Exception as e:

--- a/tests/agent/test_memory_provider.py
+++ b/tests/agent/test_memory_provider.py
@@ -435,6 +435,35 @@ class TestPluginMemoryDiscovery:
         from plugins.memory import load_memory_provider
         assert load_memory_provider("nonexistent_provider") is None
 
+    def test_retry_succeeds_on_second_attempt(self, monkeypatch):
+        """load_memory_provider retries once when first probe finds no provider.
+
+        Regression test for #47954: the plugin system may register the
+        provider milliseconds after the initial probe.  A single brief
+        retry avoids a spurious WARNING on every cold start.
+        """
+        from plugins.memory import load_memory_provider
+
+        call_count = {"n": 0}
+        fake_provider = type("FakeProvider", (), {
+            "name": "fake",
+            "is_available": lambda self: True,
+        })()
+
+        def patched_load(provider_dir):
+            call_count["n"] += 1
+            if call_count["n"] == 1:
+                return None  # first probe: provider not ready yet
+            return fake_provider  # second probe: provider registered
+
+        monkeypatch.setattr("plugins.memory._load_provider_from_dir", patched_load)
+        monkeypatch.setattr("plugins.memory.find_provider_dir", lambda name: "/fake/dir")
+        monkeypatch.setattr("time.sleep", lambda s: None)
+
+        result = load_memory_provider("fake")
+        assert result is fake_provider
+        assert call_count["n"] == 2  # retried once
+
 
 class TestUserInstalledProviderDiscovery:
     """Memory providers installed to $HERMES_HOME/plugins/ should be found.


### PR DESCRIPTION
## What does this PR do?

Adds a single brief retry (100 ms) to `load_memory_provider()` so that when the general plugin system registers a memory provider milliseconds after the initial probe, the provider is found on the second attempt instead of logging a spurious WARNING on every cold start.

## Related Issue

Fixes #47954

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `plugins/memory/__init__.py`: After the first `_load_provider_from_dir()` call returns None, wait 100 ms and retry once before logging the WARNING. This handles the race condition where the plugin system registers the provider concurrently.
- `tests/agent/test_memory_provider.py`: Added `test_retry_succeeds_on_second_attempt` — verifies that `load_memory_provider()` returns the provider on the second probe when the first probe finds nothing.

## How to Test

1. Run `python -m pytest tests/agent/test_memory_provider.py -x -q` — all 92 tests should pass, including the new `test_retry_succeeds_on_second_attempt`.
2. Set `memory.provider: honcho` in config.yaml with the honcho plugin enabled.
3. Start a fresh Hermes session and check `~/.hermes/logs/agent.log` — the "Memory provider 'honcho' loaded but no provider instance found" WARNING should no longer appear.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/agent/test_memory_provider.py -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `plugins/memory/__init__.py::load_memory_provider` (callers: 4 in codebase, flows: agent_init → memory_manager)
- Blast radius: LOW — only adds a retry wrapper; existing callers unaffected when provider loads on first attempt
- Related patterns: Race condition mitigation via brief retry; similar to flaky-test re-run patterns
