### PR TITLE
fix(docker): make /opt/hermes group-writable and ship LICENSE file

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -103,5 +103,6 @@ acp_registry/
 .hadolint.yaml
 .mailmap
 
-# Top-level LICENSE (not matched by *.md); not needed inside the container
-LICENSE
+# Top-level LICENSE (not matched by *.md); needed inside the container so
+# that PEP 639 license-files resolution succeeds when a companion container
+# runs ``uv pip install /opt/hermes[all]`` against a shared volume.

--- a/Dockerfile
+++ b/Dockerfile
@@ -197,11 +197,18 @@ COPY . .
 # resolution or downloads.
 RUN uv pip install --no-cache-dir --no-deps -e "."
 
-# Keep /opt/hermes immutable for the runtime hermes user. Hosted/container
-# instances must not be able to self-edit the installed source or venv; user
-# data, skills, plugins, config, logs, and dashboard uploads live under
-# /opt/data instead. Root can still repair the image during build/boot, but
-# supervised Hermes processes drop to the non-root hermes user.
+# Keep /opt/hermes largely immutable for the runtime hermes user.
+# Hosted/container instances must not be able to self-edit the installed
+# source or venv; user data, skills, plugins, config, logs, and dashboard
+# uploads live under /opt/data instead.  Root can still repair the image
+# during build/boot, but supervised Hermes processes drop to the non-root
+# hermes user.
+#
+# a+w is deliberately NOT set (no world-write), but group-write (a+rX,g+w)
+# is required so that a companion WebUI container — which may run as a
+# different UID in the same group — can ``uv pip install /opt/hermes[all]``
+# and create the ephemeral ``hermes_agent.egg-info/`` directory when the
+# source tree is shared via a Docker volume.
 USER root
 RUN mkdir -p /opt/hermes/bin && \
     cp /opt/hermes/docker/hermes-exec-shim.sh /opt/hermes/bin/hermes && \
@@ -209,7 +216,8 @@ RUN mkdir -p /opt/hermes/bin && \
     printf 'docker\n' > /opt/hermes/.install_method && \
     chown -R root:root /opt/hermes && \
     chmod -R a+rX /opt/hermes && \
-    chmod -R a-w /opt/hermes
+    chmod -R a-w /opt/hermes && \
+    chmod g+w /opt/hermes
 # The ``.install_method`` stamp is baked next to the running code (the install
 # tree), NOT into $HERMES_HOME. $HERMES_HOME (/opt/data) is a shared data
 # volume that is commonly bind-mounted from the host and even shared with a
@@ -242,7 +250,8 @@ ARG HERMES_GIT_SHA=
 RUN if [ -n "${HERMES_GIT_SHA}" ]; then \
         chmod u+w /opt/hermes && \
         printf '%s\n' "${HERMES_GIT_SHA}" > /opt/hermes/.hermes_build_sha && \
-        chmod a-w /opt/hermes /opt/hermes/.hermes_build_sha; \
+        chmod a-w,g+w /opt/hermes && \
+        chmod a-w /opt/hermes/.hermes_build_sha; \
     fi
 
 # ---------- s6-overlay service wiring ----------


### PR DESCRIPTION
## Summary

The `:latest` Docker image had two issues breaking multi-container Hermes WebUI deployments:

1. `/opt/hermes` was set to mode `555` (read-only, root-owned). When the WebUI container runs `uv pip install /opt/hermes[all]` against a shared volume, setuptools cannot create `hermes_agent.egg-info/` because the directory is unwritable.

2. `LICENSE` was explicitly excluded via `.dockerignore`. PEP 639 requires `license-files` to resolve, so `uv pip install` fails with: *Pattern LICENSE did not match any files.*

## Fix

- Add group-write permission on `/opt/hermes` (`a+rX,g+w`) so companion containers can create ephemeral build artifacts. The top-level directory gets `g+w` while subdirectories and files remain read-only (`a-w`).
- Stop excluding `LICENSE` from the Docker build context (update `.dockerignore`).
- Preserve group-write in the `HERMES_GIT_SHA` stamp step.

## Changes

- `Dockerfile`: `chmod g+w /opt/hermes` after the immutability lockdown; `chmod a-w,g+w` in the SHA stamp step
- `.dockerignore`: remove `LICENSE` exclusion

Fixes #48198