### PR TITLE
fix: keep initial blocked kanban tasks sticky

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -2864,10 +2864,16 @@ def _has_sticky_block(conn: sqlite3.Connection, task_id: str) -> bool:
     no ``"unblocked"`` event has fired since), the task is sticky and
     ``recompute_ready`` must *not* auto-promote it.
 
-    Returns ``False`` when there is no such event at all (e.g. the task
-    was set to ``status='blocked'`` by the circuit breaker or by direct
-    DB manipulation) — preserves the pre-#28712 auto-recover semantics
-    for that path.
+    When no block/unblock event exists, a task created directly with
+    ``initial_status='blocked'`` is also sticky: the ``created`` event
+    payload records ``status='blocked'`` and represents an explicit
+    operator parking state, not a circuit-breaker recovery candidate.
+
+    Returns ``False`` when there is no such event at all and the task was
+    not initially created blocked (e.g. the task was set to
+    ``status='blocked'`` by the circuit breaker or by direct DB
+    manipulation) — preserves the pre-#28712 auto-recover semantics for
+    that path.
     """
     row = conn.execute(
         "SELECT kind FROM task_events "
@@ -2875,7 +2881,22 @@ def _has_sticky_block(conn: sqlite3.Connection, task_id: str) -> bool:
         "ORDER BY id DESC LIMIT 1",
         (task_id,),
     ).fetchone()
-    return bool(row) and row["kind"] == "blocked"
+    if row:
+        return row["kind"] == "blocked"
+
+    created = conn.execute(
+        "SELECT payload FROM task_events "
+        "WHERE task_id = ? AND kind = 'created' "
+        "ORDER BY id ASC LIMIT 1",
+        (task_id,),
+    ).fetchone()
+    if not created or not created["payload"]:
+        return False
+    try:
+        payload = json.loads(created["payload"])
+    except (TypeError, json.JSONDecodeError):
+        return False
+    return isinstance(payload, dict) and payload.get("status") == "blocked"
 
 
 def recompute_ready(

--- a/tests/hermes_cli/test_kanban_blocked_sticky.py
+++ b/tests/hermes_cli/test_kanban_blocked_sticky.py
@@ -100,6 +100,35 @@ def test_worker_block_on_child_with_done_parents_is_still_sticky(kanban_home: Pa
 
 
 # ---------------------------------------------------------------------------
+# Operator-created blocked tasks are parking brakes, not dispatch candidates
+# ---------------------------------------------------------------------------
+
+
+def test_initial_status_blocked_is_not_auto_promoted_by_recompute_ready(kanban_home: Path) -> None:
+    """A task created with ``initial_status='blocked'`` is an explicit
+    operator parking state.  It must not be promoted by the dispatcher just
+    because it has no parents; only an explicit unblock/promote action should
+    release it."""
+    with kb.connect() as conn:
+        tid = kb.create_task(
+            conn,
+            title="parked before dispatch",
+            assignee="research-assistant",
+            initial_status="blocked",
+        )
+        task = kb.get_task(conn, tid)
+        assert task is not None
+        assert task.status == "blocked"
+
+        promoted = kb.recompute_ready(conn)
+
+        assert promoted == 0
+        task = kb.get_task(conn, tid)
+        assert task is not None
+        assert task.status == "blocked"
+
+
+# ---------------------------------------------------------------------------
 # Circuit-breaker blocks still auto-recover (preserve #40c1decb3 intent)
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
- Keep Kanban tasks created with `initial_status='blocked'` sticky during `recompute_ready()`.
- Detect the initial blocked state from the task creation event payload.
- Add regression coverage for blocked-at-create tasks not being auto-promoted.

## Test Plan
- `HOME=/home/moshe scripts/run_tests.sh tests/hermes_cli/test_kanban_blocked_sticky.py`
- `git diff --check origin/main...HEAD`
- final-newline check for touched files
