### PR TITLE
fix(desktop): resolve Electron dist from workspace

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -135,7 +135,7 @@
   },
   "build": {
     "electronVersion": "40.10.2",
-    "electronDist": "../../node_modules/electron/dist",
+    "electronDist": "./node_modules/electron/dist",
     "appId": "com.nousresearch.hermes",
     "productName": "Hermes",
     "executableName": "Hermes",

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -4519,12 +4519,26 @@ def _web_ui_build_needed(web_dir: Path) -> bool:
     return False
 
 
+def _npm_build_env(extra: dict[str, str] | None = None) -> dict[str, str]:
+    """Return an npm build env that always installs/runs dev dependencies.
+
+    Hermes Desktop launches updates from a production runtime. npm interprets
+    ``NODE_ENV=production`` and ``NPM_CONFIG_OMIT=dev`` as "skip dev deps",
+    which removes build-only tools such as TypeScript and Vite.
+    """
+    env = {**os.environ, **(extra or {})}
+    env["NODE_ENV"] = "development"
+    env["NPM_CONFIG_OMIT"] = ""
+    return env
+
+
 def _run_with_idle_timeout(
     cmd: list[str],
-    cwd: Path,
     *,
+    cwd: Path,
     idle_timeout_seconds: int = 180,
     indent: str = "    ",
+    env: dict[str, str] | None = None,
 ) -> subprocess.CompletedProcess:
     """Run a subprocess that streams output, with an idle-output timeout.
 
@@ -4559,6 +4573,7 @@ def _run_with_idle_timeout(
             encoding="utf-8",
             errors="replace",
             bufsize=1,
+            env=env,
         )
     except OSError as exc:
         # E.g. npm not on PATH between the which() check and now.
@@ -4690,7 +4705,7 @@ def _run_npm_install_deterministic(
     # unicode-animations' postinstall animates to /dev/tty (bypasses
     # --silent/capture_output). It no-ops when CI is set — same as the TUI
     # install path and nix/lib.nix npm ci hooks.
-    run_env = {**os.environ, **(env or {}), "CI": "1"}
+    run_env = {**_npm_build_env(env), "CI": "1"}
 
     lockfile = cwd / "package-lock.json"
     if lockfile.exists():
@@ -5110,16 +5125,29 @@ def _purge_electron_build_cache(desktop_dir: Path) -> list[Path]:
     return removed
 
 
-def _electron_dist_binary(project_root: Path) -> Path:
-    """Return the path to the Electron main binary inside ``node_modules``.
+def _electron_dir(project_root: Path) -> Path:
+    """Return the Electron package directory used by the desktop workspace.
 
-    electron-builder reads the binary from ``build.electronDist``
-    (``node_modules/electron/dist``) since #38673, so this is the exact file
-    whose absence makes a pack fail with "The specified electronDist does not
-    exist". The basename differs per OS (the platform Electron is named for the
-    host the build runs on).
+    npm may keep workspace-only dev dependencies under
+    ``apps/desktop/node_modules`` instead of hoisting them to the repo root.
+    Prefer that local package because ``apps/desktop/package.json`` points
+    electron-builder's ``electronDist`` there.
     """
-    dist = project_root / "node_modules" / "electron" / "dist"
+    desktop_local = project_root / "apps" / "desktop" / "node_modules" / "electron"
+    if desktop_local.exists():
+        return desktop_local
+    return project_root / "node_modules" / "electron"
+
+
+def _electron_dist_binary(project_root: Path) -> Path:
+    """Return the path to the Electron main binary inside the installed package.
+
+    electron-builder reads the binary from ``build.electronDist`` since #38673,
+    so this is the exact file whose absence makes a pack fail with "The
+    specified electronDist does not exist". The basename differs per OS (the
+    platform Electron is named for the host the build runs on).
+    """
+    dist = _electron_dir(project_root) / "dist"
     if sys.platform == "darwin":
         return dist / "Electron.app" / "Contents" / "MacOS" / "Electron"
     if sys.platform == "win32":
@@ -5169,7 +5197,7 @@ def _redownload_electron_dist(
     if _electron_dist_ok(project_root):
         return True
 
-    electron_dir = project_root / "node_modules" / "electron"
+    electron_dir = _electron_dir(project_root)
     installer = electron_dir / "install.js"
     if not installer.is_file():
         return False
@@ -5387,9 +5415,9 @@ def cmd_gui(args: argparse.Namespace):
                 print("  Pre-build first:  cd apps/desktop && npm run build")
                 print("  Or drop --skip-build to install dependencies and build automatically.")
                 sys.exit(1)
-            if not (PROJECT_ROOT / "node_modules" / "electron" / "package.json").exists():
-                print("✗ --skip-build --source requires existing workspace dependencies.")
-                print(f"  Install first:  cd {PROJECT_ROOT} && npm ci")
+            if not (_electron_dir(PROJECT_ROOT) / "package.json").exists():
+                print("✗ --skip-build --source requires existing desktop workspace dependencies.")
+                print(f"  Install first:  cd {PROJECT_ROOT} && NODE_ENV=development NPM_CONFIG_OMIT= npm ci")
                 print("  Or drop --skip-build to install dependencies and build automatically.")
                 sys.exit(1)
             print(f"→ Skipping desktop source build (--skip-build --source); using dist at {desktop_dir / 'dist'}")

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -2161,15 +2161,26 @@ function Clear-ElectronBuildCache {
     return $removed
 }
 
-# True when node_modules\electron\dist holds a usable Electron binary.
-# electron-builder reads the binary from build.electronDist
-# (node_modules\electron\dist) since #38673, so this is the exact file whose
-# absence makes a pack fail with "The specified electronDist does not exist". A
-# dist dir that exists but is missing electron.exe (partial extraction / aborted
-# postinstall) is NOT ok.
+# Return the Electron package directory used by the desktop workspace. npm may
+# keep workspace-only dev dependencies under apps/desktop/node_modules instead
+# of hoisting them to the repo root, and apps/desktop/package.json points
+# electron-builder's electronDist there.
+function Get-ElectronDir {
+    param([string]$InstallDir)
+    $desktopLocal = Join-Path $InstallDir 'apps\desktop\node_modules\electron'
+    if (Test-Path -LiteralPath $desktopLocal) { return $desktopLocal }
+    return (Join-Path $InstallDir 'node_modules\electron')
+}
+
+# True when the desktop workspace electronDist holds a usable Electron binary.
+# electron-builder reads the binary from build.electronDist since #38673, so
+# this is the exact file whose absence makes a pack fail with "The specified
+# electronDist does not exist". A dist dir that exists but is missing
+# electron.exe (partial extraction / aborted postinstall) is NOT ok.
 function Test-ElectronDist {
     param([string]$InstallDir)
-    $distExe = Join-Path $InstallDir 'node_modules\electron\dist\electron.exe'
+    $electronDir = Get-ElectronDir -InstallDir $InstallDir
+    $distExe = Join-Path $electronDir 'dist\electron.exe'
     return (Test-Path -LiteralPath $distExe)
 }
 
@@ -2193,7 +2204,7 @@ function Restore-ElectronDist {
     param([string]$InstallDir, [string]$Mirror)
     if (Test-ElectronDist -InstallDir $InstallDir) { return $true }
 
-    $electronDir = Join-Path $InstallDir 'node_modules\electron'
+    $electronDir = Get-ElectronDir -InstallDir $InstallDir
     $distExe = Join-Path $electronDir 'dist\electron.exe'
     $installer = Join-Path $electronDir 'install.js'
     if (-not (Test-Path -LiteralPath $installer)) { return $false }
@@ -2307,6 +2318,10 @@ function Install-Desktop {
         # is the artifact), but on failure we scan $npmOut for the TLS-trust
         # signature so corporate-proxy users get the NODE_EXTRA_CA_CERTS hint
         # instead of an opaque "exit 1" (issue #38016).
+        $prevNodeEnv = $env:NODE_ENV
+        $prevNpmOmit = $env:NPM_CONFIG_OMIT
+        $env:NODE_ENV = "development"
+        $env:NPM_CONFIG_OMIT = ""
         & $npmExe ci 2>&1 | ForEach-Object { "$_" } | Tee-Object -Variable npmOut
         $code = $LASTEXITCODE
         if ($code -ne 0) {
@@ -2314,6 +2329,8 @@ function Install-Desktop {
             & $npmExe install 2>&1 | ForEach-Object { "$_" } | Tee-Object -Variable npmOut
             $code = $LASTEXITCODE
         }
+        $env:NODE_ENV = $prevNodeEnv
+        $env:NPM_CONFIG_OMIT = $prevNpmOmit
         $ErrorActionPreference = $prevEAP
         if ($code -ne 0) {
             Show-NpmCertHint ($npmOut -join "`n") | Out-Null
@@ -2321,6 +2338,8 @@ function Install-Desktop {
         }
         Write-Success "Desktop workspace dependencies installed"
     } catch {
+        $env:NODE_ENV = $prevNodeEnv
+        $env:NPM_CONFIG_OMIT = $prevNpmOmit
         if ($prevEAP) { $ErrorActionPreference = $prevEAP }
         Pop-Location
         throw
@@ -2354,11 +2373,13 @@ function Install-Desktop {
     $prevCSCAuto = $env:CSC_IDENTITY_AUTO_DISCOVERY
     $prevWinCscLink = $env:WIN_CSC_LINK
     $prevWinCscKeyPassword = $env:WIN_CSC_KEY_PASSWORD
+    $prevBuildNpmOmit = $env:NPM_CONFIG_OMIT
     try {
         $ErrorActionPreference = "Continue"
         $env:CSC_IDENTITY_AUTO_DISCOVERY = "false"
         $env:WIN_CSC_LINK = ""
         $env:WIN_CSC_KEY_PASSWORD = ""
+        $env:NPM_CONFIG_OMIT = ""
         & $npmExe run pack 2>&1 | ForEach-Object { "$_" } | Tee-Object -FilePath $buildLog
         $code = $LASTEXITCODE
         if ($code -ne 0) {
@@ -2412,7 +2433,7 @@ function Install-Desktop {
                 & $npmExe run pack 2>&1 | ForEach-Object { "$_" } | Tee-Object -FilePath $buildLog
                 $code = $LASTEXITCODE
             } else {
-                Write-Warn "Could not re-download Electron from the mirror (node_modules\electron\dist still missing)"
+                Write-Warn "Could not re-download Electron from the mirror (apps\desktop\node_modules\electron\dist still missing)"
             }
         }
         $ErrorActionPreference = $prevEAP
@@ -2439,6 +2460,7 @@ function Install-Desktop {
         $env:CSC_IDENTITY_AUTO_DISCOVERY = $prevCSCAuto
         $env:WIN_CSC_LINK = $prevWinCscLink
         $env:WIN_CSC_KEY_PASSWORD = $prevWinCscKeyPassword
+        $env:NPM_CONFIG_OMIT = $prevBuildNpmOmit
     }
     Pop-Location
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -2392,9 +2392,9 @@ _desktop_pack() {
     local desktop_dir="$1"
     local mirror="${2:-}"
     if [ -n "$mirror" ]; then
-        ( cd "$desktop_dir" && ELECTRON_MIRROR="$mirror" CSC_IDENTITY_AUTO_DISCOVERY=false npm run pack )
+        ( cd "$desktop_dir" && NPM_CONFIG_OMIT= ELECTRON_MIRROR="$mirror" CSC_IDENTITY_AUTO_DISCOVERY=false npm run pack )
     else
-        ( cd "$desktop_dir" && CSC_IDENTITY_AUTO_DISCOVERY=false npm run pack )
+        ( cd "$desktop_dir" && NPM_CONFIG_OMIT= CSC_IDENTITY_AUTO_DISCOVERY=false npm run pack )
     fi
 }
 
@@ -2407,15 +2407,29 @@ _desktop_pack() {
 # failed, and we never override a user-pinned ELECTRON_MIRROR.
 DESKTOP_ELECTRON_FALLBACK_MIRROR="https://npmmirror.com/mirrors/electron/"
 
-# True (returns 0) when node_modules/electron/dist holds a usable Electron
-# binary. electron-builder reads the binary from build.electronDist
-# (node_modules/electron/dist) since #38673, so this is the exact file whose
-# absence makes a pack fail with "The specified electronDist does not exist". A
-# dist dir that exists but is missing the binary (partial extraction / aborted
-# postinstall) is NOT ok. $1 = the workspace root holding node_modules.
+# Return the Electron package directory used by the desktop workspace. npm may
+# keep workspace-only dev dependencies under apps/desktop/node_modules instead
+# of hoisting them to the repo root, and apps/desktop/package.json points
+# electron-builder's electronDist there.
+_electron_dir() {
+    local install_dir="$1"
+    if [ -d "$install_dir/apps/desktop/node_modules/electron" ]; then
+        printf '%s\n' "$install_dir/apps/desktop/node_modules/electron"
+    else
+        printf '%s\n' "$install_dir/node_modules/electron"
+    fi
+}
+
+# True (returns 0) when the desktop workspace electronDist holds a usable
+# Electron binary. electron-builder reads the binary from build.electronDist
+# since #38673, so this is the exact file whose absence makes a pack fail with
+# "The specified electronDist does not exist". A dist dir that exists but is
+# missing the binary (partial extraction / aborted postinstall) is NOT ok.
+# $1 = the workspace root holding node_modules.
 _electron_dist_ok() {
     local install_dir="$1"
-    local electron_dir="$install_dir/node_modules/electron"
+    local electron_dir
+    electron_dir="$(_electron_dir "$install_dir")"
     if [ "$OS" = "macos" ]; then
         [ -e "$electron_dir/dist/Electron.app/Contents/MacOS/Electron" ]
     else
@@ -2442,7 +2456,8 @@ _electron_dist_ok() {
 _restore_electron_dist() {
     local install_dir="$1"
     local mirror="${2:-}"
-    local electron_dir="$install_dir/node_modules/electron"
+    local electron_dir
+    electron_dir="$(_electron_dir "$install_dir")"
     _electron_dist_ok "$install_dir" && return 0
 
     [ -f "$electron_dir/install.js" ] || return 1
@@ -2500,7 +2515,7 @@ install_desktop() {
     #    `tsc -b` failing with no obvious cause. Fall back to `npm install`
     #    only if `npm ci` is unavailable or the lockfile is out of sync.
     log_info "Installing desktop workspace dependencies (includes Electron ~150MB, 1-3min)..."
-    ( cd "$INSTALL_DIR" && npm ci ) || ( cd "$INSTALL_DIR" && npm install ) || {
+    ( cd "$INSTALL_DIR" && NODE_ENV=development NPM_CONFIG_OMIT= npm ci ) || ( cd "$INSTALL_DIR" && NODE_ENV=development NPM_CONFIG_OMIT= npm install ) || {
         log_error "Desktop workspace npm install failed"
         # Common cause: a previous 'sudo npm'/'sudo npx' left root-owned files in
         # ~/.npm, so this non-root install can't write the shared cache. npm hides
@@ -2511,7 +2526,7 @@ install_desktop() {
         log_info "earlier 'sudo npm' or 'sudo npx'. Reclaim ownership and retry:"
         log_info "  sudo chown -R \"\$(id -un)\" ~/.npm && npm cache verify"
         log_info "Then re-run this installer, or build manually:"
-        log_info "  cd \"$INSTALL_DIR\" && npm ci && cd apps/desktop && npm run pack"
+        log_info "  cd \"$INSTALL_DIR\" && NODE_ENV=development NPM_CONFIG_OMIT= npm ci && cd apps/desktop && NODE_ENV=development NPM_CONFIG_OMIT= npm run pack"
         return 1
     }
     log_success "Desktop workspace dependencies installed"
@@ -2582,8 +2597,8 @@ install_desktop() {
         # trust and rebuild (@electron/get honors ELECTRON_MIRROR):
         log_info "If the log shows Electron download retries, rebuild via a reachable mirror:"
         log_info "  ELECTRON_MIRROR=<mirror-base-url> \\"
-        log_info "    bash -c 'cd \"$desktop_dir\" && CSC_IDENTITY_AUTO_DISCOVERY=false npm run pack'"
-        log_info "Otherwise build manually: cd $desktop_dir && npm run pack"
+        log_info "    bash -c 'cd \"$desktop_dir\" && NODE_ENV=development NPM_CONFIG_OMIT= CSC_IDENTITY_AUTO_DISCOVERY=false npm run pack'"
+        log_info "Otherwise build manually: cd $desktop_dir && NODE_ENV=development NPM_CONFIG_OMIT= npm run pack"
         return 1
     fi
 

--- a/tests/hermes_cli/test_gui_command.py
+++ b/tests/hermes_cli/test_gui_command.py
@@ -246,6 +246,36 @@ def test_gui_source_mode_uses_renderer_build_and_electron(tmp_path, monkeypatch)
     assert mock_run.call_args_list[1].kwargs["cwd"] == desktop_dir
 
 
+def test_gui_skip_build_source_accepts_workspace_local_electron(tmp_path, monkeypatch):
+    root = _make_desktop_tree(tmp_path)
+    desktop_dir = root / "apps" / "desktop"
+    monkeypatch.setattr(cli_main, "PROJECT_ROOT", root)
+    (desktop_dir / "dist").mkdir()
+    (desktop_dir / "dist" / "index.html").write_text("", encoding="utf-8")
+    local_electron = desktop_dir / "node_modules" / "electron"
+    local_electron.mkdir(parents=True)
+    (local_electron / "package.json").write_text("{}", encoding="utf-8")
+
+    launch_ok = subprocess.CompletedProcess(["npm", "exec", "--", "electron", "."], 0)
+    with patch("hermes_cli.main.shutil.which", return_value="/usr/bin/npm"), \
+         patch("hermes_cli.main.subprocess.run", return_value=launch_ok) as mock_run, \
+         pytest.raises(SystemExit) as exc:
+        cli_main.cmd_gui(_ns(skip_build=True, source=True))
+
+    assert exc.value.code == 0
+    assert mock_run.call_args.args[0] == ["/usr/bin/npm", "exec", "--", "electron", "."]
+
+
+def test_electron_dir_prefers_workspace_local_package(tmp_path):
+    root = _make_desktop_tree(tmp_path)
+    root_electron = root / "node_modules" / "electron"
+    local_electron = root / "apps" / "desktop" / "node_modules" / "electron"
+    root_electron.mkdir(parents=True)
+    local_electron.mkdir(parents=True)
+
+    assert cli_main._electron_dir(root) == local_electron
+
+
 @pytest.mark.parametrize(
     "argv",
     [
@@ -605,7 +635,7 @@ def test_gui_does_not_override_user_electron_mirror(tmp_path, monkeypatch, capsy
 )
 def test_electron_dist_ok_per_platform(tmp_path, monkeypatch, platform, rel):
     monkeypatch.setattr(cli_main.sys, "platform", platform)
-    electron = tmp_path / "node_modules" / "electron"
+    electron = tmp_path / "apps" / "desktop" / "node_modules" / "electron"
     # A dist dir that exists but lacks the binary is NOT ok (partial extraction).
     (electron / "dist").mkdir(parents=True)
     assert cli_main._electron_dist_ok(tmp_path) is False
@@ -620,7 +650,7 @@ def test_redownload_electron_dist_noop_when_present(tmp_path, monkeypatch):
     """Already-healthy dist → no download, so an unrelated build failure can't
     trigger a needless ~200 MB refetch."""
     monkeypatch.setattr(cli_main.sys, "platform", "linux")
-    binp = tmp_path / "node_modules" / "electron" / "dist" / "electron"
+    binp = tmp_path / "apps" / "desktop" / "node_modules" / "electron" / "dist" / "electron"
     binp.parent.mkdir(parents=True)
     binp.write_text("", encoding="utf-8")
 
@@ -632,7 +662,7 @@ def test_redownload_electron_dist_noop_when_present(tmp_path, monkeypatch):
 def test_redownload_electron_dist_missing_installer(tmp_path, monkeypatch):
     """No electron/install.js (deps never installed) → nothing to run."""
     monkeypatch.setattr(cli_main.sys, "platform", "linux")
-    (tmp_path / "node_modules" / "electron").mkdir(parents=True)
+    (tmp_path / "apps" / "desktop" / "node_modules" / "electron").mkdir(parents=True)
 
     with patch("hermes_cli.main.shutil.which", return_value="/usr/bin/node"), \
          patch("hermes_cli.main.subprocess.run") as mock_run:
@@ -644,7 +674,7 @@ def test_redownload_electron_dist_runs_installer_with_mirror(tmp_path, monkeypat
     """Missing dist → wipe any partial dist + version marker, run electron's own
     install.js with ELECTRON_MIRROR injected, and report success on the binary."""
     monkeypatch.setattr(cli_main.sys, "platform", "linux")
-    electron = tmp_path / "node_modules" / "electron"
+    electron = tmp_path / "apps" / "desktop" / "node_modules" / "electron"
     electron.mkdir(parents=True)
     (electron / "install.js").write_text("// stub", encoding="utf-8")
     # A stale partial dist + version marker that MUST be cleared first, otherwise
@@ -684,7 +714,7 @@ def test_redownload_electron_dist_returns_false_when_download_fails(tmp_path, mo
     """install.js ran but produced no binary (still blocked) → False, so the
     caller skips a doomed pack."""
     monkeypatch.setattr(cli_main.sys, "platform", "linux")
-    electron = tmp_path / "node_modules" / "electron"
+    electron = tmp_path / "apps" / "desktop" / "node_modules" / "electron"
     electron.mkdir(parents=True)
     (electron / "install.js").write_text("// stub", encoding="utf-8")
 

--- a/tests/hermes_cli/test_web_ui_build.py
+++ b/tests/hermes_cli/test_web_ui_build.py
@@ -156,6 +156,37 @@ class TestBuildWebUISkipsWhenFresh:
         assert kwargs["env"]["CI"] == "1"
         assert kwargs["env"]["PYTHON"] == "/nix/store/python"
 
+    def test_npm_install_forces_dev_dependencies_when_parent_env_is_production(self, tmp_path, monkeypatch):
+        web_dir, _ = _make_web_dir(tmp_path)
+        (web_dir / "package-lock.json").write_text("{}", encoding="utf-8")
+        monkeypatch.setenv("NODE_ENV", "production")
+        monkeypatch.setenv("NPM_CONFIG_OMIT", "dev")
+
+        mock_cp = __import__("subprocess").CompletedProcess([], 0, stdout="", stderr="")
+        with patch("hermes_cli.main.subprocess.run", return_value=mock_cp) as mock_run:
+            _run_npm_install_deterministic("/usr/bin/npm", web_dir)
+
+        _, kwargs = mock_run.call_args
+        assert kwargs["env"]["NODE_ENV"] == "development"
+        assert kwargs["env"].get("NPM_CONFIG_OMIT", "") == ""
+
+    def test_web_build_installs_dev_dependencies_when_parent_env_is_production(self, tmp_path, monkeypatch):
+        web_dir, _ = _make_web_dir(tmp_path)
+        monkeypatch.setenv("NODE_ENV", "production")
+        monkeypatch.setenv("NPM_CONFIG_OMIT", "dev")
+
+        install_cp = __import__("subprocess").CompletedProcess([], 0, stdout="", stderr="")
+        build_cp = __import__("subprocess").CompletedProcess([], 0, stdout="", stderr="")
+        with patch("hermes_cli.main.shutil.which", return_value="/usr/bin/npm"), \
+             patch("hermes_cli.main.subprocess.run", return_value=install_cp) as mock_run, \
+             patch("hermes_cli.main._run_with_idle_timeout", return_value=build_cp):
+            result = _build_web_ui(web_dir)
+
+        assert result is True
+        _, kwargs = mock_run.call_args
+        assert kwargs["env"]["NODE_ENV"] == "development"
+        assert kwargs["env"].get("NPM_CONFIG_OMIT", "") == ""
+
     def test_npm_install_uses_workspace_web_scope(self, tmp_path):
         web_dir, _ = _make_web_dir(tmp_path)
         # Real workspace checkout: the single lockfile lives at the root, so

--- a/tests/test_desktop_electron_pin.py
+++ b/tests/test_desktop_electron_pin.py
@@ -17,8 +17,10 @@ These tests lock the contract that prevents that drift, without hard-coding the
 specific version (which is allowed to move):
 
 1. the Electron dependency is an *exact* version (Electron Builder needs the
-   installed binary to match ``electronVersion`` / ``electronDist``), and
-2. the dependency, ``build.electronVersion``, and the resolved lockfile entry
+   installed binary to match ``electronVersion`` / ``electronDist``),
+2. ``electronDist`` points at the workspace-local Electron package npm actually
+   installs for apps/desktop, and
+3. the dependency, ``build.electronVersion``, and the resolved lockfile entry
    all agree — so ``npm ci`` installs exactly what the build packages.
 """
 

--- a/tests/test_install_sh_node_env_dev_deps.py
+++ b/tests/test_install_sh_node_env_dev_deps.py
@@ -1,0 +1,58 @@
+"""Regression: installer npm builds must not inherit production NODE_ENV.
+
+The desktop updater can be launched from a Hermes runtime whose environment has
+``NODE_ENV=production``. npm treats that as omit=dev, so TypeScript/Vite are not
+installed and later builds fail with ``sh: tsc: command not found``.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+INSTALL_SH = REPO_ROOT / "scripts" / "install.sh"
+INSTALL_PS1 = REPO_ROOT / "scripts" / "install.ps1"
+
+
+def _extract_function_body(name: str) -> str:
+    text = INSTALL_SH.read_text(encoding="utf-8")
+    match = re.search(
+        rf"^{re.escape(name)}\(\)\s*\{{\s*\n(?P<body>.*?)^\}}",
+        text,
+        re.MULTILINE | re.DOTALL,
+    )
+    assert match is not None, f"{name}() not found in scripts/install.sh"
+    return match["body"]
+
+
+def test_install_desktop_forces_development_env_for_npm_install_and_pack() -> None:
+    body = _extract_function_body("install_desktop")
+
+    assert "NODE_ENV=development NPM_CONFIG_OMIT= npm ci" in body
+    assert "NODE_ENV=development NPM_CONFIG_OMIT= npm install" in body
+    desktop_pack_body = _extract_function_body("_desktop_pack")
+    assert "NPM_CONFIG_OMIT=" in desktop_pack_body
+    assert "NODE_ENV=development" not in desktop_pack_body
+
+
+def test_install_desktop_user_guidance_does_not_reproduce_production_omit_dev() -> None:
+    body = _extract_function_body("install_desktop")
+
+    assert "NODE_ENV=development NPM_CONFIG_OMIT= npm ci" in body
+    assert "NODE_ENV=development NPM_CONFIG_OMIT= npm run pack" in body
+
+
+def test_install_ps1_uses_workspace_local_electron_dist() -> None:
+    text = INSTALL_PS1.read_text(encoding="utf-8")
+
+    assert "function Get-ElectronDir" in text
+    assert "apps\\desktop\\node_modules\\electron" in text
+    assert "Get-ElectronDir -InstallDir $InstallDir" in text
+
+
+def test_install_ps1_forces_dev_dependencies_for_desktop_install() -> None:
+    text = INSTALL_PS1.read_text(encoding="utf-8")
+
+    assert '$env:NODE_ENV = "development"' in text
+    assert '$env:NPM_CONFIG_OMIT = ""' in text


### PR DESCRIPTION
## Summary
- Point Desktop's `electronDist` at the workspace-local Electron package (`apps/desktop/node_modules/electron/dist`), matching where npm installs the app workspace dependency.
- Update CLI, macOS/Linux installer, and Windows installer Electron repair checks to restore the same package path that electron-builder reads.
- Force dev dependency installation for desktop/web npm install paths launched from production environments, so TypeScript/Vite are available during rebuilds.

## Why
Desktop updater rebuilds can inherit `NODE_ENV=production` / `NPM_CONFIG_OMIT=dev` and can also end up with Electron installed under the desktop workspace rather than root `node_modules`. In that state, rebuilds fail with missing build tools or `electronDist does not exist` even though the workspace install is otherwise valid.

## Validation
- `uv run --with pytest python -m pytest tests/hermes_cli/test_gui_command.py tests/hermes_cli/test_web_ui_build.py tests/test_desktop_electron_pin.py tests/test_install_sh_node_env_dev_deps.py -q`
- `bash -n scripts/install.sh`
- `python3 -m py_compile hermes_cli/main.py`
- `git diff --check`
- `NODE_ENV=production NPM_CONFIG_OMIT=dev ./venv/bin/hermes desktop --force-build --build-only`
