### PR TITLE
fix(gateway): don't surface benign "Unit not loaded" when restarting a stopped gateway

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -1045,12 +1045,7 @@ def _recover_pending_systemd_restart(
         print(
             f"↻ Clearing failed state for pending {scope_label.lower()} service restart..."
         )
-        _run_systemctl(
-            ["reset-failed", svc],
-            system=system,
-            check=False,
-            timeout=30,
-        )
+        _reset_failed_quiet(svc, system=system)
         _run_systemctl(
             ["start", svc],
             system=system,
@@ -1737,6 +1732,35 @@ def _run_systemctl(
         return subprocess.run(_systemctl_cmd(system) + args, **kwargs)
     except FileNotFoundError:
         raise RuntimeError("systemctl is not available on this system") from None
+
+
+def _reset_failed_quiet(service: str, *, system: bool = False) -> None:
+    """Best-effort ``systemctl reset-failed`` that swallows benign noise.
+
+    ``reset-failed`` only clears a unit's *failed* state. When there is nothing
+    to clear — most often because the unit is currently stopped and systemd has
+    dropped it from memory (disabled units are unloaded after a daemon-reload) —
+    systemctl exits non-zero with ``Unit <svc> not loaded`` / ``not found``.
+    Every caller follows this with a ``start``/``restart`` that loads the unit
+    anyway, so the message is harmless; printing it just makes a routine
+    ``hermes gateway restart`` of a stopped gateway look like it failed.
+
+    Capture and discard that benign output, but still surface genuinely
+    unexpected stderr so real problems aren't hidden.
+    """
+    result = _run_systemctl(
+        ["reset-failed", service],
+        system=system,
+        check=False,
+        timeout=30,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode == 0:
+        return
+    stderr = (result.stderr or "").strip()
+    if stderr and "not loaded" not in stderr and "not found" not in stderr:
+        sys.stderr.write(stderr + "\n")
 
 
 def _service_scope_label(system: bool = False) -> str:
@@ -2959,12 +2983,7 @@ def systemd_restart(system: bool = False):
             # RestartSec can otherwise delay the relaunch even though the
             # operator asked for an immediate restart, so kick the unit once
             # the old PID has exited and then wait for the replacement PID.
-            _run_systemctl(
-                ["reset-failed", svc],
-                system=system,
-                check=False,
-                timeout=30,
-            )
+            _reset_failed_quiet(svc, system=system)
             _run_systemctl(
                 ["restart", svc],
                 system=system,
@@ -2980,12 +2999,7 @@ def systemd_restart(system: bool = False):
             f"⚠ Graceful restart did not complete within {int(drain_timeout + 5)}s; "
             "forcing a service restart..."
         )
-        _run_systemctl(
-            ["reset-failed", svc],
-            system=system,
-            check=False,
-            timeout=30,
-        )
+        _reset_failed_quiet(svc, system=system)
         try:
             _run_systemctl(["restart", svc], system=system, check=True, timeout=90)
         except subprocess.CalledProcessError as exc:
@@ -3008,12 +3022,7 @@ def systemd_restart(system: bool = False):
     if _recover_pending_systemd_restart(system=system, previous_pid=pid):
         return
 
-    _run_systemctl(
-        ["reset-failed", get_service_name()],
-        system=system,
-        check=False,
-        timeout=30,
-    )
+    _reset_failed_quiet(get_service_name(), system=system)
     try:
         _run_systemctl(
             ["restart", get_service_name()], system=system, check=True, timeout=90

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -3151,3 +3151,52 @@ class TestServiceWorkingDirIsStable:
         # The old conditional dict form must NOT appear
         assert "SuccessfulExit" not in plist
         assert "<key>KeepAlive</key>\n    <dict>" not in plist
+
+
+class TestResetFailedQuiet:
+    """_reset_failed_quiet swallows benign reset-failed noise.
+
+    `hermes gateway restart` of a *stopped* gateway runs `reset-failed` before
+    `start`. A disabled+inactive unit is unloaded by systemd, so reset-failed
+    exits non-zero with "Unit ... not loaded" — harmless, but it used to print
+    a scary error line during an otherwise-successful restart.
+    """
+
+    def _capture(self, monkeypatch, returncode, stderr):
+        captured = {}
+
+        def fake_run_systemctl(args, *, system=False, **kwargs):
+            captured["args"] = args
+            captured["kwargs"] = kwargs
+            return subprocess.CompletedProcess(args, returncode, stdout="", stderr=stderr)
+
+        monkeypatch.setattr(gateway_cli, "_run_systemctl", fake_run_systemctl)
+        return captured
+
+    def test_success_is_silent(self, monkeypatch, capsys):
+        captured = self._capture(monkeypatch, 0, "")
+        gateway_cli._reset_failed_quiet("hermes-gateway-x.service")
+        assert captured["args"] == ["reset-failed", "hermes-gateway-x.service"]
+        # Output must be captured (not inherited) so systemctl can't leak to the tty.
+        assert captured["kwargs"].get("capture_output") is True
+        assert capsys.readouterr().err == ""
+
+    def test_not_loaded_is_swallowed(self, monkeypatch, capsys):
+        self._capture(
+            monkeypatch,
+            1,
+            "Failed to reset failed state of unit hermes-gateway-x.service: "
+            "Unit hermes-gateway-x.service not loaded.",
+        )
+        gateway_cli._reset_failed_quiet("hermes-gateway-x.service")
+        assert capsys.readouterr().err == ""
+
+    def test_not_found_is_swallowed(self, monkeypatch, capsys):
+        self._capture(monkeypatch, 1, "Unit hermes-gateway-x.service not found.")
+        gateway_cli._reset_failed_quiet("hermes-gateway-x.service")
+        assert capsys.readouterr().err == ""
+
+    def test_unexpected_error_is_surfaced(self, monkeypatch, capsys):
+        self._capture(monkeypatch, 1, "Interactive authentication required.")
+        gateway_cli._reset_failed_quiet("hermes-gateway-x.service")
+        assert "Interactive authentication required." in capsys.readouterr().err


### PR DESCRIPTION
## Problem

`hermes gateway restart` of a gateway that is **currently stopped** prints a scary-looking error before succeeding:

```
$ hermes gateway restart
Failed to reset failed state of unit hermes-gateway-littleram.service: Unit hermes-gateway-littleram.service not loaded.
⏳ User service process started (PID 3881581); waiting for gateway runtime...
```

The restart actually works — the service starts and the gateway comes up healthy. The error line is misleading noise.

## Root cause

`systemd_restart()` (and `_recover_pending_systemd_restart()`) run a best-effort `systemctl reset-failed` before `start`/`restart` to clear any pending failed state. But `reset-failed` only clears a *failed* state, and when the gateway is stopped — and, for a `disabled` unit, unloaded by systemd after a `daemon-reload` — there's nothing to clear, so systemctl exits non-zero with:

```
Failed to reset failed state of unit X: Unit X not loaded.
```

Those calls used `_run_systemctl(["reset-failed", ...], check=False)` which inherits stderr, so the benign message leaked straight to the user's terminal during an otherwise-successful restart.

## Fix

Route every `reset-failed` call through a small `_reset_failed_quiet()` helper that captures the output and discards the benign `not loaded` / `not found` cases, while still surfacing genuinely unexpected stderr (e.g. `Interactive authentication required`) so real problems aren't hidden. The subsequent `start`/`restart` is unchanged.

## Test

Adds `TestResetFailedQuiet` to `tests/hermes_cli/test_gateway_service.py`: success is silent (and asserts output is captured, not inherited), both benign messages are swallowed, and an unexpected error is surfaced.

```
$ python -m pytest tests/hermes_cli/test_gateway_service.py::TestResetFailedQuiet -q
4 passed
```