### PR TITLE
fix(install): relax EAP=Stop around git/uv native calls in install.ps1 (#48352)

### DIFF
--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -1305,19 +1305,35 @@ function Install-Repository {
         # Try SSH first, then HTTPS, with -c flag for atomic write fix
         Write-Info "Trying SSH clone..."
         $env:GIT_SSH_COMMAND = "ssh -o BatchMode=yes -o ConnectTimeout=5"
+        # Relax EAP=Stop around the clone: git writes normal progress ("Cloning
+        # into...", "Receiving objects: NN%") to stderr, which PowerShell 5.1
+        # wraps as a terminating NativeCommandError under EAP=Stop. The empty
+        # catch below would then swallow a *successful* clone and force the ZIP
+        # fallback -- which inits a commit-less repo and later breaks the desktop
+        # build (`git rev-parse HEAD` fails). $LASTEXITCODE is the real signal.
+        $prevEAP = $ErrorActionPreference
+        $ErrorActionPreference = "Continue"
         try {
             git -c windows.appendAtomically=false clone --depth 1 --branch $Branch $RepoUrlSsh $InstallDir
             if ($LASTEXITCODE -eq 0) { $cloneSuccess = $true }
-        } catch { }
+        } catch { } finally {
+            $ErrorActionPreference = $prevEAP
+        }
         $env:GIT_SSH_COMMAND = $null
 
         if (-not $cloneSuccess) {
             if (Test-Path $InstallDir) { Remove-Item -Recurse -Force $InstallDir -ErrorAction SilentlyContinue }
             Write-Info "SSH failed, trying HTTPS..."
+            # Same EAP=Stop relaxation as the SSH attempt above -- git's stderr
+            # progress must not be mistaken for a clone failure.
+            $prevEAP = $ErrorActionPreference
+            $ErrorActionPreference = "Continue"
             try {
                 git -c windows.appendAtomically=false clone --depth 1 --branch $Branch $RepoUrlHttps $InstallDir
                 if ($LASTEXITCODE -eq 0) { $cloneSuccess = $true }
-            } catch { }
+            } catch { } finally {
+                $ErrorActionPreference = $prevEAP
+            }
         }
 
         # Fallback: download ZIP archive (bypasses git file I/O issues entirely)
@@ -1443,8 +1459,20 @@ function Install-Venv {
         Remove-Item -Recurse -Force "venv"
     }
     
-    # uv creates the venv and pins the Python version in one step
+    # uv creates the venv and pins the Python version in one step.
+    # Relax EAP=Stop: uv writes "Using CPython X.Y.Z" to stderr, which PS 5.1
+    # turns into a terminating NativeCommandError under EAP=Stop and aborts the
+    # whole installer right after a successful clone. $LASTEXITCODE is the real
+    # success signal.
+    $prevEAP = $ErrorActionPreference
+    $ErrorActionPreference = "Continue"
     & $UvCmd venv venv --python $PythonVersion
+    $venvExitCode = $LASTEXITCODE
+    $ErrorActionPreference = $prevEAP
+    if ($venvExitCode -ne 0) {
+        Pop-Location
+        throw "Failed to create virtual environment (uv venv exited with $venvExitCode)"
+    }
 
     # Neutralize any inherited UV_PYTHON (e.g. $env:UV_PYTHON = "3.14" left in
     # the user's shell). uv honours UV_PYTHON over an existing venv for the
@@ -1514,8 +1542,16 @@ function Install-Dependencies {
         # in the wrong directory and imports fail with ModuleNotFoundError.
         # (Mirrors the same flag in scripts/install.sh::install_deps.)
         $env:UV_PROJECT_ENVIRONMENT = "$InstallDir\venv"
+        # Relax EAP=Stop: uv sync writes "Resolved/Audited NN packages" and
+        # resolve progress to stderr; under EAP=Stop PS 5.1 wraps the first such
+        # line as a terminating NativeCommandError and aborts before the
+        # $LASTEXITCODE check below can run. $LASTEXITCODE is the real signal.
+        $prevEAP = $ErrorActionPreference
+        $ErrorActionPreference = "Continue"
         & $UvCmd sync --extra all --locked
-        if ($LASTEXITCODE -eq 0) {
+        $syncExitCode = $LASTEXITCODE
+        $ErrorActionPreference = $prevEAP
+        if ($syncExitCode -eq 0) {
             Write-Success "Main package installed (hash-verified via uv.lock)"
             $script:InstalledTier = "hash-verified (uv.lock)"
             # Skip the rest of the tiered cascade -- we already have a
@@ -1589,14 +1625,22 @@ except Exception:
     if (-not $skipPipFallback) {
         foreach ($tier in $installTiers) {
         Write-Info "Trying tier: $($tier.Name) ..."
+        # Relax EAP=Stop: uv pip install writes resolve/progress info to stderr,
+        # which PS 5.1 wraps as a terminating NativeCommandError under EAP=Stop --
+        # aborting the cascade before the $LASTEXITCODE check (and the next-tier
+        # fallback) can run. $LASTEXITCODE is the real per-tier success signal.
+        $prevEAP = $ErrorActionPreference
+        $ErrorActionPreference = "Continue"
         & $UvCmd pip install -e $tier.Spec
-        if ($LASTEXITCODE -eq 0) {
+        $tierExitCode = $LASTEXITCODE
+        $ErrorActionPreference = $prevEAP
+        if ($tierExitCode -eq 0) {
             Write-Success "Main package installed ($($tier.Name))"
             $script:InstalledTier = $tier.Name
             $installed = $true
             break
         }
-        Write-Warn "Tier '$($tier.Name)' failed (exit $LASTEXITCODE). Trying next tier..."
+        Write-Warn "Tier '$($tier.Name)' failed (exit $tierExitCode). Trying next tier..."
         }
     }
     if (-not $installed) {


### PR DESCRIPTION
## Summary

Fixes #48352.

On Windows, `scripts/install.ps1` sets `$ErrorActionPreference = "Stop"` globally. When the installer runs in a **non-console PowerShell host** (the desktop GUI / any tool-hosted runspace, and the `irm | iex` path), Windows PowerShell 5.1 surfaces a native command's *normal* stderr output as `ErrorRecord`s and — under `EAP=Stop` — turns the first such line into a **terminating `NativeCommandError`**, even though the command actually succeeded (exit `0`).

The sibling update path (`Install-Repository` update branch, ~L1147-1213) and the import probe (`Install-Dependencies`, ~L1618-1628) already relax EAP and rely on `$LASTEXITCODE`. A few call sites were left unguarded; this applies the **same established in-file pattern** to those stragglers.

## Call sites fixed

- **`git clone` (SSH + HTTPS)** in `Install-Repository` — git's `Cloning into...` stderr was wrapped as a terminating error and swallowed by the empty `catch {}`, marking a **successful clone as failed** and forcing the ZIP fallback. The ZIP path then `git init`s a **commit-less** repo, which later breaks the desktop build (`git rev-parse HEAD` fails — *"Packaged builds require a git ref..."*). (Issue §1)
- **`uv venv`** in `Install-Venv` — uv's `Using CPython X.Y.Z` stderr aborted the whole installer right after a successful clone. An explicit `$LASTEXITCODE` check is added so a *genuine* failure still fails fast. (Issue §2)
- **`uv sync --extra all --locked`** (hash-verified tier) and the **`uv pip install -e` tier loop** in `Install-Dependencies` — resolve/progress stderr aborted before the existing `$LASTEXITCODE` checks (and the next-tier fallback) could run. (Issue §3)

Each fix wraps **only the native invocation** in `EAP=Continue`, captures `$LASTEXITCODE`, and restores the previous preference — leaving the existing exit-code-driven control flow intact.

## Reproduction / verification

Reproduced on **Windows 11 / PowerShell 5.1** (`git 2.54.0.windows.1`, the env from the issue). In a non-console runspace (`[PowerShell]::Create()`, how a GUI hosts PS), a bare `git clone` (no `2>&1`) under `EAP=Stop` throws:

```
The running command stopped because the preference variable "ErrorActionPreference"
... is set to Stop: Cloning into '...'.
```

With `EAP=Continue` (this patch) the same clone completes and `$LASTEXITCODE` drives success as intended. (In a plain `ConsoleHost`, native stderr goes to the console instead of becoming `ErrorRecord`s, which is why the failure is host-dependent and easy to miss.)

## Scope / risk

Single file (`scripts/install.ps1`), +50/−6. No behavioral change on the success path beyond not spuriously aborting; real failures still surface via `$LASTEXITCODE` (and a new explicit throw for `uv venv`). Parsed clean with the PS 5.1 language parser.