### PR TITLE
feat: inject user context into sub-agent system prompts

### DIFF
--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -142,6 +142,53 @@ class TestChildSystemPrompt(unittest.TestCase):
         prompt = _build_child_system_prompt("Do something", "  ")
         self.assertNotIn("CONTEXT", prompt)
 
+    def test_memory_store_injects_user_context(self):
+        """When memory_store is provided, USER CONTEXT block appears."""
+        class MockStore:
+            def format_for_system_prompt(self, target):
+                return "Test user profile" if target == "user" else None
+        prompt = _build_child_system_prompt("Task", memory_store=MockStore())
+        self.assertIn("USER CONTEXT", prompt)
+        self.assertIn("Test user profile", prompt)
+
+    def test_no_memory_store_omits_user_context(self):
+        """Without memory_store, no USER CONTEXT block appears."""
+        prompt = _build_child_system_prompt("Task")
+        self.assertNotIn("USER CONTEXT", prompt)
+
+    def test_memory_store_none_user_block_skipped(self):
+        """If memory_store returns None for 'user', no USER CONTEXT block."""
+        class EmptyStore:
+            def format_for_system_prompt(self, target):
+                return None
+        prompt = _build_child_system_prompt("Task", memory_store=EmptyStore())
+        self.assertNotIn("USER CONTEXT", prompt)
+
+    def test_subagent_context_md_injected_when_present(self):
+        """SUBAGENT_CONTEXT.md content appears as WORK STANDARDS when file exists."""
+        import tempfile, os
+        from unittest.mock import patch as mp
+        class MockStore:
+            def format_for_system_prompt(self, target):
+                return "User info" if target == "user" else None
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.md', delete=False, dir='/tmp') as f:
+            f.write("# Sub-Agent Context\nTest standards content.")
+            tmp_path = f.name
+        try:
+            from pathlib import Path
+            mock_mem_dir = Path(os.path.dirname(tmp_path))
+            with mp('tools.memory_tool.get_memory_dir', return_value=mock_mem_dir):
+                # Rename to SUBAGENT_CONTEXT.md in the temp dir
+                target = mock_mem_dir / "SUBAGENT_CONTEXT.md"
+                os.rename(tmp_path, str(target))
+                prompt = _build_child_system_prompt("Task", memory_store=MockStore())
+                self.assertIn("WORK STANDARDS", prompt)
+                self.assertIn("Test standards content", prompt)
+                os.unlink(str(target))
+        except Exception:
+            if os.path.exists(tmp_path):
+                os.unlink(tmp_path)
+
 
 class TestStripBlockedTools(unittest.TestCase):
     def test_removes_blocked_toolsets(self):

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -661,6 +661,7 @@ def _build_child_system_prompt(
     role: str = "leaf",
     max_spawn_depth: int = 2,
     child_depth: int = 1,
+    memory_store=None,
 ) -> str:
     """Build a focused system prompt for a child agent.
 
@@ -669,12 +670,34 @@ def _build_child_system_prompt(
     inspiration/openclaw/src/agents/subagent-system-prompt.ts:63-95).
     The depth note is literal truth (grounded in the passed config) so
     the LLM doesn't confabulate nesting capabilities that don't exist.
+
+    When *memory_store* is provided, injects the parent's user profile
+    and the SUBAGENT_CONTEXT.md file (if present) so child agents
+    operate with the user's quality standards and preferences rather
+    than producing generic output.
     """
     parts = [
         "You are a focused subagent working on a specific delegated task.",
         "",
         f"YOUR TASK:\n{goal}",
     ]
+
+    # ── Tier 1: User context injection ──────────────────────────────
+    if memory_store is not None:
+        user_block = memory_store.format_for_system_prompt("user")
+        if user_block:
+            parts.append(f"\nUSER CONTEXT:\n{user_block}")
+        # Load SUBAGENT_CONTEXT.md from the memories directory if it exists.
+        try:
+            from tools.memory_tool import get_memory_dir
+            subagent_ctx_path = get_memory_dir() / "SUBAGENT_CONTEXT.md"
+            if subagent_ctx_path.is_file():
+                subagent_content = subagent_ctx_path.read_text(encoding="utf-8").strip()
+                if subagent_content:
+                    parts.append(f"\nWORK STANDARDS:\n{subagent_content}")
+        except Exception:
+            pass  # Non-critical — proceed without subagent context
+
     if context and context.strip():
         parts.append(f"\nCONTEXT:\n{context}")
     if workspace_path and str(workspace_path).strip():
@@ -1077,6 +1100,7 @@ def _build_child_agent(
         role=effective_role,
         max_spawn_depth=max_spawn,
         child_depth=child_depth,
+        memory_store=getattr(parent_agent, "_memory_store", None),
     )
     # Extract parent's API key so subagents inherit auth (e.g. Nous Portal).
     parent_api_key = getattr(parent_agent, "api_key", None)


### PR DESCRIPTION
## Problem

Sub-agents receive a bare-bones system prompt with no knowledge of the user, their preferences, or quality standards. This causes delegated work to produce generic output that requires rework — the exact problem described in [0xJeff's post](https://x.com/0xJeff/status/2067482228574322693) about sub-agents lacking context.

Current sub-agent system prompt:
```
"You are a focused subagent working on a specific delegated task."
YOUR TASK: {goal}
CONTEXT: {context}
```

No user profile, no quality standards, no domain conventions.

## Solution

A 3-tier sub-agent context injection system:

| Tier | Content | Mechanism |
|------|---------|-----------|
| **1 (this PR)** | USER.md + SUBAGENT_CONTEXT.md | Automatic via `memory_store` parameter |
| **2** | Curated SUBAGENT_CONTEXT.md | User-maintained file in memories dir |
| **3** | Task-specific context | Existing `context` field in `delegate_task` |

### Changes

**`tools/delegate_tool.py`:**
- `_build_child_system_prompt()` accepts optional `memory_store` parameter
- When provided, injects USER.md as `USER CONTEXT` block
- Reads `SUBAGENT_CONTEXT.md` from memories directory as `WORK STANDARDS` block
- Both blocks are gracefully optional (no error if absent)
- Call site passes `parent_agent._memory_store` to the function

**`tests/tools/test_delegate.py`:**
- 4 new tests covering: injection with store, no store, empty store, SUBAGENT_CONTEXT.md file

### Design Decisions

**Why not inject MEMORY.md?** MEMORY.md contains session-specific infrastructure details (cron job IDs, OAuth tokens, IP addresses, service ports) that are noise for task-focused sub-agents. It wastes ~2K chars of context on irrelevant details.

**Why a separate SUBAGENT_CONTEXT.md?** The user profile (USER.md) answers "who am I working for?" SUBAGENT_CONTEXT.md answers "what does good work look like?" These are different questions with different content. A curated file gives users control over what standards sub-agents follow without bloating every delegation.

**Why read SUBAGENT_CONTEXT.md from disk instead of memory_store?** The memory store only tracks MEMORY.md and USER.md. Adding SUBAGENT_CONTEXT.md as a third memory target would require changes to the memory tool's config, file management, and UI. Reading from disk is simpler, zero-config, and the file is small (~2KB).

**Why `memory_store=None` default?** Backward compatibility. Cron jobs, tests, and other callers that don't pass memory_store get the existing behavior (no context injection).

### Before/After

**Before (sub-agent system prompt):**
```
You are a focused subagent working on a specific delegated task.
YOUR TASK: Research competitor pricing
CONTEXT: Focus on enterprise SaaS tier
```

**After (sub-agent system prompt):**
```
You are a focused subagent working on a specific delegated task.
YOUR TASK: Research competitor pricing

USER CONTEXT:
══════════════════════════════════════════════
USER PROFILE (who the user is)
══════════════════════════════════════════════
Visual design: FORMAL (medical/clinical). White BG, dark text, navy accents...
Plain-English, explicit task outcomes...

WORK STANDARDS:
# Sub-Agent Context
## Code Quality Standards
- Include tests with code changes. TDD preferred...
## Research Standards
- Cite sources with URLs. Unsourced claims are worthless...

CONTEXT: Focus on enterprise SaaS tier
```

### Testing

```
pytest tests/tools/test_delegate.py::TestChildSystemPrompt -v
# 7 passed (4 new + 3 existing)
```

Live verification: delegated a diagnostic task to a sub-agent and confirmed both USER CONTEXT and WORK STANDARDS sections appeared in the sub-agent's system prompt.

### Token Cost

~3-4K extra chars per delegation (USER.md ~1.4K + SUBAGENT_CONTEXT.md ~2K). Acceptable for the quality improvement — generic output that needs rework is far more expensive than 4K tokens of context.

## Related

- [0xJeff's post on sub-agent context](https://x.com/0xJeff/status/2067482228574322693) — identifies the exact problem this PR solves
- [Hermes Analyst 10x Better](https://x.com/0xJeff/status/2066883577141428563) — related article on nested orchestration improvements