### PR TITLE
feat(xiaomi): add Token Plan endpoint support during hermes model setup

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -406,7 +406,7 @@ PROVIDER_REGISTRY: Dict[str, ProviderConfig] = {
         id="xiaomi",
         name="Xiaomi MiMo",
         auth_type="api_key",
-        inference_base_url="https://api.xiaomimimo.com/v1",
+        inference_base_url="https://api.xiaomimimo.com/v1",  # Pay As You Go; Token Plan uses https://token-plan-{cn,sgp,ams}.xiaomimimo.com/v1
         api_key_env_vars=("XIAOMI_API_KEY",),
         base_url_env_var="XIAOMI_BASE_URL",
     ),

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -3726,7 +3726,7 @@ OPTIONAL_ENV_VARS = {
         "category": "provider",
     },
     "XIAOMI_BASE_URL": {
-        "description": "Xiaomi MiMo base URL override (default: https://api.xiaomimimo.com/v1)",
+        "description": "Xiaomi MiMo base URL override (default: https://api.xiaomimimo.com/v1). Token Plan users: https://token-plan-{cn,sgp,ams}.xiaomimimo.com/v1",
         "prompt": "Xiaomi base URL (leave empty for default)",
         "url": None,
         "password": False,

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -637,6 +637,7 @@ from hermes_cli.model_setup_flows import (
     _model_flow_api_key_provider,
     _model_flow_anthropic,
     _model_flow_moa,
+    _model_flow_xiaomi,
 )
 logger = logging.getLogger(__name__)
 
@@ -3164,6 +3165,8 @@ def select_provider_and_model(args=None):
         _model_flow_vertex(config, current_model)
     elif selected_provider == "azure-foundry":
         _model_flow_azure_foundry(config, current_model)
+    elif selected_provider == "xiaomi":
+        _model_flow_xiaomi(config, current_model)
     elif selected_provider in {
         "openai-api",
         "gemini",
@@ -3178,7 +3181,6 @@ def select_provider_and_model(args=None):
         "opencode-go",
         "alibaba",
         "huggingface",
-        "xiaomi",
         "arcee",
         "gmi",
         "nvidia",

--- a/hermes_cli/model_setup_flows.py
+++ b/hermes_cli/model_setup_flows.py
@@ -2849,6 +2849,27 @@ _XIAOMI_TOKEN_PLAN_ANTHROPIC_ENDPOINTS = {
     "eu": "https://token-plan-ams.xiaomimimo.com/anthropic",
 }
 _XIAOMI_PAYG_URL = "https://api.xiaomimimo.com/v1"
+_XIAOMI_TOKEN_PLAN_ENDPOINT_TO_CLUSTER = {
+    url: cluster for cluster, url in _XIAOMI_TOKEN_PLAN_ENDPOINTS.items()
+}
+_XIAOMI_TOKEN_PLAN_ANTHROPIC_ENDPOINT_TO_CLUSTER = {
+    url: cluster for cluster, url in _XIAOMI_TOKEN_PLAN_ANTHROPIC_ENDPOINTS.items()
+}
+_XIAOMI_TOKEN_PLAN_CLUSTER_INPUT = {"cn": "1", "sgp": "2", "eu": "3"}
+_XIAOMI_TOKEN_PLAN_CLUSTER_LABELS = {"cn": "CN", "sgp": "SGP", "eu": "EU"}
+
+
+def _xiaomi_endpoint_cluster(base_url: str) -> str | None:
+    normalized = (base_url or "").strip().rstrip("/")
+    return (
+        _XIAOMI_TOKEN_PLAN_ENDPOINT_TO_CLUSTER.get(normalized)
+        or _XIAOMI_TOKEN_PLAN_ANTHROPIC_ENDPOINT_TO_CLUSTER.get(normalized)
+    )
+
+
+def _xiaomi_is_token_plan_base_url(base_url: str) -> bool:
+    normalized = (base_url or "").strip().lower()
+    return "token-plan-" in normalized and "xiaomimimo.com" in normalized
 
 
 def _model_flow_xiaomi(config, current_model=""):
@@ -2919,8 +2940,23 @@ def _model_flow_xiaomi(config, current_model=""):
         print("  ℹ  Detected Token Plan key (tp- prefix)")
         print()
 
-    # Determine default choice based on key prefix
-    default_choice = "2" if is_token_plan_key else "1"
+    current_cluster = _xiaomi_endpoint_cluster(current_base)
+    has_custom_token_plan_base = (
+        bool(current_base)
+        and current_base.rstrip("/") != _XIAOMI_PAYG_URL
+        and current_cluster is None
+        and (is_token_plan_key or _xiaomi_is_token_plan_base_url(current_base))
+    )
+
+    # Determine default choice from the configured endpoint first so rerunning
+    # ``hermes model`` preserves the user's existing plan. Fall back to key
+    # prefix only when no endpoint is configured yet.
+    if current_cluster or has_custom_token_plan_base:
+        default_choice = "2"
+    elif current_base.rstrip("/") == _XIAOMI_PAYG_URL:
+        default_choice = "1"
+    else:
+        default_choice = "2" if is_token_plan_key else "1"
 
     try:
         choice = input(f"Plan type [{default_choice}]: ").strip() or default_choice
@@ -2939,17 +2975,34 @@ def _model_flow_xiaomi(config, current_model=""):
         print("  [3] EU  — Amsterdam (token-plan-ams.xiaomimimo.com)")
         print()
 
+        if current_cluster:
+            default_cluster_input = _XIAOMI_TOKEN_PLAN_CLUSTER_INPUT[current_cluster]
+            default_cluster_label = _XIAOMI_TOKEN_PLAN_CLUSTER_LABELS[current_cluster]
+        elif has_custom_token_plan_base:
+            default_cluster_input = ""
+            default_cluster_label = "custom"
+            print(f"  Current custom endpoint: {current_base}")
+            print("  Press Enter to keep it, or choose a regional cluster to replace it.")
+            print()
+        else:
+            default_cluster_input = "2"
+            default_cluster_label = "SGP"
+
         try:
-            cluster_input = input("Cluster [2]: ").strip() or "2"
+            cluster_input = (
+                input(f"Cluster [{default_cluster_label}]: ").strip()
+                or default_cluster_input
+            )
         except (KeyboardInterrupt, EOFError):
             print()
-            cluster_input = "2"
+            cluster_input = default_cluster_input
 
         cluster_map = {"1": "cn", "2": "sgp", "3": "eu"}
-        cluster = cluster_map.get(cluster_input, "sgp")
+        cluster = cluster_map.get(cluster_input)
 
-        # Default to OpenAI-compatible endpoint
-        effective_base = _XIAOMI_TOKEN_PLAN_ENDPOINTS[cluster]
+        # Default to OpenAI-compatible endpoint. Preserve a custom Token Plan
+        # endpoint unless the user explicitly picks one of the regional options.
+        effective_base = _XIAOMI_TOKEN_PLAN_ENDPOINTS[cluster] if cluster else current_base
     else:
         # Pay As You Go
         effective_base = _XIAOMI_PAYG_URL
@@ -3048,6 +3101,7 @@ def _model_flow_xiaomi(config, current_model=""):
             cfg["model"] = model
         model["provider"] = "xiaomi"
         model["base_url"] = effective_base
+        clear_model_endpoint_credentials(model)
         save_config(cfg)
         deactivate_provider()
 

--- a/hermes_cli/model_setup_flows.py
+++ b/hermes_cli/model_setup_flows.py
@@ -2831,6 +2831,231 @@ def _model_flow_api_key_provider(config, provider_id, current_model=""):
     else:
         print("No change.")
 
+
+# Xiaomi MiMo Token Plan endpoints (regional clusters):
+#   CN:  https://token-plan-cn.xiaomimimo.com/v1
+#   SGP: https://token-plan-sgp.xiaomimimo.com/v1
+#   EU:  https://token-plan-ams.xiaomimimo.com/v1
+# Anthropic-compatible variants use /anthropic instead of /v1.
+# Token Plan API keys use the ``tp-`` prefix.
+_XIAOMI_TOKEN_PLAN_ENDPOINTS = {
+    "cn": "https://token-plan-cn.xiaomimimo.com/v1",
+    "sgp": "https://token-plan-sgp.xiaomimimo.com/v1",
+    "eu": "https://token-plan-ams.xiaomimimo.com/v1",
+}
+_XIAOMI_TOKEN_PLAN_ANTHROPIC_ENDPOINTS = {
+    "cn": "https://token-plan-cn.xiaomimimo.com/anthropic",
+    "sgp": "https://token-plan-sgp.xiaomimimo.com/anthropic",
+    "eu": "https://token-plan-ams.xiaomimimo.com/anthropic",
+}
+_XIAOMI_PAYG_URL = "https://api.xiaomimimo.com/v1"
+
+
+def _model_flow_xiaomi(config, current_model=""):
+    """Flow for Xiaomi MiMo — supports Pay As You Go and Token Plan endpoints.
+
+    Token Plan keys (``tp-`` prefix) require a regional cluster-specific
+    endpoint instead of the default Pay As You Go URL.  This flow asks the
+    user which plan type they have, auto-detecting from the key prefix when
+    possible, and then selects the correct base URL.
+    """
+    from hermes_cli.main import _prompt_api_key
+    from hermes_cli.auth import (
+        PROVIDER_REGISTRY,
+        _prompt_model_selection,
+        _save_model_choice,
+        deactivate_provider,
+    )
+    from hermes_cli.config import (
+        get_env_value,
+        save_env_value,
+        load_config,
+        save_config,
+    )
+    from hermes_cli.models import _PROVIDER_MODELS, fetch_api_models
+
+    pconfig = PROVIDER_REGISTRY["xiaomi"]
+    key_env = "XIAOMI_API_KEY"
+    base_url_env = "XIAOMI_BASE_URL"
+
+    # ── Check / prompt for API key ────────────────────────────────────
+    existing_key = get_env_value(key_env) or os.getenv(key_env, "")
+
+    existing_key, abort = _prompt_api_key(
+        pconfig, existing_key, provider_id="xiaomi"
+    )
+    if abort:
+        return
+
+    # ── Auto-detect plan type from key prefix ─────────────────────────
+    is_token_plan_key = existing_key.startswith("tp-")
+
+    # ── Load current configuration ────────────────────────────────────
+    current_base = get_env_value(base_url_env) or os.getenv(base_url_env, "")
+    if not current_base:
+        try:
+            _m = load_config().get("model") or {}
+            if str(_m.get("provider") or "").strip().lower() == "xiaomi":
+                current_base = str(_m.get("base_url") or "").strip()
+        except Exception:
+            pass
+
+    # ── Plan type selection ───────────────────────────────────────────
+    print()
+    print("Xiaomi MiMo Plan Type")
+    print("=" * 50)
+    print()
+    print("  Xiaomi MiMo offers two billing plans with different endpoints:")
+    print()
+    print("  [1] Pay As You Go — standard per-request billing")
+    print("      Endpoint: https://api.xiaomimimo.com/v1")
+    print("      API keys: regular format")
+    print()
+    print("  [2] Token Plan — pre-purchased token allocation (regional clusters)")
+    print("      API keys: tp-xxxxx format")
+    print()
+
+    if is_token_plan_key:
+        print("  ℹ  Detected Token Plan key (tp- prefix)")
+        print()
+
+    # Determine default choice based on key prefix
+    default_choice = "2" if is_token_plan_key else "1"
+
+    try:
+        choice = input(f"Plan type [{default_choice}]: ").strip() or default_choice
+    except (KeyboardInterrupt, EOFError):
+        print()
+        choice = default_choice
+
+    if choice == "2":
+        # Token Plan: select regional cluster
+        print()
+        print("Token Plan Regional Cluster")
+        print("=" * 50)
+        print()
+        print("  [1] CN  — China (token-plan-cn.xiaomimimo.com)")
+        print("  [2] SGP — Singapore (token-plan-sgp.xiaomimimo.com)")
+        print("  [3] EU  — Amsterdam (token-plan-ams.xiaomimimo.com)")
+        print()
+
+        try:
+            cluster_input = input("Cluster [2]: ").strip() or "2"
+        except (KeyboardInterrupt, EOFError):
+            print()
+            cluster_input = "2"
+
+        cluster_map = {"1": "cn", "2": "sgp", "3": "eu"}
+        cluster = cluster_map.get(cluster_input, "sgp")
+
+        # Default to OpenAI-compatible endpoint
+        effective_base = _XIAOMI_TOKEN_PLAN_ENDPOINTS[cluster]
+    else:
+        # Pay As You Go
+        effective_base = _XIAOMI_PAYG_URL
+
+    # ── Allow manual override ─────────────────────────────────────────
+    print()
+    try:
+        override = input(f"Base URL [{effective_base}]: ").strip()
+    except (KeyboardInterrupt, EOFError):
+        print()
+        override = ""
+    if override:
+        if not override.startswith(("http://", "https://")):
+            print(
+                "  Invalid URL — must start with http:// or https://. "
+                "Keeping current value."
+            )
+        else:
+            effective_base = override
+
+    # Save base URL to env var
+    if effective_base != _XIAOMI_PAYG_URL:
+        save_env_value(base_url_env, effective_base)
+    else:
+        # Clear override when using the default PAYG URL
+        from hermes_cli.config import remove_env_value
+        remove_env_value(base_url_env)
+
+    # ── Model selection ───────────────────────────────────────────────
+    print()
+    curated = _PROVIDER_MODELS.get("xiaomi", [])
+
+    # Try models.dev first
+    mdev_models: list = []
+    try:
+        from agent.models_dev import list_agentic_models
+        mdev_models = list_agentic_models("xiaomi")
+    except Exception:
+        pass
+
+    if mdev_models:
+        if curated:
+            seen = {m.lower() for m in mdev_models}
+            merged = list(mdev_models)
+            for m in curated:
+                if m.lower() not in seen:
+                    merged.append(m)
+                    seen.add(m.lower())
+            model_list = merged
+        else:
+            model_list = mdev_models
+        print(f"  Found {len(model_list)} model(s) from models.dev registry")
+    elif curated:
+        model_list = curated
+        print(
+            f'  Showing {len(model_list)} curated models — '
+            'use "Enter custom model name" for others.'
+        )
+    else:
+        # Live probe fallback
+        api_key_for_probe = existing_key or (get_env_value(key_env) or "")
+        live_models = fetch_api_models(api_key_for_probe, effective_base)
+        if live_models:
+            model_list = live_models
+            print(f"  Found {len(model_list)} model(s) from Xiaomi MiMo API")
+        else:
+            model_list = curated
+            if model_list:
+                print(
+                    f'  Showing {len(model_list)} curated models — '
+                    'use "Enter custom model name" for others.'
+                )
+
+    if model_list:
+        selected = _prompt_model_selection(
+            model_list,
+            current_model=current_model,
+            confirm_provider="xiaomi",
+            confirm_base_url=effective_base,
+            confirm_api_key=existing_key,
+        )
+    else:
+        try:
+            selected = input("Model name: ").strip()
+        except (KeyboardInterrupt, EOFError):
+            selected = None
+
+    if selected:
+        _save_model_choice(selected)
+
+        # Update config with provider, base URL
+        cfg = load_config()
+        model = cfg.get("model")
+        if not isinstance(model, dict):
+            model = {"default": model} if model else {}
+            cfg["model"] = model
+        model["provider"] = "xiaomi"
+        model["base_url"] = effective_base
+        save_config(cfg)
+        deactivate_provider()
+
+        print(f"Default model set to: {selected} (via Xiaomi MiMo)")
+    else:
+        print("No change.")
+
+
 def _model_flow_anthropic(config, current_model=""):
     """Flow for Anthropic provider — OAuth subscription, API key, or Claude Code creds."""
     from hermes_cli.main import _run_anthropic_oauth_flow

--- a/plugins/model-providers/xiaomi/__init__.py
+++ b/plugins/model-providers/xiaomi/__init__.py
@@ -3,6 +3,14 @@
 from providers import register_provider
 from providers.base import ProviderProfile
 
+# Default base_url is Pay As You Go.  Token Plan users get a regional
+# endpoint selected during ``hermes model`` setup and stored in
+# ``model.base_url`` in config.yaml (env var: XIAOMI_BASE_URL).
+#
+# Token Plan endpoints:
+#   CN:  https://token-plan-cn.xiaomimimo.com/v1
+#   SGP: https://token-plan-sgp.xiaomimimo.com/v1
+#   EU:  https://token-plan-ams.xiaomimimo.com/v1
 xiaomi = ProviderProfile(
     name="xiaomi",
     aliases=("mimo", "xiaomi-mimo"),

--- a/tests/hermes_cli/test_xiaomi_provider.py
+++ b/tests/hermes_cli/test_xiaomi_provider.py
@@ -372,3 +372,121 @@ class TestXiaomiAgentInit:
         overlay = HERMES_OVERLAYS["xiaomi"]
         api_mode = TRANSPORT_TO_API_MODE[overlay.transport]
         assert api_mode == "chat_completions"
+
+
+# =============================================================================
+# Model setup flow regression coverage
+# =============================================================================
+
+
+def _run_xiaomi_model_flow(
+    monkeypatch,
+    inputs,
+    config_model,
+    *,
+    api_key="tp-test",
+    selected="mimo-v2.5-pro",
+):
+    """Run the interactive Xiaomi setup flow with patched I/O and config."""
+    from hermes_cli import auth as auth_mod
+    from hermes_cli import config as config_mod
+    from hermes_cli import main as main_mod
+    from hermes_cli import model_setup_flows as flows_mod
+    from agent import models_dev as models_dev_mod
+
+    saved = {}
+    cfg = {"model": dict(config_model)}
+
+    monkeypatch.setattr(main_mod, "_prompt_api_key", lambda *a, **k: (api_key, False))
+    monkeypatch.setattr(auth_mod, "_prompt_model_selection", lambda *a, **k: selected)
+    monkeypatch.setattr(auth_mod, "_save_model_choice", lambda *a, **k: None)
+    monkeypatch.setattr(auth_mod, "deactivate_provider", lambda *a, **k: None)
+    monkeypatch.setattr(models_dev_mod, "list_agentic_models", lambda provider: [selected])
+
+    def fake_get_env_value(name):
+        if name == "XIAOMI_API_KEY":
+            return api_key
+        if name == "XIAOMI_BASE_URL":
+            return ""
+        return ""
+
+    monkeypatch.setattr(config_mod, "get_env_value", fake_get_env_value)
+    monkeypatch.setattr(config_mod, "save_env_value", lambda *a, **k: None)
+    monkeypatch.setattr(config_mod, "remove_env_value", lambda *a, **k: None)
+    monkeypatch.setattr(config_mod, "load_config", lambda: cfg)
+
+    def fake_save_config(new_cfg):
+        saved.clear()
+        saved.update(new_cfg)
+
+    monkeypatch.setattr(config_mod, "save_config", fake_save_config)
+
+    iterator = iter(inputs)
+    monkeypatch.setattr("builtins.input", lambda prompt="": next(iterator))
+
+    flows_mod._model_flow_xiaomi({}, current_model="")
+    return saved["model"]
+
+
+class TestXiaomiModelFlow:
+    def test_token_plan_existing_cn_endpoint_is_default_and_preserved(self, monkeypatch):
+        model = _run_xiaomi_model_flow(
+            monkeypatch,
+            inputs=["", "", ""],
+            config_model={
+                "provider": "xiaomi",
+                "base_url": "https://token-plan-cn.xiaomimimo.com/v1",
+                "api_key": "stale-inline-key",
+                "api_mode": "anthropic_messages",
+            },
+        )
+
+        assert model["provider"] == "xiaomi"
+        assert model["base_url"] == "https://token-plan-cn.xiaomimimo.com/v1"
+        assert "api_key" not in model
+        assert "api_mode" not in model
+
+    def test_token_plan_existing_eu_endpoint_is_default_and_preserved(self, monkeypatch):
+        model = _run_xiaomi_model_flow(
+            monkeypatch,
+            inputs=["", "", ""],
+            config_model={
+                "provider": "xiaomi",
+                "base_url": "https://token-plan-ams.xiaomimimo.com/v1",
+            },
+        )
+
+        assert model["base_url"] == "https://token-plan-ams.xiaomimimo.com/v1"
+
+    def test_token_plan_custom_endpoint_is_preserved_unless_replaced(self, monkeypatch):
+        model = _run_xiaomi_model_flow(
+            monkeypatch,
+            inputs=["", "", ""],
+            config_model={
+                "provider": "xiaomi",
+                "base_url": "https://token-plan-private.xiaomimimo.com/v1",
+            },
+        )
+
+        assert model["base_url"] == "https://token-plan-private.xiaomimimo.com/v1"
+
+    def test_token_plan_region_selection_can_replace_custom_endpoint(self, monkeypatch):
+        model = _run_xiaomi_model_flow(
+            monkeypatch,
+            inputs=["", "3", ""],
+            config_model={
+                "provider": "xiaomi",
+                "base_url": "https://token-plan-private.xiaomimimo.com/v1",
+            },
+        )
+
+        assert model["base_url"] == "https://token-plan-ams.xiaomimimo.com/v1"
+
+    def test_manual_base_url_override_is_saved(self, monkeypatch):
+        model = _run_xiaomi_model_flow(
+            monkeypatch,
+            inputs=["2", "2", "https://token-plan-custom.xiaomimimo.com/v1"],
+            config_model={"provider": "xiaomi", "base_url": "https://api.xiaomimimo.com/v1"},
+        )
+
+        assert model["base_url"] == "https://token-plan-custom.xiaomimimo.com/v1"


### PR DESCRIPTION
## Problem

When a user configures Xiaomi MiMo via `hermes model`, the setup flow only offers the Pay As You Go endpoint (`https://api.xiaomimimo.com/v1`). Users subscribed to Xiaomi's **Token Plan** get HTTP 401 errors because their API keys require a different regional endpoint that the wizard never surfaces.

## Solution

Add a plan-type selection step to the `hermes model` setup flow for Xiaomi MiMo:

1. **Plan type prompt** — asks whether the user is on Pay As You Go or Token Plan
2. **Regional cluster selection** — for Token Plan, prompts for CN / SGP / EU cluster
3. **Auto-detection** — keys with the `tp-` prefix automatically default to Token Plan
4. **Custom URL escape hatch** — users can still manually enter a custom base URL

## Endpoints

| Plan | Region | Base URL |
|------|--------|----------|
| Pay As You Go | — | `https://api.xiaomimimo.com/v1` |
| Token Plan | CN | `https://token-plan-cn.xiaomimimo.com/v1` |
| Token Plan | SGP | `https://token-plan-sgp.xiaomimimo.com/v1` |
| Token Plan | EU | `https://token-plan-ams.xiaomimimo.com/v1` |

**Reference:** [Xiaomi MiMo Token Plan Documentation](https://mimo.mi.com/docs/en-US/tokenplan/Token%20Plan/subscription)

## Files Changed

- `hermes_cli/model_setup_flows.py` — new `_model_flow_xiaomi()` function with plan type + region selection
- `hermes_cli/main.py` — wires the new Xiaomi flow into the setup dispatcher
- `hermes_cli/config.py` — updated `XIAOMI_BASE_URL` description
- `hermes_cli/auth.py` — Token Plan endpoint comments
- `plugins/model-providers/xiaomi/__init__.py` — Token Plan documentation in plugin docs

## Breaking Changes

None — existing Pay As You Go users keep the same default endpoint. Token Plan is additive.