### PR TITLE
fix(tui): guard mouse motion from input leaks

### DIFF
--- a/ui-tui/packages/hermes-ink/src/ink/app-mouse.test.ts
+++ b/ui-tui/packages/hermes-ink/src/ink/app-mouse.test.ts
@@ -112,6 +112,26 @@ describe('handleMouseEvent right-click selection behavior', () => {
     expect(app.props.onMouseDownAt).not.toHaveBeenCalled()
   })
 
+  it('does not dispatch right-click paste handlers during right-button motion without a selection', () => {
+    const app = makeApp()
+
+    handleMouseEvent(app, { action: 'press', button: 0x20 | 2, col: 3, kind: 'mouse', row: 1, sequence: '' })
+
+    expect(app.props.onCopySelectionNoClear).not.toHaveBeenCalled()
+    expect(app.props.onMouseDownAt).not.toHaveBeenCalled()
+    expect(app.props.onMouseDragAt).not.toHaveBeenCalled()
+  })
+
+  it('routes modified motion to an active mouse capture target instead of paste handlers', () => {
+    const app = makeApp()
+    app.mouseCaptureTarget = {} as never
+
+    handleMouseEvent(app, { action: 'press', button: 0x20 | 2, col: 3, kind: 'mouse', row: 1, sequence: '' })
+
+    expect(app.props.onMouseDownAt).not.toHaveBeenCalled()
+    expect(app.props.onMouseDragAt).toHaveBeenCalledWith(app.mouseCaptureTarget, 2, 0, 2)
+  })
+
   it('still dispatches right-click handlers when no text is selected', () => {
     const app = makeApp()
 

--- a/ui-tui/packages/hermes-ink/src/ink/components/App.tsx
+++ b/ui-tui/packages/hermes-ink/src/ink/components/App.tsx
@@ -619,6 +619,7 @@ export function handleMouseEvent(app: App, m: ParsedMouse): void {
   const col = m.col - 1
   const row = m.row - 1
   const baseButton = m.button & 0x03
+  const isMotion = (m.button & 0x20) !== 0
 
   // Disable app click handling without blocking wheel/right-click dispatch.
   if (isMouseClicksDisabled() && baseButton === 0) {
@@ -626,7 +627,7 @@ export function handleMouseEvent(app: App, m: ParsedMouse): void {
   }
 
   if (m.action === 'press') {
-    if ((m.button & 0x20) !== 0 && baseButton === 3) {
+    if (isMotion && baseButton === 3) {
       if (app.mouseCaptureTarget) {
         app.props.onMouseUpAt(app.mouseCaptureTarget, col, row, baseButton)
         app.mouseCaptureTarget = undefined
@@ -657,15 +658,19 @@ export function handleMouseEvent(app: App, m: ParsedMouse): void {
       return
     }
 
+    if (isMotion && baseButton !== 0) {
+      if (app.mouseCaptureTarget) {
+        app.props.onMouseDragAt(app.mouseCaptureTarget, col, row, baseButton)
+      }
+
+      return
+    }
+
     if (baseButton !== 0) {
       // Non-left press breaks the multi-click chain.
       app.clickCount = 0
 
       if (baseButton === 2 && hasSelection(sel)) {
-        if ((m.button & 0x20) !== 0) {
-          return
-        }
-
         if (!app.props.getSelectedText()) {
           return
         }
@@ -695,7 +700,7 @@ export function handleMouseEvent(app: App, m: ParsedMouse): void {
       return
     }
 
-    if ((m.button & 0x20) !== 0) {
+    if (isMotion) {
       if (app.mouseCaptureTarget) {
         app.props.onMouseDragAt(app.mouseCaptureTarget, col, row, baseButton)
 

--- a/ui-tui/packages/hermes-ink/src/ink/parse-keypress.test.ts
+++ b/ui-tui/packages/hermes-ink/src/ink/parse-keypress.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
+import { InputEvent } from './events/input-event.js'
 import { INITIAL_STATE, parseMultipleKeypresses } from './parse-keypress.js'
 import { PASTE_END, PASTE_START } from './termio/csi.js'
 
@@ -129,5 +130,16 @@ describe('flush-boundary SGR mouse reassembly', () => {
     const [[key]] = parseMultipleKeypresses(INITIAL_STATE, tail)
 
     expect(key).toMatchObject({ name: 'wheelup' })
+  })
+
+  it('swallows orphaned X10 hover tails instead of leaking printable coordinate bytes', () => {
+    // DECSET 1003 no-button motion uses button code 35; X10 stores each byte
+    // as value+32, so the payload is all printable text. If the ESC was lost,
+    // those bytes can look like real input (for example RED:RED: fragments).
+    const hoverTail = '[M' + String.fromCharCode(35 + 32) + 'RE'
+    const [[key]] = parseMultipleKeypresses(INITIAL_STATE, hoverTail)
+
+    expect(key).toMatchObject({ name: 'mouse' })
+    expect(new InputEvent(key).input).toBe('')
   })
 })

--- a/ui-tui/packages/hermes-ink/src/ink/parse-keypress.ts
+++ b/ui-tui/packages/hermes-ink/src/ink/parse-keypress.ts
@@ -267,13 +267,17 @@ export function parseMultipleKeypresses(
     } else if (token.type === 'text') {
       if (inPaste) {
         pasteBuffer += token.value
-      } else if (/^\[M[\x60-\x7f][\x20-\uffff]{2}$/.test(token.value)) {
-        // Orphaned X10 wheel tail (legacy 1000/1002 terminals, fullscreen
-        // only). If the buffered ESC was flushed as a lone Escape and the X10
-        // payload (`[M` + 3 bytes) arrived as the next text token, re-synthesize
-        // with ESC so the scroll event still fires instead of leaking. SGR mouse
-        // reports no longer reach this branch — the tokenizer keeps an
-        // incomplete CSI buffered across a flush and reassembles it (see
+      } else if (/^\[M[\x20-\uffff]{3}$/.test(token.value)) {
+        // Orphaned X10 mouse tail (legacy 1000/1002/1003 terminals,
+        // fullscreen only). If the buffered ESC was flushed as a lone Escape
+        // and the X10 payload (`[M` + 3 bytes) arrived as the next text token,
+        // re-synthesize with ESC so the mouse event is parsed/suppressed
+        // instead of leaking coordinate bytes into the focused input. This
+        // covers passive hover/no-button motion too — not just wheel events —
+        // because coordinates are printable bytes and can look like user text
+        // (for example `RED:RED:` fragments while moving the pointer).
+        // SGR mouse reports no longer reach this branch — the tokenizer keeps
+        // an incomplete CSI buffered across a flush and reassembles it (see
         // termio/tokenize.ts), so the old fragment/burst recovery is gone.
         const resynthesized = '\x1b' + token.value
         keys.push(parseKeypress(resynthesized))


### PR DESCRIPTION
## Rationale

Moving the pointer into or across the TUI can produce passive mouse-motion reports. Two failure modes need to stay out of focused text input:

- legacy X10 hover tails can arrive without their ESC prefix, leaving printable coordinate bytes that show up as junk such as `RED:RED:`;
- SGR right-button motion (`0x20 | 0x02`) can look like a right-click if motion is not handled before button dispatch, causing TextInput paste handlers to run while merely hovering/moving.

## Summary

- Expand orphaned X10 mouse-tail recovery from wheel-only reports to all X10 mouse tails.
- Parse/suppress hover/no-button motion tails as mouse input instead of allowing printable coordinate bytes to reach text input.
- Handle motion packets before non-left click dispatch so right-button motion cannot trigger right-click paste handlers.
- Add regressions for orphaned X10 hover tails and SGR right-button motion with/without mouse capture.

## Test Plan

- [x] `npm --prefix ui-tui exec vitest run packages/hermes-ink/src/ink/app-mouse.test.ts packages/hermes-ink/src/ink/parse-keypress.test.ts`
- [x] `npm --prefix ui-tui run typecheck`
- [x] `cd ui-tui && npm exec eslint packages/hermes-ink/src/ink/components/App.tsx packages/hermes-ink/src/ink/app-mouse.test.ts packages/hermes-ink/src/ink/parse-keypress.ts packages/hermes-ink/src/ink/parse-keypress.test.ts`
- [x] `npm --prefix ui-tui run build`
