### PR TITLE
docs(fuzzy-match): correct strategy chain count

### DIFF
--- a/tools/fuzzy_match.py
+++ b/tools/fuzzy_match.py
@@ -6,15 +6,16 @@ Implements a multi-strategy matching chain to robustly find and replace text,
 accommodating variations in whitespace, indentation, and escaping common
 in LLM-generated code.
 
-The 8-strategy chain (inspired by OpenCode), tried in order:
+The 9-strategy chain (inspired by OpenCode), tried in order:
 1. Exact match - Direct string comparison
 2. Line-trimmed - Strip leading/trailing whitespace per line
 3. Whitespace normalized - Collapse multiple spaces/tabs to single space
 4. Indentation flexible - Ignore indentation differences entirely
 5. Escape normalized - Convert \\n literals to actual newlines
 6. Trimmed boundary - Trim first/last line whitespace only
-7. Block anchor - Match first+last lines, use similarity for middle
-8. Context-aware - 50% line similarity threshold
+7. Unicode normalized - Normalize common Unicode punctuation to ASCII
+8. Block anchor - Match first+last lines, use similarity for middle
+9. Context-aware - 50% line similarity threshold
 
 Multi-occurrence matching is handled via the replace_all flag.
 


### PR DESCRIPTION
## Summary

- Corrects stale fuzzy-match documentation that described an 8-strategy chain.
- The matcher now has 9 strategies, including `unicode_normalized`.
- Docs/comment-only update; runtime behavior is unchanged.

## Validation

- `python -m py_compile tools/fuzzy_match.py`

References #32848
