### PR TITLE
fix: /commands pagination on Telegram using inline keyboard buttons

### DIFF
--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -3573,6 +3573,77 @@ class TelegramAdapter(BasePlatformAdapter):
         page_info = f" ({start + 1}–{end} of {total})" if total_pages > 1 else ""
         return InlineKeyboardMarkup(rows), page_info
 
+    async def _handle_commands_page_callback(self, query, data: str) -> None:
+        """Handle inline keyboard pagination for /commands."""
+        import logging
+        logger = logging.getLogger(__name__)
+
+        page_str = data.split(":", 1)[1]
+        if page_str == "noop":
+            await query.answer()
+            return
+
+        try:
+            page = int(page_str)
+        except (ValueError, IndexError):
+            await query.answer(text="Invalid page.")
+            return
+
+        from hermes_cli.commands import gateway_help_lines
+        from agent.i18n import t
+        try:
+            from agent.skill_commands import get_skill_commands
+        except Exception:
+            get_skill_commands = None
+
+        entries = list(gateway_help_lines())
+        try:
+            if get_skill_commands:
+                skill_cmds = get_skill_commands()
+                if skill_cmds:
+                    entries.append("")
+                    entries.append(t("gateway.commands.skill_header"))
+                    for cmd in sorted(skill_cmds):
+                        desc = skill_cmds[cmd].get("description", "").strip() or t("gateway.commands.default_desc")
+                        entries.append(f"`{cmd}` — {desc}")
+        except Exception:
+            pass
+
+        if not entries:
+            await query.answer(text="No commands available.")
+            return
+
+        page_size = 15
+        total_pages = max(1, (len(entries) + page_size - 1) // page_size)
+        page = max(1, min(page, total_pages))
+        start = (page - 1) * page_size
+        page_entries = entries[start:start + page_size]
+
+        header = t("gateway.commands.header", total=len(entries), page=page, total_pages=total_pages)
+        text = "\n".join([header, ""] + page_entries)
+
+        # Build pagination buttons
+        from gateway.slash_commands import GatewaySlashCommandsMixin
+        buttons = GatewaySlashCommandsMixin._build_commands_page_buttons(page, total_pages)
+        keyboard = InlineKeyboardMarkup(buttons)
+
+        try:
+            formatted = self.format_message(text)
+            edit_kwargs = {
+                "text": formatted,
+                "parse_mode": ParseMode.MARKDOWN_V2,
+                "reply_markup": keyboard,
+            }
+            if hasattr(self, '_link_preview_kwargs'):
+                edit_kwargs.update(self._link_preview_kwargs())
+            await query.edit_message_text(**edit_kwargs)
+        except Exception as exc:
+            logger.debug("Commands page edit failed: %s", exc)
+            await query.answer(text="Failed to update page.")
+            return
+
+        await query.answer()
+
     async def _handle_model_picker_callback(
         self, query, data: str, chat_id: str
     ) -> None:
@@ -3893,6 +3964,11 @@ class TelegramAdapter(BasePlatformAdapter):
             chat_id = str(query.message.chat_id) if query.message else None
             if chat_id:
                 await self._handle_model_picker_callback(query, data, chat_id)
+            return
+
+        # --- Commands pagination callbacks (cmd_page:N) ---
+        if data.startswith("cmd_page:"):
+            await self._handle_commands_page_callback(query, data)
             return
 
         # --- Gmail-triage callbacks (gt:verb:arg) ---

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -973,7 +973,7 @@ class GatewaySlashCommandsMixin:
             getattr(getattr(event, "source", None), "platform", None),
         )
 
-    async def _handle_commands_command(self, event: MessageEvent) -> str:
+    async def _handle_commands_command(self, event: MessageEvent) -> Optional[str]:
         from gateway.run import _telegramize_command_mentions
         from hermes_cli.commands import gateway_help_lines
 
@@ -1004,30 +1004,83 @@ class GatewaySlashCommandsMixin:
             return t("gateway.commands.none")
 
         from gateway.config import Platform
-        page_size = 15 if event.source.platform == Platform.TELEGRAM else 20
+        is_telegram = event.source.platform == Platform.TELEGRAM
+        page_size = 15 if is_telegram else 20
         total_pages = max(1, (len(entries) + page_size - 1) // page_size)
         page = max(1, min(requested_page, total_pages))
+
+        text = self._build_commands_page(entries, page, total_pages, page_size, event)
+
+        # On Telegram, send with inline keyboard buttons for pagination
+        if is_telegram and total_pages > 1:
+            try:
+                adapter = self.adapters.get(event.source.platform)
+                if adapter and hasattr(adapter, '_bot') and adapter._bot:
+                    from telegram import InlineKeyboardButton, InlineKeyboardMarkup
+                    from telegram.constants import ParseMode
+                    buttons = self._build_commands_page_buttons(page, total_pages)
+                    keyboard = InlineKeyboardMarkup(buttons)
+                    chat_id = int(event.source.chat_id)
+                    metadata = self._thread_metadata_for_source(event.source, self._reply_anchor_for_event(event))
+                    thread_id = adapter._metadata_thread_id(metadata) if hasattr(adapter, '_metadata_thread_id') else None
+                    kwargs = {
+                        "chat_id": chat_id,
+                        "text": adapter.format_message(text) if hasattr(adapter, 'format_message') else text,
+                        "parse_mode": ParseMode.MARKDOWN_V2 if hasattr(adapter, 'format_message') else None,
+                        "reply_markup": keyboard,
+                        **(adapter._link_preview_kwargs() if hasattr(adapter, '_link_preview_kwargs') else {}),
+                    }
+                    if thread_id:
+                        kwargs["message_thread_id"] = thread_id
+                    await adapter._send_message_with_thread_fallback(**kwargs)
+                    return None  # Already sent
+            except Exception as exc:
+                logger.debug("Commands inline keyboard failed, falling back to text: %s", exc)
+
+        return _telegramize_command_mentions(
+            text,
+            getattr(getattr(event, "source", None), "platform", None),
+        )
+
+    @staticmethod
+    def _build_commands_page(
+        entries: list, page: int, total_pages: int, page_size: int, event: MessageEvent,
+    ) -> str:
+        """Build the text content for a single page of /commands."""
         start = (page - 1) * page_size
         page_entries = entries[start:start + page_size]
-
         lines = [
             t("gateway.commands.header", total=len(entries), page=page, total_pages=total_pages),
             "",
             *page_entries,
         ]
+        # Text nav fallback for non-Telegram platforms (Discord, Slack, etc.)
         if total_pages > 1:
-            nav_parts = []
-            if page > 1:
-                nav_parts.append(t("gateway.commands.nav_prev", page=page - 1))
-            if page < total_pages:
-                nav_parts.append(t("gateway.commands.nav_next", page=page + 1))
-            lines.extend(["", " | ".join(nav_parts)])
-        if page != requested_page:
-            lines.append(t("gateway.commands.out_of_range", requested=requested_page, page=page))
-        return _telegramize_command_mentions(
-            "\n".join(lines),
-            getattr(getattr(event, "source", None), "platform", None),
-        )
+            from gateway.config import Platform
+            if event.source.platform != Platform.TELEGRAM:
+                nav_parts = []
+                if page > 1:
+                    nav_parts.append(t("gateway.commands.nav_prev", page=page - 1))
+                if page < total_pages:
+                    nav_parts.append(t("gateway.commands.nav_next", page=page + 1))
+                if nav_parts:
+                    lines.extend(["", " | ".join(nav_parts)])
+        return "\n".join(lines)
+
+    @staticmethod
+    def _build_commands_page_buttons(page: int, total_pages: int) -> list:
+        """Build InlineKeyboardButton rows for /commands pagination."""
+        try:
+            from telegram import InlineKeyboardButton
+        except ImportError:
+            return []
+        row = []
+        if page > 1:
+            row.append(InlineKeyboardButton("⬅️", callback_data=f"cmd_page:{page - 1}"))
+        row.append(InlineKeyboardButton(f"{page}/{total_pages}", callback_data="cmd_page:noop"))
+        if page < total_pages:
+            row.append(InlineKeyboardButton("➡️", callback_data=f"cmd_page:{page + 1}"))
+        return [row]
 
     async def _handle_model_command(self, event: MessageEvent) -> Optional[str]:
         """Handle /model command — switch model for this session.

--- a/locales/en.yaml
+++ b/locales/en.yaml
@@ -95,8 +95,8 @@ gateway:
     default_desc:          "Skill command"
     none:                  "No commands available."
     header:                "📚 **Commands** ({total} total, page {page}/{total_pages})"
-    nav_prev:              "`/commands {page}` ← prev"
-    nav_next:              "next → `/commands {page}`"
+    nav_prev:              "/commands {page} ← prev"
+    nav_next:              "next → /commands {page}"
     out_of_range:          "_(Requested page {requested} was out of range, showing page {page}.)_"
 
   compress:

--- a/locales/zh.yaml
+++ b/locales/zh.yaml
@@ -80,8 +80,8 @@ gateway:
     default_desc:          "技能命令"
     none:                  "没有可用的命令。"
     header:                "📚 **命令**（共 {total} 个，第 {page}/{total_pages} 页）"
-    nav_prev:              "`/commands {page}` ← 上一页"
-    nav_next:              "下一页 → `/commands {page}`"
+    nav_prev:              "/commands {page} ← 上一页"
+    nav_next:              "下一页 → /commands {page}"
     out_of_range:          "_（请求的第 {requested} 页超出范围，显示第 {page} 页。）_"
 
   compress:


### PR DESCRIPTION
## Problem

The `/commands` slash command has broken pagination on Telegram:

1. **Text nav links rendered as inline code** — locale strings wrapped `/commands {page}` in backticks, which Telegram renders as non-clickable inline code
2. **Telegram strips command arguments** — even without backticks, clicking `/commands 2` only sends `/commands` (the `2` is lost), so pagination never works

## Solution

Replace text-based pagination with Telegram **InlineKeyboard buttons**:

- **`_handle_commands_command`** — on Telegram with multi-page results, sends the message directly via the adapter with `InlineKeyboardMarkup` (⬅️ `page/total` ➡️) and returns `None` to suppress the default text response
- **`_handle_commands_page_callback`** — new method that handles `cmd_page:N` callback data by editing the message in-place with the requested page and updated buttons
- **`_handle_callback_query`** — added `cmd_page:` prefix routing
- **`_build_commands_page`** / **`_build_commands_page_buttons`** — extracted as reusable static methods
- **Locale strings** — removed backtick wrapping from `nav_prev`/`nav_next` in `en.yaml` and `zh.yaml` as fallback for non-Telegram platforms

## Testing

1. Send `/commands` in a Telegram DM
2. Verify pagination buttons appear (⬅️ `1/8` ➡️)
3. Click ➡️ — message should edit in-place to page 2
4. Click ⬅️ — should return to page 1
5. Verify `/commands` still works as plain text on non-Telegram platforms

## Screenshots

Before: text links that don't work
After: inline keyboard buttons with instant page switching