### PR TITLE
fix(desktop): bind queued prompts to target session

### DIFF
--- a/apps/desktop/src/app/chat/composer/index.tsx
+++ b/apps/desktop/src/app/chat/composer/index.tsx
@@ -1409,8 +1409,13 @@ export function ChatBar({
       drainingQueueRef.current = true
 
       try {
+        const queueSessionKey = activeQueueSessionKey
         const accepted = await Promise.resolve(
-          onSubmit(entry.text, { attachments: entry.attachments, fromQueue: true })
+          onSubmit(entry.text, {
+            attachments: entry.attachments,
+            fromQueue: true,
+            targetStoredSessionId: queueSessionKey
+          })
         )
 
         if (accepted === false) {
@@ -1418,7 +1423,7 @@ export function ChatBar({
         }
 
         drainFailuresRef.current.delete(entry.id)
-        removeQueuedPrompt(activeQueueSessionKey, entry.id)
+        removeQueuedPrompt(queueSessionKey, entry.id)
         resetBrowseState(sessionId)
 
         return true

--- a/apps/desktop/src/app/chat/composer/types.ts
+++ b/apps/desktop/src/app/chat/composer/types.ts
@@ -54,7 +54,7 @@ export interface ChatBarProps {
   onSteer?: (text: string) => Promise<boolean> | boolean
   onSubmit: (
     value: string,
-    options?: { attachments?: ComposerAttachment[]; fromQueue?: boolean }
+    options?: { attachments?: ComposerAttachment[]; fromQueue?: boolean; targetStoredSessionId?: string | null }
   ) => Promise<boolean> | boolean
   onTranscribeAudio?: (audio: Blob) => Promise<string>
 }

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions.test.tsx
@@ -48,7 +48,7 @@ interface HarnessHandle {
   steerPrompt: (text: string) => Promise<boolean>
   submitText: (
     text: string,
-    options?: { attachments?: ComposerAttachment[]; fromQueue?: boolean }
+    options?: { attachments?: ComposerAttachment[]; fromQueue?: boolean; targetStoredSessionId?: string | null }
   ) => Promise<boolean>
 }
 
@@ -56,6 +56,7 @@ function Harness({
   busyRef,
   onReady,
   onSeedState,
+  onSelectedStoredSessionIdRef,
   refreshSessions,
   requestGateway,
   resumeStoredSession,
@@ -64,7 +65,8 @@ function Harness({
 }: {
   busyRef?: MutableRefObject<boolean>
   onReady: (handle: HarnessHandle) => void
-  onSeedState?: (state: Record<string, unknown>) => void
+  onSeedState?: (state: Record<string, unknown>, storedSessionId?: string | null) => void
+  onSelectedStoredSessionIdRef?: (ref: MutableRefObject<string | null>) => void
   refreshSessions: () => Promise<void>
   requestGateway: <T>(method: string, params?: Record<string, unknown>) => Promise<T>
   resumeStoredSession?: (storedSessionId: string) => Promise<void> | void
@@ -75,6 +77,9 @@ function Harness({
   const selectedStoredSessionIdRef: MutableRefObject<string | null> = {
     current: storedSessionId === undefined ? RUNTIME_SESSION_ID : storedSessionId
   }
+
+  onSelectedStoredSessionIdRef?.(selectedStoredSessionIdRef)
+
   const localBusyRef = busyRef ?? { current: false }
   const stateRef = useRef({
     messages: seedMessages ?? [],
@@ -96,11 +101,11 @@ function Harness({
     selectedStoredSessionIdRef,
     startFreshSessionDraft: () => undefined,
     sttEnabled: false,
-    updateSessionState: (_sessionId, updater) => {
+    updateSessionState: (_sessionId, updater, updateStoredSessionId) => {
       // Seed with interrupted:true so we can prove a fresh submit clears it.
       const next = updater(stateRef.current) as unknown as Record<string, unknown>
       stateRef.current = next as never
-      onSeedState?.(next)
+      onSeedState?.(next, updateStoredSessionId)
 
       return next as never
     }
@@ -322,6 +327,56 @@ describe('usePromptActions submit / queue drain semantics', () => {
     expect(requestGateway).toHaveBeenCalledWith('prompt.submit', {
       session_id: RUNTIME_SESSION_ID,
       text: 'queued message'
+    })
+  })
+
+  it('keeps a queued send bound to its session when the user switches chats mid-submit', async () => {
+    const storedArgs: Array<string | null | undefined> = []
+    let selectedRef: MutableRefObject<string | null> | null = null
+    let submitAttempts = 0
+    const requestGateway = vi.fn(async (method: string) => {
+      if (method === 'prompt.submit') {
+        submitAttempts += 1
+        // Repro: the queued prompt starts in one session, then the user clicks
+        // another chat before the async submit path finishes its optimistic
+        // stale-runtime recovery. Old code reread this mutable ref and resumed
+        // the newly selected chat instead of the queued prompt's owning chat.
+        selectedRef!.current = 'session-clicked-mid-submit'
+
+        if (submitAttempts === 1) {
+          throw new Error('404: {"detail":"Session not found"}')
+        }
+      }
+
+      if (method === 'session.resume') {
+        return { session_id: 'recovered-runtime' } as never
+      }
+
+      return {} as never
+    })
+
+    let handle: HarnessHandle | null = null
+    render(
+      <Harness
+        onReady={h => (handle = h)}
+        onSeedState={(_state, storedSessionId) => storedArgs.push(storedSessionId)}
+        onSelectedStoredSessionIdRef={ref => {
+          selectedRef = ref
+        }}
+        refreshSessions={async () => undefined}
+        requestGateway={requestGateway}
+        storedSessionId="queued-session"
+      />
+    )
+
+    await handle!.submitText('queued follow-up', {
+      fromQueue: true,
+      targetStoredSessionId: 'queued-session'
+    })
+
+    expect(storedArgs).toEqual(['queued-session', 'queued-session'])
+    expect(requestGateway).toHaveBeenCalledWith('session.resume', {
+      session_id: 'queued-session'
     })
   })
 

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions.ts
@@ -327,6 +327,7 @@ interface PromptActionsOptions {
 interface SubmitTextOptions {
   attachments?: ComposerAttachment[]
   fromQueue?: boolean
+  targetStoredSessionId?: string | null
 }
 
 /** Everything a slash handler needs about the invocation it's serving. */
@@ -551,6 +552,7 @@ export function usePromptActions({
       const visibleText = rawText.trim()
       const usingComposerAttachments = !options?.attachments
       const attachments = options?.attachments ?? $composerAttachments.get()
+      const submitStoredSessionId = options?.targetStoredSessionId ?? selectedStoredSessionIdRef.current
 
       const terminalContextBlocks = terminalContextBlocksFromDraft(rawText).join('\n\n')
       const hasImage = attachments.some(a => a.kind === 'image')
@@ -618,7 +620,7 @@ export function usePromptActions({
             // (what made drained-after-interrupt sends go silent).
             interrupted: false
           }),
-          selectedStoredSessionIdRef.current
+          submitStoredSessionId
         )
 
       // After sync rewrites refs, refresh the optimistic message in place so the
@@ -630,7 +632,7 @@ export function usePromptActions({
             ...state,
             messages: state.messages.map(message => (message.id === optimisticId ? buildUserMessage() : message))
           }),
-          selectedStoredSessionIdRef.current
+          submitStoredSessionId
         )
 
       const dropOptimistic = (sid: null | string) => {
@@ -649,7 +651,7 @@ export function usePromptActions({
             awaitingResponse: false,
             pendingBranchGroup: null
           }),
-          selectedStoredSessionIdRef.current
+          submitStoredSessionId
         )
       }
 
@@ -708,16 +710,18 @@ export function usePromptActions({
         try {
           await withSessionBusyRetry(() => requestGateway('prompt.submit', { session_id: sessionId, text }))
         } catch (firstErr) {
-          if (isSessionNotFoundError(firstErr) && selectedStoredSessionIdRef.current) {
+          if (isSessionNotFoundError(firstErr) && submitStoredSessionId) {
             // Re-register the session in the gateway and get a fresh live ID.
             const resumed = await requestGateway<{ session_id: string }>('session.resume', {
-              session_id: selectedStoredSessionIdRef.current
+              session_id: submitStoredSessionId
             })
 
             const recoveredId = resumed?.session_id
 
             if (recoveredId) {
-              activeSessionIdRef.current = recoveredId
+              if (selectedStoredSessionIdRef.current === submitStoredSessionId) {
+                activeSessionIdRef.current = recoveredId
+              }
               await withSessionBusyRetry(() => requestGateway('prompt.submit', { session_id: recoveredId, text }))
             } else {
               submitErr = firstErr


### PR DESCRIPTION
## What does this PR do?

Fixes a Hermes Desktop session-state race when a queued prompt is manually sent while a session is/was busy. The queued prompt drain previously kept reading the current selected stored-session id during submit-side stale-runtime recovery. If the user switched sessions while the async submit was in flight, the recovery path could resume the newly selected session instead of the queued prompt's owning session, making chat contents appear stuck or shared across sessions.

This change freezes the queued prompt's target stored-session id at drain time and threads it through the submit pipeline, so optimistic updates, fallback resume, and queue cleanup stay bound to the session that owned the queued prompt.

## Related Issue

No issue filed.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `apps/desktop/src/app/chat/composer/index.tsx`: capture the queue session key before draining and pass it as `targetStoredSessionId` to `onSubmit`; remove the drained entry from that captured queue key.
- `apps/desktop/src/app/chat/composer/types.ts`: extend `onSubmit` options with `targetStoredSessionId`.
- `apps/desktop/src/app/session/hooks/use-prompt-actions.ts`: use the frozen target stored-session id for optimistic updates and stale runtime resume recovery; only update `activeSessionIdRef` after recovery if the user is still viewing that same stored session.
- `apps/desktop/src/app/session/hooks/use-prompt-actions.test.tsx`: add regression coverage for a queued prompt that hits stale-runtime recovery while the user switches chats mid-submit.

## How to Test

1. `cd apps/desktop && npm run test:ui -- src/app/session/hooks/use-prompt-actions.test.tsx src/app/session/hooks/use-session-actions.test.tsx`
2. `cd apps/desktop && npm run typecheck`
3. Manual QA completed by reporter: reproduced with two desktop sessions, queued a prompt while one was busy, manually sent/drained it around the settle edge, then switched between sessions to confirm transcripts do not stick or bleed.

## Regression proof

The new regression test was run against the old implementation by temporarily checking out the pre-fix implementation files while keeping the test. It failed as expected because the old recovery path called:

```text
session.resume { session_id: "session-clicked-mid-submit" }
```

instead of the queued prompt owner:

```text
session.resume { session_id: "queued-session" }
```

With this fix restored, the same targeted test passes.

## Full-suite status

`scripts/run_tests.sh` was run locally and did not pass: `1514 files, 31914 tests passed, 30 failed`. I did **not** check the full `pytest tests/ -q` / full-suite checklist item.

To verify the failures are unrelated to this PR, I ran the same failed Python test files on both this PR branch and `HEAD~1` (the base commit before the Desktop changes). Both runs failed with the same set/count: `11 files, 25 tests failed`. The failing files are outside the Desktop renderer files touched by this PR and reproduce before this PR.

Observed failure categories include local macOS `/tmp` vs `/private/tmp` path expectations, unavailable `systemctl`/user D-Bus, macOS keychain subprocess mocking in Anthropic OAuth tests, existing read-file dedupe behavior expectations, browser-connect message expectations, and signal/shutdown timing tests.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and **most of all** tests pass (The failed ones always fail in my local even without any code change)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS (targeted UI tests + typecheck + manual reporter QA)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

No screenshots. Automated checks run locally:

```text
# Red check against old implementation:
cd apps/desktop && npm run test:ui -- src/app/session/hooks/use-prompt-actions.test.tsx -t "keeps a queued send bound"
# failed: old code resumed session-clicked-mid-submit instead of queued-session

# Green checks after fix:
cd apps/desktop && npm run test:ui -- src/app/session/hooks/use-prompt-actions.test.tsx -t "keeps a queued send bound"
# passed

cd apps/desktop && npm run test:ui -- src/app/session/hooks/use-prompt-actions.test.tsx src/app/session/hooks/use-session-actions.test.tsx
# 2 files passed, 40 tests passed

cd apps/desktop && npm run typecheck
# passed

# Canonical full Python suite (project runner):
scripts/run_tests.sh
# failed: 1514 files, 31914 tests passed, 30 failed

# A/B check for the Python failures:
# Running the same failed Python test files on this PR and on HEAD~1 (before this PR)
# produced the same failure set/count: 11 files, 25 tests failed. These failures
# are pre-existing/local-environment failures and are unrelated to the Desktop files
# changed in this PR.
```


