### PR TITLE
fix(cli): resolve Chinese IME input not displaying until next keypress on Windows

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -14221,6 +14221,13 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
                 return
             chars_added = len(text) - _prev_text_len[0]
             _prev_text_len[0] = len(text)
+            # On Windows, IME composition can deliver 2-20 characters in a
+            # single batch. Skip escape sequence stripping and paste detection
+            # for small batches to avoid interfering with IME input rendering.
+            # Actual pastes (200+ chars, 5+ lines) still exceed this threshold.
+            if sys.platform == "win32" and 0 < chars_added <= 20:
+                _prev_newline_count[0] = text.count("\n")
+                return
             if _paste_just_collapsed[0] or self._skip_paste_collapse:
                 _paste_just_collapsed[0] = False
                 self._skip_paste_collapse = False
@@ -15425,9 +15432,13 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
 
                 _aio_probe.set_event_loop_policy(_SelectEventLoopPolicy())
 
-        # Run the application with patch_stdout for proper output handling
+        # Run the application with patch_stdout for proper output handling.
+        # On Windows, use raw=True to avoid VT100 mode toggling during stdout
+        # flushes, which interferes with IME (Input Method Editor) composition.
+        # See #48161 for details.
+        _patch_stdout_kwargs = {"raw": True} if sys.platform == "win32" else {}
         try:
-            with patch_stdout():
+            with patch_stdout(**_patch_stdout_kwargs):
                 # Set the custom handler on prompt_toolkit's event loop
                 try:
                     import asyncio as _aio


### PR DESCRIPTION
## Summary

On Windows, when using a Chinese IME, confirmed characters do not appear in the input field until the user presses an additional key. This PR fixes the issue with two targeted changes.

## Root Cause

Two issues combine:

1. **patch_stdout() VT mode toggle**: The default StdoutProxy calls `output.write(text)` which toggles VT100 terminal processing on every flush. This interferes with Windows IME composition, delaying input area redraw.

2. **Paste detection misfire**: `_on_text_changed` detects `chars_added > 1` as potential paste. IME confirmation of 2+ characters triggers this. The escape sequence stripping logic can then reset `buf.text` and return early, skipping the normal render path.

## Changes

### Fix 1: `patch_stdout(raw=True)` on Windows only

```python
_patch_stdout_kwargs = {"raw": True} if sys.platform == "win32" else {}
with patch_stdout(**_patch_stdout_kwargs):
```

`raw=True` uses `output.write_raw(text)` instead of `output.write(text)`, bypassing the VT mode toggle. Other platforms keep default behavior.

**Trade-off**: Bare `print()` calls with ANSI codes won't be colorized through the proxy. However, Hermes routes all CLI output through `_cprint()` → `print_formatted_text()`, which doesn't go through StdoutProxy. The few bare `print()` calls with ANSI are in non-app subcommands that run outside the `patch_stdout` context.

### Fix 2: Skip paste detection for small batches on Windows

```python
if sys.platform == "win32" and 0 < chars_added <= 20:
    _prev_newline_count[0] = text.count("\n")
    return
```

IME composition delivers 2-20 chars in a single batch. Small batches skip escape sequence stripping and paste detection, flowing through the normal render path. Actual pastes (200+ chars, 5+ lines) still exceed the threshold and are collapsed as before.

## Testing

- Manually tested on Windows with Chinese IME (Microsoft Pinyin) — input now displays immediately after IME confirmation, no additional keypress needed.
- `py_compile` passes.
- Non-Windows platforms: no behavior change (both fixes are guarded by `sys.platform == "win32"`).

Closes #48161
