### PR TITLE
feat(gateway): add optional runtime prefix labels

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -9145,24 +9145,41 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         display_reasoning = last_reasoning.strip()
                     response = f"💭 **Reasoning:**\n```\n{display_reasoning}\n```\n\n{response}"
 
-            # Runtime-metadata footer — only on the FINAL message of the turn.
-            # Off by default (display.runtime_footer.enabled=false).  When
-            # streaming already delivered the body, we can't mutate the sent
-            # text, so we fire a separate trailing send below.
+            # Runtime first-line prefix + metadata footer — only on the FINAL
+            # message of the turn.  Both are off by default.  When streaming has
+            # already delivered the body, we can't mutate the sent text; the
+            # footer is sent as a trailing message below, while the prefix is
+            # intentionally skipped because it would no longer be a first line.
             _footer_line = ""
+            _prefix_line = ""
             try:
-                from gateway.runtime_footer import build_footer_line as _bfl
+                from gateway.runtime_footer import (
+                    build_footer_line as _bfl,
+                    build_prefix_line as _bpl,
+                )
+                _runtime_display_config = _load_gateway_config()
+                _platform_key = _platform_config_key(source.platform)
+                _result_model = agent_result.get("model")
+                _prefix_line = _bpl(
+                    user_config=_runtime_display_config,
+                    platform_key=_platform_key,
+                    model=_result_model,
+                )
                 _footer_line = _bfl(
-                    user_config=_load_gateway_config(),
-                    platform_key=_platform_config_key(source.platform),
-                    model=agent_result.get("model"),
+                    user_config=_runtime_display_config,
+                    platform_key=_platform_key,
+                    model=_result_model,
                     context_tokens=agent_result.get("last_prompt_tokens", 0) or 0,
                     context_length=agent_result.get("context_length") or None,
                     cwd=os.environ.get("TERMINAL_CWD", ""),
                 )
             except Exception as _footer_err:
-                logger.debug("runtime_footer build failed: %s", _footer_err)
+                logger.debug("runtime footer/prefix build failed: %s", _footer_err)
                 _footer_line = ""
+                _prefix_line = ""
+            if _prefix_line and response and not agent_result.get("already_sent") and not _intentional_silence:
+                if not response.lstrip().startswith(_prefix_line):
+                    response = f"{_prefix_line}\n{response}"
             if _footer_line and response and not agent_result.get("already_sent") and not _intentional_silence:
                 response = f"{response}\n\n{_footer_line}"
 

--- a/gateway/runtime_footer.py
+++ b/gateway/runtime_footer.py
@@ -29,6 +29,15 @@ import os
 from typing import Any, Iterable, Optional
 
 _DEFAULT_FIELDS: tuple[str, ...] = ("model", "context_pct", "cwd")
+_DEFAULT_PREFIX_MAP: dict[str, str] = {
+    "grok-composer": "[grok]",
+    "grok": "[grok]",
+    "gpt-5.5": "[gpt5.5]",
+    "gpt": "[gpt]",
+    "glm-5.1": "[glm]",
+    "glm-5.2": "[glm2]",
+    "glm": "[glm]",
+}
 _SEP = " · "
 
 
@@ -86,6 +95,83 @@ def resolve_footer_config(
                     resolved["fields"] = [str(f) for f in plat_footer["fields"]]
 
     return resolved
+
+
+def resolve_prefix_config(
+    user_config: dict[str, Any] | None,
+    platform_key: str | None = None,
+) -> dict[str, Any]:
+    """Resolve effective first-line runtime-prefix config for *platform_key*.
+
+    Merge order (later wins):
+        1. Built-in defaults (enabled=False)
+        2. ``display.runtime_prefix``
+        3. ``display.platforms.<platform_key>.runtime_prefix``
+
+    ``labels`` maps model/provider substrings to the exact marker to prepend.
+    Keys are matched case-insensitively against the final model string, longest
+    key first so specific model names beat broad families.
+    """
+    resolved: dict[str, Any] = {
+        "enabled": False,
+        "labels": dict(_DEFAULT_PREFIX_MAP),
+    }
+    cfg = (user_config or {}).get("display") or {}
+
+    def _merge(src: Any) -> None:
+        if not isinstance(src, dict):
+            return
+        if "enabled" in src:
+            resolved["enabled"] = bool(src.get("enabled"))
+        labels = src.get("labels") or src.get("map") or src.get("markers")
+        if isinstance(labels, dict):
+            merged = dict(resolved.get("labels") or {})
+            for key, value in labels.items():
+                k = str(key).strip().lower()
+                v = str(value).strip()
+                if k and v:
+                    merged[k] = v
+            resolved["labels"] = merged
+
+    _merge(cfg.get("runtime_prefix"))
+
+    if platform_key:
+        platforms = cfg.get("platforms") or {}
+        plat_cfg = platforms.get(platform_key)
+        if isinstance(plat_cfg, dict):
+            _merge(plat_cfg.get("runtime_prefix"))
+
+    return resolved
+
+
+def format_runtime_prefix(
+    *,
+    model: Optional[str],
+    labels: dict[str, str] | None = None,
+) -> str:
+    """Return a first-line marker for *model*, or ``""`` when unmatched."""
+    if not model:
+        return ""
+    model_l = str(model).lower()
+    mapping = labels or _DEFAULT_PREFIX_MAP
+    for needle in sorted(mapping, key=len, reverse=True):
+        if needle and needle.lower() in model_l:
+            return str(mapping[needle]).strip()
+    return ""
+
+
+def build_prefix_line(
+    *,
+    user_config: dict[str, Any] | None,
+    platform_key: str | None,
+    model: Optional[str],
+) -> str:
+    """Top-level entry point used by gateway/run.py for first-line markers."""
+    cfg = resolve_prefix_config(user_config, platform_key)
+    if not cfg.get("enabled"):
+        return ""
+    labels = cfg.get("labels") if isinstance(cfg.get("labels"), dict) else None
+    return format_runtime_prefix(model=model, labels=labels)
 
 
 def format_runtime_footer(

--- a/tests/gateway/test_runtime_footer.py
+++ b/tests/gateway/test_runtime_footer.py
@@ -11,8 +11,11 @@ from gateway.runtime_footer import (
     _home_relative_cwd,
     _model_short,
     build_footer_line,
+    build_prefix_line,
     format_runtime_footer,
+    format_runtime_prefix,
     resolve_footer_config,
+    resolve_prefix_config,
 )
 
 
@@ -200,6 +203,50 @@ def test_resolve_ignores_malformed_config():
     user = {"display": {"runtime_footer": "on"}}
     cfg = resolve_footer_config(user, "telegram")
     assert cfg["enabled"] is False
+
+
+# ---------------------------------------------------------------------------
+# runtime_prefix — first-line model markers
+# ---------------------------------------------------------------------------
+
+def test_format_runtime_prefix_defaults_grok_and_glm():
+    assert format_runtime_prefix(model="grok-composer-2.5-fast") == "[grok]"
+    assert format_runtime_prefix(model="glm-5.1") == "[glm]"
+    assert format_runtime_prefix(model="glm-5.2") == "[glm2]"
+    assert format_runtime_prefix(model="gpt-5.5") == "[gpt5.5]"
+
+
+def test_format_runtime_prefix_longest_key_wins():
+    assert format_runtime_prefix(
+        model="grok-composer-2.5-fast",
+        labels={"grok": "[generic]", "grok-composer": "[composer]"},
+    ) == "[composer]"
+
+
+def test_resolve_prefix_platform_override_and_custom_label():
+    user = {
+        "display": {
+            "runtime_prefix": {"enabled": False, "labels": {"gpt": "[gpt]"}},
+            "platforms": {"telegram": {"runtime_prefix": {"enabled": True}}},
+        },
+    }
+    cfg = resolve_prefix_config(user, "telegram")
+    assert cfg["enabled"] is True
+    assert cfg["labels"]["gpt"] == "[gpt]"
+
+
+def test_build_prefix_line_empty_when_disabled():
+    assert build_prefix_line(
+        user_config={}, platform_key="telegram", model="grok-composer-2.5-fast"
+    ) == ""
+
+
+def test_build_prefix_line_when_enabled():
+    assert build_prefix_line(
+        user_config={"display": {"runtime_prefix": {"enabled": True}}},
+        platform_key="telegram",
+        model="glm-5.1",
+    ) == "[glm]"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Add a default-off `display.runtime_prefix` option for first-line runtime/model labels on final gateway responses.
- Add focused coverage for default labels, longest-key matching, platform override, disabled default, and enabled build path.

## Problem
Gateway runtime metadata can be shown as a footer, but there is no small first-line marker option for deployments that want the model/provider family visible before the response body. This keeps the behavior opt-in and avoids changing default output.

## Tests
- `python -m py_compile gateway/runtime_footer.py gateway/run.py`
- `pytest tests/gateway/test_runtime_footer.py -q -o addopts=`
- `git diff --cached --check -- gateway/run.py gateway/runtime_footer.py tests/gateway/test_runtime_footer.py`
- `gitleaks git --log-opts="origin/main..HEAD" --no-banner --redact`
- private regex scan over the commit-range diff
