### PR TITLE
feat: add runtime context layer

### DIFF
--- a/agent/runtime_context_layer.py
+++ b/agent/runtime_context_layer.py
@@ -1,0 +1,349 @@
+from __future__ import annotations
+
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+from agent.timeline_sync import (
+    _decode_preview,
+    _default_db_path,
+    _format_duration,
+    _format_time,
+    _coerce_now,
+    describe_elapsed,
+    get_last_user_message_time,
+    get_recent_events,
+)
+
+
+def _block(name: str, lines: list[str]) -> str:
+    return "\n".join([f"[{name}]", *lines, f"[/{name}]"])
+
+
+def _bool_text(value: bool) -> str:
+    return "true" if value else "false"
+
+
+def _as_text_list(values: list[str]) -> str:
+    return ", ".join(v for v in values if v)
+
+
+def _gap_short_label(seconds: float | None) -> str:
+    if seconds is None:
+        return "unknown"
+    seconds = max(0.0, float(seconds))
+    if seconds < 120:
+        return "immediate"
+    if seconds < 30 * 60:
+        return "short_pause"
+    if seconds < 6 * 3600:
+        return "same_day_pause"
+    if seconds < 24 * 3600:
+        return "long_same_day_pause"
+    return "older_pause"
+
+
+def _reply_mode_for_gap(seconds: float | None) -> str:
+    if seconds is None:
+        return "direct_answer"
+    if seconds < 120:
+        return "direct_answer"
+    if seconds < 30 * 60:
+        return "light_resume"
+    if seconds < 6 * 3600:
+        return "recap_resume"
+    return "full_recap"
+
+
+def _timing_phrase_guidance(seconds: float | None) -> tuple[list[str], list[str], str]:
+    if seconds is None:
+        return ["earlier", "to continue", "to pick this back up"], ["just now"], "Use neutral continuation wording."
+    if seconds < 120:
+        return ["to continue", "on that"], ["last time"], "Treat as a live continuation."
+    if seconds < 30 * 60:
+        return ["earlier", "to continue", "picking this up"], ["just now", "right now"], "Use light continuation wording without over-recapping."
+    return ["earlier", "to pick this back up", "returning to this"], ["just now", "right now", "a moment ago"], "Briefly restore context before continuing."
+
+
+def _korean_phrase_guidance(seconds: float | None) -> tuple[list[str], list[str]]:
+    if seconds is not None and seconds < 120:
+        return ["이어가면", "그 흐름에서"], ["지난번", "오랜만"]
+    if seconds is not None and seconds < 30 * 60:
+        return ["아까", "조금 전", "이어가면"], ["오랜만", "지난번"]
+    return ["전에", "이어가면", "다시 잡아보면"], ["방금", "지금 막", "바로 전", "바로"]
+
+
+def _recent_user_previews(conversation_history: list[dict[str, Any]] | None, user_message: str = "") -> list[str]:
+    previews: list[str] = []
+    for msg in reversed(conversation_history or []):
+        if not isinstance(msg, dict) or msg.get("role") != "user":
+            continue
+        preview = _decode_preview(msg.get("content"), max_chars=90)
+        if preview and preview not in previews:
+            previews.append(preview)
+        if len(previews) >= 3:
+            break
+    current_preview = _decode_preview(user_message, max_chars=90) if user_message else ""
+    if current_preview and current_preview not in previews:
+        previews.insert(0, current_preview)
+    return previews[:3]
+
+
+def build_timeline_sync_block(
+    *,
+    db_path: str | Path | None = None,
+    now: Any = None,
+    session_id: str = "",
+    platform: str = "",
+    recent_window_minutes: int = 30,
+    max_events: int = 8,
+    include_other_platforms: bool = True,
+) -> str:
+    current = _coerce_now(now)
+    path = Path(db_path) if db_path else _default_db_path()
+    current_ts = current.timestamp()
+    last_user_ts = get_last_user_message_time(db_path=path, session_id=session_id)
+    elapsed = describe_elapsed(current_ts - last_user_ts) if last_user_ts else None
+
+    lines = [f"Current real time: {current.strftime('%Y-%m-%d %H:%M:%S %Z').strip()}."]
+    if platform:
+        lines.append(f"Current platform: {platform}.")
+    if session_id:
+        lines.append(f"Current session: {session_id}.")
+    if elapsed:
+        lines.append(f"Elapsed since last user message in this session: {elapsed.text}.")
+        lines.append(f"Interpretation: {elapsed.guidance}")
+    else:
+        lines.append("Elapsed since last user message in this session: unknown.")
+
+    if include_other_platforms:
+        since_ts = current_ts - max(0, int(recent_window_minutes)) * 60
+        events = get_recent_events(
+            db_path=path,
+            since_ts=since_ts,
+            limit=max_events,
+            exclude_session_id=session_id or None,
+        )
+        if events:
+            lines.append(f"Recent cross-platform events in the last {recent_window_minutes} minutes:")
+            for event in events:
+                source = str(event.get("source") or "unknown").upper()
+                when = _format_time(float(event["timestamp"]), current)
+                preview = event.get("preview") or "(empty)"
+                lines.append(f"- {when} {source}: {preview}")
+        else:
+            lines.append(f"Recent cross-platform events in the last {recent_window_minutes} minutes: none found.")
+    lines.append('Instruction: use real elapsed time when saying "just now", "earlier", or "last time". Avoid saying "just now" when the gap is not immediate.')
+    return _block("Timeline sync", lines)
+
+
+def build_rhythm_context_block(
+    *,
+    now: Any = None,
+    last_user_ts: float | None = None,
+    platform: str = "",
+    recent_events: list[dict[str, Any]] | None = None,
+) -> str:
+    current = _coerce_now(now)
+    elapsed_seconds = current.timestamp() - last_user_ts if last_user_ts else None
+    gap = describe_elapsed(elapsed_seconds) if elapsed_seconds is not None else None
+    reply_mode = _reply_mode_for_gap(elapsed_seconds)
+    gap_bucket = _gap_short_label(elapsed_seconds)
+    gap_display = gap.text if gap else "unknown"
+    baseline_seconds = 5 * 60
+    gap_vs_baseline = "unknown"
+    if elapsed_seconds is not None:
+        gap_vs_baseline = "longer_than_usual" if elapsed_seconds > baseline_seconds * 1.5 else "within_baseline"
+    lines = [
+        f"Gap: {gap_display} ({gap_bucket})",
+        f"Baseline gap: {_format_duration(baseline_seconds)}",
+        f"Gap vs baseline: {gap_vs_baseline}",
+        "Burst score: 0.00",
+        "Crossed day boundary: false",
+        "Silence meaning: attention_shift" if elapsed_seconds and elapsed_seconds >= 120 else "Silence meaning: continuous_thread",
+        f"Reply mode: {reply_mode}",
+        "Instruction: Acknowledge the pause only if useful, then continue the thread.",
+    ]
+    if recent_events:
+        lines.append("Recent rhythm events:")
+        for event in recent_events[:5]:
+            event_ts = float(event.get("timestamp") or 0.0)
+            age = describe_elapsed(current.timestamp() - event_ts).text
+            source = event.get("source") or platform or "unknown"
+            role = event.get("role") or "user"
+            preview = event.get("preview") or "(empty)"
+            lines.append(f"- {age} ago {source}/{role} — {preview}")
+    return _block("Rhythm context", lines)
+
+
+def build_expression_context_block(*, elapsed_seconds: float | None = None) -> str:
+    prefer, avoid = _korean_phrase_guidance(elapsed_seconds)
+    _, _, instruction = _timing_phrase_guidance(elapsed_seconds)
+    return _block(
+        "Expression context",
+        [
+            f"Prefer: {_as_text_list(prefer)}",
+            f"Avoid: {_as_text_list(avoid)}",
+            f"Instruction: {instruction}",
+        ],
+    )
+
+
+def build_first_line_context_block(*, reply_mode: str, elapsed_seconds: float | None = None) -> str:
+    suggested = "이어가면" if reply_mode in {"light_resume", "recap_resume", "full_recap"} else ""
+    lines = [
+        f"Suggested first line: {suggested or '(none)'}",
+        "Task mode: answer_request",
+        "Instruction: Use only when it fits the answer; do not force it.",
+    ]
+    return _block("First-line context", lines)
+
+
+def build_reply_hygiene_block(*, platform: str = "") -> str:
+    chat_platform = platform.lower() in {"telegram", "slack", "discord", "whatsapp", "signal", "matrix"}
+    return _block(
+        "Reply hygiene",
+        [
+            f"Send progress: {_bool_text(not chat_platform)}",
+            "Repeat source quote: false",
+            "Final report style: grouped_completion",
+            "Allow question: false",
+            "Max question count: 0",
+            "Keep thread context: false",
+            "Instruction: Avoid progress bubbles and repeated quotes; put the useful result in the final answer.",
+        ],
+    )
+
+
+def build_tone_precision_block(*, reply_mode: str) -> str:
+    level = "neutral" if reply_mode in {"direct_answer", "light_resume"} else "careful"
+    return _block(
+        "Tone precision",
+        [
+            f"Level: {level}",
+            "Do: answer_request, avoid_wrapper_echo",
+            "Avoid: unsupported_timeline_claim, repeated_source_quote",
+            "Instruction: Answer the request without echoing platform or context wrapper text.",
+        ],
+    )
+
+
+def build_return_tone_block(*, reply_mode: str) -> str:
+    state_gap = reply_mode in {"recap_resume", "full_recap"}
+    return _block(
+        "Return tone",
+        [
+            "Style: neutral_helpful" if not state_gap else "Style: warm_grounded_reentry",
+            "Opening intent: answer_normally" if not state_gap else "Opening intent: restore_then_continue",
+            f"State gap: {_bool_text(state_gap)}",
+            "Cautions: avoid_wrapper_echo, avoid_unverified_memory_claim",
+            "Instruction: Answer normally and keep platform wrapper text out of the reply." if not state_gap else "Instruction: Briefly restore the working context, then continue in a warm but grounded tone.",
+        ],
+    )
+
+
+def build_presence_guard_block(*, elapsed_seconds: float | None = None) -> str:
+    risk = "low" if elapsed_seconds is not None and elapsed_seconds < 120 else "guarded"
+    return _block(
+        "Presence guard",
+        [
+            f"Risk level: {risk}",
+            "Avoid presence claims: 방금, 지금 막, 바로",
+            "Instruction: Avoid claiming real-time presence or immediate continuity unless the gap is short.",
+        ],
+    )
+
+
+def build_scratchpad_leak_guard_block() -> str:
+    return _block(
+        "Scratchpad leak guard",
+        [
+            "Risk level: strict",
+            "Do not send internal planning notes, scratchpad fragments, or tool-operation comments to the user.",
+            "Avoid examples: Need..., Run..., Implement..., Add in build, Tool warning, patch notes before final.",
+            "Instruction: Use tool calls silently; send only the final user-facing summary after verification.",
+        ],
+    )
+
+
+def build_platform_digest_block(*, platform: str = "", conversation_history: list[dict[str, Any]] | None = None, user_message: str = "") -> str:
+    previews = _recent_user_previews(conversation_history, user_message)
+    if not previews:
+        previews = ["(none)"]
+    lines = [f"{platform or 'current'}:"]
+    for preview in previews:
+        lines.append(f"- user: {preview}")
+    return _block("Platform digest", lines)
+
+
+def build_memory_guard_block(*, user_message: str = "") -> str:
+    text = str(user_message or "").strip()
+    lower = text.lower()
+    wrapper_markers = ("[timeline sync]", "[rhythm context]", "[reply hygiene]", "[memory guard]")
+    category = "do_not_persist" if lower.startswith(wrapper_markers) else "needs_review"
+    persist = "false"
+    return _block(
+        "Memory guard",
+        [
+            f"User message category: {category}",
+            "Requires live verification: false",
+            f"Persist to memory: {persist}",
+            "Instruction: Do not save live wrappers, temporary work state, or scratchpad leaks as durable memory.",
+        ],
+    )
+
+
+def build_runtime_context(
+    *,
+    db_path: str | Path | None = None,
+    now: Any = None,
+    session_id: str = "",
+    platform: str = "",
+    user_message: str = "",
+    conversation_history: list[dict[str, Any]] | None = None,
+    recent_window_minutes: int = 30,
+    max_events: int = 8,
+    include_other_platforms: bool = True,
+) -> str:
+    """Build the full ephemeral runtime context layer for one model turn."""
+    current = _coerce_now(now)
+    path = Path(db_path) if db_path else _default_db_path()
+    current_ts = current.timestamp()
+    last_user_ts = get_last_user_message_time(db_path=path, session_id=session_id)
+    elapsed_seconds = current_ts - last_user_ts if last_user_ts else None
+    since_ts = current_ts - max(0, int(recent_window_minutes)) * 60
+    recent_events = get_recent_events(
+        db_path=path,
+        since_ts=since_ts,
+        limit=max_events,
+        exclude_session_id=None,
+    )
+    reply_mode = _reply_mode_for_gap(elapsed_seconds)
+
+    blocks = [
+        build_timeline_sync_block(
+            db_path=path,
+            now=current,
+            session_id=session_id,
+            platform=platform,
+            recent_window_minutes=recent_window_minutes,
+            max_events=max_events,
+            include_other_platforms=include_other_platforms,
+        ),
+        build_rhythm_context_block(
+            now=current,
+            last_user_ts=last_user_ts,
+            platform=platform,
+            recent_events=recent_events,
+        ),
+        build_expression_context_block(elapsed_seconds=elapsed_seconds),
+        build_first_line_context_block(reply_mode=reply_mode, elapsed_seconds=elapsed_seconds),
+        build_reply_hygiene_block(platform=platform),
+        build_tone_precision_block(reply_mode=reply_mode),
+        build_return_tone_block(reply_mode=reply_mode),
+        build_presence_guard_block(elapsed_seconds=elapsed_seconds),
+        build_scratchpad_leak_guard_block(),
+        build_platform_digest_block(platform=platform, conversation_history=conversation_history, user_message=user_message),
+        build_memory_guard_block(user_message=user_message),
+    ]
+    return "\n\n".join(block for block in blocks if block)

--- a/agent/timeline_sync.py
+++ b/agent/timeline_sync.py
@@ -1,0 +1,271 @@
+from __future__ import annotations
+
+import json
+import os
+import sqlite3
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Iterable, Optional
+
+from hermes_constants import get_hermes_home
+
+
+@dataclass(frozen=True)
+class ElapsedDescription:
+    seconds: float
+    text: str
+    bucket: str
+    guidance: str
+
+
+def coerce_epoch_seconds(value: Any) -> Optional[float]:
+    """Best-effort conversion to epoch seconds."""
+    if value is None or isinstance(value, bool):
+        return None
+    if isinstance(value, datetime):
+        return float(value.timestamp())
+    if isinstance(value, (int, float)):
+        numeric = float(value)
+        return numeric / 1000.0 if numeric > 10_000_000_000 else numeric
+    if isinstance(value, str):
+        text = value.strip()
+        if not text:
+            return None
+        try:
+            numeric = float(text)
+            return numeric / 1000.0 if numeric > 10_000_000_000 else numeric
+        except ValueError:
+            pass
+        try:
+            return datetime.fromisoformat(text.replace("Z", "+00:00")).timestamp()
+        except ValueError:
+            return None
+    return None
+
+
+def _format_duration(seconds: float) -> str:
+    seconds = max(0, int(round(seconds)))
+    if seconds < 60:
+        return f"{seconds} seconds"
+    minutes, rem = divmod(seconds, 60)
+    if minutes < 60:
+        if rem:
+            return f"{minutes} minutes {rem} seconds"
+        return f"{minutes} minutes"
+    hours, minutes = divmod(minutes, 60)
+    if hours < 24:
+        if minutes:
+            return f"{hours} hours {minutes} minutes"
+        return f"{hours} hours"
+    days, hours = divmod(hours, 24)
+    if hours:
+        return f"{days} days {hours} hours"
+    return f"{days} days"
+
+
+def describe_elapsed(seconds: float | int | None) -> ElapsedDescription:
+    """Classify an elapsed time gap for language guidance."""
+    if seconds is None:
+        seconds = 0
+    seconds_f = max(0.0, float(seconds))
+    if seconds_f < 120:
+        bucket = "immediate"
+        guidance = "Treat this as a live continuation."
+    elif seconds_f < 30 * 60:
+        bucket = "recent"
+        guidance = "Treat this as recent, but do not assume it happened just now."
+    elif seconds_f < 6 * 3600:
+        bucket = "earlier_today"
+        guidance = "Treat this as earlier today; state the gap if timing matters."
+    elif seconds_f < 24 * 3600:
+        bucket = "long_gap_today"
+        guidance = "Treat this as a long same-day gap; avoid saying it just happened."
+    else:
+        bucket = "older"
+        guidance = "Treat this as a prior-day or older context unless the user says otherwise."
+    return ElapsedDescription(
+        seconds=seconds_f,
+        text=_format_duration(seconds_f),
+        bucket=bucket,
+        guidance=guidance,
+    )
+
+
+def _default_db_path() -> Path:
+    override = os.getenv("HERMES_TIMELINE_SYNC_DB", "").strip()
+    if override:
+        return Path(override).expanduser()
+    return get_hermes_home() / "state.db"
+
+
+def _decode_preview(content: Any, max_chars: int = 120) -> str:
+    if content is None:
+        return ""
+    text = str(content)
+    if text.startswith("[") or text.startswith("{"):
+        try:
+            parsed = json.loads(text)
+            if isinstance(parsed, list):
+                parts: list[str] = []
+                for item in parsed:
+                    if isinstance(item, dict):
+                        value = item.get("text") or item.get("content") or ""
+                        if value:
+                            parts.append(str(value))
+                    elif item:
+                        parts.append(str(item))
+                text = " ".join(parts) or text
+            elif isinstance(parsed, dict):
+                text = str(parsed.get("text") or parsed.get("content") or text)
+        except Exception:
+            pass
+    text = " ".join(text.replace("\r", " ").replace("\n", " ").split())
+    return text[: max(0, max_chars - 1)] + "…" if len(text) > max_chars else text
+
+
+def get_last_user_message_time(*, db_path: str | Path | None = None, session_id: str) -> Optional[float]:
+    if not session_id:
+        return None
+    path = Path(db_path) if db_path else _default_db_path()
+    if not path.exists():
+        return None
+    try:
+        conn = sqlite3.connect(str(path))
+        row = conn.execute(
+            """
+            SELECT timestamp FROM messages
+            WHERE session_id = ? AND role = 'user'
+            ORDER BY timestamp DESC, id DESC
+            LIMIT 1
+            """,
+            (session_id,),
+        ).fetchone()
+        conn.close()
+    except sqlite3.Error:
+        return None
+    return float(row[0]) if row else None
+
+
+def get_recent_events(
+    *,
+    db_path: str | Path | None = None,
+    since_ts: float,
+    limit: int = 8,
+    exclude_session_id: str | None = None,
+    roles: Iterable[str] = ("user",),
+) -> list[dict[str, Any]]:
+    """Return recent cross-session events ordered by real timestamp."""
+    path = Path(db_path) if db_path else _default_db_path()
+    if not path.exists() or limit <= 0:
+        return []
+    role_values = tuple(roles) or ("user",)
+    placeholders = ",".join("?" for _ in role_values)
+    params: list[Any] = [float(since_ts), *role_values]
+    exclude_sql = ""
+    if exclude_session_id:
+        exclude_sql = "AND m.session_id != ?"
+        params.append(exclude_session_id)
+    params.append(int(limit))
+    try:
+        conn = sqlite3.connect(str(path))
+        conn.row_factory = sqlite3.Row
+        rows = conn.execute(
+            f"""
+            SELECT m.timestamp, s.source, m.session_id, m.role, m.content, s.title
+            FROM messages m
+            LEFT JOIN sessions s ON s.id = m.session_id
+            WHERE m.timestamp >= ?
+              AND m.role IN ({placeholders})
+              {exclude_sql}
+            ORDER BY m.timestamp DESC, m.id DESC
+            LIMIT ?
+            """,
+            params,
+        ).fetchall()
+        conn.close()
+    except sqlite3.Error:
+        return []
+    events: list[dict[str, Any]] = []
+    for row in rows:
+        events.append(
+            {
+                "timestamp": float(row["timestamp"]),
+                "source": row["source"] or "unknown",
+                "session_id": row["session_id"],
+                "role": row["role"],
+                "preview": _decode_preview(row["content"]),
+                "title": row["title"] or "",
+            }
+        )
+    return events
+
+
+def _format_time(ts: float, now: datetime) -> str:
+    tz = now.tzinfo or datetime.now().astimezone().tzinfo
+    return datetime.fromtimestamp(ts, tz=tz).strftime("%H:%M")
+
+
+def _coerce_now(now: Any = None) -> datetime:
+    if now is None:
+        return datetime.now().astimezone()
+    if isinstance(now, datetime):
+        return now if now.tzinfo else now.replace(tzinfo=datetime.now().astimezone().tzinfo)
+    epoch = coerce_epoch_seconds(now)
+    if epoch is None:
+        return datetime.now().astimezone()
+    return datetime.fromtimestamp(epoch, tz=timezone.utc).astimezone()
+
+
+def build_timeline_context(
+    *,
+    db_path: str | Path | None = None,
+    now: Any = None,
+    session_id: str = "",
+    platform: str = "",
+    recent_window_minutes: int = 30,
+    max_events: int = 8,
+    include_other_platforms: bool = True,
+) -> str:
+    """Build an ephemeral per-turn timeline context block."""
+    current = _coerce_now(now)
+    path = Path(db_path) if db_path else _default_db_path()
+    current_ts = current.timestamp()
+    last_user_ts = get_last_user_message_time(db_path=path, session_id=session_id)
+    elapsed = describe_elapsed(current_ts - last_user_ts) if last_user_ts else None
+
+    lines = [
+        "[Timeline sync]",
+        f"Current real time: {current.strftime('%Y-%m-%d %H:%M:%S %Z').strip()}.",
+    ]
+    if platform:
+        lines.append(f"Current platform: {platform}.")
+    if session_id:
+        lines.append(f"Current session: {session_id}.")
+    if elapsed:
+        lines.append(f"Elapsed since last user message in this session: {elapsed.text}.")
+        lines.append(f"Interpretation: {elapsed.guidance}")
+    else:
+        lines.append("Elapsed since last user message in this session: unknown.")
+
+    if include_other_platforms:
+        since_ts = current_ts - max(0, int(recent_window_minutes)) * 60
+        events = get_recent_events(
+            db_path=path,
+            since_ts=since_ts,
+            limit=max_events,
+            exclude_session_id=session_id or None,
+        )
+        if events:
+            lines.append(f"Recent cross-platform events in the last {recent_window_minutes} minutes:")
+            for event in events:
+                source = str(event.get("source") or "unknown").upper()
+                when = _format_time(float(event["timestamp"]), current)
+                preview = event.get("preview") or "(empty)"
+                lines.append(f"- {when} {source}: {preview}")
+        else:
+            lines.append(f"Recent cross-platform events in the last {recent_window_minutes} minutes: none found.")
+
+    lines.append('Instruction: use real elapsed time when saying "just now", "earlier", or "last time". Avoid saying "just now" when the gap is not immediate.')
+    lines.append("[/Timeline sync]")
+    return "\n".join(lines)

--- a/agent/timeline_sync.py
+++ b/agent/timeline_sync.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import os
+import re
 import sqlite3
 from dataclasses import dataclass
 from datetime import datetime, timezone
@@ -121,7 +122,68 @@ def _decode_preview(content: Any, max_chars: int = 120) -> str:
         except Exception:
             pass
     text = " ".join(text.replace("\r", " ").replace("\n", " ").split())
+    text = re.sub(r"\[Image attached at: [^\]]+\]", "[Image attached]", text)
     return text[: max(0, max_chars - 1)] + "…" if len(text) > max_chars else text
+
+
+def _is_synthetic_gateway_preview(preview: str) -> bool:
+    """Return True for gateway-maintenance text that should not shape time sense."""
+    text = " ".join(str(preview or "").strip().split()).lower()
+    if not text:
+        return True
+    synthetic_prefixes = (
+        "[system note:",
+        "[your active task list was preserved across context compression]",
+        "[context compaction",
+        "[timeline sync]",
+        "[rhythm context]",
+        "[expression context]",
+    )
+    if any(text.startswith(prefix) for prefix in synthetic_prefixes):
+        return True
+    synthetic_markers = (
+        "[thread context — prior messages in this thread",
+        "[thread context - prior messages in this thread",
+    )
+    return any(marker in text for marker in synthetic_markers)
+
+
+def _collapse_replay_clusters(
+    events: list[dict[str, Any]],
+    *,
+    max_span_seconds: float = 1.0,
+    min_cluster_size: int = 3,
+) -> list[dict[str, Any]]:
+    """Collapse same-source replay bursts caused by compression/session restore."""
+    if len(events) < min_cluster_size:
+        return events
+
+    ordered = sorted(events, key=lambda event: float(event.get("timestamp") or 0.0), reverse=True)
+    result: list[dict[str, Any]] = []
+    index = 0
+    while index < len(ordered):
+        first = ordered[index]
+        cluster = [first]
+        first_ts = float(first.get("timestamp") or 0.0)
+        source = str(first.get("source") or "")
+        role = str(first.get("role") or "")
+        next_index = index + 1
+        while next_index < len(ordered):
+            candidate = ordered[next_index]
+            candidate_ts = float(candidate.get("timestamp") or 0.0)
+            if source != str(candidate.get("source") or "") or role != str(candidate.get("role") or ""):
+                break
+            if abs(first_ts - candidate_ts) > max_span_seconds:
+                break
+            cluster.append(candidate)
+            next_index += 1
+
+        if len(cluster) >= min_cluster_size:
+            result.append(cluster[0])
+        else:
+            result.extend(cluster)
+        index = next_index
+    return result
 
 
 def get_last_user_message_time(*, db_path: str | Path | None = None, session_id: str) -> Optional[float]:
@@ -166,7 +228,8 @@ def get_recent_events(
     if exclude_session_id:
         exclude_sql = "AND m.session_id != ?"
         params.append(exclude_session_id)
-    params.append(int(limit))
+    query_limit = max(int(limit), int(limit) * 4)
+    params.append(query_limit)
     try:
         conn = sqlite3.connect(str(path))
         conn.row_factory = sqlite3.Row
@@ -188,17 +251,20 @@ def get_recent_events(
         return []
     events: list[dict[str, Any]] = []
     for row in rows:
+        preview = _decode_preview(row["content"])
+        if _is_synthetic_gateway_preview(preview):
+            continue
         events.append(
             {
                 "timestamp": float(row["timestamp"]),
                 "source": row["source"] or "unknown",
                 "session_id": row["session_id"],
                 "role": row["role"],
-                "preview": _decode_preview(row["content"]),
+                "preview": preview,
                 "title": row["title"] or "",
             }
         )
-    return events
+    return _collapse_replay_clusters(events)[: int(limit)]
 
 
 def _format_time(ts: float, now: datetime) -> str:

--- a/agent/transports/codex.py
+++ b/agent/transports/codex.py
@@ -89,15 +89,17 @@ class ResponsesApiTransport(ProviderTransport):
         _effort_clamp = {"minimal": "low"}
         reasoning_effort = _effort_clamp.get(reasoning_effort, reasoning_effort)
 
+        converted_tools = _responses_tools(tools)
         kwargs = {
             "model": model,
             "instructions": instructions,
             "input": _chat_messages_to_responses_input(payload_messages),
-            "tools": _responses_tools(tools),
-            "tool_choice": "auto",
-            "parallel_tool_calls": True,
             "store": False,
         }
+        if converted_tools:
+            kwargs["tools"] = converted_tools
+            kwargs["tool_choice"] = "auto"
+            kwargs["parallel_tool_calls"] = True
 
         session_id = params.get("session_id")
         if not is_github_responses and session_id:

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -32,12 +32,32 @@ _AUDIO_EXTS = frozenset({'.ogg', '.opus', '.mp3', '.wav', '.m4a', '.flac'})
 # delivered as a regular document.
 _TELEGRAM_AUDIO_ATTACHMENT_EXTS = frozenset({'.mp3', '.m4a'})
 _TELEGRAM_VOICE_EXTS = frozenset({'.ogg', '.opus'})
+_TELEGRAM_TYPING_MAX_SECONDS_DEFAULT = 30.0
 
 
 def _platform_name(platform) -> str:
     """Normalize a Platform enum / raw string into a lowercase name."""
     value = getattr(platform, "value", platform)
     return str(value or "").lower()
+
+
+def _telegram_typing_max_seconds() -> float | None:
+    """Return Telegram's max continuous typing refresh duration.
+
+    Telegram has no explicit "stop typing" Bot API call; the indicator stops
+    only when the bot stops refreshing ``send_chat_action``.  Keep a short
+    default cap so an orphaned or very long gateway task cannot make one chat
+    look like Hermes is typing forever.  Set
+    ``HERMES_TELEGRAM_TYPING_MAX_SECONDS=0`` to opt out.
+    """
+    raw = os.getenv("HERMES_TELEGRAM_TYPING_MAX_SECONDS")
+    if raw is None or raw == "":
+        return _TELEGRAM_TYPING_MAX_SECONDS_DEFAULT
+    try:
+        value = float(raw)
+    except (TypeError, ValueError):
+        return _TELEGRAM_TYPING_MAX_SECONDS_DEFAULT
+    return value if value > 0 else None
 
 
 def _thread_metadata_for_source(source, reply_to_message_id: str | None = None) -> dict | None:
@@ -2173,9 +2193,21 @@ class BasePlatformAdapter(ABC):
         # gated on network health.  Must stay below ``interval`` so a slow
         # call gets abandoned before the next scheduled tick.
         _send_typing_timeout = max(0.25, min(1.5, interval - 0.25))
+        _loop = asyncio.get_running_loop()
+        _typing_started_at = _loop.time()
+        _max_typing_seconds = (
+            _telegram_typing_max_seconds()
+            if _platform_name(getattr(self, "platform", None)) == "telegram"
+            else None
+        )
         try:
             while True:
                 if stop_event is not None and stop_event.is_set():
+                    return
+                if (
+                    _max_typing_seconds is not None
+                    and _loop.time() - _typing_started_at >= _max_typing_seconds
+                ):
                     return
                 if chat_id not in self._typing_paused:
                     try:

--- a/gateway/platforms/slack.py
+++ b/gateway/platforms/slack.py
@@ -855,16 +855,52 @@ class SlackAdapter(BasePlatformAdapter):
         *,
         finalize: bool = False,
     ) -> SendResult:
-        """Edit a previously sent Slack message."""
+        """Edit a previously sent Slack message.
+
+        Slack's chat.update rejects payloads beyond MAX_MESSAGE_LENGTH with
+        ``msg_too_long``, which would otherwise abort the entire edit and
+        freeze the streamed message at whatever content was last accepted.
+        Truncate to the first chunk so the edit always succeeds; on the
+        finalize edit, post any overflow chunks as follow-up messages so
+        no content is dropped.
+        """
         if not self._app:
             return SendResult(success=False, error="Not connected")
         try:
             formatted = self.format_message(content)
+            chunks = self.truncate_message(formatted, self.MAX_MESSAGE_LENGTH)
+            head = chunks[0] if chunks else formatted
+            overflow = chunks[1:] if len(chunks) > 1 else []
+
             await self._get_client(chat_id).chat_update(
                 channel=chat_id,
                 ts=message_id,
-                text=formatted,
+                text=head,
             )
+
+            if overflow and finalize:
+                logger.warning(
+                    "[Slack] edit_message finalize: content (%d chars) "
+                    "exceeds %d limit; posting %d follow-up chunk(s).",
+                    len(formatted),
+                    self.MAX_MESSAGE_LENGTH,
+                    len(overflow),
+                )
+                for chunk in overflow:
+                    try:
+                        await self._get_client(chat_id).chat_postMessage(
+                            channel=chat_id,
+                            text=chunk,
+                            mrkdwn=True,
+                        )
+                    except Exception as post_err:
+                        logger.error(
+                            "[Slack] Follow-up chunk post failed in %s: %s",
+                            chat_id,
+                            post_err,
+                            exc_info=True,
+                        )
+
             if finalize:
                 await self.stop_typing(chat_id)
             return SendResult(success=True, message_id=message_id)

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -14685,6 +14685,48 @@ class GatewayRunner:
         else:
             _status_thread_metadata = self._thread_metadata_for_source(source, event_message_id) if _progress_thread_id else None
 
+        def _looks_like_internal_interim_note(text: str) -> bool:
+            """Return True for terse agent scratchpad notes that should stay in logs.
+
+            Some providers emit planning fragments through the interim-assistant
+            callback (for example, "Need patch." or "Run tests.").  Chat
+            gateways must not turn those into user-visible bubbles.
+            """
+            candidate = str(text or "").strip()
+            if not candidate:
+                return True
+            if "\n" in candidate or len(candidate) > 120:
+                return False
+            lowered = candidate.lower().rstrip(".!… ")
+            internal_prefixes = (
+                "need ",
+                "run ",
+                "now ",
+                "use ",
+                "maybe ",
+                "patch ",
+                "commit ",
+                "restart ",
+                "test ",
+                "smoke ",
+            )
+            internal_phrases = (
+                "need patch",
+                "run commit",
+                "run tests",
+                "now restart gateway",
+                "need maybe",
+                "need introduce",
+                "need all tests",
+            )
+            if lowered in internal_phrases:
+                return True
+            # Keep this intentionally narrow: only imperative, short,
+            # punctuation-light fragments with no human-facing connective text.
+            if lowered.startswith(internal_prefixes) and len(lowered.split()) <= 6:
+                return True
+            return False
+
         def _status_callback_sync(event_type: str, message: str) -> None:
             if not _status_adapter or not _run_still_current():
                 return
@@ -14853,6 +14895,9 @@ class GatewayRunner:
 
             def _interim_assistant_cb(text: str, *, already_streamed: bool = False) -> None:
                 if not _run_still_current():
+                    return
+                if not already_streamed and _looks_like_internal_interim_note(text):
+                    logger.debug("suppressed internal interim assistant note")
                     return
                 if _stream_consumer is not None:
                     if already_streamed:
@@ -15571,9 +15616,18 @@ class GatewayRunner:
                     except Exception:
                         pass
                 try:
+                    _language = str(display_config.get("language") or "").strip().lower()
+                    if _language in {"ko", "kr", "korean", "한국어"}:
+                        if _elapsed_mins <= 0:
+                            _elapsed_text = "1분 미만"
+                        else:
+                            _elapsed_text = f"{_elapsed_mins}분"
+                        _notice = f"⏳ 아직 작업 중이에요. ({_elapsed_text} 경과)"
+                    else:
+                        _notice = f"⏳ Still working... ({_elapsed_mins} min elapsed{_status_detail})"
                     _notify_res = await _notify_adapter.send(
                         source.chat_id,
-                        f"⏳ Still working... ({_elapsed_mins} min elapsed{_status_detail})",
+                        _notice,
                         metadata=_status_thread_metadata,
                     )
                     if (

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2559,6 +2559,25 @@ class GatewayRunner:
             except Exception:
                 pass  # don't let interrupt failure block the ack
 
+        # Low-noise chat mode: the user's message was processed above
+        # (queued/steered/interrupted), but we skip the explanatory busy ack.
+        # This prevents operational phrases such as "Interrupting current
+        # task" from leaking into Telegram/Slack when the platform is
+        # configured for important-only notifications.
+        try:
+            _cfg = _load_gateway_config()
+            _display = _cfg.get("display", {}) if isinstance(_cfg, dict) else {}
+            _platform_key = _platform_config_key(event.source.platform)
+            _platform_cfg = ((_display.get("platforms") or {}).get(_platform_key) or {})
+            _notifications = str(
+                _platform_cfg.get("notifications", _display.get("notifications", "all"))
+            ).strip().lower()
+            if _notifications in {"important", "quiet", "silent"}:
+                logger.debug("Busy ack suppressed by display notifications=%s for session %s", _notifications, session_key)
+                return True
+        except Exception:
+            pass
+
         # Check if busy ack is disabled — skip sending but still process the input.
         # Placed before debounce so we don't stamp a "last ack" timestamp that was
         # never actually delivered.
@@ -15586,9 +15605,9 @@ class GatewayRunner:
         # Periodic "still working" notifications for long-running tasks.
         # Fires every N seconds so the user knows the agent hasn't died.
         # Config: agent.gateway_notify_interval in config.yaml, or
-        # HERMES_AGENT_NOTIFY_INTERVAL env var.  Default 180s (3 min).
+        # HERMES_AGENT_NOTIFY_INTERVAL env var. Default 300s (5 min).
         # 0 = disable notifications.
-        _NOTIFY_INTERVAL_RAW = _float_env("HERMES_AGENT_NOTIFY_INTERVAL", 180)
+        _NOTIFY_INTERVAL_RAW = _float_env("HERMES_AGENT_NOTIFY_INTERVAL", 300)
         _NOTIFY_INTERVAL = _NOTIFY_INTERVAL_RAW if _NOTIFY_INTERVAL_RAW > 0 else None
         _notify_start = time.time()
 
@@ -15598,11 +15617,30 @@ class GatewayRunner:
             _notify_adapter = self.adapters.get(source.platform)
             if not _notify_adapter:
                 return
-            while True:
+            try:
+                _cfg = _load_gateway_config()
+                _display = _cfg.get("display", {}) if isinstance(_cfg, dict) else {}
+                _platform_key = _platform_config_key(source.platform)
+                _platform_cfg = ((_display.get("platforms") or {}).get(_platform_key) or {})
+                _notifications = str(
+                    _platform_cfg.get("notifications", _display.get("notifications", "all"))
+                ).strip().lower()
+                if _notifications in {"important", "quiet", "silent"}:
+                    return
+            except Exception:
+                pass
+            while _run_still_current() and not _interrupt_detected.is_set():
                 await asyncio.sleep(_NOTIFY_INTERVAL)
+                if not _run_still_current() or _interrupt_detected.is_set():
+                    return
                 _elapsed_mins = int((time.time() - _notify_start) // 60)
                 # Include agent activity context if available.
                 _agent_ref = agent_holder[0]
+                try:
+                    if _agent_ref is not None and getattr(_agent_ref, "is_interrupted", False):
+                        return
+                except Exception:
+                    pass
                 _status_detail = ""
                 if _agent_ref and hasattr(_agent_ref, "get_activity_summary"):
                     try:

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -439,10 +439,9 @@ DEFAULT_CONFIG = {
         # Sends a status message every N seconds so the user knows the
         # agent hasn't died during long tasks.  0 = disable notifications.
         # Lower values mean faster feedback on slow tasks but more chat
-        # noise; 180s is a compromise that catches spinning weak-model runs
-        # (60+ tool iterations with tiny output) before users assume the
-        # bot is dead and /restart.
-        "gateway_notify_interval": 180,
+        # noise; 300s keeps chat platforms quiet while still confirming
+        # that long tasks are alive before users assume the bot is dead.
+        "gateway_notify_interval": 300,
         # Freshness window for the gateway auto-continue note (seconds).
         # After a gateway crash/restart/SIGTERM mid-run, the next user
         # message gets a "[System note: your previous turn was

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -227,7 +227,7 @@ def _get_enabled_plugins() -> Optional[set]:
 # Data classes
 # ---------------------------------------------------------------------------
 
-_VALID_PLUGIN_KINDS: Set[str] = {"standalone", "backend", "exclusive", "platform", "model-provider"}
+_VALID_PLUGIN_KINDS: Set[str] = {"standalone", "core", "backend", "exclusive", "platform", "model-provider"}
 
 
 @dataclass
@@ -246,6 +246,8 @@ class PluginManifest:
     # Plugin kind — see plugins.py module docstring for semantics.
     # ``standalone`` (default): hooks/tools of its own; opt-in via
     #                           ``plugins.enabled``.
+    # ``core``: bundled Hermes behavior that must auto-load without mutating
+    #           user config (for example per-turn context sync hooks).
     # ``backend``: pluggable backend for an existing core tool (e.g.
     #              image_gen). Built-in (bundled) backends auto-load;
     #              user-installed still gated by ``plugins.enabled``.
@@ -824,7 +826,7 @@ class PluginManager:
             # Bundled platform plugins (gateway adapters like IRC) auto-load
             # for the same reason: every platform Hermes ships must be
             # available out of the box without the user having to opt in.
-            if manifest.source == "bundled" and manifest.kind in ("backend", "platform"):
+            if manifest.source == "bundled" and manifest.kind in ("backend", "platform", "core"):
                 self._load_plugin(manifest)
                 continue
 

--- a/hermes_cli/plugins_cmd.py
+++ b/hermes_cli/plugins_cmd.py
@@ -783,9 +783,15 @@ def cmd_list() -> None:
     table.add_column("Source", style="dim")
 
     for name, version, description, source, _dir in entries:
+        kind = ""
+        try:
+            manifest = _read_manifest(_dir)
+            kind = str(manifest.get("kind", "")).strip().lower()
+        except Exception:
+            kind = ""
         if name in disabled:
             status = "[red]disabled[/red]"
-        elif name in enabled:
+        elif name in enabled or (source == "bundled" and kind == "core"):
             status = "[green]enabled[/green]"
         else:
             status = "[yellow]not enabled[/yellow]"

--- a/hermes_cli/tips.py
+++ b/hermes_cli/tips.py
@@ -450,7 +450,7 @@ TIPS = [
 
     # --- Gateway Behavior Env Vars ---
     'HERMES_GATEWAY_BUSY_ACK_ENABLED=false silences the ⚡/⏳/⏩ ack messages when a user messages a busy agent.',
-    'HERMES_AGENT_NOTIFY_INTERVAL (default 180s) sets how often the gateway pings with progress on long turns.',
+    'HERMES_AGENT_NOTIFY_INTERVAL (default 300s) sets how often the gateway pings with progress on long turns.',
     'HERMES_RESTART_DRAIN_TIMEOUT (default 900s) caps how long /restart waits for in-flight runs before forcing.',
     'HERMES_CHECKPOINT_TIMEOUT (default 30s) caps filesystem checkpoint creation — raise it on huge monorepos.',
 

--- a/plugins/timeline_sync/__init__.py
+++ b/plugins/timeline_sync/__init__.py
@@ -5,7 +5,8 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
-from agent.timeline_sync import build_timeline_context, coerce_epoch_seconds
+from agent.runtime_context_layer import build_runtime_context
+from agent.timeline_sync import coerce_epoch_seconds
 
 
 def _env_disabled(value: str | None) -> bool:
@@ -79,11 +80,13 @@ def on_pre_llm_call(
             default_db = Path.home() / ".hermes" / "state.db"
         if not default_db.exists():
             return None
-    context = build_timeline_context(
+    context = build_runtime_context(
         db_path=db_path,
         now=_now_override(),
         session_id=session_id or "",
         platform=platform or "",
+        user_message=user_message or "",
+        conversation_history=conversation_history or [],
         recent_window_minutes=max(0, int(settings.get("recent_window_minutes", 30))),
         max_events=max(0, int(settings.get("max_events", 8))),
         include_other_platforms=bool(settings.get("include_other_platforms", True)),

--- a/plugins/timeline_sync/__init__.py
+++ b/plugins/timeline_sync/__init__.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+import os
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from agent.timeline_sync import build_timeline_context, coerce_epoch_seconds
+
+
+def _env_disabled(value: str | None) -> bool:
+    return str(value or "").strip().lower() in {"0", "false", "no", "off", "disabled"}
+
+
+def _get_config_value(config: dict[str, Any], key: str, default: Any) -> Any:
+    section = config.get("agent") if isinstance(config, dict) else None
+    if isinstance(section, dict) and key in section:
+        return section.get(key)
+    return default
+
+
+def _load_settings() -> dict[str, Any]:
+    settings = {
+        "enabled": True,
+        "recent_window_minutes": 30,
+        "max_events": 8,
+        "include_other_platforms": True,
+    }
+    try:
+        from hermes_cli.config import load_config
+
+        config = load_config()
+        settings["enabled"] = bool(_get_config_value(config, "timeline_sync_enabled", settings["enabled"]))
+        settings["recent_window_minutes"] = int(
+            _get_config_value(config, "timeline_sync_recent_window_minutes", settings["recent_window_minutes"])
+        )
+        settings["max_events"] = int(_get_config_value(config, "timeline_sync_max_events", settings["max_events"]))
+        settings["include_other_platforms"] = bool(
+            _get_config_value(config, "timeline_sync_include_other_platforms", settings["include_other_platforms"])
+        )
+    except Exception:
+        pass
+
+    env_enabled = os.getenv("HERMES_TIMELINE_SYNC_ENABLED")
+    if _env_disabled(env_enabled):
+        settings["enabled"] = False
+    return settings
+
+
+def _now_override() -> datetime | None:
+    raw = os.getenv("HERMES_TIMELINE_SYNC_NOW")
+    epoch = coerce_epoch_seconds(raw)
+    if epoch is None:
+        return None
+    return datetime.fromtimestamp(epoch, tz=timezone.utc)
+
+
+def on_pre_llm_call(
+    *,
+    session_id: str = "",
+    user_message: str = "",
+    conversation_history: list[dict[str, Any]] | None = None,
+    platform: str = "",
+    model: str = "",
+    **kwargs: Any,
+) -> dict[str, str] | None:
+    settings = _load_settings()
+    if not settings.get("enabled", True):
+        return None
+
+    db_override = os.getenv("HERMES_TIMELINE_SYNC_DB", "").strip()
+    db_path = Path(db_override).expanduser() if db_override else None
+    if db_path is None:
+        try:
+            from hermes_constants import get_hermes_home
+
+            default_db = get_hermes_home() / "state.db"
+        except Exception:
+            default_db = Path.home() / ".hermes" / "state.db"
+        if not default_db.exists():
+            return None
+    context = build_timeline_context(
+        db_path=db_path,
+        now=_now_override(),
+        session_id=session_id or "",
+        platform=platform or "",
+        recent_window_minutes=max(0, int(settings.get("recent_window_minutes", 30))),
+        max_events=max(0, int(settings.get("max_events", 8))),
+        include_other_platforms=bool(settings.get("include_other_platforms", True)),
+    )
+    if not context.strip():
+        return None
+    return {"context": context}
+
+
+def register(ctx) -> None:
+    ctx.register_hook("pre_llm_call", on_pre_llm_call)

--- a/plugins/timeline_sync/plugin.yaml
+++ b/plugins/timeline_sync/plugin.yaml
@@ -1,0 +1,7 @@
+name: timeline_sync
+version: "0.1.0"
+description: "Injects fresh real-world time and recent cross-platform context before each LLM turn."
+author: Hermes Agent
+kind: core
+hooks:
+  - pre_llm_call

--- a/run_agent.py
+++ b/run_agent.py
@@ -6617,6 +6617,41 @@ class AIAgent:
         """Execute one streaming Responses API request and return the final response."""
         import httpx as _httpx
 
+        # OpenAI SDK 2.28.x parse_response() crashes with
+        # `'NoneType' object is not iterable` when the ChatGPT codex backend
+        # (chatgpt.com/backend-api/codex) emits response.completed with
+        # response.output=None. Coerce None -> [] before the SDK sees it.
+        # Idempotent and safe to re-run.
+        try:
+            import openai.lib._parsing._responses as _hermes_p
+            if not getattr(_hermes_p, "_hermes_none_output_patched", False):
+                _hermes_orig_parse = _hermes_p.parse_response
+
+                def _hermes_safe_parse(*, text_format, input_tools, response):
+                    if getattr(response, "output", None) is None:
+                        try:
+                            response.output = []
+                        except Exception:
+                            try:
+                                object.__setattr__(response, "output", [])
+                            except Exception:
+                                pass
+                    return _hermes_orig_parse(
+                        text_format=text_format,
+                        input_tools=input_tools,
+                        response=response,
+                    )
+
+                _hermes_p.parse_response = _hermes_safe_parse
+                try:
+                    import openai.lib.streaming.responses._responses as _hermes_s
+                    _hermes_s.parse_response = _hermes_safe_parse
+                except Exception:
+                    pass
+                _hermes_p._hermes_none_output_patched = True
+        except Exception:
+            pass
+
         active_client = client or self._ensure_primary_openai_client(reason="codex_stream_direct")
         max_stream_retries = 1
         has_tool_calls = False
@@ -6734,6 +6769,27 @@ class AIAgent:
                     logger.debug(
                         "Responses stream did not emit response.completed; falling back to create(stream=True). %s",
                         self._client_log_context(),
+                    )
+                    return self._run_codex_create_stream_fallback(api_kwargs, client=active_client)
+                raise
+            except TypeError as exc:
+                # OpenAI SDK 2.28.x parse_response() raises
+                # `'NoneType' object is not iterable` when the ChatGPT codex
+                # backend (`chatgpt.com/backend-api/codex`) sends a
+                # `response.completed` event whose `response.output` is None
+                # (output items are streamed separately via
+                # `response.output_item.done`). Fall back to the raw
+                # `create(stream=True)` path which doesn't auto-parse.
+                import traceback as _tb
+                tb_text = "".join(_tb.format_tb(exc.__traceback__))
+                if (
+                    "openai/lib/_parsing/_responses.py" in tb_text
+                    or "openai/lib/streaming/responses/_responses.py" in tb_text
+                ):
+                    logger.debug(
+                        "Codex Responses stream hit OpenAI SDK None-output parser bug; "
+                        "falling back to create(stream=True). %s error=%s",
+                        self._client_log_context(), exc,
                     )
                     return self._run_codex_create_stream_fallback(api_kwargs, client=active_client)
                 raise

--- a/run_agent.py
+++ b/run_agent.py
@@ -6839,9 +6839,13 @@ class AIAgent:
                 if terminal_response is None and isinstance(event, dict):
                     terminal_response = event.get("response")
                 if terminal_response is not None:
-                    # Backfill empty output from collected stream events
+                    # Backfill empty/None output from collected stream events.
+                    # The chatgpt.com codex backend can send response.completed
+                    # with `output=None` (output items arrive via separate
+                    # response.output_item.done events), so treat None the same
+                    # as an empty list here.
                     _out = getattr(terminal_response, "output", None)
-                    if isinstance(_out, list) and not _out:
+                    if _out is None or (isinstance(_out, list) and not _out):
                         if collected_output_items:
                             terminal_response.output = list(collected_output_items)
                             logger.debug(

--- a/tests/agent/test_runtime_context_layer.py
+++ b/tests/agent/test_runtime_context_layer.py
@@ -1,0 +1,152 @@
+from __future__ import annotations
+
+import sqlite3
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+def _make_state_db(path: Path) -> None:
+    conn = sqlite3.connect(path)
+    conn.executescript(
+        """
+        CREATE TABLE sessions (
+            id TEXT PRIMARY KEY,
+            source TEXT NOT NULL,
+            title TEXT,
+            started_at REAL NOT NULL,
+            message_count INTEGER DEFAULT 0
+        );
+        CREATE TABLE messages (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            session_id TEXT NOT NULL,
+            role TEXT NOT NULL,
+            content TEXT,
+            timestamp REAL NOT NULL
+        );
+        """
+    )
+    conn.executemany(
+        "INSERT INTO sessions (id, source, title, started_at, message_count) VALUES (?, ?, ?, ?, ?)",
+        [
+            ("telegram-1", "telegram", "Telegram thread", 1.0, 2),
+            ("slack-1", "slack", "Slack thread", 1.0, 1),
+        ],
+    )
+    conn.executemany(
+        "INSERT INTO messages (session_id, role, content, timestamp) VALUES (?, ?, ?, ?)",
+        [
+            ("telegram-1", "user", "진행해줘", 1_700_000_000.0),
+            ("telegram-1", "assistant", "진행할게", 1_700_000_010.0),
+            ("slack-1", "user", "다른 채널 확인", 1_700_000_050.0),
+        ],
+    )
+    conn.commit()
+    conn.close()
+
+
+def test_build_runtime_context_contains_expected_blocks(tmp_path):
+    from agent.runtime_context_layer import build_runtime_context
+
+    db_path = tmp_path / "state.db"
+    _make_state_db(db_path)
+    now = datetime.fromtimestamp(1_700_000_600, tz=timezone.utc)
+
+    context = build_runtime_context(
+        db_path=db_path,
+        now=now,
+        session_id="telegram-1",
+        platform="telegram",
+        user_message="다음으로 진행해줘",
+        conversation_history=[{"role": "user", "content": "그럼 다음 작업은?"}],
+        recent_window_minutes=20,
+        max_events=5,
+    )
+
+    for header in [
+        "[Timeline sync]",
+        "[Rhythm context]",
+        "[Expression context]",
+        "[First-line context]",
+        "[Reply hygiene]",
+        "[Tone precision]",
+        "[Return tone]",
+        "[Presence guard]",
+        "[Scratchpad leak guard]",
+        "[Platform digest]",
+        "[Memory guard]",
+    ]:
+        assert header in context
+    assert "Current platform: telegram" in context
+    assert "Elapsed since last user message in this session: 10 minutes" in context
+    assert "Reply mode: light_resume" in context
+    assert "Send progress: false" in context
+    assert "Repeat source quote: false" in context
+    assert "다음으로 진행해줘" in context
+    assert "[Timeline sync]" in context and "[/Timeline sync]" in context
+
+
+def test_runtime_context_uses_fresh_time_and_does_not_reuse_stale_gap(tmp_path):
+    from agent.runtime_context_layer import build_runtime_context
+
+    db_path = tmp_path / "state.db"
+    _make_state_db(db_path)
+
+    first = build_runtime_context(
+        db_path=db_path,
+        now=datetime.fromtimestamp(1_700_000_060, tz=timezone.utc),
+        session_id="telegram-1",
+        platform="telegram",
+    )
+    second = build_runtime_context(
+        db_path=db_path,
+        now=datetime.fromtimestamp(1_700_000_600, tz=timezone.utc),
+        session_id="telegram-1",
+        platform="telegram",
+    )
+
+    assert "Elapsed since last user message in this session: 1 minutes" in first
+    assert "Elapsed since last user message in this session: 10 minutes" in second
+    assert first != second
+
+
+def test_memory_guard_marks_wrapper_only_message_do_not_persist(tmp_path):
+    from agent.runtime_context_layer import build_runtime_context
+
+    db_path = tmp_path / "state.db"
+    _make_state_db(db_path)
+
+    context = build_runtime_context(
+        db_path=db_path,
+        now=datetime.fromtimestamp(1_700_000_600, tz=timezone.utc),
+        session_id="telegram-1",
+        platform="telegram",
+        user_message="[Timeline sync]\nCurrent real time: stale\n[/Timeline sync]",
+    )
+
+    assert "[Memory guard]" in context
+    assert "User message category: do_not_persist" in context
+    assert "Persist to memory: false" in context
+
+
+def test_plugin_pre_llm_call_now_returns_full_runtime_layer(tmp_path, monkeypatch):
+    from plugins.timeline_sync import on_pre_llm_call
+
+    db_path = tmp_path / "state.db"
+    _make_state_db(db_path)
+    monkeypatch.setenv("HERMES_TIMELINE_SYNC_DB", str(db_path))
+    monkeypatch.setenv("HERMES_TIMELINE_SYNC_NOW", "1700000600")
+    monkeypatch.delenv("HERMES_TIMELINE_SYNC_ENABLED", raising=False)
+
+    result = on_pre_llm_call(
+        session_id="telegram-1",
+        user_message="진행해줘",
+        conversation_history=[{"role": "user", "content": "그럼 다음 작업은?"}],
+        platform="telegram",
+        model="test-model",
+    )
+
+    assert isinstance(result, dict)
+    assert "Timeline sync" in result["context"]
+    assert "Reply hygiene" in result["context"]
+    assert "Memory guard" in result["context"]
+    assert "Repeat source quote: false" in result["context"]

--- a/tests/agent/test_timeline_sync.py
+++ b/tests/agent/test_timeline_sync.py
@@ -1,0 +1,112 @@
+from __future__ import annotations
+
+import sqlite3
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+def _make_state_db(path: Path) -> None:
+    conn = sqlite3.connect(path)
+    conn.executescript(
+        """
+        CREATE TABLE sessions (
+            id TEXT PRIMARY KEY,
+            source TEXT NOT NULL,
+            title TEXT,
+            started_at REAL NOT NULL,
+            message_count INTEGER DEFAULT 0
+        );
+        CREATE TABLE messages (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            session_id TEXT NOT NULL,
+            role TEXT NOT NULL,
+            content TEXT,
+            timestamp REAL NOT NULL
+        );
+        """
+    )
+    rows = [
+        ("slack-1", "slack", "Slack memory thread", 1000.0, 2),
+        ("telegram-1", "telegram", "Telegram main", 1010.0, 2),
+        ("cli-1", "cli", "CLI check", 1020.0, 1),
+    ]
+    conn.executemany(
+        "INSERT INTO sessions (id, source, title, started_at, message_count) VALUES (?, ?, ?, ?, ?)",
+        rows,
+    )
+    messages = [
+        ("slack-1", "user", "너의 메모리 시스템은 어떻게 작동해?", 1_700_000_000.0),
+        ("slack-1", "assistant", "메모리 구조를 설명했어", 1_700_000_010.0),
+        ("telegram-1", "user", "클론잡 좀 꺼줘", 1_700_000_100.0),
+        ("telegram-1", "assistant", "작업 삭제 완료야", 1_700_000_120.0),
+        ("cli-1", "user", "한 단어로 답", 1_700_000_200.0),
+    ]
+    conn.executemany(
+        "INSERT INTO messages (session_id, role, content, timestamp) VALUES (?, ?, ?, ?)",
+        messages,
+    )
+    conn.commit()
+    conn.close()
+
+
+def test_coerce_epoch_seconds_accepts_datetime_and_milliseconds():
+    from agent.timeline_sync import coerce_epoch_seconds
+
+    dt = datetime.fromtimestamp(1_700_000_000, tz=timezone.utc)
+
+    assert coerce_epoch_seconds(dt) == 1_700_000_000.0
+    assert coerce_epoch_seconds(1_700_000_000_000) == 1_700_000_000.0
+    assert coerce_epoch_seconds("1700000000") == 1_700_000_000.0
+    assert coerce_epoch_seconds("bad") is None
+
+
+def test_describe_elapsed_uses_real_gap_buckets():
+    from agent.timeline_sync import describe_elapsed
+
+    assert describe_elapsed(75).bucket == "immediate"
+    assert describe_elapsed(600).bucket == "recent"
+    assert describe_elapsed(7200).bucket == "earlier_today"
+    assert describe_elapsed(30 * 3600).bucket == "older"
+
+
+def test_get_recent_events_orders_sources_by_real_time(tmp_path):
+    from agent.timeline_sync import get_recent_events
+
+    db_path = tmp_path / "state.db"
+    _make_state_db(db_path)
+
+    events = get_recent_events(
+        db_path=db_path,
+        since_ts=1_700_000_050.0,
+        limit=3,
+        exclude_session_id="telegram-1",
+    )
+
+    assert [event["source"] for event in events] == ["cli"]
+    assert events[0]["preview"] == "한 단어로 답"
+
+
+def test_build_timeline_context_includes_current_time_gap_and_cross_platform_events(tmp_path):
+    from agent.timeline_sync import build_timeline_context
+
+    db_path = tmp_path / "state.db"
+    _make_state_db(db_path)
+    now = datetime.fromtimestamp(1_700_000_500, tz=timezone.utc)
+
+    context = build_timeline_context(
+        db_path=db_path,
+        now=now,
+        session_id="telegram-1",
+        platform="telegram",
+        recent_window_minutes=10,
+        max_events=5,
+    )
+
+    assert "Timeline sync" in context
+    assert "Current real time:" in context
+    assert "Current platform: telegram" in context
+    assert "Elapsed since last user message in this session: 6 minutes 40 seconds" in context
+    assert "Recent cross-platform events" in context
+    assert "CLI" in context
+    assert "한 단어로 답" in context
+    assert "Avoid saying" in context

--- a/tests/agent/test_timeline_sync.py
+++ b/tests/agent/test_timeline_sync.py
@@ -110,3 +110,107 @@ def test_build_timeline_context_includes_current_time_gap_and_cross_platform_eve
     assert "CLI" in context
     assert "한 단어로 답" in context
     assert "Avoid saying" in context
+
+
+def test_get_recent_events_filters_gateway_synthetic_user_messages(tmp_path):
+    from agent.timeline_sync import get_recent_events
+
+    db_path = tmp_path / "state.db"
+    _make_state_db(db_path)
+    conn = sqlite3.connect(db_path)
+    conn.execute(
+        "INSERT INTO messages (session_id, role, content, timestamp) VALUES (?, ?, ?, ?)",
+        (
+            "slack-1",
+            "user",
+            "[System note: Your previous turn in this session was interrupted by a gateway restart.]",
+            1_700_000_300.0,
+        ),
+    )
+    conn.execute(
+        "INSERT INTO messages (session_id, role, content, timestamp) VALUES (?, ?, ?, ?)",
+        (
+            "slack-1",
+            "user",
+            "[Your active task list was preserved across context compression]\n- [>] verify",
+            1_700_000_301.0,
+        ),
+    )
+    conn.execute(
+        "INSERT INTO messages (session_id, role, content, timestamp) VALUES (?, ?, ?, ?)",
+        ("slack-1", "user", "실제 사용자가 보낸 말", 1_700_000_302.0),
+    )
+    conn.commit()
+    conn.close()
+
+    events = get_recent_events(db_path=db_path, since_ts=1_700_000_250.0, limit=5)
+
+    previews = [event["preview"] for event in events]
+    assert "실제 사용자가 보낸 말" in previews
+    assert not any("System note" in preview for preview in previews)
+    assert not any("active task list" in preview for preview in previews)
+
+
+def test_get_recent_events_collapses_same_second_replay_clusters(tmp_path):
+    from agent.timeline_sync import get_recent_events
+
+    db_path = tmp_path / "state.db"
+    _make_state_db(db_path)
+    conn = sqlite3.connect(db_path)
+    conn.execute(
+        "INSERT INTO sessions (id, source, title, started_at, message_count) VALUES (?, ?, ?, ?, ?)",
+        ("telegram-replay", "telegram", "Replay cluster", 1_700_000_250.0, 4),
+    )
+    for idx, content in enumerate(["예전 첫 메시지", "예전 둘째 메시지", "예전 셋째 메시지", "최신 대표 메시지"]):
+        conn.execute(
+            "INSERT INTO messages (session_id, role, content, timestamp) VALUES (?, ?, ?, ?)",
+            ("telegram-replay", "user", content, 1_700_000_300.0 + idx * 0.1),
+        )
+    conn.commit()
+    conn.close()
+
+    events = get_recent_events(db_path=db_path, since_ts=1_700_000_250.0, limit=8)
+
+    previews = [event["preview"] for event in events]
+    assert "최신 대표 메시지" in previews
+    assert "예전 첫 메시지" not in previews
+    assert "예전 둘째 메시지" not in previews
+    assert "예전 셋째 메시지" not in previews
+
+
+def test_get_recent_events_filters_thread_context_wrappers(tmp_path):
+    from agent.timeline_sync import get_recent_events
+
+    db_path = tmp_path / "state.db"
+    _make_state_db(db_path)
+    conn = sqlite3.connect(db_path)
+    conn.execute(
+        "INSERT INTO messages (session_id, role, content, timestamp) VALUES (?, ?, ?, ?)",
+        (
+            "slack-1",
+            "user",
+            '[Replying to: "새 어시스턴트 스레드"] [Thread context — prior messages in this thread (not yet in conversation history):] [thread noise]',
+            1_700_000_300.0,
+        ),
+    )
+    conn.execute(
+        "INSERT INTO messages (session_id, role, content, timestamp) VALUES (?, ?, ?, ?)",
+        ("slack-1", "user", "슬랙에서 실제로 한 말", 1_700_000_301.0),
+    )
+    conn.commit()
+    conn.close()
+
+    events = get_recent_events(db_path=db_path, since_ts=1_700_000_250.0, limit=5)
+
+    previews = [event["preview"] for event in events]
+    assert "슬랙에서 실제로 한 말" in previews
+    assert not any("Thread context" in preview for preview in previews)
+
+
+def test_decode_preview_removes_local_image_paths():
+    from agent.timeline_sync import _decode_preview
+
+    preview = _decode_preview("이미지 봐줘 [Image attached at: /Users/artifact/.hermes/image_cache/img_abc.jpg]")
+
+    assert "/Users/artifact" not in preview
+    assert "Image attached" in preview

--- a/tests/gateway/test_busy_session_ack.py
+++ b/tests/gateway/test_busy_session_ack.py
@@ -315,6 +315,32 @@ class TestBusySessionAck:
         assert agent.interrupt.call_count == 2
 
     @pytest.mark.asyncio
+    async def test_important_notifications_suppress_busy_ack_but_still_interrupts(self, monkeypatch):
+        """Important-only chat mode should process input without noisy busy ack text."""
+        import gateway.run as _gr
+
+        monkeypatch.setattr(
+            _gr,
+            "_load_gateway_config",
+            lambda: {"display": {"platforms": {"telegram": {"notifications": "important"}}}},
+        )
+        runner, sentinel = _make_runner()
+        runner._busy_input_mode = "interrupt"
+        adapter = _make_adapter()
+
+        event = _make_event(text="stop and answer this")
+        sk = build_session_key(event.source)
+        agent = MagicMock()
+        runner._running_agents[sk] = agent
+        runner.adapters[event.source.platform] = adapter
+
+        result = await runner._handle_active_session_busy_message(event, sk)
+
+        assert result is True
+        agent.interrupt.assert_called_once_with("stop and answer this")
+        adapter._send_with_retry.assert_not_called()
+
+    @pytest.mark.asyncio
     async def test_ack_after_cooldown_expires(self):
         """After 30s cooldown, a new message should send a fresh ack."""
         runner, sentinel = _make_runner()

--- a/tests/gateway/test_keep_typing_timeout.py
+++ b/tests/gateway/test_keep_typing_timeout.py
@@ -198,3 +198,38 @@ class TestKeepTypingTimeoutPerTick:
         assert calls == [], (
             f"send_typing was called on a paused chat: {calls}"
         )
+
+    @pytest.mark.asyncio
+    async def test_telegram_typing_refresh_stops_after_max_duration(self, monkeypatch):
+        """Telegram typing must not be refreshed forever.
+
+        Telegram has no explicit stop-typing call, so an orphaned keep-typing
+        task can make one DM look like Hermes is typing indefinitely. The
+        Telegram-specific cap lets the loop exit on its own even while the
+        outer gateway turn is still running.
+        """
+        monkeypatch.setenv("HERMES_TELEGRAM_TYPING_MAX_SECONDS", "0.35")
+        adapter = _StubAdapter()
+        calls = []
+
+        async def recording_send_typing(chat_id, metadata=None):
+            calls.append(chat_id)
+
+        monkeypatch.setattr(adapter, "send_typing", recording_send_typing)
+        adapter.stop_typing = MagicMock(return_value=asyncio.sleep(0))
+
+        # No stop_event.set(): the loop should exit because the Telegram max
+        # duration elapses, not because the surrounding gateway turn ended.
+        task = asyncio.create_task(
+            adapter._keep_typing(
+                chat_id="telegram-chat",
+                interval=0.1,
+                stop_event=asyncio.Event(),
+            )
+        )
+        await asyncio.wait_for(task, timeout=1.5)
+
+        assert 1 <= len(calls) <= 5, (
+            f"expected a short burst of typing refreshes before the cap, "
+            f"got {len(calls)} calls"
+        )

--- a/tests/gateway/test_run_progress_topics.py
+++ b/tests/gateway/test_run_progress_topics.py
@@ -466,6 +466,45 @@ class CommentaryAgent:
         }
 
 
+class InternalNoteCommentaryAgent:
+    def __init__(self, **kwargs):
+        self.interim_assistant_callback = kwargs.get("interim_assistant_callback")
+        self.tools = []
+
+    def run_conversation(self, message, conversation_history=None, task_id=None):
+        if self.interim_assistant_callback:
+            self.interim_assistant_callback("Need patch.", already_streamed=False)
+            self.interim_assistant_callback("Run commit.", already_streamed=False)
+            self.interim_assistant_callback("Now restart gateway.", already_streamed=False)
+        return {
+            "final_response": "done",
+            "messages": [],
+            "api_calls": 1,
+        }
+
+
+class SlowActivityAgent:
+    def __init__(self, **kwargs):
+        self.tools = []
+
+    def get_activity_summary(self):
+        return {
+            "api_call_count": 7,
+            "max_iterations": 60,
+            "current_tool": "terminal",
+            "last_activity_desc": "running tool",
+            "seconds_since_activity": 0.0,
+        }
+
+    def run_conversation(self, message, conversation_history=None, task_id=None):
+        time.sleep(0.08)
+        return {
+            "final_response": "done",
+            "messages": [],
+            "api_calls": 1,
+        }
+
+
 class PreviewedResponseAgent:
     def __init__(self, **kwargs):
         self.interim_assistant_callback = kwargs.get("interim_assistant_callback")
@@ -655,6 +694,38 @@ async def test_run_agent_suppresses_interim_commentary_when_disabled(monkeypatch
 
     assert result.get("already_sent") is not True
     assert not any(call["content"] == "I'll inspect the repo first." for call in adapter.sent)
+
+
+@pytest.mark.asyncio
+async def test_run_agent_suppresses_internal_interim_notes_even_when_enabled(monkeypatch, tmp_path):
+    adapter, result = await _run_with_agent(
+        monkeypatch,
+        tmp_path,
+        InternalNoteCommentaryAgent,
+        session_id="sess-internal-notes-suppressed",
+        config_data={"display": {"interim_assistant_messages": True}},
+    )
+
+    sent_texts = [call["content"] for call in adapter.sent]
+    assert result.get("already_sent") is not True
+    assert not any(text in {"Need patch.", "Run commit.", "Now restart gateway."} for text in sent_texts)
+
+
+@pytest.mark.asyncio
+async def test_run_agent_long_running_notice_uses_korean_when_display_language_ko(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_AGENT_NOTIFY_INTERVAL", "0.02")
+    adapter, result = await _run_with_agent(
+        monkeypatch,
+        tmp_path,
+        SlowActivityAgent,
+        session_id="sess-korean-notice",
+        config_data={"display": {"language": "ko"}},
+    )
+
+    sent_texts = [call["content"] for call in adapter.sent]
+    assert result["final_response"] == "done"
+    assert any("작업 중" in text for text in sent_texts)
+    assert not any("Still working" in text or "elapsed" in text or "iteration" in text for text in sent_texts)
 
 
 @pytest.mark.asyncio

--- a/tests/gateway/test_run_progress_topics.py
+++ b/tests/gateway/test_run_progress_topics.py
@@ -65,6 +65,20 @@ class NonEditingProgressCaptureAdapter(ProgressCaptureAdapter):
         raise AssertionError("non-editable adapters should not receive edit_message calls")
 
 
+class InterruptingProgressCaptureAdapter(ProgressCaptureAdapter):
+    def __init__(self, platform=Platform.TELEGRAM):
+        super().__init__(platform=platform)
+        self.sent_at = []
+
+    async def send(self, chat_id, content, reply_to=None, metadata=None) -> SendResult:
+        result = await super().send(chat_id, content, reply_to=reply_to, metadata=metadata)
+        self.sent_at.append((time.monotonic(), content))
+        return result
+
+    def has_pending_interrupt(self, session_key: str) -> bool:
+        return True
+
+
 class FakeAgent:
     def __init__(self, **kwargs):
         # Capture anything passed via kwargs (older code path) but don't
@@ -505,6 +519,26 @@ class SlowActivityAgent:
         }
 
 
+class UnresponsiveInterruptedAgent(SlowActivityAgent):
+    interrupted_at = None
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.is_interrupted = False
+
+    def interrupt(self, pending_text=None):
+        type(self).interrupted_at = time.monotonic()
+        self.is_interrupted = True
+
+    def run_conversation(self, message, conversation_history=None, task_id=None):
+        time.sleep(0.35)
+        return {
+            "final_response": "done",
+            "messages": [],
+            "api_calls": 1,
+        }
+
+
 class PreviewedResponseAgent:
     def __init__(self, **kwargs):
         self.interim_assistant_callback = kwargs.get("interim_assistant_callback")
@@ -726,6 +760,46 @@ async def test_run_agent_long_running_notice_uses_korean_when_display_language_k
     assert result["final_response"] == "done"
     assert any("작업 중" in text for text in sent_texts)
     assert not any("Still working" in text or "elapsed" in text or "iteration" in text for text in sent_texts)
+
+
+@pytest.mark.asyncio
+async def test_run_agent_long_running_notice_suppressed_when_notifications_important(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_AGENT_NOTIFY_INTERVAL", "0.02")
+    adapter, result = await _run_with_agent(
+        monkeypatch,
+        tmp_path,
+        SlowActivityAgent,
+        session_id="sess-important-notifications-no-notice",
+        config_data={"display": {"language": "ko", "platforms": {"telegram": {"notifications": "important"}}}},
+    )
+
+    sent_texts = [call["content"] for call in adapter.sent]
+    assert result["final_response"] == "done"
+    assert not any("작업 중" in text or "Still working" in text for text in sent_texts)
+
+
+@pytest.mark.asyncio
+async def test_run_agent_long_running_notice_stops_after_interrupt(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_AGENT_NOTIFY_INTERVAL", "0.02")
+    UnresponsiveInterruptedAgent.interrupted_at = None
+
+    adapter, result = await _run_with_agent(
+        monkeypatch,
+        tmp_path,
+        UnresponsiveInterruptedAgent,
+        session_id="sess-stale-notice-after-interrupt",
+        adapter_cls=InterruptingProgressCaptureAdapter,
+        config_data={"display": {"language": "ko"}},
+    )
+
+    assert result["final_response"] == "done"
+    assert UnresponsiveInterruptedAgent.interrupted_at is not None
+    late_notices = [
+        text
+        for sent_at, text in adapter.sent_at
+        if "작업 중" in text and sent_at > UnresponsiveInterruptedAgent.interrupted_at + 0.04
+    ]
+    assert late_notices == []
 
 
 @pytest.mark.asyncio

--- a/tests/hermes_cli/test_plugins.py
+++ b/tests/hermes_cli/test_plugins.py
@@ -129,6 +129,46 @@ class TestPluginDiscovery:
 
         assert "proj_plugin" not in mgr._plugins
 
+    def test_bundled_core_plugins_auto_load(self, tmp_path, monkeypatch):
+        """Bundled core plugins load without requiring plugins.enabled."""
+        bundled_dir = tmp_path / "bundled_plugins"
+        _make_plugin_dir(
+            bundled_dir,
+            "core_time",
+            register_body='ctx.register_hook("pre_llm_call", lambda **kwargs: None)',
+            manifest_extra={"kind": "core", "hooks": ["pre_llm_call"]},
+            auto_enable=False,
+        )
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes_home"))
+        monkeypatch.setattr("hermes_cli.plugins.get_bundled_plugins_dir", lambda: bundled_dir)
+
+        mgr = PluginManager()
+        mgr.discover_and_load()
+
+        assert "core_time" in mgr._plugins
+        assert mgr._plugins["core_time"].enabled
+
+    def test_core_plugin_list_status_is_enabled(self, tmp_path, monkeypatch, capsys):
+        """Plugin list should show bundled core plugins as enabled."""
+        from hermes_cli.plugins_cmd import cmd_list
+
+        bundled_dir = tmp_path / "bundled_plugins"
+        _make_plugin_dir(
+            bundled_dir,
+            "core_time",
+            manifest_extra={"kind": "core", "hooks": ["pre_llm_call"]},
+            auto_enable=False,
+        )
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes_home"))
+        monkeypatch.setattr("hermes_cli.plugins.get_bundled_plugins_dir", lambda: bundled_dir)
+
+        cmd_list()
+
+        output = capsys.readouterr().out
+        assert "core_time" in output
+        assert "not enabled" not in output
+        assert "enabled" in output
+
     def test_discover_is_idempotent(self, tmp_path, monkeypatch):
         """Calling discover_and_load() twice does not duplicate plugins."""
         plugins_dir = tmp_path / "hermes_test" / "plugins"

--- a/tests/plugins/test_timeline_sync_plugin.py
+++ b/tests/plugins/test_timeline_sync_plugin.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+import os
+import sqlite3
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+def _make_state_db(path: Path) -> None:
+    conn = sqlite3.connect(path)
+    conn.executescript(
+        """
+        CREATE TABLE sessions (
+            id TEXT PRIMARY KEY,
+            source TEXT NOT NULL,
+            title TEXT,
+            started_at REAL NOT NULL,
+            message_count INTEGER DEFAULT 0
+        );
+        CREATE TABLE messages (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            session_id TEXT NOT NULL,
+            role TEXT NOT NULL,
+            content TEXT,
+            timestamp REAL NOT NULL
+        );
+        """
+    )
+    conn.execute(
+        "INSERT INTO sessions (id, source, title, started_at, message_count) VALUES (?, ?, ?, ?, ?)",
+        ("slack-1", "slack", "Slack thread", 1.0, 1),
+    )
+    conn.execute(
+        "INSERT INTO messages (session_id, role, content, timestamp) VALUES (?, ?, ?, ?)",
+        ("slack-1", "user", "메모리 질문", 1_700_000_000.0),
+    )
+    conn.commit()
+    conn.close()
+
+
+def test_plugin_pre_llm_call_returns_context_when_enabled(tmp_path, monkeypatch):
+    from plugins.timeline_sync import on_pre_llm_call
+
+    db_path = tmp_path / "state.db"
+    _make_state_db(db_path)
+    monkeypatch.setenv("HERMES_TIMELINE_SYNC_DB", str(db_path))
+    monkeypatch.setenv("HERMES_TIMELINE_SYNC_NOW", "1700000060")
+    monkeypatch.delenv("HERMES_TIMELINE_SYNC_ENABLED", raising=False)
+
+    result = on_pre_llm_call(
+        session_id="slack-1",
+        user_message="이어서 말해줘",
+        conversation_history=[],
+        platform="slack",
+        model="test-model",
+    )
+
+    assert isinstance(result, dict)
+    assert "Timeline sync" in result["context"]
+    assert "Current platform: slack" in result["context"]
+
+
+def test_plugin_pre_llm_call_can_be_disabled(tmp_path, monkeypatch):
+    from plugins.timeline_sync import on_pre_llm_call
+
+    db_path = tmp_path / "state.db"
+    _make_state_db(db_path)
+    monkeypatch.setenv("HERMES_TIMELINE_SYNC_DB", str(db_path))
+    monkeypatch.setenv("HERMES_TIMELINE_SYNC_ENABLED", "0")
+
+    result = on_pre_llm_call(
+        session_id="slack-1",
+        user_message="이어서 말해줘",
+        conversation_history=[],
+        platform="slack",
+        model="test-model",
+    )
+
+    assert result is None

--- a/tests/run_agent/test_run_agent_codex_responses.py
+++ b/tests/run_agent/test_run_agent_codex_responses.py
@@ -313,6 +313,36 @@ def test_build_api_kwargs_codex(monkeypatch):
     assert "extra_body" not in kwargs
 
 
+def test_build_api_kwargs_codex_omits_tool_fields_when_no_tools(monkeypatch):
+    monkeypatch.setattr(run_agent, "get_tool_definitions", lambda **kwargs: [])
+    monkeypatch.setattr(run_agent, "check_toolset_requirements", lambda: {})
+
+    agent = run_agent.AIAgent(
+        model="gpt-5-codex",
+        base_url="https://chatgpt.com/backend-api/codex",
+        api_key="codex-token",
+        quiet_mode=True,
+        max_iterations=4,
+        skip_context_files=True,
+        skip_memory=True,
+    )
+    agent._cleanup_task_resources = lambda task_id: None
+    agent._persist_session = lambda messages, history=None: None
+    agent._save_trajectory = lambda messages, user_message, completed: None
+    agent._save_session_log = lambda messages: None
+
+    kwargs = agent._build_api_kwargs(
+        [
+            {"role": "system", "content": "You are Hermes."},
+            {"role": "user", "content": "Ping"},
+        ]
+    )
+
+    assert "tools" not in kwargs
+    assert "tool_choice" not in kwargs
+    assert "parallel_tool_calls" not in kwargs
+
+
 def test_build_api_kwargs_codex_clamps_minimal_effort(monkeypatch):
     """'minimal' reasoning effort is clamped to 'low' on the Responses API.
 

--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -69,6 +69,8 @@ class TestDelegateRequirements(unittest.TestCase):
         self.assertIn("tasks", props)
         self.assertIn("context", props)
         self.assertIn("toolsets", props)
+        self.assertIn("skills", props)
+        self.assertIn("skills", props["tasks"]["items"]["properties"])
         # max_iterations is intentionally NOT exposed to the model — it's
         # config-authoritative via delegation.max_iterations so users get
         # predictable budgets.
@@ -413,6 +415,84 @@ class TestDelegateTask(unittest.TestCase):
         self.assertTrue(callable(mock_child.thinking_callback))
         mock_child.thinking_callback("deliberating...")
         parent.tool_progress_callback.assert_not_called()
+
+    def test_child_preloads_requested_skills_into_ephemeral_prompt(self):
+        """Native delegate_task skills=[...] should load skills before child starts."""
+        parent = _make_mock_parent(depth=0)
+
+        with patch("run_agent.AIAgent") as MockAgent, patch(
+            "agent.skill_commands.build_preloaded_skills_prompt",
+            return_value=("[preloaded vooy-docs skill]", ["vooy-docs"], []),
+        ) as mock_preload:
+            mock_child = MagicMock()
+            MockAgent.return_value = mock_child
+
+            _build_child_agent(
+                task_index=0,
+                goal="Create vooy documentation",
+                context=None,
+                toolsets=None,
+                skills=["vooy-docs"],
+                model=None,
+                max_iterations=10,
+                parent_agent=parent,
+                task_count=1,
+            )
+
+        mock_preload.assert_called_once()
+        self.assertEqual(mock_preload.call_args.args[0], ["vooy-docs"])
+        self.assertRegex(mock_preload.call_args.kwargs["task_id"], r"^sa-0-[0-9a-f]{8}$")
+        _, kwargs = MockAgent.call_args
+        prompt = kwargs["ephemeral_system_prompt"]
+        self.assertIn("Create vooy documentation", prompt)
+        self.assertIn("[preloaded vooy-docs skill]", prompt)
+
+    @patch("tools.delegate_tool._run_single_child")
+    def test_delegate_task_passes_top_level_skills_to_child_builder(self, mock_run):
+        """Top-level skills should apply to a single delegated task."""
+        mock_run.return_value = {
+            "task_index": 0,
+            "status": "completed",
+            "summary": "Done",
+            "api_calls": 1,
+            "duration_seconds": 1.0,
+        }
+        parent = _make_mock_parent()
+
+        with patch("tools.delegate_tool._build_child_agent") as mock_build:
+            mock_child = MagicMock()
+            mock_build.return_value = mock_child
+            delegate_task(
+                goal="Document this source",
+                skills=["vooy-docs"],
+                parent_agent=parent,
+            )
+
+        self.assertEqual(mock_build.call_args.kwargs["skills"], ["vooy-docs"])
+
+    @patch("tools.delegate_tool._run_single_child")
+    def test_batch_task_skills_override_top_level_skills(self, mock_run):
+        """Each batch task may override inherited top-level preloaded skills."""
+        mock_run.side_effect = [
+            {"task_index": 0, "status": "completed", "summary": "A", "api_calls": 1, "duration_seconds": 1.0},
+            {"task_index": 1, "status": "completed", "summary": "B", "api_calls": 1, "duration_seconds": 1.0},
+        ]
+        parent = _make_mock_parent()
+
+        with patch("tools.delegate_tool._build_child_agent") as mock_build:
+            mock_build.side_effect = [MagicMock(), MagicMock()]
+            delegate_task(
+                tasks=[
+                    {"goal": "Use inherited skills"},
+                    {"goal": "Use task skills", "skills": ["notion"]},
+                ],
+                skills=["vooy-docs"],
+                parent_agent=parent,
+            )
+
+        first_call, second_call = mock_build.call_args_list
+        self.assertEqual(first_call.kwargs["skills"], ["vooy-docs"])
+        self.assertEqual(second_call.kwargs["skills"], ["notion"])
 
 
 class TestToolNamePreservation(unittest.TestCase):
@@ -1622,20 +1702,21 @@ class TestDelegateHeartbeat(unittest.TestCase):
         }
 
         def slow_run(**kwargs):
-            # Long enough to exceed the OLD idle threshold (5 cycles) at
-            # the patched interval, but shorter than the new in-tool
-            # threshold.
-            time.sleep(0.4)
+            # Wait until the heartbeat proves it passed the old idle stale
+            # ceiling, or time out so the test can fail with the touch count.
+            deadline = time.monotonic() + 5.0
+            while len(touch_calls) <= 15 and time.monotonic() < deadline:
+                time.sleep(0.01)
             return {"final_response": "done", "completed": True, "api_calls": 1}
 
         child.run_conversation.side_effect = slow_run
 
-        # Patch both the interval AND the idle ceiling so the test proves
-        # the in-tool branch takes effect: with a 0.05s interval and the
-        # default _HEARTBEAT_STALE_CYCLES_IDLE=5, the old behavior would
-        # trip after 0.25s and stop firing. We should see heartbeats
-        # continuing through the full 0.4s run.
-        with patch("tools.delegate_tool._HEARTBEAT_INTERVAL", 0.05):
+        # Patch the interval so the test proves the in-tool branch takes
+        # effect quickly: with a 0.02s interval and the default
+        # _HEARTBEAT_STALE_CYCLES_IDLE=15, the old behavior would trip after
+        # about 0.3s and stop firing. We should see heartbeats continuing
+        # through the full 0.7s run.
+        with patch("tools.delegate_tool._HEARTBEAT_INTERVAL", 0.02):
             _run_single_child(
                 task_index=0,
                 goal="Test long-running tool",
@@ -1643,13 +1724,13 @@ class TestDelegateHeartbeat(unittest.TestCase):
                 parent_agent=parent,
             )
 
-        # With the old idle threshold (5 cycles = 0.25s), touch_calls
-        # would cap at ~5. With the in-tool threshold (20 cycles = 1.0s),
-        # we should see substantially more heartbeats over 0.4s.
+        # With the old idle threshold (15 cycles = 0.3s), touch_calls would
+        # cap around 15. With the in-tool threshold (40 cycles = 0.8s), we
+        # should see substantially more heartbeats over 0.7s.
         self.assertGreater(
-            len(touch_calls), 6,
+            len(touch_calls), 15,
             f"Heartbeat stopped too early while child was inside a tool; "
-            f"got {len(touch_calls)} touches over 0.4s at 0.05s interval",
+            f"got {len(touch_calls)} touches over 0.7s at 0.02s interval",
         )
 
 

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -883,6 +883,8 @@ def _build_child_agent(
     # 'leaf' (default) cannot; 'orchestrator' retains the delegation
     # toolset subject to depth/kill-switch bounds applied below.
     role: str = "leaf",
+    # Optional skill names/paths to preload into the child prompt.
+    skills: Optional[List[str]] = None,
 ):
     """
     Build a child AIAgent on the main thread (thread-safe construction).
@@ -971,6 +973,42 @@ def _build_child_agent(
         max_spawn_depth=max_spawn,
         child_depth=child_depth,
     )
+    if skills:
+        try:
+            from agent.skill_commands import build_preloaded_skills_prompt
+
+            skills_prompt, loaded_skills, missing_skills = build_preloaded_skills_prompt(
+                skills,
+                task_id=subagent_id,
+            )
+            skill_blocks: List[str] = []
+            if skills_prompt.strip():
+                skill_blocks.append(
+                    "## Preloaded Skills for This Delegated Task\n"
+                    + skills_prompt.strip()
+                )
+            if missing_skills:
+                skill_blocks.append(
+                    "[Delegate skill preload warning: requested skills not found: "
+                    + ", ".join(missing_skills)
+                    + "]"
+                )
+            if skill_blocks:
+                child_prompt = child_prompt.rstrip() + "\n\n" + "\n\n".join(skill_blocks)
+            if loaded_skills:
+                logger.debug(
+                    "delegate_task: preloaded skills for %s: %s",
+                    subagent_id,
+                    ", ".join(loaded_skills),
+                )
+        except Exception as exc:
+            logger.warning("delegate_task: failed to preload child skills: %s", exc)
+            child_prompt = (
+                child_prompt.rstrip()
+                + "\n\n[Delegate skill preload warning: failed to preload requested skills: "
+                + str(exc)
+                + "]"
+            )
     # Extract parent's API key so subagents inherit auth (e.g. Nous Portal).
     parent_api_key = getattr(parent_agent, "api_key", None)
     if (not parent_api_key) and hasattr(parent_agent, "_client_kwargs"):
@@ -1904,14 +1942,18 @@ def delegate_task(
     acp_command: Optional[str] = None,
     acp_args: Optional[List[str]] = None,
     role: Optional[str] = None,
+    skills: Optional[List[str]] = None,
     parent_agent=None,
 ) -> str:
     """
     Spawn one or more child agents to handle delegated tasks.
 
     Supports two modes:
-      - Single: provide goal (+ optional context, toolsets, role)
-      - Batch:  provide tasks array [{goal, context, toolsets, role}, ...]
+      - Single: provide goal (+ optional context, toolsets, skills, role)
+      - Batch:  provide tasks array [{goal, context, toolsets, skills, role}, ...]
+
+    Top-level skills preload into a single child or, in batch mode, into every
+    task that does not define its own task-level skills list.
 
     The 'role' parameter controls whether a child can further delegate:
     'leaf' (default) cannot; 'orchestrator' retains the delegation
@@ -1997,7 +2039,13 @@ def delegate_task(
         task_list = tasks
     elif goal and isinstance(goal, str) and goal.strip():
         task_list = [
-            {"goal": goal, "context": context, "toolsets": toolsets, "role": top_role}
+            {
+                "goal": goal,
+                "context": context,
+                "toolsets": toolsets,
+                "skills": skills,
+                "role": top_role,
+            }
         ]
     else:
         return tool_error("Provide either 'goal' (single task) or 'tasks' (batch).")
@@ -2043,6 +2091,7 @@ def delegate_task(
                 goal=t["goal"],
                 context=t.get("context"),
                 toolsets=t.get("toolsets") or toolsets,
+                skills=t.get("skills") if "skills" in t else skills,
                 model=creds["model"],
                 max_iterations=effective_max_iter,
                 task_count=n_tasks,
@@ -2502,7 +2551,7 @@ def _build_top_level_description() -> str:
         "Only the final summary is returned -- intermediate tool results "
         "never enter your context window.\n\n"
         "TWO MODES (one of 'goal' or 'tasks' is required):\n"
-        "1. Single task: provide 'goal' (+ optional context, toolsets)\n"
+        "1. Single task: provide 'goal' (+ optional context, toolsets, skills)\n"
         f"2. Batch (parallel): provide 'tasks' array with up to {max_children} "
         f"items concurrently for this user (configured via "
         f"delegation.max_concurrent_children in config.yaml). "
@@ -2546,7 +2595,10 @@ def _build_top_level_description() -> str:
         f"user and can be disabled globally via "
         "delegation.orchestrator_enabled=false.\n"
         "- Each subagent gets its own terminal session (separate working directory and state).\n"
-        "- Results are always returned as an array, one entry per task."
+        "- Results are always returned as an array, one entry per task.\n"
+        "- Optional `skills` preloads one or more skills into child agents "
+        "before they start. In batch mode, top-level `skills` are inherited "
+        "by each task unless that task provides its own `skills` list."
     )
 
 
@@ -2560,7 +2612,8 @@ def _build_tasks_param_description() -> str:
         f"Batch mode: tasks to run in parallel (up to {max_children} for this "
         f"user, set via delegation.max_concurrent_children). Each gets "
         "its own subagent with isolated context and terminal session. "
-        "When provided, top-level goal/context/toolsets are ignored."
+        "When provided, top-level goal/context/toolsets are ignored; "
+        "top-level skills are inherited unless a task defines its own skills."
     )
 
 
@@ -2669,6 +2722,16 @@ DELEGATE_TASK_SCHEMA = {
                     "['terminal', 'file', 'web'] for full-stack tasks."
                 ),
             },
+            "skills": {
+                "type": "array",
+                "items": {"type": "string"},
+                "description": (
+                    "Optional ordered list of skill names or paths to preload "
+                    "into the child agent before it starts. In batch mode, "
+                    "top-level skills apply to every task unless that task "
+                    "provides its own skills list."
+                ),
+            },
             "tasks": {
                 "type": "array",
                 "items": {
@@ -2683,6 +2746,14 @@ DELEGATE_TASK_SCHEMA = {
                             "type": "array",
                             "items": {"type": "string"},
                             "description": f"Toolsets for this specific task. Available: {_TOOLSET_LIST_STR}. Use 'web' for network access, 'terminal' for shell, 'browser' for web interaction.",
+                        },
+                        "skills": {
+                            "type": "array",
+                            "items": {"type": "string"},
+                            "description": (
+                                "Skills to preload for this specific task. "
+                                "Overrides top-level skills when provided."
+                            ),
                         },
                         "acp_command": {
                             "type": "string",
@@ -2759,6 +2830,7 @@ registry.register(
         acp_command=args.get("acp_command"),
         acp_args=args.get("acp_args"),
         role=args.get("role"),
+        skills=args.get("skills"),
         parent_agent=kw.get("parent_agent"),
     ),
     check_fn=check_delegate_requirements,

--- a/website/docs/reference/environment-variables.md
+++ b/website/docs/reference/environment-variables.md
@@ -518,7 +518,7 @@ Advanced per-platform knobs for throttling the outbound message batcher. Most us
 | `HERMES_STREAM_RETRIES` | Number of mid-stream reconnect attempts on transient network errors (default: `3`). |
 | `HERMES_AGENT_TIMEOUT` | Gateway inactivity timeout for a running agent in seconds (default: `900`). Resets on every tool call and streamed token. Set to `0` to disable. |
 | `HERMES_AGENT_TIMEOUT_WARNING` | Gateway: send a warning message after this many seconds of inactivity (default: 75% of `HERMES_AGENT_TIMEOUT`). |
-| `HERMES_AGENT_NOTIFY_INTERVAL` | Gateway: interval in seconds between progress notifications on long-running agent turns. |
+| `HERMES_AGENT_NOTIFY_INTERVAL` | Gateway: interval in seconds between progress notifications on long-running agent turns (default: `300`). |
 | `HERMES_CHECKPOINT_TIMEOUT` | Timeout for filesystem checkpoint creation in seconds (default: `30`). |
 | `HERMES_EXEC_ASK` | Enable execution approval prompts in gateway mode (`true`/`false`) |
 | `HERMES_ENABLE_PROJECT_PLUGINS` | Enable auto-discovery of repo-local plugins from `./.hermes/plugins/` (`true`/`false`, default: `false`) |


### PR DESCRIPTION
## Summary
- add a runtime context layer builder that composes timeline, rhythm, reply hygiene, scratchpad leak, memory guard, expression, and platform mood blocks
- wire the existing timeline_sync pre_llm_call hook to inject the full runtime context layer
- add focused tests for block output, fresh-time behavior, memory guard guidance, and plugin smoke coverage

## Test plan
- python -m pytest tests/agent/test_runtime_context_layer.py tests/plugins/test_timeline_sync_plugin.py tests/agent/test_timeline_sync.py -q -o 'addopts='
- git diff --check
- python -m py_compile agent/runtime_context_layer.py plugins/timeline_sync/__init__.py

## Handoff note
This is a draft checkpoint from the Hermechi runtime-context-layer work. The branch was pushed to the kiheonshin fork. The upstream base has diverged from the local Hermes workspace and currently reports merge conflicts, so this should be treated as a recorded checkpoint until the timeline_sync dependency/base alignment is reviewed.