### PR TITLE
feat(zai): wire reasoning_effort for GLM-5.x thinking models

### DIFF
--- a/plugins/model-providers/zai/__init__.py
+++ b/plugins/model-providers/zai/__init__.py
@@ -1,9 +1,76 @@
-"""ZAI / GLM provider profile."""
+"""ZAI / GLM provider profile.
+
+GLM-5.x is a reasoning (thinking) family: every response carries a
+``reasoning_content`` field alongside ``content``, and the API accepts a
+top-level ``reasoning_effort`` parameter that controls thinking depth
+(``minimal`` disables it entirely; ``low``/``medium``/``high`` scale it).
+``xhigh`` is a Hermes-internal level with no Z.AI equivalent, so it is
+clamped to ``high``.
+
+Without this profile the agent's ``reasoning_effort`` config is a no-op for
+Z.AI: the generic transport gate only forwards reasoning params for
+OpenRouter / Nous / GitHub / LM Studio, so the effort level never reaches
+the wire and the model keeps its server default regardless of config.
+"""
+
+from __future__ import annotations
+
+from typing import Any
 
 from providers import register_provider
 from providers.base import ProviderProfile
 
-zai = ProviderProfile(
+# Z.AI accepts these top-level reasoning_effort values. There is no distinct
+# ``xhigh`` level — empirically it yields fewer reasoning tokens than ``high``
+# — so Hermes' xhigh is clamped to high.
+_ZAI_EFFORT_MAP = {
+    "minimal": "minimal",
+    "low": "low",
+    "medium": "medium",
+    "high": "high",
+    "xhigh": "high",
+}
+
+
+def _model_supports_reasoning(model: str | None) -> bool:
+    """GLM-5.x thinking-capable model families.
+
+    Earlier GLM generations (glm-4.x, glm-4-9b, glm-4.5-flash, …) are not
+    reasoning models and do not accept ``reasoning_effort``.
+    """
+    m = (model or "").strip().lower()
+    return m.startswith("glm-5")
+
+
+class ZaiProfile(ProviderProfile):
+    """Z.AI / GLM — top-level reasoning_effort for GLM-5.x thinking models."""
+
+    def build_api_kwargs_extras(
+        self, *, reasoning_config: dict | None = None, model: str | None = None, **context
+    ) -> tuple[dict[str, Any], dict[str, Any]]:
+        extra_body: dict[str, Any] = {}
+        top_level: dict[str, Any] = {}
+
+        if not _model_supports_reasoning(model):
+            # glm-4.x and unknowns — leave the wire format untouched.
+            return extra_body, top_level
+
+        if not isinstance(reasoning_config, dict):
+            return extra_body, top_level
+
+        if reasoning_config.get("enabled") is False:
+            # Explicit disable: emit minimal so Z.AI turns thinking off.
+            top_level["reasoning_effort"] = "minimal"
+            return extra_body, top_level
+
+        effort = (reasoning_config.get("effort") or "").strip().lower()
+        if effort:
+            top_level["reasoning_effort"] = _ZAI_EFFORT_MAP.get(effort, "medium")
+
+        return extra_body, top_level
+
+
+zai = ZaiProfile(
     name="zai",
     aliases=("glm", "z-ai", "z.ai", "zhipu"),
     env_vars=("GLM_API_KEY", "ZAI_API_KEY", "Z_AI_API_KEY"),

--- a/tests/providers/test_provider_profiles.py
+++ b/tests/providers/test_provider_profiles.py
@@ -96,6 +96,82 @@ class TestKimiProfile:
         assert "reasoning_effort" not in tl
 
 
+class TestZaiProfile:
+    def test_reasoning_effort_high(self):
+        # enabled + high → top-level reasoning_effort=high, no extra_body.
+        p = get_provider_profile("zai")
+        eb, tl = p.build_api_kwargs_extras(
+            reasoning_config={"enabled": True, "effort": "high"},
+            model="glm-5.2",
+        )
+        assert tl["reasoning_effort"] == "high"
+        assert eb == {}
+
+    def test_reasoning_effort_xhigh_clamps_to_high(self):
+        # xhigh has no Z.AI equivalent — clamp to high (the max real value).
+        p = get_provider_profile("zai")
+        _, tl = p.build_api_kwargs_extras(
+            reasoning_config={"enabled": True, "effort": "xhigh"},
+            model="glm-5.2",
+        )
+        assert tl["reasoning_effort"] == "high"
+
+    def test_reasoning_disabled_emits_minimal(self):
+        # explicit disable → minimal, which turns Z.AI thinking off entirely.
+        p = get_provider_profile("zai")
+        eb, tl = p.build_api_kwargs_extras(
+            reasoning_config={"enabled": False},
+            model="glm-5.2",
+        )
+        assert tl["reasoning_effort"] == "minimal"
+        assert eb == {}
+
+    def test_reasoning_enabled_no_effort_omits(self):
+        # enabled with no effort → omit reasoning_effort so Z.AI applies its
+        # server default, matching the DeepSeek profile convention.
+        p = get_provider_profile("zai")
+        eb, tl = p.build_api_kwargs_extras(
+            reasoning_config={"enabled": True},
+            model="glm-5.2",
+        )
+        assert "reasoning_effort" not in tl
+        assert eb == {}
+
+    def test_no_config_omits(self):
+        # No reasoning_config → no params sent (server default).
+        p = get_provider_profile("zai")
+        eb, tl = p.build_api_kwargs_extras(model="glm-5.2")
+        assert tl == {}
+        assert eb == {}
+
+    def test_non_reasoning_model_untouched(self):
+        # glm-4.x are not thinking models — never send reasoning_effort.
+        p = get_provider_profile("zai")
+        for model in ("glm-4.7", "glm-4.5-flash", "glm-4-9b"):
+            eb, tl = p.build_api_kwargs_extras(
+                reasoning_config={"enabled": True, "effort": "high"},
+                model=model,
+            )
+            assert "reasoning_effort" not in tl, (model, tl)
+            assert eb == {}
+
+    def test_all_reasoning_efforts_map(self):
+        # Cover the full VALID_REASONING_EFFORTS range.
+        p = get_provider_profile("zai")
+        for effort, expected in [
+            ("minimal", "minimal"),
+            ("low", "low"),
+            ("medium", "medium"),
+            ("high", "high"),
+            ("xhigh", "high"),
+        ]:
+            _, tl = p.build_api_kwargs_extras(
+                reasoning_config={"enabled": True, "effort": effort},
+                model="glm-5",
+            )
+            assert tl["reasoning_effort"] == expected, (effort, tl)
+
+
 class TestOpenRouterProfile:
     def test_extra_body_with_prefs(self):
         p = get_provider_profile("openrouter")


### PR DESCRIPTION
## Summary

GLM-5.x is a reasoning (thinking) family: every response carries a `reasoning_content` field alongside `content`, and Z.AI's API accepts a top-level `reasoning_effort` parameter that controls thinking depth (`minimal` disables it entirely; `low`/`medium`/`high` scale it).

**The problem:** the agent's `reasoning_effort` config was a no-op for Z.AI. The generic transport gate (`_supports_reasoning_extra_body`) only forwards reasoning params for OpenRouter / Nous / GitHub / LM Studio, so the effort level never reached the wire — the model kept its server default regardless of config.

**The fix:** override `build_api_kwargs_extras` on `ZaiProfile` to emit `reasoning_effort` as a top-level API param for GLM-5.x models. This mirrors the established pattern from `DeepSeekProfile` (commit `cd9470f41`) and `KimiProfile` — reasoning controls routed through the provider profile, not the legacy transport fallback.

### Behavior
- **GLM-5.x + effort set** → `reasoning_effort` sent as top-level param
- **`xhigh`** → clamped to `high` (Hermes-internal level with no Z.AI equivalent; empirically yields fewer reasoning tokens than `high`)
- **`enabled: false`** → emits `minimal` (turns Z.AI thinking off entirely)
- **No effort / no config** → omits the param so Z.AI applies its server default
- **GLM-4.x (non-reasoning)** → untouched, never sends `reasoning_effort`

## Empirical verification

Tested against `api.z.ai/api/coding/paas/v4/chat/completions` — reasoning token counts by effort:

| effort sent | reasoning tokens |
|---|---|
| (none — current behavior) | 237 |
| `minimal` | **0** (reasoning off) |
| `low` | 184 |
| `medium` | 171 |
| `high` | 235 |
| `xhigh` | 173 *(no distinct level — clamped to high)* |

## Test plan
- [x] `TestZaiProfile` — 7 new tests covering full `VALID_REASONING_EFFORTS` range, disabled state, no-config, and non-reasoning model guard
- [x] Full `tests/providers/` suite passes (118 passed; 1 pre-existing failure in `test_bundled_plugins_discovered` unrelated to this change — `ai-gateway` missing `__init__.py` on main)
- [x] `ruff check` passes
- [x] End-to-end verified on live Z.AI gateway: agent turns with tools + multi-turn reasoning work cleanly