### PR TITLE
fix(transports/chat_completions): strip session timestamp from API-facing messages

### DIFF
--- a/agent/transports/chat_completions.py
+++ b/agent/transports/chat_completions.py
@@ -172,6 +172,16 @@ class ChatCompletionsTransport(ProviderTransport):
                 "codex_reasoning_items" in msg
                 or "codex_message_items" in msg
                 or "tool_name" in msg
+                # ``timestamp`` is a Hermes session/gateway metadata field
+                # that is not part of the OpenAI Chat Completions message
+                # schema. Permissive providers (real OpenAI, OpenRouter)
+                # silently drop it; strict OpenAI-compatible gateways
+                # (Fireworks-backed routes, opencode-go) reject any
+                # payload containing it with
+                # ``Extra inputs are not permitted, field:
+                # 'messages[N].timestamp'`` (#47868). Strip it before
+                # the request goes over the wire.
+                or "timestamp" in msg
             ):
                 needs_sanitize = True
                 break
@@ -201,6 +211,11 @@ class ChatCompletionsTransport(ProviderTransport):
             msg.pop("codex_reasoning_items", None)
             msg.pop("codex_message_items", None)
             msg.pop("tool_name", None)
+            # Strip the schema-foreign ``timestamp`` metadata field
+            # before sending to strict chat-completions providers.
+            # Internal state in the session DB is unaffected — only
+            # the API-facing message copy is mutated (#47868).
+            msg.pop("timestamp", None)
             # Drop all Hermes-internal scaffolding markers (``_``-prefixed).
             # OpenAI's message schema has no ``_``-prefixed fields, so this
             # is safe and future-proofs against new markers being added.

--- a/tests/agent/transports/test_chat_completions.py
+++ b/tests/agent/transports/test_chat_completions.py
@@ -104,6 +104,50 @@ class TestChatCompletionsBasic:
         # Original list untouched (deepcopy-on-demand)
         assert msgs[2]["tool_name"] == "execute_code"
 
+    def test_convert_messages_strips_timestamp_metadata(self, transport):
+        """``timestamp`` is session/gateway metadata, not part of the OpenAI
+        Chat Completions message schema. Permissive providers silently
+        ignore the unknown key, but strict OpenAI-compatible gateways
+        (Fireworks-backed routes via opencode-go) reject the request with
+        ``Extra inputs are not permitted, field: 'messages[N].timestamp'``,
+        which then fails every subsequent turn in the session (#47868).
+        """
+        msgs = [
+            {"role": "system", "content": "you are hermes"},
+            {"role": "user", "content": "テスト", "timestamp": 1781698587.0},
+            {"role": "assistant", "content": "ok",
+             "timestamp": 1781698588.5},
+        ]
+        result = transport.convert_messages(msgs)
+        # All timestamps stripped from the API-facing copy
+        for m in result:
+            assert "timestamp" not in m, (
+                f"timestamp leaked to wire: {m!r} (would be rejected by "
+                f"strict chat-completions providers — #47868)"
+            )
+        # The rest of the message is preserved
+        assert result[0] == {"role": "system", "content": "you are hermes"}
+        assert result[1]["role"] == "user"
+        assert result[1]["content"] == "テスト"
+        assert result[2]["content"] == "ok"
+        # Original list untouched (deepcopy-on-demand)
+        assert msgs[1]["timestamp"] == 1781698587.0
+        assert msgs[2]["timestamp"] == 1781698588.5
+
+    def test_convert_messages_without_timestamp_keeps_early_return(self, transport):
+        """Messages that don't carry any schema-foreign field must hit the
+        ``if not needs_sanitize: return messages`` fast path — the result
+        is the *same* list object (no deepcopy). The ``timestamp`` addition
+        to the detection block must not break this for clean messages.
+        """
+        msgs = [
+            {"role": "user", "content": "hi"},
+            {"role": "assistant", "content": "hello"},
+        ]
+        result = transport.convert_messages(msgs)
+        # Identity (no copy) — proves the early-return fired.
+        assert result is msgs
+
     def test_convert_messages_strips_internal_scaffolding_markers(self, transport):
         """Hermes-internal ``_``-prefixed markers must never reach the wire.
 


### PR DESCRIPTION
## Summary

Hermes session and gateway logic attach a `timestamp` field to every message stored in the live conversation history. While this metadata is useful for session bookkeeping and request-dump breadcrumbs, it is not part of the OpenAI Chat Completions `messages[]` schema.

Permissive providers such as OpenAI, OpenRouter, and MiniMax silently ignore unknown fields. However, stricter OpenAI-compatible gateways—such as Fireworks-backed routes (e.g. `opencode-go glm-5.2 → accounts/fireworks/models/glm-5p2`)—reject payloads containing schema-foreign keys with a non-retryable HTTP 400 error:

> Extra inputs are not permitted,
> field: `messages[N].timestamp`,
> value: `1781698587`

Because the offending message remains in the live session history, every subsequent turn fails in the same way. The model itself behaves correctly when given a schema-valid payload; the bug is entirely on the Hermes request-construction side (#47868).

## Changes

### `agent/transports/chat_completions.py`

- Add `timestamp` to the schema-foreign-key detection block in `ChatCompletionsTransport.convert_messages()`, ensuring that timestamp-bearing sessions bypass the early-return fast path.
- Strip `timestamp` from the API-facing message copy during sanitization.
- Preserve internal session state; only the outgoing request payload is modified.

These changes follow the same pattern already used for:

- `codex_reasoning_items`
- `codex_message_items`
- `tool_name`
- `_`-prefixed internal markers

and are consistent with the fix applied in #34437.

### `tests/agent/transports/test_chat_completions.py`

Added two regression tests:

#### `test_convert_messages_strips_timestamp_metadata`

Verifies that:

- system, user, and assistant messages containing `timestamp` are sanitized correctly;
- all remaining message contents are preserved;
- the original input list remains untouched, confirming deepcopy-on-demand behavior.

#### `test_convert_messages_without_timestamp_keeps_early_return`

Verifies that:

- clean messages still hit the existing:

```python
if not needs_sanitize:
    return messages
```

fast path;

- adding timestamp detection does not introduce unnecessary copying in the common case.

## How to Test

```bash
.venv/bin/pytest tests/agent/transports/test_chat_completions.py -v
```

Result:

```text
83 passed (2 new + 81 existing)
```

The new tests cover the fix end-to-end:

- `test_convert_messages_strips_timestamp_metadata` confirms that `timestamp` is removed from every outgoing message while preserving the rest of each message and leaving the original list unchanged.

- `test_convert_messages_without_timestamp_keeps_early_return` uses:

```python
assert result is msgs
```

to prove that the common-case fast path still returns the original list object instead of creating a copy.

## Checklist

- [x] Tests pass — 83/83 in `test_chat_completions.py`
- [x] Follows Conventional Commits
- [x] Changes are scoped to this fix only — 2 files

## Risk & Impact

Low.

This change is additive and only removes the `timestamp` field from API-facing message copies. Internal session state (`state.db`, request dumps, and bookkeeping metadata) remains unaffected.

The implementation follows the exact pattern already used for `codex_reasoning_items`, `codex_message_items`, `tool_name`, and `_`-prefixed internal markers.

No public APIs or method signatures are modified, avoiding any downstream adapter or test-stub impact.

## Type

🐛 Bug fix

Closes: #47868

## Related Findings (Out of Scope)

A similar schema-foreign metadata leak may exist in the `anthropic_messages` transport.

Because Anthropic's Messages API uses a different schema—and fields such as `tool_call_id` are valid there—any equivalent sanitization would require a dedicated schema audit and should be addressed in a separate follow-up PR.