### PR TITLE
fix(mirror): correct docstring - writes SQLite only, not JSONL

### DIFF
--- a/gateway/mirror.py
+++ b/gateway/mirror.py
@@ -34,7 +34,7 @@ def mirror_to_session(
     Append a delivery-mirror message to the target session's transcript.
 
     Finds the gateway session that matches the given platform + chat_id,
-    then writes a mirror entry to both the JSONL transcript and SQLite DB.
+    then writes a mirror entry to the SQLite session database.
 
     Returns True if mirrored successfully, False if no matching session or error.
     All errors are caught -- this is never fatal.


### PR DESCRIPTION
## Bug

`mirror_to_session()` in `gateway/mirror.py` documents:

```
Finds the gateway session that matches the given platform + chat_id,
then writes a mirror entry to both the JSONL transcript and SQLite DB.
```

But the implementation only calls `_append_to_sqlite(session_id, mirror_msg)` -
there is **no JSONL write**. The docstring promises a write path that does not
exist, which misleads anyone reading or debugging the mirror flow into looking
for a JSONL transcript that never gets written.

This is intentional behavior - sessions are stored in SQLite
(`SessionDB` / `hermes_state.py`), and the per-session `transcript.jsonl` is a
legacy format that the codebase only cleans up, never writes here. So the
**code is correct and the docstring is wrong**.

## Fix

Update the docstring to describe what the function actually does:

```
Finds the gateway session that matches the given platform + chat_id,
then writes a mirror entry to the SQLite session database.
```

Docstring-only change; no behavior change. The SQLite-only write path is left
exactly as-is.