### PR TITLE
fix(context_references): keep message newlines when stripping @ reference tokens

### DIFF
--- a/agent/context_references.py
+++ b/agent/context_references.py
@@ -420,8 +420,18 @@ def _remove_reference_tokens(message: str, refs: list[ContextReference]) -> str:
         cursor = ref.end
     pieces.append(message[cursor:])
     text = "".join(pieces)
-    text = re.sub(r"\s{2,}", " ", text)
-    text = re.sub(r"\s+([,.;:!?])", r"\1", text)
+    # Tidy the gap a removed token leaves behind WITHOUT reflowing the rest of
+    # the message. Collapsing every run of ``\s`` (which includes newlines)
+    # flattened the user's blank lines, paragraph breaks, and indentation into
+    # single spaces, so any message that used an @ reference reached the model
+    # as one run-on line. Restrict the cleanup to horizontal whitespace: collapse
+    # runs of spaces/tabs, drop horizontal whitespace before punctuation, strip
+    # the whitespace a removed token can leave at a line end, and cap the
+    # blank-line run a line-only reference leaves behind.
+    text = re.sub(r"[ \t]{2,}", " ", text)
+    text = re.sub(r"[ \t]+([,.;:!?])", r"\1", text)
+    text = re.sub(r"[ \t]+(\r?\n)", r"\1", text)
+    text = re.sub(r"\n{3,}", "\n\n", text)
     return text.strip()
 
 

--- a/tests/agent/test_context_references.py
+++ b/tests/agent/test_context_references.py
@@ -327,6 +327,65 @@ def test_defaults_allowed_root_to_cwd(tmp_path: Path):
     assert any("outside the allowed workspace" in warning for warning in result.warnings)
 
 
+def test_remove_reference_tokens_keeps_structure_but_cleans_seam():
+    from agent.context_references import (
+        _remove_reference_tokens,
+        parse_context_references,
+    )
+
+    # Inline reference: the gap the removed token leaves is still tidied to a
+    # single space, exactly like before.
+    inline = "see @file:notes.txt here"
+    assert (
+        _remove_reference_tokens(inline, parse_context_references(inline))
+        == "see here"
+    )
+
+    # A reference on its own line keeps the surrounding paragraph break instead
+    # of merging the two paragraphs onto a single line.
+    multiline = "intro line\n\n@diff\n\noutro line"
+    assert (
+        _remove_reference_tokens(multiline, parse_context_references(multiline))
+        == "intro line\n\noutro line"
+    )
+
+
+def test_reference_expansion_preserves_message_paragraphs(sample_repo: Path):
+    """Using an @ reference must not flatten the rest of the user's message.
+
+    The token-removal cleanup used to collapse every run of whitespace
+    (newlines included) into a single space, so any message that used an @
+    reference had its blank lines and paragraph breaks merged before the model
+    saw it.
+    """
+    from agent.context_references import preprocess_context_references
+
+    message = (
+        "First paragraph with the task.\n"
+        "\n"
+        "@file:src/main.py\n"
+        "\n"
+        "Second paragraph with the constraints."
+    )
+
+    result = preprocess_context_references(
+        message,
+        cwd=sample_repo,
+        context_length=100_000,
+    )
+
+    assert result.expanded
+    prose = result.message.split("--- Attached Context ---", 1)[0]
+    assert "First paragraph with the task." in prose
+    assert "Second paragraph with the constraints." in prose
+    # The paragraph break survives; the two paragraphs are not merged.
+    assert (
+        "First paragraph with the task.\n\nSecond paragraph with the constraints."
+        in prose
+    )
+    assert "the task. Second paragraph" not in prose
+
+
 @pytest.mark.asyncio
 async def test_blocks_sensitive_home_and_hermes_paths(tmp_path: Path, monkeypatch):
     from agent.context_references import preprocess_context_references_async


### PR DESCRIPTION
## What

`_remove_reference_tokens` in `agent/context_references.py` removes `@` reference tokens (`@file`, `@folder`, `@diff`, `@staged`, `@git`, `@url`) and then tidies the gap they leave behind. The tidy step used `re.sub(r"\s{2,}", " ", text)`, and `\s` matches newlines, so it reflowed the whole message. Every blank line, paragraph break, and indentation run collapsed into a single space, and any message that used an `@` reference reached the model as one run on block.

This path is not behind a config flag. `cli.py` runs it whenever a message contains `"@"`, and the TUI and gateway call the same function, so it affects interactive chat, the TUI, and the gateway alike.

## Reproduce

```python
from agent.context_references import _remove_reference_tokens, parse_context_references

msg = (
    "Please refactor the auth module.\n\n"
    "@file:auth.py\n\n"
    "Make these changes:\n1. Add logging\n2. Handle timeouts\n\n"
    "Keep the public API stable."
)
print(_remove_reference_tokens(msg, parse_context_references(msg)))
```

Before this change the two outer paragraphs are merged:

```
Please refactor the auth module. Make these changes:
1. Add logging
2. Handle timeouts Keep the public API stable.
```

After this change the structure is kept:

```
Please refactor the auth module.

Make these changes:
1. Add logging
2. Handle timeouts

Keep the public API stable.
```

## Fix

Scope the cleanup to horizontal whitespace so line structure survives:

```python
text = re.sub(r"[ \t]{2,}", " ", text)
text = re.sub(r"[ \t]+([,.;:!?])", r"\1", text)
text = re.sub(r"[ \t]+(\r?\n)", r"\1", text)
text = re.sub(r"\n{3,}", "\n\n", text)
```

The seam an inline token leaves is still collapsed to a single space, whitespace before punctuation is still removed, and a reference that sat alone on its line no longer leaves a pile of blank lines. Newlines and paragraph breaks now reach the model intact.

## Tests

Added two tests in `tests/agent/test_context_references.py`:

* `test_remove_reference_tokens_keeps_structure_but_cleans_seam` (unit: the inline seam is still tidied, the paragraph break is preserved)
* `test_reference_expansion_preserves_message_paragraphs` (integration through `preprocess_context_references`)

Both fail on `main` before this change and pass after. The full file is 17 passed and `ruff` is clean. Because this is pure `re` logic, I confirmed identical behavior on two systems, arm64 Python 3.9.6 and x86_64 Python 3.11.9.

Fixes #48484

Max Freedom Pollard
