### PR TITLE
fix(opencode-go): set supports_vision_tool_messages=False for Xiaomi MiMo backend

### DIFF
--- a/plugins/model-providers/opencode-zen/__init__.py
+++ b/plugins/model-providers/opencode-zen/__init__.py
@@ -120,6 +120,7 @@ opencode_go = OpenCodeGoProfile(
     env_vars=("OPENCODE_GO_API_KEY",),
     base_url="https://opencode.ai/zen/go/v1",
     default_aux_model="glm-5",
+    supports_vision_tool_messages=False,  # Xiaomi MiMo rejects list-type tool content (400 "text is not set")
 )
 
 register_provider(opencode_zen)


### PR DESCRIPTION
When using the opencode-go provider with Xiaomi MiMo models, tool results containing image_url parts are forwarded as-is to MiMo, which rejects list-type tool content with HTTP 400 "text is not set".

The direct 'xiaomi' provider already sets supports_vision_tool_messages=False. This adds the same flag to OpenCodeGoProfile.

使用 opencode-go + Xiaomi MiMo 时，包含图片的工具结果被原样转发给 MiMo，后者拒绝 list-type tool message 返回 400 "text is not set"。为 OpenCodeGoProfile 补上 supports_vision_tool_messages=False。