### PR TITLE
fix(tui): use targeted save_config_value for model persistence (#48305)

### DIFF
--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -1780,11 +1780,15 @@ def test_config_set_model_global_persists(monkeypatch):
         seen.update(kwargs)
         return result
 
+    def _save_config_value(key_path, value):
+        saved[key_path] = value
+        return True
+
     server._sessions["sid"] = _session(agent=_Agent())
     monkeypatch.setattr("hermes_cli.model_switch.switch_model", _switch_model)
     monkeypatch.setattr(server, "_restart_slash_worker", lambda session: None)
     monkeypatch.setattr(server, "_emit", lambda *args, **kwargs: None)
-    monkeypatch.setattr("hermes_cli.config.save_config", lambda cfg: saved.update(cfg))
+    monkeypatch.setattr("cli.save_config_value", _save_config_value)
 
     resp = server.handle_request(
         {
@@ -1800,9 +1804,9 @@ def test_config_set_model_global_persists(monkeypatch):
 
     assert resp["result"]["value"] == "anthropic/claude-sonnet-4.6"
     assert seen["is_global"] is True
-    assert saved["model"]["default"] == "anthropic/claude-sonnet-4.6"
-    assert saved["model"]["provider"] == "anthropic"
-    assert saved["model"]["base_url"] == "https://api.anthropic.com"
+    assert saved["model.default"] == "anthropic/claude-sonnet-4.6"
+    assert saved["model.provider"] == "anthropic"
+    assert saved["model.base_url"] == "https://api.anthropic.com"
 
 
 def test_config_set_model_syncs_inference_provider_env(monkeypatch):

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -1086,21 +1086,12 @@ def _restart_slash_worker(session: dict):
 
 
 def _persist_model_switch(result) -> None:
-    from hermes_cli.config import save_config
+    from cli import save_config_value
 
-    cfg = _load_cfg()
-    model_cfg = cfg.get("model")
-    if not isinstance(model_cfg, dict):
-        model_cfg = {}
-        cfg["model"] = model_cfg
-
-    model_cfg["default"] = result.new_model
-    model_cfg["provider"] = result.target_provider
+    save_config_value("model.default", result.new_model)
+    save_config_value("model.provider", result.target_provider)
     if result.base_url:
-        model_cfg["base_url"] = result.base_url
-    else:
-        model_cfg.pop("base_url", None)
-    save_config(cfg)
+        save_config_value("model.base_url", result.base_url)
 
 
 def _apply_model_switch(sid: str, session: dict, raw_input: str) -> dict:


### PR DESCRIPTION
Fixes #48305. The TUI model picker's _persist_model_switch was using save_config() which rewrites the entire config.yaml via yaml.dump, losing comments and potentially clobbering unrelated config sections. Changed to use save_config_value() with atomic_roundtrip_yaml_update for surgical key-by-key persistence, matching the CLI's approach.