### PR TITLE
fix(transport): strip internal timestamp from API messages (#48263)

### DIFF
--- a/agent/transports/chat_completions.py
+++ b/agent/transports/chat_completions.py
@@ -145,6 +145,7 @@ class ChatCompletionsTransport(ProviderTransport):
                 "codex_reasoning_items" in msg
                 or "codex_message_items" in msg
                 or "tool_name" in msg
+                or "timestamp" in msg
             ):
                 needs_sanitize = True
                 break
@@ -172,6 +173,7 @@ class ChatCompletionsTransport(ProviderTransport):
             msg.pop("codex_reasoning_items", None)
             msg.pop("codex_message_items", None)
             msg.pop("tool_name", None)
+            msg.pop("timestamp", None)
             # Drop all Hermes-internal scaffolding markers (``_``-prefixed).
             # OpenAI's message schema has no ``_``-prefixed fields, so this
             # is safe and future-proofs against new markers being added.


### PR DESCRIPTION
Fixes #48263. The timestamp field from the session DB messages table leaks into API requests. Strict providers like GLM reject this with HTTP 400 'Extra inputs are not permitted, field: messages[N].timestamp'. Added timestamp to the sanitize list in ChatCompletionsTransport.convert_messages() so it is stripped before reaching the wire.