### PR TITLE
fix: use VBS launcher for silent Windows gateway start (no CMD console flash)

### DIFF
--- a/hermes_cli/gateway_windows.py
+++ b/hermes_cli/gateway_windows.py
@@ -335,6 +335,61 @@ def _stable_gateway_working_dir(project_root: Path) -> str:
 # Script rendering
 # ---------------------------------------------------------------------------
 
+def _build_gateway_vbs_script(
+    python_path: str,
+    working_dir: str,
+    hermes_home: str,
+    profile_arg: str,
+) -> str:
+    """Build the ``gateway.vbs`` launcher (CRLF-terminated).
+
+    VBScript runs as a true GUI-subsystem process through ``wscript.exe``,
+    so Windows Task Scheduler never opens a visible console window — not
+    even the brief flash that occurs when launching a ``.cmd`` wrapper.
+    The VBS sets the working directory and environment variables, then
+    spawns ``pythonw.exe`` with ``SW_HIDE`` (0).
+    """
+    pythonw_path = _derive_venv_pythonw(python_path)
+    venv_dir = str(Path(python_path).resolve().parent.parent)
+
+    prog_args = [pythonw_path, "-m", "hermes_cli.main"]
+    if profile_arg:
+        prog_args.extend(profile_arg.split())
+    prog_args.extend(["gateway", "run"])
+
+    # Build the Run() argument — VBS string with embedded quotes for args
+    # that contain spaces (e.g. paths with spaces in them).
+    def _vbs_quote(s: str) -> str:
+        """Escape a string for use inside a VBS string literal."""
+        return s.replace('"', '""')
+
+    run_line_parts = []
+    for arg in prog_args:
+        if " " in arg:
+            run_line_parts.append(f'"""{_vbs_quote(arg)}"""')
+        else:
+            run_line_parts.append(f'"{_vbs_quote(arg)}"')
+    run_line = " & ".join(run_line_parts)
+
+    lines = [
+        f"' {_TASK_DESCRIPTION}",
+        "Set WshShell = CreateObject(\"WScript.Shell\")",
+        "",
+        f"WshShell.CurrentDirectory = \"{_vbs_quote(working_dir)}\"",
+        "",
+        "Dim envProc",
+        "Set envProc = WshShell.Environment(\"Process\")",
+        f"envProc(\"HERMES_HOME\") = \"{_vbs_quote(hermes_home)}\"",
+        "envProc(\"PYTHONIOENCODING\") = \"utf-8\"",
+        "envProc(\"HERMES_GATEWAY_DETACHED\") = \"1\"",
+        f"envProc(\"VIRTUAL_ENV\") = \"{_vbs_quote(venv_dir)}\"",
+        "",
+        f"WshShell.Run {run_line}, 0, False",
+    ]
+
+    return "\r\n".join(lines) + "\r\n"
+
+
 def _build_gateway_cmd_script(
     python_path: str,
     working_dir: str,
@@ -343,38 +398,19 @@ def _build_gateway_cmd_script(
 ) -> str:
     """Build the ``gateway.cmd`` wrapper content (CRLF-terminated).
 
-    The script:
-      - cd's into a stable working directory
-      - exports HERMES_HOME, PYTHONIOENCODING, VIRTUAL_ENV
-      - invokes ``pythonw -m hermes_cli.main [--profile X] gateway run``
-        directly so the wrapper cmd.exe exits without a visible gateway console
+    The script delegates to a companion ``.vbs`` launcher via
+    ``wscript.exe`` so that the gateway process (``pythonw.exe``) starts
+    with no visible console window.  The VBS file is generated alongside
+    the ``.cmd`` by ``_write_task_script()``.
 
     We intentionally do NOT inline PATH overrides here — cmd.exe inherits
     the per-user PATH the Scheduled Task was created with, and forcibly
     rewriting PATH tends to break Homebrew/nvm-style installations.
     """
     lines = ["@echo off", f"rem {_TASK_DESCRIPTION}"]
-    lines.append(f"cd /d {_quote_cmd_script_arg(working_dir)}")
-    lines.append(f'set "HERMES_HOME={hermes_home}"')
-    lines.append('set "PYTHONIOENCODING=utf-8"')
-    lines.append('set "HERMES_GATEWAY_DETACHED=1"')
-    # VIRTUAL_ENV lets the gateway's own python detection find the venv
-    # if someone imports hermes_constants-based logic during startup.
-    venv_dir = str(Path(python_path).resolve().parent.parent)
-    lines.append(f'set "VIRTUAL_ENV={venv_dir}"')
-
-    pythonw_path = _derive_venv_pythonw(python_path)
-    prog_args = [pythonw_path, "-m", "hermes_cli.main"]
-    if profile_arg:
-        prog_args.extend(profile_arg.split())
-    prog_args.extend(["gateway", "run"])
-    # `pythonw.exe` is a GUI-subsystem executable: cmd.exe launches it and
-    # returns immediately, so the Scheduled Task action finishes without a
-    # visible console window. Do NOT use `start` here; that creates an extra
-    # wrapper process and made gateway lifecycle/status harder to reason about.
-    # Do NOT use `--replace` for service-managed starts; repeated /Run calls
-    # should be idempotent, not churn parent/child takeover loops.
-    lines.append(" ".join(_quote_cmd_script_arg(a) for a in prog_args))
+    # Hand off to the VBS launcher in the same directory.
+    # %~dp0 = directory of this script, %~n0 = script name without extension.
+    lines.append('wscript.exe //B //Nologo "%~dp0%~n0.vbs"')
     lines.append("exit /b 0")
     return "\r\n".join(lines) + "\r\n"
 
@@ -405,7 +441,13 @@ def _build_startup_launcher(script_path: Path) -> str:
 
 
 def _write_task_script() -> Path:
-    """Generate and write the gateway.cmd wrapper. Return its absolute path."""
+    """Generate and write the gateway wrapper scripts. Return the .cmd path.
+
+    Writes two files side by side in the gateway-service directory:
+
+    * ``<task_name>.cmd`` — thin wrapper that hands off to the VBS launcher
+    * ``<task_name>.vbs`` — VBScript launcher that runs ``pythonw.exe`` hidden
+    """
     _assert_windows()
     # Local imports to avoid circular-init at module load time.
     from hermes_cli.config import get_hermes_home
@@ -420,12 +462,21 @@ def _write_task_script() -> Path:
     hermes_home = str(Path(get_hermes_home()).resolve())
     profile_arg = _profile_arg(hermes_home)
 
-    content = _build_gateway_cmd_script(python_path, working_dir, hermes_home, profile_arg)
-    script_path = get_task_script_path()
-    tmp = script_path.with_suffix(".tmp")
-    tmp.write_text(content, encoding="utf-8", newline="")
-    tmp.replace(script_path)
-    return script_path
+    # Write the .cmd wrapper (thin — delegates to .vbs)
+    cmd_content = _build_gateway_cmd_script(python_path, working_dir, hermes_home, profile_arg)
+    cmd_path = get_task_script_path()
+    tmp = cmd_path.with_suffix(".tmp")
+    tmp.write_text(cmd_content, encoding="utf-8", newline="")
+    tmp.replace(cmd_path)
+
+    # Write the .vbs launcher (does the actual work — runs pythonw hidden)
+    vbs_content = _build_gateway_vbs_script(python_path, working_dir, hermes_home, profile_arg)
+    vbs_path = cmd_path.with_suffix(".vbs")
+    tmp_vbs = vbs_path.with_suffix(".vbs.tmp")
+    tmp_vbs.write_text(vbs_content, encoding="utf-8", newline="")
+    tmp_vbs.replace(vbs_path)
+
+    return cmd_path
 
 
 # ---------------------------------------------------------------------------

--- a/tests/hermes_cli/test_gateway_windows.py
+++ b/tests/hermes_cli/test_gateway_windows.py
@@ -126,7 +126,11 @@ class TestStableWindowsGatewayWorkingDir:
         assert gateway_windows._stable_gateway_working_dir(project) == str(project)
 
 
-def test_write_task_script_anchors_cmd_cd_at_hermes_home(monkeypatch, tmp_path):
+def test_write_task_script_writes_vbs_with_hermes_home_anchor(monkeypatch, tmp_path):
+    """The .vbs launcher should anchor its working directory at HERMES_HOME.
+
+    The .cmd is now a thin wrapper that hands off to the .vbs, so the
+    stable-directory contract lives in the VBS launcher instead."""
     project = tmp_path / "project"
     hermes_home = tmp_path / "hermes-home"
     hermes_home.mkdir()
@@ -143,11 +147,19 @@ def test_write_task_script_anchors_cmd_cd_at_hermes_home(monkeypatch, tmp_path):
     monkeypatch.setattr(gateway_windows, "get_task_script_path", lambda: script_path)
 
     written = gateway_windows._write_task_script()
-    content = script_path.read_text(encoding="utf-8")
 
+    # The .cmd is written and returned
     assert written == script_path
-    assert f"cd /d {gateway_windows._quote_cmd_script_arg(str(hermes_home.resolve()))}" in content
-    assert f"cd /d {gateway_windows._quote_cmd_script_arg(str(project))}" not in content
+    cmd_content = script_path.read_text(encoding="utf-8")
+    assert "wscript.exe" in cmd_content
+
+    # The .vbs is written alongside and anchors at hermes_home
+    vbs_path = script_path.with_suffix(".vbs")
+    assert vbs_path.exists(), "VBS launcher must be written alongside .cmd"
+    vbs_content = vbs_path.read_text(encoding="utf-8")
+    assert f"WshShell.CurrentDirectory = \"{str(hermes_home.resolve())}\"" in vbs_content
+    # The VBS should NOT anchor CurrentDirectory at the project root
+    assert f'CurrentDirectory = "{str(project)}"' not in vbs_content
 
 
 def _arrange_startup_fallback(monkeypatch, tmp_path, running_pids):
@@ -188,8 +200,12 @@ def _arrange_startup_fallback(monkeypatch, tmp_path, running_pids):
     return script_path, calls
 
 
-def test_gateway_cmd_script_uses_pythonw_without_replace_or_start_churn(monkeypatch):
-    """Scheduled Task wrapper should launch pythonw once and avoid replace loops."""
+def test_gateway_cmd_script_delegates_to_vbs_launcher(monkeypatch):
+    """Scheduled Task .cmd should hand off to a VBS launcher, not run pythonw directly.
+
+    Running pythonw.exe through a .cmd wrapper causes a brief console flash
+    because Task Scheduler always opens a visible CMD window for .cmd files.
+    Delegating to wscript.exe + .vbs avoids this entirely."""
     monkeypatch.setattr(gateway_windows, "_derive_venv_pythonw", lambda exe: exe.replace("python.exe", "pythonw.exe"))
 
     content = gateway_windows._build_gateway_cmd_script(
@@ -199,11 +215,36 @@ def test_gateway_cmd_script_uses_pythonw_without_replace_or_start_churn(monkeypa
         "--profile alice",
     )
 
-    assert "pythonw.exe" in content
-    assert "gateway run" in content
-    assert "--replace" not in content
-    assert "start \"\"" not in content
+    assert "wscript.exe" in content
+    assert "%~dp0%~n0.vbs" in content, ".cmd must reference the companion .vbs by name"
     assert "exit /b 0" in content
+    # No direct pythonw invocation in the .cmd anymore
+    assert "pythonw.exe" not in content
+    assert "--replace" not in content
+
+
+def test_build_gateway_vbs_script_contains_env_and_hidden_run(monkeypatch):
+    """The VBS launcher must set environment variables and run pythonw hidden."""
+    monkeypatch.setattr(gateway_windows, "_derive_venv_pythonw", lambda exe: exe.replace("python.exe", "pythonw.exe"))
+
+    vbs = gateway_windows._build_gateway_vbs_script(
+        r"C:\\Hermes\\hermes-agent\\venv\\Scripts\\python.exe",
+        r"C:\\Hermes\\hermes-agent",
+        r"C:\\HermesHome\\profiles\\alice",
+        "--profile alice",
+    )
+
+    # Environment variables
+    assert 'HERMES_HOME' in vbs
+    assert 'PYTHONIOENCODING' in vbs
+    assert 'utf-8' in vbs
+    assert 'HERMES_GATEWAY_DETACHED' in vbs
+    assert 'VIRTUAL_ENV' in vbs
+    # Hidden run (SW_HIDE = 0)
+    assert 'WshShell.Run' in vbs
+    assert ', 0, False' in vbs, "Second argument to Run must be 0 (SW_HIDE)"
+    # Working directory
+    assert 'CurrentDirectory' in vbs
 
 
 def test_elevated_gateway_command_uses_pythonw_hidden_console(monkeypatch):


### PR DESCRIPTION
## Problem

On Windows, `hermes gateway install` creates a Scheduled Task that executes a `.cmd` batch file. Task Scheduler invariably opens a visible CMD console window when launching `.cmd` files — even when the script immediately launches `pythonw.exe` (GUI subsystem, no console) and exits. This causes a **visible CMD flash every time the ONLOGON trigger fires**.

The current `_build_gateway_cmd_script()` docstring acknowledges the goal of silent start, noting that `pythonw.exe` is a GUI-subsystem executable — but the parent `.cmd` file still creates a console window. `pythonw.exe` prevents the **gateway process** from showing a window, but does not prevent the **CMD host** from flashing one.

## Fix

Generate a companion **VBScript launcher** (`.vbs`) alongside the existing `.cmd`:

- **`.vbs` file** — runs via `wscript.exe` (true GUI subsystem, zero console window), sets environment variables & working directory, then spawns `pythonw.exe` with `SW_HIDE (0)`
- **`.cmd` file** — simplified to a thin wrapper: `wscript.exe //B //Nologo "%~dp0%~n0.vbs"`

The scheduled task still points at the `.cmd` file (no change to `_install_scheduled_task`), preserving the existing schtasks quoting and lifecycle contracts.

## Changes

`hermes_cli/gateway_windows.py`:
- **Add** `_build_gateway_vbs_script(python_path, working_dir, hermes_home, profile_arg)` — generates the VBScript launcher with proper VBS string escaping
- **Simplify** `_build_gateway_cmd_script()` — now just hands off to the VBS via `wscript.exe`, no longer sets env vars or runs pythonw directly
- **Update** `_write_task_script()` — writes both `.cmd` and `.vbs` files side by side

`tests/hermes_cli/test_gateway_windows.py`:
- **Update** `test_gateway_cmd_script_delegates_to_vbs_launcher` (was `test_gateway_cmd_script_uses_pythonw_without_replace_or_start_churn`) — verifies .cmd delegates to VBS, not pythonw directly
- **Add** `test_build_gateway_vbs_script_contains_env_and_hidden_run` — verifies VBS sets env vars and calls `Run(…, 0, False)`
- **Update** `test_write_task_script_writes_vbs_with_hermes_home_anchor` — verifies VBS is written alongside .cmd with correct working directory

## Testing

All 35 tests in `test_gateway_windows.py` pass on Windows 10 (Python 3.11):

```
35 passed in 4.86s
```

## User impact

| Before | After |
|--------|-------|
| CMD window flashes for 1-3s every login | **No visible window at all** |
| Env vars set in .cmd (lost if cmd exits early) | Env vars set in VBS (persists for child process) |
| Working dir set in .cmd | Working dir set in VBS |