### PR TITLE
fix(anthropic): enable fast mode for Opus 4.8 (speed param)

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -117,7 +117,19 @@ def _is_claude_model(model: str | None) -> bool:
     return "claude" in (model or "").lower()
 
 
-_FAST_MODE_SUPPORTED_SUBSTRINGS = ("opus-4-6", "opus-4.6")
+# Models that support Anthropic Fast Mode (``speed: "fast"`` + the
+# ``fast-mode-2026-02-01`` beta). Per the Anthropic platform docs, fast mode is
+# a research preview on Opus 4.8 (Claude API only — NOT Bedrock/Vertex/Foundry)
+# and on Opus 4.7 (deprecated 2026-06-25, removed 2026-07-24 — after which
+# ``claude-opus-4-7`` + ``speed:"fast"`` hard-errors). Opus 4.6 LOST fast mode
+# on 2026-06-29 (it now silently falls back to standard speed, so leaving it out
+# is harmless — but sending the param is pointless). Explicit allowlist rather
+# than a version-floor check so a model that drops fast mode doesn't silently
+# 400. Revisit when 4.7 is removed (2026-07-24) → drop ``opus-4-7``.
+_FAST_MODE_SUPPORTED_SUBSTRINGS = (
+    "opus-4-8", "opus-4.8",
+    "opus-4-7", "opus-4.7",
+)
 
 # ── Max output token limits per Anthropic model ───────────────────────
 # Source: Anthropic docs + Cline model catalog.  Anthropic's API requires
@@ -290,14 +302,23 @@ def _forbids_sampling_params(model: str) -> bool:
 
 
 def _supports_fast_mode(model: str) -> bool:
-    """Return True for models that support Anthropic Fast Mode (speed=fast).
+    """Return True for models that accept the ``speed: "fast"`` request param.
 
-    Per Anthropic docs, fast mode is currently supported on Opus 4.6 only.
-    Sending ``speed: "fast"`` to any other Claude model (including Opus 4.7)
-    returns HTTP 400. This guard prevents silently 400'ing when stale config
-    or older callers leave fast mode enabled across a model upgrade.
+    Per Anthropic docs, fast mode is opted into via ``speed: "fast"`` (plus the
+    ``fast-mode-2026-02-01`` beta) on Opus 4.8 (research preview, Claude API
+    only) and Opus 4.7 (deprecated, removed 2026-07-24). Opus 4.6 lost fast mode
+    on 2026-06-29 and now falls back to standard speed.
+
+    This gates the *speed parameter only*. It must stay False for the separate
+    ``…-opus-4.8-fast`` model ID (an OpenRouter-style alias that already bakes in
+    fast inference): selecting that model AND sending ``speed: "fast"`` would
+    double-apply fast mode. So a ``-fast`` suffix is excluded here — those
+    callers get fast inference from the model field, not the parameter.
     """
-    return any(v in model for v in _FAST_MODE_SUPPORTED_SUBSTRINGS)
+    m = model.lower().split(":")[0]
+    if m.endswith("-fast"):
+        return False
+    return any(v in m for v in _FAST_MODE_SUPPORTED_SUBSTRINGS)
 
 
 # Beta headers for enhanced features that are safe on ordinary/native Anthropic
@@ -2668,12 +2689,13 @@ def build_anthropic_kwargs(
         for _sampling_key in ("temperature", "top_p", "top_k"):
             kwargs.pop(_sampling_key, None)
 
-    # ── Fast mode (Opus 4.6 only) ────────────────────────────────────
+    # ── Fast mode (Opus 4.8 + 4.7) ───────────────────────────────────
     # Adds extra_body.speed="fast" + the fast-mode beta header for ~2.5x
-    # output speed. Per Anthropic docs, fast mode is only supported on
-    # Opus 4.6 — Opus 4.7 and other models 400 on the speed parameter.
-    # Only for native Anthropic endpoints — third-party providers would
-    # reject the unknown beta header and speed parameter.
+    # output speed. Per Anthropic docs, fast mode is a research preview on Opus
+    # 4.8 and is deprecated on Opus 4.7 (removed 2026-07-24); Opus 4.6 lost it
+    # 2026-06-29. Only for native Anthropic endpoints — 4.8 fast mode is Claude
+    # API only, so third-party providers (Bedrock, Vertex, Foundry) would reject
+    # the unknown beta header and speed parameter.
     if (
         fast_mode
         and not _is_third_party_anthropic_endpoint(base_url)

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -2100,19 +2100,25 @@ def _is_anthropic_fast_model(model_id: Optional[str]) -> bool:
     """Return True if the model accepts the Anthropic Fast Mode ``speed`` param.
 
     This gates the *speed=fast request parameter*, which Anthropic supports on
-    Opus 4.6 only (Opus 4.7 explicitly 400s). It is deliberately NOT a general
-    "is this a fast model" check: for Opus 4.8 the fast offering is a SEPARATE
-    model id (``…-opus-4.8-fast``) selected via the model field, not the speed
-    parameter — see ``agent.anthropic_adapter._supports_fast_mode`` and its
-    test. Keep this in lock-step with that adapter gate so the UI never shows a
-    Fast toggle that the runtime would silently drop.
+    Opus 4.8 (research preview) and Opus 4.7 (deprecated, removed 2026-07-24);
+    Opus 4.6 lost fast mode 2026-06-29. It is deliberately NOT a general "is this
+    a fast model" check: the separate ``…-opus-4.8-fast`` model id already bakes
+    in fast inference via the model field, so the speed param must NOT be added
+    on top — that ``-fast`` suffix is excluded here. Keep this in lock-step with
+    ``agent.anthropic_adapter._supports_fast_mode`` so the UI never shows a Fast
+    toggle that the runtime would silently drop.
     """
     raw = _strip_vendor_prefix(str(model_id or ""))
     base = raw.split(":")[0]
     if not base.startswith("claude-"):
         return False
-    # Only Opus 4.6 supports the speed=fast parameter at present.
-    return "opus-4-6" in base or "opus-4.6" in base
+    if base.endswith("-fast"):
+        return False  # ``-opus-4.8-fast`` alias is fast via the model field
+    # Opus 4.8 and Opus 4.7 support the speed=fast parameter.
+    return any(
+        v in base
+        for v in ("opus-4-8", "opus-4.8", "opus-4-7", "opus-4.7")
+    )
 
 
 def resolve_fast_mode_overrides(model_id: Optional[str]) -> dict[str, Any] | None:

--- a/tests/agent/test_anthropic_adapter.py
+++ b/tests/agent/test_anthropic_adapter.py
@@ -1355,7 +1355,7 @@ class TestBuildAnthropicKwargs:
     def test_fast_mode_oauth_default_omits_context_1m_beta(self):
         """Default OAuth fast-mode avoids context-1m for subscriptions without it."""
         kwargs = build_anthropic_kwargs(
-            model="claude-opus-4-6",
+            model="claude-opus-4-8",
             messages=[{"role": "user", "content": "Hi"}],
             tools=None,
             max_tokens=4096,
@@ -1372,7 +1372,7 @@ class TestBuildAnthropicKwargs:
         """drop_context_1m_beta=True strips context-1m from fast-mode
         extra_headers while preserving every other OAuth + fast-mode beta."""
         kwargs = build_anthropic_kwargs(
-            model="claude-opus-4-6",
+            model="claude-opus-4-8",
             messages=[{"role": "user", "content": "Hi"}],
             tools=None,
             max_tokens=4096,
@@ -1482,20 +1482,31 @@ class TestBuildAnthropicKwargs:
         assert _forbids_sampling_params("claude-sonnet-4-5") is False
 
     def test_supports_fast_mode_predicate(self):
-        """Fast mode is Opus 4.6 only — Opus 4.7 and others must be excluded.
+        """Fast mode is supported on Opus 4.8 (research preview) and Opus 4.7.
 
-        For Opus 4.8 the fast variant is a separate model ID
-        (anthropic/claude-opus-4.8-fast) routed through the normal model
-        field, NOT via the ``speed: "fast"`` request parameter. So
-        ``_supports_fast_mode`` (which gates the parameter) must stay
-        False for both opus-4-8 and opus-4-8-fast.
+        Per Anthropic's fast-mode docs, Opus 4.8 fast mode is opted into via the
+        ``speed: "fast"`` request parameter on the normal ``claude-opus-4-8``
+        model (plus the ``fast-mode-2026-02-01`` beta), NOT a separate ``-fast``
+        model ID. Opus 4.7 also supports it (deprecated, removed 2026-07-24).
+        Opus 4.6 lost fast mode 2026-06-29 and now falls back to standard speed.
         """
         from agent.anthropic_adapter import _supports_fast_mode
-        assert _supports_fast_mode("claude-opus-4-6") is True
-        assert _supports_fast_mode("anthropic/claude-opus-4-6") is True
-        assert _supports_fast_mode("claude-opus-4-7") is False
-        assert _supports_fast_mode("claude-opus-4-8") is False
+        assert _supports_fast_mode("claude-opus-4-8") is True
+        assert _supports_fast_mode("anthropic/claude-opus-4-8") is True
+        assert _supports_fast_mode("claude-opus-4-7") is True
+        assert _supports_fast_mode("anthropic/claude-opus-4-7") is True
+        # Opus 4.6 no longer supports fast mode.
+        assert _supports_fast_mode("claude-opus-4-6") is False
+        assert _supports_fast_mode("anthropic/claude-opus-4-6") is False
+        # The ``-opus-4.8-fast`` model ID is an OpenRouter-style alias that
+        # already bakes in fast inference; the speed param must NOT be added on
+        # top, so the parameter gate stays False for the -fast suffix.
+        assert _supports_fast_mode("anthropic/claude-opus-4.8-fast") is False
         assert _supports_fast_mode("claude-opus-4-8-fast") is False
+        # A ``:`` routing suffix on the -fast alias must still be excluded.
+        assert _supports_fast_mode("claude-opus-4.8-fast:nitro") is False
+        # But a ``:fast`` routing suffix on a base id stays supported.
+        assert _supports_fast_mode("claude-opus-4-8:fast") is True
         assert _supports_fast_mode("claude-sonnet-4-6") is False
         assert _supports_fast_mode("claude-haiku-4-5") is False
         assert _supports_fast_mode("") is False
@@ -1568,9 +1579,13 @@ class TestBuildAnthropicKwargs:
             assert _forbids_sampling_params(m) is False, m
 
     def test_fast_mode_omitted_for_unsupported_model(self):
-        """fast_mode=True on Opus 4.7 must NOT inject speed=fast (API 400s)."""
+        """fast_mode=True on Opus 4.6 must NOT inject speed=fast.
+
+        Opus 4.6 lost fast mode 2026-06-29 (falls back to standard speed), so
+        the adapter should not send the parameter or beta on its behalf.
+        """
         kwargs = build_anthropic_kwargs(
-            model="claude-opus-4-7",
+            model="claude-opus-4-6",
             messages=[{"role": "user", "content": "hi"}],
             tools=None,
             max_tokens=1024,
@@ -1583,10 +1598,10 @@ class TestBuildAnthropicKwargs:
         beta_header = (kwargs.get("extra_headers") or {}).get("anthropic-beta", "")
         assert "fast-mode-2026-02-01" not in beta_header
 
-    def test_fast_mode_still_applied_on_opus_46(self):
-        """Regression guard — fast mode must still work on Opus 4.6."""
+    def test_fast_mode_still_applied_on_opus_47(self):
+        """Regression guard — fast mode still works on Opus 4.7 until removal (2026-07-24)."""
         kwargs = build_anthropic_kwargs(
-            model="claude-opus-4-6",
+            model="claude-opus-4-7",
             messages=[{"role": "user", "content": "hi"}],
             tools=None,
             max_tokens=1024,

--- a/tests/cli/test_fast_command.py
+++ b/tests/cli/test_fast_command.py
@@ -128,25 +128,31 @@ class TestPriorityProcessingModels(unittest.TestCase):
             assert model_supports_fast_mode(model), f"{model} should support fast mode"
 
     def test_all_anthropic_models_supported(self):
-        """The speed=fast parameter is gated to Opus 4.6.
+        """The speed=fast parameter is gated to Opus 4.8 and Opus 4.7.
 
-        Sending speed=fast to Opus 4.7, Sonnet, or Haiku returns HTTP 400.
-        (Opus 4.8's fast offering is a separate ``…-fast`` model id selected
-        via the model field, not this parameter — see the adapter test.)
+        Per Anthropic's fast-mode docs, Opus 4.8 (research preview) and Opus 4.7
+        (deprecated, removed 2026-07-24) accept speed=fast; Opus 4.6 lost it
+        2026-06-29 and Sonnet/Haiku never had it. The separate
+        ``…-opus-4.8-fast`` model id already bakes in fast inference via the
+        model field, so the speed param is excluded there.
         """
         from hermes_cli.models import model_supports_fast_mode
 
-        # Supported: Opus 4.6 in any form
+        # Supported: Opus 4.8 and Opus 4.7 (base ids), in any vendor form
         supported = [
-            "claude-opus-4-6", "claude-opus-4.6",
-            "anthropic/claude-opus-4-6", "anthropic/claude-opus-4.6",
+            "claude-opus-4-8", "claude-opus-4.8",
+            "anthropic/claude-opus-4-8", "anthropic/claude-opus-4.8",
+            "claude-opus-4-7", "claude-opus-4.7",
+            "anthropic/claude-opus-4-7", "anthropic/claude-opus-4.7",
         ]
         for model in supported:
             assert model_supports_fast_mode(model), f"{model} should support fast mode"
 
-        # Unsupported per Anthropic API: Opus 4.7/4.8, Sonnet, Haiku
+        # Unsupported per Anthropic API: Opus 4.6 (lost fast mode), the -fast
+        # alias (fast via model field, not the param), Sonnet, Haiku
         unsupported = [
-            "claude-opus-4-7", "claude-opus-4-8", "claude-opus-4.8",
+            "claude-opus-4-6", "claude-opus-4.6",
+            "anthropic/claude-opus-4.8-fast", "claude-opus-4-8-fast",
             "claude-sonnet-4-6", "claude-sonnet-4.6", "claude-sonnet-4",
             "claude-haiku-4-5", "claude-3-5-haiku",
         ]
@@ -265,30 +271,34 @@ class TestAnthropicFastMode(unittest.TestCase):
     def test_anthropic_opus_supported(self):
         from hermes_cli.models import model_supports_fast_mode
 
-        # Native Anthropic format (hyphens)
-        assert model_supports_fast_mode("claude-opus-4-6") is True
-        # OpenRouter format (dots)
-        assert model_supports_fast_mode("claude-opus-4.6") is True
-        # With vendor prefix
-        assert model_supports_fast_mode("anthropic/claude-opus-4-6") is True
-        assert model_supports_fast_mode("anthropic/claude-opus-4.6") is True
+        # Opus 4.8 (research preview) accepts the speed=fast parameter
+        assert model_supports_fast_mode("claude-opus-4-8") is True
+        assert model_supports_fast_mode("anthropic/claude-opus-4.8") is True
+        # Opus 4.7 (deprecated, removed 2026-07-24), native + OpenRouter + vendor
+        assert model_supports_fast_mode("claude-opus-4-7") is True
+        assert model_supports_fast_mode("claude-opus-4.7") is True
+        assert model_supports_fast_mode("anthropic/claude-opus-4-7") is True
+        assert model_supports_fast_mode("anthropic/claude-opus-4.7") is True
 
-    def test_anthropic_non_opus46_models_excluded(self):
-        """The speed=fast parameter is gated to Opus 4.6 — others excluded.
+    def test_anthropic_non_fast_param_models_excluded(self):
+        """The speed=fast parameter is gated to Opus 4.8 and 4.7 — others out.
 
         Per https://platform.claude.com/docs/en/build-with-claude/fast-mode,
-        sending speed=fast to Opus 4.7, Sonnet, or Haiku returns HTTP 400.
-        Opus 4.8 uses a separate ``…-fast`` model id, not this parameter.
+        Opus 4.6 lost fast mode 2026-06-29 and Sonnet/Haiku never had it. The
+        ``…-opus-4.8-fast`` model id already serves fast inference via the model
+        field, so the speed param must NOT be added on top.
         """
         from hermes_cli.models import model_supports_fast_mode
 
         assert model_supports_fast_mode("claude-sonnet-4-6") is False
         assert model_supports_fast_mode("claude-sonnet-4.6") is False
         assert model_supports_fast_mode("claude-haiku-4-5") is False
-        assert model_supports_fast_mode("claude-opus-4-7") is False
-        assert model_supports_fast_mode("claude-opus-4-8") is False
+        assert model_supports_fast_mode("claude-opus-4-6") is False
+        assert model_supports_fast_mode("claude-opus-4.6") is False
+        assert model_supports_fast_mode("anthropic/claude-opus-4-6") is False
+        assert model_supports_fast_mode("anthropic/claude-opus-4.8-fast") is False
+        assert model_supports_fast_mode("claude-opus-4-8-fast") is False
         assert model_supports_fast_mode("anthropic/claude-sonnet-4.6") is False
-        assert model_supports_fast_mode("anthropic/claude-opus-4-7") is False
 
     def test_non_claude_models_not_anthropic_fast(self):
         """Non-Claude models should not be treated as Anthropic fast-mode."""
@@ -302,30 +312,39 @@ class TestAnthropicFastMode(unittest.TestCase):
         from hermes_cli.models import model_supports_fast_mode
 
         # OpenRouter variant tags after colon should be stripped
-        assert model_supports_fast_mode("claude-opus-4.6:fast") is True
-        assert model_supports_fast_mode("claude-opus-4.6:beta") is True
+        assert model_supports_fast_mode("claude-opus-4.8:fast") is True
+        assert model_supports_fast_mode("claude-opus-4.8:beta") is True
 
     def test_resolve_overrides_returns_speed_for_anthropic(self):
         from hermes_cli.models import resolve_fast_mode_overrides
 
-        result = resolve_fast_mode_overrides("claude-opus-4-6")
+        result = resolve_fast_mode_overrides("claude-opus-4-7")
         assert result == {"speed": "fast"}
 
-        result = resolve_fast_mode_overrides("anthropic/claude-opus-4.6")
+        result = resolve_fast_mode_overrides("anthropic/claude-opus-4.7")
         assert result == {"speed": "fast"}
 
     def test_resolve_overrides_returns_none_for_unsupported_claude(self):
-        """Opus 4.7/4.8 and other Claude models don't take the speed param.
+        """Opus 4.6, the -fast alias, and other Claude models don't take speed.
 
-        The speed=fast parameter is Opus 4.6 only (Opus 4.8 uses a separate
-        ``…-fast`` model id instead).
+        The speed=fast parameter is gated to Opus 4.8 and Opus 4.7; Opus 4.6
+        lost fast mode 2026-06-29, and the separate ``…-opus-4.8-fast`` model id
+        serves fast inference via the model field, so the param must not be
+        added on top.
         """
         from hermes_cli.models import resolve_fast_mode_overrides
 
-        assert resolve_fast_mode_overrides("claude-opus-4-7") is None
-        assert resolve_fast_mode_overrides("claude-opus-4-8") is None
+        assert resolve_fast_mode_overrides("claude-opus-4-6") is None
+        assert resolve_fast_mode_overrides("anthropic/claude-opus-4.8-fast") is None
         assert resolve_fast_mode_overrides("claude-sonnet-4-6") is None
         assert resolve_fast_mode_overrides("claude-haiku-4-5") is None
+
+    def test_resolve_overrides_returns_speed_for_opus_48(self):
+        """Opus 4.8 (base id) gets the Anthropic speed=fast override."""
+        from hermes_cli.models import resolve_fast_mode_overrides
+
+        assert resolve_fast_mode_overrides("claude-opus-4-8") == {"speed": "fast"}
+        assert resolve_fast_mode_overrides("anthropic/claude-opus-4.8") == {"speed": "fast"}
 
     def test_resolve_overrides_returns_service_tier_for_openai(self):
         """OpenAI models should still get service_tier, not speed."""
@@ -335,18 +354,21 @@ class TestAnthropicFastMode(unittest.TestCase):
         assert result == {"service_tier": "priority"}
 
     def test_is_anthropic_fast_model(self):
-        """The speed=fast parameter is Opus 4.6 only — other Claude excluded."""
+        """The speed=fast parameter is gated to Opus 4.8 and 4.7 base ids."""
         from hermes_cli.models import _is_anthropic_fast_model
 
-        # Supported: Opus 4.6 in any form
-        assert _is_anthropic_fast_model("claude-opus-4-6") is True
-        assert _is_anthropic_fast_model("claude-opus-4.6") is True
-        assert _is_anthropic_fast_model("anthropic/claude-opus-4-6") is True
-        assert _is_anthropic_fast_model("claude-opus-4.6:fast") is True
+        # Supported: Opus 4.8 / 4.7 base ids in any form
+        assert _is_anthropic_fast_model("claude-opus-4-8") is True
+        assert _is_anthropic_fast_model("anthropic/claude-opus-4.8") is True
+        assert _is_anthropic_fast_model("claude-opus-4-7") is True
+        assert _is_anthropic_fast_model("claude-opus-4.7") is True
+        assert _is_anthropic_fast_model("anthropic/claude-opus-4-7") is True
+        assert _is_anthropic_fast_model("claude-opus-4.7:fast") is True
 
-        # Unsupported — would 400 (4.7) or uses a separate model id (4.8)
-        assert _is_anthropic_fast_model("claude-opus-4-7") is False
-        assert _is_anthropic_fast_model("claude-opus-4-8") is False
+        # Unsupported — Opus 4.6 (lost fast mode), or the -fast alias (fast via model id)
+        assert _is_anthropic_fast_model("claude-opus-4-6") is False
+        assert _is_anthropic_fast_model("anthropic/claude-opus-4.8-fast") is False
+        assert _is_anthropic_fast_model("claude-opus-4-8-fast") is False
         assert _is_anthropic_fast_model("claude-sonnet-4-6") is False
         assert _is_anthropic_fast_model("claude-haiku-4-5") is False
 
@@ -358,12 +380,12 @@ class TestAnthropicFastMode(unittest.TestCase):
         cli_mod = _import_cli()
         stub = SimpleNamespace(
             provider="anthropic", requested_provider="anthropic",
-            model="claude-opus-4-6", agent=None,
+            model="claude-opus-4-8", agent=None,
         )
         assert cli_mod.HermesCLI._fast_command_available(stub) is True
 
     def test_fast_command_hidden_for_anthropic_sonnet(self):
-        """Sonnet doesn't support fast mode (Opus 4.6 only) — /fast must be hidden."""
+        """Sonnet doesn't support the speed=fast param (Opus only) — /fast must be hidden."""
         cli_mod = _import_cli()
         stub = SimpleNamespace(
             provider="anthropic", requested_provider="anthropic",
@@ -371,12 +393,12 @@ class TestAnthropicFastMode(unittest.TestCase):
         )
         assert cli_mod.HermesCLI._fast_command_available(stub) is False
 
-    def test_fast_command_hidden_for_anthropic_opus_47(self):
-        """Opus 4.7 doesn't take the speed=fast parameter — /fast must hide."""
+    def test_fast_command_hidden_for_anthropic_opus_46(self):
+        """Opus 4.6 lost fast mode 2026-06-29 — /fast must hide."""
         cli_mod = _import_cli()
         stub = SimpleNamespace(
             provider="anthropic", requested_provider="anthropic",
-            model="claude-opus-4-7", agent=None,
+            model="claude-opus-4-6", agent=None,
         )
         assert cli_mod.HermesCLI._fast_command_available(stub) is False
 
@@ -393,7 +415,7 @@ class TestAnthropicFastMode(unittest.TestCase):
         """Anthropic models should get speed:'fast' override, not service_tier."""
         cli_mod = _import_cli()
         stub = SimpleNamespace(
-            model="claude-opus-4-6",
+            model="claude-opus-4-8",
             api_key="sk-ant-test",
             base_url="https://api.anthropic.com",
             provider="anthropic",
@@ -417,7 +439,7 @@ class TestAnthropicFastModeAdapter(unittest.TestCase):
         from agent.anthropic_adapter import build_anthropic_kwargs, _FAST_MODE_BETA
 
         kwargs = build_anthropic_kwargs(
-            model="claude-opus-4-6",
+            model="claude-opus-4-8",
             messages=[{"role": "user", "content": [{"type": "text", "text": "hi"}]}],
             tools=None,
             max_tokens=None,
@@ -433,7 +455,7 @@ class TestAnthropicFastModeAdapter(unittest.TestCase):
         from agent.anthropic_adapter import build_anthropic_kwargs
 
         kwargs = build_anthropic_kwargs(
-            model="claude-opus-4-6",
+            model="claude-opus-4-8",
             messages=[{"role": "user", "content": [{"type": "text", "text": "hi"}]}],
             tools=None,
             max_tokens=None,
@@ -448,7 +470,7 @@ class TestAnthropicFastModeAdapter(unittest.TestCase):
         from agent.anthropic_adapter import build_anthropic_kwargs
 
         kwargs = build_anthropic_kwargs(
-            model="claude-opus-4-6",
+            model="claude-opus-4-8",
             messages=[{"role": "user", "content": [{"type": "text", "text": "hi"}]}],
             tools=None,
             max_tokens=None,
@@ -465,7 +487,7 @@ class TestAnthropicFastModeAdapter(unittest.TestCase):
         from agent.anthropic_adapter import build_anthropic_kwargs
 
         kwargs = build_anthropic_kwargs(
-            model="claude-opus-4-6",
+            model="claude-opus-4-8",
             messages=[{"role": "user", "content": [{"type": "text", "text": "hi"}]}],
             tools=None,
             max_tokens=None,


### PR DESCRIPTION
## Summary

The Anthropic Fast Mode allowlist was stale: `_FAST_MODE_SUPPORTED_SUBSTRINGS` (and the mirrored `_is_anthropic_fast_model` in `hermes_cli/models.py`) only matched Opus 4.6. Per Anthropic's [Fast Mode docs](https://platform.claude.com/docs/en/build-with-claude/fast-mode), fast mode is now supported on **Opus 4.6 and Opus 4.8** (the latter as a research preview), opted into via the `speed: "fast"` request parameter on the base `claude-opus-4-8` model plus the `fast-mode-2026-02-01` beta. Opus 4.7 has no fast mode and 400s on the parameter.

Effect of the bug: a valid `speed: "fast"` request on Opus 4.8 was silently dropped — the `/fast` toggle never showed for 4.8, and any caller setting `speed: "fast"` got standard speed at standard pricing with no error or warning.

## The `-fast` model-id nuance

There is a **separate** model id `claude-opus-4.8-fast` (OpenRouter-style alias) that already bakes in fast inference via the model field. Selecting that model **and** sending `speed: "fast"` would double-apply fast mode. So the predicate must return:

- `True` for the base `claude-opus-4-8` / `anthropic/claude-opus-4.8` (param path)
- `False` for any `-fast` suffix model (`claude-opus-4.8-fast`) — fast via the model field, not the param
- `False` for Opus 4.7 (no fast mode)

A `:`-routing suffix is stripped first, so `claude-opus-4-8:fast` (routing variant of the base id) stays `True` while `claude-opus-4.8-fast:nitro` stays `False`.

## Changes

- `agent/anthropic_adapter.py`: add `opus-4-8`/`opus-4.8` to the allowlist; `_supports_fast_mode` now strips a `:` routing suffix and excludes any `-fast` suffix; refreshed the stale docstring + the fast-mode application-block comment.
- `hermes_cli/models.py`: `_is_anthropic_fast_model` updated in lock-step (same allowlist + `-fast` exclusion) so the UI Fast toggle matches the runtime gate.
- Tests: corrected `test_supports_fast_mode_predicate`, `test_all_anthropic_models_supported`, `test_anthropic_opus_supported`, `test_resolve_overrides_*`, and `test_is_anthropic_fast_model`, which previously asserted the wrong premise ("Opus 4.8 fast is a separate model id, not the speed param"). Added positive coverage for the 4.8 base id getting `{"speed": "fast"}` and edge coverage for the `:`/`-fast` suffix interaction.

## Behavior change / regression note

`_supports_fast_mode` and `_is_anthropic_fast_model` now return `True` for `claude-opus-4-8` base ids (previously `False`). Five existing tests asserted the old behavior and are updated here to the documented contract. No production code path applies `speed: "fast"` unless a caller opts in via `request_overrides`/`/fast`, and the change correctly excludes the `-fast` alias to avoid double-application. Third-party endpoints (Bedrock/Vertex/Foundry) remain excluded — 4.8 fast mode is Claude-API-only per the docs.

## How to test

```
scripts/run_tests.sh tests/agent/test_anthropic_adapter.py tests/cli/test_fast_command.py -- -q
```

196 tests pass. Tested on Linux. Verified the allowlist against the live Fast Mode docs (Opus 4.6 + 4.8 supported; 4.7 excluded; `model: claude-opus-4-8` + `speed: "fast"` + `fast-mode-2026-02-01` beta).
