### PR TITLE
feat(mcp): add --timeout flag to 'hermes mcp login' and respect config connect_timeout

### DIFF
--- a/hermes_cli/mcp_config.py
+++ b/hermes_cli/mcp_config.py
@@ -709,9 +709,24 @@ def cmd_mcp_login(args):
     print()
     _info(f"Starting OAuth flow for '{name}'...")
 
+    # Resolve the connection timeout: CLI --timeout takes priority, then
+    # the server's config connect_timeout, then the 30s default.
+    cli_timeout = getattr(args, "timeout", None)
+    if cli_timeout is not None:
+        connect_timeout = float(cli_timeout)
+    else:
+        connect_timeout = float(server_config.get("connect_timeout", 30))
+    if connect_timeout < 30:
+        _warning(
+            f"connect_timeout={connect_timeout}s is below the 30s minimum "
+            f"needed for OAuth flows; using 30s."
+        )
+        connect_timeout = 30.0
+    _info(f"  (Timeout: {connect_timeout:.0f}s — use --timeout to override)")
+
     # Probe triggers the OAuth flow (browser redirect + callback capture).
     try:
-        tools = _probe_single_server(name, server_config)
+        tools = _probe_single_server(name, server_config, connect_timeout=connect_timeout)
         # A clean probe is NOT proof of authentication. Some MCP servers
         # (notably Google's official Drive server) serve initialize +
         # tools/list WITHOUT auth, so the probe lists tools even when the

--- a/hermes_cli/subcommands/mcp.py
+++ b/hermes_cli/subcommands/mcp.py
@@ -85,6 +85,13 @@ def build_mcp_parser(subparsers, *, cmd_mcp: Callable) -> None:
         help="Force re-authentication for an OAuth-based MCP server",
     )
     mcp_login_p.add_argument("name", help="Server name to re-authenticate")
+    mcp_login_p.add_argument(
+        "-t",
+        "--timeout",
+        type=float,
+        default=None,
+        help="OAuth connection timeout in seconds (overrides config connect_timeout, default: 30)",
+    )
 
     # ── Catalog (Nous-approved MCPs shipped with the repo) ─────────────────
     mcp_sub.add_parser(


### PR DESCRIPTION
## Problem

`hermes mcp login` hardcoded a 30-second connect timeout via `_probe_single_server()`'s default parameter, ignoring the server's own `connect_timeout` config value. OAuth flows that need more than 30s (e.g. Robinhood's PKCE browser redirect) timed out at 40s (30 + 10s overhead) before the user could complete browser authorization.

The OAuth callback listener (`_wait_for_callback` in `tools/mcp_oauth.py`) already has a 300-second timeout, but the outer `asyncio.wait_for` in the probe killed the connection at 30s first.

## Changes

- **`hermes_cli/subcommands/mcp.py`**: Add `-t`/`--timeout` CLI flag to `hermes mcp login` for per-invocation override
- **`hermes_cli/mcp_config.py`**: `cmd_mcp_login` now resolves the timeout as: CLI `--timeout` → server config `connect_timeout` → 30s default. Passes the resolved value to `_probe_single_server` instead of relying on the function default.
- Floors at 30s (minimum needed for OAuth flows) with a warning if the config value is lower.

## Usage

```bash
# Uses config connect_timeout (e.g. 180s)
hermes mcp login robinhood_trading

# Per-invocation override
hermes mcp login robinhood_trading --timeout 180
hermes mcp login robinhood_trading -t 180
```

## Files changed

- `hermes_cli/subcommands/mcp.py` (+7 lines)
- `hermes_cli/mcp_config.py` (+16 lines, -1 line)