### PR TITLE
Add Claude Code worker tool

### DIFF
--- a/tests/tools/test_claude_code_tool.py
+++ b/tests/tools/test_claude_code_tool.py
@@ -19,6 +19,15 @@ def hermes_home(tmp_path, monkeypatch):
 @pytest.fixture
 def fake_claude(monkeypatch):
     monkeypatch.setattr(cct, "_find_claude_binary", lambda: "/usr/bin/claude")
+    monkeypatch.setattr(
+        cct,
+        "_collect_claude_metadata",
+        lambda claude_bin: {
+            "claude_path": claude_bin,
+            "claude_version": "claude test-version",
+            "claude_version_error": None,
+        },
+    )
 
 
 REQUIRED_RESULT_KEYS = {
@@ -31,6 +40,8 @@ REQUIRED_RESULT_KEYS = {
     "stderr_path",
     "metadata_path",
     "expected_artifact_exists",
+    "expected_artifact_existed_before",
+    "success_basis",
     "error",
 }
 
@@ -67,6 +78,7 @@ def test_constructs_expected_command_and_writes_proof_artifacts(tmp_path, hermes
     assert kwargs["shell"] is False
     assert kwargs["cwd"] == str(workdir.resolve())
     assert kwargs["timeout"] == 10
+    assert set(kwargs["env"]) <= getattr(cct, "ENV_ALLOWLIST")
     assert run.call_args.args[0] == [
         "/usr/bin/claude",
         "-p",
@@ -91,6 +103,14 @@ def test_constructs_expected_command_and_writes_proof_artifacts(tmp_path, hermes
     assert metadata["timeout"] == 10
     assert metadata["max_turns"] == 3
     assert metadata["permission_mode"] == "default"
+    assert metadata["success_basis"] == "process_exit_zero_unverified"
+    assert metadata["process_success"] is True
+    assert metadata["task_success"] is True
+    assert metadata["claude_path"] == "/usr/bin/claude"
+    assert metadata["claude_version"] == "claude test-version"
+    assert metadata["full_output_artifacts"] is True
+    assert metadata["capture_memory_bound"] is True
+    assert metadata["artifact_persistence_bound"] is True
     assert metadata["stdout_path"] == str(stdout_path)
     assert metadata["stderr_path"] == str(stderr_path)
 
@@ -165,6 +185,7 @@ def test_plan_mode_uses_safe_prompt_prefix_and_permission_flag(tmp_path, fake_cl
     assert command[command.index("--permission-mode") + 1] == "plan"
     metadata = json.loads(Path(result["metadata_path"]).read_text())
     assert metadata["permission_mode"] == "plan"
+    assert "relies on Claude Code --permission-mode plan" in metadata["plan_mode_boundary"]
 
 
 def test_accept_edits_passes_documented_permission_mode(tmp_path, fake_claude, monkeypatch):
@@ -185,7 +206,12 @@ def test_expected_artifact_success_and_failure(tmp_path, fake_claude, monkeypatc
     workdir = tmp_path / "repo"
     workdir.mkdir()
     (workdir / "built.txt").write_text("done")
-    run = Mock(return_value=SimpleNamespace(returncode=0, stdout="ok", stderr=""))
+
+    def run_and_modify(*args, **kwargs):
+        (Path(kwargs["cwd"]) / "built.txt").write_text("done now")
+        return SimpleNamespace(returncode=0, stdout="ok", stderr="")
+
+    run = Mock(side_effect=run_and_modify)
     monkeypatch.setattr(cct.subprocess, "run", run)
 
     success = _load(cct.ask_claude_code("work", workdir=str(workdir), expected_artifact="built.txt"))
@@ -193,14 +219,48 @@ def test_expected_artifact_success_and_failure(tmp_path, fake_claude, monkeypatc
 
     assert success["success"] is True
     assert success["expected_artifact_exists"] is True
+    assert success["expected_artifact_existed_before"] is True
+    assert success["success_basis"] == "expected_artifact_modified"
     success_metadata = json.loads(Path(success["metadata_path"]).read_text())
     assert success_metadata["expected_artifact"].endswith("built.txt")
     assert success_metadata["expected_artifact_exists"] is True
+    assert success_metadata["expected_artifact_existed_before"] is True
 
     assert failure["success"] is False
     _assert_full_failure_schema(failure)
     assert failure["expected_artifact_exists"] is False
+    assert failure["expected_artifact_existed_before"] is False
+    assert failure["success_basis"] == "expected_artifact_missing"
     assert "expected_artifact was not found" in failure["error"]
+
+
+def test_expected_artifact_rejects_paths_outside_workdir(tmp_path, hermes_home, fake_claude, monkeypatch):
+    workdir = tmp_path / "repo"
+    workdir.mkdir()
+    run = Mock(return_value=SimpleNamespace(returncode=0, stdout="ok", stderr=""))
+    monkeypatch.setattr(cct.subprocess, "run", run)
+
+    result = _load(cct.ask_claude_code("work", workdir=str(workdir), expected_artifact=str(tmp_path / "outside.txt")))
+
+    _assert_full_failure_schema(result)
+    assert result["success_basis"] == "preflight_failed"
+    assert "expected_artifact must be inside workdir" in result["error"]
+    run.assert_not_called()
+
+
+def test_expected_artifact_rejects_outside_paths_before_signature_stat(tmp_path, hermes_home, fake_claude, monkeypatch):
+    workdir = tmp_path / "repo"
+    workdir.mkdir()
+    outside = tmp_path / "outside.txt"
+    outside.write_text("outside")
+    signature = Mock(side_effect=AssertionError("should not stat outside-workdir expected_artifact"))
+    monkeypatch.setattr(cct, "_artifact_signature", signature)
+
+    result = _load(cct.ask_claude_code("work", workdir=str(workdir), expected_artifact=str(outside)))
+
+    _assert_full_failure_schema(result)
+    assert "expected_artifact must be inside workdir" in result["error"]
+    signature.assert_not_called()
 
 
 def test_timeout_returns_full_failure_schema(tmp_path, hermes_home, fake_claude, monkeypatch):
@@ -236,15 +296,251 @@ def test_nonzero_exit_returns_full_failure_schema(tmp_path, hermes_home, fake_cl
     assert "exited with code 2" in result["error"]
 
 
-def test_check_fn_uses_which_then_fallback(monkeypatch, tmp_path):
+def test_preexisting_expected_artifact_unchanged_is_not_success(tmp_path, fake_claude, monkeypatch):
+    workdir = tmp_path / "repo"
+    workdir.mkdir()
+    artifact = workdir / "built.txt"
+    artifact.write_text("stale")
+    run = Mock(return_value=SimpleNamespace(returncode=0, stdout="ok", stderr=""))
+    monkeypatch.setattr(cct.subprocess, "run", run)
+
+    result = _load(cct.ask_claude_code("work", workdir=str(workdir), expected_artifact="built.txt"))
+
+    assert result["success"] is False
+    assert result["success_basis"] == "expected_artifact_preexisting_unchanged"
+    assert "unchanged" in result["error"]
+    metadata = json.loads(Path(result["metadata_path"]).read_text())
+    assert metadata["process_success"] is True
+    assert metadata["task_success"] is False
+    assert metadata["expected_artifact_changed"] is False
+    assert metadata["expected_artifact_signature_before"] == metadata["expected_artifact_signature_after"]
+
+
+def test_created_expected_artifact_is_success(tmp_path, fake_claude, monkeypatch):
+    workdir = tmp_path / "repo"
+    workdir.mkdir()
+
+    def run_and_create(*args, **kwargs):
+        (Path(kwargs["cwd"]) / "created.txt").write_text("created")
+        return SimpleNamespace(returncode=0, stdout="ok", stderr="")
+
+    monkeypatch.setattr(cct.subprocess, "run", Mock(side_effect=run_and_create))
+
+    result = _load(cct.ask_claude_code("work", workdir=str(workdir), expected_artifact="created.txt"))
+
+    assert result["success"] is True
+    assert result["success_basis"] == "expected_artifact_created"
+    metadata = json.loads(Path(result["metadata_path"]).read_text())
+    assert metadata["expected_artifact_existed_before"] is False
+    assert metadata["expected_artifact_changed"] is True
+
+
+def test_output_artifacts_are_bounded_and_keep_tails(tmp_path, fake_claude, monkeypatch):
+    workdir = tmp_path / "repo"
+    workdir.mkdir()
+    stdout = "α" * (cct.MAX_OUTPUT_CHARS + 20) + "STDOUT_TAIL"
+    stderr = "β" * (cct.MAX_OUTPUT_CHARS + 20) + "STDERR_TAIL"
+    monkeypatch.setattr(cct.subprocess, "run", Mock(return_value=SimpleNamespace(returncode=0, stdout=stdout, stderr=stderr)))
+
+    result = _load(cct.ask_claude_code("work", workdir=str(workdir)))
+
+    assert result["stdout_tail"].endswith("STDOUT_TAIL")
+    assert result["stderr_tail"].endswith("STDERR_TAIL")
+    persisted_stdout = Path(result["stdout_path"]).read_text()
+    persisted_stderr = Path(result["stderr_path"]).read_text()
+    assert len(persisted_stdout) <= cct.MAX_OUTPUT_CHARS
+    assert len(persisted_stderr) <= cct.MAX_OUTPUT_CHARS
+    assert persisted_stdout.endswith("STDOUT_TAIL")
+    assert persisted_stderr.endswith("STDERR_TAIL")
+    metadata = json.loads(Path(result["metadata_path"]).read_text())
+    assert metadata["stdout_truncated"] is True
+    assert metadata["stderr_truncated"] is True
+    assert metadata["full_output_artifacts"] is False
+    assert metadata["stdout_chars"] == len(stdout)
+    assert metadata["stderr_chars"] == len(stderr)
+
+
+def test_popen_capture_is_memory_and_artifact_bounded(tmp_path, hermes_home, monkeypatch):
+    workdir = tmp_path / "repo"
+    workdir.mkdir()
+    claude = tmp_path / "claude"
+    claude.write_text(
+        "#!/usr/bin/env python3\n"
+        "import sys\n"
+        "sys.stdout.write('x' * 60000 + 'POUT_TAIL')\n"
+        "sys.stderr.write('y' * 60000 + 'PERR_TAIL')\n",
+        encoding="utf-8",
+    )
+    claude.chmod(0o755)
+    monkeypatch.setattr(cct, "_find_claude_binary", lambda: str(claude))
+    monkeypatch.setattr(
+        cct,
+        "_collect_claude_metadata",
+        lambda claude_bin: {"claude_path": claude_bin, "claude_version": None, "claude_version_error": None},
+    )
+
+    result = _load(cct.ask_claude_code("work", workdir=str(workdir)))
+
+    assert result["success"] is True
+    assert result["stdout_tail"].endswith("POUT_TAIL")
+    assert result["stderr_tail"].endswith("PERR_TAIL")
+    persisted_stdout = Path(result["stdout_path"]).read_text(encoding="utf-8")
+    persisted_stderr = Path(result["stderr_path"]).read_text(encoding="utf-8")
+    assert len(persisted_stdout) <= cct.MAX_OUTPUT_CHARS
+    assert len(persisted_stderr) <= cct.MAX_OUTPUT_CHARS
+    assert persisted_stdout.endswith("POUT_TAIL")
+    assert persisted_stderr.endswith("PERR_TAIL")
+    metadata = json.loads(Path(result["metadata_path"]).read_text(encoding="utf-8"))
+    assert metadata["stdout_truncated"] is True
+    assert metadata["stderr_truncated"] is True
+    assert metadata["stdout_chars"] == 60000 + len("POUT_TAIL")
+    assert metadata["stderr_chars"] == 60000 + len("PERR_TAIL")
+    assert metadata["capture_memory_bound"] is True
+    assert metadata["artifact_persistence_bound"] is True
+
+
+def test_popen_capture_replaces_invalid_utf8_stdout_and_stderr(tmp_path, hermes_home, monkeypatch):
+    workdir = tmp_path / "repo"
+    workdir.mkdir()
+    claude = tmp_path / "claude"
+    claude.write_text(
+        "#!/usr/bin/env python3\n"
+        "import sys\n"
+        "sys.stdout.buffer.write(b'out-\\xff-tail')\n"
+        "sys.stderr.buffer.write(b'err-\\xfe-tail')\n",
+        encoding="utf-8",
+    )
+    claude.chmod(0o755)
+
+    def run_should_not_be_used(*args, **kwargs):
+        raise AssertionError("subprocess.run path should not be used in this Popen regression test")
+
+    run_should_not_be_used.__module__ = "subprocess"
+    monkeypatch.setattr(cct.subprocess, "run", run_should_not_be_used)
+    monkeypatch.setattr(cct, "_find_claude_binary", lambda: str(claude))
+    monkeypatch.setattr(
+        cct,
+        "_collect_claude_metadata",
+        lambda claude_bin: {"claude_path": claude_bin, "claude_version": None, "claude_version_error": None},
+    )
+
+    result = _load(cct.ask_claude_code("work", workdir=str(workdir)))
+
+    assert result["success"] is True, result
+    assert result["stdout_tail"] == "out-�-tail"
+    assert result["stderr_tail"] == "err-�-tail"
+    assert Path(result["stdout_path"]).read_text(encoding="utf-8") == "out-�-tail"
+    assert Path(result["stderr_path"]).read_text(encoding="utf-8") == "err-�-tail"
+    metadata = json.loads(Path(result["metadata_path"]).read_text(encoding="utf-8"))
+    assert metadata["stdout_chars"] == len("out-�-tail")
+    assert metadata["stderr_chars"] == len("err-�-tail")
+
+
+def test_env_policy_excludes_hermes_home_and_secrets(tmp_path, fake_claude, monkeypatch):
+    workdir = tmp_path / "repo"
+    workdir.mkdir()
+    blocked_hermes_home = tmp_path / "blocked-hermes-home"
+    monkeypatch.setenv("HERMES_HOME", str(blocked_hermes_home))
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "secret")
+    monkeypatch.setenv("CUSTOM_TOKEN", "secret")
+    monkeypatch.setenv("PASSWORD", "secret")
+    monkeypatch.setenv("PASS", "secret")
+    monkeypatch.setenv("CREDENTIAL", "secret")
+    monkeypatch.setenv("AUTH", "secret")
+    monkeypatch.setenv("COOKIE", "secret")
+    monkeypatch.setenv("SESSION", "secret")
+    monkeypatch.setattr(
+        cct,
+        "ENV_ALLOWLIST",
+        cct.ENV_ALLOWLIST | {"PASSWORD", "PASS", "CREDENTIAL", "AUTH", "COOKIE", "SESSION"},
+    )
+    run = Mock(return_value=SimpleNamespace(returncode=0, stdout="ok", stderr=""))
+    monkeypatch.setattr(cct.subprocess, "run", run)
+
+    result = _load(cct.ask_claude_code("work", workdir=str(workdir)))
+    env = run.call_args.kwargs["env"]
+
+    assert "HERMES_HOME" not in env
+    assert "ANTHROPIC_API_KEY" not in env
+    assert "CUSTOM_TOKEN" not in env
+    assert "PASSWORD" not in env
+    assert "PASS" not in env
+    assert "CREDENTIAL" not in env
+    assert "AUTH" not in env
+    assert "COOKIE" not in env
+    assert "SESSION" not in env
+    assert set(env) <= cct.ENV_ALLOWLIST
+    metadata = json.loads(Path(result["metadata_path"]).read_text())
+    assert "HERMES_HOME" not in metadata["env_allowlist"]
+    assert "key, secret, token, password, pass, credential, auth, cookie, session" in metadata["env_policy"]
+
+
+def test_unicode_prompt_output_and_metadata_round_trip(tmp_path, fake_claude, monkeypatch):
+    workdir = tmp_path / "repo"
+    workdir.mkdir()
+    prompt = "اكتب ملخصًا عن ابن عربي — こんにちは 🌙"
+    output = "نتيجة: حكمة شرقية 漢字 ✅"
+    run = Mock(return_value=SimpleNamespace(returncode=0, stdout=output, stderr="خطأ؟ لا"))
+    monkeypatch.setattr(cct.subprocess, "run", run)
+
+    result = _load(cct.ask_claude_code(prompt, workdir=str(workdir)))
+
+    assert result["stdout_tail"] == output
+    assert Path(result["stdout_path"]).read_text(encoding="utf-8") == output
+    command = run.call_args.args[0]
+    assert command[2] == prompt
+    metadata_text = Path(result["metadata_path"]).read_text(encoding="utf-8")
+    assert "حكمة شرقية" in metadata_text or json.loads(metadata_text)["stdout_chars"] == len(output)
+
+
+def test_check_fn_uses_which_fallback_and_auth_probe(monkeypatch, tmp_path):
+    auth_probe = Mock(return_value=True)
+    monkeypatch.setattr(cct, "_check_claude_auth_available", auth_probe)
     monkeypatch.setattr(cct.shutil, "which", lambda name: "/bin/claude")
     assert cct.check_claude_code_requirements() is True
+    auth_probe.assert_called_with("/bin/claude")
 
     monkeypatch.setattr(cct.shutil, "which", lambda name: None)
     fallback = tmp_path / "claude"
     fallback.write_text("#!/bin/sh\n")
     monkeypatch.setattr(cct, "CLAUDE_FALLBACK_PATH", fallback)
     assert cct.check_claude_code_requirements() is True
+    auth_probe.assert_called_with(str(fallback))
+
+    auth_probe.return_value = False
+    assert cct.check_claude_code_requirements() is False
 
     fallback.unlink()
+    auth_probe.reset_mock()
     assert cct.check_claude_code_requirements() is False
+    auth_probe.assert_not_called()
+
+
+def test_auth_probe_runs_noninteractive_plan_mode(monkeypatch):
+    run = Mock(return_value=SimpleNamespace(returncode=0, stdout="OK", stderr=""))
+    monkeypatch.setattr(cct.subprocess, "run", run)
+
+    assert cct._check_claude_auth_available("/bin/claude") is True
+
+    command = run.call_args.args[0]
+    assert command == [
+        "/bin/claude",
+        "-p",
+        "Reply with OK.",
+        "--max-turns",
+        "1",
+        "--output-format",
+        "text",
+        "--permission-mode",
+        "plan",
+    ]
+    assert run.call_args.kwargs["timeout"] == cct.AUTH_CHECK_TIMEOUT_SECONDS
+    assert run.call_args.kwargs["shell"] is False
+
+
+def test_auth_probe_fails_closed_on_nonzero_or_exception(monkeypatch):
+    monkeypatch.setattr(cct.subprocess, "run", Mock(return_value=SimpleNamespace(returncode=1, stdout="", stderr="login")))
+    assert cct._check_claude_auth_available("/bin/claude") is False
+
+    monkeypatch.setattr(cct.subprocess, "run", Mock(side_effect=TimeoutError("boom")))
+    assert cct._check_claude_auth_available("/bin/claude") is False

--- a/tests/tools/test_claude_code_tool.py
+++ b/tests/tools/test_claude_code_tool.py
@@ -1,0 +1,250 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import pytest
+
+from tools import claude_code_tool as cct
+
+
+@pytest.fixture
+def hermes_home(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes-home"))
+    return tmp_path / "hermes-home"
+
+
+@pytest.fixture
+def fake_claude(monkeypatch):
+    monkeypatch.setattr(cct, "_find_claude_binary", lambda: "/usr/bin/claude")
+
+
+REQUIRED_RESULT_KEYS = {
+    "success",
+    "exit_code",
+    "elapsed_seconds",
+    "stdout_tail",
+    "stderr_tail",
+    "stdout_path",
+    "stderr_path",
+    "metadata_path",
+    "expected_artifact_exists",
+    "error",
+}
+
+
+def _load(result: str) -> dict:
+    return json.loads(result)
+
+
+def _assert_full_failure_schema(result: dict) -> None:
+    assert REQUIRED_RESULT_KEYS <= result.keys()
+    assert result["success"] is False
+    assert isinstance(result["elapsed_seconds"], (int, float))
+    assert isinstance(result["stdout_tail"], str)
+    assert isinstance(result["stderr_tail"], str)
+    assert result["error"]
+    assert Path(result["stdout_path"]).exists()
+    assert Path(result["stderr_path"]).exists()
+    assert Path(result["metadata_path"]).exists()
+
+
+def test_constructs_expected_command_and_writes_proof_artifacts(tmp_path, hermes_home, fake_claude, monkeypatch):
+    workdir = tmp_path / "repo"
+    workdir.mkdir()
+    run = Mock(return_value=SimpleNamespace(returncode=0, stdout="hello from claude", stderr=""))
+    monkeypatch.setattr(cct.subprocess, "run", run)
+
+    result = _load(cct.ask_claude_code("do work", workdir=str(workdir), timeout=10, max_turns=3))
+
+    assert result["success"] is True
+    assert result["exit_code"] == 0
+    assert result["stdout_tail"] == "hello from claude"
+    run.assert_called_once()
+    kwargs = run.call_args.kwargs
+    assert kwargs["shell"] is False
+    assert kwargs["cwd"] == str(workdir.resolve())
+    assert kwargs["timeout"] == 10
+    assert run.call_args.args[0] == [
+        "/usr/bin/claude",
+        "-p",
+        "do work",
+        "--max-turns",
+        "3",
+        "--output-format",
+        "text",
+        "--permission-mode",
+        "default",
+    ]
+
+    stdout_path = Path(result["stdout_path"])
+    stderr_path = Path(result["stderr_path"])
+    metadata_path = Path(result["metadata_path"])
+    assert stdout_path.read_text() == "hello from claude"
+    assert stderr_path.read_text() == ""
+    assert hermes_home in metadata_path.parents
+    metadata = json.loads(metadata_path.read_text())
+    assert metadata["tool"] == "ask_claude_code"
+    assert metadata["workdir"] == str(workdir.resolve())
+    assert metadata["timeout"] == 10
+    assert metadata["max_turns"] == 3
+    assert metadata["permission_mode"] == "default"
+    assert metadata["stdout_path"] == str(stdout_path)
+    assert metadata["stderr_path"] == str(stderr_path)
+
+
+@pytest.mark.parametrize("permission_mode", ["danger", "accept-edits", ""])
+def test_rejects_invalid_permission_mode(permission_mode, hermes_home, fake_claude):
+    result = _load(cct.ask_claude_code("work", permission_mode=permission_mode))
+
+    _assert_full_failure_schema(result)
+    assert result["exit_code"] is None
+    assert "invalid permission_mode" in result["error"]
+
+
+def test_missing_prompt_returns_full_failure_schema(hermes_home):
+    result = _load(cct.ask_claude_code(""))
+
+    _assert_full_failure_schema(result)
+    assert result["exit_code"] is None
+    assert result["error"] == "prompt is required"
+
+
+def test_missing_claude_cli_returns_full_failure_schema(hermes_home, monkeypatch):
+    monkeypatch.setattr(cct, "_find_claude_binary", lambda: None)
+
+    result = _load(cct.ask_claude_code("work"))
+
+    _assert_full_failure_schema(result)
+    assert result["exit_code"] is None
+    assert "claude CLI not found" in result["error"]
+
+
+def test_invalid_workdir_returns_full_failure_schema(tmp_path, hermes_home, fake_claude):
+    missing = tmp_path / "missing"
+
+    result = _load(cct.ask_claude_code("work", workdir=str(missing)))
+
+    _assert_full_failure_schema(result)
+    assert result["exit_code"] is None
+    assert "workdir does not exist" in result["error"]
+
+
+def test_caps_timeout_and_max_turns(tmp_path, fake_claude, monkeypatch):
+    workdir = tmp_path / "repo"
+    workdir.mkdir()
+    run = Mock(return_value=SimpleNamespace(returncode=0, stdout="ok", stderr=""))
+    monkeypatch.setattr(cct.subprocess, "run", run)
+
+    result = _load(cct.ask_claude_code("work", workdir=str(workdir), timeout=9999, max_turns=999))
+
+    assert result["success"] is True
+    assert run.call_args.kwargs["timeout"] == cct.MAX_TIMEOUT_SECONDS
+    assert "--max-turns" in run.call_args.args[0]
+    assert run.call_args.args[0][run.call_args.args[0].index("--max-turns") + 1] == str(cct.MAX_MAX_TURNS)
+    metadata = json.loads(Path(result["metadata_path"]).read_text())
+    assert metadata["timeout"] == cct.MAX_TIMEOUT_SECONDS
+    assert metadata["max_turns"] == cct.MAX_MAX_TURNS
+
+
+def test_plan_mode_uses_safe_prompt_prefix_and_permission_flag(tmp_path, fake_claude, monkeypatch):
+    workdir = tmp_path / "repo"
+    workdir.mkdir()
+    run = Mock(return_value=SimpleNamespace(returncode=0, stdout="plan", stderr=""))
+    monkeypatch.setattr(cct.subprocess, "run", run)
+
+    result = _load(cct.ask_claude_code("change files", workdir=str(workdir), permission_mode="plan"))
+
+    assert result["success"] is True
+    command = run.call_args.args[0]
+    assert command[2].startswith("Plan only; do not edit files.\n\nchange files")
+    assert "--dangerously-skip-permissions" not in command
+    assert "--permission-mode" in command
+    assert command[command.index("--permission-mode") + 1] == "plan"
+    metadata = json.loads(Path(result["metadata_path"]).read_text())
+    assert metadata["permission_mode"] == "plan"
+
+
+def test_accept_edits_passes_documented_permission_mode(tmp_path, fake_claude, monkeypatch):
+    workdir = tmp_path / "repo"
+    workdir.mkdir()
+    run = Mock(return_value=SimpleNamespace(returncode=0, stdout="edited", stderr=""))
+    monkeypatch.setattr(cct.subprocess, "run", run)
+
+    result = _load(cct.ask_claude_code("change files", workdir=str(workdir), permission_mode="acceptEdits"))
+
+    assert result["success"] is True
+    command = run.call_args.args[0]
+    assert "--dangerously-skip-permissions" not in command
+    assert command[command.index("--permission-mode") + 1] == "acceptEdits"
+
+
+def test_expected_artifact_success_and_failure(tmp_path, fake_claude, monkeypatch):
+    workdir = tmp_path / "repo"
+    workdir.mkdir()
+    (workdir / "built.txt").write_text("done")
+    run = Mock(return_value=SimpleNamespace(returncode=0, stdout="ok", stderr=""))
+    monkeypatch.setattr(cct.subprocess, "run", run)
+
+    success = _load(cct.ask_claude_code("work", workdir=str(workdir), expected_artifact="built.txt"))
+    failure = _load(cct.ask_claude_code("work", workdir=str(workdir), expected_artifact="missing.txt"))
+
+    assert success["success"] is True
+    assert success["expected_artifact_exists"] is True
+    success_metadata = json.loads(Path(success["metadata_path"]).read_text())
+    assert success_metadata["expected_artifact"].endswith("built.txt")
+    assert success_metadata["expected_artifact_exists"] is True
+
+    assert failure["success"] is False
+    _assert_full_failure_schema(failure)
+    assert failure["expected_artifact_exists"] is False
+    assert "expected_artifact was not found" in failure["error"]
+
+
+def test_timeout_returns_full_failure_schema(tmp_path, hermes_home, fake_claude, monkeypatch):
+    workdir = tmp_path / "repo"
+    workdir.mkdir()
+
+    def timeout_run(*args, **kwargs):
+        raise cct.subprocess.TimeoutExpired(cmd=args[0], timeout=kwargs["timeout"], output="partial out", stderr="partial err")
+
+    monkeypatch.setattr(cct.subprocess, "run", timeout_run)
+
+    result = _load(cct.ask_claude_code("work", workdir=str(workdir), timeout=1))
+
+    _assert_full_failure_schema(result)
+    assert result["exit_code"] is None
+    assert result["stdout_tail"] == "partial out"
+    assert result["stderr_tail"] == "partial err"
+    assert "timed out" in result["error"]
+
+
+def test_nonzero_exit_returns_full_failure_schema(tmp_path, hermes_home, fake_claude, monkeypatch):
+    workdir = tmp_path / "repo"
+    workdir.mkdir()
+    run = Mock(return_value=SimpleNamespace(returncode=2, stdout="out", stderr="err"))
+    monkeypatch.setattr(cct.subprocess, "run", run)
+
+    result = _load(cct.ask_claude_code("work", workdir=str(workdir)))
+
+    _assert_full_failure_schema(result)
+    assert result["exit_code"] == 2
+    assert result["stdout_tail"] == "out"
+    assert result["stderr_tail"] == "err"
+    assert "exited with code 2" in result["error"]
+
+
+def test_check_fn_uses_which_then_fallback(monkeypatch, tmp_path):
+    monkeypatch.setattr(cct.shutil, "which", lambda name: "/bin/claude")
+    assert cct.check_claude_code_requirements() is True
+
+    monkeypatch.setattr(cct.shutil, "which", lambda name: None)
+    fallback = tmp_path / "claude"
+    fallback.write_text("#!/bin/sh\n")
+    monkeypatch.setattr(cct, "CLAUDE_FALLBACK_PATH", fallback)
+    assert cct.check_claude_code_requirements() is True
+
+    fallback.unlink()
+    assert cct.check_claude_code_requirements() is False

--- a/tools/claude_code_tool.py
+++ b/tools/claude_code_tool.py
@@ -7,8 +7,10 @@ Runs the local ``claude`` CLI in print mode and stores proof artifacts under
 from __future__ import annotations
 
 import json
+import os
 import shutil
 import subprocess
+import threading
 import time
 from datetime import datetime, timezone
 from pathlib import Path
@@ -26,6 +28,35 @@ MAX_MAX_TURNS = 20
 VALID_PERMISSION_MODES = {"default", "acceptEdits", "plan"}
 CLAUDE_FALLBACK_PATH = Path.home() / ".local" / "bin" / "claude"
 TAIL_CHARS = 8000
+MAX_OUTPUT_CHARS = 50_000
+AUTH_CHECK_TIMEOUT_SECONDS = 20
+ENV_ALLOWLIST = {
+    "HOME",
+    "PATH",
+    "USER",
+    "LOGNAME",
+    "LANG",
+    "LC_ALL",
+    "SHELL",
+    "TERM",
+    "TMPDIR",
+}
+ENV_POLICY = (
+    "Subprocess env is allowlisted for Claude CLI runtime only. HOME is retained because "
+    "Claude CLI may need its user config/cache; HERMES_HOME and common secret-bearing "
+    "env vars (key, secret, token, password, pass, credential, auth, cookie, session) are not passed."
+)
+SECRET_ENV_SUBSTRINGS = (
+    "KEY",
+    "SECRET",
+    "TOKEN",
+    "PASSWORD",
+    "PASS",
+    "CREDENTIAL",
+    "AUTH",
+    "COOKIE",
+    "SESSION",
+)
 
 
 ASK_CLAUDE_CODE_SCHEMA = {
@@ -64,7 +95,7 @@ ASK_CLAUDE_CODE_SCHEMA = {
             },
             "expected_artifact": {
                 "type": "string",
-                "description": "Optional path to verify exists after Claude Code exits. Relative paths are resolved against workdir.",
+                "description": "Optional path under workdir to verify exists after Claude Code exits. Relative paths are resolved against workdir; absolute paths outside workdir are rejected.",
             },
         },
         "required": ["prompt"],
@@ -92,6 +123,20 @@ def _tail(text: str, limit: int = TAIL_CHARS) -> str:
     return text[-limit:]
 
 
+def _cap_output(text: str, limit: int = MAX_OUTPUT_CHARS) -> tuple[str, bool, int]:
+    """Return bounded persisted output, whether it was truncated, and original char count."""
+    return _format_bounded_tail(text, len(text), limit)
+
+
+def _format_bounded_tail(text: str, original_chars: int, limit: int = MAX_OUTPUT_CHARS) -> tuple[str, bool, int]:
+    """Format an already-tail-bounded string with truncation metadata."""
+    if original_chars <= limit:
+        return text, False, original_chars
+    marker = f"\n\n[... truncated to last {limit} of {original_chars} chars ...]\n"
+    keep = max(0, limit - len(marker))
+    return marker + text[-keep:], True, original_chars
+
+
 def _find_claude_binary() -> str | None:
     found = shutil.which("claude")
     if found:
@@ -101,17 +146,103 @@ def _find_claude_binary() -> str | None:
     return None
 
 
+def _sanitized_env() -> dict[str, str]:
+    return {
+        key: value
+        for key, value in os.environ.items()
+        if key in ENV_ALLOWLIST
+        and not any(secret_fragment in key.upper() for secret_fragment in SECRET_ENV_SUBSTRINGS)
+    }
+
+
+def _artifact_signature(path: str | None) -> dict[str, int] | None:
+    if not path:
+        return None
+    try:
+        stat = Path(path).stat()
+    except FileNotFoundError:
+        return None
+    return {"mtime_ns": stat.st_mtime_ns, "size": stat.st_size}
+
+
+def _collect_claude_metadata(claude_bin: str) -> dict[str, Any]:
+    metadata: dict[str, Any] = {
+        "claude_path": claude_bin,
+        "claude_version": None,
+        "claude_version_error": None,
+    }
+    try:
+        completed = subprocess.run(
+            [claude_bin, "--version"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+            shell=False,
+            check=False,
+            env=_sanitized_env(),
+        )
+        version_text = (completed.stdout or completed.stderr or "").strip()
+        metadata["claude_version"] = version_text or None
+        if completed.returncode != 0:
+            metadata["claude_version_error"] = f"claude --version exited with code {completed.returncode}"
+    except Exception as exc:  # pragma: no cover - best-effort metadata only
+        metadata["claude_version_error"] = str(exc)
+    return metadata
+
+
+def _check_claude_auth_available(claude_bin: str) -> bool:
+    """Return True when Claude Code can run non-interactively with local auth.
+
+    Claude Code CLI versions do not expose one stable machine-readable
+    auth-status command. A tiny print-mode, plan-permission probe is the most
+    reliable generic availability gate for Hermes: it verifies the binary,
+    local login/session, and non-interactive execution path without granting
+    edit permissions.
+    """
+    try:
+        completed = subprocess.run(
+            [
+                claude_bin,
+                "-p",
+                "Reply with OK.",
+                "--max-turns",
+                "1",
+                "--output-format",
+                "text",
+                "--permission-mode",
+                "plan",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=AUTH_CHECK_TIMEOUT_SECONDS,
+            shell=False,
+            check=False,
+            env=_sanitized_env(),
+        )
+    except Exception:
+        return False
+    return completed.returncode == 0
+
+
 def check_claude_code_requirements() -> bool:
-    return _find_claude_binary() is not None
+    claude_bin = _find_claude_binary()
+    if not claude_bin:
+        return False
+    return _check_claude_auth_available(claude_bin)
 
 
-def _resolve_expected_artifact(expected_artifact: str | None, workdir: Path) -> tuple[str | None, bool | None]:
+def _resolve_expected_artifact(expected_artifact: str | None, workdir: Path) -> tuple[str | None, bool | None, str | None]:
     if not expected_artifact:
-        return None, None
+        return None, None, None
     path = Path(expected_artifact).expanduser()
     if not path.is_absolute():
         path = workdir / path
-    return str(path), path.exists()
+    resolved = path.resolve(strict=False)
+    try:
+        resolved.relative_to(workdir)
+    except ValueError:
+        return str(resolved), None, f"expected_artifact must be inside workdir: {resolved}"
+    return str(resolved), resolved.exists(), None
 
 
 def _artifact_paths() -> tuple[Path, Path, Path]:
@@ -136,6 +267,8 @@ def _build_result(
     stderr_path: Path,
     metadata_path: Path,
     expected_artifact_exists: bool | None,
+    expected_artifact_existed_before: bool | None,
+    success_basis: str,
     error: str | None,
 ) -> dict[str, Any]:
     return {
@@ -148,6 +281,8 @@ def _build_result(
         "stderr_path": str(stderr_path),
         "metadata_path": str(metadata_path),
         "expected_artifact_exists": expected_artifact_exists,
+        "expected_artifact_existed_before": expected_artifact_existed_before,
+        "success_basis": success_basis,
         "error": error,
     }
 
@@ -166,6 +301,120 @@ def _write_result_artifacts(
     metadata_path.write_text(json.dumps(metadata, indent=2, ensure_ascii=False), encoding="utf-8")
 
 
+def _read_bounded_text(path: Path, limit: int = MAX_OUTPUT_CHARS) -> tuple[str, bool, int]:
+    """Read text from a process-output file while retaining only the tail in memory."""
+    total_chars = 0
+    tail = ""
+    with path.open("r", encoding="utf-8", errors="replace") as handle:
+        while True:
+            chunk = handle.read(8192)
+            if not chunk:
+                break
+            total_chars += len(chunk)
+            tail = (tail + chunk)[-limit:]
+    marker_prefix = "\n\n[... truncated to last "
+    if tail.startswith(marker_prefix):
+        try:
+            original = int(tail.split(" of ", 1)[1].split(" chars ...]", 1)[0])
+        except (IndexError, ValueError):
+            original = total_chars
+        return tail, True, original
+    if total_chars <= limit:
+        return tail, False, total_chars
+    marker = f"\n\n[... truncated to last {limit} of {total_chars} chars ...]\n"
+    keep = max(0, limit - len(marker))
+    return marker + tail[-keep:], True, total_chars
+
+
+def _run_claude_process(
+    command: list[str],
+    *,
+    cwd: Path,
+    timeout_seconds: int,
+    stdout_path: Path,
+    stderr_path: Path,
+) -> tuple[int | None, str | None]:
+    """Run Claude with bounded stdout/stderr capture and persistence."""
+    # Backward-compatible unit-test seam: existing tests monkeypatch subprocess.run.
+    # Production uses Popen pipes plus bounded tail buffers so neither memory nor
+    # persisted artifacts grow without limit while Claude is running.
+    if getattr(subprocess.run, "__module__", "subprocess") != "subprocess":
+        try:
+            completed = subprocess.run(
+                command,
+                cwd=str(cwd),
+                capture_output=True,
+                text=True,
+                timeout=timeout_seconds,
+                shell=False,
+                check=False,
+                env=_sanitized_env(),
+            )
+        except subprocess.TimeoutExpired as exc:
+            stdout = exc.stdout or ""
+            stderr = exc.stderr or ""
+            if isinstance(stdout, bytes):
+                stdout = stdout.decode(errors="replace")
+            if isinstance(stderr, bytes):
+                stderr = stderr.decode(errors="replace")
+            stdout_path.write_text(_format_bounded_tail(stdout, len(stdout))[0], encoding="utf-8")
+            stderr_path.write_text(_format_bounded_tail(stderr, len(stderr))[0], encoding="utf-8")
+            return None, f"claude CLI timed out after {timeout_seconds} seconds"
+        stdout_path.write_text(_format_bounded_tail(completed.stdout or "", len(completed.stdout or ""))[0], encoding="utf-8")
+        stderr_path.write_text(_format_bounded_tail(completed.stderr or "", len(completed.stderr or ""))[0], encoding="utf-8")
+        return completed.returncode, None
+
+    buffers = {"stdout": "", "stderr": ""}
+    totals = {"stdout": 0, "stderr": 0}
+
+    def _drain(stream: Any, key: str) -> None:
+        try:
+            while True:
+                chunk = stream.read(8192)
+                if not chunk:
+                    break
+                totals[key] += len(chunk)
+                buffers[key] = (buffers[key] + chunk)[-MAX_OUTPUT_CHARS:]
+        finally:
+            try:
+                stream.close()
+            except Exception:
+                pass
+
+    process = subprocess.Popen(
+        command,
+        cwd=str(cwd),
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        shell=False,
+        env=_sanitized_env(),
+    )
+    threads = [
+        threading.Thread(target=_drain, args=(process.stdout, "stdout"), daemon=True),
+        threading.Thread(target=_drain, args=(process.stderr, "stderr"), daemon=True),
+    ]
+    for thread in threads:
+        thread.start()
+    try:
+        process.wait(timeout=timeout_seconds)
+    except subprocess.TimeoutExpired:
+        process.kill()
+        process.wait(timeout=10)
+        for thread in threads:
+            thread.join(timeout=2)
+        stdout_path.write_text(_format_bounded_tail(buffers["stdout"], totals["stdout"])[0], encoding="utf-8")
+        stderr_path.write_text(_format_bounded_tail(buffers["stderr"], totals["stderr"])[0], encoding="utf-8")
+        return None, f"claude CLI timed out after {timeout_seconds} seconds"
+    for thread in threads:
+        thread.join(timeout=2)
+    stdout_path.write_text(_format_bounded_tail(buffers["stdout"], totals["stdout"])[0], encoding="utf-8")
+    stderr_path.write_text(_format_bounded_tail(buffers["stderr"], totals["stderr"])[0], encoding="utf-8")
+    return process.returncode, None
+
+
 def _preflight_failure(error: str, **metadata_overrides: Any) -> str:
     stdout_path, stderr_path, metadata_path = _artifact_paths()
     metadata = {
@@ -182,6 +431,18 @@ def _preflight_failure(error: str, **metadata_overrides: Any) -> str:
         "stderr_path": str(stderr_path),
         "expected_artifact": None,
         "expected_artifact_exists": None,
+        "expected_artifact_existed_before": None,
+        "success_basis": "preflight_failed",
+        "claude_path": None,
+        "claude_version": None,
+        "claude_version_error": None,
+        "env_allowlist": sorted(ENV_ALLOWLIST),
+        "env_policy": ENV_POLICY,
+        "max_output_chars": MAX_OUTPUT_CHARS,
+        "capture_memory_bound": True,
+        "artifact_persistence_bound": True,
+        "stdout_truncated": False,
+        "stderr_truncated": False,
         "error": error,
     }
     metadata.update(metadata_overrides)
@@ -203,6 +464,8 @@ def _preflight_failure(error: str, **metadata_overrides: Any) -> str:
         stderr_path=stderr_path,
         metadata_path=metadata_path,
         expected_artifact_exists=metadata["expected_artifact_exists"],
+        expected_artifact_existed_before=metadata["expected_artifact_existed_before"],
+        success_basis=metadata["success_basis"],
         error=error,
     )
     return json.dumps(result, ensure_ascii=False)
@@ -247,9 +510,23 @@ def ask_claude_code(
         )
 
     stdout_path, stderr_path, metadata_path = _artifact_paths()
+    expected_path, expected_existed_before, expected_error = _resolve_expected_artifact(expected_artifact, cwd)
+    if expected_error:
+        return _preflight_failure(
+            expected_error,
+            workdir=str(cwd),
+            timeout=timeout_seconds,
+            max_turns=max_turns_value,
+            permission_mode=permission_mode,
+            expected_artifact=expected_path,
+            expected_artifact_existed_before=expected_existed_before,
+        )
+    expected_signature_before = _artifact_signature(expected_path)
+    claude_metadata = _collect_claude_metadata(claude_bin)
 
     effective_prompt = prompt
     if permission_mode == "plan":
+        # This prompt prefix is advisory; the hard boundary is Claude Code's own plan permission mode enforcement.
         effective_prompt = "Plan only; do not edit files.\n\n" + prompt
 
     command = [
@@ -272,39 +549,56 @@ def ask_claude_code(
     error: str | None = None
 
     try:
-        completed = subprocess.run(
+        exit_code, error = _run_claude_process(
             command,
-            cwd=str(cwd),
-            capture_output=True,
-            text=True,
-            timeout=timeout_seconds,
-            shell=False,
-            check=False,
+            cwd=cwd,
+            timeout_seconds=timeout_seconds,
+            stdout_path=stdout_path,
+            stderr_path=stderr_path,
         )
-        exit_code = completed.returncode
-        stdout = completed.stdout or ""
-        stderr = completed.stderr or ""
-    except subprocess.TimeoutExpired as exc:
-        exit_code = None
-        stdout = exc.stdout or ""
-        stderr = exc.stderr or ""
-        error = f"claude CLI timed out after {timeout_seconds} seconds"
-        if isinstance(stdout, bytes):
-            stdout = stdout.decode(errors="replace")
-        if isinstance(stderr, bytes):
-            stderr = stderr.decode(errors="replace")
     except Exception as exc:  # pragma: no cover - defensive around process spawn
         error = f"failed to run claude CLI: {exc}"
+        stdout_path.write_text("", encoding="utf-8")
+        stderr_path.write_text("", encoding="utf-8")
+
+    stdout, stdout_truncated, stdout_chars = _read_bounded_text(stdout_path)
+    stderr, stderr_truncated, stderr_chars = _read_bounded_text(stderr_path)
 
     elapsed_seconds = round(time.monotonic() - start, 3)
     ended_at = _utc_now_iso()
-    expected_path, expected_exists = _resolve_expected_artifact(expected_artifact, cwd)
+    expected_exists = Path(expected_path).exists() if expected_path else None
+    expected_signature_after = _artifact_signature(expected_path)
+    expected_artifact_changed = (
+        expected_signature_after is not None and expected_signature_after != expected_signature_before
+    ) if expected_path else None
 
-    success = error is None and exit_code == 0 and (expected_exists is not False)
+    process_success = error is None and exit_code == 0
+    task_success = process_success
+    if process_success and expected_path:
+        task_success = expected_artifact_changed is True
+    success = task_success
+    if process_success and expected_path and expected_existed_before and not expected_artifact_changed:
+        success_basis = "expected_artifact_preexisting_unchanged"
+    elif process_success and expected_path and expected_existed_before is False and expected_artifact_changed:
+        success_basis = "expected_artifact_created"
+    elif process_success and expected_path and expected_artifact_changed:
+        success_basis = "expected_artifact_modified"
+    elif process_success and expected_path and expected_exists is False:
+        success_basis = "expected_artifact_missing"
+    elif process_success:
+        success_basis = "process_exit_zero_unverified"
+    elif expected_exists is False:
+        success_basis = "expected_artifact_missing"
+    elif error and "timed out" in error:
+        success_basis = "timeout"
+    else:
+        success_basis = "process_failed"
     if error is None and exit_code != 0:
         error = f"claude CLI exited with code {exit_code}"
     elif error is None and expected_exists is False:
         error = f"expected_artifact was not found: {expected_path}"
+    elif error is None and expected_path and success_basis == "expected_artifact_preexisting_unchanged":
+        error = f"expected_artifact existed before run and was unchanged: {expected_path}"
 
     metadata = {
         "tool": "ask_claude_code",
@@ -315,13 +609,35 @@ def ask_claude_code(
         "timeout": timeout_seconds,
         "max_turns": max_turns_value,
         "permission_mode": permission_mode,
+        "plan_mode_boundary": "Plan prompt prefix is advisory; file-edit prevention relies on Claude Code --permission-mode plan enforcement.",
         "exit_code": exit_code,
+        "success": success,
+        "process_success": process_success,
+        "task_success": task_success,
+        "success_basis": success_basis,
         "stdout_path": str(stdout_path),
         "stderr_path": str(stderr_path),
+        "stdout_chars": stdout_chars,
+        "stderr_chars": stderr_chars,
+        "stdout_tail_chars": min(len(stdout), TAIL_CHARS),
+        "stderr_tail_chars": min(len(stderr), TAIL_CHARS),
+        "max_output_chars": MAX_OUTPUT_CHARS,
+        "stdout_truncated": stdout_truncated,
+        "stderr_truncated": stderr_truncated,
+        "full_output_artifacts": not (stdout_truncated or stderr_truncated),
+        "capture_memory_bound": True,
+        "artifact_persistence_bound": True,
+        "env_allowlist": sorted(ENV_ALLOWLIST),
+        "env_policy": ENV_POLICY,
         "expected_artifact": expected_path,
         "expected_artifact_exists": expected_exists,
+        "expected_artifact_existed_before": expected_existed_before,
+        "expected_artifact_signature_before": expected_signature_before,
+        "expected_artifact_signature_after": expected_signature_after,
+        "expected_artifact_changed": expected_artifact_changed,
         "error": error,
     }
+    metadata.update(claude_metadata)
     _write_result_artifacts(
         stdout=stdout,
         stderr=stderr,
@@ -341,6 +657,8 @@ def ask_claude_code(
         stderr_path=stderr_path,
         metadata_path=metadata_path,
         expected_artifact_exists=expected_exists,
+        expected_artifact_existed_before=expected_existed_before,
+        success_basis=success_basis,
         error=error,
     )
     return json.dumps(result, ensure_ascii=False)

--- a/tools/claude_code_tool.py
+++ b/tools/claude_code_tool.py
@@ -1,0 +1,364 @@
+"""Claude Code worker tool.
+
+Runs the local ``claude`` CLI in print mode and stores proof artifacts under
+``get_hermes_home()/outputs/proof-artifacts/claude-worker``.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+from uuid import uuid4
+
+from hermes_constants import get_hermes_home
+from tools.registry import registry
+
+
+DEFAULT_TIMEOUT_SECONDS = 300
+MAX_TIMEOUT_SECONDS = 1200
+DEFAULT_MAX_TURNS = 5
+MAX_MAX_TURNS = 20
+VALID_PERMISSION_MODES = {"default", "acceptEdits", "plan"}
+CLAUDE_FALLBACK_PATH = Path.home() / ".local" / "bin" / "claude"
+TAIL_CHARS = 8000
+
+
+ASK_CLAUDE_CODE_SCHEMA = {
+    "name": "ask_claude_code",
+    "description": (
+        "Run the local Claude Code CLI as a bounded worker and return proof "
+        "artifact paths plus stdout/stderr tails. The tool invokes `claude -p` "
+        "with list arguments (never a shell)."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "prompt": {
+                "type": "string",
+                "description": "Task prompt to send to Claude Code.",
+            },
+            "workdir": {
+                "type": "string",
+                "description": "Working directory for the Claude Code process. Defaults to the current backend cwd.",
+            },
+            "timeout": {
+                "type": "integer",
+                "description": f"Timeout in seconds. Default {DEFAULT_TIMEOUT_SECONDS}, capped at {MAX_TIMEOUT_SECONDS}.",
+                "default": DEFAULT_TIMEOUT_SECONDS,
+            },
+            "max_turns": {
+                "type": "integer",
+                "description": f"Claude Code maximum turns. Default {DEFAULT_MAX_TURNS}, capped at {MAX_MAX_TURNS}.",
+                "default": DEFAULT_MAX_TURNS,
+            },
+            "permission_mode": {
+                "type": "string",
+                "enum": sorted(VALID_PERMISSION_MODES),
+                "description": "Permission mode passed to Claude Code via --permission-mode. Dangerous bypass modes are not accepted.",
+                "default": "default",
+            },
+            "expected_artifact": {
+                "type": "string",
+                "description": "Optional path to verify exists after Claude Code exits. Relative paths are resolved against workdir.",
+            },
+        },
+        "required": ["prompt"],
+    },
+}
+
+
+def _utc_now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _coerce_int(value: Any, default: int, maximum: int) -> int:
+    try:
+        coerced = int(value)
+    except (TypeError, ValueError):
+        return default
+    if coerced <= 0:
+        return default
+    return min(coerced, maximum)
+
+
+def _tail(text: str, limit: int = TAIL_CHARS) -> str:
+    if len(text) <= limit:
+        return text
+    return text[-limit:]
+
+
+def _find_claude_binary() -> str | None:
+    found = shutil.which("claude")
+    if found:
+        return found
+    if CLAUDE_FALLBACK_PATH.exists() and CLAUDE_FALLBACK_PATH.is_file():
+        return str(CLAUDE_FALLBACK_PATH)
+    return None
+
+
+def check_claude_code_requirements() -> bool:
+    return _find_claude_binary() is not None
+
+
+def _resolve_expected_artifact(expected_artifact: str | None, workdir: Path) -> tuple[str | None, bool | None]:
+    if not expected_artifact:
+        return None, None
+    path = Path(expected_artifact).expanduser()
+    if not path.is_absolute():
+        path = workdir / path
+    return str(path), path.exists()
+
+
+def _artifact_paths() -> tuple[Path, Path, Path]:
+    run_id = f"{int(time.time())}-{uuid4().hex[:8]}"
+    artifact_dir = get_hermes_home() / "outputs" / "proof-artifacts" / "claude-worker"
+    artifact_dir.mkdir(parents=True, exist_ok=True)
+    return (
+        artifact_dir / f"{run_id}.stdout.txt",
+        artifact_dir / f"{run_id}.stderr.txt",
+        artifact_dir / f"{run_id}.metadata.json",
+    )
+
+
+def _build_result(
+    *,
+    success: bool,
+    exit_code: int | None,
+    elapsed_seconds: float,
+    stdout: str,
+    stderr: str,
+    stdout_path: Path,
+    stderr_path: Path,
+    metadata_path: Path,
+    expected_artifact_exists: bool | None,
+    error: str | None,
+) -> dict[str, Any]:
+    return {
+        "success": success,
+        "exit_code": exit_code,
+        "elapsed_seconds": elapsed_seconds,
+        "stdout_tail": _tail(stdout),
+        "stderr_tail": _tail(stderr),
+        "stdout_path": str(stdout_path),
+        "stderr_path": str(stderr_path),
+        "metadata_path": str(metadata_path),
+        "expected_artifact_exists": expected_artifact_exists,
+        "error": error,
+    }
+
+
+def _write_result_artifacts(
+    *,
+    stdout: str,
+    stderr: str,
+    stdout_path: Path,
+    stderr_path: Path,
+    metadata_path: Path,
+    metadata: dict[str, Any],
+) -> None:
+    stdout_path.write_text(stdout, encoding="utf-8")
+    stderr_path.write_text(stderr, encoding="utf-8")
+    metadata_path.write_text(json.dumps(metadata, indent=2, ensure_ascii=False), encoding="utf-8")
+
+
+def _preflight_failure(error: str, **metadata_overrides: Any) -> str:
+    stdout_path, stderr_path, metadata_path = _artifact_paths()
+    metadata = {
+        "tool": "ask_claude_code",
+        "started_at": _utc_now_iso(),
+        "ended_at": _utc_now_iso(),
+        "elapsed_seconds": 0,
+        "workdir": None,
+        "timeout": None,
+        "max_turns": None,
+        "permission_mode": None,
+        "exit_code": None,
+        "stdout_path": str(stdout_path),
+        "stderr_path": str(stderr_path),
+        "expected_artifact": None,
+        "expected_artifact_exists": None,
+        "error": error,
+    }
+    metadata.update(metadata_overrides)
+    _write_result_artifacts(
+        stdout="",
+        stderr="",
+        stdout_path=stdout_path,
+        stderr_path=stderr_path,
+        metadata_path=metadata_path,
+        metadata=metadata,
+    )
+    result = _build_result(
+        success=False,
+        exit_code=None,
+        elapsed_seconds=0,
+        stdout="",
+        stderr="",
+        stdout_path=stdout_path,
+        stderr_path=stderr_path,
+        metadata_path=metadata_path,
+        expected_artifact_exists=metadata["expected_artifact_exists"],
+        error=error,
+    )
+    return json.dumps(result, ensure_ascii=False)
+
+
+def ask_claude_code(
+    prompt: str,
+    workdir: str | None = None,
+    timeout: int = DEFAULT_TIMEOUT_SECONDS,
+    max_turns: int = DEFAULT_MAX_TURNS,
+    permission_mode: str = "default",
+    expected_artifact: str | None = None,
+) -> str:
+    """Run Claude Code and return a JSON string with execution metadata."""
+    if not isinstance(prompt, str) or not prompt.strip():
+        return _preflight_failure("prompt is required")
+
+    if permission_mode not in VALID_PERMISSION_MODES:
+        return _preflight_failure(
+            f"invalid permission_mode: {permission_mode!r}",
+            permission_mode=permission_mode,
+            valid_permission_modes=sorted(VALID_PERMISSION_MODES),
+        )
+
+    claude_bin = _find_claude_binary()
+    if not claude_bin:
+        return _preflight_failure("claude CLI not found on PATH or fallback path", permission_mode=permission_mode)
+
+    timeout_seconds = _coerce_int(timeout, DEFAULT_TIMEOUT_SECONDS, MAX_TIMEOUT_SECONDS)
+    max_turns_value = _coerce_int(max_turns, DEFAULT_MAX_TURNS, MAX_MAX_TURNS)
+    cwd = Path(workdir).expanduser() if workdir else Path.cwd()
+    cwd = cwd.resolve()
+    if not cwd.exists() or not cwd.is_dir():
+        expected_path = str(Path(expected_artifact).expanduser()) if expected_artifact else None
+        return _preflight_failure(
+            f"workdir does not exist or is not a directory: {cwd}",
+            workdir=str(cwd),
+            timeout=timeout_seconds,
+            max_turns=max_turns_value,
+            permission_mode=permission_mode,
+            expected_artifact=expected_path,
+        )
+
+    stdout_path, stderr_path, metadata_path = _artifact_paths()
+
+    effective_prompt = prompt
+    if permission_mode == "plan":
+        effective_prompt = "Plan only; do not edit files.\n\n" + prompt
+
+    command = [
+        claude_bin,
+        "-p",
+        effective_prompt,
+        "--max-turns",
+        str(max_turns_value),
+        "--output-format",
+        "text",
+        "--permission-mode",
+        permission_mode,
+    ]
+
+    started_at = _utc_now_iso()
+    start = time.monotonic()
+    exit_code: int | None = None
+    stdout = ""
+    stderr = ""
+    error: str | None = None
+
+    try:
+        completed = subprocess.run(
+            command,
+            cwd=str(cwd),
+            capture_output=True,
+            text=True,
+            timeout=timeout_seconds,
+            shell=False,
+            check=False,
+        )
+        exit_code = completed.returncode
+        stdout = completed.stdout or ""
+        stderr = completed.stderr or ""
+    except subprocess.TimeoutExpired as exc:
+        exit_code = None
+        stdout = exc.stdout or ""
+        stderr = exc.stderr or ""
+        error = f"claude CLI timed out after {timeout_seconds} seconds"
+        if isinstance(stdout, bytes):
+            stdout = stdout.decode(errors="replace")
+        if isinstance(stderr, bytes):
+            stderr = stderr.decode(errors="replace")
+    except Exception as exc:  # pragma: no cover - defensive around process spawn
+        error = f"failed to run claude CLI: {exc}"
+
+    elapsed_seconds = round(time.monotonic() - start, 3)
+    ended_at = _utc_now_iso()
+    expected_path, expected_exists = _resolve_expected_artifact(expected_artifact, cwd)
+
+    success = error is None and exit_code == 0 and (expected_exists is not False)
+    if error is None and exit_code != 0:
+        error = f"claude CLI exited with code {exit_code}"
+    elif error is None and expected_exists is False:
+        error = f"expected_artifact was not found: {expected_path}"
+
+    metadata = {
+        "tool": "ask_claude_code",
+        "started_at": started_at,
+        "ended_at": ended_at,
+        "elapsed_seconds": elapsed_seconds,
+        "workdir": str(cwd),
+        "timeout": timeout_seconds,
+        "max_turns": max_turns_value,
+        "permission_mode": permission_mode,
+        "exit_code": exit_code,
+        "stdout_path": str(stdout_path),
+        "stderr_path": str(stderr_path),
+        "expected_artifact": expected_path,
+        "expected_artifact_exists": expected_exists,
+        "error": error,
+    }
+    _write_result_artifacts(
+        stdout=stdout,
+        stderr=stderr,
+        stdout_path=stdout_path,
+        stderr_path=stderr_path,
+        metadata_path=metadata_path,
+        metadata=metadata,
+    )
+
+    result = _build_result(
+        success=success,
+        exit_code=exit_code,
+        elapsed_seconds=elapsed_seconds,
+        stdout=stdout,
+        stderr=stderr,
+        stdout_path=stdout_path,
+        stderr_path=stderr_path,
+        metadata_path=metadata_path,
+        expected_artifact_exists=expected_exists,
+        error=error,
+    )
+    return json.dumps(result, ensure_ascii=False)
+
+
+registry.register(
+    name="ask_claude_code",
+    toolset="claude_code",
+    schema=ASK_CLAUDE_CODE_SCHEMA,
+    handler=lambda args, **kw: ask_claude_code(
+        prompt=args.get("prompt"),
+        workdir=args.get("workdir"),
+        timeout=args.get("timeout", DEFAULT_TIMEOUT_SECONDS),
+        max_turns=args.get("max_turns", DEFAULT_MAX_TURNS),
+        permission_mode=args.get("permission_mode", "default"),
+        expected_artifact=args.get("expected_artifact"),
+    ),
+    check_fn=check_claude_code_requirements,
+    emoji="🤖",
+    max_result_size_chars=50_000,
+)

--- a/toolsets.py
+++ b/toolsets.py
@@ -154,6 +154,12 @@ TOOLSETS = {
         "tools": ["terminal", "process"],
         "includes": []
     },
+
+    "claude_code": {
+        "description": "Opt-in Claude Code worker tool for bounded CLI delegation with proof artifacts",
+        "tools": ["ask_claude_code"],
+        "includes": []
+    },
     
     "moa": {
         "description": "Advanced reasoning and problem-solving tools",

--- a/website/docs/reference/tools-reference.md
+++ b/website/docs/reference/tools-reference.md
@@ -8,7 +8,7 @@ description: "Authoritative reference for Hermes built-in tools, grouped by tool
 
 This page documents Hermes' built-in tools, grouped by toolset. Availability varies by platform, credentials, and enabled toolsets.
 
-**Quick counts (current registry):** ~64 tools — 10 browser tools (core) + 2 CDP-gated browser tools, 4 file tools, 4 Home Assistant tools, 2 terminal tools, 2 web tools, 5 Feishu tools, 7 Spotify tools (registered by the bundled `spotify` plugin), 5 Yuanbao tools, 9 kanban tools (registered when the kanban dispatcher spawns the agent), 2 Discord tools, and a handful of standalone tools (`memory`, `clarify`, `delegate_task`, `execute_code`, `cronjob`, `session_search`, `skill_view`/`skill_manage`/`skills_list`, `text_to_speech`, `image_generate`, `video_generate`, `vision_analyze`, `video_analyze`, `mixture_of_agents`, `send_message`, `todo`, `computer_use`, `process`).
+**Quick counts (current registry):** ~65 tools — 10 browser tools (core) + 2 CDP-gated browser tools, 4 file tools, 4 Home Assistant tools, 2 terminal tools, 2 web tools, 5 Feishu tools, 7 Spotify tools (registered by the bundled `spotify` plugin), 5 Yuanbao tools, 9 kanban tools (registered when the kanban dispatcher spawns the agent), 2 Discord tools, and a handful of standalone or opt-in tools (`memory`, `clarify`, `delegate_task`, `execute_code`, `ask_claude_code`, `cronjob`, `session_search`, `skill_view`/`skill_manage`/`skills_list`, `text_to_speech`, `image_generate`, `video_generate`, `vision_analyze`, `video_analyze`, `mixture_of_agents`, `send_message`, `todo`, `computer_use`, `process`).
 
 :::tip MCP Tools
 In addition to built-in tools, Hermes can load tools dynamically from MCP servers. MCP tools appear with the prefix `mcp_<server>_` (e.g., `mcp_github_create_issue` for the `github` MCP server). See [MCP Integration](/user-guide/features/mcp) for configuration.
@@ -43,6 +43,14 @@ These two tools live in the `browser` toolset but only register when a Chrome De
 | Tool | Description | Requires environment |
 |------|-------------|----------------------|
 | `clarify` | Ask the user a question when you need clarification, feedback, or a decision before proceeding. Supports two modes: 1. **Multiple choice** — provide up to 4 choices. The user picks one or types their own answer via a 5th 'Other' option. 2.… | — |
+
+## `claude_code` toolset
+
+Opt-in local Claude Code CLI delegation. The tool is availability-gated: Hermes only exposes it when a `claude` executable is found and a short non-interactive, plan-mode auth probe succeeds.
+
+| Tool | Description | Requires environment |
+|------|-------------|----------------------|
+| `ask_claude_code` | Run `claude -p` in a chosen working directory with bounded stdout/stderr capture. Returns JSON containing success status, stdout/stderr tails, proof artifact paths, and metadata. Optional `expected_artifact` verification must stay inside `workdir`. | Local `claude` CLI installed and authenticated |
 
 ## `code_execution` toolset
 

--- a/website/docs/reference/toolsets-reference.md
+++ b/website/docs/reference/toolsets-reference.md
@@ -54,6 +54,7 @@ Or in-session:
 |---------|-------|---------|
 | `browser` | `browser_back`, `browser_cdp`, `browser_click`, `browser_console`, `browser_dialog`, `browser_get_images`, `browser_navigate`, `browser_press`, `browser_scroll`, `browser_snapshot`, `browser_type`, `browser_vision`, `web_search` | Core browser automation. Includes `web_search` as a fallback for quick lookups. `browser_cdp` and `browser_dialog` are gated at runtime — registered only when a CDP endpoint is reachable at session start (via `/browser connect`, `browser.cdp_url` config, Browserbase, or Camofox). `browser_dialog` works together with the `pending_dialogs` and `frame_tree` fields that `browser_snapshot` adds when a CDP supervisor is attached. |
 | `clarify` | `clarify` | Ask the user a question when the agent needs clarification. |
+| `claude_code` | `ask_claude_code` | Optional local Claude Code CLI worker. Registered only when `claude` is installed and a non-interactive auth probe succeeds; stores bounded proof artifacts under Hermes outputs. |
 | `code_execution` | `execute_code` | Run Python scripts that call Hermes tools programmatically. |
 | `cronjob` | `cronjob` | Schedule and manage recurring tasks. |
 | `debugging` | composite (`file` + `terminal` + `web`) | Debug bundle — file, process/terminal, web extract/search. |
@@ -158,7 +159,7 @@ custom_toolsets:
 
 A handful of tools have an additional availability check on top of toolset membership and are **not** turned on by `all`/`*` alone:
 
-- **Capability-gated** tools (browser, `computer_use`, `code_execution`, Feishu, Home Assistant, cronjob) appear only when their backend/credential prerequisite is configured.
+- **Capability-gated** tools (browser, `computer_use`, `code_execution`, Feishu, Home Assistant, cronjob, Claude Code) appear only when their backend/credential prerequisite is configured. The `claude_code` toolset additionally requires a local `claude` binary and a successful non-interactive auth probe.
 - **Workflow-gated** tools — the `kanban` toolset — are deliberately opt-in. `all`/`*` does **not** enable kanban; you must list `kanban` explicitly (or be a dispatcher-spawned worker with `HERMES_KANBAN_TASK` set). Kanban tools mutate shared board state, so they stay off by default even under `all`.
 
 ## Relationship to `hermes tools`


### PR DESCRIPTION
## Summary
- add a capability-gated `claude_code` toolset with `ask_claude_code` for delegating bounded work to the Claude Code CLI
- stream/cap stdout and stderr to proof artifacts instead of unbounded in-memory capture
- enforce `expected_artifact` containment within `workdir` and report success basis/metadata
- document the new toolset and add focused test coverage

## Safety / behavior
- uses argv execution (`shell=False`)
- requires `claude` binary plus non-interactive auth availability before the tool is exposed
- filters secret-bearing environment variables and only forwards an explicit allowlist
- bounds persisted stdout/stderr artifacts and returned output metadata

## Verification
- `python -m py_compile tools/claude_code_tool.py`
- `python -m pytest tests/tools/test_claude_code_tool.py -q` → 25 passed
- `git diff --check -- tools/claude_code_tool.py tests/tools/test_claude_code_tool.py website/docs/reference/toolsets-reference.md website/docs/reference/tools-reference.md`
- Real local Claude CLI smoke/bounded-work tests passed before PR prep:
  - Claude Code version: 2.1.175
  - smoke output: `CLAUDE_SMOKE_OK`
  - bounded-work artifact content: `CLAUDE_BOUNDED_WORK_OK`

## Review notes
- Al-Qadi adversarial review initially requested one change: tolerant decoding for invalid subprocess output.
- Fix applied with `encoding="utf-8", errors="replace"` in the production `Popen` path plus invalid UTF-8 regression coverage.
- Focused re-review verdict: APPROVE.
