### PR TITLE
fix(skills): split multi-line disabled-skill strings into individual names

### DIFF
--- a/agent/skill_utils.py
+++ b/agent/skill_utils.py
@@ -456,10 +456,40 @@ def get_disabled_skill_names(platform: str | None = None) -> Set[str]:
 
 
 def _normalize_string_set(values) -> Set[str]:
+    """Parse a disabled-skill config value into a set of skill names.
+
+    Handles three forms produced by different config paths:
+
+    * A YAML list (e.g. ``feishu: [airtable, architecture]``) — iterated
+      directly.
+    * A single skill name written as a scalar (``disabled: my-skill`` or
+      ``hermes config set skills.disabled my-skill``) — treated as one
+      element.
+    * A **multi-line string** produced when ``hermes config set`` writes a
+      list value into the YAML file (the tool serialises the whole list as a
+      YAML block scalar, e.g.
+      ``cli: "- airtable\\n- architecture\\n..."``).  These are split on
+      newlines and the leading ``- `` is stripped from each line, so
+      individual skill names are recognised instead of the whole block being
+      treated as one opaque entry.
+    """
     if values is None:
         return set()
     if isinstance(values, str):
-        values = [values]
+        # Multi-line block scalar from `hermes config set` → split by line
+        if "\n" in values:
+            items: list[str] = []
+            for line in values.split("\n"):
+                stripped = line.strip()
+                if stripped.startswith("- "):
+                    items.append(stripped[2:])
+                elif stripped.startswith("-"):
+                    items.append(stripped[1:])
+                elif stripped:
+                    items.append(stripped)
+            values = items
+        else:
+            values = [values]
     return {str(v).strip() for v in values if str(v).strip()}
 
 

--- a/agent/skill_utils.py
+++ b/agent/skill_utils.py
@@ -499,6 +499,31 @@ def parse_config_string_list(value) -> List[str]:
 
 
 def _normalize_string_set(values) -> Set[str]:
+    """Parse a disabled-skill config value into a set of skill names.
+
+    Handles the forms produced by different config paths:
+
+    * A YAML list (e.g. ``feishu: [airtable, architecture]``) — iterated
+      directly.
+    * A JSON-array string from ``hermes config set`` / JSON-mode editor
+      saves (``'["a","b"]'``) — parsed via ``parse_config_string_list``
+      (#86661).
+    * A **multi-line YAML block scalar** (e.g. ``"- airtable\\n- architecture"``)
+      — split on newlines, ``- `` prefix stripped from each line.
+    * A single skill name written as a scalar — treated as one element.
+    """
+    if isinstance(values, str) and "\n" in values:
+        # Multi-line block scalar from `hermes config set` → split by line
+        items: list[str] = []
+        for line in values.split("\n"):
+            stripped = line.strip()
+            if stripped.startswith("- "):
+                items.append(stripped[2:])
+            elif stripped.startswith("-"):
+                items.append(stripped[1:])
+            elif stripped:
+                items.append(stripped)
+        values = items
     return {name.strip() for name in parse_config_string_list(values) if name.strip()}
 
 

--- a/hermes_cli/skills_config.py
+++ b/hermes_cli/skills_config.py
@@ -30,11 +30,28 @@ def _normalize_skill_names(values) -> Set[str]:
     Mirrors ``agent.skill_utils._normalize_string_set``: ``None`` (YAML null)
     means empty, a bare scalar (``disabled: my-skill``) means a single-item
     list — NOT a set of its characters (#13026).
+
+    Also handles multi-line YAML block scalars produced by ``hermes config
+    set`` for list values (e.g. ``"- airtable\\n- architecture\\n..."``),
+    splitting on newlines and stripping ``- `` prefixes.
     """
     if values is None:
         return set()
     if isinstance(values, str):
-        values = [values]
+        # Multi-line block scalar from `hermes config set` → split by line
+        if "\n" in values:
+            items: list[str] = []
+            for line in values.split("\n"):
+                stripped = line.strip()
+                if stripped.startswith("- "):
+                    items.append(stripped[2:])
+                elif stripped.startswith("-"):
+                    items.append(stripped[1:])
+                elif stripped:
+                    items.append(stripped)
+            values = items
+        else:
+            values = [values]
     try:
         return {str(v).strip() for v in values if str(v).strip()}
     except TypeError:

--- a/tests/agent/test_skill_utils.py
+++ b/tests/agent/test_skill_utils.py
@@ -277,6 +277,49 @@ class TestParseFrontmatterBOM:
         assert fm["platforms"] == ["macos"]
 
 
+# ── _normalize_string_set — multiline block scalar (#48333) ────────────────
+
+
+class TestNormalizeStringSetMultiline:
+    """_normalize_string_set must handle YAML block scalars produced by
+    ``hermes config set`` that embed the whole list as a multi-line string
+    with ``\\n`` separators and ``- `` prefixes (e.g.
+    ``"- airtable\\n- architecture\\n- ascii-art"``)."""
+
+    def test_multiline_block_scalar(self):
+        from agent.skill_utils import _normalize_string_set
+        result = _normalize_string_set(
+            "- airtable\n- architecture\n- ascii-art"
+        )
+        assert result == {"airtable", "architecture", "ascii-art"}
+
+    def test_single_line_scalar_unchanged(self):
+        from agent.skill_utils import _normalize_string_set
+        assert _normalize_string_set("my-skill") == {"my-skill"}
+
+    def test_yaml_list_unchanged(self):
+        from agent.skill_utils import _normalize_string_set
+        assert _normalize_string_set(["a", "b"]) == {"a", "b"}
+
+    def test_none_is_empty(self):
+        from agent.skill_utils import _normalize_string_set
+        assert _normalize_string_set(None) == set()
+
+    def test_multiline_no_dash_prefix(self):
+        """Lines without ``- `` prefix are treated as bare names."""
+        from agent.skill_utils import _normalize_string_set
+        assert _normalize_string_set("airtable\narchitecture") == {
+            "airtable", "architecture"
+        }
+
+    def test_multiline_with_blank_lines(self):
+        from agent.skill_utils import _normalize_string_set
+        result = _normalize_string_set(
+            "- airtable\n\n- architecture\n\n\n"
+        )
+        assert result == {"airtable", "architecture"}
+
+
 class TestBOMToleranceSiblingSites:
     """The BOM fix must cover every independent frontmatter parser, not just
     the canonical ``parse_frontmatter`` — several modules reimplement the

--- a/tests/agent/test_skill_utils.py
+++ b/tests/agent/test_skill_utils.py
@@ -357,6 +357,49 @@ class TestParseFrontmatterBOM:
         assert fm["platforms"] == ["macos"]
 
 
+# ── _normalize_string_set — multiline block scalar (#48333) ────────────────
+
+
+class TestNormalizeStringSetMultiline:
+    """_normalize_string_set must handle YAML block scalars produced by
+    ``hermes config set`` that embed the whole list as a multi-line string
+    with ``\\n`` separators and ``- `` prefixes (e.g.
+    ``"- airtable\\n- architecture\\n- ascii-art"``)."""
+
+    def test_multiline_block_scalar(self):
+        from agent.skill_utils import _normalize_string_set
+        result = _normalize_string_set(
+            "- airtable\n- architecture\n- ascii-art"
+        )
+        assert result == {"airtable", "architecture", "ascii-art"}
+
+    def test_single_line_scalar_unchanged(self):
+        from agent.skill_utils import _normalize_string_set
+        assert _normalize_string_set("my-skill") == {"my-skill"}
+
+    def test_yaml_list_unchanged(self):
+        from agent.skill_utils import _normalize_string_set
+        assert _normalize_string_set(["a", "b"]) == {"a", "b"}
+
+    def test_none_is_empty(self):
+        from agent.skill_utils import _normalize_string_set
+        assert _normalize_string_set(None) == set()
+
+    def test_multiline_no_dash_prefix(self):
+        """Lines without ``- `` prefix are treated as bare names."""
+        from agent.skill_utils import _normalize_string_set
+        assert _normalize_string_set("airtable\narchitecture") == {
+            "airtable", "architecture"
+        }
+
+    def test_multiline_with_blank_lines(self):
+        from agent.skill_utils import _normalize_string_set
+        result = _normalize_string_set(
+            "- airtable\n\n- architecture\n\n\n"
+        )
+        assert result == {"airtable", "architecture"}
+
+
 class TestBOMToleranceSiblingSites:
     """The BOM fix must cover every independent frontmatter parser, not just
     the canonical ``parse_frontmatter`` — several modules reimplement the

--- a/tests/hermes_cli/test_skills_config.py
+++ b/tests/hermes_cli/test_skills_config.py
@@ -172,3 +172,47 @@ class TestGetCategories:
         from hermes_cli.skills_config import _get_categories
         skills = [{"name": "a", "category": None, "description": ""}]
         assert "uncategorized" in _get_categories(skills)
+
+
+# ---------------------------------------------------------------------------
+# _normalize_skill_names — multiline block scalar (#48333)
+# ---------------------------------------------------------------------------
+
+class TestNormalizeSkillNamesMultiline:
+    """_normalize_skill_names must handle YAML block scalars produced by
+    ``hermes config set`` that embed the whole list as a multi-line string
+    with ``\\n`` separators and ``- `` prefixes (e.g.
+    ``"- airtable\\n- architecture\\n- ascii-art"``)."""
+
+    def test_multiline_block_scalar(self):
+        from hermes_cli.skills_config import _normalize_skill_names
+        result = _normalize_skill_names(
+            "- airtable\n- architecture\n- ascii-art"
+        )
+        assert result == {"airtable", "architecture", "ascii-art"}
+
+    def test_single_line_scalar_unchanged(self):
+        from hermes_cli.skills_config import _normalize_skill_names
+        assert _normalize_skill_names("my-skill") == {"my-skill"}
+
+    def test_yaml_list_unchanged(self):
+        from hermes_cli.skills_config import _normalize_skill_names
+        assert _normalize_skill_names(["a", "b"]) == {"a", "b"}
+
+    def test_none_is_empty(self):
+        from hermes_cli.skills_config import _normalize_skill_names
+        assert _normalize_skill_names(None) == set()
+
+    def test_multiline_no_dash_prefix(self):
+        """Lines without ``- `` prefix are treated as bare names."""
+        from hermes_cli.skills_config import _normalize_skill_names
+        assert _normalize_skill_names("airtable\narchitecture") == {
+            "airtable", "architecture"
+        }
+
+    def test_multiline_with_blank_lines(self):
+        from hermes_cli.skills_config import _normalize_skill_names
+        result = _normalize_skill_names(
+            "- airtable\n\n- architecture\n\n\n"
+        )
+        assert result == {"airtable", "architecture"}


### PR DESCRIPTION
> 此问题由 AI（Hermes Agent）发现并定位，本文由 AI 生成并发布。  
> This issue was discovered and diagnosed by AI (Hermes Agent). This text was generated and published by AI.

---

## Problem

`_normalize_string_set` in `agent/skill_utils.py` (and its twin `_normalize_skill_names` in `hermes_cli/skills_config.py`) did not handle multi-line YAML block scalars. When a user runs `hermes config set skills.platform_disabled.cli` with a list of skills, the tool serialises the value as a YAML block scalar:

```yaml
cli: "- airtable\n- architecture\n- ascii-art\n..."
```

`yaml.safe_load` returns this as a single string; the normalizers wrapped it in `[values]`, producing a set with **one element** — the entire string. The disabled check `skill_name in disabled` never matched any individual skill name, so **all skills in the platform_disabled list leaked through into available_skills**.

## Fix

Both normalizers now split multi-line strings on newlines and strip the leading `- ` (or `-`) from each line. Single-line scalars and proper YAML lists are handled unchanged.

Rebased onto the current `origin/main` (2026-08-25): upstream has since refactored `_normalize_string_set` around `parse_config_string_list` (JSON-array strings from `hermes config set`, #86661). The rebased patch keeps that refactor and layers the multi-line block-scalar splitting on top of it, so both config-serialisation forms are handled. `_normalize_skill_names` in `hermes_cli/skills_config.py` received the same multi-line fix.

12 new test cases (6 per normalizer) covering block scalars, single scalars, YAML lists, None, dashless lines, and blank lines. All pass alongside the existing suite.

## Updates / 更新记录

- **2026-08-25**: rebase 到最新 origin/main；适配上游 parse_config_string_list 重构（#86661），多行 block scalar 拆分叠加其上；冲突解决完成（mergeable）
