### PR TITLE
fix(profiles): skip large files when scanning the wrapper dir for alias wrappers

### DIFF
--- a/hermes_cli/profiles.py
+++ b/hermes_cli/profiles.py
@@ -391,6 +391,12 @@ def _is_wrapper_dir_in_path() -> bool:
     return wrapper_dir in os.environ.get("PATH", "").split(os.pathsep)
 
 
+# Wrapper scripts are a couple of lines of shell (POSIX) or .bat (Windows), so
+# they are always tiny. Skip larger files before reading: ~/.local/bin often
+# also holds unrelated extensionless CLI binaries.
+_MAX_WRAPPER_BYTES = 64 * 1024
+
+
 def create_wrapper_script(name: str, target: Optional[str] = None) -> Optional[Path]:
     """Create a shell wrapper script at ~/.local/bin/<name>.
 
@@ -445,7 +451,10 @@ def remove_wrapper_script(name: str) -> bool:
     for wrapper_path in candidates:
         if wrapper_path.exists():
             try:
-                # Verify it's our wrapper before removing
+                # Verify it's our wrapper before removing. A profile can share a
+                # name with an unrelated large binary, which is never ours.
+                if wrapper_path.stat().st_size > _MAX_WRAPPER_BYTES:
+                    continue
                 content = wrapper_path.read_text()
                 if "hermes -p" in content:
                     wrapper_path.unlink()
@@ -515,6 +524,11 @@ def find_alias_for_profile(profile_name: str) -> Optional[str]:
         if is_windows and entry.suffix != ".bat":
             continue
         if not is_windows and entry.suffix:
+            continue
+        try:
+            if entry.stat().st_size > _MAX_WRAPPER_BYTES:
+                continue
+        except OSError:
             continue
         try:
             content = entry.read_text()

--- a/tests/hermes_cli/test_profiles.py
+++ b/tests/hermes_cli/test_profiles.py
@@ -885,6 +885,35 @@ class TestFindAliasForProfile:
         (wrapper_dir / "pip").write_text("#!/bin/sh\nexec python -m pip \"$@\"\n")
         assert find_alias_for_profile("steve") is None
 
+    def test_skips_large_files_without_reading(self, profile_env, monkeypatch):
+        monkeypatch.setattr("sys.platform", "darwin")
+        from pathlib import Path
+
+        from hermes_cli.profiles import (
+            _MAX_WRAPPER_BYTES,
+            _get_wrapper_dir,
+            create_wrapper_script,
+            find_alias_for_profile,
+        )
+
+        wrapper_dir = _get_wrapper_dir()
+        wrapper_dir.mkdir(parents=True, exist_ok=True)
+        create_wrapper_script("steve")
+        big = wrapper_dir / "codex"
+        big.write_bytes(b"\x00" * (_MAX_WRAPPER_BYTES + 1))
+
+        read_paths = []
+        original_read_text = Path.read_text
+
+        def spy_read_text(self, *args, **kwargs):
+            read_paths.append(Path(self))
+            return original_read_text(self, *args, **kwargs)
+
+        monkeypatch.setattr(Path, "read_text", spy_read_text)
+
+        assert find_alias_for_profile("steve") == "steve"
+        assert big not in read_paths
+
     def test_custom_alias_on_windows(self, profile_env, monkeypatch):
         monkeypatch.setattr("sys.platform", "win32")
         from hermes_cli.profiles import create_wrapper_script, find_alias_for_profile


### PR DESCRIPTION
## Problem

`find_alias_for_profile()` reverse-looks-up which wrapper activates a profile by iterating the wrapper directory (`~/.local/bin`) and calling `read_text()` on **every** extensionless file to search for `hermes -p <profile>`. `list_profiles()` calls it **once per profile**, so `hermes profile list` and `hermes gateway list` (and anything else that lists profiles) read every candidate file in full, once per profile.

`~/.local/bin` commonly also holds large, extensionless CLI binaries (node-/bun-bundled tools that can be hundreds of MB each). On such a host this turns a status query into reading **gigabytes** off disk with tens of seconds of kernel CPU per invocation. In practice `hermes gateway list` could spend 50s+ of system time and fail to complete.

I confirmed the behaviour with `strace`: the process `read()`s the full contents of multiple 100–260 MB binaries (e.g. an extensionless `codex`/`claude`/`grok` in `~/.local/bin`), `mmap`-ing each several times. Trimming `PATH` does not help because the files are read by their resolved path, not via `PATH` discovery.

## Fix

Wrappers created by `create_wrapper_script()` are only a couple of lines of shell (`#!/bin/sh\nexec hermes -p <profile> "$@"`) or `.bat`, so they are always tiny. Guard the read with a size check (`_MAX_WRAPPER_BYTES = 64 KiB`): anything larger cannot be one of ours and is skipped **before** any `read_text()`. The same guard is applied to `remove_wrapper_script()`, whose profile-named candidate could collide with an unrelated large binary.

This is a pure performance/robustness fix — no behavioural change for real wrappers.

## Tests

Adds `TestFindAliasForProfile` with a regression test that creates a large extensionless file in the wrapper dir and asserts it is **skipped without being read** (spies on `Path.read_text`), plus basic discovery / custom-alias-preference cases.

```
$ python -m pytest tests/hermes_cli/test_profiles.py -q
129 passed
```