### PR TITLE
Fix launchd gateway status detection

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -129,22 +129,15 @@ def _get_service_pids() -> set:
         try:
             label = get_launchd_label()
             result = subprocess.run(
-                ["launchctl", "list", label],
+                ["launchctl", "print", _launchd_target(label)],
                 capture_output=True,
                 text=True,
                 timeout=5,
             )
             if result.returncode == 0:
-                # Output: "PID\tStatus\tLabel" header, then one data line
-                for line in result.stdout.strip().splitlines():
-                    parts = line.split()
-                    if len(parts) >= 3 and parts[2] == label:
-                        try:
-                            pid = int(parts[0])
-                            if pid > 0:
-                                pids.add(pid)
-                        except ValueError:
-                            pass
+                pid = _parse_launchd_print_pid(result.stdout)
+                if pid is not None and pid > 0:
+                    pids.add(pid)
         except (FileNotFoundError, subprocess.TimeoutExpired):
             pass
 
@@ -1069,14 +1062,19 @@ def _probe_launchd_service_running() -> bool:
         return False
     try:
         result = subprocess.run(
-            ["launchctl", "list", get_launchd_label()],
+            ["launchctl", "print", _launchd_target()],
             capture_output=True,
             text=True,
             timeout=10,
         )
     except subprocess.TimeoutExpired:
         return False
-    return result.returncode == 0
+    if result.returncode != 0:
+        return False
+    return (
+        _parse_launchd_print_pid(result.stdout) is not None
+        or "state = running" in result.stdout
+    )
 
 
 def get_gateway_runtime_snapshot(system: bool = False) -> GatewayRuntimeSnapshot:
@@ -3340,6 +3338,22 @@ def _launchd_fallback_to_detached(reason: str, *, exit_on_failure: bool = True) 
     return False
 
 
+def _launchd_target(label: str | None = None) -> str:
+    return f"{_launchd_domain()}/{label or get_launchd_label()}"
+
+
+def _parse_launchd_print_pid(output: str) -> int | None:
+    for line in output.splitlines():
+        stripped = line.strip()
+        if not stripped.startswith("pid = "):
+            continue
+        try:
+            return int(stripped.split("=", 1)[1].strip())
+        except ValueError:
+            return None
+    return None
+
+
 def generate_launchd_plist() -> str:
     python_path = get_python_path()
     # Stable cwd anchor — never the volatile source checkout. See
@@ -3742,10 +3756,9 @@ def launchd_restart():
 
 def launchd_status(deep: bool = False):
     plist_path = get_launchd_plist_path()
-    label = get_launchd_label()
     try:
         result = subprocess.run(
-            ["launchctl", "list", label],
+            ["launchctl", "print", _launchd_target()],
             capture_output=True,
             text=True,
             timeout=10,

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -1080,6 +1080,53 @@ class TestLaunchdDomainDetection:
         assert run_count[0] == 1  # Only probed once
 
 
+class TestLaunchdPrintStatus:
+    def test_parse_launchd_print_pid(self):
+        output = """
+        gui/501/ai.hermes.gateway = {
+            state = running
+            pid = 4242
+        }
+        """
+
+        assert gateway_cli._parse_launchd_print_pid(output) == 4242
+
+    def test_get_service_pids_reads_launchd_print_pid(self, monkeypatch):
+        monkeypatch.setattr(gateway_cli, "supports_systemd_services", lambda: False)
+        monkeypatch.setattr(gateway_cli, "is_macos", lambda: True)
+        monkeypatch.setattr(gateway_cli, "get_launchd_label", lambda: "ai.hermes.gateway")
+        monkeypatch.setattr(
+            gateway_cli,
+            "_launchd_target",
+            lambda label=None: f"gui/501/{label or 'ai.hermes.gateway'}",
+        )
+
+        calls = []
+
+        def fake_run(cmd, **kwargs):
+            calls.append(cmd)
+            return SimpleNamespace(returncode=0, stdout="state = running\npid = 4242\n", stderr="")
+
+        monkeypatch.setattr(gateway_cli.subprocess, "run", fake_run)
+
+        assert gateway_cli._get_service_pids() == {4242}
+        assert calls == [["launchctl", "print", "gui/501/ai.hermes.gateway"]]
+
+    def test_probe_launchd_service_running_accepts_running_state_without_pid(self, tmp_path, monkeypatch):
+        plist_path = tmp_path / "ai.hermes.gateway.plist"
+        plist_path.write_text("<plist/>", encoding="utf-8")
+
+        monkeypatch.setattr(gateway_cli, "get_launchd_plist_path", lambda: plist_path)
+        monkeypatch.setattr(gateway_cli, "_launchd_target", lambda label=None: "gui/501/ai.hermes.gateway")
+        monkeypatch.setattr(
+            gateway_cli.subprocess,
+            "run",
+            lambda *args, **kwargs: SimpleNamespace(returncode=0, stdout="state = running\n", stderr=""),
+        )
+
+        assert gateway_cli._probe_launchd_service_running() is True
+
+
 class TestGatewayServiceDetection:
     def test_supports_systemd_services_requires_systemctl_binary(self, monkeypatch):
         monkeypatch.setattr(gateway_cli, "is_linux", lambda: True)


### PR DESCRIPTION
## Summary

- use `launchctl print <domain>/<label>` for launchd gateway status and PID detection
- parse `pid = ...` from `launchctl print` output instead of relying on `launchctl list`
- treat `state = running` as a running-service signal when launchd does not report a PID
- add focused launchd regression tests

## Tests

- `venv/bin/python -m pytest tests/hermes_cli/test_gateway_service.py::TestLaunchdPrintStatus -q`
