### PR TITLE
docs: document repo-record MCP workflow

### DIFF
--- a/website/docs/guides/use-mcp-with-hermes.md
+++ b/website/docs/guides/use-mcp-with-hermes.md
@@ -264,7 +264,58 @@ Review the project structure and identify where configuration lives.
 Check the local git state and summarize what changed recently.
 ```
 
-### Pattern 2: GitHub triage assistant
+### Pattern 2: repo-native work record with Open Scaffold
+
+Use [Open Scaffold](https://github.com/graphanov/open-scaffold) when you want Hermes to read a repository's durable AI-work record: mission, plans, evidence notes, handoff packets, and review/gate results. Hermes remains the agent; Open Scaffold remains the repo-local record.
+
+Add the server for one scaffolded repository:
+
+```bash
+hermes mcp add open_scaffold --command npx --args -y open-scaffold@latest mcp serve --repo /absolute/path/to/repo
+hermes mcp test open_scaffold
+```
+
+Then keep the exposed surface read-oriented. Choose `select` in the `hermes mcp add` prompt, or edit `config.yaml` afterward:
+
+```yaml
+mcp_servers:
+  open_scaffold:
+    command: "npx"
+    args: ["-y", "open-scaffold@latest", "mcp", "serve", "--repo", "/absolute/path/to/repo"]
+    tools:
+      include:
+        - list_plans
+        - get_plan
+        - get_mission
+        - list_evidence
+        - get_evidence
+        - get_status
+        - search_plans
+        - list_amendments
+        - get_handoff
+        - analyze_loop
+        - gate_loop
+      prompts: false
+```
+
+Good prompts:
+
+```text
+Use the Open Scaffold MCP tools to compile the current handoff packet and tell me the next legal action.
+```
+
+```text
+Inspect the active plans and evidence notes, then say whether this repo is ready for human review or needs another attempt.
+```
+
+Boundary notes:
+
+- Open Scaffold MCP is local-first and read-only by default.
+- Its write tools require the server to be started with `--allow-write`; do not enable that until you explicitly want Hermes to mutate `.osc` files.
+- Open Scaffold records and gates work; it does not authorize Hermes to merge, publish, deploy, or spawn runtimes.
+- Pin `open-scaffold@<version>` instead of `@latest` if you need reproducible tool schemas.
+
+### Pattern 3: GitHub triage assistant
 
 ```yaml
 mcp_servers:
@@ -289,7 +340,7 @@ List open issues about MCP, cluster them by theme, and draft a high-quality issu
 Search the repo for uses of _discover_and_register_server and explain how MCP tools are registered.
 ```
 
-### Pattern 3: internal API assistant
+### Pattern 4: internal API assistant
 
 ```yaml
 mcp_servers:


### PR DESCRIPTION
## Context

This is a small MCP documentation example, not a core Hermes integration.

Hermes already supports external MCP servers. Some MCP servers expose repo-local project state rather than an external SaaS/API. This PR documents that pattern with Open Scaffold as one concrete example because it exposes a local repository's work record over MCP: mission, plans, evidence notes, handoff packets, and review/gate outputs.

## Why this belongs in the Hermes MCP guide

The existing guide already explains local project assistants, GitHub triage, internal APIs, and documentation/knowledge servers. A repo-native work-record server is another useful MCP shape:

- Hermes remains the agent using MCP tools.
- The MCP server contributes structured read access to a repo's durable project record.
- Users can keep the tool surface read-oriented with `tools.include`.
- The pattern avoids adding a native Hermes tool or dependency.

## What this PR does

- Adds a "repo-native work record with Open Scaffold" pattern to `website/docs/guides/use-mcp-with-hermes.md`.
- Shows the exact `hermes mcp add` / `hermes mcp test` command shape.
- Recommends a read-oriented tool allowlist.
- Documents boundaries around write tools, `--allow-write`, runtime spawning, merge, publish, and deploy authority.

## What this PR does not do

- Does not add a dependency on Open Scaffold.
- Does not add a native Hermes tool.
- Does not add an MCP catalog entry or imply Nous endorsement of Open Scaffold.
- Does not claim Open Scaffold improves model intelligence or is universally useful.
- Does not make Open Scaffold part of Hermes' default workflow.

## Verification

- `npm view open-scaffold version --prefer-online` -> `0.32.1`
- `npx --yes open-scaffold@latest mcp serve --repo <local-scaffolded-repo> --validate` -> JSON validation output with `verify.ok: true`
- `HERMES_HOME=/tmp/hermes-os-mcp-doc-smoke hermes mcp add open_scaffold --command npx --args -y open-scaffold@latest mcp serve --repo <local-scaffolded-repo>` -> connected and discovered 15 tools
- `HERMES_HOME=/tmp/hermes-os-mcp-doc-smoke hermes mcp test open_scaffold` -> connected and discovered 15 tools
- `git diff --check`
- `npm run build` from `website/` -> succeeded; Docusaurus reported existing broken-link/anchor warnings unrelated to this page

Note: `npm run lint:diagrams` could not run locally after `npm ci` because `ascii-guard` was not installed in the website package environment (`sh: ascii-guard: command not found`).
