### PR TITLE
feat(computer-use): add Linux backend

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -11963,69 +11963,116 @@ def main():
     build_tools_parser(subparsers, cmd_tools=cmd_tools)
 
     # =========================================================================
-    # computer-use command — manage Computer Use (cua-driver) on macOS
+    # computer-use command — manage Computer Use desktop backends
     # =========================================================================
     computer_use_parser = subparsers.add_parser(
         "computer-use",
-        help="Manage the Computer Use (cua-driver) backend (macOS)",
+        help="Manage Computer Use desktop backends",
         description=(
-            "Install or check the cua-driver binary used by the\n"
-            "`computer_use` toolset. macOS-only.\n\n"
-            "Use `hermes computer-use install` to fetch and run the\n"
-            "upstream cua-driver installer. This is equivalent to the\n"
-            "post-setup hook that `hermes tools` runs when you first\n"
-            "enable the Computer Use toolset, and is a stable target\n"
-            "for re-running the install if it didn't fire (e.g. when\n"
-            "toggling the toolset on a returning-user setup)."
+            "Install or check the desktop driver used by the `computer_use`\n"
+            "toolset. macOS uses cua-driver. Linux uses linux-computer-use.\n\n"
+            "Use `hermes computer-use install` to install the appropriate\n"
+            "driver for this platform. This is equivalent to the post-setup\n"
+            "hook that `hermes tools` runs when you first enable the Computer\n"
+            "Use toolset, and is a stable target for re-running the install."
         ),
     )
     computer_use_sub = computer_use_parser.add_subparsers(dest="computer_use_action")
 
     computer_use_install = computer_use_sub.add_parser(
         "install",
-        help="Install or repair the cua-driver binary (macOS)",
+        help="Install or repair the desktop computer-use driver for this platform",
+
     )
     computer_use_install.add_argument(
         "--upgrade",
         action="store_true",
         help=(
-            "Re-run the upstream installer even if cua-driver is already on "
-            "PATH. The upstream install.sh always pulls the latest release, "
-            "so this performs an in-place upgrade."
+            "Re-run the platform installer even if a driver is already on PATH. "
+            "On macOS this refreshes cua-driver; on Linux this upgrades the "
+            "linux-computer-use package when pipx is available."
         ),
     )
     computer_use_sub.add_parser(
         "status",
-        help="Print whether cua-driver is installed and on PATH",
+        help="Print whether the platform computer-use driver is installed and on PATH",
     )
 
     def cmd_computer_use(args):
         action = getattr(args, "computer_use_action", None)
         if action == "install":
-            from hermes_cli.tools_config import install_cua_driver
-            install_cua_driver(upgrade=bool(getattr(args, "upgrade", False)))
-            return
+            import shutil
+            import subprocess
+            import sys
+
+            upgrade = bool(getattr(args, "upgrade", False))
+            if sys.platform == "darwin":
+                from hermes_cli.tools_config import install_cua_driver
+                install_cua_driver(upgrade=upgrade)
+                return
+            if sys.platform.startswith("linux"):
+                if shutil.which("linux-computer-use") and not upgrade:
+                    print("linux-computer-use: already installed")
+                    print("  Refresh to latest: hermes computer-use install --upgrade")
+                    return
+                pkg = "git+https://github.com/tyy130/linux-computer-use"
+                if shutil.which("pipx"):
+                    cmd = ["pipx", "install", pkg]
+                    if upgrade and shutil.which("linux-computer-use"):
+                        cmd = ["pipx", "upgrade", "linux-computer-use"]
+                    subprocess.run(cmd, check=True)
+                    return
+                if shutil.which("uv"):
+                    cmd = ["uv", "tool", "install", pkg]
+                    if upgrade:
+                        cmd.insert(3, "--upgrade")
+                    subprocess.run(cmd, check=True)
+                    return
+                print("linux-computer-use install requires pipx or uv on PATH.")
+                print(f"  pipx install {pkg}")
+                print(f"  uv tool install {pkg}")
+                raise SystemExit(1)
+            print("computer-use install is currently supported on macOS and Linux.")
+            raise SystemExit(1)
         if action == "status":
             import shutil
             import subprocess
-            path = shutil.which("cua-driver")
-            if path:
-                version = ""
-                try:
-                    version = subprocess.run(
-                        ["cua-driver", "--version"],
-                        capture_output=True, text=True, timeout=5,
-                    ).stdout.strip()
-                except Exception:
-                    pass
-                if version:
-                    print(f"cua-driver: installed at {path} ({version})")
-                else:
-                    print(f"cua-driver: installed at {path}")
-                print("  Refresh to latest: hermes computer-use install --upgrade")
+            import sys
+
+            def _print_binary(name, refresh_cmd):
+                path = shutil.which(name)
+                if path:
+                    version = ""
+                    try:
+                        version = subprocess.run(
+                            [name, "--version"],
+                            capture_output=True, text=True, timeout=5,
+                        ).stdout.strip()
+                    except Exception:
+                        pass
+                    if version:
+                        print(f"{name}: installed at {path} ({version})", flush=True)
+                    else:
+                        print(f"{name}: installed at {path}", flush=True)
+                    print(f"  Refresh to latest: {refresh_cmd}", flush=True)
+                    return True
+                print(f"{name}: not installed")
+                return False
+
+            if sys.platform == "darwin":
+                if not _print_binary("cua-driver", "hermes computer-use install --upgrade"):
+                    print("  Run: hermes computer-use install")
                 return
-            print("cua-driver: not installed")
-            print("  Run: hermes computer-use install")
+            if sys.platform.startswith("linux"):
+                if _print_binary("linux-computer-use", "hermes computer-use install --upgrade"):
+                    try:
+                        subprocess.run(["linux-computer-use", "status"], check=False, timeout=10)
+                    except Exception:
+                        pass
+                else:
+                    print("  Run: hermes computer-use install")
+                return
+            print("computer_use backend: unsupported platform")
             return
         # No subcommand → show help
         computer_use_parser.print_help()

--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -516,23 +516,19 @@ TOOL_CATEGORIES = {
         ],
     },
     "computer_use": {
-        "name": "Computer Use (macOS)",
+        "name": "Computer Use (Desktop)",
         "icon": "🖱️",
-        "platform_gate": "darwin",
         "providers": [
             {
-                "name": "cua-driver (background)",
+                "name": "Platform driver (cua-driver on macOS, linux-computer-use on Linux)",
                 "badge": "★ recommended · free · local",
                 "tag": (
-                    "macOS background computer-use via SkyLight SPIs — does "
-                    "NOT steal your cursor or focus. Works with any model."
+                    "Desktop computer-use for any tool-capable model. macOS "
+                    "uses background cua-driver; Linux uses an X11-first MCP "
+                    "driver and may move pointer/focus."
                 ),
-                "env_vars": [
-                    # cua-driver reads HOME/TMPDIR from the process env, no
-                    # extra keys required. HERMES_CUA_DRIVER_VERSION is an
-                    # optional pin for reproducibility across macOS updates.
-                ],
-                "post_setup": "cua_driver",
+                "env_vars": [],
+                "post_setup": "computer_use_driver",
             },
         ],
     },
@@ -789,6 +785,65 @@ def install_cua_driver(upgrade: bool = False) -> bool:
     return ok
 
 
+def install_linux_computer_use(upgrade: bool = False) -> bool:
+    """Install or refresh the Linux computer-use MCP driver."""
+    import platform as _plat
+    import shutil
+    import subprocess
+
+    if _plat.system() != "Linux":
+        if not upgrade:
+            _print_warning("    linux-computer-use is Linux-only; skipping.")
+        return False
+
+    binary = shutil.which("linux-computer-use")
+    if binary and not upgrade:
+        _print_success(f"    linux-computer-use already installed: {binary}")
+        return True
+
+    pkg = "git+https://github.com/tyy130/linux-computer-use"
+    if shutil.which("pipx"):
+        cmd = ["pipx", "install", pkg]
+        if binary and upgrade:
+            cmd = ["pipx", "upgrade", "linux-computer-use"]
+    elif shutil.which("uv"):
+        cmd = ["uv", "tool", "install", pkg]
+        if upgrade:
+            cmd.insert(3, "--upgrade")
+    else:
+        _print_warning("    pipx or uv is required to install linux-computer-use automatically.")
+        _print_info(f"      pipx install {pkg}")
+        _print_info(f"      uv tool install {pkg}")
+        return bool(binary)
+
+    _print_info("    Installing linux-computer-use (Linux desktop MCP driver)...")
+    try:
+        result = subprocess.run(cmd, timeout=300)
+        if result.returncode == 0 and shutil.which("linux-computer-use"):
+            _print_success("    linux-computer-use installed.")
+            _print_info("    For full control on Linux, use an X11 session with xdotool + scrot installed.")
+            return True
+        _print_warning("    linux-computer-use installation did not complete. Run manually:")
+        _print_info(f"      {' '.join(cmd)}")
+        return bool(binary)
+    except subprocess.TimeoutExpired:
+        _print_warning("    linux-computer-use installation timed out. Run manually:")
+        _print_info(f"      {' '.join(cmd)}")
+        return bool(binary)
+
+
+def install_computer_use_driver(upgrade: bool = False) -> bool:
+    """Install the platform-appropriate Computer Use driver."""
+    import platform as _plat
+    system = _plat.system()
+    if system == "Darwin":
+        return install_cua_driver(upgrade=upgrade)
+    if system == "Linux":
+        return install_linux_computer_use(upgrade=upgrade)
+    _print_warning("    Computer Use desktop driver is currently supported on macOS and Linux.")
+    return False
+
+
 def _run_cua_driver_installer(label: str = "Installing", verbose: bool = True) -> bool:
     """Run the upstream cua-driver install.sh. Returns True on success.
 
@@ -970,8 +1025,8 @@ def _run_post_setup(post_setup_key: str):
             _print_warning("    Node.js not found. Install Camofox via Docker:")
             _print_info("      docker run -p 9377:9377 -e CAMOFOX_PORT=9377 jo-inc/camofox-browser")
 
-    elif post_setup_key == "cua_driver":
-        install_cua_driver(upgrade=False)
+    elif post_setup_key in {"computer_use_driver", "cua_driver"}:
+        install_computer_use_driver(upgrade=False)
 
     elif post_setup_key == "kittentts":
         try:
@@ -2141,6 +2196,9 @@ _POST_SETUP_INSTALLED: dict = {
     # a no-key provider, and (b) an installed-state check is cheap and
     # doesn't trigger a heavy import.
     "cua_driver": lambda: bool(shutil.which(_cua_driver_cmd())),
+    "computer_use_driver": lambda: bool(
+        shutil.which(_cua_driver_cmd()) or shutil.which("linux-computer-use")
+    ),
 }
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -194,10 +194,10 @@ nemo-relay = ["nemo-relay==0.3"]
 homeassistant = ["aiohttp==3.13.4"]
 sms = ["aiohttp==3.13.4"]
 teams = ["microsoft-teams-apps==2.0.13.4", "aiohttp==3.13.4"]
-# Computer use — macOS background desktop control via cua-driver (MCP stdio).
-# The cua-driver binary itself is installed via `hermes tools` post-setup
-# (curl install script); this extra just pins the MCP client used to talk
-# to it, which is already provided by the `mcp` extra.
+# Computer use — desktop control via MCP stdio backends. macOS uses cua-driver
+# (installed via `hermes tools` / `hermes computer-use install`). Linux uses the
+# companion linux-computer-use executable (`linux-computer-use mcp`). This extra
+# pins the MCP client used to talk to those drivers.
 computer-use = ["mcp==1.26.0", "starlette==1.0.1"]  # starlette: CVE-2026-48710
 acp = ["agent-client-protocol==0.9.0"]
 # mistral: Voxtral STT + TTS. Pinned to an exact verified-clean version.

--- a/tests/tools/test_computer_use.py
+++ b/tests/tools/test_computer_use.py
@@ -109,11 +109,17 @@ class TestRegistration:
         assert entry.toolset == "computer_use"
         assert entry.schema["name"] == "computer_use"
 
-    def test_check_fn_is_false_on_linux(self):
+    def test_check_fn_uses_linux_driver_on_linux(self):
         import tools.computer_use_tool  # noqa: F401
         from tools.registry import registry
         entry = registry._tools["computer_use"]
-        if sys.platform != "darwin":
+        if sys.platform.startswith("linux"):
+            with patch.dict(os.environ, {"HERMES_COMPUTER_USE_BACKEND": ""}, clear=False):
+                with patch("tools.computer_use.linux_backend.linux_driver_binary_available", return_value=True):
+                    assert entry.check_fn() is True
+                with patch("tools.computer_use.linux_backend.linux_driver_binary_available", return_value=False):
+                    assert entry.check_fn() is False
+        elif sys.platform != "darwin":
             assert entry.check_fn() is False
 
 

--- a/tests/tools/test_computer_use_linux_backend.py
+++ b/tests/tools/test_computer_use_linux_backend.py
@@ -1,0 +1,107 @@
+"""Tests for the Linux computer_use backend adapter."""
+
+from __future__ import annotations
+
+from typing import Any, cast
+from unittest.mock import patch
+
+
+def _png_b64() -> str:
+    return (
+        "iVBORw0KGgoAAAANSUhEUgAAAAgAAAAICAYAAADED76LAAAADUlEQVR4nG"
+        "NgGAUgAAABCAABgukLHQAAAABJRU5ErkJggg=="
+    )
+
+
+class FakeSession:
+    def __init__(self) -> None:
+        self.calls = []
+
+    def call_tool(self, name, args, timeout=30.0):
+        self.calls.append((name, args))
+        if name == "list_windows":
+            return {
+                "data": None,
+                "images": [],
+                "structuredContent": {
+                    "windows": [
+                        {
+                            "app_name": "demo",
+                            "pid": 123,
+                            "window_id": 456,
+                            "title": "Demo Window",
+                            "z_index": 0,
+                            "is_on_screen": True,
+                        }
+                    ]
+                },
+                "isError": False,
+            }
+        if name == "get_window_state":
+            text = '✅ demo — 1 elements\nAXWindow "Demo Window" [0,0,800,600]\n  - [1] AXButton "Save" [10,20,30,40]'
+            return {"data": text, "images": [_png_b64()], "structuredContent": None, "isError": False}
+        if name == "screenshot":
+            return {"data": '{"width": 8, "height": 8, "format": "png"}', "images": [_png_b64()], "structuredContent": None, "isError": False}
+        return {"data": {"ok": True, "message": f"{name} ok"}, "images": [], "structuredContent": None, "isError": False}
+
+
+def test_linux_capture_som_maps_mcp_result_to_capture_result():
+    from tools.computer_use.linux_backend import LinuxComputerUseBackend
+
+    backend = LinuxComputerUseBackend()
+    fake = FakeSession()
+    cast(Any, backend)._session = fake
+
+    cap = backend.capture(mode="som", app="demo")
+
+    assert cap.app == "demo"
+    assert cap.window_title == "Demo Window"
+    assert cap.width == 8
+    assert cap.height == 8
+    assert cap.png_b64 == _png_b64()
+    assert len(cap.elements) == 1
+    assert cap.elements[0].index == 1
+    assert fake.calls[0][0] == "list_windows"
+    assert fake.calls[1] == ("get_window_state", {"pid": 123, "window_id": 456})
+
+
+def test_linux_capture_vision_uses_screenshot_tool():
+    from tools.computer_use.linux_backend import LinuxComputerUseBackend
+
+    backend = LinuxComputerUseBackend()
+    fake = FakeSession()
+    cast(Any, backend)._session = fake
+
+    cap = backend.capture(mode="vision")
+
+    assert cap.png_b64 == _png_b64()
+    assert cap.width == 8
+    assert cap.height == 8
+    assert any(name == "screenshot" for name, _args in fake.calls)
+
+
+def test_linux_click_routes_button_tools_and_target_args():
+    from tools.computer_use.linux_backend import LinuxComputerUseBackend
+
+    backend = LinuxComputerUseBackend()
+    fake = FakeSession()
+    cast(Any, backend)._session = fake
+    backend._active_pid = 123
+    backend._active_window_id = 456
+
+    res = backend.click(element=7, button="middle")
+
+    assert res.ok is True
+    assert fake.calls[-1] == ("middle_click", {"element_index": 7, "pid": 123, "window_id": 456})
+
+
+def test_linux_requirement_check_respects_platform_and_binary():
+    from tools.computer_use import linux_backend
+
+    with patch.object(linux_backend.sys, "platform", "linux"), \
+         patch.object(linux_backend.shutil, "which", return_value="/usr/bin/linux-computer-use"):
+        assert linux_backend.LinuxComputerUseBackend().is_available() is True
+
+    with patch.object(linux_backend.sys, "platform", "darwin"), \
+         patch.object(linux_backend.shutil, "which", return_value="/usr/bin/linux-computer-use"):
+        assert linux_backend.LinuxComputerUseBackend().is_available() is False

--- a/tools/computer_use/__init__.py
+++ b/tools/computer_use/__init__.py
@@ -1,33 +1,38 @@
-"""Computer use toolset — universal (any-model) macOS desktop control.
+"""Computer use toolset — universal desktop control for tool-capable models.
 
 Architecture
 ------------
-This toolset drives macOS apps through cua-driver's background computer-use
-primitive (SkyLight private SPIs for focus-without-raise + pid-scoped event
-posting). Unlike #4562's pyautogui backend, it does NOT steal the user's
-cursor, keyboard focus, or Space — the agent and the user can co-work on the
-same machine.
+This toolset drives desktop applications through a platform backend while
+keeping one model-facing OpenAI function-calling schema:
 
-Unlike #4562's Anthropic-native `computer_20251124` tool, the schema here is
-a plain OpenAI function-calling schema that every tool-capable model can
-drive. Vision models get SOM (set-of-mark) captures — a screenshot with
-numbered overlays on every interactable element plus the AX tree — so they
-click by element index instead of pixel coordinates. Non-vision models can
-drive via the AX tree alone.
+* macOS uses cua-driver's background computer-use primitive (SkyLight private
+  SPIs for focus-without-raise + pid-scoped event posting). It does NOT steal
+  the user's cursor, keyboard focus, or Space, so the agent and user can
+  co-work on the same machine.
+* Linux uses the companion linux-computer-use MCP driver. The current Linux path
+  is X11-first and mirrors the cua-driver tool surface, but Linux window
+  managers may move the real pointer/focus because they do not expose macOS's
+  private background event primitive.
+
+Unlike #4562's Anthropic-native `computer_20251124` tool, the schema here is a
+plain OpenAI function-calling schema that every tool-capable model can drive.
+Vision models get SOM (set-of-mark) captures — a screenshot with numbered
+overlays on every interactable element plus the AX/AT-SPI tree — so they click
+by element index instead of pixel coordinates. Non-vision models can drive via
+the accessibility tree alone.
 
 Wiring
 ------
-* `tool.py`       — registers the `computer_use` tool via tools.registry.
-* `backend.py`    — abstract `ComputerUseBackend`; swappable implementation.
-* `cua_backend.py`— default backend; speaks MCP over stdio to `cua-driver`.
-* `schema.py`     — shared schema + docstring for the generic `computer_use`
-                    tool. Model-agnostic.
-* `capture.py`    — screenshot post-processing (PNG coercion, sizing, SOM
-                    overlay if the backend did not).
+* `tool.py`          — registers the `computer_use` tool via tools.registry.
+* `backend.py`       — abstract `ComputerUseBackend`; swappable implementation.
+* `cua_backend.py`   — macOS backend; speaks MCP over stdio to `cua-driver`.
+* `linux_backend.py` — Linux backend; speaks MCP over stdio to
+                       `linux-computer-use mcp`.
+* `schema.py`        — shared model-agnostic schema + docstring.
 
 The outer integration points (multimodal tool-result plumbing, screenshot
 eviction in the Anthropic adapter, image-aware token estimation, the
-COMPUTER_USE_GUIDANCE prompt block, approval hook, and the skill) live
+COMPUTER_USE_GUIDANCE prompt block, approval hook, and skills/docs) live
 alongside this package. See agent/anthropic_adapter.py and
 agent/prompt_builder.py for the salvaged hunks from PR #4562.
 """

--- a/tools/computer_use/linux_backend.py
+++ b/tools/computer_use/linux_backend.py
@@ -1,0 +1,389 @@
+"""Linux backend for the generic ``computer_use`` tool.
+
+This backend speaks MCP over stdio to the companion ``linux-computer-use``
+driver. The driver intentionally mirrors cua-driver's tool names where Linux
+allows it, so the model-facing Hermes schema stays unchanged across macOS and
+Linux.
+
+Install the driver with:
+
+    pipx install git+https://github.com/tyy130/linux-computer-use
+
+or make a ``linux-computer-use`` executable available on PATH. The command must
+support ``linux-computer-use mcp``.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import logging
+import os
+import re
+import shutil
+import sys
+from contextlib import AsyncExitStack
+from typing import Any, Dict, List, Optional, Tuple
+
+from tools.computer_use.backend import (
+    ActionResult,
+    CaptureResult,
+    ComputerUseBackend,
+    UIElement,
+)
+from tools.computer_use.cua_backend import (
+    _AsyncBridge,
+    _extract_tool_result,
+    _image_dimensions_from_bytes,
+    _parse_elements_from_tree,
+    _parse_key_combo,
+    _split_tree_text,
+)
+
+logger = logging.getLogger(__name__)
+
+_LINUX_DRIVER_CMD = os.environ.get("HERMES_LINUX_COMPUTER_USE_CMD", "linux-computer-use")
+_LINUX_DRIVER_ARGS = ["mcp"]
+
+
+def _is_linux() -> bool:
+    return sys.platform.startswith("linux")
+
+
+def linux_driver_binary_available() -> bool:
+    """True if the linux-computer-use executable is on PATH."""
+    return bool(shutil.which(_LINUX_DRIVER_CMD))
+
+
+def linux_driver_install_hint() -> str:
+    return (
+        "linux-computer-use is not installed or not on PATH. Install it with:\n"
+        "  pipx install git+https://github.com/tyy130/linux-computer-use\n"
+        "Or clone locally and expose a wrapper that runs `python -m linux_computer_use.cli`."
+    )
+
+
+class _LinuxDriverSession:
+    """Long-lived MCP stdio session for ``linux-computer-use mcp``."""
+
+    def __init__(self, bridge: _AsyncBridge) -> None:
+        self._bridge = bridge
+        self._session = None
+        self._exit_stack: Optional[AsyncExitStack] = None
+        self._started = False
+
+    async def _aenter(self) -> None:
+        from mcp import ClientSession, StdioServerParameters
+        from mcp.client.stdio import stdio_client
+
+        if not linux_driver_binary_available():
+            raise RuntimeError(linux_driver_install_hint())
+
+        params = StdioServerParameters(
+            command=_LINUX_DRIVER_CMD,
+            args=_LINUX_DRIVER_ARGS,
+            env={**os.environ},
+        )
+        stack = AsyncExitStack()
+        read, write = await stack.enter_async_context(stdio_client(params))
+        session = await stack.enter_async_context(ClientSession(read, write))
+        await session.initialize()
+        self._exit_stack = stack
+        self._session = session
+
+    async def _aexit(self) -> None:
+        if self._exit_stack is not None:
+            try:
+                await self._exit_stack.aclose()
+            except Exception as e:
+                # The MCP stdio context can raise an anyio cancel-scope warning
+                # when closed from a different scheduled task than it was opened
+                # in. The process is still torn down by stdio cleanup; don't
+                # surface noisy shutdown details to users after successful calls.
+                logger.debug("linux-computer-use shutdown error: %s", e)
+        self._exit_stack = None
+        self._session = None
+
+    def start(self) -> None:
+        if self._started:
+            return
+        self._bridge.start()
+        self._bridge.run(self._aenter(), timeout=15.0)
+        self._started = True
+
+    def stop(self) -> None:
+        if not self._started:
+            return
+        try:
+            self._bridge.run(self._aexit(), timeout=5.0)
+        finally:
+            self._started = False
+
+    async def _call_tool_async(self, name: str, args: Dict[str, Any]) -> Dict[str, Any]:
+        if self._session is None:
+            raise RuntimeError("linux-computer-use session not initialized")
+        result = await self._session.call_tool(name, args)
+        return _extract_tool_result(result)
+
+    def call_tool(self, name: str, args: Dict[str, Any], timeout: float = 30.0) -> Dict[str, Any]:
+        if not self._started:
+            raise RuntimeError("linux-computer-use session not started")
+        return self._bridge.run(self._call_tool_async(name, args), timeout=timeout)
+
+
+class LinuxComputerUseBackend(ComputerUseBackend):
+    """Linux/X11 computer-use backend via the linux-computer-use MCP driver."""
+
+    def __init__(self) -> None:
+        self._bridge = _AsyncBridge()
+        self._session = _LinuxDriverSession(self._bridge)
+        self._active_pid: Optional[int] = None
+        self._active_window_id: Optional[int] = None
+        self._last_app: Optional[str] = None
+
+    def start(self) -> None:
+        self._session.start()
+
+    def stop(self) -> None:
+        try:
+            self._session.stop()
+        finally:
+            self._bridge.stop()
+
+    def is_available(self) -> bool:
+        return _is_linux() and linux_driver_binary_available()
+
+    def capture(self, mode: str = "som", app: Optional[str] = None) -> CaptureResult:
+        lw_out = self._session.call_tool("list_windows", {"on_screen_only": True})
+        raw_windows = (lw_out.get("structuredContent") or {}).get("windows")
+        windows = []
+        if raw_windows:
+            windows = [
+                {
+                    "app_name": w.get("app_name", ""),
+                    "pid": int(w.get("pid") or 0),
+                    "window_id": int(w.get("window_id") or 0),
+                    "title": w.get("title", ""),
+                    "z_index": int(w.get("z_index") or 0),
+                    "off_screen": not bool(w.get("is_on_screen", True)),
+                }
+                for w in raw_windows
+            ]
+            windows.sort(key=lambda w: w["z_index"])
+
+        if not windows:
+            return CaptureResult(mode=mode, width=0, height=0, app="", window_title="<no visible Linux windows>")
+
+        if app:
+            app_lower = app.lower()
+            filtered = [
+                w for w in windows
+                if app_lower in f"{w['app_name']} {w['title']}".lower()
+            ]
+            if not filtered:
+                return CaptureResult(
+                    mode=mode,
+                    width=0,
+                    height=0,
+                    app="",
+                    window_title=f"<no visible Linux window matched app={app!r}; call list_apps>",
+                )
+            windows = filtered
+
+        target = next((w for w in windows if not w["off_screen"]), windows[0])
+        self._active_pid = target["pid"]
+        self._active_window_id = target["window_id"]
+        app_name = target["app_name"]
+        if app or not self._last_app:
+            self._last_app = app_name
+
+        png_b64: Optional[str] = None
+        elements: List[UIElement] = []
+        width = height = 0
+        window_title = target.get("title", "")
+
+        if mode == "vision":
+            sc_out = self._session.call_tool("screenshot", {"window_id": self._active_window_id})
+            if sc_out["images"]:
+                png_b64 = sc_out["images"][0]
+            if isinstance(sc_out.get("data"), str):
+                width, height = _parse_metadata_dimensions(sc_out["data"])
+        else:
+            gws_out = self._session.call_tool(
+                "get_window_state",
+                {"pid": self._active_pid, "window_id": self._active_window_id},
+            )
+            text = gws_out["data"] if isinstance(gws_out["data"], str) else ""
+            _summary, tree = _split_tree_text(text)
+            if tree:
+                elements = _parse_elements_from_tree(tree)
+            if gws_out["images"]:
+                png_b64 = gws_out["images"][0]
+            wt = re.search(r'AXWindow\s+"([^"]+)"', tree)
+            if wt:
+                window_title = wt.group(1)
+
+        png_bytes_len = 0
+        if png_b64:
+            try:
+                raw = base64.b64decode(png_b64, validate=False)
+                png_bytes_len = len(raw)
+                detected_width, detected_height = _image_dimensions_from_bytes(raw)
+                if detected_width and detected_height:
+                    width = detected_width
+                    height = detected_height
+            except Exception:
+                png_bytes_len = len(png_b64) * 3 // 4
+
+        return CaptureResult(
+            mode=mode,
+            width=width,
+            height=height,
+            png_b64=png_b64 if mode != "ax" else None,
+            elements=elements,
+            app=app_name,
+            window_title=window_title,
+            png_bytes_len=png_bytes_len,
+        )
+
+    def click(
+        self,
+        *,
+        element: Optional[int] = None,
+        x: Optional[int] = None,
+        y: Optional[int] = None,
+        button: str = "left",
+        click_count: int = 1,
+        modifiers: Optional[List[str]] = None,
+    ) -> ActionResult:
+        tool = "click"
+        if button == "right":
+            tool = "right_click"
+        elif button == "middle":
+            tool = "middle_click"
+        elif click_count == 2:
+            tool = "double_click"
+        args = _target_args(element=element, x=x, y=y, modifiers=modifiers)
+        args.update(_window_args(self._active_pid, self._active_window_id))
+        return self._action(tool, args)
+
+    def drag(
+        self,
+        *,
+        from_element: Optional[int] = None,
+        to_element: Optional[int] = None,
+        from_xy: Optional[Tuple[int, int]] = None,
+        to_xy: Optional[Tuple[int, int]] = None,
+        button: str = "left",
+        modifiers: Optional[List[str]] = None,
+    ) -> ActionResult:
+        args: Dict[str, Any] = {}
+        if from_element is not None and to_element is not None:
+            args["from_element"] = from_element
+            args["to_element"] = to_element
+        elif from_xy is not None and to_xy is not None:
+            args["from_x"], args["from_y"] = int(from_xy[0]), int(from_xy[1])
+            args["to_x"], args["to_y"] = int(to_xy[0]), int(to_xy[1])
+        else:
+            return ActionResult(ok=False, action="drag", message="drag requires from/to element or coordinate")
+        return self._action("drag", args)
+
+    def scroll(
+        self,
+        *,
+        direction: str,
+        amount: int = 3,
+        element: Optional[int] = None,
+        x: Optional[int] = None,
+        y: Optional[int] = None,
+        modifiers: Optional[List[str]] = None,
+    ) -> ActionResult:
+        args = _target_args(element=element, x=x, y=y, modifiers=modifiers, require_target=False)
+        args["direction"] = direction
+        args["amount"] = max(1, min(50, int(amount)))
+        return self._action("scroll", args)
+
+    def type_text(self, text: str) -> ActionResult:
+        return self._action("type_text", {"pid": self._active_pid, "text": text})
+
+    def key(self, keys: str) -> ActionResult:
+        key_name, modifiers = _parse_key_combo(keys)
+        if not key_name:
+            return ActionResult(ok=False, action="key", message=f"Could not parse key from {keys!r}")
+        if modifiers:
+            return self._action("hotkey", {"pid": self._active_pid, "keys": modifiers + [key_name]})
+        return self._action("press_key", {"pid": self._active_pid, "key": key_name})
+
+    def list_apps(self) -> List[Dict[str, Any]]:
+        out = self._session.call_tool("list_apps", {})
+        data = out.get("structuredContent") or out.get("data")
+        if isinstance(data, dict):
+            return data.get("apps", [])
+        return []
+
+    def focus_app(self, app: str, raise_window: bool = False) -> ActionResult:
+        res = self._action("focus_app", {"app": app, "raise_window": raise_window})
+        # Follow with list_windows to set sticky target for subsequent actions.
+        if res.ok:
+            cap = self.capture(mode="ax", app=app)
+            if cap.app:
+                res.message = (res.message + " " if res.message else "") + f"Targeted {cap.app}."
+        return res
+
+    def set_value(self, value: str, element: Optional[int] = None) -> ActionResult:
+        if element is None:
+            return ActionResult(ok=False, action="set_value", message="set_value requires element")
+        args = {"pid": self._active_pid, "window_id": self._active_window_id, "element_index": element, "value": value}
+        return self._action("set_value", args)
+
+    def _action(self, name: str, args: Dict[str, Any]) -> ActionResult:
+        try:
+            out = self._session.call_tool(name, {k: v for k, v in args.items() if v is not None})
+        except Exception as e:
+            logger.exception("linux-computer-use %s call failed", name)
+            return ActionResult(ok=False, action=name, message=f"linux-computer-use error: {e}")
+        ok = not out.get("isError")
+        data = out.get("structuredContent") or out.get("data")
+        message = ""
+        meta: Dict[str, Any] = {}
+        if isinstance(data, dict):
+            message = str(data.get("message", ""))
+            meta = data
+        elif isinstance(data, str):
+            message = data
+        return ActionResult(ok=ok, action=name, message=message, meta=meta)
+
+
+def _window_args(pid: Optional[int], window_id: Optional[int]) -> Dict[str, Any]:
+    return {"pid": pid, "window_id": window_id}
+
+
+def _target_args(
+    *,
+    element: Optional[int],
+    x: Optional[int],
+    y: Optional[int],
+    modifiers: Optional[List[str]] = None,
+    require_target: bool = True,
+) -> Dict[str, Any]:
+    args: Dict[str, Any] = {}
+    if element is not None:
+        args["element_index"] = element
+    elif x is not None and y is not None:
+        args["x"] = int(x)
+        args["y"] = int(y)
+    elif require_target:
+        raise ValueError("target requires element or x/y")
+    if modifiers:
+        args["modifier"] = modifiers
+    return args
+
+
+def _parse_metadata_dimensions(text: str) -> Tuple[int, int]:
+    try:
+        data = json.loads(text)
+    except Exception:
+        return 0, 0
+    if isinstance(data, dict):
+        return int(data.get("width") or 0), int(data.get("height") or 0)
+    return 0, 0

--- a/tools/computer_use/schema.py
+++ b/tools/computer_use/schema.py
@@ -16,14 +16,15 @@ from typing import Any, Dict
 COMPUTER_USE_SCHEMA: Dict[str, Any] = {
     "name": "computer_use",
     "description": (
-        "Drive the macOS desktop in the background — screenshots, mouse, "
-        "keyboard, scroll, drag — without stealing the user's cursor, "
-        "keyboard focus, or Space. Preferred workflow: call with "
-        "action='capture' (mode='som' gives numbered element overlays), "
-        "then click by `element` index for reliability. Pixel coordinates "
-        "are supported for models trained on them. Works on any window — "
-        "hidden, minimized, on another Space, or behind another app. "
-        "macOS only; requires cua-driver to be installed."
+        "Drive a desktop with screenshots, mouse, keyboard, scroll, and drag. "
+        "On macOS this uses cua-driver background automation without stealing "
+        "the user's cursor, keyboard focus, or Space. On Linux this uses the "
+        "linux-computer-use MCP driver; X11 is supported and may move the real "
+        "pointer/focus, while Wayland support depends on compositor portals. "
+        "Preferred workflow: call with action='capture' (mode='som' gives "
+        "numbered element overlays), then click by `element` index for "
+        "reliability. Pixel coordinates are supported for models trained on "
+        "them."
     ),
     "parameters": {
         "type": "object",
@@ -188,9 +189,10 @@ COMPUTER_USE_SCHEMA: Dict[str, Any] = {
                 "type": "boolean",
                 "description": (
                     "Only for action='focus_app'. If true, brings the "
-                    "window to front (DISRUPTS the user). Default false "
-                    "— input is routed to the app without raising, "
-                    "matching the background co-work model."
+                    "window to front (DISRUPTS the user). Default false. "
+                    "On macOS, background routing avoids raising the window; "
+                    "on Linux/X11, subsequent actions may still require or "
+                    "change focus depending on the window manager."
                 ),
             },
             # ── return shape ───────────────────────────────────────

--- a/tools/computer_use/tool.py
+++ b/tools/computer_use/tool.py
@@ -128,14 +128,25 @@ _session_auto_approve = False
 _always_allow: set = set()  # action names the user unlocked for the session
 
 
+def _default_backend_name() -> str:
+    if sys.platform == "darwin":
+        return "cua"
+    if sys.platform.startswith("linux"):
+        return "linux"
+    return "cua"
+
+
 def _get_backend() -> ComputerUseBackend:
     global _backend
     with _backend_lock:
         if _backend is None:
-            backend_name = os.environ.get("HERMES_COMPUTER_USE_BACKEND", "cua").lower()
+            backend_name = os.environ.get("HERMES_COMPUTER_USE_BACKEND", _default_backend_name()).lower()
             if backend_name in {"cua", "cua-driver", ""}:
                 from tools.computer_use.cua_backend import CuaDriverBackend
                 _backend = CuaDriverBackend()
+            elif backend_name in {"linux", "linux-computer-use", "linux_computer_use"}:
+                from tools.computer_use.linux_backend import LinuxComputerUseBackend
+                _backend = LinuxComputerUseBackend()
             elif backend_name == "noop":  # pragma: no cover
                 _backend = _NoopBackend()
             else:
@@ -810,12 +821,26 @@ def _element_to_dict(e: UIElement) -> Dict[str, Any]:
 def check_computer_use_requirements() -> bool:
     """Return True iff computer_use can run on this host.
 
-    Conditions: macOS + cua-driver binary installed (or override via env).
+    macOS uses cua-driver. Linux uses the companion linux-computer-use MCP
+    driver. HERMES_COMPUTER_USE_BACKEND can force a specific backend for tests
+    and advanced users.
     """
-    if sys.platform != "darwin":
-        return False
-    from tools.computer_use.cua_backend import cua_driver_binary_available
-    return cua_driver_binary_available()
+    forced = os.environ.get("HERMES_COMPUTER_USE_BACKEND", "").lower()
+    if forced == "noop":
+        return True
+    if forced in {"cua", "cua-driver"}:
+        from tools.computer_use.cua_backend import cua_driver_binary_available
+        return sys.platform == "darwin" and cua_driver_binary_available()
+    if forced in {"linux", "linux-computer-use", "linux_computer_use"}:
+        from tools.computer_use.linux_backend import linux_driver_binary_available
+        return sys.platform.startswith("linux") and linux_driver_binary_available()
+    if sys.platform == "darwin":
+        from tools.computer_use.cua_backend import cua_driver_binary_available
+        return cua_driver_binary_available()
+    if sys.platform.startswith("linux"):
+        from tools.computer_use.linux_backend import linux_driver_binary_available
+        return linux_driver_binary_available()
+    return False
 
 
 def get_computer_use_schema() -> Dict[str, Any]:

--- a/tools/computer_use_tool.py
+++ b/tools/computer_use_tool.py
@@ -24,10 +24,11 @@ registry.register(
     check_fn=check_computer_use_requirements,
     requires_env=[],
     description=(
-        "Universal macOS desktop control via cua-driver. Works with any "
-        "tool-capable model (Anthropic, OpenAI, OpenRouter, local vLLM, "
-        "etc.). Background computer-use: does NOT steal the user's cursor "
-        "or keyboard focus."
+        "Universal desktop computer-use via cua-driver on macOS and "
+        "linux-computer-use on Linux. Works with any tool-capable model "
+        "(Anthropic, OpenAI, OpenRouter, local vLLM, etc.). macOS supports "
+        "background computer-use without stealing cursor/focus; Linux/X11 "
+        "support may move the real pointer/focus."
     ),
 )
 

--- a/website/docs/user-guide/features/computer-use.md
+++ b/website/docs/user-guide/features/computer-use.md
@@ -3,12 +3,18 @@ title: Computer Use
 sidebar_position: 16
 ---
 
-# Computer Use (macOS)
+# Computer Use
 
-Hermes Agent can drive your Mac's desktop — clicking, typing, scrolling,
-dragging — in the **background**. Your cursor doesn't move, keyboard focus
-doesn't change, and macOS doesn't switch Spaces on you. You and the agent
-co-work on the same machine.
+Hermes Agent can drive desktop applications — clicking, typing, scrolling,
+dragging — through a model-agnostic `computer_use` tool.
+
+On **macOS**, Hermes uses `cua-driver` for true background computer-use: your
+cursor doesn't move, keyboard focus doesn't change, and macOS doesn't switch
+Spaces on you. On **Linux**, Hermes uses the companion
+[`linux-computer-use`](https://github.com/tyy130/linux-computer-use) MCP driver.
+The Linux path is X11-first and may move the real pointer/focus; Wayland support
+is intentionally reported as limited unless the compositor exposes automation
+portals.
 
 Unlike most computer-use integrations, this works with **any tool-capable
 model** — Claude, GPT, Gemini, or an open model on a local vLLM endpoint.
@@ -16,23 +22,28 @@ There's no Anthropic-native schema to worry about.
 
 ## How it works
 
-The `computer_use` toolset speaks MCP over stdio to [`cua-driver`](https://github.com/trycua/cua),
-a macOS driver that uses SkyLight private SPIs (`SLEventPostToPid`,
-`SLPSPostEventRecordTo`) and the `_AXObserverAddNotificationAndCheckRemote`
-accessibility SPI to:
+The `computer_use` toolset speaks MCP over stdio to a platform driver:
 
-- Post synthesized events directly to target processes — no HID event tap,
-  no cursor warp.
-- Flip AppKit active-state without raising windows — no Space switching.
-- Keep Chromium/Electron accessibility trees alive when windows are
-  occluded.
+- **macOS:** [`cua-driver`](https://github.com/trycua/cua), which uses SkyLight
+  private SPIs (`SLEventPostToPid`, `SLPSPostEventRecordTo`) and the
+  `_AXObserverAddNotificationAndCheckRemote` accessibility SPI to:
+  - Post synthesized events directly to target processes — no HID event tap,
+    no cursor warp.
+  - Flip AppKit active-state without raising windows — no Space switching.
+  - Keep Chromium/Electron accessibility trees alive when windows are
+    occluded.
+- **Linux:** [`linux-computer-use`](https://github.com/tyy130/linux-computer-use),
+  an X11-first MCP driver that uses `xdotool` for input, screenshot utilities
+  (`scrot`, `import`, or `gnome-screenshot`) for capture, and AT-SPI for the
+  accessibility tree/SOM element overlay.
 
-That combination is what OpenAI's Codex "background computer-use" ships.
-cua-driver is the open-source equivalent.
+The macOS combination is what OpenAI's Codex "background computer-use" ships;
+`cua-driver` is the open-source equivalent. Linux exposes the same Hermes schema
+but cannot yet promise background co-working on every compositor.
 
 ## Enabling
 
-Pick whichever path is most convenient — both run the same upstream installer:
+Pick whichever path is most convenient:
 
 **Option 1: dedicated CLI command (most direct).**
 
@@ -40,18 +51,18 @@ Pick whichever path is most convenient — both run the same upstream installer:
 hermes computer-use install
 ```
 
-This fetches and runs the upstream cua-driver installer:
-`curl -fsSL https://raw.githubusercontent.com/trycua/cua/main/libs/cua-driver/scripts/install.sh`.
+On macOS, this fetches and runs the upstream cua-driver installer. On Linux, it
+installs `linux-computer-use` from GitHub via `pipx` or `uv tool install`.
 Use `hermes computer-use status` to verify the install.
 
 **Option 2: enable the toolset interactively.**
 
-1. Run `hermes tools`, pick `🖱️ Computer Use (macOS)` → `cua-driver (background)`.
-2. The setup runs the upstream installer (same as Option 1).
+1. Run `hermes tools`, pick `🖱️ Computer Use (Desktop)` → the platform driver.
+2. The setup runs the same platform installer as Option 1.
 
-After installing, regardless of which path you took:
+After installing:
 
-3. Grant macOS permissions when prompted:
+3. macOS only: grant permissions when prompted:
    - **System Settings → Privacy & Security → Accessibility** → allow the
      terminal (or Hermes app).
    - **System Settings → Privacy & Security → Screen Recording** → allow
@@ -62,22 +73,17 @@ After installing, regardless of which path you took:
    ```
    or add `computer_use` to your enabled toolsets in `~/.hermes/config.yaml`.
 
-## Keeping cua-driver up to date
+## Keeping drivers up to date
 
-The cua-driver project ships fixes regularly (e.g. v0.1.6 fixed a Safari
-window-focus bug for UTM workflows). Hermes refreshes the binary in two
-places so you don't get stuck on a stale release:
+Hermes refreshes the platform driver in two places:
 
-- **`hermes update`** — when you update Hermes itself, if `cua-driver` is
-  on PATH the upstream installer re-runs at the end of the update.
-  No-op for non-macOS users and for users without cua-driver installed.
-- **`hermes computer-use install --upgrade`** — manual force-refresh.
-  Re-runs the upstream installer regardless of whether cua-driver is
-  already installed. Use this when you want the latest fix without
-  waiting for the next agent update.
+- **`hermes update`** — when you update Hermes itself, installed computer-use
+  drivers can be refreshed as part of the update flow.
+- **`hermes computer-use install --upgrade`** — manual force-refresh. On macOS
+  this re-runs the cua-driver installer. On Linux this upgrades
+  `linux-computer-use` when installed via `pipx`/`uv tool`.
 
-`hermes computer-use status` shows the installed version next to the
-binary path.
+`hermes computer-use status` shows the installed driver and binary path.
 
 ## Quick example
 
@@ -95,8 +101,9 @@ The agent's plan:
    and get the new screenshot.
 5. Click the top result, read the body, summarise.
 
-During all of this, your cursor stays wherever you left it and Mail never
-comes to front.
+On macOS, your cursor stays wherever you left it and Mail never comes to front.
+On Linux/X11, the same action sequence works, but the window manager may move
+pointer/focus because Linux does not expose the same background event primitive.
 
 ## Provider compatibility
 
@@ -149,12 +156,12 @@ of screenshot context, not ~600K.
 
 ## Limitations
 
-- **macOS only.** cua-driver uses private Apple SPIs that don't exist on
-  Linux or Windows. For cross-platform GUI automation, use the `browser`
-  toolset.
-- **Private SPI risk.** Apple can change SkyLight's symbol surface in any
+- **macOS private SPI risk.** Apple can change SkyLight's symbol surface in any
   OS update. Pin the driver version with the `HERMES_CUA_DRIVER_VERSION`
   env var if you want reproducibility across a macOS bump.
+- **Linux focus model.** The Linux backend is X11-first and may move the real
+  pointer or focus. Wayland compositors block global synthetic input by default;
+  future GNOME/KDE portal backends can improve this.
 - **Performance.** Background mode is slower than foreground —
   SkyLight-routed events take ~5-20ms vs direct HID posting. Not
   noticeable for agent-speed clicking; noticeable if you try to record a
@@ -167,21 +174,28 @@ of screenshot context, not ~600K.
 Override the driver binary path (tests / CI):
 
 ```
-HERMES_CUA_DRIVER_CMD=/opt/homebrew/bin/cua-driver
-HERMES_CUA_DRIVER_VERSION=0.5.0    # optional pin
+HERMES_CUA_DRIVER_CMD=/opt/homebrew/bin/cua-driver          # macOS
+HERMES_CUA_DRIVER_VERSION=0.5.0                            # optional macOS pin
+HERMES_LINUX_COMPUTER_USE_CMD=/usr/local/bin/linux-computer-use
 ```
 
 Swap the backend entirely (for testing):
 
 ```
-HERMES_COMPUTER_USE_BACKEND=noop   # records calls, no side effects
+HERMES_COMPUTER_USE_BACKEND=noop    # records calls, no side effects
+HERMES_COMPUTER_USE_BACKEND=linux   # force Linux backend
+HERMES_COMPUTER_USE_BACKEND=cua     # force macOS cua-driver backend
 ```
 
 ## Troubleshooting
 
-**`computer_use backend unavailable: cua-driver is not installed`** — Run
-`hermes computer-use install` to fetch the cua-driver binary, or run
+**`computer_use backend unavailable: cua-driver is not installed`** — On macOS,
+run `hermes computer-use install` to fetch the cua-driver binary, or run
 `hermes tools` and enable the Computer Use toolset.
+
+**`computer_use backend unavailable: linux-computer-use is not installed`** — On
+Linux, run `hermes computer-use install`, or install manually with
+`pipx install git+https://github.com/tyy130/linux-computer-use`.
 
 **Clicks seem to have no effect** — Capture and verify. A modal you
 didn't see may be blocking input. Dismiss it with `escape` or the close


### PR DESCRIPTION
## Summary
- add a first-class Linux computer_use backend that launches the linux-computer-use MCP driver
- auto-select Linux vs macOS backend behind the existing model-facing computer_use schema
- update install/status/tool setup docs for platform drivers
- add Linux backend adapter tests and keep existing macOS/noop coverage

## Verification
- python -m pytest tests/hermes_cli/test_tools_config.py tests/hermes_cli/test_post_setup_gating.py tests/hermes_cli/test_tools_disable_enable.py tests/hermes_cli/test_commands.py tests/cli/test_cli_tools_command.py tests/tools/test_computer_use.py tests/tools/test_computer_use_linux_backend.py tests/tools/test_computer_use_capture_routing.py tests/test_packaging_metadata.py -q -o 'addopts=' → 391 passed
- python -m hermes_cli.main computer-use status → detected linux-computer-use on local Cinnamon/X11
- HERMES_COMPUTER_USE_BACKEND=linux handle_computer_use capture smoke → returned Linux terminal capture JSON