### PR TITLE
feat(tts): expose speed parameter in text_to_speech tool

### DIFF
--- a/scripts/release.py
+++ b/scripts/release.py
@@ -1569,6 +1569,7 @@ AUTHOR_MAP = {
     "bsmith@bramarstrategicservices.com": "bcsmith528",  # PR #20589 salvage (register_slack_action_handler plugin API)
     "sunsky.lau@gmail.com": "liuhao1024",  # PR #45494 salvage (claim session slot before auto-resume task; #45456)
     "andrewdmwalker@gmail.com": "capt-marbles",  # PR #38440 salvage (resolve xAI OAuth credentials across profiles; #43589)
+    "hubin-ll@foxmail.com": "LLQWQ",  # PR #48327 (expose TTS speed parameter)
 }
 
 

--- a/tests/tools/test_tts_speed.py
+++ b/tests/tools/test_tts_speed.py
@@ -238,3 +238,70 @@ class TestMinimaxTtsLegacyTextToSpeech:
         _, output = self._run({}, tmp_path, monkeypatch)
         with open(output, "rb") as f:
             assert f.read() == b"\x00\x01\x02\x03"
+
+
+# ---------------------------------------------------------------------------
+# Tool-level speed parameter (text_to_speech_tool speed injection)
+# ---------------------------------------------------------------------------
+
+class TestToolLevelSpeed:
+    """Verify that the speed parameter on text_to_speech_tool injects into config."""
+
+    def test_speed_injected_into_config(self, tmp_path, monkeypatch):
+        """When speed is passed to the tool, it overrides config speed."""
+        monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+        mock_response = MagicMock()
+        mock_client = MagicMock()
+        mock_client.audio.speech.create.return_value = mock_response
+        mock_cls = MagicMock(return_value=mock_client)
+
+        with patch("tools.tts_tool._import_openai_client", return_value=mock_cls), \
+             patch("tools.tts_tool._resolve_openai_audio_client_config",
+                   return_value=("test-key", None)), \
+             patch("tools.tts_tool._load_tts_config", return_value={"provider": "openai", "openai": {}}), \
+             patch("tools.tts_tool._get_provider", return_value="openai"), \
+             patch("tools.tts_tool._resolve_command_provider_config", return_value=None), \
+             patch("tools.tts_tool._resolve_max_text_length", return_value=4096), \
+             patch("tools.tts_tool._generate_openai_tts") as mock_gen, \
+             patch("gateway.session_context.get_session_env", return_value=""):
+            from tools.tts_tool import text_to_speech_tool
+            text_to_speech_tool("Hello", str(tmp_path / "out.mp3"), speed=0.7)
+
+        # Verify the tts_config passed to the generator has speed=0.7
+        call_args = mock_gen.call_args
+        config_passed = call_args[0][2]  # (text, output_path, tts_config)
+        assert config_passed["speed"] == 0.7
+
+    def test_speed_clamped_range(self, tmp_path, monkeypatch):
+        """Speed values outside 0.25-4.0 are clamped."""
+        monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+
+        with patch("tools.tts_tool._load_tts_config", return_value={"provider": "openai", "openai": {}}), \
+             patch("tools.tts_tool._get_provider", return_value="openai"), \
+             patch("tools.tts_tool._resolve_command_provider_config", return_value=None), \
+             patch("tools.tts_tool._resolve_max_text_length", return_value=4096), \
+             patch("tools.tts_tool._generate_openai_tts") as mock_gen, \
+             patch("gateway.session_context.get_session_env", return_value=""):
+            from tools.tts_tool import text_to_speech_tool
+            text_to_speech_tool("Hello", str(tmp_path / "out.mp3"), speed=10.0)
+
+        config_passed = mock_gen.call_args[0][2]
+        assert config_passed["speed"] == 4.0
+
+    def test_no_speed_preserves_config(self, tmp_path, monkeypatch):
+        """When speed is None, config is not mutated."""
+        monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+        original_config = {"provider": "openai", "openai": {}, "speed": 1.5}
+
+        with patch("tools.tts_tool._load_tts_config", return_value=original_config), \
+             patch("tools.tts_tool._get_provider", return_value="openai"), \
+             patch("tools.tts_tool._resolve_command_provider_config", return_value=None), \
+             patch("tools.tts_tool._resolve_max_text_length", return_value=4096), \
+             patch("tools.tts_tool._generate_openai_tts") as mock_gen, \
+             patch("gateway.session_context.get_session_env", return_value=""):
+            from tools.tts_tool import text_to_speech_tool
+            text_to_speech_tool("Hello", str(tmp_path / "out.mp3"), speed=None)
+
+        config_passed = mock_gen.call_args[0][2]
+        assert config_passed.get("speed") == 1.5  # original config preserved
+        assert original_config.get("speed") == 1.5  # original not mutated

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -2018,6 +2018,7 @@ def _generate_kittentts(text: str, output_path: str, tts_config: Dict[str, Any])
 def text_to_speech_tool(
     text: str,
     output_path: Optional[str] = None,
+    speed: Optional[float] = None,
 ) -> str:
     """
     Convert text to speech audio.
@@ -2032,6 +2033,7 @@ def text_to_speech_tool(
     Args:
         text: The text to convert to speech.
         output_path: Optional custom save path. Defaults to ~/voice-memos/<timestamp>.mp3
+        speed: Optional playback speed multiplier (0.25-4.0). Overrides config.yaml.
 
     Returns:
         str: JSON result with success, file_path, and optionally MEDIA tag.
@@ -2040,6 +2042,13 @@ def text_to_speech_tool(
         return tool_error("Text is required", success=False)
 
     tts_config = _load_tts_config()
+
+    # When the model supplies a speed parameter, inject it into the config
+    # so all downstream provider functions pick it up uniformly.
+    if speed is not None:
+        clamped = max(0.25, min(4.0, float(speed)))
+        tts_config = dict(tts_config)  # shallow copy to avoid mutating the cache
+        tts_config["speed"] = clamped
     provider = _get_provider(tts_config)
 
     # User-declared command provider (type: command under tts.providers.<name>)
@@ -2713,6 +2722,10 @@ TTS_SCHEMA = {
             "output_path": {
                 "type": "string",
                 "description": f"Optional custom file path to save the audio. Defaults to {display_hermes_home()}/audio_cache/<timestamp>.mp3"
+            },
+            "speed": {
+                "type": "number",
+                "description": "Playback speed multiplier. 1.0 = normal, 0.5 = very slow (language learning), 2.0 = fast. Range: 0.25-4.0. Overrides the speed configured in config.yaml."
             }
         },
         "required": ["text"]
@@ -2725,7 +2738,8 @@ registry.register(
     schema=TTS_SCHEMA,
     handler=lambda args, **kw: text_to_speech_tool(
         text=args.get("text", ""),
-        output_path=args.get("output_path")),
+        output_path=args.get("output_path"),
+        speed=args.get("speed")),
     check_fn=check_tts_requirements,
     emoji="🔊",
 )


### PR DESCRIPTION
## Summary

Adds an optional `speed` parameter (0.25-4.0) to the `text_to_speech` tool, enabling per-request playback speed control without config changes.

## Motivation

Currently, TTS speed can only be set via `tts.speed` or `tts.<provider>.speed` in config.yaml. This requires config edits and a restart to change speed. For use cases like **language learning** (slow pronunciation practice) or **accessibility**, per-request speed control is much more practical.

## Changes

### `tools/tts_tool.py`
- Added `speed` parameter to `TTS_SCHEMA` (type: number, range 0.25-4.0)
- Added `speed` parameter to `text_to_speech_tool()` function signature
- When speed is provided, it's clamped and injected into `tts_config` before dispatching to providers
- Updated handler lambda to pass the speed arg

### `tests/tools/test_tts_speed.py`
- Added `TestToolLevelSpeed` class with 3 tests:
  - `test_speed_injected_into_config` — speed=0.7 reaches the provider config
  - `test_speed_clamped_range` — speed=10.0 clamped to 4.0
  - `test_no_speed_preserves_config` — speed=None doesn't mutate original config

## Design Decisions

- **Config injection pattern**: Rather than threading speed through every provider function, the speed is injected into `tts_config["speed"]` at the tool level. All providers already read from this path (see existing tests), so no provider changes needed.
- **Shallow copy**: `tts_config` is shallow-copied before injection to avoid mutating the cached config.
- **Clamping at tool level**: Speed is clamped to [0.25, 4.0] before injection, matching the OpenAI provider's existing range.

## Testing

```
22 passed in 0.75s (19 existing + 3 new)
```
