### PR TITLE
refactor(openviking): reuse atomic_json_write for ovcli config; drop dead constants

### DIFF
--- a/plugins/memory/openviking/__init__.py
+++ b/plugins/memory/openviking/__init__.py
@@ -48,13 +48,12 @@ from urllib.request import url2pathname
 from agent.memory_provider import MemoryProvider
 from agent.skill_commands import extract_user_instruction_from_skill_message
 from tools.registry import tool_error
+from utils import atomic_json_write
 
 logger = logging.getLogger(__name__)
 
 _DEFAULT_ENDPOINT = "http://127.0.0.1:1933"
 _OPENVIKING_SERVICE_ENDPOINT = "https://api.vikingdb.cn-beijing.volces.com/openviking"
-_DEFAULT_ACCOUNT = ""
-_DEFAULT_USER = ""
 _DEFAULT_AGENT = "hermes"
 _OVCLI_CONFIG_ENV = "OPENVIKING_CLI_CONFIG_FILE"
 _OVCLI_DEFAULT_RELATIVE_PATH = ".openviking/ovcli.conf"
@@ -828,10 +827,10 @@ def _ovcli_data_from_connection_values(values: dict) -> dict:
 
 def _write_ovcli_config(path: Path, values: dict) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
-    # Pre-create with 0600 so secrets are never briefly world-readable.
-    _precreate_secret_file(path)
-    path.write_text(json.dumps(_ovcli_data_from_connection_values(values), indent=2) + "\n", encoding="utf-8")
-    _restrict_secret_file_permissions(path)
+    # atomic_json_write creates the temp file with mode 0o600 and os.replace()s
+    # it into place — no half-written config on crash and no chmod-after-write
+    # TOCTOU window for the api_key/root_api_key it carries.
+    atomic_json_write(path, _ovcli_data_from_connection_values(values), mode=0o600)
 
 
 def _validate_openviking_reachability(endpoint: str) -> tuple[bool, str]:


### PR DESCRIPTION
Small follow-up cleanup on the OpenViking setup path merged in #48262.

## Changes
- `_write_ovcli_config` now uses `utils.atomic_json_write(path, data, mode=0o600)` instead of the local `_precreate_secret_file` + `write_text` + `chmod` sequence. The shared helper — already used by the honcho/mem0/supermemory/hindsight memory plugins — writes via temp-file + `fchmod(0600)` + `fsync` + `os.replace`, so the `ovcli.conf` (which carries `api_key`/`root_api_key`) is written **atomically** (no half-written secret file on crash) and with **no chmod-after-write TOCTOU window**. `_precreate_secret_file` stays for the `.env` writer path.
- Remove dead `_DEFAULT_ACCOUNT` / `_DEFAULT_USER` constants (0 references — the empty→`"default"` tenant fallback lives in the `_VikingClient` constructor).

## Testing
- `tests/plugins/memory/test_openviking_provider.py`, `tests/hermes_cli/test_memory_setup.py`, `tests/openviking_plugin/test_openviking.py` → **130 passed**
- `ruff check` clean; `py_compile` clean

Surfaced by a reuse/quality cleanup pass over the setup-UX work.
