### PR TITLE
Fix sidebar drag activation in installed app

### DIFF
--- a/apps/desktop/src/app/chat/sidebar/index.tsx
+++ b/apps/desktop/src/app/chat/sidebar/index.tsx
@@ -1,4 +1,4 @@
-import { KeyboardSensor, PointerSensor, useSensor, useSensors } from '@dnd-kit/core'
+import { KeyboardSensor, MouseSensor, TouchSensor, useSensor, useSensors } from '@dnd-kit/core'
 import { sortableKeyboardCoordinates } from '@dnd-kit/sortable'
 import { useStore } from '@nanostores/react'
 import type * as React from 'react'
@@ -371,7 +371,8 @@ export function ChatSidebar({
   const activeSidebarSessionId = currentView === 'chat' ? selectedSessionId : null
 
   const dndSensors = useSensors(
-    useSensor(PointerSensor, { activationConstraint: { distance: 6 } }),
+    useSensor(MouseSensor, { activationConstraint: { distance: 6 } }),
+    useSensor(TouchSensor, { activationConstraint: { distance: 6 } }),
     useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates })
   )
 

--- a/apps/desktop/src/app/chat/sidebar/profile-switcher.tsx
+++ b/apps/desktop/src/app/chat/sidebar/profile-switcher.tsx
@@ -6,7 +6,8 @@ import {
   type DragStartEvent,
   KeyboardSensor,
   type Modifier,
-  PointerSensor,
+  MouseSensor,
+  TouchSensor,
   useSensor,
   useSensors
 } from '@dnd-kit/core'
@@ -164,7 +165,8 @@ export function ProfileRail() {
 
   // distance constraint: a small drag reorders, a tap still selects the profile.
   const sensors = useSensors(
-    useSensor(PointerSensor, { activationConstraint: { distance: 4 } }),
+    useSensor(MouseSensor, { activationConstraint: { distance: 4 } }),
+    useSensor(TouchSensor, { activationConstraint: { distance: 4 } }),
     useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates })
   )
 

--- a/apps/desktop/src/app/chat/sidebar/session-row.test.tsx
+++ b/apps/desktop/src/app/chat/sidebar/session-row.test.tsx
@@ -1,4 +1,4 @@
-import { cleanup, render, screen } from '@testing-library/react'
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
 import { atom } from 'nanostores'
 import type * as React from 'react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
@@ -183,5 +183,60 @@ describe('SidebarSessionRow', () => {
     const avatar = container.querySelector('span[aria-hidden="true"]')
     expect(avatar).toBeTruthy()
     expect(tipTrigger(avatar as HTMLElement)).toBeTruthy()
+  })
+})
+
+describe('SidebarSessionRow reorder activation', () => {
+  function renderReorderableRow() {
+    const dragHandleProps = {
+      onKeyDown: vi.fn(),
+      onMouseDown: vi.fn(),
+      onPointerDown: vi.fn(),
+      onTouchStart: vi.fn()
+    }
+
+    const utils = render(
+      <SidebarSessionRow
+        dragHandleProps={dragHandleProps}
+        isPinned={false}
+        isSelected={false}
+        isWorking={false}
+        onArchive={noop}
+        onDelete={noop}
+        onPin={noop}
+        onResume={noop}
+        reorderable
+        session={makeSession({ title: 'Reorderable session' })}
+      />
+    )
+
+    return { ...utils, dragHandleProps }
+  }
+
+  it('starts reorder from row chrome, not just the tiny grab handle', () => {
+    const { container, dragHandleProps } = renderReorderableRow()
+    const chrome = container.querySelector('[data-session-row-chrome]') as HTMLElement
+
+    fireEvent.mouseDown(chrome)
+
+    expect(dragHandleProps.onMouseDown).toHaveBeenCalledTimes(1)
+  })
+
+  it('keeps the main row button wired without double-firing through row chrome', () => {
+    const { container, dragHandleProps } = renderReorderableRow()
+    const main = container.querySelector('[data-session-row-main]') as HTMLElement
+
+    fireEvent.mouseDown(main)
+
+    expect(dragHandleProps.onMouseDown).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not start reorder from the actions menu button', () => {
+    const { container, dragHandleProps } = renderReorderableRow()
+    const actions = container.querySelector('[data-session-row-actions]') as HTMLElement
+
+    fireEvent.mouseDown(actions)
+
+    expect(dragHandleProps.onMouseDown).not.toHaveBeenCalled()
   })
 })

--- a/apps/desktop/src/app/chat/sidebar/session-row.tsx
+++ b/apps/desktop/src/app/chat/sidebar/session-row.tsx
@@ -48,6 +48,13 @@ interface SidebarSessionRowProps extends React.ComponentProps<'div'> {
 
 const AGE_KEY = { day: 'ageDay', hour: 'ageHour', minute: 'ageMin' } as const
 
+function isNestedSessionRowDragHandleTarget(target: EventTarget | null): boolean {
+  return (
+    target instanceof HTMLElement &&
+    Boolean(target.closest('[data-session-row-actions], [data-session-row-main]'))
+  )
+}
+
 function formatAge(seconds: number, r: Translations['sidebar']['row']): string {
   const { unit, value } = coarseElapsed(Date.now() - seconds * 1000)
 
@@ -89,6 +96,32 @@ function SidebarSessionRowImpl({
   // True when a clarify prompt in this session is waiting on the user.
   const needsInput = useStore($attentionSessionIds).includes(session.id)
 
+  const rowDragActivationProps =
+    reorderable && dragHandleProps
+      ? {
+          onKeyDown: (event: React.KeyboardEvent<HTMLElement>) => {
+            if (!isNestedSessionRowDragHandleTarget(event.target)) {
+              dragHandleProps.onKeyDown?.(event)
+            }
+          },
+          onMouseDown: (event: React.MouseEvent<HTMLElement>) => {
+            if (!isNestedSessionRowDragHandleTarget(event.target)) {
+              dragHandleProps.onMouseDown?.(event)
+            }
+          },
+          onPointerDown: (event: React.PointerEvent<HTMLElement>) => {
+            if (!isNestedSessionRowDragHandleTarget(event.target)) {
+              dragHandleProps.onPointerDown?.(event)
+            }
+          },
+          onTouchStart: (event: React.TouchEvent<HTMLElement>) => {
+            if (!isNestedSessionRowDragHandleTarget(event.target)) {
+              dragHandleProps.onTouchStart?.(event)
+            }
+          }
+        }
+      : undefined
+
   return (
     <SessionContextMenu
       onArchive={onArchive}
@@ -121,6 +154,7 @@ function SidebarSessionRowImpl({
               <Button
                 aria-label={r.sessionActions}
                 className="size-5 rounded-[4px] bg-transparent text-transparent transition-colors duration-100 hover:bg-(--ui-control-active-background) hover:text-foreground focus-visible:bg-(--ui-control-active-background) focus-visible:text-foreground focus-visible:ring-0 data-[state=open]:bg-(--ui-control-active-background) data-[state=open]:text-foreground group-hover:text-(--ui-text-tertiary) [&_svg]:size-3.5!"
+                data-session-row-actions
                 size="icon"
                 variant="ghost"
               >
@@ -138,6 +172,7 @@ function SidebarSessionRowImpl({
           dragging && 'z-10 cursor-grabbing bg-(--ui-sidebar-surface-background)',
           className
         )}
+        data-session-row-chrome
         data-working={isWorking ? 'true' : undefined}
         onPointerDown={event => {
           // Reorder drags belong to dnd-kit (the grab handle); the ⋯ actions
@@ -147,7 +182,14 @@ function SidebarSessionRowImpl({
           // (never native HTML5 DnD: no macOS snap-back, Esc aborts
           // instantly). Sub-threshold releases stay ordinary clicks, so
           // resume / pin / open-in-window are untouched.
-          if ((event.target as HTMLElement).closest('[data-reorder-handle], [data-row-actions]')) {
+          // Reorderable rows activate a dnd-kit reorder from the whole visible
+          // row chrome (not just the tiny grabber), so the session-reference
+          // drag is suppressed for the entire row -- the two DnD systems must
+          // not fight over the same gesture.
+          if (
+            reorderable ||
+            (event.target as HTMLElement).closest('[data-reorder-handle], [data-row-actions]')
+          ) {
             return
           }
 
@@ -161,12 +203,14 @@ function SidebarSessionRowImpl({
         onPointerLeave={cancelPrewarm}
         ref={ref}
         style={style}
+        {...rowDragActivationProps}
         {...rest}
       >
         {sessionShowsRunningArc({ isWorking, needsInput }) && (
           <span aria-hidden="true" className="arc-border arc-row" />
         )}
         <SidebarRowBody
+          {...(reorderable ? dragHandleProps : undefined)}
           className={cn('z-0 group-hover:pr-12', branchStem && 'pl-3.5')}
           // Middle-click = open in a new tab (browser muscle memory). Swallow
           // the mousedown so Chromium doesn't enter autoscroll mode.
@@ -178,6 +222,7 @@ function SidebarSessionRowImpl({
               openSession(session.id, () => undefined, 'tab')
             }
           }}
+          data-session-row-main
           onClick={event => {
             const mod = event.metaKey || event.ctrlKey
 


### PR DESCRIPTION
## Summary

- replace the generic pointer sensor with explicit mouse and touch sensors for sidebar session/profile drag-and-drop
- let reorderable sidebar session rows start dragging from the visible row chrome and main row button, not only the tiny grab handle
- make native, non-reorderable session drags visibly enter a dragging state while still writing the Hermes session drag payload
- keep the actions menu excluded from reorder activation and keep keyboard drag support unchanged

## Verification

- `npm --prefix apps/desktop run test:ui -- src/app/chat/sidebar/session-row.test.tsx src/app/chat/sidebar/virtual-session-list.test.tsx src/app/chat/sidebar/order.test.ts`
- `npm --prefix apps/desktop run typecheck`
- `npm exec eslint -- src/app/chat/sidebar/session-row.tsx src/app/chat/sidebar/session-row.test.tsx`
- local packaged bundle installed at `/Applications/Hermes.app` matched the rebuilt `app.asar` hash `d7a8dc985a3cd1c1f617326fec6293ef64efb105a3b2eaf310d80d520e820a71`
- installed app stamp is clean and pinned to `OmarB97/hermes-agent@18b7f9c2c1a04062fc3deb7a12dcfe389580724a`
- live installed app CDP smoke: dispatching native `dragstart` on a visible sidebar session row wrote `application/x-hermes-session`, set the row dragging class, and `dragend` cleared it

## Notes

This PR branch is based on upstream `main` and only carries the sidebar drag fixes, so it avoids broader OmarB97 fork drift.