### PR TITLE
fix(acp): use skill user instruction for Desktop session titles

### DIFF
--- a/acp_adapter/server.py
+++ b/acp_adapter/server.py
@@ -9,6 +9,7 @@ import contextvars
 import json
 import logging
 import os
+import re
 from collections import defaultdict, deque
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
@@ -77,6 +78,8 @@ from acp_adapter.tools import build_tool_complete, build_tool_start
 
 logger = logging.getLogger(__name__)
 
+_SKILL_INVOCATION_RE = re.compile(r'^\[IMPORTANT: The user has invoked the "([^"]+)" (skill(?: bundle)?),')
+
 try:
     from hermes_cli import __version__ as HERMES_VERSION
 except Exception:
@@ -101,6 +104,24 @@ _TEXT_RESOURCE_MIME_TYPES = {
     "application/toml",
     "application/sql",
 }
+
+
+def _display_user_text_for_persistence(user_text: str) -> str:
+    """Return user-facing prompt text for session previews and titles."""
+    try:
+        from agent.skill_commands import extract_user_instruction_from_skill_message
+    except Exception:
+        return user_text or "[Image attachment]"
+
+    clean_text = extract_user_instruction_from_skill_message(user_text)
+    if clean_text:
+        return clean_text
+
+    match = _SKILL_INVOCATION_RE.match(user_text or "")
+    if match:
+        return f"{match.group(1)} {match.group(2)}"
+
+    return user_text or "[Image attachment]"
 
 
 def _resource_display_name(uri: str, name: str | None = None, title: str | None = None) -> str:
@@ -1380,6 +1401,7 @@ class HermesACPAgent(acp.Agent):
             state.is_running = True
             state.current_prompt_text = user_text or "[Image attachment]"
 
+        display_user_text = _display_user_text_for_persistence(user_text)
         logger.info("Prompt on session %s: %s", session_id, user_text[:100])
 
         conn = self._conn
@@ -1506,7 +1528,7 @@ class HermesACPAgent(acp.Agent):
                     user_message=user_content,
                     conversation_history=state.history,
                     task_id=session_id,
-                    persist_user_message=user_text or "[Image attachment]",
+                    persist_user_message=display_user_text,
                 )
                 return result
             except Exception as e:
@@ -1614,7 +1636,7 @@ class HermesACPAgent(acp.Agent):
                 maybe_auto_title(
                     self.session_manager._get_db(),
                     session_id,
-                    user_text,
+                    display_user_text,
                     final_response,
                     state.history,
                     title_callback=_notify_title_update,

--- a/tests/acp/test_server.py
+++ b/tests/acp/test_server.py
@@ -40,6 +40,31 @@ from acp_adapter.server import HermesACPAgent, HERMES_VERSION
 from acp_adapter.session import SessionManager
 from hermes_state import SessionDB
 
+_SKILL_TURN = (
+    '[IMPORTANT: The user has invoked the "release-triage" skill, indicating they want '
+    "you to follow its instructions. The full skill content is loaded below.]\n\n"
+    "# Release Triage\n\n"
+    "Large skill body that should stay model-facing only.\n\n"
+    "The user has provided the following instruction alongside the skill invocation: "
+    "summarize the failing release checks"
+)
+
+_BARE_SKILL_TURN = (
+    '[IMPORTANT: The user has invoked the "release-triage" skill, indicating they want '
+    "you to follow its instructions. The full skill content is loaded below.]\n\n"
+    "# Release Triage\n\n"
+    "Large skill body with no user instruction."
+)
+
+_BARE_BUNDLE_TURN = (
+    '[IMPORTANT: The user has invoked the "backend-dev" skill bundle, '
+    "loading 2 skills together. Treat every skill below as active guidance for this turn.]\n\n"
+    "Bundle: backend-dev\n"
+    "Skills loaded: test-driven-development, code-review\n\n"
+    '[Loaded as part of the "backend-dev" skill bundle.]\n\n'
+    "Large bundled skill body with no user instruction."
+)
+
 
 @pytest.fixture()
 def mock_manager():
@@ -1344,6 +1369,95 @@ class TestPrompt:
         assert mock_title.call_args.args[2] == "fix the broken ACP history"
         assert mock_title.call_args.args[3] == "Here is the fix."
         assert callable(mock_title.call_args.kwargs["title_callback"])
+
+    @pytest.mark.asyncio
+    async def test_prompt_persists_skill_instruction_for_preview_and_title(self, agent):
+        new_resp = await agent.new_session(cwd=".")
+        state = agent.session_manager.get_session(new_resp.session_id)
+
+        def mock_run(*args, **kwargs):
+            return {
+                "final_response": "The release check summary is ready.",
+                "messages": [
+                    {"role": "user", "content": kwargs["user_message"]},
+                    {"role": "assistant", "content": "The release check summary is ready."},
+                ],
+            }
+
+        state.agent.run_conversation = MagicMock(side_effect=mock_run)
+
+        mock_conn = MagicMock(spec=acp.Client)
+        mock_conn.session_update = AsyncMock()
+        agent._conn = mock_conn
+
+        with patch("agent.title_generator.maybe_auto_title") as mock_title:
+            await agent.prompt(
+                prompt=[TextContentBlock(type="text", text=_SKILL_TURN)],
+                session_id=new_resp.session_id,
+            )
+
+        state.agent.run_conversation.assert_called_once()
+        run_kwargs = state.agent.run_conversation.call_args.kwargs
+        assert run_kwargs["user_message"] == _SKILL_TURN
+        assert run_kwargs["persist_user_message"] == "summarize the failing release checks"
+        mock_title.assert_called_once()
+        assert mock_title.call_args.args[2] == "summarize the failing release checks"
+
+    @pytest.mark.asyncio
+    async def test_prompt_persists_bare_skill_label_not_scaffold(self, agent):
+        new_resp = await agent.new_session(cwd=".")
+        state = agent.session_manager.get_session(new_resp.session_id)
+        state.agent.run_conversation = MagicMock(return_value={
+            "final_response": "Ready.",
+            "messages": [
+                {"role": "user", "content": _BARE_SKILL_TURN},
+                {"role": "assistant", "content": "Ready."},
+            ],
+        })
+
+        mock_conn = MagicMock(spec=acp.Client)
+        mock_conn.session_update = AsyncMock()
+        agent._conn = mock_conn
+
+        with patch("agent.title_generator.maybe_auto_title") as mock_title:
+            await agent.prompt(
+                prompt=[TextContentBlock(type="text", text=_BARE_SKILL_TURN)],
+                session_id=new_resp.session_id,
+            )
+
+        run_kwargs = state.agent.run_conversation.call_args.kwargs
+        assert run_kwargs["user_message"] == _BARE_SKILL_TURN
+        assert run_kwargs["persist_user_message"] == "release-triage skill"
+        assert not run_kwargs["persist_user_message"].startswith("[IMPORTANT:")
+        assert mock_title.call_args.args[2] == "release-triage skill"
+
+    @pytest.mark.asyncio
+    async def test_prompt_persists_bare_bundle_label_not_scaffold(self, agent):
+        new_resp = await agent.new_session(cwd=".")
+        state = agent.session_manager.get_session(new_resp.session_id)
+        state.agent.run_conversation = MagicMock(return_value={
+            "final_response": "Ready.",
+            "messages": [
+                {"role": "user", "content": _BARE_BUNDLE_TURN},
+                {"role": "assistant", "content": "Ready."},
+            ],
+        })
+
+        mock_conn = MagicMock(spec=acp.Client)
+        mock_conn.session_update = AsyncMock()
+        agent._conn = mock_conn
+
+        with patch("agent.title_generator.maybe_auto_title") as mock_title:
+            await agent.prompt(
+                prompt=[TextContentBlock(type="text", text=_BARE_BUNDLE_TURN)],
+                session_id=new_resp.session_id,
+            )
+
+        run_kwargs = state.agent.run_conversation.call_args.kwargs
+        assert run_kwargs["user_message"] == _BARE_BUNDLE_TURN
+        assert run_kwargs["persist_user_message"] == "backend-dev skill bundle"
+        assert not run_kwargs["persist_user_message"].startswith("[IMPORTANT:")
+        assert mock_title.call_args.args[2] == "backend-dev skill bundle"
 
     @pytest.mark.asyncio
     async def test_prompt_sends_session_info_update_after_auto_title(self, agent):


### PR DESCRIPTION
## What does this PR do?

Fixes Desktop/ACP session titles and previews for slash-skill turns.

When a user invokes a skill, ACP still sends the full expanded skill message to the model so the skill instructions work normally. For the user-facing session preview and auto-title input, ACP now stores the extracted user instruction instead of the `[IMPORTANT: The user has invoked ...]` scaffolding and full skill body.

For a bare `/skill` invocation with no extra instruction, ACP stores a short fallback label like `release-triage skill` instead of the scaffold prefix.

## Related Issue

Fixes #48359

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `acp_adapter/server.py`
  - Reuses `extract_user_instruction_from_skill_message()` for ACP persistence/title text.
  - Keeps `user_message` passed to the agent unchanged, preserving model-facing skill behavior.
  - Uses the cleaned display text for `persist_user_message` and `maybe_auto_title()`.
- `tests/acp/test_server.py`
  - Adds regression coverage for skill turns with an instruction and bare skill turns.
  - Verifies the full scaffold still reaches the model while preview/title text stays clean.

## How to Test

```bash
/Users/blackishgreen03/workspace/hermes-agent/venv/bin/python -m pytest tests/acp/test_server.py -q
# 82 passed, 1 warning

/Users/blackishgreen03/workspace/hermes-agent/venv/bin/python -m pytest tests/agent/test_memory_skill_scaffolding.py -q
# 13 passed
```

Note: `python` is not on PATH in this local shell, so I used the repo's shared venv Python explicitly.

## Reviewer Notes

- No tool schema changes.
- No config or migration changes.
- No prompt-cache behavior change: the model still receives the full skill-expanded message for the turn.
