### PR TITLE
fix: make local Windows test run green

### DIFF
--- a/plugins/disk-cleanup/__init__.py
+++ b/plugins/disk-cleanup/__init__.py
@@ -42,7 +42,18 @@ _lock = threading.Lock()
 
 # Tool-call result shapes we can parse
 _WRITE_FILE_PATH_KEY = "path"
-_TERMINAL_PATH_REGEX = re.compile(r"(?:^|\s)(/[^\s'\"`]+|\~/[^\s'\"`]+)")
+_TERMINAL_PATH_REGEX = re.compile(
+    r"(?:^|\s)(/[^\s'\"`]+|\~/[^\s'\"`]+|[A-Za-z]:[/\\][^\s'\"`]+)"
+)
+
+
+def _looks_like_abs_path(tok: str) -> bool:
+    """True for Unix absolute / ~/... paths and Windows absolute paths."""
+    if tok.startswith(("/", "~")):
+        return True
+    if len(tok) >= 3 and tok[1] == ":" and tok[2] in ("/", "\\") and tok[0].isalpha():
+        return True
+    return False
 
 
 # ---------------------------------------------------------------------------
@@ -110,7 +121,7 @@ def _extract_paths_from_terminal(args: Dict[str, Any], result: str) -> Set[str]:
         # Tokenise the command — catches `touch /tmp/hermes-x/test_foo.py`
         try:
             for tok in shlex.split(cmd, posix=True):
-                if tok.startswith(("/", "~")):
+                if _looks_like_abs_path(tok):
                     paths.add(tok)
         except ValueError:
             pass

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -32,21 +32,26 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 
-# ── Activate venv ───────────────────────────────────────────────────────────
+# ── Locate venv ─────────────────────────────────────────────────────────────
 VENV=""
+PYTHON=""
 for candidate in "$REPO_ROOT/.venv" "$REPO_ROOT/venv" "$HOME/.hermes/hermes-agent/venv"; do
   if [ -f "$candidate/bin/activate" ]; then
     VENV="$candidate"
+    PYTHON="$VENV/bin/python"
+    break
+  fi
+  if [ -f "$candidate/Scripts/python.exe" ]; then
+    VENV="$candidate"
+    PYTHON="$VENV/Scripts/python.exe"
     break
   fi
 done
 
 if [ -z "$VENV" ]; then
-  echo "error: no virtualenv found in $REPO_ROOT/.venv or $REPO_ROOT/venv" >&2
+  echo "error: no virtualenv found in $REPO_ROOT/.venv, $REPO_ROOT/venv, or $HOME/.hermes/hermes-agent/venv" >&2
   exit 1
 fi
-
-PYTHON="$VENV/bin/python"
 
 
 # ── Live-gateway plugin (computed before we drop env) ───────────────────────
@@ -69,6 +74,11 @@ cd "$REPO_ROOT"
 exec env -i \
   PATH="$PATH" \
   HOME="$HOME" \
+  ${USERPROFILE:+USERPROFILE="$USERPROFILE"} \
+  ${HOMEDRIVE:+HOMEDRIVE="$HOMEDRIVE"} \
+  ${HOMEPATH:+HOMEPATH="$HOMEPATH"} \
+  ${SYSTEMROOT:+SYSTEMROOT="$SYSTEMROOT"} \
+  ${WINDIR:+WINDIR="$WINDIR"} \
   TZ=UTC \
   LANG=C.UTF-8 \
   LC_ALL=C.UTF-8 \

--- a/tests/plugins/memory/test_hindsight_provider.py
+++ b/tests/plugins/memory/test_hindsight_provider.py
@@ -381,6 +381,7 @@ class TestPostSetup:
         user_home = tmp_path / "user-home"
         user_home.mkdir()
         monkeypatch.setenv("HOME", str(user_home))
+        monkeypatch.setattr("pathlib.Path.home", lambda: user_home)
 
         selections = iter([1, 0])  # local_embedded, openai
         monkeypatch.setattr("hermes_cli.memory_setup._curses_select", lambda *args, **kwargs: next(selections))
@@ -415,6 +416,7 @@ class TestPostSetup:
         user_home = tmp_path / "user-home"
         user_home.mkdir()
         monkeypatch.setenv("HOME", str(user_home))
+        monkeypatch.setattr("pathlib.Path.home", lambda: user_home)
 
         selections = iter([1, 0])  # local_embedded, openai
         monkeypatch.setattr("hermes_cli.memory_setup._curses_select", lambda *args, **kwargs: next(selections))
@@ -438,6 +440,7 @@ class TestPostSetup:
         user_home = tmp_path / "user-home"
         user_home.mkdir()
         monkeypatch.setenv("HOME", str(user_home))
+        monkeypatch.setattr("pathlib.Path.home", lambda: user_home)
 
         selections = iter([1, 0])  # local_embedded, openai
         monkeypatch.setattr("hermes_cli.memory_setup._curses_select", lambda *args, **kwargs: next(selections))


### PR DESCRIPTION
## Summary

Fix the remaining Windows-only test failures when running the canonical `scripts/run_tests.sh` natively in Git Bash.

## Changes

- **`plugins/disk-cleanup/__init__.py`** — detect Windows absolute paths (`C:/...` / `C:\\...`) when scanning `terminal` tool commands and output, so ephemeral files are tracked on Windows too.
- **`tests/plugins/memory/test_hindsight_provider.py`** — mock `Path.home()` in three `TestPostSetup` cases. On Windows `Path.home()` ignores `HOME` and uses `USERPROFILE`, causing the profile env file to be written outside the test temp dir.
- **`scripts/run_tests.sh`** — support native Windows virtualenv layout (`.venv/Scripts/python.exe`) and preserve Windows home/system environment variables (`USERPROFILE`, `HOMEDRIVE`, `HOMEPATH`, `SYSTEMROOT`, `WINDIR`) when running in the hermetic `env -i` sandbox.

## Verification

```bash
scripts/run_tests.sh -j 4 \
  tests/hermes_cli/test_memory_setup_provider_arg.py \
  tests/plugins/test_disk_cleanup_plugin.py \
  tests/plugins/memory/
```

Result on Windows/Git Bash:

```
6 files, 261 tests passed, 0 failed
```

These failures were unrelated to the XMemo removal PR (#48216), so they are fixed separately here.
