### PR TITLE
feat: add side project idea triage helper

### DIFF
--- a/docs/side-project-idea-triage-spec.md
+++ b/docs/side-project-idea-triage-spec.md
@@ -1,0 +1,78 @@
+# Side Project Idea Triage Helper Spec
+
+## Problem
+
+Joe collects side-project ideas faster than he can execute them. The nightly Hermes loop needs a small offline helper that can turn a Markdown idea dump into a ranked shortlist without contacting external services or mutating live systems.
+
+## Goals
+
+- Parse human-maintained Markdown idea notes into structured idea records.
+- Score ideas with a simple, transparent heuristic aligned with Joe's operating manual:
+  - high leverage / compounding value
+  - low effort and reversible first step
+  - fits personal systems, investment framework, health, information aggregation, or side projects
+  - penalizes vague ideas and blocked ideas
+- Emit Markdown by default for morning review, with JSON available for automation.
+- Stay offline, deterministic, and easy to test.
+
+## Non-goals
+
+- No network calls, LLM calls, deployment, messaging, or integration with real people.
+- No writes to source notes unless a future explicit command is added.
+- No attempt to be a full product-management system.
+
+## Input contract
+
+A Markdown file may contain ideas as `## Idea title` / `### Idea title` sections. Inside each section, optional fields can be written as bullets:
+
+```markdown
+## Investor signal digest
+- Area: information aggregation
+- Impact: 5
+- Effort: 2
+- Confidence: 4
+- First step: Parse watchlist links and produce a daily brief
+- Blocked: false
+- Notes: Compounds BD top-of-funnel quality
+```
+
+Accepted numeric fields are `impact`, `effort`, `confidence`, and `urgency`, each clamped to 1-5. `Area`, `First step`, `Blocked`, and `Notes` are optional. Non-idea prose before the first idea heading is ignored.
+
+## Output contract
+
+Default Markdown output includes:
+
+1. A title: `# Side Project Idea Triage`
+2. A ranked table with rank, title, area, score, impact, effort, confidence, and first step.
+3. A `## Top recommendation` section explaining why the first idea won.
+4. A `## Watch / defer` section for blocked or low-score ideas.
+
+JSON output returns `ideas` sorted by score with the parsed fields and score explanation.
+
+## Scoring
+
+Base score:
+
+```text
+impact * 3 + confidence * 2 + urgency + area_bonus - effort * 2 - penalties
+```
+
+Area bonus:
+
+- +3: information aggregation, investment, personal systems, health, side projects, dev tools
+- +1: learning, writing, finance
+- +0: everything else
+
+Penalties:
+
+- +8 penalty if blocked
+- +4 penalty if no first step
+- +2 penalty if notes/title contain vague markers such as `someday`, `maybe`, or `research more`
+
+Higher score ranks first.
+
+## Verification plan
+
+- Unit tests for parsing well-formed ideas and ignoring template/instructional prose.
+- Unit tests for ranking, blocked penalties, and missing first-step penalties.
+- CLI smoke test on a temporary Markdown sample in both Markdown and JSON modes.

--- a/scripts/side_project_idea_triage.py
+++ b/scripts/side_project_idea_triage.py
@@ -1,0 +1,302 @@
+#!/usr/bin/env python3
+"""Rank side-project ideas from a local Markdown note.
+
+Offline, deterministic helper for turning a human-maintained idea dump into a
+small reviewable shortlist. It intentionally reads only local files and writes
+only to stdout/stderr.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Iterable
+
+
+PREFERRED_AREA_BONUSES = {
+    "information aggregation": 3,
+    "investment": 3,
+    "investing": 3,
+    "personal systems": 3,
+    "health": 3,
+    "side projects": 3,
+    "side project": 3,
+    "dev tools": 3,
+    "developer tools": 3,
+    "learning": 1,
+    "writing": 1,
+    "finance": 1,
+}
+
+VAGUE_MARKERS = ("someday", "maybe", "research more", "one day", "eventually")
+SKIP_HEADINGS = {"template", "example", "examples", "instructions", "guidance"}
+NUMERIC_FIELDS = {"impact", "effort", "confidence", "urgency"}
+TEXT_FIELDS = {"area", "first step", "notes"}
+BOOL_FIELDS = {"blocked"}
+FIELD_ALIASES = {
+    "first-step": "first step",
+    "first_step": "first step",
+    "next step": "first step",
+    "next_step": "first step",
+}
+
+
+@dataclass
+class Idea:
+    title: str
+    area: str = "uncategorized"
+    impact: int = 3
+    effort: int = 3
+    confidence: int = 3
+    urgency: int = 3
+    first_step: str = ""
+    notes: str = ""
+    blocked: bool = False
+    score: int = 0
+    score_explanation: str = ""
+    raw_fields: dict[str, str] = field(default_factory=dict)
+
+    def as_dict(self) -> dict[str, object]:
+        return {
+            "title": self.title,
+            "area": self.area,
+            "impact": self.impact,
+            "effort": self.effort,
+            "confidence": self.confidence,
+            "urgency": self.urgency,
+            "first_step": self.first_step,
+            "notes": self.notes,
+            "blocked": self.blocked,
+            "score": self.score,
+            "score_explanation": self.score_explanation,
+        }
+
+
+_HEADING_RE = re.compile(r"^(#{2,3})\s+(.+?)\s*$")
+_FIELD_RE = re.compile(r"^\s*[-*]\s*([^:]{2,40}):\s*(.*?)\s*$")
+
+
+def _normalize_field_name(name: str) -> str:
+    normalized = name.strip().lower().replace("_", " ")
+    return FIELD_ALIASES.get(normalized, normalized)
+
+
+def _clamp_rating(value: str, default: int = 3) -> int:
+    try:
+        rating = int(float(value.strip()))
+    except (TypeError, ValueError):
+        return default
+    return max(1, min(5, rating))
+
+
+def _parse_bool(value: str) -> bool:
+    return value.strip().lower() in {"1", "true", "yes", "y", "blocked"}
+
+
+def _looks_like_real_idea(title: str, fields: dict[str, str]) -> bool:
+    if title.strip().lower() in SKIP_HEADINGS:
+        return False
+    if not fields:
+        return False
+    return bool(({"impact", "first step", "area", "effort"} & set(fields)))
+
+
+def parse_ideas(markdown: str) -> list[Idea]:
+    """Parse Markdown idea sections into Idea records.
+
+    Only level-2 and level-3 headings are considered idea candidates. Prose and
+    bullets before the first candidate are ignored, and template/instruction
+    sections are explicitly skipped.
+    """
+    candidates: list[tuple[str, dict[str, str]]] = []
+    current_title: str | None = None
+    current_fields: dict[str, str] = {}
+
+    def flush() -> None:
+        nonlocal current_title, current_fields
+        if current_title and _looks_like_real_idea(current_title, current_fields):
+            candidates.append((current_title, dict(current_fields)))
+        current_title = None
+        current_fields = {}
+
+    for line in markdown.splitlines():
+        heading = _HEADING_RE.match(line)
+        if heading:
+            flush()
+            current_title = heading.group(2).strip().strip("# ")
+            continue
+        if current_title is None:
+            continue
+        field_match = _FIELD_RE.match(line)
+        if not field_match:
+            continue
+        name = _normalize_field_name(field_match.group(1))
+        value = field_match.group(2).strip()
+        if name in NUMERIC_FIELDS | TEXT_FIELDS | BOOL_FIELDS:
+            current_fields[name] = value
+    flush()
+
+    return [_idea_from_fields(title, fields) for title, fields in candidates]
+
+
+def _idea_from_fields(title: str, fields: dict[str, str]) -> Idea:
+    return Idea(
+        title=title,
+        area=fields.get("area", "uncategorized") or "uncategorized",
+        impact=_clamp_rating(fields.get("impact", "3")),
+        effort=_clamp_rating(fields.get("effort", "3")),
+        confidence=_clamp_rating(fields.get("confidence", "3")),
+        urgency=_clamp_rating(fields.get("urgency", "3")),
+        first_step=fields.get("first step", ""),
+        notes=fields.get("notes", ""),
+        blocked=_parse_bool(fields.get("blocked", "false")),
+        raw_fields=fields,
+    )
+
+
+def score_idea(idea: Idea) -> Idea:
+    area_bonus = PREFERRED_AREA_BONUSES.get(idea.area.strip().lower(), 0)
+    penalties: list[str] = []
+    penalty_points = 0
+
+    if idea.blocked:
+        penalty_points += 8
+        penalties.append("blocked -8")
+    if not idea.first_step.strip():
+        penalty_points += 4
+        penalties.append("missing first step -4")
+    vague_text = f"{idea.title} {idea.notes}".lower()
+    if any(marker in vague_text for marker in VAGUE_MARKERS):
+        penalty_points += 2
+        penalties.append("vague wording -2")
+
+    score = (
+        idea.impact * 3
+        + idea.confidence * 2
+        + idea.urgency
+        + area_bonus
+        - idea.effort * 2
+        - penalty_points
+    )
+    idea.score = score
+    reason = (
+        f"impact {idea.impact}*3 + confidence {idea.confidence}*2 + urgency {idea.urgency} "
+        f"+ area bonus {area_bonus} - effort {idea.effort}*2"
+    )
+    if penalties:
+        reason += " - " + ", ".join(penalties)
+    idea.score_explanation = reason
+    return idea
+
+
+def rank_ideas(ideas: Iterable[Idea]) -> list[Idea]:
+    scored = [score_idea(idea) for idea in ideas]
+    return sorted(
+        scored,
+        key=lambda idea: (
+            -idea.score,
+            idea.blocked,
+            idea.effort,
+            -idea.impact,
+            idea.title.lower(),
+        ),
+    )
+
+
+def _cell(value: object) -> str:
+    text = str(value).replace("\n", " ").strip()
+    return text.replace("|", "\\|") or "—"
+
+
+def render_markdown(ideas: list[Idea], *, limit: int | None = None) -> str:
+    shown = ideas[:limit] if limit else ideas
+    lines = [
+        "# Side Project Idea Triage",
+        "",
+        "| Rank | Title | Area | Score | Impact | Effort | Confidence | First step |",
+        "|---:|---|---|---:|---:|---:|---:|---|",
+    ]
+    for idx, idea in enumerate(shown, start=1):
+        lines.append(
+            "| {rank} | {title} | {area} | {score} | {impact} | {effort} | {confidence} | {first_step} |".format(
+                rank=idx,
+                title=_cell(idea.title),
+                area=_cell(idea.area),
+                score=idea.score,
+                impact=idea.impact,
+                effort=idea.effort,
+                confidence=idea.confidence,
+                first_step=_cell(idea.first_step),
+            )
+        )
+
+    actionable = [idea for idea in ideas if not idea.blocked]
+    top = actionable[0] if actionable else (ideas[0] if ideas else None)
+    if top:
+        lines.extend(
+            [
+                "",
+                "## Top recommendation",
+                f"**{top.title}** — score {top.score}. {top.score_explanation}.",
+            ]
+        )
+        if top.first_step:
+            lines.append(f"Next move: {top.first_step}")
+
+    defer = [idea for idea in ideas if idea.blocked or idea.score <= 8]
+    lines.extend(["", "## Watch / defer"])
+    if defer:
+        for idea in defer:
+            status = "blocked" if idea.blocked else "low score"
+            lines.append(f"- **{idea.title}** ({status}, score {idea.score}): {idea.score_explanation}")
+    else:
+        lines.append("- No blocked or low-score ideas in this input.")
+
+    return "\n".join(lines) + "\n"
+
+
+def render_json(ideas: list[Idea]) -> str:
+    return json.dumps({"ideas": [idea.as_dict() for idea in ideas]}, ensure_ascii=False, indent=2)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Rank side-project ideas from a local Markdown file.",
+    )
+    parser.add_argument("path", type=Path, help="Markdown file containing idea sections")
+    parser.add_argument(
+        "--format",
+        choices=("markdown", "json"),
+        default="markdown",
+        help="Output format (default: markdown)",
+    )
+    parser.add_argument("--limit", type=int, default=None, help="Maximum ideas to show in Markdown output")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    try:
+        markdown = args.path.read_text(encoding="utf-8")
+    except OSError as exc:
+        print(f"Failed to read {args.path}: {exc}", file=sys.stderr)
+        return 1
+
+    ideas = rank_ideas(parse_ideas(markdown))
+    if not ideas:
+        print("No side-project ideas found. Add ## idea headings with fields such as Impact and First step.", file=sys.stderr)
+        return 2
+
+    if args.format == "json":
+        print(render_json(ideas))
+    else:
+        print(render_markdown(ideas, limit=args.limit), end="")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/tests/scripts/test_side_project_idea_triage.py
+++ b/tests/scripts/test_side_project_idea_triage.py
@@ -1,0 +1,165 @@
+"""Tests for the offline side-project idea triage helper."""
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+
+SCRIPT_PATH = Path(__file__).resolve().parents[2] / "scripts" / "side_project_idea_triage.py"
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("side_project_idea_triage", SCRIPT_PATH)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+triage = _load_module()
+
+
+def test_parse_ideas_ignores_instructions_and_template_sections():
+    markdown = """
+# Brain dump
+
+Use this file for side project ideas. The bullets below are guidance, not data.
+- Impact: 5
+- First step: Do not parse this
+
+## Template
+- Area: copy this
+- Impact: 5
+- Effort: 1
+- First step: Fill this later
+
+## Investor signal digest
+- Area: information aggregation
+- Impact: 5
+- Effort: 2
+- Confidence: 4
+- Urgency: 5
+- First step: Parse watchlist links and produce a daily brief
+- Notes: Compounds BD top-of-funnel quality
+
+### Fridge chore reminder
+- Area: personal systems
+- Impact: 3
+- Effort: 1
+- Confidence: 5
+- First step: Emit due/overdue household task summary
+"""
+
+    ideas = triage.parse_ideas(markdown)
+
+    assert [idea.title for idea in ideas] == [
+        "Investor signal digest",
+        "Fridge chore reminder",
+    ]
+    assert ideas[0].area == "information aggregation"
+    assert ideas[0].impact == 5
+    assert ideas[0].first_step == "Parse watchlist links and produce a daily brief"
+
+
+def test_ranking_rewards_leverage_and_penalizes_blockers_and_vagueness():
+    markdown = """
+## Maybe build a huge super app someday
+- Area: side projects
+- Impact: 5
+- Effort: 5
+- Confidence: 2
+- First step:
+- Notes: maybe research more someday
+
+## Investor signal digest
+- Area: information aggregation
+- Impact: 5
+- Effort: 2
+- Confidence: 4
+- Urgency: 5
+- First step: Parse watchlist links and produce a daily brief
+
+## Bank integration autoposter
+- Area: finance
+- Impact: 5
+- Effort: 1
+- Confidence: 5
+- First step: Wire credentials and send messages
+- Blocked: true
+"""
+
+    ranked = triage.rank_ideas(triage.parse_ideas(markdown))
+
+    assert ranked[0].title == "Investor signal digest"
+    assert ranked[-1].title == "Maybe build a huge super app someday"
+    blocked = next(idea for idea in ranked if idea.title == "Bank integration autoposter")
+    assert blocked.blocked is True
+    assert "blocked" in blocked.score_explanation.lower()
+
+
+def test_markdown_output_contains_ranked_table_and_defer_section():
+    ideas = triage.rank_ideas(
+        triage.parse_ideas(
+            """
+## Quick food logger
+- Area: health
+- Impact: 4
+- Effort: 2
+- Confidence: 4
+- First step: Convert meal notes to weekly macro deltas
+
+## OAuth bank sync
+- Area: finance
+- Impact: 5
+- Effort: 1
+- Confidence: 4
+- First step: Connect live account
+- Blocked: true
+"""
+        )
+    )
+
+    output = triage.render_markdown(ideas)
+
+    assert output.startswith("# Side Project Idea Triage")
+    assert "| 1 | Quick food logger | health |" in output
+    assert "## Top recommendation" in output
+    assert "## Watch / defer" in output
+    assert "OAuth bank sync" in output
+
+
+def test_cli_json_output(tmp_path, capsys):
+    sample = tmp_path / "ideas.md"
+    sample.write_text(
+        """
+## Skill watcher
+- Area: dev tools
+- Impact: 4
+- Effort: 2
+- Confidence: 4
+- First step: Scan local skill catalog and flag stale entries
+""".strip(),
+        encoding="utf-8",
+    )
+
+    exit_code = triage.main([str(sample), "--format", "json"])
+
+    assert exit_code == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["ideas"][0]["title"] == "Skill watcher"
+    assert payload["ideas"][0]["score"] > 0
+
+
+def test_cli_no_ideas_exits_nonzero(tmp_path, capsys):
+    sample = tmp_path / "ideas.md"
+    sample.write_text("# Notes only\n- Impact: 5\n", encoding="utf-8")
+
+    exit_code = triage.main([str(sample)])
+
+    assert exit_code == 2
+    assert "No side-project ideas found" in capsys.readouterr().err


### PR DESCRIPTION
## Summary

- Add `scripts/side_project_idea_triage.py`, an offline helper that parses Markdown side-project idea notes and ranks them with a transparent heuristic.
- Document the input/output contract and scoring rules in `docs/side-project-idea-triage-spec.md`.
- Add focused tests for parsing, ranking penalties, Markdown rendering, JSON CLI output, and no-ideas failure handling.

## Why

Joe's operating manual calls for small life-optimization tools around side projects, investment framework, health, and information aggregation. This gives nightly/proactive workflows a deterministic way to turn a loose idea dump into a reviewable shortlist without contacting external services or mutating any source notes.

## Tests

- `scripts/run_tests.sh tests/scripts/test_side_project_idea_triage.py`
- `python -m py_compile scripts/side_project_idea_triage.py tests/scripts/test_side_project_idea_triage.py`
- Smoke: `python scripts/side_project_idea_triage.py /tmp/joe_side_project_ideas_sample.md`
- Smoke JSON validation: `python scripts/side_project_idea_triage.py /tmp/joe_side_project_ideas_sample.md --format json >/tmp/joe_side_project_ideas_sample.json && python -m json.tool /tmp/joe_side_project_ideas_sample.json >/dev/null`

## Risk

Low: standalone script + docs + tests only; no live integrations, no network calls, no writes beyond stdout/stderr.
