### PR TITLE
fix(desktop): update usage from status events

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-message-stream.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream.ts
@@ -1072,6 +1072,10 @@ export function useMessageStream({
           })
         }
       } else if (event.type === 'status.update') {
+        if (payload?.usage && (!explicitSid || isActiveEvent)) {
+          setCurrentUsage(current => ({ ...current, ...payload.usage }))
+        }
+
         if (sessionId && payload?.kind === 'compacting') {
           setSessionCompacting(sessionId, true)
           compactedTurnRef.current.add(sessionId)

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -753,7 +753,7 @@ def _emit(event: str, sid: str, payload: dict | None = None):
     write_json({"jsonrpc": "2.0", "method": "event", "params": params})
 
 
-def _status_update(sid: str, kind: str, text: str | None = None):
+def _status_update(sid: str, kind: str, text: str | None = None, *, agent=None):
     body = (text if text is not None else kind).strip()
     if not body:
         return
@@ -766,7 +766,13 @@ def _status_update(sid: str, kind: str, text: str | None = None):
 
         if COMPACTION_STATUS_MARKER in body:
             out_kind = "compacting"
-    _emit("status.update", sid, {"kind": out_kind, "text": body})
+    payload: dict = {"kind": out_kind, "text": body}
+    if agent is not None:
+        try:
+            payload["usage"] = _get_usage(agent)
+        except Exception:
+            pass
+    _emit("status.update", sid, payload)
 
 
 def _estimate_image_tokens(width: int, height: int) -> int:
@@ -2994,7 +3000,10 @@ def _agent_cbs(sid: str) -> dict:
             {"text": text, **({"verbose": True} if _session_verbose(sid) else {})},
         ),
         "status_callback": lambda kind, text=None: _status_update(
-            sid, str(kind), None if text is None else str(text)
+            sid,
+            str(kind),
+            None if text is None else str(text),
+            agent=(_sessions.get(sid) or {}).get("agent"),
         ),
         # Credits/notice spine (L1): an AgentNotice fired by the agent becomes a
         # notification.show WS event; a recovery clear becomes notification.clear.


### PR DESCRIPTION
## Summary

This PR lets Desktop update the visible usage/context count from `status.update` events.

The gateway now includes current usage in status updates when an agent is available, and the Desktop stream handler merges that usage for the active session.

## Why

Desktop already updates usage from `session.info` and turn completion events. During long-running turns, status events can arrive before completion, so carrying usage there keeps the status bar closer to the current backend state.

## Validation

- `npm run typecheck`
- `.venv\Scripts\python.exe -m py_compile tui_gateway\server.py`
- `git diff --check`