### PR TITLE
fix(honcho): disable AI self-observation by default

### DIFF
--- a/plugins/memory/honcho/__init__.py
+++ b/plugins/memory/honcho/__init__.py
@@ -1164,7 +1164,7 @@ class HonchoMemoryProvider(MemoryProvider):
                 observe_me = bool(getattr(cfg, "user_observe_me", True))
                 observe_others = bool(getattr(cfg, "user_observe_others", True))
             else:
-                observe_me = bool(getattr(cfg, "ai_observe_me", True))
+                observe_me = bool(getattr(cfg, "ai_observe_me", False))
                 observe_others = bool(getattr(cfg, "ai_observe_others", True))
             if not (observe_me or observe_others):
                 reasons.append(

--- a/plugins/memory/honcho/client.py
+++ b/plugins/memory/honcho/client.py
@@ -248,7 +248,7 @@ def _normalize_observation_mode(val: str) -> str:
 _OBSERVATION_PRESETS = {
     "directional": {
         "user_observe_me": True, "user_observe_others": True,
-        "ai_observe_me": True, "ai_observe_others": True,
+        "ai_observe_me": False, "ai_observe_others": True,
     },
     "unified": {
         "user_observe_me": True, "user_observe_others": False,
@@ -366,7 +366,7 @@ class HonchoClientConfig:
     # Resolved from "observation" object in config, falling back to observation_mode preset.
     user_observe_me: bool = True
     user_observe_others: bool = True
-    ai_observe_me: bool = True
+    ai_observe_me: bool = False
     ai_observe_others: bool = True
     # Session resolution
     session_strategy: str = "per-directory"
@@ -598,7 +598,7 @@ class HonchoClientConfig:
             # observationMode keep the old "unified" default so users
             # aren't silently switched to full bidirectional observation.
             # New installations (no host block, no credentials) get
-            # "directional" (all observations on) as the new default.
+            # "directional" (user self+other, AI other-only) as the new default.
             observation_mode=_normalize_observation_mode(
                 host_block.get("observationMode")
                 or raw.get("observationMode")

--- a/plugins/memory/honcho/session.py
+++ b/plugins/memory/honcho/session.py
@@ -131,7 +131,7 @@ class HonchoSessionManager:
         # Per-peer observation booleans (granular, from config)
         self._user_observe_me: bool = config.user_observe_me if config else True
         self._user_observe_others: bool = config.user_observe_others if config else True
-        self._ai_observe_me: bool = config.ai_observe_me if config else True
+        self._ai_observe_me: bool = config.ai_observe_me if config else False
         self._ai_observe_others: bool = config.ai_observe_others if config else True
         self._message_max_chars: int = (
             config.message_max_chars if config else 25000

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -139,6 +139,8 @@ AUTHOR_MAP = {
     "prostoandrei9@gmail.com": "vladkvlchk",
     "116314616+ThyFriendlyFox@users.noreply.github.com": "ThyFriendlyFox",
     "liliangjya@gmail.com": "truenorth-lj",
+    "lebedyn.sergij@gmail.com": "lebedyncrs",
+    "7259302+lebedyncrs@users.noreply.github.com": "lebedyncrs",
     "16943149+nepenth@users.noreply.github.com": "nepenth",
     "ben.bartholomew@vectorize.io": "benfrank241",
     "74339271+SaguaroDev@users.noreply.github.com": "SaguaroDev",

--- a/tests/honcho_plugin/test_client.py
+++ b/tests/honcho_plugin/test_client.py
@@ -563,6 +563,21 @@ class TestObservationModeMigration:
         cfg_file.write_text(json.dumps({}))
         cfg = HonchoClientConfig.from_global_config(config_path=cfg_file)
         assert cfg.observation_mode == "directional"
+        assert cfg.ai_observe_me is False
+        assert cfg.ai_observe_others is True
+
+    def test_directional_preset_disables_ai_self_observation(self, tmp_path):
+        """Directional mode: AI observes user but not its own messages."""
+        cfg_file = tmp_path / "config.json"
+        cfg_file.write_text(json.dumps({
+            "apiKey": "k",
+            "hosts": {"hermes": {"enabled": True, "observationMode": "directional"}},
+        }))
+        cfg = HonchoClientConfig.from_global_config(config_path=cfg_file)
+        assert cfg.ai_observe_me is False
+        assert cfg.ai_observe_others is True
+        assert cfg.user_observe_me is True
+        assert cfg.user_observe_others is True
 
     def test_explicit_directional_respected(self, tmp_path):
         """Existing config with explicit observationMode → uses what's set."""

--- a/tests/honcho_plugin/test_empty_profile_hint.py
+++ b/tests/honcho_plugin/test_empty_profile_hint.py
@@ -20,7 +20,7 @@ def _make_provider(**cfg_overrides) -> HonchoMemoryProvider:
     # Defaults match HonchoClientConfig defaults
     cfg.user_observe_me = cfg_overrides.get("user_observe_me", True)
     cfg.user_observe_others = cfg_overrides.get("user_observe_others", True)
-    cfg.ai_observe_me = cfg_overrides.get("ai_observe_me", True)
+    cfg.ai_observe_me = cfg_overrides.get("ai_observe_me", False)
     cfg.ai_observe_others = cfg_overrides.get("ai_observe_others", True)
     cfg.message_max_chars = 25000
     provider._config = cfg

--- a/tests/honcho_plugin/test_session.py
+++ b/tests/honcho_plugin/test_session.py
@@ -100,6 +100,18 @@ class TestHonchoSession:
 
 
 # ---------------------------------------------------------------------------
+# HonchoSessionManager observation defaults
+# ---------------------------------------------------------------------------
+
+
+class TestObservationDefaults:
+    def test_ai_self_observation_off_without_config(self):
+        mgr = HonchoSessionManager()
+        assert mgr._ai_observe_me is False
+        assert mgr._ai_observe_others is True
+
+
+# ---------------------------------------------------------------------------
 # HonchoSessionManager._sanitize_id
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

- Default `ai_observe_me` to `false` across the Honcho config chain (`HonchoClientConfig`, directional observation preset, and `HonchoSessionManager` fallback).
- Prevents user facts (e.g. tennis, haircut, calendar) from being absorbed into the AI peer's self-representation when the model echoes them in its own replies.
- Directional mode still enables `ai_observe_others: true`, so the AI peer continues to model the user from user messages.

## Root cause

Langfuse traces showed user facts appearing under "AI Self-Representation" because `_ai_observe_me` defaulted to `true`. When the AI sends messages containing user info (responses to queries), Honcho self-observation absorbed that content into the AI's persona.

## Test plan

- [x] `scripts/run_tests.sh tests/honcho_plugin/test_client.py tests/honcho_plugin/test_session.py tests/honcho_plugin/test_empty_profile_hint.py` — 207 passed
- [x] `TestObservationModeMigration::test_directional_preset_disables_ai_self_observation`
- [x] `TestObservationDefaults::test_ai_self_observation_off_without_config`

Users who want AI self-observation can opt in via `honcho.json`:

```json
"observation": {
  "ai": { "observeMe": true, "observeOthers": true }
}
```

Made with [Cursor](https://cursor.com)