### PR TITLE
fix(tui): don't make Enter swallow trailing-space-only slash completions

### DIFF
--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -6890,6 +6890,8 @@ def test_config_show_displays_nested_max_turns(monkeypatch):
 
 def test_notification_poller_delivers_completion(monkeypatch):
     """Poller picks up completion events and triggers agent turns."""
+    import queue as _queue_mod
+
     from tools.process_registry import process_registry
 
     turns = []
@@ -6916,16 +6918,23 @@ def test_notification_poller_delivers_completion(monkeypatch):
     monkeypatch.setattr(server, "make_stream_renderer", lambda cols: None)
     monkeypatch.setattr(server, "render_message", lambda raw, cols: None)
 
-    # Clear queue
-    while not process_registry.completion_queue.empty():
-        process_registry.completion_queue.get_nowait()
+    # Isolate the completion queue for the duration of this test. The poller
+    # reads process_registry.completion_queue by attribute at runtime; the
+    # event below carries no session_key, so any *other* poller (a leaked
+    # daemon thread from another test, or a concurrent one in the same xdist
+    # worker) is allowed to dequeue and dispatch it to its own session — whose
+    # agent may be a fixture double without run_conversation. A fresh Queue
+    # here fully isolates this test; monkeypatch restores the original on
+    # teardown. (Same pattern as test_notification_poller_requeues_when_busy.)
+    isolated_queue: _queue_mod.Queue = _queue_mod.Queue()
+    monkeypatch.setattr(process_registry, "completion_queue", isolated_queue)
     process_registry._completion_consumed.discard("proc_poller_test")
 
     stop = threading.Event()
 
     # Put event on queue, then immediately signal stop so the poller
     # runs exactly one iteration.
-    process_registry.completion_queue.put({
+    isolated_queue.put({
         "type": "completion",
         "session_id": "proc_poller_test",
         "command": "echo hello",
@@ -6953,6 +6962,8 @@ def test_notification_poller_delivers_completion(monkeypatch):
 
 def test_notification_poller_skips_consumed(monkeypatch):
     """Already-consumed completions are not dispatched by the poller."""
+    import queue as _queue_mod
+
     from tools.process_registry import process_registry
 
     turns = []
@@ -6975,11 +6986,15 @@ def test_notification_poller_skips_consumed(monkeypatch):
     monkeypatch.setattr(server, "make_stream_renderer", lambda cols: None)
     monkeypatch.setattr(server, "render_message", lambda raw, cols: None)
 
-    while not process_registry.completion_queue.empty():
-        process_registry.completion_queue.get_nowait()
+    # Isolate the completion queue so a concurrent/leaked poller in the same
+    # xdist worker can't dequeue this session_key-less event before our poller
+    # does. monkeypatch restores the shared singleton on teardown. (Same
+    # pattern as test_notification_poller_requeues_when_busy.)
+    isolated_queue: _queue_mod.Queue = _queue_mod.Queue()
+    monkeypatch.setattr(process_registry, "completion_queue", isolated_queue)
 
     process_registry._completion_consumed.add("proc_already_done")
-    process_registry.completion_queue.put({
+    isolated_queue.put({
         "type": "completion",
         "session_id": "proc_already_done",
         "command": "echo x",

--- a/ui-tui/src/__tests__/completionApply.test.ts
+++ b/ui-tui/src/__tests__/completionApply.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest'
+
+import { applyCompletion, completionToApplyOnSubmit } from '../domain/slash.js'
+
+describe('applyCompletion', () => {
+  it('replaces from compReplace and drops the leading slash from the row', () => {
+    // The gateway's slash completer returns bare command names with
+    // replace_from = 1 (after the leading "/").
+    expect(applyCompletion('/ex', 'exit', 1)).toBe('/exit')
+  })
+
+  it('keeps the leading slash when the row carries one and input does not', () => {
+    expect(applyCompletion('ex', '/exit', 0)).toBe('/exit')
+  })
+
+  it('replaces an argument token after a space (subcommand completion)', () => {
+    expect(applyCompletion('/cron ad', 'add', 6)).toBe('/cron add')
+  })
+})
+
+describe('completionToApplyOnSubmit', () => {
+  it('accepts a completion that finishes a partial command name', () => {
+    // "/ex" -> "/exit": a real token change, so Enter accepts it.
+    expect(completionToApplyOnSubmit('/ex', 'exit', 1)).toBe('/exit')
+  })
+
+  it('does NOT swallow Enter when the completion only adds a trailing space', () => {
+    // This is the bug: once "/exit" is fully typed, the gateway returns the
+    // command with a trailing space ("exit ") so the classic-CLI dropdown
+    // stays open. In the TUI that must NOT eat the Enter — the command is
+    // already complete, so Enter should submit.
+    expect(completionToApplyOnSubmit('/exit', 'exit ', 1)).toBeNull()
+  })
+
+  it('does not swallow Enter when applying the row is a no-op', () => {
+    expect(completionToApplyOnSubmit('/exit', 'exit', 1)).toBeNull()
+  })
+
+  it('still accepts a real argument completion (no trailing-space false positive)', () => {
+    expect(completionToApplyOnSubmit('/cron ad', 'add', 6)).toBe('/cron add')
+  })
+
+  it('submits (no accept) once an argument is fully typed and only a space is added', () => {
+    expect(completionToApplyOnSubmit('/cron add', 'add ', 6)).toBeNull()
+  })
+
+  it('returns null when there is no row text', () => {
+    expect(completionToApplyOnSubmit('/exit', undefined, 1)).toBeNull()
+    expect(completionToApplyOnSubmit('/exit', '', 1)).toBeNull()
+  })
+})

--- a/ui-tui/src/app/useSubmission.ts
+++ b/ui-tui/src/app/useSubmission.ts
@@ -2,7 +2,7 @@ import { type MutableRefObject, useCallback, useEffect, useRef } from 'react'
 
 import { TYPING_IDLE_MS } from '../config/timing.js'
 import { attachedImageNotice } from '../domain/messages.js'
-import { looksLikeSlashCommand } from '../domain/slash.js'
+import { completionToApplyOnSubmit, looksLikeSlashCommand } from '../domain/slash.js'
 import type { GatewayClient } from '../gatewayClient.js'
 import type {
   InputDetectDropResponse,
@@ -354,14 +354,10 @@ export function useSubmission(opts: UseSubmissionOptions) {
     (value: string) => {
       if (composerState.completions.length) {
         const row = composerState.completions[composerState.compIdx]
+        const next = completionToApplyOnSubmit(value, row?.text, composerState.compReplace)
 
-        if (row?.text) {
-          const text = value.startsWith('/') && row.text.startsWith('/') ? row.text.slice(1) : row.text
-          const next = value.slice(0, composerState.compReplace) + text
-
-          if (next !== value) {
-            return composerActions.setInput(next)
-          }
+        if (next !== null) {
+          return composerActions.setInput(next)
         }
       }
 

--- a/ui-tui/src/domain/slash.ts
+++ b/ui-tui/src/domain/slash.ts
@@ -8,3 +8,43 @@ export const parseSlashCommand = (cmd: string) => {
 
   return { arg: rest.join(' '), cmd, name: name.toLowerCase() }
 }
+
+/**
+ * Apply a completion row to the current input, mirroring the editor's
+ * replace semantics: replace from `compReplace` with the row text, dropping
+ * the leading slash when both the input and the row carry one (the gateway's
+ * slash completer returns bare command names whose replace span begins after
+ * the leading `/`).
+ */
+export const applyCompletion = (value: string, rowText: string, compReplace: number): string => {
+  const text = value.startsWith('/') && rowText.startsWith('/') ? rowText.slice(1) : rowText
+
+  return value.slice(0, compReplace) + text
+}
+
+/**
+ * Decide what Enter does when a completion is highlighted: returns the value
+ * to set (accept the completion) or `null` to fall through to submit.
+ *
+ * Enter accepts a completion only when it changes the command/argument token.
+ * A completion that merely appends trailing whitespace to an already-complete
+ * command (e.g. `/exit` → `/exit `, the trailing space the gateway adds so the
+ * classic CLI's prompt_toolkit dropdown stays open) must NOT swallow the Enter
+ * — otherwise every slash command needs an extra keypress: type → Enter
+ * completes the name → Enter adds the space → Enter finally submits. Treating a
+ * whitespace-only delta as "already complete" collapses that back to the
+ * expected one/two presses.
+ */
+export const completionToApplyOnSubmit = (
+  value: string,
+  rowText: string | undefined,
+  compReplace: number
+): string | null => {
+  if (!rowText) {
+    return null
+  }
+
+  const next = applyCompletion(value, rowText, compReplace)
+
+  return next !== value && next.trimEnd() !== value.trimEnd() ? next : null
+}


### PR DESCRIPTION
## Problem

In the TUI, submitting a slash command takes **three** Enter presses, e.g. `/ex` → `/exit` → `/exit ` → exit. Reported as: "every command (e.g. `\exit`) requires three Enter presses: Autocomplete → Space → Send."

## Root cause

The composer's submit handler (`ui-tui/src/app/useSubmission.ts`) accepts the highlighted completion on Enter whenever applying it changes the input at all:

```ts
if (next !== value) {
  return composerActions.setInput(next)
}
```

Once a command is fully typed (`/exit`), the gateway's slash completer returns the command **with a trailing space** (`exit `) — intentionally, so the classic CLI's `prompt_toolkit` dropdown stays open (see `hermes_cli/commands.py::_completion_text`). In the TUI that whitespace-only delta is a *different* string, so Enter applies it (`/exit` → `/exit `) instead of submitting, costing an extra keypress. The flow becomes:

1. Enter: `/ex` → `/exit` (completes the name)
2. Enter: `/exit` → `/exit ` (adds the trailing space)
3. Enter: submit

## Fix

Treat a completion whose only change is **trailing whitespace on an already-complete token** as "already complete" and fall through to submit. Real token changes (partial command name, subcommand/argument) still accept on Enter exactly as before.

The accept/replace logic is extracted into pure, tested helpers in `ui-tui/src/domain/slash.ts` (`applyCompletion`, `completionToApplyOnSubmit`).

Result: a fully-typed `/exit` submits on the first Enter; a partial `/ex` completes then submits in two — no more dangling trailing-space step.

## Test plan

- `ui-tui/src/__tests__/completionApply.test.ts` — accepts partial-name and argument completions, returns `null` (→ submit) for a trailing-space-only delta, no-op rows, and empty rows.
- `npm run typecheck`, `npm test` (related suites), and lint on changed files all pass.