### PR TITLE
feat(reasoning): allow loopback providers to use reasoning

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -4817,6 +4817,13 @@ class AIAgent:
             opts = self._lmstudio_reasoning_options_cached()
             # "off-only" (or absent) means no real reasoning capability.
             return any(opt and opt != "off" for opt in opts)
+        # Local/custom providers on loopback may support reasoning (e.g.
+        # command-code-proxy). The operator controls the upstream and opts in
+        # by configuring reasoning_effort.
+        if base_url_host_matches(self._base_url_lower, "localhost") or base_url_host_matches(
+            self._base_url_lower, "127.0.0.1"
+        ):
+            return True
         if "openrouter" not in self._base_url_lower:
             return False
         if "api.mistral.ai" in self._base_url_lower:


### PR DESCRIPTION
## Summary

This PR allows loopback providers to receive the `reasoning` extra body when `reasoning_effort` is configured.

The existing gate already allows known hosted providers and LM Studio. This adds the same opt-in path for local/custom providers running on `localhost` or `127.0.0.1`.

## Why

Some local proxy providers support reasoning parameters even though they do not match the existing hosted-provider checks. Since loopback providers are controlled by the local operator, sending the field only when reasoning is configured is a reasonable opt-in path.

## Validation

- `.venv\Scripts\python.exe -m py_compile run_agent.py`
- `git diff --check`