### PR TITLE
fix(gateway): suppress transient status chatter on chat platforms

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -68,8 +68,8 @@ _PLATFORM_CONNECT_TIMEOUT_SECS_DEFAULT = 30.0
 _ADAPTER_DISCONNECT_TIMEOUT_SECS_DEFAULT = 5.0
 _TELEGRAM_COMMAND_MENTION_RE = re.compile(r"(?<![\w:/])/([A-Za-z0-9][A-Za-z0-9_-]*)")
 
-_TELEGRAM_NOISY_STATUS_RE = re.compile(
-    r"("  # transient/auxiliary status that should stay in logs, not Telegram chat
+_GATEWAY_NOISY_STATUS_RE = re.compile(
+    r"("  # transient/auxiliary status that should stay in logs, not chat platforms
     r"auxiliary\s+.+\s+failed"
     r"|compression\s+summary\s+failed"
     r"|fallback\s+context\s+marker"
@@ -86,6 +86,8 @@ _TELEGRAM_NOISY_STATUS_RE = re.compile(
     r")",
     re.IGNORECASE | re.DOTALL,
 )
+# Backwards-compatible alias for tests/plugins that imported the old name.
+_TELEGRAM_NOISY_STATUS_RE = _GATEWAY_NOISY_STATUS_RE
 
 _GATEWAY_PROVIDER_ERROR_RE = re.compile(
     r"("  # infrastructure/provider error preambles, not ordinary assistant prose
@@ -363,12 +365,14 @@ def _prepare_gateway_status_message(platform: Any, event_type: str, message: str
     text = str(message or "").strip()
     if not text:
         return None
+
+    text = _redact_gateway_user_facing_secrets(text)
+    if _GATEWAY_NOISY_STATUS_RE.search(text):
+        return None
+
     if _gateway_platform_value(platform) != "telegram":
         return text
 
-    text = _redact_gateway_user_facing_secrets(text)
-    if _TELEGRAM_NOISY_STATUS_RE.search(text):
-        return None
     if _looks_like_gateway_provider_error(text):
         return _gateway_provider_error_reply(text)
     return text

--- a/tests/gateway/test_telegram_noise_filter.py
+++ b/tests/gateway/test_telegram_noise_filter.py
@@ -7,8 +7,8 @@ from gateway.run import (
 )
 
 
-def test_telegram_status_suppresses_auxiliary_and_retry_noise():
-    """Auxiliary failures and retry backoff chatter should not hit Telegram."""
+def test_gateway_status_suppresses_auxiliary_and_retry_noise_across_chat_platforms():
+    """Auxiliary failures and retry backoff chatter should not hit chat platforms."""
     noisy_messages = [
         "⚠ Auxiliary title generation failed: HTTP 400: Operation contains cybersecurity risk",
         "⚠ Compression summary failed: upstream error. Inserted a fallback context marker.",
@@ -19,14 +19,16 @@ def test_telegram_status_suppresses_auxiliary_and_retry_noise():
         "⚠️ Max retries (3) exhausted — trying fallback...",
     ]
 
-    for message in noisy_messages:
-        assert _prepare_gateway_status_message(Platform.TELEGRAM, "warn", message) is None
+    for platform in (Platform.TELEGRAM, Platform.FEISHU, Platform.DISCORD):
+        for message in noisy_messages:
+            assert _prepare_gateway_status_message(platform, "warn", message) is None
 
 
-def test_non_telegram_status_is_unchanged():
-    """The Telegram quieting policy must not hide CLI/Discord diagnostics."""
-    message = "⏳ Retrying in 4.2s (attempt 1/3)..."
+def test_non_noisy_status_is_unchanged_on_non_telegram_platforms():
+    """The gateway noise policy must preserve normal status on Feishu/Discord."""
+    message = "Working — terminal"
 
+    assert _prepare_gateway_status_message(Platform.FEISHU, "lifecycle", message) == message
     assert _prepare_gateway_status_message(Platform.DISCORD, "lifecycle", message) == message
     assert _prepare_gateway_status_message("local", "lifecycle", message) == message
 


### PR DESCRIPTION
## Summary
- generalize the transient status/noise filter from Telegram-only to chat-platform delivery
- keep auxiliary failures, compression-summary fallback chatter, retry/backoff notices, and max-retry fallback notices in logs instead of sending them to Feishu/Discord/Telegram chats
- preserve normal non-noisy status messages and Telegram provider-error formatting

## Tests
- `python -m py_compile gateway/run.py`
- `python -m pytest tests/gateway/test_telegram_noise_filter.py -o 'addopts=' -q`
- `python -m pytest tests/gateway/test_telegram_noise_filter.py tests/gateway/test_telegram_status_update.py tests/gateway/test_goal_status_notice.py -o 'addopts=' -q`
