### PR TITLE
feat: notify users when provider fallback activates

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -1287,10 +1287,25 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
                 api_mode=agent.api_mode,
             )
 
-        agent._buffer_status(
+        fallback_message = (
             f"🔄 Primary model failed — switching to fallback: "
             f"{fb_model} via {fb_provider}"
         )
+        agent._buffer_status(fallback_message)
+        try:
+            from agent.credits_tracker import AgentNotice
+
+            agent._emit_notice(
+                AgentNotice(
+                    text=fallback_message,
+                    level="warn",
+                    kind="ttl",
+                    ttl_ms=15000,
+                    key="provider.fallback.active",
+                )
+            )
+        except Exception:
+            logger.debug("fallback notice emission failed", exc_info=True)
         logger.info(
             "Fallback activated: %s → %s (%s)",
             old_model, fb_model, fb_provider,

--- a/tests/run_agent/test_provider_fallback.py
+++ b/tests/run_agent/test_provider_fallback.py
@@ -103,6 +103,39 @@ class TestFallbackChainAdvancement:
             assert agent.model == "gpt-4o"
             assert agent._fallback_activated is True
 
+    def test_successful_fallback_emits_user_visible_notice(self):
+        fbs = [{"provider": "openai", "model": "gpt-4o"}]
+        agent = _make_agent(fallback_model=fbs)
+        notices = []
+        agent.notice_callback = notices.append
+
+        with patch(
+            "agent.auxiliary_client.resolve_provider_client",
+            return_value=(_mock_client(), "gpt-4o"),
+        ):
+            assert agent._try_activate_fallback() is True
+
+        assert len(notices) == 1
+        notice = notices[0]
+        assert notice.text == "🔄 Primary model failed — switching to fallback: gpt-4o via openai"
+        assert notice.level == "warn"
+        assert notice.kind == "ttl"
+        assert notice.key == "provider.fallback.active"
+
+    def test_fallback_notice_callback_errors_do_not_block_recovery(self):
+        fbs = [{"provider": "openai", "model": "gpt-4o"}]
+        agent = _make_agent(fallback_model=fbs)
+        agent.notice_callback = MagicMock(side_effect=RuntimeError("render failed"))
+
+        with patch(
+            "agent.auxiliary_client.resolve_provider_client",
+            return_value=(_mock_client(), "gpt-4o"),
+        ):
+            assert agent._try_activate_fallback() is True
+
+        assert agent.model == "gpt-4o"
+        agent.notice_callback.assert_called_once()
+
     def test_second_fallback_works(self):
         fbs = [
             {"provider": "openai", "model": "gpt-4o"},

--- a/website/docs/user-guide/features/fallback-providers.md
+++ b/website/docs/user-guide/features/fallback-providers.md
@@ -116,6 +116,20 @@ When triggered, Hermes:
 
 The switch is seamless — your conversation history, tool calls, and context are preserved. The agent continues from exactly where it left off, just using a different model.
 
+### Fallback Visibility
+
+When fallback activates, Hermes emits an out-of-band notice through the active driver so you can tell that the current turn is no longer running on the primary model. Messaging platforms receive a standalone notice such as:
+
+```text
+🔄 Primary model failed — switching to fallback: grok-4.3 via xai-oauth
+```
+
+The notice is separate from verbose retry/status chatter: transient retries remain buffered and are only shown if recovery fails, but the successful provider switch itself is user-visible. This helps you interpret answer quality, latency, privacy posture, and local-vs-cloud execution while preserving the seamless fallback behavior.
+
+:::note
+The notice reports the model/provider that Hermes switched to for the current turn. Because fallback is turn-scoped, the next user message starts by trying the primary model again.
+:::
+
 :::info Per-Turn, Not Per-Session
 Fallback is **turn-scoped**: each new user message starts with the primary model restored. If the primary fails mid-turn, fallback activates for that turn only. On the next message, Hermes tries the primary again. Within a single turn, fallback activates at most once — if the fallback also fails, normal error handling takes over (retries, then error message). This prevents cascading failover loops within a turn while giving the primary model a fresh chance every turn.
 :::


### PR DESCRIPTION
## Summary
- emit a user-visible AgentNotice whenever primary model fallback successfully activates
- keep noisy retry/status chatter buffered as before; only the actual provider/model switch becomes visible
- document fallback visibility in the Fallback Providers guide

## Why
Fallback is supposed to keep a session alive when the primary provider fails, but users still need to know when the active turn is no longer running on the primary model. That matters for:

- answer-quality expectations when a different model takes over
- latency expectations and debugging provider incidents
- privacy/locality posture, especially when fallback moves between cloud providers and local models
- trust: seamless failover should not be invisible failover

Previously, successful fallback activation was logged and buffered internally, but the user-facing status was often suppressed on successful recovery. This PR makes the successful fallback switch itself visible without resurfacing all transient retry noise.

## Behavior
When fallback activates, drivers that bind `notice_callback` receive a notice like:

```text
🔄 Primary model failed — switching to fallback: grok-4.3 via xai-oauth
```

The notice is fail-soft: callback/rendering errors are swallowed and do not block fallback recovery.

## Tests
- `python -m compileall -q agent/chat_completion_helpers.py run_agent.py gateway/run.py`
- `python -m pytest tests/run_agent/test_provider_fallback.py tests/gateway/test_notice_rendering.py -q -o 'addopts='`

Result:

```text
33 passed
```
