### PR TITLE
fix(gateway): add text-based model picker to Weixin adapter

### DIFF
--- a/gateway/platforms/helpers.py
+++ b/gateway/platforms/helpers.py
@@ -409,9 +409,15 @@ def convert_table_to_bullets(text: str) -> str:
 class TextModelPicker:
     """Text-based interactive model picker for platforms without inline keyboards.
 
-    Provides a multi-step drill-down flow (provider selection -> model selection)
-    that works on text-only platforms like WeChat and Yuanbao. Users reply with
-    numbers to navigate the menu.
+    Provides a multi-step drill-down flow (provider selection -> model selection
+    -> optional expensive-model confirmation) that works on text-only platforms
+    like WeChat and Yuanbao.  Users reply with numbers to navigate the menu.
+
+    State is keyed by ``session_key`` (which already encodes per-user isolation
+    in group chats), not bare ``chat_id`` — this prevents one group participant
+    from consuming another's picker.  Each state entry also carries the
+    ``requester_user_id`` of the user who initiated the picker and an
+    ``expires_at`` deadline, both validated on every subsequent response.
 
     Usage::
 
@@ -419,17 +425,27 @@ class TextModelPicker:
         self._model_picker = TextModelPicker(self)
 
         # In adapter when handling /model command:
-        await self._model_picker.send(chat_id, providers, current_model, current_provider,
-                                      session_key, on_model_selected)
+        await self._model_picker.send(chat_id, providers, current_model,
+                                      current_provider, session_key,
+                                      on_model_selected, requester_user_id)
 
         # In adapter message handler (before processing as normal message):
-        result = await self._model_picker.handle_response(chat_id, text)
+        result = await self._model_picker.handle_response(
+            session_key, text, requester_user_id,
+        )
         if result is not None:
             return  # message consumed by picker
     """
 
     # Exit keywords that cancel the picker at any stage
     EXIT_KEYWORDS: frozenset[str] = frozenset({"q", "quit", "exit", "cancel", "done", "0"})
+
+    # Confirmation affirmations for the expensive-model gate
+    CONFIRM_KEYWORDS: frozenset[str] = frozenset({"y", "yes", "confirm", "ok", "1"})
+
+    # Picker state expires after this many seconds (matches Matrix adapter's
+    # approval timeout default).
+    DEFAULT_TIMEOUT_SECONDS: int = 300
 
     def __init__(self, adapter):
         """Initialize with a reference to the platform adapter.
@@ -480,12 +496,17 @@ class TextModelPicker:
         current_provider: str,
         session_key: str,
         on_model_selected,
+        requester_user_id: str | None = None,
         metadata: dict | None = None,
-    ):
+    ) -> "SendResult":
         """Send an interactive text-based model picker.
 
         Two-step drill-down: provider selection -> model selection.
         Users reply with a number at each step, or 0 to cancel.
+
+        State is registered *only* after the picker message is successfully
+        delivered — a failed ``send()`` must not leave a stale state that would
+        intercept the next ordinary message (see hermes-sweeper review #48199).
         """
         from gateway.platforms.base import SendResult
 
@@ -494,56 +515,83 @@ class TextModelPicker:
             msg = self._adapter.format_message(text)
             result = await self._adapter.send(chat_id, msg)
 
-            self._state[chat_id] = {
+            if not result.success:
+                # Do NOT register state on send failure — the gateway will
+                # fall back to its static text list, and a stale state would
+                # hijack the next ordinary message.
+                return result
+
+            # Purge any expired entries to bound memory growth.
+            self._cleanup_expired()
+
+            self._state[session_key] = {
                 "stage": "provider",
                 "providers": providers,
                 "session_key": session_key,
+                "chat_id": chat_id,
                 "current_model": current_model,
                 "current_provider": current_provider,
                 "on_model_selected": on_model_selected,
+                "requester_user_id": requester_user_id or "",
+                "expires_at": time.monotonic() + self.DEFAULT_TIMEOUT_SECONDS,
             }
 
-            return SendResult(
-                success=result.success,
-                message_id=result.message_id,
-            )
+            return result
         except Exception as e:
             logger.warning("[%s] send_model_picker failed: %s", self._adapter.name, e)
-            from gateway.platforms.base import SendResult
             return SendResult(success=False, error=str(e))
 
     async def handle_response(
         self,
-        chat_id: str,
+        session_key: str,
         text: str,
+        requester_user_id: str | None = None,
     ) -> str | None:
         """Process a user reply as a model picker selection.
 
-        Returns None if there's no active picker state for this chat (the
+        Returns None if there's no active picker state for this session (the
         message should be forwarded to the agent normally). Returns a
         non-None value when the message was consumed by the picker flow.
+
+        Security checks (all must pass before the reply is treated as a picker
+        selection):
+        - **Session match**: state is keyed by ``session_key``, which already
+          isolates group participants via ``build_session_key()``.
+        - **Requester match**: the ``requester_user_id`` stored at ``send()``
+          time must equal the one passed here.  A reply from a different user
+          in the same group session falls through to the agent.
+        - **Expiry**: state past ``expires_at`` is discarded and falls through.
 
         Users can exit the picker by:
         - Typing 0
         - Typing one of: q, quit, exit, cancel, done
         - Sending an empty message
         """
-        state = self._state.get(chat_id)
+        state = self._state.get(session_key)
         if state is None:
+            return None
+
+        # Expiry check — discard stale state and fall through.
+        if self._is_expired(state):
+            self._state.pop(session_key, None)
+            return None
+
+        # Requester validation — only the user who opened the picker may
+        # interact with it.  Other group members' messages pass through.
+        stored_requester = state.get("requester_user_id", "")
+        if stored_requester and requester_user_id and requester_user_id != stored_requester:
             return None
 
         text = text.strip()
 
         # Check for exit conditions
         if not text or text.lower() in self.EXIT_KEYWORDS:
-            self._state.pop(chat_id, None)
+            self._state.pop(session_key, None)
             await self._adapter.send(
-                chat_id,
+                state.get("chat_id", ""),
                 self._adapter.format_message("Model selection cancelled."),
             )
             return "picker_cancelled"
-
-        from hermes_cli.providers import get_label
 
         if state["stage"] == "provider":
             # User is selecting a provider
@@ -566,7 +614,7 @@ class TextModelPicker:
 
             if selected_provider is None:
                 await self._adapter.send(
-                    chat_id,
+                    state.get("chat_id", ""),
                     self._adapter.format_message(
                         f"Invalid selection. Reply with a number (1-{len(state['providers'])}) "
                         f"or a provider slug, or 0 to cancel."
@@ -576,39 +624,33 @@ class TextModelPicker:
 
             models = selected_provider.get("models", [])
             provider_name = selected_provider.get("name", selected_provider.get("slug", "?"))
+            provider_slug = selected_provider["slug"]
 
             if not models:
                 # No curated models — switch directly to the provider
                 try:
                     confirm = await state["on_model_selected"](
-                        chat_id, "", selected_provider["slug"],
+                        state.get("chat_id", ""), "", provider_slug,
                     )
                 except Exception as exc:
                     logger.warning("[%s] picker callback failed: %s", self._adapter.name, exc)
                     confirm = f"Switch to {provider_name} failed: {exc}"
-                self._state.pop(chat_id, None)
-                await self._adapter.send(chat_id, self._adapter.format_message(confirm))
+                self._state.pop(session_key, None)
+                await self._adapter.send(state.get("chat_id", ""), self._adapter.format_message(confirm))
                 return "picker_consumed"
 
             if len(models) == 1:
-                # Only one model — switch directly
-                try:
-                    confirm = await state["on_model_selected"](
-                        chat_id, models[0], selected_provider["slug"],
-                    )
-                except Exception as exc:
-                    logger.warning("[%s] picker callback failed: %s", self._adapter.name, exc)
-                    confirm = f"Switch to {models[0]} on {provider_name} failed: {exc}"
-                self._state.pop(chat_id, None)
-                await self._adapter.send(chat_id, self._adapter.format_message(confirm))
-                return "picker_consumed"
+                # Only one model — run expensive-model gate, then switch
+                return await self._gate_and_switch(
+                    session_key, state, models[0], provider_slug, provider_name,
+                )
 
             # Multiple models — send model list
             model_text = self._build_model_text(models, provider_name)
-            await self._adapter.send(chat_id, self._adapter.format_message(model_text))
+            await self._adapter.send(state.get("chat_id", ""), self._adapter.format_message(model_text))
 
             state["stage"] = "model"
-            state["selected_provider_slug"] = selected_provider["slug"]
+            state["selected_provider_slug"] = provider_slug
             state["selected_provider_name"] = provider_name
             state["selected_provider_models"] = models
             return "picker_consumed"
@@ -634,7 +676,7 @@ class TextModelPicker:
 
             if selected_model is None:
                 await self._adapter.send(
-                    chat_id,
+                    state.get("chat_id", ""),
                     self._adapter.format_message(
                         f"Invalid selection. Reply with a number (1-{len(models)}) "
                         f"or an exact model name, or 0 to cancel."
@@ -642,25 +684,123 @@ class TextModelPicker:
                 )
                 return "picker_consumed"
 
-            try:
-                confirm = await state["on_model_selected"](
-                    chat_id, selected_model, provider_slug,
+            return await self._gate_and_switch(
+                session_key, state, selected_model, provider_slug, provider_name,
+            )
+
+        if state["stage"] == "confirm":
+            # Expensive-model confirmation stage
+            pending_model = state.get("pending_model", "")
+            pending_provider_slug = state.get("pending_provider_slug", "")
+            pending_provider_name = state.get("pending_provider_name", "?")
+
+            if text.lower() in self.CONFIRM_KEYWORDS:
+                # User confirmed — proceed with the switch
+                self._state.pop(session_key, None)
+                try:
+                    confirm = await state["on_model_selected"](
+                        state.get("chat_id", ""), pending_model, pending_provider_slug,
+                    )
+                except Exception as exc:
+                    logger.warning("[%s] picker callback failed: %s", self._adapter.name, exc)
+                    confirm = f"Switch to {pending_model} on {pending_provider_name} failed: {exc}"
+                await self._adapter.send(state.get("chat_id", ""), self._adapter.format_message(confirm))
+                return "picker_consumed"
+            else:
+                # Declined — cancel
+                self._state.pop(session_key, None)
+                await self._adapter.send(
+                    state.get("chat_id", ""),
+                    self._adapter.format_message(
+                        f"Model switch cancelled. Current model unchanged "
+                        f"({state.get('current_model', 'unknown')})."
+                    ),
                 )
-            except Exception as exc:
-                logger.warning("[%s] picker callback failed: %s", self._adapter.name, exc)
-                confirm = f"Switch to {selected_model} on {provider_name} failed: {exc}"
-            self._state.pop(chat_id, None)
-            await self._adapter.send(chat_id, self._adapter.format_message(confirm))
-            return "picker_consumed"
+                return "picker_cancelled"
 
         # Unknown stage — clear state and fall through
-        self._state.pop(chat_id, None)
+        self._state.pop(session_key, None)
         return None
 
-    def clear_state(self, chat_id: str) -> None:
-        """Clear picker state for a chat (e.g., on disconnect)."""
-        self._state.pop(chat_id, None)
+    async def _gate_and_switch(
+        self,
+        session_key: str,
+        state: dict,
+        model: str,
+        provider_slug: str,
+        provider_name: str,
+    ) -> str:
+        """Run the expensive-model guard; switch directly or enter confirm stage.
 
-    def is_active(self, chat_id: str) -> bool:
-        """Return True if there's an active picker session for this chat."""
-        return chat_id in self._state
+        Mirrors the typed ``/model <name>`` path in ``slash_commands.py`` which
+        gates expensive switches behind a confirmation prompt.  Inline-keyboard
+        pickers (Telegram/Discord) provide their own UI confirmation; this text
+        picker needs an equivalent text-based gate (see hermes-sweeper #48199).
+        """
+        chat_id = state.get("chat_id", "")
+
+        # Check if this model is above the cost guardrail.
+        cost_warning = None
+        try:
+            from hermes_cli.model_cost_guard import expensive_model_warning
+
+            cost_warning = await asyncio.to_thread(
+                expensive_model_warning,
+                model,
+                provider=provider_slug,
+            )
+        except Exception:
+            cost_warning = None
+
+        if cost_warning is not None:
+            # Enter confirmation stage
+            warning_text = (
+                f"⚠️ Expensive Model Warning\n\n"
+                f"{cost_warning.message}\n\n"
+                f"Reply with 'y' to confirm switching to {model}, "
+                f"or 'n'/0 to cancel."
+            )
+            await self._adapter.send(chat_id, self._adapter.format_message(warning_text))
+
+            state["stage"] = "confirm"
+            state["pending_model"] = model
+            state["pending_provider_slug"] = provider_slug
+            state["pending_provider_name"] = provider_name
+            # Refresh expiry so the confirmation window gets a full timeout
+            state["expires_at"] = time.monotonic() + self.DEFAULT_TIMEOUT_SECONDS
+            return "picker_consumed"
+
+        # Not expensive — switch immediately
+        try:
+            confirm = await state["on_model_selected"](
+                chat_id, model, provider_slug,
+            )
+        except Exception as exc:
+            logger.warning("[%s] picker callback failed: %s", self._adapter.name, exc)
+            confirm = f"Switch to {model} on {provider_name} failed: {exc}"
+        self._state.pop(session_key, None)
+        await self._adapter.send(chat_id, self._adapter.format_message(confirm))
+        return "picker_consumed"
+
+    @staticmethod
+    def _is_expired(state: dict) -> bool:
+        """Check if a picker state has passed its expiry deadline."""
+        expires_at = state.get("expires_at")
+        return expires_at is not None and time.monotonic() > float(expires_at)
+
+    def _cleanup_expired(self) -> None:
+        """Remove all expired states. Called on send() and periodically."""
+        expired_keys = [
+            key for key, state in self._state.items()
+            if self._is_expired(state)
+        ]
+        for key in expired_keys:
+            self._state.pop(key, None)
+
+    def clear_state(self, session_key: str) -> None:
+        """Clear picker state for a session (e.g., on disconnect)."""
+        self._state.pop(session_key, None)
+
+    def is_active(self, session_key: str) -> bool:
+        """Return True if there's an active picker session for this key."""
+        return session_key in self._state

--- a/gateway/platforms/helpers.py
+++ b/gateway/platforms/helpers.py
@@ -409,6 +409,41 @@ def convert_table_to_bullets(text: str) -> str:
 class TextModelPicker:
     """Text-based interactive model picker for platforms without inline keyboards.
 
+    **DM-only.**  This picker is restricted to private (1:1) chats.  When
+    ``chat_type`` is a non-DM scope (``"group"``, ``"channel"``, ``"thread"``,
+    etc.), ``send()`` returns a failed ``SendResult`` so the gateway falls
+    back to its static text list, and ``handle_response()`` returns ``None``
+    so any plain-text reply falls through to the agent unconsumed.
+
+    Why DM-only:
+      - **Single-user state machine.**  Pickers are a private conversation
+        between the user and the bot: "pick a provider", "pick a model",
+        "confirm".  This sequence lives in memory keyed by ``session_key``,
+        and any *other* user's plain-text reply in the same chat (a "1"
+        posted while someone is picking) would be consumed by the wrong
+        session if the chat is shared.
+      - **Even with requester validation, the UX is broken.**  We do check
+        that ``requester_user_id`` matches the picker opener on every reply,
+        and that does prevent another user from *switching* the opener's
+        model.  But it does not prevent the noise: a "1" the other user
+        types in normal chat gets silently swallowed by the picker and
+        vanishes from the conversation, which is confusing and looks like
+        a bug to both parties.
+      - **Group bot etiquette already restricts this elsewhere.**  Yuanbao's
+        ``GroupAtGuardMiddleware`` requires ``@bot`` to dispatch any non-
+        owner slash command in a group, and WeChat groups are similarly
+        access-gated.  Picker-on-text is too easy to misuse accidentally in
+        that environment.
+      - **The typed escape hatch still works in groups.**  ``/model <name>
+        --provider <slug>`` is unaffected — only the interactive menu is
+        restricted.  Users who need to switch a model in a group can still
+        do so explicitly; they just don't get the drill-down menu there.
+
+    Inline-keyboard pickers (Telegram / Discord / Matrix) are not affected
+    by this restriction — they use button callbacks (``callback_query`` /
+    reaction events) that are bound to the originating ``message_id``, so
+    the multi-user cross-talk problem does not arise.
+
     Provides a multi-step drill-down flow (provider selection -> model selection
     -> optional expensive-model confirmation) that works on text-only platforms
     like WeChat and Yuanbao.  Users reply with numbers to navigate the menu.
@@ -427,11 +462,12 @@ class TextModelPicker:
         # In adapter when handling /model command:
         await self._model_picker.send(chat_id, providers, current_model,
                                       current_provider, session_key,
-                                      on_model_selected, requester_user_id)
+                                      on_model_selected, requester_user_id,
+                                      chat_type=source.chat_type)
 
         # In adapter message handler (before processing as normal message):
         result = await self._model_picker.handle_response(
-            session_key, text, requester_user_id,
+            session_key, text, requester_user_id, chat_type=source.chat_type,
         )
         if result is not None:
             return  # message consumed by picker

--- a/gateway/platforms/helpers.py
+++ b/gateway/platforms/helpers.py
@@ -447,6 +447,13 @@ class TextModelPicker:
     # approval timeout default).
     DEFAULT_TIMEOUT_SECONDS: int = 300
 
+    # Chat types that are considered DM (private) scope.  Picker is DM-only:
+    # the multi-step interactive state machine doesn't mix with multi-user
+    # group chatter, and requester validation alone is not enough to keep
+    # other participants' replies from confusing the flow.
+    # Aligned with ``gateway/slash_access._DM_CHAT_TYPES``.
+    _DM_CHAT_TYPES: frozenset[str] = frozenset({"dm", "direct", "private", ""})
+
     def __init__(self, adapter):
         """Initialize with a reference to the platform adapter.
 
@@ -498,6 +505,7 @@ class TextModelPicker:
         on_model_selected,
         requester_user_id: str | None = None,
         metadata: dict | None = None,
+        chat_type: str = "",
     ) -> "SendResult":
         """Send an interactive text-based model picker.
 
@@ -507,8 +515,20 @@ class TextModelPicker:
         State is registered *only* after the picker message is successfully
         delivered — a failed ``send()`` must not leave a stale state that would
         intercept the next ordinary message (see hermes-sweeper review #48199).
+
+        DM-only: when ``chat_type`` is a non-DM scope (e.g. ``"group"``),
+        returns a failed ``SendResult`` immediately so the caller falls back
+        to its static text list.  This avoids the multi-user cross-talk that
+        makes an interactive state machine unreliable in groups.
         """
         from gateway.platforms.base import SendResult
+
+        if chat_type and chat_type.lower() not in self._DM_CHAT_TYPES:
+            logger.info(
+                "[%s] text picker skipped in chat_type=%s (DM-only)",
+                self._adapter.name, chat_type,
+            )
+            return SendResult(success=False, error="text picker is DM-only")
 
         try:
             text = self._build_provider_text(providers, current_model, current_provider)
@@ -546,12 +566,17 @@ class TextModelPicker:
         session_key: str,
         text: str,
         requester_user_id: str | None = None,
+        chat_type: str = "",
     ) -> str | None:
         """Process a user reply as a model picker selection.
 
         Returns None if there's no active picker state for this session (the
         message should be forwarded to the agent normally). Returns a
         non-None value when the message was consumed by the picker flow.
+
+        DM-only: when ``chat_type`` is a non-DM scope, always falls through
+        so the multi-user group chatter is never consumed by a single-user
+        picker state machine.
 
         Security checks (all must pass before the reply is treated as a picker
         selection):
@@ -567,6 +592,11 @@ class TextModelPicker:
         - Typing one of: q, quit, exit, cancel, done
         - Sending an empty message
         """
+        # DM-only guard runs first so a non-DM scope never reaches the
+        # state lookup below — cheaper than touching the dict at all.
+        if chat_type and chat_type.lower() not in self._DM_CHAT_TYPES:
+            return None
+
         state = self._state.get(session_key)
         if state is None:
             return None

--- a/gateway/platforms/helpers.py
+++ b/gateway/platforms/helpers.py
@@ -401,3 +401,266 @@ def convert_table_to_bullets(text: str) -> str:
         i += 1
 
     return '\n'.join(out)
+
+
+# ─── Text-Based Model Picker ───────────────────────────────────────────────────
+
+
+class TextModelPicker:
+    """Text-based interactive model picker for platforms without inline keyboards.
+
+    Provides a multi-step drill-down flow (provider selection -> model selection)
+    that works on text-only platforms like WeChat and Yuanbao. Users reply with
+    numbers to navigate the menu.
+
+    Usage::
+
+        # In adapter.__init__:
+        self._model_picker = TextModelPicker(self)
+
+        # In adapter when handling /model command:
+        await self._model_picker.send(chat_id, providers, current_model, current_provider,
+                                      session_key, on_model_selected)
+
+        # In adapter message handler (before processing as normal message):
+        result = await self._model_picker.handle_response(chat_id, text)
+        if result is not None:
+            return  # message consumed by picker
+    """
+
+    # Exit keywords that cancel the picker at any stage
+    EXIT_KEYWORDS: frozenset[str] = frozenset({"q", "quit", "exit", "cancel", "done", "0"})
+
+    def __init__(self, adapter):
+        """Initialize with a reference to the platform adapter.
+
+        The adapter must implement:
+        - send(chat_id, content) -> SendResult
+        - format_message(content) -> str
+        - name: str (for logging)
+        """
+        self._adapter = adapter
+        self._state: dict[str, dict] = {}
+
+    @staticmethod
+    def _build_provider_text(
+        providers: list,
+        current_model: str,
+        current_provider: str,
+    ) -> str:
+        """Build a numbered text list of providers for the user to choose from."""
+        from hermes_cli.providers import get_label
+
+        lines = [f"Current: {current_model or 'unknown'} ({get_label(current_provider)})", ""]
+        lines.append("Select a provider (reply with the number, or 0 to cancel):")
+        lines.append("")
+        for i, p in enumerate(providers, 1):
+            tag = " [current]" if p.get("is_current") else ""
+            model_count = len(p.get("models", []))
+            lines.append(f"  {i}. {p['name']} ({model_count} models){tag}")
+        lines.append("")
+        lines.append("Or type /model <name> --provider <slug> directly.")
+        return "\n".join(lines)
+
+    @staticmethod
+    def _build_model_text(models: list, provider_name: str) -> str:
+        """Build a fully enumerated text list of models."""
+        lines = [f"Models available on {provider_name}:", ""]
+        for i, m in enumerate(models, 1):
+            lines.append(f"  {i}. {m}")
+        lines.append("")
+        lines.append("Reply with the model number, exact model name, or 0 to cancel.")
+        return "\n".join(lines)
+
+    async def send(
+        self,
+        chat_id: str,
+        providers: list,
+        current_model: str,
+        current_provider: str,
+        session_key: str,
+        on_model_selected,
+        metadata: dict | None = None,
+    ):
+        """Send an interactive text-based model picker.
+
+        Two-step drill-down: provider selection -> model selection.
+        Users reply with a number at each step, or 0 to cancel.
+        """
+        from gateway.platforms.base import SendResult
+
+        try:
+            text = self._build_provider_text(providers, current_model, current_provider)
+            msg = self._adapter.format_message(text)
+            result = await self._adapter.send(chat_id, msg)
+
+            self._state[chat_id] = {
+                "stage": "provider",
+                "providers": providers,
+                "session_key": session_key,
+                "current_model": current_model,
+                "current_provider": current_provider,
+                "on_model_selected": on_model_selected,
+            }
+
+            return SendResult(
+                success=result.success,
+                message_id=result.message_id,
+            )
+        except Exception as e:
+            logger.warning("[%s] send_model_picker failed: %s", self._adapter.name, e)
+            from gateway.platforms.base import SendResult
+            return SendResult(success=False, error=str(e))
+
+    async def handle_response(
+        self,
+        chat_id: str,
+        text: str,
+    ) -> str | None:
+        """Process a user reply as a model picker selection.
+
+        Returns None if there's no active picker state for this chat (the
+        message should be forwarded to the agent normally). Returns a
+        non-None value when the message was consumed by the picker flow.
+
+        Users can exit the picker by:
+        - Typing 0
+        - Typing one of: q, quit, exit, cancel, done
+        - Sending an empty message
+        """
+        state = self._state.get(chat_id)
+        if state is None:
+            return None
+
+        text = text.strip()
+
+        # Check for exit conditions
+        if not text or text.lower() in self.EXIT_KEYWORDS:
+            self._state.pop(chat_id, None)
+            await self._adapter.send(
+                chat_id,
+                self._adapter.format_message("Model selection cancelled."),
+            )
+            return "picker_cancelled"
+
+        from hermes_cli.providers import get_label
+
+        if state["stage"] == "provider":
+            # User is selecting a provider
+            selected_provider = None
+
+            # Try numeric selection
+            if text.isdigit():
+                idx = int(text) - 1
+                providers = state["providers"]
+                if 0 <= idx < len(providers):
+                    selected_provider = providers[idx]
+
+            # Try slug match
+            if selected_provider is None:
+                slug = text.lower().strip()
+                for p in state["providers"]:
+                    if p.get("slug", "").lower() == slug:
+                        selected_provider = p
+                        break
+
+            if selected_provider is None:
+                await self._adapter.send(
+                    chat_id,
+                    self._adapter.format_message(
+                        f"Invalid selection. Reply with a number (1-{len(state['providers'])}) "
+                        f"or a provider slug, or 0 to cancel."
+                    ),
+                )
+                return "picker_consumed"
+
+            models = selected_provider.get("models", [])
+            provider_name = selected_provider.get("name", selected_provider.get("slug", "?"))
+
+            if not models:
+                # No curated models — switch directly to the provider
+                try:
+                    confirm = await state["on_model_selected"](
+                        chat_id, "", selected_provider["slug"],
+                    )
+                except Exception as exc:
+                    logger.warning("[%s] picker callback failed: %s", self._adapter.name, exc)
+                    confirm = f"Switch to {provider_name} failed: {exc}"
+                self._state.pop(chat_id, None)
+                await self._adapter.send(chat_id, self._adapter.format_message(confirm))
+                return "picker_consumed"
+
+            if len(models) == 1:
+                # Only one model — switch directly
+                try:
+                    confirm = await state["on_model_selected"](
+                        chat_id, models[0], selected_provider["slug"],
+                    )
+                except Exception as exc:
+                    logger.warning("[%s] picker callback failed: %s", self._adapter.name, exc)
+                    confirm = f"Switch to {models[0]} on {provider_name} failed: {exc}"
+                self._state.pop(chat_id, None)
+                await self._adapter.send(chat_id, self._adapter.format_message(confirm))
+                return "picker_consumed"
+
+            # Multiple models — send model list
+            model_text = self._build_model_text(models, provider_name)
+            await self._adapter.send(chat_id, self._adapter.format_message(model_text))
+
+            state["stage"] = "model"
+            state["selected_provider_slug"] = selected_provider["slug"]
+            state["selected_provider_name"] = provider_name
+            state["selected_provider_models"] = models
+            return "picker_consumed"
+
+        if state["stage"] == "model":
+            models = state.get("selected_provider_models", [])
+            provider_slug = state.get("selected_provider_slug", "")
+            provider_name = state.get("selected_provider_name", "?")
+            selected_model = None
+
+            # Try numeric selection
+            if text.isdigit():
+                idx = int(text) - 1
+                if 0 <= idx < len(models):
+                    selected_model = models[idx]
+
+            # Try exact model name match
+            if selected_model is None:
+                for m in models:
+                    if m.lower() == text.lower():
+                        selected_model = m
+                        break
+
+            if selected_model is None:
+                await self._adapter.send(
+                    chat_id,
+                    self._adapter.format_message(
+                        f"Invalid selection. Reply with a number (1-{len(models)}) "
+                        f"or an exact model name, or 0 to cancel."
+                    ),
+                )
+                return "picker_consumed"
+
+            try:
+                confirm = await state["on_model_selected"](
+                    chat_id, selected_model, provider_slug,
+                )
+            except Exception as exc:
+                logger.warning("[%s] picker callback failed: %s", self._adapter.name, exc)
+                confirm = f"Switch to {selected_model} on {provider_name} failed: {exc}"
+            self._state.pop(chat_id, None)
+            await self._adapter.send(chat_id, self._adapter.format_message(confirm))
+            return "picker_consumed"
+
+        # Unknown stage — clear state and fall through
+        self._state.pop(chat_id, None)
+        return None
+
+    def clear_state(self, chat_id: str) -> None:
+        """Clear picker state for a chat (e.g., on disconnect)."""
+        self._state.pop(chat_id, None)
+
+    def is_active(self, chat_id: str) -> bool:
+        """Return True if there's an active picker session for this chat."""
+        return chat_id in self._state

--- a/gateway/platforms/weixin.py
+++ b/gateway/platforms/weixin.py
@@ -1225,6 +1225,7 @@ class WeixinAdapter(BasePlatformAdapter):
         )
         self._pending_text_batches: Dict[str, MessageEvent] = {}
         self._pending_text_batch_tasks: Dict[str, asyncio.Task] = {}
+        self._model_picker_state: Dict[str, dict] = {}
 
         if self._account_id and not self._token:
             persisted = load_weixin_account(hermes_home, self._account_id)
@@ -1467,6 +1468,17 @@ class WeixinAdapter(BasePlatformAdapter):
             timestamp=datetime.now(),
         )
         logger.info("[%s] inbound from=%s type=%s media=%d", self.name, _safe_id(sender_id), source.chat_type, len(media_paths))
+
+        # Model picker response intercept: if there's active picker state for
+        # this chat and the message is plain text, handle it as a picker
+        # selection instead of forwarding to the agent.
+        if text and event.message_type == MessageType.TEXT:
+            picker_result = await self._handle_picker_response(
+                chat_id=effective_chat_id, text=text,
+            )
+            if picker_result is not None:
+                return  # message consumed by picker flow
+
         if event.message_type == MessageType.TEXT:
             self._enqueue_text_event(event)
         else:
@@ -2267,6 +2279,213 @@ class WeixinAdapter(BasePlatformAdapter):
                 "len": str(kw["plaintext_size"]),
             },
         }
+
+    # ------------------------------------------------------------------
+    # Model picker (text-only interactive flow for platforms without
+    # inline keyboards, e.g. WeChat).
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _build_picker_provider_text(
+        providers: list,
+        current_model: str,
+        current_provider: str,
+    ) -> str:
+        """Build a numbered text list of providers for the user to choose from."""
+        from hermes_cli.providers import get_label
+
+        lines = [f"Current: {current_model or 'unknown'} ({get_label(current_provider)})", ""]
+        lines.append("Select a provider (reply with the number):")
+        lines.append("")
+        for i, p in enumerate(providers, 1):
+            tag = " [current]" if p.get("is_current") else ""
+            model_count = len(p.get("models", []))
+            lines.append(f"  {i}. {p['name']} ({model_count} models){tag}")
+        lines.append("")
+        lines.append("Or type /model <name> --provider <slug> directly.")
+        return "\n".join(lines)
+
+    @staticmethod
+    def _build_picker_model_text(models: list, provider_name: str) -> str:
+        """Build a fully enumerated text list of models.
+        Shows every model — no paging, since WeChat has no inline keyboard.
+        """
+        lines = [f"Models available on {provider_name}:", ""]
+        for i, m in enumerate(models, 1):
+            lines.append(f"  {i}. {m}")
+        lines.append("")
+        lines.append("Reply with the model number or exact model name.")
+        return "\n".join(lines)
+
+    async def send_model_picker(
+        self,
+        chat_id: str,
+        providers: list,
+        current_model: str,
+        current_provider: str,
+        session_key: str,
+        on_model_selected,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> SendResult:
+        """Send an interactive text-based model picker.
+
+        Two-step drill-down: provider selection -> model selection.
+        On WeChat, the user replies with a number at each step.
+        """
+        try:
+            text = self._build_picker_provider_text(
+                providers, current_model, current_provider,
+            )
+            msg = self.format_message(text)
+            result = await self.send(chat_id, msg)
+
+            self._model_picker_state[chat_id] = {
+                "stage": "provider",
+                "providers": providers,
+                "session_key": session_key,
+                "current_model": current_model,
+                "current_provider": current_provider,
+                "on_model_selected": on_model_selected,
+            }
+
+            return SendResult(
+                success=result.success,
+                message_id=result.message_id,
+            )
+        except Exception as e:
+            logger.warning("[%s] send_model_picker failed: %s", self.name, e)
+            return SendResult(success=False, error=str(e))
+
+    async def _handle_picker_response(
+        self, chat_id: str, text: str,
+    ) -> Optional[str]:
+        """Process a user reply as a model picker selection.
+
+        Returns None if there's no active picker state for this chat (the
+        message should be forwarded to the agent normally). Returns a
+        non-None value when the message was consumed by the picker flow.
+        """
+        state = self._model_picker_state.get(chat_id)
+        if state is None:
+            return None
+
+        text = text.strip()
+        from hermes_cli.providers import get_label
+
+        if state["stage"] == "provider":
+            # User is selecting a provider
+            selected_provider = None
+            selected_idx = None
+
+            # Try numeric selection
+            if text.isdigit():
+                idx = int(text) - 1
+                providers = state["providers"]
+                if 0 <= idx < len(providers):
+                    selected_provider = providers[idx]
+                    selected_idx = idx
+
+            # Try slug match
+            if selected_provider is None:
+                slug = text.lower().strip()
+                for p in state["providers"]:
+                    if p.get("slug", "").lower() == slug:
+                        selected_provider = p
+                        break
+
+            if selected_provider is None:
+                await self.send(
+                    chat_id,
+                    self.format_message(
+                        f"Invalid selection. Reply with a number (1-{len(state['providers'])}) "
+                        f"or a provider slug."
+                    ),
+                )
+                return "picker_consumed"
+
+            models = selected_provider.get("models", [])
+            provider_name = selected_provider.get("name", selected_provider.get("slug", "?"))
+
+            if not models:
+                # No curated models — switch directly to the provider
+                # (auto-detect model from endpoint).
+                try:
+                    confirm = await state["on_model_selected"](
+                        chat_id, "", selected_provider["slug"],
+                    )
+                except Exception as exc:
+                    logger.warning("[%s] picker callback failed: %s", self.name, exc)
+                    confirm = f"Switch to {provider_name} failed: {exc}"
+                self._model_picker_state.pop(chat_id, None)
+                await self.send(chat_id, self.format_message(confirm))
+                return "picker_consumed"
+
+            if len(models) == 1:
+                # Only one model — switch directly
+                try:
+                    confirm = await state["on_model_selected"](
+                        chat_id, models[0], selected_provider["slug"],
+                    )
+                except Exception as exc:
+                    logger.warning("[%s] picker callback failed: %s", self.name, exc)
+                    confirm = f"Switch to {models[0]} on {provider_name} failed: {exc}"
+                self._model_picker_state.pop(chat_id, None)
+                await self.send(chat_id, self.format_message(confirm))
+                return "picker_consumed"
+
+            # Multiple models — send model list
+            model_text = self._build_picker_model_text(models, provider_name)
+            await self.send(chat_id, self.format_message(model_text))
+
+            state["stage"] = "model"
+            state["selected_provider_slug"] = selected_provider["slug"]
+            state["selected_provider_name"] = provider_name
+            state["selected_provider_models"] = models
+            return "picker_consumed"
+
+        if state["stage"] == "model":
+            models = state.get("selected_provider_models", [])
+            provider_slug = state.get("selected_provider_slug", "")
+            provider_name = state.get("selected_provider_name", "?")
+            selected_model = None
+
+            # Try numeric selection
+            if text.isdigit():
+                idx = int(text) - 1
+                if 0 <= idx < len(models):
+                    selected_model = models[idx]
+
+            # Try exact model name match
+            if selected_model is None:
+                for m in models:
+                    if m.lower() == text.lower():
+                        selected_model = m
+                        break
+
+            if selected_model is None:
+                await self.send(
+                    chat_id,
+                    self.format_message(
+                        f"Invalid selection. Reply with a number (1-{len(models)}) "
+                        f"or an exact model name."
+                    ),
+                )
+                return "picker_consumed"
+
+            try:
+                confirm = await state["on_model_selected"](
+                    chat_id, selected_model, provider_slug,
+                )
+            except Exception as exc:
+                logger.warning("[%s] picker callback failed: %s", self.name, exc)
+                confirm = f"Switch to {selected_model} on {provider_name} failed: {exc}"
+            self._model_picker_state.pop(chat_id, None)
+            await self.send(chat_id, self.format_message(confirm))
+            return "picker_consumed"
+
+        # Unknown stage — clear state and fall through
+        self._model_picker_state.pop(chat_id, None)
+        return None
 
     async def get_chat_info(self, chat_id: str) -> Dict[str, Any]:
         chat_type = "group" if chat_id.endswith("@chatroom") else "dm"

--- a/gateway/platforms/weixin.py
+++ b/gateway/platforms/weixin.py
@@ -1470,11 +1470,15 @@ class WeixinAdapter(BasePlatformAdapter):
         logger.info("[%s] inbound from=%s type=%s media=%d", self.name, _safe_id(sender_id), source.chat_type, len(media_paths))
 
         # Model picker response intercept: if there's active picker state for
-        # this chat and the message is plain text, handle it as a picker
+        # this session and the message is plain text, handle it as a picker
         # selection instead of forwarding to the agent.
         if text and event.message_type == MessageType.TEXT:
+            picker_session_key = self._text_batch_key(event)
             picker_result = await self._handle_picker_response(
-                chat_id=effective_chat_id, text=text,
+                chat_id=effective_chat_id,
+                session_key=picker_session_key,
+                text=text,
+                requester_user_id=sender_id,
             )
             if picker_result is not None:
                 return  # message consumed by picker flow
@@ -2294,6 +2298,7 @@ class WeixinAdapter(BasePlatformAdapter):
         current_provider: str,
         session_key: str,
         on_model_selected,
+        requester_user_id: Optional[str] = None,
         metadata: Optional[Dict[str, Any]] = None,
     ) -> SendResult:
         """Send an interactive text-based model picker.
@@ -2308,19 +2313,28 @@ class WeixinAdapter(BasePlatformAdapter):
             current_provider=current_provider,
             session_key=session_key,
             on_model_selected=on_model_selected,
+            requester_user_id=requester_user_id,
             metadata=metadata,
         )
 
     async def _handle_picker_response(
-        self, chat_id: str, text: str,
+        self,
+        chat_id: str,
+        session_key: str,
+        text: str,
+        requester_user_id: Optional[str] = None,
     ) -> Optional[str]:
         """Process a user reply as a model picker selection.
 
-        Returns None if there's no active picker state for this chat (the
+        Returns None if there's no active picker state for this session (the
         message should be forwarded to the agent normally). Returns a
         non-None value when the message was consumed by the picker flow.
         """
-        return await self._model_picker.handle_response(chat_id, text)
+        return await self._model_picker.handle_response(
+            session_key=session_key,
+            text=text,
+            requester_user_id=requester_user_id,
+        )
 
     async def get_chat_info(self, chat_id: str) -> Dict[str, Any]:
         chat_type = "group" if chat_id.endswith("@chatroom") else "dm"

--- a/gateway/platforms/weixin.py
+++ b/gateway/platforms/weixin.py
@@ -1479,6 +1479,7 @@ class WeixinAdapter(BasePlatformAdapter):
                 session_key=picker_session_key,
                 text=text,
                 requester_user_id=sender_id,
+                chat_type=chat_type,
             )
             if picker_result is not None:
                 return  # message consumed by picker flow
@@ -2300,11 +2301,15 @@ class WeixinAdapter(BasePlatformAdapter):
         on_model_selected,
         requester_user_id: Optional[str] = None,
         metadata: Optional[Dict[str, Any]] = None,
+        chat_type: str = "",
     ) -> SendResult:
         """Send an interactive text-based model picker.
 
         Two-step drill-down: provider selection -> model selection.
         On WeChat, the user replies with a number at each step, or 0/q/quit/exit/cancel/done to cancel.
+
+        DM-only: ``chat_type`` is forwarded to the picker which rejects
+        non-DM scopes (groups) so the gateway falls back to its static list.
         """
         return await self._model_picker.send(
             chat_id=chat_id,
@@ -2315,6 +2320,7 @@ class WeixinAdapter(BasePlatformAdapter):
             on_model_selected=on_model_selected,
             requester_user_id=requester_user_id,
             metadata=metadata,
+            chat_type=chat_type,
         )
 
     async def _handle_picker_response(
@@ -2323,6 +2329,7 @@ class WeixinAdapter(BasePlatformAdapter):
         session_key: str,
         text: str,
         requester_user_id: Optional[str] = None,
+        chat_type: str = "",
     ) -> Optional[str]:
         """Process a user reply as a model picker selection.
 
@@ -2334,6 +2341,7 @@ class WeixinAdapter(BasePlatformAdapter):
             session_key=session_key,
             text=text,
             requester_user_id=requester_user_id,
+            chat_type=chat_type,
         )
 
     async def get_chat_info(self, chat_id: str) -> Dict[str, Any]:

--- a/gateway/platforms/weixin.py
+++ b/gateway/platforms/weixin.py
@@ -56,7 +56,7 @@ except ImportError:  # pragma: no cover - dependency gate
     CRYPTO_AVAILABLE = False
 
 from gateway.config import Platform, PlatformConfig
-from gateway.platforms.helpers import MessageDeduplicator
+from gateway.platforms.helpers import MessageDeduplicator, TextModelPicker
 from gateway.platforms.base import (
     BasePlatformAdapter,
     MessageEvent,
@@ -1225,7 +1225,7 @@ class WeixinAdapter(BasePlatformAdapter):
         )
         self._pending_text_batches: Dict[str, MessageEvent] = {}
         self._pending_text_batch_tasks: Dict[str, asyncio.Task] = {}
-        self._model_picker_state: Dict[str, dict] = {}
+        self._model_picker = TextModelPicker(self)
 
         if self._account_id and not self._token:
             persisted = load_weixin_account(hermes_home, self._account_id)
@@ -2283,39 +2283,8 @@ class WeixinAdapter(BasePlatformAdapter):
     # ------------------------------------------------------------------
     # Model picker (text-only interactive flow for platforms without
     # inline keyboards, e.g. WeChat).
+    # Uses shared TextModelPicker from helpers.py
     # ------------------------------------------------------------------
-
-    @staticmethod
-    def _build_picker_provider_text(
-        providers: list,
-        current_model: str,
-        current_provider: str,
-    ) -> str:
-        """Build a numbered text list of providers for the user to choose from."""
-        from hermes_cli.providers import get_label
-
-        lines = [f"Current: {current_model or 'unknown'} ({get_label(current_provider)})", ""]
-        lines.append("Select a provider (reply with the number):")
-        lines.append("")
-        for i, p in enumerate(providers, 1):
-            tag = " [current]" if p.get("is_current") else ""
-            model_count = len(p.get("models", []))
-            lines.append(f"  {i}. {p['name']} ({model_count} models){tag}")
-        lines.append("")
-        lines.append("Or type /model <name> --provider <slug> directly.")
-        return "\n".join(lines)
-
-    @staticmethod
-    def _build_picker_model_text(models: list, provider_name: str) -> str:
-        """Build a fully enumerated text list of models.
-        Shows every model — no paging, since WeChat has no inline keyboard.
-        """
-        lines = [f"Models available on {provider_name}:", ""]
-        for i, m in enumerate(models, 1):
-            lines.append(f"  {i}. {m}")
-        lines.append("")
-        lines.append("Reply with the model number or exact model name.")
-        return "\n".join(lines)
 
     async def send_model_picker(
         self,
@@ -2330,31 +2299,17 @@ class WeixinAdapter(BasePlatformAdapter):
         """Send an interactive text-based model picker.
 
         Two-step drill-down: provider selection -> model selection.
-        On WeChat, the user replies with a number at each step.
+        On WeChat, the user replies with a number at each step, or 0/q/quit/exit/cancel/done to cancel.
         """
-        try:
-            text = self._build_picker_provider_text(
-                providers, current_model, current_provider,
-            )
-            msg = self.format_message(text)
-            result = await self.send(chat_id, msg)
-
-            self._model_picker_state[chat_id] = {
-                "stage": "provider",
-                "providers": providers,
-                "session_key": session_key,
-                "current_model": current_model,
-                "current_provider": current_provider,
-                "on_model_selected": on_model_selected,
-            }
-
-            return SendResult(
-                success=result.success,
-                message_id=result.message_id,
-            )
-        except Exception as e:
-            logger.warning("[%s] send_model_picker failed: %s", self.name, e)
-            return SendResult(success=False, error=str(e))
+        return await self._model_picker.send(
+            chat_id=chat_id,
+            providers=providers,
+            current_model=current_model,
+            current_provider=current_provider,
+            session_key=session_key,
+            on_model_selected=on_model_selected,
+            metadata=metadata,
+        )
 
     async def _handle_picker_response(
         self, chat_id: str, text: str,
@@ -2365,127 +2320,7 @@ class WeixinAdapter(BasePlatformAdapter):
         message should be forwarded to the agent normally). Returns a
         non-None value when the message was consumed by the picker flow.
         """
-        state = self._model_picker_state.get(chat_id)
-        if state is None:
-            return None
-
-        text = text.strip()
-        from hermes_cli.providers import get_label
-
-        if state["stage"] == "provider":
-            # User is selecting a provider
-            selected_provider = None
-            selected_idx = None
-
-            # Try numeric selection
-            if text.isdigit():
-                idx = int(text) - 1
-                providers = state["providers"]
-                if 0 <= idx < len(providers):
-                    selected_provider = providers[idx]
-                    selected_idx = idx
-
-            # Try slug match
-            if selected_provider is None:
-                slug = text.lower().strip()
-                for p in state["providers"]:
-                    if p.get("slug", "").lower() == slug:
-                        selected_provider = p
-                        break
-
-            if selected_provider is None:
-                await self.send(
-                    chat_id,
-                    self.format_message(
-                        f"Invalid selection. Reply with a number (1-{len(state['providers'])}) "
-                        f"or a provider slug."
-                    ),
-                )
-                return "picker_consumed"
-
-            models = selected_provider.get("models", [])
-            provider_name = selected_provider.get("name", selected_provider.get("slug", "?"))
-
-            if not models:
-                # No curated models — switch directly to the provider
-                # (auto-detect model from endpoint).
-                try:
-                    confirm = await state["on_model_selected"](
-                        chat_id, "", selected_provider["slug"],
-                    )
-                except Exception as exc:
-                    logger.warning("[%s] picker callback failed: %s", self.name, exc)
-                    confirm = f"Switch to {provider_name} failed: {exc}"
-                self._model_picker_state.pop(chat_id, None)
-                await self.send(chat_id, self.format_message(confirm))
-                return "picker_consumed"
-
-            if len(models) == 1:
-                # Only one model — switch directly
-                try:
-                    confirm = await state["on_model_selected"](
-                        chat_id, models[0], selected_provider["slug"],
-                    )
-                except Exception as exc:
-                    logger.warning("[%s] picker callback failed: %s", self.name, exc)
-                    confirm = f"Switch to {models[0]} on {provider_name} failed: {exc}"
-                self._model_picker_state.pop(chat_id, None)
-                await self.send(chat_id, self.format_message(confirm))
-                return "picker_consumed"
-
-            # Multiple models — send model list
-            model_text = self._build_picker_model_text(models, provider_name)
-            await self.send(chat_id, self.format_message(model_text))
-
-            state["stage"] = "model"
-            state["selected_provider_slug"] = selected_provider["slug"]
-            state["selected_provider_name"] = provider_name
-            state["selected_provider_models"] = models
-            return "picker_consumed"
-
-        if state["stage"] == "model":
-            models = state.get("selected_provider_models", [])
-            provider_slug = state.get("selected_provider_slug", "")
-            provider_name = state.get("selected_provider_name", "?")
-            selected_model = None
-
-            # Try numeric selection
-            if text.isdigit():
-                idx = int(text) - 1
-                if 0 <= idx < len(models):
-                    selected_model = models[idx]
-
-            # Try exact model name match
-            if selected_model is None:
-                for m in models:
-                    if m.lower() == text.lower():
-                        selected_model = m
-                        break
-
-            if selected_model is None:
-                await self.send(
-                    chat_id,
-                    self.format_message(
-                        f"Invalid selection. Reply with a number (1-{len(models)}) "
-                        f"or an exact model name."
-                    ),
-                )
-                return "picker_consumed"
-
-            try:
-                confirm = await state["on_model_selected"](
-                    chat_id, selected_model, provider_slug,
-                )
-            except Exception as exc:
-                logger.warning("[%s] picker callback failed: %s", self.name, exc)
-                confirm = f"Switch to {selected_model} on {provider_name} failed: {exc}"
-            self._model_picker_state.pop(chat_id, None)
-            await self.send(chat_id, self.format_message(confirm))
-            return "picker_consumed"
-
-        # Unknown stage — clear state and fall through
-        self._model_picker_state.pop(chat_id, None)
-        return None
+        return await self._model_picker.handle_response(chat_id, text)
 
     async def get_chat_info(self, chat_id: str) -> Dict[str, Any]:
         chat_type = "group" if chat_id.endswith("@chatroom") else "dm"

--- a/gateway/platforms/yuanbao.py
+++ b/gateway/platforms/yuanbao.py
@@ -60,7 +60,7 @@ from gateway.platforms.base import (
     cache_image_from_bytes,
     cache_video_from_bytes,
 )
-from gateway.platforms.helpers import MessageDeduplicator
+from gateway.platforms.helpers import MessageDeduplicator, TextModelPicker
 from gateway.platforms.yuanbao_media import (
     download_url as media_download_url,
     get_cos_credentials,
@@ -3228,6 +3228,16 @@ class DispatchMiddleware(InboundMiddleware):
     async def handle(self, ctx: InboundContext, next_fn) -> None:
         adapter = ctx.adapter
 
+        # Model picker response intercept: if there's active picker state for
+        # this chat and the message is plain text, handle it as a picker
+        # selection instead of forwarding to the agent.
+        if ctx.raw_text and ctx.msg_type == MessageType.TEXT:
+            picker_result = await adapter._handle_picker_response(
+                chat_id=ctx.chat_id, text=ctx.raw_text,
+            )
+            if picker_result is not None:
+                return  # message consumed by picker flow
+
         _sk = build_session_key(
             ctx.source,
             group_sessions_per_user=adapter.config.extra.get("group_sessions_per_user", True),
@@ -5263,6 +5273,9 @@ class YuanbaoAdapter(BasePlatformAdapter):
         )
         self._auto_sethome_done: bool = bool(_existing_home) and not _existing_home.startswith("group:")
 
+        # Text-based model picker for platforms without inline keyboards
+        self._model_picker = TextModelPicker(self)
+
     # ------------------------------------------------------------------
     # Task tracking helper
     # ------------------------------------------------------------------
@@ -5517,6 +5530,48 @@ class YuanbaoAdapter(BasePlatformAdapter):
             file_path=file_path, filename=filename,
             **kwargs,
         )
+
+    # ------------------------------------------------------------------
+    # Model picker (text-only interactive flow for platforms without
+    # inline keyboards, e.g. Yuanbao).
+    # Uses shared TextModelPicker from helpers.py
+    # ------------------------------------------------------------------
+
+    async def send_model_picker(
+        self,
+        chat_id: str,
+        providers: list,
+        current_model: str,
+        current_provider: str,
+        session_key: str,
+        on_model_selected,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> SendResult:
+        """Send an interactive text-based model picker.
+
+        Two-step drill-down: provider selection -> model selection.
+        On Yuanbao, the user replies with a number at each step, or 0/q/quit/exit/cancel/done to cancel.
+        """
+        return await self._model_picker.send(
+            chat_id=chat_id,
+            providers=providers,
+            current_model=current_model,
+            current_provider=current_provider,
+            session_key=session_key,
+            on_model_selected=on_model_selected,
+            metadata=metadata,
+        )
+
+    async def _handle_picker_response(
+        self, chat_id: str, text: str,
+    ) -> Optional[str]:
+        """Process a user reply as a model picker selection.
+
+        Returns None if there's no active picker state for this chat (the
+        message should be forwarded to the agent normally). Returns a
+        non-None value when the message was consumed by the picker flow.
+        """
+        return await self._model_picker.handle_response(chat_id, text)
 
     async def _get_cached_token(self) -> dict:
         """Get the current valid sign token (using module-level cache)."""

--- a/gateway/platforms/yuanbao.py
+++ b/gateway/platforms/yuanbao.py
@@ -3242,6 +3242,7 @@ class DispatchMiddleware(InboundMiddleware):
                 session_key=picker_session_key,
                 text=ctx.raw_text,
                 requester_user_id=ctx.source.user_id,
+                chat_type=ctx.chat_type,
             )
             if picker_result is not None:
                 return  # message consumed by picker flow
@@ -5555,11 +5556,15 @@ class YuanbaoAdapter(BasePlatformAdapter):
         on_model_selected,
         requester_user_id: Optional[str] = None,
         metadata: Optional[Dict[str, Any]] = None,
+        chat_type: str = "",
     ) -> SendResult:
         """Send an interactive text-based model picker.
 
         Two-step drill-down: provider selection -> model selection.
         On Yuanbao, the user replies with a number at each step, or 0/q/quit/exit/cancel/done to cancel.
+
+        DM-only: ``chat_type`` is forwarded to the picker which rejects
+        non-DM scopes (groups) so the gateway falls back to its static list.
         """
         return await self._model_picker.send(
             chat_id=chat_id,
@@ -5570,6 +5575,7 @@ class YuanbaoAdapter(BasePlatformAdapter):
             on_model_selected=on_model_selected,
             requester_user_id=requester_user_id,
             metadata=metadata,
+            chat_type=chat_type,
         )
 
     async def _handle_picker_response(
@@ -5578,6 +5584,7 @@ class YuanbaoAdapter(BasePlatformAdapter):
         session_key: str,
         text: str,
         requester_user_id: Optional[str] = None,
+        chat_type: str = "",
     ) -> Optional[str]:
         """Process a user reply as a model picker selection.
 
@@ -5589,6 +5596,7 @@ class YuanbaoAdapter(BasePlatformAdapter):
             session_key=session_key,
             text=text,
             requester_user_id=requester_user_id,
+            chat_type=chat_type,
         )
 
     async def _get_cached_token(self) -> dict:

--- a/gateway/platforms/yuanbao.py
+++ b/gateway/platforms/yuanbao.py
@@ -3229,11 +3229,19 @@ class DispatchMiddleware(InboundMiddleware):
         adapter = ctx.adapter
 
         # Model picker response intercept: if there's active picker state for
-        # this chat and the message is plain text, handle it as a picker
+        # this session and the message is plain text, handle it as a picker
         # selection instead of forwarding to the agent.
-        if ctx.raw_text and ctx.msg_type == MessageType.TEXT:
+        if ctx.raw_text and ctx.msg_type == MessageType.TEXT and ctx.source is not None:
+            picker_session_key = build_session_key(
+                ctx.source,
+                group_sessions_per_user=adapter.config.extra.get("group_sessions_per_user", True),
+                thread_sessions_per_user=adapter.config.extra.get("thread_sessions_per_user", False),
+            )
             picker_result = await adapter._handle_picker_response(
-                chat_id=ctx.chat_id, text=ctx.raw_text,
+                chat_id=ctx.chat_id,
+                session_key=picker_session_key,
+                text=ctx.raw_text,
+                requester_user_id=ctx.source.user_id,
             )
             if picker_result is not None:
                 return  # message consumed by picker flow
@@ -5545,6 +5553,7 @@ class YuanbaoAdapter(BasePlatformAdapter):
         current_provider: str,
         session_key: str,
         on_model_selected,
+        requester_user_id: Optional[str] = None,
         metadata: Optional[Dict[str, Any]] = None,
     ) -> SendResult:
         """Send an interactive text-based model picker.
@@ -5559,19 +5568,28 @@ class YuanbaoAdapter(BasePlatformAdapter):
             current_provider=current_provider,
             session_key=session_key,
             on_model_selected=on_model_selected,
+            requester_user_id=requester_user_id,
             metadata=metadata,
         )
 
     async def _handle_picker_response(
-        self, chat_id: str, text: str,
+        self,
+        chat_id: str,
+        session_key: str,
+        text: str,
+        requester_user_id: Optional[str] = None,
     ) -> Optional[str]:
         """Process a user reply as a model picker selection.
 
-        Returns None if there's no active picker state for this chat (the
+        Returns None if there's no active picker state for this session (the
         message should be forwarded to the agent normally). Returns a
         non-None value when the message was consumed by the picker flow.
         """
-        return await self._model_picker.handle_response(chat_id, text)
+        return await self._model_picker.handle_response(
+            session_key=session_key,
+            text=text,
+            requester_user_id=requester_user_id,
+        )
 
     async def _get_cached_token(self) -> dict:
         """Get the current valid sign token (using module-level cache)."""

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -1745,6 +1745,7 @@ class GatewaySlashCommandsMixin:
                         session_key=session_key,
                         on_model_selected=_on_model_selected,
                         metadata=metadata,
+                        chat_type=source.chat_type or "",
                     )
                     if result.success:
                         return None  # Picker sent — adapter handles the response

--- a/tests/gateway/test_helpers.py
+++ b/tests/gateway/test_helpers.py
@@ -1,10 +1,12 @@
 """Tests for gateway platform helpers."""
 
-import pytest
-from unittest.mock import AsyncMock, MagicMock
+import time
+from unittest.mock import AsyncMock, MagicMock, patch
 
-from gateway.platforms.helpers import TextModelPicker
+import pytest
+
 from gateway.platforms.base import SendResult
+from gateway.platforms.helpers import TextModelPicker
 
 
 class TestTextModelPicker:
@@ -24,6 +26,8 @@ class TestTextModelPicker:
         """Create a TextModelPicker instance."""
         return TextModelPicker(mock_adapter)
 
+    # ── Text formatting ──────────────────────────────────────────────
+
     def test_build_provider_text_format(self, picker):
         """Test provider list text formatting."""
         providers = [
@@ -31,7 +35,7 @@ class TestTextModelPicker:
             {"name": "DeepSeek", "slug": "deepseek", "models": ["ds-v4"], "is_current": False},
         ]
         text = TextModelPicker._build_provider_text(providers, "qwen-v3", "alibaba")
-        
+
         assert "Current: qwen-v3" in text
         assert "1. Alibaba (1 models) [current]" in text
         assert "2. DeepSeek (1 models)" in text
@@ -49,23 +53,65 @@ class TestTextModelPicker:
         """Test model list text formatting."""
         models = ["model-a", "model-b", "model-c"]
         text = TextModelPicker._build_model_text(models, "TestProvider")
-        
+
         assert "Models available on TestProvider:" in text
         assert "1. model-a" in text
         assert "2. model-b" in text
         assert "3. model-c" in text
         assert "or 0 to cancel" in text
 
+    # ── send() ──────────────────────────────────────────────────────
+
     @pytest.mark.asyncio
     async def test_send_stores_state(self, picker, mock_adapter):
-        """Test send_model_picker stores state correctly."""
+        """Test send_model_picker stores state correctly, keyed by session_key."""
         providers = [
             {"name": "Alibaba", "slug": "alibaba", "models": ["qwen-v3"], "is_current": True},
         ]
-        
+
         async def on_model_selected(chat_id, model, provider_slug):
             return f"Switched to {model}"
-        
+
+        result = await picker.send(
+            chat_id="chat-123",
+            providers=providers,
+            current_model="qwen-v3",
+            current_provider="alibaba",
+            session_key="sess-abc",
+            on_model_selected=on_model_selected,
+            requester_user_id="user-A",
+        )
+
+        assert result.success is True
+        # State is keyed by session_key, NOT chat_id
+        assert "sess-abc" in picker._state
+        assert "chat-123" not in picker._state
+        state = picker._state["sess-abc"]
+        assert state["stage"] == "provider"
+        assert state["chat_id"] == "chat-123"
+        assert state["current_model"] == "qwen-v3"
+        assert state["on_model_selected"] is on_model_selected
+        assert state["requester_user_id"] == "user-A"
+        assert "expires_at" in state
+        mock_adapter.send.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_send_failure_does_not_register_state(self, picker, mock_adapter):
+        """send() must not register state when adapter.send() fails.
+
+        Without this guard, the gateway falls back to its static text list
+        but the stale state would intercept the next ordinary message.
+        (hermes-sweeper review #48199)
+        """
+        mock_adapter.send = AsyncMock(return_value=SendResult(success=False, error="network"))
+
+        providers = [
+            {"name": "Alibaba", "slug": "alibaba", "models": ["qwen-v3"], "is_current": True},
+        ]
+
+        async def on_model_selected(chat_id, model, provider_slug):
+            return "ok"
+
         result = await picker.send(
             chat_id="chat-123",
             providers=providers,
@@ -74,20 +120,85 @@ class TestTextModelPicker:
             session_key="sess-abc",
             on_model_selected=on_model_selected,
         )
-        
-        assert result.success is True
-        assert "chat-123" in picker._state
-        state = picker._state["chat-123"]
-        assert state["stage"] == "provider"
-        assert state["current_model"] == "qwen-v3"
-        assert state["on_model_selected"] is on_model_selected
-        mock_adapter.send.assert_called_once()
+
+        assert result.success is False
+        # Critical: no state registered on failure
+        assert "sess-abc" not in picker._state
+
+    # ── handle_response() — no state / fall-through ──────────────────
 
     @pytest.mark.asyncio
     async def test_handle_response_no_state_returns_none(self, picker):
         """Test handle_response returns None when no active state."""
-        result = await picker.handle_response("chat-123", "1")
+        result = await picker.handle_response("sess-abc", "1")
         assert result is None
+
+    # ── handle_response() — expiry ───────────────────────────────────
+
+    @pytest.mark.asyncio
+    async def test_handle_response_expired_state_returns_none(self, picker, mock_adapter):
+        """Expired state must be discarded and fall through to the agent.
+
+        (hermes-sweeper review #48199)
+        """
+        picker._state["sess-abc"] = {
+            "stage": "provider",
+            "providers": [],
+            "chat_id": "chat-123",
+            "current_model": "old",
+            "on_model_selected": AsyncMock(),
+            "requester_user_id": "user-A",
+            "expires_at": time.monotonic() - 1,  # already expired
+        }
+
+        result = await picker.handle_response("sess-abc", "1", requester_user_id="user-A")
+        assert result is None
+        assert "sess-abc" not in picker._state  # expired state cleaned up
+        mock_adapter.send.assert_not_called()  # no message sent
+
+    # ── handle_response() — requester validation ─────────────────────
+
+    @pytest.mark.asyncio
+    async def test_handle_response_requester_mismatch_returns_none(self, picker, mock_adapter):
+        """A reply from a different user in the same group session must fall through.
+
+        (hermes-sweeper review #48199 — group isolation)
+        """
+        picker._state["sess-abc"] = {
+            "stage": "provider",
+            "providers": [{"name": "Alibaba", "slug": "alibaba", "models": ["qwen"], "is_current": True}],
+            "chat_id": "chat-123",
+            "current_model": "old",
+            "on_model_selected": AsyncMock(),
+            "requester_user_id": "user-A",
+            "expires_at": time.monotonic() + 300,
+        }
+
+        # User-B tries to interact with user-A's picker
+        result = await picker.handle_response("sess-abc", "1", requester_user_id="user-B")
+        assert result is None
+        # State preserved — user-A can still interact
+        assert "sess-abc" in picker._state
+        mock_adapter.send.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_handle_response_no_requester_stored_allows_anonymous(self, picker, mock_adapter):
+        """When no requester_user_id was stored, any user may interact (DM case)."""
+        picker._state["sess-abc"] = {
+            "stage": "provider",
+            "providers": [{"name": "Alibaba", "slug": "alibaba", "models": ["qwen"], "is_current": True}],
+            "chat_id": "chat-123",
+            "current_model": "old",
+            "on_model_selected": AsyncMock(),
+            "requester_user_id": "",  # not set — DM or legacy
+            "expires_at": time.monotonic() + 300,
+        }
+
+        result = await picker.handle_response("sess-abc", "1", requester_user_id="anyone")
+        # Should proceed normally (no requester mismatch check when stored is empty)
+        assert result is not None
+
+    # ── handle_response() — provider stage ──────────────────────────
 
     @pytest.mark.asyncio
     async def test_handle_response_provider_selection_advances_to_model(self, picker, mock_adapter):
@@ -96,121 +207,43 @@ class TestTextModelPicker:
             {"name": "Alibaba", "slug": "alibaba", "models": ["qwen-v3", "qwen-v2"], "is_current": True},
             {"name": "DeepSeek", "slug": "deepseek", "models": ["ds-v4"], "is_current": False},
         ]
-        
+
         async def on_model_selected(chat_id, model, provider_slug):
             return f"Switched to {model}"
-        
-        # Setup initial state
-        picker._state["chat-123"] = {
+
+        picker._state["sess-abc"] = {
             "stage": "provider",
             "providers": providers,
+            "chat_id": "chat-123",
             "current_model": "qwen-v3",
             "on_model_selected": on_model_selected,
+            "requester_user_id": "user-A",
+            "expires_at": time.monotonic() + 300,
         }
-        
-        result = await picker.handle_response("chat-123", "1")
+
+        result = await picker.handle_response("sess-abc", "1", requester_user_id="user-A")
         assert result == "picker_consumed"
-        assert picker._state["chat-123"]["stage"] == "model"
-        assert picker._state["chat-123"]["selected_provider_slug"] == "alibaba"
+        assert picker._state["sess-abc"]["stage"] == "model"
+        assert picker._state["sess-abc"]["selected_provider_slug"] == "alibaba"
 
     @pytest.mark.asyncio
-    async def test_handle_response_single_model_auto_switches(self, picker, mock_adapter):
-        """Test selecting a provider with single model auto-switches."""
-        async def on_model_selected(chat_id, model, provider_slug):
-            return f"Switched to {model} via {provider_slug}"
-        
-        picker._state["chat-123"] = {
-            "stage": "provider",
-            "providers": [
-                {"name": "DeepSeek", "slug": "deepseek", "models": ["ds-v4"], "is_current": False},
-            ],
-            "current_model": "old-model",
-            "on_model_selected": on_model_selected,
-        }
-        
-        result = await picker.handle_response("chat-123", "1")
-        assert result == "picker_consumed"
-        assert "chat-123" not in picker._state  # State cleared after switch
-        mock_adapter.send.assert_called_once()
-
-    @pytest.mark.asyncio
-    async def test_handle_response_model_selection_completes(self, picker, mock_adapter):
-        """Test selecting a model completes the flow."""
-        async def on_model_selected(chat_id, model, provider_slug):
-            return f"Switched to {model} via {provider_slug}"
-        
-        picker._state["chat-123"] = {
-            "stage": "model",
-            "selected_provider_slug": "alibaba",
-            "selected_provider_name": "Alibaba",
-            "selected_provider_models": ["qwen-v3", "qwen-v2"],
-            "on_model_selected": on_model_selected,
-        }
-        
-        result = await picker.handle_response("chat-123", "2")
-        assert result == "picker_consumed"
-        assert "chat-123" not in picker._state  # State cleared
-        mock_adapter.send.assert_called_once()
-
-    @pytest.mark.asyncio
-    async def test_handle_response_cancel_with_zero(self, picker, mock_adapter):
-        """Test typing 0 cancels the picker."""
-        picker._state["chat-123"] = {
-            "stage": "provider",
-            "providers": [],
-            "current_model": "old",
-            "on_model_selected": AsyncMock(),
-        }
-        
-        result = await picker.handle_response("chat-123", "0")
-        assert result == "picker_cancelled"
-        assert "chat-123" not in picker._state
-        mock_adapter.send.assert_called_once()
-        assert "cancelled" in mock_adapter.send.call_args[0][1].lower()
-
-    @pytest.mark.asyncio
-    async def test_handle_response_cancel_with_quit(self, picker, mock_adapter):
-        """Test typing quit cancels the picker."""
-        picker._state["chat-123"] = {
-            "stage": "provider",
-            "providers": [],
-            "current_model": "old",
-            "on_model_selected": AsyncMock(),
-        }
-        
-        result = await picker.handle_response("chat-123", "quit")
-        assert result == "picker_cancelled"
-        assert "chat-123" not in picker._state
-
-    @pytest.mark.asyncio
-    async def test_handle_response_cancel_with_empty(self, picker, mock_adapter):
-        """Test empty message cancels the picker."""
-        picker._state["chat-123"] = {
-            "stage": "provider",
-            "providers": [],
-            "current_model": "old",
-            "on_model_selected": AsyncMock(),
-        }
-        
-        result = await picker.handle_response("chat-123", "")
-        assert result == "picker_cancelled"
-        assert "chat-123" not in picker._state
-
-    @pytest.mark.asyncio
-    async def test_handle_response_invalid_selection(self, picker, mock_adapter):
+    async def test_handle_response_invalid_provider_selection(self, picker, mock_adapter):
         """Test invalid selection sends error but keeps state."""
-        picker._state["chat-123"] = {
+        picker._state["sess-abc"] = {
             "stage": "provider",
             "providers": [
                 {"name": "Alibaba", "slug": "alibaba", "models": ["qwen"], "is_current": True},
             ],
+            "chat_id": "chat-123",
             "current_model": "old",
             "on_model_selected": AsyncMock(),
+            "requester_user_id": "",
+            "expires_at": time.monotonic() + 300,
         }
-        
-        result = await picker.handle_response("chat-123", "99")
+
+        result = await picker.handle_response("sess-abc", "99")
         assert result == "picker_consumed"
-        assert picker._state["chat-123"]["stage"] == "provider"  # State preserved
+        assert picker._state["sess-abc"]["stage"] == "provider"  # State preserved
         mock_adapter.send.assert_called_once()
         assert "Invalid selection" in mock_adapter.send.call_args[0][1]
 
@@ -218,69 +251,305 @@ class TestTextModelPicker:
     async def test_handle_response_slug_selection(self, picker, mock_adapter):
         """Test selecting by provider slug works."""
         async def on_model_selected(chat_id, model, provider_slug):
-            return f"Switched"
-        
-        picker._state["chat-123"] = {
+            return "Switched"
+
+        picker._state["sess-abc"] = {
             "stage": "provider",
             "providers": [
                 {"name": "Alibaba", "slug": "alibaba", "models": ["qwen"], "is_current": True},
             ],
+            "chat_id": "chat-123",
             "current_model": "old",
             "on_model_selected": on_model_selected,
+            "requester_user_id": "",
+            "expires_at": time.monotonic() + 300,
         }
-        
-        result = await picker.handle_response("chat-123", "alibaba")
+
+        result = await picker.handle_response("sess-abc", "alibaba")
         assert result == "picker_consumed"
 
+    # ── handle_response() — model stage ─────────────────────────────
+
     @pytest.mark.asyncio
-    async def test_handle_response_model_by_name(self, picker, mock_adapter):
-        """Test selecting model by exact name works."""
+    async def test_handle_response_model_selection_completes(self, picker, mock_adapter):
+        """Test selecting a model completes the flow (non-expensive model)."""
         async def on_model_selected(chat_id, model, provider_slug):
-            return f"Switched"
-        
-        picker._state["chat-123"] = {
+            return f"Switched to {model} via {provider_slug}"
+
+        picker._state["sess-abc"] = {
             "stage": "model",
+            "chat_id": "chat-123",
             "selected_provider_slug": "alibaba",
             "selected_provider_name": "Alibaba",
             "selected_provider_models": ["qwen-v3", "qwen-v2"],
             "on_model_selected": on_model_selected,
+            "current_model": "old",
+            "requester_user_id": "",
+            "expires_at": time.monotonic() + 300,
         }
-        
-        result = await picker.handle_response("chat-123", "qwen-v3")
+
+        # Patch expensive_model_warning to return None (not expensive)
+        with patch("hermes_cli.model_cost_guard.expensive_model_warning", return_value=None):
+            result = await picker.handle_response("sess-abc", "2")
         assert result == "picker_consumed"
-        assert "chat-123" not in picker._state
+        assert "sess-abc" not in picker._state  # State cleared
+        mock_adapter.send.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_handle_response_model_by_name(self, picker, mock_adapter):
+        """Test selecting model by exact name works (non-expensive)."""
+        async def on_model_selected(chat_id, model, provider_slug):
+            return "Switched"
+
+        picker._state["sess-abc"] = {
+            "stage": "model",
+            "chat_id": "chat-123",
+            "selected_provider_slug": "alibaba",
+            "selected_provider_name": "Alibaba",
+            "selected_provider_models": ["qwen-v3", "qwen-v2"],
+            "on_model_selected": on_model_selected,
+            "current_model": "old",
+            "requester_user_id": "",
+            "expires_at": time.monotonic() + 300,
+        }
+
+        with patch("hermes_cli.model_cost_guard.expensive_model_warning", return_value=None):
+            result = await picker.handle_response("sess-abc", "qwen-v3")
+        assert result == "picker_consumed"
+        assert "sess-abc" not in picker._state
 
     @pytest.mark.asyncio
     async def test_handle_response_model_case_insensitive(self, picker, mock_adapter):
-        """Test model selection is case insensitive."""
+        """Test model selection is case insensitive (non-expensive)."""
         async def on_model_selected(chat_id, model, provider_slug):
-            return f"Switched"
-        
-        picker._state["chat-123"] = {
+            return "Switched"
+
+        picker._state["sess-abc"] = {
             "stage": "model",
+            "chat_id": "chat-123",
             "selected_provider_slug": "alibaba",
             "selected_provider_name": "Alibaba",
             "selected_provider_models": ["Qwen-V3", "qwen-v2"],
             "on_model_selected": on_model_selected,
+            "current_model": "old",
+            "requester_user_id": "",
+            "expires_at": time.monotonic() + 300,
         }
-        
-        result = await picker.handle_response("chat-123", "QWEN-V3")
+
+        with patch("hermes_cli.model_cost_guard.expensive_model_warning", return_value=None):
+            result = await picker.handle_response("sess-abc", "QWEN-V3")
         assert result == "picker_consumed"
+
+    # ── handle_response() — single-model auto-switch ─────────────────
+
+    @pytest.mark.asyncio
+    async def test_handle_response_single_model_auto_switches(self, picker, mock_adapter):
+        """Test selecting a provider with single model auto-switches (non-expensive)."""
+        async def on_model_selected(chat_id, model, provider_slug):
+            return f"Switched to {model} via {provider_slug}"
+
+        picker._state["sess-abc"] = {
+            "stage": "provider",
+            "providers": [
+                {"name": "DeepSeek", "slug": "deepseek", "models": ["ds-v4"], "is_current": False},
+            ],
+            "chat_id": "chat-123",
+            "current_model": "old-model",
+            "on_model_selected": on_model_selected,
+            "requester_user_id": "",
+            "expires_at": time.monotonic() + 300,
+        }
+
+        with patch("hermes_cli.model_cost_guard.expensive_model_warning", return_value=None):
+            result = await picker.handle_response("sess-abc", "1")
+        assert result == "picker_consumed"
+        assert "sess-abc" not in picker._state  # State cleared after switch
+        mock_adapter.send.assert_called_once()
+
+    # ── handle_response() — expensive-model confirmation ────────────
+
+    @pytest.mark.asyncio
+    async def test_expensive_model_enters_confirm_stage(self, picker, mock_adapter):
+        """Selecting an expensive model must enter a confirmation stage.
+
+        (hermes-sweeper review #48199)
+        """
+        from decimal import Decimal
+        from hermes_cli.model_cost_guard import ExpensiveModelWarning
+
+        fake_warning = ExpensiveModelWarning(
+            model="gpt-5.5-pro",
+            provider="openai",
+            input_cost_per_million=Decimal("50"),
+            output_cost_per_million=Decimal("200"),
+            source="models.dev",
+            message="!!! EXPENSIVE MODEL WARNING !!!",
+        )
+
+        picker._state["sess-abc"] = {
+            "stage": "model",
+            "chat_id": "chat-123",
+            "selected_provider_slug": "openai",
+            "selected_provider_name": "OpenAI",
+            "selected_provider_models": ["gpt-5.5-pro", "gpt-4o"],
+            "on_model_selected": AsyncMock(return_value="Switched!"),
+            "current_model": "old",
+            "requester_user_id": "",
+            "expires_at": time.monotonic() + 300,
+        }
+
+        with patch(
+            "hermes_cli.model_cost_guard.expensive_model_warning",
+            return_value=fake_warning,
+        ):
+            result = await picker.handle_response("sess-abc", "1")
+
+        assert result == "picker_consumed"
+        # State should be in confirm stage
+        assert picker._state["sess-abc"]["stage"] == "confirm"
+        assert picker._state["sess-abc"]["pending_model"] == "gpt-5.5-pro"
+        # on_model_selected should NOT have been called yet
+        picker._state["sess-abc"]["on_model_selected"].assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_expensive_model_confirm_proceeds(self, picker, mock_adapter):
+        """User confirming in the confirm stage completes the switch."""
+        on_selected = AsyncMock(return_value="Switched to gpt-5.5-pro")
+
+        picker._state["sess-abc"] = {
+            "stage": "confirm",
+            "chat_id": "chat-123",
+            "pending_model": "gpt-5.5-pro",
+            "pending_provider_slug": "openai",
+            "pending_provider_name": "OpenAI",
+            "on_model_selected": on_selected,
+            "current_model": "old",
+            "requester_user_id": "",
+            "expires_at": time.monotonic() + 300,
+        }
+
+        result = await picker.handle_response("sess-abc", "y")
+        assert result == "picker_consumed"
+        assert "sess-abc" not in picker._state  # State cleared
+        on_selected.assert_called_once()
+        # Check it was called with the pending model
+        assert on_selected.call_args[0][1] == "gpt-5.5-pro"
+
+    @pytest.mark.asyncio
+    async def test_expensive_model_confirm_cancel(self, picker, mock_adapter):
+        """User declining in the confirm stage cancels the switch."""
+        on_selected = AsyncMock(return_value="should not be called")
+
+        picker._state["sess-abc"] = {
+            "stage": "confirm",
+            "chat_id": "chat-123",
+            "pending_model": "gpt-5.5-pro",
+            "pending_provider_slug": "openai",
+            "pending_provider_name": "OpenAI",
+            "on_model_selected": on_selected,
+            "current_model": "old",
+            "requester_user_id": "",
+            "expires_at": time.monotonic() + 300,
+        }
+
+        result = await picker.handle_response("sess-abc", "n")
+        assert result == "picker_cancelled"
+        assert "sess-abc" not in picker._state
+        on_selected.assert_not_called()
+
+    # ── handle_response() — cancel conditions ───────────────────────
+
+    @pytest.mark.asyncio
+    async def test_handle_response_cancel_with_zero(self, picker, mock_adapter):
+        """Test typing 0 cancels the picker."""
+        picker._state["sess-abc"] = {
+            "stage": "provider",
+            "providers": [],
+            "chat_id": "chat-123",
+            "current_model": "old",
+            "on_model_selected": AsyncMock(),
+            "requester_user_id": "",
+            "expires_at": time.monotonic() + 300,
+        }
+
+        result = await picker.handle_response("sess-abc", "0")
+        assert result == "picker_cancelled"
+        assert "sess-abc" not in picker._state
+        mock_adapter.send.assert_called_once()
+        assert "cancelled" in mock_adapter.send.call_args[0][1].lower()
+
+    @pytest.mark.asyncio
+    async def test_handle_response_cancel_with_quit(self, picker, mock_adapter):
+        """Test typing quit cancels the picker."""
+        picker._state["sess-abc"] = {
+            "stage": "provider",
+            "providers": [],
+            "chat_id": "chat-123",
+            "current_model": "old",
+            "on_model_selected": AsyncMock(),
+            "requester_user_id": "",
+            "expires_at": time.monotonic() + 300,
+        }
+
+        result = await picker.handle_response("sess-abc", "quit")
+        assert result == "picker_cancelled"
+        assert "sess-abc" not in picker._state
+
+    @pytest.mark.asyncio
+    async def test_handle_response_cancel_with_empty(self, picker, mock_adapter):
+        """Test empty message cancels the picker."""
+        picker._state["sess-abc"] = {
+            "stage": "provider",
+            "providers": [],
+            "chat_id": "chat-123",
+            "current_model": "old",
+            "on_model_selected": AsyncMock(),
+            "requester_user_id": "",
+            "expires_at": time.monotonic() + 300,
+        }
+
+        result = await picker.handle_response("sess-abc", "")
+        assert result == "picker_cancelled"
+        assert "sess-abc" not in picker._state
+
+    # ── Utility methods ──────────────────────────────────────────────
 
     def test_is_active(self, picker):
         """Test is_active method."""
-        assert picker.is_active("chat-123") is False
-        picker._state["chat-123"] = {"stage": "provider"}
-        assert picker.is_active("chat-123") is True
+        assert picker.is_active("sess-abc") is False
+        picker._state["sess-abc"] = {"stage": "provider"}
+        assert picker.is_active("sess-abc") is True
 
     def test_clear_state(self, picker):
         """Test clear_state method."""
-        picker._state["chat-123"] = {"stage": "provider"}
-        picker.clear_state("chat-123")
-        assert "chat-123" not in picker._state
+        picker._state["sess-abc"] = {"stage": "provider"}
+        picker.clear_state("sess-abc")
+        assert "sess-abc" not in picker._state
 
     def test_exit_keywords_coverage(self):
         """Test all exit keywords are recognized."""
         keywords = ["q", "quit", "exit", "cancel", "done", "0"]
         for kw in keywords:
             assert kw in TextModelPicker.EXIT_KEYWORDS
+
+    def test_confirm_keywords_coverage(self):
+        """Test all confirm keywords are recognized."""
+        keywords = ["y", "yes", "confirm", "ok", "1"]
+        for kw in keywords:
+            assert kw in TextModelPicker.CONFIRM_KEYWORDS
+
+    @pytest.mark.asyncio
+    async def test_cleanup_expired_removes_stale_entries(self, picker):
+        """Test that _cleanup_expired removes expired states."""
+        picker._state["sess-old"] = {
+            "stage": "provider",
+            "expires_at": time.monotonic() - 100,  # expired
+        }
+        picker._state["sess-fresh"] = {
+            "stage": "provider",
+            "expires_at": time.monotonic() + 300,  # fresh
+        }
+
+        picker._cleanup_expired()
+        assert "sess-old" not in picker._state
+        assert "sess-fresh" in picker._state

--- a/tests/gateway/test_helpers.py
+++ b/tests/gateway/test_helpers.py
@@ -553,3 +553,171 @@ class TestTextModelPicker:
         picker._cleanup_expired()
         assert "sess-old" not in picker._state
         assert "sess-fresh" in picker._state
+
+    # ── DM-only guard ─────────────────────────────────────────────────
+
+    @pytest.mark.asyncio
+    async def test_send_group_chat_returns_failure_without_registering_state(self, picker, mock_adapter):
+        """send() in a group chat must fail fast and never register state.
+
+        The gateway reads ``result.success`` and falls back to its static
+        text list when the picker is unavailable — so we must NOT leave a
+        stale state that would hijack the next ordinary message.
+        """
+        providers = [
+            {"name": "Alibaba", "slug": "alibaba", "models": ["qwen-v3"], "is_current": True},
+        ]
+
+        async def on_model_selected(chat_id, model, provider_slug):
+            return "ok"
+
+        result = await picker.send(
+            chat_id="chat-123",
+            providers=providers,
+            current_model="qwen-v3",
+            current_provider="alibaba",
+            session_key="sess-abc",
+            on_model_selected=on_model_selected,
+            chat_type="group",
+        )
+
+        assert result.success is False
+        assert "DM-only" in (result.error or "")
+        # Adapter.send must NOT have been called — fail before doing real work.
+        mock_adapter.send.assert_not_called()
+        # And no state registered.
+        assert "sess-abc" not in picker._state
+
+    @pytest.mark.asyncio
+    async def test_send_dm_chat_succeeds(self, picker, mock_adapter):
+        """Explicit chat_type='dm' produces a normal picker send."""
+        providers = [
+            {"name": "Alibaba", "slug": "alibaba", "models": ["qwen-v3"], "is_current": True},
+        ]
+
+        async def on_model_selected(chat_id, model, provider_slug):
+            return "ok"
+
+        result = await picker.send(
+            chat_id="chat-123",
+            providers=providers,
+            current_model="qwen-v3",
+            current_provider="alibaba",
+            session_key="sess-abc",
+            on_model_selected=on_model_selected,
+            chat_type="dm",
+        )
+
+        assert result.success is True
+        assert "sess-abc" in picker._state
+
+    @pytest.mark.asyncio
+    async def test_send_direct_chat_type_accepted_as_dm(self, picker, mock_adapter):
+        """chat_type='direct' is in the DM set alongside 'dm'/'private'."""
+        providers = [
+            {"name": "Alibaba", "slug": "alibaba", "models": ["qwen-v3"], "is_current": True},
+        ]
+
+        async def on_model_selected(chat_id, model, provider_slug):
+            return "ok"
+
+        result = await picker.send(
+            chat_id="chat-123",
+            providers=providers,
+            current_model="qwen-v3",
+            current_provider="alibaba",
+            session_key="sess-abc",
+            on_model_selected=on_model_selected,
+            chat_type="direct",
+        )
+
+        assert result.success is True
+
+    @pytest.mark.asyncio
+    async def test_send_empty_chat_type_succeeds_for_backward_compat(self, picker, mock_adapter):
+        """When chat_type is empty (legacy callers), picker still works.
+
+        Empty string is in _DM_CHAT_TYPES — this preserves backward
+        compatibility for adapters that don't pass chat_type.
+        """
+        providers = [
+            {"name": "Alibaba", "slug": "alibaba", "models": ["qwen-v3"], "is_current": True},
+        ]
+
+        async def on_model_selected(chat_id, model, provider_slug):
+            return "ok"
+
+        result = await picker.send(
+            chat_id="chat-123",
+            providers=providers,
+            current_model="qwen-v3",
+            current_provider="alibaba",
+            session_key="sess-abc",
+            on_model_selected=on_model_selected,
+            chat_type="",
+        )
+
+        assert result.success is True
+
+    @pytest.mark.asyncio
+    async def test_handle_response_group_chat_returns_none_without_touching_state(self, picker, mock_adapter):
+        """handle_response in a group chat falls through before any state lookup.
+
+        Even if a stale state somehow exists (e.g. from a future code path
+        or a manual test setup), a non-DM scope must not consume messages.
+        """
+        picker._state["sess-abc"] = {
+            "stage": "provider",
+            "providers": [{"name": "Alibaba", "slug": "alibaba", "models": ["qwen"], "is_current": True}],
+            "chat_id": "chat-123",
+            "current_model": "old",
+            "on_model_selected": AsyncMock(),
+            "requester_user_id": "",
+            "expires_at": time.monotonic() + 300,
+        }
+
+        result = await picker.handle_response(
+            session_key="sess-abc", text="1", requester_user_id="user-A", chat_type="group",
+        )
+        assert result is None
+        # State untouched.
+        assert "sess-abc" in picker._state
+        mock_adapter.send.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_handle_response_dm_chat_consumes_state_normally(self, picker, mock_adapter):
+        """chat_type='dm' does not block — picker behaves as before."""
+        picker._state["sess-abc"] = {
+            "stage": "provider",
+            "providers": [{"name": "Alibaba", "slug": "alibaba", "models": ["qwen"], "is_current": True}],
+            "chat_id": "chat-123",
+            "current_model": "old",
+            "on_model_selected": AsyncMock(return_value="Switched"),
+            "requester_user_id": "",
+            "expires_at": time.monotonic() + 300,
+        }
+
+        with patch("hermes_cli.model_cost_guard.expensive_model_warning", return_value=None):
+            result = await picker.handle_response(
+                session_key="sess-abc", text="1", chat_type="dm",
+            )
+        assert result == "picker_consumed"
+
+    @pytest.mark.asyncio
+    async def test_handle_response_empty_chat_type_consumes_state_normally(self, picker, mock_adapter):
+        """Empty chat_type (legacy callers) — picker behaves as before."""
+        picker._state["sess-abc"] = {
+            "stage": "provider",
+            "providers": [{"name": "Alibaba", "slug": "alibaba", "models": ["qwen"], "is_current": True}],
+            "chat_id": "chat-123",
+            "current_model": "old",
+            "on_model_selected": AsyncMock(return_value="Switched"),
+            "requester_user_id": "",
+            "expires_at": time.monotonic() + 300,
+        }
+
+        with patch("hermes_cli.model_cost_guard.expensive_model_warning", return_value=None):
+            result = await picker.handle_response(
+                session_key="sess-abc", text="1", chat_type="",
+            )
+        assert result == "picker_consumed"

--- a/tests/gateway/test_helpers.py
+++ b/tests/gateway/test_helpers.py
@@ -1,0 +1,286 @@
+"""Tests for gateway platform helpers."""
+
+import pytest
+from unittest.mock import AsyncMock, MagicMock
+
+from gateway.platforms.helpers import TextModelPicker
+from gateway.platforms.base import SendResult
+
+
+class TestTextModelPicker:
+    """Tests for the TextModelPicker helper class."""
+
+    @pytest.fixture
+    def mock_adapter(self):
+        """Create a mock adapter for testing."""
+        adapter = MagicMock()
+        adapter.name = "test"
+        adapter.send = AsyncMock(return_value=SendResult(success=True, message_id="msg-123"))
+        adapter.format_message = lambda x: x
+        return adapter
+
+    @pytest.fixture
+    def picker(self, mock_adapter):
+        """Create a TextModelPicker instance."""
+        return TextModelPicker(mock_adapter)
+
+    def test_build_provider_text_format(self, picker):
+        """Test provider list text formatting."""
+        providers = [
+            {"name": "Alibaba", "slug": "alibaba", "models": ["qwen-v3"], "is_current": True},
+            {"name": "DeepSeek", "slug": "deepseek", "models": ["ds-v4"], "is_current": False},
+        ]
+        text = TextModelPicker._build_provider_text(providers, "qwen-v3", "alibaba")
+        
+        assert "Current: qwen-v3" in text
+        assert "1. Alibaba (1 models) [current]" in text
+        assert "2. DeepSeek (1 models)" in text
+        assert "or 0 to cancel" in text
+
+    def test_build_provider_text_empty_current(self, picker):
+        """Test provider text with empty current model."""
+        providers = [
+            {"name": "Alibaba", "slug": "alibaba", "models": ["qwen-v3"], "is_current": False},
+        ]
+        text = TextModelPicker._build_provider_text(providers, "", "alibaba")
+        assert "Current: unknown" in text
+
+    def test_build_model_text_format(self, picker):
+        """Test model list text formatting."""
+        models = ["model-a", "model-b", "model-c"]
+        text = TextModelPicker._build_model_text(models, "TestProvider")
+        
+        assert "Models available on TestProvider:" in text
+        assert "1. model-a" in text
+        assert "2. model-b" in text
+        assert "3. model-c" in text
+        assert "or 0 to cancel" in text
+
+    @pytest.mark.asyncio
+    async def test_send_stores_state(self, picker, mock_adapter):
+        """Test send_model_picker stores state correctly."""
+        providers = [
+            {"name": "Alibaba", "slug": "alibaba", "models": ["qwen-v3"], "is_current": True},
+        ]
+        
+        async def on_model_selected(chat_id, model, provider_slug):
+            return f"Switched to {model}"
+        
+        result = await picker.send(
+            chat_id="chat-123",
+            providers=providers,
+            current_model="qwen-v3",
+            current_provider="alibaba",
+            session_key="sess-abc",
+            on_model_selected=on_model_selected,
+        )
+        
+        assert result.success is True
+        assert "chat-123" in picker._state
+        state = picker._state["chat-123"]
+        assert state["stage"] == "provider"
+        assert state["current_model"] == "qwen-v3"
+        assert state["on_model_selected"] is on_model_selected
+        mock_adapter.send.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_handle_response_no_state_returns_none(self, picker):
+        """Test handle_response returns None when no active state."""
+        result = await picker.handle_response("chat-123", "1")
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_handle_response_provider_selection_advances_to_model(self, picker, mock_adapter):
+        """Test selecting a provider with multiple models advances to model stage."""
+        providers = [
+            {"name": "Alibaba", "slug": "alibaba", "models": ["qwen-v3", "qwen-v2"], "is_current": True},
+            {"name": "DeepSeek", "slug": "deepseek", "models": ["ds-v4"], "is_current": False},
+        ]
+        
+        async def on_model_selected(chat_id, model, provider_slug):
+            return f"Switched to {model}"
+        
+        # Setup initial state
+        picker._state["chat-123"] = {
+            "stage": "provider",
+            "providers": providers,
+            "current_model": "qwen-v3",
+            "on_model_selected": on_model_selected,
+        }
+        
+        result = await picker.handle_response("chat-123", "1")
+        assert result == "picker_consumed"
+        assert picker._state["chat-123"]["stage"] == "model"
+        assert picker._state["chat-123"]["selected_provider_slug"] == "alibaba"
+
+    @pytest.mark.asyncio
+    async def test_handle_response_single_model_auto_switches(self, picker, mock_adapter):
+        """Test selecting a provider with single model auto-switches."""
+        async def on_model_selected(chat_id, model, provider_slug):
+            return f"Switched to {model} via {provider_slug}"
+        
+        picker._state["chat-123"] = {
+            "stage": "provider",
+            "providers": [
+                {"name": "DeepSeek", "slug": "deepseek", "models": ["ds-v4"], "is_current": False},
+            ],
+            "current_model": "old-model",
+            "on_model_selected": on_model_selected,
+        }
+        
+        result = await picker.handle_response("chat-123", "1")
+        assert result == "picker_consumed"
+        assert "chat-123" not in picker._state  # State cleared after switch
+        mock_adapter.send.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_handle_response_model_selection_completes(self, picker, mock_adapter):
+        """Test selecting a model completes the flow."""
+        async def on_model_selected(chat_id, model, provider_slug):
+            return f"Switched to {model} via {provider_slug}"
+        
+        picker._state["chat-123"] = {
+            "stage": "model",
+            "selected_provider_slug": "alibaba",
+            "selected_provider_name": "Alibaba",
+            "selected_provider_models": ["qwen-v3", "qwen-v2"],
+            "on_model_selected": on_model_selected,
+        }
+        
+        result = await picker.handle_response("chat-123", "2")
+        assert result == "picker_consumed"
+        assert "chat-123" not in picker._state  # State cleared
+        mock_adapter.send.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_handle_response_cancel_with_zero(self, picker, mock_adapter):
+        """Test typing 0 cancels the picker."""
+        picker._state["chat-123"] = {
+            "stage": "provider",
+            "providers": [],
+            "current_model": "old",
+            "on_model_selected": AsyncMock(),
+        }
+        
+        result = await picker.handle_response("chat-123", "0")
+        assert result == "picker_cancelled"
+        assert "chat-123" not in picker._state
+        mock_adapter.send.assert_called_once()
+        assert "cancelled" in mock_adapter.send.call_args[0][1].lower()
+
+    @pytest.mark.asyncio
+    async def test_handle_response_cancel_with_quit(self, picker, mock_adapter):
+        """Test typing quit cancels the picker."""
+        picker._state["chat-123"] = {
+            "stage": "provider",
+            "providers": [],
+            "current_model": "old",
+            "on_model_selected": AsyncMock(),
+        }
+        
+        result = await picker.handle_response("chat-123", "quit")
+        assert result == "picker_cancelled"
+        assert "chat-123" not in picker._state
+
+    @pytest.mark.asyncio
+    async def test_handle_response_cancel_with_empty(self, picker, mock_adapter):
+        """Test empty message cancels the picker."""
+        picker._state["chat-123"] = {
+            "stage": "provider",
+            "providers": [],
+            "current_model": "old",
+            "on_model_selected": AsyncMock(),
+        }
+        
+        result = await picker.handle_response("chat-123", "")
+        assert result == "picker_cancelled"
+        assert "chat-123" not in picker._state
+
+    @pytest.mark.asyncio
+    async def test_handle_response_invalid_selection(self, picker, mock_adapter):
+        """Test invalid selection sends error but keeps state."""
+        picker._state["chat-123"] = {
+            "stage": "provider",
+            "providers": [
+                {"name": "Alibaba", "slug": "alibaba", "models": ["qwen"], "is_current": True},
+            ],
+            "current_model": "old",
+            "on_model_selected": AsyncMock(),
+        }
+        
+        result = await picker.handle_response("chat-123", "99")
+        assert result == "picker_consumed"
+        assert picker._state["chat-123"]["stage"] == "provider"  # State preserved
+        mock_adapter.send.assert_called_once()
+        assert "Invalid selection" in mock_adapter.send.call_args[0][1]
+
+    @pytest.mark.asyncio
+    async def test_handle_response_slug_selection(self, picker, mock_adapter):
+        """Test selecting by provider slug works."""
+        async def on_model_selected(chat_id, model, provider_slug):
+            return f"Switched"
+        
+        picker._state["chat-123"] = {
+            "stage": "provider",
+            "providers": [
+                {"name": "Alibaba", "slug": "alibaba", "models": ["qwen"], "is_current": True},
+            ],
+            "current_model": "old",
+            "on_model_selected": on_model_selected,
+        }
+        
+        result = await picker.handle_response("chat-123", "alibaba")
+        assert result == "picker_consumed"
+
+    @pytest.mark.asyncio
+    async def test_handle_response_model_by_name(self, picker, mock_adapter):
+        """Test selecting model by exact name works."""
+        async def on_model_selected(chat_id, model, provider_slug):
+            return f"Switched"
+        
+        picker._state["chat-123"] = {
+            "stage": "model",
+            "selected_provider_slug": "alibaba",
+            "selected_provider_name": "Alibaba",
+            "selected_provider_models": ["qwen-v3", "qwen-v2"],
+            "on_model_selected": on_model_selected,
+        }
+        
+        result = await picker.handle_response("chat-123", "qwen-v3")
+        assert result == "picker_consumed"
+        assert "chat-123" not in picker._state
+
+    @pytest.mark.asyncio
+    async def test_handle_response_model_case_insensitive(self, picker, mock_adapter):
+        """Test model selection is case insensitive."""
+        async def on_model_selected(chat_id, model, provider_slug):
+            return f"Switched"
+        
+        picker._state["chat-123"] = {
+            "stage": "model",
+            "selected_provider_slug": "alibaba",
+            "selected_provider_name": "Alibaba",
+            "selected_provider_models": ["Qwen-V3", "qwen-v2"],
+            "on_model_selected": on_model_selected,
+        }
+        
+        result = await picker.handle_response("chat-123", "QWEN-V3")
+        assert result == "picker_consumed"
+
+    def test_is_active(self, picker):
+        """Test is_active method."""
+        assert picker.is_active("chat-123") is False
+        picker._state["chat-123"] = {"stage": "provider"}
+        assert picker.is_active("chat-123") is True
+
+    def test_clear_state(self, picker):
+        """Test clear_state method."""
+        picker._state["chat-123"] = {"stage": "provider"}
+        picker.clear_state("chat-123")
+        assert "chat-123" not in picker._state
+
+    def test_exit_keywords_coverage(self):
+        """Test all exit keywords are recognized."""
+        keywords = ["q", "quit", "exit", "cancel", "done", "0"]
+        for kw in keywords:
+            assert kw in TextModelPicker.EXIT_KEYWORDS

--- a/tests/gateway/test_weixin.py
+++ b/tests/gateway/test_weixin.py
@@ -1205,3 +1205,266 @@ class TestWeixinApiTimeout:
             )
         )
         assert result == {"ret": 0, "msgs": [], "get_updates_buf": "buf-123"}
+
+
+class TestWeixinModelPicker:
+    """Tests for the text-based model picker on WeChat."""
+
+    def test_build_picker_provider_text_current_provider_marked(self):
+        providers = [
+            {"name": "Alibaba DashScope", "slug": "alibaba", "models": ["qwen3.7-plus"], "is_current": False},
+            {"name": "DeepSeek", "slug": "deepseek", "models": ["deepseek-v4-flash"], "is_current": True},
+            {"name": "OpenAI", "slug": "openai", "models": ["gpt-4o"], "is_current": False},
+        ]
+        text = WeixinAdapter._build_picker_provider_text(
+            providers, "deepseek-v4-flash", "deepseek"
+        )
+        assert "Current: deepseek-v4-flash (DeepSeek)" in text
+        assert "1. Alibaba DashScope (1 models)" in text
+        assert "2. DeepSeek (1 models) [current]" in text
+        assert "3. OpenAI (1 models)" in text
+        assert "Select a provider (reply with the number):" in text
+
+    def test_build_picker_provider_text_empty_current(self):
+        providers = [
+            {"name": "Alibaba", "slug": "alibaba", "models": ["qwen3.7-plus"], "is_current": False},
+        ]
+        text = WeixinAdapter._build_picker_provider_text(providers, "", "alibaba")
+        assert "Current: unknown (Alibaba)" in text
+
+    def test_build_picker_model_text_shows_all_models(self):
+        models = ["qwen3.7-plus", "qwen3.6-flash", "deepseek-v4-flash", "qwen3.5-plus", "qwen3-coder-plus"]
+        text = WeixinAdapter._build_picker_model_text(models, "Alibaba DashScope")
+        assert "Models available on Alibaba DashScope:" in text
+        for i, m in enumerate(models, 1):
+            assert f"  {i}. {m}" in text
+        assert "Reply with the model number or exact model name." in text
+
+    def test_build_picker_model_text_empty_list(self):
+        text = WeixinAdapter._build_picker_model_text([], "Custom Provider")
+        assert "Models available on Custom Provider:" in text
+        assert "Reply with the model number or exact model name." in text
+
+    @pytest.mark.asyncio
+    async def test_send_model_picker_sends_message_and_stores_state(self):
+        adapter = _make_adapter()
+        adapter.send = AsyncMock(return_value=SendResult(success=True, message_id="msg-123"))
+
+        providers = [
+            {"name": "Alibaba", "slug": "alibaba", "models": ["qwen3.7-plus", "qwen3.6-flash"], "is_current": True},
+            {"name": "DeepSeek", "slug": "deepseek", "models": ["deepseek-v4-flash"], "is_current": False},
+        ]
+
+        async def on_model_selected(chat_id, model, provider_slug):
+            return f"Switched to {model} via {provider_slug}"
+
+        result = await adapter.send_model_picker(
+            chat_id="chat-123",
+            providers=providers,
+            current_model="qwen3.6-flash",
+            current_provider="alibaba",
+            session_key="sess-abc",
+            on_model_selected=on_model_selected,
+        )
+
+        assert result.success is True
+        assert result.message_id == "msg-123"
+        assert "chat-123" in adapter._model_picker_state
+        state = adapter._model_picker_state["chat-123"]
+        assert state["stage"] == "provider"
+        assert state["current_model"] == "qwen3.6-flash"
+        assert state["on_model_selected"] is on_model_selected
+
+    @pytest.mark.asyncio
+    async def test_handle_picker_response_no_state_returns_none(self):
+        adapter = _make_adapter()
+        # No picker state exists
+        result = await adapter._handle_picker_response(chat_id="chat-no-state", text="1")
+        assert result is None  # Message should be forwarded to agent normally
+
+    @pytest.mark.asyncio
+    async def test_handle_picker_response_provider_select_by_number(self):
+        """When provider has multiple models, state advances to model stage."""
+        adapter = _make_adapter()
+        adapter.send = AsyncMock(return_value=SendResult(success=True, message_id="msg-456"))
+
+        providers = [
+            {"name": "Alibaba", "slug": "alibaba", "models": ["qwen3.7-plus", "qwen3.6-flash"], "is_current": True},
+            {"name": "DeepSeek", "slug": "deepseek", "models": ["deepseek-v4-flash"], "is_current": False},
+        ]
+
+        async def on_model_selected(chat_id, model, provider_slug):
+            return f"Switched to {model} via {provider_slug}"
+
+        # Set up picker state at provider stage
+        adapter._model_picker_state["chat-123"] = {
+            "stage": "provider",
+            "providers": providers,
+            "current_model": "qwen3.6-flash",
+            "on_model_selected": on_model_selected,
+        }
+
+        # User selects provider #1 (Alibaba) - has 2 models, should advance to model stage
+        result = await adapter._handle_picker_response(chat_id="chat-123", text="1")
+        assert result == "picker_consumed"
+        # State should advance to model stage
+        state = adapter._model_picker_state["chat-123"]
+        assert state["stage"] == "model"
+        assert state["selected_provider_slug"] == "alibaba"
+        assert state["selected_provider_models"] == ["qwen3.7-plus", "qwen3.6-flash"]
+
+    @pytest.mark.asyncio
+    async def test_handle_picker_response_provider_select_by_slug(self):
+        """Slug selection also works, and advances to model stage for multi-model providers."""
+        adapter = _make_adapter()
+        adapter.send = AsyncMock(return_value=SendResult(success=True, message_id="msg-789"))
+
+        providers = [
+            {"name": "Alibaba", "slug": "alibaba", "models": ["qwen3.7-plus"], "is_current": True},
+            {"name": "DeepSeek", "slug": "deepseek", "models": ["deepseek-v4-flash"], "is_current": False},
+        ]
+
+        async def on_model_selected(chat_id, model, provider_slug):
+            return f"Switched to {model} via {provider_slug}"
+
+        adapter._model_picker_state["chat-123"] = {
+            "stage": "provider",
+            "providers": providers,
+            "current_model": "qwen3.7-plus",
+            "on_model_selected": on_model_selected,
+        }
+
+        # User types provider slug "alibaba" - has 1 model, should auto-switch
+        result = await adapter._handle_picker_response(chat_id="chat-123", text="alibaba")
+        assert result == "picker_consumed"
+        # With single model, should auto-switch (state cleared)
+        assert "chat-123" not in adapter._model_picker_state
+        # Should have sent confirmation
+        adapter.send.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_handle_picker_response_invalid_provider_selection(self):
+        adapter = _make_adapter()
+        adapter.send = AsyncMock(return_value=SendResult(success=True, message_id="msg-invalid"))
+
+        providers = [
+            {"name": "Alibaba", "slug": "alibaba", "models": ["qwen3.7-plus"], "is_current": True},
+            {"name": "DeepSeek", "slug": "deepseek", "models": ["deepseek-v4-flash"], "is_current": False},
+        ]
+
+        adapter._model_picker_state["chat-123"] = {
+            "stage": "provider",
+            "providers": providers,
+            "current_model": "qwen3.7-plus",
+            "on_model_selected": AsyncMock(),
+        }
+
+        # User types invalid selection
+        result = await adapter._handle_picker_response(chat_id="chat-123", text="99")
+        assert result == "picker_consumed"
+        # Should have sent error message
+        adapter.send.assert_called_once()
+        call_args = adapter.send.call_args
+        assert "Invalid selection" in call_args[0][1]  # second arg is message text
+        # State should remain
+        assert adapter._model_picker_state["chat-123"]["stage"] == "provider"
+
+    @pytest.mark.asyncio
+    async def test_handle_picker_response_single_model_auto_switches(self):
+        adapter = _make_adapter()
+        adapter.send = AsyncMock(return_value=SendResult(success=True, message_id="msg-auto"))
+
+        async def on_model_selected(chat_id, model, provider_slug):
+            return f"Switched to {model} via {provider_slug}"
+
+        adapter._model_picker_state["chat-123"] = {
+            "stage": "provider",
+            "providers": [
+                {"name": "DeepSeek", "slug": "deepseek", "models": ["deepseek-v4-flash"], "is_current": False},
+            ],
+            "current_model": "qwen3.6-flash",
+            "on_model_selected": on_model_selected,
+        }
+
+        # User selects provider with only 1 model - should auto-switch
+        result = await adapter._handle_picker_response(chat_id="chat-123", text="1")
+        assert result == "picker_consumed"
+        # State should be cleared after switch
+        assert "chat-123" not in adapter._model_picker_state
+        # Should have called on_model_selected
+        adapter.send.assert_called_once()
+        call_args = adapter.send.call_args
+        assert "deepseek-v4-flash" in call_args[0][1]
+        assert "deepseek" in call_args[0][1]
+
+    @pytest.mark.asyncio
+    async def test_handle_picker_response_model_select_by_number(self):
+        adapter = _make_adapter()
+        adapter.send = AsyncMock(return_value=SendResult(success=True, message_id="msg-model"))
+
+        async def on_model_selected(chat_id, model, provider_slug):
+            return f"Switched to {model} via {provider_slug}"
+
+        adapter._model_picker_state["chat-123"] = {
+            "stage": "model",
+            "selected_provider_slug": "alibaba",
+            "selected_provider_name": "Alibaba DashScope",
+            "selected_provider_models": ["qwen3.7-plus", "qwen3.6-flash", "deepseek-v4-flash"],
+            "on_model_selected": on_model_selected,
+        }
+
+        # User selects model #2
+        result = await adapter._handle_picker_response(chat_id="chat-123", text="2")
+        assert result == "picker_consumed"
+        # State should be cleared
+        assert "chat-123" not in adapter._model_picker_state
+        # Confirmation should be sent
+        adapter.send.assert_called_once()
+        call_args = adapter.send.call_args
+        # Confirmation message contains model name and provider slug
+        assert "qwen3.6-flash" in call_args[0][1]
+        assert "alibaba" in call_args[0][1]
+
+    @pytest.mark.asyncio
+    async def test_handle_picker_response_model_select_by_name(self):
+        adapter = _make_adapter()
+        adapter.send = AsyncMock(return_value=SendResult(success=True, message_id="msg-name"))
+
+        async def on_model_selected(chat_id, model, provider_slug):
+            return f"Switched to {model} via {provider_slug}"
+
+        adapter._model_picker_state["chat-123"] = {
+            "stage": "model",
+            "selected_provider_slug": "alibaba",
+            "selected_provider_name": "Alibaba",
+            "selected_provider_models": ["qwen3.7-plus", "qwen3.6-flash"],
+            "on_model_selected": on_model_selected,
+        }
+
+        # User types exact model name
+        result = await adapter._handle_picker_response(chat_id="chat-123", text="qwen3.7-plus")
+        assert result == "picker_consumed"
+        assert "chat-123" not in adapter._model_picker_state
+        adapter.send.assert_called_once()
+        assert "qwen3.7-plus" in adapter.send.call_args[0][1]
+
+    @pytest.mark.asyncio
+    async def test_handle_picker_response_model_case_insensitive(self):
+        adapter = _make_adapter()
+        adapter.send = AsyncMock(return_value=SendResult(success=True, message_id="msg-ci"))
+
+        async def on_model_selected(chat_id, model, provider_slug):
+            return f"Switched to {model} via {provider_slug}"
+
+        adapter._model_picker_state["chat-123"] = {
+            "stage": "model",
+            "selected_provider_slug": "alibaba",
+            "selected_provider_name": "Alibaba",
+            "selected_provider_models": ["Qwen3.7-Plus", "qwen3.6-flash"],
+            "on_model_selected": on_model_selected,
+        }
+
+        # User types model name in different case
+        result = await adapter._handle_picker_response(chat_id="chat-123", text="Qwen3.7-PLUS")
+        assert result == "picker_consumed"
+        assert "chat-123" not in adapter._model_picker_state

--- a/tests/gateway/test_weixin.py
+++ b/tests/gateway/test_weixin.py
@@ -1251,6 +1251,7 @@ class TestWeixinModelPicker:
 
     @pytest.mark.asyncio
     async def test_send_model_picker_sends_message_and_stores_state(self):
+        """State is keyed by session_key and includes requester + expiry."""
         adapter = _make_adapter()
         adapter.send = AsyncMock(return_value=SendResult(success=True, message_id="msg-123"))
 
@@ -1269,22 +1270,78 @@ class TestWeixinModelPicker:
             current_provider="alibaba",
             session_key="sess-abc",
             on_model_selected=on_model_selected,
+            requester_user_id="user-A",
         )
 
         assert result.success is True
         assert result.message_id == "msg-123"
-        assert "chat-123" in adapter._model_picker._state
-        state = adapter._model_picker._state["chat-123"]
+        # State keyed by session_key, not chat_id
+        assert "sess-abc" in adapter._model_picker._state
+        assert "chat-123" not in adapter._model_picker._state
+        state = adapter._model_picker._state["sess-abc"]
         assert state["stage"] == "provider"
+        assert state["chat_id"] == "chat-123"
         assert state["current_model"] == "qwen3.6-flash"
         assert state["on_model_selected"] is on_model_selected
+        assert state["requester_user_id"] == "user-A"
+        assert "expires_at" in state
+
+    @pytest.mark.asyncio
+    async def test_send_model_picker_failure_does_not_register_state(self):
+        """Failed send must not leave stale state."""
+        adapter = _make_adapter()
+        adapter.send = AsyncMock(return_value=SendResult(success=False, error="network"))
+
+        providers = [
+            {"name": "Alibaba", "slug": "alibaba", "models": ["qwen3.7-plus"], "is_current": True},
+        ]
+
+        async def on_model_selected(chat_id, model, provider_slug):
+            return "ok"
+
+        result = await adapter.send_model_picker(
+            chat_id="chat-123",
+            providers=providers,
+            current_model="qwen3.6-flash",
+            current_provider="alibaba",
+            session_key="sess-abc",
+            on_model_selected=on_model_selected,
+        )
+
+        assert result.success is False
+        assert "sess-abc" not in adapter._model_picker._state
 
     @pytest.mark.asyncio
     async def test_handle_picker_response_no_state_returns_none(self):
         adapter = _make_adapter()
         # No picker state exists
-        result = await adapter._handle_picker_response(chat_id="chat-no-state", text="1")
+        result = await adapter._handle_picker_response(
+            chat_id="chat-no-state", session_key="sess-none", text="1",
+        )
         assert result is None  # Message should be forwarded to agent normally
+
+    @pytest.mark.asyncio
+    async def test_handle_picker_response_requester_mismatch_returns_none(self):
+        """A reply from a different user in the same group falls through."""
+        adapter = _make_adapter()
+        adapter.send = AsyncMock(return_value=SendResult(success=True, message_id="msg-x"))
+
+        adapter._model_picker._state["sess-abc"] = {
+            "stage": "provider",
+            "providers": [{"name": "Alibaba", "slug": "alibaba", "models": ["qwen"], "is_current": True}],
+            "chat_id": "chat-123",
+            "current_model": "old",
+            "on_model_selected": AsyncMock(),
+            "requester_user_id": "user-A",
+            "expires_at": __import__("time").monotonic() + 300,
+        }
+
+        # User-B tries to interact
+        result = await adapter._handle_picker_response(
+            chat_id="chat-123", session_key="sess-abc", text="1", requester_user_id="user-B",
+        )
+        assert result is None
+        assert "sess-abc" in adapter._model_picker._state  # state preserved for user-A
 
     @pytest.mark.asyncio
     async def test_handle_picker_response_provider_select_by_number(self):
@@ -1301,18 +1358,23 @@ class TestWeixinModelPicker:
             return f"Switched to {model} via {provider_slug}"
 
         # Set up picker state at provider stage
-        adapter._model_picker._state["chat-123"] = {
+        adapter._model_picker._state["sess-abc"] = {
             "stage": "provider",
             "providers": providers,
+            "chat_id": "chat-123",
             "current_model": "qwen3.6-flash",
             "on_model_selected": on_model_selected,
+            "requester_user_id": "",
+            "expires_at": __import__("time").monotonic() + 300,
         }
 
         # User selects provider #1 (Alibaba) - has 2 models, should advance to model stage
-        result = await adapter._handle_picker_response(chat_id="chat-123", text="1")
+        result = await adapter._handle_picker_response(
+            chat_id="chat-123", session_key="sess-abc", text="1",
+        )
         assert result == "picker_consumed"
         # State should advance to model stage
-        state = adapter._model_picker._state["chat-123"]
+        state = adapter._model_picker._state["sess-abc"]
         assert state["stage"] == "model"
         assert state["selected_provider_slug"] == "alibaba"
         assert state["selected_provider_models"] == ["qwen3.7-plus", "qwen3.6-flash"]
@@ -1331,18 +1393,24 @@ class TestWeixinModelPicker:
         async def on_model_selected(chat_id, model, provider_slug):
             return f"Switched to {model} via {provider_slug}"
 
-        adapter._model_picker._state["chat-123"] = {
+        adapter._model_picker._state["sess-abc"] = {
             "stage": "provider",
             "providers": providers,
+            "chat_id": "chat-123",
             "current_model": "qwen3.7-plus",
             "on_model_selected": on_model_selected,
+            "requester_user_id": "",
+            "expires_at": __import__("time").monotonic() + 300,
         }
 
         # User types provider slug "alibaba" - has 1 model, should auto-switch
-        result = await adapter._handle_picker_response(chat_id="chat-123", text="alibaba")
+        with patch("hermes_cli.model_cost_guard.expensive_model_warning", return_value=None):
+            result = await adapter._handle_picker_response(
+                chat_id="chat-123", session_key="sess-abc", text="alibaba",
+            )
         assert result == "picker_consumed"
         # With single model, should auto-switch (state cleared)
-        assert "chat-123" not in adapter._model_picker._state
+        assert "sess-abc" not in adapter._model_picker._state
         # Should have sent confirmation
         adapter.send.assert_called_once()
 
@@ -1356,22 +1424,27 @@ class TestWeixinModelPicker:
             {"name": "DeepSeek", "slug": "deepseek", "models": ["deepseek-v4-flash"], "is_current": False},
         ]
 
-        adapter._model_picker._state["chat-123"] = {
+        adapter._model_picker._state["sess-abc"] = {
             "stage": "provider",
             "providers": providers,
+            "chat_id": "chat-123",
             "current_model": "qwen3.7-plus",
             "on_model_selected": AsyncMock(),
+            "requester_user_id": "",
+            "expires_at": __import__("time").monotonic() + 300,
         }
 
         # User types invalid selection
-        result = await adapter._handle_picker_response(chat_id="chat-123", text="99")
+        result = await adapter._handle_picker_response(
+            chat_id="chat-123", session_key="sess-abc", text="99",
+        )
         assert result == "picker_consumed"
         # Should have sent error message
         adapter.send.assert_called_once()
         call_args = adapter.send.call_args
         assert "Invalid selection" in call_args[0][1]  # second arg is message text
         # State should remain
-        assert adapter._model_picker._state["chat-123"]["stage"] == "provider"
+        assert adapter._model_picker._state["sess-abc"]["stage"] == "provider"
 
     @pytest.mark.asyncio
     async def test_handle_picker_response_single_model_auto_switches(self):
@@ -1381,20 +1454,26 @@ class TestWeixinModelPicker:
         async def on_model_selected(chat_id, model, provider_slug):
             return f"Switched to {model} via {provider_slug}"
 
-        adapter._model_picker._state["chat-123"] = {
+        adapter._model_picker._state["sess-abc"] = {
             "stage": "provider",
             "providers": [
                 {"name": "DeepSeek", "slug": "deepseek", "models": ["deepseek-v4-flash"], "is_current": False},
             ],
+            "chat_id": "chat-123",
             "current_model": "qwen3.6-flash",
             "on_model_selected": on_model_selected,
+            "requester_user_id": "",
+            "expires_at": __import__("time").monotonic() + 300,
         }
 
         # User selects provider with only 1 model - should auto-switch
-        result = await adapter._handle_picker_response(chat_id="chat-123", text="1")
+        with patch("hermes_cli.model_cost_guard.expensive_model_warning", return_value=None):
+            result = await adapter._handle_picker_response(
+                chat_id="chat-123", session_key="sess-abc", text="1",
+            )
         assert result == "picker_consumed"
         # State should be cleared after switch
-        assert "chat-123" not in adapter._model_picker._state
+        assert "sess-abc" not in adapter._model_picker._state
         # Should have called on_model_selected
         adapter.send.assert_called_once()
         call_args = adapter.send.call_args
@@ -1409,19 +1488,26 @@ class TestWeixinModelPicker:
         async def on_model_selected(chat_id, model, provider_slug):
             return f"Switched to {model} via {provider_slug}"
 
-        adapter._model_picker._state["chat-123"] = {
+        adapter._model_picker._state["sess-abc"] = {
             "stage": "model",
+            "chat_id": "chat-123",
             "selected_provider_slug": "alibaba",
             "selected_provider_name": "Alibaba DashScope",
             "selected_provider_models": ["qwen3.7-plus", "qwen3.6-flash", "deepseek-v4-flash"],
             "on_model_selected": on_model_selected,
+            "current_model": "old",
+            "requester_user_id": "",
+            "expires_at": __import__("time").monotonic() + 300,
         }
 
         # User selects model #2
-        result = await adapter._handle_picker_response(chat_id="chat-123", text="2")
+        with patch("hermes_cli.model_cost_guard.expensive_model_warning", return_value=None):
+            result = await adapter._handle_picker_response(
+                chat_id="chat-123", session_key="sess-abc", text="2",
+            )
         assert result == "picker_consumed"
         # State should be cleared
-        assert "chat-123" not in adapter._model_picker._state
+        assert "sess-abc" not in adapter._model_picker._state
         # Confirmation should be sent
         adapter.send.assert_called_once()
         call_args = adapter.send.call_args
@@ -1437,18 +1523,25 @@ class TestWeixinModelPicker:
         async def on_model_selected(chat_id, model, provider_slug):
             return f"Switched to {model} via {provider_slug}"
 
-        adapter._model_picker._state["chat-123"] = {
+        adapter._model_picker._state["sess-abc"] = {
             "stage": "model",
+            "chat_id": "chat-123",
             "selected_provider_slug": "alibaba",
             "selected_provider_name": "Alibaba",
             "selected_provider_models": ["qwen3.7-plus", "qwen3.6-flash"],
             "on_model_selected": on_model_selected,
+            "current_model": "old",
+            "requester_user_id": "",
+            "expires_at": __import__("time").monotonic() + 300,
         }
 
         # User types exact model name
-        result = await adapter._handle_picker_response(chat_id="chat-123", text="qwen3.7-plus")
+        with patch("hermes_cli.model_cost_guard.expensive_model_warning", return_value=None):
+            result = await adapter._handle_picker_response(
+                chat_id="chat-123", session_key="sess-abc", text="qwen3.7-plus",
+            )
         assert result == "picker_consumed"
-        assert "chat-123" not in adapter._model_picker._state
+        assert "sess-abc" not in adapter._model_picker._state
         adapter.send.assert_called_once()
         assert "qwen3.7-plus" in adapter.send.call_args[0][1]
 
@@ -1460,18 +1553,25 @@ class TestWeixinModelPicker:
         async def on_model_selected(chat_id, model, provider_slug):
             return f"Switched to {model} via {provider_slug}"
 
-        adapter._model_picker._state["chat-123"] = {
+        adapter._model_picker._state["sess-abc"] = {
             "stage": "model",
+            "chat_id": "chat-123",
             "selected_provider_slug": "alibaba",
             "selected_provider_name": "Alibaba",
             "selected_provider_models": ["Qwen3.7-Plus", "qwen3.6-flash"],
             "on_model_selected": on_model_selected,
+            "current_model": "old",
+            "requester_user_id": "",
+            "expires_at": __import__("time").monotonic() + 300,
         }
 
         # User types model name in different case
-        result = await adapter._handle_picker_response(chat_id="chat-123", text="Qwen3.7-PLUS")
+        with patch("hermes_cli.model_cost_guard.expensive_model_warning", return_value=None):
+            result = await adapter._handle_picker_response(
+                chat_id="chat-123", session_key="sess-abc", text="Qwen3.7-PLUS",
+            )
         assert result == "picker_consumed"
-        assert "chat-123" not in adapter._model_picker._state
+        assert "sess-abc" not in adapter._model_picker._state
 
     @pytest.mark.asyncio
     async def test_handle_picker_response_cancel_with_zero(self):
@@ -1482,18 +1582,23 @@ class TestWeixinModelPicker:
         async def on_model_selected(chat_id, model, provider_slug):
             return f"Switched to {model} via {provider_slug}"
 
-        adapter._model_picker._state["chat-123"] = {
+        adapter._model_picker._state["sess-abc"] = {
             "stage": "provider",
             "providers": [
                 {"name": "Alibaba", "slug": "alibaba", "models": ["qwen3.7-plus"], "is_current": True},
             ],
+            "chat_id": "chat-123",
             "current_model": "qwen3.6-flash",
             "on_model_selected": on_model_selected,
+            "requester_user_id": "",
+            "expires_at": __import__("time").monotonic() + 300,
         }
 
-        result = await adapter._handle_picker_response(chat_id="chat-123", text="0")
+        result = await adapter._handle_picker_response(
+            chat_id="chat-123", session_key="sess-abc", text="0",
+        )
         assert result == "picker_cancelled"
-        assert "chat-123" not in adapter._model_picker._state
+        assert "sess-abc" not in adapter._model_picker._state
         adapter.send.assert_called_once()
         assert "cancelled" in adapter.send.call_args[0][1].lower()
 
@@ -1506,18 +1611,23 @@ class TestWeixinModelPicker:
         async def on_model_selected(chat_id, model, provider_slug):
             return f"Switched to {model} via {provider_slug}"
 
-        adapter._model_picker._state["chat-123"] = {
+        adapter._model_picker._state["sess-abc"] = {
             "stage": "provider",
             "providers": [
                 {"name": "Alibaba", "slug": "alibaba", "models": ["qwen3.7-plus"], "is_current": True},
             ],
+            "chat_id": "chat-123",
             "current_model": "qwen3.6-flash",
             "on_model_selected": on_model_selected,
+            "requester_user_id": "",
+            "expires_at": __import__("time").monotonic() + 300,
         }
 
-        result = await adapter._handle_picker_response(chat_id="chat-123", text="quit")
+        result = await adapter._handle_picker_response(
+            chat_id="chat-123", session_key="sess-abc", text="quit",
+        )
         assert result == "picker_cancelled"
-        assert "chat-123" not in adapter._model_picker._state
+        assert "sess-abc" not in adapter._model_picker._state
 
     @pytest.mark.asyncio
     async def test_handle_picker_response_cancel_with_empty_message(self):
@@ -1528,15 +1638,20 @@ class TestWeixinModelPicker:
         async def on_model_selected(chat_id, model, provider_slug):
             return f"Switched to {model} via {provider_slug}"
 
-        adapter._model_picker._state["chat-123"] = {
+        adapter._model_picker._state["sess-abc"] = {
             "stage": "provider",
             "providers": [
                 {"name": "Alibaba", "slug": "alibaba", "models": ["qwen3.7-plus"], "is_current": True},
             ],
+            "chat_id": "chat-123",
             "current_model": "qwen3.6-flash",
             "on_model_selected": on_model_selected,
+            "requester_user_id": "",
+            "expires_at": __import__("time").monotonic() + 300,
         }
 
-        result = await adapter._handle_picker_response(chat_id="chat-123", text="")
+        result = await adapter._handle_picker_response(
+            chat_id="chat-123", session_key="sess-abc", text="",
+        )
         assert result == "picker_cancelled"
-        assert "chat-123" not in adapter._model_picker._state
+        assert "sess-abc" not in adapter._model_picker._state

--- a/tests/gateway/test_weixin.py
+++ b/tests/gateway/test_weixin.py
@@ -1211,39 +1211,43 @@ class TestWeixinModelPicker:
     """Tests for the text-based model picker on WeChat."""
 
     def test_build_picker_provider_text_current_provider_marked(self):
+        from gateway.platforms.helpers import TextModelPicker
         providers = [
             {"name": "Alibaba DashScope", "slug": "alibaba", "models": ["qwen3.7-plus"], "is_current": False},
             {"name": "DeepSeek", "slug": "deepseek", "models": ["deepseek-v4-flash"], "is_current": True},
             {"name": "OpenAI", "slug": "openai", "models": ["gpt-4o"], "is_current": False},
         ]
-        text = WeixinAdapter._build_picker_provider_text(
+        text = TextModelPicker._build_provider_text(
             providers, "deepseek-v4-flash", "deepseek"
         )
         assert "Current: deepseek-v4-flash (DeepSeek)" in text
         assert "1. Alibaba DashScope (1 models)" in text
         assert "2. DeepSeek (1 models) [current]" in text
         assert "3. OpenAI (1 models)" in text
-        assert "Select a provider (reply with the number):" in text
+        assert "Select a provider (reply with the number, or 0 to cancel):" in text
 
     def test_build_picker_provider_text_empty_current(self):
+        from gateway.platforms.helpers import TextModelPicker
         providers = [
             {"name": "Alibaba", "slug": "alibaba", "models": ["qwen3.7-plus"], "is_current": False},
         ]
-        text = WeixinAdapter._build_picker_provider_text(providers, "", "alibaba")
+        text = TextModelPicker._build_provider_text(providers, "", "alibaba")
         assert "Current: unknown (Alibaba)" in text
 
     def test_build_picker_model_text_shows_all_models(self):
+        from gateway.platforms.helpers import TextModelPicker
         models = ["qwen3.7-plus", "qwen3.6-flash", "deepseek-v4-flash", "qwen3.5-plus", "qwen3-coder-plus"]
-        text = WeixinAdapter._build_picker_model_text(models, "Alibaba DashScope")
+        text = TextModelPicker._build_model_text(models, "Alibaba DashScope")
         assert "Models available on Alibaba DashScope:" in text
         for i, m in enumerate(models, 1):
             assert f"  {i}. {m}" in text
-        assert "Reply with the model number or exact model name." in text
+        assert "Reply with the model number, exact model name, or 0 to cancel." in text
 
     def test_build_picker_model_text_empty_list(self):
-        text = WeixinAdapter._build_picker_model_text([], "Custom Provider")
+        from gateway.platforms.helpers import TextModelPicker
+        text = TextModelPicker._build_model_text([], "Custom Provider")
         assert "Models available on Custom Provider:" in text
-        assert "Reply with the model number or exact model name." in text
+        assert "Reply with the model number, exact model name, or 0 to cancel." in text
 
     @pytest.mark.asyncio
     async def test_send_model_picker_sends_message_and_stores_state(self):
@@ -1269,8 +1273,8 @@ class TestWeixinModelPicker:
 
         assert result.success is True
         assert result.message_id == "msg-123"
-        assert "chat-123" in adapter._model_picker_state
-        state = adapter._model_picker_state["chat-123"]
+        assert "chat-123" in adapter._model_picker._state
+        state = adapter._model_picker._state["chat-123"]
         assert state["stage"] == "provider"
         assert state["current_model"] == "qwen3.6-flash"
         assert state["on_model_selected"] is on_model_selected
@@ -1297,7 +1301,7 @@ class TestWeixinModelPicker:
             return f"Switched to {model} via {provider_slug}"
 
         # Set up picker state at provider stage
-        adapter._model_picker_state["chat-123"] = {
+        adapter._model_picker._state["chat-123"] = {
             "stage": "provider",
             "providers": providers,
             "current_model": "qwen3.6-flash",
@@ -1308,7 +1312,7 @@ class TestWeixinModelPicker:
         result = await adapter._handle_picker_response(chat_id="chat-123", text="1")
         assert result == "picker_consumed"
         # State should advance to model stage
-        state = adapter._model_picker_state["chat-123"]
+        state = adapter._model_picker._state["chat-123"]
         assert state["stage"] == "model"
         assert state["selected_provider_slug"] == "alibaba"
         assert state["selected_provider_models"] == ["qwen3.7-plus", "qwen3.6-flash"]
@@ -1327,7 +1331,7 @@ class TestWeixinModelPicker:
         async def on_model_selected(chat_id, model, provider_slug):
             return f"Switched to {model} via {provider_slug}"
 
-        adapter._model_picker_state["chat-123"] = {
+        adapter._model_picker._state["chat-123"] = {
             "stage": "provider",
             "providers": providers,
             "current_model": "qwen3.7-plus",
@@ -1338,7 +1342,7 @@ class TestWeixinModelPicker:
         result = await adapter._handle_picker_response(chat_id="chat-123", text="alibaba")
         assert result == "picker_consumed"
         # With single model, should auto-switch (state cleared)
-        assert "chat-123" not in adapter._model_picker_state
+        assert "chat-123" not in adapter._model_picker._state
         # Should have sent confirmation
         adapter.send.assert_called_once()
 
@@ -1352,7 +1356,7 @@ class TestWeixinModelPicker:
             {"name": "DeepSeek", "slug": "deepseek", "models": ["deepseek-v4-flash"], "is_current": False},
         ]
 
-        adapter._model_picker_state["chat-123"] = {
+        adapter._model_picker._state["chat-123"] = {
             "stage": "provider",
             "providers": providers,
             "current_model": "qwen3.7-plus",
@@ -1367,7 +1371,7 @@ class TestWeixinModelPicker:
         call_args = adapter.send.call_args
         assert "Invalid selection" in call_args[0][1]  # second arg is message text
         # State should remain
-        assert adapter._model_picker_state["chat-123"]["stage"] == "provider"
+        assert adapter._model_picker._state["chat-123"]["stage"] == "provider"
 
     @pytest.mark.asyncio
     async def test_handle_picker_response_single_model_auto_switches(self):
@@ -1377,7 +1381,7 @@ class TestWeixinModelPicker:
         async def on_model_selected(chat_id, model, provider_slug):
             return f"Switched to {model} via {provider_slug}"
 
-        adapter._model_picker_state["chat-123"] = {
+        adapter._model_picker._state["chat-123"] = {
             "stage": "provider",
             "providers": [
                 {"name": "DeepSeek", "slug": "deepseek", "models": ["deepseek-v4-flash"], "is_current": False},
@@ -1390,7 +1394,7 @@ class TestWeixinModelPicker:
         result = await adapter._handle_picker_response(chat_id="chat-123", text="1")
         assert result == "picker_consumed"
         # State should be cleared after switch
-        assert "chat-123" not in adapter._model_picker_state
+        assert "chat-123" not in adapter._model_picker._state
         # Should have called on_model_selected
         adapter.send.assert_called_once()
         call_args = adapter.send.call_args
@@ -1405,7 +1409,7 @@ class TestWeixinModelPicker:
         async def on_model_selected(chat_id, model, provider_slug):
             return f"Switched to {model} via {provider_slug}"
 
-        adapter._model_picker_state["chat-123"] = {
+        adapter._model_picker._state["chat-123"] = {
             "stage": "model",
             "selected_provider_slug": "alibaba",
             "selected_provider_name": "Alibaba DashScope",
@@ -1417,7 +1421,7 @@ class TestWeixinModelPicker:
         result = await adapter._handle_picker_response(chat_id="chat-123", text="2")
         assert result == "picker_consumed"
         # State should be cleared
-        assert "chat-123" not in adapter._model_picker_state
+        assert "chat-123" not in adapter._model_picker._state
         # Confirmation should be sent
         adapter.send.assert_called_once()
         call_args = adapter.send.call_args
@@ -1433,7 +1437,7 @@ class TestWeixinModelPicker:
         async def on_model_selected(chat_id, model, provider_slug):
             return f"Switched to {model} via {provider_slug}"
 
-        adapter._model_picker_state["chat-123"] = {
+        adapter._model_picker._state["chat-123"] = {
             "stage": "model",
             "selected_provider_slug": "alibaba",
             "selected_provider_name": "Alibaba",
@@ -1444,7 +1448,7 @@ class TestWeixinModelPicker:
         # User types exact model name
         result = await adapter._handle_picker_response(chat_id="chat-123", text="qwen3.7-plus")
         assert result == "picker_consumed"
-        assert "chat-123" not in adapter._model_picker_state
+        assert "chat-123" not in adapter._model_picker._state
         adapter.send.assert_called_once()
         assert "qwen3.7-plus" in adapter.send.call_args[0][1]
 
@@ -1456,7 +1460,7 @@ class TestWeixinModelPicker:
         async def on_model_selected(chat_id, model, provider_slug):
             return f"Switched to {model} via {provider_slug}"
 
-        adapter._model_picker_state["chat-123"] = {
+        adapter._model_picker._state["chat-123"] = {
             "stage": "model",
             "selected_provider_slug": "alibaba",
             "selected_provider_name": "Alibaba",
@@ -1467,4 +1471,72 @@ class TestWeixinModelPicker:
         # User types model name in different case
         result = await adapter._handle_picker_response(chat_id="chat-123", text="Qwen3.7-PLUS")
         assert result == "picker_consumed"
-        assert "chat-123" not in adapter._model_picker_state
+        assert "chat-123" not in adapter._model_picker._state
+
+    @pytest.mark.asyncio
+    async def test_handle_picker_response_cancel_with_zero(self):
+        """User can cancel picker by typing 0."""
+        adapter = _make_adapter()
+        adapter.send = AsyncMock(return_value=SendResult(success=True, message_id="msg-cancel"))
+
+        async def on_model_selected(chat_id, model, provider_slug):
+            return f"Switched to {model} via {provider_slug}"
+
+        adapter._model_picker._state["chat-123"] = {
+            "stage": "provider",
+            "providers": [
+                {"name": "Alibaba", "slug": "alibaba", "models": ["qwen3.7-plus"], "is_current": True},
+            ],
+            "current_model": "qwen3.6-flash",
+            "on_model_selected": on_model_selected,
+        }
+
+        result = await adapter._handle_picker_response(chat_id="chat-123", text="0")
+        assert result == "picker_cancelled"
+        assert "chat-123" not in adapter._model_picker._state
+        adapter.send.assert_called_once()
+        assert "cancelled" in adapter.send.call_args[0][1].lower()
+
+    @pytest.mark.asyncio
+    async def test_handle_picker_response_cancel_with_quit(self):
+        """User can cancel picker by typing quit."""
+        adapter = _make_adapter()
+        adapter.send = AsyncMock(return_value=SendResult(success=True, message_id="msg-cancel"))
+
+        async def on_model_selected(chat_id, model, provider_slug):
+            return f"Switched to {model} via {provider_slug}"
+
+        adapter._model_picker._state["chat-123"] = {
+            "stage": "provider",
+            "providers": [
+                {"name": "Alibaba", "slug": "alibaba", "models": ["qwen3.7-plus"], "is_current": True},
+            ],
+            "current_model": "qwen3.6-flash",
+            "on_model_selected": on_model_selected,
+        }
+
+        result = await adapter._handle_picker_response(chat_id="chat-123", text="quit")
+        assert result == "picker_cancelled"
+        assert "chat-123" not in adapter._model_picker._state
+
+    @pytest.mark.asyncio
+    async def test_handle_picker_response_cancel_with_empty_message(self):
+        """User can cancel picker by sending empty message."""
+        adapter = _make_adapter()
+        adapter.send = AsyncMock(return_value=SendResult(success=True, message_id="msg-cancel"))
+
+        async def on_model_selected(chat_id, model, provider_slug):
+            return f"Switched to {model} via {provider_slug}"
+
+        adapter._model_picker._state["chat-123"] = {
+            "stage": "provider",
+            "providers": [
+                {"name": "Alibaba", "slug": "alibaba", "models": ["qwen3.7-plus"], "is_current": True},
+            ],
+            "current_model": "qwen3.6-flash",
+            "on_model_selected": on_model_selected,
+        }
+
+        result = await adapter._handle_picker_response(chat_id="chat-123", text="")
+        assert result == "picker_cancelled"
+        assert "chat-123" not in adapter._model_picker._state

--- a/tests/gateway/test_yuanbao.py
+++ b/tests/gateway/test_yuanbao.py
@@ -1,0 +1,165 @@
+"""Tests for Yuanbao platform adapter."""
+
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from gateway.platforms.yuanbao import YuanbaoAdapter
+from gateway.platforms.base import SendResult, MessageEvent, MessageType
+from gateway.config import PlatformConfig
+
+
+def _make_config():
+    """Create a test PlatformConfig for Yuanbao."""
+    return PlatformConfig(
+        enabled=True,
+        token="test-token",
+        extra={
+            "app_id": "test-app-id",
+            "app_secret": "test-app-secret",
+            "bot_id": "test-bot-id",
+        },
+    )
+
+
+def _make_adapter():
+    """Create a YuanbaoAdapter for testing."""
+    config = _make_config()
+    adapter = YuanbaoAdapter(config)
+    # Mock the outbound manager to avoid WS connection
+    adapter._outbound = MagicMock()
+    adapter._outbound.send_text = AsyncMock(return_value=SendResult(success=True, message_id="msg-123"))
+    return adapter
+
+
+class TestYuanbaoModelPicker:
+    """Tests for the text-based model picker on Yuanbao."""
+
+    @pytest.mark.asyncio
+    async def test_send_model_picker_delegates_to_text_model_picker(self):
+        """Test send_model_picker delegates to TextModelPicker."""
+        adapter = _make_adapter()
+        
+        providers = [
+            {"name": "Alibaba", "slug": "alibaba", "models": ["qwen-v3"], "is_current": True},
+        ]
+        
+        async def on_model_selected(chat_id, model, provider_slug):
+            return f"Switched to {model}"
+        
+        result = await adapter.send_model_picker(
+            chat_id="chat-123",
+            providers=providers,
+            current_model="qwen-v3",
+            current_provider="alibaba",
+            session_key="sess-abc",
+            on_model_selected=on_model_selected,
+        )
+        
+        assert result.success is True
+        assert "chat-123" in adapter._model_picker._state
+        state = adapter._model_picker._state["chat-123"]
+        assert state["stage"] == "provider"
+        assert state["on_model_selected"] is on_model_selected
+
+    @pytest.mark.asyncio
+    async def test_handle_picker_response_delegates_to_text_model_picker(self):
+        """Test _handle_picker_response delegates to TextModelPicker."""
+        adapter = _make_adapter()
+        
+        # Setup state directly in the picker
+        adapter._model_picker._state["chat-123"] = {
+            "stage": "provider",
+            "providers": [
+                {"name": "Alibaba", "slug": "alibaba", "models": ["qwen-v3"], "is_current": True},
+            ],
+            "current_model": "old-model",
+            "on_model_selected": AsyncMock(return_value="Switched"),
+        }
+        
+        result = await adapter._handle_picker_response("chat-123", "1")
+        assert result == "picker_consumed"
+
+    @pytest.mark.asyncio
+    async def test_handle_picker_response_no_state_returns_none(self):
+        """Test _handle_picker_response returns None when no active picker."""
+        adapter = _make_adapter()
+        
+        result = await adapter._handle_picker_response("chat-123", "1")
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_model_picker_initialized_in_init(self):
+        """Test TextModelPicker is initialized in __init__."""
+        adapter = _make_adapter()
+        
+        from gateway.platforms.helpers import TextModelPicker
+        assert isinstance(adapter._model_picker, TextModelPicker)
+        assert adapter._model_picker._adapter is adapter
+
+
+class TestYuanbaoAdapterBasics:
+    """Basic tests for Yuanbao adapter."""
+
+    def test_adapter_creation(self):
+        """Test YuanbaoAdapter can be created."""
+        config = _make_config()
+        adapter = YuanbaoAdapter(config)
+        assert adapter is not None
+        assert adapter.PLATFORM.value == "yuanbao"
+
+    def test_max_text_chunk(self):
+        """Test MAX_TEXT_CHUNK is set."""
+        config = _make_config()
+        adapter = YuanbaoAdapter(config)
+        assert adapter.MAX_TEXT_CHUNK == 4000
+
+    def test_splits_long_messages(self):
+        """Test splits_long_messages flag is set."""
+        config = _make_config()
+        adapter = YuanbaoAdapter(config)
+        assert adapter.splits_long_messages is True
+
+    def test_format_message_exists(self):
+        """Test format_message method exists."""
+        config = _make_config()
+        adapter = YuanbaoAdapter(config)
+        # Yuanbao uses MarkdownProcessor.markdown_hint_system_prompt
+        # but format_message is inherited from base
+        assert hasattr(adapter, 'format_message')
+
+
+class TestYuanbaoSendMethods:
+    """Tests for Yuanbao send methods."""
+
+    @pytest.mark.asyncio
+    async def test_send_delegates_to_outbound(self):
+        """Test send delegates to OutboundManager."""
+        adapter = _make_adapter()
+        
+        result = await adapter.send("chat-123", "Hello")
+        
+        assert result.success is True
+        adapter._outbound.send_text.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_send_model_picker_exists(self):
+        """Test send_model_picker method exists and works."""
+        adapter = _make_adapter()
+        
+        providers = [
+            {"name": "Test", "slug": "test", "models": ["model-1"], "is_current": True},
+        ]
+        
+        async def callback(chat_id, model, provider):
+            return "Done"
+        
+        result = await adapter.send_model_picker(
+            chat_id="chat-123",
+            providers=providers,
+            current_model="model-1",
+            current_provider="test",
+            session_key="sess",
+            on_model_selected=callback,
+        )
+        
+        assert result.success is True

--- a/tests/gateway/test_yuanbao.py
+++ b/tests/gateway/test_yuanbao.py
@@ -36,16 +36,16 @@ class TestYuanbaoModelPicker:
 
     @pytest.mark.asyncio
     async def test_send_model_picker_delegates_to_text_model_picker(self):
-        """Test send_model_picker delegates to TextModelPicker."""
+        """Test send_model_picker delegates to TextModelPicker, state keyed by session_key."""
         adapter = _make_adapter()
-        
+
         providers = [
             {"name": "Alibaba", "slug": "alibaba", "models": ["qwen-v3"], "is_current": True},
         ]
-        
+
         async def on_model_selected(chat_id, model, provider_slug):
             return f"Switched to {model}"
-        
+
         result = await adapter.send_model_picker(
             chat_id="chat-123",
             providers=providers,
@@ -53,45 +53,82 @@ class TestYuanbaoModelPicker:
             current_provider="alibaba",
             session_key="sess-abc",
             on_model_selected=on_model_selected,
+            requester_user_id="user-A",
         )
-        
+
         assert result.success is True
-        assert "chat-123" in adapter._model_picker._state
-        state = adapter._model_picker._state["chat-123"]
+        # State keyed by session_key, not chat_id
+        assert "sess-abc" in adapter._model_picker._state
+        assert "chat-123" not in adapter._model_picker._state
+        state = adapter._model_picker._state["sess-abc"]
         assert state["stage"] == "provider"
+        assert state["chat_id"] == "chat-123"
         assert state["on_model_selected"] is on_model_selected
+        assert state["requester_user_id"] == "user-A"
+        assert "expires_at" in state
 
     @pytest.mark.asyncio
     async def test_handle_picker_response_delegates_to_text_model_picker(self):
         """Test _handle_picker_response delegates to TextModelPicker."""
+        import time
         adapter = _make_adapter()
-        
+
         # Setup state directly in the picker
-        adapter._model_picker._state["chat-123"] = {
+        adapter._model_picker._state["sess-abc"] = {
             "stage": "provider",
             "providers": [
                 {"name": "Alibaba", "slug": "alibaba", "models": ["qwen-v3"], "is_current": True},
             ],
+            "chat_id": "chat-123",
             "current_model": "old-model",
             "on_model_selected": AsyncMock(return_value="Switched"),
+            "requester_user_id": "",
+            "expires_at": time.monotonic() + 300,
         }
-        
-        result = await adapter._handle_picker_response("chat-123", "1")
+
+        with patch("hermes_cli.model_cost_guard.expensive_model_warning", return_value=None):
+            result = await adapter._handle_picker_response(
+                chat_id="chat-123", session_key="sess-abc", text="1",
+            )
         assert result == "picker_consumed"
 
     @pytest.mark.asyncio
     async def test_handle_picker_response_no_state_returns_none(self):
         """Test _handle_picker_response returns None when no active picker."""
         adapter = _make_adapter()
-        
-        result = await adapter._handle_picker_response("chat-123", "1")
+
+        result = await adapter._handle_picker_response(
+            chat_id="chat-123", session_key="sess-none", text="1",
+        )
         assert result is None
+
+    @pytest.mark.asyncio
+    async def test_handle_picker_response_requester_mismatch_returns_none(self):
+        """A reply from a different user falls through to the agent."""
+        import time
+        adapter = _make_adapter()
+
+        adapter._model_picker._state["sess-abc"] = {
+            "stage": "provider",
+            "providers": [{"name": "Alibaba", "slug": "alibaba", "models": ["qwen"], "is_current": True}],
+            "chat_id": "chat-123",
+            "current_model": "old",
+            "on_model_selected": AsyncMock(),
+            "requester_user_id": "user-A",
+            "expires_at": time.monotonic() + 300,
+        }
+
+        result = await adapter._handle_picker_response(
+            chat_id="chat-123", session_key="sess-abc", text="1", requester_user_id="user-B",
+        )
+        assert result is None
+        assert "sess-abc" in adapter._model_picker._state  # state preserved for user-A
 
     @pytest.mark.asyncio
     async def test_model_picker_initialized_in_init(self):
         """Test TextModelPicker is initialized in __init__."""
         adapter = _make_adapter()
-        
+
         from gateway.platforms.helpers import TextModelPicker
         assert isinstance(adapter._model_picker, TextModelPicker)
         assert adapter._model_picker._adapter is adapter


### PR DESCRIPTION
## What does this PR do?

Adds a reusable text-based interactive model picker for platforms without inline keyboard support (WeChat, Yuanbao). Previously, `/model` command on these platforms failed to switch models because the adapters lacked the `send_model_picker` method.

The fix extracts the picker logic into a reusable `TextModelPicker` class in `helpers.py`, then applies it to both Weixin and Yuanbao adapters. **The picker is restricted to DM chats** — see "Scope" below.

## Scope: DM-only

The interactive text picker is intentionally restricted to private (1:1) chats. In a group, a multi-user state machine keyed on plain-text replies is fragile: another participant's `1` mid-conversation would be consumed by the wrong session, and even with requester validation the swallowed message looks like a bug to both parties. WeChat groups and Yuanbao groups are already access-gated upstream (Yuanbao's `GroupAtGuardMiddleware` requires `@bot` to dispatch, WeChat's `group_policy` defaults to `disabled`), so making the picker DM-only is consistent with existing group etiquette.

The typed escape hatch `/model <name> --provider <slug>` is unaffected and still works in groups. Inline-keyboard pickers (Telegram / Discord / Matrix) are also unaffected — they use button callbacks bound to the originating `message_id`, so the multi-user cross-talk problem does not arise.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)
- [x] ♻️ Refactor (code improvement without functional change)
- [x] 🔒 Security fix (pickers are DM-only; see Scope)

## Changes Made

### Core Changes
- `gateway/platforms/helpers.py`: Add `TextModelPicker` class for reusable text-based model selection with two-step flow (provider → model), expensive-model confirmation gate, expiry, and DM-only enforcement.

### Adapter Updates
- `gateway/platforms/weixin.py`: Refactor to use `TextModelPicker`, remove duplicated picker logic (~133 lines).
- `gateway/platforms/yuanbao.py`: Add `TextModelPicker` integration with picker intercept in `DispatchMiddleware`.

### Gateway glue
- `gateway/slash_commands.py`: Forward `source.chat_type` to `send_model_picker` so the DM-only check fires at the picker entry point.

### Tests
- `tests/gateway/test_helpers.py` (new): 34 unit tests for `TextModelPicker`.
- `tests/gateway/test_weixin.py`: 18 tests for adapter integration.
- `tests/gateway/test_yuanbao.py` (new): 6 tests for Yuanbao picker integration.

## Backward Compatibility

The `/model <name> --provider <slug>` command format remains fully compatible:
- When model name or provider is provided → direct switch (no picker)
- When only `/model` is sent → show interactive picker in DM; static text list in group
- All adapter `send_model_picker` / `_handle_picker_response` signatures add only optional parameters (default `None` / `""`), so older callers continue to work

## How to Test

```bash
pytest tests/gateway/test_helpers.py -v
pytest tests/gateway/test_weixin.py -v -k "ModelPicker"
pytest tests/gateway/test_yuanbao.py -v
```

All tests pass.

## Screenshots

| Step 1 | Step 2 |
| --- | --- |
| User sends `/model` and selects provider | User selects model and gets confirmation |
| <img width="1170" height="2307" alt="weixin-model-picker-1" src="https://github.com/user-attachments/assets/c265fe67-678c-4d8a-a785-9bc11f9ccf01" /> | <img width="1170" height="2301" alt="weixin-model-picker-2" src="https://github.com/user-attachments/assets/334d5a48-dd50-4f95-8208-4ae3af5a08b1" /> |

## Screenshots for expensive model

| Step 1 | Step 2 | Step 3 |
| --- | --- | --- |
|  <img width="1206" height="2480" alt="expensive-model-1" src="https://github.com/user-attachments/assets/382fa2d7-0864-4e5c-8d15-7dce62d3df01" /> |  <img width="1206" height="2477" alt="expensive-model-2" src="https://github.com/user-attachments/assets/3a386e18-943a-4f91-a844-4d3d470e32ba" /> |  <img width="1206" height="1872" alt="expensive-model-3" src="https://github.com/user-attachments/assets/6e8f47e8-ad60-49fe-b954-f6f46e314b3c" /> |
