### PR TITLE
fix(desktop): stop stale sessions when starting a new chat

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
@@ -22,6 +22,8 @@ vi.mock('@/hermes', async importOriginal => ({
 
 const RUNTIME_SESSION_ID = 'rt-new-001'
 
+type SessionActions = ReturnType<typeof useSessionActions>
+
 function Harness({
   onReady,
   requestGateway
@@ -55,6 +57,41 @@ function Harness({
   return null
 }
 
+function ActionsHarness({
+  activeSessionId = null,
+  onReady,
+  requestGateway
+}: {
+  activeSessionId?: string | null
+  onReady: (actions: SessionActions) => void
+  requestGateway: <T>(method: string, params?: Record<string, unknown>) => Promise<T>
+}) {
+  const ref = <T,>(value: T): MutableRefObject<T> => ({ current: value })
+
+  const actions = useSessionActions({
+    activeSessionId,
+    activeSessionIdRef: ref<string | null>(activeSessionId),
+    busyRef: ref(false),
+    creatingSessionRef: ref(false),
+    ensureSessionState: () => ({}) as ClientSessionState,
+    getRouteToken: () => 'token',
+    navigate: vi.fn() as never,
+    requestGateway,
+    runtimeIdByStoredSessionIdRef: ref(new Map<string, string>()),
+    selectedStoredSessionId: null,
+    selectedStoredSessionIdRef: ref<string | null>(null),
+    sessionStateByRuntimeIdRef: ref(new Map<string, ClientSessionState>()),
+    syncSessionStateToView: vi.fn(),
+    updateSessionState: () => ({}) as ClientSessionState
+  })
+
+  useEffect(() => {
+    onReady(actions)
+  }, [actions, onReady])
+
+  return null
+}
+
 async function createWith(profileSetup: () => void): Promise<Record<string, unknown> | undefined> {
   let createParams: Record<string, unknown> | undefined
 
@@ -78,6 +115,33 @@ async function createWith(profileSetup: () => void): Promise<Record<string, unkn
 
   return createParams
 }
+
+describe('startFreshSessionDraft worker cleanup', () => {
+  afterEach(() => {
+    cleanup()
+    vi.restoreAllMocks()
+  })
+
+  it('closes the previous runtime session when starting a fresh draft', async () => {
+    const requestGateway = vi.fn(async () => ({} as never))
+    let actions: SessionActions | null = null
+
+    render(
+      <ActionsHarness
+        activeSessionId="runtime-old"
+        onReady={value => (actions = value)}
+        requestGateway={requestGateway}
+      />
+    )
+    await waitFor(() => expect(actions).not.toBeNull())
+
+    actions!.startFreshSessionDraft()
+
+    await waitFor(() =>
+      expect(requestGateway).toHaveBeenCalledWith('session.close', { session_id: 'runtime-old' })
+    )
+  })
+})
 
 describe('createBackendSessionForSend profile routing', () => {
   afterEach(() => {

--- a/apps/desktop/src/app/session/hooks/use-session-actions.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions.ts
@@ -394,6 +394,12 @@ export function useSessionActions({
 
   const startFreshSessionDraft = useCallback(
     (replaceRoute = false) => {
+      const previousActiveSessionId = activeSessionIdRef.current
+
+      if (previousActiveSessionId) {
+        void requestGateway('session.close', { session_id: previousActiveSessionId }).catch(() => undefined)
+      }
+
       busyRef.current = false
       setBusy(false)
       setAwaitingResponse(false)
@@ -426,7 +432,7 @@ export function useSessionActions({
       // Never clear the composer here — ChatBar's per-thread draft swap owns it.
       setFreshDraftReady(true)
     },
-    [activeSessionIdRef, busyRef, navigate, selectedStoredSessionIdRef]
+    [activeSessionIdRef, busyRef, navigate, requestGateway, selectedStoredSessionIdRef]
   )
 
   const createBackendSessionForSend = useCallback(


### PR DESCRIPTION
## Summary
- Stop stale runtime sessions when starting a new desktop chat.
- Prevent background workers from an abandoned/new-chat transition from leaking into the next thread.

## Test Plan
- `cd apps/desktop && npm run test:ui -- src/app/session/hooks/use-session-actions.test.tsx`
- `cd apps/desktop && npm run typecheck`
- `git diff --check`
