### PR TITLE
fix(docker): chown /opt/hermes to hermes user for WebUI egg-info (#48198)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -151,7 +151,11 @@ RUN cd web && npm run build && \
 # fail to load.  See tools/lazy_deps.py.
 USER root
 RUN chmod -R a+rX /opt/hermes && \
-    chown -R hermes:hermes /opt/hermes/.venv /opt/hermes/ui-tui /opt/hermes/node_modules
+    chown -R hermes:hermes /opt/hermes/.venv /opt/hermes/ui-tui /opt/hermes/node_modules && \
+    # The /opt/hermes directory itself must be writable so that a
+    # second container sharing this path (WebUI) can run
+    # ``uv pip install /opt/hermes[all]`` which writes hermes_agent.egg-info/.
+    chown hermes:hermes /opt/hermes
 # Start as root so the s6-overlay stage2 hook can usermod/groupmod and chown
 # the data volume. Each supervised service then drops to the hermes user via
 # `s6-setuidgid hermes` in its run script. If HERMES_UID is unset, services


### PR DESCRIPTION
Fixes #48198. The Docker image shipped /opt/hermes as 555 root:root, preventing the WebUI container from creating hermes_agent.egg-info/ when running uv pip install /opt/hermes[all]. Now chown hermes:hermes /opt/hermes so the runtime user can write to it.