### PR TITLE
fix(gateway): don't inject phantom code fences when truncating around complete fenced blocks

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -4880,7 +4880,16 @@ class BasePlatformAdapter(ABC):
             # (like parentheses) inside the broken span would be unescaped,
             # causing MarkdownV2 parse errors on Telegram.
             candidate = remaining[:split_at]
-            backtick_count = candidate.count("`") - candidate.count("\\`")
+            # Only genuinely-unpaired INLINE backticks should affect parity.
+            # Strip COMPLETE triple-backtick fenced regions first: their six
+            # fence backticks (and any single backticks inside the fence body)
+            # are not inline spans, and counting them can flip parity odd,
+            # which would wrongly push split_at back into a closed fence and
+            # make the downstream carry-over emit a phantom empty ``` block
+            # that was never in the source. Open (unterminated) fences are left
+            # intact so a real mid-fence split still closes/reopens correctly.
+            inline_candidate = re.sub(r"```.*?```", "", candidate, flags=re.DOTALL)
+            backtick_count = inline_candidate.count("`") - inline_candidate.count("\\`")
             if backtick_count % 2 == 1:
                 # Find the last unescaped backtick and split before it
                 last_bt = candidate.rfind("`")

--- a/tests/gateway/test_platform_base.py
+++ b/tests/gateway/test_platform_base.py
@@ -1210,6 +1210,50 @@ class TestTruncateMessage:
                 f"Chunk {i} too long: {len(chunk)} > {max_len}"
             )
 
+    def test_truncate_no_phantom_fences_when_fence_contains_single_backtick(self):
+        """Regression: a COMPLETE fenced block whose body holds an odd number
+        of single backticks must not be miscounted by the inline-span parity
+        guard. The guard counts only unpaired INLINE backticks; counting the
+        fence's own backticks flips parity odd, pushes the split back into the
+        closed fence, and makes the carry-over inject a phantom empty ``` block
+        that was never in the source.
+        """
+        adapter = self._adapter()
+        # Body 'result = `x' has one single backtick; the fence is complete.
+        code_fence = "```\nresult = `x\n```"
+        content = "Some text\n" + code_fence + "\n" + "B" * 50
+        chunks = adapter.truncate_message(content, max_length=44)
+        assert len(chunks) > 1
+        for i, chunk in enumerate(chunks):
+            assert "```\n```" not in chunk, (
+                f"Chunk {i} contains an empty phantom code block: {chunk!r}"
+            )
+        # The complete fence (and its inline backtick) survives verbatim and is
+        # confined to the first chunk; no chunk reopens a fence spuriously.
+        assert "result = `x" in chunks[0]
+
+    def test_truncate_open_fence_still_closes_and_reopens(self):
+        """The phantom-fence fix must NOT regress the carry-over for a genuine
+        mid-fence split: when the split falls inside an OPEN code block, the
+        chunk closes the fence and the next chunk reopens it with the language
+        tag. This holds even when the open fence body contains a single inline
+        backtick.
+        """
+        adapter = self._adapter()
+        msg = "```python\n" + "v = `tick\n" + "y = 2\n" * 80 + "```\nTail"
+        chunks = adapter.truncate_message(msg, max_length=300)
+        assert len(chunks) > 1
+        # Every chunk has balanced triple-backtick fences.
+        for i, chunk in enumerate(chunks):
+            fence_count = chunk.count("```")
+            assert fence_count % 2 == 0, (
+                f"Chunk {i} has unbalanced fences ({fence_count}): {chunk!r}"
+            )
+        # Continuation chunks reopen the code block with the language tag.
+        assert any("```python" in chunk for chunk in chunks[1:]), (
+            "No continuation chunk reopened the open fence with its language tag"
+        )
+
 
 # ---------------------------------------------------------------------------
 # _get_human_delay


### PR DESCRIPTION
## What does this PR do?

`BasePlatformAdapter.truncate_message` guards against splitting inside an inline code span (`` `...` ``) by checking whether the candidate slice has an odd number of unescaped backticks. The problem: that count also included the six backticks of a **complete** triple-backtick fence (and any single backticks inside the fence body).

When a fenced code block near the split boundary contains an odd number of single backticks, parity goes odd, the guard wrongly moves `split_at` backward into the already-closed fence, and the downstream fence carry-over then emits a phantom empty `` ``` `` code block that was never in the source.

The fix strips complete triple-backtick fenced regions from the candidate before counting, so only genuinely-unpaired **inline** backticks affect parity. Open (unterminated) fences are left intact, preserving the documented close-and-reopen carry-over for splits that genuinely fall inside an open code block.

Note: this is **distinct** from the platform UTF-16 / length-counting truncation issues. Those are about measuring chunk length in the right unit; this is a different mechanism entirely (fenced-block backtick parity in the inline-span guard).

## Related Issue

No existing issue.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `gateway/platforms/base.py` (`truncate_message`): strip complete `` ```...``` `` fenced regions from the candidate slice before the inline-backtick parity count (~8 lines + comments), so the guard only reacts to genuinely-unpaired inline backticks.
- `tests/gateway/test_platform_base.py`: two regression tests in `TestTruncateMessage`.

## How to Test

Before this fix, on `main`:

```python
from gateway.platforms.base import BasePlatformAdapter
code_fence = "```\nresult = `x\n```"
content = "Some text\n" + code_fence + "\n" + "B" * 50
BasePlatformAdapter.truncate_message(content, 44)
# Chunk 1 -> '```\n```\nBBBBBBBBBB... (2/3)'   <- phantom empty code block injected
```

After this fix:

```python
# Chunk 0 -> 'Some text\n```\nresult = `x\n``` (1/3)'   <- complete fence intact
# Chunk 1 -> 'BBBBBBBBBBBBBBBBBBBBBBBBBBBBBB (2/3)'      <- no phantom fence
```

CI-runner proof (`scripts/run_tests.sh`, per-file isolation, TZ=UTC, deterministic):

```
scripts/run_tests.sh tests/gateway/test_platform_base.py
=== Summary: 1 files, 150 tests passed, 0 failed (100% complete) in 1.9s ===
```

The two new regression tests:
- `test_truncate_no_phantom_fences_when_fence_contains_single_backtick` - asserts no `` ```\n``` `` phantom block is produced for the failing input.
- `test_truncate_open_fence_still_closes_and_reopens` - confirms a genuine mid-fence split still closes the fence and reopens it with the language tag (the carry-over behavior is not regressed).

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(gateway):`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix (no unrelated commits)
- [x] I've run the CI-parity runner (`scripts/run_tests.sh tests/gateway/test_platform_base.py`) and all tests pass (150 passed, 0 failed)
- [x] I've added tests for my changes (two regression tests)
- [x] I've tested on my platform: Ubuntu 24.04

### Documentation & Housekeeping

- [x] I've updated relevant documentation (docstrings/comments), code comments explain the parity rule; no user-facing docs affected
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys, N/A (no config keys)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows, N/A (no architecture change)
- [x] I've considered cross-platform impact, N/A (pure string logic, no platform-specific calls)
- [x] I've updated tool descriptions/schemas if I changed tool behavior, N/A (internal helper, no tool surface change)

## Screenshots / Logs

```
$ scripts/run_tests.sh tests/gateway/test_platform_base.py -- -v -k "phantom or open_fence"
=== Summary: 1 files, 2 tests passed, 0 failed in 0.7s ===
```
