### PR TITLE
fix(desktop): align electronDist with workspace install

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -135,7 +135,7 @@
   },
   "build": {
     "electronVersion": "40.10.2",
-    "electronDist": "../../node_modules/electron/dist",
+    "electronDist": "node_modules/electron/dist",
     "appId": "com.nousresearch.hermes",
     "productName": "Hermes",
     "executableName": "Hermes",

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -5110,16 +5110,35 @@ def _purge_electron_build_cache(desktop_dir: Path) -> list[Path]:
     return removed
 
 
-def _electron_dist_binary(project_root: Path) -> Path:
-    """Return the path to the Electron main binary inside ``node_modules``.
+def _electron_dist_dir(project_root: Path) -> Path:
+    """Return the desktop build's configured Electron dist directory.
 
-    electron-builder reads the binary from ``build.electronDist``
-    (``node_modules/electron/dist``) since #38673, so this is the exact file
-    whose absence makes a pack fail with "The specified electronDist does not
-    exist". The basename differs per OS (the platform Electron is named for the
-    host the build runs on).
+    Electron Builder reads the binary from ``build.electronDist``. Keep the
+    CLI's preflight/re-download checks aligned with that package config instead
+    of assuming a specific npm workspace hoist layout. Older checkouts without a
+    readable desktop package fall back to the historical root ``node_modules``
+    location so tests and source-mode validation stay conservative.
     """
-    dist = project_root / "node_modules" / "electron" / "dist"
+    desktop_dir = project_root / "apps" / "desktop"
+    package_json = desktop_dir / "package.json"
+    try:
+        package = json.loads(package_json.read_text(encoding="utf-8"))
+        configured = package.get("build", {}).get("electronDist")
+    except (OSError, json.JSONDecodeError, TypeError):
+        configured = None
+    if isinstance(configured, str) and configured.strip():
+        return (desktop_dir / configured).resolve()
+    return project_root / "node_modules" / "electron" / "dist"
+
+
+def _electron_dist_binary(project_root: Path) -> Path:
+    """Return the path to the configured Electron main binary.
+
+    The basename differs per OS (the platform Electron is named for the host the
+    build runs on). This is the exact file whose absence makes a pack fail with
+    "The specified electronDist does not exist".
+    """
+    dist = _electron_dist_dir(project_root)
     if sys.platform == "darwin":
         return dist / "Electron.app" / "Contents" / "MacOS" / "Electron"
     if sys.platform == "win32":
@@ -5128,7 +5147,7 @@ def _electron_dist_binary(project_root: Path) -> Path:
 
 
 def _electron_dist_ok(project_root: Path) -> bool:
-    """True when ``node_modules/electron/dist`` holds a usable Electron binary.
+    """True when ``build.electronDist`` holds a usable Electron binary.
 
     A directory that exists but is missing the binary (a partial extraction from
     a corrupt cached zip, or an interrupted postinstall) counts as NOT ok, since
@@ -5147,17 +5166,17 @@ def _redownload_electron_dist(
     *,
     mirror: Optional[str] = None,
 ) -> bool:
-    """(Re)populate ``node_modules/electron/dist`` via electron's own downloader.
+    """(Re)populate ``build.electronDist`` via electron's own downloader.
 
     Since #38673 the desktop build pins ``build.electronDist`` to
-    ``node_modules/electron/dist``, so electron-builder reads the Electron binary
+    an installed Electron package, so electron-builder reads the Electron binary
     straight from there and never downloads it during ``npm run pack``. That dist
     tree is produced by the ``electron`` package's postinstall (``install.js``)
     during ``npm ci``. When that download is blocked or throttled (GitHub's
     release host is unreachable in some regions — #47266), the dist is missing
     and re-running ``pack`` only re-throws "The specified electronDist does not
-    exist". The mirror fallback therefore has to drive *this* downloader, not
-    another ``pack``.
+    exist". The mirror fallback therefore has to drive *this* downloader in the
+    configured Electron package directory, not another ``pack``.
 
     No-op (returns True) when the dist binary is already present, so an unrelated
     build failure doesn't trigger a needless ~200 MB re-download. Otherwise drops
@@ -5169,7 +5188,8 @@ def _redownload_electron_dist(
     if _electron_dist_ok(project_root):
         return True
 
-    electron_dir = project_root / "node_modules" / "electron"
+    dist_dir = _electron_dist_dir(project_root)
+    electron_dir = dist_dir.parent
     installer = electron_dir / "install.js"
     if not installer.is_file():
         return False
@@ -5177,7 +5197,6 @@ def _redownload_electron_dist(
     if not node:
         return False
 
-    dist_dir = electron_dir / "dist"
     shutil.rmtree(dist_dir, ignore_errors=True)
     try:
         (electron_dir / "path.txt").unlink()
@@ -5387,7 +5406,8 @@ def cmd_gui(args: argparse.Namespace):
                 print("  Pre-build first:  cd apps/desktop && npm run build")
                 print("  Or drop --skip-build to install dependencies and build automatically.")
                 sys.exit(1)
-            if not (PROJECT_ROOT / "node_modules" / "electron" / "package.json").exists():
+            electron_package = _electron_dist_dir(PROJECT_ROOT).parent / "package.json"
+            if not electron_package.exists():
                 print("✗ --skip-build --source requires existing workspace dependencies.")
                 print(f"  Install first:  cd {PROJECT_ROOT} && npm ci")
                 print("  Or drop --skip-build to install dependencies and build automatically.")
@@ -5448,13 +5468,13 @@ def cmd_gui(args: argparse.Namespace):
                 # failure was something else, the clean re-download is harmless
                 # and the retry fails the same way.
                 purged = _purge_electron_build_cache(desktop_dir)
-                # electronDist is pinned to node_modules/electron/dist (#38673):
+                # electronDist is pinned to an installed Electron package (#38673):
                 # electron-builder reads the Electron binary from there and `pack`
                 # never downloads it, so purging the cache + re-running pack can't
-                # by itself repopulate a missing/partial dist. When the dist is
-                # actually gone, re-run electron's own downloader so the retry has
-                # a binary to read. Gated on the dist check so an unrelated build
-                # failure (tsc/vite) doesn't trigger a pointless ~200 MB refetch.
+                # by itself repopulate a missing/partial dist. When the configured
+                # dist is actually gone, re-run electron's own downloader so the
+                # retry has a binary to read. Gated on the dist check so an unrelated
+                # build failure (tsc/vite) doesn't trigger a pointless ~200 MB refetch.
                 restored = False
                 if not _electron_dist_ok(PROJECT_ROOT):
                     restored = _redownload_electron_dist(PROJECT_ROOT, env)
@@ -5484,7 +5504,7 @@ def cmd_gui(args: argparse.Namespace):
                 mirror_env["ELECTRON_MIRROR"] = mirror
                 # electronDist is pinned (#38673), so `npm run pack` never
                 # downloads Electron — the mirror only helps if it drives
-                # electron's own downloader. Re-fetch the binary through the
+                # electron's own downloader. Re-fetch the configured binary through the
                 # mirror first; otherwise the retry just re-reads the same missing
                 # dist and re-throws "electronDist does not exist" (#47266).
                 have_dist = _electron_dist_ok(PROJECT_ROOT)
@@ -5495,7 +5515,7 @@ def cmd_gui(args: argparse.Namespace):
                     build_result = subprocess.run([npm, "run", build_script], cwd=desktop_dir, env=mirror_env, check=False)
                 else:
                     print("  ✗ Could not re-download Electron from the mirror "
-                          "(node_modules/electron/dist still missing)")
+                          "(configured electronDist still missing)")
             if build_result.returncode != 0:
                 print("✗ Desktop GUI build failed")
                 print(f"  Run manually:  cd apps/desktop && npm run {build_script}")

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -2161,28 +2161,28 @@ function Clear-ElectronBuildCache {
     return $removed
 }
 
-# True when node_modules\electron\dist holds a usable Electron binary.
-# electron-builder reads the binary from build.electronDist
-# (node_modules\electron\dist) since #38673, so this is the exact file whose
-# absence makes a pack fail with "The specified electronDist does not exist". A
-# dist dir that exists but is missing electron.exe (partial extraction / aborted
-# postinstall) is NOT ok.
+# True when apps\desktop\node_modules\electron\dist holds a usable Electron binary.
+# electron-builder reads the binary from build.electronDist relative to
+# apps/desktop since #38673, so this is the exact file whose absence makes a
+# pack fail with "The specified electronDist does not exist". A dist dir that
+# exists but is missing electron.exe (partial extraction / aborted postinstall)
+# is NOT ok.
 function Test-ElectronDist {
     param([string]$InstallDir)
-    $distExe = Join-Path $InstallDir 'node_modules\electron\dist\electron.exe'
+    $distExe = Join-Path $InstallDir 'apps\desktop\node_modules\electron\dist\electron.exe'
     return (Test-Path -LiteralPath $distExe)
 }
 
-# (Re)populate node_modules\electron\dist via electron's own downloader.
+# (Re)populate apps\desktop\node_modules\electron\dist via electron's own downloader.
 #
-# Since #38673 the desktop build pins build.electronDist to
-# node_modules\electron\dist, so electron-builder reads the Electron binary
-# straight from there and never downloads it during `npm run pack`. That dist
-# tree is produced by the electron package's postinstall (install.js) during
-# `npm ci`. When that download is blocked/throttled (GitHub's release host is
-# unreachable in some regions - #47266), dist is missing and re-running pack only
-# re-throws "The specified electronDist does not exist". The mirror fallback
-# therefore has to drive THIS downloader, not another pack.
+# Since #38673 the desktop build pins build.electronDist relative to apps/desktop,
+# so electron-builder reads the Electron binary straight from there and never
+# downloads it during `npm run pack`. That dist tree is produced by the electron
+# package's postinstall (install.js) during `npm ci`. When that download is
+# blocked/throttled (GitHub's release host is unreachable in some regions -
+# #47266), dist is missing and re-running pack only re-throws "The specified
+# electronDist does not exist". The mirror fallback therefore has to drive THIS
+# downloader, not another pack.
 #
 # No-op (returns $true) when the dist binary is already present. Otherwise drops a
 # partial dist + version marker (electron's install.js short-circuits when
@@ -2193,7 +2193,7 @@ function Restore-ElectronDist {
     param([string]$InstallDir, [string]$Mirror)
     if (Test-ElectronDist -InstallDir $InstallDir) { return $true }
 
-    $electronDir = Join-Path $InstallDir 'node_modules\electron'
+    $electronDir = Join-Path $InstallDir 'apps\desktop\node_modules\electron'
     $distExe = Join-Path $electronDir 'dist\electron.exe'
     $installer = Join-Path $electronDir 'install.js'
     if (-not (Test-Path -LiteralPath $installer)) { return $false }
@@ -2370,12 +2370,12 @@ function Install-Desktop {
             # once; @electron/get re-downloads with its own SHASUM check. Without
             # this a corrupt download hard-fails the whole installer.
             $purged = @(Clear-ElectronBuildCache -DesktopDir $desktopDir)
-            # electronDist is pinned to node_modules\electron\dist (#38673):
+            # electronDist is pinned relative to apps/desktop (#38673):
             # electron-builder reads the Electron binary from there and `pack`
             # never downloads it, so purging the cache + re-running pack can't by
-            # itself repopulate a missing/partial dist. When the dist is actually
-            # gone, re-run electron's own downloader so the retry has a binary to
-            # read. Gated on the dist check so an unrelated build failure
+            # itself repopulate a missing/partial dist. When the configured dist is
+            # actually gone, re-run electron's own downloader so the retry has a
+            # binary to read. Gated on the dist check so an unrelated build failure
             # (tsc/vite) doesn't trigger a pointless ~200MB refetch.
             $restored = $false
             if (-not (Test-ElectronDist -InstallDir $InstallDir)) {
@@ -2403,7 +2403,7 @@ function Install-Desktop {
             Write-Info "  (set ELECTRON_MIRROR yourself to use a different/trusted mirror)"
             # electronDist is pinned (#38673), so `npm run pack` never downloads
             # Electron - the mirror only helps if it drives electron's own
-            # downloader. Re-fetch the binary through the mirror first; otherwise
+            # downloader. Re-fetch the configured binary through the mirror first; otherwise
             # the retry just re-reads the same missing dist and re-throws
             # "The specified electronDist does not exist" (#47266).
             $haveDist = Test-ElectronDist -InstallDir $InstallDir
@@ -2412,7 +2412,7 @@ function Install-Desktop {
                 & $npmExe run pack 2>&1 | ForEach-Object { "$_" } | Tee-Object -FilePath $buildLog
                 $code = $LASTEXITCODE
             } else {
-                Write-Warn "Could not re-download Electron from the mirror (node_modules\electron\dist still missing)"
+                Write-Warn "Could not re-download Electron from the mirror (configured electronDist still missing)"
             }
         }
         $ErrorActionPreference = $prevEAP

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -2407,15 +2407,15 @@ _desktop_pack() {
 # failed, and we never override a user-pinned ELECTRON_MIRROR.
 DESKTOP_ELECTRON_FALLBACK_MIRROR="https://npmmirror.com/mirrors/electron/"
 
-# True (returns 0) when node_modules/electron/dist holds a usable Electron
-# binary. electron-builder reads the binary from build.electronDist
-# (node_modules/electron/dist) since #38673, so this is the exact file whose
-# absence makes a pack fail with "The specified electronDist does not exist". A
-# dist dir that exists but is missing the binary (partial extraction / aborted
-# postinstall) is NOT ok. $1 = the workspace root holding node_modules.
+# True (returns 0) when apps/desktop/node_modules/electron/dist holds a usable
+# Electron binary. electron-builder reads the binary from build.electronDist
+# relative to apps/desktop since #38673, so this is the exact file whose absence
+# makes a pack fail with "The specified electronDist does not exist". A dist dir
+# that exists but is missing the binary (partial extraction / aborted
+# postinstall) is NOT ok. $1 = the workspace root holding apps/desktop.
 _electron_dist_ok() {
     local install_dir="$1"
-    local electron_dir="$install_dir/node_modules/electron"
+    local electron_dir="$install_dir/apps/desktop/node_modules/electron"
     if [ "$OS" = "macos" ]; then
         [ -e "$electron_dir/dist/Electron.app/Contents/MacOS/Electron" ]
     else
@@ -2423,26 +2423,26 @@ _electron_dist_ok() {
     fi
 }
 
-# (Re)populate node_modules/electron/dist via electron's own downloader.
+# (Re)populate apps/desktop/node_modules/electron/dist via electron's own downloader.
 #
-# Since #38673 the desktop build pins build.electronDist to
-# node_modules/electron/dist, so electron-builder reads the Electron binary
-# straight from there and never downloads it during `npm run pack`. That dist
-# tree is produced by the electron package's postinstall (install.js) during
-# `npm ci`. When that download is blocked/throttled (GitHub's release host is
-# unreachable in some regions - #47266), dist is missing and re-running pack only
-# re-throws "The specified electronDist does not exist". The mirror fallback
-# therefore has to drive THIS downloader, not another pack.
+# Since #38673 the desktop build pins build.electronDist relative to apps/desktop,
+# so electron-builder reads the Electron binary straight from there and never
+# downloads it during `npm run pack`. That dist tree is produced by the electron
+# package's postinstall (install.js) during `npm ci`. When that download is
+# blocked/throttled (GitHub's release host is unreachable in some regions -
+# #47266), dist is missing and re-running pack only re-throws "The specified
+# electronDist does not exist". The mirror fallback therefore has to drive THIS
+# downloader, not another pack.
 #
 # No-op (returns 0) when the dist binary is already present. Otherwise drops a
 # partial dist + version marker (electron's install.js short-circuits when
 # path.txt already matches) and runs the downloader once. $1 = the workspace root
-# holding node_modules; optional $2 = an ELECTRON_MIRROR base URL. Best-effort:
+# holding apps/desktop; optional $2 = an ELECTRON_MIRROR base URL. Best-effort:
 # returns 0 iff the dist binary exists afterward.
 _restore_electron_dist() {
     local install_dir="$1"
     local mirror="${2:-}"
-    local electron_dir="$install_dir/node_modules/electron"
+    local electron_dir="$install_dir/apps/desktop/node_modules/electron"
     _electron_dist_ok "$install_dir" && return 0
 
     [ -f "$electron_dir/install.js" ] || return 1
@@ -2531,12 +2531,12 @@ install_desktop() {
         # (b) Corrupt cached Electron zip is the most common self-healable cause.
         local purged
         purged="$(clear_electron_build_cache "$desktop_dir")"
-        # electronDist is pinned to node_modules/electron/dist (#38673):
-        # electron-builder reads the binary from there and `pack` never downloads
+        # electronDist is pinned relative to apps/desktop (#38673):
+        # electron-builder reads the Electron binary from there and `pack` never downloads
         # it, so purging the cache + re-running pack can't by itself repopulate a
-        # missing/partial dist. When the dist is actually gone, re-run electron's
-        # own downloader so the retry has a binary to read. Gated on the dist
-        # check so an unrelated build failure (tsc/vite) doesn't trigger a
+        # missing/partial dist. When the configured dist is actually gone, re-run
+        # electron's own downloader so the retry has a binary to read. Gated on the
+        # dist check so an unrelated build failure (tsc/vite) doesn't trigger a
         # pointless ~200MB refetch.
         local restored=false
         if ! _electron_dist_ok "$INSTALL_DIR"; then
@@ -2570,7 +2570,7 @@ install_desktop() {
                 pack_ok=true
             fi
         else
-            log_warn "Could not re-download Electron from the mirror (node_modules/electron/dist still missing)"
+            log_warn "Could not re-download Electron from the mirror (configured electronDist still missing)"
         fi
     fi
 

--- a/tests/hermes_cli/test_gui_command.py
+++ b/tests/hermes_cli/test_gui_command.py
@@ -616,6 +616,23 @@ def test_electron_dist_ok_per_platform(tmp_path, monkeypatch, platform, rel):
     assert cli_main._electron_dist_ok(tmp_path) is True
 
 
+def test_electron_dist_ok_uses_configured_workspace_dist(tmp_path, monkeypatch):
+    """The health check follows build.electronDist, not a hard-coded hoist path."""
+    monkeypatch.setattr(cli_main.sys, "platform", "linux")
+    desktop_dir = tmp_path / "apps" / "desktop"
+    desktop_dir.mkdir(parents=True)
+    (desktop_dir / "package.json").write_text(
+        '{"build": {"electronDist": "node_modules/electron/dist"}}',
+        encoding="utf-8",
+    )
+
+    binp = desktop_dir / "node_modules" / "electron" / "dist" / "electron"
+    binp.parent.mkdir(parents=True)
+    binp.write_text("", encoding="utf-8")
+
+    assert cli_main._electron_dist_ok(tmp_path) is True
+
+
 def test_redownload_electron_dist_noop_when_present(tmp_path, monkeypatch):
     """Already-healthy dist → no download, so an unrelated build failure can't
     trigger a needless ~200 MB refetch."""
@@ -678,6 +695,38 @@ def test_redownload_electron_dist_runs_installer_with_mirror(tmp_path, monkeypat
     # The partial dir + marker were dropped before the re-download.
     assert not (electron / "dist" / "leftover").exists()
     assert not (electron / "path.txt").exists()
+
+
+def test_redownload_electron_dist_uses_configured_workspace_dist(tmp_path, monkeypatch):
+    """The mirror fallback runs install.js next to the configured Electron dist."""
+    monkeypatch.setattr(cli_main.sys, "platform", "linux")
+    desktop_dir = tmp_path / "apps" / "desktop"
+    desktop_dir.mkdir(parents=True)
+    (desktop_dir / "package.json").write_text(
+        '{"build": {"electronDist": "node_modules/electron/dist"}}',
+        encoding="utf-8",
+    )
+    electron = desktop_dir / "node_modules" / "electron"
+    electron.mkdir(parents=True)
+    (electron / "install.js").write_text("// stub", encoding="utf-8")
+
+    captured = {}
+
+    def fake_run(cmd, **kwargs):
+        captured["cmd"] = cmd
+        captured["cwd"] = kwargs.get("cwd")
+        binp = electron / "dist" / "electron"
+        binp.parent.mkdir(parents=True, exist_ok=True)
+        binp.write_text("", encoding="utf-8")
+        return subprocess.CompletedProcess(cmd, 0)
+
+    with patch("hermes_cli.main.shutil.which", return_value="/usr/bin/node"), \
+         patch("hermes_cli.main.subprocess.run", side_effect=fake_run):
+        ok = cli_main._redownload_electron_dist(tmp_path, {})
+
+    assert ok is True
+    assert captured["cmd"] == ["/usr/bin/node", str(electron / "install.js")]
+    assert captured["cwd"] == str(electron)
 
 
 def test_redownload_electron_dist_returns_false_when_download_fails(tmp_path, monkeypatch):

--- a/tests/test_desktop_electron_pin.py
+++ b/tests/test_desktop_electron_pin.py
@@ -94,3 +94,29 @@ def test_lockfile_resolves_the_pinned_electron():
         f"but the pin is {spec!r}; run `npm install --package-lock-only` so "
         "`npm ci` stays consistent."
     )
+
+
+def test_electron_dist_points_at_locked_install_location():
+    """Electron Builder must read the Electron package npm actually installs."""
+    if not ROOT_LOCK.is_file():
+        pytest.skip("root package-lock.json not present")
+    pkg = _desktop_pkg()
+    electron_dist = pkg.get("build", {}).get("electronDist")
+    assert electron_dist, "build.electronDist is missing"
+
+    dist = (DESKTOP_PKG.parent / electron_dist).resolve()
+    assert dist.name == "dist", f"build.electronDist must point at a dist dir, got {electron_dist!r}"
+    try:
+        electron_package_key = dist.parent.relative_to(REPO_ROOT).as_posix()
+    except ValueError:
+        pytest.fail(f"build.electronDist points outside the repository: {electron_dist!r}")
+        return
+
+    lock = json.loads(ROOT_LOCK.read_text(encoding="utf-8"))
+    packages = lock.get("packages", {})
+    assert electron_package_key in packages, (
+        f"build.electronDist resolves to {electron_package_key!r}, but package-lock.json "
+        "does not install Electron there. Align build.electronDist with the "
+        "workspace install location so electron-builder can find the binary."
+    )
+    assert packages[electron_package_key].get("version") == _electron_spec(pkg)


### PR DESCRIPTION
## What does this PR do?

Fixes the desktop packaging failure caused by `electron-builder` looking for Electron in the wrong workspace location.

The desktop app currently sets:

```json
"electronDist": "../../node_modules/electron/dist"
```

That resolves to the repository root `node_modules/electron/dist`, but the current npm lockfile installs Electron under the desktop workspace:

```text
apps/desktop/node_modules/electron/dist
```

When the root-level Electron dist is missing, `hermes desktop` fails during packaging with:

```text
The specified electronDist does not exist: .../node_modules/electron/dist
```

This PR updates the desktop Electron dist path to match the actual workspace install location and makes the CLI/installer fallback logic use that same configured path.

## Related Issue

N/A

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `apps/desktop/package.json`
  - Changed `build.electronDist` to `node_modules/electron/dist`, which resolves to `apps/desktop/node_modules/electron/dist`.

- `hermes_cli/main.py`
  - Resolves Electron dist from `apps/desktop/package.json` instead of assuming root `node_modules`.
  - Uses the configured dist path for Electron health checks and re-download fallback.
  - Updates `--skip-build --source` dependency validation to check the configured Electron package location.

- `scripts/install.sh`
  - Updates the POSIX installer Electron dist checks and re-download fallback to use `apps/desktop/node_modules/electron/dist`.

- `scripts/install.ps1`
  - Updates the Windows installer Electron dist checks and re-download fallback to use `apps\desktop\node_modules\electron\dist`.

- `tests/test_desktop_electron_pin.py`
  - Adds regression coverage to ensure `build.electronDist` points at the Electron package location present in `package-lock.json`.

- `tests/hermes_cli/test_gui_command.py`
  - Adds regression coverage proving the CLI Electron dist checks follow `build.electronDist` instead of a hard-coded root path.

## How to Test

1. Run focused regression tests:

   ```bash
   uv run --with pytest --with pyyaml --with psutil \
     python -m pytest \
     tests/test_desktop_electron_pin.py \
     tests/hermes_cli/test_gui_command.py \
     -q -o 'addopts='
   ```

   Result:

   ```text
   41 passed
   ```

2. Build the desktop package:

   ```bash
   npm ci
   cd apps/desktop
   npm run pack
   ```

3. Confirm `electron-builder` uses the workspace-local Electron dist:

   ```text
   using custom unpacked Electron distribution  electronDist=node_modules/electron/dist
   copying unpacked Electron  source=.../apps/desktop/node_modules/electron/dist
   ```

## Checklist

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: WSL2 / Linux x64

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

N/A

## Screenshots / Logs

Failure before the fix:

```text
The specified electronDist does not exist: .../node_modules/electron/dist
```

Successful packaging after the fix:

```text
using custom unpacked Electron distribution  electronDist=node_modules/electron/dist
copying unpacked Electron  source=.../apps/desktop/node_modules/electron/dist
```

Focused tests:

```text
41 passed
```