### PR TITLE
feat(memory): add XMemo cloud memory provider

### DIFF
--- a/plugins/memory/xmemo/README.md
+++ b/plugins/memory/xmemo/README.md
@@ -1,0 +1,100 @@
+# XMemo Memory Provider
+
+User-owned cloud memory for AI agents. XMemo provides orchestrated recall,
+semantic search, durable fact storage, working state, reminders, and session
+snapshots across sessions and tools.
+
+## Requirements
+
+- Hermes already depends on `httpx`.
+- An XMemo account at [xmemo.dev](https://xmemo.dev).
+- Authentication via **API key** or **browser device-login flow**.
+
+## Install
+
+XMemo is bundled with Hermes. To activate it:
+
+```bash
+hermes memory setup xmemo
+```
+
+This writes:
+
+- `config.yaml` → `memory.provider = xmemo`
+- `$HERMES_HOME/.env` → `XMEMO_KEY`
+- `$HERMES_HOME/xmemo.json` → non-secret provider settings
+
+The API key is never written to `xmemo.json`. Do not paste tokens into shell
+history, logs, or git-tracked files.
+
+### Authentication
+
+`hermes memory setup xmemo` offers two ways to authenticate:
+
+1. **API key** — create a scoped API key in the XMemo Memory Console:
+   [xmemo.dev](https://xmemo.dev) → **API Keys** → **Create API key**.
+   Paste the key shown in the one-time secret dialog. The token is validated
+   immediately against the authenticated `/v1/auth/token/validate` endpoint.
+2. **Device login** — the plugin shows a URL and a user code. Open the URL in
+   your browser, approve the request, and the CLI polls XMemo for the access
+   token. No long-lived token needs to be copied by hand.
+
+If your XMemo account has not completed onboarding, setup will tell you to
+finish setup in the browser first (HTTP 409 `setup_required`).
+
+## Config
+
+Config file: `$HERMES_HOME/xmemo.json`
+
+| Key | Default | Description |
+|-----|---------|-------------|
+| `base_url` | `https://xmemo.dev` | XMemo service URL |
+| `agent_id` | `hermes` | Agent family identifier |
+| `agent_instance_id` | auto-generated | Stable install identifier (random UUID) |
+| `bucket` | `work` | Storage namespace |
+| `scope` | `hermes/default` | Project/session scope |
+| `team_id` | `""` | Optional team ID for team-shared memories |
+| `timeout_seconds` | `5.0` | REST request timeout |
+| `prefetch_max_items` | `5` | Max context items per recall |
+| `prefetch_max_tokens` | `900` | Max context tokens per recall |
+| `enable_workflow_tools` | `false` | Expose reminder/event tools |
+| `enable_destructive_tools` | `false` | Expose `xmemo_forget` |
+| `capture_timeline` | `false` | Record high-signal turns to timeline |
+
+## Default tools
+
+These tools are always available:
+
+| Tool | Description |
+|------|-------------|
+| `xmemo_recall_context` | Build a bounded, ranked context pack |
+| `xmemo_search` | Semantic search over XMemo memories |
+| `xmemo_remember` | Save a durable fact |
+| `xmemo_update_state` | Save active task / next action / blocker with TTL |
+
+## Optional tools
+
+Set `enable_workflow_tools: true` in `xmemo.json` to expose:
+
+| Tool | Description |
+|------|-------------|
+| `xmemo_record_event` | Append a timeline event or milestone |
+| `xmemo_create_reminder` | Create a TODO / action item |
+| `xmemo_list_reminders` | List open or completed reminders |
+| `xmemo_complete_reminder` | Mark a reminder as completed |
+
+Set `enable_destructive_tools: true` to expose:
+
+| Tool | Description |
+|------|-------------|
+| `xmemo_forget` | Delete a memory by exact id |
+
+## Privacy and lifecycle notes
+
+- `xmemo_forget` requires an exact memory id and is disabled by default.
+- Automatic timeline writes are disabled by default. When `capture_timeline` is
+  `true`, only high-signal turns (decisions, preferences, blockers, etc.) are
+  recorded.
+- Hermes built-in `memory` tool writes are mirrored to XMemo `remember`.
+- Prefetch cache is isolated per session, so concurrent gateway sessions cannot
+  cross-contaminate recall context.

--- a/plugins/memory/xmemo/__init__.py
+++ b/plugins/memory/xmemo/__init__.py
@@ -1,0 +1,1178 @@
+"""XMemo memory provider plugin for Hermes Agent.
+
+Provides user-owned cloud memory via XMemo's REST API: orchestrated recall,
+semantic search, durable fact storage, working state, reminders, and session
+snapshots.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+import threading
+import time
+from typing import Any, Dict, List, Optional
+
+from agent.memory_provider import MemoryProvider
+from tools.registry import tool_error
+
+from .client import XMemoClient, XMemoClientError
+from .config import load_config, save_config
+
+logger = logging.getLogger(__name__)
+
+# Circuit breaker: pause API calls after consecutive failures.
+_BREAKER_THRESHOLD = 5
+_BREAKER_COOLDOWN_SECONDS = 120
+
+# Max time prefetch() may wait for an in-flight background recall. Keep this
+# short because prefetch() runs on the API-call critical path.
+_PREFETCH_JOIN_TIMEOUT_SECONDS = 0.25
+
+
+# ---------------------------------------------------------------------------
+# Tool schemas
+# ---------------------------------------------------------------------------
+
+SEARCH_SCHEMA = {
+    "name": "xmemo_search",
+    "description": (
+        "Search XMemo memories by natural-language query. "
+        "Returns relevant facts ranked by semantic similarity. "
+        "Use this when the user asks about saved information or when prior "
+        "context could change the answer."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "query": {
+                "type": "string",
+                "description": "What to search for.",
+            },
+            "limit": {
+                "type": "integer",
+                "description": "Max results (default 5, max 20).",
+            },
+            "memory_type": {
+                "type": "string",
+                "description": "Optional memory type filter (e.g. semantic, episodic, working).",
+            },
+        },
+        "required": ["query"],
+    },
+}
+
+REMEMBER_SCHEMA = {
+    "name": "xmemo_remember",
+    "description": (
+        "Save a durable fact to XMemo. Use for explicit preferences, decisions, "
+        "conventions, architecture notes, action items, or bug-fix context that "
+        "should survive across sessions. Skip transient chat."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "content": {
+                "type": "string",
+                "description": "The fact to remember. One clear concept per call.",
+            },
+            "path": {
+                "type": "string",
+                "description": "Logical path or category, e.g. 'notes/decisions' or 'hermes/preferences'.",
+            },
+            "memory_type": {
+                "type": "string",
+                "description": "Memory type: semantic, episodic, procedural, working, identity (default semantic).",
+            },
+            "importance": {
+                "type": "number",
+                "description": "Importance from 0.0 to 1.0 (default 0.7).",
+            },
+        },
+        "required": ["content", "path"],
+    },
+}
+
+UPDATE_STATE_SCHEMA = {
+    "name": "xmemo_update_state",
+    "description": (
+        "Save the current working state to XMemo with TTL. Use for active task, "
+        "next action, or blocker during long-running work so future sessions can resume."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "current_task": {
+                "type": "string",
+                "description": "Short description of the active task.",
+            },
+            "next_action": {
+                "type": "string",
+                "description": "The very next step the agent should take.",
+            },
+            "blocked_reason": {
+                "type": "string",
+                "description": "Why work is blocked, if applicable.",
+            },
+            "ttl_seconds": {
+                "type": "integer",
+                "description": "Time-to-live in seconds (default 86400 = 1 day).",
+            },
+        },
+        "required": [],
+    },
+}
+
+RECALL_CONTEXT_SCHEMA = {
+    "name": "xmemo_recall_context",
+    "description": (
+        "Build a bounded, ranked context pack from XMemo memories. "
+        "Use when you need a focused memory summary rather than raw search results."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "query": {
+                "type": "string",
+                "description": "What to recall context for.",
+            },
+            "max_items": {
+                "type": "integer",
+                "description": "Max memory items to include (default 5, max 20).",
+            },
+            "memory_type": {
+                "type": "string",
+                "description": "Optional memory type filter (semantic, episodic, working, identity, procedural).",
+            },
+        },
+        "required": ["query"],
+    },
+}
+
+RECORD_EVENT_SCHEMA = {
+    "name": "xmemo_record_event",
+    "description": (
+        "Record a significant session event, milestone, decision, or handoff note "
+        "to the XMemo timeline. Use for durable audit-style notes, not transient chat."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "content": {
+                "type": "string",
+                "description": "The event note to save.",
+            },
+            "event_type": {
+                "type": "string",
+                "description": "Event type: event, milestone, decision, handoff (default event).",
+            },
+        },
+        "required": ["content"],
+    },
+}
+
+CREATE_REMINDER_SCHEMA = {
+    "name": "xmemo_create_reminder",
+    "description": (
+        "Create a TODO or action item in XMemo to revisit later. "
+        "Use when the user asks you to follow up, save a task, or remind them."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "content": {
+                "type": "string",
+                "description": "What to remember to do.",
+            },
+            "due_at": {
+                "type": "string",
+                "description": "Optional due time as ISO 8601 string.",
+            },
+        },
+        "required": ["content"],
+    },
+}
+
+LIST_REMINDERS_SCHEMA = {
+    "name": "xmemo_list_reminders",
+    "description": (
+        "List XMemo TODO/action items. Use when the user asks what tasks, follow-ups, "
+        "or reminders are pending or done."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "item_status": {
+                "type": "string",
+                "description": "Filter by status: open or completed (default open).",
+            },
+            "limit": {
+                "type": "integer",
+                "description": "Max results (default 20).",
+            },
+        },
+        "required": [],
+    },
+}
+
+COMPLETE_REMINDER_SCHEMA = {
+    "name": "xmemo_complete_reminder",
+    "description": (
+        "Mark a XMemo TODO/action item as completed. "
+        "Use when the user says a saved task is done, resolved, or no longer needed."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "todo_id": {
+                "type": "string",
+                "description": "The exact TODO item ID from xmemo_list_reminders.",
+            },
+            "note": {
+                "type": "string",
+                "description": "Optional completion note.",
+            },
+        },
+        "required": ["todo_id"],
+    },
+}
+
+MARK_USED_SCHEMA = {
+    "name": "xmemo_mark_used",
+    "description": (
+        "Tell XMemo that a recalled memory influenced the current answer. "
+        "Call this after using a specific memory returned by xmemo_search or "
+        "xmemo_recall_context."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "memory_id": {
+                "type": "string",
+                "description": "Exact memory ID returned by xmemo_search.",
+            },
+            "context": {
+                "type": "string",
+                "description": "Optional short note on how the memory was used.",
+            },
+        },
+        "required": ["memory_id"],
+    },
+}
+
+FORGET_SCHEMA = {
+    "name": "xmemo_forget",
+    "description": (
+        "Delete a memory from XMemo. Use only when the user explicitly asks to "
+        "forget or remove a specific saved fact. Requires an exact memory ID."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "memory_id": {
+                "type": "string",
+                "description": "Exact memory ID from xmemo_search.",
+            },
+            "reason": {
+                "type": "string",
+                "description": "Optional reason for deletion.",
+            },
+        },
+        "required": ["memory_id"],
+    },
+}
+
+# Schemas exposed by default. Workflow/destructive tools are opt-in via config.
+_CORE_TOOL_SCHEMAS = [
+    RECALL_CONTEXT_SCHEMA,
+    SEARCH_SCHEMA,
+    REMEMBER_SCHEMA,
+    UPDATE_STATE_SCHEMA,
+]
+
+_WORKFLOW_TOOL_SCHEMAS = [
+    RECORD_EVENT_SCHEMA,
+    CREATE_REMINDER_SCHEMA,
+    LIST_REMINDERS_SCHEMA,
+    COMPLETE_REMINDER_SCHEMA,
+]
+
+_FEEDBACK_TOOL_SCHEMAS = [
+    MARK_USED_SCHEMA,
+]
+
+_DESTRUCTIVE_TOOL_SCHEMAS = [
+    FORGET_SCHEMA,
+]
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _is_trivial_prompt(text: str) -> bool:
+    """Skip recall for acknowledgements, slash commands, and empty input."""
+    if not text or not text.strip():
+        return True
+    cleaned = text.strip().lower()
+    if cleaned.startswith("/"):
+        return True
+    return bool(
+        re.match(
+            r"^(yes|no|ok|okay|sure|thanks|thank you|y|n|yep|nope|yeah|nah|"
+            r"continue|go ahead|do it|proceed|got it|cool|nice|great|done|next|lgtm|k)$",
+            cleaned,
+            re.IGNORECASE,
+        )
+    )
+
+
+def _format_search_results(results: List[Dict[str, Any]]) -> str:
+    """Format search results into a concise text block."""
+    if not results:
+        return ""
+    lines = []
+    for i, item in enumerate(results, 1):
+        content = item.get("content", "")
+        if not content:
+            continue
+        memory_type = item.get("memory_type", "semantic")
+        path = item.get("path", "")
+        score = item.get("similarity") or item.get("score")
+        header = f"{i}. [{memory_type}]"
+        if path:
+            header += f" {path}"
+        if score is not None:
+            header += f" (sim {score:.3f})"
+        lines.append(header)
+        lines.append(f"   {content.strip()}")
+    return "\n".join(lines)
+
+
+def _format_recall_context(context: Dict[str, Any]) -> str:
+    """Extract context_text from a recall_context response."""
+    if not context:
+        return ""
+    text = context.get("context_text", "")
+    if text and text.strip():
+        return text.strip()
+    items = context.get("items", [])
+    if not items:
+        return ""
+    lines = []
+    for i, item in enumerate(items, 1):
+        content = item.get("content", "")
+        if not content:
+            continue
+        lines.append(f"{i}. {content.strip()}")
+    return "\n".join(lines)
+
+
+def _session_key(session_id: str) -> str:
+    """Normalize session id for cache keys."""
+    return session_id or "__default__"
+
+
+def _as_bool(value: Any) -> bool:
+    """Parse bool-like values from JSON/config strings."""
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        return value.strip().lower() in {"1", "true", "yes", "on"}
+    return bool(value)
+
+
+def _is_high_signal_turn(user_content: str, assistant_content: str) -> bool:
+    """Detect turns that likely contain durable facts without LLM extraction."""
+    text = f"{user_content} {assistant_content}".lower()
+    high_signal_phrases = [
+        "remember",
+        "save this",
+        "write this down",
+        "keep in mind",
+        "going forward",
+        "from now on",
+        "we decided",
+        "decision:",
+        "architecture decision",
+        "root cause",
+        "fix was",
+        "lesson learned",
+        "runbook",
+        "handoff",
+        "blocked by",
+        "blocker:",
+    ]
+    return any(phrase in text for phrase in high_signal_phrases)
+
+
+def _redact_for_log(text: str, max_len: int = 200) -> str:
+    """Truncate and redact sensitive-looking content before storing/logging."""
+    if not text:
+        return ""
+    if len(text) > max_len:
+        text = text[:max_len] + "..."
+    # Mask likely tokens/keys in logs (best-effort).
+    return re.sub(r"\b[a-zA-Z0-9_-]{24,}\b", "[REDACTED]", text)
+
+
+# ---------------------------------------------------------------------------
+# MemoryProvider implementation
+# ---------------------------------------------------------------------------
+
+
+class XMemoMemoryProvider(MemoryProvider):
+    """XMemo cloud memory provider for Hermes Agent."""
+
+    def __init__(self):
+        self._config: Dict[str, Any] = {}
+        self._client: Optional[XMemoClient] = None
+        self._client_lock = threading.Lock()
+
+        # Per-session prefetch cache
+        self._prefetch_results: Dict[str, str] = {}
+        self._prefetch_threads: Dict[str, threading.Thread] = {}
+        self._prefetch_lock = threading.Lock()
+
+        # Background worker references for clean shutdown
+        self._snapshot_thread: Optional[threading.Thread] = None
+
+        # Circuit breaker state
+        self._consecutive_failures = 0
+        self._breaker_open_until = 0.0
+
+        # Session / runtime metadata
+        self._session_id = ""
+        self._turn_count = 0
+        self._agent_context = "primary"
+        self._auto_write_enabled = True
+
+    @property
+    def name(self) -> str:
+        return "xmemo"
+
+    def is_available(self) -> bool:
+        """Check if XMemo is configured. No network calls and no file writes."""
+        try:
+            cfg = load_config(create_instance=False)
+            return bool(cfg.get("api_key"))
+        except Exception:
+            return False
+
+    def get_config_schema(self) -> List[Dict[str, Any]]:
+        return [
+            {
+                "key": "base_url",
+                "description": "XMemo service URL",
+                "default": "https://xmemo.dev",
+            },
+            {
+                "key": "api_key",
+                "description": "XMemo service token",
+                "secret": True,
+                "required": True,
+                "env_var": "XMEMO_KEY",
+                "url": "https://xmemo.dev",
+            },
+            {
+                "key": "agent_id",
+                "description": "Agent family identifier",
+                "default": "hermes",
+            },
+            {
+                "key": "bucket",
+                "description": "Default storage namespace",
+                "default": "work",
+                "choices": ["work", "private", "public"],
+            },
+            {
+                "key": "scope",
+                "description": "Default project/session scope",
+                "default": "hermes/default",
+            },
+            {
+                "key": "team_id",
+                "description": "Optional team ID for team-shared memories",
+                "default": "",
+            },
+            {
+                "key": "timeout_seconds",
+                "description": "REST request timeout",
+                "default": "5.0",
+            },
+            {
+                "key": "enable_workflow_tools",
+                "description": "Expose reminder/event workflow tools",
+                "default": "false",
+                "choices": ["true", "false"],
+            },
+            {
+                "key": "enable_destructive_tools",
+                "description": "Expose the xmemo_forget destructive tool",
+                "default": "false",
+                "choices": ["true", "false"],
+            },
+            {
+                "key": "capture_timeline",
+                "description": "Record high-signal turns to the XMemo timeline",
+                "default": "false",
+                "choices": ["true", "false"],
+            },
+        ]
+
+    def save_config(self, values: Dict[str, Any], hermes_home: str) -> None:
+        """Write non-secret config to $HERMES_HOME/xmemo.json."""
+        save_config(values, hermes_home=hermes_home)
+
+    def post_setup(self, hermes_home: str, config: Dict[str, Any]) -> None:
+        """Run the full XMemo setup wizard after provider selection."""
+        from .cli import cmd_setup
+
+        cmd_setup(provider=self, hermes_home=hermes_home, config=config)
+
+    def _is_breaker_open(self) -> bool:
+        if self._consecutive_failures < _BREAKER_THRESHOLD:
+            return False
+        if time.monotonic() >= self._breaker_open_until:
+            self._consecutive_failures = 0
+            return False
+        return True
+
+    def _record_success(self) -> None:
+        self._consecutive_failures = 0
+
+    def _record_failure(self) -> None:
+        self._consecutive_failures += 1
+        if self._consecutive_failures >= _BREAKER_THRESHOLD:
+            self._breaker_open_until = time.monotonic() + _BREAKER_COOLDOWN_SECONDS
+            logger.warning(
+                "XMemo circuit breaker tripped after %d consecutive failures. "
+                "Pausing API calls for %ds.",
+                self._consecutive_failures,
+                _BREAKER_COOLDOWN_SECONDS,
+            )
+
+    def _get_client(self) -> XMemoClient:
+        """Thread-safe client accessor with lazy initialization."""
+        with self._client_lock:
+            if self._client is not None:
+                return self._client
+            self._client = XMemoClient(
+                base_url=self._config.get("base_url", "https://xmemo.dev"),
+                api_key=self._config.get("api_key", ""),
+                agent_id=self._config.get("agent_id", "hermes"),
+                agent_instance_id=self._config.get("agent_instance_id", ""),
+                timeout=float(self._config.get("timeout_seconds", 5.0)),
+            )
+            return self._client
+
+    def initialize(self, session_id: str, **kwargs) -> None:
+        """Initialize XMemo provider for a session."""
+        self._config = load_config(create_instance=True)
+        self._session_id = session_id or ""
+        self._turn_count = 0
+
+        self._agent_context = kwargs.get("agent_context", "primary") or "primary"
+        self._auto_write_enabled = self._agent_context == "primary"
+
+        # Scope per-profile if the active Hermes profile differs from default
+        profile = kwargs.get("agent_identity") or "default"
+        configured_scope = self._config.get("scope", "hermes/default")
+        if configured_scope == "hermes/default" and profile != "default":
+            self._config["scope"] = f"hermes/{profile}"
+            try:
+                save_config(self._config)
+            except Exception:
+                pass
+
+        if not self._config.get("api_key"):
+            logger.debug("XMemo not configured — plugin inactive")
+            return
+
+        # Optional token validation; failure does not block startup.
+        try:
+            client = self._get_client()
+            client.validate_token()
+            self._record_success()
+        except XMemoClientError as exc:
+            if exc.status_code == 409:
+                logger.warning(
+                    "XMemo account setup is required before the memory provider can be used. "
+                    "Complete onboarding at %s and then restart your Hermes session.",
+                    self._config.get("base_url", "https://xmemo.dev"),
+                )
+            else:
+                logger.debug("XMemo token validation failed (non-blocking): %s", exc)
+        except Exception as exc:
+            logger.debug("XMemo token validation failed (non-blocking): %s", exc)
+
+    def system_prompt_block(self) -> str:
+        """Return static provider instructions for the system prompt."""
+        if not self._config.get("api_key"):
+            return ""
+        scope = self._config.get("scope", "hermes/default")
+        return (
+            "# XMemo Memory\n"
+            "Active. User-owned cloud memory is available.\n"
+            f"Scope: {scope}.\n"
+            "Use xmemo_search to recall saved facts before answering. "
+            "Use xmemo_remember to store durable facts (preferences, decisions, conventions, action items). "
+            "Use xmemo_update_state to save the current task state with TTL."
+        )
+
+    def prefetch(self, query: str, *, session_id: str = "") -> str:
+        """Return prefetched XMemo context for the upcoming turn."""
+        if self._is_breaker_open():
+            return ""
+
+        if _is_trivial_prompt(query):
+            return ""
+
+        key = _session_key(session_id or self._session_id)
+        thread = self._prefetch_threads.get(key)
+        if thread and thread.is_alive():
+            thread.join(timeout=_PREFETCH_JOIN_TIMEOUT_SECONDS)
+
+        with self._prefetch_lock:
+            result = self._prefetch_results.pop(key, "")
+
+        if not result:
+            return ""
+        return f"## XMemo Memory\n{result}"
+
+    def queue_prefetch(self, query: str, *, session_id: str = "") -> None:
+        """Fire a background recall for the next turn."""
+        if self._is_breaker_open():
+            return
+        if not self._config.get("api_key"):
+            return
+        if _is_trivial_prompt(query):
+            return
+
+        key = _session_key(session_id or self._session_id)
+
+        # Guard against a hung prior thread for this session
+        prior = self._prefetch_threads.get(key)
+        if prior and prior.is_alive():
+            logger.debug(
+                "XMemo prefetch skipped: prior thread still running for session %s", key
+            )
+            return
+
+        def _run() -> None:
+            try:
+                client = self._get_client()
+                context = client.recall_context(
+                    query=query,
+                    bucket=self._config.get("bucket", "work"),
+                    scope=self._config.get("scope", "hermes/default"),
+                    team_id=self._config.get("team_id", ""),
+                    max_items=int(self._config.get("prefetch_max_items", 5)),
+                    max_tokens=int(self._config.get("prefetch_max_tokens", 900)),
+                    prefer_working=True,
+                )
+                text = _format_recall_context(context)
+                if text:
+                    with self._prefetch_lock:
+                        self._prefetch_results[key] = text
+                self._record_success()
+            except Exception as exc:
+                self._record_failure()
+                logger.debug("XMemo prefetch failed: %s", exc)
+
+        t = threading.Thread(target=_run, daemon=True, name=f"xmemo-prefetch-{key}")
+        with self._prefetch_lock:
+            self._prefetch_threads[key] = t
+        t.start()
+
+    def sync_turn(
+        self,
+        user_content: str,
+        assistant_content: str,
+        *,
+        session_id: str = "",
+        messages: Optional[List[Dict[str, Any]]] = None,
+    ) -> None:
+        """Persist a completed turn to XMemo if it is high-signal."""
+        if self._is_breaker_open():
+            return
+        if not self._config.get("api_key"):
+            return
+        if not self._auto_write_enabled:
+            return
+
+        self._turn_count += 1
+
+        # Automatic timeline writes are opt-in only. When disabled, do not record
+        # any turn — even high-signal ones — to avoid surprising privacy behavior.
+        if not _as_bool(self._config.get("capture_timeline", False)):
+            return
+
+        # When enabled, still only persist high-signal turns to avoid noise.
+        if not _is_high_signal_turn(user_content, assistant_content):
+            return
+
+        # Defensive truncation to avoid storing long raw outputs or secrets.
+        safe_user = _redact_for_log(user_content, max_len=240)
+        summary = f"Turn {self._turn_count}: {safe_user[:120]}..."
+
+        try:
+            client = self._get_client()
+            client.record_event(
+                content=summary,
+                event_type="session_event",
+                bucket=self._config.get("bucket", "work"),
+                scope=self._config.get("scope", "hermes/default"),
+                team_id=self._config.get("team_id", ""),
+                session_id=session_id or self._session_id,
+            )
+            self._record_success()
+        except Exception as exc:
+            self._record_failure()
+            logger.debug("XMemo sync_turn failed: %s", exc)
+
+    def get_tool_schemas(self) -> List[Dict[str, Any]]:
+        # Must be callable BEFORE initialize() because MemoryManager.add_provider()
+        # indexes tool names for routing immediately after loading. Read config
+        # from disk if we have not been initialized yet.
+        cfg = self._config if self._config else load_config(create_instance=False)
+        schemas = list(_CORE_TOOL_SCHEMAS)
+        if _as_bool(cfg.get("enable_workflow_tools", False)):
+            schemas.extend(_WORKFLOW_TOOL_SCHEMAS)
+        if _as_bool(cfg.get("enable_destructive_tools", False)):
+            schemas.extend(_DESTRUCTIVE_TOOL_SCHEMAS)
+        # Feedback tools remain internal by default; can be exposed via config later.
+        return schemas
+
+    def handle_tool_call(self, tool_name: str, args: Dict[str, Any], **kwargs) -> str:
+        """Route a tool call to the correct XMemo API."""
+        if self._is_breaker_open():
+            return json.dumps({
+                "error": "XMemo API temporarily unavailable after multiple failures. Will retry automatically."
+            })
+
+        try:
+            client = self._get_client()
+        except Exception as exc:
+            return tool_error(str(exc))
+
+        if tool_name == "xmemo_search":
+            return self._handle_search(client, args)
+        if tool_name == "xmemo_remember":
+            return self._handle_remember(client, args)
+        if tool_name == "xmemo_update_state":
+            return self._handle_update_state(client, args)
+        if tool_name == "xmemo_recall_context":
+            return self._handle_recall_context(client, args)
+        if tool_name == "xmemo_record_event":
+            return self._handle_record_event(client, args)
+        if tool_name == "xmemo_create_reminder":
+            return self._handle_create_reminder(client, args)
+        if tool_name == "xmemo_list_reminders":
+            return self._handle_list_reminders(client, args)
+        if tool_name == "xmemo_complete_reminder":
+            return self._handle_complete_reminder(client, args)
+        if tool_name == "xmemo_mark_used":
+            return self._handle_mark_used(client, args)
+        if tool_name == "xmemo_forget":
+            return self._handle_forget(client, args)
+
+        return tool_error(f"Unknown XMemo tool: {tool_name}")
+
+    def _handle_search(self, client: XMemoClient, args: Dict[str, Any]) -> str:
+        query = args.get("query", "").strip()
+        if not query:
+            return tool_error("Missing required parameter: query")
+
+        try:
+            limit = min(int(args.get("limit", 5)), 20)
+        except (ValueError, TypeError):
+            limit = 5
+        memory_type = args.get("memory_type", "%")
+
+        try:
+            results = client.search(
+                query=query,
+                bucket=self._config.get("bucket", "work"),
+                scope=self._config.get("scope", "hermes/default"),
+                team_id=self._config.get("team_id", ""),
+                memory_type=memory_type,
+                limit=limit,
+            )
+            self._record_success()
+            if not results:
+                return json.dumps({"result": "No relevant XMemo memories found."})
+            return json.dumps({
+                "results": results,
+                "formatted": _format_search_results(results),
+                "count": len(results),
+            })
+        except Exception as exc:
+            self._record_failure()
+            return tool_error(f"XMemo search failed: {exc}")
+
+    def _handle_remember(self, client: XMemoClient, args: Dict[str, Any]) -> str:
+        content = args.get("content", "").strip()
+        path = args.get("path", "").strip()
+        if not content:
+            return tool_error("Missing required parameter: content")
+        if not path:
+            return tool_error("Missing required parameter: path")
+
+        memory_type = args.get("memory_type", "semantic")
+        importance = args.get("importance")
+        if importance is not None:
+            try:
+                importance = float(importance)
+            except (ValueError, TypeError):
+                importance = None
+
+        try:
+            result = client.remember(
+                content=content,
+                path=path,
+                bucket=self._config.get("bucket", "work"),
+                scope=self._config.get("scope", "hermes/default"),
+                team_id=self._config.get("team_id", ""),
+                memory_type=memory_type,
+                importance=importance,
+            )
+            self._record_success()
+            memory_id = result.get("id") if isinstance(result, dict) else None
+            return json.dumps({
+                "result": "Saved to XMemo.",
+                "memory_id": memory_id,
+            })
+        except Exception as exc:
+            self._record_failure()
+            return tool_error(f"XMemo remember failed: {exc}")
+
+    def _handle_update_state(self, client: XMemoClient, args: Dict[str, Any]) -> str:
+        current_task = args.get("current_task", "").strip()
+        next_action = args.get("next_action", "").strip()
+        blocked_reason = args.get("blocked_reason", "").strip()
+        try:
+            ttl_seconds = int(args.get("ttl_seconds", 86400))
+        except (ValueError, TypeError):
+            ttl_seconds = 86400
+
+        if not any([current_task, next_action, blocked_reason]):
+            return tool_error(
+                "At least one of current_task, next_action, or blocked_reason is required"
+            )
+
+        try:
+            result = client.update_state(
+                current_task=current_task,
+                next_action=next_action,
+                blocked_reason=blocked_reason,
+                bucket=self._config.get("bucket", "work"),
+                scope=self._config.get("scope", "hermes/default"),
+                team_id=self._config.get("team_id", ""),
+                ttl_seconds=ttl_seconds,
+            )
+            self._record_success()
+            return json.dumps({
+                "result": "Working state saved to XMemo.",
+                "state_key": result.get("state_key")
+                if isinstance(result, dict)
+                else None,
+                "id": result.get("id") if isinstance(result, dict) else None,
+            })
+        except Exception as exc:
+            self._record_failure()
+            return tool_error(f"XMemo update_state failed: {exc}")
+
+    def _handle_recall_context(self, client: XMemoClient, args: Dict[str, Any]) -> str:
+        query = args.get("query", "").strip()
+        if not query:
+            return tool_error("Missing required parameter: query")
+
+        try:
+            max_items = min(int(args.get("max_items", 5)), 20)
+        except (ValueError, TypeError):
+            max_items = 5
+        memory_type = args.get("memory_type", "auto")
+
+        try:
+            context = client.recall_context(
+                query=query,
+                bucket=self._config.get("bucket", "work"),
+                scope=self._config.get("scope", "hermes/default"),
+                team_id=self._config.get("team_id", ""),
+                max_items=max_items,
+                max_tokens=int(self._config.get("prefetch_max_tokens", 900)),
+                memory_type=memory_type,
+                prefer_working=True,
+            )
+            self._record_success()
+            text = _format_recall_context(context)
+            if not text:
+                return json.dumps({"result": "No relevant XMemo context found."})
+            return json.dumps({
+                "context": text,
+                "items": context.get("items", []) if isinstance(context, dict) else [],
+            })
+        except Exception as exc:
+            self._record_failure()
+            return tool_error(f"XMemo recall_context failed: {exc}")
+
+    def _handle_record_event(self, client: XMemoClient, args: Dict[str, Any]) -> str:
+        content = args.get("content", "").strip()
+        if not content:
+            return tool_error("Missing required parameter: content")
+
+        event_type = args.get("event_type", "event").strip() or "event"
+
+        try:
+            result = client.record_event(
+                content=content,
+                event_type=event_type,
+                bucket=self._config.get("bucket", "work"),
+                scope=self._config.get("scope", "hermes/default"),
+                team_id=self._config.get("team_id", ""),
+                session_id=self._session_id,
+            )
+            self._record_success()
+            return json.dumps({
+                "result": "Event recorded in XMemo timeline.",
+                "event_id": result.get("id") if isinstance(result, dict) else None,
+            })
+        except Exception as exc:
+            self._record_failure()
+            return tool_error(f"XMemo record_event failed: {exc}")
+
+    def _handle_create_reminder(self, client: XMemoClient, args: Dict[str, Any]) -> str:
+        content = args.get("content", "").strip()
+        if not content:
+            return tool_error("Missing required parameter: content")
+
+        due_at = args.get("due_at", "").strip()
+
+        try:
+            result = client.create_reminder(
+                content=content,
+                due_at=due_at,
+                bucket=self._config.get("bucket", "work"),
+                scope=self._config.get("scope", "hermes/default"),
+                team_id=self._config.get("team_id", ""),
+                session_id=self._session_id,
+            )
+            self._record_success()
+            return json.dumps({
+                "result": "Reminder saved to XMemo.",
+                "todo_id": result.get("id") if isinstance(result, dict) else None,
+            })
+        except Exception as exc:
+            self._record_failure()
+            return tool_error(f"XMemo create_reminder failed: {exc}")
+
+    def _handle_list_reminders(self, client: XMemoClient, args: Dict[str, Any]) -> str:
+        item_status = args.get("item_status", "open") or "open"
+        try:
+            limit = min(int(args.get("limit", 20)), 100)
+        except (ValueError, TypeError):
+            limit = 20
+
+        try:
+            items = client.list_reminders(
+                bucket=self._config.get("bucket", "work"),
+                scope=self._config.get("scope", "hermes/default"),
+                team_id=self._config.get("team_id", ""),
+                item_status=item_status,
+                limit=limit,
+            )
+            self._record_success()
+            if not items:
+                return json.dumps({
+                    "result": f"No {item_status} XMemo reminders found."
+                })
+            return json.dumps({
+                "items": items,
+                "count": len(items),
+            })
+        except Exception as exc:
+            self._record_failure()
+            return tool_error(f"XMemo list_reminders failed: {exc}")
+
+    def _handle_complete_reminder(
+        self, client: XMemoClient, args: Dict[str, Any]
+    ) -> str:
+        todo_id = args.get("todo_id", "").strip()
+        if not todo_id:
+            return tool_error("Missing required parameter: todo_id")
+
+        note = args.get("note", "").strip()
+
+        try:
+            result = client.complete_reminder(
+                todo_id=todo_id,
+                note=note,
+                bucket=self._config.get("bucket", "work"),
+                scope=self._config.get("scope", "hermes/default"),
+                team_id=self._config.get("team_id", ""),
+            )
+            self._record_success()
+            return json.dumps({
+                "result": "Reminder marked completed.",
+                "todo_id": result.get("id") if isinstance(result, dict) else todo_id,
+            })
+        except Exception as exc:
+            self._record_failure()
+            return tool_error(f"XMemo complete_reminder failed: {exc}")
+
+    def _handle_mark_used(self, client: XMemoClient, args: Dict[str, Any]) -> str:
+        memory_id = args.get("memory_id", "").strip()
+        if not memory_id:
+            return tool_error("Missing required parameter: memory_id")
+
+        context = args.get("context", "").strip()
+
+        try:
+            result = client.mark_used(
+                memory_id=memory_id,
+                context=context,
+            )
+            self._record_success()
+            return json.dumps({
+                "result": "Memory usage recorded in XMemo.",
+                "memory_id": result.get("id")
+                if isinstance(result, dict)
+                else memory_id,
+            })
+        except Exception as exc:
+            self._record_failure()
+            return tool_error(f"XMemo mark_used failed: {exc}")
+
+    def _handle_forget(self, client: XMemoClient, args: Dict[str, Any]) -> str:
+        memory_id = args.get("memory_id", "").strip()
+        if not memory_id:
+            return tool_error("Missing required parameter: memory_id")
+
+        reason = args.get("reason", "").strip()
+
+        try:
+            result = client.forget(
+                memory_id=memory_id,
+                reason=reason,
+                bucket=self._config.get("bucket", "work"),
+                scope=self._config.get("scope", "hermes/default"),
+                team_id=self._config.get("team_id", ""),
+            )
+            self._record_success()
+            return json.dumps({
+                "result": "Memory deleted from XMemo.",
+                "memory_id": result.get("id")
+                if isinstance(result, dict)
+                else memory_id,
+            })
+        except Exception as exc:
+            self._record_failure()
+            return tool_error(f"XMemo forget failed: {exc}")
+
+    def shutdown(self) -> None:
+        """Clean shutdown: flush threads and close client."""
+        for t in list(self._prefetch_threads.values()):
+            if t and t.is_alive():
+                t.join(timeout=1.0)
+        if self._snapshot_thread and self._snapshot_thread.is_alive():
+            self._snapshot_thread.join(timeout=5.0)
+        with self._client_lock:
+            if self._client is not None:
+                try:
+                    self._client.close()
+                except Exception as exc:
+                    logger.debug("XMemo client close failed: %s", exc)
+                self._client = None
+
+    def on_session_switch(
+        self,
+        new_session_id: str,
+        *,
+        parent_session_id: str = "",
+        reset: bool = False,
+        rewound: bool = False,
+        **kwargs,
+    ) -> None:
+        """Update session tracking and clean stale prefetch cache."""
+        old_key = _session_key(self._session_id)
+        self._session_id = new_session_id or ""
+
+        if reset or rewound:
+            with self._prefetch_lock:
+                self._prefetch_results.pop(old_key, None)
+                old_thread = self._prefetch_threads.pop(old_key, None)
+            if old_thread and old_thread.is_alive():
+                old_thread.join(timeout=1.0)
+
+        if reset:
+            self._turn_count = 0
+
+    def on_memory_write(
+        self,
+        action: str,
+        target: str,
+        content: str,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        """Mirror Hermes built-in memory writes to XMemo."""
+        if self._is_breaker_open():
+            return
+        if not self._config.get("api_key"):
+            return
+        if not self._auto_write_enabled:
+            return
+        if action not in {"add", "replace"}:
+            # Remove is not mirrored until we have stable remote id mapping.
+            return
+        if not content:
+            return
+
+        path = f"hermes/builtin-memory/{target}"
+        try:
+            client = self._get_client()
+            client.remember(
+                content=content,
+                path=path,
+                bucket=self._config.get("bucket", "work"),
+                scope=self._config.get("scope", "hermes/default"),
+                team_id=self._config.get("team_id", ""),
+                memory_type="semantic",
+            )
+            self._record_success()
+        except Exception as exc:
+            self._record_failure()
+            logger.debug("XMemo on_memory_write mirror failed: %s", exc)
+
+    def on_session_end(self, messages: List[Dict[str, Any]]) -> None:
+        """Capture a restart snapshot at session end."""
+        if self._is_breaker_open() or not self._config.get("api_key"):
+            return
+        if not self._auto_write_enabled:
+            return
+
+        def _snapshot() -> None:
+            try:
+                client = self._get_client()
+                client.create_restart_snapshot(
+                    session_id=self._session_id,
+                    bucket=self._config.get("bucket", "work"),
+                    scope=self._config.get("scope", "hermes/default"),
+                    team_id=self._config.get("team_id", ""),
+                )
+                self._record_success()
+            except Exception as exc:
+                self._record_failure()
+                logger.debug("XMemo session-end snapshot failed: %s", exc)
+
+        self._snapshot_thread = threading.Thread(
+            target=_snapshot, daemon=True, name="xmemo-snapshot"
+        )
+        self._snapshot_thread.start()
+
+
+def register(ctx) -> None:
+    """Register XMemo as a memory provider plugin."""
+    ctx.register_memory_provider(XMemoMemoryProvider())

--- a/plugins/memory/xmemo/cli.py
+++ b/plugins/memory/xmemo/cli.py
@@ -1,0 +1,384 @@
+"""Setup wizard for the XMemo memory provider.
+
+Invoked by ``hermes memory setup xmemo`` via the provider's ``post_setup()``
+hook. Collects credentials and preferences, then writes:
+  - config.yaml  → memory.provider = xmemo
+  - .env         → XMEMO_KEY
+  - xmemo.json   → non-secret provider settings
+"""
+
+from __future__ import annotations
+
+import os
+import stat
+import sys
+import time
+from pathlib import Path
+from typing import Any, Dict, Optional, Tuple
+
+import httpx
+
+from hermes_cli.secret_prompt import masked_secret_prompt
+
+from .client import XMemoClient, XMemoClientError
+
+
+def _prompt(label: str, default: str | None = None, secret: bool = False) -> str:
+    """Prompt for a value with optional default and secret masking."""
+    suffix = f" [{default}]" if default else ""
+    if secret:
+        val = masked_secret_prompt(f"  {label}{suffix}: ")
+    else:
+        sys.stdout.write(f"  {label}{suffix}: ")
+        sys.stdout.flush()
+        val = sys.stdin.readline().strip()
+    return val or (default or "")
+
+
+def _curses_select(title: str, choices: list[str], default: int = 0) -> int:
+    """Interactive single-select for choice fields."""
+    try:
+        from hermes_cli.curses_ui import curses_radiolist
+
+        return curses_radiolist(
+            title, choices, selected=default, cancel_returns=default
+        )
+    except Exception:
+        # Fallback: print numbered list and read stdin
+        print(f"\n  {title}")
+        for i, choice in enumerate(choices):
+            marker = ">" if i == default else " "
+            print(f"    {marker} {i + 1}. {choice}")
+        sys.stdout.write("  Select (number): ")
+        sys.stdout.flush()
+        try:
+            idx = int(sys.stdin.readline().strip()) - 1
+            if 0 <= idx < len(choices):
+                return idx
+        except ValueError:
+            pass
+        return default
+
+
+def _write_env_vars(env_path: Path, env_writes: dict) -> None:
+    """Append or update env vars in .env file."""
+    env_path.parent.mkdir(parents=True, exist_ok=True)
+
+    existing_lines = []
+    if env_path.exists():
+        existing_lines = env_path.read_text(encoding="utf-8").splitlines()
+
+    updated_keys: set[str] = set()
+    new_lines: list[str] = []
+    for line in existing_lines:
+        key_match = line.split("=", 1)[0].strip() if "=" in line else ""
+        if key_match in env_writes:
+            new_lines.append(f"{key_match}={env_writes[key_match]}")
+            updated_keys.add(key_match)
+        else:
+            new_lines.append(line)
+
+    for key, val in env_writes.items():
+        if key not in updated_keys:
+            new_lines.append(f"{key}={val}")
+
+    env_path.write_text("\n".join(new_lines) + "\n", encoding="utf-8")
+    try:
+        env_path.chmod(stat.S_IRUSR | stat.S_IWUSR)
+    except OSError:
+        pass
+
+
+def _validate_api_key(
+    base_url: str, api_key: str, client: Optional[XMemoClient] = None
+) -> Tuple[bool, str]:
+    """Return (ok, message) after validating the XMemo API token."""
+    own_client = client is None
+    client = client or XMemoClient(base_url=base_url, api_key=api_key, timeout=5.0)
+    try:
+        client.validate_token()
+        return True, ""
+    except XMemoClientError as exc:
+        if exc.status_code == 409:
+            return (
+                False,
+                "XMemo account setup is required. Complete onboarding in your browser first.",
+            )
+        if exc.status_code in (401, 403):
+            return False, "Invalid or expired XMemo token."
+        return False, f"XMemo token validation failed (HTTP {exc.status_code})."
+    except Exception as exc:
+        return False, f"XMemo token validation failed: {exc}"
+    finally:
+        if own_client:
+            client.close()
+
+
+def _run_device_login(
+    base_url: str,
+    timeout_seconds: float = 300.0,
+    *,
+    client: Optional[httpx.Client] = None,
+) -> Optional[str]:
+    """OAuth-style device login flow for headless CLI.
+
+    Returns the access token once the user approves the request in the browser,
+    or None if the flow times out.
+    """
+    base = base_url.rstrip("/")
+    start_url = f"{base}/v1/auth/device/start"
+    token_url = f"{base}/v1/auth/device/token"
+
+    own_client = client is None
+    client = client or httpx.Client(timeout=10.0)
+    try:
+        resp = client.post(
+            start_url,
+            json={
+                "client_id": "hermes-xmemo-plugin",
+                "token_type": "api_key",
+                "scopes": ["memory:read", "memory:write"],
+            },
+        )
+        resp.raise_for_status()
+        data = resp.json()
+        device_code = data["device_code"]
+        user_code = data["user_code"]
+        verification_uri = (
+            data.get("verification_uri_complete") or data["verification_uri"]
+        )
+        interval = max(2, data.get("interval", 5))
+
+        print(f"\n  Open this URL in your browser to approve Hermes:")
+        print(f"    {verification_uri}")
+        print(f"  User code: {user_code}\n")
+
+        deadline = time.monotonic() + timeout_seconds
+        while time.monotonic() < deadline:
+            time.sleep(interval)
+            poll_resp = client.post(
+                token_url,
+                json={
+                    "device_code": device_code,
+                    "grant_type": "urn:ietf:params:oauth:grant-type:device_code",
+                },
+            )
+            if poll_resp.status_code == 200:
+                token_data = poll_resp.json()
+                error = token_data.get("error")
+                if error:
+                    if error == "authorization_pending":
+                        continue
+                    raise RuntimeError(f"Device login failed: {error}")
+                access_token = token_data.get("access_token")
+                if access_token:
+                    return access_token
+                continue
+            try:
+                err_body = poll_resp.json()
+                err = err_body.get("error")
+                err_desc = err_body.get("error_description")
+            except Exception:
+                err = None
+                err_desc = None
+            if err == "authorization_pending":
+                continue
+            if err == "setup_required":
+                raise RuntimeError(
+                    err_desc
+                    or "XMemo account setup is required. Complete onboarding in your browser first."
+                )
+            raise RuntimeError(
+                f"Device login failed: {err_desc or err or f'HTTP {poll_resp.status_code}'}"
+            )
+    finally:
+        if own_client:
+            client.close()
+    return None
+
+
+def _configure_auth(
+    provider_config: Dict[str, Any], env_writes: Dict[str, str]
+) -> None:
+    """Prompt for API-key or device-login authentication."""
+    base_url = provider_config.get("base_url", "https://xmemo.dev")
+    methods = ["Paste an API key", "Sign in with browser (device login)"]
+    choice = _curses_select("Authentication method", methods, default=0)
+
+    if choice == 1:
+        try:
+            token = _run_device_login(base_url)
+        except RuntimeError as exc:
+            print(f"  {exc}")
+            token = None
+        if token:
+            env_writes["XMEMO_KEY"] = token
+            print("  Device login succeeded. Token saved to .env")
+        else:
+            print(
+                "  Device login did not complete. "
+                "You can set XMEMO_KEY manually and run setup again."
+            )
+        return
+
+    # API key path
+    existing = os.environ.get("XMEMO_KEY", "")
+    while True:
+        if existing:
+            masked = f"...{existing[-4:]}" if len(existing) > 4 else "set"
+            prompt_text = f"XMemo service token (current: {masked}, blank to keep)"
+        else:
+            print(
+                "  Create an API key at https://xmemo.dev "
+                "(Memory Console -> API Keys -> Create API key)"
+            )
+            prompt_text = "XMemo service token"
+        val = _prompt(prompt_text, secret=True)
+        if not val:
+            if existing:
+                # Keep existing token; do not touch .env
+                print("  Keeping existing token.")
+            else:
+                print(
+                    "  No token provided. Set XMEMO_KEY manually and run setup again."
+                )
+            break
+        ok, msg = _validate_api_key(base_url, val)
+        if ok:
+            env_writes["XMEMO_KEY"] = val
+            print("  Token validated successfully.")
+            break
+        print(f"  {msg}")
+
+
+def _run_schema_setup(
+    provider: Any,
+    hermes_home: str,
+    config: Dict[str, Any],
+) -> None:
+    """Walk the provider's config schema and persist answers."""
+    from hermes_constants import get_hermes_home
+    from hermes_cli.config import load_config, save_config as save_global_config
+
+    schema = (
+        provider.get_config_schema() if hasattr(provider, "get_config_schema") else []
+    )
+
+    provider_name = provider.name if hasattr(provider, "name") else "xmemo"
+    if not isinstance(config.get("memory"), dict):
+        config["memory"] = {}
+
+    provider_config = config["memory"].get(provider_name, {})
+    if not isinstance(provider_config, dict):
+        provider_config = {}
+
+    env_path = get_hermes_home() / ".env"
+    env_writes: Dict[str, str] = {}
+
+    if schema:
+        print(f"\n  Configuring XMemo:\n")
+        for field in schema:
+            key = field["key"]
+            desc = field.get("description", key)
+            default = field.get("default")
+            is_secret = field.get("secret", False)
+            choices = field.get("choices")
+            env_var = field.get("env_var")
+            url = field.get("url")
+
+            when = field.get("when")
+            if when and isinstance(when, dict):
+                if not all(provider_config.get(k) == v for k, v in when.items()):
+                    continue
+
+            if key == "api_key":
+                _configure_auth(provider_config, env_writes)
+                continue
+
+            if choices and not is_secret:
+                current = provider_config.get(key, default)
+                current_idx = 0
+                if current and current in choices:
+                    current_idx = choices.index(current)
+                sel = _curses_select(f"  {desc}", choices, default=current_idx)
+                provider_config[key] = choices[sel]
+            elif is_secret:
+                existing = os.environ.get(env_var, "") if env_var else ""
+                if existing:
+                    masked = f"...{existing[-4:]}" if len(existing) > 4 else "set"
+                    val = _prompt(
+                        f"{desc} (current: {masked}, blank to keep)", secret=True
+                    )
+                else:
+                    if url:
+                        print(f"  Get yours at {url}")
+                    val = _prompt(desc, secret=True)
+                if val and env_var:
+                    env_writes[env_var] = val
+            else:
+                current = provider_config.get(key)
+                effective_default = current or default
+                val = _prompt(
+                    desc,
+                    default=str(effective_default) if effective_default else None,
+                )
+                if val:
+                    provider_config[key] = val
+                    if env_var and env_var not in env_writes:
+                        env_writes[env_var] = val
+
+    config["memory"]["provider"] = provider_name
+
+    # Merge current provider_config into the global memory.<provider> block so
+    # the non-secret values are also visible in config.yaml (in addition to the
+    # native xmemo.json written by save_config).
+    existing_memory = config.setdefault("memory", {})
+    existing_provider_cfg = existing_memory.get(provider_name, {})
+    if isinstance(existing_provider_cfg, dict):
+        existing_provider_cfg.update(provider_config)
+        existing_memory[provider_name] = existing_provider_cfg
+
+    save_global_config(config)
+
+    if hasattr(provider, "save_config"):
+        try:
+            provider.save_config(provider_config, hermes_home)
+        except Exception as exc:
+            print(f"  Failed to write XMemo config: {exc}")
+
+    if env_writes:
+        _write_env_vars(env_path, env_writes)
+
+    print(f"\n  Memory provider: {provider_name}")
+    print(f"  Activation saved to config.yaml")
+    print(f"  Provider config saved to {hermes_home}/xmemo.json")
+    if env_writes:
+        print(f"  API key saved to {hermes_home}/.env")
+    print(f"\n  Start a new session to activate.\n")
+
+
+def cmd_setup(
+    provider: Any | None = None,
+    hermes_home: str = "",
+    config: Dict[str, Any] | None = None,
+) -> None:
+    """Entry point for the XMemo setup wizard.
+
+    Called with a provider instance when invoked from ``post_setup()``.
+    """
+    from hermes_constants import get_hermes_home
+
+    if provider is None:
+        from . import XMemoMemoryProvider
+
+        provider = XMemoMemoryProvider()
+
+    if not hermes_home:
+        hermes_home = str(get_hermes_home())
+
+    if config is None:
+        from hermes_cli.config import load_config
+
+        config = load_config()
+
+    _run_schema_setup(provider, hermes_home, config)

--- a/plugins/memory/xmemo/client.py
+++ b/plugins/memory/xmemo/client.py
@@ -1,0 +1,395 @@
+"""Synchronous REST client for XMemo.
+
+Deliberately lightweight: uses ``httpx.Client`` directly instead of the async
+``memory_manager.client.RemoteMemoryManager`` so Hermes does not inherit the
+full Memory OS server dependency tree.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any, Dict, List, Optional
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+
+class XMemoClientError(Exception):
+    """Raised when an XMemo API call fails."""
+
+    def __init__(self, message: str, status_code: int = 0, response_body: Any = None):
+        super().__init__(message)
+        self.status_code = status_code
+        self.response_body = response_body
+
+
+class XMemoClient:
+    """Synchronous XMemo REST client."""
+
+    def __init__(
+        self,
+        base_url: str,
+        api_key: str,
+        agent_id: str = "hermes",
+        agent_instance_id: str = "",
+        timeout: float = 5.0,
+        transport: Optional[Any] = None,
+    ):
+        self.base_url = base_url.rstrip("/")
+        self.api_key = api_key
+        self.agent_id = agent_id
+        self.agent_instance_id = agent_instance_id
+        self.timeout = timeout
+
+        self.headers: Dict[str, str] = {"X-API-Key": api_key}
+        if agent_id:
+            self.headers["X-Memory-OS-Agent-ID"] = agent_id
+        if agent_instance_id:
+            self.headers["X-Memory-OS-Agent-Instance-ID"] = agent_instance_id
+
+        client_kwargs: Dict[str, Any] = {
+            "base_url": self.base_url,
+            "headers": self.headers,
+            "timeout": httpx.Timeout(timeout),
+        }
+        if transport is not None:
+            client_kwargs["transport"] = transport
+        self._client = httpx.Client(**client_kwargs)
+
+    def _request(
+        self,
+        method: str,
+        path: str,
+        *,
+        params: Optional[Dict[str, Any]] = None,
+        json_body: Optional[Dict[str, Any]] = None,
+    ) -> Any:
+        """Make a synchronous request and return parsed JSON."""
+        url = f"{self.base_url}{path}"
+        try:
+            response = self._client.request(
+                method=method,
+                url=url,
+                params=params,
+                json=json_body,
+            )
+            response.raise_for_status()
+            if response.status_code == 204 or not response.content:
+                return {}
+            return response.json()
+        except httpx.HTTPStatusError as exc:
+            body = None
+            try:
+                body = exc.response.json()
+            except Exception:
+                body = exc.response.text
+            logger.debug(
+                "XMemo API error: %s %s -> %s: %s",
+                method,
+                path,
+                exc.response.status_code,
+                body,
+            )
+            raise XMemoClientError(
+                f"XMemo API error {exc.response.status_code}: {body}",
+                status_code=exc.response.status_code,
+                response_body=body,
+            ) from exc
+        except Exception as exc:
+            logger.debug("XMemo request failed: %s %s -> %s", method, path, exc)
+            raise XMemoClientError(f"XMemo request failed: {exc}") from exc
+
+    def health(self) -> Dict[str, Any]:
+        """Check service health."""
+        return self._request("GET", "/health")
+
+    def validate_token(self) -> Dict[str, Any]:
+        """Validate the configured API token against the authenticated endpoint."""
+        return self._request("GET", "/v1/auth/token/validate")
+
+    def recall_context(
+        self,
+        query: str,
+        *,
+        bucket: str = "work",
+        scope: str = "hermes/default",
+        team_id: str = "",
+        max_items: int = 5,
+        max_tokens: int = 900,
+        memory_type: str = "auto",
+        prefer_working: bool = True,
+    ) -> Dict[str, Any]:
+        """Build a bounded context pack from XMemo memories."""
+        json_body: Dict[str, Any] = {
+            "query": query,
+            "bucket": bucket,
+            "scope": scope,
+            "max_items": max_items,
+            "max_tokens": max_tokens,
+            "memory_type": memory_type,
+            "prefer_working": prefer_working,
+        }
+        if team_id:
+            json_body["team_id"] = team_id
+        return self._request("POST", "/v1/recall/context", json_body=json_body)
+
+    def search(
+        self,
+        query: str,
+        *,
+        bucket: str = "work",
+        scope: str = "hermes/default",
+        team_id: str = "",
+        memory_type: str = "%",
+        limit: int = 5,
+        explain: bool = False,
+        prefer_working: bool = False,
+    ) -> List[Dict[str, Any]]:
+        """Semantic search over XMemo memories."""
+        params: Dict[str, Any] = {
+            "query": query,
+            "bucket": bucket,
+            "scope": scope,
+            "memory_type": memory_type,
+            "limit": limit,
+            "explain": explain,
+            "prefer_working": prefer_working,
+        }
+        if team_id:
+            params["team_id"] = team_id
+        result = self._request("GET", "/v1/memories/search", params=params)
+        if isinstance(result, dict):
+            return result.get("results", []) or []
+        if isinstance(result, list):
+            return result
+        return []
+
+    def remember(
+        self,
+        content: str,
+        path: str,
+        *,
+        bucket: str = "work",
+        scope: str = "hermes/default",
+        team_id: str = "",
+        memory_type: str = "semantic",
+        importance: Optional[float] = None,
+        confidence: Optional[float] = None,
+        dedupe: bool = True,
+        semantic_key: str = "",
+    ) -> Dict[str, Any]:
+        """Save a durable fact to XMemo."""
+        payload: Dict[str, Any] = {
+            "content": content,
+            "path": path,
+            "bucket": bucket,
+            "scope": scope,
+            "memory_type": memory_type,
+            "dedupe": dedupe,
+        }
+        if team_id:
+            payload["team_id"] = team_id
+        if importance is not None:
+            payload["importance"] = importance
+        if confidence is not None:
+            payload["confidence"] = confidence
+        if semantic_key:
+            payload["semantic_key"] = semantic_key
+        return self._request("POST", "/v1/remember", json_body=payload)
+
+    def update_state(
+        self,
+        *,
+        state_key: str = "active_task",
+        content: str = "",
+        current_task: str = "",
+        next_action: str = "",
+        blocked_reason: str = "",
+        bucket: str = "work",
+        scope: str = "hermes/default",
+        team_id: str = "",
+        ttl_seconds: int = 86400,
+    ) -> Dict[str, Any]:
+        """Persist active working state with TTL."""
+        payload: Dict[str, Any] = {
+            "state_key": state_key,
+            "bucket": bucket,
+            "scope": scope,
+            "ttl_seconds": ttl_seconds,
+        }
+        if team_id:
+            payload["team_id"] = team_id
+        if content:
+            payload["content"] = content
+        if current_task:
+            payload["current_task"] = current_task
+        if next_action:
+            payload["next_action"] = next_action
+        if blocked_reason:
+            payload["blocked_reason"] = blocked_reason
+        return self._request("POST", "/v1/update_state", json_body=payload)
+
+    def record_event(
+        self,
+        content: str,
+        *,
+        event_type: str = "event",
+        bucket: str = "work",
+        scope: str = "hermes/default",
+        team_id: str = "",
+        session_id: str = "",
+    ) -> Dict[str, Any]:
+        """Append a timeline event."""
+        payload: Dict[str, Any] = {
+            "content": content,
+            "event_type": event_type,
+            "bucket": bucket,
+            "scope": scope,
+        }
+        if team_id:
+            payload["team_id"] = team_id
+        if session_id:
+            payload["session_id"] = session_id
+        return self._request("POST", "/v1/timeline/events", json_body=payload)
+
+    def create_restart_snapshot(
+        self,
+        *,
+        session_id: str = "",
+        bucket: str = "work",
+        scope: str = "hermes/default",
+        team_id: str = "",
+        state_key: str = "active_task",
+    ) -> Dict[str, Any]:
+        """Capture a restart snapshot before handoff or shutdown."""
+        payload: Dict[str, Any] = {
+            "bucket": bucket,
+            "scope": scope,
+            "state_key": state_key,
+        }
+        if team_id:
+            payload["team_id"] = team_id
+        if session_id:
+            payload["session_id"] = session_id
+        return self._request("POST", "/v1/restart/snapshot", json_body=payload)
+
+    def create_reminder(
+        self,
+        content: str,
+        *,
+        bucket: str = "work",
+        scope: str = "hermes/default",
+        team_id: str = "",
+        due_at: str = "",
+        session_id: str = "",
+    ) -> Dict[str, Any]:
+        """Create a TODO/action item to revisit later."""
+        payload: Dict[str, Any] = {
+            "content": content,
+            "bucket": bucket,
+            "scope": scope,
+        }
+        if team_id:
+            payload["team_id"] = team_id
+        if due_at:
+            payload["due_at"] = due_at
+        if session_id:
+            payload["session_id"] = session_id
+        return self._request("POST", "/v1/reminders", json_body=payload)
+
+    def list_reminders(
+        self,
+        *,
+        bucket: str = "work",
+        scope: str = "hermes/default",
+        team_id: str = "",
+        item_status: str = "open",
+        limit: int = 20,
+    ) -> List[Dict[str, Any]]:
+        """List open or completed TODO items."""
+        params: Dict[str, Any] = {
+            "bucket": bucket,
+            "scope": scope,
+            "item_status": item_status,
+            "limit": limit,
+        }
+        if team_id:
+            params["team_id"] = team_id
+        result = self._request("GET", "/v1/reminders", params=params)
+        if isinstance(result, dict):
+            return result.get("items", []) or result.get("reminders", []) or []
+        if isinstance(result, list):
+            return result
+        return []
+
+    def complete_reminder(
+        self,
+        todo_id: str,
+        *,
+        bucket: str = "work",
+        scope: str = "hermes/default",
+        team_id: str = "",
+        note: str = "",
+    ) -> Dict[str, Any]:
+        """Mark a TODO item as completed."""
+        payload: Dict[str, Any] = {"bucket": bucket, "scope": scope}
+        if team_id:
+            payload["team_id"] = team_id
+        if note:
+            payload["note"] = note
+        return self._request(
+            "POST", f"/v1/reminders/{todo_id}/complete", json_body=payload
+        )
+
+    def mark_used(
+        self,
+        memory_id: str,
+        *,
+        context: str = "",
+        action: str = "used",
+        usage_tracking_id: str = "",
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> Dict[str, Any]:
+        """Record that a recalled memory was used in the answer.
+
+        Payload matches Memory OS MemoryUsageRequest: only usage_tracking_id,
+        action, context, and metadata are accepted (extra="forbid").
+        """
+        payload: Dict[str, Any] = {"action": action}
+        if context:
+            payload["context"] = context
+        if usage_tracking_id:
+            payload["usage_tracking_id"] = usage_tracking_id
+        if metadata:
+            payload["metadata"] = metadata
+        return self._request(
+            "POST", f"/v1/memories/{memory_id}/usage", json_body=payload
+        )
+
+    def forget(
+        self,
+        memory_id: str,
+        *,
+        bucket: str = "work",
+        scope: str = "hermes/default",
+        team_id: str = "",
+        reason: str = "",
+    ) -> Dict[str, Any]:
+        """Delete a memory by exact id."""
+        payload: Dict[str, Any] = {"bucket": bucket, "scope": scope}
+        if team_id:
+            payload["team_id"] = team_id
+        if reason:
+            payload["reason"] = reason
+        return self._request(
+            "POST", f"/v1/memories/{memory_id}/forget", json_body=payload
+        )
+
+    def close(self) -> None:
+        """Close the underlying HTTP client."""
+        try:
+            self._client.close()
+        except Exception as exc:
+            logger.debug("XMemo client close failed: %s", exc)

--- a/plugins/memory/xmemo/config.py
+++ b/plugins/memory/xmemo/config.py
@@ -1,0 +1,168 @@
+"""XMemo provider configuration loader.
+
+Reads settings from (highest to lowest priority):
+  1. Environment variables: XMEMO_KEY, MEMORY_OS_API_KEY
+  2. $HERMES_HOME/xmemo.json for non-secret values only
+
+Secrets (api_key) are NEVER read from xmemo.json. If a stale api_key is found
+in the file it is ignored and will be removed on the next save_config().
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import uuid
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+from hermes_constants import get_hermes_home
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_BASE_URL = "https://xmemo.dev"
+DEFAULT_BUCKET = "work"
+DEFAULT_SCOPE = "hermes/default"
+DEFAULT_TIMEOUT_SECONDS = 5.0
+DEFAULT_PREFETCH_MAX_ITEMS = 5
+DEFAULT_PREFETCH_MAX_TOKENS = 900
+
+
+def _config_path() -> Path:
+    return get_hermes_home() / "xmemo.json"
+
+
+def _default_agent_instance_id() -> str:
+    """Generate a stable, opaque, non-reversible install identifier."""
+    return uuid.uuid4().hex
+
+
+def _load_file_cfg() -> Dict[str, Any]:
+    """Read non-secret config from xmemo.json."""
+    cfg_path = _config_path()
+    if not cfg_path.exists():
+        return {}
+    try:
+        data = json.loads(cfg_path.read_text(encoding="utf-8")) or {}
+    except Exception as exc:
+        logger.debug("Failed to read %s: %s", cfg_path, exc)
+        return {}
+
+    # Defensive: if someone previously wrote a secret into this file, drop it
+    # in memory and schedule cleanup on next save.
+    if "api_key" in data:
+        logger.warning(
+            "xmemo.json contained an api_key; it has been ignored. "
+            "Use the XMEMO_KEY environment variable or run 'hermes memory setup xmemo'."
+        )
+        data = {k: v for k, v in data.items() if k != "api_key"}
+    return data
+
+
+def load_config(*, create_instance: bool = False) -> Dict[str, Any]:
+    """Load XMemo provider configuration.
+
+    Args:
+        create_instance: If True, generate and persist a missing
+            ``agent_instance_id``. Callers that only *read* config (e.g.
+            ``is_available()``) should pass False to avoid side effects.
+    """
+    file_cfg = _load_file_cfg()
+
+    api_key = os.environ.get("XMEMO_KEY") or os.environ.get("MEMORY_OS_API_KEY", "")
+
+    base_url = (
+        os.environ.get("XMEMO_URL")
+        or os.environ.get("MEMORY_OS_URL")
+        or file_cfg.get("base_url", "")
+        or DEFAULT_BASE_URL
+    )
+
+    agent_id = os.environ.get("XMEMO_AGENT_ID") or file_cfg.get("agent_id", "hermes")
+
+    agent_instance_id = os.environ.get("XMEMO_AGENT_INSTANCE_ID") or file_cfg.get(
+        "agent_instance_id", ""
+    )
+
+    bucket = os.environ.get("XMEMO_BUCKET") or file_cfg.get("bucket", DEFAULT_BUCKET)
+    scope = os.environ.get("XMEMO_SCOPE") or file_cfg.get("scope", DEFAULT_SCOPE)
+    team_id = os.environ.get("XMEMO_TEAM_ID") or file_cfg.get("team_id", "")
+
+    timeout = file_cfg.get("timeout_seconds", DEFAULT_TIMEOUT_SECONDS)
+    if "XMEMO_TIMEOUT_SECONDS" in os.environ:
+        try:
+            timeout = float(os.environ["XMEMO_TIMEOUT_SECONDS"])
+        except ValueError:
+            pass
+
+    prefetch_max_items = file_cfg.get("prefetch_max_items", DEFAULT_PREFETCH_MAX_ITEMS)
+    if "XMEMO_PREFETCH_MAX_ITEMS" in os.environ:
+        try:
+            prefetch_max_items = int(os.environ["XMEMO_PREFETCH_MAX_ITEMS"])
+        except ValueError:
+            pass
+
+    prefetch_max_tokens = file_cfg.get(
+        "prefetch_max_tokens", DEFAULT_PREFETCH_MAX_TOKENS
+    )
+    if "XMEMO_PREFETCH_MAX_TOKENS" in os.environ:
+        try:
+            prefetch_max_tokens = int(os.environ["XMEMO_PREFETCH_MAX_TOKENS"])
+        except ValueError:
+            pass
+
+    enable_workflow_tools = file_cfg.get("enable_workflow_tools", False)
+    enable_destructive_tools = file_cfg.get("enable_destructive_tools", False)
+    capture_timeline = file_cfg.get("capture_timeline", False)
+
+    config = {
+        "api_key": api_key,
+        "base_url": base_url,
+        "agent_id": agent_id,
+        "agent_instance_id": agent_instance_id,
+        "bucket": bucket,
+        "scope": scope,
+        "team_id": team_id,
+        "timeout_seconds": timeout,
+        "prefetch_max_items": prefetch_max_items,
+        "prefetch_max_tokens": prefetch_max_tokens,
+        "enable_workflow_tools": enable_workflow_tools,
+        "enable_destructive_tools": enable_destructive_tools,
+        "capture_timeline": capture_timeline,
+    }
+
+    if create_instance and not config["agent_instance_id"]:
+        config["agent_instance_id"] = _default_agent_instance_id()
+        try:
+            save_config(config)
+        except Exception as exc:
+            logger.debug("Failed to persist generated agent_instance_id: %s", exc)
+
+    return config
+
+
+def save_config(values: Dict[str, Any], hermes_home: Optional[str] = None) -> None:
+    """Persist non-secret XMemo config to $HERMES_HOME/xmemo.json."""
+    if hermes_home:
+        cfg_path = Path(hermes_home) / "xmemo.json"
+    else:
+        cfg_path = _config_path()
+    cfg_path.parent.mkdir(parents=True, exist_ok=True)
+
+    existing: Dict[str, Any] = {}
+    if cfg_path.exists():
+        try:
+            existing = json.loads(cfg_path.read_text(encoding="utf-8")) or {}
+        except Exception:
+            pass
+
+    # Never write secrets to disk; also remove any stale secret that may exist.
+    safe_values = {k: v for k, v in values.items() if k != "api_key"}
+    existing = {k: v for k, v in existing.items() if k != "api_key"}
+    existing.update(safe_values)
+
+    cfg_path.write_text(
+        json.dumps(existing, indent=2, ensure_ascii=False) + "\n",
+        encoding="utf-8",
+    )

--- a/plugins/memory/xmemo/plugin.yaml
+++ b/plugins/memory/xmemo/plugin.yaml
@@ -1,0 +1,7 @@
+name: xmemo
+version: 1.0.0
+description: "XMemo — user-owned cloud memory for AI agents, with orchestrated recall, semantic search, and durable fact storage."
+pip_dependencies:
+  - httpx
+hooks:
+  - on_session_end

--- a/tests/plugins/memory/test_xmemo.py
+++ b/tests/plugins/memory/test_xmemo.py
@@ -1,0 +1,337 @@
+"""Tests for the bundled XMemo memory provider."""
+
+from __future__ import annotations
+
+import httpx
+import json
+import os
+from pathlib import Path
+from typing import Any, Dict, List
+
+import pytest
+
+
+def _load_provider(tmp_path: Path):
+    """Load the bundled XMemo provider into a temp HERMES_HOME."""
+    from plugins.memory import load_memory_provider
+
+    os.environ["HERMES_HOME"] = str(tmp_path)
+    provider = load_memory_provider("xmemo")
+    assert provider is not None
+    return provider
+
+
+@pytest.fixture
+def provider(tmp_path):
+    provider = _load_provider(tmp_path)
+    provider.initialize("test-session")
+    return provider
+
+
+class FakeClient:
+    def __init__(self, search_results=None, recall_context=None):
+        self.search_results = search_results or []
+        self.recall_context_response = recall_context or {}
+        self.calls: List[Dict[str, Any]] = []
+
+    def _record(self, method, **kwargs):
+        self.calls.append({"method": method, **kwargs})
+
+    def health(self):
+        self._record("health")
+        return {"status": "ok"}
+
+    def validate_token(self):
+        self._record("validate_token")
+        return {"status": "valid"}
+
+    def recall_context(self, **kwargs):
+        self._record("recall_context", **kwargs)
+        return self.recall_context_response
+
+    def search(self, **kwargs):
+        self._record("search", **kwargs)
+        return self.search_results
+
+    def remember(self, **kwargs):
+        self._record("remember", **kwargs)
+        return {"id": "mem-123"}
+
+    def update_state(self, **kwargs):
+        self._record("update_state", **kwargs)
+        return {"id": "state-123"}
+
+    def record_event(self, **kwargs):
+        self._record("record_event", **kwargs)
+        return {"id": "event-123"}
+
+    def create_reminder(self, **kwargs):
+        self._record("create_reminder", **kwargs)
+        return {"id": "reminder-123"}
+
+    def list_reminders(self, **kwargs):
+        self._record("list_reminders", **kwargs)
+        return []
+
+    def complete_reminder(self, **kwargs):
+        self._record("complete_reminder", **kwargs)
+        return {"id": kwargs.get("todo_id", "reminder-123")}
+
+    def mark_used(self, **kwargs):
+        self._record("mark_used", **kwargs)
+        if "bucket" in kwargs or "scope" in kwargs:
+            raise ValueError("MemoryUsageRequest does not accept bucket/scope")
+        return {"id": kwargs.get("memory_id", "mem-123")}
+
+    def forget(self, **kwargs):
+        self._record("forget", **kwargs)
+        return {"id": kwargs.get("memory_id", "mem-123")}
+
+    def create_restart_snapshot(self, **kwargs):
+        self._record("create_restart_snapshot", **kwargs)
+        return {"id": "snapshot-123"}
+
+    def close(self):
+        self._record("close")
+
+
+def test_external_load(provider):
+    assert provider.name == "xmemo"
+
+
+def test_default_tool_schemas(provider):
+    names = {s["name"] for s in provider.get_tool_schemas()}
+    assert names == {
+        "xmemo_recall_context",
+        "xmemo_search",
+        "xmemo_remember",
+        "xmemo_update_state",
+    }
+
+
+def test_remember_routes_to_api(provider, monkeypatch):
+    fake = FakeClient()
+    monkeypatch.setattr(provider, "_get_client", lambda: fake)
+
+    result = json.loads(
+        provider.handle_tool_call(
+            "xmemo_remember",
+            {"content": "user likes small PRs", "path": "hermes/preferences"},
+        )
+    )
+    assert result["result"] == "Saved to XMemo."
+    assert fake.calls[0]["method"] == "remember"
+
+
+def test_mark_used_payload_no_bucket_scope(provider, monkeypatch):
+    fake = FakeClient()
+    monkeypatch.setattr(provider, "_get_client", lambda: fake)
+
+    result = json.loads(
+        provider.handle_tool_call(
+            "xmemo_mark_used",
+            {"memory_id": "mem-456", "context": "used in answer"},
+        )
+    )
+    assert result["result"] == "Memory usage recorded in XMemo."
+    assert fake.calls[0]["method"] == "mark_used"
+    assert "bucket" not in fake.calls[0]
+    assert "scope" not in fake.calls[0]
+
+
+def test_capture_timeline_false_no_auto_write(provider, monkeypatch):
+    fake = FakeClient()
+    monkeypatch.setattr(provider, "_get_client", lambda: fake)
+
+    provider.sync_turn("remember that I prefer small PRs", "got it")
+    assert fake.calls == []
+
+
+def test_redaction_replaces_token(provider, monkeypatch, tmp_path):
+    from plugins.memory.xmemo.config import save_config
+
+    os.environ["HERMES_HOME"] = str(tmp_path)
+    save_config({"capture_timeline": True}, str(tmp_path))
+
+    # Re-load plugin with capture_timeline enabled
+    provider2 = _load_provider(tmp_path)
+    provider2.initialize("test-session")
+    provider2._config["api_key"] = "test-key"
+
+    fake = FakeClient()
+    monkeypatch.setattr(provider2, "_get_client", lambda: fake)
+
+    secret = "sk-" + "a" * 50
+    provider2.sync_turn(f"remember this token {secret}", "ok")
+    assert len(fake.calls) == 1
+    assert fake.calls[0]["method"] == "record_event"
+    content = fake.calls[0]["content"]
+    assert secret not in content
+    assert "[REDACTED]" in content
+
+
+def test_rest_mark_used_usage_endpoint():
+    from plugins.memory.xmemo.client import XMemoClient
+
+    requests: List[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        return httpx.Response(200, json={"id": "mem-123"})
+
+    client = XMemoClient(
+        base_url="https://xmemo.dev",
+        api_key="test-key",
+        transport=httpx.MockTransport(handler),
+    )
+    client.mark_used("mem-123", context="used in answer")
+    client.close()
+
+    assert len(requests) == 1
+    assert requests[0].url.path == "/v1/memories/mem-123/usage"
+    body = json.loads(requests[0].content)
+    assert body["action"] == "used"
+    assert "bucket" not in body
+    assert "scope" not in body
+
+
+def test_team_id_passed_to_api_calls(provider, monkeypatch):
+    provider._config["team_id"] = "team-abc"
+    fake = FakeClient()
+    monkeypatch.setattr(provider, "_get_client", lambda: fake)
+
+    provider.handle_tool_call(
+        "xmemo_remember",
+        {"content": "team note", "path": "hermes/team-note"},
+    )
+    remember_call = fake.calls[0]
+    assert remember_call["team_id"] == "team-abc"
+
+
+def test_setup_required_409_does_not_crash_initialize(tmp_path, monkeypatch):
+    from plugins.memory.xmemo.client import XMemoClientError
+
+    os.environ["HERMES_HOME"] = str(tmp_path)
+    os.environ["XMEMO_KEY"] = "test-key"
+    provider = _load_provider(tmp_path)
+
+    calls = []
+
+    class FailingValidationClient:
+        def validate_token(self):
+            calls.append("validate_token")
+            raise XMemoClientError("setup required", status_code=409)
+
+        def close(self):
+            pass
+
+    monkeypatch.setattr(provider, "_get_client", lambda: FailingValidationClient())
+
+    provider.initialize("test-session")
+    assert calls == ["validate_token"]
+
+
+def test_validate_api_key_ok():
+    from plugins.memory.xmemo.cli import _validate_api_key
+    from plugins.memory.xmemo.client import XMemoClient
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.path == "/v1/auth/token/validate"
+        return httpx.Response(200, json={"status": "ok"})
+
+    client = XMemoClient(
+        base_url="https://xmemo.dev",
+        api_key="test-key",
+        transport=httpx.MockTransport(handler),
+    )
+    ok, msg = _validate_api_key("https://xmemo.dev", "test-key", client=client)
+    assert ok is True
+    assert msg == ""
+
+
+def test_validate_api_key_setup_required():
+    from plugins.memory.xmemo.cli import _validate_api_key
+    from plugins.memory.xmemo.client import XMemoClient
+
+    client = XMemoClient(
+        base_url="https://xmemo.dev",
+        api_key="test-key",
+        transport=httpx.MockTransport(
+            lambda r: httpx.Response(409, json={"setup_state": "setup_required"})
+        ),
+    )
+    ok, msg = _validate_api_key("https://xmemo.dev", "test-key", client=client)
+    assert ok is False
+    assert "setup is required" in msg
+
+
+def test_device_login_setup_required_fails_fast(monkeypatch):
+    from plugins.memory.xmemo.cli import _run_device_login
+    import time
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path.endswith("/start"):
+            return httpx.Response(
+                200,
+                json={
+                    "device_code": "dev-setup",
+                    "user_code": "USER-CODE",
+                    "verification_uri": "https://xmemo.dev/device-login",
+                    "verification_uri_complete": "https://xmemo.dev/device-login?user_code=USER-CODE",
+                    "expires_in": 600,
+                    "interval": 1,
+                },
+            )
+        return httpx.Response(
+            400,
+            json={
+                "error": "setup_required",
+                "error_description": "Complete XMemo onboarding before authorizing device login",
+            },
+        )
+
+    client = httpx.Client(transport=httpx.MockTransport(handler))
+    monkeypatch.setattr(time, "sleep", lambda s: None)
+    with pytest.raises(RuntimeError, match="onboarding"):
+        _run_device_login("https://xmemo.dev", timeout_seconds=10.0, client=client)
+
+
+def test_device_login_returns_token(monkeypatch):
+    from plugins.memory.xmemo.cli import _run_device_login
+    import time
+
+    responses = {
+        "start": httpx.Response(
+            200,
+            json={
+                "device_code": "dev-123",
+                "user_code": "USER-CODE",
+                "verification_uri": "https://xmemo.dev/device-login",
+                "verification_uri_complete": "https://xmemo.dev/device-login?user_code=USER-CODE",
+                "expires_in": 600,
+                "interval": 1,
+            },
+        ),
+        "pending": httpx.Response(
+            400,
+            json={"error": "authorization_pending"},
+        ),
+        "token": httpx.Response(
+            200,
+            json={"access_token": "tok_abc:secret", "token_type": "Bearer"},
+        ),
+    }
+    call_count = {"n": 0}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path.endswith("/start"):
+            return responses["start"]
+        call_count["n"] += 1
+        if call_count["n"] == 1:
+            return responses["pending"]
+        return responses["token"]
+
+    client = httpx.Client(transport=httpx.MockTransport(handler))
+    monkeypatch.setattr(time, "sleep", lambda s: None)
+    token = _run_device_login("https://xmemo.dev", timeout_seconds=10.0, client=client)
+    assert token == "tok_abc:secret"


### PR DESCRIPTION
## Summary

Add **XMemo** as a bundled cloud memory provider for Hermes, living under `plugins/memory/xmemo/`.

XMemo provides user-owned cloud memory: orchestrated recall, semantic search, durable fact storage, working state, reminders, and cross-session restart snapshots.

## What's included

- `plugins/memory/xmemo/__init__.py` — `XMemoMemoryProvider` implementing the `MemoryProvider` ABC
- `plugins/memory/xmemo/client.py` — `httpx`-based REST client for the XMemo API
- `plugins/memory/xmemo/config.py` — profile-aware config loader/saver
- `plugins/memory/xmemo/cli.py` — `hermes memory setup xmemo` wizard with API-key and device-login flows
- `plugins/memory/xmemo/plugin.yaml` — bundled plugin metadata
- `plugins/memory/xmemo/README.md` — usage and configuration docs
- `tests/plugins/memory/test_xmemo.py` — provider + client + CLI tests

## Key features

- Cloud memory via `https://xmemo.dev` (configurable `base_url`)
- Authentication by **scoped API key** or **browser device-login** OAuth-style flow
- Token validation during setup with friendly `setup_required` handling
- `team_id` support for team-scoped memories
- Configurable recall/search/update state tools
- Optional workflow tools (reminders/events) and destructive tools (`xmemo_forget`) gated by config

## Usage

```bash
hermes memory setup xmemo
```

Or manually:

```bash
hermes config set memory.provider xmemo
echo "XMEMO_KEY=your-key" >> ~/.hermes/.env
```

## Tests

```bash
python -m pytest tests/plugins/memory/test_xmemo.py -v
```

All 13 XMemo tests pass. The provider is discovered alongside the existing bundled memory providers.

## Notes

- No new runtime dependencies beyond `httpx`, which Hermes already uses.
- All state paths use `get_hermes_home()` for profile safety.
- Tool schemas are prefixed with `xmemo_` to avoid collisions with built-ins and other providers.
