### PR TITLE
fix: guard malformed process notifications

### DIFF
--- a/tests/tools/test_notify_on_complete.py
+++ b/tests/tools/test_notify_on_complete.py
@@ -91,8 +91,10 @@ class TestCompletionQueue:
         s.exited = True
         s.exit_code = 0
         registry._running[s.id] = s
+        before = time.time()
         with patch.object(registry, "_write_checkpoint"):
             registry._move_to_finished(s)
+        after = time.time()
 
         assert not registry.completion_queue.empty()
         completion = registry.completion_queue.get_nowait()
@@ -101,6 +103,7 @@ class TestCompletionQueue:
         assert completion["exit_code"] == 0
         assert completion["completion_reason"] == "exited"
         assert completion["termination_source"] == ""
+        assert before <= completion["completed_at"] <= after
         assert "build succeeded" in completion["output"]
 
     def test_move_to_finished_nonzero_exit(self, registry):

--- a/tests/tools/test_process_registry.py
+++ b/tests/tools/test_process_registry.py
@@ -1086,8 +1086,38 @@ def test_format_watch_disabled_event():
 def test_format_returns_none_for_empty_event():
     evt = {}
     result = format_process_notification(evt)
-    assert result is not None
-    assert "unknown" in result
+    assert result is None
+
+
+def test_format_returns_none_for_unknown_event_type():
+    evt = {"type": "unknown_event", "message": "do not inject me"}
+    result = format_process_notification(evt)
+    assert result is None
+
+
+def test_format_watch_overflow_tripped_event():
+    evt = {
+        "type": "watch_overflow_tripped",
+        "session_id": "",
+        "session_key": "",
+        "command": "",
+        "message": "Watch-pattern overflow: suppressing further watch_match events.",
+    }
+    result = format_process_notification(evt)
+    assert result == "[IMPORTANT: Watch-pattern overflow: suppressing further watch_match events.]"
+
+
+def test_format_watch_overflow_released_event():
+    evt = {
+        "type": "watch_overflow_released",
+        "session_id": "",
+        "session_key": "",
+        "command": "",
+        "suppressed": 3,
+        "message": "Watch-pattern notifications resumed. 3 match event(s) were suppressed.",
+    }
+    result = format_process_notification(evt)
+    assert result == "[IMPORTANT: Watch-pattern notifications resumed. 3 match event(s) were suppressed.]"
 
 
 def test_drain_notifications_returns_pending_events():

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -902,6 +902,7 @@ class ProcessRegistry:
                 "exit_code": session.exit_code,
                 "completion_reason": session.completion_reason,
                 "termination_source": session.termination_source,
+                "completed_at": time.time(),
                 "output": output_tail,
             })
 
@@ -1622,12 +1623,20 @@ def format_process_notification(evt: dict) -> "str | None":
     Handles completion events (notify_on_complete), watch pattern matches,
     and watch disabled events from the unified completion_queue.
     """
+    if not isinstance(evt, dict) or not evt:
+        return None
+
     evt_type = evt.get("type", "completion")
-    _sid = evt.get("session_id", "unknown")
-    _cmd = evt.get("command", "unknown")
+    _sid = str(evt.get("session_id") or "").strip()
+    _cmd = str(evt.get("command") or "").strip()
+
+    if evt_type in {"watch_overflow_tripped", "watch_overflow_released"}:
+        msg = str(evt.get("message") or "").strip()
+        return f"[IMPORTANT: {msg}]" if msg else None
 
     if evt_type == "watch_disabled":
-        return f"[IMPORTANT: {evt.get('message', '')}]"
+        msg = str(evt.get("message") or "").strip()
+        return f"[IMPORTANT: {msg}]" if msg else None
 
     if evt_type == "watch_match":
         _pat = evt.get("pattern", "?")
@@ -1646,6 +1655,12 @@ def format_process_notification(evt: dict) -> "str | None":
 
     if evt_type == "async_delegation":
         return _format_async_delegation(evt)
+
+    if evt_type != "completion":
+        return None
+
+    if not (_sid or _cmd or "exit_code" in evt or evt.get("output")):
+        return None
 
     _exit = evt.get("exit_code", "?")
     _out = evt.get("output", "")


### PR DESCRIPTION
## Summary
- stamp `completed_at` on notify-on-complete process completion events
- ignore empty/malformed/unknown process notification events instead of formatting them as `unknown` completions
- render watch-pattern overflow/release summaries as explicit `[IMPORTANT: ...]` watch notices

## Root cause
`format_process_notification({})` fell through to the completion formatter and produced a synthetic `Background process unknown ...` prompt. The same fallback also mishandled global watch-overflow summary events (`watch_overflow_tripped` / `watch_overflow_released`) because those events intentionally do not have a process id or command.

Separately, WebUI issue nesquena/hermes-webui#4029 needs agent-side completion events to carry a `completed_at` timestamp so WebUI's stale-completion age gate can distinguish fresh completions from old queue residue.

## Related reconnaissance
- Searched existing `NousResearch/hermes-agent` issues/PRs for `Background process unknown`, `unknown completed`, `watch_overflow`, and `watch_overflow_tripped`; no duplicate found.
- Related WebUI tracker: nesquena/hermes-webui#4029 (agent-side `completed_at` stamp still required).

## Test plan
- `python3 -m py_compile tools/process_registry.py`
- `PYTHONPATH=. python3 -m pytest tests/tools/test_notify_on_complete.py tests/tools/test_process_registry.py tests/tools/test_watch_patterns.py -q -o addopts=`
- Static added-line scan: 0 findings
