### PR TITLE
fix(skills): strip _comment keys so ComfyUI workflows submit cleanly

### DIFF
--- a/skills/creative/comfyui/scripts/_common.py
+++ b/skills/creative/comfyui/scripts/_common.py
@@ -671,6 +671,21 @@ def unwrap_workflow(payload: Any) -> dict:
     )
 
 
+def strip_comment_keys(workflow: dict) -> dict:
+    """Drop underscore-prefixed top-level keys before submitting to /prompt.
+
+    ComfyUI's /prompt endpoint treats every top-level key as a node and calls
+    `.get()` on its value (e.g. `node_data.get('_meta')`). A `_comment` whose
+    value is a string raises `AttributeError: 'str' object has no attribute
+    'get'`, returning HTTP 500. Authors commonly add `_comment`/`_meta`-style
+    metadata keys to document a workflow, so strip any `_`-prefixed top-level
+    key (not just `_comment`) to keep the submitted graph valid. Real node ids
+    are numeric strings, so this never removes a node. Returns a new dict; the
+    input is not mutated.
+    """
+    return {k: v for k, v in workflow.items() if not k.startswith("_")}
+
+
 def is_link(value: Any) -> bool:
     """True if `value` is a [node_id, output_index] connection (length-2 list)."""
     return (

--- a/skills/creative/comfyui/scripts/run_workflow.py
+++ b/skills/creative/comfyui/scripts/run_workflow.py
@@ -64,7 +64,7 @@ from _common import (  # noqa: E402
     coerce_seed, emit_json, http_get, http_post, http_request,
     is_cloud_host, is_link, log, looks_like_video_workflow,
     media_type_from_filename, new_client_id, resolve_api_key, resolve_url,
-    safe_path_join, unwrap_workflow,
+    safe_path_join, strip_comment_keys, unwrap_workflow,
 )
 
 
@@ -171,6 +171,10 @@ class ComfyRunner:
 
     # ---------- submit ----------
     def submit(self, workflow: dict) -> dict:
+        # ComfyUI's /prompt rejects underscore-prefixed comment/metadata keys
+        # (it calls .get() on every top-level value). Strip them defensively so
+        # any workflow — bundled or user-authored — submits cleanly.
+        workflow = strip_comment_keys(workflow)
         payload: dict[str, Any] = {"prompt": workflow, "client_id": self.client_id}
         if self.partner_key:
             payload["extra_data"] = {"api_key_comfy_org": self.partner_key}

--- a/skills/creative/comfyui/tests/test_common.py
+++ b/skills/creative/comfyui/tests/test_common.py
@@ -21,6 +21,7 @@ from _common import (
     parse_model_list,
     resolve_url,
     safe_path_join,
+    strip_comment_keys,
     unwrap_workflow,
 )
 
@@ -441,3 +442,59 @@ class TestVideoWorkflow:
 
     def test_wan_workflow(self, video_workflow):
         assert looks_like_video_workflow(video_workflow) is True
+
+
+# =============================================================================
+# Comment-key stripping (regression: ComfyUI 500 on top-level _comment)
+# =============================================================================
+
+class TestStripCommentKeys:
+    def test_removes_underscore_top_level_keys(self):
+        wf = {
+            "_comment": "documentation string",
+            "_meta": {"author": "someone"},
+            "3": {"class_type": "KSampler", "inputs": {}},
+        }
+        cleaned = strip_comment_keys(wf)
+        assert cleaned == {"3": {"class_type": "KSampler", "inputs": {}}}
+
+    def test_preserves_real_nodes_and_nested_meta(self):
+        wf = {
+            "_comment": "doc",
+            "3": {
+                "class_type": "KSampler",
+                "_meta": {"title": "KSampler"},
+                "inputs": {"seed": 1},
+            },
+        }
+        cleaned = strip_comment_keys(wf)
+        # Numeric node ids survive, and node-level _meta (valid ComfyUI) is untouched.
+        assert "3" in cleaned
+        assert cleaned["3"]["_meta"] == {"title": "KSampler"}
+        assert cleaned["3"]["inputs"] == {"seed": 1}
+
+    def test_does_not_mutate_input(self):
+        wf = {"_comment": "doc", "3": {"class_type": "KSampler"}}
+        strip_comment_keys(wf)
+        assert "_comment" in wf  # original untouched
+
+    def test_noop_on_clean_workflow(self, sd15_workflow):
+        cleaned = strip_comment_keys(sd15_workflow)
+        assert cleaned == sd15_workflow
+
+    def test_bundled_workflows_have_no_comment_top_level_key(self, workflows_dir):
+        """Every bundled workflow must submit cleanly to ComfyUI /prompt.
+
+        Invariant over the whole catalog, not just the originally-affected
+        files: no top-level key may start with '_', since ComfyUI calls
+        `.get()` on every top-level value and a string-valued comment key
+        triggers a 500.
+        """
+        import json
+        offenders = {}
+        for wf_path in sorted(workflows_dir.glob("*.json")):
+            data = json.loads(wf_path.read_text())
+            bad = [k for k in data if k.startswith("_")]
+            if bad:
+                offenders[wf_path.name] = bad
+        assert offenders == {}, f"underscore-prefixed top-level keys found: {offenders}"

--- a/skills/creative/comfyui/workflows/animatediff_video.json
+++ b/skills/creative/comfyui/workflows/animatediff_video.json
@@ -1,5 +1,4 @@
 {
-  "_comment": "AnimateDiff text-to-video at 16 frames. Required: comfyui-animatediff-evolved + comfyui-videohelpersuite custom nodes; SD1.5 checkpoint; AnimateDiff motion module (e.g. mm_sd_v15_v2.ckpt in models/animatediff_models/). Outputs a webp animation.",
   "3": {
     "class_type": "KSampler",
     "_meta": {"title": "KSampler"},

--- a/skills/creative/comfyui/workflows/flux_dev_txt2img.json
+++ b/skills/creative/comfyui/workflows/flux_dev_txt2img.json
@@ -1,5 +1,4 @@
 {
-  "_comment": "Flux Dev text-to-image using the modern sampler chain (BasicScheduler/Guider/SamplerCustomAdvanced). Required: flux1-dev.safetensors (UNET), t5xxl_fp16.safetensors + clip_l.safetensors (CLIP), ae.safetensors (VAE).",
   "6": {
     "class_type": "CLIPTextEncode",
     "_meta": {"title": "Prompt"},

--- a/skills/creative/comfyui/workflows/sd15_txt2img.json
+++ b/skills/creative/comfyui/workflows/sd15_txt2img.json
@@ -1,5 +1,4 @@
 {
-  "_comment": "SD 1.5 text-to-image. Smallest model, fastest. Required model: v1-5-pruned-emaonly.safetensors (or any SD1.5 checkpoint)",
   "3": {
     "class_type": "KSampler",
     "_meta": {"title": "KSampler"},

--- a/skills/creative/comfyui/workflows/sdxl_img2img.json
+++ b/skills/creative/comfyui/workflows/sdxl_img2img.json
@@ -1,5 +1,4 @@
 {
-  "_comment": "SDXL img2img: load an input image, encode to latent, denoise partially. Use --input-image image=./photo.png with run_workflow.py. Lower 'denoise' value preserves more of the source image.",
   "1": {
     "class_type": "LoadImage",
     "_meta": {"title": "Load Source Image"},

--- a/skills/creative/comfyui/workflows/sdxl_inpaint.json
+++ b/skills/creative/comfyui/workflows/sdxl_inpaint.json
@@ -1,5 +1,4 @@
 {
-  "_comment": "SDXL inpainting: given an image + mask, regenerate the masked region. Upload both: --input-image image=./photo.png --input-image mask_image=./mask.png. White pixels in mask = regenerate; black = preserve.",
   "1": {
     "class_type": "LoadImage",
     "_meta": {"title": "Load Source"},

--- a/skills/creative/comfyui/workflows/sdxl_txt2img.json
+++ b/skills/creative/comfyui/workflows/sdxl_txt2img.json
@@ -1,5 +1,4 @@
 {
-  "_comment": "SDXL text-to-image at 1024x1024. Required model: sd_xl_base_1.0.safetensors (or any SDXL checkpoint).",
   "3": {
     "class_type": "KSampler",
     "_meta": {"title": "KSampler"},

--- a/skills/creative/comfyui/workflows/upscale_4x.json
+++ b/skills/creative/comfyui/workflows/upscale_4x.json
@@ -1,5 +1,4 @@
 {
-  "_comment": "Standalone 4x upscale of an input image using ESRGAN. Required model: 4x-UltraSharp.pth (or any upscaler in models/upscale_models/). Upload with --input-image image=./photo.png.",
   "1": {
     "class_type": "LoadImage",
     "_meta": {"title": "Load Image"},

--- a/skills/creative/comfyui/workflows/wan_video_t2v.json
+++ b/skills/creative/comfyui/workflows/wan_video_t2v.json
@@ -1,5 +1,4 @@
 {
-  "_comment": "Wan 2.1 text-to-video. Cloud: confirmed available. Local: download wan2.1_t2v_1.3B_fp16.safetensors → models/diffusion_models/ (or models/unet/), umt5_xxl_fp16.safetensors → models/text_encoders/ (or models/clip/), wan_2.1_vae.safetensors → models/vae/. Output: MP4. Large model — only on cloud or 24 GB+ local GPU.",
   "6": {
     "class_type": "CLIPTextEncode",
     "_meta": {"title": "Prompt"},


### PR DESCRIPTION
## What does this PR do?

Every bundled ComfyUI workflow JSON in `skills/creative/comfyui/workflows/` ships with a top-level `_comment` key, which makes the comfyui skill return HTTP 500 on every workflow submission (non-functional out of the box).

ComfyUI's `/prompt` endpoint treats each top-level key as a node and calls `.get()` on its value (`node_data.get('_meta', {})`). `_comment`'s value is a string, so it raises `AttributeError: 'str' object has no attribute 'get'`, which the server returns as a 500. `unwrap_workflow()` passes the dict through (the numeric nodes still have `class_type`), and `ComfyRunner.submit()` POSTs it including `_comment`.

The fix has two parts:

- **Code (root cause):** add `strip_comment_keys()` in `_common.py` and call it in `ComfyRunner.submit()` just before building the `/prompt` payload. It drops any underscore-prefixed top-level key (not just `_comment`), so user-authored workflows that carry comment/metadata keys also submit cleanly. Numeric node ids and node-level `_meta` (valid ComfyUI titles) are untouched, and the input dict is not mutated. `submit()` is the single chokepoint shared by `run_workflow.py` and `run_batch.py`, so both paths are covered.
- **Data (cleanup):** remove the top-level `_comment` key from all 8 bundled workflow files (one-line removal each; node graphs and formatting otherwise unchanged).

This is the right approach because the data cleanup fixes the shipped files today, while the code strip is a defensive guard so the whole class of bug cannot recur from user-authored workflows.

## Related Issue

Fixes #48139

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `skills/creative/comfyui/scripts/_common.py` - new `strip_comment_keys()` helper (pure function, no input mutation)
- `skills/creative/comfyui/scripts/run_workflow.py` - import and apply `strip_comment_keys()` in `ComfyRunner.submit()` before the `/prompt` payload is built
- `skills/creative/comfyui/tests/test_common.py` - new `TestStripCommentKeys` (5 tests) plus a catalog-wide invariant
- 8 bundled workflows under `skills/creative/comfyui/workflows/` - removed the top-level `_comment` key from each (animatediff_video, flux_dev_txt2img, sd15_txt2img, sdxl_img2img, sdxl_inpaint, sdxl_txt2img, upscale_4x, wan_video_t2v)

## How to Test

Reproduction (before this PR):

1. Fresh install with the comfyui skill active and a running ComfyUI server.
2. Ask the agent to generate any image (`run_workflow.py` submits a bundled workflow JSON to `/prompt`).
3. ComfyUI returns HTTP 500 every time (`AttributeError: 'str' object has no attribute 'get'` in `validate_prompt`).

After this PR, the same submission proceeds normally because `_comment` no longer reaches `/prompt`.

Automated verification (CI-parity runner, hermetic env):

```
$ scripts/run_tests.sh skills/creative/comfyui/tests/
=== Summary: 5 files, 114 tests passed, 0 failed in 1.4s (16 workers) ===
  ... test_common.py (70 passed)
```

Proof the data fix landed (and every file is still valid JSON with its node graph intact):

```
RESULT: 0/8 files contain _comment; 0/8 contain any underscore-prefixed top-level key
PASS: all bundled workflows are clean and submit-safe
```

Note: verification is at the unit / CI-parity level on Ubuntu 24.04. I did not run a live GPU ComfyUI server end to end, but the fix is mechanical: it removes exactly the string-valued top-level key that produces the documented `AttributeError` before the payload is POSTed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass (via `scripts/run_tests.sh`, 114 passed / 0 failed)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu 24.04

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) - N/A (internal fix; the new helper is documented with a docstring)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys - N/A (no config keys)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows - N/A
- [x] I've considered cross-platform impact (Windows, macOS) - pure-Python stdlib dict comprehension, no OS-specific paths
- [x] I've updated tool descriptions/schemas if I changed tool behavior - N/A (no tool schema change)

## Screenshots / Logs

```
$ scripts/run_tests.sh skills/creative/comfyui/tests/
Discovered 5 test files (122 tests); running with -j 16
  ✓ test_check_deps.py (11)
  ✓ test_run_workflow.py (19)
  ✓ test_common.py (70)
  ✓ test_cloud_integration.py (8 skipped, cloud-only)
  ✓ test_extract_schema.py (14)
=== Summary: 5 files, 114 tests passed, 0 failed ===
```
