### PR TITLE
fix(auth): allow user plugins to override inference_base_url for hardcoded providers

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -448,6 +448,29 @@ try:
     from providers import list_providers as _list_providers_for_registry
     for _pp in _list_providers_for_registry():
         if _pp.name in PROVIDER_REGISTRY:
+            # Allow user plugins to override runtime fields for hardcoded
+            # api_key providers — respects "last writer wins" semantics
+            # from providers/__init__.py so user plugins under
+            # $HERMES_HOME/plugins/model-providers/<name>/ can override
+            # the bundled profile's inference_base_url without editing
+            # core code.
+            _existing = PROVIDER_REGISTRY[_pp.name]
+            if _existing.auth_type == "api_key":
+                if _pp.base_url:
+                    _existing.inference_base_url = _pp.base_url
+                _api_vars = tuple(
+                    v for v in _pp.env_vars
+                    if not v.endswith("_BASE_URL") and not v.endswith("_URL")
+                )
+                _url_var = next(
+                    (v for v in _pp.env_vars
+                     if v.endswith("_BASE_URL") or v.endswith("_URL")),
+                    None,
+                )
+                if _api_vars:
+                    _existing.api_key_env_vars = _api_vars
+                if _url_var:
+                    _existing.base_url_env_var = _url_var
             continue
         if _pp.auth_type != "api_key" or not _pp.env_vars:
             continue

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -198,6 +198,7 @@ AUTHOR_MAP = {
     "liuhao1024@users.noreply.github.com": "liuhao1024",
     "annguyenNous@users.noreply.github.com": "annguyenNous",
     "285874597+annguyenNous@users.noreply.github.com": "annguyenNous",
+    "xiaoxinova@users.noreply.github.com": "xiaoxinova",
     "kylekahraman@users.noreply.github.com": "kylekahraman",
     "130975919+kylekahraman@users.noreply.github.com": "kylekahraman",
     "seppe@fushia.be": "seppegadeyne",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -393,6 +393,56 @@ def _hermetic_environment(tmp_path, monkeypatch):
     monkeypatch.delenv("GMI_BASE_URL", raising=False)
 
 
+    # 6. Reset provider registry and clear sys.modules so bundled plugins
+    #    are re-imported fresh with the clean HERMES_HOME.
+    try:
+        import providers as _providers_mod
+        _providers_mod._discovered = False
+        _providers_mod._REGISTRY.clear()
+        _providers_mod._ALIASES.clear()
+        # Also evict cached plugin modules from sys.modules so the
+        # next discovery re-imports them (and calls register_provider
+        # again) instead of being no-ops.
+        for _key in list(sys.modules):
+            if _key.startswith("plugins.model_providers."):
+                del sys.modules[_key]
+    except Exception:
+        pass
+
+    # 7. Re-sync PROVIDER_REGISTRY from the now-clean providers module.
+    try:
+        from hermes_cli.auth import PROVIDER_REGISTRY, ProviderConfig
+        from providers import list_providers as _list_providers_for_registry
+        for _pp in _list_providers_for_registry():
+            if _pp.name in PROVIDER_REGISTRY:
+                _existing = PROVIDER_REGISTRY[_pp.name]
+                if _existing.auth_type == "api_key":
+                    if _pp.base_url:
+                        _existing.inference_base_url = _pp.base_url
+                    _api_vars = tuple(v for v in _pp.env_vars if not v.endswith("_BASE_URL") and not v.endswith("_URL"))
+                    _url_var = next((v for v in _pp.env_vars if v.endswith("_BASE_URL") or v.endswith("_URL")), None)
+                    if _api_vars:
+                        _existing.api_key_env_vars = _api_vars
+                    if _url_var:
+                        _existing.base_url_env_var = _url_var
+                continue
+            if _pp.auth_type != "api_key" or not _pp.env_vars:
+                continue
+            _api_key_vars = tuple(v for v in _pp.env_vars if not v.endswith("_BASE_URL") and not v.endswith("_URL"))
+            _base_url_var = next((v for v in _pp.env_vars if v.endswith("_BASE_URL") or v.endswith("_URL")), None)
+            PROVIDER_REGISTRY[_pp.name] = ProviderConfig(
+                id=_pp.name,
+                name=_pp.display_name or _pp.name,
+                auth_type="api_key",
+                inference_base_url=_pp.base_url,
+                api_key_env_vars=_api_key_vars or _pp.env_vars,
+                base_url_env_var=_base_url_var or "",
+            )
+    except Exception:
+        pass
+
+
+
 # Backward-compat alias — old tests reference this fixture name. Keep it
 # as a no-op wrapper so imports don't break.
 @pytest.fixture(autouse=True)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -426,6 +426,13 @@ def _hermetic_environment(tmp_path, monkeypatch):
                     if _url_var:
                         _existing.base_url_env_var = _url_var
                 continue
+            # Skip providers that need custom token resolution or are special-cased
+            # in resolve_provider() (copilot/kimi/zai have bespoke token refresh;
+            # openrouter/custom are aggregator/user-supplied and handled outside
+            # the registry — adding them here breaks runtime_provider resolution
+            # that relies on `openrouter not in PROVIDER_REGISTRY`).
+            if _pp.name in {"copilot", "kimi-coding", "kimi-coding-cn", "zai", "openrouter", "custom"}:
+                continue
             if _pp.auth_type != "api_key" or not _pp.env_vars:
                 continue
             _api_key_vars = tuple(v for v in _pp.env_vars if not v.endswith("_BASE_URL") and not v.endswith("_URL"))


### PR DESCRIPTION
## What does this PR do?

User plugins registered via `$HERMES_HOME/plugins/model-providers/<name>/` can override a bundled provider's `base_url` in `providers._REGISTRY` via `register_provider()` (last writer wins — the last call sets the value), but when the provider is hardcoded in `PROVIDER_REGISTRY` (`hermes_cli/auth.py`), the override is silently ignored — the auto-extend loop skips the entry with `continue` before checking the user plugin's fields.

This means user plugins cannot change the runtime `inference_base_url` for any hardcoded api-key provider (stepfun, arcee, gmi, minimax, etc.), making region-specific endpoints (e.g. stepfun's `.com` for China vs `.ai` for international) impossible to configure without editing core source.

This patch updates the auto-extend loop to propagate user plugin fields (`base_url`, `api_key_env_vars`, `base_url_env_var`) to existing `PROVIDER_REGISTRY` entries when the hardcoded entry uses `auth_type="api_key"`.

## Related Issue

Fixes #48450

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/auth.py` (+23/-0) — propagate user plugin `base_url`, `api_key_env_vars`, `base_url_env_var` to hardcoded `PROVIDER_REGISTRY` entries for api-key providers
- `tests/conftest.py` (+57/-0) — reset providers registry + clear `sys.modules` in `_hermetic_environment` to ensure clean test isolation for bundled defaults
- `scripts/release.py` (+1/-0) — map xiaoxinova to AUTHOR_MAP for contributor attribution

## Additional Changes (Test Infrastructure)

`tests/conftest.py` — The `_hermetic_environment` fixture now:

1. **Clears `plugins.model_providers.*` from `sys.modules`** after resetting `providers._discovered/_REGISTRY/_ALIASES`, preventing cached plugin modules from skipping re-discovery when `HERMES_HOME` is redirected to a temp directory.

2. **Re-syncs `PROVIDER_REGISTRY`** via the same in-place update logic used in `auth.py`, ensuring hardcoded api-key providers pick up bundled defaults rather than stale user-plugin overrides.

3. **Skips `openrouter`/`custom`** (and other aggregator providers) during re-sync, preserving the invariant that these providers are resolved via dedicated credential-pool/env-var paths, not via `PROVIDER_REGISTRY`. Without this guard, `resolve_provider()` assumptions break and `test_runtime_provider_resolution.py` fails.

Without these changes, `providers.list_providers()` would return 0 results after a reset (because `_discover_providers()` sees cached modules and returns early), causing `test_base_urls` to fail on clean CI environments.

`scripts/release.py` — Added `"xiaoxinova@users.noreply.github.com": "xiaoxinova"` to `AUTHOR_MAP` so the `check-attribution` workflow recognizes this contributor and passes.

## How to Test

1. Place a user plugin at `$HERMES_HOME/plugins/model-providers/stepfun/__init__.py` with `base_url="https://api.stepfun.com/step_plan/v1"`
2. Start a session with `model.provider: stepfun`
3. Observe agent.log — base_url should be `.com`, not `.ai`
4. Verify programmatically:
   ```python
   from providers import get_provider_profile
   from hermes_cli.auth import PROVIDER_REGISTRY
   assert get_provider_profile("stepfun").base_url == PROVIDER_REGISTRY["stepfun"].inference_base_url
   ```

## Verification

*(Clean HERMES_HOME, no user plugins)*

| Test file | Result |
|-----------|--------|
| `tests/hermes_cli/test_api_key_providers.py` | 165/165 passed |
| `tests/hermes_cli/test_runtime_provider_resolution.py` | 127/127 passed |
| `tests/providers/test_provider_profiles.py` | 95/95 passed |
| **Total** | **387/387 passed** |

Manual verification confirms `PROVIDER_REGISTRY["stepfun"].inference_base_url` is updated from the user plugin's `base_url`, and `runtime_provider.resolve_runtime_provider()` returns the correct URL end-to-end.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix (no unrelated commits)
- [x] I've run targeted tests and they all pass
- [x] I've tested on my platform: Docker/Linux (x86_64)