### PR TITLE
fix(gateway): prevent stale session lock from orphaned guard swap (#48300)

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -3983,8 +3983,22 @@ class BasePlatformAdapter(ABC):
                 # same session.
                 current_task = asyncio.current_task()
                 if current_task is not None and self._session_tasks.get(session_key) is current_task:
-                    del self._session_tasks[session_key]
-                    self._release_session_guard(session_key, guard=interrupt_event)
+                    # Only clean up _session_tasks if we can also release the
+                    # guard.  When a concurrent command swapped the guard
+                    # (_active_sessions[key] is now a different Event), the
+                    # guard-match in _release_session_guard fails and the
+                    # entry survives — but _session_tasks was already deleted
+                    # below the old code, leaving _active_sessions[key]
+                    # orphaned with no detectable owner.  Keeping the
+                    # _session_tasks entry lets _session_task_is_stale()
+                    # identify the done task on the next handle_message()
+                    # entry and heal the split-brain automatically.
+                    current_guard = self._active_sessions.get(session_key)
+                    if current_guard is None or (interrupt_event is not None and current_guard is interrupt_event):
+                        del self._session_tasks[session_key]
+                        self._release_session_guard(session_key, guard=interrupt_event)
+                    # else: guard was swapped — leave _session_tasks so the
+                    # done task is visible to _session_task_is_stale().
     
     async def cancel_background_tasks(self) -> None:
         """Cancel any in-flight background message-processing tasks.


### PR DESCRIPTION
Fixes #48300. When a concurrent command swaps the active-session guard, the old task's finally block deleted _session_tasks before calling _release_session_guard. If the guard had already been swapped, the guard-match failed, leaving an orphaned _active_sessions entry with no detectable owner — a permanent deadlock. Now the finally block only deletes _session_tasks when the guard can also be released; if the guard was swapped, the done task remains so _session_task_is_stale() detects it and _heal_stale_session_lock() clears the split-brain on next entry.