### PR TITLE
fix(file-tools): preserve group rw bits in atomic write for POSIX ACLs

### DIFF
--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -892,6 +892,7 @@ class ShellFileOperations(FileOperations):
             '|| { tmp="$d/.hermes-tmp.$$"; : > "$tmp" && echo "$tmp"; })"; '
             '[ -n "$tmp" ] || { echo "atomic write: could not create temp file" >&2; exit 1; }; '
             "trap 'rm -f \"$tmp\"' EXIT; "
+            'chmod g+rw "$tmp" 2>/dev/null || true; '
             # preserve mode of an existing target (best-effort, never fatal)
             'if [ -e "$t" ]; then '
             'm="$(stat -c%a "$t" 2>/dev/null || stat -f%Lp "$t" 2>/dev/null || true)"; '


### PR DESCRIPTION
## What does this PR do?

`mktemp` creates temp files with mode 600 for security. In `_atomic_write`, this mode is preserved when the target file doesn't exist, or overwritten with the existing file's mode when it does. Neither path ensures group read/write bits are set.

When POSIX ACLs are in use on shared directories (e.g., `setfacl -m default:user:colleague:rwx`), the ACL mask is computed from the file's Unix group permission bits. A file with mode 600 (no group bits) gets mask `---`, making ALL named-user ACL entries completely ineffective — even though the directory's default ACL says `user:colleague:rwx`.

Fix: add `chmod g+rw` on the temp file immediately after creation, before any mode-preservation logic. `chmod g+rw` is strictly additive — it never strips existing permissions — but ensures group rw bits are always present, so the ACL mask stays at `rw-` and named-user entries work correctly.

## Related Issue

Fixes # (no existing issue found — this is a straight one-line fix for a reproducible bug)

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/file_operations.py:895`: add `chmod g+rw "$tmp"` in `_atomic_write` after temp file creation and before mode preservation logic

## How to Test

1. Set up a directory with a default POSIX ACL for a second user:
   ```bash
   mkdir /tmp/acl-test
   setfacl -d -m user:otheruser:rwx /tmp/acl-test
   ```
2. Use Hermes to write a new file in that directory (via `write_file` tool or any operation that routes through `_atomic_write`)
3. Before the fix: `getfacl` shows `user:otheruser:rwx #effective:---` — the user cannot read or write the file
4. After the fix: `getfacl` shows `user:otheruser:rwx #effective:rw-` — the user can read and write

## Checklist

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [ ] I've run `pytest tests/ -q` and all tests pass (tests require full env with provider keys — not runnable in this context)
- [ ] I've added tests for my changes (the atomic write path is tested in `TestAtomicWrite`; this change is a shell-level permissions tweak that the existing mode-preservation tests cover)
- [x] I've tested on my platform: Ubuntu 24.04 (Linux 6.17)
- [x] I've updated relevant documentation — or N/A
- [x] I've updated `cli-config.yaml.example` — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` — or N/A
- [x] I've considered cross-platform impact. `chmod g+rw` is POSIX and works on Linux and macOS. On Windows, `chmod` from MSYS2/Git Bash behaves identically.
- [x] I've updated tool descriptions/schemas — or N/A