### PR TITLE
fix(desktop): refresh sidebar after auto-title

### DIFF
--- a/agent/title_generator.py
+++ b/agent/title_generator.py
@@ -119,7 +119,8 @@ def auto_title_session(
         return
 
     try:
-        session_db.set_session_title(session_id, title)
+        if not session_db.set_session_title(session_id, title):
+            return
         logger.debug("Auto-generated session title: %s", title)
         if title_callback is not None:
             try:

--- a/apps/desktop/src/app/session/hooks/use-message-stream.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream.ts
@@ -35,6 +35,7 @@ import { notify } from '@/store/notifications'
 import { requestDesktopOnboarding } from '@/store/onboarding'
 import { clearAllPrompts, setApprovalRequest, setSecretRequest, setSudoRequest } from '@/store/prompts'
 import {
+  applySessionTitleUpdate,
   setCurrentBranch,
   setCurrentCwd,
   setCurrentFastMode,
@@ -44,6 +45,7 @@ import {
   setCurrentReasoningEffort,
   setCurrentServiceTier,
   setCurrentUsage,
+  setSessions,
   setTurnStartedAt,
   setYoloActive
 } from '@/store/session'
@@ -899,6 +901,16 @@ export function useMessageStream({
         if (payload?.usage) {
           setCurrentUsage(current => ({ ...current, ...payload.usage }))
         }
+      } else if (event.type === 'session.title.updated') {
+        const title = typeof payload?.title === 'string' ? payload.title : ''
+        const storedSessionId = typeof payload?.stored_session_id === 'string' ? payload.stored_session_id : null
+
+        if (title.trim()) {
+          setSessions(prev => applySessionTitleUpdate(prev, sessionId, storedSessionId, title))
+        }
+
+        void refreshSessions().catch(() => undefined)
+        broadcastSessionsChanged()
       } else if (event.type === 'tool.start' || event.type === 'tool.progress' || event.type === 'tool.generating') {
         if (!sessionId) {
           return
@@ -1134,6 +1146,7 @@ export function useMessageStream({
       flushQueuedDeltas,
       queryClient,
       refreshHermesConfig,
+      refreshSessions,
       sessionInterrupted,
       updateSessionState,
       upsertToolCall

--- a/apps/desktop/src/lib/chat-messages.ts
+++ b/apps/desktop/src/lib/chat-messages.ts
@@ -25,6 +25,8 @@ export type GatewayEventPayload = {
   rendered?: string
   status?: string
   message?: string
+  title?: string
+  stored_session_id?: string
   id?: string
   name?: string
   tool_id?: string

--- a/apps/desktop/src/store/session.test.ts
+++ b/apps/desktop/src/store/session.test.ts
@@ -9,6 +9,7 @@ import {
   $currentCwd,
   $workingSessionIds,
   applyConfiguredDefaultProjectDir,
+  applySessionTitleUpdate,
   getRecentlySettledSessionIds,
   mergeSessionPage,
   sessionPinId,
@@ -180,6 +181,33 @@ describe('mergeSessionPage', () => {
     const merged = mergeSessionPage(previous, incoming, ['b'])
 
     expect(merged.map(s => s.id)).toEqual(['b', 'a-new'])
+  })
+})
+
+describe('applySessionTitleUpdate', () => {
+  it('updates the matching stored session title', () => {
+    const sessions = [
+      session({ id: 'stored-1', title: null }),
+      session({ id: 'other', title: 'Other' })
+    ]
+
+    const next = applySessionTitleUpdate(sessions, 'runtime-1', 'stored-1', '  Rome Origins  ')
+
+    expect(next).not.toBe(sessions)
+    expect(next.find(s => s.id === 'stored-1')?.title).toBe('Rome Origins')
+    expect(next.find(s => s.id === 'other')?.title).toBe('Other')
+  })
+
+  it('matches compression lineage roots without touching unrelated sessions', () => {
+    const sessions = [
+      session({ id: 'tip-2', _lineage_root_id: 'root-1', title: null }),
+      session({ id: 'other', _lineage_root_id: 'root-2', title: 'Other' })
+    ]
+
+    const next = applySessionTitleUpdate(sessions, null, 'root-1', 'Updated')
+
+    expect(next.find(s => s.id === 'tip-2')?.title).toBe('Updated')
+    expect(next.find(s => s.id === 'other')?.title).toBe('Other')
   })
 })
 

--- a/apps/desktop/src/store/session.ts
+++ b/apps/desktop/src/store/session.ts
@@ -169,6 +169,44 @@ export function mergeSessionPage(
   return survivors.length ? [...survivors, ...incoming] : incoming
 }
 
+export function applySessionTitleUpdate(
+  sessions: SessionInfo[],
+  runtimeSessionId: null | string | undefined,
+  storedSessionId: null | string | undefined,
+  title: string
+): SessionInfo[] {
+  const normalizedTitle = title.trim()
+
+  if (!normalizedTitle) {
+    return sessions
+  }
+
+  const ids = new Set([runtimeSessionId, storedSessionId].filter((id): id is string => Boolean(id)))
+
+  if (ids.size === 0) {
+    return sessions
+  }
+
+  let changed = false
+  const next = sessions.map(session => {
+    const lineageId = session._lineage_root_id ?? ''
+
+    if (!ids.has(session.id) && (!lineageId || !ids.has(lineageId))) {
+      return session
+    }
+
+    if (session.title === normalizedTitle) {
+      return session
+    }
+
+    changed = true
+
+    return { ...session, title: normalizedTitle }
+  })
+
+  return changed ? next : sessions
+}
+
 export const $connection = atom<HermesConnection | null>(null)
 export const $gatewayState = atom('idle')
 export const $sessions = atom<SessionInfo[]>([])

--- a/tests/agent/test_title_generator.py
+++ b/tests/agent/test_title_generator.py
@@ -137,6 +137,7 @@ class TestAutoTitleSession:
     def test_invokes_title_callback_after_setting_title(self):
         db = MagicMock()
         db.get_session_title.return_value = None
+        db.set_session_title.return_value = True
         seen = []
         with patch("agent.title_generator.generate_title", return_value="Readable Session"):
             auto_title_session(
@@ -148,6 +149,24 @@ class TestAutoTitleSession:
             )
         db.set_session_title.assert_called_once_with("sess-1", "Readable Session")
         assert seen == ["Readable Session"]
+
+    def test_skips_title_callback_when_title_did_not_persist(self):
+        db = MagicMock()
+        db.get_session_title.return_value = None
+        db.set_session_title.return_value = False
+        seen = []
+
+        with patch("agent.title_generator.generate_title", return_value="Readable Session"):
+            auto_title_session(
+                db,
+                "missing-session",
+                "hello",
+                "hi there",
+                title_callback=seen.append,
+            )
+
+        db.set_session_title.assert_called_once_with("missing-session", "Readable Session")
+        assert seen == []
 
     def test_skips_if_generation_fails(self):
         db = MagicMock()

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -5472,7 +5472,7 @@ class _ImmediateThread:
 
 
 def test_prompt_submit_auto_titles_session_on_complete(monkeypatch):
-    """maybe_auto_title is called after a successful (complete) prompt."""
+    """maybe_auto_title is called after a successful prompt and can refresh UI."""
 
     class _Agent:
         def run_conversation(
@@ -5488,7 +5488,8 @@ def test_prompt_submit_auto_titles_session_on_complete(monkeypatch):
 
     server._sessions["sid"] = _session(agent=_Agent())
     monkeypatch.setattr(server.threading, "Thread", _ImmediateThread)
-    monkeypatch.setattr(server, "_emit", lambda *args, **kwargs: None)
+    emitted = []
+    monkeypatch.setattr(server, "_emit", lambda *args, **kwargs: emitted.append(args))
     monkeypatch.setattr(server, "make_stream_renderer", lambda cols: None)
     monkeypatch.setattr(server, "render_message", lambda raw, cols: None)
     monkeypatch.setattr(server, "_get_db", lambda: None)
@@ -5507,6 +5508,13 @@ def test_prompt_submit_auto_titles_session_on_complete(monkeypatch):
     assert args[1] == "session-key"
     assert args[2] == "Tell me about Rome"
     assert args[3] == "Rome was founded in 753 BC."
+    callback = mock_title.call_args.kwargs["title_callback"]
+    callback("Rome Origins")
+    assert emitted[-1] == (
+        "session.title.updated",
+        "sid",
+        {"stored_session_id": "session-key", "title": "Rome Origins"},
+    )
 
 
 def test_prompt_submit_skips_auto_title_when_interrupted(monkeypatch):

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -6223,12 +6223,25 @@ def _run_prompt_submit(rid, sid: str, session: dict, text: Any) -> None:
                 try:
                     from agent.title_generator import maybe_auto_title
 
+                    stored_session_id = session.get("session_key") or sid
+
+                    def _on_auto_title(title: str) -> None:
+                        _emit(
+                            "session.title.updated",
+                            sid,
+                            {
+                                "stored_session_id": stored_session_id,
+                                "title": title,
+                            },
+                        )
+
                     maybe_auto_title(
                         _get_db(),
-                        session.get("session_key") or sid,
+                        stored_session_id,
                         text,
                         raw,
                         session.get("history", []),
+                        title_callback=_on_auto_title,
                     )
                 except Exception:
                     pass


### PR DESCRIPTION
## Summary
- emit a title-specific TUI gateway event after async auto-title generation persists a title
- patch Desktop sidebar session rows by runtime id, stored id, or compression lineage, then refresh/broadcast the session list
- only fire auto-title callbacks after `set_session_title()` confirms the title was stored

Fixes #47926. Related to #44810, but that backend-only PR emits `session.info`; the current Desktop sidebar does not patch title rows from that event, and `_session_info()` does not carry the title.

## Testing
- `$HOME/.hermes/hermes-agent/venv/bin/python -m pytest tests/agent/test_title_generator.py`
- `$HOME/.hermes/hermes-agent/venv/bin/python -m pytest tests/agent/test_title_generator.py tests/test_tui_gateway_server.py -k "title_callback or auto_title or session_title"`
- `npm --workspace apps/desktop run typecheck`
- `npm --workspace apps/desktop run test:ui -- src/store/session.test.ts -t applySessionTitleUpdate`
- `npm --workspace apps/desktop exec eslint -- --quiet src/store/session.ts src/store/session.test.ts src/app/session/hooks/use-message-stream.ts src/lib/chat-messages.ts`
- `git diff --check`

Note: running the full `src/store/session.test.ts` file in this local jsdom setup still fails in pre-existing workspaceCwdForNewSession tests because `window.localStorage` is unavailable; the new `applySessionTitleUpdate` focused tests pass.