### PR TITLE
fix(gateway): guard shared-audience chats against owner/backend leaks

### DIFF
--- a/gateway/session.py
+++ b/gateway/session.py
@@ -374,6 +374,46 @@ def build_session_context_prompt(
             uid = _hash_sender_id(uid)
         lines.append(f"**User ID:** {uid}")
 
+    # Shared-audience confidentiality guard.
+    #
+    # A non-DM chat (group/channel/thread, or any session flagged as shared
+    # multi-user) is read by EVERY participant, not just the owner. Owner-only
+    # operational detail must never default to such a chat just because the
+    # triggering command happened to arrive there. This block is cache-stable
+    # (no per-turn data) so it does not bust the prompt cache.
+    #
+    # Gated on the audience being multi-person rather than on the per-user
+    # isolation knob: a group with group_sessions_per_user=True still posts
+    # every reply to the shared channel, so the audience is shared regardless.
+    _is_dm = context.source.chat_type == "dm"
+    _multi_person_audience = (
+        context.source.platform != Platform.LOCAL
+        and not _is_dm
+        and (
+            context.shared_multi_user_session
+            or context.source.chat_type in ("group", "channel", "thread")
+            or bool(context.source.thread_id)
+        )
+    )
+    if _multi_person_audience:
+        lines.append("")
+        lines.append(
+            "**Shared audience — confidentiality:** This chat is read by every "
+            "participant, NOT just the owner. Treat it as a public, non-owner "
+            "audience. Do NOT post owner-private or backend-internal detail here, "
+            "even when an authorized owner command triggered the work. Never "
+            "reveal in this chat: agent/infrastructure internals (config files, "
+            ".env, allowlists, bridges, session/silo/memory mechanics, gateway "
+            "restart/drain behavior, IDs/LIDs, internal tooling), or other "
+            "people's personal data (phone numbers or fragments, the names "
+            "behind those numbers, contact mappings). When an owner asks for an "
+            "administrative/backend action from inside a shared chat, perform it "
+            "and send the detailed operational report to the OWNER's private "
+            "channel (DM / the owner's home channel) — post at most a brief, "
+            "neutral acknowledgement to the shared chat, or nothing. When in "
+            "doubt about whether a detail is owner-private, route it privately."
+        )
+
     # Platform-specific behavioral notes
     if context.source.platform == Platform.SLACK:
         lines.append("")

--- a/tests/gateway/test_session.py
+++ b/tests/gateway/test_session.py
@@ -430,6 +430,104 @@ class TestBuildSessionContextPrompt:
         assert "Multi-user thread" not in prompt
 
 
+class TestSharedAudienceConfidentialityGuard:
+    """The session-context prompt must warn against leaking owner-private /
+    backend-internal detail into any multi-person (non-DM) audience.
+
+    Regression for the ProgramaLoL incident: an owner-authorized onboarding
+    command issued from inside a WhatsApp group caused the agent to post
+    backend internals (allowlists, bridges, silos, LIDs) and other members'
+    phone fragments + names into the shared group. The guard is a behavior
+    contract — assert the invariant ("present iff multi-person audience"),
+    not the exact wording.
+    """
+
+    _MARKER = "Shared audience — confidentiality"
+
+    def _prompt(self, source, **config_kwargs):
+        config = GatewayConfig(
+            platforms={Platform.TELEGRAM: PlatformConfig(enabled=True, token="fake")},
+            **config_kwargs,
+        )
+        return build_session_context_prompt(build_session_context(source, config))
+
+    def test_group_audience_gets_confidentiality_guard(self):
+        source = SessionSource(
+            platform=Platform.TELEGRAM,
+            chat_id="-100222",
+            chat_name="ProgramaLoL",
+            chat_type="group",
+            user_name="Alice",
+        )
+        prompt = self._prompt(source)
+        assert self._MARKER in prompt
+        # The actionable instruction: route owner/backend detail privately.
+        assert "private channel" in prompt
+        assert "owner-private" in prompt or "backend-internal" in prompt
+
+    def test_per_user_isolated_group_still_gets_guard(self):
+        """Incident config: group_sessions_per_user=True isolates per user but
+        every reply still lands in the shared channel, so the guard MUST fire."""
+        source = SessionSource(
+            platform=Platform.TELEGRAM,
+            chat_id="-100222",
+            chat_name="ProgramaLoL",
+            chat_type="group",
+            user_name="Alice",
+        )
+        prompt = self._prompt(source, group_sessions_per_user=True)
+        assert self._MARKER in prompt
+
+    def test_shared_group_gets_guard(self):
+        source = SessionSource(
+            platform=Platform.TELEGRAM,
+            chat_id="-100222",
+            chat_name="ProgramaLoL",
+            chat_type="group",
+            user_name="Alice",
+        )
+        prompt = self._prompt(source, group_sessions_per_user=False)
+        assert self._MARKER in prompt
+
+    def test_thread_audience_gets_guard(self):
+        source = SessionSource(
+            platform=Platform.TELEGRAM,
+            chat_id="-100222",
+            chat_name="Test Group",
+            chat_type="group",
+            thread_id="17585",
+            user_name="Alice",
+        )
+        prompt = self._prompt(source)
+        assert self._MARKER in prompt
+
+    def test_channel_audience_gets_guard(self):
+        source = SessionSource(
+            platform=Platform.TELEGRAM,
+            chat_id="-100333",
+            chat_name="Announcements",
+            chat_type="channel",
+        )
+        prompt = self._prompt(source)
+        assert self._MARKER in prompt
+
+    def test_dm_is_exempt(self):
+        """A 1:1 DM is owner-private by nature; no shared-audience warning."""
+        source = SessionSource(
+            platform=Platform.TELEGRAM,
+            chat_id="111",
+            chat_type="dm",
+            user_name="Owner",
+        )
+        prompt = self._prompt(source)
+        assert self._MARKER not in prompt
+
+    def test_local_cli_is_exempt(self):
+        source = SessionSource(platform=Platform.LOCAL, chat_id="cli", chat_type="dm")
+        prompt = self._prompt(source)
+        assert self._MARKER not in prompt
+
+
 class TestSenderPrefixWithBackfill:
     """Regression: sender prefix must not wrap the backfill context block.
 
@@ -788,6 +886,39 @@ class TestWhatsAppSessionKeyConsistency:
         assert first_entry.session_key == "agent:main:discord:group:guild-123"
         assert second_entry.session_key == "agent:main:discord:group:guild-123"
         assert first_entry.session_id == second_entry.session_id
+
+    def test_shared_group_two_users_share_one_coherent_session(self, store):
+        """ProgramaLoL incident — coherence half.
+
+        With group_sessions_per_user=False, two DIFFERENT humans posting to the
+        same group must resolve to ONE session_id so the agent keeps a single
+        coherent context. The incident showed the failure mode: one user's run
+        held the onboarding context while a second user's separate shard had
+        none and contradicted it ("no traigo contexto de qué son esos IDs").
+        Locking this invariant prevents that split-brain from returning via a
+        default flip.
+        """
+        store.config.group_sessions_per_user = False
+        aldo = SessionSource(
+            platform=Platform.WHATSAPP,
+            chat_id="120363@g.us",
+            chat_type="group",
+            user_id="96370627199010@lid",
+            user_name="Aldo",
+        )
+        necro = SessionSource(
+            platform=Platform.WHATSAPP,
+            chat_id="120363@g.us",
+            chat_type="group",
+            user_id="74831349469423@lid",
+            user_name="Necro",
+        )
+        aldo_entry = store.get_or_create_session(aldo)
+        necro_entry = store.get_or_create_session(necro)
+
+        # Same group → same key → same single coherent session.
+        assert aldo_entry.session_key == necro_entry.session_key
+        assert aldo_entry.session_id == necro_entry.session_id
 
     def test_telegram_dm_includes_chat_id(self):
         """Non-WhatsApp DMs should also include chat_id to separate users."""


### PR DESCRIPTION
## What

Adds a cache-stable **"Shared audience — confidentiality"** block to the gateway session-context system prompt for any non-DM (multi-person) audience — group, channel, thread, or any session flagged `shared_multi_user_session`.

## Why

A gateway session prompt tells the agent *who* is speaking but nothing about *who else can read the chat*. When an authorized owner issues an administrative/backend command from inside a **group**, the agent's natural completion is to post its full operational debrief back to the origin — which is the group — exposing it to every member.

Observed failure: an owner onboarding command sent in a WhatsApp group caused the agent to post backend internals (allowlists, the bridge, session/silo mechanics, LIDs, gateway restart behavior) **and other members' phone fragments + the names behind them** into the shared group. The completion defaulted to origin routing because nothing in the prompt marked the group as a shared, non-owner audience.

## How

`build_session_context_prompt()` now emits a confidentiality block when the audience is multi-person. It is gated on the **audience shape** (group/channel/thread or the shared-session flag), not on the `group_sessions_per_user` knob — because a per-user-isolated group still posts every reply to the shared channel, so the audience is shared regardless. The block instructs the agent to route owner-private / backend-internal detail to the owner's private channel and post at most a neutral acknowledgement to the shared chat.

The block carries no per-turn data, so it does not bust the per-conversation prompt cache.

## How to test

```
pytest tests/gateway/test_session.py -q   # 87 passed
```

New `TestSharedAudienceConfidentialityGuard`: the block fires for group / channel / thread audiences (including a per-user-isolated group), and is **absent** for a 1:1 DM and for the local CLI. Assertions are on the invariant ("present iff multi-person audience"), not exact wording.

## Platforms tested

Linux. The change is platform-agnostic (applies to every gateway platform via the shared session-context builder).
