### PR TITLE
fix(agent): clear persisted system prompt on mid-session model switch (#48173)

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -1489,6 +1489,15 @@ def switch_model(agent, new_model, new_provider, api_key='', base_url='', api_mo
     # ── Invalidate cached system prompt so it rebuilds next turn ──
     agent._cached_system_prompt = None
 
+    # Also invalidate the persisted system prompt in the session DB so
+    # gateway turns (which construct fresh AIAgent instances and restore
+    # from DB) don't resurrect the old Model:/Provider: header.
+    if hasattr(agent, "_session_db") and agent._session_db and agent.session_id:
+        try:
+            agent._session_db.update_system_prompt(agent.session_id, "")
+        except Exception:
+            pass  # non-fatal — cache invalidation still works in-memory
+
     # ── Update _primary_runtime so the change persists across turns ──
     _cc = agent.context_compressor if hasattr(agent, "context_compressor") and agent.context_compressor else None
     agent._primary_runtime = {


### PR DESCRIPTION
Fixes #48173. After switch_model() clears _cached_system_prompt in memory, the gateway still reads the stale prompt from the session DB on the next turn. Now switch_model also clears the persisted system_prompt in the session DB so the gateway rebuilds it fresh with the new Model:/Provider: header.