### PR TITLE
fix(vision): accept pixel-correct resize when bytes grow (#48013)

### DIFF
--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -552,8 +552,7 @@ def try_shrink_image_parts_in_messages(api_messages: list) -> bool:
                     Path(tmp.name).unlink(missing_ok=True)
                 except Exception:
                     pass
-            if not resized or len(resized) >= len(url):
-                # Shrink didn't help (or made it bigger — corrupt input?).
+            if not resized:
                 return None
             return resized
         except Exception as exc:


### PR DESCRIPTION
Fixes #48013. Removed the byte-size comparison that discarded valid dimension-reduced resizes of PNG images. The _resize_image_for_vision function already handles dimension reduction; the caller should trust its output.