### PR TITLE
fix(dashboard): resume chat in the session's owning profile

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -6533,11 +6533,60 @@ async def cancel_oauth_session(
 
 
 
-def _session_latest_descendant(session_id: str):
+def _find_session_profile(session_id: str) -> Optional[str]:
+    """Best-effort: name of the profile whose ``state.db`` owns *session_id*.
+
+    Read-only and cheap: opens each profile's db with ``read_only=True`` and
+    does a single ``resolve_session_id`` + ``get_session`` point lookup (no
+    table scan, no descendant walk), so it cannot write-lock a live writer.
+    Returns the owning profile name (possibly ``"default"``), or ``None`` if no
+    profile claims the id.
+
+    Used only as a cold-path fallback when a session lookup arrives without an
+    explicit ``?profile=`` — e.g. a bookmarked or desktop-restored
+    ``/chat?resume=<id>`` URL — so such links resolve against the owning
+    profile's db instead of 404ing against whichever profile is sticky-active.
+    """
+    from hermes_state import SessionDB
+    from hermes_cli import profiles as profiles_mod
+
+    try:
+        infos = profiles_mod.list_profiles()
+    except Exception:
+        _log.debug("list_profiles failed during session-owner lookup", exc_info=True)
+        return None
+    for info in infos:
+        db_path = Path(info.path) / "state.db"
+        if not db_path.exists():
+            continue
+        try:
+            db = SessionDB(db_path=db_path, read_only=True)
+        except Exception:
+            _log.debug("owner-lookup: could not open %s read-only", db_path, exc_info=True)
+            continue
+        try:
+            sid = db.resolve_session_id(session_id)
+            if sid and db.get_session(sid):
+                return info.name
+        except Exception:
+            _log.debug("owner-lookup probe failed for profile %s", info.name, exc_info=True)
+        finally:
+            db.close()
+    return None
+
+
+def _session_latest_descendant(session_id: str, profile: Optional[str] = None):
     """Resolve a session id to the newest child leaf session.
 
     /model may create child sessions. Dashboard refresh should continue the
     newest child instead of reopening the old parent.
+
+    ``profile`` selects which profile's ``state.db`` to walk — compression
+    lineage never crosses profiles. When ``profile`` is omitted and the id is
+    not found in the process/default db, fall back to locating the owning
+    profile (see :func:`_find_session_profile`) so resume links that carry no
+    profile — notably the desktop's restored ``/chat?resume=<id>`` URL —
+    resolve instead of 404ing when a different profile is sticky-active.
     """
     from hermes_state import SessionDB
 
@@ -6552,11 +6601,22 @@ def _session_latest_descendant(session_id: str):
             except Exception:
                 return None
 
-    db = SessionDB()
+    db = _open_session_db_for_profile(profile)
     try:
         sid = db.resolve_session_id(session_id)
         if not sid or not db.get_session(sid):
-            return None, []
+            # Not in the requested/default db. Locate the owning profile and
+            # walk its db instead. Session ids are globally unique, so this is
+            # safe and resolves a session whose owner differs from the
+            # requested/sticky-active profile, plus links that carry no profile.
+            owner = _find_session_profile(session_id)
+            if owner is None:
+                return None, []
+            db.close()
+            db = _open_session_db_for_profile(owner)
+            sid = db.resolve_session_id(session_id)
+            if not sid or not db.get_session(sid):
+                return None, []
 
         conn = (
             getattr(db, "conn", None)
@@ -6781,8 +6841,8 @@ async def get_session_detail(session_id: str, profile: Optional[str] = None):
 
 
 @app.get("/api/sessions/{session_id}/latest-descendant")
-async def get_session_latest_descendant(session_id: str):
-    latest, path = _session_latest_descendant(session_id)
+async def get_session_latest_descendant(session_id: str, profile: Optional[str] = None):
+    latest, path = _session_latest_descendant(session_id, profile)
     if not latest:
         raise HTTPException(status_code=404, detail="Session not found")
     return {
@@ -10524,6 +10584,38 @@ def _resolve_chat_argv(
     if requested and requested.lower() != "current":
         profile_dir = _resolve_profile_dir(requested)
 
+    # A *resume* must run in the profile that OWNS the session. The dashboard
+    # switcher's `profile` is only a hint — often the sticky-active profile,
+    # not the session's owner (and a bare desktop-restored /chat?resume=<id>
+    # URL carries none). Binding the wrong HERMES_HOME makes the TUI reopen the
+    # wrong state.db and 404 ("session not found"). Resolve the real owner and
+    # pin HERMES_HOME to it explicitly, so an inherited active-profile
+    # HERMES_HOME cannot misroute a default-owned resume either.
+    resume_profile: Optional[str] = requested or None
+    resume_home: Optional[Path] = None
+    if resume:
+        hint = requested if (requested and requested.lower() != "current") else None
+        owner: Optional[str] = None
+        if hint:
+            # Trust an explicit named profile only if it actually owns the
+            # session; otherwise fall through to the cross-profile lookup.
+            probe = _open_session_db_for_profile(hint)
+            try:
+                psid = probe.resolve_session_id(resume)
+                if psid and probe.get_session(psid):
+                    owner = hint
+            finally:
+                probe.close()
+        if owner is None:
+            owner = _find_session_profile(resume)
+        if owner:
+            resume_profile = None if owner == "default" else owner
+            # profile_dir drives gateway-attach below: None => attach the
+            # in-memory (default-profile) gateway; a named profile spawns its
+            # own. resume_home is the HERMES_HOME we pin for the resume.
+            profile_dir = None if owner == "default" else _resolve_profile_dir(owner)
+            resume_home = _resolve_profile_dir(owner)  # "default" -> ~/.hermes
+
     argv, cwd = _make_tui_argv(PROJECT_ROOT / "ui-tui", tui_dev=False)
     env = os.environ.copy()
     try:
@@ -10543,9 +10635,14 @@ def _resolve_chat_argv(
 
     if profile_dir is not None:
         env["HERMES_HOME"] = str(profile_dir)
+    elif resume_home is not None:
+        # Default-owned resume: pin HERMES_HOME to the default home so an
+        # inherited active-profile value can't misroute it, while still
+        # attaching the in-memory (default) gateway below.
+        env["HERMES_HOME"] = str(resume_home)
 
     if resume:
-        latest_resume, _latest_path = _session_latest_descendant(resume)
+        latest_resume, _latest_path = _session_latest_descendant(resume, profile=resume_profile)
         if latest_resume:
             resume = latest_resume
         env["HERMES_TUI_RESUME"] = resume

--- a/tests/hermes_cli/test_web_server_profile_unification.py
+++ b/tests/hermes_cli/test_web_server_profile_unification.py
@@ -554,3 +554,129 @@ class TestProfileScopedChatPty:
         with pytest.raises(web_server.HTTPException) as exc:
             web_server._resolve_chat_argv(profile="ghost")
         assert exc.value.status_code == 404
+
+
+class TestProfileScopedChatResume:
+    """Resuming a chat must resolve the session in its OWNING profile, not the
+    dashboard's sticky-active/management profile.
+
+    Regression for cross-profile "session not found": the dashboard stores
+    sessions in per-profile state.db files, but the resume path (latest
+    descendant + chat PTY) used the process/active profile only, so reopening a
+    chat that belongs to a different profile than the one currently selected —
+    including a bare desktop-restored ``/chat?resume=<id>`` URL carrying no
+    ``?profile=`` — 404'd. See ``_find_session_profile`` /
+    ``_session_latest_descendant`` / ``_resolve_chat_argv``.
+    """
+
+    @staticmethod
+    def _seed(home, sid, *, parent=None):
+        import hermes_state
+
+        db = hermes_state.SessionDB(db_path=home / "state.db")
+        try:
+            kw = {"model": "test"}
+            if parent is not None:
+                kw["parent_session_id"] = parent
+            db.create_session(session_id=sid, source="tui", **kw)
+        finally:
+            db.close()
+
+    @staticmethod
+    def _patch_tui(monkeypatch):
+        monkeypatch.setattr(
+            "hermes_cli.main._make_tui_argv",
+            lambda root, tui_dev=False: (["cat"], None),
+            raising=False,
+        )
+
+    def test_find_session_profile_locates_owner(self, isolated_profiles):
+        import hermes_cli.web_server as web_server
+
+        self._seed(isolated_profiles["worker_beta"], "wb-sess")
+        self._seed(isolated_profiles["default"], "def-sess")
+        assert web_server._find_session_profile("wb-sess") == "worker_beta"
+        assert web_server._find_session_profile("def-sess") == "default"
+        assert web_server._find_session_profile("nope-zzz") is None
+
+    def test_latest_descendant_walks_owning_profile_chain(
+        self, isolated_profiles, monkeypatch
+    ):
+        import hermes_state
+        import hermes_cli.web_server as web_server
+
+        monkeypatch.setattr(
+            hermes_state, "DEFAULT_DB_PATH", isolated_profiles["default"] / "state.db"
+        )
+        # parent -> child compression chain lives ONLY in worker_beta
+        self._seed(isolated_profiles["worker_beta"], "p")
+        self._seed(isolated_profiles["worker_beta"], "c", parent="p")
+
+        # explicit owning profile walks to the tip
+        assert web_server._session_latest_descendant("p", profile="worker_beta")[0] == "c"
+        # no profile -> cross-profile fallback still resolves it (was None before)
+        assert web_server._session_latest_descendant("p")[0] == "c"
+        # a wrong/sticky profile -> fallback corrects to the real owner
+        assert web_server._session_latest_descendant("p", profile="default")[0] == "c"
+        # genuinely unknown id stays clean
+        assert web_server._session_latest_descendant("ghost-zzz") == (None, [])
+
+    def test_latest_descendant_endpoint_honors_and_falls_back(
+        self, client, isolated_profiles
+    ):
+        self._seed(isolated_profiles["worker_beta"], "wb1")
+        # explicit profile
+        r = client.get(
+            "/api/sessions/wb1/latest-descendant", params={"profile": "worker_beta"}
+        )
+        assert r.status_code == 200 and r.json()["session_id"] == "wb1"
+        # no profile -> fallback resolves the owner (regression: used to 404)
+        r = client.get("/api/sessions/wb1/latest-descendant")
+        assert r.status_code == 200 and r.json()["session_id"] == "wb1"
+        # genuinely missing -> 404
+        assert client.get("/api/sessions/ghost-zzz/latest-descendant").status_code == 404
+
+    def test_chat_argv_resume_binds_owning_profile(
+        self, isolated_profiles, monkeypatch
+    ):
+        import hermes_state
+        import hermes_cli.web_server as web_server
+
+        monkeypatch.setattr(
+            hermes_state, "DEFAULT_DB_PATH", isolated_profiles["default"] / "state.db"
+        )
+        self._patch_tui(monkeypatch)
+        # worker_beta-owned session whose compression tip is "wc"
+        self._seed(isolated_profiles["worker_beta"], "wp")
+        self._seed(isolated_profiles["worker_beta"], "wc", parent="wp")
+
+        # The reported bug: resume a worker_beta session while the switcher is on
+        # the default/empty scope. Must bind worker_beta and walk to the tip.
+        _, _, env = web_server._resolve_chat_argv(resume="wp", profile="")
+        assert env["HERMES_HOME"] == str(isolated_profiles["worker_beta"])
+        assert env["HERMES_TUI_RESUME"] == "wc"
+        # Named owner spawns its own gateway (no in-memory attach).
+        assert "HERMES_TUI_GATEWAY_URL" not in env
+
+        # Correct explicit hint also binds worker_beta.
+        _, _, env = web_server._resolve_chat_argv(resume="wp", profile="worker_beta")
+        assert env["HERMES_HOME"] == str(isolated_profiles["worker_beta"])
+        assert env["HERMES_TUI_RESUME"] == "wc"
+
+    def test_chat_argv_resume_default_owned_stays_default(
+        self, isolated_profiles, monkeypatch
+    ):
+        import hermes_state
+        import hermes_cli.web_server as web_server
+
+        monkeypatch.setattr(
+            hermes_state, "DEFAULT_DB_PATH", isolated_profiles["default"] / "state.db"
+        )
+        self._patch_tui(monkeypatch)
+        self._seed(isolated_profiles["default"], "dp")
+
+        # Even when the switcher points at worker_beta, a default-owned resume
+        # must bind the default home (the wrong hint is corrected to the owner).
+        _, _, env = web_server._resolve_chat_argv(resume="dp", profile="worker_beta")
+        assert env["HERMES_HOME"] == str(isolated_profiles["default"])
+        assert env["HERMES_TUI_RESUME"] == "dp"


### PR DESCRIPTION
## What

Reopening a dashboard chat that belongs to a different profile than the one currently selected in the profile switcher fails with **"session not found."** The desktop app hits this too: it restores its last `/chat?resume=<id>` URL on launch, which carries no `?profile=`, so the resume is scoped to whatever profile happens to be sticky-active.

Root cause: sessions are stored in per-profile `state.db` files, but the resume path resolved them only against the process/active profile:

- `_session_latest_descendant()` always opened the process db, and `/api/sessions/{id}/latest-descendant` took no `profile` argument.
- `_resolve_chat_argv()` bound `HERMES_HOME` from the switcher hint, so the spawned TUI reopened the wrong `state.db` and 404'd.

## Fix

- `_session_latest_descendant(session_id, profile=None)` opens the requested profile's db and, on a miss, falls back to locating the owning profile and walking the compression chain there. Session ids are globally unique, so this is safe.
- `/api/sessions/{id}/latest-descendant` accepts `?profile=`, matching the sibling read endpoints (`/messages`, detail).
- `_resolve_chat_argv()` resolves a resume target's owning profile and pins `HERMES_HOME` to it explicitly (including the default home), so the spawned TUI reopens the correct `state.db` regardless of the hint. Named owners still spawn their own gateway; default-owned resumes keep the in-memory gateway attach.
- New `_find_session_profile()`: read-only point-lookup across profiles (no table scan, no descendant walk), used only on the cold path.

## Repro

1. Have a session in the default profile and a non-default profile active in the switcher (or open a desktop window whose restored URL is `/chat?resume=<default-session-id>` with no `?profile=`).
2. Resume that session. Before: `session not found`. After: resumes correctly.

## Scope / relation to other PRs

This is the **resume / chat-PTY** half of cross-profile session handling. It complements #44162 (the transcript-load path — `getSessionMessages`, for #44147); the two don't overlap in code. A frontend change could additionally thread the owning profile into the resume URL to skip the lookup, but the server-side fix makes resume correct even for bookmarked / desktop-restored URLs that carry no profile.

## Testing

- New regression tests in `tests/hermes_cli/test_web_server_profile_unification.py::TestProfileScopedChatResume`: owner lookup; latest-descendant resolution in / without / with-wrong profile; the endpoint's `?profile=` honoring + no-profile fallback; and `_resolve_chat_argv` binding the owner for both named- and default-owned resumes.
- `scripts/run_tests.sh tests/hermes_cli/test_web_server.py tests/hermes_cli/test_web_server_profile_unification.py` — pass (3 unrelated, pre-existing failures in the status/update-hermes endpoints reproduce on `main` without this change).
- `scripts/check-windows-footguns.py hermes_cli/web_server.py` — clean.
