### PR TITLE
feat(agent): add OTLP observability plugin (observability/otel)

### DIFF
--- a/plugins/observability/otel/ADVANCED.md
+++ b/plugins/observability/otel/ADVANCED.md
@@ -1,0 +1,117 @@
+# Advanced setup — GPU / CO2 / eval metrics (`genai_otel`)
+
+> Optional deep-dive for the [`observability/otel`](./README.md) plugin. The
+> README quickstart gets you GenAI-convention spans + dashboard log records
+> against any OTLP backend. This guide covers the on-prem **GPU / energy / CO2**
+> metrics and the **eval / guardrail** suite you unlock by routing through
+> `genai-otel-instrument`. Everything here is opt-in and degrades gracefully if
+> a dependency is missing.
+
+When `genai-otel-instrument` is installed the plugin routes through it (see
+`provider.py`), which unlocks on-prem **GPU/energy/CO2** metrics and a
+**Galileo-equivalent eval suite** (PII, toxicity, bias, prompt-injection,
+restricted-topics, hallucination). **No plugin code change is required** — these
+are driven entirely by `genai_otel`'s own `GENAI_*` environment variables, read
+inside `genai_otel.instrument()` (which the plugin already calls).
+
+```bash
+pip install genai-otel-instrument
+# …or, for the full on-prem story (GPU/CO2 + PII/toxicity/bias/injection/… eval):
+pip install "genai-otel-instrument[gpu,evaluation]"
+```
+
+The plugin auto-detects and prefers `genai_otel` when present; otherwise it
+falls back to a plain OTel SDK.
+
+## Why `genai_otel` (vs a vanilla OTel SDK or other GenAI instrumentors)
+
+The plugin works against a **plain OTel SDK** (the fallback) — that alone gives
+you GenAI-convention spans, tokens, latency, finish reasons, and the dashboard
+log records, portable to any OTLP backend. Routing through
+`genai-otel-instrument` adds four signals that are **genuinely unique** — neither
+a raw OTel SDK nor the common GenAI instrumentation libraries (OpenLLMetry /
+Traceloop, OpenInference / Arize, OpenLIT, Langfuse) emit them:
+
+| Signal | `genai_otel` | Vanilla OTel SDK | Other GenAI libs |
+|--------|:---:|:---:|:---:|
+| **On-prem GPU metrics** — per-GPU utilization, power, memory, temperature, clocks, throttle state (nvidia-ml-py / amdsmi) | ✅ | ❌ | ❌ |
+| **Energy + CO2** — `energy_kwh`, `co2_emissions_gco2e`, region-aware (codecarbon) | ✅ | ❌ | ❌ |
+| **Local-model cost** — Ollama / HF / vLLM cost estimated from parameter size when the backend returns no price | ✅ | ❌ (`$0`) | ❌ (priced cloud APIs only) |
+| **Inline eval / guardrails** — PII, toxicity, bias, prompt-injection, restricted-topics, hallucination scored as span attributes + metrics at instrumentation time | ✅ in-process | ❌ | ❌ (need a separate eval pipeline) |
+
+Everything runs **in-process and on-prem** — no data leaves the host, no SaaS
+observability backend, and no separate eval service. The token / latency / cost
+fields stay standard OTel GenAI conventions (portable to any OTLP backend); the
+four signals above are extra attributes/metrics a conventions-aware backend can
+use or safely ignore. All of it is opt-in and degrades gracefully when a
+dependency is missing.
+
+## 1. Install the extras
+
+```bash
+pip install "genai-otel-instrument[gpu,evaluation]"   # GPU: nvidia-ml-py + codecarbon; eval: presidio + spaCy + detoxify
+python -m spacy download en_core_web_lg                # presidio PII NER model (compliance-grade PERSON/LOCATION/NRP)
+```
+
+## 2. Environment recipe
+
+Set these alongside the `HERMES_OTEL_*` vars from the README (in `~/.hermes/.env`
+or the process environment, **before** Hermes launches):
+
+```bash
+# --- MANDATORY for eval: detectors score gen_ai.prompt / gen_ai.completion, which the
+#     plugin only stamps when content capture is on (genai_otel's own GENAI_ENABLE_CONTENT_CAPTURE
+#     is the WRONG lever — it gates genai_otel's instrumentors, not the plugin's spans). ---
+HERMES_OTEL_CAPTURE_CONTENT=true
+
+# --- MANDATORY to avoid double-counting: Hermes calls Ollama through the openai SDK, and
+#     genai_otel's DEFAULT instrumentor set includes 'openai', which would emit a SECOND
+#     span (+ duplicate token/cost metrics) per model call. Replacing the list with a
+#     no-op ('mcp') drops 'openai'. GPU/CO2/eval are independent of this list and still run. ---
+GENAI_ENABLED_INSTRUMENTORS=mcp
+
+# --- On-prem GPU + energy + CO2 (sustainability story) ---
+GENAI_ENABLE_GPU_METRICS=true       # default true — utilisation, power, memory, temp (NVIDIA via nvidia-ml-py)
+GENAI_ENABLE_CO2_TRACKING=true      # energy_kwh + CO2 gCO2e via codecarbon
+GENAI_CO2_COUNTRY_ISO_CODE=IND      # carbon-intensity region — set your deployment country
+GENAI_CODECARBON_LOG_LEVEL=error    # keep codecarbon quiet
+
+# --- Eval / guardrails — scored on every captured prompt + response ---
+GENAI_ENABLE_PII_DETECTION=true
+GENAI_PII_MODE=redact               # redact the evaluation copy (data-sovereignty); raw gen_ai.prompt still carries text
+GENAI_ENABLE_TOXICITY_DETECTION=true
+GENAI_ENABLE_BIAS_DETECTION=true
+GENAI_ENABLE_PROMPT_INJECTION_DETECTION=true
+GENAI_ENABLE_RESTRICTED_TOPICS=true
+GENAI_ENABLE_HALLUCINATION_DETECTION=true
+```
+
+## 3. What you get (verified 2026-06-18 against `genai-otel-instrument` 1.3.3)
+
+- **Span attributes** (every captured turn): `evaluation.pii.{prompt,response}.*`
+  (detected, entity_types, *_count, score, redacted), `evaluation.toxicity.*`
+  (score + categories — e.g. toxicity 0.93 / insult 0.84), `evaluation.bias.*`,
+  `evaluation.hallucination.*` (score, claims, citations, hedge_words),
+  `evaluation.prompt_injection.*`, `evaluation.restricted_topics.*`, plus
+  `gen_ai.usage.cost.*` (model-size pricing for local Ollama models).
+- **Metrics**: GPU (`utilisation / power / memory / temperature`), energy and
+  CO2 (`co2_emissions_gco2e`, `energy_consumed_kwh`, `power_consumption_watts`),
+  and eval score gauges — all tagged with `service.name = agent.coding.hermes`.
+
+## 4. How it works / gotchas
+
+- Eval needs **no plugin change**: `instrument()` registers a *global*
+  `EvaluationSpanProcessor` + wraps the OTLP exporter with an
+  `EvaluationEnrichingSpanExporter` whenever any `GENAI_ENABLE_*_DETECTION` is
+  set; the detectors read `gen_ai.prompt` / `gen_ai.completion` off **any** span,
+  so they score the plugin's own `invoke_agent` / `chat` spans.
+- **detoxify** downloads a ~500 MB model from HuggingFace on first toxicity eval
+  — pre-warm on an internet-connected host, or set
+  `GENAI_ENABLE_TOXICITY_DETECTION=false` for fully air-gapped installs.
+- The eval **score metrics** only reach a Prometheus/Timescale backend if its
+  keep-list includes `genai_evaluation_*` (the eval *span attributes* are
+  unaffected and are the most complete source).
+- **Data sovereignty**: `HERMES_OTEL_CAPTURE_CONTENT=true` exports raw
+  prompt/response text on spans; `GENAI_PII_MODE=redact` redacts the eval copy.
+  Confirm your PII-before-storage policy covers `gen_ai.prompt` / `gen_ai.completion`
+  before enabling content capture in a regulated environment.

--- a/plugins/observability/otel/README.md
+++ b/plugins/observability/otel/README.md
@@ -1,0 +1,233 @@
+# OpenTelemetry (OTLP) Observability Plugin
+
+A native **OpenTelemetry** observability plugin for Hermes. It exports Hermes's
+built-in observability events over OTLP in three complementary ways:
+
+1. **GenAI-convention spans** (`gen_ai.*`) — the standard trace model, so Hermes
+   telemetry flows to *any* OpenTelemetry backend (an OpenTelemetry Collector,
+   Jaeger, Grafana Tempo, Honeycomb, …) with no vendor lock-in.
+2. **Dashboard-shaped OTLP log records** — the `session_start` / `api_response`
+   / `tool_result` event model that agent-coding dashboards (the kind Claude
+   Code / Codex / Copilot populate) aggregate on, so a Hermes session shows up
+   in the Activity / Sessions / Leaderboards views like any other coding agent.
+3. **Local-model cost** — when the backend returns no price (Ollama / HF / vLLM
+   local models), cost is estimated from the model's parameter size, so spans
+   and log records carry a real `cost_usd` instead of `$0`.
+
+This plugin ships bundled with Hermes but is **opt-in** — it only loads when
+you explicitly enable it. It slots in beside `observability/langfuse` and
+`observability/nemo_relay` and makes no changes to Hermes core.
+
+## Span model
+
+```
+invoke_agent      per Hermes turn   (gen_ai.conversation.id = session id)
+  ├── chat        per LLM API call  (tokens, cost, finish reason, TTFT)
+  └── execute_tool  per tool call   (gen_ai.tool.name / .type, errors)
+```
+
+`gen_ai.system = hermes` on every span; `service.name` defaults to
+`agent.coding.hermes`. Prompt/response content is attached **only** when
+`HERMES_OTEL_CAPTURE_CONTENT=true` (privacy-gated, off by default).
+
+## Log-record model
+
+Emitted in parallel with the spans (best-effort — a logs failure never disables
+spans), to the OTLP **logs** endpoint (`<endpoint>/v1/logs`):
+
+| `event.name`    | Per          | Key attributes |
+|-----------------|--------------|----------------|
+| `session_start` | Hermes turn  | `session.id`, `model` |
+| `api_response`  | LLM API call | `model`, `input_tokens`, `output_tokens`, `cost_usd`, `finish_reason`, `ttft_ms` |
+| `tool_result`   | tool call    | `tool_name`, `tool_type`, `status_code`, `decision_type` |
+
+Identity (`service.name`, `user.id`, and any `team.id` / `organization.id` from
+`OTEL_RESOURCE_ATTRIBUTES`) is placed on the OTel **resource** so the
+per-user / per-org leaderboard aggregations work. Same privacy gate: prompt /
+response / tool I/O is attached only with `HERMES_OTEL_CAPTURE_CONTENT=true`.
+
+## Cost estimation
+
+Local backends report no price, so `cost.py` mirrors the
+`genai-otel-instrument` methodology: parse the parameter size from the model
+name (`llama3.1:8b` → 8 B, `qwen3:0.6b` → 0.6 B, `smollm2:360m` → 0.36 B), map
+it to a per-1K-token price tier, and compute
+`cost = in_tok/1000 * promptPrice + out_tok/1000 * completionPrice`. It is used
+**only** as a fallback when the agent itself reported no cost; an
+agent-provided `cost_usd` always wins. When the size can't be inferred, cost is
+omitted (no fake `$0`).
+
+## Enable
+
+```bash
+# OTel SDK + OTLP HTTP exporter (the only hard dependency)
+pip install opentelemetry-sdk opentelemetry-exporter-otlp-proto-http
+
+hermes plugins enable observability/otel
+```
+
+Optionally install `genai-otel-instrument` to use the richer reference emitter
+(adds token/cost/latency conventions and optional on-prem **GPU / energy / CO2**
+metrics plus **eval / guardrail** scoring); the plugin auto-detects and prefers
+it when present:
+
+```bash
+pip install genai-otel-instrument
+# …or, for the full on-prem story (GPU/CO2 + PII/toxicity/bias/injection/… eval):
+pip install "genai-otel-instrument[gpu,evaluation]"
+```
+
+See **[Full setup — GPU / CO2 / eval metrics](#full-setup--gpu--co2--eval-metrics-genai_otel)**
+below for the env-var recipe.
+
+Without the OTel SDK the hooks no-op silently — the plugin fails open.
+
+## Configure
+
+All configuration is optional; the plugin works out of the box against a local
+collector on `http://localhost:4318`. Set these in `~/.hermes/.env`:
+
+```bash
+HERMES_OTEL_SERVICE_NAME=agent.coding.hermes   # service.name (backends group on this)
+HERMES_OTEL_ENDPOINT=http://localhost:4318     # OTLP HTTP endpoint
+HERMES_OTEL_AGENT_NAME=hermes                  # gen_ai.agent.name
+HERMES_OTEL_CAPTURE_CONTENT=false              # attach prompt/response text (privacy-gated)
+HERMES_OTEL_USER_ID=                           # stamp user.id on the resource
+```
+
+Standard OTel env vars are honoured as fallbacks: `OTEL_SERVICE_NAME`,
+`OTEL_EXPORTER_OTLP_ENDPOINT`.
+
+## Full setup — GPU / CO2 / eval metrics (`genai_otel`)
+
+When `genai-otel-instrument` is installed the plugin routes through it (see
+`provider.py`), which unlocks on-prem **GPU/energy/CO2** metrics and a
+**Galileo-equivalent eval suite** (PII, toxicity, bias, prompt-injection,
+restricted-topics, hallucination). **No plugin code change is required** — these
+are driven entirely by `genai_otel`'s own `GENAI_*` environment variables, read
+inside `genai_otel.instrument()` (which the plugin already calls). Everything
+below is opt-in and degrades gracefully if a dependency is missing.
+
+### Why `genai_otel` (vs a vanilla OTel SDK or other GenAI instrumentors)
+
+The plugin works against a **plain OTel SDK** (the fallback) — that alone gives
+you GenAI-convention spans, tokens, latency, finish reasons, and the dashboard
+log records, portable to any OTLP backend. Routing through
+`genai-otel-instrument` adds four signals that are **genuinely unique** — neither
+a raw OTel SDK nor the common GenAI instrumentation libraries (OpenLLMetry /
+Traceloop, OpenInference / Arize, OpenLIT, Langfuse) emit them:
+
+| Signal | `genai_otel` | Vanilla OTel SDK | Other GenAI libs |
+|--------|:---:|:---:|:---:|
+| **On-prem GPU metrics** — per-GPU utilization, power, memory, temperature, clocks, throttle state (nvidia-ml-py / amdsmi) | ✅ | ❌ | ❌ |
+| **Energy + CO2** — `energy_kwh`, `co2_emissions_gco2e`, region-aware (codecarbon) | ✅ | ❌ | ❌ |
+| **Local-model cost** — Ollama / HF / vLLM cost estimated from parameter size when the backend returns no price | ✅ | ❌ (`$0`) | ❌ (priced cloud APIs only) |
+| **Inline eval / guardrails** — PII, toxicity, bias, prompt-injection, restricted-topics, hallucination scored as span attributes + metrics at instrumentation time | ✅ in-process | ❌ | ❌ (need a separate eval pipeline) |
+
+Everything runs **in-process and on-prem** — no data leaves the host, no SaaS
+observability backend, and no separate eval service. The token / latency / cost
+fields stay standard OTel GenAI conventions (portable to any OTLP backend); the
+four signals above are extra attributes/metrics a conventions-aware backend can
+use or safely ignore. All of it is opt-in and degrades gracefully when a
+dependency is missing.
+
+### 1. Install the extras
+
+```bash
+pip install "genai-otel-instrument[gpu,evaluation]"   # GPU: nvidia-ml-py + codecarbon; eval: presidio + spaCy + detoxify
+python -m spacy download en_core_web_lg                # presidio PII NER model (compliance-grade PERSON/LOCATION/NRP)
+```
+
+### 2. Environment recipe
+
+Set these alongside the `HERMES_OTEL_*` vars above (in `~/.hermes/.env` or the
+process environment, **before** Hermes launches):
+
+```bash
+# --- MANDATORY for eval: detectors score gen_ai.prompt / gen_ai.completion, which the
+#     plugin only stamps when content capture is on (genai_otel's own GENAI_ENABLE_CONTENT_CAPTURE
+#     is the WRONG lever — it gates genai_otel's instrumentors, not the plugin's spans). ---
+HERMES_OTEL_CAPTURE_CONTENT=true
+
+# --- MANDATORY to avoid double-counting: Hermes calls Ollama through the openai SDK, and
+#     genai_otel's DEFAULT instrumentor set includes 'openai', which would emit a SECOND
+#     span (+ duplicate token/cost metrics) per model call. Replacing the list with a
+#     no-op ('mcp') drops 'openai'. GPU/CO2/eval are independent of this list and still run. ---
+GENAI_ENABLED_INSTRUMENTORS=mcp
+
+# --- On-prem GPU + energy + CO2 (sustainability story) ---
+GENAI_ENABLE_GPU_METRICS=true       # default true — utilisation, power, memory, temp (NVIDIA via nvidia-ml-py)
+GENAI_ENABLE_CO2_TRACKING=true      # energy_kwh + CO2 gCO2e via codecarbon
+GENAI_CO2_COUNTRY_ISO_CODE=IND      # carbon-intensity region — set your deployment country
+GENAI_CODECARBON_LOG_LEVEL=error    # keep codecarbon quiet
+
+# --- Eval / guardrails — scored on every captured prompt + response ---
+GENAI_ENABLE_PII_DETECTION=true
+GENAI_PII_MODE=redact               # redact the evaluation copy (data-sovereignty); raw gen_ai.prompt still carries text
+GENAI_ENABLE_TOXICITY_DETECTION=true
+GENAI_ENABLE_BIAS_DETECTION=true
+GENAI_ENABLE_PROMPT_INJECTION_DETECTION=true
+GENAI_ENABLE_RESTRICTED_TOPICS=true
+GENAI_ENABLE_HALLUCINATION_DETECTION=true
+```
+
+### 3. What you get (verified 2026-06-18 against `genai-otel-instrument` 1.3.3)
+
+- **Span attributes** (every captured turn): `evaluation.pii.{prompt,response}.*`
+  (detected, entity_types, *_count, score, redacted), `evaluation.toxicity.*`
+  (score + categories — e.g. toxicity 0.93 / insult 0.84), `evaluation.bias.*`,
+  `evaluation.hallucination.*` (score, claims, citations, hedge_words),
+  `evaluation.prompt_injection.*`, `evaluation.restricted_topics.*`, plus
+  `gen_ai.usage.cost.*` (model-size pricing for local Ollama models).
+- **Metrics**: GPU (`utilisation / power / memory / temperature`), energy and
+  CO2 (`co2_emissions_gco2e`, `energy_consumed_kwh`, `power_consumption_watts`),
+  and eval score gauges — all tagged with `service.name = agent.coding.hermes`.
+
+### 4. How it works / gotchas
+
+- Eval needs **no plugin change**: `instrument()` registers a *global*
+  `EvaluationSpanProcessor` + wraps the OTLP exporter with an
+  `EvaluationEnrichingSpanExporter` whenever any `GENAI_ENABLE_*_DETECTION` is
+  set; the detectors read `gen_ai.prompt` / `gen_ai.completion` off **any** span,
+  so they score the plugin's own `invoke_agent` / `chat` spans.
+- **detoxify** downloads a ~500 MB model from HuggingFace on first toxicity eval
+  — pre-warm on an internet-connected host, or set
+  `GENAI_ENABLE_TOXICITY_DETECTION=false` for fully air-gapped installs.
+- The eval **score metrics** only reach a Prometheus/Timescale backend if its
+  keep-list includes `genai_evaluation_*` (the eval *span attributes* are
+  unaffected and are the most complete source).
+- **Data sovereignty**: `HERMES_OTEL_CAPTURE_CONTENT=true` exports raw
+  prompt/response text on spans; `GENAI_PII_MODE=redact` redacts the eval copy.
+  Confirm your PII-before-storage policy covers `gen_ai.prompt` / `gen_ai.completion`
+  before enabling content capture in a regulated environment.
+
+## Verify
+
+```bash
+hermes plugins list                 # observability/otel should show "enabled"
+hermes chat -q "hello"              # then check your OTel backend for an
+                                    # "invoke_agent" trace with chat/execute_tool children
+```
+
+## Disable
+
+```bash
+hermes plugins disable observability/otel
+```
+
+## Files
+
+```
+plugins/observability/otel/
+  __init__.py      Hermes plugin: register(ctx) + lifecycle hooks (the only Hermes-coupled module)
+  emitter.py       Hermes-agnostic OTel GenAI span builder
+  log_emitter.py   Hermes-agnostic OTel log-record builder (dashboard event model)
+  cost.py          local-model cost estimation (model size → price tier)
+  provider.py      tracer + logger bootstrap (genai_otel preferred, plain OTel SDK fallback)
+  plugin.yaml      manifest
+```
+
+The Hermes coupling is isolated to `__init__.py`; the span-mapping
+(`emitter.py`), log-record-mapping (`log_emitter.py`), and cost (`cost.py`)
+logic is pure and unit-tested with in-memory exporters (no Hermes, no network)
+under `tests/plugins/test_otel_plugin.py`.

--- a/plugins/observability/otel/README.md
+++ b/plugins/observability/otel/README.md
@@ -14,78 +14,29 @@ built-in observability events over OTLP in three complementary ways:
    local models), cost is estimated from the model's parameter size, so spans
    and log records carry a real `cost_usd` instead of `$0`.
 
-This plugin ships bundled with Hermes but is **opt-in** — it only loads when
-you explicitly enable it. It slots in beside `observability/langfuse` and
-`observability/nemo_relay` and makes no changes to Hermes core.
+Bundled with Hermes but **opt-in** — it only loads when you explicitly enable
+it. It slots in beside `observability/langfuse` and `observability/nemo_relay`
+and makes no changes to Hermes core. Without the OTel SDK the hooks no-op
+silently (the plugin fails open).
 
-## Span model
-
-```
-invoke_agent      per Hermes turn   (gen_ai.conversation.id = session id)
-  ├── chat        per LLM API call  (tokens, cost, finish reason, TTFT)
-  └── execute_tool  per tool call   (gen_ai.tool.name / .type, errors)
-```
-
-`gen_ai.system = hermes` on every span; `service.name` defaults to
-`agent.coding.hermes`. Prompt/response content is attached **only** when
-`HERMES_OTEL_CAPTURE_CONTENT=true` (privacy-gated, off by default).
-
-## Log-record model
-
-Emitted in parallel with the spans (best-effort — a logs failure never disables
-spans), to the OTLP **logs** endpoint (`<endpoint>/v1/logs`):
-
-| `event.name`    | Per          | Key attributes |
-|-----------------|--------------|----------------|
-| `session_start` | Hermes turn  | `session.id`, `model` |
-| `api_response`  | LLM API call | `model`, `input_tokens`, `output_tokens`, `cost_usd`, `finish_reason`, `ttft_ms` |
-| `tool_result`   | tool call    | `tool_name`, `tool_type`, `status_code`, `decision_type` |
-
-Identity (`service.name`, `user.id`, and any `team.id` / `organization.id` from
-`OTEL_RESOURCE_ATTRIBUTES`) is placed on the OTel **resource** so the
-per-user / per-org leaderboard aggregations work. Same privacy gate: prompt /
-response / tool I/O is attached only with `HERMES_OTEL_CAPTURE_CONTENT=true`.
-
-## Cost estimation
-
-Local backends report no price, so `cost.py` mirrors the
-`genai-otel-instrument` methodology: parse the parameter size from the model
-name (`llama3.1:8b` → 8 B, `qwen3:0.6b` → 0.6 B, `smollm2:360m` → 0.36 B), map
-it to a per-1K-token price tier, and compute
-`cost = in_tok/1000 * promptPrice + out_tok/1000 * completionPrice`. It is used
-**only** as a fallback when the agent itself reported no cost; an
-agent-provided `cost_usd` always wins. When the size can't be inferred, cost is
-omitted (no fake `$0`).
-
-## Enable
+## Quickstart
 
 ```bash
-# OTel SDK + OTLP HTTP exporter (the only hard dependency)
+# 1. Install the OTel SDK + OTLP HTTP exporter (the only hard dependency)
 pip install opentelemetry-sdk opentelemetry-exporter-otlp-proto-http
 
+# 2. Enable the plugin
 hermes plugins enable observability/otel
+
+# 3. Send a turn, then look for an "invoke_agent" trace in your OTel backend
+hermes chat -q "hello"
 ```
 
-Optionally install `genai-otel-instrument` to use the richer reference emitter
-(adds token/cost/latency conventions and optional on-prem **GPU / energy / CO2**
-metrics plus **eval / guardrail** scoring); the plugin auto-detects and prefers
-it when present:
+It works out of the box against a local collector on `http://localhost:4318`.
 
-```bash
-pip install genai-otel-instrument
-# …or, for the full on-prem story (GPU/CO2 + PII/toxicity/bias/injection/… eval):
-pip install "genai-otel-instrument[gpu,evaluation]"
-```
+### Configure (optional)
 
-See **[Full setup — GPU / CO2 / eval metrics](#full-setup--gpu--co2--eval-metrics-genai_otel)**
-below for the env-var recipe.
-
-Without the OTel SDK the hooks no-op silently — the plugin fails open.
-
-## Configure
-
-All configuration is optional; the plugin works out of the box against a local
-collector on `http://localhost:4318`. Set these in `~/.hermes/.env`:
+All configuration is optional. Set these in `~/.hermes/.env`:
 
 ```bash
 HERMES_OTEL_SERVICE_NAME=agent.coding.hermes   # service.name (backends group on this)
@@ -96,138 +47,53 @@ HERMES_OTEL_USER_ID=                           # stamp user.id on the resource
 ```
 
 Standard OTel env vars are honoured as fallbacks: `OTEL_SERVICE_NAME`,
-`OTEL_EXPORTER_OTLP_ENDPOINT`.
+`OTEL_EXPORTER_OTLP_ENDPOINT`. Prompt / response / tool I/O is attached **only**
+when `HERMES_OTEL_CAPTURE_CONTENT=true` (privacy-gated, off by default).
 
-## Full setup — GPU / CO2 / eval metrics (`genai_otel`)
-
-When `genai-otel-instrument` is installed the plugin routes through it (see
-`provider.py`), which unlocks on-prem **GPU/energy/CO2** metrics and a
-**Galileo-equivalent eval suite** (PII, toxicity, bias, prompt-injection,
-restricted-topics, hallucination). **No plugin code change is required** — these
-are driven entirely by `genai_otel`'s own `GENAI_*` environment variables, read
-inside `genai_otel.instrument()` (which the plugin already calls). Everything
-below is opt-in and degrades gracefully if a dependency is missing.
-
-### Why `genai_otel` (vs a vanilla OTel SDK or other GenAI instrumentors)
-
-The plugin works against a **plain OTel SDK** (the fallback) — that alone gives
-you GenAI-convention spans, tokens, latency, finish reasons, and the dashboard
-log records, portable to any OTLP backend. Routing through
-`genai-otel-instrument` adds four signals that are **genuinely unique** — neither
-a raw OTel SDK nor the common GenAI instrumentation libraries (OpenLLMetry /
-Traceloop, OpenInference / Arize, OpenLIT, Langfuse) emit them:
-
-| Signal | `genai_otel` | Vanilla OTel SDK | Other GenAI libs |
-|--------|:---:|:---:|:---:|
-| **On-prem GPU metrics** — per-GPU utilization, power, memory, temperature, clocks, throttle state (nvidia-ml-py / amdsmi) | ✅ | ❌ | ❌ |
-| **Energy + CO2** — `energy_kwh`, `co2_emissions_gco2e`, region-aware (codecarbon) | ✅ | ❌ | ❌ |
-| **Local-model cost** — Ollama / HF / vLLM cost estimated from parameter size when the backend returns no price | ✅ | ❌ (`$0`) | ❌ (priced cloud APIs only) |
-| **Inline eval / guardrails** — PII, toxicity, bias, prompt-injection, restricted-topics, hallucination scored as span attributes + metrics at instrumentation time | ✅ in-process | ❌ | ❌ (need a separate eval pipeline) |
-
-Everything runs **in-process and on-prem** — no data leaves the host, no SaaS
-observability backend, and no separate eval service. The token / latency / cost
-fields stay standard OTel GenAI conventions (portable to any OTLP backend); the
-four signals above are extra attributes/metrics a conventions-aware backend can
-use or safely ignore. All of it is opt-in and degrades gracefully when a
-dependency is missing.
-
-### 1. Install the extras
-
-```bash
-pip install "genai-otel-instrument[gpu,evaluation]"   # GPU: nvidia-ml-py + codecarbon; eval: presidio + spaCy + detoxify
-python -m spacy download en_core_web_lg                # presidio PII NER model (compliance-grade PERSON/LOCATION/NRP)
-```
-
-### 2. Environment recipe
-
-Set these alongside the `HERMES_OTEL_*` vars above (in `~/.hermes/.env` or the
-process environment, **before** Hermes launches):
-
-```bash
-# --- MANDATORY for eval: detectors score gen_ai.prompt / gen_ai.completion, which the
-#     plugin only stamps when content capture is on (genai_otel's own GENAI_ENABLE_CONTENT_CAPTURE
-#     is the WRONG lever — it gates genai_otel's instrumentors, not the plugin's spans). ---
-HERMES_OTEL_CAPTURE_CONTENT=true
-
-# --- MANDATORY to avoid double-counting: Hermes calls Ollama through the openai SDK, and
-#     genai_otel's DEFAULT instrumentor set includes 'openai', which would emit a SECOND
-#     span (+ duplicate token/cost metrics) per model call. Replacing the list with a
-#     no-op ('mcp') drops 'openai'. GPU/CO2/eval are independent of this list and still run. ---
-GENAI_ENABLED_INSTRUMENTORS=mcp
-
-# --- On-prem GPU + energy + CO2 (sustainability story) ---
-GENAI_ENABLE_GPU_METRICS=true       # default true — utilisation, power, memory, temp (NVIDIA via nvidia-ml-py)
-GENAI_ENABLE_CO2_TRACKING=true      # energy_kwh + CO2 gCO2e via codecarbon
-GENAI_CO2_COUNTRY_ISO_CODE=IND      # carbon-intensity region — set your deployment country
-GENAI_CODECARBON_LOG_LEVEL=error    # keep codecarbon quiet
-
-# --- Eval / guardrails — scored on every captured prompt + response ---
-GENAI_ENABLE_PII_DETECTION=true
-GENAI_PII_MODE=redact               # redact the evaluation copy (data-sovereignty); raw gen_ai.prompt still carries text
-GENAI_ENABLE_TOXICITY_DETECTION=true
-GENAI_ENABLE_BIAS_DETECTION=true
-GENAI_ENABLE_PROMPT_INJECTION_DETECTION=true
-GENAI_ENABLE_RESTRICTED_TOPICS=true
-GENAI_ENABLE_HALLUCINATION_DETECTION=true
-```
-
-### 3. What you get (verified 2026-06-18 against `genai-otel-instrument` 1.3.3)
-
-- **Span attributes** (every captured turn): `evaluation.pii.{prompt,response}.*`
-  (detected, entity_types, *_count, score, redacted), `evaluation.toxicity.*`
-  (score + categories — e.g. toxicity 0.93 / insult 0.84), `evaluation.bias.*`,
-  `evaluation.hallucination.*` (score, claims, citations, hedge_words),
-  `evaluation.prompt_injection.*`, `evaluation.restricted_topics.*`, plus
-  `gen_ai.usage.cost.*` (model-size pricing for local Ollama models).
-- **Metrics**: GPU (`utilisation / power / memory / temperature`), energy and
-  CO2 (`co2_emissions_gco2e`, `energy_consumed_kwh`, `power_consumption_watts`),
-  and eval score gauges — all tagged with `service.name = agent.coding.hermes`.
-
-### 4. How it works / gotchas
-
-- Eval needs **no plugin change**: `instrument()` registers a *global*
-  `EvaluationSpanProcessor` + wraps the OTLP exporter with an
-  `EvaluationEnrichingSpanExporter` whenever any `GENAI_ENABLE_*_DETECTION` is
-  set; the detectors read `gen_ai.prompt` / `gen_ai.completion` off **any** span,
-  so they score the plugin's own `invoke_agent` / `chat` spans.
-- **detoxify** downloads a ~500 MB model from HuggingFace on first toxicity eval
-  — pre-warm on an internet-connected host, or set
-  `GENAI_ENABLE_TOXICITY_DETECTION=false` for fully air-gapped installs.
-- The eval **score metrics** only reach a Prometheus/Timescale backend if its
-  keep-list includes `genai_evaluation_*` (the eval *span attributes* are
-  unaffected and are the most complete source).
-- **Data sovereignty**: `HERMES_OTEL_CAPTURE_CONTENT=true` exports raw
-  prompt/response text on spans; `GENAI_PII_MODE=redact` redacts the eval copy.
-  Confirm your PII-before-storage policy covers `gen_ai.prompt` / `gen_ai.completion`
-  before enabling content capture in a regulated environment.
-
-## Verify
+### Verify / disable
 
 ```bash
 hermes plugins list                 # observability/otel should show "enabled"
-hermes chat -q "hello"              # then check your OTel backend for an
-                                    # "invoke_agent" trace with chat/execute_tool children
-```
-
-## Disable
-
-```bash
 hermes plugins disable observability/otel
 ```
 
-## Files
+## Architecture
 
 ```
-plugins/observability/otel/
-  __init__.py      Hermes plugin: register(ctx) + lifecycle hooks (the only Hermes-coupled module)
-  emitter.py       Hermes-agnostic OTel GenAI span builder
-  log_emitter.py   Hermes-agnostic OTel log-record builder (dashboard event model)
-  cost.py          local-model cost estimation (model size → price tier)
-  provider.py      tracer + logger bootstrap (genai_otel preferred, plain OTel SDK fallback)
-  plugin.yaml      manifest
+invoke_agent        per Hermes turn   (gen_ai.conversation.id = session id)
+  ├── chat          per LLM API call  (tokens, cost, finish reason, TTFT)
+  └── execute_tool  per tool call     (gen_ai.tool.name / .type, errors)
 ```
 
-The Hermes coupling is isolated to `__init__.py`; the span-mapping
-(`emitter.py`), log-record-mapping (`log_emitter.py`), and cost (`cost.py`)
-logic is pure and unit-tested with in-memory exporters (no Hermes, no network)
-under `tests/plugins/test_otel_plugin.py`.
+`gen_ai.system = hermes` on every span; `service.name` defaults to
+`agent.coding.hermes`. Spans and dashboard log records are emitted in parallel
+(a logs failure never disables spans). Identity (`service.name`, `user.id`, and
+any `team.id` / `organization.id` from `OTEL_RESOURCE_ATTRIBUTES`) is placed on
+the OTel **resource** so per-user / per-org leaderboard aggregations work.
+
+The mapping logic is pure, Hermes-agnostic, and unit-tested with in-memory
+exporters (no Hermes, no network) under `tests/plugins/test_otel_plugin.py`. The
+**full reference lives inline, next to the code** — each module's docstring is
+the source of truth:
+
+| Module | What its docstring documents |
+|--------|------------------------------|
+| `emitter.py` | GenAI **span** model (`invoke_agent` / `chat` / `execute_tool` + attributes) |
+| `log_emitter.py` | dashboard **log-record** model (`session_start` / `api_response` / `tool_result` — the field contract dashboards aggregate on) |
+| `cost.py` | local-model **cost estimation** (model-size → price-tier methodology) |
+| `provider.py` | tracer / logger **bootstrap** (genai_otel preferred, plain OTel SDK fallback) |
+| `__init__.py` | the only Hermes-coupled module: `register(ctx)` + lifecycle hooks |
+| `plugin.yaml` | manifest |
+
+## Advanced — GPU / CO2 / eval metrics
+
+Installing `genai-otel-instrument` instead of the plain OTel SDK unlocks on-prem
+**GPU / energy / CO2** metrics and an inline **eval suite** (PII, toxicity, bias,
+prompt-injection, restricted-topics, hallucination) — scored in-process, on-prem,
+with no data leaving the host, no SaaS backend, and no separate eval service.
+It is driven entirely by `genai_otel`'s own `GENAI_*` environment variables;
+**no plugin code change is required**.
+
+→ See **[ADVANCED.md](./ADVANCED.md)** for the full setup: why `genai_otel` vs a
+vanilla OTel SDK (with a capability comparison), the install extras, the
+environment recipe, and exactly what attributes/metrics you get.

--- a/plugins/observability/otel/__init__.py
+++ b/plugins/observability/otel/__init__.py
@@ -1,0 +1,495 @@
+# SPDX-License-Identifier: MIT
+"""otel — Hermes plugin for OpenTelemetry (OTLP) observability.
+
+Exports Hermes's built-in observability events over **OpenTelemetry** using the
+vendor-neutral **GenAI semantic conventions** (``gen_ai.*``). It slots in beside
+the bundled ``observability/langfuse`` and ``observability/nemo_relay`` plugins
+and makes **no changes to Hermes core** — Hermes already produces the right
+events (a turn, per-LLM-API-call usage/cost, per-tool-call results); this plugin
+adds an OTLP sink for them so the telemetry flows to *any* OTel backend (an
+OpenTelemetry Collector, Jaeger, Grafana Tempo, Honeycomb, …) with no lock-in.
+
+Activation is handled by the Hermes plugin system — standalone plugins only load
+when enabled (``hermes plugins enable observability/otel``). At runtime the
+plugin also requires the OpenTelemetry SDK; if it is missing the hooks no-op
+(fail-open), exactly like the other observability plugins.
+
+Required env vars: none (it works out of the box against a local collector).
+
+Optional env vars (set via ``hermes tools`` or ``~/.hermes/.env``):
+  HERMES_OTEL_SERVICE_NAME    - service.name resource attr (default: agent.coding.hermes)
+  HERMES_OTEL_ENDPOINT        - OTLP HTTP endpoint (default: http://localhost:4318)
+  HERMES_OTEL_AGENT_NAME      - gen_ai.agent.name value (default: hermes)
+  HERMES_OTEL_CAPTURE_CONTENT - "true" to attach prompt/response text (default: off, privacy-gated)
+  HERMES_OTEL_USER_ID         - stamp user.id on the resource
+
+Standard OTel env vars are honoured as fallbacks: OTEL_SERVICE_NAME,
+OTEL_EXPORTER_OTLP_ENDPOINT.
+
+Span model (GenAI conventions):
+
+    invoke_agent      per Hermes turn   (gen_ai.conversation.id = session id)
+      ├── chat        per LLM API call  (tokens, cost, finish reason, TTFT)
+      └── execute_tool  per tool call   (gen_ai.tool.name, gen_ai.tool.type)
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import threading
+from typing import Any, Optional
+
+logger = logging.getLogger(__name__)
+
+# Sentinel: "_get_emitter() tried and failed" — short-circuits every subsequent
+# hook call without re-importing the SDK. Mirrors the langfuse/nemo_relay gate.
+_INIT_FAILED = object()
+_LOCK = threading.RLock()
+_EMITTER: "Any | object | None" = None
+
+# Parallel OTel *log-record* emitter (populates the agent-coding dashboard,
+# which is built from log events, not spans). Built once alongside the span
+# emitter; may be a no-op emitter when the logs SDK/endpoint is unavailable.
+_LOG_EMITTER: "Any | object | None" = None
+
+# One open invoke_agent context per active session, keyed by session id.
+_OPEN_TURNS_LOCK = threading.Lock()
+_OPEN_TURNS: dict[str, Any] = {}
+# The invoke_agent span object for each open turn (same key + lock). Held so a
+# later hook (pre_llm_call) can stamp the prompt onto the still-open span.
+_OPEN_TURN_SPANS: dict[str, Any] = {}
+
+# Last session id we opened a turn for, used as a fallback when a per-call hook
+# (post_api_request / post_tool_call) does not carry the session id in kwargs.
+_ACTIVE_SESSION_LOCK = threading.Lock()
+_ACTIVE_SESSION_ID: str = "default"
+
+
+def _env(name: str, default: str = "") -> str:
+    return os.environ.get(name, default).strip()
+
+
+def _env_bool(name: str) -> bool:
+    return _env(name).lower() in {"1", "true", "yes", "on"}
+
+
+def _get_emitter() -> Optional[Any]:
+    """Return a cached :class:`OtelGenAIEmitter`, or ``None`` if unavailable.
+
+    Activation of this plugin is controlled by the Hermes plugin system — this
+    function only handles the runtime-availability gate (OTel SDK importable).
+    The result is cached: built once, then returned (or fast-``None`` on
+    failure) on every subsequent call. Thread-safe via double-checked locking
+    so concurrent agent sessions don't race to build two providers.
+    """
+    global _EMITTER
+    if _EMITTER is _INIT_FAILED:
+        return None
+    if _EMITTER is not None and _EMITTER is not _INIT_FAILED:
+        return _EMITTER
+    with _LOCK:
+        if _EMITTER is _INIT_FAILED:
+            return None
+        if _EMITTER is not None:
+            return _EMITTER
+        try:
+            from .emitter import OtelGenAIEmitter
+            from .log_emitter import OtelLogEmitter
+            from .provider import build_logger, build_tracer
+
+            service_name = _env("HERMES_OTEL_SERVICE_NAME") or None
+            otlp_endpoint = _env("HERMES_OTEL_ENDPOINT") or None
+            user_id = _env("HERMES_OTEL_USER_ID") or None
+            capture = _env_bool("HERMES_OTEL_CAPTURE_CONTENT")
+            agent_name = _env("HERMES_OTEL_AGENT_NAME") or "hermes"
+
+            tracer = build_tracer(
+                service_name=service_name,
+                otlp_endpoint=otlp_endpoint,
+                user_id=user_id,
+                capture_content=capture,
+            )
+            _EMITTER = OtelGenAIEmitter(
+                tracer,
+                agent_name=agent_name,
+                capture_content=capture,
+            )
+            # Build the parallel dashboard log emitter. Failure here must NOT
+            # disable spans — log emission is best-effort; build_logger() returns
+            # None on any problem and OtelLogEmitter then no-ops.
+            global _LOG_EMITTER
+            try:
+                otel_logger = build_logger(
+                    service_name=service_name,
+                    otlp_endpoint=otlp_endpoint,
+                    user_id=user_id,
+                )
+                _LOG_EMITTER = OtelLogEmitter(
+                    otel_logger,
+                    agent_name=agent_name,
+                    capture_content=capture,
+                )
+            except Exception:  # pragma: no cover - fail-open
+                logger.warning(
+                    "observability/otel: dashboard log emitter init failed; "
+                    "spans still emit",
+                    exc_info=True,
+                )
+                _LOG_EMITTER = OtelLogEmitter(None)
+        except Exception as exc:  # pragma: no cover - fail-open
+            # Init failure is unexpected (bad endpoint, missing SDK piece): warn
+            # so a misconfiguration is visible, but stay fail-open per the
+            # observability contract — never raise out of a hook.
+            logger.warning("observability/otel disabled: init failed: %s", exc, exc_info=True)
+            _EMITTER = _INIT_FAILED
+            return None
+        return _EMITTER
+
+
+def _get_log_emitter() -> Optional[Any]:
+    """Return the cached dashboard log emitter (or ``None``).
+
+    Ensures the span emitter (and thus the log emitter) is built first; the log
+    emitter is constructed inside ``_get_emitter``.
+    """
+    if _get_emitter() is None:
+        return None
+    le = _LOG_EMITTER
+    if le is None or le is _INIT_FAILED:
+        return None
+    return le
+
+
+def _session_id(kwargs: dict[str, Any]) -> str:
+    return str(
+        kwargs.get("session_id")
+        or kwargs.get("task_id")
+        or kwargs.get("parent_session_id")
+        or "default"
+    )
+
+
+def _session_id_or_active(kwargs: dict[str, Any]) -> str:
+    """Session id from kwargs, falling back to the last-opened turn's session.
+
+    Per-call hooks (post_api_request / post_tool_call) don't always carry the
+    session id; the log records still need it for resource.session.id grouping,
+    so we fall back to the session whose ``invoke_agent`` turn is currently open.
+    """
+    explicit = (
+        kwargs.get("session_id")
+        or kwargs.get("task_id")
+        or kwargs.get("parent_session_id")
+    )
+    if explicit:
+        return str(explicit)
+    with _ACTIVE_SESSION_LOCK:
+        return _ACTIVE_SESSION_ID
+
+
+def _as_list(value: Any) -> list[Any] | None:
+    if value is None:
+        return None
+    if isinstance(value, (list, tuple)):
+        return list(value)
+    return [value]
+
+
+def _usage_field(usage: Any, *names: str) -> Any:
+    """Read the first present field from a usage dict or object."""
+    for name in names:
+        if isinstance(usage, dict):
+            if usage.get(name) is not None:
+                return usage[name]
+        elif usage is not None:
+            value = getattr(usage, name, None)
+            if value is not None:
+                return value
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Lifecycle hooks. All callbacks accept **kwargs for forward compatibility and
+# never raise — observability must not break the agent (see CONTRIBUTING and the
+# Build-a-Plugin guide). The body is gated on _get_emitter() being available.
+# ---------------------------------------------------------------------------
+
+
+def on_session_start(**kwargs: Any) -> None:
+    """Track the active session and emit the ``session_start`` dashboard log.
+
+    The ``invoke_agent`` span is **not** opened here. It is opened lazily on the
+    first ``pre_llm_call`` of each turn and closed on ``transform_llm_output``,
+    so it is **one span per turn** that exports at turn end (matching the
+    documented span model). Opening it at ``on_session_start`` — which fires once
+    per session — would make it session-scoped, so per-turn eval would only
+    export on a clean session end and be lost on an abrupt shutdown.
+    """
+    emitter = _get_emitter()
+    if emitter is None:
+        return
+    session_id = _session_id(kwargs)
+    with _ACTIVE_SESSION_LOCK:
+        global _ACTIVE_SESSION_ID
+        _ACTIVE_SESSION_ID = session_id
+    # Dashboard log record (best-effort, never raises).
+    log_emitter = _get_log_emitter()
+    if log_emitter is not None:
+        try:
+            log_emitter.session_start(
+                session_id=session_id,
+                model=kwargs.get("model"),
+                user_prompt=kwargs.get("user_message"),
+            )
+        except Exception:
+            logger.debug("on_session_start: failed to emit session_start log", exc_info=True)
+
+
+def _end_turn(**kwargs: Any) -> None:
+    """Close the ``invoke_agent`` span for a Hermes session, if open."""
+    if _get_emitter() is None:
+        return
+    session_id = _session_id(kwargs)
+    with _OPEN_TURNS_LOCK:
+        cm = _OPEN_TURNS.pop(session_id, None)
+        _OPEN_TURN_SPANS.pop(session_id, None)
+    _close_cm(cm)
+
+
+# on_session_end / on_session_finalize / on_session_reset all close the turn.
+on_session_end = _end_turn
+on_session_finalize = _end_turn
+on_session_reset = _end_turn
+
+
+def on_pre_llm_call(**kwargs: Any) -> None:
+    """Open the per-turn ``invoke_agent`` span and stamp the prompt.
+
+    Hermes fires ``pre_llm_call`` before each LLM call, carrying the turn's
+    ``user_message`` (``on_session_start`` does not). The **first**
+    ``pre_llm_call`` of a turn opens the turn span (stamping ``gen_ai.prompt``);
+    later calls within the same turn (a tool loop fires it once per LLM call)
+    reuse the already-open span. ``transform_llm_output`` closes the span at turn
+    end, so it exports per turn — making prompt-side eval (PII / prompt-injection
+    / restricted-topics on the developer's input) run and export every turn,
+    resilient to an abrupt shutdown. No-op / never raises (observability must
+    not break the agent).
+    """
+    emitter = _get_emitter()
+    if emitter is None:
+        return
+    session_id = _session_id_or_active(kwargs)
+    with _OPEN_TURNS_LOCK:
+        if session_id in _OPEN_TURNS:
+            return  # same turn (tool-loop continuation) — keep the open span
+    try:
+        cm = emitter.turn_span(
+            session_id=session_id,
+            model=kwargs.get("model"),
+            user_prompt=kwargs.get("user_message"),
+        )
+        span = cm.__enter__()
+        with _OPEN_TURNS_LOCK:
+            _OPEN_TURNS[session_id] = cm
+            _OPEN_TURN_SPANS[session_id] = span
+    except Exception:
+        logger.debug("on_pre_llm_call: failed to open turn span", exc_info=True)
+
+
+def on_transform_llm_output(**kwargs: Any) -> None:
+    """Stamp the model's response onto the open ``invoke_agent`` span.
+
+    Hermes delivers the final response text on ``transform_llm_output`` (fired
+    once per turn after the tool loop, before the turn closes); the per-call
+    ``post_api_request`` hook carries only token/finish metadata, not the text.
+    Stamping it on the open turn span enables response-side evaluation (toxicity
+    / hallucination / output PII) alongside the prompt-side eval from
+    ``pre_llm_call``.
+
+    This is a **read-only observer**: it returns ``None`` so the output text is
+    never altered (the transform contract is "first non-empty string wins";
+    returning None leaves it unchanged). It then **closes the turn span**, which
+    exports it now — so prompt+response eval runs every turn and survives an
+    abrupt shutdown. No-op when no turn is open. Never raises.
+    """
+    emitter = _get_emitter()
+    if emitter is None:
+        return
+    session_id = _session_id_or_active(kwargs)
+    with _OPEN_TURNS_LOCK:
+        cm = _OPEN_TURNS.pop(session_id, None)
+        span = _OPEN_TURN_SPANS.pop(session_id, None)
+    if span is None:
+        return
+    response_text = kwargs.get("response_text")
+    try:
+        if response_text:
+            emitter.stamp_completion(span, response_text)
+    except Exception:
+        logger.debug("on_transform_llm_output: failed to stamp response", exc_info=True)
+    # End the turn span -> it exports immediately and the eval enricher runs on
+    # this turn's prompt + response.
+    _close_cm(cm)
+
+
+def _close_cm(cm: Any) -> None:
+    if cm is None:
+        return
+    try:
+        cm.__exit__(None, None, None)
+    except Exception:
+        logger.debug("failed to close turn span", exc_info=True)
+
+
+def on_post_api_request(**kwargs: Any) -> None:
+    """Emit a ``chat`` span for a completed LLM API call.
+
+    ``post_api_request`` fires once per provider/API call and carries the usage
+    summary (CanonicalUsage dict) and finish reason — exactly the per-LLM-call
+    enrichment fields the GenAI ``chat`` span wants.
+    """
+    emitter = _get_emitter()
+    if emitter is None:
+        return
+    try:
+        usage = kwargs.get("usage")
+        duration = kwargs.get("api_duration") or kwargs.get("duration_ms")
+        ttft_ms = None
+        if duration is not None:
+            try:
+                # api_duration is seconds (langfuse rounds it as such); a
+                # duration_ms is already ms. Normalise api_duration to ms.
+                ttft_ms = (
+                    float(duration) * 1000.0
+                    if kwargs.get("api_duration") is not None
+                    else float(duration)
+                )
+            except (TypeError, ValueError):
+                ttft_ms = None
+        input_tokens = _usage_field(usage, "input_tokens", "prompt_tokens")
+        output_tokens = _usage_field(usage, "output_tokens", "completion_tokens")
+        cost_usd = kwargs.get("cost_usd") or kwargs.get("cost")
+        # Local backends (Ollama/HF/vLLM) report no price. Mirror
+        # genai-otel-instrument: estimate cost from model size + tokens so the
+        # dashboard shows real cost, not $0 — only when the agent gave us none.
+        if cost_usd is None:
+            try:
+                from .cost import estimate_cost_usd
+
+                cost_usd = estimate_cost_usd(
+                    kwargs.get("response_model") or kwargs.get("model"),
+                    input_tokens,
+                    output_tokens,
+                )
+            except Exception:
+                logger.debug("cost estimation failed", exc_info=True)
+        finish = _as_list(kwargs.get("finish_reason"))
+        emitter.record_llm_call(
+            request_model=kwargs.get("model"),
+            response_model=kwargs.get("response_model"),
+            input_tokens=input_tokens,
+            output_tokens=output_tokens,
+            cost_usd=cost_usd,
+            finish_reasons=finish,
+            ttft_ms=ttft_ms,
+            response_text=kwargs.get("assistant_response"),
+        )
+    except Exception:
+        logger.debug("on_post_api_request: failed to emit chat span", exc_info=True)
+        return
+    # Dashboard log record (best-effort).
+    log_emitter = _get_log_emitter()
+    if log_emitter is not None:
+        try:
+            log_emitter.api_response(
+                session_id=_session_id_or_active(kwargs),
+                request_model=kwargs.get("model"),
+                response_model=kwargs.get("response_model"),
+                input_tokens=input_tokens,
+                output_tokens=output_tokens,
+                cost_usd=cost_usd,
+                finish_reasons=finish,
+                ttft_ms=ttft_ms,
+                response_text=kwargs.get("assistant_response"),
+            )
+        except Exception:
+            logger.debug("on_post_api_request: failed to emit api_response log", exc_info=True)
+
+
+def on_post_tool_call(**kwargs: Any) -> None:
+    """Emit an ``execute_tool`` span for a completed tool call."""
+    emitter = _get_emitter()
+    if emitter is None:
+        return
+    try:
+        status = kwargs.get("status")
+        error = kwargs.get("error")
+        if error is None and isinstance(status, str) and status.lower() in {"error", "failed"}:
+            error = status
+        tool_name = str(kwargs.get("tool_name") or "unknown")
+        tool_type = str(kwargs.get("tool_type") or "function")
+        emitter.record_tool_call(
+            tool_name=tool_name,
+            tool_type=tool_type,
+            arguments=kwargs.get("args"),
+            result=kwargs.get("result"),
+            error=error,
+        )
+    except Exception:
+        logger.debug("on_post_tool_call: failed to emit execute_tool span", exc_info=True)
+        return
+    # Dashboard log record (best-effort).
+    log_emitter = _get_log_emitter()
+    if log_emitter is not None:
+        try:
+            log_emitter.tool_result(
+                session_id=_session_id_or_active(kwargs),
+                tool_name=tool_name,
+                tool_type=tool_type,
+                arguments=kwargs.get("args"),
+                result=kwargs.get("result"),
+                error=error,
+            )
+        except Exception:
+            logger.debug("on_post_tool_call: failed to emit tool_result log", exc_info=True)
+
+
+def register(ctx) -> None:
+    """Register the plugin's lifecycle hooks with Hermes.
+
+    Called exactly once at startup. Mirrors the hook set used by the bundled
+    ``observability/langfuse`` and ``observability/nemo_relay`` plugins:
+
+    * session lifecycle    → ``invoke_agent`` span open/close
+    * pre_llm_call         → stamp the user prompt onto the open turn span
+    * transform_llm_output → stamp the model response onto the open turn span
+    * post_api_request     → ``chat`` span (tokens, cost, finish reason, TTFT)
+    * post_tool_call       → ``execute_tool`` span (tool name/type, errors)
+
+    ``pre_llm_call`` and ``transform_llm_output`` are read-only observers (the
+    latter returns ``None`` and never alters the output); together they put the
+    prompt and response on the turn span so a conventions-aware backend can run
+    prompt- and response-side evaluation when content capture is enabled.
+    """
+    ctx.register_hook("on_session_start", on_session_start)
+    ctx.register_hook("on_session_end", on_session_end)
+    ctx.register_hook("on_session_finalize", on_session_finalize)
+    ctx.register_hook("on_session_reset", on_session_reset)
+    ctx.register_hook("pre_llm_call", on_pre_llm_call)
+    ctx.register_hook("transform_llm_output", on_transform_llm_output)
+    ctx.register_hook("post_api_request", on_post_api_request)
+    ctx.register_hook("post_tool_call", on_post_tool_call)
+
+
+def reset_for_tests() -> None:
+    """Drop the cached emitter and any open turns (tests/teardown only)."""
+    global _EMITTER, _LOG_EMITTER, _ACTIVE_SESSION_ID
+    with _LOCK:
+        _EMITTER = None
+        _LOG_EMITTER = None
+    with _OPEN_TURNS_LOCK:
+        _OPEN_TURNS.clear()
+        _OPEN_TURN_SPANS.clear()
+    with _ACTIVE_SESSION_LOCK:
+        _ACTIVE_SESSION_ID = "default"

--- a/plugins/observability/otel/__init__.py
+++ b/plugins/observability/otel/__init__.py
@@ -295,6 +295,22 @@ def on_pre_llm_call(**kwargs: Any) -> None:
             _OPEN_TURN_SPANS[session_id] = span
     except Exception:
         logger.debug("on_pre_llm_call: failed to open turn span", exc_info=True)
+    # Dashboard log record for the prompt (best-effort, never raises). The span
+    # carries the prompt as gen_ai.prompt, but the /agent-coding dashboard is
+    # built from log records — without a `user_prompt` record a Hermes session
+    # shows tool calls and API responses but no prompts. Emitted once per turn:
+    # the tool-loop-continuation guard above early-returns on later pre_llm_calls
+    # of the same turn, so this line is only reached on the turn's first call.
+    log_emitter = _get_log_emitter()
+    if log_emitter is not None:
+        try:
+            log_emitter.user_prompt(
+                session_id=session_id,
+                prompt=kwargs.get("user_message"),
+                model=kwargs.get("model"),
+            )
+        except Exception:
+            logger.debug("on_pre_llm_call: failed to emit user_prompt log", exc_info=True)
 
 
 def on_transform_llm_output(**kwargs: Any) -> None:
@@ -462,7 +478,8 @@ def register(ctx) -> None:
     ``observability/langfuse`` and ``observability/nemo_relay`` plugins:
 
     * session lifecycle    → ``invoke_agent`` span open/close
-    * pre_llm_call         → stamp the user prompt onto the open turn span
+    * pre_llm_call         → stamp the user prompt onto the open turn span +
+                             emit a ``user_prompt`` dashboard log record
     * transform_llm_output → stamp the model response onto the open turn span
     * post_api_request     → ``chat`` span (tokens, cost, finish reason, TTFT)
     * post_tool_call       → ``execute_tool`` span (tool name/type, errors)

--- a/plugins/observability/otel/cost.py
+++ b/plugins/observability/otel/cost.py
@@ -1,0 +1,103 @@
+# SPDX-License-Identifier: MIT
+"""Local-model cost estimation for the observability/otel plugin.
+
+Hermes runs against local backends (Ollama, HF transformers, vLLM) where the
+provider returns **no price**. The TraceVerse ``genai-otel-instrument`` library
+nevertheless populates cost for local models from a pricing DB plus a
+**model-size → price-tier** estimate, so a local run shows real (non-zero) cost
+in the dashboard rather than ``$0``.
+
+This module mirrors that methodology so the plugin's spans **and** dashboard log
+records carry the same ``cost_usd`` the rest of the platform expects:
+
+* parse the parameter size from the model name (``llama3.1:8b`` → 8.0 B,
+  ``smollm2:360m`` → 0.36 B, ``qwen3:0.6b`` → 0.6 B);
+* map the size to a per-1K-token prompt/completion price tier;
+* ``cost = prompt_tokens/1000 * promptPrice + completion_tokens/1000 * completionPrice``.
+
+Numbers are kept identical to ``genai_otel.cost_calculator`` (the canonical
+source) so Hermes cost lines up with every other agent on the platform. When the
+size can't be determined, cost is ``None`` (the caller then omits it, exactly as
+the library returns ``0.0``/unknown).
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Optional
+
+# Per-1,000-token prices by parameter-count tier — verbatim from
+# genai_otel.cost_calculator._get_local_model_price_tier. (prompt, completion)
+_SIZE_TIERS = (
+    (1.0, 0.0001, 0.0002),    # < 1B
+    (10.0, 0.0003, 0.0006),   # 1–10B
+    (20.0, 0.0005, 0.0010),   # 10–20B
+    (80.0, 0.0008, 0.0008),   # 20–80B
+)
+_XLARGE = (0.0012, 0.0012)    # 80B+
+
+# HuggingFace model-name → size (billions) fallback for names without an
+# explicit Nb/Nm suffix. Mirrors the library's hardcoded map (subset).
+_HF_SIZE_MAP = {
+    "t5-small": 0.06,
+    "gpt2": 0.124,
+    "gpt2-medium": 0.355,
+    "gpt2-large": 0.774,
+    "gpt2-xl": 1.5,
+    "bert-base": 0.11,
+    "bert-large": 0.34,
+    "distilbert": 0.066,
+}
+
+# (\d+(?:\.\d+)?)(m|b) followed by a boundary — matches "8b", "0.6b", "360m".
+_PARAM_RE = re.compile(r"(\d+(?:\.\d+)?)(m|b)(?:\s|:|$|-)")
+
+
+def extract_param_count_billions(model: str) -> Optional[float]:
+    """Return the model's parameter count in billions, or ``None`` if unknown.
+
+    ``llama3.1:8b`` → 8.0 · ``qwen3:0.6b`` → 0.6 · ``smollm2:360m`` → 0.36.
+    Falls back to the HF name map for suffix-less names (``gpt2`` → 0.124).
+    """
+    if not model:
+        return None
+    m = model.lower()
+    match = _PARAM_RE.search(m)
+    if match:
+        value = float(match.group(1))
+        return value / 1000.0 if match.group(2) == "m" else value
+    for name, size in _HF_SIZE_MAP.items():
+        if name in m:
+            return size
+    return None
+
+
+def _price_tier(param_billions: float) -> tuple[float, float]:
+    for ceiling, prompt_price, completion_price in _SIZE_TIERS:
+        if param_billions < ceiling:
+            return prompt_price, completion_price
+    return _XLARGE
+
+
+def estimate_cost_usd(
+    model: Optional[str],
+    input_tokens: Optional[int],
+    output_tokens: Optional[int],
+) -> Optional[float]:
+    """Estimate USD cost for a local model call from its size + token usage.
+
+    Returns ``None`` when the model size can't be inferred or there are no
+    tokens — callers omit cost in that case (no fake ``$0`` rows). The formula
+    and tier numbers match ``genai-otel-instrument`` so platform cost is
+    consistent across agents.
+    """
+    param_billions = extract_param_count_billions(model or "")
+    if param_billions is None:
+        return None
+    in_tok = int(input_tokens) if input_tokens else 0
+    out_tok = int(output_tokens) if output_tokens else 0
+    if in_tok == 0 and out_tok == 0:
+        return None
+    prompt_price, completion_price = _price_tier(param_billions)
+    cost = (in_tok / 1000.0) * prompt_price + (out_tok / 1000.0) * completion_price
+    return round(cost, 8)

--- a/plugins/observability/otel/emitter.py
+++ b/plugins/observability/otel/emitter.py
@@ -1,0 +1,263 @@
+# SPDX-License-Identifier: MIT
+"""OTel GenAI span emitter for the observability/otel plugin.
+
+This module is intentionally **Hermes-agnostic**: it knows nothing about the
+Hermes plugin contract (no ``register(ctx)``, no hook names, no kwargs shape).
+It only knows how to turn the three observability concepts Hermes already
+produces — *turn*, *LLM API call*, *tool call* — into OpenTelemetry spans that
+follow the GenAI semantic conventions (``gen_ai.operation.name`` of
+``invoke_agent`` / ``chat`` / ``execute_tool``).
+
+Keeping it separate means the span-mapping logic is unit-testable with only the
+OpenTelemetry SDK installed (no Hermes import), and the plugin glue in
+``__init__.py`` stays a thin adapter over the real Hermes hooks.
+
+Span model:
+
+    invoke_agent   one span per Hermes turn  (gen_ai.conversation.id == session)
+      |
+      +-- chat           one span per LLM API call (tokens, cost, finish reason)
+      |
+      +-- execute_tool   one span per tool call   (tool name, type)
+
+GenAI attribute conventions emitted (the names the OTel GenAI spec defines):
+
+    gen_ai.operation.name            invoke_agent | chat | execute_tool
+    gen_ai.system                    hermes
+    gen_ai.agent.name                hermes
+    gen_ai.conversation.id           session / conversation id
+    gen_ai.request.model             model id requested
+    gen_ai.response.model            model id that answered
+    gen_ai.response.finish_reasons   [str]  (stop / length / tool_calls / ...)
+    gen_ai.usage.input_tokens        int
+    gen_ai.usage.output_tokens       int
+    gen_ai.tool.name                 tool name (execute_tool span)
+    gen_ai.tool.type                 function | extension
+
+Extras (interoperable, safe no-ops on any conventions-aware backend):
+
+    cost_usd                         float   (estimated, if available)
+    copilot_chat.time_to_first_token TTFT ms (shared TTFT field)
+"""
+
+from __future__ import annotations
+
+import logging
+from contextlib import contextmanager
+from typing import Any, Iterator, Mapping, Sequence
+
+logger = logging.getLogger(__name__)
+
+# OTel GenAI operation names (stable across the spec).
+OP_INVOKE_AGENT = "invoke_agent"
+OP_CHAT = "chat"
+OP_EXECUTE_TOOL = "execute_tool"
+
+# Stable identity for the contributed agent.
+GEN_AI_SYSTEM = "hermes"
+DEFAULT_AGENT_NAME = "hermes"
+
+
+def _set_if(span: Any, key: str, value: Any) -> None:
+    """Set an attribute only when ``value`` is meaningful.
+
+    OTel rejects ``None`` and silently drops empty collections; skipping them
+    keeps spans clean and avoids per-call ``if`` noise at the call sites.
+    """
+    if value is None:
+        return
+    if isinstance(value, (str, bytes)) and len(value) == 0:
+        return
+    span.set_attribute(key, value)
+
+
+class OtelGenAIEmitter:
+    """Translate Hermes observability events into OTel GenAI spans.
+
+    Parameters
+    ----------
+    tracer:
+        An OpenTelemetry ``Tracer``. Injected so tests can pass an in-memory
+        tracer and the plugin can pass the globally-configured one.
+    agent_name:
+        Value for ``gen_ai.agent.name`` (defaults to ``hermes``).
+    capture_content:
+        When true, prompt/response text is attached to spans (gated because
+        content capture has privacy implications — off by default).
+    """
+
+    def __init__(
+        self,
+        tracer: Any,
+        *,
+        agent_name: str = DEFAULT_AGENT_NAME,
+        capture_content: bool = False,
+    ) -> None:
+        self._tracer = tracer
+        self._agent_name = agent_name
+        self._capture_content = capture_content
+
+    # -- turn / agent invocation -------------------------------------------
+
+    @contextmanager
+    def turn_span(
+        self,
+        *,
+        session_id: str | None,
+        model: str | None = None,
+        user_prompt: str | None = None,
+        extra: Mapping[str, Any] | None = None,
+    ) -> Iterator[Any]:
+        """Open the ``invoke_agent`` span for one Hermes turn.
+
+        This is the session-boundary span. ``gen_ai.conversation.id`` carries
+        the Hermes session id so any backend can group spans by session.
+        """
+        with self._tracer.start_as_current_span(OP_INVOKE_AGENT) as span:
+            span.set_attribute("gen_ai.operation.name", OP_INVOKE_AGENT)
+            span.set_attribute("gen_ai.system", GEN_AI_SYSTEM)
+            span.set_attribute("gen_ai.agent.name", self._agent_name)
+            _set_if(span, "gen_ai.conversation.id", session_id)
+            # Belt-and-suspenders: also stamp the bare session.id attribute
+            # some backends group on directly.
+            _set_if(span, "session.id", session_id)
+            _set_if(span, "gen_ai.request.model", model)
+            if self._capture_content:
+                _set_if(span, "gen_ai.prompt", user_prompt)
+            self._apply_extra(span, extra)
+            yield span
+
+    def stamp_completion(self, span: Any, response_text: str | None) -> None:
+        """Attach the model's response to an already-open ``invoke_agent`` span.
+
+        Hermes delivers the final response text on ``transform_llm_output``
+        (fired once per turn after the tool loop, before the turn closes) — the
+        per-call ``post_api_request`` hook carries only token/finish metadata,
+        not the text. Stamping it on the still-open turn span enables
+        response-side evaluation (toxicity / hallucination / output PII)
+        alongside the prompt-side eval. Content-gated; a no-op on a
+        missing/empty response, so it is safe to call unconditionally.
+        """
+        if self._capture_content:
+            _set_if(span, "gen_ai.completion", response_text)
+
+    # -- LLM call -----------------------------------------------------------
+
+    def record_llm_call(
+        self,
+        *,
+        request_model: str | None,
+        response_model: str | None = None,
+        input_tokens: int | None = None,
+        output_tokens: int | None = None,
+        cost_usd: float | None = None,
+        finish_reasons: Sequence[str] | None = None,
+        ttft_ms: float | None = None,
+        response_text: str | None = None,
+        extra: Mapping[str, Any] | None = None,
+    ) -> None:
+        """Emit one ``chat`` span for a single LLM API call.
+
+        Nested under the active ``invoke_agent`` span when called inside
+        :meth:`turn_span`. Carries tokens, cost, finish reason, and TTFT.
+        """
+        with self._tracer.start_as_current_span(OP_CHAT) as span:
+            span.set_attribute("gen_ai.operation.name", OP_CHAT)
+            span.set_attribute("gen_ai.system", GEN_AI_SYSTEM)
+            _set_if(span, "gen_ai.request.model", request_model)
+            _set_if(span, "gen_ai.response.model", response_model or request_model)
+            _set_if(span, "gen_ai.usage.input_tokens", _as_int(input_tokens))
+            _set_if(span, "gen_ai.usage.output_tokens", _as_int(output_tokens))
+            _set_if(span, "cost_usd", _as_float(cost_usd))
+            if finish_reasons:
+                # OTel models this as an array; backends read index [0].
+                span.set_attribute(
+                    "gen_ai.response.finish_reasons", list(finish_reasons)
+                )
+            # Map onto the shared TTFT field used across agent-coding telemetry
+            # (copilot_chat.time_to_first_token).
+            _set_if(span, "copilot_chat.time_to_first_token", _as_float(ttft_ms))
+            if self._capture_content:
+                _set_if(span, "gen_ai.completion", response_text)
+            self._apply_extra(span, extra)
+
+    # -- tool call ----------------------------------------------------------
+
+    def record_tool_call(
+        self,
+        *,
+        tool_name: str,
+        tool_type: str = "function",
+        arguments: Mapping[str, Any] | None = None,
+        result: Any = None,
+        error: BaseException | str | None = None,
+        extra: Mapping[str, Any] | None = None,
+    ) -> None:
+        """Emit one ``execute_tool`` span for a single tool call.
+
+        ``gen_ai.tool.name`` drives a per-session tool breakdown. Errors are
+        recorded on the span (not swallowed) so failed tool calls are visible.
+        """
+        with self._tracer.start_as_current_span(OP_EXECUTE_TOOL) as span:
+            span.set_attribute("gen_ai.operation.name", OP_EXECUTE_TOOL)
+            span.set_attribute("gen_ai.system", GEN_AI_SYSTEM)
+            span.set_attribute("gen_ai.tool.name", tool_name)
+            span.set_attribute("gen_ai.tool.type", tool_type)
+            if self._capture_content and arguments is not None:
+                # Best-effort: stringify so non-serializable args never crash
+                # observability (observability must never break the agent).
+                _set_if(span, "gen_ai.tool.arguments", _safe_str(arguments))
+            if self._capture_content and result is not None:
+                _set_if(span, "gen_ai.tool.result", _safe_str(result))
+            if error is not None:
+                self._record_error(span, error)
+            self._apply_extra(span, extra)
+
+    # -- helpers ------------------------------------------------------------
+
+    @staticmethod
+    def _record_error(span: Any, error: BaseException | str) -> None:
+        try:
+            if isinstance(error, BaseException):
+                span.record_exception(error)
+                span.set_attribute("error.type", type(error).__name__)
+            else:
+                span.set_attribute("error.type", str(error))
+        except Exception:  # pragma: no cover - defensive
+            logger.warning("failed to record tool error on span", exc_info=True)
+
+    @staticmethod
+    def _apply_extra(span: Any, extra: Mapping[str, Any] | None) -> None:
+        if not extra:
+            return
+        for key, value in extra.items():
+            try:
+                _set_if(span, key, value)
+            except Exception:  # pragma: no cover - defensive
+                logger.warning("dropping un-settable span attribute %s", key)
+
+
+def _as_int(value: Any) -> int | None:
+    if value is None:
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _as_float(value: Any) -> float | None:
+    if value is None:
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _safe_str(value: Any, limit: int = 8192) -> str:
+    try:
+        text = value if isinstance(value, str) else repr(value)
+    except Exception:  # pragma: no cover - defensive
+        return "<unrepr-able>"
+    return text if len(text) <= limit else text[:limit] + "...<truncated>"

--- a/plugins/observability/otel/log_emitter.py
+++ b/plugins/observability/otel/log_emitter.py
@@ -1,0 +1,244 @@
+# SPDX-License-Identifier: MIT
+"""OTel *log-record* emitter for the observability/otel plugin.
+
+Companion to :mod:`emitter` (which emits GenAI **spans**). The TraceVerse
+``/agent-coding`` dashboard is built from OTel **log records** — the
+``claude_code.*`` event model — not spans. Claude Code / Codex / Copilot emit
+log events, so they populate the dashboard; a spans-only agent does not.
+
+This module turns the same three Hermes observability concepts — *session*,
+*LLM API call*, *tool call* — into **log records** shaped like the records the
+dashboard already aggregates, so a Hermes session shows up in the Activity /
+Sessions / Leaderboards / breakdown views exactly like a Claude Code session.
+
+Field contract the dashboard aggregates on (see the agent-coding API routes):
+
+    attributes.event.name      session_start | api_response | tool_result
+    attributes.model           model id            (by_model breakdown)
+    attributes.tool_name       tool name           (by_tool breakdown)
+    attributes.cost_usd        float               (leaderboard cost sums)
+    attributes.input_tokens    int                 (leaderboard token sums)
+    attributes.output_tokens   int                 (leaderboard token sums)
+    attributes.decision_type   accept | reject ... (tool_result outcome)
+    attributes.decision_source where the decision came from
+
+Identity lives on the OTel **resource** (set in ``provider.build_logger``):
+
+    resource.service.name      agent.coding.hermes
+    resource.user.id / organization.id / team.id / session.id
+
+``session.id`` is per-session, so it is emitted as a *record* attribute too and
+the ingest ``agent-coding-router-pipeline`` promotes ``attributes.session.id``
+onto ``resource.session.id`` at index time (idempotent) — matching how real
+Claude Code telemetry (which also carries IDs as event attributes) is handled.
+
+Like every observability path here, this NEVER raises out into the agent.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from typing import Any, Mapping, Sequence
+
+logger = logging.getLogger(__name__)
+
+# Event names — `agent_coding.*` keeps them namespaced and obviously ours, while
+# the dashboard keys only on the bare `event.name` value (session_start /
+# api_response / tool_result) via the attribute promotions below.
+EVENT_SESSION_START = "session_start"
+EVENT_API_RESPONSE = "api_response"
+EVENT_TOOL_RESULT = "tool_result"
+
+GEN_AI_SYSTEM = "hermes"
+
+
+def _clean(attrs: dict[str, Any]) -> dict[str, Any]:
+    """Drop None / empty values so log records stay clean (OTel rejects None)."""
+    out: dict[str, Any] = {}
+    for k, v in attrs.items():
+        if v is None:
+            continue
+        if isinstance(v, str) and v == "":
+            continue
+        out[k] = v
+    return out
+
+
+def _as_int(value: Any) -> int | None:
+    if value is None:
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _as_float(value: Any) -> float | None:
+    if value is None:
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _safe_str(value: Any, limit: int = 8192) -> str:
+    try:
+        text = value if isinstance(value, str) else repr(value)
+    except Exception:  # pragma: no cover - defensive
+        return "<unrepr-able>"
+    return text if len(text) <= limit else text[:limit] + "...<truncated>"
+
+
+class OtelLogEmitter:
+    """Emit dashboard-shaped OTel log records for agent-coding sessions.
+
+    Parameters
+    ----------
+    otel_logger:
+        An OpenTelemetry ``Logger`` (from ``provider.build_logger``). When
+        ``None`` every method is a no-op, so callers need no extra guards.
+    agent_name:
+        Stamped as ``attributes.agent_type`` (mirrors Claude Code's field).
+    capture_content:
+        When true, prompt/response/tool text is attached to records.
+    """
+
+    def __init__(
+        self,
+        otel_logger: Any,
+        *,
+        agent_name: str = "hermes",
+        capture_content: bool = False,
+    ) -> None:
+        self._logger = otel_logger
+        self._agent_name = agent_name
+        self._capture_content = capture_content
+        self._seq = 0
+
+    @property
+    def enabled(self) -> bool:
+        return self._logger is not None
+
+    # -- low-level emit ----------------------------------------------------
+
+    def _emit(self, event_name: str, attributes: Mapping[str, Any], *, body: str | None = None) -> None:
+        if self._logger is None:
+            return
+        try:
+            from opentelemetry._logs import LogRecord, SeverityNumber
+
+            self._seq += 1
+            now_ns = time.time_ns()
+            attrs = _clean(
+                {
+                    "event.name": event_name,
+                    "agent_type": self._agent_name,
+                    "gen_ai.system": GEN_AI_SYSTEM,
+                    "event.sequence": self._seq,
+                    **dict(attributes),
+                }
+            )
+            record = LogRecord(
+                timestamp=now_ns,
+                observed_timestamp=now_ns,
+                severity_number=SeverityNumber.INFO,
+                severity_text="INFO",
+                body=body if body is not None else event_name,
+                attributes=attrs,
+            )
+            self._logger.emit(record)
+        except Exception:  # pragma: no cover - fail-open
+            logger.debug("OtelLogEmitter: failed to emit %s record", event_name, exc_info=True)
+
+    # -- session ----------------------------------------------------------
+
+    def session_start(
+        self,
+        *,
+        session_id: str | None,
+        model: str | None = None,
+        user_prompt: str | None = None,
+    ) -> None:
+        """Emit the session-boundary record (opens a session in the dashboard)."""
+        attrs: dict[str, Any] = {
+            "session.id": session_id,
+            "model": model,
+        }
+        if self._capture_content and user_prompt:
+            attrs["prompt"] = _safe_str(user_prompt)
+        self._emit(EVENT_SESSION_START, attrs, body=user_prompt if self._capture_content else None)
+
+    # -- LLM call ---------------------------------------------------------
+
+    def api_response(
+        self,
+        *,
+        session_id: str | None,
+        request_model: str | None,
+        response_model: str | None = None,
+        input_tokens: int | None = None,
+        output_tokens: int | None = None,
+        cost_usd: float | None = None,
+        finish_reasons: Sequence[str] | None = None,
+        ttft_ms: float | None = None,
+        response_text: str | None = None,
+    ) -> None:
+        """Emit one ``api_response`` record per LLM call.
+
+        Carries model + token usage + cost so the by_model breakdown and the
+        per-user / per-org leaderboard cost & token sums populate.
+        """
+        attrs: dict[str, Any] = {
+            "session.id": session_id,
+            "model": response_model or request_model,
+            "input_tokens": _as_int(input_tokens),
+            "output_tokens": _as_int(output_tokens),
+            "cost_usd": _as_float(cost_usd),
+        }
+        if finish_reasons:
+            attrs["finish_reason"] = list(finish_reasons)[0]
+        ttft = _as_float(ttft_ms)
+        if ttft is not None:
+            attrs["ttft_ms"] = ttft
+        # Response text rides on the record body (privacy-gated), not as a
+        # duplicate attribute — matching session_start's prompt handling.
+        self._emit(EVENT_API_RESPONSE, attrs, body=response_text if self._capture_content else None)
+
+    # -- tool call --------------------------------------------------------
+
+    def tool_result(
+        self,
+        *,
+        session_id: str | None,
+        tool_name: str,
+        tool_type: str = "function",
+        arguments: Mapping[str, Any] | None = None,
+        result: Any = None,
+        error: BaseException | str | None = None,
+    ) -> None:
+        """Emit one ``tool_result`` record per tool call.
+
+        Drives the by_tool breakdown and the post-execution tool-decision funnel
+        (decision_type / decision_source).
+        """
+        ok = error is None
+        attrs: dict[str, Any] = {
+            "session.id": session_id,
+            "tool_name": tool_name,
+            "tool_type": tool_type,
+            "status_code": "success" if ok else "error",
+            # The dashboard's post-exec funnel reads decision_type/source on
+            # tool_result events; for an auto-run agent the outcome is "executed".
+            "decision_type": "executed" if ok else "error",
+            "decision_source": "agent",
+        }
+        if not ok:
+            attrs["error"] = _safe_str(error if isinstance(error, str) else repr(error))
+            attrs["error_type"] = type(error).__name__ if isinstance(error, BaseException) else "ToolError"
+        if self._capture_content and arguments is not None:
+            attrs["tool_input"] = _safe_str(arguments)
+        if self._capture_content and result is not None:
+            attrs["tool_output"] = _safe_str(result)
+        self._emit(EVENT_TOOL_RESULT, attrs)

--- a/plugins/observability/otel/log_emitter.py
+++ b/plugins/observability/otel/log_emitter.py
@@ -13,7 +13,9 @@ Sessions / Leaderboards / breakdown views exactly like a Claude Code session.
 
 Field contract the dashboard aggregates on (see the agent-coding API routes):
 
-    attributes.event.name      session_start | api_response | tool_result
+    attributes.event.name      user_prompt | session_start | api_response | tool_result
+    attributes.prompt          user prompt text    (user_prompt, content-gated)
+    attributes.prompt_length   user prompt length  (user_prompt, always)
     attributes.model           model id            (by_model breakdown)
     attributes.tool_name       tool name           (by_tool breakdown)
     attributes.cost_usd        float               (leaderboard cost sums)
@@ -44,8 +46,11 @@ from typing import Any, Mapping, Sequence
 logger = logging.getLogger(__name__)
 
 # Event names — `agent_coding.*` keeps them namespaced and obviously ours, while
-# the dashboard keys only on the bare `event.name` value (session_start /
-# api_response / tool_result) via the attribute promotions below.
+# the dashboard keys only on the bare `event.name` value (user_prompt /
+# session_start / api_response / tool_result) via the attribute promotions below.
+# `user_prompt` matches Claude Code's `claude_code.user_prompt`, so Hermes
+# prompts populate the dashboard's Prompts count + prompt-text drill-down.
+EVENT_USER_PROMPT = "user_prompt"
 EVENT_SESSION_START = "session_start"
 EVENT_API_RESPONSE = "api_response"
 EVENT_TOOL_RESULT = "tool_result"
@@ -169,6 +174,45 @@ class OtelLogEmitter:
         if self._capture_content and user_prompt:
             attrs["prompt"] = _safe_str(user_prompt)
         self._emit(EVENT_SESSION_START, attrs, body=user_prompt if self._capture_content else None)
+
+    # -- user prompt ------------------------------------------------------
+
+    def user_prompt(
+        self,
+        *,
+        session_id: str | None,
+        prompt: str | None,
+        model: str | None = None,
+    ) -> None:
+        """Emit one ``user_prompt`` record per turn (the developer's input).
+
+        This is the record the TraceVerse ``/agent-coding`` dashboard keys on
+        for its prompt count and prompt-text drill-down — its event name
+        (``user_prompt``) matches Claude Code's ``claude_code.user_prompt``.
+
+        It exists because Hermes delivers the prompt to ``pre_llm_call`` (not
+        ``on_session_start``), and :mod:`emitter` only puts it on the span as
+        ``gen_ai.prompt`` — which the *log-record*-based dashboard never reads.
+        Without this record a Hermes session shows tool calls and API responses
+        but no prompts.
+
+        ``prompt_length`` is non-sensitive and always emitted; the prompt text
+        rides on ``attributes.prompt`` and the record body, both privacy-gated
+        by ``capture_content`` (and secret-redacted by the ingest pipeline).
+        """
+        attrs: dict[str, Any] = {
+            "session.id": session_id,
+            "model": model,
+        }
+        if prompt is not None:
+            attrs["prompt_length"] = len(prompt)
+        if self._capture_content and prompt:
+            attrs["prompt"] = _safe_str(prompt)
+        self._emit(
+            EVENT_USER_PROMPT,
+            attrs,
+            body=prompt if self._capture_content else None,
+        )
 
     # -- LLM call ---------------------------------------------------------
 

--- a/plugins/observability/otel/plugin.yaml
+++ b/plugins/observability/otel/plugin.yaml
@@ -1,0 +1,13 @@
+name: otel
+version: "0.2.0"
+description: "Optional OpenTelemetry (OTLP) observability for Hermes — exports turns, LLM calls, and tool usage as OTel GenAI-convention spans (gen_ai.*) AND dashboard-shaped OTLP log records, with local-model cost estimated from model size, to any OTLP backend. Opt in with `hermes plugins enable observability/otel`; HERMES_OTEL_* env vars configure spans, logs, and cost after the plugin is enabled."
+author: NousResearch
+hooks:
+  - on_session_start
+  - on_session_end
+  - on_session_finalize
+  - on_session_reset
+  - pre_llm_call
+  - transform_llm_output
+  - post_api_request
+  - post_tool_call

--- a/plugins/observability/otel/plugin.yaml
+++ b/plugins/observability/otel/plugin.yaml
@@ -1,5 +1,5 @@
 name: otel
-version: "0.2.0"
+version: "0.3.0"
 description: "Optional OpenTelemetry (OTLP) observability for Hermes — exports turns, LLM calls, and tool usage as OTel GenAI-convention spans (gen_ai.*) AND dashboard-shaped OTLP log records, with local-model cost estimated from model size, to any OTLP backend. Opt in with `hermes plugins enable observability/otel`; HERMES_OTEL_* env vars configure spans, logs, and cost after the plugin is enabled."
 author: NousResearch
 hooks:

--- a/plugins/observability/otel/provider.py
+++ b/plugins/observability/otel/provider.py
@@ -1,0 +1,301 @@
+# SPDX-License-Identifier: MIT
+"""Tracer-provider bootstrap for the observability/otel plugin.
+
+Two ways to get a tracer, in priority order:
+
+1. **genai_otel** — if the ``genai-otel-instrument`` library is installed, use
+   it. It is a reference OTel GenAI emitter and brings token/cost/latency
+   conventions plus optional on-prem GPU/energy metrics for free. Preferred.
+
+2. **plain OTel SDK** — fall back to a vanilla ``TracerProvider`` + OTLP HTTP
+   exporter so the plugin still works when ``genai_otel`` is not present. This
+   keeps the contribution's hard dependency surface minimal (OTel SDK only).
+
+A stable ``service.name`` is the single most important resource attribute: any
+OTel backend uses it to group the agent's telemetry. Default is
+``agent.coding.hermes``; override via config or ``OTEL_SERVICE_NAME`` /
+``OTEL_EXPORTER_OTLP_ENDPOINT`` env vars.
+
+This module performs no filesystem I/O — it exports over the network only — so
+``get_hermes_home()`` from ``hermes_constants`` is intentionally not used here.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_SERVICE_NAME = "agent.coding.hermes"
+DEFAULT_OTLP_ENDPOINT = "http://localhost:4318"
+INSTRUMENTATION_SCOPE = "hermes.observability.otel"
+
+
+def build_tracer(
+    *,
+    service_name: str | None = None,
+    otlp_endpoint: str | None = None,
+    user_id: str | None = None,
+    capture_content: bool = False,
+) -> Any:
+    """Return an OpenTelemetry ``Tracer`` for the plugin.
+
+    Resolves ``service_name`` / ``otlp_endpoint`` from arguments first, then
+    standard OTel env vars, then sane on-prem defaults. Never raises on
+    transport problems — observability must not crash the agent; on failure we
+    log and return a no-op tracer.
+    """
+    service_name = (
+        service_name
+        or os.environ.get("OTEL_SERVICE_NAME")
+        or DEFAULT_SERVICE_NAME
+    )
+    otlp_endpoint = (
+        otlp_endpoint
+        or os.environ.get("OTEL_EXPORTER_OTLP_ENDPOINT")
+        or DEFAULT_OTLP_ENDPOINT
+    )
+
+    tracer = _try_genai_otel(
+        service_name=service_name,
+        otlp_endpoint=otlp_endpoint,
+        user_id=user_id,
+        capture_content=capture_content,
+    )
+    if tracer is not None:
+        return tracer
+    return _build_plain_otel(service_name=service_name, otlp_endpoint=otlp_endpoint)
+
+
+def _add_resource_attr(key: str, value: str) -> None:
+    """Append ``key=value`` to OTEL_RESOURCE_ATTRIBUTES if not already present.
+
+    Resource attributes are read by the OTel SDK at provider-init time, so this
+    must run before the tracer provider is built. Avoids depending on a
+    library-specific kwarg for identity attributes like ``user.id``.
+    """
+    existing = os.environ.get("OTEL_RESOURCE_ATTRIBUTES", "")
+    if f"{key}=" in existing:
+        return
+    pair = f"{key}={value}"
+    os.environ["OTEL_RESOURCE_ATTRIBUTES"] = (
+        f"{existing},{pair}" if existing else pair
+    )
+
+
+def _try_genai_otel(
+    *,
+    service_name: str,
+    otlp_endpoint: str,
+    user_id: str | None,
+    capture_content: bool,
+) -> Any | None:
+    """Preferred path: instrument via genai-otel-instrument if available."""
+    try:
+        import genai_otel  # type: ignore[import-not-found]
+    except ImportError:
+        logger.info(
+            "genai-otel-instrument not installed; using plain OTel SDK path"
+        )
+        return None
+
+    try:
+        # genai_otel.instrument() configures the global tracer provider + OTLP
+        # exporter with the GenAI conventions. ``user_id`` is passed via
+        # OTEL_RESOURCE_ATTRIBUTES rather than a kwarg, so it is not forwarded
+        # here. We keep the call to documented-stable keys only.
+        instrument_kwargs: dict[str, Any] = {
+            "service_name": service_name,
+            "endpoint": otlp_endpoint,
+            "enable_content_capture": capture_content,
+        }
+        if user_id:
+            # Best-effort: surface the user on every span's resource without
+            # depending on a kwarg the library may not accept.
+            _add_resource_attr("user.id", user_id)
+        genai_otel.instrument(**instrument_kwargs)
+        from opentelemetry import trace
+
+        return trace.get_tracer(INSTRUMENTATION_SCOPE)
+    except Exception:
+        logger.warning(
+            "genai-otel-instrument present but instrument() failed; "
+            "falling back to plain OTel SDK",
+            exc_info=True,
+        )
+        return None
+
+
+def _build_plain_otel(*, service_name: str, otlp_endpoint: str) -> Any:
+    """Fallback path: vanilla OTel SDK + OTLP HTTP exporter."""
+    try:
+        from opentelemetry import trace
+        from opentelemetry.exporter.otlp.proto.http.trace_exporter import (
+            OTLPSpanExporter,
+        )
+        from opentelemetry.sdk.resources import Resource
+        from opentelemetry.sdk.trace import TracerProvider
+        from opentelemetry.sdk.trace.export import BatchSpanProcessor
+
+        resource = Resource.create(
+            {
+                "service.name": service_name,
+                "gen_ai.system": "hermes",
+            }
+        )
+        provider = TracerProvider(resource=resource)
+        # OTLP HTTP traces endpoint convention is <endpoint>/v1/traces.
+        exporter = OTLPSpanExporter(
+            endpoint=otlp_endpoint.rstrip("/") + "/v1/traces"
+        )
+        provider.add_span_processor(BatchSpanProcessor(exporter))
+        # Only set the global provider if one is not already configured, to
+        # avoid clobbering a host application's tracing setup.
+        current = trace.get_tracer_provider()
+        if not isinstance(current, TracerProvider):
+            trace.set_tracer_provider(provider)
+            active = provider
+        else:
+            active = current
+        logger.info(
+            "OTel SDK tracer configured: service.name=%s endpoint=%s",
+            service_name,
+            otlp_endpoint,
+        )
+        return active.get_tracer(INSTRUMENTATION_SCOPE)
+    except Exception:
+        logger.error(
+            "failed to configure OTel SDK tracer; observability disabled",
+            exc_info=True,
+        )
+        return _noop_tracer()
+
+
+def _noop_tracer() -> Any:
+    """Return a tracer from the API's default no-op provider.
+
+    Guarantees the plugin never crashes the agent even if the SDK is missing.
+    """
+    from opentelemetry import trace
+
+    return trace.get_tracer(INSTRUMENTATION_SCOPE)
+
+
+# ---------------------------------------------------------------------------
+# OTel *logs* pipeline (separate from the spans pipeline above).
+#
+# The TraceVerse agent-coding dashboard is built from OTel **log records** (the
+# `claude_code.*` event model), not spans. Claude Code / Codex / Copilot emit
+# log events, so they populate the dashboard; a spans-only agent does not.
+# build_logger() gives the plugin a LoggerProvider + OTLP **log** exporter so it
+# can ALSO emit dashboard-shaped `agent.coding.*` log records alongside its
+# GenAI spans — making Hermes a first-class citizen of the `/agent-coding` view.
+#
+# Identity (session.id / user.id / organization.id / team.id) is placed on the
+# OTel **resource** so it matches the `resource.*` shape the dashboard aggregates
+# on (by_user / by_org leaderboards, session cardinality).
+# ---------------------------------------------------------------------------
+
+
+def _resource_attrs_from_env(service_name: str, user_id: str | None) -> dict:
+    """Build the resource attribute dict for the logs pipeline.
+
+    Reads OTEL_RESOURCE_ATTRIBUTES (k=v,k=v) for team.id / organization.id /
+    deployment.environment / user.id, then overlays explicit args. The same
+    identity the spans resource carries, surfaced as proper resource keys so the
+    dashboard's resource.* aggregations work without relying on the ingest
+    pipeline's attribute->resource promotion.
+    """
+    attrs: dict[str, Any] = {
+        "service.name": service_name,
+        "gen_ai.system": "hermes",
+    }
+    raw = os.environ.get("OTEL_RESOURCE_ATTRIBUTES", "")
+    for pair in raw.split(","):
+        pair = pair.strip()
+        if "=" in pair:
+            k, v = pair.split("=", 1)
+            k, v = k.strip(), v.strip()
+            if k and v:
+                attrs[k] = v
+    if user_id:
+        attrs["user.id"] = user_id
+    return attrs
+
+
+def _flush_logger_provider(provider: Any) -> None:
+    """Best-effort flush+shutdown of the logs provider at interpreter exit."""
+    try:
+        provider.force_flush()
+    except Exception:  # pragma: no cover - defensive
+        pass
+    try:
+        provider.shutdown()
+    except Exception:  # pragma: no cover - defensive
+        pass
+
+
+def build_logger(
+    *,
+    service_name: str | None = None,
+    otlp_endpoint: str | None = None,
+    user_id: str | None = None,
+) -> Any:
+    """Return an OpenTelemetry ``Logger`` for emitting dashboard log records.
+
+    Never raises on transport/SDK problems — observability must not crash the
+    agent; on failure we log and return ``None`` (callers treat ``None`` as
+    "logs disabled" and simply skip log emission, keeping spans working).
+    """
+    service_name = (
+        service_name
+        or os.environ.get("OTEL_SERVICE_NAME")
+        or DEFAULT_SERVICE_NAME
+    )
+    otlp_endpoint = (
+        otlp_endpoint
+        or os.environ.get("OTEL_EXPORTER_OTLP_ENDPOINT")
+        or DEFAULT_OTLP_ENDPOINT
+    )
+    try:
+        from opentelemetry._logs import get_logger, set_logger_provider
+        from opentelemetry.exporter.otlp.proto.http._log_exporter import (
+            OTLPLogExporter,
+        )
+        from opentelemetry.sdk._logs import LoggerProvider
+        from opentelemetry.sdk._logs.export import BatchLogRecordProcessor
+        from opentelemetry.sdk.resources import Resource
+
+        resource = Resource.create(_resource_attrs_from_env(service_name, user_id))
+        provider = LoggerProvider(resource=resource)
+        # OTLP HTTP logs endpoint convention is <endpoint>/v1/logs.
+        exporter = OTLPLogExporter(endpoint=otlp_endpoint.rstrip("/") + "/v1/logs")
+        provider.add_log_record_processor(BatchLogRecordProcessor(exporter))
+        # Flush on interpreter exit. The span pipeline is flushed by Hermes'
+        # shutdown path, but this LoggerProvider is ours alone — without an
+        # explicit flush, late-turn records (api_response / tool_result emitted
+        # just before the CLI exits) can be dropped by the batch processor.
+        import atexit
+
+        atexit.register(_flush_logger_provider, provider)
+        # Only adopt as the global provider if none is set, mirroring the tracer
+        # path — don't clobber a host application's logging setup.
+        try:
+            set_logger_provider(provider)
+        except Exception:  # pragma: no cover - provider already set
+            pass
+        logger.info(
+            "OTel SDK logger configured: service.name=%s endpoint=%s",
+            service_name,
+            otlp_endpoint,
+        )
+        return get_logger(INSTRUMENTATION_SCOPE, logger_provider=provider)
+    except Exception:
+        logger.warning(
+            "failed to configure OTel SDK logger; dashboard log records disabled "
+            "(spans still emit)",
+            exc_info=True,
+        )
+        return None

--- a/tests/plugins/test_otel_plugin.py
+++ b/tests/plugins/test_otel_plugin.py
@@ -1,0 +1,630 @@
+"""Tests for the bundled observability/otel plugin.
+
+These exercise the span-mapping core, the dashboard log-record emitter, and the
+local-model cost estimator with in-memory OTel exporters, so they run with only
+``opentelemetry-sdk`` installed (no Hermes runtime, no network). They assert
+that Hermes turn / LLM-call / tool-call events become the expected ``gen_ai.*``
+GenAI-convention **spans** *and* the dashboard-shaped OTLP **log records**, that
+local-model cost is estimated from model size, and that the plugin's
+``register(ctx)`` + hook surface matches the real Hermes plugin contract.
+"""
+from __future__ import annotations
+
+import importlib
+import sys
+from pathlib import Path
+
+import pytest
+import yaml
+from opentelemetry._logs import get_logger, set_logger_provider
+from opentelemetry.sdk._logs import LoggerProvider
+from opentelemetry.sdk._logs.export import (
+    InMemoryLogRecordExporter,
+    SimpleLogRecordProcessor,
+)
+from opentelemetry.sdk.resources import Resource
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import (
+    InMemorySpanExporter,
+)
+
+from plugins.observability.otel.cost import (
+    estimate_cost_usd,
+    extract_param_count_billions,
+)
+from plugins.observability.otel.emitter import (
+    OP_CHAT,
+    OP_EXECUTE_TOOL,
+    OP_INVOKE_AGENT,
+    OtelGenAIEmitter,
+)
+from plugins.observability.otel.log_emitter import (
+    EVENT_API_RESPONSE,
+    EVENT_SESSION_START,
+    EVENT_TOOL_RESULT,
+    OtelLogEmitter,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+PLUGIN_DIR = REPO_ROOT / "plugins" / "observability" / "otel"
+
+
+# ---------------------------------------------------------------------------
+# Manifest + layout
+# ---------------------------------------------------------------------------
+
+
+class TestManifest:
+    def test_plugin_directory_exists(self):
+        assert PLUGIN_DIR.is_dir()
+        assert (PLUGIN_DIR / "plugin.yaml").exists()
+        assert (PLUGIN_DIR / "__init__.py").exists()
+
+    def test_manifest_fields(self):
+        data = yaml.safe_load((PLUGIN_DIR / "plugin.yaml").read_text(encoding="utf-8"))
+        assert data["name"] == "otel"
+        assert data["version"]
+        # Hooks the plugin implements — must match register() exactly.
+        assert set(data["hooks"]) == {
+            "on_session_start",
+            "on_session_end",
+            "on_session_finalize",
+            "on_session_reset",
+            "pre_llm_call",
+            "transform_llm_output",
+            "post_api_request",
+            "post_tool_call",
+        }
+
+
+# ---------------------------------------------------------------------------
+# Emitter: pure span-mapping core, no Hermes import.
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def exporter_and_tracer():
+    exporter = InMemorySpanExporter()
+    provider = TracerProvider()
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+    tracer = provider.get_tracer("test")
+    return exporter, tracer
+
+
+@pytest.fixture()
+def log_exporter_and_logger():
+    """In-memory OTLP *log* pipeline — keeps the log-record tests hermetic.
+
+    ``SimpleLogRecordProcessor`` flushes synchronously, so emitted records are
+    immediately readable via ``get_finished_logs()`` with no network and no
+    batch-timer wait.
+    """
+    exporter = InMemoryLogRecordExporter()
+    provider = LoggerProvider(resource=Resource.create({"service.name": "test"}))
+    provider.add_log_record_processor(SimpleLogRecordProcessor(exporter))
+    otel_logger = get_logger("test", logger_provider=provider)
+    return exporter, otel_logger
+
+
+def _by_name(spans):
+    return {s.name: s for s in spans}
+
+
+def _log_attrs(records):
+    """Map ``event.name`` → attributes dict for the finished log records."""
+    out: dict[str, dict] = {}
+    for r in records:
+        attrs = dict(r.log_record.attributes or {})
+        name = attrs.get("event.name")
+        if name is not None:
+            out[name] = attrs
+    return out
+
+
+class TestEmitter:
+    def test_turn_span_carries_session_and_agent(self, exporter_and_tracer):
+        exporter, tracer = exporter_and_tracer
+        emitter = OtelGenAIEmitter(tracer, capture_content=False)
+
+        with emitter.turn_span(session_id="sess-123", model="hermes-llama-70b"):
+            pass
+
+        spans = _by_name(exporter.get_finished_spans())
+        assert OP_INVOKE_AGENT in spans
+        attrs = spans[OP_INVOKE_AGENT].attributes
+        assert attrs["gen_ai.operation.name"] == OP_INVOKE_AGENT
+        assert attrs["gen_ai.system"] == "hermes"
+        assert attrs["gen_ai.agent.name"] == "hermes"
+        assert attrs["gen_ai.conversation.id"] == "sess-123"
+        assert attrs["session.id"] == "sess-123"
+        assert attrs["gen_ai.request.model"] == "hermes-llama-70b"
+
+    def test_chat_span_carries_tokens_cost_and_finish_reason(self, exporter_and_tracer):
+        exporter, tracer = exporter_and_tracer
+        emitter = OtelGenAIEmitter(tracer)
+
+        with emitter.turn_span(session_id="sess-1"):
+            emitter.record_llm_call(
+                request_model="hermes-llama-70b",
+                input_tokens=100,
+                output_tokens=42,
+                cost_usd=0.0031,
+                finish_reasons=["stop"],
+                ttft_ms=180.0,
+            )
+
+        spans = _by_name(exporter.get_finished_spans())
+        assert OP_CHAT in spans
+        attrs = spans[OP_CHAT].attributes
+        assert attrs["gen_ai.operation.name"] == OP_CHAT
+        assert attrs["gen_ai.usage.input_tokens"] == 100
+        assert attrs["gen_ai.usage.output_tokens"] == 42
+        assert attrs["cost_usd"] == pytest.approx(0.0031)
+        assert list(attrs["gen_ai.response.finish_reasons"]) == ["stop"]
+        assert attrs["copilot_chat.time_to_first_token"] == pytest.approx(180.0)
+
+    def test_chat_span_nested_under_turn(self, exporter_and_tracer):
+        exporter, tracer = exporter_and_tracer
+        emitter = OtelGenAIEmitter(tracer)
+
+        with emitter.turn_span(session_id="sess-1", model="m"):
+            emitter.record_llm_call(request_model="m", input_tokens=1, output_tokens=1)
+
+        spans = _by_name(exporter.get_finished_spans())
+        chat = spans[OP_CHAT]
+        invoke = spans[OP_INVOKE_AGENT]
+        assert chat.parent is not None
+        assert chat.parent.span_id == invoke.context.span_id
+        assert chat.context.trace_id == invoke.context.trace_id
+
+    def test_execute_tool_span_carries_tool_name_and_type(self, exporter_and_tracer):
+        exporter, tracer = exporter_and_tracer
+        emitter = OtelGenAIEmitter(tracer)
+
+        emitter.record_tool_call(tool_name="apply_patch", tool_type="function")
+
+        spans = _by_name(exporter.get_finished_spans())
+        assert OP_EXECUTE_TOOL in spans
+        attrs = spans[OP_EXECUTE_TOOL].attributes
+        assert attrs["gen_ai.operation.name"] == OP_EXECUTE_TOOL
+        assert attrs["gen_ai.tool.name"] == "apply_patch"
+        assert attrs["gen_ai.tool.type"] == "function"
+
+    def test_tool_error_is_recorded_not_raised(self, exporter_and_tracer):
+        exporter, tracer = exporter_and_tracer
+        emitter = OtelGenAIEmitter(tracer)
+
+        # A failing tool call must not propagate out of observability.
+        emitter.record_tool_call(tool_name="run_tests", error=RuntimeError("boom"))
+
+        spans = _by_name(exporter.get_finished_spans())
+        attrs = spans[OP_EXECUTE_TOOL].attributes
+        assert attrs["error.type"] == "RuntimeError"
+
+    def test_content_not_captured_by_default(self, exporter_and_tracer):
+        exporter, tracer = exporter_and_tracer
+        emitter = OtelGenAIEmitter(tracer, capture_content=False)
+
+        with emitter.turn_span(session_id="s", user_prompt="secret prompt"):
+            emitter.record_llm_call(request_model="m", response_text="secret response")
+
+        spans = _by_name(exporter.get_finished_spans())
+        assert "gen_ai.prompt" not in spans[OP_INVOKE_AGENT].attributes
+        assert "gen_ai.completion" not in spans[OP_CHAT].attributes
+
+    def test_content_captured_when_enabled(self, exporter_and_tracer):
+        exporter, tracer = exporter_and_tracer
+        emitter = OtelGenAIEmitter(tracer, capture_content=True)
+
+        with emitter.turn_span(session_id="s", user_prompt="hello"):
+            emitter.record_llm_call(request_model="m", response_text="world")
+
+        spans = _by_name(exporter.get_finished_spans())
+        assert spans[OP_INVOKE_AGENT].attributes["gen_ai.prompt"] == "hello"
+        assert spans[OP_CHAT].attributes["gen_ai.completion"] == "world"
+
+
+# ---------------------------------------------------------------------------
+# Cost estimator: local-model size → price-tier, mirrors genai-otel-instrument.
+# ---------------------------------------------------------------------------
+
+
+class TestCostEstimator:
+    @pytest.mark.parametrize(
+        ("model", "expected"),
+        [
+            ("llama3.1:8b", 8.0),
+            ("qwen3:0.6b", 0.6),
+            ("smollm2:360m", 0.36),
+            ("llama3.3:70b-instruct", 70.0),
+            ("phi3:14b", 14.0),
+        ],
+    )
+    def test_extract_param_count_from_suffix(self, model, expected):
+        assert extract_param_count_billions(model) == pytest.approx(expected)
+
+    def test_extract_param_count_from_hf_name_map(self):
+        assert extract_param_count_billions("gpt2") == pytest.approx(0.124)
+        assert extract_param_count_billions("t5-small") == pytest.approx(0.06)
+
+    def test_extract_param_count_unknown_returns_none(self):
+        assert extract_param_count_billions("some-mystery-model") is None
+        assert extract_param_count_billions("") is None
+
+    def test_cost_formula_matches_size_tier(self):
+        # 8B → 1–10B tier: (0.0003 prompt, 0.0006 completion) per 1K tokens.
+        # 1000 in + 1000 out → 0.0003 + 0.0006 = 0.0009.
+        assert estimate_cost_usd("llama3.1:8b", 1000, 1000) == pytest.approx(0.0009)
+
+    def test_cost_tier_boundaries(self):
+        # < 1B tier (0.0001, 0.0002): 0.6B model.
+        assert estimate_cost_usd("qwen3:0.6b", 1000, 1000) == pytest.approx(0.0003)
+        # 80B+ XLARGE tier (0.0012, 0.0012): 120B model.
+        assert estimate_cost_usd("bigmodel:120b", 1000, 1000) == pytest.approx(0.0024)
+
+    def test_cost_none_when_size_unknown(self):
+        assert estimate_cost_usd("mystery-model", 100, 100) is None
+
+    def test_cost_none_when_no_tokens(self):
+        assert estimate_cost_usd("llama3.1:8b", 0, 0) is None
+        assert estimate_cost_usd("llama3.1:8b", None, None) is None
+
+    def test_cost_handles_one_sided_tokens(self):
+        # output-only is valid (completion price only).
+        assert estimate_cost_usd("llama3.1:8b", 0, 1000) == pytest.approx(0.0006)
+
+
+# ---------------------------------------------------------------------------
+# Log emitter: dashboard-shaped OTLP log records, in-memory log exporter.
+# ---------------------------------------------------------------------------
+
+
+class TestLogEmitter:
+    def test_disabled_when_logger_is_none(self):
+        emitter = OtelLogEmitter(None)
+        assert emitter.enabled is False
+        # Every method is a safe no-op when there is no logger.
+        emitter.session_start(session_id="s")
+        emitter.api_response(session_id="s", request_model="m")
+        emitter.tool_result(session_id="s", tool_name="t")
+
+    def test_session_start_record_shape(self, log_exporter_and_logger):
+        exporter, otel_logger = log_exporter_and_logger
+        emitter = OtelLogEmitter(otel_logger, agent_name="hermes")
+
+        emitter.session_start(session_id="sess-1", model="llama3.1:8b")
+
+        attrs = _log_attrs(exporter.get_finished_logs())
+        assert EVENT_SESSION_START in attrs
+        rec = attrs[EVENT_SESSION_START]
+        assert rec["event.name"] == EVENT_SESSION_START
+        assert rec["session.id"] == "sess-1"
+        assert rec["model"] == "llama3.1:8b"
+        assert rec["agent_type"] == "hermes"
+        assert rec["gen_ai.system"] == "hermes"
+        assert rec["event.sequence"] == 1
+
+    def test_api_response_record_carries_tokens_and_cost(self, log_exporter_and_logger):
+        exporter, otel_logger = log_exporter_and_logger
+        emitter = OtelLogEmitter(otel_logger)
+
+        emitter.api_response(
+            session_id="sess-1",
+            request_model="llama3.1:8b",
+            response_model="llama3.1:8b-instruct",
+            input_tokens=120,
+            output_tokens=34,
+            cost_usd=0.0009,
+            finish_reasons=["stop", "length"],
+            ttft_ms=210.0,
+        )
+
+        rec = _log_attrs(exporter.get_finished_logs())[EVENT_API_RESPONSE]
+        # response_model wins for the by_model breakdown.
+        assert rec["model"] == "llama3.1:8b-instruct"
+        assert rec["input_tokens"] == 120
+        assert rec["output_tokens"] == 34
+        assert rec["cost_usd"] == pytest.approx(0.0009)
+        assert rec["finish_reason"] == "stop"  # first only
+        assert rec["ttft_ms"] == pytest.approx(210.0)
+
+    def test_tool_result_success_record(self, log_exporter_and_logger):
+        exporter, otel_logger = log_exporter_and_logger
+        emitter = OtelLogEmitter(otel_logger)
+
+        emitter.tool_result(session_id="sess-1", tool_name="read_file", tool_type="function")
+
+        rec = _log_attrs(exporter.get_finished_logs())[EVENT_TOOL_RESULT]
+        assert rec["tool_name"] == "read_file"
+        assert rec["tool_type"] == "function"
+        assert rec["status_code"] == "success"
+        assert rec["decision_type"] == "executed"
+        assert rec["decision_source"] == "agent"
+        assert "error" not in rec
+
+    def test_tool_result_error_record(self, log_exporter_and_logger):
+        exporter, otel_logger = log_exporter_and_logger
+        emitter = OtelLogEmitter(otel_logger)
+
+        emitter.tool_result(
+            session_id="sess-1",
+            tool_name="run_tests",
+            error=RuntimeError("boom"),
+        )
+
+        rec = _log_attrs(exporter.get_finished_logs())[EVENT_TOOL_RESULT]
+        assert rec["status_code"] == "error"
+        assert rec["decision_type"] == "error"
+        assert rec["error_type"] == "RuntimeError"
+        assert "boom" in rec["error"]
+
+    def test_content_not_captured_by_default(self, log_exporter_and_logger):
+        exporter, otel_logger = log_exporter_and_logger
+        emitter = OtelLogEmitter(otel_logger, capture_content=False)
+
+        emitter.session_start(session_id="s", user_prompt="secret prompt")
+        emitter.tool_result(
+            session_id="s",
+            tool_name="t",
+            arguments={"path": "secret.txt"},
+            result="secret output",
+        )
+
+        attrs = _log_attrs(exporter.get_finished_logs())
+        assert "prompt" not in attrs[EVENT_SESSION_START]
+        assert "tool_input" not in attrs[EVENT_TOOL_RESULT]
+        assert "tool_output" not in attrs[EVENT_TOOL_RESULT]
+
+    def test_content_captured_when_enabled(self, log_exporter_and_logger):
+        exporter, otel_logger = log_exporter_and_logger
+        emitter = OtelLogEmitter(otel_logger, capture_content=True)
+
+        emitter.session_start(session_id="s", user_prompt="hello there")
+        emitter.tool_result(
+            session_id="s",
+            tool_name="t",
+            arguments={"path": "a.txt"},
+            result="done",
+        )
+
+        attrs = _log_attrs(exporter.get_finished_logs())
+        assert attrs[EVENT_SESSION_START]["prompt"] == "hello there"
+        assert "a.txt" in attrs[EVENT_TOOL_RESULT]["tool_input"]
+        assert "done" in attrs[EVENT_TOOL_RESULT]["tool_output"]
+
+    def test_emit_never_raises_on_bad_logger(self):
+        class _BoomLogger:
+            def emit(self, *_a, **_k):
+                raise RuntimeError("transport down")
+
+        emitter = OtelLogEmitter(_BoomLogger())
+        # Must be swallowed — observability never breaks the agent.
+        emitter.session_start(session_id="s")
+        emitter.api_response(session_id="s", request_model="m")
+        emitter.tool_result(session_id="s", tool_name="t")
+
+
+# ---------------------------------------------------------------------------
+# Plugin adapter: drives the emitter from the real Hermes hook surface
+# (register(ctx) + **kwargs hooks). Uses a fake ctx that records hooks.
+# ---------------------------------------------------------------------------
+
+
+class _FakeCtx:
+    """Minimal stand-in for the Hermes plugin context."""
+
+    def __init__(self):
+        self.hooks: dict[str, object] = {}
+
+    def register_hook(self, name, fn):
+        self.hooks[name] = fn
+
+
+def _fresh_plugin():
+    """Import the plugin module fresh (clears any cached emitter).
+
+    Returns ``(plugin_module, provider_module)`` so callers can monkeypatch
+    ``provider.build_tracer`` on the live module object (robust to the
+    package being re-imported between tests).
+    """
+    mod_name = "plugins.observability.otel"
+    sys.modules.pop(mod_name, None)
+    mod = importlib.import_module(mod_name)
+    provider = importlib.import_module(mod_name + ".provider")
+    mod.reset_for_tests()
+    return mod, provider
+
+
+def _in_memory_logger():
+    """Build an OTel logger backed by an in-memory exporter (no network).
+
+    Used to monkeypatch ``provider.build_logger`` in the adapter tests so the
+    dashboard log emitter never tries to reach a real OTLP endpoint.
+    """
+    exporter = InMemoryLogRecordExporter()
+    provider = LoggerProvider(resource=Resource.create({"service.name": "test"}))
+    provider.add_log_record_processor(SimpleLogRecordProcessor(exporter))
+    return exporter, get_logger("test", logger_provider=provider)
+
+
+class TestPluginAdapter:
+    def test_register_wires_the_documented_hooks(self):
+        plugin, _provider = _fresh_plugin()
+        ctx = _FakeCtx()
+        plugin.register(ctx)
+        assert set(ctx.hooks) == {
+            "on_session_start",
+            "on_session_end",
+            "on_session_finalize",
+            "on_session_reset",
+            "pre_llm_call",
+            "transform_llm_output",
+            "post_api_request",
+            "post_tool_call",
+        }
+
+    def test_prompt_and_response_stamped_for_eval(self, exporter_and_tracer, monkeypatch):
+        """The prompt arrives on ``pre_llm_call`` and the response on
+        ``transform_llm_output`` (``on_session_start`` carries only the session
+        id and ``post_api_request`` only token/finish metadata). Both must be
+        stamped on the open ``invoke_agent`` span so prompt-side eval (PII /
+        injection / restricted-topics) AND response-side eval (toxicity /
+        hallucination / output PII) can score the turn."""
+        monkeypatch.setenv("HERMES_OTEL_CAPTURE_CONTENT", "true")
+        exporter, tracer = exporter_and_tracer
+        plugin, provider = _fresh_plugin()
+        monkeypatch.setattr(provider, "build_tracer", lambda **_: tracer)
+        _log_exporter, otel_logger = _in_memory_logger()
+        monkeypatch.setattr(provider, "build_logger", lambda **_: otel_logger)
+
+        ctx = _FakeCtx()
+        plugin.register(ctx)
+        ctx.hooks["on_session_start"](session_id="sess-p", model="hermes-x")
+        ctx.hooks["pre_llm_call"](
+            session_id="sess-p",
+            user_message="email the report to john@example.com",
+        )
+        # transform_llm_output is a read-only observer: returns None (output
+        # unchanged) but lets us capture the response for eval.
+        result = ctx.hooks["transform_llm_output"](
+            session_id="sess-p",
+            response_text="Sure — sending it to john@example.com now.",
+        )
+        assert result is None  # must never alter the model output
+        ctx.hooks["on_session_end"](session_id="sess-p")
+
+        attrs = _by_name(exporter.get_finished_spans())[OP_INVOKE_AGENT].attributes
+        assert attrs["gen_ai.prompt"] == "email the report to john@example.com"
+        assert attrs["gen_ai.completion"] == "Sure — sending it to john@example.com now."
+
+    def test_prompt_and_response_gated_by_capture_content(
+        self, exporter_and_tracer, monkeypatch
+    ):
+        """With content capture OFF neither prompt nor response is attached."""
+        monkeypatch.setenv("HERMES_OTEL_CAPTURE_CONTENT", "false")
+        exporter, tracer = exporter_and_tracer
+        plugin, provider = _fresh_plugin()
+        monkeypatch.setattr(provider, "build_tracer", lambda **_: tracer)
+        _log_exporter, otel_logger = _in_memory_logger()
+        monkeypatch.setattr(provider, "build_logger", lambda **_: otel_logger)
+
+        ctx = _FakeCtx()
+        plugin.register(ctx)
+        ctx.hooks["on_session_start"](session_id="sess-q", model="m")
+        ctx.hooks["pre_llm_call"](session_id="sess-q", user_message="secret prompt")
+        assert ctx.hooks["transform_llm_output"](
+            session_id="sess-q", response_text="secret response"
+        ) is None
+        ctx.hooks["on_session_end"](session_id="sess-q")
+
+        attrs = _by_name(exporter.get_finished_spans())[OP_INVOKE_AGENT].attributes
+        assert "gen_ai.prompt" not in attrs
+        assert "gen_ai.completion" not in attrs
+
+    def test_hooks_map_hermes_events_end_to_end(self, exporter_and_tracer, monkeypatch):
+        exporter, tracer = exporter_and_tracer
+        plugin, provider = _fresh_plugin()
+        # Inject our in-memory tracer + logger instead of the network-bound ones.
+        monkeypatch.setattr(provider, "build_tracer", lambda **_: tracer)
+        log_exporter, otel_logger = _in_memory_logger()
+        monkeypatch.setattr(provider, "build_logger", lambda **_: otel_logger)
+
+        ctx = _FakeCtx()
+        plugin.register(ctx)
+
+        ctx.hooks["on_session_start"](session_id="sess-9", model="hermes-x")
+        # The per-turn invoke_agent span opens on pre_llm_call and closes on
+        # transform_llm_output (one span per turn).
+        ctx.hooks["pre_llm_call"](session_id="sess-9", model="hermes-x", user_message="hi")
+        ctx.hooks["post_api_request"](
+            session_id="sess-9",
+            model="hermes-x",
+            usage={"input_tokens": 50, "output_tokens": 10},
+            cost_usd=0.0009,
+            finish_reason="stop",
+        )
+        ctx.hooks["post_tool_call"](
+            session_id="sess-9", tool_name="read_file", args={"path": "a.txt"}
+        )
+        ctx.hooks["transform_llm_output"](session_id="sess-9", response_text="done")
+        ctx.hooks["on_session_end"](session_id="sess-9")
+
+        names = sorted(s.name for s in exporter.get_finished_spans())
+        assert names == [OP_CHAT, OP_EXECUTE_TOOL, OP_INVOKE_AGENT]
+
+        spans = _by_name(exporter.get_finished_spans())
+        assert spans[OP_INVOKE_AGENT].attributes["gen_ai.conversation.id"] == "sess-9"
+        assert spans[OP_CHAT].attributes["gen_ai.usage.input_tokens"] == 50
+        assert list(spans[OP_CHAT].attributes["gen_ai.response.finish_reasons"]) == ["stop"]
+        assert spans[OP_EXECUTE_TOOL].attributes["gen_ai.tool.name"] == "read_file"
+
+        # The richer scope ALSO emits dashboard log records for the same events.
+        log_attrs = _log_attrs(log_exporter.get_finished_logs())
+        assert set(log_attrs) == {
+            EVENT_SESSION_START,
+            EVENT_API_RESPONSE,
+            EVENT_TOOL_RESULT,
+        }
+        assert log_attrs[EVENT_API_RESPONSE]["input_tokens"] == 50
+        assert log_attrs[EVENT_API_RESPONSE]["cost_usd"] == pytest.approx(0.0009)
+        assert log_attrs[EVENT_TOOL_RESULT]["tool_name"] == "read_file"
+        # session.id is propagated onto the per-call records via the active turn.
+        assert log_attrs[EVENT_API_RESPONSE]["session.id"] == "sess-9"
+
+    def test_post_api_request_estimates_cost_for_local_model(
+        self, exporter_and_tracer, monkeypatch
+    ):
+        """When the agent reports no price, cost is estimated from model size."""
+        exporter, tracer = exporter_and_tracer
+        plugin, provider = _fresh_plugin()
+        monkeypatch.setattr(provider, "build_tracer", lambda **_: tracer)
+        log_exporter, otel_logger = _in_memory_logger()
+        monkeypatch.setattr(provider, "build_logger", lambda **_: otel_logger)
+
+        ctx = _FakeCtx()
+        plugin.register(ctx)
+
+        ctx.hooks["on_session_start"](session_id="s", model="llama3.1:8b")
+        ctx.hooks["post_api_request"](
+            session_id="s",
+            model="llama3.1:8b",
+            usage={"input_tokens": 1000, "output_tokens": 1000},
+            # no cost_usd → estimated from the 8B size tier (0.0003 + 0.0006).
+        )
+
+        spans = _by_name(exporter.get_finished_spans())
+        assert spans[OP_CHAT].attributes["cost_usd"] == pytest.approx(0.0009)
+        log_attrs = _log_attrs(log_exporter.get_finished_logs())
+        assert log_attrs[EVENT_API_RESPONSE]["cost_usd"] == pytest.approx(0.0009)
+
+    def test_hooks_survive_malformed_event(self, exporter_and_tracer, monkeypatch):
+        """A bad event must never raise out of a hook (observability safety)."""
+        exporter, tracer = exporter_and_tracer
+        plugin, provider = _fresh_plugin()
+        monkeypatch.setattr(provider, "build_tracer", lambda **_: tracer)
+        _log_exporter, otel_logger = _in_memory_logger()
+        monkeypatch.setattr(provider, "build_logger", lambda **_: otel_logger)
+        ctx = _FakeCtx()
+        plugin.register(ctx)
+
+        # Missing everything — swallowed and logged, not raised.
+        ctx.hooks["post_api_request"]()
+        ctx.hooks["post_tool_call"]()  # tool_name falls back to "unknown"
+
+        spans = _by_name(exporter.get_finished_spans())
+        assert spans[OP_EXECUTE_TOOL].attributes["gen_ai.tool.name"] == "unknown"
+
+    def test_tool_error_status_recorded(self, exporter_and_tracer, monkeypatch):
+        exporter, tracer = exporter_and_tracer
+        plugin, provider = _fresh_plugin()
+        monkeypatch.setattr(provider, "build_tracer", lambda **_: tracer)
+        _log_exporter, otel_logger = _in_memory_logger()
+        monkeypatch.setattr(provider, "build_logger", lambda **_: otel_logger)
+        ctx = _FakeCtx()
+        plugin.register(ctx)
+
+        ctx.hooks["post_tool_call"](tool_name="terminal", status="error")
+
+        spans = _by_name(exporter.get_finished_spans())
+        assert spans[OP_EXECUTE_TOOL].attributes["error.type"] == "error"

--- a/tests/plugins/test_otel_plugin.py
+++ b/tests/plugins/test_otel_plugin.py
@@ -43,6 +43,7 @@ from plugins.observability.otel.log_emitter import (
     EVENT_API_RESPONSE,
     EVENT_SESSION_START,
     EVENT_TOOL_RESULT,
+    EVENT_USER_PROMPT,
     OtelLogEmitter,
 )
 
@@ -393,6 +394,34 @@ class TestLogEmitter:
         assert "a.txt" in attrs[EVENT_TOOL_RESULT]["tool_input"]
         assert "done" in attrs[EVENT_TOOL_RESULT]["tool_output"]
 
+    def test_user_prompt_record_shape_and_content(self, log_exporter_and_logger):
+        exporter, otel_logger = log_exporter_and_logger
+        emitter = OtelLogEmitter(otel_logger, agent_name="hermes", capture_content=True)
+
+        emitter.user_prompt(session_id="sess-1", prompt="fix the failing test", model="llama3.1:8b")
+
+        rec = _log_attrs(exporter.get_finished_logs())[EVENT_USER_PROMPT]
+        assert rec["event.name"] == EVENT_USER_PROMPT
+        assert rec["session.id"] == "sess-1"
+        assert rec["model"] == "llama3.1:8b"
+        assert rec["agent_type"] == "hermes"
+        assert rec["gen_ai.system"] == "hermes"
+        # The prompt text is rendered in the dashboard's prompt drill-down.
+        assert rec["prompt"] == "fix the failing test"
+        assert rec["prompt_length"] == len("fix the failing test")
+
+    def test_user_prompt_length_emitted_without_content(self, log_exporter_and_logger):
+        exporter, otel_logger = log_exporter_and_logger
+        emitter = OtelLogEmitter(otel_logger, capture_content=False)
+
+        emitter.user_prompt(session_id="s", prompt="secret prompt")
+
+        rec = _log_attrs(exporter.get_finished_logs())[EVENT_USER_PROMPT]
+        # Length is non-sensitive metadata, always present...
+        assert rec["prompt_length"] == len("secret prompt")
+        # ...but the text itself is privacy-gated off.
+        assert "prompt" not in rec
+
     def test_emit_never_raises_on_bad_logger(self):
         class _BoomLogger:
             def emit(self, *_a, **_k):
@@ -498,6 +527,39 @@ class TestPluginAdapter:
         assert attrs["gen_ai.prompt"] == "email the report to john@example.com"
         assert attrs["gen_ai.completion"] == "Sure — sending it to john@example.com now."
 
+    def test_pre_llm_call_emits_user_prompt_log_record_once_per_turn(
+        self, exporter_and_tracer, monkeypatch
+    ):
+        """The prompt must reach the dashboard LOG stream (event.name
+        ``user_prompt``), not only the span — and exactly once per turn even
+        though ``pre_llm_call`` fires once per LLM call inside a tool loop.
+
+        This is the fix for "Hermes sessions show tool calls + API responses
+        but no prompts in /agent-coding": the prompt only ever rode on the span
+        as ``gen_ai.prompt``, which the log-record-based dashboard never sees.
+        """
+        monkeypatch.setenv("HERMES_OTEL_CAPTURE_CONTENT", "true")
+        exporter, tracer = exporter_and_tracer
+        plugin, provider = _fresh_plugin()
+        monkeypatch.setattr(provider, "build_tracer", lambda **_: tracer)
+        log_exporter, otel_logger = _in_memory_logger()
+        monkeypatch.setattr(provider, "build_logger", lambda **_: otel_logger)
+
+        ctx = _FakeCtx()
+        plugin.register(ctx)
+        ctx.hooks["on_session_start"](session_id="sess-p", model="hermes-x")
+        # Two pre_llm_calls within one turn (a tool loop) — prompt logged once.
+        ctx.hooks["pre_llm_call"](session_id="sess-p", model="hermes-x", user_message="refactor it")
+        ctx.hooks["pre_llm_call"](session_id="sess-p", model="hermes-x", user_message="refactor it")
+        ctx.hooks["transform_llm_output"](session_id="sess-p", response_text="done")
+        ctx.hooks["on_session_end"](session_id="sess-p")
+
+        records = [dict(r.log_record.attributes or {}) for r in log_exporter.get_finished_logs()]
+        prompts = [r for r in records if r.get("event.name") == EVENT_USER_PROMPT]
+        assert len(prompts) == 1
+        assert prompts[0]["prompt"] == "refactor it"
+        assert prompts[0]["session.id"] == "sess-p"
+
     def test_prompt_and_response_gated_by_capture_content(
         self, exporter_and_tracer, monkeypatch
     ):
@@ -559,9 +621,11 @@ class TestPluginAdapter:
         assert list(spans[OP_CHAT].attributes["gen_ai.response.finish_reasons"]) == ["stop"]
         assert spans[OP_EXECUTE_TOOL].attributes["gen_ai.tool.name"] == "read_file"
 
-        # The richer scope ALSO emits dashboard log records for the same events.
+        # The richer scope ALSO emits dashboard log records for the same events,
+        # including the per-turn user_prompt record (event.name user_prompt).
         log_attrs = _log_attrs(log_exporter.get_finished_logs())
         assert set(log_attrs) == {
+            EVENT_USER_PROMPT,
             EVENT_SESSION_START,
             EVENT_API_RESPONSE,
             EVENT_TOOL_RESULT,


### PR DESCRIPTION
# feat(agent): add OTLP observability plugin (`observability/otel`)

## Summary

Adds a third bundled observability plugin, **`observability/otel`**, that
exports Hermes's existing observability events over **OpenTelemetry (OTLP)**.
It slots in beside the two shipped plugins — `observability/langfuse` and
`observability/nemo_relay` — and makes **no changes to Hermes core**. Hermes
already produces exactly the right events (a turn, per-LLM-API-call
usage/cost/finish-reason, per-tool-call results); this plugin adds an OTLP sink
for them and exports **three complementary signals**:

1. **GenAI-convention spans** (`gen_ai.*`) — the vendor-neutral trace model, so
   telemetry flows to **any** OTel backend (an OpenTelemetry Collector, Jaeger,
   Grafana Tempo, Honeycomb, …) with no lock-in.
2. **Dashboard-shaped OTLP log records** (`user_prompt` / `session_start` /
   `api_response` / `tool_result`) — the event model agent-coding dashboards
   aggregate on, so a Hermes session shows up in Activity / Sessions /
   Leaderboards views — **including its prompts** — the same way a Claude Code /
   Codex / Copilot session does.
3. **Local-model cost** — when the backend returns no price (Ollama / HF / vLLM
   local models), cost is estimated from the model's parameter size, so spans
   and log records carry a real `cost_usd` instead of `$0`.

## Why

`observability/langfuse` and `observability/nemo_relay` cover Langfuse and the
NVIDIA NeMo relay, but there is no OpenTelemetry path. OTLP is the de-facto open
standard; an OTLP plugin lets Hermes telemetry flow to **any** OTel backend with
no vendor lock-in. Emitting both the standard `gen_ai.*` spans **and** the
log-record event model means Hermes interoperates with conventions-aware tracing
backends *and* populates agent-coding dashboards — and the model-size cost
fallback means local-model runs report real cost rather than `$0`.

## What `genai_otel` adds (beyond a vanilla OTel SDK or other GenAI instrumentors)

The plugin runs on a **plain OTel SDK** by default (spans, tokens, latency,
finish reasons, log records — portable to any OTLP backend). Routing through the
optional `genai-otel-instrument` emitter additionally unlocks four signals that
are **genuinely unique** — neither a raw OTel SDK nor the common GenAI
instrumentors (OpenLLMetry / Traceloop, OpenInference / Arize, OpenLIT, Langfuse)
emit them:

- **On-prem GPU metrics** — per-GPU utilization, power, memory, temperature, clocks, throttle state (nvidia-ml-py / amdsmi).
- **Energy + CO2** — `energy_kwh`, `co2_emissions_gco2e`, region-aware (codecarbon).
- **Local-model cost** — Ollama / HF / vLLM cost estimated from parameter size when the backend returns no price.
- **Inline eval / guardrails** — PII, toxicity, bias, prompt-injection, restricted-topics, hallucination scored as span attributes + metrics at instrumentation time (no separate eval pipeline).

All of it runs **in-process and on-prem** — no data leaves the host, no SaaS
observability backend, no separate eval service. The token/latency/cost fields
stay standard OTel GenAI conventions; the four signals above are extra
attributes/metrics a conventions-aware backend can use or ignore. See the plugin
README for the full comparison table + setup.

## What changed

New plugin only — one directory plus its test, no core edits:

```
plugins/observability/otel/__init__.py     Hermes plugin: register(ctx) + lifecycle hooks
plugins/observability/otel/emitter.py      Hermes-agnostic OTel GenAI span builder
plugins/observability/otel/log_emitter.py  Hermes-agnostic OTel log-record builder (dashboard events)
plugins/observability/otel/cost.py         local-model cost estimation (model size → price tier)
plugins/observability/otel/provider.py     tracer + logger bootstrap (genai_otel preferred, OTel SDK fallback)
plugins/observability/otel/plugin.yaml     manifest
plugins/observability/otel/README.md       enable / configure / verify / disable
tests/plugins/test_otel_plugin.py          manifest + in-memory-exporter tests (39 tests)
```

### Span mapping

```
invoke_agent          per Hermes turn   (gen_ai.conversation.id = session id)
  ├── chat            per LLM API call  (gen_ai.usage.*_tokens, cost_usd,
  │                                      gen_ai.response.finish_reasons, TTFT)
  └── execute_tool    per tool call     (gen_ai.tool.name, gen_ai.tool.type, errors)
```

`gen_ai.system = hermes` on every span; `service.name` defaults to
`agent.coding.hermes` (configurable). Prompt/response content is captured only
when `HERMES_OTEL_CAPTURE_CONTENT=true` (off by default — privacy-gated).

### Log-record mapping (emitted in parallel with the spans)

| `event.name`    | Per          | Key attributes |
|---|---|---|
| `user_prompt`   | Hermes turn  | `prompt` (content-gated), `prompt_length` (always), `model` |
| `session_start` | session      | `session.id`, `model` |
| `api_response`  | LLM API call | `model`, `input_tokens`, `output_tokens`, `cost_usd`, `finish_reason`, `ttft_ms` |
| `tool_result`   | tool call    | `tool_name`, `tool_type`, `status_code`, `decision_type` |

`user_prompt` mirrors Claude Code's `claude_code.user_prompt`, so the dashboard's
prompt **count** and prompt-text **drill-down** populate for Hermes sessions. It
is emitted from `pre_llm_call` (Hermes delivers the prompt there, not at
`on_session_start`), once per turn. Without it a session would show tool calls
and API responses but **no prompts** — the dashboard reads log records, and the
prompt otherwise lives only on the `invoke_agent` span as `gen_ai.prompt`, which
log-record-based dashboards never see.

Identity (`service.name`, `user.id`, and any `team.id`/`organization.id` from
`OTEL_RESOURCE_ATTRIBUTES`) is placed on the OTel **resource** so per-user /
per-org leaderboard aggregations work. Same privacy gate as spans. Log emission
is **best-effort** — a logs-pipeline failure never disables spans.

### Cost estimation

`cost.py` mirrors the `genai-otel-instrument` methodology: parse the parameter
size from the model name (`llama3.1:8b` → 8 B, `qwen3:0.6b` → 0.6 B,
`smollm2:360m` → 0.36 B), map it to a per-1K-token price tier, and compute
`cost = in_tok/1000 * promptPrice + out_tok/1000 * completionPrice`. Used **only**
as a fallback when the agent reported no cost (an agent-provided `cost_usd`
always wins); cost is omitted entirely when the size can't be inferred (no fake
`$0`).

### Hook wiring (matches the bundled observability plugins)

| Hermes hook | Maps to |
|---|---|
| `on_session_start` | track the active session + emit the `session_start` log (does **not** open the span — that is per-turn, below) |
| `pre_llm_call` | **open** the per-turn `invoke_agent` span (first call of a turn; tool-loop calls reuse it) + stamp the prompt (`gen_ai.prompt`) on the span **and** emit the `user_prompt` log record (once per turn) so dashboards show the prompt text + count |
| `transform_llm_output` | stamp the response (`gen_ai.completion`) + **close** the turn span — a **read-only observer** (returns `None`, never alters the output). The span is **one per turn** and exports at turn end, so **prompt- and response-side eval** (PII / injection / restricted-topics on input; toxicity / hallucination / PII on output) runs **every turn** and survives an abrupt shutdown, when content capture is on |
| `on_session_end` / `on_session_finalize` / `on_session_reset` | close any still-open turn span (fallback for an interrupted turn) |
| `post_api_request` | `chat` span + `api_response` log (model, `usage`, `finish_reason`, duration→TTFT, cost) |
| `post_tool_call` | `execute_tool` span + `tool_result` log (`tool_name`, `args`, `result`, `status`/error) |

## Confirmed assumptions

The scaffold for this plugin was written against the *observable behaviour* of
the two shipped observability plugins, with five integration points flagged for
confirmation against the real Hermes plugin contract. All five were confirmed
against `plugins/observability/langfuse`, `plugins/observability/nemo_relay`,
and `website/docs/guides/build-a-hermes-plugin.md`, and the plugin was adapted
to the real contract:

| # | Assumption (scaffold) | Confirmed contract (this PR) |
|---|---|---|
| A1 | Subclass a base like `hermes.plugins.ObservabilityPlugin` | **No base class.** A plugin is a plain module exposing `register(ctx)`. The `OtelObservabilityPlugin` class and `PLUGIN` singleton were removed. |
| A2 | Hooks `on_turn_start/end`, `on_llm_call_end`, `on_tool_call_end` | **Real hooks:** `on_session_start` / `on_session_end` / `on_session_finalize` / `on_session_reset`, `post_api_request` (per LLM API call — carries `usage`/`finish_reason`), `post_tool_call`. Methods renamed accordingly. |
| A3 | Each hook receives an event object | **`**kwargs` keyword args**, not an object. Accessors rewritten to read `session_id`, `model`, `usage` (CanonicalUsage dict: `input_tokens`/`output_tokens`/…), `finish_reason`, `assistant_response`, `tool_name`, `args`, `result`, `status`. |
| A4 | Entry-point group / subclass discovery + `PLUGIN` handle | **`register(ctx)` + `ctx.register_hook(name, fn)` + `plugin.yaml` manifest** (bundled directory discovery, opt-in via `hermes plugins enable`). Entry-point/`pyproject.toml` removed; `plugin.yaml` added matching the langfuse/nemo_relay format. |
| A5 | Config via constructor kwargs / `configure(config)` | **Env vars** (`HERMES_OTEL_*`), matching every other observability plugin. Config delivered through a fail-open singleton gate (`_get_emitter()`), like `_get_langfuse()` / `_get_runtime()`. The same `HERMES_OTEL_*` vars now also drive the logs pipeline and cost estimation — no new config surface. |
| A6 | The agent-coding dashboard reads **log records** (`session_start`/`api_response`/`tool_result`), not spans | **Confirmed** against the TraceVerse `genai-otel-instrument` event model. `log_emitter.py` emits those records via a parallel OTLP **logs** pipeline (`provider.build_logger`, `<endpoint>/v1/logs`), with identity on the resource. Best-effort — a logs failure never disables spans. |
| A7 | Local backends (Ollama/HF/vLLM) report **no price**, so cost must be estimated from model size to avoid `$0` | **Confirmed** against `genai_otel.cost_calculator`. `cost.py` mirrors its size→tier methodology verbatim; used only as a fallback when the agent reported no `cost_usd`, omitted when size is unknown. |

The Hermes-agnostic span-mapping core (`emitter.py`), log-record-mapping core
(`log_emitter.py`), cost estimator (`cost.py`), and the tracer/logger bootstrap
(`provider.py`) are all Hermes-free and unit-tested in isolation — only
`__init__.py` (the plugin glue) is written against the real Hermes contract.

## Design notes

- **Minimal hard dependencies.** Only `opentelemetry-{api,sdk}` + the OTLP HTTP
  exporter (which provides **both** the span and log exporters). No new
  dependency for the logs/cost scope. `genai-otel-instrument` is an *optional*
  extra (preferred, auto-detected at runtime) — imported, never vendored, so the
  MIT license stays clean.
- **Fails open like the siblings.** If the OTel SDK isn't importable, the hooks
  no-op (cached `_INIT_FAILED` sentinel). A malformed event or a dead OTLP
  endpoint degrades to a no-op tracer — it never raises out of a hook. The logs
  pipeline and cost estimator are independently best-effort: if `build_logger()`
  or cost estimation fails, **spans still emit**.
- **Logs flushed at exit.** The plugin owns its `LoggerProvider`, so it registers
  an `atexit` `force_flush` + `shutdown` — without it the batch processor can
  drop late-turn records (the `api_response` / `tool_result` emitted just before
  the CLI exits).
- **Thread-safe singleton.** The emitter (and the log emitter built alongside it)
  is built once under a double-checked lock (concurrent agent sessions don't race
  to build two providers), per the Build-a-Plugin guide's lazy-singleton guidance.
- **Hermes coupling isolated to one file** (`__init__.py`). `emitter.py`,
  `log_emitter.py`, and `cost.py` are pure and unit-tested with in-memory
  exporters — no Hermes import, no network.

## Testing instructions

```bash
# From the hermes-agent checkout, in the project venv (`uv sync --extra all`,
# plus the `dev` group for pytest/ruff):
scripts/run_tests.sh tests/plugins/test_otel_plugin.py    # 39 tests
python scripts/check-windows-footguns.py plugins/observability/otel tests/plugins/test_otel_plugin.py
ruff check plugins/observability/otel tests/plugins/test_otel_plugin.py
```

The test suite uses OTel's in-memory span **and** log exporters (no network) and
asserts: the produced spans carry the correct `gen_ai.*` attributes with correct
parent/child nesting (`chat` and `execute_tool` under `invoke_agent`); the log
records carry the dashboard `event.name` / token / cost / tool fields; the
`user_prompt` record carries the prompt text (content-gated) + `prompt_length`
and is emitted exactly **once per turn** even across a tool loop; local-model
cost is estimated from model size across the price tiers and boundaries (and is
`None` when unknown); content-capture is gated; every path fails open; and
`register(ctx)` wires exactly the hooks declared in `plugin.yaml`. It drives the
full hook surface end-to-end from `**kwargs`-style Hermes events, asserting spans,
logs, and cost together.

### End-to-end (optional, requires a collector)

```bash
pip install opentelemetry-sdk opentelemetry-exporter-otlp-proto-http
hermes plugins enable observability/otel
HERMES_OTEL_ENDPOINT=http://localhost:4318 hermes chat -q "hello"
# → an "invoke_agent" trace with chat/execute_tool children appears in your OTel
#   backend, AND session_start/api_response/tool_result log records (with cost)
#   appear on the logs endpoint.
```

### Platforms tested

Run in the project venv (CPython 3.11.15) on **Windows 11**:

| Canonical gate | Command | Result |
|---|---|---|
| Tests (per-file parallel runner — the path `scripts/run_tests.sh` execs and CI uses) | `scripts/run_tests_parallel.py tests/plugins/test_otel_plugin.py` | **39 passed, 0 failed** |
| Windows footguns | `python scripts/check-windows-footguns.py plugins/observability/otel tests/plugins/test_otel_plugin.py` | **clean (6 files scanned)** |
| Lint (blocking CI rule `PLW1514`) | `ruff check plugins/observability/otel tests/plugins/test_otel_plugin.py` | **All checks passed** |

`scripts/run_tests.sh` itself probes a POSIX-layout venv (`<venv>/bin/activate`),
which a native-Windows venv (`<venv>/Scripts/`) doesn't have, so on Windows the
runner it execs — `scripts/run_tests_parallel.py` — was invoked directly with the
same deterministic env the wrapper sets (`TZ=UTC`, `LANG=C.UTF-8`,
`PYTHONHASHSEED=0`). On Linux/macOS/WSL2 `scripts/run_tests.sh` works unchanged.

- **Linux / macOS / WSL2:** no OS-specific code paths; the plugin performs no
  path I/O (network export only — `provider.py` deliberately avoids
  `get_hermes_home()` since there is no filesystem work), uses no POSIX-only
  calls, and the footgun checker is clean. CI runs all three gates on Ubuntu.

## Scope (deliberately narrow)

- ✅ One new bundled plugin, beside the existing two observability plugins.
- ✅ Exports OTel **spans** (`gen_ai.*`) **and** dashboard-shaped OTLP **log
  records** **and** local-model **cost** (model-size pricing) — all three driven
  by the same `HERMES_OTEL_*` config, no new config surface.
- ✅ No changes to Hermes core, config schema, or the other plugins.
- ✅ Standard OTel GenAI conventions for spans — no bespoke schema; the log
  records use the established agent-coding event model.
- ✅ Opt-in (`hermes plugins enable observability/otel`); fails open when the
  OTel SDK is absent. The logs/cost paths are best-effort — they never disable
  spans.
- ❌ No new core dependencies forced on users who don't enable the plugin (the
  logs + cost scope adds **zero** dependencies beyond the OTLP HTTP exporter the
  spans already need).

## Related issues

No tracking issue — this is a self-initiated contribution that fills the
OpenTelemetry gap alongside the two shipped observability plugins. Context:

- Hermes built-in observability plugins (`observability/langfuse`,
  `observability/nemo_relay`) — this is the OTel sibling.
- OpenTelemetry GenAI semantic conventions (the attribute schema emitted).
