### PR TITLE
fix(desktop): persist session context usage

### DIFF
--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -146,6 +146,7 @@ def _record_codex_app_server_usage(agent, turn) -> dict[str, Any]:
                 cache_read_tokens=canonical_usage.cache_read_tokens,
                 cache_write_tokens=canonical_usage.cache_write_tokens,
                 reasoning_tokens=canonical_usage.reasoning_tokens,
+                last_prompt_tokens=prompt_tokens,
                 estimated_cost_usd=float(cost_result.amount_usd)
                 if cost_result.amount_usd is not None else None,
                 cost_status=cost_result.status,

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -1866,6 +1866,7 @@ def run_conversation(
                                 cache_read_tokens=canonical_usage.cache_read_tokens,
                                 cache_write_tokens=canonical_usage.cache_write_tokens,
                                 reasoning_tokens=canonical_usage.reasoning_tokens,
+                                last_prompt_tokens=prompt_tokens,
                                 estimated_cost_usd=float(cost_result.amount_usd)
                                 if cost_result.amount_usd is not None else None,
                                 cost_status=cost_result.status,

--- a/apps/desktop/src/app/session/hooks/use-session-actions.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions.ts
@@ -686,7 +686,10 @@ export function useSessionActions({
           ...current,
           input: stored.input_tokens || 0,
           output: stored.output_tokens || 0,
-          total: (stored.input_tokens || 0) + (stored.output_tokens || 0)
+          total: (stored.input_tokens || 0) + (stored.output_tokens || 0),
+          ...(stored.last_prompt_tokens
+            ? { context_used: stored.last_prompt_tokens }
+            : {})
         }))
       }
 
@@ -1012,7 +1015,10 @@ export function useSessionActions({
               ...current,
               input: stored.input_tokens || 0,
               output: stored.output_tokens || 0,
-              total: (stored.input_tokens || 0) + (stored.output_tokens || 0)
+              total: (stored.input_tokens || 0) + (stored.output_tokens || 0),
+              ...(stored.last_prompt_tokens
+                ? { context_used: stored.last_prompt_tokens }
+                : {})
             }))
           }
 

--- a/apps/desktop/src/types/hermes.ts
+++ b/apps/desktop/src/types/hermes.ts
@@ -293,6 +293,7 @@ export interface SessionInfo {
   _lineage_root_id?: null | string
   input_tokens: number
   is_active: boolean
+  last_prompt_tokens?: number
   last_active: number
   message_count: number
   model: null | string

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -529,6 +529,7 @@ CREATE TABLE IF NOT EXISTS sessions (
     cache_read_tokens INTEGER DEFAULT 0,
     cache_write_tokens INTEGER DEFAULT 0,
     reasoning_tokens INTEGER DEFAULT 0,
+    last_prompt_tokens INTEGER DEFAULT 0,
     cwd TEXT,
     billing_provider TEXT,
     billing_base_url TEXT,
@@ -1525,6 +1526,7 @@ class SessionDB:
         cache_read_tokens: int = 0,
         cache_write_tokens: int = 0,
         reasoning_tokens: int = 0,
+        last_prompt_tokens: Optional[int] = None,
         estimated_cost_usd: Optional[float] = None,
         actual_cost_usd: Optional[float] = None,
         cost_status: Optional[str] = None,
@@ -1557,6 +1559,10 @@ class SessionDB:
                    cache_read_tokens = ?,
                    cache_write_tokens = ?,
                    reasoning_tokens = ?,
+                   last_prompt_tokens = CASE
+                       WHEN ? IS NULL THEN last_prompt_tokens
+                       ELSE ?
+                   END,
                    estimated_cost_usd = COALESCE(?, 0),
                    actual_cost_usd = CASE
                        WHEN ? IS NULL THEN actual_cost_usd
@@ -1578,6 +1584,10 @@ class SessionDB:
                    cache_read_tokens = cache_read_tokens + ?,
                    cache_write_tokens = cache_write_tokens + ?,
                    reasoning_tokens = reasoning_tokens + ?,
+                   last_prompt_tokens = CASE
+                       WHEN ? IS NULL THEN last_prompt_tokens
+                       ELSE ?
+                   END,
                    estimated_cost_usd = COALESCE(estimated_cost_usd, 0) + COALESCE(?, 0),
                    actual_cost_usd = CASE
                        WHEN ? IS NULL THEN actual_cost_usd
@@ -1598,6 +1608,8 @@ class SessionDB:
             cache_read_tokens,
             cache_write_tokens,
             reasoning_tokens,
+            last_prompt_tokens,
+            last_prompt_tokens,
             estimated_cost_usd,
             actual_cost_usd,
             actual_cost_usd,

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -137,6 +137,15 @@ class TestSessionLifecycle:
         assert session["input_tokens"] == 300
         assert session["output_tokens"] == 150
 
+    def test_update_token_counts_persists_latest_prompt_tokens(self, db):
+        db.create_session(session_id="s1", source="cli")
+        db.update_token_counts("s1", input_tokens=200, output_tokens=100, last_prompt_tokens=180)
+        db.update_token_counts("s1", input_tokens=100, output_tokens=50, last_prompt_tokens=260)
+
+        session = db.get_session("s1")
+        assert session["input_tokens"] == 300
+        assert session["last_prompt_tokens"] == 260
+
     def test_update_token_counts_tracks_api_call_count(self, db):
         """api_call_count increments with each update_token_counts call."""
         db.create_session(session_id="s1", source="cli")
@@ -157,6 +166,21 @@ class TestSessionLifecycle:
         session = db.get_session("s1")
         assert session["api_call_count"] == 5
         assert session["input_tokens"] == 300
+
+    def test_update_token_counts_last_prompt_tokens_absolute(self, db):
+        db.create_session(session_id="s1", source="cli")
+        db.update_token_counts("s1", input_tokens=100, output_tokens=50, last_prompt_tokens=90)
+        db.update_token_counts(
+            "s1",
+            input_tokens=300,
+            output_tokens=150,
+            last_prompt_tokens=240,
+            absolute=True,
+        )
+
+        session = db.get_session("s1")
+        assert session["input_tokens"] == 300
+        assert session["last_prompt_tokens"] == 240
 
     def test_update_token_counts_backfills_model_when_null(self, db):
         db.create_session(session_id="s1", source="telegram")

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -2369,7 +2369,21 @@ def _sync_session_key_after_compress(
             pass
 
 
-def _get_usage(agent) -> dict:
+def _session_last_prompt_tokens(session: dict | None) -> int:
+    """Return the last persisted prompt-token count for a resumed session."""
+    try:
+        db = _get_db()
+        session_key = (session or {}).get("session_key")
+        if db and session_key:
+            row = db.get_session(session_key)
+            if row:
+                return int(row.get("last_prompt_tokens") or 0)
+    except Exception:
+        pass
+    return 0
+
+
+def _get_usage(agent, *, fallback_last_prompt_tokens: int = 0) -> dict:
     g = lambda k, fb=None: getattr(agent, k, 0) or (getattr(agent, fb, 0) if fb else 0)
     usage = {
         "model": getattr(agent, "model", "") or "",
@@ -2385,7 +2399,12 @@ def _get_usage(agent) -> dict:
     }
     comp = getattr(agent, "context_compressor", None)
     if comp:
-        ctx_used = getattr(comp, "last_prompt_tokens", 0) or usage["total"] or 0
+        ctx_used = (
+            getattr(comp, "last_prompt_tokens", 0)
+            or fallback_last_prompt_tokens
+            or usage["total"]
+            or 0
+        )
         ctx_max = getattr(comp, "context_length", 0) or 0
         if ctx_max:
             usage["context_used"] = ctx_used
@@ -2539,7 +2558,10 @@ def _session_info(agent, session: dict | None = None) -> dict:
         "release_date": "",
         "update_behind": None,
         "update_command": "",
-        "usage": _get_usage(agent),
+        "usage": _get_usage(
+            agent,
+            fallback_last_prompt_tokens=_session_last_prompt_tokens(session),
+        ),
         "profile_name": _current_profile_name(),
     }
     try:
@@ -4982,7 +5004,10 @@ def _(rid, params: dict) -> dict:
         return err
     agent = session.get("agent")
     usage: dict = (
-        _get_usage(agent)
+        _get_usage(
+            agent,
+            fallback_last_prompt_tokens=_session_last_prompt_tokens(session),
+        )
         if agent is not None
         else {"calls": 0, "input": 0, "output": 0, "total": 0}
     )


### PR DESCRIPTION
## Summary

This PR persists each session's latest prompt/context usage and hydrates it back into Desktop session state.

That lets Hermes show the current context count as soon as a session is opened, instead of showing `0` until another message is sent.

## Why

Desktop already receives prompt usage during normal turns, but that value was only reflected live. After reopening or switching to an existing session, the status bar could fall back to zero even when the session had known recent usage.

## What changed

- store `last_prompt_tokens` with session token counts
- update the value from runtime/codex prompt usage
- expose the stored value through gateway session info/usage APIs
- hydrate Desktop preview/session state from the persisted value
- add DB coverage for the new persisted field

## Validation

- `npm run typecheck`
- `.venv\Scripts\python.exe -m pytest tests/test_hermes_state.py -q` (`270 passed`)
- `.venv\Scripts\python.exe -m py_compile hermes_state.py agent\conversation_loop.py agent\codex_runtime.py tui_gateway\server.py`
- `git diff --check origin/main..HEAD`