### PR TITLE
fix(tools): detect macOS app-bundle Chrome in browser availability gate

### DIFF
--- a/tests/tools/test_browser_chromium_check.py
+++ b/tests/tools/test_browser_chromium_check.py
@@ -60,8 +60,53 @@ class TestChromiumInstalled:
         (tmp_path / "chromium_headless_shell-1208").mkdir()
         assert bt._chromium_installed() is True
 
+    def test_true_when_macos_app_bundle_chrome_present(self, monkeypatch):
+        """macOS app-bundle Chrome counts even when not on PATH (#48172).
 
+        The installer's find_system_browser() already treats this exact path as
+        a usable system browser, but a .app bundle has no PATH entry, so the
+        runtime gate used to hide the browser tools on existing/source installs.
+        """
+        monkeypatch.delenv("AGENT_BROWSER_EXECUTABLE_PATH", raising=False)
+        monkeypatch.setattr(bt.sys, "platform", "darwin")
+        monkeypatch.setattr(bt.shutil, "which", lambda name: None)
+        monkeypatch.setattr(bt, "_chromium_search_roots", lambda: [])
+        chrome = "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome"
+        monkeypatch.setattr(bt.os.path, "isfile", lambda p: p == chrome)
 
+        assert bt._chromium_installed() is True
+
+    def test_true_when_macos_app_bundle_chromium_present(self, monkeypatch):
+        """macOS app-bundle Chromium counts even when not on PATH (#48172)."""
+        monkeypatch.delenv("AGENT_BROWSER_EXECUTABLE_PATH", raising=False)
+        monkeypatch.setattr(bt.sys, "platform", "darwin")
+        monkeypatch.setattr(bt.shutil, "which", lambda name: None)
+        monkeypatch.setattr(bt, "_chromium_search_roots", lambda: [])
+        chromium = "/Applications/Chromium.app/Contents/MacOS/Chromium"
+        monkeypatch.setattr(bt.os.path, "isfile", lambda p: p == chromium)
+
+        assert bt._chromium_installed() is True
+
+    def test_false_on_macos_without_app_bundle_path_or_cache(self, monkeypatch):
+        """No PATH chrome, no .app bundle, no Playwright cache → not installed."""
+        monkeypatch.delenv("AGENT_BROWSER_EXECUTABLE_PATH", raising=False)
+        monkeypatch.setattr(bt.sys, "platform", "darwin")
+        monkeypatch.setattr(bt.shutil, "which", lambda name: None)
+        monkeypatch.setattr(bt, "_chromium_search_roots", lambda: [])
+        monkeypatch.setattr(bt.os.path, "isfile", lambda p: False)
+
+        assert bt._chromium_installed() is False
+
+    def test_app_bundle_paths_ignored_off_darwin(self, monkeypatch):
+        """The /Applications fallback must only fire on macOS."""
+        monkeypatch.delenv("AGENT_BROWSER_EXECUTABLE_PATH", raising=False)
+        monkeypatch.setattr(bt.sys, "platform", "linux")
+        monkeypatch.setattr(bt.shutil, "which", lambda name: None)
+        monkeypatch.setattr(bt, "_chromium_search_roots", lambda: [])
+        chrome = "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome"
+        monkeypatch.setattr(bt.os.path, "isfile", lambda p: p == chrome)
+
+        assert bt._chromium_installed() is False
 
     def test_result_cached(self, monkeypatch, tmp_path):
         monkeypatch.setenv("PLAYWRIGHT_BROWSERS_PATH", str(tmp_path))

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -3604,7 +3604,9 @@ def _chromium_installed() -> bool:
        agent-browser at a pre-installed Chrome/Chromium.
     2. System Chrome/Chromium in PATH (``google-chrome``, ``chromium``,
        ``chromium-browser``, ``chrome``).
-    3. Playwright's browser cache (current logic) — directories containing
+    3. macOS app-bundle Chrome/Chromium under ``/Applications`` — the same
+       system browsers the installer's ``find_system_browser()`` recognises.
+    4. Playwright's browser cache (current logic) — directories containing
        ``chromium-*`` or ``chromium_headless_shell-*``.
 
     agent-browser (0.26+) downloads Playwright's chromium / headless-shell
@@ -3636,7 +3638,21 @@ def _chromium_installed() -> bool:
         _cached_chromium_installed = True
         return True
 
-    # 3. Playwright browser cache (legacy — chromium-* / chromium_headless_shell-* dirs)
+    # 3. macOS app bundles. A usable Chrome/Chromium .app has no entry on PATH,
+    #    so step 2 misses it on installs where AGENT_BROWSER_EXECUTABLE_PATH was
+    #    never persisted to ~/.hermes/.env (existing/source/migrated installs).
+    #    These are the same locations the installer's find_system_browser()
+    #    treats as usable system browsers (scripts/install.sh) — #48172.
+    if sys.platform == "darwin":
+        for bundle in (
+            "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
+            "/Applications/Chromium.app/Contents/MacOS/Chromium",
+        ):
+            if os.path.isfile(bundle):
+                _cached_chromium_installed = True
+                return True
+
+    # 4. Playwright browser cache (legacy — chromium-* / chromium_headless_shell-* dirs)
     for root in _chromium_search_roots():
         if not root or not os.path.isdir(root):
             continue


### PR DESCRIPTION
## What does this PR do?

Teaches the runtime `browser` availability gate to recognize macOS app-bundle Chrome/Chromium, so the local browser tools aren't hidden when a usable browser is installed but only reachable via `/Applications` (not on `PATH`, no `AGENT_BROWSER_EXECUTABLE_PATH`, no Playwright cache).

## Related Issue

Fixes #48172

## Root Cause

`_chromium_installed()` in `tools/browser_tool.py` checked three sources — `AGENT_BROWSER_EXECUTABLE_PATH`, Chrome/Chromium on `PATH`, and the Playwright browser cache — but never the macOS app-bundle locations. The installer's `find_system_browser()` (`scripts/install.sh`) already treats those exact paths as usable system browsers and persists `AGENT_BROWSER_EXECUTABLE_PATH` to `~/.hermes/.env`. On installs where that persistence didn't happen (existing installs, source checkouts, configs migrated from before the installer wrote the env var), a user with Chrome at the normal `.app` path — and no `chrome` on `PATH` — had `check_browser_requirements()` hide the local browser tools even though a usable browser was present.

## Changes Made

- `tools/browser_tool.py`: add a Darwin-only app-bundle fallback to `_chromium_installed()`, checking the same locations as the installer:
  - `/Applications/Google Chrome.app/Contents/MacOS/Google Chrome`
  - `/Applications/Chromium.app/Contents/MacOS/Chromium`
- `tests/tools/test_browser_chromium_check.py`: 4 regression tests (Chrome bundle, Chromium bundle, negative case, and a guard that the fallback does **not** fire off-macOS).

Scoped to system `/Applications` to mirror `find_system_browser()` exactly; per-user `~/Applications` and `/browser connect` auto-launch are tracked separately in #48171.

## How to Test

```
python -m pytest tests/tools/test_browser_chromium_check.py -q
```

Manual: on macOS with Chrome installed at `/Applications/Google Chrome.app`, no `AGENT_BROWSER_EXECUTABLE_PATH` set, and no `chrome`/`chromium` on `PATH`, start Hermes in local browser mode — the `browser_*` tools are now advertised.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] Branch created from `main`
- [x] `pytest tests/tools/test_browser_chromium_check.py` passes (14) + broader browser suite (106) with no regressions
- [x] Targeted regression tests added, isolated (monkeypatch, no `~/.hermes` writes)
- [x] Cross-platform: fallback is Darwin-gated; a test verifies it does not fire on other platforms
- [x] Single logical change, conventional commit

## AI Disclosure

This bug was investigated and fixed with AI assistance.
