### PR TITLE
fix(gateway): remove 15-line reasoning cap, use <blockquote> on Matrix

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -8357,14 +8357,30 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             if _show_reasoning_effective and response:
                 last_reasoning = agent_result.get("last_reasoning")
                 if last_reasoning:
-                    # Collapse long reasoning to keep messages readable
-                    lines = last_reasoning.strip().splitlines()
-                    if len(lines) > 15:
-                        display_reasoning = "\n".join(lines[:15])
-                        display_reasoning += f"\n_... ({len(lines) - 15} more lines)_"
+                    reasoning = last_reasoning.strip()
+                    platform_key = _platform_config_key(source.platform)
+                    if platform_key == "matrix":
+                        # Quote-prefix so MatrixAdapter._markdown_to_html emits
+                        # <blockquote>, which Element wraps at viewport width.
+                        # <pre> code-fence (legacy) disabled wrap on mobile.
+                        quoted = "\n".join(
+                            f"> {ln}" if ln else ">"
+                            for ln in reasoning.splitlines()
+                        )
+                        response = f"💭 **Reasoning:**\n\n{quoted}\n\n{response}"
                     else:
-                        display_reasoning = last_reasoning.strip()
-                    response = f"💭 **Reasoning:**\n```\n{display_reasoning}\n```\n\n{response}"
+                        lines = reasoning.splitlines()
+                        if len(lines) > 1000:
+                            display_reasoning = "\n".join(lines[:1000])
+                            display_reasoning += (
+                                f"\n_... ({len(lines) - 1000} more lines)_"
+                            )
+                        else:
+                            display_reasoning = reasoning
+                        response = (
+                            f"💭 **Reasoning:**\n```\n{display_reasoning}\n```"
+                            f"\n\n{response}"
+                        )
 
             # Runtime-metadata footer — only on the FINAL message of the turn.
             # Off by default (display.runtime_footer.enabled=false).  When


### PR DESCRIPTION
## Summary

The Matrix gateway clipped reasoning blocks at 15 lines and wrapped them in a triple-backtick code fence. Element renders the resulting `<pre>` without word-wrap, so long lines clip off-screen on mobile, and chains-of-thought users wanted to monitor in full were truncated.

## Changes

Per-platform branching in `gateway/run.py`:

- **Matrix:** quote-prefix every reasoning line so `MatrixAdapter._markdown_to_html` emits a single `<blockquote>`. Element wraps blockquote text at viewport width, and the full reasoning is visible inline (no collapse widget — users actively want to monitor it).
- **CLI / Telegram / Slack:** keep the legacy code-fence (terminals want monospace), but raise the cap from 15 lines to 1000. Effectively unbounded for normal monitoring while still bounding pathological runaway loops.

No changes to `gateway/platforms/matrix.py` (the `<blockquote>` rendering at line 2935 already does the right thing) or `gateway/stream_consumer.py` (`<think>`-stripping path is unrelated).

## Test plan

- [ ] DM a Matrix bot with `display.show_reasoning: true` something that triggers >20 lines of reasoning
- [ ] Element mobile: reasoning visible inline, text wraps at viewport width, no "... N more lines" suffix
- [ ] Element web: same behaviour
- [ ] CLI: legacy code-fence renders, line cap is now 1000 not 15

🤖 Generated with [Claude Code](https://claude.com/claude-code)