### PR TITLE
fix(tools): drop empty-name tools before they reach the provider

### DIFF
--- a/tests/tools/test_schema_sanitizer.py
+++ b/tests/tools/test_schema_sanitizer.py
@@ -700,3 +700,56 @@ def test_strip_slash_enum_ignores_non_string_enum_values():
     props = tools[0]["function"]["parameters"]["properties"]
     assert props["level"]["enum"] == [1, 2, 3]
     assert props["flag"]["enum"] == [True, False]
+
+
+# ---------------------------------------------------------------------------
+# Empty / missing tool name guard
+#
+# A single misbehaving MCP server can register a tool with a blank name. The
+# provider (Anthropic and others) then rejects the WHOLE request with a 400
+# ("tools.N...name: String should have at least 1 character"), bricking every
+# turn. sanitize_tool_schemas drops the uncallable tool so the request stays
+# valid; well-formed tools are never affected.
+# ---------------------------------------------------------------------------
+
+
+def test_empty_name_tool_is_dropped():
+    tools = [_tool("good", {"type": "object", "properties": {}}), _tool("", {"type": "object"})]
+    out = sanitize_tool_schemas(tools)
+    assert len(out) == 1
+    assert out[0]["function"]["name"] == "good"
+
+
+def test_whitespace_only_name_tool_is_dropped():
+    tools = [_tool("   ", {"type": "object"}), _tool("keep", {"type": "object"})]
+    out = sanitize_tool_schemas(tools)
+    assert [t["function"]["name"] for t in out] == ["keep"]
+
+
+def test_missing_name_key_tool_is_dropped():
+    tools = [
+        {"type": "function", "function": {"parameters": {"type": "object"}}},
+        _tool("keep", {"type": "object"}),
+    ]
+    out = sanitize_tool_schemas(tools)
+    assert [t["function"]["name"] for t in out] == ["keep"]
+
+
+def test_none_name_tool_is_dropped():
+    tools = [_tool(None, {"type": "object"}), _tool("keep", {"type": "object"})]  # type: ignore[arg-type]
+    out = sanitize_tool_schemas(tools)
+    assert [t["function"]["name"] for t in out] == ["keep"]
+
+
+def test_bare_name_tool_without_function_wrapper_is_honored():
+    # Some callers pass a flat {"name": ...} shape rather than the function envelope.
+    tools = [{"name": ""}, {"name": "flatkeep", "parameters": {"type": "object"}}]
+    out = sanitize_tool_schemas(tools)
+    assert len(out) == 1
+    assert out[0].get("name") == "flatkeep"
+
+
+def test_all_named_tools_pass_through_unchanged_count():
+    tools = [_tool("a", {"type": "object"}), _tool("b", {"type": "object"})]
+    out = sanitize_tool_schemas(tools)
+    assert [t["function"]["name"] for t in out] == ["a", "b"]

--- a/tools/schema_sanitizer.py
+++ b/tools/schema_sanitizer.py
@@ -57,6 +57,27 @@ def sanitize_tool_schemas(tools: list[dict]) -> list[dict]:
 
     sanitized: list[dict] = []
     for tool in tools:
+        # Drop tools with an empty/missing name before they reach the provider API.
+        # Anthropic (and others) reject the whole request with a 400 if any tool has a
+        # blank name (e.g. "tools.100.custom.name: String should have at least 1
+        # character"), which a single misbehaving MCP server can trigger. An unnamed
+        # tool is uncallable anyway, so dropping it is strictly safe and keeps the
+        # request valid. Log the culprit so the source can be fixed.
+        _nm = ""
+        if isinstance(tool, dict):
+            _fn = tool.get("function")
+            if isinstance(_fn, dict):
+                _nm = _fn.get("name") or ""
+            else:
+                _nm = tool.get("name") or ""
+        if not str(_nm).strip():
+            logger.warning(
+                "Dropping tool with empty/missing name before send (type=%r); "
+                "an upstream provider would reject the whole request. Tool: %.200s",
+                (tool.get("type") if isinstance(tool, dict) else type(tool).__name__),
+                repr(tool),
+            )
+            continue
         sanitized.append(_sanitize_single_tool(tool))
     return sanitized
 


### PR DESCRIPTION
## What does this PR do?

`sanitize_tool_schemas` now drops any tool whose `name` is empty, whitespace-only, or missing **before** the tool list is sent to the provider.

A single misbehaving MCP server (or a dynamically-built tool) can register a tool with a blank name. The provider then rejects the **entire** request with a 400 — e.g. Anthropic returns `tools.100.custom.name: String should have at least 1 character` — which bricks *every* turn for the whole session until the offending server is removed. An unnamed tool is uncallable anyway (the model can never address it), so dropping it is strictly safe and keeps the rest of the request valid. The dropped tool is logged at WARNING with its type and a truncated repr so the source can be fixed.

## Related Issue

Addresses the chat/completions side of the empty-tool-name failure mode tracked in #11411.

Complementary to #11435, which fixes the **Responses API input** path (dropping orphan `function_call_output` blocks with an empty name in `run_agent.py`). This PR fixes the **outgoing tool-schema** path in `sanitize_tool_schemas`, which runs before every provider send regardless of API mode. The two are different code paths for the same class of 400 and don't overlap.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/schema_sanitizer.py` — in `sanitize_tool_schemas`, skip + log any tool whose resolved name (`function.name`, or top-level `name` for the bare shape) is empty/whitespace/missing. Well-formed tools are untouched.
- `tests/tools/test_schema_sanitizer.py` — 6 new tests: empty name dropped, whitespace-only dropped, missing-`name`-key dropped, `None` name dropped, bare `{"name": ...}` (no function wrapper) honored, and all-named-tools pass through unchanged.

## How to Test

1. Build a tool list containing one valid tool and one with `function.name == ""`.
2. Call `sanitize_tool_schemas([...])`.
3. Before: the empty-name tool passes through and the provider 400s the whole request. After: the empty-name tool is dropped (with a WARNING logged) and the valid tool is returned unchanged.

```
pytest tests/tools/test_schema_sanitizer.py -q
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(tools):`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate (found #11435 — the complementary Responses-API path; this PR is the distinct chat/completions tool-schema path)
- [x] My PR contains **only** changes related to this fix (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass (49 in `tests/tools/test_schema_sanitizer.py`: 43 existing + 6 new)
- [x] I've added tests for my changes
- [x] I've tested on my platform: Ubuntu Linux (Python 3.11)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (docstring/inline comment explaining the guard) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A (no config keys)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) — N/A (pure Python, no OS primitives; passes the Windows-footgun check)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A
