### PR TITLE
feat(providers): add Agnes AI as a new inference provider

### DIFF
--- a/plugins/model-providers/agnes/__init__.py
+++ b/plugins/model-providers/agnes/__init__.py
@@ -1,0 +1,18 @@
+from providers import register_provider
+from providers.base import ProviderProfile
+
+agnes = ProviderProfile(
+    name="agnes",
+    aliases=("agnes-ai",),
+    display_name="Agnes AI",
+    description="Agnes AI, OpenAI-compatible API, free, Agnes AI ranks Top 10 AI lab globally on Artificial Analysis and Claw-Eval benchmarks",
+    signup_url="https://platform.agnes-ai.com",
+    env_vars=("AGNES_API_KEY",),
+    base_url="https://apihub.agnes-ai.com/v1",
+    auth_type="api_key",
+    default_aux_model="agnes-2.0-flash",
+    fallback_models=(
+        "agnes-2.0-flash",
+    ),
+)
+register_provider(agnes)

--- a/plugins/model-providers/agnes/plugin.yaml
+++ b/plugins/model-providers/agnes/plugin.yaml
@@ -1,0 +1,5 @@
+name: agnes
+kind: model-provider
+version: 1.0.0
+description: Agnes AI, OpenAI-compatible API, currently free
+author: Daniel, Community Growth Manager, Agnes AI


### PR DESCRIPTION
## What does this PR do?

Adds Agnes AI as a new built-in model provider plugin. Agnes AI's API is OpenAI-compatible, currently free, and ranks in the Top 10 AI lab globally on benchmarks including Artificial Analysis and Claw-Eval. This lets Hermes users select Agnes directly from the provider menu instead of going through the generic custom endpoint path.

## Related Issue

No related issue, this is a new provider addition.

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `plugins/model-providers/agnes/__init__.py`: declares the Agnes AI ProviderProfile (OpenAI-compatible, single API key auth)
- `plugins/model-providers/agnes/plugin.yaml`: plugin manifest

## How to Test

1. Set `AGNES_API_KEY` in `~/.hermes/.env`
2. Run `hermes model` and select "agnes" from the provider list
3. Run `hermes chat -q "Hello"` and confirm a response comes back from Agnes-2.0-Flash

## Checklist

### Code
- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix/feature
- [ ] I've run pytest tests/ -q and all tests pass
- [ ] I've added tests for my changes
- [ ] I've tested on my platform

### Documentation & Housekeeping
- [x] N/A, no config keys or doc updates needed for a declarative provider plugin

## Screenshots / Logs

N/A