### PR TITLE
fix(anthropic): normalize forced tool_choice name to mcp__ on the OAuth wire

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -396,6 +396,23 @@ _CLAUDE_CODE_SYSTEM_PREFIX = "You are Claude Code, Anthropic's official CLI for 
 _MCP_TOOL_PREFIX = "mcp__"
 
 
+def _to_oauth_wire_name(name: str) -> str:
+    """Normalize a tool name to the double-underscore ``mcp__`` OAuth wire form.
+
+    Anthropic's subscription/OAuth billing classifier treats a single-underscore
+    ``mcp_`` tool name as a third-party-app fingerprint and rejects the request
+    (HTTP 400).  Every tool name placed on the OAuth wire — in ``tools[]``, in
+    replayed ``tool_use`` history, and in a forced ``tool_choice`` — must land on
+    the ``mcp__`` form so they match each other and clear the classifier.
+    """
+    if name.startswith("mcp__"):
+        return name  # already correct, don't double-prefix
+    if name.startswith("mcp_"):
+        # single-underscore native MCP tool -> promote to double
+        return "mcp__" + name[len("mcp_"):]
+    return _MCP_TOOL_PREFIX + name  # bare name -> mcp__<name>
+
+
 def _get_claude_code_version() -> str:
     """Lazily detect the installed Claude Code version when OAuth headers need it."""
     global _claude_code_version_cache
@@ -2916,14 +2933,8 @@ def build_anthropic_kwargs(
         #    so any session with an MCP server configured still tripped the
         #    classifier. normalize_response reverses both forms via registry
         #    lookup so the dispatcher still sees the original name. GH-25255.
-        def _to_oauth_wire_name(name: str) -> str:
-            if name.startswith("mcp__"):
-                return name  # already correct, don't double-prefix
-            if name.startswith("mcp_"):
-                # single-underscore native MCP tool -> promote to double
-                return "mcp__" + name[len("mcp_"):]
-            return _MCP_TOOL_PREFIX + name  # bare name -> mcp__<name>
-
+        # ``_to_oauth_wire_name`` is defined at module scope so the forced
+        # ``tool_choice`` name below can be normalized with the same rule.
         if anthropic_tools:
             for tool in anthropic_tools:
                 if "name" in tool:
@@ -2961,8 +2972,15 @@ def build_anthropic_kwargs(
             # Anthropic has no tool_choice "none" — omit tools entirely to prevent use
             kwargs.pop("tools", None)
         elif isinstance(tool_choice, str):
-            # Specific tool name
-            kwargs["tool_choice"] = {"type": "tool", "name": tool_choice}
+            # Specific tool name. Under OAuth the tools[] entries above were
+            # renamed to the double-underscore ``mcp__`` wire form, so the
+            # forced name must get the same normalization — otherwise it (a)
+            # no longer matches any entry in tools[] (Anthropic rejects the
+            # request with HTTP 400) and (b) can leak a single-underscore
+            # ``mcp_`` name onto the OAuth wire, the exact classifier
+            # fingerprint this transform exists to remove.
+            forced_name = _to_oauth_wire_name(tool_choice) if is_oauth else tool_choice
+            kwargs["tool_choice"] = {"type": "tool", "name": forced_name}
 
     # Map reasoning_config to Anthropic's thinking parameter.
     # Claude 4.6+ models use adaptive thinking + output_config.effort.

--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -384,6 +384,23 @@ _CLAUDE_CODE_SYSTEM_PREFIX = "You are Claude Code, Anthropic's official CLI for 
 _MCP_TOOL_PREFIX = "mcp__"
 
 
+def _to_oauth_wire_name(name: str) -> str:
+    """Normalize a tool name to the double-underscore ``mcp__`` OAuth wire form.
+
+    Anthropic's subscription/OAuth billing classifier treats a single-underscore
+    ``mcp_`` tool name as a third-party-app fingerprint and rejects the request
+    (HTTP 400).  Every tool name placed on the OAuth wire — in ``tools[]``, in
+    replayed ``tool_use`` history, and in a forced ``tool_choice`` — must land on
+    the ``mcp__`` form so they match each other and clear the classifier.
+    """
+    if name.startswith("mcp__"):
+        return name  # already correct, don't double-prefix
+    if name.startswith("mcp_"):
+        # single-underscore native MCP tool -> promote to double
+        return "mcp__" + name[len("mcp_"):]
+    return _MCP_TOOL_PREFIX + name  # bare name -> mcp__<name>
+
+
 def _get_claude_code_version() -> str:
     """Lazily detect the installed Claude Code version when OAuth headers need it."""
     global _claude_code_version_cache
@@ -2797,14 +2814,8 @@ def build_anthropic_kwargs(
         #    so any session with an MCP server configured still tripped the
         #    classifier. normalize_response reverses both forms via registry
         #    lookup so the dispatcher still sees the original name. GH-25255.
-        def _to_oauth_wire_name(name: str) -> str:
-            if name.startswith("mcp__"):
-                return name  # already correct, don't double-prefix
-            if name.startswith("mcp_"):
-                # single-underscore native MCP tool -> promote to double
-                return "mcp__" + name[len("mcp_"):]
-            return _MCP_TOOL_PREFIX + name  # bare name -> mcp__<name>
-
+        # ``_to_oauth_wire_name`` is defined at module scope so the forced
+        # ``tool_choice`` name below can be normalized with the same rule.
         if anthropic_tools:
             for tool in anthropic_tools:
                 if "name" in tool:
@@ -2842,8 +2853,15 @@ def build_anthropic_kwargs(
             # Anthropic has no tool_choice "none" — omit tools entirely to prevent use
             kwargs.pop("tools", None)
         elif isinstance(tool_choice, str):
-            # Specific tool name
-            kwargs["tool_choice"] = {"type": "tool", "name": tool_choice}
+            # Specific tool name. Under OAuth the tools[] entries above were
+            # renamed to the double-underscore ``mcp__`` wire form, so the
+            # forced name must get the same normalization — otherwise it (a)
+            # no longer matches any entry in tools[] (Anthropic rejects the
+            # request with HTTP 400) and (b) can leak a single-underscore
+            # ``mcp_`` name onto the OAuth wire, the exact classifier
+            # fingerprint this transform exists to remove.
+            forced_name = _to_oauth_wire_name(tool_choice) if is_oauth else tool_choice
+            kwargs["tool_choice"] = {"type": "tool", "name": forced_name}
 
     # Map reasoning_config to Anthropic's thinking parameter.
     # Claude 4.6+ models use adaptive thinking + output_config.effort.

--- a/tests/agent/test_anthropic_mcp_prefix_strip.py
+++ b/tests/agent/test_anthropic_mcp_prefix_strip.py
@@ -155,3 +155,60 @@ class TestAnthropicOAuthOutgoingPrefix:
         for n in names:
             assert not (n.startswith("mcp_") and not n.startswith("mcp__"))
 
+    def test_non_oauth_path_untouched(self):
+        """Non-OAuth requests never get the prefix — schemas pass through as-is."""
+        kwargs = self._build([
+            {"type": "function", "function": {"name": "read_file",
+                                              "description": "x", "parameters": {}}},
+            {"type": "function", "function": {"name": "mcp_linear_get_issue",
+                                              "description": "y", "parameters": {}}},
+        ], is_oauth=False)
+        names = sorted(t["name"] for t in kwargs["tools"])
+        assert names == ["mcp_linear_get_issue", "read_file"]
+
+    # -- Forced tool_choice must get the same wire-name normalization --------
+    #
+    # The OAuth transform renames tools[] (and tool_use history) to ``mcp__``,
+    # but a forced ``tool_choice`` is a sibling site that was left on the raw
+    # caller name. That breaks the request two ways: tool_choice.name no longer
+    # matches any tools[] entry (Anthropic rejects with HTTP 400), and an MCP
+    # server tool leaks the single-underscore ``mcp_`` classifier fingerprint
+    # onto the OAuth wire.
+
+    def _build_forced(self, name, is_oauth=True):
+        from agent.anthropic_adapter import build_anthropic_kwargs
+        return build_anthropic_kwargs(
+            model="claude-sonnet-4-6",
+            messages=[{"role": "user", "content": "Hi"}],
+            tools=[{
+                "type": "function",
+                "function": {"name": name, "description": "x", "parameters": {}},
+            }],
+            max_tokens=4096,
+            reasoning_config=None,
+            tool_choice=name,
+            is_oauth=is_oauth,
+        )
+
+    def test_oauth_tool_choice_matches_renamed_bare_tool(self):
+        """Forced tool_choice is normalized to ``mcp__`` so it matches tools[]."""
+        kwargs = self._build_forced("read_file")
+        assert kwargs["tool_choice"] == {"type": "tool", "name": "mcp__read_file"}
+        # The forced name MUST equal the (renamed) tools[] entry, or Anthropic
+        # rejects the request with HTTP 400.
+        assert kwargs["tool_choice"]["name"] == kwargs["tools"][0]["name"]
+
+    def test_oauth_tool_choice_promotes_single_underscore_mcp(self):
+        """Forced MCP-server tool name must not leak single-underscore ``mcp_``."""
+        kwargs = self._build_forced("mcp_linear_get_issue")
+        name = kwargs["tool_choice"]["name"]
+        assert name == "mcp__linear_get_issue"
+        assert name == kwargs["tools"][0]["name"]
+        # The core invariant: nothing single-underscore reaches the wire.
+        assert not (name.startswith("mcp_") and not name.startswith("mcp__"))
+
+    def test_non_oauth_tool_choice_untouched(self):
+        """Non-OAuth: tool_choice and tools[] both stay the bare name."""
+        kwargs = self._build_forced("read_file", is_oauth=False)
+        assert kwargs["tool_choice"] == {"type": "tool", "name": "read_file"}
+        assert kwargs["tools"][0]["name"] == "read_file"


### PR DESCRIPTION
## Summary

Follow-up to #25255 / `b70a4e753` ("normalize MCP-server tool names to `mcp__` on OAuth wire").

Under `is_oauth=True`, `build_anthropic_kwargs` rewrites every tool name to the double-underscore `mcp__` wire form so it clears Anthropic's subscription/OAuth billing classifier — which treats a **single-underscore** `mcp_` name as a third-party-app fingerprint and rejects the request with HTTP 400. That rename is applied to `tools[]` and to replayed `tool_use` history:

```python
# under `if is_oauth:`
for tool in anthropic_tools:
    tool["name"] = _to_oauth_wire_name(tool["name"])   # read_file -> mcp__read_file
# ... and tool_use history blocks likewise
```

But the **forced `tool_choice`** mapping is a sibling site that was left on the raw caller name:

```python
elif isinstance(tool_choice, str):
    kwargs["tool_choice"] = {"type": "tool", "name": tool_choice}   # NOT normalized
```

So any OAuth request that forces a specific tool breaks two ways:

1. **HTTP 400 (name mismatch).** `tools[]` becomes `mcp__read_file` but `tool_choice.name` stays `read_file`. The Messages API requires `tool_choice.name` to match a name present in `tools[]`, so the request is rejected.
2. **Classifier-fingerprint leak.** With an MCP-server tool (`tool_choice="mcp_linear_get_issue"`), the single-underscore `mcp_` name reaches the OAuth wire via `tool_choice` — the exact invariant this transform exists to enforce ("ZERO single-underscore `mcp_` names on the wire").

Reachable through `auxiliary_client.py` / the Anthropic transport, which forward a caller-supplied `tool_choice` (incl. the OpenAI `{"type":"function","function":{"name":…}}` form, normalized to a bare string) together with `is_oauth`.

## Fix

Hoist `_to_oauth_wire_name` from a closure to module scope and apply it to the forced name when `is_oauth`:

```python
forced_name = _to_oauth_wire_name(tool_choice) if is_oauth else tool_choice
kwargs["tool_choice"] = {"type": "tool", "name": forced_name}
```

The non-OAuth path is untouched.

## Tests

Added to `TestAnthropicOAuthOutgoingPrefix` in `tests/agent/test_anthropic_mcp_prefix_strip.py`:
- `test_oauth_tool_choice_matches_renamed_bare_tool` — `read_file` → `tool_choice.name == "mcp__read_file"` and equals the `tools[]` entry;
- `test_oauth_tool_choice_promotes_single_underscore_mcp` — `mcp_linear_get_issue` → `mcp__linear_get_issue`, no single-underscore on the wire;
- `test_non_oauth_tool_choice_untouched` — non-OAuth keeps the bare name.

The two OAuth cases **fail without the fix**; all 12 existing prefix tests still pass.