### PR TITLE
feat: add documentation maintainer automation

### DIFF
--- a/cron/blueprint_catalog.py
+++ b/cron/blueprint_catalog.py
@@ -96,6 +96,12 @@ class AutomationBlueprint:
     slots: List[BlueprintSlot] = field(default_factory=list)
     deliver_default: str = "origin"
     skills: tuple = ()        # skills the job loads before running
+    job_options: Dict[str, Any] = field(default_factory=dict)
+    # Extra create_job kwargs whose values are rendered from slot values.
+    # Empty rendered strings are omitted, so optional slots can drive optional
+    # job fields such as ``workdir`` without forcing every blueprint user to
+    # provide them.
+    job_template_options: Dict[str, str] = field(default_factory=dict)
     tags: tuple = ()
 
 
@@ -429,6 +435,64 @@ CATALOG: List[AutomationBlueprint] = [
         tags=("learning", "daily"),
     ),
     AutomationBlueprint(
+        key="documentation-maintainer",
+        title="Documentation maintainer",
+        description="A scheduled codebase docs agent: checks documentation "
+        "against source-of-truth code, fixes small high-confidence drift, and "
+        "reports what it verified.",
+        category="developer",
+        schedule_template="{minute} {hour} * * {dow}",
+        prompt_template=(
+            "Act as the documentation maintenance agent for this repository. "
+            "Repository root path, if configured as this cron job's workdir: "
+            "{repo_path}. Focus area: {focus}. Mandatory "
+            "preflight before any docs audit: inspect git status, fetch "
+            "origin/main, ensure the run is on latest main with a clean tree, "
+            "then run Auggie indexing with --wait-for-indexing and run "
+            "CocoIndex. If latest-main checkout, Auggie indexing, or CocoIndex "
+            "cannot complete, stop and report the blocker. Treat documentation "
+            "as a build artifact and living system map. Run a two-pass scan: "
+            "first structural evidence (README, manifests, CI, docs indexes, "
+            "entry points, route/command registries, generated-doc scripts), then "
+            "semantic evidence (APIs, services, schemas, migrations, feature "
+            "flags, platform adapters, and behavior tests). Refresh the docs so "
+            "new engineers and agents can answer: overview, architecture, tech "
+            "stack, project structure, entry points, systems/features, request "
+            "and data flows, contribution paths, and references. Find stale "
+            "commands, missing feature docs, broken links, and mismatches between "
+            "code/config/tests and documentation. Keep an evidence ledger mapping "
+            "each proposed edit to source paths and commands/tests. Make only "
+            "small, high-confidence documentation edits; do not change product "
+            "code unless a docs test or generator requires it. Use search_files "
+            "and read_file before editing, cite exact paths in the final summary, "
+            "and run the narrowest relevant docs or test command. If there are no "
+            "safe edits, report what you checked and leave the tree unchanged."
+        ),
+        slots=[
+            BlueprintSlot(
+                name="repo_path", type="text", label="Repository path",
+                default="", optional=True,
+                help="absolute repository path; sets the cron job workdir when provided",
+            ),
+            BlueprintSlot(
+                name="focus", type="text", label="Docs focus?",
+                default="recent code and documentation drift",
+                help="area to audit, e.g. CLI docs, config docs, desktop docs",
+            ),
+            _TIME("09:30"),
+            BlueprintSlot(
+                name="day", type="enum", label="Which day?",
+                default="monday",
+                options=("monday", "tuesday", "wednesday", "thursday", "friday"),
+            ),
+            _DELIVER,
+        ],
+        skills=("documentation-maintainer",),
+        job_options={"enabled_toolsets": ["terminal", "file"]},
+        job_template_options={"workdir": "{repo_path}"},
+        tags=("documentation", "developer", "maintenance"),
+    ),
+    AutomationBlueprint(
         key="gratitude-journal",
         title="Gratitude & reflection prompt",
         description="A gentle evening prompt to reflect on the day and note "
@@ -694,9 +758,13 @@ def fill_blueprint(
 
     schedule = _resolve_schedule(blueprint, resolved)
 
-    # Render the prompt with whatever slots it references.
+    # Render the prompt with whatever slots it references. Optional blank slots
+    # remain available as empty strings so a prompt can mention an optional
+    # field without forcing the user to fill it.
+    format_values = {s.name: "" for s in blueprint.slots}
+    format_values.update(resolved)
     try:
-        prompt = blueprint.prompt_template.format(**resolved)
+        prompt = blueprint.prompt_template.format(**format_values)
     except KeyError as e:
         raise BlueprintFillError(f"blueprint prompt missing value for {e}") from e
 
@@ -708,6 +776,15 @@ def fill_blueprint(
     }
     if blueprint.skills:
         spec["skills"] = list(blueprint.skills)
+    if blueprint.job_options:
+        spec.update(blueprint.job_options)
+    for key, template in blueprint.job_template_options.items():
+        try:
+            rendered = template.format(**format_values).strip()
+        except KeyError as e:
+            raise BlueprintFillError(f"blueprint job option {key!r} missing value for {e}") from e
+        if rendered:
+            spec[key] = rendered
     if origin is not None:
         spec["origin"] = origin
     return spec

--- a/hermes_cli/blueprint_cmd.py
+++ b/hermes_cli/blueprint_cmd.py
@@ -186,8 +186,16 @@ def build_blueprint_seed(blueprint) -> str:
             bits.append(f" — {s.help}")
         lines.append("".join(bits))
 
+    extra_job_fields: List[str] = []
+    if getattr(blueprint, "skills", None):
+        extra_job_fields.append(f"skills={list(blueprint.skills)!r}")
+    for key, value in getattr(blueprint, "job_options", {}).items():
+        extra_job_fields.append(f"{key}={value!r}")
+    for key, template in getattr(blueprint, "job_template_options", {}).items():
+        extra_job_fields.append(f"{key} rendered from `{template}` if non-empty")
+
     lines.append("")
-    lines.append(
+    create_instruction = (
         "Once you have my answers, create the job by calling the cronjob tool "
         "with action='create'. Build the schedule as a cron expression from "
         f"this template: `{blueprint.schedule_template}` "
@@ -195,8 +203,11 @@ def build_blueprint_seed(blueprint) -> str:
         f"choice using {dict(WEEKDAY_PRESETS)}, {{interval_min}} from any "
         "interval). Use this exact prompt for the job (substituting my "
         f"answers into any {{slot}} placeholders): \"{blueprint.prompt_template}\". "
-        "Confirm the schedule and what it will do before you create it."
     )
+    if extra_job_fields:
+        create_instruction += "Also pass these cronjob fields: " + ", ".join(extra_job_fields) + ". "
+    create_instruction += "Confirm the schedule and what it will do before you create it."
+    lines.append(create_instruction)
     return "\n".join(lines)
 
 

--- a/skills/software-development/documentation-maintainer/SKILL.md
+++ b/skills/software-development/documentation-maintainer/SKILL.md
@@ -1,0 +1,136 @@
+---
+name: documentation-maintainer
+description: "Audit and repair codebase documentation drift: compare docs to source, make small high-confidence docs fixes, and verify docs/tests."
+version: 1.0.0
+author: Hermes Agent
+license: MIT
+platforms: [linux, macos, windows]
+metadata:
+  hermes:
+    tags: [documentation, docs, maintenance, drift, automation, codebase]
+    related_skills: [hermes-agent, systematic-debugging, test-driven-development, requesting-code-review]
+---
+
+# Documentation Maintainer
+
+## Overview
+
+Use this skill when acting as a documentation maintenance agent for a codebase. The job is to keep documentation aligned with the source of truth in code, tests, configuration, CLI behavior, and generated catalogs.
+
+The maintainer should make small, safe documentation repairs without creating product-code churn. Treat code and tests as the source of truth; treat documentation as the artifact to reconcile unless the investigation proves the docs are correct and the code is broken.
+
+Documentation should behave like a build artifact: generated or refreshed from repository evidence, versioned with the code it describes, and safe for both humans and agents to use as a navigation map. The goal is not just typo-fixing; it is keeping a living system map current.
+
+## When to Use
+
+Use this skill for:
+- Scheduled documentation drift checks.
+- Reviewing recent code changes for missing or stale docs.
+- Fixing stale commands, option names, config keys, tool names, routes, feature descriptions, or setup instructions.
+- Updating generated documentation only through its generator when the repo has one.
+- Refreshing structured codebase wiki pages such as overview, architecture, tech stack, project structure, entry points, systems, features, contribution guide, and references.
+- Producing a concise report of checked areas when no safe edit is available.
+
+Do not use this skill for:
+- Large documentation rewrites without user direction.
+- Marketing copy or new conceptual docs that require product decisions.
+- Product-code changes, except tiny generator/test fixture updates that are necessary to keep docs generation working.
+- Publishing, committing, pushing, or opening PRs unless explicitly asked.
+
+## Operating Loop
+
+### Scheduled-run architecture
+
+- Prefer scheduling through the `documentation-maintainer` automation blueprint rather than creating an ad-hoc cron job by hand.
+- Provide the repository path when setting up the blueprint; Hermes stores it as the cron job `workdir`, so the run loads the repo's context files and terminal/file tools execute against the intended checkout.
+- The blueprint intentionally narrows the scheduled agent to the `terminal` and `file` toolsets. It should inspect, edit, and verify the repository, not browse the web or call unrelated integrations during routine docs maintenance.
+- The bundled skill alone is not auto-scheduled. Installing it only makes the operating procedure available; the user must opt in through the blueprint or an explicit cron job.
+
+1. Prepare the workspace.
+   - Run `git status --short --branch` before doing anything else.
+   - The run must be on latest `origin/main`. If the tree is clean, run `git fetch origin main` and `git checkout main && git pull --ff-only`. If local changes block this, stop and report the blocker rather than auditing stale code.
+   - Run Auggie workspace indexing before codebase retrieval, from the repository root: `auggie --print --wait-for-indexing --workspace-root "$PWD" -i "Index this workspace for documentation maintenance. Do not edit files."`
+   - Run CocoIndex before the docs audit. Prefer the repo's documented CocoIndex command if present; otherwise try `cocoindex update` / `cocoindex index` or `coco index`. If CocoIndex is unavailable, stop and report that the preflight cannot complete.
+
+2. Establish scope.
+   - Read the user's requested focus if present.
+   - If running as a cron job, use the job prompt as the focus and assume the repository root is the working directory.
+
+3. Find the source of truth.
+   - Use `search_files` to locate relevant code, tests, config defaults, CLI command registries, schemas, generated-doc scripts, and existing docs.
+   - Use `read_file` on the exact files before editing.
+   - Do a two-pass scan:
+     1. Structural scan: README, package manifests, config defaults, CI workflows, docs index/sidebar, entry points, route registries, command registries, and generated-doc scripts.
+     2. Semantic scan: API routes, service classes, data models/schemas, database migrations, feature flags, platform adapters, user-facing command examples, and tests that encode behavior.
+   - For Hermes-Agent, common source-of-truth files include:
+     - `hermes_cli/commands.py` for slash/CLI command registry.
+     - `hermes_cli/config.py` for default config and env metadata.
+     - `toolsets.py` and `tools/registry.py` for tool exposure.
+     - `cron/blueprint_catalog.py` and `tools/blueprints.py` for automation docs.
+     - `website/scripts/` for generated Docusaurus pages.
+     - `AGENTS.md` for developer-facing policy.
+
+4. Compare docs against code.
+   - Check names, flags, config keys, env var names, paths, schedules, command examples, setup flows, supported platforms, and generated catalogs.
+   - Prefer verifying behavior with tests or a harmless command over inferring from names.
+   - If documentation and code disagree, identify the exact code line or test that proves the intended behavior.
+   - Maintain an evidence ledger while working: every proposed doc edit should be backed by at least one source path and, when possible, a test or harmless command.
+
+5. Refresh the codebase map.
+   - Ensure the docs answer the questions a new engineer or agent needs on day one:
+     - What are the major components and how are they composed?
+     - What are the request/control/data flows through the system?
+     - What are the entry points, CLIs, services, adapters, and generated artifacts?
+     - Where should a contributor make common changes?
+     - What has changed since the previous documented commit or docs run?
+   - Prefer targeted updates to existing pages. If a repo has a generated wiki/docs tree, update through the generator. If no page exists and the gap is clearly source-grounded, create the smallest useful page and wire it into the docs index/sidebar.
+
+6. Edit narrowly.
+   - Touch only documentation or generator/test files required for documentation correctness.
+   - Keep the user's wording style and the surrounding document structure.
+   - Do not reformat whole files.
+   - Do not introduce new user-facing environment variables for non-secret settings.
+   - In Hermes-Agent docs, use `get_hermes_home()` / `display_hermes_home()` language when documenting profile-scoped paths.
+
+7. Verify.
+   - Run the narrowest relevant check first.
+   - For Hermes-Agent, prefer `scripts/run_tests.sh` over direct `pytest`.
+   - If a generated docs script was touched, run that script or its test.
+   - If website docs were touched, run the relevant website script/test when practical.
+
+8. Report.
+   - Summarize changed files with path references.
+   - State what source-of-truth files were checked.
+   - Include the evidence ledger: source paths, generated-doc inputs, and tests/commands used to justify edits.
+   - Include the exact verification command and result.
+   - If no edit was safe, say what was checked and why no change was made.
+
+## Safe Fix Patterns
+
+- Command drift: registry says `/foo --bar`, docs say `/foo --baz`; update docs and command examples.
+- Config drift: `DEFAULT_CONFIG` has `section.key`, docs refer to removed `HERMES_OLD_KEY`; update docs to `hermes config set section.key ...`.
+- Generated catalog drift: source catalog changed; run or fix the generator instead of hand-editing generated output.
+- Codebase map drift: a new service/entry point/route exists but the architecture or project-structure docs do not mention it; add a concise source-grounded section with source-path references.
+- Link drift: move or rename links only after locating the target file.
+- Feature capability drift: tests or adapter code prove a platform does not support a claimed behavior; update support wording precisely.
+
+## Pitfalls
+
+1. Do not run against a stale branch. Latest `origin/main` plus completed Auggie and CocoIndex indexing are mandatory preflights.
+2. Do not guess based on old documentation. Trace the current code.
+3. Do not turn a documentation maintenance run into a feature implementation.
+4. Do not hide uncertainty. If source-of-truth is ambiguous, report the ambiguity instead of inventing docs.
+5. Do not edit secrets, `.env`, credentials, or private local notes as part of docs maintenance.
+6. Do not break prompt caching by trying to mutate current-session skills/tools; scheduled jobs should load this skill at job start.
+
+## Verification Checklist
+
+- [ ] Latest `origin/main` checked out or a blocker reported.
+- [ ] Auggie indexing completed from the repository root.
+- [ ] CocoIndex completed, or missing/unavailable CocoIndex was reported as a blocker.
+- [ ] Structural and semantic scans completed for the requested focus.
+- [ ] Evidence ledger ties each edit to source paths/tests/commands.
+- [ ] Each edited statement was traced to current code, tests, or generated source.
+- [ ] Only documentation/generator/test files necessary for docs correctness changed.
+- [ ] Relevant docs generation or tests ran successfully, or a blocker is reported clearly.
+- [ ] Final response cites changed files and verification output.

--- a/tests/cron/test_blueprint_catalog.py
+++ b/tests/cron/test_blueprint_catalog.py
@@ -72,6 +72,47 @@ class TestScheduleResolution:
         spec = fill_blueprint(get_blueprint("morning-brief"), {})
         assert spec["schedule"] == "0 8 * * *"
 
+    def test_documentation_maintainer_schedules_with_skill(self):
+        blueprint = get_blueprint("documentation-maintainer")
+        assert blueprint is not None
+        spec = fill_blueprint(
+            blueprint,
+            {
+                "repo_path": "/tmp/repo",
+                "focus": "CLI docs",
+                "time": "09:30",
+                "day": "monday",
+                "deliver": "origin",
+            },
+        )
+
+        assert spec["schedule"] == "30 9 * * 1"
+        assert spec["skills"] == ["documentation-maintainer"]
+        assert spec["enabled_toolsets"] == ["terminal", "file"]
+        assert spec["workdir"] == "/tmp/repo"
+        assert "Repository root path" in spec["prompt"]
+        assert "Focus area: CLI docs" in spec["prompt"]
+        assert "latest main" in spec["prompt"]
+        assert "Auggie indexing" in spec["prompt"]
+        assert "CocoIndex" in spec["prompt"]
+        assert "build artifact" in spec["prompt"]
+        assert "two-pass scan" in spec["prompt"]
+        assert "evidence ledger" in spec["prompt"]
+        assert "small, high-confidence documentation edits" in spec["prompt"]
+
+    def test_documentation_maintainer_can_omit_workdir(self):
+        blueprint = get_blueprint("documentation-maintainer")
+        assert blueprint is not None
+
+        spec = fill_blueprint(
+            blueprint,
+            {"focus": "CLI docs", "time": "09:30", "day": "monday", "deliver": "origin"},
+        )
+
+        assert "workdir" not in spec
+        assert spec["enabled_toolsets"] == ["terminal", "file"]
+        assert "Focus area: CLI docs" in spec["prompt"]
+
 
 class TestValidation:
     def test_invalid_time_rejected(self):
@@ -153,6 +194,17 @@ class TestRenderers:
         assert entry["scheduleHuman"]
         assert "fields" in entry
 
+    def test_documentation_maintainer_catalog_entry(self):
+        blueprint = get_blueprint("documentation-maintainer")
+        assert blueprint is not None
+        entry = blueprint_catalog_entry(blueprint)
+
+        assert entry["category"] == "developer"
+        field_names = [field["name"] for field in entry["fields"]]
+        assert "repo_path" in field_names
+        assert "focus=" in entry["command"]
+        assert entry["scheduleHuman"] == "monday at 09:30"
+
 
 @pytest.fixture
 def isolated_home(tmp_path, monkeypatch):
@@ -185,6 +237,17 @@ class TestCommandHandler:
         assert "cronjob tool" in res.agent_seed
         # the schedule template is handed to the agent to build the cron expr
         assert "* * *" in res.agent_seed
+
+    def test_documentation_maintainer_seed_preserves_job_fields(self, isolated_home):
+        from hermes_cli.blueprint_cmd import handle_blueprint_command
+
+        res = handle_blueprint_command("documentation-maintainer")
+
+        assert res.agent_seed is not None
+        assert "repo_path" in res.agent_seed
+        assert "skills=['documentation-maintainer']" in res.agent_seed
+        assert "enabled_toolsets=['terminal', 'file']" in res.agent_seed
+        assert "workdir rendered from `{repo_path}` if non-empty" in res.agent_seed
 
     def test_name_match_is_forgiving(self, isolated_home):
         from hermes_cli.blueprint_cmd import handle_blueprint_command, match_blueprint

--- a/tests/skills/test_documentation_maintainer_skill.py
+++ b/tests/skills/test_documentation_maintainer_skill.py
@@ -1,0 +1,44 @@
+from pathlib import Path
+
+import yaml
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SKILL_MD = REPO_ROOT / "skills" / "software-development" / "documentation-maintainer" / "SKILL.md"
+
+
+def _frontmatter_and_body():
+    src = SKILL_MD.read_text(encoding="utf-8")
+    assert src.startswith("---\n")
+    end = src.find("\n---\n", 4)
+    assert end != -1, "SKILL.md missing closing YAML frontmatter fence"
+    frontmatter = yaml.safe_load(src[4:end])
+    body = src[end + len("\n---\n"):]
+    return frontmatter, body
+
+
+def test_documentation_maintainer_skill_metadata():
+    frontmatter, body = _frontmatter_and_body()
+
+    assert frontmatter["name"] == "documentation-maintainer"
+    assert "documentation" in frontmatter["metadata"]["hermes"]["tags"]
+    assert "systematic-debugging" in frontmatter["metadata"]["hermes"]["related_skills"]
+    assert len(frontmatter["description"]) <= 1024
+    assert "## Operating Loop" in body
+    assert "git status --short --branch" in body
+    assert "Auggie workspace indexing" in body
+    assert "CocoIndex" in body
+    assert "latest `origin/main`" in body
+    assert "Documentation should behave like a build artifact" in body
+    assert "Scheduled-run architecture" in body
+    assert "cron job `workdir`" in body
+    assert "`terminal` and `file` toolsets" in body
+    assert "two-pass scan" in body
+    assert "evidence ledger" in body
+
+
+def test_documentation_maintainer_skill_is_not_auto_scheduled_on_install():
+    """The bundled skill is loaded by the curated blueprint; installing the skill alone should not create a duplicate suggestion."""
+    from tools.blueprints import parse_blueprint
+
+    assert parse_blueprint(SKILL_MD.read_text(encoding="utf-8")) is None

--- a/website/docs/reference/skills-catalog.md
+++ b/website/docs/reference/skills-catalog.md
@@ -154,6 +154,7 @@ If a skill is missing from this list but present in the repo, the catalog is reg
 
 | Skill | Description | Path |
 |-------|-------------|------|
+| [`documentation-maintainer`](/docs/user-guide/skills/bundled/software-development/software-development-documentation-maintainer) | Audit and repair codebase documentation drift: compare docs to source, make small high-confidence docs fixes, and verify docs/tests. | `software-development/documentation-maintainer` |
 | [`hermes-agent-skill-authoring`](/docs/user-guide/skills/bundled/software-development/software-development-hermes-agent-skill-authoring) | Author in-repo SKILL.md: frontmatter, validator, structure. | `software-development/hermes-agent-skill-authoring` |
 | [`node-inspect-debugger`](/docs/user-guide/skills/bundled/software-development/software-development-node-inspect-debugger) | Debug Node.js via --inspect + Chrome DevTools Protocol CLI. | `software-development/node-inspect-debugger` |
 | [`plan`](/docs/user-guide/skills/bundled/software-development/software-development-plan) | Plan mode: write an actionable markdown plan to .hermes/plans/, no execution. Bite-sized tasks, exact paths, complete code. | `software-development/plan` |

--- a/website/docs/user-guide/skills/bundled/software-development/software-development-documentation-maintainer.md
+++ b/website/docs/user-guide/skills/bundled/software-development/software-development-documentation-maintainer.md
@@ -1,0 +1,154 @@
+---
+title: "Documentation Maintainer"
+sidebar_label: "Documentation Maintainer"
+description: "Audit and repair codebase documentation drift: compare docs to source, make small high-confidence docs fixes, and verify docs/tests"
+---
+
+{/* This page is auto-generated from the skill's SKILL.md by website/scripts/generate-skill-docs.py. Edit the source SKILL.md, not this page. */}
+
+# Documentation Maintainer
+
+Audit and repair codebase documentation drift: compare docs to source, make small high-confidence docs fixes, and verify docs/tests.
+
+## Skill metadata
+
+| | |
+|---|---|
+| Source | Bundled (installed by default) |
+| Path | `skills/software-development/documentation-maintainer` |
+| Version | `1.0.0` |
+| Author | Hermes Agent |
+| License | MIT |
+| Platforms | linux, macos, windows |
+| Tags | `documentation`, `docs`, `maintenance`, `drift`, `automation`, `codebase` |
+| Related skills | [`hermes-agent`](/docs/user-guide/skills/bundled/autonomous-ai-agents/autonomous-ai-agents-hermes-agent), [`systematic-debugging`](/docs/user-guide/skills/bundled/software-development/software-development-systematic-debugging), [`test-driven-development`](/docs/user-guide/skills/bundled/software-development/software-development-test-driven-development), [`requesting-code-review`](/docs/user-guide/skills/bundled/software-development/software-development-requesting-code-review) |
+
+## Reference: full SKILL.md
+
+:::info
+The following is the complete skill definition that Hermes loads when this skill is triggered. This is what the agent sees as instructions when the skill is active.
+:::
+
+# Documentation Maintainer
+
+## Overview
+
+Use this skill when acting as a documentation maintenance agent for a codebase. The job is to keep documentation aligned with the source of truth in code, tests, configuration, CLI behavior, and generated catalogs.
+
+The maintainer should make small, safe documentation repairs without creating product-code churn. Treat code and tests as the source of truth; treat documentation as the artifact to reconcile unless the investigation proves the docs are correct and the code is broken.
+
+Documentation should behave like a build artifact: generated or refreshed from repository evidence, versioned with the code it describes, and safe for both humans and agents to use as a navigation map. The goal is not just typo-fixing; it is keeping a living system map current.
+
+## When to Use
+
+Use this skill for:
+- Scheduled documentation drift checks.
+- Reviewing recent code changes for missing or stale docs.
+- Fixing stale commands, option names, config keys, tool names, routes, feature descriptions, or setup instructions.
+- Updating generated documentation only through its generator when the repo has one.
+- Refreshing structured codebase wiki pages such as overview, architecture, tech stack, project structure, entry points, systems, features, contribution guide, and references.
+- Producing a concise report of checked areas when no safe edit is available.
+
+Do not use this skill for:
+- Large documentation rewrites without user direction.
+- Marketing copy or new conceptual docs that require product decisions.
+- Product-code changes, except tiny generator/test fixture updates that are necessary to keep docs generation working.
+- Publishing, committing, pushing, or opening PRs unless explicitly asked.
+
+## Operating Loop
+
+### Scheduled-run architecture
+
+- Prefer scheduling through the `documentation-maintainer` automation blueprint rather than creating an ad-hoc cron job by hand.
+- Provide the repository path when setting up the blueprint; Hermes stores it as the cron job `workdir`, so the run loads the repo's context files and terminal/file tools execute against the intended checkout.
+- The blueprint intentionally narrows the scheduled agent to the `terminal` and `file` toolsets. It should inspect, edit, and verify the repository, not browse the web or call unrelated integrations during routine docs maintenance.
+- The bundled skill alone is not auto-scheduled. Installing it only makes the operating procedure available; the user must opt in through the blueprint or an explicit cron job.
+
+1. Prepare the workspace.
+   - Run `git status --short --branch` before doing anything else.
+   - The run must be on latest `origin/main`. If the tree is clean, run `git fetch origin main` and `git checkout main && git pull --ff-only`. If local changes block this, stop and report the blocker rather than auditing stale code.
+   - Run Auggie workspace indexing before codebase retrieval, from the repository root: `auggie --print --wait-for-indexing --workspace-root "$PWD" -i "Index this workspace for documentation maintenance. Do not edit files."`
+   - Run CocoIndex before the docs audit. Prefer the repo's documented CocoIndex command if present; otherwise try `cocoindex update` / `cocoindex index` or `coco index`. If CocoIndex is unavailable, stop and report that the preflight cannot complete.
+
+2. Establish scope.
+   - Read the user's requested focus if present.
+   - If running as a cron job, use the job prompt as the focus and assume the repository root is the working directory.
+
+3. Find the source of truth.
+   - Use `search_files` to locate relevant code, tests, config defaults, CLI command registries, schemas, generated-doc scripts, and existing docs.
+   - Use `read_file` on the exact files before editing.
+   - Do a two-pass scan:
+     1. Structural scan: README, package manifests, config defaults, CI workflows, docs index/sidebar, entry points, route registries, command registries, and generated-doc scripts.
+     2. Semantic scan: API routes, service classes, data models/schemas, database migrations, feature flags, platform adapters, user-facing command examples, and tests that encode behavior.
+   - For Hermes-Agent, common source-of-truth files include:
+     - `hermes_cli/commands.py` for slash/CLI command registry.
+     - `hermes_cli/config.py` for default config and env metadata.
+     - `toolsets.py` and `tools/registry.py` for tool exposure.
+     - `cron/blueprint_catalog.py` and `tools/blueprints.py` for automation docs.
+     - `website/scripts/` for generated Docusaurus pages.
+     - `AGENTS.md` for developer-facing policy.
+
+4. Compare docs against code.
+   - Check names, flags, config keys, env var names, paths, schedules, command examples, setup flows, supported platforms, and generated catalogs.
+   - Prefer verifying behavior with tests or a harmless command over inferring from names.
+   - If documentation and code disagree, identify the exact code line or test that proves the intended behavior.
+   - Maintain an evidence ledger while working: every proposed doc edit should be backed by at least one source path and, when possible, a test or harmless command.
+
+5. Refresh the codebase map.
+   - Ensure the docs answer the questions a new engineer or agent needs on day one:
+     - What are the major components and how are they composed?
+     - What are the request/control/data flows through the system?
+     - What are the entry points, CLIs, services, adapters, and generated artifacts?
+     - Where should a contributor make common changes?
+     - What has changed since the previous documented commit or docs run?
+   - Prefer targeted updates to existing pages. If a repo has a generated wiki/docs tree, update through the generator. If no page exists and the gap is clearly source-grounded, create the smallest useful page and wire it into the docs index/sidebar.
+
+6. Edit narrowly.
+   - Touch only documentation or generator/test files required for documentation correctness.
+   - Keep the user's wording style and the surrounding document structure.
+   - Do not reformat whole files.
+   - Do not introduce new user-facing environment variables for non-secret settings.
+   - In Hermes-Agent docs, use `get_hermes_home()` / `display_hermes_home()` language when documenting profile-scoped paths.
+
+7. Verify.
+   - Run the narrowest relevant check first.
+   - For Hermes-Agent, prefer `scripts/run_tests.sh` over direct `pytest`.
+   - If a generated docs script was touched, run that script or its test.
+   - If website docs were touched, run the relevant website script/test when practical.
+
+8. Report.
+   - Summarize changed files with path references.
+   - State what source-of-truth files were checked.
+   - Include the evidence ledger: source paths, generated-doc inputs, and tests/commands used to justify edits.
+   - Include the exact verification command and result.
+   - If no edit was safe, say what was checked and why no change was made.
+
+## Safe Fix Patterns
+
+- Command drift: registry says `/foo --bar`, docs say `/foo --baz`; update docs and command examples.
+- Config drift: `DEFAULT_CONFIG` has `section.key`, docs refer to removed `HERMES_OLD_KEY`; update docs to `hermes config set section.key ...`.
+- Generated catalog drift: source catalog changed; run or fix the generator instead of hand-editing generated output.
+- Codebase map drift: a new service/entry point/route exists but the architecture or project-structure docs do not mention it; add a concise source-grounded section with source-path references.
+- Link drift: move or rename links only after locating the target file.
+- Feature capability drift: tests or adapter code prove a platform does not support a claimed behavior; update support wording precisely.
+
+## Pitfalls
+
+1. Do not run against a stale branch. Latest `origin/main` plus completed Auggie and CocoIndex indexing are mandatory preflights.
+2. Do not guess based on old documentation. Trace the current code.
+3. Do not turn a documentation maintenance run into a feature implementation.
+4. Do not hide uncertainty. If source-of-truth is ambiguous, report the ambiguity instead of inventing docs.
+5. Do not edit secrets, `.env`, credentials, or private local notes as part of docs maintenance.
+6. Do not break prompt caching by trying to mutate current-session skills/tools; scheduled jobs should load this skill at job start.
+
+## Verification Checklist
+
+- [ ] Latest `origin/main` checked out or a blocker reported.
+- [ ] Auggie indexing completed from the repository root.
+- [ ] CocoIndex completed, or missing/unavailable CocoIndex was reported as a blocker.
+- [ ] Structural and semantic scans completed for the requested focus.
+- [ ] Evidence ledger ties each edit to source paths/tests/commands.
+- [ ] Each edited statement was traced to current code, tests, or generated source.
+- [ ] Only documentation/generator/test files necessary for docs correctness changed.
+- [ ] Relevant docs generation or tests ran successfully, or a blocker is reported clearly.
+- [ ] Final response cites changed files and verification output.

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -318,6 +318,7 @@ const sidebars: SidebarsConfig = {
                   key: 'skills-bundled-software-development',
                   collapsed: true,
                   items: [
+                    'user-guide/skills/bundled/software-development/software-development-documentation-maintainer',
                     'user-guide/skills/bundled/software-development/software-development-hermes-agent-skill-authoring',
                     'user-guide/skills/bundled/software-development/software-development-node-inspect-debugger',
                     'user-guide/skills/bundled/software-development/software-development-plan',


### PR DESCRIPTION
## Summary
- add a bundled `documentation-maintainer` skill for source-grounded docs drift audits
- add a scheduled Documentation Maintainer automation blueprint with `repo_path` → cron `workdir`, attached skill, and narrowed `terminal`/`file` toolsets
- teach the conversational `/blueprint documentation-maintainer` setup path to preserve attached skills and extra cron job fields
- generate the bundled skill docs/catalog/sidebar entries

## Test Plan
- `scripts/run_tests.sh tests/cron/test_blueprint_catalog.py tests/skills/test_documentation_maintainer_skill.py`
- `git diff --check`
