### PR TITLE
fix(goal): keep goals across session lineage

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1361,6 +1361,15 @@ DEFAULT_CONFIG = {
             "timeout": 120,        # seconds — compression summarises large contexts; increase for local models
             "extra_body": {},
         },
+        "goal_judge": {
+            "provider": "auto",
+            "model": "",
+            "base_url": "",
+            "api_key": "",
+            "timeout": 30,
+            "extra_body": {},
+            "max_tokens": 4096,
+        },
         # Note: session_search no longer uses an auxiliary LLM (PR #27590 —
         # single-shape tool returns DB content directly). The old
         # ``auxiliary.session_search.*`` block was removed here. Existing

--- a/hermes_cli/goals.py
+++ b/hermes_cli/goals.py
@@ -7,8 +7,9 @@ continuation prompt back into the same session and keeps working until the
 goal is done, turn budget is exhausted, the user pauses/clears it, or the
 user sends a new message (which takes priority and pauses the goal loop).
 
-State is persisted in SessionDB's ``state_meta`` table keyed by
-``goal:<session_id>`` so ``/resume`` picks it up.
+State is persisted in SessionDB's ``state_meta`` table keyed by the
+conversation lineage root (``goal:<root_session_id>``) so ``/resume``,
+compression continuations, and branch tips in the same thread pick it up.
 
 Design notes / invariants:
 
@@ -236,6 +237,91 @@ def _get_session_db() -> Optional[Any]:
     return db
 
 
+def _goal_lineage_ids(db: Any, session_id: str) -> List[str]:
+    """Return session ids from current tip to lineage root."""
+    sid = (session_id or "").strip()
+    if not sid:
+        return []
+
+    current = sid
+    lineage = [sid]
+    seen = {sid}
+    for _ in range(100):
+        try:
+            row = db.get_session(current)
+        except Exception as exc:
+            logger.debug("GoalManager: lineage lookup failed for %s: %s", current, exc)
+            return lineage
+        if not row:
+            return lineage
+        if _session_has_model_config_marker(row, "_delegate_from"):
+            return lineage
+        parent = str(row.get("parent_session_id") or "").strip()
+        if not parent or parent in seen:
+            return lineage
+        seen.add(parent)
+        lineage.append(parent)
+        current = parent
+
+    return lineage
+
+
+def _session_has_model_config_marker(row: Dict[str, Any], marker: str) -> bool:
+    raw = row.get("model_config")
+    if isinstance(raw, dict):
+        return bool(raw.get(marker))
+    if not raw:
+        return False
+    try:
+        parsed = json.loads(raw)
+    except Exception:
+        return False
+    return isinstance(parsed, dict) and bool(parsed.get(marker))
+
+
+def goal_storage_id(session_id: str) -> str:
+    """Return the stable state_meta id for a session's visible thread.
+
+    Live session ids can rotate during compression and branch/fork flows create
+    child rows. Users experience those rows as one conversation thread when they
+    share a parent chain, so goal state is stored on the parent-chain root.
+    """
+    sid = (session_id or "").strip()
+    if not sid:
+        return ""
+    db = _get_session_db()
+    if db is None:
+        return sid
+
+    lineage = _goal_lineage_ids(db, sid)
+    return lineage[-1] if lineage else sid
+
+
+def _goal_state_timestamp(state: GoalState) -> float:
+    return max(float(state.last_turn_at or 0.0), float(state.created_at or 0.0))
+
+
+def _select_goal_candidate(candidates: List[Tuple[float, int, str, GoalState]]) -> Tuple[str, GoalState]:
+    """Choose the goal state that should represent this visible thread.
+
+    New writes live on the lineage root. Legacy rows may still exist on any
+    tip/parent session from before thread-bound goals. A root active/paused
+    state is canonical, but a root terminal state must not hide a nearer active
+    legacy goal: that is the exact compression/branch failure this migration is
+    meant to repair.
+    """
+    root = candidates[-1]
+    if root[3].status in {"active", "paused"}:
+        return root[2], root[3]
+
+    for _, _, key, state in candidates:
+        if state.status in {"active", "paused"}:
+            return key, state
+
+    _, _, key, state = max(candidates, key=lambda item: (item[0], item[1]))
+    return key, state
+
+
 def load_goal(session_id: str) -> Optional[GoalState]:
     """Load the goal for a session, or None if none exists."""
     if not session_id:
@@ -243,18 +329,36 @@ def load_goal(session_id: str) -> Optional[GoalState]:
     db = _get_session_db()
     if db is None:
         return None
+    lineage = _goal_lineage_ids(db, session_id) or [session_id]
+    storage_id = lineage[-1]
+    keys = [_meta_key(sid) for sid in lineage]
+
+    candidates: List[Tuple[float, int, str, GoalState]] = []
     try:
-        raw = db.get_meta(_meta_key(session_id))
+        for index, key in enumerate(keys):
+            raw = db.get_meta(key)
+            if not raw:
+                continue
+            try:
+                state = GoalState.from_json(raw)
+            except Exception as exc:
+                logger.warning("GoalManager: could not parse stored goal for %s: %s", session_id, exc)
+                continue
+            candidates.append((_goal_state_timestamp(state), -index, key, state))
     except Exception as exc:
         logger.debug("GoalManager: get_meta failed: %s", exc)
         return None
-    if not raw:
+    if not candidates:
         return None
-    try:
-        return GoalState.from_json(raw)
-    except Exception as exc:
-        logger.warning("GoalManager: could not parse stored goal for %s: %s", session_id, exc)
-        return None
+
+    loaded_from_key, state = _select_goal_candidate(candidates)
+    root_key = _meta_key(storage_id)
+    if storage_id and loaded_from_key != root_key:
+        try:
+            db.set_meta(root_key, state.to_json())
+        except Exception as exc:
+            logger.debug("GoalManager: goal lineage migration failed: %s", exc)
+    return state
 
 
 def save_goal(session_id: str, state: GoalState) -> None:
@@ -265,7 +369,7 @@ def save_goal(session_id: str, state: GoalState) -> None:
     if db is None:
         return
     try:
-        db.set_meta(_meta_key(session_id), state.to_json())
+        db.set_meta(_meta_key(goal_storage_id(session_id)), state.to_json())
     except Exception as exc:
         logger.debug("GoalManager: set_meta failed: %s", exc)
 
@@ -276,6 +380,7 @@ def clear_goal(session_id: str) -> None:
     if state is None:
         return
     state.status = "cleared"
+    state.last_turn_at = time.time()
     save_goal(session_id, state)
 
 
@@ -539,6 +644,7 @@ class GoalManager:
         if not self._state:
             return None
         self._state.status = "paused"
+        self._state.last_turn_at = time.time()
         self._state.paused_reason = reason
         save_goal(self.session_id, self._state)
         return self._state
@@ -547,6 +653,7 @@ class GoalManager:
         if not self._state:
             return None
         self._state.status = "active"
+        self._state.last_turn_at = time.time()
         self._state.paused_reason = None
         if reset_budget:
             self._state.turns_used = 0
@@ -557,6 +664,7 @@ class GoalManager:
         if self._state is None:
             return
         self._state.status = "cleared"
+        self._state.last_turn_at = time.time()
         save_goal(self.session_id, self._state)
         self._state = None
 
@@ -564,6 +672,7 @@ class GoalManager:
         if not self._state:
             return
         self._state.status = "done"
+        self._state.last_turn_at = time.time()
         self._state.last_verdict = "done"
         self._state.last_reason = reason
         save_goal(self.session_id, self._state)
@@ -582,6 +691,7 @@ class GoalManager:
         if not text:
             raise ValueError("subgoal text is empty")
         self._state.subgoals.append(text)
+        self._state.last_turn_at = time.time()
         save_goal(self.session_id, self._state)
         return text
 
@@ -595,6 +705,7 @@ class GoalManager:
                 f"index out of range (1..{len(self._state.subgoals)})"
             )
         removed = self._state.subgoals.pop(idx)
+        self._state.last_turn_at = time.time()
         save_goal(self.session_id, self._state)
         return removed
 
@@ -604,6 +715,7 @@ class GoalManager:
             raise RuntimeError("no active goal")
         prev = len(self._state.subgoals)
         self._state.subgoals = []
+        self._state.last_turn_at = time.time()
         save_goal(self.session_id, self._state)
         return prev
 
@@ -702,8 +814,8 @@ class GoalManager:
                     "model in ~/.hermes/config.yaml:\n"
                     "  auxiliary:\n"
                     "    goal_judge:\n"
-                    "      provider: openrouter\n"
-                    "      model: google/gemini-3-flash-preview\n"
+                    "      provider: opencode-go\n"
+                    "      model: deepseek-v4-flash\n"
                     "Then /goal resume to continue."
                 ),
             }

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -103,6 +103,46 @@ def _delete_delegate_children(conn, parent_ids: List[str]) -> List[str]:
         conn.execute(f"DELETE FROM sessions WHERE id IN ({ph})", ids)
     return ids
 
+
+def _migrate_goal_meta_to_orphaned_children(
+    conn,
+    parent_ids: List[str],
+    *,
+    exclude_ids: Optional[List[str]] = None,
+) -> None:
+    """Copy ``goal:<parent>`` state to child rows that are about to be orphaned."""
+    parents = [sid for sid in parent_ids if sid]
+    if not parents:
+        return
+    excluded = {sid for sid in (exclude_ids or []) if sid}
+    ph = ",".join("?" * len(parents))
+    rows = conn.execute(
+        f"SELECT id, parent_session_id FROM sessions WHERE parent_session_id IN ({ph})",
+        parents,
+    ).fetchall()
+    for row in rows:
+        child_id = row["id"]
+        if child_id in excluded:
+            continue
+        parent_id = row["parent_session_id"]
+        parent_goal = conn.execute(
+            "SELECT value FROM state_meta WHERE key = ?",
+            (f"goal:{parent_id}",),
+        ).fetchone()
+        if parent_goal is None:
+            continue
+        child_key = f"goal:{child_id}"
+        child_goal = conn.execute(
+            "SELECT 1 FROM state_meta WHERE key = ?",
+            (child_key,),
+        ).fetchone()
+        if child_goal is not None:
+            continue
+        conn.execute(
+            "INSERT INTO state_meta (key, value) VALUES (?, ?)",
+            (child_key, parent_goal["value"]),
+        )
+
 T = TypeVar("T")
 
 DEFAULT_DB_PATH = get_hermes_home() / "state.db"
@@ -3801,6 +3841,11 @@ class SessionDB:
             if cursor.fetchone()[0] == 0:
                 return False
             removed_delegate_ids.extend(_delete_delegate_children(conn, [session_id]))
+            _migrate_goal_meta_to_orphaned_children(
+                conn,
+                [session_id],
+                exclude_ids=removed_delegate_ids,
+            )
             # Orphan remaining child sessions (branches, etc.) so FK is satisfied.
             conn.execute(
                 "UPDATE sessions SET parent_session_id = NULL "
@@ -3915,6 +3960,11 @@ class SessionDB:
 
             existing_placeholders = ",".join("?" * len(existing))
             removed_delegate_ids.extend(_delete_delegate_children(conn, existing))
+            _migrate_goal_meta_to_orphaned_children(
+                conn,
+                existing,
+                exclude_ids=existing + removed_delegate_ids,
+            )
             # Orphan remaining children whose parent is in the kill list so the
             # FK constraint stays satisfied. Pin children whose parent
             # is itself in the kill list rather than NULL-ing parents
@@ -4012,6 +4062,11 @@ class SessionDB:
                 return 0
 
             placeholders = ",".join("?" * len(session_ids))
+            _migrate_goal_meta_to_orphaned_children(
+                conn,
+                list(session_ids),
+                exclude_ids=list(session_ids),
+            )
             conn.execute(
                 f"UPDATE sessions SET parent_session_id = NULL "
                 f"WHERE parent_session_id IN ({placeholders})",
@@ -4072,6 +4127,11 @@ class SessionDB:
 
             # Orphan any sessions whose parent is about to be deleted
             placeholders = ",".join("?" * len(session_ids))
+            _migrate_goal_meta_to_orphaned_children(
+                conn,
+                list(session_ids),
+                exclude_ids=list(session_ids),
+            )
             conn.execute(
                 f"UPDATE sessions SET parent_session_id = NULL "
                 f"WHERE parent_session_id IN ({placeholders})",

--- a/tests/hermes_cli/test_aux_config.py
+++ b/tests/hermes_cli/test_aux_config.py
@@ -42,6 +42,14 @@ def test_title_generation_present_in_default_config():
     assert tg["extra_body"] == {}
 
 
+def test_goal_judge_default_uses_auto_provider_path():
+    """Goal judging should not require a provider-specific API key by default."""
+    gj = DEFAULT_CONFIG["auxiliary"]["goal_judge"]
+    assert gj["provider"] == "auto"
+    assert gj["model"] == ""
+    assert gj["max_tokens"] >= 4096
+
+
 def test_session_search_no_longer_appears_in_auxiliary_model_config():
     """session_search is a direct DB-backed tool, not an auxiliary LLM task."""
     assert "session_search" not in DEFAULT_CONFIG["auxiliary"]

--- a/tests/tui_gateway/test_goal_command.py
+++ b/tests/tui_gateway/test_goal_command.py
@@ -122,6 +122,242 @@ def test_goal_set_returns_send_with_notice(server, session):
     assert mgr.state.status == "active"
 
 
+def test_goal_state_is_bound_to_lineage_root(hermes_home):
+    from hermes_cli.goals import GoalManager, _meta_key
+    from hermes_state import SessionDB
+
+    db = SessionDB()
+    db.create_session("lineage-root-session", "tui")
+    db.create_session("lineage-child-session", "tui", parent_session_id="lineage-root-session")
+    db.create_session("lineage-grandchild-session", "tui", parent_session_id="lineage-child-session")
+
+    GoalManager("lineage-grandchild-session").set("keep this goal on the thread")
+
+    assert db.get_meta(_meta_key("lineage-grandchild-session")) is None
+    assert db.get_meta(_meta_key("lineage-child-session")) is None
+    assert db.get_meta(_meta_key("lineage-root-session")) is not None
+    child_state = GoalManager("lineage-child-session").state
+    root_state = GoalManager("lineage-root-session").state
+    assert child_state is not None
+    assert root_state is not None
+    assert child_state.goal == "keep this goal on the thread"
+    assert root_state.goal == "keep this goal on the thread"
+
+
+def test_legacy_tip_goal_migrates_to_lineage_root(hermes_home):
+    from hermes_cli.goals import GoalManager, GoalState, _meta_key
+    from hermes_state import SessionDB
+
+    db = SessionDB()
+    db.create_session("legacy-root-session", "tui")
+    db.create_session("legacy-child-session", "tui", parent_session_id="legacy-root-session")
+    db.set_meta(_meta_key("legacy-child-session"), GoalState(goal="legacy child goal").to_json())
+
+    mgr = GoalManager("legacy-child-session")
+
+    assert mgr.state is not None
+    assert mgr.state.goal == "legacy child goal"
+    assert db.get_meta(_meta_key("legacy-root-session")) is not None
+    root_state = GoalManager("legacy-root-session").state
+    assert root_state is not None
+    assert root_state.goal == "legacy child goal"
+
+
+def test_newer_legacy_tip_goal_beats_stale_root_goal(hermes_home):
+    from hermes_cli.goals import GoalManager, GoalState, _meta_key
+    from hermes_state import SessionDB
+
+    db = SessionDB()
+    db.create_session("stale-root-session", "tui")
+    db.create_session("newer-child-session", "tui", parent_session_id="stale-root-session")
+    db.set_meta(
+        _meta_key("stale-root-session"),
+        GoalState(goal="old cleared root", status="cleared", created_at=1.0, last_turn_at=2.0).to_json(),
+    )
+    db.set_meta(
+        _meta_key("newer-child-session"),
+        GoalState(goal="new active child", status="active", created_at=3.0).to_json(),
+    )
+
+    mgr = GoalManager("newer-child-session")
+
+    assert mgr.state is not None
+    assert mgr.state.goal == "new active child"
+    root_state = GoalManager("stale-root-session").state
+    assert root_state is not None
+    assert root_state.goal == "new active child"
+
+
+def test_active_legacy_tip_goal_beats_stale_root_terminal_goal(hermes_home):
+    from hermes_cli.goals import GoalManager, GoalState, _meta_key
+    from hermes_state import SessionDB
+
+    db = SessionDB()
+    db.create_session("fresh-root-session", "tui")
+    db.create_session("stale-child-session", "tui", parent_session_id="fresh-root-session")
+    db.set_meta(_meta_key("fresh-root-session"), GoalState(goal="fresh cleared root", status="cleared").to_json())
+    db.set_meta(
+        _meta_key("stale-child-session"),
+        GoalState(goal="stale active child", status="active", created_at=1.0).to_json(),
+    )
+
+    mgr = GoalManager("stale-child-session")
+
+    assert mgr.state is not None
+    assert mgr.state.goal == "stale active child"
+    assert mgr.state.status == "active"
+
+
+def test_active_tip_goal_still_beats_newer_root_terminal_goal(hermes_home):
+    from hermes_cli.goals import GoalManager, GoalState, _meta_key
+    from hermes_state import SessionDB
+
+    db = SessionDB()
+    db.create_session("fresh-root-session-2", "tui")
+    db.create_session("stale-child-session-2", "tui", parent_session_id="fresh-root-session-2")
+    db.set_meta(
+        _meta_key("fresh-root-session-2"),
+        GoalState(goal="fresh cleared root", status="cleared", created_at=3.0, last_turn_at=4.0).to_json(),
+    )
+    db.set_meta(
+        _meta_key("stale-child-session-2"),
+        GoalState(goal="stale active child", status="active", created_at=1.0).to_json(),
+    )
+
+    mgr = GoalManager("stale-child-session-2")
+
+    assert mgr.state is not None
+    assert mgr.state.goal == "stale active child"
+    assert mgr.state.status == "active"
+
+
+def test_legacy_parent_goal_migrates_to_lineage_root(hermes_home):
+    from hermes_cli.goals import GoalManager, GoalState, _meta_key
+    from hermes_state import SessionDB
+
+    db = SessionDB()
+    db.create_session("parent-root-session", "tui")
+    db.create_session("legacy-parent-session", "tui", parent_session_id="parent-root-session")
+    db.create_session("parent-grandchild-session", "tui", parent_session_id="legacy-parent-session")
+    db.set_meta(
+        _meta_key("legacy-parent-session"),
+        GoalState(goal="legacy parent goal", status="active", created_at=1.0).to_json(),
+    )
+
+    mgr = GoalManager("parent-grandchild-session")
+
+    assert mgr.state is not None
+    assert mgr.state.goal == "legacy parent goal"
+    root_state = GoalManager("parent-root-session").state
+    assert root_state is not None
+    assert root_state.goal == "legacy parent goal"
+
+
+def test_delegate_session_does_not_inherit_parent_goal(hermes_home):
+    from hermes_cli.goals import GoalManager, _meta_key
+    from hermes_state import SessionDB
+
+    db = SessionDB()
+    db.create_session("delegate-parent-session", "tui")
+    db.create_session(
+        "delegate-child-session",
+        "subagent",
+        parent_session_id="delegate-parent-session",
+        model_config={"_delegate_from": "delegate-parent-session"},
+    )
+
+    GoalManager("delegate-parent-session").set("parent-only goal")
+
+    assert GoalManager("delegate-child-session").state is None
+    GoalManager("delegate-child-session").set("child-only goal")
+    assert db.get_meta(_meta_key("delegate-parent-session")) is not None
+    assert db.get_meta(_meta_key("delegate-child-session")) is not None
+    assert GoalManager("delegate-parent-session").state.goal == "parent-only goal"
+    assert GoalManager("delegate-child-session").state.goal == "child-only goal"
+
+
+def test_deleted_lineage_root_migrates_goal_to_orphaned_child(hermes_home):
+    from hermes_cli.goals import GoalManager, _meta_key
+    from hermes_state import SessionDB
+
+    db = SessionDB()
+    db.create_session("delete-root-session", "tui")
+    db.create_session("delete-child-session", "tui", parent_session_id="delete-root-session")
+    GoalManager("delete-root-session").set("survive root delete")
+
+    assert db.delete_session("delete-root-session") is True
+
+    child = db.get_session("delete-child-session")
+    assert child is not None
+    assert child.get("parent_session_id") is None
+    assert db.get_meta(_meta_key("delete-child-session")) is not None
+    child_state = GoalManager("delete-child-session").state
+    assert child_state is not None
+    assert child_state.goal == "survive root delete"
+
+
+def test_bulk_deleted_lineage_root_migrates_goal_to_orphaned_child(hermes_home):
+    from hermes_cli.goals import GoalManager, _meta_key
+    from hermes_state import SessionDB
+
+    db = SessionDB()
+    db.create_session("bulk-delete-root-session", "tui")
+    db.create_session("bulk-delete-child-session", "tui", parent_session_id="bulk-delete-root-session")
+    GoalManager("bulk-delete-root-session").set("survive bulk root delete")
+
+    assert db.delete_sessions(["bulk-delete-root-session"]) == 1
+
+    child = db.get_session("bulk-delete-child-session")
+    assert child is not None
+    assert child.get("parent_session_id") is None
+    assert db.get_meta(_meta_key("bulk-delete-child-session")) is not None
+    child_state = GoalManager("bulk-delete-child-session").state
+    assert child_state is not None
+    assert child_state.goal == "survive bulk root delete"
+
+
+def test_empty_deleted_lineage_root_migrates_goal_to_orphaned_child(hermes_home):
+    from hermes_cli.goals import GoalManager, _meta_key
+    from hermes_state import SessionDB
+
+    db = SessionDB()
+    db.create_session("empty-delete-root-session", "tui")
+    db.create_session("empty-delete-child-session", "tui", parent_session_id="empty-delete-root-session")
+    GoalManager("empty-delete-root-session").set("survive empty root delete")
+    db.end_session("empty-delete-root-session", "tui_shutdown")
+
+    assert db.delete_empty_sessions() == 1
+
+    child = db.get_session("empty-delete-child-session")
+    assert child is not None
+    assert child.get("parent_session_id") is None
+    assert db.get_meta(_meta_key("empty-delete-child-session")) is not None
+    child_state = GoalManager("empty-delete-child-session").state
+    assert child_state is not None
+    assert child_state.goal == "survive empty root delete"
+
+
+def test_pruned_lineage_root_migrates_goal_to_orphaned_child(hermes_home):
+    from hermes_cli.goals import GoalManager, _meta_key
+    from hermes_state import SessionDB
+
+    db = SessionDB()
+    db.create_session("prune-root-session", "tui")
+    db.create_session("prune-child-session", "tui", parent_session_id="prune-root-session")
+    GoalManager("prune-root-session").set("survive prune root delete")
+    db.end_session("prune-root-session", "tui_shutdown")
+
+    assert db.prune_sessions(older_than_days=0) == 1
+
+    child = db.get_session("prune-child-session")
+    assert child is not None
+    assert child.get("parent_session_id") is None
+    assert db.get_meta(_meta_key("prune-child-session")) is not None
+    child_state = GoalManager("prune-child-session").state
+    assert child_state is not None
+    assert child_state.goal == "survive prune root delete"
+
+
 def test_goal_pause_after_set(server, session):
     sid, session_key, _ = session
     _call(server, "command.dispatch", name="goal", arg="write a story", session_id=sid)


### PR DESCRIPTION
## Summary
- Keep `/goal` state attached to the whole conversation lineage instead of one transient session id.
- Preserve active or paused legacy goals when compression/resume creates child sessions.
- Migrate goal state before session delete/prune operations can orphan it.
- Prevent delegate/subagent child sessions from accidentally inheriting the parent goal.

## Test Plan
- `/Users/yu/.hermes/hermes-agent/venv/bin/python -m pytest tests/hermes_cli/test_aux_config.py tests/tui_gateway/test_goal_command.py -q`
- `git diff --check`
