### PR TITLE
test(gateway): add missing coverage for config edge cases and delivery paths

### DIFF
--- a/tests/gateway/test_config_edge_cases.py
+++ b/tests/gateway/test_config_edge_cases.py
@@ -1,0 +1,324 @@
+"""Tests for gateway/config.py edge cases and uncovered code paths.
+
+Tests for lines that were not covered:
+- Platform._missing_() method (lines 112-154)
+- Platform._scan_bundled_plugin_platforms() method (lines 157-175)
+- Plugin registry handling in _missing_() (lines 142-152)
+- HomeChannel.to_dict() with thread_id (line 205)
+- get_home_channel() method (lines 480-485)
+- get_reset_policy() method (lines 487-505)
+"""
+
+import pytest
+from unittest.mock import MagicMock, patch
+from pathlib import Path
+
+from gateway.config import (
+    Platform,
+    GatewayConfig,
+    HomeChannel,
+    SessionResetPolicy,
+    _Platform__bundled_plugin_names,
+)
+
+
+class TestPlatformMissingMethod:
+    """Test Platform._missing_() method for dynamic platform creation."""
+
+    def test_missing_empty_string_returns_none(self):
+        """Test that empty string returns None."""
+        result = Platform._missing_("")
+        assert result is None
+
+    def test_missing_non_string_returns_none(self):
+        """Test that non-string values return None."""
+        result = Platform._missing_(123)
+        assert result is None
+
+    def test_missing_whitespace_only_returns_none(self):
+        """Test that whitespace-only strings return None."""
+        result = Platform._missing_("   ")
+        assert result is None
+
+    def test_missing_valid_builtin_platform_returns_member(self):
+        """Test that valid built-in platform names return enum member."""
+        result = Platform._missing_("telegram")
+        assert result is Platform.TELEGRAM
+
+    def test_missing_invalid_platform_returns_none(self):
+        """Test that invalid platform names return None."""
+        result = Platform._missing_("completely_invalid_platform")
+        assert result is None
+
+    def test_missing_cached_platform_returns_same_object(self):
+        """Test that cached builtin platforms return the same object (identity-stable)."""
+        # Use a builtin platform that's guaranteed to be cached
+        result1 = Platform._missing_("telegram")
+        result2 = Platform._missing_("telegram")
+        
+        # Should be the same object (cached)
+        assert result1 is result2
+        assert result1 is Platform.TELEGRAM
+
+class TestPlatformScanBundledPlugins:
+    """Test Platform._scan_bundled_plugin_platforms() method."""
+
+    def test_scan_returns_empty_set_when_no_plugins_dir(self):
+        """Test that scan returns empty set when plugins directory doesn't exist."""
+        with patch("pathlib.Path.is_dir", return_value=False):
+            result = Platform._scan_bundled_plugin_platforms()
+            assert result == set()
+
+    def test_scan_finds_plugin_directories(self):
+        """Test that scan finds plugin directories with plugin.yaml/plugin.yml."""
+        # Test that the method doesn't crash and returns a set
+        with patch("pathlib.Path.is_dir", return_value=False):
+            result = Platform._scan_bundled_plugin_platforms()
+            assert isinstance(result, set)
+
+
+class TestHomeChannelToDictWithThreadId:
+    """Test HomeChannel.to_dict() with thread_id."""
+
+    def test_to_dict_without_thread_id(self):
+        """Test to_dict() without thread_id excludes thread_id key."""
+        hc = HomeChannel(
+            platform=Platform.TELEGRAM,
+            chat_id="12345",
+            name="Home",
+            thread_id=None
+        )
+        
+        result = hc.to_dict()
+        assert result == {
+            "platform": "telegram",
+            "chat_id": "12345",
+            "name": "Home"
+        }
+        assert "thread_id" not in result
+
+    def test_to_dict_with_thread_id(self):
+        """Test to_dict() with thread_id includes thread_id key."""
+        hc = HomeChannel(
+            platform=Platform.TELEGRAM,
+            chat_id="12345",
+            name="Home",
+            thread_id="thread678"
+        )
+        
+        result = hc.to_dict()
+        assert result == {
+            "platform": "telegram",
+            "chat_id": "12345",
+            "name": "Home",
+            "thread_id": "thread678"
+        }
+
+
+class TestGatewayConfigGetHomeChannel:
+    """Test GatewayConfig.get_home_channel() method."""
+
+    def test_get_home_channel_returns_config_home_channel(self):
+        """Test that get_home_channel returns the configured home channel."""
+        config = GatewayConfig(
+            platforms={
+                Platform.TELEGRAM: MagicMock(home_channel=HomeChannel(
+                    platform=Platform.TELEGRAM,
+                    chat_id="12345",
+                    name="Home"
+                ))
+            }
+        )
+        
+        result = config.get_home_channel(Platform.TELEGRAM)
+        assert result is not None
+        assert result.chat_id == "12345"
+
+    def test_get_home_channel_returns_none_when_not_configured(self):
+        """Test that get_home_channel returns None when platform not configured."""
+        config = GatewayConfig()
+        
+        result = config.get_home_channel(Platform.TELEGRAM)
+        assert result is None
+
+    def test_get_home_channel_returns_none_for_nonexistent_platform(self):
+        """Test that get_home_channel returns None for non-existent platform."""
+        config = GatewayConfig(
+            platforms={
+                Platform.DISCORD: MagicMock(home_channel=None)
+            }
+        )
+        
+        result = config.get_home_channel(Platform.TELEGRAM)
+        assert result is None
+
+
+class TestGatewayConfigGetResetPolicy:
+    """Test GatewayConfig.get_reset_policy() method."""
+
+    def test_get_reset_policy_returns_default(self):
+        """Test that get_reset_policy returns default policy when no overrides."""
+        config = GatewayConfig()
+        
+        result = config.get_reset_policy(platform=None, session_type=None)
+        assert result is config.default_reset_policy
+
+    def test_get_reset_policy_returns_platform_override(self):
+        """Test that get_reset_policy returns platform-specific override."""
+        custom_policy = SessionResetPolicy(mode="daily", at_hour=10)
+        
+        config = GatewayConfig(
+            reset_by_platform={
+                Platform.TELEGRAM: custom_policy
+            }
+        )
+        
+        result = config.get_reset_policy(platform=Platform.TELEGRAM)
+        assert result is custom_policy
+
+    def test_get_reset_policy_returns_type_override(self):
+        """Test that get_reset_policy returns type-specific override."""
+        custom_policy = SessionResetPolicy(mode="idle", idle_minutes=60)
+        
+        config = GatewayConfig(
+            reset_by_type={
+                "api": custom_policy
+            }
+        )
+        
+        result = config.get_reset_policy(session_type="api")
+        assert result is custom_policy
+
+    def test_get_reset_policy_platform_takes_precedence_over_type(self):
+        """Test that platform override takes precedence over type override."""
+        platform_policy = SessionResetPolicy(mode="daily")
+        type_policy = SessionResetPolicy(mode="idle")
+        
+        config = GatewayConfig(
+            reset_by_platform={
+                Platform.TELEGRAM: platform_policy
+            },
+            reset_by_type={
+                "chat": type_policy
+            }
+        )
+        
+        # Platform override should take precedence
+        result = config.get_reset_policy(platform=Platform.TELEGRAM, session_type="chat")
+        assert result is platform_policy
+
+
+class TestPlatformDynamicCreationIdentity:
+    """Test that dynamically created platforms are identity-stable."""
+
+    def test_dynamic_platform_is_stable(self):
+        """Test that Platform._missing_('irc') is cached."""
+        # Save and restore _value2member_map_ to avoid polluting other tests
+        saved = dict(Platform._value2member_map_)
+        try:
+            Platform._value2member_map_.clear()
+            result1 = Platform._missing_("irc")
+            result2 = Platform._missing_("irc")
+            assert result1 is result2
+            assert result1 is not None
+            assert result1._value_ == "irc"
+        finally:
+            Platform._value2member_map_.clear()
+            Platform._value2member_map_.update(saved)
+
+    def test_builtin_platform_cached(self):
+        """Test that builtin platforms are cached."""
+        # Access builtin platform
+        result1 = Platform.TELEGRAM
+        result2 = Platform.TELEGRAM
+        
+        assert result1 is result2
+        assert "telegram" in Platform._value2member_map_
+
+
+class TestBuiltinPlatformValuesSnapshot:
+    """Test that builtin platforms are correctly defined."""
+
+    def test_builtin_platforms_is_frozenset(self):
+        """Test that _BUILTIN_PLATFORM_VALUES exists and is a frozenset."""
+        # Access via the module attribute
+        from gateway.config import _BUILTIN_PLATFORM_VALUES as bpv
+        assert isinstance(bpv, frozenset)
+
+    def test_builtin_platforms_contains_telegram(self):
+        """Test that telegram is in builtin platforms."""
+        from gateway.config import _BUILTIN_PLATFORM_VALUES as bpv
+        assert "telegram" in bpv
+
+    def test_builtin_platforms_contains_discord(self):
+        """Test that discord is in builtin platforms."""
+        from gateway.config import _BUILTIN_PLATFORM_VALUES as bpv
+        assert "discord" in bpv
+
+    def test_builtin_platforms_does_not_contain_fake(self):
+        """Test that fake platform is not in builtin platforms."""
+        from gateway.config import _BUILTIN_PLATFORM_VALUES as bpv
+        assert "fake_plugin" not in bpv
+
+
+class TestGatewayConfigPlatformConnectedCheckers:
+    """Test platform connection checkers."""
+
+    def test_weixin_requires_account_id(self):
+        """Test that Weixin requires account_id in extras."""
+        config = GatewayConfig(
+            platforms={
+                Platform.WEIXIN: MagicMock(
+                    extra={"account_id": "test_account"},
+                    token="test_token"
+                )
+            }
+        )
+        
+        # Configured with account_id should be connected
+        result = config._is_platform_connected(Platform.WEIXIN, config.platforms[Platform.WEIXIN])
+        assert result is True
+
+    def test_weixin_requires_token_or_extra_token(self):
+        """Test that Weixin requires token or extra token."""
+        # With token directly
+        config1 = GatewayConfig(
+            platforms={
+                Platform.WEIXIN: MagicMock(
+                    extra={"account_id": "test"},
+                    token="test_token"
+                )
+            }
+        )
+        assert config1._is_platform_connected(
+            Platform.WEIXIN, config1.platforms[Platform.WEIXIN]
+        ) is True
+        
+        # With extra token - mock extra.get() to return the token value
+        extra_mock = MagicMock()
+        extra_mock.get.return_value = "***"
+        config2 = GatewayConfig(
+            platforms={
+                Platform.WEIXIN: MagicMock(
+                    extra=extra_mock,
+                    account_id="test"
+                )
+            }
+        )
+        # The connected checker should find the token in extra.get()
+        assert config2._is_platform_connected(
+            Platform.WEIXIN, config2.platforms[Platform.WEIXIN]
+        ) is True
+        
+        # Without token or extra token
+        config3 = GatewayConfig(
+            platforms={
+                Platform.WEIXIN: MagicMock(
+                    extra={"account_id": "test"},
+                    token=None
+                )
+            }
+        )
+        assert config3._is_platform_connected(
+            Platform.WEIXIN, config3.platforms[Platform.WEIXIN]
+        ) is False

--- a/tests/gateway/test_delivery_edge_cases.py
+++ b/tests/gateway/test_delivery_edge_cases.py
@@ -1,0 +1,442 @@
+"""Tests for delivery edge cases and uncovered code paths.
+
+Tests for gateway/delivery.py lines that were not covered:
+- Unknown platform handling (lines 84-86, 92-94)
+- to_string() with thread_id (line 103)
+- deliver() success/error handling (lines 150-169)
+- _deliver_local() file writing (lines 179-212)
+- _save_full_output() (lines 219-224)
+- _deliver_to_platform() with adapter (lines 233-254)
+"""
+
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+from pathlib import Path
+
+from gateway.config import Platform
+from gateway.delivery import DeliveryTarget, DeliveryRouter, MAX_PLATFORM_OUTPUT, TRUNCATED_VISIBLE
+from gateway.session import SessionSource
+
+
+class TestUnknownPlatformHandling:
+    """Test unknown platform handling in parse()."""
+
+    def test_unknown_platform_with_colon_treated_as_local(self):
+        """Unknown platform string with colon should fall back to LOCAL."""
+        target = DeliveryTarget.parse("unknown:12345")
+        assert target.platform == Platform.LOCAL
+        assert target.chat_id is None
+
+    def test_unknown_platform_without_colon_treated_as_local(self):
+        """Unknown platform string without colon should fall back to LOCAL."""
+        target = DeliveryTarget.parse("completely_unknown")
+        assert target.platform == Platform.LOCAL
+        assert target.chat_id is None
+
+    def test_unknown_platform_case_insensitive(self):
+        """Unknown platform names should be case-insensitive."""
+        target = DeliveryTarget.parse("UNKNOWN_PLATFORM")
+        assert target.platform == Platform.LOCAL
+
+    def test_unknown_platform_with_thread_id(self):
+        """Unknown platform with thread_id should still fall back to LOCAL."""
+        target = DeliveryTarget.parse("unknown_platform:chat:thread123")
+        assert target.platform == Platform.LOCAL
+        assert target.chat_id is None
+
+
+class TestToStringWithThreadId:
+    """Test to_string() roundtrip with thread_id."""
+
+    def test_platform_chat_id_thread_id_roundtrip(self):
+        """Test roundtrip for platform:chat_id:thread_id format."""
+        target = DeliveryTarget.parse("telegram:12345:thread678")
+        assert target.platform == Platform.TELEGRAM
+        assert target.chat_id == "12345"
+        assert target.thread_id == "thread678"
+        
+        result = target.to_string()
+        assert result == "telegram:12345:thread678"
+        
+        # Verify roundtrip
+        reparsed = DeliveryTarget.parse(result)
+        assert reparsed.platform == Platform.TELEGRAM
+        assert reparsed.chat_id == "12345"
+        assert reparsed.thread_id == "thread678"
+
+    def test_slack_channel_thread_roundtrip(self):
+        """Test Slack channel:thread format preserves case."""
+        target = DeliveryTarget.parse("slack:C123ABC:thread456")
+        assert target.platform == Platform.SLACK
+        assert target.chat_id == "C123ABC"
+        assert target.thread_id == "thread456"
+        
+        result = target.to_string()
+        assert result == "slack:C123ABC:thread456"
+
+
+class TestDeliveryRouterSuccessPath:
+    """Test deliver() success path for LOCAL and platform targets."""
+
+    @pytest.mark.asyncio
+    async def test_deliver_local_success(self):
+        """Test successful local delivery saves file and returns path."""
+        with patch("gateway.delivery.get_hermes_home") as mock_home:
+            mock_home.return_value = Path("/tmp/hermes")
+            
+            router = DeliveryRouter(
+                config=MagicMock(),
+                adapters={}
+            )
+            
+            result = await router.deliver(
+                content="Test content",
+                targets=[DeliveryTarget.parse("local")],
+                job_id="test_job",
+                job_name="Test Job"
+            )
+            
+            # Check that local delivery succeeded
+            assert "local" in result
+            assert result["local"]["success"] is True
+            assert "path" in result["local"]["result"]
+            assert "timestamp" in result["local"]["result"]
+
+    @pytest.mark.asyncio
+    async def test_deliver_platform_success(self):
+        """Test successful platform delivery calls adapter.send()."""
+        mock_adapter = AsyncMock()
+        mock_adapter.send = AsyncMock(return_value={"sent": True})
+        
+        config = MagicMock()
+        router = DeliveryRouter(
+            config=config,
+            adapters={Platform.TELEGRAM: mock_adapter}
+        )
+        
+        result = await router.deliver(
+            content="Test message",
+            targets=[
+                DeliveryTarget(
+                    platform=Platform.TELEGRAM,
+                    chat_id="12345",
+                    thread_id="thread678",
+                    is_explicit=True
+                )
+            ],
+            job_id="test_job",
+            metadata={"key": "value"}
+        )
+        
+        # Check that delivery succeeded
+        assert "telegram:12345:thread678" in result
+        assert result["telegram:12345:thread678"]["success"] is True
+
+        # Verify adapter.send was called with correct positional args
+        # (metadata may include platform-specific additions like DM topic info)
+        mock_adapter.send.assert_called_once()
+        call_args = mock_adapter.send.call_args
+        assert call_args.args[0] == "12345"
+        assert call_args.args[1] == "Test message"
+        assert call_args.kwargs["metadata"]["key"] == "value"
+
+
+class TestDeliveryRouterErrorPath:
+    """Test deliver() error handling."""
+
+    @pytest.mark.asyncio
+    async def test_deliver_platform_no_adapter(self):
+        """Test error when no adapter configured for platform."""
+        config = MagicMock()
+        router = DeliveryRouter(
+            config=config,
+            adapters={}
+        )
+        
+        result = await router.deliver(
+            content="Test message",
+            targets=[
+                DeliveryTarget(
+                    platform=Platform.TELEGRAM,
+                    chat_id="12345"
+                )
+            ]
+        )
+        
+        # Check that delivery failed with error
+        assert "telegram:12345" in result
+        assert result["telegram:12345"]["success"] is False
+        assert "error" in result["telegram:12345"]
+        assert "No adapter configured" in result["telegram:12345"]["error"]
+
+    @pytest.mark.asyncio
+    async def test_deliver_platform_no_chat_id(self):
+        """Test error when no chat_id provided for platform delivery."""
+        mock_adapter = AsyncMock()
+        config = MagicMock()
+        router = DeliveryRouter(
+            config=config,
+            adapters={Platform.TELEGRAM: mock_adapter}
+        )
+        
+        result = await router.deliver(
+            content="Test message",
+            targets=[
+                DeliveryTarget(
+                    platform=Platform.TELEGRAM,
+                    chat_id=None  # No chat_id
+                )
+            ]
+        )
+        
+        assert "telegram" in result
+        assert result["telegram"]["success"] is False
+        assert "No chat ID" in result["telegram"]["error"]
+
+    @pytest.mark.asyncio
+    async def test_deliver_mixed_success_failure(self):
+        """Test deliver() with mix of successful and failed targets."""
+        mock_telegram_adapter = AsyncMock()
+        mock_telegram_adapter.send = AsyncMock(return_value={"sent": True})
+        
+        mock_discord_adapter = AsyncMock()
+        mock_discord_adapter.send = AsyncMock(side_effect=Exception("Discord error"))
+        
+        config = MagicMock()
+        router = DeliveryRouter(
+            config=config,
+            adapters={
+                Platform.TELEGRAM: mock_telegram_adapter,
+                Platform.DISCORD: mock_discord_adapter
+            }
+        )
+        
+        result = await router.deliver(
+            content="Test message",
+            targets=[
+                DeliveryTarget(
+                    platform=Platform.TELEGRAM,
+                    chat_id="12345"
+                ),
+                DeliveryTarget(
+                    platform=Platform.DISCORD,
+                    chat_id="98765"
+                )
+            ]
+        )
+        
+        # Telegram should succeed
+        assert "telegram:12345" in result
+        assert result["telegram:12345"]["success"] is True
+        
+        # Discord should fail
+        assert "discord:98765" in result
+        assert result["discord:98765"]["success"] is False
+        assert "Discord error" in result["discord:98765"]["error"]
+
+
+class TestDeliverLocalFileWriting:
+    """Test _deliver_local() file writing logic."""
+
+    def test_deliver_local_creates_directory_structure(self):
+        """Test that _deliver_local creates necessary directory structure."""
+        with patch("gateway.delivery.get_hermes_home") as mock_home:
+            mock_home.return_value = Path("/tmp/hermes")
+            
+            router = DeliveryRouter(
+                config=MagicMock(),
+                adapters={}
+            )
+            
+            # Should not raise even if directory doesn't exist
+            result = router._deliver_local(
+                content="Test content",
+                job_id="test_job",
+                job_name="Test Job",
+                metadata={"key": "value"}
+            )
+            
+            assert "path" in result
+            # Verify file was created in job directory
+            path = Path(result["path"])
+            assert path.parent.name == "test_job"
+            assert path.suffix == ".md"
+
+    def test_deliver_local_includes_job_name(self):
+        """Test that local output includes job name in header."""
+        with patch("gateway.delivery.get_hermes_home") as mock_home:
+            mock_home.return_value = Path("/tmp/hermes")
+            
+            router = DeliveryRouter(
+                config=MagicMock(),
+                adapters={}
+            )
+            
+            result = router._deliver_local(
+                content="Test content",
+                job_id="test_job",
+                job_name="My Job",
+                metadata=None
+            )
+            
+            # Check file was created
+            assert "path" in result
+            path = Path(result["path"])
+            assert path.exists()
+            
+            # Read file content
+            content = path.read_text()
+            assert "# My Job" in content
+            assert "**Job ID:** test_job" in content
+            assert "Test content" in content
+
+    def test_deliver_local_without_job_id(self):
+        """Test local delivery without job_id goes to misc directory."""
+        with patch("gateway.delivery.get_hermes_home") as mock_home:
+            mock_home.return_value = Path("/tmp/hermes")
+            
+            router = DeliveryRouter(
+                config=MagicMock(),
+                adapters={}
+            )
+            
+            result = router._deliver_local(
+                content="Test content",
+                job_id=None,
+                job_name=None,
+                metadata=None
+            )
+            
+            # Check file is in misc directory
+            assert "path" in result
+            assert "misc" in str(result["path"])
+
+
+class TestSaveFullOutput:
+    """Test _save_full_output() method."""
+
+    def test_save_full_output_creates_file(self):
+        """Test that _save_full_output creates the output file."""
+        with patch("gateway.delivery.get_hermes_home") as mock_home:
+            mock_home.return_value = Path("/tmp/hermes")
+            
+            router = DeliveryRouter(
+                config=MagicMock(),
+                adapters={}
+            )
+            
+            path = router._save_full_output("Full output content", "job123")
+            
+            assert isinstance(path, Path)
+            assert path.exists()
+            assert path.read_text() == "Full output content"
+
+    def test_save_full_output_file_naming(self):
+        """Test that output file follows expected naming pattern."""
+        with patch("gateway.delivery.get_hermes_home") as mock_home:
+            mock_home.return_value = Path("/tmp/hermes")
+            
+            router = DeliveryRouter(
+                config=MagicMock(),
+                adapters={}
+            )
+            
+            path = router._save_full_output("Content", "test_job_456")
+            
+            # File should be named job_id_timestamp.txt
+            assert "test_job_456_" in str(path)
+            assert str(path).endswith(".txt")
+
+
+class TestDeliverToPlatform:
+    """Test _deliver_to_platform() async method."""
+
+    @pytest.mark.asyncio
+    async def test_deliver_to_platform_calls_adapter(self):
+        """Test that _deliver_to_platform correctly calls adapter.send()."""
+        mock_adapter = AsyncMock()
+        mock_adapter.send = AsyncMock(return_value={"sent": True})
+        
+        target = DeliveryTarget(
+            platform=Platform.TELEGRAM,
+            chat_id="12345",
+            is_explicit=True
+        )
+        
+        router = DeliveryRouter(
+            config=MagicMock(),
+            adapters={Platform.TELEGRAM: mock_adapter}
+        )
+        
+        result = await router._deliver_to_platform(target, "Message content", {"key": "value"})
+        
+        assert result == {"sent": True}
+        mock_adapter.send.assert_called_once()
+        call_args = mock_adapter.send.call_args
+        assert call_args.args[0] == "12345"
+        assert call_args.args[1] == "Message content"
+        # metadata should contain the original metadata
+        assert call_args.kwargs["metadata"]["key"] == "value"
+
+    @pytest.mark.asyncio
+    async def test_deliver_to_platform_adds_thread_id_to_metadata(self):
+        """Test that thread_id is added to metadata when provided."""
+        mock_adapter = AsyncMock()
+        mock_adapter.send = AsyncMock(return_value={"sent": True})
+        
+        target = DeliveryTarget(
+            platform=Platform.TELEGRAM,
+            chat_id="12345",
+            thread_id="thread678",
+            is_explicit=True
+        )
+        
+        router = DeliveryRouter(
+            config=MagicMock(),
+            adapters={Platform.TELEGRAM: mock_adapter}
+        )
+        
+        result = await router._deliver_to_platform(target, "Message", {})
+        
+        mock_adapter.send.assert_called_once()
+        call_args = mock_adapter.send.call_args
+        # thread_id is present in metadata; platform may override its value
+        # (e.g. Telegram may resolve/replace it with a DM topic ID)
+        assert "thread_id" in call_args.kwargs["metadata"]
+
+    @pytest.mark.asyncio
+    async def test_deliver_to_platform_truncates_oversized_content(self):
+        """Test that oversized content is truncated and saved to file."""
+        with patch("gateway.delivery.get_hermes_home") as mock_home:
+            mock_home.return_value = Path("/tmp/hermes")
+            
+            mock_adapter = AsyncMock()
+            mock_adapter.send = AsyncMock(return_value={"sent": True})
+            
+            # Create content larger than MAX_PLATFORM_OUTPUT
+            oversized_content = "A" * (MAX_PLATFORM_OUTPUT + 100)
+            
+            router = DeliveryRouter(
+                config=MagicMock(),
+                adapters={Platform.TELEGRAM: mock_adapter}
+            )
+            
+            result = await router._deliver_to_platform(
+                DeliveryTarget(
+                    platform=Platform.TELEGRAM,
+                    chat_id="12345"
+                ),
+                oversized_content,
+                {"job_id": "test_job"}
+            )
+            
+            # Should still succeed (content was truncated)
+            assert result["sent"] is True
+            
+            # Verify adapter was called with truncated content
+            call_args = mock_adapter.send.call_args
+            assert len(call_args.args[1]) <= MAX_PLATFORM_OUTPUT
+            assert "[truncated" in call_args.args[1]
+            
+            # Verify metadata includes job_id (for file saving)
+            assert call_args.kwargs["metadata"].get("job_id") == "test_job"


### PR DESCRIPTION
## Summary

Add test files for two gateway modules that had no test coverage for key edge-case code paths.

**`tests/gateway/test_config_edge_cases.py`** (25 tests):
- `Platform._missing_()` — dynamic enum creation, caching, whitespace/non-string guards, builtin lookup
- `Platform._scan_bundled_plugin_platforms()` — missing plugins dir returns empty set
- `HomeChannel.to_dict()` — with and without `thread_id`
- `GatewayConfig.get_home_channel()` — found, not configured, non-existent platform
- `GatewayConfig.get_reset_policy()` — default, platform override, type override, platform-over-type precedence
- `_BUILTIN_PLATFORM_VALUES` frozenset snapshot assertions
- Weixin connection checker with/without token

**`tests/gateway/test_delivery_edge_cases.py`** (19 tests):
- `DeliveryTarget.parse()` — unknown platform falls back to LOCAL
- `DeliveryTarget.to_string()` roundtrip with thread_id (telegram, slack)
- `DeliveryRouter.deliver()` — LOCAL success, platform success, no adapter error, no chat_id error, mixed success/failure
- `DeliveryRouter._deliver_local()` — directory creation, job naming, misc dir fallback
- `DeliveryRouter._save_full_output()` — file creation and naming convention
- `DeliveryRouter._deliver_to_platform()` — adapter call, thread_id metadata passthrough, oversized content truncation

All 44 tests pass against `v2026.6.5` (v0.16.0).

## Test plan

- [x] `pytest tests/gateway/test_config_edge_cases.py -v` — 25/25 pass
- [x] `pytest tests/gateway/test_delivery_edge_cases.py -v` — 19/19 pass
- [x] Full gateway test suite — no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)