### PR TITLE
fix: harden macOS desktop and browser resolution

### DIFF
--- a/apps/desktop/electron/backend-env.cjs
+++ b/apps/desktop/electron/backend-env.cjs
@@ -106,7 +106,9 @@ module.exports = {
   appendUniquePathEntries,
   buildDesktopBackendEnv,
   buildDesktopBackendPath,
+  currentPathValue,
   delimiterForPlatform,
   normalizeHermesHomeRoot,
+  pathModuleForPlatform,
   pathEnvKey
 }

--- a/apps/desktop/electron/desktop-path-resolver.cjs
+++ b/apps/desktop/electron/desktop-path-resolver.cjs
@@ -1,0 +1,71 @@
+'use strict'
+
+const path = require('node:path')
+const {
+  buildDesktopBackendPath,
+  currentPathValue,
+  delimiterForPlatform,
+  pathModuleForPlatform
+} = require('./backend-env.cjs')
+
+function buildDesktopResolverPath({
+  hermesHome,
+  venvRoot,
+  currentEnv = process.env,
+  platform = process.platform,
+  pathModule = pathModuleForPlatform(platform)
+} = {}) {
+  return buildDesktopBackendPath({
+    hermesHome,
+    venvRoot,
+    currentPath: currentPathValue(currentEnv, platform),
+    platform,
+    pathModule
+  })
+}
+
+function executableExtensions({ platform = process.platform, currentEnv = process.env } = {}) {
+  if (platform !== 'win32') return ['']
+  return ['', ...(currentEnv?.PATHEXT || '.COM;.EXE;.BAT;.CMD').split(';').filter(Boolean)]
+}
+
+function commandIncludesPathSeparator(command, { platform = process.platform, pathModule = pathModuleForPlatform(platform) } = {}) {
+  return command.includes(pathModule.sep) || (platform === 'win32' && command.includes('/'))
+}
+
+function findExecutableOnPath(command, {
+  searchPath,
+  currentEnv = process.env,
+  platform = process.platform,
+  pathModule = pathModuleForPlatform(platform),
+  fileExists,
+  isWindowsBinaryPathInWsl = () => false,
+  isWsl = false
+} = {}) {
+  if (!command || typeof fileExists !== 'function') return null
+
+  if (pathModule.isAbsolute(command) || commandIncludesPathSeparator(command, { platform, pathModule })) {
+    if (!fileExists(command)) return null
+    if (isWindowsBinaryPathInWsl(command, { isWsl })) return null
+    return command
+  }
+
+  const pathEntries = String(searchPath ?? currentPathValue(currentEnv, platform) ?? '')
+    .split(delimiterForPlatform(platform))
+    .filter(Boolean)
+  const extensions = executableExtensions({ platform, currentEnv })
+
+  for (const entry of pathEntries) {
+    for (const extension of extensions) {
+      const candidate = pathModule.join(entry, `${command}${extension}`)
+      if (fileExists(candidate)) return candidate
+    }
+  }
+
+  return null
+}
+
+module.exports = {
+  buildDesktopResolverPath,
+  findExecutableOnPath
+}

--- a/apps/desktop/electron/desktop-path-resolver.test.cjs
+++ b/apps/desktop/electron/desktop-path-resolver.test.cjs
@@ -1,0 +1,25 @@
+const test = require('node:test')
+const assert = require('node:assert/strict')
+const path = require('node:path')
+
+const { buildDesktopResolverPath, findExecutableOnPath } = require('./desktop-path-resolver.cjs')
+
+test('desktop resolver PATH includes Homebrew before resolving GUI-launched binaries', () => {
+  const resolverPath = buildDesktopResolverPath({
+    hermesHome: '/Users/alice/.hermes',
+    venvRoot: '/Users/alice/.hermes/hermes-agent/venv',
+    currentEnv: { PATH: '/usr/bin:/bin:/usr/sbin:/sbin' },
+    platform: 'darwin',
+    pathModule: path.posix
+  })
+
+  const found = findExecutableOnPath('hermes', {
+    searchPath: resolverPath,
+    currentEnv: { PATH: '/usr/bin:/bin:/usr/sbin:/sbin' },
+    platform: 'darwin',
+    pathModule: path.posix,
+    fileExists: candidate => candidate === '/opt/homebrew/bin/hermes'
+  })
+
+  assert.equal(found, '/opt/homebrew/bin/hermes')
+})

--- a/apps/desktop/electron/desktop-update-paths.cjs
+++ b/apps/desktop/electron/desktop-update-paths.cjs
@@ -1,0 +1,24 @@
+'use strict'
+
+const path = require('node:path')
+
+function uniqueValues(values) {
+  const seen = new Set()
+  const result = []
+  for (const value of values) {
+    if (!value || seen.has(value)) continue
+    seen.add(value)
+    result.push(value)
+  }
+  return result
+}
+
+function rebuiltMacAppCandidates(updateRoot, arch = process.arch) {
+  const releaseDir = path.join(updateRoot, 'apps', 'desktop', 'release')
+  const currentArchDir = arch === 'x64' ? 'mac-x64' : arch === 'arm64' ? 'mac-arm64' : null
+  return uniqueValues([currentArchDir, 'mac-arm64', 'mac-x64', 'mac']).map(directory =>
+    path.join(releaseDir, directory, 'Hermes.app')
+  )
+}
+
+module.exports = { rebuiltMacAppCandidates }

--- a/apps/desktop/electron/desktop-update-paths.test.cjs
+++ b/apps/desktop/electron/desktop-update-paths.test.cjs
@@ -1,0 +1,24 @@
+const test = require('node:test')
+const assert = require('node:assert/strict')
+const path = require('node:path')
+
+const { rebuiltMacAppCandidates } = require('./desktop-update-paths.cjs')
+
+test('rebuilt mac app candidates include the x64 electron-builder output', () => {
+  const root = '/tmp/hermes-update'
+  const candidates = rebuiltMacAppCandidates(root, 'x64')
+
+  assert.deepEqual(candidates, [
+    path.join(root, 'apps', 'desktop', 'release', 'mac-x64', 'Hermes.app'),
+    path.join(root, 'apps', 'desktop', 'release', 'mac-arm64', 'Hermes.app'),
+    path.join(root, 'apps', 'desktop', 'release', 'mac', 'Hermes.app')
+  ])
+})
+
+test('rebuilt mac app candidates prefer arm64 on Apple Silicon', () => {
+  const root = '/tmp/hermes-update'
+  const candidates = rebuiltMacAppCandidates(root, 'arm64')
+
+  assert.equal(candidates[0], path.join(root, 'apps', 'desktop', 'release', 'mac-arm64', 'Hermes.app'))
+  assert.ok(candidates.includes(path.join(root, 'apps', 'desktop', 'release', 'mac-x64', 'Hermes.app')))
+})

--- a/apps/desktop/electron/main.cjs
+++ b/apps/desktop/electron/main.cjs
@@ -40,12 +40,14 @@ const { waitForDashboardPort } = require('./backend-ready.cjs')
 const { serializeJsonBody, setJsonRequestHeaders } = require('./oauth-net-request.cjs')
 const { fetchMarketplaceThemes, searchMarketplaceThemes } = require('./vscode-marketplace.cjs')
 const { buildDesktopBackendEnv, normalizeHermesHomeRoot } = require('./backend-env.cjs')
+const { buildDesktopResolverPath, findExecutableOnPath } = require('./desktop-path-resolver.cjs')
 const { readWindowsUserEnvVar } = require('./windows-user-env.cjs')
 const { readDirForIpc } = require('./fs-read-dir.cjs')
 const { gitRootForIpc } = require('./git-root.cjs')
 const { worktreesForIpc } = require('./git-worktrees.cjs')
 const { OFFICIAL_REPO_HTTPS_URL, isOfficialSshRemote } = require('./update-remote.cjs')
 const { runRebuildWithRetry } = require('./update-rebuild.cjs')
+const { rebuiltMacAppCandidates } = require('./desktop-update-paths.cjs')
 const {
   buildPosixCleanupScript,
   buildWindowsCleanupScript,
@@ -274,6 +276,14 @@ const HERMES_HOME = resolveHermesHome()
 const ACTIVE_HERMES_ROOT = path.join(HERMES_HOME, 'hermes-agent')
 // VENV_ROOT — venv lives inside the repo, exactly like install.ps1 does it.
 const VENV_ROOT = path.join(ACTIVE_HERMES_ROOT, 'venv')
+// GUI-launched macOS apps often inherit a minimal PATH that omits Homebrew.
+// Resolve desktop prerequisites against the same augmented PATH we pass to the
+// backend so Hermes, Python, and Git can be found before the backend exists.
+const DESKTOP_RESOLVER_PATH = buildDesktopResolverPath({
+  hermesHome: HERMES_HOME,
+  venvRoot: VENV_ROOT,
+  currentEnv: process.env
+})
 // BOOTSTRAP_COMPLETE_MARKER — written by the first-launch bootstrap runner
 // (Phase 1D) after install.ps1 has completed all stages and the user has
 // finished initial configuration. Presence of this marker means the install
@@ -1095,29 +1105,13 @@ function unpackedPathFor(filePath) {
 }
 
 function findOnPath(command) {
-  if (!command) return null
-
-  if (path.isAbsolute(command) || command.includes(path.sep) || (IS_WINDOWS && command.includes('/'))) {
-    if (!fileExists(command)) return null
-    if (isWindowsBinaryPathInWsl(command, { isWsl: IS_WSL })) return null
-    return command
-  }
-
-  const pathEntries = String(process.env.PATH || '')
-    .split(path.delimiter)
-    .filter(Boolean)
-  const extensions = IS_WINDOWS
-    ? ['', ...(process.env.PATHEXT || '.COM;.EXE;.BAT;.CMD').split(';').filter(Boolean)]
-    : ['']
-
-  for (const entry of pathEntries) {
-    for (const extension of extensions) {
-      const candidate = path.join(entry, `${command}${extension}`)
-      if (fileExists(candidate)) return candidate
-    }
-  }
-
-  return null
+  return findExecutableOnPath(command, {
+    searchPath: DESKTOP_RESOLVER_PATH,
+    currentEnv: process.env,
+    fileExists,
+    isWindowsBinaryPathInWsl,
+    isWsl: IS_WSL
+  })
 }
 
 function isCommandScript(command) {
@@ -2028,10 +2022,7 @@ async function applyUpdatesPosixInApp() {
     return { ok: false, backendUpdated: true, error: 'desktop rebuild failed' }
   }
 
-  const rebuiltApp = [
-    path.join(updateRoot, 'apps', 'desktop', 'release', 'mac-arm64', 'Hermes.app'),
-    path.join(updateRoot, 'apps', 'desktop', 'release', 'mac', 'Hermes.app')
-  ].find(directoryExists)
+  const rebuiltApp = rebuiltMacAppCandidates(updateRoot).find(directoryExists)
   const targetApp = runningAppBundle()
 
   // No bundle to swap (dev run, Linux AppImage, or unresolved paths): the

--- a/hermes_cli/browser_connect.py
+++ b/hermes_cli/browser_connect.py
@@ -14,11 +14,11 @@ from hermes_constants import get_hermes_home
 DEFAULT_BROWSER_CDP_PORT = 9222
 DEFAULT_BROWSER_CDP_URL = f"http://127.0.0.1:{DEFAULT_BROWSER_CDP_PORT}"
 
-_DARWIN_APPS = (
-    "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
-    "/Applications/Chromium.app/Contents/MacOS/Chromium",
-    "/Applications/Brave Browser.app/Contents/MacOS/Brave Browser",
-    "/Applications/Microsoft Edge.app/Contents/MacOS/Microsoft Edge",
+_DARWIN_APP_SUFFIXES = (
+    "Google Chrome.app/Contents/MacOS/Google Chrome",
+    "Chromium.app/Contents/MacOS/Chromium",
+    "Brave Browser.app/Contents/MacOS/Brave Browser",
+    "Microsoft Edge.app/Contents/MacOS/Microsoft Edge",
 )
 
 _WINDOWS_BROWSER_GROUPS = (
@@ -70,6 +70,16 @@ _LINUX_BIN_NAMES = tuple(name for names, _ in _LINUX_BROWSER_GROUPS for name in 
 _LINUX_INSTALL_PATHS = tuple(path for _, paths in _LINUX_BROWSER_GROUPS for path in paths)
 
 
+def get_darwin_browser_app_paths(home: str | None = None) -> tuple[str, ...]:
+    """Return system and per-user macOS browser bundle executable paths."""
+    if home is None:
+        home = os.path.expanduser("~")
+    roots = ["/Applications"]
+    if home:
+        roots.append(os.path.join(home, "Applications"))
+    return tuple(os.path.join(root, suffix) for suffix in _DARWIN_APP_SUFFIXES for root in roots)
+
+
 def get_chrome_debug_candidates(system: str) -> list[str]:
     candidates: list[str] = []
     seen: set[str] = set()
@@ -93,7 +103,7 @@ def get_chrome_debug_candidates(system: str) -> list[str]:
                     add(os.path.join(base, *parts))
 
     if system == "Darwin":
-        for app in _DARWIN_APPS:
+        for app in get_darwin_browser_app_paths():
             add(app)
         return candidates
 

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -15,6 +15,7 @@ import sys
 import textwrap
 from dataclasses import dataclass
 from pathlib import Path
+from xml.sax.saxutils import escape as _xml_escape
 
 PROJECT_ROOT = Path(__file__).parent.parent.resolve()
 
@@ -48,6 +49,11 @@ from hermes_cli.setup import (
 from hermes_cli.colors import Colors, color
 
 logger = logging.getLogger(__name__)
+
+
+def _plist_string(value: object) -> str:
+    """Return a launchd plist string element with XML-sensitive chars escaped."""
+    return f"<string>{_xml_escape(str(value))}</string>"
 
 # =============================================================================
 # Process Management (for manual gateway runs)
@@ -3375,18 +3381,18 @@ def generate_launchd_plist() -> str:
 
     # Build ProgramArguments array, including --profile when using a named profile
     prog_args = [
-        f"<string>{python_path}</string>",
-        "<string>-m</string>",
-        "<string>hermes_cli.main</string>",
+        _plist_string(python_path),
+        _plist_string("-m"),
+        _plist_string("hermes_cli.main"),
     ]
     if profile_arg:
         for part in profile_arg.split():
-            prog_args.append(f"<string>{part}</string>")
+            prog_args.append(_plist_string(part))
     prog_args.extend(
         [
-            "<string>gateway</string>",
-            "<string>run</string>",
-            "<string>--replace</string>",
+            _plist_string("gateway"),
+            _plist_string("run"),
+            _plist_string("--replace"),
         ]
     )
     prog_args_xml = "\n        ".join(prog_args)
@@ -3396,7 +3402,7 @@ def generate_launchd_plist() -> str:
 <plist version="1.0">
 <dict>
     <key>Label</key>
-    <string>{label}</string>
+    {_plist_string(label)}
 
     <key>ProgramArguments</key>
     <array>
@@ -3404,16 +3410,16 @@ def generate_launchd_plist() -> str:
     </array>
     
     <key>WorkingDirectory</key>
-    <string>{working_dir}</string>
+    {_plist_string(working_dir)}
     
     <key>EnvironmentVariables</key>
     <dict>
         <key>PATH</key>
-        <string>{sane_path}</string>
+        {_plist_string(sane_path)}
         <key>VIRTUAL_ENV</key>
-        <string>{venv_dir}</string>
+        {_plist_string(venv_dir)}
         <key>HERMES_HOME</key>
-        <string>{hermes_home}</string>
+        {_plist_string(hermes_home)}
     </dict>
 
     <key>LimitLoadToSessionType</key>
@@ -3429,10 +3435,10 @@ def generate_launchd_plist() -> str:
     <true/>
     
     <key>StandardOutPath</key>
-    <string>{log_dir}/gateway.log</string>
+    {_plist_string(log_dir / "gateway.log")}
     
     <key>StandardErrorPath</key>
-    <string>{log_dir}/gateway.error.log</string>
+    {_plist_string(log_dir / "gateway.error.log")}
 </dict>
 </plist>
 """

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -24,6 +24,7 @@ import mimetypes
 import os
 import re
 import secrets
+import shlex
 import shutil
 import stat
 import subprocess
@@ -8970,7 +8971,7 @@ def _resolve_profile_dir(name: str) -> Path:
 def _profile_setup_command(name: str) -> str:
     """Return the shell command used to configure a profile in the CLI."""
     _resolve_profile_dir(name)
-    return "hermes setup" if name == "default" else f"{name} setup"
+    return "hermes setup" if name == "default" else f"hermes -p {shlex.quote(name)} setup"
 
 
 def _write_profile_model(profile_dir: Path, provider: str, model: str) -> None:

--- a/tests/cli/test_cli_browser_connect.py
+++ b/tests/cli/test_cli_browser_connect.py
@@ -9,6 +9,7 @@ from unittest.mock import patch
 
 from cli import HermesCLI
 from hermes_cli.browser_connect import (
+    get_darwin_browser_app_paths,
     get_chrome_debug_candidates,
     is_browser_debug_ready,
     manual_chrome_debug_command,
@@ -181,6 +182,27 @@ class TestChromeDebugLaunch:
             candidates = get_chrome_debug_candidates("Linux")
 
         assert candidates == [brave, edge]
+
+    def test_darwin_candidates_include_user_applications(self, monkeypatch):
+        home = "/Users/alice"
+        user_chrome = os.path.join(
+            home,
+            "Applications",
+            "Google Chrome.app",
+            "Contents",
+            "MacOS",
+            "Google Chrome",
+        )
+
+        monkeypatch.setattr(
+            "hermes_cli.browser_connect.os.path.expanduser",
+            lambda value: home if value == "~" else value,
+        )
+        with patch("hermes_cli.browser_connect.os.path.isfile", side_effect=lambda path: path == user_chrome):
+            candidates = get_chrome_debug_candidates("Darwin")
+
+        assert user_chrome in candidates
+        assert user_chrome in get_darwin_browser_app_paths(home)
 
     def test_launch_tries_next_browser_when_first_candidate_fails(self):
         brave = "/usr/bin/brave-browser"

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -1,6 +1,7 @@
 """Tests for gateway service management helpers."""
 
 import os
+import plistlib
 import subprocess
 from pathlib import Path
 from types import SimpleNamespace
@@ -2171,6 +2172,40 @@ class TestProfileArg:
         plist = gateway_cli.generate_launchd_plist()
         assert "<string>--profile</string>" in plist
         assert "<string>mybot</string>" in plist
+
+    def test_launchd_plist_escapes_dynamic_xml_strings(self, tmp_path, monkeypatch):
+        """Dynamic launchd values can contain XML-sensitive chars in user paths."""
+        hermes_home = tmp_path / "Hermes & Co"
+        hermes_home.mkdir()
+        venv_dir = tmp_path / "venv & tools"
+        venv_dir.mkdir()
+
+        monkeypatch.setattr(gateway_cli, "get_python_path", lambda: "/Users/a&b/.venv/bin/python")
+        monkeypatch.setattr(gateway_cli, "_stable_service_working_dir", lambda: hermes_home)
+        monkeypatch.setattr(gateway_cli, "get_hermes_home", lambda: hermes_home)
+        monkeypatch.setattr(gateway_cli, "get_launchd_label", lambda: "ai.hermes.gateway&dev")
+        monkeypatch.setattr(gateway_cli, "_profile_arg", lambda _home=None: "--profile a&b")
+        monkeypatch.setattr(gateway_cli, "_detect_venv_dir", lambda: venv_dir)
+        monkeypatch.setattr(gateway_cli, "_build_service_path_dirs", lambda: ["/tmp/a&b/bin"])
+        monkeypatch.setattr(gateway_cli.shutil, "which", lambda _name: None)
+        monkeypatch.setenv("PATH", "/usr/bin:/tmp/c&d/bin")
+
+        plist = gateway_cli.generate_launchd_plist()
+
+        assert "&amp;" in plist
+        parsed = plistlib.loads(plist.encode("utf-8"))
+        assert parsed["Label"] == "ai.hermes.gateway&dev"
+        assert parsed["ProgramArguments"][:5] == [
+            "/Users/a&b/.venv/bin/python",
+            "-m",
+            "hermes_cli.main",
+            "--profile",
+            "a&b",
+        ]
+        assert parsed["WorkingDirectory"] == str(hermes_home)
+        assert parsed["EnvironmentVariables"]["PATH"] == "/tmp/a&b/bin:/usr/bin:/tmp/c&d/bin"
+        assert parsed["EnvironmentVariables"]["VIRTUAL_ENV"] == str(venv_dir)
+        assert parsed["EnvironmentVariables"]["HERMES_HOME"] == str(hermes_home)
 
     def test_launchd_plist_supports_aqua_and_background_sessions(self):
         # macOS 26+ only loads the agent in non-Aqua sessions when the plist

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -2727,7 +2727,7 @@ class TestNewEndpoints:
         names = [p["name"] for p in self.client.get("/api/profiles").json()["profiles"]]
         assert "test-prof-2" not in names
 
-    def test_profile_setup_command_uses_named_profile_wrapper(self):
+    def test_profile_setup_command_uses_canonical_profile_flag(self):
         from hermes_constants import get_hermes_home
 
         (get_hermes_home() / "profiles" / "coder").mkdir(parents=True)
@@ -2735,7 +2735,7 @@ class TestNewEndpoints:
         resp = self.client.get("/api/profiles/coder/setup-command")
 
         assert resp.status_code == 200
-        assert resp.json()["command"] == "coder setup"
+        assert resp.json()["command"] == "hermes -p coder setup"
 
     def test_profile_setup_command_uses_hermes_for_default_profile(self):
         from hermes_constants import get_hermes_home
@@ -2975,7 +2975,7 @@ class TestNewEndpoints:
         assert resp.status_code == 200
         assert calls
         assert calls[0][:4] == ["cmd.exe", "/c", "start", ""]
-        assert calls[0][-1] == "coder setup"
+        assert calls[0][-1] == "hermes -p coder setup"
 
     def test_profiles_create_rejects_invalid_name(self):
         resp = self.client.post("/api/profiles", json={"name": "Has Spaces"})

--- a/tests/tools/test_browser_chromium_check.py
+++ b/tests/tools/test_browser_chromium_check.py
@@ -60,8 +60,25 @@ class TestChromiumInstalled:
         (tmp_path / "chromium_headless_shell-1208").mkdir()
         assert bt._chromium_installed() is True
 
+    def test_true_when_macos_user_app_bundle_present(self, monkeypatch):
+        monkeypatch.delenv("AGENT_BROWSER_EXECUTABLE_PATH", raising=False)
+        monkeypatch.setattr(bt.sys, "platform", "darwin")
+        monkeypatch.setattr(bt.shutil, "which", lambda _name: None)
+        monkeypatch.setenv("HOME", "/Users/alice")
 
+        user_chrome = os.path.join(
+            "/Users/alice",
+            "Applications",
+            "Google Chrome.app",
+            "Contents",
+            "MacOS",
+            "Google Chrome",
+        )
+        monkeypatch.setattr(bt.os.path, "isfile", lambda path: path == user_chrome)
+        monkeypatch.setattr(bt.os.path, "isdir", lambda _path: False)
 
+        assert bt._detect_system_chromium_executable() == user_chrome
+        assert bt._chromium_installed() is True
 
     def test_result_cached(self, monkeypatch, tmp_path):
         monkeypatch.setenv("PLAYWRIGHT_BROWSERS_PATH", str(tmp_path))
@@ -115,5 +132,4 @@ class TestRunBrowserCommandChromiumGuard:
     """Verify _run_browser_command fails fast (no timeout hang) when
     Chromium is missing in local mode.
     """
-
 

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -2017,6 +2017,13 @@ def _run_browser_command(
         # used during CLI discovery.
         browser_env["PATH"] = _merge_browser_path(browser_env.get("PATH", ""))
         browser_env["AGENT_BROWSER_SOCKET_DIR"] = task_socket_dir
+        if (
+            not session_info.get("cdp_url")
+            and "AGENT_BROWSER_EXECUTABLE_PATH" not in browser_env
+        ):
+            chromium_executable = _detect_system_chromium_executable()
+            if chromium_executable:
+                browser_env["AGENT_BROWSER_EXECUTABLE_PATH"] = chromium_executable
 
         # Tell the agent-browser daemon to self-terminate after being idle
         # for our configured inactivity timeout.  This is the daemon-side
@@ -3595,6 +3602,33 @@ def _chromium_search_roots() -> List[str]:
     return roots
 
 
+def _detect_system_chromium_executable() -> Optional[str]:
+    """Return a configured/system browser executable path when one is available."""
+    ab_path = os.environ.get("AGENT_BROWSER_EXECUTABLE_PATH", "").strip()
+    if ab_path:
+        if os.path.isfile(ab_path):
+            return ab_path
+        resolved = shutil.which(ab_path)
+        if resolved:
+            return resolved
+
+    for name in ("google-chrome", "chromium", "chromium-browser", "chrome"):
+        resolved = shutil.which(name)
+        if resolved:
+            return resolved
+
+    if sys.platform == "darwin":
+        try:
+            from hermes_cli.browser_connect import get_darwin_browser_app_paths
+        except Exception:
+            return None
+        for candidate in get_darwin_browser_app_paths():
+            if os.path.isfile(candidate):
+                return candidate
+
+    return None
+
+
 def _chromium_installed() -> bool:
     """Return True when a usable Chromium (or headless-shell) build is on disk.
 
@@ -3603,7 +3637,7 @@ def _chromium_installed() -> bool:
     1. ``AGENT_BROWSER_EXECUTABLE_PATH`` env var — the official way to point
        agent-browser at a pre-installed Chrome/Chromium.
     2. System Chrome/Chromium in PATH (``google-chrome``, ``chromium``,
-       ``chromium-browser``, ``chrome``).
+       ``chromium-browser``, ``chrome``) or a macOS app bundle.
     3. Playwright's browser cache (current logic) — directories containing
        ``chromium-*`` or ``chromium_headless_shell-*``.
 
@@ -3618,21 +3652,8 @@ def _chromium_installed() -> bool:
     if _cached_chromium_installed is not None:
         return _cached_chromium_installed
 
-    # 1. AGENT_BROWSER_EXECUTABLE_PATH — explicit user-configured browser
-    ab_path = os.environ.get("AGENT_BROWSER_EXECUTABLE_PATH", "").strip()
-    if ab_path:
-        if os.path.isfile(ab_path) or shutil.which(ab_path):
-            _cached_chromium_installed = True
-            return True
-
-    # 2. System Chrome/Chromium in PATH (common names)
-    system_chrome = (
-        shutil.which("google-chrome")
-        or shutil.which("chromium")
-        or shutil.which("chromium-browser")
-        or shutil.which("chrome")
-    )
-    if system_chrome:
+    # 1-2. Explicit env var, PATH browsers, and macOS app bundles.
+    if _detect_system_chromium_executable():
         _cached_chromium_installed = True
         return True
 


### PR DESCRIPTION
## Summary

- resolve desktop startup prerequisites against the same augmented backend PATH used at runtime, so GUI-launched macOS apps can find Homebrew-installed `hermes`, Python, and Git before the backend starts
- include Electron Builder's `release/mac-x64/Hermes.app` output when the in-app updater chooses the rebuilt macOS app bundle
- XML-escape dynamic launchd plist values and use the canonical `hermes -p <profile> setup` dashboard setup command instead of relying on optional profile wrapper aliases
- discover macOS browser bundles under both `/Applications` and `~/Applications`, and pass a detected local browser executable through to `agent-browser` when needed

Fixes #48158.
Fixes #48160.
Fixes #48164.
Fixes #48169.
Fixes #48171.
Fixes #48172.

## Tests

- `node --test apps/desktop/electron/backend-env.test.cjs apps/desktop/electron/desktop-path-resolver.test.cjs apps/desktop/electron/desktop-update-paths.test.cjs apps/desktop/electron/update-rebuild.test.cjs`
- `scripts/run_tests.sh tests/hermes_cli/test_gateway_service.py -- -k launchd_plist`
- `scripts/run_tests.sh tests/hermes_cli/test_web_server.py -- -k 'profile_setup_command or profile_open_terminal_uses_windows_cmd'`
- `scripts/run_tests.sh tests/cli/test_cli_browser_connect.py tests/tools/test_browser_chromium_check.py`
- `scripts/run_tests.sh tests/hermes_cli/test_web_server.py`
- `git diff --check`

## Notes

- I did not use labels.
- A full `tests/hermes_cli/test_gateway_service.py` run on macOS includes unrelated Linux systemd user-service tests that fail at the platform preflight; the launchd-focused subset covering this change passes.
