### PR TITLE
fix(desktop): point electronDist at the nested workspace install so packaging finds Electron

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -135,7 +135,7 @@
   },
   "build": {
     "electronVersion": "40.10.2",
-    "electronDist": "../../node_modules/electron/dist",
+    "electronDist": "node_modules/electron/dist",
     "appId": "com.nousresearch.hermes",
     "productName": "Hermes",
     "executableName": "Hermes",

--- a/tests/test_desktop_electron_pin.py
+++ b/tests/test_desktop_electron_pin.py
@@ -94,3 +94,39 @@ def test_lockfile_resolves_the_pinned_electron():
         f"but the pin is {spec!r}; run `npm install --package-lock-only` so "
         "`npm ci` stays consistent."
     )
+
+
+def test_electron_dist_matches_lockfile_install_location():
+    """build.electronDist must point at where the lockfile installs Electron.
+
+    electron-builder copies the unpacked Electron from ``build.electronDist``
+    (resolved relative to ``apps/desktop``). If the lockfile installs Electron
+    *nested* under ``apps/desktop/node_modules/electron`` but electronDist points
+    at the workspace root (``../../node_modules/electron/dist``), packaging fails
+    with ``The specified electronDist does not exist`` — the Windows installer's
+    "Building desktop app" failure. Lock the two together so a lockfile hoist
+    change (root <-> nested) can't silently break the path again.
+    """
+    if not ROOT_LOCK.is_file():
+        pytest.skip("root package-lock.json not present")
+    electron_dist = _desktop_pkg().get("build", {}).get("electronDist")
+    assert electron_dist, "build.electronDist is missing"
+
+    lock = json.loads(ROOT_LOCK.read_text(encoding="utf-8"))
+    electron_paths = [
+        path
+        for path in lock.get("packages", {})
+        if path.endswith("node_modules/electron")
+    ]
+    assert electron_paths, "no electron entry found in package-lock.json"
+
+    desktop_dir = REPO_ROOT / "apps" / "desktop"
+    # electronDist is resolved relative to the apps/desktop project dir.
+    configured = (desktop_dir / electron_dist).resolve()
+    # Where the lockfile actually places Electron's unpacked dist.
+    installed = {(REPO_ROOT / p / "dist").resolve() for p in electron_paths}
+    assert configured in installed, (
+        f"build.electronDist={electron_dist!r} resolves to {configured}, but the "
+        f"lockfile installs Electron at {sorted(str(p) for p in installed)}. "
+        "electron-builder will fail with 'electronDist does not exist'."
+    )


### PR DESCRIPTION
## Problem

A fresh Windows install fails at **"Building desktop app"**:

```
electron-builder  version=26.15.3
packaging       platform=win32 arch=x64 electron=40.10.2
⨯ The specified electronDist does not exist:
  C:\HermesNode\hermes-home\hermes-agent\node_modules\electron\dist
    at selectElectron (app-builder-lib/src/electron/ElectronFramework.ts:193)
npm error Lifecycle script `builder` failed  (exit 1)
```

The renderer (vite) build succeeds — only the `electron-builder` pack step fails.

## Root cause

`apps/desktop/package.json` sets:

```json
"build": { "electronVersion": "40.10.2", "electronDist": "../../node_modules/electron/dist" }
```

`electronDist: "../../node_modules/electron/dist"` points at the **workspace root** `node_modules/electron/dist`. That was correct when Electron was hoisted to the root (added in f3b32e9). But the **current committed `package-lock.json` installs Electron nested** at `apps/desktop/node_modules/electron` — the only electron entry in the lockfile — and the root `package.json` has no electron dependency:

```
$ jq '.packages | keys[] | select(endswith("node_modules/electron"))' package-lock.json
"apps/desktop/node_modules/electron"
```

So `npm ci` never creates `<root>/node_modules/electron`, and electron-builder aborts before packaging. (The droplet/server install avoids this only because `hermes desktop` builds the renderer + launches Electron from source — it never runs `electron-builder`. Any path that runs `npm run pack` hits it.)

## Fix

electron-builder resolves a **relative** `electronDist` against the project dir (`apps/desktop`), so point it at the local install that `npm ci` actually produces:

```diff
-    "electronDist": "../../node_modules/electron/dist",
+    "electronDist": "node_modules/electron/dist",
```

Verified on Windows — `npm run pack` now succeeds:

```
using custom unpacked Electron distribution  electronDist=node_modules\electron\dist
copying unpacked Electron  source=...\apps\desktop\node_modules\electron\dist
  → release\win-unpacked\Hermes.exe   (Electron 40.10.2)   exit 0
```

## Test

Adds `test_electron_dist_matches_lockfile_install_location` to `tests/test_desktop_electron_pin.py`, locking `build.electronDist` to the lockfile's actual Electron install path. It fails on the old `../../` value and passes on the fix, so a future hoist change (root ↔ nested) can't silently reintroduce the broken path.

```
$ python -m pytest tests/test_desktop_electron_pin.py -q
4 passed
```