### PR TITLE
fix: resolve desktop Electron dist from workspace

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -135,7 +135,7 @@
   },
   "build": {
     "electronVersion": "40.10.2",
-    "electronDist": "../../node_modules/electron/dist",
+    "electronDist": "node_modules/electron/dist",
     "appId": "com.nousresearch.hermes",
     "productName": "Hermes",
     "executableName": "Hermes",

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -5110,16 +5110,22 @@ def _purge_electron_build_cache(desktop_dir: Path) -> list[Path]:
     return removed
 
 
-def _electron_dist_binary(project_root: Path) -> Path:
-    """Return the path to the Electron main binary inside ``node_modules``.
+def _desktop_electron_package_dir(project_root: Path) -> Path:
+    """Return the desktop workspace's installed ``electron`` package dir."""
+    return project_root / "apps" / "desktop" / "node_modules" / "electron"
 
-    electron-builder reads the binary from ``build.electronDist``
-    (``node_modules/electron/dist``) since #38673, so this is the exact file
-    whose absence makes a pack fail with "The specified electronDist does not
-    exist". The basename differs per OS (the platform Electron is named for the
-    host the build runs on).
+
+def _electron_dist_binary(project_root: Path) -> Path:
+    """Return the path to the Electron main binary inside the desktop workspace.
+
+    electron-builder resolves ``build.electronDist`` relative to the desktop
+    project dir. With npm workspace installs, the Electron package lives at
+    ``apps/desktop/node_modules/electron``, so this is the exact file whose
+    absence makes a pack fail with "The specified electronDist does not exist".
+    The basename differs per OS (the platform Electron is named for the host the
+    build runs on).
     """
-    dist = project_root / "node_modules" / "electron" / "dist"
+    dist = _desktop_electron_package_dir(project_root) / "dist"
     if sys.platform == "darwin":
         return dist / "Electron.app" / "Contents" / "MacOS" / "Electron"
     if sys.platform == "win32":
@@ -5128,7 +5134,7 @@ def _electron_dist_binary(project_root: Path) -> Path:
 
 
 def _electron_dist_ok(project_root: Path) -> bool:
-    """True when ``node_modules/electron/dist`` holds a usable Electron binary.
+    """True when the desktop workspace Electron dist holds a usable binary.
 
     A directory that exists but is missing the binary (a partial extraction from
     a corrupt cached zip, or an interrupted postinstall) counts as NOT ok, since
@@ -5147,17 +5153,17 @@ def _redownload_electron_dist(
     *,
     mirror: Optional[str] = None,
 ) -> bool:
-    """(Re)populate ``node_modules/electron/dist`` via electron's own downloader.
+    """(Re)populate desktop Electron's ``dist`` via electron's own downloader.
 
-    Since #38673 the desktop build pins ``build.electronDist`` to
-    ``node_modules/electron/dist``, so electron-builder reads the Electron binary
-    straight from there and never downloads it during ``npm run pack``. That dist
-    tree is produced by the ``electron`` package's postinstall (``install.js``)
-    during ``npm ci``. When that download is blocked or throttled (GitHub's
-    release host is unreachable in some regions — #47266), the dist is missing
-    and re-running ``pack`` only re-throws "The specified electronDist does not
-    exist". The mirror fallback therefore has to drive *this* downloader, not
-    another ``pack``.
+    Since #38673 the desktop build pins ``build.electronDist``, so
+    electron-builder reads the Electron binary straight from there and never
+    downloads it during ``npm run pack``. That dist tree is produced by the
+    desktop workspace's ``electron`` package postinstall (``install.js``) during
+    ``npm ci``. When that download is blocked or throttled (GitHub's release host
+    is unreachable in some regions — #47266), the dist is missing and re-running
+    ``pack`` only re-throws "The specified electronDist does not exist". The
+    mirror fallback therefore has to drive *this* downloader, not another
+    ``pack``.
 
     No-op (returns True) when the dist binary is already present, so an unrelated
     build failure doesn't trigger a needless ~200 MB re-download. Otherwise drops
@@ -5169,7 +5175,7 @@ def _redownload_electron_dist(
     if _electron_dist_ok(project_root):
         return True
 
-    electron_dir = project_root / "node_modules" / "electron"
+    electron_dir = _desktop_electron_package_dir(project_root)
     installer = electron_dir / "install.js"
     if not installer.is_file():
         return False
@@ -5387,7 +5393,7 @@ def cmd_gui(args: argparse.Namespace):
                 print("  Pre-build first:  cd apps/desktop && npm run build")
                 print("  Or drop --skip-build to install dependencies and build automatically.")
                 sys.exit(1)
-            if not (PROJECT_ROOT / "node_modules" / "electron" / "package.json").exists():
+            if not (_desktop_electron_package_dir(PROJECT_ROOT) / "package.json").exists():
                 print("✗ --skip-build --source requires existing workspace dependencies.")
                 print(f"  Install first:  cd {PROJECT_ROOT} && npm ci")
                 print("  Or drop --skip-build to install dependencies and build automatically.")
@@ -5448,7 +5454,7 @@ def cmd_gui(args: argparse.Namespace):
                 # failure was something else, the clean re-download is harmless
                 # and the retry fails the same way.
                 purged = _purge_electron_build_cache(desktop_dir)
-                # electronDist is pinned to node_modules/electron/dist (#38673):
+                # electronDist is pinned to apps/desktop/node_modules/electron/dist (#38673):
                 # electron-builder reads the Electron binary from there and `pack`
                 # never downloads it, so purging the cache + re-running pack can't
                 # by itself repopulate a missing/partial dist. When the dist is
@@ -5495,7 +5501,7 @@ def cmd_gui(args: argparse.Namespace):
                     build_result = subprocess.run([npm, "run", build_script], cwd=desktop_dir, env=mirror_env, check=False)
                 else:
                     print("  ✗ Could not re-download Electron from the mirror "
-                          "(node_modules/electron/dist still missing)")
+                          "(apps/desktop/node_modules/electron/dist still missing)")
             if build_result.returncode != 0:
                 print("✗ Desktop GUI build failed")
                 print(f"  Run manually:  cd apps/desktop && npm run {build_script}")

--- a/tests/hermes_cli/test_gui_command.py
+++ b/tests/hermes_cli/test_gui_command.py
@@ -246,6 +246,30 @@ def test_gui_source_mode_uses_renderer_build_and_electron(tmp_path, monkeypatch)
     assert mock_run.call_args_list[1].kwargs["cwd"] == desktop_dir
 
 
+def test_gui_skip_build_source_accepts_desktop_workspace_electron(tmp_path, monkeypatch):
+    root = _make_desktop_tree(tmp_path)
+    desktop_dir = root / "apps" / "desktop"
+    monkeypatch.setattr(cli_main, "PROJECT_ROOT", root)
+    (desktop_dir / "dist").mkdir()
+    (desktop_dir / "dist" / "index.html").write_text("", encoding="utf-8")
+    (desktop_dir / "node_modules" / "electron").mkdir(parents=True)
+    (desktop_dir / "node_modules" / "electron" / "package.json").write_text("{}", encoding="utf-8")
+
+    launch_ok = subprocess.CompletedProcess(["npm", "exec", "--", "electron", "."], 0)
+
+    with patch("hermes_cli.main.shutil.which", return_value="/usr/bin/npm"), \
+         patch("hermes_cli.main._run_npm_install_deterministic") as mock_install, \
+         patch("hermes_cli.main.subprocess.run", return_value=launch_ok) as mock_run, \
+         pytest.raises(SystemExit) as exc:
+        cli_main.cmd_gui(_ns(source=True, skip_build=True))
+
+    assert exc.value.code == 0
+    mock_install.assert_not_called()
+    mock_run.assert_called_once()
+    assert mock_run.call_args.args[0] == ["/usr/bin/npm", "exec", "--", "electron", "."]
+    assert mock_run.call_args.kwargs["cwd"] == desktop_dir
+
+
 @pytest.mark.parametrize(
     "argv",
     [
@@ -605,7 +629,7 @@ def test_gui_does_not_override_user_electron_mirror(tmp_path, monkeypatch, capsy
 )
 def test_electron_dist_ok_per_platform(tmp_path, monkeypatch, platform, rel):
     monkeypatch.setattr(cli_main.sys, "platform", platform)
-    electron = tmp_path / "node_modules" / "electron"
+    electron = tmp_path / "apps" / "desktop" / "node_modules" / "electron"
     # A dist dir that exists but lacks the binary is NOT ok (partial extraction).
     (electron / "dist").mkdir(parents=True)
     assert cli_main._electron_dist_ok(tmp_path) is False
@@ -620,7 +644,7 @@ def test_redownload_electron_dist_noop_when_present(tmp_path, monkeypatch):
     """Already-healthy dist → no download, so an unrelated build failure can't
     trigger a needless ~200 MB refetch."""
     monkeypatch.setattr(cli_main.sys, "platform", "linux")
-    binp = tmp_path / "node_modules" / "electron" / "dist" / "electron"
+    binp = tmp_path / "apps" / "desktop" / "node_modules" / "electron" / "dist" / "electron"
     binp.parent.mkdir(parents=True)
     binp.write_text("", encoding="utf-8")
 
@@ -632,7 +656,7 @@ def test_redownload_electron_dist_noop_when_present(tmp_path, monkeypatch):
 def test_redownload_electron_dist_missing_installer(tmp_path, monkeypatch):
     """No electron/install.js (deps never installed) → nothing to run."""
     monkeypatch.setattr(cli_main.sys, "platform", "linux")
-    (tmp_path / "node_modules" / "electron").mkdir(parents=True)
+    (tmp_path / "apps" / "desktop" / "node_modules" / "electron").mkdir(parents=True)
 
     with patch("hermes_cli.main.shutil.which", return_value="/usr/bin/node"), \
          patch("hermes_cli.main.subprocess.run") as mock_run:
@@ -644,7 +668,7 @@ def test_redownload_electron_dist_runs_installer_with_mirror(tmp_path, monkeypat
     """Missing dist → wipe any partial dist + version marker, run electron's own
     install.js with ELECTRON_MIRROR injected, and report success on the binary."""
     monkeypatch.setattr(cli_main.sys, "platform", "linux")
-    electron = tmp_path / "node_modules" / "electron"
+    electron = tmp_path / "apps" / "desktop" / "node_modules" / "electron"
     electron.mkdir(parents=True)
     (electron / "install.js").write_text("// stub", encoding="utf-8")
     # A stale partial dist + version marker that MUST be cleared first, otherwise
@@ -684,7 +708,7 @@ def test_redownload_electron_dist_returns_false_when_download_fails(tmp_path, mo
     """install.js ran but produced no binary (still blocked) → False, so the
     caller skips a doomed pack."""
     monkeypatch.setattr(cli_main.sys, "platform", "linux")
-    electron = tmp_path / "node_modules" / "electron"
+    electron = tmp_path / "apps" / "desktop" / "node_modules" / "electron"
     electron.mkdir(parents=True)
     (electron / "install.js").write_text("// stub", encoding="utf-8")
 


### PR DESCRIPTION
## Summary
- resolve desktop `electronDist` from the desktop workspace instead of the repo root
- align desktop rebuild recovery helpers with the workspace-local Electron package
- cover workspace-local Electron dist and `--skip-build --source` behavior in GUI tests

## Problem
`hermes desktop --build-only --force-build` could fail after update because Electron was installed at `apps/desktop/node_modules/electron/dist`, while `electron-builder` was configured to look under the repo root at `node_modules/electron/dist`.

## Verification
- `uv run --extra dev pytest tests/hermes_cli/test_gui_command.py -q` → 36 passed
- `hermes desktop --build-only --force-build` → packaged app ready
