### PR TITLE
fix(gateway): strip timestamp prefixes with multi-word timezone names (Windows)

### DIFF
--- a/gateway/message_timestamps.py
+++ b/gateway/message_timestamps.py
@@ -13,11 +13,20 @@ from typing import Any, Optional, Tuple
 
 
 # Current gateway format: [Tue 2026-04-28 13:40:53 CEST]
+#
+# The timezone token must allow internal spaces. ``format_message_timestamp``
+# builds the suffix from ``strftime("%Z")``, which on POSIX returns a short
+# abbreviation (``CEST``) but on Windows returns the full descriptive name with
+# spaces (``Pacific Daylight Time``). A space-free token only matched the POSIX
+# shape, so a prefix this module formatted on Windows could never be stripped
+# again -- breaking the strip/render idempotence and accumulating
+# ``[timestamp] [timestamp] ...`` prefixes. Match one or more space-separated
+# tokens so the parser recognises every name the formatter can emit.
 _HUMAN_TIMESTAMP_RE = re.compile(
     r"^\[(?P<dow>[A-Z][a-z]{2}) "
     r"(?P<date>\d{4}-\d{2}-\d{2}) "
     r"(?P<time>\d{2}:\d{2}:\d{2})"
-    r"(?: (?P<tz>[A-Za-z0-9_+\-/:]+))?\]\s*"
+    r"(?: (?P<tz>[A-Za-z0-9_+\-/:]+(?: [A-Za-z0-9_+\-/:]+)*))?\]\s*"
 )
 
 # Older gateway format: [2026-04-13T17:02:06+0200] or [+02:00]

--- a/tests/gateway/test_message_timestamps.py
+++ b/tests/gateway/test_message_timestamps.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timedelta, tzinfo
 from zoneinfo import ZoneInfo
 
 from gateway.message_timestamps import (
@@ -10,6 +10,27 @@ from run_agent import AIAgent
 
 
 BERLIN = ZoneInfo("Europe/Berlin")
+
+
+class _WindowsStyleTZ(tzinfo):
+    """A tzinfo whose name contains spaces, mirroring how Windows reports the
+    local zone through ``datetime.strftime('%Z')`` (e.g. ``Pacific Daylight
+    Time``).  POSIX systems return short abbreviations like ``PDT``, but
+    Windows returns the full descriptive name, which is what the gateway emits
+    when no IANA timezone is configured (``tz`` is ``None`` and the code falls
+    back to ``astimezone()``)."""
+
+    def utcoffset(self, dt):
+        return timedelta(hours=-7)
+
+    def dst(self, dt):
+        return timedelta(0)
+
+    def tzname(self, dt):
+        return "Pacific Daylight Time"
+
+
+_WINDOWS_TZ = _WindowsStyleTZ()
 
 
 def _epoch(year, month, day, hour, minute, second):
@@ -59,6 +80,45 @@ def test_strip_leading_message_timestamps_removes_multiple_prefixes_and_prefers_
 
     assert stripped == "[Example User] This should go on our todo list"
     assert embedded_ts == _epoch(2026, 4, 27, 15, 54, 44)
+
+
+def test_strip_removes_multiword_timezone_prefix():
+    # Windows ``strftime('%Z')`` yields multi-word zone names. The strip pass
+    # (which runs on every inbound gateway message to keep storage clean) must
+    # still recognise such a prefix, otherwise contaminated rows are persisted
+    # and never cleaned.
+    content = (
+        "[Tue 2026-04-28 13:40:53 Pacific Daylight Time] "
+        "[Example User] hello"
+    )
+
+    stripped, _embedded = strip_leading_message_timestamps(content)
+
+    assert stripped == "[Example User] hello"
+
+
+def test_render_is_idempotent_with_multiword_timezone():
+    # Re-rendering a row that already carries a multi-word-timezone prefix must
+    # not stack a second prefix. On affected systems this is the
+    # "[timestamp] [timestamp] ..." accumulation the module exists to prevent.
+    ts = datetime(2026, 4, 28, 13, 40, 53, tzinfo=_WINDOWS_TZ).timestamp()
+
+    once = render_user_content_with_timestamp(
+        "[Example User] hi", ts, tz=_WINDOWS_TZ
+    )
+    twice = render_user_content_with_timestamp(once, ts, tz=_WINDOWS_TZ)
+
+    assert once == twice
+    assert once.count("2026-04-28") == 1
+
+
+def test_strip_still_handles_abbreviation_timezones():
+    # Guard against over-widening: short abbreviations and numeric offsets must
+    # keep stripping exactly as before the multi-word fix.
+    for tz_token in ("PDT", "CEST", "UTC", "GMT+5", "+05:30"):
+        content = f"[Tue 2026-04-28 13:40:53 {tz_token}] body"
+        stripped, _embedded = strip_leading_message_timestamps(content)
+        assert stripped == "body", tz_token
 
 
 def test_coerce_message_timestamp_accepts_datetime_and_epoch():


### PR DESCRIPTION
### What this fixes
`gateway/message_timestamps.py` writes message timestamps as `[Tue 2026-04-28 13:40:53 <tz>]`, where `<tz>` comes from `strftime("%Z")`. On Linux and macOS that is a short abbreviation (`CEST`), but on Windows it is the full descriptive name with spaces (`Pacific Daylight Time`). The strip regex `_HUMAN_TIMESTAMP_RE` only allowed a space free timezone token, so on Windows the module cannot recognise a prefix it formatted itself. This uses the system zone name when no timezone is configured, the common default on Windows and Windows Server.

Two consequences, both Windows only:
- `strip_leading_message_timestamps` runs on every inbound gateway message to keep storage clean and is what cleans the legacy contaminated rows this module documents. On Windows it cannot strip a multi word zone prefix, so those rows are never cleaned.
- `render_user_content_with_timestamp` (used when `gateway.message_timestamps.enabled` is on) strips then re-adds a prefix, so on an already-prefixed row the failed strip leaves a stacked timestamp.

Fixes #48133.

### The fix
I widened the timezone group so it accepts one or more space separated tokens:

```diff
- (?P<tz>[A-Za-z0-9_+\-/:]+)
+ (?P<tz>[A-Za-z0-9_+\-/:]+(?: [A-Za-z0-9_+\-/:]+)*)
```

This matches every name `strftime("%Z")` can emit, making the parser symmetric with the formatter. It is bounded by the closing `]`, so it never runs past the prefix, and the no timezone and short abbreviation shapes still match exactly as before.

### Testing
I confirmed the bug two ways: the regression tests below and a direct reproduction. I added three tests in `tests/gateway/test_message_timestamps.py`:
- `test_strip_removes_multiword_timezone_prefix`: a `Pacific Daylight Time` prefix is stripped.
- `test_render_is_idempotent_with_multiword_timezone`: re-rendering a row that already carries such a prefix does not stack a second one.
- `test_strip_still_handles_abbreviation_timezones`: a guard that `PDT`, `CEST`, `UTC`, `GMT+5`, and `+05:30` still strip, so the change does not over widen.

The first two fail on clean `main` and pass with this change, the third passes both ways. The full `tests/gateway/test_message_timestamps.py` passes (11 total, 8 original plus 3 new), and ruff is clean on both files. I did not run the full suite locally, so I am relying on continuous integration for that.

Max Freedom Pollard
