### PR TITLE
fix(gateway): prevent strip_markdown from eating bullets (#48150)

### DIFF
--- a/gateway/platforms/helpers.py
+++ b/gateway/platforms/helpers.py
@@ -166,8 +166,8 @@ class TextBatchAggregator:
 # ─── Markdown Stripping ──────────────────────────────────────────────────────
 
 # Pre-compiled regexes for performance
-_RE_BOLD = re.compile(r"\*\*(.+?)\*\*", re.DOTALL)
-_RE_ITALIC_STAR = re.compile(r"\*(.+?)\*", re.DOTALL)
+_RE_BOLD = re.compile(r"(?<!\*)\*\*(?!\s|\*)+(.+?)(?<!\s|\*)\*\*(?!\*)", re.DOTALL)
+_RE_ITALIC_STAR = re.compile(r"(?<!\*)\*(?!\s|\*)+(.+?)(?<!\s|\*)\*(?!\*)", re.DOTALL)
 _RE_BOLD_UNDER = re.compile(r"\b__(?![\s_])(.+?)(?<![\s_])__\b", re.DOTALL)
 _RE_ITALIC_UNDER = re.compile(r"\b_(?![\s_])(.+?)(?<![\s_])_\b", re.DOTALL)
 _RE_CODE_BLOCK = re.compile(r"```[a-zA-Z0-9_+-]*\n?")


### PR DESCRIPTION
Fixes #48150. The star emphasis regexes in strip_markdown lacked boundary guards, matching list bullets (* item) and literal asterisks (a * b) as italic spans. Added lookaround assertions matching the existing underscore regex behavior so only real emphasis spans are stripped.