### PR TITLE
fix(comfyui): remove `_comment` keys from bundled workflow JSONs

### DIFF
--- a/skills/creative/comfyui/workflows/animatediff_video.json
+++ b/skills/creative/comfyui/workflows/animatediff_video.json
@@ -1,5 +1,4 @@
 {
-  "_comment": "AnimateDiff text-to-video at 16 frames. Required: comfyui-animatediff-evolved + comfyui-videohelpersuite custom nodes; SD1.5 checkpoint; AnimateDiff motion module (e.g. mm_sd_v15_v2.ckpt in models/animatediff_models/). Outputs a webp animation.",
   "3": {
     "class_type": "KSampler",
     "_meta": {"title": "KSampler"},

--- a/skills/creative/comfyui/workflows/flux_dev_txt2img.json
+++ b/skills/creative/comfyui/workflows/flux_dev_txt2img.json
@@ -1,5 +1,4 @@
 {
-  "_comment": "Flux Dev text-to-image using the modern sampler chain (BasicScheduler/Guider/SamplerCustomAdvanced). Required: flux1-dev.safetensors (UNET), t5xxl_fp16.safetensors + clip_l.safetensors (CLIP), ae.safetensors (VAE).",
   "6": {
     "class_type": "CLIPTextEncode",
     "_meta": {"title": "Prompt"},

--- a/skills/creative/comfyui/workflows/sd15_txt2img.json
+++ b/skills/creative/comfyui/workflows/sd15_txt2img.json
@@ -1,5 +1,4 @@
 {
-  "_comment": "SD 1.5 text-to-image. Smallest model, fastest. Required model: v1-5-pruned-emaonly.safetensors (or any SD1.5 checkpoint)",
   "3": {
     "class_type": "KSampler",
     "_meta": {"title": "KSampler"},

--- a/skills/creative/comfyui/workflows/sdxl_img2img.json
+++ b/skills/creative/comfyui/workflows/sdxl_img2img.json
@@ -1,5 +1,4 @@
 {
-  "_comment": "SDXL img2img: load an input image, encode to latent, denoise partially. Use --input-image image=./photo.png with run_workflow.py. Lower 'denoise' value preserves more of the source image.",
   "1": {
     "class_type": "LoadImage",
     "_meta": {"title": "Load Source Image"},

--- a/skills/creative/comfyui/workflows/sdxl_inpaint.json
+++ b/skills/creative/comfyui/workflows/sdxl_inpaint.json
@@ -1,5 +1,4 @@
 {
-  "_comment": "SDXL inpainting: given an image + mask, regenerate the masked region. Upload both: --input-image image=./photo.png --input-image mask_image=./mask.png. White pixels in mask = regenerate; black = preserve.",
   "1": {
     "class_type": "LoadImage",
     "_meta": {"title": "Load Source"},

--- a/skills/creative/comfyui/workflows/sdxl_txt2img.json
+++ b/skills/creative/comfyui/workflows/sdxl_txt2img.json
@@ -1,5 +1,4 @@
 {
-  "_comment": "SDXL text-to-image at 1024x1024. Required model: sd_xl_base_1.0.safetensors (or any SDXL checkpoint).",
   "3": {
     "class_type": "KSampler",
     "_meta": {"title": "KSampler"},

--- a/skills/creative/comfyui/workflows/upscale_4x.json
+++ b/skills/creative/comfyui/workflows/upscale_4x.json
@@ -1,5 +1,4 @@
 {
-  "_comment": "Standalone 4x upscale of an input image using ESRGAN. Required model: 4x-UltraSharp.pth (or any upscaler in models/upscale_models/). Upload with --input-image image=./photo.png.",
   "1": {
     "class_type": "LoadImage",
     "_meta": {"title": "Load Image"},

--- a/skills/creative/comfyui/workflows/wan_video_t2v.json
+++ b/skills/creative/comfyui/workflows/wan_video_t2v.json
@@ -1,5 +1,4 @@
 {
-  "_comment": "Wan 2.1 text-to-video. Cloud: confirmed available. Local: download wan2.1_t2v_1.3B_fp16.safetensors → models/diffusion_models/ (or models/unet/), umt5_xxl_fp16.safetensors → models/text_encoders/ (or models/clip/), wan_2.1_vae.safetensors → models/vae/. Output: MP4. Large model — only on cloud or 24 GB+ local GPU.",
   "6": {
     "class_type": "CLIPTextEncode",
     "_meta": {"title": "Prompt"},


### PR DESCRIPTION
## Summary

All 8 bundled workflow JSON files in `skills/creative/comfyui/workflows/` contain a top-level `_comment` key with a descriptive string value. ComfyUI's `/prompt` endpoint treats every top-level key as a node definition and expects each value to be a dict. The `_comment` string causes:

```
AttributeError: 'str' object has no attribute 'get'
```

This results in **HTTP 500 on every workflow submission**, making the ComfyUI skill completely non-functional out of the box.

## Fix

Remove the `_comment` key from all 8 bundled workflow files. Each file loses exactly 1 line.

## Test plan

- [ ] Verify all 8 workflow JSON files are valid JSON after removal
- [ ] Submit any bundled workflow to ComfyUI `/prompt` endpoint - should no longer return 500
- [ ] Confirm no other keys were modified (diff shows only deletions)

Fixes #48139
