### PR TITLE
fix(desktop): WSL clipboard paste always fails on WSL

### DIFF
--- a/apps/desktop/electron/main.cjs
+++ b/apps/desktop/electron/main.cjs
@@ -5731,6 +5731,40 @@ ipcMain.handle('hermes:saveImageBuffer', async (_event, payload) => {
 })
 
 ipcMain.handle('hermes:saveClipboardImage', async () => {
+  // On WSL, Electron's clipboard.readImage() reads from the X11 clipboard,
+  // but WSLg puts images on the Wayland clipboard. Use powershell.exe
+  // (Windows clipboard) as the primary source for reliability.
+  if (isWslEnvironment()) {
+    try {
+      const result = execFileSync(
+        '/mnt/c/Windows/System32/WindowsPowerShell/v1.0/powershell.exe',
+        [
+          '-NoProfile',
+          '-NonInteractive',
+          '-Command',
+          'Add-Type -AssemblyName System.Windows.Forms;' +
+            'Add-Type -AssemblyName System.Drawing;' +
+            '$img = [System.Windows.Forms.Clipboard]::GetImage();' +
+            'if ($null -eq $img) { exit 1 };' +
+            '$ms = New-Object System.IO.MemoryStream;' +
+            '$img.Save($ms, [System.Drawing.Imaging.ImageFormat]::Png);' +
+            'Write-Output ([System.Convert]::ToBase64String($ms.ToArray()))',
+        ],
+        { timeout: 15000, maxBuffer: 50 * 1024 * 1024 },
+      )
+      // execFileSync on WSL returns the stdout Buffer directly when
+      // the child exits with code 0, not a SpawnSyncReturns object
+      // with a .stdout property.
+      const b64 = (result.stdout ?? result).toString().trim()
+      if (b64) {
+        const pngPath = await writeComposerImage(Buffer.from(b64, 'base64'), '.png')
+        if (pngPath) return pngPath
+      }
+    } catch {
+      // Fall through to Electron's clipboard.readImage()
+    }
+  }
+
   const image = clipboard.readImage()
   if (!image || image.isEmpty()) {
     return ''


### PR DESCRIPTION
On WSL2, clicking + → **Paste image** in Hermes Desktop always returns "No image found in clipboard" even when an image is on the Windows clipboard. Two issues:

**Issue 1: WSL clipboard path missing**
Electron's clipboard.readImage() reads from the X11 clipboard, but WSLg puts images on the Wayland clipboard. On WSL, this path always returns empty.

Fix: Add a WSL-specific handler that reads from the Windows clipboard directly via powershell.exe before falling back to clipboard.readImage().

**Issue 2: execFileSync return type mismatch**
Inside the WSL handler, execFileSync returns a Buffer directly when the child exits with code 0, not a SpawnSyncReturns { stdout, stderr, status } object. The code did result.stdout.toString() where result.stdout is undefined, throwing. The exception is caught by catch, execution falls through to clipboard.readImage() — which also returns empty on WSLg.

Fix: Use (result.stdout ?? result) to handle both return shapes.

**What does this PR do?**
Adds a WSL-specific clipboard image paste handler that reads from the Windows clipboard directly via powershell.exe, with a fallback to Electron's built-in clipboard.readImage() if the Windows path fails. Also fixes a bug where execFileSync's return value was incorrectly destructured as result.stdout when on WSL it returns a Buffer directly.

**Related Issue**
Fixes clipboard paste not working on WSL2 (no associated issue — found during local testing).

**Type of Change**
 🐛 Bug fix (non-breaking change that fixes an issue)

**Changes Made**
`apps/desktop/electron/main.cjs` — Added WSL-specific clipboard handler with safe execFileSync return value handling

**How to Test**

1. Use Hermes Desktop on WSL2 (with `appendWindowsPath = false` in `/etc/wsl.conf`)
2. Copy an image to Windows clipboard (Win+Shift+S or Ctrl+C on an image)
3. Click + → "**Paste image**"
4. Before fix: "No image found in clipboard" — After fix: image attaches successfully

**Checklist**
Code
 I've tested on my platform: WSL2 (Ubuntu 24.04) on Windows 11