### PR TITLE
fix: serialize TUI gateway websocket sends

### DIFF
--- a/tests/test_tui_gateway_ws.py
+++ b/tests/test_tui_gateway_ws.py
@@ -1,4 +1,5 @@
 import asyncio
+import concurrent.futures
 import threading
 import time
 
@@ -121,6 +122,43 @@ def test_ws_write_loop_stall_does_not_latch_transport(monkeypatch):
         while len(sent) < 2 and time.time() < deadline:
             time.sleep(0.01)
         assert len(sent) == 2
+        assert transport._closed is False
+    finally:
+        loop.call_soon_threadsafe(loop.stop)
+        thread.join(timeout=2)
+        loop.close()
+
+
+def test_ws_transport_serializes_concurrent_sends():
+    active_sends = 0
+    max_active_sends = 0
+    sent = []
+
+    class FakeWS:
+        async def send_text(self, line):
+            nonlocal active_sends, max_active_sends
+            active_sends += 1
+            max_active_sends = max(max_active_sends, active_sends)
+            try:
+                await asyncio.sleep(0.05)
+                sent.append(line)
+            finally:
+                active_sends -= 1
+
+    loop = asyncio.new_event_loop()
+    thread = threading.Thread(target=loop.run_forever, daemon=True)
+    thread.start()
+    try:
+        transport = ws_mod.WSTransport(FakeWS(), loop, peer="serialize-test")
+        with concurrent.futures.ThreadPoolExecutor(max_workers=2) as pool:
+            futures = [
+                pool.submit(transport.write, {"idx": 1}),
+                pool.submit(transport.write, {"idx": 2}),
+            ]
+            assert [f.result(timeout=2) for f in futures] == [True, True]
+
+        assert len(sent) == 2
+        assert max_active_sends == 1
         assert transport._closed is False
     finally:
         loop.call_soon_threadsafe(loop.stop)

--- a/tui_gateway/ws.py
+++ b/tui_gateway/ws.py
@@ -75,6 +75,11 @@ class WSTransport:
         self._loop = loop
         self._peer = peer
         self._closed = False
+        # Starlette WebSocket sends are not a safe free-for-all: long foreground
+        # tasks can emit frames from several worker paths while the uvicorn loop
+        # is catching up. Serialize writes per socket so reconnect/log spam under
+        # high-output tasks is not amplified by overlapping send_text() calls.
+        self._send_lock = asyncio.Lock()
 
     def write(self, obj: dict) -> bool:
         if self._closed:
@@ -130,7 +135,10 @@ class WSTransport:
 
     async def _safe_send(self, line: str) -> None:
         try:
-            await self._ws.send_text(line)
+            async with self._send_lock:
+                if self._closed:
+                    return
+                await self._ws.send_text(line)
         except Exception as exc:
             self._closed = True
             _log.warning(


### PR DESCRIPTION
## Summary
- serialize per-socket TUI gateway WebSocket sends with an asyncio lock
- keep the existing loop-stall behavior: slow writes do not latch the transport closed
- add regression coverage proving concurrent writer paths cannot overlap `send_text()` on the same socket

Fixes #48445

## Test Plan
- [x] `.venv/Scripts/python.exe -m pytest tests/test_tui_gateway_ws.py -q -o addopts=` — 4 passed
- [x] `.venv/Scripts/python.exe -m pytest tests/test_tui_gateway_server.py tests/test_tui_gateway_ws.py -q -o addopts=` — 281 passed, 1 warning

## Notes
- Full `tests/` on native Windows currently has unrelated baseline failures tracked in #48986. This PR was verified with the affected TUI gateway test slice.
