### PR TITLE
fix(cli): keep session arg coalescing subcommands in sync

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -10045,47 +10045,6 @@ def _coalesce_session_name_args(argv: list) -> list:
     Tokens are collected after the flag until we hit another flag (``-*``)
     or a known top-level subcommand.
     """
-    _SUBCOMMANDS = {
-        "chat",
-        "model",
-        "gateway",
-        "setup",
-        "whatsapp",
-        "whatsapp-cloud",
-        "login",
-        "logout",
-        "auth",
-        "status",
-        "cron",
-        "doctor",
-        "config",
-        "pairing",
-        "skills",
-        "tools",
-        "mcp",
-        "sessions",
-        "insights",
-        "version",
-        "update",
-        "uninstall",
-        "profile",
-        "dashboard",
-        "desktop",
-        "gui",
-        "honcho",
-        "claw",
-        "plugins",
-        "security",
-        "acp",
-        "webhook",
-        "memory",
-        "dump",
-        "debug",
-        "backup",
-        "import",
-        "completion",
-        "logs",
-    }
     _SESSION_FLAGS = {"-c", "--continue", "-r", "--resume"}
 
     result = []
@@ -10100,7 +10059,7 @@ def _coalesce_session_name_args(argv: list) -> list:
             while (
                 i < len(argv)
                 and not argv[i].startswith("-")
-                and argv[i] not in _SUBCOMMANDS
+                and argv[i] not in _BUILTIN_SUBCOMMANDS
             ):
                 parts.append(argv[i])
                 i += 1

--- a/tests/hermes_cli/test_coalesce_session_args.py
+++ b/tests/hermes_cli/test_coalesce_session_args.py
@@ -110,3 +110,15 @@ class TestCoalesceSessionNameArgs:
         assert _coalesce_session_name_args(
             ["-c", "my", "setup"]
         ) == ["-c", "my", "setup"]
+
+    def test_stops_at_later_added_subcommand(self):
+        """hermes -r my session send telegram hi → stops before 'send'."""
+        assert _coalesce_session_name_args(
+            ["-r", "my", "session", "send", "telegram", "hi"]
+        ) == ["-r", "my session", "send", "telegram", "hi"]
+
+    def test_stops_at_hyphenated_subcommand(self):
+        """hermes -c my session prompt-size → stops before 'prompt-size'."""
+        assert _coalesce_session_name_args(
+            ["-c", "my", "session", "prompt-size"]
+        ) == ["-c", "my session", "prompt-size"]

--- a/tests/hermes_cli/test_completion.py
+++ b/tests/hermes_cli/test_completion.py
@@ -2,7 +2,6 @@
 
 import argparse
 import os
-import re
 import shutil
 import subprocess
 import tempfile
@@ -227,26 +226,14 @@ class TestGenerateFish:
 # ---------------------------------------------------------------------------
 
 class TestSubcommandDrift:
-    def test_SUBCOMMANDS_covers_required_commands(self):
-        """_SUBCOMMANDS must include all known top-level commands so that
-        multi-word session names after -c/-r are never accidentally split.
-        """
-        import inspect
-        from hermes_cli.main import _coalesce_session_name_args
+    def test_session_arg_coalescing_stops_at_builtin_commands(self):
+        """Every known top-level command must stop -c/-r name collection."""
+        from hermes_cli.main import _BUILTIN_SUBCOMMANDS, _coalesce_session_name_args
 
-        source = inspect.getsource(_coalesce_session_name_args)
-        match = re.search(r'_SUBCOMMANDS\s*=\s*\{([^}]+)\}', source, re.DOTALL)
-        assert match, "_SUBCOMMANDS block not found in _coalesce_session_name_args()"
-        defined = set(re.findall(r'"(\w+)"', match.group(1)))
-
-        required = {
-            "chat", "model", "gateway", "setup", "login", "logout", "auth",
-            "status", "cron", "config", "sessions", "version", "update",
-            "uninstall", "profile", "skills", "tools", "mcp", "plugins",
-            "acp", "claw", "honcho", "completion", "logs",
-        }
-        missing = required - defined
-        assert not missing, f"Missing from _SUBCOMMANDS: {missing}"
+        for command in _BUILTIN_SUBCOMMANDS - {"help"}:
+            assert _coalesce_session_name_args(
+                ["-r", "my", "session", command, "tail"]
+            ) == ["-r", "my session", command, "tail"]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- use the existing `_BUILTIN_SUBCOMMANDS` list as the stop boundary for `-c/--continue` and `-r/--resume` session name coalescing
- add regressions for newly added and hyphenated subcommands so commands like `send` and `prompt-size` are not swallowed into the session name
- replace the brittle source-regex drift test with behavioral coverage against the shared command set

## Why
`_coalesce_session_name_args()` carried a second hand-maintained `_SUBCOMMANDS` set that had drifted from the real built-in command registry. As a result, invocations such as `hermes -r my session send telegram hi` were coalesced into a session name instead of stopping at `send`.

## Test plan
- `python -m pytest tests/hermes_cli/test_coalesce_session_args.py tests/hermes_cli/test_completion.py -q`
- `uv run ruff check hermes_cli/main.py tests/hermes_cli/test_coalesce_session_args.py tests/hermes_cli/test_completion.py`

## Duplicate check
Searched open PRs/issues for `coalesce_session_name_args`, `_SUBCOMMANDS`, `continue resume send`, and `prompt-size`; only unrelated results were found.