### PR TITLE
ci: introduce consolidated PR gate

### DIFF
--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -1,0 +1,261 @@
+name: PR Gate
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: pr-gate-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  history:
+    name: history
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+      - name: Reject PRs with no common ancestor on main
+        run: |
+          if ! BASE=$(git merge-base origin/main HEAD 2>/dev/null) || [ -z "$BASE" ]; then
+            echo "::error::This PR has no common ancestor with main. Rebase the changes onto current main before merging."
+            exit 1
+          fi
+          echo "Common ancestor with main: $BASE"
+
+  contributor:
+    name: contributor attribution
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+      - name: Check for unmapped contributor emails
+        run: |
+          set -euo pipefail
+          BASE="${{ github.event.pull_request.base.sha }}"
+          HEAD="${{ github.event.pull_request.head.sha }}"
+          CHANGED=$(git diff --name-only "$BASE"..."$HEAD" -- '*.py' '**/*.py' '.github/workflows/pr-gate.yml' '.github/workflows/contributor-check.yml' || true)
+          if [ -z "$CHANGED" ]; then
+            echo "No Python files changed, skipping attribution check."
+            exit 0
+          fi
+
+          MERGE_BASE=$(git merge-base origin/main HEAD)
+          NEW_EMAILS=$(git log ${MERGE_BASE}..HEAD --format='%ae' --no-merges | sort -u)
+          if [ -z "$NEW_EMAILS" ]; then
+            echo "No new commits to check."
+            exit 0
+          fi
+
+          MISSING=""
+          while IFS= read -r email; do
+            case "$email" in
+              *teknium*|*noreply@github.com*|*dependabot*|*github-actions*|*anthropic.com*|*cursor.com*)
+                continue ;;
+            esac
+            if echo "$email" | grep -qP '\+.*@users\.noreply\.github\.com'; then
+              continue
+            fi
+            if ! grep -qF "\"${email}\"" scripts/release.py 2>/dev/null; then
+              AUTHOR=$(git log --author="$email" --format='%an' -1)
+              MISSING="${MISSING}\n  ${email} (${AUTHOR})"
+            fi
+          done <<< "$NEW_EMAILS"
+
+          if [ -n "$MISSING" ]; then
+            echo "::error::New contributor email(s) are missing from scripts/release.py AUTHOR_MAP."
+            echo -e "$MISSING"
+            exit 1
+          fi
+          echo "All contributor emails are mapped in AUTHOR_MAP."
+
+  supply-chain:
+    name: supply chain
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+      - name: Scan PR for critical supply-chain risks
+        run: |
+          set -euo pipefail
+          BASE="${{ github.event.pull_request.base.sha }}"
+          HEAD="${{ github.event.pull_request.head.sha }}"
+          DIFF=$(git diff "$BASE"..."$HEAD" -- . ':!uv.lock' ':!*.lock' ':!package-lock.json' ':!yarn.lock' || true)
+          FINDINGS=""
+
+          PTH_FILES=$(git diff --name-only "$BASE"..."$HEAD" | grep '\.pth$' || true)
+          if [ -n "$PTH_FILES" ]; then
+            FINDINGS="${FINDINGS}\nCRITICAL: .pth file added or modified:\n${PTH_FILES}\n"
+          fi
+
+          B64_EXEC_HITS=$(echo "$DIFF" | grep -n '^+' | grep -iE 'base64\.(b64decode|decodebytes|urlsafe_b64decode)' | grep -iE 'exec\(|eval\(' | head -10 || true)
+          if [ -n "$B64_EXEC_HITS" ]; then
+            FINDINGS="${FINDINGS}\nCRITICAL: base64 decode + exec/eval combo:\n${B64_EXEC_HITS}\n"
+          fi
+
+          PROC_HITS=$(echo "$DIFF" | grep -n '^+' | grep -E 'subprocess\.(Popen|call|run)\s*\(' | grep -iE 'base64|\\x[0-9a-f]{2}|chr\(' | head -10 || true)
+          if [ -n "$PROC_HITS" ]; then
+            FINDINGS="${FINDINGS}\nCRITICAL: subprocess with encoded/obfuscated command:\n${PROC_HITS}\n"
+          fi
+
+          SETUP_HITS=$(git diff --name-only "$BASE"..."$HEAD" | grep -E '^(setup\.py|setup\.cfg|sitecustomize\.py|usercustomize\.py|__init__\.pth)$' || true)
+          if [ -n "$SETUP_HITS" ]; then
+            FINDINGS="${FINDINGS}\nCRITICAL: install-hook file added or modified:\n${SETUP_HITS}\n"
+          fi
+
+          if [ -n "$FINDINGS" ]; then
+            echo "::error::Critical supply-chain risk patterns detected."
+            echo -e "$FINDINGS"
+            exit 1
+          fi
+          echo "No critical supply-chain patterns detected."
+
+      - name: Check PyPI dependency upper bounds
+        run: |
+          set -euo pipefail
+          BASE="${{ github.event.pull_request.base.sha }}"
+          HEAD="${{ github.event.pull_request.head.sha }}"
+          ADDED=$(git diff "$BASE"..."$HEAD" -- pyproject.toml | grep '^+' | grep -v '^+++' || true)
+          if [ -z "$ADDED" ]; then
+            echo "No pyproject.toml additions, skipping dependency bounds check."
+            exit 0
+          fi
+          UNBOUNDED=$(echo "$ADDED" | grep -oE '"[a-zA-Z0-9_-]+(\[[^\]]*\])?>=[ 0-9.]+"' | grep -v ',<' || true)
+          if [ -n "$UNBOUNDED" ]; then
+            echo "::error::PyPI dependencies without upper bounds detected. Add <next_major ceiling."
+            echo "$UNBOUNDED"
+            exit 1
+          fi
+          echo "No unbounded added PyPI dependency specs found."
+
+  lint:
+    name: lint
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Install uv
+        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5
+      - name: Install ruff and ty
+        run: |
+          uv tool install ruff
+          uv tool install ty
+      - name: ruff check
+        run: ruff check .
+      - name: ty check advisory
+        run: ty check --output-format gitlab --exit-zero > ty.json
+
+  windows-footguns:
+    name: Windows footguns
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: '3.11'
+      - name: Run footgun checker
+        run: python scripts/check-windows-footguns.py --all
+
+  uv-lock:
+    name: uv lock
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Install uv
+        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5
+      - name: Verify uv.lock is up-to-date
+        run: uv lock --check
+
+  tests:
+    name: tests (${{ matrix.slice }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        slice: [1, 2, 3, 4, 5, 6]
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Restore duration cache
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: test_durations.json
+          key: test-durations
+      - name: Install ripgrep (prebuilt binary)
+        run: |
+          set -euo pipefail
+          RG_VERSION=15.1.0
+          RG_SHA256=1c9297be4a084eea7ecaedf93eb03d058d6faae29bbc57ecdaf5063921491599
+          RG_TARBALL=ripgrep-${RG_VERSION}-x86_64-unknown-linux-musl.tar.gz
+          curl -sSfL -o "$RG_TARBALL" \
+            "https://github.com/BurntSushi/ripgrep/releases/download/${RG_VERSION}/${RG_TARBALL}"
+          echo "${RG_SHA256}  ${RG_TARBALL}" | sha256sum -c -
+          tar -xzf "$RG_TARBALL"
+          sudo mv "ripgrep-${RG_VERSION}-x86_64-unknown-linux-musl/rg" /usr/local/bin/rg
+          rm -rf "$RG_TARBALL" "ripgrep-${RG_VERSION}-x86_64-unknown-linux-musl"
+      - name: Install uv
+        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5
+        with:
+          enable-cache: true
+          cache-dependency-glob: |
+            pyproject.toml
+            uv.lock
+      - name: Set up Python 3.11
+        run: uv python install 3.11
+      - name: Install dependencies
+        run: uv sync --locked --python 3.11 --extra all --extra dev
+      - name: Minimize uv cache
+        run: uv cache prune --ci
+      - name: Run test slice
+        env:
+          OPENROUTER_API_KEY: ""
+          OPENAI_API_KEY: ""
+          NOUS_API_KEY: ""
+        run: |
+          source .venv/bin/activate
+          python scripts/run_tests_parallel.py --slice ${{ matrix.slice }}/6
+
+  pr-gate:
+    name: PR Gate
+    runs-on: ubuntu-latest
+    if: always()
+    needs:
+      - history
+      - contributor
+      - supply-chain
+      - lint
+      - windows-footguns
+      - uv-lock
+      - tests
+    steps:
+      - name: Summarize gate result
+        run: |
+          cat > results.json <<'JSON'
+          ${{ toJSON(needs) }}
+          JSON
+          python3 - <<'PY'
+          import json
+          from pathlib import Path
+
+          needs = json.loads(Path('results.json').read_text(encoding='utf-8'))
+          failed = []
+          for name, data in sorted(needs.items()):
+              result = data.get('result')
+              print(f"{name}: {result}")
+              if result not in {'success', 'skipped'}:
+                  failed.append(f"{name}={result}")
+          if failed:
+              raise SystemExit('PR Gate failed: ' + ', '.join(failed))
+          print('PR Gate passed.')
+          PY

--- a/docs/plans/2026-06-18-001-simplify-cicd-plan.md
+++ b/docs/plans/2026-06-18-001-simplify-cicd-plan.md
@@ -1,0 +1,291 @@
+---
+title: "ci: Simplify CI/CD into PR Gate, Main Deploy, and Release Publish"
+status: active
+date: 2026-06-18
+type: ci
+target_repo: hermes-agent
+origin: user request after CI/CD audit: reduce workflow sprawl and unblock continuous deployment
+---
+
+# ci: Simplify CI/CD into PR Gate, Main Deploy, and Release Publish
+
+## Summary
+
+Hermes Agent's CI/CD is intentionally defensive, but the current shape makes continuous deployment harder than it needs to be. The repo has many active workflows where PR validation, post-merge deployment, scheduled maintenance, and release publishing are mixed across separate files and GitHub's Actions UI also shows additional dynamic/legacy workflows.
+
+The simplification target is not weaker validation. The target is a smaller operational surface:
+
+1. **PR Gate** — one required PR workflow that answers: "Can this change enter main?"
+2. **Main Deploy** — one post-merge workflow that answers: "What did current main deploy?"
+3. **Release Publish** — one release workflow that answers: "What user-facing artifacts were published?"
+
+Everything else should either be folded into one of those three, become a job inside them, or be explicitly documented as a GitHub-managed/dynamic workflow that is not part of Hermes' deploy train.
+
+---
+
+## Current Inventory
+
+### Current branch rulesets
+
+GitHub rulesets currently protect `main` through two active branch rulesets:
+
+| Ruleset | Enforcement | Relevant rule | Current required signal |
+|---|---|---|---|
+| `protect-main` | active | required status checks | `test (1)` through `test (6)`, `check-attribution`, `ruff + ty diff`, `ruff enforcement (blocking)`, `Windows footguns (blocking)`, `Scan PR for critical supply chain risks`, `Check PyPI dependency upper bounds`, `check-common-ancestor` |
+| `dep-version-gate` | active | pull request reviewer rule | Team approval for dependency/version files: `pyproject.toml`, `uv.lock`, `flake.lock`, `**/package.json`, `**/package-lock.json` |
+
+This means the first simplification target is concrete: collapse the thirteen required status contexts in `protect-main` into one Hermes-owned `PR Gate` context, while preserving the separate dependency-review ruleset.
+
+### PR validation workflows
+
+These currently run on PRs and contribute to the large required-check surface:
+
+| Workflow | Current file | Current role | Simplification destination |
+|---|---|---|---|
+| Tests | `.github/workflows/tests.yml` | Python tests, sharded via `scripts/run_tests_parallel.py`, plus e2e job | `pr-gate.yml` |
+| Lint (ruff + ty) | `.github/workflows/lint.yml` | Advisory ruff/ty diff, blocking ruff, Windows footgun scan | `pr-gate.yml` |
+| Typecheck | `.github/workflows/typecheck.yml` | TS package typecheck matrix plus desktop build | `pr-gate.yml` |
+| Docs Site Checks | `.github/workflows/docs-site-checks.yml` | Docusaurus / skills docs build, currently PR-wide | `pr-gate.yml` with path-aware job |
+| Docker / shell lint | `.github/workflows/docker-lint.yml` | hadolint + shellcheck | `pr-gate.yml` with Docker path-aware job |
+| Docker Build and Publish | `.github/workflows/docker-publish.yml` | PR Docker build/smoke/integration plus main/release publish | Split: PR jobs to `pr-gate.yml`; publish jobs to `main-deploy.yml` / `release.yml` |
+| uv.lock check | `.github/workflows/uv-lockfile-check.yml` | `uv lock --check` against merged PR state | `pr-gate.yml` |
+| Supply Chain Audit | `.github/workflows/supply-chain-audit.yml` | Critical diff scanner, dependency bounds, MCP catalog label gate | `pr-gate.yml` |
+| OSV-Scanner | `.github/workflows/osv-scanner.yml` | lockfile vulnerability scan, non-blocking findings | `pr-gate.yml` for PR status; scheduled Security tab scan can remain separate only if explicitly desired |
+| History Check | `.github/workflows/history-check.yml` | reject unrelated-history PRs | `pr-gate.yml` |
+| Contributor Attribution Check | `.github/workflows/contributor-check.yml` | contributor email mapping check | `pr-gate.yml` |
+
+### Post-merge / deployment workflows
+
+| Workflow | Current file | Current role | Simplification destination |
+|---|---|---|---|
+| Deploy Site | `.github/workflows/deploy-site.yml` | GitHub Pages docs deploy; Vercel hook on release/manual | `main-deploy.yml` for Pages, `release.yml` for production release hook |
+| Build Skills Index | `.github/workflows/skills-index.yml` | scheduled/manual skills-index artifact and deploy-site trigger | `main-deploy.yml` scheduled job or explicit maintenance job inside same workflow |
+| Skills Index Freshness Check | `.github/workflows/skills-index-freshness.yml` | scheduled stale-index issue signal | keep only if it remains a clear maintenance signal; otherwise fold into skills-index job summary |
+| Docker Build and Publish | `.github/workflows/docker-publish.yml` | main/release Docker Hub publish | `main-deploy.yml` for main images; `release.yml` for tag images |
+
+### Release / artifact workflows
+
+| Workflow | Current file | Current role | Simplification destination |
+|---|---|---|---|
+| Publish to PyPI | `.github/workflows/upload_to_pypi.yml` | CalVer tag/manual PyPI publish + Sigstore + GitHub Release attach | `release.yml` |
+| Build Windows Installer | `.github/workflows/build-windows-installer.yml` | admin-only manual signed Windows installer | `release.yml` as manual/admin-gated job |
+
+### GitHub-managed or dynamic workflows visible in Actions UI
+
+GitHub reports additional active workflows that are not present in `origin/main:.github/workflows`, e.g. CodeQL, Dependabot, Copilot, and other dynamic/legacy entries. These should not be counted as Hermes-owned deploy train files unless their source path exists in repo.
+
+Action: document them separately as **GitHub-managed/dynamic**, then avoid making deploy decisions from the raw Actions workflow count alone.
+
+---
+
+## Problems to Solve
+
+### P1. PR validation and deployment are mixed
+
+`docker-publish.yml` currently owns both PR Docker validation and main/release Docker publication. That makes the workflow hard to reason about and makes the PR gate look like a deployment pipeline.
+
+**Target:** PR validation belongs in `pr-gate.yml`; publication belongs in `main-deploy.yml` or `release.yml`.
+
+### P2. Many workflows exist only to keep required checks from going pending
+
+Several files intentionally avoid PR path filters because required checks can remain pending when a path-gated workflow does not run. The reason is valid, but the result is a broad CI surface.
+
+**Target:** use one always-present `pr-gate.yml` with internal `classify` and path-aware jobs. Required check points to `PR Gate`, not every specialized workflow.
+
+### P3. Main Docker publish serializes continuous deployment
+
+Main/release Docker runs are intentionally not cancelled so every main merge gets an image. This is safe but creates a 8-16 minute post-merge queue during rapid merges.
+
+**Target decision needed:** either preserve one-image-per-main-commit or switch to a deploy train that publishes the latest approved main on a cadence/manual dispatch. Do not hide this trade-off inside YAML.
+
+### P4. External `action_required` runs pollute deploy visibility
+
+Fork/approval-required PRs can show many `action_required` checks. These are not the same as failed trusted CI and should be separated in any deploy dashboard/report.
+
+**Target:** `PR Gate` summary should classify `action_required` / untrusted PR state separately from failing validated CI.
+
+### P5. Lockfile checks are correct but train-hostile
+
+`uv.lock check` runs against GitHub's merged PR state, which is the right safety property. In rapid merge trains it can force follow-up PRs to rebase/regenerate `uv.lock`.
+
+**Target:** isolate dependency/lockfile PRs in the train and allow only one dependency-touching PR in the ready-to-merge lane at a time.
+
+---
+
+## Target Architecture
+
+```text
+.github/workflows/
+  pr-gate.yml          # required PR check surface
+  main-deploy.yml      # post-merge deployment from main
+  release.yml          # tag/release/manual artifact publishing
+```
+
+Optional exceptions must justify why they cannot be jobs inside those three:
+
+- GitHub-managed dynamic workflows: CodeQL, Dependabot, Copilot.
+- Low-frequency maintenance signal that cannot be represented in `main-deploy.yml` without confusing deploy state.
+
+---
+
+## Proposed `pr-gate.yml` Shape
+
+```yaml
+name: PR Gate
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  classify:
+    outputs:
+      python: ...
+      frontend: ...
+      docs: ...
+      docker: ...
+      deps: ...
+      mcp_catalog: ...
+
+  history:
+  contributor:
+  supply-chain:
+  dependency-bounds:
+  uv-lock:
+  lint:
+  windows-footguns:
+  typecheck:
+  tests:
+
+  docs:
+    if: needs.classify.outputs.docs == 'true'
+
+  docker-lint:
+    if: needs.classify.outputs.docker == 'true'
+
+  docker-smoke:
+    if: needs.classify.outputs.docker == 'true' || needs.classify.outputs.python == 'true'
+
+  summary:
+    if: always()
+```
+
+Important: the `summary` job must fail if any required internal job failed, and succeed when a non-applicable job was intentionally skipped. That preserves a single required check without path-gated pending behavior.
+
+---
+
+## Proposed `main-deploy.yml` Shape
+
+```yaml
+name: Main Deploy
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  classify:
+  docker-publish:
+    if: needs.classify.outputs.docker_or_python == 'true'
+  docs-pages:
+    if: needs.classify.outputs.docs_or_skills == 'true'
+  skills-index:
+    if: github.event_name == 'schedule' || needs.classify.outputs.skills == 'true'
+  summary:
+```
+
+Open decision: keep one Docker image per main commit, or batch/cancel superseded main runs. If continuous deployment throughput is the priority, make this an explicit release-train policy rather than an accidental consequence of `cancel-in-progress`.
+
+---
+
+## Proposed `release.yml` Shape
+
+```yaml
+name: Release Publish
+
+on:
+  release:
+    types: [published]
+  push:
+    tags: ['v20*']
+  workflow_dispatch:
+
+jobs:
+  docker-release:
+  pypi:
+  sigstore:
+  github-release-assets:
+  vercel-production-hook:
+  windows-installer:
+    if: inputs.build_windows_installer == 'true'
+```
+
+Release publishing should be the only place where PyPI, release-tag Docker images, Sigstore artifacts, and optional signed installer artifacts are considered together.
+
+---
+
+## Migration Plan
+
+### Phase 1 — Inventory and branch-protection alignment
+
+1. Land this plan.
+2. Export current branch protection / required check names from GitHub settings.
+3. Classify existing checks as:
+   - required PR gate,
+   - advisory PR signal,
+   - deploy,
+   - release,
+   - maintenance,
+   - GitHub-managed/dynamic.
+4. Decide the final required check name: `PR Gate`.
+
+Stop condition: do not delete existing workflows until branch protection can be updated safely.
+
+### Phase 2 — Introduce `pr-gate.yml` without removing old workflows
+
+1. Add `pr-gate.yml` with internal jobs copied from the existing workflows.
+2. Keep old workflows active temporarily.
+3. Verify `PR Gate` returns the same blocking result as the old required set for at least several PRs.
+4. Update branch protection to require `PR Gate` instead of the old per-workflow checks.
+
+Stop condition: if `PR Gate` summary cannot faithfully propagate internal failures, do not remove old required checks.
+
+### Phase 3 — Split deploy concerns
+
+1. Move main Docker publish jobs out of `docker-publish.yml` into `main-deploy.yml`.
+2. Move docs Pages deploy out of `deploy-site.yml` into `main-deploy.yml`.
+3. Keep release-specific Docker/PyPI/signing behavior in `release.yml`.
+4. Verify main push deploys are still observable from one workflow summary.
+
+Stop condition: no release publishing behavior should change silently.
+
+### Phase 4 — Delete or archive old workflows
+
+After branch protection and deploy observability are proven:
+
+- remove `tests.yml`, `lint.yml`, `typecheck.yml`, `docs-site-checks.yml`, `docker-lint.yml`, `uv-lockfile-check.yml`, `history-check.yml`, `contributor-check.yml`, `supply-chain-audit.yml` after their jobs are represented inside `pr-gate.yml`;
+- remove PR responsibilities from `docker-publish.yml`, then remove the file after deploy behavior is represented in `main-deploy.yml` / `release.yml`;
+- remove `deploy-site.yml`, `skills-index.yml`, `upload_to_pypi.yml`, and `build-windows-installer.yml` after equivalent jobs exist and have passed live dry-runs.
+
+---
+
+## Acceptance Criteria
+
+- GitHub branch protection has at most one Hermes-owned required PR workflow check: `PR Gate`.
+- PR authors can tell from one workflow summary whether the PR is blocked by tests, docs, Docker, deps, security, external approval, or contributor attribution.
+- Main deploy status is visible from one workflow: `Main Deploy`.
+- Release publish status is visible from one workflow: `Release Publish`.
+- Docker publish, Pages deploy, PyPI publish, Sigstore signing, and Windows signing still have real successful runs after migration.
+- The old workflow count in `.github/workflows` is reduced substantially, not replaced with more files.
+
+---
+
+## Non-goals
+
+- Do not weaken supply-chain protections.
+- Do not remove SHA pinning for GitHub Actions.
+- Do not change dependency pinning policy.
+- Do not make Docker publish behavior less observable.
+- Do not hide failing checks behind a green summary job.
+- Do not update branch protection blindly from code; branch protection changes must be coordinated with repository settings.


### PR DESCRIPTION
## Summary
- add a new always-present `PR Gate` workflow that aggregates the current required PR checks into one future branch-protection context
- keep all existing workflows intact so this can run in parallel before any ruleset switch
- document the CI/CD simplification target: `PR Gate`, `Main Deploy`, `Release Publish`
- record the current `protect-main` and `dep-version-gate` ruleset findings so the required-check migration has a concrete target

## Verification
- `python3 - <<'PY' ... yaml.safe_load(...)` for `.github/workflows/pr-gate.yml`
- `git diff --check`
- `actionlint v1.7.7 .github/workflows/pr-gate.yml`

## Migration note
This PR intentionally does **not** delete existing workflows. The next step after this lands is to observe `PR Gate` against real PRs, then update `protect-main` required status checks from the 13 current contexts to the single `PR Gate` context.
