### PR TITLE
fix(skills): guard _rmtree_writable against escaping SKILLS_DIR

### DIFF
--- a/tests/tools/test_skills_sync.py
+++ b/tests/tools/test_skills_sync.py
@@ -5,6 +5,8 @@ import json
 from pathlib import Path
 from unittest.mock import patch
 
+import pytest
+
 from tools.skills_sync import (
     _get_bundled_dir,
     _read_manifest,
@@ -13,6 +15,7 @@ from tools.skills_sync import (
     _discover_bundled_skills,
     _compute_relative_dest,
     _dir_hash,
+    _rmtree_writable,
     sync_skills,
     reset_bundled_skill,
     restore_official_optional_skill,
@@ -1188,3 +1191,60 @@ class TestUpdateBackupRecovery:
             result2 = sync_skills(quiet=True)
         assert "old-skill" in result2["updated"]
         assert result2["user_modified"] == []
+
+
+class TestRmtreeWritableScopeGuard:
+    """_rmtree_writable must never remove SKILLS_DIR itself or escape it.
+
+    Defense-in-depth for the catastrophic data-loss class in #48200: every
+    caller passes a skill dir or its ``.bak`` sibling under SKILLS_DIR, but a
+    degenerate ``dest`` collapsing to SKILLS_DIR (and its ``.bak`` landing in
+    HERMES_HOME) must abort rather than wipe the skills root / HERMES_HOME.
+    """
+
+    def test_removes_skill_dir_inside_skills(self, tmp_path):
+        skills_dir = tmp_path / "skills"
+        target = skills_dir / "mlops" / "axolotl"
+        target.mkdir(parents=True)
+        (target / "SKILL.md").write_text("x")
+        with patch("tools.skills_sync.SKILLS_DIR", skills_dir):
+            _rmtree_writable(target)
+        assert not target.exists()
+        assert skills_dir.exists()
+
+    def test_removes_bak_sibling_inside_skills(self, tmp_path):
+        skills_dir = tmp_path / "skills"
+        bak = skills_dir / "mlops" / "axolotl.bak"
+        bak.mkdir(parents=True)
+        with patch("tools.skills_sync.SKILLS_DIR", skills_dir):
+            _rmtree_writable(bak)
+        assert not bak.exists()
+
+    def test_refuses_skills_root_itself(self, tmp_path):
+        skills_dir = tmp_path / "skills"
+        (skills_dir / "keep").mkdir(parents=True)
+        with patch("tools.skills_sync.SKILLS_DIR", skills_dir):
+            with pytest.raises(ValueError, match="outside the skills directory"):
+                _rmtree_writable(skills_dir)
+        assert (skills_dir / "keep").exists()  # nothing was wiped
+
+    def test_refuses_bak_sibling_in_hermes_home(self, tmp_path):
+        # dest==SKILLS_DIR -> backup = SKILLS_DIR.with_suffix('.bak') lands
+        # next to skills/ inside HERMES_HOME. Must be refused.
+        skills_dir = tmp_path / "skills"
+        skills_dir.mkdir()
+        outside = tmp_path / "skills.bak"
+        outside.mkdir()
+        (outside / "important").write_text("secret")
+        with patch("tools.skills_sync.SKILLS_DIR", skills_dir):
+            with pytest.raises(ValueError, match="outside the skills directory"):
+                _rmtree_writable(outside)
+        assert (outside / "important").exists()
+
+    def test_refuses_hermes_home_parent(self, tmp_path):
+        skills_dir = tmp_path / "skills"
+        skills_dir.mkdir()
+        with patch("tools.skills_sync.SKILLS_DIR", skills_dir):
+            with pytest.raises(ValueError, match="outside the skills directory"):
+                _rmtree_writable(tmp_path)  # the HERMES_HOME-equivalent root
+        assert tmp_path.exists()

--- a/tools/skills_sync.py
+++ b/tools/skills_sync.py
@@ -670,8 +670,25 @@ def _rmtree_writable(path: Path) -> None:
     (``r-xr-xr-x``).  Removing a child requires write permission on its
     parent directory, so the retry handler makes the failing path **and its
     parent** writable before re-attempting.  See #34860, #34972.
+
+    Safety: refuses to remove ``SKILLS_DIR`` itself or any path outside it.
+    Every caller passes a skill directory or its ``.bak`` sibling under
+    ``SKILLS_DIR``, but a degenerate ``dest`` — e.g. a bundled layout whose
+    relative path collapses to ``.`` so ``dest == SKILLS_DIR`` — must never
+    escalate into wiping the skills root or all of ``HERMES_HOME``. A
+    ``..``-traversal can't happen here (``_compute_relative_dest`` uses
+    ``Path.relative_to``), so guarding the root boundary is sufficient.
+    Defense-in-depth for #48200.
     """
     import stat
+
+    resolved = Path(path).resolve()
+    skills_root = SKILLS_DIR.resolve()
+    if resolved == skills_root or skills_root not in resolved.parents:
+        raise ValueError(
+            f"_rmtree_writable refusing to remove a path outside the skills "
+            f"directory: {str(path)!r} (skills dir: {skills_root})"
+        )
 
     def _on_error(func, fpath, exc_info):
         # Unlinking a child requires the parent dir to be writable, so chmod


### PR DESCRIPTION
## What does this PR do?

Adds a scope guard to `_rmtree_writable()` in `tools/skills_sync.py` so a skill sync can never `rmtree` `SKILLS_DIR` itself or any path outside it. This is defense-in-depth for the data-loss class reported in #48200 (hardening recommendations 4 and 6).

## Related Issue

Related to #48200

**Scope note (intentionally not "Fixes"):** #48200 reports a full `~/.hermes/` wipe whose exact mechanism the reporter could not pin down (logs lost). This PR does **not** claim to be the sole root cause fix — it closes one concrete escalation path the reporter explicitly flagged (recs 4/6) and is valuable hardening on its own. The other recommendations (default `pre_update_backup`, an update timeout, post-update validation) are policy/feature decisions better left to maintainers.

## Root Cause (of the guarded path)

`_rmtree_writable()` ran a bare `shutil.rmtree()` on whatever it was handed. All callers pass a skill directory or its `.bak` sibling computed via `_compute_relative_dest()` → `SKILLS_DIR / rel`. A `..`-traversal can't occur (`Path.relative_to` forbids it), but if `rel` ever collapses to `.` then `dest == SKILLS_DIR`, and:

- `_rmtree_writable(dest)` would wipe the **entire skills root**, and
- `backup = dest.with_suffix(".bak")` becomes `HERMES_HOME/skills.bak`, so a stale-backup cleanup `rmtree` would target a path **inside `HERMES_HOME` but outside `skills/`**.

There was no boundary check preventing either.

## Changes Made

- `tools/skills_sync.py`: resolve the target and raise `ValueError` if it equals `SKILLS_DIR` or is not strictly inside it, before any `rmtree`.
- `tests/tools/test_skills_sync.py`: 5 tests — removes a skill dir and a `.bak` sibling inside `SKILLS_DIR` (still works); refuses `SKILLS_DIR` itself, a `skills.bak` sibling in `HERMES_HOME`, and the `HERMES_HOME` root.

## How to Test

```
python -m pytest tests/tools/test_skills_sync.py -q
```

## Type of Change

- [x] Bug fix / safety hardening (non-breaking)

## Checklist

- [x] Branch from `main`
- [x] `pytest tests/tools/test_skills_sync.py` passes (64: 59 existing + 5 new), no regressions
- [x] Tests isolated (patch `SKILLS_DIR` to a tmp dir, no writes to real `~/.hermes`)
- [x] Single logical change, conventional commit
- [x] No behavior change for legitimate callers (all operate strictly inside `SKILLS_DIR`)

## AI Disclosure

This issue was investigated and the fix written with AI assistance.
