### PR TITLE
fix: tolerate non-object tool args during compression

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -482,9 +482,10 @@ def _summarize_tool_result(tool_name: str, tool_args: str, tool_content: str) ->
         [search_files] content search for 'compress' in agent/ -> 12 matches
     """
     try:
-        args = json.loads(tool_args) if tool_args else {}
+        parsed_args = json.loads(tool_args) if tool_args else {}
     except (json.JSONDecodeError, TypeError):
-        args = {}
+        parsed_args = {}
+    args = parsed_args if isinstance(parsed_args, dict) else {}
 
     content = tool_content or ""
     content_len = len(content)

--- a/tests/agent/test_context_compressor.py
+++ b/tests/agent/test_context_compressor.py
@@ -7,6 +7,7 @@ from agent.context_compressor import (
     ContextCompressor,
     HISTORICAL_TASK_HEADING,
     SUMMARY_PREFIX,
+    _summarize_tool_result,
 )
 
 
@@ -86,6 +87,26 @@ class TestPreflightDeferral:
 
         assert compressor.should_defer_preflight_to_real_usage(93_000) is False
 
+
+
+class TestSummarizeToolResult:
+    @pytest.mark.parametrize("tool_args", [
+        '[{"code": "print(1)"}]',
+        '"not an object"',
+        "123",
+        "true",
+        "null",
+    ])
+    def test_non_object_tool_args_do_not_crash(self, tool_args):
+        """Regression: pre-compression pruning may see legacy non-dict args."""
+        summary = _summarize_tool_result(
+            "execute_code",
+            tool_args,
+            '{"output": "1", "exit_code": 0}',
+        )
+
+        assert summary.startswith("[execute_code]")
+        assert "lines output" in summary
 
 
 class TestCompress:


### PR DESCRIPTION
## Summary
- Normalize parsed tool-call arguments in `_summarize_tool_result()` so only JSON objects are used as mapping-style args.
- Add regression coverage for non-object JSON tool args (`list`, `str`, `number`, `bool`, `null`) during compression tool-result summarization.

## Root cause
During pre-compression pruning, `_summarize_tool_result()` parses stored tool-call arguments and later assumes the parsed value is a dict. If a legacy or malformed stored call contains valid JSON that is not an object, such as a list, `json.loads()` succeeds and returns a non-dict. The next tool-specific summary branch can then call `.get()` on that value and crash the whole turn before the model call starts.

This keeps the existing malformed-JSON fallback behavior but also treats valid non-object JSON as empty args, producing a less-specific summary instead of aborting compression.

## Related reconnaissance
- Checked current `origin/main`: `_summarize_tool_result()` still parsed directly into `args` and used `args.get(...)`.
- Checked open PRs/issues for compression/tool-result overlap. PR #48105 touches compression/session handoff broadly, but does not patch this `_summarize_tool_result()` argument-type guard.

## Test plan
- `python3 -m pytest tests/agent/test_context_compressor.py::TestSummarizeToolResult -q -o addopts=''`
- `python3 -m pytest tests/agent/test_context_compressor.py -q -o addopts=''`
- `python3 -m py_compile agent/context_compressor.py tests/agent/test_context_compressor.py`
- `git diff --check`
- Added-line static scan: 0 findings
