### PR TITLE
Add Gemma-4 content-bound tool-call & reasoning fallback (#29115)

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -550,6 +550,17 @@ def strip_think_blocks(agent, content: str) -> str:
         content,
         flags=re.DOTALL | re.IGNORECASE,
     )
+    # 1d. Gemma-4 pipe-delimited special-token markup.
+    #     vLLM's gemma4 parser intermittently leaves <|tool_call>...<tool_call|>
+    #     and <|channel>...<channel|> spans (plus the <|"|> string delimiter)
+    #     in content. The tool call is recovered upstream
+    #     (gemma4_fallback.apply_gemma_fallback) and reasoning is captured into
+    #     the reasoning field; here we clean the stored/delivered content of any
+    #     residual Gemma markup. Generic for every consumer of the stored message
+    #     (CLI, api_server, Telegram, Matrix, persistence). (#6626 / #29115)
+    if "<|" in content or "|>" in content:
+        from agent.gemma4_fallback import strip_gemma_markup
+        content = strip_gemma_markup(content)
     # 2. Unterminated reasoning block — open tag at a block boundary
     #    (start of text, or after a newline) with no matching close.
     #    Strip from the tag to end of string.  Fixes #8878 / #9568

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -831,6 +831,13 @@ def build_assistant_message(agent, assistant_message, finish_reason: str) -> dic
         if think_blocks:
             combined = "\n\n".join(b.strip() for b in think_blocks if b.strip())
             reasoning_text = combined or None
+        # Gemma-4 emits reasoning as <|channel>thought...<channel|>.
+        # When the gemma4 reasoning parser misses it, capture it here so it is
+        # routed to the reasoning field instead of leaking into the message.
+        if not reasoning_text and "<|channel>" in content:
+            from agent.gemma4_fallback import extract_gemma_reasoning
+            _gemma_reasoning, _ = extract_gemma_reasoning(content)
+            reasoning_text = _gemma_reasoning
 
     if reasoning_text and agent.verbose_logging:
         logging.debug(f"Captured reasoning ({len(reasoning_text)} chars): {reasoning_text}")

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -3545,6 +3545,25 @@ def run_conversation(
                 else:
                     assistant_message.content = str(raw)
 
+            # Recover a Gemma-4 tool call that vLLM's gemma4
+            # parser intermittently leaks into content as raw
+            # <|tool_call>...<tool_call|> markup with an empty tool_calls
+            # field. Run BEFORE the tool-call gate so the tool still
+            # executes and the markup never reaches the visible message.
+            # Generic across every platform / api_mode (this is the
+            # post-normalization chokepoint). Thinking stays enabled.
+            # (#6626 / #29115)
+            try:
+                from agent.gemma4_fallback import apply_gemma_fallback
+                _gemma_recovered = apply_gemma_fallback(assistant_message)
+            except Exception:
+                _gemma_recovered = False
+            if _gemma_recovered and agent.verbose_logging:
+                agent._vprint(
+                    f"{agent.log_prefix}🔧 Gemma-4 fallback: recovered "
+                    f"{len(assistant_message.tool_calls or [])} tool call(s) leaked into content"
+                )
+
             try:
                 from hermes_cli.plugins import (
                     has_hook,

--- a/agent/gemma4_fallback.py
+++ b/agent/gemma4_fallback.py
@@ -1,0 +1,173 @@
+"""Gemma-4 special-token content fallback.
+
+vLLM's ``gemma4`` tool-call / reasoning parsers intermittently fail to extract
+Gemma-4's pipe-delimited markup, leaving it raw in ``message.content`` with an
+empty ``message.tool_calls``. The agent then leaks the markup verbatim to the
+user and never executes the tool. (Upstream: hermes-agent #6626 / #29115,
+mlx-lm #1096.)
+
+Gemma-4 emits (authoritative: ``tool_chat_template_gemma4.jinja``):
+
+    tool call : ``<|tool_call>call:NAME{ARGS}<tool_call|>``
+    reasoning : ``<|channel>thought\\n…\\n<channel|>``
+    string    : wrapped in ``<|"|>…<|"|>`` (keys are BARE at every depth;
+                numbers / booleans bare; objects ``{…}``; lists ``[…]``)
+
+These helpers parse that markup back into structured tool_calls + reasoning so
+the tool still executes and the visible message stays clean — with thinking
+left ENABLED (no reasoning-off workaround). Pure stdlib, no agent imports, so
+it is trivially unit-testable.
+"""
+from __future__ import annotations
+
+import json
+import re
+from types import SimpleNamespace
+from typing import List, Optional, Tuple
+
+# String-literal delimiter (the only token that wraps free text).
+_STR = '<|"|>'
+
+# Complete spans.
+_TOOLCALL_RE = re.compile(
+    r'<\|tool_call>\s*call:\s*([A-Za-z0-9_.\-]+)\s*\{(.*?)\}\s*<tool_call\|>',
+    re.DOTALL,
+)
+_CHANNEL_RE = re.compile(r'<\|channel>(.*?)<channel\|>', re.DOTALL)
+
+# Unterminated spans (stream truncated / parser dropped the closer).
+_TOOLCALL_OPEN_RE = re.compile(r'<\|tool_call>.*\Z', re.DOTALL)
+_CHANNEL_OPEN_RE = re.compile(r'<\|channel>.*\Z', re.DOTALL)
+
+# Residual bare Gemma special tokens (string delimiter + known opens/closes).
+_RESIDUAL_RE = re.compile(
+    r'<\|"\|>'
+    r'|<\|(?:tool_call|channel|turn|tool|tool_response|think|image|audio|video)\b[^>]*>'
+    r'|<(?:tool_call|channel|turn|tool|tool_response)\|>'
+)
+
+# Quote a bare key: identifier directly before ':' at start / after ',' or '{'.
+_BARE_KEY_RE = re.compile(r'([{,]\s*|^\s*)([A-Za-z_][A-Za-z0-9_.\-]*)\s*:')
+
+
+def _gemma_args_to_json(body: str) -> str:
+    """Convert a Gemma-serialized argument body (text between the call's outer
+    braces) into a JSON object string.
+
+    Strings are extracted first (odd segments between ``<|"|>`` delimiters) and
+    JSON-encoded, so any ``:`` / ``,`` / ``{`` / ``}`` inside a literal can't
+    corrupt the structural parse. Bare keys are quoted per structural segment
+    only — never inside an encoded string literal (which would otherwise
+    mangle a value like ``"a,b:c"``).
+    """
+    if not body.strip():
+        return "{}"
+    segs = body.split(_STR)
+    out: List[str] = []
+    for i, seg in enumerate(segs):
+        if i % 2 == 1:
+            # String literal — JSON-encode (handles quotes, newlines, etc.).
+            out.append(json.dumps(seg))
+        else:
+            # Structural skeleton — quote bare keys, normalise Python ``None``.
+            seg = _BARE_KEY_RE.sub(lambda m: f'{m.group(1)}"{m.group(2)}":', seg)
+            seg = re.sub(r':\s*None\b', ':null', seg)
+            out.append(seg)
+    return "{" + "".join(out) + "}"
+
+
+def parse_gemma_tool_calls(content: str) -> Tuple[List[SimpleNamespace], str]:
+    """Parse ``<|tool_call>call:NAME{…}<tool_call|>`` blocks out of *content*.
+
+    Returns ``(tool_calls, cleaned_content)`` where each tool call is a
+    ``SimpleNamespace`` shaped like an OpenAI tool call (``.id``, ``.type``,
+    ``.function.name``, ``.function.arguments`` as a JSON string). Empty list
+    when no complete block is present. ``cleaned_content`` has the parsed
+    blocks (and any unterminated trailing open) removed.
+    """
+    if not content or "<|tool_call>" not in content:
+        return [], content
+    calls: List[SimpleNamespace] = []
+    for i, m in enumerate(_TOOLCALL_RE.finditer(content)):
+        name = m.group(1)
+        try:
+            args_json = _gemma_args_to_json(m.group(2))
+            json.loads(args_json)  # validate
+        except (ValueError, TypeError):
+            # Best-effort: run the tool with empty args and let the model
+            # recover from the tool error — far better than leaking markup.
+            args_json = "{}"
+        calls.append(
+            SimpleNamespace(
+                id=f"call_gemma_{i}",
+                type="function",
+                function=SimpleNamespace(name=name, arguments=args_json),
+            )
+        )
+    cleaned = _TOOLCALL_RE.sub("", content)
+    cleaned = _TOOLCALL_OPEN_RE.sub("", cleaned)
+    return calls, cleaned
+
+
+def extract_gemma_reasoning(content: str) -> Tuple[Optional[str], str]:
+    """Pull ``<|channel>…<channel|>`` reasoning out of *content*.
+
+    Returns ``(reasoning_text_or_None, cleaned_content)``. A leading channel
+    label line (e.g. ``thought``) is dropped from the captured reasoning.
+    """
+    if not content or "<|channel>" not in content:
+        return None, content
+    chunks: List[str] = []
+    for m in _CHANNEL_RE.finditer(content):
+        body = m.group(1)
+        # Drop a leading channel-name label ("thought\n…").
+        body = re.sub(r'^[ \t]*[A-Za-z0-9_\-]+[ \t]*\n', '', body, count=1)
+        body = body.strip()
+        if body:
+            chunks.append(body)
+    cleaned = _CHANNEL_RE.sub("", content)
+    cleaned = _CHANNEL_OPEN_RE.sub("", cleaned)
+    return ("\n\n".join(chunks) or None), cleaned
+
+
+def strip_gemma_markup(content: str) -> str:
+    """Remove every Gemma-4 pipe-delimited special-token span from *content*.
+
+    Defence-in-depth for ``strip_think_blocks``: complete + unterminated
+    tool-call and channel spans, then any residual bare special token.
+    """
+    if not content or ("<|" not in content and "|>" not in content):
+        return content
+    content = _TOOLCALL_RE.sub("", content)
+    content = _CHANNEL_RE.sub("", content)
+    content = _TOOLCALL_OPEN_RE.sub("", content)
+    content = _CHANNEL_OPEN_RE.sub("", content)
+    content = _RESIDUAL_RE.sub("", content)
+    return content
+
+
+def apply_gemma_fallback(assistant_message) -> bool:
+    """Recover a Gemma-4 tool call that leaked into content.
+
+    Mutates *assistant_message* in place: when ``tool_calls`` is empty and the
+    content carries ``<|tool_call>`` markup, parse it into structured
+    ``tool_calls`` and strip that markup from ``content``. Returns ``True`` if a
+    tool call was recovered. No-op (``False``) when tool_calls already exist or
+    no markup is found. Channel/reasoning markup is intentionally left in
+    content for the reasoning-extraction layer (``build_assistant_message`` /
+    ``strip_think_blocks``) to handle.
+    """
+    if getattr(assistant_message, "tool_calls", None):
+        return False
+    content = getattr(assistant_message, "content", None)
+    if not content or "<|tool_call>" not in content:
+        return False
+    calls, cleaned = parse_gemma_tool_calls(content)
+    if not calls:
+        return False
+    assistant_message.tool_calls = calls
+    try:
+        assistant_message.content = cleaned
+    except Exception:
+        pass
+    return True

--- a/gateway/stream_consumer.py
+++ b/gateway/stream_consumer.py
@@ -101,10 +101,15 @@ class GatewayStreamConsumer:
     _OPEN_THINK_TAGS = (
         "<REASONING_SCRATCHPAD>", "<think>", "<reasoning>",
         "<THINKING>", "<thinking>", "<thought>",
+        # Gemma-4 pipe-delimited spans (vLLM gemma4 parser leak):
+        # suppress live so streaming platforms (Telegram, Matrix) never flash
+        # the raw markup. The state machine is tag-shape-agnostic.
+        "<|channel>", "<|tool_call>",
     )
     _CLOSE_THINK_TAGS = (
         "</REASONING_SCRATCHPAD>", "</think>", "</reasoning>",
         "</THINKING>", "</thinking>", "</thought>",
+        "<channel|>", "<tool_call|>",
     )
 
     # Class-wide monotonic counter for native-streaming draft ids.  Telegram

--- a/tests/test_gemma4_fallback.py
+++ b/tests/test_gemma4_fallback.py
@@ -1,0 +1,243 @@
+"""Unit tests for the Gemma-4 content fallback (agent/gemma4_fallback.py).
+
+Pure-logic tests — no agent runtime, no network, no GPU. Run with:
+    python -m pytest tests/test_gemma4_fallback.py -q
+or standalone:
+    python tests/test_gemma4_fallback.py
+"""
+import json
+from types import SimpleNamespace
+
+import pytest
+
+from agent.gemma4_fallback import (
+    _gemma_args_to_json,
+    apply_gemma_fallback,
+    extract_gemma_reasoning,
+    parse_gemma_tool_calls,
+    strip_gemma_markup,
+)
+
+S = '<|"|>'  # string delimiter
+
+
+# ── _gemma_args_to_json ──────────────────────────────────────────────
+class TestArgsToJson:
+    def test_empty(self):
+        assert json.loads(_gemma_args_to_json("")) == {}
+
+    def test_single_string(self):
+        body = f"command:{S}ls -la{S}"
+        assert json.loads(_gemma_args_to_json(body)) == {"command": "ls -la"}
+
+    def test_string_and_number(self):
+        body = f"command:{S}ls{S},timeout:30"
+        assert json.loads(_gemma_args_to_json(body)) == {"command": "ls", "timeout": 30}
+
+    def test_boolean(self):
+        body = f"name:{S}x{S},verbose:true,quiet:false"
+        assert json.loads(_gemma_args_to_json(body)) == {
+            "name": "x", "verbose": True, "quiet": False,
+        }
+
+    def test_nested_object_bare_keys(self):
+        # escape_keys=False propagates: nested keys are ALSO bare.
+        body = f"opts:{{depth:2,label:{S}deep{S}}}"
+        assert json.loads(_gemma_args_to_json(body)) == {
+            "opts": {"depth": 2, "label": "deep"},
+        }
+
+    def test_list_of_strings(self):
+        body = f"tags:[{S}a{S},{S}b{S}]"
+        assert json.loads(_gemma_args_to_json(body)) == {"tags": ["a", "b"]}
+
+    def test_list_of_objects(self):
+        body = f"items:[{{x:1}},{{y:2}}]"
+        assert json.loads(_gemma_args_to_json(body)) == {
+            "items": [{"x": 1}, {"y": 2}],
+        }
+
+    def test_string_value_with_colon(self):
+        body = f"url:{S}http://example.com:8080/p{S}"
+        assert json.loads(_gemma_args_to_json(body)) == {
+            "url": "http://example.com:8080/p",
+        }
+
+    def test_string_value_with_comma_and_colon_not_mangled(self):
+        # The danger case: a literal that contains ",key:" must NOT be
+        # interpreted as a structural key (the per-segment quoting guards this).
+        body = f"note:{S}a,b:c{S},n:1"
+        assert json.loads(_gemma_args_to_json(body)) == {"note": "a,b:c", "n": 1}
+
+    def test_string_value_with_embedded_quote(self):
+        body = f'msg:{S}he said "hi"{S}'
+        assert json.loads(_gemma_args_to_json(body)) == {"msg": 'he said "hi"'}
+
+    def test_string_value_with_braces(self):
+        body = f"tpl:{S}{{a}}{S}"
+        assert json.loads(_gemma_args_to_json(body)) == {"tpl": "{a}"}
+
+    def test_hyphen_dot_key(self):
+        body = f"content-type:{S}text/plain{S},a.b:1"
+        assert json.loads(_gemma_args_to_json(body)) == {
+            "content-type": "text/plain", "a.b": 1,
+        }
+
+    def test_none_to_null(self):
+        body = "value:None"
+        assert json.loads(_gemma_args_to_json(body)) == {"value": None}
+
+
+# ── parse_gemma_tool_calls ───────────────────────────────────────────
+class TestParseToolCalls:
+    def test_none(self):
+        calls, cleaned = parse_gemma_tool_calls("just a normal reply")
+        assert calls == []
+        assert cleaned == "just a normal reply"
+
+    def test_single(self):
+        c = f"<|tool_call>call:bash{{command:{S}ls{S}}}<tool_call|>"
+        calls, cleaned = parse_gemma_tool_calls(c)
+        assert len(calls) == 1
+        assert calls[0].type == "function"
+        assert calls[0].function.name == "bash"
+        assert json.loads(calls[0].function.arguments) == {"command": "ls"}
+        assert cleaned.strip() == ""
+
+    def test_multiple(self):
+        c = (
+            f"<|tool_call>call:f{{a:1}}<tool_call|>"
+            f"<|tool_call>call:g{{b:2}}<tool_call|>"
+        )
+        calls, _ = parse_gemma_tool_calls(c)
+        assert [k.function.name for k in calls] == ["f", "g"]
+        assert json.loads(calls[1].function.arguments) == {"b": 2}
+
+    def test_nested_braces_not_truncated(self):
+        c = f"<|tool_call>call:f{{opts:{{b:1}}}}<tool_call|>"
+        calls, _ = parse_gemma_tool_calls(c)
+        assert json.loads(calls[0].function.arguments) == {"opts": {"b": 1}}
+
+    def test_surrounding_text_preserved(self):
+        c = f"Sure!<|tool_call>call:f{{a:1}}<tool_call|>done"
+        calls, cleaned = parse_gemma_tool_calls(c)
+        assert len(calls) == 1
+        assert "Sure!" in cleaned and "done" in cleaned
+        assert "<|tool_call>" not in cleaned
+
+    def test_unterminated_tail_stripped(self):
+        c = f"text<|tool_call>call:f{{a:1"  # truncated, no closer
+        calls, cleaned = parse_gemma_tool_calls(c)
+        assert calls == []  # no COMPLETE block
+        assert "<|tool_call>" not in cleaned
+        assert cleaned == "text"
+
+    def test_malformed_args_fallback_to_empty(self):
+        # Name parses, args are garbage -> empty args, tool still recovered.
+        c = f"<|tool_call>call:f{{:::}}<tool_call|>"
+        calls, _ = parse_gemma_tool_calls(c)
+        assert len(calls) == 1
+        assert calls[0].function.name == "f"
+        assert json.loads(calls[0].function.arguments) == {}
+
+
+# ── extract_gemma_reasoning ──────────────────────────────────────────
+class TestExtractReasoning:
+    def test_none(self):
+        r, cleaned = extract_gemma_reasoning("plain answer")
+        assert r is None
+        assert cleaned == "plain answer"
+
+    def test_single_with_label(self):
+        c = "<|channel>thought\nI should add two numbers.\n<channel|>The answer is 4."
+        r, cleaned = extract_gemma_reasoning(c)
+        assert r == "I should add two numbers."
+        assert "<|channel>" not in cleaned
+        assert "The answer is 4." in cleaned
+
+    def test_multiple(self):
+        c = "<|channel>thought\nstep one\n<channel|>x<|channel>thought\nstep two\n<channel|>y"
+        r, _ = extract_gemma_reasoning(c)
+        assert "step one" in r and "step two" in r
+
+    def test_unterminated_tail_stripped(self):
+        c = "answer<|channel>thought\nrambling without a close"
+        r, cleaned = extract_gemma_reasoning(c)
+        assert r is None  # no complete channel span -> nothing captured
+        assert cleaned == "answer"
+
+
+# ── strip_gemma_markup ───────────────────────────────────────────────
+class TestStripMarkup:
+    def test_noop_clean(self):
+        assert strip_gemma_markup("nothing special") == "nothing special"
+
+    def test_strips_toolcall_and_channel(self):
+        c = (
+            f"<|channel>thought\nthinking\n<channel|>"
+            f"Hello <|tool_call>call:f{{a:1}}<tool_call|> world"
+        )
+        out = strip_gemma_markup(c)
+        assert "<|" not in out and "|>" not in out
+        assert "Hello" in out and "world" in out
+
+    def test_strips_residual_string_delimiter(self):
+        assert "<|" not in strip_gemma_markup(f"leftover {S}oops{S} text")
+
+
+# ── apply_gemma_fallback (object mutation) ───────────────────────────
+class TestApplyFallback:
+    def test_recovers_and_mutates(self):
+        msg = SimpleNamespace(
+            content=f"<|tool_call>call:bash{{command:{S}ls{S}}}<tool_call|>",
+            tool_calls=None,
+        )
+        assert apply_gemma_fallback(msg) is True
+        assert len(msg.tool_calls) == 1
+        assert msg.tool_calls[0].function.name == "bash"
+        assert "<|tool_call>" not in (msg.content or "")
+
+    def test_noop_when_tool_calls_present(self):
+        existing = [SimpleNamespace(id="x", type="function",
+                                    function=SimpleNamespace(name="g", arguments="{}"))]
+        msg = SimpleNamespace(content="<|tool_call>call:f{a:1}<tool_call|>",
+                              tool_calls=existing)
+        assert apply_gemma_fallback(msg) is False
+        assert msg.tool_calls is existing  # untouched
+
+    def test_noop_when_no_markup(self):
+        msg = SimpleNamespace(content="normal answer", tool_calls=None)
+        assert apply_gemma_fallback(msg) is False
+
+    def test_leaves_channel_for_reasoning_layer(self):
+        msg = SimpleNamespace(
+            content=f"<|channel>thought\nx\n<channel|><|tool_call>call:f{{a:1}}<tool_call|>",
+            tool_calls=None,
+        )
+        assert apply_gemma_fallback(msg) is True
+        # tool_call markup removed, channel markup preserved for next layer
+        assert "<|tool_call>" not in msg.content
+        assert "<|channel>" in msg.content
+
+
+# ── realistic leaked blob (mirrors the Element screenshot) ───────────
+def test_realistic_patch_leak():
+    blob = (
+        "<|channel>thought\nI'll patch the file.\n<channel|>"
+        f"<|tool_call>call:patch{{path:{S}/tmp/a.py{S},"
+        f"content:{S}print('hi'){S},mode:{S}overwrite{S}}}<tool_call|>"
+    )
+    msg = SimpleNamespace(content=blob, tool_calls=None)
+    assert apply_gemma_fallback(msg) is True
+    tc = msg.tool_calls[0]
+    assert tc.function.name == "patch"
+    args = json.loads(tc.function.arguments)
+    assert args == {"path": "/tmp/a.py", "content": "print('hi')", "mode": "overwrite"}
+    # reasoning extractable, final content fully clean
+    reasoning, _ = extract_gemma_reasoning(msg.content)
+    assert reasoning == "I'll patch the file."
+    assert strip_gemma_markup(msg.content).strip() == ""
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-q"]))


### PR DESCRIPTION
## Problem

When Hermes serves **Gemma-4 via vLLM** with the `gemma4` tool-call and reasoning parsers, the vLLM parser **intermittently** fails to extract Gemma-4's pipe-delimited markup. On a missed parse the markup is left raw in `message.content` with an **empty** `message.tool_calls`. Gemma-4's emit format (per `tool_chat_template_gemma4.jinja`):

```
tool call : <|tool_call>call:NAME{ARGS}<tool_call|>
reasoning : <|channel>thought\n...\n<channel|>
string arg: <|"|>...<|"|>      (keys are BARE at every depth; numbers/bools bare; objects {}; lists [])
```

Because Hermes only reads structured `message.tool_calls`, a missed parse means:

1. the **tool is never executed** (`tool_calls` is empty), and
2. the raw markup **leaks verbatim** to the user (messaging platforms, CLI, transcripts).

This implements the content-bound tool-call extraction layer requested in #29115, and addresses the Gemma-4 tool-calling / reasoning leaks in #6626 and #43873.

## Minimal reproduction

A single assistant turn where the parser missed looks like this in `message.content` (with `message.tool_calls is None`):

```
<|channel>thought
I'll patch the file.
<channel|><|tool_call>call:patch{path:<|"|>/tmp/a.py<|"|>,content:<|"|>print('hi')<|"|>,mode:<|"|>overwrite<|"|>}<tool_call|>
```

Today the user sees that entire blob as the assistant message, and `patch` never runs. The bundled test `test_realistic_patch_leak` reproduces exactly this and asserts the fix recovers it:

```python
from types import SimpleNamespace
from agent.gemma4_fallback import apply_gemma_fallback, extract_gemma_reasoning, strip_gemma_markup

msg = SimpleNamespace(content=BLOB, tool_calls=None)
assert apply_gemma_fallback(msg) is True            # recovered onto the message
tc = msg.tool_calls[0]
assert tc.function.name == "patch"
assert json.loads(tc.function.arguments) == {"path": "/tmp/a.py",
                                              "content": "print('hi')",
                                              "mode": "overwrite"}
reasoning, _ = extract_gemma_reasoning(msg.content)  # routed, not leaked
assert reasoning == "I'll patch the file."
assert strip_gemma_markup(msg.content).strip() == ""  # nothing left to leak
```

## Fix

A small, model-agnostic content fallback in `agent/gemma4_fallback.py` (pure stdlib, no new deps), wired into four points:

- **`conversation_loop.py`** — at the post-normalization chokepoint, **before** the `if assistant_message.tool_calls:` gate: `apply_gemma_fallback()` parses leaked `<|tool_call>` into structured `tool_calls` and strips that markup, so the tool **executes**.
- **`chat_completion_helpers.build_assistant_message`** — `extract_gemma_reasoning()` routes `<|channel>...<channel|>` into the reasoning field.
- **`agent_runtime_helpers.strip_think_blocks`** — `strip_gemma_markup()` cleans any residual markup at the storage boundary every consumer reads (CLI, API replay, gateway delivery, transcript, compression).
- **`gateway/stream_consumer.py`** — suppresses the spans during live streaming so platforms never flash raw markup mid-stream.

### Why it works

- The recovery runs at the **chokepoint before the tool-call gate**. `build_assistant_message` runs *after* that gate, so recovering there would clean the transcript but never execute the tool — recovering before the gate makes the tool run.
- `_gemma_args_to_json` handles the format's sharp edges: it splits on the `<|"|>` string delimiter and JSON-encodes the string segments **first**, then quotes bare keys **per structural segment only** — so a string value containing `,key:` (or `:`, `{`, `"`, newlines) can't corrupt the structural parse. Malformed args degrade to `{}` (tool runs, model recovers) rather than leaking.
- **Thinking stays enabled.** The fallback is a **no-op on the happy path** — guarded on `tool_calls` empty AND markup present — so it adds nothing when the parser succeeds.

## Tests

`tests/test_gemma4_fallback.py` — 32 unit tests covering the arg converter (strings, numbers, bools, nested objects, lists, embedded quotes/colons/commas/braces, hyphen/dot keys, `None`→`null`), tool-call parsing (single/multiple/nested-braces/unterminated/malformed), reasoning extraction, markup stripping, the object-mutation entrypoint, and the minimal end-to-end reproduction above.

```
$ python -m pytest tests/test_gemma4_fallback.py -q
32 passed
```
