### PR TITLE
fix(tui-gateway): fall back to launch profile own terminal.cwd config

### DIFF
--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -1066,6 +1066,14 @@ def _completion_cwd(params: dict | None = None) -> str:
         # profile's config before falling back to the launch profile's env var.
         or _profile_configured_cwd(_profile_home(params.get("profile")))
         or os.environ.get("TERMINAL_CWD")
+        # Fall back to the LAUNCH profile's own config.yaml terminal.cwd.
+        # TERMINAL_CWD is normally bridged from config.yaml when cli.py is
+        # imported, but some entry points (e.g. `hermes dashboard`'s
+        # cmd_dashboard()) can reach this code without that bridge having
+        # run in this process, leaving the only remaining fallback as
+        # os.getcwd() -- which on a launchd-started process can resolve to
+        # "/" and break non-image file attachments (issue #48314).
+        or _profile_configured_cwd(Path(_hermes_home))
         or os.getcwd()
     )
     try:


### PR DESCRIPTION
## Problem

_completion_cwd() resolved a non-default profile terminal.cwd via _profile_configured_cwd(), but for the LAUNCH profile it relied solely on TERMINAL_CWD env var (bridged from config.yaml when cli.py is imported). Entry points reaching this code without that bridge having run (e.g. hermes dashboard cmd_dashboard()) fall through to os.getcwd(), which on launchd can resolve to / -- breaking non-image file attachments with [Errno 30] Read-only file system: /.hermes (issue #48314).

## Fix

Add _profile_configured_cwd(Path(_hermes_home)) fallback before os.getcwd(), so launch profile config.yaml terminal.cwd is read directly as last resort.

Fixes #48314