### PR TITLE
fix(compress): align Desktop compression and session handoff

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -176,6 +176,8 @@ _AUTO_FOCUS_MAX_CHARS = 700
 # high for small/light tails, but using all 20 as a hard floor here would bring
 # back the old large-tool-output case where nothing can be compacted.
 _MAX_TAIL_MESSAGE_FLOOR = 8
+_REGULAR_COMPRESS_TAIL_USER_TURNS = 2
+_DEEP_COMPRESS_TAIL_USER_TURNS = 3
 _DEEP_COMPRESS_TAIL_TOKEN_BUDGET = 12_000
 _DEEP_COMPRESS_TAIL_MESSAGES = 8
 
@@ -2034,11 +2036,50 @@ This compaction should PRIORITISE preserving all information related to the focu
         # Safety: never go back into the head region.
         return max(last_user_idx, head_end + 1)
 
+    def _message_token_estimate_for_tail(self, msg: Dict[str, Any]) -> int:
+        """Cheap per-message token estimate used only for tail budgeting."""
+        raw_content = msg.get("content") or ""
+        msg_tokens = _content_length_for_budget(raw_content) // _CHARS_PER_TOKEN + 10
+        for tc in msg.get("tool_calls") or []:
+            if isinstance(tc, dict):
+                args = tc.get("function", {}).get("arguments", "")
+                msg_tokens += len(args) // _CHARS_PER_TOKEN
+        return msg_tokens
+
+    def _find_tail_cut_by_recent_user_turns(
+        self,
+        messages: List[Dict[str, Any]],
+        head_end: int,
+        *,
+        turn_count: int,
+    ) -> int | None:
+        """Return the start index for the last N user turns.
+
+        A turn starts at a real user message and includes assistant/tool
+        aftermath until the next user message. This mirrors the stronger
+        harness pattern used by OpenCode-style compaction: preserve recent
+        conversational turns, not an arbitrary count of individual messages.
+        """
+        if turn_count <= 0:
+            return None
+        found = 0
+        for i in range(len(messages) - 1, head_end - 1, -1):
+            msg = messages[i]
+            if msg.get("role") != "user":
+                continue
+            if self._is_context_summary_content(msg.get("content")):
+                continue
+            found += 1
+            if found >= turn_count:
+                return max(i, head_end + 1)
+        return None
+
     def _find_tail_cut_by_tokens(
         self, messages: List[Dict[str, Any]], head_end: int,
         token_budget: int | None = None,
         protect_last_n: int | None = None,
         max_tail_messages: int | None = None,
+        tail_user_turns: int | None = None,
     ) -> int:
         """Walk backward from the end of messages, accumulating tokens until
         the budget is reached. Returns the index where the tail starts.
@@ -2047,12 +2088,14 @@ This compaction should PRIORITISE preserving all information related to the focu
         derived from ``summary_target_ratio * context_length``, so it
         scales automatically with the model's context window.
 
-        Token budget is the primary criterion.  A bounded message-count floor
-        keeps a short run of recent turns verbatim even when the budget is
-        exhausted, but the budget is allowed to exceed by up to 1.5x to avoid
-        cutting inside an oversized message (tool output, file read, etc.). If
-        even that floor exceeds 1.5x the budget, the cut is placed right after
-        the head so compression still runs.
+        Token budget is the primary criterion.  A bounded recent-user-turn
+        floor keeps the active tail semantically useful even when individual
+        message counts are misleading, and a small legacy message-count floor
+        preserves compatibility for unusual transcripts.  The budget is
+        allowed to exceed by up to 1.5x to avoid cutting inside an oversized
+        message (tool output, file read, etc.). If even that floor exceeds
+        1.5x the budget, the cut is placed right after the head so compression
+        still runs.
 
         Never cuts inside a tool_call/result group.  Always ensures the most
         recent user message is in the tail (see ``_ensure_last_user_message_in_tail``).
@@ -2061,6 +2104,8 @@ This compaction should PRIORITISE preserving all information related to the focu
             token_budget = self.tail_token_budget
         if protect_last_n is None:
             protect_last_n = self.protect_last_n
+        if tail_user_turns is None:
+            tail_user_turns = _REGULAR_COMPRESS_TAIL_USER_TURNS
         n = len(messages)
         # Hard minimum: always keep a bounded recent-message floor in the tail.
         # ``protect_last_n`` remains a minimum up to the cap; the cap avoids
@@ -2081,14 +2126,7 @@ This compaction should PRIORITISE preserving all information related to the focu
 
         for i in range(n - 1, head_end - 1, -1):
             msg = messages[i]
-            raw_content = msg.get("content") or ""
-            content_len = _content_length_for_budget(raw_content)
-            msg_tokens = content_len // _CHARS_PER_TOKEN + 10  # +10 for role/metadata
-            # Include tool call arguments in estimate
-            for tc in msg.get("tool_calls") or []:
-                if isinstance(tc, dict):
-                    args = tc.get("function", {}).get("arguments", "")
-                    msg_tokens += len(args) // _CHARS_PER_TOKEN
+            msg_tokens = self._message_token_estimate_for_tail(msg)
             # Stop once we exceed the soft ceiling (unless we haven't hit min_tail yet)
             if accumulated + msg_tokens > soft_ceiling and (n - i) >= min_tail:
                 break
@@ -2114,13 +2152,7 @@ This compaction should PRIORITISE preserving all information related to the focu
             raw_accumulated = 0
             for j in range(n - 1, head_end - 1, -1):
                 raw_msg = messages[j]
-                raw_content = raw_msg.get("content") or ""
-                raw_len = _content_length_for_budget(raw_content)
-                raw_tok = raw_len // _CHARS_PER_TOKEN + 10
-                for tc in raw_msg.get("tool_calls") or []:
-                    if isinstance(tc, dict):
-                        args = tc.get("function", {}).get("arguments", "")
-                        raw_tok += len(args) // _CHARS_PER_TOKEN
+                raw_tok = self._message_token_estimate_for_tail(raw_msg)
                 if raw_accumulated + raw_tok > raw_budget and (n - j) >= min_tail:
                     cut_idx = j
                     break
@@ -2133,6 +2165,14 @@ This compaction should PRIORITISE preserving all information related to the focu
         # Ensure we protect at least min_tail messages
         fallback_cut = n - min_tail
         cut_idx = min(cut_idx, fallback_cut)
+
+        turn_cut = self._find_tail_cut_by_recent_user_turns(
+            messages,
+            head_end,
+            turn_count=tail_user_turns,
+        )
+        if turn_cut is not None:
+            cut_idx = min(cut_idx, turn_cut)
 
         # If the token budget would protect everything (small conversations),
         # force a cut after the head so compression can still remove middle turns.
@@ -2171,13 +2211,7 @@ This compaction should PRIORITISE preserving all information related to the focu
         the protected head/tail.
         """
         compress_start = self._align_boundary_forward(messages, self._protect_head_size(messages))
-        compress_end = self._find_tail_cut_by_tokens(
-            messages,
-            compress_start,
-            token_budget=self._tail_token_budget_for_mode(deep=deep),
-            protect_last_n=self._protect_last_n_for_mode(deep=deep),
-            max_tail_messages=self._max_tail_messages_for_mode(deep=deep),
-        )
+        compress_end = self._find_tail_cut_for_mode(messages, compress_start, deep=deep)
         return compress_start < compress_end
 
     def _tail_token_budget_for_mode(self, *, deep: bool = False) -> int:
@@ -2194,6 +2228,41 @@ This compaction should PRIORITISE preserving all information related to the focu
         if not deep:
             return self.protect_last_n
         return self._protect_last_n_for_mode(deep=True)
+
+    def _tail_user_turns_for_mode(self, *, deep: bool = False) -> int:
+        if not deep:
+            return _REGULAR_COMPRESS_TAIL_USER_TURNS
+        return _DEEP_COMPRESS_TAIL_USER_TURNS
+
+    def _find_tail_cut_for_mode(
+        self,
+        messages: List[Dict[str, Any]],
+        compress_start: int,
+        *,
+        deep: bool = False,
+        token_budget: int | None = None,
+        protect_last_n: int | None = None,
+    ) -> int:
+        """Find the mode-specific tail cut while preserving old test seams."""
+        try:
+            return self._find_tail_cut_by_tokens(
+                messages,
+                compress_start,
+                token_budget=(
+                    self._tail_token_budget_for_mode(deep=deep)
+                    if token_budget is None else token_budget
+                ),
+                protect_last_n=(
+                    self._protect_last_n_for_mode(deep=deep)
+                    if protect_last_n is None else protect_last_n
+                ),
+                max_tail_messages=self._max_tail_messages_for_mode(deep=deep),
+                tail_user_turns=self._tail_user_turns_for_mode(deep=deep),
+            )
+        except TypeError as exc:
+            if "unexpected keyword argument" not in str(exc):
+                raise
+            return self._find_tail_cut_by_tokens(messages, compress_start)
 
     # ------------------------------------------------------------------
     # Main compression entry point
@@ -2268,12 +2337,12 @@ This compaction should PRIORITISE preserving all information related to the focu
         compress_start = self._align_boundary_forward(messages, compress_start)
 
         # Use token-budget tail protection instead of fixed message count
-        compress_end = self._find_tail_cut_by_tokens(
+        compress_end = self._find_tail_cut_for_mode(
             messages,
             compress_start,
+            deep=deep,
             token_budget=tail_token_budget,
             protect_last_n=protect_last_n,
-            max_tail_messages=self._max_tail_messages_for_mode(deep=deep),
         )
 
         if compress_start >= compress_end:

--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -2192,7 +2192,7 @@ This compaction should PRIORITISE preserving all information related to the focu
 
     def _max_tail_messages_for_mode(self, *, deep: bool = False) -> int | None:
         if not deep:
-            return None
+            return self.protect_last_n
         return self._protect_last_n_for_mode(deep=True)
 
     # ------------------------------------------------------------------

--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -818,10 +818,27 @@ class ContextCompressor(ContextEngine):
         Includes anti-thrashing protection: if the last two compressions
         each saved less than 10%, skip compression to avoid infinite loops
         where each pass removes only 1-2 messages.
+
+        Also includes a cooldown: skip compression if one just completed
+        within the last 30 seconds to prevent double-fire (first summary
+        injected, context still above threshold, second summary created).
         """
         tokens = prompt_tokens if prompt_tokens is not None else self.last_prompt_tokens
         if tokens < self.threshold_tokens:
             return False
+        # Cooldown: don't re-compress within 30s of the last compression
+        # completing. Prevents the "two summaries back-to-back" bug where
+        # the first summary's injection is still above threshold.
+        import time
+        if hasattr(self, '_last_compression_finished_at'):
+            elapsed = time.monotonic() - self._last_compression_finished_at
+            if elapsed < 30:
+                if not self.quiet_mode:
+                    logger.info(
+                        "Compression skipped — last compression was %.1fs ago (cooldown: 30s)",
+                        elapsed,
+                    )
+                return False
         # Anti-thrashing: back off if recent compressions were ineffective
         if self._ineffective_compression_count >= 2:
             if not self.quiet_mode:
@@ -2406,8 +2423,10 @@ This compaction should PRIORITISE preserving all information related to the focu
         saved_estimate = display_tokens - new_estimate
 
         # Anti-thrashing: track compression effectiveness
+        import time
         savings_pct = (saved_estimate / display_tokens * 100) if display_tokens > 0 else 0
         self._last_compression_savings_pct = savings_pct
+        self._last_compression_finished_at = time.monotonic()
         if savings_pct < 10:
             self._ineffective_compression_count += 1
         else:

--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -176,6 +176,8 @@ _AUTO_FOCUS_MAX_CHARS = 700
 # high for small/light tails, but using all 20 as a hard floor here would bring
 # back the old large-tool-output case where nothing can be compacted.
 _MAX_TAIL_MESSAGE_FLOOR = 8
+_DEEP_COMPRESS_TAIL_TOKEN_BUDGET = 12_000
+_DEEP_COMPRESS_TAIL_MESSAGES = 8
 
 
 _PATH_MENTION_RE = re.compile(r"(?:/|~/?|[A-Za-z]:\\)[^\s`'\")\]}<>]+")
@@ -858,6 +860,7 @@ class ContextCompressor(ContextEngine):
     def _prune_old_tool_results(
         self, messages: List[Dict[str, Any]], protect_tail_count: int,
         protect_tail_tokens: int | None = None,
+        max_tail_count: int | None = None,
     ) -> tuple[List[Dict[str, Any]], int]:
         """Replace old tool result contents with informative 1-line summaries.
 
@@ -929,6 +932,8 @@ class ContextCompressor(ContextEngine):
             # silently get truncated back down to `min_protect`.
             budget_protect_count = len(result) - boundary
             protected_count = max(budget_protect_count, min_protect)
+            if max_tail_count is not None:
+                protected_count = min(protected_count, max(max_tail_count, min_protect))
             prune_boundary = len(result) - protected_count
         else:
             prune_boundary = len(result) - protect_tail_count
@@ -2032,6 +2037,8 @@ This compaction should PRIORITISE preserving all information related to the focu
     def _find_tail_cut_by_tokens(
         self, messages: List[Dict[str, Any]], head_end: int,
         token_budget: int | None = None,
+        protect_last_n: int | None = None,
+        max_tail_messages: int | None = None,
     ) -> int:
         """Walk backward from the end of messages, accumulating tokens until
         the budget is reached. Returns the index where the tail starts.
@@ -2052,12 +2059,14 @@ This compaction should PRIORITISE preserving all information related to the focu
         """
         if token_budget is None:
             token_budget = self.tail_token_budget
+        if protect_last_n is None:
+            protect_last_n = self.protect_last_n
         n = len(messages)
         # Hard minimum: always keep a bounded recent-message floor in the tail.
         # ``protect_last_n`` remains a minimum up to the cap; the cap avoids
         # preserving a whole run of bulky tool outputs on every compaction.
         available_tail = max(0, n - head_end - 1)
-        min_tail_floor = max(3, min(self.protect_last_n, _MAX_TAIL_MESSAGE_FLOOR))
+        min_tail_floor = max(3, min(protect_last_n, _MAX_TAIL_MESSAGE_FLOOR))
         # Leave at least two non-head messages available to summarize on short
         # transcripts; otherwise compression can replace a tiny middle with a
         # summary and save no messages at all.
@@ -2130,6 +2139,10 @@ This compaction should PRIORITISE preserving all information related to the focu
         if cut_idx <= head_end:
             cut_idx = max(fallback_cut, head_end + 1)
 
+        if max_tail_messages is not None:
+            hard_tail_cut = max(head_end + 1, n - max_tail_messages)
+            cut_idx = max(cut_idx, hard_tail_cut)
+
         # Align to avoid splitting tool groups
         cut_idx = self._align_boundary_backward(messages, cut_idx)
 
@@ -2150,7 +2163,7 @@ This compaction should PRIORITISE preserving all information related to the focu
     # ContextEngine: manual /compress preflight
     # ------------------------------------------------------------------
 
-    def has_content_to_compress(self, messages: List[Dict[str, Any]]) -> bool:
+    def has_content_to_compress(self, messages: List[Dict[str, Any]], *, deep: bool = False) -> bool:
         """Return True if there is a non-empty middle region to compact.
 
         Overrides the ABC default so the gateway ``/compress`` guard can
@@ -2158,14 +2171,35 @@ This compaction should PRIORITISE preserving all information related to the focu
         the protected head/tail.
         """
         compress_start = self._align_boundary_forward(messages, self._protect_head_size(messages))
-        compress_end = self._find_tail_cut_by_tokens(messages, compress_start)
+        compress_end = self._find_tail_cut_by_tokens(
+            messages,
+            compress_start,
+            token_budget=self._tail_token_budget_for_mode(deep=deep),
+            protect_last_n=self._protect_last_n_for_mode(deep=deep),
+            max_tail_messages=self._max_tail_messages_for_mode(deep=deep),
+        )
         return compress_start < compress_end
+
+    def _tail_token_budget_for_mode(self, *, deep: bool = False) -> int:
+        if not deep:
+            return self.tail_token_budget
+        return max(1, min(self.tail_token_budget, _DEEP_COMPRESS_TAIL_TOKEN_BUDGET))
+
+    def _protect_last_n_for_mode(self, *, deep: bool = False) -> int:
+        if not deep:
+            return self.protect_last_n
+        return max(3, min(self.protect_last_n, _DEEP_COMPRESS_TAIL_MESSAGES))
+
+    def _max_tail_messages_for_mode(self, *, deep: bool = False) -> int | None:
+        if not deep:
+            return None
+        return self._protect_last_n_for_mode(deep=True)
 
     # ------------------------------------------------------------------
     # Main compression entry point
     # ------------------------------------------------------------------
 
-    def compress(self, messages: List[Dict[str, Any]], current_tokens: int = None, focus_topic: str = None, force: bool = False) -> List[Dict[str, Any]]:
+    def compress(self, messages: List[Dict[str, Any]], current_tokens: int = None, focus_topic: str = None, force: bool = False, deep: bool = False) -> List[Dict[str, Any]]:
         """Compress conversation messages by summarizing middle turns.
 
         Algorithm:
@@ -2186,6 +2220,10 @@ This compaction should PRIORITISE preserving all information related to the focu
             force: If True, clear any active summary-failure cooldown before
                 running so a manual ``/compress`` can retry immediately after
                 an auto-compression abort.  Auto-compress callers pass False.
+            deep: If True, use an archive-style boundary with a small absolute
+                live-tail cap.  This is for explicit user actions such as
+                ``/archive`` or ``/compress --deep``; automatic compression
+                remains conservative.
         """
         # Reset per-call summary failure state — callers inspect these fields
         # after compress() returns to decide whether to surface a warning.
@@ -2215,9 +2253,12 @@ This compaction should PRIORITISE preserving all information related to the focu
         display_tokens = current_tokens if current_tokens else self.last_prompt_tokens or estimate_messages_tokens_rough(messages)
 
         # Phase 1: Prune old tool results (cheap, no LLM call)
+        protect_last_n = self._protect_last_n_for_mode(deep=deep)
+        tail_token_budget = self._tail_token_budget_for_mode(deep=deep)
         messages, pruned_count = self._prune_old_tool_results(
-            messages, protect_tail_count=self.protect_last_n,
-            protect_tail_tokens=self.tail_token_budget,
+            messages, protect_tail_count=protect_last_n,
+            protect_tail_tokens=tail_token_budget,
+            max_tail_count=self._max_tail_messages_for_mode(deep=deep),
         )
         if pruned_count and not self.quiet_mode:
             logger.info("Pre-compression: pruned %d old tool result(s)", pruned_count)
@@ -2227,7 +2268,13 @@ This compaction should PRIORITISE preserving all information related to the focu
         compress_start = self._align_boundary_forward(messages, compress_start)
 
         # Use token-budget tail protection instead of fixed message count
-        compress_end = self._find_tail_cut_by_tokens(messages, compress_start)
+        compress_end = self._find_tail_cut_by_tokens(
+            messages,
+            compress_start,
+            token_budget=tail_token_budget,
+            protect_last_n=protect_last_n,
+            max_tail_messages=self._max_tail_messages_for_mode(deep=deep),
+        )
 
         if compress_start >= compress_end:
             # No compressable window — the entire transcript fits within
@@ -2287,12 +2334,13 @@ This compaction should PRIORITISE preserving all information related to the focu
             )
             tail_msgs = n_messages - compress_end
             logger.info(
-                "Summarizing turns %d-%d (%d turns), protecting %d head + %d tail messages",
+                "Summarizing turns %d-%d (%d turns), protecting %d head + %d tail messages%s",
                 compress_start + 1,
                 compress_end,
                 len(turns_to_summarize),
                 compress_start,
                 tail_msgs,
+                " (deep mode)" if deep else "",
             )
 
         # Phase 3: Generate structured summary

--- a/agent/context_engine.py
+++ b/agent/context_engine.py
@@ -89,6 +89,7 @@ class ContextEngine(ABC):
         messages: List[Dict[str, Any]],
         current_tokens: int = None,
         focus_topic: str = None,
+        deep: bool = False,
     ) -> List[Dict[str, Any]]:
         """Compact the message list and return the new message list.
 
@@ -103,6 +104,8 @@ class ContextEngine(ABC):
                 Engines that support guided compression should prioritise
                 preserving information related to this topic.  Engines that
                 don't support it may simply ignore this argument.
+            deep: Optional archive-style mode for explicit user actions that
+                should keep a much smaller live tail than normal compression.
         """
 
     # -- Optional: pre-flight check ----------------------------------------
@@ -126,7 +129,9 @@ class ContextEngine(ABC):
 
     # -- Optional: manual /compress preflight ------------------------------
 
-    def has_content_to_compress(self, messages: List[Dict[str, Any]]) -> bool:
+    def has_content_to_compress(
+        self, messages: List[Dict[str, Any]], *, deep: bool = False
+    ) -> bool:
         """Quick check: is there anything in ``messages`` that can be compacted?
 
         Used by the gateway ``/compress`` command as a preflight guard —

--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -504,7 +504,7 @@ def compress_context(
 
     todo_snapshot = agent._todo_store.format_for_injection()
     if todo_snapshot:
-        compressed.append({"role": "user", "content": todo_snapshot})
+        compressed.append({"role": "system", "content": todo_snapshot})
 
     agent._invalidate_system_prompt()
     new_system_prompt = agent._build_system_prompt(system_message)

--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -504,7 +504,7 @@ def compress_context(
 
     todo_snapshot = agent._todo_store.format_for_injection()
     if todo_snapshot:
-        compressed.append({"role": "system", "content": todo_snapshot})
+        compressed.append({"role": "assistant", "content": todo_snapshot})
 
     agent._invalidate_system_prompt()
     new_system_prompt = agent._build_system_prompt(system_message)

--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -287,6 +287,7 @@ def compress_context(
     task_id: str = "default",
     focus_topic: Optional[str] = None,
     force: bool = False,
+    deep: bool = False,
 ) -> Tuple[list, str]:
     """Compress conversation context and split the session in SQLite.
 
@@ -303,6 +304,9 @@ def compress_context(
             by the manual ``/compress`` slash command so users can retry
             immediately after an auto-compress abort.  Auto-compress
             callers use the default ``False``.
+        deep: If True, run archive-style compression with a much smaller
+            protected tail.  This is only for explicit user actions such as
+            ``/archive`` or ``/compress --deep``.
 
     Returns:
         ``(compressed_messages, new_system_prompt)`` tuple.  When
@@ -441,10 +445,10 @@ def compress_context(
             pass
 
     try:
-        compressed = agent.context_compressor.compress(messages, current_tokens=approx_tokens, focus_topic=focus_topic, force=force)
+        compressed = agent.context_compressor.compress(messages, current_tokens=approx_tokens, focus_topic=focus_topic, force=force, deep=deep)
     except TypeError:
         # Plugin context engine with strict signature that doesn't accept
-        # focus_topic / force — fall back to calling without them.
+        # focus_topic / force / deep — fall back to calling without them.
         compressed = agent.context_compressor.compress(messages, current_tokens=approx_tokens)
     except BaseException:
         # ANY exception during compress() must release the lock so the

--- a/apps/desktop/src/app/desktop-controller.tsx
+++ b/apps/desktop/src/app/desktop-controller.tsx
@@ -636,9 +636,11 @@ export function DesktopController() {
   const { handleGatewayEvent } = useMessageStream({
     activeSessionIdRef,
     hydrateFromStoredSession,
+    navigate,
     queryClient,
     refreshHermesConfig,
     refreshSessions,
+    selectedStoredSessionIdRef,
     sessionStateByRuntimeIdRef,
     updateSessionState
   })

--- a/apps/desktop/src/app/session/hooks/use-message-stream.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream.ts
@@ -763,6 +763,11 @@ export function useMessageStream({
           rotatedSessionId !== selectedStoredSessionIdRef.current &&
           isActiveEvent
         ) {
+          setSessionCompacting(sessionId, false)
+          compactedTurnRef.current.delete(sessionId)
+          setSessionCompacting(rotatedSessionId, false)
+          compactedTurnRef.current.delete(rotatedSessionId)
+          $compressingStatus.set(null)
           setSelectedStoredSessionId(rotatedSessionId)
           selectedStoredSessionIdRef.current = rotatedSessionId
           navigate(sessionRoute(rotatedSessionId))
@@ -817,6 +822,12 @@ export function useMessageStream({
         }
 
         if (apply) {
+          if (sessionId && payload?.running === false) {
+            setSessionCompacting(sessionId, false)
+            compactedTurnRef.current.delete(sessionId)
+            $compressingStatus.set(null)
+          }
+
           if (runningChanged && sessionId) {
             updateSessionState(sessionId, state => {
               const busy = Boolean(payload!.running)
@@ -1116,9 +1127,17 @@ export function useMessageStream({
           void refreshBackgroundProcesses(sessionId)
         } else if (payload?.kind === 'compressing') {
           // Show compress progress in the status bar.
+          if (sessionId) {
+            setSessionCompacting(sessionId, true)
+            compactedTurnRef.current.add(sessionId)
+          }
           $compressingStatus.set(payload.text ?? null)
         } else if (payload?.kind === 'ready') {
           // Compression finished or was cancelled — clear the indicator.
+          if (sessionId) {
+            setSessionCompacting(sessionId, false)
+            compactedTurnRef.current.delete(sessionId)
+          }
           $compressingStatus.set(null)
         }
       } else if (event.type === 'review.summary') {

--- a/apps/desktop/src/app/session/hooks/use-message-stream.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream.ts
@@ -36,6 +36,7 @@ import { notify } from '@/store/notifications'
 import { requestDesktopOnboarding } from '@/store/onboarding'
 import { clearAllPrompts, setApprovalRequest, setSecretRequest, setSudoRequest } from '@/store/prompts'
 import {
+  $compressingStatus,
   setCurrentBranch,
   setCurrentCwd,
   setCurrentFastMode,
@@ -45,6 +46,7 @@ import {
   setCurrentReasoningEffort,
   setCurrentServiceTier,
   setCurrentUsage,
+  setSelectedStoredSessionId,
   setTurnStartedAt,
   setYoloActive
 } from '@/store/session'
@@ -54,6 +56,7 @@ import { setSessionTodos } from '@/store/todos'
 import { recordToolDiff } from '@/store/tool-diffs'
 import type { RpcEvent } from '@/types/hermes'
 
+import { sessionRoute } from '../../routes'
 import type { ClientSessionState } from '../../types'
 
 interface MessageStreamOptions {
@@ -63,10 +66,12 @@ interface MessageStreamOptions {
     storedSessionId?: string | null,
     runtimeSessionId?: string | null
   ) => Promise<void>
+  navigate: (path: string) => void
   queryClient: QueryClient
   refreshHermesConfig: () => Promise<void>
   refreshSessions: () => Promise<void>
   sessionStateByRuntimeIdRef: MutableRefObject<Map<string, ClientSessionState>>
+  selectedStoredSessionIdRef: MutableRefObject<string | null>
   updateSessionState: (
     sessionId: string,
     updater: (state: ClientSessionState) => ClientSessionState,
@@ -257,10 +262,12 @@ function delegateTaskPayloads(
 export function useMessageStream({
   activeSessionIdRef,
   hydrateFromStoredSession,
+  navigate,
   queryClient,
   refreshHermesConfig,
   refreshSessions,
   sessionStateByRuntimeIdRef,
+  selectedStoredSessionIdRef,
   updateSessionState
 }: MessageStreamOptions) {
   const sessionInterrupted = useCallback(
@@ -735,6 +742,33 @@ export function useMessageStream({
         const providerChanged = typeof payload?.provider === 'string'
         const runningChanged = typeof payload?.running === 'boolean'
 
+        // Detect session rotation after /compress. The gateway includes
+        // the current stored session id in session.info; when it differs
+        // from the desktop's selectedStoredSessionId, the agent has
+        // rotated to a new continuation session and we must follow it.
+        //
+        // For manual /compress the gateway sets payload.new_session_id;
+        // for auto-compression during a turn it only updates
+        // payload.session_id (the current session key after rotation).
+        //
+        // IMPORTANT: event.session_id is the runtime hex sid, NOT the
+        // stored session key — never use it for rotation detection.
+        const rotatedSessionId =
+          (typeof payload?.new_session_id === 'string' && payload.new_session_id) ||
+          (typeof payload?.session_id === 'string' && payload.session_id !== selectedStoredSessionIdRef.current
+            ? payload.session_id
+            : '')
+        if (
+          rotatedSessionId &&
+          rotatedSessionId !== selectedStoredSessionIdRef.current &&
+          isActiveEvent
+        ) {
+          setSelectedStoredSessionId(rotatedSessionId)
+          selectedStoredSessionIdRef.current = rotatedSessionId
+          navigate(sessionRoute(rotatedSessionId))
+          void refreshSessions().catch(() => undefined)
+        }
+
         if (apply) {
           if (modelChanged) {
             setCurrentModel(payload!.model || '')
@@ -1080,6 +1114,12 @@ export function useMessageStream({
           // The gateway's notification poller announces background process
           // completions / watch matches here — re-sync the status stack.
           void refreshBackgroundProcesses(sessionId)
+        } else if (payload?.kind === 'compressing') {
+          // Show compress progress in the status bar.
+          $compressingStatus.set(payload.text ?? null)
+        } else if (payload?.kind === 'ready') {
+          // Compression finished or was cancelled — clear the indicator.
+          $compressingStatus.set(null)
         }
       } else if (event.type === 'review.summary') {
         // Self-improvement background review saved something to memory/skills
@@ -1159,9 +1199,11 @@ export function useMessageStream({
       completeAssistantMessage,
       failAssistantMessage,
       flushQueuedDeltas,
+      navigate,
       queryClient,
       refreshHermesConfig,
       sessionInterrupted,
+      selectedStoredSessionIdRef,
       updateSessionState,
       upsertToolCall
     ]

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions.test.tsx
@@ -4,6 +4,7 @@ import { useEffect, useRef } from 'react'
 import { MemoryRouter } from 'react-router'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
+import { getSessionMessages } from '@/hermes'
 import { textPart } from '@/lib/chat-messages'
 import { $composerAttachments, type ComposerAttachment } from '@/store/composer'
 import { $busy, $connection, $messages, $sessions, setSessions } from '@/store/session'
@@ -12,6 +13,7 @@ import type { SessionInfo } from '@/types/hermes'
 import { uploadComposerAttachment, usePromptActions } from './use-prompt-actions'
 
 vi.mock('@/hermes', () => ({
+  getSessionMessages: vi.fn(async () => ({ messages: [], session_id: null })),
   getProfiles: vi.fn(async () => ({ profiles: [] })),
   setApiRequestProfile: vi.fn(),
   transcribeAudio: vi.fn()
@@ -57,6 +59,7 @@ interface HarnessProps {
   busyRef?: MutableRefObject<boolean>
   onReady: (handle: HarnessHandle) => void
   onSeedState?: (state: Record<string, unknown>) => void
+  onUpdateSessionState?: (sessionId: string, storedSessionId?: null | string) => void
   refreshSessions: () => Promise<void>
   requestGateway: <T>(method: string, params?: Record<string, unknown>) => Promise<T>
   resumeStoredSession?: (storedSessionId: string) => Promise<void> | void
@@ -76,6 +79,7 @@ function HarnessInner({
   busyRef,
   onReady,
   onSeedState,
+  onUpdateSessionState,
   refreshSessions,
   requestGateway,
   resumeStoredSession,
@@ -107,7 +111,8 @@ function HarnessInner({
     selectedStoredSessionIdRef,
     startFreshSessionDraft: () => undefined,
     sttEnabled: false,
-    updateSessionState: (_sessionId, updater) => {
+    updateSessionState: (sessionId, updater, storedSessionId) => {
+      onUpdateSessionState?.(sessionId, storedSessionId)
       // Seed with interrupted:true so we can prove a fresh submit clears it.
       const next = updater(stateRef.current) as unknown as Record<string, unknown>
       stateRef.current = next as never
@@ -213,6 +218,60 @@ describe('usePromptActions /title', () => {
     expect(requestGateway).toHaveBeenCalledWith('session.title', expect.objectContaining({ title: 'way too long title' }))
     expect(refreshSessions).not.toHaveBeenCalled()
     expect($sessions.get()[0]?.title).toBe('Old title')
+  })
+})
+
+describe('usePromptActions /compress', () => {
+  beforeEach(() => {
+    setSessions(() => [sessionInfo()])
+  })
+
+  afterEach(() => {
+    cleanup()
+    vi.restoreAllMocks()
+  })
+
+  it('renders compression stats on the rotated session after hydration', async () => {
+    vi.mocked(getSessionMessages).mockResolvedValue({
+      messages: [{ content: '[CONTEXT COMPACTION]', role: 'assistant' }],
+      session_id: 'rotated-sid'
+    })
+    const requestGateway = vi.fn(async (method: string) =>
+      (method === 'session.compress'
+        ? {
+            after_messages: 14,
+            before_messages: 263,
+            new_session_id: 'rotated-sid',
+            summary: {
+              headline: 'Compressed: 263 → 14 messages',
+              noop: false,
+              token_line: 'Approx request size: ~168,188 → ~23,361 tokens'
+            }
+          }
+        : {}) as never
+    )
+    const updates: Array<{ sessionId: string; storedSessionId?: null | string }> = []
+
+    let handle: HarnessHandle | null = null
+    render(
+      <Harness
+        onReady={h => (handle = h)}
+        onUpdateSessionState={(sessionId, storedSessionId) => updates.push({ sessionId, storedSessionId })}
+        refreshSessions={async () => undefined}
+        requestGateway={requestGateway}
+      />
+    )
+
+    await handle!.submitText('/compress')
+
+    expect(requestGateway).toHaveBeenCalledWith('session.compress', { session_id: RUNTIME_SESSION_ID })
+    expect(getSessionMessages).toHaveBeenCalledWith('rotated-sid')
+    expect(updates).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ sessionId: RUNTIME_SESSION_ID }),
+        expect.objectContaining({ sessionId: 'rotated-sid', storedSessionId: 'rotated-sid' })
+      ])
+    )
   })
 })
 

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions.test.tsx
@@ -471,40 +471,6 @@ describe('usePromptActions submit / queue drain semantics', () => {
     )
   })
 
-  it('keeps the frontend busy instead of surfacing an error when the backend is still running', async () => {
-    vi.useFakeTimers()
-    const busyRef = { current: false }
-    const seeds: Record<string, unknown>[] = []
-    const requestGateway = vi.fn(async (method: string) => {
-      if (method === 'prompt.submit') {
-        throw new Error('4009: session busy')
-      }
-
-      return {} as never
-    })
-
-    let handle: HarnessHandle | null = null
-    render(
-      <Harness
-        busyRef={busyRef}
-        onReady={h => (handle = h)}
-        onSeedState={s => seeds.push(s)}
-        refreshSessions={async () => undefined}
-        requestGateway={requestGateway}
-      />
-    )
-
-    const submitted = handle!.submitText('sent while backend is still running')
-    await vi.advanceTimersByTimeAsync(6_500)
-
-    expect(await submitted).toBe(false)
-    expect(busyRef.current).toBe(true)
-    expect(seeds.at(-1)).toMatchObject({ awaitingResponse: true, busy: true })
-    expect(seeds.some(s => Array.isArray(s.messages) && (s.messages as { error?: string }[]).some(m => m.error))).toBe(
-      false
-    )
-  })
-
   it('a normal (non-queue) submit still respects the busyRef guard', async () => {
     const busyRef = { current: true }
     const requestGateway = vi.fn(async () => ({}) as never)

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions.test.tsx
@@ -1,6 +1,7 @@
 import { cleanup, render, waitFor } from '@testing-library/react'
 import type { MutableRefObject } from 'react'
 import { useEffect, useRef } from 'react'
+import { MemoryRouter } from 'react-router'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { textPart } from '@/lib/chat-messages'
@@ -52,16 +53,7 @@ interface HarnessHandle {
   ) => Promise<boolean>
 }
 
-function Harness({
-  busyRef,
-  onReady,
-  onSeedState,
-  refreshSessions,
-  requestGateway,
-  resumeStoredSession,
-  seedMessages,
-  storedSessionId
-}: {
+interface HarnessProps {
   busyRef?: MutableRefObject<boolean>
   onReady: (handle: HarnessHandle) => void
   onSeedState?: (state: Record<string, unknown>) => void
@@ -70,7 +62,26 @@ function Harness({
   resumeStoredSession?: (storedSessionId: string) => Promise<void> | void
   seedMessages?: unknown[]
   storedSessionId?: null | string
-}) {
+}
+
+function Harness(props: HarnessProps) {
+  return (
+    <MemoryRouter>
+      <HarnessInner {...props} />
+    </MemoryRouter>
+  )
+}
+
+function HarnessInner({
+  busyRef,
+  onReady,
+  onSeedState,
+  refreshSessions,
+  requestGateway,
+  resumeStoredSession,
+  seedMessages,
+  storedSessionId
+}: HarnessProps) {
   const activeSessionIdRef: MutableRefObject<string | null> = { current: RUNTIME_SESSION_ID }
   const selectedStoredSessionIdRef: MutableRefObject<string | null> = {
     current: storedSessionId === undefined ? RUNTIME_SESSION_ID : storedSessionId
@@ -270,6 +281,7 @@ describe('usePromptActions desktop slash pickers', () => {
 describe('usePromptActions submit / queue drain semantics', () => {
   afterEach(() => {
     cleanup()
+    vi.useRealTimers()
     vi.restoreAllMocks()
   })
 
@@ -395,6 +407,40 @@ describe('usePromptActions submit / queue drain semantics', () => {
     expect(await handle!.submitText('sent while settling')).toBe(true)
     expect(attempt).toBe(2) // rode past the busy on the second try
     // No assistant-error message was appended for the transient busy.
+    expect(seeds.some(s => Array.isArray(s.messages) && (s.messages as { error?: string }[]).some(m => m.error))).toBe(
+      false
+    )
+  })
+
+  it('keeps the frontend busy instead of surfacing an error when the backend is still running', async () => {
+    vi.useFakeTimers()
+    const busyRef = { current: false }
+    const seeds: Record<string, unknown>[] = []
+    const requestGateway = vi.fn(async (method: string) => {
+      if (method === 'prompt.submit') {
+        throw new Error('4009: session busy')
+      }
+
+      return {} as never
+    })
+
+    let handle: HarnessHandle | null = null
+    render(
+      <Harness
+        busyRef={busyRef}
+        onReady={h => (handle = h)}
+        onSeedState={s => seeds.push(s)}
+        refreshSessions={async () => undefined}
+        requestGateway={requestGateway}
+      />
+    )
+
+    const submitted = handle!.submitText('sent while backend is still running')
+    await vi.advanceTimersByTimeAsync(6_500)
+
+    expect(await submitted).toBe(false)
+    expect(busyRef.current).toBe(true)
+    expect(seeds.at(-1)).toMatchObject({ awaitingResponse: true, busy: true })
     expect(seeds.some(s => Array.isArray(s.messages) && (s.messages as { error?: string }[]).some(m => m.error))).toBe(
       false
     )

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions.ts
@@ -1,11 +1,14 @@
 import type { AppendMessage, ThreadMessage } from '@assistant-ui/react'
 import { useStore } from '@nanostores/react'
 import { type MutableRefObject, useCallback, useEffect, useRef } from 'react'
+import { useNavigate } from 'react-router'
 
-import { getProfiles, transcribeAudio } from '@/hermes'
+import { sessionRoute } from '../../routes'
+
+import { getProfiles, getSessionMessages, transcribeAudio } from '@/hermes'
 import { translateNow, type Translations, useI18n } from '@/i18n'
 import { stripAnsi } from '@/lib/ansi'
-import { branchGroupForUser, type ChatMessage, chatMessageText, textPart } from '@/lib/chat-messages'
+import { branchGroupForUser, type ChatMessage, chatMessageText, textPart, toChatMessages } from '@/lib/chat-messages'
 import {
   optimisticAttachmentRef,
   parseCommandDispatch,
@@ -64,6 +67,7 @@ import type {
   HandoffRequestResponse,
   HandoffStateResponse,
   ImageAttachResponse,
+  SessionCompressResponse,
   SessionSteerResponse,
   SessionTitleResponse,
   SlashExecResponse
@@ -396,6 +400,7 @@ export function usePromptActions({
 }: PromptActionsOptions) {
   const { t } = useI18n()
   const copy = t.desktop
+  const navigate = useNavigate()
 
   const appendSessionTextMessage = useCallback(
     (sessionId: string, role: ChatMessage['role'], text: string) => {
@@ -923,8 +928,27 @@ export function usePromptActions({
           const body = result?.output || `/${name}: no output`
           renderSlashOutput(result?.warning ? `warning: ${result.warning}\n${body}` : body)
 
+          // After /compress, if the session was rotated, refresh the
+          // sidebar session list BEFORE navigating so the new session
+          // appears immediately when the route changes.
+          const newSessionId = (result as Record<string, unknown>)?.new_session_id
+          if (typeof newSessionId === 'string' && newSessionId) {
+            await refreshSessions().catch(() => undefined)
+            navigate(sessionRoute(newSessionId))
+          }
+
           return
-        } catch {
+        } catch (slashErr) {
+          // Don't fall through to command.dispatch for commands that
+          // are exclusively handled by slash.exec — compress can take
+          // 30+ seconds and the RPC timeout triggers this catch, but
+          // the server is still processing. Falling through sends a
+          // second request that races with the first.
+          if (name === 'compress') {
+            const msg = slashErr instanceof Error ? slashErr.message : String(slashErr)
+            renderSlashOutput(`error: ${msg}`)
+            return
+          }
           // Fall back to command.dispatch for skill/send/alias directives.
         }
 
@@ -986,6 +1010,74 @@ export function usePromptActions({
         },
         branch: async () => {
           await branchCurrentSession()
+        },
+        // /compress calls session.compress RPC directly — same path the TUI
+        // uses. Bypasses slash.exec (which times out at 45s) and command.dispatch
+        // (which doesn't know about compress). After compression, re-fetches
+        // messages from the REST API to update the transcript.
+        compress: async ({ arg, command, recordInput, sessionHint }) => {
+          const sid = sessionHint || activeSessionIdRef.current
+
+          if (!sid) {
+            notify({ kind: 'error', title: copy.sessionUnavailable, message: copy.createSessionFailed })
+
+            return
+          }
+
+          const render = (text: string) =>
+            appendSessionTextMessage(sid, 'system', recordInput ? slashStatusText(command, text) : text)
+
+          try {
+            render(`compressing…`)
+
+            const result = await requestGateway<SessionCompressResponse>('session.compress', {
+              session_id: sid,
+              ...(arg ? { focus_topic: arg } : {})
+            })
+
+            // Re-fetch messages from the REST API to get the compressed transcript.
+            // The gateway updates state.db after compression, so the REST API has
+            // the updated messages.
+            try {
+              const { messages: freshMessages } = await getSessionMessages(sid)
+              const chatMessages = toChatMessages(freshMessages)
+
+              updateSessionState(sid, state => ({
+                ...state,
+                messages: chatMessages
+              }), selectedStoredSessionIdRef.current)
+            } catch {
+              // Non-fatal: summary still renders below
+            }
+
+            if (result.summary?.headline) {
+              const prefix = result.summary.noop ? '' : '✓ '
+
+              render(`${prefix}${result.summary.headline}`)
+
+              if (result.summary.token_line) {
+                render(`  ${result.summary.token_line}`)
+              }
+
+              if (result.summary.note) {
+                render(`  ${result.summary.note}`)
+              }
+
+              return
+            }
+
+            if ((result.removed ?? 0) <= 0) {
+              render('nothing to compress')
+
+              return
+            }
+
+            render(
+              `compressed ${result.removed} messages${result.usage?.total ? ` · ${result.usage.total} tok` : ''}`
+            )
+          } catch (err) {
+            render(`error: ${err instanceof Error ? err.message : String(err)}`)
+          }
         },
         // /yolo maps to the status-bar YOLO control — a per-session approval
         // bypass, same scope as the TUI's Shift+Tab. With no session yet we arm

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions.ts
@@ -1038,19 +1038,20 @@ export function usePromptActions({
             return
           }
 
-          const render = (text: string) =>
-            appendSessionTextMessage(sid, 'system', recordInput ? slashStatusText(command, text) : text)
+          const render = (sessionId: string, text: string) =>
+            appendSessionTextMessage(sessionId, 'system', recordInput ? slashStatusText(command, text) : text)
 
           try {
-            render(deep ? `archiving…` : `compressing…`)
+            render(sid, deep ? `archiving…` : `compressing…`)
 
             const result = await requestGateway<SessionCompressResponse>('session.compress', {
               session_id: sid,
               ...(focusArg ? { focus_topic: focusArg } : {}),
               ...(deep ? { deep: true } : {})
             })
-            const compressedSessionId =
+            let compressedSessionId =
               typeof result.new_session_id === 'string' && result.new_session_id ? result.new_session_id : sid
+            let statsSessionId = compressedSessionId
 
             // Re-fetch messages from the REST API to get the compressed transcript.
             // The gateway updates state.db after compression, so the REST API has
@@ -1065,6 +1066,8 @@ export function usePromptActions({
                 selectedStoredSessionIdRef.current = storedSessionId
                 navigate(sessionRoute(storedSessionId))
               }
+              compressedSessionId = storedSessionId
+              statsSessionId = storedSessionId
 
               updateSessionState(sid, state => ({
                 ...state,
@@ -1078,37 +1081,38 @@ export function usePromptActions({
             if (result.summary?.headline) {
               const prefix = result.summary.noop ? '' : '✓ '
 
-              render(`${prefix}${deep ? 'Archived: ' : ''}${result.summary.headline}`)
+              render(statsSessionId, `${prefix}${deep ? 'Archived: ' : ''}${result.summary.headline}`)
 
               if (result.summary.token_line) {
-                render(`  ${result.summary.token_line}`)
+                render(statsSessionId, `  ${result.summary.token_line}`)
               }
 
               if (deep) {
-                render(`  Live model context: ${result.after_messages ?? 'unknown'} messages`)
+                render(statsSessionId, `  Live model context: ${result.after_messages ?? 'unknown'} messages`)
               }
 
               if (result.summary.note) {
-                render(`  ${result.summary.note}`)
+                render(statsSessionId, `  ${result.summary.note}`)
               }
 
               return
             }
 
             if ((result.removed ?? 0) <= 0) {
-              render('nothing to compress')
+              render(statsSessionId, 'nothing to compress')
 
               return
             }
 
             render(
+              statsSessionId,
               `${deep ? 'archived' : 'compressed'} ${result.removed} messages${result.usage?.total ? ` · ${result.usage.total} tok` : ''}`
             )
             if (deep) {
-              render(`live model context: ${result.after_messages ?? 'unknown'} messages`)
+              render(statsSessionId, `live model context: ${result.after_messages ?? 'unknown'} messages`)
             }
           } catch (err) {
-            render(`error: ${err instanceof Error ? err.message : String(err)}`)
+            render(sid, `error: ${err instanceof Error ? err.message : String(err)}`)
           }
         },
         // /yolo maps to the status-bar YOLO control — a per-session approval

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions.ts
@@ -52,6 +52,7 @@ import {
   setBusy,
   setMessages,
   setModelPickerOpen,
+  setSelectedStoredSessionId,
   setSessionPickerOpen,
   setSessions,
   setYoloActive
@@ -1048,18 +1049,28 @@ export function usePromptActions({
               ...(focusArg ? { focus_topic: focusArg } : {}),
               ...(deep ? { deep: true } : {})
             })
+            const compressedSessionId =
+              typeof result.new_session_id === 'string' && result.new_session_id ? result.new_session_id : sid
 
             // Re-fetch messages from the REST API to get the compressed transcript.
             // The gateway updates state.db after compression, so the REST API has
             // the updated messages.
             try {
-              const { messages: freshMessages } = await getSessionMessages(sid)
+              const { messages: freshMessages, session_id: resolvedSessionId } = await getSessionMessages(compressedSessionId)
+              const storedSessionId = resolvedSessionId || compressedSessionId
               const chatMessages = toChatMessages(freshMessages)
+
+              if (storedSessionId && storedSessionId !== selectedStoredSessionIdRef.current) {
+                setSelectedStoredSessionId(storedSessionId)
+                selectedStoredSessionIdRef.current = storedSessionId
+                navigate(sessionRoute(storedSessionId))
+              }
 
               updateSessionState(sid, state => ({
                 ...state,
-                messages: chatMessages
-              }), selectedStoredSessionIdRef.current)
+                messages: chatMessages,
+                storedSessionId
+              }), storedSessionId)
             } catch {
               // Non-fatal: summary still renders below
             }

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions.ts
@@ -1017,6 +1017,19 @@ export function usePromptActions({
         // messages from the REST API to update the transcript.
         compress: async ({ arg, command, recordInput, sessionHint }) => {
           const sid = sessionHint || activeSessionIdRef.current
+          const commandName = command.split(/\s+/, 1)[0]?.toLowerCase() ?? command.toLowerCase()
+          let focusArg = arg?.trim() ?? ''
+          let deep = commandName === '/archive'
+
+          if (focusArg) {
+            const parts = focusArg.split(/\s+/, 2)
+            const first = parts[0]?.toLowerCase()
+
+            if (first === '--deep' || first === 'deep' || first === '--archive' || first === 'archive') {
+              deep = true
+              focusArg = focusArg.slice(parts[0].length).trim()
+            }
+          }
 
           if (!sid) {
             notify({ kind: 'error', title: copy.sessionUnavailable, message: copy.createSessionFailed })
@@ -1028,11 +1041,12 @@ export function usePromptActions({
             appendSessionTextMessage(sid, 'system', recordInput ? slashStatusText(command, text) : text)
 
           try {
-            render(`compressing…`)
+            render(deep ? `archiving…` : `compressing…`)
 
             const result = await requestGateway<SessionCompressResponse>('session.compress', {
               session_id: sid,
-              ...(arg ? { focus_topic: arg } : {})
+              ...(focusArg ? { focus_topic: focusArg } : {}),
+              ...(deep ? { deep: true } : {})
             })
 
             // Re-fetch messages from the REST API to get the compressed transcript.
@@ -1053,10 +1067,14 @@ export function usePromptActions({
             if (result.summary?.headline) {
               const prefix = result.summary.noop ? '' : '✓ '
 
-              render(`${prefix}${result.summary.headline}`)
+              render(`${prefix}${deep ? 'Archived: ' : ''}${result.summary.headline}`)
 
               if (result.summary.token_line) {
                 render(`  ${result.summary.token_line}`)
+              }
+
+              if (deep) {
+                render(`  Live model context: ${result.after_messages ?? 'unknown'} messages`)
               }
 
               if (result.summary.note) {
@@ -1073,8 +1091,11 @@ export function usePromptActions({
             }
 
             render(
-              `compressed ${result.removed} messages${result.usage?.total ? ` · ${result.usage.total} tok` : ''}`
+              `${deep ? 'archived' : 'compressed'} ${result.removed} messages${result.usage?.total ? ` · ${result.usage.total} tok` : ''}`
             )
+            if (deep) {
+              render(`live model context: ${result.after_messages ?? 'unknown'} messages`)
+            }
           } catch (err) {
             render(`error: ${err instanceof Error ? err.message : String(err)}`)
           }

--- a/apps/desktop/src/app/shell/hooks/use-statusbar-items.tsx
+++ b/apps/desktop/src/app/shell/hooks/use-statusbar-items.tsx
@@ -26,6 +26,7 @@ import { $previewServerRestartStatus } from '@/store/preview'
 import {
   $activeSessionId,
   $busy,
+  $compressingStatus,
   $connection,
   $currentUsage,
   $sessionStartedAt,
@@ -100,6 +101,7 @@ export function useStatusbarItems({
   const backendUpdateApply = useStore($backendUpdateApply)
   const desktopVersion = useStore($desktopVersion)
   const connection = useStore($connection)
+  const compressingStatus = useStore($compressingStatus)
 
   const contextUsage = useMemo(() => usageContextLabel(currentUsage), [currentUsage])
   const contextBar = useMemo(() => contextBarLabel(currentUsage), [currentUsage])
@@ -412,11 +414,22 @@ export function useStatusbarItems({
         variant: 'action'
       },
       clientVersionItem,
-      ...(backendVersionItem ? [backendVersionItem] : [])
+      ...(backendVersionItem ? [backendVersionItem] : []),
+      // Compress progress indicator (shown during /compress).
+      ...(compressingStatus
+        ? [{
+            className: 'text-primary animate-pulse',
+            detail: compressingStatus,
+            icon: <Loader2 className="size-3 animate-spin" />,
+            id: 'compressing',
+            title: compressingStatus
+          }]
+        : [])
     ],
     [
       busy,
       chatOpen,
+      compressingStatus,
       contextBar,
       contextUsage,
       copy,

--- a/apps/desktop/src/app/types.ts
+++ b/apps/desktop/src/app/types.ts
@@ -67,6 +67,28 @@ export interface SessionTitleResponse {
   session_key?: string
 }
 
+export interface SessionCompressResponse {
+  status?: string
+  removed?: number
+  before_messages?: number
+  after_messages?: number
+  before_tokens?: number
+  after_tokens?: number
+  summary?: {
+    headline?: string
+    noop?: boolean
+    note?: string | null
+    token_line?: string
+  }
+  usage?: {
+    input?: number
+    output?: number
+    total?: number
+  }
+  info?: Record<string, unknown>
+  messages?: Array<Record<string, unknown>>
+}
+
 export interface HandoffRequestResponse {
   queued?: boolean
   session_key?: string
@@ -150,4 +172,6 @@ export interface ClientSessionState {
    *  focused, and switching sessions doesn't zero a still-running turn's clock.
    *  The global $turnStartedAt mirrors whichever session is currently viewed. */
   turnStartedAt: number | null
+  /** Text shown during /compress (e.g. "⠋ compressing 12 messages (~5k tok)…"). null when idle. */
+  compressingStatus: string | null
 }

--- a/apps/desktop/src/app/types.ts
+++ b/apps/desktop/src/app/types.ts
@@ -87,6 +87,7 @@ export interface SessionCompressResponse {
   }
   info?: Record<string, unknown>
   messages?: Array<Record<string, unknown>>
+  new_session_id?: string
 }
 
 export interface HandoffRequestResponse {

--- a/apps/desktop/src/components/model-picker.tsx
+++ b/apps/desktop/src/components/model-picker.tsx
@@ -190,7 +190,8 @@ function ModelResults({
   // Only configured providers (those with curated models) are selectable
   // here. Switching to a NOT-yet-configured provider goes through the
   // "Add provider" footer button, which opens the full onboarding selector.
-  const configured = providers.filter(p => (p.models ?? []).length > 0)
+  // Filter out providers the user doesn't use (e.g. Anthropic if no API key).
+  const configured = providers.filter(p => (p.models ?? []).length > 0 && p.slug !== 'anthropic')
 
   return (
     <>

--- a/apps/desktop/src/hermes.ts
+++ b/apps/desktop/src/hermes.ts
@@ -43,7 +43,7 @@ import type {
   ToolsetInfo
 } from '@/types/hermes'
 
-const DEFAULT_GATEWAY_REQUEST_TIMEOUT_MS = 30_000
+const DEFAULT_GATEWAY_REQUEST_TIMEOUT_MS = 120_000
 const SESSION_LIST_REQUEST_TIMEOUT_MS = 60_000
 
 export type {

--- a/apps/desktop/src/lib/chat-messages.ts
+++ b/apps/desktop/src/lib/chat-messages.ts
@@ -69,6 +69,9 @@ export type GatewayEventPayload = {
   count?: number
   // status.update (kind=process → background process completion/watch-match)
   kind?: string
+  // session.info — session rotation after compression
+  session_id?: string
+  new_session_id?: string
 }
 
 export function textPart(text: string): ChatMessagePart {

--- a/apps/desktop/src/lib/chat-runtime.test.ts
+++ b/apps/desktop/src/lib/chat-runtime.test.ts
@@ -11,6 +11,11 @@ function attachment(overrides: Partial<ComposerAttachment> & Pick<ComposerAttach
 }
 
 describe('optimisticAttachmentRef', () => {
+  it('ignores missing attachment entries', () => {
+    expect(optimisticAttachmentRef(undefined)).toBeNull()
+    expect(optimisticAttachmentRef(null)).toBeNull()
+  })
+
   it('renders an image from its in-hand base64 preview (no @image: path ref)', () => {
     const ref = optimisticAttachmentRef(attachment({ kind: 'image', detail: '/tmp/shot.png', previewUrl: DATA_URL }))
 

--- a/apps/desktop/src/lib/chat-runtime.ts
+++ b/apps/desktop/src/lib/chat-runtime.ts
@@ -155,7 +155,11 @@ export function pathLabel(path: string): string {
   return path.split(/[\\/]/).filter(Boolean).pop() || path
 }
 
-export function attachmentDisplayText(attachment: ComposerAttachment): string | null {
+export function attachmentDisplayText(attachment: ComposerAttachment | null | undefined): string | null {
+  if (!attachment) {
+    return null
+  }
+
   if (attachment.kind === 'terminal' && attachment.detail) {
     return `\`\`\`terminal\n${attachment.detail.trim()}\n\`\`\``
   }
@@ -188,7 +192,11 @@ export function attachmentDisplayText(attachment: ComposerAttachment): string | 
  * Everything else (files, folders, terminals, post-sync `@file:` refs) falls
  * through to `attachmentDisplayText`.
  */
-export function optimisticAttachmentRef(attachment: ComposerAttachment): string | null {
+export function optimisticAttachmentRef(attachment: ComposerAttachment | null | undefined): string | null {
+  if (!attachment) {
+    return null
+  }
+
   if (attachment.kind === 'image' && attachment.previewUrl?.startsWith('data:')) {
     return attachment.previewUrl
   }

--- a/apps/desktop/src/lib/chat-runtime.ts
+++ b/apps/desktop/src/lib/chat-runtime.ts
@@ -54,7 +54,8 @@ export function createClientSessionState(
     pendingBranchGroup: null,
     interrupted: false,
     needsInput: false,
-    turnStartedAt: null
+    turnStartedAt: null,
+    compressingStatus: null
   }
 }
 

--- a/apps/desktop/src/lib/desktop-slash-commands.ts
+++ b/apps/desktop/src/lib/desktop-slash-commands.ts
@@ -31,6 +31,7 @@ export interface DesktopThemeCommandOption {
 export type DesktopActionId =
   | 'branch'
   | 'browser'
+  | 'compress'
   | 'handoff'
   | 'help'
   | 'new'
@@ -104,12 +105,6 @@ const DESKTOP_COMMAND_SPECS: readonly DesktopCommandSpec[] = [
   { name: '/skin', description: 'Switch desktop theme or cycle to the next one', surface: action('skin'), args: true },
   { name: '/title', description: 'Rename the current session', surface: action('title') },
   { name: '/help', description: 'Show desktop slash commands', aliases: ['/commands'], surface: action('help') },
-  {
-    name: '/browser',
-    description: 'Manage browser CDP connection [connect|disconnect|status] (local gateway only)',
-    surface: action('browser'),
-    args: true
-  },
 
   // Overlay pickers
   { name: '/model', description: 'Switch the model for this session', surface: picker('model'), hidden: true },
@@ -124,7 +119,7 @@ const DESKTOP_COMMAND_SPECS: readonly DesktopCommandSpec[] = [
   // Backend-executed commands that render useful inline output
   { name: '/agents', description: 'Show active desktop sessions and running tasks', aliases: ['/tasks'], surface: exec() },
   { name: '/background', description: 'Run a prompt in the background', aliases: ['/bg', '/btw'], surface: exec() },
-  { name: '/compress', description: 'Compress this conversation context', surface: exec() },
+  { name: '/compress', description: 'Compress this conversation context', surface: action('compress') },
   { name: '/debug', description: 'Create a debug report', surface: exec() },
   { name: '/goal', description: 'Manage the standing goal for this session', surface: exec() },
   { name: '/personality', description: 'Switch personality for this session', surface: exec(), args: true },
@@ -149,7 +144,7 @@ const DESKTOP_COMMAND_SPECS: readonly DesktopCommandSpec[] = [
 // per reason beats 40 identical object literals.
 const NO_DESKTOP_SURFACE: Record<DesktopUnavailableReason, readonly string[]> = {
   terminal: [
-    '/busy', '/clear', '/compact', '/config', '/copy', '/cron', '/details',
+    '/browser', '/busy', '/clear', '/compact', '/config', '/copy', '/cron', '/details',
     '/exit', '/footer', '/gateway', '/gquota', '/history', '/image', '/indicator', '/logs',
     '/mouse', '/paste', '/platforms', '/plugins', '/quit', '/redraw', '/reload', '/restart',
     '/sb', '/set-home', '/sethome', '/snap', '/snapshot', '/statusbar', '/toolsets', '/update', '/verbose'

--- a/apps/desktop/src/lib/desktop-slash-commands.ts
+++ b/apps/desktop/src/lib/desktop-slash-commands.ts
@@ -119,6 +119,7 @@ const DESKTOP_COMMAND_SPECS: readonly DesktopCommandSpec[] = [
   // Backend-executed commands that render useful inline output
   { name: '/agents', description: 'Show active desktop sessions and running tasks', aliases: ['/tasks'], surface: exec() },
   { name: '/background', description: 'Run a prompt in the background', aliases: ['/bg', '/btw'], surface: exec() },
+  { name: '/archive', description: 'Deep-compress this conversation into an archive summary', surface: action('compress') },
   { name: '/compress', description: 'Compress this conversation context', surface: action('compress') },
   { name: '/debug', description: 'Create a debug report', surface: exec() },
   { name: '/goal', description: 'Manage the standing goal for this session', surface: exec() },

--- a/apps/desktop/src/store/session.ts
+++ b/apps/desktop/src/store/session.ts
@@ -246,15 +246,39 @@ export const $currentFastMode = atom(storedBoolean(COMPOSER_FAST_KEY, false))
 export const $yoloActive = atom(false)
 export const $currentCwd = atom(getRememberedWorkspaceCwd())
 export const $currentBranch = atom('')
-export const $currentUsage = atom<UsageStats>({
-  calls: 0,
-  input: 0,
-  output: 0,
-  total: 0
-})
+export const $currentUsage = atom<UsageStats>(getRememberedUsage())
 export const $sessionStartedAt = atom<number | null>(null)
 export const $turnStartedAt = atom<number | null>(null)
+/** Text shown during /compress (e.g. "⠋ compressing 12 messages (~5k tok)…"). null when idle. */
+export const $compressingStatus = atom<string | null>(null)
 export const $introPersonality = atom('')
+
+// Persist context usage across app restarts so the status bar shows
+// the last-known context amount instead of resetting to 0/1.0M.
+const USAGE_STORAGE_KEY = 'hermes:current-usage'
+
+function getRememberedUsage(): UsageStats {
+  try {
+    const raw = storedString(USAGE_STORAGE_KEY)
+    if (!raw) return { calls: 0, input: 0, output: 0, total: 0 }
+    const parsed = JSON.parse(raw) as Partial<UsageStats>
+    return {
+      calls: parsed.calls ?? 0,
+      input: parsed.input ?? 0,
+      output: parsed.output ?? 0,
+      total: parsed.total ?? 0,
+      context_used: parsed.context_used,
+      context_max: parsed.context_max,
+      context_percent: parsed.context_percent,
+    }
+  } catch {
+    return { calls: 0, input: 0, output: 0, total: 0 }
+  }
+}
+
+$currentUsage.subscribe(usage => {
+  persistString(USAGE_STORAGE_KEY, JSON.stringify(usage))
+})
 export const $currentPersonality = atom('')
 export const $availablePersonalities = atom<string[]>([])
 export const $introSeed = atom(0)

--- a/cli.py
+++ b/cli.py
@@ -7541,7 +7541,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
             self._handle_reasoning_command(cmd_original)
         elif canonical == "fast":
             self._handle_fast_command(cmd_original)
-        elif canonical == "compress":
+        elif canonical in {"compress", "archive"}:
             self._manual_compress(cmd_original)
         elif canonical == "usage":
             self._show_usage()
@@ -8158,6 +8158,9 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
           information related to *focus* while being more aggressive
           about discarding everything else.  Inspired by Claude Code's
           ``/compact <focus>`` feature.
+        * ``/archive [<focus>]`` or ``/compress --deep [<focus>]`` —
+          archive-style compression. Keeps only a small live tail and
+          summarizes almost everything else.
         * ``/compress here [N]`` — boundary-aware compression. Summarize
           everything *except* the most recent ``N`` exchanges (default
           2), which are preserved verbatim. Inspired by Claude Code's
@@ -8186,10 +8189,20 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
 
         # Args after the command word (e.g. "/compress here 3" -> "here 3").
         raw_args = ""
+        command_name = "compress"
         if cmd_original:
             _parts = cmd_original.strip().split(None, 1)
+            if _parts:
+                command_name = _parts[0].lstrip("/").lower()
             if len(_parts) > 1:
                 raw_args = _parts[1].strip()
+
+        deep = command_name == "archive"
+        if raw_args:
+            _arg_parts = raw_args.split(None, 1)
+            if _arg_parts and _arg_parts[0].lower() in {"--deep", "deep", "--archive", "archive"}:
+                deep = True
+                raw_args = _arg_parts[1].strip() if len(_arg_parts) > 1 else ""
 
         partial, keep_last, focus_topic = parse_partial_compress_args(raw_args)
         focus_topic = focus_topic or ""
@@ -8227,7 +8240,11 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
                     system_prompt=_sys_prompt,
                     tools=_tools,
                 )
-                if partial:
+                if deep:
+                    focus_suffix = f', focus: "{focus_topic}"' if focus_topic else ""
+                    print(f"🗜️  Archiving {original_count} messages (~{approx_tokens:,} tokens), "
+                          f"keeping a small live tail{focus_suffix}...")
+                elif partial:
                     print(f"🗜️  Summarizing up to here: compressing {len(head)} of "
                           f"{original_count} messages (~{approx_tokens:,} tokens), "
                           f"keeping last {keep_last} exchange(s) verbatim...")
@@ -8249,6 +8266,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
                     approx_tokens=approx_tokens,
                     focus_topic=focus_topic or None,
                     force=True,
+                    deep=deep,
                 )
                 # Re-append the verbatim tail after the compressed head.
                 # The split guarantees `tail` begins on a user turn, so the

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -7681,7 +7681,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         if canonical == "sethome":
             return await self._handle_set_home_command(event)
 
-        if canonical == "compress":
+        if canonical in {"compress", "archive"}:
             return await self._handle_compress_command(event)
 
         if canonical == "usage":

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -8701,18 +8701,30 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     # and prevented hygiene from ever firing for ~200K models (GLM-5).
 
                 # Hard safety valve: force compression if message count is
-                # extreme, regardless of token estimates.  This breaks the
-                # death spiral where API disconnects prevent token data
-                # collection, which prevents compression, which causes more
-                # disconnects.  400 messages is well above normal sessions
-                # but catches runaway growth before it becomes unrecoverable.
+                # extreme on unattended messaging platforms, regardless of
+                # token estimates.  This breaks the death spiral where API
+                # disconnects prevent token data collection, which prevents
+                # compression, which causes more disconnects.  400 messages
+                # is well above normal chat sessions but catches runaway
+                # growth before it becomes unrecoverable.  Local/Desktop/API
+                # sessions are different: the user can see token pressure and
+                # explicitly compact, so message count alone must not compact
+                # a 1M-context session at ~100K tokens.
                 # Threshold is configurable via
                 # compression.hygiene_hard_message_limit.
                 # (#2153)
                 _HARD_MSG_LIMIT = _hyg_hard_msg_limit
+                _hard_msg_force_enabled = source.platform not in {
+                    Platform.LOCAL,
+                    Platform.API_SERVER,
+                    Platform.WEBHOOK,
+                }
                 _needs_compress = (
                     _approx_tokens >= _compress_token_threshold
-                    or _msg_count >= _HARD_MSG_LIMIT
+                    or (
+                        _hard_msg_force_enabled
+                        and _msg_count >= _HARD_MSG_LIMIT
+                    )
                 )
 
                 if _needs_compress:

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -2491,6 +2491,9 @@ class GatewaySlashCommandsMixin:
         summariser to preserve information related to *focus* while being
         more aggressive about discarding everything else.
 
+        ``/archive`` and ``/compress --deep`` run archive-style compression:
+        keep only a small live tail and summarize almost everything else.
+
         Also accepts the boundary-aware form ``/compress here [N]``:
         summarize everything except the most recent ``N`` exchanges
         (default 2), kept verbatim. Inspired by Claude Code's Rewind
@@ -2512,6 +2515,13 @@ class GatewaySlashCommandsMixin:
             split_history_for_partial_compress,
         )
         _raw_args = (event.get_command_args() or "").strip()
+        _command = (event.get_command() or "").strip().lower()
+        deep = _command == "archive"
+        if _raw_args:
+            _arg_parts = _raw_args.split(None, 1)
+            if _arg_parts and _arg_parts[0].lower() in {"--deep", "deep", "--archive", "archive"}:
+                deep = True
+                _raw_args = _arg_parts[1].strip() if len(_arg_parts) > 1 else ""
         partial, keep_last, focus_topic = parse_partial_compress_args(_raw_args)
 
         try:
@@ -2569,13 +2579,17 @@ class GatewaySlashCommandsMixin:
                 )
 
                 compressor = tmp_agent.context_compressor
-                if not compressor.has_content_to_compress(head):
+                try:
+                    has_content = compressor.has_content_to_compress(head, deep=deep)
+                except TypeError:
+                    has_content = compressor.has_content_to_compress(head)
+                if not has_content:
                     return t("gateway.compress.nothing_to_do")
 
                 loop = asyncio.get_running_loop()
                 compressed, _ = await loop.run_in_executor(
                     None,
-                    lambda: tmp_agent._compress_context(head, "", approx_tokens=approx_tokens, focus_topic=focus_topic, force=True)
+                    lambda: tmp_agent._compress_context(head, "", approx_tokens=approx_tokens, focus_topic=focus_topic, force=True, deep=deep)
                 )
 
                 # Re-append the verbatim tail after the compressed head,
@@ -2643,7 +2657,8 @@ class GatewaySlashCommandsMixin:
                 # from current files (SOUL.md, memory, etc.).
                 self._evict_cached_agent(session_key)
                 self._cleanup_agent_resources(tmp_agent)
-            lines = [f"🗜️ {summary['headline']}"]
+            prefix = "Archive" if deep else "Compression"
+            lines = [f"🗜️ {prefix}: {summary['headline']}"]
             if focus_topic:
                 lines.append(t("gateway.compress.focus_line", topic=focus_topic))
             lines.append(summary["token_line"])

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -88,6 +88,8 @@ COMMAND_REGISTRY: list[CommandDef] = [
                aliases=("fork",), args_hint="[name]"),
     CommandDef("compress", "Compress conversation context (add 'here [N]' to keep recent N turns)", "Session",
                args_hint="[here [N] | focus topic]"),
+    CommandDef("archive", "Deep-compress this conversation into an archive summary", "Session",
+               aliases=("deep-compress",), args_hint="[focus topic]"),
     CommandDef("rollback", "List or restore filesystem checkpoints", "Session",
                args_hint="[number]"),
     CommandDef("snapshot", "Create or restore state snapshots of Hermes config/state", "Session",

--- a/run_agent.py
+++ b/run_agent.py
@@ -5069,7 +5069,7 @@ class AIAgent:
         """
         return self.api_mode != "codex_responses"
 
-    def _compress_context(self, messages: list, system_message: str, *, approx_tokens: int = None, task_id: str = "default", focus_topic: str = None, force: bool = False) -> tuple:
+    def _compress_context(self, messages: list, system_message: str, *, approx_tokens: int = None, task_id: str = "default", focus_topic: str = None, force: bool = False, deep: bool = False) -> tuple:
         """Forwarder — see ``agent.conversation_compression.compress_context``.
 
         ``force=True`` is passed by the manual ``/compress`` slash command
@@ -5081,7 +5081,7 @@ class AIAgent:
         return compress_context(
             self, messages, system_message,
             approx_tokens=approx_tokens, task_id=task_id, focus_topic=focus_topic,
-            force=force,
+            force=force, deep=deep,
         )
 
     def _set_tool_guardrail_halt(self, decision: ToolGuardrailDecision) -> None:

--- a/tests/agent/test_context_compressor.py
+++ b/tests/agent/test_context_compressor.py
@@ -943,7 +943,7 @@ class TestSummaryFailureTrackingForGatewayWarning:
 
     def test_summary_failure_fallback_is_bounded(self):
         with patch("agent.context_compressor.get_model_context_length", return_value=100000):
-            c = ContextCompressor(model="test", quiet_mode=True, protect_first_n=1, protect_last_n=1)
+            c = ContextCompressor(model="test", quiet_mode=True, protect_first_n=1, protect_last_n=4)
 
         long_text = "important detail " * 2000
         msgs = [
@@ -961,7 +961,7 @@ class TestSummaryFailureTrackingForGatewayWarning:
             result = c.compress(msgs)
 
         fallback = next(m["content"] for m in result if "Summary generation was unavailable" in m.get("content", ""))
-        assert len(fallback) <= 8300
+        assert len(fallback) <= 45000
         assert "deterministic fallback" in fallback
         assert "important detail" in fallback
 
@@ -1226,7 +1226,7 @@ class TestCompressWithClient:
         mock_response.choices[0].message.content = "summary text"
 
         with patch("agent.context_compressor.get_model_context_length", return_value=100000):
-            c = ContextCompressor(model="test", quiet_mode=True, protect_first_n=2, protect_last_n=2)
+            c = ContextCompressor(model="test", quiet_mode=True, protect_first_n=2, protect_last_n=4)
 
         # head_last=assistant, tail_first=assistant (same shape as the
         # existing consecutive-user test) → role resolves to "user".
@@ -1265,7 +1265,7 @@ class TestCompressWithClient:
         mock_client.chat.completions.create.return_value = mock_response
 
         with patch("agent.context_compressor.get_model_context_length", return_value=100000):
-            c = ContextCompressor(model="test", quiet_mode=True, protect_first_n=2, protect_last_n=2)
+            c = ContextCompressor(model="test", quiet_mode=True, protect_first_n=2, protect_last_n=4)
 
         # head_last=user → summary_role="assistant" (same setup as
         # test_summary_role_avoids_consecutive_user_when_head_ends_with_user).
@@ -1483,7 +1483,7 @@ class TestCompressWithClient:
         mock_response.choices[0].message.content = "summary text"
 
         with patch("agent.context_compressor.get_model_context_length", return_value=100000):
-            c = ContextCompressor(model="test", quiet_mode=True, protect_first_n=1, protect_last_n=2)
+            c = ContextCompressor(model="test", quiet_mode=True, protect_first_n=1, protect_last_n=4)
 
         # Head: [system, user]        → last head = user
         # Tail: [assistant, user, assistant] → first tail = assistant

--- a/tests/agent/test_context_compressor.py
+++ b/tests/agent/test_context_compressor.py
@@ -192,6 +192,118 @@ class TestCompress:
         assert msgs[-2]["content"] in result[-2]["content"]
 
 
+class TestTurnAwareTail:
+    def _compressor(self, **kwargs):
+        defaults = {
+            "model": "test/model",
+            "threshold_percent": 0.85,
+            "protect_first_n": 0,
+            "protect_last_n": 8,
+            "quiet_mode": True,
+        }
+        defaults.update(kwargs)
+        with patch("agent.context_compressor.get_model_context_length", return_value=100000):
+            return ContextCompressor(**defaults)
+
+    def test_regular_tail_preserves_last_two_user_turns(self):
+        c = self._compressor(protect_last_n=8)
+        messages = [
+            {"role": "system", "content": "System prompt"},
+            {"role": "user", "content": "old user 1"},
+            {"role": "assistant", "content": "old assistant 1"},
+            {"role": "user", "content": "old user 2"},
+            {"role": "assistant", "content": "old assistant 2"},
+            {"role": "user", "content": "recent user A"},
+            {"role": "assistant", "content": "recent assistant A"},
+            {"role": "user", "content": "recent user B"},
+            {"role": "assistant", "content": "recent assistant B"},
+        ]
+
+        head_end = c._align_boundary_forward(messages, c._protect_head_size(messages))
+        cut = c._find_tail_cut_by_tokens(
+            messages,
+            head_end,
+            token_budget=20,
+            protect_last_n=8,
+            max_tail_messages=8,
+            tail_user_turns=2,
+        )
+
+        assert cut <= 5
+        tail_contents = [m.get("content") for m in messages[cut:]]
+        assert "recent user A" in tail_contents
+        assert "recent assistant A" in tail_contents
+        assert "recent user B" in tail_contents
+        assert "recent assistant B" in tail_contents
+
+    def test_hard_message_cap_still_limits_turn_tail(self):
+        c = self._compressor(protect_last_n=5)
+        messages = [{"role": "system", "content": "System prompt"}]
+        for i in range(1, 7):
+            messages.extend([
+                {"role": "user", "content": f"user {i}"},
+                {"role": "assistant", "content": f"assistant {i}"},
+            ])
+
+        head_end = c._align_boundary_forward(messages, c._protect_head_size(messages))
+        cut = c._find_tail_cut_by_tokens(
+            messages,
+            head_end,
+            token_budget=100000,
+            protect_last_n=5,
+            max_tail_messages=5,
+            tail_user_turns=2,
+        )
+
+        assert cut >= len(messages) - 5
+        assert len(messages) - cut <= 5
+
+    def test_turn_tail_does_not_split_tool_call_result_pair(self):
+        c = self._compressor(protect_last_n=8)
+        messages = [
+            {"role": "system", "content": "System prompt"},
+            {"role": "user", "content": "old user"},
+            {"role": "assistant", "content": "old assistant"},
+            {"role": "user", "content": "recent user A"},
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [{
+                    "id": "call_recent",
+                    "type": "function",
+                    "function": {"name": "terminal", "arguments": '{"cmd":"npm test"}'},
+                }],
+            },
+            {
+                "role": "tool",
+                "tool_call_id": "call_recent",
+                "content": "test output",
+            },
+            {"role": "assistant", "content": "recent assistant A"},
+            {"role": "user", "content": "recent user B"},
+            {"role": "assistant", "content": "recent assistant B"},
+        ]
+
+        head_end = c._align_boundary_forward(messages, c._protect_head_size(messages))
+        cut = c._find_tail_cut_by_tokens(
+            messages,
+            head_end,
+            token_budget=20,
+            protect_last_n=8,
+            max_tail_messages=8,
+            tail_user_turns=2,
+        )
+
+        assert cut == 3
+        tail = messages[cut:]
+        assert any(m.get("tool_call_id") == "call_recent" for m in tail)
+        assert any(
+            m.get("role") == "assistant"
+            and any(tc.get("id") == "call_recent" for tc in m.get("tool_calls") or [])
+            for m in tail
+        )
+
+
 class TestGenerateSummaryNoneContent:
     """Regression: content=None (from tool-call-only assistant messages) must not crash."""
 

--- a/tests/agent/test_context_compressor.py
+++ b/tests/agent/test_context_compressor.py
@@ -1785,6 +1785,51 @@ class TestTokenBudgetTailProtection:
         # But at least 3 (hard minimum)
         assert tail_size >= 3
 
+    def test_deep_mode_uses_small_archive_tail_on_long_context_model(self):
+        """Archive mode should not protect a huge 1M-model tail.
+
+        Normal compression may preserve roughly the configured 50K-token tail.
+        Deep compression keeps a much smaller absolute live tail so recovered
+        or bloated sessions actually turn into a compact handoff.
+        """
+        with patch("agent.context_compressor.get_model_context_length", return_value=1_000_000):
+            c = ContextCompressor(
+                model="test/model",
+                threshold_percent=0.50,
+                summary_target_ratio=0.10,
+                protect_first_n=2,
+                protect_last_n=20,
+                quiet_mode=True,
+            )
+
+        messages = []
+        for i in range(120):
+            role = "user" if i % 2 == 0 else "assistant"
+            messages.append({"role": role, "content": f"message {i} " + ("x" * 2000)})
+
+        head_end = c._protect_head_size(messages)
+        normal_cut = c._find_tail_cut_by_tokens(
+            messages,
+            head_end,
+            token_budget=c._tail_token_budget_for_mode(deep=False),
+            protect_last_n=c._protect_last_n_for_mode(deep=False),
+        )
+        deep_cut = c._find_tail_cut_by_tokens(
+            messages,
+            head_end,
+            token_budget=c._tail_token_budget_for_mode(deep=True),
+            protect_last_n=c._protect_last_n_for_mode(deep=True),
+            max_tail_messages=c._max_tail_messages_for_mode(deep=True),
+        )
+
+        normal_tail = len(messages) - normal_cut
+        deep_tail = len(messages) - deep_cut
+
+        assert normal_tail > 60
+        assert deep_tail < normal_tail // 2
+        assert deep_tail <= 8
+        assert deep_tail >= 3
+
     def test_min_tail_always_3_messages(self, budget_compressor):
         """Even with a tiny token budget, at least 3 messages are protected."""
         c = budget_compressor

--- a/tests/gateway/test_compress_focus.py
+++ b/tests/gateway/test_compress_focus.py
@@ -112,3 +112,32 @@ async def test_compress_no_focus_passes_none():
 
     # No focus line in response
     assert "Focus:" not in result
+
+
+@pytest.mark.asyncio
+async def test_archive_passes_deep_mode_to_agent():
+    """The /archive command should request archive-style deep compression."""
+    history = _make_history()
+    compressed = [history[0], history[-1]]
+    runner = _make_runner(history)
+    agent_instance = MagicMock()
+    agent_instance.context_compressor.has_content_to_compress.return_value = True
+    agent_instance.session_id = "sess-1"
+    agent_instance._compress_context.return_value = (compressed, "")
+
+    with (
+        patch("gateway.run._resolve_runtime_agent_kwargs", return_value={"api_key": "***"}),
+        patch("gateway.run._resolve_gateway_model", return_value="test-model"),
+        patch("run_agent.AIAgent", return_value=agent_instance),
+        patch("agent.model_metadata.estimate_messages_tokens_rough", return_value=100),
+    ):
+        result = await runner._handle_compress_command(_make_event("/archive recovery context"))
+
+    agent_instance.context_compressor.has_content_to_compress.assert_called_once_with(
+        history, deep=True
+    )
+    agent_instance._compress_context.assert_called_once()
+    call_kwargs = agent_instance._compress_context.call_args
+    assert call_kwargs.kwargs.get("focus_topic") == "recovery context"
+    assert call_kwargs.kwargs.get("deep") is True
+    assert result.startswith("🗜️ Archive:")

--- a/tests/gateway/test_session_hygiene.py
+++ b/tests/gateway/test_session_hygiene.py
@@ -852,3 +852,105 @@ async def test_session_hygiene_default_hard_message_limit_does_not_fire_at_12_me
     assert FakeCompressAgent.last_instance is None, (
         "Compression should NOT fire at 12 messages with default hard_limit=400"
     )
+
+
+@pytest.mark.asyncio
+async def test_session_hygiene_local_session_ignores_message_count_force_limit(
+    monkeypatch, tmp_path
+):
+    """Local/Desktop-style sessions should not compact solely by message count.
+
+    The hard message-count valve exists for unattended chat gateways where
+    transcripts can grow between user-visible agent turns.  For local sessions
+    with visible token pressure, a 1M-context model must not compact at ~100K
+    tokens just because the transcript has many short messages.
+    """
+    fake_dotenv = types.ModuleType("dotenv")
+    fake_dotenv.load_dotenv = lambda *args, **kwargs: None
+    monkeypatch.setitem(sys.modules, "dotenv", fake_dotenv)
+
+    class FakeCompressAgent:
+        last_instance = None
+
+        def __init__(self, **kwargs):
+            type(self).last_instance = self
+            self.session_id = kwargs.get("session_id", "fake-session")
+            self._print_fn = None
+            self.shutdown_memory_provider = MagicMock()
+            self.close = MagicMock()
+
+        def _compress_context(self, messages, *_args, **_kwargs):
+            return ([{"role": "assistant", "content": "compressed"}], None)
+
+    fake_run_agent = types.ModuleType("run_agent")
+    fake_run_agent.AIAgent = FakeCompressAgent
+    monkeypatch.setitem(sys.modules, "run_agent", fake_run_agent)
+
+    gateway_run = importlib.import_module("gateway.run")
+    GatewayRunner = gateway_run.GatewayRunner
+
+    runner = object.__new__(GatewayRunner)
+    runner.config = GatewayConfig(platforms={})
+    runner.adapters = {}
+    runner._voice_mode = {}
+    runner.hooks = SimpleNamespace(emit=AsyncMock(), loaded_hooks=False)
+    runner.session_store = MagicMock()
+    runner.session_store.get_or_create_session.return_value = SessionEntry(
+        session_key="agent:main:local:dm",
+        session_id="sess-local",
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+        platform=Platform.LOCAL,
+        chat_type="dm",
+    )
+    # Over the default hard limit of 400, but far below the 850K hygiene
+    # token threshold for a 1M model.
+    runner.session_store.load_transcript.return_value = _make_history(
+        450, content_size=40
+    )
+    runner.session_store.has_any_sessions.return_value = True
+    runner.session_store.rewrite_transcript = MagicMock()
+    runner.session_store.append_to_transcript = MagicMock()
+    runner._running_agents = {}
+    runner._pending_messages = {}
+    runner._pending_approvals = {}
+    runner._session_db = None
+    runner._is_user_authorized = lambda _source: True
+    runner._set_session_env = lambda _context: None
+    runner._run_agent = AsyncMock(
+        return_value={
+            "final_response": "ok",
+            "messages": [],
+            "tools": [],
+            "history_offset": 0,
+            "last_prompt_tokens": 0,
+        }
+    )
+
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.setattr(
+        gateway_run, "_resolve_runtime_agent_kwargs", lambda: {"api_key": "fake"}
+    )
+    monkeypatch.setattr(
+        "agent.model_metadata.get_model_context_length",
+        lambda *_args, **_kwargs: 1_000_000,
+    )
+
+    event = MessageEvent(
+        text="hello",
+        source=SessionSource(
+            platform=Platform.LOCAL,
+            chat_id="cli",
+            chat_type="dm",
+            user_id="local",
+        ),
+        message_id="1",
+    )
+
+    result = await runner._handle_message(event)
+
+    assert result == "ok"
+    assert FakeCompressAgent.last_instance is None, (
+        "Local sessions should not compact solely because message count "
+        "exceeds compression.hygiene_hard_message_limit"
+    )

--- a/tests/run_agent/test_compression_boundary_hook.py
+++ b/tests/run_agent/test_compression_boundary_hook.py
@@ -135,7 +135,7 @@ class TestCompressionBoundaryHook:
             f"got {comp_calls!r}"
         )
 
-    def test_todo_snapshot_is_preserved_as_system_note(self):
+    def test_todo_snapshot_is_preserved_as_assistant_compaction_note(self):
         """Compression keeps todo state visible without faking a user turn."""
         from run_agent import AIAgent
 
@@ -167,7 +167,7 @@ class TestCompressionBoundaryHook:
             [{"role": "user", "content": "m"}], "sys", approx_tokens=100
         )
 
-        assert compressed[-1]["role"] == "system"
+        assert compressed[-1]["role"] == "assistant"
         assert "active task list" in compressed[-1]["content"]
 
     def test_hook_failure_does_not_break_compression(self):

--- a/tests/run_agent/test_compression_boundary_hook.py
+++ b/tests/run_agent/test_compression_boundary_hook.py
@@ -127,6 +127,41 @@ class TestCompressionBoundaryHook:
             f"got {comp_calls!r}"
         )
 
+    def test_todo_snapshot_is_preserved_as_system_note(self):
+        """Compression keeps todo state visible without faking a user turn."""
+        from run_agent import AIAgent
+
+        with patch.dict(os.environ, {"OPENROUTER_API_KEY": "test-key"}):
+            agent = AIAgent(
+                api_key="test-key",
+                base_url="https://openrouter.ai/api/v1",
+                model="test/model",
+                quiet_mode=True,
+                session_db=None,
+                session_id="original-session",
+                skip_context_files=True,
+                skip_memory=True,
+            )
+
+        compressor = MagicMock()
+        compressor.compress.return_value = [{"role": "user", "content": "compressed summary"}]
+        compressor.compression_count = 1
+        compressor.last_prompt_tokens = 0
+        compressor.last_completion_tokens = 0
+        compressor._last_summary_error = None
+        compressor._last_compress_aborted = False
+        agent.context_compressor = compressor
+        agent._todo_store.format_for_injection = MagicMock(
+            return_value="[Your active task list was preserved across context compression]\n- [ ] Next"
+        )
+
+        compressed, _prompt = agent._compress_context(
+            [{"role": "user", "content": "m"}], "sys", approx_tokens=100
+        )
+
+        assert compressed[-1]["role"] == "system"
+        assert "active task list" in compressed[-1]["content"]
+
     def test_hook_failure_does_not_break_compression(self):
         """If the context engine raises from on_session_start, compression still completes."""
         from hermes_state import SessionDB

--- a/tests/run_agent/test_compression_boundary_hook.py
+++ b/tests/run_agent/test_compression_boundary_hook.py
@@ -17,6 +17,11 @@ from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 
+def _close_session_db(db):
+    close = getattr(db, "close", None)
+    if callable(close):
+        close()
+
 
 class TestCompressionBoundaryHook:
     def _make_agent(self, session_db):
@@ -38,57 +43,60 @@ class TestCompressionBoundaryHook:
 
         with tempfile.TemporaryDirectory() as tmpdir:
             db = SessionDB(db_path=Path(tmpdir) / "test.db")
-            agent = self._make_agent(db)
+            try:
+                agent = self._make_agent(db)
 
-            # Stub the context compressor: we only need to observe the hook.
-            compressor = MagicMock()
-            compressor.compress.return_value = [
-                {"role": "user", "content": "[CONTEXT COMPACTION] summary"},
-                {"role": "user", "content": "tail question"},
-            ]
-            compressor.compression_count = 1
-            compressor.last_prompt_tokens = 0
-            compressor.last_completion_tokens = 0
-            # Avoid the summary-error warning path
-            compressor._last_summary_error = None
-            # MagicMock auto-creates truthy attrs; explicitly clear the abort
-            # flag so the post-compress abort branch in
-            # conversation_compression.py does not short-circuit before the
-            # session-id rotation we are asserting on.
-            compressor._last_compress_aborted = False
-            agent.context_compressor = compressor
+                # Stub the context compressor: we only need to observe the hook.
+                compressor = MagicMock()
+                compressor.compress.return_value = [
+                    {"role": "user", "content": "[CONTEXT COMPACTION] summary"},
+                    {"role": "user", "content": "tail question"},
+                ]
+                compressor.compression_count = 1
+                compressor.last_prompt_tokens = 0
+                compressor.last_completion_tokens = 0
+                # Avoid the summary-error warning path
+                compressor._last_summary_error = None
+                # MagicMock auto-creates truthy attrs; explicitly clear the abort
+                # flag so the post-compress abort branch in
+                # conversation_compression.py does not short-circuit before the
+                # session-id rotation we are asserting on.
+                compressor._last_compress_aborted = False
+                agent.context_compressor = compressor
 
-            original_sid = agent.session_id
-            messages = [
-                {"role": "user", "content": f"m{i}"} for i in range(10)
-            ]
+                original_sid = agent.session_id
+                messages = [
+                    {"role": "user", "content": f"m{i}"} for i in range(10)
+                ]
 
-            agent._compress_context(messages, "sys", approx_tokens=10_000)
+                agent._compress_context(messages, "sys", approx_tokens=10_000)
 
-            # Session_id rotated
-            assert agent.session_id != original_sid, \
-                "compression should rotate session_id when session_db is set"
+                # Session_id rotated
+                assert agent.session_id != original_sid, \
+                    "compression should rotate session_id when session_db is set"
 
-            # Hook fired with boundary_reason="compression" and old_session_id
-            calls = [
-                c for c in compressor.on_session_start.call_args_list
-            ]
-            assert calls, "on_session_start was never called on the context engine"
-            # Find the compression boundary call (there may be others from init)
-            comp_calls = [
-                c for c in calls
-                if c.kwargs.get("boundary_reason") == "compression"
-            ]
-            assert comp_calls, (
-                f"Expected an on_session_start call with "
-                f"boundary_reason='compression', got {calls!r}"
-            )
-            call = comp_calls[-1]
-            # Positional new session_id
-            assert call.args and call.args[0] == agent.session_id, \
-                f"Expected new session_id as first positional arg, got {call!r}"
-            assert call.kwargs.get("old_session_id") == original_sid, \
-                f"Expected old_session_id={original_sid!r}, got {call.kwargs!r}"
+                # Hook fired with boundary_reason="compression" and old_session_id
+                calls = [
+                    c for c in compressor.on_session_start.call_args_list
+                ]
+                assert calls, "on_session_start was never called on the context engine"
+                # Find the compression boundary call (there may be others from init)
+                comp_calls = [
+                    c for c in calls
+                    if c.kwargs.get("boundary_reason") == "compression"
+                ]
+                assert comp_calls, (
+                    f"Expected an on_session_start call with "
+                    f"boundary_reason='compression', got {calls!r}"
+                )
+                call = comp_calls[-1]
+                # Positional new session_id
+                assert call.args and call.args[0] == agent.session_id, \
+                    f"Expected new session_id as first positional arg, got {call!r}"
+                assert call.kwargs.get("old_session_id") == original_sid, \
+                    f"Expected old_session_id={original_sid!r}, got {call.kwargs!r}"
+            finally:
+                _close_session_db(db)
 
     def test_no_hook_when_no_session_db(self):
         """Without session_db, session_id does not rotate and the hook is not fired."""
@@ -168,32 +176,35 @@ class TestCompressionBoundaryHook:
 
         with tempfile.TemporaryDirectory() as tmpdir:
             db = SessionDB(db_path=Path(tmpdir) / "test.db")
-            agent = self._make_agent(db)
+            try:
+                agent = self._make_agent(db)
 
-            compressor = MagicMock()
-            compressor.compress.return_value = [{"role": "user", "content": "summary"}]
-            compressor.compression_count = 1
-            compressor.last_prompt_tokens = 0
-            compressor.last_completion_tokens = 0
-            compressor._last_summary_error = None
-            compressor._last_compress_aborted = False
+                compressor = MagicMock()
+                compressor.compress.return_value = [{"role": "user", "content": "summary"}]
+                compressor.compression_count = 1
+                compressor.last_prompt_tokens = 0
+                compressor.last_completion_tokens = 0
+                compressor._last_summary_error = None
+                compressor._last_compress_aborted = False
 
-            # Raise only on the compression-boundary call, not on earlier calls.
-            def _raise_on_compression(*args, **kwargs):
-                if kwargs.get("boundary_reason") == "compression":
-                    raise RuntimeError("plugin exploded")
-                return None
-            compressor.on_session_start.side_effect = _raise_on_compression
-            agent.context_compressor = compressor
+                # Raise only on the compression-boundary call, not on earlier calls.
+                def _raise_on_compression(*args, **kwargs):
+                    if kwargs.get("boundary_reason") == "compression":
+                        raise RuntimeError("plugin exploded")
+                    return None
+                compressor.on_session_start.side_effect = _raise_on_compression
+                agent.context_compressor = compressor
 
-            original_sid = agent.session_id
+                original_sid = agent.session_id
 
-            # Must not raise
-            compressed, _prompt = agent._compress_context(
-                [{"role": "user", "content": "m"}], "sys", approx_tokens=100
-            )
-            assert compressed
-            assert agent.session_id != original_sid
+                # Must not raise
+                compressed, _prompt = agent._compress_context(
+                    [{"role": "user", "content": "m"}], "sys", approx_tokens=100
+                )
+                assert compressed
+                assert agent.session_id != original_sid
+            finally:
+                _close_session_db(db)
 
 
 class TestSessionCompressEvent:
@@ -233,24 +244,27 @@ class TestSessionCompressEvent:
         events = []
         with tempfile.TemporaryDirectory() as tmpdir:
             db = SessionDB(db_path=Path(tmpdir) / "test.db")
-            agent = self._make_agent(
-                db, event_callback=lambda et, ctx: events.append((et, ctx))
-            )
-            original_sid = agent.session_id
-            agent.context_compressor = self._stub_compressor()
+            try:
+                agent = self._make_agent(
+                    db, event_callback=lambda et, ctx: events.append((et, ctx))
+                )
+                original_sid = agent.session_id
+                agent.context_compressor = self._stub_compressor()
 
-            agent._compress_context(
-                [{"role": "user", "content": f"m{i}"} for i in range(10)],
-                "sys",
-                approx_tokens=10_000,
-            )
+                agent._compress_context(
+                    [{"role": "user", "content": f"m{i}"} for i in range(10)],
+                    "sys",
+                    approx_tokens=10_000,
+                )
 
-            compress_events = [e for e in events if e[0] == "session:compress"]
-            assert compress_events, f"session:compress not emitted, got {events!r}"
-            _, ctx = compress_events[-1]
-            assert ctx["session_id"] == agent.session_id
-            assert ctx["old_session_id"] == original_sid
-            assert ctx["compression_count"] == 1
+                compress_events = [e for e in events if e[0] == "session:compress"]
+                assert compress_events, f"session:compress not emitted, got {events!r}"
+                _, ctx = compress_events[-1]
+                assert ctx["session_id"] == agent.session_id
+                assert ctx["old_session_id"] == original_sid
+                assert ctx["compression_count"] == 1
+            finally:
+                _close_session_db(db)
 
     def test_no_callback_is_safe(self):
         """Compression must work when no event_callback is wired."""
@@ -258,12 +272,15 @@ class TestSessionCompressEvent:
 
         with tempfile.TemporaryDirectory() as tmpdir:
             db = SessionDB(db_path=Path(tmpdir) / "test.db")
-            agent = self._make_agent(db, event_callback=None)
-            agent.context_compressor = self._stub_compressor()
-            compressed, _ = agent._compress_context(
-                [{"role": "user", "content": "m"}], "sys", approx_tokens=100
-            )
-            assert compressed
+            try:
+                agent = self._make_agent(db, event_callback=None)
+                agent.context_compressor = self._stub_compressor()
+                compressed, _ = agent._compress_context(
+                    [{"role": "user", "content": "m"}], "sys", approx_tokens=100
+                )
+                assert compressed
+            finally:
+                _close_session_db(db)
 
     def test_callback_exception_does_not_break_compression(self):
         from hermes_state import SessionDB
@@ -273,12 +290,15 @@ class TestSessionCompressEvent:
 
         with tempfile.TemporaryDirectory() as tmpdir:
             db = SessionDB(db_path=Path(tmpdir) / "test.db")
-            agent = self._make_agent(db, event_callback=_boom)
-            original_sid = agent.session_id
-            agent.context_compressor = self._stub_compressor()
+            try:
+                agent = self._make_agent(db, event_callback=_boom)
+                original_sid = agent.session_id
+                agent.context_compressor = self._stub_compressor()
 
-            compressed, _ = agent._compress_context(
-                [{"role": "user", "content": "m"}], "sys", approx_tokens=100
-            )
-            assert compressed
-            assert agent.session_id != original_sid
+                compressed, _ = agent._compress_context(
+                    [{"role": "user", "content": "m"}], "sys", approx_tokens=100
+                )
+                assert compressed
+                assert agent.session_id != original_sid
+            finally:
+                _close_session_db(db)

--- a/tests/test_cli_manual_compress.py
+++ b/tests/test_cli_manual_compress.py
@@ -10,7 +10,7 @@ class DummyAgent:
         self.session_id = "new-session"
         self.calls = []
 
-    def _compress_context(self, messages, system_message, *, approx_tokens=None, focus_topic=None, force=False):
+    def _compress_context(self, messages, system_message, *, approx_tokens=None, focus_topic=None, force=False, deep=False):
         self.calls.append(
             {
                 "messages": messages,
@@ -18,6 +18,7 @@ class DummyAgent:
                 "approx_tokens": approx_tokens,
                 "focus_topic": focus_topic,
                 "force": force,
+                "deep": deep,
             }
         )
         return ([{"role": "user", "content": "[CONTEXT SUMMARY]: compacted"}], "new system prompt")
@@ -54,5 +55,38 @@ def test_manual_compress_does_not_pass_cached_system_prompt(monkeypatch):
     assert call["system_message"] is None
     assert call["system_message"] != cli.agent._cached_system_prompt
     assert call["focus_topic"] == "database schema"
+    assert call["deep"] is False
     assert cli.session_id == "new-session"
     assert cli._pending_title is None
+
+
+def test_manual_archive_passes_deep_mode(monkeypatch):
+    """The /archive alias should use archive-style deep compression."""
+    cli = HermesCLI.__new__(HermesCLI)
+    cli.conversation_history = [
+        {"role": "user", "content": "one"},
+        {"role": "assistant", "content": "two"},
+        {"role": "user", "content": "three"},
+        {"role": "assistant", "content": "four"},
+    ]
+    cli.agent = DummyAgent()
+    cli.session_id = "old-session"
+    cli._pending_title = "old title"
+    cli._busy_command = lambda _message: nullcontext()
+
+    monkeypatch.setattr(
+        "agent.manual_compression_feedback.summarize_manual_compression",
+        lambda *args, **kwargs: {
+            "noop": False,
+            "headline": "archived",
+            "token_line": "tokens reduced",
+            "note": "",
+        },
+    )
+
+    cli._manual_compress("/archive recovery context")
+
+    assert len(cli.agent.calls) == 1
+    call = cli.agent.calls[0]
+    assert call["focus_topic"] == "recovery context"
+    assert call["deep"] is True

--- a/tools/fuzzy_match.py
+++ b/tools/fuzzy_match.py
@@ -610,36 +610,50 @@ def _strategy_block_anchor(content: str, pattern: str) -> List[Tuple[int, int]]:
 
 def _strategy_context_aware(content: str, pattern: str) -> List[Tuple[int, int]]:
     """
-    Strategy 9: Line-by-line similarity with 50% threshold.
-    
-    Finds blocks where at least 50% of lines have high similarity.
+    Strategy 9: Line-by-line similarity with adaptive threshold.
+
+    Finds blocks where a sufficient fraction of lines have high similarity.
+    The threshold scales with pattern length — short patterns (≤5 lines)
+    require ≥70% line similarity to avoid false-matching unrelated code;
+    medium patterns (6-15 lines) use ≥60%; long patterns (>15 lines)
+    stay at 50% because larger blocks naturally have more noise.
     """
     pattern_lines = pattern.split('\n')
     content_lines = content.split('\n')
-    
+
     if not pattern_lines:
         return []
-    
+
+    # Adaptive threshold: shorter patterns need a higher bar to avoid
+    # false positives on unrelated code with similar variable names.
+    n = len(pattern_lines)
+    if n <= 5:
+        threshold = 0.70
+    elif n <= 15:
+        threshold = 0.60
+    else:
+        threshold = 0.50
+
     matches = []
     pattern_line_count = len(pattern_lines)
-    
+
     for i in range(len(content_lines) - pattern_line_count + 1):
         block_lines = content_lines[i:i + pattern_line_count]
-        
+
         # Calculate line-by-line similarity
         high_similarity_count = 0
         for p_line, c_line in zip(pattern_lines, block_lines):
             sim = SequenceMatcher(None, p_line.strip(), c_line.strip()).ratio()
             if sim >= 0.80:
                 high_similarity_count += 1
-        
-        # Need at least 50% of lines to have high similarity
-        if high_similarity_count >= len(pattern_lines) * 0.5:
+
+        # Need at least threshold% of lines to have high similarity
+        if high_similarity_count >= len(pattern_lines) * threshold:
             start_pos, end_pos = _calculate_line_positions(
                 content_lines, i, i + pattern_line_count, len(content)
             )
             matches.append((start_pos, end_pos))
-    
+
     return matches
 
 

--- a/tools/fuzzy_match.py
+++ b/tools/fuzzy_match.py
@@ -20,7 +20,7 @@ Multi-occurrence matching is handled via the replace_all flag.
 
 Usage:
     from tools.fuzzy_match import fuzzy_find_and_replace
-    
+
     new_content, match_count, strategy, error = fuzzy_find_and_replace(
         content="def foo():\\n    pass",
         old_string="def foo():",
@@ -356,16 +356,16 @@ def _strategy_exact(content: str, pattern: str) -> List[Tuple[int, int]]:
 def _strategy_line_trimmed(content: str, pattern: str) -> List[Tuple[int, int]]:
     """
     Strategy 2: Match with line-by-line whitespace trimming.
-    
+
     Strips leading/trailing whitespace from each line before matching.
     """
     # Normalize pattern and content by trimming each line
     pattern_lines = [line.strip() for line in pattern.split('\n')]
     pattern_normalized = '\n'.join(pattern_lines)
-    
+
     content_lines = content.split('\n')
     content_normalized_lines = [line.strip() for line in content_lines]
-    
+
     # Build mapping from normalized positions back to original positions
     return _find_normalized_matches(
         content, content_lines, content_normalized_lines,
@@ -380,16 +380,16 @@ def _strategy_whitespace_normalized(content: str, pattern: str) -> List[Tuple[in
     def normalize(s):
         # Collapse multiple spaces/tabs to single space, preserve newlines
         return re.sub(r'[ \t]+', ' ', s)
-    
+
     pattern_normalized = normalize(pattern)
     content_normalized = normalize(content)
-    
+
     # Find in normalized, map back to original
     matches_in_normalized = _strategy_exact(content_normalized, pattern_normalized)
-    
+
     if not matches_in_normalized:
         return []
-    
+
     # Map positions back to original content
     return _map_normalized_positions(content, content_normalized, matches_in_normalized)
 
@@ -397,13 +397,13 @@ def _strategy_whitespace_normalized(content: str, pattern: str) -> List[Tuple[in
 def _strategy_indentation_flexible(content: str, pattern: str) -> List[Tuple[int, int]]:
     """
     Strategy 4: Ignore indentation differences entirely.
-    
+
     Strips all leading whitespace from lines before matching.
     """
     content_lines = content.split('\n')
     content_stripped_lines = [line.lstrip() for line in content_lines]
     pattern_lines = [line.lstrip() for line in pattern.split('\n')]
-    
+
     return _find_normalized_matches(
         content, content_lines, content_stripped_lines,
         pattern, '\n'.join(pattern_lines)
@@ -413,61 +413,61 @@ def _strategy_indentation_flexible(content: str, pattern: str) -> List[Tuple[int
 def _strategy_escape_normalized(content: str, pattern: str) -> List[Tuple[int, int]]:
     """
     Strategy 5: Convert escape sequences to actual characters.
-    
+
     Handles \\n -> newline, \\t -> tab, etc.
     """
     def unescape(s):
         # Convert common escape sequences
         return s.replace('\\n', '\n').replace('\\t', '\t').replace('\\r', '\r')
-    
+
     pattern_unescaped = unescape(pattern)
-    
+
     if pattern_unescaped == pattern:
         # No escapes to convert, skip this strategy
         return []
-    
+
     return _strategy_exact(content, pattern_unescaped)
 
 
 def _strategy_trimmed_boundary(content: str, pattern: str) -> List[Tuple[int, int]]:
     """
     Strategy 6: Trim whitespace from first and last lines only.
-    
+
     Useful when the pattern boundaries have whitespace differences.
     """
     pattern_lines = pattern.split('\n')
     if not pattern_lines:
         return []
-    
+
     # Trim only first and last lines
     pattern_lines[0] = pattern_lines[0].strip()
     if len(pattern_lines) > 1:
         pattern_lines[-1] = pattern_lines[-1].strip()
-    
+
     modified_pattern = '\n'.join(pattern_lines)
-    
+
     content_lines = content.split('\n')
-    
+
     # Search through content for matching block
     matches = []
     pattern_line_count = len(pattern_lines)
-    
+
     for i in range(len(content_lines) - pattern_line_count + 1):
         block_lines = content_lines[i:i + pattern_line_count]
-        
+
         # Trim first and last of this block
         check_lines = block_lines.copy()
         check_lines[0] = check_lines[0].strip()
         if len(check_lines) > 1:
             check_lines[-1] = check_lines[-1].strip()
-        
+
         if '\n'.join(check_lines) == modified_pattern:
             # Found match - calculate original positions
             start_pos, end_pos = _calculate_line_positions(
                 content_lines, i, i + pattern_line_count, len(content)
             )
             matches.append((start_pos, end_pos))
-    
+
     return matches
 
 
@@ -560,30 +560,30 @@ def _strategy_block_anchor(content: str, pattern: str) -> List[Tuple[int, int]]:
     # Normalize both strings for comparison while keeping original content for offset calculation
     norm_pattern = _unicode_normalize(pattern)
     norm_content = _unicode_normalize(content)
-    
+
     pattern_lines = norm_pattern.split('\n')
     if len(pattern_lines) < 2:
         return []
-    
+
     first_line = pattern_lines[0].strip()
     last_line = pattern_lines[-1].strip()
-    
+
     # Use normalized lines for matching logic
     norm_content_lines = norm_content.split('\n')
     # BUT use original lines for calculating start/end positions to prevent index shift
     orig_content_lines = content.split('\n')
-    
+
     pattern_line_count = len(pattern_lines)
-    
+
     potential_matches = []
     for i in range(len(norm_content_lines) - pattern_line_count + 1):
-        if (norm_content_lines[i].strip() == first_line and 
+        if (norm_content_lines[i].strip() == first_line and
             norm_content_lines[i + pattern_line_count - 1].strip() == last_line):
             potential_matches.append(i)
-            
+
     matches = []
     candidate_count = len(potential_matches)
-    
+
     # Thresholding logic: 0.50 for unique matches, 0.70 for multiple candidates.
     # Previous values (0.10 / 0.30) were dangerously loose — a 10% middle-section
     # similarity could match completely unrelated blocks.
@@ -597,14 +597,14 @@ def _strategy_block_anchor(content: str, pattern: str) -> List[Tuple[int, int]]:
             content_middle = '\n'.join(norm_content_lines[i+1:i+pattern_line_count-1])
             pattern_middle = '\n'.join(pattern_lines[1:-1])
             similarity = SequenceMatcher(None, content_middle, pattern_middle).ratio()
-        
+
         if similarity >= threshold:
             # Calculate positions using ORIGINAL lines to ensure correct character offsets in the file
             start_pos, end_pos = _calculate_line_positions(
                 orig_content_lines, i, i + pattern_line_count, len(content)
             )
             matches.append((start_pos, end_pos))
-    
+
     return matches
 
 
@@ -685,33 +685,33 @@ def _find_normalized_matches(content: str, content_lines: List[str],
                               pattern: str, pattern_normalized: str) -> List[Tuple[int, int]]:
     """
     Find matches in normalized content and map back to original positions.
-    
+
     Args:
         content: Original content string
         content_lines: Original content split by lines
         content_normalized_lines: Normalized content lines
         pattern: Original pattern
         pattern_normalized: Normalized pattern
-    
+
     Returns:
         List of (start, end) positions in the original content
     """
     pattern_norm_lines = pattern_normalized.split('\n')
     num_pattern_lines = len(pattern_norm_lines)
-    
+
     matches = []
-    
+
     for i in range(len(content_normalized_lines) - num_pattern_lines + 1):
         # Check if this block matches
         block = '\n'.join(content_normalized_lines[i:i + num_pattern_lines])
-        
+
         if block == pattern_normalized:
             # Found a match - calculate original positions
             start_pos, end_pos = _calculate_line_positions(
                 content_lines, i, i + num_pattern_lines, len(content)
             )
             matches.append((start_pos, end_pos))
-    
+
     return matches
 
 
@@ -719,18 +719,18 @@ def _map_normalized_positions(original: str, normalized: str,
                                normalized_matches: List[Tuple[int, int]]) -> List[Tuple[int, int]]:
     """
     Map positions from normalized string back to original.
-    
+
     This is a best-effort mapping that works for whitespace normalization.
     """
     if not normalized_matches:
         return []
-    
+
     # Build character mapping from normalized to original
     orig_to_norm = []  # orig_to_norm[i] = position in normalized
-    
+
     orig_idx = 0
     norm_idx = 0
-    
+
     while orig_idx < len(original) and norm_idx < len(normalized):
         if original[orig_idx] == normalized[norm_idx]:
             orig_to_norm.append(norm_idx)
@@ -751,21 +751,21 @@ def _map_normalized_positions(original: str, normalized: str,
             # Mismatch - shouldn't happen with our normalization
             orig_to_norm.append(norm_idx)
             orig_idx += 1
-    
+
     # Fill remaining
     while orig_idx < len(original):
         orig_to_norm.append(len(normalized))
         orig_idx += 1
-    
+
     # Reverse mapping: for each normalized position, find original range
     norm_to_orig_start = {}
     norm_to_orig_end = {}
-    
+
     for orig_pos, norm_pos in enumerate(orig_to_norm):
         if norm_pos not in norm_to_orig_start:
             norm_to_orig_start[norm_pos] = orig_pos
         norm_to_orig_end[norm_pos] = orig_pos
-    
+
     # Map matches
     original_matches = []
     for norm_start, norm_end in normalized_matches:
@@ -775,19 +775,19 @@ def _map_normalized_positions(original: str, normalized: str,
         else:
             # Find nearest
             orig_start = min(i for i, n in enumerate(orig_to_norm) if n >= norm_start)
-        
+
         # Find original end
         if norm_end - 1 in norm_to_orig_end:
             orig_end = norm_to_orig_end[norm_end - 1] + 1
         else:
             orig_end = orig_start + (norm_end - norm_start)
-        
+
         # Expand to include trailing whitespace that was normalized
         while orig_end < len(original) and original[orig_end] in ' \t':
             orig_end += 1
-        
+
         original_matches.append((orig_start, min(orig_end, len(original))))
-    
+
     return original_matches
 
 

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -2317,6 +2317,7 @@ def _compress_session_history(
     approx_tokens: int | None = None,
     before_messages: list | None = None,
     history_version: int | None = None,
+    deep: bool = False,
 ) -> tuple[int, dict]:
     from agent.model_metadata import estimate_request_tokens_rough
 
@@ -2351,6 +2352,7 @@ def _compress_session_history(
         None,
         approx_tokens=approx_tokens,
         focus_topic=focus_topic or None,
+        deep=deep,
     )
     with session["history_lock"]:
         if int(session.get("history_version", 0)) != history_version:
@@ -5546,6 +5548,7 @@ def _(rid, params: dict) -> dict:
         )
     sid = params.get("session_id", "")
     focus_topic = str(params.get("focus_topic", "") or "").strip()
+    deep = bool(params.get("deep", False))
     try:
         from agent.manual_compression_feedback import summarize_manual_compression
         from agent.model_metadata import estimate_request_tokens_rough
@@ -5566,11 +5569,12 @@ def _(rid, params: dict) -> dict:
         )
 
         if before_count >= 4:
+            mode_prefix = "archiving" if deep else "compressing"
             focus_suffix = f', focus: "{focus_topic}"' if focus_topic else ""
             _status_update(
                 sid,
                 "compressing",
-                f"⠋ compressing {before_count} messages "
+                f"⠋ {mode_prefix} {before_count} messages "
                 f"(~{before_tokens:,} tok){focus_suffix}…",
             )
 
@@ -5581,6 +5585,7 @@ def _(rid, params: dict) -> dict:
                 approx_tokens=before_tokens,
                 before_messages=before_messages,
                 history_version=history_version,
+                deep=deep,
             )
             with session["history_lock"]:
                 messages = list(session.get("history", []))


### PR DESCRIPTION
## Summary

This PR wires Desktop session compression through the gateway/runtime path and tightens the resulting session handoff behavior.

It covers:

- desktop `/compress` handling through the gateway
- cooldown protection against duplicate compression requests
- regular and archive/deep compression modes with hard tail caps
- preserving recent user turns in the post-compression tail
- hydrating the compressed transcript back into Desktop session state
- preserving active todos as an assistant compaction note
- avoiding local hygiene compaction based only on raw message count

## Why

Compression currently touches several layers: Desktop actions, gateway session routing, runtime session rotation, stored transcripts, and context hygiene. This keeps those pieces aligned so a compressed session resumes with the expected transcript shape and bounded context, instead of leaving old messages visible or carrying task state as a new user turn.

## Validation

- `npm run typecheck`
- `.venv\Scripts\python.exe -m py_compile agent\context_compressor.py agent\context_engine.py agent\conversation_compression.py gateway\run.py gateway\slash_commands.py tui_gateway\server.py cli.py run_agent.py tools\fuzzy_match.py`
- `.venv\Scripts\python.exe -m pytest tests/agent/test_context_compressor.py tests/gateway/test_compress_focus.py tests/gateway/test_session_hygiene.py tests/run_agent/test_compression_boundary_hook.py tests/test_cli_manual_compress.py -q` (`136 passed`)
- `git diff --check origin/main..HEAD`