### PR TITLE
fix(desktop): resolve electronDist dynamically + self-heal blocked installs (supersedes #48081/#48082)

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -21,7 +21,7 @@
     "build": "node scripts/assert-root-install.cjs && node scripts/write-build-stamp.cjs && node scripts/stage-native-deps.cjs && tsc -b && vite build && npm run postbuild",
     "postbuild": "node scripts/assert-dist-built.cjs",
     "prebuilder": "node scripts/patch-electron-builder-mac-binary.cjs",
-    "builder": "cross-env NODE_OPTIONS=--max-old-space-size=16384 electron-builder",
+    "builder": "cross-env NODE_OPTIONS=--max-old-space-size=16384 node scripts/run-electron-builder.cjs",
     "pack": "npm run build && npm run builder -- --dir",
     "dist": "npm run build && npm run builder",
     "dist:mac": "npm run build && npm run builder -- --mac",
@@ -135,7 +135,6 @@
   },
   "build": {
     "electronVersion": "40.10.2",
-    "electronDist": "node_modules/electron/dist",
     "appId": "com.nousresearch.hermes",
     "productName": "Hermes",
     "executableName": "Hermes",

--- a/apps/desktop/scripts/run-electron-builder.cjs
+++ b/apps/desktop/scripts/run-electron-builder.cjs
@@ -1,0 +1,88 @@
+#!/usr/bin/env node
+"use strict"
+
+// Run electron-builder with build.electronDist resolved at runtime instead of
+// hardcoded in package.json.
+//
+// Why this exists (the bug it kills for good):
+//   electron-builder 26.8.x can stage an Electron.app without its main
+//   MacOS/Electron binary when it re-unpacks Electron from its own cache
+//   (#38673), so the desktop build pins build.electronDist at the *already
+//   unpacked* electron package's dist to make electron-builder reuse it. But
+//   electronDist in package.json is a static relative path, and npm workspace
+//   hoisting is NOT deterministic: depending on the npm version and what else
+//   is installed, npm may nest the workspace-only electron devDep under
+//   apps/desktop/node_modules/electron OR hoist it to the repo-root
+//   node_modules/electron. A static path matches only one layout, so a clean
+//   install intermittently fails with "The specified electronDist does not
+//   exist" (the June desktop-build outage: #47917, #48019, #48021, #48084).
+//
+// The fix: resolve the electron package the same way Node's runtime does —
+// require.resolve("electron/package.json") walks node_modules from this script
+// upward and finds electron wherever npm actually put it. The path can never
+// drift out of sync with the install layout again, on any OS or npm version.
+//
+//   - dist present  -> pass -c.electronDist=<abs>/dist so electron-builder
+//                      reuses the unpacked runtime (keeps the #38673 fast path
+//                      that dodges the 26.8.x missing-binary re-unpack bug).
+//   - dist absent   -> omit electronDist entirely and let electron-builder
+//                      fetch Electron itself via @electron/get (honoring
+//                      build.electronVersion + any ELECTRON_MIRROR). This is
+//                      the network-blocked / skipped-postinstall case; the
+//                      mac-binary prebuilder patch is the backstop for it.
+
+const fs = require("node:fs")
+const path = require("node:path")
+const { spawnSync } = require("node:child_process")
+
+function electronDistDir() {
+  let pkgJson
+  try {
+    pkgJson = require.resolve("electron/package.json")
+  } catch {
+    return null
+  }
+  return path.join(path.dirname(pkgJson), "dist")
+}
+
+function distBinary(dist) {
+  if (process.platform === "darwin") {
+    return path.join(dist, "Electron.app", "Contents", "MacOS", "Electron")
+  }
+  if (process.platform === "win32") {
+    return path.join(dist, "electron.exe")
+  }
+  return path.join(dist, "electron")
+}
+
+function electronBuilderCli() {
+  const pkgJson = require.resolve("electron-builder/package.json")
+  const bin = require(pkgJson).bin
+  const rel = typeof bin === "string" ? bin : bin["electron-builder"]
+  return path.join(path.dirname(pkgJson), rel)
+}
+
+const passthrough = process.argv.slice(2)
+const args = []
+
+const dist = electronDistDir()
+if (dist && fs.existsSync(distBinary(dist))) {
+  // Absolute so electron-builder never re-resolves it against the app dir.
+  args.push(`-c.electronDist=${dist}`)
+} else {
+  console.warn(
+    "[run-electron-builder] electron dist not found on disk; letting " +
+      "electron-builder fetch Electron via @electron/get (electronVersion + " +
+      "ELECTRON_MIRROR apply)."
+  )
+}
+args.push(...passthrough)
+
+const result = spawnSync(process.execPath, [electronBuilderCli(), ...args], {
+  stdio: "inherit",
+})
+if (result.error) {
+  console.error(`[run-electron-builder] failed to launch electron-builder: ${result.error.message}`)
+  process.exit(1)
+}
+process.exit(result.status == null ? 1 : result.status)

--- a/apps/desktop/scripts/run-electron-builder.cjs
+++ b/apps/desktop/scripts/run-electron-builder.cjs
@@ -1,48 +1,21 @@
-#!/usr/bin/env node
 "use strict"
 
-// Run electron-builder with build.electronDist resolved at runtime instead of
-// hardcoded in package.json.
-//
-// Why this exists (the bug it kills for good):
-//   electron-builder 26.8.x can stage an Electron.app without its main
-//   MacOS/Electron binary when it re-unpacks Electron from its own cache
-//   (#38673), so the desktop build pins build.electronDist at the *already
-//   unpacked* electron package's dist to make electron-builder reuse it. But
-//   electronDist in package.json is a static relative path, and npm workspace
-//   hoisting is NOT deterministic: depending on the npm version and what else
-//   is installed, npm may nest the workspace-only electron devDep under
-//   apps/desktop/node_modules/electron OR hoist it to the repo-root
-//   node_modules/electron. A static path matches only one layout, so a clean
-//   install intermittently fails with "The specified electronDist does not
-//   exist" (the June desktop-build outage: #47917, #48019, #48021, #48084).
-//
-// The fix: resolve the electron package the same way Node's runtime does —
-// require.resolve("electron/package.json") walks node_modules from this script
-// upward and finds electron wherever npm actually put it. The path can never
-// drift out of sync with the install layout again, on any OS or npm version.
-//
-//   - dist present  -> pass -c.electronDist=<abs>/dist so electron-builder
-//                      reuses the unpacked runtime (keeps the #38673 fast path
-//                      that dodges the 26.8.x missing-binary re-unpack bug).
-//   - dist absent   -> omit electronDist entirely and let electron-builder
-//                      fetch Electron itself via @electron/get (honoring
-//                      build.electronVersion + any ELECTRON_MIRROR). This is
-//                      the network-blocked / skipped-postinstall case; the
-//                      mac-binary prebuilder patch is the backstop for it.
+// Resolve electronDist at runtime (#38673, #47917): electron-builder 26.8.x can
+// re-unpack a broken Electron.app; reusing the installed dist dodges that.
+// npm workspace hoisting is non-deterministic — require.resolve finds electron
+// wherever it landed. Dist present → -c.electronDist=<abs>/dist; absent → let
+// electron-builder fetch via @electron/get (electronVersion + ELECTRON_MIRROR).
 
 const fs = require("node:fs")
 const path = require("node:path")
 const { spawnSync } = require("node:child_process")
 
 function electronDistDir() {
-  let pkgJson
   try {
-    pkgJson = require.resolve("electron/package.json")
+    return path.join(path.dirname(require.resolve("electron/package.json")), "dist")
   } catch {
     return null
   }
-  return path.join(path.dirname(pkgJson), "dist")
 }
 
 function distBinary(dist) {
@@ -62,27 +35,23 @@ function electronBuilderCli() {
   return path.join(path.dirname(pkgJson), rel)
 }
 
-const passthrough = process.argv.slice(2)
-const args = []
-
 const dist = electronDistDir()
+const args = []
 if (dist && fs.existsSync(distBinary(dist))) {
-  // Absolute so electron-builder never re-resolves it against the app dir.
   args.push(`-c.electronDist=${dist}`)
 } else {
   console.warn(
-    "[run-electron-builder] electron dist not found on disk; letting " +
-      "electron-builder fetch Electron via @electron/get (electronVersion + " +
-      "ELECTRON_MIRROR apply)."
+    "[run-electron-builder] no local electron dist; electron-builder will fetch " +
+      "via @electron/get (electronVersion + ELECTRON_MIRROR)."
   )
 }
-args.push(...passthrough)
+args.push(...process.argv.slice(2))
 
 const result = spawnSync(process.execPath, [electronBuilderCli(), ...args], {
   stdio: "inherit",
 })
 if (result.error) {
-  console.error(`[run-electron-builder] failed to launch electron-builder: ${result.error.message}`)
+  console.error(`[run-electron-builder] spawn failed: ${result.error.message}`)
   process.exit(1)
 }
 process.exit(result.status == null ? 1 : result.status)

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -5167,6 +5167,21 @@ def _electron_dist_ok(project_root: Path) -> bool:
         return False
 
 
+def _electron_pkg_staged_missing_dist(project_root: Path) -> bool:
+    """True when electron package staged but its dist is missing.
+
+    npm runs postinstall scripts after staging package files on disk. For the
+    blocked-download failure mode, ``electron/package.json`` + ``install.js``
+    exist but ``dist/`` is missing because ``install.js`` failed.
+    """
+    electron_dir = _electron_dir(project_root)
+    return (
+        (electron_dir / "package.json").is_file()
+        and (electron_dir / "install.js").is_file()
+        and not _electron_dist_ok(project_root)
+    )
+
+
 def _redownload_electron_dist(
     project_root: Path,
     env: dict,
@@ -5442,44 +5457,28 @@ def cmd_gui(args: argparse.Namespace):
             nixos_env = _nixos_build_env()
             install_result = _run_npm_install_deterministic(npm, PROJECT_ROOT, capture_output=False, env=nixos_env)
             if install_result.returncode != 0:
-                # The most common dependency-install failure is electron's
-                # postinstall binary download being blocked/throttled: its
-                # install.js does `process.exit(1)` on a failed download, which
-                # fails the whole `npm ci`/`npm install` (#47266, #47917, #48021).
-                # npm runs postinstall scripts LAST — after every package is
-                # already staged on disk — so when the binary download is the
-                # casualty the electron package itself (package.json, install.js)
-                # is present and only its dist/ is missing. Bailing here is what
-                # made the mirror self-heal further down dead code on a blocked
-                # network: that self-heal only runs after a failed `pack`, but
-                # the install step exits first so `pack` is never reached.
-                #
-                # If the electron package staged (so npm got far enough to be a
-                # download casualty, not a genuine dependency-resolution error),
-                # try to repopulate the dist via electron's own downloader
-                # (canonical first, then the public mirror) and carry on to the
-                # build. Even if that can't fetch it, `npm run pack` now resolves
-                # electronDist dynamically and lets electron-builder fetch
-                # Electron itself, so the pack-time mirror fallback gets a final
-                # shot. Hard-fail only when electron never staged at all.
-                electron_pkg = _electron_dir(PROJECT_ROOT) / "package.json"
-                if not electron_pkg.is_file():
+                # npm runs postinstall scripts LAST. When Electron's binary
+                # download is blocked/throttled (#47266/#47917/#48021), the
+                # package files are staged (package.json + install.js) but dist/
+                # is missing. In that specific shape, attempt a best-effort
+                # dist repair and continue to pack; otherwise, fail fast so
+                # unrelated install errors aren't mislabeled as Electron issues.
+                if not _electron_pkg_staged_missing_dist(PROJECT_ROOT):
                     print("✗ Desktop dependency install failed")
                     print(f"  Run manually:  cd {PROJECT_ROOT} && npm ci")
                     sys.exit(install_result.returncode or 1)
-                if not _electron_dist_ok(PROJECT_ROOT):
-                    repaired = _redownload_electron_dist(PROJECT_ROOT, env)
-                    if not repaired and not env.get("ELECTRON_MIRROR"):
-                        repaired = _redownload_electron_dist(
-                            PROJECT_ROOT, env, mirror=_ELECTRON_FALLBACK_MIRROR
-                        )
-                    if repaired:
-                        print("  ⚠ Dependency install failed on the Electron binary "
-                              "download; repopulated the Electron dist and continuing.")
-                    else:
-                        print("  ⚠ Dependency install failed on the Electron binary "
-                              "download; continuing to the build so electron-builder "
-                              "can fetch Electron itself.")
+                repaired = _redownload_electron_dist(PROJECT_ROOT, env)
+                if not repaired and not env.get("ELECTRON_MIRROR"):
+                    repaired = _redownload_electron_dist(
+                        PROJECT_ROOT, env, mirror=_ELECTRON_FALLBACK_MIRROR
+                    )
+                if repaired:
+                    print("  ⚠ Dependency install failed with a missing Electron dist; "
+                          "repopulated it and continuing.")
+                else:
+                    print("  ⚠ Dependency install failed with a missing Electron dist; "
+                          "continuing to the build so electron-builder can attempt "
+                          "the Electron fetch itself.")
 
             build_label = "source build" if source_mode else "packaged app"
             print(f"→ Building desktop {build_label}...")
@@ -5508,18 +5507,15 @@ def cmd_gui(args: argparse.Namespace):
                 # verification, which is the real source of truth. If the
                 # failure was something else, the clean re-download is harmless
                 # and the retry fails the same way.
-                purged = _purge_electron_build_cache(desktop_dir)
-                # The build reuses the already-unpacked electron dist when it is
-                # present (resolved dynamically by scripts/run-electron-builder.cjs,
-                # #38673), so purging the build cache + re-running pack can't by
-                # itself repopulate a missing/partial dist. When the dist is
-                # actually gone, re-run electron's own downloader so the retry has
-                # a binary to reuse. Gated on the dist check so an unrelated build
-                # failure (tsc/vite) doesn't trigger a pointless ~200 MB refetch.
+                # Only run the Electron cache repair path when Electron dist is
+                # actually missing/corrupt. This avoids retrying unrelated build
+                # failures (e.g., tsc/vite) under an Electron-specific narrative.
+                purged: list[Path] = []
                 restored = False
                 if not _electron_dist_ok(PROJECT_ROOT):
+                    purged = _purge_electron_build_cache(desktop_dir)
                     restored = _redownload_electron_dist(PROJECT_ROOT, env)
-                if purged or restored:
+                if restored:
                     print("  ⚠ Desktop build failed; refreshed the Electron download and retrying once...")
                     for p in purged:
                         print(f"    - {p}")

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -5110,6 +5110,15 @@ def _purge_electron_build_cache(desktop_dir: Path) -> list[Path]:
     return removed
 
 
+# Public Electron mirror used as a last-resort fallback when the canonical
+# GitHub release host is blocked/throttled (#47266). npmmirror.com (Alibaba) is
+# the de-facto Electron community mirror. @electron/get SHASUM-checks the
+# download, but the SHASUMS come from the same mirror, so reaching for it is an
+# explicit trust trade-off we only make AFTER the canonical download fails, and
+# never when the user has pinned their own ELECTRON_MIRROR.
+_ELECTRON_FALLBACK_MIRROR = "https://npmmirror.com/mirrors/electron/"
+
+
 def _electron_dir(project_root: Path) -> Path:
     """Return the Electron package directory the desktop workspace installs.
 
@@ -5164,17 +5173,17 @@ def _redownload_electron_dist(
     *,
     mirror: Optional[str] = None,
 ) -> bool:
-    """(Re)populate ``node_modules/electron/dist`` via electron's own downloader.
+    """(Re)populate the electron package's ``dist`` via electron's own downloader.
 
-    Since #38673 the desktop build pins ``build.electronDist`` to
-    ``node_modules/electron/dist``, so electron-builder reads the Electron binary
-    straight from there and never downloads it during ``npm run pack``. That dist
-    tree is produced by the ``electron`` package's postinstall (``install.js``)
-    during ``npm ci``. When that download is blocked or throttled (GitHub's
-    release host is unreachable in some regions — #47266), the dist is missing
-    and re-running ``pack`` only re-throws "The specified electronDist does not
-    exist". The mirror fallback therefore has to drive *this* downloader, not
-    another ``pack``.
+    Since #38673 the desktop build reuses the ``electron`` package's already
+    unpacked ``dist`` (resolved dynamically at pack time by
+    ``scripts/run-electron-builder.cjs``) to dodge electron-builder 26.8.x's
+    missing-binary re-unpack bug. That dist tree is produced by the ``electron``
+    package's postinstall (``install.js``) during ``npm ci``. When that download
+    is blocked or throttled (GitHub's release host is unreachable in some
+    regions — #47266), the dist is missing. Pre-fetching it here — optionally via
+    a mirror — gives the build a dist to reuse; if it can't, the build falls back
+    to letting electron-builder fetch Electron itself, so this is best-effort.
 
     No-op (returns True) when the dist binary is already present, so an unrelated
     build failure doesn't trigger a needless ~200 MB re-download. Otherwise drops
@@ -5433,9 +5442,44 @@ def cmd_gui(args: argparse.Namespace):
             nixos_env = _nixos_build_env()
             install_result = _run_npm_install_deterministic(npm, PROJECT_ROOT, capture_output=False, env=nixos_env)
             if install_result.returncode != 0:
-                print("✗ Desktop dependency install failed")
-                print(f"  Run manually:  cd {PROJECT_ROOT} && npm ci")
-                sys.exit(install_result.returncode or 1)
+                # The most common dependency-install failure is electron's
+                # postinstall binary download being blocked/throttled: its
+                # install.js does `process.exit(1)` on a failed download, which
+                # fails the whole `npm ci`/`npm install` (#47266, #47917, #48021).
+                # npm runs postinstall scripts LAST — after every package is
+                # already staged on disk — so when the binary download is the
+                # casualty the electron package itself (package.json, install.js)
+                # is present and only its dist/ is missing. Bailing here is what
+                # made the mirror self-heal further down dead code on a blocked
+                # network: that self-heal only runs after a failed `pack`, but
+                # the install step exits first so `pack` is never reached.
+                #
+                # If the electron package staged (so npm got far enough to be a
+                # download casualty, not a genuine dependency-resolution error),
+                # try to repopulate the dist via electron's own downloader
+                # (canonical first, then the public mirror) and carry on to the
+                # build. Even if that can't fetch it, `npm run pack` now resolves
+                # electronDist dynamically and lets electron-builder fetch
+                # Electron itself, so the pack-time mirror fallback gets a final
+                # shot. Hard-fail only when electron never staged at all.
+                electron_pkg = _electron_dir(PROJECT_ROOT) / "package.json"
+                if not electron_pkg.is_file():
+                    print("✗ Desktop dependency install failed")
+                    print(f"  Run manually:  cd {PROJECT_ROOT} && npm ci")
+                    sys.exit(install_result.returncode or 1)
+                if not _electron_dist_ok(PROJECT_ROOT):
+                    repaired = _redownload_electron_dist(PROJECT_ROOT, env)
+                    if not repaired and not env.get("ELECTRON_MIRROR"):
+                        repaired = _redownload_electron_dist(
+                            PROJECT_ROOT, env, mirror=_ELECTRON_FALLBACK_MIRROR
+                        )
+                    if repaired:
+                        print("  ⚠ Dependency install failed on the Electron binary "
+                              "download; repopulated the Electron dist and continuing.")
+                    else:
+                        print("  ⚠ Dependency install failed on the Electron binary "
+                              "download; continuing to the build so electron-builder "
+                              "can fetch Electron itself.")
 
             build_label = "source build" if source_mode else "packaged app"
             print(f"→ Building desktop {build_label}...")
@@ -5465,12 +5509,12 @@ def cmd_gui(args: argparse.Namespace):
                 # failure was something else, the clean re-download is harmless
                 # and the retry fails the same way.
                 purged = _purge_electron_build_cache(desktop_dir)
-                # electronDist is pinned to node_modules/electron/dist (#38673):
-                # electron-builder reads the Electron binary from there and `pack`
-                # never downloads it, so purging the cache + re-running pack can't
-                # by itself repopulate a missing/partial dist. When the dist is
+                # The build reuses the already-unpacked electron dist when it is
+                # present (resolved dynamically by scripts/run-electron-builder.cjs,
+                # #38673), so purging the build cache + re-running pack can't by
+                # itself repopulate a missing/partial dist. When the dist is
                 # actually gone, re-run electron's own downloader so the retry has
-                # a binary to read. Gated on the dist check so an unrelated build
+                # a binary to reuse. Gated on the dist check so an unrelated build
                 # failure (tsc/vite) doesn't trigger a pointless ~200 MB refetch.
                 restored = False
                 if not _electron_dist_ok(PROJECT_ROOT):
@@ -5496,23 +5540,19 @@ def cmd_gui(args: argparse.Namespace):
                 print("  ⚠ Desktop build still failing; the Electron download from "
                       "GitHub looks blocked. Re-downloading via a public mirror "
                       "(npmmirror.com)... (set ELECTRON_MIRROR to use another mirror)")
-                mirror = "https://npmmirror.com/mirrors/electron/"
+                mirror = _ELECTRON_FALLBACK_MIRROR
                 mirror_env = dict(env)
                 mirror_env["ELECTRON_MIRROR"] = mirror
-                # electronDist is pinned (#38673), so `npm run pack` never
-                # downloads Electron — the mirror only helps if it drives
-                # electron's own downloader. Re-fetch the binary through the
-                # mirror first; otherwise the retry just re-reads the same missing
-                # dist and re-throws "electronDist does not exist" (#47266).
-                have_dist = _electron_dist_ok(PROJECT_ROOT)
-                if not have_dist:
-                    have_dist = _redownload_electron_dist(PROJECT_ROOT, env, mirror=mirror)
-                if have_dist:
-                    _stop_desktop_processes_locking_build(desktop_dir)
-                    build_result = subprocess.run([npm, "run", build_script], cwd=desktop_dir, env=mirror_env, check=False)
-                else:
-                    print("  ✗ Could not re-download Electron from the mirror "
-                          "(node_modules/electron/dist still missing)")
+                # Pre-fetch the binary through the mirror via electron's own
+                # downloader so the retry has a dist to reuse. If that can't be
+                # populated, still retry the pack under ELECTRON_MIRROR: the
+                # build now resolves electronDist dynamically and, when the dist
+                # is absent, lets electron-builder fetch Electron itself through
+                # @electron/get — which honors ELECTRON_MIRROR (#47266).
+                if not _electron_dist_ok(PROJECT_ROOT):
+                    _redownload_electron_dist(PROJECT_ROOT, env, mirror=mirror)
+                _stop_desktop_processes_locking_build(desktop_dir)
+                build_result = subprocess.run([npm, "run", build_script], cwd=desktop_dir, env=mirror_env, check=False)
             if build_result.returncode != 0:
                 print("✗ Desktop GUI build failed")
                 print(f"  Run manually:  cd apps/desktop && npm run {build_script}")

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -5110,12 +5110,8 @@ def _purge_electron_build_cache(desktop_dir: Path) -> list[Path]:
     return removed
 
 
-# Public Electron mirror used as a last-resort fallback when the canonical
-# GitHub release host is blocked/throttled (#47266). npmmirror.com (Alibaba) is
-# the de-facto Electron community mirror. @electron/get SHASUM-checks the
-# download, but the SHASUMS come from the same mirror, so reaching for it is an
-# explicit trust trade-off we only make AFTER the canonical download fails, and
-# never when the user has pinned their own ELECTRON_MIRROR.
+# Last-resort Electron mirror after GitHub download fails (#47266). Only used
+# when the user hasn't pinned ELECTRON_MIRROR.
 _ELECTRON_FALLBACK_MIRROR = "https://npmmirror.com/mirrors/electron/"
 
 
@@ -5168,12 +5164,7 @@ def _electron_dist_ok(project_root: Path) -> bool:
 
 
 def _electron_pkg_staged_missing_dist(project_root: Path) -> bool:
-    """True when electron package staged but its dist is missing.
-
-    npm runs postinstall scripts after staging package files on disk. For the
-    blocked-download failure mode, ``electron/package.json`` + ``install.js``
-    exist but ``dist/`` is missing because ``install.js`` failed.
-    """
+    """electron staged (package.json + install.js) but dist missing — blocked postinstall."""
     electron_dir = _electron_dir(project_root)
     return (
         (electron_dir / "package.json").is_file()
@@ -5188,25 +5179,7 @@ def _redownload_electron_dist(
     *,
     mirror: Optional[str] = None,
 ) -> bool:
-    """(Re)populate the electron package's ``dist`` via electron's own downloader.
-
-    Since #38673 the desktop build reuses the ``electron`` package's already
-    unpacked ``dist`` (resolved dynamically at pack time by
-    ``scripts/run-electron-builder.cjs``) to dodge electron-builder 26.8.x's
-    missing-binary re-unpack bug. That dist tree is produced by the ``electron``
-    package's postinstall (``install.js``) during ``npm ci``. When that download
-    is blocked or throttled (GitHub's release host is unreachable in some
-    regions — #47266), the dist is missing. Pre-fetching it here — optionally via
-    a mirror — gives the build a dist to reuse; if it can't, the build falls back
-    to letting electron-builder fetch Electron itself, so this is best-effort.
-
-    No-op (returns True) when the dist binary is already present, so an unrelated
-    build failure doesn't trigger a needless ~200 MB re-download. Otherwise drops
-    any partial dist + version marker (electron's install.js short-circuits when
-    ``path.txt`` already matches) and runs the downloader once, optionally via a
-    mirror. Best-effort: never raises. Returns True iff the dist binary exists
-    afterward.
-    """
+    """Best-effort: run electron's install.js to populate dist/ (optional mirror)."""
     if _electron_dist_ok(project_root):
         return True
 
@@ -5233,6 +5206,15 @@ def _redownload_electron_dist(
     except OSError:
         return False
     return _electron_dist_ok(project_root)
+
+
+def _try_redownload_electron_dist(project_root: Path, env: dict) -> bool:
+    """Canonical download, then fallback mirror unless the user pinned one."""
+    if _redownload_electron_dist(project_root, env):
+        return True
+    if env.get("ELECTRON_MIRROR"):
+        return False
+    return _redownload_electron_dist(project_root, env, mirror=_ELECTRON_FALLBACK_MIRROR)
 
 
 def _stop_desktop_processes_locking_build(desktop_dir: Path) -> list[int]:
@@ -5457,21 +5439,11 @@ def cmd_gui(args: argparse.Namespace):
             nixos_env = _nixos_build_env()
             install_result = _run_npm_install_deterministic(npm, PROJECT_ROOT, capture_output=False, env=nixos_env)
             if install_result.returncode != 0:
-                # npm runs postinstall scripts LAST. When Electron's binary
-                # download is blocked/throttled (#47266/#47917/#48021), the
-                # package files are staged (package.json + install.js) but dist/
-                # is missing. In that specific shape, attempt a best-effort
-                # dist repair and continue to pack; otherwise, fail fast so
-                # unrelated install errors aren't mislabeled as Electron issues.
                 if not _electron_pkg_staged_missing_dist(PROJECT_ROOT):
                     print("✗ Desktop dependency install failed")
                     print(f"  Run manually:  cd {PROJECT_ROOT} && npm ci")
                     sys.exit(install_result.returncode or 1)
-                repaired = _redownload_electron_dist(PROJECT_ROOT, env)
-                if not repaired and not env.get("ELECTRON_MIRROR"):
-                    repaired = _redownload_electron_dist(
-                        PROJECT_ROOT, env, mirror=_ELECTRON_FALLBACK_MIRROR
-                    )
+                repaired = _try_redownload_electron_dist(PROJECT_ROOT, env)
                 if repaired:
                     print("  ⚠ Dependency install failed with a missing Electron dist; "
                           "repopulated it and continuing.")
@@ -5494,22 +5466,9 @@ def cmd_gui(args: argparse.Namespace):
                     print(f"  ⚠ Stopped running desktop app to free the build output (pid {', '.join(map(str, stopped))})")
             build_result = subprocess.run([npm, "run", build_script], cwd=desktop_dir, env=env, check=False)
             if build_result.returncode != 0 and not source_mode:
-                # A corrupt cached Electron zip makes `pack` fail with an ENOENT
-                # on the final `electron` -> `Hermes` rename: unpack-electron
-                # extracted a partial tree (missing the 193 MB binary) from the
-                # bad zip. We do NOT try to prove the zip is corrupt ourselves —
-                # stdlib zipfile silently tolerates the prepended/concatenated
-                # junk that is the most common corruption (a partial download
-                # resumed into the same file), so a `testzip()` gate would pass
-                # and never self-heal. Instead, on any packaged-build failure we
-                # purge the version's cached zip + the half-written unpacked dir
-                # and retry once: @electron/get re-downloads with its own SHASUM
-                # verification, which is the real source of truth. If the
-                # failure was something else, the clean re-download is harmless
-                # and the retry fails the same way.
-                # Only run the Electron cache repair path when Electron dist is
-                # actually missing/corrupt. This avoids retrying unrelated build
-                # failures (e.g., tsc/vite) under an Electron-specific narrative.
+                # Corrupt cached Electron zip → partial unpack → ENOENT on rename.
+                # stdlib zipfile won't catch the common concat-junk case, so purge
+                # and retry once; @electron/get SHASUM is the real gate.
                 purged: list[Path] = []
                 restored = False
                 if not _electron_dist_ok(PROJECT_ROOT):
@@ -5524,27 +5483,12 @@ def cmd_gui(args: argparse.Namespace):
                     _stop_desktop_processes_locking_build(desktop_dir)
                     build_result = subprocess.run([npm, "run", build_script], cwd=desktop_dir, env=env, check=False)
             if build_result.returncode != 0 and not source_mode and not env.get("ELECTRON_MIRROR"):
-                # Still failing and the user hasn't pinned a mirror: GitHub's
-                # Electron release host is likely blocked/throttled (the repeating
-                # "retrying" download log). Retry once via npmmirror.com — the
-                # de-facto Electron community mirror (Alibaba). @electron/get
-                # SHASUM-checks the download, but the SHASUMS come from the same
-                # mirror, so that guards against a corrupt/partial download, NOT
-                # a compromised mirror: reaching for it is an explicit trust
-                # trade-off we only make AFTER the canonical GitHub download has
-                # failed, and we never override a user-pinned ELECTRON_MIRROR.
                 print("  ⚠ Desktop build still failing; the Electron download from "
                       "GitHub looks blocked. Re-downloading via a public mirror "
                       "(npmmirror.com)... (set ELECTRON_MIRROR to use another mirror)")
                 mirror = _ELECTRON_FALLBACK_MIRROR
                 mirror_env = dict(env)
                 mirror_env["ELECTRON_MIRROR"] = mirror
-                # Pre-fetch the binary through the mirror via electron's own
-                # downloader so the retry has a dist to reuse. If that can't be
-                # populated, still retry the pack under ELECTRON_MIRROR: the
-                # build now resolves electronDist dynamically and, when the dist
-                # is absent, lets electron-builder fetch Electron itself through
-                # @electron/get — which honors ELECTRON_MIRROR (#47266).
                 if not _electron_dist_ok(PROJECT_ROOT):
                     _redownload_electron_dist(PROJECT_ROOT, env, mirror=mirror)
                 _stop_desktop_processes_locking_build(desktop_dir)

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -2335,25 +2335,20 @@ function Install-Desktop {
         }
         $ErrorActionPreference = $prevEAP
         if ($code -ne 0) {
-            # npm runs postinstall scripts LAST, after every package is staged on
-            # disk. The most common failure here is electron's install.js doing
-            # `process.exit(1)` on a blocked/throttled binary download (#47266,
-            # #47917, #48021): the whole tree is present and only electron's dist\
-            # is missing. If the electron package staged, repopulate its dist via
-            # electron's own downloader (canonical, then the public mirror) and
-            # carry on to the build; even if that can't fetch it, `npm run pack`
-            # resolves electronDist dynamically and lets electron-builder fetch
-            # Electron itself, so the build-stage mirror fallback gets a final
-            # shot. Bailing here is what made that fallback unreachable on a
-            # blocked network. Only hard-fail when electron never staged at all.
-            $electronPkg = Join-Path (Get-ElectronDir -InstallDir $InstallDir) 'package.json'
-            if (Test-Path -LiteralPath $electronPkg) {
-                Write-Warn "Desktop dependency install failed on the Electron binary download; self-healing..."
-                if (-not (Test-ElectronDist -InstallDir $InstallDir)) {
-                    if (-not (Restore-ElectronDist -InstallDir $InstallDir)) {
-                        if (-not $env:ELECTRON_MIRROR) {
-                            Restore-ElectronDist -InstallDir $InstallDir -Mirror $script:DesktopElectronFallbackMirror | Out-Null
-                        }
+            # npm runs postinstall scripts after staging package files. For the
+            # blocked Electron download case, package.json + install.js exist but
+            # dist is missing. Heal that specific shape and continue; otherwise
+            # fail fast so unrelated install failures aren't mislabeled.
+            $electronDir = Get-ElectronDir -InstallDir $InstallDir
+            $electronPkg = Join-Path $electronDir 'package.json'
+            $electronInstaller = Join-Path $electronDir 'install.js'
+            if ((Test-Path -LiteralPath $electronPkg) -and
+                (Test-Path -LiteralPath $electronInstaller) -and
+                (-not (Test-ElectronDist -InstallDir $InstallDir))) {
+                Write-Warn "Desktop dependency install failed with a missing Electron dist; attempting self-heal..."
+                if (-not (Restore-ElectronDist -InstallDir $InstallDir)) {
+                    if (-not $env:ELECTRON_MIRROR) {
+                        Restore-ElectronDist -InstallDir $InstallDir -Mirror $script:DesktopElectronFallbackMirror | Out-Null
                     }
                 }
             } else {
@@ -2412,19 +2407,16 @@ function Install-Desktop {
             # Purge the cached download + any stale unpacked output and retry
             # once; @electron/get re-downloads with its own SHASUM check. Without
             # this a corrupt download hard-fails the whole installer.
-            $purged = @(Clear-ElectronBuildCache -DesktopDir $desktopDir)
-            # The build reuses the already-unpacked electron dist when present
-            # (resolved dynamically by scripts\run-electron-builder.cjs, #38673),
-            # so purging the build cache + re-running pack can't by itself
-            # repopulate a missing/partial dist. When the dist is actually gone,
-            # re-run electron's own downloader so the retry has a binary to reuse.
-            # Gated on the dist check so an unrelated build failure (tsc/vite)
-            # doesn't trigger a pointless ~200MB refetch.
+            # Only run Electron cache repair when dist is actually missing/corrupt.
+            # This avoids retrying unrelated build failures (tsc/vite) under an
+            # Electron-specific narrative.
+            $purged = @()
             $restored = $false
             if (-not (Test-ElectronDist -InstallDir $InstallDir)) {
+                $purged = @(Clear-ElectronBuildCache -DesktopDir $desktopDir)
                 $restored = Restore-ElectronDist -InstallDir $InstallDir
             }
-            if ($purged.Count -gt 0 -or $restored) {
+            if ($restored) {
                 Write-Warn "Desktop build failed - refreshed the Electron download, retrying once:"
                 foreach ($p in $purged) { Write-Info "  - $p" }
                 & $npmExe run pack 2>&1 | ForEach-Object { "$_" } | Tee-Object -FilePath $buildLog

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -2161,6 +2161,12 @@ function Clear-ElectronBuildCache {
     return $removed
 }
 
+# Public Electron mirror used as a last-resort fallback when GitHub's release
+# host is blocked/throttled (#47266). npmmirror.com (Alibaba) is the de-facto
+# Electron community mirror; only reached AFTER the canonical download fails and
+# never when the user has pinned their own ELECTRON_MIRROR.
+$script:DesktopElectronFallbackMirror = "https://npmmirror.com/mirrors/electron/"
+
 # Return the Electron package directory the desktop workspace installs. npm may
 # nest workspace-only dev dependencies under apps\desktop\node_modules instead
 # of hoisting them to the repo root; which layout you get depends on the npm
@@ -2188,14 +2194,14 @@ function Test-ElectronDist {
 
 # (Re)populate the desktop Electron dist via electron's own downloader.
 #
-# Since #38673 the desktop build pins build.electronDist, so electron-builder
-# reads the Electron binary straight from there and never downloads it during
-# `npm run pack`. That dist tree is produced by the electron package's
-# postinstall (install.js) during `npm ci`. When that download is
-# blocked/throttled (GitHub's release host is unreachable in some regions -
-# #47266), dist is missing and re-running pack only re-throws "The specified
-# electronDist does not exist". The mirror fallback therefore has to drive THIS
-# downloader, not another pack.
+# Since #38673 the desktop build reuses the electron package's already-unpacked
+# dist (resolved dynamically by scripts\run-electron-builder.cjs) to dodge
+# electron-builder 26.8.x's missing-binary re-unpack bug. That dist tree is
+# produced by the electron package's postinstall (install.js) during `npm ci`.
+# When that download is blocked/throttled (GitHub's release host is unreachable
+# in some regions - #47266), dist is missing. Pre-fetching it here gives the
+# build a dist to reuse; if it can't, the build lets electron-builder fetch
+# Electron itself, so this is best-effort.
 #
 # No-op (returns $true) when the dist binary is already present. Otherwise drops a
 # partial dist + version marker (electron's install.js short-circuits when
@@ -2329,10 +2335,34 @@ function Install-Desktop {
         }
         $ErrorActionPreference = $prevEAP
         if ($code -ne 0) {
-            Show-NpmCertHint ($npmOut -join "`n") | Out-Null
-            throw "desktop workspace npm install failed (exit $code) -- see lines above for cause"
+            # npm runs postinstall scripts LAST, after every package is staged on
+            # disk. The most common failure here is electron's install.js doing
+            # `process.exit(1)` on a blocked/throttled binary download (#47266,
+            # #47917, #48021): the whole tree is present and only electron's dist\
+            # is missing. If the electron package staged, repopulate its dist via
+            # electron's own downloader (canonical, then the public mirror) and
+            # carry on to the build; even if that can't fetch it, `npm run pack`
+            # resolves electronDist dynamically and lets electron-builder fetch
+            # Electron itself, so the build-stage mirror fallback gets a final
+            # shot. Bailing here is what made that fallback unreachable on a
+            # blocked network. Only hard-fail when electron never staged at all.
+            $electronPkg = Join-Path (Get-ElectronDir -InstallDir $InstallDir) 'package.json'
+            if (Test-Path -LiteralPath $electronPkg) {
+                Write-Warn "Desktop dependency install failed on the Electron binary download; self-healing..."
+                if (-not (Test-ElectronDist -InstallDir $InstallDir)) {
+                    if (-not (Restore-ElectronDist -InstallDir $InstallDir)) {
+                        if (-not $env:ELECTRON_MIRROR) {
+                            Restore-ElectronDist -InstallDir $InstallDir -Mirror $script:DesktopElectronFallbackMirror | Out-Null
+                        }
+                    }
+                }
+            } else {
+                Show-NpmCertHint ($npmOut -join "`n") | Out-Null
+                throw "desktop workspace npm install failed (exit $code) -- see lines above for cause"
+            }
+        } else {
+            Write-Success "Desktop workspace dependencies installed"
         }
-        Write-Success "Desktop workspace dependencies installed"
     } catch {
         if ($prevEAP) { $ErrorActionPreference = $prevEAP }
         Pop-Location
@@ -2383,13 +2413,13 @@ function Install-Desktop {
             # once; @electron/get re-downloads with its own SHASUM check. Without
             # this a corrupt download hard-fails the whole installer.
             $purged = @(Clear-ElectronBuildCache -DesktopDir $desktopDir)
-            # electronDist is pinned to node_modules\electron\dist (#38673):
-            # electron-builder reads the Electron binary from there and `pack`
-            # never downloads it, so purging the cache + re-running pack can't by
-            # itself repopulate a missing/partial dist. When the dist is actually
-            # gone, re-run electron's own downloader so the retry has a binary to
-            # read. Gated on the dist check so an unrelated build failure
-            # (tsc/vite) doesn't trigger a pointless ~200MB refetch.
+            # The build reuses the already-unpacked electron dist when present
+            # (resolved dynamically by scripts\run-electron-builder.cjs, #38673),
+            # so purging the build cache + re-running pack can't by itself
+            # repopulate a missing/partial dist. When the dist is actually gone,
+            # re-run electron's own downloader so the retry has a binary to reuse.
+            # Gated on the dist check so an unrelated build failure (tsc/vite)
+            # doesn't trigger a pointless ~200MB refetch.
             $restored = $false
             if (-not (Test-ElectronDist -InstallDir $InstallDir)) {
                 $restored = Restore-ElectronDist -InstallDir $InstallDir
@@ -2410,22 +2440,25 @@ function Install-Desktop {
         # trade-off we only make AFTER the canonical GitHub download has failed,
         # and we never override a user-pinned ELECTRON_MIRROR.
         if ($code -ne 0 -and -not $env:ELECTRON_MIRROR) {
-            $mirror = "https://npmmirror.com/mirrors/electron/"
+            $mirror = $script:DesktopElectronFallbackMirror
             Write-Warn "Desktop build still failing - the Electron download from GitHub looks blocked."
             Write-Warn "Re-downloading Electron via a public mirror ($mirror), then rebuilding:"
             Write-Info "  (set ELECTRON_MIRROR yourself to use a different/trusted mirror)"
-            # electronDist is pinned (#38673), so `npm run pack` never downloads
-            # Electron - the mirror only helps if it drives electron's own
-            # downloader. Re-fetch the binary through the mirror first; otherwise
-            # the retry just re-reads the same missing dist and re-throws
-            # "The specified electronDist does not exist" (#47266).
-            $haveDist = Test-ElectronDist -InstallDir $InstallDir
-            if (-not $haveDist) { $haveDist = Restore-ElectronDist -InstallDir $InstallDir -Mirror $mirror }
-            if ($haveDist) {
+            # Pre-fetch the binary through the mirror via electron's own downloader
+            # so the retry has a dist to reuse. If that can't be populated, still
+            # retry the pack under ELECTRON_MIRROR: the build resolves electronDist
+            # dynamically and, when the dist is absent, lets electron-builder fetch
+            # Electron itself via @electron/get, which honors ELECTRON_MIRROR (#47266).
+            if (-not (Test-ElectronDist -InstallDir $InstallDir)) {
+                Restore-ElectronDist -InstallDir $InstallDir -Mirror $mirror | Out-Null
+            }
+            $prevMirror = $env:ELECTRON_MIRROR
+            $env:ELECTRON_MIRROR = $mirror
+            try {
                 & $npmExe run pack 2>&1 | ForEach-Object { "$_" } | Tee-Object -FilePath $buildLog
                 $code = $LASTEXITCODE
-            } else {
-                Write-Warn "Could not re-download Electron from the mirror (node_modules\electron\dist still missing)"
+            } finally {
+                $env:ELECTRON_MIRROR = $prevMirror
             }
         }
         $ErrorActionPreference = $prevEAP

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -2161,18 +2161,10 @@ function Clear-ElectronBuildCache {
     return $removed
 }
 
-# Public Electron mirror used as a last-resort fallback when GitHub's release
-# host is blocked/throttled (#47266). npmmirror.com (Alibaba) is the de-facto
-# Electron community mirror; only reached AFTER the canonical download fails and
-# never when the user has pinned their own ELECTRON_MIRROR.
+# Last-resort Electron mirror after GitHub download fails (#47266).
 $script:DesktopElectronFallbackMirror = "https://npmmirror.com/mirrors/electron/"
 
-# Return the Electron package directory the desktop workspace installs. npm may
-# nest workspace-only dev dependencies under apps\desktop\node_modules instead
-# of hoisting them to the repo root; which layout you get depends on the npm
-# version and what else is installed. apps\desktop\package.json points
-# electron-builder's electronDist there, so prefer the workspace-local package
-# and fall back to the root hoist.
+# Electron package dir — workspace-local nest first, then root hoist.
 function Get-ElectronDir {
     param([string]$InstallDir)
     $desktopLocal = Join-Path $InstallDir 'apps\desktop\node_modules\electron'
@@ -2180,11 +2172,7 @@ function Get-ElectronDir {
     return (Join-Path $InstallDir 'node_modules\electron')
 }
 
-# True when the desktop workspace electronDist holds a usable Electron binary.
-# electron-builder reads the binary from build.electronDist since #38673, so
-# this is the exact file whose absence makes a pack fail with "The specified
-# electronDist does not exist". A dist dir that exists but is missing
-# electron.exe (partial extraction / aborted postinstall) is NOT ok.
+# True when dist/ holds a usable Electron binary (#38673 / run-electron-builder.cjs).
 function Test-ElectronDist {
     param([string]$InstallDir)
     $electronDir = Get-ElectronDir -InstallDir $InstallDir
@@ -2192,22 +2180,7 @@ function Test-ElectronDist {
     return (Test-Path -LiteralPath $distExe)
 }
 
-# (Re)populate the desktop Electron dist via electron's own downloader.
-#
-# Since #38673 the desktop build reuses the electron package's already-unpacked
-# dist (resolved dynamically by scripts\run-electron-builder.cjs) to dodge
-# electron-builder 26.8.x's missing-binary re-unpack bug. That dist tree is
-# produced by the electron package's postinstall (install.js) during `npm ci`.
-# When that download is blocked/throttled (GitHub's release host is unreachable
-# in some regions - #47266), dist is missing. Pre-fetching it here gives the
-# build a dist to reuse; if it can't, the build lets electron-builder fetch
-# Electron itself, so this is best-effort.
-#
-# No-op (returns $true) when the dist binary is already present. Otherwise drops a
-# partial dist + version marker (electron's install.js short-circuits when
-# path.txt already matches) and runs the downloader once, optionally via a
-# mirror. Best-effort: never throws. Returns $true iff the dist binary exists
-# afterward.
+# Best-effort: run electron/install.js to populate dist/ (optional mirror).
 function Restore-ElectronDist {
     param([string]$InstallDir, [string]$Mirror)
     if (Test-ElectronDist -InstallDir $InstallDir) { return $true }
@@ -2238,6 +2211,23 @@ function Restore-ElectronDist {
         $env:ELECTRON_MIRROR = $prevMirror
     }
     return (Test-Path -LiteralPath $distExe)
+}
+
+function Test-ElectronPkgStagedMissingDist {
+    param([string]$InstallDir)
+    $electronDir = Get-ElectronDir -InstallDir $InstallDir
+    return (
+        (Test-Path -LiteralPath (Join-Path $electronDir 'package.json')) -and
+        (Test-Path -LiteralPath (Join-Path $electronDir 'install.js')) -and
+        (-not (Test-ElectronDist -InstallDir $InstallDir))
+    )
+}
+
+function Try-RestoreElectronDist {
+    param([string]$InstallDir)
+    if (Restore-ElectronDist -InstallDir $InstallDir) { return $true }
+    if ($env:ELECTRON_MIRROR) { return $false }
+    return Restore-ElectronDist -InstallDir $InstallDir -Mirror $script:DesktopElectronFallbackMirror
 }
 
 function Install-Desktop {
@@ -2335,22 +2325,9 @@ function Install-Desktop {
         }
         $ErrorActionPreference = $prevEAP
         if ($code -ne 0) {
-            # npm runs postinstall scripts after staging package files. For the
-            # blocked Electron download case, package.json + install.js exist but
-            # dist is missing. Heal that specific shape and continue; otherwise
-            # fail fast so unrelated install failures aren't mislabeled.
-            $electronDir = Get-ElectronDir -InstallDir $InstallDir
-            $electronPkg = Join-Path $electronDir 'package.json'
-            $electronInstaller = Join-Path $electronDir 'install.js'
-            if ((Test-Path -LiteralPath $electronPkg) -and
-                (Test-Path -LiteralPath $electronInstaller) -and
-                (-not (Test-ElectronDist -InstallDir $InstallDir))) {
+            if (Test-ElectronPkgStagedMissingDist -InstallDir $InstallDir) {
                 Write-Warn "Desktop dependency install failed with a missing Electron dist; attempting self-heal..."
-                if (-not (Restore-ElectronDist -InstallDir $InstallDir)) {
-                    if (-not $env:ELECTRON_MIRROR) {
-                        Restore-ElectronDist -InstallDir $InstallDir -Mirror $script:DesktopElectronFallbackMirror | Out-Null
-                    }
-                }
+                Try-RestoreElectronDist -InstallDir $InstallDir | Out-Null
             } else {
                 Show-NpmCertHint ($npmOut -join "`n") | Out-Null
                 throw "desktop workspace npm install failed (exit $code) -- see lines above for cause"
@@ -2400,16 +2377,6 @@ function Install-Desktop {
         & $npmExe run pack 2>&1 | ForEach-Object { "$_" } | Tee-Object -FilePath $buildLog
         $code = $LASTEXITCODE
         if ($code -ne 0) {
-            # A corrupt cached Electron zip makes `pack` fail with an opaque
-            # ENOENT on the final `electron` -> `Hermes` rename: app-builder's
-            # unpack-electron extracted a partial tree (missing the binary) from
-            # the bad zip, and re-running reuses the poisoned cache forever.
-            # Purge the cached download + any stale unpacked output and retry
-            # once; @electron/get re-downloads with its own SHASUM check. Without
-            # this a corrupt download hard-fails the whole installer.
-            # Only run Electron cache repair when dist is actually missing/corrupt.
-            # This avoids retrying unrelated build failures (tsc/vite) under an
-            # Electron-specific narrative.
             $purged = @()
             $restored = $false
             if (-not (Test-ElectronDist -InstallDir $InstallDir)) {
@@ -2423,24 +2390,11 @@ function Install-Desktop {
                 $code = $LASTEXITCODE
             }
         }
-        # Still failing and the user hasn't pinned their own mirror: GitHub's
-        # Electron release host is likely blocked/throttled (the repeating
-        # "retrying" log). Retry once via npmmirror.com — the de-facto Electron
-        # community mirror (Alibaba). @electron/get SHASUM-checks the download,
-        # but the SHASUMS come from the same mirror, so that guards against a
-        # corrupt/partial download, NOT a compromised mirror: an explicit trust
-        # trade-off we only make AFTER the canonical GitHub download has failed,
-        # and we never override a user-pinned ELECTRON_MIRROR.
         if ($code -ne 0 -and -not $env:ELECTRON_MIRROR) {
             $mirror = $script:DesktopElectronFallbackMirror
             Write-Warn "Desktop build still failing - the Electron download from GitHub looks blocked."
             Write-Warn "Re-downloading Electron via a public mirror ($mirror), then rebuilding:"
             Write-Info "  (set ELECTRON_MIRROR yourself to use a different/trusted mirror)"
-            # Pre-fetch the binary through the mirror via electron's own downloader
-            # so the retry has a dist to reuse. If that can't be populated, still
-            # retry the pack under ELECTRON_MIRROR: the build resolves electronDist
-            # dynamically and, when the dist is absent, lets electron-builder fetch
-            # Electron itself via @electron/get, which honors ELECTRON_MIRROR (#47266).
             if (-not (Test-ElectronDist -InstallDir $InstallDir)) {
                 Restore-ElectronDist -InstallDir $InstallDir -Mirror $mirror | Out-Null
             }

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -2517,24 +2517,19 @@ install_desktop() {
     #    `tsc -b` failing with no obvious cause. Fall back to `npm install`
     #    only if `npm ci` is unavailable or the lockfile is out of sync.
     log_info "Installing desktop workspace dependencies (includes Electron ~150MB, 1-3min)..."
+    local electron_dir
+    electron_dir="$(_electron_dir "$INSTALL_DIR")"
     if ( cd "$INSTALL_DIR" && npm ci ) || ( cd "$INSTALL_DIR" && npm install ); then
         log_success "Desktop workspace dependencies installed"
-    elif [ -f "$(_electron_dir "$INSTALL_DIR")/package.json" ]; then
-        # npm staged every package and then failed in a postinstall script —
-        # almost always electron's install.js doing `process.exit(1)` on a
-        # blocked/throttled binary download (#47266, #47917, #48021). The whole
-        # tree is present; only electron's dist/ is missing. Repopulate it via
-        # electron's own downloader (canonical, then the public mirror) and carry
-        # on to the build; even if that fails, `npm run pack` resolves
-        # electronDist dynamically and lets electron-builder fetch Electron
-        # itself, so the build-stage fallback below gets a final shot. Bailing
-        # here is what made that fallback unreachable on a blocked network.
-        log_warn "Desktop dependency install failed on the Electron binary download; self-healing..."
-        if ! _electron_dist_ok "$INSTALL_DIR"; then
-            _restore_electron_dist "$INSTALL_DIR" \
-                || ( [ -z "${ELECTRON_MIRROR:-}" ] && _restore_electron_dist "$INSTALL_DIR" "$DESKTOP_ELECTRON_FALLBACK_MIRROR" ) \
-                || true
-        fi
+    elif [ -f "$electron_dir/package.json" ] && [ -f "$electron_dir/install.js" ] && ! _electron_dist_ok "$INSTALL_DIR"; then
+        # npm runs postinstall scripts after staging package files. For the
+        # blocked Electron download case, package.json + install.js are present
+        # but dist/ is missing. Heal that specific shape and continue; otherwise
+        # fail fast so unrelated install errors are not mislabeled as Electron.
+        log_warn "Desktop dependency install failed with a missing Electron dist; attempting self-heal..."
+        _restore_electron_dist "$INSTALL_DIR" \
+            || ( [ -z "${ELECTRON_MIRROR:-}" ] && _restore_electron_dist "$INSTALL_DIR" "$DESKTOP_ELECTRON_FALLBACK_MIRROR" ) \
+            || true
     else
         log_error "Desktop workspace npm install failed"
         # Common cause: a previous 'sudo npm'/'sudo npx' left root-owned files in
@@ -2563,20 +2558,16 @@ install_desktop() {
         pack_ok=true
     else
         # (b) Corrupt cached Electron zip is the most common self-healable cause.
-        local purged
-        purged="$(clear_electron_build_cache "$desktop_dir")"
-        # The build reuses the already-unpacked electron dist when present
-        # (resolved dynamically by scripts/run-electron-builder.cjs, #38673), so
-        # purging the build cache + re-running pack can't by itself repopulate a
-        # missing/partial dist. When the dist is actually gone, re-run electron's
-        # own downloader so the retry has a binary to reuse. Gated on the dist
-        # check so an unrelated build failure (tsc/vite) doesn't trigger a
-        # pointless ~200MB refetch.
+        local purged=""
+        # Only run Electron cache repair when dist is actually missing/corrupt.
+        # This avoids retrying unrelated build failures (tsc/vite) under an
+        # Electron-specific narrative.
         local restored=false
         if ! _electron_dist_ok "$INSTALL_DIR"; then
+            purged="$(clear_electron_build_cache "$desktop_dir")"
             if _restore_electron_dist "$INSTALL_DIR"; then restored=true; fi
         fi
-        if [ -n "$purged" ] || [ "$restored" = true ]; then
+        if [ "$restored" = true ]; then
             log_warn "Desktop build failed; refreshed the Electron download and retrying once..."
             if _desktop_pack "$desktop_dir"; then
                 pack_ok=true

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -2441,14 +2441,14 @@ _electron_dist_ok() {
 
 # (Re)populate the desktop Electron dist via electron's own downloader.
 #
-# Since #38673 the desktop build pins build.electronDist, so electron-builder
-# reads the Electron binary straight from there and never downloads it during
-# `npm run pack`. That dist tree is produced by the electron package's
-# postinstall (install.js) during `npm ci`. When that download is
-# blocked/throttled (GitHub's release host is unreachable in some regions -
-# #47266), dist is missing and re-running pack only re-throws "The specified
-# electronDist does not exist". The mirror fallback therefore has to drive THIS
-# downloader, not another pack.
+# Since #38673 the desktop build reuses the electron package's already-unpacked
+# dist (resolved dynamically by scripts/run-electron-builder.cjs) to dodge
+# electron-builder 26.8.x's missing-binary re-unpack bug. That dist tree is
+# produced by the electron package's postinstall (install.js) during `npm ci`.
+# When that download is blocked/throttled (GitHub's release host is unreachable
+# in some regions - #47266), dist is missing. Pre-fetching it here gives the
+# build a dist to reuse; if it can't, the build lets electron-builder fetch
+# Electron itself, so this is best-effort.
 #
 # No-op (returns 0) when the dist binary is already present. Otherwise drops a
 # partial dist + version marker (electron's install.js short-circuits when
@@ -2517,7 +2517,25 @@ install_desktop() {
     #    `tsc -b` failing with no obvious cause. Fall back to `npm install`
     #    only if `npm ci` is unavailable or the lockfile is out of sync.
     log_info "Installing desktop workspace dependencies (includes Electron ~150MB, 1-3min)..."
-    ( cd "$INSTALL_DIR" && npm ci ) || ( cd "$INSTALL_DIR" && npm install ) || {
+    if ( cd "$INSTALL_DIR" && npm ci ) || ( cd "$INSTALL_DIR" && npm install ); then
+        log_success "Desktop workspace dependencies installed"
+    elif [ -f "$(_electron_dir "$INSTALL_DIR")/package.json" ]; then
+        # npm staged every package and then failed in a postinstall script —
+        # almost always electron's install.js doing `process.exit(1)` on a
+        # blocked/throttled binary download (#47266, #47917, #48021). The whole
+        # tree is present; only electron's dist/ is missing. Repopulate it via
+        # electron's own downloader (canonical, then the public mirror) and carry
+        # on to the build; even if that fails, `npm run pack` resolves
+        # electronDist dynamically and lets electron-builder fetch Electron
+        # itself, so the build-stage fallback below gets a final shot. Bailing
+        # here is what made that fallback unreachable on a blocked network.
+        log_warn "Desktop dependency install failed on the Electron binary download; self-healing..."
+        if ! _electron_dist_ok "$INSTALL_DIR"; then
+            _restore_electron_dist "$INSTALL_DIR" \
+                || ( [ -z "${ELECTRON_MIRROR:-}" ] && _restore_electron_dist "$INSTALL_DIR" "$DESKTOP_ELECTRON_FALLBACK_MIRROR" ) \
+                || true
+        fi
+    else
         log_error "Desktop workspace npm install failed"
         # Common cause: a previous 'sudo npm'/'sudo npx' left root-owned files in
         # ~/.npm, so this non-root install can't write the shared cache. npm hides
@@ -2530,8 +2548,7 @@ install_desktop() {
         log_info "Then re-run this installer, or build manually:"
         log_info "  cd \"$INSTALL_DIR\" && npm ci && cd apps/desktop && npm run pack"
         return 1
-    }
-    log_success "Desktop workspace dependencies installed"
+    fi
 
     # 2. Build, with up to three escalating attempts so a transient/blocked
     #    Electron download self-heals instead of failing the whole install:
@@ -2548,11 +2565,11 @@ install_desktop() {
         # (b) Corrupt cached Electron zip is the most common self-healable cause.
         local purged
         purged="$(clear_electron_build_cache "$desktop_dir")"
-        # electronDist is pinned to node_modules/electron/dist (#38673):
-        # electron-builder reads the binary from there and `pack` never downloads
-        # it, so purging the cache + re-running pack can't by itself repopulate a
+        # The build reuses the already-unpacked electron dist when present
+        # (resolved dynamically by scripts/run-electron-builder.cjs, #38673), so
+        # purging the build cache + re-running pack can't by itself repopulate a
         # missing/partial dist. When the dist is actually gone, re-run electron's
-        # own downloader so the retry has a binary to read. Gated on the dist
+        # own downloader so the retry has a binary to reuse. Gated on the dist
         # check so an unrelated build failure (tsc/vite) doesn't trigger a
         # pointless ~200MB refetch.
         local restored=false
@@ -2568,26 +2585,18 @@ install_desktop() {
     fi
 
     # (c) Still failing and the user hasn't pinned their own mirror: the GitHub
-    #     release host is likely blocked/throttled. Re-download the Electron
-    #     binary via a public mirror, then retry. The mirror MUST drive
-    #     electron's own downloader — `npm run pack` reads the pinned electronDist
-    #     and never downloads, so a mirror passed only to pack is a no-op (#47266).
+    #     release host is likely blocked/throttled. Pre-fetch the Electron binary
+    #     via a public mirror so the retry has a dist to reuse, then retry under
+    #     ELECTRON_MIRROR regardless: the build resolves electronDist dynamically
+    #     and, when the dist is absent, lets electron-builder fetch Electron
+    #     itself via @electron/get — which honors ELECTRON_MIRROR (#47266).
     if [ "$pack_ok" = false ] && [ -z "${ELECTRON_MIRROR:-}" ]; then
         log_warn "Desktop build still failing — the Electron download from GitHub looks blocked."
         log_warn "Re-downloading Electron via a public mirror ($DESKTOP_ELECTRON_FALLBACK_MIRROR), then rebuilding..."
         log_warn "  (set ELECTRON_MIRROR yourself to use a different/trusted mirror)"
-        local have_dist=false
-        if _electron_dist_ok "$INSTALL_DIR"; then
-            have_dist=true
-        elif _restore_electron_dist "$INSTALL_DIR" "$DESKTOP_ELECTRON_FALLBACK_MIRROR"; then
-            have_dist=true
-        fi
-        if [ "$have_dist" = true ]; then
-            if _desktop_pack "$desktop_dir" "$DESKTOP_ELECTRON_FALLBACK_MIRROR"; then
-                pack_ok=true
-            fi
-        else
-            log_warn "Could not re-download Electron from the mirror (node_modules/electron/dist still missing)"
+        _electron_dist_ok "$INSTALL_DIR" || _restore_electron_dist "$INSTALL_DIR" "$DESKTOP_ELECTRON_FALLBACK_MIRROR" || true
+        if _desktop_pack "$desktop_dir" "$DESKTOP_ELECTRON_FALLBACK_MIRROR"; then
+            pack_ok=true
         fi
     fi
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -2398,21 +2398,10 @@ _desktop_pack() {
     fi
 }
 
-# Public Electron mirror used as a last-resort fallback when GitHub's release
-# host is blocked/throttled (the repeating "retrying" symptom). npmmirror.com is
-# the de-facto Electron community mirror (Alibaba). @electron/get SHASUM-checks
-# the download, but the SHASUMS come from the same mirror — that guards against a
-# corrupt/partial download, NOT a compromised mirror. Reaching for it is an
-# explicit trust trade-off we only make AFTER the canonical GitHub download has
-# failed, and we never override a user-pinned ELECTRON_MIRROR.
+# Last-resort Electron mirror after GitHub download fails (#47266).
 DESKTOP_ELECTRON_FALLBACK_MIRROR="https://npmmirror.com/mirrors/electron/"
 
-# Return the Electron package directory the desktop workspace installs. npm may
-# nest workspace-only dev dependencies under apps/desktop/node_modules instead
-# of hoisting them to the repo root; which layout you get depends on the npm
-# version and what else is installed. apps/desktop/package.json points
-# electron-builder's electronDist there, so prefer the workspace-local package
-# and fall back to the root hoist. $1 = the workspace root holding node_modules.
+# Electron package dir — workspace-local nest first, then root hoist.
 _electron_dir() {
     local install_dir="$1"
     if [ -d "$install_dir/apps/desktop/node_modules/electron" ]; then
@@ -2422,12 +2411,7 @@ _electron_dir() {
     fi
 }
 
-# True (returns 0) when the desktop workspace electronDist holds a usable
-# Electron binary. electron-builder reads the binary from build.electronDist
-# since #38673, so this is the exact file whose absence makes a pack fail with
-# "The specified electronDist does not exist". A dist dir that exists but is
-# missing the binary (partial extraction / aborted postinstall) is NOT ok.
-# $1 = the workspace root holding node_modules.
+# True when dist/ holds a usable Electron binary (#38673 / run-electron-builder.cjs).
 _electron_dist_ok() {
     local install_dir="$1"
     local electron_dir
@@ -2439,22 +2423,7 @@ _electron_dist_ok() {
     fi
 }
 
-# (Re)populate the desktop Electron dist via electron's own downloader.
-#
-# Since #38673 the desktop build reuses the electron package's already-unpacked
-# dist (resolved dynamically by scripts/run-electron-builder.cjs) to dodge
-# electron-builder 26.8.x's missing-binary re-unpack bug. That dist tree is
-# produced by the electron package's postinstall (install.js) during `npm ci`.
-# When that download is blocked/throttled (GitHub's release host is unreachable
-# in some regions - #47266), dist is missing. Pre-fetching it here gives the
-# build a dist to reuse; if it can't, the build lets electron-builder fetch
-# Electron itself, so this is best-effort.
-#
-# No-op (returns 0) when the dist binary is already present. Otherwise drops a
-# partial dist + version marker (electron's install.js short-circuits when
-# path.txt already matches) and runs the downloader once. $1 = the workspace root
-# holding node_modules; optional $2 = an ELECTRON_MIRROR base URL. Best-effort:
-# returns 0 iff the dist binary exists afterward.
+# Best-effort: run electron/install.js to populate dist/ (optional mirror).
 _restore_electron_dist() {
     local install_dir="$1"
     local mirror="${2:-}"
@@ -2474,6 +2443,19 @@ _restore_electron_dist() {
         ( cd "$electron_dir" && node install.js ) || true
     fi
     _electron_dist_ok "$install_dir"
+}
+
+_electron_pkg_staged_missing_dist() {
+    local install_dir="$1"
+    local electron_dir
+    electron_dir="$(_electron_dir "$install_dir")"
+    [ -f "$electron_dir/package.json" ] && [ -f "$electron_dir/install.js" ] && ! _electron_dist_ok "$install_dir"
+}
+
+_restore_electron_dist_with_fallback() {
+    local install_dir="$1"
+    _restore_electron_dist "$install_dir" \
+        || { [ -z "${ELECTRON_MIRROR:-}" ] && _restore_electron_dist "$install_dir" "$DESKTOP_ELECTRON_FALLBACK_MIRROR"; }
 }
 
 # Build apps/desktop into a launchable native app. Mirrors install.ps1's
@@ -2517,19 +2499,11 @@ install_desktop() {
     #    `tsc -b` failing with no obvious cause. Fall back to `npm install`
     #    only if `npm ci` is unavailable or the lockfile is out of sync.
     log_info "Installing desktop workspace dependencies (includes Electron ~150MB, 1-3min)..."
-    local electron_dir
-    electron_dir="$(_electron_dir "$INSTALL_DIR")"
     if ( cd "$INSTALL_DIR" && npm ci ) || ( cd "$INSTALL_DIR" && npm install ); then
         log_success "Desktop workspace dependencies installed"
-    elif [ -f "$electron_dir/package.json" ] && [ -f "$electron_dir/install.js" ] && ! _electron_dist_ok "$INSTALL_DIR"; then
-        # npm runs postinstall scripts after staging package files. For the
-        # blocked Electron download case, package.json + install.js are present
-        # but dist/ is missing. Heal that specific shape and continue; otherwise
-        # fail fast so unrelated install errors are not mislabeled as Electron.
+    elif _electron_pkg_staged_missing_dist "$INSTALL_DIR"; then
         log_warn "Desktop dependency install failed with a missing Electron dist; attempting self-heal..."
-        _restore_electron_dist "$INSTALL_DIR" \
-            || ( [ -z "${ELECTRON_MIRROR:-}" ] && _restore_electron_dist "$INSTALL_DIR" "$DESKTOP_ELECTRON_FALLBACK_MIRROR" ) \
-            || true
+        _restore_electron_dist_with_fallback "$INSTALL_DIR" || true
     else
         log_error "Desktop workspace npm install failed"
         # Common cause: a previous 'sudo npm'/'sudo npx' left root-owned files in
@@ -2557,11 +2531,7 @@ install_desktop() {
     if _desktop_pack "$desktop_dir"; then
         pack_ok=true
     else
-        # (b) Corrupt cached Electron zip is the most common self-healable cause.
         local purged=""
-        # Only run Electron cache repair when dist is actually missing/corrupt.
-        # This avoids retrying unrelated build failures (tsc/vite) under an
-        # Electron-specific narrative.
         local restored=false
         if ! _electron_dist_ok "$INSTALL_DIR"; then
             purged="$(clear_electron_build_cache "$desktop_dir")"
@@ -2575,12 +2545,7 @@ install_desktop() {
         fi
     fi
 
-    # (c) Still failing and the user hasn't pinned their own mirror: the GitHub
-    #     release host is likely blocked/throttled. Pre-fetch the Electron binary
-    #     via a public mirror so the retry has a dist to reuse, then retry under
-    #     ELECTRON_MIRROR regardless: the build resolves electronDist dynamically
-    #     and, when the dist is absent, lets electron-builder fetch Electron
-    #     itself via @electron/get — which honors ELECTRON_MIRROR (#47266).
+    # (c) GitHub blocked → mirror fallback (#47266).
     if [ "$pack_ok" = false ] && [ -z "${ELECTRON_MIRROR:-}" ]; then
         log_warn "Desktop build still failing — the Electron download from GitHub looks blocked."
         log_warn "Re-downloading Electron via a public mirror ($DESKTOP_ELECTRON_FALLBACK_MIRROR), then rebuilding..."

--- a/tests/hermes_cli/test_gui_command.py
+++ b/tests/hermes_cli/test_gui_command.py
@@ -485,13 +485,15 @@ def test_gui_retries_pack_once_after_purging_build_cache(tmp_path, monkeypatch):
          patch("hermes_cli.main._desktop_linux_sandbox_fixup", return_value=True), \
          patch("hermes_cli.main._write_desktop_build_stamp"), \
          patch("hermes_cli.main._purge_electron_build_cache", return_value=[Path("/c/electron.zip")]) as mock_purge, \
+         patch("hermes_cli.main._electron_dist_ok", return_value=False), \
+         patch("hermes_cli.main._redownload_electron_dist", return_value=True), \
          patch("hermes_cli.main.subprocess.run", side_effect=[pack_fail, pack_ok, launch_ok]) as mock_run, \
          pytest.raises(SystemExit) as exc:
         cli_main.cmd_gui(_ns())
 
     assert exc.value.code == 0
     mock_purge.assert_called_once()
-    # pack(fail) → purge → pack(ok) → launch = 3 subprocess.run calls
+    # pack(fail) → repair succeeds → pack(ok) → launch = 3 subprocess.run calls
     assert mock_run.call_count == 3
     assert mock_run.call_args_list[0].args[0] == ["/usr/bin/npm", "run", "pack"]
     assert mock_run.call_args_list[1].args[0] == ["/usr/bin/npm", "run", "pack"]
@@ -578,6 +580,7 @@ def test_gui_install_failure_self_heals_electron_and_continues(tmp_path, monkeyp
     # electron package staged on disk (postinstall download was the casualty).
     (root / "apps" / "desktop" / "node_modules" / "electron").mkdir(parents=True)
     (root / "apps" / "desktop" / "node_modules" / "electron" / "package.json").write_text("{}", encoding="utf-8")
+    (root / "apps" / "desktop" / "node_modules" / "electron" / "install.js").write_text("", encoding="utf-8")
 
     install_fail = subprocess.CompletedProcess(["npm", "ci"], 1)
     pack_ok = subprocess.CompletedProcess(["npm", "run", "pack"], 0)
@@ -618,6 +621,31 @@ def test_gui_install_failure_hard_fails_when_electron_not_staged(tmp_path, monke
 
     assert exc.value.code == 1
     mock_run.assert_not_called()  # build never started
+    assert "Desktop dependency install failed" in capsys.readouterr().out
+
+
+def test_gui_install_failure_hard_fails_when_electron_dist_exists(tmp_path, monkeypatch, capsys):
+    """If npm install fails but Electron dist is already present, don't classify
+    it as the blocked-download shape; fail fast as a generic install error."""
+    root = _make_desktop_tree(tmp_path)
+    monkeypatch.setattr(cli_main, "PROJECT_ROOT", root)
+    _make_packaged_executable(root, monkeypatch, platform="linux")
+    electron_dir = root / "apps" / "desktop" / "node_modules" / "electron"
+    electron_dir.mkdir(parents=True)
+    (electron_dir / "package.json").write_text("{}", encoding="utf-8")
+    (electron_dir / "install.js").write_text("", encoding="utf-8")
+
+    install_fail = subprocess.CompletedProcess(["npm", "ci"], 1)
+
+    with patch("hermes_cli.main.shutil.which", return_value="/usr/bin/npm"), \
+         patch("hermes_cli.main._run_npm_install_deterministic", return_value=install_fail), \
+         patch("hermes_cli.main._electron_dist_ok", return_value=True), \
+         patch("hermes_cli.main.subprocess.run") as mock_run, \
+         pytest.raises(SystemExit) as exc:
+        cli_main.cmd_gui(_ns())
+
+    assert exc.value.code == 1
+    mock_run.assert_not_called()
     assert "Desktop dependency install failed" in capsys.readouterr().out
 
 

--- a/tests/hermes_cli/test_gui_command.py
+++ b/tests/hermes_cli/test_gui_command.py
@@ -535,10 +535,12 @@ def test_gui_redownloads_electron_via_mirror_then_repacks(tmp_path, monkeypatch,
     assert "Desktop GUI build failed" in capsys.readouterr().out
 
 
-def test_gui_skips_pack_when_electron_redownload_unrecoverable(tmp_path, monkeypatch, capsys):
-    """When the Electron binary can't be fetched at all (mirror also blocked),
-    skip the pointless final pack — it would just re-throw the same missing
-    electronDist — and fail with a clear message instead."""
+def test_gui_retries_pack_under_mirror_even_when_prefetch_blocked(tmp_path, monkeypatch, capsys):
+    """When electron's own downloader can't fetch the binary (even via the
+    mirror), still retry pack under ELECTRON_MIRROR: the build resolves
+    electronDist dynamically and lets electron-builder fetch Electron itself
+    via @electron/get, which honors the mirror. That retry is no longer
+    pointless (it was, back when electronDist was a static path)."""
     root = _make_desktop_tree(tmp_path)
     monkeypatch.setattr(cli_main, "PROJECT_ROOT", root)
     _make_packaged_executable(root, monkeypatch, platform="linux")
@@ -553,17 +555,70 @@ def test_gui_skips_pack_when_electron_redownload_unrecoverable(tmp_path, monkeyp
          patch("hermes_cli.main._purge_electron_build_cache", return_value=[]), \
          patch("hermes_cli.main._electron_dist_ok", return_value=False), \
          patch("hermes_cli.main._redownload_electron_dist", return_value=False), \
-         patch("hermes_cli.main.subprocess.run", side_effect=[pack_fail]) as mock_run, \
+         patch("hermes_cli.main.subprocess.run", side_effect=[pack_fail, pack_fail]) as mock_run, \
          pytest.raises(SystemExit) as exc:
         cli_main.cmd_gui(_ns())
 
     assert exc.value.code == 1
-    # Only the initial pack ran; both retries were skipped because no binary
-    # could be produced.
-    assert mock_run.call_count == 1
-    out = capsys.readouterr().out
-    assert "Could not re-download Electron from the mirror" in out
-    assert "Desktop GUI build failed" in out
+    # Initial pack + mirror-driven pack = 2; the mirror retry runs even though
+    # the pre-fetch failed, so electron-builder gets a shot at downloading.
+    assert mock_run.call_count == 2
+    assert "ELECTRON_MIRROR" not in (mock_run.call_args_list[0].kwargs.get("env") or {})
+    assert mock_run.call_args_list[1].kwargs["env"]["ELECTRON_MIRROR"]
+    assert "Desktop GUI build failed" in capsys.readouterr().out
+
+
+def test_gui_install_failure_self_heals_electron_and_continues(tmp_path, monkeypatch, capsys):
+    """npm ci failing on electron's blocked binary download must NOT abort the
+    install: with the electron package staged, repopulate its dist and continue
+    to the build instead of sys.exit-ing before pack ever runs (#47266/#48021)."""
+    root = _make_desktop_tree(tmp_path)
+    monkeypatch.setattr(cli_main, "PROJECT_ROOT", root)
+    packaged_exe = _make_packaged_executable(root, monkeypatch, platform="linux")
+    # electron package staged on disk (postinstall download was the casualty).
+    (root / "apps" / "desktop" / "node_modules" / "electron").mkdir(parents=True)
+    (root / "apps" / "desktop" / "node_modules" / "electron" / "package.json").write_text("{}", encoding="utf-8")
+
+    install_fail = subprocess.CompletedProcess(["npm", "ci"], 1)
+    pack_ok = subprocess.CompletedProcess(["npm", "run", "pack"], 0)
+    launch_ok = subprocess.CompletedProcess([str(packaged_exe)], 0)
+
+    with patch("hermes_cli.main.shutil.which", return_value="/usr/bin/npm"), \
+         patch("hermes_cli.main._run_npm_install_deterministic", return_value=install_fail), \
+         patch("hermes_cli.main._desktop_linux_sandbox_fixup", return_value=True), \
+         patch("hermes_cli.main._write_desktop_build_stamp"), \
+         patch("hermes_cli.main._electron_dist_ok", return_value=False), \
+         patch("hermes_cli.main._redownload_electron_dist", return_value=True) as mock_dl, \
+         patch("hermes_cli.main.subprocess.run", side_effect=[pack_ok, launch_ok]) as mock_run, \
+         pytest.raises(SystemExit) as exc:
+        cli_main.cmd_gui(_ns())
+
+    assert exc.value.code == 0
+    mock_dl.assert_called()  # tried to repopulate the dist
+    # pack + launch ran — the install failure did NOT abort the build.
+    assert mock_run.call_count == 2
+    assert "repopulated" in capsys.readouterr().out.lower()
+
+
+def test_gui_install_failure_hard_fails_when_electron_not_staged(tmp_path, monkeypatch, capsys):
+    """A dependency-install failure where electron never even staged is a genuine
+    error (not a blocked binary download) — hard-fail with guidance, don't try to
+    self-heal a tree that isn't there."""
+    root = _make_desktop_tree(tmp_path)
+    monkeypatch.setattr(cli_main, "PROJECT_ROOT", root)
+    _make_packaged_executable(root, monkeypatch, platform="linux")
+
+    install_fail = subprocess.CompletedProcess(["npm", "ci"], 1)
+
+    with patch("hermes_cli.main.shutil.which", return_value="/usr/bin/npm"), \
+         patch("hermes_cli.main._run_npm_install_deterministic", return_value=install_fail), \
+         patch("hermes_cli.main.subprocess.run") as mock_run, \
+         pytest.raises(SystemExit) as exc:
+        cli_main.cmd_gui(_ns())
+
+    assert exc.value.code == 1
+    mock_run.assert_not_called()  # build never started
+    assert "Desktop dependency install failed" in capsys.readouterr().out
 
 
 def test_gui_does_not_override_user_electron_mirror(tmp_path, monkeypatch, capsys):

--- a/tests/hermes_cli/test_gui_command.py
+++ b/tests/hermes_cli/test_gui_command.py
@@ -591,7 +591,7 @@ def test_gui_install_failure_self_heals_electron_and_continues(tmp_path, monkeyp
          patch("hermes_cli.main._desktop_linux_sandbox_fixup", return_value=True), \
          patch("hermes_cli.main._write_desktop_build_stamp"), \
          patch("hermes_cli.main._electron_dist_ok", return_value=False), \
-         patch("hermes_cli.main._redownload_electron_dist", return_value=True) as mock_dl, \
+         patch("hermes_cli.main._try_redownload_electron_dist", return_value=True) as mock_dl, \
          patch("hermes_cli.main.subprocess.run", side_effect=[pack_ok, launch_ok]) as mock_run, \
          pytest.raises(SystemExit) as exc:
         cli_main.cmd_gui(_ns())

--- a/tests/test_desktop_electron_pin.py
+++ b/tests/test_desktop_electron_pin.py
@@ -96,40 +96,57 @@ def test_lockfile_resolves_the_pinned_electron():
     )
 
 
-def test_electron_dist_matches_lockfile_install_location():
-    """build.electronDist must point at where the lockfile installs Electron.
+DESKTOP_DIR = REPO_ROOT / "apps" / "desktop"
+ELECTRON_BUILDER_WRAPPER = DESKTOP_DIR / "scripts" / "run-electron-builder.cjs"
 
-    electron-builder copies the unpacked Electron from ``build.electronDist``
-    (resolved relative to ``apps/desktop``). npm workspace hoisting is not
-    deterministic across machines/npm versions: it may nest Electron under
-    ``apps/desktop/node_modules/electron`` or hoist it to the repo root. If
-    electronDist points at one location while the lockfile installs at the
-    other, packaging fails with ``The specified electronDist does not exist`` —
-    the "Building desktop app" failure reported after the June lockfile
-    regeneration floated Electron and reshuffled the hoist. Lock the two
-    together so a hoist change (root <-> nested) can't silently break the path
-    again.
+
+def test_no_static_electron_dist_that_can_drift():
+    """build.electronDist must NOT be a hardcoded path in package.json.
+
+    electron-builder reads the unpacked Electron from ``build.electronDist``, but
+    npm workspace hoisting is not deterministic across machines/npm versions: it
+    may nest Electron under ``apps/desktop/node_modules/electron`` or hoist it to
+    the repo root. A static relative path matches only one layout, so a clean
+    install intermittently fails with ``The specified electronDist does not
+    exist`` (the June desktop-build outage: #47917, #48019, #48021, #48084).
+
+    The fix resolves electronDist at runtime (``scripts/run-electron-builder.cjs``
+    via ``require.resolve``), so there must be no static value to drift. If a
+    future change re-pins a hardcoded path here, this fails and points back at
+    the dynamic resolver.
     """
-    if not ROOT_LOCK.is_file():
-        pytest.skip("root package-lock.json not present")
-    electron_dist = _desktop_pkg().get("build", {}).get("electronDist")
-    assert electron_dist, "build.electronDist is missing"
+    assert "electronDist" not in _desktop_pkg().get("build", {}), (
+        "build.electronDist is hardcoded again. npm hoisting is non-deterministic, "
+        "so a static path silently breaks packaging when the layout changes. Let "
+        "scripts/run-electron-builder.cjs resolve it dynamically instead."
+    )
 
-    lock = json.loads(ROOT_LOCK.read_text(encoding="utf-8"))
-    electron_paths = [
-        path
-        for path in lock.get("packages", {})
-        if path.endswith("node_modules/electron")
-    ]
-    assert electron_paths, "no electron entry found in package-lock.json"
 
-    desktop_dir = REPO_ROOT / "apps" / "desktop"
-    # electronDist is resolved relative to the apps/desktop project dir.
-    configured = (desktop_dir / electron_dist).resolve()
-    # Where the lockfile actually places Electron's unpacked dist.
-    installed = {(REPO_ROOT / p / "dist").resolve() for p in electron_paths}
-    assert configured in installed, (
-        f"build.electronDist={electron_dist!r} resolves to {configured}, but the "
-        f"lockfile installs Electron at {sorted(str(p) for p in installed)}. "
-        "electron-builder will fail with 'electronDist does not exist'."
+def test_builder_script_routes_through_dynamic_resolver():
+    """`npm run builder` must invoke the dynamic-resolver wrapper, not bare
+    electron-builder — otherwise electronDist is never injected and the hoist
+    bug returns."""
+    builder = _desktop_pkg().get("scripts", {}).get("builder", "")
+    assert "run-electron-builder.cjs" in builder, (
+        f"the 'builder' script must run scripts/run-electron-builder.cjs, got "
+        f"{builder!r}"
+    )
+    assert ELECTRON_BUILDER_WRAPPER.is_file(), (
+        f"missing dynamic-resolver wrapper at {ELECTRON_BUILDER_WRAPPER}"
+    )
+
+
+def test_resolver_uses_node_module_resolution():
+    """The wrapper must locate Electron via Node module resolution so the path
+    follows npm's actual install layout (nested or hoisted) instead of a
+    hardcoded guess."""
+    src = ELECTRON_BUILDER_WRAPPER.read_text(encoding="utf-8")
+    assert 'require.resolve("electron/package.json")' in src, (
+        "run-electron-builder.cjs must resolve electron via "
+        "require.resolve('electron/package.json') to stay hoist-proof."
+    )
+    # And it must hand the resolved dist to electron-builder as an override.
+    assert "-c.electronDist=" in src, (
+        "run-electron-builder.cjs must pass the resolved dist to electron-builder "
+        "via -c.electronDist."
     )

--- a/tests/test_desktop_electron_pin.py
+++ b/tests/test_desktop_electron_pin.py
@@ -101,20 +101,7 @@ ELECTRON_BUILDER_WRAPPER = DESKTOP_DIR / "scripts" / "run-electron-builder.cjs"
 
 
 def test_no_static_electron_dist_that_can_drift():
-    """build.electronDist must NOT be a hardcoded path in package.json.
-
-    electron-builder reads the unpacked Electron from ``build.electronDist``, but
-    npm workspace hoisting is not deterministic across machines/npm versions: it
-    may nest Electron under ``apps/desktop/node_modules/electron`` or hoist it to
-    the repo root. A static relative path matches only one layout, so a clean
-    install intermittently fails with ``The specified electronDist does not
-    exist`` (the June desktop-build outage: #47917, #48019, #48021, #48084).
-
-    The fix resolves electronDist at runtime (``scripts/run-electron-builder.cjs``
-    via ``require.resolve``), so there must be no static value to drift. If a
-    future change re-pins a hardcoded path here, this fails and points back at
-    the dynamic resolver.
-    """
+    """build.electronDist must not be a static path — hoisting is non-deterministic."""
     assert "electronDist" not in _desktop_pkg().get("build", {}), (
         "build.electronDist is hardcoded again. npm hoisting is non-deterministic, "
         "so a static path silently breaks packaging when the layout changes. Let "
@@ -123,9 +110,7 @@ def test_no_static_electron_dist_that_can_drift():
 
 
 def test_builder_script_routes_through_dynamic_resolver():
-    """`npm run builder` must invoke the dynamic-resolver wrapper, not bare
-    electron-builder — otherwise electronDist is never injected and the hoist
-    bug returns."""
+    """npm run builder must invoke run-electron-builder.cjs, not bare electron-builder."""
     builder = _desktop_pkg().get("scripts", {}).get("builder", "")
     assert "run-electron-builder.cjs" in builder, (
         f"the 'builder' script must run scripts/run-electron-builder.cjs, got "
@@ -137,9 +122,7 @@ def test_builder_script_routes_through_dynamic_resolver():
 
 
 def test_resolver_uses_node_module_resolution():
-    """The wrapper must locate Electron via Node module resolution so the path
-    follows npm's actual install layout (nested or hoisted) instead of a
-    hardcoded guess."""
+    """Wrapper must resolve electron via require.resolve and pass -c.electronDist."""
     src = ELECTRON_BUILDER_WRAPPER.read_text(encoding="utf-8")
     assert 'require.resolve("electron/package.json")' in src, (
         "run-electron-builder.cjs must resolve electron via "


### PR DESCRIPTION
## Summary

A consolidated fix for the June desktop-build outage that removes the whole failure class instead of chasing each symptom. **Supersedes the static-path approach in #48081 (merged) and the install-step self-heal in #48082 (open), and closes out the community cluster #48003 / #48012 / #48033.**

Three distinct faults converged; this closes all three:

| # | Failure mode | Status |
|---|---|---|
| 1 | `The specified electronDist does not exist` (path mismatch) | **fixed permanently** (dynamic resolution) |
| 2 | `ERR_DLOPEN_FAILED … extract-zip-win32-x64-msvc` (native binding) | already fixed by the exact `40.10.2` pin on main |
| 3 | `npm ci` aborts on a blocked Electron download | **fixed** (install-step self-heal) |

## Root cause (the part #48081 left open — "Gap B")

`build.electronDist` was a **static relative path** in `apps/desktop/package.json`, but npm workspace hoisting is **not deterministic** — depending on the npm version and what else is installed, npm nests the workspace-only `electron` devDep under `apps/desktop/node_modules/electron` **or** hoists it to the repo root. A static path matches only one layout, so a clean install intermittently fails with `The specified electronDist does not exist`.

#48081 re-pointed the path at the nested layout (correct *today*), but **electron-builder reads `electronDist` statically** — so a future hoist change silently breaks it again, caught only by a CI invariant, never self-corrected. #48082 fixes the blocked-download case but doesn't change *when* the path resolves.

## Research — why this is the durable fix, and how others solve it

I traced the original intent and surveyed how real electron + npm-workspace monorepos handle this before settling on the approach:

- **Why `electronDist` exists here at all (#38673 / commit `f3b32e9f5`):** it was added because **electron-builder 26.8.x can stage an `Electron.app` missing its `Contents/MacOS/Electron` binary** when it re-unpacks Electron from its own cache, failing the `electron → Hermes` rename with `ENOENT`. Pointing `electronDist` at the already-unpacked dist makes electron-builder **reuse** it and dodge that bug. So removing `electronDist` outright would reintroduce the macOS failure — the fix has to *keep dist-reuse* while making the path correct. (We're on `electron-builder@^26.8.1`, the affected line.)
- **electron-builder's own monorepo guidance ([electron-userland/electron-builder#7103](https://github.com/electron-userland/electron-builder/issues/7103)):** for npm/yarn workspaces, (1) **pin `electron` to an exact version** (no `^`/`~`) — done, `40.10.2`; and (2) don't hardcode the path — let electron-builder resolve Electron via node module resolution. v26 explicitly added workspace support that checks both the project dir and the app dir ([#9219](https://github.com/electron-userland/electron-builder/pull/9219)).
- **`electronDist` accepts a path string OR a resolver function in v26** ([electron.build/configuration](https://www.electron.build/configuration)), and **`-c.electronDist=<path>` is a documented CLI override** that *merges* onto the package.json `build` config ([electron.build/cli](https://www.electron.build/cli); the Arch packaging guide uses exactly `electron-builder ... -c.electronDist=$electronDist -c.electronVersion=$electronVer`).

Conclusion: resolve the path the way Node's runtime does and hand it to electron-builder as a merge override — hoist-proof, keeps dist-reuse, no config-file migration.

## Fix

**1. Dynamic, hoist-proof `electronDist` (`scripts/run-electron-builder.cjs`)**

`require.resolve("electron/package.json")` walks `node_modules` from the desktop project upward and finds Electron wherever npm actually put it. The path can never drift out of sync with the install layout again, on any OS / npm version.

- **dist present** → pass `-c.electronDist=<abs>/dist` so electron-builder reuses the unpacked runtime (keeps the #38673 fast path that dodges the 26.8.x missing-binary re-unpack bug).
- **dist absent** → omit `electronDist`; electron-builder fetches Electron itself via `@electron/get`, honoring `electronVersion` + `ELECTRON_MIRROR`.

`package.json`: the `builder` script runs the wrapper and the static `build.electronDist` is removed (the resolver owns it).

**2. Install-step self-heal (`main.py` / `install.sh` / `install.ps1`)**

electron's `install.js` does `process.exit(1)` on a blocked/throttled binary download, failing the whole `npm ci` *before* `pack` — which made the pack-time mirror self-heal dead code on a blocked network (#47266/#47917/#48021). npm runs postinstall scripts **last**, so when the download is the casualty the electron package is staged and only its `dist/` is missing. On that failure we repopulate the dist (canonical, then `npmmirror.com`) and **continue to the build** instead of aborting; we hard-fail only when electron never staged at all (a genuine dependency error). The pack-time fallback now also retries under `ELECTRON_MIRROR` even when the pre-fetch is blocked, because the wrapper lets electron-builder download Electron itself via the mirror.

## Validation

- `tests/test_desktop_electron_pin.py` + `tests/hermes_cli/test_gui_command.py`: **46 passed** (new contracts: no static electronDist to drift, builder routes through the resolver, resolver uses `require.resolve` + injects `-c.electronDist`; install-failure self-heals and continues; genuine install failure still hard-fails; pack retries under the mirror when pre-fetch is blocked).
- Wrapper functionally verified against fake `electron` / `electron-builder` packages: injects `-c.electronDist=<abs>` when the dist exists, omits it when absent.
- `install.sh` desktop tests (symlink-stomp, node-prefix, browser, unmerged-index, no-initial-commit): **17 passed**. `node --check`, `bash -n`, `py_compile` clean.
- Not yet run: a full local `npm ci && npm run pack` on each OS (heavy ~200MB download). The change to electron-builder's resolved path is behaviorally equivalent to #48081 in the common (nested) case — only the path *source* changes (static → `require.resolve`).

## Credits

Salvages/supersedes the overlapping community work in #48003 (@sitkarev), #48012 (@omegazheng), #48033 (@james47kjv), and #48082 (@AIalliAI) — authorship preserved via co-author trailers. Closes #48084, #48019, #48021; relates to #47917, #46785, #47266.