### PR TITLE
fix(doctor): reconfigure stdout to utf-8 before printing unicode

### DIFF
--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -397,6 +397,14 @@ def run_doctor(args):
     should_fix = getattr(args, 'fix', False)
     ack_target = getattr(args, 'ack', None)
 
+    # Ensure Unicode box-drawing characters and emoji render correctly regardless
+    # of the terminal's default encoding (e.g. latin-1 on some systems).
+    if hasattr(sys.stdout, "reconfigure"):
+        try:
+            sys.stdout.reconfigure(encoding="utf-8", errors="replace")
+        except Exception:
+            pass
+
     # Doctor runs from the interactive CLI, so CLI-gated tool availability
     # checks (like cronjob management) should see the same context as `hermes`.
     os.environ.setdefault("HERMES_INTERACTIVE", "1")


### PR DESCRIPTION
## Summary\n- Reconfigure doctor stdout to UTF-8 before printing unicode-heavy diagnostics\n- Prevents UnicodeEncodeError in terminals with non-UTF-8 encodings (e.g. some SSH sessions)\n\n## Test plan\n- Not run; defensive runtime fix only\n