### PR TITLE
fix(desktop): clear compaction flag on `message.delta` to prevent stale "Summarizing thread" status

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-message-stream.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream.ts
@@ -858,6 +858,12 @@ export function useMessageStream({
         }
       } else if (event.type === 'message.delta') {
         if (sessionId) {
+          // Clear compaction flag when model resumes streaming — compaction
+          // may have finished mid-turn without a fresh message.start event.
+          if (compactedTurnRef.current.has(sessionId)) {
+            setSessionCompacting(sessionId, false)
+            compactedTurnRef.current.delete(sessionId)
+          }
           appendAssistantDelta(sessionId, coerceGatewayText(payload?.text))
         }
       } else if (event.type === 'thinking.delta') {


### PR DESCRIPTION
## Summary

The `$compactionActive` flag is set when the gateway emits `status.update` with `kind === 'compacting'`, but only cleared on `message.start`, `message.complete`, or `error`.

When compaction finishes mid-turn and the model resumes streaming **without** emitting a fresh `message.start`, the "Summarizing thread" label persists indefinitely even though the model is actively generating output. The user sees a stale status like:

```
Summarizing thread  4:00
```

while the model is clearly still working.

## Root cause

In `use-message-stream.ts`, the `message.delta` handler (line 859) appends assistant text deltas but never checks or clears the compaction state. If the gateway doesn't emit a new `message.start` after compaction completes (which is valid for in-turn compaction), the flag stays `true` forever.

## Fix

Clear the compaction flag on the first `message.delta` event for a session that was in the compacting state. This ensures the UI transitions back to the normal streaming/thinking status as soon as the model produces output after compaction completes.

**File changed:** `apps/desktop/src/app/session/hooks/use-message-stream.ts` (+6 lines)

## Test plan

- [ ] Trigger a long conversation that forces mid-turn auto-compaction
- [ ] Verify "Summarizing thread" label appears during compaction
- [ ] Verify label clears once the model resumes streaming (no stale 4:00 timer)
- [ ] Verify background sessions don't interfere with foreground compaction display

Fixes #48098
