### PR TITLE
fix(hermes_state): persist billing provider/base_url after mid-session /model switch

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -1708,6 +1708,27 @@ def switch_model(agent, new_model, new_provider, api_key='', base_url='', api_mo
         old_model, old_provider, new_model, new_provider,
     )
 
+    # ── Persist billing route to session DB ──
+    # The agent's _session_db / session_id may not be set in all contexts
+    # (tests, bare agents without a session DB, etc.).  This ensures the
+    # dashboard Model cards show the actual provider after a mid-session
+    # /model switch instead of the stale session-creation provider.
+    # See #48248 for the full bug description.
+    _session_db = getattr(agent, "_session_db", None)
+    _session_id = getattr(agent, "session_id", None)
+    if _session_db is not None and _session_id:
+        try:
+            _session_db.update_session_billing_route(
+                _session_id,
+                provider=agent.provider,
+                base_url=agent.base_url,
+                billing_mode=getattr(agent, "api_mode", None),
+            )
+        except Exception:
+            logger.warning(
+                "Failed to persist billing route after model switch",
+                exc_info=True,
+            )
 
 
 def invoke_tool(agent, function_name: str, function_args: dict, effective_task_id: str,

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -1516,6 +1516,36 @@ class SessionDB:
             )
         self._execute_write(_do)
 
+    def update_session_billing_route(
+        self,
+        session_id: str,
+        *,
+        provider: str,
+        base_url: str,
+        billing_mode: Optional[str] = None,
+    ) -> None:
+        """Unconditionally update the billing provider/base_url for a session.
+
+        Unlike ``update_token_counts`` which uses ``COALESCE(billing_provider, ?)``
+        (only filling in NULL), this unconditionally sets the billing fields so
+        that the dashboard reflects the user's latest /model switch.
+
+        Also nulls ``system_prompt`` so the cached snapshot (which embeds a
+        stale ``Model:`` / ``Provider:`` header) is rebuilt — matching the
+        behavior of ``update_session_model`` (see #48173, #48248).
+        """
+        def _do(conn):
+            conn.execute(
+                """UPDATE sessions SET
+                   billing_provider = ?,
+                   billing_base_url = ?,
+                   billing_mode = COALESCE(?, billing_mode),
+                   system_prompt = NULL
+                   WHERE id = ?""",
+                (provider, base_url, billing_mode, session_id),
+            )
+        self._execute_write(_do)
+
     def update_token_counts(
         self,
         session_id: str,


### PR DESCRIPTION
## Summary

Persist `billing_provider`, `billing_base_url`, and `billing_mode` in the session database after a mid-session `/model` switch, so the dashboard Model cards show the correct provider badge and token usage/cost is attributed to the right provider.

## Root Cause

The session database records `billing_provider` / `billing_base_url` using `COALESCE(column, ?)` in `update_token_counts()`, making them **write-once** — the first value written at session creation is permanently locked. When a user switches models mid-session via `/model`, the runtime (`agent.provider`, `agent.base_url`) updates correctly, but the session row never reflects the new provider.

The maintainers already recognized this `COALESCE` problem for the `model` column and added `update_session_model()` — an unconditional `UPDATE sessions SET model = ? WHERE id = ?`. This PR extends the same pattern to billing fields.

## Changes

### `hermes_state.py` — new `update_session_billing_route()` method

Unconditionally sets `billing_provider`, `billing_base_url`, and `billing_mode` (no `COALESCE`), matching the pattern of `update_session_model()`. Also nulls `system_prompt` so the cached snapshot (which embeds a stale `Model:` / `Provider:` header) is rebuilt.

### `agent/agent_runtime_helpers.py` — call from `switch_model()`

After a successful model/provider swap, persist the billing route to the session DB. Uses `getattr` guards so the call is safe for tests and bare agents without a session DB.

## Test Plan

- [x] `update_session_billing_route()` follows the same `_execute_write(_do)` pattern as `update_session_model()`
- [x] `switch_model()` call is guarded by `getattr` for agent contexts without `_session_db` / `session_id`
- [x] Existing `update_session_model()` / `update_token_counts()` tests remain unaffected (no schema changes)

Closes #48248