### PR TITLE
fix(logging): reconfigure stderr before wrapping

### DIFF
--- a/hermes_logging.py
+++ b/hermes_logging.py
@@ -58,16 +58,29 @@ def _safe_stderr():  # type: ignore[return]
 
     On Windows the console encoding is often a legacy MBCS codec
     (cp949, cp1252, …) that raises ``UnicodeEncodeError`` for characters
-    like the em-dash (U+2014).  We wrap ``sys.stderr`` in a
-    ``TextIOWrapper`` with ``errors='replace'`` so log lines are never
-    lost — un-encodable characters are replaced with ``?`` instead of
-    crashing the process.
+    like the em-dash (U+2014).  Prefer reconfiguring the existing text stream
+    to ``errors='replace'`` so log lines are never lost while preserving the
+    console's real encoding and stream identity.  If reconfiguration is not
+    available, fall back to a tolerant ``TextIOWrapper`` around the buffer.
     """
     stream = sys.stderr
     encoding = getattr(stream, "encoding", None) or "utf-8"
-    # Already UTF-8 or surrogate-aware — no wrapping needed.
-    if encoding.lower().replace("-", "") in ("utf8", "utf8surrogateescape"):
+    errors = getattr(stream, "errors", None)
+    # Already UTF-8 or tolerant — no wrapping needed.
+    if (
+        encoding.lower().replace("-", "") in ("utf8", "utf8surrogateescape")
+        or errors == "replace"
+    ):
         return stream
+
+    reconfigure = getattr(stream, "reconfigure", None)
+    if callable(reconfigure):
+        try:
+            reconfigure(errors="replace")
+            return stream
+        except Exception:
+            pass
+
     try:
         buf = getattr(stream, "buffer", None)
         if buf is not None:

--- a/tests/test_hermes_logging.py
+++ b/tests/test_hermes_logging.py
@@ -1013,13 +1013,42 @@ class TestSafeStderr:
         # Should return the same object (or a equivalent stream)
         assert result is fake_stderr or getattr(result, "encoding", "").lower().startswith("utf")
 
-    def test_wraps_non_utf8_stderr(self, monkeypatch):
-        """On non-UTF-8 systems (e.g. Windows cp949), wraps stderr with UTF-8."""
-        import io
+    def test_reconfigures_non_utf8_stderr_when_supported(self, monkeypatch):
+        """On non-UTF-8 stderr, prefer reconfigure() over replacing the stream."""
 
         class FakeStderr:
             """Simulates a Windows stderr with legacy encoding."""
             encoding = "cp949"
+            errors = "strict"
+
+            def __init__(self):
+                self.reconfigured_with = None
+
+            def reconfigure(self, **kwargs):
+                self.reconfigured_with = kwargs
+                self.errors = kwargs.get("errors", self.errors)
+
+            def write(self, s):
+                pass
+
+            def flush(self):
+                pass
+
+        fake = FakeStderr()
+        monkeypatch.setattr(sys, "stderr", fake)
+        result = hermes_logging._safe_stderr()
+
+        assert result is fake
+        assert fake.reconfigured_with == {"errors": "replace"}
+        assert fake.errors == "replace"
+
+    def test_wraps_non_utf8_stderr_when_reconfigure_unavailable(self, monkeypatch):
+        """Fallback for stderr-like streams without reconfigure()."""
+        import io
+
+        class FakeStderr:
+            encoding = "cp949"
+            errors = "strict"
             buffer = io.BytesIO()
 
             def write(self, s):
@@ -1031,7 +1060,7 @@ class TestSafeStderr:
         fake = FakeStderr()
         monkeypatch.setattr(sys, "stderr", fake)
         result = hermes_logging._safe_stderr()
-        # Should be a TextIOWrapper, not the original FakeStderr
+
         assert isinstance(result, io.TextIOWrapper)
         assert result.encoding == "utf-8"
         assert result.errors == "replace"


### PR DESCRIPTION
## Summary
- prefer `sys.stderr.reconfigure(errors="replace")` for legacy-encoded stderr streams
- keep the existing stderr stream identity when possible instead of layering a new `TextIOWrapper`
- retain the UTF-8 wrapper fallback for streams that do not support `reconfigure()`

## Why
`_safe_stderr()` exists to avoid `UnicodeEncodeError` on legacy console encodings such as cp949/cp1252. On modern Python text streams, reconfiguring the existing stream is safer than replacing it: logging keeps the original stream object and avoids extra wrappers around the same underlying buffer.

## Tests
- `uv run pytest tests/test_hermes_logging.py::TestSafeStderr -q`
- `uv run pytest tests/test_hermes_logging.py -q`
