### PR TITLE
fix(installer): ensure system Node directory is on PATH for npm lifecycle scripts

### DIFF
--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -767,6 +767,15 @@ function Test-Node {
     if (Get-Command node -ErrorAction SilentlyContinue) {
         $version = node --version
         if (Test-NodeVersionOk $version) {
+            # Ensure the directory containing node.exe is on PATH so that npm
+            # lifecycle scripts (which spawn child processes like "node install.js")
+            # can resolve node even when the parent npm.cmd was found through a
+            # different PATH entry (e.g. a .cmd shim).  Mirrors the explicit
+            # $env:Path prepend used for Hermes-managed Node below.
+            $nodeExeDir = Split-Path (Get-Command node).Source -Parent
+            if ($env:Path -notlike "*$nodeExeDir*") {
+                $env:Path = "$nodeExeDir;$env:Path"
+            }
             Write-Success "Node.js $version found"
             $script:HasNode = $true
             return $true


### PR DESCRIPTION
## Summary

The Windows installer (`scripts/install.ps1`) detects a system-installed Node.js via `Get-Command node`, sets `$HasNode`, and proceeds to invoke npm for desktop dependency installation. However, npm lifecycle scripts (e.g. `node install.js`) run as **child processes** with the inherited `$env:Path`.

If `node.exe` is discoverable through a `.cmd` shim or a different PATH entry than the directory containing `node.exe` itself, those child processes fail with:

```
'node' is not recognized as an internal or external command
```

The **Hermes-managed Node** path already explicitly prepends the node directory to `$env:Path` (lines 781, 820), but the **system Node** detection path did not.

## Fix

After detecting a valid system Node, extract its directory via `Split-Path (Get-Command node).Source -Parent` and prepend it to `$env:Path` if not already present. Mirrors the existing pattern for Hermes-managed Node.

**File changed:** `scripts/install.ps1` (+9 lines)

## Test plan

- [ ] On Windows with system Node (e.g. nvm-windows), run the installer
- [ ] Verify npm lifecycle scripts can resolve `node` and complete successfully
- [ ] Verify no duplicate PATH entries when Node dir is already on PATH
- [ ] Verify Hermes-managed Node path (portable download) still works as before

Fixes #48130
