### PR TITLE
fix(tui): MCP headline counts connected servers, not disabled ones

### DIFF
--- a/ui-tui/src/__tests__/brandingMcpCount.test.ts
+++ b/ui-tui/src/__tests__/brandingMcpCount.test.ts
@@ -1,0 +1,111 @@
+import { PassThrough } from 'stream'
+
+import { renderSync } from '@hermes/ink'
+import React from 'react'
+import { describe, expect, it } from 'vitest'
+
+import { SessionPanel } from '../components/branding.js'
+import { DEFAULT_THEME } from '../theme.js'
+import type { McpServerStatus, SessionInfo } from '../types.js'
+
+// Invariant under test: the TUI banner's MCP headline counts *connected*
+// servers, never configured-but-disabled ones. This mirrors the classic CLI
+// banner (`mcp_connected = sum(1 for s in mcp_status if s["connected"])` in
+// hermes_cli/banner.py) and the "connected" label on the MCP collapse toggle.
+//
+// Regression: branding.tsx used the raw `info.mcp_servers.length`, so a
+// disabled `linear` server alongside a connected `nous-support` server made
+// the TUI report "2 MCP" while the classic CLI correctly reported "1 MCP".
+
+const delay = (ms: number) => new Promise(resolve => setTimeout(resolve, ms))
+
+const makeStreams = (columns = 100) => {
+  const stdout = new PassThrough()
+  const stdin = new PassThrough()
+  const stderr = new PassThrough()
+
+  Object.assign(stdout, { columns, isTTY: false, rows: 40 })
+  Object.assign(stdin, { isTTY: false })
+  Object.assign(stderr, { isTTY: false })
+
+  let captured = ''
+  stdout.on('data', chunk => {
+    captured += chunk.toString()
+  })
+
+  return { capture: () => captured, stderr, stdin, stdout }
+}
+
+const mcp = (over: Partial<McpServerStatus> & Pick<McpServerStatus, 'name'>): McpServerStatus => ({
+  connected: false,
+  tools: 0,
+  transport: 'http',
+  ...over
+})
+
+const baseInfo = (mcp_servers: McpServerStatus[]): SessionInfo => ({
+  mcp_servers,
+  model: 'test-model',
+  skills: { core: ['a', 'b'] },
+  tools: { file: ['read_file', 'write_file'] }
+})
+
+async function renderFooter(info: SessionInfo): Promise<string> {
+  const streams = makeStreams()
+
+  const instance = renderSync(React.createElement(SessionPanel, { info, sid: 'test', t: DEFAULT_THEME }), {
+    patchConsole: false,
+    stderr: streams.stderr as NodeJS.WriteStream,
+    stdin: streams.stdin as NodeJS.ReadStream,
+    stdout: streams.stdout as NodeJS.WriteStream
+  })
+
+  try {
+    await delay(20)
+
+    // Strip ANSI so we can assert on the rendered text content.
+    // eslint-disable-next-line no-control-regex
+    return streams.capture().replace(/\u001b\[[0-9;]*m/g, '')
+  } finally {
+    instance.unmount()
+    instance.cleanup()
+  }
+}
+
+describe('branding MCP headline count', () => {
+  it('counts only connected servers, not configured-but-disabled ones', async () => {
+    const frame = await renderFooter(
+      baseInfo([
+        mcp({ connected: true, name: 'nous-support', status: 'connected', tools: 6 }),
+        mcp({ connected: false, disabled: true, name: 'linear', status: 'disabled' })
+      ])
+    )
+
+    // One connected server → "1 MCP", never "2 MCP".
+    expect(frame).toContain('1 MCP')
+    expect(frame).not.toContain('2 MCP')
+  })
+
+  it('drops the MCP segment entirely when no server is connected', async () => {
+    const frame = await renderFooter(
+      baseInfo([mcp({ connected: false, disabled: true, name: 'linear', status: 'disabled' })])
+    )
+
+    // Matches the classic CLI, which only appends "· N MCP" when N > 0.
+    expect(frame).not.toContain('MCP servers')
+    expect(frame).not.toMatch(/\d MCP\b/)
+  })
+
+  it('counts every connected server when several are connected', async () => {
+    const frame = await renderFooter(
+      baseInfo([
+        mcp({ connected: true, name: 'alpha', status: 'connected' }),
+        mcp({ connected: true, name: 'beta', status: 'connected' }),
+        mcp({ connected: false, disabled: true, name: 'gamma', status: 'disabled' })
+      ])
+    )
+
+    expect(frame).toContain('2 MCP')
+    expect(frame).not.toContain('3 MCP')
+  })
+})

--- a/ui-tui/src/components/branding.tsx
+++ b/ui-tui/src/components/branding.tsx
@@ -223,6 +223,12 @@ export function SessionPanel({ info, maxWidth, sid, t }: SessionPanelProps) {
   const toolEntries = Object.entries(info.tools).sort()
   const toolsTotal = flat(info.tools).length
 
+  // MCP headline counts *connected* servers, not configured-but-disabled ones,
+  // so it matches the classic CLI banner (`sum(s.connected)` in
+  // hermes_cli/banner.py) and the "connected" label on the collapse toggle.
+  const mcpServers = info.mcp_servers ?? []
+  const mcpConnected = mcpServers.filter(s => s.connected).length
+
   const toolsBody = () => {
     const shown = toolEntries.slice(0, TOOLSETS_MAX)
     const overflow = toolEntries.length - TOOLSETS_MAX
@@ -376,10 +382,10 @@ export function SessionPanel({ info, maxWidth, sid, t }: SessionPanelProps) {
         )}
 
         {/* ── MCP Servers (collapsed by default) ── */}
-        {info.mcp_servers && info.mcp_servers.length > 0 && (
+        {mcpServers.length > 0 && (
           <Box flexDirection="column" marginTop={1}>
             <CollapseToggle
-              count={info.mcp_servers.length}
+              count={mcpConnected}
               onToggle={() => setMcpOpen(v => !v)}
               open={mcpOpen}
               suffix="connected"
@@ -395,7 +401,7 @@ export function SessionPanel({ info, maxWidth, sid, t }: SessionPanelProps) {
         <Text color={t.color.text}>
           {toolsTotal} tools{' · '}
           {skillsTotal} skills
-          {info.mcp_servers?.length ? ` · ${info.mcp_servers.length} MCP` : ''}
+          {mcpConnected ? ` · ${mcpConnected} MCP` : ''}
           {' · '}
           <Text color={t.color.muted}>/help for commands</Text>
         </Text>


### PR DESCRIPTION
The TUI banner counted MCP servers with the raw `info.mcp_servers.length`, so a configured-but-**disabled** server was tallied alongside connected ones.

## Symptom

Same machine, same config:
- `hermes` (classic CLI): `38 tools · 1 MCP server`
- `hermes --tui`: `32 tools · 2 MCP`

With a disabled `linear` server and a connected `nous-support` server, the TUI reported **2 MCP** while the classic CLI correctly reported **1**. The MCP collapse toggle even labels the count `connected`, which was wrong for the same reason — it showed the configured total.

(The `38` vs `32` tool-count half is a separate timing bug, fixed in its own PR.)

## Root cause

`ui-tui/src/components/branding.tsx` used `info.mcp_servers.length` for both the collapse toggle `count` and the footer `· N MCP` segment. The classic banner uses connected-only semantics:

```python
# hermes_cli/banner.py
mcp_connected = sum(1 for s in mcp_status if s["connected"])
...
if mcp_connected:
    summary_parts.append(f"{mcp_connected} MCP servers")
```

Both surfaces are handed the *same* `get_mcp_status()` payload by the gateway; only the frontend counting diverged.

## Fix

Compute `mcpConnected = mcp_servers.filter(s => s.connected).length` once and use it for both the toggle and the footer. Drop the `· N MCP` segment entirely when none are connected, matching the classic banner (which only appends it when the count is > 0). The expandable MCP section still lists every configured server, including disabled ones, so nothing is hidden.

## Test

`ui-tui/src/__tests__/brandingMcpCount.test.ts` renders `SessionPanel` and asserts the headline equals the **connected** count, never the configured total — across connected+disabled, all-disabled, and multi-connected cases. Verified it fails against the pre-fix `length`-based code (all three cases) and passes after.

`npm run typecheck` and `eslint` clean. The 278-test gateway suite is unaffected (frontend-only change).

## Infographic

![MCP count fix — holographic card](https://v3b.fal.media/files/b/0a9ec99b/8O1s2AGnU59IOnrohL3sa_EWVHwIOc.png)
