### PR TITLE
fix: honor model request overrides at agent startup

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -132,6 +132,42 @@ def _custom_provider_extra_body_for_agent(
     return fallback
 
 
+def _model_request_overrides_for_agent() -> Dict[str, Any]:
+    """Return model.request_overrides from config.yaml when present.
+
+    This is a low-level escape hatch for provider-native request fields that
+    Hermes has not promoted to first-class config yet. Explicit per-turn
+    request overrides still win over this global default.
+    """
+    try:
+        from hermes_cli.config import load_config
+
+        cfg = load_config()
+        model_cfg = cfg.get("model", {}) if isinstance(cfg, dict) else {}
+        raw = model_cfg.get("request_overrides") if isinstance(model_cfg, dict) else None
+        if isinstance(raw, dict):
+            return dict(raw)
+    except Exception:
+        pass
+    return {}
+
+
+def _merge_request_overrides(agent, additions: Dict[str, Any]) -> None:
+    if not isinstance(additions, dict) or not additions:
+        return
+    overrides = dict(getattr(agent, "request_overrides", {}) or {})
+    for key, value in additions.items():
+        if key == "extra_body" and isinstance(value, dict):
+            merged_extra_body = dict(value)
+            existing_extra_body = overrides.get("extra_body")
+            if isinstance(existing_extra_body, dict):
+                merged_extra_body.update(existing_extra_body)
+            overrides["extra_body"] = merged_extra_body
+        else:
+            overrides.setdefault(key, value)
+    agent.request_overrides = overrides
+
+
 def _merge_custom_provider_extra_body(agent, custom_providers: List[Dict[str, Any]]) -> None:
     extra_body = _custom_provider_extra_body_for_agent(
         provider=agent.provider,
@@ -142,13 +178,7 @@ def _merge_custom_provider_extra_body(agent, custom_providers: List[Dict[str, An
     if not extra_body:
         return
 
-    overrides = dict(getattr(agent, "request_overrides", {}) or {})
-    merged_extra_body = dict(extra_body)
-    existing_extra_body = overrides.get("extra_body")
-    if isinstance(existing_extra_body, dict):
-        merged_extra_body.update(existing_extra_body)
-    overrides["extra_body"] = merged_extra_body
-    agent.request_overrides = overrides
+    _merge_request_overrides(agent, {"extra_body": dict(extra_body)})
 
 
 def init_agent(
@@ -487,6 +517,7 @@ def init_agent(
     agent.reasoning_config = reasoning_config  # None = use default (medium for OpenRouter)
     agent.service_tier = service_tier
     agent.request_overrides = dict(request_overrides or {})
+    _merge_request_overrides(agent, _model_request_overrides_for_agent())
     agent.prefill_messages = prefill_messages or []  # Prefilled conversation turns
     agent._force_ascii_payload = False
     

--- a/tests/agent/test_custom_provider_extra_body.py
+++ b/tests/agent/test_custom_provider_extra_body.py
@@ -1,6 +1,10 @@
 from types import SimpleNamespace
 
-from agent.agent_init import _merge_custom_provider_extra_body
+from agent.agent_init import (
+    _merge_custom_provider_extra_body,
+    _merge_request_overrides,
+    _model_request_overrides_for_agent,
+)
 
 
 def test_custom_provider_extra_body_merges_into_request_overrides():
@@ -91,3 +95,61 @@ def test_custom_provider_extra_body_ignores_other_custom_models():
     )
 
     assert agent.request_overrides == {}
+
+
+def test_model_request_overrides_reads_model_config(monkeypatch):
+    def fake_load_config():
+        return {
+            "model": {
+                "request_overrides": {
+                    "extra_body": {"text": {"verbosity": "low"}}
+                }
+            }
+        }
+
+    monkeypatch.setattr("hermes_cli.config.load_config", fake_load_config)
+
+    assert _model_request_overrides_for_agent() == {
+        "extra_body": {"text": {"verbosity": "low"}}
+    }
+
+
+def test_model_request_overrides_ignores_non_mapping_config(monkeypatch):
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config",
+        lambda: {"model": {"request_overrides": "low"}},
+    )
+
+    assert _model_request_overrides_for_agent() == {}
+
+
+def test_merge_request_overrides_preserves_explicit_turn_override():
+    agent = SimpleNamespace(
+        request_overrides={
+            "service_tier": "priority",
+            "extra_body": {
+                "text": {"verbosity": "medium"},
+                "caller_only": True,
+            },
+        }
+    )
+
+    _merge_request_overrides(
+        agent,
+        {
+            "service_tier": "default",
+            "extra_body": {
+                "text": {"verbosity": "low"},
+                "provider_default": True,
+            },
+        },
+    )
+
+    assert agent.request_overrides == {
+        "service_tier": "priority",
+        "extra_body": {
+            "text": {"verbosity": "medium"},
+            "provider_default": True,
+            "caller_only": True,
+        },
+    }


### PR DESCRIPTION
## Summary
- Load optional `model.request_overrides` from `config.yaml` during agent startup.
- Merge global request overrides into `AIAgent.request_overrides` without clobbering explicit per-turn overrides.
- Reuse the existing `extra_body` merge behavior so provider-native fields like OpenAI Responses `text.verbosity` can be configured without local source patches.

Refs #20203

## Test Plan
- [x] `python -m pytest tests/agent/test_custom_provider_extra_body.py tests/run_agent/test_run_agent_codex_responses.py -q -o 'addopts='` — 83 passed, 1 warning

## Notes
- Explicit per-turn request overrides still win over global `model.request_overrides`.
- This is intentionally a low-level escape hatch for provider-native request body fields that Hermes has not promoted to first-class config yet.
