### PR TITLE
fix: use provider-aware context for tool search

### DIFF
--- a/model_tools.py
+++ b/model_tools.py
@@ -551,8 +551,27 @@ def _resolve_active_context_length() -> int:
         model_id = (model_cfg.get("model") or model_cfg.get("default") or "").strip()
         if not model_id:
             return 0
+        provider = str(model_cfg.get("provider") or cfg.get("provider") or "").strip()
+        base_url = str(model_cfg.get("base_url") or "").strip()
+        api_key = str(model_cfg.get("api_key") or "").strip()
+        config_context_length = model_cfg.get("context_length")
+        if isinstance(config_context_length, str):
+            try:
+                config_context_length = int(config_context_length)
+            except ValueError:
+                config_context_length = None
+        custom_providers = cfg.get("custom_providers")
+        if not isinstance(custom_providers, list):
+            custom_providers = None
         from agent.model_metadata import get_model_context_length
-        return int(get_model_context_length(model_id) or 0)
+        return int(get_model_context_length(
+            model_id,
+            base_url=base_url,
+            api_key=api_key,
+            config_context_length=config_context_length,
+            provider=provider,
+            custom_providers=custom_providers,
+        ) or 0)
     except Exception as e:
         logger.debug("Could not resolve active context length: %s", e)
         return 0

--- a/tests/tools/test_tool_search.py
+++ b/tests/tools/test_tool_search.py
@@ -134,6 +134,24 @@ class TestClassification:
 
 
 class TestThresholdGate:
+    def test_active_context_length_uses_configured_provider(self, monkeypatch):
+        """Tool Search's auto gate must use the provider-specific model window.
+
+        GPT-5.5 is 1.05M on the direct OpenAI API but 272K through
+        ChatGPT Codex OAuth. The auto threshold should use the active provider
+        from config.yaml, not the bare model fallback.
+        """
+        import hermes_cli.config as config_mod
+        import model_tools
+
+        monkeypatch.setattr(
+            config_mod,
+            "load_config",
+            lambda: {"model": {"default": "gpt-5.5", "provider": "openai-codex"}},
+        )
+
+        assert model_tools._resolve_active_context_length() == 272_000
+
     def test_off_never_activates(self):
         from tools.tool_search import ToolSearchConfig, should_activate
         cfg = ToolSearchConfig.from_raw({"enabled": "off"})


### PR DESCRIPTION
## Summary
- pass the configured provider/base URL/API key/context override into Tool Search's active context-length resolver
- fixes Codex OAuth GPT-5.5 being treated like the direct OpenAI 1.05M window instead of the 272K Codex window
- add a regression test for provider-aware Tool Search auto thresholding

## Tests
- RED: `uv run python -m pytest tests/tools/test_tool_search.py::TestThresholdGate::test_active_context_length_uses_configured_provider -v -o 'addopts='` failed before the fix with `1050000 == 272000`
- GREEN: `uv run python -m pytest tests/tools/test_tool_search.py::TestThresholdGate::test_active_context_length_uses_configured_provider -v -o 'addopts='`
- `uv run python -m pytest tests/tools/test_tool_search.py tests/hermes_cli/test_custom_provider_context_length.py -q -o 'addopts='`