### PR TITLE
fix(desktop): dispose open PTY sessions in before-quit handler

### DIFF
--- a/apps/desktop/electron/main.cjs
+++ b/apps/desktop/electron/main.cjs
@@ -6551,6 +6551,12 @@ app.on('before-quit', () => {
   flushDesktopLogBufferSync()
   closePreviewWatchers()
 
+  // Kill open PTYs before environment teardown to avoid the node-pty#904
+  // ThreadSafeFunction SIGABRT race.
+  for (const id of [...terminalSessions.keys()]) {
+    disposeTerminalSession(id)
+  }
+
   if (hermesProcess && !hermesProcess.killed) {
     hermesProcess.kill('SIGTERM')
   }


### PR DESCRIPTION
## Summary

The `before-quit` handler tears down the bootstrap controller, preview watchers, and the Python backend — but never disposes live PTY sessions. When `app.quit()` proceeds to `FreeEnvironment()`, node-pty's `ThreadSafeFunction::CallJS` callback fires on a half-torn-down environment and the process aborts with `SIGABRT` (the upstream race documented in microsoft/node-pty#904).

This adds a `terminalSessions` sweep to `before-quit`, reusing the existing `disposeTerminalSession()` helper (which already calls `pty.kill()` and removes the map entry), so all ThreadSafeFunctions are torn down before the environment is freed.

## Changes

- Iterate `terminalSessions.keys()` in the `before-quit` handler and call `disposeTerminalSession()` for each entry, placed after `closePreviewWatchers()` and before `hermesProcess.kill('SIGTERM')`.

## Test plan

- [ ] Open one or more terminal sessions in Desktop (`/terminal` or built-in terminal tab)
- [ ] Quit the app (Cmd+Q / app menu → Quit) — verify no macOS crash report is generated
- [ ] Trigger an in-app update that calls `app.quit()` for the updater handoff — verify clean relaunch with no SIGABRT crash report
- [ ] Verify terminal sessions that were open before quit do not leak (no orphaned PTY child processes after quit)

Closes #48335