### PR TITLE
fix(kanban): emit blocked event for initial_status="blocked" tasks (fixes #47777)

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -2280,6 +2280,11 @@ def create_task(
                         "goal_mode": bool(goal_mode) or None,
                     },
                 )
+                # Emit a "blocked" event so tasks created with
+                # initial_status="blocked" are treated as sticky-blocked
+                # by recompute_ready (#47777).
+                if task_status == "blocked":
+                    _append_event(conn, task_id, "blocked", {"reason": "created with initial_status=blocked"})
             return task_id
         except sqlite3.IntegrityError:
             if attempt == 1:

--- a/tests/hermes_cli/test_kanban_blocked_sticky.py
+++ b/tests/hermes_cli/test_kanban_blocked_sticky.py
@@ -277,3 +277,59 @@ def test_protocol_violation_loop_is_broken(kanban_home: Path) -> None:
 # (landed via #28754 / #28781).  The original PR shipped a duplicate test
 # here; dropped during salvage to avoid two assertions of the same contract.
 # ---------------------------------------------------------------------------
+
+
+# ---------------------------------------------------------------------------
+# Created-blocked tasks must stay blocked (issue #47777)
+# ---------------------------------------------------------------------------
+
+
+def test_created_blocked_task_stays_blocked(kanban_home: Path) -> None:
+    """A task created with initial_status='blocked' must stay blocked
+    across dispatcher ticks, not be auto-promoted by recompute_ready."""
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="parked task", initial_status="blocked")
+        assert kb.get_task(conn, tid).status == "blocked"
+
+        for _ in range(5):
+            promoted = kb.recompute_ready(conn)
+            assert promoted == 0, "created-blocked task must not auto-promote"
+            assert kb.get_task(conn, tid).status == "blocked"
+
+
+def test_created_blocked_with_done_parents_stays_blocked(kanban_home: Path) -> None:
+    """Created-blocked must stay blocked even when all parents are done."""
+    with kb.connect() as conn:
+        parent = kb.create_task(conn, title="parent")
+        child = kb.create_task(conn, title="child", parents=[parent], initial_status="blocked")
+        kb.complete_task(conn, parent, result="parent ok")
+
+        assert kb.get_task(conn, child).status == "blocked"
+        promoted = kb.recompute_ready(conn)
+        assert promoted == 0
+        assert kb.get_task(conn, child).status == "blocked"
+
+
+def test_created_blocked_can_be_unblocked(kanban_home: Path) -> None:
+    """A created-blocked task can be explicitly unblocked and then
+    promoted normally (#47777)."""
+    with kb.connect() as conn:
+        parent = kb.create_task(conn, title="parent")
+        child = kb.create_task(
+            conn, title="child", parents=[parent], initial_status="blocked"
+        )
+        kb.complete_task(conn, parent, result="parent ok")
+
+        # Must stay blocked until explicit unblock.
+        assert kb.recompute_ready(conn) == 0
+        assert kb.get_task(conn, child).status == "blocked"
+
+        # Explicit unblock frees it (status flips to ready because
+        # all parents are done).
+        kb.unblock_task(conn, child)
+        assert kb.get_task(conn, child).status == "ready"
+
+        # recompute_ready sees the task is already ready.
+        promoted = kb.recompute_ready(conn)
+        assert promoted == 0
+        assert kb.get_task(conn, child).status == "ready"


### PR DESCRIPTION
Fixes NousResearch/hermes-agent#47777

## Problem

A task created with `initial_status="blocked"` is auto-promoted to `ready` on the next dispatch tick (≤60s) because `recompute_ready()` calls `_has_sticky_block()`, which looks for a `"blocked"` event in `task_events`. No such event is emitted at creation time, so `_has_sticky_block()` returns `False` and the task is promoted — even though its status is `blocked`. This can cause unwanted worker spawns and, in the worst case, fabricated human approvals for decision records (as described in the issue).

## Root Cause

In `create_task()` (`hermes_cli/kanban_db.py`), when `initial_status="blocked"` is passed, the task row gets `status='blocked'` but only a `"created"` event is appended to `task_events`. The `"blocked"` event is never emitted. By contrast, `kanban_block()` (the explicit block path) does emit a `"blocked"` event, so explicitly-blocked tasks are correctly treated as sticky-blocked by `_has_sticky_block()`. Created-blocked tasks diverge purely because of this missing event row.

## Fix

After the `"created"` event in `create_task()`, emit a `"blocked"` event when `task_status == "blocked"`:

```python
if task_status == "blocked":
    _append_event(conn, task_id, "blocked", {"reason": "created with initial_status=blocked"})
```

This ensures created-blocked tasks are treated identically to explicitly-blocked tasks by `_has_sticky_block()` and `recompute_ready()`. Only an explicit `unblock_task()` releases them.

## Changes

- `hermes_cli/kanban_db.py` — `create_task()`: emit `"blocked"` event when `initial_status="blocked"` (5 lines added)
- `tests/hermes_cli/test_kanban_blocked_sticky.py` — 3 new regression tests:
  - `test_created_blocked_task_stays_blocked` — standalone blocked task survives 5 recompute ticks
  - `test_created_blocked_with_done_parents_stays_blocked` — blocked child with done parents stays blocked
  - `test_created_blocked_can_be_unblocked` — explicit unblock works and promotes correctly

## Impact

- **Minimal**: No change to `recompute_ready()` logic or any existing behavior for non-blocked tasks, explicitly-blocked tasks, or normal `todo → ready` promotion.
- **Correct**: Created-blocked tasks now match the established sticky-block semantic — they stay blocked until an explicit `unblock_task()` call.
- **Data-integrity**: Prevents the race window where a parked task can be auto-promoted, spawned, and auto-completed with fabricated approvals within seconds of creation.
- All 9 tests in `test_kanban_blocked_sticky.py` pass.