### PR TITLE
fix(gateway): avoid self-restart deadlock

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -3096,6 +3096,16 @@ def systemd_restart(system: bool = False):
         svc = get_service_name()
         drain_timeout = _get_restart_drain_timeout()
 
+        # When `hermes gateway restart` is invoked from a gateway-handled
+        # terminal tool call, the service PID is an ancestor of this CLI
+        # process. Waiting synchronously for that ancestor to exit deadlocks:
+        # the gateway is draining this very agent while this command is
+        # waiting for the gateway to finish draining. Hand the restart request
+        # to the gateway and return so the active agent can finish normally.
+        if _request_gateway_self_restart(pid):
+            print("✓ Service restart requested")
+            return
+
         print(f"⏳ {scope_label} service restarting gracefully (PID {pid})...")
         if _graceful_restart_via_sigusr1(pid, drain_timeout + 5):
             # The gateway exits with code 75 for a planned service restart.

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -118,6 +118,35 @@ class TestSystemdServiceRefresh:
             ("wait", False, None),
         ]
 
+    def test_systemd_restart_from_gateway_child_requests_async_self_restart(
+        self, monkeypatch, capsys
+    ):
+        calls = []
+
+        monkeypatch.setattr(gateway_cli, "_select_systemd_scope", lambda system=False: False)
+        monkeypatch.setattr(gateway_cli, "_require_service_installed", lambda action, system=False: None)
+        monkeypatch.setattr(gateway_cli, "_preflight_user_systemd", lambda: None)
+        monkeypatch.setattr(gateway_cli, "refresh_systemd_unit_if_needed", lambda system=False: None)
+        monkeypatch.setattr(gateway_cli, "_sync_hermes_home_from_systemd_unit", lambda system=False: None)
+        monkeypatch.setattr(gateway_cli, "_get_restart_drain_timeout", lambda: 180.0)
+        monkeypatch.setattr(status, "get_running_pid", lambda cleanup_stale=True: 4321)
+        monkeypatch.setattr(gateway_cli, "_request_gateway_self_restart", lambda pid: calls.append(("self", pid)) or True)
+        monkeypatch.setattr(
+            gateway_cli,
+            "_graceful_restart_via_sigusr1",
+            lambda pid, drain_timeout: calls.append(("wait", pid, drain_timeout)) or True,
+        )
+        monkeypatch.setattr(
+            gateway_cli,
+            "_run_systemctl",
+            lambda args, **kwargs: calls.append(("systemctl", args)),
+        )
+
+        gateway_cli.systemd_restart()
+
+        assert calls == [("self", 4321)]
+        assert "Service restart requested" in capsys.readouterr().out
+
     def test_systemd_stop_marks_running_gateway_as_planned_stop(self, monkeypatch):
         calls = []
         markers = []


### PR DESCRIPTION
## What does this PR do?

Fixes a gateway restart deadlock when `hermes gateway restart` is invoked from a terminal tool call that is itself being handled by the running gateway process.

Before this change, the CLI could wait synchronously for the gateway service PID to drain while the gateway was waiting for the active agent/tool call to finish, creating a self-restart deadlock. This change detects the existing gateway self-restart path and returns after requesting the async restart so the active gateway-handled request can finish normally.

## Why this is still needed after the latest upstream fixes

Current `origin/main` already contains related mitigations, including:

- `245b95b09 fix(terminal): block gateway lifecycle commands from inside the gateway process`
- `75ed07ace fix(gateway): break the restart loop at the source on session resume`

Those changes reduce re-entry/replay risk, but they do not add the async self-restart handoff inside `systemd_restart()` itself. The systemd path can still deadlock if it reaches the synchronous graceful-restart wait while running as a gateway-handled child process.

A live Feishu + systemd gateway reproduced this exact path on current upstream during update verification:

```text
COMMAND=/home/ubuntu/.local/bin/hermes gateway restart --system
Gateway drain timed out after 60.0s with 1 active agent(s); interrupting remaining work
systemd: Scheduled restart job
systemd: Started hermes-gateway.service
```

Deadlock chain:

1. Gateway is running as a systemd service.
2. A gateway platform message, e.g. Feishu, triggers an agent turn.
3. The agent invokes a terminal tool with `hermes gateway restart --system`.
4. `systemd_restart()` begins a synchronous graceful restart and waits for the service PID to drain.
5. The gateway is waiting for the active agent/tool call to finish before draining.
6. The tool call is waiting for the gateway restart to finish.
7. The drain eventually times out; resume/replay paths can make this look like a repeated restart loop.

This PR keeps the systemd path aligned with the existing self-restart mechanism: if the CLI is running under the gateway process tree, request the gateway-managed async restart and return immediately instead of waiting synchronously on its own ancestor.

## Related Issue

N/A — found while operating a live gateway from a gateway chat. Related to the broader class of gateway restart/replay loop reports, but this PR intentionally fixes only the `systemd_restart()` self-deadlock path.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Updated `hermes_cli/gateway.py` so `systemd_restart()` uses `_request_gateway_self_restart(pid)` before entering the synchronous graceful-restart wait path.
- Added regression coverage in `tests/hermes_cli/test_gateway_service.py` for the gateway-child restart path.
- Verified the new path requests async self-restart and does not call the blocking graceful restart/systemctl path.

## How to Test

Run the targeted gateway service tests:

```bash
HERMES_HOME=$(mktemp -d) PYTHONPATH=$PWD /home/ubuntu/.hermes/hermes-agent/venv/bin/python   -m pytest tests/hermes_cli/test_gateway_service.py -q -o 'addopts='
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu/Linux

### Documentation and Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Rebased on current `origin/main` and validated the full gateway service test file:

```text
$ HERMES_HOME=$(mktemp -d) PYTHONPATH=$PWD /home/ubuntu/.hermes/hermes-agent/venv/bin/python -m pytest tests/hermes_cli/test_gateway_service.py -q -o 'addopts='
........................................................................ [ 43%]
........................................................................ [ 87%]
....................                                                     [100%]
164 passed in 3.86s
```
