### PR TITLE
fix(desktop): show cancelled state instead of failure UI when install is cancelled

### DIFF
--- a/apps/desktop/src/components/desktop-install-overlay.tsx
+++ b/apps/desktop/src/components/desktop-install-overlay.tsx
@@ -164,6 +164,7 @@ const EMPTY_STATE: DesktopBootstrapState = {
   manifest: null,
   stages: {},
   error: null,
+  cancelled: false,
   log: [],
   startedAt: null,
   completedAt: null,
@@ -223,7 +224,12 @@ function applyEvent(state: DesktopBootstrapState, ev: DesktopBootstrapEvent): De
   }
 
   if (ev.type === 'failed') {
-    return { ...state, active: false, error: ev.error || 'unknown error' }
+    return {
+      ...state,
+      active: false,
+      error: ev.error || 'unknown error',
+      cancelled: ev.error === 'bootstrap cancelled by user'
+    }
   }
 
   if (ev.type === 'unsupported-platform') {
@@ -249,6 +255,7 @@ export function DesktopInstallOverlay({ enabled = true }: DesktopInstallOverlayP
   const [logOpen, setLogOpen] = useState(false)
   const [copied, setCopied] = useState(false)
   const [cancelling, setCancelling] = useState(false)
+  const [logPath, setLogPath] = useState<string | null>(null)
   const [now, setNow] = useState(() => Date.now())
   const logEndRef = useRef<HTMLDivElement | null>(null)
 
@@ -314,6 +321,25 @@ export function DesktopInstallOverlay({ enabled = true }: DesktopInstallOverlayP
       setLogOpen(true)
     }
   }, [state.error])
+
+  // Real failures (not user cancellation) get a transcript saved to disk by
+  // main.cjs -- fetch the actual path instead of assuming the Windows default.
+  useEffect(() => {
+    if (!state.error || state.cancelled) {
+      return
+    }
+
+    window.hermesDesktop
+      ?.getRecentLogs?.()
+      .then(result => {
+        if (result?.path) {
+          setLogPath(result.path)
+        }
+      })
+      .catch(() => {
+        // ignore -- footer falls back to the hardcoded default path
+      })
+  }, [state.error, state.cancelled])
 
   // Mount logic: show whenever a bootstrap is in flight, completed-with-error,
   // or actively running with a manifest. Hide entirely after a successful
@@ -406,7 +432,8 @@ export function DesktopInstallOverlay({ enabled = true }: DesktopInstallOverlayP
   ).length
 
   const totalCount = stages.length
-  const failed = Boolean(state.error)
+  const cancelled = Boolean(state.cancelled)
+  const failed = Boolean(state.error) && !cancelled
   const progressPct = totalCount > 0 ? Math.round((completedCount / totalCount) * 100) : 0
   const currentStartedAt = currentStage ? state.stages[currentStage]?.startedAt : null
   const currentElapsed = typeof currentStartedAt === 'number' ? formatElapsed(now - currentStartedAt) : ''
@@ -417,10 +444,16 @@ export function DesktopInstallOverlay({ enabled = true }: DesktopInstallOverlayP
         {/* Header -- always visible, never scrolls */}
         <div className="flex-shrink-0 p-8 pb-4">
           <h2 className="text-2xl font-semibold tracking-tight">
-            {failed ? copy.failedTitle : state.active ? copy.settingUpTitle : copy.finishingTitle}
+            {cancelled
+              ? 'Installation cancelled'
+              : failed
+                ? copy.failedTitle
+                : state.active
+                  ? copy.settingUpTitle
+                  : copy.finishingTitle}
           </h2>
           <p className="mt-1.5 text-sm text-muted-foreground">
-            {failed ? copy.failedDesc : copy.activeDesc}
+            {cancelled ? null : failed ? copy.failedDesc : copy.activeDesc}
           </p>
         </div>
 
@@ -536,13 +569,38 @@ export function DesktopInstallOverlay({ enabled = true }: DesktopInstallOverlayP
           </div>
         )}
 
+        {/* Cancelled footer: only way forward is to retry. */}
+        {cancelled && (
+          <div className="flex-shrink-0 bg-card p-4">
+            <div className="flex items-center justify-end">
+              <Button
+                onClick={async () => {
+                  try {
+                    await window.hermesDesktop?.resetBootstrap?.()
+                  } catch {
+                    // best-effort -- continue with reload regardless
+                  }
+
+                  window.location.reload()
+                }}
+                size="sm"
+                variant="default"
+              >
+                Retry
+              </Button>
+            </div>
+          </div>
+        )}
+
         {/* Footer -- always visible, never scrolls; only renders on failure */}
         {failed && (
           <div className="flex-shrink-0 bg-card p-4">
             <div className="flex items-center justify-between gap-2">
               <span className="text-xs text-muted-foreground">
                 {copy.transcriptSaved}{' '}
-                <code className="rounded bg-muted/50 px-1 py-0.5 font-mono">%LOCALAPPDATA%\hermes\logs\</code>
+                <code className="rounded bg-muted/50 px-1 py-0.5 font-mono">
+                  {logPath || '%LOCALAPPDATA%\\hermes\\logs\\'}
+                </code>
               </span>
               <div className="flex gap-2">
                 <Button

--- a/apps/desktop/src/global.d.ts
+++ b/apps/desktop/src/global.d.ts
@@ -375,6 +375,7 @@ export interface DesktopBootstrapState {
   manifest: { type: 'manifest'; stages: DesktopBootstrapStageDescriptor[]; protocolVersion: number | null } | null
   stages: Record<string, DesktopBootstrapStageResult>
   error: string | null
+  cancelled?: boolean
   log: Array<{ ts: number; stage: string | null; line: string; stream?: 'stdout' | 'stderr' }>
   startedAt: number | null
   completedAt: number | null


### PR DESCRIPTION
## What does this PR do?

When the user clicks **Cancel install** during first-launch bootstrap, `main.cjs` emits `{ type: 'failed', error: 'bootstrap cancelled by user' }`. The install overlay treated this as a genuine failure, showing the red error block and "Installation failed" title — confusing UX for an intentional user action.

This PR fixes two issues in the install overlay:

1. **Cancel vs failure distinction** — `applyEvent` now sets `cancelled: true` when the failed event carries the cancellation message. The render shows a clean "Installation cancelled" state (no red error block, single Retry button) instead of the failure UI.

2. **Hardcoded Windows log path** — The failure footer was showing `%LOCALAPPDATA%\hermes\logs\` on all platforms including macOS/Linux. Now loads the actual path dynamically via `getRecentLogs()` IPC, falling back to the hardcoded string if unavailable.

## Related Issue

N/A

## Type of Change

- [x] 🐛 Bug fix

## Changes Made

- `apps/desktop/src/components/desktop-install-overlay.tsx` — detect cancellation in `applyEvent`, add cancelled UI branch, dynamic log path via `getRecentLogs()`
- `apps/desktop/src/global.d.ts` — add `cancelled?: boolean` to `DesktopBootstrapState`

## How to Test

1. Launch Hermes Desktop on a machine without Hermes Agent installed (or delete `.hermes-bootstrap-complete` marker)
2. Wait for the install overlay to appear and a stage to start running
3. Click **Cancel install**
4. Verify: overlay shows "Installation cancelled" title, no red error block, single Retry button
5. For the log path fix: trigger a genuine install failure and verify the footer shows the correct platform-specific log path

## Checklist

- [x] Contributing Guide read
- [x] Conventional Commits format
- [x] Duplicate PR check done
- [x] `pytest tests/ -q` passed
- [x] Platform: Windows 11 + WSL2 Ubuntu