### PR TITLE
fix(cli): disable idle refresh_interval in non-fullscreen mode to prevent auto-scroll

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -12822,7 +12822,15 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
             # rendering the first post-turn value (usually ``✓ 0s``) forever.
             # A low-rate refresh keeps the clock honest without reintroducing a
             # custom repaint thread or touching conversation state.
-            refresh_interval=1.0,
+            #
+            # In non-fullscreen mode the periodic redraw sends ANSI output to
+            # the terminal, which causes terminal emulators with "auto-scroll
+            # on output" (Xshell, iTerm2, Windows Terminal, etc.) to snap the
+            # viewport back to the bottom when the user has scrolled up to
+            # read history.  Disable the idle refresh in non-fullscreen mode;
+            # the clock will freeze after the turn completes but any user
+            # input (key press, paste) triggers a full repaint anyway.
+            refresh_interval=0,
             # Erase the live bottom chrome (status bar, input box, separator
             # rules) on exit instead of freezing a final copy into scrollback.
             # Without this, prompt_toolkit's render_as_done teardown repaints


### PR DESCRIPTION
## Summary

After commit 6724daa2c, the classic CLI uses refresh_interval=1.0 to keep the status bar clock ticking during idle. In non-fullscreen mode, this periodic redraw sends ANSI output to the terminal once per second.

Terminal emulators with auto-scroll on output (Xshell, iTerm2, Windows Terminal) interpret this as new content and snap the viewport to the bottom.

## Fix

Set refresh_interval=0 in non-fullscreen mode. The clock freezes after turn completes but any user input triggers a full repaint.

## Changes

- cli.py: 1 line + 8 comment lines

Fixes #48309