### PR TITLE
fix(update): guard gateway import chain and self-heal autostash-poisoned trees

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -4366,6 +4366,16 @@ _UPDATE_CRITICAL_FILES = (
     "model_tools.py",
     "toolsets.py",
     "hermes_constants.py",
+    # Desktop/gateway hot path. These are not imported by the CLI at startup
+    # (so a break here still lets ``hermes update`` run), but they ARE imported
+    # lazily on the first gateway WebSocket — gateway_ws → tui_gateway.ws →
+    # tui_gateway.server. A syntax error here (e.g. orphan ``<<<<<<<`` conflict
+    # markers re-applied from an autostash) leaves the CLI bootable but crash-
+    # loops the desktop backend on every connection, which presents to the user
+    # as a permanently broken desktop app. Validate them on update too.
+    "hermes_cli/web_server.py",
+    "tui_gateway/ws.py",
+    "tui_gateway/server.py",
 )
 
 
@@ -6253,6 +6263,37 @@ def _restore_stashed_changes(
         # Don't sys.exit — the code update itself succeeded, only the stash
         # restore had conflicts.  Let cmd_update continue with pip install,
         # skill sync, and gateway restart.
+        return False
+
+    # The apply was clean (returncode 0, no unmerged entries) — but a clean
+    # apply can still re-brick the tree. If the stash captured orphan conflict
+    # markers from an earlier interrupted update, or a local edit that doesn't
+    # parse, those lines re-apply silently as ordinary content and produce a
+    # tree that imports with a SyntaxError. The post-pull guard ran *before*
+    # this restore, so it can't catch poison the restore itself reintroduces —
+    # this is the failure mode where a desktop install crash-loops on the
+    # gateway WebSocket while ``hermes update`` keeps reporting success. Re-
+    # validate the critical files now; if the restore broke one, roll the
+    # working tree back to HEAD and keep the stash so nothing is lost.
+    syntax_ok, failing_path, syntax_error = _validate_critical_files_syntax(cwd)
+    if not syntax_ok:
+        print(
+            "✗ Restoring local changes re-introduced a syntax error in a critical file:"
+        )
+        print(f"  {failing_path}")
+        if syntax_error:
+            for line in str(syntax_error).splitlines()[:6]:
+                print(f"    {line}")
+        print("\nYour stashed changes are preserved — nothing is lost.")
+        print(f"  Stash ref: {stash_ref}")
+        subprocess.run(
+            git_cmd + ["reset", "--hard", "HEAD"],
+            cwd=cwd,
+            capture_output=True,
+        )
+        print("Working tree reset to clean state so Hermes stays runnable.")
+        print(f"Restore your changes later with: git stash apply {stash_ref}")
+        # Leave the stash in place (don't drop it) so the user can recover.
         return False
 
     stash_selector = _resolve_stash_selector(git_cmd, cwd, stash_ref)

--- a/tests/hermes_cli/test_update_autostash.py
+++ b/tests/hermes_cli/test_update_autostash.py
@@ -304,6 +304,97 @@ def test_restore_stashed_changes_auto_resets_non_interactive(monkeypatch, tmp_pa
     assert len(reset_calls) == 1
 
 
+def test_restore_stashed_changes_resets_when_clean_apply_reintroduces_syntax_error(
+    monkeypatch, tmp_path, capsys
+):
+    """A *clean* stash apply (no merge conflict) can still re-brick the tree.
+
+    If the stash captured orphan conflict markers from an earlier interrupted
+    update, they re-apply as ordinary content — ``git stash apply`` reports
+    success with no unmerged entries — and the file imports with a
+    SyntaxError. The post-pull guard ran *before* this restore, so it can't
+    catch poison the restore itself reintroduces. This path has to re-validate,
+    reset to HEAD, and keep the stash for recovery.
+
+    Regression for the desktop crash-loop where ``tui_gateway/server.py`` was
+    left starting with ``<<<<<<< Updated upstream`` while ``hermes update``
+    kept reporting success (issue #46791).
+    """
+    calls = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append((cmd, kwargs))
+        if cmd[1:3] == ["stash", "apply"]:
+            return SimpleNamespace(stdout="applied\n", stderr="", returncode=0)
+        if cmd[1:3] == ["diff", "--name-only"]:
+            return SimpleNamespace(stdout="", stderr="", returncode=0)
+        if cmd[1:3] == ["reset", "--hard"]:
+            return SimpleNamespace(stdout="", stderr="", returncode=0)
+        raise AssertionError(f"unexpected command after poisoned restore: {cmd}")
+
+    monkeypatch.setattr(hermes_main.subprocess, "run", fake_run)
+    monkeypatch.setattr(
+        hermes_main,
+        "_validate_critical_files_syntax",
+        lambda root: (
+            False,
+            str(Path(root) / "tui_gateway/server.py"),
+            "SyntaxError: invalid syntax",
+        ),
+    )
+
+    result = hermes_main._restore_stashed_changes(
+        ["git"], tmp_path, "abc123", prompt_user=False
+    )
+
+    assert result is False
+    out = capsys.readouterr().out
+    assert "re-introduced a syntax error" in out
+    assert "tui_gateway/server.py" in out
+    assert "stashed changes are preserved" in out
+    assert "Working tree reset to clean state" in out
+    assert "git stash apply abc123" in out
+    # Reset exactly once, and the stash is NOT dropped — it stays recoverable.
+    assert [c[1:3] for c, _ in calls] == [
+        ["stash", "apply"],
+        ["diff", "--name-only"],
+        ["reset", "--hard"],
+    ]
+    assert not any(c[1:3] == ["stash", "drop"] for c, _ in calls)
+
+
+def test_restore_stashed_changes_drops_stash_when_clean_apply_validates(
+    monkeypatch, tmp_path
+):
+    """The post-restore syntax check must not disturb the happy path: a clean
+    apply whose critical files still parse proceeds to drop the stash."""
+    calls = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append((cmd, kwargs))
+        if cmd[1:3] == ["stash", "apply"]:
+            return SimpleNamespace(stdout="applied\n", stderr="", returncode=0)
+        if cmd[1:3] == ["diff", "--name-only"]:
+            return SimpleNamespace(stdout="", stderr="", returncode=0)
+        if cmd[1:3] == ["stash", "list"]:
+            return SimpleNamespace(stdout="stash@{0} abc123\n", stderr="", returncode=0)
+        if cmd[1:3] == ["stash", "drop"]:
+            return SimpleNamespace(stdout="dropped\n", stderr="", returncode=0)
+        raise AssertionError(f"unexpected command: {cmd}")
+
+    monkeypatch.setattr(hermes_main.subprocess, "run", fake_run)
+    monkeypatch.setattr(
+        hermes_main, "_validate_critical_files_syntax", lambda root: (True, None, None)
+    )
+
+    result = hermes_main._restore_stashed_changes(
+        ["git"], tmp_path, "abc123", prompt_user=False
+    )
+
+    assert result is True
+    assert any(c[1:3] == ["stash", "drop"] for c, _ in calls)
+
+
 def test_stash_local_changes_if_needed_raises_when_stash_ref_missing(monkeypatch, tmp_path):
     def fake_run(cmd, **kwargs):
         if cmd[-2:] == ["status", "--porcelain"]:

--- a/tests/hermes_cli/test_update_post_pull_syntax_guard.py
+++ b/tests/hermes_cli/test_update_post_pull_syntax_guard.py
@@ -116,6 +116,33 @@ def test_validate_critical_files_syntax_detects_break_in_main_py(tmp_path):
     assert failing_path is not None and failing_path.endswith("hermes_cli/main.py")
 
 
+def test_validate_critical_files_syntax_detects_break_in_gateway_server(tmp_path):
+    """The desktop/gateway hot path is guarded too. ``tui_gateway/server.py``
+    is not imported by the CLI at startup, so a break there still lets
+    ``hermes update`` run — but it crash-loops the desktop backend on the first
+    gateway WebSocket. The guard must catch it like the CLI-bootstrap files
+    (issue #46791)."""
+    _populate_critical_tree(tmp_path, broken_file="tui_gateway/server.py")
+
+    ok, failing_path, error = hermes_main._validate_critical_files_syntax(tmp_path)
+
+    assert ok is False
+    assert failing_path is not None and failing_path.endswith("tui_gateway/server.py")
+    assert error is not None
+
+
+def test_gateway_import_chain_is_in_critical_files():
+    """gateway_ws → tui_gateway.ws → tui_gateway.server is the desktop import
+    chain that bricked installs when it carried conflict markers; all three
+    must be validated on update so the guard's auto-rollback covers them."""
+    for relpath in (
+        "hermes_cli/web_server.py",
+        "tui_gateway/ws.py",
+        "tui_gateway/server.py",
+    ):
+        assert relpath in hermes_main._UPDATE_CRITICAL_FILES
+
+
 def test_validate_critical_files_syntax_tolerates_missing_files(tmp_path):
     """A refactor may legitimately remove one of the critical files — the
     guard should skip missing files, not falsely flag the install as broken."""


### PR DESCRIPTION
## Problem

A desktop install crash-loops forever with the backend dying on every gateway WebSocket:

```
File ".../tui_gateway/server.py", line 1
    <<<<<<< Updated upstream
    ^^
SyntaxError: invalid syntax
```

The `<<<<<<< Updated upstream` / `>>>>>>> Stashed changes` markers are the **autostash** signature: `hermes update` stashed local changes, pulled, and the restore re-applied orphan conflict markers into `tui_gateway/server.py`. The CLI still boots (it doesn't import that file at startup), but the desktop backend imports it lazily on the first WS connection (`gateway_ws → tui_gateway.ws → tui_gateway.server`), so it `SyntaxError`s, the desktop relaunches it, and it loops indefinitely while `hermes update` keeps reporting success.

Two gaps let this through:

1. **The post-pull syntax guard didn't cover the gateway hot path.** `_UPDATE_CRITICAL_FILES` only listed the 8 CLI-bootstrap files, so a broken `tui_gateway/server.py` passed validation and auto-rollback never fired.
2. **The guard runs *before* the autostash restore.** The poison is reintroduced by `_restore_stashed_changes` *after* validation already passed. The existing reset only triggers on a *conflicting* apply — a stash that carries marker text and applies *cleanly* slipped through. This also prevents self-healing: every subsequent update re-stashes and re-applies the same markers.

## Fix

- Add `hermes_cli/web_server.py`, `tui_gateway/ws.py`, `tui_gateway/server.py` to `_UPDATE_CRITICAL_FILES` so the post-pull guard, its auto-rollback, and the production-tree CI invariant all cover the desktop/gateway import chain.
- Re-run `_validate_critical_files_syntax` after a *clean* stash apply in `_restore_stashed_changes`; if the restore re-introduced a broken critical file, `git reset --hard HEAD` and **keep the stash** for manual recovery instead of leaving the tree bricked.

Net effect: a tree poisoned by an earlier interrupted/old-version update **self-heals on the next `hermes update`** rather than staying permanently broken.

## Verification

- End-to-end against a real git repo reproducing the exact `<<<<<<< Updated upstream` poisoning of `tui_gateway/server.py`: after `_restore_stashed_changes`, markers are gone, the file compiles, and the stash is preserved.
- 83 tests pass across `test_update_post_pull_syntax_guard.py`, `test_update_autostash.py`, `test_cmd_update.py`, `test_update_interrupted_recovery.py`, `test_install_unmerged_index.py`.
- New tests: gateway file caught by the guard; gateway chain present in the critical list; clean-apply-reintroduces-syntax-error resets + keeps stash; clean-apply-that-validates still drops the stash (happy path unchanged).

## Scope

This addresses the concrete `hermes update` (Python) self-heal portion of #46791. The broader shared-"resolver" refactor across `scripts/install.ps1` / `install.sh` that the issue proposes is **not** included here, so this intentionally does not auto-close it.

Refs #46791