### PR TITLE
fix(cli): make refresh_interval configurable, default to 0 (disabled)

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -12816,13 +12816,13 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
             style=style,
             full_screen=False,
             mouse_support=False,
-            # The status bar contains wall-clock read-outs (live prompt elapsed
-            # and idle-since-last-turn). Once a turn finishes there may be no
-            # further events to invalidate the app, so prompt_toolkit would keep
-            # rendering the first post-turn value (usually ``✓ 0s``) forever.
-            # A low-rate refresh keeps the clock honest without reintroducing a
-            # custom repaint thread or touching conversation state.
-            refresh_interval=1.0,
+            # Read from display.cli_refresh_interval (default 0 = disabled).
+            # When non-zero, prompt_toolkit redraws the UI on this cadence
+            # during idle, keeping wall-clock status-bar read-outs ticking.
+            # Set to 0 to suppress background redraws entirely — avoids
+            # fighting terminal auto-scroll in non-fullscreen mode (Xshell,
+            # iTerm2, Windows Terminal). See #48309.
+            refresh_interval=float(CLI_CONFIG.get("display", {}).get("cli_refresh_interval", 0)),
             # Erase the live bottom chrome (status bar, input box, separator
             # rules) on exit instead of freezing a final copy into scrollback.
             # Without this, prompt_toolkit's render_as_done teardown repaints

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1557,6 +1557,12 @@ DEFAULT_CONFIG = {
         # TUI busy indicator style: kaomoji (default), emoji, unicode (braille
         # spinner), or ascii.  Live-swappable via `/indicator <style>`.
         "tui_status_indicator": "kaomoji",
+        # Seconds between prompt_toolkit redraws in the classic CLI when idle.
+        # 0 = disabled (no background refresh — the pre-0.15.2 behaviour).
+        # Positive values e.g. 1.0 keep wall-clock status-bar read-outs
+        # (idle-since-last-turn) ticking but may fight terminal auto-scroll in
+        # non-fullscreen mode on some emulators (Xshell, iTerm2, etc.).
+        "cli_refresh_interval": 0,
         "user_message_preview": {  # CLI: how many submitted user-message lines to echo back in scrollback
             "first_lines": 2,
             "last_lines": 2,


### PR DESCRIPTION
## Problem

Commit `6724daa2c` ("fix: keep CLI idle timer ticking #45592") added `refresh_interval=1.0` to the prompt_toolkit `Application` in non-fullscreen classic CLI mode. This causes a full UI redraw every second during idle time.

Terminal emulators with "auto-scroll on output" (Xshell, iTerm2, Windows Terminal, etc.) interpret the ANSI output from each redraw as new content and auto-scroll the viewport to the bottom — even when the user has manually scrolled up to read conversation history.

**Fixes: #48309**

## Root Cause

The original code explicitly warned against this (cli.py ~L12927 before `6724daa2c`):

```
# Do not repaint the idle prompt every second. In non-full-screen
# prompt_toolkit mode, background redraws can fight tmux/Ghostty/cmux
# viewport restoration after focus changes...
```

## Change

Drive `refresh_interval` from `display.cli_refresh_interval` in `config.yaml`, defaulting to `0` (disabled — the pre-0.15.2 behavior). Users who want the idle clock to keep ticking can set it to `1.0` (or any positive value).

### cli.py (1 line change)
```python
# Before (hardcoded):
refresh_interval=1.0,

# After (config-driven, default 0 = off):
refresh_interval=float(CLI_CONFIG.get("display", {}).get("cli_refresh_interval", 0)),
```

### hermes_cli/config.py (1 key added)
```python
"cli_refresh_interval": 0,  # seconds; 0 = disabled
```

## Testing
- [x] `python3 -m py_compile cli.py hermes_cli/config.py` — passes
- [x] `scripts/run_tests.sh tests/cli/` — 78 files, 924 tests, 0 failures
- [x] Manual verification: idle scrolling stays put on Xshell (SSH)