### PR TITLE
docs: enforce agent worktree methodology

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,6 +26,42 @@ reviewing any change:
   high. Most new capability should arrive as a CLI command + skill, a
   service-gated tool, or a plugin — not as core surface.
 
+## Worktree / PR Discipline for Agent Changes
+
+Agent-owned repository changes happen in an isolated worktree by default. Treat
+`main` and the primary checkout as read-only snapshots of `origin/main`: inspect,
+`git fetch`, and fast-forward only. Do not edit, stage, commit, or push directly
+from the default branch unless a human maintainer explicitly takes ownership of
+that exception.
+
+For Hermes Agent itself, or any project without a stronger repo-owned helper:
+
+1. Start from a freshly fetched remote default branch:
+   `git fetch origin --prune && git worktree add -b agent/<slug> ../hermes-agent-<slug> origin/main`.
+2. Bootstrap/install dependencies in that worktree when validation depends on an
+   editable install or generated local config. Do not blindly reuse another
+   checkout's virtualenv for proof that is supposed to exercise this checkout.
+3. Keep the slice narrow. Before editing, validation, staging, commit, or push,
+   inspect shared state and the owned diff with `git status --short --branch
+   --untracked-files=all`, `git diff --name-status HEAD -- <owned-paths...>`,
+   and `git diff --check HEAD -- <owned-paths...>`.
+4. Treat unrelated dirty or staged files as another agent's work. Never stage,
+   unstage, reset, revert, clean, or summarize unrelated files. Stage explicit
+   owned paths only; never use `git add .` or `git add -A` in agent sessions.
+5. Push only the dedicated feature branch, open a PR, and report the commit SHA,
+   PR URL, and validation. Spawned subagents stay PR-free; the launching agent
+   owns final scoped review, push, and PR creation.
+6. Rebase only your own feature branch onto fresh `origin/main`; if it was
+   already pushed, update that branch with `git push --force-with-lease`. Never
+   force-push `main` or a branch you do not solely own.
+7. After the PR merges, remove only your own worktree/branch.
+
+`hermes -w` is a convenience for disposable isolation, not a substitute for a
+repo-owned methodology. It creates `.worktrees/hermes-<hash>` from the current
+`HEAD`, does not fetch or run project preflight/bootstrap, and auto-removes the
+worktree unless it contains commits unreachable from remotes. Use the explicit
+worktree/PR flow for durable repo work.
+
 ## Contribution Rubric — What We Want / What We Don't
 
 This is the project's intent layer. Use it two ways:
@@ -1216,12 +1252,14 @@ guards and be dispatched inline, not via `_process_message_background()`
 (which races session lifecycle).
 
 ### Squash merges from stale branches silently revert recent fixes
-Before squash-merging a PR, ensure the branch is up to date with `main`
-(`git fetch origin main && git reset --hard origin/main` in the worktree,
-then re-apply the PR's commits). A stale branch's version of an unrelated
-file will silently overwrite recent fixes on main when squashed. Verify
-with `git diff HEAD~1..HEAD` after merging — unexpected deletions are a
-red flag.
+Before squash-merging a PR, ensure the feature branch is up to date with
+`origin/main` from inside the owning worktree. Fetch, inspect the scoped diff,
+then rebase the feature branch onto `origin/main`; if the branch was already
+pushed, update only that feature branch with `git push --force-with-lease`.
+Do not reset/reapply from the default branch, and never force-push `main`.
+A stale branch's version of an unrelated file can silently overwrite recent
+fixes on main when squashed. Verify the merge result with a scoped
+`git diff HEAD~1..HEAD` after merging — unexpected deletions are a red flag.
 
 ### Don't wire in dead code without E2E validation
 Unused code that was never shipped was dead for a reason. Before wiring an

--- a/skills/autonomous-ai-agents/hermes-agent/SKILL.md
+++ b/skills/autonomous-ai-agents/hermes-agent/SKILL.md
@@ -74,6 +74,25 @@ hermes [flags] [command]
 
 No subcommand defaults to `chat`.
 
+### Worktree policy for coding tasks
+
+When Hermes is changing a git repository, first read the project's local
+instructions (`AGENTS.md`, `CLAUDE.md`, `.cursorrules`, etc.). If they define a
+repo-owned worktree or preflight command, use that instead of generic `hermes -w`.
+
+Default durable PR workflow:
+1. Keep the primary/default-branch checkout read-only.
+2. Fetch and branch a dedicated worktree from `origin/<default-branch>`.
+3. Bootstrap that worktree's own environment if the project uses editable
+   installs, generated config, or per-checkout virtualenvs.
+4. Own a narrow path set; stage only explicit paths, never `git add .`.
+5. Push the feature branch and open a PR; do not push the default branch.
+
+`hermes -w` is useful for disposable isolation, but it branches from the current
+`HEAD`, does not run project preflight/bootstrap/validation, and auto-removes the
+worktree unless it has commits unreachable from remotes. Use repo-owned or
+explicit worktree flows for production/durable changes.
+
 ### Chat
 
 ```
@@ -613,7 +632,7 @@ terminal(command="tmux new-session -d -s resumed 'hermes --resume 20260225_14305
 ### Tips
 
 - **Prefer `delegate_task` for quick subtasks** — less overhead than spawning a full process
-- **Use `-w` (worktree mode)** when spawning agents that edit code — prevents git conflicts
+- **Use project worktree policy for coding agents** — repo-owned helpers/preflight beat generic `hermes -w`; use `-w` only when its disposable current-HEAD worktree semantics are acceptable
 - **Set timeouts** for one-shot mode — complex tasks can take 5-10 minutes
 - **Use `hermes chat -q` for fire-and-forget** — no PTY needed
 - **Use tmux for interactive sessions** — raw PTY mode has `\r` vs `\n` issues with prompt_toolkit

--- a/website/docs/developer-guide/contributing.md
+++ b/website/docs/developer-guide/contributing.md
@@ -59,12 +59,22 @@ uv pip install -e ".[all,dev]"
 npm install
 ```
 
-After that, create branches and run tests from that checkout:
+After that, keep the installed checkout as a clean primary snapshot and do
+agent-owned work from a dedicated worktree:
 
 ```bash
-git checkout -b fix/description
+git fetch origin --prune
+git worktree add -b agent/fix-description ../hermes-agent-fix-description origin/main
+cd ../hermes-agent-fix-description
+
+# Bootstrap this checkout if your validation depends on editable-install paths.
+uv pip install -e ".[all,dev]"
 scripts/run_tests.sh
 ```
+
+If you are a human working in a throwaway clone, a normal feature branch is fine.
+For Hermes agents and long-running contributor work, use the worktree flow so the
+primary checkout and default branch remain read-only.
 
 ### Manual clone fallback
 
@@ -211,6 +221,23 @@ Hermes has terminal access. Security matters.
 
 ## Pull Request Process
 
+### Branch and worktree discipline
+
+For agent-owned changes, branch in a dedicated worktree from the freshly fetched
+remote default branch. Keep the primary checkout/default branch clean and
+read-only, stage explicit paths only, push the feature branch, and open a PR.
+Do not commit or push directly to `main`.
+
+```bash
+git fetch origin --prune
+git worktree add -b agent/short-description ../hermes-agent-short-description origin/main
+cd ../hermes-agent-short-description
+```
+
+Human contributors in a personal throwaway clone can use a normal feature branch,
+but PRs should still be narrow, current with `origin/main`, and never include
+unrelated staged files.
+
 ### Branch Naming
 
 ```
@@ -223,10 +250,15 @@ refactor/description   # Code restructuring
 
 ### Before Submitting
 
-1. **Run tests**: `pytest tests/ -v`
+1. **Run scoped tests through the wrapper**: `scripts/run_tests.sh <paths...>`
+   (or the full `scripts/run_tests.sh` before broad changes)
 2. **Test manually**: Run `hermes` and exercise the code path you changed
-3. **Check cross-platform impact**: Consider macOS and different Linux distros
-4. **Keep PRs focused**: One logical change per PR
+3. **Review the owned diff**: `git status --short --branch --untracked-files=all`,
+   `git diff --name-status HEAD -- <owned-paths...>`, and `git diff --check HEAD -- <owned-paths...>`
+4. **Keep PRs focused**: One logical change per PR; do not include unrelated
+   dirty or staged files
+5. **Update against `origin/main`** before merge; rebase your feature branch and
+   use `--force-with-lease` only on that branch if it was already pushed
 
 ### PR Description
 

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -691,23 +691,38 @@ Leaving the list empty, or omitting the key, is a no-op.
 
 ## Git Worktree Isolation
 
-Enable isolated git worktrees for running multiple agents in parallel on the same repo:
+Enable automatic disposable git worktrees for CLI sessions:
 
 ```yaml
 worktree: true    # Always create a worktree (same as hermes -w)
 # worktree: false # Default — only when -w flag is passed
 ```
 
-When enabled, each CLI session creates a fresh worktree under `.worktrees/` with its own branch. Agents can edit files, commit, push, and create PRs without interfering with each other. Clean worktrees are removed on exit; dirty ones are kept for manual recovery.
+When enabled, each CLI session creates a fresh worktree under `.worktrees/` from
+the current `HEAD` with a branch like `hermes/hermes-<hash>`. This is useful for
+quick isolation when running multiple agents on one repo, but it is not a full
+repo-governance workflow: Hermes does not fetch `origin`, branch from the remote
+default branch, run project-specific preflight/claim checks, bootstrap a
+per-worktree environment, validate, push, or open a PR for you.
 
-You can also list gitignored files to copy into worktrees via `.worktreeinclude` in your repo root:
+On exit, automatic worktree cleanup preserves a worktree only when it has commits
+that are not reachable from any remote branch. Uncommitted-only edits are not a
+durable handoff; commit and push work you need to keep, or use a manual/repo-owned
+worktree workflow for PR-bound changes.
 
-```
+You can list gitignored files to copy into automatic worktrees via
+`.worktreeinclude` in your repo root:
+
+```text
 # .worktreeinclude
-.env
-.venv/
-node_modules/
+.env.local
+config/local.yaml
 ```
+
+Keep `.worktreeinclude` small and intentional. Avoid copying `.venv/`,
+`node_modules/`, caches, secrets, or generated artifacts unless your repository
+explicitly says that is safe. Projects with editable installs usually need each
+worktree to run its own bootstrap so paths point at the active checkout.
 
 ## Context Compression
 

--- a/website/docs/user-guide/git-worktrees.md
+++ b/website/docs/user-guide/git-worktrees.md
@@ -2,172 +2,227 @@
 sidebar_position: 3
 sidebar_label: "Git Worktrees"
 title: "Git Worktrees"
-description: "Run multiple Hermes agents safely on the same repository using git worktrees and isolated checkouts"
+description: "Run Hermes agents safely with dedicated git worktrees, narrow ownership, and PR handoff"
 ---
 
 # Git Worktrees
 
-Hermes Agent is often used on large, long‑lived repositories. When you want to:
+Hermes Agent is often used on large, long-lived repositories. When you want to
+run multiple agents, protect the default branch, or keep a long-running change
+reviewable, use a dedicated git worktree for each task.
 
-- Run **multiple agents in parallel** on the same project, or
-- Keep experimental refactors isolated from your main branch,
+A worktree is not just a convenience checkout. For agent-owned code changes it is
+part of the safety boundary:
 
-Git **worktrees** are the safest way to give each agent its own checkout without duplicating the entire repository.
-
-This page shows how to combine worktrees with Hermes so each session has a clean, isolated working directory.
+- The primary checkout stays a read-only snapshot of `origin/<default-branch>`.
+- Each task gets its own branch and working directory.
+- Agents stage, validate, commit, push, and open PRs only for their owned paths.
+- The default branch reaches changes only through a merged pull request.
 
 ## Why Use Worktrees with Hermes?
 
-Hermes treats the **current working directory** as the project root:
+Hermes treats the current working directory as the project root:
 
 - CLI: the directory where you run `hermes` or `hermes chat`
-- Messaging gateways: the directory set by `terminal.cwd` in `~/.hermes/config.yaml`
+- Messaging gateways: the directory set by `terminal.cwd` in `config.yaml`
 
-If you run multiple agents in the **same checkout**, their changes can interfere with each other:
+If multiple agents share one checkout, their edits, generated files, staged
+state, and test artifacts can collide. Worktrees give each session:
 
-- One agent may delete or rewrite files the other is using.
-- It becomes harder to understand which changes belong to which experiment.
-
-With worktrees, each agent gets:
-
-- Its **own branch and working directory**
-- Its **own Checkpoint Manager history** for `/rollback`
+- Its own branch and working directory
+- Its own Checkpoint Manager history for `/rollback`
+- A clear ownership boundary for review and cleanup
 
 See also: [Checkpoints and /rollback](./checkpoints-and-rollback.md).
 
-## Quick Start: Creating a Worktree
+## Default Agent Methodology
 
-From your main repository (containing `.git/`), create a new worktree for a feature branch:
+Before editing a repository, read its local context files (`AGENTS.md`,
+`CLAUDE.md`, `.cursorrules`, or equivalent). If the repository provides its own
+worktree/preflight command, use that command instead of generic git commands.
+Project policy wins over this generic guide.
 
-```bash
-# From the main repo root
-cd /path/to/your/repo
-
-# Create a new branch and worktree in ../repo-feature
-git worktree add ../repo-feature feature/hermes-experiment
-```
-
-This creates:
-
-- A new directory: `../repo-feature`
-- A new branch: `feature/hermes-experiment` checked out in that directory
-
-Now you can `cd` into the new worktree and run Hermes there:
+When there is no repo-owned helper, use this baseline flow from the primary
+checkout:
 
 ```bash
-cd ../repo-feature
+cd /path/to/repo
 
-# Start Hermes in the worktree
-hermes
+git fetch origin --prune
+default_branch="$(git remote show origin | sed -n 's/.*HEAD branch: //p')"
+default_branch="${default_branch:-main}"
+
+slug="fix-short-description"
+repo_name="$(basename "$(git rev-parse --show-toplevel)")"
+worktree_path="../${repo_name}-${slug}"
+branch="agent/${slug}"
+
+git worktree add -b "$branch" "$worktree_path" "origin/${default_branch}"
+cd "$worktree_path"
 ```
 
-Hermes will:
+Then install or bootstrap the environment inside that worktree if the project
+uses per-checkout editable installs, generated config, or a managed virtualenv.
+Do not blindly reuse another checkout's `.venv`; many Python and Node projects
+record absolute paths or editable-install metadata per checkout.
 
-- See `../repo-feature` as the project root.
-- Use that directory for context files, code edits, and tools.
-- Use a **separate checkpoint history** for `/rollback` scoped to this worktree.
+## Scope and Ownership Before Editing
+
+Declare the slice you own in your prompt or handoff notes. Before editing,
+validation, staging, committing, or pushing, inspect both shared state and the
+owned paths:
+
+```bash
+git status --short --branch --untracked-files=all
+git diff --name-status HEAD -- path/to/owned/file path/to/owned/dir
+git diff --check HEAD -- path/to/owned/file path/to/owned/dir
+```
+
+Rules for agents:
+
+- Treat unrelated dirty or staged files as another agent's work.
+- Do not stage, unstage, reset, revert, summarize, or clean unrelated files.
+- If an owned file overlaps unrelated work, stop and ask the maintainer.
+- Stage only intentional paths; do not use `git add .` or `git add -A`.
+- Keep each branch narrow and short-lived.
 
 ## Running Multiple Agents in Parallel
 
-You can create multiple worktrees, each with its own branch:
+Create one worktree per task, with non-overlapping owned paths:
 
 ```bash
-cd /path/to/your/repo
+cd /path/to/repo
 
-git worktree add ../repo-experiment-a feature/hermes-a
-git worktree add ../repo-experiment-b feature/hermes-b
+git fetch origin --prune
+git worktree add -b agent/task-a ../repo-task-a origin/main
+git worktree add -b agent/task-b ../repo-task-b origin/main
 ```
 
-In separate terminals:
+Start each Hermes process from the worktree it owns:
 
 ```bash
 # Terminal 1
-cd ../repo-experiment-a
+cd ../repo-task-a
 hermes
 
 # Terminal 2
-cd ../repo-experiment-b
+cd ../repo-task-b
 hermes
 ```
 
-Each Hermes process:
+Avoid assigning the same file or generated artifact to two active worktrees.
+Overlapping paths should serialize through one owning worktree instead of racing.
+If a repository has a claim/preflight system, use it before each edit and before
+handoff.
 
-- Works on its own branch (`feature/hermes-a` vs `feature/hermes-b`).
-- Writes checkpoints under a different shadow repo hash (derived from the worktree path).
-- Can use `/rollback` independently without affecting the other.
+## Validation, Commit, Push, and PR Handoff
 
-This is especially useful when:
+Run the repository's scoped validation for the paths you changed. Prefer project
+wrappers when they exist because they know local environment, generated files,
+and CI parity requirements.
 
-- Running batch refactors.
-- Trying different approaches to the same task.
-- Pairing CLI + gateway sessions against the same upstream repo.
+Before committing:
+
+```bash
+git status --short --branch --untracked-files=all
+git diff --name-status HEAD -- path/to/owned/file path/to/owned/dir
+git diff --check HEAD -- path/to/owned/file path/to/owned/dir
+```
+
+Commit and push only the owned paths:
+
+```bash
+git add -- path/to/owned/file path/to/owned/dir
+git diff --cached --name-status
+git commit -m "fix: concise description"
+git push -u origin HEAD
+```
+
+Then open a pull request with the validation evidence in the body. Do not push
+directly to the default branch. Spawned subagents should stay PR-free; the
+launching agent owns final review, push, and PR creation.
+
+If your feature branch already exists and you need to update it against the
+latest default branch, fetch and rebase that feature branch, then push it with
+`--force-with-lease`. Never force-push the default branch or a branch you do not
+solely own.
 
 ## Cleaning Up Worktrees Safely
 
-When you are done with an experiment:
-
-1. Decide whether to keep or discard the work.
-2. If you want to keep it:
-   - Merge the branch into your main branch as usual.
-3. Remove the worktree:
+After the PR merges, clean up only the worktree and branch you own:
 
 ```bash
-cd /path/to/your/repo
+cd /path/to/primary-checkout
 
-# Remove the worktree directory and its reference
-git worktree remove ../repo-feature
+git fetch origin --prune
+git worktree remove ../repo-task-a
+git branch -d agent/task-a
 ```
 
-Notes:
+Use `git worktree list` to inspect existing worktrees. Do not remove another
+agent's worktree unless you have explicit confirmation that it is stale and safe
+to delete.
 
-- `git worktree remove` will refuse to remove a worktree with uncommitted changes unless you force it.
-- Removing a worktree does **not** automatically delete the branch; you can delete or keep the branch using normal `git branch` commands.
-- Hermes checkpoint data under `~/.hermes/checkpoints/` is not automatically pruned when you remove a worktree, but it is usually very small.
-
-## Best Practices
-
-- **One worktree per Hermes experiment**
-  - Create a dedicated branch/worktree for each substantial change.
-  - This keeps diffs focused and PRs small and reviewable.
-- **Name branches after the experiment**
-  - e.g. `feature/hermes-checkpoints-docs`, `feature/hermes-refactor-tests`.
-- **Commit frequently**
-  - Use git commits for high‑level milestones.
-  - Use [checkpoints and /rollback](./checkpoints-and-rollback.md) as a safety net for tool‑driven edits in between.
-- **Avoid running Hermes from the bare repo root when using worktrees**
-  - Prefer the worktree directories instead, so each agent has a clear scope.
+Hermes checkpoint data under `~/.hermes/checkpoints/` is not automatically pruned
+when you remove a worktree, but it is usually small.
 
 ## Using `hermes -w` (Automatic Worktree Mode)
 
-Hermes has a built‑in `-w` flag that **automatically creates a disposable git worktree** with its own branch. You don't need to set up worktrees manually — just `cd` into your repo and run:
+Hermes has a built-in `-w` / `--worktree` flag that creates a disposable worktree
+for a CLI session:
 
 ```bash
-cd /path/to/your/repo
+cd /path/to/repo
 hermes -w
 ```
 
 Hermes will:
 
-- Create a temporary worktree under `.worktrees/` inside your repo.
-- Check out an isolated branch (e.g. `hermes/hermes-<hash>`).
-- Run the full CLI session inside that worktree.
+- Create a worktree under `.worktrees/` in the current repository.
+- Create a branch like `hermes/hermes-<hash>` from the current `HEAD`.
+- Run the CLI session from that worktree.
+- Copy paths listed in `.worktreeinclude` when present.
 
-This is the easiest way to get worktree isolation. You can also combine it with a single query:
+Important limits:
 
-```bash
-hermes -w -z "Fix issue #123"
+- `hermes -w` does not fetch `origin` or branch from `origin/<default-branch>`.
+- It does not run project-specific preflight, claim, bootstrap, or validation
+  commands.
+- On exit, Hermes removes the worktree and branch unless the worktree has commits
+  that are not reachable from any remote branch. Uncommitted-only edits are not a
+  durable handoff.
+
+Use `hermes -w` for quick isolation and disposable experiments. For durable PR
+work, production repositories, or projects with their own worktree method, prefer
+the explicit/repo-owned worktree flow above.
+
+## `.worktreeinclude`
+
+You can list gitignored files to copy into automatic `hermes -w` worktrees:
+
+```text
+# .worktreeinclude
+.env.local
+config/local.yaml
 ```
 
-For parallel agents, open multiple terminals and run `hermes -w` in each — every invocation gets its own worktree and branch automatically.
+Keep this list small and intentional. Avoid copying virtualenvs, dependency
+folders, caches, secrets, or generated artifacts unless the repository explicitly
+says doing so is safe. Many projects require each worktree to run its own
+bootstrap so editable installs and generated config point at the correct
+checkout.
 
 ## Putting It All Together
 
-- Use **git worktrees** to give each Hermes session its own clean checkout.
-- Use **branches** to capture the high‑level history of your experiments.
-- Use **checkpoints + `/rollback`** to recover from mistakes inside each worktree.
+Use this checklist for agent-owned repo changes:
 
-This combination gives you:
+1. Read the repo's local agent instructions.
+2. Create or enter a dedicated worktree from freshly fetched `origin/<default-branch>`.
+3. Bootstrap that worktree's environment if needed.
+4. Own a narrow path set; avoid overlap with other worktrees.
+5. Validate, stage, commit, and push only owned paths.
+6. Open a PR; never push the default branch directly.
+7. Remove only your worktree after the PR merges.
 
-- Strong guarantees that different agents and experiments do not step on each other.
-- Fast iteration cycles with easy recovery from bad edits.
-- Clean, reviewable pull requests.
+This combination gives you isolated edits, reproducible validation evidence, and
+clean pull-request handoff without letting concurrent agents step on each other.

--- a/website/docs/user-guide/skills/bundled/autonomous-ai-agents/autonomous-ai-agents-hermes-agent.md
+++ b/website/docs/user-guide/skills/bundled/autonomous-ai-agents/autonomous-ai-agents-hermes-agent.md
@@ -91,6 +91,25 @@ hermes [flags] [command]
 
 No subcommand defaults to `chat`.
 
+### Worktree policy for coding tasks
+
+When Hermes is changing a git repository, first read the project's local
+instructions (`AGENTS.md`, `CLAUDE.md`, `.cursorrules`, etc.). If they define a
+repo-owned worktree or preflight command, use that instead of generic `hermes -w`.
+
+Default durable PR workflow:
+1. Keep the primary/default-branch checkout read-only.
+2. Fetch and branch a dedicated worktree from `origin/<default-branch>`.
+3. Bootstrap that worktree's own environment if the project uses editable
+   installs, generated config, or per-checkout virtualenvs.
+4. Own a narrow path set; stage only explicit paths, never `git add .`.
+5. Push the feature branch and open a PR; do not push the default branch.
+
+`hermes -w` is useful for disposable isolation, but it branches from the current
+`HEAD`, does not run project preflight/bootstrap/validation, and auto-removes the
+worktree unless it has commits unreachable from remotes. Use repo-owned or
+explicit worktree flows for production/durable changes.
+
 ### Chat
 
 ```
@@ -360,7 +379,7 @@ The registry of record is `hermes_cli/commands.py` — every consumer
 
 ```
 ~/.hermes/config.yaml       Main configuration
-~/.hermes/.env              API keys and secrets
+~/.hermes/.env              API keys and secrets (under $HERMES_HOME if set)
 $HERMES_HOME/skills/        Installed skills
 ~/.hermes/sessions/         Gateway routing index, request dumps, *.jsonl transcripts (and optional per-session JSON snapshots when sessions.write_json_snapshots: true)
 ~/.hermes/state.db          Canonical session store (SQLite + FTS5)
@@ -630,7 +649,7 @@ terminal(command="tmux new-session -d -s resumed 'hermes --resume 20260225_14305
 ### Tips
 
 - **Prefer `delegate_task` for quick subtasks** — less overhead than spawning a full process
-- **Use `-w` (worktree mode)** when spawning agents that edit code — prevents git conflicts
+- **Use project worktree policy for coding agents** — repo-owned helpers/preflight beat generic `hermes -w`; use `-w` only when its disposable current-HEAD worktree semantics are acceptable
 - **Set timeouts** for one-shot mode — complex tasks can take 5-10 minutes
 - **Use `hermes chat -q` for fire-and-forget** — no PTY needed
 - **Use tmux for interactive sessions** — raw PTY mode has `\r` vs `\n` issues with prompt_toolkit
@@ -927,7 +946,7 @@ hermes-agent/
 ```
 <!-- ascii-guard-ignore-end -->
 
-Config: `~/.hermes/config.yaml` (settings), `~/.hermes/.env` (API keys).
+Config: `~/.hermes/config.yaml` (settings), `~/.hermes/.env` (API keys) — both under `$HERMES_HOME` when it is set.
 
 ### Adding a Tool (3 files)
 


### PR DESCRIPTION
## Summary
- Add AGENTS.md policy requiring agent-owned repo changes to happen in dedicated worktrees, with owned-path staging, PR handoff, and no default-branch pushes.
- Rewrite the Git Worktrees user guide around the durable worktree/PR methodology and document the limits of automatic `hermes -w`.
- Update contributing/configuration docs and the bundled hermes-agent skill docs so agents load the same guidance.

## Validation
- `python3 website/scripts/generate-skill-docs.py`
- custom markdown fence/trailing-whitespace check over changed markdown files
- `git diff --check HEAD -- <changed paths>`
- `npm ci`
- `npm run build` (succeeds; emits existing broken-link/broken-anchor warnings outside this slice)
- `npm run lint:diagrams` attempted but local npm deps do not provide `ascii-guard`; verified with `uvx ascii-guard lint --exclude-code-blocks docs` instead