### PR TITLE
Add AWS Knowledge optional MCP catalog entry

### DIFF
--- a/optional-mcps/aws-knowledge/manifest.yaml
+++ b/optional-mcps/aws-knowledge/manifest.yaml
@@ -1,0 +1,36 @@
+# Nous-approved MCP catalog entry.
+# Presence in this directory = approval. Merged via PR review.
+manifest_version: 1
+
+name: aws-knowledge
+description: Authoritative AWS docs, API references, What's New, and Well-Architected guidance.
+source: https://awslabs.github.io/mcp/servers/aws-knowledge-mcp-server
+
+# AWS hosts the Knowledge MCP server as a fully managed, public remote service
+# over Streamable HTTP. It is read-only and requires no AWS account, no
+# credentials, and nothing installed locally — just connect. Usage is subject
+# to AWS-side rate limits. Hermes's MCP client connects directly via the URL.
+transport:
+  type: http
+  url: https://knowledge-mcp.global.api.aws
+
+auth:
+  type: none
+  # Public, unauthenticated endpoint. No API key, no AWS account.
+
+# Tool selection at install time:
+# The Knowledge server exposes read-only tools (search_documentation,
+# read_documentation, recommend, plus regional availability lookups). We leave
+# `default_enabled` unset so the install-time checklist starts with everything
+# pre-checked — users prune what they don't want.
+
+post_install: |
+  No authentication is required — the AWS Knowledge MCP server is a public,
+  read-only endpoint. Start a new Hermes session to load the tools.
+
+  Usage is subject to AWS-side rate limits and the AWS Site Terms. For
+  credentialed, write-capable AWS access, use the separate IAM-authenticated
+  AWS MCP server instead.
+
+  Re-run the tool checklist any time with:
+    hermes mcp configure aws-knowledge


### PR DESCRIPTION
## What

Adds an `aws-knowledge` entry to `optional-mcps/` so users can install the AWS Knowledge MCP server via `hermes mcp install`.

## Details

- **Transport:** remote Streamable HTTP at `https://knowledge-mcp.global.api.aws`
- **Auth:** `none` — public, AWS-managed endpoint; no AWS account, no credentials, nothing installed locally (subject to AWS-side rate limits)
- **Surface:** read-only authoritative AWS knowledge — docs, API references, What's New, Builder Center, blog posts, Well-Architected guidance, and regional API/CloudFormation availability
- For credentialed, write-capable AWS access, users should use the separate IAM-authenticated AWS MCP server instead (noted in `post_install`).

Source: https://awslabs.github.io/mcp/servers/aws-knowledge-mcp-server

## Validation

Loads cleanly through the real catalog loader:

```
hermes_cli.mcp_catalog.list_catalog()  # entry present, transport=http, auth=none
hermes_cli.mcp_catalog.catalog_diagnostics()  # []  (no validation errors)
```