### PR TITLE
fix(cron): discover plugins before cron agent construction (#48043)

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -1587,6 +1587,20 @@ def _run_job_impl(job: dict) -> tuple[bool, str, str, Optional[str]]:
             except Exception as e:
                 logger.debug("Job '%s': failed to load credential pool for %s: %s", job_id, runtime_provider, e)
 
+        # Discover and load plugins so lifecycle hooks (pre_tool_call,
+        # post_tool_call, etc.) fire during cron execution.  Idempotent:
+        # subsequent ticks short-circuit on already-loaded plugins.  Must
+        # happen BEFORE AIAgent construction so the tool registry picks up
+        # plugin-registered hooks.  See #48043.
+        try:
+            from hermes_cli.plugins import discover_plugins
+            discover_plugins()
+        except Exception as _plugin_exc:
+            logger.warning(
+                "Job '%s': plugin discovery failed (non-fatal): %s",
+                job_id, _plugin_exc,
+            )
+
         # Initialize MCP servers so configured mcp_servers are available to
         # the agent's tool registry before AIAgent is constructed. Without
         # this, cron jobs never saw any MCP tools — only the gateway / CLI


### PR DESCRIPTION
Fixes #48043. Plugin hooks (pre_tool_call, post_tool_call) silently no-op during cron job execution because discover_plugins() was never called before the cron agent runs. The gateway calls it at startup, but the cron scheduler creates a fresh AIAgent per job without plugin discovery. This adds a discover_plugins() call in _run_job_impl() before AIAgent construction, matching the pattern used for discover_mcp_tools(). All 128 scheduler tests and 72 plugin tests pass.