### PR TITLE
refactor: lift shared ingress normalization into gateway.ingress

### DIFF
--- a/docs/plans/2026-06-12-unified-api-webhook-router.md
+++ b/docs/plans/2026-06-12-unified-api-webhook-router.md
@@ -1,0 +1,302 @@
+# Unified API/Webhook Router Implementation Plan
+
+> **For Hermes:** Use subagent-driven-development skill to implement this plan task-by-task.
+
+**Goal:** Build a shared ingress seam for HTTP-driven agent entrypoints so API server runs, generic webhooks, and Graph-style webhooks can converge on one normalized request/event pipeline without changing public behavior.
+
+**Architecture:** Start with a narrow internal seam instead of a big-bang router rewrite. Introduce a small normalized ingress envelope/helper layer used by webhook-style adapters first, then progressively move API server request parsing and run/session orchestration onto the same primitives once the envelope and dispatch contracts are proven stable.
+
+**Tech Stack:** Python 3.11, aiohttp, Hermes gateway adapters, SessionDB/state.db, pytest
+
+---
+
+## Confirmed codebase context
+
+- Generic webhooks currently terminate in `gateway/platforms/webhook.py` and convert an HTTP POST directly into a `MessageEvent`, then call `self.handle_message(event)` in a background task.
+- Microsoft Graph webhook ingress in `gateway/platforms/msgraph_webhook.py` independently builds a `MessageEvent` and independently schedules `self.handle_message(event)`.
+- API server ingress in `gateway/platforms/api_server.py` does **not** use `MessageEvent` or `BasePlatformAdapter.handle_message()`. It parses HTTP bodies directly, creates an `AIAgent` directly via `_create_agent()`, and separately implements session continuity, SSE streaming, approval wiring, and run status/event plumbing.
+- The safest confirmed unification seam today is **before** agent execution but **after** request validation/parsing: a normalized internal ingress envelope plus shared dispatch helpers for HTTP-originated event sources.
+
+## Design constraints
+
+- Do **not** change public HTTP routes, response schemas, or authentication semantics in the first slice.
+- Do **not** push API server traffic through the gateway active-session queue until the session/approval/streaming semantics are explicitly mapped.
+- Preserve prompt-caching invariants: no mid-conversation toolset or system-prompt mutation.
+- Keep the first slice reversible and low-risk: internal-only helpers with immediate concrete consumers.
+
+---
+
+### Task 1: Add a shared ingress envelope module
+
+**Objective:** Create a single internal representation for HTTP-originated gateway events.
+
+**Files:**
+- Create: `gateway/ingress.py`
+- Test: `tests/gateway/test_ingress.py`
+
+**Step 1: Write failing tests**
+
+Add tests that expect:
+- an `IngressEnvelope` dataclass carrying normalized event fields
+- a helper that turns an envelope into a `MessageEvent` using a platform adapter
+- a helper that schedules `adapter.handle_message(event)` and tracks the background task set
+
+Example assertions to add:
+
+```python
+envelope = IngressEnvelope(
+    text="hello",
+    message_id="evt-1",
+    chat_id="webhook:route:evt-1",
+    chat_name="webhook/route",
+    chat_type="webhook",
+    user_id="webhook:route",
+    user_name="route",
+    raw_payload={"ok": True},
+)
+
+event = build_ingress_message_event(adapter, envelope)
+assert event.text == "hello"
+assert event.message_id == "evt-1"
+assert event.source.platform == Platform.WEBHOOK
+assert event.source.chat_id == "webhook:route:evt-1"
+```
+
+**Step 2: Run test to verify failure**
+
+Run: `python -m pytest tests/gateway/test_ingress.py -q -o 'addopts='`
+Expected: FAIL — module/functions do not exist yet
+
+**Step 3: Write minimal implementation**
+
+Create `gateway/ingress.py` with:
+- `IngressEnvelope` dataclass
+- `build_ingress_message_event(adapter, envelope)`
+- `schedule_ingress_envelope(adapter, envelope)`
+- `schedule_ingress_event(adapter, event)`
+
+Keep the module internal and dependency-light.
+
+**Step 4: Run test to verify pass**
+
+Run: `python -m pytest tests/gateway/test_ingress.py -q -o 'addopts='`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add gateway/ingress.py tests/gateway/test_ingress.py
+git commit -m "feat: add shared ingress envelope helpers"
+```
+
+---
+
+### Task 2: Move generic webhook agent-mode dispatch onto the shared seam
+
+**Objective:** Replace webhook-local event construction/dispatch boilerplate with the shared ingress helper.
+
+**Files:**
+- Modify: `gateway/platforms/webhook.py`
+- Test: `tests/gateway/test_webhook_adapter.py`
+
+**Step 1: Write failing test**
+
+Add or extend a test so it verifies the accepted webhook still:
+- returns HTTP 202
+- produces the same session-scoped `chat_id`
+- sends a `MessageEvent` with the route-derived identity fields
+- preserves `delivery_id` as `message_id`
+
+**Step 2: Run test to verify failure**
+
+Run: `python -m pytest tests/gateway/test_webhook_adapter.py -q -o 'addopts='`
+Expected: FAIL after the new expectations are added
+
+**Step 3: Write minimal implementation**
+
+In `gateway/platforms/webhook.py`:
+- import the new ingress helper(s)
+- replace the inline `build_source(...)`, `MessageEvent(...)`, `asyncio.create_task(...)`, and `_background_tasks` plumbing with one `IngressEnvelope` + `schedule_ingress_envelope(...)`
+- keep `deliver_only` untouched
+- keep response payloads/status codes untouched
+
+**Step 4: Run test to verify pass**
+
+Run: `python -m pytest tests/gateway/test_webhook_adapter.py -q -o 'addopts='`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add gateway/platforms/webhook.py tests/gateway/test_webhook_adapter.py
+git commit -m "refactor: route webhook ingress through shared envelope"
+```
+
+---
+
+### Task 3: Move MS Graph webhook dispatch onto the same seam
+
+**Objective:** Make the second webhook-like ingress source consume the same envelope helper.
+
+**Files:**
+- Modify: `gateway/platforms/msgraph_webhook.py`
+- Test: `tests/gateway/test_msgraph_webhook.py`
+
+**Step 1: Write failing test**
+
+Add or extend a test so it verifies accepted notifications still:
+- return HTTP 202
+- create a `MessageEvent` with `Platform.MSGRAPH_WEBHOOK`
+- preserve the receipt key as `message_id`
+- schedule through the shared path
+
+**Step 2: Run test to verify failure**
+
+Run: `python -m pytest tests/gateway/test_msgraph_webhook.py -q -o 'addopts='`
+Expected: FAIL after the new expectation is added
+
+**Step 3: Write minimal implementation**
+
+In `gateway/platforms/msgraph_webhook.py`:
+- import the new ingress helper(s)
+- replace `_build_message_event()` and the default scheduler branch with `IngressEnvelope` + `schedule_ingress_envelope(...)`
+- keep the custom scheduler extension point intact
+
+**Step 4: Run test to verify pass**
+
+Run: `python -m pytest tests/gateway/test_msgraph_webhook.py -q -o 'addopts='`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add gateway/platforms/msgraph_webhook.py tests/gateway/test_msgraph_webhook.py
+git commit -m "refactor: route msgraph webhook ingress through shared envelope"
+```
+
+---
+
+### Task 4: Add normalized HTTP request metadata helpers for API/webhook convergence
+
+**Objective:** Introduce shared request-metadata plumbing without changing wire behavior.
+
+**Files:**
+- Modify: `gateway/ingress.py`
+- Modify: `gateway/platforms/api_server.py`
+- Modify: `gateway/platforms/webhook.py`
+- Test: `tests/gateway/test_ingress.py`
+- Test: `tests/gateway/test_api_server_jobs.py`
+
+**Step 1: Write failing tests**
+
+Add tests for a small request-context helper that extracts sanitized:
+- `remote`
+- `peer_ip`
+- `forwarded_for`
+- `real_ip`
+- `user_agent`
+- `method`
+- `path`
+
+and keeps line breaks/control characters out of loggable values.
+
+**Step 2: Run test to verify failure**
+
+Run: `python -m pytest tests/gateway/test_ingress.py tests/gateway/test_api_server_jobs.py -q -o 'addopts='`
+Expected: FAIL
+
+**Step 3: Write minimal implementation**
+
+- move the generic request-audit extraction logic out of `api_server.py` into `gateway/ingress.py`
+- keep API server response behavior unchanged
+- optionally use the same helper for webhook logging/trace context, but do not alter webhook JSON responses
+
+**Step 4: Run test to verify pass**
+
+Run: `python -m pytest tests/gateway/test_ingress.py tests/gateway/test_api_server_jobs.py -q -o 'addopts='`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add gateway/ingress.py gateway/platforms/api_server.py gateway/platforms/webhook.py tests/gateway/test_ingress.py tests/gateway/test_api_server_jobs.py
+git commit -m "refactor: share ingress request metadata extraction"
+```
+
+---
+
+### Task 5: Document the next API-server migration seam
+
+**Objective:** Leave the next implementer with an exact, safe follow-on slice.
+
+**Files:**
+- Modify: `docs/plans/2026-06-12-unified-api-webhook-router.md`
+
+**Step 1: Add follow-on notes**
+
+Document the next migration target precisely:
+- extract API-server request parsing into pure helpers
+- normalize `chat_completions`, `session_chat`, and `runs` into one internal request model
+- only then consider a shared router/executor layer
+
+**Step 2: Verification**
+
+Read the updated plan and confirm it distinguishes:
+- current thin slice
+- next safe vertical slice
+- work explicitly deferred because it is higher risk
+
+**Step 3: Commit**
+
+```bash
+git add docs/plans/2026-06-12-unified-api-webhook-router.md
+git commit -m "docs: refine unified ingress follow-on slices"
+```
+
+---
+
+## Smallest safe vertical slice
+
+1. Add `gateway/ingress.py`.
+2. Route `gateway/platforms/webhook.py` through it.
+3. Route `gateway/platforms/msgraph_webhook.py` through it.
+4. Add tests proving event identity and scheduling semantics are unchanged.
+
+This is the minimum slice that creates a real unification seam with **two live ingress consumers** and no API contract changes.
+
+## Validation commands
+
+Run these from repo root:
+
+```bash
+python -m pytest tests/gateway/test_ingress.py -q -o 'addopts='
+python -m pytest tests/gateway/test_webhook_adapter.py -q -o 'addopts='
+python -m pytest tests/gateway/test_msgraph_webhook.py -q -o 'addopts='
+python -m pytest tests/gateway/test_api_server_jobs.py -q -o 'addopts='
+python -m pytest tests/gateway/test_webhook_adapter.py tests/gateway/test_msgraph_webhook.py tests/gateway/test_api_server_jobs.py tests/gateway/test_ingress.py -q -o 'addopts='
+```
+
+If broader time permits:
+
+```bash
+python -m pytest tests/gateway/ -q -o 'addopts='
+```
+
+## Risks
+
+- **API server is structurally different today.** Forcing it onto `MessageEvent` too early risks breaking SSE streams, approval waits, and session continuity headers.
+- **Webhook route semantics differ from chat semantics.** Route-specific delivery metadata must stay outside the generic envelope or be clearly marked optional.
+- **Background task lifecycle matters.** Any shared scheduler helper must preserve `_background_tasks` tracking so disconnect/cleanup behavior remains unchanged.
+
+## Rollback notes
+
+- The thin slice is fully reversible: revert `gateway/ingress.py` plus the adapter call sites in `gateway/platforms/webhook.py` and `gateway/platforms/msgraph_webhook.py`.
+- If a regression appears, roll back only the shared-dispatch adoption while keeping the plan document.
+- Do **not** partially roll back just one consumer after the helper lands unless tests prove the other consumer still exercises the helper correctly.
+
+## Explicitly deferred
+
+- No public route consolidation yet
+- No API server transport rewrite yet
+- No shared approval/session executor yet
+- No dashboard/control-plane contract changes yet

--- a/docs/plans/2026-06-12-unified-api-webhook-router.md
+++ b/docs/plans/2026-06-12-unified-api-webhook-router.md
@@ -300,3 +300,11 @@ python -m pytest tests/gateway/ -q -o 'addopts='
 - No API server transport rewrite yet
 - No shared approval/session executor yet
 - No dashboard/control-plane contract changes yet
+
+## Next Migration Seam (Phase 2)
+
+To safely continue the unified router migration without breaking SSE streams, approval waits, or session continuity headers, the next implementer must adhere to this strict sequence:
+
+1. **Extract API-server request parsing:** Move the parsing logic out of `_handle_chat_completions`, `_handle_session_chat`, and `_handle_runs` into pure, testable helpers (similar to the `/v1/responses` slice).
+2. **Normalize Request Models:** Converge `NormalizedSessionChatRequest`, `NormalizedRunRequest`, and `NormalizedChatCompletionsRequest` into a single, cohesive internal request model inside `gateway/ingress.py`.
+3. **Shared Executor Layer:** Only after parsing and normalization are fully shared and proven green, attempt to converge on a shared router/executor layer that safely handles the gateway's active-session queue.

--- a/gateway/ingress.py
+++ b/gateway/ingress.py
@@ -1,0 +1,94 @@
+"""Shared helpers for HTTP-style ingress sources.
+
+This module is intentionally narrow: it defines a small normalized envelope
+for gateway-style ingress events and the common boilerplate for turning those
+into ``MessageEvent`` objects and scheduling background dispatch.
+
+The first concrete consumers are webhook-like adapters.  API-server request
+handlers still own their direct ``AIAgent`` execution path for now, but can
+progressively reuse the request/envelope helpers added here as the ingress
+surfaces converge.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+from typing import Any, Protocol
+
+from gateway.platforms.base import MessageEvent, MessageType, SessionSource
+
+
+class IngressAdapter(Protocol):
+    """Minimal adapter surface required by the shared ingress helpers."""
+
+    _background_tasks: set[asyncio.Task]
+
+    def build_source(
+        self,
+        *,
+        chat_id: str,
+        chat_name: str | None = None,
+        chat_type: str = "dm",
+        user_id: str | None = None,
+        user_name: str | None = None,
+    ) -> SessionSource: ...
+
+    async def handle_message(self, event: MessageEvent): ...
+
+
+@dataclass(frozen=True)
+class IngressEnvelope:
+    """Normalized internal representation for HTTP-originated message ingress."""
+
+    text: str
+    message_id: str | None
+    chat_id: str
+    chat_name: str | None = None
+    chat_type: str = "webhook"
+    user_id: str | None = None
+    user_name: str | None = None
+    raw_payload: Any = None
+    internal: bool = False
+
+
+def build_ingress_message_event(adapter: IngressAdapter, envelope: IngressEnvelope) -> MessageEvent:
+    """Build a ``MessageEvent`` for an ingress envelope using an adapter's source factory."""
+
+    source = adapter.build_source(
+        chat_id=envelope.chat_id,
+        chat_name=envelope.chat_name,
+        chat_type=envelope.chat_type,
+        user_id=envelope.user_id,
+        user_name=envelope.user_name,
+    )
+    return MessageEvent(
+        text=envelope.text,
+        message_type=MessageType.TEXT,
+        source=source,
+        raw_message=envelope.raw_payload,
+        message_id=envelope.message_id,
+        internal=envelope.internal,
+    )
+
+
+def schedule_ingress_event(adapter: IngressAdapter, event: MessageEvent) -> asyncio.Task | None:
+    """Schedule a background ingress event and register it with the adapter."""
+
+    task = asyncio.create_task(adapter.handle_message(event))
+    try:
+        adapter._background_tasks.add(task)
+    except TypeError:
+        # Mirror the base adapter's test-friendly behavior: some tests stub
+        # task creation with lightweight sentinels that aren't hashable.
+        return None
+    if hasattr(task, "add_done_callback"):
+        task.add_done_callback(adapter._background_tasks.discard)
+    return task
+
+
+def schedule_ingress_envelope(adapter: IngressAdapter, envelope: IngressEnvelope) -> asyncio.Task | None:
+    """Build and schedule an ingress envelope in one step."""
+
+    event = build_ingress_message_event(adapter, envelope)
+    return schedule_ingress_event(adapter, event)

--- a/gateway/ingress.py
+++ b/gateway/ingress.py
@@ -201,25 +201,31 @@ def _normalize_chat_content(
 
     if isinstance(content, list):
         parts: List[str] = []
+        total_len = 0
         items = content[:MAX_CONTENT_LIST_SIZE] if len(content) > MAX_CONTENT_LIST_SIZE else content
         for item in items:
             if isinstance(item, str):
                 if item:
-                    parts.append(item[:MAX_NORMALIZED_TEXT_LENGTH])
+                    part = item[:MAX_NORMALIZED_TEXT_LENGTH]
+                    parts.append(part)
+                    total_len += len(part)
             elif isinstance(item, dict):
                 item_type = str(item.get("type") or "").strip().lower()
                 if item_type in {"text", "input_text", "output_text"}:
                     text = item.get("text", "")
                     if text:
                         try:
-                            parts.append(str(text)[:MAX_NORMALIZED_TEXT_LENGTH])
+                            part = str(text)[:MAX_NORMALIZED_TEXT_LENGTH]
+                            parts.append(part)
+                            total_len += len(part)
                         except Exception:
                             pass
             elif isinstance(item, list):
                 nested = _normalize_chat_content(item, _max_depth=_max_depth, _depth=_depth + 1)
                 if nested:
                     parts.append(nested)
-            if sum(len(p) for p in parts) >= MAX_NORMALIZED_TEXT_LENGTH:
+                    total_len += len(nested)
+            if total_len >= MAX_NORMALIZED_TEXT_LENGTH:
                 break
         result = "\n".join(parts)
         return result[:MAX_NORMALIZED_TEXT_LENGTH] if len(result) > MAX_NORMALIZED_TEXT_LENGTH else result

--- a/gateway/ingress.py
+++ b/gateway/ingress.py
@@ -1,22 +1,35 @@
 """Shared helpers for HTTP-style ingress sources.
 
-This module is intentionally narrow: it defines a small normalized envelope
-for gateway-style ingress events and the common boilerplate for turning those
-into ``MessageEvent`` objects and scheduling background dispatch.
+This module now holds two narrow families of ingress logic:
 
-The first concrete consumers are webhook-like adapters.  API-server request
-handlers still own their direct ``AIAgent`` execution path for now, but can
-progressively reuse the request/envelope helpers added here as the ingress
-surfaces converge.
+1. Webhook-style envelope helpers that build/schedule ``MessageEvent`` objects.
+2. Request-normalization helpers shared by HTTP API ingress surfaces.
+
+The goal is deliberately modest: provide a proven internal seam after parsing and
+before execution, without changing public handler behavior.
 """
 
 from __future__ import annotations
 
 import asyncio
 from dataclasses import dataclass
-from typing import Any, Protocol
+from typing import Any, Dict, List, Optional, Protocol
+
+try:
+    from aiohttp import web
+except ImportError:  # pragma: no cover - import guard mirrors api_server optional dependency handling
+    web = None  # type: ignore[assignment]
 
 from gateway.platforms.base import MessageEvent, MessageType, SessionSource
+
+MAX_NORMALIZED_TEXT_LENGTH = 65_536
+MAX_CONTENT_LIST_SIZE = 1_000
+
+_TRUE_REQUEST_BOOL_STRINGS = frozenset({"1", "true", "yes", "on"})
+_FALSE_REQUEST_BOOL_STRINGS = frozenset({"0", "false", "no", "off"})
+_TEXT_PART_TYPES = frozenset({"text", "input_text", "output_text"})
+_IMAGE_PART_TYPES = frozenset({"image_url", "input_image"})
+_FILE_PART_TYPES = frozenset({"file", "input_file"})
 
 
 class IngressAdapter(Protocol):
@@ -51,6 +64,51 @@ class IngressEnvelope:
     user_name: str | None = None
     raw_payload: Any = None
     internal: bool = False
+
+
+@dataclass(frozen=True)
+class NormalizedSessionChatRequest:
+    """Normalized request payload shared by session chat sync + streaming endpoints."""
+
+    user_message: Any
+    system_prompt: Optional[str] = None
+
+
+@dataclass(frozen=True)
+class NormalizedRunRequest:
+    """Normalized /v1/runs request body before response-store expansion."""
+
+    raw_input: Any
+    user_message: str
+    conversation_history: List[Dict[str, str]]
+    instructions: Optional[str] = None
+    previous_response_id: Optional[str] = None
+    session_id: Optional[str] = None
+
+
+@dataclass(frozen=True)
+class NormalizedChatCompletionsRequest:
+    """Normalized /v1/chat/completions request body."""
+
+    user_message: Any
+    history: List[Dict[str, Any]]
+    conversation_messages: List[Dict[str, Any]]
+    system_prompt: Optional[str] = None
+
+
+@dataclass(frozen=True)
+class NormalizedResponsesRequest:
+    """Normalized /v1/responses request body before response-store chaining."""
+
+    raw_input: Any
+    input_messages: List[Dict[str, Any]]
+    user_message: Any
+    conversation_history: List[Dict[str, Any]]
+    instructions: Optional[str] = None
+    previous_response_id: Optional[str] = None
+    conversation: Optional[str] = None
+    store: bool = True
+    history_from_input_messages: bool = False
 
 
 def build_ingress_message_event(adapter: IngressAdapter, envelope: IngressEnvelope) -> MessageEvent:
@@ -93,3 +151,419 @@ def schedule_ingress_envelope(adapter: IngressAdapter, envelope: IngressEnvelope
 
     event = build_ingress_message_event(adapter, envelope)
     return schedule_ingress_event(adapter, event)
+
+
+def _openai_error(
+    message: str,
+    err_type: str = "invalid_request_error",
+    param: Optional[str] = None,
+    code: Optional[str] = None,
+) -> Dict[str, Any]:
+    """OpenAI-style error envelope."""
+    return {
+        "error": {
+            "message": message,
+            "type": err_type,
+            "param": param,
+            "code": code,
+        }
+    }
+
+
+def _coerce_request_bool(value: Any, default: bool = False) -> bool:
+    """Normalize boolean-like API payload values."""
+    if isinstance(value, bool):
+        return value
+    if value is None:
+        return default
+    if isinstance(value, str):
+        normalized = value.strip().lower()
+        if normalized in _TRUE_REQUEST_BOOL_STRINGS:
+            return True
+        if normalized in _FALSE_REQUEST_BOOL_STRINGS:
+            return False
+        return default
+    if isinstance(value, (int, float)):
+        return bool(value)
+    return default
+
+
+def _normalize_chat_content(
+    content: Any, *, _max_depth: int = 10, _depth: int = 0,
+) -> str:
+    """Normalize OpenAI chat message content into a plain text string."""
+    if _depth > _max_depth:
+        return ""
+    if content is None:
+        return ""
+    if isinstance(content, str):
+        return content[:MAX_NORMALIZED_TEXT_LENGTH] if len(content) > MAX_NORMALIZED_TEXT_LENGTH else content
+
+    if isinstance(content, list):
+        parts: List[str] = []
+        items = content[:MAX_CONTENT_LIST_SIZE] if len(content) > MAX_CONTENT_LIST_SIZE else content
+        for item in items:
+            if isinstance(item, str):
+                if item:
+                    parts.append(item[:MAX_NORMALIZED_TEXT_LENGTH])
+            elif isinstance(item, dict):
+                item_type = str(item.get("type") or "").strip().lower()
+                if item_type in {"text", "input_text", "output_text"}:
+                    text = item.get("text", "")
+                    if text:
+                        try:
+                            parts.append(str(text)[:MAX_NORMALIZED_TEXT_LENGTH])
+                        except Exception:
+                            pass
+            elif isinstance(item, list):
+                nested = _normalize_chat_content(item, _max_depth=_max_depth, _depth=_depth + 1)
+                if nested:
+                    parts.append(nested)
+            if sum(len(p) for p in parts) >= MAX_NORMALIZED_TEXT_LENGTH:
+                break
+        result = "\n".join(parts)
+        return result[:MAX_NORMALIZED_TEXT_LENGTH] if len(result) > MAX_NORMALIZED_TEXT_LENGTH else result
+
+    try:
+        result = str(content)
+        return result[:MAX_NORMALIZED_TEXT_LENGTH] if len(result) > MAX_NORMALIZED_TEXT_LENGTH else result
+    except Exception:
+        return ""
+
+
+def _normalize_multimodal_content(content: Any) -> Any:
+    """Validate and normalize multimodal content for API-style ingress."""
+    if content is None:
+        return ""
+    if isinstance(content, str):
+        return content[:MAX_NORMALIZED_TEXT_LENGTH] if len(content) > MAX_NORMALIZED_TEXT_LENGTH else content
+    if not isinstance(content, list):
+        return _normalize_chat_content(content)
+
+    items = content[:MAX_CONTENT_LIST_SIZE] if len(content) > MAX_CONTENT_LIST_SIZE else content
+    normalized_parts: List[Dict[str, Any]] = []
+
+    for part in items:
+        if isinstance(part, str):
+            if part:
+                trimmed = part[:MAX_NORMALIZED_TEXT_LENGTH]
+                normalized_parts.append({"type": "text", "text": trimmed})
+            continue
+
+        if not isinstance(part, dict):
+            continue
+
+        raw_type = part.get("type")
+        part_type = str(raw_type or "").strip().lower()
+
+        if part_type in _TEXT_PART_TYPES:
+            text = part.get("text")
+            if text is None:
+                continue
+            if not isinstance(text, str):
+                text = str(text)
+            if text:
+                trimmed = text[:MAX_NORMALIZED_TEXT_LENGTH]
+                normalized_parts.append({"type": "text", "text": trimmed})
+            continue
+
+        if part_type in _IMAGE_PART_TYPES:
+            detail = part.get("detail")
+            image_ref = part.get("image_url")
+            if isinstance(image_ref, dict):
+                url_value = image_ref.get("url")
+                detail = image_ref.get("detail", detail)
+            else:
+                url_value = image_ref
+            if not isinstance(url_value, str) or not url_value.strip():
+                raise ValueError("invalid_image_url:Image parts must include a non-empty image URL.")
+            url_value = url_value.strip()
+            lowered = url_value.lower()
+            if lowered.startswith("data:"):
+                if not lowered.startswith("data:image/") or "," not in url_value:
+                    raise ValueError(
+                        "unsupported_content_type:Only image data URLs are supported. "
+                        "Non-image data payloads are not supported."
+                    )
+            elif not (lowered.startswith("http://") or lowered.startswith("https://")):
+                raise ValueError(
+                    "invalid_image_url:Image inputs must use http(s) URLs or data:image/... URLs."
+                )
+            image_part: Dict[str, Any] = {"type": "image_url", "image_url": {"url": url_value}}
+            if detail is not None:
+                if not isinstance(detail, str) or not detail.strip():
+                    raise ValueError("invalid_content_part:Image detail must be a non-empty string when provided.")
+                image_part["image_url"]["detail"] = detail.strip()
+            normalized_parts.append(image_part)
+            continue
+
+        if part_type in _FILE_PART_TYPES:
+            raise ValueError(
+                "unsupported_content_type:Inline image inputs are supported, "
+                "but uploaded files and document inputs are not supported on this endpoint."
+            )
+
+        raise ValueError(
+            f"unsupported_content_type:Unsupported content part type {raw_type!r}. "
+            "Only text and image_url/input_image parts are supported."
+        )
+
+    if not normalized_parts:
+        return ""
+    if all(p.get("type") == "text" for p in normalized_parts):
+        return "\n".join(p["text"] for p in normalized_parts if p.get("text"))
+    return normalized_parts
+
+
+def _content_has_visible_payload(content: Any) -> bool:
+    """True when content has any text or image attachment."""
+    if isinstance(content, str):
+        return bool(content.strip())
+    if isinstance(content, list):
+        for part in content:
+            if isinstance(part, dict):
+                ptype = str(part.get("type") or "").strip().lower()
+                if ptype in _TEXT_PART_TYPES and str(part.get("text") or "").strip():
+                    return True
+                if ptype in _IMAGE_PART_TYPES:
+                    return True
+    return False
+
+
+def _multimodal_validation_error(exc: ValueError, *, param: str) -> Any:
+    """Translate a multimodal validation ``ValueError`` into a 400 response."""
+    raw = str(exc)
+    code, _, message = raw.partition(":")
+    if not message:
+        code, message = "invalid_content_part", raw
+    assert web is not None
+    return web.json_response(
+        _openai_error(message, code=code, param=param),
+        status=400,
+    )
+
+
+def _session_chat_user_message(body: Dict[str, Any], *, param: str = "message") -> tuple[Any, Any]:
+    """Parse and normalize session chat ``message`` / ``input`` like chat completions."""
+    user_message = body.get("message") or body.get("input")
+    if not _content_has_visible_payload(user_message):
+        assert web is not None
+        return None, web.json_response(
+            _openai_error("Missing 'message' field", code="missing_message"),
+            status=400,
+        )
+    try:
+        return _normalize_multimodal_content(user_message), None
+    except ValueError as exc:
+        return None, _multimodal_validation_error(exc, param=param)
+
+
+def _normalize_session_chat_request(
+    body: Dict[str, Any], *, message_param: str = "message"
+) -> tuple[Optional[NormalizedSessionChatRequest], Any]:
+    """Normalize shared session-chat request fields used by sync + SSE handlers."""
+    user_message, err = _session_chat_user_message(body, param=message_param)
+    if err is not None:
+        return None, err
+    system_prompt = body.get("system_message") or body.get("instructions")
+    if system_prompt is not None and not isinstance(system_prompt, str):
+        assert web is not None
+        return None, web.json_response(
+            _openai_error("system_message must be a string", code="invalid_system_message"),
+            status=400,
+        )
+    return NormalizedSessionChatRequest(
+        user_message=user_message,
+        system_prompt=system_prompt,
+    ), None
+
+
+def _normalize_run_request(
+    body: Dict[str, Any],
+) -> tuple[Optional[NormalizedRunRequest], Any]:
+    """Normalize /v1/runs body fields prior to previous_response expansion."""
+    raw_input = body.get("input")
+    if not raw_input:
+        assert web is not None
+        return None, web.json_response(_openai_error("Missing 'input' field"), status=400)
+
+    user_message = raw_input
+    conversation_history: List[Dict[str, str]] = []
+    if isinstance(raw_input, list):
+        last_message = raw_input[-1] if raw_input else None
+        if isinstance(last_message, dict):
+            user_message = _normalize_chat_content(last_message.get("content", ""))
+        else:
+            user_message = _normalize_chat_content(last_message)
+    elif not isinstance(raw_input, str):
+        user_message = _normalize_chat_content(raw_input)
+
+    if not user_message:
+        assert web is not None
+        return None, web.json_response(_openai_error("No user message found in input"), status=400)
+
+    raw_history = body.get("conversation_history")
+    if raw_history:
+        if not isinstance(raw_history, list):
+            assert web is not None
+            return None, web.json_response(
+                _openai_error("'conversation_history' must be an array of message objects"),
+                status=400,
+            )
+        for i, entry in enumerate(raw_history):
+            if not isinstance(entry, dict) or "role" not in entry or "content" not in entry:
+                assert web is not None
+                return None, web.json_response(
+                    _openai_error(f"conversation_history[{i}] must have 'role' and 'content' fields"),
+                    status=400,
+                )
+            conversation_history.append({"role": str(entry["role"]), "content": str(entry["content"])})
+    elif isinstance(raw_input, list) and len(raw_input) > 1:
+        for msg in raw_input[:-1]:
+            if isinstance(msg, dict) and msg.get("role") and msg.get("content"):
+                conversation_history.append(
+                    {
+                        "role": str(msg["role"]),
+                        "content": _normalize_chat_content(msg["content"]),
+                    }
+                )
+
+    return NormalizedRunRequest(
+        raw_input=raw_input,
+        user_message=str(user_message),
+        conversation_history=conversation_history,
+        instructions=body.get("instructions"),
+        previous_response_id=body.get("previous_response_id"),
+        session_id=body.get("session_id"),
+    ), None
+
+
+def _normalize_chat_completions_request(
+    body: Dict[str, Any],
+) -> tuple[Optional[NormalizedChatCompletionsRequest], Any]:
+    """Normalize /v1/chat/completions request fields prior to session handling."""
+    messages = body.get("messages")
+    if not messages or not isinstance(messages, list):
+        assert web is not None
+        return None, web.json_response(
+            {"error": {"message": "Missing or invalid 'messages' field", "type": "invalid_request_error"}},
+            status=400,
+        )
+
+    system_prompt = None
+    conversation_messages: List[Dict[str, Any]] = []
+    for idx, msg in enumerate(messages):
+        role = msg.get("role", "") if isinstance(msg, dict) else ""
+        raw_content = msg.get("content", "") if isinstance(msg, dict) else ""
+        if role == "system":
+            content = _normalize_chat_content(raw_content)
+            if system_prompt is None:
+                system_prompt = content
+            else:
+                system_prompt = system_prompt + "\n" + content
+        elif role in {"user", "assistant"}:
+            try:
+                content = _normalize_multimodal_content(raw_content)
+            except ValueError as exc:
+                return None, _multimodal_validation_error(exc, param=f"messages[{idx}].content")
+            conversation_messages.append({"role": role, "content": content})
+
+    user_message: Any = ""
+    history: List[Dict[str, Any]] = []
+    if conversation_messages:
+        user_message = conversation_messages[-1].get("content", "")
+        history = conversation_messages[:-1]
+
+    if not _content_has_visible_payload(user_message):
+        assert web is not None
+        return None, web.json_response(
+            {"error": {"message": "No user message found in messages", "type": "invalid_request_error"}},
+            status=400,
+        )
+
+    return NormalizedChatCompletionsRequest(
+        user_message=user_message,
+        history=history,
+        conversation_messages=conversation_messages,
+        system_prompt=system_prompt,
+    ), None
+
+
+def _normalize_responses_request(
+    body: Dict[str, Any],
+) -> tuple[Optional[NormalizedResponsesRequest], Any]:
+    """Normalize /v1/responses request fields before response-store chaining."""
+    raw_input = body.get("input")
+    if raw_input is None:
+        assert web is not None
+        return None, web.json_response(_openai_error("Missing 'input' field"), status=400)
+
+    instructions = body.get("instructions")
+    previous_response_id = body.get("previous_response_id")
+    conversation = body.get("conversation")
+    store = _coerce_request_bool(body.get("store"), default=True)
+
+    if conversation and previous_response_id:
+        assert web is not None
+        return None, web.json_response(_openai_error("Cannot use both 'conversation' and 'previous_response_id'"), status=400)
+
+    input_messages: List[Dict[str, Any]] = []
+    if isinstance(raw_input, str):
+        input_messages = [{"role": "user", "content": raw_input}]
+    elif isinstance(raw_input, list):
+        for idx, item in enumerate(raw_input):
+            if isinstance(item, str):
+                input_messages.append({"role": "user", "content": item})
+            elif isinstance(item, dict):
+                role = item.get("role", "user")
+                try:
+                    content = _normalize_multimodal_content(item.get("content", ""))
+                except ValueError as exc:
+                    return None, _multimodal_validation_error(exc, param=f"input[{idx}].content")
+                input_messages.append({"role": role, "content": content})
+    else:
+        assert web is not None
+        return None, web.json_response(_openai_error("'input' must be a string or array"), status=400)
+
+    conversation_history: List[Dict[str, Any]] = []
+    history_from_input_messages = False
+    raw_history = body.get("conversation_history")
+    if raw_history:
+        if not isinstance(raw_history, list):
+            assert web is not None
+            return None, web.json_response(
+                _openai_error("'conversation_history' must be an array of message objects"),
+                status=400,
+            )
+        for i, entry in enumerate(raw_history):
+            if not isinstance(entry, dict) or "role" not in entry or "content" not in entry:
+                assert web is not None
+                return None, web.json_response(
+                    _openai_error(f"conversation_history[{i}] must have 'role' and 'content' fields"),
+                    status=400,
+                )
+            try:
+                entry_content = _normalize_multimodal_content(entry["content"])
+            except ValueError as exc:
+                return None, _multimodal_validation_error(exc, param=f"conversation_history[{i}].content")
+            conversation_history.append({"role": str(entry["role"]), "content": entry_content})
+    else:
+        conversation_history = list(input_messages[:-1])
+        history_from_input_messages = True
+
+    user_message: Any = input_messages[-1].get("content", "") if input_messages else ""
+    if not _content_has_visible_payload(user_message):
+        assert web is not None
+        return None, web.json_response(_openai_error("No user message found in input"), status=400)
+
+    return NormalizedResponsesRequest(
+        raw_input=raw_input,
+        input_messages=input_messages,
+        user_message=user_message,
+        conversation_history=conversation_history,
+        instructions=instructions,
+        previous_response_id=previous_response_id,
+        conversation=conversation,
+        store=store,
+        history_from_input_messages=history_from_input_messages,
+    ), None

--- a/gateway/ingress.py
+++ b/gateway/ingress.py
@@ -32,6 +32,7 @@ class IngressAdapter(Protocol):
         chat_type: str = "dm",
         user_id: str | None = None,
         user_name: str | None = None,
+        **kwargs: Any,
     ) -> SessionSource: ...
 
     async def handle_message(self, event: MessageEvent): ...

--- a/gateway/ingress.py
+++ b/gateway/ingress.py
@@ -567,3 +567,37 @@ def _normalize_responses_request(
         store=store,
         history_from_input_messages=history_from_input_messages,
     ), None
+
+from typing import Any, Dict
+
+def clean_log_value(value: Any, *, max_len: int = 200) -> str:
+    """Sanitize request metadata before it reaches security logs."""
+    if value is None:
+        return ""
+    text = str(value).replace("\r", " ").replace("\n", " ").strip()
+    return text[:max_len]
+
+def extract_request_audit_context(request: Any) -> Dict[str, str]:
+    """Return non-secret source metadata for security/audit warnings."""
+    peer_ip = ""
+    try:
+        peer = request.transport.get_extra_info("peername") if request.transport else None
+        if isinstance(peer, (tuple, list)) and peer:
+            peer_ip = str(peer[0])
+    except Exception:
+        peer_ip = ""
+
+    return {
+        "remote": clean_log_value(getattr(request, "remote", "") or peer_ip),
+        "peer_ip": clean_log_value(peer_ip),
+        "forwarded_for": clean_log_value(request.headers.get("X-Forwarded-For", "")),
+        "real_ip": clean_log_value(request.headers.get("X-Real-IP", "")),
+        "method": clean_log_value(request.method, max_len=16),
+        "path": clean_log_value(getattr(request, "path_qs", ""), max_len=500),
+        "user_agent": clean_log_value(request.headers.get("User-Agent", ""), max_len=300),
+    }
+
+def extract_request_audit_log_suffix(request: Any) -> str:
+    ctx = extract_request_audit_context(request)
+    fields = [f"{key}={value!r}" for key, value in ctx.items() if value]
+    return " ".join(fields) if fields else "source='unknown'"

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -323,18 +323,6 @@ else:
     cors_middleware = None  # type: ignore[assignment]
 
 
-def _openai_error(message: str, err_type: str = "invalid_request_error", param: str = None, code: str = None) -> Dict[str, Any]:
-    """OpenAI-style error envelope."""
-    return {
-        "error": {
-            "message": message,
-            "type": err_type,
-            "param": param,
-            "code": code,
-        }
-    }
-
-
 if AIOHTTP_AVAILABLE:
     @web.middleware
     async def body_limit_middleware(request, handler):

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -54,6 +54,8 @@ except ImportError:
 
 from gateway.config import Platform, PlatformConfig
 from gateway.ingress import (
+    extract_request_audit_context,
+    extract_request_audit_log_suffix,
     _coerce_request_bool,
     _content_has_visible_payload,
     _multimodal_validation_error,
@@ -617,13 +619,13 @@ class APIServerAdapter(BasePlatformAdapter):
         }
 
     def _request_audit_log_suffix(self, request: "web.Request") -> str:
-        ctx = self._request_audit_context(request)
+        ctx = extract_request_audit_context(request)
         fields = [f"{key}={value!r}" for key, value in ctx.items() if value]
         return " ".join(fields) if fields else "source='unknown'"
 
     def _cron_origin_from_request(self, request: "web.Request") -> Dict[str, str]:
         """Persist safe API source metadata on cron jobs created over HTTP."""
-        ctx = self._request_audit_context(request)
+        ctx = extract_request_audit_context(request)
         origin = {
             "platform": "api_server",
             "chat_id": "api",
@@ -663,7 +665,7 @@ class APIServerAdapter(BasePlatformAdapter):
 
         logger.warning(
             "API server rejected invalid API key: %s",
-            self._request_audit_log_suffix(request),
+            extract_request_audit_log_suffix(request),
         )
         return web.json_response(
             {"error": {"message": "Invalid API key", "type": "invalid_request_error", "code": "invalid_api_key"}},
@@ -2808,7 +2810,7 @@ class APIServerAdapter(BasePlatformAdapter):
             logger.warning(
                 "Cron jobs API rejected invalid job_id %r: %s",
                 job_id,
-                self._request_audit_log_suffix(request),
+                extract_request_audit_log_suffix(request),
             )
             return job_id, web.json_response(
                 {"error": "Invalid job ID format"}, status=400,

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -53,6 +53,18 @@ except ImportError:
     web = None  # type: ignore[assignment]
 
 from gateway.config import Platform, PlatformConfig
+from gateway.ingress import (
+    _coerce_request_bool,
+    _content_has_visible_payload,
+    _multimodal_validation_error,
+    _normalize_chat_completions_request,
+    _normalize_chat_content,
+    _normalize_multimodal_content,
+    _normalize_responses_request,
+    _normalize_run_request,
+    _normalize_session_chat_request,
+    _openai_error,
+)
 from gateway.platforms.base import (
     BasePlatformAdapter,
     SendResult,
@@ -90,8 +102,6 @@ DEFAULT_PORT = 8642
 MAX_STORED_RESPONSES = 100
 MAX_REQUEST_BYTES = 10_000_000  # 10 MB — accommodates long agent conversations with tool calls
 CHAT_COMPLETIONS_SSE_KEEPALIVE_SECONDS = 30.0
-MAX_NORMALIZED_TEXT_LENGTH = 65_536  # 64 KB cap for normalized content parts
-MAX_CONTENT_LIST_SIZE = 1_000  # Max items when content is an array
 
 
 def _coerce_port(value: Any, default: int = DEFAULT_PORT) -> int:
@@ -101,266 +111,6 @@ def _coerce_port(value: Any, default: int = DEFAULT_PORT) -> int:
     except (TypeError, ValueError):
         return default
 
-
-_TRUE_REQUEST_BOOL_STRINGS = frozenset({"1", "true", "yes", "on"})
-_FALSE_REQUEST_BOOL_STRINGS = frozenset({"0", "false", "no", "off"})
-
-
-def _coerce_request_bool(value: Any, default: bool = False) -> bool:
-    """Normalize boolean-like API payload values.
-
-    External clients should send real JSON booleans, but some OpenAI-compatible
-    frontends and middleware serialize flags like ``stream`` as strings.  Using
-    Python truthiness on those values misroutes requests because ``"false"`` is
-    still truthy.  Treat only explicit bool-ish scalars as booleans; everything
-    else falls back to the caller's default.
-    """
-    if isinstance(value, bool):
-        return value
-    if value is None:
-        return default
-    if isinstance(value, str):
-        normalized = value.strip().lower()
-        if normalized in _TRUE_REQUEST_BOOL_STRINGS:
-            return True
-        if normalized in _FALSE_REQUEST_BOOL_STRINGS:
-            return False
-        return default
-    if isinstance(value, (int, float)):
-        return bool(value)
-    return default
-
-
-def _normalize_chat_content(
-    content: Any, *, _max_depth: int = 10, _depth: int = 0,
-) -> str:
-    """Normalize OpenAI chat message content into a plain text string.
-
-    Some clients (Open WebUI, LobeChat, etc.) send content as an array of
-    typed parts instead of a plain string::
-
-        [{"type": "text", "text": "hello"}, {"type": "input_text", "text": "..."}]
-
-    This function flattens those into a single string so the agent pipeline
-    (which expects strings) doesn't choke.
-
-    Defensive limits prevent abuse: recursion depth, list size, and output
-    length are all bounded.
-    """
-    if _depth > _max_depth:
-        return ""
-    if content is None:
-        return ""
-    if isinstance(content, str):
-        return content[:MAX_NORMALIZED_TEXT_LENGTH] if len(content) > MAX_NORMALIZED_TEXT_LENGTH else content
-
-    if isinstance(content, list):
-        parts: List[str] = []
-        total_len = 0
-        items = content[:MAX_CONTENT_LIST_SIZE] if len(content) > MAX_CONTENT_LIST_SIZE else content
-        for item in items:
-            if isinstance(item, str):
-                if item:
-                    part = item[:MAX_NORMALIZED_TEXT_LENGTH]
-                    parts.append(part)
-                    total_len += len(part)
-            elif isinstance(item, dict):
-                item_type = str(item.get("type") or "").strip().lower()
-                if item_type in {"text", "input_text", "output_text"}:
-                    text = item.get("text", "")
-                    if text:
-                        try:
-                            part = str(text)[:MAX_NORMALIZED_TEXT_LENGTH]
-                            parts.append(part)
-                            total_len += len(part)
-                        except Exception:
-                            pass
-                # Silently skip image_url / other non-text parts
-            elif isinstance(item, list):
-                nested = _normalize_chat_content(item, _max_depth=_max_depth, _depth=_depth + 1)
-                if nested:
-                    parts.append(nested)
-                    total_len += len(nested)
-            # Check accumulated size
-            if total_len >= MAX_NORMALIZED_TEXT_LENGTH:
-                break
-        result = "\n".join(parts)
-        return result[:MAX_NORMALIZED_TEXT_LENGTH] if len(result) > MAX_NORMALIZED_TEXT_LENGTH else result
-
-    # Fallback for unexpected types (int, float, bool, etc.)
-    try:
-        result = str(content)
-        return result[:MAX_NORMALIZED_TEXT_LENGTH] if len(result) > MAX_NORMALIZED_TEXT_LENGTH else result
-    except Exception:
-        return ""
-
-
-# Content part type aliases used by the OpenAI Chat Completions and Responses
-# APIs.  We accept both spellings on input and emit a single canonical internal
-# shape (``{"type": "text", ...}`` / ``{"type": "image_url", ...}``) that the
-# rest of the agent pipeline already understands.
-_TEXT_PART_TYPES = frozenset({"text", "input_text", "output_text"})
-_IMAGE_PART_TYPES = frozenset({"image_url", "input_image"})
-_FILE_PART_TYPES = frozenset({"file", "input_file"})
-
-
-def _normalize_multimodal_content(content: Any) -> Any:
-    """Validate and normalize multimodal content for the API server.
-
-    Returns a plain string when the content is text-only, or a list of
-    ``{"type": "text"|"image_url", ...}`` parts when images are present.
-    The output shape is the native OpenAI Chat Completions vision format,
-    which the agent pipeline accepts verbatim (OpenAI-wire providers) or
-    converts (``_preprocess_anthropic_content`` for Anthropic).
-
-    Raises ``ValueError`` with an OpenAI-style code on invalid input:
-      * ``unsupported_content_type`` — file/input_file/file_id parts, or
-        non-image ``data:`` URLs.
-      * ``invalid_image_url`` — missing URL or unsupported scheme.
-      * ``invalid_content_part`` — malformed text/image objects.
-
-    Callers translate the ValueError into a 400 response.
-    """
-    # Scalar passthrough mirrors ``_normalize_chat_content``.
-    if content is None:
-        return ""
-    if isinstance(content, str):
-        return content[:MAX_NORMALIZED_TEXT_LENGTH] if len(content) > MAX_NORMALIZED_TEXT_LENGTH else content
-    if not isinstance(content, list):
-        # Mirror the legacy text-normalizer's fallback so callers that
-        # pre-existed image support still get a string back.
-        return _normalize_chat_content(content)
-
-    items = content[:MAX_CONTENT_LIST_SIZE] if len(content) > MAX_CONTENT_LIST_SIZE else content
-    normalized_parts: List[Dict[str, Any]] = []
-    text_accum_len = 0
-
-    for part in items:
-        if isinstance(part, str):
-            if part:
-                trimmed = part[:MAX_NORMALIZED_TEXT_LENGTH]
-                normalized_parts.append({"type": "text", "text": trimmed})
-                text_accum_len += len(trimmed)
-            continue
-
-        if not isinstance(part, dict):
-            # Ignore unknown scalars for forward compatibility with future
-            # Responses API additions (e.g. ``refusal``).  The same policy
-            # the text normalizer applies.
-            continue
-
-        raw_type = part.get("type")
-        part_type = str(raw_type or "").strip().lower()
-
-        if part_type in _TEXT_PART_TYPES:
-            text = part.get("text")
-            if text is None:
-                continue
-            if not isinstance(text, str):
-                text = str(text)
-            if text:
-                trimmed = text[:MAX_NORMALIZED_TEXT_LENGTH]
-                normalized_parts.append({"type": "text", "text": trimmed})
-                text_accum_len += len(trimmed)
-            continue
-
-        if part_type in _IMAGE_PART_TYPES:
-            detail = part.get("detail")
-            image_ref = part.get("image_url")
-            # OpenAI Responses sends ``input_image`` with a top-level
-            # ``image_url`` string; Chat Completions sends ``image_url`` as
-            # ``{"url": "...", "detail": "..."}``.  Support both.
-            if isinstance(image_ref, dict):
-                url_value = image_ref.get("url")
-                detail = image_ref.get("detail", detail)
-            else:
-                url_value = image_ref
-            if not isinstance(url_value, str) or not url_value.strip():
-                raise ValueError("invalid_image_url:Image parts must include a non-empty image URL.")
-            url_value = url_value.strip()
-            lowered = url_value.lower()
-            if lowered.startswith("data:"):
-                if not lowered.startswith("data:image/") or "," not in url_value:
-                    raise ValueError(
-                        "unsupported_content_type:Only image data URLs are supported. "
-                        "Non-image data payloads are not supported."
-                    )
-            elif not (lowered.startswith("http://") or lowered.startswith("https://")):
-                raise ValueError(
-                    "invalid_image_url:Image inputs must use http(s) URLs or data:image/... URLs."
-                )
-            image_part: Dict[str, Any] = {"type": "image_url", "image_url": {"url": url_value}}
-            if detail is not None:
-                if not isinstance(detail, str) or not detail.strip():
-                    raise ValueError("invalid_content_part:Image detail must be a non-empty string when provided.")
-                image_part["image_url"]["detail"] = detail.strip()
-            normalized_parts.append(image_part)
-            continue
-
-        if part_type in _FILE_PART_TYPES:
-            raise ValueError(
-                "unsupported_content_type:Inline image inputs are supported, "
-                "but uploaded files and document inputs are not supported on this endpoint."
-            )
-
-        # Unknown part type — reject explicitly so clients get a clear error
-        # instead of a silently dropped turn.
-        raise ValueError(
-            f"unsupported_content_type:Unsupported content part type {raw_type!r}. "
-            "Only text and image_url/input_image parts are supported."
-        )
-
-    if not normalized_parts:
-        return ""
-
-    # Text-only: collapse to a plain string so downstream logging/trajectory
-    # code sees the native shape and prompt caching on text-only turns is
-    # unaffected.
-    if all(p.get("type") == "text" for p in normalized_parts):
-        return "\n".join(p["text"] for p in normalized_parts if p.get("text"))
-
-    return normalized_parts
-
-
-def _content_has_visible_payload(content: Any) -> bool:
-    """True when content has any text or image attachment.  Used to reject empty turns."""
-    if isinstance(content, str):
-        return bool(content.strip())
-    if isinstance(content, list):
-        for part in content:
-            if isinstance(part, dict):
-                ptype = str(part.get("type") or "").strip().lower()
-                if ptype in _TEXT_PART_TYPES and str(part.get("text") or "").strip():
-                    return True
-                if ptype in _IMAGE_PART_TYPES:
-                    return True
-    return False
-
-
-def _multimodal_validation_error(exc: ValueError, *, param: str) -> "web.Response":
-    """Translate a ``_normalize_multimodal_content`` ValueError into a 400 response."""
-    raw = str(exc)
-    code, _, message = raw.partition(":")
-    if not message:
-        code, message = "invalid_content_part", raw
-    return web.json_response(
-        _openai_error(message, code=code, param=param),
-        status=400,
-    )
-
-
-def _session_chat_user_message(body: Dict[str, Any], *, param: str = "message") -> tuple[Any, Optional["web.Response"]]:
-    """Parse and normalize session chat ``message`` / ``input`` like chat completions."""
-    user_message = body.get("message") or body.get("input")
-    if not _content_has_visible_payload(user_message):
-        return None, web.json_response(
-            _openai_error("Missing 'message' field", code="missing_message"),
-            status=400,
-        )
-    try:
-        return _normalize_multimodal_content(user_message), None
-    except ValueError as exc:
-        return None, _multimodal_validation_error(exc, param=param)
 
 
 def check_api_server_requirements() -> bool:
@@ -1556,17 +1306,15 @@ class APIServerAdapter(BasePlatformAdapter):
         body, err = await self._read_json_body(request)
         if err:
             return err
-        user_message, err = _session_chat_user_message(body)
+        normalized_request, err = _normalize_session_chat_request(body)
         if err is not None:
             return err
-        system_prompt = body.get("system_message") or body.get("instructions")
-        if system_prompt is not None and not isinstance(system_prompt, str):
-            return web.json_response(_openai_error("system_message must be a string", code="invalid_system_message"), status=400)
+        assert normalized_request is not None
         history = self._conversation_history_for_session(session_id)
         result, usage = await self._run_agent(
-            user_message=user_message,
+            user_message=normalized_request.user_message,
             conversation_history=history,
-            ephemeral_system_prompt=system_prompt,
+            ephemeral_system_prompt=normalized_request.system_prompt,
             session_id=session_id,
             gateway_session_key=gateway_session_key,
         )
@@ -1600,12 +1348,10 @@ class APIServerAdapter(BasePlatformAdapter):
         body, err = await self._read_json_body(request)
         if err:
             return err
-        user_message, err = _session_chat_user_message(body)
+        normalized_request, err = _normalize_session_chat_request(body)
         if err is not None:
             return err
-        system_prompt = body.get("system_message") or body.get("instructions")
-        if system_prompt is not None and not isinstance(system_prompt, str):
-            return web.json_response(_openai_error("system_message must be a string", code="invalid_system_message"), status=400)
+        assert normalized_request is not None
 
         loop = asyncio.get_running_loop()
         queue: "asyncio.Queue[Optional[tuple[str, Dict[str, Any]]]]" = asyncio.Queue()
@@ -1649,13 +1395,13 @@ class APIServerAdapter(BasePlatformAdapter):
 
         async def _run_and_signal() -> None:
             try:
-                await queue.put(_event_payload("run.started", {"user_message": {"role": "user", "content": user_message}}))
+                await queue.put(_event_payload("run.started", {"user_message": {"role": "user", "content": normalized_request.user_message}}))
                 await queue.put(_event_payload("message.started", {"message": {"id": message_id, "role": "assistant"}}))
                 history = self._conversation_history_for_session(session_id)
                 result, usage = await self._run_agent(
-                    user_message=user_message,
+                    user_message=normalized_request.user_message,
                     conversation_history=history,
-                    ephemeral_system_prompt=system_prompt,
+                    ephemeral_system_prompt=normalized_request.system_prompt,
                     session_id=session_id,
                     stream_delta_callback=_delta,
                     tool_progress_callback=_tool_progress,
@@ -1663,7 +1409,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 )
                 final_response = result.get("final_response", "") if isinstance(result, dict) else ""
                 effective_session_id = result.get("session_id", session_id) if isinstance(result, dict) else session_id
-                turn_messages = self._turn_transcript_messages(history, user_message, result) if isinstance(result, dict) else []
+                turn_messages = self._turn_transcript_messages(history, normalized_request.user_message, result) if isinstance(result, dict) else []
                 await queue.put(_event_payload("assistant.completed", {
                     "session_id": effective_session_id,
                     "message_id": message_id,
@@ -1738,49 +1484,16 @@ class APIServerAdapter(BasePlatformAdapter):
         except (json.JSONDecodeError, Exception):
             return web.json_response(_openai_error("Invalid JSON in request body"), status=400)
 
-        messages = body.get("messages")
-        if not messages or not isinstance(messages, list):
-            return web.json_response(
-                {"error": {"message": "Missing or invalid 'messages' field", "type": "invalid_request_error"}},
-                status=400,
-            )
+        normalized_request, err = _normalize_chat_completions_request(body)
+        if err is not None:
+            return err
+        assert normalized_request is not None
 
         stream = _coerce_request_bool(body.get("stream"), default=False)
-
-        # Extract system message (becomes ephemeral system prompt layered ON TOP of core)
-        system_prompt = None
-        conversation_messages: List[Dict[str, str]] = []
-
-        for idx, msg in enumerate(messages):
-            role = msg.get("role", "")
-            raw_content = msg.get("content", "")
-            if role == "system":
-                # System messages don't support images (Anthropic rejects, OpenAI
-                # text-model systems don't render them).  Flatten to text.
-                content = _normalize_chat_content(raw_content)
-                if system_prompt is None:
-                    system_prompt = content
-                else:
-                    system_prompt = system_prompt + "\n" + content
-            elif role in {"user", "assistant"}:
-                try:
-                    content = _normalize_multimodal_content(raw_content)
-                except ValueError as exc:
-                    return _multimodal_validation_error(exc, param=f"messages[{idx}].content")
-                conversation_messages.append({"role": role, "content": content})
-
-        # Extract the last user message as the primary input
-        user_message: Any = ""
-        history = []
-        if conversation_messages:
-            user_message = conversation_messages[-1].get("content", "")
-            history = conversation_messages[:-1]
-
-        if not _content_has_visible_payload(user_message):
-            return web.json_response(
-                {"error": {"message": "No user message found in messages", "type": "invalid_request_error"}},
-                status=400,
-            )
+        system_prompt = normalized_request.system_prompt
+        conversation_messages = list(normalized_request.conversation_messages)
+        user_message = normalized_request.user_message
+        history = list(normalized_request.history)
 
         # Allow caller to scope long-term memory (e.g. Honcho) with a
         # stable per-channel identifier via X-Hermes-Session-Key.  This
@@ -2815,67 +2528,27 @@ class APIServerAdapter(BasePlatformAdapter):
                 status=400,
             )
 
-        raw_input = body.get("input")
-        if raw_input is None:
-            return web.json_response(_openai_error("Missing 'input' field"), status=400)
+        normalized_request, err = _normalize_responses_request(body)
+        if err is not None:
+            return err
+        assert normalized_request is not None
 
-        instructions = body.get("instructions")
-        previous_response_id = body.get("previous_response_id")
-        conversation = body.get("conversation")
-        store = _coerce_request_bool(body.get("store"), default=True)
-
-        # conversation and previous_response_id are mutually exclusive
-        if conversation and previous_response_id:
-            return web.json_response(_openai_error("Cannot use both 'conversation' and 'previous_response_id'"), status=400)
+        instructions = normalized_request.instructions
+        previous_response_id = normalized_request.previous_response_id
+        conversation = normalized_request.conversation
+        store = normalized_request.store
+        conversation_history = list(normalized_request.conversation_history)
+        input_messages = list(normalized_request.input_messages)
+        user_message = normalized_request.user_message
+        history_from_input_messages = normalized_request.history_from_input_messages
 
         # Resolve conversation name to latest response_id
         if conversation:
             previous_response_id = self._response_store.get_conversation(conversation)
             # No error if conversation doesn't exist yet — it's a new conversation
 
-        # Normalize input to message list
-        input_messages: List[Dict[str, Any]] = []
-        if isinstance(raw_input, str):
-            input_messages = [{"role": "user", "content": raw_input}]
-        elif isinstance(raw_input, list):
-            for idx, item in enumerate(raw_input):
-                if isinstance(item, str):
-                    input_messages.append({"role": "user", "content": item})
-                elif isinstance(item, dict):
-                    role = item.get("role", "user")
-                    try:
-                        content = _normalize_multimodal_content(item.get("content", ""))
-                    except ValueError as exc:
-                        return _multimodal_validation_error(exc, param=f"input[{idx}].content")
-                    input_messages.append({"role": role, "content": content})
-        else:
-            return web.json_response(_openai_error("'input' must be a string or array"), status=400)
-
-        # Accept explicit conversation_history from the request body.
-        # This lets stateless clients supply their own history instead of
-        # relying on server-side response chaining via previous_response_id.
-        # Precedence: explicit conversation_history > previous_response_id.
-        conversation_history: List[Dict[str, Any]] = []
-        raw_history = body.get("conversation_history")
-        if raw_history:
-            if not isinstance(raw_history, list):
-                return web.json_response(
-                    _openai_error("'conversation_history' must be an array of message objects"),
-                    status=400,
-                )
-            for i, entry in enumerate(raw_history):
-                if not isinstance(entry, dict) or "role" not in entry or "content" not in entry:
-                    return web.json_response(
-                        _openai_error(f"conversation_history[{i}] must have 'role' and 'content' fields"),
-                        status=400,
-                    )
-                try:
-                    entry_content = _normalize_multimodal_content(entry["content"])
-                except ValueError as exc:
-                    return _multimodal_validation_error(exc, param=f"conversation_history[{i}].content")
-                conversation_history.append({"role": str(entry["role"]), "content": entry_content})
-            if previous_response_id:
-                logger.debug("Both conversation_history and previous_response_id provided; using conversation_history")
+        if conversation_history and previous_response_id:
+            logger.debug("Both conversation_history and previous_response_id provided; using conversation_history")
 
         stored_session_id = None
         if not conversation_history and previous_response_id:
@@ -2889,11 +2562,11 @@ class APIServerAdapter(BasePlatformAdapter):
                 instructions = stored.get("instructions")
 
         # Append new input messages to history (all but the last become history)
-        for msg in input_messages[:-1]:
-            conversation_history.append(msg)
+        if not history_from_input_messages:
+            for msg in input_messages[:-1]:
+                conversation_history.append(msg)
 
-        # Last input message is the user_message
-        user_message: Any = input_messages[-1].get("content", "") if input_messages else ""
+        # Last input message is the user_message, already normalized above.
         if not _content_has_visible_payload(user_message):
             return web.json_response(_openai_error("No user message found in input"), status=400)
 
@@ -3651,38 +3324,19 @@ class APIServerAdapter(BasePlatformAdapter):
         except Exception:
             return web.json_response(_openai_error("Invalid JSON"), status=400)
 
-        raw_input = body.get("input")
-        if not raw_input:
-            return web.json_response(_openai_error("Missing 'input' field"), status=400)
+        normalized_request, err = _normalize_run_request(body)
+        if err is not None:
+            return err
+        assert normalized_request is not None
 
-        user_message = raw_input if isinstance(raw_input, str) else (raw_input[-1].get("content", "") if isinstance(raw_input, list) else "")
-        if not user_message:
-            return web.json_response(_openai_error("No user message found in input"), status=400)
-
-        instructions = body.get("instructions")
-        previous_response_id = body.get("previous_response_id")
-
-        # Accept explicit conversation_history from the request body.
-        # Precedence: explicit conversation_history > previous_response_id.
-        conversation_history: List[Dict[str, str]] = []
-        raw_history = body.get("conversation_history")
-        if raw_history:
-            if not isinstance(raw_history, list):
-                return web.json_response(
-                    _openai_error("'conversation_history' must be an array of message objects"),
-                    status=400,
-                )
-            for i, entry in enumerate(raw_history):
-                if not isinstance(entry, dict) or "role" not in entry or "content" not in entry:
-                    return web.json_response(
-                        _openai_error(f"conversation_history[{i}] must have 'role' and 'content' fields"),
-                        status=400,
-                    )
-                conversation_history.append({"role": str(entry["role"]), "content": str(entry["content"])})
-            if previous_response_id:
-                logger.debug("Both conversation_history and previous_response_id provided; using conversation_history")
+        instructions = normalized_request.instructions
+        previous_response_id = normalized_request.previous_response_id
+        conversation_history: List[Dict[str, str]] = list(normalized_request.conversation_history)
+        user_message = normalized_request.user_message
 
         stored_session_id = None
+        if conversation_history and previous_response_id:
+            logger.debug("Both conversation_history and previous_response_id provided; using conversation_history")
         if not conversation_history and previous_response_id:
             stored = self._response_store.get(previous_response_id)
             if stored:
@@ -3693,21 +3347,10 @@ class APIServerAdapter(BasePlatformAdapter):
 
         # When input is a multi-message array, extract all but the last
         # message as conversation history (the last becomes user_message).
-        # Only fires when no explicit history was provided.
-        if not conversation_history and isinstance(raw_input, list) and len(raw_input) > 1:
-            for msg in raw_input[:-1]:
-                if isinstance(msg, dict) and msg.get("role") and msg.get("content"):
-                    content = msg["content"]
-                    if isinstance(content, list):
-                        # Flatten multi-part content blocks to text
-                        content = " ".join(
-                            part.get("text", "") for part in content
-                            if isinstance(part, dict) and part.get("type") == "text"
-                        )
-                    conversation_history.append({"role": msg["role"], "content": str(content)})
+        # Done inside _normalize_run_request when no explicit history exists.
 
         run_id = f"run_{uuid.uuid4().hex}"
-        session_id = body.get("session_id") or stored_session_id or run_id
+        session_id = normalized_request.session_id or stored_session_id or run_id
         approval_session_key = gateway_session_key or session_id or run_id
         ephemeral_system_prompt = instructions
         loop = asyncio.get_running_loop()

--- a/gateway/platforms/msgraph_webhook.py
+++ b/gateway/platforms/msgraph_webhook.py
@@ -20,13 +20,8 @@ except ImportError:
     web = None  # type: ignore[assignment]
 
 from gateway.config import Platform, PlatformConfig
-from gateway.platforms.base import (
-    BasePlatformAdapter,
-    MessageEvent,
-    MessageType,
-    SendResult,
-    is_network_accessible,
-)
+from gateway.ingress import build_ingress_message_event, IngressEnvelope, schedule_ingress_event
+from gateway.platforms.base import BasePlatformAdapter, MessageEvent, SendResult, is_network_accessible
 
 logger = logging.getLogger(__name__)
 
@@ -356,21 +351,18 @@ class MSGraphWebhookAdapter(BasePlatformAdapter):
         receipt_key: Optional[str],
     ) -> MessageEvent:
         message_id = receipt_key or f"sha1:{sha1(json.dumps(notification, sort_keys=True).encode('utf-8')).hexdigest()}"
-        source = self.build_source(
+        envelope = IngressEnvelope(
+            text=self._render_prompt(notification),
+            message_id=message_id,
             chat_id=f"msgraph:{notification.get('subscriptionId', 'unknown')}",
             chat_name="msgraph/webhook",
             chat_type="webhook",
             user_id="msgraph",
             user_name="Microsoft Graph",
-        )
-        return MessageEvent(
-            text=self._render_prompt(notification),
-            message_type=MessageType.TEXT,
-            source=source,
-            raw_message=notification,
-            message_id=message_id,
+            raw_payload=notification,
             internal=True,
         )
+        return build_ingress_message_event(self, envelope)
 
     def _render_prompt(self, notification: Dict[str, Any]) -> str:
         template = self.config.extra.get("prompt", "")
@@ -416,6 +408,4 @@ class MSGraphWebhookAdapter(BasePlatformAdapter):
                 task.add_done_callback(self._background_tasks.discard)
             return
 
-        task = asyncio.create_task(self.handle_message(event))
-        self._background_tasks.add(task)
-        task.add_done_callback(self._background_tasks.discard)
+        schedule_ingress_event(self, event)

--- a/gateway/platforms/webhook.py
+++ b/gateway/platforms/webhook.py
@@ -48,12 +48,8 @@ except ImportError:
     web = None  # type: ignore[assignment]
 
 from gateway.config import Platform, PlatformConfig
-from gateway.platforms.base import (
-    BasePlatformAdapter,
-    MessageEvent,
-    MessageType,
-    SendResult,
-)
+from gateway.ingress import IngressEnvelope, schedule_ingress_envelope
+from gateway.platforms.base import BasePlatformAdapter, SendResult
 
 logger = logging.getLogger(__name__)
 
@@ -633,20 +629,15 @@ class WebhookAdapter(BasePlatformAdapter):
         self._delivery_info_order.append((now, session_chat_id))
         self._prune_delivery_info(now)
 
-        # Build source and event
-        source = self.build_source(
+        envelope = IngressEnvelope(
+            text=prompt,
+            message_id=delivery_id,
             chat_id=session_chat_id,
             chat_name=f"webhook/{route_name}",
             chat_type="webhook",
             user_id=f"webhook:{route_name}",
             user_name=route_name,
-        )
-        event = MessageEvent(
-            text=prompt,
-            message_type=MessageType.TEXT,
-            source=source,
-            raw_message=payload,
-            message_id=delivery_id,
+            raw_payload=payload,
         )
 
         logger.info(
@@ -659,9 +650,7 @@ class WebhookAdapter(BasePlatformAdapter):
         )
 
         # Non-blocking — return 202 Accepted immediately
-        task = asyncio.create_task(self.handle_message(event))
-        self._background_tasks.add(task)
-        task.add_done_callback(self._background_tasks.discard)
+        schedule_ingress_envelope(self, envelope)
 
         return web.json_response(
             {

--- a/tests/gateway/test_api_server_multimodal.py
+++ b/tests/gateway/test_api_server_multimodal.py
@@ -14,13 +14,8 @@ from aiohttp import web
 from aiohttp.test_utils import TestClient, TestServer
 
 from gateway.config import PlatformConfig
-from gateway.platforms.api_server import (
-    APIServerAdapter,
-    _content_has_visible_payload,
-    _normalize_multimodal_content,
-    cors_middleware,
-    security_headers_middleware,
-)
+from gateway.ingress import _content_has_visible_payload, _normalize_multimodal_content
+from gateway.platforms.api_server import APIServerAdapter, cors_middleware, security_headers_middleware
 
 
 # ---------------------------------------------------------------------------

--- a/tests/gateway/test_api_server_normalize.py
+++ b/tests/gateway/test_api_server_normalize.py
@@ -1,4 +1,5 @@
 """Tests for API server request/content normalization helpers."""
+import gateway.ingress as ingress
 from gateway.ingress import (
     _normalize_chat_completions_request,
     _normalize_chat_content,
@@ -359,7 +360,7 @@ class TestNormalizeChatContent:
             sum_calls += 1
             return sum(values)
 
-        monkeypatch.setattr(api_server, "sum", counting_sum, raising=False)
+        monkeypatch.setattr(ingress, "sum", counting_sum, raising=False)
         result = _normalize_chat_content(content)
 
         assert result.count("x") == 1000

--- a/tests/gateway/test_api_server_normalize.py
+++ b/tests/gateway/test_api_server_normalize.py
@@ -1,7 +1,269 @@
-"""Tests for _normalize_chat_content in the API server adapter."""
+"""Tests for API server request/content normalization helpers."""
+from gateway.ingress import (
+    _normalize_chat_completions_request,
+    _normalize_chat_content,
+    _normalize_responses_request,
+    _normalize_run_request,
+    _normalize_session_chat_request,
+)
 
-from gateway.platforms import api_server
-from gateway.platforms.api_server import _normalize_chat_content
+
+class TestNormalizeSessionChatRequest:
+    """Session chat request normalization shared by sync + streaming endpoints."""
+
+    def test_uses_system_message_when_present(self):
+        normalized, err = _normalize_session_chat_request(
+            {"message": "hello", "system_message": "stay focused"}
+        )
+        assert err is None
+        assert normalized.user_message == "hello"
+        assert normalized.system_prompt == "stay focused"
+
+    def test_falls_back_to_instructions(self):
+        normalized, err = _normalize_session_chat_request(
+            {"message": "hello", "instructions": "be concise"}
+        )
+        assert err is None
+        assert normalized.user_message == "hello"
+        assert normalized.system_prompt == "be concise"
+
+    def test_accepts_multimodal_message(self):
+        normalized, err = _normalize_session_chat_request(
+            {
+                "message": [
+                    {"type": "input_text", "text": "What is this?"},
+                    {"type": "input_image", "image_url": "data:image/png;base64,AAAA"},
+                ]
+            }
+        )
+        assert err is None
+        assert normalized.user_message == [
+            {"type": "text", "text": "What is this?"},
+            {"type": "image_url", "image_url": {"url": "data:image/png;base64,AAAA"}},
+        ]
+        assert normalized.system_prompt is None
+
+    def test_rejects_non_string_system_message(self):
+        normalized, err = _normalize_session_chat_request(
+            {"message": "hello", "system_message": ["not", "a", "string"]}
+        )
+        assert normalized is None
+        assert err is not None
+        assert err.status == 400
+
+
+class TestNormalizeRunRequest:
+    """/v1/runs request normalization shared by the runs handler."""
+
+    def test_accepts_string_input(self):
+        normalized, err = _normalize_run_request({"input": "hello"})
+        assert err is None
+        assert normalized.user_message == "hello"
+        assert normalized.instructions is None
+        assert normalized.previous_response_id is None
+        assert normalized.conversation_history == []
+        assert normalized.raw_input == "hello"
+
+    def test_extracts_history_from_multi_message_input(self):
+        normalized, err = _normalize_run_request(
+            {
+                "input": [
+                    {"role": "system", "content": "ignore me"},
+                    {"role": "user", "content": "first"},
+                    {"role": "assistant", "content": [{"type": "text", "text": "second"}]},
+                    {"role": "user", "content": "final"},
+                ]
+            }
+        )
+        assert err is None
+        assert normalized.user_message == "final"
+        assert normalized.conversation_history == [
+            {"role": "system", "content": "ignore me"},
+            {"role": "user", "content": "first"},
+            {"role": "assistant", "content": "second"},
+        ]
+
+    def test_preserves_explicit_conversation_history(self):
+        normalized, err = _normalize_run_request(
+            {
+                "input": [
+                    {"role": "user", "content": "first"},
+                    {"role": "user", "content": "final"},
+                ],
+                "conversation_history": [{"role": "assistant", "content": "from body"}],
+                "previous_response_id": "resp_123",
+                "instructions": "be concise",
+                "session_id": "sess_1",
+            }
+        )
+        assert err is None
+        assert normalized.user_message == "final"
+        assert normalized.conversation_history == [{"role": "assistant", "content": "from body"}]
+        assert normalized.previous_response_id == "resp_123"
+        assert normalized.instructions == "be concise"
+        assert normalized.session_id == "sess_1"
+
+    def test_rejects_missing_input(self):
+        normalized, err = _normalize_run_request({"model": "test"})
+        assert normalized is None
+        assert err is not None
+        assert err.status == 400
+
+    def test_rejects_invalid_conversation_history_shape(self):
+        normalized, err = _normalize_run_request(
+            {"input": "hello", "conversation_history": {"role": "user"}}
+        )
+        assert normalized is None
+        assert err is not None
+        assert err.status == 400
+
+
+class TestNormalizeResponsesRequest:
+    """/v1/responses request normalization prior to response-store chaining."""
+
+    def test_wraps_string_input_as_single_user_message(self):
+        normalized, err = _normalize_responses_request({"input": "hello"})
+        assert err is None
+        assert normalized.input_messages == [{"role": "user", "content": "hello"}]
+        assert normalized.user_message == "hello"
+        assert normalized.conversation_history == []
+        assert normalized.instructions is None
+        assert normalized.previous_response_id is None
+        assert normalized.conversation is None
+        assert normalized.store is True
+
+    def test_extracts_history_from_array_input_and_preserves_metadata(self):
+        normalized, err = _normalize_responses_request(
+            {
+                "input": [
+                    {"role": "user", "content": "first"},
+                    {"role": "assistant", "content": [{"type": "text", "text": "second"}]},
+                    {
+                        "role": "user",
+                        "content": [
+                            {"type": "input_text", "text": "final"},
+                            {"type": "input_image", "image_url": "https://example.com/cat.png"},
+                        ],
+                    },
+                ],
+                "instructions": "be concise",
+                "previous_response_id": "resp_1",
+                "conversation": None,
+                "store": "false",
+            }
+        )
+        assert err is None
+        assert normalized.input_messages == [
+            {"role": "user", "content": "first"},
+            {"role": "assistant", "content": "second"},
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "final"},
+                    {"type": "image_url", "image_url": {"url": "https://example.com/cat.png"}},
+                ],
+            },
+        ]
+        assert normalized.conversation_history == [
+            {"role": "user", "content": "first"},
+            {"role": "assistant", "content": "second"},
+        ]
+        assert normalized.user_message == [
+            {"type": "text", "text": "final"},
+            {"type": "image_url", "image_url": {"url": "https://example.com/cat.png"}},
+        ]
+        assert normalized.instructions == "be concise"
+        assert normalized.previous_response_id == "resp_1"
+        assert normalized.store is False
+
+    def test_explicit_conversation_history_takes_precedence(self):
+        normalized, err = _normalize_responses_request(
+            {
+                "input": [
+                    {"role": "user", "content": "first"},
+                    {"role": "user", "content": "final"},
+                ],
+                "conversation_history": [{"role": "assistant", "content": [{"type": "text", "text": "from body"}]}],
+                "previous_response_id": "resp_123",
+            }
+        )
+        assert err is None
+        assert normalized.conversation_history == [{"role": "assistant", "content": "from body"}]
+        assert normalized.previous_response_id == "resp_123"
+        assert normalized.user_message == "final"
+
+    def test_rejects_missing_input(self):
+        normalized, err = _normalize_responses_request({"model": "test"})
+        assert normalized is None
+        assert err is not None
+        assert err.status == 400
+
+    def test_rejects_conversation_and_previous_response_id_together(self):
+        normalized, err = _normalize_responses_request(
+            {"input": "hello", "conversation": "chat-1", "previous_response_id": "resp_1"}
+        )
+        assert normalized is None
+        assert err is not None
+        assert err.status == 400
+
+
+class TestNormalizeChatCompletionsRequest:
+    """/v1/chat/completions request normalization."""
+
+    def test_combines_system_messages_and_extracts_last_user_message(self):
+        normalized, err = _normalize_chat_completions_request(
+            {
+                "messages": [
+                    {"role": "system", "content": "be helpful"},
+                    {"role": "user", "content": "first"},
+                    {"role": "assistant", "content": "second"},
+                    {"role": "system", "content": [{"type": "text", "text": "stay concise"}]},
+                    {"role": "user", "content": "final"},
+                ]
+            }
+        )
+        assert err is None
+        assert normalized.system_prompt == "be helpful\nstay concise"
+        assert normalized.user_message == "final"
+        assert normalized.history == [
+            {"role": "user", "content": "first"},
+            {"role": "assistant", "content": "second"},
+        ]
+
+    def test_preserves_multimodal_user_content(self):
+        normalized, err = _normalize_chat_completions_request(
+            {
+                "messages": [
+                    {
+                        "role": "user",
+                        "content": [
+                            {"type": "text", "text": "what is this?"},
+                            {"type": "image_url", "image_url": {"url": "https://example.com/cat.png"}},
+                        ],
+                    }
+                ]
+            }
+        )
+        assert err is None
+        assert normalized.user_message == [
+            {"type": "text", "text": "what is this?"},
+            {"type": "image_url", "image_url": {"url": "https://example.com/cat.png"}},
+        ]
+        assert normalized.history == []
+
+    def test_rejects_missing_messages(self):
+        normalized, err = _normalize_chat_completions_request({"model": "test"})
+        assert normalized is None
+        assert err is not None
+        assert err.status == 400
+
+    def test_rejects_missing_user_message(self):
+        normalized, err = _normalize_chat_completions_request(
+            {"messages": [{"role": "system", "content": "only system"}]}
+        )
+        assert normalized is None
+        assert err is not None
+        assert err.status == 400
 
 
 class TestNormalizeChatContent:

--- a/tests/gateway/test_ingress.py
+++ b/tests/gateway/test_ingress.py
@@ -1,0 +1,105 @@
+"""Tests for shared HTTP-ingress helpers."""
+
+import asyncio
+from unittest.mock import AsyncMock
+
+import pytest
+
+from gateway.config import PlatformConfig
+from gateway.ingress import (
+    IngressEnvelope,
+    build_ingress_message_event,
+    schedule_ingress_envelope,
+    schedule_ingress_event,
+)
+from gateway.platforms.webhook import WebhookAdapter
+
+
+def _make_adapter() -> WebhookAdapter:
+    config = PlatformConfig(enabled=True, extra={"host": "127.0.0.1", "port": 0, "routes": {}})
+    return WebhookAdapter(config)
+
+
+class TestBuildIngressMessageEvent:
+    def test_builds_message_event_with_route_identity(self):
+        adapter = _make_adapter()
+        envelope = IngressEnvelope(
+            text="hello from ingress",
+            message_id="evt-1",
+            chat_id="webhook:ci:evt-1",
+            chat_name="webhook/ci",
+            chat_type="webhook",
+            user_id="webhook:ci",
+            user_name="ci",
+            raw_payload={"ref": "main"},
+        )
+
+        event = build_ingress_message_event(adapter, envelope)
+
+        assert event.text == "hello from ingress"
+        assert event.message_id == "evt-1"
+        assert event.raw_message == {"ref": "main"}
+        assert event.source.platform == adapter.platform
+        assert event.source.chat_id == "webhook:ci:evt-1"
+        assert event.source.chat_name == "webhook/ci"
+        assert event.source.chat_type == "webhook"
+        assert event.source.user_id == "webhook:ci"
+        assert event.source.user_name == "ci"
+
+
+class TestScheduleIngressEvent:
+    @pytest.mark.asyncio
+    async def test_tracks_background_task_until_completion(self):
+        adapter = _make_adapter()
+        captured = []
+
+        async def _capture(event):
+            captured.append(event)
+
+        adapter.handle_message = _capture
+        event = build_ingress_message_event(
+            adapter,
+            IngressEnvelope(
+                text="hello",
+                message_id="evt-2",
+                chat_id="webhook:test:evt-2",
+                raw_payload={"ok": True},
+            ),
+        )
+
+        task = schedule_ingress_event(adapter, event)
+        assert task in adapter._background_tasks
+
+        await task
+        await asyncio.sleep(0)
+
+        assert captured == [event]
+        assert task not in adapter._background_tasks
+
+    @pytest.mark.asyncio
+    async def test_schedule_envelope_builds_and_dispatches_event(self):
+        adapter = _make_adapter()
+        adapter.handle_message = AsyncMock()
+        envelope = IngressEnvelope(
+            text="dispatch me",
+            message_id="evt-3",
+            chat_id="webhook:test:evt-3",
+            chat_name="webhook/test",
+            user_id="webhook:test",
+            user_name="test",
+            raw_payload={"value": 3},
+            internal=True,
+        )
+
+        task = schedule_ingress_envelope(adapter, envelope)
+        await task
+
+        adapter.handle_message.assert_awaited_once()
+        await_args = adapter.handle_message.await_args
+        assert await_args is not None
+        dispatched_event = await_args.args[0]
+        assert dispatched_event.text == "dispatch me"
+        assert dispatched_event.message_id == "evt-3"
+        assert dispatched_event.internal is True
+        assert dispatched_event.source.chat_id == "webhook:test:evt-3"
+        assert dispatched_event.raw_message == {"value": 3}

--- a/tests/gateway/test_msgraph_webhook.py
+++ b/tests/gateway/test_msgraph_webhook.py
@@ -1,10 +1,12 @@
 """Tests for the Microsoft Graph webhook adapter."""
 
 import asyncio
+from typing import cast
 
 import pytest
 
 from gateway.config import GatewayConfig, Platform, PlatformConfig, _apply_env_overrides
+from gateway.platforms.base import MessageEvent
 from gateway.platforms.msgraph_webhook import AIOHTTP_AVAILABLE, MSGraphWebhookAdapter
 
 
@@ -177,11 +179,14 @@ class TestMSGraphNotifications:
         await asyncio.sleep(0.05)
 
         assert len(scheduled) == 1
-        notification, event = scheduled[0]
+        notification, event_obj = scheduled[0]
+        event = cast(MessageEvent, event_obj)
         assert notification["id"] == "notif-1"
         assert event.source.platform == Platform.MSGRAPH_WEBHOOK
         assert event.source.chat_type == "webhook"
         assert event.message_id == "id:notif-1"
+        assert event.internal is True
+        assert event.raw_message == payload["value"][0]
 
     @pytest.mark.anyio
     async def test_bad_client_state_rejected_as_auth_failure(self):

--- a/tests/gateway/test_webhook_adapter.py
+++ b/tests/gateway/test_webhook_adapter.py
@@ -499,6 +499,41 @@ class TestHTTPHandling:
             assert data["status"] == "accepted"
             assert data["route"] == "test"
 
+        adapter.handle_message.assert_awaited_once()
+        await_args = adapter.handle_message.await_args
+        assert await_args is not None
+        event = await_args.args[0]
+        assert event.text == "hi"
+        assert event.message_id
+        assert event.source.platform == Platform.WEBHOOK
+        assert event.source.chat_id == f"webhook:test:{event.message_id}"
+        assert event.source.chat_name == "webhook/test"
+        assert event.source.user_id == "webhook:test"
+        assert event.source.user_name == "test"
+        assert event.raw_message == {"data": "value"}
+
+    @pytest.mark.asyncio
+    async def test_webhook_preserves_delivery_id_as_message_id(self):
+        """Accepted webhook events keep delivery_id as MessageEvent.message_id."""
+        routes = {"test": {"secret": _INSECURE_NO_AUTH, "prompt": "hi"}}
+        adapter = _make_adapter(routes=routes)
+        adapter.handle_message = AsyncMock()
+
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post(
+                "/webhooks/test",
+                json={"data": "value"},
+                headers={"X-GitHub-Delivery": "delivery-xyz"},
+            )
+            assert resp.status == 202
+
+        await_args = adapter.handle_message.await_args
+        assert await_args is not None
+        event = await_args.args[0]
+        assert event.message_id == "delivery-xyz"
+        assert event.source.chat_id == "webhook:test:delivery-xyz"
+
     @pytest.mark.asyncio
     async def test_route_without_secret_rejects_unsigned_request(self):
         """Missing HMAC secret must fail closed even if connect() was bypassed."""

--- a/tests/gateway/test_webhook_adapter.py
+++ b/tests/gateway/test_webhook_adapter.py
@@ -535,6 +535,36 @@ class TestHTTPHandling:
         assert event.source.chat_id == "webhook:test:delivery-xyz"
 
     @pytest.mark.asyncio
+    async def test_webhook_handler_dispatches_shared_ingress_envelope(self):
+        """Webhook requests dispatch through the shared ingress envelope helper."""
+        routes = {"deploy": {"secret": _INSECURE_NO_AUTH, "prompt": "Deploy {branch}"}}
+        adapter = _make_adapter(routes=routes)
+        adapter.handle_message = AsyncMock()
+
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post(
+                "/webhooks/deploy",
+                json={"branch": "main"},
+                headers={"X-GitHub-Delivery": "delivery-42"},
+            )
+            assert resp.status == 202
+
+            await asyncio.sleep(0)
+
+        adapter.handle_message.assert_awaited_once()
+        dispatched_event = adapter.handle_message.await_args_list[0].args[0]
+        assert dispatched_event.text == "Deploy main"
+        assert dispatched_event.message_id == "delivery-42"
+        assert dispatched_event.raw_message == {"branch": "main"}
+        assert dispatched_event.source.chat_id == "webhook:deploy:delivery-42"
+        assert dispatched_event.source.chat_name == "webhook/deploy"
+        assert dispatched_event.source.chat_type == "webhook"
+        assert dispatched_event.source.user_id == "webhook:deploy"
+        assert dispatched_event.source.user_name == "deploy"
+        assert adapter._background_tasks == set()
+
+    @pytest.mark.asyncio
     async def test_route_without_secret_rejects_unsigned_request(self):
         """Missing HMAC secret must fail closed even if connect() was bypassed."""
         routes = {"test": {"prompt": "hi"}}


### PR DESCRIPTION
## Summary
- add a shared ingress envelope seam for webhook-style adapters
- lift shared API ingress normalization into `gateway.ingress`
- reuse shared request metadata extraction in `api_server.py`
- document the next safe follow-on migration seam
- keep normalization linear on current `main` after rebasing this slice cleanly

## Why
This re-cuts the ingress/router work into a clean thin slice on top of current `main`.
It supersedes the earlier oversized PR and removes unrelated daemon/backup noise so the change is reviewable on its own merits.

## Validation
```bash
python -m pytest tests/gateway/test_ingress.py tests/gateway/test_api_server_normalize.py tests/gateway/test_api_server.py tests/gateway/test_api_server_multimodal.py tests/gateway/test_webhook_adapter.py tests/gateway/test_msgraph_webhook.py -o 'addopts=' -q
```

Result: `316 passed, 0 failed`

## Notes
- supersedes #46232
- excludes the unrelated queue-worker/backup-file churn from the old branch
