### PR TITLE
Skip retries on usage limit exhaustion

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -594,6 +594,8 @@ def recover_with_credential_pool(
     Returns (recovered, has_retried_429).
     On rate limits: first occurrence retries same credential (sets flag True).
                     second consecutive failure rotates to next credential.
+                    Non-transient usage-limit exhaustion rotates immediately;
+                    it never retries the same credential first.
     On billing exhaustion: immediately rotates.
     On auth failures: attempts token refresh before rotating.
 
@@ -692,16 +694,7 @@ def recover_with_credential_pool(
                 return True, False
             return False, True
 
-        usage_limit_reached = False
-        if error_context:
-            context_reason = str(error_context.get("reason") or "").lower()
-            context_message = str(error_context.get("message") or "").lower()
-            usage_limit_reached = (
-                "usage_limit_reached" in context_reason
-                or "gousagelimit" in context_reason
-                or "usage limit reached" in context_message
-                or "usage limit has been reached" in context_message
-            )
+        usage_limit_reached = is_usage_limit_reached_context(error_context)
         if not has_retried_429 and not usage_limit_reached:
             return False, True
         rotate_status = status_code if status_code is not None else 429
@@ -2400,6 +2393,15 @@ def extract_api_error_context(error: Exception) -> Dict[str, Any]:
             if value not in {None, ""}:
                 context["reset_at"] = value
                 break
+        resets_in_seconds = payload.get("resets_in_seconds")
+        if resets_in_seconds is not None and resets_in_seconds != "":
+            try:
+                reset_delay = float(resets_in_seconds)
+                context["resets_in_seconds"] = reset_delay
+                if "reset_at" not in context:
+                    context["reset_at"] = time.time() + reset_delay
+            except (TypeError, ValueError):
+                pass
         retry_after = payload.get("retry_after")
         if retry_after not in {None, ""} and "reset_at" not in context:
             try:
@@ -2457,6 +2459,52 @@ def extract_api_error_context(error: Exception) -> Dict[str, Any]:
                         context["reset_at"] = time.time() + float(sec_match.group(1))
 
     return context
+
+
+def is_usage_limit_reached_context(error_context: Optional[Dict[str, Any]]) -> bool:
+    """Return True for quota-exhaustion 429s that should not be retried.
+
+    Providers use HTTP 429 for both transient rate limiting and exhausted
+    account/plan quota. ``usage_limit_reached`` is the latter: immediate
+    retrying cannot succeed and just burns more requests, so callers should
+    rotate credentials, activate fallback, queue, or stop with guidance.
+    """
+    if not error_context:
+        return False
+    context_reason = str(error_context.get("reason") or "").lower()
+    context_message = str(error_context.get("message") or "").lower()
+    return (
+        "usage_limit_reached" in context_reason
+        or "gousagelimit" in context_reason
+        or "usage limit reached" in context_message
+        or "usage limit has been reached" in context_message
+    )
+
+
+def format_usage_limit_reset(error_context: Optional[Dict[str, Any]]) -> str:
+    """Format reset timing from extracted provider context for user output."""
+    if not error_context:
+        return "Reset-Zeitpunkt unbekannt."
+    seconds = error_context.get("resets_in_seconds")
+    if isinstance(seconds, (int, float)) and seconds >= 0:
+        total = int(seconds)
+        hours = total // 3600
+        minutes = (total % 3600) // 60
+        if hours and minutes:
+            return f"Reset in {hours} Stunden und {minutes} Minuten."
+        if hours:
+            return f"Reset in {hours} Stunden."
+        if minutes:
+            return f"Reset in {minutes} Minuten."
+        return f"Reset in {total} Sekunden."
+    reset_at = error_context.get("reset_at")
+    if reset_at is not None and reset_at != "":
+        try:
+            reset_ts = float(reset_at)
+            return time.strftime("Reset am %Y-%m-%d um %H:%M:%S UTC.", time.gmtime(reset_ts))
+        except (TypeError, ValueError):
+            return f"Reset: {reset_at}."
+    return "Reset-Zeitpunkt unbekannt."
 
 
 

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -2604,6 +2604,50 @@ def run_conversation(
                         agent._buffer_vprint(f"   📋 Details: {_err_body_str}")
                 agent._buffer_vprint(f"   ⏱️  Elapsed: {elapsed_time:.2f}s  Context: {len(api_messages)} msgs, ~{approx_tokens:,} tokens")
 
+                try:
+                    from agent.agent_runtime_helpers import (
+                        format_usage_limit_reset,
+                        is_usage_limit_reached_context,
+                    )
+                    _usage_limit_reached = (
+                        classified.reason == FailoverReason.rate_limit
+                        and is_usage_limit_reached_context(error_context)
+                    )
+                except Exception:
+                    _usage_limit_reached = False
+                if _usage_limit_reached:
+                    _reset_message = format_usage_limit_reset(error_context)
+                    if agent._has_pending_fallback():
+                        agent._buffer_status(
+                            f"⚠️ Nutzungslimit erreicht ({_reset_message}) — switching to fallback provider..."
+                        )
+                        if agent._try_activate_fallback(reason=classified.reason):
+                            retry_count = 0
+                            compression_attempts = 0
+                            _retry.primary_recovery_attempted = False
+                            continue
+                    agent._flush_status_buffer()
+                    agent._emit_status(
+                        f"❌ Nutzungslimit erreicht. {_reset_message} Retries werden übersprungen."
+                    )
+                    logger.warning(
+                        "%sUsage limit reached for provider=%s model=%s; skipping API retries. reset=%s",
+                        agent.log_prefix,
+                        _provider,
+                        _model,
+                        _reset_message,
+                    )
+                    agent._persist_session(messages, conversation_history)
+                    return {
+                        "messages": messages,
+                        "completed": False,
+                        "api_calls": api_call_count,
+                        "error": f"Usage limit reached. {_reset_message}",
+                        "partial": True,
+                        "failed": True,
+                        "usage_limit_reached": True,
+                    }
+
                 # Actionable hint for OpenRouter "no tool endpoints" error.
                 # Buffered like the rest of the retry trace — surfaced only
                 # if every retry+fallback exhausts.  Avoids spamming users

--- a/tests/agent/test_credential_pool_routing.py
+++ b/tests/agent/test_credential_pool_routing.py
@@ -232,3 +232,67 @@ class TestPoolRotationCycle:
         )
         assert recovered is False
         assert has_retried is False
+
+    def test_usage_limit_429_rotates_without_retry_same_credential(self):
+        """usage_limit_reached is quota exhaustion, not a transient 429."""
+        agent, pool, entries = self._make_agent_with_pool(3)
+
+        recovered, has_retried = agent._recover_with_credential_pool(
+            status_code=429,
+            has_retried_429=False,
+            error_context={
+                "reason": "usage_limit_reached",
+                "message": "You hit your usage limit.",
+                "resets_in_seconds": 63980,
+            },
+        )
+
+        assert recovered is True
+        assert has_retried is False
+        pool.mark_exhausted_and_rotate.assert_called_once_with(
+            status_code=429,
+            error_context={
+                "reason": "usage_limit_reached",
+                "message": "You hit your usage limit.",
+                "resets_in_seconds": 63980,
+            },
+        )
+        agent._swap_credential.assert_called_once_with(entries[1])
+
+
+class TestUsageLimitErrorContext:
+    def test_extract_context_parses_resets_in_seconds(self, monkeypatch):
+        from agent.agent_runtime_helpers import extract_api_error_context
+
+        class APIError(Exception):
+            body = {
+                "error": {
+                    "type": "usage_limit_reached",
+                    "message": "You hit your usage limit.",
+                    "resets_in_seconds": 120,
+                }
+            }
+
+        monkeypatch.setattr("agent.agent_runtime_helpers.time.time", lambda: 1000.0)
+
+        context = extract_api_error_context(APIError("429"))
+
+        assert context["reason"] == "usage_limit_reached"
+        assert context["message"] == "You hit your usage limit."
+        assert context["resets_in_seconds"] == 120.0
+        assert context["reset_at"] == 1120.0
+
+    def test_usage_limit_detection_and_reset_formatting(self):
+        from agent.agent_runtime_helpers import (
+            format_usage_limit_reset,
+            is_usage_limit_reached_context,
+        )
+
+        context = {
+            "reason": "usage_limit_reached",
+            "message": "quota exhausted",
+            "resets_in_seconds": 63980.0,
+        }
+
+        assert is_usage_limit_reached_context(context) is True
+        assert format_usage_limit_reset(context) == "Reset in 17 Stunden und 46 Minuten."


### PR DESCRIPTION
## Summary

- Treat `usage_limit_reached` 429s as quota exhaustion rather than transient rate limits.
- Rotate credential-pool entries immediately instead of retrying the same exhausted credential first.
- Parse `resets_in_seconds` into error context and surface a reset message when no fallback/recovery path is available.
- Skip the normal API retry/backoff loop for usage-limit exhaustion; use fallback if configured, otherwise stop with a clear user-facing message.

## Verification

- `python -m pytest tests/agent/test_credential_pool_routing.py -q -o 'addopts='`
- `python -m compileall -q agent/agent_runtime_helpers.py agent/conversation_loop.py`
