### PR TITLE
fix(auth): share Codex and xAI OAuth state across profiles

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1259,6 +1259,9 @@ def init_agent(
     _codex_gpt55_autoraise = str(
         _compression_cfg.get("codex_gpt55_autoraise", True)
     ).lower() in {"true", "1", "yes"}
+    _codex_gpt55_autoraise_notice = str(
+        _compression_cfg.get("codex_gpt55_autoraise_notice", True)
+    ).lower() in {"true", "1", "yes"}
     agent._compression_threshold_autoraised = None
     try:
         from agent.auxiliary_client import (
@@ -1278,7 +1281,8 @@ def init_agent(
             # the user's global threshold already meets/exceeds the raised
             # value, since nothing actually changed for them.
             if (
-                _is_codex_gpt55_fn(agent.model, agent.provider)
+                _codex_gpt55_autoraise_notice
+                and _is_codex_gpt55_fn(agent.model, agent.provider)
                 and _model_cthresh > _prev_threshold + 1e-9
             ):
                 agent._compression_threshold_autoraised = {

--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -656,11 +656,7 @@ class CredentialPool:
         if self.provider != "xai-oauth" or entry.source != "loopback_pkce":
             return entry
         try:
-            with _auth_store_lock():
-                auth_store = _load_auth_store()
-                state = _load_provider_state(auth_store, "xai-oauth")
-            if not isinstance(state, dict):
-                return entry
+            state = auth_mod._read_xai_oauth_tokens()
             tokens = state.get("tokens")
             if not isinstance(tokens, dict):
                 return entry
@@ -837,6 +833,22 @@ class CredentialPool:
                     _store_provider_state(auth_store, "openai-codex", state, set_active=False)
 
                 elif self.provider == "xai-oauth":
+                    if auth_mod._xai_shared_store_enabled():
+                        try:
+                            current_state = auth_mod._read_xai_oauth_tokens(_lock=False)
+                        except Exception:
+                            current_state = {}
+                        auth_mod._write_shared_xai_oauth_state(
+                            {
+                                "access_token": entry.access_token,
+                                "refresh_token": entry.refresh_token,
+                                "token_type": "Bearer",
+                            },
+                            discovery=current_state.get("discovery") if isinstance(current_state, dict) else None,
+                            redirect_uri=str((current_state or {}).get("redirect_uri") or "") if isinstance(current_state, dict) else "",
+                            last_refresh=entry.last_refresh or datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+                        )
+                        return
                     state = _load_provider_state(auth_store, "xai-oauth")
                     if not isinstance(state, dict):
                         return
@@ -1917,7 +1929,10 @@ def _seed_from_singletons(provider: str, entries: List[PooledCredential]) -> Tup
         if _is_suppressed(provider, "loopback_pkce"):
             return changed, active_sources
 
-        state = _load_provider_state(auth_store, "xai-oauth")
+        try:
+            state = auth_mod._read_xai_oauth_tokens()
+        except Exception:
+            state = _load_provider_state(auth_store, "xai-oauth")
         tokens = state.get("tokens") if isinstance(state, dict) else None
         if isinstance(tokens, dict) and tokens.get("access_token"):
             active_sources.add("loopback_pkce")

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -4352,8 +4352,82 @@ def _pool_codex_access_token() -> str:
 
 
 # =============================================================================
-# xAI Grok OAuth — tokens stored in ~/.hermes/auth.json
+# xAI Grok OAuth — tokens stored in a shared store for named profiles
 # =============================================================================
+
+XAI_SHARED_STORE_FILENAME = "xai_oauth.json"
+_xai_shared_lock_holder = threading.local()
+
+
+def _xai_shared_store_enabled() -> bool:
+    """Return True when xAI OAuth should use the cross-profile shared store.
+
+    Named Hermes profiles live below ``<root>/profiles/<name>``. Their xAI
+    refresh tokens must be shared because the server can rotate refresh_token
+    on every refresh; sibling profiles with copied tokens then replay revoked
+    grants. Classic single-home installs keep the historical auth.json layout.
+    Tests can force shared mode by setting ``HERMES_SHARED_AUTH_DIR``.
+    """
+    override = os.getenv("HERMES_SHARED_AUTH_DIR", "").strip()
+    if override:
+        if os.environ.get("PYTEST_CURRENT_TEST"):
+            real_home = os.environ.get("HOME", "").strip()
+            if real_home:
+                real_home_shared = (
+                    Path(real_home) / ".hermes" / "shared" / XAI_SHARED_STORE_FILENAME
+                ).resolve(strict=False)
+                try:
+                    resolved = (Path(override).expanduser() / XAI_SHARED_STORE_FILENAME).resolve(strict=False)
+                except Exception:
+                    return False
+                if resolved == real_home_shared:
+                    return False
+        return True
+    try:
+        return "profiles" in get_hermes_home().parts
+    except Exception:
+        return False
+
+
+def _xai_shared_auth_dir() -> Path:
+    override = os.getenv("HERMES_SHARED_AUTH_DIR", "").strip()
+    if override:
+        return Path(override).expanduser()
+    from hermes_constants import get_default_hermes_root
+    return get_default_hermes_root() / "shared"
+
+
+def _xai_shared_store_path() -> Path:
+    path = _xai_shared_auth_dir() / XAI_SHARED_STORE_FILENAME
+    if os.environ.get("PYTEST_CURRENT_TEST") and not os.getenv("HERMES_SHARED_AUTH_DIR", "").strip():
+        real_home = os.environ.get("HOME", "").strip()
+        if not real_home:
+            return path
+        real_home_shared = (
+            Path(real_home) / ".hermes" / "shared" / XAI_SHARED_STORE_FILENAME
+        ).resolve(strict=False)
+        try:
+            resolved = path.resolve(strict=False)
+        except Exception:
+            resolved = path
+        if resolved == real_home_shared:
+            raise RuntimeError(
+                f"Refusing to touch real user shared xAI auth store during test run: "
+                f"{path}. Set HERMES_SHARED_AUTH_DIR to a tmp_path in your test fixture."
+            )
+    return path
+
+
+@contextmanager
+def _xai_shared_store_lock(timeout_seconds: float = AUTH_LOCK_TIMEOUT_SECONDS):
+    with _file_lock(
+        _xai_shared_store_path().with_suffix(".lock"),
+        _xai_shared_lock_holder,
+        timeout_seconds,
+        "Timed out waiting for shared xAI auth lock",
+    ):
+        yield
+
 
 def _xai_oauth_state_from_store(auth_store: Dict[str, Any]) -> Optional[Dict[str, Any]]:
     """Return usable xAI OAuth state from provider state or credential pool."""
@@ -4402,24 +4476,7 @@ def _xai_oauth_state_has_usable_tokens(state: Optional[Dict[str, Any]]) -> bool:
     )
 
 
-def _read_xai_oauth_tokens(*, _lock: bool = True) -> Dict[str, Any]:
-    if _lock:
-        with _auth_store_lock():
-            auth_store = _load_auth_store()
-    else:
-        auth_store = _load_auth_store()
-    state = _xai_oauth_state_from_store(auth_store)
-    if not _xai_oauth_state_has_usable_tokens(state):
-        global_state = _xai_oauth_state_from_store(_load_global_auth_store())
-        if _xai_oauth_state_has_usable_tokens(global_state):
-            state = global_state
-    if not state:
-        raise AuthError(
-            "No xAI OAuth credentials stored. Select xAI Grok OAuth (SuperGrok / Premium+) in `hermes model`.",
-            provider="xai-oauth",
-            code="xai_auth_missing",
-            relogin_required=True,
-        )
+def _validate_xai_oauth_state(state: Dict[str, Any]) -> Dict[str, Any]:
     tokens = state.get("tokens")
     if not isinstance(tokens, dict):
         raise AuthError(
@@ -4449,7 +4506,117 @@ def _read_xai_oauth_tokens(*, _lock: bool = True) -> Dict[str, Any]:
         "last_refresh": state.get("last_refresh"),
         "discovery": state.get("discovery") or {},
         "redirect_uri": state.get("redirect_uri"),
+        "source": state.get("source") or "hermes-auth-store",
     }
+
+
+def _read_shared_xai_oauth_state() -> Optional[Dict[str, Any]]:
+    if not _xai_shared_store_enabled():
+        return None
+    try:
+        path = _xai_shared_store_path()
+    except RuntimeError:
+        return None
+    if not path.is_file():
+        return None
+    try:
+        payload = json.loads(path.read_text())
+    except (OSError, ValueError) as exc:
+        logger.debug("Shared xAI auth store at %s is unreadable: %s", path, exc)
+        return None
+    if not isinstance(payload, dict):
+        return None
+    state = dict(payload)
+    state["source"] = "hermes-shared-xai-store"
+    try:
+        return _validate_xai_oauth_state(state)
+    except AuthError as exc:
+        logger.debug("Shared xAI auth store at %s is invalid: %s", path, exc)
+        return None
+
+
+def _write_shared_xai_oauth_state(
+    tokens: Dict[str, Any],
+    *,
+    discovery: Optional[Dict[str, Any]],
+    redirect_uri: str,
+    last_refresh: str,
+) -> None:
+    with _xai_shared_store_lock():
+        path = _xai_shared_store_path()
+        path.parent.mkdir(parents=True, exist_ok=True)
+        secure_parent_dir(path)
+        payload = {
+            "_schema": 1,
+            "tokens": tokens,
+            "last_refresh": last_refresh,
+            "auth_mode": "oauth_pkce",
+            "updated_at": datetime.now(timezone.utc).isoformat(),
+        }
+        if discovery:
+            payload["discovery"] = discovery
+        if redirect_uri:
+            payload["redirect_uri"] = redirect_uri
+        tmp = path.with_name(f"{path.name}.tmp.{os.getpid()}.{uuid.uuid4().hex}")
+        fd = os.open(
+            str(tmp),
+            os.O_WRONLY | os.O_CREAT | os.O_EXCL,
+            stat.S_IRUSR | stat.S_IWUSR,
+        )
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as fh:
+                fh.write(json.dumps(payload, indent=2, sort_keys=True) + "\n")
+                fh.flush()
+                os.fsync(fh.fileno())
+            atomic_replace(tmp, path)
+            try:
+                dir_fd = os.open(str(path.parent), os.O_RDONLY)
+            except OSError:
+                dir_fd = None
+            if dir_fd is not None:
+                try:
+                    os.fsync(dir_fd)
+                finally:
+                    os.close(dir_fd)
+        finally:
+            try:
+                if tmp.exists():
+                    tmp.unlink()
+            except OSError:
+                pass
+        try:
+            path.chmod(stat.S_IRUSR | stat.S_IWUSR)
+        except OSError:
+            pass
+
+
+def _clear_shared_xai_oauth_state(reason: str, *, expected_refresh_token: Optional[str] = None) -> None:
+    """Remove shared xAI OAuth state after terminal auth failure.
+
+    If ``expected_refresh_token`` is supplied, clear only when the shared file
+    still holds that same refresh token. xAI refresh tokens can rotate on every
+    refresh; this prevents a losing process from deleting a token chain that a
+    sibling profile already rotated successfully.
+    """
+    try:
+        with _xai_shared_store_lock():
+            path = _xai_shared_store_path()
+            if expected_refresh_token:
+                current = _read_shared_xai_oauth_state()
+                current_tokens = current.get("tokens") if isinstance(current, dict) else None
+                current_refresh = ""
+                if isinstance(current_tokens, dict):
+                    current_refresh = str(current_tokens.get("refresh_token", "") or "").strip()
+                if current_refresh and current_refresh != str(expected_refresh_token).strip():
+                    logger.debug("Skipping shared xAI clear for %s; shared token already rotated", reason)
+                    return
+            try:
+                path.unlink()
+            except FileNotFoundError:
+                pass
+        _oauth_trace("xai_shared_store_cleared", reason=reason)
+    except Exception as exc:
+        logger.debug("Failed to clear shared xAI auth store: %s", exc)
 
 
 def _profile_has_own_xai_oauth_state(auth_store: Dict[str, Any]) -> bool:
@@ -4508,6 +4675,31 @@ def _write_through_xai_oauth_to_global_root(state: Dict[str, Any]) -> None:
         logger.debug("xAI OAuth: write-through to global root failed: %s", exc)
 
 
+def _read_xai_oauth_tokens(*, _lock: bool = True) -> Dict[str, Any]:
+    if _lock:
+        with _auth_store_lock():
+            return _read_xai_oauth_tokens(_lock=False)
+
+    shared_state = _read_shared_xai_oauth_state()
+    if shared_state:
+        return shared_state
+
+    auth_store = _load_auth_store()
+    state = _xai_oauth_state_from_store(auth_store)
+    if not _xai_oauth_state_has_usable_tokens(state):
+        global_state = _xai_oauth_state_from_store(_load_global_auth_store())
+        if _xai_oauth_state_has_usable_tokens(global_state):
+            state = global_state
+    if not state:
+        raise AuthError(
+            "No xAI OAuth credentials stored. Select xAI Grok OAuth (SuperGrok / Premium+) in `hermes model`.",
+            provider="xai-oauth",
+            code="xai_auth_missing",
+            relogin_required=True,
+        )
+    return _validate_xai_oauth_state(state)
+
+
 def _save_xai_oauth_tokens(
     tokens: Dict[str, Any],
     *,
@@ -4519,6 +4711,26 @@ def _save_xai_oauth_tokens(
         last_refresh = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
     with _auth_store_lock():
         auth_store = _load_auth_store()
+        if _xai_shared_store_enabled():
+            _write_shared_xai_oauth_state(
+                tokens,
+                discovery=discovery,
+                redirect_uri=redirect_uri,
+                last_refresh=last_refresh,
+            )
+            state = _load_provider_state(auth_store, "xai-oauth") or {}
+            state.pop("tokens", None)
+            state["last_refresh"] = last_refresh
+            state["auth_mode"] = "oauth_pkce"
+            state["shared_store"] = XAI_SHARED_STORE_FILENAME
+            if discovery:
+                state["discovery"] = discovery
+            if redirect_uri:
+                state["redirect_uri"] = redirect_uri
+            _save_provider_state(auth_store, "xai-oauth", state)
+            _save_auth_store(auth_store)
+            return
+
         # A profile that lacks its own xai-oauth block is reading the root
         # grant through _load_provider_state's fallback. When such a profile
         # refreshes the (rotating) grant, we must write the rotated chain back
@@ -4536,7 +4748,6 @@ def _save_xai_oauth_tokens(
         _save_auth_store(auth_store)
         if write_through_to_root:
             _write_through_xai_oauth_to_global_root(state)
-
 
 def _xai_access_token_is_expiring(access_token: str, skew_seconds: int = 0) -> bool:
     if not isinstance(access_token, str) or "." not in access_token:
@@ -4831,6 +5042,76 @@ def _refresh_xai_oauth_tokens(
     return updated_tokens
 
 
+def _refresh_xai_oauth_locked(
+    *,
+    force_refresh: bool,
+    refresh_if_expiring: bool,
+    refresh_skew_seconds: int,
+    refresh_timeout_seconds: float,
+) -> tuple[Dict[str, Any], Dict[str, Any], str]:
+    """Re-read and refresh xAI OAuth tokens while caller holds required locks.
+
+    Caller must hold ``_auth_store_lock`` and, when shared mode is enabled,
+    ``_xai_shared_store_lock``. Keeping the shared lock across read -> refresh
+    -> write prevents sibling profiles from spending the same rotating refresh
+    token concurrently.
+    """
+    data = _read_xai_oauth_tokens(_lock=False)
+    tokens = dict(data["tokens"])
+    access_token = str(tokens.get("access_token", "") or "").strip()
+    discovery = dict(data.get("discovery") or {})
+    token_endpoint = str(discovery.get("token_endpoint", "") or "").strip()
+    redirect_uri = str(data.get("redirect_uri", "") or "").strip()
+    should_refresh = bool(force_refresh)
+    if (not should_refresh) and refresh_if_expiring:
+        should_refresh = _xai_access_token_is_expiring(access_token, refresh_skew_seconds)
+    if should_refresh:
+        if not token_endpoint:
+            token_endpoint = _xai_oauth_discovery(refresh_timeout_seconds)["token_endpoint"]
+        attempted_refresh_token = str(tokens.get("refresh_token", "") or "").strip()
+        try:
+            tokens = _refresh_xai_oauth_tokens(
+                tokens,
+                token_endpoint=token_endpoint,
+                redirect_uri=redirect_uri,
+                timeout_seconds=refresh_timeout_seconds,
+            )
+            access_token = str(tokens.get("access_token", "") or "").strip()
+        except AuthError as exc:
+            if _is_terminal_xai_oauth_refresh_error(exc):
+                # Terminal failure (HTTP 400/401 — invalid_grant, token revoked).
+                # Clear dead tokens from the active xAI store so subsequent sessions fail fast
+                # without a network retry. Mirrors credential_pool.py quarantine.
+                try:
+                    if _xai_shared_store_enabled():
+                        _clear_shared_xai_oauth_state(
+                            "runtime_refresh_failure",
+                            expected_refresh_token=attempted_refresh_token,
+                        )
+                    _q_store = _load_auth_store()
+                    _q_state = _load_provider_state(_q_store, "xai-oauth") or {}
+                    _q_tokens = dict(_q_state.get("tokens") or {})
+                    _q_tokens.pop("access_token", None)
+                    _q_tokens.pop("refresh_token", None)
+                    _q_state["tokens"] = _q_tokens
+                    _q_state["last_auth_error"] = {
+                        "provider": "xai-oauth",
+                        "code": exc.code or "xai_refresh_failed",
+                        "message": str(exc),
+                        "reason": "runtime_refresh_failure",
+                        "relogin_required": True,
+                        "at": datetime.now(timezone.utc).isoformat(),
+                    }
+                    _store_provider_state(_q_store, "xai-oauth", _q_state, set_active=False)
+                    _save_auth_store(_q_store)
+                except Exception as _save_exc:
+                    logger.debug(
+                        "xAI OAuth: failed to persist quarantined state: %s", _save_exc,
+                    )
+            raise
+    return data, tokens, access_token
+
+
 def resolve_xai_oauth_runtime_credentials(
     *,
     force_refresh: bool = False,
@@ -4850,53 +5131,21 @@ def resolve_xai_oauth_runtime_credentials(
         should_refresh = _xai_access_token_is_expiring(access_token, refresh_skew_seconds)
     if should_refresh:
         with _auth_store_lock(timeout_seconds=max(float(AUTH_LOCK_TIMEOUT_SECONDS), refresh_timeout_seconds + 5.0)):
-            data = _read_xai_oauth_tokens(_lock=False)
-            tokens = dict(data["tokens"])
-            access_token = str(tokens.get("access_token", "") or "").strip()
-            discovery = dict(data.get("discovery") or {})
-            token_endpoint = str(discovery.get("token_endpoint", "") or "").strip()
-            redirect_uri = str(data.get("redirect_uri", "") or "").strip()
-            should_refresh = bool(force_refresh)
-            if (not should_refresh) and refresh_if_expiring:
-                should_refresh = _xai_access_token_is_expiring(access_token, refresh_skew_seconds)
-            if should_refresh:
-                if not token_endpoint:
-                    token_endpoint = _xai_oauth_discovery(refresh_timeout_seconds)["token_endpoint"]
-                try:
-                    tokens = _refresh_xai_oauth_tokens(
-                        tokens,
-                        token_endpoint=token_endpoint,
-                        redirect_uri=redirect_uri,
-                        timeout_seconds=refresh_timeout_seconds,
+            if _xai_shared_store_enabled():
+                with _xai_shared_store_lock(timeout_seconds=max(float(AUTH_LOCK_TIMEOUT_SECONDS), refresh_timeout_seconds + 5.0)):
+                    data, tokens, access_token = _refresh_xai_oauth_locked(
+                        force_refresh=force_refresh,
+                        refresh_if_expiring=refresh_if_expiring,
+                        refresh_skew_seconds=refresh_skew_seconds,
+                        refresh_timeout_seconds=refresh_timeout_seconds,
                     )
-                    access_token = str(tokens.get("access_token", "") or "").strip()
-                except AuthError as exc:
-                    if _is_terminal_xai_oauth_refresh_error(exc):
-                        # Terminal failure (HTTP 400/401/403 — invalid_grant, token revoked).
-                        # Clear dead tokens from auth.json so subsequent sessions fail fast
-                        # without a network retry. Mirrors credential_pool.py quarantine.
-                        try:
-                            _q_store = _load_auth_store()
-                            _q_state = _load_provider_state(_q_store, "xai-oauth") or {}
-                            _q_tokens = dict(_q_state.get("tokens") or {})
-                            _q_tokens.pop("access_token", None)
-                            _q_tokens.pop("refresh_token", None)
-                            _q_state["tokens"] = _q_tokens
-                            _q_state["last_auth_error"] = {
-                                "provider": "xai-oauth",
-                                "code": exc.code or "xai_refresh_failed",
-                                "message": str(exc),
-                                "reason": "runtime_refresh_failure",
-                                "relogin_required": True,
-                                "at": datetime.now(timezone.utc).isoformat(),
-                            }
-                            _store_provider_state(_q_store, "xai-oauth", _q_state, set_active=False)
-                            _save_auth_store(_q_store)
-                        except Exception as _save_exc:
-                            logger.debug(
-                                "xAI OAuth: failed to persist quarantined state: %s", _save_exc,
-                            )
-                    raise
+            else:
+                data, tokens, access_token = _refresh_xai_oauth_locked(
+                    force_refresh=force_refresh,
+                    refresh_if_expiring=refresh_if_expiring,
+                    refresh_skew_seconds=refresh_skew_seconds,
+                    refresh_timeout_seconds=refresh_timeout_seconds,
+                )
 
     base_url = _xai_validate_inference_base_url(
         os.getenv("HERMES_XAI_BASE_URL", "").strip().rstrip("/")

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -96,6 +96,7 @@ STEPFUN_STEP_PLAN_CN_BASE_URL = "https://api.stepfun.com/step_plan/v1"
 CODEX_OAUTH_CLIENT_ID = "app_EMoamEEZ73f0CkXaXp7hrann"
 CODEX_OAUTH_TOKEN_URL = "https://auth.openai.com/oauth/token"
 CODEX_ACCESS_TOKEN_REFRESH_SKEW_SECONDS = 120
+CODEX_SHARED_STORE_FILENAME = "codex_auth.json"
 XAI_OAUTH_ISSUER = "https://auth.x.ai"
 XAI_OAUTH_DISCOVERY_URL = f"{XAI_OAUTH_ISSUER}/.well-known/openid-configuration"
 XAI_OAUTH_CLIENT_ID = "b1a00492-073a-47ea-816f-4c329264a828"
@@ -1287,6 +1288,8 @@ def write_credential_pool(provider_id: str, entries: List[Dict[str, Any]]) -> Pa
             if isinstance(entry, dict) else entry
             for entry in entries
         ]
+        if provider_id == "openai-codex":
+            _reconcile_codex_pool_to_shared(auth_store)
         return _save_auth_store(auth_store)
 
 
@@ -3349,25 +3352,379 @@ def _print_loopback_ssh_hint(redirect_uri: str, *, docs_url: str | None = None) 
 
 
 # =============================================================================
-# OpenAI Codex auth — tokens stored in ~/.hermes/auth.json (not ~/.codex/)
+# OpenAI Codex auth — profile cache + Hermes-owned shared store
 #
 # Hermes maintains its own Codex OAuth session separate from the Codex CLI
-# and VS Code extension. This prevents refresh token rotation conflicts
-# where one app's refresh invalidates the other's session.
+# and VS Code extension.  Codex refresh tokens rotate on refresh, so all
+# Hermes profiles under the same root also share a canonical token chain at
+# <hermes-root>/shared/codex_auth.json. Profile-local auth.json entries are
+# caches for profile isolation/status; the shared store prevents one profile
+# from leaving sibling profiles with stale single-use refresh tokens.
 # =============================================================================
 
+_codex_shared_lock_holder = threading.local()
+
+
+def _codex_shared_auth_dir() -> Path:
+    override = os.getenv("HERMES_SHARED_AUTH_DIR", "").strip()
+    if override:
+        return Path(override).expanduser()
+    from hermes_constants import get_default_hermes_root
+    return get_default_hermes_root() / "shared"
+
+
+def _codex_shared_store_path() -> Path:
+    path = _codex_shared_auth_dir() / CODEX_SHARED_STORE_FILENAME
+    if os.environ.get("PYTEST_CURRENT_TEST"):
+        from hermes_constants import get_default_hermes_root
+        real_home_shared = (
+            get_default_hermes_root() / "shared" / CODEX_SHARED_STORE_FILENAME
+        ).resolve(strict=False)
+        try:
+            resolved = path.resolve(strict=False)
+        except Exception:
+            resolved = path
+        if resolved == real_home_shared:
+            raise RuntimeError(
+                f"Refusing to touch real user shared Codex auth store during test run: "
+                f"{path}. Set HERMES_SHARED_AUTH_DIR to a tmp_path in your test fixture."
+            )
+    return path
+
+
+@contextmanager
+def _codex_shared_store_lock(timeout_seconds: float = AUTH_LOCK_TIMEOUT_SECONDS):
+    """Cross-profile lock for the shared Codex OAuth token chain.
+
+    When this lock is used together with a profile auth lock, acquire the
+    profile ``_auth_store_lock`` first and this shared lock second. Runtime
+    refresh keeps both locks across read -> refresh -> write so only one
+    profile can spend the shared single-use refresh token at a time.
+    """
+    try:
+        lock_path = _codex_shared_store_path().with_suffix(".lock")
+    except RuntimeError:
+        yield
+        return
+    with _file_lock(
+        lock_path,
+        _codex_shared_lock_holder,
+        timeout_seconds,
+        "Timed out waiting for shared Codex auth lock",
+    ):
+        yield
+
+
+def _codex_tokens_usable(tokens: Any) -> bool:
+    return (
+        isinstance(tokens, dict)
+        and bool(str(tokens.get("access_token", "") or "").strip())
+        and bool(str(tokens.get("refresh_token", "") or "").strip())
+    )
+
+
+def _read_shared_codex_state() -> Optional[Dict[str, Any]]:
+    try:
+        path = _codex_shared_store_path()
+    except RuntimeError:
+        return None
+    if not path.is_file():
+        return None
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError) as exc:
+        logger.debug("Shared Codex auth store at %s is unreadable: %s", path, exc)
+        return None
+    if not isinstance(payload, dict):
+        return None
+    tokens = payload.get("tokens")
+    if not _codex_tokens_usable(tokens):
+        return None
+    return payload
+
+
+def _codex_shared_state_is_fresher(local_state: Dict[str, Any], shared: Dict[str, Any]) -> bool:
+    shared_tokens = shared.get("tokens") if isinstance(shared, dict) else None
+    local_tokens = local_state.get("tokens") if isinstance(local_state, dict) else None
+    if not _codex_tokens_usable(shared_tokens):
+        return False
+    if not _codex_tokens_usable(local_tokens):
+        return True
+    shared_refresh = str(shared_tokens.get("refresh_token", "") or "").strip()
+    local_refresh = str(local_tokens.get("refresh_token", "") or "").strip()
+    if shared_refresh and shared_refresh != local_refresh:
+        return True
+    shared_last = _parse_iso_timestamp(shared.get("last_refresh") or shared.get("updated_at")) or 0.0
+    local_last = _parse_iso_timestamp(local_state.get("last_refresh")) or 0.0
+    return shared_last > local_last
+
+
+def _merge_shared_codex_state(state: Dict[str, Any]) -> bool:
+    """Copy fresher shared Codex tokens into a profile-local state dict."""
+    shared = _read_shared_codex_state()
+    if not shared or not _codex_shared_state_is_fresher(state, shared):
+        return False
+    tokens = shared.get("tokens")
+    if not _codex_tokens_usable(tokens):
+        return False
+    state["tokens"] = dict(tokens)
+    state["last_refresh"] = shared.get("last_refresh") or shared.get("updated_at")
+    state["auth_mode"] = shared.get("auth_mode") or "chatgpt"
+    if shared.get("label"):
+        state["label"] = shared.get("label")
+    return True
+
+
+def _write_shared_codex_state(
+    tokens: Dict[str, Any],
+    *,
+    last_refresh: Optional[str] = None,
+    label: Optional[str] = None,
+) -> None:
+    """Persist the canonical cross-profile Codex OAuth token chain.
+
+    Best-effort; profile-local auth.json remains the immediate cache. The
+    shared file is intentionally Hermes-owned and separate from ~/.codex/auth.json.
+    """
+    if not _codex_tokens_usable(tokens):
+        return
+    if last_refresh is None:
+        last_refresh = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+    shared = {
+        "_schema": 1,
+        "tokens": {
+            "access_token": str(tokens.get("access_token", "") or ""),
+            "refresh_token": str(tokens.get("refresh_token", "") or ""),
+        },
+        "auth_mode": "chatgpt",
+        "last_refresh": last_refresh,
+        "updated_at": datetime.now(timezone.utc).isoformat(),
+    }
+    if label and str(label).strip():
+        shared["label"] = str(label).strip()
+    token_type = tokens.get("token_type")
+    if token_type:
+        shared["tokens"]["token_type"] = token_type
+    try:
+        with _codex_shared_store_lock():
+            path = _codex_shared_store_path()
+            path.parent.mkdir(parents=True, exist_ok=True)
+            secure_parent_dir(path)
+            tmp = path.with_name(f"{path.name}.tmp.{os.getpid()}.{uuid.uuid4().hex}")
+            fd = os.open(
+                str(tmp),
+                os.O_WRONLY | os.O_CREAT | os.O_EXCL,
+                stat.S_IRUSR | stat.S_IWUSR,
+            )
+            try:
+                with os.fdopen(fd, "w", encoding="utf-8") as fh:
+                    fh.write(json.dumps(shared, indent=2, sort_keys=True) + "\n")
+                    fh.flush()
+                    os.fsync(fh.fileno())
+                os.replace(tmp, path)
+            finally:
+                try:
+                    if tmp.exists():
+                        tmp.unlink()
+                except OSError:
+                    pass
+    except Exception as exc:
+        logger.debug("Failed to write shared Codex auth store: %s", exc)
+
+
+def _clear_shared_codex_state(reason: str, *, expected_refresh_token: Optional[str] = None) -> None:
+    """Remove shared Codex state after terminal auth failure.
+
+    If ``expected_refresh_token`` is supplied, clear only when the shared file
+    still holds that same refresh token. This avoids process A deleting a fresh
+    token chain after process B already rotated it successfully.
+    """
+    try:
+        with _codex_shared_store_lock():
+            path = _codex_shared_store_path()
+            if expected_refresh_token:
+                current = _read_shared_codex_state()
+                current_tokens = current.get("tokens") if isinstance(current, dict) else None
+                current_refresh = ""
+                if isinstance(current_tokens, dict):
+                    current_refresh = str(current_tokens.get("refresh_token", "") or "").strip()
+                if current_refresh and current_refresh != str(expected_refresh_token).strip():
+                    logger.debug("Skipping shared Codex clear for %s; shared token already rotated", reason)
+                    return
+            try:
+                path.unlink()
+            except FileNotFoundError:
+                pass
+    except Exception as exc:
+        logger.debug("Failed to clear shared Codex auth store: %s", exc)
+
+
+def _codex_pool_entry_usable_for_promotion(entry: Any) -> bool:
+    if not isinstance(entry, dict):
+        return False
+    if not _codex_tokens_usable(entry):
+        return False
+    if entry.get("last_status") == "exhausted":
+        # Do not promote a credential the runtime has already marked bad.  A
+        # rate-limit marker means the account is still valid, but promoting it
+        # would not restore availability; the quota path should stay explicit.
+        return False
+    source = str(entry.get("source") or "").strip()
+    return source in {"device_code", "manual:device_code"}
+
+
+def _codex_pool_entry_last_refresh(entry: Dict[str, Any]) -> float:
+    return (
+        _parse_iso_timestamp(entry.get("last_refresh"))
+        or _parse_iso_timestamp(entry.get("updated_at"))
+        or 0.0
+    )
+
+
+def _latest_codex_pool_state(auth_store: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+    pool = auth_store.get("credential_pool") if isinstance(auth_store, dict) else None
+    entries = pool.get("openai-codex") if isinstance(pool, dict) else None
+    if not isinstance(entries, list):
+        return None
+    usable = [entry for entry in entries if _codex_pool_entry_usable_for_promotion(entry)]
+    if not usable:
+        return None
+    entry = max(
+        usable,
+        key=lambda e: (
+            _codex_pool_entry_last_refresh(e),
+            int(e.get("priority") or 0),
+            str(e.get("id") or ""),
+        ),
+    )
+    last_refresh = entry.get("last_refresh") or datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+    tokens = {
+        "access_token": str(entry.get("access_token") or ""),
+        "refresh_token": str(entry.get("refresh_token") or ""),
+    }
+    if entry.get("token_type"):
+        tokens["token_type"] = entry.get("token_type")
+    state: Dict[str, Any] = {
+        "tokens": tokens,
+        "last_refresh": last_refresh,
+        "auth_mode": "chatgpt",
+    }
+    if entry.get("label"):
+        state["label"] = entry.get("label")
+    return state
+
+
+def _codex_state_refresh_token(state: Any) -> str:
+    tokens = state.get("tokens") if isinstance(state, dict) else None
+    if not isinstance(tokens, dict):
+        return ""
+    return str(tokens.get("refresh_token") or "").strip()
+
+
+def _codex_state_last_refresh(state: Any) -> float:
+    if not isinstance(state, dict):
+        return 0.0
+    return (
+        _parse_iso_timestamp(state.get("last_refresh"))
+        or _parse_iso_timestamp(state.get("updated_at"))
+        or 0.0
+    )
+
+
+def _codex_pool_state_should_promote(candidate: Optional[Dict[str, Any]], *states: Any) -> bool:
+    if not candidate or not _codex_tokens_usable(candidate.get("tokens")):
+        return False
+    candidate_refresh = _codex_state_refresh_token(candidate)
+    candidate_last = _codex_state_last_refresh(candidate)
+    saw_usable_state = False
+    for state in states:
+        tokens = state.get("tokens") if isinstance(state, dict) else None
+        if not _codex_tokens_usable(tokens):
+            continue
+        saw_usable_state = True
+        if candidate_refresh and candidate_refresh == _codex_state_refresh_token(state):
+            return False
+        state_last = _codex_state_last_refresh(state)
+        if candidate_last and state_last and candidate_last <= state_last:
+            return False
+    return True if saw_usable_state else True
+
+
+def _reconcile_codex_pool_to_shared(auth_store: Dict[str, Any]) -> bool:
+    """Promote a newer usable Codex pool credential into the canonical chain.
+
+    This closes the gap where ``hermes auth add openai-codex`` or a pool-level
+    recovery writes a fresh ``credential_pool.openai-codex`` entry but leaves
+    ``providers.openai-codex`` and ``shared/codex_auth.json`` on an older
+    rotating refresh-token chain.  The function mutates ``auth_store`` and
+    writes the shared store; callers remain responsible for saving auth_store.
+    """
+    candidates = []
+    local_candidate = _latest_codex_pool_state(auth_store)
+    if local_candidate:
+        candidates.append(local_candidate)
+    global_store = _load_global_auth_store()
+    global_candidate = _latest_codex_pool_state(global_store) if global_store else None
+    if global_candidate:
+        candidates.append(global_candidate)
+    if not candidates:
+        return False
+    candidate = max(candidates, key=_codex_state_last_refresh)
+
+    providers = auth_store.get("providers") if isinstance(auth_store, dict) else None
+    local_state = providers.get("openai-codex") if isinstance(providers, dict) else None
+    effective_state = _load_provider_state(auth_store, "openai-codex") or local_state or {}
+    shared_state = _read_shared_codex_state() or {}
+    if not _codex_pool_state_should_promote(candidate, effective_state, shared_state):
+        return False
+
+    tokens = dict(candidate["tokens"])
+    last_refresh = candidate.get("last_refresh")
+    label = candidate.get("label")
+    previous_tokens = None
+    if isinstance(local_state, dict) and isinstance(local_state.get("tokens"), dict):
+        previous_tokens = local_state.get("tokens")
+    state = dict(local_state or {})
+    state["tokens"] = tokens
+    state["last_refresh"] = last_refresh
+    state["auth_mode"] = "chatgpt"
+    if label:
+        state["label"] = label
+    _save_provider_state(auth_store, "openai-codex", state)
+    _sync_codex_pool_entries(
+        auth_store,
+        tokens,
+        last_refresh,
+        previous_singleton_tokens=previous_tokens,
+    )
+    _write_shared_codex_state(tokens, last_refresh=last_refresh, label=label)
+    logger.info("Codex auth reconciled newer credential_pool token into shared store")
+    return True
+
+
 def _read_codex_tokens(*, _lock: bool = True) -> Dict[str, Any]:
-    """Read Codex OAuth tokens from Hermes auth store (~/.hermes/auth.json).
+    """Read Codex OAuth tokens from Hermes auth store or shared store.
     
     Returns dict with 'tokens' (access_token, refresh_token) and 'last_refresh'.
-    Raises AuthError if no Codex tokens are stored.
+    Profile-local auth.json is a cache; the Hermes-owned shared Codex store is
+    merged first when it holds a fresher rotating refresh-token chain.
     """
     if _lock:
         with _auth_store_lock():
-            auth_store = _load_auth_store()
-    else:
-        auth_store = _load_auth_store()
-    state = _load_provider_state(auth_store, "openai-codex")
+            return _read_codex_tokens(_lock=False)
+
+    auth_store = _load_auth_store()
+    if _reconcile_codex_pool_to_shared(auth_store):
+        _save_auth_store(auth_store)
+
+    state = _load_provider_state(auth_store, "openai-codex") or {}
+    if not isinstance(state, dict):
+        state = {}
+
+    if _merge_shared_codex_state(state):
+        _save_provider_state(auth_store, "openai-codex", state)
+        _save_auth_store(auth_store)
+
     if not state:
         raise AuthError(
             "No Codex credentials stored. Run `hermes auth` to authenticate.",
@@ -3532,6 +3889,7 @@ def _save_codex_tokens(tokens: Dict[str, str], last_refresh: str = None, label: 
             previous_singleton_tokens=previous_singleton_tokens,
         )
         _save_auth_store(auth_store)
+        _write_shared_codex_state(tokens, last_refresh=last_refresh, label=label)
 
 
 def _recover_codex_tokens_from_cli(reason: str) -> Optional[Dict[str, str]]:
@@ -3711,6 +4069,11 @@ def _refresh_codex_auth_tokens(
             f"refresh_token rejected: {getattr(exc, 'code', None) or 'auth_error'}"
         )
         if not imported:
+            if _is_terminal_codex_oauth_refresh_error(exc):
+                _clear_shared_codex_state(
+                    str(getattr(exc, "code", None) or "terminal_refresh_failure"),
+                    expected_refresh_token=str(tokens.get("refresh_token", "") or ""),
+                )
             raise
         return imported
 
@@ -3843,19 +4206,22 @@ def resolve_codex_runtime_credentials(
     if (not should_refresh) and refresh_if_expiring:
         should_refresh = _codex_access_token_is_expiring(access_token, refresh_skew_seconds)
     if should_refresh:
-        # Re-read under lock to avoid racing with other Hermes processes
+        # Re-read under locks to avoid racing with sibling profiles that share
+        # the single-use Codex refresh token. Lock order is profile auth first,
+        # shared Codex second, matching the shared-store invariant above.
         with _auth_store_lock(timeout_seconds=max(float(AUTH_LOCK_TIMEOUT_SECONDS), refresh_timeout_seconds + 5.0)):
-            data = _read_codex_tokens(_lock=False)
-            tokens = dict(data["tokens"])
-            access_token = str(tokens.get("access_token", "") or "").strip()
-
-            should_refresh = bool(force_refresh)
-            if (not should_refresh) and refresh_if_expiring:
-                should_refresh = _codex_access_token_is_expiring(access_token, refresh_skew_seconds)
-
-            if should_refresh:
-                tokens = _refresh_codex_auth_tokens(tokens, refresh_timeout_seconds)
+            with _codex_shared_store_lock(timeout_seconds=max(float(AUTH_LOCK_TIMEOUT_SECONDS), refresh_timeout_seconds + 5.0)):
+                data = _read_codex_tokens(_lock=False)
+                tokens = dict(data["tokens"])
                 access_token = str(tokens.get("access_token", "") or "").strip()
+
+                should_refresh = bool(force_refresh)
+                if (not should_refresh) and refresh_if_expiring:
+                    should_refresh = _codex_access_token_is_expiring(access_token, refresh_skew_seconds)
+
+                if should_refresh:
+                    tokens = _refresh_codex_auth_tokens(tokens, refresh_timeout_seconds)
+                    access_token = str(tokens.get("access_token", "") or "").strip()
 
     base_url = (
         os.getenv("HERMES_CODEX_BASE_URL", "").strip().rstrip("/")

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1260,6 +1260,11 @@ DEFAULT_CONFIG = {
                                       # exact route is affected — gpt-5.5 on OpenAI's
                                       # direct API, OpenRouter, and Copilot keep the
                                       # global threshold regardless.
+        "codex_gpt55_autoraise_notice": True,  # When True (default), show the one-time
+                                      # startup notice that explains the gpt-5.5
+                                      # autoraise and the opt-back-out command. Set to
+                                      # False if you want the 85% threshold lift but
+                                      # prefer to suppress the informational notice.
     },
 
     # Anthropic prompt caching (Claude via OpenRouter or native Anthropic API).

--- a/tests/hermes_cli/test_auth_codex_provider.py
+++ b/tests/hermes_cli/test_auth_codex_provider.py
@@ -16,9 +16,13 @@ from hermes_cli.auth import (
     _save_codex_tokens,
     _import_codex_cli_tokens,
     _login_openai_codex,
+    _read_shared_codex_state,
+    _write_shared_codex_state,
+    _clear_shared_codex_state,
     refresh_codex_oauth_pure,
     resolve_codex_runtime_credentials,
     resolve_provider,
+    write_credential_pool,
 )
 
 
@@ -48,6 +52,11 @@ def _jwt_with_exp(exp_epoch: int) -> str:
     payload = {"exp": exp_epoch}
     encoded = base64.urlsafe_b64encode(json.dumps(payload).encode("utf-8")).rstrip(b"=").decode("utf-8")
     return f"h.{encoded}.s"
+
+
+@pytest.fixture(autouse=True)
+def _isolated_codex_shared_store(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_SHARED_AUTH_DIR", str(tmp_path / "shared-auth"))
 
 
 def test_read_codex_tokens_success(tmp_path, monkeypatch):
@@ -157,7 +166,9 @@ def test_resolve_codex_runtime_credentials_falls_back_to_pool_when_singleton_emp
 
     resolved = resolve_codex_runtime_credentials()
     assert resolved["api_key"] == "pool-fallback-token"
-    assert resolved["source"] == "credential_pool"
+    # Pool-only credentials are now promoted into the Hermes auth store and
+    # shared Codex store before runtime use, preventing future drift.
+    assert resolved["source"] == "hermes-auth-store"
     assert resolved["base_url"]  # default codex backend URL
 
 
@@ -223,15 +234,231 @@ def test_resolve_provider_explicit_codex_does_not_fallback(monkeypatch):
 
 def test_save_codex_tokens_roundtrip(tmp_path, monkeypatch):
     hermes_home = tmp_path / "hermes"
+    shared_dir = tmp_path / "shared"
     hermes_home.mkdir(parents=True, exist_ok=True)
     (hermes_home / "auth.json").write_text(json.dumps({"version": 1, "providers": {}}))
     monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.setenv("HERMES_SHARED_AUTH_DIR", str(shared_dir))
 
     _save_codex_tokens({"access_token": "at123", "refresh_token": "rt456"})
     data = _read_codex_tokens()
 
     assert data["tokens"]["access_token"] == "at123"
     assert data["tokens"]["refresh_token"] == "rt456"
+    shared = _read_shared_codex_state()
+    assert shared["tokens"]["access_token"] == "at123"
+    assert shared["tokens"]["refresh_token"] == "rt456"
+
+
+def test_resolve_codex_runtime_credentials_adopts_fresher_shared_store(tmp_path, monkeypatch):
+    hermes_home = tmp_path / "hermes"
+    shared_dir = tmp_path / "shared"
+    _setup_hermes_auth(hermes_home, access_token="local-at", refresh_token="local-rt")
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.setenv("HERMES_SHARED_AUTH_DIR", str(shared_dir))
+    _write_shared_codex_state(
+        {"access_token": "shared-at", "refresh_token": "shared-rt"},
+        last_refresh="2026-02-27T00:00:00Z",
+    )
+
+    resolved = resolve_codex_runtime_credentials(refresh_if_expiring=False)
+
+    assert resolved["api_key"] == "shared-at"
+    payload = json.loads((hermes_home / "auth.json").read_text())
+    tokens = payload["providers"]["openai-codex"]["tokens"]
+    assert tokens["access_token"] == "shared-at"
+    assert tokens["refresh_token"] == "shared-rt"
+
+
+def test_resolve_codex_runtime_credentials_bootstraps_empty_profile_from_shared_store(tmp_path, monkeypatch):
+    hermes_home = tmp_path / "hermes"
+    shared_dir = tmp_path / "shared"
+    hermes_home.mkdir(parents=True, exist_ok=True)
+    (hermes_home / "auth.json").write_text(json.dumps({"version": 1, "providers": {}}))
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.setenv("HERMES_SHARED_AUTH_DIR", str(shared_dir))
+    _write_shared_codex_state(
+        {"access_token": "shared-at", "refresh_token": "shared-rt"},
+        last_refresh="2026-02-27T00:00:00Z",
+    )
+
+    resolved = resolve_codex_runtime_credentials(refresh_if_expiring=False)
+
+    assert resolved["api_key"] == "shared-at"
+    payload = json.loads((hermes_home / "auth.json").read_text())
+    assert payload["providers"]["openai-codex"]["tokens"]["refresh_token"] == "shared-rt"
+
+
+def test_resolve_codex_runtime_credentials_promotes_newer_global_pool_to_shared(tmp_path, monkeypatch):
+    """Profile runtime should self-heal when root pool is newer than shared store."""
+    root = tmp_path / "hermes"
+    profile = root / "profiles" / "lark-a330"
+    profile.mkdir(parents=True, exist_ok=True)
+    root.mkdir(parents=True, exist_ok=True)
+    shared_dir = tmp_path / "shared"
+    (root / "auth.json").write_text(json.dumps({
+        "version": 1,
+        "providers": {
+            "openai-codex": {
+                "tokens": {"access_token": "old-at", "refresh_token": "old-rt"},
+                "last_refresh": "2026-06-16T15:13:08Z",
+                "auth_mode": "chatgpt",
+            },
+        },
+        "credential_pool": {
+            "openai-codex": [
+                {
+                    "id": "root-new",
+                    "source": "manual:device_code",
+                    "auth_type": "oauth",
+                    "access_token": "new-at",
+                    "refresh_token": "new-rt",
+                    "last_refresh": "2026-06-16T23:29:20Z",
+                    "label": "root@example.test",
+                }
+            ]
+        },
+    }))
+    (profile / "auth.json").write_text(json.dumps({
+        "version": 1,
+        "providers": {
+            "openai-codex": {
+                "tokens": {"access_token": "old-at", "refresh_token": "old-rt"},
+                "last_refresh": "2026-06-16T15:13:08Z",
+                "auth_mode": "chatgpt",
+            },
+        },
+        "credential_pool": {
+            "openai-codex": [
+                {
+                    "id": "profile-old",
+                    "source": "device_code",
+                    "auth_type": "oauth",
+                    "access_token": "old-at",
+                    "refresh_token": "old-rt",
+                    "last_refresh": "2026-06-16T15:13:08Z",
+                    "last_status": "exhausted",
+                    "last_error_code": 401,
+                    "last_error_reason": "token_invalidated",
+                }
+            ]
+        },
+    }))
+    monkeypatch.setenv("HERMES_HOME", str(profile))
+    monkeypatch.setenv("HERMES_SHARED_AUTH_DIR", str(shared_dir))
+    _write_shared_codex_state(
+        {"access_token": "old-at", "refresh_token": "old-rt"},
+        last_refresh="2026-06-16T15:13:08Z",
+    )
+
+    resolved = resolve_codex_runtime_credentials(refresh_if_expiring=False)
+
+    assert resolved["api_key"] == "new-at"
+    profile_auth = json.loads((profile / "auth.json").read_text())
+    profile_state = profile_auth["providers"]["openai-codex"]
+    assert profile_state["tokens"]["refresh_token"] == "new-rt"
+    profile_entry = profile_auth["credential_pool"]["openai-codex"][0]
+    assert profile_entry["access_token"] == "new-at"
+    assert profile_entry["refresh_token"] == "new-rt"
+    assert profile_entry["last_status"] is None
+    assert profile_entry["last_error_code"] is None
+    shared = _read_shared_codex_state()
+    assert shared is not None
+    assert shared["tokens"]["refresh_token"] == "new-rt"
+    assert shared["last_refresh"] == "2026-06-16T23:29:20Z"
+
+
+def test_write_credential_pool_openai_codex_writes_through_shared_store(tmp_path, monkeypatch):
+    """Pool-level re-auth must not leave providers/shared on an older token chain."""
+    hermes_home = tmp_path / "hermes"
+    shared_dir = tmp_path / "shared"
+    _setup_hermes_auth(hermes_home, access_token="old-at", refresh_token="old-rt")
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.setenv("HERMES_SHARED_AUTH_DIR", str(shared_dir))
+    _write_shared_codex_state(
+        {"access_token": "old-at", "refresh_token": "old-rt"},
+        last_refresh="2026-06-16T15:13:08Z",
+    )
+
+    write_credential_pool("openai-codex", [
+        {
+            "id": "pool-new",
+            "source": "manual:device_code",
+            "auth_type": "oauth",
+            "access_token": "new-at",
+            "refresh_token": "new-rt",
+            "last_refresh": "2026-06-16T23:29:20Z",
+            "label": "root@example.test",
+        }
+    ])
+
+    auth = json.loads((hermes_home / "auth.json").read_text())
+    assert auth["providers"]["openai-codex"]["tokens"]["access_token"] == "new-at"
+    assert auth["providers"]["openai-codex"]["tokens"]["refresh_token"] == "new-rt"
+    shared = _read_shared_codex_state()
+    assert shared is not None
+    assert shared["tokens"]["access_token"] == "new-at"
+    assert shared["tokens"]["refresh_token"] == "new-rt"
+
+
+def test_resolve_codex_runtime_credentials_refresh_writes_shared_store(tmp_path, monkeypatch):
+    hermes_home = tmp_path / "hermes"
+    shared_dir = tmp_path / "shared"
+    expiring_token = _jwt_with_exp(int(time.time()) - 10)
+    _setup_hermes_auth(hermes_home, access_token=expiring_token, refresh_token="refresh-old")
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.setenv("HERMES_SHARED_AUTH_DIR", str(shared_dir))
+
+    def _fake_refresh(access_token, refresh_token, *, timeout_seconds=20.0):
+        assert refresh_token == "refresh-old"
+        return {"access_token": "access-new", "refresh_token": "refresh-new"}
+
+    monkeypatch.setattr("hermes_cli.auth.refresh_codex_oauth_pure", _fake_refresh)
+
+    resolved = resolve_codex_runtime_credentials()
+
+    assert resolved["api_key"] == "access-new"
+    shared = _read_shared_codex_state()
+    assert shared["tokens"]["refresh_token"] == "refresh-new"
+    payload = json.loads((hermes_home / "auth.json").read_text())
+    assert payload["providers"]["openai-codex"]["tokens"]["refresh_token"] == "refresh-new"
+
+
+def test_codex_refresh_429_does_not_clear_shared_store(tmp_path, monkeypatch):
+    hermes_home = tmp_path / "hermes"
+    shared_dir = tmp_path / "shared"
+    _setup_hermes_auth(hermes_home, access_token="access", refresh_token="refresh-old")
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.setenv("HERMES_SHARED_AUTH_DIR", str(shared_dir))
+    _write_shared_codex_state({"access_token": "access", "refresh_token": "refresh-old"})
+
+    def _rate_limited(*args, **kwargs):
+        raise AuthError(
+            "rate limited",
+            provider="openai-codex",
+            code="codex_rate_limited",
+            relogin_required=False,
+        )
+
+    monkeypatch.setattr("hermes_cli.auth.refresh_codex_oauth_pure", _rate_limited)
+
+    with pytest.raises(AuthError) as exc:
+        resolve_codex_runtime_credentials(force_refresh=True, refresh_if_expiring=False)
+
+    assert exc.value.code == "codex_rate_limited"
+    assert _read_shared_codex_state()["tokens"]["refresh_token"] == "refresh-old"
+
+
+def test_clear_shared_codex_state_is_compare_and_clear(tmp_path, monkeypatch):
+    shared_dir = tmp_path / "shared"
+    monkeypatch.setenv("HERMES_SHARED_AUTH_DIR", str(shared_dir))
+    _write_shared_codex_state({"access_token": "new-at", "refresh_token": "new-rt"})
+
+    _clear_shared_codex_state("stale_failure", expected_refresh_token="old-rt")
+    assert _read_shared_codex_state()["tokens"]["refresh_token"] == "new-rt"
+
+    _clear_shared_codex_state("matching_failure", expected_refresh_token="new-rt")
+    assert _read_shared_codex_state() is None
 
 
 def test_save_codex_tokens_syncs_credential_pool(tmp_path, monkeypatch):

--- a/tests/hermes_cli/test_auth_codex_self_heal.py
+++ b/tests/hermes_cli/test_auth_codex_self_heal.py
@@ -20,6 +20,11 @@ from hermes_cli.auth import AuthError, _refresh_codex_auth_tokens, resolve_codex
 STALE = {"access_token": "stale-access", "refresh_token": "stale-refresh"}
 
 
+@pytest.fixture(autouse=True)
+def _isolated_codex_shared_store(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_SHARED_AUTH_DIR", str(tmp_path / "shared-auth"))
+
+
 def test_self_heals_on_stale_refresh_token(monkeypatch):
     """invalid_grant (relogin-required) → reimport from ~/.codex and persist it."""
     saved = {}

--- a/tests/hermes_cli/test_auth_xai_oauth_provider.py
+++ b/tests/hermes_cli/test_auth_xai_oauth_provider.py
@@ -1889,6 +1889,237 @@ def test_pool_manual_entry_does_not_sync_back_to_singleton(tmp_path, monkeypatch
 
 
 # ---------------------------------------------------------------------------
+# Shared xAI OAuth store across named profiles
+# ---------------------------------------------------------------------------
+
+
+def test_save_xai_oauth_tokens_writes_shared_store_not_profile_token_copy(tmp_path, monkeypatch):
+    """xAI OAuth refresh tokens rotate, so named profiles must not each keep
+    their own long-lived copy.  Saving a login/refresh should update the
+    cross-profile shared store and leave only non-secret profile metadata in
+    auth.json."""
+    from hermes_cli.auth import _save_xai_oauth_tokens
+
+    hermes_home = tmp_path / "hermes" / "profiles" / "lark-a"
+    shared_dir = tmp_path / "hermes" / "shared"
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.setenv("HERMES_SHARED_AUTH_DIR", str(shared_dir))
+
+    tokens = {
+        "access_token": "AT-shared",
+        "refresh_token": "RT-shared",
+        "id_token": "ID-shared",
+        "expires_in": 3600,
+        "token_type": "Bearer",
+    }
+    discovery = {"token_endpoint": "https://auth.x.ai/oauth2/token"}
+    _save_xai_oauth_tokens(
+        tokens,
+        discovery=discovery,
+        redirect_uri="http://127.0.0.1:56121/callback",
+        last_refresh="2026-06-02T00:00:00Z",
+    )
+
+    shared = json.loads((shared_dir / "xai_oauth.json").read_text())
+    assert shared["tokens"] == tokens
+    assert shared["discovery"] == discovery
+    assert shared["redirect_uri"] == "http://127.0.0.1:56121/callback"
+    assert shared["last_refresh"] == "2026-06-02T00:00:00Z"
+
+    profile_auth = json.loads((hermes_home / "auth.json").read_text())
+    profile_state = profile_auth["providers"]["xai-oauth"]
+    assert profile_auth["active_provider"] == "xai-oauth"
+    assert profile_state["auth_mode"] == "oauth_pkce"
+    assert profile_state.get("shared_store") == "xai_oauth.json"
+    assert "tokens" not in profile_state
+
+
+def test_read_xai_oauth_tokens_uses_shared_store_when_profile_has_no_copy(tmp_path, monkeypatch):
+    """A newly spawned profile with no local xAI token copy should still be
+    usable when the shared xAI OAuth store exists."""
+    from hermes_cli.auth import _read_xai_oauth_tokens
+
+    hermes_home = tmp_path / "hermes" / "profiles" / "lark-b"
+    shared_dir = tmp_path / "hermes" / "shared"
+    hermes_home.mkdir(parents=True)
+    shared_dir.mkdir(parents=True)
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.setenv("HERMES_SHARED_AUTH_DIR", str(shared_dir))
+
+    shared_payload = {
+        "_schema": 1,
+        "tokens": {
+            "access_token": "AT-from-shared",
+            "refresh_token": "RT-from-shared",
+            "expires_in": 3600,
+            "token_type": "Bearer",
+        },
+        "discovery": {"token_endpoint": "https://auth.x.ai/oauth2/token"},
+        "redirect_uri": "http://127.0.0.1:56121/callback",
+        "last_refresh": "2026-06-02T01:00:00Z",
+    }
+    (shared_dir / "xai_oauth.json").write_text(json.dumps(shared_payload))
+    (hermes_home / "auth.json").write_text(json.dumps({"version": 1, "providers": {}}))
+
+    data = _read_xai_oauth_tokens()
+    assert data["tokens"]["access_token"] == "AT-from-shared"
+    assert data["tokens"]["refresh_token"] == "RT-from-shared"
+    assert data["discovery"]["token_endpoint"] == "https://auth.x.ai/oauth2/token"
+    assert data["redirect_uri"] == "http://127.0.0.1:56121/callback"
+
+
+def test_xai_oauth_runtime_refresh_rotates_shared_store_not_profile_copy(tmp_path, monkeypatch):
+    """When one profile refreshes xAI OAuth, the rotated refresh_token must be
+    written to the same shared file all profiles read.  Otherwise sibling
+    profiles keep replaying a revoked refresh token."""
+    from hermes_cli.auth import resolve_xai_oauth_runtime_credentials
+
+    hermes_home = tmp_path / "hermes" / "profiles" / "lark-c"
+    shared_dir = tmp_path / "hermes" / "shared"
+    hermes_home.mkdir(parents=True)
+    shared_dir.mkdir(parents=True)
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.setenv("HERMES_SHARED_AUTH_DIR", str(shared_dir))
+
+    old_access = _jwt_with_exp(int(time.time()) - 60)
+    new_access = _jwt_with_exp(int(time.time()) + 3600)
+    (shared_dir / "xai_oauth.json").write_text(json.dumps({
+        "_schema": 1,
+        "tokens": {
+            "access_token": old_access,
+            "refresh_token": "RT-old",
+            "expires_in": 3600,
+            "token_type": "Bearer",
+        },
+        "discovery": {"token_endpoint": "https://auth.x.ai/oauth2/token"},
+        "last_refresh": "2026-06-02T01:00:00Z",
+    }))
+    (hermes_home / "auth.json").write_text(json.dumps({"version": 1, "providers": {}}))
+
+    def _fake_refresh(access_token, refresh_token, **kwargs):
+        assert access_token == old_access
+        assert refresh_token == "RT-old"
+        return {
+            "access_token": new_access,
+            "refresh_token": "RT-rotated",
+            "id_token": "",
+            "expires_in": 3600,
+            "token_type": "Bearer",
+            "last_refresh": "2026-06-02T02:00:00Z",
+        }
+
+    monkeypatch.setattr("hermes_cli.auth.refresh_xai_oauth_pure", _fake_refresh)
+
+    creds = resolve_xai_oauth_runtime_credentials(force_refresh=True)
+    assert creds["api_key"] == new_access
+
+    shared_after = json.loads((shared_dir / "xai_oauth.json").read_text())
+    assert shared_after["tokens"]["access_token"] == new_access
+    assert shared_after["tokens"]["refresh_token"] == "RT-rotated"
+    assert shared_after["last_refresh"] == "2026-06-02T02:00:00Z"
+
+    profile_auth = json.loads((hermes_home / "auth.json").read_text())
+    assert "xai-oauth" not in profile_auth.get("providers", {}) or "tokens" not in profile_auth["providers"]["xai-oauth"]
+
+
+def test_xai_oauth_runtime_refresh_holds_shared_lock_across_rotation(tmp_path, monkeypatch):
+    """Shared xAI refresh must be serialized across profiles while spending the
+    rotating refresh_token; locking only the profile-local auth.json is not enough."""
+    from contextlib import contextmanager
+
+    from hermes_cli.auth import resolve_xai_oauth_runtime_credentials
+
+    hermes_home = tmp_path / "hermes" / "profiles" / "lark-d"
+    shared_dir = tmp_path / "hermes" / "shared"
+    hermes_home.mkdir(parents=True)
+    shared_dir.mkdir(parents=True)
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.setenv("HERMES_SHARED_AUTH_DIR", str(shared_dir))
+
+    old_access = _jwt_with_exp(int(time.time()) - 60)
+    new_access = _jwt_with_exp(int(time.time()) + 3600)
+    (shared_dir / "xai_oauth.json").write_text(json.dumps({
+        "_schema": 1,
+        "tokens": {
+            "access_token": old_access,
+            "refresh_token": "RT-old",
+            "expires_in": 3600,
+            "token_type": "Bearer",
+        },
+        "discovery": {"token_endpoint": "https://auth.x.ai/oauth2/token"},
+        "last_refresh": "2026-06-02T01:00:00Z",
+    }))
+    (hermes_home / "auth.json").write_text(json.dumps({"version": 1, "providers": {}}))
+
+    lock_depth = {"value": 0}
+
+    @contextmanager
+    def _recording_shared_lock(*args, **kwargs):
+        lock_depth["value"] += 1
+        try:
+            yield
+        finally:
+            lock_depth["value"] -= 1
+
+    def _fake_refresh(access_token, refresh_token, **kwargs):
+        assert refresh_token == "RT-old"
+        assert lock_depth["value"] > 0
+        return {
+            "access_token": new_access,
+            "refresh_token": "RT-rotated",
+            "id_token": "",
+            "expires_in": 3600,
+            "token_type": "Bearer",
+            "last_refresh": "2026-06-02T02:00:00Z",
+        }
+
+    monkeypatch.setattr("hermes_cli.auth._xai_shared_store_lock", _recording_shared_lock)
+    monkeypatch.setattr("hermes_cli.auth.refresh_xai_oauth_pure", _fake_refresh)
+
+    creds = resolve_xai_oauth_runtime_credentials(force_refresh=True)
+    assert creds["api_key"] == new_access
+
+
+def test_xai_oauth_terminal_refresh_failure_does_not_clear_rotated_shared_store(tmp_path, monkeypatch):
+    """A stale loser in a refresh-token race must not delete the fresh shared
+    chain another profile already wrote."""
+    from hermes_cli.auth import _clear_shared_xai_oauth_state
+
+    hermes_home = tmp_path / "hermes" / "profiles" / "lark-e"
+    shared_dir = tmp_path / "hermes" / "shared"
+    hermes_home.mkdir(parents=True)
+    shared_dir.mkdir(parents=True)
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.setenv("HERMES_SHARED_AUTH_DIR", str(shared_dir))
+
+    shared_path = shared_dir / "xai_oauth.json"
+    shared_path.write_text(json.dumps({
+        "_schema": 1,
+        "tokens": {
+            "access_token": "AT-fresh",
+            "refresh_token": "RT-fresh",
+            "expires_in": 3600,
+            "token_type": "Bearer",
+        },
+        "discovery": {"token_endpoint": "https://auth.x.ai/oauth2/token"},
+        "last_refresh": "2026-06-02T02:00:00Z",
+    }))
+
+    _clear_shared_xai_oauth_state(
+        "runtime_refresh_failure",
+        expected_refresh_token="RT-stale",
+    )
+    assert shared_path.exists()
+    assert json.loads(shared_path.read_text())["tokens"]["refresh_token"] == "RT-fresh"
+
+    _clear_shared_xai_oauth_state(
+        "runtime_refresh_failure",
+        expected_refresh_token="RT-fresh",
+    )
+    assert not shared_path.exists()
+
+
+# ---------------------------------------------------------------------------
 # Auxiliary client routing
 # ---------------------------------------------------------------------------
 

--- a/website/docs/guides/xai-grok-oauth.md
+++ b/website/docs/guides/xai-grok-oauth.md
@@ -53,7 +53,7 @@ hermes model
 hermes
 ```
 
-After the first login, credentials are stored under `~/.hermes/auth.json` and refreshed automatically before they expire.
+After the first login, credentials are refreshed automatically before they expire. Classic single-home installs store them under `~/.hermes/auth.json`; named profiles under `~/.hermes/profiles/<name>/` use a shared `~/.hermes/shared/xai_oauth.json` token store so all profiles see the same rotated refresh token.
 
 ## Logging In Manually
 
@@ -100,7 +100,7 @@ If the consent page renders the authorization code directly on the page (xAI's c
 
 1. Hermes opens your browser to `accounts.x.ai`.
 2. You sign in (or confirm your existing session) and approve access.
-3. xAI redirects back to Hermes and the tokens are saved to `~/.hermes/auth.json`.
+3. xAI redirects back to Hermes and the tokens are saved. In classic mode they live in the current Hermes `auth.json`; in named profile mode the refreshable token state lives in the cross-profile `shared/xai_oauth.json` store and the profile keeps only a non-secret marker.
 4. From then on, Hermes refreshes the access token in the background — you stay signed in until you `hermes auth remove xai-oauth` or revoke access from your xAI account settings.
 
 ## Checking Login Status


### PR DESCRIPTION
## Summary
- add a Hermes-owned shared OAuth store for OpenAI Codex tokens so named profiles import and refresh the same canonical ChatGPT token chain
- add shared xAI OAuth store handling for named profiles, including serialized refresh-token rotation and compare-and-clear protection on terminal refresh failures
- route xAI OAuth runtime credentials through the shared store and add regression coverage for cross-profile refresh behavior

## Tests
- `python -m py_compile agent/agent_init.py agent/credential_pool.py hermes_cli/auth.py hermes_cli/config.py`
- `python -m pytest tests/hermes_cli/test_auth_codex_provider.py tests/hermes_cli/test_auth_codex_self_heal.py tests/hermes_cli/test_auth_xai_oauth_provider.py tests/agent/test_credential_pool.py tests/agent/test_credential_pool_routing.py tests/tools/test_credential_pool_env_fallback.py -o 'addopts=' -q`
