### PR TITLE
feat: surface Z.AI account quota usage

### DIFF
--- a/agent/account_usage.py
+++ b/agent/account_usage.py
@@ -617,6 +617,104 @@ def _fetch_openrouter_account_usage(base_url: Optional[str], api_key: Optional[s
     )
 
 
+def _zai_reset_ms(value: Any) -> Optional[datetime]:
+    if isinstance(value, (int, float)) and not isinstance(value, bool):
+        # Z.AI returns epoch milliseconds for quota reset times.
+        return datetime.fromtimestamp(float(value) / 1000.0, tz=timezone.utc)
+    return _parse_dt(value)
+
+
+def _zai_window_label(item: dict[str, Any]) -> str:
+    kind = str(item.get("type") or "").strip().upper()
+    unit = item.get("unit")
+    number = item.get("number")
+    if kind == "TOKENS_LIMIT" and unit == 3 and number == 5:
+        return "5h tokens"
+    if kind == "TOKENS_LIMIT" and unit == 6 and number == 1:
+        return "Weekly tokens"
+    if kind == "TIME_LIMIT":
+        return "MCP/tools"
+    return kind.replace("_", " ").title() or "Quota"
+
+
+def _fetch_zai_account_usage(
+    base_url: Optional[str], api_key: Optional[str]
+) -> Optional[AccountUsageSnapshot]:
+    """Z.AI (GLM Coding Plan) quota snapshot.
+
+    Uses the official monitor endpoint consumed by Z.AI usage trackers. The
+    endpoint returns plan tier plus percentage-used windows for token quotas and
+    MCP/tool usage. If Z.AI changes or disables the endpoint, failures are caught
+    by fetch_account_usage and the quota block disappears rather than displaying
+    invented numbers.
+    """
+    runtime = resolve_runtime_provider(
+        requested="zai",
+        explicit_base_url=base_url,
+        explicit_api_key=api_key,
+    )
+    token = str(runtime.get("api_key", "") or "").strip()
+    if not token:
+        return None
+
+    headers = {
+        "Authorization": f"Bearer {token}",
+        "Accept": "application/json",
+    }
+    with httpx.Client(timeout=10.0) as client:
+        response = client.get(
+            "https://api.z.ai/api/monitor/usage/quota/limit", headers=headers
+        )
+        response.raise_for_status()
+    payload = response.json() or {}
+    if payload.get("success") is False:
+        return AccountUsageSnapshot(
+            provider="zai",
+            source="quota_api",
+            fetched_at=_utc_now(),
+            title="Z.AI (GLM) quotas",
+            unavailable_reason=str(payload.get("msg") or "quota API unavailable"),
+        )
+    data = payload.get("data") or {}
+    windows: list[AccountUsageWindow] = []
+    details: list[str] = []
+    for item in data.get("limits") or ():
+        if not isinstance(item, dict):
+            continue
+        pct = item.get("percentage")
+        try:
+            used_percent = float(pct) if pct is not None else None
+        except (TypeError, ValueError):
+            used_percent = None
+        detail = None
+        if item.get("remaining") is not None and item.get("currentValue") is not None:
+            detail = f"remaining {item.get('remaining')} / used {item.get('currentValue')}"
+        windows.append(
+            AccountUsageWindow(
+                label=_zai_window_label(item),
+                used_percent=used_percent,
+                reset_at=_zai_reset_ms(item.get("nextResetTime")),
+                detail=detail,
+            )
+        )
+        for usage_detail in item.get("usageDetails") or ():
+            if isinstance(usage_detail, dict) and usage_detail.get("modelCode"):
+                details.append(
+                    f"{usage_detail.get('modelCode')}: {usage_detail.get('usage', 0)}"
+                )
+
+    details.append("Usage dashboard: https://z.ai/manage-apikey/subscription")
+    return AccountUsageSnapshot(
+        provider="zai",
+        source="quota_api",
+        fetched_at=_utc_now(),
+        title="Z.AI (GLM) quotas",
+        plan=_title_case_slug(data.get("level")),
+        windows=tuple(windows),
+        details=tuple(details),
+    )
+
+
 def fetch_account_usage(
     provider: Optional[str],
     *,
@@ -633,6 +731,8 @@ def fetch_account_usage(
             return _fetch_anthropic_account_usage()
         if normalized == "openrouter":
             return _fetch_openrouter_account_usage(base_url, api_key)
+        if normalized in {"zai", "glm", "z-ai", "z.ai", "zhipu"}:
+            return _fetch_zai_account_usage(base_url, api_key)
     except Exception:
         return None
     return None

--- a/hermes_cli/status.py
+++ b/hermes_cli/status.py
@@ -165,12 +165,15 @@ def show_status(args):
             continue
         value = _resolve_env(env_ref)
         has_key = bool(value)
-        display = redact_key(value) if not show_all else value
+        # Never print raw secrets, even with --all. Status output is commonly
+        # pasted into bug reports, audits, logs, and agent contexts; --all may
+        # expand optional sections but must not become a secret-dump mode.
+        display = redact_key(value)
         print(f"  {name:<12}  {check_mark(has_key)} {display}")
 
     from hermes_cli.auth import get_anthropic_key
     anthropic_value = get_anthropic_key()
-    anthropic_display = redact_key(anthropic_value) if not show_all else anthropic_value
+    anthropic_display = redact_key(anthropic_value)
     print(f"  {'Anthropic':<12}  {check_mark(bool(anthropic_value))} {anthropic_display}")
 
     # =========================================================================

--- a/tests/agent/test_zai_account_usage.py
+++ b/tests/agent/test_zai_account_usage.py
@@ -1,0 +1,112 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import httpx
+
+from agent.account_usage import (
+    _zai_reset_ms,
+    _zai_window_label,
+    fetch_account_usage,
+    render_account_usage_lines,
+)
+
+
+def test_zai_reset_ms_parses_epoch_milliseconds():
+    assert _zai_reset_ms(1781719502287) == datetime.fromtimestamp(
+        1781719502287 / 1000.0, tz=timezone.utc
+    )
+
+
+def test_zai_window_labels_known_limit_shapes():
+    assert _zai_window_label({"type": "TOKENS_LIMIT", "unit": 3, "number": 5}) == "5h tokens"
+    assert _zai_window_label({"type": "TOKENS_LIMIT", "unit": 6, "number": 1}) == "Weekly tokens"
+    assert _zai_window_label({"type": "TIME_LIMIT"}) == "MCP/tools"
+
+
+def test_zai_fetch_renders_real_quota_api(monkeypatch):
+    monkeypatch.setattr(
+        "agent.account_usage.resolve_runtime_provider",
+        lambda **_: {"api_key": "zai-test-key", "base_url": "https://api.z.ai/api/coding/paas/v4"},
+    )
+
+    seen = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen["url"] = str(request.url)
+        seen["auth"] = request.headers.get("Authorization")
+        return httpx.Response(
+            200,
+            json={
+                "code": 200,
+                "msg": "Operation successful",
+                "success": True,
+                "data": {
+                    "level": "pro",
+                    "limits": [
+                        {
+                            "type": "TOKENS_LIMIT",
+                            "unit": 3,
+                            "number": 5,
+                            "percentage": 2,
+                            "nextResetTime": 1781719502287,
+                        },
+                        {
+                            "type": "TOKENS_LIMIT",
+                            "unit": 6,
+                            "number": 1,
+                            "percentage": 1,
+                            "nextResetTime": 1782306187986,
+                        },
+                        {
+                            "type": "TIME_LIMIT",
+                            "unit": 5,
+                            "number": 1,
+                            "currentValue": 0,
+                            "remaining": 1000,
+                            "percentage": 0,
+                            "nextResetTime": 1784293387993,
+                            "usageDetails": [
+                                {"modelCode": "search-prime", "usage": 0},
+                                {"modelCode": "web-reader", "usage": 0},
+                            ],
+                        },
+                    ],
+                },
+            },
+        )
+
+    original_client = httpx.Client
+    monkeypatch.setattr(
+        httpx,
+        "Client",
+        lambda *args, **kwargs: original_client(transport=httpx.MockTransport(handler)),
+    )
+
+    snapshot = fetch_account_usage("zai")
+    assert snapshot is not None
+    assert snapshot.provider == "zai"
+    assert snapshot.source == "quota_api"
+    assert snapshot.plan == "Pro"
+    assert [w.label for w in snapshot.windows] == ["5h tokens", "Weekly tokens", "MCP/tools"]
+    assert snapshot.windows[0].used_percent == 2.0
+    assert "search-prime: 0" in snapshot.details
+    assert "web-reader: 0" in snapshot.details
+    assert seen == {
+        "url": "https://api.z.ai/api/monitor/usage/quota/limit",
+        "auth": "Bearer zai-test-key",
+    }
+
+    lines = render_account_usage_lines(snapshot)
+    assert lines[0] == "📈 Z.AI (GLM) quotas"
+    assert "Provider: zai (Pro)" in lines
+    assert any("5h tokens: 98% remaining (2% used)" in line for line in lines)
+    assert any("Usage dashboard: https://z.ai/manage-apikey/subscription" == line for line in lines)
+
+
+def test_zai_fetch_none_without_key(monkeypatch):
+    monkeypatch.setattr(
+        "agent.account_usage.resolve_runtime_provider",
+        lambda **_: {"api_key": "", "base_url": "https://api.z.ai/api/coding/paas/v4"},
+    )
+    assert fetch_account_usage("glm") is None

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -6159,6 +6159,29 @@ def _(rid, params: dict) -> dict:
             usage["credits_lines"] = credits
     except Exception:
         pass
+
+    # Provider account limits (openai-codex / anthropic / openrouter / zai …) —
+    # the same block the CLI and gateway /usage render. Resolved from the
+    # resident agent's provider/base_url/api_key, so it appears whenever a live
+    # agent backs the session. Fail-open: omitted on any error or when no agent
+    # is resident.
+    try:
+        from agent.account_usage import fetch_account_usage, render_account_usage_lines
+
+        if agent is not None:
+            _provider = getattr(agent, "provider", None)
+            if _provider:
+                _snapshot = fetch_account_usage(
+                    _provider,
+                    base_url=getattr(agent, "base_url", None),
+                    api_key=getattr(agent, "api_key", None),
+                )
+                if _snapshot:
+                    _account_lines = render_account_usage_lines(_snapshot)
+                    if _account_lines:
+                        usage["account_lines"] = _account_lines
+    except Exception:
+        pass
     return _ok(rid, usage)
 
 

--- a/ui-tui/src/app/slash/commands/session.ts
+++ b/ui-tui/src/app/slash/commands/session.ts
@@ -584,6 +584,13 @@ export const sessionCommands: SlashCommand[] = [
         // present, before the token panel.
         const creditsLines = r?.credits_lines ?? []
 
+        // Provider account limits (openai-codex / anthropic / openrouter / zai …) —
+        // the same block the CLI and gateway /usage render. Also agent-resolved,
+        // so it can appear before the first API call (e.g. a configured GLM key).
+        const accountLines = r?.account_lines ?? []
+        if (accountLines.length) {
+          ctx.transcript.panel('Account limits', [{ text: accountLines.join('\n') }])
+        }
         if (creditsLines.length) {
           ctx.transcript.panel('Nous credits', [{ text: creditsLines.join('\n') }])
         }

--- a/ui-tui/src/gatewayTypes.ts
+++ b/ui-tui/src/gatewayTypes.ts
@@ -316,6 +316,7 @@ export interface SessionUndoResponse {
 
 export interface SessionUsageResponse {
   active_subagents?: number
+  account_lines?: string[]
   cache_read?: number
   cache_write?: number
   calls?: number


### PR DESCRIPTION
## Summary
- add Z.AI/GLM account quota snapshots to the shared account-usage renderer
- expose provider account quota lines in the TUI `/usage` response/panel
- keep `hermes status --all` from printing raw API keys

## Verification
```bash
PYTHONPATH=/home/kavi/.hermes/hermes-agent /tmp/hermes-pr-test-venv/bin/python -m pytest tests/hermes_cli/test_status.py tests/hermes_cli/test_status_model_provider.py tests/agent/test_zai_account_usage.py -q -o 'addopts='
# 27 passed

PYTHONPATH=/home/kavi/.hermes/hermes-agent /tmp/hermes-pr-test-venv/bin/python -m pytest tests/tools/test_execute_code_approval_cluster.py -q -o 'addopts='
# 20 passed

npm run typecheck --prefix ui-tui
```
