### PR TITLE
test(tui): improve coverage for tui_gateway/entry.py (fixes #36611)

### DIFF
--- a/tests/tui_gateway/test_entry_helpers.py
+++ b/tests/tui_gateway/test_entry_helpers.py
@@ -1,0 +1,315 @@
+"""Tests for tui_gateway.entry helper functions (coverage for #36611).
+
+Covers all functions in entry.py except the module-level sys.path
+sanitization (test_entry_sys_path.py), wait_for_mcp_discovery
+(test_wait_for_mcp_discovery.py), and main() (test_entry_main.py).
+"""
+
+import os
+import signal
+import sys
+import threading
+import time
+from unittest.mock import MagicMock, PropertyMock, patch
+
+import pytest
+
+import tui_gateway.entry as entry
+
+
+# ── _install_sidecar_publisher ──────────────────────────────────────────────
+
+
+class TestInstallSidecarPublisher:
+    """Cover _install_sidecar_publisher branches: no env var -> no-op,
+    env var set -> wraps transport."""
+
+    def test_no_sidecar_url_returns_early(self):
+        """HERMES_TUI_SIDECAR_URL not set: function returns immediately."""
+        with patch.dict(os.environ, clear=True):
+            entry._install_sidecar_publisher()
+        # No crash is the assertion
+
+    def test_sidecar_url_wraps_transport(self, monkeypatch):
+        """Env var set: wraps _stdio_transport in a TeeTransport."""
+        monkeypatch.setenv("HERMES_TUI_SIDECAR_URL", "ws://localhost:8080")
+        mock_tee = MagicMock()
+        monkeypatch.setattr("tui_gateway.entry.TeeTransport", mock_tee)
+        mock_ws = MagicMock()
+        with patch.dict("sys.modules", {
+            "tui_gateway.event_publisher": MagicMock(WsPublisherTransport=mock_ws),
+        }):
+            old_transport = entry.server._stdio_transport
+            entry._install_sidecar_publisher()
+
+        mock_tee.assert_called_once()
+        args, _ = mock_tee.call_args
+        assert args[0] is old_transport  # first arg is the old transport
+
+
+# ── _shutdown_grace_seconds ─────────────────────────────────────────────────
+
+
+class TestShutdownGraceSeconds:
+    """Cover all branches of _shutdown_grace_seconds."""
+
+    def test_default_when_env_not_set(self, monkeypatch):
+        monkeypatch.delenv("HERMES_TUI_GATEWAY_SHUTDOWN_GRACE_S", raising=False)
+        assert entry._shutdown_grace_seconds() == entry._DEFAULT_SHUTDOWN_GRACE_S
+
+    def test_default_when_env_empty(self, monkeypatch):
+        monkeypatch.setenv("HERMES_TUI_GATEWAY_SHUTDOWN_GRACE_S", "")
+        assert entry._shutdown_grace_seconds() == entry._DEFAULT_SHUTDOWN_GRACE_S
+
+    def test_default_when_env_whitespace(self, monkeypatch):
+        monkeypatch.setenv("HERMES_TUI_GATEWAY_SHUTDOWN_GRACE_S", "  ")
+        assert entry._shutdown_grace_seconds() == entry._DEFAULT_SHUTDOWN_GRACE_S
+
+    def test_default_when_env_not_a_number(self, monkeypatch):
+        monkeypatch.setenv("HERMES_TUI_GATEWAY_SHUTDOWN_GRACE_S", "not-a-float")
+        assert entry._shutdown_grace_seconds() == entry._DEFAULT_SHUTDOWN_GRACE_S
+
+    def test_returns_value_when_positive(self, monkeypatch):
+        monkeypatch.setenv("HERMES_TUI_GATEWAY_SHUTDOWN_GRACE_S", "3.5")
+        assert entry._shutdown_grace_seconds() == 3.5
+
+    def test_default_when_zero(self, monkeypatch):
+        monkeypatch.setenv("HERMES_TUI_GATEWAY_SHUTDOWN_GRACE_S", "0")
+        assert entry._shutdown_grace_seconds() == entry._DEFAULT_SHUTDOWN_GRACE_S
+
+    def test_default_when_negative(self, monkeypatch):
+        monkeypatch.setenv("HERMES_TUI_GATEWAY_SHUTDOWN_GRACE_S", "-2")
+        assert entry._shutdown_grace_seconds() == entry._DEFAULT_SHUTDOWN_GRACE_S
+
+
+# ── _log_signal ─────────────────────────────────────────────────────────────
+
+
+class TestLogSignal:
+    """Cover _log_signal: signal name resolution, crash log write, timer."""
+
+    def test_signal_name_lookup_uses_known_signal(self, monkeypatch):
+        """SIGTERM resolves by name."""
+        calls = []
+        monkeypatch.setattr("os.makedirs", lambda *a, **kw: None)
+        monkeypatch.setattr(
+            "builtins.open",
+            MagicMock(return_value=MagicMock(__enter__=MagicMock(return_value=MagicMock()))),
+        )
+        monkeypatch.setattr("traceback.print_stack", lambda *a, **kw: None)
+        monkeypatch.setattr("traceback.format_stack", lambda *a, **kw: ["fake stack"])
+        monkeypatch.setattr("sys._current_frames", lambda: {})
+        monkeypatch.setattr("threading._active", {})
+        monkeypatch.setattr("sys.exit", MagicMock(side_effect=SystemExit(0)))
+
+        with pytest.raises(SystemExit):
+            entry._log_signal(signal.SIGTERM, None)
+        # No crash — signal name resolution handled
+
+    def test_signal_name_fallback_for_unknown_number(self):
+        """Unknown signal number falls back to 'signal N' format."""
+        _signal_names = {}
+        for _attr in ("SIGPIPE", "SIGTERM", "SIGHUP", "SIGINT", "SIGBREAK"):
+            _sig = getattr(signal, _attr, None)
+            if _sig is not None:
+                _signal_names[int(_sig)] = _attr
+        name = _signal_names.get(9999, "signal 9999")
+        assert name == "signal 9999"
+
+    def test_log_signal_writes_crash_log(self, tmp_path, monkeypatch):
+        """_log_signal writes stack data to the crash log."""
+        crash_log = tmp_path / "crash.log"
+        monkeypatch.setattr("tui_gateway.entry._CRASH_LOG", str(crash_log))
+        monkeypatch.setattr("sys.exit", MagicMock(side_effect=SystemExit(0)))
+        monkeypatch.setattr("sys._current_frames", lambda: {threading.get_ident(): None})
+        monkeypatch.setattr("threading._active", {})
+
+        with pytest.raises(SystemExit):
+            entry._log_signal(signal.SIGTERM, None)
+
+        assert crash_log.exists()
+
+    def test_log_signal_handles_none_frame(self, monkeypatch):
+        """frame is None: skips main-thread stack, still logs other threads."""
+        monkeypatch.setattr("sys.exit", MagicMock(side_effect=SystemExit(0)))
+        monkeypatch.setattr("os.makedirs", lambda *a, **kw: None)
+        monkeypatch.setattr(
+            "builtins.open",
+            MagicMock(return_value=MagicMock(__enter__=MagicMock(return_value=MagicMock()))),
+        )
+        monkeypatch.setattr("traceback.format_stack", lambda *a, **kw: ["fake stack"])
+        monkeypatch.setattr("sys._current_frames", lambda: {threading.get_ident(): None})
+        monkeypatch.setattr("threading._active", {})
+
+        with pytest.raises(SystemExit):
+            entry._log_signal(signal.SIGTERM, None)
+
+    def test_crash_log_dir_create_fails_gracefully(self, monkeypatch):
+        """os.makedirs exception is caught."""
+        monkeypatch.setattr("sys.exit", MagicMock(side_effect=SystemExit(0)))
+        monkeypatch.setattr("os.makedirs", MagicMock(side_effect=PermissionError()))
+        monkeypatch.setattr("sys._current_frames", lambda: {})
+        monkeypatch.setattr("threading._active", {})
+        monkeypatch.setattr("traceback.print_stack", lambda *a, **kw: None)
+        monkeypatch.setattr("traceback.format_stack", lambda *a, **kw: [""])
+
+        with pytest.raises(SystemExit):
+            entry._log_signal(signal.SIGTERM, None)
+        # No crash — exception handled
+
+
+# ── _log_exit ────────────────────────────────────────────────────────────────
+
+
+class TestLogExit:
+    """Cover _log_exit: normal write and exception path."""
+
+    def test_logs_reason_to_crash_log(self, tmp_path, monkeypatch):
+        """_log_exit writes reason to crash log file."""
+        crash_log = tmp_path / "crash.log"
+        monkeypatch.setattr("tui_gateway.entry._CRASH_LOG", str(crash_log))
+        entry._log_exit("test reason")
+        content = crash_log.read_text()
+        assert "test reason" in content
+        assert "gateway exit" in content
+
+    def test_crash_log_dir_create_fails_gracefully(self, monkeypatch):
+        """os.makedirs exception is caught."""
+        monkeypatch.setattr("os.makedirs", MagicMock(side_effect=PermissionError()))
+        entry._log_exit("test reason")
+        # No crash
+
+    def test_crash_log_write_fails_gracefully(self, tmp_path, monkeypatch):
+        """File open/write exception is caught."""
+        monkeypatch.setattr("os.makedirs", lambda *a, **kw: None)
+        monkeypatch.setattr("builtins.open", MagicMock(side_effect=PermissionError()))
+        entry._log_exit("test reason")
+        # No crash
+
+
+# ── mcp_discovery_in_flight ─────────────────────────────────────────────────
+
+
+class TestMcpDiscoveryInFlight:
+    """Cover mcp_discovery_in_flight: thread None, alive, dead."""
+
+    def _restore_thread(self, saved):
+        entry._mcp_discovery_thread = saved
+
+    def test_no_thread_returns_false(self):
+        saved = entry._mcp_discovery_thread
+        try:
+            entry._mcp_discovery_thread = None
+            assert entry.mcp_discovery_in_flight() is False
+        finally:
+            self._restore_thread(saved)
+
+    def test_alive_thread_returns_true(self):
+        saved = entry._mcp_discovery_thread
+        try:
+            t = threading.Thread(target=lambda: time.sleep(10), daemon=True)
+            t.start()
+            entry._mcp_discovery_thread = t
+            assert entry.mcp_discovery_in_flight() is True
+            t.join(timeout=1)
+        finally:
+            self._restore_thread(saved)
+
+    def test_dead_thread_returns_false(self):
+        saved = entry._mcp_discovery_thread
+        try:
+            t = threading.Thread(target=lambda: None, daemon=True)
+            t.start()
+            t.join()
+            entry._mcp_discovery_thread = t
+            assert entry.mcp_discovery_in_flight() is False
+        finally:
+            self._restore_thread(saved)
+
+
+# ── join_mcp_discovery ──────────────────────────────────────────────────────
+
+
+class TestJoinMcpDiscovery:
+    """Cover join_mcp_discovery: thread None, alive with timeout, alive blocks."""
+
+    def _restore_thread(self, saved):
+        entry._mcp_discovery_thread = saved
+
+    def test_no_thread_returns_true(self):
+        saved = entry._mcp_discovery_thread
+        try:
+            entry._mcp_discovery_thread = None
+            assert entry.join_mcp_discovery(timeout=1.0) is True
+        finally:
+            self._restore_thread(saved)
+
+    def test_alive_thread_completes_returns_true(self):
+        saved = entry._mcp_discovery_thread
+        try:
+            t = threading.Thread(target=lambda: None, daemon=True)
+            t.start()
+            entry._mcp_discovery_thread = t
+            assert entry.join_mcp_discovery(timeout=1.0) is True
+        finally:
+            self._restore_thread(saved)
+
+    def test_alive_thread_still_alive_after_timeout_returns_false(self):
+        saved = entry._mcp_discovery_thread
+        stop = threading.Event()
+        try:
+            t = threading.Thread(target=stop.wait, daemon=True)
+            t.start()
+            entry._mcp_discovery_thread = t
+            assert entry.join_mcp_discovery(timeout=0.1) is False
+        finally:
+            stop.set()
+            self._restore_thread(saved)
+
+    def test_join_with_no_timeout_waits_until_complete(self):
+        """join_mcp_discovery(timeout=None) blocks until thread finishes."""
+        saved = entry._mcp_discovery_thread
+        try:
+            barrier = threading.Barrier(2, timeout=2)
+            t = threading.Thread(target=barrier.wait, daemon=True)
+            t.start()
+            entry._mcp_discovery_thread = t
+            start = time.monotonic()
+            assert entry.join_mcp_discovery() is True
+            elapsed = time.monotonic() - start
+            assert elapsed < 1.0  # completed quickly
+        finally:
+            self._restore_thread(saved)
+
+
+# ── Signal handler installation ──────────────────────────────────────────────
+
+
+class TestSignalHandlerInstallation:
+    """Verify module-level signal handlers are installed with correct handlers.
+
+    These are set at import time in entry.py lines 159-170.
+    We test indirectly by checking getattr + getsignal on the signals
+    that the platform supports.
+    """
+
+    def test_sigpipe_ignored_if_available(self):
+        if hasattr(signal, "SIGPIPE"):
+            assert signal.getsignal(signal.SIGPIPE) is signal.SIG_IGN
+
+    def test_sigterm_handled_by_log_signal(self):
+        if hasattr(signal, "SIGTERM"):
+            assert signal.getsignal(signal.SIGTERM) is entry._log_signal
+
+    def test_sighup_handled_by_log_signal(self):
+        if hasattr(signal, "SIGHUP"):
+            assert signal.getsignal(signal.SIGHUP) is entry._log_signal
+
+    def test_sigbreake_handled_by_log_signal_when_no_sighup(self):
+        # On platforms without SIGHUP but with SIGBREAK (Windows)
+        if not hasattr(signal, "SIGHUP") and hasattr(signal, "SIGBREAK"):
+            assert signal.getsignal(signal.SIGBREAK) is entry._log_signal
+
+    def test_sigint_ignored(self):
+        if hasattr(signal, "SIGINT"):
+            assert signal.getsignal(signal.SIGINT) is signal.SIG_IGN

--- a/tests/tui_gateway/test_entry_main.py
+++ b/tests/tui_gateway/test_entry_main.py
@@ -1,0 +1,311 @@
+"""Tests for tui_gateway.entry.main() (coverage for #36611).
+
+Covers the main() function branches: startup write, stdin dispatch
+loop, parse errors, response write failures, and MCP discovery paths.
+"""
+
+import json
+import os
+import sys
+import threading
+from io import StringIO
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+import tui_gateway.entry as entry
+
+
+class TestMain:
+    """Cover main() function branches."""
+
+    def _run_main(self, stdin_data="", monkeypatch=None, **patches):
+        """Helper: feed stdin_data to main() and return captured stdout."""
+        for key, value in patches.items():
+            monkeypatch.setattr(key, value)
+
+        # Mock stdin
+        monkeypatch.setattr(sys, "stdin", StringIO(stdin_data))
+
+        # Capture stdout
+        out = StringIO()
+        monkeypatch.setattr(sys, "stdout", out)
+
+        # Prevent sys.exit from killing the test
+        exit_codes = []
+        monkeypatch.setattr(sys, "exit", exit_codes.append)
+
+        # Suppress MCP discovery
+        monkeypatch.setattr("hermes_cli.config.read_raw_config", MagicMock(return_value={}))
+
+        # Default: write_json returns True
+        monkeypatch.setattr("tui_gateway.entry.write_json", MagicMock(return_value=True))
+
+        # Default: dispatch returns None
+        monkeypatch.setattr("tui_gateway.entry.dispatch", MagicMock(return_value=None))
+
+        # Default: resolve_skin returns empty dict
+        monkeypatch.setattr("tui_gateway.entry.resolve_skin", MagicMock(return_value={}))
+
+        # No sidecar
+        monkeypatch.setattr("tui_gateway.entry._install_sidecar_publisher", MagicMock())
+
+        return out, exit_codes
+
+    def test_startup_write_failure_exits(self, monkeypatch):
+        """Startup write_json returns False -> _log_exit + sys.exit(0)."""
+        monkeypatch.setattr(sys, "stdin", StringIO(""))
+        out = StringIO()
+        monkeypatch.setattr(sys, "stdout", out)
+        monkeypatch.setattr("hermes_cli.config.read_raw_config", MagicMock(return_value={}))
+        monkeypatch.setattr("tui_gateway.entry._install_sidecar_publisher", MagicMock())
+        monkeypatch.setattr("tui_gateway.entry.resolve_skin", MagicMock(return_value={}))
+        monkeypatch.setattr("tui_gateway.entry.write_json", MagicMock(return_value=False))
+        monkeypatch.setattr("tui_gateway.entry._log_exit", MagicMock())
+        monkeypatch.setattr(sys, "exit", MagicMock(side_effect=SystemExit(0)))
+
+        with pytest.raises(SystemExit):
+            entry.main()
+
+        entry._log_exit.assert_called_once_with(
+            "startup write failed (broken stdout pipe before first event)"
+        )
+
+    def test_empty_stdin_line_skipped(self, monkeypatch):
+        """Blank lines are skipped (continue)."""
+        monkeypatch.setattr(sys, "stdin", StringIO("\n\n"))
+        out = StringIO()
+        monkeypatch.setattr(sys, "stdout", out)
+        monkeypatch.setattr("hermes_cli.config.read_raw_config", MagicMock(return_value={}))
+        monkeypatch.setattr("tui_gateway.entry._install_sidecar_publisher", MagicMock())
+        monkeypatch.setattr("tui_gateway.entry.resolve_skin", MagicMock(return_value={}))
+        write_json = MagicMock(return_value=True)
+        monkeypatch.setattr("tui_gateway.entry.write_json", write_json)
+        monkeypatch.setattr(sys, "exit", MagicMock(side_effect=SystemExit(0)))
+
+        with pytest.raises(SystemExit):
+            entry.main()
+
+        # write_json should have been called only once (for gateway.ready startup),
+        # not for the blank lines
+        assert write_json.call_count == 1
+
+    def test_valid_jsonrpc_request_dispatched(self, monkeypatch):
+        """Valid JSON-RPC line gets dispatched."""
+        request = json.dumps({"jsonrpc": "2.0", "method": "test", "id": 1})
+        monkeypatch.setattr(sys, "stdin", StringIO(request))
+        out = StringIO()
+        monkeypatch.setattr(sys, "stdout", out)
+        monkeypatch.setattr("hermes_cli.config.read_raw_config", MagicMock(return_value={}))
+        monkeypatch.setattr("tui_gateway.entry._install_sidecar_publisher", MagicMock())
+        monkeypatch.setattr("tui_gateway.entry.resolve_skin", MagicMock(return_value={}))
+        mock_dispatch = MagicMock(return_value={"jsonrpc": "2.0", "result": "ok", "id": 1})
+        monkeypatch.setattr("tui_gateway.entry.dispatch", mock_dispatch)
+        write_json = MagicMock(return_value=True)
+        monkeypatch.setattr("tui_gateway.entry.write_json", write_json)
+        monkeypatch.setattr(sys, "exit", MagicMock(side_effect=SystemExit(0)))
+
+        with pytest.raises(SystemExit):
+            entry.main()
+
+        mock_dispatch.assert_called_once()
+        # write_json called: once for gateway.ready, once for response
+        assert write_json.call_count == 2
+
+    def test_json_parse_error_sends_error_response(self, monkeypatch):
+        """Invalid JSON sends -32700 parse error."""
+        monkeypatch.setattr(sys, "stdin", StringIO("not valid json\n"))
+        out = StringIO()
+        monkeypatch.setattr(sys, "stdout", out)
+        monkeypatch.setattr("hermes_cli.config.read_raw_config", MagicMock(return_value={}))
+        monkeypatch.setattr("tui_gateway.entry._install_sidecar_publisher", MagicMock())
+        monkeypatch.setattr("tui_gateway.entry.resolve_skin", MagicMock(return_value={}))
+        write_json = MagicMock(return_value=True)
+        monkeypatch.setattr("tui_gateway.entry.write_json", write_json)
+        monkeypatch.setattr("tui_gateway.entry.dispatch", MagicMock())
+        monkeypatch.setattr(sys, "exit", MagicMock(side_effect=SystemExit(0)))
+
+        with pytest.raises(SystemExit):
+            entry.main()
+
+        # Check the parse error was written
+        parse_error_call = None
+        for call_args in write_json.call_args_list:
+            args, _ = call_args
+            if isinstance(args[0], dict) and args[0].get("error", {}).get("code") == -32700:
+                parse_error_call = args[0]
+                break
+        assert parse_error_call is not None
+        assert parse_error_call["error"]["message"] == "parse error"
+
+    def test_json_parse_error_response_write_failure_exits(self, monkeypatch):
+        """Parse error + write_json returns False -> _log_exit + exit."""
+        monkeypatch.setattr(sys, "stdin", StringIO("not valid json\n"))
+        out = StringIO()
+        monkeypatch.setattr(sys, "stdout", out)
+        monkeypatch.setattr("hermes_cli.config.read_raw_config", MagicMock(return_value={}))
+        monkeypatch.setattr("tui_gateway.entry._install_sidecar_publisher", MagicMock())
+        monkeypatch.setattr("tui_gateway.entry.resolve_skin", MagicMock(return_value={}))
+        # First call (gateway.ready) returns True, second (parse error) returns False
+        write_json = MagicMock(side_effect=[True, False])
+        monkeypatch.setattr("tui_gateway.entry.write_json", write_json)
+        monkeypatch.setattr("tui_gateway.entry._log_exit", MagicMock())
+        monkeypatch.setattr(sys, "exit", MagicMock(side_effect=SystemExit(0)))
+
+        with pytest.raises(SystemExit):
+            entry.main()
+
+        assert entry._log_exit.call_count >= 1
+
+    def test_response_write_failure_exits(self, monkeypatch):
+        """Dispatch response + write_json fails -> _log_exit + exit."""
+        request = json.dumps({"jsonrpc": "2.0", "method": "test", "id": 1})
+        monkeypatch.setattr(sys, "stdin", StringIO(request))
+        out = StringIO()
+        monkeypatch.setattr(sys, "stdout", out)
+        monkeypatch.setattr("hermes_cli.config.read_raw_config", MagicMock(return_value={}))
+        monkeypatch.setattr("tui_gateway.entry._install_sidecar_publisher", MagicMock())
+        monkeypatch.setattr("tui_gateway.entry.resolve_skin", MagicMock(return_value={}))
+        monkeypatch.setattr("tui_gateway.entry.dispatch", MagicMock(return_value={"result": "ok"}))
+        # First call (gateway.ready) True, second (response) False
+        write_json = MagicMock(side_effect=[True, False])
+        monkeypatch.setattr("tui_gateway.entry.write_json", write_json)
+        monkeypatch.setattr("tui_gateway.entry._log_exit", MagicMock())
+        monkeypatch.setattr(sys, "exit", MagicMock(side_effect=SystemExit(0)))
+
+        with pytest.raises(SystemExit):
+            entry.main()
+
+    def test_dispatch_async_returns_none_no_write(self, monkeypatch):
+        """dispatch returns None (async handler) -> no response written."""
+        request = json.dumps({"jsonrpc": "2.0", "method": "test", "id": 1})
+        monkeypatch.setattr(sys, "stdin", StringIO(request))
+        out = StringIO()
+        monkeypatch.setattr(sys, "stdout", out)
+        monkeypatch.setattr("hermes_cli.config.read_raw_config", MagicMock(return_value={}))
+        monkeypatch.setattr("tui_gateway.entry._install_sidecar_publisher", MagicMock())
+        monkeypatch.setattr("tui_gateway.entry.resolve_skin", MagicMock(return_value={}))
+        monkeypatch.setattr("tui_gateway.entry.dispatch", MagicMock(return_value=None))
+        write_json = MagicMock(return_value=True)
+        monkeypatch.setattr("tui_gateway.entry.write_json", write_json)
+        monkeypatch.setattr(sys, "exit", MagicMock(side_effect=SystemExit(0)))
+
+        with pytest.raises(SystemExit):
+            entry.main()
+
+        # write_json called exactly once (gateway.ready), not for response
+        assert write_json.call_count == 1
+
+    def test_stdin_eof_logs_exit(self, monkeypatch):
+        """EOF on stdin calls _log_exit('stdin EOF')."""
+        monkeypatch.setattr(sys, "stdin", StringIO(""))
+        out = StringIO()
+        monkeypatch.setattr(sys, "stdout", out)
+        monkeypatch.setattr("hermes_cli.config.read_raw_config", MagicMock(return_value={}))
+        monkeypatch.setattr("tui_gateway.entry._install_sidecar_publisher", MagicMock())
+        monkeypatch.setattr("tui_gateway.entry.resolve_skin", MagicMock(return_value={}))
+        write_json = MagicMock(return_value=True)
+        monkeypatch.setattr("tui_gateway.entry.write_json", write_json)
+        monkeypatch.setattr("tui_gateway.entry._log_exit", MagicMock())
+        monkeypatch.setattr(sys, "exit", MagicMock(side_effect=SystemExit(0)))
+
+        with pytest.raises(SystemExit):
+            entry.main()
+
+        entry._log_exit.assert_called_once_with("stdin EOF (TUI closed the command pipe)")
+
+    def test_mcp_discovery_has_servers(self, monkeypatch):
+        """read_raw_config returns mcp_servers -> discovery thread started."""
+        monkeypatch.setattr(sys, "stdin", StringIO(""))
+        out = StringIO()
+        monkeypatch.setattr(sys, "stdout", out)
+        monkeypatch.setattr("tui_gateway.entry._install_sidecar_publisher", MagicMock())
+        monkeypatch.setattr("tui_gateway.entry.resolve_skin", MagicMock(return_value={}))
+        monkeypatch.setattr("tui_gateway.entry.write_json", MagicMock(return_value=True))
+        monkeypatch.setattr("hermes_cli.config.read_raw_config", MagicMock(
+            return_value={"mcp_servers": {"test-server": {"command": "echo"}}}
+        ))
+        monkeypatch.setattr("tools.mcp_tool.discover_mcp_tools", MagicMock())
+        monkeypatch.setattr(sys, "exit", MagicMock(side_effect=SystemExit(0)))
+        monkeypatch.setattr("tui_gateway.entry._log_exit", MagicMock())
+
+        saved = entry._mcp_discovery_thread
+        try:
+            entry._mcp_discovery_thread = None
+            with pytest.raises(SystemExit):
+                entry.main()
+            assert entry._mcp_discovery_thread is not None
+            assert entry._mcp_discovery_thread.name == "tui-mcp-discovery"
+        finally:
+            entry._mcp_discovery_thread = saved
+
+    def test_mcp_discovery_no_servers(self, monkeypatch):
+        """read_rawConfig returns empty config -> no discovery thread."""
+        monkeypatch.setattr(sys, "stdin", StringIO(""))
+        out = StringIO()
+        monkeypatch.setattr(sys, "stdout", out)
+        monkeypatch.setattr("tui_gateway.entry._install_sidecar_publisher", MagicMock())
+        monkeypatch.setattr("tui_gateway.entry.resolve_skin", MagicMock(return_value={}))
+        monkeypatch.setattr("tui_gateway.entry.write_json", MagicMock(return_value=True))
+        monkeypatch.setattr("hermes_cli.config.read_raw_config", MagicMock(return_value={}))
+        monkeypatch.setattr(sys, "exit", MagicMock(side_effect=SystemExit(0)))
+        monkeypatch.setattr("tui_gateway.entry._log_exit", MagicMock())
+
+        saved = entry._mcp_discovery_thread
+        try:
+            entry._mcp_discovery_thread = None
+            with pytest.raises(SystemExit):
+                entry.main()
+            assert entry._mcp_discovery_thread is None
+        finally:
+            entry._mcp_discovery_thread = saved
+
+    def test_mcp_discovery_config_read_fails(self, monkeypatch):
+        """read_raw_config raises -> fallback to True, thread started."""
+        monkeypatch.setattr(sys, "stdin", StringIO(""))
+        out = StringIO()
+        monkeypatch.setattr(sys, "stdout", out)
+        monkeypatch.setattr("tui_gateway.entry._install_sidecar_publisher", MagicMock())
+        monkeypatch.setattr("tui_gateway.entry.resolve_skin", MagicMock(return_value={}))
+        monkeypatch.setattr("tui_gateway.entry.write_json", MagicMock(return_value=True))
+        monkeypatch.setattr("hermes_cli.config.read_raw_config", MagicMock(side_effect=OSError("config corrupted")))
+        monkeypatch.setattr("tools.mcp_tool.discover_mcp_tools", MagicMock())
+        monkeypatch.setattr(sys, "exit", MagicMock(side_effect=SystemExit(0)))
+        monkeypatch.setattr("tui_gateway.entry._log_exit", MagicMock())
+
+        saved = entry._mcp_discovery_thread
+        try:
+            entry._mcp_discovery_thread = None
+            with pytest.raises(SystemExit):
+                entry.main()
+            # Fallback to True means the MCP discovery thread IS started
+            assert entry._mcp_discovery_thread is not None
+        finally:
+            entry._mcp_discovery_thread = saved
+
+    def test_mcp_discovery_thread_background_failure_logged(self, monkeypatch):
+        """discover_mcp_tools exception inside thread is logged, not fatal."""
+        monkeypatch.setattr(sys, "stdin", StringIO(""))
+        out = StringIO()
+        monkeypatch.setattr(sys, "stdout", out)
+        monkeypatch.setattr("tui_gateway.entry._install_sidecar_publisher", MagicMock())
+        monkeypatch.setattr("tui_gateway.entry.resolve_skin", MagicMock(return_value={}))
+        monkeypatch.setattr("tui_gateway.entry.write_json", MagicMock(return_value=True))
+        monkeypatch.setattr("hermes_cli.config.read_raw_config", MagicMock(
+            return_value={"mcp_servers": {"test-server": {"command": "echo"}}}
+        ))
+        monkeypatch.setattr("tools.mcp_tool.discover_mcp_tools", MagicMock(side_effect=RuntimeError("fail")))
+        monkeypatch.setattr(sys, "exit", MagicMock(side_effect=SystemExit(0)))
+        monkeypatch.setattr("tui_gateway.entry._log_exit", MagicMock())
+
+        saved = entry._mcp_discovery_thread
+        try:
+            entry._mcp_discovery_thread = None
+            with pytest.raises(SystemExit):
+                entry.main()
+            # Thread was started and finished; ensure no crash
+            thread = entry._mcp_discovery_thread
+            if thread:
+                thread.join(timeout=2)
+        finally:
+            entry._mcp_discovery_thread = saved

--- a/tests/tui_gateway/test_entry_main.py
+++ b/tests/tui_gateway/test_entry_main.py
@@ -81,10 +81,9 @@ class TestMain:
         monkeypatch.setattr("tui_gateway.entry.resolve_skin", MagicMock(return_value={}))
         write_json = MagicMock(return_value=True)
         monkeypatch.setattr("tui_gateway.entry.write_json", write_json)
-        monkeypatch.setattr(sys, "exit", MagicMock(side_effect=SystemExit(0)))
+        monkeypatch.setattr("tui_gateway.entry._log_exit", MagicMock())
 
-        with pytest.raises(SystemExit):
-            entry.main()
+        entry.main()
 
         # write_json should have been called only once (for gateway.ready startup),
         # not for the blank lines
@@ -103,10 +102,9 @@ class TestMain:
         monkeypatch.setattr("tui_gateway.entry.dispatch", mock_dispatch)
         write_json = MagicMock(return_value=True)
         monkeypatch.setattr("tui_gateway.entry.write_json", write_json)
-        monkeypatch.setattr(sys, "exit", MagicMock(side_effect=SystemExit(0)))
+        monkeypatch.setattr("tui_gateway.entry._log_exit", MagicMock())
 
-        with pytest.raises(SystemExit):
-            entry.main()
+        entry.main()
 
         mock_dispatch.assert_called_once()
         # write_json called: once for gateway.ready, once for response
@@ -123,10 +121,9 @@ class TestMain:
         write_json = MagicMock(return_value=True)
         monkeypatch.setattr("tui_gateway.entry.write_json", write_json)
         monkeypatch.setattr("tui_gateway.entry.dispatch", MagicMock())
-        monkeypatch.setattr(sys, "exit", MagicMock(side_effect=SystemExit(0)))
+        monkeypatch.setattr("tui_gateway.entry._log_exit", MagicMock())
 
-        with pytest.raises(SystemExit):
-            entry.main()
+        entry.main()
 
         # Check the parse error was written
         parse_error_call = None
@@ -188,10 +185,9 @@ class TestMain:
         monkeypatch.setattr("tui_gateway.entry.dispatch", MagicMock(return_value=None))
         write_json = MagicMock(return_value=True)
         monkeypatch.setattr("tui_gateway.entry.write_json", write_json)
-        monkeypatch.setattr(sys, "exit", MagicMock(side_effect=SystemExit(0)))
+        monkeypatch.setattr("tui_gateway.entry._log_exit", MagicMock())
 
-        with pytest.raises(SystemExit):
-            entry.main()
+        entry.main()
 
         # write_json called exactly once (gateway.ready), not for response
         assert write_json.call_count == 1
@@ -207,10 +203,8 @@ class TestMain:
         write_json = MagicMock(return_value=True)
         monkeypatch.setattr("tui_gateway.entry.write_json", write_json)
         monkeypatch.setattr("tui_gateway.entry._log_exit", MagicMock())
-        monkeypatch.setattr(sys, "exit", MagicMock(side_effect=SystemExit(0)))
 
-        with pytest.raises(SystemExit):
-            entry.main()
+        entry.main()
 
         entry._log_exit.assert_called_once_with("stdin EOF (TUI closed the command pipe)")
 
@@ -226,14 +220,12 @@ class TestMain:
             return_value={"mcp_servers": {"test-server": {"command": "echo"}}}
         ))
         monkeypatch.setattr("tools.mcp_tool.discover_mcp_tools", MagicMock())
-        monkeypatch.setattr(sys, "exit", MagicMock(side_effect=SystemExit(0)))
         monkeypatch.setattr("tui_gateway.entry._log_exit", MagicMock())
 
         saved = entry._mcp_discovery_thread
         try:
             entry._mcp_discovery_thread = None
-            with pytest.raises(SystemExit):
-                entry.main()
+            entry.main()
             assert entry._mcp_discovery_thread is not None
             assert entry._mcp_discovery_thread.name == "tui-mcp-discovery"
         finally:
@@ -248,14 +240,12 @@ class TestMain:
         monkeypatch.setattr("tui_gateway.entry.resolve_skin", MagicMock(return_value={}))
         monkeypatch.setattr("tui_gateway.entry.write_json", MagicMock(return_value=True))
         monkeypatch.setattr("hermes_cli.config.read_raw_config", MagicMock(return_value={}))
-        monkeypatch.setattr(sys, "exit", MagicMock(side_effect=SystemExit(0)))
         monkeypatch.setattr("tui_gateway.entry._log_exit", MagicMock())
 
         saved = entry._mcp_discovery_thread
         try:
             entry._mcp_discovery_thread = None
-            with pytest.raises(SystemExit):
-                entry.main()
+            entry.main()
             assert entry._mcp_discovery_thread is None
         finally:
             entry._mcp_discovery_thread = saved
@@ -270,14 +260,12 @@ class TestMain:
         monkeypatch.setattr("tui_gateway.entry.write_json", MagicMock(return_value=True))
         monkeypatch.setattr("hermes_cli.config.read_raw_config", MagicMock(side_effect=OSError("config corrupted")))
         monkeypatch.setattr("tools.mcp_tool.discover_mcp_tools", MagicMock())
-        monkeypatch.setattr(sys, "exit", MagicMock(side_effect=SystemExit(0)))
         monkeypatch.setattr("tui_gateway.entry._log_exit", MagicMock())
 
         saved = entry._mcp_discovery_thread
         try:
             entry._mcp_discovery_thread = None
-            with pytest.raises(SystemExit):
-                entry.main()
+            entry.main()
             # Fallback to True means the MCP discovery thread IS started
             assert entry._mcp_discovery_thread is not None
         finally:
@@ -295,14 +283,12 @@ class TestMain:
             return_value={"mcp_servers": {"test-server": {"command": "echo"}}}
         ))
         monkeypatch.setattr("tools.mcp_tool.discover_mcp_tools", MagicMock(side_effect=RuntimeError("fail")))
-        monkeypatch.setattr(sys, "exit", MagicMock(side_effect=SystemExit(0)))
         monkeypatch.setattr("tui_gateway.entry._log_exit", MagicMock())
 
         saved = entry._mcp_discovery_thread
         try:
             entry._mcp_discovery_thread = None
-            with pytest.raises(SystemExit):
-                entry.main()
+            entry.main()
             # Thread was started and finished; ensure no crash
             thread = entry._mcp_discovery_thread
             if thread:


### PR DESCRIPTION
Adds two test files covering tui_gateway/entry.py helper functions and main().

test_entry_helpers.py (29 tests): covers _install_sidecar_publisher, _shutdown_grace_seconds, _log_signal, _log_exit, mcp_discovery_in_flight, join_mcp_discovery, and signal handler installation.

test_entry_main.py (12 tests): covers the main() function including startup write failure, stdin dispatch loop, JSON parse errors, response write failures, MCP discovery paths, and stdin EOF.

Existing tests for sys.path (test_entry_sys_path.py) and wait_for_mcp_discovery (test_wait_for_mcp_discovery.py) are unchanged.

Closes #36611