### PR TITLE
fix(display): guard tool-preview truncation against tiny tool_preview_length

### DIFF
--- a/agent/display.py
+++ b/agent/display.py
@@ -257,8 +257,9 @@ def build_tool_preview(tool_name: str, args: dict, max_len: int | None = None) -
     preview = _oneline(str(value))
     if not preview:
         return None
-    if max_len > 0 and len(preview) > max_len:
-        preview = preview[:max_len - 3] + "..."
+    # Route through _truncate_preview so the max_len <= 3 guard is applied
+    # consistently (a bare `[:max_len - 3]` slice goes negative for 1-3).
+    preview = _truncate_preview(preview, max_len)
     return preview
 
 
@@ -876,15 +877,18 @@ def get_cute_tool_message(
         s = str(s)
         if _tool_preview_max_len == 0:
             return s  # no limit
-        limit = _tool_preview_max_len
-        return (s[:limit-3] + "...") if len(s) > limit else s
+        return _truncate_preview(s, _tool_preview_max_len)
 
     def _path(p, n=35):
         p = str(p)
         if _tool_preview_max_len == 0:
             return p  # no limit
         limit = _tool_preview_max_len
-        return ("..." + p[-(limit-3):]) if len(p) > limit else p
+        if len(p) <= limit:
+            return p
+        if limit <= 3:
+            return "." * limit
+        return "..." + p[-(limit - 3):]
 
     def _wrap(line: str) -> str:
         """Apply skin tool prefix and failure suffix."""


### PR DESCRIPTION
## Bug

`agent/display.py` truncates tool previews with the idiom `text[:max_len - 3] + "..."`
in **four** places, but only one of them guards against a small `max_len`.

`_truncate_preview` (the canonical helper) does it correctly:

```python
def _truncate_preview(text: str, max_len: int | None) -> str:
    if max_len and max_len > 0 and len(text) > max_len:
        if max_len <= 3:                 # ? guard: avoids a negative slice
            return "." * max_len
        return text[:max_len - 3] + "..."
    return text
```

The three siblings omit that guard:

```python
# build_tool_preview()
preview = preview[:max_len - 3] + "..."

# _trunc()
return (s[:limit-3] + "...") if len(s) > limit else s

# _path()
return ("..." + p[-(limit-3):]) if len(p) > limit else p
```

`max_len` / `limit` come from `_tool_preview_max_len`, which is set straight from
the user''s `display.tool_preview_length` config via `set_tool_preview_max_len()`
(only clamped to `>= 0`). So a user can set `tool_preview_length: 1` (or `2`/`3`),
and then for any preview longer than the limit:

- `max_len = 3` ? `text[:0] + "..."` ? `"..."` (3 chars for a limit of 3 - over budget)
- `max_len = 2` ? `text[:-1] + "..."` ? **drops the last character and appends `...`**,
  producing output *longer* than the configured limit (e.g. `"hello"` ? `"hell..."`)
- `_path` with `limit = 2` ? `p[-(-1):]` = `p[1:]` ? drops the *first* character and
  prepends `...` - same corruption from the other end.

So a small `tool_preview_length` silently mangles previews instead of shortening
them - the opposite of what the setting is for. The author already fixed this in
`_truncate_preview`; the siblings were missed.

## Fix

- `build_tool_preview()` and `_trunc()` now route through `_truncate_preview`,
  reusing its guard (and removing the duplicated slice logic - DRY).
- `_path()` truncates from the front (keeps the tail), so it can''t reuse
  `_truncate_preview`; it gets the same `limit <= 3` guard inline.

Behavior is unchanged for normal `tool_preview_length` values (0 = unlimited, or
any value > 3); only the previously-corrupting 1-3 range is corrected.

## Verification

- Confirmed all four sites and the `_truncate_preview` guard on current `main`.
- Confirmed `_tool_preview_max_len` is user-settable to 1-3 via
  `display.tool_preview_length` (`set_tool_preview_max_len` clamps only to `>= 0`).
- No open PR touches `tool_preview` (checked before opening).