### PR TITLE
fix(desktop): dispose open PTY sessions in before-quit handler

### DIFF
--- a/apps/desktop/electron/main.cjs
+++ b/apps/desktop/electron/main.cjs
@@ -6551,6 +6551,12 @@ app.on('before-quit', () => {
   flushDesktopLogBufferSync()
   closePreviewWatchers()
 
+  // Kill open PTYs before environment teardown to avoid the node-pty#904
+  // ThreadSafeFunction SIGABRT race.
+  for (const id of [...terminalSessions.keys()]) {
+    disposeTerminalSession(id)
+  }
+
   if (hermesProcess && !hermesProcess.killed) {
     hermesProcess.kill('SIGTERM')
   }

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -45,6 +45,7 @@ ACP_REGISTRY_MANIFEST = REPO_ROOT / "acp_registry" / "agent.json"
 
 # Auto-extracted from noreply emails + manual overrides
 AUTHOR_MAP = {
+    "286497132+srojk34@users.noreply.github.com": "srojk34",
     "59806492+sitkarev@users.noreply.github.com": "sitkarev",
     "zheng@omegasys.eu": "omegazheng",
     "220877172+james47kjv@users.noreply.github.com": "james47kjv",


### PR DESCRIPTION
## Summary
Desktop no longer crashes with SIGABRT on quit/update-restart when a terminal tab is open.

The `before-quit` handler tears down preview watchers and the Python backend but never disposed live PTY sessions, so node-pty's ThreadSafeFunction (microsoft/node-pty#904) fired on a half-freed napi environment during `app.quit()` → `FreeEnvironment()`.

## Changes
- `apps/desktop/electron/main.cjs`: sweep `terminalSessions.keys()` in `before-quit`, calling the existing `disposeTerminalSession()` (pty.kill() + map delete) after `closePreviewWatchers()` and before the backend SIGTERM.
- `scripts/release.py`: AUTHOR_MAP entry for srojk34.

Salvage of #48393 by @srojk34 — authorship preserved via cherry-pick. Closes #48335.

## Validation
Premise confirmed on main: `before-quit` never touched `terminalSessions`; PTYs only died on sender-`destroyed`/`onExit`, neither guaranteed before env teardown.

## Infographic
![pty-disposal-on-quit](https://v3b.fal.media/files/b/0a9eca67/vDodPnJJezUXaQ5bg82JQ_dtuem84B.png)
