### PR TITLE
fix(email): use BODY.PEEK[] by default, configurable via platforms.email.imap_peek

### DIFF
--- a/plugins/platforms/email/adapter.py
+++ b/plugins/platforms/email/adapter.py
@@ -486,6 +486,12 @@ class EmailAdapter(BasePlatformAdapter):
         # Track message IDs we've already processed to avoid duplicates
         self._seen_uids: set = set()
         self._seen_uids_max: int = 2000   # cap to prevent unbounded memory growth
+        # Highest numeric UID present at startup. Under BODY.PEEK[] polling,
+        # fetched messages stay UNSEEN, so without this floor a restart in a
+        # large (>_seen_uids_max) inbox could replay old mail dropped by
+        # _trim_seen_uids (#60637). UIDs are monotonic, so any UID above this
+        # watermark arrived after connect() and is genuinely new.
+        self._startup_uid_watermark: Optional[int] = None
         self._poll_task: Optional[asyncio.Task] = None
 
         # Map chat_id (sender email) -> last subject + message-id for threading
@@ -512,6 +518,36 @@ class EmailAdapter(BasePlatformAdapter):
         except (ValueError, TypeError):
             # Fallback: just clear old entries if sort fails
             self._seen_uids = set(list(self._seen_uids)[-self._seen_uids_max // 2:])
+
+    def _max_uid(self, uids) -> Optional[int]:
+        """Largest numeric UID in ``uids`` (bytes/str/int), or ``None``.
+
+        Non-numeric entries are skipped so one malformed UID can't poison the
+        watermark. Returns ``None`` for an empty / all-malformed collection.
+        """
+        best: Optional[int] = None
+        for uid in uids:
+            try:
+                n = int(uid)
+            except (TypeError, ValueError):
+                continue
+            if best is None or n > best:
+                best = n
+        return best
+
+    def _seed_seen_uids(self, uids) -> None:
+        """Seed ``_seen_uids`` from existing UIDs and set the startup watermark.
+
+        Called once from ``connect()`` with every UID currently in the mailbox.
+        The watermark (highest existing UID) is computed from the *full* set
+        before trimming, so trimming can never lower the replay floor: only
+        mail with a UID above the watermark is processed, which by IMAP UID
+        monotonicity means mail that arrived after startup.
+        """
+        for uid in uids:
+            self._seen_uids.add(uid)
+        self._startup_uid_watermark = self._max_uid(self._seen_uids)
+        self._trim_seen_uids()
 
     def _connect_smtp(self) -> smtplib.SMTP:
         """Create an SMTP connection, selecting the correct protocol for the port.
@@ -596,10 +632,7 @@ class EmailAdapter(BasePlatformAdapter):
             imap.select("INBOX")
             status, data = imap.uid("search", None, "ALL")
             if status == "OK" and data and data[0]:
-                for uid in data[0].split():
-                    self._seen_uids.add(uid)
-            # Keep only the most recent UIDs to prevent unbounded growth
-            self._trim_seen_uids()
+                self._seed_seen_uids(data[0].split())
             imap.logout()
             logger.info("[Email] IMAP connection test passed. %d existing messages skipped.", len(self._seen_uids))
         except Exception as e:
@@ -671,6 +704,16 @@ class EmailAdapter(BasePlatformAdapter):
                 for uid in data[0].split():
                     if uid in self._seen_uids:
                         continue
+                    # Skip mail that already existed at startup. Under
+                    # BODY.PEEK[] fetched messages stay UNSEEN, so without this
+                    # floor a restart in a large (>_seen_uids_max) inbox could
+                    # replay old mail that _trim_seen_uids dropped (#60637).
+                    if self._startup_uid_watermark is not None:
+                        try:
+                            if int(uid) <= self._startup_uid_watermark:
+                                continue
+                        except (TypeError, ValueError):
+                            pass
                     self._seen_uids.add(uid)
                     # Trim periodically to prevent unbounded memory growth
                     if len(self._seen_uids) > self._seen_uids_max:
@@ -1260,6 +1303,25 @@ def _build_adapter(config):
     return EmailAdapter(config)
 
 
+def _apply_yaml_config(yaml_cfg: dict, email_cfg: dict) -> Optional[dict]:
+    """Bridge ``platforms.email.*`` keys into ``PlatformConfig.extra``.
+
+    Implements the ``apply_yaml_config_fn`` contract (#24849). The generic
+    shared-key loop in ``load_gateway_config()`` bridges only a fixed key set
+    (allow_from, require_mention, dm_policy, …); it does not cover
+    email-specific options. The EmailAdapter reads ``imap_peek`` and
+    ``skip_attachments`` from ``PlatformConfig.extra``, so without this hook a
+    top-level ``platforms.email.imap_peek: false`` would never reach the
+    adapter (only a nested ``extra:`` block would). Bridge them here.
+    """
+    seeded: dict = {}
+    if "imap_peek" in email_cfg:
+        seeded["imap_peek"] = email_cfg["imap_peek"]
+    if "skip_attachments" in email_cfg:
+        seeded["skip_attachments"] = email_cfg["skip_attachments"]
+    return seeded or None
+
+
 def register(ctx) -> None:
     """Plugin entry point — called by the Hermes plugin system."""
     ctx.register_platform(
@@ -1267,6 +1329,7 @@ def register(ctx) -> None:
         label="Email",
         adapter_factory=_build_adapter,
         check_fn=check_email_requirements,
+        apply_yaml_config_fn=_apply_yaml_config,
         is_connected=_is_connected,
         required_env=["EMAIL_ADDRESS", "EMAIL_PASSWORD", "EMAIL_SMTP_HOST"],
         install_hint="Email uses the Python stdlib (smtplib/imaplib) — no extra deps",

--- a/plugins/platforms/email/adapter.py
+++ b/plugins/platforms/email/adapter.py
@@ -42,7 +42,7 @@ from gateway.platforms.base import (
     cache_document_from_bytes,
     cache_image_from_bytes,
 )
-from gateway.config import Platform, PlatformConfig
+from gateway.config import Platform, PlatformConfig, _coerce_bool
 from utils import env_int, env_bool
 
 logger = logging.getLogger(__name__)
@@ -448,6 +448,13 @@ class EmailAdapter(BasePlatformAdapter):
         #       skip_attachments: true
         self._skip_attachments = extra.get("skip_attachments", False)
 
+        # Use BODY.PEEK[] for IMAP fetch to avoid marking messages as read on
+        # the server.  Set to false to restore the legacy RFC822 behaviour.
+        #   platforms:
+        #     email:
+        #       imap_peek: false
+        self._imap_peek = _coerce_bool(extra.get("imap_peek"), True)
+
         # Require the sender's From: domain to be authenticated (SPF/DKIM/DMARC)
         # before trusting it for authorization. The From: header is
         # attacker-controlled and unauthenticated by IMAP, so an allowlist keyed
@@ -669,7 +676,8 @@ class EmailAdapter(BasePlatformAdapter):
                     if len(self._seen_uids) > self._seen_uids_max:
                         self._trim_seen_uids()
 
-                    status, msg_data = imap.uid("fetch", uid, "(RFC822)")
+                    fetch_cmd = "(BODY.PEEK[])" if self._imap_peek else "(RFC822)"
+                    status, msg_data = imap.uid("fetch", uid, fetch_cmd)
                     if status != "OK":
                         continue
 

--- a/plugins/platforms/email/adapter.py
+++ b/plugins/platforms/email/adapter.py
@@ -486,12 +486,11 @@ class EmailAdapter(BasePlatformAdapter):
         # Track message IDs we've already processed to avoid duplicates
         self._seen_uids: set = set()
         self._seen_uids_max: int = 2000   # cap to prevent unbounded memory growth
-        # Highest numeric UID present at startup. Under BODY.PEEK[] polling,
-        # fetched messages stay UNSEEN, so without this floor a restart in a
-        # large (>_seen_uids_max) inbox could replay old mail dropped by
-        # _trim_seen_uids (#60637). UIDs are monotonic, so any UID above this
-        # watermark arrived after connect() and is genuinely new.
-        self._startup_uid_watermark: Optional[int] = None
+        # Highest UID known to be consumed in the current UIDVALIDITY epoch.
+        # BODY.PEEK[] leaves fetched messages UNSEEN, so this durable-in-process
+        # boundary prevents replay after _seen_uids evicts older entries.
+        self._uid_watermark: Optional[int] = None
+        self._uidvalidity: Optional[int] = None
         self._poll_task: Optional[asyncio.Task] = None
 
         # Map chat_id (sender email) -> last subject + message-id for threading
@@ -536,18 +535,80 @@ class EmailAdapter(BasePlatformAdapter):
         return best
 
     def _seed_seen_uids(self, uids) -> None:
-        """Seed ``_seen_uids`` from existing UIDs and set the startup watermark.
+        """Seed UID state from all messages in the current mailbox epoch.
 
         Called once from ``connect()`` with every UID currently in the mailbox.
         The watermark (highest existing UID) is computed from the *full* set
-        before trimming, so trimming can never lower the replay floor: only
-        mail with a UID above the watermark is processed, which by IMAP UID
-        monotonicity means mail that arrived after startup.
+        before trimming, so trimming can never lower the consumed boundary.
         """
-        for uid in uids:
-            self._seen_uids.add(uid)
-        self._startup_uid_watermark = self._max_uid(self._seen_uids)
+        uid_list = list(uids)
+        self._seen_uids = set(uid_list)
+        self._uid_watermark = self._max_uid(uid_list)
         self._trim_seen_uids()
+
+    def _record_consumed_uid(self, uid) -> None:
+        """Record a UID as consumed and advance the replay boundary."""
+        try:
+            numeric_uid = int(uid)
+        except (TypeError, ValueError):
+            numeric_uid = None
+        if numeric_uid is not None and (
+            self._uid_watermark is None or numeric_uid > self._uid_watermark
+        ):
+            self._uid_watermark = numeric_uid
+        self._seen_uids.add(uid)
+        if len(self._seen_uids) > self._seen_uids_max:
+            self._trim_seen_uids()
+
+    @staticmethod
+    def _read_uidvalidity(imap) -> Optional[int]:
+        """Return the selected mailbox's UIDVALIDITY, when advertised."""
+        try:
+            response = imap.response("UIDVALIDITY")
+        except Exception:
+            return None
+        if not isinstance(response, (tuple, list)) or len(response) < 2:
+            return None
+        values = response[1]
+        if not isinstance(values, (tuple, list)) or not values:
+            return None
+        raw = values[-1]
+        if isinstance(raw, bytes):
+            raw = raw.decode("ascii", errors="ignore")
+        match = re.search(r"\d+", str(raw))
+        return int(match.group(0)) if match else None
+
+    def _sync_uidvalidity(self, imap) -> bool:
+        """Reset and reseed UID state when the mailbox epoch changes."""
+        current = self._read_uidvalidity(imap)
+        if current is None:
+            return True
+        if self._uidvalidity is None:
+            self._uidvalidity = current
+            return True
+        if current == self._uidvalidity:
+            return True
+
+        status, data = imap.uid("search", None, "ALL")
+        if status != "OK" or not data:
+            logger.warning(
+                "[Email] UIDVALIDITY changed from %s to %s but UID state could not be reseeded",
+                self._uidvalidity,
+                current,
+            )
+            return False
+
+        old_uidvalidity = self._uidvalidity
+        self._uidvalidity = current
+        existing_uids = data[0].split() if data[0] else []
+        self._seed_seen_uids(existing_uids)
+        logger.info(
+            "[Email] UIDVALIDITY changed from %s to %s; reseeded %d existing UIDs",
+            old_uidvalidity,
+            current,
+            len(existing_uids),
+        )
+        return True
 
     def _connect_smtp(self) -> smtplib.SMTP:
         """Create an SMTP connection, selecting the correct protocol for the port.
@@ -630,9 +691,10 @@ class EmailAdapter(BasePlatformAdapter):
             _send_imap_id(imap)
             # Mark all existing messages as seen so we only process new ones
             imap.select("INBOX")
+            self._uidvalidity = self._read_uidvalidity(imap)
             status, data = imap.uid("search", None, "ALL")
-            if status == "OK" and data and data[0]:
-                self._seed_seen_uids(data[0].split())
+            if status == "OK" and data:
+                self._seed_seen_uids(data[0].split() if data[0] else [])
             imap.logout()
             logger.info("[Email] IMAP connection test passed. %d existing messages skipped.", len(self._seen_uids))
         except Exception as e:
@@ -696,28 +758,32 @@ class EmailAdapter(BasePlatformAdapter):
                 imap.login(self._address, self._password)
                 _send_imap_id(imap)
                 imap.select("INBOX")
+                if not self._sync_uidvalidity(imap):
+                    return results
 
                 status, data = imap.uid("search", None, "UNSEEN")
                 if status != "OK" or not data or not data[0]:
                     return results
 
-                for uid in data[0].split():
+                uids = data[0].split()
+                try:
+                    uids = sorted(uids, key=int)
+                except (TypeError, ValueError):
+                    pass
+
+                for uid in uids:
                     if uid in self._seen_uids:
                         continue
-                    # Skip mail that already existed at startup. Under
-                    # BODY.PEEK[] fetched messages stay UNSEEN, so without this
-                    # floor a restart in a large (>_seen_uids_max) inbox could
-                    # replay old mail that _trim_seen_uids dropped (#60637).
-                    if self._startup_uid_watermark is not None:
+                    # BODY.PEEK[] leaves consumed mail UNSEEN. Skip anything at
+                    # or below the consumed boundary even if _seen_uids evicted
+                    # it after crossing the bounded-set cap (#60637).
+                    if self._uid_watermark is not None:
                         try:
-                            if int(uid) <= self._startup_uid_watermark:
+                            if int(uid) <= self._uid_watermark:
                                 continue
                         except (TypeError, ValueError):
                             pass
-                    self._seen_uids.add(uid)
-                    # Trim periodically to prevent unbounded memory growth
-                    if len(self._seen_uids) > self._seen_uids_max:
-                        self._trim_seen_uids()
+                    self._record_consumed_uid(uid)
 
                     fetch_cmd = "(BODY.PEEK[])" if self._imap_peek else "(RFC822)"
                     status, msg_data = imap.uid("fetch", uid, fetch_cmd)
@@ -1314,11 +1380,28 @@ def _apply_yaml_config(yaml_cfg: dict, email_cfg: dict) -> Optional[dict]:
     top-level ``platforms.email.imap_peek: false`` would never reach the
     adapter (only a nested ``extra:`` block would). Bridge them here.
     """
+    # Match load_gateway_config() precedence: gateway.platforms is the base,
+    # top-level platforms overrides it, and the legacy direct email block has
+    # final precedence when present. ``email_cfg`` preserves direct calls to
+    # this hook in isolation (including plugin tests).
+    effective: dict = dict(email_cfg) if isinstance(email_cfg, dict) else {}
+    gateway_cfg = yaml_cfg.get("gateway") if isinstance(yaml_cfg, dict) else None
+    gateway_platforms = gateway_cfg.get("platforms") if isinstance(gateway_cfg, dict) else None
+    platforms = yaml_cfg.get("platforms") if isinstance(yaml_cfg, dict) else None
+    sources = (
+        gateway_platforms.get("email") if isinstance(gateway_platforms, dict) else None,
+        platforms.get("email") if isinstance(platforms, dict) else None,
+        yaml_cfg.get("email") if isinstance(yaml_cfg, dict) else None,
+    )
+    for source in sources:
+        if isinstance(source, dict):
+            effective.update(source)
+
     seeded: dict = {}
-    if "imap_peek" in email_cfg:
-        seeded["imap_peek"] = email_cfg["imap_peek"]
-    if "skip_attachments" in email_cfg:
-        seeded["skip_attachments"] = email_cfg["skip_attachments"]
+    if "imap_peek" in effective:
+        seeded["imap_peek"] = effective["imap_peek"]
+    if "skip_attachments" in effective:
+        seeded["skip_attachments"] = effective["skip_attachments"]
     return seeded or None
 
 

--- a/tests/gateway/test_email_imap_peek.py
+++ b/tests/gateway/test_email_imap_peek.py
@@ -1,16 +1,25 @@
 """
-Test that EmailAdapter respects the platforms.email.imap_peek config option.
+Tests for the Email IMAP peek + restart replay-guard behavior.
 
-Verifies the IMAP FETCH uses BODY.PEEK[] by default (so polling does not mark
-unread messages as read) and RFC822 when imap_peek is explicitly false, and
-that the selector actually reaches the imap.uid("fetch", ...) call.
+Covers:
+- ``platforms.email.imap_peek`` config coercion (BODY.PEEK[] vs RFC822).
+- The ``_apply_yaml_config`` bridge that routes a top-level
+  ``platforms.email.imap_peek`` / ``skip_attachments`` key into
+  ``PlatformConfig.extra`` (the generic shared-key loop does not cover these).
+- The real ``load_gateway_config()`` path so the user-facing config.yaml key
+  is proven to reach the adapter, not just a hand-built ``extra`` dict.
+- The startup UID watermark that keeps BODY.PEEK[] default safe against
+  restart replay in large (>_seen_uids_max) inboxes (#60637).
 """
 
 import os
 from unittest.mock import MagicMock, patch
 
 from gateway.config import PlatformConfig
-from plugins.platforms.email.adapter import EmailAdapter
+from plugins.platforms.email.adapter import (
+    EmailAdapter,
+    _apply_yaml_config,
+)
 
 _EMAIL_ENV = {
     "EMAIL_ADDRESS": "hermes@test.com",
@@ -23,7 +32,7 @@ _EMAIL_ENV = {
 }
 
 # Minimal valid message body so downstream parsing in _fetch_new_messages
-# does not raise; the assertion only cares about the FETCH selector.
+# does not raise; the assertions only care about the FETCH selector / UID.
 _SAMPLE_RAW = (
     b"From: sender@test.com\n"
     b"To: hermes@test.com\n"
@@ -40,15 +49,14 @@ def _make_adapter(extra: dict) -> EmailAdapter:
         return EmailAdapter(config)
 
 
-def _fetch_selector(extra: dict) -> str:
-    """Run _fetch_new_messages against a mocked IMAP server and return the
-    FETCH selector that was passed to imap.uid("fetch", uid, <selector>)."""
-    adapter = _make_adapter(extra)
+def _fetched_uids(adapter: EmailAdapter):
+    """Run _fetch_new_messages against a mocked IMAP server; return the list
+    of UIDs that actually reached the imap.uid('fetch', ...) call."""
     mock_imap = MagicMock()
 
     def _uid(cmd, *args):
         if cmd == "search":
-            return ("OK", [b"123"])
+            return ("OK", [b"5 2501"])
         if cmd == "fetch":
             return ("OK", [(b"1 (BODY.PEEK[])", _SAMPLE_RAW)])
         return ("OK", [b""])
@@ -61,12 +69,10 @@ def _fetch_selector(extra: dict) -> str:
     ), patch("plugins.platforms.email.adapter._send_imap_id"):
         adapter._fetch_new_messages()
 
-    fetch_calls = [
-        c for c in mock_imap.uid.call_args_list if c.args and c.args[0] == "fetch"
-    ]
-    assert fetch_calls, "expected an imap.uid('fetch', ...) call"
-    return fetch_calls[0].args[2]
+    return [c.args[1] for c in mock_imap.uid.call_args_list if c.args and c.args[0] == "fetch"]
 
+
+# --- config coercion --------------------------------------------------------
 
 def test_imap_peek_defaults_to_true():
     """Without explicit config, imap_peek should default to True (BODY.PEEK[])."""
@@ -93,11 +99,151 @@ def test_imap_peek_string_true():
     assert _make_adapter({"imap_peek": "true"})._imap_peek is True
 
 
+# --- FETCH selector ---------------------------------------------------------
+
 def test_fetch_uses_body_peek_by_default():
     """The FETCH call must receive (BODY.PEEK[]) by default."""
-    assert _fetch_selector({}) == "(BODY.PEEK[])"
+    adapter = _make_adapter({})
+    mock_imap = MagicMock()
+
+    def _uid(cmd, *args):
+        if cmd == "search":
+            return ("OK", [b"123"])
+        if cmd == "fetch":
+            return ("OK", [(b"1 (BODY.PEEK[])", _SAMPLE_RAW)])
+        return ("OK", [b""])
+
+    mock_imap.uid.side_effect = _uid
+
+    with patch(
+        "plugins.platforms.email.adapter.imaplib.IMAP4_SSL",
+        return_value=mock_imap,
+    ), patch("plugins.platforms.email.adapter._send_imap_id"):
+        adapter._fetch_new_messages()
+
+    fetch_calls = [
+        c for c in mock_imap.uid.call_args_list if c.args and c.args[0] == "fetch"
+    ]
+    assert fetch_calls, "expected an imap.uid('fetch', ...) call"
+    assert fetch_calls[0].args[2] == "(BODY.PEEK[])"
 
 
 def test_fetch_uses_rfc822_when_peek_disabled():
     """With imap_peek: false, the FETCH call must receive (RFC822)."""
-    assert _fetch_selector({"imap_peek": False}) == "(RFC822)"
+    adapter = _make_adapter({"imap_peek": False})
+    mock_imap = MagicMock()
+
+    def _uid(cmd, *args):
+        if cmd == "search":
+            return ("OK", [b"123"])
+        if cmd == "fetch":
+            return ("OK", [(b"1 (RFC822)", _SAMPLE_RAW)])
+        return ("OK", [b""])
+
+    mock_imap.uid.side_effect = _uid
+
+    with patch(
+        "plugins.platforms.email.adapter.imaplib.IMAP4_SSL",
+        return_value=mock_imap,
+    ), patch("plugins.platforms.email.adapter._send_imap_id"):
+        adapter._fetch_new_messages()
+
+    fetch_calls = [
+        c for c in mock_imap.uid.call_args_list if c.args and c.args[0] == "fetch"
+    ]
+    assert fetch_calls, "expected an imap.uid('fetch', ...) call"
+    assert fetch_calls[0].args[2] == "(RFC822)"
+
+
+# --- _apply_yaml_config bridge (pure function) ------------------------------
+
+def test_apply_yaml_config_bridges_imap_peek_false():
+    assert _apply_yaml_config({}, {"imap_peek": False}) == {"imap_peek": False}
+
+
+def test_apply_yaml_config_bridges_skip_attachments():
+    assert _apply_yaml_config({}, {"skip_attachments": True}) == {"skip_attachments": True}
+
+
+def test_apply_yaml_config_returns_none_when_nothing_to_bridge():
+    assert _apply_yaml_config({}, {}) is None
+
+
+# --- real config-loading path (config.yaml -> PlatformConfig.extra) ---------
+
+def test_imap_peek_reaches_extra_via_load_gateway_config(tmp_path, monkeypatch):
+    """A top-level ``platforms.email.imap_peek`` in config.yaml must reach the
+    email PlatformConfig.extra via the apply_yaml_config_fn bridge — not only a
+    nested ``extra:`` block."""
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir()
+    (hermes_home / "config.yaml").write_text(
+        "platforms:\n"
+        "  email:\n"
+        "    imap_peek: false\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    from gateway.config import Platform, load_gateway_config
+
+    config = load_gateway_config()
+    email_cfg = config.platforms.get(Platform.EMAIL)
+    assert email_cfg is not None, "email platform missing from config.platforms"
+    assert email_cfg.extra.get("imap_peek") is False
+
+
+def test_skip_attachments_reaches_extra_via_load_gateway_config(tmp_path, monkeypatch):
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir()
+    (hermes_home / "config.yaml").write_text(
+        "platforms:\n"
+        "  email:\n"
+        "    skip_attachments: true\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    from gateway.config import Platform, load_gateway_config
+
+    config = load_gateway_config()
+    email_cfg = config.platforms.get(Platform.EMAIL)
+    assert email_cfg is not None
+    assert email_cfg.extra.get("skip_attachments") is True
+
+
+# --- startup UID watermark + replay guard (#60637) --------------------------
+
+def test_max_uid_picks_numeric_max():
+    assert _make_adapter({})._max_uid([b"1", b"10", b"2", b"2500"]) == 2500
+
+
+def test_max_uid_ignores_non_numeric():
+    assert _make_adapter({})._max_uid([b"abc", b"5", None]) == 5
+
+
+def test_max_uid_empty_is_none():
+    assert _make_adapter({})._max_uid([]) is None
+
+
+def test_seed_seen_uids_sets_watermark_to_max_and_trims():
+    """Startup seeding must record the highest UID (watermark) from the full
+    set before trimming, so trimming can never lower the replay floor."""
+    adapter = _make_adapter({})
+    uids = [str(i).encode() for i in range(1, 2501)]  # 2500 UIDs > 2000 cap
+    adapter._seed_seen_uids(uids)
+    assert adapter._startup_uid_watermark == 2500
+    assert len(adapter._seen_uids) <= adapter._seen_uids_max
+
+
+def test_fetch_skips_preexisting_uids_under_peek():
+    """Under BODY.PEEK[], a UID at/below the startup watermark (here b'5',
+    dropped from the trimmed _seen_uids) must NOT be replayed, while a UID
+    above it (b'2501', genuinely new) is fetched."""
+    adapter = _make_adapter({})  # peek defaults to True
+    adapter._seed_seen_uids([str(i).encode() for i in range(1, 2501)])
+    assert adapter._startup_uid_watermark == 2500
+
+    fetched = _fetched_uids(adapter)
+    assert b"5" not in fetched, "pre-existing UID below watermark was replayed"
+    assert b"2501" in fetched, "new UID above watermark was not fetched"

--- a/tests/gateway/test_email_imap_peek.py
+++ b/tests/gateway/test_email_imap_peek.py
@@ -1,0 +1,103 @@
+"""
+Test that EmailAdapter respects the platforms.email.imap_peek config option.
+
+Verifies the IMAP FETCH uses BODY.PEEK[] by default (so polling does not mark
+unread messages as read) and RFC822 when imap_peek is explicitly false, and
+that the selector actually reaches the imap.uid("fetch", ...) call.
+"""
+
+import os
+from unittest.mock import MagicMock, patch
+
+from gateway.config import PlatformConfig
+from plugins.platforms.email.adapter import EmailAdapter
+
+_EMAIL_ENV = {
+    "EMAIL_ADDRESS": "hermes@test.com",
+    "EMAIL_PASSWORD": "secret",
+    "EMAIL_IMAP_HOST": "imap.test.com",
+    "EMAIL_IMAP_PORT": "993",
+    "EMAIL_SMTP_HOST": "smtp.test.com",
+    "EMAIL_SMTP_PORT": "587",
+    "EMAIL_POLL_INTERVAL": "15",
+}
+
+# Minimal valid message body so downstream parsing in _fetch_new_messages
+# does not raise; the assertion only cares about the FETCH selector.
+_SAMPLE_RAW = (
+    b"From: sender@test.com\n"
+    b"To: hermes@test.com\n"
+    b"Subject: peek test\n"
+    b"Message-ID: <peek@test.com>\n"
+    b"\n"
+    b"hello\n"
+)
+
+
+def _make_adapter(extra: dict) -> EmailAdapter:
+    config = PlatformConfig(enabled=True, extra=extra)
+    with patch.dict(os.environ, _EMAIL_ENV):
+        return EmailAdapter(config)
+
+
+def _fetch_selector(extra: dict) -> str:
+    """Run _fetch_new_messages against a mocked IMAP server and return the
+    FETCH selector that was passed to imap.uid("fetch", uid, <selector>)."""
+    adapter = _make_adapter(extra)
+    mock_imap = MagicMock()
+
+    def _uid(cmd, *args):
+        if cmd == "search":
+            return ("OK", [b"123"])
+        if cmd == "fetch":
+            return ("OK", [(b"1 (BODY.PEEK[])", _SAMPLE_RAW)])
+        return ("OK", [b""])
+
+    mock_imap.uid.side_effect = _uid
+
+    with patch(
+        "plugins.platforms.email.adapter.imaplib.IMAP4_SSL",
+        return_value=mock_imap,
+    ), patch("plugins.platforms.email.adapter._send_imap_id"):
+        adapter._fetch_new_messages()
+
+    fetch_calls = [
+        c for c in mock_imap.uid.call_args_list if c.args and c.args[0] == "fetch"
+    ]
+    assert fetch_calls, "expected an imap.uid('fetch', ...) call"
+    return fetch_calls[0].args[2]
+
+
+def test_imap_peek_defaults_to_true():
+    """Without explicit config, imap_peek should default to True (BODY.PEEK[])."""
+    assert _make_adapter({})._imap_peek is True
+
+
+def test_imap_peek_false_restores_rfc822():
+    """Setting imap_peek: false should disable PEEK and use RFC822."""
+    assert _make_adapter({"imap_peek": False})._imap_peek is False
+
+
+def test_imap_peek_true_explicit():
+    """Explicitly setting imap_peek: true should enable PEEK."""
+    assert _make_adapter({"imap_peek": True})._imap_peek is True
+
+
+def test_imap_peek_string_false():
+    """String 'false' should be coerced to bool False."""
+    assert _make_adapter({"imap_peek": "false"})._imap_peek is False
+
+
+def test_imap_peek_string_true():
+    """String 'true' should be coerced to bool True."""
+    assert _make_adapter({"imap_peek": "true"})._imap_peek is True
+
+
+def test_fetch_uses_body_peek_by_default():
+    """The FETCH call must receive (BODY.PEEK[]) by default."""
+    assert _fetch_selector({}) == "(BODY.PEEK[])"
+
+
+def test_fetch_uses_rfc822_when_peek_disabled():
+    """With imap_peek: false, the FETCH call must receive (RFC822)."""
+    assert _fetch_selector({"imap_peek": False}) == "(RFC822)"

--- a/tests/gateway/test_email_imap_peek.py
+++ b/tests/gateway/test_email_imap_peek.py
@@ -8,8 +8,8 @@ Covers:
   ``PlatformConfig.extra`` (the generic shared-key loop does not cover these).
 - The real ``load_gateway_config()`` path so the user-facing config.yaml key
   is proven to reach the adapter, not just a hand-built ``extra`` dict.
-- The startup UID watermark that keeps BODY.PEEK[] default safe against
-  restart replay in large (>_seen_uids_max) inboxes (#60637).
+- The consumed UID watermark and UIDVALIDITY reset that keep BODY.PEEK[] safe
+  against bounded-set replay and mailbox epoch changes (#60637).
 """
 
 import os
@@ -49,14 +49,25 @@ def _make_adapter(extra: dict) -> EmailAdapter:
         return EmailAdapter(config)
 
 
-def _fetched_uids(adapter: EmailAdapter):
+def _fetched_uids(
+    adapter: EmailAdapter,
+    *,
+    unseen: bytes = b"5 2501",
+    uidvalidity: int | None = None,
+    all_uids: bytes = b"",
+):
     """Run _fetch_new_messages against a mocked IMAP server; return the list
     of UIDs that actually reached the imap.uid('fetch', ...) call."""
     mock_imap = MagicMock()
+    mock_imap.response.return_value = (
+        ("UIDVALIDITY", [str(uidvalidity).encode()])
+        if uidvalidity is not None
+        else None
+    )
 
     def _uid(cmd, *args):
         if cmd == "search":
-            return ("OK", [b"5 2501"])
+            return ("OK", [all_uids if args[-1] == "ALL" else unseen])
         if cmd == "fetch":
             return ("OK", [(b"1 (BODY.PEEK[])", _SAMPLE_RAW)])
         return ("OK", [b""])
@@ -212,7 +223,34 @@ def test_skip_attachments_reaches_extra_via_load_gateway_config(tmp_path, monkey
     assert email_cfg.extra.get("skip_attachments") is True
 
 
-# --- startup UID watermark + replay guard (#60637) --------------------------
+def test_platforms_email_overrides_gateway_platforms_email(tmp_path, monkeypatch):
+    """Top-level ``platforms`` has documented precedence over
+    ``gateway.platforms`` for email-specific bridged keys."""
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir()
+    (hermes_home / "config.yaml").write_text(
+        "gateway:\n"
+        "  platforms:\n"
+        "    email:\n"
+        "      imap_peek: true\n"
+        "      skip_attachments: false\n"
+        "platforms:\n"
+        "  email:\n"
+        "    imap_peek: false\n"
+        "    skip_attachments: true\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    from gateway.config import Platform, load_gateway_config
+
+    config = load_gateway_config()
+    email_cfg = config.platforms[Platform.EMAIL]
+    assert email_cfg.extra.get("imap_peek") is False
+    assert email_cfg.extra.get("skip_attachments") is True
+
+
+# --- consumed UID watermark + replay guard (#60637) -------------------------
 
 def test_max_uid_picks_numeric_max():
     assert _make_adapter({})._max_uid([b"1", b"10", b"2", b"2500"]) == 2500
@@ -227,23 +265,61 @@ def test_max_uid_empty_is_none():
 
 
 def test_seed_seen_uids_sets_watermark_to_max_and_trims():
-    """Startup seeding must record the highest UID (watermark) from the full
-    set before trimming, so trimming can never lower the replay floor."""
+    """Seeding records the highest UID from the full set before trimming."""
     adapter = _make_adapter({})
     uids = [str(i).encode() for i in range(1, 2501)]  # 2500 UIDs > 2000 cap
     adapter._seed_seen_uids(uids)
-    assert adapter._startup_uid_watermark == 2500
+    assert adapter._uid_watermark == 2500
     assert len(adapter._seen_uids) <= adapter._seen_uids_max
 
 
 def test_fetch_skips_preexisting_uids_under_peek():
-    """Under BODY.PEEK[], a UID at/below the startup watermark (here b'5',
+    """Under BODY.PEEK[], a UID at/below the consumed watermark (here b'5',
     dropped from the trimmed _seen_uids) must NOT be replayed, while a UID
     above it (b'2501', genuinely new) is fetched."""
     adapter = _make_adapter({})  # peek defaults to True
     adapter._seed_seen_uids([str(i).encode() for i in range(1, 2501)])
-    assert adapter._startup_uid_watermark == 2500
+    assert adapter._uid_watermark == 2500
 
     fetched = _fetched_uids(adapter)
     assert b"5" not in fetched, "pre-existing UID below watermark was replayed"
     assert b"2501" in fetched, "new UID above watermark was not fetched"
+
+
+def test_consumed_watermark_advances_past_evicted_post_start_uid():
+    """After enough new unread mail to trigger a trim, an evicted post-start
+    UID must remain below the advancing watermark and never be fetched again."""
+    adapter = _make_adapter({})
+    adapter._seed_seen_uids(str(i).encode() for i in range(1, 2501))
+
+    # The seed keeps 1,000 entries. Consuming 1,001 more crosses the 2,000 cap
+    # and evicts UID 2501 from the bounded set while advancing the watermark.
+    for uid in range(2501, 3502):
+        adapter._record_consumed_uid(str(uid).encode())
+
+    assert adapter._uid_watermark == 3501
+    assert b"2501" not in adapter._seen_uids
+
+    fetched = _fetched_uids(adapter, unseen=b"2501 3502")
+    assert fetched == [b"3502"]
+    assert adapter._uid_watermark == 3502
+
+
+def test_uidvalidity_change_resets_and_reseeds_uid_state():
+    """A new UIDVALIDITY epoch may restart UIDs below the old watermark; the
+    adapter must reseed from the new epoch and process only later arrivals."""
+    adapter = _make_adapter({})
+    adapter._uidvalidity = 10
+    adapter._seed_seen_uids(str(i).encode() for i in range(1, 2501))
+    assert adapter._uid_watermark == 2500
+
+    fetched = _fetched_uids(
+        adapter,
+        unseen=b"1 2 3",
+        uidvalidity=11,
+        all_uids=b"1 2",
+    )
+
+    assert adapter._uidvalidity == 11
+    assert fetched == [b"3"]
+    assert adapter._uid_watermark == 3


### PR DESCRIPTION
The email gateway IMAP fetch uses `RFC822`, which marks messages as read on the server. This is unexpected side-effect — Hermes reading your inbox should not change message state.

This PR switches the fetch to `BODY.PEEK[]` by default, with a config override:

```yaml
# config.yaml
platforms:
  email:
    imap_peek: false   # restore legacy RFC822 behaviour
```

**Why config-gated instead of a hardcoded swap?**

There are several open PRs (#43032, #43018, #43017, #43016, #41395, #21987, #14939) that all do the same raw `RFC822` → `BODY.PEEK[]` replacement. Making it configurable gives users who rely on the read-marking behaviour (e.g. to track which emails the agent has processed) a way to opt back out without patching core.

Default is `true` (PEEK), matching what every other PR proposes.

Fixes #42997.