### PR TITLE
Restore gateway final completion sentinel

### DIFF
--- a/gateway/final_sentinel.py
+++ b/gateway/final_sentinel.py
@@ -1,0 +1,72 @@
+"""Gateway final-message sentinel helpers.
+
+The sentinel is user-facing completion clarity for Telegram/Discord gateway
+turns. It is intentionally separate from runtime telemetry/footer handling and
+from model-generated response text.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+FINAL_MESSAGE_SENTINEL = "COMPLETE"
+SUPPORTED_FINAL_SENTINEL_PLATFORMS = {"telegram", "discord"}
+
+
+def platform_name(platform: Any) -> str:
+    """Normalize a Platform enum / raw platform value to lowercase text."""
+    value = getattr(platform, "value", platform)
+    return str(value or "").lower()
+
+
+def is_final_sentinel_platform(platform: Any) -> bool:
+    """Return True when this platform should receive final sentinels."""
+    return platform_name(platform) in SUPPORTED_FINAL_SENTINEL_PLATFORMS
+
+
+def strip_trailing_final_sentinel(text: str) -> str:
+    """Remove a model-produced trailing standalone sentinel if present.
+
+    The durable marker is sent by the gateway as a separate message. If the
+    model includes a final standalone COMPLETE line, strip it from the body so
+    the user does not see duplicates or a marker buried in the main response.
+    """
+    if not isinstance(text, str) or not text:
+        return text
+
+    lines = text.rstrip().splitlines()
+    if not lines:
+        return ""
+    if lines[-1].strip() != FINAL_MESSAGE_SENTINEL:
+        return text
+    return "\n".join(lines[:-1]).rstrip()
+
+
+def should_send_final_sentinel(
+    *,
+    platform: Any,
+    message_type: Any = None,
+    response_delivered: bool = False,
+    is_ephemeral_response: bool = False,
+    failed: bool = False,
+    suppressed_or_stale: bool = False,
+) -> bool:
+    """Return True when a gateway turn should emit standalone COMPLETE.
+
+    Gate out non-user-facing/system-ish paths. The caller must only pass
+    response_delivered=True after the main visible response has actually been
+    delivered (normal path) or was confirmed delivered by streaming.
+    """
+    if not is_final_sentinel_platform(platform):
+        return False
+    if not response_delivered:
+        return False
+    if failed or suppressed_or_stale or is_ephemeral_response:
+        return False
+
+    message_type_value = getattr(message_type, "value", message_type)
+    if str(message_type_value or "").lower() == "command":
+        return False
+
+    return True

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -491,6 +491,11 @@ from pathlib import Path as _Path
 sys.path.insert(0, str(_Path(__file__).resolve().parents[2]))
 
 from gateway.config import Platform, PlatformConfig
+from gateway.final_sentinel import (
+    FINAL_MESSAGE_SENTINEL,
+    should_send_final_sentinel,
+    strip_trailing_final_sentinel,
+)
 from gateway.session import SessionSource, build_session_key
 from hermes_constants import get_default_hermes_root, get_hermes_dir, get_hermes_home
 
@@ -4219,6 +4224,8 @@ class BasePlatformAdapter(ABC):
                     session_key,
                 )
                 response = None
+            if response:
+                response = strip_trailing_final_sentinel(response)
             if not response:
                 logger.debug("[%s] Handler returned empty/None response for %s", self.name, event.source.chat_id)
             if response:
@@ -4479,6 +4486,25 @@ class BasePlatformAdapter(ABC):
                         "for %s (empty after extract, recovery yielded nothing).",
                         self.name, len(_response_pre_extract), event.source.chat_id,
                     )
+
+                # Send the standalone completion marker after the main visible
+                # response has been delivered. This is gateway-side user-facing
+                # completion clarity for Telegram/Discord, not model text and
+                # not runtime/footer telemetry.
+                if should_send_final_sentinel(
+                    platform=self.platform,
+                    message_type=event.message_type,
+                    response_delivered=delivery_succeeded,
+                    is_ephemeral_response=is_ephemeral_response,
+                ):
+                    try:
+                        await self._send_with_retry(
+                            chat_id=event.source.chat_id,
+                            content=FINAL_MESSAGE_SENTINEL,
+                            metadata=_thread_metadata,
+                        )
+                    except Exception as _sentinel_err:
+                        logger.debug("[%s] final sentinel send failed: %s", self.name, _sentinel_err)
 
             # Determine overall success for the processing hook
             processing_ok = delivery_succeeded if delivery_attempted else not bool(response)

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -54,6 +54,11 @@ from typing import Dict, Optional, Any, List, Union
 from agent.account_usage import fetch_account_usage, render_account_usage_lines
 from agent.async_utils import safe_schedule_threadsafe
 from agent.i18n import t
+from gateway.final_sentinel import (
+    FINAL_MESSAGE_SENTINEL,
+    should_send_final_sentinel,
+    strip_trailing_final_sentinel,
+)
 from hermes_cli.config import cfg_get
 from hermes_cli.fallback_config import get_fallback_chain
 
@@ -9103,6 +9108,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     agent_result, response, history_len=len(history),
                 )
                 response = _sanitize_gateway_final_response(source.platform, response)
+                if response:
+                    response = strip_trailing_final_sentinel(response)
 
             # Ordering contract: the agent thread already updated the contextvar
             # in conversation_compression.py; propagate to SessionEntry + _save().
@@ -9470,6 +9477,22 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                             )
                     except Exception as _e:
                         logger.debug("trailing footer send failed: %s", _e)
+                if should_send_final_sentinel(
+                    platform=source.platform,
+                    message_type=getattr(event, "message_type", None),
+                    response_delivered=True,
+                    failed=bool(agent_result.get("failed")),
+                ):
+                    try:
+                        _sentinel_adapter = self.adapters.get(source.platform)
+                        if _sentinel_adapter:
+                            await _sentinel_adapter.send(
+                                source.chat_id,
+                                FINAL_MESSAGE_SENTINEL,
+                                metadata=self._thread_metadata_for_source(source, self._reply_anchor_for_event(event)),
+                            )
+                    except Exception as _e:
+                        logger.debug("final sentinel send failed: %s", _e)
                 return None
 
             return response

--- a/tests/gateway/test_final_message_sentinel.py
+++ b/tests/gateway/test_final_message_sentinel.py
@@ -1,0 +1,110 @@
+import pytest
+
+from gateway.config import Platform, PlatformConfig
+from gateway.final_sentinel import (
+    FINAL_MESSAGE_SENTINEL,
+    should_send_final_sentinel,
+    strip_trailing_final_sentinel,
+)
+from gateway.platforms.base import BasePlatformAdapter, MessageEvent, MessageType, SendResult
+from gateway.session import SessionSource
+
+
+class _SentinelAdapter(BasePlatformAdapter):
+    def __init__(self, platform: Platform):
+        super().__init__(PlatformConfig(enabled=True, token="test"), platform)
+        self.sent: list[tuple[str, str]] = []
+
+    async def connect(self):
+        return True
+
+    async def disconnect(self):
+        pass
+
+    async def send(self, chat_id, content, reply_to=None, metadata=None):
+        self.sent.append((chat_id, content))
+        return SendResult(success=True, message_id=str(len(self.sent)))
+
+    async def get_chat_info(self, chat_id):
+        return {}
+
+
+def _event(platform: Platform, *, message_type: MessageType = MessageType.TEXT) -> MessageEvent:
+    return MessageEvent(
+        text="hello",
+        message_type=message_type,
+        source=SessionSource(platform=platform, chat_id="chat-1", chat_type="dm"),
+    )
+
+
+async def _run_background(adapter: _SentinelAdapter, event: MessageEvent, response: str) -> None:
+    async def _handler(_event):
+        return response
+
+    adapter._message_handler = _handler
+    await adapter._process_message_background(event, "telegram:chat-1")
+
+
+@pytest.mark.asyncio
+async def test_telegram_normal_response_sends_standalone_complete():
+    adapter = _SentinelAdapter(Platform.TELEGRAM)
+
+    await _run_background(adapter, _event(Platform.TELEGRAM), "main response")
+
+    assert [content for _, content in adapter.sent] == ["main response", FINAL_MESSAGE_SENTINEL]
+
+
+@pytest.mark.asyncio
+async def test_discord_normal_response_sends_standalone_complete():
+    adapter = _SentinelAdapter(Platform.DISCORD)
+
+    await _run_background(adapter, _event(Platform.DISCORD), "main response")
+
+    assert [content for _, content in adapter.sent] == ["main response", FINAL_MESSAGE_SENTINEL]
+
+
+@pytest.mark.asyncio
+async def test_non_target_platform_does_not_send_complete():
+    adapter = _SentinelAdapter(Platform.SLACK)
+
+    await _run_background(adapter, _event(Platform.SLACK), "main response")
+
+    assert [content for _, content in adapter.sent] == ["main response"]
+
+
+@pytest.mark.asyncio
+async def test_command_response_does_not_send_complete():
+    adapter = _SentinelAdapter(Platform.TELEGRAM)
+
+    await _run_background(
+        adapter,
+        _event(Platform.TELEGRAM, message_type=MessageType.COMMAND),
+        "system command response",
+    )
+
+    assert [content for _, content in adapter.sent] == ["system command response"]
+
+
+def test_helper_strips_model_body_complete_line():
+    assert strip_trailing_final_sentinel("Answer\n\nCOMPLETE") == "Answer"
+    assert strip_trailing_final_sentinel("Answer\nCOMPLETE\n") == "Answer"
+    assert strip_trailing_final_sentinel("Answer COMPLETE") == "Answer COMPLETE"
+
+
+def test_helper_gates_failed_or_undelivered_turns():
+    assert should_send_final_sentinel(
+        platform=Platform.TELEGRAM,
+        message_type=MessageType.TEXT,
+        response_delivered=True,
+    )
+    assert not should_send_final_sentinel(
+        platform=Platform.TELEGRAM,
+        message_type=MessageType.TEXT,
+        response_delivered=False,
+    )
+    assert not should_send_final_sentinel(
+        platform=Platform.TELEGRAM,
+        message_type=MessageType.TEXT,
+        response_delivered=True,
+        failed=True,
+    )


### PR DESCRIPTION
## Summary

Restores a gateway-side final completion sentinel for platform responses. The current source did not have an active helper/path for sending a standalone completion marker after the visible response, so completion signaling could drift from the actual response delivery path.

## Files changed

- `gateway/final_sentinel.py`
  - Adds a centralized helper for the final sentinel text, platform gating, and duplicate-body stripping.
- `gateway/platforms/base.py`
  - Sends the standalone completion marker after successful normal Telegram/Discord response delivery.
- `gateway/run.py`
  - Sends the standalone completion marker for streamed/already-sent response paths after media/footer handling.
- `tests/gateway/test_final_message_sentinel.py`
  - Adds focused coverage for supported platforms, unsupported platforms, command gating, duplicate stripping, and failed delivery.

## Validation

- `python -m py_compile gateway/final_sentinel.py gateway/platforms/base.py gateway/run.py tests/gateway/test_final_message_sentinel.py`
- `python -m pytest tests/gateway/test_final_message_sentinel.py -q` — 6 passed
- `python -m pytest tests/gateway/test_stream_consumer_draft.py tests/gateway/test_pending_drain_race.py -q` — 21 passed
- `git diff --check` — pass

## Safety notes

- No deploy or gateway restart is required by this change.
- The sentinel is sent as a separate platform message, not bundled into the runtime footer.
- The change applies to both normal response delivery and streamed/already-sent response paths.
- A model-produced trailing standalone `COMPLETE` is stripped from the response body before delivery to avoid duplicate visible body text.
- This does not change unrelated registry, dashboard, or lifecycle-state wiring.