### PR TITLE
fix(tests): type-correct OpenViking skill-scaffolding test sentinels

### DIFF
--- a/tests/openviking_plugin/test_openviking.py
+++ b/tests/openviking_plugin/test_openviking.py
@@ -1,6 +1,7 @@
 """Tests for plugins/memory/openviking/__init__.py — URI normalization and payload handling."""
 
 import json
+from typing import Any, cast
 
 import plugins.memory.openviking as openviking_plugin
 from plugins.memory.openviking import OpenVikingMemoryProvider
@@ -127,7 +128,7 @@ class TestOpenVikingSkillQuerySafety:
         RecordingVikingClient.calls = []
         monkeypatch.setattr(openviking_plugin, "_VikingClient", RecordingVikingClient)
         provider = OpenVikingMemoryProvider()
-        provider._client = object()
+        provider._client = cast(Any, object())
         provider._endpoint = "http://openviking.test"
         provider._api_key = ""
         provider._account = "default"
@@ -143,6 +144,7 @@ class TestOpenVikingSkillQuerySafety:
         )
 
         provider.queue_prefetch(skill_message)
+        assert provider._prefetch_thread is not None
         provider._prefetch_thread.join(timeout=5.0)
 
         assert RecordingVikingClient.calls == [
@@ -156,7 +158,7 @@ class TestOpenVikingSkillQuerySafety:
         RecordingVikingClient.calls = []
         monkeypatch.setattr(openviking_plugin, "_VikingClient", RecordingVikingClient)
         provider = OpenVikingMemoryProvider()
-        provider._client = object()
+        provider._client = cast(Any, object())
         provider._endpoint = "http://openviking.test"
         provider._api_key = ""
         provider._account = "default"
@@ -173,6 +175,7 @@ class TestOpenVikingSkillQuerySafety:
         )
 
         provider.queue_prefetch(skill_message)
+        assert provider._prefetch_thread is not None
         provider._prefetch_thread.join(timeout=5.0)
 
         assert RecordingVikingClient.calls == [
@@ -186,7 +189,7 @@ class TestOpenVikingSkillQuerySafety:
         RecordingVikingClient.calls = []
         monkeypatch.setattr(openviking_plugin, "_VikingClient", RecordingVikingClient)
         provider = OpenVikingMemoryProvider()
-        provider._client = object()
+        provider._client = cast(Any, object())
         skill_message = (
             '[IMPORTANT: The user has invoked the "skill-creator" skill, indicating they want '
             "you to follow its instructions. The full skill content is loaded below.]\n\n"
@@ -203,7 +206,7 @@ class TestOpenVikingSkillQuerySafety:
         RecordingVikingClient.calls = []
         monkeypatch.setattr(openviking_plugin, "_VikingClient", RecordingVikingClient)
         provider = OpenVikingMemoryProvider()
-        provider._client = object()
+        provider._client = cast(Any, object())
         provider._endpoint = "http://openviking.test"
         provider._api_key = ""
         provider._account = "default"
@@ -220,6 +223,7 @@ class TestOpenVikingSkillQuerySafety:
         )
 
         provider.sync_turn(skill_message, "Done.")
+        assert provider._sync_thread is not None
         provider._sync_thread.join(timeout=5.0)
 
         assert RecordingVikingClient.calls == [
@@ -237,7 +241,7 @@ class TestOpenVikingSkillQuerySafety:
         RecordingVikingClient.calls = []
         monkeypatch.setattr(openviking_plugin, "_VikingClient", RecordingVikingClient)
         provider = OpenVikingMemoryProvider()
-        provider._client = object()
+        provider._client = cast(Any, object())
         skill_message = (
             '[IMPORTANT: The user has invoked the "skill-creator" skill, indicating they want '
             "you to follow its instructions. The full skill content is loaded below.]\n\n"


### PR DESCRIPTION
## Problem
The skill-scaffolding regression tests added in #47311 (cherry-picked from @ehz0ah's #32663, commit e3adbb5ae9) introduced new `ty` diagnostics on main: assigning a bare `object()` to the typed `_client: Optional[_VikingClient]` field, and calling `.join()` on `_{sync,prefetch}_thread`, typed `Optional[threading.Thread]`. Caught by the lint-diff bot on #47311 (+2 new `ty` issues).

## Fix
Test-only, no production change. Fixes the whole pattern in `tests/openviking_plugin/test_openviking.py`, not just the 2 flagged lines:
- `_client = object()` → `cast(Any, object())` (×5) — the repo's idiomatic sentinel-cast pattern.
- `_{sync,prefetch}_thread.join(...)` now preceded by `assert provider._{sync,prefetch}_thread is not None` (×3) — narrows the Optional for the type checker and documents the invariant that a background thread must have been spawned for that turn.

## Testing
- `scripts/run_tests.sh tests/openviking_plugin/` → 22 passed
- `tests/agent/test_memory_skill_scaffolding.py` → 35 passed (combined)
- `ruff check` clean; `ty check tests/openviking_plugin/test_openviking.py`: 24 → 16 diagnostics (both flagged lines resolved)
- `git diff --check` clean
