### PR TITLE
fix(darwinian-evolver): render model-proposed prompts in a Jinja sandbox

### DIFF
--- a/optional-skills/research/darwinian-evolver/scripts/parrot_openrouter.py
+++ b/optional-skills/research/darwinian-evolver/scripts/parrot_openrouter.py
@@ -17,6 +17,7 @@ import sys
 from pathlib import Path
 
 import jinja2
+from jinja2.sandbox import SandboxedEnvironment
 from openai import OpenAI
 
 # Vendored problem types from upstream (AGPL — only run via subprocess in production)
@@ -33,6 +34,19 @@ from darwinian_evolver.problem import Organism
 from darwinian_evolver.problem import Problem
 
 DEFAULT_MODEL = os.environ.get("EVOLVER_MODEL", "openai/gpt-4o-mini")
+
+# Prompt templates rendered here come from LLM output (the mutator asks the model
+# to propose a new prompt template and stores it on the organism), so the
+# template *source* is untrusted. Rendering untrusted source with the default
+# ``jinja2.Template`` allows server-side template injection — e.g.
+# ``{{ ''.__class__.__mro__[1].__subclasses__() }}`` reaches arbitrary Python
+# objects and, from there, code execution. Render through a SandboxedEnvironment
+# instead, which blocks access to unsafe attributes/builtins while still
+# evaluating ordinary expressions (so a legitimate ``{{ phrase }}`` template
+# keeps working). Autoescape is intentionally left off: these templates build a
+# plaintext prompt for an LLM (not HTML), and the evolver compares the model's
+# echo against the exact phrase, so HTML-escaping would corrupt the output.
+_JINJA_SANDBOX = SandboxedEnvironment()
 
 
 def _client() -> OpenAI:
@@ -62,7 +76,13 @@ class ParrotOrganism(Organism):
 
     def run(self, phrase: str) -> str:
         try:
-            prompt = jinja2.Template(self.prompt_template).render(phrase=phrase)
+            # self.prompt_template is LLM-proposed (untrusted source) — render it
+            # in the sandbox. SecurityError subclasses TemplateError, so a
+            # blocked injection attempt is caught here and the organism simply
+            # scores low instead of executing attacker-controlled code.
+            prompt = _JINJA_SANDBOX.from_string(self.prompt_template).render(
+                phrase=phrase
+            )
         except jinja2.exceptions.TemplateError as e:
             return f"Error rendering prompt: {e}"
         if not prompt:
@@ -104,7 +124,10 @@ template in the LAST triple-backtick block of your response.
         learning_log_entries: list[LearningLogEntry],
     ) -> list[ParrotOrganism]:
         fc = failure_cases[0]
-        prompt = jinja2.Template(self.IMPROVEMENT_PROMPT_TEMPLATE).render(
+        # IMPROVEMENT_PROMPT_TEMPLATE is a trusted constant, but it interpolates
+        # model-derived values (organism.prompt_template, fc.response); render in
+        # the sandbox too for consistency and defense in depth.
+        prompt = _JINJA_SANDBOX.from_string(self.IMPROVEMENT_PROMPT_TEMPLATE).render(
             organism=organism, failure_case=fc
         )
         try:

--- a/tests/skills/test_darwinian_evolver_skill.py
+++ b/tests/skills/test_darwinian_evolver_skill.py
@@ -10,7 +10,10 @@ so these tests verify:
 from __future__ import annotations
 
 import ast
+import importlib.util
 import re
+import sys
+import types
 from pathlib import Path
 
 import pytest
@@ -100,3 +103,137 @@ def test_skill_pitfalls_section_present() -> None:
     # Pitfalls we discovered during the spike — keep them in sync with reality.
     assert "Initial organism must be viable" in src
     assert "generator" in src  # loop.run() pitfall
+
+
+# ---------------------------------------------------------------------------
+# SSTI hardening: model-proposed prompt templates must be rendered sandboxed
+# ---------------------------------------------------------------------------
+
+
+def _load_parrot_module():
+    """Import parrot_openrouter.py with its heavy/optional deps stubbed.
+
+    The script imports ``openai`` and the upstream (AGPL, installed at runtime
+    via ``uv --project``) ``darwinian_evolver`` package — neither is available
+    in the hermetic test env. We register minimal stand-ins in ``sys.modules``
+    so the *real* ``ParrotOrganism`` / ``ImproveParrotMutator`` classes load and
+    we can exercise the actual Jinja render path.
+    """
+
+    class _Base:
+        def __init__(self, **kw):
+            self.__dict__.update(kw)
+
+        def __class_getitem__(cls, item):  # support Generic[...] subscription
+            return cls
+
+    def _mod(name):
+        m = types.ModuleType(name)
+        sys.modules[name] = m
+        return m
+
+    openai = _mod("openai")
+
+    class _OpenAI:
+        def __init__(self, *a, **k):
+            ...
+
+    openai.OpenAI = _OpenAI
+
+    _mod("darwinian_evolver")
+    cc = _mod("darwinian_evolver.cli_common")
+    cc.build_hyperparameter_config_from_args = lambda *a, **k: None
+    cc.register_hyperparameter_args = lambda *a, **k: None
+    cc.parse_learning_log_view_type = lambda *a, **k: None
+    _mod("darwinian_evolver.evolve_problem_loop").EvolveProblemLoop = _Base
+    _mod("darwinian_evolver.learning_log").LearningLogEntry = _Base
+    prob = _mod("darwinian_evolver.problem")
+    for _n in (
+        "EvaluationFailureCase",
+        "EvaluationResult",
+        "Evaluator",
+        "Mutator",
+        "Organism",
+        "Problem",
+    ):
+        setattr(prob, _n, _Base)
+
+    path = SKILL_DIR / "scripts" / "parrot_openrouter.py"
+    spec = importlib.util.spec_from_file_location("parrot_openrouter_under_test", path)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+@pytest.fixture()
+def parrot(monkeypatch):
+    mod = _load_parrot_module()
+    # Never hit the network: make the LLM call echo its rendered prompt so the
+    # tests can observe exactly what the template produced.
+    monkeypatch.setattr(mod, "_prompt_llm", lambda prompt: f"RENDERED:{prompt}")
+    return mod
+
+
+# A classic SSTI escape: reach into Python object internals via attribute
+# access. Non-weaponized — it only reads a count of subclasses, but on an
+# unsandboxed renderer this same chain leads to arbitrary code execution.
+_SSTI_PAYLOAD = "{{ ''.__class__.__mro__[1].__subclasses__()|length }}"
+
+
+def test_model_template_ssti_is_blocked(parrot):
+    """A model-proposed template that escapes to object internals must not render.
+
+    On the unpatched tree ``jinja2.Template`` evaluates the attribute chain and
+    returns a number (proof the sandbox escape worked). On the patched tree the
+    SandboxedEnvironment raises SecurityError (a TemplateError subclass), which
+    ``ParrotOrganism.run`` catches and surfaces as a render error.
+    """
+    out = parrot.ParrotOrganism(prompt_template=_SSTI_PAYLOAD).run("anything")
+
+    assert out.startswith("Error rendering prompt:"), (
+        f"expected the sandbox to reject the injection, got {out!r}"
+    )
+    assert "unsafe" in out  # SecurityError message from the sandbox
+    # The escape must not have produced its numeric result.
+    assert not out.startswith("RENDERED:")
+
+
+def test_benign_template_still_evaluates(parrot):
+    """Ordinary expressions must still render — the sink stays a live template."""
+    out = parrot.ParrotOrganism(prompt_template="{{ 7*7 }}").run("anything")
+    assert out == "RENDERED:49"
+
+
+def test_phrase_substitution_is_verbatim(parrot):
+    """``{{ phrase }}`` must pass the phrase through unchanged (no HTML escaping).
+
+    Autoescape is intentionally off: the rendered text is a plaintext LLM prompt
+    and the evolver compares the model's echo against the exact phrase, so a
+    quoted phrase must survive byte-for-byte.
+    """
+    out = parrot.ParrotOrganism(prompt_template="Say {{ phrase }}").run('"bla bla".')
+    assert out == 'RENDERED:Say "bla bla".'
+
+
+def test_mutator_to_run_cycle_is_sandboxed(parrot):
+    """End-to-end (the PoC fuzz target): a malicious template the *mutator*
+    extracts from model output is also rendered sandboxed when the resulting
+    organism runs."""
+    # Drive ImproveParrotMutator.mutate with model output whose LAST fenced block
+    # is the SSTI payload, exactly as the real parsing expects.
+    fenced = f"Here is an improved template:\n```\n{_SSTI_PAYLOAD}\n```"
+    parrot._prompt_llm = lambda prompt: fenced  # the mutate() call
+
+    fc = parrot.ParrotEvaluationFailureCase(
+        phrase="bla", response="nope", data_point_id="t0"
+    )
+    seed = parrot.ParrotOrganism(prompt_template="Say {{ phrase }}")
+    children = parrot.ImproveParrotMutator().mutate(seed, [fc], [])
+    assert children, "mutator should have produced a child organism"
+    assert children[0].prompt_template == _SSTI_PAYLOAD
+
+    # Now the child runs; restore the echo stub so we'd *see* any leaked render.
+    parrot._prompt_llm = lambda prompt: f"RENDERED:{prompt}"
+    out = children[0].run("anything")
+    assert out.startswith("Error rendering prompt:")
+    assert not out.startswith("RENDERED:")


### PR DESCRIPTION
## What does this PR do?

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->

Hardens the **darwinian-evolver** optional research skill against server-side
template injection (SSTI) when it renders LLM-proposed prompt templates.

The parrot driver
(`optional-skills/research/darwinian-evolver/scripts/parrot_openrouter.py`)
evolves prompt templates by asking the model to propose an improved template,
parsing the model's text out of the last fenced block, and storing it on the
organism. `ParrotOrganism.run` then renders that stored text as a Jinja
template *source* with the default renderer:

```python
# ParrotOrganism.run
prompt = jinja2.Template(self.prompt_template).render(phrase=phrase)
```

Because `self.prompt_template` is model output used as the template **source**
(not just an interpolated value), the default `jinja2.Template` renderer
evaluates whatever Jinja expressions the model emits. A proposed template that
walks Python object internals via attribute access can therefore reach arbitrary
objects and, from there, code execution in the local process.

The skill is opt-in — it is not on Hermes' default execution path, ships as an
optional skill that the user must explicitly install/run, and needs
user-supplied API credentials — but it is a genuine model-output-to-template
sink, so it is worth closing at the source.

Why this approach: the minimal control that closes this sink class is to render
model-derived template source through Jinja's `SandboxedEnvironment` instead of
the default `jinja2.Template`. The sandbox blocks the unsafe attribute/builtin
chain while still evaluating normal expressions, so legitimate templates keep
working, no public signature changes, and no new dependency is added (`jinja2`
is already pinned in the project).

### Affected sites

- `optional-skills/research/darwinian-evolver/scripts/parrot_openrouter.py:65`
  — `ParrotOrganism.run` renders the model-proposed `self.prompt_template`
  (the decisive sink).

A second render of the trusted developer constant
`IMPROVEMENT_PROMPT_TEMPLATE` in `ImproveParrotMutator.mutate` (around line 107)
only interpolates values, not source, so it is not the injection point; it is
routed through the same sandbox for consistency and defense in depth.

## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Fixes #

## Type of Change

<!-- Check the one that applies. -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [x] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- `optional-skills/research/darwinian-evolver/scripts/parrot_openrouter.py`
  - Import `SandboxedEnvironment` from `jinja2.sandbox` and add one
    module-level `_JINJA_SANDBOX = SandboxedEnvironment()`.
  - Render both call sites (`ParrotOrganism.run` and the developer template in
    `ImproveParrotMutator.mutate`) via `_JINJA_SANDBOX.from_string(...)` instead
    of `jinja2.Template(...)`.
- `tests/skills/test_darwinian_evolver_skill.py`
  - Add regression tests (heavy/optional deps stubbed, no network) that exercise
    the real render path, including the full mutate → run cycle.

Notes on the approach:

- `jinja2` is already a project dependency (`jinja2==3.1.6`); no new dependency
  is introduced and no public signatures change.
- The sandbox blocks unsafe attribute/builtin access but still evaluates normal
  expressions, so `{{ phrase }}` and `{{ 7*7 }}` keep working. `SecurityError`
  subclasses `TemplateError`, which `run()` already catches, so a blocked
  injection simply makes that organism score low instead of executing — no new
  error handling needed.
- **Autoescape is intentionally left off.** These templates produce a *plaintext
  prompt* for an LLM (not HTML), and the evolver compares the model's echo to
  the exact phrase, so HTML-escaping would corrupt legitimate output. The
  control that closes the SSTI here is the sandbox, not escaping. This is
  documented in a comment at the environment definition.

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. `pytest tests/skills/test_darwinian_evolver_skill.py -q` → all pass (18
   passed: 14 pre-existing + 4 new).
2. Revert just the script to `main` and re-run with the tests kept: the SSTI
   regression tests (`test_model_template_ssti_is_blocked`,
   `test_mutator_to_run_cycle_is_sandboxed`) fail because the model-proposed
   template is evaluated by the unsandboxed renderer (2 failed, 16 passed),
   confirming the sandbox is what closes the sink.
3. Benign behavior is asserted by `test_benign_template_still_evaluates`
   (`{{ 7*7 }}` → `49`) and `test_phrase_substitution_is_verbatim`
   (`Say {{ phrase }}` with a quoted phrase renders unchanged), proving the
   change is backward-compatible and that autoescape-off is preserved.

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Python 3.11)

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A (behavior-preserving security fix; rationale captured in a code comment at the sandbox definition)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A (no config keys added/changed)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A (no architecture/workflow change)
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — pure Python + Jinja sandbox, no platform-specific behavior
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A (no tool description/schema change)

## For New Skills

<!-- Only fill this out if you're adding a skill. Delete this section otherwise. -->

N/A — this hardens an existing optional skill; no new skill is added.

- [ ] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [ ] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

Targeted test run on the fix (full file, 14 pre-existing + 4 new):

```
tests/skills/test_darwinian_evolver_skill.py::test_model_template_ssti_is_blocked PASSED [ 83%]
tests/skills/test_darwinian_evolver_skill.py::test_benign_template_still_evaluates PASSED [ 88%]
tests/skills/test_darwinian_evolver_skill.py::test_phrase_substitution_is_verbatim PASSED [ 94%]
tests/skills/test_darwinian_evolver_skill.py::test_mutator_to_run_cycle_is_sandboxed PASSED [100%]
============================== 18 passed in 0.09s ==============================
```

Same tests with the script reverted to base (proving the sink is live):

```
FAILED tests/skills/test_darwinian_evolver_skill.py::test_model_template_ssti_is_blocked
FAILED tests/skills/test_darwinian_evolver_skill.py::test_mutator_to_run_cycle_is_sandboxed
========================= 2 failed, 16 passed in 0.09s =========================
```

Lint (`ruff check` on both changed files): `All checks passed!`
