### PR TITLE
fix(hermes_state): clear cached system_prompt on mid-session model switch

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -1508,10 +1508,14 @@ class SessionDB:
         Unlike ``update_token_counts`` which uses ``COALESCE(model, ?)``
         (only filling in NULL), this unconditionally sets the model column
         so that the dashboard reflects the user's latest /model choice.
+
+        Also nulls ``system_prompt`` so the cached snapshot (which embeds a
+        stale ``Model:`` / ``Provider:`` header) is rebuilt from the active
+        runtime state on the next turn. See #48173.
         """
         def _do(conn):
             conn.execute(
-                "UPDATE sessions SET model = ? WHERE id = ?",
+                "UPDATE sessions SET model = ?, system_prompt = NULL WHERE id = ?",
                 (model, session_id),
             )
         self._execute_write(_do)

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -173,7 +173,8 @@ class TestSessionLifecycle:
         assert session["model"] == "anthropic/claude-opus-4.6"
 
     def test_update_session_model_overwrites_existing(self, db):
-        """A mid-session /model switch must overwrite the stored model.
+        """A mid-session /model switch must overwrite the stored model
+        and clear the cached system_prompt (#48173).
 
         update_token_counts uses COALESCE(model, ?) (first-writer-wins), so
         the dashboard kept showing the original model after a switch (#34850).
@@ -186,9 +187,16 @@ class TestSessionLifecycle:
                                model="xiaomi/mimo-v2.5-pro")
         assert db.get_session("s1")["model"] == "xiaomi/mimo-v2.5-pro"
 
-        # Explicit switch overwrites it.
+        # Explicit switch overwrites it and clears system_prompt.
+        # First set a system_prompt to verify it gets nulled.
+        db.update_system_prompt("s1", "Model: xiaomi/mimo-v2.5-pro\nProvider: openai-codex")
+        assert db.get_session("s1")["system_prompt"] is not None
+
         db.update_session_model("s1", "xiaomi/mimo-v2.5")
-        assert db.get_session("s1")["model"] == "xiaomi/mimo-v2.5"
+        sess = db.get_session("s1")
+        assert sess["model"] == "xiaomi/mimo-v2.5"
+        assert sess["system_prompt"] is None, \
+            "system_prompt must be nulled so the next turn rebuilds it with the updated Model:/Provider: headers"
 
         # And a subsequent token update does NOT revert it (COALESCE no-ops
         # because the column is now non-NULL).


### PR DESCRIPTION
## Summary

After a `/model` switch mid-conversation, `update_session_model()` now also NULLs the persisted `system_prompt` column. The cached system_prompt snapshot embeds the old `Model:` / `Provider:` header, so the next gateway turn resurrects a stale label even though the actual API calls use the new model.

## Root cause

`switch_model()` in `agent_runtime_helpers.py` only cleared `agent._cached_system_prompt` in memory, but the gateway constructs fresh `AIAgent` instances and restores the persisted `sessions.system_prompt` for prefix-cache stability — so the next turn reused the stale snapshot.

## Fix

`UPDATE sessions SET model = ?, system_prompt = NULL WHERE id = ?`

This preserves the existing dashboard/session-model fix while forcing the cached prompt to be rebuilt with the new `Model:` / `Provider:` values.

## Test

- `test_update_session_model_overwrites_existing` updated to verify `system_prompt` is nulled after a model switch

Closes #48173