### PR TITLE
fix(state): allow billing fields to update on model switch (#48248)

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -814,9 +814,9 @@ class SessionDB:
                    cost_status = COALESCE(?, cost_status),
                    cost_source = COALESCE(?, cost_source),
                    pricing_version = COALESCE(?, pricing_version),
-                   billing_provider = COALESCE(billing_provider, ?),
-                   billing_base_url = COALESCE(billing_base_url, ?),
-                   billing_mode = COALESCE(billing_mode, ?),
+                   billing_provider = ?,
+                   billing_base_url = ?,
+                   billing_mode = ?,
                    model = COALESCE(model, ?),
                    api_call_count = ?
                    WHERE id = ?"""
@@ -835,9 +835,9 @@ class SessionDB:
                    cost_status = COALESCE(?, cost_status),
                    cost_source = COALESCE(?, cost_source),
                    pricing_version = COALESCE(?, pricing_version),
-                   billing_provider = COALESCE(billing_provider, ?),
-                   billing_base_url = COALESCE(billing_base_url, ?),
-                   billing_mode = COALESCE(billing_mode, ?),
+                   billing_provider = ?,
+                   billing_base_url = ?,
+                   billing_mode = ?,
                    model = COALESCE(model, ?),
                    api_call_count = COALESCE(api_call_count, 0) + ?
                    WHERE id = ?"""


### PR DESCRIPTION
Fixes #48248. billing_provider, billing_base_url, and billing_mode used COALESCE making them write-once. Mid-session /model switches updated the runtime but the session DB kept the old provider, causing stale provider badges and misattributed cost analytics. Changed to direct assignment so billing fields reflect the current provider.