### PR TITLE
fix(discord): distinguish 30032 cap error from generic sync failures

### DIFF
--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -1238,6 +1238,28 @@ class DiscordAdapter(BasePlatformAdapter):
             return True
         return False
 
+    @staticmethod
+    def _is_discord_command_cap_error(exc: Any) -> bool:
+        """True iff ``exc`` is the Discord 100-global-commands cap error.
+
+        Discord rejects the batch with HTTP 400 / error code 30032 when an
+        app already has the maximum number of global application commands.
+        Mirrors the precision of ``_is_discord_rate_limit``: prefers
+        ``exc.code == 30032`` set by discord.py's HTTPException, falls back
+        to status + text matching for older discord.py forks, mocks, and
+        exotic transports. Never swallows arbitrary 400s — only the specific
+        cap message — so unrelated bugs keep producing stack traces.
+        """
+        code = getattr(exc, "code", None)
+        if code == 30032:
+            return True
+        response = getattr(exc, "response", None)
+        status = getattr(response, "status", None) or getattr(response, "status_code", None)
+        if status != 400:
+            return False
+        text = (getattr(exc, "text", "") or str(exc) or "")
+        return "Maximum number of application commands reached" in text
+
     def _command_sync_mutation_interval_seconds(self) -> float:
         return _DISCORD_COMMAND_SYNC_MUTATION_INTERVAL_SECONDS
 
@@ -1282,6 +1304,20 @@ class DiscordAdapter(BasePlatformAdapter):
                 # persist Discord's retry-after when it refuses the batch.
                 summary = await asyncio.wait_for(self._safe_sync_slash_commands(), timeout=600)
             except Exception as e:
+                # Discord's hard 100-global-command cap (HTTP 400 / code 30032)
+                # is the one known cause of intermittent sync failures on
+                # loaded installs. Detect it BEFORE the rate-limit fallback so
+                # the operator gets a clear, actionable message instead of
+                # either the generic "sync failed" stack trace from the outer
+                # except or a misrouted rate-limit cooldown.
+                if self._is_discord_command_cap_error(e):
+                    logger.warning(
+                        "[%s] Discord slash command cap reached (HTTP 30032); "
+                        "sync aborted. Disable unused plugins or trim "
+                        "COMMAND_REGISTRY to free slots before the next reconnect.",
+                        self.name,
+                    )
+                    return
                 if not self._is_discord_rate_limit(e):
                     raise
                 retry_after = self._extract_discord_retry_after(e)

--- a/tests/gateway/test_discord_connect.py
+++ b/tests/gateway/test_discord_connect.py
@@ -1,5 +1,6 @@
 import asyncio
 import json
+import logging
 import sys
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
@@ -989,3 +990,92 @@ async def test_safe_sync_detects_contexts_drift():
     fake_http.edit_global_command.assert_not_awaited()
     fake_http.delete_global_command.assert_awaited_once_with(999, 77)
     fake_http.upsert_global_command.assert_awaited_once_with(999, desired)
+
+
+@pytest.mark.asyncio
+async def test_post_connect_initialization_logs_cap_error_with_distinct_message(tmp_path, monkeypatch):
+    """A 30032 cap error raised inside _safe_sync_slash_commands must be
+    caught at the inner except, produce a distinct 'cap reached' log line,
+    and NOT propagate to the outer 'Slash command sync failed' branch
+    (which would hide the actual cause under a stack trace).
+    """
+    adapter = DiscordAdapter(PlatformConfig(enabled=True, token="test-token"))
+    monkeypatch.setattr("hermes_constants.get_hermes_home", lambda: tmp_path)
+
+    class _DesiredCommand:
+        def to_dict(self, tree):
+            return {"name": "status", "description": "Show Hermes status", "type": 1, "options": []}
+
+    adapter._client = SimpleNamespace(
+        tree=SimpleNamespace(get_commands=lambda: [_DesiredCommand()]),
+        application_id=4242,
+        user=SimpleNamespace(id=4242),
+    )
+
+    class _CapHTTPException(Exception):
+        code = 30032
+        response = SimpleNamespace(status=400, status_code=400)
+        text = "Maximum number of application commands reached (100)."
+
+        def __str__(self):
+            return self.text
+
+    sync = AsyncMock(side_effect=_CapHTTPException("cap"))
+    monkeypatch.setattr(adapter, "_safe_sync_slash_commands", sync)
+
+    captured = []
+
+    class _CaptureHandler(logging.Handler):
+        def emit(self, record):
+            captured.append(record.getMessage())
+
+    cap_logger = logging.getLogger("plugins.platforms.discord.adapter")
+    cap_logger.addHandler(_CaptureHandler())
+    prev_level = cap_logger.level
+    cap_logger.setLevel(logging.WARNING)
+    try:
+        # Must NOT raise — the inner cap-detection must absorb it cleanly.
+        await adapter._run_post_connect_initialization()
+    finally:
+        cap_logger.setLevel(prev_level)
+        cap_logger.removeHandler(cap_logger.handlers[-1])
+
+    sync.assert_awaited_once()
+    assert any("cap reached" in msg for msg in captured), (
+        f"expected cap-specific log line, got: {captured!r}"
+    )
+    assert not any("Slash command sync failed" in msg for msg in captured), (
+        f"cap error fell through to generic 'sync failed' branch: {captured!r}"
+    )
+
+
+def test_is_discord_command_cap_error_detects_30032():
+    """Unit test for the helper that distinguishes 30032 cap errors from
+    generic 400s. False positives here would mask unrelated bugs; false
+    negatives would route cap errors through the generic 'sync failed'
+    branch and bury the real cause under a stack trace.
+    """
+    class _CapErr:
+        code = 30032
+        response = SimpleNamespace(status=400, status_code=400)
+        text = "Maximum number of application commands reached (100)."
+
+    class _Generic400Err:
+        code = 50035
+        response = SimpleNamespace(status=400, status_code=400)
+        text = "Invalid Form Body"
+
+    class _RateLimitErr:
+        response = SimpleNamespace(status=429, status_code=429)
+        text = "Too Many Requests"
+
+    assert DiscordAdapter._is_discord_command_cap_error(_CapErr()) is True
+    assert DiscordAdapter._is_discord_command_cap_error(_Generic400Err()) is False
+    assert DiscordAdapter._is_discord_command_cap_error(_RateLimitErr()) is False
+
+    # Fallback path: no ``code`` attr but text matches → still detected.
+    class _LegacyCapErr:
+        response = SimpleNamespace(status=400, status_code=400)
+        text = "Maximum number of application commands reached (100)."
+
+    assert DiscordAdapter._is_discord_command_cap_error(_LegacyCapErr()) is True


### PR DESCRIPTION
## Problem

On loaded installs, the inner `_safe_sync_slash_commands` can hit Discord's hard 100-global-application-commands cap (HTTP 400 / code 30032). Today this surfaces in the gateway log as:

```
[Discord] Slash command sync failed: 400 Bad Request (error code: 30032):
  Maximum number of application commands reached (100).
```

…followed by a full stack trace — identical to every other sync failure (timeouts, network errors, random HTTP 500s). The actual cause is buried under noise that looks like a real bug.

This is especially bad because:
- It triggers AFTER `_record_command_sync_attempt` already wrote a "we tried" entry, with no matching success / rate-limit record.
- The operator has no hint that the cap was the actual cause or how to fix it (drop plugins / trim COMMAND_REGISTRY).
- The outer `except Exception` swallows it so the gateway survives, but the log is misleading.

The pre-flight registration-time cap (`_DISCORD_MAX_APP_COMMANDS = 100` at line 39) protects against hitting 30032 on registration, but doesn't make the sync **resilient** if 30032 surfaces for any reason (fetch/upsert drift, external command registration, plugin race conditions).

## Fix

Detect the cap error in the inner `except` of `_run_post_connect_initialization` (where `_safe_sync_slash_commands` is awaited) BEFORE the rate-limit fallback. Emit a distinct, actionable warning naming the cause and the remediation. Never re-raises, so the outer defensive `except` never sees it.

Detection mirrors `_is_discord_rate_limit`:
- prefers `exc.code == 30032` (set by discord.py's HTTPException)
- falls back to `status == 400` + `"Maximum number of application commands reached"` in `exc.text` so older discord.py forks / mocks / exotic transports are still covered.

## Diff

```
 plugins/platforms/discord/adapter.py  |  36 +++++++++++++
 tests/gateway/test_discord_connect.py |  90 +++++++++++++++++++++++++++++++++++
 2 files changed, 126 insertions(+)
```

126 lines added, 0 deleted, 1 commit. No churn.

## Tests

| Test | What it proves |
|---|---|
| `test_post_connect_initialization_logs_cap_error_with_distinct_message` | A 30032 mid-sync emits `"cap reached"` log line, does NOT re-raise, does NOT fall through to the outer `"sync failed"` branch |
| `test_is_discord_command_cap_error_detects_30032` | Helper discriminates 30032 from generic 400s (code 50035) and 429s; covers both code-based and text-based detection paths |

```
$ bash scripts/run_tests.sh tests/gateway/test_discord_connect.py
[100.0% | 20/20] ✓ 2.5s

$ bash scripts/run_tests.sh tests/gateway/
314 files, 6858 tests passed, 0 failed (100% complete) in 58.4s
```

## What this does NOT do

- Does NOT change the registration-time cap (`_DISCORD_MAX_APP_COMMANDS = 100`) — that already exists.
- Does NOT change `_safe_sync_slash_commands` — the existing diff-based sync logic is preserved.
- Does NOT introduce new state files, sentinels, or summary dict fields.

It's a pure logging-clarity change in the inner `except` of `_run_post_connect_initialization`, plus a focused unit test for the discriminator helper.