### PR TITLE
fix(windows): suppress console-window flashes from gateway subprocesses + cache nearest_root

### DIFF
--- a/agent/coding_context.py
+++ b/agent/coding_context.py
@@ -56,6 +56,7 @@ import logging
 import os
 import re
 import subprocess
+import sys
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Optional
@@ -96,6 +97,10 @@ _MAX_VERIFY_COMMANDS = 8
 _MAX_FACT_FILE_BYTES = 256 * 1024
 
 _GIT_TIMEOUT = 2.5
+
+# Win32 CREATE_NO_WINDOW — suppress the console flash when the windowless
+# gateway shells out to git to build per-turn coding context. 0 elsewhere.
+_NO_WINDOW = 0x08000000 if sys.platform == "win32" else 0
 
 
 # Per-model edit-format steering. Matching the edit tool format to how a model
@@ -594,6 +599,7 @@ def _git(cwd: Path, *args: str) -> str:
             capture_output=True,
             text=True,
             timeout=_GIT_TIMEOUT,
+            creationflags=_NO_WINDOW,
         )
     except (OSError, subprocess.SubprocessError):
         return ""

--- a/agent/context_references.py
+++ b/agent/context_references.py
@@ -7,11 +7,16 @@ import mimetypes
 import os
 import re
 import subprocess
+import sys
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Awaitable, Callable
 
 from agent.model_metadata import estimate_tokens_rough
+
+# Win32 CREATE_NO_WINDOW — suppress the console flash when the windowless
+# gateway shells out to git/rg to resolve @-file references. 0 elsewhere.
+_NO_WINDOW = 0x08000000 if sys.platform == "win32" else 0
 
 _QUOTED_REFERENCE_VALUE = r'(?:`[^`\n]+`|"[^"\n]+"|\'[^\'\n]+\')'
 REFERENCE_PATTERN = re.compile(
@@ -298,6 +303,7 @@ def _expand_git_reference(
             text=True,
             timeout=30,
             stdin=subprocess.DEVNULL,
+            creationflags=_NO_WINDOW,
         )
     except subprocess.TimeoutExpired:
         return f"{ref.raw}: git command timed out (30s)", None
@@ -491,6 +497,7 @@ def _rg_files(path: Path, cwd: Path, limit: int) -> list[Path] | None:
             text=True,
             timeout=10,
             stdin=subprocess.DEVNULL,
+            creationflags=_NO_WINDOW,
         )
     except (FileNotFoundError, OSError, subprocess.TimeoutExpired):
         return None

--- a/agent/lsp/client.py
+++ b/agent/lsp/client.py
@@ -259,8 +259,15 @@ class LSPClient:
             env.update(self._env)
 
         cmd = self._command
+        creationflags = 0
         if sys.platform == "win32":
             cmd = self._win_wrap_cmd(cmd)
+            # Suppress the cmd.exe console window that would otherwise
+            # flash every time we launch a ``.cmd``-wrapped language
+            # server (e.g. pyright-langserver.CMD). CREATE_NO_WINDOW.
+            from hermes_cli._subprocess_compat import windows_hide_flags
+
+            creationflags = windows_hide_flags()
 
         try:
             self._proc = await asyncio.create_subprocess_exec(
@@ -271,6 +278,7 @@ class LSPClient:
                 stderr=asyncio.subprocess.PIPE,
                 env=env,
                 cwd=self._cwd,
+                creationflags=creationflags,
             )
         except FileNotFoundError as e:
             raise LSPProtocolError(

--- a/agent/lsp/install.py
+++ b/agent/lsp/install.py
@@ -37,6 +37,11 @@ from typing import Any, Dict, Optional
 
 logger = logging.getLogger("agent.lsp.install")
 
+# Win32 CREATE_NO_WINDOW — suppress the console window that flashes when
+# we shell out to npm/pip/go (all ``.cmd``/console apps on Windows) to
+# auto-install a language server. 0 on non-Windows so the kwarg is inert.
+_NO_WINDOW = 0x08000000 if sys.platform == "win32" else 0
+
 # Package-name → install-strategy hint registry.  Each entry is a
 # tuple of strategy name + package name + executable name.  When the
 # install completes, we look for the executable in
@@ -263,6 +268,7 @@ def _install_npm(
             text=True,
             timeout=300,
             stdin=subprocess.DEVNULL,
+            creationflags=_NO_WINDOW,
         )
         if proc.returncode != 0:
             logger.warning(
@@ -312,6 +318,7 @@ def _install_go(pkg: str, bin_name: str) -> Optional[str]:
             timeout=600,
             env=env,
             stdin=subprocess.DEVNULL,
+            creationflags=_NO_WINDOW,
         )
         if proc.returncode != 0:
             logger.warning(
@@ -350,6 +357,7 @@ def _install_pip(pkg: str, bin_name: str) -> Optional[str]:
             text=True,
             timeout=300,
             stdin=subprocess.DEVNULL,
+            creationflags=_NO_WINDOW,
         )
         if proc.returncode != 0:
             logger.warning(

--- a/agent/lsp/workspace.py
+++ b/agent/lsp/workspace.py
@@ -29,6 +29,15 @@ logger = logging.getLogger("agent.lsp.workspace")
 # folds collapse to one entry.
 _workspace_cache: dict = {}
 
+# Cache: (start_dir, markers, excludes, ceiling) → resolved root (or None).
+# ``nearest_root`` is invoked ~5× per file write (via ``enabled_for``,
+# ``_get_or_spawn``, ``_mark_broken_for_file``, and the typescript
+# double-resolve), each time re-stat'ing up to ``markers × parents``
+# paths.  Memoizing collapses that to one walk per (dir, server-marker-set).
+# Same staleness profile as ``_workspace_cache`` — cleared on shutdown /
+# ``hermes lsp restart``.
+_root_cache: dict = {}
+
 
 def normalize_path(path: str) -> str:
     """Normalize a path for use as a stable map key.
@@ -140,6 +149,28 @@ def nearest_root(
     markers_list = list(markers)
     excludes_list = list(excludes) if excludes else []
 
+    cache_key = (
+        str(start_path),
+        tuple(markers_list),
+        tuple(excludes_list),
+        str(ceiling_path) if ceiling_path is not None else None,
+    )
+    if cache_key in _root_cache:
+        return _root_cache[cache_key]
+
+    result = _nearest_root_uncached(
+        start_path, ceiling_path, markers_list, excludes_list
+    )
+    _root_cache[cache_key] = result
+    return result
+
+
+def _nearest_root_uncached(
+    start_path: Path,
+    ceiling_path: Optional[Path],
+    markers_list: list,
+    excludes_list: list,
+) -> Optional[str]:
     cur = start_path
     # Defensive cap matching ``find_git_worktree``.  Bounded walk
     # protects against pathological inputs even though the
@@ -211,6 +242,7 @@ def clear_cache() -> None:
     up stale results from a previous session.
     """
     _workspace_cache.clear()
+    _root_cache.clear()
 
 
 __all__ = [

--- a/tools/checkpoint_manager.py
+++ b/tools/checkpoint_manager.py
@@ -55,6 +55,7 @@ import os
 import re
 import shutil
 import subprocess
+import sys
 import time
 from pathlib import Path
 from hermes_constants import get_hermes_home
@@ -63,6 +64,11 @@ from typing import Dict, List, Optional, Set, Tuple
 from utils import env_int
 
 logger = logging.getLogger(__name__)
+
+# Win32 CREATE_NO_WINDOW — suppress the console window that flashes when
+# the windowless gateway (pythonw.exe) shells out to git for shadow
+# checkpoints on every agent file edit. 0 on non-Windows (inert kwarg).
+_NO_WINDOW = 0x08000000 if sys.platform == "win32" else 0
 
 # ---------------------------------------------------------------------------
 # Constants
@@ -308,6 +314,7 @@ def _run_git(
             env=env,
             cwd=str(normalized_working_dir),
             stdin=subprocess.DEVNULL,
+            creationflags=_NO_WINDOW,
         )
         ok = result.returncode == 0
         stdout = result.stdout.strip()
@@ -428,6 +435,7 @@ def _init_store(store: Path, working_dir: str) -> Optional[str]:
             capture_output=True, text=True,
             env=init_env, timeout=_GIT_TIMEOUT,
             stdin=subprocess.DEVNULL,
+            creationflags=_NO_WINDOW,
         )
         if result.returncode != 0:
             return f"Shadow store init failed: {result.stderr.strip()}"


### PR DESCRIPTION
## What & why

On Windows, the headless gateway runs as `pythonw.exe` (no console). When it shells out to console programs **without** the Win32 `CREATE_NO_WINDOW` flag, a `cmd.exe` window flashes on screen. The worst offenders fire on **every agent file edit / turn**, so the user sees windows popping up repeatedly during normal operation.

This was originally tracked down from `pyright-langserver.CMD` being launched via `cmd.exe /c` by the LSP client (npm shims are `.cmd` files), but the same gap exists in several other gateway-reachable spawn sites.

## Changes

**Console-flash suppression (`CREATE_NO_WINDOW`):**

| File | Spawn | Trigger |
|------|-------|---------|
| `agent/lsp/client.py` | `.cmd`-wrapped language servers (pyright etc.) | LSP diagnostics |
| `agent/lsp/install.py` | npm / pip / go LSP auto-install | first use of a server |
| `tools/checkpoint_manager.py` | shadow-git snapshot | **every file edit** |
| `agent/coding_context.py` | per-turn `git` status/branch | **every turn** |
| `agent/context_references.py` | `git` / `rg` for `@`-file refs | `@` references |

All pass `creationflags` gated on `sys.platform == 'win32'` so the value is an inert `0` on POSIX (still a valid `Popen` kwarg — no behavior change off Windows). `capture_output` is preserved (we hide the window, not detach the process), reusing the existing `windows_hide_flags()` helper where imported.

**Performance:**

- `agent/lsp/workspace.py`: memoize `nearest_root`. It previously did an **uncached** upward filesystem walk (markers × parent dirs of `.exists()` stat calls) and is invoked ~5× per file write (via `enabled_for`, `_get_or_spawn`, `_mark_broken_for_file`, and the typescript double-resolve). Adds `_root_cache` mirroring the existing `_workspace_cache`, cleared in `clear_cache()` — same staleness profile as the git-worktree cache (reset on shutdown / `hermes lsp restart`).

## Testing

- All 6 modules import cleanly.
- `tests/agent/lsp/` suites pass (workspace, service, install, broken-set, backend-gate): **42 passed**. The one pre-existing failure `test_normalize_path_expands_tilde` is an unrelated Windows `HOME`/`USERPROFILE` quirk present on `main` and untouched here.
- Added a manual functional check confirming `nearest_root` cache hit/miss consistency, population, and `clear_cache()` reset.

## Notes

- No behavior change on Linux/macOS (the flag resolves to `0`).
- The LSP client architecture already pools language-server clients by `(server_id, root)` and reuses them — there is **no** per-write process churn; the window-flash was purely a spawn-flag omission.
