### PR TITLE
Add Hugging Face optional MCP catalog entry

### DIFF
--- a/optional-mcps/huggingface/manifest.yaml
+++ b/optional-mcps/huggingface/manifest.yaml
@@ -1,0 +1,38 @@
+# Nous-approved MCP catalog entry.
+# Presence in this directory = approval. Merged via PR review.
+manifest_version: 1
+
+name: huggingface
+description: Search and read Hub models, datasets, and Spaces; generate images via Hugging Face.
+source: https://github.com/huggingface/hf-mcp-server
+
+# Hugging Face runs an official remote MCP server (hf.co/mcp) as a stateless
+# Streamable HTTP service — nothing to install locally. Appending `?login`
+# triggers the OAuth authorization flow so the agent acts as your authenticated
+# Hub account (selected tools + Spaces from huggingface.co/settings/mcp). Hermes's
+# MCP client + mcp_oauth_manager handle PKCE, token exchange, and refresh.
+transport:
+  type: http
+  url: https://huggingface.co/mcp?login
+
+auth:
+  type: oauth
+  # OAuth is the recommended path (scoped, expiring tokens) over a static
+  # HF_TOKEN bearer header. The `?login` suffix on the URL is what tells the
+  # server to negotiate OAuth rather than serve the anonymous tool set.
+
+# Tool selection at install time:
+# The HF MCP exposes Hub search/read tools plus an image generator and any
+# Gradio apps you enable. We leave `default_enabled` unset so the install-time
+# checklist starts with everything pre-checked — users prune what they don't
+# want, and can curate the authoritative set at huggingface.co/settings/mcp.
+
+post_install: |
+  On first connection, Hermes will open a browser to authenticate with Hugging
+  Face. After auth, restart your Hermes session so the tools are loaded.
+
+  Authenticated users curate their tool + Gradio-app set at:
+    https://huggingface.co/settings/mcp
+
+  Re-run the local tool checklist any time with:
+    hermes mcp configure huggingface


### PR DESCRIPTION
## What

Adds a `huggingface` entry to `optional-mcps/` so users can install Hugging Face's official remote MCP server via `hermes mcp install`.

## Details

- **Transport:** remote Streamable HTTP at `https://huggingface.co/mcp?login`
- **Auth:** OAuth — the `?login` suffix tells the server to negotiate OAuth (scoped, expiring tokens) rather than serve the anonymous tool set; handled by Hermes's existing MCP client + `mcp_oauth_manager`
- **Surface:** Hub search/read (models, datasets, Spaces, repo files, model cards) + image generation; authenticated users curate their tool/Gradio-app set at https://huggingface.co/settings/mcp
- Mirrors the existing `optional-mcps/linear` remote-OAuth manifest.

Source: https://github.com/huggingface/hf-mcp-server

## Validation

Loads cleanly through the real catalog loader:

```
hermes_cli.mcp_catalog.list_catalog()  # entry present, transport=http, auth=oauth
hermes_cli.mcp_catalog.catalog_diagnostics()  # []  (no validation errors)
```