### PR TITLE
fix(agent): prefer native vision over auxiliary pre-analysis in auto mode

### DIFF
--- a/agent/image_routing.py
+++ b/agent/image_routing.py
@@ -336,13 +336,15 @@ def decide_image_input_mode(
     if mode_cfg == "text":
         return "text"
 
-    # auto
-    if _explicit_aux_vision_override(cfg):
-        return "text"
-
+    # auto — use native when the main model supports vision; fall back to
+    # text (pre-analyze via auxiliary if configured) only when it doesn't.
     supports = _lookup_supports_vision(provider, model, cfg)
     if supports is True:
         return "native"
+
+    if _explicit_aux_vision_override(cfg):
+        return "text"
+
     return "text"
 
 

--- a/tests/agent/test_image_routing.py
+++ b/tests/agent/test_image_routing.py
@@ -97,11 +97,13 @@ class TestDecideImageInputMode:
         with patch("agent.image_routing._lookup_supports_vision", return_value=None):
             assert decide_image_input_mode("openrouter", "brand-new-slug", {}) == "text"
 
-    def test_auto_respects_aux_vision_override_even_for_vision_model(self):
-        """If the user configured a dedicated vision backend, don't bypass it."""
+    def test_auto_with_vision_model_and_aux_override_uses_native(self):
+        """Vision-capable main model should route natively even when a vision
+        auxiliary backend is configured. The auxiliary is a fallback for
+        non-vision models, not an override for vision-capable ones."""
         cfg = {"auxiliary": {"vision": {"provider": "openrouter", "model": "google/gemini-2.5-flash"}}}
         with patch("agent.image_routing._lookup_supports_vision", return_value=True):
-            assert decide_image_input_mode("anthropic", "claude-sonnet-4", cfg) == "text"
+            assert decide_image_input_mode("anthropic", "claude-sonnet-4", cfg) == "native"
 
     def test_none_config_is_auto(self):
         with patch("agent.image_routing._lookup_supports_vision", return_value=True):
@@ -280,14 +282,24 @@ class TestAutoModeRespectsOverride:
             assert decide_image_input_mode("custom", "unknown", {}) == "text"
 
     def test_explicit_aux_vision_override_still_wins(self):
-        # If the user has configured a dedicated vision aux backend, respect
-        # it even when supports_vision: true is also set.
+        # When the model does NOT support vision, a configured auxiliary
+        # backend correctly routes to text (pre-analysis) mode.
+        cfg = {
+            "model": {"supports_vision": False},
+            "auxiliary": {"vision": {"provider": "openrouter", "model": "gemini-2.5-pro"}},
+        }
+        with patch("agent.models_dev.get_model_capabilities", return_value=None):
+            assert decide_image_input_mode("custom", "qwen3.6-35b", cfg) == "text"
+
+    def test_auto_vision_model_with_aux_override_bypasses_aux(self):
+        # When the model DOES support vision, auxiliary config is ignored
+        # and native inline attachment is used.
         cfg = {
             "model": {"supports_vision": True},
             "auxiliary": {"vision": {"provider": "openrouter", "model": "gemini-2.5-pro"}},
         }
         with patch("agent.models_dev.get_model_capabilities", return_value=None):
-            assert decide_image_input_mode("custom", "qwen3.6-35b", cfg) == "text"
+            assert decide_image_input_mode("custom", "gpt-5", cfg) == "native"
 
 
 # ─── build_native_content_parts ──────────────────────────────────────────────


### PR DESCRIPTION
## Bug

When `agent.image_input_mode` is set to `"auto"` (the default), and the user has configured an `auxiliary.vision` backend, images are **always** routed through the auxiliary vision model for pre-analysis, even when the active main model is vision-capable.

This forces an unnecessary extra round-trip for every image and discards native multimodal pixels that the main model could have seen directly.

## Reproduction

Given this config:

```yaml
model:
  default: assistant
  provider: custom

providers:
  custom:
    models:
      assistant:
        supports_vision: true

auxiliary:
  vision:
    provider: main
    model: vision-specialist
```

Any image sent while `assistant` is active incorrectly routes to the auxiliary model instead of being attached inline.

## Root cause

In `agent/image_routing.py::decide_image_input_mode()`, the `auto` branch checked `_explicit_aux_vision_override()` **before** `_lookup_supports_vision()`. This meant the mere presence of an auxiliary backend short-circuited the capability lookup.

## Fix

Swap the order in `auto` mode:

1. Check if the main model supports vision → `native`
2. Only if it doesn't, check for auxiliary override → `text`
3. Otherwise → `text` (fallback)

## Tests

- Updated `test_auto_respects_aux_vision_override_even_for_vision_model` → renamed to `test_auto_with_vision_model_and_aux_override_uses_native`, now asserts `"native"`
- Updated `test_explicit_aux_vision_override_still_wins` to test the non-vision-model case (aux still used as fallback)
- Added `test_auto_vision_model_with_aux_override_bypasses_aux` for the new native routing case via `model.supports_vision` config override

All 18 `test_image_routing.py` tests pass.

## Backwards compatibility

Users who relied on the auxiliary backend even for vision-capable main models can restore the old behavior by setting `agent.image_input_mode: text`.
