### PR TITLE
feat(mcp): add Chatblocks catalog entry

### DIFF
--- a/hermes_cli/mcp_catalog.py
+++ b/hermes_cli/mcp_catalog.py
@@ -76,6 +76,7 @@ class TransportSpec:
     command: Optional[str] = None
     args: List[str] = field(default_factory=list)
     url: Optional[str] = None
+    headers: Dict[str, str] = field(default_factory=dict)
     version: Optional[str] = None  # informational, pinned
 
 
@@ -184,11 +185,15 @@ def _parse_manifest(path: Path) -> CatalogEntry:
     args = transport_raw.get("args") or []
     if not isinstance(args, list):
         raise CatalogError(f"{path}: transport.args must be a list")
+    headers_raw = transport_raw.get("headers") or {}
+    if not isinstance(headers_raw, dict):
+        raise CatalogError(f"{path}: transport.headers must be a mapping")
     transport = TransportSpec(
         type=t_type,
         command=transport_raw.get("command"),
         args=[str(a) for a in args],
         url=transport_raw.get("url"),
+        headers={str(k): str(v) for k, v in headers_raw.items()},
         version=transport_raw.get("version"),
     )
     if t_type == "stdio" and not transport.command:
@@ -470,6 +475,8 @@ def _build_server_config(
             cfg["args"] = [_expand_install_dir(a, install_dir) for a in t.args]
     elif t.type == "http":
         cfg["url"] = t.url
+        if t.headers:
+            cfg["headers"] = dict(t.headers)
         if entry.auth.type == "oauth":
             cfg["auth"] = "oauth"
     return cfg

--- a/optional-mcps/chatblocks/manifest.yaml
+++ b/optional-mcps/chatblocks/manifest.yaml
@@ -1,0 +1,40 @@
+# Nous-approved MCP catalog entry.
+# Presence in this directory = approval. Merged via PR review.
+manifest_version: 1
+name: chatblocks
+description: Create, build, and publish persistent canvas blocks through the hosted Chatblocks MCP server.
+source: https://docs.chatblocks.ai/mcp/setup
+transport:
+  type: http
+  url: https://chatblocks.ai/api/mcp/v1
+  headers:
+    Authorization: "Bearer ${CHATBLOCKS_API_KEY}"
+auth:
+  type: api_key
+  env:
+    - name: CHATBLOCKS_API_KEY
+      prompt: "Chatblocks cb_live_* API key"
+      required: true
+      secret: true
+tools:
+  default_enabled:
+    - canvases.list
+    - canvases.get
+    - blocks.list
+    - blocks.init
+    - blocks.setFiles
+    - blocks.build
+    - blocks.publish
+    - placements.create
+post_install: |
+  Create a Chatblocks key from the canvas agent-connect overlay, or use
+  https://chatblocks.ai/api/agent/bootstrap for agent-first setup. Restart
+  Hermes after install so the Chatblocks tools load.
+
+  Existing-account config shape:
+
+    mcp_servers:
+      chatblocks:
+        url: "https://chatblocks.ai/api/mcp/v1"
+        headers:
+          Authorization: "Bearer ${CHATBLOCKS_API_KEY}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -318,6 +318,7 @@ locales = ["locales/*.yaml"]
 # entry; tests/test_packaging_metadata.py enforces an entry per optional-mcps/<name>.
 "optional-mcps/linear" = ["optional-mcps/linear/manifest.yaml"]
 "optional-mcps/n8n" = ["optional-mcps/n8n/manifest.yaml"]
+"optional-mcps/chatblocks" = ["optional-mcps/chatblocks/manifest.yaml"]
 
 [tool.setuptools.package-data]
 hermes_cli = ["web_dist/**/*", "tui_dist/**/*", "scripts/install.sh", "scripts/install.ps1"]

--- a/tests/hermes_cli/test_mcp_catalog.py
+++ b/tests/hermes_cli/test_mcp_catalog.py
@@ -166,6 +166,22 @@ class TestManifestParsing:
         assert e.install.ref == "v1.0.0"
         assert e.install.bootstrap == ["pip install -r requirements.txt"]
 
+    def test_http_transport_headers(self, catalog_dir):
+        body = _basic_manifest(
+            transport={
+                "type": "http",
+                "url": "https://mcp.example.com/mcp",
+                "headers": {"Authorization": "Bearer ${DEMO_KEY}"},
+            },
+            auth={"type": "api_key"},
+        )
+        _write_manifest(catalog_dir, "demo", body)
+        from hermes_cli.mcp_catalog import list_catalog
+
+        e = list_catalog()[0]
+        assert e.transport.type == "http"
+        assert e.transport.headers == {"Authorization": "Bearer ${DEMO_KEY}"}
+
     def test_invalid_manifest_skipped(self, catalog_dir):
         # Broken: wrong manifest_version
         _write_manifest(catalog_dir, "bad", {
@@ -306,6 +322,26 @@ class TestInstall:
         server = load_config()["mcp_servers"]["demo"]
         assert server["url"] == "https://mcp.example.com/sse"
         assert server["auth"] == "oauth"
+
+    def test_install_http_writes_headers(self, catalog_dir):
+        body = _basic_manifest(
+            transport={
+                "type": "http",
+                "url": "https://mcp.example.com/mcp",
+                "headers": {"Authorization": "Bearer ${DEMO_KEY}"},
+            },
+            auth={"type": "api_key"},
+        )
+        _write_manifest(catalog_dir, "demo", body)
+
+        from hermes_cli.config import load_config
+        from hermes_cli.mcp_catalog import install_entry
+
+        install_entry(_entry("demo"), enable=True)
+
+        server = load_config()["mcp_servers"]["demo"]
+        assert server["url"] == "https://mcp.example.com/mcp"
+        assert server["headers"] == {"Authorization": "Bearer secret-val"}
 
     def test_install_required_env_missing_raises(self, catalog_dir, monkeypatch):
         body = _basic_manifest(


### PR DESCRIPTION
## What does this PR do?

Adds Chatblocks to the optional MCP catalog.

Chatblocks runs a hosted MCP server at `https://chatblocks.ai/api/mcp/v1`. The server uses an `Authorization` header with a `cb_live_*` workspace key, so this also teaches the catalog parser to carry `transport.headers` from a manifest into the saved `mcp_servers.<name>` config.

I kept the catalog entry HTTP-only. It does not add install commands, git clones, bootstrap scripts, or local execution.

## Related Issue

No issue yet. This is a small catalog addition plus the parser support needed for API-key-backed hosted MCP servers.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/mcp_catalog.py`
  - Parses optional `transport.headers` from catalog manifests.
  - Writes those headers into the installed HTTP MCP server config.
- `optional-mcps/chatblocks/manifest.yaml`
  - Adds the Chatblocks hosted MCP endpoint.
  - Prompts for `CHATBLOCKS_API_KEY` and saves `Authorization: Bearer ${CHATBLOCKS_API_KEY}`.
- `pyproject.toml`
  - Adds the Chatblocks manifest to the per-entry `optional-mcps` data-files mapping.
- `tests/hermes_cli/test_mcp_catalog.py`
  - Covers parsing HTTP transport headers.
  - Covers installing an HTTP catalog entry with resolved headers.

## How to Test

1. Run the catalog tests:

   ```bash
   uv run --extra dev pytest tests/hermes_cli/test_mcp_catalog.py tests/test_packaging_metadata.py
   ```

2. Run lint for the touched Python files:

   ```bash
   uv run --extra dev ruff check hermes_cli/mcp_catalog.py tests/hermes_cli/test_mcp_catalog.py
   ```

3. Install the catalog entry from a checkout and confirm the saved config contains:

   ```yaml
   mcp_servers:
     chatblocks:
       url: https://chatblocks.ai/api/mcp/v1
       headers:
         Authorization: Bearer <resolved CHATBLOCKS_API_KEY>
   ```

## Checklist

### Code

- [x] I've read the Contributing Guide.
- [x] My commit message follows Conventional Commits.
- [x] I searched existing PRs for a duplicate Chatblocks MCP catalog entry.
- [x] My PR contains only changes related to this catalog entry and its required HTTP header support.
- [ ] I've run `pytest tests/ -q` and all tests pass. Not run; I ran the focused suites listed below.
- [x] I've added tests for my changes.
- [x] I've tested on my platform: macOS.

### Documentation & Housekeeping

- [x] Documentation update: N/A. The manifest `post_install` text contains the user-facing setup note.
- [x] `cli-config.yaml.example` update: N/A.
- [x] `CONTRIBUTING.md` / `AGENTS.md` update: N/A.
- [x] Cross-platform impact considered: no shell commands, local processes, path handling, or platform-specific APIs added.
- [x] Tool descriptions/schemas update: N/A.

## MCP catalog review

This PR changes `optional-mcps/**` and `hermes_cli/mcp_catalog.py`, so it should stay draft until a maintainer reviews it under the repository's MCP catalog policy.

Specific review notes:

- The new manifest is HTTP-only and has no stdio command, git install, bootstrap command, or local executable path.
- The only requested secret is `CHATBLOCKS_API_KEY`.
- The saved header is needed because the Chatblocks MCP server authorizes requests with `Authorization: Bearer <key>`.
- The parser change is generic: manifests may now include `transport.headers` as a mapping for HTTP transports.

## Screenshots / Logs

Focused checks run locally:

```text
uv run --extra dev pytest tests/hermes_cli/test_mcp_catalog.py tests/test_packaging_metadata.py
# 46 passed

uv run --extra dev ruff check hermes_cli/mcp_catalog.py tests/hermes_cli/test_mcp_catalog.py
# All checks passed

git diff --check
# passed
```
