### PR TITLE
fix(cli): suppress redundant 'preparing execute_code…' status line

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -10851,7 +10851,10 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
 
         from agent.display import get_tool_emoji
         emoji = get_tool_emoji(tool_name, default="⚡")
-        _cprint(f"  ┊ {emoji} preparing {tool_name}…")
+        # Skip the "preparing" status line for execute_code — the code preview
+        # from tool.started follows immediately, making it redundant noise.
+        if tool_name != "execute_code":
+            _cprint(f"  ┊ {emoji} preparing {tool_name}…")
 
     # ====================================================================
     # Tool progress callback (audio cues for voice mode)


### PR DESCRIPTION
## Summary

In `_on_tool_gen_start()` (cli.py:8955), a `preparing {tool_name}…` status line is printed when the model begins generating tool-call arguments. For most tools this is useful feedback, but for `execute_code` the subsequent `tool.started` progress event immediately shows a multi-line code preview, making the `preparing` line redundant noise.

## Change

Skip the `preparing` status line only when `tool_name == "execute_code"`. All other tools continue to show it as before.

```
Before:
  ┊ ⚡ preparing execute_code…          ← redundant
  ┊ 🐍 print("hello world")
  ... output ...

After:
  ┊ 🐍 print("hello world")
  ... output ...
```

Closes #48128

## Related

- #47773 — multi-line code preview for execute_code (the preview that makes `preparing` redundant)
- #8423 — option to suppress code display for execute_code (opposite direction)