### PR TITLE
fix(tests): validate runner slices before discovery

### DIFF
--- a/scripts/run_tests_parallel.py
+++ b/scripts/run_tests_parallel.py
@@ -4,7 +4,7 @@
 The minimum-viable replacement for pytest-xdist + a subprocess-isolation
 plugin. Discovers test files under ``tests/`` (excluding integration/e2e
 unless explicitly requested), then runs one ``python -m pytest <file>``
-subprocess per file, with bounded parallelism (default: ``os.cpu_count()``).
+subprocess per file, with bounded parallelism (default: ``os.cpu_count() * 2``).
 
 Why per-file rather than per-test?
     Per-test spawn overhead (~250ms × 17k tests = 70min CPU minimum)
@@ -23,13 +23,13 @@ Why drop xdist entirely?
     the job.
 
 Usage:
-    python scripts/run_tests_parallel.py [pytest_args...]
+    python scripts/run_tests_parallel.py [paths...] [-- pytest_args...]
 
-    Common pytest args pass through (e.g. ``-v``, ``-x``, ``--tb=long``,
-    ``-k 'pattern'``, ``--lf``).
+    Common pytest args pass through after a literal ``--`` separator
+    (e.g. ``-- -v -x --tb=long -k 'pattern' --lf``).
 
 Environment:
-    HERMES_TEST_WORKERS  Override worker count (default: os.cpu_count())
+    HERMES_TEST_WORKERS  Override worker count (default: os.cpu_count()*2)
     HERMES_TEST_PATHS    Override discovery roots (colon-sep, default: 'tests')
 
 Exit code: 0 if every file's pytest exited 0; 1 otherwise.
@@ -78,6 +78,34 @@ _DEFAULT_FILE_TIMEOUT_SECONDS = 140.0 # set by observing the slowest file at com
 # wall-clock seconds. Used by ``--slice`` to distribute files across
 # CI jobs by estimated total time, so no one job gets all the slow files.
 _DURATIONS_FILE = "test_durations.json"
+
+
+def _parse_slice_spec(slice_raw: str) -> tuple[int, int]:
+    """Parse and validate a ``--slice`` value in ``I/N`` form."""
+    try:
+        idx_s, count_s = slice_raw.split("/", 1)
+        slice_index = int(idx_s)
+        slice_count = int(count_s)
+    except (ValueError, AttributeError):
+        print(
+            f"error: --slice must be I/N (e.g. 1/4), got: {slice_raw!r}",
+            file=sys.stderr,
+        )
+        sys.exit(2)
+
+    if slice_count < 1:
+        print(
+            f"error: --slice count must be at least 1, got {slice_count}",
+            file=sys.stderr,
+        )
+        sys.exit(2)
+    if not (1 <= slice_index <= slice_count):
+        print(
+            f"error: --slice index must be 1..{slice_count}, got {slice_index}",
+            file=sys.stderr,
+        )
+        sys.exit(2)
+    return slice_index, slice_count
 
 
 def _count_tests(
@@ -551,13 +579,6 @@ def _slice_files(
     """
     if slice_count < 2:
         return files
-    if not (1 <= slice_index <= slice_count):
-        print(
-            f"error: --slice index must be 1..{slice_count}, got {slice_index}",
-            file=sys.stderr,
-        )
-        sys.exit(2)
-
     # Build (file, estimated_duration) pairs.
     default_dur = 2.0
     file_durs: List[Tuple[Path, float]] = []
@@ -666,13 +687,7 @@ def main() -> int:
     slice_index: int | None = None
     slice_count: int = 1
     if slice_raw:
-        try:
-            idx_s, count_s = slice_raw.split("/", 1)
-            slice_index = int(idx_s)
-            slice_count = int(count_s)
-        except (ValueError, AttributeError):
-            print(f"error: --slice must be I/N (e.g. 1/4), got: {slice_raw!r}", file=sys.stderr)
-            sys.exit(2)
+        slice_index, slice_count = _parse_slice_spec(slice_raw)
 
     repo_root = Path(__file__).resolve().parent.parent
 

--- a/tests/test_run_tests_parallel.py
+++ b/tests/test_run_tests_parallel.py
@@ -38,6 +38,54 @@ _HANDOFF_DIR = Path(os.environ.get("TMPDIR", "/tmp")) / "hermes-isolation-probe"
 _HANDOFF_DIR.mkdir(exist_ok=True)
 
 
+def test_invalid_slice_range_exits_before_discovery(tmp_path: Path) -> None:
+    repo_root = Path(__file__).resolve().parent.parent
+    runner = repo_root / "scripts" / "run_tests_parallel.py"
+    missing_root = tmp_path / "missing"
+
+    proc = subprocess.run(
+        [
+            sys.executable,
+            str(runner),
+            "--paths",
+            str(missing_root),
+            "--slice",
+            "999/2",
+        ],
+        cwd=repo_root,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        timeout=10,
+    )
+
+    assert proc.returncode == 2
+    assert "error: --slice index must be 1..2, got 999" in proc.stderr
+    assert "No test files discovered" not in proc.stderr
+
+
+def test_invalid_env_slice_range_exits_before_discovery(tmp_path: Path) -> None:
+    repo_root = Path(__file__).resolve().parent.parent
+    runner = repo_root / "scripts" / "run_tests_parallel.py"
+    missing_root = tmp_path / "missing"
+    env = os.environ.copy()
+    env["HERMES_TEST_SLICE"] = "2/1"
+
+    proc = subprocess.run(
+        [sys.executable, str(runner), "--paths", str(missing_root)],
+        cwd=repo_root,
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        timeout=10,
+    )
+
+    assert proc.returncode == 2
+    assert "error: --slice index must be 1..1, got 2" in proc.stderr
+    assert "No test files discovered" not in proc.stderr
+
+
 def _handoff_path_for(nonce: str) -> Path:
     return _HANDOFF_DIR / f"grandchild-{nonce}.json"
 


### PR DESCRIPTION
## Summary
- validate `--slice` / `HERMES_TEST_SLICE` ranges immediately after parsing
- reject invalid ranges such as `999/2` before discovery and pytest collection
- update the runner docstring to show the required `--` separator for pytest passthrough args and the current default worker count

## Why
The runner parsed malformed slice specs early, but range validation still lived inside `_slice_files()`. That meant obviously invalid values could spend time discovering and collecting tests before failing.

## Test plan
- `python -m pytest tests/test_run_tests_parallel.py -q`
- `uv run ruff check scripts/run_tests_parallel.py tests/test_run_tests_parallel.py`
- `python scripts/run_tests_parallel.py --paths tests/hermes_cli/test_coalesce_session_args.py -- -k stops --tb=short`

## Duplicate check
Searched open PRs for `run_tests_parallel slice invalid slice HERMES_TEST_SLICE pytest args passthrough`; no matching open PRs were found.