### PR TITLE
fix(search): strip adjacent and stacked boolean operators in FTS5 sanitizer

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -3202,10 +3202,28 @@ class SessionDB:
         sanitized = re.sub(r"\*+", "*", sanitized)
         sanitized = re.sub(r"(^|\s)\*", r"\1", sanitized)
 
-        # Step 4: Remove dangling boolean operators at start/end that would
-        # cause syntax errors (e.g. "hello AND" or "OR world")
-        sanitized = re.sub(r"(?i)^(AND|OR|NOT)\b\s*", "", sanitized.strip())
-        sanitized = re.sub(r"(?i)\s+(AND|OR|NOT)\s*$", "", sanitized.strip())
+        # Step 4: Remove dangling boolean operators that would cause syntax
+        # errors. FTS5 rejects bare operators at the start/end (e.g. "hello AND",
+        # "OR world") *and* adjacent/repeated operators in the middle (e.g.
+        # "python AND OR java" -> 'fts5: syntax error near "OR"'). The previous
+        # single leading + single trailing pass missed both adjacent runs and
+        # stacked operators, leaving an invalid query that silently returned
+        # zero results once the OperationalError was swallowed downstream.
+        #
+        # First collapse any run of 2+ whitespace-separated operators down to
+        # the first one ("python AND OR java" -> "python AND java", preserving
+        # the user's first/intended operator), then strip leading and trailing
+        # operators to a fixpoint so stacked operators ("a OR AND b OR") can't
+        # leave a second dangling operator behind.
+        sanitized = sanitized.strip()
+        sanitized = re.sub(
+            r"(?i)\b(AND|OR|NOT)(?:\s+(?:AND|OR|NOT)\b)+", r"\1", sanitized
+        )
+        prev = None
+        while prev != sanitized:
+            prev = sanitized
+            sanitized = re.sub(r"(?i)^(?:AND|OR|NOT)\b\s*", "", sanitized).strip()
+            sanitized = re.sub(r"(?i)\s*\b(?:AND|OR|NOT)$", "", sanitized).strip()
 
         # Step 5: Wrap unquoted dotted and/or hyphenated terms in double
         # quotes.  FTS5's tokenizer splits on dots and hyphens, turning

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -972,6 +972,63 @@ class TestFTS5Search:
         assert any("deployment" in (r.get("snippet") or r.get("content", "")).lower()
                    for r in results)
 
+    def test_search_adjacent_operators_still_find_content(self, db):
+        """Adjacent/repeated boolean operators must not silently return empty.
+
+        FTS5 rejects adjacent operators ('a AND OR b' -> 'syntax error near
+        "OR"') and stacked operators at the ends. Step 4 of _sanitize_fts5_query
+        used to remove only ONE leading and ONE trailing operator, so a user who
+        double-typed an operator ('python AND OR java') got an invalid query
+        whose OperationalError was swallowed into zero results -- even though the
+        content was present. Regression for that silent-empty bug; mirrors
+        test_search_colon_query_still_finds_content.
+        """
+        db.create_session(session_id="s1", source="cli")
+        db.append_message("s1", role="user", content="python and java are languages")
+
+        # Control: each keyword is found on its own.
+        assert len(db.search_messages("python")) >= 1
+        assert len(db.search_messages("java")) >= 1
+
+        # Adjacent operators in the middle must still find content.
+        results = db.search_messages("python AND OR java")
+        assert isinstance(results, list)
+        assert len(results) >= 1, "adjacent-operator query silently returned []"
+
+        # A trailing run of operators must not leave a dangling operator.
+        results = db.search_messages("python OR AND")
+        assert isinstance(results, list)
+        assert len(results) >= 1, "trailing operator run silently returned []"
+
+    def test_sanitize_fts5_query_strips_adjacent_operators(self):
+        """_sanitize_fts5_query must not leave any bare/dangling boolean operator.
+
+        Direct unit test on the sanitizer: the output must be a clean, valid
+        FTS5 query with no leading, trailing, or adjacent operators left behind.
+        """
+        s = SessionDB._sanitize_fts5_query
+
+        # Adjacent middle operators collapse to the first (intended) one.
+        assert s("python AND OR java") == "python AND java"
+        assert s("a AND OR b") == "a AND b"
+
+        # Stacked operators at the ends are fully stripped (fixpoint).
+        assert s("foo AND OR") == "foo"
+        assert s("hello AND OR") == "hello"
+        assert s("a OR AND b OR") == "a OR b"
+
+        # All-operator garbage sanitizes to empty, not a dangling operator.
+        assert s("AND OR") == ""
+        assert s("NOT NOT") == ""
+
+        # Sanity: nothing left in any result is a bare operator at an edge.
+        for q in ("python AND OR java", "foo AND OR", "a OR AND b OR"):
+            out = s(q)
+            tokens = out.split()
+            if tokens:
+                assert tokens[0].upper() not in ("AND", "OR", "NOT"), out
+                assert tokens[-1].upper() not in ("AND", "OR", "NOT"), out
+
     def test_search_quoted_phrase_preserved(self, db):
         """User-provided quoted phrases should be preserved for exact matching."""
         db.create_session(session_id="s1", source="cli")


### PR DESCRIPTION
## What does this PR do?

`SessionDB._sanitize_fts5_query` (session search, `hermes_state.py`) is supposed to scrub user/LLM search input so it never reaches FTS5 `MATCH` as invalid syntax. Step 4 of that pipeline removes dangling boolean operators -- but it only stripped **one** leading and **one** trailing operator, and nothing in the middle.

So queries with adjacent or stacked operators slipped through as invalid FTS5:

- `"python AND OR java"` -> survived unchanged -> `fts5: syntax error near "OR"`
- `"foo AND OR"` -> became `"foo AND"` (a dangling trailing operator -- the exact case the Step 4 comment says it prevents)
- `"a OR AND b OR"` -> became `"a OR AND b"` (adjacent operators left intact)

`search_messages` catches that `OperationalError` and returns `[]`. The result is **silent zero results even when matching content exists** -- the same silent-empty data-loss class that the existing colon fix (`test_search_colon_query_still_finds_content`) guards against. A user who simply double-types an operator gets "no results" instead of their messages.

### Fix

Step 4 now:
1. Collapses any run of 2+ whitespace-separated operators down to the first one (`"python AND OR java"` -> `"python AND java"`, preserving the user's first/intended operator).
2. Strips leading and trailing operators to a **fixpoint**, so stacked operators (`"a OR AND b OR"`) can't leave a second dangling operator behind.

This is a minimal, behavior-preserving change to the existing Step 4 mechanism (no new step, no change to quoting/colon/wildcard handling).

### How this differs from related work (not a duplicate)

- **Distinct from #9651** (`fix(search): default FTS5 multi-keyword queries to OR`): that PR *adds a new Step 7* to default-OR-join multi-keyword queries for CJK recall. It does **not** touch Step 4's dangling-operator logic, so the adjacent-operator bug survives that change. This PR fixes Step 4 itself.
- **Distinct from the holographic-memory FTS5 PRs** (#43435, #43490): those fix `plugins/memory/holographic/{store,retrieval}.py` -- a different module and a different code path (the memory tool). This PR fixes `hermes_state.py::SessionDB._sanitize_fts5_query`, the session-search sanitizer.

No existing issue tracks this specific bug (searched issues + open PRs for `fts5`, `_sanitize_fts5_query`, `dangling operator`, `adjacent operators`, `AND OR search` -- nothing matched), so no `Fixes #` line; the description stands on its own.

## Related Issue

No existing issue. (Searched the tracker and open PRs first.)

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_state.py`: rewrote Step 4 of `SessionDB._sanitize_fts5_query` to collapse adjacent operator runs and strip leading/trailing operators to a fixpoint (with an explanatory comment).
- `tests/test_hermes_state.py`: added two regression tests in `TestFTS5Search`:
  - `test_search_adjacent_operators_still_find_content` -- end-to-end search that asserts content is **found** (catches the silent zero-results regression, not just "does not crash").
  - `test_sanitize_fts5_query_strips_adjacent_operators` -- direct unit test on the sanitizer output for adjacent / stacked / all-operator inputs.

## How to Test

Reproduce on `main` (before this fix):

```python
from hermes_state import SessionDB
s = SessionDB._sanitize_fts5_query
s("python AND OR java")   # -> 'python AND OR java'  (invalid FTS5)
s("foo AND OR")           # -> 'foo AND'             (dangling trailing operator)
# end-to-end: search_messages("python AND OR java") returns []
# even though a message containing "python" and "java" exists (swallowed OperationalError)
```

After this fix:

```python
s("python AND OR java")   # -> 'python AND java'  (valid)
s("foo AND OR")           # -> 'foo'              (valid)
# search_messages("python AND OR java") now returns the matching message
```

CI-parity runner proof (per-file isolated, the project's canonical runner):

```
$ bash scripts/run_tests.sh tests/test_hermes_state.py
=== Summary: 1 files, 270 tests passed, 0 failed (100% complete) in 2.8s ===
```

Before/after on the new tests specifically (run against unfixed vs fixed `hermes_state.py`):

```
# unfixed code:
2 failed  (test_search_adjacent_operators_still_find_content, test_sanitize_fts5_query_strips_adjacent_operators)
# fixed code:
2 passed
```

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(search):`)
- [x] I searched for existing PRs to make sure this isn't a duplicate (see "How this differs from related work" above)
- [x] My PR contains only changes related to this fix (2 files: the fix + its tests)
- [x] I've run the test suite and all tests pass (`scripts/run_tests.sh tests/test_hermes_state.py` -> 270 passed, 0 failed)
- [x] I've added tests for my changes (a content-finding regression test + a direct sanitizer unit test)
- [x] I've tested on my platform: Ubuntu 24.04

### Documentation & Housekeeping

- [x] I've updated relevant documentation (docstrings/comments in Step 4) -- or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys -- N/A (no config change)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows -- N/A
- [x] I've considered cross-platform impact -- N/A (pure stdlib `re`, no platform-specific code)
- [x] I've updated tool descriptions/schemas if I changed tool behavior -- N/A (sanitization is internal; external search behavior only becomes more correct)
