### PR TITLE
fix(telegram): use message_thread_id metadata for DM topic sends

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -11534,7 +11534,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # route to the correct topic even when reply anchor is unavailable.
             tid = str(thread_id)
             if tid and tid not in {"", "1"}:
-                metadata["direct_messages_topic_id"] = tid
+                metadata["message_thread_id"] = tid
             if reply_to_message_id is not None:
                 metadata["telegram_reply_to_message_id"] = str(reply_to_message_id)
         return metadata

--- a/tests/gateway/test_dm_topic_thread_metadata.py
+++ b/tests/gateway/test_dm_topic_thread_metadata.py
@@ -1,0 +1,24 @@
+"""Lock down the DM-topic metadata key for `_thread_metadata_for_target`.
+
+Regression test for the bot-API-routing fix: the topic id must live
+under `message_thread_id` (the standard Bot API field), NOT under
+`direct_messages_topic_id` (a legacy key that `sendMessage` silently
+ignores — which is why startup/shutdown notifications used to land
+in the DM root instead of the configured topic).
+"""
+from unittest.mock import patch
+
+from gateway.config import Platform
+from gateway.run import GatewayRunner
+
+
+def test_dm_topic_target_uses_message_thread_id():
+    runner = GatewayRunner.__new__(GatewayRunner)
+
+    with patch.object(GatewayRunner, "_is_telegram_dm_topic_target", return_value=True):
+        meta = runner._thread_metadata_for_target(
+            Platform.TELEGRAM, "777", "239",
+        )
+
+    assert meta["message_thread_id"] == "239"
+    assert "direct_messages_topic_id" not in meta


### PR DESCRIPTION
## What does this PR do?

Swaps `direct_messages_topic_id` for `message_thread_id` in the topic-routing metadata built by `GatewayRunner._thread_metadata_for_target`. The previous key is only honored by the local-message flow; `sendMessage` ignores it, so the gateway's own startup and shutdown notifications reached the DM root instead of the configured home-channel topic. Operators saw the "♻️ Gateway online" message appear in the lobby even though `TELEGRAM_HOME_CHANNEL_THREAD_ID` was set, and the gateway log happily reported "Sent home-channel startup notification" — making the bug invisible until you actually looked at the chat.

## Related Issue

I'm too lazy to prompt this for a single line change.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `gateway/run.py` (line 11537) — in the DM-topic metadata builder, replace `metadata["direct_messages_topic_id"] = tid` with `metadata["message_thread_id"] = tid`. Affects every caller of the same metadata dict: home-channel startup notifications, home-channel shutdown notifications, and any other topic-routed synthetic send that goes through `_thread_metadata_for_target` without a reply anchor.

## How to Test

Repro requires a Telegram DM with topics enabled and a configured home channel pointing at a non-root topic.

1. In `~/.hermes/.env`:
   ```
   TELEGRAM_HOME_CHANNEL=<your_chat_id>
   TELEGRAM_HOME_CHANNEL_THREAD_ID=<system_topic_id>
   TELEGRAM_REPLY_TO_MODE=off
   ```
2. Restart the gateway: `~/.hermes/skills/restart-hermes-gateway/scripts/restart-gw.sh`.
3. Watch `~/.hermes/logs/gateway.log` for the startup line.

**Before the fix:** the gateway log shows a clean

```
INFO gateway.run: Sent home-channel startup notification to telegram:<chat_id>
```

— i.e. the send *succeeds* with no errors, but the "♻️ Gateway online" message arrives in the DM root (the General lobby of topic mode), not in `<system_topic_id>`. The shutdown counterpart behaves the same way: the log says the notification was sent, but it lands in the wrong topic. From the operator's perspective, the home channel appears to "work" but the topic routing is silently broken.

**After the fix:** the log still shows

```
INFO gateway.run: Sent home-channel startup notification to telegram:<chat_id>
```

— but this time the "♻️ Gateway online" message arrives in the configured `<system_topic_id>` topic, not the DM root. Same for the shutdown notification. The only observable difference is *where* the message lands; the gateway log is identical.

4. Quick automated check: `pytest tests/gateway/test_dm_topic_thread_metadata.py -v` — the new test pins the metadata key. If anyone ever puts `direct_messages_topic_id` back, it fails.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Debian 13 (kernel 6.12)

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A **(N/A)**
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A **(N/A)**
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A **(N/A)**
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A (no platform-specific code touched) **(N/A)**
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A **(N/A)**


## Screenshots / Logs

The log line is identical before and after — the bug was silent.
The only observable difference is *where* the "♻️ Gateway online" message arrives in the Telegram client: the DM root (before) vs. `<system_topic_id>` (after). The shutdown notification behaves the same way.