### PR TITLE
fix(gateway): log image-part count at the native attach site

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -18123,10 +18123,30 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                                 "Native image attachment: skipped %d unreadable path(s): %s",
                                 len(_skipped), _skipped,
                             )
-                        if any(p.get("type") == "image_url" for p in _parts):
+                        _img_parts = sum(
+                            1 for p in _parts if p.get("type") == "image_url"
+                        )
+                        if _img_parts:
                             _run_message: Any = _parts
+                            # Confirm at the ATTACH site how many image parts
+                            # actually made it onto the turn. The prepare-time
+                            # log ("N image(s) will be attached") fires before
+                            # the bytes are read, so a silent drop between the
+                            # two sites was previously invisible. This closes
+                            # that observability gap.
+                            logger.info(
+                                "Native image attachment: attached %d image part(s) "
+                                "to the user turn (buffered=%d, skipped=%d).",
+                                _img_parts, len(_native_imgs), len(_skipped),
+                            )
                         else:
                             # All images failed to read — fall back to plain text.
+                            logger.warning(
+                                "Native image attachment: 0 image parts attached "
+                                "despite %d buffered path(s) — falling back to "
+                                "text-only turn (the model will NOT see the image).",
+                                len(_native_imgs),
+                            )
                             _run_message = message
                     except Exception as _img_exc:
                         logger.warning(


### PR DESCRIPTION
## Summary

The native image attach path logs `"N image(s) will be attached"` at **prepare-time** — before the image bytes are read and the multimodal parts are built. If the parts silently fail to materialize between prepare and the `run_conversation` call site, the turn falls back to a **text-only** message with **no trace in the logs**. That makes "the model says it can't see my image" reports impossible to root-cause: you can't tell from logs whether pixels actually reached the turn.

## Change

Add an attach-site log (pure observability, no behavior change):

- On success, log how many `image_url` parts actually made it onto the user turn, with `buffered` and `skipped` counts.
- When **0** parts attach despite buffered paths, log a `warning` that the turn fell back to text-only and the model will not see the image.

This closes the gap between the prepare-time "will attach" log and what the model actually received.

## How to test

This is a logging-only change. Exercise the native image path (attach an image on a vision-capable model) and confirm the new `"attached N image part(s)"` line appears at INFO, or the `"0 image parts attached"` warning on the fallback path.

Tested on Linux; no functional tests needed (no behavior change). `gateway/run.py` parses and the gateway image-routing suite stays green.
