### PR TITLE
fix(codex): proactive context-pressure retire + handoff on app-server runtime (#36801)

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1578,6 +1578,13 @@ def init_agent(
         )
     agent.compression_enabled = compression_enabled
     agent.compression_in_place = compression_in_place
+    # Codex app-server proactive retire-and-handoff threshold (issue #36801).
+    try:
+        agent.codex_retire_threshold = float(
+            _compression_cfg.get("codex_retire_threshold", 0.85)
+        )
+    except (TypeError, ValueError):
+        agent.codex_retire_threshold = 0.85
 
     # Reject models whose context window is below the minimum required
     # for reliable tool-calling workflows (64K tokens).

--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -228,6 +228,69 @@ def _record_codex_app_server_usage(agent, turn) -> dict[str, Any]:
     }
 
 
+def _maybe_retire_codex_for_context(agent, turn, usage_result, messages) -> None:
+    """Issue #36801: proactively retire the codex app-server thread when its
+    context fills past ``compression.codex_retire_threshold``, seeding the next
+    turn with a structured summary so context survives the reset.
+
+    Codex owns its conversation context inside the subprocess, so Hermes can't
+    compress it in place — the only lever is to retire (close) the thread and
+    reseed a fresh one. This runs AFTER usage recording, where the real prompt
+    token count and the codex-reported context window are both known.
+
+    No-op unless compression is enabled, a session is still live, the threshold
+    is positive, and both the context window and prompt-token count are known.
+    """
+    if not getattr(agent, "compression_enabled", False):
+        return
+    session = getattr(agent, "_codex_session", None)
+    if session is None:
+        return  # already retired this turn (crash / should_retire path above)
+
+    threshold = getattr(agent, "codex_retire_threshold", 0.85)
+    if not threshold or threshold <= 0:
+        return
+
+    context_window = getattr(turn, "model_context_window", None)
+    if not isinstance(context_window, int) or context_window <= 0:
+        return
+    prompt_tokens = int((usage_result or {}).get("prompt_tokens") or 0)
+    if prompt_tokens <= 0:
+        return
+    if prompt_tokens / context_window < threshold:
+        return
+
+    # Build the handoff summary from Hermes' projected `messages` using the
+    # auxiliary summary model — NOT codex — so the summarization itself can't
+    # overflow the already-full codex window.
+    summary = None
+    compressor = getattr(agent, "context_compressor", None)
+    if compressor is not None:
+        try:
+            summary = compressor.build_handoff_summary(messages)
+        except Exception:
+            logger.debug("codex handoff summary failed", exc_info=True)
+
+    # Retire the thread regardless: even a summary-less retire beats riding an
+    # over-full window into a hard reset. With a summary the next turn reseeds;
+    # without one it starts clean (documented fallback).
+    try:
+        session.close()
+    except Exception:
+        pass
+    agent._codex_session = None
+    agent._codex_pending_handoff = summary or None
+    logger.warning(
+        "codex app-server: proactively retired thread at %d/%d prompt tokens "
+        "(%.0f%% >= %.0f%% threshold); next turn reseeds %s",
+        prompt_tokens,
+        context_window,
+        100.0 * prompt_tokens / context_window,
+        100.0 * threshold,
+        "with handoff summary" if summary else "clean (summary unavailable)",
+    )
+
+
 def run_codex_app_server_turn(
     agent,
     *,
@@ -288,6 +351,27 @@ def run_codex_app_server_turn(
     # standard run_conversation() flow (line ~11823) before the early
     # return reaches us. Do NOT append again — that would duplicate.
 
+    # Reseed a freshly respawned codex thread with the handoff summary stashed
+    # when the previous session was proactively retired for context pressure
+    # (issue #36801). The codex subprocess owns its own context, so a respawn
+    # starts blank; prepend the summary to this first turn so Goal/Discoveries/
+    # Files survive instead of a cold history=0 reset. Only the codex-bound
+    # input is augmented — Hermes' own `messages` projection stays clean.
+    _pending_handoff = getattr(agent, "_codex_pending_handoff", None)
+    if _pending_handoff:
+        user_message = (
+            "[Context handoff] The previous session was compacted and reset to "
+            "stay within the model's context window. Structured summary of the "
+            "conversation so far:\n\n"
+            f"{_pending_handoff}\n\n"
+            "[End of summary — continue from here with the user's next message:]\n"
+            f"{user_message}"
+        )
+        agent._codex_pending_handoff = None
+        logger.info(
+            "codex app-server: reseeded respawned thread with handoff summary"
+        )
+
     try:
         turn = agent._codex_session.run_turn(user_input=user_message)
     except Exception as exc:
@@ -345,6 +429,13 @@ def run_codex_app_server_turn(
     )
     usage_result = _record_codex_app_server_usage(agent, turn)
     api_calls = 1
+
+    # Proactive context-pressure retire + handoff (issue #36801). Codex owns
+    # its thread context; when this turn's prompt occupies too much of the
+    # reported window, summarize → retire the thread → stash the summary so the
+    # next turn respawns codex seeded with it, instead of growing unbounded
+    # until a silent hard reset.
+    _maybe_retire_codex_for_context(agent, turn, usage_result, messages)
 
     # Now check the skill nudge AFTER iters were incremented — same
     # pattern the chat_completions path uses (line ~15432).

--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -1371,6 +1371,25 @@ Summary generation was unavailable, so this is a best-effort deterministic fallb
         self.summary_model = ""  # empty = use main model
         self._summary_failure_cooldown_until = 0.0  # no cooldown — retry immediately
 
+    def build_handoff_summary(
+        self, messages: List[Dict[str, Any]]
+    ) -> Optional[str]:
+        """Produce a structured handoff summary for a runtime that owns its own
+        conversation context (e.g. the Codex app-server thread), so a retired
+        session can be reseeded instead of cold-reset (issue #36801).
+
+        Returns the raw summary string (Goal/Progress/Decisions/Files/...), or
+        None if there is nothing to summarize or summarization is unavailable —
+        the caller should then retire without a seed rather than block.
+        """
+        if not messages:
+            return None
+        try:
+            return self._generate_summary(messages)
+        except Exception:
+            logger.debug("handoff summary generation failed", exc_info=True)
+            return None
+
     def _generate_summary(
         self,
         turns_to_summarize: List[Dict[str, Any]],

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1309,6 +1309,14 @@ DEFAULT_CONFIG = {
                                       # session_search and recoverable, not deleted.
                                       # Default False during rollout; will flip on
                                       # after live validation.
+        "codex_retire_threshold": 0.85,  # Codex app-server runtime only. When a
+                                      # turn's prompt tokens reach this fraction of
+                                      # the codex-reported context window, Hermes
+                                      # summarizes the conversation, retires the
+                                      # codex thread, and reseeds the next turn with
+                                      # the summary — instead of letting the thread
+                                      # grow unbounded until a silent hard context
+                                      # reset. 0 disables. See issue #36801.
     },
 
     # Kanban subsystem (orchestrator workers + dispatcher-driven child tasks).

--- a/tests/agent/transports/test_codex_proactive_compaction.py
+++ b/tests/agent/transports/test_codex_proactive_compaction.py
@@ -1,0 +1,119 @@
+"""Tests for proactive context-pressure retire + handoff on the Codex
+app-server runtime path (issue #36801).
+
+The codex subprocess owns its own conversation context, so Hermes cannot
+compress it in place — the guard's job is to detect high context occupancy
+*after* a turn, summarize Hermes' projection, retire the thread, and stash the
+summary so the next turn reseeds a fresh thread instead of cold-resetting.
+"""
+
+import types
+
+import pytest
+
+from agent.codex_runtime import _maybe_retire_codex_for_context
+from agent.context_compressor import ContextCompressor
+
+
+class _FakeSession:
+    def __init__(self):
+        self.closed = False
+
+    def close(self):
+        self.closed = True
+
+
+def _make_agent(*, prompt_tokens, window, threshold=0.85, enabled=True,
+                summary="GOAL: ship\nFILES: a.py"):
+    session = _FakeSession()
+    compressor = types.SimpleNamespace(
+        build_handoff_summary=lambda messages: summary,
+    )
+    agent = types.SimpleNamespace(
+        compression_enabled=enabled,
+        codex_retire_threshold=threshold,
+        context_compressor=compressor,
+        _codex_session=session,
+        _codex_pending_handoff=None,
+    )
+    turn = types.SimpleNamespace(model_context_window=window)
+    usage_result = {"prompt_tokens": prompt_tokens}
+    return agent, turn, usage_result, session
+
+
+def test_retires_and_stashes_summary_when_over_threshold():
+    agent, turn, usage, session = _make_agent(prompt_tokens=90_000, window=100_000)
+    _maybe_retire_codex_for_context(agent, turn, usage, messages=[{"role": "user", "content": "hi"}])
+    assert session.closed is True
+    assert agent._codex_session is None
+    assert agent._codex_pending_handoff == "GOAL: ship\nFILES: a.py"
+
+
+def test_no_retire_when_under_threshold():
+    agent, turn, usage, session = _make_agent(prompt_tokens=50_000, window=100_000)
+    _maybe_retire_codex_for_context(agent, turn, usage, messages=[{"role": "user", "content": "hi"}])
+    assert session.closed is False
+    assert agent._codex_session is session
+    assert agent._codex_pending_handoff is None
+
+
+def test_retires_clean_when_summary_unavailable():
+    agent, turn, usage, session = _make_agent(prompt_tokens=95_000, window=100_000, summary=None)
+    _maybe_retire_codex_for_context(agent, turn, usage, messages=[{"role": "user", "content": "hi"}])
+    assert session.closed is True
+    assert agent._codex_session is None
+    # No seed stashed → next turn starts clean (documented fallback).
+    assert agent._codex_pending_handoff is None
+
+
+def test_noop_when_compression_disabled():
+    agent, turn, usage, session = _make_agent(prompt_tokens=99_000, window=100_000, enabled=False)
+    _maybe_retire_codex_for_context(agent, turn, usage, messages=[{"role": "user", "content": "hi"}])
+    assert session.closed is False
+    assert agent._codex_session is session
+
+
+def test_noop_when_threshold_zero_disables():
+    agent, turn, usage, session = _make_agent(prompt_tokens=99_000, window=100_000, threshold=0)
+    _maybe_retire_codex_for_context(agent, turn, usage, messages=[{"role": "user", "content": "hi"}])
+    assert session.closed is False
+
+
+def test_noop_when_window_unknown():
+    agent, turn, usage, session = _make_agent(prompt_tokens=99_000, window=None)
+    _maybe_retire_codex_for_context(agent, turn, usage, messages=[{"role": "user", "content": "hi"}])
+    assert session.closed is False
+
+
+def test_noop_when_session_already_retired():
+    agent, turn, usage, _session = _make_agent(prompt_tokens=99_000, window=100_000)
+    agent._codex_session = None  # e.g. crash/should_retire path already closed it
+    # Must not raise even though there is no session to close.
+    _maybe_retire_codex_for_context(agent, turn, usage, messages=[{"role": "user", "content": "hi"}])
+    assert agent._codex_pending_handoff is None
+
+
+def test_build_handoff_summary_empty_returns_none():
+    compressor = object.__new__(ContextCompressor)  # bypass heavy __init__
+    assert compressor.build_handoff_summary([]) is None
+
+
+def test_build_handoff_summary_delegates_to_generate_summary():
+    compressor = object.__new__(ContextCompressor)
+    compressor._generate_summary = lambda msgs: "SUMMARY"  # type: ignore[method-assign]
+    out = compressor.build_handoff_summary([{"role": "user", "content": "hello"}])
+    assert out == "SUMMARY"
+
+
+def test_build_handoff_summary_swallows_generator_errors():
+    compressor = object.__new__(ContextCompressor)
+
+    def _boom(_msgs):
+        raise RuntimeError("aux model down")
+
+    compressor._generate_summary = _boom  # type: ignore[method-assign]
+    assert compressor.build_handoff_summary([{"role": "user", "content": "x"}]) is None
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
Fixes #36801.

## Problem

The Codex app-server runtime (`run_codex_app_server_turn`) hands each turn to a persistent `codex app-server` subprocess that **owns its own conversation thread**. Unlike the chat-completions path — which runs a preflight compaction check in `build_turn_context()` before every model call — the codex path had **no proactive compaction**. Sessions grow unbounded inside the subprocess until codex hits its hard context ceiling and silently hard-resets, losing all context. The failure is silent: the operator only notices after context is already gone (and on metered Codex seats the retained context is also a per-turn budget burn).

Compressing Hermes' `messages` list (the naive fix) does **not** help — codex holds the real history internally; `run_turn()` only forwards the new user message. The only lever is to retire the thread and reseed a fresh one.

## Fix

A proactive, post-turn guard on the codex path:

1. After `_record_codex_app_server_usage()` — where the real prompt-token count and codex-reported `model_context_window` are both known — compute `prompt_tokens / context_window`.
2. When it reaches `compression.codex_retire_threshold` (new config, default **0.85**, `0` disables), build a structured handoff summary from Hermes' projected `messages` via the **auxiliary summary model** (not codex — so the summarization itself can't overflow the already-full window), then **retire** the codex thread (`close()` + drop) and stash the summary.
3. On the next turn, the respawned (blank) codex thread is **reseeded** by prepending the summary to the first user input — so Goal/Discoveries/Files survive instead of a cold `history=0` reset.

This implements the flow proposed in the issue (extract usage → proactive threshold → handoff-on-retire) plus the structured-summary handoff suggested in the thread.

## Notes

- Opt-out / tunable via `compression.codex_retire_threshold` (`0` disables).
- Reuses existing summary machinery via a small public `ContextCompressor.build_handoff_summary()` seam.
- Best-effort: if summarization is unavailable it still retires (announced via `logger.warning`) rather than ride an over-full window into a hard reset.
- No behavior change on the chat-completions path, or when the codex window/usage is unknown.

## Tests

New `tests/agent/transports/test_codex_proactive_compaction.py` (10 cases): over/under threshold, summary-less retire, disabled (flag + `threshold=0`), unknown window, already-retired session, and the `build_handoff_summary` seam (empty / delegate / error-swallow). All pass; existing `test_context_compressor.py` + `test_codex_app_server_session.py` (154 tests) remain green.
