### PR TITLE
fix(honcho): disable AI self-observation by default

### DIFF
--- a/plugins/memory/honcho/README.md
+++ b/plugins/memory/honcho/README.md
@@ -287,11 +287,11 @@ Maps 1:1 to Honcho's per-peer `SessionPeerConfig`. When present, overrides `obse
 |-------|---------|-------------|
 | `user.observeMe` | `true` | User peer self-observation (Honcho builds user representation) |
 | `user.observeOthers` | `true` | User peer observes AI messages |
-| `ai.observeMe` | `true` | AI peer self-observation (Honcho builds AI representation) |
+| `ai.observeMe` | `false` | AI peer self-observation (Honcho builds AI representation). Off by default — when on, user facts echoed in AI replies can leak into AI self-representation |
 | `ai.observeOthers` | `true` | AI peer observes user messages (enables cross-peer dialectic) |
 
 Presets:
-- `"directional"` (default): all four `true`
+- `"directional"` (default): user both on; AI `observeMe=false`, `observeOthers=true`
 - `"unified"`: user `observeMe=true`, AI `observeOthers=true`, rest `false`
 
 ### Hardcoded Limits

--- a/plugins/memory/honcho/__init__.py
+++ b/plugins/memory/honcho/__init__.py
@@ -1164,7 +1164,7 @@ class HonchoMemoryProvider(MemoryProvider):
                 observe_me = bool(getattr(cfg, "user_observe_me", True))
                 observe_others = bool(getattr(cfg, "user_observe_others", True))
             else:
-                observe_me = bool(getattr(cfg, "ai_observe_me", True))
+                observe_me = bool(getattr(cfg, "ai_observe_me", False))
                 observe_others = bool(getattr(cfg, "ai_observe_others", True))
             if not (observe_me or observe_others):
                 reasons.append(

--- a/plugins/memory/honcho/client.py
+++ b/plugins/memory/honcho/client.py
@@ -248,7 +248,7 @@ def _normalize_observation_mode(val: str) -> str:
 _OBSERVATION_PRESETS = {
     "directional": {
         "user_observe_me": True, "user_observe_others": True,
-        "ai_observe_me": True, "ai_observe_others": True,
+        "ai_observe_me": False, "ai_observe_others": True,
     },
     "unified": {
         "user_observe_me": True, "user_observe_others": False,
@@ -366,7 +366,7 @@ class HonchoClientConfig:
     # Resolved from "observation" object in config, falling back to observation_mode preset.
     user_observe_me: bool = True
     user_observe_others: bool = True
-    ai_observe_me: bool = True
+    ai_observe_me: bool = False
     ai_observe_others: bool = True
     # Session resolution
     session_strategy: str = "per-directory"
@@ -598,7 +598,7 @@ class HonchoClientConfig:
             # observationMode keep the old "unified" default so users
             # aren't silently switched to full bidirectional observation.
             # New installations (no host block, no credentials) get
-            # "directional" (all observations on) as the new default.
+            # "directional" (user self+other, AI other-only) as the new default.
             observation_mode=_normalize_observation_mode(
                 host_block.get("observationMode")
                 or raw.get("observationMode")

--- a/plugins/memory/honcho/session.py
+++ b/plugins/memory/honcho/session.py
@@ -131,7 +131,7 @@ class HonchoSessionManager:
         # Per-peer observation booleans (granular, from config)
         self._user_observe_me: bool = config.user_observe_me if config else True
         self._user_observe_others: bool = config.user_observe_others if config else True
-        self._ai_observe_me: bool = config.ai_observe_me if config else True
+        self._ai_observe_me: bool = config.ai_observe_me if config else False
         self._ai_observe_others: bool = config.ai_observe_others if config else True
         self._message_max_chars: int = (
             config.message_max_chars if config else 25000

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -139,6 +139,8 @@ AUTHOR_MAP = {
     "prostoandrei9@gmail.com": "vladkvlchk",
     "116314616+ThyFriendlyFox@users.noreply.github.com": "ThyFriendlyFox",
     "liliangjya@gmail.com": "truenorth-lj",
+    "lebedyn.sergij@gmail.com": "lebedyncrs",
+    "7259302+lebedyncrs@users.noreply.github.com": "lebedyncrs",
     "16943149+nepenth@users.noreply.github.com": "nepenth",
     "ben.bartholomew@vectorize.io": "benfrank241",
     "74339271+SaguaroDev@users.noreply.github.com": "SaguaroDev",

--- a/tests/honcho_plugin/test_client.py
+++ b/tests/honcho_plugin/test_client.py
@@ -563,6 +563,21 @@ class TestObservationModeMigration:
         cfg_file.write_text(json.dumps({}))
         cfg = HonchoClientConfig.from_global_config(config_path=cfg_file)
         assert cfg.observation_mode == "directional"
+        assert cfg.ai_observe_me is False
+        assert cfg.ai_observe_others is True
+
+    def test_directional_preset_disables_ai_self_observation(self, tmp_path):
+        """Directional mode: AI observes user but not its own messages."""
+        cfg_file = tmp_path / "config.json"
+        cfg_file.write_text(json.dumps({
+            "apiKey": "k",
+            "hosts": {"hermes": {"enabled": True, "observationMode": "directional"}},
+        }))
+        cfg = HonchoClientConfig.from_global_config(config_path=cfg_file)
+        assert cfg.ai_observe_me is False
+        assert cfg.ai_observe_others is True
+        assert cfg.user_observe_me is True
+        assert cfg.user_observe_others is True
 
     def test_explicit_directional_respected(self, tmp_path):
         """Existing config with explicit observationMode → uses what's set."""

--- a/tests/honcho_plugin/test_empty_profile_hint.py
+++ b/tests/honcho_plugin/test_empty_profile_hint.py
@@ -20,7 +20,7 @@ def _make_provider(**cfg_overrides) -> HonchoMemoryProvider:
     # Defaults match HonchoClientConfig defaults
     cfg.user_observe_me = cfg_overrides.get("user_observe_me", True)
     cfg.user_observe_others = cfg_overrides.get("user_observe_others", True)
-    cfg.ai_observe_me = cfg_overrides.get("ai_observe_me", True)
+    cfg.ai_observe_me = cfg_overrides.get("ai_observe_me", False)
     cfg.ai_observe_others = cfg_overrides.get("ai_observe_others", True)
     cfg.message_max_chars = 25000
     provider._config = cfg

--- a/tests/honcho_plugin/test_session.py
+++ b/tests/honcho_plugin/test_session.py
@@ -100,6 +100,18 @@ class TestHonchoSession:
 
 
 # ---------------------------------------------------------------------------
+# HonchoSessionManager observation defaults
+# ---------------------------------------------------------------------------
+
+
+class TestObservationDefaults:
+    def test_ai_self_observation_off_without_config(self):
+        mgr = HonchoSessionManager()
+        assert mgr._ai_observe_me is False
+        assert mgr._ai_observe_others is True
+
+
+# ---------------------------------------------------------------------------
 # HonchoSessionManager._sanitize_id
 # ---------------------------------------------------------------------------
 

--- a/website/docs/user-guide/features/honcho.md
+++ b/website/docs/user-guide/features/honcho.md
@@ -194,7 +194,7 @@ Two peers × two toggles = four flags. `observationMode` is a shorthand preset:
 
 | Preset | User flags | AI flags | Semantics |
 |--------|-----------|----------|-----------|
-| `"directional"` (default) | me: on, others: on | me: on, others: on | Full mutual observation. Enables cross-peer dialectic — "what does the AI know about the user, based on what the user said and the AI replied." |
+| `"directional"` (default) | me: on, others: on | me: off, others: on | AI models the user from user messages; AI self-observation off so echoed user facts (e.g. *"you play tennis Tuesdays"*) don't land in AI self-representation. Cross-peer dialectic still works via `observeOthers`. |
 | `"unified"` | me: on, others: off | me: off, others: on | Shared-pool semantics — the AI observes the user's messages only, the user peer only self-models. Single-observer pool. |
 
 Override the preset with an explicit `observation` block for per-peer control:
@@ -210,9 +210,9 @@ Common patterns:
 
 | Intent | Config |
 |--------|--------|
-| Full observation (most users) | `"observationMode": "directional"` |
+| Default (most users) — AI models user, not its own echoes | `"observationMode": "directional"` |
+| Full mutual observation (all four on) | `"observation": { "user": {"observeMe": true, "observeOthers": true}, "ai": {"observeMe": true, "observeOthers": true} }` |
 | AI shouldn't re-model the user from its own replies | `"ai": {"observeMe": true, "observeOthers": false}` |
-| Strong persona the AI peer shouldn't update from self-observation | `"ai": {"observeMe": false, "observeOthers": true}` |
 
 Server-side toggles set via the [Honcho dashboard](https://app.honcho.dev) win over local defaults — Hermes syncs them back at session init.
 

--- a/website/docs/user-guide/features/memory-providers.md
+++ b/website/docs/user-guide/features/memory-providers.md
@@ -154,7 +154,7 @@ The mapping:
 | **Workspace** | Shared environment. All Hermes profiles under one workspace see the same user identity. |
 | **User peer** (`peerName`) | The human. Shared across profiles in the workspace. |
 | **AI peer** (`aiPeer`) | One per Hermes profile. Host key `hermes` → default; `hermes.<profile>` for others. |
-| **Observation** | Per-peer toggles controlling what Honcho models from whose messages. `directional` (default, all four on) or `unified` (single-observer pool). |
+| **Observation** | Per-peer toggles controlling what Honcho models from whose messages. `directional` (default: user both on, AI observes others only) or `unified` (single-observer pool). |
 
 ### New profile, fresh Honcho peer
 
@@ -195,7 +195,7 @@ Each host block can override the observation config independently. Example: a co
 
 Presets via `observationMode`:
 
-- **`"directional"`** (default) — all four flags on. Full mutual observation; enables cross-peer dialectic.
+- **`"directional"`** (default) — user both on; AI `observeMe: false`, `observeOthers: true`. AI models the user from user messages without self-observation (avoids user facts echoed in AI replies landing in AI self-representation).
 - **`"unified"`** — user `observeMe: true`, AI `observeOthers: true`, rest false. Single-observer pool; AI models the user but not itself, user peer only self-models.
 
 Server-side toggles set via the [Honcho dashboard](https://app.honcho.dev) win over local defaults — synced back at session init.


### PR DESCRIPTION
## Problem

With `ai_observe_me: true`, Honcho treats the AI peer's **own messages** as input for its self-representation. When the model answers questions about the user, it repeats user facts in its replies and those facts land under **AI Self-Representation** instead of the user peer.

Example: user says *"I play tennis on Tuesdays"* → AI replies *"Got it, you play tennis on Tuesdays"* → Honcho stores tennis under the AI persona, not the user.

## Solution

Set `ai_observe_me` default to `false` in:

- `HonchoClientConfig` dataclass default
- `"directional"` observation preset
- `HonchoSessionManager` fallback when no config is passed

AI still observes the user via `ai_observe_others: true`. Opt back in explicitly:

```json
"observation": { "ai": { "observeMe": true, "observeOthers": true } }
```

Also maps `lebedyncrs` in `AUTHOR_MAP` for contributor attribution CI.

## Test plan

- [x] `scripts/run_tests.sh tests/honcho_plugin/test_client.py tests/honcho_plugin/test_session.py tests/honcho_plugin/test_empty_profile_hint.py` - 207 passed
- [x] `test_directional_preset_disables_ai_self_observation`
- [x] `test_ai_self_observation_off_without_config`
