### PR TITLE
fix(vision): refuse stale inbound-cache images in native fast path

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -18182,6 +18182,19 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 else:
                     _run_message = message
 
+                # Record the inbound images attached THIS turn so the native
+                # vision fast path can refuse a stale cache path that reached
+                # the model via transcript replay or memory recall (it would
+                # otherwise silently describe an older, unrelated image).
+                # Set unconditionally — an empty list means "no inbound image
+                # this turn", which correctly makes any image_cache path stale.
+                _vision_turn_token = None
+                try:
+                    from tools.vision_tools import set_current_turn_image_paths
+                    _vision_turn_token = set_current_turn_image_paths(_native_imgs or [])
+                except Exception:
+                    _vision_turn_token = None
+
                 _api_run_message = _wrap_current_message_with_observed_context(
                     _run_message,
                     observed_group_context,
@@ -18200,6 +18213,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     _conversation_kwargs["persist_user_timestamp"] = _persist_user_timestamp_override
                 result = agent.run_conversation(_api_run_message, **_conversation_kwargs)
             finally:
+                try:
+                    if _vision_turn_token is not None:
+                        from tools.vision_tools import reset_current_turn_image_paths
+                        reset_current_turn_image_paths(_vision_turn_token)
+                except Exception:
+                    pass
                 unregister_gateway_notify(_approval_session_key)
                 # Cancel any pending clarify entries so blocked agent
                 # threads don't hang past the end of the run (interrupt,

--- a/tests/tools/test_vision_native_fast_path.py
+++ b/tests/tools/test_vision_native_fast_path.py
@@ -303,3 +303,118 @@ class TestHandleVisionAnalyzeFastPath:
         assert isinstance(result, str)
         assert json.loads(result) == {"sentinel": "aux-path"}
         mock_aux.assert_called_once()
+
+
+# ─── stale inbound-cache image guard ─────────────────────────────────────────
+
+
+class TestStaleInboundCacheGuard:
+    """Native fast path must refuse an inbound-cache image that wasn't attached
+    on the current turn.
+
+    Regression for 2026-06-17: a stale ``image_cache/img_*.jpg`` path recalled
+    from memory was loaded and described as the wrong image. The guard only
+    polices files inside the inbound image-cache dir; everything else (browser
+    screenshots, generated images, arbitrary local files) and CLI/test contexts
+    with no turn set are unaffected.
+    """
+
+    def _run(self, coro):
+        return asyncio.new_event_loop().run_until_complete(coro)
+
+    def test_no_turn_context_allows_any_cache_path(self, tmp_path, monkeypatch):
+        """Default (contextvar None) — CLI/tests — never restricts."""
+        from tools import vision_tools
+
+        cache_dir = tmp_path / "image_cache"
+        cache_dir.mkdir()
+        img = cache_dir / "img_deadbeef0001.png"
+        img.write_bytes(_TINY_PNG)
+        monkeypatch.setattr(
+            "gateway.platforms.base.get_image_cache_dir", lambda: cache_dir
+        )
+
+        # No set_current_turn_image_paths call -> contextvar is None -> inert.
+        result = self._run(vision_tools._vision_analyze_native(str(img), "?"))
+        assert isinstance(result, dict) and result.get("_multimodal") is True
+
+    def test_stale_cache_path_rejected_when_not_in_turn(self, tmp_path, monkeypatch):
+        """A cache image absent from the current turn's set is refused."""
+        from tools import vision_tools
+
+        cache_dir = tmp_path / "image_cache"
+        cache_dir.mkdir()
+        fresh = cache_dir / "img_fresh00000001.png"
+        fresh.write_bytes(_TINY_PNG)
+        stale = cache_dir / "img_stale00000002.png"
+        stale.write_bytes(_TINY_PNG)
+        monkeypatch.setattr(
+            "gateway.platforms.base.get_image_cache_dir", lambda: cache_dir
+        )
+
+        # This turn attached only the fresh image.
+        token = vision_tools.set_current_turn_image_paths([str(fresh)])
+        try:
+            stale_res = self._run(vision_tools._vision_analyze_native(str(stale), "?"))
+            fresh_res = self._run(vision_tools._vision_analyze_native(str(fresh), "?"))
+        finally:
+            vision_tools.reset_current_turn_image_paths(token)
+
+        # Stale path fails closed with a clear, actionable error.
+        assert isinstance(stale_res, str)
+        parsed = json.loads(stale_res)
+        assert parsed.get("success") is False
+        assert "earlier message" in parsed.get("error", "")
+        # Fresh path (in the turn set) still works.
+        assert isinstance(fresh_res, dict) and fresh_res.get("_multimodal") is True
+
+    def test_empty_turn_set_makes_all_cache_paths_stale(self, tmp_path, monkeypatch):
+        """A turn that attached no inbound images rejects any cache path.
+
+        This is the text-routing / recall case: the user's current message had
+        no image, but a stale cache path was recalled into context.
+        """
+        from tools import vision_tools
+
+        cache_dir = tmp_path / "image_cache"
+        cache_dir.mkdir()
+        stale = cache_dir / "img_stale00000003.png"
+        stale.write_bytes(_TINY_PNG)
+        monkeypatch.setattr(
+            "gateway.platforms.base.get_image_cache_dir", lambda: cache_dir
+        )
+
+        token = vision_tools.set_current_turn_image_paths([])  # no images this turn
+        try:
+            result = self._run(vision_tools._vision_analyze_native(str(stale), "?"))
+        finally:
+            vision_tools.reset_current_turn_image_paths(token)
+
+        assert isinstance(result, str)
+        assert json.loads(result).get("success") is False
+
+    def test_non_cache_path_never_restricted(self, tmp_path, monkeypatch):
+        """Files outside the inbound cache dir are out of scope for the guard.
+
+        Browser screenshots, generated images, and arbitrary local paths must
+        keep working even when the turn set is empty.
+        """
+        from tools import vision_tools
+
+        cache_dir = tmp_path / "image_cache"
+        cache_dir.mkdir()
+        monkeypatch.setattr(
+            "gateway.platforms.base.get_image_cache_dir", lambda: cache_dir
+        )
+
+        # Image lives OUTSIDE the inbound cache dir (e.g. a generated image).
+        other = tmp_path / "generated_image.png"
+        other.write_bytes(_TINY_PNG)
+
+        token = vision_tools.set_current_turn_image_paths([])  # empty turn set
+        try:
+            result = self._run(vision_tools._vision_analyze_native(str(other), "?"))
+        finally:
+            vision_tools.reset_current_turn_image_paths(token)
+
+        assert isinstance(result, dict) and result.get("_multimodal") is True

--- a/tools/vision_tools.py
+++ b/tools/vision_tools.py
@@ -31,13 +31,14 @@ Usage:
 import base64
 import contextlib
 import asyncio
+import contextvars
 import json
 from concurrent.futures import ThreadPoolExecutor
 import logging
 import os
 import uuid
 from pathlib import Path
-from typing import Any, Awaitable, Dict, Optional
+from typing import Any, Awaitable, Dict, List, Optional
 from urllib.parse import urlparse
 import httpx
 from agent.auxiliary_client import async_call_llm, extract_content_or_reasoning
@@ -47,6 +48,91 @@ from tools.website_policy import check_website_access
 import sys
 
 logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Current-turn inbound-image guard
+# ---------------------------------------------------------------------------
+# Inbound user photos are cached to ``{HERMES_HOME}/cache/images`` (legacy
+# ``image_cache``) as ``img_<hash>.<ext>``.  The gateway records the paths it
+# attached for THIS turn here, so the native vision fast path can refuse a
+# cache path that belongs to some OTHER (older) turn.
+#
+# Why this exists: ``[Image attached at: .../image_cache/img_x.jpg]`` hints and
+# raw cache paths leak into durable context via transcript replay AND memory
+# recall.  A later turn can then hand ``vision_analyze`` a 12-hour-old cache
+# path; without this guard the fast path silently loads those stale pixels and
+# the model confidently describes the WRONG image (observed 2026-06-17: a fresh
+# "what's this game" photo was answered from an unrelated morning screenshot
+# recalled out of Mnemosyne working memory).
+#
+# Default ``None`` means "no gateway turn context" (CLI, tests, subagents) —
+# the guard is INERT and every path resolves as before.  An empty list means
+# "this turn attached no inbound images", so ANY cache path is stale.  Browser
+# screenshots (``cache/vision``), generated images, and http(s) URLs live
+# outside the inbound cache dir and are never restricted.
+_current_turn_image_paths: contextvars.ContextVar[Optional[List[str]]] = (
+    contextvars.ContextVar("vision_current_turn_image_paths", default=None)
+)
+
+
+def set_current_turn_image_paths(paths: Optional[List[str]]) -> contextvars.Token:
+    """Record the inbound image paths attached on the current gateway turn.
+
+    Pass the list the gateway attached natively (may be empty), or ``None`` to
+    clear. Returns a token; pass it to :func:`reset_current_turn_image_paths`
+    in a ``finally`` so the setting is scoped to exactly one turn.
+    """
+    norm: Optional[List[str]] = None
+    if paths is not None:
+        norm = []
+        for p in paths:
+            try:
+                norm.append(os.path.basename(os.path.realpath(os.path.expanduser(str(p)))))
+            except Exception:
+                continue
+    return _current_turn_image_paths.set(norm)
+
+
+def reset_current_turn_image_paths(token: contextvars.Token) -> None:
+    """Reset the current-turn image-path contextvar using ``token``."""
+    try:
+        _current_turn_image_paths.reset(token)
+    except Exception:
+        pass
+
+
+def _inbound_image_cache_dir() -> Optional[Path]:
+    """Return the resolved inbound-image cache dir, or None if unavailable."""
+    try:
+        from gateway.platforms.base import get_image_cache_dir
+        return get_image_cache_dir().resolve()
+    except Exception:
+        try:
+            return get_hermes_dir("cache/images", "image_cache").resolve()
+        except Exception:
+            return None
+
+
+def _is_stale_inbound_cache_path(resolved_path: Path) -> bool:
+    """True if *resolved_path* is an inbound cache image NOT from this turn.
+
+    Only inbound-image-cache files are policed. A path outside that directory
+    (browser screenshot, generated image, arbitrary local file, downloaded
+    URL) is never considered stale. When there is no gateway turn context
+    (contextvar is ``None``), nothing is stale — CLI and tests are unaffected.
+    """
+    live = _current_turn_image_paths.get()
+    if live is None:
+        return False  # no gateway turn context — inert
+    cache_dir = _inbound_image_cache_dir()
+    if cache_dir is None:
+        return False
+    try:
+        if resolved_path.parent != cache_dir:
+            return False  # not an inbound-cache image — out of scope
+    except Exception:
+        return False
+    return resolved_path.name not in set(live)
 
 _debug = DebugSession("vision_tools", env_var="VISION_TOOLS_DEBUG")
 
@@ -966,6 +1052,35 @@ async def _vision_analyze_native(
             resolve_image_source,
         )
 
+        # Reject inbound-cache images that belong to an OLDER turn, before
+        # doing any resolution work. A stale ``image_cache/img_*`` path can
+        # reach us via transcript replay or memory recall; loading it would
+        # describe the wrong image. Out-of-scope paths (browser screenshots,
+        # generated images, other local files) and CLI/test contexts (no
+        # turn set) pass through unchanged. Mirrors image_source.py's own
+        # file:// / expanduser handling so the staleness check inspects the
+        # exact same path the resolver below will end up reading.
+        _stale_check_src = (
+            image_url[len("file://"):]
+            if image_url.lower().startswith("file://") else image_url
+        )
+        _stale_check_path = Path(os.path.expanduser(_stale_check_src))
+        if _stale_check_path.is_file():
+            try:
+                if _is_stale_inbound_cache_path(_stale_check_path.resolve()):
+                    logger.warning(
+                        "Native vision: refusing stale inbound-cache image %s "
+                        "(not attached on the current turn)", _stale_check_path,
+                    )
+                    return tool_error(
+                        "That image isn't available — the referenced cache path "
+                        "is from an earlier message, not the current one. If you "
+                        "need to look at an image, ask the user to send it again.",
+                        success=False,
+                    )
+            except Exception:
+                pass  # never let the guard crash the fast path
+
         try:
             resolved = await resolve_image_source(image_url, ResolveContext(task_id=task_id))
         except ImageResolutionError as exc:
@@ -999,8 +1114,6 @@ async def _vision_analyze_native(
                 except Exception:
                     pass
             temp_image_path = normalized_path
-            should_cleanup = True
-            image_size_bytes = temp_image_path.stat().st_size
 
         image_data_url = await _run_encode_on_cpu_executor(
             _image_to_base64_data_url,


### PR DESCRIPTION
## Summary

The native vision fast path (`_vision_analyze_native` in `tools/vision_tools.py`) loaded whatever image path it was handed. A stale `image_cache/img_*.jpg` path from an **earlier** turn can reach the model via transcript replay **or** memory recall; the fast path then silently loaded those old pixels and the model confidently described the **wrong image**.

This is not a hallucination — a stale image is actually served to the model. Observed on a production WhatsApp deployment: a fresh "what's this game?" photo was answered from an unrelated screenshot cached ~12 hours earlier in a different session, because that older `[Image attached at: …/image_cache/img_*]` path had been recalled into context and passed to `vision_analyze`.

## Root cause

`_vision_analyze_native` resolves any local path that `is_file()` and embeds it, with no check that the path belongs to the **current** turn. Cache paths are durable strings that outlive their turn (they survive in transcript history and in memory recall for the 24h cache-GC window), so a later turn can reference one and get pixels that have nothing to do with the user's current message.

## Fix

A per-turn guard:

- The gateway records the inbound image basenames attached on the current turn in a contextvar (`set_current_turn_image_paths`).
- `_is_stale_inbound_cache_path()` returns True only for a path **inside the inbound image-cache dir** that is **not** in the current turn's set.
- `_vision_analyze_native` fails closed with an actionable error ("that image isn't available … ask the user to send it again") instead of rendering stale pixels.

Deliberately narrow:

- **Inert** when there is no gateway turn context (CLI, subagents, tests) — the contextvar default is `None`, so existing behavior is unchanged.
- Only polices files inside the inbound image-cache dir. Browser screenshots (`cache/vision`), generated images, arbitrary local files, and `http(s)` URLs are **never** restricted.
- Wrapped so the guard can never crash the fast path.

## Behavior change / regression note

The only behavior change is: a `vision_analyze` call on an inbound-cache path **not** attached to the current turn now returns an error instead of an image envelope. The fixture that could turn red is any test that calls `_vision_analyze_native` on an `image_cache/img_*` path *while a current-turn set is active and excludes it*. No such test exists today; the four new tests cover the boundaries (no-context inert, stale rejected, empty-turn-set rejects all cache paths, non-cache path unrestricted).

## How to test

```
scripts/run_tests.sh tests/tools/test_vision_native_fast_path.py -- -q -k StaleInboundCacheGuard
```

Tested on Linux. 25/25 in the file pass; broader vision + image-routing suites (163 tests) green.

Related: #46115 scrubs the `[Image attached at: …]` markers from transcript persistence/replay, which removes one source of stale paths but not memory recall; this guard backstops the tool itself regardless of how a stale path arrives.

## Rebase note (2026-07-04)

Rebased onto current `main`, resolving one real conflict in `tools/vision_tools.py`: `main` had meanwhile replaced the old `local_path.is_file() / elif _validate_image_url_async(...)` branching in `_vision_analyze_native` with a unified `resolve_image_source()` call (`tools/image_source.py`) that also handles `data:`/container/sandbox-confinement paths. The staleness guard now runs as a pre-check against the same resolved local path *before* calling the unified resolver (mirroring the resolver's own `file://` + `expanduser` handling), so the fix applies cleanly on top of the new resolver instead of reintroducing the old branch it replaced.

Re-verified after rebase: 25/25 in `test_vision_native_fast_path.py`, 426/428 in the broader `tests/tools/` vision+image sweep (2 pre-existing failures unrelated to this change — missing `aiohttp` in this env, confirmed identical on clean `origin/main`).
