### PR TITLE
fix(docker): normalize Windows drive-letter paths for `-w` flag (#48137)

### DIFF
--- a/tools/environments/docker.py
+++ b/tools/environments/docker.py
@@ -534,6 +534,14 @@ class DockerEnvironment(BaseEnvironment):
     ):
         if cwd == "~":
             cwd = "/root"
+        # Windows drive-letter paths (e.g. "C:\Users\...") cannot reach the
+        # Linux container's `-w` (workdir) flag. Fall back to /workspace.
+        if len(cwd) >= 2 and cwd[1] == ":":
+            logger.debug(
+                "Normalizing Windows host path %r to /workspace for Docker -w flag (#48137)",
+                cwd,
+            )
+            cwd = "/workspace"
         super().__init__(cwd=cwd, timeout=timeout)
         self._persistent = persistent_filesystem
         self._persist_across_processes = persist_across_processes


### PR DESCRIPTION
## Summary

On Windows native (Hermes Desktop, not WSL2) with `terminal.backend: docker`, Windows host paths (e.g. `C:\Users\<user>`) leak into the `docker run -w` flag, causing exit code 125 and complete failure of the Docker backend on Windows.

## Fix

This adds a normalization check in `DockerEnvironment.__init__` (tools/environments/docker.py): any Windows drive-letter path (detected by `len(cwd) >= 2 and cwd[1] == ":"`) is converted to `/workspace` before reaching the docker subprocess call, consistent with the existing `~` → `/root` normalization on the line above.

The root cause is that `_get_env_config()` in tools/terminal_tool.py logs a corrected value but the raw Windows path still reaches `-w`. This fix applies at the constructor level as a safety net for all code paths.

## Testing

- Confirmed by the issue reporter: a similar workaround patch resolves both the exit 125 failure and allows `pwd` to correctly return `/workspace` inside the container.
- The change is minimal (8 lines added), with zero impact on non-Windows systems.

Closes #48137