### PR TITLE
fix: strip gateway timestamp/observed fields for Mistral models

### DIFF
--- a/agent/transports/chat_completions.py
+++ b/agent/transports/chat_completions.py
@@ -164,6 +164,8 @@ class ChatCompletionsTransport(ProviderTransport):
         strip_extra_content = not _model_consumes_thought_signature(
             kwargs.get("model")
         )
+        _model_lower = (kwargs.get("model") or "").lower()
+        strip_gateway_metadata = "mistral" in _model_lower
         needs_sanitize = False
         for msg in messages:
             if not isinstance(msg, dict):
@@ -172,6 +174,7 @@ class ChatCompletionsTransport(ProviderTransport):
                 "codex_reasoning_items" in msg
                 or "codex_message_items" in msg
                 or "tool_name" in msg
+                or (strip_gateway_metadata and ("timestamp" in msg or "observed" in msg))
             ):
                 needs_sanitize = True
                 break
@@ -201,6 +204,11 @@ class ChatCompletionsTransport(ProviderTransport):
             msg.pop("codex_reasoning_items", None)
             msg.pop("codex_message_items", None)
             msg.pop("tool_name", None)
+            # Mistral's strict Pydantic schema rejects gateway-injected
+            # metadata fields (timestamp, observed) as extra inputs.
+            if strip_gateway_metadata:
+                msg.pop("timestamp", None)
+                msg.pop("observed", None)
             # Drop all Hermes-internal scaffolding markers (``_``-prefixed).
             # OpenAI's message schema has no ``_``-prefixed fields, so this
             # is safe and future-proofs against new markers being added.


### PR DESCRIPTION
## Problem

`bd7fc8fdc` (`feat(gateway): inject stable human-readable message timestamps`) adds `timestamp` (epoch float) and `observed` fields directly into message dicts via `_apply_persist_user_message_override` in `run_agent.py`.

These fields are stored on the same dict that gets sent to the API. Mistral models use strict Pydantic validation and reject extra fields with:

```
HTTP 400: 1 validation error for UserMessage
timestamp — Extra inputs are not permitted [type=extra_forbidden, input_value=1781771079.0, input_type=float]
```

This breaks **all multi-turn conversations** after the first message — the second message always fails because the persisted first user message now carries `timestamp` in the API payload.

## Confirmed affected models

Tested directly via Nvidia NIM API:
- `mistralai/mistral-small-4-119b-2603` — rejects timestamp field (HTTP 400)
- `mistralai/mistral-nemotron` — rejects in production gateway logs
- `qwen/qwen3.5-397b-a17b`, `stepfun-ai/step-3.7-flash`, `deepseek-ai/deepseek-v4-flash` — permissive, unaffected

## Fix

In the existing `sanitize_messages` method in `chat_completions.py`, detect Mistral models and strip `timestamp`/`observed` before the API call. Two changes required:

1. **Detection** — add to `needs_sanitize` check (without this, a plain `{role, content, timestamp}` message bypasses sanitization entirely and returns early)
2. **Strip** — `msg.pop()` guarded by `strip_gateway_metadata` flag (Mistral-only)