### PR TITLE
fix(hindsight): use local timezone in retain payload timestamps

### DIFF
--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -386,8 +386,8 @@ def _normalize_observation_scopes(value: Any) -> Any:
 
     Returns one of:
       * ``None`` — nothing configured; Hindsight applies its ``combined`` default.
-      * a keyword string — ``"per_tag"`` / ``"combined"`` / ``"all_combinations"``.
-      * ``list[list[str]]`` — custom scopes, one inner list per consolidation pass.
+      * a keyword string -- ``"per_tag"`` / ``"combined"`` / ``"all_combinations"``.
+      * ``list[list[str]]`` -- custom scopes, one inner list per consolidation pass.
 
     Accepts a keyword string, a JSON-encoded list, a flat list of tags (treated as
     a single scope), or a list of tag-lists. Anything unrecognized yields ``None``
@@ -428,9 +428,14 @@ def _normalize_observation_scopes(value: Any) -> Any:
     return None
 
 
-def _utc_timestamp() -> str:
-    """Return current UTC timestamp in ISO-8601 with milliseconds and Z suffix."""
-    return datetime.now(timezone.utc).isoformat(timespec="milliseconds").replace("+00:00", "Z")
+def _local_timestamp() -> str:
+    """Return current local timestamp in ISO-8601 with milliseconds and timezone offset.
+
+    Uses the user's local timezone so downstream memory extraction LLMs
+    render dates/times in the user's actual context instead of UTC.
+    Offset-aware timestamps are still unambiguous (convertible to UTC losslessly).
+    """
+    return datetime.now().astimezone().isoformat(timespec="milliseconds")
 
 
 def _embedded_profile_name(config: dict[str, Any]) -> str:
@@ -1442,7 +1447,7 @@ class HindsightMemoryProvider(MemoryProvider):
 
     def _build_metadata(self, *, message_count: int, turn_index: int) -> Dict[str, str]:
         metadata: Dict[str, str] = {
-            "retained_at": _utc_timestamp(),
+            "retained_at": _local_timestamp(),
             "message_count": str(message_count),
             "turn_index": str(turn_index),
         }


### PR DESCRIPTION
## Summary

_utc_timestamp() forced UTC Zulu, causing downstream memory extraction LLMs to render dates/times in UTC instead of the user's local context. Changed to _local_timestamp() which emits offset-aware ISO-8601 local timestamps. Storage remains unambiguous (offset-aware timestamps are losslessly convertible to UTC).

Closes #46424