### PR TITLE
fix(gateway): consume was_auto_reset flag to prevent model-override wipe after auto-reset

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -8375,7 +8375,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     self._record_telegram_topic_binding(source, session_entry)
                 except Exception:
                     logger.debug("Failed to record Telegram topic binding", exc_info=True)
-        if getattr(session_entry, "was_auto_reset", False):
+        # Capture and immediately consume was_auto_reset so it does not
+        # re-fire on subsequent messages — preventing the cleanup from
+        # wiping model/reasoning overrides set between turns (Closes #48031).
+        _was_auto_reset = getattr(session_entry, "was_auto_reset", False)
+        if _was_auto_reset:
             # Treat auto-reset as a full conversation boundary — drop every
             # session-scoped transient state so the fresh session does not
             # inherit the previous conversation's model/reasoning overrides
@@ -8384,11 +8388,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             self._set_session_reasoning_override(session_key, None)
             if hasattr(self, "_pending_model_notes"):
                 self._pending_model_notes.pop(session_key, None)
+            session_entry.was_auto_reset = False
         
         # Emit session:start for new or auto-reset sessions
         _is_new_session = (
             session_entry.created_at == session_entry.updated_at
-            or getattr(session_entry, "was_auto_reset", False)
+            or _was_auto_reset
             or getattr(session_entry, "is_fresh_reset", False)
         )
         # Consume the is_fresh_reset flag immediately so it doesn't leak
@@ -8424,7 +8429,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         
         # If the previous session expired and was auto-reset, prepend a notice
         # so the agent knows this is a fresh conversation (not an intentional /reset).
-        if getattr(session_entry, 'was_auto_reset', False):
+        if _was_auto_reset:
             reset_reason = getattr(session_entry, 'auto_reset_reason', None) or 'idle'
             if reset_reason == "suspended":
                 context_note = "[System note: The user's previous session was stopped and suspended. This is a fresh conversation with no prior context.]"

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -1331,6 +1331,11 @@ class GatewaySlashCommandsMixin:
             if _sess_db is not None:
                 try:
                     _sess_entry = self.session_store.get_or_create_session(source)
+                    # If this session was auto-reset, consume the flag so the
+                    # next regular message's cleanup does not wipe the model
+                    # override just stored below (Closes #48031).
+                    if getattr(_sess_entry, "was_auto_reset", False):
+                        _sess_entry.was_auto_reset = False
                     _sess_db.update_session_model(
                         _sess_entry.session_id, result.new_model
                     )


### PR DESCRIPTION
## Problem

`/model <name>` switch is silently lost when it's the first message after a session auto-reset. The session DB shows the new model, the UI says the new model, but actual API calls use the previous/default model.

## Root Cause

`/model` commands are handled by `_handle_model_command()` which returns directly without entering `_handle_message_with_agent()`, where `was_auto_reset` is normally consumed. The next regular message finds `was_auto_reset` still `True` and the cleanup at line 8378 wipes `_session_model_overrides`, silently losing the model override set by `/model`.

## Fix

**Two-part fix:**

1. **`_handle_message_with_agent()` (run.py):** Capture `was_auto_reset` into a local variable and consume the flag immediately after the cleanup block so subsequent messages in the same auto-reset session don't re-fire the cleanup.

2. **`_handle_model_command()` (slash_commands.py):** Consume `was_auto_reset` on the session entry obtained from `get_or_create_session()` so that even when the command bypasses `_handle_message_with_agent()`, the flag is cleared before the next regular message arrives.

## Verification

- `was_auto_reset` consumed immediately after cleanup prevents re-fire
- `_is_new_session` and context notice still work (use saved local variable)
- `/model X` as first message after auto-reset now works correctly

Closes #48031