### PR TITLE
fix: pass finalize=True in got_done fallback for draft streaming

### DIFF
--- a/gateway/stream_consumer.py
+++ b/gateway/stream_consumer.py
@@ -673,7 +673,9 @@ class GatewayStreamConsumer:
                                 # not duplicate the visible prefix.
                                 await self._send_fallback_final(self._accumulated)
                         elif not self._already_sent:
-                            self._final_response_sent = await self._send_or_edit(self._accumulated)
+                            self._final_response_sent = await self._send_or_edit(
+                                self._accumulated, finalize=True,
+                            )
                             if self._final_response_sent:
                                 self._final_content_delivered = True
                     return


### PR DESCRIPTION
Fix a message-disappearance bug in Telegram draft streaming when the network is unstable.

## Root cause

When draft streaming is active (transport: auto) and the primary finalize=True send
at line 613 fails (network blip, proxy drop, API timeout), the got_done handler falls
through to a fallback path (line 675) that calls _send_or_edit() without
finalize=True. This re-enters the draft path (requires not finalize), sending another
ephemeral sendRichMessageDraft instead of a real message. The draft clears, no real
message appears, and the gateway suppresses its own fallback because
_final_response_sent=True.

## Fix

Pass finalize=True so the fallback sends a real message via adapter.send() instead
of another draft.

## Tests

All 111 stream consumer tests pass (including 18 draft-specific tests).