### PR TITLE
fix(telegram): handle topic-qualified chat ids

### DIFF
--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -1173,6 +1173,19 @@ class TelegramAdapter(BasePlatformAdapter):
         thread_id = metadata.get("thread_id") or metadata.get("message_thread_id")
         return str(thread_id) if thread_id is not None else None
 
+    _TOPIC_QUALIFIED_CHAT_ID_RE = re.compile(r"^\s*(-?\d+):(\d+)\s*$")
+
+    @classmethod
+    def _split_topic_qualified_chat_id(
+        cls,
+        chat_id: str,
+    ) -> tuple[str, Optional[str]]:
+        """Split legacy ``chat_id:thread_id`` values at the send boundary."""
+        match = cls._TOPIC_QUALIFIED_CHAT_ID_RE.fullmatch(str(chat_id))
+        if not match:
+            return str(chat_id), None
+        return match.group(1), match.group(2)
+
     @classmethod
     def _metadata_direct_messages_topic_id(cls, metadata: Optional[Dict[str, Any]]) -> Optional[str]:
         if not metadata:
@@ -4447,6 +4460,10 @@ class TelegramAdapter(BasePlatformAdapter):
         # Skip whitespace-only text to prevent Telegram 400 empty-text errors.
         if not content or not content.strip():
             return SendResult(success=True, message_id=None)
+
+        chat_id, target_thread_id = self._split_topic_qualified_chat_id(chat_id)
+        if target_thread_id and self._metadata_thread_id(metadata) is None:
+            metadata = {**(metadata or {}), "thread_id": target_thread_id}
         
         try:
             # Bot API 10.1 rich fast-path: send the raw agent markdown via

--- a/tests/gateway/test_telegram_rich_messages.py
+++ b/tests/gateway/test_telegram_rich_messages.py
@@ -139,6 +139,19 @@ async def test_plain_markdown_stays_on_legacy_path():
 
 
 @pytest.mark.asyncio
+async def test_send_accepts_legacy_topic_qualified_chat_id():
+    """Legacy home values may still encode ``chat_id:thread_id`` together."""
+    adapter = _make_adapter()
+
+    result = await adapter.send("-1003703772259:4294967297", RICH_CONTENT)
+
+    assert result.success is True
+    api_kwargs = _rich_api_kwargs(adapter)
+    assert api_kwargs["chat_id"] == -1003703772259
+    assert api_kwargs["message_thread_id"] == 4294967297
+
+
+@pytest.mark.asyncio
 async def test_expect_edits_metadata_keeps_preview_on_legacy_path():
     adapter = _make_adapter()
 

--- a/tests/gateway/test_telegram_rich_messages.py
+++ b/tests/gateway/test_telegram_rich_messages.py
@@ -152,6 +152,22 @@ async def test_send_accepts_legacy_topic_qualified_chat_id():
 
 
 @pytest.mark.asyncio
+async def test_explicit_metadata_thread_overrides_qualified_chat_id():
+    adapter = _make_adapter()
+
+    result = await adapter.send(
+        "-1003703772259:4294967297",
+        RICH_CONTENT,
+        metadata={"thread_id": "777"},
+    )
+
+    assert result.success is True
+    api_kwargs = _rich_api_kwargs(adapter)
+    assert api_kwargs["chat_id"] == -1003703772259
+    assert api_kwargs["message_thread_id"] == 777
+
+
+@pytest.mark.asyncio
 async def test_expect_edits_metadata_keeps_preview_on_legacy_path():
     adapter = _make_adapter()
 

--- a/tests/tools/test_send_message_telegram_proxy.py
+++ b/tests/tools/test_send_message_telegram_proxy.py
@@ -155,3 +155,38 @@ class TestSendTelegramStandaloneProxy:
         assert "get_updates_request" not in call_kwargs
         httpx_request_factory.assert_not_called()
         bot.send_message.assert_awaited_once()
+
+    def test_topic_qualified_chat_id_is_split_for_standalone_send(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Standalone sends must accept legacy ``chat_id:thread_id`` homes."""
+        from tools.send_message_tool import _send_telegram
+
+        for var in (
+            "TELEGRAM_PROXY",
+            "HTTPS_PROXY",
+            "https_proxy",
+            "HTTP_PROXY",
+            "http_proxy",
+            "ALL_PROXY",
+            "all_proxy",
+            "NO_PROXY",
+            "no_proxy",
+        ):
+            monkeypatch.delenv(var, raising=False)
+        monkeypatch.setattr("gateway.run._gateway_runner_ref", lambda: None)
+        monkeypatch.setattr(sys, "platform", "linux")
+
+        bot = _make_bot()
+        bot_factory = MagicMock(return_value=bot)
+        httpx_request_factory = MagicMock(side_effect=lambda **kw: MagicMock(_kw=kw))
+        _install_telegram_mock_with_request(monkeypatch, bot_factory, httpx_request_factory)
+
+        result: dict[str, Any] = asyncio.run(
+            _send_telegram("tok", "-1003703772259:4294967297", "hello world")
+        )
+
+        assert result["success"] is True
+        kwargs = bot.send_message.call_args.kwargs
+        assert kwargs["chat_id"] == -1003703772259
+        assert kwargs["message_thread_id"] == 4294967297

--- a/tests/tools/test_send_message_tool.py
+++ b/tests/tools/test_send_message_tool.py
@@ -25,7 +25,7 @@ def _reset_signal_scheduler():
     yield
     _reset_scheduler()
 
-from gateway.config import Platform
+from gateway.config import HomeChannel, Platform
 from tools.send_message_tool import (
     _parse_target_ref,
     _resolve_slack_user_target,
@@ -275,6 +275,45 @@ def _ensure_slack_mock(monkeypatch):
 
 
 class TestSendMessageTool:
+
+    def test_bare_telegram_target_preserves_home_thread_id(self):
+        telegram_cfg = SimpleNamespace(enabled=True, token="***", extra={})
+        home = HomeChannel(
+            platform=Platform.TELEGRAM,
+            chat_id="-1003703772259",
+            name="Hermes Discussions",
+            thread_id="4294967297",
+        )
+        config = SimpleNamespace(
+            platforms={Platform.TELEGRAM: telegram_cfg},
+            get_home_channel=lambda _platform: home,
+        )
+
+        with patch("gateway.config.load_gateway_config", return_value=config), \
+             patch("tools.interrupt.is_interrupted", return_value=False), \
+             patch("model_tools._run_async", side_effect=_run_async_immediately), \
+             patch("tools.send_message_tool._send_to_platform", new=AsyncMock(return_value={"success": True})) as send_mock, \
+             patch("gateway.mirror.mirror_to_session", return_value=True):
+            result = json.loads(
+                send_message_tool(
+                    {
+                        "action": "send",
+                        "target": "telegram",
+                        "message": "home topic",
+                    }
+                )
+            )
+
+        assert result["success"] is True
+        send_mock.assert_awaited_once_with(
+            Platform.TELEGRAM,
+            telegram_cfg,
+            "-1003703772259",
+            "home topic",
+            thread_id="4294967297",
+            media_files=[],
+            force_document=False,
+        )
 
     def test_ntfy_topic_target_bypasses_channel_directory(self):
         ntfy_platform = Platform("ntfy")

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -453,6 +453,8 @@ def _handle_send(args):
                 home = HomeChannel(platform=platform, chat_id=wx_home, name="Weixin Home")
         if home:
             chat_id = home.chat_id
+            if thread_id is None:
+                thread_id = getattr(home, "thread_id", None)
             used_home_channel = True
         else:
             home_env = _HOME_CHANNEL_ENV_OVERRIDES.get(
@@ -1233,6 +1235,11 @@ async def _send_telegram(token, chat_id, message, media_files=None, thread_id=No
 
         # Telegram accepts a numeric chat_id OR an @username string; normalize
         # rather than force-int so username home channels don't crash (#13206).
+        topic_target = _TELEGRAM_TOPIC_TARGET_RE.fullmatch(str(chat_id))
+        if topic_target:
+            chat_id = topic_target.group(1)
+            if thread_id is None:
+                thread_id = topic_target.group(2)
         int_chat_id = normalize_telegram_chat_id(chat_id)
         media_files = media_files or []
         thread_kwargs = {}


### PR DESCRIPTION
## Summary

Fix Telegram forum-topic home-channel delivery on current `main`.

This ports the still-relevant behavior from the original patch to the plugin-based Telegram architecture and addresses maintainer feedback:

- preserve `HomeChannel.thread_id` when `send_message(target="telegram")` resolves a bare platform target to its configured home channel
- accept legacy topic-qualified Telegram homes (`chat_id:thread_id`) at the current adapter `send()` boundary
- accept the same legacy form in the standalone Telegram sender used outside the live gateway
- leave edit/draft paths unchanged because their chat/thread IDs come from live Telegram routing state
- add regressions for structured home topics, adapter delivery, and standalone delivery

Explicit targets and channel-directory targets already split forum-topic identifiers on current `main`; this patch does not duplicate that logic elsewhere.

## Validation

- `577 passed` across `tests/gateway/test_telegram*.py` and `tests/tools/test_send_message*.py`
- CI-style isolated touched suites:
  - `tests/gateway/test_telegram_rich_messages.py`: 28 passed
  - `tests/tools/test_send_message_tool.py`: 48 passed
  - `tests/tools/test_send_message_telegram_proxy.py`: 3 passed
  - `tests/tools/test_send_message_target_parse.py`: 3 passed
  - `tests/gateway/test_telegram_thread_fallback.py`: 20 passed
- `ruff check` passed for all changed files
- `git diff --check` passed

The replacement commit uses Jeff's GitHub noreply identity, fixing the original attribution-check failure.
