### PR TITLE
fix(tui): persist model switch marker as user message

### DIFF
--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -3497,11 +3497,11 @@ def test_config_set_model_switches_agent_without_touching_env(monkeypatch):
             "Model: anthropic/claude-sonnet-4.6\nProvider: anthropic"
         )
         assert agent._cached_system_prompt == db.system_prompt
-        assert session["history"][-1]["role"] == "system"
+        assert session["history"][-1]["role"] == "user"
         assert "changed to anthropic/claude-sonnet-4.6" in session["history"][-1]["content"]
         assert db.messages[-1] == {
             "session_id": "session-key",
-            "role": "system",
+            "role": "user",
             "content": session["history"][-1]["content"],
         }
         # ...and the shared process env was NOT touched.

--- a/tests/tui_gateway/test_model_switch_marker.py
+++ b/tests/tui_gateway/test_model_switch_marker.py
@@ -1,0 +1,40 @@
+"""Regression tests for gateway model-switch history markers."""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from tui_gateway.server import _append_model_switch_marker
+
+
+def test_model_switch_marker_is_user_message_not_mid_history_system():
+    """Model switches must not inject a system role after conversation turns.
+
+    Strict OpenAI-compatible providers such as vLLM reject message arrays that
+    contain system messages after the beginning of the conversation.
+    """
+    db = MagicMock()
+    session = {
+        "session_key": "sess-1",
+        "history": [
+            {"role": "user", "content": "hello"},
+            {"role": "assistant", "content": "hi"},
+        ],
+        "history_version": 7,
+        "agent": SimpleNamespace(_session_db=db),
+    }
+
+    _append_model_switch_marker(
+        session,
+        model="qwen3.6-35b",
+        provider="api.lucasnicolas.dev",
+    )
+
+    marker = session["history"][-1]
+    assert marker["role"] == "user"
+    assert "active model for this chat has changed to qwen3.6-35b" in marker["content"]
+    assert session["history_version"] == 8
+    db.append_message.assert_called_once_with(
+        session_id="sess-1",
+        role="user",
+        content=marker["content"],
+    )

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -1721,7 +1721,11 @@ def _append_model_switch_marker(session: dict | None, *, model: str, provider: s
         f"{model}{provider_part}. From this point forward, use this runtime "
         "metadata when answering questions about what model/provider is active.]"
     )
-    entry = {"role": "system", "content": marker}
+    # Persist as a user message, not a system message.  The gateway appends
+    # this marker after prior conversation turns, and strict OpenAI-compatible
+    # providers such as vLLM reject system messages that are not at the
+    # beginning of the API message list.
+    entry = {"role": "user", "content": marker}
 
     lock = session.get("history_lock")
     if lock is not None:
@@ -1736,14 +1740,14 @@ def _append_model_switch_marker(session: dict | None, *, model: str, provider: s
         agent = session.get("agent")
         db = getattr(agent, "_session_db", None) if agent is not None else None
         if db is not None:
-            db.append_message(session_id=session_key, role="system", content=marker)
+            db.append_message(session_id=session_key, role="user", content=marker)
             return
 
         _ensure_session_db_row(session)
         with _session_db(session) as scoped_db:
             if scoped_db is not None:
                 scoped_db.append_message(
-                    session_id=session_key, role="system", content=marker
+                    session_id=session_key, role="user", content=marker
                 )
     except Exception:
         logger.debug("failed to persist model switch marker", exc_info=True)


### PR DESCRIPTION
## What does this PR do?

Fixes a gateway/TUI model-switch bug where `_append_model_switch_marker()` persisted an informational model-switch marker as `role: "system"` after prior conversation turns.

Strict OpenAI-compatible providers such as vLLM reject message arrays with system messages outside the beginning of the conversation, returning:

```text
HTTP 400: System message must be at the beginning.
```

The marker is runtime metadata for the next model, not a privileged instruction. This PR persists it as a `user` message instead, so it can safely appear mid-history and later be merged with adjacent user messages by the existing sanitizer.

## Related Issue

Fixes #48338

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tui_gateway/server.py`
  - Persist model-switch markers as `role: "user"` instead of `role: "system"` in both in-memory history and SQLite session persistence.
  - Added a comment explaining why strict OpenAI-compatible providers require this.
- `tests/tui_gateway/test_model_switch_marker.py`
  - Added a regression test that verifies model-switch markers are appended and persisted as user messages, not mid-history system messages.

## How to Test

1. Run the focused regression:
   ```bash
   scripts/run_tests.sh tests/tui_gateway/test_model_switch_marker.py tests/gateway/test_model_switch_persistence.py
   ```
2. Run the relevant gateway/TUI slice:
   ```bash
   scripts/run_tests.sh tests/tui_gateway/ tests/gateway/test_model_switch_persistence.py
   ```
3. Reproduce against a strict provider by sending messages shaped like:
   ```python
   [
       {"role": "system", "content": "..."},
       {"role": "user", "content": "hello"},
       {"role": "assistant", "content": "hi"},
       {"role": "system", "content": "[System: The active model ...]"},
       {"role": "user", "content": "say hi again"},
   ]
   ```
   Before this fix, vLLM returns `HTTP 400: System message must be at the beginning.` With this change, the gateway no longer creates that mid-history system role.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Test Results

Passed:

```text
scripts/run_tests.sh tests/tui_gateway/test_model_switch_marker.py tests/gateway/test_model_switch_persistence.py
# 2 files, 10 tests passed, 0 failed

scripts/run_tests.sh tests/tui_gateway/ tests/gateway/test_model_switch_persistence.py
# 13 files, 143 tests passed, 0 failed

git diff --check
# passed

python3 scripts/check-windows-footguns.py --diff origin/main
# passed; no Windows footguns found in changed diff
```

Full-suite note:

I attempted a full `scripts/run_tests.sh` run after installing `[all,dev]` per CONTRIBUTING. The full suite is very large; I stopped it after the relevant suites had already passed and the run had progressed past 22k passing tests with several failures in unrelated test files. I am not claiming full-suite green for this PR.

## Screenshots / Logs

Relevant failure reproduced before the fix:

```text
HTTP 400: {"error":{"message":"System message must be at the beginning.","type":"BadRequestError","param":null,"code":400}}
```
