### PR TITLE
fix: prefer Hermes env key for OpenRouter fallback

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -103,7 +103,7 @@ OpenAI = _OpenAIProxy()  # module-level name, resolves lazily on call/isinstance
 from agent.credential_pool import load_pool
 from agent.model_metadata import MINIMUM_CONTEXT_LENGTH, get_model_context_length
 from agent.process_bootstrap import build_keepalive_http_client
-from hermes_cli.config import get_hermes_home
+from hermes_cli.config import get_env_value_prefer_dotenv, get_hermes_home
 from hermes_constants import OPENROUTER_BASE_URL
 from utils import base_url_host_matches, base_url_hostname, env_float, model_forces_max_completion_tokens, normalize_proxy_env_vars
 
@@ -1986,25 +1986,34 @@ def _resolve_api_key_provider() -> Tuple[Optional[OpenAI], Optional[str]]:
 
 
 def _try_openrouter(explicit_api_key: str = None, model: str = None) -> Tuple[Optional[OpenAI], Optional[str]]:
+    # A deliberate Hermes .env key must win over stale shell exports and
+    # manually-added pool entries. get_env_value_prefer_dotenv() also applies
+    # the active profile's secret scope to the process-environment fallback.
+    or_key = str(explicit_api_key or "").strip()
+    if not or_key:
+        or_key = str(get_env_value_prefer_dotenv("OPENROUTER_API_KEY") or "").strip()
+    if or_key:
+        logger.debug("Auxiliary client: OpenRouter via explicit/env key")
+        return _create_openai_client(
+            api_key=or_key,
+            base_url=OPENROUTER_BASE_URL,
+            default_headers=build_or_headers(),
+        ), model or _OPENROUTER_MODEL
+
     pool_present, entry = _select_pool_entry("openrouter")
     if pool_present:
-        or_key = explicit_api_key or _pool_runtime_api_key(entry)
+        or_key = _pool_runtime_api_key(entry)
         if or_key:
             base_url = _pool_runtime_base_url(entry, OPENROUTER_BASE_URL) or OPENROUTER_BASE_URL
             logger.debug("Auxiliary client: OpenRouter via pool")
             return _create_openai_client(api_key=or_key, base_url=base_url,
                            default_headers=build_or_headers()), model or _OPENROUTER_MODEL
-        # Pool exists but is exhausted (no usable runtime key) — fall through to
-        # the OPENROUTER_API_KEY env-var path rather than failing outright.
-        logger.debug("Auxiliary client: OpenRouter pool exhausted, trying OPENROUTER_API_KEY")
+        # Explicit and environment credentials were checked before the pool, so
+        # an exhausted pool entry is the final credential source to consider.
+        logger.debug("Auxiliary client: OpenRouter pool exhausted after explicit/env lookup")
 
-    or_key = explicit_api_key or os.getenv("OPENROUTER_API_KEY")
-    if not or_key:
-        _mark_provider_unhealthy("openrouter", ttl=60)
-        return None, None
-    logger.debug("Auxiliary client: OpenRouter")
-    return _create_openai_client(api_key=or_key, base_url=OPENROUTER_BASE_URL,
-                   default_headers=build_or_headers()), model or _OPENROUTER_MODEL
+    _mark_provider_unhealthy("openrouter", ttl=60)
+    return None, None
 
 
 def _describe_openrouter_unavailable() -> str:
@@ -2015,7 +2024,7 @@ def _describe_openrouter_unavailable() -> str:
             return "OpenRouter credential pool has no usable entries (credentials may be exhausted)"
         if not _pool_runtime_api_key(entry):
             return "OpenRouter credential pool entry is missing a runtime API key"
-    if not str(os.getenv("OPENROUTER_API_KEY") or "").strip():
+    if not str(get_env_value_prefer_dotenv("OPENROUTER_API_KEY") or "").strip():
         return "OPENROUTER_API_KEY not set"
     return "no usable OpenRouter credentials found"
 

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -1101,6 +1101,39 @@ class TestExplicitProviderRouting:
             for record in caplog.records
         )
 
+    def test_try_openrouter_dotenv_key_beats_manual_pool_entry(self, tmp_path, monkeypatch):
+        """A Hermes .env key must win over stale manual OpenRouter credentials."""
+        hermes_home = tmp_path / "hermes"
+        hermes_home.mkdir()
+        (hermes_home / ".env").write_text("OPENROUTER_API_KEY=dotenv-openrouter-key\n")
+        (hermes_home / "auth.json").write_text(json.dumps({
+            "version": 1,
+            "credential_pool": {
+                "openrouter": [{
+                    "id": "stale-manual-entry",
+                    "label": "stale manual key",
+                    "auth_type": "api_key",
+                    "priority": 0,
+                    "source": "manual",
+                    "access_token": "stale-manual-openrouter-key",
+                    "base_url": OPENROUTER_BASE_URL,
+                }],
+            },
+        }))
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.setenv("OPENROUTER_API_KEY", "stale-shell-openrouter-key")
+
+        from hermes_cli.config import invalidate_env_cache
+
+        invalidate_env_cache()
+        with patch("agent.auxiliary_client.OpenAI") as mock_openai:
+            client, model = _try_openrouter()
+
+        assert client is mock_openai.return_value
+        assert model == _OPENROUTER_MODEL
+        assert mock_openai.call_args.kwargs["api_key"] == "dotenv-openrouter-key"
+        assert mock_openai.call_args.kwargs["base_url"] == OPENROUTER_BASE_URL
+
     def test_try_openrouter_pool_exhausted_falls_back_to_env(self, monkeypatch):
         """Pool present but exhausted → fall through to OPENROUTER_API_KEY env var."""
         monkeypatch.setenv("OPENROUTER_API_KEY", "sk-or-env-fallback")


### PR DESCRIPTION
## What does this PR do?

Fixes auxiliary OpenRouter credential precedence on current `main`. `_try_openrouter()` now uses `get_env_value_prefer_dotenv()` before consulting the OpenRouter credential pool, so a deliberate Hermes `.env` key wins over both a stale shell export and a stale manual pool entry. Explicit caller-provided keys remain the highest-precedence source.

The implementation continues to construct clients through `_create_openai_client()` and applies the same `.env`-first lookup to the unavailable diagnostic.

## Related Issue

Fixes #48829

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `agent/auxiliary_client.py`
  - Prefer explicit key, then `get_env_value_prefer_dotenv("OPENROUTER_API_KEY")`, then a usable credential-pool entry.
  - Preserve `_create_openai_client()` construction and scoped process-environment fallback.
  - Align OpenRouter unavailable diagnostics with the `.env`-first resolver.
- `tests/agent/test_auxiliary_client.py`
  - Add an integration-style regression test with a temporary `HERMES_HOME`, a real `.env` key, a persisted stale manual pool entry, and a stale shell export.

## How to Test

1. `HOME=/home/ubuntu ./scripts/run_tests.sh tests/agent/test_auxiliary_client.py -q`
2. Confirm the regression test selects `dotenv-openrouter-key`, not the stale manual-pool or shell key.
3. Run `git diff --check origin/main...HEAD`.

Result: the canonical per-file runner passed all 317 tests in `tests/agent/test_auxiliary_client.py` in 19.0 seconds; `py_compile` and `git diff --check` also passed.

## Checklist

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md) (not re-read for this update)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass (not run locally)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Not applicable.
