### PR TITLE
fix(gateway): consume `was_auto_reset` before slash commands to prevent /model override loss

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -8333,6 +8333,20 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
         session_entry = self.session_store.get_or_create_session(source)
         session_key = session_entry.session_key
+
+        # Consume the auto-reset flag immediately so that slash commands
+        # processed earlier in _handle_message (e.g. /model) do not leave
+        # it stale.  Without this early consume, a /model issued as the
+        # first message after an auto-reset sets an override that the
+        # override-clearing block below would wipe on the *next* regular
+        # message — because /model returns from _handle_message before
+        # _handle_message_with_agent is ever reached, so the flag was
+        # never consumed.  (#48031)
+        _was_auto_reset = getattr(session_entry, "was_auto_reset", False)
+        if _was_auto_reset:
+            session_entry.was_auto_reset = False
+            session_entry.auto_reset_reason = None
+
         self._cache_session_source(session_key, source)
         if self._is_telegram_topic_lane(source):
             try:
@@ -8390,7 +8404,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     self._record_telegram_topic_binding(source, session_entry)
                 except Exception:
                     logger.debug("Failed to record Telegram topic binding", exc_info=True)
-        if getattr(session_entry, "was_auto_reset", False):
+        if _was_auto_reset:
             # Treat auto-reset as a full conversation boundary — drop every
             # session-scoped transient state so the fresh session does not
             # inherit the previous conversation's model/reasoning overrides
@@ -8403,7 +8417,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # Emit session:start for new or auto-reset sessions
         _is_new_session = (
             session_entry.created_at == session_entry.updated_at
-            or getattr(session_entry, "was_auto_reset", False)
+            or _was_auto_reset
             or getattr(session_entry, "is_fresh_reset", False)
         )
         # Consume the is_fresh_reset flag immediately so it doesn't leak
@@ -8439,7 +8453,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         
         # If the previous session expired and was auto-reset, prepend a notice
         # so the agent knows this is a fresh conversation (not an intentional /reset).
-        if getattr(session_entry, 'was_auto_reset', False):
+        if _was_auto_reset:
             reset_reason = getattr(session_entry, 'auto_reset_reason', None) or 'idle'
             if reset_reason == "suspended":
                 context_note = "[System note: The user's previous session was stopped and suspended. This is a fresh conversation with no prior context.]"
@@ -8498,8 +8512,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             except Exception as e:
                 logger.debug("Auto-reset notification failed (non-fatal): %s", e)
 
-            session_entry.was_auto_reset = False
-            session_entry.auto_reset_reason = None
+        # (was_auto_reset and auto_reset_reason are now consumed at the top
+        #  of this function — see the early-consume block above.)
 
         # Auto-load skill(s) for topic/channel bindings (Telegram DM Topics,
         # Discord channel_skill_bindings).  Supports a single name or ordered list.


### PR DESCRIPTION
## Summary

After a session auto-reset (idle timeout, daily schedule, suspension), the `was_auto_reset` flag is persisted to the session DB. On the next message, `_handle_message_with_agent` checks this flag and clears session-scoped model/reasoning overrides.

**The problem:** Slash commands like `/model` are processed in `_handle_message` **before** `_handle_message_with_agent` is reached. `/model` sets the override and returns immediately — `_handle_message_with_agent` is never called for that message, so `was_auto_reset` is never consumed.

On the **next** regular message, `_handle_message_with_agent` runs, sees `was_auto_reset` still `True`, and **wipes the override that `/model` just set**.

The user sees "Model switched to X" but actual API calls go to the old model.

## Fix

Consume `was_auto_reset` immediately after loading the session entry at the top of `_handle_message_with_agent`, before the override-clearing block. Save the value in a local `_was_auto_reset` variable for downstream checks (is_new_session, context notice, etc.).

**File changed:** `gateway/run.py` (+19, -5)

## Test plan

- [ ] Let a session idle until auto-reset triggers
- [ ] Send `/model <new_model>` as the first message after reset
- [ ] Send a regular message
- [ ] Verify the response comes from the new model (check provider logs)
- [ ] Verify the auto-reset context notice still appears correctly
- [ ] Verify `is_new_session` still fires for auto-reset sessions

Fixes #48031
