### PR TITLE
feat(plugins): add delegate-task guard plugins

### DIFF
--- a/plugins/code-modification-guard/__init__.py
+++ b/plugins/code-modification-guard/__init__.py
@@ -1,0 +1,131 @@
+"""Hermes plugin that guards code modification delegation."""
+
+import re
+from typing import Any
+
+
+BLOCK_MESSAGE = (
+    'delegate_task 不可用于代码修改任务。请使用 codex exec --sandbox workspace-write "prompt" 完成代码修改。\n'
+    "分工原则：Claude 规划，Codex 实现。"
+)
+
+
+_RESEARCH_PATTERNS = tuple(
+    re.compile(pattern, re.IGNORECASE)
+    for pattern in (
+        r"研究",
+        r"\bresearch\b",
+        r"分析",
+        r"\banaly[sz]e\b",
+        r"\bsummarize\b",
+        r"总结",
+        r"报告",
+        r"\breport\b",
+    )
+)
+
+
+_CODE_MODIFICATION_PATTERNS = tuple(
+    re.compile(pattern, re.IGNORECASE)
+    for pattern in (
+        r"修改",
+        r"修复",
+        r"\bfix(?:e[ds])?\b",
+        r"\bbug(?:s)?\b",
+        r"\brefactor(?:ed|ing)?\b",
+        r"\bimplement(?:ed|ing|ation)?\b",
+        r"实现",
+        r"添加",
+        r"\badd(?:ed|ing)?\b",
+        r"\badd\s+feature\b",
+        r"代码",
+        r"\bcode\b",
+        r"\bfile(?:s)?\b",
+        r"文件",
+        r"\bfunction(?:s)?\b",
+        r"函数",
+        r"\bclass(?:es)?\b",
+        r"类",
+        r"\bedit(?:ed|ing)?\b",
+        r"\bchange(?:d|s|ing)?\b",
+        r"\bupdate(?:d|s|ing)?\b",
+        r"\brewrite(?:s|ing|n)?\b",
+        r"写入",
+        r"\bcreate\s+file\b",
+        r"\btest(?:s|ed|ing)?\b",
+        r"测试",
+        r"\bdebug(?:ged|ging)?\b",
+        r"调试",
+        r"\bpatch(?:ed|es|ing)?\b",
+        r"\bcommit(?:s|ted|ting)?\b",
+        r"\bpr\b",
+        r"\bpull\s+request\b",
+    )
+)
+
+
+_CODE_FILE_PATH_PATTERN = re.compile(
+    r"(?<![\w.-])(?:[\w.-]+/)*[\w.-]+\."
+    r"(?:py|pyi|js|jsx|ts|tsx|mjs|cjs|go|rs|java|kt|kts|c|cc|cpp|cxx|h|hpp|cs|rb|php|swift|scala|sh|bash|zsh|fish|ps1|sql|html|css|scss|sass|vue|svelte|json|yaml|yml|toml|md|rst|lock)(?![\w.-])",
+    re.IGNORECASE,
+)
+
+
+def register(ctx) -> None:
+    ctx.register_hook("pre_tool_call", on_pre_tool_call)
+
+
+def on_pre_tool_call(*, tool_name: str = "", args: dict = None, **kwargs):
+    # 只拦截 delegate_task，其他工具一律放行。
+    if tool_name != "delegate_task":
+        return None
+
+    if not isinstance(args, dict):
+        return None
+
+    for goal in _iter_goals(args):
+        if _has_code_modification_intent(goal):
+            return {"action": "block", "message": BLOCK_MESSAGE}
+
+    return None
+
+
+def _iter_goals(args: dict):
+    # 检查顶层 goal。
+    goal = args.get("goal")
+    if isinstance(goal, str):
+        yield goal
+
+    # 检查 tasks[].goal，忽略格式异常的 task。
+    tasks = args.get("tasks")
+    if not isinstance(tasks, list):
+        return
+
+    for task in tasks:
+        if not isinstance(task, dict):
+            continue
+        task_goal = task.get("goal")
+        if isinstance(task_goal, str):
+            yield task_goal
+
+
+def _has_code_modification_intent(goal: str) -> bool:
+    text = goal.strip()
+    if not text:
+        return False
+
+    # 研究/分析/总结/报告类任务放行，即使提到代码修改关键词。
+    if _matches_any(_RESEARCH_PATTERNS, text):
+        return False
+
+    has_explicit_file_path = bool(_CODE_FILE_PATH_PATTERN.search(text))
+
+    # 短目标且没有明确代码文件路径时按简单问题处理。
+    if len(text) < 50 and not has_explicit_file_path:
+        return False
+
+    return _matches_any(_CODE_MODIFICATION_PATTERNS, text)
+
+
+def _matches_any(patterns: tuple[Any, ...], text: str) -> bool:
+    return any(pattern.search(text) for pattern in patterns)

--- a/plugins/code-modification-guard/plugin.yaml
+++ b/plugins/code-modification-guard/plugin.yaml
@@ -1,0 +1,6 @@
+name: code-modification-guard
+version: "1.0.0"
+description: "Blocks delegate_task when the goal contains code modification intent. Forces agent to use codex exec instead."
+author: mosqlee
+hooks:
+  - pre_tool_call

--- a/plugins/tool-guard/__init__.py
+++ b/plugins/tool-guard/__init__.py
@@ -1,0 +1,339 @@
+"""
+tool-guard — Hermes plugin to intercept and guard tool calls.
+
+When a user specifies a tool like "Claude Code" or "Codex" in a
+delegate_task goal, and that tool has recently failed with connectivity
+or proxy errors, this plugin blocks the call and returns a clear error
+message instead of allowing silent fallback or substitution.
+
+Configuration
+-------------
+Reads from plugin.yaml ``config`` section, overridable via
+``~/.hermes/tool-guard-config.yaml`` (external file takes precedence).
+
+See plugin.yaml for all available settings.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+import time
+from pathlib import Path
+from threading import Lock
+from typing import Any, Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Failure state — module-level singleton, thread-safe
+# ---------------------------------------------------------------------------
+
+_lock = Lock()
+# {tool_name_lower: {"failures": int, "last_failure": float, "last_error": str}}
+_failure_state: Dict[str, Dict[str, Any]] = {}
+
+
+def _load_config() -> Dict[str, Any]:
+    """Load config from plugin.yaml defaults, overridden by external file."""
+    defaults = {
+        "guarded_tools": ["claude-code", "claude code", "codex"],
+        "failure_patterns": [
+            "connection refused",
+            "connect refused",
+            "proxy error",
+            "ERR_PROXY",
+            "tunnel.*fail",
+            "ECONNREFUSED",
+            "ETIMEDOUT",
+            "socket hang up",
+            "502 Bad Gateway",
+            "503 Service Unavailable",
+            "504 Gateway Timeout",
+            "Could not connect",
+            "unable to connect",
+            "No API key found",
+            "provider.*unavailable",
+            "rate limit",
+        ],
+        "cooldown_seconds": 300,
+        "max_consecutive_failures": 1,
+    }
+
+    # Try external config file first
+    external = Path.home() / ".hermes" / "tool-guard-config.yaml"
+    if external.exists():
+        try:
+            import yaml
+
+            with open(external) as f:
+                user_cfg = yaml.safe_load(f) or {}
+            if isinstance(user_cfg, dict):
+                defaults.update(user_cfg)
+                logger.debug("tool-guard: loaded external config from %s", external)
+                return defaults
+        except Exception as exc:
+            logger.warning("tool-guard: failed to load %s: %s", external, exc)
+
+    # Try plugin.yaml config section
+    plugin_yaml = Path(__file__).parent / "plugin.yaml"
+    if plugin_yaml.exists():
+        try:
+            import yaml
+
+            with open(plugin_yaml) as f:
+                manifest = yaml.safe_load(f) or {}
+            plugin_cfg = manifest.get("config", {})
+            if isinstance(plugin_cfg, dict):
+                defaults.update(plugin_cfg)
+        except Exception as exc:
+            logger.debug("tool-guard: failed to read plugin.yaml config: %s", exc)
+
+    return defaults
+
+
+_config: Optional[Dict[str, Any]] = None
+
+
+def _get_config() -> Dict[str, Any]:
+    global _config
+    if _config is None:
+        _config = _load_config()
+    return _config
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _mentions_guarded_tool(goal_text: str, guarded_tools: List[str]) -> Optional[str]:
+    """Return the first guarded tool name mentioned in *goal_text*, or None."""
+    text_lower = goal_text.lower()
+    for tool_name in guarded_tools:
+        if tool_name.lower() in text_lower:
+            return tool_name
+    return None
+
+
+def _is_failure_active(tool_key: str, cooldown: int, min_failures: int) -> Optional[str]:
+    """Check if the given tool has an active failure within cooldown window.
+
+    Returns the last error string if blocked, or None if allowed.
+    """
+    with _lock:
+        state = _failure_state.get(tool_key)
+        if state is None:
+            return None
+        if state["failures"] < min_failures:
+            return None
+        elapsed = time.monotonic() - state["last_failure"]
+        if elapsed > cooldown:
+            # Cooldown expired — clear state
+            del _failure_state[tool_key]
+            return None
+        return state["last_error"]
+
+
+def _record_failure(tool_key: str, error_summary: str) -> None:
+    """Record a connectivity failure for *tool_key*."""
+    with _lock:
+        if tool_key in _failure_state:
+            _failure_state[tool_key]["failures"] += 1
+            _failure_state[tool_key]["last_failure"] = time.monotonic()
+            _failure_state[tool_key]["last_error"] = error_summary
+        else:
+            _failure_state[tool_key] = {
+                "failures": 1,
+                "last_failure": time.monotonic(),
+                "last_error": error_summary,
+            }
+        logger.info(
+            "tool-guard: recorded failure for '%s' (count=%d): %s",
+            tool_key,
+            _failure_state[tool_key]["failures"],
+            error_summary[:200],
+        )
+
+
+def _clear_failure(tool_key: str) -> None:
+    """Clear failure state for *tool_key* after a successful call."""
+    with _lock:
+        if tool_key in _failure_state:
+            del _failure_state[tool_key]
+            logger.info("tool-guard: cleared failure state for '%s'", tool_key)
+
+
+def _compile_patterns(patterns: List[str]) -> List[re.Pattern]:
+    """Compile a list of regex pattern strings (case-insensitive)."""
+    compiled = []
+    for p in patterns:
+        try:
+            compiled.append(re.compile(p, re.IGNORECASE))
+        except re.error:
+            logger.warning("tool-guard: invalid regex pattern skipped: %s", p)
+    return compiled
+
+
+def _matches_failure_pattern(text: str, patterns: List[re.Pattern]) -> Optional[str]:
+    """Return the first matching pattern's string, or None."""
+    for pat in patterns:
+        m = pat.search(text)
+        if m:
+            return m.group(0)
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Hook: pre_tool_call
+# ---------------------------------------------------------------------------
+
+def _pre_tool_call(
+    tool_name: str,
+    args: Optional[Dict[str, Any]] = None,
+    task_id: str = "",
+    session_id: str = "",
+    tool_call_id: str = "",
+    **_kwargs: Any,
+) -> Optional[Dict[str, Any]]:
+    """Block delegate_task calls to recently-failed guarded tools.
+
+    Returns ``{"action": "block", "message": "..."}`` when the tool should
+    be blocked, or ``None`` to allow the call.
+    """
+    if tool_name != "delegate_task":
+        return None
+    if not isinstance(args, dict):
+        return None
+
+    cfg = _get_config()
+    guarded_tools: List[str] = cfg.get("guarded_tools", [])
+    cooldown: int = cfg.get("cooldown_seconds", 300)
+    min_failures: int = cfg.get("max_consecutive_failures", 1)
+
+    # Extract the goal text from delegate_task args
+    goal = args.get("goal", "") or ""
+    if not goal:
+        return None
+
+    mentioned = _mentions_guarded_tool(goal, guarded_tools)
+    if mentioned is None:
+        return None
+
+    # Normalize the tool key for failure lookup
+    tool_key = mentioned.lower().strip()
+
+    error_info = _is_failure_active(tool_key, cooldown, min_failures)
+    if error_info is not None:
+        msg = (
+            f"⚠️ **tool-guard**: Blocked delegate_task — the tool **{mentioned}** "
+            f"has recently failed due to a connectivity issue and is being "
+            f"guarded to prevent silent substitution.\n\n"
+            f"**Last error:** {error_info}\n\n"
+            f"**Cooldown:** {cooldown}s remaining (failures are tracked per-tool). "
+            f"Retry after the cooldown expires, or resolve the connectivity issue.\n\n"
+            f"To clear the block immediately, you can reset the failure state "
+            f"or adjust config in ~/.hermes/tool-guard-config.yaml."
+        )
+        logger.warning("tool-guard: BLOCKED delegate_task — '%s' is down: %s", mentioned, error_info)
+        return {"action": "block", "message": msg}
+
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Hook: post_tool_call
+# ---------------------------------------------------------------------------
+
+_failure_regexes: Optional[List[re.Pattern]] = None
+
+
+def _post_tool_call(
+    tool_name: str,
+    args: Optional[Dict[str, Any]] = None,
+    result: Any = None,
+    task_id: str = "",
+    session_id: str = "",
+    tool_call_id: str = "",
+    duration_ms: int = 0,
+    **_kwargs: Any,
+) -> None:
+    """Monitor delegate_task results for connectivity failure patterns.
+
+    When a failure is detected, records the state so subsequent
+    pre_tool_call hooks can block the same tool.
+    """
+    if tool_name != "delegate_task":
+        return
+
+    cfg = _get_config()
+    guarded_tools: List[str] = cfg.get("guarded_tools", [])
+
+    # Compile patterns lazily
+    global _failure_regexes
+    if _failure_regexes is None:
+        _failure_regexes = _compile_patterns(cfg.get("failure_patterns", []))
+
+    # Serialize result to string for pattern matching
+    if result is None:
+        return
+    if isinstance(result, dict):
+        result_text = json.dumps(result)
+    elif isinstance(result, str):
+        result_text = result
+    else:
+        result_text = str(result)
+
+    # Check for failure patterns
+    match = _matches_failure_pattern(result_text, _failure_regexes)
+    if match is None:
+        # No failure — if this was a guarded tool call, clear its state
+        if isinstance(args, dict):
+            goal = args.get("goal", "") or ""
+            mentioned = _mentions_guarded_tool(goal, guarded_tools)
+            if mentioned:
+                _clear_failure(mentioned.lower().strip())
+        return
+
+    # Failure detected — figure out which guarded tool was involved
+    if not isinstance(args, dict):
+        return
+
+    goal = args.get("goal", "") or ""
+    mentioned = _mentions_guarded_tool(goal, guarded_tools)
+    if mentioned is None:
+        # Failure in delegate_task but not about a guarded tool — ignore
+        return
+
+    tool_key = mentioned.lower().strip()
+
+    # Extract a concise error summary from the result
+    if isinstance(result, dict):
+        error_summary = result.get("error", "") or result.get("output", "") or match
+    else:
+        # Truncate long results for the error summary
+        error_summary = result_text[:500] if len(result_text) > 500 else result_text
+
+    _record_failure(tool_key, error_summary)
+
+
+# ---------------------------------------------------------------------------
+# Plugin registration entrypoint
+# ---------------------------------------------------------------------------
+
+def register(ctx) -> None:
+    """Called by the Hermes plugin system to register hooks.
+
+    Args:
+        ctx: PluginContext instance providing register_hook() and metadata.
+    """
+    ctx.register_hook("pre_tool_call", _pre_tool_call)
+    ctx.register_hook("post_tool_call", _post_tool_call)
+
+    cfg = _get_config()
+    logger.info(
+        "tool-guard: loaded — guarding tools %s, cooldown=%ds, min_failures=%d",
+        cfg.get("guarded_tools", []),
+        cfg.get("cooldown_seconds", 300),
+        cfg.get("max_consecutive_failures", 1),
+    )

--- a/plugins/tool-guard/plugin.yaml
+++ b/plugins/tool-guard/plugin.yaml
@@ -1,0 +1,54 @@
+name: tool-guard
+version: 1.0.0
+description: >
+  Intercepts delegate_task calls to guarded tools (e.g. Claude Code, Codex).
+  When a guarded tool is unavailable due to connectivity/proxy errors, blocks
+  the call with a clear error message instead of allowing silent substitution.
+  Also monitors post_tool_call results to track tool failures over time.
+author: user
+kind: standalone
+provides_hooks:
+  - pre_tool_call
+  - post_tool_call
+
+# ── Plugin configuration ──────────────────────────────────────────────
+# Edit the `config` section below, or create ~/.hermes/tool-guard-config.yaml
+# with the same keys. The external file takes precedence.
+#
+# guarded_tools:
+#   Tools whose names (in delegate_task goal/context) trigger monitoring.
+#   Matches are case-insensitive substrings.
+#
+# failure_patterns:
+#   Regex patterns in tool result text that indicate connectivity failures.
+#
+# cooldown_seconds:
+#   How long (seconds) a failure stays in effect. During this window any
+#   delegate_task mentioning the failed tool is blocked.
+#
+# max_consecutive_failures:
+#   Number of consecutive failures before blocking kicks in (default: 1 = immediate).
+config:
+  guarded_tools:
+    - claude-code
+    - claude code
+    - codex
+  failure_patterns:
+    - connection refused
+    - connect refused
+    - proxy error
+    - ERR_PROXY
+    - tunnel.*fail
+    - ECONNREFUSED
+    - ETIMEDOUT
+    - socket hang up
+    - 502 Bad Gateway
+    - 503 Service Unavailable
+    - 504 Gateway Timeout
+    - Could not connect
+    - unable to connect
+    - "No API key found"
+    - "provider.*unavailable"
+    - "rate limit"
+  cooldown_seconds: 300
+  max_consecutive_failures: 1

--- a/tests/test_plugins_delegate_guard.py
+++ b/tests/test_plugins_delegate_guard.py
@@ -1,0 +1,147 @@
+import importlib.util
+import sys
+import uuid
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def load_plugin(name: str):
+    plugin_path = ROOT / "plugins" / name / "__init__.py"
+    module_name = f"test_plugin_{name.replace('-', '_')}_{uuid.uuid4().hex}"
+    spec = importlib.util.spec_from_file_location(module_name, plugin_path)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+class HookCollector:
+    def __init__(self):
+        self.hooks = {}
+
+    def register_hook(self, name, callback):
+        self.hooks[name] = callback
+
+
+def configure_tool_guard(plugin, cooldown_seconds=300):
+    plugin._config = {
+        "guarded_tools": ["claude-code", "claude code", "codex"],
+        "failure_patterns": ["connection refused", "proxy error"],
+        "cooldown_seconds": cooldown_seconds,
+        "max_consecutive_failures": 1,
+    }
+    plugin._failure_regexes = None
+    plugin._failure_state.clear()
+
+
+def test_code_modification_guard_blocks_delegate_code_changes():
+    plugin = load_plugin("code-modification-guard")
+
+    result = plugin.on_pre_tool_call(
+        tool_name="delegate_task",
+        args={
+            "goal": (
+                "Please implement the fix in run_agent.py, update the function, "
+                "and add tests for the changed behavior."
+            )
+        },
+    )
+
+    assert result["action"] == "block"
+    assert "delegate_task" in result["message"]
+    assert "codex exec" in result["message"]
+
+
+def test_code_modification_guard_allows_research_tasks():
+    plugin = load_plugin("code-modification-guard")
+
+    result = plugin.on_pre_tool_call(
+        tool_name="delegate_task",
+        args={
+            "goal": (
+                "Research how run_agent.py handles code modification requests "
+                "and summarize the implementation options."
+            )
+        },
+    )
+
+    assert result is None
+
+
+def test_code_modification_guard_allows_short_goals_without_file_paths():
+    plugin = load_plugin("code-modification-guard")
+
+    result = plugin.on_pre_tool_call(
+        tool_name="delegate_task",
+        args={"goal": "fix bug"},
+    )
+
+    assert result is None
+
+
+def test_code_modification_guard_allows_non_delegate_task_tools():
+    plugin = load_plugin("code-modification-guard")
+
+    result = plugin.on_pre_tool_call(
+        tool_name="read_file",
+        args={
+            "goal": (
+                "Please implement the fix in run_agent.py, update the function, "
+                "and add tests for the changed behavior."
+            )
+        },
+    )
+
+    assert result is None
+
+
+def test_tool_guard_registers_hooks_with_importlib_loaded_plugin():
+    plugin = load_plugin("tool-guard")
+    configure_tool_guard(plugin)
+    collector = HookCollector()
+
+    plugin.register(collector)
+
+    assert set(collector.hooks) == {"pre_tool_call", "post_tool_call"}
+
+
+def test_tool_guard_blocks_after_recorded_failure_and_clears_after_success():
+    plugin = load_plugin("tool-guard")
+    configure_tool_guard(plugin)
+    args = {"goal": "Use Codex to inspect this issue"}
+
+    plugin._post_tool_call(
+        tool_name="delegate_task",
+        args=args,
+        result="proxy error: could not connect to upstream",
+    )
+    blocked = plugin._pre_tool_call(tool_name="delegate_task", args=args)
+
+    assert blocked["action"] == "block"
+    assert "codex" in blocked["message"]
+    assert "proxy error" in blocked["message"]
+
+    plugin._post_tool_call(tool_name="delegate_task", args=args, result="completed")
+
+    assert plugin._pre_tool_call(tool_name="delegate_task", args=args) is None
+
+
+def test_tool_guard_clears_failure_after_cooldown(monkeypatch):
+    plugin = load_plugin("tool-guard")
+    configure_tool_guard(plugin)
+    args = {"goal": "Use Codex to inspect this issue"}
+
+    now = 1000.0
+    monkeypatch.setattr(plugin.time, "monotonic", lambda: now)
+    plugin._post_tool_call(
+        tool_name="delegate_task",
+        args=args,
+        result="connection refused by proxy",
+    )
+
+    monkeypatch.setattr(plugin.time, "monotonic", lambda: now + 301.0)
+
+    assert plugin._pre_tool_call(tool_name="delegate_task", args=args) is None
+    assert plugin._failure_state == {}


### PR DESCRIPTION
## Summary

Two new user-installable plugins that intercept `delegate_task` calls using the `pre_tool_call` hook mechanism.

### code-modification-guard
Blocks `delegate_task` when the goal contains code modification intent (fix/implement/refactor/test/debug etc.), forcing the agent to use `codex exec` instead. 

**Key behaviors:**
- Exempts research/analysis/summary tasks (中英文)
- Short goals (<50 chars) without explicit file paths are allowed
- Only targets `delegate_task` — other tools unaffected
- Supports batch tasks (`tasks[].goal`)

### tool-guard
Monitors `delegate_task` calls to guarded tools (Claude Code, Codex). When a guarded tool fails with connectivity/proxy errors, blocks subsequent calls within a configurable cooldown window to prevent silent substitution.

**Key behaviors:**
- Tracks failures per-tool with configurable cooldown (default 300s)
- Auto-clears failure state after cooldown expires
- Configurable via `plugin.yaml` or `~/.hermes/tool-guard-config.yaml`
- Uses both `pre_tool_call` (block) and `post_tool_call` (detect failures) hooks

## Testing

7 pytest tests covering:
- Blocking code modification goals (Chinese + English)
- Allowing research/analysis tasks
- Allowing short goals without file paths
- Allowing non-delegate_task tools
- Tool-guard failure recording, blocking, and clearing
- Cooldown expiry behavior
- Hook registration verification

All tests pass with `pytest tests/test_plugins_delegate_guard.py -v` (7 passed in 1.52s).

## Usage

