### PR TITLE
fix(cron): accept system-generated "once at" schedule display in parse_schedule

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -286,16 +286,30 @@ def parse_duration(s: str) -> int:
     return value * multipliers[unit]
 
 
+# Matches the one-shot display string emitted by ``_schedule_display_for_job``
+# and the ISO-timestamp branch below (e.g. ``"once at 2026-06-19 12:00"``).
+# The Edit Job modal pre-fills its schedule input with that display string, so
+# parse_schedule must accept the system's own output. Case-insensitive and
+# whitespace-tolerant between tokens; optional seconds component.
+ONCE_AT_RE = re.compile(
+    r"^\s*once\s+at\s+"
+    r"(?P<date>\d{4}-\d{2}-\d{2})"
+    r"\s+"
+    r"(?P<time>\d{2}:\d{2}(?::\d{2})?)\s*$",
+    re.IGNORECASE,
+)
+
+
 def parse_schedule(schedule: str) -> Dict[str, Any]:
     """
     Parse schedule string into structured format.
-    
+
     Returns dict with:
         - kind: "once" | "interval" | "cron"
         - For "once": "run_at" (ISO timestamp)
         - For "interval": "minutes" (int)
         - For "cron": "expr" (cron expression)
-    
+
     Examples:
         "30m"              → once in 30 minutes
         "2h"               → once in 2 hours
@@ -303,11 +317,25 @@ def parse_schedule(schedule: str) -> Dict[str, Any]:
         "every 2h"         → recurring every 2 hours
         "0 9 * * *"        → cron expression
         "2026-02-03T14:00" → once at timestamp
+
+    Also accepts the ``"once at YYYY-MM-DD HH:MM[:SS]"`` form that the system
+    emits as a one-shot display string, so that re-submitting an unchanged
+    schedule_display (e.g. from the Edit Job modal) round-trips cleanly. This
+    form is system-generated and intentionally omitted from the user-facing
+    suggestion list below.
     """
     schedule = schedule.strip()
     original = schedule
     schedule_lower = schedule.lower()
-    
+
+    # System-emitted one-shot display string. Normalize to the ISO form and let
+    # the timestamp branch below produce an identical result (gateway-local
+    # time), so the display round-trips back to the same run_at.
+    once_at = ONCE_AT_RE.match(schedule)
+    if once_at:
+        schedule = f"{once_at.group('date')}T{once_at.group('time')}"
+        schedule_lower = schedule.lower()
+
     # "every X" pattern → recurring interval
     if schedule_lower.startswith("every "):
         duration_str = schedule[6:].strip()

--- a/tests/cron/test_jobs.py
+++ b/tests/cron/test_jobs.py
@@ -111,6 +111,72 @@ class TestParseSchedule:
             parse_schedule("99 99 99 99 99")
 
 
+class TestParseScheduleOnceAt:
+    """The display strings emitted for one-shot jobs must round-trip back
+    through parse_schedule().
+
+    ``_schedule_display_for_job`` / ``parse_schedule`` emit
+    ``"once at YYYY-MM-DD HH:MM"`` for one-shot jobs, and the Edit Job modal
+    pre-fills its schedule input with that display string. Re-feeding the
+    system's own output must succeed, not raise ``400 INVALID SCHEDULE``.
+    """
+
+    def test_once_at_round_trip_preserves_run_at(self):
+        # Core contract: the display a one-shot produces parses back to the
+        # exact same run_at.
+        iso = parse_schedule("2030-01-15T14:00:00")
+        assert iso["display"] == "once at 2030-01-15 14:00"
+
+        redo = parse_schedule(iso["display"])
+        assert redo["kind"] == "once"
+        assert redo["run_at"] == iso["run_at"]
+
+    def test_once_at_round_trip_via_created_job(self, tmp_cron_dir):
+        # The same contract, exercised through the real create_job path that
+        # populates schedule_display — this is what the Edit modal re-submits.
+        job = create_job(prompt="ping", schedule="2030-01-15T14:00:00")
+        assert job["schedule_display"] == "once at 2030-01-15 14:00"
+
+        redo = parse_schedule(job["schedule_display"])
+        assert redo["kind"] == "once"
+        assert redo["run_at"] == job["schedule"]["run_at"]
+
+    def test_once_at_case_insensitive(self):
+        baseline = parse_schedule("once at 2026-06-19 12:00")
+        for variant in ("ONCE AT 2026-06-19 12:00", "Once At 2026-06-19 12:00"):
+            result = parse_schedule(variant)
+            assert result["kind"] == "once"
+            assert result["run_at"] == baseline["run_at"]
+
+    def test_once_at_whitespace_tolerant(self):
+        baseline = parse_schedule("once at 2026-06-19 12:00")
+        result = parse_schedule("  once   at   2026-06-19   12:00  ")
+        assert result["kind"] == "once"
+        assert result["run_at"] == baseline["run_at"]
+
+    def test_once_at_with_seconds_retained(self):
+        result = parse_schedule("once at 2026-06-19 12:00:30")
+        assert result["kind"] == "once"
+        run_at = datetime.fromisoformat(result["run_at"])
+        assert (run_at.hour, run_at.minute, run_at.second) == (12, 0, 30)
+
+    def test_once_at_malformed_raises_with_original_hints(self):
+        # "once at <garbage>" must reject cleanly with the SAME suggestion
+        # list as today. The fix is additive: no new format hint is taught,
+        # because "once at ..." is system-emitted, not a user-facing format.
+        with pytest.raises(ValueError) as excinfo:
+            parse_schedule("once at banana")
+        message = str(excinfo.value)
+        assert "Duration:" in message
+        assert "Interval:" in message
+        assert "Cron:" in message
+        assert "Timestamp:" in message
+        # The suggestion block (everything after the echoed input) must NOT
+        # gain a new "once at" hint — that form is system-emitted, not taught.
+        hints = message.split("Use:", 1)[1]
+        assert "once at" not in hints.lower()
+
+
 # =========================================================================
 # compute_next_run
 # =========================================================================


### PR DESCRIPTION
## Summary

`cron/jobs.py::parse_schedule()` did not accept the
`"once at YYYY-MM-DD HH:MM"` form that
`_schedule_display_for_job()` emits for one-shot jobs. Because the Edit
Job modal pre-fills its schedule input with `schedule_display`, opening
an existing one-shot job and clicking Save without changes returns
`400 INVALID SCHEDULE 'once at ...'` — the parser rejects the system's
own previously-generated output.

This PR makes the parser accept the form, normalizing it to the same
internal representation as an ISO timestamp input.

## Reproduction (pre-fix)

1. Create a one-shot job with schedule `2026-06-19T12:00:00`. Saves OK,
   `schedule_display` becomes `"once at 2026-06-19 12:00"`.
2. Open the job in Edit Job. The schedule field is pre-filled with
   `"once at 2026-06-19 12:00"`.
3. Click Save without changes →
   `400 INVALID SCHEDULE 'once at 2026-06-19 12:00'`.

## Fix

Extend `parse_schedule()` to recognize the `"once at YYYY-MM-DD HH:MM"`
(and `HH:MM:SS`) form, case-insensitive, whitespace-tolerant. The
match is parsed as gateway-local time, then funneled into the
existing ISO-timestamp code path so downstream behavior is identical.

`_schedule_display_for_job()` is unchanged — the fix is purely
parser-side, so the contract going forward is: "anything the system
emits as a display string is a valid schedule input".

## Tests

- Round-trip property test: a job's `schedule_display`, re-fed to
  `parse_schedule()`, yields the same `run_at`.
- Case-insensitive parsing.
- Optional `:SS` component.
- Malformed `"once at ..."` still raises `ValueError` with the
  pre-existing four-format suggestion list (no public-API surface
  expansion for users).

All pre-existing cron tests pass locally.

## Non-goals

- No frontend changes. The Edit Job modal continues to pre-fill the
  schedule field with `schedule_display`; this PR just makes that
  pre-fill survive a no-op save.
- No new public format. `"once at ..."` is documented as system-emitted
  only; the user-facing format help (`Duration / Interval / Cron /
  Timestamp`) is unchanged.
