### PR TITLE
fix(agent): add google-gemini-cli to auxiliary resolve_provider_client (#48201)

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -3333,6 +3333,19 @@ def resolve_provider_client(
         return (_to_async_client(client, final_model, is_vision=is_vision) if async_mode
                 else (client, final_model))
 
+    # ── Google Gemini OAuth (google-gemini-cli → Cloud Code Assist) ──
+    if provider == "google-gemini-cli":
+        from agent.gemini_cloudcode_adapter import GeminiCloudCodeClient
+        from hermes_cli.auth import DEFAULT_GEMINI_CLOUDCODE_BASE_URL
+        base_url = DEFAULT_GEMINI_CLOUDCODE_BASE_URL
+        client = GeminiCloudCodeClient(base_url=base_url)
+        final_model = _normalize_resolved_model(
+            model or "gemini-2.5-flash", provider
+        )
+        logger.debug("resolve_provider_client: google-gemini-cli (%s)", final_model)
+        return (_to_async_client(client, final_model, is_vision=is_vision) if async_mode
+                else (client, final_model))
+
     # ── Custom endpoint (OPENAI_BASE_URL + OPENAI_API_KEY) ───────────
     if provider == "custom":
         if explicit_base_url:
@@ -3734,6 +3747,8 @@ def resolve_provider_client(
             return resolve_provider_client("openai-codex", model, async_mode)
         if provider == "xai-oauth":
             return resolve_provider_client("xai-oauth", model, async_mode)
+        if provider == "google-gemini-cli":
+            return resolve_provider_client("google-gemini-cli", model, async_mode)
         # Other OAuth providers not directly supported
         logger.warning("resolve_provider_client: OAuth provider %s not "
                        "directly supported, try 'auto'", provider)


### PR DESCRIPTION
Fixes #48201. Add google-gemini-cli OAuth provider handling in auxiliary client resolve_provider_client, routing it to GeminiCloudCodeClient. Previously it fell through to the catch-all warning, making vision and compression tasks unavailable for Google Gemini OAuth users.