### PR TITLE
fix(cron): prevent gateway crash from cron job LLM failures (#48234)

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -1694,7 +1694,7 @@ def _run_job_impl(job: dict) -> tuple[bool, str, str, Optional[str]]:
                     if _idle_secs >= _cron_inactivity_limit:
                         _inactivity_timeout = True
                         break
-        except Exception:
+        except BaseException:
             _cron_pool.shutdown(wait=False, cancel_futures=True)
             raise
         finally:
@@ -1953,9 +1953,12 @@ def tick(verbose: bool = True, adapters=None, loop=None) -> int:
                 mark_job_run(job["id"], success, error, delivery_error=delivery_error)
                 return True
 
-            except Exception as e:
-                logger.error("Error processing job %s: %s", job['id'], e)
-                mark_job_run(job["id"], False, str(e))
+            except BaseException as e:
+                logger.error("Error processing job %s: %s", job['id'], e, exc_info=True)
+                try:
+                    mark_job_run(job["id"], False, str(e))
+                except Exception:
+                    pass
                 return False
 
         # Partition due jobs: jobs with a per-job workdir and/or profile touch

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -17920,8 +17920,8 @@ def _start_cron_ticker(stop_event: threading.Event, adapters=None, loop=None, in
     while not stop_event.is_set():
         try:
             cron_tick(verbose=False, adapters=adapters, loop=loop)
-        except Exception as e:
-            logger.debug("Cron tick error: %s", e)
+        except BaseException as e:
+            logger.error("Cron tick error (non-fatal): %s", e, exc_info=True)
 
         tick_count += 1
 


### PR DESCRIPTION
Fixes #48234. Catch BaseException instead of Exception in cron ticker thread and job processing to prevent transient provider errors (e.g. IndexError from malformed LLM responses) from crashing the gateway process. Cron job failures are now always caught, logged, and marked as failed without propagating to the gateway main loop.