### PR TITLE
fix(compression): guard feasibility auto-lower against unresolved aux context

### DIFF
--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -164,7 +164,13 @@ def check_compression_model_feasibility(agent: Any) -> None:
             )
 
         threshold = agent.context_compressor.threshold_tokens
-        if aux_context < threshold:
+        # Guard against an unresolved aux context (get_model_context_length can
+        # yield 0/None): the floor check above is itself gated on `aux_context`
+        # being truthy, so a falsy value reaches here un-vetted. Without this
+        # guard, `0 < threshold` would silently set the session threshold to 0
+        # (breaking compression for the whole session) and `None < threshold`
+        # would raise TypeError during AIAgent.__init__.
+        if aux_context and aux_context < threshold:
             # Auto-correct: lower the live session threshold so
             # compression actually works this session.  The hard floor
             # above guarantees aux_context >= MINIMUM_CONTEXT_LENGTH,


### PR DESCRIPTION
## Bug

`check_compression_model_feasibility()` in `agent/conversation_compression.py`
resolves the auxiliary compression model''s context window, then auto-lowers the
session threshold to fit it. Two adjacent checks treat the resolved value
**inconsistently**:

```python
# Hard floor - GUARDS against a falsy aux_context (0 / None):
if aux_context and aux_context < MINIMUM_CONTEXT_LENGTH:
    raise ValueError(...)

threshold = agent.context_compressor.threshold_tokens
# Auto-lower - does NOT guard:
if aux_context < threshold:
    ...
    new_threshold = aux_context
    agent.context_compressor.threshold_tokens = new_threshold
```

`get_model_context_length()` can return a falsy value when the aux model''s
context can''t be resolved. The floor check explicitly handles that with
`if aux_context and ...`, but the auto-lower block does not - and its comment
even claims *"The hard floor above guarantees aux_context >= MINIMUM_CONTEXT_LENGTH"*,
which is false precisely because that floor is skipped for a falsy `aux_context`.

So when `aux_context` is unresolved:

- **`aux_context == 0`** ? `0 < threshold` is `True` ? the block runs and sets
  `threshold_tokens = 0`, **breaking compression for the entire session**
  (and `aux_context / main_ctx` becomes a meaningless 0%).
- **`aux_context is None`** ? `None < threshold` raises
  `TypeError: '<' not supported between instances of 'NoneType' and 'int'`
  **during `AIAgent.__init__`**.

## Fix

Apply the same truthiness guard the floor check uses:

```python
if aux_context and aux_context < threshold:
```

Now the auto-lower only runs for a real, positive context value. As a bonus
the existing comment becomes accurate: reaching the block implies `aux_context`
is truthy and passed the floor, so it really is `>= MINIMUM_CONTEXT_LENGTH`.
When the context is unresolved, the function simply leaves the threshold
unchanged (the pre-existing default behavior) instead of zeroing it or crashing.

## Verification

- Confirmed on current `main`: the floor check (line ~164) uses
  `if aux_context and ...` while the auto-lower (line ~177) uses a bare
  `if aux_context < threshold:`.
- Confirmed `get_model_context_length()` is typed to return `int | None` and
  has branches that can yield a non-positive / unset value.
- One-line behavioral guard; no change for the normal (resolved-context) path.