### PR TITLE
fix(loop): duck-type Mock check to avoid ImportError under thread-pool dispatch

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -1103,8 +1103,14 @@ def run_conversation(
                     # No display/TTS consumer. Still prefer streaming for
                     # health checking, but skip for Mock clients in tests
                     # (mocks return SimpleNamespace, not stream iterators).
-                    from unittest.mock import Mock
-                    if isinstance(getattr(agent, "client", None), Mock):
+                    # Use duck-typing instead of importing unittest.mock to
+                    # avoid ImportError crashes in agent-based cron jobs
+                    # (stdlib import fails intermittently under thread-pool
+                    # dispatch — crondispatch-internal edge case). The
+                    # streaming path is the safe default when the check
+                    # can't run.
+                    _client = getattr(agent, "client", None)
+                    if _client is not None and hasattr(_client, "assert_called"):
                         _use_streaming = False
 
                 def _perform_api_call(next_api_kwargs):


### PR DESCRIPTION
## Problem

Under Python 3.14, a lazy `from unittest.mock import Mock` inside `run_conversation()` (line 1102) fails intermittently when dispatched via ThreadPoolExecutor — an edge case in `crondispatch`-internal imports. This causes agent-based cron jobs (Monica Exchange Sync, Action Tracker, Hermes Desktop Update) to crash with:

`RuntimeError: No module named 'unittest.mock'`

## Fix

Replace the Mock import with duck-typing: check for `hasattr(client, "assert_called")` instead of `isinstance(..., Mock)`. The streaming path is the safe default when the check can't run, so there's no behavioral change for test clients.

## Testing

- Verified duck-typing check passes for actual Mock objects (returns True)
- Verified it returns False for real API clients (SimpleNamespace, httpx.Client, etc.)
- All 4 affected cron jobs pass with this fix applied

## Related

Fixes `RuntimeError: No module named 'unittest.mock'` in Hermes cron dispatch under Python 3.14.