### PR TITLE
fix(skills_hub): pass usedforsecurity=False to md5 cache keys (FIPS compatibility)

### DIFF
--- a/tools/skills_hub.py
+++ b/tools/skills_hub.py
@@ -1069,7 +1069,7 @@ class WellKnownSkillSource(SkillSource):
         }
 
     def _parse_index(self, index_url: str) -> Optional[dict]:
-        cache_key = f"well_known_index_{hashlib.md5(index_url.encode()).hexdigest()}"
+        cache_key = f"well_known_index_{hashlib.md5(index_url.encode(), usedforsecurity=False).hexdigest()}"
         cached = _read_index_cache(cache_key)
         if isinstance(cached, dict) and isinstance(cached.get("skills"), list):
             return cached
@@ -1334,7 +1334,7 @@ class SkillsShSource(SkillSource):
             # entries; the sitemap walks the full ~20k+ catalog.
             return self._sitemap_catalog(limit)
 
-        cache_key = f"skills_sh_search_{hashlib.md5(f'{query}|{limit}'.encode()).hexdigest()}"
+        cache_key = f"skills_sh_search_{hashlib.md5(f'{query}|{limit}'.encode(), usedforsecurity=False).hexdigest()}"
         cached = _read_index_cache(cache_key)
         if cached is not None:
             return [SkillMeta(**item) for item in cached][:limit]
@@ -1561,7 +1561,7 @@ class SkillsShSource(SkillSource):
         )
 
     def _fetch_detail_page(self, identifier: str) -> Optional[dict]:
-        cache_key = f"skills_sh_detail_{hashlib.md5(identifier.encode()).hexdigest()}"
+        cache_key = f"skills_sh_detail_{hashlib.md5(identifier.encode(), usedforsecurity=False).hexdigest()}"
         cached = _read_index_cache(cache_key)
         if isinstance(cached, dict):
             return cached
@@ -2048,7 +2048,7 @@ class ClawHubSource(SkillSource):
 
         # Non-empty query catalog miss, or catalog walker failure: fall back to
         # the lightweight listing API for a best-effort response.
-        cache_key = f"clawhub_search_listing_v1_{hashlib.md5(query.encode()).hexdigest()}_{limit}"
+        cache_key = f"clawhub_search_listing_v1_{hashlib.md5(query.encode(), usedforsecurity=False).hexdigest()}_{limit}"
         cached = _read_index_cache(cache_key)
         if cached is not None:
             return self._finalize_search_results(
@@ -2154,7 +2154,7 @@ class ClawHubSource(SkillSource):
         )
 
     def _search_catalog(self, query: str, limit: int = 10) -> List[SkillMeta]:
-        cache_key = f"clawhub_search_catalog_v1_{hashlib.md5(f'{query}|{limit}'.encode()).hexdigest()}"
+        cache_key = f"clawhub_search_catalog_v1_{hashlib.md5(f'{query}|{limit}'.encode(), usedforsecurity=False).hexdigest()}"
         cached = _read_index_cache(cache_key)
         if cached is not None:
             return [SkillMeta(**s) for s in cached][:limit]


### PR DESCRIPTION
## Bug

`tools/skills_hub.py` builds five cache keys with `hashlib.md5(...)` and none of
them pass `usedforsecurity=False`:

```python
cache_key = f"well_known_index_{hashlib.md5(index_url.encode()).hexdigest()}"
cache_key = f"skills_sh_search_{hashlib.md5(f'{query}|{limit}'.encode()).hexdigest()}"
cache_key = f"skills_sh_detail_{hashlib.md5(identifier.encode()).hexdigest()}"
cache_key = f"clawhub_search_listing_v1_{hashlib.md5(query.encode()).hexdigest()}_{limit}"
cache_key = f"clawhub_search_catalog_v1_{hashlib.md5(f'{query}|{limit}'.encode()).hexdigest()}"
```

On a **FIPS-mode Python build** (RHEL/CentOS/Rocky with the system FIPS policy
enabled, some hardened/government environments), `hashlib.md5()` **raises
`ValueError: [digital envelope routines] unsupported`** unless it is explicitly
marked non-security with `usedforsecurity=False`. That turns every Skills Hub
search / index / detail lookup into a crash on those systems, even though MD5
here is only used to derive a cache key - never for security.

## Fix

Pass `usedforsecurity=False` on all five calls:

```python
hashlib.md5(index_url.encode(), usedforsecurity=False)
```

- Correct semantically: these are cache-key digests, not security hashes.
- Safe everywhere: `usedforsecurity=False` has been supported since Python 3.9
  (Hermes''s floor) and is a no-op on non-FIPS builds - the cache keys are
  byte-for-byte identical.
- Fixes the crash on FIPS-enabled systems.

## Scope

Limited to the five cache-key sites in `tools/skills_hub.py`. Other `hashlib.md5`
call sites (platform file-checksum protocols, etc.) are left for separate review
since some are dictated by external API requirements.