### PR TITLE
fix(desktop): preserve profile for session windows

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -6955,8 +6955,9 @@ function focusWindow(win) {
 function spawnSecondaryWindow({
   sessionId,
   watch,
-  newSession
-}: { sessionId?: string; watch?: boolean; newSession?: boolean } = {}) {
+  newSession,
+  profile
+}: { sessionId?: string; watch?: boolean; newSession?: boolean; profile?: null | string } = {}) {
   const icon = getAppIconPath()
 
   const win = new BrowserWindow({
@@ -7002,7 +7003,8 @@ function spawnSecondaryWindow({
       devServer: DEV_SERVER,
       rendererIndexPath: DEV_SERVER ? undefined : resolveRendererIndex(),
       watch,
-      newSession
+      newSession,
+      profile
     })
   )
 
@@ -7010,8 +7012,11 @@ function spawnSecondaryWindow({
 }
 
 // Open (or focus) a standalone window for a single chat session.
-function createSessionWindow(sessionId, { watch = false } = {}) {
-  return sessionWindows.openOrFocus(sessionId, () => spawnSecondaryWindow({ sessionId, watch }))
+function createSessionWindow(sessionId, { watch = false, profile = null } = {}) {
+  const profileKey = typeof profile === 'string' && profile.trim() ? profile.trim() : null
+  const windowKey = profileKey ? `${profileKey}:${sessionId}` : sessionId
+
+  return sessionWindows.openOrFocus(windowKey, () => spawnSecondaryWindow({ sessionId, watch, profile: profileKey }))
 }
 
 // Open a fresh compact window on the new-session draft (#/). Not registry-keyed:
@@ -7361,7 +7366,9 @@ ipcMain.handle('hermes:window:openSession', async (_event, sessionId, opts) => {
     return { ok: false, error: 'invalid-session-id' }
   }
 
-  createSessionWindow(sessionId.trim(), { watch: opts?.watch === true })
+  const profile = typeof opts?.profile === 'string' && opts.profile.trim() ? opts.profile.trim() : null
+
+  createSessionWindow(sessionId.trim(), { profile, watch: opts?.watch === true })
 
   return { ok: true }
 })

--- a/apps/desktop/electron/session-windows.test.ts
+++ b/apps/desktop/electron/session-windows.test.ts
@@ -83,6 +83,18 @@ test('buildSessionWindowUrl adds the watch flag for spectator windows, before th
   assert.equal(url, 'http://localhost:5173/?win=secondary&watch=1#/abc')
 })
 
+test('buildSessionWindowUrl adds the owning profile before the hash route', () => {
+  const url = buildSessionWindowUrl('abc', { devServer: 'http://localhost:5173', profile: 'research profile' })
+
+  assert.equal(url, 'http://localhost:5173/?win=secondary&profile=research%20profile#/abc')
+})
+
+test('buildSessionWindowUrl keeps profile and watch flags before the hash route', () => {
+  const url = buildSessionWindowUrl('abc', { devServer: 'http://localhost:5173', profile: 'research', watch: true })
+
+  assert.equal(url, 'http://localhost:5173/?win=secondary&profile=research&watch=1#/abc')
+})
+
 test('buildSessionWindowUrl routes new-session windows to the draft (#/)', () => {
   const url = buildSessionWindowUrl(null, { devServer: 'http://localhost:5173', newSession: true })
 

--- a/apps/desktop/electron/session-windows.ts
+++ b/apps/desktop/electron/session-windows.ts
@@ -39,11 +39,29 @@ function chatWindowWebPreferences(preloadPath: string) {
 // treated as the route by HashRouter and would break routeSessionId(). The
 // renderer reads the flag from window.location.search to suppress the install /
 // onboarding overlays and the global session sidebar. `new=1` marks the compact
-// scratch window; `watch=1` marks a spectator window (e.g. a running subagent's
-// session): the renderer resumes it lazily so the gateway never builds an agent
-// just to stream into it.
-function buildSessionWindowUrl(sessionId: string, { devServer, rendererIndexPath, watch, newSession }: any = {}) {
-  const query = `?win=secondary${newSession ? '&new=1' : ''}${watch ? '&watch=1' : ''}`
+// scratch window; `profile` pins a stored-session window to the owning profile;
+// `watch=1` marks a spectator window (e.g. a running subagent's session): the
+// renderer resumes it lazily so the gateway never builds an agent just to
+// stream into it.
+function buildSessionWindowUrl(
+  sessionId: null | string,
+  { devServer, rendererIndexPath, watch, newSession, profile }: any = {}
+) {
+  const queryParts = ['win=secondary']
+
+  if (newSession) {
+    queryParts.push('new=1')
+  }
+
+  if (typeof profile === 'string' && profile.trim()) {
+    queryParts.push(`profile=${encodeURIComponent(profile.trim())}`)
+  }
+
+  if (watch) {
+    queryParts.push('watch=1')
+  }
+
+  const query = `?${queryParts.join('&')}`
   const route = newSession ? '#/' : `#/${encodeURIComponent(sessionId)}`
 
   if (devServer) {

--- a/apps/desktop/src/app/chat/sidebar/session-actions-menu.tsx
+++ b/apps/desktop/src/app/chat/sidebar/session-actions-menu.tsx
@@ -126,7 +126,7 @@ function useSessionActions({
             label: r.newWindow,
             onSelect: () => {
               triggerHaptic('selection')
-              void openSessionInNewWindow(sessionId)
+              void openSessionInNewWindow(sessionId, { profile })
             }
           }
         ]

--- a/apps/desktop/src/app/chat/sidebar/session-row.tsx
+++ b/apps/desktop/src/app/chat/sidebar/session-row.tsx
@@ -171,7 +171,7 @@ export function SidebarSessionRow({
               event.preventDefault()
               event.stopPropagation()
               triggerHaptic('selection')
-              void openSessionInNewWindow(session.id)
+              void openSessionInNewWindow(session.id, { profile: session.profile })
 
               return
             }

--- a/apps/desktop/src/app/desktop-controller.tsx
+++ b/apps/desktop/src/app/desktop-controller.tsx
@@ -73,7 +73,7 @@ import {
 import { onSessionsChanged } from '../store/session-sync'
 import { clearSessionTodos, setSessionTodos, todosForHydration } from '../store/todos'
 import { openUpdatesWindow, startUpdatePoller, stopUpdatePoller } from '../store/updates'
-import { isSecondaryWindow } from '../store/windows'
+import { isSecondaryWindow, secondaryWindowProfile } from '../store/windows'
 
 import { ChatView } from './chat'
 import { requestComposerFocus, requestComposerInsert } from './chat/composer/focus'
@@ -207,6 +207,7 @@ export function DesktopController() {
   const narrowViewport = useMediaQuery(SIDEBAR_COLLAPSE_MEDIA_QUERY)
 
   const routedSessionId = routeSessionId(location.pathname)
+  const routedSessionProfile = secondaryWindowProfile()
   const routeToken = `${location.pathname}:${location.search}:${location.hash}`
   const routeTokenRef = useRef(routeToken)
   routeTokenRef.current = routeToken
@@ -854,6 +855,7 @@ export function DesktopController() {
 
   useGatewayBoot({
     handleGatewayEvent: handleDesktopGatewayEvent,
+    initialProfile: routedSessionProfile,
     onConnectionReady: c => {
       connectionRef.current = c
     },
@@ -965,6 +967,7 @@ export function DesktopController() {
     resumeSession,
     resumeFailedSessionId,
     resumeExhaustedSessionId,
+    routeProfile: routedSessionProfile,
     routedSessionId,
     runtimeIdByStoredSessionIdRef,
     selectedStoredSessionId,

--- a/apps/desktop/src/app/gateway/hooks/use-gateway-boot.test.tsx
+++ b/apps/desktop/src/app/gateway/hooks/use-gateway-boot.test.tsx
@@ -105,9 +105,10 @@ function fakeDesktop() {
   }
 }
 
-function Harness() {
+function Harness({ initialProfile = null }: { initialProfile?: null | string } = {}) {
   useGatewayBoot({
     handleGatewayEvent: () => undefined,
+    initialProfile,
     onConnectionReady: () => undefined,
     onGatewayReady: () => undefined,
     refreshHermesConfig: async () => undefined,
@@ -162,6 +163,16 @@ async function advanceBackoff() {
 }
 
 describe('useGatewayBoot remote reconnect loop (real hook, fake socket)', () => {
+  it('uses a secondary-window profile hint for the first backend connection', async () => {
+    const desktop = fakeDesktop()
+    ;(window as { hermesDesktop?: unknown }).hermesDesktop = desktop
+
+    render(<Harness initialProfile="research" />)
+    await flushAsync()
+
+    expect(desktop.getConnection).toHaveBeenCalledWith('research')
+  })
+
   it('INITIAL boot against a dead VPS: getConnection hangs (waitForHermes) → app sits in the connecting combo, then fails', async () => {
     // The report's actual path: a fresh launch pointed at an unreachable VPS.
     // startHermes()'s remote branch awaits waitForHermes() for 45s before it

--- a/apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts
+++ b/apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts
@@ -50,6 +50,7 @@ const RECONNECT_ESCALATE_AFTER = 6
 
 interface GatewayBootOptions {
   handleGatewayEvent: (event: RpcEvent) => void
+  initialProfile?: null | string
   onConnectionReady: (
     connection: Awaited<ReturnType<NonNullable<typeof window.hermesDesktop>['getConnection']>> | null
   ) => void
@@ -60,6 +61,7 @@ interface GatewayBootOptions {
 
 export function useGatewayBoot({
   handleGatewayEvent,
+  initialProfile = null,
   onConnectionReady,
   onGatewayReady,
   refreshHermesConfig,
@@ -96,6 +98,10 @@ export function useGatewayBoot({
 
       return () => void (cancelled = true)
     }
+
+    const initialProfileKey = normalizeProfileKey(initialProfile || $activeGatewayProfile.get())
+    const initialProfileHint = initialProfile?.trim() ? initialProfileKey : undefined
+    $activeGatewayProfile.set(initialProfileKey)
 
     // --- Reconnect-after-sleep machinery -------------------------------------
     // macOS sleep silently drops the renderer's WebSocket. The backend Python
@@ -226,10 +232,11 @@ export function useGatewayBoot({
     // resumes are no-op swaps and reconnects target the right backend.
     // Best-effort: a missing preference means "default". Shared by boot + soft
     // switch.
-    async function adoptPrimaryProfile() {
+    async function adoptPrimaryProfile(profileHint?: null | string) {
       try {
-        const pref = await desktop.profile?.get?.()
-        const profileKey = (pref?.profile ?? '').trim() || 'default'
+        const hintedProfile = profileHint?.trim() ? normalizeProfileKey(profileHint) : ''
+        const pref = hintedProfile ? null : await desktop.profile?.get?.()
+        const profileKey = hintedProfile || (pref?.profile ?? '').trim() || 'default'
         $activeGatewayProfile.set(profileKey)
         setPrimaryGateway(gateway, profileKey)
         void ensureGatewayForProfile(profileKey)
@@ -327,7 +334,7 @@ export function useGatewayBoot({
 
     const gateway = new HermesGateway()
     callbacksRef.current.onGatewayReady(gateway)
-    setPrimaryGateway(gateway, normalizeProfileKey($activeGatewayProfile.get()))
+    setPrimaryGateway(gateway, initialProfileKey)
     // Secondary (background-profile) sockets funnel into the same handler.
     configureGatewayRegistry({ onEvent: event => callbacksRef.current.handleGatewayEvent(event) })
 
@@ -357,7 +364,7 @@ export function useGatewayBoot({
       }
     })
 
-    const sourceProfile = normalizeProfileKey($activeGatewayProfile.get())
+    const sourceProfile = initialProfileKey
     const offEvent = gateway.onEvent(event => callbacksRef.current.handleGatewayEvent({ ...event, profile: sourceProfile }))
 
     // Wake signals: power resume (macOS/Windows), network coming back, and the
@@ -431,7 +438,7 @@ export function useGatewayBoot({
 
     async function boot() {
       try {
-        const conn = await desktop.getConnection()
+        const conn = await desktop.getConnection(initialProfileHint)
 
         if (cancelled) {
           return
@@ -455,7 +462,7 @@ export function useGatewayBoot({
           return
         }
 
-        await adoptPrimaryProfile()
+        await adoptPrimaryProfile(initialProfileHint)
 
         setDesktopBootStep({
           phase: 'renderer.config',

--- a/apps/desktop/src/app/session/hooks/use-route-resume.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-route-resume.test.tsx
@@ -14,9 +14,10 @@ interface HarnessProps {
   freshDraftReady: boolean
   gatewayState: string
   locationPathname: string
-  resumeSession: (sessionId: string, focus: boolean) => Promise<unknown>
+  resumeSession: (sessionId: string, focus: boolean, profileHint?: string | null) => Promise<unknown>
   resumeFailedSessionId?: null | string
   resumeExhaustedSessionId?: null | string
+  routeProfile?: string | null
   routedSessionId: null | string
   runtimeIdByStoredSessionIdRef: MutableRefObject<Map<string, string>>
   selectedStoredSessionId: null | string
@@ -139,7 +140,7 @@ describe('useRouteResume', () => {
     )
 
     expect(resumeSession).toHaveBeenCalledTimes(1)
-    expect(resumeSession).toHaveBeenCalledWith('session-1', true)
+    expect(resumeSession).toHaveBeenCalledWith('session-1', true, undefined)
   })
 
   it('resumes when pathname changes to a routed session', () => {
@@ -189,7 +190,38 @@ describe('useRouteResume', () => {
     )
 
     expect(resumeSession).toHaveBeenCalledTimes(1)
-    expect(resumeSession).toHaveBeenCalledWith('session-2', true)
+    expect(resumeSession).toHaveBeenCalledWith('session-2', true, undefined)
+  })
+
+  it('passes the secondary window profile hint into routed resume', () => {
+    const resumeSession = vi.fn(async () => undefined)
+    const startFreshSessionDraft = vi.fn()
+    const activeSessionIdRef: MutableRefObject<null | string> = { current: null }
+    const creatingSessionRef = { current: false }
+    const runtimeIdByStoredSessionIdRef = { current: new Map() }
+    const selectedStoredSessionIdRef: MutableRefObject<null | string> = { current: null }
+
+    render(
+      <RouteResumeHarness
+        activeSessionId={null}
+        activeSessionIdRef={activeSessionIdRef}
+        creatingSessionRef={creatingSessionRef}
+        currentView="chat"
+        freshDraftReady
+        gatewayState="open"
+        locationPathname="/session-2"
+        resumeSession={resumeSession}
+        routeProfile="research"
+        routedSessionId="session-2"
+        runtimeIdByStoredSessionIdRef={runtimeIdByStoredSessionIdRef}
+        selectedStoredSessionId={null}
+        selectedStoredSessionIdRef={selectedStoredSessionIdRef}
+        startFreshSessionDraft={startFreshSessionDraft}
+      />
+    )
+
+    expect(resumeSession).toHaveBeenCalledTimes(1)
+    expect(resumeSession).toHaveBeenCalledWith('session-2', true, 'research')
   })
 
   it('resumes the selected route again when the gateway reconnects', () => {
@@ -257,7 +289,7 @@ describe('useRouteResume', () => {
     )
 
     expect(resumeSession).toHaveBeenCalledTimes(1)
-    expect(resumeSession).toHaveBeenCalledWith('session-1', true)
+    expect(resumeSession).toHaveBeenCalledWith('session-1', true, undefined)
   })
 })
 
@@ -307,7 +339,7 @@ describe('useRouteResume bounded auto-retry after a failed resume', () => {
     // First backoff window (1s) elapses → one retry.
     vi.advanceTimersByTime(1_000)
     expect(resumeSession).toHaveBeenCalledTimes(1)
-    expect(resumeSession).toHaveBeenCalledWith('session-1', true)
+    expect(resumeSession).toHaveBeenCalledWith('session-1', true, undefined)
   })
 
   it('does NOT retry a failed session that is not the routed one', () => {

--- a/apps/desktop/src/app/session/hooks/use-route-resume.ts
+++ b/apps/desktop/src/app/session/hooks/use-route-resume.ts
@@ -11,7 +11,7 @@ interface RouteResumeOptions {
   freshDraftReady: boolean
   gatewayState: string | undefined
   locationPathname: string
-  resumeSession: (sessionId: string, focus: boolean) => Promise<unknown>
+  resumeSession: (sessionId: string, focus: boolean, profileHint?: string | null) => Promise<unknown>
   // Stored-session id whose most recent resume failed terminally (set by
   // useSessionActions, mirrored from $resumeFailedSessionId). While this equals
   // routedSessionId the window would otherwise latch on the loader forever, so
@@ -23,6 +23,7 @@ interface RouteResumeOptions {
   // armed->cleared edge is an unambiguous "give me a fresh backoff cycle"
   // signal the effect below uses to reset the attempt counter.
   resumeExhaustedSessionId: string | null
+  routeProfile?: string | null
   routedSessionId: string | null
   runtimeIdByStoredSessionIdRef: MutableRefObject<Map<string, string>>
   selectedStoredSessionId: string | null
@@ -76,6 +77,7 @@ export function useRouteResume({
   resumeSession,
   resumeFailedSessionId,
   resumeExhaustedSessionId,
+  routeProfile,
   routedSessionId,
   runtimeIdByStoredSessionIdRef,
   selectedStoredSessionId,
@@ -147,7 +149,7 @@ export function useRouteResume({
       // rebinds/reaps the session on its side, and trusting it strands Desktop on
       // a dead id ("session not found"). Otherwise keep skipping when already active.
       if ((gatewayBecameOpen || !alreadyActive) && shouldResume && !creatingSessionRef.current) {
-        void resumeSession(routedSessionId, true)
+        void resumeSession(routedSessionId, true, routeProfile)
       }
 
       return
@@ -170,6 +172,7 @@ export function useRouteResume({
     gatewayState,
     locationPathname,
     resumeSession,
+    routeProfile,
     routedSessionId,
     runtimeIdByStoredSessionIdRef,
     selectedStoredSessionId,
@@ -267,7 +270,7 @@ export function useRouteResume({
       // having fired. A flapping backend could then hit MAX in a couple of
       // re-renders with far fewer than MAX real attempts. (Point 3)
       retryAttemptRef.current += 1
-      void resumeSession(sessionId, true)
+      void resumeSession(sessionId, true, routeProfile)
     }, resumeRetryDelayMs(attempt))
 
     return () => clearTimeout(timer)
@@ -279,6 +282,7 @@ export function useRouteResume({
     resumeSession,
     resumeFailedSessionId,
     resumeExhaustedSessionId,
+    routeProfile,
     routedSessionId,
     selectedStoredSessionIdRef
   ])

--- a/apps/desktop/src/global.d.ts
+++ b/apps/desktop/src/global.d.ts
@@ -30,7 +30,10 @@ declare global {
       // with an error code when the sessionId is empty/invalid. `watch` opens
       // a spectator window (lazy resume — no agent build) for live-streaming
       // a running subagent's session.
-      openSessionWindow: (sessionId: string, opts?: { watch?: boolean }) => Promise<{ ok: boolean; error?: string }>
+      openSessionWindow: (
+        sessionId: string,
+        opts?: { profile?: string | null; watch?: boolean }
+      ) => Promise<{ ok: boolean; error?: string }>
       // Open (or focus) a compact secondary window on the new-session draft.
       openNewSessionWindow: () => Promise<{ ok: boolean; error?: string }>
       // The pop-out pet overlay: a transparent always-on-top window hosting only

--- a/apps/desktop/src/store/windows.test.ts
+++ b/apps/desktop/src/store/windows.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-import { canOpenSessionWindow, openNewSessionInNewWindow, openSessionInNewWindow } from './windows'
+import { canOpenSessionWindow, openNewSessionInNewWindow, openSessionInNewWindow, secondaryWindowProfile } from './windows'
 
 const desktopWindow = window as unknown as { hermesDesktop?: Window['hermesDesktop'] }
 const initialHermesDesktop = desktopWindow.hermesDesktop
@@ -89,6 +89,16 @@ describe('openSessionInNewWindow', () => {
     expect(notifyError).not.toHaveBeenCalled()
   })
 
+  it('forwards the owning profile for secondary session windows', async () => {
+    const open = vi.fn().mockResolvedValue({ ok: true })
+    installBridge(open)
+
+    await openSessionInNewWindow('s1', { profile: 'research' })
+
+    expect(open).toHaveBeenCalledWith('s1', { profile: 'research' })
+    expect(notifyError).not.toHaveBeenCalled()
+  })
+
   it('notifies on an ok:false result', async () => {
     installBridge(vi.fn().mockResolvedValue({ ok: false, error: 'invalid-session-id' }))
 
@@ -103,6 +113,14 @@ describe('openSessionInNewWindow', () => {
     await openSessionInNewWindow('s1')
 
     expect(notifyError).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('secondaryWindowProfile', () => {
+  it('reads the profile hint from the window query string', () => {
+    window.history.replaceState(null, '', '/?win=secondary&profile=research#/s1')
+
+    expect(secondaryWindowProfile()).toBe('research')
   })
 })
 

--- a/apps/desktop/src/store/windows.ts
+++ b/apps/desktop/src/store/windows.ts
@@ -72,6 +72,28 @@ export function isWatchWindow(): boolean {
   return result
 }
 
+let secondaryWindowProfileCache: string | null | undefined
+
+export function secondaryWindowProfile(): string | null {
+  if (secondaryWindowProfileCache !== undefined) {
+    return secondaryWindowProfileCache
+  }
+
+  let result: string | null = null
+
+  try {
+    const profile = new URLSearchParams(window.location.search).get('profile')?.trim()
+
+    result = profile || null
+  } catch {
+    result = null
+  }
+
+  secondaryWindowProfileCache = result
+
+  return result
+}
+
 // True when running inside the Electron desktop shell (the preload bridge is
 // present). The "open in new window" affordance is desktop-only.
 export function canOpenSessionWindow(): boolean {
@@ -97,7 +119,10 @@ async function openWindow(call: () => Promise<WindowOpenResult>, failMessage: st
 // Open (or focus) a standalone OS window for a single chat session. No-ops
 // gracefully outside Electron so callers can wire it unconditionally.
 // `watch: true` opens a spectator window (lazy resume, live-mirror stream).
-export async function openSessionInNewWindow(sessionId: string, opts?: { watch?: boolean }): Promise<void> {
+export async function openSessionInNewWindow(
+  sessionId: string,
+  opts?: { profile?: string | null; watch?: boolean }
+): Promise<void> {
   if (!sessionId || !canOpenSessionWindow()) {
     return
   }


### PR DESCRIPTION
## Summary

Pass the owning profile through desktop secondary session windows so opening a stored session in a new window resumes it against the correct profile context.

Previously, `openSessionInNewWindow()` only forwarded `sessionId` and `watch`, while the secondary-window URL and route-resume path had no profile hint. That meant a pop-out window could fall back to the active/default profile during cold resume, which is wrong for profile-scoped sessions.

## Changes

- Forward `profile` from session-row and session-actions-menu into the desktop bridge.
- Include `profile=` in the secondary-window URL before the hash route.
- Read the profile hint in the renderer and pass it into routed resume.
- Prefer the hinted profile during session lookup and gateway swap.
- Key the secondary-window registry by profile + session id so same-id sessions from different profiles cannot collide.
- Add regressions for URL construction, bridge forwarding, and routed resume hinting.

## Tests

```text
node --test apps/desktop/electron/session-windows.test.cjs
npm run test:ui -- src/store/windows.test.ts src/app/session/hooks/use-route-resume.test.tsx
npm run typecheck