### PR TITLE
feat: wire R1 route advisory surfaces

### DIFF
--- a/apps/desktop/src/app/chat/composer/index.tsx
+++ b/apps/desktop/src/app/chat/composer/index.tsx
@@ -16,6 +16,7 @@ import {
 import { hermesDirectiveFormatter, type SlashChipKind } from '@/components/assistant-ui/directive-text'
 import { composerFill, composerSurfaceGlass } from '@/components/chat/composer-dock'
 import { Button } from '@/components/ui/button'
+import { getRouteAdvisory, type RouteAdvisoryResponse } from '@/hermes'
 import { useMediaQuery } from '@/hooks/use-media-query'
 import { useResizeObserver } from '@/hooks/use-resize-observer'
 import { useI18n } from '@/i18n'
@@ -94,6 +95,7 @@ import {
   RICH_INPUT_SLOT,
   slashChipElement
 } from './rich-editor'
+import { RouteAdvisoryBanner } from './route-advisory-banner'
 import { ComposerStatusStack } from './status-stack'
 import { detectTrigger, extractClipboardImageBlobs, textBeforeCaret, type TriggerState } from './text-utils'
 import { ComposerTriggerPopover } from './trigger-popover'
@@ -155,6 +157,8 @@ const cloneAttachments = (attachments: ComposerAttachment[]) => attachments.map(
 // Quiet period after the last keystroke before persisting the draft;
 // unmount/pagehide flushes bypass it.
 const DRAFT_PERSIST_DEBOUNCE_MS = 400
+const ROUTE_ADVISORY_DEBOUNCE_MS = 650
+const ROUTE_ADVISORY_MIN_CHARS = 12
 
 export function ChatBar({
   busy,
@@ -224,9 +228,11 @@ export function ChatBar({
   const [tight, setTight] = useState(false)
   const [dragActive, setDragActive] = useState(false)
   const [queueEdit, setQueueEdit] = useState<QueueEditState | null>(null)
+  const [routeAdvisory, setRouteAdvisory] = useState<RouteAdvisoryResponse | null>(null)
   const [focusRequestId, setFocusRequestId] = useState(0)
   const queueEditRef = useRef(queueEdit)
   queueEditRef.current = queueEdit
+  const routeAdvisoryRequestRef = useRef(0)
   const dragDepthRef = useRef(0)
   const composingRef = useRef(false) // true during IME composition (CJK input)
   const lastSpokenIdRef = useRef<string | null>(null)
@@ -380,6 +386,34 @@ export function ChatBar({
       renderComposerContents(editor, draft)
     }
   }, [draft])
+
+  useEffect(() => {
+    const text = draft.trim()
+    const requestId = routeAdvisoryRequestRef.current + 1
+    routeAdvisoryRequestRef.current = requestId
+
+    if (inputDisabled || text.length < ROUTE_ADVISORY_MIN_CHARS || SLASH_COMMAND_RE.test(text)) {
+      setRouteAdvisory(null)
+
+      return undefined
+    }
+
+    const handle = window.setTimeout(() => {
+      void getRouteAdvisory(text, 'desktop')
+        .then(advisory => {
+          if (routeAdvisoryRequestRef.current === requestId) {
+            setRouteAdvisory(advisory)
+          }
+        })
+        .catch(() => {
+          if (routeAdvisoryRequestRef.current === requestId) {
+            setRouteAdvisory(null)
+          }
+        })
+    }, ROUTE_ADVISORY_DEBOUNCE_MS)
+
+    return () => window.clearTimeout(handle)
+  }, [draft, inputDisabled])
 
   useEffect(() => {
     if (urlOpen) {
@@ -1933,6 +1967,7 @@ export function ChatBar({
                   </div>
                 )}
                 {attachments.length > 0 && <AttachmentList attachments={attachments} onRemove={onRemoveAttachment} />}
+                <RouteAdvisoryBanner advisory={routeAdvisory} />
                 <div
                   className={cn(
                     'grid w-full',

--- a/apps/desktop/src/app/chat/composer/route-advisory-banner.test.tsx
+++ b/apps/desktop/src/app/chat/composer/route-advisory-banner.test.tsx
@@ -1,0 +1,43 @@
+import { cleanup, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { RouteAdvisoryBanner, shouldDisplayRouteAdvisory } from './route-advisory-banner'
+
+describe('RouteAdvisoryBanner', () => {
+  afterEach(() => cleanup())
+
+  it('renders an advisory-only route recommendation without implying auto-switching', () => {
+    render(
+      <RouteAdvisoryBanner
+        advisory={{
+          advisory_mode: true,
+          auto_execute: false,
+          blocked_actions: ['raw_client_upload'],
+          confidence: 8,
+          profile: 'business-growth',
+          requires_approval: true,
+          route_id: 'business-growth'
+        }}
+      />
+    )
+
+    expect(screen.getByRole('status', { name: 'Route advisory' })).toBeTruthy()
+    expect(screen.getByText(/Recommended profile: business-growth/i)).toBeTruthy()
+    expect(screen.getByText(/confidence 8/i)).toBeTruthy()
+    expect(screen.getByText(/Advisory only/i)).toBeTruthy()
+    expect(screen.getByText(/No profile switch or auto-execution/i)).toBeTruthy()
+    expect(screen.getByText(/Blocked actions: raw_client_upload/i)).toBeTruthy()
+  })
+
+  it('hides macos/main-hermes default decisions so normal prompts are quiet', () => {
+    expect(
+      shouldDisplayRouteAdvisory({
+        advisory_mode: true,
+        auto_execute: false,
+        confidence: 0,
+        profile: 'macos',
+        route_id: 'main-hermes'
+      })
+    ).toBe(false)
+  })
+})

--- a/apps/desktop/src/app/chat/composer/route-advisory-banner.tsx
+++ b/apps/desktop/src/app/chat/composer/route-advisory-banner.tsx
@@ -1,0 +1,56 @@
+import type { RouteAdvisoryResponse } from '@/types/hermes'
+
+const DEFAULT_ROUTE_IDS = new Set(['main-hermes', 'macos', 'default'])
+
+function routeName(advisory: RouteAdvisoryResponse): string {
+  return String(advisory.route_id || advisory.profile || '').trim()
+}
+
+export function shouldDisplayRouteAdvisory(advisory: null | RouteAdvisoryResponse | undefined): advisory is RouteAdvisoryResponse {
+  if (!advisory || advisory.error) {
+    return false
+  }
+
+  if (advisory.advisory_mode !== true || advisory.auto_execute !== false) {
+    return false
+  }
+
+  const route = routeName(advisory).toLowerCase()
+  const profile = String(advisory.profile || '').trim().toLowerCase()
+
+  if (!route || DEFAULT_ROUTE_IDS.has(route) || DEFAULT_ROUTE_IDS.has(profile)) {
+    return false
+  }
+
+  return Number(advisory.confidence ?? 0) > 0
+}
+
+export function RouteAdvisoryBanner({ advisory }: { advisory: null | RouteAdvisoryResponse | undefined }) {
+  if (!shouldDisplayRouteAdvisory(advisory)) {
+    return null
+  }
+
+  const profile = advisory.profile || advisory.route_id || 'specialist profile'
+  const confidence = Number(advisory.confidence ?? 0)
+  const blockedActions = advisory.blocked_actions?.filter(Boolean) ?? []
+
+  return (
+    <div
+      aria-label="Route advisory"
+      className="rounded-lg border border-[color-mix(in_srgb,var(--dt-composer-ring)_34%,transparent)] bg-accent/14 px-3 py-2 text-[0.72rem] leading-snug text-foreground shadow-sm"
+      role="status"
+    >
+      <div className="flex flex-wrap items-center gap-x-2 gap-y-1">
+        <span className="font-medium">Recommended profile: {profile}</span>
+        <span className="text-muted-foreground">confidence {Number.isInteger(confidence) ? confidence : confidence.toFixed(1)}</span>
+        <span className="rounded-full border border-[color-mix(in_srgb,var(--dt-composer-ring)_26%,transparent)] px-2 py-0.5 text-[0.66rem] uppercase tracking-wide text-muted-foreground">
+          Advisory only
+        </span>
+      </div>
+      <div className="mt-1 text-muted-foreground">No profile switch or auto-execution will happen from this banner.</div>
+      {blockedActions.length > 0 && (
+        <div className="mt-1 text-muted-foreground">Blocked actions: {blockedActions.join(', ')}</div>
+      )}
+    </div>
+  )
+}

--- a/apps/desktop/src/hermes.test.ts
+++ b/apps/desktop/src/hermes.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-import { getSessionMessages, listAllProfileSessions, listSessions } from './hermes'
+import { getRouteAdvisory, getSessionMessages, listAllProfileSessions, listSessions } from './hermes'
 
 const emptySessionsResponse = {
   limit: 0,
@@ -55,6 +55,22 @@ describe('Hermes REST session helpers', () => {
     expect(api).toHaveBeenCalledWith({
       path: '/api/sessions/session-1/messages?profile=xiaoxuxu',
       profile: 'xiaoxuxu'
+    })
+  })
+
+  it('does not persist Desktop draft route previews by default', async () => {
+    api.mockResolvedValue({ route_id: 'main-hermes', profile: 'macos', auto_execute: false })
+
+    await getRouteAdvisory('draft text that has not been sent yet')
+
+    expect(api).toHaveBeenCalledWith({
+      path: '/api/route',
+      method: 'POST',
+      body: {
+        prompt: 'draft text that has not been sent yet',
+        surface: 'desktop',
+        log: false
+      }
     })
   })
 })

--- a/apps/desktop/src/hermes.ts
+++ b/apps/desktop/src/hermes.ts
@@ -688,7 +688,7 @@ export function getRouteAdvisory(prompt: string, surface = 'desktop'): Promise<R
     ...profileScoped(),
     path: '/api/route',
     method: 'POST',
-    body: { prompt, surface }
+    body: { prompt, surface, log: false }
   })
 }
 

--- a/apps/desktop/src/hermes.ts
+++ b/apps/desktop/src/hermes.ts
@@ -33,6 +33,7 @@ import type {
   ProfileSetupCommand,
   ProfileSoul,
   ProfilesResponse,
+  RouteAdvisoryResponse,
   SessionInfo,
   SessionMessagesResponse,
   SessionSearchResponse,
@@ -88,6 +89,7 @@ export type {
   ProfileSetupCommand,
   ProfileSoul,
   ProfilesResponse,
+  RouteAdvisoryResponse,
   RpcEvent,
   SessionCreateResponse,
   SessionInfo,
@@ -678,6 +680,15 @@ export function setGlobalModel(
       provider,
       model
     }
+  })
+}
+
+export function getRouteAdvisory(prompt: string, surface = 'desktop'): Promise<RouteAdvisoryResponse> {
+  return window.hermesDesktop.api<RouteAdvisoryResponse>({
+    ...profileScoped(),
+    path: '/api/route',
+    method: 'POST',
+    body: { prompt, surface }
   })
 }
 

--- a/apps/desktop/src/types/hermes.ts
+++ b/apps/desktop/src/types/hermes.ts
@@ -191,6 +191,21 @@ export interface HermesConfig {
 
 export type HermesConfigRecord = Record<string, unknown>
 
+export interface RouteAdvisoryResponse {
+  advisory_mode?: boolean
+  auto_execute?: boolean
+  blocked?: boolean
+  blocked_actions?: string[]
+  confidence?: number
+  error?: null | string
+  owner?: string
+  profile?: string
+  prompt_class?: string
+  requires_approval?: boolean
+  route_id?: string
+  route_name?: string
+}
+
 export interface ModelInfoResponse {
   auto_context_length?: number
   capabilities?: Record<string, unknown>

--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -184,6 +184,45 @@ def _coerce_job_text(value: Any, fallback: str = "") -> str:
     return str(value)
 
 
+def _build_route_advisory(prompt_text: str) -> Optional[Dict[str, Any]]:
+    """Create advisory-only routing metadata for a cron job prompt.
+
+    Cron creation must never fail just because the local routing helper is
+    unavailable. R1 stores/logs the advisory but does not change the job's
+    execution profile, model, provider, or schedule.
+    """
+    if not prompt_text or not prompt_text.strip():
+        return None
+    try:
+        from hermes_cli.route_advisory import classify_route_advisory
+
+        return classify_route_advisory(
+            prompt_text,
+            surface="cron:create",
+            log=True,
+        )
+    except Exception as exc:
+        logger.warning("Cron route advisory failed; keeping macos ownership: %s", exc)
+        return {
+            "surface": "cron:create",
+            "route_id": "main-hermes",
+            "route_name": "Main Hermes / Orchestration",
+            "owner": "macos",
+            "profile": "macos",
+            "prompt_class": "orchestration",
+            "action": "Main Hermes handles",
+            "blocked": False,
+            "blocked_actions": [],
+            "requires_approval": False,
+            "reason": "Route advisory failed; default to Main Hermes/macOS.",
+            "confidence": 0.0,
+            "advisory_mode": True,
+            "auto_execute": False,
+            "is_live": True,
+            "error": f"{type(exc).__name__}: {exc}",
+        }
+
+
 def _schedule_display_for_job(job: Dict[str, Any]) -> str:
     display = _coerce_job_text(job.get("schedule_display")).strip()
     if display:
@@ -755,6 +794,7 @@ def create_job(
         # Delivery configuration
         "deliver": deliver,
         "origin": origin,  # Tracks where job was created for "origin" delivery
+        "routing_advisory": _build_route_advisory(prompt_text),
         "enabled_toolsets": normalized_toolsets,
         "workdir": normalized_workdir,
     }

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -56,6 +56,7 @@ from agent.async_utils import safe_schedule_threadsafe
 from agent.i18n import t
 from hermes_cli.config import cfg_get
 from hermes_cli.fallback_config import get_fallback_chain
+from hermes_cli.route_advisory import classify_route_advisory, format_route_advisory
 
 # --- Agent cache tuning ---------------------------------------------------
 # Bounds the per-session AIAgent cache to prevent unbounded growth in
@@ -2256,6 +2257,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         self._restart_drain_timeout = self._load_restart_drain_timeout()
         self._provider_routing = self._load_provider_routing()
         self._fallback_model = self._load_fallback_model()
+        self._route_advisory_config = self._load_route_advisory_config()
 
         # Wire process registry into session store for reset protection
         from tools.process_registry import process_registry
@@ -2315,6 +2317,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         self._queued_events: Dict[str, List[MessageEvent]] = {}
         self._pending_native_image_paths_by_session: Dict[str, List[str]] = {}
         self._busy_ack_ts: Dict[str, float] = {}  # last busy-ack timestamp per session (debounce)
+        self._route_advisory_sent: Dict[str, tuple[str, float]] = {}
         self._session_run_generation: Dict[str, int] = {}
         # Startup restore gate: while restart-interrupted sessions are being
         # auto-resumed, real inbound messages are queued instead of competing
@@ -3667,6 +3670,145 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # No explicit legacy knob → follow busy_input_mode.
         input_mode = GatewayRunner._load_busy_input_mode()
         return "queue" if input_mode == "queue" else "interrupt"
+
+    @staticmethod
+    def _load_route_advisory_config() -> Dict[str, Any]:
+        """Load R1 profile-routing advisory settings.
+
+        R1 is intentionally advisory-only: this controls whether the gateway
+        announces a route suggestion before the normal macOS-owned agent turn.
+        It never switches profile or dispatches specialist execution.
+        """
+        cfg = _load_gateway_runtime_config()
+        enabled_raw = os.getenv("HERMES_ROUTE_ADVISORY_ENABLED", "").strip()
+        if enabled_raw:
+            enabled = is_truthy_value(enabled_raw, default=False)
+        else:
+            enabled = is_truthy_value(
+                cfg_get(
+                    cfg,
+                    "routing",
+                    "advisory",
+                    "enabled",
+                    default=cfg_get(cfg, "routing", "advisory_enabled", default=False),
+                ),
+                default=False,
+            )
+        gateway_notice = is_truthy_value(
+            cfg_get(cfg, "routing", "advisory", "gateway_notice", default=True),
+            default=True,
+        )
+        try:
+            min_confidence = float(
+                cfg_get(cfg, "routing", "advisory", "min_confidence", default=1.0)
+            )
+        except (TypeError, ValueError):
+            min_confidence = 1.0
+        try:
+            cooldown_seconds = float(
+                cfg_get(cfg, "routing", "advisory", "cooldown_seconds", default=3600)
+            )
+        except (TypeError, ValueError):
+            cooldown_seconds = 3600.0
+        platforms = cfg_get(cfg, "routing", "advisory", "platforms", default=["telegram"])
+        if isinstance(platforms, str):
+            raw_platforms = platforms.strip()
+            if raw_platforms.startswith("["):
+                try:
+                    parsed_platforms = json.loads(raw_platforms)
+                except Exception:
+                    parsed_platforms = None
+                platforms = parsed_platforms if isinstance(parsed_platforms, list) else [raw_platforms]
+            else:
+                platforms = [raw_platforms]
+        if not isinstance(platforms, list):
+            platforms = ["telegram"]
+        platforms = {str(platform).strip().lower() for platform in platforms if str(platform).strip()}
+        if not platforms:
+            platforms = {"telegram"}
+        return {
+            "enabled": bool(enabled),
+            "gateway_notice": bool(gateway_notice),
+            "min_confidence": min_confidence,
+            "cooldown_seconds": max(0.0, cooldown_seconds),
+            "platforms": platforms,
+        }
+
+    async def _maybe_send_route_advisory(
+        self,
+        event: MessageEvent,
+        source: SessionSource,
+        *,
+        command: Optional[str] = None,
+    ) -> Optional[Dict[str, Any]]:
+        """Log and optionally announce an advisory-only route suggestion."""
+        route_cfg = getattr(self, "_route_advisory_config", None) or self._load_route_advisory_config()
+        if not route_cfg.get("enabled"):
+            return None
+        if command:
+            return None
+        if getattr(event, "internal", False):
+            return None
+        if event.message_type != MessageType.TEXT:
+            return None
+        prompt_text = (event.text or "").strip()
+        if not prompt_text:
+            return None
+
+        platform_value = getattr(source.platform, "value", str(source.platform or "")).lower()
+        surface = f"gateway:{platform_value or 'unknown'}"
+        loop = asyncio.get_running_loop()
+        try:
+            advisory = await loop.run_in_executor(
+                None,
+                lambda: classify_route_advisory(prompt_text, surface=surface, log=True),
+            )
+        except Exception as exc:
+            logger.debug("Route advisory failed for %s: %s", surface, exc)
+            return None
+
+        if not route_cfg.get("gateway_notice", True):
+            return advisory
+        if platform_value not in route_cfg.get("platforms", {"telegram"}):
+            return advisory
+        if advisory.get("route_id") in {None, "", "main-hermes"}:
+            return advisory
+        try:
+            confidence = float(advisory.get("confidence") or 0.0)
+        except (TypeError, ValueError):
+            confidence = 0.0
+        if confidence < float(route_cfg.get("min_confidence", 1.0)):
+            return advisory
+
+        session_key = self._session_key_for_source(source)
+        sent_cache = getattr(self, "_route_advisory_sent", None)
+        if sent_cache is None:
+            sent_cache = {}
+            self._route_advisory_sent = sent_cache
+        now = time.time()
+        cache_key = str(advisory.get("route_id") or "")
+        last_route, last_ts = sent_cache.get(session_key, ("", 0.0))
+        cooldown = float(route_cfg.get("cooldown_seconds", 3600.0))
+        if last_route == cache_key and cooldown > 0 and now - last_ts < cooldown:
+            return advisory
+
+        adapter = self.adapters.get(source.platform)
+        if adapter is None:
+            return advisory
+        notice = (
+            format_route_advisory(advisory)
+            + "\nR1 is advisory-only: continue normally to keep Main Hermes/macOS in control; "
+              "ask explicitly before any specialist profile or Kanban dispatch."
+        )
+        metadata = self._thread_metadata_for_source(source, self._reply_anchor_for_event(event))
+        try:
+            await adapter.send(source.chat_id, notice, metadata=metadata)
+            sent_cache[session_key] = (cache_key, now)
+        except Exception as exc:
+            logger.debug("Failed to send route advisory for %s: %s", surface, exc)
+        return advisory
+
+    @staticmethod
 
     @staticmethod
     def _load_restart_drain_timeout() -> float:
@@ -7950,6 +8092,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         _run_generation = self._begin_session_run_generation(_quick_key)
 
         try:
+            await self._maybe_send_route_advisory(event, source, command=command)
             _agent_result = await self._handle_message_with_agent(event, source, _quick_key, _run_generation)
             # Goal continuation: after the agent returns a final response
             # for this turn, check any standing /goal — the judge will

--- a/hermes_cli/route_advisory.py
+++ b/hermes_cli/route_advisory.py
@@ -1,7 +1,7 @@
 """Profile route advisory helpers for safe Hermes routing surfaces.
 
 R1 is advisory-only: this module classifies a prompt with the local
-``hermes-route`` command, normalizes the result, and writes a sanitized audit
+``hermes-route`` command, normalizes the result, and writes a metadata-only audit
 record. It never switches profiles or executes work in a specialist lane.
 """
 
@@ -10,7 +10,6 @@ from __future__ import annotations
 import hashlib
 import json
 import os
-import re
 import shutil
 import subprocess
 from datetime import datetime, timezone
@@ -21,15 +20,6 @@ from hermes_constants import get_hermes_home
 
 DEFAULT_ROUTE_COMMAND = "/usr/local/bin/hermes-route"
 DEFAULT_TIMEOUT_SECS = 2.0
-
-_SECRET_PATTERNS = (
-    re.compile(r"\bsk-[A-Za-z0-9][A-Za-z0-9_\-]{12,}\b"),
-    re.compile(r"\bgh[pousr]_[A-Za-z0-9_]{20,}\b"),
-    re.compile(r"\bxox[baprs]-[A-Za-z0-9\-]{20,}\b"),
-    re.compile(r"\bhf_[A-Za-z0-9]{20,}\b"),
-    re.compile(r"\bglpat-[A-Za-z0-9_\-]{20,}\b"),
-    re.compile(r"(?i)\b(Bearer\s+)[A-Za-z0-9._\-]{20,}\b"),
-)
 
 
 def _utc_now() -> str:
@@ -48,24 +38,12 @@ def _route_command() -> str | None:
     return None
 
 
-def _redact(text: str) -> str:
-    value = str(text or "")
-    for pattern in _SECRET_PATTERNS:
-        value = pattern.sub(lambda m: (m.group(1) if m.lastindex else "") + "[REDACTED]", value)
-    return value
-
-
 def _prompt_fingerprint(prompt: str) -> dict[str, str | int]:
+    """Return metadata-only prompt fingerprints without retaining prompt text."""
     text = str(prompt or "")
-    normalized = " ".join(text.split())
-    redacted = _redact(normalized)
-    preview = redacted[:160]
-    if len(redacted) > 160:
-        preview += "…"
     return {
         "prompt_sha256": hashlib.sha256(text.encode("utf-8", errors="replace")).hexdigest(),
         "prompt_length": len(text),
-        "prompt_preview": preview,
     }
 
 
@@ -144,7 +122,7 @@ def normalize_route_payload(payload: Mapping[str, Any], *, surface: str) -> dict
 
 
 def log_route_decision(advisory: Mapping[str, Any], prompt: str, *, log_path: Path | None = None) -> Path:
-    """Append a sanitized JSONL route-decision record and return its path."""
+    """Append a metadata-only JSONL route-decision record and return its path."""
     target = log_path or (get_hermes_home() / "logs" / "routing_decisions.jsonl")
     target.parent.mkdir(parents=True, exist_ok=True)
     record = {
@@ -194,7 +172,8 @@ def classify_route_advisory(
         else:
             try:
                 completed = subprocess.run(
-                    [route_command, "--json", prompt_text],
+                    [route_command, "--json", "--stdin"],
+                    input=prompt_text,
                     capture_output=True,
                     text=True,
                     timeout=timeout,

--- a/hermes_cli/route_advisory.py
+++ b/hermes_cli/route_advisory.py
@@ -1,0 +1,250 @@
+"""Profile route advisory helpers for safe Hermes routing surfaces.
+
+R1 is advisory-only: this module classifies a prompt with the local
+``hermes-route`` command, normalizes the result, and writes a sanitized audit
+record. It never switches profiles or executes work in a specialist lane.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import re
+import shutil
+import subprocess
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Mapping
+
+from hermes_constants import get_hermes_home
+
+DEFAULT_ROUTE_COMMAND = "/usr/local/bin/hermes-route"
+DEFAULT_TIMEOUT_SECS = 2.0
+
+_SECRET_PATTERNS = (
+    re.compile(r"\bsk-[A-Za-z0-9][A-Za-z0-9_\-]{12,}\b"),
+    re.compile(r"\bgh[pousr]_[A-Za-z0-9_]{20,}\b"),
+    re.compile(r"\bxox[baprs]-[A-Za-z0-9\-]{20,}\b"),
+    re.compile(r"\bhf_[A-Za-z0-9]{20,}\b"),
+    re.compile(r"\bglpat-[A-Za-z0-9_\-]{20,}\b"),
+    re.compile(r"(?i)\b(Bearer\s+)[A-Za-z0-9._\-]{20,}\b"),
+)
+
+
+def _utc_now() -> str:
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def _route_command() -> str | None:
+    configured = os.environ.get("HERMES_ROUTE_COMMAND", "").strip()
+    if configured:
+        return configured
+    discovered = shutil.which("hermes-route")
+    if discovered:
+        return discovered
+    if Path(DEFAULT_ROUTE_COMMAND).exists():
+        return DEFAULT_ROUTE_COMMAND
+    return None
+
+
+def _redact(text: str) -> str:
+    value = str(text or "")
+    for pattern in _SECRET_PATTERNS:
+        value = pattern.sub(lambda m: (m.group(1) if m.lastindex else "") + "[REDACTED]", value)
+    return value
+
+
+def _prompt_fingerprint(prompt: str) -> dict[str, str | int]:
+    text = str(prompt or "")
+    normalized = " ".join(text.split())
+    redacted = _redact(normalized)
+    preview = redacted[:160]
+    if len(redacted) > 160:
+        preview += "…"
+    return {
+        "prompt_sha256": hashlib.sha256(text.encode("utf-8", errors="replace")).hexdigest(),
+        "prompt_length": len(text),
+        "prompt_preview": preview,
+    }
+
+
+def _coerce_bool(value: Any, default: bool = False) -> bool:
+    if isinstance(value, bool):
+        return value
+    if value is None:
+        return default
+    if isinstance(value, str):
+        return value.strip().lower() in {"1", "true", "yes", "on"}
+    return bool(value)
+
+
+def _coerce_float(value: Any, default: float = 0.0) -> float:
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _coerce_string_list(value: Any) -> list[str]:
+    if not isinstance(value, list):
+        return []
+    return [str(item) for item in value if str(item).strip()]
+
+
+def _fallback_advisory(
+    *,
+    surface: str,
+    error: str | None = None,
+    reason: str = "Route advisory unavailable; default to Main Hermes/macOS.",
+) -> dict[str, Any]:
+    return {
+        "timestamp": _utc_now(),
+        "surface": str(surface or "unknown"),
+        "route_id": "main-hermes",
+        "route_name": "Main Hermes / Orchestration",
+        "owner": "macos",
+        "profile": "macos",
+        "prompt_class": "orchestration",
+        "action": "Main Hermes handles",
+        "blocked": False,
+        "blocked_actions": [],
+        "requires_approval": False,
+        "reason": reason,
+        "confidence": 0.0,
+        "advisory_mode": True,
+        "auto_execute": False,
+        "is_live": True,
+        "error": error,
+    }
+
+
+def normalize_route_payload(payload: Mapping[str, Any], *, surface: str) -> dict[str, Any]:
+    route_id = str(payload.get("route_id") or "main-hermes")
+    profile = str(payload.get("profile") or ("macos" if route_id == "main-hermes" else route_id))
+    return {
+        "timestamp": _utc_now(),
+        "surface": str(surface or "unknown"),
+        "route_id": route_id,
+        "route_name": str(payload.get("route_name") or route_id),
+        "owner": str(payload.get("owner") or profile or "macos"),
+        "profile": profile,
+        "prompt_class": str(payload.get("prompt_class") or "orchestration"),
+        "action": str(payload.get("action") or "Route advisory only"),
+        "blocked": _coerce_bool(payload.get("blocked"), False),
+        "blocked_actions": _coerce_string_list(payload.get("blocked_actions")),
+        "requires_approval": _coerce_bool(payload.get("requires_approval"), False),
+        "reason": str(payload.get("reason") or ""),
+        "confidence": _coerce_float(payload.get("confidence"), 0.0),
+        "advisory_mode": True,
+        "auto_execute": False,
+        "is_live": _coerce_bool(payload.get("is_live"), route_id != "vault-local"),
+        "error": payload.get("error"),
+    }
+
+
+def log_route_decision(advisory: Mapping[str, Any], prompt: str, *, log_path: Path | None = None) -> Path:
+    """Append a sanitized JSONL route-decision record and return its path."""
+    target = log_path or (get_hermes_home() / "logs" / "routing_decisions.jsonl")
+    target.parent.mkdir(parents=True, exist_ok=True)
+    record = {
+        "timestamp": advisory.get("timestamp") or _utc_now(),
+        "surface": advisory.get("surface") or "unknown",
+        "route_id": advisory.get("route_id"),
+        "profile": advisory.get("profile"),
+        "owner": advisory.get("owner"),
+        "confidence": advisory.get("confidence"),
+        "blocked": advisory.get("blocked"),
+        "requires_approval": advisory.get("requires_approval"),
+        "blocked_actions": advisory.get("blocked_actions") or [],
+        "advisory_mode": True,
+        "auto_execute": False,
+        "error": advisory.get("error"),
+    }
+    record.update(_prompt_fingerprint(prompt))
+    with target.open("a", encoding="utf-8") as handle:
+        handle.write(json.dumps(record, ensure_ascii=False, sort_keys=True) + "\n")
+    return target
+
+
+def classify_route_advisory(
+    prompt: str,
+    *,
+    surface: str = "unknown",
+    timeout: float = DEFAULT_TIMEOUT_SECS,
+    log: bool = True,
+    command: str | None = None,
+) -> dict[str, Any]:
+    """Return an advisory-only route decision for ``prompt``.
+
+    Failures are intentionally safe: no route command, timeout, parse error, or
+    non-JSON output falls back to Main Hermes/macOS and can still be logged for
+    observability. The helper never mutates session profile or job execution.
+    """
+    prompt_text = str(prompt or "")
+    if not prompt_text.strip():
+        advisory = _fallback_advisory(
+            surface=surface,
+            reason="Empty prompt; default to Main Hermes/macOS.",
+        )
+    else:
+        route_command = command or _route_command()
+        if not route_command:
+            advisory = _fallback_advisory(surface=surface, error="hermes-route command not found")
+        else:
+            try:
+                completed = subprocess.run(
+                    [route_command, "--json", prompt_text],
+                    capture_output=True,
+                    text=True,
+                    timeout=timeout,
+                    check=False,
+                )
+            except subprocess.TimeoutExpired:
+                advisory = _fallback_advisory(surface=surface, error="hermes-route timeout")
+            except OSError as exc:
+                advisory = _fallback_advisory(surface=surface, error=f"hermes-route failed: {exc}")
+            else:
+                try:
+                    payload = json.loads(completed.stdout or "{}")
+                except json.JSONDecodeError:
+                    advisory = _fallback_advisory(
+                        surface=surface,
+                        error=f"hermes-route non-json output rc={completed.returncode}",
+                    )
+                else:
+                    if not isinstance(payload, dict):
+                        advisory = _fallback_advisory(
+                            surface=surface,
+                            error=f"hermes-route invalid payload rc={completed.returncode}",
+                        )
+                    elif completed.returncode not in {0, 1} and payload.get("error"):
+                        advisory = _fallback_advisory(
+                            surface=surface,
+                            error=str(payload.get("error")),
+                        )
+                    else:
+                        advisory = normalize_route_payload(payload, surface=surface)
+                        if completed.returncode not in {0, 1}:
+                            advisory["error"] = f"hermes-route rc={completed.returncode}"
+    if log:
+        try:
+            log_route_decision(advisory, prompt_text)
+        except OSError as exc:
+            advisory = dict(advisory)
+            advisory["log_error"] = str(exc)
+    return advisory
+
+
+def format_route_advisory(advisory: Mapping[str, Any]) -> str:
+    """Render a concise user-facing advisory line."""
+    route_id = advisory.get("route_id") or "main-hermes"
+    profile = advisory.get("profile") or "macos"
+    confidence = _coerce_float(advisory.get("confidence"), 0.0)
+    approval = "; approval required before specialist execution" if advisory.get("requires_approval") else ""
+    blocked = advisory.get("blocked_actions") or []
+    blocked_text = f"; guarded actions: {', '.join(blocked)}" if blocked else ""
+    return (
+        f"Route advisory: {route_id} -> profile {profile} "
+        f"(confidence {confidence:.2f}; advisory-only, no auto-switch{approval}{blocked_text})."
+    )

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -649,7 +649,7 @@ class ConfigUpdate(BaseModel):
 class RouteAdvisoryRequest(BaseModel):
     prompt: str
     surface: str = "dashboard"
-    log: bool = True
+    log: bool = False
 
 
 class EnvVarUpdate(BaseModel):

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -67,6 +67,7 @@ from gateway.status import (
     get_runtime_status_running_pid,
     read_runtime_status,
 )
+from hermes_cli.route_advisory import classify_route_advisory
 from utils import env_var_enabled
 
 try:
@@ -643,6 +644,12 @@ CONFIG_SCHEMA = _ordered_schema
 class ConfigUpdate(BaseModel):
     config: dict
     profile: Optional[str] = None
+
+
+class RouteAdvisoryRequest(BaseModel):
+    prompt: str
+    surface: str = "dashboard"
+    log: bool = True
 
 
 class EnvVarUpdate(BaseModel):
@@ -1611,6 +1618,20 @@ async def fs_git_root(path: str):
 async def fs_default_cwd():
     cwd = _fs_default_cwd()
     return {"cwd": cwd, "branch": _fs_git_branch(cwd)}
+
+
+@app.post("/api/route")
+async def post_route_advisory(payload: RouteAdvisoryRequest):
+    """Return an advisory-only profile route decision for dashboard composers."""
+    prompt = str(payload.prompt or "")
+    if not prompt.strip():
+        raise HTTPException(status_code=400, detail="prompt is required")
+    surface = str(payload.surface or "dashboard").strip() or "dashboard"
+    loop = asyncio.get_running_loop()
+    return await loop.run_in_executor(
+        None,
+        lambda: classify_route_advisory(prompt, surface=surface, log=bool(payload.log)),
+    )
 
 
 @app.get("/api/status")

--- a/tests/cron/test_jobs.py
+++ b/tests/cron/test_jobs.py
@@ -193,10 +193,41 @@ class TestJobCRUD:
         assert job["prompt"] == "Check server status"
         assert job["enabled"] is True
         assert job["schedule"]["kind"] == "once"
+        assert "routing_advisory" in job
 
         fetched = get_job(job["id"])
         assert fetched is not None
         assert fetched["prompt"] == "Check server status"
+
+    def test_create_stores_route_advisory_without_changing_execution(self, tmp_cron_dir, monkeypatch):
+        def fake_advisory(prompt_text):
+            assert prompt_text == "Prepare BMI ASCAP radio promotion reminder"
+            return {
+                "route_id": "business-growth",
+                "profile": "business-growth",
+                "owner": "business-growth",
+                "confidence": 4.0,
+                "advisory_mode": True,
+                "auto_execute": False,
+                "requires_approval": True,
+                "blocked_actions": ["unapproved_account_access"],
+            }
+
+        monkeypatch.setattr("cron.jobs._build_route_advisory", fake_advisory)
+
+        job = create_job(
+            prompt="Prepare BMI ASCAP radio promotion reminder",
+            schedule="every 1h",
+            provider="openai-codex",
+            model="gpt-5.5",
+        )
+
+        assert job["routing_advisory"]["route_id"] == "business-growth"
+        assert job["routing_advisory"]["auto_execute"] is False
+        # R1 is advisory-only: cron execution remains on the explicitly chosen job config.
+        assert job["provider"] == "openai-codex"
+        assert job["model"] == "gpt-5.5"
+        assert job.get("routed_profile") is None
 
     def test_list_jobs(self, tmp_cron_dir):
         create_job(prompt="Job 1", schedule="every 1h")

--- a/tests/gateway/test_route_advisory.py
+++ b/tests/gateway/test_route_advisory.py
@@ -1,0 +1,125 @@
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from gateway.config import GatewayConfig, Platform, PlatformConfig
+from gateway.platforms.base import MessageEvent, MessageType
+from gateway.run import GatewayRunner
+from gateway.session import SessionSource
+
+
+def _make_runner(platform=Platform.TELEGRAM):
+    runner = object.__new__(GatewayRunner)
+    runner.config = GatewayConfig(platforms={platform: PlatformConfig(enabled=True)})
+    runner._route_advisory_config = {
+        "enabled": True,
+        "gateway_notice": True,
+        "min_confidence": 1.0,
+        "cooldown_seconds": 3600.0,
+        "platforms": {"telegram"},
+    }
+    runner._route_advisory_sent = {}
+    adapter = SimpleNamespace(send=AsyncMock())
+    runner.adapters = {platform: adapter}  # type: ignore[assignment]
+    runner.session_store = None  # type: ignore[assignment]
+
+    def _thread_meta(source, reply_to_message_id=None):
+        return {"thread_id": source.thread_id} if source.thread_id else {}
+
+    runner._thread_metadata_for_source = _thread_meta  # type: ignore[method-assign]
+    return runner, adapter
+
+
+def _make_event(text="Prepare BMI ASCAP radio promotion plan", platform=Platform.TELEGRAM):
+    source = SessionSource(
+        platform=platform,
+        user_id="u1",
+        chat_id="c1",
+        user_name="tester",
+        chat_type="dm",
+        thread_id="t1" if platform == Platform.TELEGRAM else None,
+    )
+    return MessageEvent(
+        text=text,
+        message_type=MessageType.TEXT,
+        source=source,
+        message_id="m1",
+    )
+
+
+@pytest.mark.asyncio
+async def test_gateway_route_advisory_sends_telegram_notice(monkeypatch):
+    runner, adapter = _make_runner()
+    event = _make_event()
+
+    def fake_classify(prompt, *, surface, log):
+        assert prompt == event.text
+        assert surface == "gateway:telegram"
+        assert log is True
+        return {
+            "route_id": "business-growth",
+            "profile": "business-growth",
+            "owner": "business-growth",
+            "confidence": 4.0,
+            "requires_approval": True,
+            "blocked_actions": ["unapproved_account_access"],
+            "advisory_mode": True,
+            "auto_execute": False,
+        }
+
+    monkeypatch.setattr("gateway.run.classify_route_advisory", fake_classify)
+
+    advisory = await runner._maybe_send_route_advisory(event, event.source, command=None)
+
+    assert advisory is not None
+    assert advisory["route_id"] == "business-growth"
+    adapter.send.assert_awaited_once()
+    args, kwargs = adapter.send.await_args
+    assert args[0] == "c1"
+    assert "Route advisory: business-growth -> profile business-growth" in args[1]
+    assert "advisory-only" in args[1]
+    assert kwargs["metadata"] == {"thread_id": "t1"}
+
+
+@pytest.mark.asyncio
+async def test_gateway_route_advisory_skips_commands(monkeypatch):
+    runner, adapter = _make_runner()
+    event = _make_event("/status")
+
+    called = {"value": False}
+
+    def fake_classify(*args, **kwargs):
+        called["value"] = True
+        return {}
+
+    monkeypatch.setattr("gateway.run.classify_route_advisory", fake_classify)
+
+    advisory = await runner._maybe_send_route_advisory(event, event.source, command="status")
+
+    assert advisory is None
+    assert called["value"] is False
+    adapter.send.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_gateway_route_advisory_debounces_same_route(monkeypatch):
+    runner, adapter = _make_runner()
+    event = _make_event()
+
+    monkeypatch.setattr(
+        "gateway.run.classify_route_advisory",
+        lambda *args, **kwargs: {
+            "route_id": "design-media",
+            "profile": "design-media",
+            "owner": "design-media",
+            "confidence": 3.0,
+            "requires_approval": True,
+            "blocked_actions": ["raw_client_data_upload"],
+        },
+    )
+
+    await runner._maybe_send_route_advisory(event, event.source, command=None)
+    await runner._maybe_send_route_advisory(event, event.source, command=None)
+
+    adapter.send.assert_awaited_once()

--- a/tests/hermes_cli/test_dashboard_route_advisory.py
+++ b/tests/hermes_cli/test_dashboard_route_advisory.py
@@ -17,7 +17,7 @@ def test_dashboard_route_advisory_endpoint(monkeypatch, _isolate_hermes_home):
     def fake_classify(prompt, *, surface, log):
         assert prompt == "Prepare BMI ASCAP radio promotion plan"
         assert surface == "dashboard:composer"
-        assert log is True
+        assert log is False
         return {
             "route_id": "business-growth",
             "profile": "business-growth",
@@ -42,6 +42,36 @@ def test_dashboard_route_advisory_endpoint(monkeypatch, _isolate_hermes_home):
     body = response.json()
     assert body["route_id"] == "business-growth"
     assert body["profile"] == "business-growth"
+    assert body["auto_execute"] is False
+
+
+def test_dashboard_route_advisory_honors_explicit_log_true(monkeypatch, _isolate_hermes_home):
+    def fake_classify(prompt, *, surface, log):
+        assert prompt == "Prepare radio route audit"
+        assert surface == "dashboard:composer"
+        assert log is True
+        return {
+            "route_id": "business-growth",
+            "profile": "business-growth",
+            "advisory_mode": True,
+            "auto_execute": False,
+        }
+
+    monkeypatch.setattr("hermes_cli.web_server.classify_route_advisory", fake_classify)
+
+    client = _client()
+    response = client.post(
+        "/api/route",
+        json={
+            "prompt": "Prepare radio route audit",
+            "surface": "dashboard:composer",
+            "log": True,
+        },
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["route_id"] == "business-growth"
     assert body["auto_execute"] is False
 
 

--- a/tests/hermes_cli/test_dashboard_route_advisory.py
+++ b/tests/hermes_cli/test_dashboard_route_advisory.py
@@ -1,0 +1,52 @@
+import pytest
+
+
+def _client():
+    try:
+        from starlette.testclient import TestClient
+    except ImportError:
+        pytest.skip("fastapi/starlette not installed")
+    from hermes_cli.web_server import app, _SESSION_HEADER_NAME, _SESSION_TOKEN
+
+    client = TestClient(app)
+    client.headers[_SESSION_HEADER_NAME] = _SESSION_TOKEN
+    return client
+
+
+def test_dashboard_route_advisory_endpoint(monkeypatch, _isolate_hermes_home):
+    def fake_classify(prompt, *, surface, log):
+        assert prompt == "Prepare BMI ASCAP radio promotion plan"
+        assert surface == "dashboard:composer"
+        assert log is True
+        return {
+            "route_id": "business-growth",
+            "profile": "business-growth",
+            "owner": "business-growth",
+            "confidence": 4.0,
+            "advisory_mode": True,
+            "auto_execute": False,
+        }
+
+    monkeypatch.setattr("hermes_cli.web_server.classify_route_advisory", fake_classify)
+
+    client = _client()
+    response = client.post(
+        "/api/route",
+        json={
+            "prompt": "Prepare BMI ASCAP radio promotion plan",
+            "surface": "dashboard:composer",
+        },
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["route_id"] == "business-growth"
+    assert body["profile"] == "business-growth"
+    assert body["auto_execute"] is False
+
+
+def test_dashboard_route_advisory_requires_prompt(_isolate_hermes_home):
+    client = _client()
+    response = client.post("/api/route", json={"prompt": "   "})
+
+    assert response.status_code == 400

--- a/tests/hermes_cli/test_route_advisory.py
+++ b/tests/hermes_cli/test_route_advisory.py
@@ -28,17 +28,25 @@ def test_classify_route_advisory_normalizes_and_logs(monkeypatch, tmp_path):
         "is_live": True,
     }
 
+    captured = {}
+
     def fake_run(args, **kwargs):
-        assert args[:2] == ["/bin/hermes-route-test", "--json"]
+        captured["args"] = args
+        captured["kwargs"] = kwargs
+        assert args == ["/bin/hermes-route-test", "--json", "--stdin"]
         return SimpleNamespace(returncode=0, stdout=json.dumps(payload), stderr="")
 
     monkeypatch.setattr("hermes_cli.route_advisory.subprocess.run", fake_run)
 
+    confidential_text = "Use Bearer abcdefghijklmnopqrstuvwxyz123456 for confidential BMI radio registration notes"
     advisory = classify_route_advisory(
-        "Use Bearer abcdefghijklmnopqrstuvwxyz123456 for BMI radio registration",
+        confidential_text,
         surface="cron:create",
         command="/bin/hermes-route-test",
     )
+
+    assert confidential_text not in captured["args"]
+    assert captured["kwargs"]["input"] == confidential_text
 
     assert advisory["route_id"] == "business-growth"
     assert advisory["profile"] == "business-growth"
@@ -53,8 +61,9 @@ def test_classify_route_advisory_normalizes_and_logs(monkeypatch, tmp_path):
     assert records[0]["surface"] == "cron:create"
     assert records[0]["route_id"] == "business-growth"
     assert records[0]["prompt_sha256"]
-    assert "Bearer abc" not in records[0]["prompt_preview"]
-    assert "[REDACTED]" in records[0]["prompt_preview"]
+    assert records[0]["prompt_length"] == len(confidential_text)
+    assert "prompt_preview" not in records[0]
+    assert "confidential BMI radio registration notes" not in json.dumps(records[0])
 
 
 def test_classify_route_advisory_timeout_falls_back_to_macos(monkeypatch, tmp_path):

--- a/tests/hermes_cli/test_route_advisory.py
+++ b/tests/hermes_cli/test_route_advisory.py
@@ -1,0 +1,94 @@
+import json
+import subprocess
+from pathlib import Path
+from types import SimpleNamespace
+
+from hermes_cli.route_advisory import classify_route_advisory, format_route_advisory
+
+
+def test_classify_route_advisory_normalizes_and_logs(monkeypatch, tmp_path):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+
+    payload = {
+        "route_id": "business-growth",
+        "route_name": "Business-Growth",
+        "owner": "business-growth",
+        "profile": "business-growth",
+        "prompt_class": "business",
+        "action": "Route to Business-Growth (requires approval)",
+        "blocked": False,
+        "blocked_actions": ["unapproved_account_access"],
+        "requires_approval": True,
+        "reason": "Requires future approval.",
+        "confidence": 5,
+        "advisory_mode": True,
+        "auto_execute": False,
+        "is_live": True,
+    }
+
+    def fake_run(args, **kwargs):
+        assert args[:2] == ["/bin/hermes-route-test", "--json"]
+        return SimpleNamespace(returncode=0, stdout=json.dumps(payload), stderr="")
+
+    monkeypatch.setattr("hermes_cli.route_advisory.subprocess.run", fake_run)
+
+    advisory = classify_route_advisory(
+        "Use Bearer abcdefghijklmnopqrstuvwxyz123456 for BMI radio registration",
+        surface="cron:create",
+        command="/bin/hermes-route-test",
+    )
+
+    assert advisory["route_id"] == "business-growth"
+    assert advisory["profile"] == "business-growth"
+    assert advisory["advisory_mode"] is True
+    assert advisory["auto_execute"] is False
+    assert advisory["requires_approval"] is True
+    assert advisory["blocked_actions"] == ["unapproved_account_access"]
+
+    log_path = home / "logs" / "routing_decisions.jsonl"
+    records = [json.loads(line) for line in log_path.read_text().splitlines()]
+    assert len(records) == 1
+    assert records[0]["surface"] == "cron:create"
+    assert records[0]["route_id"] == "business-growth"
+    assert records[0]["prompt_sha256"]
+    assert "Bearer abc" not in records[0]["prompt_preview"]
+    assert "[REDACTED]" in records[0]["prompt_preview"]
+
+
+def test_classify_route_advisory_timeout_falls_back_to_macos(monkeypatch, tmp_path):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+
+    def fake_run(args, **kwargs):
+        raise subprocess.TimeoutExpired(args, timeout=1.0)
+
+    monkeypatch.setattr("hermes_cli.route_advisory.subprocess.run", fake_run)
+
+    advisory = classify_route_advisory(
+        "What should I work on next?",
+        surface="gateway:telegram",
+        command="/bin/hermes-route-test",
+    )
+
+    assert advisory["route_id"] == "main-hermes"
+    assert advisory["profile"] == "macos"
+    assert advisory["auto_execute"] is False
+    assert advisory["error"] == "hermes-route timeout"
+    assert (home / "logs" / "routing_decisions.jsonl").exists()
+
+
+def test_format_route_advisory_is_advisory_only():
+    text = format_route_advisory({
+        "route_id": "design-media",
+        "profile": "design-media",
+        "confidence": 3,
+        "requires_approval": True,
+        "blocked_actions": ["raw_client_data_upload"],
+    })
+
+    assert "design-media -> profile design-media" in text
+    assert "advisory-only, no auto-switch" in text
+    assert "approval required" in text


### PR DESCRIPTION
## Summary

- Adds R1 route-advisory surfaces across Hermes CLI/API, gateway, cron metadata, and Desktop composer UI.
- Keeps R1 advisory-only: no automatic profile switch, no specialist auto-execution, and advisory payloads normalize `auto_execute=false`.
- Tightens route-advisory privacy: route logs are metadata-only, Desktop draft advisory calls default to `log=false`, and helper subprocess prompt text is passed via stdin instead of argv.

## Test plan

Fresh local verification before opening this PR:

- `git diff --check origin/main...HEAD` — clean
- `git merge-tree --write-tree origin/main HEAD` — exit 0 / clean merge-tree preflight
- `PYTHONPATH=$WT python -m py_compile hermes_cli/route_advisory.py hermes_cli/web_server.py gateway/run.py cron/jobs.py` — passed
- `PYTHONPATH=$WT python -m pytest tests/hermes_cli/test_route_advisory.py tests/hermes_cli/test_dashboard_route_advisory.py tests/gateway/test_route_advisory.py tests/cron/test_jobs.py -q` — 97 passed in 6.30s
- `npm --prefix apps/desktop run test:ui -- --run src/hermes.test.ts src/app/chat/composer/route-advisory-banner.test.tsx` — 2 files / 6 tests passed
- `npm --prefix apps/desktop run typecheck` — exit 0

Notes:

- Branch head: `085606fa65a1c4f92eb2118c70fd75a8f110f5eb`
- Current upstream base observed before PR creation: `9c3c5da356c34c27fd4709eab88cb41e9591a719`
- The branch is 2 commits ahead / 2 commits behind current `origin/main`; merge-tree preflight was clean, but the fresh automated tests above were run on the PR branch head rather than a materialized merge commit.
