### PR TITLE
fix(desktop): retry the self-update rebuild once so the app relaunches

### DIFF
--- a/apps/bootstrap-installer/src-tauri/src/update.rs
+++ b/apps/bootstrap-installer/src-tauri/src/update.rs
@@ -286,7 +286,7 @@ async fn run_update(app: AppHandle) -> Result<()> {
     emit_stage(&app, "rebuild", StageState::Running, None, None);
     let started = Instant::now();
     let rebuild_args: Vec<String> = vec!["desktop".into(), "--build-only".into()];
-    let rebuild = run_streamed(
+    let mut rebuild = run_streamed(
         &app,
         &hermes,
         &rebuild_args,
@@ -295,6 +295,33 @@ async fn run_update(app: AppHandle) -> Result<()> {
         Some("rebuild"),
     )
     .await?;
+
+    // Retry-once: the first `--build-only` can return nonzero on a still-settling
+    // post-update tree or a network-blocked Electron fetch that our self-heal
+    // repaired mid-run. A second attempt then builds clean off the healed dist
+    // (the content-hash stamp makes it a near-no-op when the first actually
+    // succeeded). Without this the updater bails here and never reaches the
+    // relaunch below — the app updates but doesn't restart. Matches the
+    // retry-once `hermes update` already does above, and `hermes update`'s own
+    // desktop rebuild in cmd_update.
+    if rebuild_needs_retry(rebuild.exit_code) {
+        emit_log(
+            &app,
+            Some("rebuild"),
+            LogStream::Stdout,
+            "[rebuild] first desktop rebuild failed; retrying once (a self-healed \
+             Electron download builds clean on the second run)…",
+        );
+        rebuild = run_streamed(
+            &app,
+            &hermes,
+            &rebuild_args,
+            &install_root,
+            &child_env,
+            Some("rebuild"),
+        )
+        .await?;
+    }
     let rebuild_ms = started.elapsed().as_millis() as u64;
 
     if rebuild.exit_code != Some(0) {
@@ -531,6 +558,14 @@ fn is_locked(path: &Path) -> bool {
         Ok(_) => false,
         Err(_) => true,
     }
+}
+
+/// Whether the `desktop --build-only` rebuild should be retried once. Any
+/// non-success exit qualifies: the common cause is a transient first-attempt
+/// failure (still-settling tree / self-healed Electron download) that a clean
+/// second run resolves.
+fn rebuild_needs_retry(exit_code: Option<i32>) -> bool {
+    exit_code != Some(0)
 }
 
 /// Spawn `hermes <args>` from `cwd`, stream stdout/stderr as Log events on the
@@ -968,6 +1003,16 @@ mod tests {
             Some("main".to_string())
         );
         assert_eq!(update_branch_from_args(["--update"]), None);
+    }
+
+    #[test]
+    fn rebuild_retries_only_on_failure() {
+        assert!(!rebuild_needs_retry(Some(0)), "a clean rebuild must not retry");
+        assert!(rebuild_needs_retry(Some(1)), "a failed rebuild retries once");
+        assert!(
+            rebuild_needs_retry(None),
+            "a killed/signalled rebuild (no exit code) retries once"
+        );
     }
 
     #[test]

--- a/apps/desktop/electron/main.cjs
+++ b/apps/desktop/electron/main.cjs
@@ -45,6 +45,7 @@ const { readDirForIpc } = require('./fs-read-dir.cjs')
 const { gitRootForIpc } = require('./git-root.cjs')
 const { worktreesForIpc } = require('./git-worktrees.cjs')
 const { OFFICIAL_REPO_HTTPS_URL, isOfficialSshRemote } = require('./update-remote.cjs')
+const { runRebuildWithRetry } = require('./update-rebuild.cjs')
 const {
   buildPosixCleanupScript,
   buildWindowsCleanupScript,
@@ -2009,10 +2010,14 @@ async function applyUpdatesPosixInApp() {
   }
 
   emitUpdateProgress({ stage: 'rebuild', message: 'Rebuilding the desktop app…', percent: 60 })
-  const rebuilt = await runStreamedUpdate(hermes, ['desktop', '--build-only'], {
-    cwd: updateRoot,
-    env,
-    stage: 'rebuild'
+  // Retry-once: a first rebuild can fail on a still-settling tree or a
+  // self-healed (network-blocked) Electron download; a second run builds clean
+  // off the healed dist so we reach the swap+relaunch below instead of bailing.
+  const rebuilt = await runRebuildWithRetry(attempt => {
+    if (attempt > 0) {
+      emitUpdateProgress({ stage: 'rebuild', message: 'Retrying the desktop rebuild…', percent: 60 })
+    }
+    return runStreamedUpdate(hermes, ['desktop', '--build-only'], { cwd: updateRoot, env, stage: 'rebuild' })
   })
   if (rebuilt.code !== 0) {
     emitUpdateProgress({

--- a/apps/desktop/electron/update-rebuild.cjs
+++ b/apps/desktop/electron/update-rebuild.cjs
@@ -1,0 +1,29 @@
+'use strict'
+
+/**
+ * Retry-once policy for the desktop `--build-only` rebuild during self-update.
+ *
+ * The first rebuild can return nonzero on a still-settling post-update tree or a
+ * network-blocked Electron fetch that the installer's self-heal repaired mid-run.
+ * A second attempt then builds clean off the healed dist (the content-hash stamp
+ * makes it a near-no-op when the first actually succeeded). Without the retry the
+ * updater bails before the relaunch step — the app updates but doesn't restart.
+ */
+
+function shouldRetryRebuild(code) {
+  return code !== 0
+}
+
+/**
+ * Run `rebuild()` (async, resolves `{ code, ... }`), retrying once on failure.
+ * Returns the final result.
+ */
+async function runRebuildWithRetry(rebuild) {
+  let result = await rebuild(0)
+  if (shouldRetryRebuild(result.code)) {
+    result = await rebuild(1)
+  }
+  return result
+}
+
+module.exports = { shouldRetryRebuild, runRebuildWithRetry }

--- a/apps/desktop/electron/update-rebuild.test.cjs
+++ b/apps/desktop/electron/update-rebuild.test.cjs
@@ -1,0 +1,55 @@
+/**
+ * Tests for electron/update-rebuild.cjs — the retry-once policy for the desktop
+ * `--build-only` rebuild during self-update.
+ *
+ * Run with: node --test electron/update-rebuild.test.cjs
+ * (Wired into npm test:desktop:platforms in package.json.)
+ *
+ * Why this matters: a first rebuild can return nonzero on a still-settling tree
+ * or a self-healed (network-blocked) Electron download. Without a second attempt
+ * the updater bails before the relaunch step — the app updates but never restarts
+ * (the field report behind this fix). The retry must fire on failure, not on
+ * success, and must run at most twice.
+ */
+
+const test = require('node:test')
+const assert = require('node:assert/strict')
+
+const { shouldRetryRebuild, runRebuildWithRetry } = require('./update-rebuild.cjs')
+
+test('shouldRetryRebuild retries only on a non-success exit', () => {
+  assert.equal(shouldRetryRebuild(0), false)
+  assert.equal(shouldRetryRebuild(1), true)
+  assert.equal(shouldRetryRebuild(null), true)
+})
+
+test('a clean first rebuild runs once and does not retry', async () => {
+  const codes = []
+  const result = await runRebuildWithRetry(attempt => {
+    codes.push(attempt)
+    return Promise.resolve({ code: 0 })
+  })
+  assert.deepEqual(codes, [0])
+  assert.equal(result.code, 0)
+})
+
+test('a failed first rebuild retries once and succeeds', async () => {
+  const codes = []
+  const result = await runRebuildWithRetry(attempt => {
+    codes.push(attempt)
+    return Promise.resolve({ code: attempt === 0 ? 1 : 0 })
+  })
+  assert.deepEqual(codes, [0, 1])
+  assert.equal(result.code, 0)
+})
+
+test('a rebuild that keeps failing runs at most twice and reports the failure', async () => {
+  const codes = []
+  const result = await runRebuildWithRetry(attempt => {
+    codes.push(attempt)
+    return Promise.resolve({ code: 1, error: 'rebuild-failed' })
+  })
+  assert.deepEqual(codes, [0, 1])
+  assert.equal(result.code, 1)
+  assert.equal(result.error, 'rebuild-failed')
+})

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -37,7 +37,7 @@
     "test:desktop:nsis": "node scripts/test-desktop.mjs nsis",
     "test:desktop:existing": "node scripts/test-desktop.mjs existing",
     "test:desktop:fresh": "node scripts/test-desktop.mjs fresh",
-    "test:desktop:platforms": "node --test electron/bootstrap-platform.test.cjs electron/hardening.test.cjs electron/backend-env.test.cjs electron/backend-probes.test.cjs electron/bootstrap-runner.test.cjs electron/connection-config.test.cjs electron/dashboard-token.test.cjs electron/gateway-ws-probe.test.cjs electron/oauth-net-request.test.cjs electron/desktop-uninstall.test.cjs electron/session-windows.test.cjs electron/workspace-cwd.test.cjs electron/fs-read-dir.test.cjs electron/git-root.test.cjs electron/windows-child-process.test.cjs electron/update-remote.test.cjs electron/windows-user-env.test.cjs",
+    "test:desktop:platforms": "node --test electron/bootstrap-platform.test.cjs electron/hardening.test.cjs electron/backend-env.test.cjs electron/backend-probes.test.cjs electron/bootstrap-runner.test.cjs electron/connection-config.test.cjs electron/dashboard-token.test.cjs electron/gateway-ws-probe.test.cjs electron/oauth-net-request.test.cjs electron/desktop-uninstall.test.cjs electron/session-windows.test.cjs electron/workspace-cwd.test.cjs electron/fs-read-dir.test.cjs electron/git-root.test.cjs electron/windows-child-process.test.cjs electron/update-remote.test.cjs electron/update-rebuild.test.cjs electron/windows-user-env.test.cjs",
     "typecheck": "tsc -p . --noEmit",
     "lint": "eslint src/ electron/",
     "lint:fix": "eslint src/ electron/ --fix",


### PR DESCRIPTION
## Summary

Fast-follow to #48091 (the desktop Electron self-heal). Field report after that merged: an update that triggered a from-scratch reinstall **rebuilt fine but didn't relaunch** — the app was updated and worked when launched manually.

Root cause: the desktop self-update runs `hermes update` → `hermes desktop --build-only` → relaunch, and **only relaunches if the rebuild returns 0**. The first `--build-only` can exit nonzero on a still-settling post-update tree, or on a network-blocked Electron fetch that #48091's self-heal repaired *mid-run*. Both updaters then bail before the relaunch step:

- `apps/bootstrap-installer/src-tauri/src/update.rs` (Tauri setup binary): rebuild nonzero → `return Err` before `launch_macos_app_and_exit`.
- `apps/desktop/electron/main.cjs` `applyUpdatesPosixInApp` (mac/linux drag-install): rebuild nonzero → early return before the swap+`open`.

The `hermes update` *stage* already retries once in both updaters, and the CLI `hermes update`'s own desktop rebuild retries once (`hermes_cli/main.py`) — the `--build-only` rebuild stage was the one path that didn't. This adds that same retry-once.

A second `--build-only` builds clean off the healed dist and is a near-no-op when the first actually succeeded (the content-hash stamp short-circuits). The happy path (first build returns 0) is unchanged.

## Changes

- **update.rs** — retry stage 2 once before failing; extract `rebuild_needs_retry()` + unit test.
- **main.cjs** — retry via a new `electron/update-rebuild.cjs` helper (`runRebuildWithRetry` / `shouldRetryRebuild`), behavior-tested with an injected runner; wired `update-rebuild.test.cjs` into `test:desktop:platforms`.

## Test plan

- `cargo test rebuild_retries_only_on_failure` → ok (retry on `Some(1)`/`None`, not on `Some(0)`).
- `node --test electron/update-rebuild.test.cjs` → 4 passing (no-retry on success; retry-then-succeed; at-most-twice on persistent failure; predicate contract).
- `node -c electron/main.cjs` clean.
- Pre-existing macOS-only failure `update::tests::lock_probe_paths_include_desktop_app_payload` is unrelated (fails identically on clean `origin/main`).