### PR TITLE
fix(docker): prevent Windows drive-letter paths reaching ``docker run -w``

### DIFF
--- a/tests/tools/test_docker_environment.py
+++ b/tests/tools/test_docker_environment.py
@@ -918,6 +918,55 @@ def test_find_reusable_container_prefers_running_over_stopped(monkeypatch):
     )
 
 
+# ── Windows drive-letter cwd handling (#48137) ─────────────────────
+
+
+def test_windows_drive_letter_cwd_normalized_to_workspace(monkeypatch):
+    """A Windows-style CWD (e.g. C:\\Users\\...) must be rewritten to
+    /workspace before it reaches ``docker run -w``."""
+
+    monkeypatch.setattr(docker_env, "find_docker", lambda: "/usr/bin/docker")
+    monkeypatch.setattr(docker_env, "_get_active_profile_name", lambda: "default")
+    _mock_subprocess_run(monkeypatch)
+
+    env = _make_dummy_env(cwd="C:\\Users\\testuser")
+    assert env.cwd == "/workspace", (
+        f"expected /workspace for Windows CWD, got {env.cwd!r}"
+    )
+
+
+def test_windows_drive_letter_single_char_drive(monkeypatch):
+    """D: or Z: — any single-letter drive prefix triggers the guard."""
+
+    monkeypatch.setattr(docker_env, "find_docker", lambda: "/usr/bin/docker")
+    monkeypatch.setattr(docker_env, "_get_active_profile_name", lambda: "default")
+    _mock_subprocess_run(monkeypatch)
+
+    env = _make_dummy_env(cwd="D:\\work\\project")
+    assert env.cwd == "/workspace"
+
+
+def test_posix_cwd_passes_through(monkeypatch):
+    """POSIX paths must NOT be rewritten."""
+
+    monkeypatch.setattr(docker_env, "find_docker", lambda: "/usr/bin/docker")
+    monkeypatch.setattr(docker_env, "_get_active_profile_name", lambda: "default")
+    _mock_subprocess_run(monkeypatch)
+
+    env = _make_dummy_env(cwd="/home/user/project")
+    assert env.cwd == "/home/user/project"
+
+
+def test_tilde_cwd_still_normalized(monkeypatch):
+    """~ must still be normalized to /root (existing behaviour)."""
+
+    monkeypatch.setattr(docker_env, "find_docker", lambda: "/usr/bin/docker")
+    monkeypatch.setattr(docker_env, "_get_active_profile_name", lambda: "default")
+    _mock_subprocess_run(monkeypatch)
+
+    env = _make_dummy_env(cwd="~")
+    assert env.cwd == "/root"
+
 # ── Cleanup correctness (issue #20561) ────────────────────────────
 
 

--- a/tools/environments/docker.py
+++ b/tools/environments/docker.py
@@ -534,6 +534,16 @@ class DockerEnvironment(BaseEnvironment):
     ):
         if cwd == "~":
             cwd = "/root"
+        # On native Windows, TERMINAL_CWD can be a drive-letter path
+        # (e.g. C:\\Users\\<user>) that leaks into ``docker run -w``.
+        # Docker rejects Windows-style paths inside Linux containers;
+        # fall back to a container-internal default instead.
+        if len(cwd) >= 2 and cwd[1] == ":":
+            logger.info(
+                "Inside Docker environment, ignoring Windows-style cwd "
+                "(%r) and defaulting to /workspace.", cwd,
+            )
+            cwd = "/workspace"
         super().__init__(cwd=cwd, timeout=timeout)
         self._persistent = persistent_filesystem
         self._persist_across_processes = persist_across_processes
@@ -595,6 +605,26 @@ class DockerEnvironment(BaseEnvironment):
                 logger.warning(f"Docker volume '{vol}' missing colon, skipping")
 
         host_cwd_abs = os.path.abspath(os.path.expanduser(host_cwd)) if host_cwd else ""
+        # On native Windows, TERMINAL_CWD defaults to the user's entire
+        # profile directory (C:\\Users\\<name>).  Blindly bind-mounting
+        # that into /workspace exposes Documents, Pictures, AppData,
+        # browser cookies, and NTUSER.DAT inside the sandbox.  Scope it
+        # to a dedicated subdirectory instead.
+        if (
+            host_cwd_abs
+            and len(host_cwd_abs) >= 2
+            and host_cwd_abs[1] == ":"
+        ):
+            scoped = os.path.join(host_cwd_abs, ".hermes_docker_workspace")
+            try:
+                os.makedirs(scoped, exist_ok=True)
+                host_cwd_abs = scoped
+            except OSError:
+                logger.debug(
+                    "Cannot create scoped workspace %r, skipping cwd mount",
+                    scoped,
+                )
+                host_cwd_abs = ""
         bind_host_cwd = (
             auto_mount_cwd
             and bool(host_cwd_abs)


### PR DESCRIPTION
## Summary

Two related fixes for native Windows + Docker backend (#48137).

### Issue 1 (crash): `-w` receives raw Windows path

`DockerEnvironment.__init__` now detects drive-letter paths (e.g. `C:\Users\...`) and rewrites them to `/workspace` before they reach `docker run -w`. Docker rejects Windows-style paths inside Linux containers with exit code 125.

### Issue 2 (security): auto_mount_cwd mounts entire user profile

When `docker_mount_cwd_to_workspace` is true on Windows, the terminal CWD defaults to the user profile root. Bind-mounting that into `/workspace` exposed Documents, Pictures, AppData, browser cookies, and NTUSER.DAT inside the sandbox. The mount is now scoped to a `.hermes_docker_workspace` subdirectory.

## Changes

```python
# tools/environments/docker.py:535-543 (Issue 1)
if len(cwd) >= 2 and cwd[1] == ":":
    cwd = "/workspace"

# tools/environments/docker.py:607-619 (Issue 2)
if host_cwd_abs and len(host_cwd_abs) >= 2 and host_cwd_abs[1] == ":":
    scoped = os.path.join(host_cwd_abs, ".hermes_docker_workspace")
    os.makedirs(scoped, exist_ok=True)
    host_cwd_abs = scoped
```

## Testing

4 new tests + 69 existing = 73/73 docker tests pass (0 regressions):
- `test_windows_drive_letter_cwd_normalized_to_workspace`
- `test_windows_drive_letter_single_char_drive`
- `test_posix_cwd_passes_through`
- `test_tilde_cwd_still_normalized`

Fixes #48137