### PR TITLE
fix(aux-client): treat HTTP 410 Gone as model-not-found to trigger No…

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -2558,7 +2558,7 @@ def _is_unsupported_temperature_error(exc: Exception) -> bool:
 
 
 def _is_model_not_found_error(exc: Exception) -> bool:
-    """Detect "the requested model doesn't exist" errors (404 / invalid model).
+    """Detect "the requested model doesn't exist" errors (404 / 410 / invalid model).
 
     This fires when a resolved model name is no longer served by the endpoint
     — most commonly when a long-lived process pinned a Portal-recommended model
@@ -2568,10 +2568,17 @@ def _is_model_not_found_error(exc: Exception) -> bool:
         Model 'gpt-5.4-mini' not found. The requested model does not exist
         in our configuration or OpenRouter catalog.
 
+    It can also return 410 Gone when a model is permanently retired (#48269):
+    providers use 410 to signal that the resource is gone and will not return.
+    Both 404 and 410 trigger the stale-model self-heal in call_llm /
+    async_call_llm so callers automatically retry with the Portal's current
+    recommendation instead of propagating a cryptic HTTP error.
+
     Distinct from :func:`_is_payment_error` (which also matches some 404s for
     free-tier/credit language) — this one keys on "does not exist / not found /
     not a valid model" phrasing, and explicitly excludes the billing keywords
     that the payment path already owns so the two predicates don't overlap.
+    A 410 with billing keywords is also excluded and left to _is_payment_error.
     """
     status = getattr(exc, "status_code", None)
     err_lower = str(exc).lower()
@@ -2582,8 +2589,16 @@ def _is_model_not_found_error(exc: Exception) -> bool:
         "not available on the free tier",
     )):
         return False
-    if status not in {404, 400, None}:
+    # 404 = model not found, 400 = invalid model ID, 410 = model retired/gone.
+    # 410 Gone is the status providers return when a model has been permanently
+    # removed from the catalog — treat it the same as 404 so the Nous
+    # stale-model self-heal fires and retries with the current recommendation
+    # instead of surfacing a cryptic "Gone" error to the user (#48269).
+    if status not in {404, 400, 410, None}:
         return False
+    # 410 with no body keywords: still a model-not-found condition.
+    if status == 410:
+        return True
     return any(kw in err_lower for kw in (
         "model does not exist",
         "does not exist in our configuration",
@@ -2594,6 +2609,7 @@ def _is_model_not_found_error(exc: Exception) -> bool:
         "the model `",            # OpenAI-style: "The model `X` does not exist"
         "model_not_found",
         "unknown model",
+        "gone",                   # 410 Gone body text from some providers
     ))
 
 

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -1398,6 +1398,29 @@ class TestIsModelNotFoundError:
         exc.status_code = 500
         assert _is_model_not_found_error(exc) is False
 
+    # ── 410 Gone — retired model (#48269) ────────────────────────────────────
+
+    def test_410_bare_is_model_not_found(self):
+        """HTTP 410 Gone means the model has been permanently retired.
+        The stale-model self-heal must fire so we retry with a fresh
+        Portal recommendation instead of surfacing a cryptic 'Gone' error."""
+        exc = Exception("Gone")
+        exc.status_code = 410
+        assert _is_model_not_found_error(exc) is True
+
+    def test_410_with_model_gone_body(self):
+        """410 with a 'model has been removed' body is a model-not-found error."""
+        exc = Exception("qwen3-vl:235b-instruct has been removed from the catalog")
+        exc.status_code = 410
+        assert _is_model_not_found_error(exc) is True
+
+    def test_410_with_billing_keywords_is_not_model_not_found(self):
+        """A 410 that also contains billing language belongs to _is_payment_error,
+        not the model-not-found predicate (billing guard fires first)."""
+        exc = Exception("Model gone: insufficient credits for remaining access")
+        exc.status_code = 410
+        assert _is_model_not_found_error(exc) is False
+
 
 class TestRefreshNousRecommendedModel:
     """_refresh_nous_recommended_model picks a fresh model after a stale 404."""

--- a/tools/vision_tools.py
+++ b/tools/vision_tools.py
@@ -47,10 +47,18 @@ logger = logging.getLogger(__name__)
 
 _debug = DebugSession("vision_tools", env_var="VISION_TOOLS_DEBUG")
 
-# Configurable HTTP download timeout for _download_image().
-# Separate from auxiliary.vision.timeout which governs the LLM API call.
-# Resolution: config.yaml auxiliary.vision.download_timeout → env var → 30s default.
-def _resolve_download_timeout() -> float:
+def _get_download_timeout() -> float:
+    """Return the image HTTP download timeout, resolved fresh from config.yaml.
+
+    Resolution order:
+      1. HERMES_VISION_DOWNLOAD_TIMEOUT env var (process-lifetime override).
+      2. config.yaml auxiliary.vision.download_timeout (read each call so a
+         running gateway picks up changes without a restart).
+      3. 30 s hard-coded default.
+
+    Evaluated per-call (not at module import) so a config.yaml edit takes
+    effect on the next vision_analyze call in the same process (#48269).
+    """
     env_val = os.getenv("HERMES_VISION_DOWNLOAD_TIMEOUT", "").strip()
     if env_val:
         try:
@@ -66,8 +74,6 @@ def _resolve_download_timeout() -> float:
     except Exception:
         pass
     return 30.0
-
-_VISION_DOWNLOAD_TIMEOUT = _resolve_download_timeout()
 
 # Hard cap on downloaded image file size (50 MB). Prevents OOM from
 # attacker-hosted multi-gigabyte files or decompression bombs.
@@ -199,7 +205,7 @@ async def _download_image(image_url: str, destination: Path, max_retries: int = 
             # Enable follow_redirects to handle image CDNs that redirect (e.g., Imgur, Picsum)
             # SSRF: event_hooks validates each redirect target against private IP ranges
             async with httpx.AsyncClient(
-                timeout=_VISION_DOWNLOAD_TIMEOUT,
+                timeout=_get_download_timeout(),
                 follow_redirects=True,
                 event_hooks={"response": [_ssrf_redirect_guard]},
             ) as client:


### PR DESCRIPTION
…us stale-model self-heal

When the Nous Portal's recommended vision model is retired, the inference endpoint returns HTTP 410 Gone instead of 404.  _is_model_not_found_error previously only checked for status 404 and 400, so the stale-model self-heal in call_llm / async_call_llm never fired on a 410.  Users saw a cryptic 'Gone' error and the agent kept retrying the dead model indefinitely (#48269).

Changes:
- agent/auxiliary_client.py (_is_model_not_found_error): add 410 to the accepted status set; short-circuit to True for any bare 410 (billing guard still fires first for 410s that contain credit/billing keywords, keeping the two predicates non-overlapping). Update docstring.
- tools/vision_tools.py: replace module-level _VISION_DOWNLOAD_TIMEOUT (evaluated once at import time) with _get_download_timeout() evaluated per call, so config.yaml auxiliary.vision.download_timeout changes take effect in a running gateway without a restart.
- tests/agent/test_auxiliary_client.py: add three 410-specific cases to TestIsModelNotFoundError.

## What does this PR do?

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->



## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Fixes #

## Type of Change

<!-- Check the one that applies. -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- 

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. 
2. 
3. 

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [ ] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

<!-- Only fill this out if you're adding a skill. Delete this section otherwise. -->

- [ ] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [ ] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

