### PR TITLE
feat: add Hermes DB file registry

### DIFF
--- a/hermes_cli/profile_distribution.py
+++ b/hermes_cli/profile_distribution.py
@@ -71,6 +71,7 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 
 from agent.skill_utils import is_excluded_skill_path
+from hermes_constants import registered_db_root_entries
 
 
 # ---------------------------------------------------------------------------
@@ -101,9 +102,7 @@ USER_OWNED_EXCLUDE: frozenset = frozenset({
     # Credentials & runtime secrets
     "auth.json", ".env",
     # Databases & runtime state
-    "state.db", "state.db-shm", "state.db-wal",
-    "hermes_state.db", "response_store.db",
-    "response_store.db-shm", "response_store.db-wal",
+    *registered_db_root_entries(),
     "gateway.pid", "gateway_state.json", "processes.json",
     "auth.lock", "active_profile", ".update_check",
     "errors.log", ".hermes_history",

--- a/hermes_cli/profiles.py
+++ b/hermes_cli/profiles.py
@@ -32,6 +32,7 @@ from pathlib import Path, PurePosixPath, PureWindowsPath
 from typing import List, Optional
 
 from agent.skill_utils import is_excluded_skill_path
+from hermes_constants import registered_db_root_entries
 
 _PROFILE_ID_RE = re.compile(r"^[a-z0-9][a-z0-9_-]{0,63}$")
 
@@ -115,9 +116,7 @@ _CLONE_ALL_DEFAULT_EXCLUDE_ROOT: frozenset[str] = frozenset({
 #   state-snapshots     — quick-backup snapshot trees
 #   checkpoints         — session checkpoint data
 _CLONE_ALL_HISTORY_EXCLUDE_ROOT: frozenset[str] = frozenset({
-    "state.db",
-    "state.db-wal",
-    "state.db-shm",
+    *registered_db_root_entries(),
     "sessions",
     "backups",
     "state-snapshots",
@@ -207,9 +206,7 @@ _DEFAULT_EXPORT_EXCLUDE_ROOT = frozenset({
     "bin",                  # installed binaries (tirith, etc.)
     "node_modules",         # npm packages
     # Databases & runtime state
-    "state.db", "state.db-shm", "state.db-wal",
-    "hermes_state.db",
-    "response_store.db", "response_store.db-shm", "response_store.db-wal",
+    *registered_db_root_entries(),
     "gateway.pid", "gateway_state.json", "processes.json",
     "auth.json",            # API keys, OAuth tokens, credential pools
     ".env",                 # API keys (dotenv)

--- a/hermes_constants.py
+++ b/hermes_constants.py
@@ -11,6 +11,61 @@ from contextvars import ContextVar, Token
 from pathlib import Path
 
 
+# Root-level SQLite database files owned by Hermes. Keep this registry as the
+# single source of truth for profile export/distribution exclusions and startup
+# hygiene checks. Values are intentionally plain dictionaries so this module
+# stays import-safe for early CLI startup paths.
+REGISTERED_DB_FILES = {
+    "state.db": {
+        "purpose": "session metadata, message history, and FTS indexes",
+        "module": "hermes_state.SessionDB",
+        "scope": "profile-or-default-home",
+        "durability": "durable",
+        "sync_semantics": "do_not_file_sync_multi_writer",
+        "legacy_names": ("hermes_state.db",),
+        "auto_cleanup_legacy": True,
+    },
+    "response_store.db": {
+        "purpose": "OpenAI Responses API conversation cache",
+        "module": "gateway.platforms.api_server.ResponseStore",
+        "scope": "machine-local",
+        "durability": "cache",
+        "sync_semantics": "do_not_sync",
+        "legacy_names": (),
+        "auto_cleanup_legacy": False,
+    },
+    "kanban.db": {
+        "purpose": "Kanban multi-agent work queue when a root-local board is used",
+        "module": "hermes_cli.kanban_db",
+        "scope": "machine-local-or-explicit-central-board",
+        "durability": "durable-coordination-state",
+        "sync_semantics": "single-writer-or-provider-required",
+        "legacy_names": (),
+        "auto_cleanup_legacy": False,
+    },
+}
+
+
+def sqlite_sidecar_names(db_name: str) -> tuple[str, str]:
+    """Return SQLite sidecar filenames for a root DB filename."""
+    return (f"{db_name}-wal", f"{db_name}-shm")
+
+
+def registered_db_root_entries(*, include_sidecars: bool = True, include_legacy: bool = True) -> frozenset[str]:
+    """Return root-level database filenames/sidecars known to Hermes."""
+    names: set[str] = set()
+    for db_name, info in REGISTERED_DB_FILES.items():
+        names.add(db_name)
+        if include_sidecars:
+            names.update(sqlite_sidecar_names(db_name))
+        if include_legacy:
+            for legacy_name in info.get("legacy_names", ()):
+                names.add(legacy_name)
+                if include_sidecars:
+                    names.update(sqlite_sidecar_names(legacy_name))
+    return frozenset(names)
+
+
 _profile_fallback_warned: bool = False
 _UNSET = object()
 _HERMES_HOME_OVERRIDE: ContextVar[str | object] = ContextVar(

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -24,7 +24,11 @@ import time
 from pathlib import Path
 
 from agent.memory_manager import sanitize_context
-from hermes_constants import get_hermes_home
+from hermes_constants import (
+    REGISTERED_DB_FILES,
+    get_hermes_home,
+    registered_db_root_entries,
+)
 from typing import Any, Callable, Dict, List, Optional, Tuple, TypeVar
 
 logger = logging.getLogger(__name__)
@@ -106,6 +110,63 @@ def _delete_delegate_children(conn, parent_ids: List[str]) -> List[str]:
 T = TypeVar("T")
 
 DEFAULT_DB_PATH = get_hermes_home() / "state.db"
+
+
+def _cleanup_legacy_database_files(hermes_home: Path) -> None:
+    """Remove explicitly registered empty legacy DB files and warn otherwise."""
+    for db_name, info in REGISTERED_DB_FILES.items():
+        if not info.get("auto_cleanup_legacy"):
+            continue
+        for legacy_name in info.get("legacy_names", ()):
+            legacy_path = hermes_home / legacy_name
+            try:
+                if not legacy_path.exists():
+                    continue
+                size = legacy_path.stat().st_size
+                if size == 0:
+                    legacy_path.unlink()
+                    logger.warning(
+                        "Removed empty legacy database %s for %s",
+                        legacy_path,
+                        db_name,
+                    )
+                else:
+                    logger.warning(
+                        "Keeping non-empty legacy database %s (%d bytes); "
+                        "manual review required before removal",
+                        legacy_path,
+                        size,
+                    )
+            except OSError as exc:
+                logger.warning(
+                    "Could not inspect legacy database %s: %s",
+                    legacy_path,
+                    exc,
+                )
+
+
+def _warn_unregistered_database_files(hermes_home: Path) -> None:
+    """Warn about root-level .db files not declared in REGISTERED_DB_FILES."""
+    registered = registered_db_root_entries(include_sidecars=True, include_legacy=True)
+    try:
+        candidates = list(hermes_home.glob("*.db"))
+    except OSError as exc:
+        logger.debug("Could not scan Hermes home for database files %s: %s", hermes_home, exc)
+        return
+    for db_file in candidates:
+        if db_file.name in registered:
+            continue
+        try:
+            size = db_file.stat().st_size
+        except OSError:
+            size = -1
+        logger.warning(
+            "Unregistered database file in Hermes home: %s (%d bytes). "
+            "Add it to REGISTERED_DB_FILES in hermes_constants.py to suppress this warning.",
+            db_file.name,
+            size,
+        )
+
 
 SCHEMA_VERSION = 16
 
@@ -707,6 +768,8 @@ class SessionDB:
                 return
 
             self.db_path.parent.mkdir(parents=True, exist_ok=True)
+            _cleanup_legacy_database_files(self.db_path.parent)
+            _warn_unregistered_database_files(self.db_path.parent)
 
             def _connect_and_init():
                 self._conn = sqlite3.connect(

--- a/tests/test_db_file_registry.py
+++ b/tests/test_db_file_registry.py
@@ -1,0 +1,59 @@
+"""Tests for the Hermes-home database file registry."""
+
+import logging
+
+from hermes_constants import (
+    REGISTERED_DB_FILES,
+    registered_db_root_entries,
+)
+from hermes_state import SessionDB
+
+
+def test_registered_db_file_registry_includes_current_and_legacy_names():
+    assert "state.db" in REGISTERED_DB_FILES
+    assert "response_store.db" in REGISTERED_DB_FILES
+    assert "kanban.db" in REGISTERED_DB_FILES
+
+    root_entries = registered_db_root_entries()
+    assert "state.db" in root_entries
+    assert "state.db-wal" in root_entries
+    assert "state.db-shm" in root_entries
+    assert "hermes_state.db" in root_entries
+    assert "response_store.db" in root_entries
+    assert "response_store.db-wal" in root_entries
+
+
+def test_session_db_removes_empty_legacy_state_db(tmp_path, caplog):
+    legacy = tmp_path / "hermes_state.db"
+    legacy.touch()
+
+    with caplog.at_level(logging.WARNING):
+        db = SessionDB(tmp_path / "state.db")
+        db.close()
+
+    assert not legacy.exists()
+    assert "Removed empty legacy database" in caplog.text
+
+
+def test_session_db_preserves_nonempty_legacy_state_db(tmp_path, caplog):
+    legacy = tmp_path / "hermes_state.db"
+    legacy.write_bytes(b"not empty")
+
+    with caplog.at_level(logging.WARNING):
+        db = SessionDB(tmp_path / "state.db")
+        db.close()
+
+    assert legacy.exists()
+    assert "Keeping non-empty legacy database" in caplog.text
+
+
+def test_session_db_warns_for_unregistered_root_db(tmp_path, caplog):
+    rogue = tmp_path / "plugin_cache.db"
+    rogue.touch()
+
+    with caplog.at_level(logging.WARNING):
+        db = SessionDB(tmp_path / "state.db")
+        db.close()
+
+    assert "Unregistered database file" in caplog.text
+    assert "plugin_cache.db" in caplog.text


### PR DESCRIPTION
## Summary

- add a central root-level SQLite DB registry in `hermes_constants.py`
- derive profile export/distribution DB exclusions from the registry
- clean up empty legacy `hermes_state.db` files at `SessionDB` startup and warn for non-empty legacy DBs
- warn on unregistered root-level `.db` files so future DB additions are visible

Fixes #28515

## Tests

- `python -m compileall -q hermes_constants.py hermes_state.py hermes_cli/profiles.py hermes_cli/profile_distribution.py tests/test_db_file_registry.py`
- `python -m pytest tests/test_db_file_registry.py tests/hermes_cli/test_profiles.py tests/hermes_cli/test_profile_distribution.py tests/gateway/test_api_server.py::TestResponseStore -q -o 'addopts='`
