### PR TITLE
Add cronjob full prompt inspection

### DIFF
--- a/tests/cron/test_cronjob_schema.py
+++ b/tests/cron/test_cronjob_schema.py
@@ -19,6 +19,26 @@ def test_cronjob_schema_action_description_flags_create_requirements():
     assert "REQUIRED" in action_desc
 
 
+def test_cronjob_schema_action_description_mentions_get_before_update():
+    """`action` description should advertise full-prompt inspection."""
+    from tools.cronjob_tools import CRONJOB_SCHEMA
+
+    action_desc = CRONJOB_SCHEMA["parameters"]["properties"]["action"]["description"]
+    job_id_desc = CRONJOB_SCHEMA["parameters"]["properties"]["job_id"]["description"]
+    assert "get" in action_desc
+    assert "full current prompt" in action_desc
+    assert "get" in job_id_desc
+
+
+def test_cronjob_schema_include_prompt_parameter_exists():
+    """List/update callers can request the full prompt when useful."""
+    from tools.cronjob_tools import CRONJOB_SCHEMA
+
+    include_prompt = CRONJOB_SCHEMA["parameters"]["properties"]["include_prompt"]
+    assert include_prompt["type"] == "boolean"
+    assert "full prompt" in include_prompt["description"]
+
+
 def test_cronjob_schema_schedule_description_flags_required_for_create():
     """`schedule` description must explicitly state REQUIRED for action=create."""
     from tools.cronjob_tools import CRONJOB_SCHEMA

--- a/tests/tools/test_cronjob_tools.py
+++ b/tests/tools/test_cronjob_tools.py
@@ -264,6 +264,69 @@ class TestUnifiedCronjobTool:
         assert listing["jobs"][0]["name"] == "Server Check"
         assert listing["jobs"][0]["state"] == "scheduled"
 
+    def test_get_returns_full_existing_job_prompt(self):
+        long_prompt = "Inspect the current job before editing. " * 8
+        created = json.loads(
+            cronjob(
+                action="create",
+                prompt=long_prompt,
+                schedule="every 1h",
+                name="Inspectable",
+            )
+        )
+
+        result = json.loads(cronjob(action="get", job_id=created["job_id"]))
+
+        assert result["success"] is True
+        assert result["job"]["job_id"] == created["job_id"]
+        assert result["job"]["name"] == "Inspectable"
+        assert result["job"]["prompt"] == long_prompt
+        assert result["job"]["prompt_preview"].endswith("...")
+        assert result["job"]["raw_schedule"]["kind"] == "interval"
+        assert result["job"]["repeat_state"]["times"] is None
+
+    def test_show_alias_resolves_by_name(self):
+        created = json.loads(
+            cronjob(
+                action="create",
+                prompt="Full prompt by name",
+                schedule="every 1h",
+                name="named-inspection-job",
+            )
+        )
+
+        result = json.loads(cronjob(action="show", job_id="named-inspection-job"))
+
+        assert result["success"] is True
+        assert result["job"]["job_id"] == created["job_id"]
+        assert result["job"]["prompt"] == "Full prompt by name"
+
+    def test_list_can_optionally_include_full_prompts(self):
+        long_prompt = "A prompt that is long enough to be truncated in preview. " * 5
+        cronjob(action="create", prompt=long_prompt, schedule="every 1h")
+
+        default_listing = json.loads(cronjob(action="list"))
+        full_listing = json.loads(cronjob(action="list", include_prompt=True))
+
+        assert "prompt" not in default_listing["jobs"][0]
+        assert full_listing["jobs"][0]["prompt"] == long_prompt
+
+    def test_update_can_optionally_echo_full_prompt(self):
+        created = json.loads(cronjob(action="create", prompt="old", schedule="every 1h"))
+        new_prompt = "new full prompt"
+
+        result = json.loads(
+            cronjob(
+                action="update",
+                job_id=created["job_id"],
+                prompt=new_prompt,
+                include_prompt=True,
+            )
+        )
+
+        assert result["success"] is True
+        assert result["job"]["prompt"] == new_prompt
+
     def test_list_handles_partial_legacy_job_records(self):
         from cron.jobs import save_jobs
 

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -22,6 +22,7 @@ sys.path.insert(0, str(Path(__file__).parent.parent))
 from cron.jobs import (
     AmbiguousJobReference,
     create_job,
+    get_job,
     list_jobs,
     parse_schedule,
     pause_job,
@@ -425,7 +426,7 @@ def _validate_cron_script_path(script: Optional[str]) -> Optional[str]:
     return None
 
 
-def _format_job(job: Dict[str, Any]) -> Dict[str, Any]:
+def _format_job(job: Dict[str, Any], *, include_prompt: bool = False) -> Dict[str, Any]:
     prompt = str(job.get("prompt") or "")
     skills = _canonical_skills(job.get("skill"), job.get("skills"))
     job_id = str(job.get("id") or "unknown")
@@ -451,6 +452,8 @@ def _format_job(job: Dict[str, Any]) -> Dict[str, Any]:
         "paused_at": job.get("paused_at"),
         "paused_reason": job.get("paused_reason"),
     }
+    if include_prompt:
+        result["prompt"] = prompt
     if job.get("script"):
         result["script"] = job["script"]
     if job.get("no_agent"):
@@ -482,6 +485,7 @@ def cronjob(
     enabled_toolsets: Optional[List[str]] = None,
     workdir: Optional[str] = None,
     no_agent: Optional[bool] = None,
+    include_prompt: bool = False,
     task_id: str = None,
 ) -> str:
     """Unified cron job management tool."""
@@ -567,7 +571,10 @@ def cronjob(
             )
 
         if normalized == "list":
-            jobs = [_format_job(job) for job in list_jobs(include_disabled=include_disabled)]
+            jobs = [
+                _format_job(job, include_prompt=include_prompt)
+                for job in list_jobs(include_disabled=include_disabled)
+            ]
             return json.dumps({"success": True, "count": len(jobs), "jobs": jobs}, indent=2)
 
         if not job_id:
@@ -599,6 +606,21 @@ def cronjob(
             )
         # Resolve to canonical ID (supports name-based lookup)
         job_id = job["id"]
+
+        if normalized in {"get", "show"}:
+            full_job = get_job(job_id) or job
+            formatted = _format_job(full_job, include_prompt=True)
+            formatted.update(
+                {
+                    "raw_schedule": full_job.get("schedule"),
+                    "repeat_state": full_job.get("repeat"),
+                    "origin": full_job.get("origin"),
+                    "context_from": full_job.get("context_from"),
+                    "created_at": full_job.get("created_at"),
+                    "last_error": full_job.get("last_error"),
+                }
+            )
+            return json.dumps({"success": True, "job": formatted}, indent=2)
 
         if normalized == "remove":
             removed = remove_job(job_id)
@@ -711,7 +733,13 @@ def cronjob(
             if not updates:
                 return tool_error("No updates provided.", success=False)
             updated = update_job(job_id, updates)
-            return json.dumps({"success": True, "job": _format_job(updated)}, indent=2)
+            return json.dumps(
+                {
+                    "success": True,
+                    "job": _format_job(updated, include_prompt=include_prompt),
+                },
+                indent=2,
+            )
 
         return tool_error(f"Unknown cron action '{action}'", success=False)
 
@@ -726,7 +754,10 @@ CRONJOB_SCHEMA = {
 
 Use action='create' to schedule a new job from a prompt or one or more skills.
 Use action='list' to inspect jobs.
+Use action='get' with job_id to inspect a full existing job, including the complete prompt.
 Use action='update', 'pause', 'resume', 'remove', or 'run' to manage an existing job.
+
+When changing an existing job, use action='list' if needed to find the job_id, then action='get' to inspect the full current prompt before action='update'. Do not use action='create' for an existing job.
 
 To stop a job the user no longer wants: first action='list' to find the job_id, then action='remove' with that job_id. Never guess job IDs — always list first.
 
@@ -744,11 +775,11 @@ Important safety rule: cron-run sessions should not recursively schedule more cr
         "properties": {
             "action": {
                 "type": "string",
-                "description": "One of: create, list, update, pause, resume, remove, run. When action=create, the 'schedule' and 'prompt' fields are REQUIRED."
+                "description": "One of: create, list, get, update, pause, resume, remove, run. Use get + job_id to read the full current prompt before updating an existing job. When action=create, the 'schedule' and 'prompt' fields are REQUIRED."
             },
             "job_id": {
                 "type": "string",
-                "description": "Required for update/pause/resume/remove/run"
+                "description": "Required for get/update/pause/resume/remove/run"
             },
             "prompt": {
                 "type": "string",
@@ -834,6 +865,11 @@ Important safety rule: cron-run sessions should not recursively schedule more cr
                 "type": "string",
                 "description": "Optional absolute path to run the job from. When set, AGENTS.md / CLAUDE.md / .cursorrules from that directory are injected into the system prompt, and the terminal/file/code_exec tools use it as their working directory — useful for running a job inside a specific project repo. Must be an absolute path that exists. When unset (default), preserves the original behaviour: no project context files, tools use the scheduler's cwd. On update, pass an empty string to clear. Jobs with workdir run sequentially (not parallel) to keep per-job directories isolated."
             },
+            "include_prompt": {
+                "type": "boolean",
+                "default": False,
+                "description": "For list/update responses, include the full prompt instead of only prompt_preview. action=get always includes the full prompt."
+            },
         },
         "required": ["action"]
     }
@@ -889,6 +925,7 @@ registry.register(
         enabled_toolsets=args.get("enabled_toolsets"),
         workdir=args.get("workdir"),
         no_agent=args.get("no_agent"),
+        include_prompt=bool(args.get("include_prompt", False)),
         task_id=kw.get("task_id"),
     ))(),
     check_fn=check_cronjob_requirements,


### PR DESCRIPTION
## Summary

- add `cronjob(action="get")` / `cronjob(action="show")` to inspect a full existing cron job
- include the complete prompt for `get` / `show`
- add optional `include_prompt` support for list/update responses
- update schema guidance so agents inspect an existing job before updating it
- add cron tool and schema regression tests

## Tests

- `venv/bin/python -m pytest tests/cron/test_cronjob_schema.py tests/tools/test_cronjob_tools.py -q`
