### PR TITLE
fix(desktop): connect to Ollama-style local endpoints via /v1 probe fallback

### DIFF
--- a/apps/desktop/src/hermes.ts
+++ b/apps/desktop/src/hermes.ts
@@ -359,8 +359,14 @@ export function validateProviderCredential(
   key: string,
   value: string,
   apiKey?: string
-): Promise<{ ok: boolean; reachable: boolean; message: string; models?: string[] }> {
-  return window.hermesDesktop.api<{ ok: boolean; reachable: boolean; message: string; models?: string[] }>({
+): Promise<{ ok: boolean; reachable: boolean; message: string; models?: string[]; base_url?: string }> {
+  return window.hermesDesktop.api<{
+    ok: boolean
+    reachable: boolean
+    message: string
+    models?: string[]
+    base_url?: string
+  }>({
     ...profileScoped(),
     path: '/api/providers/validate',
     method: 'POST',

--- a/apps/desktop/src/store/onboarding.test.ts
+++ b/apps/desktop/src/store/onboarding.test.ts
@@ -335,6 +335,53 @@ describe('saveOnboardingLocalEndpoint', () => {
     expect($desktopOnboarding.get().configured).toBe(true)
   })
 
+  it('persists the /v1 base_url the probe resolved when the user pasted the bare root (Ollama)', async () => {
+    const calls: { body?: unknown; path: string }[] = []
+
+    const api = vi.fn(async ({ body, path }: { body?: unknown; path: string }) => {
+      calls.push({ body, path })
+
+      if (path === '/api/providers/validate') {
+        // User pasted Ollama's bare root; the backend probe falls back to the
+        // /v1 surface and reports the base_url that actually advertised models.
+        return {
+          ok: true,
+          reachable: true,
+          message: '',
+          models: ['llama3.2'],
+          base_url: 'http://127.0.0.1:11434/v1'
+        }
+      }
+
+      if (path === '/api/model/set') {
+        return { ok: true, provider: 'custom', model: 'llama3.2', base_url: 'http://127.0.0.1:11434/v1' }
+      }
+
+      throw new Error(`unexpected api path: ${path}`)
+    })
+
+    installApiMock(api)
+
+    const result = await saveOnboardingLocalEndpoint('http://127.0.0.1:11434', '', {
+      requestGateway: readyGateway()
+    })
+
+    expect(result.ok).toBe(true)
+
+    // The probe is called with the raw root the user typed…
+    const probe = calls.find(c => c.path === '/api/providers/validate')
+    expect(probe?.body).toMatchObject({ key: 'OPENAI_BASE_URL', value: 'http://127.0.0.1:11434' })
+
+    // …but the resolved /v1 URL is what gets persisted, so the runtime can reach it.
+    const assign = calls.find(c => c.path === '/api/model/set')
+    expect(assign?.body).toMatchObject({
+      scope: 'main',
+      provider: 'custom',
+      model: 'llama3.2',
+      base_url: 'http://127.0.0.1:11434/v1'
+    })
+  })
+
   it('forwards the API key to the probe and persists it for auth-gated endpoints', async () => {
     const calls: { body?: unknown; path: string }[] = []
 

--- a/apps/desktop/src/store/onboarding.ts
+++ b/apps/desktop/src/store/onboarding.ts
@@ -804,6 +804,11 @@ export async function saveOnboardingLocalEndpoint(baseUrl: string, apiKey: strin
   // the endpoint is up; an unreachable probe hard-blocks because we can't
   // resolve a model to route to.
   let model = ''
+  // The probe may resolve the model surface to the OpenAI-compat /v1 path (e.g.
+  // a user who pasted Ollama's bare root http://127.0.0.1:11434). Persist the
+  // URL that actually advertised models, not the raw input, so the runtime can
+  // reach it.
+  let resolvedUrl = url
 
   try {
     const probe = await validateProviderCredential('OPENAI_BASE_URL', url, key)
@@ -817,6 +822,7 @@ export async function saveOnboardingLocalEndpoint(baseUrl: string, apiKey: strin
     }
 
     model = (probe.models?.[0] ?? '').trim()
+    resolvedUrl = (probe.base_url ?? '').trim() || url
   } catch {
     return { ok: false, message: `Could not reach ${url}.` }
   }
@@ -829,7 +835,7 @@ export async function saveOnboardingLocalEndpoint(baseUrl: string, apiKey: strin
   }
 
   try {
-    await setModelAssignment({ scope: 'main', provider: 'custom', model, base_url: url, api_key: key })
+    await setModelAssignment({ scope: 'main', provider: 'custom', model, base_url: resolvedUrl, api_key: key })
     await ctx.requestGateway('reload.env').catch(() => undefined)
 
     const runtime = await checkRuntime(ctx)
@@ -837,7 +843,7 @@ export async function saveOnboardingLocalEndpoint(baseUrl: string, apiKey: strin
     if (!runtime.ready) {
       const detail = (runtime.reason ?? '').trim()
 
-      return { ok: false, message: detail || `Saved, but Hermes still cannot reach ${url}.` }
+      return { ok: false, message: detail || `Saved, but Hermes still cannot reach ${resolvedUrl}.` }
     }
 
     notifyReady('Local / custom endpoint')

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -3772,18 +3772,41 @@ async def validate_provider_credential(body: EnvVarUpdate, request: Request):
     # ids the endpoint advertises (OpenAI ``/v1/models`` shape) so the GUI can
     # auto-pick a default without asking the user to type a model name.
     if key == "OPENAI_BASE_URL":
-        url = value.rstrip("/") + "/models"
+        base = value.rstrip("/")
         # Send the optional API key so endpoints that require auth on
         # ``/v1/models`` (many hosted OpenAI-compatible servers) still enumerate
         # their models instead of returning an empty list behind a 401.
         api_key = (body.api_key or "").strip()
         headers = {"Authorization": f"Bearer {api_key}"} if api_key else None
+        # Probe the URL as given, then the OpenAI-compat ``/v1`` surface. Local
+        # servers (Ollama, llama.cpp, vLLM) serve models at ``/v1/models``, so a
+        # user who pastes the bare root (e.g. http://127.0.0.1:11434) must still
+        # enumerate models instead of hard-failing with "advertised no models".
+        # Return the candidate that actually worked as ``base_url`` so the caller
+        # persists the URL the runtime can reach. Mirrors the CLI's
+        # ``probe_api_models`` fallback and the runtime's /v1 normalization.
+        candidates = [base]
+        if not base.lower().endswith("/v1"):
+            candidates.append(base + "/v1")
+        reached = False
         try:
             with httpx.Client(timeout=httpx.Timeout(8.0)) as client:
-                resp = client.get(url, headers=headers)
-            return {"ok": True, "reachable": True, "message": "", "models": _parse_model_ids(resp)}
+                for candidate in candidates:
+                    try:
+                        resp = client.get(candidate + "/models", headers=headers)
+                    except Exception:
+                        continue
+                    reached = True
+                    models = _parse_model_ids(resp)
+                    if models:
+                        return {"ok": True, "reachable": True, "message": "",
+                                "models": models, "base_url": candidate}
         except Exception:
-            return {"ok": False, "reachable": False, "message": f"Could not reach {url}."}
+            return {"ok": False, "reachable": False, "message": f"Could not reach {value}."}
+        if reached:
+            # Endpoint is up but advertised no models on any surface.
+            return {"ok": True, "reachable": True, "message": "", "models": [], "base_url": base}
+        return {"ok": False, "reachable": False, "message": f"Could not reach {value}."}
 
     probe = _CREDENTIAL_PROBES.get(key)
     if not probe:

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -256,6 +256,121 @@ class TestWebServerEndpoints:
         assert resp.status_code == 200
         assert resp.json()["can_update_hermes"] is False
 
+    def test_validate_openai_base_url_falls_back_to_v1_for_bare_root(self, monkeypatch):
+        """A user who pastes a local root (e.g. Ollama's http://host:11434) must
+        still enumerate models: the probe falls back to the OpenAI-compat /v1
+        surface and reports the base_url that actually worked, so the saved
+        endpoint is reachable at runtime instead of hard-failing 'no models'."""
+        import httpx
+
+        seen = []
+
+        class FakeHttpxClient:
+            def __init__(self, *args, **kwargs):
+                pass
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *_exc):
+                return False
+
+            def get(self, url, headers=None):
+                seen.append(url)
+                # Ollama serves models only under /v1; the bare root 404s.
+                if url.endswith("/v1/models"):
+                    return httpx.Response(
+                        200, json={"data": [{"id": "llama3.2"}]},
+                        request=httpx.Request("GET", url),
+                    )
+                return httpx.Response(
+                    404, json={"error": "not found"},
+                    request=httpx.Request("GET", url),
+                )
+
+        monkeypatch.setattr(httpx, "Client", FakeHttpxClient)
+
+        resp = self.client.post(
+            "/api/providers/validate",
+            json={"key": "OPENAI_BASE_URL", "value": "http://127.0.0.1:11434", "api_key": ""},
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["ok"] is True
+        assert data["reachable"] is True
+        assert data["models"] == ["llama3.2"]
+        # Reports the working /v1 surface so the caller persists a reachable URL.
+        assert data["base_url"] == "http://127.0.0.1:11434/v1"
+        # Tried the bare root first, then the /v1 fallback.
+        assert seen == [
+            "http://127.0.0.1:11434/models",
+            "http://127.0.0.1:11434/v1/models",
+        ]
+
+    def test_validate_openai_base_url_reachable_but_no_models(self, monkeypatch):
+        """An endpoint that is up but advertises no models on any surface stays a
+        soft block (ok+reachable, empty models) so the GUI shows 'start a model',
+        not a misleading 'could not reach'."""
+        import httpx
+
+        class FakeHttpxClient:
+            def __init__(self, *args, **kwargs):
+                pass
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *_exc):
+                return False
+
+            def get(self, url, headers=None):
+                # Up on every surface, but no models loaded.
+                return httpx.Response(
+                    200, json={"data": []}, request=httpx.Request("GET", url)
+                )
+
+        monkeypatch.setattr(httpx, "Client", FakeHttpxClient)
+
+        resp = self.client.post(
+            "/api/providers/validate",
+            json={"key": "OPENAI_BASE_URL", "value": "http://127.0.0.1:11434", "api_key": ""},
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["ok"] is True
+        assert data["reachable"] is True
+        assert data["models"] == []
+
+    def test_validate_openai_base_url_unreachable(self, monkeypatch):
+        """A genuinely unreachable endpoint reports reachable=False so offline
+        users get the 'could not reach' message, not a 'no models' block."""
+        import httpx
+
+        class FakeHttpxClient:
+            def __init__(self, *args, **kwargs):
+                pass
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *_exc):
+                return False
+
+            def get(self, url, headers=None):
+                raise httpx.ConnectError("refused", request=httpx.Request("GET", url))
+
+        monkeypatch.setattr(httpx, "Client", FakeHttpxClient)
+
+        resp = self.client.post(
+            "/api/providers/validate",
+            json={"key": "OPENAI_BASE_URL", "value": "http://127.0.0.1:11434", "api_key": ""},
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["ok"] is False
+        assert data["reachable"] is False
+        assert "Could not reach" in data["message"]
+
     def test_dashboard_update_capability_detects_generic_container(self, monkeypatch):
         import hermes_constants
         import hermes_cli.web_server as web_server


### PR DESCRIPTION
## Problem

Reported on Discord ("Hermes not connecting to Ollama?"): pointing the
desktop app at a local Ollama instance fails with

> Connected to http://127.0.0.1:11434, but it advertised no models at /v1/models. Start a model on that endpoint and try again.

even though the endpoint is up and has models pulled.

## Root cause

The desktop onboarding probe `/api/providers/validate` (the `OPENAI_BASE_URL`
branch in `hermes_cli/web_server.py`) builds the discovery URL as
`{value}/models`. Ollama (and llama.cpp / vLLM) serve the OpenAI-compatible
model list at **`/v1/models`**, not at the server root. A user who pastes the
bare root `http://127.0.0.1:11434` (exactly what the field shows) gets a 404 at
`/models`, which parses to zero models → the misleading "advertised no models
at /v1/models" hard block.

This is a desktop-only regression of behavior the **CLI already gets right**:
`hermes_cli/model_setup_flows.py` → `probe_api_models()` tries the `/v1`
fallback and saves the URL that actually worked, and the runtime
(`runtime_provider._auto_detect_local_model`) normalizes to `/v1` too. The
desktop probe reimplemented a naive single-shot version without the fallback.

## Fix

- **Backend** (`web_server.py`): probe the URL as given, then the OpenAI-compat
  `/v1` surface; return the `base_url` that actually advertised models so the
  caller persists a URL the runtime can reach (saving the bare root would 404
  at chat time too). Reachable-but-empty stays a soft block ("start a model");
  genuinely unreachable still reports `reachable=False`.
- **Frontend** (`onboarding.ts`, `hermes.ts`): `saveOnboardingLocalEndpoint`
  now persists `probe.base_url` (the resolved `/v1` URL) instead of the raw
  input.

## Tests

- `tests/hermes_cli/test_web_server.py`: `/v1` fallback for a bare root +
  resolved `base_url`; reachable-but-no-models soft block; unreachable case.
- `apps/desktop/src/store/onboarding.test.ts`: pasting the bare Ollama root
  persists the resolved `/v1` base_url.

All green; desktop `tsc --noEmit` clean.