### PR TITLE
feat: add native WHOOP integration

### DIFF
--- a/docs/plans/2026-06-16-whoop-integration.md
+++ b/docs/plans/2026-06-16-whoop-integration.md
@@ -1,0 +1,282 @@
+# WHOOP Integration Implementation Plan
+
+> **For Hermes:** Use subagent-driven-development skill or native Claude Code/Codex to implement this plan task-by-task.
+
+**Goal:** Add a bundled WHOOP integration to Hermes so Graham can authenticate once and let agents read WHOOP recovery/sleep/cycle/workout data through safe tool calls.
+
+**Architecture:** Mirror the existing Spotify integration: provider-specific OAuth helpers live in `hermes_cli/auth.py`; API client and tool schemas live in a bundled plugin under `plugins/whoop`; tool availability gates on `get_auth_status("whoop")`. Keep the first slice read-only. No medical advice; expose raw health metrics plus lightweight summaries only.
+
+**Tech Stack:** Python 3.11, `httpx`, Hermes plugin loader, `tools.registry.tool_result/tool_error`, pytest.
+
+---
+
+## Official WHOOP API Facts Captured
+
+- Developer app required in WHOOP Developer Dashboard.
+- Client secret must not be logged or pasted into chat. Credentials belong in local CLI prompts, env vars, or approved secret stores.
+- OAuth authorization URL: `https://api.prod.whoop.com/oauth/oauth2/auth`
+- OAuth token URL: `https://api.prod.whoop.com/oauth/oauth2/token`
+- API base: `https://api.prod.whoop.com/developer/v2`
+- Redirect URI must match the dashboard.
+- OAuth `state` must be eight characters when generated manually.
+- Collections paginate with `records` plus `next_token`; follow-up requests use `nextToken`.
+- Documented collection example: `GET /activity/sleep?start=...&end=...`
+- Default rate limits: 100 requests/minute and 10,000/day.
+
+---
+
+## Task 1: Add RED auth tests
+
+**Objective:** Define the auth contract before touching production code.
+
+**Files:**
+- Create: `tests/hermes_cli/test_whoop_auth.py`
+- Reference: `tests/hermes_cli/test_spotify_auth.py`
+- Modify later: `hermes_cli/auth.py`
+
+**Step 1: Write failing tests**
+
+Cover:
+- `get_auth_status("whoop")` returns logged-out status when no state exists.
+- `resolve_whoop_runtime_credentials()` raises `AuthError` when unauthenticated.
+- env resolution accepts `HERMES_WHOOP_CLIENT_ID`, `WHOOP_CLIENT_ID`, `HERMES_WHOOP_CLIENT_SECRET`, `WHOOP_CLIENT_SECRET`, redirect/base URL overrides.
+- expired tokens refresh through the WHOOP token URL and persist updated state.
+- state generator returns exactly 8 characters.
+
+**Step 2: Run RED**
+
+```bash
+python -m pytest tests/hermes_cli/test_whoop_auth.py -q -o 'addopts='
+```
+
+Expected: FAIL due missing WHOOP symbols.
+
+---
+
+## Task 2: Implement WHOOP auth helpers
+
+**Objective:** Add service-provider auth state support without changing inference provider behavior.
+
+**Files:**
+- Modify: `hermes_cli/auth.py`
+
+**Implementation notes:**
+- Add constants:
+  - `DEFAULT_WHOOP_AUTH_URL`
+  - `DEFAULT_WHOOP_TOKEN_URL`
+  - `DEFAULT_WHOOP_API_BASE_URL`
+  - `DEFAULT_WHOOP_REDIRECT_URI = "http://127.0.0.1:43828/whoop/callback"`
+  - `WHOOP_ACCESS_TOKEN_REFRESH_SKEW_SECONDS = 120`
+  - `DEFAULT_WHOOP_SCOPE = "read:profile read:cycles read:recovery read:sleep read:workout"` unless docs/tests prove different scope names.
+- Add `"whoop": "WHOOP"` to `SERVICE_PROVIDER_NAMES`.
+- Mirror Spotify helper shape where practical:
+  - `_whoop_client_id(...)`
+  - `_whoop_client_secret(...)`
+  - `_whoop_redirect_uri(...)`
+  - `_whoop_api_base_url(...)`
+  - `_whoop_auth_url(...)`
+  - `_whoop_token_url(...)`
+  - `_whoop_state_token()` returning exactly 8 chars.
+  - `_whoop_token_payload_to_state(...)`
+  - `_refresh_whoop_oauth_state(...)`
+  - `resolve_whoop_runtime_credentials(...)`
+  - `get_whoop_auth_status()`
+- Fail closed when client secret is absent during code exchange/refresh.
+- Do not print secrets; redact secret presence as boolean only.
+
+**Step 3: Run GREEN**
+
+```bash
+python -m pytest tests/hermes_cli/test_whoop_auth.py -q -o 'addopts='
+```
+
+Expected: PASS.
+
+---
+
+## Task 3: Add WHOOP API client tests
+
+**Objective:** Lock request paths, pagination, refresh-on-401, and error formatting.
+
+**Files:**
+- Create: `tests/tools/test_whoop_client.py`
+- Create later: `plugins/whoop/client.py`
+
+**Step 1: Write failing tests**
+
+Cover:
+- `WhoopClient.request("GET", "/activity/sleep", params={...})` uses bearer auth and base URL.
+- 401 triggers one forced refresh and retries once.
+- 429 errors include retry/rate-limit context.
+- `paginate_collection()` accumulates records and follows `next_token` via `nextToken`.
+- `max_pages` stops runaway pagination.
+
+**Step 2: Run RED**
+
+```bash
+python -m pytest tests/tools/test_whoop_client.py -q -o 'addopts='
+```
+
+Expected: FAIL due missing `plugins.whoop.client`.
+
+---
+
+## Task 4: Implement `plugins/whoop/client.py`
+
+**Objective:** Provide a thin, testable WHOOP Web API client.
+
+**Files:**
+- Create: `plugins/whoop/client.py`
+
+**API shape:**
+- Exceptions: `WhoopError`, `WhoopAuthRequiredError`, `WhoopAPIError`.
+- Runtime resolver: `resolve_whoop_runtime_credentials()` from `hermes_cli.auth`.
+- `request(method, path, params=None, json_body=None, allow_retry_on_401=True)`.
+- Convenience methods:
+  - `get_profile()` -> `GET /user/profile/basic`
+  - `get_cycle(cycle_id)` -> `GET /cycle/{cycle_id}` if official docs confirm; otherwise skip get-by-id.
+  - `get_cycles(...)` -> `GET /cycle`
+  - `get_recovery(...)` -> `GET /recovery`
+  - `get_sleep(...)` -> `GET /activity/sleep`
+  - `get_workouts(...)` -> `GET /activity/workout`
+- `paginate_collection(path, params, max_pages=1)`.
+
+**Step 3: Run GREEN**
+
+```bash
+python -m pytest tests/tools/test_whoop_client.py -q -o 'addopts='
+```
+
+---
+
+## Task 5: Add tool schema and handler tests
+
+**Objective:** Define a minimal read-only tool surface for agents.
+
+**Files:**
+- Create: `tests/tools/test_whoop_tools.py`
+- Create later: `plugins/whoop/tools.py`
+
+**Tools:**
+- `whoop_profile`
+- `whoop_cycles`
+- `whoop_recovery`
+- `whoop_sleep`
+- `whoop_workouts`
+
+**Required behavior:**
+- Tool handlers return `tool_result` JSON on success and `tool_error` JSON on validation/API/auth failures.
+- `list` action accepts `start`, `end`, `limit`, `nextToken`, `max_pages`.
+- `latest` action uses the documented latest endpoint if confirmed; otherwise it lists with `limit=1` and labels this as derived latest.
+- Clamp `limit` to documented max if known, otherwise conservative 25.
+- Clamp `max_pages` to 1-10.
+
+**Step 1: Run RED**
+
+```bash
+python -m pytest tests/tools/test_whoop_tools.py -q -o 'addopts='
+```
+
+---
+
+## Task 6: Implement `plugins/whoop/tools.py` and plugin registration
+
+**Objective:** Register WHOOP tools in Hermes' plugin system.
+
+**Files:**
+- Create: `plugins/whoop/tools.py`
+- Create: `plugins/whoop/__init__.py`
+- Create: `plugins/whoop/plugin.yaml`
+- Modify: `toolsets.py` if explicit toolset listing is required by current loader/tests.
+
+**Registration pattern:**
+- Copy the Spotify plugin structure:
+  - `_check_whoop_available()` calls `get_auth_status("whoop")` and returns `logged_in`.
+  - `register(ctx)` registers each tool with `toolset="whoop"`.
+  - Emoji optional, keep boring if unsure. This is fitness telemetry, not a disco ball.
+
+**Step 2: Run GREEN**
+
+```bash
+python -m pytest tests/tools/test_whoop_tools.py tests/providers/test_plugin_discovery.py -q -o 'addopts='
+```
+
+---
+
+## Task 7: Add docs
+
+**Objective:** Tell Graham/future users how to set it up without leaking secrets.
+
+**Files:**
+- Create: `website/docs/user-guide/features/whoop.md` or matching feature-doc location.
+- Modify: sidebar/index only if required by docs build.
+
+**Docs content:**
+- Create WHOOP Developer app.
+- Redirect URI: `http://127.0.0.1:43828/whoop/callback`.
+- Set credentials locally:
+
+```bash
+hermes config env-path
+# then edit the local .env or export locally:
+export HERMES_WHOOP_CLIENT_ID="..."
+export HERMES_WHOOP_CLIENT_SECRET="..."
+```
+
+- Run:
+
+```bash
+hermes auth whoop
+```
+
+- Tool examples:
+  - `whoop_profile`
+  - `whoop_recovery action=latest`
+  - `whoop_sleep action=list start=... end=...`
+
+**Secret-safe warning:** Never paste WHOOP client secret/token into chat.
+
+---
+
+## Task 8: Final targeted verification
+
+**Objective:** Prove the first slice is safe and works locally.
+
+Run:
+
+```bash
+python -m pytest \
+  tests/hermes_cli/test_whoop_auth.py \
+  tests/tools/test_whoop_client.py \
+  tests/tools/test_whoop_tools.py \
+  -q -o 'addopts='
+
+git diff --stat
+git diff --check
+```
+
+Expected:
+- WHOOP tests pass.
+- `git diff --check` clean.
+- No unrelated files modified.
+- No secrets in diff.
+
+---
+
+## Blast Radius
+
+- **Local-only code branch/worktree:** `/Users/admin/.openclaw/workspace/projects/howard-hermes-migration/repo/hermes-agent-whoop` on `feat/whoop-integration`.
+- **No production routing/gateway/cron changes** in first slice.
+- **No external sends.** OAuth only opens browser/local callback when Graham runs `hermes auth whoop` himself.
+- **Credential risk:** client secret is required by WHOOP; all UX must direct Graham to local `.env`/CLI only. Never chat.
+- **Health-data risk:** WHOOP data is personal health telemetry. Treat outputs as private to Graham/Personal Tracking unless explicitly authorized.
+
+---
+
+## Completion Criteria
+
+- `hermes auth whoop` exists or a clearly documented `hermes auth` service-provider flow accepts `whoop`.
+- WHOOP tools only appear/execute when authenticated.
+- Profile/cycle/recovery/sleep/workout reads are available to agents.
+- Tests pass for auth, client, tools, and plugin registration.
+- Docs include secret-safe setup and redirect URI.

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -118,6 +118,12 @@ DEFAULT_SPOTIFY_REDIRECT_URI = "http://127.0.0.1:43827/spotify/callback"
 SPOTIFY_DOCS_URL = "https://hermes-agent.nousresearch.com/docs/user-guide/features/spotify"
 SPOTIFY_DASHBOARD_URL = "https://developer.spotify.com/dashboard"
 SPOTIFY_ACCESS_TOKEN_REFRESH_SKEW_SECONDS = 120
+DEFAULT_WHOOP_OAUTH_BASE_URL = "https://api.prod.whoop.com/oauth/oauth2"
+DEFAULT_WHOOP_API_BASE_URL = "https://api.prod.whoop.com/developer/v2"
+DEFAULT_WHOOP_REDIRECT_URI = "http://127.0.0.1:43828/whoop/callback"
+WHOOP_DOCS_URL = "https://developer.whoop.com/api"
+WHOOP_DASHBOARD_URL = "https://developer.whoop.com/api"
+WHOOP_ACCESS_TOKEN_REFRESH_SKEW_SECONDS = 120
 
 XAI_OAUTH_DOCS_URL = "https://hermes-agent.nousresearch.com/docs/guides/xai-grok-oauth"
 OAUTH_OVER_SSH_DOCS_URL = "https://hermes-agent.nousresearch.com/docs/guides/oauth-over-ssh"
@@ -133,8 +139,18 @@ DEFAULT_SPOTIFY_SCOPE = " ".join((
     "user-library-read",
     "user-library-modify",
 ))
+DEFAULT_WHOOP_SCOPE = " ".join((
+    "offline",
+    "read:recovery",
+    "read:sleep",
+    "read:workout",
+    "read:profile",
+    "read:body_measurement",
+    "read:cycles",
+))
 SERVICE_PROVIDER_NAMES: Dict[str, str] = {
     "spotify": "Spotify",
+    "whoop": "WHOOP",
 }
 
 # Google Gemini OAuth (google-gemini-cli provider, Cloud Code Assist backend)
@@ -3098,6 +3114,612 @@ def login_spotify_command(args) -> None:
     print(f"  Auth state: {saved_to}")
     print("  Provider state saved under providers.spotify")
     print(f"  Docs: {SPOTIFY_DOCS_URL}")
+
+
+# =============================================================================
+# WHOOP OAuth helpers (service-provider auth, separate from inference providers)
+# =============================================================================
+
+def _whoop_scope_list(raw_scope: Optional[str] = None) -> List[str]:
+    scope_text = (raw_scope or DEFAULT_WHOOP_SCOPE).strip()
+    scopes = [part for part in scope_text.split() if part]
+    seen: set[str] = set()
+    ordered: List[str] = []
+    for scope in scopes:
+        if scope not in seen:
+            seen.add(scope)
+            ordered.append(scope)
+    return ordered
+
+
+def _whoop_scope_string(raw_scope: Optional[str] = None) -> str:
+    return " ".join(_whoop_scope_list(raw_scope))
+
+
+def _whoop_state_token() -> str:
+    """WHOOP requires manually-generated OAuth state values to be 8 chars."""
+    return uuid.uuid4().hex[:8]
+
+
+def _whoop_client_id(
+    explicit: Optional[str] = None,
+    state: Optional[Dict[str, Any]] = None,
+) -> str:
+    from hermes_cli.config import get_env_value
+
+    candidates = (
+        explicit,
+        get_env_value("HERMES_WHOOP_CLIENT_ID"),
+        get_env_value("WHOOP_CLIENT_ID"),
+        state.get("client_id") if isinstance(state, dict) else None,
+    )
+    for candidate in candidates:
+        cleaned = str(candidate or "").strip()
+        if cleaned:
+            return cleaned
+    raise AuthError(
+        "WHOOP client_id is required. Set HERMES_WHOOP_CLIENT_ID or run `hermes auth whoop`.",
+        provider="whoop",
+        code="whoop_client_id_missing",
+    )
+
+
+def _whoop_client_secret(
+    explicit: Optional[str] = None,
+    state: Optional[Dict[str, Any]] = None,
+) -> str:
+    from hermes_cli.config import get_env_value
+
+    candidates = (
+        explicit,
+        get_env_value("HERMES_WHOOP_CLIENT_SECRET"),
+        get_env_value("WHOOP_CLIENT_SECRET"),
+        state.get("client_secret") if isinstance(state, dict) else None,
+    )
+    for candidate in candidates:
+        cleaned = str(candidate or "").strip()
+        if cleaned:
+            return cleaned
+    raise AuthError(
+        "WHOOP client_secret is required. Set HERMES_WHOOP_CLIENT_SECRET or run `hermes auth whoop`.",
+        provider="whoop",
+        code="whoop_client_secret_missing",
+    )
+
+
+def _whoop_redirect_uri(
+    explicit: Optional[str] = None,
+    state: Optional[Dict[str, Any]] = None,
+) -> str:
+    from hermes_cli.config import get_env_value
+
+    candidates = (
+        explicit,
+        get_env_value("HERMES_WHOOP_REDIRECT_URI"),
+        get_env_value("WHOOP_REDIRECT_URI"),
+        state.get("redirect_uri") if isinstance(state, dict) else None,
+        DEFAULT_WHOOP_REDIRECT_URI,
+    )
+    for candidate in candidates:
+        cleaned = str(candidate or "").strip()
+        if cleaned:
+            return cleaned
+    return DEFAULT_WHOOP_REDIRECT_URI
+
+
+def _whoop_api_base_url(state: Optional[Dict[str, Any]] = None) -> str:
+    from hermes_cli.config import get_env_value
+
+    candidates = (
+        get_env_value("HERMES_WHOOP_API_BASE_URL"),
+        state.get("api_base_url") if isinstance(state, dict) else None,
+        DEFAULT_WHOOP_API_BASE_URL,
+    )
+    for candidate in candidates:
+        cleaned = str(candidate or "").strip().rstrip("/")
+        if cleaned:
+            return cleaned
+    return DEFAULT_WHOOP_API_BASE_URL
+
+
+def _whoop_oauth_base_url(state: Optional[Dict[str, Any]] = None) -> str:
+    from hermes_cli.config import get_env_value
+
+    candidates = (
+        get_env_value("HERMES_WHOOP_OAUTH_BASE_URL"),
+        state.get("oauth_base_url") if isinstance(state, dict) else None,
+        DEFAULT_WHOOP_OAUTH_BASE_URL,
+    )
+    for candidate in candidates:
+        cleaned = str(candidate or "").strip().rstrip("/")
+        if cleaned:
+            return cleaned
+    return DEFAULT_WHOOP_OAUTH_BASE_URL
+
+
+def _whoop_build_authorize_url(
+    *,
+    client_id: str,
+    redirect_uri: str,
+    scope: str,
+    state: str,
+    oauth_base_url: str,
+) -> str:
+    query = urlencode({
+        "client_id": client_id,
+        "response_type": "code",
+        "redirect_uri": redirect_uri,
+        "scope": scope,
+        "state": state,
+    })
+    return f"{oauth_base_url}/auth?{query}"
+
+
+def _whoop_validate_redirect_uri(redirect_uri: str) -> tuple[str, int, str]:
+    parsed = urlparse(redirect_uri)
+    if parsed.scheme != "http":
+        raise AuthError(
+            "WHOOP OAuth redirect_uri must use http://localhost or http://127.0.0.1.",
+            provider="whoop",
+            code="whoop_redirect_invalid",
+        )
+    host = parsed.hostname or ""
+    if host not in {"127.0.0.1", "localhost"}:
+        raise AuthError(
+            "WHOOP OAuth redirect_uri must point to localhost or 127.0.0.1.",
+            provider="whoop",
+            code="whoop_redirect_invalid",
+        )
+    if not parsed.port:
+        raise AuthError(
+            "WHOOP OAuth redirect_uri must include an explicit localhost port.",
+            provider="whoop",
+            code="whoop_redirect_invalid",
+        )
+    return host, parsed.port, parsed.path or "/"
+
+
+def _make_whoop_callback_handler(expected_path: str) -> tuple[type[BaseHTTPRequestHandler], dict[str, Any]]:
+    result: dict[str, Any] = {
+        "code": None,
+        "state": None,
+        "error": None,
+        "error_description": None,
+    }
+
+    class _WHOOPCallbackHandler(BaseHTTPRequestHandler):
+        def do_GET(self) -> None:  # noqa: N802
+            parsed = urlparse(self.path)
+            if parsed.path != expected_path:
+                self.send_response(404)
+                self.end_headers()
+                self.wfile.write(b"Not found.")
+                return
+            params = parse_qs(parsed.query)
+            result["code"] = params.get("code", [None])[0]
+            result["state"] = params.get("state", [None])[0]
+            result["error"] = params.get("error", [None])[0]
+            result["error_description"] = params.get("error_description", [None])[0]
+            self.send_response(200)
+            self.send_header("Content-Type", "text/html; charset=utf-8")
+            self.end_headers()
+            if result["error"]:
+                body = "<html><body><h1>WHOOP authorization failed.</h1>You can close this tab.</body></html>"
+            else:
+                body = "<html><body><h1>WHOOP authorization received.</h1>You can close this tab.</body></html>"
+            self.wfile.write(body.encode("utf-8"))
+
+        def log_message(self, format: str, *args: Any) -> None:  # noqa: A003
+            return
+
+    return _WHOOPCallbackHandler, result
+
+
+def _whoop_wait_for_callback(
+    redirect_uri: str,
+    *,
+    timeout_seconds: float = 180.0,
+) -> dict[str, Any]:
+    host, port, path = _whoop_validate_redirect_uri(redirect_uri)
+    handler_cls, result = _make_whoop_callback_handler(path)
+
+    class _ReuseHTTPServer(HTTPServer):
+        allow_reuse_address = True
+
+    try:
+        server = _ReuseHTTPServer((host, port), handler_cls)
+    except OSError as exc:
+        raise AuthError(
+            f"Could not bind WHOOP callback server on {host}:{port}: {exc}",
+            provider="whoop",
+            code="whoop_callback_bind_failed",
+        ) from exc
+
+    thread = threading.Thread(target=server.serve_forever, kwargs={"poll_interval": 0.1}, daemon=True)
+    thread.start()
+    deadline = time.monotonic() + max(5.0, timeout_seconds)
+    try:
+        while time.monotonic() < deadline:
+            if result["code"] or result["error"]:
+                return result
+            time.sleep(0.1)
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=1.0)
+    raise AuthError(
+        "WHOOP authorization timed out waiting for the local callback.",
+        provider="whoop",
+        code="whoop_callback_timeout",
+    )
+
+
+def _whoop_token_payload_to_state(
+    token_payload: Dict[str, Any],
+    *,
+    client_id: str,
+    client_secret: str,
+    redirect_uri: str,
+    requested_scope: str,
+    oauth_base_url: str,
+    api_base_url: str,
+    previous_state: Optional[Dict[str, Any]] = None,
+) -> Dict[str, Any]:
+    now = datetime.now(timezone.utc)
+    expires_in = _coerce_ttl_seconds(token_payload.get("expires_in", 0))
+    expires_at = datetime.fromtimestamp(now.timestamp() + expires_in, tz=timezone.utc)
+    state = dict(previous_state or {})
+    # Keep the long-lived WHOOP app secret in the local .env/secret store, not duplicated
+    # into provider auth state. Existing states that already contain it are scrubbed on refresh.
+    state.pop("client_secret", None)
+    state.update({
+        "client_id": client_id,
+        "redirect_uri": redirect_uri,
+        "oauth_base_url": oauth_base_url,
+        "api_base_url": api_base_url,
+        "scope": requested_scope,
+        "granted_scope": str(token_payload.get("scope") or requested_scope).strip(),
+        "token_type": str(token_payload.get("token_type", "Bearer") or "Bearer").strip() or "Bearer",
+        "access_token": str(token_payload.get("access_token", "") or "").strip(),
+        "refresh_token": str(
+            token_payload.get("refresh_token")
+            or state.get("refresh_token")
+            or ""
+        ).strip(),
+        "obtained_at": now.isoformat(),
+        "expires_at": expires_at.isoformat(),
+        "expires_in": expires_in,
+        "auth_type": "oauth_authorization_code",
+    })
+    return state
+
+
+def _whoop_exchange_code_for_tokens(
+    *,
+    client_id: str,
+    client_secret: str,
+    code: str,
+    redirect_uri: str,
+    oauth_base_url: str,
+    timeout_seconds: float = 20.0,
+) -> Dict[str, Any]:
+    try:
+        response = httpx.post(
+            f"{oauth_base_url}/token",
+            headers={"Content-Type": "application/x-www-form-urlencoded"},
+            data={
+                "grant_type": "authorization_code",
+                "code": code,
+                "redirect_uri": redirect_uri,
+                "client_id": client_id,
+                "client_secret": client_secret,
+            },
+            timeout=timeout_seconds,
+        )
+    except Exception as exc:
+        raise AuthError(
+            f"WHOOP token exchange failed: {exc}",
+            provider="whoop",
+            code="whoop_token_exchange_failed",
+        ) from exc
+
+    if response.status_code >= 400:
+        detail = response.text.strip()
+        raise AuthError(
+            "WHOOP token exchange failed."
+            + (f" Response: {detail}" if detail else ""),
+            provider="whoop",
+            code="whoop_token_exchange_failed",
+        )
+    payload = response.json()
+    if not isinstance(payload, dict) or not str(payload.get("access_token", "") or "").strip():
+        raise AuthError(
+            "WHOOP token response did not include an access_token.",
+            provider="whoop",
+            code="whoop_token_exchange_invalid",
+        )
+    return payload
+
+
+def _refresh_whoop_oauth_state(
+    state: Dict[str, Any],
+    *,
+    timeout_seconds: float = 20.0,
+) -> Dict[str, Any]:
+    refresh_token = str(state.get("refresh_token", "") or "").strip()
+    if not refresh_token:
+        raise AuthError(
+            "WHOOP refresh token missing. Run `hermes auth whoop` again.",
+            provider="whoop",
+            code="whoop_refresh_token_missing",
+            relogin_required=True,
+        )
+
+    client_id = _whoop_client_id(state=state)
+    client_secret = _whoop_client_secret(state=state)
+    oauth_base_url = _whoop_oauth_base_url(state)
+    try:
+        response = httpx.post(
+            f"{oauth_base_url}/token",
+            headers={"Content-Type": "application/x-www-form-urlencoded"},
+            data={
+                "grant_type": "refresh_token",
+                "refresh_token": refresh_token,
+                "client_id": client_id,
+                "client_secret": client_secret,
+            },
+            timeout=timeout_seconds,
+        )
+    except Exception as exc:
+        raise AuthError(
+            f"WHOOP token refresh failed: {exc}",
+            provider="whoop",
+            code="whoop_refresh_failed",
+        ) from exc
+
+    if response.status_code >= 400:
+        detail = response.text.strip()
+        raise AuthError(
+            "WHOOP token refresh failed. Run `hermes auth whoop` again."
+            + (f" Response: {detail}" if detail else ""),
+            provider="whoop",
+            code="whoop_refresh_failed",
+            relogin_required=True,
+        )
+    payload = response.json()
+    if not isinstance(payload, dict) or not str(payload.get("access_token", "") or "").strip():
+        raise AuthError(
+            "WHOOP refresh response did not include an access_token.",
+            provider="whoop",
+            code="whoop_refresh_invalid",
+            relogin_required=True,
+        )
+    return _whoop_token_payload_to_state(
+        payload,
+        client_id=client_id,
+        client_secret=client_secret,
+        redirect_uri=_whoop_redirect_uri(state=state),
+        requested_scope=str(state.get("scope") or DEFAULT_WHOOP_SCOPE),
+        oauth_base_url=oauth_base_url,
+        api_base_url=_whoop_api_base_url(state),
+        previous_state=state,
+    )
+
+
+def resolve_whoop_runtime_credentials(
+    *,
+    force_refresh: bool = False,
+    refresh_if_expiring: bool = True,
+    refresh_skew_seconds: int = WHOOP_ACCESS_TOKEN_REFRESH_SKEW_SECONDS,
+) -> Dict[str, Any]:
+    with _auth_store_lock():
+        # Match get_whoop_auth_status() semantics: in profile mode, a WHOOP
+        # login stored at the global Hermes root should be visible until the
+        # profile shadows it with its own provider state. If a refresh is
+        # needed, persist the refreshed state into the active profile store
+        # without changing the active LLM provider.
+        auth_store = _load_auth_store()
+        state = get_provider_auth_state("whoop")
+        if not state:
+            raise AuthError(
+                "WHOOP is not authenticated. Run `hermes auth whoop` first.",
+                provider="whoop",
+                code="whoop_auth_missing",
+                relogin_required=True,
+            )
+
+        should_refresh = bool(force_refresh)
+        if not should_refresh and refresh_if_expiring:
+            should_refresh = _is_expiring(state.get("expires_at"), refresh_skew_seconds)
+        if should_refresh:
+            state = _refresh_whoop_oauth_state(state)
+            _store_provider_state(auth_store, "whoop", state, set_active=False)
+            _save_auth_store(auth_store)
+
+    access_token = str(state.get("access_token", "") or "").strip()
+    if not access_token:
+        raise AuthError(
+            "WHOOP access token missing. Run `hermes auth whoop` again.",
+            provider="whoop",
+            code="whoop_access_token_missing",
+            relogin_required=True,
+        )
+    return {
+        "provider": "whoop",
+        "access_token": access_token,
+        "api_key": access_token,
+        "token_type": str(state.get("token_type", "Bearer") or "Bearer"),
+        "base_url": _whoop_api_base_url(state),
+        "scope": str(state.get("granted_scope") or state.get("scope") or "").strip(),
+        "client_id": _whoop_client_id(state=state),
+        "redirect_uri": _whoop_redirect_uri(state=state),
+        "expires_at": state.get("expires_at"),
+    }
+
+
+def get_whoop_auth_status() -> Dict[str, Any]:
+    state = get_provider_auth_state("whoop")
+    if not state:
+        return {"logged_in": False}
+    expires_at = state.get("expires_at")
+    refresh_token = str(state.get("refresh_token", "") or "").strip()
+    return {
+        "logged_in": bool(refresh_token or not _is_expiring(expires_at, 0)),
+        "auth_type": state.get("auth_type", "oauth_authorization_code"),
+        "client_id": state.get("client_id"),
+        "redirect_uri": state.get("redirect_uri"),
+        "scope": state.get("granted_scope") or state.get("scope"),
+        "expires_at": expires_at,
+        "api_base_url": state.get("api_base_url"),
+        "has_refresh_token": bool(refresh_token),
+    }
+
+
+def _whoop_interactive_setup(redirect_uri_hint: str) -> str:
+    """Collect local WHOOP OAuth app credentials and persist them to ~/.hermes/.env."""
+    from hermes_cli.config import save_env_value
+
+    print()
+    print("=" * 70)
+    print("WHOOP first-time setup")
+    print("=" * 70)
+    print()
+    print("WHOOP requires a developer app for local OAuth. Create one in the")
+    print("WHOOP Developer Dashboard, allow-list the redirect URI below, then paste")
+    print("the Client ID and Client Secret into this local terminal prompt.")
+    print()
+    print(f"Docs: {WHOOP_DOCS_URL}")
+    print(f"Dashboard: {WHOOP_DASHBOARD_URL}")
+    print(f"Redirect URI: {redirect_uri_hint}")
+    print()
+
+    if not _is_remote_session():
+        try:
+            webbrowser.open(WHOOP_DASHBOARD_URL)
+        except Exception:
+            pass
+
+    try:
+        client_id = input("WHOOP Client ID: ").strip()
+    except (EOFError, KeyboardInterrupt):
+        print()
+        raise SystemExit("WHOOP setup cancelled.")
+    if not client_id:
+        print()
+        print(f"No Client ID entered. See {WHOOP_DOCS_URL} for setup instructions.")
+        raise SystemExit("WHOOP setup cancelled: empty Client ID.")
+
+    try:
+        import getpass
+
+        client_secret = getpass.getpass("WHOOP Client Secret: ").strip()
+    except (EOFError, KeyboardInterrupt):
+        print()
+        raise SystemExit("WHOOP setup cancelled.")
+    if not client_secret:
+        print()
+        print(f"No Client Secret entered. See {WHOOP_DOCS_URL} for setup instructions.")
+        raise SystemExit("WHOOP setup cancelled: empty Client Secret.")
+
+    save_env_value("HERMES_WHOOP_CLIENT_ID", client_id)
+    save_env_value("HERMES_WHOOP_CLIENT_SECRET", client_secret)
+    if redirect_uri_hint and redirect_uri_hint != DEFAULT_WHOOP_REDIRECT_URI:
+        save_env_value("HERMES_WHOOP_REDIRECT_URI", redirect_uri_hint)
+    print()
+    print("Saved WHOOP OAuth app settings to ~/.hermes/.env")
+    print()
+    return client_id
+
+
+def login_whoop_command(args) -> None:
+    existing_state = get_provider_auth_state("whoop") or {}
+    explicit_client_id = getattr(args, "client_id", None)
+    explicit_client_secret = getattr(args, "client_secret", None)
+    try:
+        client_id = _whoop_client_id(explicit_client_id, existing_state)
+        client_secret = _whoop_client_secret(explicit_client_secret, existing_state)
+    except AuthError as exc:
+        if getattr(exc, "code", "") not in {"whoop_client_id_missing", "whoop_client_secret_missing"}:
+            raise
+        client_id = _whoop_interactive_setup(
+            redirect_uri_hint=getattr(args, "redirect_uri", None) or DEFAULT_WHOOP_REDIRECT_URI,
+        )
+        client_secret = _whoop_client_secret(explicit_client_secret, existing_state)
+
+    redirect_uri = _whoop_redirect_uri(getattr(args, "redirect_uri", None), existing_state)
+    scope = _whoop_scope_string(getattr(args, "scope", None) or existing_state.get("scope"))
+    oauth_base_url = _whoop_oauth_base_url(existing_state)
+    api_base_url = _whoop_api_base_url(existing_state)
+    open_browser = not getattr(args, "no_browser", False)
+
+    state_nonce = _whoop_state_token()
+    authorize_url = _whoop_build_authorize_url(
+        client_id=client_id,
+        redirect_uri=redirect_uri,
+        scope=scope,
+        state=state_nonce,
+        oauth_base_url=oauth_base_url,
+    )
+
+    print("Starting WHOOP OAuth login...")
+    print(f"Client ID: {client_id}")
+    print(f"Redirect URI: {redirect_uri}")
+    print("Make sure this redirect URI is allow-listed in your WHOOP developer app.")
+    print()
+    print("Open this URL to authorize Hermes:")
+    print(authorize_url)
+    print()
+    print(f"Docs: {WHOOP_DOCS_URL}")
+    print()
+    _print_loopback_ssh_hint(redirect_uri, docs_url=WHOOP_DOCS_URL)
+
+    if open_browser and not _is_remote_session():
+        try:
+            opened = webbrowser.open(authorize_url)
+        except Exception:
+            opened = False
+        if opened:
+            print("Browser opened for WHOOP authorization.")
+        else:
+            print("Could not open the browser automatically; use the URL above.")
+
+    callback = _whoop_wait_for_callback(
+        redirect_uri,
+        timeout_seconds=float(getattr(args, "timeout", None) or 180.0),
+    )
+    if callback.get("error"):
+        detail = callback.get("error_description") or callback["error"]
+        raise SystemExit(f"WHOOP authorization failed: {detail}")
+    if callback.get("state") != state_nonce:
+        raise SystemExit("WHOOP authorization failed: state mismatch.")
+
+    token_payload = _whoop_exchange_code_for_tokens(
+        client_id=client_id,
+        client_secret=client_secret,
+        code=str(callback.get("code") or ""),
+        redirect_uri=redirect_uri,
+        oauth_base_url=oauth_base_url,
+        timeout_seconds=float(getattr(args, "timeout", None) or 20.0),
+    )
+    whoop_state = _whoop_token_payload_to_state(
+        token_payload,
+        client_id=client_id,
+        client_secret=client_secret,
+        redirect_uri=redirect_uri,
+        requested_scope=scope,
+        oauth_base_url=oauth_base_url,
+        api_base_url=api_base_url,
+    )
+
+    with _auth_store_lock():
+        auth_store = _load_auth_store()
+        _store_provider_state(auth_store, "whoop", whoop_state, set_active=False)
+        saved_to = _save_auth_store(auth_store)
+
+    print("WHOOP login successful!")
+    print(f"  Auth state: {saved_to}")
+    print("  Provider state saved under providers.whoop")
+    print(f"  Docs: {WHOOP_DOCS_URL}")
 
 # =============================================================================
 # SSH / remote session detection
@@ -6148,6 +6770,8 @@ def get_auth_status(provider_id: Optional[str] = None) -> Dict[str, Any]:
         return {"logged_in": False}
     if target == "spotify":
         return get_spotify_auth_status()
+    if target == "whoop":
+        return get_whoop_auth_status()
     if target == "nous":
         return get_nous_auth_status()
     if target == "openai-codex":

--- a/hermes_cli/auth_commands.py
+++ b/hermes_cli/auth_commands.py
@@ -544,6 +544,20 @@ def auth_spotify_command(args) -> None:
     raise SystemExit(f"Unknown Spotify auth action: {action}")
 
 
+def auth_whoop_command(args) -> None:
+    action = str(getattr(args, "whoop_action", "") or "login").strip().lower()
+    if action in {"", "login"}:
+        auth_mod.login_whoop_command(args)
+        return
+    if action == "status":
+        auth_status_command(SimpleNamespace(provider="whoop"))
+        return
+    if action == "logout":
+        auth_logout_command(SimpleNamespace(provider="whoop"))
+        return
+    raise SystemExit(f"Unknown WHOOP auth action: {action}")
+
+
 def _interactive_auth() -> None:
     """Interactive credential pool management when `hermes auth` is called bare."""
     # Show current pool status first
@@ -797,6 +811,9 @@ def auth_command(args) -> None:
         return
     if action == "spotify":
         auth_spotify_command(args)
+        return
+    if action == "whoop":
+        auth_whoop_command(args)
         return
     # No subcommand — launch interactive mode
     _interactive_auth()

--- a/hermes_cli/subcommands/auth.py
+++ b/hermes_cli/subcommands/auth.py
@@ -106,4 +106,29 @@ def build_auth_parser(subparsers, *, cmd_auth: Callable) -> None:
     auth_spotify.add_argument(
         "--timeout", type=float, help="Callback/token exchange timeout in seconds"
     )
+    auth_whoop = auth_subparsers.add_parser(
+        "whoop", help="Authenticate Hermes with WHOOP via local OAuth"
+    )
+    auth_whoop.add_argument(
+        "whoop_action",
+        nargs="?",
+        choices=["login", "status", "logout"],
+        default="login",
+    )
+    auth_whoop.add_argument(
+        "--client-id", help="WHOOP app client_id (or set HERMES_WHOOP_CLIENT_ID)"
+    )
+    auth_whoop.add_argument(
+        "--redirect-uri",
+        help="Allow-listed localhost redirect URI for your WHOOP developer app",
+    )
+    auth_whoop.add_argument("--scope", help="Override requested WHOOP scopes")
+    auth_whoop.add_argument(
+        "--no-browser",
+        action="store_true",
+        help="Do not attempt to open the browser automatically",
+    )
+    auth_whoop.add_argument(
+        "--timeout", type=float, help="Callback/token exchange timeout in seconds"
+    )
     auth_parser.set_defaults(func=cmd_auth)

--- a/hermes_cli/subcommands/logout.py
+++ b/hermes_cli/subcommands/logout.py
@@ -21,7 +21,7 @@ def build_logout_parser(subparsers, *, cmd_logout: Callable) -> None:
     )
     logout_parser.add_argument(
         "--provider",
-        choices=["nous", "openai-codex", "xai-oauth", "spotify"],
+        choices=["nous", "openai-codex", "xai-oauth", "spotify", "whoop"],
         default=None,
         help="Provider to log out from (default: active provider)",
     )

--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -111,7 +111,19 @@ def gui_toolset_label(label: str) -> str:
 # `hermes tools` → X (Twitter) Search setup walks users through credential
 # setup. The tool's check_fn means the schema still won't appear to the
 # model if the credential later goes missing or expires.
-_DEFAULT_OFF_TOOLSETS = {"moa", "homeassistant", "spotify", "discord", "discord_admin", "video", "video_gen", "x_search"}
+_DEFAULT_OFF_TOOLSETS = {
+    "moa",
+    "homeassistant",
+    "spotify",
+    "discord",
+    "discord_admin",
+    "video",
+    "video_gen",
+    "x_search",
+    # Health/wearable data is sensitive. Keep WHOOP explicit opt-in even
+    # when the plugin is installed and OAuth tokens are present.
+    "whoop",
+}
 
 
 def _xai_credentials_present() -> bool:

--- a/plugins/whoop/__init__.py
+++ b/plugins/whoop/__init__.py
@@ -1,0 +1,43 @@
+"""WHOOP integration plugin — bundled, auto-loaded.
+
+Registers read-only WHOOP tools for profile, cycles, recovery, sleep, and
+workouts. Auth state lives under ``providers.whoop`` in the Hermes auth store
+and is configured with ``hermes auth whoop``.
+"""
+
+from __future__ import annotations
+
+from plugins.whoop.tools import (
+    WHOOP_CYCLES_SCHEMA,
+    WHOOP_PROFILE_SCHEMA,
+    WHOOP_RECOVERY_SCHEMA,
+    WHOOP_SLEEP_SCHEMA,
+    WHOOP_WORKOUTS_SCHEMA,
+    _check_whoop_available,
+    _handle_whoop_cycles,
+    _handle_whoop_profile,
+    _handle_whoop_recovery,
+    _handle_whoop_sleep,
+    _handle_whoop_workouts,
+)
+
+_TOOLS = (
+    ("whoop_profile", WHOOP_PROFILE_SCHEMA, _handle_whoop_profile, "💪"),
+    ("whoop_cycles", WHOOP_CYCLES_SCHEMA, _handle_whoop_cycles, "🔄"),
+    ("whoop_recovery", WHOOP_RECOVERY_SCHEMA, _handle_whoop_recovery, "🟢"),
+    ("whoop_sleep", WHOOP_SLEEP_SCHEMA, _handle_whoop_sleep, "😴"),
+    ("whoop_workouts", WHOOP_WORKOUTS_SCHEMA, _handle_whoop_workouts, "🏋️"),
+)
+
+
+def register(ctx) -> None:
+    """Register all WHOOP tools. Called once by the plugin loader."""
+    for name, schema, handler, emoji in _TOOLS:
+        ctx.register_tool(
+            name=name,
+            toolset="whoop",
+            schema=schema,
+            handler=handler,
+            check_fn=_check_whoop_available,
+            emoji=emoji,
+        )

--- a/plugins/whoop/client.py
+++ b/plugins/whoop/client.py
@@ -1,0 +1,217 @@
+"""Thin WHOOP API helper used by Hermes native tools."""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Dict, Optional
+
+import httpx
+
+from hermes_cli.auth import AuthError, resolve_whoop_runtime_credentials
+
+
+class WHOOPError(RuntimeError):
+    """Base WHOOP tool error."""
+
+
+class WHOOPAuthRequiredError(WHOOPError):
+    """Raised when the user needs to authenticate with WHOOP first."""
+
+
+class WHOOPAPIError(WHOOPError):
+    """Structured WHOOP API failure."""
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        status_code: Optional[int] = None,
+        response_body: Optional[str] = None,
+    ) -> None:
+        super().__init__(message)
+        self.status_code = status_code
+        self.response_body = response_body
+        self.path: Optional[str] = None
+
+
+class WHOOPClient:
+    def __init__(self) -> None:
+        self._runtime = self._resolve_runtime(refresh_if_expiring=True)
+
+    def _resolve_runtime(self, *, force_refresh: bool = False, refresh_if_expiring: bool = True) -> Dict[str, Any]:
+        try:
+            return resolve_whoop_runtime_credentials(
+                force_refresh=force_refresh,
+                refresh_if_expiring=refresh_if_expiring,
+            )
+        except AuthError as exc:
+            raise WHOOPAuthRequiredError(str(exc)) from exc
+
+    @property
+    def base_url(self) -> str:
+        return str(self._runtime.get("base_url") or "").rstrip("/")
+
+    def _headers(self) -> Dict[str, str]:
+        return {
+            "Authorization": f"Bearer {self._runtime['access_token']}",
+            "Accept": "application/json",
+            "Content-Type": "application/json",
+        }
+
+    def request(
+        self,
+        method: str,
+        path: str,
+        *,
+        params: Optional[Dict[str, Any]] = None,
+        allow_retry_on_401: bool = True,
+        empty_response: Optional[Dict[str, Any]] = None,
+    ) -> Any:
+        url = f"{self.base_url}{path}"
+        response = httpx.request(
+            method,
+            url,
+            headers=self._headers(),
+            params=_strip_none(params),
+            timeout=30.0,
+        )
+        if response.status_code == 401 and allow_retry_on_401:
+            self._runtime = self._resolve_runtime(force_refresh=True, refresh_if_expiring=True)
+            return self.request(
+                method,
+                path,
+                params=params,
+                allow_retry_on_401=False,
+                empty_response=empty_response,
+            )
+        if response.status_code >= 400:
+            self._raise_api_error(response, method=method, path=path)
+        if response.status_code == 204 or not response.content:
+            return empty_response or {"success": True, "status_code": response.status_code, "empty": True}
+        if "application/json" in response.headers.get("content-type", ""):
+            return response.json()
+        return {"success": True, "text": response.text}
+
+    def _raise_api_error(self, response: httpx.Response, *, method: str, path: str) -> None:
+        detail = response.text.strip()
+        message = _friendly_whoop_error_message(
+            status_code=response.status_code,
+            detail=_extract_whoop_error_detail(response, fallback=detail),
+            method=method,
+            path=path,
+            retry_after=response.headers.get("Retry-After"),
+        )
+        error = WHOOPAPIError(message, status_code=response.status_code, response_body=detail)
+        error.path = path
+        raise error
+
+    def get_profile(self) -> Any:
+        return self.request("GET", "/user/profile/basic")
+
+    def list_cycles(self, **params: Any) -> Any:
+        return self._list_collection("/cycle", **params)
+
+    def get_cycle(self, cycle_id: str) -> Any:
+        return self.request("GET", f"/cycle/{cycle_id}")
+
+    def list_recovery(self, **params: Any) -> Any:
+        return self._list_collection("/recovery", **params)
+
+    def get_recovery(self, cycle_id: str) -> Any:
+        return self.request("GET", f"/cycle/{cycle_id}/recovery")
+
+    def list_sleep(self, **params: Any) -> Any:
+        return self._list_collection("/activity/sleep", **params)
+
+    def get_sleep(self, sleep_id: str) -> Any:
+        return self.request("GET", f"/activity/sleep/{sleep_id}")
+
+    def list_workouts(self, **params: Any) -> Any:
+        return self._list_collection("/activity/workout", **params)
+
+    def get_workout(self, workout_id: str) -> Any:
+        return self.request("GET", f"/activity/workout/{workout_id}")
+
+    def _list_collection(
+        self,
+        path: str,
+        *,
+        start: Optional[str] = None,
+        end: Optional[str] = None,
+        limit: Optional[int] = None,
+        next_token: Optional[str] = None,
+        max_pages: int = 1,
+    ) -> Any:
+        pages = max(1, int(max_pages or 1))
+        params: Dict[str, Any] = {
+            "start": start,
+            "end": end,
+            "limit": limit,
+        }
+        token = next_token
+        records: list[Any] = []
+        last_payload: Any = None
+        for _ in range(pages):
+            if token:
+                params["nextToken"] = token
+            payload = self.request("GET", path, params=params)
+            last_payload = payload
+            if not isinstance(payload, dict):
+                return payload
+            page_records = payload.get("records")
+            if isinstance(page_records, list):
+                records.extend(page_records)
+            token = str(payload.get("next_token") or "").strip() or None
+            if not token:
+                break
+        if isinstance(last_payload, dict):
+            combined = dict(last_payload)
+            combined["records"] = records
+            combined["next_token"] = token
+            return combined
+        return {"records": records, "next_token": token}
+
+
+def _strip_none(values: Optional[Dict[str, Any]]) -> Dict[str, Any]:
+    if not values:
+        return {}
+    return {key: value for key, value in values.items() if value is not None}
+
+
+def _extract_whoop_error_detail(response: httpx.Response, *, fallback: str = "") -> str:
+    try:
+        payload = response.json()
+    except Exception:
+        return fallback
+    if isinstance(payload, dict):
+        for key in ("error_description", "message", "detail", "error"):
+            value = payload.get(key)
+            if isinstance(value, str) and value.strip():
+                return value.strip()
+        try:
+            return json.dumps(payload, ensure_ascii=False)
+        except Exception:
+            return fallback
+    return fallback
+
+
+def _friendly_whoop_error_message(
+    *,
+    status_code: int,
+    detail: str,
+    method: str,
+    path: str,
+    retry_after: Optional[str] = None,
+) -> str:
+    prefix = f"WHOOP API {method.upper()} {path} failed with HTTP {status_code}"
+    if status_code == 401:
+        prefix += "; authentication failed. Run `hermes auth whoop` again if this persists"
+    elif status_code == 403:
+        prefix += "; requested WHOOP scope may not be granted"
+    elif status_code == 429:
+        prefix += "; rate limited"
+        if retry_after:
+            prefix += f" (retry after {retry_after}s)"
+    if detail:
+        prefix += f": {detail}"
+    return prefix

--- a/plugins/whoop/plugin.yaml
+++ b/plugins/whoop/plugin.yaml
@@ -1,0 +1,11 @@
+name: whoop
+version: 1.0.0
+description: "Native WHOOP integration — read-only profile, cycles, recovery, sleep, and workout tools using WHOOP Developer API OAuth. Auth via `hermes auth whoop`. Tools gate on `providers.whoop` in ~/.hermes/auth.json."
+author: NousResearch
+kind: backend
+provides_tools:
+  - whoop_profile
+  - whoop_cycles
+  - whoop_recovery
+  - whoop_sleep
+  - whoop_workouts

--- a/plugins/whoop/tools.py
+++ b/plugins/whoop/tools.py
@@ -1,0 +1,231 @@
+"""Native WHOOP tools for Hermes (registered via plugins/whoop)."""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+
+from hermes_cli.auth import get_auth_status
+from plugins.whoop.client import (
+    WHOOPAPIError,
+    WHOOPAuthRequiredError,
+    WHOOPClient,
+    WHOOPError,
+)
+from tools.registry import tool_error, tool_result
+
+
+def _check_whoop_available() -> bool:
+    try:
+        return bool(get_auth_status("whoop").get("logged_in"))
+    except Exception:
+        return False
+
+
+def _whoop_client() -> WHOOPClient:
+    return WHOOPClient()
+
+
+def _whoop_tool_error(exc: Exception) -> str:
+    if isinstance(exc, WHOOPAPIError):
+        return tool_error(str(exc), status_code=exc.status_code)
+    if isinstance(exc, (WHOOPError, WHOOPAuthRequiredError)):
+        return tool_error(str(exc))
+    return tool_error(f"WHOOP tool failed: {type(exc).__name__}: {exc}")
+
+
+def _coerce_limit(raw: Any, *, default: int = 25, minimum: int = 1, maximum: int = 25) -> int:
+    try:
+        value = int(raw)
+    except Exception:
+        value = default
+    return max(minimum, min(maximum, value))
+
+
+def _coerce_max_pages(raw: Any, *, default: int = 1, minimum: int = 1, maximum: int = 10) -> int:
+    try:
+        value = int(raw)
+    except Exception:
+        value = default
+    return max(minimum, min(maximum, value))
+
+
+def _list_kwargs(args: dict) -> Dict[str, Any]:
+    return {
+        "start": args.get("start"),
+        "end": args.get("end"),
+        "limit": _coerce_limit(args.get("limit")) if args.get("limit") is not None else None,
+        "next_token": args.get("next_token") or args.get("nextToken"),
+        "max_pages": _coerce_max_pages(args.get("max_pages")),
+    }
+
+
+def _first_record(payload: Any, *, empty_message: str) -> Any:
+    if isinstance(payload, dict) and isinstance(payload.get("records"), list) and payload["records"]:
+        return payload["records"][0]
+    return {"empty": True, "message": empty_message, "source": payload}
+
+
+def _require_id(args: dict, *, field: str = "id") -> str | None:
+    raw = args.get(field) or args.get("whoop_id")
+    value = str(raw or "").strip()
+    return value or None
+
+
+def _handle_whoop_profile(args: dict, **kw) -> str:
+    try:
+        return tool_result(_whoop_client().get_profile())
+    except Exception as exc:
+        return _whoop_tool_error(exc)
+
+
+def _handle_whoop_cycles(args: dict, **kw) -> str:
+    action = str(args.get("action") or "latest").strip().lower()
+    try:
+        client = _whoop_client()
+        if action == "list":
+            return tool_result(client.list_cycles(**_list_kwargs(args)))
+        if action == "latest":
+            return tool_result(_first_record(
+                client.list_cycles(**_list_kwargs(args)),
+                empty_message="No WHOOP cycles found for the requested window.",
+            ))
+        if action == "get":
+            cycle_id = _require_id(args)
+            if not cycle_id:
+                return tool_error("id is required for action='get'")
+            return tool_result(client.get_cycle(cycle_id))
+        return tool_error(f"Unknown whoop_cycles action: {action}")
+    except Exception as exc:
+        return _whoop_tool_error(exc)
+
+
+def _handle_whoop_recovery(args: dict, **kw) -> str:
+    action = str(args.get("action") or "latest").strip().lower()
+    try:
+        client = _whoop_client()
+        if action == "list":
+            return tool_result(client.list_recovery(**_list_kwargs(args)))
+        if action == "latest":
+            return tool_result(_first_record(
+                client.list_recovery(**_list_kwargs(args)),
+                empty_message="No WHOOP recovery records found for the requested window.",
+            ))
+        if action == "get":
+            cycle_id = _require_id(args, field="cycle_id")
+            if not cycle_id:
+                return tool_error("cycle_id is required for action='get'")
+            return tool_result(client.get_recovery(cycle_id))
+        return tool_error(f"Unknown whoop_recovery action: {action}")
+    except Exception as exc:
+        return _whoop_tool_error(exc)
+
+
+def _handle_whoop_sleep(args: dict, **kw) -> str:
+    action = str(args.get("action") or "latest").strip().lower()
+    try:
+        client = _whoop_client()
+        if action == "list":
+            return tool_result(client.list_sleep(**_list_kwargs(args)))
+        if action == "latest":
+            return tool_result(_first_record(
+                client.list_sleep(**_list_kwargs(args)),
+                empty_message="No WHOOP sleep records found for the requested window.",
+            ))
+        if action == "get":
+            sleep_id = _require_id(args)
+            if not sleep_id:
+                return tool_error("id is required for action='get'")
+            return tool_result(client.get_sleep(sleep_id))
+        return tool_error(f"Unknown whoop_sleep action: {action}")
+    except Exception as exc:
+        return _whoop_tool_error(exc)
+
+
+def _handle_whoop_workouts(args: dict, **kw) -> str:
+    action = str(args.get("action") or "list").strip().lower()
+    try:
+        client = _whoop_client()
+        if action == "list":
+            return tool_result(client.list_workouts(**_list_kwargs(args)))
+        if action == "latest":
+            return tool_result(_first_record(
+                client.list_workouts(**_list_kwargs(args)),
+                empty_message="No WHOOP workouts found for the requested window.",
+            ))
+        if action == "get":
+            workout_id = _require_id(args)
+            if not workout_id:
+                return tool_error("id is required for action='get'")
+            return tool_result(client.get_workout(workout_id))
+        return tool_error(f"Unknown whoop_workouts action: {action}")
+    except Exception as exc:
+        return _whoop_tool_error(exc)
+
+
+COMMON_STRING = {"type": "string"}
+_COMMON_RANGE_PROPS = {
+    "start": {"type": "string", "description": "ISO-8601 start timestamp"},
+    "end": {"type": "string", "description": "ISO-8601 end timestamp"},
+    "limit": {"type": "integer", "minimum": 1, "maximum": 25},
+    "next_token": COMMON_STRING,
+    "max_pages": {"type": "integer", "minimum": 1, "maximum": 10},
+}
+
+WHOOP_PROFILE_SCHEMA = {
+    "name": "whoop_profile",
+    "description": "Fetch the authenticated user's basic WHOOP profile. Read-only; not medical advice.",
+    "parameters": {"type": "object", "properties": {}},
+}
+
+WHOOP_CYCLES_SCHEMA = {
+    "name": "whoop_cycles",
+    "description": "Fetch WHOOP physiological cycles. Use latest for the most recent cycle or list for a paginated range.",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "action": {"type": "string", "enum": ["latest", "list", "get"]},
+            "id": COMMON_STRING,
+            **_COMMON_RANGE_PROPS,
+        },
+    },
+}
+
+WHOOP_RECOVERY_SCHEMA = {
+    "name": "whoop_recovery",
+    "description": "Fetch WHOOP recovery records. Returns raw metrics only; no medical advice.",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "action": {"type": "string", "enum": ["latest", "list", "get"]},
+            "cycle_id": {"type": "string", "description": "WHOOP cycle ID for action='get'"},
+            "id": {"type": "string", "description": "Alias for cycle_id"},
+            **_COMMON_RANGE_PROPS,
+        },
+    },
+}
+
+WHOOP_SLEEP_SCHEMA = {
+    "name": "whoop_sleep",
+    "description": "Fetch WHOOP sleep records. Returns raw metrics only; no medical advice.",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "action": {"type": "string", "enum": ["latest", "list", "get"]},
+            "id": COMMON_STRING,
+            **_COMMON_RANGE_PROPS,
+        },
+    },
+}
+
+WHOOP_WORKOUTS_SCHEMA = {
+    "name": "whoop_workouts",
+    "description": "Fetch WHOOP workout/activity records. Returns raw metrics only; no medical advice.",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "action": {"type": "string", "enum": ["latest", "list", "get"]},
+            "id": COMMON_STRING,
+            **_COMMON_RANGE_PROPS,
+        },
+    },
+}

--- a/run_agent.py
+++ b/run_agent.py
@@ -1483,7 +1483,15 @@ class AIAgent:
         if 0 <= idx < len(messages):
             msg = messages[idx]
             if isinstance(msg, dict) and msg.get("role") == "user":
-                if override is not None:
+                # Text-only call paths may pass a synthetic API-facing prompt
+                # and a cleaner transcript string separately. Multimodal
+                # turns, however, keep image/audio blocks in the live
+                # messages list that is still used for the API request after
+                # early crash-resilience persistence. Do not replace those
+                # blocks with the text-only persistence override before the
+                # model call is built. The paired timestamp override still
+                # applies — it is metadata, not content.
+                if override is not None and not isinstance(msg.get("content"), list):
                     msg["content"] = override
                 if timestamp is not None:
                     msg["timestamp"] = timestamp

--- a/tests/hermes_cli/test_whoop_auth.py
+++ b/tests/hermes_cli/test_whoop_auth.py
@@ -1,0 +1,240 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from hermes_cli import auth as auth_mod
+
+
+def test_whoop_default_api_base_url_uses_developer_v2() -> None:
+    assert auth_mod.DEFAULT_WHOOP_API_BASE_URL == "https://api.prod.whoop.com/developer/v2"
+
+
+def test_store_provider_state_whoop_does_not_overwrite_active_provider() -> None:
+    auth_store = {"active_provider": "nous", "providers": {}}
+
+    auth_mod._store_provider_state(
+        auth_store,
+        "whoop",
+        {"access_token": "tok"},
+        set_active=False,
+    )
+
+    assert auth_store["active_provider"] == "nous"
+    assert auth_store["providers"]["whoop"]["access_token"] == "tok"
+
+
+def test_resolve_whoop_runtime_credentials_refreshes_expiring_token(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    with auth_mod._auth_store_lock():
+        store = auth_mod._load_auth_store()
+        store["active_provider"] = "nous"
+        auth_mod._store_provider_state(
+            store,
+            "whoop",
+            {
+                "client_id": "whoop-client",
+                "client_secret": "whoop-secret",
+                "redirect_uri": auth_mod.DEFAULT_WHOOP_REDIRECT_URI,
+                "api_base_url": auth_mod.DEFAULT_WHOOP_API_BASE_URL,
+                "oauth_base_url": auth_mod.DEFAULT_WHOOP_OAUTH_BASE_URL,
+                "scope": auth_mod.DEFAULT_WHOOP_SCOPE,
+                "access_token": "expired-token",
+                "refresh_token": "refresh-token",
+                "token_type": "Bearer",
+                "expires_at": "2000-01-01T00:00:00+00:00",
+            },
+            set_active=False,
+        )
+        auth_mod._save_auth_store(store)
+
+    monkeypatch.setattr(
+        auth_mod,
+        "_refresh_whoop_oauth_state",
+        lambda state, timeout_seconds=20.0: {
+            **{k: v for k, v in state.items() if k != "client_secret"},
+            "access_token": "fresh-token",
+            "expires_at": "2099-01-01T00:00:00+00:00",
+        },
+    )
+
+    creds = auth_mod.resolve_whoop_runtime_credentials()
+
+    assert creds["access_token"] == "fresh-token"
+    assert "refresh_token" not in creds
+    persisted = auth_mod.get_provider_auth_state("whoop")
+    assert persisted is not None
+    assert persisted["access_token"] == "fresh-token"
+    assert "client_secret" not in persisted
+    assert auth_mod.get_active_provider() == "nous"
+
+
+def test_resolve_whoop_runtime_credentials_skips_refresh_if_fresh(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    refresh_calls: list = []
+
+    with auth_mod._auth_store_lock():
+        store = auth_mod._load_auth_store()
+        auth_mod._store_provider_state(
+            store,
+            "whoop",
+            {
+                "client_id": "whoop-client",
+                "access_token": "fresh-token",
+                "refresh_token": "rtoken",
+                "expires_at": "2099-01-01T00:00:00+00:00",
+            },
+            set_active=False,
+        )
+        auth_mod._save_auth_store(store)
+
+    monkeypatch.setattr(
+        auth_mod,
+        "_refresh_whoop_oauth_state",
+        lambda state, **kw: refresh_calls.append(1) or state,
+    )
+
+    creds = auth_mod.resolve_whoop_runtime_credentials()
+    assert creds["access_token"] == "fresh-token"
+    assert "refresh_token" not in creds
+    assert refresh_calls == []
+
+
+def test_resolve_whoop_runtime_credentials_uses_provider_state_fallback(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    fallback_state = {
+        "client_id": "global-whoop-client",
+        "access_token": "global-access-token",
+        "refresh_token": "global-refresh-token",
+        "expires_at": "2099-01-01T00:00:00+00:00",
+    }
+    monkeypatch.setattr(auth_mod, "get_provider_auth_state", lambda provider: fallback_state if provider == "whoop" else None)
+
+    creds = auth_mod.resolve_whoop_runtime_credentials()
+
+    assert creds["access_token"] == "global-access-token"
+    assert "refresh_token" not in creds
+
+
+def test_get_whoop_auth_status_logged_in(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    with auth_mod._auth_store_lock():
+        store = auth_mod._load_auth_store()
+        auth_mod._store_provider_state(
+            store,
+            "whoop",
+            {
+                "client_id": "whoop-client",
+                "access_token": "tok",
+                "refresh_token": "rtok",
+                "expires_at": "2099-01-01T00:00:00+00:00",
+            },
+            set_active=False,
+        )
+        auth_mod._save_auth_store(store)
+
+    status = auth_mod.get_whoop_auth_status()
+    assert status["logged_in"] is True
+    assert status.get("client_id") == "whoop-client"
+    assert "has_refresh_token" in status
+
+
+def test_get_whoop_auth_status_logged_out(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    status = auth_mod.get_whoop_auth_status()
+    assert status["logged_in"] is False
+
+
+def test_whoop_state_token_is_exactly_eight_chars() -> None:
+    state = auth_mod._whoop_state_token()
+    assert len(state) == 8
+
+
+def test_whoop_interactive_setup_persists_client_id(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys,
+) -> None:
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    inputs = iter(["wizard-client-123"])
+    monkeypatch.setattr("builtins.input", lambda prompt="": next(inputs))
+    monkeypatch.setattr("getpass.getpass", lambda prompt="": "wizard-secret-456")
+    monkeypatch.setattr(auth_mod, "webbrowser", SimpleNamespace(open=lambda *_a, **_k: False))
+    monkeypatch.setattr(auth_mod, "_is_remote_session", lambda: True)
+
+    result = auth_mod._whoop_interactive_setup(
+        redirect_uri_hint=auth_mod.DEFAULT_WHOOP_REDIRECT_URI,
+    )
+    assert result == "wizard-client-123"
+
+    env_path = tmp_path / ".env"
+    assert env_path.exists()
+    env_text = env_path.read_text()
+    assert "HERMES_WHOOP_CLIENT_ID=wizard-client-123" in env_text
+    assert "HERMES_WHOOP_CLIENT_SECRET=wizard-secret-456" in env_text
+
+    output = capsys.readouterr().out
+    assert auth_mod.WHOOP_DOCS_URL in output
+
+
+def test_whoop_interactive_setup_empty_aborts(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setattr("builtins.input", lambda prompt="": "")
+    monkeypatch.setattr(auth_mod, "webbrowser", SimpleNamespace(open=lambda *_a, **_k: False))
+    monkeypatch.setattr(auth_mod, "_is_remote_session", lambda: True)
+
+    with pytest.raises(SystemExit):
+        auth_mod._whoop_interactive_setup(
+            redirect_uri_hint=auth_mod.DEFAULT_WHOOP_REDIRECT_URI,
+        )
+
+    env_path = tmp_path / ".env"
+    if env_path.exists():
+        assert "HERMES_WHOOP_CLIENT_ID" not in env_path.read_text()
+
+
+def test_get_auth_status_whoop_dispatches(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    status = auth_mod.get_auth_status("whoop")
+    assert "logged_in" in status
+
+def test_whoop_token_state_does_not_persist_client_secret() -> None:
+    state = auth_mod._whoop_token_payload_to_state(
+        {"access_token": "access", "refresh_token": "refresh", "expires_in": 3600},
+        client_id="whoop-client",
+        client_secret="do-not-store",
+        redirect_uri=auth_mod.DEFAULT_WHOOP_REDIRECT_URI,
+        requested_scope=auth_mod.DEFAULT_WHOOP_SCOPE,
+        oauth_base_url=auth_mod.DEFAULT_WHOOP_OAUTH_BASE_URL,
+        api_base_url=auth_mod.DEFAULT_WHOOP_API_BASE_URL,
+        previous_state={"client_secret": "old-secret"},
+    )
+
+    assert state["client_id"] == "whoop-client"
+    assert state["access_token"] == "access"
+    assert "client_secret" not in state

--- a/tests/hermes_cli/test_whoop_toolset_config.py
+++ b/tests/hermes_cli/test_whoop_toolset_config.py
@@ -1,0 +1,18 @@
+from hermes_cli.tools_config import _get_platform_tools
+
+
+def test_whoop_plugin_toolset_defaults_off_for_cli_and_telegram():
+    assert "whoop" not in _get_platform_tools({}, "cli", include_default_mcp_servers=False)
+    assert "whoop" not in _get_platform_tools({}, "telegram", include_default_mcp_servers=False)
+
+
+def test_whoop_plugin_toolset_can_be_enabled_explicitly_for_cli_and_telegram():
+    config = {
+        "platform_toolsets": {
+            "cli": ["hermes-cli", "whoop"],
+            "telegram": ["hermes-telegram", "whoop"],
+        }
+    }
+
+    assert "whoop" in _get_platform_tools(config, "cli", include_default_mcp_servers=False)
+    assert "whoop" in _get_platform_tools(config, "telegram", include_default_mcp_servers=False)

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -97,6 +97,41 @@ def agent_with_memory_tool():
         return a
 
 
+def test_persist_user_message_override_preserves_multimodal_content(agent):
+    """Persistence override must not strip image/audio blocks before API use."""
+    multimodal_content = [
+        {"type": "text", "text": "see attached"},
+        {"type": "image_url", "image_url": {"url": "data:image/png;base64,abc"}},
+    ]
+    messages = [{"role": "user", "content": multimodal_content}]
+    agent._persist_user_message_idx = 0
+    agent._persist_user_message_override = "clean transcript text"
+    agent._persist_user_message_timestamp = "2026-06-18T12:00:00Z"
+
+    agent._apply_persist_user_message_override(messages)
+
+    assert messages[0]["content"] is multimodal_content
+    assert messages[0]["timestamp"] == "2026-06-18T12:00:00Z"
+
+
+def test_persist_user_message_override_rewrites_text_content(agent):
+    """Text-only turns still get the cleaner transcript override."""
+    messages = [{"role": "user", "content": "api-facing prompt"}]
+    agent._persist_user_message_idx = 0
+    agent._persist_user_message_override = "clean transcript text"
+    agent._persist_user_message_timestamp = "2026-06-18T12:00:00Z"
+
+    agent._apply_persist_user_message_override(messages)
+
+    assert messages == [
+        {
+            "role": "user",
+            "content": "clean transcript text",
+            "timestamp": "2026-06-18T12:00:00Z",
+        }
+    ]
+
+
 def test_aiagent_reuses_existing_errors_log_handler():
     """Repeated AIAgent init should not accumulate duplicate errors.log handlers."""
     root_logger = logging.getLogger()

--- a/tests/tools/test_whoop_client.py
+++ b/tests/tools/test_whoop_client.py
@@ -57,6 +57,7 @@ def test_whoop_client_retries_once_after_401(monkeypatch: pytest.MonkeyPatch) ->
     )
 
     def fake_request(method, url, headers=None, **kw):
+        assert headers is not None
         calls.append(headers["Authorization"])
         if len(calls) == 1:
             return _FakeResponse(401, {"error": "expired"})

--- a/tests/tools/test_whoop_client.py
+++ b/tests/tools/test_whoop_client.py
@@ -1,0 +1,170 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from plugins.whoop import client as whoop_mod
+
+
+class _FakeResponse:
+    def __init__(self, status_code: int, payload=None, *, text: str = "", headers=None):
+        self.status_code = status_code
+        self._payload = payload
+        self.text = text or (json.dumps(payload) if payload is not None else "")
+        self.headers = headers or {"content-type": "application/json"}
+        self.content = self.text.encode("utf-8") if self.text else b""
+
+    def json(self):
+        if self._payload is None:
+            raise ValueError("no json")
+        return self._payload
+
+
+_RUNTIME = {
+    "access_token": "token-1",
+    "base_url": "https://api.prod.whoop.com/developer/v2",
+}
+
+
+def test_whoop_client_uses_bearer_auth_and_base_url(monkeypatch: pytest.MonkeyPatch) -> None:
+    seen: dict = {}
+    monkeypatch.setattr(
+        whoop_mod, "resolve_whoop_runtime_credentials", lambda **kw: {**_RUNTIME}
+    )
+
+    def fake_request(method, url, headers=None, params=None, **kw):
+        seen.update({"method": method, "url": url, "headers": headers, "params": params})
+        return _FakeResponse(200, {"records": []})
+
+    monkeypatch.setattr(whoop_mod.httpx, "request", fake_request)
+
+    client = whoop_mod.WHOOPClient()
+    payload = client.request("GET", "/activity/sleep", params={"start": "2026-01-01T00:00:00Z"})
+
+    assert payload == {"records": []}
+    assert seen["method"] == "GET"
+    assert seen["url"] == "https://api.prod.whoop.com/developer/v2/activity/sleep"
+    assert seen["headers"]["Authorization"] == "Bearer token-1"
+    assert seen["params"] == {"start": "2026-01-01T00:00:00Z"}
+
+
+def test_whoop_client_retries_once_after_401(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[str] = []
+    tokens = iter([{**_RUNTIME}, {**_RUNTIME, "access_token": "token-2"}])
+    monkeypatch.setattr(
+        whoop_mod, "resolve_whoop_runtime_credentials", lambda **kw: next(tokens)
+    )
+
+    def fake_request(method, url, headers=None, **kw):
+        calls.append(headers["Authorization"])
+        if len(calls) == 1:
+            return _FakeResponse(401, {"error": "expired"})
+        return _FakeResponse(200, {"user_id": 42})
+
+    monkeypatch.setattr(whoop_mod.httpx, "request", fake_request)
+
+    client = whoop_mod.WHOOPClient()
+    payload = client.request("GET", "/user/profile/basic")
+    assert payload["user_id"] == 42
+    assert calls == ["Bearer token-1", "Bearer token-2"]
+
+
+def test_whoop_client_raises_after_double_401(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        whoop_mod, "resolve_whoop_runtime_credentials", lambda **kw: {**_RUNTIME}
+    )
+    monkeypatch.setattr(
+        whoop_mod.httpx, "request", lambda *a, **kw: _FakeResponse(401, {"error": "denied"})
+    )
+
+    client = whoop_mod.WHOOPClient()
+    with pytest.raises(whoop_mod.WHOOPAPIError):
+        client.request("GET", "/user/profile/basic")
+
+
+def test_whoop_client_429_error_includes_retry_context(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        whoop_mod, "resolve_whoop_runtime_credentials", lambda **kw: {**_RUNTIME}
+    )
+    monkeypatch.setattr(
+        whoop_mod.httpx,
+        "request",
+        lambda *a, **kw: _FakeResponse(
+            429,
+            {"message": "slow down"},
+            headers={"content-type": "application/json", "Retry-After": "30"},
+        ),
+    )
+
+    client = whoop_mod.WHOOPClient()
+    with pytest.raises(whoop_mod.WHOOPAPIError) as exc:
+        client.request("GET", "/recovery")
+
+    message = str(exc.value)
+    assert "rate limited" in message
+    assert "retry after 30s" in message
+    assert "slow down" in message
+
+
+def test_whoop_client_paginates_records_with_next_token(monkeypatch: pytest.MonkeyPatch) -> None:
+    seen_params: list[dict] = []
+    pages = iter([
+        _FakeResponse(200, {"records": [{"id": 1}], "next_token": "page-2"}),
+        _FakeResponse(200, {"records": [{"id": 2}], "next_token": None}),
+    ])
+    monkeypatch.setattr(
+        whoop_mod, "resolve_whoop_runtime_credentials", lambda **kw: {**_RUNTIME}
+    )
+
+    def fake_request(method, url, headers=None, params=None, **kw):
+        seen_params.append(dict(params or {}))
+        return next(pages)
+
+    monkeypatch.setattr(whoop_mod.httpx, "request", fake_request)
+
+    client = whoop_mod.WHOOPClient()
+    payload = client.list_sleep(start="2026-01-01T00:00:00Z", max_pages=5)
+
+    assert payload["records"] == [{"id": 1}, {"id": 2}]
+    assert seen_params[0] == {"start": "2026-01-01T00:00:00Z"}
+    assert seen_params[1]["nextToken"] == "page-2"
+
+
+def test_whoop_client_max_pages_stops_runaway_pagination(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls = 0
+    monkeypatch.setattr(
+        whoop_mod, "resolve_whoop_runtime_credentials", lambda **kw: {**_RUNTIME}
+    )
+
+    def fake_request(method, url, headers=None, params=None, **kw):
+        nonlocal calls
+        calls += 1
+        return _FakeResponse(200, {"records": [{"page": calls}], "next_token": "more"})
+
+    monkeypatch.setattr(whoop_mod.httpx, "request", fake_request)
+
+    client = whoop_mod.WHOOPClient()
+    payload = client.list_cycles(max_pages=2)
+
+    assert calls == 2
+    assert payload["records"] == [{"page": 1}, {"page": 2}]
+    assert payload["next_token"] == "more"
+
+def test_whoop_client_get_recovery_uses_cycle_recovery_path(monkeypatch: pytest.MonkeyPatch) -> None:
+    seen: dict = {}
+    monkeypatch.setattr(
+        whoop_mod, "resolve_whoop_runtime_credentials", lambda **kw: {**_RUNTIME}
+    )
+
+    def fake_request(method, url, headers=None, params=None, **kw):
+        seen["url"] = url
+        return _FakeResponse(200, {"cycle_id": "cycle-123", "score": {"recovery_score": 91}})
+
+    monkeypatch.setattr(whoop_mod.httpx, "request", fake_request)
+
+    client = whoop_mod.WHOOPClient()
+    payload = client.get_recovery("cycle-123")
+
+    assert payload["cycle_id"] == "cycle-123"
+    assert seen["url"].endswith("/cycle/cycle-123/recovery")

--- a/tests/tools/test_whoop_tools.py
+++ b/tests/tools/test_whoop_tools.py
@@ -1,0 +1,181 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from plugins.whoop import register as whoop_register
+from plugins.whoop import tools as whoop_tool
+
+
+def test_whoop_profile_tool_returns_result(monkeypatch: pytest.MonkeyPatch) -> None:
+    class _StubClient:
+        def get_profile(self):
+            return {"user_id": 99, "email": "test@example.com", "first_name": "Test"}
+
+    monkeypatch.setattr(whoop_tool, "_whoop_client", lambda: _StubClient())
+    result = json.loads(whoop_tool._handle_whoop_profile({}))
+    assert result["user_id"] == 99
+
+
+def test_whoop_cycles_list_passes_query_params(monkeypatch: pytest.MonkeyPatch) -> None:
+    seen: list[dict] = []
+
+    class _StubClient:
+        def list_cycles(self, **kw):
+            seen.append(kw)
+            return {"records": [], "next_token": None}
+
+    monkeypatch.setattr(whoop_tool, "_whoop_client", lambda: _StubClient())
+    json.loads(whoop_tool._handle_whoop_cycles({
+        "action": "list",
+        "start": "2024-01-01T00:00:00Z",
+        "end": "2024-01-31T00:00:00Z",
+        "limit": 10,
+        "nextToken": "abc",
+        "max_pages": 2,
+    }))
+    assert seen
+    assert seen[0].get("start") == "2024-01-01T00:00:00Z"
+    assert seen[0].get("limit") == 10
+    assert seen[0].get("next_token") == "abc"
+    assert seen[0].get("max_pages") == 2
+
+
+def test_whoop_recovery_latest_returns_first_record(monkeypatch: pytest.MonkeyPatch) -> None:
+    class _StubClient:
+        def list_recovery(self, **kw):
+            return {"records": [{"score": {"recovery_score": 85}}], "next_token": None}
+
+    monkeypatch.setattr(whoop_tool, "_whoop_client", lambda: _StubClient())
+    result = json.loads(whoop_tool._handle_whoop_recovery({"action": "latest"}))
+    assert result["score"]["recovery_score"] == 85
+
+
+def test_whoop_recovery_missing_action_defaults_to_latest(monkeypatch: pytest.MonkeyPatch) -> None:
+    class _StubClient:
+        def list_recovery(self, **kw):
+            return {"records": [{"score": {"recovery_score": 72}}], "next_token": None}
+
+    monkeypatch.setattr(whoop_tool, "_whoop_client", lambda: _StubClient())
+    result = json.loads(whoop_tool._handle_whoop_recovery({}))
+    assert result["score"]["recovery_score"] == 72
+
+
+def test_whoop_sleep_get_by_id(monkeypatch: pytest.MonkeyPatch) -> None:
+    seen: list[str] = []
+
+    class _StubClient:
+        def get_sleep(self, sleep_id):
+            seen.append(sleep_id)
+            return {"id": sleep_id, "start": "2024-01-01T22:00:00Z"}
+
+    monkeypatch.setattr(whoop_tool, "_whoop_client", lambda: _StubClient())
+    result = json.loads(whoop_tool._handle_whoop_sleep({"action": "get", "id": "42"}))
+    assert seen == ["42"]
+    assert result["id"] == "42"
+
+
+def test_whoop_sleep_get_requires_id(monkeypatch: pytest.MonkeyPatch) -> None:
+    class _StubClient:
+        pass
+
+    monkeypatch.setattr(whoop_tool, "_whoop_client", lambda: _StubClient())
+    result = json.loads(whoop_tool._handle_whoop_sleep({"action": "get"}))
+    assert "error" in result or "id" in str(result).lower()
+
+
+def test_whoop_workouts_list(monkeypatch: pytest.MonkeyPatch) -> None:
+    class _StubClient:
+        def list_workouts(self, **kw):
+            return {"records": [{"id": 1, "sport_id": 0}], "next_token": None}
+
+    monkeypatch.setattr(whoop_tool, "_whoop_client", lambda: _StubClient())
+    result = json.loads(whoop_tool._handle_whoop_workouts({"action": "list"}))
+    assert result["records"][0]["id"] == 1
+
+
+def test_whoop_tools_gated_when_not_authenticated() -> None:
+    """_check_whoop_available returns False without auth state (isolated HERMES_HOME from conftest)."""
+    assert whoop_tool._check_whoop_available() is False
+
+
+def test_whoop_plugin_registers_five_tools() -> None:
+    calls: list[dict] = []
+
+    class _FakeCtx:
+        def register_tool(self, **kw):
+            calls.append(kw)
+
+    whoop_register(_FakeCtx())
+    expected = {"whoop_profile", "whoop_cycles", "whoop_recovery", "whoop_sleep", "whoop_workouts"}
+    assert {call["name"] for call in calls} == expected
+    assert {call["toolset"] for call in calls} == {"whoop"}
+    assert all(call["check_fn"] is whoop_tool._check_whoop_available for call in calls)
+
+
+def test_whoop_cycles_latest_returns_first_record(monkeypatch: pytest.MonkeyPatch) -> None:
+    class _StubClient:
+        def list_cycles(self, **kw):
+            return {"records": [{"id": 10, "score": {"strain": 12.5}}], "next_token": None}
+
+    monkeypatch.setattr(whoop_tool, "_whoop_client", lambda: _StubClient())
+    result = json.loads(whoop_tool._handle_whoop_cycles({"action": "latest"}))
+    assert result["id"] == 10
+
+
+def test_whoop_workouts_get_by_id(monkeypatch: pytest.MonkeyPatch) -> None:
+    seen: list[str] = []
+
+    class _StubClient:
+        def get_workout(self, workout_id):
+            seen.append(workout_id)
+            return {"id": workout_id, "sport_id": 71}
+
+    monkeypatch.setattr(whoop_tool, "_whoop_client", lambda: _StubClient())
+    result = json.loads(whoop_tool._handle_whoop_workouts({"action": "get", "id": "99"}))
+    assert seen == ["99"]
+    assert result["sport_id"] == 71
+
+
+def test_whoop_tool_unknown_action_returns_tool_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    class _StubClient:
+        pass
+
+    monkeypatch.setattr(whoop_tool, "_whoop_client", lambda: _StubClient())
+    result = json.loads(whoop_tool._handle_whoop_cycles({"action": "dance"}))
+    assert "error" in result
+
+
+def test_whoop_limit_and_max_pages_are_clamped(monkeypatch: pytest.MonkeyPatch) -> None:
+    seen: list[dict] = []
+
+    class _StubClient:
+        def list_sleep(self, **kw):
+            seen.append(kw)
+            return {"records": []}
+
+    monkeypatch.setattr(whoop_tool, "_whoop_client", lambda: _StubClient())
+    json.loads(whoop_tool._handle_whoop_sleep({"action": "list", "limit": 999, "max_pages": 99}))
+    assert seen[0]["limit"] == 25
+    assert seen[0]["max_pages"] == 10
+
+def test_whoop_recovery_get_uses_cycle_id(monkeypatch: pytest.MonkeyPatch) -> None:
+    seen: list[str] = []
+
+    class _StubClient:
+        def get_recovery(self, cycle_id):
+            seen.append(cycle_id)
+            return {"cycle_id": cycle_id, "score": {"recovery_score": 88}}
+
+    monkeypatch.setattr(whoop_tool, "_whoop_client", lambda: _StubClient())
+    result = json.loads(whoop_tool._handle_whoop_recovery({"action": "get", "cycle_id": "abc"}))
+    assert seen == ["abc"]
+    assert result["score"]["recovery_score"] == 88
+
+
+def test_whoop_handler_returns_tool_error_when_client_init_fails(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(whoop_tool, "_whoop_client", lambda: (_ for _ in ()).throw(RuntimeError("boom")))
+    result = json.loads(whoop_tool._handle_whoop_cycles({"action": "latest"}))
+    assert "error" in result
+    assert "boom" in result["error"]

--- a/toolsets.py
+++ b/toolsets.py
@@ -603,8 +603,10 @@ def get_toolset(name: str) -> Optional[Dict[str, Any]]:
         return toolset if toolset else None
 
     if toolset:
+        raw_tools = toolset.get("tools", [])
+        declared_tools = raw_tools if isinstance(raw_tools, list) else []
         merged_tools = sorted(
-            set(toolset.get("tools", []))
+            set(declared_tools)
             | set(registry.get_tool_names_for_toolset(name))
         )
         return {**toolset, "tools": merged_tools}

--- a/toolsets.py
+++ b/toolsets.py
@@ -317,6 +317,14 @@ TOOLSETS = {
         "includes": []
     },
 
+    "whoop": {
+        "description": "Read-only WHOOP profile, cycles, recovery, sleep, and workout tools",
+        "tools": [
+            "whoop_profile", "whoop_cycles", "whoop_recovery", "whoop_sleep", "whoop_workouts",
+        ],
+        "includes": []
+    },
+
 
     # Scenario-specific toolsets
     

--- a/website/docs/user-guide/features/whoop.md
+++ b/website/docs/user-guide/features/whoop.md
@@ -1,0 +1,158 @@
+# WHOOP
+
+Hermes can read WHOOP profile, recovery, sleep, cycle, and workout data through WHOOP's official Developer API. The integration is read-only: it exposes your metrics to the agent, but it does not write data back to WHOOP and it does not provide medical advice.
+
+WHOOP health telemetry is personal data. Treat it like private context and only share summaries outside your own Hermes session when you explicitly choose to.
+
+## Prerequisites
+
+- A WHOOP account.
+- Hermes Agent installed and running.
+- A WHOOP Developer app with OAuth credentials from the WHOOP Developer Dashboard.
+
+## Setup
+
+### 1. Create a WHOOP Developer app
+
+Open the WHOOP Developer docs/dashboard:
+
+```bash
+open https://developer.whoop.com/api
+```
+
+Create an app and configure the redirect URI exactly as:
+
+```text
+http://127.0.0.1:43828/whoop/callback
+```
+
+Requested scopes:
+
+```text
+offline read:profile read:body_measurement read:cycles read:recovery read:sleep read:workout
+```
+
+WHOOP requires an OAuth `state` value with exactly eight characters. Hermes generates that automatically during `hermes auth whoop`.
+
+### 2. Store credentials locally
+
+Do not paste your WHOOP client secret into chat. Put it only in your local shell or Hermes `.env` file.
+
+Find the env file:
+
+```bash
+hermes config env-path
+```
+
+Then add:
+
+```bash
+HERMES_WHOOP_CLIENT_ID="your-client-id"
+HERMES_WHOOP_CLIENT_SECRET="your-client-secret"
+```
+
+Hermes also accepts `WHOOP_CLIENT_ID` and `WHOOP_CLIENT_SECRET`, but the `HERMES_` names are preferred.
+
+### 3. Run OAuth login
+
+```bash
+hermes auth whoop
+```
+
+After approval, tokens are stored under `providers.whoop` in your Hermes auth store. This does not change your active LLM provider.
+
+## Verify
+
+```bash
+hermes auth status whoop
+```
+
+A logged-in status means WHOOP tools can appear when the `whoop` toolset is enabled. Access tokens refresh automatically when expiring, and WHOOP API 401 responses trigger one forced refresh and retry.
+
+## Enable the toolset
+
+```bash
+hermes tools
+```
+
+Toggle the WHOOP toolset on, then start a new session. Toolset changes take effect on a fresh session so prompt/tool caching stays stable.
+
+## Tools
+
+WHOOP tools are read-only and return raw API data plus light wrapper metadata. They do not diagnose, prescribe, or provide medical advice.
+
+### `whoop_profile`
+
+Fetches your basic WHOOP profile.
+
+Example prompt:
+
+```text
+Show my WHOOP profile.
+```
+
+### `whoop_cycles`
+
+Fetches physiological cycle records.
+
+Actions:
+
+- `latest` — fetch the most recent record by listing with `limit=1`.
+- `list` — fetch paginated records.
+- `get` — fetch a record by `id`.
+
+Common args for `list` / `latest`:
+
+- `start` — ISO-8601 start timestamp.
+- `end` — ISO-8601 end timestamp.
+- `limit` — clamped to 1-25.
+- `next_token` / `nextToken` — pagination token.
+- `max_pages` — clamped to 1-10.
+
+### `whoop_recovery`
+
+Fetches recovery records.
+
+Actions:
+
+- `latest` — fetch the most recent recovery record by listing with `limit=1`.
+- `list` — fetch paginated recovery records.
+- `get` — fetch recovery for a specific WHOOP cycle via `cycle_id` (`id` is accepted as an alias).
+
+Example prompt:
+
+```text
+What was my latest WHOOP recovery score? Keep it factual, no medical advice.
+```
+
+### `whoop_sleep`
+
+Fetches sleep records.
+
+Example prompt:
+
+```text
+Pull my WHOOP sleep records for the last week and summarize duration and disturbances.
+```
+
+### `whoop_workouts`
+
+Fetches workout/activity records.
+
+Example prompt:
+
+```text
+List my latest WHOOP workouts and total the strain by day.
+```
+
+## Pagination and rate limits
+
+WHOOP collections return `records` and may include `next_token`. Follow-up requests use `nextToken`. Hermes handles that internally when `max_pages` is greater than 1.
+
+Default WHOOP API limits are 100 requests/minute and 10,000/day. If WHOOP returns `429`, Hermes surfaces the rate-limit context and `Retry-After` value when present.
+
+## Privacy and safety
+
+- Never paste WHOOP client secrets, access tokens, refresh tokens, or OAuth codes into chat.
+- WHOOP data is personal health telemetry. Keep it in private sessions unless you intentionally share it.
+- Hermes can summarize metrics, but it is not a clinician. For medical decisions, talk to a qualified professional. Annoying boilerplate, yes. Still true.


### PR DESCRIPTION
## Summary
- Adds a native WHOOP plugin/toolset with cycles, sleep, recovery, workout, and profile read-only tools
- Adds WHOOP OAuth login/status/logout support with local secret-safe setup and token refresh handling
- Documents setup/usage and adds targeted unit coverage for auth, tool registration, client requests, and tool handlers

## Test Plan
- `./.venv/bin/python -m pytest -o addopts='' tests/hermes_cli/test_whoop_auth.py tests/hermes_cli/test_whoop_toolset_config.py tests/tools/test_whoop_client.py tests/tools/test_whoop_tools.py -q`
- `./.venv/bin/python -m pytest -o addopts='' tests/hermes_cli/test_auth_commands.py -q`
- `./.venv/bin/python -m hermes_cli.main auth whoop --help`
- `./.venv/bin/python -m hermes_cli.main logout --help` and verified WHOOP is listed

## Safety / blast radius
- Read-only WHOOP API tools only; no writes to WHOOP
- Credentials are configured through local auth/env flows; no live credentials included
- The branch stops short of any live credential setup or gateway restart
