### PR TITLE
fix: recover Codex streams with null output

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -769,13 +769,13 @@ class _CodexCompletionsAdapter:
                 # new failure mode for auxiliary calls.
                 pass
 
+        # Collect output items and text deltas during streaming —
+        # the Codex backend can return empty response.output from
+        # get_final_response() even when items were streamed.
+        collected_output_items: List[Any] = []
+        collected_text_deltas: List[str] = []
+        has_function_calls = False
         try:
-            # Collect output items and text deltas during streaming —
-            # the Codex backend can return empty response.output from
-            # get_final_response() even when items were streamed.
-            collected_output_items: List[Any] = []
-            collected_text_deltas: List[str] = []
-            has_function_calls = False
             if total_timeout:
                 timeout_timer = threading.Timer(float(total_timeout), _close_client_on_timeout)
                 timeout_timer.daemon = True
@@ -857,11 +857,35 @@ class _CodexCompletionsAdapter:
         except Exception as exc:
             if timed_out.is_set():
                 raise TimeoutError(_timeout_message()) from exc
-            logger.debug("Codex auxiliary Responses API call failed: %s", exc)
-            raise
+            # The ChatGPT/Codex Responses endpoint can emit a terminal
+            # response.completed event with response.output=null.  The OpenAI
+            # SDK streaming parser then crashes with TypeError("'NoneType'
+            # object is not iterable") before stream.get_final_response() is
+            # reachable, even though useful output_text.delta events may have
+            # already been yielded.  Treat that SDK parser failure as a
+            # partial-success path for text-only auxiliary calls so background
+            # title generation/compression do not spam user-visible warnings.
+            if (
+                isinstance(exc, TypeError)
+                and "NoneType" in str(exc)
+                and "not iterable" in str(exc)
+                and collected_text_deltas
+                and not has_function_calls
+            ):
+                logger.debug(
+                    "Codex auxiliary: recovered %d text deltas after SDK "
+                    "response.output=None parser failure",
+                    len(collected_text_deltas),
+                )
+            else:
+                logger.debug("Codex auxiliary Responses API call failed: %s", exc)
+                raise
         finally:
             if timeout_timer is not None:
                 timeout_timer.cancel()
+
+        if collected_text_deltas and not text_parts and not tool_calls_raw:
+            text_parts.append("".join(collected_text_deltas))
 
         content = "".join(text_parts).strip() or None
 

--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -245,7 +245,7 @@ def run_codex_stream(agent, api_kwargs: dict, client: Any = None, on_first_delta
                 # but get_final_response() can return an empty output list.
                 # Backfill from collected items or synthesize from deltas.
                 _out = getattr(final_response, "output", None)
-                if isinstance(_out, list) and not _out:
+                if _out is None or (isinstance(_out, list) and not _out):
                     if collected_output_items:
                         final_response.output = list(collected_output_items)
                         logger.debug(
@@ -329,6 +329,19 @@ def run_codex_stream(agent, api_kwargs: dict, client: Any = None, on_first_delta
                 )
                 return agent._run_codex_create_stream_fallback(api_kwargs, client=active_client)
             raise
+        except TypeError as exc:
+            # openai>=2.24 tries to parse response.completed with
+            # `for output in response.output`; the ChatGPT Codex backend can
+            # emit output=null while valid items were already streamed via
+            # response.output_item.done. Route that SDK parsing gap through
+            # the raw create(stream=True) fallback, which can backfill items.
+            if "'NoneType' object is not iterable" in str(exc):
+                logger.debug(
+                    "Responses stream parser hit output=None; falling back to create(stream=True). %s",
+                    agent._client_log_context(),
+                )
+                return agent._run_codex_create_stream_fallback(api_kwargs, client=active_client)
+            raise
 
 
 
@@ -408,7 +421,7 @@ def run_codex_create_stream_fallback(agent, api_kwargs: dict, client: Any = None
             if terminal_response is not None:
                 # Backfill empty output from collected stream events
                 _out = getattr(terminal_response, "output", None)
-                if isinstance(_out, list) and not _out:
+                if _out is None or (isinstance(_out, list) and not _out):
                     if collected_output_items:
                         terminal_response.output = list(collected_output_items)
                         logger.debug(

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -2331,6 +2331,42 @@ class TestCodexAuxiliaryAdapterTimeout:
         assert fake_client.responses.kwargs["timeout"] == 12.5
         assert response.choices[0].message.content == "summary"
 
+    def test_recovers_text_deltas_when_sdk_parser_crashes_on_null_output(self):
+        """Codex may send response.output=null in the terminal event.
+
+        The OpenAI SDK parser raises TypeError before get_final_response() can
+        be called, but prior output_text.delta events are still enough for
+        text-only auxiliary calls such as title generation.
+        """
+        class NullOutputCrashStream:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc, tb):
+                return False
+
+            def __iter__(self):
+                yield SimpleNamespace(type="response.output_text.delta", delta="Recovered ")
+                yield SimpleNamespace(type="response.output_text.delta", delta="Title")
+                raise TypeError("'NoneType' object is not iterable")
+
+            def get_final_response(self):  # pragma: no cover - SDK crash prevents this
+                raise AssertionError("should not need final response after parser crash")
+
+        class FakeResponses:
+            def stream(self, **kwargs):
+                return NullOutputCrashStream()
+
+        fake_client = SimpleNamespace(responses=FakeResponses())
+        adapter = _CodexCompletionsAdapter(fake_client, "gpt-5.5")
+
+        response = adapter.create(
+            messages=[{"role": "user", "content": "title me"}],
+            timeout=12.5,
+        )
+
+        assert response.choices[0].message.content == "Recovered Title"
+
     def test_enforces_total_timeout_while_stream_keeps_emitting_events(self):
         class SlowAliveStream:
             def __enter__(self):


### PR DESCRIPTION
## Summary
- Recover auxiliary text-only Codex calls when the SDK parser crashes on terminal response.output=null after streaming text deltas
- Route main Codex stream parser TypeError for null output through the raw create(stream=True) fallback
- Treat both null and empty output as backfillable from collected streamed output items

## Test Plan
- scripts/run_tests.sh tests/agent/test_auxiliary_client.py -q