### PR TITLE
fix(bootstrap-installer): prevent panic when truncating multi-byte UTF-8 output

### DIFF
--- a/apps/bootstrap-installer/src-tauri/src/bootstrap.rs
+++ b/apps/bootstrap-installer/src-tauri/src/bootstrap.rs
@@ -814,7 +814,11 @@ fn truncate(s: &str, max: usize) -> String {
     if s.len() <= max {
         s.to_string()
     } else {
-        format!("{}...", &s[..max])
+        let mut end = max;
+        while end > 0 && !s.is_char_boundary(end) {
+            end -= 1;
+        }
+        format!("{}...", &s[..end])
     }
 }
 


### PR DESCRIPTION
## Summary

`truncate()` in `bootstrap.rs` uses `&s[..max]` to slice the string by byte offset. If `max` falls inside a multi-byte UTF-8 sequence, Rust panics with `byte index N is not a char boundary`. The install scripts emit multi-byte characters throughout (`⚠`, `✓`, `→`), so when a failed manifest call produces >4000 bytes of output, the error-handling path can hit this panic and crash the installer silently — the user never sees the actual error message.

## Changes

Walk backwards from `max` to the nearest `is_char_boundary()` position before slicing. `is_char_boundary()` is stable since Rust 1.0 and compatible with the crate's MSRV 1.77 (`str::floor_char_boundary` requires 1.82).

## Test plan

- [x] `cargo test --lib` in `apps/bootstrap-installer/src-tauri` — all bootstrap tests pass (the one pre-existing `lock_probe_paths_include_desktop_app_payload` failure in `update.rs` is unrelated)
- [ ] Trigger a manifest parse failure with >4000 bytes of multi-byte output — verify the error message is displayed instead of a panic

Closes no tracked issue — discovered by code audit.