### PR TITLE
fix(agent): flush session updates during tool execution

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -560,6 +560,14 @@ def run_conversation(
             should_review_memory=_should_review_memory,
         )
 
+    # Pre-loop DB flush: persist the user message (and any prior un-flushed
+    # history) before the first API call.  If the process dies during the
+    # API request, the at least the user's message survives in state.db.
+    try:
+        agent._flush_messages_to_session_db(messages)
+    except Exception:
+        pass  # non-fatal; turn-end flush will retry
+
     while (api_call_count < agent.max_iterations and agent.iteration_budget.remaining > 0) or agent._budget_grace_call:
         # Reset per-turn checkpoint dedup so each iteration can take one snapshot
         agent._checkpoint_mgr.new_turn()
@@ -3942,6 +3950,16 @@ def run_conversation(
                         pass
 
                 agent._execute_tool_calls(assistant_message, messages, effective_task_id, api_call_count)
+
+                # Incremental DB flush: persist messages after each tool
+                # batch so a mid-turn process kill doesn't lose everything.
+                # _flush_messages_to_session_db is idempotent (tracks
+                # already-flushed message identities), so repeated calls
+                # are safe and cheap.
+                try:
+                    agent._flush_messages_to_session_db(messages)
+                except Exception:
+                    pass  # non-fatal; turn-end flush will retry
 
                 if agent._tool_guardrail_halt_decision is not None:
                     decision = agent._tool_guardrail_halt_decision


### PR DESCRIPTION
## Summary

This PR flushes incremental session DB updates while a tool call is still running.

The change keeps persisted conversation state more current during long tool executions, instead of waiting until the full turn finishes before writing the latest assistant/tool activity.

## Why

Long-running tools can leave a gap between what has happened in the active turn and what has been flushed to the session database. Flushing incremental updates during tool execution reduces stale stored state for consumers that reload or inspect the session while the turn is still active.

## Validation

- `.venv\Scripts\python.exe -m py_compile agent\conversation_loop.py`
- `git diff --check origin/main..HEAD`