### PR TITLE
docs(sap): Hermes<->CrewAI integration skills + guide

### DIFF
--- a/docs/sap-crew-integration.md
+++ b/docs/sap-crew-integration.md
@@ -1,0 +1,117 @@
+# SAP Crew Integration — Hermes as admin console, CrewAI as SAP orchestrator
+
+Two distinct entry paths — Hermes is **admin-facing only**:
+
+- **Admin** → Telegram + CLI → **Hermes** (master orchestrator). Single admin identity,
+  one bearer token. Hermes delegates SAP work to the crew and runs ops/monitoring.
+- **End user** → HTTP from app/site → **api-railway directly** (`/v1/copilot/chat`). End
+  users do NOT go through Hermes. That path already exists and is complete (Firebase /
+  channel-session auth + per-user quota + crew + quality gate).
+
+The CrewAI control-plane (`apps/api-railway`) is the **SAP skills/agents orchestrator**
+(7 agents, 4-task pipeline, abaplint quality gate). Hermes connects to it over MCP
+(control-plane = MCP server, Hermes = MCP client).
+
+## Architecture
+
+```
+ADMIN (Telegram / CLI)                       END USER (app / site)
+   → HERMES (master, single admin token)        → HTTP POST /v1/copilot/chat
+       1. coarse triage: is this SAP?               → api-railway: auth + quota + crew
+            ├ no  → Hermes' own tools                  │  (direct, no Hermes)
+            └ yes → sap_copilot_delegate(...)          │
+                      → /v1/copilot/chat               ▼
+                      → crew 4-task + quality gate  AuditMiddleware logs every /v1/*
+       2. deliver reply on Telegram/CLI            + enforces block / throttle / revoke
+                                                       │
+   ◄── observe + control ──────────────────────────────┘
+       admin_* MCP tools → /v1/admin/{audit,control}
+```
+
+Hermes is also the **audit/admin plane** over the end-user traffic: it observes, verifies,
+audits, and actively controls the external requests it never routes.
+
+Admin uses the machinery/admin bearer → treated as a paid (unlimited) plan, so admin
+delegation never consumes end-user quota. Auth and quota stay **authoritative in the
+control-plane**; the `/v1/auth/introspect` endpoint is available for the site/app to do
+read-only pre-flight (login + quota UX) before calling `/v1/copilot/chat`.
+
+## 1. Register the control-plane MCP server in Hermes
+
+Add to `~/.hermes/config.yaml`:
+
+```yaml
+mcp_servers:
+  sap_crew:
+    url: "https://<api-railway-host>/mcp"
+    headers:
+      Authorization: "Bearer ${API_RAILWAY_TOKEN}"
+    timeout: 180          # full crew pipeline is high-latency
+    connect_timeout: 60
+```
+
+`tools/mcp_tool.py` (`register_mcp_servers`) discovers and registers the remote tools into
+the Hermes registry. They appear as native tools:
+- `sap_copilot_delegate` — full crew pipeline (use for end-to-end SAP tasks)
+- granular: `abap_lint`, `sap_adt_cli`, `sap_odata_query`, `sap_bapi_call`,
+  `sap_hana_query`, `sap_docs_search`, `cpi_lint`, ...
+
+## 2. Secrets
+
+Admin is a single identity → one bearer in `~/.hermes/.env` (never in versioned YAML).
+Use the control-plane `MACHINERY_API_TOKEN` (server secret → unlimited plan):
+
+```
+API_RAILWAY_TOKEN=<machinery-api-token>
+API_RAILWAY_URL=https://<api-railway-host>
+```
+
+## 3. Enable the routing skill
+
+The `sap` optional-skill (`optional-skills/sap/sap-crew-delegate`) tells Hermes when to
+delegate. Install it into `~/.hermes/skills/` (or your skills dir) so it loads.
+
+## 4. Channels (admin only)
+
+Enable Telegram + CLI in `~/.hermes/config.yaml`. No per-channel identity mapping is
+needed — Hermes serves a single admin, so the one `API_RAILWAY_TOKEN` is used for every
+delegation. (No `channel_identity_link` table — that was only relevant if end users came
+through Hermes, which they do not: they hit api-railway over HTTP directly.)
+
+## Audit / admin plane (Hermes observes + controls external traffic)
+
+End users hit the control-plane directly, but the admin must be able to see and govern
+that traffic. The control-plane provides:
+
+- **Capture:** `AuditMiddleware` (`app/middleware/audit.py`) records every external
+  `/v1/*` request (method, path, status, latency, request-id, subject, client) to a
+  file-based audit log (`audit_service`, JSONL under `ARTIFACT_BASE_DIR/audit`). The
+  copilot route adds a rich record (message, reply, plan, model, quality-gate
+  improvements, quota).
+- **Control:** the same middleware enforces blocked users (403) and throttles (429);
+  `require_machinery_bearer` rejects revoked tokens. Admin (machinery token) is always
+  exempt from enforcement.
+- **Admin API** (`/v1/admin/*`, guarded by `require_machinery_bearer`):
+  `GET /audit`, `GET /audit/{request_id}`, `GET /audit/stats`, `GET /audit/stream` (SSE),
+  `GET /control`, `POST /control/{block,unblock,throttle,revoke,cancel}`.
+
+Hermes drives this through the `admin_*` MCP tools (see the `sap-admin-audit` skill).
+
+## Control-plane endpoints used
+
+- `POST /v1/auth/introspect` (`app/api/routes/auth.py`) — read-only validate + quota
+  snapshot. Reuses `require_machinery_bearer` and `daily_quota.get_usage` (no increment).
+- `sap_copilot_delegate` MCP tool (`app/api/routes/mcp_sse.py`) — POSTs to
+  `/v1/copilot/chat`, which re-validates and consumes quota once, then runs the crew.
+- `admin_*` MCP tools → `/v1/admin/{audit,control}` — observe + control external traffic.
+
+## Verify
+
+1. Start the control-plane; confirm `/v1/auth/introspect` and `/mcp` respond.
+2. In Hermes, check the `register_mcp_servers` log line lists `sap_crew.*` tools (or run
+   `/tools`).
+3. Pre-flight: `curl -X POST $API_RAILWAY_URL/v1/auth/introspect -H "Authorization: Bearer
+   $API_RAILWAY_TOKEN" -d '{"plan":"PRO"}'` → `{valid:true, ...}`.
+4. Delegation: ask Hermes a SAP task; confirm it calls `sap_copilot_delegate` and the
+   reply carries crew/quality-gate output (`agent.log`).
+```

--- a/optional-skills/sap/DESCRIPTION.md
+++ b/optional-skills/sap/DESCRIPTION.md
@@ -1,0 +1,5 @@
+# SAP
+
+Skills for delegating SAP/ABAP work to the CrewAI control-plane (`apps/api-railway`).
+Hermes acts as the master front door (auth + plan + intent triage) and delegates the
+full SAP workflow to the crew pipeline via MCP.

--- a/optional-skills/sap/sap-admin-audit/SKILL.md
+++ b/optional-skills/sap/sap-admin-audit/SKILL.md
@@ -1,0 +1,45 @@
+---
+name: sap-admin-audit
+description: Observe, verify, audit and actively control the external HTTP traffic hitting the CrewAI control-plane (apps/api-railway). End users call the control-plane directly over HTTP; this skill lets the admin (Telegram/CLI) see those requests, inspect a specific one, view stats, and take control actions — block/unblock a user, throttle, revoke a token, cancel an in-flight request. Trigger on: "who is using the API", "show recent requests", "audit", "what did user X ask", "block user", "throttle", "revoke token", "cancel request", "API stats", "is the backend being abused".
+version: 1.0.0
+author: Hermes Agent (Nous Research)
+license: MIT
+metadata:
+  hermes:
+    tags: [SAP, Admin, Audit, Observability, Control, MCP]
+    related_skills: [sap-crew-delegate]
+---
+
+# SAP Admin / Audit
+
+End users hit the CrewAI control-plane (`apps/api-railway`) **directly over HTTP**
+(`/v1/copilot/chat` etc.) — they do not pass through Hermes. The control-plane audits
+every external `/v1/*` request and exposes an admin plane. Hermes (admin, via Telegram/CLI)
+uses these `admin_*` MCP tools (from the `sap_crew` server) to watch and control it.
+
+## Observe / verify / audit (read)
+
+- `admin_audit_list(limit, user_id?, path?, status?, days?)` — recent external requests,
+  newest first. Each row: request_id, path, method, user_id, status, latency_ms, client.
+  Copilot rows also carry message, reply_snippet, plan, model, improvements (quality gate).
+- `admin_audit_get(request_id)` — full entries for one request.
+- `admin_audit_stats(days?)` — totals, by status/user/path, latency p50/p95/p99.
+- `admin_control_state()` — blocked users, throttles, revoked tokens, in-flight requests.
+
+## Control (write — irreversible-ish, confirm with the operator first)
+
+- `admin_block_user(user_id)` / `admin_unblock_user(user_id)` — block returns 403 for all
+  that user's external traffic.
+- `admin_throttle(user_id, rpm)` — per-user requests/minute cap; `rpm<=0` clears it.
+- `admin_revoke_token(token_fp)` — reject a bearer by its fingerprint (read it from an
+  audit row). The machinery/admin secret itself cannot be revoked.
+- `admin_cancel_request(request_id)` — cooperative cancel of an in-flight request
+  (best-effort: long crew runs check the flag at stage boundaries).
+
+## Guidance
+
+- For read questions ("who/what/how many"), call the read tools and summarize.
+- For control actions, state exactly what will happen and confirm before calling, then
+  report the new control state.
+- Identify offenders from `admin_audit_stats` (top_users) or repeated 4xx/5xx in
+  `admin_audit_list`, then act with block/throttle/revoke.

--- a/optional-skills/sap/sap-crew-delegate/SKILL.md
+++ b/optional-skills/sap/sap-crew-delegate/SKILL.md
@@ -1,0 +1,70 @@
+---
+name: sap-crew-delegate
+description: Delegate SAP/ABAP/CDS/RAP/CPI/transport tasks to the CrewAI control-plane. Hermes does pre-flight (validate login + plan + quota via the auth introspect endpoint) then fires the full crew workflow (4-agent pipeline + Hermes quality gate) through the registered sap_crew MCP server. Trigger when the user asks for SAP/ABAP code generation, review, analysis, transport release, or anything referencing Z*/Y* objects, ABAP, CDS, RAP, BTP, CPI, or SAP transactions.
+version: 1.0.0
+author: Hermes Agent (Nous Research)
+license: MIT
+metadata:
+  hermes:
+    tags: [SAP, ABAP, CrewAI, Delegation, MCP, Quality-Gate]
+    related_skills: [mcp]
+---
+
+# SAP Crew Delegate
+
+Hermes is the **master orchestrator**; the CrewAI backend (`apps/api-railway`) is the
+**SAP skills/agents orchestrator**. For SAP-domain work, Hermes does NOT solve the task
+itself — it triages, authenticates, and delegates the whole task to the crew, which runs
+its 4-agent pipeline (orchestration → synthesis → review → final) plus the Hermes
+quality gate (abaplint + auto-fix), and returns a finished answer.
+
+## Prerequisites
+
+1. The `sap_crew` MCP server registered in `~/.hermes/config.yaml` (see
+   `docs/sap-crew-integration.md`). This exposes `sap_copilot_delegate` and the granular
+   SAP tools (`sap_*`, `abap_lint`, `cpi_*`).
+2. `API_RAILWAY_TOKEN` set in `~/.hermes/.env` (bearer for the control-plane).
+
+## When to delegate
+
+Trigger delegation when the request is SAP-domain:
+- ABAP code generation, refactor, review, TDD
+- CDS / RAP / BTP / Clean Core questions
+- Objects named `Z*` / `Y*`, transactions, transports
+- CPI iFlows, OData, BAPI/RFC, HANA
+
+Generic dev/web/research tasks → handle with Hermes' own tools, do NOT delegate.
+
+This skill runs in the **admin** context (Telegram / CLI), single identity, one
+`API_RAILWAY_TOKEN`. End users never reach this skill — they call api-railway over HTTP
+directly.
+
+## Flow
+
+1. **Delegate the full task.** Call the `sap_copilot_delegate` tool from the `sap_crew`
+   MCP server with the request:
+   - `prompt`: the full SAP request
+   - `plan`: `pro` for admin (machinery token = unlimited)
+   - `intent_hint`: optional short hint (e.g. "abap-review", "cds-generate")
+
+   The control-plane re-validates the token and consumes quota exactly once (admin = no
+   quota cost). This call is **high latency** (cheap-first + 4 agents + lint loop) — up to
+   ~180s.
+
+2. **Deliver.** Return the crew's `reply` on Telegram/CLI. Mention any quality-gate
+   improvements the crew reported.
+
+Optional health/quota peek (mostly a no-op for admin):
+`POST $API_RAILWAY_URL/v1/auth/introspect` → `{valid, plan, used, limit, allowed}`.
+
+## Granular fallback
+
+For a single, well-scoped SAP action (e.g. just lint a snippet, just read one ADT
+object), call the matching granular `sap_crew` tool directly (`abap_lint`,
+`sap_adt_cli`, `sap_odata_query`, ...) instead of the full pipeline.
+
+## Notes
+
+- Never put `API_RAILWAY_TOKEN` in the versioned config — use `~/.hermes/.env`.
+- Do not re-implement the SAP intent analysis or cheap-first routing here; that lives in
+  the control-plane. Hermes only does coarse "is this SAP?" triage.


### PR DESCRIPTION
Hermes side of the master/skill orchestration with the api-railway control-plane:

- optional-skills/sap/sap-crew-delegate: admin triages SAP intent and delegates the full task to the crew via the sap_copilot_delegate MCP tool.
- optional-skills/sap/sap-admin-audit: admin observes and controls external HTTP traffic via the admin_* MCP tools (audit list/get/stats, block, throttle, revoke, cancel).
- docs/sap-crew-integration.md: topology (admin via Telegram/CLI, end users direct over HTTP), mcp_servers config, secrets, and the audit/admin plane.

## What does this PR do?

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->



## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Fixes #

## Type of Change

<!-- Check the one that applies. -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- 

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. 
2. 
3. 

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [ ] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

<!-- Only fill this out if you're adding a skill. Delete this section otherwise. -->

- [ ] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [ ] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

