### PR TITLE
fix(hindsight): preserve HINDSIGHT_API_PORT during profile env materialization

### DIFF
--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -549,10 +549,22 @@ def _embedded_profile_env_path(config: dict[str, Any]):
 
 
 def _materialize_embedded_profile_env(config: dict[str, Any], *, llm_api_key: str | None = None):
-    """Write the profile-scoped env file that standalone hindsight-embed uses."""
+    """Write the profile-scoped env file that standalone hindsight-embed uses.
+
+    Preserves ``HINDSIGHT_API_PORT`` from the existing file so that a
+    user-specified or hash-allocated port survives gateway restarts.
+    The port is not part of the plugin config dict, so without this
+    preservation every materialization would silently drop it and the
+    daemon would re-bind to a different (hash-derived) port on the next
+    start.
+    """
     profile_env = _embedded_profile_env_path(config)
     profile_env.parent.mkdir(parents=True, exist_ok=True)
     env_values = _build_embedded_profile_env(config, llm_api_key=llm_api_key)
+    if profile_env.exists():
+        existing = _load_simple_env(profile_env)
+        if "HINDSIGHT_API_PORT" in existing:
+            env_values["HINDSIGHT_API_PORT"] = existing["HINDSIGHT_API_PORT"]
     profile_env.write_text(
         "".join(f"{key}={value}\n" for key, value in env_values.items()),
         encoding="utf-8",
@@ -1421,7 +1433,13 @@ class HindsightMemoryProvider(MemoryProvider):
                     profile_env = _embedded_profile_env_path(self._config)
                     expected_env = _build_embedded_profile_env(self._config)
                     saved = _load_simple_env(profile_env)
-                    config_changed = saved != expected_env
+                    # HINDSIGHT_API_PORT is not part of _build_embedded_profile_env
+                    # (it is hash-allocated or user-set and preserved across
+                    # materialization). Exclude it from the drift comparison so
+                    # a stable port does not trigger a spurious daemon restart.
+                    saved_for_compare = {k: v for k, v in saved.items()
+                                         if k != "HINDSIGHT_API_PORT"}
+                    config_changed = saved_for_compare != expected_env
 
                     if config_changed:
                         profile_env = _materialize_embedded_profile_env(self._config)

--- a/tests/plugins/memory/test_hindsight_provider.py
+++ b/tests/plugins/memory/test_hindsight_provider.py
@@ -23,6 +23,8 @@ from plugins.memory.hindsight import (
     RETAIN_SCHEMA,
     _load_config,
     _build_embedded_profile_env,
+    _load_simple_env,
+    _materialize_embedded_profile_env,
     _normalize_observation_scopes,
     _normalize_retain_tags,
     _resolve_bank_id_template,
@@ -416,6 +418,62 @@ class TestConfig:
         })
 
         assert env["HINDSIGHT_EMBED_DAEMON_IDLE_TIMEOUT"] == "42"
+
+    def test_materialize_preserves_existing_port(self, tmp_path, monkeypatch):
+        """HINDSIGHT_API_PORT must survive env re-materialization."""
+        monkeypatch.setenv("HOME", str(tmp_path))
+        config = {
+            "profile": "hermes",
+            "llm_provider": "openai",
+            "llm_model": "gpt-4o-mini",
+        }
+        # Simulate a first-run state where the port already exists.
+        profile_env = tmp_path / ".hindsight" / "profiles" / "hermes.env"
+        profile_env.parent.mkdir(parents=True, exist_ok=True)
+        profile_env.write_text(
+            "HINDSIGHT_API_LLM_PROVIDER=openai\n"
+            "HINDSIGHT_API_LLM_API_KEY=old-key\n"
+            "HINDSIGHT_API_LLM_MODEL=old-model\n"
+            "HINDSIGHT_API_LOG_LEVEL=info\n"
+            "HINDSIGHT_API_PORT=9178\n"
+        )
+        _materialize_embedded_profile_env(config, llm_api_key="new-key")
+        result = _load_simple_env(profile_env)
+        assert result["HINDSIGHT_API_PORT"] == "9178"
+        assert result["HINDSIGHT_API_LLM_API_KEY"] == "new-key"
+
+    def test_materialize_no_port_when_absent(self, tmp_path, monkeypatch):
+        """No HINDSIGHT_API_PORT key should be added if it wasn't there before."""
+        monkeypatch.setenv("HOME", str(tmp_path))
+        config = {
+            "profile": "hermes",
+            "llm_provider": "openai",
+            "llm_model": "gpt-4o-mini",
+        }
+        profile_env = tmp_path / ".hindsight" / "profiles" / "hermes.env"
+        profile_env.parent.mkdir(parents=True, exist_ok=True)
+        profile_env.write_text(
+            "HINDSIGHT_API_LLM_PROVIDER=openai\n"
+            "HINDSIGHT_API_LLM_API_KEY=old-key\n"
+            "HINDSIGHT_API_LLM_MODEL=old-model\n"
+            "HINDSIGHT_API_LOG_LEVEL=info\n"
+        )
+        _materialize_embedded_profile_env(config, llm_api_key="new-key")
+        result = _load_simple_env(profile_env)
+        assert "HINDSIGHT_API_PORT" not in result
+
+    def test_materialize_port_first_run(self, tmp_path, monkeypatch):
+        """First materialization (no existing file) must not fabricate a port."""
+        monkeypatch.setenv("HOME", str(tmp_path))
+        config = {
+            "profile": "hermes",
+            "llm_provider": "openai",
+            "llm_model": "gpt-4o-mini",
+        }
+        _materialize_embedded_profile_env(config, llm_api_key="key1")
+        profile_env = tmp_path / ".hindsight" / "profiles" / "hermes.env"
+        result = _load_simple_env(profile_env)
+        assert "HINDSIGHT_API_PORT" not in result
 
     def test_get_client_passes_idle_timeout_to_hindsight_embedded(self, monkeypatch):
         captured = {}


### PR DESCRIPTION
## Problem\n\n`_materialize_embedded_profile_env` rewrites the profile `.env` file on each gateway start, but only writes LLM-related keys (`HINDSIGHT_API_LLM_PROVIDER`, `HINDSIGHT_API_LLM_API_KEY`, etc.). This silently drops `HINDSIGHT_API_PORT`, which was either explicitly set by the user or hash-allocated on first run.\n\nOn the next restart, the port gets re-allocated via hash (deterministic for the same profile name), so the daemon always binds to the hash-assigned port regardless of user intent.\n\n## Fix\n\nPreserve the existing `HINDSIGHT_API_PORT` value when materializing the profile env, so user-specified ports survive gateway restarts.\n\n## Reproduction\n\n1. Set `HINDSIGHT_API_PORT=9178` in `~/.hindsight/profiles/<profile>.env`\n2. Restart gateway\n3. Observe the port reverts to the hash-assigned value (e.g. 9177 for profile "hermes")