### PR TITLE
fix(gateway): log slash commands as inbound messages

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -7483,6 +7483,23 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             if _denied is not None:
                 return _denied
 
+        # Log slash commands as inbound messages so model switches and
+        # other state changes are visible in gateway.log for debugging
+        # and analytics.  Regular messages are logged inside
+        # _handle_message_with_agent, but slash commands return early
+        # before reaching that path.  (Fixes #48240)
+        if command and canonical:
+            _slash_platform = source.platform.value if hasattr(source.platform, "value") else str(source.platform)
+            _slash_args = (event.get_command_args() or "").strip()[:60]
+            logger.info(
+                "inbound slash command: platform=%s user=%s chat=%s command=/%s args=%r",
+                _slash_platform,
+                source.user_name or source.user_id or "unknown",
+                source.chat_id or "unknown",
+                canonical,
+                _slash_args,
+            )
+
         # Fire the ``command:<canonical>`` hook for any recognized slash
         # command — built-in OR plugin-registered. Handlers can return a
         # dict with ``{"decision": "deny" | "handled" | "rewrite", ...}``


### PR DESCRIPTION
## Summary

Slash commands (/model, /new, /stop, /reasoning, /voice, etc.) were never logged as inbound messages in gateway.log. They are dispatched early in _handle_message and return before reaching _handle_message_with_agent.

This makes model switches invisible in logs, hindering debugging and analytics.

## Fix

Add an inbound slash command log line after command resolution and access check, before hook dispatch. Uses same field format as existing inbound message log.

## Changes

- gateway/run.py: +17 lines

Fixes #48240