### PR TITLE
fix(gateway): support webhook SMS delivery

### DIFF
--- a/gateway/channel_directory.py
+++ b/gateway/channel_directory.py
@@ -70,6 +70,36 @@ def _apply_channel_aliases(platforms: Dict[str, Any]) -> None:
                 })
 
 
+def _inject_configured_home_channels(platforms: Dict[str, Any]) -> None:
+    """Expose configured home channels even before a live adapter discovers them."""
+    try:
+        from gateway.config import load_gateway_config
+        config = load_gateway_config()
+    except Exception:
+        return
+
+    for platform, pconfig in getattr(config, "platforms", {}).items():
+        try:
+            plat_name = platform.value
+        except Exception:
+            plat_name = str(platform)
+        home = getattr(pconfig, "home_channel", None)
+        if not home or not getattr(home, "chat_id", None):
+            continue
+        entries = platforms.setdefault(plat_name, [])
+        if not isinstance(entries, list):
+            continue
+        chat_id = str(home.chat_id)
+        if any(isinstance(e, dict) and e.get("id") == chat_id for e in entries):
+            continue
+        entries.append({
+            "id": chat_id,
+            "name": getattr(home, "name", None) or f"{plat_name.title()} Home",
+            "type": "dm",
+            "thread_id": getattr(home, "thread_id", None),
+        })
+
+
 def _normalize_channel_query(value: str) -> str:
     return value.lstrip("#").strip().lower()
 
@@ -302,17 +332,20 @@ def load_directory() -> Dict[str, Any]:
     """Load the cached channel directory from disk."""
     if not DIRECTORY_PATH.exists():
         base = {"updated_at": None, "platforms": {}}
+        _inject_configured_home_channels(base["platforms"])
         _apply_channel_aliases(base["platforms"])
         return base
     try:
         with open(DIRECTORY_PATH, encoding="utf-8") as f:
             data = json.load(f)
+        _inject_configured_home_channels(data.setdefault("platforms", {}))
         # Re-apply aliases on read so friendly names take effect immediately,
         # even between timed rebuilds and for brand-new alias entries.
         _apply_channel_aliases(data.setdefault("platforms", {}))
         return data
     except Exception:
         base = {"updated_at": None, "platforms": {}}
+        _inject_configured_home_channels(base["platforms"])
         _apply_channel_aliases(base["platforms"])
         return base
 

--- a/gateway/config.py
+++ b/gateway/config.py
@@ -468,7 +468,11 @@ _PLATFORM_CONNECTED_CHECKERS: dict[Platform, Callable[[PlatformConfig], bool]] =
     ),
     Platform.SIGNAL: lambda cfg: bool(cfg.extra.get("http_url")),
     Platform.EMAIL: lambda cfg: bool(cfg.extra.get("address")),
-    Platform.SMS: lambda cfg: bool(os.getenv("TWILIO_ACCOUNT_SID")),
+    Platform.SMS: lambda cfg: bool(
+        os.getenv("TWILIO_ACCOUNT_SID")
+        or os.getenv("SMS_GATEWAY_URL")
+        or cfg.extra.get("gateway_url")
+    ),
     Platform.API_SERVER: lambda cfg: True,
     Platform.WEBHOOK: lambda cfg: True,
     Platform.MSGRAPH_WEBHOOK: lambda cfg: bool(
@@ -1623,13 +1627,17 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
             thread_id=os.getenv("EMAIL_HOME_ADDRESS_THREAD_ID") or None,
         )
 
-    # SMS (Twilio)
+    # SMS (Twilio or outbound-only custom webhook)
     twilio_sid = os.getenv("TWILIO_ACCOUNT_SID")
-    if twilio_sid:
+    sms_gateway_url = os.getenv("SMS_GATEWAY_URL")
+    if twilio_sid or sms_gateway_url:
         if Platform.SMS not in config.platforms:
             config.platforms[Platform.SMS] = PlatformConfig()
         config.platforms[Platform.SMS].enabled = True
         config.platforms[Platform.SMS].api_key = os.getenv("TWILIO_AUTH_TOKEN", "")
+        if sms_gateway_url:
+            config.platforms[Platform.SMS].extra["backend"] = os.getenv("SMS_BACKEND", "webhook")
+            config.platforms[Platform.SMS].extra["gateway_url"] = sms_gateway_url
     sms_home = os.getenv("SMS_HOME_CHANNEL")
     if sms_home and Platform.SMS in config.platforms:
         config.platforms[Platform.SMS].home_channel = HomeChannel(

--- a/gateway/platforms/sms.py
+++ b/gateway/platforms/sms.py
@@ -1,7 +1,7 @@
-"""SMS (Twilio) platform adapter.
+"""SMS platform adapter.
 
-Connects to the Twilio REST API for outbound SMS and runs an aiohttp
-webhook server to receive inbound messages.
+Connects to the Twilio REST API for full inbound/outbound SMS, or to a
+custom outbound webhook for send-only SMS delivery.
 
 Shares credentials with the optional telephony skill — same env vars:
   - TWILIO_ACCOUNT_SID
@@ -16,6 +16,10 @@ Gateway-specific env vars:
   - SMS_ALLOWED_USERS    (comma-separated E.164 phone numbers)
   - SMS_ALLOW_ALL_USERS  (true/false)
   - SMS_HOME_CHANNEL     (phone number for cron delivery)
+  - SMS_BACKEND          (twilio/webhook/auto; auto selects webhook when
+                          SMS_GATEWAY_URL is set and Twilio creds are absent)
+  - SMS_GATEWAY_URL      (custom outbound webhook accepting JSON {to,message})
+  - SMS_GATEWAY_TIMEOUT  (default 20 seconds)
 """
 
 import asyncio
@@ -50,24 +54,35 @@ def check_sms_requirements() -> bool:
         import aiohttp  # noqa: F401
     except ImportError:
         return False
-    return bool(os.getenv("TWILIO_ACCOUNT_SID") and os.getenv("TWILIO_AUTH_TOKEN"))
+    twilio_ready = bool(os.getenv("TWILIO_ACCOUNT_SID") and os.getenv("TWILIO_AUTH_TOKEN"))
+    webhook_ready = bool(os.getenv("SMS_GATEWAY_URL"))
+    return twilio_ready or webhook_ready
 
 
 class SmsAdapter(BasePlatformAdapter):
     """
-    Twilio SMS <-> Hermes gateway adapter.
+    SMS <-> Hermes gateway adapter.
 
-    Each inbound phone number gets its own Hermes session (multi-tenant).
-    Replies are always sent from the configured TWILIO_PHONE_NUMBER.
+    Twilio mode supports inbound and outbound SMS. Webhook mode is outbound-only
+    and exists for custom SMS gateways that accept ``{"to", "message"}`` JSON.
     """
 
     MAX_MESSAGE_LENGTH = MAX_SMS_LENGTH
 
     def __init__(self, config: PlatformConfig):
         super().__init__(config, Platform.SMS)
-        self._account_sid: str = os.environ["TWILIO_ACCOUNT_SID"]
-        self._auth_token: str = os.environ["TWILIO_AUTH_TOKEN"]
+        requested_backend = (
+            os.getenv("SMS_BACKEND")
+            or str(config.extra.get("backend") or "auto")
+        ).strip().lower() or "auto"
+        if requested_backend == "auto":
+            requested_backend = "webhook" if (os.getenv("SMS_GATEWAY_URL") or config.extra.get("gateway_url")) and not os.getenv("TWILIO_ACCOUNT_SID") else "twilio"
+        self._backend: str = requested_backend
+        self._account_sid: str = os.getenv("TWILIO_ACCOUNT_SID", "")
+        self._auth_token: str = os.getenv("TWILIO_AUTH_TOKEN", "") or (config.api_key or "")
         self._from_number: str = os.getenv("TWILIO_PHONE_NUMBER", "")
+        self._gateway_url: str = (os.getenv("SMS_GATEWAY_URL") or str(config.extra.get("gateway_url") or "")).strip()
+        self._gateway_timeout: float = float(os.getenv("SMS_GATEWAY_TIMEOUT", "20") or 20)
         self._webhook_port: int = int(
             os.getenv("SMS_WEBHOOK_PORT", str(DEFAULT_WEBHOOK_PORT))
         )
@@ -89,6 +104,23 @@ class SmsAdapter(BasePlatformAdapter):
     async def connect(self) -> bool:
         import aiohttp
         from aiohttp import web
+
+        if self._backend == "webhook":
+            if not self._gateway_url:
+                msg = "[sms] SMS_BACKEND=webhook but SMS_GATEWAY_URL is not set"
+                logger.error(msg)
+                self._set_fatal_error("sms_missing_gateway_url", msg, retryable=False)
+                return False
+            self._http_session = aiohttp.ClientSession(
+                timeout=aiohttp.ClientTimeout(total=self._gateway_timeout),
+                trust_env=True,
+            )
+            self._running = True
+            logger.info(
+                "[sms] webhook backend ready (outbound only), home: %s",
+                redact_phone(os.getenv("SMS_HOME_CHANNEL", "")),
+            )
+            return True
 
         if not self._from_number:
             msg = "[sms] TWILIO_PHONE_NUMBER not set — cannot send replies"
@@ -163,6 +195,9 @@ class SmsAdapter(BasePlatformAdapter):
         chunks = self.truncate_message(formatted)
         last_result = SendResult(success=True)
 
+        if self._backend == "webhook":
+            return await self._send_via_webhook(chat_id, chunks)
+
         url = f"{TWILIO_API_BASE}/{self._account_sid}/Messages.json"
         headers = {
             "Authorization": self._basic_auth_header(),
@@ -205,6 +240,53 @@ class SmsAdapter(BasePlatformAdapter):
                 await session.close()
 
         return last_result
+
+    async def _send_via_webhook(self, chat_id: str, chunks: list[str]) -> SendResult:
+        """Send SMS chunks through a custom outbound webhook backend."""
+        import aiohttp
+
+        if not self._gateway_url:
+            return SendResult(success=False, error="SMS_GATEWAY_URL is not set")
+
+        session = self._http_session or aiohttp.ClientSession(
+            timeout=aiohttp.ClientTimeout(total=self._gateway_timeout),
+            trust_env=True,
+        )
+        last_response: Any = None
+        try:
+            for chunk in chunks:
+                payload = {"to": chat_id, "message": chunk}
+                try:
+                    async with session.post(self._gateway_url, json=payload) as resp:
+                        text = await resp.text()
+                        try:
+                            body: Any = await resp.json(content_type=None)
+                        except Exception:
+                            body = text
+                        last_response = body
+                        if resp.status >= 400:
+                            logger.error(
+                                "[sms] webhook send failed to %s: %s %s",
+                                redact_phone(chat_id),
+                                resp.status,
+                                str(body)[:300],
+                            )
+                            return SendResult(success=False, error=f"webhook {resp.status}: {str(body)[:300]}", raw_response=body)
+                        if isinstance(body, dict):
+                            failed = int(body.get("failed") or 0)
+                            errors = body.get("errors") or []
+                            if failed or errors:
+                                return SendResult(success=False, error=f"webhook failed={failed} errors={errors}", raw_response=body)
+                except Exception as e:
+                    logger.error("[sms] webhook send error to %s: %s", redact_phone(chat_id), e)
+                    return SendResult(success=False, error=str(e))
+        finally:
+            if not self._http_session and session:
+                await session.close()
+        message_id = ""
+        if isinstance(last_response, dict):
+            message_id = str(last_response.get("message_id") or last_response.get("id") or "")
+        return SendResult(success=True, message_id=message_id, raw_response=last_response)
 
     async def get_chat_info(self, chat_id: str) -> Dict[str, Any]:
         return {"name": chat_id, "type": "dm"}

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -6602,7 +6602,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         elif platform == Platform.SMS:
             from gateway.platforms.sms import SmsAdapter, check_sms_requirements
             if not check_sms_requirements():
-                logger.warning("SMS: aiohttp not installed or TWILIO_ACCOUNT_SID/TWILIO_AUTH_TOKEN not set")
+                logger.warning("SMS: aiohttp not installed or neither Twilio credentials nor SMS_GATEWAY_URL are set")
                 return None
             return SmsAdapter(config)
 

--- a/hermes_cli/status.py
+++ b/hermes_cli/status.py
@@ -444,6 +444,8 @@ def show_status(args):
     for name, (token_var, home_var) in platforms.items():
         token = os.getenv(token_var, "")
         has_token = bool(token)
+        if name == "SMS":
+            has_token = bool(os.getenv("TWILIO_ACCOUNT_SID") or os.getenv("SMS_GATEWAY_URL"))
         
         home_channel = ""
         if home_var:

--- a/tests/gateway/test_sms.py
+++ b/tests/gateway/test_sms.py
@@ -49,11 +49,29 @@ class TestSmsConfigLoading:
             config = load_gateway_config()
             hc = config.platforms[Platform.SMS].home_channel
             assert hc is not None
-            assert hc.chat_id == "+15559876543"
+            assert hc.chat_id == env["SMS_HOME_CHANNEL"]
             assert hc.name == "My Phone"
             assert hc.platform == Platform.SMS
 
-# ── Format / truncate ───────────────────────────────────────────────
+    def test_env_overrides_create_webhook_sms_config(self):
+        from gateway.config import load_gateway_config
+
+        env = {
+            "SMS_BACKEND": "webhook",
+            "SMS_GATEWAY_URL": "https://sms.example/send",
+            "SMS_HOME_CHANNEL": "+155****6543",
+            "SMS_HOME_CHANNEL_NAME": "My Phone",
+        }
+        with patch.dict(os.environ, env, clear=False):
+            config = load_gateway_config()
+            assert Platform.SMS in config.platforms
+            pc = config.platforms[Platform.SMS]
+            assert pc.enabled is True
+            assert pc.extra["backend"] == "webhook"
+            assert pc.home_channel is not None
+            assert pc.home_channel.chat_id == env["SMS_HOME_CHANNEL"]
+
+# ── Format / truncate
 
 class TestSmsFormatAndTruncate:
     """Test SmsAdapter.format_message strips markdown."""
@@ -161,6 +179,18 @@ class TestSmsRequirements:
             except ImportError:
                 assert result is False
 
+    def test_check_sms_requirements_webhook_url(self):
+        from gateway.platforms.sms import check_sms_requirements
+
+        env = {"SMS_GATEWAY_URL": "https://sms.example/send"}
+        with patch.dict(os.environ, env, clear=True):
+            result = check_sms_requirements()
+            try:
+                import aiohttp  # noqa: F401
+                assert result is True
+            except ImportError:
+                assert result is False
+
 
 # ── Toolset verification ───────────────────────────────────────────
 
@@ -227,7 +257,9 @@ class TestStartupGuard:
         env = {
             "TWILIO_ACCOUNT_SID": "ACtest",
             "TWILIO_AUTH_TOKEN": "tok",
-            "TWILIO_PHONE_NUMBER": "+15550001111",
+            "TWILIO_PHONE_NUMBER": "+155****1111",
+            "SMS_BACKEND": "twilio",
+            "SMS_GATEWAY_URL": "",
         }
         if extra_env:
             env.update(extra_env)
@@ -313,6 +345,26 @@ class TestStartupGuard:
             )
             result = await adapter.connect()
             assert result is True
+            await adapter.disconnect()
+
+    @pytest.mark.asyncio
+    async def test_custom_webhook_backend_allows_outbound_only_start(self):
+        from gateway.platforms.sms import SmsAdapter
+
+        mock_session = AsyncMock()
+        env = {
+            "SMS_BACKEND": "webhook",
+            "SMS_GATEWAY_URL": "https://sms.example/send",
+            "SMS_HOME_CHANNEL": "+155****6543",
+        }
+        with patch.dict(os.environ, env, clear=True), \
+             patch("aiohttp.ClientSession", return_value=mock_session):
+            pc = PlatformConfig(enabled=True)
+            adapter = SmsAdapter(pc)
+            result = await adapter.connect()
+            assert result is True
+            assert adapter._backend == "webhook"
+            assert adapter._running is True
             await adapter.disconnect()
 
 

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -909,7 +909,7 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
         elif platform == Platform.EMAIL:
             result = await _send_email(pconfig.extra, chat_id, chunk)
         elif platform == Platform.SMS:
-            result = await _send_sms(pconfig.api_key, chat_id, chunk)
+            result = await _send_sms(pconfig.api_key, chat_id, chunk, pconfig.extra)
         elif platform == Platform.MATRIX:
             result = await _send_matrix(pconfig.token, pconfig.extra, chat_id, chunk)
         elif platform == Platform.DINGTALK:
@@ -1448,10 +1448,12 @@ async def _send_email(extra, chat_id, message):
         return _error(f"Email send failed: {e}")
 
 
-async def _send_sms(auth_token, chat_id, message):
-    """Send a single SMS via Twilio REST API.
+async def _send_sms(auth_token, chat_id, message, extra=None):
+    """Send a single SMS via Twilio REST API or custom outbound webhook.
 
     Uses HTTP Basic auth (Account SID : Auth Token) and form-encoded POST.
+    If SMS_BACKEND=webhook or SMS_GATEWAY_URL is configured without Twilio
+    credentials, posts JSON {to,message} to the configured webhook instead.
     Chunking is handled by _send_to_platform() before this is called.
     """
     try:
@@ -1461,10 +1463,7 @@ async def _send_sms(auth_token, chat_id, message):
 
     import base64
 
-    account_sid = os.getenv("TWILIO_ACCOUNT_SID", "")
-    from_number = os.getenv("TWILIO_PHONE_NUMBER", "")
-    if not account_sid or not auth_token or not from_number:
-        return {"error": "SMS not configured (TWILIO_ACCOUNT_SID, TWILIO_AUTH_TOKEN, TWILIO_PHONE_NUMBER required)"}
+    extra = extra or {}
 
     # Strip markdown — SMS renders it as literal characters
     message = re.sub(r"\*\*(.+?)\*\*", r"\1", message, flags=re.DOTALL)
@@ -1477,6 +1476,37 @@ async def _send_sms(auth_token, chat_id, message):
     message = re.sub(r"\[([^\]]+)\]\([^\)]+\)", r"\1", message)
     message = re.sub(r"\n{3,}", "\n\n", message)
     message = message.strip()
+
+    account_sid = os.getenv("TWILIO_ACCOUNT_SID", "")
+    from_number = os.getenv("TWILIO_PHONE_NUMBER", "")
+    gateway_url = (os.getenv("SMS_GATEWAY_URL") or str(extra.get("gateway_url") or "")).strip()
+    backend = (os.getenv("SMS_BACKEND") or str(extra.get("backend") or "auto")).strip().lower() or "auto"
+    use_webhook = bool(gateway_url) and (backend == "webhook" or not (account_sid and auth_token and from_number))
+
+    if use_webhook:
+        try:
+            timeout = float(os.getenv("SMS_GATEWAY_TIMEOUT", "20") or 20)
+            async with aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(total=timeout), trust_env=True) as session:
+                async with session.post(gateway_url, json={"to": chat_id, "message": message}) as resp:
+                    text = await resp.text()
+                    try:
+                        body = await resp.json(content_type=None)
+                    except Exception:
+                        body = text
+                    if resp.status >= 400:
+                        return _error(f"SMS webhook error ({resp.status}): {str(body)[:300]}")
+                    if isinstance(body, dict):
+                        failed = int(body.get("failed") or 0)
+                        errors = body.get("errors") or []
+                        if failed or errors:
+                            return _error(f"SMS webhook failed={failed} errors={errors}")
+                    message_id = body.get("message_id") or body.get("id") or "" if isinstance(body, dict) else ""
+                    return {"success": True, "platform": "sms", "chat_id": chat_id, "message_id": str(message_id), "raw_response": body}
+        except Exception as e:
+            return _error(f"SMS webhook send failed: {e}")
+
+    if not account_sid or not auth_token or not from_number:
+        return {"error": "SMS not configured (Twilio credentials or SMS_GATEWAY_URL required)"}
 
     try:
         from gateway.platforms.base import resolve_proxy_url, proxy_kwargs_for_aiohttp


### PR DESCRIPTION
## Summary
- Treat `SMS_BACKEND=webhook` / `SMS_GATEWAY_URL` as a first-class SMS backend alongside Twilio.
- Allow `send_message` and channel-directory listing to use configured SMS home channels in outbound-only webhook deployments.
- Update status output and SMS tests so webhook-backed SMS reports as configured.

## Test plan
- [x] `/home/olle/.hermes/hermes-agent/venv/bin/python -m py_compile gateway/channel_directory.py gateway/config.py gateway/platforms/sms.py gateway/run.py hermes_cli/status.py tools/send_message_tool.py`
- [x] `/home/olle/.hermes/hermes-agent/venv/bin/python -m pytest tests/gateway/test_sms.py -q -o 'addopts='` -> 42 passed
- [x] `git diff --check -- gateway/channel_directory.py gateway/config.py gateway/platforms/sms.py gateway/run.py hermes_cli/status.py tools/send_message_tool.py tests/gateway/test_sms.py`

🤖 Generated with Hermes Agent