### PR TITLE
fix(desktop): read Windows clipboard DIB images

### DIFF
--- a/apps/desktop/electron/clipboard-image.cjs
+++ b/apps/desktop/electron/clipboard-image.cjs
@@ -1,0 +1,239 @@
+'use strict'
+
+const ENCODED_IMAGE_FORMATS = [
+  'image/png',
+  'image/jpeg',
+  'image/jpg',
+  'image/bmp',
+  'image/x-bmp',
+  'application/x-ms-bmp'
+]
+const DIB_READ_FORMATS = ['image/x-dib', 'application/dib']
+const FALLBACK_READ_FORMATS = [...ENCODED_IMAGE_FORMATS, ...DIB_READ_FORMATS]
+
+function imageToPngBuffer(image) {
+  if (!image || typeof image.isEmpty !== 'function' || image.isEmpty()) {
+    return null
+  }
+  if (typeof image.toPNG !== 'function') {
+    return null
+  }
+  const png = image.toPNG()
+  return Buffer.isBuffer(png) && png.length > 0 ? png : null
+}
+
+function safeReadBuffer(clipboardImpl, format) {
+  try {
+    const buffer = clipboardImpl.readBuffer(format)
+    return Buffer.isBuffer(buffer) && buffer.length > 0 ? buffer : null
+  } catch {
+    return null
+  }
+}
+
+function safeReadImage(clipboardImpl) {
+  try {
+    return clipboardImpl.readImage?.('clipboard')
+  } catch {
+    return null
+  }
+}
+
+function safeCreateFromBuffer(nativeImageImpl, buffer) {
+  try {
+    return nativeImageImpl.createFromBuffer(buffer)
+  } catch {
+    return null
+  }
+}
+
+function safeCreateFromBitmap(nativeImageImpl, bitmap, options) {
+  try {
+    return nativeImageImpl.createFromBitmap(bitmap, options)
+  } catch {
+    return null
+  }
+}
+
+function clipboardFormats(clipboardImpl) {
+  try {
+    const formats = clipboardImpl.availableFormats('clipboard')
+    return Array.isArray(formats) ? formats.map(String) : []
+  } catch {
+    return []
+  }
+}
+
+function orderedImageFormats(formats) {
+  const seen = new Set()
+  const ordered = []
+  for (const format of FALLBACK_READ_FORMATS) {
+    const match = formats.find(item => item.toLowerCase() === format)
+    if (match && !seen.has(format)) {
+      seen.add(format)
+      ordered.push(match)
+    } else if (!seen.has(format)) {
+      seen.add(format)
+      ordered.push(format)
+    }
+  }
+  for (const format of formats) {
+    const lower = format.toLowerCase()
+    if (seen.has(lower)) continue
+    if (lower.startsWith('image/') || lower.includes('bitmap') || lower.includes('dib')) {
+      seen.add(lower)
+      ordered.push(format)
+    }
+  }
+  return ordered
+}
+
+function formatMayBeDib(format) {
+  const lower = String(format || '').toLowerCase()
+  return (
+    lower === 'cf_dib' ||
+    lower === 'cf_dibv5' ||
+    lower === 'image/bmp' ||
+    lower === 'image/x-bmp' ||
+    lower === 'image/x-dib' ||
+    lower === 'application/dib' ||
+    lower === 'application/x-ms-bmp' ||
+    lower.includes('dib')
+  )
+}
+
+function pixelOffsetForDib(buffer, headerSize, bitCount, compression) {
+  let offset = headerSize
+
+  // BITMAPINFOHEADER + BI_BITFIELDS stores channel masks immediately after
+  // the 40-byte header. BITMAPV4/V5 already include those masks in headerSize.
+  if (headerSize === 40 && compression === 3) {
+    offset += 12
+  }
+
+  if (bitCount <= 8) {
+    const colorsUsed = buffer.length >= 40 ? buffer.readUInt32LE(32) : 0
+    offset += (colorsUsed || (1 << bitCount)) * 4
+  }
+
+  return offset
+}
+
+function dibHasExplicitAlphaMask(buffer, headerSize, bitCount) {
+  if (bitCount !== 32 || headerSize < 56 || buffer.length < 56) {
+    return false
+  }
+  return buffer.readUInt32LE(52) !== 0
+}
+
+function dibToBitmap(buffer) {
+  if (!Buffer.isBuffer(buffer) || buffer.length < 40) {
+    return null
+  }
+
+  const headerSize = buffer.readUInt32LE(0)
+  if (headerSize < 40 || headerSize > buffer.length) {
+    return null
+  }
+
+  const width = buffer.readInt32LE(4)
+  const signedHeight = buffer.readInt32LE(8)
+  const planes = buffer.readUInt16LE(12)
+  const bitCount = buffer.readUInt16LE(14)
+  const compression = buffer.readUInt32LE(16)
+  const height = Math.abs(signedHeight)
+
+  if (width <= 0 || height <= 0 || planes !== 1) {
+    return null
+  }
+  if (bitCount !== 24 && bitCount !== 32) {
+    return null
+  }
+  if (compression !== 0 && compression !== 3) {
+    return null
+  }
+
+  const rowStride = Math.floor((width * bitCount + 31) / 32) * 4
+  const pixelOffset = pixelOffsetForDib(buffer, headerSize, bitCount, compression)
+  const required = pixelOffset + rowStride * height
+  if (pixelOffset < headerSize || required > buffer.length) {
+    return null
+  }
+
+  const topDown = signedHeight < 0
+  const bitmap = Buffer.alloc(width * height * 4)
+  const preserveAlpha = dibHasExplicitAlphaMask(buffer, headerSize, bitCount)
+  let sawAlpha = false
+
+  for (let y = 0; y < height; y += 1) {
+    const srcY = topDown ? y : height - 1 - y
+    const srcRow = pixelOffset + srcY * rowStride
+    const dstRow = y * width * 4
+
+    for (let x = 0; x < width; x += 1) {
+      const src = srcRow + x * (bitCount / 8)
+      const dst = dstRow + x * 4
+      bitmap[dst] = buffer[src]
+      bitmap[dst + 1] = buffer[src + 1]
+      bitmap[dst + 2] = buffer[src + 2]
+      bitmap[dst + 3] = preserveAlpha ? buffer[src + 3] : 255
+      if (preserveAlpha && bitmap[dst + 3] !== 0) {
+        sawAlpha = true
+      }
+    }
+  }
+
+  // Many Windows DIB producers leave the alpha byte zero even though pixels
+  // are opaque. Preserve explicit real alpha when present, otherwise make it
+  // visible.
+  if (preserveAlpha && !sawAlpha) {
+    for (let i = 3; i < bitmap.length; i += 4) {
+      bitmap[i] = 255
+    }
+  }
+
+  return { bitmap, width, height }
+}
+
+function imageFromDib(nativeImageImpl, buffer) {
+  const parsed = dibToBitmap(buffer)
+  if (!parsed) {
+    return null
+  }
+  return safeCreateFromBitmap(nativeImageImpl, parsed.bitmap, {
+    width: parsed.width,
+    height: parsed.height
+  })
+}
+
+function readClipboardImagePng(clipboardImpl, nativeImageImpl) {
+  const direct = imageToPngBuffer(safeReadImage(clipboardImpl))
+  if (direct) {
+    return direct
+  }
+
+  const formats = orderedImageFormats(clipboardFormats(clipboardImpl))
+  for (const format of formats) {
+    const buffer = safeReadBuffer(clipboardImpl, format)
+    if (!buffer) continue
+
+    const encoded = imageToPngBuffer(safeCreateFromBuffer(nativeImageImpl, buffer))
+    if (encoded) {
+      return encoded
+    }
+
+    if (formatMayBeDib(format)) {
+      const dib = imageToPngBuffer(imageFromDib(nativeImageImpl, buffer))
+      if (dib) {
+        return dib
+      }
+    }
+  }
+
+  return null
+}
+
+module.exports = {
+  __testing: { dibToBitmap, orderedImageFormats },
+  readClipboardImagePng
+}

--- a/apps/desktop/electron/clipboard-image.test.cjs
+++ b/apps/desktop/electron/clipboard-image.test.cjs
@@ -1,0 +1,259 @@
+'use strict'
+
+const assert = require('node:assert/strict')
+const test = require('node:test')
+
+const { __testing, readClipboardImagePng } = require('./clipboard-image.cjs')
+
+function nativeImage({ empty = false, png = Buffer.from('png') } = {}) {
+  return {
+    isEmpty: () => empty,
+    toPNG: () => png
+  }
+}
+
+function fakeClipboard({ image, formats = [], buffers = {} } = {}) {
+  return {
+    availableFormats: () => formats,
+    readBuffer: format => {
+      const value = buffers[format]
+      if (value instanceof Error) throw value
+      return value || Buffer.alloc(0)
+    },
+    readImage: () => image || nativeImage({ empty: true })
+  }
+}
+
+function makeDib32BottomUp(width, height, topDownBgraRows) {
+  const headerSize = 40
+  const rowStride = width * 4
+  const buffer = Buffer.alloc(headerSize + rowStride * height)
+  buffer.writeUInt32LE(headerSize, 0)
+  buffer.writeInt32LE(width, 4)
+  buffer.writeInt32LE(height, 8)
+  buffer.writeUInt16LE(1, 12)
+  buffer.writeUInt16LE(32, 14)
+  buffer.writeUInt32LE(0, 16)
+  buffer.writeUInt32LE(rowStride * height, 20)
+
+  for (let y = 0; y < height; y += 1) {
+    const srcRow = topDownBgraRows[height - 1 - y]
+    Buffer.from(srcRow).copy(buffer, headerSize + y * rowStride)
+  }
+
+  return buffer
+}
+
+function makeDib32TopDown(width, height, topDownBgraRows) {
+  const headerSize = 40
+  const rowStride = width * 4
+  const buffer = Buffer.alloc(headerSize + rowStride * height)
+  buffer.writeUInt32LE(headerSize, 0)
+  buffer.writeInt32LE(width, 4)
+  buffer.writeInt32LE(-height, 8)
+  buffer.writeUInt16LE(1, 12)
+  buffer.writeUInt16LE(32, 14)
+  buffer.writeUInt32LE(0, 16)
+  buffer.writeUInt32LE(rowStride * height, 20)
+
+  for (let y = 0; y < height; y += 1) {
+    Buffer.from(topDownBgraRows[y]).copy(buffer, headerSize + y * rowStride)
+  }
+
+  return buffer
+}
+
+function makeDib32Bitfields(width, height, topDownBgraRows) {
+  const headerSize = 40
+  const maskBytes = 12
+  const rowStride = width * 4
+  const buffer = Buffer.alloc(headerSize + maskBytes + rowStride * height)
+  buffer.writeUInt32LE(headerSize, 0)
+  buffer.writeInt32LE(width, 4)
+  buffer.writeInt32LE(height, 8)
+  buffer.writeUInt16LE(1, 12)
+  buffer.writeUInt16LE(32, 14)
+  buffer.writeUInt32LE(3, 16) // BI_BITFIELDS
+  buffer.writeUInt32LE(rowStride * height, 20)
+  buffer.writeUInt32LE(0x00ff0000, headerSize)
+  buffer.writeUInt32LE(0x0000ff00, headerSize + 4)
+  buffer.writeUInt32LE(0x000000ff, headerSize + 8)
+
+  for (let y = 0; y < height; y += 1) {
+    const srcRow = topDownBgraRows[height - 1 - y]
+    Buffer.from(srcRow).copy(buffer, headerSize + maskBytes + y * rowStride)
+  }
+
+  return buffer
+}
+
+function makeDib24BottomUp(width, height, topDownBgrRows) {
+  const headerSize = 40
+  const rowStride = Math.floor((width * 24 + 31) / 32) * 4
+  const buffer = Buffer.alloc(headerSize + rowStride * height)
+  buffer.writeUInt32LE(headerSize, 0)
+  buffer.writeInt32LE(width, 4)
+  buffer.writeInt32LE(height, 8)
+  buffer.writeUInt16LE(1, 12)
+  buffer.writeUInt16LE(24, 14)
+  buffer.writeUInt32LE(0, 16)
+  buffer.writeUInt32LE(rowStride * height, 20)
+
+  for (let y = 0; y < height; y += 1) {
+    const srcRow = topDownBgrRows[height - 1 - y]
+    Buffer.from(srcRow).copy(buffer, headerSize + y * rowStride)
+  }
+
+  return buffer
+}
+
+test('readClipboardImagePng uses clipboard.readImage first', () => {
+  const directPng = Buffer.from('direct')
+  const clipboard = fakeClipboard({
+    image: nativeImage({ png: directPng }),
+    formats: ['image/png'],
+    buffers: { 'image/png': Buffer.from('fallback') }
+  })
+
+  const result = readClipboardImagePng(clipboard, {
+    createFromBuffer: () => nativeImage({ png: Buffer.from('fallback-png') })
+  })
+
+  assert.deepEqual(result, directPng)
+})
+
+test('readClipboardImagePng falls back to encoded image clipboard buffers', () => {
+  const encoded = Buffer.from('encoded-image')
+  const converted = Buffer.from('converted-png')
+  const clipboard = fakeClipboard({
+    formats: ['text/plain', 'image/png'],
+    buffers: { 'image/png': encoded }
+  })
+
+  const result = readClipboardImagePng(clipboard, {
+    createFromBuffer: buffer => {
+      assert.deepEqual(buffer, encoded)
+      return nativeImage({ png: converted })
+    }
+  })
+
+  assert.deepEqual(result, converted)
+})
+
+test('readClipboardImagePng converts Windows DIB clipboard buffers', () => {
+  const topRed = [0, 0, 255, 255]
+  const bottomBlue = [255, 0, 0, 255]
+  const dib = makeDib32BottomUp(1, 2, [topRed, bottomBlue])
+  const png = Buffer.from('dib-png')
+  const clipboard = fakeClipboard({
+    formats: ['CF_DIB'],
+    buffers: { CF_DIB: dib }
+  })
+
+  const result = readClipboardImagePng(clipboard, {
+    createFromBitmap: (bitmap, options) => {
+      assert.deepEqual(options, { width: 1, height: 2 })
+      assert.deepEqual([...bitmap], [...topRed, ...bottomBlue])
+      return nativeImage({ png })
+    },
+    createFromBuffer: () => nativeImage({ empty: true })
+  })
+
+  assert.deepEqual(result, png)
+})
+
+test('readClipboardImagePng probes slash-form BMP when Windows advertises CF_DIB', () => {
+  const dib = makeDib32BottomUp(1, 1, [[4, 3, 2, 255]])
+  const png = Buffer.from('bmp-dib-png')
+  const clipboard = fakeClipboard({
+    formats: ['CF_DIB'],
+    buffers: {
+      CF_DIB: new Error('Electron rejects native CF_DIB format names'),
+      'image/bmp': dib
+    }
+  })
+
+  const result = readClipboardImagePng(clipboard, {
+    createFromBitmap: (bitmap, options) => {
+      assert.deepEqual(options, { width: 1, height: 1 })
+      assert.deepEqual([...bitmap], [4, 3, 2, 255])
+      return nativeImage({ png })
+    },
+    createFromBuffer: () => nativeImage({ empty: true })
+  })
+
+  assert.deepEqual(result, png)
+})
+
+test('dibToBitmap makes zero-alpha 32-bit DIB pixels visible', () => {
+  const dib = makeDib32BottomUp(1, 1, [[8, 7, 6, 0]])
+
+  const parsed = __testing.dibToBitmap(dib)
+
+  assert.deepEqual(parsed, {
+    bitmap: Buffer.from([8, 7, 6, 255]),
+    width: 1,
+    height: 1
+  })
+})
+
+test('dibToBitmap treats 32-bit BI_RGB alpha bytes as opaque', () => {
+  const dib = makeDib32BottomUp(2, 1, [[8, 7, 6, 0, 5, 4, 3, 128]])
+
+  const parsed = __testing.dibToBitmap(dib)
+
+  assert.deepEqual(parsed, {
+    bitmap: Buffer.from([8, 7, 6, 255, 5, 4, 3, 255]),
+    width: 2,
+    height: 1
+  })
+})
+
+test('dibToBitmap handles 32-bit BI_BITFIELDS masks after BITMAPINFOHEADER', () => {
+  const dib = makeDib32Bitfields(1, 1, [[4, 3, 2, 99]])
+
+  const parsed = __testing.dibToBitmap(dib)
+
+  assert.deepEqual(parsed, {
+    bitmap: Buffer.from([4, 3, 2, 255]),
+    width: 1,
+    height: 1
+  })
+})
+
+test('dibToBitmap handles 24-bit row padding', () => {
+  const topRed = [0, 0, 255]
+  const bottomBlue = [255, 0, 0]
+  const dib = makeDib24BottomUp(1, 2, [topRed, bottomBlue])
+
+  const parsed = __testing.dibToBitmap(dib)
+
+  assert.deepEqual(parsed, {
+    bitmap: Buffer.from([0, 0, 255, 255, 255, 0, 0, 255]),
+    width: 1,
+    height: 2
+  })
+})
+
+test('dibToBitmap handles top-down negative-height DIBs', () => {
+  const first = [1, 2, 3, 255]
+  const second = [4, 5, 6, 255]
+  const dib = makeDib32TopDown(1, 2, [first, second])
+
+  const parsed = __testing.dibToBitmap(dib)
+
+  assert.deepEqual(parsed, {
+    bitmap: Buffer.from([...first, ...second]),
+    width: 1,
+    height: 2
+  })
+})
+
+test('readClipboardImagePng returns null when no image format is usable', () => {
+  const result = readClipboardImagePng(fakeClipboard({ formats: ['text/plain'] }), {
+    createFromBuffer: () => nativeImage({ empty: true }),
+    createFromBitmap: () => nativeImage({ empty: true })
+  })
+
+  assert.equal(result, null)
+})

--- a/apps/desktop/electron/main.cjs
+++ b/apps/desktop/electron/main.cjs
@@ -43,6 +43,7 @@ const { buildDesktopBackendEnv, normalizeHermesHomeRoot } = require('./backend-e
 const { readWindowsUserEnvVar } = require('./windows-user-env.cjs')
 const { readDirForIpc } = require('./fs-read-dir.cjs')
 const { gitRootForIpc } = require('./git-root.cjs')
+const { readClipboardImagePng } = require('./clipboard-image.cjs')
 const { worktreesForIpc } = require('./git-worktrees.cjs')
 const { OFFICIAL_REPO_HTTPS_URL, isOfficialSshRemote } = require('./update-remote.cjs')
 const { runRebuildWithRetry } = require('./update-rebuild.cjs')
@@ -5731,12 +5732,12 @@ ipcMain.handle('hermes:saveImageBuffer', async (_event, payload) => {
 })
 
 ipcMain.handle('hermes:saveClipboardImage', async () => {
-  const image = clipboard.readImage()
-  if (!image || image.isEmpty()) {
+  const png = readClipboardImagePng(clipboard, nativeImage)
+  if (!png) {
     return ''
   }
 
-  return writeComposerImage(image.toPNG(), '.png')
+  return writeComposerImage(png, '.png')
 })
 
 ipcMain.handle('hermes:normalizePreviewTarget', (_event, target, baseDir) =>

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -37,7 +37,7 @@
     "test:desktop:nsis": "node scripts/test-desktop.mjs nsis",
     "test:desktop:existing": "node scripts/test-desktop.mjs existing",
     "test:desktop:fresh": "node scripts/test-desktop.mjs fresh",
-    "test:desktop:platforms": "node --test electron/bootstrap-platform.test.cjs electron/hardening.test.cjs electron/backend-env.test.cjs electron/backend-probes.test.cjs electron/bootstrap-runner.test.cjs electron/connection-config.test.cjs electron/dashboard-token.test.cjs electron/gateway-ws-probe.test.cjs electron/oauth-net-request.test.cjs electron/desktop-uninstall.test.cjs electron/session-windows.test.cjs electron/workspace-cwd.test.cjs electron/fs-read-dir.test.cjs electron/git-root.test.cjs electron/windows-child-process.test.cjs electron/update-remote.test.cjs electron/update-rebuild.test.cjs electron/windows-user-env.test.cjs",
+    "test:desktop:platforms": "node --test electron/bootstrap-platform.test.cjs electron/hardening.test.cjs electron/backend-env.test.cjs electron/backend-probes.test.cjs electron/bootstrap-runner.test.cjs electron/clipboard-image.test.cjs electron/connection-config.test.cjs electron/dashboard-token.test.cjs electron/gateway-ws-probe.test.cjs electron/oauth-net-request.test.cjs electron/desktop-uninstall.test.cjs electron/session-windows.test.cjs electron/workspace-cwd.test.cjs electron/fs-read-dir.test.cjs electron/git-root.test.cjs electron/windows-child-process.test.cjs electron/update-remote.test.cjs electron/update-rebuild.test.cjs electron/windows-user-env.test.cjs",
     "typecheck": "tsc -p . --noEmit",
     "lint": "eslint src/ electron/",
     "lint:fix": "eslint src/ electron/ --fix",


### PR DESCRIPTION
Fixes #48054.

## Summary
- add a desktop clipboard image helper that keeps the existing `readImage` path and falls back to advertised image buffers
- probe Windows DIB/BMP clipboard formats and convert 24/32-bit DIB pixels into a native image before saving
- cover DIB row ordering, row padding, BI_BITFIELDS offset, and alpha handling

## Tests
- `node --test apps/desktop/electron/clipboard-image.test.cjs`
- `npm --workspace apps/desktop run typecheck`
- `npm --workspace apps/desktop exec eslint -- --quiet electron/clipboard-image.cjs electron/clipboard-image.test.cjs`
- `node --check apps/desktop/electron/main.cjs && node --check apps/desktop/electron/clipboard-image.cjs && node --check apps/desktop/electron/clipboard-image.test.cjs && git diff --cached --check`