### PR TITLE
chore(release): map infinitycrew39 author email

### DIFF
--- a/scripts/release.py
+++ b/scripts/release.py
@@ -1569,6 +1569,7 @@ AUTHOR_MAP = {
     "bsmith@bramarstrategicservices.com": "bcsmith528",  # PR #20589 salvage (register_slack_action_handler plugin API)
     "sunsky.lau@gmail.com": "liuhao1024",  # PR #45494 salvage (claim session slot before auto-resume task; #45456)
     "andrewdmwalker@gmail.com": "capt-marbles",  # PR #38440 salvage (resolve xAI OAuth credentials across profiles; #43589)
+    "infinitycrew39@gmail.com": "infinitycrew39",  # PR #47945 salvage (scope langfuse trace state by turn/request ids; #48292)
 }
 
 


### PR DESCRIPTION
## Summary

Adds `infinitycrew39@gmail.com -> infinitycrew39` to `AUTHOR_MAP` in `scripts/release.py`.

The #47945 langfuse trace-scope salvage (merged as #48292) cherry-picked two commits authored by `infinitycrew39@gmail.com`. Without a map entry the contributor audit (`scripts/contributor_audit.py`, which imports `resolve_author`) treats that email as an unmapped author. This maps it to the contributor's GitHub handle so they're correctly credited in release-note audits.

Verified: `resolve_author("infinitycrew39", "infinitycrew39@gmail.com")` now returns `@infinitycrew39`.