### PR TITLE
fix(install): relax native stderr handling in install.ps1 (#48352)

### DIFF
--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -185,6 +185,18 @@ function Write-Err {
     Write-Host "[X] $Message" -ForegroundColor Red
 }
 
+function Invoke-NativeWithRelaxedErrorAction {
+    param([scriptblock]$Script)
+
+    $prevEAP = $ErrorActionPreference
+    $ErrorActionPreference = "Continue"
+    try {
+        & $Script
+    } finally {
+        $ErrorActionPreference = $prevEAP
+    }
+}
+
 # Inspect npm output for a TLS-trust failure and, if found, print actionable
 # remediation. npm/Node surface corporate MITM proxies and missing root CAs as
 # "unable to get local issuer certificate" / "self-signed certificate in
@@ -1306,7 +1318,7 @@ function Install-Repository {
         Write-Info "Trying SSH clone..."
         $env:GIT_SSH_COMMAND = "ssh -o BatchMode=yes -o ConnectTimeout=5"
         try {
-            git -c windows.appendAtomically=false clone --depth 1 --branch $Branch $RepoUrlSsh $InstallDir
+            Invoke-NativeWithRelaxedErrorAction { git -c windows.appendAtomically=false clone --depth 1 --branch $Branch $RepoUrlSsh $InstallDir }
             if ($LASTEXITCODE -eq 0) { $cloneSuccess = $true }
         } catch { }
         $env:GIT_SSH_COMMAND = $null
@@ -1315,7 +1327,7 @@ function Install-Repository {
             if (Test-Path $InstallDir) { Remove-Item -Recurse -Force $InstallDir -ErrorAction SilentlyContinue }
             Write-Info "SSH failed, trying HTTPS..."
             try {
-                git -c windows.appendAtomically=false clone --depth 1 --branch $Branch $RepoUrlHttps $InstallDir
+                Invoke-NativeWithRelaxedErrorAction { git -c windows.appendAtomically=false clone --depth 1 --branch $Branch $RepoUrlHttps $InstallDir }
                 if ($LASTEXITCODE -eq 0) { $cloneSuccess = $true }
             } catch { }
         }
@@ -1443,8 +1455,11 @@ function Install-Venv {
         Remove-Item -Recurse -Force "venv"
     }
     
-    # uv creates the venv and pins the Python version in one step
-    & $UvCmd venv venv --python $PythonVersion
+    # uv creates the venv and pins the Python version in one step.  uv emits
+    # normal progress such as "Using CPython ..." on stderr; under Windows
+    # PowerShell 5.1 with EAP=Stop that stderr is a NativeCommandError unless
+    # we temporarily relax EAP and trust $LASTEXITCODE for real failures.
+    Invoke-NativeWithRelaxedErrorAction { & $UvCmd venv venv --python $PythonVersion }
 
     # Neutralize any inherited UV_PYTHON (e.g. $env:UV_PYTHON = "3.14" left in
     # the user's shell). uv honours UV_PYTHON over an existing venv for the
@@ -1514,7 +1529,7 @@ function Install-Dependencies {
         # in the wrong directory and imports fail with ModuleNotFoundError.
         # (Mirrors the same flag in scripts/install.sh::install_deps.)
         $env:UV_PROJECT_ENVIRONMENT = "$InstallDir\venv"
-        & $UvCmd sync --extra all --locked
+        Invoke-NativeWithRelaxedErrorAction { & $UvCmd sync --extra all --locked }
         if ($LASTEXITCODE -eq 0) {
             Write-Success "Main package installed (hash-verified via uv.lock)"
             $script:InstalledTier = "hash-verified (uv.lock)"
@@ -1589,7 +1604,7 @@ except Exception:
     if (-not $skipPipFallback) {
         foreach ($tier in $installTiers) {
         Write-Info "Trying tier: $($tier.Name) ..."
-        & $UvCmd pip install -e $tier.Spec
+        Invoke-NativeWithRelaxedErrorAction { & $UvCmd pip install -e $tier.Spec }
         if ($LASTEXITCODE -eq 0) {
             Write-Success "Main package installed ($($tier.Name))"
             $script:InstalledTier = $tier.Name

--- a/tests/test_install_ps1_native_stderr_eap.py
+++ b/tests/test_install_ps1_native_stderr_eap.py
@@ -1,0 +1,69 @@
+"""Regression tests for #48352: Windows PowerShell 5.1 native stderr.
+
+PowerShell 5.1 turns stderr from native commands into ``NativeCommandError``
+records when ``$ErrorActionPreference = "Stop"``.  ``scripts/install.ps1`` has a
+few git/uv calls where stderr can be normal progress output, so those calls must
+run with EAP temporarily relaxed and then inspect ``$LASTEXITCODE``.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+INSTALL_PS1 = REPO_ROOT / "scripts" / "install.ps1"
+
+
+def _install_ps1() -> str:
+    return INSTALL_PS1.read_text(encoding="utf-8")
+
+
+def _assert_relaxed_call(text: str, command_pattern: str) -> None:
+    helper_block_pattern = (
+        r"Invoke-NativeWithRelaxedErrorAction\s*\{[^}]*"
+        + command_pattern
+        + r"[^}]*\}"
+    )
+    inline_pattern = (
+        r"\$ErrorActionPreference\s*=\s*\"Continue\"[\s\S]{0,900}?"
+        + command_pattern
+    )
+    assert re.search(helper_block_pattern, text) or re.search(inline_pattern, text), (
+        f"install.ps1 must relax ErrorActionPreference around {command_pattern}"
+    )
+
+
+def test_repository_stage_relieves_eap_for_ssh_and_https_git_clone() -> None:
+    text = _install_ps1()
+    assert "function Invoke-NativeWithRelaxedErrorAction" in text
+    _assert_relaxed_call(
+        text,
+        r"git -c windows\.appendAtomically=false clone --depth 1 --branch \$Branch \$RepoUrlSsh \$InstallDir",
+    )
+    _assert_relaxed_call(
+        text,
+        r"git -c windows\.appendAtomically=false clone --depth 1 --branch \$Branch \$RepoUrlHttps \$InstallDir",
+    )
+
+
+def test_uv_venv_and_dependency_installs_relax_eap() -> None:
+    text = _install_ps1()
+    _assert_relaxed_call(text, r"& \$UvCmd venv venv --python \$PythonVersion")
+    _assert_relaxed_call(text, r"& \$UvCmd sync --extra all --locked")
+    _assert_relaxed_call(text, r"& \$UvCmd pip install -e \$tier\.Spec")
+
+
+def test_native_eap_helper_always_restores_previous_preference() -> None:
+    text = _install_ps1()
+    m = re.search(
+        r"function Invoke-NativeWithRelaxedErrorAction \{(?P<body>[\s\S]*?)^\}",
+        text,
+        re.MULTILINE,
+    )
+    assert m is not None, "expected a shared helper for NativeCommandError-safe calls"
+    body = m.group("body")
+    assert "$prevEAP = $ErrorActionPreference" in body
+    assert '$ErrorActionPreference = "Continue"' in body
+    assert "finally" in body
+    assert "$ErrorActionPreference = $prevEAP" in body


### PR DESCRIPTION
## What

Fixes #48352 by making the Windows installer tolerant of normal native-command stderr from `git` and `uv` under Windows PowerShell 5.1 with `$ErrorActionPreference = "Stop"`.

The patch adds a small `Invoke-NativeWithRelaxedErrorAction` helper that temporarily sets `$ErrorActionPreference = "Continue"` and restores the previous value in `finally`, then uses it around every reported native call site:

- SSH `git clone`
- HTTPS `git clone`
- `uv venv venv --python $PythonVersion`
- `uv sync --extra all --locked`
- tiered fallback `uv pip install -e $tier.Spec`

The existing `$LASTEXITCODE` checks remain responsible for detecting real native-command failures.

## Why

PowerShell 5.1 can wrap native stderr as terminating `NativeCommandError` when EAP is `Stop`. `git clone` and `uv` legitimately write progress/status lines to stderr, causing the installer to abort or fall through to the ZIP path even when the command succeeded.

## Verification

Regression tests were written first and failed on upstream/main. Verified after the fix with:

```bash
/Users/evinova-self/.hermes/hermes-agent/venv/bin/python3 -m pytest \
  tests/test_install_ps1_native_stderr_eap.py \
  tests/test_install_no_initial_commit.py \
  tests/test_install_unmerged_index.py \
  -v -o "addopts=" --tb=short
```

Result: `10 passed in 0.40s`.

Publication gate checks:

- Same-author duplicate search for `#48352`: none found.
- Same-author branch search for `fix/48352*`: none found.
- Competitor search found PR #45299, but it only guards the `uv venv` layer and does not cover git clone, `uv sync`, or fallback `uv pip install`; scored 4/10, not a blocker.

Auto-published by Moonsong via Path B automated pipeline.
