### PR TITLE
feat(acp): advertise thought-level session config

### DIFF
--- a/acp_adapter/server.py
+++ b/acp_adapter/server.py
@@ -46,6 +46,8 @@ from acp.schema import (
     SetSessionModeResponse,
     ResourceContentBlock,
     SessionCapabilities,
+    SessionConfigOptionSelect,
+    SessionConfigSelectOption,
     SessionForkCapabilities,
     SessionInfoUpdate,
     SessionListCapabilities,
@@ -502,6 +504,8 @@ class HermesACPAgent(acp.Agent):
 
     _EDIT_APPROVAL_POLICY_CONFIG_ID = "edit_approval_policy"
     _EDIT_APPROVAL_POLICY_DEFAULT = "ask"
+    _THOUGHT_LEVEL_CONFIG_ID = "thought_level"
+    _THOUGHT_LEVEL_VALUES = ("none", "minimal", "low", "medium", "high", "xhigh")
     _MODE_DEFAULT = "default"
     _MODE_ACCEPT_EDITS = "accept_edits"
     _MODE_DONT_ASK = "dont_ask"
@@ -559,6 +563,35 @@ class HermesACPAgent(acp.Agent):
                 ),
             ],
         )
+
+    def _thought_level_current_value(self, state: SessionState) -> str:
+        reasoning_config = getattr(state.agent, "reasoning_config", None)
+        if isinstance(reasoning_config, dict):
+            if reasoning_config.get("enabled") is False:
+                return "none"
+            effort = str(reasoning_config.get("effort") or "").strip().lower()
+            if effort in self._THOUGHT_LEVEL_VALUES:
+                return effort
+        return "medium"
+
+    def _session_config_options(self, state: SessionState) -> list[Any]:
+        return [
+            SessionConfigOptionSelect(
+                type="select",
+                id=self._THOUGHT_LEVEL_CONFIG_ID,
+                name="Thought level",
+                category="thought_level",
+                description="Controls the reasoning effort Hermes requests from reasoning-capable models.",
+                current_value=self._thought_level_current_value(state),
+                options=[
+                    SessionConfigSelectOption(
+                        value=value,
+                        name=("Off" if value == "none" else value.capitalize()),
+                    )
+                    for value in self._THOUGHT_LEVEL_VALUES
+                ],
+            )
+        ]
 
     def _edit_approval_policy_for_state(self, state: SessionState) -> tuple[str, str | None]:
         mode = str(getattr(state, "mode", "") or self._MODE_DEFAULT)
@@ -1121,6 +1154,7 @@ class HermesACPAgent(acp.Agent):
             session_id=state.session_id,
             models=self._build_model_state(state),
             modes=self._session_modes(state),
+            config_options=self._session_config_options(state),
             field_meta=self._provenance_meta(
                 state.session_id, getattr(state.agent, "session_id", state.session_id)
             ),
@@ -1168,6 +1202,7 @@ class HermesACPAgent(acp.Agent):
         return LoadSessionResponse(
             models=self._build_model_state(state),
             modes=self._session_modes(state),
+            config_options=self._session_config_options(state),
             field_meta=self._provenance_meta(
                 session_id, getattr(state.agent, "session_id", session_id)
             ),
@@ -1203,6 +1238,7 @@ class HermesACPAgent(acp.Agent):
         return ResumeSessionResponse(
             models=self._build_model_state(state),
             modes=self._session_modes(state),
+            config_options=self._session_config_options(state),
             field_meta=self._provenance_meta(
                 state.session_id, getattr(state.agent, "session_id", state.session_id)
             ),
@@ -2048,6 +2084,11 @@ class HermesACPAgent(acp.Agent):
         if str(config_id) == self._EDIT_APPROVAL_POLICY_CONFIG_ID:
             mode = self._EDIT_APPROVAL_POLICY_TO_MODE.get(str(value), self._MODE_DEFAULT)
             setattr(state, "mode", mode)
+        elif str(config_id) == self._THOUGHT_LEVEL_CONFIG_ID:
+            from hermes_constants import parse_reasoning_effort
+            parsed = parse_reasoning_effort(str(value))
+            if parsed is not None:
+                setattr(state.agent, "reasoning_config", parsed)
         else:
             options = getattr(state, "config_options", None)
             if not isinstance(options, dict):
@@ -2056,4 +2097,4 @@ class HermesACPAgent(acp.Agent):
             setattr(state, "config_options", options)
         self.session_manager.save_session(session_id)
         logger.info("Session %s: config option %s updated", session_id, config_id)
-        return SetSessionConfigOptionResponse(config_options=[])
+        return SetSessionConfigOptionResponse(config_options=self._session_config_options(state))

--- a/tests/acp_adapter/test_acp_commands.py
+++ b/tests/acp_adapter/test_acp_commands.py
@@ -16,6 +16,7 @@ class FakeAgent:
         self.disabled_toolsets = []
         self.tools = []
         self.valid_tool_names = set()
+        self.reasoning_config = None
         self.steers = []
         self.runs = []
 
@@ -65,6 +66,49 @@ def make_agent_and_state():
     conn = CaptureConn()
     acp_agent.on_connect(conn)
     return acp_agent, state, fake, conn
+
+
+@pytest.mark.asyncio
+async def test_acp_new_session_advertises_thought_level_config_option():
+    fake = FakeAgent()
+    manager = SessionManager(agent_factory=lambda **kwargs: fake, db=NoopDb())
+    acp_agent = HermesACPAgent(session_manager=manager)
+
+    response = await acp_agent.new_session(cwd=".")
+
+    thought = next((opt for opt in response.config_options if opt.id == "thought_level"), None)
+    assert thought is not None
+    assert thought.category == "thought_level"
+    assert thought.current_value == "medium"
+    assert [opt.value for opt in thought.options] == ["none", "minimal", "low", "medium", "high", "xhigh"]
+
+
+@pytest.mark.asyncio
+async def test_acp_set_thought_level_updates_agent_reasoning_config():
+    acp_agent, state, fake, _conn = make_agent_and_state()
+
+    response = await acp_agent.set_config_option(
+        session_id=state.session_id,
+        config_id="thought_level",
+        value="high",
+    )
+
+    assert fake.reasoning_config == {"enabled": True, "effort": "high"}
+    thought = next((opt for opt in response.config_options if opt.id == "thought_level"), None)
+    assert thought.current_value == "high"
+
+
+@pytest.mark.asyncio
+async def test_acp_set_thought_level_none_disables_reasoning():
+    acp_agent, state, fake, _conn = make_agent_and_state()
+
+    await acp_agent.set_config_option(
+        session_id=state.session_id,
+        config_id="thought_level",
+        value="none",
+    )
+
+    assert fake.reasoning_config == {"enabled": False}
 
 
 def test_acp_real_agent_gets_session_db_for_recall(monkeypatch):


### PR DESCRIPTION
## Summary
- advertise ACP's standardized `thought_level` session config option from `hermes acp`
- map `session/set_config_option` for `thought_level` into `AIAgent.reasoning_config`
- return updated configOptions so ACP clients can refresh the selected value

## Why
ACP v1 defines `configOptions` with `category: thought_level` for reasoning-level selectors. Hermes already has internal `reasoning_config`, but the ACP adapter did not advertise or apply that surface, so clients could not provide a real reasoning-effort dropdown.

## Related work
- Related to #30290, but not a duplicate: #30290 makes ACP session creation honor existing persisted agent reasoning config. This PR exposes the ACP-standard client-controlled `thought_level` option and maps `session/set_config_option` back into that same internal `reasoning_config`.
- Also related to #25364's reasoning selector request, but this is scoped to the ACP adapter surface rather than Hermes' own `/model` UI.

## Tests
- `python -m pytest tests/acp_adapter/test_acp_commands.py::test_acp_new_session_advertises_thought_level_config_option tests/acp_adapter/test_acp_commands.py::test_acp_set_thought_level_updates_agent_reasoning_config tests/acp_adapter/test_acp_commands.py::test_acp_set_thought_level_none_disables_reasoning -q -o 'addopts='`
- `python -m pytest tests/acp_adapter -q -o 'addopts='`

## Live probe
Ran the ACP adapter from this worktree over stdio and verified `session/new` returns `configOptions[thought_level]` with current `medium`, and `session/set_config_option` to `high` returns the updated current value.
