### PR TITLE
fix(desktop): normalize epoch seconds to milliseconds in Artifacts timestamp

### DIFF
--- a/apps/desktop/src/app/artifacts/index.tsx
+++ b/apps/desktop/src/app/artifacts/index.tsx
@@ -306,7 +306,12 @@ export function collectArtifactsForSession(session: SessionInfo, messages: Sessi
 }
 
 function formatArtifactTime(timestamp: number): string {
-  return ARTIFACT_TIME_FMT.format(new Date(timestamp))
+  // Timestamps from the session DB are epoch seconds (~1.78e9 in 2026).
+  // JavaScript's Date() interprets numbers < 1e12 as milliseconds, so
+  // epoch seconds would produce a date in Jan 1970 instead of 2026.
+  // Normalize by multiplying by 1000 only when the value is clearly in seconds.
+  const ms = timestamp < 1e12 ? timestamp * 1000 : timestamp
+  return ARTIFACT_TIME_FMT.format(new Date(ms))
 }
 
 function pageRangeLabel(total: number, page: number, pageSize: number, a: Translations['artifacts']): string {


### PR DESCRIPTION
## Summary

Timestamps from the session DB are stored as Unix epoch seconds (~1.78e9 in 2026), but JavaScript's  interprets values < 1e12 as **milliseconds**. This caused the Desktop Artifacts page to display session dates as January 1970 instead of the correct date.

## Fix

In , the  function now detects seconds-scale timestamps (values < 1e12, which clearly can't be milliseconds — 1e12 ms = year 2002) and multiplies by 1000 before passing to .

## Test



## Issue

Fixes #48350