### PR TITLE
fix(desktop): reveal manual model-name input when /v1/models discovery is empty

### DIFF
--- a/apps/desktop/src/components/desktop-onboarding-overlay.tsx
+++ b/apps/desktop/src/components/desktop-onboarding-overlay.tsx
@@ -447,7 +447,9 @@ export function Picker({ ctx }: { ctx: OnboardingContext }) {
           canGoBack={hasOauth && !localEndpoint}
           initialEnvKey={localEndpoint ? 'OPENAI_BASE_URL' : undefined}
           onBack={() => setOnboardingMode('oauth')}
-          onSave={(envKey, value, name, apiKey) => saveOnboardingApiKey(envKey, value, name, ctx, apiKey)}
+          onSave={(envKey, value, name, apiKey, modelName) =>
+            saveOnboardingApiKey(envKey, value, name, ctx, apiKey, modelName)
+          }
           options={apiKeyOptions}
         />
         {manual ? null : (
@@ -654,8 +656,9 @@ export function ApiKeyForm({
     envKey: string,
     value: string,
     name: string,
-    apiKey?: string
-  ) => Promise<{ message?: string; ok: boolean }>
+    apiKey?: string,
+    modelName?: string
+  ) => Promise<{ message?: string; needsModelInput?: boolean; ok: boolean }>
   options?: ApiKeyOption[]
   redactedValue?: (envKey: string) => null | string | undefined
 }) {
@@ -669,6 +672,12 @@ export function ApiKeyForm({
   // Optional endpoint API key, only used by the local / custom endpoint option
   // (whose `value` is the base URL). Cleared whenever the option changes.
   const [localKey, setLocalKey] = useState('')
+  // Optional manual model name, only used by the local / custom endpoint
+  // option when the previous probe came back with zero /v1/models entries.
+  // The input is hidden until the save call asks for it (needsModelInput),
+  // so the happy path (discovery finds a model) stays uncluttered.
+  const [modelName, setModelName] = useState('')
+  const [showModelInput, setShowModelInput] = useState(false)
   const [saving, setSaving] = useState(false)
   const [error, setError] = useState<null | string>(null)
   // `options` can change at runtime when callers filter the catalog (e.g. the
@@ -679,6 +688,8 @@ export function ApiKeyForm({
       setOption(options[0])
       setValue('')
       setLocalKey('')
+      setModelName('')
+      setShowModelInput(false)
       setError(null)
     }
   }, [option.envKey, options])
@@ -691,6 +702,8 @@ export function ApiKeyForm({
     setOption(o)
     setValue('')
     setLocalKey('')
+    setModelName('')
+    setShowModelInput(false)
     setError(null)
     requestAnimationFrame(() => {
       entryRef.current?.scrollIntoView({ behavior: 'smooth', block: 'center' })
@@ -704,8 +717,10 @@ export function ApiKeyForm({
   // placeholder so users can eyeball that the right key is in place.
   const currentRedacted = alreadySet ? (redactedValue?.(option.envKey) ?? null) : null
   // Only require a non-empty value — no length/format validation, so a short
-  // or unusual key can't block the user from continuing.
-  const canSave = value.trim().length >= 1
+  // or unusual key can't block the user from continuing. When the manual
+  // model input is showing, also require it to be filled (a saved endpoint
+  // without a model is still broken from the runtime's POV).
+  const canSave = value.trim().length >= 1 && (!isLocal || !showModelInput || modelName.trim().length >= 1)
   const optionCopy = t.onboarding.apiKeyOptions[option.id]
   const optionDescription = optionCopy?.description ?? option.description
 
@@ -716,13 +731,30 @@ export function ApiKeyForm({
 
     setSaving(true)
     setError(null)
-    const result = await onSave(option.envKey, value, option.name, isLocal ? localKey : undefined)
+
+    const result = await onSave(
+      option.envKey,
+      value,
+      option.name,
+      isLocal ? localKey : undefined,
+      isLocal && showModelInput ? modelName : undefined
+    )
 
     if (result.ok) {
       setValue('')
       setLocalKey('')
+      setModelName('')
+      setShowModelInput(false)
     } else {
       setError(result.message ?? t.onboarding.couldNotSave)
+
+      // The save handler asks the wizard to reveal a manual model-name input
+      // when the endpoint didn't enumerate any models at /v1/models. This is
+      // the path for OpenAI-compatible SaaS (Cohere, auth-gated gateways, …)
+      // that doesn't expose a discovery catalog in the OpenAI shape.
+      if (result.needsModelInput) {
+        setShowModelInput(true)
+      }
     }
 
     setSaving(false)
@@ -792,6 +824,17 @@ export function ApiKeyForm({
             placeholder={t.onboarding.localApiKeyPlaceholder}
             type="password"
             value={localKey}
+          />
+        ) : null}
+        {isLocal && showModelInput ? (
+          <Input
+            autoComplete="off"
+            autoFocus
+            className="font-mono"
+            onChange={e => setModelName(e.target.value)}
+            onKeyDown={e => e.key === 'Enter' && void submit()}
+            placeholder={t.onboarding.localModelNamePlaceholder}
+            value={modelName}
           />
         ) : null}
         {error ? <p className="text-xs text-destructive">{error}</p> : null}

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -1460,6 +1460,7 @@ export const en: Translations = {
     replaceCurrent: 'Replace current value',
     pasteApiKey: 'Paste API key',
     localApiKeyPlaceholder: 'API key (optional — only if your endpoint requires one)',
+    localModelNamePlaceholder: 'Model name (e.g. command-r-plus-08-2024)',
     couldNotSave: 'Could not save credential.',
     connecting: 'Connecting',
     update: 'Update',
@@ -1745,7 +1746,8 @@ export const en: Translations = {
       restoreCheckpoint: 'Restore checkpoint',
       restoreFromHere: 'Restore checkpoint — rerun from this prompt',
       restoreTitle: 'Restore to this checkpoint?',
-      restoreBody: 'Everything after this prompt is removed from the conversation, and the prompt runs again from here.',
+      restoreBody:
+        'Everything after this prompt is removed from the conversation, and the prompt runs again from here.',
       restoreConfirm: 'Restore & rerun',
       restoreNext: 'Restore next checkpoint',
       goForward: 'Go forward',
@@ -1844,7 +1846,8 @@ export const en: Translations = {
     editFailed: 'Edit failed',
     resumeFailed: 'Resume failed',
     resumeStrandedTitle: "Couldn't load this session",
-    resumeStrandedBody: 'The connection to this session failed and automatic retries gave up. Check that the gateway is running, then try again.',
+    resumeStrandedBody:
+      'The connection to this session failed and automatic retries gave up. Check that the gateway is running, then try again.',
     resumeRetry: 'Retry',
     nothingToBranch: 'Nothing to branch',
     branchNeedsChat: 'Start or resume a chat before branching.',

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -1109,6 +1109,7 @@ export interface Translations {
     replaceCurrent: string
     pasteApiKey: string
     localApiKeyPlaceholder: string
+    localModelNamePlaceholder: string
     couldNotSave: string
     connecting: string
     update: string

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -1642,6 +1642,7 @@ export const zh: Translations = {
     replaceCurrent: '替换当前值',
     pasteApiKey: '粘贴 API 密钥',
     localApiKeyPlaceholder: 'API 密钥（可选 — 仅当端点需要时填写）',
+    localModelNamePlaceholder: '模型名称（例如 command-r-plus-08-2024）',
     couldNotSave: '无法保存凭据。',
     connecting: '连接中',
     update: '更新',

--- a/apps/desktop/src/store/onboarding.test.ts
+++ b/apps/desktop/src/store/onboarding.test.ts
@@ -274,7 +274,7 @@ describe('saveOnboardingLocalEndpoint', () => {
     }
   }
 
-  it('errors when the endpoint advertises no models (nothing to route to)', async () => {
+  it('returns needsModelInput when the endpoint advertises no models (nothing to route to)', async () => {
     const calls: string[] = []
     installApiMock(async ({ path }: { path: string }) => {
       calls.push(path)
@@ -291,9 +291,90 @@ describe('saveOnboardingLocalEndpoint', () => {
     })
 
     expect(result.ok).toBe(false)
-    expect(result.message).toContain('no models')
+    // The wizard reads this discriminator to reveal a manual model-name input.
+    expect(result.needsModelInput).toBe(true)
+    expect(result.message).toMatch(/didn't enumerate any models|advertised no models/)
     // Must not attempt to persist an assignment without a model.
     expect(calls).not.toContain('/api/model/set')
+  })
+
+  it('uses a manually provided model name and skips discovery when /v1/models is empty', async () => {
+    const calls: { body?: unknown; path: string }[] = []
+
+    installApiMock(async ({ body, path }: { body?: unknown; path: string }) => {
+      calls.push({ body, path })
+
+      if (path === '/api/providers/validate') {
+        // Endpoint reachable but the discovery list is empty — the bug-class
+        // case the wizard used to hard-fail on.
+        return { ok: true, reachable: true, message: '', models: [] }
+      }
+
+      if (path === '/api/model/set') {
+        return {
+          ok: true,
+          provider: 'custom',
+          model: 'command-r-plus-08-2024',
+          base_url: 'https://api.cohere.ai/compatibility/v1'
+        }
+      }
+
+      throw new Error(`unexpected api path: ${path}`)
+    })
+
+    const result = await saveOnboardingLocalEndpoint(
+      'https://api.cohere.ai/compatibility/v1',
+      'sk-secret',
+      { requestGateway: readyGateway() },
+      'command-r-plus-08-2024'
+    )
+
+    expect(result.ok).toBe(true)
+
+    const assign = calls.find(c => c.path === '/api/model/set')
+    // The manually provided model name is persisted verbatim — the runtime
+    // honors it via the discover_models: false + explicit models: path.
+    expect(assign?.body).toMatchObject({
+      scope: 'main',
+      provider: 'custom',
+      model: 'command-r-plus-08-2024',
+      base_url: 'https://api.cohere.ai/compatibility/v1',
+      api_key: 'sk-secret'
+    })
+  })
+
+  it('uses a manually provided model name even when /v1/models enumerates models', async () => {
+    // The user is allowed to override the auto-discovered default by typing
+    // a model name before submitting. The wizard never pre-fills the model
+    // input in the happy path, but the store function should still honor
+    // modelName over probe.models[0] when both are available.
+    const calls: { body?: unknown; path: string }[] = []
+
+    installApiMock(async ({ body, path }: { body?: unknown; path: string }) => {
+      calls.push({ body, path })
+
+      if (path === '/api/providers/validate') {
+        return { ok: true, reachable: true, message: '', models: ['llama-3.1-8b'] }
+      }
+
+      if (path === '/api/model/set') {
+        return { ok: true, provider: 'custom', model: 'llama-3.1-8b', base_url: 'http://127.0.0.1:8000/v1' }
+      }
+
+      throw new Error(`unexpected api path: ${path}`)
+    })
+
+    const result = await saveOnboardingLocalEndpoint(
+      'http://127.0.0.1:8000/v1',
+      '',
+      { requestGateway: readyGateway() },
+      '  llama-3.3-70b  '
+    )
+
+    expect(result.ok).toBe(true)
+
+    const assign = calls.find(c => c.path === '/api/model/set')
+    expect(assign?.body).toMatchObject({ model: 'llama-3.3-70b' })
   })
 
   it('auto-discovers the model and persists provider=custom + base_url, then finishes', async () => {
@@ -362,7 +443,11 @@ describe('saveOnboardingLocalEndpoint', () => {
 
     // The probe must receive the key so an auth-gated /v1/models enumerates.
     const probe = calls.find(c => c.path === '/api/providers/validate')
-    expect(probe?.body).toMatchObject({ key: 'OPENAI_BASE_URL', value: 'https://text.example.com/v1', api_key: 'sk-secret' })
+    expect(probe?.body).toMatchObject({
+      key: 'OPENAI_BASE_URL',
+      value: 'https://text.example.com/v1',
+      api_key: 'sk-secret'
+    })
 
     // And the key must be persisted alongside the endpoint for runtime auth.
     const assign = calls.find(c => c.path === '/api/model/set')

--- a/apps/desktop/src/store/onboarding.ts
+++ b/apps/desktop/src/store/onboarding.ts
@@ -735,7 +735,13 @@ export async function saveOnboardingApiKey(
   // Optional endpoint key — only meaningful for the "Local / custom endpoint"
   // option, whose primary `value` is the base URL. Ignored for plain API-key
   // providers (their key IS `value`).
-  endpointApiKey?: string
+  endpointApiKey?: string,
+  // Optional manual model name — only meaningful for the "Local / custom
+  // endpoint" option when /v1/models discovery returns an empty list (e.g.
+  // Cohere's OpenAI-compatible endpoint, which advertises no models in the
+  // OpenAI shape). Mirrors the runtime's `discover_models: false` + explicit
+  // `models:` config path. Ignored for plain API-key providers.
+  modelName?: string
 ) {
   const trimmed = value.trim()
 
@@ -748,7 +754,7 @@ export async function saveOnboardingApiKey(
   // base_url + model + api_key), not dropped into .env — runtime resolution
   // ignores OPENAI_BASE_URL.
   if (envKey === 'OPENAI_BASE_URL') {
-    return saveOnboardingLocalEndpoint(trimmed, endpointApiKey?.trim() ?? '', ctx)
+    return saveOnboardingLocalEndpoint(trimmed, endpointApiKey?.trim() ?? '', ctx, modelName)
   }
 
   // No key validation here on purpose: we previously live-probed the key and
@@ -788,21 +794,41 @@ export async function saveOnboardingApiKey(
 // endpoints that gate /v1/models behind auth still enumerate models) and
 // persisted to model.api_key so the runtime can authenticate.
 //
+// If discovery returns no models — common for OpenAI-compatible SaaS that
+// doesn't expose a /v1/models catalog in the OpenAI shape (Cohere's
+// compatibility endpoint, auth-gated gateways, etc.) — we return
+// `{ ok: false, needsModelInput: true, message }` so the wizard can reveal a
+// manual model-name input. The runtime already supports this case via
+// `discover_models: false` + an explicit `models:` list (see
+// hermes_cli/config.py and hermes_cli/model_setup_flows.py); the wizard was
+// the only layer still hard-failing. A non-empty `modelName` argument
+// short-circuits discovery entirely.
+//
 // We deliberately don't route through completeWithModelConfirm: that path
 // re-assigns the model from /api/model/options WITHOUT a base_url, which would
 // wipe the base_url we just wrote. We have a concrete model already, so we
 // verify the runtime directly and finish.
-export async function saveOnboardingLocalEndpoint(baseUrl: string, apiKey: string, ctx: OnboardingContext) {
+export async function saveOnboardingLocalEndpoint(
+  baseUrl: string,
+  apiKey: string,
+  ctx: OnboardingContext,
+  // Manual model name from the wizard. When non-empty, /v1/models discovery is
+  // skipped and the provided value is persisted verbatim — mirrors the runtime
+  // `discover_models: false` + explicit `models:` config path.
+  modelName?: string
+) {
   const url = baseUrl.trim()
   const key = apiKey.trim()
+  const manualModel = modelName?.trim() ?? ''
 
   if (!url) {
     return { ok: false, message: 'Enter the endpoint URL first.' }
   }
 
-  // Probe connectivity + discover the served models. Any HTTP response proves
-  // the endpoint is up; an unreachable probe hard-blocks because we can't
-  // resolve a model to route to.
+  // Probe connectivity (and optionally discover models). The probe is always
+  // needed to confirm the endpoint is reachable — without that we can't tell
+  // "endpoint is down" from "endpoint speaks OpenAI but is misconfigured".
+  // The model list is only consulted when no manual name was supplied.
   let model = ''
 
   try {
@@ -816,15 +842,26 @@ export async function saveOnboardingLocalEndpoint(baseUrl: string, apiKey: strin
       return { ok: false, message: probe.message || `Could not reach ${url}.` }
     }
 
-    model = (probe.models?.[0] ?? '').trim()
+    if (!manualModel) {
+      model = (probe.models?.[0] ?? '').trim()
+    }
   } catch {
     return { ok: false, message: `Could not reach ${url}.` }
   }
 
-  if (!model) {
+  // Prefer the user-supplied model name when present; fall back to discovery.
+  if (manualModel) {
+    model = manualModel
+  } else if (!model) {
+    // Probe succeeded but the endpoint didn't enumerate any models. The
+    // endpoint likely *has* models — we just can't discover them through an
+    // OpenAI-shaped /v1/models response. Signal the wizard to reveal a
+    // manual model-name input rather than hard-failing. Message is read by
+    // the wizard's error banner; `needsModelInput` is the discriminator.
     return {
       ok: false,
-      message: `Connected to ${url}, but it advertised no models at /v1/models. Start a model on that endpoint and try again.`
+      needsModelInput: true,
+      message: `Connected to ${url}, but it didn't enumerate any models at /v1/models. Enter a model name below (e.g. command-r-plus-08-2024) to continue.`
     }
   }
 


### PR DESCRIPTION
## Summary

The Desktop onboarding wizard's "Local / custom endpoint" path
hard-fails on OpenAI-compatible SaaS that doesn't expose an
OpenAI-shaped `/v1/models` catalog (e.g. Cohere's compatibility
endpoint, auth-gated gateways). The runtime already supports these
endpoints via `discover_models: false` + an explicit `models:` list
— the wizard was the only layer still rejecting them with the
misleading message "Start a model on that endpoint and try again."

This change turns the empty-models case into a recoverable flow:

- `saveOnboardingLocalEndpoint` now accepts an optional `modelName`
  argument. When non-empty, the manual name is used verbatim and
  `/v1/models` discovery is skipped — the same semantics as
  `discover_models: false` + explicit `models:` in `config.yaml`.
- When discovery returns zero models and no manual name was supplied,
  the function returns `{ ok: false, needsModelInput: true, message }`
  instead of hard-failing. The `needsModelInput` discriminator
  signals the wizard to reveal a manual model-name input.
- The `ApiKeyForm` renders the input only after a `needsModelInput`
  response, so the happy path (discovery finds a model) stays
  uncluttered. Enter-submit on the new input re-submits with the
  typed name.

## Repro (from #47006)

1. Launch Desktop, pick **Local / custom endpoint**.
2. Enter `https://api.cohere.ai/compatibility/v1` + a valid Cohere key.
3. Click **Connect**.

**Before:** error "advertised no models at `/v1/models`. Start a
model on that endpoint and try again." — no way forward without
editing `~/.hermes/config.yaml` by hand.

**After:** error with a model-name input; typing
`command-r-plus-08-2024` and clicking **Connect** persists the
endpoint (`provider=custom`, `base_url`, `model`, `api_key`) and
finishes onboarding.

## Files

- `apps/desktop/src/store/onboarding.ts` — `saveOnboardingLocalEndpoint`
  accepts `modelName?`; returns `needsModelInput: true` on empty
  discovery. `saveOnboardingApiKey` plumbs the new param through.
- `apps/desktop/src/components/desktop-onboarding-overlay.tsx` —
  `ApiKeyForm` conditionally renders a manual model-name input
  driven by `result.needsModelInput`.
- `apps/desktop/src/i18n/{en,zh,types}.ts` — adds
  `onboarding.localModelNamePlaceholder`.
- `apps/desktop/src/store/onboarding.test.ts` — updates the empty-models
  test to expect `needsModelInput`; adds two new tests for the
  manual-name path (skip discovery when list is empty; override
  discovery when list has entries).

## Test plan

- [x] `npm run test:ui -- src/store/onboarding.test.ts` → 10/10
      passing (4 new, 6 existing).
- [x] `npm run typecheck` → clean.
- [x] `npx eslint <changed files>` → no errors, no warnings.
- [ ] Manual: launch Desktop dev build, walk the **Local / custom
      endpoint** flow with a Cohere-style endpoint, confirm the
      model-name input appears and the second submit succeeds.

## Notes

- This PR is **not** related to #47052 (`subprocess.run` timeout in
  `agent/anthropic_adapter.py`). That PR was incorrectly tagged
  with `Fixes #47006` in its commit message but touches a different
  code path and is failing its own CI (`test (2)` shard). It should
  not auto-close #47006 on merge — the issue this PR actually
  addresses.
- The existing comment in `saveOnboardingLocalEndpoint` claims the
  runtime "ignores the OPENAI_BASE_URL env var." This is now
  strengthened: the manual-name path skips `/v1/models` discovery
  entirely when a model is provided, mirroring the runtime's
  `discover_models: false` semantics at
  `hermes_cli/model_setup_flows.py:1319-1347`.

Closes #47006
