### PR TITLE
fix(skills): plugin skill_view ignores file_path, returns linked_files=None

### DIFF
--- a/tests/test_plugin_skills.py
+++ b/tests/test_plugin_skills.py
@@ -267,6 +267,72 @@ class TestSkillViewQualifiedName:
         assert self.pm.find_plugin_skill("superpowers:writing-plans") is None
 
 
+class TestPluginSkillFilePath:
+    """Plugin skills should support file_path like local skills do.
+
+    Previously, _serve_plugin_skill ignored the file_path parameter entirely,
+    always returning SKILL.md content with linked_files=None. These tests
+    verify the fix: file_path reads sub-files, linked_files is probed, and
+    missing files return a helpful error.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _isolate(self, tmp_path, monkeypatch):
+        from hermes_cli import plugins as plugins_mod
+        from hermes_cli.plugins import PluginManager
+
+        self.pm = PluginManager()
+        monkeypatch.setattr(plugins_mod, "_plugin_manager", self.pm)
+        empty = tmp_path / "empty"
+        empty.mkdir()
+        monkeypatch.setattr("tools.skills_tool.SKILLS_DIR", empty)
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+
+    def _register_skill_with_files(self, tmp_path):
+        """Register a plugin skill with references/ sub-directory."""
+        d = tmp_path / "plugins" / "myplugin" / "skills" / "foo"
+        d.mkdir(parents=True, exist_ok=True)
+        md = d / "SKILL.md"
+        md.write_text("---\nname: foo\ndescription: test\n---\nFoo body.\n")
+        refs = d / "references"
+        refs.mkdir(exist_ok=True)
+        (refs / "api.md").write_text("# API Reference\nDetails here.")
+        self.pm._plugin_skills["myplugin:foo"] = {
+            "path": md, "plugin": "myplugin", "bare_name": "foo", "description": "",
+        }
+        return md
+
+    def test_file_path_reads_subfile(self, tmp_path):
+        from tools.skills_tool import skill_view
+
+        self._register_skill_with_files(tmp_path)
+        result = json.loads(
+            skill_view("myplugin:foo", file_path="references/api.md")
+        )
+        assert result["success"] is True
+        assert "API Reference" in result["content"]
+        assert result.get("file") == "references/api.md"
+
+    def test_linked_files_probed(self, tmp_path):
+        from tools.skills_tool import skill_view
+
+        self._register_skill_with_files(tmp_path)
+        result = json.loads(skill_view("myplugin:foo"))
+        assert result["linked_files"] is not None
+        assert "references/api.md" in result["linked_files"]["references"]
+
+    def test_file_path_not_found_lists_available(self, tmp_path):
+        from tools.skills_tool import skill_view
+
+        self._register_skill_with_files(tmp_path)
+        result = json.loads(
+            skill_view("myplugin:foo", file_path="references/missing.md")
+        )
+        assert result["success"] is False
+        assert "available_files" in result
+        assert "references/api.md" in result["available_files"]
+
+
 class TestSkillViewPluginGuards:
     @pytest.fixture(autouse=True)
     def _isolate(self, tmp_path, monkeypatch):

--- a/tools/skills_tool.py
+++ b/tools/skills_tool.py
@@ -762,9 +762,15 @@ def _serve_plugin_skill(
     *,
     preprocess: bool = True,
     session_id: str | None = None,
+    file_path: str | None = None,
 ) -> str:
-    """Read a plugin-provided skill, apply guards, return JSON."""
+    """Read a plugin-provided skill, apply guards, return JSON.
+
+    When *file_path* is given, return the content of that file within the skill
+    directory instead of SKILL.md — mirroring the local-skill behaviour.
+    """
     from hermes_cli.plugins import _get_disabled_plugins, get_plugin_manager
+    from tools.path_security import validate_within_dir, has_traversal_component
 
     if namespace in _get_disabled_plugins():
         return json.dumps(
@@ -831,6 +837,77 @@ def _serve_plugin_skill(
     except Exception:
         banner = ""
 
+    skill_dir = skill_md.parent
+
+    # ── linked_files: probe the skill directory like local skills ────────
+    linked_files: Dict[str, list] = {}
+    if skill_dir.exists():
+        references_dir = skill_dir / "references"
+        if references_dir.is_dir():
+            ref_files = [f.relative_to(skill_dir).as_posix() for f in references_dir.iterdir() if f.is_file()]
+            if ref_files:
+                linked_files["references"] = sorted(ref_files)
+        templates_dir = skill_dir / "templates"
+        if templates_dir.is_dir():
+            tpl_files = [f.relative_to(skill_dir).as_posix() for f in templates_dir.iterdir() if f.is_file()]
+            if tpl_files:
+                linked_files["templates"] = sorted(tpl_files)
+        assets_dir = skill_dir / "assets"
+        if assets_dir.is_dir():
+            asset_files = [f.relative_to(skill_dir).as_posix() for f in assets_dir.iterdir() if f.is_file()]
+            if asset_files:
+                linked_files["assets"] = sorted(asset_files)
+        scripts_dir = skill_dir / "scripts"
+        if scripts_dir.is_dir():
+            script_files = [f.relative_to(skill_dir).as_posix() for f in scripts_dir.iterdir() if f.is_file()]
+            if script_files:
+                linked_files["scripts"] = sorted(script_files)
+
+    # ── file_path: serve a specific sub-file instead of SKILL.md ─────────
+    if file_path:
+        if has_traversal_component(file_path):
+            return json.dumps(
+                {"success": False, "error": f"file_path contains '..' traversal: {file_path}"},
+                ensure_ascii=False,
+            )
+        target = skill_dir / file_path
+        path_err = validate_within_dir(target, skill_dir)
+        if path_err:
+            return json.dumps(
+                {"success": False, "error": f"file_path escapes skill directory: {file_path}"},
+                ensure_ascii=False,
+            )
+        if not target.is_file():
+            available = []
+            if linked_files:
+                for sub in linked_files.values():
+                    available.extend(sub)
+            return json.dumps(
+                {
+                    "success": False,
+                    "error": f"File not found within skill {namespace}:{bare}: {file_path}",
+                    "available_files": sorted(set(available)),
+                },
+                ensure_ascii=False,
+            )
+        try:
+            sub_content = target.read_text(encoding="utf-8", errors="replace")
+        except Exception as exc:
+            return json.dumps(
+                {"success": False, "error": f"Cannot read {file_path}: {exc}"},
+                ensure_ascii=False,
+            )
+        return json.dumps(
+            {
+                "success": True,
+                "name": f"{namespace}:{bare}",
+                "file": file_path,
+                "content": sub_content,
+                "linked_files": linked_files if linked_files else None,
+            },
+            ensure_ascii=False,
+        )
+
     rendered_content = content
     if preprocess:
         try:
@@ -852,7 +929,7 @@ def _serve_plugin_skill(
             "name": f"{namespace}:{bare}",
             "content": f"{banner}{rendered_content}" if banner else rendered_content,
             "description": description,
-            "linked_files": None,
+            "linked_files": linked_files if linked_files else None,
             "readiness_status": SkillReadinessStatus.AVAILABLE.value,
         },
         ensure_ascii=False,
@@ -943,6 +1020,7 @@ def skill_view(
                     bare,
                     preprocess=preprocess,
                     session_id=task_id,
+                    file_path=file_path,
                 )
 
             # Plugin exists but this specific skill is missing?


### PR DESCRIPTION
## Bug

`_serve_plugin_skill()` in `tools/skills_tool.py` does not accept a `file_path` parameter. When `skill_view()` is called with `file_path` for a qualified plugin skill name (e.g. `myplugin:foo`), the plugin branch calls `_serve_plugin_skill()` without forwarding `file_path`. The function always returns `SKILL.md` content and hardcodes `linked_files` to `None`.

This breaks the documented workflow where agents call:
```python
skill_view(name="myplugin:foo", file_path="references/api.md")
```
to read sub-files within plugin skills — a pattern that works perfectly for local (non-plugin) skills via the regular branch (line ~1121).

## Fix

1. `_serve_plugin_skill()` now accepts `file_path` and probes `linked_files` by scanning `references/`, `templates/`, `assets/`, `scripts/` subdirectories — mirroring local-skill behaviour.
2. When `file_path` is given, the function reads and returns that sub-file's content (with path-traversal guards via `validate_within_dir` + `has_traversal_component`).
3. When `file_path` refers to a non-existent file, returns a helpful error listing `available_files`.
4. The `skill_view()` plugin dispatch (line ~940) now forwards `file_path`.

## Tests

3 new tests in `TestPluginSkillFilePath`:
- `test_file_path_reads_subfile` — verifies sub-file content is returned
- `test_linked_files_probed` — verifies `linked_files` dict is populated
- `test_file_path_not_found_lists_available` — verifies error + available_files

All existing plugin skill tests continue to pass. Two pre-existing failures in `test_skills_tool.py` are unrelated Windows path-separator bugs (confirmed failing on clean `main`).

## Verification

```
tests/test_plugin_skills.py — 11 passed (including 3 new)
```
