### PR TITLE
fix(gateway): keep markdown bullet lists and literal asterisks in plain-text stripping

### DIFF
--- a/gateway/platforms/helpers.py
+++ b/gateway/platforms/helpers.py
@@ -165,9 +165,15 @@ class TextBatchAggregator:
 
 # ─── Markdown Stripping ──────────────────────────────────────────────────────
 
-# Pre-compiled regexes for performance
-_RE_BOLD = re.compile(r"\*\*(.+?)\*\*", re.DOTALL)
-_RE_ITALIC_STAR = re.compile(r"\*(.+?)\*", re.DOTALL)
+# Pre-compiled regexes for performance.
+# The emphasis delimiters require a non-space, non-delimiter character on the
+# inside edge of the span, mirroring how Markdown actually parses emphasis.
+# Without these guards the star variants pair up unrelated ``*`` characters
+# across a run of text, so ``*`` list bullets ("* item\n* item") and literal
+# asterisks ("a * b * c") get swallowed as if they were italic spans. The
+# underscore variants already carry the same guards.
+_RE_BOLD = re.compile(r"\*\*(?![\s*])(.+?)(?<![\s*])\*\*", re.DOTALL)
+_RE_ITALIC_STAR = re.compile(r"\*(?![\s*])(.+?)(?<![\s*])\*", re.DOTALL)
 _RE_BOLD_UNDER = re.compile(r"\b__(?![\s_])(.+?)(?<![\s_])__\b", re.DOTALL)
 _RE_ITALIC_UNDER = re.compile(r"\b_(?![\s_])(.+?)(?<![\s_])_\b", re.DOTALL)
 _RE_CODE_BLOCK = re.compile(r"```[a-zA-Z0-9_+-]*\n?")

--- a/tests/gateway/test_helpers_strip_markdown.py
+++ b/tests/gateway/test_helpers_strip_markdown.py
@@ -1,0 +1,52 @@
+"""Regression tests for ``gateway.platforms.helpers.strip_markdown``.
+
+The shared helper strips Markdown formatting for plain-text platforms
+(SMS, iMessage/BlueBubbles, Feishu, QQ Bot, Photon). The star emphasis
+regexes used to lack the inside-edge guards that the underscore variants
+already had, so ``*`` list bullets and literal asterisks were swallowed as
+if they were italic spans. These tests pin the corrected behaviour and the
+emphasis stripping that must keep working.
+"""
+
+from gateway.platforms.helpers import strip_markdown
+
+
+class TestStripMarkdownPreservesBulletsAndLiterals:
+    def test_simple_star_bullet_list_is_preserved(self):
+        text = "* first item\n* second item"
+        assert strip_markdown(text) == text
+
+    def test_star_bullet_list_with_lead_in_is_preserved(self):
+        text = "Here are steps:\n* Install deps\n* Run tests\n* Ship it"
+        assert strip_markdown(text) == text
+
+    def test_literal_asterisks_with_spaces_are_preserved(self):
+        text = "Compute a * b * c for the area"
+        assert strip_markdown(text) == text
+
+    def test_wildcard_and_double_star_glob_are_preserved(self):
+        text = "Use the * wildcard and the ** glob"
+        assert strip_markdown(text) == text
+
+
+class TestStripMarkdownStillStripsEmphasis:
+    def test_bold_star_is_stripped(self):
+        assert strip_markdown("**bold**") == "bold"
+
+    def test_italic_star_is_stripped(self):
+        assert strip_markdown("This is *very* important") == "This is very important"
+
+    def test_bold_underscore_is_stripped(self):
+        assert strip_markdown("__bold__") == "bold"
+
+    def test_italic_underscore_is_stripped(self):
+        assert strip_markdown("_italic_") == "italic"
+
+    def test_bold_inside_dash_bullet_is_stripped_marker_kept(self):
+        text = "- **Step 1**: do this\n- **Step 2**: do that"
+        assert strip_markdown(text) == "- Step 1: do this\n- Step 2: do that"
+
+    def test_inline_code_and_heading_and_link_still_work(self):
+        assert strip_markdown("`code`") == "code"
+        assert strip_markdown("# Heading") == "Heading"
+        assert strip_markdown("[click here](http://example.com)") == "click here"


### PR DESCRIPTION
### What this fixes
`strip_markdown` in `gateway/platforms/helpers.py` is the shared plain text formatter for the SMS, iMessage (BlueBubbles), Feishu, QQ Bot, and Photon adapters. Its star emphasis regexes treated any two `*` in a run of text as an italic span, so `*` bullet markers and literal asterisks were swallowed:

```python
strip_markdown("Here are steps:\n* Install deps\n* Run tests\n* Ship it")
# before: "Here are steps:\n Install deps\n Run tests\n* Ship it"
strip_markdown("Compute a * b * c for the area")
# before: "Compute a  b  c for the area"
```

Bullet lists are one of the most common things an agent writes, so this corrupts ordinary output on every plain text platform, on every operating system, by default.

Fixes #48150.

### The fix
The underscore emphasis regexes already guard the inside edge of the span. The star variants did not. I added the same guards so the star regexes match real emphasis only:

```diff
-_RE_BOLD        = re.compile(r"\*\*(.+?)\*\*", re.DOTALL)
-_RE_ITALIC_STAR = re.compile(r"\*(.+?)\*", re.DOTALL)
+_RE_BOLD        = re.compile(r"\*\*(?![\s*])(.+?)(?<![\s*])\*\*", re.DOTALL)
+_RE_ITALIC_STAR = re.compile(r"\*(?![\s*])(.+?)(?<![\s*])\*", re.DOTALL)
```

A `*` bullet is always `*` followed by a space, and a literal `a * b` has spaces on both sides, so the guards leave them alone while `*italic*` and `**bold**` still unwrap exactly as before. This brings the star variants into symmetry with `_RE_ITALIC_UNDER` and `_RE_BOLD_UNDER`.

### Testing
I added `tests/gateway/test_helpers_strip_markdown.py` with two groups:

- bullets and literal asterisks are preserved (`* item` lists, `a * b * c`, `*` and `**` used as plain text),
- existing emphasis still strips (`**bold**`, `*italic*`, `__bold__`, `_italic_`, inline code, headings, links, and bold inside a `-` bullet).

The first group fails on clean `main` and passes with this change, the second group passes both ways so the guards are not over fitted. Locally, `tests/gateway/test_helpers_strip_markdown.py` and `tests/gateway/test_bluebubbles.py` are green (66 passed), and ruff is clean on both touched files. I did not run the entire suite locally, so I left that box unchecked and am relying on continuous integration.

The same un guarded pattern also exists in a few sibling copies (the text to speech stripper, and the IRC and LINE adapters). I kept those out of this change to keep it tight and matchable to the single helper, and I am happy to follow up on them separately.
