### PR TITLE
fix(desktop): convert epoch seconds to milliseconds in formatArtifactTime

### DIFF
--- a/apps/desktop/src/app/artifacts/index.test.ts
+++ b/apps/desktop/src/app/artifacts/index.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest'
 
 import type { SessionInfo, SessionMessage } from '@/types/hermes'
 
-import { collectArtifactsForSession } from './index'
+import { collectArtifactsForSession, formatArtifactTime } from './index'
 
 function makeSession(overrides: Partial<SessionInfo> = {}): SessionInfo {
   return {
@@ -22,6 +22,29 @@ function makeSession(overrides: Partial<SessionInfo> = {}): SessionInfo {
     ...overrides
   }
 }
+
+describe('formatArtifactTime', () => {
+  it('converts epoch seconds to correct month (Jun, not Jan)', () => {
+    // 1781773226 seconds = 2026-06-18 17:00:26 UTC
+    // Before fix, seconds were passed directly to new Date() → Jan 21 1970
+    const result = formatArtifactTime(1781773226)
+    expect(result).toContain('Jun')
+    expect(result).not.toContain('Jan')
+  })
+
+  it('handles millisecond timestamps (>= 1e12) correctly', () => {
+    const msTimestamp = 1781773226000 // already in ms
+    const result = formatArtifactTime(msTimestamp)
+    expect(result).toContain('Jun')
+    expect(result).not.toContain('Jan')
+  })
+
+  it('produces same output for equivalent seconds and milliseconds', () => {
+    const seconds = 1781773226
+    const milliseconds = 1781773226000
+    expect(formatArtifactTime(seconds)).toBe(formatArtifactTime(milliseconds))
+  })
+})
 
 describe('collectArtifactsForSession', () => {
   it('indexes plain https links from assistant text', () => {

--- a/apps/desktop/src/app/artifacts/index.tsx
+++ b/apps/desktop/src/app/artifacts/index.tsx
@@ -305,8 +305,12 @@ export function collectArtifactsForSession(session: SessionInfo, messages: Sessi
   return Array.from(found.values())
 }
 
-function formatArtifactTime(timestamp: number): string {
-  return ARTIFACT_TIME_FMT.format(new Date(timestamp))
+export function formatArtifactTime(timestamp: number): string {
+  // Backend timestamps (message.timestamp, session.started_at, session.last_active)
+  // are Unix epoch seconds from Python's time.time(). Convert to milliseconds
+  // for JavaScript Date. Threshold: values < 1e12 are seconds, >= 1e12 are ms.
+  const ms = timestamp < 1e12 ? timestamp * 1000 : timestamp
+  return ARTIFACT_TIME_FMT.format(new Date(ms))
 }
 
 function pageRangeLabel(total: number, page: number, pageSize: number, a: Translations['artifacts']): string {


### PR DESCRIPTION
## What does this PR do?

Fixes the Desktop Artifacts page displaying session timestamps as Jan 1970-era dates. Backend timestamps from Python's `time.time()` are Unix epoch **seconds**, but JavaScript's `new Date()` expects **milliseconds**. Passing seconds directly (e.g., `1781773226`) produced dates near the Unix epoch instead of the correct 2026 date.

## Related Issue

Fixes #48350

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `apps/desktop/src/app/artifacts/index.tsx`: Added seconds-vs-milliseconds normalizer in `formatArtifactTime()` using a `1e12` threshold. Exported the function for testability.
- `apps/desktop/src/app/artifacts/index.test.ts`: Added 3 regression tests for `formatArtifactTime` — epoch seconds conversion, millisecond passthrough, and equivalence assertion.

## How to Test

1. Open Hermes Desktop with a session that has timestamps stored as epoch seconds (any session created via CLI)
2. Navigate to the Artifacts page
3. Verify timestamps show the correct date/time (e.g., "Jun 18, 5:00 PM") instead of "Jan 21, 22:56"
4. Run `cd apps/desktop && npx vitest run src/app/artifacts/index.test.ts` — all 5 tests should pass

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `npx vitest run` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

⚠️ GitNexus unavailable — grep-based fallback used.
- Checked: `apps/desktop/src/app/artifacts/index.tsx` — `formatArtifactTime` is used at 2 call sites (line 719, 831)
- Blast radius: LOW — single function, no control-flow changes, only affects timestamp display
- Related patterns: Python seconds vs JavaScript milliseconds — common cross-language timestamp bug
