### PR TITLE
feat(cron): expose per-job Model field in Create/Edit Job modal

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -7046,6 +7046,7 @@ class CronJobCreate(BaseModel):
     name: str = ""
     deliver: str = "local"
     skills: Optional[List[str]] = None
+    model: str = ""
 
 
 class CronJobUpdate(BaseModel):
@@ -7218,6 +7219,7 @@ async def create_cron_job(body: CronJobCreate, profile: str = "default"):
             name=body.name,
             deliver=body.deliver,
             skills=body.skills,
+            model=body.model,
         )
     except Exception as e:
         _log.exception("POST /api/cron/jobs failed")

--- a/web/src/i18n/en.ts
+++ b/web/src/i18n/en.ts
@@ -230,6 +230,8 @@ export const en: Translations = {
     newJob: "New Cron Job",
     nameOptional: "Name (optional)",
     namePlaceholder: "e.g. Daily summary",
+    modelOptional: "Model (optional)",
+    modelPlaceholder: "e.g. moonshotai/kimi-k2.6 (leaves the gateway default if empty)",
     prompt: "Prompt",
     promptPlaceholder: "What should the agent do on each run?",
     schedule: "Schedule (cron expression)",

--- a/web/src/i18n/types.ts
+++ b/web/src/i18n/types.ts
@@ -249,6 +249,8 @@ export interface Translations {
     newJob: string;
     nameOptional: string;
     namePlaceholder: string;
+    modelOptional?: string;
+    modelPlaceholder?: string;
     prompt: string;
     promptPlaceholder: string;
     schedule: string;

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -509,7 +509,7 @@ export const api = {
     fetchJSON<CronJob[]>(`/api/cron/jobs?profile=${encodeURIComponent(profile)}`),
   getCronDeliveryTargets: () =>
     fetchJSON<{ targets: CronDeliveryTarget[] }>("/api/cron/delivery-targets"),
-  createCronJob: (job: { prompt: string; schedule: string; name?: string; deliver?: string; skills?: string[] }, profile = "default") =>
+  createCronJob: (job: { prompt: string; schedule: string; name?: string; deliver?: string; skills?: string[]; model?: string }, profile = "default") =>
     fetchJSON<CronJob>(`/api/cron/jobs?profile=${encodeURIComponent(profile)}`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
@@ -519,7 +519,7 @@ export const api = {
     fetchJSON<CronJob>(`/api/cron/jobs/${encodeURIComponent(id)}/pause?profile=${encodeURIComponent(profile)}`, { method: "POST" }),
   updateCronJob: (
     id: string,
-    updates: { prompt?: string; schedule?: string; name?: string; deliver?: string; skills?: string[] },
+    updates: { prompt?: string; schedule?: string; name?: string; deliver?: string; skills?: string[]; model?: string | null },
     profile = "default",
   ) =>
     fetchJSON<CronJob>(
@@ -1878,6 +1878,7 @@ export interface CronJob {
   enabled: boolean;
   state?: string | null;
   deliver?: string | null;
+  model?: string | null;
   last_run_at?: string | null;
   next_run_at?: string | null;
   last_error?: string | null;

--- a/web/src/pages/CronPage.tsx
+++ b/web/src/pages/CronPage.tsx
@@ -211,6 +211,7 @@ export default function CronPage() {
     DEFAULT_SCHEDULE_STATE,
   );
   const [name, setName] = useState("");
+  const [model, setModel] = useState("");
   const closeCreateModal = useCallback(() => setCreateModalOpen(false), []);
   const createModalRef = useModalBehavior({
     open: createModalOpen,
@@ -229,6 +230,7 @@ export default function CronPage() {
   const [editPrompt, setEditPrompt] = useState("");
   const [editSchedule, setEditSchedule] = useState("");
   const [editName, setEditName] = useState("");
+  const [editModel, setEditModel] = useState("");
   const [editDeliver, setEditDeliver] = useState("local");
   const [editSkills, setEditSkills] = useState<string[]>([]);
   const [saving, setSaving] = useState(false);
@@ -251,6 +253,7 @@ export default function CronPage() {
       asText(job.schedule?.expr) || asText(job.schedule_display) || "",
     );
     setEditName(getJobName(job));
+    setEditModel(asText(job.model));
     setEditDeliver(asText(job.deliver) || "local");
     setEditSkills(Array.isArray(job.skills) ? job.skills.filter(Boolean) : []);
   }, []);
@@ -373,6 +376,7 @@ export default function CronPage() {
           name: name.trim() || undefined,
           deliver,
           skills: jobSkills.length > 0 ? jobSkills : undefined,
+          model: model.trim() || undefined,
         },
         createProfile,
       );
@@ -380,6 +384,7 @@ export default function CronPage() {
       setPrompt("");
       setScheduleState(DEFAULT_SCHEDULE_STATE);
       setName("");
+      setModel("");
       setDeliver("local");
       setJobSkills([]);
       setCreateModalOpen(false);
@@ -407,6 +412,7 @@ export default function CronPage() {
           name: editName.trim(),
           deliver: editDeliver,
           skills: editSkills,
+          model: editModel.trim() || null,
         },
         getJobProfile(editJob),
       );
@@ -610,6 +616,21 @@ export default function CronPage() {
                 />
               </div>
 
+              <div className="grid gap-2">
+                <Label htmlFor="cron-model">
+                  {t.cron.modelOptional ?? "Model (optional)"}
+                </Label>
+                <Input
+                  id="cron-model"
+                  placeholder={
+                    t.cron.modelPlaceholder ??
+                    "e.g. moonshotai/kimi-k2.6 (leaves the gateway default if empty)"
+                  }
+                  value={model}
+                  onChange={(e) => setModel(e.target.value)}
+                />
+              </div>
+
               <ScheduleBuilder
                 value={scheduleState}
                 onChange={setScheduleState}
@@ -713,6 +734,21 @@ export default function CronPage() {
                   placeholder={t.cron.promptPlaceholder}
                   value={editPrompt}
                   onChange={(e) => setEditPrompt(e.target.value)}
+                />
+              </div>
+
+              <div className="grid gap-2">
+                <Label htmlFor="edit-cron-model">
+                  {t.cron.modelOptional ?? "Model (optional)"}
+                </Label>
+                <Input
+                  id="edit-cron-model"
+                  placeholder={
+                    t.cron.modelPlaceholder ??
+                    "e.g. moonshotai/kimi-k2.6 (leaves the gateway default if empty)"
+                  }
+                  value={editModel}
+                  onChange={(e) => setEditModel(e.target.value)}
                 />
               </div>
 


### PR DESCRIPTION
## Summary

The cron scheduler already resolves a per-job `model` override
(`cron/scheduler.py`: `model = job.get("model") or os.getenv("HERMES_MODEL") or ""`).
The cron UI did not expose it, so users either accept the gateway
default or hand-edit `~/.hermes/cron/jobs.json`. Hand-editing is
fragile: the gateway rewrites the file on each tick, so the user has
to stop the gateway to make the edit stick.

This PR adds a free-text **Model (optional)** input to the Create and
Edit Job modals, wired into the existing create/update payload under
the `model` key.

## Screenshots

**Create Job modal**

| Before | After |
| --- | --- |
| ![Create job modal before](https://raw.githubusercontent.com/nujovich/hermes-agent/pr2-screenshots/cron-create-before.png) | ![Create job modal after](https://raw.githubusercontent.com/nujovich/hermes-agent/pr2-screenshots/cron-create-after.png) |

**Edit Job modal** (After shows the field pre-filled from the job's `model`)

| Before | After |
| --- | --- |
| ![Edit job modal before](https://raw.githubusercontent.com/nujovich/hermes-agent/pr2-screenshots/cron-edit-before.png) | ![Edit job modal after](https://raw.githubusercontent.com/nujovich/hermes-agent/pr2-screenshots/cron-edit-after.png) |

## A note (I was not sure if backend supports model)

The PUT path forwards the whole `updates` dict, so `model` round-trips. 
But the POST handler whitelisted fields (`prompt`/`schedule`/`name`/`deliver`/`skills`) and
`CronJobCreate` had no `model` field, so a frontend-only change would
have been **silently dropped on create**. I added the minimal forward
(2 lines): `model` on `CronJobCreate` + passing it to `create_job()`
(which already accepted the kwarg). Happy to split that into its own
commit/PR if you'd prefer the UI and backend forward to land
separately.

## Files

- `web/src/pages/CronPage.tsx` — Model input in both modals, state,
  payload wiring (create omits empty; edit clears to `null`).
- `web/src/lib/api.ts` — `model` on the create/update payload types and
  on the `CronJob` interface.
- `web/src/i18n/{types,en}.ts` — optional `modelOptional` /
  `modelPlaceholder` keys + English strings, following the existing
  optional-key + `??` fallback pattern (other locales fill in later).
- `hermes_cli/web_server.py` — `model` on `CronJobCreate` + forwarded
  in the POST handler.

## Question for maintainers

Three viable UX shapes — I want your call before I iterate:

1. **Free text** (this PR). User types `moonshotai/kimi-k2.6` or any
   string. Smallest change, no model-registry dependency.
2. **Dropdown** populated from the gateway's known models (whatever
   list `/model` or the providers config exposes). Requires a backend
   endpoint to expose that list.
3. **Autocomplete** combining (1) and (2): free text with suggestions
   from the known list.

I shipped (1) because it's the minimal change that closes the gap.
Tell me which direction you want and I'll iterate inside this same PR.

## Coordination

I checked PR #48275 (pluggable CronScheduler). It's backend-only and
explicitly does not touch the model field. No conflict either way on
merge order.

## Out of scope

- `provider` and `base_url` fields (separate PRs if you want them).
- Public docs (`docs/user-guide/features/cron` doesn't currently list
  `model` as a field — happy to do a follow-up docs PR once the UX
  shape is settled).

## Tests

There is no unit-test harness for the web dashboard (`web/package.json`
exposes only `dev`/`build`/`lint`/`typecheck`), so per the no-new-test-
framework constraint this ships with a manual test note instead.
`npm run typecheck` and `npm run lint` pass.

## Manual test

1. Open Create Job modal → type `moonshotai/kimi-k2.6` in Model →
   create the job.
2. Inspect `~/.hermes/cron/jobs.json` — new job has
   `"model": "moonshotai/kimi-k2.6"`.
3. Open Edit Job on the same job — Model field shows the saved value.
4. Change to a different model id, save, re-inspect JSON: updated.
5. Clear the field, save, re-inspect: `"model": null`.
