### PR TITLE
fix(gateway): guard cron ticker against SystemExit from provider SDKs

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -2083,8 +2083,13 @@ def tick(verbose: bool = True, adapters=None, loop=None, sync: bool = True) -> i
                 mark_job_run(job["id"], success, error, delivery_error=delivery_error)
                 return True
 
-            except Exception as e:
-                logger.error("Error processing job %s: %s", job['id'], e)
+            except BaseException as e:
+                # Catch BaseException (not just Exception) so that SystemExit
+                # from a misbehaving provider SDK or agent retry path does
+                # not escape the job execution and potentially crash the
+                # gateway.  A single failed cron job must never tear down
+                # the gateway — log and mark as failed instead.
+                logger.error("Error processing job %s: %s", job['id'], e, exc_info=True)
                 mark_job_run(job["id"], False, str(e))
                 return False
 
@@ -2184,6 +2189,16 @@ def tick(verbose: bool = True, adapters=None, loop=None, sync: bool = True) -> i
             _remaining = [len(_all_futures)]
 
             def _on_done(_f: concurrent.futures.Future) -> None:
+                # Log exceptions from completed futures so cron job failures
+                # are visible instead of silently swallowed in async mode.
+                # Without this, an unhandled error inside _process_job (e.g.
+                # SystemExit from a provider SDK) would disappear silently.
+                if _f.exception() is not None:
+                    logger.error(
+                        "Cron job execution error (async): %s",
+                        _f.exception(),
+                        exc_info=_f.exception(),
+                    )
                 _remaining[0] -= 1
                 if _remaining[0] <= 0:
                     _sweep_mcp_orphans()

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -16492,8 +16492,13 @@ def _start_cron_ticker(stop_event: threading.Event, adapters=None, loop=None, in
     while not stop_event.is_set():
         try:
             cron_tick(verbose=False, adapters=adapters, loop=loop, sync=False)
-        except Exception as e:
-            logger.debug("Cron tick error: %s", e)
+        except BaseException as e:
+            # Catch BaseException (not just Exception) so that SystemExit
+            # raised by a misbehaving provider SDK or agent retry path
+            # cannot tear down the gateway process.  A single failed cron
+            # LLM call must never kill the gateway — it serves all
+            # connected platforms (Feishu, Telegram, Discord, …).
+            logger.error("Cron tick error (non-fatal): %s", e, exc_info=True)
 
         tick_count += 1
 


### PR DESCRIPTION
## Summary

A cron-scheduled LLM call that hits a provider error can cause the gateway process to exit with code 1, disconnecting all messaging platforms.

The root cause: the cron ticker and job processor only catch `Exception`, but some provider SDKs raise `SystemExit` after retry exhaustion.

## Fix (3 changes)

1. `gateway/run.py` _start_cron_ticker: Exception to BaseException + debug to error
2. `cron/scheduler.py` _process_job: Exception to BaseException
3. `cron/scheduler.py` _on_done: log exceptions from futures

Fixes #48234