### PR TITLE
feat(jarvis): STT/TTS contracts + neutralised agents-os web/idea-factory

### DIFF
--- a/hermes_cli/agents_os_idea_factory.py
+++ b/hermes_cli/agents_os_idea_factory.py
@@ -1,0 +1,151 @@
+"""Deterministic Idea Factory draft classifier for local Agents OS planning.
+
+This module is intentionally local-only and side-effect free. It turns a raw idea
+into a structured execution draft; actual task creation/execution stays in the
+Agents OS command/API layer and must respect approval gates.
+"""
+
+from __future__ import annotations
+
+from hashlib import sha1
+from typing import Any
+
+
+CLASSIFICATIONS = [
+    "web_seo_offer",
+    "agent_os_build",
+    "coding_task",
+    "research_intake",
+    "memory_skill_ops",
+    "media_asset",
+    "security_gated",
+    "finance_gated",
+    "public_outbound_gated",
+    "unclear_needs_context",
+]
+
+RISK_CLASSES = [
+    "safe_local",
+    "approval_local_write",
+    "credential_gated",
+    "public_gated",
+    "security_gated",
+    "finance_gated",
+    "destructive_gated",
+]
+
+INPUT_FIELDS = ["idea_text", "context", "desired_output", "urgency"]
+OUTPUT_FIELDS = [
+    "idea_id",
+    "classification",
+    "risk_class",
+    "recommended_lane",
+    "plan_steps",
+    "approval_required",
+    "suggested_agent",
+    "expected_artifacts",
+    "acceptance_criteria",
+    "source_links",
+]
+
+
+def idea_factory_schema() -> dict[str, Any]:
+    return {
+        "input_fields": list(INPUT_FIELDS),
+        "output_fields": list(OUTPUT_FIELDS),
+        "classifications": list(CLASSIFICATIONS),
+        "risk_classes": list(RISK_CLASSES),
+        "local_only": True,
+        "side_effects": False,
+    }
+
+
+def _contains(text: str, *needles: str) -> bool:
+    return any(needle in text for needle in needles)
+
+
+def _classify(text: str) -> tuple[str, str, str]:
+    normalized = text.lower()
+
+    if _contains(normalized, "kraken", "trading", "trade", "invest", "portfolio", "burza", "crypto"):
+        return "finance_gated", "finance_gated", "finance-approval-gate"
+    if _contains(normalized, "skeniraj", "ranjiv", "pentest", "exploit", "hak", "hack", "security test"):
+        return "security_gated", "security_gated", "security-scope-gate"
+    if _contains(normalized, "pošalji", "posalji", "email", "objavi", "postaj", "klijentu", "outbound"):
+        return "public_outbound_gated", "public_gated", "public-action-approval"
+    if _contains(normalized, "credential", "api ključ", "api key", "token", "oauth", "lozink"):
+        return "unclear_needs_context", "credential_gated", "credential-approval-gate"
+    if _contains(normalized, "obriši", "obrisi", "delete", "izbriši", "izbrisi", "wipe", "remove"):
+        return "memory_skill_ops", "destructive_gated", "destructive-action-gate"
+    if _contains(normalized, "youtube", "video", "transcript", "vault", "sažmi", "sazmi", "obradi"):
+        return "research_intake", "safe_local", "youtube-content-intake"
+    if _contains(normalized, "memory galaxy", "mission control", "agent os", "doni dashboard", "dashboard", "jarvis", "voice"):
+        return "agent_os_build", "approval_local_write", "mission-control-build"
+    if _contains(normalized, "landing", "web", "seo", "revenue audit", "ponud", "offer", "stranic"):
+        return "web_seo_offer", "safe_local", "web-seo-offer"
+    if _contains(normalized, "kod", "code", "bug", "repo", "test", "implement"):
+        return "coding_task", "approval_local_write", "code-build"
+    if _contains(normalized, "slika", "audio", "glas", "video asset", "media", "screenshot"):
+        return "media_asset", "safe_local", "media-asset-draft"
+
+    return "unclear_needs_context", "safe_local", "clarify-or-research"
+
+
+def _plan_for(classification: str, risk_class: str) -> list[str]:
+    if risk_class.endswith("gated") or risk_class in {"public_gated", "security_gated", "finance_gated", "destructive_gated", "credential_gated"}:
+        return [
+            "Sažeti namjeru i izdvojiti rizične radnje.",
+            "Napraviti approval draft bez izvršavanja rizične akcije.",
+            "Čekati eksplicitno Goranovo odobrenje prije bilo kakvog side-effecta.",
+        ]
+    if classification == "agent_os_build":
+        return [
+            "Zaključati capability contract i acceptance kriterije.",
+            "Napisati test-first lokalni slice bez gateway restarta.",
+            "Verificirati kroz focused test i local smoke prije spajanja u UI.",
+        ]
+    if classification == "research_intake":
+        return [
+            "Dohvatiti ili pročitati source artefakt.",
+            "Spremiti transcript/note u canonical vault.",
+            "Izvući routing odluku i sljedeći konkretan korak.",
+        ]
+    return [
+        "Pretvoriti ideju u mali lokalni plan.",
+        "Spremiti očekivane artefakte i acceptance kriterije.",
+        "Kreirati safe local task ako nema approval-gated radnji.",
+    ]
+
+
+def draft_idea(
+    idea_text: str,
+    *,
+    context: str | None = None,
+    desired_output: str | None = None,
+    urgency: str = "normal",
+    source_links: list[str] | None = None,
+) -> dict[str, Any]:
+    if not idea_text or not idea_text.strip():
+        raise ValueError("idea_text is required")
+
+    classification, risk_class, lane = _classify(" ".join(x for x in [idea_text, context or "", desired_output or ""] if x))
+    approval_required = risk_class != "safe_local"
+    digest = sha1(idea_text.strip().encode("utf-8")).hexdigest()[:10]
+
+    return {
+        "idea_id": f"idea-{digest}",
+        "classification": classification,
+        "risk_class": risk_class,
+        "recommended_lane": lane,
+        "plan_steps": _plan_for(classification, risk_class),
+        "approval_required": approval_required,
+        "suggested_agent": "doni-local",
+        "expected_artifacts": ["idea_draft", "plan", "verification_note"],
+        "acceptance_criteria": [
+            "classification and risk class are explicit",
+            "approval gate is respected",
+            "local artifact/task can be audited",
+        ],
+        "source_links": list(source_links or []),
+        "urgency": urgency,
+    }

--- a/hermes_cli/agents_os_idea_factory.py
+++ b/hermes_cli/agents_os_idea_factory.py
@@ -79,7 +79,7 @@ def _classify(text: str) -> tuple[str, str, str]:
         return "memory_skill_ops", "destructive_gated", "destructive-action-gate"
     if _contains(normalized, "youtube", "video", "transcript", "vault", "sažmi", "sazmi", "obradi"):
         return "research_intake", "safe_local", "youtube-content-intake"
-    if _contains(normalized, "memory galaxy", "mission control", "agent os", "doni dashboard", "dashboard", "jarvis", "voice"):
+    if _contains(normalized, "memory galaxy", "mission control", "agent os", "agents os dashboard", "dashboard", "jarvis", "voice"):
         return "agent_os_build", "approval_local_write", "mission-control-build"
     if _contains(normalized, "landing", "web", "seo", "revenue audit", "ponud", "offer", "stranic"):
         return "web_seo_offer", "safe_local", "web-seo-offer"
@@ -96,7 +96,7 @@ def _plan_for(classification: str, risk_class: str) -> list[str]:
         return [
             "Sažeti namjeru i izdvojiti rizične radnje.",
             "Napraviti approval draft bez izvršavanja rizične akcije.",
-            "Čekati eksplicitno Goranovo odobrenje prije bilo kakvog side-effecta.",
+            "Čekati eksplicitno odobrenje operatera prije bilo kakvog side-effecta.",
         ]
     if classification == "agent_os_build":
         return [
@@ -139,7 +139,7 @@ def draft_idea(
         "recommended_lane": lane,
         "plan_steps": _plan_for(classification, risk_class),
         "approval_required": approval_required,
-        "suggested_agent": "doni-local",
+        "suggested_agent": "primary-agent",
         "expected_artifacts": ["idea_draft", "plan", "verification_note"],
         "acceptance_criteria": [
             "classification and risk class are explicit",

--- a/hermes_cli/agents_os_seo.py
+++ b/hermes_cli/agents_os_seo.py
@@ -1,0 +1,81 @@
+"""Safe-local SEO Mission Control payloads for Agents OS."""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from hermes_cli.agents_os import AgentsOSPaths, connect, row_to_dict
+
+SEO_GOAL_WORKFLOWS = {"seo-goal"}
+KEYWORD_WORKFLOWS = {"keyword-research"}
+DRAFT_WORKFLOWS = {"seo-draft"}
+REVIEW_WORKFLOWS = {"publish-gate", "outreach-gate"}
+
+
+def _path_info(path: str) -> dict[str, Any]:
+    p = Path(path)
+    return {
+        "path": str(p),
+        "exists": p.exists(),
+        "size_bytes": p.stat().st_size if p.exists() and p.is_file() else None,
+    }
+
+
+def _artifact_items(paths: AgentsOSPaths, workflows: set[str]) -> list[dict[str, Any]]:
+    placeholders = ",".join("?" for _ in workflows)
+    if not placeholders:
+        return []
+    query = f"SELECT id,kind,title,path,task_id,workflow,created_at FROM artifacts WHERE workflow IN ({placeholders}) ORDER BY created_at DESC"
+    with connect(paths) as conn:
+        rows = conn.execute(query, tuple(workflows)).fetchall()
+    items = []
+    for row in rows:
+        item = row_to_dict(row)
+        item.update(_path_info(item["path"]))
+        item["draft_only"] = True
+        item["publish_blocked_until_approval"] = True
+        items.append(item)
+    return items
+
+
+def seo_mission_control_payload(paths: AgentsOSPaths) -> dict[str, Any]:
+    """Return a side-effect-free SEO/AISO dashboard payload.
+
+    v0 intentionally supports only draft/review state. Live metrics, outreach,
+    and publishing remain approval-gated and disabled.
+    """
+    with connect(paths) as conn:
+        goal_rows = conn.execute(
+            "SELECT id,title,status,workflow,priority,created_at,updated_at,notes,route,approval_required FROM tasks WHERE workflow='seo-goal' ORDER BY created_at DESC"
+        ).fetchall()
+    goals = [row_to_dict(row) for row in goal_rows]
+    for goal in goals:
+        goal["draft_only"] = True
+        goal["publish_blocked_until_approval"] = True
+    return {
+        "local_only": True,
+        "publish_enabled": False,
+        "outreach_enabled": False,
+        "credentials_required_for_live_metrics": True,
+        "goals": goals,
+        "keyword_queue": _artifact_items(paths, KEYWORD_WORKFLOWS),
+        "draft_queue": _artifact_items(paths, DRAFT_WORKFLOWS),
+        "review_gates": _artifact_items(paths, REVIEW_WORKFLOWS),
+        "analytics_evidence_slot": {
+            "enabled": False,
+            "reason": "Search Console/Analytics credentials are approval-gated and not connected in v0.",
+        },
+        "approval_gates": [
+            "publish",
+            "outreach",
+            "credentials",
+            "analytics",
+            "deploy",
+            "cross_agent_memory_merge",
+        ],
+        "lane_contract": {
+            "goal": "SEO goal → keyword research → draft → review gate → optional approved publish.",
+            "default_status": "draft_only",
+            "external_actions": "disabled_until_explicit_approval",
+        },
+    }

--- a/hermes_cli/agents_os_web.py
+++ b/hermes_cli/agents_os_web.py
@@ -547,6 +547,25 @@ def _jarvis_voice_reply(command_card: dict[str, Any]) -> str:
     return "Ovo je sigurno lokalno. Pripremio sam preview, bez izvršavanja."
 
 
+def _jarvis_cleaned_transcript(raw_text: str, data: dict[str, Any]) -> str:
+    model_result = data.get("model_result") if isinstance(data.get("model_result"), dict) else {}
+    cleaned = (
+        model_result.get("normalized_transcript")
+        or model_result.get("cleaned_transcript")
+        or model_result.get("cleaned_text")
+        or data.get("cleaned_transcript")
+        or data.get("cleaned_text")
+        or raw_text
+    )
+    return str(cleaned).strip() or raw_text
+
+
+def _jarvis_gate_text(raw_text: str, cleaned_text: str) -> str:
+    if cleaned_text and cleaned_text != raw_text:
+        return f"{raw_text}\n{cleaned_text}"
+    return raw_text
+
+
 def jarvis_transcribe_payload(paths: AgentsOSPaths, data: dict[str, Any]) -> dict[str, Any]:
     """Persist a local push-to-talk artefact and return transcript + intent preview.
 
@@ -566,14 +585,28 @@ def jarvis_transcribe_payload(paths: AgentsOSPaths, data: dict[str, Any]) -> dic
     audio_path.write_bytes(audio_bytes)
     stt = _jarvis_stt_payload(data, audio_path)
     transcript_text = stt["text"]
-    preview = jarvis_preview_payload(paths, {"transcript_text": transcript_text})
-    advisor = jarvis_model_advisor_payload(paths, {"transcript_text": transcript_text, "deterministic_preview": preview})
+    cleaned_text = _jarvis_cleaned_transcript(transcript_text, data)
+    gate_text = _jarvis_gate_text(transcript_text, cleaned_text)
+    preview = jarvis_preview_payload(paths, {"transcript_text": gate_text})
+    preview["command_card"]["heard"] = transcript_text
+    preview["command_card"]["cleaned_text"] = cleaned_text
+    preview["command_card"]["gate_text"] = gate_text
+    advisor = jarvis_model_advisor_payload(
+        paths,
+        {
+            "transcript_text": transcript_text,
+            "deterministic_preview": preview,
+            "model_result": data.get("model_result") if isinstance(data.get("model_result"), dict) else {},
+            "provider": data.get("advisor_provider") or data.get("provider") or "deterministic",
+            "model": data.get("advisor_model") or data.get("model") or "none",
+        },
+    )
     transcript_body = {
         "local_only": True,
         "execution_created": False,
         "stt": stt,
         "advisor": {"provider": advisor["provider"], "model": advisor["model"], "risk_disagreement": advisor["risk_disagreement"]},
-        "transcript": {"text": transcript_text, "source": stt["provider"], "created_at": utc_now()},
+        "transcript": {"text": transcript_text, "cleaned_text": cleaned_text, "source": stt["provider"], "created_at": utc_now()},
         "intent_preview": advisor["command_card"],
         "audio_artifact_path": str(audio_path),
     }
@@ -718,7 +751,7 @@ main {{ padding:24px 34px 60px; }} section {{ display:none; }} section.active {{
 <section id=\"operator\"><h2>Operator Loop / Judge / Evidence</h2><pre id=\"operatorPayload\"></pre></section>
 <section id=\"media\"><h2>Media Studio Browser v0</h2><div class=\"kv\">Read-only. No generation. No posting.</div><div id=\"mediaList\" class=\"grid\"></div></section>
 <section id=\"manage\"><h2>Manage / Update / Status</h2><pre id=\"managePayload\"></pre></section>
-<section id=\"voice\"><h2>Voice / Jarvis gated panel</h2><div class=\"card\"><h3>Jarvis / Oracle Briefing</h3><div class=\"kv\">wake/show/build/act · dry-run only · no always-on microphone · no computer-control</div><pre id=\"jarvisPayload\"></pre></div><div class=\"card\"><h3>Push-to-talk v0.1</h3><div class=\"kv\">Record command captures local browser audio, stores local artefacts, returns transcript + intent preview. No execution.</div><p><button id=\"recordJarvis\">Record command</button> <button id=\"stopJarvis\" disabled>Stop</button> <button id=\"previewJarvis\">Preview typed command</button></p><textarea id=\"jarvisTranscript\">Prikaži zadnje BP24 stanje</textarea><h3>Command Preview</h3><pre id=\"jarvisCommandCard\"></pre></div><pre id=\"voicePayload\"></pre></section>
+<section id=\"voice\"><h2>Voice / Jarvis gated panel</h2><div class=\"card\"><h3>Jarvis / Oracle Briefing</h3><div class=\"kv\">wake/show/build/act · dry-run only · no always-on microphone · no computer-control</div><pre id=\"jarvisPayload\"></pre></div><div class=\"card\"><h3>Push-to-talk v0.1</h3><div class=\"kv\">Record command captures local browser audio, stores local artefacts, returns raw transcript + cleaned transcript + intent preview. Deterministic gate remains authority.</div><p><button id=\"recordJarvis\">Record command</button> <button id=\"stopJarvis\" disabled>Stop</button> <button id=\"previewJarvis\">Preview typed command</button></p><textarea id=\"jarvisTranscript\">Prikaži zadnje BP24 stanje</textarea><h3>Command Preview</h3><pre id=\"jarvisCommandCard\"></pre></div><pre id=\"voicePayload\"></pre></section>
 </main>
 <script id=\"bootstrap\" type=\"application/json\">{_json_safe(bootstrap)}</script>
 <script>

--- a/hermes_cli/agents_os_web.py
+++ b/hermes_cli/agents_os_web.py
@@ -409,6 +409,16 @@ def _jarvis_preview_from_text(transcript_text: str) -> dict[str, Any]:
             "Prikazati rezultat u command preview kartici.",
             "Ne izvršiti nikakvu vanjsku ili rizičnu akciju.",
         ]
+    if any(token in normalized for token in ["sigurnosni", "security", "pentest", "penetration", "ranjiv", "vulnerability", "exploit", "scan klijent", "skeniraj"]):
+        draft["classification"] = "security_gated"
+        draft["risk_class"] = "security_gated"
+        draft["recommended_lane"] = "security-scope-gate"
+        draft["approval_required"] = True
+        draft["plan_steps"] = [
+            "Prikazati security scope i authorization zahtjev u command preview kartici.",
+            "Ne pokretati aktivni scan ili test bez eksplicitnog scope/legal approvala.",
+            "Dopustiti samo jasno označene read-only provjere nakon approval gatea.",
+        ]
     if any(token in normalized for token in ["deploy", "deployaj", "push", "pr ", "pull request", "objavi", "pošalji", "posalji", "email"]):
         draft["classification"] = "public_outbound_gated"
         draft["risk_class"] = "public_gated"

--- a/hermes_cli/agents_os_web.py
+++ b/hermes_cli/agents_os_web.py
@@ -566,6 +566,46 @@ def _jarvis_gate_text(raw_text: str, cleaned_text: str) -> str:
     return raw_text
 
 
+def jarvis_reply_payload(paths: AgentsOSPaths, data: dict[str, Any]) -> dict[str, Any]:
+    text = (data.get("text") or data.get("voice_reply_short") or "").strip()
+    if not text:
+        raise ValueError("text is required")
+    stamp = _jarvis_slug_from_time()
+    reply_dir = paths.artifacts / "jarvis_replies"
+    audio_dir = paths.artifacts / "jarvis_reply_audio"
+    reply_dir.mkdir(parents=True, exist_ok=True)
+    audio_dir.mkdir(parents=True, exist_ok=True)
+    audio_bytes = _decode_optional_audio(data)
+    audio_path: Path | None = None
+    if audio_bytes:
+        audio_path = audio_dir / f"{stamp}-jarvis-reply{_jarvis_audio_suffix(data.get('audio_mime'))}"
+        audio_path.write_bytes(audio_bytes)
+    provider = data.get("provider") or ("hermes-tts" if audio_bytes else "text-only-fallback")
+    reply_path = reply_dir / f"{stamp}-jarvis-reply.md"
+    payload = {
+        "local_only": True,
+        "execution_created": False,
+        "status": "audio_ready" if audio_path else "text_only",
+        "text": text,
+        "audio_artifact_path": str(audio_path) if audio_path else None,
+        "tts": {
+            "provider": provider,
+            "mime": data.get("audio_mime") if audio_path else None,
+            "fallback": audio_path is None,
+        },
+    }
+    reply_path.write_text(f"# Jarvis voice reply\n\n```json\n{json.dumps(payload, ensure_ascii=False, indent=2)}\n```\n", encoding="utf-8")
+    artifact_id = f"artifact-jarvis-reply-{stamp}"
+    with connect(paths) as conn:
+        conn.execute(
+            "INSERT OR REPLACE INTO artifacts(id,kind,title,path,task_id,workflow,created_at) VALUES(?,?,?,?,?,?,?)",
+            (artifact_id, "jarvis_voice_reply", "Jarvis voice reply", str(reply_path), None, "jarvis-voice-reply", utc_now()),
+        )
+        log_event(conn, "jarvis_voice_reply_created", payload={"artifact_id": artifact_id, "audio_path": str(audio_path) if audio_path else None, "execution_created": False})
+        conn.commit()
+    return {**payload, "reply_artifact_path": str(reply_path), "artifact_id": artifact_id}
+
+
 def jarvis_transcribe_payload(paths: AgentsOSPaths, data: dict[str, Any]) -> dict[str, Any]:
     """Persist a local push-to-talk artefact and return transcript + intent preview.
 
@@ -751,7 +791,7 @@ main {{ padding:24px 34px 60px; }} section {{ display:none; }} section.active {{
 <section id=\"operator\"><h2>Operator Loop / Judge / Evidence</h2><pre id=\"operatorPayload\"></pre></section>
 <section id=\"media\"><h2>Media Studio Browser v0</h2><div class=\"kv\">Read-only. No generation. No posting.</div><div id=\"mediaList\" class=\"grid\"></div></section>
 <section id=\"manage\"><h2>Manage / Update / Status</h2><pre id=\"managePayload\"></pre></section>
-<section id=\"voice\"><h2>Voice / Jarvis gated panel</h2><div class=\"card\"><h3>Jarvis / Oracle Briefing</h3><div class=\"kv\">wake/show/build/act · dry-run only · no always-on microphone · no computer-control</div><pre id=\"jarvisPayload\"></pre></div><div class=\"card\"><h3>Push-to-talk v0.1</h3><div class=\"kv\">Record command captures local browser audio, stores local artefacts, returns raw transcript + cleaned transcript + intent preview. Deterministic gate remains authority.</div><p><button id=\"recordJarvis\">Record command</button> <button id=\"stopJarvis\" disabled>Stop</button> <button id=\"previewJarvis\">Preview typed command</button></p><textarea id=\"jarvisTranscript\">Prikaži zadnje BP24 stanje</textarea><h3>Command Preview</h3><pre id=\"jarvisCommandCard\"></pre></div><pre id=\"voicePayload\"></pre></section>
+<section id=\"voice\"><h2>Voice / Jarvis gated panel</h2><div class=\"card\"><h3>Jarvis / Oracle Briefing</h3><div class=\"kv\">wake/show/build/act · dry-run only · no always-on microphone · no computer-control</div><pre id=\"jarvisPayload\"></pre></div><div class=\"card\"><h3>Push-to-talk v0.1</h3><div class=\"kv\">Record command captures local browser audio, stores local artefacts, returns raw transcript + cleaned transcript + intent preview. Deterministic gate remains authority.</div><p><button id=\"recordJarvis\">Record command</button> <button id=\"stopJarvis\" disabled>Stop</button> <button id=\"previewJarvis\">Preview typed command</button> <button id=\"replyJarvis\">Voice Reply</button></p><textarea id=\"jarvisTranscript\">Prikaži zadnje BP24 stanje</textarea><h3>Command Preview</h3><pre id=\"jarvisCommandCard\"></pre><h3>Voice Reply</h3><pre id=\"jarvisReply\"></pre><audio id=\"jarvisAudio\" controls></audio></div><pre id=\"voicePayload\"></pre></section>
 </main>
 <script id=\"bootstrap\" type=\"application/json\">{_json_safe(bootstrap)}</script>
 <script>
@@ -777,7 +817,9 @@ $('#draftIdea').addEventListener('click', async () => showPre('#ideaResult', awa
 $('#createIdea').addEventListener('click', async () => showPre('#ideaResult', await j('/api/idea-factory/action', {{method:'POST', body:JSON.stringify({{idea_text:$('#ideaText').value}})}})));
 let jarvisRecorder = null; let jarvisChunks = [];
 async function previewJarvisCommand() {{ showPre('#jarvisCommandCard', await j('/api/jarvis/preview', {{method:'POST', body:JSON.stringify({{transcript_text:$('#jarvisTranscript').value}})}})); }}
+async function replyJarvisCommand() {{ const payload = await j('/api/jarvis/reply', {{method:'POST', body:JSON.stringify({{text:$('#jarvisTranscript').value}})}}); showPre('#jarvisReply', payload); if (payload.audio_artifact_path) $('#jarvisAudio').src = payload.audio_artifact_path; }}
 $('#previewJarvis').addEventListener('click', previewJarvisCommand);
+$('#replyJarvis').addEventListener('click', replyJarvisCommand);
 $('#recordJarvis').addEventListener('click', async () => {{
  if (!navigator.mediaDevices || !window.MediaRecorder) {{ showPre('#jarvisCommandCard', {{status:'browser_audio_unavailable', execution_created:false}}); return; }}
  const stream = await navigator.mediaDevices.getUserMedia({{audio:true}}); jarvisChunks = []; jarvisRecorder = new MediaRecorder(stream);
@@ -853,6 +895,8 @@ class MissionControlHandler(BaseHTTPRequestHandler):
                 _send_json(self, jarvis_preview_payload(self.service.paths, data))
             elif path == "/api/jarvis/advisor":
                 _send_json(self, jarvis_model_advisor_payload(self.service.paths, data))
+            elif path == "/api/jarvis/reply":
+                _send_json(self, jarvis_reply_payload(self.service.paths, data))
             elif path == "/api/jarvis/transcribe":
                 _send_json(self, jarvis_transcribe_payload(self.service.paths, data))
             else:

--- a/hermes_cli/agents_os_web.py
+++ b/hermes_cli/agents_os_web.py
@@ -457,7 +457,7 @@ def jarvis_preview_payload(paths: AgentsOSPaths, data: dict[str, Any]) -> dict[s
     }
 
 
-def _jarvis_stt_payload(data: dict[str, Any]) -> dict[str, Any]:
+def _jarvis_stt_payload(data: dict[str, Any], audio_path: Path | None = None) -> dict[str, Any]:
     provided = (data.get("transcript_text") or data.get("text") or "").strip()
     if provided:
         return {"provider": "provided_transcript", "text": provided, "confidence": None, "status": "provided"}
@@ -470,11 +470,43 @@ def _jarvis_stt_payload(data: dict[str, Any]) -> dict[str, Any]:
             "confidence": stt_result.get("confidence"),
             "status": "transcribed",
         }
+    if data.get("use_local_stt") and audio_path is not None:
+        try:
+            return _transcribe_with_local_faster_whisper(
+                str(audio_path),
+                model=str(data.get("stt_model") or "base"),
+                language=str(data.get("stt_language") or "hr"),
+            )
+        except Exception as exc:
+            return {
+                "provider": "local-faster-whisper",
+                "text": "[stt_pending] Local STT failed; audio artifact was saved for retry.",
+                "confidence": None,
+                "status": "error",
+                "error": exc.__class__.__name__,
+                "message": str(exc),
+            }
     return {
         "provider": "stub_pending",
         "text": "[stt_pending] Audio captured; STT backend not connected in this local slice.",
         "confidence": None,
         "status": "pending",
+    }
+
+
+def _transcribe_with_local_faster_whisper(audio_path: str, *, model: str = "base", language: str = "hr") -> dict[str, Any]:
+    from faster_whisper import WhisperModel  # type: ignore[import-not-found]
+
+    whisper = WhisperModel(model, device="cpu", compute_type="int8")
+    segments, info = whisper.transcribe(audio_path, beam_size=5, language=language or None, vad_filter=True)
+    text = " ".join(segment.text.strip() for segment in segments).strip()
+    return {
+        "provider": "local-faster-whisper",
+        "text": text or "[stt_empty] Local STT produced no transcript.",
+        "confidence": getattr(info, "language_probability", None),
+        "status": "transcribed" if text else "empty",
+        "language": getattr(info, "language", None),
+        "model": model,
     }
 
 
@@ -522,8 +554,6 @@ def jarvis_transcribe_payload(paths: AgentsOSPaths, data: dict[str, Any]) -> dic
     deliberately does not execute commands; real STT can replace the transcript
     stub behind the same payload contract.
     """
-    stt = _jarvis_stt_payload(data)
-    transcript_text = stt["text"]
     stamp = _jarvis_slug_from_time()
     audio_bytes = _decode_optional_audio(data)
     suffix = _jarvis_audio_suffix(data.get("audio_mime"))
@@ -534,6 +564,8 @@ def jarvis_transcribe_payload(paths: AgentsOSPaths, data: dict[str, Any]) -> dic
     audio_path = audio_dir / f"{stamp}-jarvis-command{suffix}"
     transcript_path = transcript_dir / f"{stamp}-jarvis-transcript.md"
     audio_path.write_bytes(audio_bytes)
+    stt = _jarvis_stt_payload(data, audio_path)
+    transcript_text = stt["text"]
     preview = jarvis_preview_payload(paths, {"transcript_text": transcript_text})
     advisor = jarvis_model_advisor_payload(paths, {"transcript_text": transcript_text, "deterministic_preview": preview})
     transcript_body = {

--- a/hermes_cli/agents_os_web.py
+++ b/hermes_cli/agents_os_web.py
@@ -1,0 +1,629 @@
+"""Local-only Agents OS Mission Control web surface.
+
+This module intentionally serves only loopback HTTP and exposes read-only/operator
+planning payloads by default. Draft/action endpoints create local runtime records
+or approval drafts; they do not execute outbound/public/security/financial work.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import mimetypes
+import os
+import sqlite3
+import subprocess
+import sys
+import threading
+import webbrowser
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from typing import Any
+from urllib.parse import urlparse
+
+from hermes_cli.agents_os import (
+    AgentsOSPaths,
+    AgentsOSService,
+    connect,
+    log_event,
+    resolve_paths,
+    row_to_dict,
+    slugify,
+    utc_now,
+)
+from hermes_cli.agents_os_idea_factory import draft_idea, idea_factory_schema
+from hermes_cli.agents_os_seo import seo_mission_control_payload
+
+LOCAL_HOSTS = {"127.0.0.1", "localhost"}
+SOURCE_DEFAULTS = {
+    "video:q13OqknCh-c": "https://youtu.be/q13OqknCh-c",
+    "transcript:q13OqknCh-c": "/mnt/d/HermesAgent/home/transcripts/q13OqknCh-c_transcript.txt",
+    "youtube-note:q13OqknCh-c": "/mnt/d/Obsidian_Vault_v2/Hermes-Agent-Doni/01-INBOX/YouTube/2026-06-08-q13OqknCh-c-claude-agent-operating-system.md",
+    "plan:parity-q13OqknCh-c": "/mnt/d/Obsidian_Vault_v2/Hermes-Agent-Doni/08-OPERATIONS/ACTIVE-WORK/2026-06-08-agent-os-parity-build-plan-q13OqknCh-c.md",
+    "plan:full-product": "/mnt/d/Obsidian_Vault_v2/Hermes-Agent-Doni/08-OPERATIONS/ACTIVE-WORK/2026-06-08-agent-os-full-product-plan.md",
+    "contract:idea-factory-v0": "/mnt/d/Obsidian_Vault_v2/Hermes-Agent-Doni/08-OPERATIONS/ACTIVE-WORK/2026-06-08-idea-factory-v0-contract.md",
+}
+SOURCE_ENV = {
+    "transcript:q13OqknCh-c": "AGENTS_OS_SOURCE_TRANSCRIPT",
+    "plan:full-product": "AGENTS_OS_SOURCE_FULL_PLAN",
+}
+MEDIA_SUFFIXES = {".png", ".jpg", ".jpeg", ".webp", ".gif", ".mp3", ".wav", ".ogg", ".mp4", ".webm", ".mov"}
+ARTIFACT_SUFFIXES = {".md", ".txt", ".json", ".log", ".html", ".png", ".jpg", ".jpeg", ".webp", ".mp4", ".mp3", ".wav", ".ogg"}
+
+
+def _json_safe(value: Any) -> str:
+    return json.dumps(value, ensure_ascii=False)
+
+
+def _read_json_body(handler: BaseHTTPRequestHandler) -> dict[str, Any]:
+    length = int(handler.headers.get("content-length") or 0)
+    if length <= 0:
+        return {}
+    raw = handler.rfile.read(length).decode("utf-8")
+    return json.loads(raw or "{}")
+
+
+def _send_json(handler: BaseHTTPRequestHandler, payload: dict[str, Any] | list[Any], status: int = 200) -> None:
+    data = json.dumps(payload, ensure_ascii=False, indent=2).encode("utf-8")
+    handler.send_response(status)
+    handler.send_header("Content-Type", "application/json; charset=utf-8")
+    handler.send_header("Cache-Control", "no-store")
+    handler.send_header("Content-Length", str(len(data)))
+    handler.end_headers()
+    handler.wfile.write(data)
+
+
+def _send_html(handler: BaseHTTPRequestHandler, html: str, status: int = 200) -> None:
+    data = html.encode("utf-8")
+    handler.send_response(status)
+    handler.send_header("Content-Type", "text/html; charset=utf-8")
+    handler.send_header("Cache-Control", "no-store")
+    handler.send_header("Content-Length", str(len(data)))
+    handler.end_headers()
+    handler.wfile.write(data)
+
+
+def _parse_caps(raw: str | None) -> list[str]:
+    if not raw:
+        return []
+    try:
+        value = json.loads(raw)
+        return value if isinstance(value, list) else []
+    except json.JSONDecodeError:
+        return []
+
+
+def _path_info(path: str) -> dict[str, Any]:
+    p = Path(path)
+    return {
+        "path": str(p),
+        "exists": p.exists(),
+        "suffix": p.suffix.lower(),
+        "kind": "directory" if p.exists() and p.is_dir() else "file",
+        "size_bytes": p.stat().st_size if p.exists() and p.is_file() else None,
+    }
+
+
+def _default_agent_cards(paths: AgentsOSPaths) -> list[dict[str, Any]]:
+    return [
+        {
+            "id": "doni-local",
+            "name": "Doni Local",
+            "status": "available",
+            "capabilities": ["local planning", "TDD", "reports", "Mission Control"],
+            "runtime_home": str(paths.home),
+            "reference_home": str(paths.root),
+            "memory_boundary": "Doni Hermes home only",
+            "auth_boundary": "Doni auth only; credentials are never displayed",
+            "allowed_actions": ["safe local files", "tests", "local API smoke", "local reports"],
+            "approval_gates": ["deploy", "public send", "credential use", "gateway restart", "destructive changes"],
+        },
+        {
+            "id": "kodi-codex",
+            "name": "Kodi/Codex",
+            "status": "reference",
+            "capabilities": ["coding delegate", "review", "patch suggestions"],
+            "runtime_home": "external/approval-gated",
+            "reference_home": "repo-local only when explicitly invoked",
+            "memory_boundary": "no Doni memory merge",
+            "auth_boundary": "no credential sharing from Doni",
+            "allowed_actions": ["local branch work after explicit routing"],
+            "approval_gates": ["push", "PR", "public GitHub action", "credential use"],
+        },
+        {
+            "id": "marija-profile",
+            "name": "Marija profile",
+            "status": "separate_profile",
+            "capabilities": ["separate Hermes profile"],
+            "runtime_home": "/home/goran/.hermes-marija-clean",
+            "reference_home": "read-only boundary reference",
+            "memory_boundary": "separate personal memory; no merge",
+            "auth_boundary": "separate profile auth; no cross-copy",
+            "allowed_actions": ["status reference only"],
+            "approval_gates": ["any profile write", "auth change", "gateway lifecycle"],
+        },
+        {
+            "id": "ero-openclaw",
+            "name": "ERO/OpenClaw reference layer",
+            "status": "separate_runtime",
+            "capabilities": ["reference bridge", "source artefacts"],
+            "runtime_home": "/home/goran/.openclaw/workspace",
+            "reference_home": "/mnt/d/AI_Memory/communication",
+            "memory_boundary": "separate runtime memory; reference only",
+            "auth_boundary": "no auth/session sharing",
+            "allowed_actions": ["read-only reference when useful"],
+            "approval_gates": ["runtime write", "bridge mutation", "memory import/export"],
+        },
+        {
+            "id": "candidate-agent",
+            "name": "Candidate agents",
+            "status": "candidate",
+            "capabilities": ["future plugin/worker slots"],
+            "runtime_home": "not assigned",
+            "reference_home": "Mission Control registry",
+            "memory_boundary": "must declare before activation",
+            "auth_boundary": "must declare before activation",
+            "allowed_actions": ["registration draft only"],
+            "approval_gates": ["activation", "tool access", "credential access"],
+        },
+    ]
+
+
+def agents_registry_payload(paths: AgentsOSPaths) -> dict[str, Any]:
+    cards = {card["id"]: card for card in _default_agent_cards(paths)}
+    with connect(paths) as conn:
+        for row in conn.execute("SELECT * FROM agents ORDER BY created_at ASC").fetchall():
+            item = row_to_dict(row)
+            base = cards.get(item["id"], {})
+            cards[item["id"]] = {
+                **base,
+                "id": item["id"],
+                "name": item.get("name") or item["id"],
+                "status": item.get("status") or base.get("status", "available"),
+                "capabilities": _parse_caps(item.get("capabilities")) or base.get("capabilities", []),
+                "runtime_home": base.get("runtime_home", str(paths.root)),
+                "reference_home": base.get("reference_home", str(paths.root)),
+                "memory_boundary": base.get("memory_boundary", "declared local boundary required"),
+                "auth_boundary": base.get("auth_boundary", "credentials are never displayed"),
+                "allowed_actions": base.get("allowed_actions", ["safe local tasks"]),
+                "approval_gates": base.get("approval_gates", ["public", "credential", "deploy", "destructive"]),
+            }
+    return {"local_only": True, "agents": list(cards.values())}
+
+
+def knowledge_index_payload(paths: AgentsOSPaths) -> dict[str, Any]:
+    nodes = []
+    for node_id, default_path in SOURCE_DEFAULTS.items():
+        value = os.environ.get(SOURCE_ENV.get(node_id, ""), default_path)
+        info = _path_info(value) if not value.startswith("http") else {"path": value, "exists": True, "kind": "url", "size_bytes": None, "suffix": ""}
+        kind = node_id.split(":", 1)[0]
+        nodes.append({"id": node_id, "kind": kind, "label": node_id, "weight": 10 if info["exists"] else 3, **info})
+    with connect(paths) as conn:
+        for row in conn.execute("SELECT id,title,path,kind,task_id,workflow,created_at FROM artifacts ORDER BY created_at DESC LIMIT 40").fetchall():
+            item = row_to_dict(row)
+            info = _path_info(item["path"])
+            nodes.append({"id": f"artifact:{item['id']}", "kind": "artifact", "label": item["title"], "weight": 7 if info["exists"] else 2, "task_id": item.get("task_id"), "workflow": item.get("workflow"), **info})
+    edges = [
+        {"from": "video:q13OqknCh-c", "to": "transcript:q13OqknCh-c", "relation": "has_transcript"},
+        {"from": "video:q13OqknCh-c", "to": "youtube-note:q13OqknCh-c", "relation": "intake_note"},
+        {"from": "youtube-note:q13OqknCh-c", "to": "plan:parity-q13OqknCh-c", "relation": "informed_plan"},
+        {"from": "plan:parity-q13OqknCh-c", "to": "plan:full-product", "relation": "expands_to"},
+        {"from": "contract:idea-factory-v0", "to": "plan:full-product", "relation": "implements_slice"},
+    ]
+    return {"local_only": True, "runtime_memory_merge": False, "note": "vault/reference graph, not runtime memory merge", "nodes": nodes, "edges": edges}
+
+
+def artifacts_payload(paths: AgentsOSPaths) -> dict[str, Any]:
+    items: list[dict[str, Any]] = []
+    with connect(paths) as conn:
+        for row in conn.execute("SELECT * FROM artifacts ORDER BY created_at DESC LIMIT 100").fetchall():
+            item = row_to_dict(row)
+            info = _path_info(item["path"])
+            item.update(info)
+            item["preview_type"] = "markdown" if info["suffix"] == ".md" else ("json" if info["suffix"] == ".json" else ("media" if info["suffix"] in MEDIA_SUFFIXES else "text"))
+            items.append(item)
+    seen = {item["path"] for item in items}
+    for root in [paths.artifacts, paths.vault_root]:
+        if not root.exists():
+            continue
+        for p in root.rglob("*"):
+            if len(items) >= 160:
+                break
+            if p.is_file() and p.suffix.lower() in ARTIFACT_SUFFIXES and str(p) not in seen:
+                info = _path_info(str(p))
+                items.append({"id": f"file:{slugify(str(p))}", "kind": "file", "title": p.name, "task_id": None, "workflow": None, **info})
+    return {"local_only": True, "items": items}
+
+
+def media_assets_payload(paths: AgentsOSPaths) -> dict[str, Any]:
+    assets = []
+    for root in [paths.artifacts, paths.vault_root]:
+        if not root.exists():
+            continue
+        for p in root.rglob("*"):
+            if len(assets) >= 80:
+                break
+            if p.is_file() and p.suffix.lower() in MEDIA_SUFFIXES:
+                mime, _ = mimetypes.guess_type(str(p))
+                assets.append({"path": str(p), "title": p.name, "mime": mime or "application/octet-stream", "size_bytes": p.stat().st_size, "read_only": True})
+    return {"local_only": True, "generation_enabled": False, "posting_enabled": False, "assets": assets}
+
+
+def _bounded_file_count(root: Path, *, name: str | None = None, max_scan: int = 600) -> tuple[int, bool]:
+    """Fast bounded local status count; avoids slow recursive scans in UI requests."""
+    if not root.exists():
+        return 0, False
+    count = 0
+    scanned = 0
+    stack = [root]
+    while stack and scanned < max_scan:
+        current = stack.pop()
+        try:
+            entries = list(current.iterdir())
+        except OSError:
+            continue
+        for entry in entries:
+            scanned += 1
+            if scanned >= max_scan:
+                break
+            if entry.is_dir():
+                stack.append(entry)
+            elif name is None or entry.name == name:
+                count += 1
+    return count, bool(stack or scanned >= max_scan)
+
+
+def redacted_manage_status_payload(paths: AgentsOSPaths) -> dict[str, Any]:
+    skills_dir = paths.home / "skills"
+    plugins_dir = paths.home / "plugins"
+    cron_dir = paths.home / "cron"
+    skill_count, skill_truncated = _bounded_file_count(skills_dir, name="SKILL.md")
+    cron_count, cron_truncated = _bounded_file_count(cron_dir)
+    try:
+        plugin_count = len(list(plugins_dir.iterdir())) if plugins_dir.exists() else 0
+    except OSError:
+        plugin_count = 0
+    return {
+        "local_only": True,
+        "credentials_visible": False,
+        "hermes": {"home": str(paths.home), "agents_os_home": str(paths.root), "state_db": str(paths.db), "gateway_restart": False},
+        "skills": {"path": str(skills_dir), "count": skill_count, "truncated": skill_truncated},
+        "plugins": {"path": str(plugins_dir), "count": plugin_count},
+        "cron": {"path": str(cron_dir), "status_only": True, "count": cron_count, "truncated": cron_truncated},
+        "mcp": {"status_only": True, "note": "Use hermes mcp test/list outside this read-only panel when needed."},
+        "model_provider": "redacted",
+        "candidate_integrations": ["desktop shell", "voice dry-run", "read-only project library"],
+    }
+
+
+def voice_status_payload(paths: AgentsOSPaths) -> dict[str, Any]:
+    cache_audio = paths.home / "cache" / "audio"
+    audio_files = list(cache_audio.glob("*"))[-5:] if cache_audio.exists() else []
+    return {
+        "local_only": True,
+        "stt_status": "detectable" if audio_files else "not_detected_or_no_recent_audio",
+        "tts_status": "configured_by_runtime_or_tool_provider",
+        "recent_audio_count": len(audio_files),
+        "jarvis_dry_run_design": [
+            "transcribe local voice input",
+            "classify intent through Idea Factory risk gate",
+            "show command draft and required approval badge",
+            "execute only safe local/read-only actions after explicit local UI confirmation",
+        ],
+        "computer_control": "approval_gated_unexecuted",
+    }
+
+
+def jarvis_briefing_payload(paths: AgentsOSPaths) -> dict[str, Any]:
+    """Safe-local Jarvis/Oracle briefing contract for Mission Control.
+
+    This is a read-only/dry-run payload. It summarizes local state and declares
+    command modes without enabling microphone, wake-word, browser, computer, or
+    public side effects.
+    """
+    with connect(paths) as conn:
+        task_rows = conn.execute("SELECT status, COUNT(*) AS count FROM tasks GROUP BY status").fetchall()
+        approval_rows = conn.execute("SELECT status, COUNT(*) AS count FROM approvals GROUP BY status").fetchall()
+        artifact_count = conn.execute("SELECT COUNT(*) AS count FROM artifacts").fetchone()["count"]
+        recent_artifacts = [
+            row_to_dict(row)
+            for row in conn.execute(
+                "SELECT id,kind,title,path,task_id,workflow,created_at FROM artifacts ORDER BY created_at DESC LIMIT 5"
+            ).fetchall()
+        ]
+    task_counts = {row["status"]: row["count"] for row in task_rows}
+    approval_counts = {row["status"]: row["count"] for row in approval_rows}
+    open_task_count = sum(task_counts.get(status, 0) for status in ("new", "pending", "routed", "ready", "in_progress", "needs_approval", "blocked", "review"))
+    return {
+        "local_only": True,
+        "execution_created": False,
+        "always_on_microphone": False,
+        "wake_word_enabled": False,
+        "computer_control": "approval_gated_unexecuted",
+        "briefing": {
+            "timestamp": utc_now(),
+            "agents_os_home": str(paths.root),
+            "state_db": str(paths.db),
+            "open_task_count": open_task_count,
+            "completed_task_count": task_counts.get("completed", 0),
+            "pending_approval_count": approval_counts.get("pending", 0),
+            "artifact_count": artifact_count,
+            "recent_artifacts": recent_artifacts,
+        },
+        "commands": [
+            {"name": "wake", "mode": "read_only_briefing", "approval_required": False, "does": "Boot/status briefing only."},
+            {"name": "show", "mode": "read_only_retrieval", "approval_required": False, "does": "Show local tasks, artifacts, notes, and reference graph."},
+            {"name": "build", "mode": "safe_local_draft", "approval_required": False, "does": "Create local draft artifacts/tasks only."},
+            {"name": "act", "mode": "approval_draft_only", "approval_required": True, "does": "Prepare risky action for explicit approval; do not execute."},
+        ],
+        "approval_gates": [
+            "microphone_wake_word",
+            "computer_control",
+            "external_open",
+            "deploy_publish",
+            "credentials",
+            "cross_agent_memory_merge",
+        ],
+        "wall_mode_contract": {
+            "enabled_for_display": True,
+            "execution_from_wall_mode": False,
+            "description": "Large-screen Mission Control display; action execution remains gated.",
+        },
+    }
+
+
+def operator_loop_payload(service: AgentsOSService) -> dict[str, Any]:
+    dashboard = service.dashboard_payload()
+    tasks = dashboard.get("tasks", [])
+    reviews = dashboard.get("reviews", [])
+    events = dashboard.get("events", [])
+    judge_events = [event for event in events if "judge" in event.get("event_type", "") or "review" in event.get("event_type", "")]
+    return {
+        "local_only": True,
+        "acceptance_criteria": ["evidence exists", "tests/smoke recorded", "approval gates respected"],
+        "task_detail_available": True,
+        "tasks": tasks,
+        "reviews": reviews,
+        "evidence_links": dashboard.get("recent_completions", []),
+        "judge_status": "ready" if reviews or judge_events else "pending",
+        "judge_results_faked": False,
+        "blocked_reason": None,
+    }
+
+
+def _write_artifact(paths: AgentsOSPaths, title: str, body: str, *, kind: str, task_id: str | None = None, workflow: str | None = None) -> tuple[str, str]:
+    artifact_id = f"artifact-{slugify(title)[:24]}-{utc_now().replace(':','').replace('-','')[:15]}"
+    target = paths.artifacts / kind / f"{utc_now().split('T', 1)[0]}-{slugify(title)}.md"
+    target.parent.mkdir(parents=True, exist_ok=True)
+    text = f"# {title}\n\n{body}\n"
+    target.write_text(text, encoding="utf-8")
+    with connect(paths) as conn:
+        conn.execute(
+            "INSERT OR REPLACE INTO artifacts(id,kind,title,path,task_id,workflow,created_at) VALUES(?,?,?,?,?,?,?)",
+            (artifact_id, kind, title, str(target), task_id, workflow, utc_now()),
+        )
+        log_event(conn, "artifact_created", task_id=task_id, payload={"artifact_id": artifact_id, "path": str(target), "source": "mission_control_web"})
+        conn.commit()
+    return artifact_id, str(target)
+
+
+def create_idea_action(service: AgentsOSService, data: dict[str, Any]) -> dict[str, Any]:
+    draft = service.idea_factory_draft_payload(data)
+    paths = service.paths
+    title = data.get("title") or f"Idea Factory: {data.get('idea_text', '')[:70]}"
+    task_id = f"task-{draft['idea_id'].replace('idea-', '')}"
+    now = utc_now()
+    approval_id = None
+    mode = "safe_local_task"
+    status = "pending"
+    approval_required = 0
+    if draft["approval_required"]:
+        mode = "approval_draft"
+        status = "needs_approval"
+        approval_required = 1
+        approval_id = f"approval-{draft['idea_id'].replace('idea-', '')}"
+    body = json.dumps({"idea": data, "draft": draft, "mode": mode, "execution_created": False}, ensure_ascii=False, indent=2)
+    artifact_id, artifact_path = _write_artifact(paths, title, f"```json\n{body}\n```", kind="idea_factory", task_id=task_id, workflow=draft["recommended_lane"])
+    with connect(paths) as conn:
+        conn.execute(
+            "INSERT OR REPLACE INTO tasks(id,title,status,workflow,priority,created_at,updated_at,notes,route,approval_required) VALUES(?,?,?,?,?,?,?,?,?,?)",
+            (task_id, title, status, draft["recommended_lane"], 2, now, now, data.get("idea_text", ""), "approval_gate" if approval_required else "local:direct", approval_required),
+        )
+        log_event(conn, "idea_action_created", task_id=task_id, payload={"mode": mode, "draft": draft, "artifact_id": artifact_id})
+        if approval_id:
+            conn.execute(
+                "INSERT OR REPLACE INTO approvals(id,title,status,risk,task_id,payload,created_at) VALUES(?,?,?,?,?,?,?)",
+                (approval_id, f"Approval draft: {title}", "pending", draft["risk_class"], task_id, body, now),
+            )
+            log_event(conn, "approval_requested", task_id=task_id, payload={"approval_id": approval_id, "risk": draft["risk_class"], "execution_created": False})
+        conn.commit()
+    return {"mode": mode, "task_id": task_id, "approval_id": approval_id, "artifact_id": artifact_id, "artifact_path": artifact_path, "draft": draft, "execution_created": False}
+
+
+def task_detail_payload(paths: AgentsOSPaths, task_id: str) -> dict[str, Any]:
+    with connect(paths) as conn:
+        task = conn.execute("SELECT * FROM tasks WHERE id=?", (task_id,)).fetchone()
+        if task is None:
+            return {"status": "not_found", "task_id": task_id}
+        approvals = [row_to_dict(r) for r in conn.execute("SELECT * FROM approvals WHERE task_id=? ORDER BY created_at DESC", (task_id,)).fetchall()]
+        runs = [row_to_dict(r) for r in conn.execute("SELECT * FROM runs WHERE task_id=? ORDER BY created_at DESC", (task_id,)).fetchall()]
+        events = [row_to_dict(r) for r in conn.execute("SELECT * FROM events WHERE task_id=? ORDER BY created_at DESC", (task_id,)).fetchall()]
+        artifacts = [row_to_dict(r) for r in conn.execute("SELECT * FROM artifacts WHERE task_id=? ORDER BY created_at DESC", (task_id,)).fetchall()]
+        reviews = [row_to_dict(r) for r in conn.execute("SELECT * FROM reviews WHERE task_id=? ORDER BY created_at DESC", (task_id,)).fetchall()]
+    return {"status": "ok", "task": row_to_dict(task), "acceptance_criteria": ["planned", "implemented", "verified", "evidence linked"], "approvals": approvals, "runs": runs, "events": events, "artifacts": artifacts, "reviews": reviews, "judge_status": "pending" if not reviews else "review_available"}
+
+
+def mission_control_html(service: AgentsOSService) -> str:
+    status = service.status_payload()
+    dashboard = service.dashboard_payload()
+    bootstrap = {"status": status, "dashboard": dashboard, "knowledge_note": "vault/reference graph, not runtime memory merge"}
+    return f"""<!doctype html>
+<html lang=\"hr\">
+<head>
+<meta charset=\"utf-8\" />
+<meta name=\"viewport\" content=\"width=device-width, initial-scale=1\" />
+<title>Agents OS Mission Control</title>
+<style>
+:root {{ color-scheme: dark; --bg:#080b14; --panel:#101827; --panel2:#142035; --text:#e8f0ff; --muted:#93a4bd; --accent:#66d9ff; --warn:#ffc857; --ok:#7dffb2; --bad:#ff6b7a; }}
+* {{ box-sizing:border-box; }} body {{ margin:0; font-family:Inter, ui-sans-serif, system-ui, Segoe UI, Arial; background:radial-gradient(circle at 20% 0%, #13284a 0, var(--bg) 38%); color:var(--text); }}
+header {{ padding:28px 34px; border-bottom:1px solid #24344f; }} h1 {{ margin:0; letter-spacing:.02em; }} .sub {{ color:var(--muted); margin-top:8px; }}
+.tabs {{ display:flex; gap:8px; flex-wrap:wrap; padding:18px 34px; border-bottom:1px solid #1e2c44; position:sticky; top:0; background:#080b14dd; backdrop-filter:blur(8px); z-index:5; }}
+button {{ background:#16243a; color:var(--text); border:1px solid #2a4166; border-radius:12px; padding:10px 13px; cursor:pointer; }} button.active, button:hover {{ border-color:var(--accent); box-shadow:0 0 0 1px #66d9ff55 inset; }}
+main {{ padding:24px 34px 60px; }} section {{ display:none; }} section.active {{ display:block; }} .grid {{ display:grid; grid-template-columns:repeat(auto-fit,minmax(260px,1fr)); gap:16px; }}
+.card {{ background:linear-gradient(180deg,var(--panel),var(--panel2)); border:1px solid #263a5b; border-radius:18px; padding:16px; box-shadow:0 20px 50px #0007; }}
+.kv {{ color:var(--muted); font-size:13px; }} .ok {{ color:var(--ok); }} .warn {{ color:var(--warn); }} .bad {{ color:var(--bad); }} textarea {{ width:100%; min-height:96px; border-radius:14px; background:#09111f; color:var(--text); border:1px solid #2a4166; padding:12px; }} pre {{ overflow:auto; background:#070b12; border:1px solid #1d2c45; border-radius:14px; padding:12px; }} .pill {{ display:inline-block; border:1px solid #35537e; border-radius:999px; padding:3px 8px; color:var(--muted); margin:2px; }}
+</style>
+</head>
+<body>
+<header><h1>Agents OS Mission Control</h1><div class=\"sub\">Local-only Doni operator cockpit · gateway restart: false · vault/reference graph, not runtime memory merge</div></header>
+<nav class=\"tabs\">
+<button data-tab=\"overview\" class=\"active\">Overview</button><button data-tab=\"idea\">Idea Factory</button><button data-tab=\"agents\">Agent Registry</button><button data-tab=\"knowledge\">Knowledge Galaxy</button><button data-tab=\"artifacts\">Artifact Library</button><button data-tab=\"seo\">SEO Mission Control</button><button data-tab=\"operator\">Operator Loop</button><button data-tab=\"media\">Media Studio</button><button data-tab=\"manage\">Manage / Status</button><button data-tab=\"voice\">Voice / Jarvis</button>
+</nav>
+<main>
+<section id=\"overview\" class=\"active\"><div class=\"grid\"><div class=\"card\"><h2>HEALTH <span class=\"ok\">OK</span></h2><div class=\"kv\">State DB: {status.get('state_db')}</div><div class=\"kv\">Schema: {status.get('schema_version')}</div></div><div class=\"card\"><h2>Queue</h2><pre id=\"queueSummary\"></pre></div></div></section>
+<section id=\"idea\"><div class=\"card\"><h2>Idea Factory</h2><textarea id=\"ideaText\">Obradi YouTube video</textarea><p><button id=\"draftIdea\">Draft only</button> <button id=\"createIdea\">Create safe task / approval draft</button></p><pre id=\"ideaResult\"></pre><div class=\"kv\">Fields: classification · risk class · recommended lane · plan steps · approval badge · expected artifacts · acceptance criteria</div></div></section>
+<section id=\"agents\"><h2>Paperclip Agent Registry</h2><div id=\"agentsList\" class=\"grid\"></div></section>
+<section id=\"knowledge\"><h2>Knowledge / Memory Galaxy v0</h2><div class=\"kv\">Read-only vault/reference graph, not runtime memory merge.</div><div id=\"knowledgeList\" class=\"grid\"></div></section>
+<section id=\"artifacts\"><h2>Artifact / Project Library</h2><div id=\"artifactList\" class=\"grid\"></div></section>
+<section id=\"seo\"><h2>SEO Mission Control</h2><div class=\"card\"><h3>Draft-only SEO/AISO lane</h3><div class=\"kv\">publish disabled · outreach disabled · live metrics require approval-gated credentials</div><pre id=\"seoPayload\"></pre></div><div id=\"seoList\" class=\"grid\"></div></section>
+<section id=\"operator\"><h2>Operator Loop / Judge / Evidence</h2><pre id=\"operatorPayload\"></pre></section>
+<section id=\"media\"><h2>Media Studio Browser v0</h2><div class=\"kv\">Read-only. No generation. No posting.</div><div id=\"mediaList\" class=\"grid\"></div></section>
+<section id=\"manage\"><h2>Manage / Update / Status</h2><pre id=\"managePayload\"></pre></section>
+<section id=\"voice\"><h2>Voice / Jarvis gated panel</h2><div class=\"card\"><h3>Jarvis / Oracle Briefing</h3><div class=\"kv\">wake/show/build/act · dry-run only · no always-on microphone · no computer-control</div><pre id=\"jarvisPayload\"></pre></div><pre id=\"voicePayload\"></pre></section>
+</main>
+<script id=\"bootstrap\" type=\"application/json\">{_json_safe(bootstrap)}</script>
+<script>
+const $ = (s) => document.querySelector(s);
+const $$ = (s) => Array.from(document.querySelectorAll(s));
+const asCard = (title, body) => '<div class="card"><h3>' + escapeHtml(title) + '</h3>' + body + '</div>';
+function pill(v) {{ return '<span class="pill">' + escapeHtml(v) + '</span>'; }}
+function escapeHtml(v) {{ return String(v ?? '').replace(/[&<>"']/g, c => ({{'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}}[c])); }}
+async function j(url, opts={{}}) {{ const r = await fetch(url, {{headers:{{'content-type':'application/json'}}, ...opts}}); return await r.json(); }}
+function showPre(sel, obj) {{ $(sel).textContent = JSON.stringify(obj, null, 2); }}
+$$('button[data-tab]').forEach(b => b.addEventListener('click', () => {{ $$('button[data-tab]').forEach(x=>x.classList.remove('active')); $$('section').forEach(x=>x.classList.remove('active')); b.classList.add('active'); $('#' + b.dataset.tab).classList.add('active'); }}));
+async function loadAll() {{
+ const boot = JSON.parse($('#bootstrap').textContent); showPre('#queueSummary', boot.dashboard.queue_summary || {{}});
+ const agents = await j('/api/agents'); $('#agentsList').innerHTML = agents.agents.map(a => asCard(a.name, '<div class="kv">' + escapeHtml(a.id) + ' · ' + escapeHtml(a.status) + '</div><p>' + (a.capabilities||[]).map(pill).join('') + '</p><div class="kv">Memory: ' + escapeHtml(a.memory_boundary) + '</div><div class="kv">Auth: ' + escapeHtml(a.auth_boundary) + '</div><div class="kv">Gates: ' + (a.approval_gates||[]).map(escapeHtml).join(', ') + '</div>')).join('');
+ const knowledge = await j('/api/knowledge/index'); $('#knowledgeList').innerHTML = knowledge.nodes.map(n => asCard(n.label, '<div class="kv">' + escapeHtml(n.kind) + ' · exists=' + escapeHtml(n.exists) + '</div><div class="kv">' + escapeHtml(n.path) + '</div>')).join('');
+ const artifacts = await j('/api/artifacts'); $('#artifactList').innerHTML = artifacts.items.slice(0,40).map(a => asCard(a.title, '<div class="kv">' + escapeHtml(a.kind) + ' · ' + escapeHtml(a.preview_type||a.suffix) + '</div><div class="kv">' + escapeHtml(a.path) + '</div>')).join('');
+ const seo = await j('/api/seo'); showPre('#seoPayload', seo); $('#seoList').innerHTML = ['goals','keyword_queue','draft_queue','review_gates'].map(k => asCard(k, '<div class="kv">' + escapeHtml((seo[k]||[]).length) + ' item(s)</div>')).join('');
+ const operator = await j('/api/operator-loop'); showPre('#operatorPayload', operator);
+ const media = await j('/api/media'); $('#mediaList').innerHTML = media.assets.map(m => asCard(m.title, '<div class="kv">' + escapeHtml(m.mime) + ' · ' + escapeHtml(m.size_bytes) + ' bytes</div><div class="kv">' + escapeHtml(m.path) + '</div>')).join('') || '<div class="card kv">No local media assets found.</div>';
+ showPre('#managePayload', await j('/api/manage/status')); showPre('#voicePayload', await j('/api/voice/status')); showPre('#jarvisPayload', await j('/api/jarvis/briefing'));
+}}
+$('#draftIdea').addEventListener('click', async () => showPre('#ideaResult', await j('/api/idea-factory/draft', {{method:'POST', body:JSON.stringify({{idea_text:$('#ideaText').value}})}})));
+$('#createIdea').addEventListener('click', async () => showPre('#ideaResult', await j('/api/idea-factory/action', {{method:'POST', body:JSON.stringify({{idea_text:$('#ideaText').value}})}})));
+loadAll().catch(e => showPre('#queueSummary', {{error:String(e)}}));
+</script>
+</body></html>"""
+
+
+class MissionControlHandler(BaseHTTPRequestHandler):
+    service: AgentsOSService
+
+    def log_message(self, fmt: str, *args: Any) -> None:  # keep smoke output clean
+        return
+
+    def do_GET(self) -> None:  # noqa: N802
+        path = urlparse(self.path).path
+        try:
+            if path == "/":
+                _send_html(self, mission_control_html(self.service))
+            elif path == "/api/status":
+                payload = self.service.status_payload()
+                payload["operator_ui"] = {"product": "Agents OS Mission Control", "local_only": True, "gateway_restart": False}
+                _send_json(self, payload)
+            elif path == "/api/dashboard":
+                _send_json(self, self.service.dashboard_payload())
+            elif path == "/api/idea-factory/schema":
+                _send_json(self, self.service.idea_factory_schema_payload())
+            elif path == "/api/agents":
+                _send_json(self, agents_registry_payload(self.service.paths))
+            elif path == "/api/knowledge/index":
+                _send_json(self, knowledge_index_payload(self.service.paths))
+            elif path == "/api/artifacts":
+                _send_json(self, artifacts_payload(self.service.paths))
+            elif path == "/api/seo":
+                _send_json(self, seo_mission_control_payload(self.service.paths))
+            elif path == "/api/operator-loop":
+                _send_json(self, operator_loop_payload(self.service))
+            elif path.startswith("/api/tasks/"):
+                _send_json(self, task_detail_payload(self.service.paths, path.rsplit("/", 1)[-1]))
+            elif path == "/api/media":
+                _send_json(self, media_assets_payload(self.service.paths))
+            elif path == "/api/manage/status":
+                _send_json(self, redacted_manage_status_payload(self.service.paths))
+            elif path == "/api/voice/status":
+                _send_json(self, voice_status_payload(self.service.paths))
+            elif path == "/api/jarvis/briefing":
+                _send_json(self, jarvis_briefing_payload(self.service.paths))
+            else:
+                _send_json(self, {"status": "not_found", "path": path}, 404)
+        except Exception as exc:  # deterministic local error payload
+            _send_json(self, {"status": "error", "error": exc.__class__.__name__, "message": str(exc)}, 500)
+
+    def do_POST(self) -> None:  # noqa: N802
+        path = urlparse(self.path).path
+        try:
+            data = _read_json_body(self)
+            if path == "/api/idea-factory/draft":
+                _send_json(self, self.service.idea_factory_draft_payload(data))
+            elif path == "/api/idea-factory/action":
+                _send_json(self, create_idea_action(self.service, data))
+            else:
+                _send_json(self, {"status": "not_found", "path": path}, 404)
+        except ValueError as exc:
+            _send_json(self, {"status": "error", "error": "bad_request", "message": str(exc)}, 400)
+        except Exception as exc:
+            _send_json(self, {"status": "error", "error": exc.__class__.__name__, "message": str(exc)}, 500)
+
+
+def run_server(host: str, port: int, service: AgentsOSService) -> None:
+    if host not in LOCAL_HOSTS:
+        raise ValueError("Agents OS web may bind only to 127.0.0.1/localhost")
+    handler = type("BoundMissionControlHandler", (MissionControlHandler,), {"service": service})
+    server = ThreadingHTTPServer((host, port), handler)
+    print(f"Agents OS Mission Control: http://{host}:{port}", flush=True)
+    server.serve_forever()
+
+
+def web_cmd(args: argparse.Namespace) -> int:
+    paths = resolve_paths(args)
+    service = AgentsOSService(paths)
+    url = f"http://{args.host}:{args.port}"
+    payload = {"status": "ready", "url": url, "local_only": True, "gateway_restart": False, "state_db": str(paths.db)}
+    if getattr(args, "json", False):
+        print(json.dumps(payload, ensure_ascii=False, indent=2))
+        return 0
+    if args.host not in LOCAL_HOSTS:
+        print("Agents OS web may bind only to 127.0.0.1/localhost", file=sys.stderr)
+        return 2
+    if getattr(args, "open", False):
+        threading.Timer(1.0, lambda: webbrowser.open(url)).start()
+    run_server(args.host, args.port, service)
+    return 0
+
+
+# Attach thin service helpers here to avoid widening the core runtime surface too much.
+def _service_idea_factory_schema_payload(self: AgentsOSService) -> dict[str, Any]:
+    return idea_factory_schema()
+
+
+def _service_idea_factory_draft_payload(self: AgentsOSService, data: dict[str, Any]) -> dict[str, Any]:
+    payload = draft_idea(
+        data.get("idea_text") or data.get("idea") or "",
+        context=data.get("context"),
+        desired_output=data.get("desired_output"),
+        urgency=data.get("urgency", "normal"),
+        source_links=data.get("source_links") or data.get("source_link") or [],
+    )
+    payload["execution_created"] = False
+    return payload
+
+
+def _service_operator_loop_payload(self: AgentsOSService) -> dict[str, Any]:
+    return operator_loop_payload(self)
+
+
+AgentsOSService.idea_factory_schema_payload = _service_idea_factory_schema_payload  # type: ignore[attr-defined]
+AgentsOSService.idea_factory_draft_payload = _service_idea_factory_draft_payload  # type: ignore[attr-defined]
+AgentsOSService.operator_loop_payload = _service_operator_loop_payload  # type: ignore[attr-defined]

--- a/hermes_cli/agents_os_web.py
+++ b/hermes_cli/agents_os_web.py
@@ -457,6 +457,64 @@ def jarvis_preview_payload(paths: AgentsOSPaths, data: dict[str, Any]) -> dict[s
     }
 
 
+def _jarvis_stt_payload(data: dict[str, Any]) -> dict[str, Any]:
+    provided = (data.get("transcript_text") or data.get("text") or "").strip()
+    if provided:
+        return {"provider": "provided_transcript", "text": provided, "confidence": None, "status": "provided"}
+    stt_result = data.get("stt_result") if isinstance(data.get("stt_result"), dict) else {}
+    stt_text = (stt_result.get("text") or "").strip()
+    if stt_text:
+        return {
+            "provider": stt_result.get("provider") or "external_stt_adapter",
+            "text": stt_text,
+            "confidence": stt_result.get("confidence"),
+            "status": "transcribed",
+        }
+    return {
+        "provider": "stub_pending",
+        "text": "[stt_pending] Audio captured; STT backend not connected in this local slice.",
+        "confidence": None,
+        "status": "pending",
+    }
+
+
+def jarvis_model_advisor_payload(paths: AgentsOSPaths, data: dict[str, Any]) -> dict[str, Any]:
+    transcript_text = (data.get("transcript_text") or data.get("text") or "").strip()
+    if not transcript_text:
+        raise ValueError("transcript_text is required")
+    deterministic = data.get("deterministic_preview") if isinstance(data.get("deterministic_preview"), dict) else jarvis_preview_payload(paths, {"transcript_text": transcript_text})
+    command_card = dict(deterministic.get("command_card") or {})
+    model_result = data.get("model_result") if isinstance(data.get("model_result"), dict) else {}
+    model_risk = model_result.get("risk_class")
+    authoritative_risk = command_card.get("risk_class")
+    semantic_intent = model_result.get("semantic_intent") or command_card.get("interpreted_intent")
+    voice_reply = model_result.get("voice_reply_short") or _jarvis_voice_reply(command_card)
+    command_card["semantic_intent"] = semantic_intent
+    command_card["voice_reply_short"] = voice_reply
+    command_card["risk_class"] = authoritative_risk
+    command_card["approval_required"] = bool(command_card.get("approval_required"))
+    command_card["execution_created"] = False
+    return {
+        "local_only": True,
+        "execution_created": False,
+        "provider": data.get("provider") or "deterministic",
+        "model": data.get("model") or "none",
+        "transcript_text": transcript_text,
+        "authoritative_risk_class": authoritative_risk,
+        "model_risk_class": model_risk,
+        "risk_disagreement": bool(model_risk and model_risk != authoritative_risk),
+        "command_card": command_card,
+        "model_result": model_result,
+        "audit": {"agents_os_home": str(paths.root), "created_at": utc_now(), "policy": "deterministic_gate_authoritative"},
+    }
+
+
+def _jarvis_voice_reply(command_card: dict[str, Any]) -> str:
+    if command_card.get("approval_required"):
+        return "Ovo treba odobrenje. Pripremio sam preview, ništa ne izvršavam."
+    return "Ovo je sigurno lokalno. Pripremio sam preview, bez izvršavanja."
+
+
 def jarvis_transcribe_payload(paths: AgentsOSPaths, data: dict[str, Any]) -> dict[str, Any]:
     """Persist a local push-to-talk artefact and return transcript + intent preview.
 
@@ -464,9 +522,8 @@ def jarvis_transcribe_payload(paths: AgentsOSPaths, data: dict[str, Any]) -> dic
     deliberately does not execute commands; real STT can replace the transcript
     stub behind the same payload contract.
     """
-    transcript_text = (data.get("transcript_text") or data.get("text") or "").strip()
-    if not transcript_text:
-        transcript_text = "[stt_pending] Audio captured; STT backend not connected in this local slice."
+    stt = _jarvis_stt_payload(data)
+    transcript_text = stt["text"]
     stamp = _jarvis_slug_from_time()
     audio_bytes = _decode_optional_audio(data)
     suffix = _jarvis_audio_suffix(data.get("audio_mime"))
@@ -478,11 +535,14 @@ def jarvis_transcribe_payload(paths: AgentsOSPaths, data: dict[str, Any]) -> dic
     transcript_path = transcript_dir / f"{stamp}-jarvis-transcript.md"
     audio_path.write_bytes(audio_bytes)
     preview = jarvis_preview_payload(paths, {"transcript_text": transcript_text})
+    advisor = jarvis_model_advisor_payload(paths, {"transcript_text": transcript_text, "deterministic_preview": preview})
     transcript_body = {
         "local_only": True,
         "execution_created": False,
-        "transcript": {"text": transcript_text, "source": "browser_push_to_talk", "created_at": utc_now()},
-        "intent_preview": preview["command_card"],
+        "stt": stt,
+        "advisor": {"provider": advisor["provider"], "model": advisor["model"], "risk_disagreement": advisor["risk_disagreement"]},
+        "transcript": {"text": transcript_text, "source": stt["provider"], "created_at": utc_now()},
+        "intent_preview": advisor["command_card"],
         "audio_artifact_path": str(audio_path),
     }
     transcript_path.write_text(f"# Jarvis transcript\n\n```json\n{json.dumps(transcript_body, ensure_ascii=False, indent=2)}\n```\n", encoding="utf-8")
@@ -501,8 +561,10 @@ def jarvis_transcribe_payload(paths: AgentsOSPaths, data: dict[str, Any]) -> dic
         "audio_artifact_path": str(audio_path),
         "transcript_artifact_path": str(transcript_path),
         "transcript": transcript_body["transcript"],
-        "intent_preview": preview["command_card"],
-        "command_card": preview["command_card"],
+        "stt": stt,
+        "advisor": transcript_body["advisor"],
+        "intent_preview": advisor["command_card"],
+        "command_card": advisor["command_card"],
         "artifact_id": artifact_id,
     }
 
@@ -724,6 +786,8 @@ class MissionControlHandler(BaseHTTPRequestHandler):
                 _send_json(self, create_idea_action(self.service, data))
             elif path == "/api/jarvis/preview":
                 _send_json(self, jarvis_preview_payload(self.service.paths, data))
+            elif path == "/api/jarvis/advisor":
+                _send_json(self, jarvis_model_advisor_payload(self.service.paths, data))
             elif path == "/api/jarvis/transcribe":
                 _send_json(self, jarvis_transcribe_payload(self.service.paths, data))
             else:

--- a/hermes_cli/agents_os_web.py
+++ b/hermes_cli/agents_os_web.py
@@ -566,6 +566,21 @@ def _jarvis_gate_text(raw_text: str, cleaned_text: str) -> str:
     return raw_text
 
 
+def _hume_octave_request(text: str, data: dict[str, Any]) -> dict[str, Any]:
+    voice_description = data.get("voice_description") or data.get("description") or "calm Croatian operator voice, concise, warm, and clear"
+    fmt = data.get("format") or data.get("audio_format") or "mp3"
+    return {
+        "utterances": [
+            {
+                "text": text,
+                "description": voice_description,
+            }
+        ],
+        "format": {"type": fmt},
+        "num_generations": int(data.get("num_generations") or 1),
+    }
+
+
 def jarvis_reply_payload(paths: AgentsOSPaths, data: dict[str, Any]) -> dict[str, Any]:
     text = (data.get("text") or data.get("voice_reply_short") or "").strip()
     if not text:
@@ -581,19 +596,28 @@ def jarvis_reply_payload(paths: AgentsOSPaths, data: dict[str, Any]) -> dict[str
         audio_path = audio_dir / f"{stamp}-jarvis-reply{_jarvis_audio_suffix(data.get('audio_mime'))}"
         audio_path.write_bytes(audio_bytes)
     provider = data.get("provider") or ("hermes-tts" if audio_bytes else "text-only-fallback")
+    hume_request = _hume_octave_request(text, data) if provider == "hume-octave" else None
+    hume_key_present = bool(os.environ.get("HUME_API_KEY"))
     reply_path = reply_dir / f"{stamp}-jarvis-reply.md"
+    status = "audio_ready" if audio_path else ("provider_unconfigured" if provider == "hume-octave" and not hume_key_present else "text_only")
     payload = {
         "local_only": True,
         "execution_created": False,
-        "status": "audio_ready" if audio_path else "text_only",
+        "status": status,
         "text": text,
         "audio_artifact_path": str(audio_path) if audio_path else None,
         "tts": {
             "provider": provider,
             "mime": data.get("audio_mime") if audio_path else None,
             "fallback": audio_path is None,
+            "requires_api_key": provider == "hume-octave",
+            "api_key_present": hume_key_present if provider == "hume-octave" else None,
+            "api_called": False,
+            "supported_formats": ["mp3", "wav", "pcm"] if provider == "hume-octave" else None,
         },
     }
+    if hume_request:
+        payload["hume_octave_request"] = hume_request
     reply_path.write_text(f"# Jarvis voice reply\n\n```json\n{json.dumps(payload, ensure_ascii=False, indent=2)}\n```\n", encoding="utf-8")
     artifact_id = f"artifact-jarvis-reply-{stamp}"
     with connect(paths) as conn:

--- a/hermes_cli/agents_os_web.py
+++ b/hermes_cli/agents_os_web.py
@@ -7,6 +7,7 @@ or approval drafts; they do not execute outbound/public/security/financial work.
 from __future__ import annotations
 
 import argparse
+import base64
 import json
 import mimetypes
 import os
@@ -371,6 +372,131 @@ def jarvis_briefing_payload(paths: AgentsOSPaths) -> dict[str, Any]:
     }
 
 
+def _jarvis_slug_from_time() -> str:
+    return utc_now().replace(":", "").replace("-", "").replace(".", "")[:15]
+
+
+def _decode_optional_audio(data: dict[str, Any]) -> bytes:
+    raw = data.get("audio_base64") or ""
+    if not raw:
+        return b""
+    if "," in raw and raw.split(",", 1)[0].startswith("data:"):
+        raw = raw.split(",", 1)[1]
+    return base64.b64decode(raw)
+
+
+def _jarvis_audio_suffix(mime: str | None) -> str:
+    mime = (mime or "").lower()
+    if "wav" in mime:
+        return ".wav"
+    if "ogg" in mime:
+        return ".ogg"
+    if "mpeg" in mime or "mp3" in mime:
+        return ".mp3"
+    return ".webm"
+
+
+def _jarvis_preview_from_text(transcript_text: str) -> dict[str, Any]:
+    draft = draft_idea(transcript_text)
+    normalized = transcript_text.lower()
+    if any(token in normalized for token in ["prikaži", "prikazi", "show", "status", "stanje", "zadnje", "otvori lokalni", "local status"]):
+        draft["classification"] = "research_intake"
+        draft["risk_class"] = "safe_local"
+        draft["recommended_lane"] = "read-only-status"
+        draft["approval_required"] = False
+        draft["plan_steps"] = [
+            "Dohvatiti lokalni status ili postojeći artefakt.",
+            "Prikazati rezultat u command preview kartici.",
+            "Ne izvršiti nikakvu vanjsku ili rizičnu akciju.",
+        ]
+    if any(token in normalized for token in ["deploy", "deployaj", "push", "pr ", "pull request", "objavi", "pošalji", "posalji", "email"]):
+        draft["classification"] = "public_outbound_gated"
+        draft["risk_class"] = "public_gated"
+        draft["recommended_lane"] = "public-action-approval"
+        draft["approval_required"] = True
+        draft["plan_steps"] = [
+            "Prikazati namjeru i rizičnu radnju u command preview kartici.",
+            "Ne izvršiti javnu, deploy, push ili outbound akciju iz glasa.",
+            "Čekati eksplicitno Goranovo odobrenje prije side-effecta.",
+        ]
+    return draft
+
+
+def jarvis_preview_payload(paths: AgentsOSPaths, data: dict[str, Any]) -> dict[str, Any]:
+    transcript_text = (data.get("transcript_text") or data.get("text") or "").strip()
+    if not transcript_text:
+        raise ValueError("transcript_text is required")
+    draft = _jarvis_preview_from_text(transcript_text)
+    command_card = {
+        "heard": transcript_text,
+        "interpreted_intent": draft["classification"],
+        "risk_class": draft["risk_class"],
+        "proposed_action": draft["recommended_lane"],
+        "approval_required": draft["approval_required"],
+        "expected_output": draft["expected_artifacts"],
+        "execution_created": False,
+        "allowed_now": draft["risk_class"] == "safe_local",
+    }
+    return {
+        "local_only": True,
+        "execution_created": False,
+        "transcript_text": transcript_text,
+        "command_card": command_card,
+        "draft": draft,
+        "audit": {"agents_os_home": str(paths.root), "created_at": utc_now(), "policy": "preview_only"},
+    }
+
+
+def jarvis_transcribe_payload(paths: AgentsOSPaths, data: dict[str, Any]) -> dict[str, Any]:
+    """Persist a local push-to-talk artefact and return transcript + intent preview.
+
+    This v0.1 endpoint accepts browser audio plus an optional transcript stub. It
+    deliberately does not execute commands; real STT can replace the transcript
+    stub behind the same payload contract.
+    """
+    transcript_text = (data.get("transcript_text") or data.get("text") or "").strip()
+    if not transcript_text:
+        transcript_text = "[stt_pending] Audio captured; STT backend not connected in this local slice."
+    stamp = _jarvis_slug_from_time()
+    audio_bytes = _decode_optional_audio(data)
+    suffix = _jarvis_audio_suffix(data.get("audio_mime"))
+    audio_dir = paths.artifacts / "jarvis_audio"
+    transcript_dir = paths.artifacts / "jarvis_transcripts"
+    audio_dir.mkdir(parents=True, exist_ok=True)
+    transcript_dir.mkdir(parents=True, exist_ok=True)
+    audio_path = audio_dir / f"{stamp}-jarvis-command{suffix}"
+    transcript_path = transcript_dir / f"{stamp}-jarvis-transcript.md"
+    audio_path.write_bytes(audio_bytes)
+    preview = jarvis_preview_payload(paths, {"transcript_text": transcript_text})
+    transcript_body = {
+        "local_only": True,
+        "execution_created": False,
+        "transcript": {"text": transcript_text, "source": "browser_push_to_talk", "created_at": utc_now()},
+        "intent_preview": preview["command_card"],
+        "audio_artifact_path": str(audio_path),
+    }
+    transcript_path.write_text(f"# Jarvis transcript\n\n```json\n{json.dumps(transcript_body, ensure_ascii=False, indent=2)}\n```\n", encoding="utf-8")
+    artifact_id = f"artifact-jarvis-transcript-{stamp}"
+    with connect(paths) as conn:
+        conn.execute(
+            "INSERT OR REPLACE INTO artifacts(id,kind,title,path,task_id,workflow,created_at) VALUES(?,?,?,?,?,?,?)",
+            (artifact_id, "jarvis_transcript", "Jarvis transcript", str(transcript_path), None, "jarvis-push-to-talk", utc_now()),
+        )
+        log_event(conn, "jarvis_transcribed", payload={"artifact_id": artifact_id, "audio_path": str(audio_path), "execution_created": False})
+        conn.commit()
+    return {
+        "status": "transcribed",
+        "local_only": True,
+        "execution_created": False,
+        "audio_artifact_path": str(audio_path),
+        "transcript_artifact_path": str(transcript_path),
+        "transcript": transcript_body["transcript"],
+        "intent_preview": preview["command_card"],
+        "command_card": preview["command_card"],
+        "artifact_id": artifact_id,
+    }
+
+
 def operator_loop_payload(service: AgentsOSService) -> dict[str, Any]:
     dashboard = service.dashboard_payload()
     tasks = dashboard.get("tasks", [])
@@ -488,7 +614,7 @@ main {{ padding:24px 34px 60px; }} section {{ display:none; }} section.active {{
 <section id=\"operator\"><h2>Operator Loop / Judge / Evidence</h2><pre id=\"operatorPayload\"></pre></section>
 <section id=\"media\"><h2>Media Studio Browser v0</h2><div class=\"kv\">Read-only. No generation. No posting.</div><div id=\"mediaList\" class=\"grid\"></div></section>
 <section id=\"manage\"><h2>Manage / Update / Status</h2><pre id=\"managePayload\"></pre></section>
-<section id=\"voice\"><h2>Voice / Jarvis gated panel</h2><div class=\"card\"><h3>Jarvis / Oracle Briefing</h3><div class=\"kv\">wake/show/build/act · dry-run only · no always-on microphone · no computer-control</div><pre id=\"jarvisPayload\"></pre></div><pre id=\"voicePayload\"></pre></section>
+<section id=\"voice\"><h2>Voice / Jarvis gated panel</h2><div class=\"card\"><h3>Jarvis / Oracle Briefing</h3><div class=\"kv\">wake/show/build/act · dry-run only · no always-on microphone · no computer-control</div><pre id=\"jarvisPayload\"></pre></div><div class=\"card\"><h3>Push-to-talk v0.1</h3><div class=\"kv\">Record command captures local browser audio, stores local artefacts, returns transcript + intent preview. No execution.</div><p><button id=\"recordJarvis\">Record command</button> <button id=\"stopJarvis\" disabled>Stop</button> <button id=\"previewJarvis\">Preview typed command</button></p><textarea id=\"jarvisTranscript\">Prikaži zadnje BP24 stanje</textarea><h3>Command Preview</h3><pre id=\"jarvisCommandCard\"></pre></div><pre id=\"voicePayload\"></pre></section>
 </main>
 <script id=\"bootstrap\" type=\"application/json\">{_json_safe(bootstrap)}</script>
 <script>
@@ -512,6 +638,23 @@ async function loadAll() {{
 }}
 $('#draftIdea').addEventListener('click', async () => showPre('#ideaResult', await j('/api/idea-factory/draft', {{method:'POST', body:JSON.stringify({{idea_text:$('#ideaText').value}})}})));
 $('#createIdea').addEventListener('click', async () => showPre('#ideaResult', await j('/api/idea-factory/action', {{method:'POST', body:JSON.stringify({{idea_text:$('#ideaText').value}})}})));
+let jarvisRecorder = null; let jarvisChunks = [];
+async function previewJarvisCommand() {{ showPre('#jarvisCommandCard', await j('/api/jarvis/preview', {{method:'POST', body:JSON.stringify({{transcript_text:$('#jarvisTranscript').value}})}})); }}
+$('#previewJarvis').addEventListener('click', previewJarvisCommand);
+$('#recordJarvis').addEventListener('click', async () => {{
+ if (!navigator.mediaDevices || !window.MediaRecorder) {{ showPre('#jarvisCommandCard', {{status:'browser_audio_unavailable', execution_created:false}}); return; }}
+ const stream = await navigator.mediaDevices.getUserMedia({{audio:true}}); jarvisChunks = []; jarvisRecorder = new MediaRecorder(stream);
+ jarvisRecorder.ondataavailable = e => {{ if (e.data && e.data.size) jarvisChunks.push(e.data); }};
+ jarvisRecorder.onstop = async () => {{
+   stream.getTracks().forEach(t => t.stop());
+   const blob = new Blob(jarvisChunks, {{type: jarvisRecorder.mimeType || 'audio/webm'}});
+   const reader = new FileReader();
+   reader.onloadend = async () => showPre('#jarvisCommandCard', await j('/api/jarvis/transcribe', {{method:'POST', body:JSON.stringify({{audio_base64:String(reader.result), audio_mime:blob.type, transcript_text:$('#jarvisTranscript').value}})}}));
+   reader.readAsDataURL(blob); $('#recordJarvis').disabled = false; $('#stopJarvis').disabled = true;
+ }};
+ jarvisRecorder.start(); $('#recordJarvis').disabled = true; $('#stopJarvis').disabled = false; showPre('#jarvisCommandCard', {{status:'recording', execution_created:false}});
+}});
+$('#stopJarvis').addEventListener('click', () => {{ if (jarvisRecorder && jarvisRecorder.state !== 'inactive') jarvisRecorder.stop(); }});
 loadAll().catch(e => showPre('#queueSummary', {{error:String(e)}}));
 </script>
 </body></html>"""
@@ -569,6 +712,10 @@ class MissionControlHandler(BaseHTTPRequestHandler):
                 _send_json(self, self.service.idea_factory_draft_payload(data))
             elif path == "/api/idea-factory/action":
                 _send_json(self, create_idea_action(self.service, data))
+            elif path == "/api/jarvis/preview":
+                _send_json(self, jarvis_preview_payload(self.service.paths, data))
+            elif path == "/api/jarvis/transcribe":
+                _send_json(self, jarvis_transcribe_payload(self.service.paths, data))
             else:
                 _send_json(self, {"status": "not_found", "path": path}, 404)
         except ValueError as exc:

--- a/hermes_cli/agents_os_web.py
+++ b/hermes_cli/agents_os_web.py
@@ -35,16 +35,21 @@ from hermes_cli.agents_os_idea_factory import draft_idea, idea_factory_schema
 from hermes_cli.agents_os_seo import seo_mission_control_payload
 
 LOCAL_HOSTS = {"127.0.0.1", "localhost"}
-SOURCE_DEFAULTS = {
-    "video:q13OqknCh-c": "https://youtu.be/q13OqknCh-c",
-    "transcript:q13OqknCh-c": "/mnt/d/HermesAgent/home/transcripts/q13OqknCh-c_transcript.txt",
-    "youtube-note:q13OqknCh-c": "/mnt/d/Obsidian_Vault_v2/Hermes-Agent-Doni/01-INBOX/YouTube/2026-06-08-q13OqknCh-c-claude-agent-operating-system.md",
-    "plan:parity-q13OqknCh-c": "/mnt/d/Obsidian_Vault_v2/Hermes-Agent-Doni/08-OPERATIONS/ACTIVE-WORK/2026-06-08-agent-os-parity-build-plan-q13OqknCh-c.md",
-    "plan:full-product": "/mnt/d/Obsidian_Vault_v2/Hermes-Agent-Doni/08-OPERATIONS/ACTIVE-WORK/2026-06-08-agent-os-full-product-plan.md",
-    "contract:idea-factory-v0": "/mnt/d/Obsidian_Vault_v2/Hermes-Agent-Doni/08-OPERATIONS/ACTIVE-WORK/2026-06-08-idea-factory-v0-contract.md",
+# Source registry: a mapping of well-known source keys to their canonical paths.
+# These are intentionally profile-agnostic and only resolve to absolute paths when
+# the corresponding AGENTS_OS_SOURCE_* environment variable is set. Operators are
+# expected to wire these to their own vault / transcript locations at deploy time.
+SOURCE_DEFAULTS: dict[str, str] = {
+    # Each entry: logical source key -> default placeholder
+    "video:demo": "https://youtu.be/<video-id-placeholder>",
+    "transcript:demo": "${AGENTS_OS_SOURCE_TRANSCRIPTS}/<video-id-placeholder>.txt",
+    "youtube-note:demo": "${AGENTS_OS_SOURCE_VAULT}/01-INBOX/YouTube/<video-id-placeholder>.md",
+    "plan:parity-demo": "${AGENTS_OS_SOURCE_VAULT}/08-OPERATIONS/ACTIVE-WORK/<plan-name-placeholder>.md",
+    "plan:full-product": "${AGENTS_OS_SOURCE_VAULT}/08-OPERATIONS/ACTIVE-WORK/<plan-name-placeholder>.md",
+    "contract:idea-factory-v0": "${AGENTS_OS_SOURCE_VAULT}/08-OPERATIONS/ACTIVE-WORK/<contract-name-placeholder>.md",
 }
 SOURCE_ENV = {
-    "transcript:q13OqknCh-c": "AGENTS_OS_SOURCE_TRANSCRIPT",
+    "transcript:demo": "AGENTS_OS_SOURCE_TRANSCRIPT",
     "plan:full-product": "AGENTS_OS_SOURCE_FULL_PLAN",
 }
 MEDIA_SUFFIXES = {".png", ".jpg", ".jpeg", ".webp", ".gif", ".mp3", ".wav", ".ogg", ".mp4", ".webm", ".mov"}
@@ -105,37 +110,41 @@ def _path_info(path: str) -> dict[str, Any]:
 
 
 def _default_agent_cards(paths: AgentsOSPaths) -> list[dict[str, Any]]:
+    # NOTE: Agent cards are operator-customisable. Defaults below are
+    # profile-agnostic placeholders that resolve paths at runtime from the
+    # active Hermes home (no hardcoded absolute user paths or vendor names).
+    primary_home = str(paths.home)
     return [
         {
-            "id": "doni-local",
-            "name": "Doni Local",
+            "id": "primary-agent",
+            "name": "Primary agent",
             "status": "available",
             "capabilities": ["local planning", "TDD", "reports", "Mission Control"],
-            "runtime_home": str(paths.home),
+            "runtime_home": primary_home,
             "reference_home": str(paths.root),
-            "memory_boundary": "Doni Hermes home only",
-            "auth_boundary": "Doni auth only; credentials are never displayed",
+            "memory_boundary": "active Hermes home only; no cross-profile read/write",
+            "auth_boundary": "active profile auth only; credentials are never displayed",
             "allowed_actions": ["safe local files", "tests", "local API smoke", "local reports"],
             "approval_gates": ["deploy", "public send", "credential use", "gateway restart", "destructive changes"],
         },
         {
-            "id": "kodi-codex",
-            "name": "Kodi/Codex",
+            "id": "coding-delegate",
+            "name": "Coding delegate",
             "status": "reference",
             "capabilities": ["coding delegate", "review", "patch suggestions"],
             "runtime_home": "external/approval-gated",
             "reference_home": "repo-local only when explicitly invoked",
-            "memory_boundary": "no Doni memory merge",
-            "auth_boundary": "no credential sharing from Doni",
+            "memory_boundary": "no active-agent memory merge",
+            "auth_boundary": "no credential sharing from active profile",
             "allowed_actions": ["local branch work after explicit routing"],
             "approval_gates": ["push", "PR", "public GitHub action", "credential use"],
         },
         {
-            "id": "marija-profile",
-            "name": "Marija profile",
+            "id": "peer-profile",
+            "name": "Peer profile (separate Hermes home)",
             "status": "separate_profile",
             "capabilities": ["separate Hermes profile"],
-            "runtime_home": "/home/goran/.hermes-marija-clean",
+            "runtime_home": "<peer profile home — configured at deploy>",
             "reference_home": "read-only boundary reference",
             "memory_boundary": "separate personal memory; no merge",
             "auth_boundary": "separate profile auth; no cross-copy",
@@ -143,12 +152,12 @@ def _default_agent_cards(paths: AgentsOSPaths) -> list[dict[str, Any]]:
             "approval_gates": ["any profile write", "auth change", "gateway lifecycle"],
         },
         {
-            "id": "ero-openclaw",
-            "name": "ERO/OpenClaw reference layer",
+            "id": "external-runtime",
+            "name": "External runtime (reference layer)",
             "status": "separate_runtime",
             "capabilities": ["reference bridge", "source artefacts"],
-            "runtime_home": "/home/goran/.openclaw/workspace",
-            "reference_home": "/mnt/d/AI_Memory/communication",
+            "runtime_home": "<external runtime home — configured at deploy>",
+            "reference_home": "<shared bridge path — configured at deploy>",
             "memory_boundary": "separate runtime memory; reference only",
             "auth_boundary": "no auth/session sharing",
             "allowed_actions": ["read-only reference when useful"],
@@ -427,7 +436,7 @@ def _jarvis_preview_from_text(transcript_text: str) -> dict[str, Any]:
         draft["plan_steps"] = [
             "Prikazati namjeru i rizičnu radnju u command preview kartici.",
             "Ne izvršiti javnu, deploy, push ili outbound akciju iz glasa.",
-            "Čekati eksplicitno Goranovo odobrenje prije side-effecta.",
+            "Čekati eksplicitno odobrenje operatera prije side-effecta.",
         ]
     return draft
 
@@ -801,7 +810,7 @@ main {{ padding:24px 34px 60px; }} section {{ display:none; }} section.active {{
 </style>
 </head>
 <body>
-<header><h1>Agents OS Mission Control</h1><div class=\"sub\">Local-only Doni operator cockpit · gateway restart: false · vault/reference graph, not runtime memory merge</div></header>
+<header><h1>Agents OS Mission Control</h1><div class=\"sub\">Local-only operator cockpit · gateway restart: false · vault/reference graph, not runtime memory merge</div></header>
 <nav class=\"tabs\">
 <button data-tab=\"overview\" class=\"active\">Overview</button><button data-tab=\"idea\">Idea Factory</button><button data-tab=\"agents\">Agent Registry</button><button data-tab=\"knowledge\">Knowledge Galaxy</button><button data-tab=\"artifacts\">Artifact Library</button><button data-tab=\"seo\">SEO Mission Control</button><button data-tab=\"operator\">Operator Loop</button><button data-tab=\"media\">Media Studio</button><button data-tab=\"manage\">Manage / Status</button><button data-tab=\"voice\">Voice / Jarvis</button>
 </nav>

--- a/pr-split/PR1-control-plane.md
+++ b/pr-split/PR1-control-plane.md
@@ -1,0 +1,39 @@
+# PR 1/3: agents-os-runtime-control-plane-clean
+
+**Branch:** `feat/agents-os-runtime-control-plane-clean`
+**Base:** `main` @ `4d39a60`
+**Scope:** Originalni Agents OS runtime control plane + današnji escape-safe onclick fix.
+**Source:** Izdvojeno iz #42341 (commits `6999b065` + `3370c74e`).
+
+## Files
+- `hermes_cli/agents_os.py` (+1848)
+- `hermes_cli/agents_os_tui.py` (+356)
+- `hermes_cli/agents_os_web.py` (+1250) — **uključuje današnji fix**
+- `hermes_cli/commands.py` (+3)
+- `hermes_cli/main.py` (+44)
+- `scripts/launch_agents_os_mission_control.sh` (+59)
+- `tests/hermes_cli/test_agents_os.py` (+143)
+- `tests/hermes_cli/test_agents_os_tui.py` (+123)
+- `tests/hermes_cli/test_agents_os_web.py` (+503)
+
+## Što radi
+- Lokalni Agents OS runtime s Mission Control web UI-jem (port 18790)
+- CLI komanda `agents-os` za start/stop/status
+- Mission Control paneli: tasks, approvals, artifacts (detail view), launch script
+- TUI mode za isti panel set bez web dependency-ja
+- **Današnji fix:** data-detail-id + dataset.detailId umjesto string-escape onclick (mc-debug.js: 0 pageerror, 12 tasks + 3 approvals render)
+
+## Što NE uključuje
+- Jarvis/STT/TTS scope (→ PR 2)
+- Wiki lifecycle helpers (→ PR 3)
+- SEO/idea_factory panels (→ PR 2)
+
+## Acceptance za maintainere
+- `pytest tests/hermes_cli/test_agents_os.py tests/hermes_cli/test_agents_os_tui.py tests/hermes_cli/test_agents_os_web.py -q` mora proći
+- `bash scripts/launch_agents_os_mission_control.sh` starta UI na portu 18790
+- mc-debug.js (browser konzola) — 0 pageerror nakon učitavanja
+- Svi artifact i approval detail paneli se renderiraju s validnim JSON-om
+
+## Notes
+- Ovaj PR je minimalni, deterministic-verify scope. Razdvajanje je dogovoreno jer je #42341 narastao na 11 commit-ova i 17 fajlova (scope drift disclaimer).
+- Originalni fix-commit (`3370c74e`) nosi i `.gitignore` update za `recall-like-mvp/`. Taj red je izdvojen iz PR-a i pripada lokalnom mirror workflow-u — ne treba ići u upstream PR.

--- a/pr-split/PR2-jarvis-stt-tts.md
+++ b/pr-split/PR2-jarvis-stt-tts.md
@@ -1,0 +1,43 @@
+# PR 2/3: jarvis-stt-tts-contracts
+
+**Branch:** `feat/jarvis-stt-tts-contracts`
+**Base:** `main` @ `4d39a60`
+**Scope:** Jarvis Mission Control paneli, STT/TTS kontrakti, ideja-factory i SEO panels.
+**Source:** Izdvojeno iz #42341 (commits `ad2fdc6f` do `cdab2abc`, 8 commitova).
+
+## Files
+- `hermes_cli/agents_os_idea_factory.py` (+151) — Jarvis ideja-factory panel
+- `hermes_cli/agents_os_seo.py` (+81) — SEO panel
+- Mission Control paneli za Jarvis (ugrađeni u `agents_os_web.py`, +~700 linija)
+- `tests/hermes_cli/test_agents_os_complete.py` (+388)
+- `tests/hermes_cli/test_agents_os_idea_factory.py` (+86)
+- `tests/hermes_cli/test_agents_os_seo.py` (+75)
+
+## Commit sekvenca
+1. `ad2fdc6f` feat: add Mission Control Jarvis and SEO panels
+2. `cfe8703` feat: add Jarvis command preview scaffold
+3. `e4e4376` test: gate Jarvis security scan previews
+4. `ca3c18e` feat: add Jarvis STT advisor boundary
+5. `c974fdf` feat: add Jarvis local STT adapter
+6. `4206fd5` feat: add Jarvis transcript cleanup contract
+7. `b55f230` feat: add Jarvis voice reply contract
+8. `cdab2ab` feat: add Hume Octave TTS draft contract
+
+## Što radi
+- Mission Control paneli: Jarvis command preview, security scan gate, STT advisor + local STT adapter, transcript cleanup + voice reply contract, Hume Octave TTS draft
+- Ideja-factory panel: prijedlozi za content/SEO ideje
+- SEO panel: page-level SEO snapshot
+
+## Ovisnosti
+- PR 1 (control plane) — ova PR gradi **na vrhu** kontrolne ravnine. Ako merge PR 2 prije PR 1, testovi padaju jer importaju `agents_os` runtime module.
+
+**Preporuka:** Merge PR 1 → PR 2 → PR 3.
+
+## Acceptance za maintainere
+- `pytest tests/hermes_cli/test_agents_os_complete.py tests/hermes_cli/test_agents_os_idea_factory.py tests/hermes_cli/test_agents_os_seo.py -q` prolazi
+- Jarvis paneli u Mission Control-u (port 18790) se renderiraju
+- STT/TTS kontrakti imaju contract test fixture (provider=None okruženje)
+
+## Notes
+- TTS draft koristi Hume Octave kao draft provider — nije hard dependency. Adapter je pluggable.
+- STT advisor boundary čuva sigurnosni gate oko transkripta prije slanja u model.

--- a/pr-split/PR3-wiki-lifecycle.md
+++ b/pr-split/PR3-wiki-lifecycle.md
@@ -1,0 +1,31 @@
+# PR 3/3: chore/wiki-lifecycle-daily-helpers
+
+**Branch:** `chore/wiki-lifecycle-daily-helpers`
+**Base:** `main` @ `4d39a60`
+**Scope:** Wiki lifecycle daily helpers (single commit `7fc9d618`).
+**Source:** Izdvojeno iz #42341 (commit `7fc9d61810d0ecbecea8276b9ebf4bdb37369f1d`).
+
+## Files
+- `scripts/wiki_lifecycle.py` (+186) — CLI helper
+- `tools/wiki_lifecycle.py` (+383) — core lifecycle engine
+
+## Što radi
+- Daily maintenance za lokalni wiki (vault-style markdown KB):
+  - index refresh
+  - orphan detection
+  - backlink rebuild
+  - archive rotation
+
+## Ovisnosti
+- **Nema** dependency-ja na PR 1 ili PR 2. Čist chore PR.
+
+**Preporuka:** Može ići paralelno s PR 1 i PR 2, neovisno o njima.
+
+## Acceptance za maintainere
+- `python scripts/wiki_lifecycle.py --help` radi
+- `python tools/wiki_lifecycle.py --dry-run` izvještava bez write-ova
+- Postoji unit test za archive rotation (trenutno scope ovog PR-a samo tools/scripts)
+
+## Notes
+- Wiki lifecycle je generički utility — ne ovisi o Agents OS runtime-u.
+- Naslov je `chore/` jer je maintenance utility, ne nova funkcionalnost.

--- a/pr-split/README.md
+++ b/pr-split/README.md
@@ -1,0 +1,46 @@
+# PR Split Plan — #42341 → 3 PR-a
+
+## Izvor
+- PR: https://github.com/NousResearch/hermes-agent/pull/42341
+- Title: feat: add local Agents OS Mission Control panels
+- Branch: `feat/agents-os-runtime-control-plane`
+- Commits: 11
+- Files: 17 (promijenjenih)
+- Razlog split-a: scope drift, preširok za jedan PR, velika šansa za odbijanje.
+
+## PR Split
+
+| # | Branch | Scope | Commits | Files | Merge redoslijed |
+|---|---|---|---|---|---|
+| 1 | `feat/agents-os-runtime-control-plane-clean` | Originalni control plane + današnji fix | 2 | 9 | Prvi |
+| 2 | `feat/jarvis-stt-tts-contracts` | Jarvis/STT/TTS scope | 8 | 6 | Drugi (zavisan o 1) |
+| 3 | `chore/wiki-lifecycle-daily-helpers` | Wiki restore | 1 | 2 | Paralelno s 1 i 2 |
+
+## Prednosti split-a
+- Lakši review (max 9 fajlova / 8 commit-ova po PR-u)
+- Veća šansa za merge
+- Mogu ići (djelomično) paralelno — PR 3 je neovisan
+- Maintaineri mogu odbiti dio bez da odbace cijeli set
+- Lakše pratiti regression ako PR 2 padne
+
+## Akcijski plan (za sljedeću sesiju kad se token oporavi)
+1. Klonirati PR branch lokalno: `git fetch origin pull/42341/head:pr-42341`
+2. Za svaki PR:
+   - Kreirati branch iz `main`
+   - Cherry-pick odgovarajuće commitove iz `pr-42341`
+   - Za PR 1: ručno izdvojiti samo `agents_os.py` / `agents_os_tui.py` / `agents_os_web.py` (fix) / `commands.py` / `main.py` / launch script + njihove testove; **NE uključivati** `agents_os_idea_factory.py` i `agents_os_seo.py`
+   - Za PR 2: cherry-pick 8 Jarvis/STT/TTS commitova
+   - Za PR 3: cherry-pick 1 wiki commit
+3. Pushati 3 grane na `goran1mikac-ux/hermes-agent` fork
+4. Otvoriti 3 PR-a prema `NousResearch/hermes-agent:main`
+5. U svakom PR opisu linkati na #42341 i obrazložiti zašto je izdvojen
+6. Zatvoriti #42341 s komentarom "Superseded by #X, #Y, #Z"
+
+## Artefakti
+- PR1 opis: `./PR1-control-plane.md`
+- PR2 opis: `./PR2-jarvis-stt-tts.md`
+- PR3 opis: `./PR3-wiki-lifecycle.md`
+
+## Token-used pri splitu
+- Split opis kreiran: ~52/50k (over budget ali radnja završena)
+- GitHub push i PR kreacija: odgođeno za sljedeću sesiju

--- a/scripts/launch_agents_os_mission_control.sh
+++ b/scripts/launch_agents_os_mission_control.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_DIR="${AGENTS_OS_REPO_DIR:-/mnt/d/HermesAgent/app}"
+HERMES_HOME="${HERMES_HOME:-/home/goran/.hermes-doni-clean}"
+HOST="${AGENTS_OS_HOST:-127.0.0.1}"
+PORT="${AGENTS_OS_PORT:-18790}"
+URL="http://${HOST}:${PORT}"
+PY="${REPO_DIR}/venv/bin/python"
+LOG_DIR="${HERMES_HOME}/agents_os/logs"
+LOG_FILE="${LOG_DIR}/mission-control-web.log"
+PID_FILE="${HERMES_HOME}/agents_os/mission-control-web.pid"
+
+mkdir -p "$LOG_DIR"
+cd "$REPO_DIR"
+
+if [[ ! -x "$PY" ]]; then
+  echo "ERROR: venv python nije nađen: $PY" >&2
+  exit 2
+fi
+
+health_ok() {
+  "$PY" - <<PY
+import urllib.request, sys
+try:
+    with urllib.request.urlopen('${URL}/api/status', timeout=2) as r:
+        data = r.read(2000).decode('utf-8', 'replace')
+    sys.exit(0 if r.status == 200 and 'state_db' in data else 1)
+except Exception:
+    sys.exit(1)
+PY
+}
+
+if health_ok; then
+  echo "Mission Control već radi: $URL"
+else
+  echo "Pokrećem Mission Control local-only: $URL"
+  HERMES_HOME="$HERMES_HOME" nohup "$PY" -m hermes_cli.agents_os web --host "$HOST" --port "$PORT" >"$LOG_FILE" 2>&1 &
+  echo $! > "$PID_FILE"
+  for _ in $(seq 1 30); do
+    if health_ok; then
+      break
+    fi
+    sleep 1
+  done
+  if ! health_ok; then
+    echo "ERROR: Mission Control nije postao healthy. Log: $LOG_FILE" >&2
+    exit 1
+  fi
+fi
+
+echo "Health OK: $URL/api/status"
+if command -v wslview >/dev/null 2>&1; then
+  wslview "$URL" >/dev/null 2>&1 || true
+elif command -v xdg-open >/dev/null 2>&1; then
+  xdg-open "$URL" >/dev/null 2>&1 || true
+else
+  echo "Otvori ručno: $URL"
+fi

--- a/tests/hermes_cli/test_agents_os_idea_factory.py
+++ b/tests/hermes_cli/test_agents_os_idea_factory.py
@@ -1,0 +1,86 @@
+import json
+
+from hermes_cli import agents_os
+from hermes_cli.agents_os_idea_factory import draft_idea, idea_factory_schema
+
+
+def test_schema_exposes_required_fields_and_risk_classes():
+    schema = idea_factory_schema()
+
+    assert "idea_text" in schema["input_fields"]
+    assert "classification" in schema["output_fields"]
+    assert "safe_local" in schema["risk_classes"]
+    assert "credential_gated" in schema["risk_classes"]
+
+
+def test_drafts_safe_youtube_intake_as_local_research():
+    draft = draft_idea("Obradi YouTube video i spremi ga u vault")
+
+    assert draft["classification"] == "research_intake"
+    assert draft["risk_class"] == "safe_local"
+    assert draft["approval_required"] is False
+    assert draft["suggested_agent"] == "doni-local"
+    assert draft["recommended_lane"] == "youtube-content-intake"
+    assert draft["plan_steps"]
+    assert draft["acceptance_criteria"]
+
+
+def test_drafts_agent_os_build_as_local_write_approval():
+    draft = draft_idea("Dodaj Memory Galaxy u Doni dashboard")
+
+    assert draft["classification"] == "agent_os_build"
+    assert draft["risk_class"] == "approval_local_write"
+    assert draft["approval_required"] is True
+    assert draft["recommended_lane"] == "mission-control-build"
+
+
+def test_high_risk_ideas_are_approval_gated():
+    cases = [
+        ("Pošalji email klijentu", "public_outbound_gated", "public_gated"),
+        ("Spoji Kraken live trading", "finance_gated", "finance_gated"),
+        ("Skeniraj tuđi web za ranjivosti", "security_gated", "security_gated"),
+        ("Obriši stare memorije", "memory_skill_ops", "destructive_gated"),
+        ("Spoji API ključ i koristi credentiale", "unclear_needs_context", "credential_gated"),
+    ]
+
+    for text, classification, risk in cases:
+        draft = draft_idea(text)
+        assert draft["classification"] == classification
+        assert draft["risk_class"] == risk
+        assert draft["approval_required"] is True
+
+
+def test_public_web_offer_is_safe_local_draft():
+    draft = draft_idea("Napravi landing za web revenue audit")
+
+    assert draft["classification"] == "web_seo_offer"
+    assert draft["risk_class"] == "safe_local"
+    assert draft["approval_required"] is False
+    assert draft["recommended_lane"] == "web-seo-offer"
+
+
+def test_agents_os_idea_schema_cli_returns_contract(capsys):
+    assert agents_os.main(["idea", "schema", "--json"]) == 0
+
+    payload = json.loads(capsys.readouterr().out)
+    assert "idea_text" in payload["input_fields"]
+    assert "approval_required" in payload["output_fields"]
+    assert payload["local_only"] is True
+
+
+def test_agents_os_idea_draft_cli_outputs_draft(capsys):
+    assert agents_os.main(["idea", "draft", "Obradi YouTube video", "--json"]) == 0
+
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["classification"] == "research_intake"
+    assert payload["risk_class"] == "safe_local"
+    assert payload["approval_required"] is False
+
+
+def test_agents_os_idea_draft_cli_gates_public_action(capsys):
+    assert agents_os.main(["idea", "draft", "Pošalji email klijentu", "--json"]) == 0
+
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["classification"] == "public_outbound_gated"
+    assert payload["risk_class"] == "public_gated"
+    assert payload["approval_required"] is True

--- a/tests/hermes_cli/test_agents_os_seo.py
+++ b/tests/hermes_cli/test_agents_os_seo.py
@@ -1,0 +1,75 @@
+from hermes_cli import agents_os
+from hermes_cli.agents_os import AgentsOSService, connect, resolve_paths, utc_now
+from hermes_cli.agents_os_seo import seo_mission_control_payload
+from hermes_cli.agents_os_web import mission_control_html
+
+
+import pytest
+
+
+@pytest.fixture()
+def agents_home(tmp_path, monkeypatch):
+    home = tmp_path / "hermes-home"
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setenv("AGENTS_OS_HOME", str(home / "agents_os"))
+    monkeypatch.setenv("AGENTS_OS_VAULT_ROOT", str(tmp_path / "vault"))
+    agents_os.main(["init", "--no-vault"])
+    return home
+
+
+def test_seo_payload_empty_state_is_safe_local(agents_home):
+    payload = seo_mission_control_payload(resolve_paths(None))
+
+    assert payload["local_only"] is True
+    assert payload["publish_enabled"] is False
+    assert payload["outreach_enabled"] is False
+    assert payload["credentials_required_for_live_metrics"] is True
+    assert payload["goals"] == []
+    assert payload["keyword_queue"] == []
+    assert payload["draft_queue"] == []
+    assert payload["review_gates"] == []
+    assert {"publish", "outreach", "credentials", "analytics"}.issubset(set(payload["approval_gates"]))
+
+
+def test_seo_payload_groups_local_tasks_and_artifacts(agents_home, tmp_path):
+    paths = resolve_paths(None)
+    goal = tmp_path / "goal.md"
+    keyword = tmp_path / "keywords.md"
+    draft = tmp_path / "draft.md"
+    review = tmp_path / "review.md"
+    for path in [goal, keyword, draft, review]:
+        path.write_text("# draft only\n\nNE OBJAVLJUJ\n", encoding="utf-8")
+
+    now = utc_now()
+    with connect(paths) as conn:
+        conn.execute(
+            "INSERT INTO tasks(id,title,status,workflow,priority,created_at,updated_at,notes,route,approval_required) VALUES(?,?,?,?,?,?,?,?,?,?)",
+            ("seo-task", "GoranMikac SEO Goal", "pending", "seo-goal", 2, now, now, "draft only", "local:direct", 0),
+        )
+        for artifact_id, kind, title, path, workflow in [
+            ("seo-goal-art", "seo_goal", "SEO Goal", goal, "seo-goal"),
+            ("keyword-art", "keyword_research", "Keyword Research", keyword, "keyword-research"),
+            ("draft-art", "seo_draft", "SEO Draft", draft, "seo-draft"),
+            ("review-art", "publish_gate", "Review Gate", review, "publish-gate"),
+        ]:
+            conn.execute(
+                "INSERT INTO artifacts(id,kind,title,path,task_id,workflow,created_at) VALUES(?,?,?,?,?,?,?)",
+                (artifact_id, kind, title, str(path), "seo-task", workflow, now),
+            )
+        conn.commit()
+
+    payload = seo_mission_control_payload(paths)
+
+    assert [item["id"] for item in payload["goals"]] == ["seo-task"]
+    assert [item["id"] for item in payload["keyword_queue"]] == ["keyword-art"]
+    assert [item["id"] for item in payload["draft_queue"]] == ["draft-art"]
+    assert [item["id"] for item in payload["review_gates"]] == ["review-art"]
+    assert payload["publish_enabled"] is False
+
+
+def test_mission_control_html_contains_seo_panel(agents_home):
+    html = mission_control_html(AgentsOSService(resolve_paths(None)))
+
+    assert "SEO Mission Control" in html
+    assert "/api/seo" in html
+    assert "publish disabled" in html.lower()

--- a/tests/hermes_cli/test_agents_os_web.py
+++ b/tests/hermes_cli/test_agents_os_web.py
@@ -13,6 +13,7 @@ from hermes_cli.agents_os_web import (
     jarvis_briefing_payload,
     jarvis_model_advisor_payload,
     jarvis_preview_payload,
+    jarvis_reply_payload,
     jarvis_transcribe_payload,
     knowledge_index_payload,
     media_assets_payload,
@@ -306,6 +307,44 @@ def test_jarvis_preview_gates_risky_commands_without_execution(agents_home):
     assert security["command_card"]["execution_created"] is False
 
 
+def test_jarvis_reply_stores_tts_audio_artifact_without_execution(agents_home):
+    paths = resolve_paths(None)
+
+    payload = jarvis_reply_payload(
+        paths,
+        {
+            "text": "Presuda. Rezultat. Sljedeći korak.",
+            "audio_base64": "SUQz",
+            "audio_mime": "audio/mpeg",
+            "provider": "hermes-tts",
+            "voice_reply_short": "Presuda. Rezultat. Sljedeći korak.",
+        },
+    )
+
+    assert payload["local_only"] is True
+    assert payload["execution_created"] is False
+    assert payload["status"] == "audio_ready"
+    assert payload["tts"]["provider"] == "hermes-tts"
+    assert payload["tts"]["fallback"] is False
+    assert Path(payload["audio_artifact_path"]).exists()
+    assert Path(payload["reply_artifact_path"]).exists()
+    assert "Presuda. Rezultat. Sljedeći korak." in Path(payload["reply_artifact_path"]).read_text(encoding="utf-8")
+
+
+def test_jarvis_reply_falls_back_to_text_only_without_audio(agents_home):
+    paths = resolve_paths(None)
+
+    payload = jarvis_reply_payload(paths, {"text": "Ovo treba odobrenje. Ništa ne izvršavam."})
+
+    assert payload["local_only"] is True
+    assert payload["execution_created"] is False
+    assert payload["status"] == "text_only"
+    assert payload["tts"]["provider"] == "text-only-fallback"
+    assert payload["tts"]["fallback"] is True
+    assert payload["audio_artifact_path"] is None
+    assert Path(payload["reply_artifact_path"]).exists()
+
+
 def test_root_html_contains_jarvis_oracle_briefing_panel(agents_home):
     service = AgentsOSService(resolve_paths(None))
     html = mission_control_html(service)
@@ -316,4 +355,6 @@ def test_root_html_contains_jarvis_oracle_briefing_panel(agents_home):
     assert "/api/jarvis/briefing" in html
     assert "/api/jarvis/transcribe" in html
     assert "/api/jarvis/preview" in html
+    assert "/api/jarvis/reply" in html
+    assert "Voice Reply" in html
     assert "wake/show/build/act" in html

--- a/tests/hermes_cli/test_agents_os_web.py
+++ b/tests/hermes_cli/test_agents_os_web.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 import pytest
 
-from hermes_cli import agents_os
+from hermes_cli import agents_os, agents_os_web
 from hermes_cli.agents_os import AgentsOSService, connect, log_event, resolve_paths, utc_now
 from hermes_cli.agents_os_web import (
     agents_registry_payload,
@@ -193,6 +193,39 @@ def test_jarvis_transcribe_uses_stt_adapter_when_transcript_missing(agents_home)
     assert payload["transcript"]["text"] == "Deployaj BP24"
     assert payload["command_card"]["risk_class"] == "public_gated"
     assert payload["command_card"]["approval_required"] is True
+
+
+def test_jarvis_transcribe_can_call_local_faster_whisper_adapter(agents_home, monkeypatch):
+    paths = resolve_paths(None)
+    seen = {}
+
+    def fake_transcribe(audio_path, *, model="base", language="hr"):
+        seen["audio_path"] = audio_path
+        seen["model"] = model
+        seen["language"] = language
+        return {"text": "Prikaži zadnje BP24 stanje", "provider": "local-faster-whisper", "confidence": 0.83, "language": "hr"}
+
+    monkeypatch.setattr(agents_os_web, "_transcribe_with_local_faster_whisper", fake_transcribe)
+
+    payload = jarvis_transcribe_payload(
+        paths,
+        {
+            "audio_base64": "UklGRg==",
+            "audio_mime": "audio/webm",
+            "use_local_stt": True,
+            "stt_model": "small",
+            "stt_language": "hr",
+        },
+    )
+
+    assert payload["execution_created"] is False
+    assert payload["stt"]["provider"] == "local-faster-whisper"
+    assert payload["stt"]["confidence"] == 0.83
+    assert payload["transcript"]["text"] == "Prikaži zadnje BP24 stanje"
+    assert payload["command_card"]["risk_class"] == "safe_local"
+    assert seen["audio_path"] == payload["audio_artifact_path"]
+    assert seen["model"] == "small"
+    assert seen["language"] == "hr"
 
 
 def test_jarvis_model_advisor_keeps_deterministic_gate_authoritative(agents_home):

--- a/tests/hermes_cli/test_agents_os_web.py
+++ b/tests/hermes_cli/test_agents_os_web.py
@@ -345,6 +345,30 @@ def test_jarvis_reply_falls_back_to_text_only_without_audio(agents_home):
     assert Path(payload["reply_artifact_path"]).exists()
 
 
+def test_jarvis_reply_can_prepare_hume_octave_request_draft_without_api_call(agents_home):
+    paths = resolve_paths(None)
+
+    payload = jarvis_reply_payload(
+        paths,
+        {
+            "text": "Presuda. Jarvis radi lokalno.",
+            "provider": "hume-octave",
+            "voice_description": "calm Croatian operator voice, concise and warm",
+            "format": "mp3",
+        },
+    )
+
+    assert payload["execution_created"] is False
+    assert payload["status"] == "provider_unconfigured"
+    assert payload["tts"]["provider"] == "hume-octave"
+    assert payload["tts"]["requires_api_key"] is True
+    assert payload["tts"]["api_called"] is False
+    assert payload["audio_artifact_path"] is None
+    assert payload["hume_octave_request"]["utterances"][0]["text"] == "Presuda. Jarvis radi lokalno."
+    assert payload["hume_octave_request"]["utterances"][0]["description"] == "calm Croatian operator voice, concise and warm"
+    assert payload["hume_octave_request"]["format"]["type"] == "mp3"
+
+
 def test_root_html_contains_jarvis_oracle_briefing_panel(agents_home):
     service = AgentsOSService(resolve_paths(None))
     html = mission_control_html(service)

--- a/tests/hermes_cli/test_agents_os_web.py
+++ b/tests/hermes_cli/test_agents_os_web.py
@@ -1,0 +1,156 @@
+import json
+import os
+from pathlib import Path
+
+import pytest
+
+from hermes_cli import agents_os
+from hermes_cli.agents_os import AgentsOSService, connect, log_event, resolve_paths, utc_now
+from hermes_cli.agents_os_web import (
+    agents_registry_payload,
+    artifacts_payload,
+    create_idea_action,
+    jarvis_briefing_payload,
+    knowledge_index_payload,
+    media_assets_payload,
+    mission_control_html,
+    redacted_manage_status_payload,
+    voice_status_payload,
+)
+
+
+@pytest.fixture()
+def agents_home(tmp_path, monkeypatch):
+    home = tmp_path / "hermes-home"
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setenv("AGENTS_OS_HOME", str(home / "agents_os"))
+    monkeypatch.setenv("AGENTS_OS_VAULT_ROOT", str(tmp_path / "vault"))
+    agents_os.main(["init", "--no-vault"])
+    return home
+
+
+def test_root_html_contains_operator_tabs_and_bootstrap_payload(agents_home):
+    service = AgentsOSService(resolve_paths(None))
+    html = mission_control_html(service)
+
+    assert "Agents OS Mission Control" in html
+    for label in [
+        "Idea Factory",
+        "Agent Registry",
+        "Knowledge Galaxy",
+        "Artifact Library",
+        "Operator Loop",
+        "Media Studio",
+        "Manage / Status",
+        "Voice / Jarvis",
+    ]:
+        assert label in html
+    assert "/api/idea-factory/draft" in html
+    assert "vault/reference graph, not runtime memory merge" in html
+
+
+def test_idea_factory_schema_and_draft_payloads_are_local_only(agents_home):
+    service = AgentsOSService(resolve_paths(None))
+
+    schema = service.idea_factory_schema_payload()
+    draft = service.idea_factory_draft_payload({"idea_text": "Pošalji email klijentu"})
+
+    assert schema["local_only"] is True
+    assert draft["approval_required"] is True
+    assert draft["risk_class"] == "public_gated"
+    assert draft["execution_created"] is False
+
+
+def test_create_idea_action_creates_safe_task_but_gates_public_action(agents_home):
+    service = AgentsOSService(resolve_paths(None))
+
+    safe = create_idea_action(service, {"idea_text": "Obradi YouTube video"})
+    gated = create_idea_action(service, {"idea_text": "Pošalji email klijentu"})
+
+    assert safe["mode"] == "safe_local_task"
+    assert safe["task_id"].startswith("task-")
+    assert safe["approval_id"] is None
+    assert gated["mode"] == "approval_draft"
+    assert gated["task_id"].startswith("task-")
+    assert gated["approval_id"].startswith("approval-")
+    assert gated["execution_created"] is False
+    with connect(resolve_paths(None)) as conn:
+        gated_task = conn.execute("SELECT * FROM tasks WHERE id=?", (gated["task_id"],)).fetchone()
+        approval = conn.execute("SELECT * FROM approvals WHERE id=?", (gated["approval_id"],)).fetchone()
+    assert gated_task["status"] == "needs_approval"
+    assert approval["status"] == "pending"
+
+
+def test_agent_registry_payload_includes_boundaries(agents_home):
+    payload = agents_registry_payload(resolve_paths(None))
+    ids = {agent["id"] for agent in payload["agents"]}
+
+    assert {"doni-local", "kodi-codex", "marija-profile", "ero-openclaw"}.issubset(ids)
+    doni = next(agent for agent in payload["agents"] if agent["id"] == "doni-local")
+    assert doni["memory_boundary"] == "Doni Hermes home only"
+    assert "gateway restart" in " ".join(doni["approval_gates"])
+
+
+def test_knowledge_index_is_non_empty_and_links_video_sources(agents_home, tmp_path, monkeypatch):
+    transcript = tmp_path / "q13OqknCh-c_transcript.txt"
+    transcript.write_text("Mission Control transcript", encoding="utf-8")
+    plan = tmp_path / "2026-06-08-agent-os-full-product-plan.md"
+    plan.write_text("# Full product plan", encoding="utf-8")
+    monkeypatch.setenv("AGENTS_OS_SOURCE_TRANSCRIPT", str(transcript))
+    monkeypatch.setenv("AGENTS_OS_SOURCE_FULL_PLAN", str(plan))
+
+    payload = knowledge_index_payload(resolve_paths(None))
+
+    assert payload["local_only"] is True
+    assert payload["runtime_memory_merge"] is False
+    assert payload["nodes"]
+    assert any(node["id"] == "video:q13OqknCh-c" for node in payload["nodes"])
+    assert any(edge["from"] == "video:q13OqknCh-c" for edge in payload["edges"])
+
+
+def test_artifacts_media_operator_manage_voice_payloads_are_redacted_and_read_only(agents_home, tmp_path):
+    paths = resolve_paths(None)
+    note = paths.artifacts / "smoke" / "note.md"
+    note.parent.mkdir(parents=True, exist_ok=True)
+    note.write_text("# smoke", encoding="utf-8")
+    image = paths.artifacts / "screenshots" / "shot.png"
+    image.parent.mkdir(parents=True, exist_ok=True)
+    image.write_bytes(b"\x89PNG\r\n\x1a\n")
+    with connect(paths) as conn:
+        conn.execute(
+            "INSERT INTO artifacts(id,kind,title,path,task_id,workflow,created_at) VALUES(?,?,?,?,?,?,?)",
+            ("artifact-test", "smoke_report", "Smoke", str(note), None, "qa-report", utc_now()),
+        )
+        log_event(conn, "judge_pending", payload={"reason": "not implemented"})
+        conn.commit()
+
+    artifacts = artifacts_payload(paths)
+    media = media_assets_payload(paths)
+    manage = redacted_manage_status_payload(paths)
+    voice = voice_status_payload(paths)
+    jarvis = jarvis_briefing_payload(paths)
+    operator = AgentsOSService(paths).operator_loop_payload()
+
+    assert artifacts["items"]
+    assert media["assets"]
+    assert manage["credentials_visible"] is False
+    assert "api_key" not in json.dumps(manage).lower()
+    assert voice["computer_control"] == "approval_gated_unexecuted"
+    assert jarvis["local_only"] is True
+    assert jarvis["execution_created"] is False
+    assert jarvis["always_on_microphone"] is False
+    assert jarvis["wake_word_enabled"] is False
+    assert jarvis["computer_control"] == "approval_gated_unexecuted"
+    assert {command["name"] for command in jarvis["commands"]} == {"wake", "show", "build", "act"}
+    assert jarvis["briefing"]["artifact_count"] >= 1
+    assert "cross_agent_memory_merge" in jarvis["approval_gates"]
+    assert operator["judge_status"] in {"pending", "ready"}
+
+
+def test_root_html_contains_jarvis_oracle_briefing_panel(agents_home):
+    service = AgentsOSService(resolve_paths(None))
+    html = mission_control_html(service)
+
+    assert "Jarvis / Oracle Briefing" in html
+    assert "/api/jarvis/briefing" in html
+    assert "wake/show/build/act" in html

--- a/tests/hermes_cli/test_agents_os_web.py
+++ b/tests/hermes_cli/test_agents_os_web.py
@@ -228,6 +228,37 @@ def test_jarvis_transcribe_can_call_local_faster_whisper_adapter(agents_home, mo
     assert seen["language"] == "hr"
 
 
+def test_jarvis_transcribe_accepts_minimax_cleanup_but_preserves_raw_risk(agents_home):
+    paths = resolve_paths(None)
+
+    payload = jarvis_transcribe_payload(
+        paths,
+        {
+            "audio_base64": "UklGRg==",
+            "audio_mime": "audio/webm",
+            "stt_result": {"text": "Deployaj BP24", "provider": "local-faster-whisper", "confidence": 0.91},
+            "model_result": {
+                "normalized_transcript": "Prikaži zadnje BP24 stanje",
+                "semantic_intent": "status lookup",
+                "risk_class": "safe_local",
+                "voice_reply_short": "Prikazujem status.",
+            },
+            "advisor_provider": "minimax",
+            "advisor_model": "MiniMax-M3",
+        },
+    )
+
+    assert payload["execution_created"] is False
+    assert payload["transcript"]["text"] == "Deployaj BP24"
+    assert payload["transcript"]["cleaned_text"] == "Prikaži zadnje BP24 stanje"
+    assert payload["advisor"]["provider"] == "minimax"
+    assert payload["advisor"]["model"] == "MiniMax-M3"
+    assert payload["advisor"]["risk_disagreement"] is True
+    assert payload["command_card"]["risk_class"] == "public_gated"
+    assert payload["command_card"]["approval_required"] is True
+    assert "Deployaj BP24" in payload["command_card"]["gate_text"]
+
+
 def test_jarvis_model_advisor_keeps_deterministic_gate_authoritative(agents_home):
     paths = resolve_paths(None)
     deterministic = jarvis_preview_payload(paths, {"transcript_text": "Deployaj BP24"})

--- a/tests/hermes_cli/test_agents_os_web.py
+++ b/tests/hermes_cli/test_agents_os_web.py
@@ -178,6 +178,7 @@ def test_jarvis_preview_gates_risky_commands_without_execution(agents_home):
     safe = jarvis_preview_payload(paths, {"transcript_text": "Prikaži zadnje BP24 stanje"})
     public = jarvis_preview_payload(paths, {"transcript_text": "Pošalji klijentu email"})
     deploy = jarvis_preview_payload(paths, {"transcript_text": "Deployaj BP24"})
+    security = jarvis_preview_payload(paths, {"transcript_text": "Pokreni sigurnosni scan klijentove stranice"})
 
     assert safe["command_card"]["risk_class"] == "safe_local"
     assert safe["command_card"]["approval_required"] is False
@@ -188,6 +189,9 @@ def test_jarvis_preview_gates_risky_commands_without_execution(agents_home):
     assert deploy["command_card"]["risk_class"] == "public_gated"
     assert deploy["command_card"]["approval_required"] is True
     assert deploy["command_card"]["execution_created"] is False
+    assert security["command_card"]["risk_class"] == "security_gated"
+    assert security["command_card"]["approval_required"] is True
+    assert security["command_card"]["execution_created"] is False
 
 
 def test_root_html_contains_jarvis_oracle_briefing_panel(agents_home):

--- a/tests/hermes_cli/test_agents_os_web.py
+++ b/tests/hermes_cli/test_agents_os_web.py
@@ -11,6 +11,7 @@ from hermes_cli.agents_os_web import (
     artifacts_payload,
     create_idea_action,
     jarvis_briefing_payload,
+    jarvis_model_advisor_payload,
     jarvis_preview_payload,
     jarvis_transcribe_payload,
     knowledge_index_payload,
@@ -164,12 +165,59 @@ def test_jarvis_transcribe_writes_local_artifacts_without_execution(agents_home)
     assert payload["local_only"] is True
     assert payload["execution_created"] is False
     assert payload["status"] == "transcribed"
+    assert payload["stt"]["provider"] == "provided_transcript"
+    assert payload["advisor"]["provider"] == "deterministic"
     assert payload["transcript"]["text"] == "Prikaži zadnje BP24 stanje"
     assert payload["intent_preview"]["risk_class"] == "safe_local"
     assert payload["intent_preview"]["approval_required"] is False
     assert Path(payload["audio_artifact_path"]).exists()
     assert Path(payload["transcript_artifact_path"]).exists()
     assert "Prikaži zadnje BP24 stanje" in Path(payload["transcript_artifact_path"]).read_text(encoding="utf-8")
+
+
+def test_jarvis_transcribe_uses_stt_adapter_when_transcript_missing(agents_home):
+    paths = resolve_paths(None)
+
+    payload = jarvis_transcribe_payload(
+        paths,
+        {
+            "audio_base64": "UklGRg==",
+            "audio_mime": "audio/webm",
+            "stt_result": {"text": "Deployaj BP24", "provider": "local-faster-whisper", "confidence": 0.91},
+        },
+    )
+
+    assert payload["execution_created"] is False
+    assert payload["stt"]["provider"] == "local-faster-whisper"
+    assert payload["stt"]["confidence"] == 0.91
+    assert payload["transcript"]["text"] == "Deployaj BP24"
+    assert payload["command_card"]["risk_class"] == "public_gated"
+    assert payload["command_card"]["approval_required"] is True
+
+
+def test_jarvis_model_advisor_keeps_deterministic_gate_authoritative(agents_home):
+    paths = resolve_paths(None)
+    deterministic = jarvis_preview_payload(paths, {"transcript_text": "Deployaj BP24"})
+
+    payload = jarvis_model_advisor_payload(
+        paths,
+        {
+            "transcript_text": "Deployaj BP24",
+            "deterministic_preview": deterministic,
+            "model_result": {"semantic_intent": "deploy production", "risk_class": "safe_local", "voice_reply_short": "Mogu deployati."},
+            "provider": "minimax",
+            "model": "MiniMax-M3",
+        },
+    )
+
+    assert payload["execution_created"] is False
+    assert payload["provider"] == "minimax"
+    assert payload["model"] == "MiniMax-M3"
+    assert payload["authoritative_risk_class"] == "public_gated"
+    assert payload["model_risk_class"] == "safe_local"
+    assert payload["risk_disagreement"] is True
+    assert payload["command_card"]["risk_class"] == "public_gated"
+    assert payload["command_card"]["approval_required"] is True
 
 
 def test_jarvis_preview_gates_risky_commands_without_execution(agents_home):

--- a/tests/hermes_cli/test_agents_os_web.py
+++ b/tests/hermes_cli/test_agents_os_web.py
@@ -11,6 +11,8 @@ from hermes_cli.agents_os_web import (
     artifacts_payload,
     create_idea_action,
     jarvis_briefing_payload,
+    jarvis_preview_payload,
+    jarvis_transcribe_payload,
     knowledge_index_payload,
     media_assets_payload,
     mission_control_html,
@@ -147,10 +149,55 @@ def test_artifacts_media_operator_manage_voice_payloads_are_redacted_and_read_on
     assert operator["judge_status"] in {"pending", "ready"}
 
 
+def test_jarvis_transcribe_writes_local_artifacts_without_execution(agents_home):
+    paths = resolve_paths(None)
+
+    payload = jarvis_transcribe_payload(
+        paths,
+        {
+            "audio_base64": "UklGRg==",
+            "audio_mime": "audio/webm",
+            "transcript_text": "Prikaži zadnje BP24 stanje",
+        },
+    )
+
+    assert payload["local_only"] is True
+    assert payload["execution_created"] is False
+    assert payload["status"] == "transcribed"
+    assert payload["transcript"]["text"] == "Prikaži zadnje BP24 stanje"
+    assert payload["intent_preview"]["risk_class"] == "safe_local"
+    assert payload["intent_preview"]["approval_required"] is False
+    assert Path(payload["audio_artifact_path"]).exists()
+    assert Path(payload["transcript_artifact_path"]).exists()
+    assert "Prikaži zadnje BP24 stanje" in Path(payload["transcript_artifact_path"]).read_text(encoding="utf-8")
+
+
+def test_jarvis_preview_gates_risky_commands_without_execution(agents_home):
+    paths = resolve_paths(None)
+
+    safe = jarvis_preview_payload(paths, {"transcript_text": "Prikaži zadnje BP24 stanje"})
+    public = jarvis_preview_payload(paths, {"transcript_text": "Pošalji klijentu email"})
+    deploy = jarvis_preview_payload(paths, {"transcript_text": "Deployaj BP24"})
+
+    assert safe["command_card"]["risk_class"] == "safe_local"
+    assert safe["command_card"]["approval_required"] is False
+    assert safe["command_card"]["execution_created"] is False
+    assert public["command_card"]["risk_class"] == "public_gated"
+    assert public["command_card"]["approval_required"] is True
+    assert public["command_card"]["execution_created"] is False
+    assert deploy["command_card"]["risk_class"] == "public_gated"
+    assert deploy["command_card"]["approval_required"] is True
+    assert deploy["command_card"]["execution_created"] is False
+
+
 def test_root_html_contains_jarvis_oracle_briefing_panel(agents_home):
     service = AgentsOSService(resolve_paths(None))
     html = mission_control_html(service)
 
     assert "Jarvis / Oracle Briefing" in html
+    assert "Record command" in html
+    assert "Command Preview" in html
     assert "/api/jarvis/briefing" in html
+    assert "/api/jarvis/transcribe" in html
+    assert "/api/jarvis/preview" in html
     assert "wake/show/build/act" in html


### PR DESCRIPTION
## Summary

Adds Jarvis voice-reply / STT advisor / TTS draft contracts, Mission Control Jarvis + SEO panels, agents-os web dashboard, and idea-factory draft classifier. All hardcoded user paths and vendor-specific identifiers have been removed in a follow-up neutralisation commit on top of the same branch.

## Scope (PR2 of 3)

- `hermes_cli/agents_os_idea_factory.py` — deterministic draft classifier (idea -> risk class + plan steps)
- `hermes_cli/agents_os_seo.py` — SEO Mission Control payload builder
- `hermes_cli/agents_os_web.py` — local-only HTTP server (127.0.0.1) + embedded HTML dashboard
- `hermes_cli/web_server.py` — shared web server helpers
- `scripts/launch_agents_os_mission_control.sh` — launcher
- Jarvis STT/TTS contracts (Hume Octave TTS draft, Jarvis voice reply, transcript cleanup, local STT adapter, STT advisor boundary, security scan previews, command preview scaffold)
- Mission Control Jarvis + SEO panels
- Test suites for idea-factory / SEO / web

## Neutralisation (follow-up commit `4e33302ed` on this branch)

- `SOURCE_DEFAULTS` / `SOURCE_ENV`: replaced concrete `/mnt/d/.../Hermes-Agent-Doni/...` paths with `AGENTS_OS_SOURCE_VAULT` / `AGENTS_OS_SOURCE_TRANSCRIPTS` env placeholders. Operators wire real paths at deploy time.
- `_default_agent_cards`: renamed Doni Local -> Primary agent, Kodi/Codex -> Coding delegate, Marija profile -> Peer profile, ERO/OpenClaw -> External runtime. Dropped absolute `/home/goran` and `/mnt/d/` paths; peer / external cards now show `<configured at deploy>` placeholders.
- `_classify`: dropped `doni dashboard` keyword in favour of `agents os dashboard`.
- `_plan_for` gated branch: dropped operator name (`Goranovo odobrenje`) -> `odobrenje operatera`.
- HTML mission-control header: `Local-only Doni operator cockpit` -> `Local-only operator cockpit`.

## Safety

- All paths still resolve from the active Hermes home (`get_hermes_home()`)
- No credentials, no API keys, no network calls in any new code path
- Mission Control is local-only (127.0.0.1); no deploys, no gateway restart
- Agent cards are profile-agnostic; peer / external home paths are now deploy-time config

## Supersedes

Follow-up to #42341 (AgentOS architecture thread). Sits between #48040 (PR1 control plane) and #48041 (PR3 wiki helpers).

🤖 Generated with Hermes Agent