### PR TITLE
feat: add agent kanban rework loop

### DIFF
--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -2289,6 +2289,12 @@ DEFAULT_CONFIG = {
         # raise these to keep more early failure evidence.
         "worker_log_rotate_bytes": 2 * 1024 * 1024,
         "worker_log_backup_count": 1,
+        # Review-loop mode. "human" preserves the historical contract:
+        # review feedback that needs changes is handed off via completion or
+        # comments and a human/orchestrator decides what to requeue. "agent"
+        # enables the constrained kanban_request_rework/request-rework path
+        # that marks linked implementation cards needs_rework for dispatch.
+        "review_loop_mode": "human",
         # Profile assigned to the root/orchestration task after Triage
         # decomposition. When unset, falls back to the default profile (the
         # one `hermes` launches with no -p flag). This does not control the

--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -35,9 +35,11 @@ from hermes_cli import kanban_swarm as ks
 _STATUS_ICONS = {
     "todo":     "◻",
     "ready":    "▶",
+    "needs_rework": "↩",
     "running":  "●",
     "scheduled":"⏱",
     "blocked":  "⊘",
+    "review":   "◇",
     "done":     "✓",
     "archived": "—",
 }
@@ -572,6 +574,28 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
     p_comment.add_argument("--max-len", type=int, default=None,
                            help="Trim the stored comment body to this many characters")
 
+    p_request_rework = sub.add_parser(
+        "request-rework",
+        help="Append reviewer feedback and mark a linked target needs_rework",
+    )
+    p_request_rework.add_argument("target_task_id")
+    p_request_rework.add_argument(
+        "feedback",
+        nargs="+",
+        help="Actionable feedback for the implementation task",
+    )
+    p_request_rework.add_argument(
+        "--reviewer-task",
+        dest="reviewer_task_id",
+        required=True,
+        help="Reviewer task linked to the target task",
+    )
+    p_request_rework.add_argument(
+        "--author",
+        default=None,
+        help="Author name (default: active profile)",
+    )
+
     # --- attach / attachments / attach-rm ---
     p_attach = sub.add_parser("attach", help="Attach a local file to a task")
     p_attach.add_argument("task_id")
@@ -1061,6 +1085,7 @@ def kanban_command(args: argparse.Namespace) -> int:
             "attach":   _cmd_attach,
             "attachments": _cmd_attachments,
             "attach-rm": _cmd_attach_rm,
+            "request-rework": _cmd_request_rework,
             "complete": _cmd_complete,
             "edit":     _cmd_edit,
             "block":    _cmd_block,
@@ -2126,6 +2151,38 @@ def _cmd_attach_rm(args: argparse.Namespace) -> int:
     return 0
 
 
+def _cmd_request_rework(args: argparse.Namespace) -> int:
+    feedback = " ".join(args.feedback).strip()
+    if not feedback:
+        print("kanban request-rework: feedback is required", file=sys.stderr)
+        return 2
+    try:
+        from hermes_cli.config import load_config
+
+        cfg = load_config() or {}
+        mode = str((cfg.get("kanban") or {}).get("review_loop_mode", "human")).strip().lower()
+    except Exception:
+        mode = "human"
+    if mode != "agent":
+        print(
+            "kanban request-rework requires kanban.review_loop_mode=agent; "
+            "default human mode preserves blocked/unblock as the human gate",
+            file=sys.stderr,
+        )
+        return 2
+    author = args.author or _profile_author()
+    with kb.connect_closing() as conn:
+        kb.request_rework_task(
+            conn,
+            args.target_task_id,
+            feedback=feedback,
+            reviewer_task_id=args.reviewer_task_id,
+            author=author,
+        )
+    print(f"Rework requested for {args.target_task_id}")
+    return 0
+
+
 def _worker_run_id_for(task_id: str) -> Optional[int]:
     if os.environ.get("HERMES_KANBAN_TASK") != task_id:
         return None
@@ -2737,7 +2794,17 @@ def _cmd_stats(args: argparse.Namespace) -> int:
         print(json.dumps(stats, indent=2, ensure_ascii=False))
         return 0
     print("By status:")
-    for k in ("triage", "todo", "scheduled", "ready", "running", "blocked", "done"):
+    for k in (
+        "triage",
+        "todo",
+        "scheduled",
+        "ready",
+        "needs_rework",
+        "running",
+        "blocked",
+        "review",
+        "done",
+    ):
         print(f"  {k:8s}  {stats['by_status'].get(k, 0)}")
     if stats["by_assignee"]:
         print("\nBy assignee:")

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -99,7 +99,10 @@ _log = logging.getLogger(__name__)
 # Constants
 # ---------------------------------------------------------------------------
 
-VALID_STATUSES = {"triage", "todo", "scheduled", "ready", "running", "blocked", "review", "done", "archived"}
+VALID_STATUSES = {
+    "triage", "todo", "scheduled", "ready", "needs_rework", "running",
+    "blocked", "review", "done", "archived",
+}
 VALID_INITIAL_STATUSES = {"running", "blocked"}
 
 # Typed block reasons. Distinguishes the two fundamentally different things a
@@ -3701,6 +3704,130 @@ def list_comments_after(
     ]
 
 
+def _tasks_are_linked(conn: sqlite3.Connection, left_id: str, right_id: str) -> bool:
+    """Return True when either task is linked as parent/child of the other."""
+    return bool(
+        conn.execute(
+            "SELECT 1 FROM task_links "
+            "WHERE (parent_id = ? AND child_id = ?) "
+            "   OR (parent_id = ? AND child_id = ?) "
+            "LIMIT 1",
+            (left_id, right_id, right_id, left_id),
+        ).fetchone()
+    )
+
+
+def request_rework_task(
+    conn: sqlite3.Connection,
+    target_task_id: str,
+    *,
+    reason: Optional[str] = None,
+    feedback: Optional[str] = None,
+    reviewer: str = "kanban-reviewer",
+    author: Optional[str] = None,
+    reviewer_task_id: str,
+    metadata: Optional[dict] = None,
+) -> bool:
+    """Record actionable review feedback and requeue a task for agent work.
+
+    This is not an unblock path: sticky ``blocked`` tasks remain blocked until
+    the explicit human/orchestrator unblock primitive runs. The reviewer task
+    must be linked to the target to avoid arbitrary lifecycle mutation by
+    review workers. This DB primitive is mode-agnostic by design; CLI/tool
+    callers enforce ``kanban.review_loop_mode`` before reaching it.
+    """
+    message = (reason if reason is not None else feedback or "").strip()
+    if not message:
+        raise ValueError("rework feedback is required")
+    reviewer_name = (author or reviewer or "kanban-reviewer").strip()
+    if not reviewer_name:
+        raise ValueError("reviewer is required")
+    now = int(time.time())
+    with write_txn(conn):
+        target = conn.execute(
+            "SELECT status, current_run_id FROM tasks WHERE id = ?",
+            (target_task_id,),
+        ).fetchone()
+        if target is None:
+            raise ValueError(f"unknown task {target_task_id}")
+        status = target["status"]
+        if status == "archived":
+            raise ValueError("cannot request rework on archived task")
+        if status == "running":
+            raise ValueError(
+                "cannot request rework on running task; wait for the active "
+                "implementation run to finish before requesting rework"
+            )
+        if status == "blocked" or _has_sticky_block(conn, target_task_id):
+            raise ValueError(
+                "cannot request rework on blocked task; unblock requires the "
+                "human/orchestrator path"
+            )
+        if not reviewer_task_id:
+            raise ValueError("reviewer_task_id is required for request rework")
+        reviewer_row = conn.execute(
+            "SELECT 1 FROM tasks WHERE id = ?", (reviewer_task_id,)
+        ).fetchone()
+        if reviewer_row is None:
+            raise ValueError(f"unknown reviewer task {reviewer_task_id}")
+        if not _tasks_are_linked(conn, target_task_id, reviewer_task_id):
+            raise ValueError(
+                "reviewer task must be linked to target task before "
+                "requesting rework"
+            )
+        if status not in {"done", "needs_rework"}:
+            raise ValueError(
+                "cannot request rework on task that has not completed "
+                "implementation"
+            )
+        current_run_id = target["current_run_id"]
+        if current_run_id:
+            conn.execute(
+                """
+                UPDATE task_runs
+                   SET status = 'reclaimed', outcome = 'reclaimed',
+                       summary = COALESCE(summary, 'rework requested'),
+                       ended_at = ?,
+                       claim_lock = NULL, claim_expires = NULL, worker_pid = NULL
+                 WHERE id = ? AND ended_at IS NULL
+                """,
+                (now, int(current_run_id)),
+            )
+        conn.execute(
+            "INSERT INTO task_comments (task_id, author, body, created_at) "
+            "VALUES (?, ?, ?, ?)",
+            (target_task_id, reviewer_name, f"REQUEST_CHANGES: {message}", now),
+        )
+        payload: dict[str, Any] = {
+            "reason": message,
+            "reviewer": reviewer_name,
+            "reviewer_task_id": reviewer_task_id,
+        }
+        if metadata:
+            payload["metadata"] = metadata
+        conn.execute(
+            "UPDATE tasks "
+            "SET status = 'needs_rework', result = NULL, completed_at = NULL, "
+            "claim_lock = NULL, claim_expires = NULL, worker_pid = NULL, "
+            "current_run_id = NULL "
+            "WHERE id = ?",
+            (target_task_id,),
+        )
+        # A completed parent being reopened invalidates already-promoted
+        # children. Keep running/done children untouched, but stop stale
+        # ready work from being dispatched until the parent completes again.
+        conn.execute(
+            "UPDATE tasks SET status = 'todo' "
+            "WHERE status = 'ready' "
+            "AND id IN ("
+            "  SELECT child_id FROM task_links WHERE parent_id = ?"
+            ")",
+            (target_task_id,),
+        )
+        _append_event(conn, target_task_id, "rework_requested", payload)
+    return True
+
+
 # ---------------------------------------------------------------------------
 # Attachments
 # ---------------------------------------------------------------------------
@@ -4230,19 +4357,19 @@ def claim_task(
     ttl_seconds: Optional[int] = None,
     claimer: Optional[str] = None,
 ) -> Optional[Task]:
-    """Atomically transition ``ready -> running``.
+    """Atomically transition ``ready``/``needs_rework`` -> ``running``.
 
     Returns the claimed ``Task`` on success, ``None`` if the task was
-    already claimed (or is not in ``ready`` status).
+    already claimed (or is not in a claimable status).
     """
     now = int(time.time())
     lock = claimer or _claimer_id()
     expires = now + _resolve_claim_ttl_seconds(ttl_seconds)
     with write_txn(conn):
-        # Structural invariant: never transition ready -> running while any
+        # Structural invariant: never transition ready/needs_rework -> running while any
         # parent is not yet 'done'. This is the single enforcement point
         # regardless of which writer (create_task, link_tasks, unblock_task,
-        # release_stale_claims, manual SQL) set status='ready'. If a racy
+        # release_stale_claims, manual SQL) set a claimable status. If a racy
         # writer promoted a task with undone parents, demote it back to
         # 'todo' here — recompute_ready will re-promote when the parents
         # actually finish. See RCA at
@@ -4256,7 +4383,7 @@ def claim_task(
         if undone:
             conn.execute(
                 "UPDATE tasks SET status = 'todo' "
-                "WHERE id = ? AND status = 'ready'",
+                "WHERE id = ? AND status IN ('ready', 'needs_rework')",
                 (task_id,),
             )
             _append_event(
@@ -4269,7 +4396,8 @@ def claim_task(
         # it when the CAS resets the pointer below. No-op when the invariant
         # holds (the common case).
         stale = conn.execute(
-            "SELECT current_run_id FROM tasks WHERE id = ? AND status = 'ready'",
+            "SELECT current_run_id FROM tasks "
+            "WHERE id = ? AND status IN ('ready', 'needs_rework')",
             (task_id,),
         ).fetchone()
         if stale and stale["current_run_id"]:
@@ -4292,7 +4420,7 @@ def claim_task(
                    claim_expires = ?,
                    started_at    = COALESCE(started_at, ?)
              WHERE id = ?
-               AND status = 'ready'
+               AND status IN ('ready', 'needs_rework')
                AND claim_lock IS NULL
             """,
             (lock, expires, now, task_id),
@@ -5623,33 +5751,7 @@ def block_task(
     kind: Optional[str] = None,
     expected_run_id: Optional[int] = None,
 ) -> bool:
-    """Transition ``running``/``ready`` → ``blocked`` (or route elsewhere).
-
-    ``kind`` (one of :data:`VALID_BLOCK_KINDS`, or ``None`` for a legacy
-    un-typed block) drives routing instead of every block landing in one
-    undifferentiated ``blocked`` bucket:
-
-    * ``dependency`` — the task is only waiting on another task. It does NOT
-      sit in ``blocked`` (where a cron would keep "unblocking" it); it goes to
-      ``todo`` so the existing parent-gating / ``recompute_ready`` machinery
-      promotes it automatically once its parents finish. No human, no cron, no
-      retry storm. This is Dale's "Type 2 — dependency blocked".
-
-    * ``needs_input`` / ``capability`` / ``None`` — "truly blocked" (Dale's
-      "Type 1"). Lands in ``blocked`` for a human. BUT: each time such a task
-      is re-blocked for the SAME kind after having been unblocked, the
-      unblock-loop counter (``block_recurrences``) increments. When it reaches
-      :data:`BLOCK_RECURRENCE_LIMIT`, the task is routed to ``triage`` instead
-      of ``blocked`` — breaking the cron-unblock ↔ worker-re-block loop and
-      forcing a human-in-the-loop triage decision.
-
-    * ``transient`` — treated like a generic block for routing, but a worker
-      can use it to signal "this might clear on its own"; it still participates
-      in the loop breaker so a forever-flaky task eventually escalates.
-
-    Returns True on any successful transition (to ``blocked``, ``todo``, or
-    ``triage``), False when the task wasn't in a blockable state.
-    """
+    """Transition ``running``/``ready``/``needs_rework`` to blocked or routed work."""
     if kind is not None and kind not in VALID_BLOCK_KINDS:
         raise ValueError(
             f"block kind must be one of {sorted(VALID_BLOCK_KINDS)} or None"
@@ -5684,7 +5786,7 @@ def block_task(
                        worker_pid    = NULL,
                        block_kind    = ?
                  WHERE id = ?
-                   AND status IN ('running', 'ready')
+                   AND status IN ('running', 'ready', 'needs_rework')
                 """ + ("" if expected_run_id is None else " AND current_run_id = ?"),
                 (kind, task_id) if expected_run_id is None
                 else (kind, task_id, int(expected_run_id)),
@@ -5737,7 +5839,7 @@ def block_task(
                        block_kind    = ?,
                        block_recurrences = ?
                  WHERE id = ?
-                   AND status IN ('running', 'ready')
+                   AND status IN ('running', 'ready', 'needs_rework')
                 """ + ("" if expected_run_id is None else " AND current_run_id = ?"),
                 (kind, recurrences, task_id) if expected_run_id is None
                 else (kind, recurrences, task_id, int(expected_run_id)),
@@ -5775,7 +5877,7 @@ def block_task(
                            block_kind    = ?,
                            block_recurrences = ?
                      WHERE id = ?
-                       AND status IN ('running', 'ready')
+                       AND status IN ('running', 'ready', 'needs_rework')
                     """,
                     (kind, recurrences, task_id),
                 )
@@ -5790,7 +5892,7 @@ def block_task(
                            block_kind    = ?,
                            block_recurrences = ?
                      WHERE id = ?
-                       AND status IN ('running', 'ready')
+                       AND status IN ('running', 'ready', 'needs_rework')
                        AND current_run_id = ?
                     """,
                     (kind, recurrences, task_id, int(expected_run_id)),
@@ -8044,13 +8146,15 @@ def check_respawn_guard(conn: sqlite3.Connection, task_id: str) -> Optional[str]
         A completed run exists within ``_RESPAWN_GUARD_SUCCESS_WINDOW``
         seconds.  Useful work already succeeded for this task; wait for
         human review rather than immediately re-spawning. Bypassed when an
-        explicit re-queue event (status change, promote, unblock, reclaim)
-        arrives AFTER that completion — that's a deliberate re-run request.
+        explicit re-queue event (status change, promote, unblock, reclaim,
+        rework request) arrives AFTER that completion — that's a deliberate
+        re-run request.
 
     ``"active_pr"``
         A GitHub PR URL appears in a recent task comment (within
         ``_RESPAWN_GUARD_PR_WINDOW`` seconds).  A prior worker already
-        opened a PR; re-spawning risks a duplicate PR on the same task.
+        opened a PR; re-spawning risks a duplicate PR on the same task. This
+        remains authoritative after explicit re-queue events.
 
     Stale / dead claim locks are NOT a guard reason — they are handled
     by ``release_stale_claims`` and ``detect_crashed_workers`` which
@@ -8125,7 +8229,9 @@ def check_respawn_guard(conn: sqlite3.Connection, task_id: str) -> Optional[str]
         requeued_after = conn.execute(
             "SELECT 1 FROM task_events "
             "WHERE task_id = ? AND created_at >= ? "
-            "AND kind IN ('status', 'promoted', 'unblocked', 'reclaimed') "
+            "AND kind IN ("
+            "'status', 'promoted', 'unblocked', 'reclaimed', 'rework_requested'"
+            ") "
             "LIMIT 1",
             (task_id, completed_at),
         ).fetchone()
@@ -8133,6 +8239,8 @@ def check_respawn_guard(conn: sqlite3.Connection, task_id: str) -> Optional[str]
             return "recent_success"
 
     # 4. GitHub PR URL in a recent comment — prior worker already opened a PR.
+    #    Explicit re-queues bypass recent_success, not active_pr: the existing
+    #    PR remains the owner of follow-up work until this guard becomes stale.
     pr_cutoff = now - _RESPAWN_GUARD_PR_WINDOW
     for c in conn.execute(
         "SELECT body FROM task_comments WHERE task_id = ? AND created_at >= ?",
@@ -8160,7 +8268,7 @@ def has_spawnable_ready(conn: sqlite3.Connection) -> bool:
     """
     rows = conn.execute(
         "SELECT DISTINCT assignee FROM tasks "
-        "WHERE status = 'ready' AND assignee IS NOT NULL "
+        "WHERE status IN ('ready', 'needs_rework') AND assignee IS NOT NULL "
         "    AND claim_lock IS NULL"
     ).fetchall()
     if not rows:
@@ -8292,7 +8400,7 @@ def _dispatch_once_locked(
       2. Reclaim stale running tasks (no recent heartbeat).
       3. Reclaim crashed running tasks (host-local PID no longer alive).
       3. Promote todo -> ready where all parents are done.
-      4. For each ready task with an assignee, atomically claim and call
+      4. For each ready/needs_rework task with an assignee, atomically claim and call
          ``spawn_fn(task, workspace_path, board) -> Optional[int]``. The
          return value (if any) is recorded as ``worker_pid`` so subsequent
          ticks can detect crashes before the TTL expires.
@@ -8359,7 +8467,7 @@ def _dispatch_once_locked(
 
     ready_rows = conn.execute(
         "SELECT id, assignee FROM tasks "
-        "WHERE status = 'ready' AND claim_lock IS NULL "
+        "WHERE status IN ('ready', 'needs_rework') AND claim_lock IS NULL "
         "ORDER BY priority DESC, created_at ASC"
     ).fetchall()
     # Honour kanban.max_in_progress: if the board already has enough running

--- a/plugins/kanban/dashboard/dist/index.js
+++ b/plugins/kanban/dashboard/dist/index.js
@@ -87,25 +87,34 @@
   }
 
   // Order matches BOARD_COLUMNS in plugin_api.py.
-  const COLUMN_ORDER = ["triage", "todo", "ready", "running", "blocked", "done"];
+  const COLUMN_ORDER = [
+    "triage", "todo", "scheduled", "ready", "needs_rework", "running",
+    "blocked", "review", "done",
+  ];
   // English fallback dictionaries — used when the i18n catalog is missing
   // a key, and as defaults for the get*() helpers below so callers running
   // outside any React component (where there's no `t`) still get sane text.
   const FALLBACK_COLUMN_LABEL = {
     triage: "Triage",
     todo: "Todo",
+    scheduled: "Scheduled",
     ready: "Ready",
+    needs_rework: "Needs Rework",
     running: "In Progress",
     blocked: "Blocked",
+    review: "Review",
     done: "Done",
     archived: "Archived",
   };
   const FALLBACK_COLUMN_HELP = {
     triage: "Raw ideas — a specifier will flesh out the spec",
     todo: "Waiting on dependencies or unassigned",
+    scheduled: "Deferred until a scheduled time",
     ready: "Dependencies satisfied; assign a profile to dispatch",
+    needs_rework: "Reviewer requested actionable changes; dispatcher can re-run the assignee",
     running: "Claimed by a worker — in-flight",
     blocked: "Worker asked for human input",
+    review: "Awaiting reviewer judgment",
     done: "Completed",
     archived: "Archived",
   };
@@ -154,9 +163,12 @@
   const COLUMN_DOT = {
     triage: "hermes-kanban-dot-triage",
     todo: "hermes-kanban-dot-todo",
+    scheduled: "hermes-kanban-dot-scheduled",
     ready: "hermes-kanban-dot-ready",
+    needs_rework: "hermes-kanban-dot-needs-rework",
     running: "hermes-kanban-dot-running",
     blocked: "hermes-kanban-dot-blocked",
+    review: "hermes-kanban-dot-review",
     done: "hermes-kanban-dot-done",
     archived: "hermes-kanban-dot-archived",
   };
@@ -717,6 +729,10 @@
 
     // --- actions ------------------------------------------------------------
     const moveTask = useCallback(function (taskId, newStatus) {
+      if (newStatus === "needs_rework") {
+        setError("Needs Rework is review-controlled. Use request-rework with reviewer feedback instead of drag/drop.");
+        return;
+      }
       const confirmMsg = getDestructiveConfirm(t, newStatus);
       if (confirmMsg && !window.confirm(confirmMsg)) return;
       const patch = withCompletionSummary({ status: newStatus }, 1, t);
@@ -753,6 +769,10 @@
       setFailedIds(new Set());
     }, []);
     const moveSelected = useCallback(function (newStatus) {
+      if (newStatus === "needs_rework") {
+        setError("Needs Rework is review-controlled. Use request-rework with reviewer feedback instead of bulk move.");
+        return;
+      }
       const confirmMsg = DESTRUCTIVE_TRANSITIONS[newStatus];
       if (confirmMsg && !window.confirm(confirmMsg)) return;
       if (selectedIds.size === 0) return;
@@ -892,6 +912,10 @@
 
     const applyBulk = useCallback(function (patch, confirmMsg) {
       if (selectedIds.size === 0) return;
+      if (patch && patch.status === "needs_rework") {
+        setError("Needs Rework is review-controlled. Use request-rework with reviewer feedback instead of bulk move.");
+        return;
+      }
       if (confirmMsg && !window.confirm(confirmMsg)) return;
       const finalPatch = withCompletionSummary(patch, selectedIds.size, t);
       if (!finalPatch) return;
@@ -1706,7 +1730,7 @@
           className: msg.ok ? "hermes-kanban-msg-ok" : "hermes-kanban-msg-err",
         }, msg.text) : null,
 
-        settings ? h("div", { className: "grid gap-3 sm:grid-cols-3" },
+        settings ? h("div", { className: "grid gap-3 sm:grid-cols-4" },
           h("div", { className: "flex flex-col gap-1" },
             h(Label, { className: "text-xs text-muted-foreground" },
               "Orchestrator profile"),
@@ -1757,6 +1781,23 @@
               settings.auto_decompose
                 ? "The dispatcher decomposes new triage tasks automatically."
                 : "Triage tasks stay in triage until you click ⚗ Decompose."),
+          ),
+          h("div", { className: "flex flex-col gap-1" },
+            h(Label, { className: "text-xs text-muted-foreground" },
+              "Review loop"),
+            h(Select, Object.assign({
+              value: settings.review_loop_mode || "human",
+              className: "h-8",
+            }, selectChangeHandler(function (v) {
+              saveSettings({ review_loop_mode: v || "human" });
+            })),
+              h(SelectOption, { value: "human" }, "Human gate"),
+              h(SelectOption, { value: "agent" }, "Agent rework"),
+            ),
+            h("div", { className: "text-[10px] text-muted-foreground" },
+              (settings.review_loop_mode || "human") === "agent"
+                ? "Reviewers may use kanban_request_rework on linked tasks; blocked still means human/external gate."
+                : "Default safe mode: reviewers hand off feedback; humans/orchestrators decide what to requeue."),
           ),
         ) : h("div", { className: "text-xs text-muted-foreground" },
           "Loading…"),

--- a/plugins/kanban/dashboard/dist/style.css
+++ b/plugins/kanban/dashboard/dist/style.css
@@ -172,9 +172,12 @@
 }
 .hermes-kanban-dot-triage   { background: #b47dd6; }  /* lilac — fresh/unspecified */
 .hermes-kanban-dot-todo     { background: var(--color-muted-foreground); }
+.hermes-kanban-dot-scheduled { background: #8b5cf6; }  /* violet */
 .hermes-kanban-dot-ready    { background: #d4b348; }  /* amber */
+.hermes-kanban-dot-needs-rework { background: #f97316; }  /* orange */
 .hermes-kanban-dot-running  { background: #3fb97d; }  /* green */
 .hermes-kanban-dot-blocked  { background: var(--color-destructive, #d14a4a); }
+.hermes-kanban-dot-review   { background: #38bdf8; }  /* sky */
 .hermes-kanban-dot-done     { background: #4a8cd1; }  /* blue */
 .hermes-kanban-dot-archived { background: var(--color-border); }
 

--- a/plugins/kanban/dashboard/plugin_api.py
+++ b/plugins/kanban/dashboard/plugin_api.py
@@ -148,7 +148,8 @@ def _conn(board: Optional[str] = None):
 # tasks into ``todo`` and makes the dashboard look like the Scheduled column
 # disappeared.
 BOARD_COLUMNS: list[str] = [
-    "triage", "todo", "scheduled", "ready", "running", "blocked", "review", "done",
+    "triage", "todo", "scheduled", "ready", "needs_rework", "running",
+    "blocked", "review", "done",
 ]
 
 
@@ -886,6 +887,14 @@ def update_task(task_id: str, payload: UpdateTaskBody, board: Optional[str] = Qu
                 ok = kanban_db.block_task(conn, task_id, reason=payload.block_reason)
             elif s == "scheduled":
                 ok = kanban_db.schedule_task(conn, task_id, reason=payload.block_reason)
+            elif s == "needs_rework":
+                raise HTTPException(
+                    status_code=400,
+                    detail=(
+                        "Cannot set status to 'needs_rework' directly; use "
+                        "request-rework with linked reviewer feedback"
+                    ),
+                )
             elif s == "ready":
                 # Re-open a blocked/scheduled task, or just an explicit status set.
                 current = kanban_db.get_task(conn, task_id)
@@ -1281,6 +1290,16 @@ def bulk_update(payload: BulkTaskBody, board: Optional[str] = Query(None)):
                         continue
                     elif s == "scheduled":
                         ok = kanban_db.schedule_task(conn, tid)
+                    elif s == "needs_rework":
+                        entry.update(
+                            ok=False,
+                            error=(
+                                "Cannot set status to 'needs_rework' directly; "
+                                "use request-rework with linked reviewer feedback"
+                            ),
+                        )
+                        results.append(entry)
+                        continue
                     elif s in {"todo", "triage"}:
                         ok = _set_status_direct(conn, tid, s)
                     else:
@@ -2668,6 +2687,7 @@ class OrchestrationSettingsBody(BaseModel):
     default_assignee: Optional[str] = None
     auto_decompose: Optional[bool] = None
     auto_promote_children: Optional[bool] = None
+    review_loop_mode: Optional[str] = None
 
 
 @router.get("/orchestration")
@@ -2684,6 +2704,9 @@ def get_orchestration_settings():
     explicit_default = (kanban_cfg.get("default_assignee") or "").strip()
     auto_decompose = bool(kanban_cfg.get("auto_decompose", True))
     auto_promote_children = bool(kanban_cfg.get("auto_promote_children", True))
+    review_loop_mode = str(kanban_cfg.get("review_loop_mode", "human") or "human").strip().lower()
+    if review_loop_mode not in {"human", "agent"}:
+        review_loop_mode = "human"
 
     # Resolve fallbacks the same way the decomposer does.
     resolved_orch = explicit_orch
@@ -2707,6 +2730,7 @@ def get_orchestration_settings():
         "default_assignee": explicit_default,
         "auto_decompose": auto_decompose,
         "auto_promote_children": auto_promote_children,
+        "review_loop_mode": review_loop_mode,
         "resolved_orchestrator_profile": resolved_orch,
         "resolved_default_assignee": resolved_default,
         "active_profile": active_default,
@@ -2774,6 +2798,15 @@ def set_orchestration_settings(payload: OrchestrationSettingsBody):
 
     if payload.auto_promote_children is not None:
         kanban_section["auto_promote_children"] = bool(payload.auto_promote_children)
+
+    if payload.review_loop_mode is not None:
+        mode = str(payload.review_loop_mode or "").strip().lower()
+        if mode not in {"human", "agent"}:
+            raise HTTPException(
+                status_code=400,
+                detail="review_loop_mode must be 'human' or 'agent'",
+            )
+        kanban_section["review_loop_mode"] = mode
 
     try:
         save_config(cfg)

--- a/tests/hermes_cli/test_kanban_cli.py
+++ b/tests/hermes_cli/test_kanban_cli.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import subprocess
+import sys
 import threading
 from pathlib import Path
 
@@ -38,6 +40,309 @@ def kanban_home(tmp_path, monkeypatch):
 # run_slash smoke tests (end-to-end via the same entry both CLI and gateway use)
 # ---------------------------------------------------------------------------
 
+def test_run_slash_no_args_shows_usage(kanban_home):
+    out = kc.run_slash("")
+    assert "kanban" in out.lower()
+    assert "create" in out.lower() or "subcommand" in out.lower() or "action" in out.lower()
+
+
+def test_run_slash_create_and_list(kanban_home):
+    out = kc.run_slash("create 'ship feature' --assignee alice")
+    assert "Created" in out
+    out = kc.run_slash("list")
+    assert "ship feature" in out
+    assert "alice" in out
+
+
+def test_run_slash_create_worktree_path_and_branch(kanban_home, tmp_path):
+    target = tmp_path / ".worktrees" / "t6-wire"
+    target_arg = target.as_posix()
+    out = kc.run_slash(
+        f"create 'ship worktree' --workspace worktree:{target_arg} --branch wt/t6-wire"
+    )
+    assert "Created" in out
+
+    with kb.connect() as conn:
+        tasks = kb.list_tasks(conn)
+    task = tasks[0]
+    assert task.workspace_kind == "worktree"
+    assert task.workspace_path == target_arg
+    assert task.branch_name == "wt/t6-wire"
+
+
+def test_run_slash_rejects_branch_without_worktree(kanban_home):
+    out = kc.run_slash("create 'bad branch' --workspace scratch --branch wt/bad")
+    assert "--branch is only valid with --workspace worktree" in out
+
+
+def test_run_slash_create_with_parent_and_cascade(kanban_home):
+    # Parent then child via --parent
+    out1 = kc.run_slash("create 'parent' --assignee alice")
+    # Extract the "t_xxxx" id from "Created t_xxxx (ready, ...)"
+    import re
+    m = re.search(r"(t_[a-f0-9]+)", out1)
+    assert m
+    p = m.group(1)
+    out2 = kc.run_slash(f"create 'child' --assignee bob --parent {p}")
+    assert "todo" in out2  # child starts as todo
+
+    # Complete parent; list should promote child to ready
+    kc.run_slash(f"complete {p}")
+    # Explicit filter: child should now be ready (was todo before complete).
+    ready_list = kc.run_slash("list --status ready")
+    assert "child" in ready_list
+
+
+def test_run_slash_show_includes_comments(kanban_home):
+    out = kc.run_slash("create 'x'")
+    import re
+    tid = re.search(r"(t_[a-f0-9]+)", out).group(1)
+    kc.run_slash(f"comment {tid} 'remember to include performance section'")
+    show = kc.run_slash(f"show {tid}")
+    assert "performance section" in show
+
+
+def test_run_slash_comment_max_len_trims_long_body(kanban_home):
+    out = kc.run_slash("create 'x'")
+    import re
+    tid = re.search(r"(t_[a-f0-9]+)", out).group(1)
+    kc.run_slash(f"comment {tid} '{'x' * 30}' --max-len 20")
+    show = kc.run_slash(f"show {tid}")
+    assert "trimmed to 20 chars by --max-len" in show
+    assert "x" * 30 not in show
+
+
+def test_run_slash_block_unblock_cycle(kanban_home):
+    out = kc.run_slash("create 'x' --assignee alice")
+    import re
+    tid = re.search(r"(t_[a-f0-9]+)", out).group(1)
+    # Claim first so block() finds it running
+    kc.run_slash(f"claim {tid}")
+    assert "Blocked" in kc.run_slash(f"block {tid} 'need decision'")
+    assert "Unblocked" in kc.run_slash(f"unblock {tid}")
+
+
+def test_run_slash_blocks_needs_rework_task(kanban_home):
+    with kb.connect() as conn:
+        target = kb.create_task(conn, title="implementation", assignee="hefesto")
+        assert kb.complete_task(conn, target, result="implementation done")
+        reviewer = kb.create_task(
+            conn, title="review", assignee="temis", parents=[target]
+        )
+        kb.request_rework_task(
+            conn,
+            target_task_id=target,
+            reviewer_task_id=reviewer,
+            feedback="missing regression test",
+            author="temis",
+        )
+
+    out = kc.run_slash(f"block {target} 'needs human decision'")
+
+    assert "Blocked" in out
+    with kb.connect() as conn:
+        task = kb.get_task(conn, target)
+        assert task is not None
+        assert task.status == "blocked"
+
+
+def test_run_slash_request_rework_rejects_default_human_mode(kanban_home):
+    with kb.connect() as conn:
+        target = kb.create_task(conn, title="implementation", assignee="hefesto")
+        assert kb.complete_task(conn, target, result="implementation done")
+        reviewer = kb.create_task(
+            conn, title="review", assignee="temis", parents=[target]
+        )
+
+    out = kc.run_slash(
+        f"request-rework {target} --reviewer-task {reviewer} 'missing regression test'"
+    )
+
+    assert "review_loop_mode" in out
+    assert "agent" in out
+    with kb.connect() as conn:
+        task = kb.get_task(conn, target)
+        assert task is not None
+        assert task.status == "done"
+
+
+def test_main_propagates_request_rework_rejection_exit_code(kanban_home):
+    with kb.connect() as conn:
+        target = kb.create_task(conn, title="implementation", assignee="hefesto")
+        reviewer = kb.create_task(
+            conn, title="review", assignee="temis", parents=[target]
+        )
+
+    env = os.environ.copy()
+    env["HERMES_HOME"] = str(kanban_home)
+    proc = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "hermes_cli.main",
+            "kanban",
+            "request-rework",
+            target,
+            "missing regression test",
+            "--reviewer-task",
+            reviewer,
+        ],
+        cwd=Path(__file__).resolve().parents[2],
+        env=env,
+        text=True,
+        capture_output=True,
+    )
+
+    assert proc.returncode != 0
+    assert "review_loop_mode" in (proc.stdout + proc.stderr)
+    with kb.connect() as conn:
+        task = kb.get_task(conn, target)
+        assert task is not None
+        assert task.status == "ready"
+
+
+def test_main_successful_subcommand_exits_zero(kanban_home):
+    env = os.environ.copy()
+    env["HERMES_HOME"] = str(kanban_home)
+
+    proc = subprocess.run(
+        [sys.executable, "-m", "hermes_cli.main", "kanban", "stats", "--json"],
+        cwd=Path(__file__).resolve().parents[2],
+        env=env,
+        text=True,
+        capture_output=True,
+    )
+
+    assert proc.returncode == 0
+    assert json.loads(proc.stdout)["by_status"] == {}
+
+
+def test_run_slash_request_rework_marks_linked_target(kanban_home):
+    Path(kanban_home, "config.yaml").write_text(
+        "kanban:\n  review_loop_mode: agent\n"
+    )
+    with kb.connect() as conn:
+        target = kb.create_task(conn, title="implementation", assignee="hefesto")
+        assert kb.complete_task(conn, target, result="implementation done")
+        reviewer = kb.create_task(
+            conn, title="review", assignee="temis", parents=[target]
+        )
+
+    out = kc.run_slash(
+        f"request-rework {target} --reviewer-task {reviewer} 'missing regression test'"
+    )
+
+    assert "Rework requested" in out
+    with kb.connect() as conn:
+        task = kb.get_task(conn, target)
+        assert task is not None
+        assert task.status == "needs_rework"
+
+
+def test_run_slash_request_rework_rejects_archived_target(kanban_home):
+    Path(kanban_home, "config.yaml").write_text(
+        "kanban:\n  review_loop_mode: agent\n"
+    )
+    with kb.connect() as conn:
+        target = kb.create_task(conn, title="implementation", assignee="hefesto")
+        reviewer = kb.create_task(
+            conn, title="review", assignee="temis", parents=[target]
+        )
+        assert kb.archive_task(conn, target)
+
+    out = kc.run_slash(
+        f"request-rework {target} --reviewer-task {reviewer} 'missing regression test'"
+    )
+
+    assert "archived" in out
+    with kb.connect() as conn:
+        task = kb.get_task(conn, target)
+        assert task is not None
+        assert task.status == "archived"
+
+
+def test_run_slash_stats_prints_review_loop_statuses(kanban_home):
+    with kb.connect() as conn:
+        needs_rework = kb.create_task(conn, title="implementation", assignee="hefesto")
+        assert kb.complete_task(conn, needs_rework, result="implementation done")
+        reviewer = kb.create_task(
+            conn, title="review", assignee="temis", parents=[needs_rework]
+        )
+        kb.request_rework_task(
+            conn,
+            target_task_id=needs_rework,
+            reviewer_task_id=reviewer,
+            feedback="missing regression test",
+            author="temis",
+        )
+        review = kb.create_task(conn, title="manual review", assignee="temis")
+        conn.execute("UPDATE tasks SET status = 'review' WHERE id = ?", (review,))
+        conn.commit()
+
+    out = kc.run_slash("stats")
+
+    assert "needs_rework" in out
+    assert "review" in out
+
+
+def test_run_slash_json_output(kanban_home):
+    out = kc.run_slash("create 'jsontask' --assignee alice --json")
+    payload = json.loads(out)
+    assert payload["title"] == "jsontask"
+    assert payload["assignee"] == "alice"
+    assert payload["status"] == "ready"
+
+
+def test_run_slash_dispatch_dry_run_counts(kanban_home):
+    kc.run_slash("create 'a' --assignee alice")
+    kc.run_slash("create 'b' --assignee bob")
+    out = kc.run_slash("dispatch --dry-run")
+    assert "Spawned:" in out
+
+
+def test_run_slash_context_output_format(kanban_home):
+    out = kc.run_slash("create 'tech spec' --assignee alice --body 'write an RFC'")
+    import re
+    tid = re.search(r"(t_[a-f0-9]+)", out).group(1)
+    kc.run_slash(f"comment {tid} 'remember to include performance section'")
+    ctx = kc.run_slash(f"context {tid}")
+    assert "tech spec" in ctx
+    assert "write an RFC" in ctx
+    assert "performance section" in ctx
+
+
+def test_run_slash_tenant_filter(kanban_home):
+    kc.run_slash("create 'biz-a task' --tenant biz-a --assignee alice")
+    kc.run_slash("create 'biz-b task' --tenant biz-b --assignee alice")
+    a = kc.run_slash("list --tenant biz-a")
+    b = kc.run_slash("list --tenant biz-b")
+    assert "biz-a task" in a and "biz-b task" not in a
+    assert "biz-b task" in b and "biz-a task" not in b
+
+
+def test_run_slash_session_filter(kanban_home):
+    """`hermes kanban list --session <id>` filters by the originating
+    chat session id stamped on tasks created from inside an ACP loop."""
+    from hermes_cli import kanban_db as kb
+    with kb.connect() as conn:
+        kb.create_task(
+            conn, title="from sess-1 a", assignee="alice", session_id="sess-1"
+        )
+        kb.create_task(
+            conn, title="from sess-1 b", assignee="alice", session_id="sess-1"
+        )
+        kb.create_task(
+            conn, title="from sess-2", assignee="alice", session_id="sess-2"
+        )
+        kb.create_task(conn, title="cli only", assignee="alice")
+    out_1 = kc.run_slash("list --session sess-1")
+    out_2 = kc.run_slash("list --session sess-2")
+    assert "from sess-1 a" in out_1
+    assert "from sess-1 b" in out_1
+    assert "from sess-2" not in out_1
+    assert "cli only" not in out_1
+    assert "from sess-2" in out_2
+    assert "from sess-1 a" not in out_2
 
 
 def test_kanban_list_json_includes_session_id(kanban_home):

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -45,6 +45,13 @@ def _init_git_repo(repo: Path) -> None:
 
 
 
+def test_needs_rework_is_valid_status_and_default_review_loop_is_human():
+    from hermes_cli.config import DEFAULT_CONFIG
+
+    assert "needs_rework" in kb.VALID_STATUSES
+    assert DEFAULT_CONFIG["kanban"]["review_loop_mode"] == "human"
+
+
 
 
 
@@ -373,6 +380,32 @@ def test_respawn_guard_defers_rate_limited_within_cooldown(
 
 
 
+def test_block_accepts_needs_rework_as_human_gate(kanban_home):
+    with kb.connect() as conn:
+        target = kb.create_task(conn, title="implementation", assignee="hefesto")
+        assert kb.complete_task(conn, target, result="implementation done")
+        reviewer = kb.create_task(conn, title="review", assignee="temis", parents=[target])
+        kb.request_rework_task(
+            conn,
+            target_task_id=target,
+            reviewer_task_id=reviewer,
+            feedback="missing regression test",
+            author="temis",
+        )
+
+        rework_task = kb.get_task(conn, target)
+        assert rework_task is not None
+        assert rework_task.status == "needs_rework"
+        assert kb.block_task(conn, target, reason="needs human decision")
+
+        blocked = kb.get_task(conn, target)
+        events = kb.list_events(conn, target)
+
+    assert blocked is not None
+    assert blocked.status == "blocked"
+    assert any(event.kind == "blocked" for event in events)
+
+
 
 
 def test_recompute_ready_honours_dispatcher_failure_limit(kanban_home):
@@ -489,6 +522,275 @@ def test_delete_task_removes_task_and_cascades(kanban_home):
 
 
 
+def test_request_rework_marks_linked_target_needs_rework_with_feedback(kanban_home):
+    with kb.connect() as conn:
+        target = kb.create_task(conn, title="implementation", assignee="hefesto")
+        assert kb.complete_task(conn, target, result="implementation done")
+        reviewer = kb.create_task(conn, title="review", assignee="temis", parents=[target])
+
+        kb.request_rework_task(
+            conn,
+            target_task_id=target,
+            reviewer_task_id=reviewer,
+            feedback="missing regression test for retries",
+            author="temis",
+        )
+
+        task = kb.get_task(conn, target)
+        comments = kb.list_comments(conn, target)
+        events = kb.list_events(conn, target)
+
+    assert task is not None
+    assert task.status == "needs_rework"
+    assert comments[-1].author == "temis"
+    assert "missing regression test" in comments[-1].body
+    assert any(e.kind == "rework_requested" for e in events)
+
+
+def test_request_rework_demotes_ready_children_until_parent_completes_again(kanban_home):
+    with kb.connect() as conn:
+        target = kb.create_task(conn, title="implementation", assignee="hefesto")
+        assert kb.complete_task(conn, target, result="implementation done")
+        reviewer = kb.create_task(conn, title="review", assignee="temis", parents=[target])
+        downstream = kb.create_task(conn, title="ship", assignee="odiseo", parents=[target])
+        running_child = kb.create_task(
+            conn, title="already running", assignee="odiseo", parents=[target]
+        )
+        kb.claim_task(conn, running_child, claimer="host:running-child")
+
+        reviewer_before = kb.get_task(conn, reviewer)
+        downstream_before = kb.get_task(conn, downstream)
+        running_before = kb.get_task(conn, running_child)
+        assert reviewer_before is not None
+        assert reviewer_before.status == "ready"
+        assert downstream_before is not None
+        assert downstream_before.status == "ready"
+        assert running_before is not None
+        assert running_before.status == "running"
+
+        kb.request_rework_task(
+            conn,
+            target_task_id=target,
+            reviewer_task_id=reviewer,
+            feedback="missing regression test for retries",
+            author="temis",
+        )
+
+        reopened = kb.get_task(conn, target)
+        reviewer_after = kb.get_task(conn, reviewer)
+        downstream_after = kb.get_task(conn, downstream)
+        running_after = kb.get_task(conn, running_child)
+
+    assert reopened is not None
+    assert reopened.status == "needs_rework"
+    assert reviewer_after is not None
+    assert reviewer_after.status == "todo"
+    assert downstream_after is not None
+    assert downstream_after.status == "todo"
+    assert running_after is not None
+    assert running_after.status == "running"
+
+
+def test_request_rework_rejects_incomplete_target_status(kanban_home):
+    with kb.connect() as conn:
+        target = kb.create_task(conn, title="implementation", assignee="hefesto")
+        reviewer = kb.create_task(conn, title="review", assignee="temis", parents=[target])
+
+        with pytest.raises(ValueError, match="completed implementation"):
+            kb.request_rework_task(
+                conn,
+                target_task_id=target,
+                reviewer_task_id=reviewer,
+                feedback="please redo before implementation finished",
+                author="temis",
+            )
+
+        task = kb.get_task(conn, target)
+
+    assert task is not None
+    assert task.status == "ready"
+
+
+def test_request_rework_allows_additional_feedback_on_needs_rework(kanban_home):
+    with kb.connect() as conn:
+        target = kb.create_task(conn, title="implementation", assignee="hefesto")
+        assert kb.complete_task(conn, target, result="implementation done")
+        first_review = kb.create_task(conn, title="review", assignee="temis", parents=[target])
+        assert kb.request_rework_task(
+            conn,
+            target_task_id=target,
+            reviewer_task_id=first_review,
+            feedback="missing regression test",
+            author="temis",
+        )
+        second_review = kb.create_task(
+            conn, title="follow-up review", assignee="temis", parents=[target]
+        )
+
+        assert kb.request_rework_task(
+            conn,
+            target_task_id=target,
+            reviewer_task_id=second_review,
+            feedback="also update docs",
+            author="temis",
+        )
+        task = kb.get_task(conn, target)
+        comments = kb.list_comments(conn, target)
+
+    assert task is not None
+    assert task.status == "needs_rework"
+    assert [comment.body for comment in comments][-2:] == [
+        "REQUEST_CHANGES: missing regression test",
+        "REQUEST_CHANGES: also update docs",
+    ]
+
+
+def test_request_rework_clears_stale_completion_fields_but_keeps_history(kanban_home):
+    with kb.connect() as conn:
+        target = kb.create_task(conn, title="implementation", assignee="hefesto")
+        assert kb.complete_task(
+            conn,
+            target,
+            result="stale done result",
+            summary="completed implementation summary",
+        )
+        reviewer = kb.create_task(conn, title="review", assignee="temis", parents=[target])
+
+        completed = kb.get_task(conn, target)
+        assert completed is not None
+        assert completed.status == "done"
+        assert completed.result == "stale done result"
+        assert completed.completed_at is not None
+
+        kb.request_rework_task(
+            conn,
+            target_task_id=target,
+            reviewer_task_id=reviewer,
+            feedback="please address review feedback",
+            author="temis",
+        )
+
+        reopened = kb.get_task(conn, target)
+        runs = kb.list_runs(conn, target)
+        comments = kb.list_comments(conn, target)
+        events = kb.list_events(conn, target)
+
+    assert reopened is not None
+    assert reopened.status == "needs_rework"
+    assert reopened.result is None
+    assert reopened.completed_at is None
+    assert [run.summary for run in runs] == ["completed implementation summary"]
+    assert comments[-1].body == "REQUEST_CHANGES: please address review feedback"
+    assert any(e.kind == "completed" for e in events)
+    assert any(e.kind == "rework_requested" for e in events)
+
+
+def test_request_rework_rejects_unlinked_target(kanban_home):
+    with kb.connect() as conn:
+        target = kb.create_task(conn, title="implementation", assignee="hefesto")
+        unrelated_reviewer = kb.create_task(conn, title="review", assignee="temis")
+
+        with pytest.raises(ValueError, match="linked"):
+            kb.request_rework_task(
+                conn,
+                target_task_id=target,
+                reviewer_task_id=unrelated_reviewer,
+                feedback="please redo",
+                author="temis",
+            )
+
+
+def test_request_rework_requires_reviewer_task_id(kanban_home):
+    with kb.connect() as conn:
+        target = kb.create_task(conn, title="implementation", assignee="hefesto")
+
+        with pytest.raises(ValueError, match="reviewer_task_id"):
+            kb.request_rework_task(
+                conn,
+                target_task_id=target,
+                reviewer_task_id="",
+                feedback="please redo",
+                author="temis",
+            )
+
+        task = kb.get_task(conn, target)
+        assert task is not None
+        assert task.status == "ready"
+
+
+def test_request_rework_does_not_bypass_sticky_block(kanban_home):
+    with kb.connect() as conn:
+        target = kb.create_task(conn, title="implementation", assignee="hefesto")
+        reviewer = kb.create_task(conn, title="review", assignee="temis", parents=[target])
+        kb.block_task(conn, target, reason="human decision required")
+
+        with pytest.raises(ValueError, match="blocked"):
+            kb.request_rework_task(
+                conn,
+                target_task_id=target,
+                reviewer_task_id=reviewer,
+                feedback="please redo",
+                author="temis",
+            )
+
+        task = kb.get_task(conn, target)
+        assert task is not None
+        assert task.status == "blocked"
+
+
+def test_request_rework_rejects_running_target(kanban_home):
+    with kb.connect() as conn:
+        target = kb.create_task(conn, title="implementation", assignee="hefesto")
+        reviewer = kb.create_task(conn, title="review", assignee="temis", parents=[target])
+        claimed = kb.claim_task(conn, target, claimer="active-worker")
+        assert claimed is not None
+
+        with pytest.raises(ValueError, match="running"):
+            kb.request_rework_task(
+                conn,
+                target_task_id=target,
+                reviewer_task_id=reviewer,
+                feedback="please redo",
+                author="temis",
+            )
+
+        task = kb.get_task(conn, target)
+        assert task is not None
+        assert task.status == "running"
+
+
+def test_request_rework_rejects_archived_target(kanban_home):
+    with kb.connect() as conn:
+        target = kb.create_task(conn, title="implementation", assignee="hefesto")
+        reviewer = kb.create_task(conn, title="review", assignee="temis", parents=[target])
+        assert kb.archive_task(conn, target)
+
+        with pytest.raises(ValueError, match="archived"):
+            kb.request_rework_task(
+                conn,
+                target_task_id=target,
+                reviewer_task_id=reviewer,
+                feedback="please redo",
+                author="temis",
+            )
+
+        task = kb.get_task(conn, target)
+        assert task is not None
+        assert task.status == "archived"
+
+
+def test_claim_task_accepts_needs_rework_without_unblock(kanban_home):
+    with kb.connect() as conn:
+        task_id = kb.create_task(conn, title="fix requested changes", assignee="hefesto")
+        conn.execute("UPDATE tasks SET status = 'needs_rework' WHERE id = ?", (task_id,))
+        conn.commit()
+
+        claimed = kb.claim_task(conn, task_id, claimer="test-claimer")
+
+    assert claimed is not None
+    assert claimed.status == "running"
+
+
 # ---------------------------------------------------------------------------
 # Dispatcher
 # ---------------------------------------------------------------------------
@@ -505,6 +807,70 @@ def test_delete_task_removes_task_and_cascades(kanban_home):
 
 
 
+
+
+def test_needs_rework_bypasses_recent_success_respawn_guard(
+    kanban_home, all_assignees_spawnable
+):
+    """Reviewer-requested rework supersedes the just-completed run."""
+    with kb.connect() as conn:
+        target = kb.create_task(conn, title="implementation", assignee="hefesto")
+        assert kb.complete_task(conn, target, result="implementation done")
+        reviewer = kb.create_task(conn, title="review", assignee="temis", parents=[target])
+        assert kb.request_rework_task(
+            conn,
+            target_task_id=target,
+            reviewer_task_id=reviewer,
+            feedback="missing regression test",
+            author="temis",
+        )
+
+        task = kb.get_task(conn, target)
+        assert task is not None
+        assert task.status == "needs_rework"
+        assert kb.check_respawn_guard(conn, target) is None
+        res = kb.dispatch_once(conn, dry_run=True)
+
+    assert (target, "hefesto", "") in res.spawned
+    assert not res.respawn_guarded
+
+
+def test_needs_rework_retains_active_pr_respawn_guard(
+    kanban_home, all_assignees_spawnable
+):
+    """Rework remains guarded while a recent PR already owns the task."""
+    with kb.connect() as conn:
+        target = kb.create_task(conn, title="implementation", assignee="hefesto")
+        assert kb.complete_task(conn, target, result="PR opened")
+        old_end = int(time.time()) - kb._RESPAWN_GUARD_SUCCESS_WINDOW - 60
+        conn.execute(
+            "UPDATE task_runs SET ended_at = ? "
+            "WHERE task_id = ? AND outcome = 'completed'",
+            (old_end, target),
+        )
+        kb.add_comment(
+            conn,
+            target,
+            "worker",
+            "PR created: https://github.com/NousResearch/hermes-agent/pull/48274",
+        )
+        reviewer = kb.create_task(conn, title="review", assignee="temis", parents=[target])
+        assert kb.request_rework_task(
+            conn,
+            target_task_id=target,
+            reviewer_task_id=reviewer,
+            feedback="address review comments",
+            author="temis",
+        )
+
+        task = kb.get_task(conn, target)
+        assert task is not None
+        assert task.status == "needs_rework"
+        assert kb.check_respawn_guard(conn, target) == "active_pr"
+        res = kb.dispatch_once(conn, dry_run=True)
+
+    assert (target, "active_pr") in res.respawn_guarded
+    assert not res.spawned
 
 
 

--- a/tests/plugins/test_kanban_dashboard_plugin.py
+++ b/tests/plugins/test_kanban_dashboard_plugin.py
@@ -74,10 +74,68 @@ def test_board_empty(client):
     assert set(names) == kb.VALID_STATUSES - {"archived"}
     for expected in ("triage", "todo", "scheduled", "ready", "running", "blocked", "done"):
         assert expected in names, f"missing column {expected}: {names}"
+    assert "needs_rework" in names
     assert all(len(c["tasks"]) == 0 for c in data["columns"])
     assert data["tenants"] == []
     assert data["assignees"] == []
     assert data["latest_event_id"] == 0
+
+
+def test_orchestration_settings_expose_review_loop_mode(client):
+    r = client.get("/api/plugins/kanban/orchestration")
+    assert r.status_code == 200
+    assert r.json()["review_loop_mode"] == "human"
+
+    updated = client.put(
+        "/api/plugins/kanban/orchestration",
+        json={"review_loop_mode": "agent"},
+    )
+    assert updated.status_code == 200, updated.text
+    assert updated.json()["review_loop_mode"] == "agent"
+
+
+def test_dashboard_rejects_direct_needs_rework_status(client):
+    created = client.post(
+        "/api/plugins/kanban/tasks",
+        json={"title": "implementation", "assignee": "hefesto"},
+    )
+    assert created.status_code == 200, created.text
+    task_id = created.json()["task"]["id"]
+
+    patched = client.patch(
+        f"/api/plugins/kanban/tasks/{task_id}",
+        json={"status": "needs_rework"},
+    )
+
+    assert patched.status_code == 400
+    assert "request-rework" in patched.text
+    with kb.connect() as conn:
+        task = kb.get_task(conn, task_id)
+        assert task is not None
+        assert task.status == "ready"
+
+
+def test_dashboard_bulk_rejects_direct_needs_rework_status(client):
+    created = client.post(
+        "/api/plugins/kanban/tasks",
+        json={"title": "implementation", "assignee": "hefesto"},
+    )
+    assert created.status_code == 200, created.text
+    task_id = created.json()["task"]["id"]
+
+    bulk = client.post(
+        "/api/plugins/kanban/tasks/bulk",
+        json={"ids": [task_id], "status": "needs_rework"},
+    )
+
+    assert bulk.status_code == 200, bulk.text
+    result = bulk.json()["results"][0]
+    assert result["ok"] is False
+    assert "request-rework" in result["error"]
+    with kb.connect() as conn:
+        task = kb.get_task(conn, task_id)
+        assert task is not None
+        assert task.status == "ready"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/tools/test_kanban_tools.py
+++ b/tests/tools/test_kanban_tools.py
@@ -40,6 +40,52 @@ def test_kanban_tools_hidden_without_env_var(monkeypatch, tmp_path):
     )
 
 
+def test_kanban_request_rework_visible_only_in_agent_review_loop(monkeypatch, tmp_path):
+    """request-rework has zero tool-schema footprint until explicitly enabled."""
+    monkeypatch.setenv("HERMES_KANBAN_TASK", "t_fake")
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+
+    import tools.kanban_tools  # ensure registered
+    from tools.registry import invalidate_check_fn_cache, registry
+    from toolsets import resolve_toolset
+
+    def names() -> set[str]:
+        invalidate_check_fn_cache()
+        schema = registry.get_definitions(set(resolve_toolset("hermes-cli")), quiet=True)
+        return {s["function"].get("name") for s in schema if "function" in s}
+
+    assert "kanban_request_rework" not in names()
+
+    (home / "config.yaml").write_text(
+        "kanban:\n  review_loop_mode: agent\n",
+        encoding="utf-8",
+    )
+
+    assert "kanban_request_rework" in names()
+
+
+def test_kanban_orchestrator_sees_request_rework_in_agent_review_loop(monkeypatch, tmp_path):
+    monkeypatch.delenv("HERMES_KANBAN_TASK", raising=False)
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    (home / "config.yaml").write_text(
+        "toolsets:\n  - kanban\nkanban:\n  review_loop_mode: agent\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(home))
+
+    import tools.kanban_tools  # ensure registered
+    from tools.registry import invalidate_check_fn_cache, registry
+    from toolsets import resolve_toolset
+
+    invalidate_check_fn_cache()
+    schema = registry.get_definitions(set(resolve_toolset("hermes-cli")), quiet=True)
+    names = {s["function"].get("name") for s in schema if "function" in s}
+    assert "kanban_request_rework" in names
+
+
 # ---------------------------------------------------------------------------
 # Handler happy paths
 # ---------------------------------------------------------------------------
@@ -393,6 +439,111 @@ def test_comment_ignores_caller_supplied_author(worker_env):
         assert comments[0].author == "test-worker"
     finally:
         conn.close()
+
+
+def test_request_rework_rejects_default_human_review_loop_mode(worker_env):
+    from hermes_cli import kanban_db as kb
+    from tools import kanban_tools as kt
+
+    conn = kb.connect()
+    try:
+        target = kb.create_task(conn, title="implementation", assignee="hefesto")
+        assert kb.complete_task(conn, target, result="implementation done")
+        kb.link_tasks(conn, target, worker_env)
+    finally:
+        conn.close()
+
+    out = kt._handle_request_rework({
+        "target_task_id": target,
+        "feedback": "missing regression test",
+    })
+    err = json.loads(out).get("error", "")
+    assert "review_loop_mode" in err
+    assert "agent" in err
+
+
+def test_request_rework_marks_linked_target_in_agent_mode(worker_env):
+    from pathlib import Path
+
+    from hermes_cli import kanban_db as kb
+    from tools import kanban_tools as kt
+
+    Path(os.environ["HERMES_HOME"], "config.yaml").write_text(
+        "kanban:\n  review_loop_mode: agent\n"
+    )
+
+    conn = kb.connect()
+    try:
+        target = kb.create_task(conn, title="implementation", assignee="hefesto")
+        assert kb.complete_task(conn, target, result="implementation done")
+        kb.link_tasks(conn, target, worker_env)
+    finally:
+        conn.close()
+
+    out = kt._handle_request_rework({
+        "target_task_id": target,
+        "feedback": "missing regression test",
+    })
+    data = json.loads(out)
+    assert data["ok"] is True
+    assert data["task_id"] == target
+
+    conn = kb.connect()
+    try:
+        task = kb.get_task(conn, target)
+        comments = kb.list_comments(conn, target)
+    finally:
+        conn.close()
+
+    assert task is not None
+    assert task.status == "needs_rework"
+    assert comments[-1].author == "test-worker"
+    assert "missing regression test" in comments[-1].body
+
+
+def test_request_rework_rejects_conflicting_worker_reviewer_task_id(worker_env):
+    """A scoped worker cannot attribute rework to another reviewer task."""
+    from pathlib import Path
+
+    from hermes_cli import kanban_db as kb
+    from tools import kanban_tools as kt
+
+    Path(os.environ["HERMES_HOME"], "config.yaml").write_text(
+        "kanban:\n  review_loop_mode: agent\n"
+    )
+
+    conn = kb.connect()
+    try:
+        target = kb.create_task(conn, title="implementation", assignee="hefesto")
+        assert kb.complete_task(conn, target, result="implementation done")
+        foreign_reviewer = kb.create_task(
+            conn, title="other review", assignee="another-reviewer"
+        )
+        kb.link_tasks(conn, target, worker_env)
+        kb.link_tasks(conn, target, foreign_reviewer)
+    finally:
+        conn.close()
+
+    out = kt._handle_request_rework({
+        "target_task_id": target,
+        "reviewer_task_id": foreign_reviewer,
+        "feedback": "missing regression test",
+    })
+    err = json.loads(out).get("error", "")
+
+    assert f"worker is scoped to task {worker_env}" in err
+    assert foreign_reviewer in err
+
+    conn = kb.connect()
+    try:
+        task = kb.get_task(conn, target)
+        comments = kb.list_comments(conn, target)
+    finally:
+        conn.close()
+
+    assert task is not None
+    assert task.status == "done"
+    assert not any("REQUEST_CHANGES" in comment.body for comment in comments)
 
 
 def test_create_happy_path(worker_env):

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -984,6 +984,68 @@ def _handle_comment(args: dict, **kw) -> str:
         return tool_error(f"kanban_comment: {e}")
 
 
+def _review_loop_mode() -> str:
+    try:
+        from hermes_cli.config import load_config
+
+        cfg = load_config() or {}
+        kanban_cfg = cfg.get("kanban") or {}
+        mode = str(kanban_cfg.get("review_loop_mode", "human")).strip().lower()
+        return mode or "human"
+    except Exception:
+        return "human"
+
+
+def _check_kanban_rework_mode() -> bool:
+    """Expose rework requests only to opted-in Kanban agent loops."""
+    return _check_kanban_mode() and _review_loop_mode() == "agent"
+
+
+def _handle_request_rework(args: dict, **kw) -> str:
+    """Request actionable rework on a linked implementation task."""
+    mode = _review_loop_mode()
+    if mode != "agent":
+        return tool_error(
+            "kanban_request_rework requires kanban.review_loop_mode: agent; "
+            "default human mode preserves blocked/unblock as the human gate"
+        )
+    target_task_id = args.get("target_task_id") or args.get("task_id")
+    if not target_task_id:
+        return tool_error("target_task_id is required")
+    feedback = args.get("feedback") or args.get("reason")
+    if not feedback or not str(feedback).strip():
+        return tool_error("feedback is required")
+    reviewer_task_id = args.get("reviewer_task_id") or os.environ.get("HERMES_KANBAN_TASK")
+    if not reviewer_task_id:
+        return tool_error(
+            "reviewer_task_id is required when not running inside a kanban worker"
+        )
+    reviewer_task_id = str(reviewer_task_id)
+    ownership_error = _enforce_worker_task_ownership(reviewer_task_id)
+    if ownership_error:
+        return ownership_error
+    board = args.get("board")
+    author = os.environ.get("HERMES_PROFILE") or "worker"
+    try:
+        kb, conn = _connect(board=board)
+        try:
+            kb.request_rework_task(
+                conn,
+                str(target_task_id),
+                feedback=str(feedback),
+                reviewer_task_id=reviewer_task_id,
+                author=author,
+            )
+            return _ok(task_id=str(target_task_id), reviewer_task_id=reviewer_task_id)
+        finally:
+            conn.close()
+    except ValueError as e:
+        return tool_error(f"kanban_request_rework: {e}")
+    except Exception as e:
+        logger.exception("kanban_request_rework failed")
+        return tool_error(f"kanban_request_rework: {e}")
+
+
 def _handle_attach(args: dict, **kw) -> str:
     """Attach an inline (base64) file to a task.
 
@@ -1603,8 +1665,8 @@ KANBAN_LIST_SCHEMA = {
             "status": {
                 "type": "string",
                 "enum": [
-                    "triage", "todo", "ready", "running",
-                    "blocked", "done", "archived",
+                    "triage", "todo", "scheduled", "ready", "needs_rework",
+                    "running", "blocked", "review", "done", "archived",
                 ],
                 "description": "Optional task status filter.",
             },
@@ -1917,6 +1979,38 @@ KANBAN_ATTACHMENTS_SCHEMA = {
     },
 }
 
+KANBAN_REQUEST_REWORK_SCHEMA = {
+    "name": "kanban_request_rework",
+    "description": (
+        "Request actionable rework on a linked implementation task without "
+        "using blocked as a review loop. Only succeeds when "
+        "kanban.review_loop_mode is 'agent'; human mode keeps blocked/unblock "
+        "as the human gate."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "target_task_id": {
+                "type": "string",
+                "description": "Implementation task that should be marked needs_rework.",
+            },
+            "feedback": {
+                "type": "string",
+                "description": "Actionable reviewer feedback to append to the target task.",
+            },
+            "reviewer_task_id": {
+                "type": "string",
+                "description": (
+                    "Reviewer task id. Defaults to HERMES_KANBAN_TASK from "
+                    "the env and must be linked to the target task."
+                ),
+            },
+            "board": _board_schema_prop(),
+        },
+        "required": ["target_task_id", "feedback"],
+    },
+}
+
 KANBAN_CREATE_SCHEMA = {
     "name": "kanban_create",
     "description": (
@@ -2220,6 +2314,15 @@ registry.register(
     handler=_handle_attachments,
     check_fn=_check_kanban_mode,
     emoji="📎",
+)
+
+registry.register(
+    name="kanban_request_rework",
+    toolset="kanban",
+    schema=KANBAN_REQUEST_REWORK_SCHEMA,
+    handler=_handle_request_rework,
+    check_fn=_check_kanban_rework_mode,
+    emoji="↩",
 )
 
 registry.register(

--- a/toolsets.py
+++ b/toolsets.py
@@ -80,7 +80,7 @@ _HERMES_CORE_TOOLS = [
     # tools/kanban_tools.py.
     "kanban_show", "kanban_list",
     "kanban_complete", "kanban_block", "kanban_heartbeat",
-    "kanban_comment", "kanban_create", "kanban_link",
+    "kanban_comment", "kanban_request_rework", "kanban_create", "kanban_link",
     "kanban_unblock",
     "kanban_attach", "kanban_attach_url", "kanban_attachments",
     # Computer use (macOS, gated on cua-driver being installed via check_fn)
@@ -317,7 +317,7 @@ TOOLSETS = {
         ),
         "tools": [
             "kanban_show", "kanban_list", "kanban_complete", "kanban_block",
-            "kanban_heartbeat", "kanban_comment",
+            "kanban_heartbeat", "kanban_comment", "kanban_request_rework",
             "kanban_create", "kanban_link",
             "kanban_unblock",
             "kanban_attach", "kanban_attach_url", "kanban_attachments",

--- a/website/docs/user-guide/features/kanban.md
+++ b/website/docs/user-guide/features/kanban.md
@@ -14,7 +14,8 @@ Hermes Kanban is a durable task board, shared across all your Hermes profiles, t
 
 The board has two front doors, both backed by the same `~/.hermes/kanban.db`:
 
-- **Agents drive the board through a dedicated `kanban_*` toolset** — `kanban_show`, `kanban_list`, `kanban_complete`, `kanban_block`, `kanban_heartbeat`, `kanban_comment`, `kanban_attach`, `kanban_attach_url`, `kanban_attachments`, `kanban_create`, `kanban_link`, `kanban_unblock`. The dispatcher spawns each worker with these tools already in its schema; orchestrator profiles can also enable the `kanban` toolset explicitly. The model reads and routes tasks by calling tools directly, *not* by shelling out to `hermes kanban`. See [How workers interact with the board](#how-workers-interact-with-the-board) below.
+- **Agents drive the board through a dedicated `kanban_*` toolset** — `kanban_show`, `kanban_list`, `kanban_complete`, `kanban_block`, `kanban_heartbeat`, `kanban_comment`, `kanban_attach`, `kanban_attach_url`, `kanban_attachments`, `kanban_request_rework`, `kanban_create`, `kanban_link`, `kanban_unblock`. The dispatcher spawns each worker with these tools already in its schema; orchestrator profiles can also enable the `kanban` toolset explicitly. The model reads and routes tasks by calling tools directly, *not* by shelling out to `hermes kanban`. See [How workers interact with the board](#how-workers-interact-with-the-board) below.
+
 - **You (and scripts, and cron) drive the board through `hermes kanban …`** on the CLI, `/kanban …` as a slash command, or the dashboard. These are for humans and automation — the places without a tool-calling model behind them.
 
 Both surfaces route through the same `kanban_db` layer, so reads see a consistent view and writes can't drift. The rest of this page shows CLI examples because they're easy to copy-paste, but every CLI verb has a tool-call equivalent the model uses.
@@ -59,14 +60,14 @@ They coexist: a kanban worker may call `delegate_task` internally during its run
   (e.g. one per project, repo, or domain); see [Boards (multi-project)](#boards-multi-project)
   below. Single-project users stay on the `default` board and never see the
   word "board" outside this docs section.
-- **Task** — a row with title, optional body, one assignee (a profile name), status (`triage | todo | ready | running | blocked | done | archived`), optional tenant namespace, optional idempotency key (dedup for retried automation).
+- **Task** — a row with title, optional body, one assignee (a profile name), status (`triage | todo | scheduled | ready | needs_rework | running | blocked | review | done | archived`), optional tenant namespace, optional idempotency key (dedup for retried automation). `needs_rework` means a reviewer found actionable changes and the dispatcher may re-run the assignee; `blocked` remains the sticky human/external-decision gate.
 - **Link** — `task_links` row recording a parent → child dependency. The dispatcher promotes `todo → ready` when all parents are `done`.
 - **Comment** — the inter-agent protocol. Agents and humans append comments; when a worker is (re-)spawned it reads the full comment thread as part of its context.
 - **Workspace** — the directory a worker operates in. Three kinds:
   - `scratch` (default) — fresh tmp dir under `~/.hermes/kanban/workspaces/<id>/` (or `~/.hermes/kanban/boards/<slug>/workspaces/<id>/` on non-default boards). **Deleted when the task completes** — scratch is ephemeral by design. Files explicitly declared through `kanban_complete(artifacts=[...])` are copied into durable per-task attachment storage before cleanup; existing deliverable paths in legacy completion summaries receive the same treatment. Other scratch files are removed. A missing declared scratch artifact keeps the task in-flight so the worker can correct the path and retry. Use `worktree:` or `dir:<path>` when the whole workspace should remain available. The first time a scratch workspace is created on an install, the dispatcher logs a warning and emits a `tip_scratch_workspace` event on the task (visible via `hermes kanban show <id>`).
   - `dir:<path>` — an existing shared directory (Obsidian vault, mail ops dir, per-account folder). **Must be an absolute path.** Relative paths like `dir:../tenants/foo/` are rejected at dispatch because they'd resolve against whatever CWD the dispatcher happens to be in, which is ambiguous and a confused-deputy escape vector. The path is otherwise trusted — it's your box, your filesystem, the worker runs with your uid. This is the trusted-local-user threat model; kanban is single-host by design. **Preserved on completion.**
   - `worktree` — a git worktree under `.worktrees/<id>/` for coding tasks. Use `worktree:<path>` to pin the exact target path. Worker-side `git worktree add` creates it, using `--branch` when provided. **Preserved on completion.**
-- **Dispatcher** — a long-lived loop that, every N seconds (default 60): reclaims stale claims, reclaims crashed workers (PID gone but TTL not yet expired), promotes ready tasks, atomically claims, spawns assigned profiles. Runs **inside the gateway** by default (`kanban.dispatch_in_gateway: true`). One dispatcher sweeps all boards per tick; workers are spawned with `HERMES_KANBAN_BOARD` pinned so they can't see other boards. After `kanban.failure_limit` consecutive spawn failures on the same task (default: 2) the dispatcher auto-blocks it with the last error as the reason — prevents thrashing on tasks whose profile doesn't exist, workspace can't mount, etc.
+- **Dispatcher** — a long-lived loop that, every N seconds (default 60): reclaims stale claims, reclaims crashed workers (PID gone but TTL not yet expired), promotes ready tasks, atomically claims `ready`/`needs_rework`, spawns assigned profiles. Runs **inside the gateway** by default (`kanban.dispatch_in_gateway: true`). One dispatcher sweeps all boards per tick; workers are spawned with `HERMES_KANBAN_BOARD` pinned so they can't see other boards. After `kanban.failure_limit` consecutive spawn failures on the same task (default: 2) the dispatcher auto-blocks it with the last error as the reason — prevents thrashing on tasks whose profile doesn't exist, workspace can't mount, etc.
 - **Tenant** — optional string namespace *within* a board. One specialist fleet can serve multiple businesses (`--tenant business-a`) with data isolation by workspace path and memory key prefix. Tenants are a soft filter; boards are the hard isolation boundary.
 
 ## Boards (multi-project)
@@ -226,7 +227,15 @@ up on the next tick (60s by default).
 kanban:
   dispatch_in_gateway: true        # default
   dispatch_interval_seconds: 60    # default
+  review_loop_mode: human          # default: reviewers hand off; humans/orchestrators requeue
 ```
+
+Set `kanban.review_loop_mode: agent` only when you want reviewer agents to
+send linked implementation tasks back through the dispatcher themselves. In
+that mode `kanban_request_rework` / `hermes kanban request-rework` records a
+`REQUEST_CHANGES` comment, emits a `rework_requested` event, and moves the
+linked target to `needs_rework`. It does **not** unblock sticky `blocked`
+tasks; `blocked → ready` still requires `kanban_unblock` or an operator.
 
 Override the config flag at runtime via `HERMES_KANBAN_DISPATCH_IN_GATEWAY=0`
 for debugging. Standard gateway supervision applies: run `hermes gateway
@@ -299,9 +308,15 @@ parent, missing input, unmet capability) before unblocking, or raise
 | `kanban_attach` | Attach a file to a task by passing its bytes inline (base64); stored under the task's attachments dir (25 MB cap). | file bytes + name |
 | `kanban_attach_url` | Attach a file to a task by URL. | `url` |
 | `kanban_attachments` | List a task's attachments. | — |
+| `kanban_request_rework` | In `kanban.review_loop_mode: agent`, mark a linked implementation task `needs_rework` with reviewer feedback. Rejects unlinked targets and blocked tasks. | `target_task_id`, `feedback` |
 | `kanban_create` | (Orchestrators) fan out into child tasks with an `assignee`, optional `parents`, `skills`, etc. | `title`, `assignee` |
 | `kanban_link` | (Orchestrators) add a `parent_id → child_id` dependency edge after the fact. | `parent_id`, `child_id` |
 | `kanban_unblock` | (Orchestrators) move a blocked task to `ready` when all parents are done, or `todo` while any parent remains open. | `task_id` |
+
+Use `kanban_block` for “I need a human/external decision before this can continue”.
+Use `kanban_request_rework` for “review found actionable changes and the original
+assignee should retry”. Keeping those states separate prevents an agent review loop
+from accidentally bypassing the human gate.
 
 A typical worker turn looks like:
 
@@ -542,12 +557,12 @@ hermes dashboard        # "Kanban" tab appears in the nav, after "Skills"
 
 ### What the plugin gives you
 
-- A **Kanban** tab showing one column per status: `triage`, `todo`, `ready`, `running`, `blocked`, `done` (plus `archived` when the toggle is on).
+- A **Kanban** tab showing one column per status: `triage`, `todo`, `scheduled`, `ready`, `needs_rework`, `running`, `blocked`, `review`, `done` (plus `archived` when the toggle is on).
   - `triage` is the parking column for rough ideas. By default (`kanban.auto_decompose: true`), the dispatcher auto-runs the **decomposer** on tasks that land here. The built-in decomposer uses the `auxiliary.kanban_decomposer` model path, reads your profile roster (with descriptions), and fans the task out into a small graph of child tasks routed to the best-fit specialists. The original task stays alive as the parent of every child so its assignee (`kanban.orchestrator_profile`, or the active default profile when unset) wakes back up to judge completion when everything finishes. Flip the **Orchestration: Auto/Manual** pill at the top of the page (emerald = Auto, muted gray = Manual), or by editing `config.yaml` directly. Both modes coexist with `hermes kanban specify` - that's still available as a single-task spec rewrite when you don't want fan-out.
 - Cards show the task id, title, priority badge, tenant tag, assigned profile, comment/link counts, a **progress pill** (`N/M` children done when the task has dependents), and "created N ago". A per-card checkbox enables multi-select.
 - **Per-profile lanes inside Running** — toolbar checkbox toggles sub-grouping of the Running column by assignee.
 - **Live updates via WebSocket** — the plugin tails the append-only `task_events` table on a short poll interval; the board reflects changes the instant any profile (CLI, gateway, or another dashboard tab) acts. Reloads are debounced so a burst of events triggers a single refetch.
-- **Drag-drop** cards between columns to change status. The drop sends `PATCH /api/plugins/kanban/tasks/:id` which routes through the same `kanban_db` code the CLI uses — the three surfaces can never drift. Moves into destructive statuses (`done`, `archived`, `blocked`) prompt for confirmation. Touch devices use a pointer-based fallback so the board is usable from a tablet.
+- **Drag-drop** cards between columns to change status. The drop sends `PATCH /api/plugins/kanban/tasks/:id` which routes through the same `kanban_db` code the CLI uses — the three surfaces can never drift. Moves into destructive statuses (`done`, `archived`, `blocked`) prompt for confirmation. `needs_rework` is read-only from drag/drop: use `kanban_request_rework` / `hermes kanban request-rework` so reviewer feedback and link checks are recorded. Touch devices use a pointer-based fallback so the board is usable from a tablet.
 - **Create-task dialog** — click `+` on any column header to open a modal with labeled fields: title, assignee, priority, skills, workspace kind/path (seeded from the board's project directory; per-task override), goal mode, and (optionally) a parent task from a dropdown over every existing task. Press Enter to create the task, Shift+Enter to insert a newline in the title field, or Escape to cancel. Creating from the Triage column automatically parks the new task in triage.
 - **Multi-select with bulk actions** — shift/ctrl-click a card or tick its checkbox to add it to the selection. A bulk action bar appears at the top with batch status transitions, archive, and reassign (by profile dropdown, or "(unassign)"). Destructive batches confirm first. Per-id partial failures are reported without aborting the rest.
 - **Click a card** (without shift/ctrl) to open a side drawer (Escape or click-outside closes) with:
@@ -581,6 +596,7 @@ Config knobs (all under `kanban:` in `~/.hermes/config.yaml`):
 |---|---|---|
 | `auto_decompose` | `true` | Dispatcher auto-runs the decomposer every tick. |
 | `auto_decompose_per_tick` | `3` | Cap on decompositions per dispatcher tick. Excess defers to the next tick. |
+| `review_loop_mode` | `"human"` | `human` keeps rework decisions in comments/completions plus explicit human/orchestrator action; `agent` enables the constrained request-rework path for linked review tasks. |
 | `orchestrator_profile` | `""` | Profile assigned to the root/orchestration task after decomposition. Empty = fall back to active default profile. |
 | `default_assignee` | `""` | Where a child task lands when the LLM picks an unknown profile. Empty = fall back to active default. |
 | `auto_subscribe_on_create` | `true` | When a worker calls `kanban_create` from inside a session with a persistent delivery channel (messaging gateway or TUI), the originating session is auto-subscribed to the new task's completion/block events. The dispatcher still drives the delivery — this only changes whether the caller's chat/key shows up in the notify-sub table. Set to `false` to require explicit `kanban_notify-subscribe` calls per task. |
@@ -635,8 +651,8 @@ All routes are mounted under `/api/plugins/kanban/` and protected by the dashboa
 | `GET` | `/profiles` | List installed profiles with their descriptions (consumed by the dashboard's profile-description editor and the orchestrator picker). |
 | `PATCH` | `/profiles/:name` | Set or clear a profile's description (user-authored — `description_auto: false`). Returns `{ok, profile, description}`. |
 | `POST` | `/profiles/:name/describe-auto` | Generate a description for a profile via `auxiliary.profile_describer`. Persists with `description_auto: true` so the dashboard can surface a "review" badge. |
-| `GET` | `/orchestration` | Read the kanban orchestration settings (`orchestrator_profile`, `default_assignee`, `auto_decompose`) plus the *resolved* effective values after fallbacks. |
-| `PUT` | `/orchestration` | Update one or more of the three orchestration keys in `config.yaml`. Validates that non-empty profile names actually exist. |
+| `GET` | `/orchestration` | Read the kanban orchestration settings (`orchestrator_profile`, `default_assignee`, `auto_decompose`, `review_loop_mode`) plus the *resolved* effective values after fallbacks. |
+| `PUT` | `/orchestration` | Update one or more orchestration keys in `config.yaml`. Validates that non-empty profile names actually exist and `review_loop_mode` is `human` or `agent`. |
 | `POST` | `/links` | Add a dependency (`parent_id` → `child_id`) |
 | `DELETE` | `/links?parent_id=…&child_id=…` | Remove a dependency |
 | `POST` | `/dispatch?max=…&dry_run=…` | Nudge the dispatcher — skip the 60 s wait |
@@ -716,6 +732,8 @@ hermes kanban link <parent_id> <child_id>
 hermes kanban unlink <parent_id> <child_id>
 hermes kanban claim <id> [--ttl SECONDS]
 hermes kanban comment <id> "<text>" [--author NAME]
+hermes kanban request-rework <target_id> --reviewer-task <review_id> "<feedback>"
+        # requires kanban.review_loop_mode: agent; target/reviewer must be linked
 
 # Bulk verbs — accept multiple ids:
 hermes kanban complete <id>... [--result "..."]


### PR DESCRIPTION
## Summary

- Adds an opt-in Kanban review/rework loop with a new `needs_rework` task state.
- Keeps `blocked` as the sticky human/orchestrator gate; reviewer feedback does not unblock or bypass blocked tasks.
- Binds model-facing reviewer identity to the dispatcher-scoped worker task.
- Rebases rework dispatch on the current explicit-requeue mechanism while deliberately retaining the `active_pr` guard.
- Adds CLI/tool/dashboard/docs/test coverage for requesting, claiming, dispatching, displaying, and manually blocking rework.

## Motivation

Kanban review workflows need a way for a reviewer agent to send actionable implementation feedback back to the original worker without weakening the existing `blocked` human gate. `needs_rework` represents normal review feedback; `blocked` remains reserved for human/orchestrator intervention.

## Changes

- Adds `kanban.review_loop_mode`, defaulting to `human`.
- Adds `needs_rework` as a claimable/dispatchable status.
- Adds `kanban request-rework` and matching `kanban_request_rework` tool support, hidden from the model schema unless `review_loop_mode=agent`.
- Requires the reviewer task to be linked to the implementation target.
- For dispatcher-scoped workers, derives/validates reviewer identity against `HERMES_KANBAN_TASK` and rejects a conflicting supplied `reviewer_task_id`.
- Rejects rework requests for `blocked`, `archived`, `running`, and incomplete implementation targets.
- Allows additional feedback while a target is already in `needs_rework`.
- Clears stale `result` and `completed_at` when a completed task is reopened for rework.
- Treats `rework_requested` as an explicit requeue event so it bypasses `recent_success` using the current main-branch mechanism.
- Deliberately retains `active_pr`: an existing recent PR still guards against duplicate worker/PR creation after rework is requested.
- Includes `review` and `needs_rework` in stats/dashboard surfaces.
- Allows manual `block` on `needs_rework` tasks.
- Propagates non-zero integer return codes from CLI subcommand handlers.
- Updates Kanban docs and regression coverage.

## Related work

- Related to #42896 / #43060 (`request_review`): that path covers implementation → review. This PR covers reviewer feedback → implementation rework after review finds actionable changes.
- Related to #46706 / #46898: keeps the stricter reviewed-loop behavior opt-in via `kanban.review_loop_mode: agent` while preserving default human gating.

## Test Plan

- [x] Rebased onto current `origin/main`.
- [x] Kanban-focused pytest suites in an isolated `HERMES_HOME`:

```text
534 tests passed across 4 files, 0 failed (16.1s runner wall)
```

Covered files:

```text
tests/hermes_cli/test_kanban_db.py
tests/hermes_cli/test_kanban_cli.py
tests/tools/test_kanban_tools.py
tests/plugins/test_kanban_dashboard_plugin.py
```

- [x] Regression: a scoped worker rejects a conflicting `reviewer_task_id` and leaves the target unchanged.
- [x] Regression: `rework_requested` bypasses `recent_success` through explicit-requeue detection.
- [x] Regression: a recent PR still returns `active_pr` and remains respawn-guarded.
- [x] Post-commit critical subset: `5 passed`.
- [x] `ruff check` on every touched Python file: `All checks passed!`.
- [x] `node --check plugins/kanban/dashboard/dist/index.js`.
- [x] `scripts/check-windows-footguns.py --diff origin/main`: no findings.
- [x] `git diff --check origin/main...HEAD`.
- [x] Isolated CLI/tool smoke:
  - completed target → `needs_rework` → present in dry-run spawn set;
  - recent PR → `active_pr`;
  - forged reviewer identity rejected and target remains `done`.
- [x] Manual behavior retained: human mode rejects rework; blocked/archived/running/incomplete targets remain protected; `needs_rework` can be manually blocked.

## Platforms Tested

- macOS local development machine for targeted pytest, lint, syntax, and isolated Kanban CLI/tool smoke checks.
- GitHub Actions Ubuntu workflows may require maintainer approval because this PR comes from a fork.

## Notes for Reviewers

The two requested follow-ups are now explicit regression contracts:

1. Worker reviewer identity is tied to `HERMES_KANBAN_TASK`; conflicting tool input is rejected.
2. Rework uses current explicit-requeue handling for `recent_success`, while `active_pr` remains authoritative.

