### PR TITLE
fix(cron): remove leaked "blueprint" jargon from meal-plan prompt

### DIFF
--- a/cron/blueprint_catalog.py
+++ b/cron/blueprint_catalog.py
@@ -371,7 +371,7 @@ CATALOG: List[AutomationBlueprint] = [
         prompt_template=(
             "Build the user a meal plan for the coming week: {meals} per day, "
             "suited to a {diet} diet and roughly {effort} cooking effort. "
-            "Include a consolidated grocery list grouped by aisle. Keep blueprints "
+            "Include a consolidated grocery list grouped by aisle. Keep the plan "
             "simple and skimmable."
         ),
         slots=[

--- a/tests/cron/test_blueprint_catalog.py
+++ b/tests/cron/test_blueprint_catalog.py
@@ -73,6 +73,29 @@ class TestScheduleResolution:
         assert spec["schedule"] == "0 8 * * *"
 
 
+class TestAllBlueprints:
+    """Catalog-wide invariants — guard every entry, not just the spot-checks above."""
+
+    @pytest.mark.parametrize("blueprint", CATALOG, ids=lambda b: b.key)
+    def test_defaults_render_without_leftover_placeholders(self, blueprint):
+        # Filling with defaults must resolve every {slot} in both the schedule
+        # and the prompt. A leftover "{...}" means a template references a slot
+        # the blueprint doesn't define (or a renamed one).
+        spec = fill_blueprint(blueprint, {})
+        assert "{" not in spec["schedule"] and "}" not in spec["schedule"], spec["schedule"]
+        assert "{" not in spec["prompt"] and "}" not in spec["prompt"], spec["prompt"]
+        # Non-passthrough schedules are standard 5-field cron expressions.
+        assert len(spec["schedule"].split()) == 5, spec["schedule"]
+
+    @pytest.mark.parametrize("blueprint", CATALOG, ids=lambda b: b.key)
+    def test_prompt_has_no_internal_jargon(self, blueprint):
+        # prompt_template is the instruction sent to the agent at run time. It
+        # talks to the user about their automation (meals, news, habits…), so it
+        # must not leak the internal "blueprint" concept — a class of bug left
+        # behind by the plan->blueprint rename.
+        assert "blueprint" not in blueprint.prompt_template.lower(), blueprint.key
+
+
 class TestValidation:
     def test_invalid_time_rejected(self):
         with pytest.raises(BlueprintFillError, match="invalid time"):


### PR DESCRIPTION
### What

The `meal-plan` automation blueprint's `prompt_template` in `cron/blueprint_catalog.py` ended with:

> Include a consolidated grocery list grouped by aisle. **Keep blueprints simple and skimmable.**

That `blueprints` is a leftover from the `plan` → `blueprint` rename. `prompt_template` is the instruction actually sent to the agent when the cron job runs, and the sentence is about the user's *meal plan*, not the internal blueprint system — so the agent gets a confusing instruction referencing an internal concept.

### Why

`prompt_template` strings are user-facing runtime instructions. They should talk about the user's automation (meals, news, habits…), never the internal "blueprint" machinery. This is a small correctness/clarity bug.

### Fix

- Reword to "Keep the plan simple and skimmable."
- Add two catalog-wide regression tests (the existing tests only spot-check a few entries), each parametrized over all of `CATALOG`:
  - `test_defaults_render_without_leftover_placeholders` — every blueprint fills with defaults to a clean 5-field cron and a prompt with no leftover `{placeholders}`.
  - `test_prompt_has_no_internal_jargon` — no `prompt_template` leaks the internal "blueprint" word.

### How to test

```bash
python -m pytest tests/cron/test_blueprint_catalog.py -q
```

`test_prompt_has_no_internal_jargon[meal-plan]` fails before the wording fix and passes after; full file is 55 passed.

### Platforms

Tested on macOS (Python 3.12). Change is pure-Python string/test, platform-independent.