### PR TITLE
fix(model-switch): prevent custom provider misattribution in TUI model picker

### DIFF
--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -879,10 +879,12 @@ def switch_model(
                                 resolved_in_current_catalog = True
                                 break
 
-        # --- Step e: detect_provider_for_model() as last resort ---
+        # --- Step e: detect_provider_for_model() as last resort --
         _base = current_base_url or ""
-        is_custom = current_provider in {"custom", "local"} or (
-            "localhost" in _base or "127.0.0.1" in _base
+        is_custom = (
+            current_provider in {"custom", "local"}
+            or current_provider.startswith("custom:")
+            or ("localhost" in _base or "127.0.0.1" in _base)
         )
 
         if (

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -1879,8 +1879,18 @@ def detect_static_provider_for_model(
         return None
 
     # --- Step 1: check static provider catalogs for a direct match ---
+    # If the current provider is a custom endpoint (custom or custom:*),
+    # never auto-switch away from it based on a static catalog match —
+    # the user explicitly configured their own endpoint and the same model
+    # name may be served there.
+    _is_custom_current = (
+        current_provider == "custom"
+        or current_provider.startswith("custom:")
+    )
     for pid, models in _PROVIDER_MODELS.items():
         if pid in current_keys or pid in _AGGREGATOR_PROVIDERS:
+            continue
+        if _is_custom_current:
             continue
         if any(name_lower == m.lower() for m in models):
             return (pid, name)

--- a/tests/hermes_cli/test_models.py
+++ b/tests/hermes_cli/test_models.py
@@ -301,6 +301,21 @@ class TestDetectProviderForModel:
         assert result is not None
         assert result[0] not in {"nous",}  # nous has claude models but shouldn't be suggested
 
+    def test_custom_provider_not_overridden_by_static_catalog(self):
+        """When current provider is custom:*, static catalog match must NOT
+        override it — otherwise a model served by the user's local endpoint
+        gets misattributed to the native provider (e.g. ollama)."""
+        # "llama-3.1-8b" exists in the static ollama catalog.  If the user's
+        # current provider is custom:ollama, detection must NOT switch to the
+        # native "ollama" provider.
+        result = detect_provider_for_model("llama-3.1-8b", "custom:ollama")
+        assert result is None, f"expected None but got {result}"
+
+    def test_custom_provider_bare_custom_not_overridden(self):
+        """Same as above but for bare 'custom' provider."""
+        result = detect_provider_for_model("llama-3.1-8b", "custom")
+        assert result is None, f"expected None but got {result}"
+
 
 class TestIsNousFreeTier:
     """Tests for is_nous_free_tier — account tier detection."""

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -2044,9 +2044,9 @@ def _restart_slash_worker(sid: str, session: dict):
 
 
 def _persist_model_switch(result) -> None:
-    from hermes_cli.config import save_config
+    from hermes_cli.config import load_config, save_config
 
-    cfg = _load_cfg()
+    cfg = load_config()
     model_cfg = cfg.get("model")
     if not isinstance(model_cfg, dict):
         model_cfg = {}


### PR DESCRIPTION
## Problem

When switching models via `hermes dashboard --tui`, the model picker silently rewrites `model.provider` from `custom:<name>` to the wrong native provider or `openrouter`, and can destroy `model_slots` / `model_fallback` config sections.

Two interacting bugs:

1. **Provider misattribution**: `detect_static_provider_for_model()` matches models against native provider catalogs even when the current provider is a custom endpoint (`custom:ollama` etc.), causing the provider to be rewritten.
2. **Incomplete `is_custom` guard**: The `is_custom` check in `switch_model()` step e only covered bare `"custom"` and `"local"`, missing `custom:*` patterns — so the OpenRouter last-resort fallback still fired for named custom providers.
3. **Config write robustness**: `_persist_model_switch()` used `_load_cfg()` (raw YAML) instead of `load_config()` (deep-merged), risking loss of config sections through the save/normalize cycle.

## Changes

### `hermes_cli/models.py`
- `detect_static_provider_for_model()`: skip the entire static catalog scan when `current_provider` is `"custom"` or starts with `"custom:"`

### `hermes_cli/model_switch.py`
- `switch_model()` step e: extend `is_custom` to also match `current_provider.startswith("custom:")`

### `tui_gateway/server.py`
- `_persist_model_switch()`: use `load_config()` instead of `_load_cfg()` for a fully merged config

### `tests/hermes_cli/test_models.py`
- `test_custom_provider_not_overridden_by_static_catalog`: verifies `custom:ollama` is not overridden by native deepseek catalog
- `test_custom_provider_bare_custom_not_overridden`: same for bare `custom`

## Testing

```
tests/hermes_cli/test_models.py:          78 passed (incl. 2 new)
tests/gateway/test_model_switch_persistence.py + related: 19 passed
tests/test_tui_gateway_server.py:        278 passed
```

Fixes #48305