### PR TITLE
fix(kanban): isolate worker browser sessions

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -261,6 +261,20 @@ def _normalize_board_slug(slug: Optional[str]) -> Optional[str]:
     return s
 
 
+def _agent_browser_session_slug(value: object) -> str:
+    """Return a conservative slug for agent-browser session names."""
+    text = str(value or "").strip().lower()
+    slug = re.sub(r"[^a-z0-9]+", "-", text).strip("-")
+    return slug or "unknown"
+
+
+def _kanban_agent_browser_session_name(board: str, task_id: str) -> str:
+    return (
+        f"kanban-{_agent_browser_session_slug(board)}-"
+        f"{_agent_browser_session_slug(task_id)}"
+    )
+
+
 def kanban_home() -> Path:
     """Return the shared Hermes root that anchors the kanban board.
 
@@ -6798,6 +6812,15 @@ def _default_spawn(
     # board slug still forces it to the right directory.
     resolved_board = _normalize_board_slug(board) or get_current_board()
     env["HERMES_KANBAN_BOARD"] = resolved_board
+    # Agent Browser stores CDP bindings and page state per local session.
+    # Give every Kanban worker a deterministic browser session by default
+    # so ad-hoc agent-browser shell-outs cannot collide on the global
+    # "default" session. Preserve explicit operator overrides.
+    if not env.get("AGENT_BROWSER_SESSION", "").strip():
+        env["AGENT_BROWSER_SESSION"] = _kanban_agent_browser_session_name(
+            resolved_board,
+            task.id,
+        )
     # HERMES_PROFILE is the author the kanban_comment tool defaults to.
     # `hermes -p <assignee>` activates the profile, but the env var is
     # what the tool reads — set it explicitly here so comments are

--- a/tests/hermes_cli/test_kanban_boards.py
+++ b/tests/hermes_cli/test_kanban_boards.py
@@ -423,6 +423,7 @@ class TestWorkerSpawnEnv:
         env = captured["env"]
         assert env["HERMES_KANBAN_BOARD"] == "spawntest"
         assert env["HERMES_KANBAN_TASK"] == "t_abc"
+        assert env["AGENT_BROWSER_SESSION"] == "kanban-spawntest-t-abc"
         # DB path should match the per-board DB, not the legacy default.
         expected_db = fresh_home / "kanban" / "boards" / "spawntest" / "kanban.db"
         assert env["HERMES_KANBAN_DB"] == str(expected_db)
@@ -461,6 +462,78 @@ class TestWorkerSpawnEnv:
         env = captured["env"]
         assert env["HERMES_KANBAN_BOARD"] == "default"
         assert env["HERMES_KANBAN_DB"] == str(fresh_home / "kanban.db")
+        assert env["AGENT_BROWSER_SESSION"] == "kanban-default-t-def"
+
+    def test_default_spawn_preserves_explicit_agent_browser_session(
+        self,
+        fresh_home,
+        monkeypatch,
+    ):
+        captured = {}
+
+        class FakeProc:
+            pid = 1
+
+        def fake_popen(cmd, *args, **kwargs):
+            captured["env"] = kwargs.get("env", {})
+            return FakeProc()
+
+        monkeypatch.setattr(subprocess, "Popen", fake_popen)
+        monkeypatch.setenv("AGENT_BROWSER_SESSION", "operator-session")
+        task = kb.Task(
+            id="t_override",
+            title="",
+            body=None,
+            assignee="teknium",
+            status="ready",
+            priority=0,
+            created_by=None,
+            created_at=0,
+            started_at=None,
+            completed_at=None,
+            workspace_kind="scratch",
+            workspace_path=None,
+            claim_lock=None,
+            claim_expires=None,
+            tenant=None,
+        )
+
+        kb._default_spawn(task, str(fresh_home / "ws"), board="spawntest")
+
+        assert captured["env"]["AGENT_BROWSER_SESSION"] == "operator-session"
+
+    def test_default_spawn_sanitizes_agent_browser_session(self, fresh_home, monkeypatch):
+        captured = {}
+
+        class FakeProc:
+            pid = 1
+
+        def fake_popen(cmd, *args, **kwargs):
+            captured["env"] = kwargs.get("env", {})
+            return FakeProc()
+
+        monkeypatch.setattr(subprocess, "Popen", fake_popen)
+        task = kb.Task(
+            id="T_weird_ID",
+            title="",
+            body=None,
+            assignee="teknium",
+            status="ready",
+            priority=0,
+            created_by=None,
+            created_at=0,
+            started_at=None,
+            completed_at=None,
+            workspace_kind="scratch",
+            workspace_path=None,
+            claim_lock=None,
+            claim_expires=None,
+            tenant=None,
+        )
+
+        kb._default_spawn(task, str(fresh_home / "ws"), board="qa-board")
+
+        assert captured["env"]["AGENT_BROWSER_SESSION"] == "kanban-qa-board-t-weird-id"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- set a deterministic `AGENT_BROWSER_SESSION` for dispatcher-spawned Kanban workers when the operator has not explicitly provided one
- derive the session from board + task id with conservative slugging, e.g. `kanban-qa-t-smoke-a`
- preserve an existing non-empty `AGENT_BROWSER_SESSION` override

## Context
This is the upstream defense-in-depth fix for LS-1967 / parent LS-1906. The Hermes Kanban Browser Use RCA found that worker shell-outs to `agent-browser` can collide on the local default session unless Kanban injects per-worker browser-session isolation.

RCA: https://github.com/leonardsellem/gbrain-brain/blob/06cbeb1e9ab25a71970a9db9c82ad99b7870a9f3/projects/homelab/docs/brainstorms/2026-06-18-hermes-kanban-browser-use-reliability-rca-requirements.md
Plan: https://github.com/leonardsellem/gbrain-brain/blob/06cbeb1e9ab25a71970a9db9c82ad99b7870a9f3/projects/homelab/docs/plans/2026-06-18-hermes-kanban-browser-use-reliability-plan.md

## Verification
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run python -m pytest tests/hermes_cli/test_kanban_boards.py -q` -> 58 passed
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run python -m pytest tests/hermes_cli/test_kanban_boards.py tests/hermes_cli/test_kanban_worker_spawn_toolsets.py -q` -> 60 passed
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run pytest tests/hermes_cli/test_kanban_worker_spawn_toolsets.py -q` -> 2 passed
- `uv run ruff check hermes_cli/kanban_db.py tests/hermes_cli/test_kanban_boards.py` -> pass
- `python -m py_compile hermes_cli/kanban_db.py` -> pass
- manual spawn smoke with two tasks captured distinct sessions: `kanban-qa-t-smoke-a`, `kanban-qa-t-smoke-b`
