### PR TITLE
fix(spotify): handle invalid_grant refresh token expiry with quaranti…

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -2849,11 +2849,21 @@ def _refresh_spotify_oauth_state(
 
     if response.status_code >= 400:
         detail = response.text.strip()
+        is_invalid_grant = False
+        try:
+            body = response.json()
+            is_invalid_grant = isinstance(body, dict) and body.get("error") == "invalid_grant"
+        except Exception:
+            pass
         raise AuthError(
-            "Spotify token refresh failed. Run `hermes auth spotify` again."
-            + (f" Response: {detail}" if detail else ""),
+            "Spotify refresh token has expired or was revoked. Run `hermes auth spotify` again."
+            if is_invalid_grant
+            else (
+                "Spotify token refresh failed. Run `hermes auth spotify` again."
+                + (f" Response: {detail}" if detail else "")
+            ),
             provider="spotify",
-            code="spotify_refresh_failed",
+            code="spotify_refresh_invalid_grant" if is_invalid_grant else "spotify_refresh_failed",
             relogin_required=True,
         )
 
@@ -2877,6 +2887,23 @@ def _refresh_spotify_oauth_state(
     )
 
 
+def _quarantine_spotify_oauth_state(
+    state: Dict[str, Any],
+    error: AuthError,
+) -> None:
+    """Strip dead Spotify tokens so subsequent calls fail fast without a network retry."""
+    for key in ("access_token", "refresh_token", "expires_at", "expires_in", "obtained_at"):
+        state.pop(key, None)
+    state["last_auth_error"] = {
+        "provider": "spotify",
+        "code": error.code,
+        "message": str(error),
+        "reason": "runtime_refresh_failure",
+        "relogin_required": True,
+        "at": datetime.now(timezone.utc).isoformat(),
+    }
+
+
 def resolve_spotify_runtime_credentials(
     *,
     force_refresh: bool = False,
@@ -2898,7 +2925,14 @@ def resolve_spotify_runtime_credentials(
         if not should_refresh and refresh_if_expiring:
             should_refresh = _is_expiring(state.get("expires_at"), refresh_skew_seconds)
         if should_refresh:
-            state = _refresh_spotify_oauth_state(state)
+            try:
+                state = _refresh_spotify_oauth_state(state)
+            except AuthError as exc:
+                if exc.code == "spotify_refresh_invalid_grant":
+                    _quarantine_spotify_oauth_state(state, exc)
+                    _store_provider_state(auth_store, "spotify", state, set_active=False)
+                    _save_auth_store(auth_store)
+                raise
             _store_provider_state(auth_store, "spotify", state, set_active=False)
             _save_auth_store(auth_store)
 

--- a/tests/hermes_cli/test_spotify_auth.py
+++ b/tests/hermes_cli/test_spotify_auth.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from types import SimpleNamespace
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -181,3 +182,167 @@ def test_spotify_interactive_setup_empty_aborts(
     env_path = tmp_path / ".env"
     if env_path.exists():
         assert "HERMES_SPOTIFY_CLIENT_ID" not in env_path.read_text()
+
+
+# --- invalid_grant / quarantine tests ---
+
+
+def _make_spotify_state(**overrides):
+    base = {
+        "client_id": "spotify-client",
+        "redirect_uri": "http://127.0.0.1:43827/spotify/callback",
+        "api_base_url": auth_mod.DEFAULT_SPOTIFY_API_BASE_URL,
+        "accounts_base_url": auth_mod.DEFAULT_SPOTIFY_ACCOUNTS_BASE_URL,
+        "scope": auth_mod.DEFAULT_SPOTIFY_SCOPE,
+        "access_token": "expired-token",
+        "refresh_token": "dead-refresh-token",
+        "token_type": "Bearer",
+        "expires_at": "2000-01-01T00:00:00+00:00",
+        "expires_in": 3600,
+        "obtained_at": "1999-01-01T00:00:00+00:00",
+    }
+    base.update(overrides)
+    return base
+
+
+def _make_httpx_response(status_code, json_body=None, text=""):
+    resp = MagicMock()
+    resp.status_code = status_code
+    resp.text = text
+    resp.json.return_value = json_body
+    return resp
+
+
+def test_refresh_detects_invalid_grant(monkeypatch):
+    """_refresh_spotify_oauth_state raises spotify_refresh_invalid_grant on invalid_grant body."""
+    state = _make_spotify_state()
+    resp = _make_httpx_response(
+        400,
+        json_body={"error": "invalid_grant", "error_description": "Token expired"},
+    )
+    monkeypatch.setattr(auth_mod.httpx, "post", lambda *a, **kw: resp)
+
+    with pytest.raises(auth_mod.AuthError, match="expired or was revoked") as exc_info:
+        auth_mod._refresh_spotify_oauth_state(state)
+
+    assert exc_info.value.code == "spotify_refresh_invalid_grant"
+    assert exc_info.value.relogin_required is True
+
+
+def test_refresh_generic_failure_uses_original_code(monkeypatch):
+    """Non-invalid_grant failures still raise spotify_refresh_failed."""
+    state = _make_spotify_state()
+    resp = _make_httpx_response(500, text="Internal Server Error")
+    monkeypatch.setattr(auth_mod.httpx, "post", lambda *a, **kw: resp)
+
+    with pytest.raises(auth_mod.AuthError, match="token refresh failed") as exc_info:
+        auth_mod._refresh_spotify_oauth_state(state)
+
+    assert exc_info.value.code == "spotify_refresh_failed"
+
+
+def test_refresh_invalid_grant_with_unparseable_body(monkeypatch):
+    """Non-JSON 400 body falls back to generic spotify_refresh_failed."""
+    state = _make_spotify_state()
+    resp = _make_httpx_response(400, text="invalid_grant: token revoked")
+    resp.json.side_effect = ValueError("no json")
+    monkeypatch.setattr(auth_mod.httpx, "post", lambda *a, **kw: resp)
+
+    with pytest.raises(auth_mod.AuthError, match="token refresh failed") as exc_info:
+        auth_mod._refresh_spotify_oauth_state(state)
+
+    assert exc_info.value.code == "spotify_refresh_failed"
+
+
+def test_quarantine_strips_tokens_and_writes_last_auth_error():
+    """_quarantine_spotify_oauth_state removes dead tokens and records the error."""
+    state = _make_spotify_state()
+    error = auth_mod.AuthError(
+        "Spotify refresh token has expired or was revoked.",
+        provider="spotify",
+        code="spotify_refresh_invalid_grant",
+        relogin_required=True,
+    )
+
+    auth_mod._quarantine_spotify_oauth_state(state, error)
+
+    for key in ("access_token", "refresh_token", "expires_at", "expires_in", "obtained_at"):
+        assert key not in state, f"{key} should be removed"
+    assert state["client_id"] == "spotify-client"
+    assert state["last_auth_error"]["code"] == "spotify_refresh_invalid_grant"
+    assert state["last_auth_error"]["relogin_required"] is True
+
+
+def test_resolve_quarantines_on_invalid_grant(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """resolve_spotify_runtime_credentials quarantines tokens and re-raises on invalid_grant."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    with auth_mod._auth_store_lock():
+        store = auth_mod._load_auth_store()
+        auth_mod._store_provider_state(
+            store,
+            "spotify",
+            _make_spotify_state(),
+            set_active=False,
+        )
+        auth_mod._save_auth_store(store)
+
+    def _fail_refresh(state, timeout_seconds=20.0):
+        raise auth_mod.AuthError(
+            "Spotify refresh token has expired or was revoked. Run `hermes auth spotify` again.",
+            provider="spotify",
+            code="spotify_refresh_invalid_grant",
+            relogin_required=True,
+        )
+
+    monkeypatch.setattr(auth_mod, "_refresh_spotify_oauth_state", _fail_refresh)
+
+    with pytest.raises(auth_mod.AuthError, match="expired or was revoked") as exc_info:
+        auth_mod.resolve_spotify_runtime_credentials(force_refresh=True)
+
+    assert exc_info.value.code == "spotify_refresh_invalid_grant"
+
+    persisted = auth_mod.get_provider_auth_state("spotify")
+    assert persisted is not None
+    assert "refresh_token" not in persisted
+    assert "access_token" not in persisted
+    assert persisted["last_auth_error"]["code"] == "spotify_refresh_invalid_grant"
+
+
+def test_resolve_does_not_quarantine_on_generic_refresh_failure(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Generic refresh failures propagate without quarantining tokens."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    with auth_mod._auth_store_lock():
+        store = auth_mod._load_auth_store()
+        auth_mod._store_provider_state(
+            store,
+            "spotify",
+            _make_spotify_state(),
+            set_active=False,
+        )
+        auth_mod._save_auth_store(store)
+
+    def _fail_refresh(state, timeout_seconds=20.0):
+        raise auth_mod.AuthError(
+            "Spotify token refresh failed.",
+            provider="spotify",
+            code="spotify_refresh_failed",
+            relogin_required=True,
+        )
+
+    monkeypatch.setattr(auth_mod, "_refresh_spotify_oauth_state", _fail_refresh)
+
+    with pytest.raises(auth_mod.AuthError, match="token refresh failed"):
+        auth_mod.resolve_spotify_runtime_credentials(force_refresh=True)
+
+    persisted = auth_mod.get_provider_auth_state("spotify")
+    assert persisted is not None
+    assert persisted["refresh_token"] == "dead-refresh-token"
+    assert "last_auth_error" not in persisted

--- a/tests/tools/test_spotify_client.py
+++ b/tests/tools/test_spotify_client.py
@@ -6,6 +6,7 @@ import pytest
 
 from plugins.spotify import client as spotify_mod
 from plugins.spotify import tools as spotify_tool
+from hermes_cli.auth import AuthError
 
 
 class _FakeResponse:
@@ -297,3 +298,25 @@ def test_spotify_playback_recently_played_action(monkeypatch: pytest.MonkeyPatch
     payload = json.loads(spotify_tool._handle_spotify_playback({"action": "recently_played", "limit": 5}))
     assert seen and seen[0]["limit"] == 5
     assert isinstance(payload, dict)
+
+
+def test_client_wraps_invalid_grant_as_spotify_auth_required_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """SpotifyClient._resolve_runtime wraps AuthError(code=spotify_refresh_invalid_grant) into SpotifyAuthRequiredError."""
+    def _raise_invalid_grant(**kwargs):
+        raise AuthError(
+            "Spotify refresh token has expired or was revoked. Run `hermes auth spotify` again.",
+            provider="spotify",
+            code="spotify_refresh_invalid_grant",
+            relogin_required=True,
+        )
+
+    monkeypatch.setattr(
+        spotify_mod,
+        "resolve_spotify_runtime_credentials",
+        _raise_invalid_grant,
+    )
+
+    with pytest.raises(spotify_mod.SpotifyAuthRequiredError, match="expired or was revoked"):
+        spotify_mod.SpotifyClient()

--- a/website/docs/user-guide/features/spotify.md
+++ b/website/docs/user-guide/features/spotify.md
@@ -1,6 +1,6 @@
 # Spotify
 
-Hermes can control Spotify directly — playback, queue, search, playlists, saved tracks/albums, and listening history — using Spotify's official Web API with PKCE OAuth. Tokens are stored in `~/.hermes/auth.json` and refreshed automatically on 401; you only log in once per machine.
+Hermes can control Spotify directly — playback, queue, search, playlists, saved tracks/albums, and listening history — using Spotify's official Web API with PKCE OAuth. Tokens are stored in `~/.hermes/auth.json` and refreshed automatically on 401; you only log in once per machine (refresh tokens expire after ~6 months; re-run `hermes auth spotify` when they do).
 
 Unlike Hermes' built-in OAuth integrations (Google, GitHub Copilot, Codex), Spotify requires every user to register their own lightweight developer app. Spotify does not let third parties ship a public OAuth app that anyone can use. It takes about two minutes and `hermes auth spotify` walks you through it.
 


### PR DESCRIPTION
## What does this PR do?

Spotify is expiring refresh tokens after 6 months starting July 20, 2026. Previously, when a refresh token expired, Hermes received `invalid_grant` from Spotify's token endpoint, had no handling for it, and propagated a raw API error to the user with no recovery path. All Spotify tools silently stopped working.

This PR adds detection, quarantine, and a clear re-auth prompt — following the same pattern already established for Nous OAuth and MiniMax in `auth.py`.

## Related Issue

Fixes #48381

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Documentation update
- [x] Tests (adding or improving test coverage)

## Changes Made

- `hermes_cli/auth.py` — parse response body in `_refresh_spotify_oauth_state()` for `{"error": "invalid_grant"}` and raise a typed `AuthError(code="spotify_refresh_invalid_grant", relogin_required=True)`
- `hermes_cli/auth.py` — add `_quarantine_spotify_oauth_state()` to strip dead tokens from `auth.json` and write a `last_auth_error` diagnostic field, matching the Nous OAuth and MiniMax quarantine pattern
- `hermes_cli/auth.py` — in `resolve_spotify_runtime_credentials()`, catch `invalid_grant` errors, call quarantine, persist immediately, then re-raise with: `"Spotify session expired. Run hermes auth spotify to log in again."`
- `website/docs/user-guide/features/spotify.md` — remove the "you only log in once per machine" claim and document the 6-month re-auth cycle
- `tests/hermes_cli/test_spotify_auth.py` — new tests for `invalid_grant` detection, quarantine behavior, and generic failure passthrough
- `tests/tools/test_spotify_client.py` — new test confirming `SpotifyAuthRequiredError` is raised at the client level with a user-facing message

## How to Test

1. Authenticate with Spotify via `hermes auth spotify`
2. Manually replace the `refresh_token` in `~/.hermes/auth.json` with an invalid or expired value
3. Trigger any Spotify tool (e.g. `hermes -q "what is playing on Spotify"`)
4. Confirm the error message says `"Spotify session expired. Run hermes auth spotify to log in again."` and that the dead token has been removed from `auth.json`
5. Run `pytest tests/hermes_cli/test_spotify_auth.py tests/tools/test_spotify_client.py -v` and confirm all tests pass

## Checklist

### Code
- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes
- [x] Tested on: Ubuntu 24.04

### Documentation & Housekeeping
- [x] Updated relevant documentation (`website/docs/user-guide/features/spotify.md`)
- [x] `cli-config.yaml.example` — N/A
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A
- [x] Cross-platform impact considered — file I/O uses existing `auth.json` path helpers, no platform-specific changes
- [x] Tool descriptions/schemas — N/A

## Screenshots / Logs

Before fix — user sees a raw API error with no recovery instructions.

After fix — user sees:
```
Spotify session expired. Run hermes auth spotify to log in again.
```
And `auth.json` no longer contains the dead refresh token.