### PR TITLE
fix(nix): refresh npmDepsHash after the Electron 40.10.2 pin (#47792)

### DIFF
--- a/nix/lib.nix
+++ b/nix/lib.nix
@@ -21,7 +21,7 @@ let
 
   # Single npm deps fetch from the workspace root lockfile.
   # All workspace packages share this derivation.
-  npmDepsHash = "sha256-m9cjbjzi4SaFCjODfdrawS5e+1ag+MpRn528/upSNqo=";
+  npmDepsHash = "sha256-kbjJksq7limRIYqP3DwI+GNgCXkG96tXcsQqmuEedxo=";
 
   npmDeps = pkgs.fetchNpmDeps {
     inherit src;


### PR DESCRIPTION
## Summary

Every Nix build of the npm workspaces currently fails with:

```
ERROR: npmDepsHash is out of date
The package-lock.json in src is not the same as the in /nix/store/...-npm-deps.
```

**Root cause:** PR #47792 ("pin Electron below the broken native extract-zip install") pinned Electron to an exact `40.10.2` and regenerated the root `package-lock.json` — dropping `@electron/get@5` + `@electron-internal/extract-zip`, restoring `@electron/get@2` + `extract-zip@2` + `yauzl`. That PR touched `apps/desktop/package.json`, `package.json`, `package-lock.json`, and a test, but **not `nix/lib.nix`**. The single shared `npmDepsHash` still described the old `40.10.3` lockfile, so `npmConfigHook`'s consistency check fails on `hermes-tui`, `hermes-web`, and `hermes-desktop`.

This is reproducible on current `main` (HEAD at branch point), not just stale checkouts.

## Fix

Regenerate the one shared hash in `nix/lib.nix`:

```diff
-  npmDepsHash = "sha256-m9cjbjzi4SaFCjODfdrawS5e+1ag+MpRn528/upSNqo=";
+  npmDepsHash = "sha256-kbjJksq7limRIYqP3DwI+GNgCXkG96tXcsQqmuEedxo=";
```

Computed via `fetchNpmDeps` (authoritative — `prefetch-npm-deps` can disagree, per the notes in `lib.nix`).

## Test plan

```
nix build .#tui.npmDeps   # builds clean (FOD hash matches)
nix build .#tui           # Validating consistency -> Installing dependencies
                          # -> Finished npmConfigHook   (no "out of date" error)
```

## Follow-up (not in this PR)

The `nix-lockfile-fix` automation should have caught this. See open PR #41004 ("Update nix-lockfile-fix.yml to stage nix/lib.nix") — the auto-refresh workflow apparently doesn't stage `nix/lib.nix`, which is exactly why a lockfile-changing PR (#47792) could land without the hash following it. Worth landing that to prevent recurrence.