### PR TITLE
fix(subprocess): add UTF-8 encoding to _popen_bash for Windows (#47939)

### DIFF
--- a/tools/environments/base.py
+++ b/tools/environments/base.py
@@ -141,6 +141,8 @@ def _popen_bash(
     Backends with special Popen needs (e.g. local's ``preexec_fn``) can bypass
     this and call :func:`_pipe_stdin` directly.
     """
+    kwargs.setdefault("encoding", "utf-8")
+    kwargs.setdefault("errors", "replace")
     proc = subprocess.Popen(
         cmd,
         stdout=subprocess.PIPE,


### PR DESCRIPTION
Fixes #47939. Added encoding='utf-8' and errors='replace' defaults to _popen_bash() in environments/base.py to prevent UnicodeDecodeError on Windows when subprocess output contains non-UTF-8 bytes.