### PR TITLE
fix(gateway): guard bare int(os.getenv) casts with env_int

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -53,6 +53,7 @@ except ImportError:
     web = None  # type: ignore[assignment]
 
 from gateway.config import Platform, PlatformConfig
+from utils import env_int
 from gateway.platforms.base import (
     BasePlatformAdapter,
     SendResult,
@@ -1043,7 +1044,7 @@ class APIServerAdapter(BasePlatformAdapter):
         user_config = _load_gateway_config()
         enabled_toolsets = sorted(_get_platform_tools(user_config, "api_server"))
 
-        max_iterations = int(os.getenv("HERMES_MAX_ITERATIONS", "90"))
+        max_iterations = env_int("HERMES_MAX_ITERATIONS", 90)
 
         # Load fallback provider chain so the API server platform has the
         # same fallback behaviour as Telegram/Discord/Slack (fixes #4954).

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1155,7 +1155,7 @@ sys.path.insert(0, str(Path(__file__).parent.parent))
 
 # Resolve Hermes home directory (respects HERMES_HOME override)
 from hermes_constants import get_hermes_home
-from utils import atomic_json_write, atomic_yaml_write, base_url_host_matches, is_truthy_value
+from utils import atomic_json_write, atomic_yaml_write, base_url_host_matches, env_int, is_truthy_value
 _hermes_home = get_hermes_home()
 
 # Load environment variables from ~/.hermes/.env first.
@@ -10632,7 +10632,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             disabled_toolsets = agent_cfg.get("disabled_toolsets") or None
 
             pr = self._provider_routing
-            max_iterations = int(os.getenv("HERMES_MAX_ITERATIONS", "90"))
+            max_iterations = env_int("HERMES_MAX_ITERATIONS", 90)
             reasoning_config = self._resolve_session_reasoning_config(source=source)
             self._reasoning_config = reasoning_config
             self._service_tier = self._load_service_tier()
@@ -14582,7 +14582,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             os.environ["HERMES_SESSION_KEY"] = session_key or ""
 
             # Read from env var or use default (same as CLI)
-            max_iterations = int(os.getenv("HERMES_MAX_ITERATIONS", "90"))
+            max_iterations = env_int("HERMES_MAX_ITERATIONS", 90)
             
             # Map platform enum to the platform hint key the agent understands.
             # Platform.LOCAL ("local") maps to "cli"; others pass through as-is.

--- a/utils.py
+++ b/utils.py
@@ -323,6 +323,17 @@ def env_int(key: str, default: int = 0) -> int:
         return default
 
 
+def env_float(key: str, default: float = 0.0) -> float:
+    """Read an environment variable as a float, with fallback."""
+    raw = os.getenv(key, "").strip()
+    if not raw:
+        return default
+    try:
+        return float(raw)
+    except (ValueError, TypeError):
+        return default
+
+
 def env_bool(key: str, default: bool = False) -> bool:
     """Read an environment variable as a boolean."""
     return is_truthy_value(os.getenv(key, ""), default=default)


### PR DESCRIPTION
## Summary

Bare `int(os.getenv(...))` calls crash the gateway with `ValueError` when an environment variable contains a non-numeric string (e.g. `HERMES_MAX_ITERATIONS=abc`). Replace with `env_int()` from `utils.py` which catches `ValueError`/`TypeError` and falls back to the default.

Also adds `env_float()` to `utils.py` as a companion to the existing `env_int()` and `env_bool()` helpers.

## Changes

- **utils.py**: Add `env_float(key, default)` helper
- **gateway/run.py**: Replace 2 bare `int(os.getenv("HERMES_MAX_ITERATIONS", "90"))` with `env_int("HERMES_MAX_ITERATIONS", 90)`
- **gateway/platforms/api_server.py**: Replace 1 bare `int(os.getenv("HERMES_MAX_ITERATIONS", "90"))` with `env_int("HERMES_MAX_ITERATIONS", 90)`

## Test Plan

- [x] `python -m pytest tests/ -x --no-header -q` passes
- [x] `env_int("NONEXISTENT", 90)` returns 90
- [x] `env_int()` with invalid value returns default (not ValueError)
- [x] `env_float()` added as companion to env_int
