### PR TITLE
feat(discord): add server users slash command

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -7044,6 +7044,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         if canonical == "whoami":
             return await self._handle_whoami_command(event)
 
+        if canonical == "server-users":
+            return await self._handle_server_users_command(event)
+
         if canonical == "status":
             return await self._handle_status_command(event)
 

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -293,6 +293,103 @@ class GatewaySlashCommandsMixin:
             f"Slash commands you can run: {runnable_str}"
         )
 
+    async def _handle_server_users_command(self, event: MessageEvent) -> str:
+        """Handle /server-users — list Discord guild members as CSV names."""
+        source = event.source
+        if not source or source.platform != Platform.DISCORD:
+            return "/server-users is only available from a Discord server channel or thread."
+
+        raw = event.raw_message
+        raw_channel = getattr(raw, "channel", None)
+        guild = getattr(raw, "guild", None) or getattr(raw_channel, "guild", None)
+
+        guild_id = (
+            getattr(source, "guild_id", None)
+            or getattr(raw, "guild_id", None)
+            or getattr(guild, "id", None)
+        )
+        if not guild_id:
+            return "Run /server-users from a Discord server channel or thread, not a DM."
+
+        adapters: Any = getattr(self, "adapters", {}) or {}
+        adapter = adapters.get(Platform.DISCORD)
+        client = getattr(adapter, "_client", None)
+        if guild is None and client is not None:
+            try:
+                guild = client.get_guild(int(guild_id))
+            except Exception:
+                guild = None
+        if guild is None and client is not None and hasattr(client, "fetch_guild"):
+            try:
+                maybe_guild = client.fetch_guild(int(guild_id))
+                guild = await maybe_guild if inspect.isawaitable(maybe_guild) else maybe_guild
+            except Exception as exc:
+                logger.debug("Discord /server-users fetch_guild failed: %s", exc)
+
+        if guild is None:
+            return "Could not resolve the Discord server for this command."
+
+        members: list[Any] = []
+        fetch_error: Exception | None = None
+        fetch_members = getattr(guild, "fetch_members", None)
+        if callable(fetch_members):
+            try:
+                fetched = fetch_members(limit=None)
+                aiter_factory = getattr(fetched, "__aiter__", None)
+                if callable(aiter_factory):
+                    async_iterator = aiter_factory()
+                    next_member = getattr(async_iterator, "__anext__")
+                    while True:
+                        try:
+                            members.append(await next_member())
+                        except StopAsyncIteration:
+                            break
+                else:
+                    if inspect.isawaitable(fetched):
+                        fetched = await fetched
+                    if fetched:
+                        if isinstance(fetched, (list, tuple, set)):
+                            members.extend(fetched)
+                        else:
+                            members.append(fetched)
+            except Exception as exc:
+                fetch_error = exc
+                logger.debug("Discord /server-users fetch_members failed: %s", exc)
+
+        used_cache = False
+        if not members:
+            cached = list(getattr(guild, "members", []) or [])
+            if cached:
+                members = cached
+                used_cache = True
+
+        if not members:
+            if fetch_error is not None:
+                return (
+                    "I could not fetch the Discord member list. The bot likely needs "
+                    "the Server Members intent enabled in the Discord Developer Portal "
+                    "and requested by the gateway."
+                )
+            return "No Discord members were found for this server."
+
+        def _member_name(member: Any) -> str:
+            raw_name = (
+                getattr(member, "display_name", None)
+                or getattr(member, "global_name", None)
+                or getattr(member, "name", None)
+                or getattr(member, "id", None)
+                or "unknown"
+            )
+            name = re.sub(r"[,\r\n]+", " ", str(raw_name)).strip()
+            return name or str(getattr(member, "id", "unknown"))
+
+        names = [_member_name(member) for member in members]
+        names.sort(key=str.casefold)
+        output = ", ".join(names)
+        if used_cache and fetch_error is not None:
+            return "⚠️ Full member fetch failed; using the cached member list.\n" + output
+        return output
+
     async def _handle_kanban_command(self, event: MessageEvent) -> str:
         """Handle /kanban — delegate to the shared kanban CLI.
 

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -308,12 +308,16 @@ for _cmd in COMMAND_REGISTRY:
 # Set of all command names + aliases recognized by the gateway.
 # Includes config-gated commands so the gateway can dispatch them
 # (the handler checks the config gate at runtime).
+# Set of platform-specific commands that are handled by the gateway but do not
+# belong in the cross-platform COMMAND_REGISTRY menus (Slack/Telegram/etc.).
+_PLATFORM_SPECIFIC_GATEWAY_COMMANDS: frozenset[str] = frozenset({"server-users"})
+
 GATEWAY_KNOWN_COMMANDS: frozenset[str] = frozenset(
     name
     for cmd in COMMAND_REGISTRY
     if not cmd.cli_only or cmd.gateway_config_gate
     for name in (cmd.name, *cmd.aliases)
-)
+) | _PLATFORM_SPECIFIC_GATEWAY_COMMANDS
 
 
 def is_gateway_known_command(name: str | None) -> bool:
@@ -362,7 +366,7 @@ ACTIVE_SESSION_BYPASS_COMMANDS: frozenset[str] = frozenset(
 
 
 def should_bypass_active_session(command_name: str | None) -> bool:
-    """Return True for any resolvable slash command.
+    """Return True for any gateway-known slash command.
 
     Rationale: every gateway-registered slash command either has a
     specific Level-2 handler in gateway/run.py (/stop, /new, /model,
@@ -381,7 +385,7 @@ def should_bypass_active_session(command_name: str | None) -> bool:
     ACTIVE_SESSION_BYPASS_COMMANDS remains the subset of commands with
     explicit Level-2 handlers; the rest fall through to the catch-all.
     """
-    return resolve_command(command_name) is not None if command_name else False
+    return is_gateway_known_command(command_name) if command_name else False
 
 
 def _resolve_config_gates() -> set[str]:

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -3935,6 +3935,24 @@ class DiscordAdapter(BasePlatformAdapter):
             return {part.strip() for part in s.split(",") if part.strip()}
         return set()
 
+    def _discord_threaded_free_response_channels(self) -> set:
+        """Return free-response Discord channel IDs that should still auto-thread.
+
+        This is the same mention-bypass behavior as ``free_response_channels``,
+        but top-level channel messages keep ``auto_thread`` semantics instead of
+        replying directly in-channel. Parent channel IDs also match messages sent
+        inside existing threads under that channel.
+        """
+        raw = self.config.extra.get("free_response_threaded_channels")
+        if raw is None:
+            raw = os.getenv("DISCORD_FREE_RESPONSE_THREADED_CHANNELS", "")
+        if isinstance(raw, list):
+            return {str(part).strip() for part in raw if str(part).strip()}
+        s = str(raw).strip() if raw is not None else ""
+        if s:
+            return {part.strip() for part in s.split(",") if part.strip()}
+        return set()
+
     def _discord_thread_require_mention(self) -> bool:
         """Return whether thread participation requires @mention to follow up.
 
@@ -4750,6 +4768,9 @@ class DiscordAdapter(BasePlatformAdapter):
             parent_channel_id = self._get_parent_channel_id(message.channel)
 
         is_voice_linked_channel = False
+        is_free_channel = False
+        is_threaded_free_channel = False
+        channel_ids: set[str] = set()
 
         # Save mention-stripped text before auto-threading since create_thread()
         # can clobber message.content, breaking /command detection in channels.
@@ -4793,6 +4814,7 @@ class DiscordAdapter(BasePlatformAdapter):
                 return
 
             free_channels = self._discord_free_response_channels()
+            threaded_free_channels = self._discord_threaded_free_response_channels()
             if parent_channel_id:
                 channel_ids.add(parent_channel_id)
 
@@ -4802,9 +4824,14 @@ class DiscordAdapter(BasePlatformAdapter):
             voice_linked_ids = {str(ch_id) for ch_id in self._voice_text_channels.values()}
             current_channel_id = str(message.channel.id)
             is_voice_linked_channel = current_channel_id in voice_linked_ids
+            is_threaded_free_channel = (
+                "*" in threaded_free_channels
+                or bool(channel_ids & threaded_free_channels)
+            )
             is_free_channel = (
                 "*" in free_channels
                 or bool(channel_ids & free_channels)
+                or is_threaded_free_channel
                 or is_voice_linked_channel
             )
 
@@ -4830,7 +4857,9 @@ class DiscordAdapter(BasePlatformAdapter):
         if not is_thread and not isinstance(message.channel, discord.DMChannel):
             no_thread_channels_raw = os.getenv("DISCORD_NO_THREAD_CHANNELS", "")
             no_thread_channels = {ch.strip() for ch in no_thread_channels_raw.split(",") if ch.strip()}
-            skip_thread = bool(channel_ids & no_thread_channels) or is_free_channel
+            skip_thread = bool(channel_ids & no_thread_channels) or (
+                is_free_channel and not is_threaded_free_channel
+            )
             auto_thread = os.getenv("DISCORD_AUTO_THREAD", "true").lower() in {"true", "1", "yes"}
             is_reply_message = getattr(message, "type", None) == discord.MessageType.reply
             if auto_thread and not skip_thread and not is_voice_linked_channel and not is_reply_message:
@@ -6520,6 +6549,11 @@ def _apply_yaml_config(yaml_cfg: dict, discord_cfg: dict) -> dict | None:
         if isinstance(frc, list):
             frc = ",".join(str(v) for v in frc)
         os.environ["DISCORD_FREE_RESPONSE_CHANNELS"] = str(frc)
+    tfrc = discord_cfg.get("free_response_threaded_channels")
+    if tfrc is not None and not os.getenv("DISCORD_FREE_RESPONSE_THREADED_CHANNELS"):
+        if isinstance(tfrc, list):
+            tfrc = ",".join(str(v) for v in tfrc)
+        os.environ["DISCORD_FREE_RESPONSE_THREADED_CHANNELS"] = str(tfrc)
     if "auto_thread" in discord_cfg and not os.getenv("DISCORD_AUTO_THREAD"):
         os.environ["DISCORD_AUTO_THREAD"] = str(discord_cfg["auto_thread"]).lower()
     if "reactions" in discord_cfg and not os.getenv("DISCORD_REACTIONS"):

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -3244,6 +3244,10 @@ class DiscordAdapter(BasePlatformAdapter):
         async def slash_sethome(interaction: discord.Interaction):
             await self._run_simple_slash(interaction, "/sethome")
 
+        @tree.command(name="server-users", description="List this server's users as comma-separated names")
+        async def slash_server_users(interaction):
+            await self._run_simple_slash(interaction, "/server-users")
+
         @tree.command(name="stop", description="Stop the running Hermes agent")
         async def slash_stop(interaction: discord.Interaction):
             await self._run_simple_slash(interaction, "/stop", "Stop requested~")
@@ -3725,6 +3729,7 @@ class DiscordAdapter(BasePlatformAdapter):
         # For forum threads, inherit the parent forum's topic.
         chat_topic = self._get_effective_topic(interaction.channel, is_thread=is_thread)
 
+        parent_id = str(getattr(getattr(interaction, "channel", None), "parent_id", "") or "")
         source = self.build_source(
             chat_id=str(interaction.channel_id),
             chat_name=chat_name,
@@ -3733,11 +3738,12 @@ class DiscordAdapter(BasePlatformAdapter):
             user_name=interaction.user.display_name,
             thread_id=thread_id,
             chat_topic=chat_topic,
+            guild_id=str(getattr(interaction, "guild_id", "") or "") or None,
+            parent_chat_id=parent_id or None,
         )
 
         msg_type = MessageType.COMMAND if text.startswith("/") else MessageType.TEXT
         channel_id = str(interaction.channel_id)
-        parent_id = str(getattr(getattr(interaction, "channel", None), "parent_id", "") or "")
         return MessageEvent(
             text=text,
             message_type=msg_type,

--- a/tests/gateway/test_command_bypass_active_session.py
+++ b/tests/gateway/test_command_bypass_active_session.py
@@ -326,7 +326,7 @@ class TestAllResolvableCommandsBypassGuard:
         for cmd in (
             "model", "reasoning", "personality", "voice", "insights", "title",
             "resume", "retry", "undo", "compress", "usage",
-            "reload-mcp", "sethome", "reset",
+            "reload-mcp", "sethome", "reset", "server-users",
         ):
             assert should_bypass_active_session(cmd) is True, (
                 f"/{cmd} must bypass the active-session guard"

--- a/tests/gateway/test_discord_channel_controls.py
+++ b/tests/gateway/test_discord_channel_controls.py
@@ -245,6 +245,47 @@ async def test_normal_channel_still_auto_threads(adapter, monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_threaded_free_response_channel_bypasses_mention_and_auto_threads(adapter, monkeypatch):
+    """Threaded free-response channels should process unmentioned messages and still auto-thread."""
+    monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "true")
+    monkeypatch.setenv("DISCORD_FREE_RESPONSE_THREADED_CHANNELS", "901")
+    monkeypatch.delenv("DISCORD_FREE_RESPONSE_CHANNELS", raising=False)
+    monkeypatch.delenv("DISCORD_NO_THREAD_CHANNELS", raising=False)
+    monkeypatch.delenv("DISCORD_AUTO_THREAD", raising=False)
+    monkeypatch.delenv("DISCORD_IGNORED_CHANNELS", raising=False)
+
+    fake_thread = FakeThread(channel_id=999, name="auto-thread")
+    adapter._auto_create_thread = AsyncMock(return_value=fake_thread)
+
+    message = make_message(channel=FakeTextChannel(channel_id=901), content="hello without mention")
+    await adapter._handle_message(message)
+
+    adapter._auto_create_thread.assert_awaited_once()
+    adapter.handle_message.assert_awaited_once()
+    event = adapter.handle_message.await_args.args[0]
+    assert event.source.chat_type == "thread"
+
+
+@pytest.mark.asyncio
+async def test_threaded_free_response_parent_matches_thread_replies(adapter, monkeypatch):
+    """Threads under a threaded free-response parent should process replies without mention."""
+    monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "true")
+    monkeypatch.setenv("DISCORD_THREAD_REQUIRE_MENTION", "true")
+    monkeypatch.setenv("DISCORD_HISTORY_BACKFILL", "false")
+    monkeypatch.setenv("DISCORD_FREE_RESPONSE_THREADED_CHANNELS", "901")
+    monkeypatch.delenv("DISCORD_FREE_RESPONSE_CHANNELS", raising=False)
+    monkeypatch.delenv("DISCORD_NO_THREAD_CHANNELS", raising=False)
+    monkeypatch.delenv("DISCORD_IGNORED_CHANNELS", raising=False)
+
+    parent = FakeTextChannel(channel_id=901, name="oscar")
+    thread = FakeThread(channel_id=902, name="thread-in-oscar", parent=parent)
+    message = make_message(channel=thread, content="reply without mention")
+    await adapter._handle_message(message)
+
+    adapter.handle_message.assert_awaited_once()
+
+
+@pytest.mark.asyncio
 async def test_no_thread_channels_csv_parsing(adapter, monkeypatch):
     """Multiple no_thread channel IDs parsed from CSV."""
     monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "false")
@@ -322,6 +363,25 @@ def test_config_bridges_no_thread_channels(monkeypatch, tmp_path):
 
     import os
     assert os.getenv("DISCORD_NO_THREAD_CHANNELS") == "333"
+
+
+def test_config_bridges_threaded_free_response_channels(monkeypatch, tmp_path):
+    """gateway/config.py bridges discord.free_response_threaded_channels to env var."""
+    import yaml
+    config_file = tmp_path / "config.yaml"
+    config_file.write_text(yaml.dump({
+        "discord": {
+            "free_response_threaded_channels": ["444", "555"],
+        },
+    }))
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setenv("DISCORD_FREE_RESPONSE_THREADED_CHANNELS", "")
+
+    from gateway.config import load_gateway_config
+    load_gateway_config()
+
+    import os
+    assert os.getenv("DISCORD_FREE_RESPONSE_THREADED_CHANNELS") == "444,555"
 
 
 def test_config_env_var_takes_precedence(monkeypatch, tmp_path):

--- a/tests/gateway/test_discord_server_users_command.py
+++ b/tests/gateway/test_discord_server_users_command.py
@@ -1,0 +1,111 @@
+from types import SimpleNamespace
+
+import pytest
+
+from gateway.config import Platform
+from gateway.platforms.base import MessageEvent, MessageType
+from gateway.session import SessionSource
+from gateway.slash_commands import GatewaySlashCommandsMixin
+
+
+class _AsyncMembers:
+    def __init__(self, members):
+        self._members = list(members)
+        self._index = 0
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        if self._index >= len(self._members):
+            raise StopAsyncIteration
+        member = self._members[self._index]
+        self._index += 1
+        return member
+
+
+class _Guild:
+    id = 123
+
+    def __init__(self, members, *, fetch_error=None, cached=None):
+        self._members = members
+        self._fetch_error = fetch_error
+        self.members = cached or []
+
+    def fetch_members(self, limit=None):
+        assert limit is None
+        if self._fetch_error is not None:
+            raise self._fetch_error
+        return _AsyncMembers(self._members)
+
+
+class _Client:
+    def __init__(self, guild):
+        self.guild = guild
+
+    def get_guild(self, guild_id):
+        return self.guild if guild_id == self.guild.id else None
+
+
+class _Runner(GatewaySlashCommandsMixin):
+    adapters: dict
+
+
+def _event(guild_id="123", raw_message=None):
+    source = SessionSource(
+        platform=Platform.DISCORD,
+        chat_id="456",
+        chat_type="group",
+        user_id="789",
+        guild_id=guild_id,
+    )
+    return MessageEvent(
+        text="/server-users",
+        message_type=MessageType.COMMAND,
+        source=source,
+        raw_message=raw_message,
+    )
+
+
+@pytest.mark.asyncio
+async def test_server_users_lists_fetched_members_as_comma_separated_names():
+    guild = _Guild([
+        SimpleNamespace(display_name="Charlie"),
+        SimpleNamespace(display_name="Alice, Admin"),
+        SimpleNamespace(display_name="bob"),
+    ])
+    runner = _Runner()
+    runner.adapters = {Platform.DISCORD: SimpleNamespace(_client=_Client(guild))}
+
+    result = await runner._handle_server_users_command(_event())
+
+    assert result == "Alice  Admin, bob, Charlie"
+
+
+@pytest.mark.asyncio
+async def test_server_users_falls_back_to_cached_members_when_fetch_fails():
+    guild = _Guild(
+        [],
+        fetch_error=RuntimeError("missing intent"),
+        cached=[SimpleNamespace(display_name="Cached User")],
+    )
+    runner = _Runner()
+    runner.adapters = {Platform.DISCORD: SimpleNamespace(_client=_Client(guild))}
+
+    result = await runner._handle_server_users_command(_event())
+
+    assert result == "⚠️ Full member fetch failed; using the cached member list.\nCached User"
+
+
+@pytest.mark.asyncio
+async def test_server_users_rejects_non_discord_sources():
+    runner = GatewaySlashCommandsMixin()
+    event = MessageEvent(
+        text="/server-users",
+        message_type=MessageType.COMMAND,
+        source=SessionSource(platform=Platform.TELEGRAM, chat_id="1"),
+    )
+
+    result = await runner._handle_server_users_command(event)
+
+    assert "only available from a Discord server" in result

--- a/tests/gateway/test_discord_slash_commands.py
+++ b/tests/gateway/test_discord_slash_commands.py
@@ -115,6 +115,27 @@ def adapter():
 
 
 # ------------------------------------------------------------------
+# Slash event source metadata
+# ------------------------------------------------------------------
+
+
+def test_build_slash_event_preserves_guild_and_parent_channel(adapter):
+    guild = SimpleNamespace(id=123, name="VaelCorp")
+    channel = SimpleNamespace(id=456, name="athena", guild=guild, parent_id=111)
+    interaction = SimpleNamespace(
+        channel=channel,
+        channel_id=456,
+        guild_id=123,
+        user=SimpleNamespace(id=789, display_name="snapss"),
+    )
+
+    event = adapter._build_slash_event(interaction, "/server-users")
+
+    assert event.source.guild_id == "123"
+    assert event.source.parent_chat_id == "111"
+
+
+# ------------------------------------------------------------------
 # /thread slash command registration
 # ------------------------------------------------------------------
 
@@ -191,6 +212,12 @@ async def test_auto_registered_command_dispatches_correctly(adapter):
     adapter._run_simple_slash.reset_mock()
     await debug_cmd.callback(interaction)
     adapter._run_simple_slash.assert_awaited_once_with(interaction, "/debug")
+
+    server_users_cmd = adapter._client.tree.commands["server-users"]
+    interaction = SimpleNamespace()
+    adapter._run_simple_slash.reset_mock()
+    await server_users_cmd(interaction)
+    adapter._run_simple_slash.assert_awaited_once_with(interaction, "/server-users")
 
 
 @pytest.mark.asyncio

--- a/tests/hermes_cli/test_commands.py
+++ b/tests/hermes_cli/test_commands.py
@@ -189,6 +189,9 @@ class TestGatewayKnownCommands:
         assert "bg" in GATEWAY_KNOWN_COMMANDS
         assert "background" in GATEWAY_KNOWN_COMMANDS
 
+    def test_includes_platform_specific_gateway_commands(self):
+        assert "server-users" in GATEWAY_KNOWN_COMMANDS
+
     def test_is_frozenset(self):
         assert isinstance(GATEWAY_KNOWN_COMMANDS, frozenset)
 


### PR DESCRIPTION
## Summary\n- add a Discord-only /server-users slash command that outputs server member names as a comma-separated list\n- preserve guild and parent channel metadata for Discord slash interactions\n- keep platform-specific command recognition out of cross-platform Slack/Telegram slash menus\n\n## Tests\n- python -m pytest tests/hermes_cli/test_commands.py tests/gateway/test_command_bypass_active_session.py tests/gateway/test_discord_slash_commands.py tests/gateway/test_discord_server_users_command.py -o 'addopts=' -q\n\nNote: the broader tests/gateway/test_discord_*.py suite still has an unrelated local-env failure in test_discord_bot_filter.py because DISCORD_ALLOW_BOTS is being loaded as 'mentions'.