### PR TITLE
fix(desktop): self-heal a network-blocked desktop install before pack (#47917 follow-up to #48081)

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -135,7 +135,7 @@
   },
   "build": {
     "electronVersion": "40.10.2",
-    "electronDist": "../../node_modules/electron/dist",
+    "electronDist": "node_modules/electron/dist",
     "appId": "com.nousresearch.hermes",
     "productName": "Hermes",
     "executableName": "Hermes",

--- a/apps/desktop/scripts/patch-electron-builder-mac-binary.cjs
+++ b/apps/desktop/scripts/patch-electron-builder-mac-binary.cjs
@@ -24,6 +24,11 @@ const replacement = `    // ${marker}: electron-builder 26.8.x can sometimes cop
     if (!fs.existsSync(bundledElectronBinary)) {
         const candidates = [
             path.join(packager.info.framework.distMacOsAppName, "Contents", "MacOS", electronBranding.productName),
+            // npm may nest the workspace-only electron devDep under
+            // apps/desktop/node_modules (process.cwd() during pack), or hoist
+            // it to the repo root. Try the workspace-local install first, then
+            // the root hoist, so the fallback works under either layout.
+            path.join(process.cwd(), "node_modules", "electron", "dist", "Electron.app", "Contents", "MacOS", electronBranding.productName),
             path.join(process.cwd(), "..", "..", "node_modules", "electron", "dist", "Electron.app", "Contents", "MacOS", electronBranding.productName),
         ];
         const sourceBinary = candidates.find(candidate => fs.existsSync(candidate));

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -5110,16 +5110,33 @@ def _purge_electron_build_cache(desktop_dir: Path) -> list[Path]:
     return removed
 
 
-def _electron_dist_binary(project_root: Path) -> Path:
-    """Return the path to the Electron main binary inside ``node_modules``.
+def _electron_dir(project_root: Path) -> Path:
+    """Return the Electron package directory the desktop workspace installs.
 
-    electron-builder reads the binary from ``build.electronDist``
-    (``node_modules/electron/dist``) since #38673, so this is the exact file
-    whose absence makes a pack fail with "The specified electronDist does not
-    exist". The basename differs per OS (the platform Electron is named for the
-    host the build runs on).
+    npm may keep workspace-only dev dependencies under
+    ``apps/desktop/node_modules`` instead of hoisting them to the repo root.
+    Which layout you get depends on the npm version and what else is installed,
+    so a build path that assumes one or the other breaks intermittently across
+    machines. ``apps/desktop/package.json`` points electron-builder's
+    ``electronDist`` at ``node_modules/electron/dist`` relative to the desktop
+    project, so prefer the workspace-local package and fall back to the root
+    hoist when that's where npm landed it.
     """
-    dist = project_root / "node_modules" / "electron" / "dist"
+    desktop_local = project_root / "apps" / "desktop" / "node_modules" / "electron"
+    if desktop_local.exists():
+        return desktop_local
+    return project_root / "node_modules" / "electron"
+
+
+def _electron_dist_binary(project_root: Path) -> Path:
+    """Return the path to the Electron main binary inside the installed package.
+
+    electron-builder reads the binary from ``build.electronDist`` since #38673,
+    so this is the exact file whose absence makes a pack fail with "The
+    specified electronDist does not exist". The basename differs per OS (the
+    platform Electron is named for the host the build runs on).
+    """
+    dist = _electron_dir(project_root) / "dist"
     if sys.platform == "darwin":
         return dist / "Electron.app" / "Contents" / "MacOS" / "Electron"
     if sys.platform == "win32":
@@ -5169,7 +5186,7 @@ def _redownload_electron_dist(
     if _electron_dist_ok(project_root):
         return True
 
-    electron_dir = project_root / "node_modules" / "electron"
+    electron_dir = _electron_dir(project_root)
     installer = electron_dir / "install.js"
     if not installer.is_file():
         return False
@@ -5387,8 +5404,8 @@ def cmd_gui(args: argparse.Namespace):
                 print("  Pre-build first:  cd apps/desktop && npm run build")
                 print("  Or drop --skip-build to install dependencies and build automatically.")
                 sys.exit(1)
-            if not (PROJECT_ROOT / "node_modules" / "electron" / "package.json").exists():
-                print("✗ --skip-build --source requires existing workspace dependencies.")
+            if not (_electron_dir(PROJECT_ROOT) / "package.json").exists():
+                print("✗ --skip-build --source requires existing desktop workspace dependencies.")
                 print(f"  Install first:  cd {PROJECT_ROOT} && npm ci")
                 print("  Or drop --skip-build to install dependencies and build automatically.")
                 sys.exit(1)

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -5110,6 +5110,16 @@ def _purge_electron_build_cache(desktop_dir: Path) -> list[Path]:
     return removed
 
 
+# Public Electron mirror used as a last-resort fallback when GitHub's release
+# host is blocked/throttled (the repeating "retrying" download symptom).
+# npmmirror.com is the de-facto Electron community mirror (Alibaba). @electron/get
+# SHASUM-checks the download, but the SHASUMS come from the same mirror — that
+# guards against a corrupt/partial download, NOT a compromised mirror. Reaching
+# for it is an explicit trust trade-off we only make AFTER the canonical GitHub
+# download has failed, and we never override a user-pinned ELECTRON_MIRROR.
+_ELECTRON_FALLBACK_MIRROR = "https://npmmirror.com/mirrors/electron/"
+
+
 def _electron_dir(project_root: Path) -> Path:
     """Return the Electron package directory the desktop workspace installs.
 
@@ -5433,9 +5443,35 @@ def cmd_gui(args: argparse.Namespace):
             nixos_env = _nixos_build_env()
             install_result = _run_npm_install_deterministic(npm, PROJECT_ROOT, capture_output=False, env=nixos_env)
             if install_result.returncode != 0:
-                print("✗ Desktop dependency install failed")
-                print(f"  Run manually:  cd {PROJECT_ROOT} && npm ci")
-                sys.exit(install_result.returncode or 1)
+                # The most common dependency-install failure is electron's
+                # postinstall binary download being blocked/throttled: its
+                # install.js does `process.exit(1)` on a failed download, which
+                # fails the whole `npm ci`/`npm install` (#47266, #47917). npm
+                # runs postinstall scripts LAST — after every package is already
+                # staged on disk — so when the binary download is the casualty
+                # the only thing missing is the desktop workspace's electron/dist.
+                # Repopulate it via electron's own downloader (canonical source
+                # first, then a public mirror when the user hasn't pinned one) and
+                # carry on to the build instead of aborting here. Without this, the
+                # mirror self-heal further down is dead code on a blocked network:
+                # it only runs after a failed `pack`, but the install step exits
+                # first so `pack` is never reached. _redownload_electron_dist
+                # resolves the right package dir via _electron_dir (#48081).
+                repaired = False
+                if not _electron_dist_ok(PROJECT_ROOT):
+                    repaired = _redownload_electron_dist(PROJECT_ROOT, env)
+                    if not repaired and not env.get("ELECTRON_MIRROR"):
+                        repaired = _redownload_electron_dist(
+                            PROJECT_ROOT, env, mirror=_ELECTRON_FALLBACK_MIRROR
+                        )
+                if repaired:
+                    print("  ⚠ Dependency install failed on the Electron binary "
+                          "download; repopulated the desktop Electron dist via a "
+                          "mirror and continuing.")
+                else:
+                    print("✗ Desktop dependency install failed")
+                    print(f"  Run manually:  cd {PROJECT_ROOT} && npm ci")
+                    sys.exit(install_result.returncode or 1)
 
             build_label = "source build" if source_mode else "packaged app"
             print(f"→ Building desktop {build_label}...")
@@ -5496,7 +5532,7 @@ def cmd_gui(args: argparse.Namespace):
                 print("  ⚠ Desktop build still failing; the Electron download from "
                       "GitHub looks blocked. Re-downloading via a public mirror "
                       "(npmmirror.com)... (set ELECTRON_MIRROR to use another mirror)")
-                mirror = "https://npmmirror.com/mirrors/electron/"
+                mirror = _ELECTRON_FALLBACK_MIRROR
                 mirror_env = dict(env)
                 mirror_env["ELECTRON_MIRROR"] = mirror
                 # electronDist is pinned (#38673), so `npm run pack` never

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -2161,28 +2161,41 @@ function Clear-ElectronBuildCache {
     return $removed
 }
 
-# True when node_modules\electron\dist holds a usable Electron binary.
-# electron-builder reads the binary from build.electronDist
-# (node_modules\electron\dist) since #38673, so this is the exact file whose
-# absence makes a pack fail with "The specified electronDist does not exist". A
-# dist dir that exists but is missing electron.exe (partial extraction / aborted
-# postinstall) is NOT ok.
+# Return the Electron package directory the desktop workspace installs. npm may
+# nest workspace-only dev dependencies under apps\desktop\node_modules instead
+# of hoisting them to the repo root; which layout you get depends on the npm
+# version and what else is installed. apps\desktop\package.json points
+# electron-builder's electronDist there, so prefer the workspace-local package
+# and fall back to the root hoist.
+function Get-ElectronDir {
+    param([string]$InstallDir)
+    $desktopLocal = Join-Path $InstallDir 'apps\desktop\node_modules\electron'
+    if (Test-Path -LiteralPath $desktopLocal) { return $desktopLocal }
+    return (Join-Path $InstallDir 'node_modules\electron')
+}
+
+# True when the desktop workspace electronDist holds a usable Electron binary.
+# electron-builder reads the binary from build.electronDist since #38673, so
+# this is the exact file whose absence makes a pack fail with "The specified
+# electronDist does not exist". A dist dir that exists but is missing
+# electron.exe (partial extraction / aborted postinstall) is NOT ok.
 function Test-ElectronDist {
     param([string]$InstallDir)
-    $distExe = Join-Path $InstallDir 'node_modules\electron\dist\electron.exe'
+    $electronDir = Get-ElectronDir -InstallDir $InstallDir
+    $distExe = Join-Path $electronDir 'dist\electron.exe'
     return (Test-Path -LiteralPath $distExe)
 }
 
-# (Re)populate node_modules\electron\dist via electron's own downloader.
+# (Re)populate the desktop Electron dist via electron's own downloader.
 #
-# Since #38673 the desktop build pins build.electronDist to
-# node_modules\electron\dist, so electron-builder reads the Electron binary
-# straight from there and never downloads it during `npm run pack`. That dist
-# tree is produced by the electron package's postinstall (install.js) during
-# `npm ci`. When that download is blocked/throttled (GitHub's release host is
-# unreachable in some regions - #47266), dist is missing and re-running pack only
-# re-throws "The specified electronDist does not exist". The mirror fallback
-# therefore has to drive THIS downloader, not another pack.
+# Since #38673 the desktop build pins build.electronDist, so electron-builder
+# reads the Electron binary straight from there and never downloads it during
+# `npm run pack`. That dist tree is produced by the electron package's
+# postinstall (install.js) during `npm ci`. When that download is
+# blocked/throttled (GitHub's release host is unreachable in some regions -
+# #47266), dist is missing and re-running pack only re-throws "The specified
+# electronDist does not exist". The mirror fallback therefore has to drive THIS
+# downloader, not another pack.
 #
 # No-op (returns $true) when the dist binary is already present. Otherwise drops a
 # partial dist + version marker (electron's install.js short-circuits when
@@ -2193,7 +2206,7 @@ function Restore-ElectronDist {
     param([string]$InstallDir, [string]$Mirror)
     if (Test-ElectronDist -InstallDir $InstallDir) { return $true }
 
-    $electronDir = Join-Path $InstallDir 'node_modules\electron'
+    $electronDir = Get-ElectronDir -InstallDir $InstallDir
     $distExe = Join-Path $electronDir 'dist\electron.exe'
     $installer = Join-Path $electronDir 'install.js'
     if (-not (Test-Path -LiteralPath $installer)) { return $false }

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -2329,8 +2329,32 @@ function Install-Desktop {
         }
         $ErrorActionPreference = $prevEAP
         if ($code -ne 0) {
-            Show-NpmCertHint ($npmOut -join "`n") | Out-Null
-            throw "desktop workspace npm install failed (exit $code) -- see lines above for cause"
+            # The usual cause is electron's postinstall binary download being
+            # blocked/throttled: its install.js does process.exit(1) on a failed
+            # download, which fails the whole `npm ci`/`npm install` (#47266,
+            # #47917). npm runs postinstall scripts LAST -- after every package is
+            # already staged on disk -- so when the binary download is the
+            # casualty the only thing missing is the desktop workspace's
+            # electron\dist. Repopulate it via electron's own downloader
+            # (canonical source first, then the public mirror when the user hasn't
+            # pinned one) and carry on to the build; the mirror self-heal after
+            # `pack` below is otherwise unreachable on a blocked network because
+            # this install step throws first. Restore-ElectronDist resolves the
+            # right package dir via Get-ElectronDir (#48081).
+            $depsRepaired = $false
+            if (-not (Test-ElectronDist -InstallDir $InstallDir)) {
+                if (Restore-ElectronDist -InstallDir $InstallDir) {
+                    $depsRepaired = $true
+                } elseif ((-not $env:ELECTRON_MIRROR) -and (Restore-ElectronDist -InstallDir $InstallDir -Mirror "https://npmmirror.com/mirrors/electron/")) {
+                    $depsRepaired = $true
+                }
+            }
+            if ($depsRepaired) {
+                Write-Warn "Dependency install failed on the Electron binary download; repopulated the desktop Electron dist via a mirror and continuing."
+            } else {
+                Show-NpmCertHint ($npmOut -join "`n") | Out-Null
+                throw "desktop workspace npm install failed (exit $code) -- see lines above for cause"
+            }
         }
         Write-Success "Desktop workspace dependencies installed"
     } catch {

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -2407,15 +2407,31 @@ _desktop_pack() {
 # failed, and we never override a user-pinned ELECTRON_MIRROR.
 DESKTOP_ELECTRON_FALLBACK_MIRROR="https://npmmirror.com/mirrors/electron/"
 
-# True (returns 0) when node_modules/electron/dist holds a usable Electron
-# binary. electron-builder reads the binary from build.electronDist
-# (node_modules/electron/dist) since #38673, so this is the exact file whose
-# absence makes a pack fail with "The specified electronDist does not exist". A
-# dist dir that exists but is missing the binary (partial extraction / aborted
-# postinstall) is NOT ok. $1 = the workspace root holding node_modules.
+# Return the Electron package directory the desktop workspace installs. npm may
+# nest workspace-only dev dependencies under apps/desktop/node_modules instead
+# of hoisting them to the repo root; which layout you get depends on the npm
+# version and what else is installed. apps/desktop/package.json points
+# electron-builder's electronDist there, so prefer the workspace-local package
+# and fall back to the root hoist. $1 = the workspace root holding node_modules.
+_electron_dir() {
+    local install_dir="$1"
+    if [ -d "$install_dir/apps/desktop/node_modules/electron" ]; then
+        printf '%s\n' "$install_dir/apps/desktop/node_modules/electron"
+    else
+        printf '%s\n' "$install_dir/node_modules/electron"
+    fi
+}
+
+# True (returns 0) when the desktop workspace electronDist holds a usable
+# Electron binary. electron-builder reads the binary from build.electronDist
+# since #38673, so this is the exact file whose absence makes a pack fail with
+# "The specified electronDist does not exist". A dist dir that exists but is
+# missing the binary (partial extraction / aborted postinstall) is NOT ok.
+# $1 = the workspace root holding node_modules.
 _electron_dist_ok() {
     local install_dir="$1"
-    local electron_dir="$install_dir/node_modules/electron"
+    local electron_dir
+    electron_dir="$(_electron_dir "$install_dir")"
     if [ "$OS" = "macos" ]; then
         [ -e "$electron_dir/dist/Electron.app/Contents/MacOS/Electron" ]
     else
@@ -2423,16 +2439,16 @@ _electron_dist_ok() {
     fi
 }
 
-# (Re)populate node_modules/electron/dist via electron's own downloader.
+# (Re)populate the desktop Electron dist via electron's own downloader.
 #
-# Since #38673 the desktop build pins build.electronDist to
-# node_modules/electron/dist, so electron-builder reads the Electron binary
-# straight from there and never downloads it during `npm run pack`. That dist
-# tree is produced by the electron package's postinstall (install.js) during
-# `npm ci`. When that download is blocked/throttled (GitHub's release host is
-# unreachable in some regions - #47266), dist is missing and re-running pack only
-# re-throws "The specified electronDist does not exist". The mirror fallback
-# therefore has to drive THIS downloader, not another pack.
+# Since #38673 the desktop build pins build.electronDist, so electron-builder
+# reads the Electron binary straight from there and never downloads it during
+# `npm run pack`. That dist tree is produced by the electron package's
+# postinstall (install.js) during `npm ci`. When that download is
+# blocked/throttled (GitHub's release host is unreachable in some regions -
+# #47266), dist is missing and re-running pack only re-throws "The specified
+# electronDist does not exist". The mirror fallback therefore has to drive THIS
+# downloader, not another pack.
 #
 # No-op (returns 0) when the dist binary is already present. Otherwise drops a
 # partial dist + version marker (electron's install.js short-circuits when
@@ -2442,7 +2458,8 @@ _electron_dist_ok() {
 _restore_electron_dist() {
     local install_dir="$1"
     local mirror="${2:-}"
-    local electron_dir="$install_dir/node_modules/electron"
+    local electron_dir
+    electron_dir="$(_electron_dir "$install_dir")"
     _electron_dist_ok "$install_dir" && return 0
 
     [ -f "$electron_dir/install.js" ] || return 1

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -2517,20 +2517,46 @@ install_desktop() {
     #    `tsc -b` failing with no obvious cause. Fall back to `npm install`
     #    only if `npm ci` is unavailable or the lockfile is out of sync.
     log_info "Installing desktop workspace dependencies (includes Electron ~150MB, 1-3min)..."
-    ( cd "$INSTALL_DIR" && npm ci ) || ( cd "$INSTALL_DIR" && npm install ) || {
-        log_error "Desktop workspace npm install failed"
-        # Common cause: a previous 'sudo npm'/'sudo npx' left root-owned files in
-        # ~/.npm, so this non-root install can't write the shared cache. npm hides
-        # it behind a confusing EEXIST / "File exists" message while the real errno
-        # is EACCES (-13). Point the user at the fix instead of a raw npm trace.
-        log_info "If the errors above mention EACCES / 'permission denied' / EEXIST while"
-        log_info "writing the npm cache, your ~/.npm likely holds root-owned files from an"
-        log_info "earlier 'sudo npm' or 'sudo npx'. Reclaim ownership and retry:"
-        log_info "  sudo chown -R \"\$(id -un)\" ~/.npm && npm cache verify"
-        log_info "Then re-run this installer, or build manually:"
-        log_info "  cd \"$INSTALL_DIR\" && npm ci && cd apps/desktop && npm run pack"
-        return 1
-    }
+    local deps_ok=true
+    ( cd "$INSTALL_DIR" && npm ci ) || ( cd "$INSTALL_DIR" && npm install ) || deps_ok=false
+    if [ "$deps_ok" = false ]; then
+        # The usual cause is electron's postinstall binary download being
+        # blocked/throttled: its install.js does `process.exit(1)` on a failed
+        # download, which fails the whole `npm ci`/`npm install` (#47266, #47917).
+        # npm runs postinstall scripts LAST — after every package is already
+        # staged on disk — so when the binary download is the casualty the only
+        # thing missing is the desktop workspace's electron/dist. Repopulate it
+        # via electron's own downloader (canonical source first, then the public
+        # mirror when the user hasn't pinned one) and carry on to the build; the
+        # mirror self-heal in step 2 below only runs after a failed `pack`, so on
+        # a blocked network the install bails before it can ever be reached.
+        # _restore_electron_dist resolves the right package dir via _electron_dir
+        # (#48081), so this composes with either npm layout.
+        local deps_repaired=false
+        if ! _electron_dist_ok "$INSTALL_DIR"; then
+            if _restore_electron_dist "$INSTALL_DIR"; then
+                deps_repaired=true
+            elif [ -z "${ELECTRON_MIRROR:-}" ] && _restore_electron_dist "$INSTALL_DIR" "$DESKTOP_ELECTRON_FALLBACK_MIRROR"; then
+                deps_repaired=true
+            fi
+        fi
+        if [ "$deps_repaired" = true ]; then
+            log_warn "Dependency install failed on the Electron binary download; repopulated the desktop Electron dist via a mirror and continuing."
+        else
+            log_error "Desktop workspace npm install failed"
+            # Common cause: a previous 'sudo npm'/'sudo npx' left root-owned files in
+            # ~/.npm, so this non-root install can't write the shared cache. npm hides
+            # it behind a confusing EEXIST / "File exists" message while the real errno
+            # is EACCES (-13). Point the user at the fix instead of a raw npm trace.
+            log_info "If the errors above mention EACCES / 'permission denied' / EEXIST while"
+            log_info "writing the npm cache, your ~/.npm likely holds root-owned files from an"
+            log_info "earlier 'sudo npm' or 'sudo npx'. Reclaim ownership and retry:"
+            log_info "  sudo chown -R \"\$(id -un)\" ~/.npm && npm cache verify"
+            log_info "Then re-run this installer, or build manually:"
+            log_info "  cd \"$INSTALL_DIR\" && npm ci && cd apps/desktop && npm run pack"
+            return 1
+        fi
+    fi
     log_success "Desktop workspace dependencies installed"
 
     # 2. Build, with up to three escalating attempts so a transient/blocked

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -45,6 +45,9 @@ ACP_REGISTRY_MANIFEST = REPO_ROOT / "acp_registry" / "agent.json"
 
 # Auto-extracted from noreply emails + manual overrides
 AUTHOR_MAP = {
+    "59806492+sitkarev@users.noreply.github.com": "sitkarev",
+    "zheng@omegasys.eu": "omegazheng",
+    "220877172+james47kjv@users.noreply.github.com": "james47kjv",
     "yuhanglin@YuhangdeMac-mini.local": "1960697431",
     "despitemeguru@gmail.com": "definitelynotguru",
     "chaslui@outlook.com": "ChasLui",

--- a/tests/hermes_cli/test_gui_command.py
+++ b/tests/hermes_cli/test_gui_command.py
@@ -616,6 +616,33 @@ def test_electron_dist_ok_per_platform(tmp_path, monkeypatch, platform, rel):
     assert cli_main._electron_dist_ok(tmp_path) is True
 
 
+def test_electron_dir_prefers_workspace_local_package(tmp_path):
+    """npm may nest electron under apps/desktop; resolve there over the root hoist."""
+    root_electron = tmp_path / "node_modules" / "electron"
+    local_electron = tmp_path / "apps" / "desktop" / "node_modules" / "electron"
+    root_electron.mkdir(parents=True)
+    local_electron.mkdir(parents=True)
+
+    assert cli_main._electron_dir(tmp_path) == local_electron
+
+
+def test_electron_dir_falls_back_to_root_hoist(tmp_path):
+    """When npm hoists electron to the repo root, resolve there."""
+    root_electron = tmp_path / "node_modules" / "electron"
+    root_electron.mkdir(parents=True)
+
+    assert cli_main._electron_dir(tmp_path) == root_electron
+
+
+def test_electron_dist_ok_finds_workspace_local_binary(tmp_path, monkeypatch):
+    """A nested apps/desktop electron with a valid binary counts as ok."""
+    monkeypatch.setattr(cli_main.sys, "platform", "linux")
+    binp = tmp_path / "apps" / "desktop" / "node_modules" / "electron" / "dist" / "electron"
+    binp.parent.mkdir(parents=True)
+    binp.write_text("", encoding="utf-8")
+    assert cli_main._electron_dist_ok(tmp_path) is True
+
+
 def test_redownload_electron_dist_noop_when_present(tmp_path, monkeypatch):
     """Already-healthy dist → no download, so an unrelated build failure can't
     trigger a needless ~200 MB refetch."""

--- a/tests/hermes_cli/test_gui_command.py
+++ b/tests/hermes_cli/test_gui_command.py
@@ -592,6 +592,125 @@ def test_gui_does_not_override_user_electron_mirror(tmp_path, monkeypatch, capsy
     assert "Desktop GUI build failed" in capsys.readouterr().out
 
 
+def test_gui_install_failure_redownloads_electron_then_builds(tmp_path, monkeypatch, capsys):
+    """A failed dependency install whose only casualty is the Electron binary
+    download (#47266/#47917) repopulates the desktop Electron dist via the
+    downloader and CONTINUES to the build instead of aborting — otherwise the
+    mirror self-heal after `pack` is unreachable on a blocked network because
+    electron's install.js fails the whole `npm ci` first."""
+    root = _make_desktop_tree(tmp_path)
+    monkeypatch.setattr(cli_main, "PROJECT_ROOT", root)
+    packaged_exe = _make_packaged_executable(root, monkeypatch)
+    monkeypatch.delenv("ELECTRON_MIRROR", raising=False)
+
+    install_fail = subprocess.CompletedProcess(["npm", "ci"], 1)
+    pack_ok = subprocess.CompletedProcess(["npm", "run", "pack"], 0)
+    launch_ok = subprocess.CompletedProcess([str(packaged_exe)], 0)
+
+    with patch("hermes_cli.main.shutil.which", return_value="/usr/bin/npm"), \
+         patch("hermes_cli.main._run_npm_install_deterministic", return_value=install_fail), \
+         patch("hermes_cli.main._desktop_build_needed", return_value=True), \
+         patch("hermes_cli.main._write_desktop_build_stamp"), \
+         patch("hermes_cli.main._desktop_macos_relaunchable_fixup"), \
+         patch("hermes_cli.main._electron_dist_ok", return_value=False), \
+         patch("hermes_cli.main._redownload_electron_dist", return_value=True) as mock_dl, \
+         patch("hermes_cli.main.subprocess.run", side_effect=[pack_ok, launch_ok]) as mock_run, \
+         pytest.raises(SystemExit) as exc:
+        cli_main.cmd_gui(_ns())
+
+    assert exc.value.code == 0
+    # Canonical (no-mirror) re-download repopulated the dist; no mirror needed.
+    mock_dl.assert_called_once()
+    assert mock_dl.call_args.kwargs.get("mirror") is None
+    # The build proceeded despite the failed dependency install.
+    assert mock_run.call_args_list[0].args[0] == ["/usr/bin/npm", "run", "pack"]
+    out = capsys.readouterr().out
+    assert "repopulated the desktop Electron dist" in out
+    assert "Desktop dependency install failed" not in out
+
+
+def test_gui_install_failure_falls_back_to_mirror_redownload(tmp_path, monkeypatch, capsys):
+    """When the canonical re-download also fails and the user has not pinned a
+    mirror, the install-failure path drives electron's downloader via the public
+    mirror before giving up — then continues to the build."""
+    root = _make_desktop_tree(tmp_path)
+    monkeypatch.setattr(cli_main, "PROJECT_ROOT", root)
+    packaged_exe = _make_packaged_executable(root, monkeypatch)
+    monkeypatch.delenv("ELECTRON_MIRROR", raising=False)
+
+    install_fail = subprocess.CompletedProcess(["npm", "ci"], 1)
+    pack_ok = subprocess.CompletedProcess(["npm", "run", "pack"], 0)
+    launch_ok = subprocess.CompletedProcess([str(packaged_exe)], 0)
+
+    with patch("hermes_cli.main.shutil.which", return_value="/usr/bin/npm"), \
+         patch("hermes_cli.main._run_npm_install_deterministic", return_value=install_fail), \
+         patch("hermes_cli.main._desktop_build_needed", return_value=True), \
+         patch("hermes_cli.main._write_desktop_build_stamp"), \
+         patch("hermes_cli.main._desktop_macos_relaunchable_fixup"), \
+         patch("hermes_cli.main._electron_dist_ok", return_value=False), \
+         patch("hermes_cli.main._redownload_electron_dist", side_effect=[False, True]) as mock_dl, \
+         patch("hermes_cli.main.subprocess.run", side_effect=[pack_ok, launch_ok]) as mock_run, \
+         pytest.raises(SystemExit) as exc:
+        cli_main.cmd_gui(_ns())
+
+    assert exc.value.code == 0
+    assert mock_dl.call_count == 2
+    assert mock_dl.call_args_list[0].kwargs.get("mirror") is None
+    assert mock_dl.call_args_list[1].kwargs["mirror"] == cli_main._ELECTRON_FALLBACK_MIRROR
+    assert mock_run.call_args_list[0].args[0] == ["/usr/bin/npm", "run", "pack"]
+
+
+def test_gui_install_failure_aborts_when_electron_unrecoverable(tmp_path, monkeypatch, capsys):
+    """If the Electron binary can't be fetched at all (canonical AND mirror
+    blocked), the install failure aborts exactly as before — no build attempt."""
+    root = _make_desktop_tree(tmp_path)
+    monkeypatch.setattr(cli_main, "PROJECT_ROOT", root)
+    _make_packaged_executable(root, monkeypatch)
+    monkeypatch.delenv("ELECTRON_MIRROR", raising=False)
+
+    install_fail = subprocess.CompletedProcess(["npm", "ci"], 1)
+
+    with patch("hermes_cli.main.shutil.which", return_value="/usr/bin/npm"), \
+         patch("hermes_cli.main._run_npm_install_deterministic", return_value=install_fail), \
+         patch("hermes_cli.main._desktop_build_needed", return_value=True), \
+         patch("hermes_cli.main._electron_dist_ok", return_value=False), \
+         patch("hermes_cli.main._redownload_electron_dist", return_value=False) as mock_dl, \
+         patch("hermes_cli.main.subprocess.run") as mock_run, \
+         pytest.raises(SystemExit) as exc:
+        cli_main.cmd_gui(_ns())
+
+    assert exc.value.code == 1
+    assert mock_dl.call_count == 2  # canonical, then mirror — both failed
+    mock_run.assert_not_called()  # never reached the build
+    assert "Desktop dependency install failed" in capsys.readouterr().out
+
+
+def test_gui_install_failure_does_not_add_mirror_when_user_pinned(tmp_path, monkeypatch, capsys):
+    """A user-pinned ELECTRON_MIRROR is honored by the downloader itself, so the
+    install-failure path makes exactly ONE re-download attempt (no npmmirror
+    fallback) and never overrides the user's mirror."""
+    root = _make_desktop_tree(tmp_path)
+    monkeypatch.setattr(cli_main, "PROJECT_ROOT", root)
+    _make_packaged_executable(root, monkeypatch)
+    monkeypatch.setenv("ELECTRON_MIRROR", "https://mirror.example/electron/")
+
+    install_fail = subprocess.CompletedProcess(["npm", "ci"], 1)
+
+    with patch("hermes_cli.main.shutil.which", return_value="/usr/bin/npm"), \
+         patch("hermes_cli.main._run_npm_install_deterministic", return_value=install_fail), \
+         patch("hermes_cli.main._desktop_build_needed", return_value=True), \
+         patch("hermes_cli.main._electron_dist_ok", return_value=False), \
+         patch("hermes_cli.main._redownload_electron_dist", return_value=False) as mock_dl, \
+         patch("hermes_cli.main.subprocess.run") as mock_run, \
+         pytest.raises(SystemExit) as exc:
+        cli_main.cmd_gui(_ns())
+
+    assert exc.value.code == 1
+    mock_dl.assert_called_once()
+    assert mock_dl.call_args.kwargs.get("mirror") is None
+    mock_run.assert_not_called()
+
+
 # ── electronDist (re)download helper tests (#47266) ───────────────────
 
 

--- a/tests/test_desktop_electron_pin.py
+++ b/tests/test_desktop_electron_pin.py
@@ -94,3 +94,42 @@ def test_lockfile_resolves_the_pinned_electron():
         f"but the pin is {spec!r}; run `npm install --package-lock-only` so "
         "`npm ci` stays consistent."
     )
+
+
+def test_electron_dist_matches_lockfile_install_location():
+    """build.electronDist must point at where the lockfile installs Electron.
+
+    electron-builder copies the unpacked Electron from ``build.electronDist``
+    (resolved relative to ``apps/desktop``). npm workspace hoisting is not
+    deterministic across machines/npm versions: it may nest Electron under
+    ``apps/desktop/node_modules/electron`` or hoist it to the repo root. If
+    electronDist points at one location while the lockfile installs at the
+    other, packaging fails with ``The specified electronDist does not exist`` —
+    the "Building desktop app" failure reported after the June lockfile
+    regeneration floated Electron and reshuffled the hoist. Lock the two
+    together so a hoist change (root <-> nested) can't silently break the path
+    again.
+    """
+    if not ROOT_LOCK.is_file():
+        pytest.skip("root package-lock.json not present")
+    electron_dist = _desktop_pkg().get("build", {}).get("electronDist")
+    assert electron_dist, "build.electronDist is missing"
+
+    lock = json.loads(ROOT_LOCK.read_text(encoding="utf-8"))
+    electron_paths = [
+        path
+        for path in lock.get("packages", {})
+        if path.endswith("node_modules/electron")
+    ]
+    assert electron_paths, "no electron entry found in package-lock.json"
+
+    desktop_dir = REPO_ROOT / "apps" / "desktop"
+    # electronDist is resolved relative to the apps/desktop project dir.
+    configured = (desktop_dir / electron_dist).resolve()
+    # Where the lockfile actually places Electron's unpacked dist.
+    installed = {(REPO_ROOT / p / "dist").resolve() for p in electron_paths}
+    assert configured in installed, (
+        f"build.electronDist={electron_dist!r} resolves to {configured}, but the "
+        f"lockfile installs Electron at {sorted(str(p) for p in installed)}. "
+        "electron-builder will fail with 'electronDist does not exist'."
+    )


### PR DESCRIPTION
## Summary

**Re-scoped + restacked on #48081.** Adds the one gap that #48081 (the workspace-local `electronDist` resolver, which I'm treating as the canonical fix for #47917) leaves open: making the pack-time Electron mirror self-heal **reachable** on a network-blocked install.

**Stacked on #48081 — please merge that first.** This PR's first commit is #48081's; only the second commit (`fix(desktop): self-heal a network-blocked desktop install before pack`) is new. Rebase onto `main` once #48081 lands.

## The gap

electron's `install.js` does `process.exit(1)` on a blocked/throttled binary download, which fails the whole `npm ci`. All three desktop-build paths bail at the **dependency-install** step — `hermes_cli/main.py` `cmd_gui` (`sys.exit`), `scripts/install.sh` `install_desktop` (`return 1`), `scripts/install.ps1` `Install-Desktop` (`throw`) — **before** `npm run pack`. So the mirror self-heal added in #47276 (which only runs *after* a failed pack) is never reached on a blocked network. #48081 re-points that self-heal to the right directory but doesn't change *when* it runs, so the gap survives.

## Fix

On a dependency-install failure, repopulate the desktop Electron dist via electron's own downloader (canonical source first, then `npmmirror.com` when the user hasn't pinned `ELECTRON_MIRROR`) and **continue to the build** instead of aborting; hard-fail only when the dist still can't be fetched. The self-heal calls #48081's resolver-aware helpers (`_redownload_electron_dist` / `_restore_electron_dist` / `Restore-ElectronDist`), so it composes with either npm layout (nested or hoisted). Applied to `hermes desktop` (the `hermes update` rebuild path), `install.sh`, and `install.ps1`. Also DRYs the npmmirror fallback URL into one constant.

## What changed vs the earlier version of this PR

Dropped the install-script path re-points (the earlier "part A") — **#48081 supersedes them with a better, layout-agnostic resolver**. This PR is now purely the reachability hardening.

## Test plan

- `scripts/run_tests.sh tests/hermes_cli/test_gui_command.py` → **42 passed** (4 new: install-failure → canonical re-download → continue; mirror fallback; unrecoverable → abort as before; user-pinned `ELECTRON_MIRROR` not overridden).
- `python -m py_compile hermes_cli/main.py`, `bash -n scripts/install.sh` clean. install.ps1 change mirrors the existing `Restore-ElectronDist` usage.
- A user-pinned `ELECTRON_MIRROR` is never overridden in any path.
