### PR TITLE
fix(teams): correctness fixes for chunking, retries, threading, images

### DIFF
--- a/plugins/platforms/teams/adapter.py
+++ b/plugins/platforms/teams/adapter.py
@@ -27,6 +27,7 @@ import html
 import json
 import logging
 import os
+from collections import OrderedDict
 from typing import Any, Dict, Optional
 from urllib.parse import quote
 
@@ -95,7 +96,6 @@ from gateway.platforms.base import (
     MessageEvent,
     MessageType,
     SendResult,
-    cache_image_from_url,
     cache_media_bytes,
 )
 
@@ -470,6 +470,51 @@ _ALLOWED_TEAMS_SERVICE_HOSTS = frozenset({
 import re as _re_teams
 _TEAMS_CONV_ID_RE = _re_teams.compile(r"^[A-Za-z0-9:@\-_.]+$")
 
+# HTTP statuses worth retrying on an outbound send: rate-limit + server-side
+# transients. Everything else (4xx client errors, malformed cards, permission
+# denials) is permanent and must NOT set SendResult.retryable, otherwise
+# base._send_with_retry retries the identical payload and skips its plain-text
+# fallback.
+_TEAMS_RETRYABLE_HTTP_STATUSES = frozenset({429, 500, 502, 503, 504})
+
+
+def _is_transient_send_error(exc: BaseException) -> bool:
+    """Classify an outbound send failure as transient (retryable) vs permanent.
+
+    Retryable: HTTP 429 / 5xx, request timeouts, and connection/transport
+    failures. Permanent (returns False so base falls back to plain text):
+    HTTP 4xx other than 429, malformed/oversized payloads, permission denials,
+    and local errors such as ``ValueError`` / ``OSError``.
+
+    The Teams SDK's outbound HTTP layer is ``httpx`` and calls
+    ``raise_for_status()``, so HTTP failures arrive as ``httpx.HTTPStatusError``
+    carrying ``response.status_code``. ``httpx`` is imported lazily here to keep
+    it off the module import path (see the lazy-import note near the top).
+    """
+    if isinstance(exc, asyncio.TimeoutError):
+        return True
+    # httpx.HTTPStatusError carries the response; classify by status code.
+    status = getattr(getattr(exc, "response", None), "status_code", None)
+    if isinstance(status, int):
+        return status in _TEAMS_RETRYABLE_HTTP_STATUSES
+    try:
+        import httpx
+
+        if isinstance(exc, (httpx.TimeoutException, httpx.TransportError)):
+            return True
+    except Exception:
+        pass
+    # Fallback heuristics for transport errors that carry no status / when httpx
+    # is unavailable.
+    text = str(exc).lower()
+    if "timeout" in text or "timed out" in text:
+        return True
+    if "connection" in text and ("reset" in text or "refused" in text or "aborted" in text):
+        return True
+    if "broken pipe" in text or "remote disconnected" in text:
+        return True
+    return False
+
 
 def _validate_teams_service_url(raw: str) -> Optional[str]:
     """Return a normalized service URL or ``None`` if it is not allowed.
@@ -687,6 +732,12 @@ def check_teams_requirements() -> bool:
     return ensure_and_bind("platform.teams", _import, globals(), prompt=False)
 
 
+# Max number of conversation references kept for proactive sends. Mirrors the
+# dedup cache cap; evicted LRU-first. References are in-memory only (rebuilt as
+# conversations send inbound messages), so eviction only affects idle chats.
+_CONV_REF_CACHE_SIZE = 1000
+
+
 class TeamsAdapter(BasePlatformAdapter):
     """Microsoft Teams adapter using the microsoft-teams-apps SDK."""
 
@@ -701,12 +752,26 @@ class TeamsAdapter(BasePlatformAdapter):
         self._port = _coerce_port(
             extra.get("port") or os.getenv("TEAMS_PORT", str(_DEFAULT_PORT))
         )
+        # Bot Framework service host for proactive sends (App.send/App.reply).
+        # Regional/government tenants (GCC/GCC-High) need a non-global host;
+        # validate against the allowlist so a tampered value can't redirect a
+        # freshly minted bearer token. None => SDK default (global host).
+        self._service_url = _validate_teams_service_url(
+            os.getenv("TEAMS_SERVICE_URL", "").strip()
+            or extra.get("service_url", "")
+        )
         self._app: Optional["App"] = None
         self._runner: Optional["web.AppRunner"] = None
         self._dedup = MessageDeduplicator(max_size=1000)
         # Maps chat_id → ConversationReference captured from incoming messages.
         # Used to send cards with the correct conversation type (personal/group/channel).
-        self._conv_refs: Dict[str, Any] = {}
+        # Bounded with LRU eviction (same cap as the dedup cache) so a long-lived
+        # bot in many conversations does not accumulate references without bound.
+        self._conv_refs: "OrderedDict[str, Any]" = OrderedDict()
+        # Maps chat_id → {"name": str, "type": str} observed on inbound messages.
+        # Teams has no on-demand conversation lookup, so get_chat_info() replays
+        # the type/name we saw on the activity rather than guessing.
+        self._chat_meta: Dict[str, Dict[str, str]] = {}
 
     async def connect(self) -> bool:
         # Lazy-install the Teams SDK on demand (parity with Slack/Discord/etc.),
@@ -741,13 +806,19 @@ class TeamsAdapter(BasePlatformAdapter):
             aiohttp_app = web.Application()
             aiohttp_app.router.add_get("/health", lambda _: web.Response(text="ok"))
 
-            self._app = App(
+            app_kwargs: Dict[str, Any] = dict(
                 client_id=self._client_id,
                 client_secret=self._client_secret,
                 tenant_id=self._tenant_id,
                 http_server_adapter=_AiohttpBridgeAdapter(aiohttp_app),
                 client=ClientOptions(headers={"User-Agent": "Hermes"}),
             )
+            # Only override the SDK default when an allowlisted host was
+            # supplied, so proactive sends reach the tenant's regional/
+            # government Bot Framework endpoint instead of the global host.
+            if self._service_url:
+                app_kwargs["service_url"] = self._service_url
+            self._app = App(**app_kwargs)
 
             # Register message handler before initialize()
             @self._app.on_message
@@ -796,13 +867,21 @@ class TeamsAdapter(BasePlatformAdapter):
         self._mark_disconnected()
         logger.info("[teams] Disconnected")
 
-    async def _fetch_attachment_bytes(self, url: str, timeout: float = 30.0) -> bytes:
+    async def _fetch_attachment_bytes(
+        self,
+        url: str,
+        timeout: float = 30.0,
+        headers: Optional[Dict[str, str]] = None,
+    ) -> bytes:
         """Download attachment bytes with SSRF protection.
 
-        Teams file attachments carry pre-authenticated SharePoint download
-        URLs (no extra auth header needed). Validates the URL against the
-        SSRF guard and follows redirects through the shared redirect guard,
-        matching the cache_*_from_url helpers in gateway.platforms.base.
+        Teams ``file.download.info`` attachments carry pre-authenticated
+        SharePoint download URLs (no extra auth header needed). Bot Connector
+        attachment URLs (inline images on ``serviceUrl`` hosts such as
+        ``smba.trafficmanager.net``) are bearer-gated — callers pass the bot
+        token via *headers*. Validates the URL against the SSRF guard and
+        follows redirects through the shared redirect guard, matching the
+        cache_*_from_url helpers in gateway.platforms.base.
         """
         from tools.url_safety import is_safe_url
         from gateway.platforms.base import _ssrf_redirect_guard
@@ -812,25 +891,61 @@ class TeamsAdapter(BasePlatformAdapter):
 
         import httpx
 
+        request_headers = {"User-Agent": "Mozilla/5.0 (compatible; HermesAgent/1.0)"}
+        if headers:
+            request_headers.update(headers)
+
         async with httpx.AsyncClient(
             timeout=timeout,
             follow_redirects=True,
             event_hooks={"response": [_ssrf_redirect_guard]},
         ) as client:
-            response = await client.get(
-                url,
-                headers={"User-Agent": "Mozilla/5.0 (compatible; HermesAgent/1.0)"},
-            )
+            response = await client.get(url, headers=request_headers)
             response.raise_for_status()
             return response.content
+
+    async def _bot_auth_header(
+        self, content_url: str, service_url: Optional[str]
+    ) -> Dict[str, str]:
+        """Return an ``Authorization`` header for a Bot Connector attachment URL.
+
+        Inline Teams images arrive as attachments whose ``content_url`` lives
+        on the conversation's Bot Connector host and require the app-only Bot
+        Framework token. To avoid leaking that bearer token to arbitrary
+        third-party image hosts, the header is attached **only** when
+        ``content_url`` shares a host with the activity's ``service_url``.
+        Returns an empty dict when there is no live app, no service URL, the
+        hosts differ, or the token cannot be acquired.
+        """
+        if not (self._app and content_url and service_url):
+            return {}
+        from urllib.parse import urlsplit
+
+        try:
+            if urlsplit(content_url).hostname != urlsplit(service_url).hostname:
+                return {}
+        except Exception:
+            return {}
+        try:
+            token = await self._app._get_bot_token()
+        except Exception as e:
+            logger.warning("[teams] Could not acquire bot token for attachment fetch: %s", e)
+            return {}
+        token_str = str(token) if token else ""
+        if not token_str:
+            return {}
+        return {"Authorization": f"Bearer {token_str}"}
 
     async def _on_message(self, ctx: ActivityContext[MessageActivity]) -> None:
         """Process an incoming Teams message and dispatch to the gateway."""
         activity = ctx.activity
 
-        # Self-message filter
+        # Self-message filter. App.id is the bare client_id GUID, but Teams
+        # delivers the bot's own from_.id in the channel-prefixed Bot Framework
+        # form "28:<appId>", so match either the bare GUID or that suffix.
         bot_id = self._app.id if self._app else None
-        if bot_id and getattr(activity.from_, "id", None) == bot_id:
+        from_id = getattr(activity.from_, "id", None)
+        if bot_id and from_id and (from_id == bot_id or from_id.endswith(":" + bot_id)):
             return
 
         # Deduplication
@@ -838,10 +953,14 @@ class TeamsAdapter(BasePlatformAdapter):
         if msg_id and self._dedup.is_duplicate(msg_id):
             return
 
-        # Cache the conversation reference for proactive sends (approval cards, etc.)
+        # Cache the conversation reference for proactive sends (approval cards, etc.).
+        # LRU-bounded: refresh recency on each inbound, evict the oldest when over cap.
         conv_id = getattr(activity.conversation, "id", None)
         if conv_id:
             self._conv_refs[conv_id] = ctx.conversation_ref
+            self._conv_refs.move_to_end(conv_id)
+            if len(self._conv_refs) > _CONV_REF_CACHE_SIZE:
+                self._conv_refs.popitem(last=False)
 
         # Extract text — strip bot @mentions
         text = ""
@@ -864,10 +983,27 @@ class TeamsAdapter(BasePlatformAdapter):
         else:
             chat_type = "dm"
 
+        # Remember the conversation's type/name so get_chat_info() can return a
+        # valid enum type instead of "unknown" (Teams has no lookup API).
+        if conv_id:
+            self._chat_meta[conv_id] = {
+                "name": getattr(conv, "name", None) or "",
+                "type": chat_type,
+            }
+
         # Build source
         from_account = activity.from_
         user_id = getattr(from_account, "aad_object_id", None) or getattr(from_account, "id", "")
         user_name = getattr(from_account, "name", None) or ""
+
+        # Thread support for channel/group conversations: replies carry
+        # ``reply_to_id`` (the thread root); a top-level post is itself the
+        # root, so fall back to the message id. Without this, every message in
+        # a conversation shares thread_id=None and collapses into one session.
+        # DMs stay unthreaded. Mirrors Mattermost (root_id or post_id).
+        thread_id = None
+        if chat_type != "dm":
+            thread_id = getattr(activity, "reply_to_id", None) or msg_id
 
         source = self.build_source(
             chat_id=conv.id,
@@ -875,6 +1011,7 @@ class TeamsAdapter(BasePlatformAdapter):
             chat_type=chat_type,
             user_id=str(user_id),
             user_name=user_name,
+            thread_id=thread_id,
             guild_id=getattr(conv, "tenant_id", None) or self._tenant_id,
         )
 
@@ -882,6 +1019,9 @@ class TeamsAdapter(BasePlatformAdapter):
         media_urls = []
         media_types = []
         media_kinds = []
+        # Bot Connector attachment URLs (inline images) live on this host and
+        # require the bot bearer token; used to scope the auth header below.
+        activity_service_url = getattr(activity, "service_url", None)
         for att in getattr(activity, "attachments", None) or []:
             content_url = getattr(att, "content_url", None)
             content_type = (getattr(att, "content_type", None) or "").lower()
@@ -923,12 +1063,21 @@ class TeamsAdapter(BasePlatformAdapter):
                 continue
 
             if content_url and content_type.startswith("image/"):
+                # Inline Teams images are served from the Bot Connector host and
+                # need the bot bearer token; an anonymous GET returns 401/403 so
+                # the image never reaches vision. Fetch with the scoped auth
+                # header, then cache the bytes (parity with the file/document
+                # branches below).
                 try:
-                    cached = await cache_image_from_url(content_url)
+                    auth = await self._bot_auth_header(content_url, activity_service_url)
+                    data = await self._fetch_attachment_bytes(content_url, headers=auth)
+                    cached = cache_media_bytes(
+                        data, mime_type=content_type, default_kind="image"
+                    )
                     if cached:
-                        media_urls.append(cached)
-                        media_types.append(content_type)
-                        media_kinds.append("image")
+                        media_urls.append(cached.path)
+                        media_types.append(cached.media_type)
+                        media_kinds.append(cached.kind)
                 except Exception as e:
                     logger.warning("[teams] Failed to cache image attachment: %s", e)
                 continue
@@ -1143,7 +1292,7 @@ class TeamsAdapter(BasePlatformAdapter):
             return SendResult(success=True, message_id=message_id)
         except Exception as e:
             logger.error("[teams] send_exec_approval failed: %s", e, exc_info=True)
-            return SendResult(success=False, error=str(e), retryable=True)
+            return SendResult(success=False, error=str(e), retryable=_is_transient_send_error(e))
 
     async def send(
         self,
@@ -1156,7 +1305,7 @@ class TeamsAdapter(BasePlatformAdapter):
             return SendResult(success=False, error="Teams app not initialized")
 
         formatted = self.format_message(content)
-        chunks = self.truncate_message(formatted)
+        chunks = self.truncate_message(formatted, self.MAX_MESSAGE_LENGTH)
         last_message_id = None
 
         for chunk in chunks:
@@ -1177,7 +1326,7 @@ class TeamsAdapter(BasePlatformAdapter):
                     result = await self._app.send(chat_id, chunk)
                 last_message_id = getattr(result, "id", None)
             except Exception as e:
-                return SendResult(success=False, error=str(e), retryable=True)
+                return SendResult(success=False, error=str(e), retryable=_is_transient_send_error(e))
 
         return SendResult(success=True, message_id=last_message_id)
 
@@ -1229,7 +1378,7 @@ class TeamsAdapter(BasePlatformAdapter):
             return SendResult(success=True, message_id=getattr(result, "id", None))
         except Exception as e:
             logger.error("[teams] send_image failed: %s", e, exc_info=True)
-            return SendResult(success=False, error=str(e), retryable=True)
+            return SendResult(success=False, error=str(e), retryable=_is_transient_send_error(e))
 
     async def send_image_file(
         self,
@@ -1247,7 +1396,10 @@ class TeamsAdapter(BasePlatformAdapter):
         )
 
     async def get_chat_info(self, chat_id: str) -> dict:
-        return {"name": chat_id, "type": "unknown", "chat_id": chat_id}
+        meta = self._chat_meta.get(chat_id) or {}
+        chat_type = meta.get("type") or "dm"
+        name = meta.get("name") or chat_id
+        return {"name": name, "type": chat_type, "chat_id": chat_id}
 
 
 # ── Interactive setup ─────────────────────────────────────────────────────────

--- a/tests/gateway/test_teams.py
+++ b/tests/gateway/test_teams.py
@@ -1,5 +1,6 @@
 """Tests for the Microsoft Teams platform adapter plugin."""
 
+import base64
 import json
 import sys
 import types
@@ -86,6 +87,7 @@ def _ensure_teams_mock():
     microsoft_teams_api.MessageActivity = MagicMock
     microsoft_teams_api.ConversationReference = MagicMock
     microsoft_teams_api.MessageActivityInput = MagicMock
+    microsoft_teams_api.Attachment = MagicMock
 
     # TypingActivityInput mock
     class MockTypingActivityInput:
@@ -497,6 +499,157 @@ class TestTeamsSend:
         call_args = mock_app.send.call_args
         assert call_args[0][0] == "conv-id"
 
+    @pytest.mark.anyio
+    async def test_send_oversized_body_splits_into_multiple_chunks(self):
+        # A body well over MAX_MESSAGE_LENGTH (28 KB) must be delivered as
+        # more than one Teams activity.
+        adapter = TeamsAdapter(_make_config(
+            client_id="id", client_secret="secret", tenant_id="tenant",
+        ))
+        mock_result = MagicMock()
+        mock_result.id = "chunk-id"
+        mock_app = MagicMock()
+        mock_app.send = AsyncMock(return_value=mock_result)
+        adapter._app = mock_app
+
+        big_body = "word " * 8000  # 40000 chars, > 28000
+        result = await adapter.send("conv-id", big_body)
+
+        assert result.success is True
+        assert mock_app.send.await_count > 1, (
+            "A body larger than MAX_MESSAGE_LENGTH must be split across "
+            "multiple send() calls."
+        )
+        # Every chunk goes to the same conversation.
+        for call in mock_app.send.await_args_list:
+            assert call.args[0] == "conv-id"
+
+    @pytest.mark.anyio
+    async def test_send_ten_kb_body_is_single_chunk(self):
+        # Regression for CHUNK: send() must chunk at Teams' MAX_MESSAGE_LENGTH
+        # (28 KB), not the base-class default (4096). A ~10 KB body fits in one
+        # Teams message and must NOT be fragmented.
+        adapter = TeamsAdapter(_make_config(
+            client_id="id", client_secret="secret", tenant_id="tenant",
+        ))
+        mock_result = MagicMock()
+        mock_result.id = "only-chunk"
+        mock_app = MagicMock()
+        mock_app.send = AsyncMock(return_value=mock_result)
+        adapter._app = mock_app
+
+        body = "x" * 10000  # ~10 KB, < 28000
+        result = await adapter.send("conv-id", body)
+
+        assert result.success is True
+        assert result.message_id == "only-chunk"
+        assert mock_app.send.await_count == 1, (
+            "A ~10 KB body fits in one Teams message; send() must not split it. "
+            "truncate_message must be called with MAX_MESSAGE_LENGTH (28000), "
+            "not the 4096 base default."
+        )
+
+    @pytest.mark.anyio
+    async def test_send_with_numeric_reply_to_uses_reply(self):
+        # A digit reply_to routes through the SDK's threaded reply() path.
+        adapter = TeamsAdapter(_make_config(
+            client_id="id", client_secret="secret", tenant_id="tenant",
+        ))
+        mock_result = MagicMock()
+        mock_result.id = "reply-id"
+        mock_app = MagicMock()
+        mock_app.reply = AsyncMock(return_value=mock_result)
+        mock_app.send = AsyncMock()
+        adapter._app = mock_app
+
+        result = await adapter.send("conv-id", "Hello", reply_to="42")
+
+        assert result.success is True
+        assert result.message_id == "reply-id"
+        mock_app.reply.assert_awaited_once_with("conv-id", "42", "Hello")
+        mock_app.send.assert_not_awaited()
+
+    @pytest.mark.anyio
+    async def test_send_reply_falls_back_to_flat_send_on_error(self):
+        # Group chats 400 on threaded sends; reply() failure must fall back to
+        # a flat send rather than failing the whole send.
+        adapter = TeamsAdapter(_make_config(
+            client_id="id", client_secret="secret", tenant_id="tenant",
+        ))
+        mock_result = MagicMock()
+        mock_result.id = "flat-id"
+        mock_app = MagicMock()
+        mock_app.reply = AsyncMock(side_effect=Exception("threaded send not supported"))
+        mock_app.send = AsyncMock(return_value=mock_result)
+        adapter._app = mock_app
+
+        result = await adapter.send("conv-id", "Hello", reply_to="42")
+
+        assert result.success is True
+        assert result.message_id == "flat-id"
+        mock_app.reply.assert_awaited_once()
+        mock_app.send.assert_awaited_once_with("conv-id", "Hello")
+
+    @pytest.mark.anyio
+    async def test_send_failure_is_retryable(self):
+        # A transient send failure (httpx 5xx) must surface as retryable so the
+        # base layer retries instead of falling back to plain text.
+        import httpx
+
+        adapter = TeamsAdapter(_make_config(
+            client_id="id", client_secret="secret", tenant_id="tenant",
+        ))
+        transient = httpx.HTTPStatusError(
+            "server error",
+            request=httpx.Request("POST", "https://example.test"),
+            response=httpx.Response(503),
+        )
+        mock_app = MagicMock()
+        mock_app.send = AsyncMock(side_effect=transient)
+        adapter._app = mock_app
+
+        result = await adapter.send("conv-id", "Hello")
+        assert result.success is False
+        assert result.retryable is True
+
+    @pytest.mark.anyio
+    async def test_send_permanent_failure_is_not_retryable(self):
+        # A permanent failure (httpx 4xx / local error) must NOT be retryable so
+        # base falls back to its plain-text path instead of retrying the same
+        # payload.
+        import httpx
+
+        adapter = TeamsAdapter(_make_config(
+            client_id="id", client_secret="secret", tenant_id="tenant",
+        ))
+        permanent = httpx.HTTPStatusError(
+            "bad request",
+            request=httpx.Request("POST", "https://example.test"),
+            response=httpx.Response(400),
+        )
+        mock_app = MagicMock()
+        mock_app.send = AsyncMock(side_effect=permanent)
+        adapter._app = mock_app
+
+        result = await adapter.send("conv-id", "Hello")
+        assert result.success is False
+        assert result.retryable is False
+
+    @pytest.mark.anyio
+    async def test_send_success_is_not_retryable(self):
+        adapter = TeamsAdapter(_make_config(
+            client_id="id", client_secret="secret", tenant_id="tenant",
+        ))
+        mock_result = MagicMock()
+        mock_result.id = "ok-id"
+        mock_app = MagicMock()
+        mock_app.send = AsyncMock(return_value=mock_result)
+        adapter._app = mock_app
+
+        result = await adapter.send("conv-id", "Hello")
+        assert result.success is True
+        assert result.retryable is False
+
 
 def _make_summary_payload():
     return TeamsMeetingSummaryPayload(
@@ -833,13 +986,30 @@ class TestTeamsAttachmentClassification:
         from gateway.platforms.base import MessageType
 
         adapter = self._make_adapter()
+        # Both the image branch and the document branch download via
+        # _fetch_attachment_bytes; the document branch is the only one that
+        # keeps cache_media_bytes' real classification (no per-call mock), so
+        # mock both downloads to harmless bytes.
         adapter._fetch_attachment_bytes = AsyncMock(return_value=b"%PDF-1.4 fake")
+        # Inline Teams images need the bot bearer token; with no live host the
+        # adapter would otherwise try to mint one — stub the auth header.
+        adapter._bot_auth_header = AsyncMock(return_value={})
 
-        async def fake_cache_image(url, *a, **kw):
-            return "/tmp/img.png"
+        # The image branch now caches raw bytes via cache_media_bytes(...,
+        # default_kind="image"); the document branch caches by filename/mime.
+        # Return the right kind for each so classification (document wins) is
+        # exercised the same way production sees it.
+        def fake_cache_media_bytes(data, *, filename="", mime_type="", default_kind=None):
+            if default_kind == "image" or mime_type.startswith("image/"):
+                return SimpleNamespace(
+                    path="/tmp/img.png", media_type="image/png", kind="image"
+                )
+            return SimpleNamespace(
+                path="/tmp/report.pdf", media_type="application/pdf", kind="document"
+            )
 
         with pytest.MonkeyPatch.context() as mp:
-            mp.setattr(_teams_mod, "cache_image_from_url", fake_cache_image)
+            mp.setattr(_teams_mod, "cache_media_bytes", fake_cache_media_bytes)
             activity = self._make_activity([
                 self._image_attachment(),
                 self._file_download_attachment(),
@@ -867,12 +1037,19 @@ class TestTeamsAttachmentClassification:
         from gateway.platforms.base import MessageType
 
         adapter = self._make_adapter()
+        # Inline images are fetched with the scoped bot bearer header and then
+        # cached as bytes (parity with the file/document branches). Mock at
+        # those boundaries: auth header, byte download, and the cache.
+        adapter._bot_auth_header = AsyncMock(return_value={})
+        adapter._fetch_attachment_bytes = AsyncMock(return_value=b"\x89PNG fake")
 
-        async def fake_cache_image(url, *a, **kw):
-            return "/tmp/img.png"
+        def fake_cache_media_bytes(data, *, filename="", mime_type="", default_kind=None):
+            return SimpleNamespace(
+                path="/tmp/img.png", media_type="image/png", kind="image"
+            )
 
         with pytest.MonkeyPatch.context() as mp:
-            mp.setattr(_teams_mod, "cache_image_from_url", fake_cache_image)
+            mp.setattr(_teams_mod, "cache_media_bytes", fake_cache_media_bytes)
             activity = self._make_activity([self._image_attachment()])
             await adapter._on_message(self._make_ctx(activity))
 
@@ -1067,3 +1244,349 @@ class TestTeamsStandaloneSend:
         assert "error" in result
         assert "Bot Framework conversation ID" in result["error"]
         assert len(session.calls) == 0
+
+
+# ---------------------------------------------------------------------------
+# Tests: connect() success path
+# ---------------------------------------------------------------------------
+
+class TestTeamsConnectSuccess:
+    @pytest.mark.anyio
+    async def test_connect_success_marks_connected_and_registers_webhook(self, monkeypatch):
+        """connect() should build the aiohttp app, start the SDK + runner/site,
+        register the webhook route, and mark the adapter connected."""
+        monkeypatch.setattr(_teams_mod, "TEAMS_SDK_AVAILABLE", True)
+        monkeypatch.setattr(_teams_mod, "AIOHTTP_AVAILABLE", True)
+        monkeypatch.setattr(_teams_mod, "check_teams_requirements", lambda: True)
+
+        # Mock the aiohttp ``web`` module so no real socket is bound. The same
+        # Application instance is returned on each web.Application() call
+        # (MagicMock return_value identity), so route wiring is assertable.
+        fake_web = MagicMock()
+        runner = AsyncMock()
+        site = AsyncMock()
+        fake_web.AppRunner.return_value = runner
+        fake_web.TCPSite.return_value = site
+        monkeypatch.setattr(_teams_mod, "web", fake_web)
+
+        # Fake App whose initialize() drives the bridge's register_route the
+        # way the real SDK http server does (POST /api/messages).
+        captured = {}
+
+        class _FakeApp:
+            def __init__(self, **kwargs):
+                self._adapter = kwargs.get("http_server_adapter")
+                captured["app"] = self
+                captured["kwargs"] = kwargs
+
+            def on_message(self, func):
+                return func
+
+            def on_card_action(self, func):
+                return func
+
+            async def initialize(self):
+                self._adapter.register_route(
+                    "POST", "/api/messages", AsyncMock()
+                )
+
+        monkeypatch.setattr(_teams_mod, "App", _FakeApp)
+        # ClientOptions is consumed by App(**kwargs); keep it a harmless factory.
+        monkeypatch.setattr(_teams_mod, "ClientOptions", MagicMock())
+
+        adapter = TeamsAdapter(_make_config(
+            client_id="id", client_secret="secret", tenant_id="tenant", port=3978,
+        ))
+
+        result = await adapter.connect()
+
+        assert result is True
+        assert adapter.is_connected is True
+        assert adapter._running is True
+        assert adapter._app is captured["app"]
+
+        # Runner + site lifecycle was driven.
+        fake_web.AppRunner.assert_called_once()
+        runner.setup.assert_awaited_once()
+        fake_web.TCPSite.assert_called_once()
+        site.start.assert_awaited_once()
+
+        # The SDK webhook route was registered onto the aiohttp app via the bridge.
+        app_obj = fake_web.Application.return_value
+        registered = [c.args for c in app_obj.router.add_route.call_args_list]
+        assert ("POST", "/api/messages") == registered[0][:2]
+
+    @pytest.mark.anyio
+    async def test_connect_failure_sets_retryable_fatal_error(self, monkeypatch):
+        """An exception during setup should be caught and reported as a
+        retryable CONNECT_FAILED fatal error (not propagate)."""
+        monkeypatch.setattr(_teams_mod, "TEAMS_SDK_AVAILABLE", True)
+        monkeypatch.setattr(_teams_mod, "AIOHTTP_AVAILABLE", True)
+        monkeypatch.setattr(_teams_mod, "check_teams_requirements", lambda: True)
+
+        fake_web = MagicMock()
+        fake_web.Application.side_effect = RuntimeError("boom")
+        monkeypatch.setattr(_teams_mod, "web", fake_web)
+
+        adapter = TeamsAdapter(_make_config(
+            client_id="id", client_secret="secret", tenant_id="tenant",
+        ))
+        result = await adapter.connect()
+        assert result is False
+        assert adapter.is_connected is False
+
+
+# ---------------------------------------------------------------------------
+# Tests: send_image
+# ---------------------------------------------------------------------------
+
+class TestTeamsSendImage:
+    @pytest.mark.anyio
+    async def test_send_image_returns_error_without_app(self):
+        adapter = TeamsAdapter(_make_config(
+            client_id="id", client_secret="secret", tenant_id="tenant",
+        ))
+        adapter._app = None
+        result = await adapter.send_image("conv-id", "https://example.test/x.png")
+        assert result.success is False
+        assert "not initialized" in result.error
+
+    @pytest.mark.anyio
+    async def test_send_image_url_uses_app_send(self):
+        adapter = TeamsAdapter(_make_config(
+            client_id="id", client_secret="secret", tenant_id="tenant",
+        ))
+        mock_result = MagicMock()
+        mock_result.id = "img-msg-1"
+        mock_app = MagicMock()
+        mock_app.send = AsyncMock(return_value=mock_result)
+        adapter._app = mock_app
+
+        result = await adapter.send_image(
+            "conv-id", "https://example.test/pic.png", caption="hi"
+        )
+
+        assert result.success is True
+        assert result.message_id == "img-msg-1"
+        # No cached conversation reference → flat app.send path.
+        mock_app.send.assert_awaited_once()
+        assert mock_app.send.await_args.args[0] == "conv-id"
+
+    @pytest.mark.anyio
+    async def test_send_image_local_path_encodes_data_uri(self, tmp_path, monkeypatch):
+        adapter = TeamsAdapter(_make_config(
+            client_id="id", client_secret="secret", tenant_id="tenant",
+        ))
+        mock_result = MagicMock()
+        mock_result.id = "img-msg-2"
+        mock_app = MagicMock()
+        mock_app.send = AsyncMock(return_value=mock_result)
+        adapter._app = mock_app
+
+        img = tmp_path / "pic.png"
+        img.write_bytes(b"\x89PNG\r\n\x1a\nFAKE")
+
+        # Capture the Attachment constructed for the local-path branch.
+        captured = {}
+
+        def _fake_attachment(content_type=None, content_url=None, **kw):
+            captured["content_type"] = content_type
+            captured["content_url"] = content_url
+            return MagicMock()
+
+        import microsoft_teams.api as _api_mod
+        monkeypatch.setattr(_api_mod, "Attachment", _fake_attachment, raising=False)
+
+        result = await adapter.send_image("conv-id", str(img))
+
+        assert result.success is True
+        assert result.message_id == "img-msg-2"
+        assert captured["content_type"] == "image/png"
+        assert captured["content_url"].startswith("data:image/png;base64,")
+        # Round-trip the encoded bytes to be sure the file was embedded.
+        b64 = captured["content_url"].split(",", 1)[1]
+        assert base64.b64decode(b64) == b"\x89PNG\r\n\x1a\nFAKE"
+
+    @pytest.mark.anyio
+    async def test_send_image_uses_conversation_reference_when_cached(self):
+        adapter = TeamsAdapter(_make_config(
+            client_id="id", client_secret="secret", tenant_id="tenant",
+        ))
+        mock_result = MagicMock()
+        mock_result.id = "img-msg-3"
+        mock_app = MagicMock()
+        mock_app.send = AsyncMock(return_value=mock_result)
+        mock_app.activity_sender = MagicMock()
+        mock_app.activity_sender.send = AsyncMock(return_value=mock_result)
+        adapter._app = mock_app
+        adapter._conv_refs["conv-id"] = MagicMock()  # cached reference
+
+        result = await adapter.send_image("conv-id", "https://example.test/pic.png")
+
+        assert result.success is True
+        mock_app.activity_sender.send.assert_awaited_once()
+        mock_app.send.assert_not_awaited()
+
+    @pytest.mark.anyio
+    async def test_send_image_handles_error(self):
+        # send_image swallows the exception and reports a transient transport
+        # failure as retryable.
+        import httpx
+
+        adapter = TeamsAdapter(_make_config(
+            client_id="id", client_secret="secret", tenant_id="tenant",
+        ))
+        mock_app = MagicMock()
+        mock_app.send = AsyncMock(
+            side_effect=httpx.ConnectError("upload failed")
+        )
+        adapter._app = mock_app
+
+        result = await adapter.send_image("conv-id", "https://example.test/pic.png")
+        assert result.success is False
+        assert "upload failed" in result.error
+        assert result.retryable is True
+
+
+# ---------------------------------------------------------------------------
+# Tests: get_chat_info
+# ---------------------------------------------------------------------------
+
+class TestTeamsGetChatInfo:
+    @pytest.mark.anyio
+    async def test_get_chat_info_unseen_chat_defaults_to_dm(self):
+        # Teams has no on-demand lookup; an unseen chat must fall back to a
+        # valid enum type ("dm") and name=chat_id — never "unknown".
+        adapter = TeamsAdapter(_make_config(
+            client_id="id", client_secret="secret", tenant_id="tenant",
+        ))
+        info = await adapter.get_chat_info("19:abc@thread.v2")
+        assert info == {
+            "name": "19:abc@thread.v2",
+            "type": "dm",
+            "chat_id": "19:abc@thread.v2",
+        }
+        assert info["type"] != "unknown"
+
+    @pytest.mark.anyio
+    async def test_get_chat_info_reflects_cached_meta(self):
+        # get_chat_info replays the type/name observed on inbound messages.
+        adapter = TeamsAdapter(_make_config(
+            client_id="id", client_secret="secret", tenant_id="tenant",
+        ))
+        adapter._chat_meta["19:room@thread.v2"] = {
+            "name": "Project Room",
+            "type": "channel",
+        }
+        info = await adapter.get_chat_info("19:room@thread.v2")
+        assert info == {
+            "name": "Project Room",
+            "type": "channel",
+            "chat_id": "19:room@thread.v2",
+        }
+
+
+# ---------------------------------------------------------------------------
+# Tests: Adaptive Card action authorization gate (_on_card_action)
+#
+# This is the most security-sensitive path in the adapter: clicking an
+# approval button resolves a *gateway command approval*. The handler must
+# default-deny (require TEAMS_ALLOWED_USERS or explicit TEAMS_ALLOW_ALL_USERS)
+# and must never resolve an approval for an unauthorized clicker.
+# ---------------------------------------------------------------------------
+
+class TestTeamsCardActionAuth:
+    def _make_adapter(self):
+        adapter = TeamsAdapter(_make_config(
+            client_id="bot-id", client_secret="secret", tenant_id="tenant",
+        ))
+        adapter._app = MagicMock()
+        adapter._app.id = "bot-id"
+        return adapter
+
+    def _make_ctx(self, *, clicker_aad="clicker-aad", clicker_id="clicker-id",
+                  hermes_action="approve_once", session_key="sess-1"):
+        ctx = MagicMock()
+        ctx.activity.value.action.data = {
+            "hermes_action": hermes_action,
+            "session_key": session_key,
+        }
+        ctx.activity.from_ = MagicMock()
+        ctx.activity.from_.aad_object_id = clicker_aad
+        ctx.activity.from_.id = clicker_id
+        return ctx
+
+    def _patch_approval(self, monkeypatch, *, blocking=True):
+        """Patch the approval helpers _on_card_action imports lazily.
+
+        Returns the resolve spy; has_blocking_approval is stubbed so the
+        accept paths reach the resolve call without a real pending request.
+        """
+        resolve_spy = MagicMock()
+        monkeypatch.setattr("tools.approval.resolve_gateway_approval", resolve_spy)
+        monkeypatch.setattr("tools.approval.has_blocking_approval", lambda _k: blocking)
+        return resolve_spy
+
+    @pytest.mark.anyio
+    async def test_default_deny_when_no_env_set(self, monkeypatch):
+        monkeypatch.delenv("TEAMS_ALLOWED_USERS", raising=False)
+        monkeypatch.delenv("TEAMS_ALLOW_ALL_USERS", raising=False)
+        resolve_spy = self._patch_approval(monkeypatch)
+
+        adapter = self._make_adapter()
+        resp = await adapter._on_card_action(self._make_ctx())
+
+        assert resp.status == 200
+        resolve_spy.assert_not_called()
+
+    @pytest.mark.anyio
+    async def test_reject_clicker_not_in_allowlist(self, monkeypatch):
+        monkeypatch.setenv("TEAMS_ALLOWED_USERS", "alice-aad,bob-aad")
+        monkeypatch.delenv("TEAMS_ALLOW_ALL_USERS", raising=False)
+        resolve_spy = self._patch_approval(monkeypatch)
+
+        adapter = self._make_adapter()
+        ctx = self._make_ctx(clicker_aad="mallory-aad", clicker_id="mallory-id")
+        resp = await adapter._on_card_action(ctx)
+
+        assert resp.status == 200
+        resolve_spy.assert_not_called()
+
+    @pytest.mark.anyio
+    async def test_accept_clicker_in_allowlist(self, monkeypatch):
+        monkeypatch.setenv("TEAMS_ALLOWED_USERS", "alice-aad,bob-aad")
+        monkeypatch.delenv("TEAMS_ALLOW_ALL_USERS", raising=False)
+        resolve_spy = self._patch_approval(monkeypatch)
+
+        adapter = self._make_adapter()
+        ctx = self._make_ctx(clicker_aad="bob-aad", hermes_action="approve_once")
+        resp = await adapter._on_card_action(ctx)
+
+        assert resp.status == 200
+        resolve_spy.assert_called_once_with("sess-1", "once")
+
+    @pytest.mark.anyio
+    async def test_accept_wildcard_allowlist(self, monkeypatch):
+        monkeypatch.setenv("TEAMS_ALLOWED_USERS", "*")
+        monkeypatch.delenv("TEAMS_ALLOW_ALL_USERS", raising=False)
+        resolve_spy = self._patch_approval(monkeypatch)
+
+        adapter = self._make_adapter()
+        ctx = self._make_ctx(clicker_aad="anyone-aad", hermes_action="deny")
+        resp = await adapter._on_card_action(ctx)
+
+        assert resp.status == 200
+        resolve_spy.assert_called_once_with("sess-1", "deny")
+
+    @pytest.mark.anyio
+    async def test_accept_allow_all_users_env(self, monkeypatch):
+        monkeypatch.delenv("TEAMS_ALLOWED_USERS", raising=False)
+        monkeypatch.setenv("TEAMS_ALLOW_ALL_USERS", "true")
+        resolve_spy = self._patch_approval(monkeypatch)
+
+        adapter = self._make_adapter()
+        ctx = self._make_ctx(clicker_aad="random-aad", hermes_action="approve_session")
+        resp = await adapter._on_card_action(ctx)
+
+        assert resp.status == 200
+        resolve_spy.assert_called_once_with("sess-1", "session")


### PR DESCRIPTION
## Summary

This fixes a batch of independent correctness defects in the Microsoft Teams
platform adapter (`plugins/platforms/teams/adapter.py`) and backfills tests for
several previously untested surfaces. Each fix is localized and preserves
existing behaviour on the common path; the adapter's architecture is unchanged.

## Fixes

| Area | Problem | Fix |
|------|---------|-----|
| **Chunking** | `send()` chunked at the base default (4096) instead of the declared/registered Teams limit (28000), needlessly fragmenting replies | Pass `self.MAX_MESSAGE_LENGTH` to `truncate_message()` |
| **Retry classification** | `SendResult.retryable` was hard-coded `True` on every caught send exception, so `base._send_with_retry` retried permanent errors (4xx, malformed cards, permission denials) and skipped its plain-text fallback | Added `_is_transient_send_error()` (httpx 429/5xx, timeouts, transport errors → retryable; else permanent), used at all three send sites |
| **Proactive service URL** | `service_url` was never passed to `App()`, so `App.send`/`App.reply` always targeted the global Bot Framework host — breaking regional/government (GCC/GCC-High) tenants | Read + allowlist-validate `TEAMS_SERVICE_URL` / `extra['service_url']` in `__init__`, forward to `App()` when set (unchanged when unset) |
| **`get_chat_info`** | Returned the out-of-contract type `"unknown"` (base requires `dm`/`group`/`channel`) | Cache the type/name observed on inbound activities and replay it; fall back to a valid `"dm"`/`chat_id` |
| **Channel threading** | `thread_id` was never passed to `build_source`, collapsing every channel/group thread into one session | Derive `thread_id` from `reply_to_id` (or message id) for non-DM conversations, mirroring the Mattermost adapter |
| **Inbound images** | Inline image attachments were fetched anonymously, but Bot Connector `contentUrl`s are bearer-gated (401/403), so images never reached the vision path | Fetch with the bot token via a **host-scoped** `Authorization` header (attached only when the content URL shares the activity's `serviceUrl` host, to avoid leaking the token to third-party hosts), then cache the bytes |
| **Self-message filter** | Compared `activity.from_.id` to the bare `client_id`, but Teams delivers the bot's own id as `"28:<appId>"`, so the filter never matched | Match the bare GUID **or** the `:`-delimited suffix form |
| **Conv-ref cache** | `_conv_refs` grew without bound | LRU-bounded `OrderedDict` with the same cap as the dedup cache |

## Testing

- `tests/gateway/test_teams.py`: **73 passing** (was 52).
- Fixed the two `TestTeamsAttachmentClassification` tests that monkeypatched the now-removed `cache_image_from_url`.
- Added coverage for: the Adaptive Card action **authorization gate** (default-deny; allowlist accept/reject; `*` / `ALLOW_ALL`), `connect()` success path, `send_image` (URL / local path / cached conv-ref / error), `get_chat_info`, multi-chunk **and** single-chunk send (chunking regression), `reply_to` threading, and `SendResult.retryable` classification.
- Verified the SDK-facing assumptions (App auth/JWT, `_get_bot_token`, `App(service_url=...)`, status-code behaviour) against the installed `microsoft-teams-apps` package.

## Scope notes

- **Deliberately deferred to a follow-up** (riskier, touch lifecycle): `connect()` `AppRunner` cleanup on bind failure + a port-conflict lock, and closing the SDK `App`'s HTTP clients on `disconnect()`; and applying `thread_id` in the out-of-process `_standalone_send` cron path.
- One originally-suspected bug — that the threaded-reply `reply_to.isdigit()` guard drops valid ids — was investigated and found **correct** against the SDK's conversation-id contract, so it was intentionally left unchanged.

Happy to split this into per-fix commits if you'd prefer that for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
