### PR TITLE
feat(desktop): show goal status in composer

### DIFF
--- a/apps/desktop/src/app/chat/composer/status-stack/index.tsx
+++ b/apps/desktop/src/app/chat/composer/status-stack/index.tsx
@@ -29,6 +29,10 @@ import { StatusItemRow } from './status-row'
 const BACKGROUND_POLL_MS = 5_000
 
 const groupLabel = (group: StatusGroup, s: Translations['statusStack']) => {
+  if (group.type === 'goal') {
+    return s.goal
+  }
+
   if (group.type === 'todo') {
     return s.todos(group.items.filter(i => i.todoStatus === 'completed').length, group.items.length)
   }
@@ -101,9 +105,11 @@ export function ComposerStatusStack({ queue, sessionId }: ComposerStatusStackPro
             </Button>
           ) : undefined
         }
-        defaultCollapsed={group.type !== 'todo'}
+        defaultCollapsed={group.type !== 'goal' && group.type !== 'todo'}
         icon={
-          group.type === 'todo' ? (
+          group.type === 'goal' ? (
+            <Codicon className="text-muted-foreground/70" name="target" size="0.8rem" />
+          ) : group.type === 'todo' ? (
             <Codicon className="text-muted-foreground/70" name="checklist" size="0.8rem" />
           ) : undefined
         }

--- a/apps/desktop/src/app/chat/composer/status-stack/status-row.tsx
+++ b/apps/desktop/src/app/chat/composer/status-stack/status-row.tsx
@@ -11,7 +11,8 @@ import { type Translations, useI18n } from '@/i18n'
 import { ArrowUpRight, X } from '@/lib/icons'
 import type { TodoStatus } from '@/lib/todos'
 import { cn } from '@/lib/utils'
-import type { ComposerStatusItem } from '@/store/composer-status'
+import { type ComposerStatusItem, setGoalStatusFromText } from '@/store/composer-status'
+import { $gateway } from '@/store/gateway'
 
 const toolLabel = (name: string) =>
   name
@@ -31,6 +32,16 @@ const TODO_GLYPHS: Record<Exclude<TodoStatus, 'in_progress' | 'pending'>, { icon
 // Left slot: braille spinner while running, otherwise a small status dot
 // (green = done, red = failed) so the slot is always filled and rows align.
 function leadingGlyph(item: ComposerStatusItem, s: Translations['statusStack']): ReactNode {
+  if (item.type === 'goal') {
+    if (item.goalStatus === 'paused') {
+      return <Codicon className="text-amber-500/80" name="debug-pause" size="0.8rem" />
+    }
+
+    if (item.goalStatus === 'done') {
+      return <Codicon className="text-emerald-500/80" name="pass-filled" size="0.8rem" />
+    }
+  }
+
   if (item.todoStatus === 'pending') {
     return (
       <span
@@ -94,6 +105,31 @@ export const StatusItemRow = memo(function StatusItemRow({ item, onDismiss, onOp
         : onDismiss && { label: s.dismiss, onClick: () => onDismiss(item.id) }
       : null
 
+  const runGoalCommand = (command: 'clear' | 'pause' | 'resume') => {
+    if (!item.sessionId) {
+      return
+    }
+
+    void $gateway
+      .get()
+      ?.request<{ output?: string; type?: string }>('command.dispatch', { arg: command, name: 'goal', session_id: item.sessionId })
+      .then(result => {
+        setGoalStatusFromText(item.sessionId!, result?.output || `Goal ${command === 'clear' ? 'cleared' : command}d`)
+      })
+      .catch(() => undefined)
+  }
+
+  const goalMeta =
+    item.type === 'goal'
+      ? [
+          item.goalStatus ?? null,
+          item.turnsUsed !== undefined && item.maxTurns !== undefined ? `${item.turnsUsed}/${item.maxTurns}` : null,
+          item.goalVerdict ? `judge: ${item.goalVerdict}` : null
+        ]
+          .filter(Boolean)
+          .join(' · ')
+      : ''
+
   const canOpen = item.type === 'subagent' && !!onOpen
   const hasOutput = item.type === 'background' && !!item.output
   const onActivate = canOpen ? onOpen : hasOutput ? () => setOutputOpen(open => !open) : undefined
@@ -104,7 +140,39 @@ export const StatusItemRow = memo(function StatusItemRow({ item, onDismiss, onOp
         leading={leadingGlyph(item, s)}
         onActivate={onActivate}
         trailing={
-          action ? (
+          item.type === 'goal' ? (
+            <div className="flex shrink-0 items-center gap-0.5">
+              {item.goalStatus !== 'done' && (
+                <Button
+                  className="h-4 rounded px-1 text-[0.58rem] text-muted-foreground/70 hover:text-foreground/90"
+                  onClick={event => {
+                    event.stopPropagation()
+                    runGoalCommand(item.goalStatus === 'paused' ? 'resume' : 'pause')
+                  }}
+                  size="micro"
+                  type="button"
+                  variant="text"
+                >
+                  {item.goalStatus === 'paused' ? s.goalResume : s.goalPause}
+                </Button>
+              )}
+              <Tip label={s.goalClear}>
+                <Button
+                  aria-label={s.goalClear}
+                  className="-my-1 size-4 rounded-md text-muted-foreground/60 hover:text-foreground/90"
+                  onClick={event => {
+                    event.stopPropagation()
+                    runGoalCommand('clear')
+                  }}
+                  size="icon-xs"
+                  type="button"
+                  variant="ghost"
+                >
+                  <X size={12} />
+                </Button>
+              </Tip>
+            </div>
+          ) : action ? (
             <Tip label={action.label}>
               <Button
                 aria-label={action.label}
@@ -141,6 +209,12 @@ export const StatusItemRow = memo(function StatusItemRow({ item, onDismiss, onOp
           <span className="shrink-0 truncate text-[0.62rem] leading-4 text-muted-foreground/70">
             {toolLabel(item.currentTool)}
           </span>
+        )}
+        {item.type === 'goal' && goalMeta && (
+          <span className="shrink-0 truncate text-[0.62rem] leading-4 text-muted-foreground/70">{goalMeta}</span>
+        )}
+        {item.type === 'goal' && item.reason && (
+          <span className="shrink truncate text-[0.62rem] leading-4 text-muted-foreground/55">{item.reason}</span>
         )}
         {failed && typeof item.exitCode === 'number' && item.exitCode !== 0 && (
           <span className="shrink-0 rounded bg-destructive/15 px-1 text-[0.58rem] font-semibold text-destructive tabular-nums">

--- a/apps/desktop/src/app/session/hooks/use-message-stream.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream.ts
@@ -28,7 +28,7 @@ import { isProviderSetupErrorMessage } from '@/lib/provider-setup-errors'
 import { parseTodos } from '@/lib/todos'
 import { setClarifyRequest } from '@/store/clarify'
 import { setSessionCompacting } from '@/store/compaction'
-import { refreshBackgroundProcesses } from '@/store/composer-status'
+import { refreshBackgroundProcesses, setGoalStatusFromText } from '@/store/composer-status'
 import { $gateway } from '@/store/gateway'
 import { dispatchNativeNotification } from '@/store/native-notifications'
 import { notify } from '@/store/notifications'
@@ -1075,6 +1075,12 @@ export function useMessageStream({
         if (sessionId && payload?.kind === 'compacting') {
           setSessionCompacting(sessionId, true)
           compactedTurnRef.current.add(sessionId)
+        } else if (sessionId && payload?.kind === 'goal') {
+          const text = typeof payload.text === 'string' ? payload.text : ''
+
+          if (text.trim()) {
+            setGoalStatusFromText(sessionId, text)
+          }
         } else if (sessionId && payload?.kind === 'process') {
           // The gateway's notification poller announces background process
           // completions / watch matches here — re-sync the status stack.

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -1330,6 +1330,10 @@ export const en: Translations = {
   statusStack: {
     agents: 'Agents',
     background: count => `${count} Background`,
+    goal: 'Goal',
+    goalClear: 'Clear goal',
+    goalPause: 'Pause',
+    goalResume: 'Resume',
     subagents: count => `${count} Subagent${count === 1 ? '' : 's'}`,
     todos: (done, total) => `Tasks ${done}/${total}`,
     running: 'Running',

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -1458,6 +1458,10 @@ export const ja = defineLocale({
   statusStack: {
     agents: 'エージェント',
     background: count => `バックグラウンド ${count} 件`,
+    goal: 'ゴール',
+    goalClear: 'ゴールを削除',
+    goalPause: '一時停止',
+    goalResume: '再開',
     subagents: count => `サブエージェント ${count} 件`,
     todos: (done, total) => `タスク ${done}/${total}`,
     running: '実行中',

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -1010,6 +1010,10 @@ export interface Translations {
   statusStack: {
     agents: string
     background: (count: number) => string
+    goal: string
+    goalClear: string
+    goalPause: string
+    goalResume: string
     subagents: (count: number) => string
     todos: (done: number, total: number) => string
     running: string

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -1412,6 +1412,10 @@ export const zhHant = defineLocale({
   statusStack: {
     agents: '代理',
     background: count => `${count} 個背景任務`,
+    goal: '目標',
+    goalClear: '刪除目標',
+    goalPause: '暫停',
+    goalResume: '繼續',
     subagents: count => `${count} 個子代理`,
     todos: (done, total) => `任務 ${done}/${total}`,
     running: '執行中',

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -1517,6 +1517,10 @@ export const zh: Translations = {
   statusStack: {
     agents: '代理',
     background: count => `${count} 个后台任务`,
+    goal: '目标',
+    goalClear: '删除目标',
+    goalPause: '暂停',
+    goalResume: '继续',
     subagents: count => `${count} 个子代理`,
     todos: (done, total) => `任务 ${done}/${total}`,
     running: '运行中',

--- a/apps/desktop/src/store/composer-status.test.ts
+++ b/apps/desktop/src/store/composer-status.test.ts
@@ -1,6 +1,13 @@
 import { beforeEach, describe, expect, it } from 'vitest'
 
-import { $backgroundStatusBySession, dismissBackgroundProcess, reconcileBackgroundProcesses } from './composer-status'
+import {
+  $backgroundStatusBySession,
+  $goalStatusBySession,
+  dismissBackgroundProcess,
+  groupStatusItems,
+  reconcileBackgroundProcesses,
+  setGoalStatusFromText
+} from './composer-status'
 
 const SID = 'sess-1'
 
@@ -18,6 +25,7 @@ const items = () => $backgroundStatusBySession.get()[SID] ?? []
 describe('reconcileBackgroundProcesses', () => {
   beforeEach(() => {
     $backgroundStatusBySession.set({})
+    $goalStatusBySession.set({})
   })
 
   it('maps registry entries to status items', () => {
@@ -95,5 +103,76 @@ describe('reconcileBackgroundProcesses', () => {
     reconcileBackgroundProcesses(SID, [])
 
     expect($backgroundStatusBySession.get()).toEqual({})
+  })
+})
+
+describe('goal status items', () => {
+  beforeEach(() => {
+    $goalStatusBySession.set({})
+  })
+
+  it('parses goal set notices into a status row', () => {
+    setGoalStatusFromText(SID, '⊙ Goal set (20-turn budget): fix the desktop slash bug')
+
+    expect($goalStatusBySession.get()[SID]).toMatchObject({
+      goalStatus: 'active',
+      maxTurns: 20,
+      state: 'running',
+      title: 'fix the desktop slash bug',
+      type: 'goal'
+    })
+  })
+
+  it('updates judge turn metadata and clears on stop output', () => {
+    setGoalStatusFromText(SID, '⊙ Goal set (20-turn budget): fix the desktop slash bug')
+    setGoalStatusFromText(SID, '↻ Continuing toward goal (3/20): still working')
+
+    expect($goalStatusBySession.get()[SID]).toMatchObject({
+      goalVerdict: 'continue',
+      reason: 'still working',
+      turnsUsed: 3
+    })
+
+    setGoalStatusFromText(SID, 'Goal cleared')
+
+    expect($goalStatusBySession.get()[SID]).toBeUndefined()
+  })
+
+  it('clears stale goal rows when backend reports no active goal', () => {
+    setGoalStatusFromText(SID, '⊙ Goal set (20-turn budget): fix the desktop slash bug')
+    setGoalStatusFromText(SID, 'No active goal. Set one with /goal <text>.')
+
+    expect($goalStatusBySession.get()[SID]).toBeUndefined()
+  })
+
+  it('parses backend goal status lines into status rows', () => {
+    setGoalStatusFromText(SID, '⊙ Goal (active, 2/20 turns): keep this thread alive')
+
+    expect($goalStatusBySession.get()[SID]).toMatchObject({
+      goalStatus: 'active',
+      maxTurns: 20,
+      state: 'running',
+      title: 'keep this thread alive',
+      turnsUsed: 2
+    })
+
+    setGoalStatusFromText(SID, '✓ Goal done (4/20 turns): keep this thread alive')
+
+    expect($goalStatusBySession.get()[SID]).toMatchObject({
+      goalStatus: 'done',
+      state: 'done',
+      title: 'keep this thread alive',
+      turnsUsed: 4
+    })
+  })
+
+  it('groups goal rows before todos and background rows', () => {
+    const groups = groupStatusItems([
+      { id: 'bg', state: 'running', title: 'bg', type: 'background' },
+      { id: 'todo:a', state: 'running', title: 'todo', todoStatus: 'in_progress', type: 'todo' },
+      { goalStatus: 'active', id: 'goal', state: 'running', title: 'goal', type: 'goal' }
+    ])
+
+    expect(groups.map(group => group.type)).toEqual(['goal', 'todo', 'background'])
   })
 })

--- a/apps/desktop/src/store/composer-status.ts
+++ b/apps/desktop/src/store/composer-status.ts
@@ -8,23 +8,35 @@ import { dispatchNativeNotification } from './native-notifications'
 import { $subagentsBySession, type SubagentProgress } from './subagents'
 import { $todosBySession } from './todos'
 
-/** Composer status stack feed — merged todos, subagents, background per session. */
+/** Composer status stack feed — merged goals, todos, subagents, background per session. */
 export type StatusItemState = 'done' | 'failed' | 'running'
-export type StatusItemType = 'background' | 'subagent' | 'todo'
+export type StatusItemType = 'background' | 'goal' | 'subagent' | 'todo'
+
+export type GoalCardStatus = 'active' | 'paused' | 'done'
 
 export interface ComposerStatusItem {
   /** background: non-zero exit shown inline when failed. */
   exitCode?: number
   /** subagent: active tool label shown on the right. */
   currentTool?: string
+  /** goal: active | paused | done. */
+  goalStatus?: GoalCardStatus
+  /** goal: latest judge verdict. */
+  goalVerdict?: string
   id: string
   /** background process: captured stdout/stderr tail for the inline viewer. */
   output?: string
+  /** goal: judge reason / paused reason summary. */
+  reason?: string
   /** subagent: its own stored session id — row click opens that session window
    *  (livestreamed by the gateway's child-session mirror). */
   sessionId?: string
   state: StatusItemState
   title: string
+  /** goal: current judge turn count. */
+  turnsUsed?: number
+  /** goal: max judge turn budget. */
+  maxTurns?: number
   /** todo: the full four-state status driving the row's checkmark glyph. */
   todoStatus?: TodoStatus
   type: StatusItemType
@@ -33,6 +45,118 @@ export interface ComposerStatusItem {
 // Writable source for background work, synced from the gateway's process
 // registry (`terminal(background=true)` spawns) via `process.list`.
 export const $backgroundStatusBySession = atom<Record<string, ComposerStatusItem[]>>({})
+export const $goalStatusBySession = atom<Record<string, ComposerStatusItem>>({})
+
+const GOAL_BUDGET_RE = /\((?<max>\d+)-turn budget\)/
+const GOAL_TURNS_RE = /(?<used>\d+)\/(?<max>\d+)(?:\s+turns)?/
+
+const firstLine = (text: string) => text.trim().split('\n')[0]?.trim() ?? ''
+
+export function setGoalStatusFromText(sid: string, text: string) {
+  const line = firstLine(text)
+
+  if (!sid || !line) {
+    return
+  }
+
+  const current = $goalStatusBySession.get()
+  const prev = current[sid]
+  let next: ComposerStatusItem | null = null
+
+  if (line.startsWith('⊙ Goal set')) {
+    const title = line.split(':').slice(1).join(':').trim() || prev?.title || 'Goal'
+    const maxTurns = Number(line.match(GOAL_BUDGET_RE)?.groups?.max || '') || prev?.maxTurns
+    next = {
+      id: 'goal',
+      goalStatus: 'active',
+      maxTurns,
+      sessionId: sid,
+      state: 'running',
+      title,
+      type: 'goal'
+    }
+  } else if (line.startsWith('⊙ Goal (active')) {
+    const turns = line.match(GOAL_TURNS_RE)?.groups
+    next = {
+      ...(prev ?? { id: 'goal', sessionId: sid, title: 'Goal', type: 'goal' as const }),
+      goalStatus: 'active',
+      maxTurns: Number(turns?.max || '') || prev?.maxTurns,
+      state: 'running',
+      title: line.split('):').slice(1).join('):').trim() || prev?.title || 'Goal',
+      turnsUsed: Number(turns?.used || '') || prev?.turnsUsed
+    }
+  } else if (line.startsWith('⏸ Goal (paused')) {
+    const turns = line.match(GOAL_TURNS_RE)?.groups
+    next = {
+      ...(prev ?? { id: 'goal', sessionId: sid, title: 'Goal', type: 'goal' as const }),
+      goalStatus: 'paused',
+      maxTurns: Number(turns?.max || '') || prev?.maxTurns,
+      state: 'failed',
+      title: line.split('):').slice(1).join('):').trim() || prev?.title || 'Goal',
+      turnsUsed: Number(turns?.used || '') || prev?.turnsUsed
+    }
+  } else if (line.startsWith('✓ Goal done')) {
+    const turns = line.match(GOAL_TURNS_RE)?.groups
+    next = {
+      ...(prev ?? { id: 'goal', sessionId: sid, title: 'Goal', type: 'goal' as const }),
+      goalStatus: 'done',
+      maxTurns: Number(turns?.max || '') || prev?.maxTurns,
+      state: 'done',
+      title: line.split('):').slice(1).join('):').trim() || prev?.title || 'Goal',
+      turnsUsed: Number(turns?.used || '') || prev?.turnsUsed
+    }
+  } else if (line.startsWith('⏸ Goal paused')) {
+    const turns = line.match(GOAL_TURNS_RE)?.groups
+    next = {
+      ...(prev ?? { id: 'goal', sessionId: sid, title: 'Goal', type: 'goal' as const }),
+      goalStatus: 'paused',
+      maxTurns: Number(turns?.max || '') || prev?.maxTurns,
+      reason: line.replace(/^⏸ Goal paused\s*[—-]?\s*/, '').trim(),
+      state: 'failed',
+      turnsUsed: Number(turns?.used || '') || prev?.turnsUsed
+    }
+  } else if (line.startsWith('✓ Goal achieved')) {
+    next = {
+      ...(prev ?? { id: 'goal', sessionId: sid, title: 'Goal', type: 'goal' as const }),
+      goalStatus: 'done',
+      reason: line.replace(/^✓ Goal achieved:\s*/, '').trim(),
+      state: 'done'
+    }
+  } else if (line.startsWith('↻ Continuing toward goal')) {
+    const turns = line.match(GOAL_TURNS_RE)?.groups
+    next = {
+      ...(prev ?? { id: 'goal', sessionId: sid, title: 'Goal', type: 'goal' as const }),
+      goalStatus: 'active',
+      goalVerdict: 'continue',
+      maxTurns: Number(turns?.max || '') || prev?.maxTurns,
+      reason: line.split(':').slice(1).join(':').trim() || prev?.reason,
+      state: 'running',
+      turnsUsed: Number(turns?.used || '') || prev?.turnsUsed
+    }
+  } else if (/goal\s+(cleared|stopped|deleted)/i.test(line) || /^No (active )?goal/i.test(line)) {
+    const out = { ...current }
+    delete out[sid]
+    $goalStatusBySession.set(out)
+
+    return
+  } else if (/goal\s+resumed/i.test(line)) {
+    next = {
+      ...(prev ?? { id: 'goal', sessionId: sid, title: 'Goal', type: 'goal' as const }),
+      goalStatus: 'active',
+      state: 'running'
+    }
+  } else if (/goal\s+paused/i.test(line)) {
+    next = {
+      ...(prev ?? { id: 'goal', sessionId: sid, title: 'Goal', type: 'goal' as const }),
+      goalStatus: 'paused',
+      state: 'failed'
+    }
+  }
+
+  if (next) {
+    $goalStatusBySession.set({ ...current, [sid]: next })
+  }
+}
 
 // Rows the user X-ed away. The registry keeps finished processes around for a
 // while, so without this every refresh would resurrect a dismissed row.
@@ -57,14 +181,18 @@ const todoToItem = (t: TodoItem): ComposerStatusItem => ({
 
 // The single thing the stack reads: a typed, merged item list per session.
 export const $statusItemsBySession = computed(
-  [$subagentsBySession, $backgroundStatusBySession, $todosBySession],
-  (subs, background, todos) => {
+  [$goalStatusBySession, $subagentsBySession, $backgroundStatusBySession, $todosBySession],
+  (goals, subs, background, todos) => {
     const out: Record<string, ComposerStatusItem[]> = {}
 
     const push = (sid: string, items: ComposerStatusItem[]) => {
       if (items.length > 0) {
         out[sid] = out[sid] ? [...out[sid], ...items] : items
       }
+    }
+
+    for (const [sid, goal] of Object.entries(goals)) {
+      push(sid, [goal])
     }
 
     for (const [sid, list] of Object.entries(todos)) {
@@ -84,7 +212,7 @@ export const $statusItemsBySession = computed(
 )
 
 // Fixed render order for the groups in the stack (top → bottom, above queue).
-const TYPE_ORDER: readonly StatusItemType[] = ['todo', 'subagent', 'background']
+const TYPE_ORDER: readonly StatusItemType[] = ['goal', 'todo', 'subagent', 'background']
 
 export interface StatusGroup {
   items: ComposerStatusItem[]


### PR DESCRIPTION
## Summary
- Show `/goal` status in the desktop composer status stack.
- Surface running/paused/done state, turn budget, and latest judge verdict.
- Add pause/resume/clear controls for the active goal from desktop.
- Update the status card from gateway goal status events.

## Test Plan
- `cd apps/desktop && npm run test:ui -- src/store/composer-status.test.ts`
- `cd apps/desktop && npm run typecheck`
- `git diff --check`
