### PR TITLE
feat(skills): add OKF v0.2 opt-in and migration to llm-wiki

### DIFF
--- a/skills/research/llm-wiki/SKILL.md
+++ b/skills/research/llm-wiki/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: llm-wiki
 description: "Karpathy's LLM Wiki: build/query interlinked markdown KB."
-version: 2.1.0
+version: 2.2.0
 author: Hermes Agent
 license: MIT
 platforms: [linux, macos, windows]
@@ -68,6 +68,86 @@ wiki/
 **Layer 2 — The Wiki:** Agent-owned markdown files. Created, updated, and
 cross-referenced by the agent.
 **Layer 3 — The Schema:** `SCHEMA.md` defines structure, conventions, and tag taxonomy.
+
+## Open Knowledge Format (OKF) — Optional Interoperability Standard
+
+The wiki layout above is *shaped* like a bundle in Google's
+[Open Knowledge Format (OKF) v0.2](https://github.com/GoogleCloudPlatform/knowledge-catalog/blob/main/okf/SPEC.md),
+an open standard for representing knowledge as a directory of markdown files
+with YAML frontmatter
+([announcement](https://cloud.google.com/blog/products/data-analytics/how-the-open-knowledge-format-can-improve-data-sharing)).
+Opting in gives the wiki a recognized interoperability contract, so any
+OKF-aware tool or agent can consume it without bespoke parsing.
+
+OKF is deliberately minimal. Its only hard requirements (§11) are:
+
+1. Every non-reserved `.md` file has a parseable YAML frontmatter block.
+2. Every frontmatter block contains a non-empty `type` field.
+3. Reserved filenames (`index.md`, `log.md`) follow §8 and §9 when present.
+
+**A default wiki is not conformant yet.** Three gaps have to be closed first,
+which is what the migration below does:
+
+- `SCHEMA.md` and the `raw/` sources carry no `type` (`raw/` frontmatter has
+  only `source_url`/`ingested`/`sha256`), so they fail rule 2 — and `SCHEMA.md`
+  has no frontmatter at all, failing rule 1.
+- `log.md` uses `## [YYYY-MM-DD] action | subject`, but §9 requires a bare
+  ISO 8601 `## YYYY-MM-DD` date heading.
+- `sources:` is a list of bare paths; OKF §5.1 wants an entry with a
+  `resource` key. This one is a soft issue, not a conformance failure.
+
+**What changes when a wiki opts in:**
+
+- **`type` is required** (§4.1). Type values are *not* registered centrally and
+  consumers MUST tolerate unknown ones, so any non-empty string is valid.
+  Title-Case (`Entity`, `Concept`, `Comparison`, `Query`, `Reference`) is a
+  convention borrowed from the spec's examples, not a requirement.
+- **Recommended fields** gain defined meaning: `title`, `description`,
+  `resource` (canonical URI of the underlying asset), `tags`. The existing
+  `created`/`updated`/`confidence`/`contested` fields are carried through as
+  extension keys — §4.1 says consumers preserve unknown keys and MUST NOT
+  reject a document for having them.
+- **Provenance moves to frontmatter** (§5.1): `sources` entries take a
+  `resource`, plus optional `id`, `title`, and the credibility signals
+  `author`, `usage_count`, `last_modified`.
+- **Trust and lifecycle become expressible** (§5.2–§5.5): `generated: { by, at }`,
+  `verified: [{ by, at }]`, `status`, `stale_after`. Actors use the §7
+  convention — `human:<id>`, `process:<id>`, or `<producer>/<version>`.
+- **Cross-links** MAY use bundle-relative markdown links (`[text](/path.md)`,
+  §6.1) for portability. `[[wikilinks]]` keep working; the migration does not
+  touch them, so Obsidian-first vaults are unaffected.
+- **`index.md`** carries no frontmatter except an optional `okf_version` at the
+  bundle root (§8).
+- **Broken links stay tolerated** (§6.1) and soft issues never invalidate a
+  bundle (§11) — so the OKF lint step reports them separately from the wiki's
+  own stricter broken-wikilink check.
+
+### Opting in
+
+`scripts/okf.py` does the migration and the conformance check. Every command is
+a dry run until `--write`, and every command is idempotent.
+
+```bash
+WIKI="${WIKI_PATH:-$HOME/wiki}"
+
+python3 scripts/okf.py check   "$WIKI"           # what fails today, and why
+python3 scripts/okf.py migrate "$WIKI"           # preview the opt-in
+python3 scripts/okf.py migrate "$WIKI" --write   # apply it
+```
+
+`migrate` adds the missing `type` fields, Title-Cases the known ones, rewrites
+`sources` entries to carry a `resource`, converts `log.md` to ISO date
+headings, and declares `okf_version: "0.2"` in the root `index.md`. It edits
+the frontmatter as text, so comments, key order, and the body survive
+unchanged. Ask the user before running `--write` on a wiki you did not create —
+it rewrites every page's frontmatter.
+
+Wikis already on OKF v0.1 upgrade with `python3 scripts/okf.py upgrade "$WIKI"`,
+which applies the two §13.1 breaking changes: `timestamp` becomes
+`generated.at`, and a body `# Citations` list becomes `sources` frontmatter.
+
+Add `--json` to any command for machine-readable output. `check` exits non-zero
+on a hard failure, so it works as a pre-commit or CI gate on a shared wiki.
 
 ## Resuming an Existing Wiki (CRITICAL — do this every session)
 
@@ -141,6 +221,26 @@ Adapt to the user's domain. The schema constrains agent behavior and ensures con
   confidence: high | medium | low        # how well-supported the claims are
   contested: true                        # set when the page has unresolved contradictions
   contradictions: [other-page-slug]      # pages this one conflicts with
+  ---
+  ```
+
+When the wiki has opted in to OKF, `type` is Title-Case and `sources` entries
+carry a `resource` (see the OKF section above). `scripts/okf.py migrate`
+converts an existing wiki to that form; new pages should be written in it
+directly:
+
+  ```yaml
+  ---
+  title: Page Title
+  created: YYYY-MM-DD
+  updated: YYYY-MM-DD
+  type: Entity                           # Title-Case under OKF
+  description: One-line summary for index generators and search snippets.
+  tags: [from taxonomy below]
+  sources:
+    - id: source-name
+      resource: /raw/articles/source-name.md
+  generated: { by: human:<id>, at: YYYY-MM-DDTHH:MM:SSZ }
   ---
   ```
 
@@ -360,10 +460,19 @@ wiki = "<WIKI_PATH>"
 
 ⑪ **Log rotation:** If log.md exceeds 500 entries, rotate it.
 
-⑫ **Report findings** with specific file paths and suggested actions, grouped by
+⑫ **OKF conformance (when opted in):** If the root `index.md` declares
+   `okf_version`, run `python3 scripts/okf.py check "$WIKI"`. It reports §11
+   hard failures (unparseable frontmatter, missing `type`, malformed reserved
+   files) separately from soft issues (bare-string `sources`, legacy
+   `timestamp`), because the spec says consumers MUST NOT reject a bundle over
+   the soft ones. Broken links are tolerated by OKF §6.1 — they still appear in
+   step ② under the wiki's own stricter rules, not as OKF failures.
+
+⑬ **Report findings** with specific file paths and suggested actions, grouped by
    severity (broken links > orphans > source drift > contested pages > stale content > style issues).
 
-⑬ **Append to log.md:** `## [YYYY-MM-DD] lint | N issues found`
+⑭ **Append to log.md:** `## [YYYY-MM-DD] lint | N issues found`
+   (under OKF, `## YYYY-MM-DD` with a `* **Lint**: N issues found` bullet)
 
 ## Working with the Wiki
 
@@ -496,8 +605,17 @@ vault in Obsidian on your laptop/phone — changes appear within seconds.
   The agent should check log size during lint.
 - **Handle contradictions explicitly** — don't silently overwrite. Note both claims with dates,
   mark in frontmatter, flag for user review.
+- **Preview the OKF migration before writing** — `scripts/okf.py migrate` rewrites frontmatter
+  across every page. Run it without `--write` first, and confirm with the user before applying
+  it to a wiki you did not create.
 
 ## Related Tools
+
+[Open Knowledge Format (OKF)](https://github.com/GoogleCloudPlatform/knowledge-catalog/blob/main/okf/SPEC.md)
+is Google's open spec for representing knowledge as markdown + YAML frontmatter.
+The wiki opts in via `scripts/okf.py` — see the OKF section above. Google ships
+no standalone validator; `scripts/okf.py` implements the §11 conformance rules
+directly against the spec text.
 
 [llm-wiki-compiler](https://github.com/atomicmemory/llm-wiki-compiler) is a Node.js CLI that
 compiles sources into a concept wiki with the same Karpathy inspiration. It's Obsidian-compatible,

--- a/skills/research/llm-wiki/scripts/okf.py
+++ b/skills/research/llm-wiki/scripts/okf.py
@@ -1,0 +1,452 @@
+#!/usr/bin/env python3
+"""OKF v0.2 conformance checker and migrator for an llm-wiki bundle.
+
+The wiki this skill builds is *shaped* like an Open Knowledge Format bundle
+but is not conformant out of the box: ``SCHEMA.md`` and the ``raw/`` sources
+carry no ``type``, ``log.md`` headings are ``## [DATE] action | subject``
+rather than ISO date headings, and ``sources:`` is a list of bare paths where
+OKF requires a ``resource`` per entry.  This script reports those gaps and,
+on request, closes them.
+
+Subcommands
+-----------
+  check WIKI     report OKF v0.2 conformance; exit 1 on a hard failure
+  migrate WIKI   bring a Karpathy-style wiki to OKF v0.2 (the opt-in)
+  upgrade WIKI   bring an existing OKF v0.1 bundle to v0.2
+
+Every subcommand is a dry run until ``--write`` is passed, and every one is
+idempotent: running it twice changes nothing the second time.  Edits are
+applied as targeted text surgery on the frontmatter block, never as a YAML
+reserialize, so comments, key order, and formatting survive untouched.
+
+Spec: https://github.com/GoogleCloudPlatform/knowledge-catalog/blob/main/okf/SPEC.md
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+
+try:
+    import yaml
+except ImportError:  # pragma: no cover - pyyaml ships with hermes
+    sys.exit("okf.py requires pyyaml (pip install pyyaml)")
+
+OKF_VERSION = "0.2"
+RESERVED = {"index.md", "log.md"}
+TYPE_MAP = {
+    "entity": "Entity",
+    "concept": "Concept",
+    "comparison": "Comparison",
+    "query": "Query",
+    "summary": "Summary",
+}
+SKIP_DIRS = {".git", ".obsidian", "_archive", "node_modules"}
+FM = re.compile(r"\A---\n(.*?)\n---[ \t]*\n?", re.DOTALL)
+LOG_ENTRY = re.compile(r"^##\s*\[(\d{4}-\d{2}-\d{2})\]\s*(\w+)\s*\|\s*(.*?)\s*$")
+ISO_DATE = re.compile(r"^##\s+(\d{4}-\d{2}-\d{2})\s*$")
+
+
+@dataclass
+class Report:
+    hard: list[str] = field(default_factory=list)
+    soft: list[str] = field(default_factory=list)
+    changes: list[str] = field(default_factory=list)
+
+    def as_dict(self) -> dict:
+        return {
+            "okf_version": OKF_VERSION,
+            "conformant": not self.hard,
+            "hard_failures": self.hard,
+            "soft_issues": self.soft,
+            "changes": self.changes,
+        }
+
+
+# ---------------------------------------------------------------------------
+# frontmatter surgery
+# ---------------------------------------------------------------------------
+
+
+def split_frontmatter(text: str) -> tuple[str | None, str]:
+    """Return (frontmatter_text, body). frontmatter_text is None when absent."""
+    m = FM.match(text)
+    if not m:
+        return None, text
+    return m.group(1), text[m.end() :]
+
+
+def parse_frontmatter(fm_text: str | None) -> dict | None:
+    if fm_text is None:
+        return None
+    try:
+        data = yaml.safe_load(fm_text)
+    except yaml.YAMLError:
+        return None
+    return data if isinstance(data, dict) else None
+
+
+def rebuild(fm_text: str, body: str) -> str:
+    return f"---\n{fm_text}\n---\n{body}"
+
+
+def insert_key(fm_text: str, key: str, value: str) -> str:
+    """Insert ``key: value`` at the top of a frontmatter block."""
+    return f"{key}: {value}\n{fm_text}" if fm_text.strip() else f"{key}: {value}"
+
+
+def replace_scalar(fm_text: str, key: str, new_line: str) -> str:
+    pattern = re.compile(rf"^{re.escape(key)}:[^\n]*$", re.MULTILINE)
+    return pattern.sub(lambda _m: new_line, fm_text, count=1)
+
+
+def md_files(wiki: Path):
+    for path in sorted(wiki.rglob("*.md")):
+        if any(part in SKIP_DIRS for part in path.relative_to(wiki).parts):
+            continue
+        yield path
+
+
+def concept_files(wiki: Path):
+    for path in md_files(wiki):
+        if path.name not in RESERVED:
+            yield path
+
+
+def default_type(wiki: Path, path: Path) -> str:
+    rel = path.relative_to(wiki)
+    if rel.parts[0] == "raw":
+        return "Source"
+    if path.name == "SCHEMA.md":
+        return "Reference"
+    return TYPE_MAP.get(rel.parts[0].rstrip("s").lower(), "Concept")
+
+
+# ---------------------------------------------------------------------------
+# check
+# ---------------------------------------------------------------------------
+
+
+def opted_in(wiki: Path) -> bool:
+    index = wiki / "index.md"
+    if not index.is_file():
+        return False
+    fm = parse_frontmatter(split_frontmatter(index.read_text(encoding="utf-8"))[0])
+    return bool(fm and fm.get("okf_version"))
+
+
+def check(wiki: Path) -> Report:
+    rep = Report()
+    for path in concept_files(wiki):
+        rel = path.relative_to(wiki)
+        fm_text, _ = split_frontmatter(path.read_text(encoding="utf-8"))
+        if fm_text is None:
+            rep.hard.append(f"{rel}: no YAML frontmatter block (§11.1)")
+            continue
+        fm = parse_frontmatter(fm_text)
+        if fm is None:
+            rep.hard.append(f"{rel}: frontmatter does not parse as a YAML mapping (§11.1)")
+            continue
+        if not str(fm.get("type") or "").strip():
+            rep.hard.append(f"{rel}: missing non-empty 'type' (§11.2)")
+        for entry in fm.get("sources") or []:
+            if isinstance(entry, str):
+                rep.soft.append(f"{rel}: sources entry {entry!r} has no 'resource' key (§5.1)")
+        if "timestamp" in fm and "generated" not in fm:
+            rep.soft.append(f"{rel}: legacy 'timestamp'; v0.2 uses generated.at (§13.1)")
+
+    for path in md_files(wiki):
+        if path.name != "index.md":
+            continue
+        rel = path.relative_to(wiki)
+        fm = parse_frontmatter(split_frontmatter(path.read_text(encoding="utf-8"))[0])
+        if fm is None:
+            continue
+        extra = set(fm) - {"okf_version"}
+        if extra or path.parent != wiki:
+            rep.hard.append(f"{rel}: index.md carries frontmatter beyond okf_version (§8)")
+
+    log = wiki / "log.md"
+    if log.is_file():
+        legacy = [
+            line
+            for line in log.read_text(encoding="utf-8").splitlines()
+            if LOG_ENTRY.match(line)
+        ]
+        if legacy:
+            rep.hard.append(
+                f"log.md: {len(legacy)} heading(s) are not ISO date headings (§9)"
+            )
+    return rep
+
+
+# ---------------------------------------------------------------------------
+# migrate: karpathy wiki -> OKF v0.2
+# ---------------------------------------------------------------------------
+
+
+def migrate_log(text: str) -> str:
+    """Rewrite ``## [DATE] action | subject`` into date-grouped §9 sections.
+
+    Legacy entries become one bullet per action with their detail lines nested
+    beneath, newest-first order preserved. Already-migrated logs are returned
+    byte-identical, so the rewrite is a one-pass fixpoint.
+    """
+    head: list[str] = []
+    order: list[str] = []
+    groups: dict[str, list[str]] = {}
+    current: str | None = None
+    legacy = False
+
+    for line in text.splitlines():
+        m = LOG_ENTRY.match(line)
+        iso = ISO_DATE.match(line)
+        if m or iso:
+            date = (m or iso).group(1)  # type: ignore[union-attr]
+            if date not in groups:
+                groups[date] = []
+                order.append(date)
+            current = date
+            if m:
+                legacy = True
+                action, subject = m.group(2), m.group(3)
+                bullet = f"* **{action.capitalize()}**"
+                groups[date].append(f"{bullet}: {subject}" if subject else bullet)
+            continue
+        if current is None:
+            head.append(line)
+        elif legacy and line.lstrip().startswith(("-", "*")) and groups[current]:
+            groups[current].append(f"  {line.lstrip()}")
+        else:
+            groups[current].append(line)
+
+    if not order or not legacy:
+        return text
+
+    out = "\n".join(head).rstrip()
+    for date in order:
+        body = "\n".join(groups[date]).strip("\n")
+        out += f"\n\n## {date}\n{body}" if body else f"\n\n## {date}"
+    return out.lstrip("\n") + "\n"
+
+
+def migrate(wiki: Path, rep: Report) -> dict[Path, str]:
+    edits: dict[Path, str] = {}
+
+    for path in concept_files(wiki):
+        rel = path.relative_to(wiki)
+        original = path.read_text(encoding="utf-8")
+        raw_fm, body = split_frontmatter(original)
+        created = raw_fm is None
+        fm_text = raw_fm or ""
+        fm = parse_frontmatter(fm_text) or {}
+
+        new_fm = fm_text
+        current = str(fm.get("type") or "").strip()
+        if not current:
+            new_fm = insert_key(new_fm, "type", default_type(wiki, path))
+            rep.changes.append(f"{rel}: + type: {default_type(wiki, path)}")
+        elif current in TYPE_MAP:
+            new_fm = replace_scalar(new_fm, "type", f"type: {TYPE_MAP[current]}")
+            rep.changes.append(f"{rel}: type {current} -> {TYPE_MAP[current]}")
+
+        sources = fm.get("sources")
+        if isinstance(sources, list) and any(isinstance(s, str) for s in sources):
+            rendered = ["sources:"]
+            for entry in sources:
+                if isinstance(entry, str):
+                    ref = entry if entry.startswith(("/", "http")) else f"/{entry}"
+                    rendered.append(f"  - id: {Path(entry).stem}")
+                    rendered.append(f"    resource: {ref}")
+                elif isinstance(entry, dict):
+                    rendered.append(f"  - {json.dumps(entry, default=str)}")
+            new_fm = re.sub(
+                r"^sources:[^\n]*(?:\n[ \t]+[^\n]*)*$",
+                lambda _m, block="\n".join(rendered): block,
+                new_fm,
+                count=1,
+                flags=re.MULTILINE,
+            )
+            rep.changes.append(f"{rel}: sources -> OKF entries with 'resource'")
+
+        updated = rebuild(new_fm, body) if (new_fm != fm_text or created) else original
+        if updated != original:
+            edits[path] = updated
+
+    index = wiki / "index.md"
+    if index.is_file():
+        original = index.read_text(encoding="utf-8")
+        raw_fm, body = split_frontmatter(original)
+        fm = parse_frontmatter(raw_fm) or {}
+        if str(fm.get("okf_version") or "") != OKF_VERSION:
+            declared = f'okf_version: "{OKF_VERSION}"'
+            new_fm = (
+                replace_scalar(raw_fm, "okf_version", declared)
+                if raw_fm is not None and "okf_version" in fm
+                else insert_key(raw_fm or "", "okf_version", f'"{OKF_VERSION}"')
+            )
+            edits[index] = rebuild(new_fm, body)
+            rep.changes.append(f"index.md: {declared}")
+
+    log = wiki / "log.md"
+    if log.is_file():
+        original = log.read_text(encoding="utf-8")
+        migrated = migrate_log(original)
+        if migrated != original:
+            edits[log] = migrated
+            rep.changes.append("log.md: headings -> ISO date groups (§9)")
+    return edits
+
+
+# ---------------------------------------------------------------------------
+# upgrade: OKF v0.1 bundle -> v0.2
+# ---------------------------------------------------------------------------
+
+
+def extract_citations(body: str) -> tuple[list[str], str]:
+    m = re.search(r"^#+\s*Citations\s*$", body, re.MULTILINE)
+    if not m:
+        return [], body
+    rest = body[m.end() :]
+    end = re.search(r"^#{1,6}\s+\S", rest, re.MULTILINE)
+    block = rest[: end.start()] if end else rest
+    items = re.findall(r"^\s*[-*]\s+(.*\S)\s*$", block, re.MULTILINE)
+    if not items:
+        return [], body
+    return items, body[: m.start()] + (rest[end.start() :] if end else "")
+
+
+def citation_entries(items: list[str]) -> list[str]:
+    out = ["sources:"]
+    for i, raw in enumerate(items, 1):
+        link = re.search(r"\[([^\]]+)\]\(([^)]+)\)", raw)
+        url = re.search(r"https?://\S+", raw)
+        if link:
+            title, resource = link.group(1), link.group(2)
+        elif url:
+            title, resource = raw.replace(url.group(0), "").strip(" -—:"), url.group(0)
+        else:
+            title, resource = raw, raw
+        out.append(f"  - id: source-{i}")
+        out.append(f"    resource: {resource}")
+        if title and title != resource:
+            out.append(f"    title: {title}")
+    return out
+
+
+def upgrade(wiki: Path, rep: Report) -> dict[Path, str]:
+    edits: dict[Path, str] = {}
+    for path in concept_files(wiki):
+        rel = path.relative_to(wiki)
+        original = path.read_text(encoding="utf-8")
+        raw_fm, body = split_frontmatter(original)
+        if raw_fm is None:
+            continue
+        fm = parse_frontmatter(raw_fm)
+        if fm is None:
+            continue
+        new_fm, new_body = raw_fm, body
+
+        if "timestamp" in fm and "generated" not in fm:
+            actor = str(fm.get("generated_by") or "human:unknown")
+            # Read the raw scalar, not fm["timestamp"]: PyYAML resolves an ISO
+            # 8601 timestamp into a datetime whose str() is not ISO 8601.
+            raw_ts = re.search(r"^timestamp:[ \t]*(.+?)[ \t]*$", new_fm, re.MULTILINE)
+            stamp = raw_ts.group(1).strip("\"'") if raw_ts else str(fm["timestamp"])
+            new_fm = replace_scalar(
+                new_fm, "timestamp", f"generated: {{ by: {actor}, at: {stamp} }}"
+            )
+            rep.changes.append(f"{rel}: timestamp -> generated.at (§13.1)")
+
+        if "sources" not in fm:
+            items, stripped = extract_citations(new_body)
+            if items:
+                new_body = stripped
+                new_fm = new_fm.rstrip("\n") + "\n" + "\n".join(citation_entries(items))
+                rep.changes.append(f"{rel}: # Citations -> sources ({len(items)}) (§13.1)")
+
+        if new_fm != raw_fm or new_body != body:
+            edits[path] = rebuild(new_fm, new_body)
+
+    index = wiki / "index.md"
+    if index.is_file():
+        original = index.read_text(encoding="utf-8")
+        raw_fm, body = split_frontmatter(original)
+        fm = parse_frontmatter(raw_fm) or {}
+        if raw_fm is not None and fm.get("okf_version") and str(fm["okf_version"]) != OKF_VERSION:
+            edits[index] = rebuild(
+                replace_scalar(raw_fm, "okf_version", f'okf_version: "{OKF_VERSION}"'),
+                body,
+            )
+            rep.changes.append(f'index.md: okf_version -> "{OKF_VERSION}"')
+    return edits
+
+
+# ---------------------------------------------------------------------------
+# cli
+# ---------------------------------------------------------------------------
+
+
+def apply(edits: dict[Path, str], write: bool) -> None:
+    if not write:
+        return
+    for path, text in edits.items():
+        path.write_text(text, encoding="utf-8")
+
+
+def emit(rep: Report, as_json: bool, write: bool, wiki: Path) -> int:
+    if as_json:
+        print(json.dumps(rep.as_dict(), indent=2))
+        return 1 if rep.hard else 0
+
+    if rep.changes:
+        verb = "applied" if write else "would apply"
+        print(f"{len(rep.changes)} change(s) {verb} in {wiki}:")
+        for line in rep.changes:
+            print(f"  {line}")
+        if not write:
+            print("\nDry run. Re-run with --write to apply.")
+    if rep.hard:
+        print(f"\nHARD failures ({len(rep.hard)}) — bundle is NOT OKF {OKF_VERSION} conformant:")
+        for line in rep.hard:
+            print(f"  {line}")
+    if rep.soft:
+        print(f"\nSoft issues ({len(rep.soft)}) — conformant, but recommended to fix:")
+        for line in rep.soft:
+            print(f"  {line}")
+    if not rep.changes and not rep.hard and not rep.soft:
+        print(f"{wiki}: OKF {OKF_VERSION} conformant, nothing to do.")
+    return 1 if rep.hard else 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="OKF v0.2 checker/migrator for an llm-wiki bundle.")
+    parser.add_argument("command", choices=("check", "migrate", "upgrade"))
+    parser.add_argument("wiki", type=Path)
+    parser.add_argument("--write", action="store_true", help="apply changes (default: dry run)")
+    parser.add_argument("--json", action="store_true", dest="as_json")
+    args = parser.parse_args(argv)
+
+    wiki: Path = args.wiki.expanduser()
+    if not wiki.is_dir():
+        print(f"not a directory: {wiki}", file=sys.stderr)
+        return 2
+
+    rep = Report()
+    if args.command == "check":
+        rep = check(wiki)
+    else:
+        runner = migrate if args.command == "migrate" else upgrade
+        apply(runner(wiki, rep), args.write)
+        if args.write:
+            post = check(wiki)
+            rep.hard, rep.soft = post.hard, post.soft
+    return emit(rep, args.as_json, args.write, wiki)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/skills/test_llm_wiki_okf.py
+++ b/tests/skills/test_llm_wiki_okf.py
@@ -1,0 +1,409 @@
+"""Tests for the llm-wiki bundled skill's OKF v0.2 tooling.
+
+Covers the SKILL.md authoring standards and the behavior of
+``scripts/okf.py`` — the conformance checker and migrator that backs the
+skill's optional Open Knowledge Format support.
+
+The load-bearing properties, in the order a reviewer should care about them:
+
+* ``check`` separates OKF §11 hard failures from soft issues, because the
+  spec says consumers MUST NOT reject a bundle over the soft ones.
+* ``migrate`` turns a default Karpathy-style wiki into a conformant bundle —
+  the claim the skill makes — verified by running ``check`` on the result.
+* Both subcommands are dry-run by default and idempotent, so a second
+  ``--write`` is a no-op rather than compounding edits.
+* Frontmatter edits are text surgery: unrelated keys, comments, and ordering
+  survive, and a legacy ISO 8601 ``timestamp`` is not mangled by a YAML
+  round-trip.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import re
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+import pytest
+import yaml
+
+SKILL_DIR = Path(__file__).resolve().parents[2] / "skills" / "research" / "llm-wiki"
+SCRIPT = SKILL_DIR / "scripts" / "okf.py"
+
+
+@pytest.fixture(scope="module")
+def skill_source() -> str:
+    return (SKILL_DIR / "SKILL.md").read_text(encoding="utf-8")
+
+
+@pytest.fixture(scope="module")
+def frontmatter(skill_source: str) -> dict:
+    m = re.search(r"^---\n(.*?)\n---", skill_source, re.DOTALL)
+    assert m, "SKILL.md missing YAML frontmatter"
+    return yaml.safe_load(m.group(1))
+
+
+@pytest.fixture(scope="module")
+def okf():
+    spec = importlib.util.spec_from_file_location("llm_wiki_okf", SCRIPT)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    # register before exec: @dataclass resolves annotations via sys.modules
+    sys.modules[spec.name] = module
+    try:
+        spec.loader.exec_module(module)
+    except Exception:  # pragma: no cover - defensive cleanup
+        sys.modules.pop(spec.name, None)
+        raise
+    yield module
+    sys.modules.pop(spec.name, None)
+
+
+def run(*args: str) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [sys.executable, str(SCRIPT), *args],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def write(path: Path, text: str) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(textwrap.dedent(text), encoding="utf-8")
+    return path
+
+
+@pytest.fixture
+def wiki(tmp_path: Path) -> Path:
+    """A default Karpathy-style wiki: shaped like OKF, not yet conformant."""
+    root = tmp_path / "wiki"
+    write(root / "SCHEMA.md", "# Wiki Schema\n\n## Domain\nAI research.\n")
+    write(root / "index.md", "# Wiki Index\n\n## Entities\n- [[anthropic]]\n")
+    write(
+        root / "log.md",
+        """\
+        # Wiki Log
+
+        > Chronological record of all wiki actions. Append-only.
+
+        ## [2026-05-22] ingest | Karpathy LLM Wiki post
+        - Created entities/anthropic.md
+        - Updated index.md
+
+        ## [2026-05-15] create | Wiki initialized
+        - Domain: AI research
+        """,
+    )
+    write(
+        root / "entities" / "anthropic.md",
+        """\
+        ---
+        title: Anthropic
+        created: 2026-05-22
+        updated: 2026-05-22
+        type: entity
+        tags: [company, lab]
+        sources: [raw/articles/karpathy.md]
+        confidence: high
+        ---
+
+        # Anthropic
+
+        An AI safety lab. See [[transformer-architecture]].
+        """,
+    )
+    write(
+        root / "raw" / "articles" / "karpathy.md",
+        """\
+        ---
+        source_url: https://example.test/post
+        ingested: 2026-05-22
+        sha256: deadbeef
+        ---
+
+        Raw article body.
+        """,
+    )
+    return root
+
+
+# ---------------------------------------------------------------------------
+# Authoring standards
+# ---------------------------------------------------------------------------
+
+
+def test_skill_files_present() -> None:
+    assert (SKILL_DIR / "SKILL.md").is_file()
+    assert SCRIPT.is_file()
+
+
+def test_description_within_limit(frontmatter: dict) -> None:
+    desc = frontmatter["description"]
+    assert len(desc) <= 60, f"description is {len(desc)} chars (limit 60): {desc!r}"
+
+
+def test_skill_documents_the_script(skill_source: str) -> None:
+    assert "scripts/okf.py" in skill_source
+
+
+def test_skill_cites_okf_v02(skill_source: str, okf) -> None:
+    """The skill must not advertise a version the tooling does not implement."""
+    assert okf.OKF_VERSION == "0.2"
+    assert "v0.2" in skill_source
+    assert "okf_version: \"0.2\"" in skill_source
+
+
+# ---------------------------------------------------------------------------
+# check: hard failures vs soft issues (OKF §11)
+# ---------------------------------------------------------------------------
+
+
+def test_check_flags_default_wiki_as_nonconformant(wiki: Path) -> None:
+    result = run("check", str(wiki), "--json")
+    assert result.returncode == 1
+    report = json.loads(result.stdout)
+    assert report["conformant"] is False
+    blob = "\n".join(report["hard_failures"])
+    # SCHEMA.md has no frontmatter; raw/ has frontmatter but no type; the log
+    # uses the skill's own legacy heading format. All three are §11 failures.
+    assert "SCHEMA.md" in blob
+    assert "raw/articles/karpathy.md" in blob
+    assert "log.md" in blob
+
+
+def test_bare_string_sources_are_soft_not_hard(wiki: Path) -> None:
+    report = json.loads(run("check", str(wiki), "--json").stdout)
+    assert any("resource" in s for s in report["soft_issues"])
+    assert not any("resource" in h for h in report["hard_failures"])
+
+
+def test_unknown_type_values_are_accepted(wiki: Path) -> None:
+    """§4.1: consumers MUST tolerate unknown types."""
+    write(
+        wiki / "concepts" / "widget.md",
+        """\
+        ---
+        type: Wholly Invented Domain Type
+        ---
+
+        # Widget
+        """,
+    )
+    report = json.loads(run("check", str(wiki), "--json").stdout)
+    assert not any("widget.md" in h for h in report["hard_failures"])
+
+
+def test_broken_links_are_not_a_failure(wiki: Path) -> None:
+    """§6.1: consumers MUST tolerate broken links."""
+    write(
+        wiki / "concepts" / "dangling.md",
+        """\
+        ---
+        type: Concept
+        ---
+
+        # Dangling
+
+        See [nothing](/concepts/does-not-exist.md).
+        """,
+    )
+    report = json.loads(run("check", str(wiki), "--json").stdout)
+    assert not any("dangling.md" in issue for issue in report["hard_failures"])
+
+
+def test_check_never_writes(wiki: Path) -> None:
+    before = {p: p.read_bytes() for p in wiki.rglob("*.md")}
+    run("check", str(wiki))
+    assert {p: p.read_bytes() for p in wiki.rglob("*.md")} == before
+
+
+# ---------------------------------------------------------------------------
+# migrate: karpathy wiki -> OKF v0.2
+# ---------------------------------------------------------------------------
+
+
+def test_migrate_is_dry_run_by_default(wiki: Path) -> None:
+    before = {p: p.read_bytes() for p in wiki.rglob("*.md")}
+    result = run("migrate", str(wiki))
+    assert "Dry run" in result.stdout
+    assert {p: p.read_bytes() for p in wiki.rglob("*.md")} == before
+
+
+def test_migrate_produces_a_conformant_bundle(wiki: Path) -> None:
+    assert run("migrate", str(wiki), "--write").returncode == 0
+    verify = run("check", str(wiki), "--json")
+    assert verify.returncode == 0, verify.stdout
+    assert json.loads(verify.stdout)["conformant"] is True
+
+
+def test_migrate_is_idempotent(wiki: Path) -> None:
+    run("migrate", str(wiki), "--write")
+    snapshot = {p: p.read_text(encoding="utf-8") for p in wiki.rglob("*.md")}
+    second = run("migrate", str(wiki), "--write")
+    assert {p: p.read_text(encoding="utf-8") for p in wiki.rglob("*.md")} == snapshot
+    assert "nothing to do" in second.stdout
+
+
+def test_migrate_titlecases_known_types(wiki: Path) -> None:
+    run("migrate", str(wiki), "--write")
+    page = (wiki / "entities" / "anthropic.md").read_text(encoding="utf-8")
+    assert "type: Entity" in page
+
+
+def test_migrate_preserves_unrelated_frontmatter_and_body(wiki: Path) -> None:
+    """Extension keys survive: §4.1 says consumers preserve unknown keys."""
+    run("migrate", str(wiki), "--write")
+    page = (wiki / "entities" / "anthropic.md").read_text(encoding="utf-8")
+    fm = yaml.safe_load(page.split("---")[1])
+    assert fm["confidence"] == "high"
+    assert fm["tags"] == ["company", "lab"]
+    assert str(fm["created"]) == "2026-05-22"
+    assert "See [[transformer-architecture]]." in page
+
+
+def test_migrate_rewrites_sources_with_resource(wiki: Path) -> None:
+    run("migrate", str(wiki), "--write")
+    fm = yaml.safe_load(
+        (wiki / "entities" / "anthropic.md").read_text(encoding="utf-8").split("---")[1]
+    )
+    assert fm["sources"] == [
+        {"id": "karpathy", "resource": "/raw/articles/karpathy.md"}
+    ]
+
+
+def test_migrate_adds_okf_version_only_at_bundle_root(wiki: Path) -> None:
+    """§8: index.md carries no frontmatter except root okf_version."""
+    write(wiki / "entities" / "index.md", "# Entities\n\n* [Anthropic](anthropic.md)\n")
+    run("migrate", str(wiki), "--write")
+    root_fm = yaml.safe_load(
+        (wiki / "index.md").read_text(encoding="utf-8").split("---")[1]
+    )
+    assert root_fm == {"okf_version": "0.2"}
+    assert not (wiki / "entities" / "index.md").read_text(encoding="utf-8").startswith("---")
+
+
+def test_migrate_rewrites_log_to_iso_headings(wiki: Path) -> None:
+    """§9: date headings MUST be ISO 8601, newest first."""
+    run("migrate", str(wiki), "--write")
+    log = (wiki / "log.md").read_text(encoding="utf-8")
+    assert "## 2026-05-22" in log
+    assert "## [2026-05-22]" not in log
+    assert log.index("## 2026-05-22") < log.index("## 2026-05-15")
+    # the action survives as prose, and its detail lines stay with it
+    assert "**Ingest**: Karpathy LLM Wiki post" in log
+    assert "- Created entities/anthropic.md" in log
+
+
+def test_migrate_leaves_wikilinks_alone(wiki: Path) -> None:
+    """Obsidian-first vaults keep working: opting in must not break links."""
+    run("migrate", str(wiki), "--write")
+    page = (wiki / "entities" / "anthropic.md").read_text(encoding="utf-8")
+    assert "[[transformer-architecture]]" in page
+
+
+def test_migrate_skips_archive_and_dotdirs(wiki: Path) -> None:
+    stale = write(wiki / "_archive" / "old.md", "no frontmatter here\n")
+    write(wiki / ".obsidian" / "note.md", "internal\n")
+    run("migrate", str(wiki), "--write")
+    assert stale.read_text(encoding="utf-8") == "no frontmatter here\n"
+    assert run("check", str(wiki)).returncode == 0
+
+
+# ---------------------------------------------------------------------------
+# upgrade: OKF v0.1 -> v0.2 (spec §13.1 breaking changes)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def v01_bundle(tmp_path: Path) -> Path:
+    root = tmp_path / "bundle"
+    write(root / "index.md", '---\nokf_version: "0.1"\n---\n# Index\n')
+    write(
+        root / "concepts" / "revenue.md",
+        """\
+        ---
+        type: Metric
+        title: Revenue
+        timestamp: 2026-06-20T22:53:05Z
+        ---
+
+        # Definition
+
+        Revenue is gross sales minus returns.
+
+        # Citations
+
+        - [GA4 schema](https://developers.google.com/analytics/bigquery/export-schema)
+        - https://internal.example.test/handbook
+
+        # Notes
+
+        Reviewed quarterly.
+        """,
+    )
+    return root
+
+
+def test_v01_bundle_is_still_conformant(v01_bundle: Path) -> None:
+    """A v0.1 bundle must not be reported as broken — only as upgradable."""
+    report = json.loads(run("check", str(v01_bundle), "--json").stdout)
+    assert report["conformant"] is True
+    assert any("timestamp" in s for s in report["soft_issues"])
+
+
+def test_upgrade_moves_timestamp_to_generated(v01_bundle: Path) -> None:
+    run("upgrade", str(v01_bundle), "--write")
+    text = (v01_bundle / "concepts" / "revenue.md").read_text(encoding="utf-8")
+    # the literal ISO 8601 string is preserved, not a YAML-coerced datetime
+    assert "at: 2026-06-20T22:53:05Z" in text
+    assert "timestamp:" not in text
+
+
+def test_upgrade_moves_citations_to_sources(v01_bundle: Path) -> None:
+    run("upgrade", str(v01_bundle), "--write")
+    text = (v01_bundle / "concepts" / "revenue.md").read_text(encoding="utf-8")
+    fm = yaml.safe_load(text.split("---")[1])
+    resources = [s["resource"] for s in fm["sources"]]
+    assert "https://developers.google.com/analytics/bigquery/export-schema" in resources
+    assert "https://internal.example.test/handbook" in resources
+    assert fm["sources"][0]["title"] == "GA4 schema"
+    assert "# Citations" not in text
+    # sibling sections are untouched
+    assert "# Notes" in text
+    assert "Reviewed quarterly." in text
+
+
+def test_upgrade_bumps_declared_version(v01_bundle: Path) -> None:
+    run("upgrade", str(v01_bundle), "--write")
+    fm = yaml.safe_load(
+        (v01_bundle / "index.md").read_text(encoding="utf-8").split("---")[1]
+    )
+    assert fm["okf_version"] == "0.2"
+
+
+def test_upgrade_is_idempotent(v01_bundle: Path) -> None:
+    run("upgrade", str(v01_bundle), "--write")
+    snapshot = {p: p.read_text(encoding="utf-8") for p in v01_bundle.rglob("*.md")}
+    run("upgrade", str(v01_bundle), "--write")
+    assert {p: p.read_text(encoding="utf-8") for p in v01_bundle.rglob("*.md")} == snapshot
+
+
+# ---------------------------------------------------------------------------
+# CLI contract
+# ---------------------------------------------------------------------------
+
+
+def test_missing_directory_exits_two(tmp_path: Path) -> None:
+    assert run("check", str(tmp_path / "nope")).returncode == 2
+
+
+def test_log_migration_preserves_already_iso_logs(okf) -> None:
+    already = (
+        "# Wiki Log\n\n## 2026-05-22\n* **Update**: something\n\n## 2026-05-15\n"
+        "* **Initialization**: created\n"
+    )
+    assert okf.migrate_log(already) == already


### PR DESCRIPTION
## Motivation

The `llm-wiki` skill prescribes YAML frontmatter, cross-links, `index.md`, and `log.md` as an ad-hoc convention. Google's [Open Knowledge Format](https://github.com/GoogleCloudPlatform/knowledge-catalog/blob/main/okf/SPEC.md) ([blog](https://cloud.google.com/blog/products/data-analytics/how-the-open-knowledge-format-can-improve-data-sharing)) standardizes exactly that shape, so adopting it lets a wiki built with this skill be consumed by any OKF-aware tool without bespoke parsing.

This replaces the original v0.1 docs-only proposal. Both reviews were right, and both are addressed by dropping the "already conformant" claim entirely.

## What changed since review

**@teknium1 (hermes-sweeper) — the conformance claim was overstated.** Correct, and it was the load-bearing problem. A default wiki is genuinely *not* conformant: `SCHEMA.md` has no frontmatter (fails §11.1), `raw/` sources have frontmatter but no `type` (fails §11.2), and `log.md` uses `## [YYYY-MM-DD] action | subject` where §9 requires a bare ISO date heading. Rather than narrow the claim in prose, this ships the migration that actually closes the gaps, and the skill now states plainly which three things fail before you opt in.

**@craigdfrench (multi-model panel) — Title-Case is not mandated.** Confirmed against the spec: §4.1 says type values "are **not** registered centrally" and consumers "MUST tolerate unknown types gracefully." The skill now presents Title-Case as a convention borrowed from the spec's examples, not a requirement, and a test asserts an invented type is accepted. The panel's non-blocking note about broken links is also resolved: §6.1 tolerance is now explicit, and broken links are reported as soft issues, separately from the wiki's own stricter check.

**@pooluut — "any plan to update to okf2.0?"** Yes — that's this. The spec moved to **v0.2** while this PR was open, which invalidated every section reference in the original (§9 conformance is now §11, §5.1 links are now §6.1, §7 logs are now §9). All references are re-verified against current spec text, and §13.1's two breaking changes have a migration path.

## What this adds

`skills/research/llm-wiki/scripts/okf.py` — a conformance checker and migrator:

| Command | Purpose |
|---|---|
| `check` | Report §11 hard failures separately from soft issues; non-zero exit on hard failure |
| `migrate` | Karpathy-style wiki → OKF v0.2 |
| `upgrade` | Existing v0.1 bundle → v0.2 (§13.1) |

Properties that make it safe to point at an existing wiki:

- **Dry run by default.** Nothing is written without `--write`.
- **Idempotent.** A second `--write` reports "nothing to do" rather than compounding edits.
- **Non-destructive.** Frontmatter is edited as targeted text surgery, never a YAML reserialize, so comments, key order, and unknown extension keys (`confidence`, `contested`, `sources`) survive. A legacy ISO 8601 `timestamp` is read as a raw scalar because PyYAML resolves it into a `datetime` whose `str()` is no longer ISO 8601.
- **Spec-faithful about severity.** §11 says consumers MUST NOT reject a bundle for missing optional fields, unknown types, unknown keys, or broken links — so those are soft issues, never failures.
- **`[[wikilinks]]` are left alone**, so Obsidian-first vaults are unaffected by opting in.

## Verification

```
tests/skills/test_llm_wiki_okf.py ......................... 26 passed
tests/skills/test_authoring_standards.py .................. 1160 passed
scripts/check-windows-footguns.py --all ................... ✓ 943 files
ruff check skills/research/llm-wiki/ tests/ ............... All checks passed
```

The tests assert behavior, not snapshots: `migrate` output is verified by running `check` on the result, idempotence by byte-comparing two write passes, and spec tolerance rules by fixture (unknown type accepted, broken link accepted, extension keys preserved).

Also exercised against a real 4,426-page wiki — 0.9s, no crashes on `bq:`-style URIs or scope descriptors. It flagged 164 files with unparseable frontmatter; spot-checking confirmed genuine YAML errors (`title: Episode 11: Parameterization with jinja` — unquoted colon), not false positives.

## Notes

- No new core tool, no new model-facing surface, no dependency: a skill script using `pyyaml`, already a Hermes dependency.
- Google ships no standalone OKF validator (only a `google-adk` reference agent), so `scripts/okf.py` implements §11 directly against the spec text. The skill says so rather than implying official tooling exists.
- Opt-in remains opt-in: a wiki with no `okf_version` behaves exactly as before, and the new lint step only runs when the root `index.md` declares one.
