### PR TITLE
feat(desktop): add work queue MVP

### DIFF
--- a/apps/desktop/src/app/chat/sidebar/index.tsx
+++ b/apps/desktop/src/app/chat/sidebar/index.tsx
@@ -822,6 +822,7 @@ export function ChatSidebar({
                   (item.id === 'work-queue' && currentView === 'work-queue')
 
                 const isNewSession = item.id === 'new-session'
+                const label = s.nav[item.id] || item.label
 
                 return (
                   <SidebarMenuItem key={item.id}>
@@ -852,13 +853,13 @@ export function ChatSidebar({
 
                         onNavigate(item)
                       }}
-                      tooltip={s.nav[item.id] ?? item.label}
+                      tooltip={label}
                       type="button"
                     >
                       <item.icon className="size-4 shrink-0 text-[color-mix(in_srgb,currentColor_72%,transparent)]" />
                       {contentVisible && (
                         <>
-                          <span className="min-w-0 flex-1 truncate">{s.nav[item.id] ?? item.label}</span>
+                          <span className="min-w-0 flex-1 truncate">{label}</span>
                           {isNewSession && (
                             <KbdGroup
                               className={cn('ml-auto opacity-55', newSessionKbdFlash && 'opacity-100!')}

--- a/apps/desktop/src/app/chat/sidebar/index.tsx
+++ b/apps/desktop/src/app/chat/sidebar/index.tsx
@@ -63,6 +63,7 @@ import {
   setPinnedSessionOrder,
   setSidebarAgentsGrouped,
   setSidebarCronOpen,
+  setSidebarOpen,
   setSidebarPinsOpen,
   setSidebarRecentsOpen,
   setSidebarSessionOrderIds,
@@ -332,6 +333,12 @@ export function ChatSidebar({
   const overlayMounted = useStore($sidebarOverlayMounted)
   const contentVisible = sidebarOpen || overlayMounted
   const panesFlipped = useStore($panesFlipped)
+
+  useEffect(() => {
+    if (currentView === 'work-queue' && !sidebarOpen) {
+      setSidebarOpen(true)
+    }
+  }, [currentView, sidebarOpen])
   const agentsGrouped = useStore($sidebarAgentsGrouped)
   const pinnedSessionIds = useStore($pinnedSessionIds)
   const pinsOpen = useStore($sidebarPinsOpen)

--- a/apps/desktop/src/app/chat/sidebar/index.tsx
+++ b/apps/desktop/src/app/chat/sidebar/index.tsx
@@ -823,6 +823,7 @@ export function ChatSidebar({
 
                 const isNewSession = item.id === 'new-session'
                 const label = s.nav[item.id] || item.label
+                const showTextLabel = contentVisible || item.id === 'work-queue'
 
                 return (
                   <SidebarMenuItem key={item.id}>
@@ -857,10 +858,10 @@ export function ChatSidebar({
                       type="button"
                     >
                       <item.icon className="size-4 shrink-0 text-[color-mix(in_srgb,currentColor_72%,transparent)]" />
-                      {contentVisible && (
+                      {showTextLabel && (
                         <>
                           <span className="min-w-0 flex-1 truncate">{label}</span>
-                          {isNewSession && (
+                          {contentVisible && isNewSession && (
                             <KbdGroup
                               className={cn('ml-auto opacity-55', newSessionKbdFlash && 'opacity-100!')}
                               keys={[...NEW_SESSION_KBD]}

--- a/apps/desktop/src/app/chat/sidebar/index.tsx
+++ b/apps/desktop/src/app/chat/sidebar/index.tsx
@@ -131,7 +131,7 @@ const SIDEBAR_NAV: SidebarNavItem[] = [
     route: SKILLS_ROUTE
   },
   { id: 'messaging', label: '', icon: props => <Codicon name="comment" {...props} />, route: MESSAGING_ROUTE },
-  { id: 'work-queue', label: '', icon: props => <Codicon name="checklist" {...props} />, route: WORK_QUEUE_ROUTE },
+  { id: 'work-queue', label: 'Work Queue', icon: props => <Codicon name="checklist" {...props} />, route: WORK_QUEUE_ROUTE },
   { id: 'artifacts', label: '', icon: props => <Codicon name="files" {...props} />, route: ARTIFACTS_ROUTE }
 ]
 

--- a/apps/desktop/src/app/chat/sidebar/index.tsx
+++ b/apps/desktop/src/app/chat/sidebar/index.tsx
@@ -95,7 +95,7 @@ import {
   sessionPinId
 } from '@/store/session'
 
-import { type AppView, ARTIFACTS_ROUTE, MESSAGING_ROUTE, SKILLS_ROUTE } from '../../routes'
+import { type AppView, ARTIFACTS_ROUTE, MESSAGING_ROUTE, SKILLS_ROUTE, WORK_QUEUE_ROUTE } from '../../routes'
 import { SidebarPanelLabel } from '../../shell/sidebar-label'
 import type { SidebarNavItem } from '../../types'
 
@@ -131,6 +131,7 @@ const SIDEBAR_NAV: SidebarNavItem[] = [
     route: SKILLS_ROUTE
   },
   { id: 'messaging', label: '', icon: props => <Codicon name="comment" {...props} />, route: MESSAGING_ROUTE },
+  { id: 'work-queue', label: '', icon: props => <Codicon name="checklist" {...props} />, route: WORK_QUEUE_ROUTE },
   { id: 'artifacts', label: '', icon: props => <Codicon name="files" {...props} />, route: ARTIFACTS_ROUTE }
 ]
 
@@ -533,6 +534,7 @@ export function ChatSidebar({
 
     if (!next.length && agentOrderIds.length) {
       setSidebarSessionOrderIds([])
+
       return
     }
 
@@ -816,7 +818,8 @@ export function ChatSidebar({
                 const active =
                   (item.id === 'skills' && currentView === 'skills') ||
                   (item.id === 'messaging' && currentView === 'messaging') ||
-                  (item.id === 'artifacts' && currentView === 'artifacts')
+                  (item.id === 'artifacts' && currentView === 'artifacts') ||
+                  (item.id === 'work-queue' && currentView === 'work-queue')
 
                 const isNewSession = item.id === 'new-session'
 

--- a/apps/desktop/src/app/desktop-controller.tsx
+++ b/apps/desktop/src/app/desktop-controller.tsx
@@ -54,8 +54,8 @@ import {
   $gatewayState,
   $messages,
   $messagingSessions,
-  $resumeFailedSessionId,
   $resumeExhaustedSessionId,
+  $resumeFailedSessionId,
   $selectedStoredSessionId,
   $sessions,
   $workingSessionIds,
@@ -135,6 +135,7 @@ const CronView = lazy(async () => ({ default: (await import('./cron')).CronView 
 const MessagingView = lazy(async () => ({ default: (await import('./messaging')).MessagingView }))
 const ProfilesView = lazy(async () => ({ default: (await import('./profiles')).ProfilesView }))
 const SettingsView = lazy(async () => ({ default: (await import('./settings')).SettingsView }))
+const WorkQueueView = lazy(async () => ({ default: (await import('./work-queue')).WorkQueueView }))
 const SkillsView = lazy(async () => ({ default: (await import('./skills')).SkillsView }))
 
 // Latest cron-job sessions surfaced in the collapsed "Cron jobs" section. The
@@ -233,7 +234,8 @@ export function DesktopController() {
     openCommandCenterSection,
     profilesOpen,
     settingsOpen,
-    toggleCommandCenter
+    toggleCommandCenter,
+    workQueueOpen
   } = useOverlayRouting()
 
   const terminalSidebarOpen = chatOpen && terminalTakeover
@@ -1025,6 +1027,12 @@ export function DesktopController() {
           <ProfilesView onClose={closeOverlayToPreviousRoute} />
         </Suspense>
       )}
+
+      {workQueueOpen && (
+        <Suspense fallback={null}>
+          <WorkQueueView onClose={closeOverlayToPreviousRoute} />
+        </Suspense>
+      )}
     </>
   )
 
@@ -1185,6 +1193,7 @@ export function DesktopController() {
           <Route element={null} path="settings" />
           <Route element={null} path="command-center" />
           <Route element={null} path="agents" />
+          <Route element={null} path="work-queue" />
           <Route element={<Navigate replace to={NEW_CHAT_ROUTE} />} path="new" />
           <Route element={<LegacySessionRedirect />} path="sessions/:sessionId" />
           <Route element={<Navigate replace to={NEW_CHAT_ROUTE} />} path="*" />

--- a/apps/desktop/src/app/routes.ts
+++ b/apps/desktop/src/app/routes.ts
@@ -4,6 +4,7 @@ export const SETTINGS_ROUTE = '/settings'
 export const COMMAND_CENTER_ROUTE = '/command-center'
 export const SKILLS_ROUTE = '/skills'
 export const MESSAGING_ROUTE = '/messaging'
+export const WORK_QUEUE_ROUTE = '/work-queue'
 export const ARTIFACTS_ROUTE = '/artifacts'
 export const CRON_ROUTE = '/cron'
 export const PROFILES_ROUTE = '/profiles'
@@ -19,6 +20,7 @@ export type AppView =
   | 'profiles'
   | 'settings'
   | 'skills'
+  | 'work-queue'
 
 export type AppRouteId =
   | 'agents'
@@ -30,6 +32,7 @@ export type AppRouteId =
   | 'profiles'
   | 'settings'
   | 'skills'
+  | 'work-queue'
 
 export interface AppRoute {
   id: AppRouteId
@@ -43,6 +46,7 @@ export const APP_ROUTES = [
   { id: 'command-center', path: COMMAND_CENTER_ROUTE, view: 'command-center' },
   { id: 'skills', path: SKILLS_ROUTE, view: 'skills' },
   { id: 'messaging', path: MESSAGING_ROUTE, view: 'messaging' },
+  { id: 'work-queue', path: WORK_QUEUE_ROUTE, view: 'work-queue' },
   { id: 'artifacts', path: ARTIFACTS_ROUTE, view: 'artifacts' },
   { id: 'cron', path: CRON_ROUTE, view: 'cron' },
   { id: 'profiles', path: PROFILES_ROUTE, view: 'profiles' },
@@ -55,7 +59,7 @@ const RESERVED_PATHS: ReadonlySet<string> = new Set(APP_ROUTES.map(route => rout
 // Views that render as a full-screen modal card (OverlayView) over the shell.
 // While one is open the app's titlebar control clusters must hide so they don't
 // bleed over the overlay (they sit at a higher z-index than the overlay card).
-export const OVERLAY_VIEWS: ReadonlySet<AppView> = new Set(['agents', 'command-center', 'cron', 'profiles', 'settings'])
+export const OVERLAY_VIEWS: ReadonlySet<AppView> = new Set(['agents', 'command-center', 'cron', 'profiles', 'settings', 'work-queue'])
 
 export function isOverlayView(view: AppView): boolean {
   return OVERLAY_VIEWS.has(view)

--- a/apps/desktop/src/app/shell/hooks/use-overlay-routing.ts
+++ b/apps/desktop/src/app/shell/hooks/use-overlay-routing.ts
@@ -16,6 +16,7 @@ export function useOverlayRouting() {
   const agentsOpen = currentView === 'agents'
   const cronOpen = currentView === 'cron'
   const profilesOpen = currentView === 'profiles'
+  const workQueueOpen = currentView === 'work-queue'
   const chatOpen = currentView === 'chat'
   const overlayOpen = isOverlayView(currentView)
 
@@ -66,6 +67,7 @@ export function useOverlayRouting() {
     openCommandCenterSection,
     profilesOpen,
     settingsOpen,
+    workQueueOpen,
     toggleCommandCenter
   }
 }

--- a/apps/desktop/src/app/types.ts
+++ b/apps/desktop/src/app/types.ts
@@ -114,7 +114,7 @@ export type CommandDispatchResponse =
   | SkillCommandDispatchResponse
   | SendCommandDispatchResponse
 
-export type SidebarNavId = 'artifacts' | 'command-center' | 'messaging' | 'new-session' | 'settings' | 'skills'
+export type SidebarNavId = 'artifacts' | 'command-center' | 'messaging' | 'new-session' | 'settings' | 'skills' | 'work-queue'
 
 export interface SidebarNavItem {
   id: SidebarNavId

--- a/apps/desktop/src/app/work-queue/index.tsx
+++ b/apps/desktop/src/app/work-queue/index.tsx
@@ -5,7 +5,7 @@ import { useNavigate } from 'react-router-dom'
 import { PageLoader } from '@/components/page-loader'
 import { Button } from '@/components/ui/button'
 import { Codicon } from '@/components/ui/codicon'
-import { archiveWorkQueueItem, getWorkQueue, snoozeWorkQueueItem, updateWorkQueueItem, type WorkQueueItem } from '@/hermes'
+import { archiveWorkQueueItem, createWorkQueueItem, getWorkQueue, snoozeWorkQueueItem, updateWorkQueueItem, type WorkQueueItem } from '@/hermes'
 import { cn } from '@/lib/utils'
 import { notify, notifyError } from '@/store/notifications'
 
@@ -117,6 +117,24 @@ export function WorkQueueView({ onClose }: WorkQueueViewProps) {
     [refresh]
   )
 
+  const createSampleItem = useCallback(
+    () =>
+      mutate(
+        () =>
+          createWorkQueueItem({
+            title: 'Review sample work item',
+            summary: 'This is a manual test item to confirm the Work Queue is saving and displaying items.',
+            detail: 'Archive or mark this done after confirming the Work Queue works.',
+            source: 'manual',
+            status: 'needs_review',
+            priority: 'normal',
+            actions: ['mark_done', 'archive', 'snooze']
+          }),
+        'Created sample work item'
+      ),
+    [mutate]
+  )
+
   const openSelected = useCallback(() => {
     if (!selected?.source_url) {
       return
@@ -144,10 +162,18 @@ export function WorkQueueView({ onClose }: WorkQueueViewProps) {
           <div className="grid min-h-0 flex-1 grid-cols-[minmax(0,1fr)_minmax(320px,0.45fr)] gap-4">
             <div className="min-h-0 overflow-y-auto rounded-lg border bg-card/40">
               {items.length === 0 ? (
-                <div className="flex h-full min-h-80 flex-col items-center justify-center gap-2 text-center text-muted-foreground">
+                <div className="flex h-full min-h-80 flex-col items-center justify-center gap-3 px-6 text-center text-muted-foreground">
                   <Codicon className="size-8" name="check-all" />
-                  <div className="text-sm font-medium text-foreground">Queue is clear</div>
-                  <div className="max-w-sm text-xs">No failed cron jobs, running desktop actions, active sessions, or manual items need attention.</div>
+                  <div className="space-y-1">
+                    <div className="text-sm font-medium text-foreground">No work items yet</div>
+                    <div className="max-w-md text-xs">
+                      Failed or paused cron jobs, running desktop actions, active sessions, and manual follow-ups will appear here when they need attention.
+                    </div>
+                  </div>
+                  <Button onClick={() => void createSampleItem()} size="sm" variant="outline">
+                    <Codicon className="mr-2 size-4" name="add" />
+                    Create sample item
+                  </Button>
                 </div>
               ) : (
                 <div className="divide-y">

--- a/apps/desktop/src/app/work-queue/index.tsx
+++ b/apps/desktop/src/app/work-queue/index.tsx
@@ -1,0 +1,240 @@
+import type * as React from 'react'
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+
+import { PageLoader } from '@/components/page-loader'
+import { Button } from '@/components/ui/button'
+import { Codicon } from '@/components/ui/codicon'
+import { archiveWorkQueueItem, getWorkQueue, snoozeWorkQueueItem, updateWorkQueueItem, type WorkQueueItem } from '@/hermes'
+import { cn } from '@/lib/utils'
+import { notify, notifyError } from '@/store/notifications'
+
+import { useRefreshHotkey } from '../hooks/use-refresh-hotkey'
+import { OverlayView } from '../overlays/overlay-view'
+
+interface WorkQueueViewProps {
+  onClose: () => void
+}
+
+const STATUS_LABELS: Record<string, string> = {
+  blocked: 'Blocked',
+  done: 'Done',
+  failed: 'Failed',
+  needs_review: 'Needs Vlad',
+  running: 'Running',
+  scheduled: 'Scheduled',
+  snoozed: 'Snoozed'
+}
+
+const STATUS_TONE: Record<string, string> = {
+  blocked: 'bg-amber-500/10 text-amber-600 dark:text-amber-300',
+  done: 'bg-muted text-muted-foreground',
+  failed: 'bg-destructive/10 text-destructive',
+  needs_review: 'bg-primary/10 text-primary',
+  running: 'bg-sky-500/10 text-sky-600 dark:text-sky-300',
+  scheduled: 'bg-muted text-muted-foreground',
+  snoozed: 'bg-muted text-muted-foreground'
+}
+
+const SECTIONS = [
+  { id: 'needs', label: 'Needs Vlad', statuses: ['needs_review', 'blocked', 'failed'] },
+  { id: 'running', label: 'Running', statuses: ['running'] },
+  { id: 'scheduled', label: 'Scheduled', statuses: ['scheduled', 'snoozed'] },
+  { id: 'done', label: 'Done', statuses: ['done'] }
+] as const
+
+function formatWhen(value?: null | string): string {
+  if (!value) {
+    return '—'
+  }
+
+  const date = new Date(value)
+
+  if (Number.isNaN(date.getTime())) {
+    return value
+  }
+
+  return date.toLocaleString(undefined, { dateStyle: 'medium', timeStyle: 'short' })
+}
+
+function statusLabel(status: string): string {
+  return STATUS_LABELS[status] ?? status.replace(/_/g, ' ')
+}
+
+function Pill({ children, className }: { children: React.ReactNode; className?: string }) {
+  return <span className={cn('rounded-full px-2 py-0.5 text-[11px] font-medium', className)}>{children}</span>
+}
+
+export function WorkQueueView({ onClose }: WorkQueueViewProps) {
+  const navigate = useNavigate()
+  const [items, setItems] = useState<WorkQueueItem[]>([])
+  const [selectedId, setSelectedId] = useState<string | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [refreshing, setRefreshing] = useState(false)
+
+  const refresh = useCallback(async () => {
+    setRefreshing(true)
+
+    try {
+      const result = await getWorkQueue()
+      setItems(result.items)
+      setSelectedId(current => current ?? result.items[0]?.id ?? null)
+    } catch (error) {
+      notifyError(error, 'Failed to load work queue')
+    } finally {
+      setLoading(false)
+      setRefreshing(false)
+    }
+  }, [])
+
+  useEffect(() => {
+    void refresh()
+  }, [refresh])
+
+  useRefreshHotkey(() => void refresh())
+
+  const selected = useMemo(() => items.find(item => item.id === selectedId) ?? items[0] ?? null, [items, selectedId])
+
+  const grouped = useMemo(
+    () =>
+      SECTIONS.map(section => ({
+        ...section,
+        items: items.filter(item => section.statuses.includes(item.status as never))
+      })),
+    [items]
+  )
+
+  const mutate = useCallback(
+    async (action: () => Promise<WorkQueueItem>, message: string) => {
+      try {
+        await action()
+        notify({ message })
+        await refresh()
+      } catch (error) {
+        notifyError(error, 'Work queue action failed')
+      }
+    },
+    [refresh]
+  )
+
+  const openSelected = useCallback(() => {
+    if (!selected?.source_url) {
+      return
+    }
+
+    navigate(selected.source_url)
+  }, [navigate, selected])
+
+  return (
+    <OverlayView headerContent={<div className="text-sm font-semibold">Work Queue</div>} onClose={onClose}>
+      <div className="flex h-full min-h-0 flex-col gap-4 p-4">
+        <div className="flex items-center justify-between gap-3">
+          <div>
+            <p className="text-sm text-muted-foreground">Unified cockpit for cron failures, live sessions, desktop actions, and manual follow-up.</p>
+          </div>
+          <Button disabled={refreshing} onClick={() => void refresh()} size="sm" variant="outline">
+            <Codicon className={cn('mr-2 size-4', refreshing && 'animate-spin')} name="refresh" />
+            Refresh
+          </Button>
+        </div>
+
+        {loading ? (
+          <PageLoader label="Loading work queue..." />
+        ) : (
+          <div className="grid min-h-0 flex-1 grid-cols-[minmax(0,1fr)_minmax(320px,0.45fr)] gap-4">
+            <div className="min-h-0 overflow-y-auto rounded-lg border bg-card/40">
+              {items.length === 0 ? (
+                <div className="flex h-full min-h-80 flex-col items-center justify-center gap-2 text-center text-muted-foreground">
+                  <Codicon className="size-8" name="check-all" />
+                  <div className="text-sm font-medium text-foreground">Queue is clear</div>
+                  <div className="max-w-sm text-xs">No failed cron jobs, running desktop actions, active sessions, or manual items need attention.</div>
+                </div>
+              ) : (
+                <div className="divide-y">
+                  {grouped.map(section => (
+                    <section key={section.id}>
+                      <div className="sticky top-0 z-1 flex items-center justify-between bg-background/95 px-3 py-2 backdrop-blur">
+                        <h3 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">{section.label}</h3>
+                        <span className="text-xs text-muted-foreground">{section.items.length}</span>
+                      </div>
+                      {section.items.map(item => (
+                        <button
+                          className={cn(
+                            'flex w-full flex-col gap-2 px-3 py-3 text-left transition-colors hover:bg-muted/50',
+                            selected?.id === item.id && 'bg-muted'
+                          )}
+                          key={item.id}
+                          onClick={() => setSelectedId(item.id)}
+                          type="button"
+                        >
+                          <div className="flex items-start justify-between gap-3">
+                            <div className="min-w-0">
+                              <div className="truncate text-sm font-medium">{item.title}</div>
+                              {item.summary ? <div className="mt-1 line-clamp-2 text-xs text-muted-foreground">{item.summary}</div> : null}
+                            </div>
+                            <Pill className={STATUS_TONE[item.status] ?? 'bg-muted text-muted-foreground'}>{statusLabel(item.status)}</Pill>
+                          </div>
+                          <div className="flex flex-wrap items-center gap-2 text-[11px] text-muted-foreground">
+                            <span>{item.source}</span>
+                            <span>·</span>
+                            <span>{item.priority}</span>
+                            <span>·</span>
+                            <span>{formatWhen(item.updated_at)}</span>
+                          </div>
+                        </button>
+                      ))}
+                    </section>
+                  ))}
+                </div>
+              )}
+            </div>
+
+            <aside className="min-h-0 overflow-hidden rounded-lg border bg-card/40">
+              {selected ? (
+                <div className="flex h-full min-h-0 flex-col">
+                  <div className="border-b p-4">
+                    <div className="flex items-start justify-between gap-3">
+                      <div className="min-w-0">
+                        <h2 className="text-base font-semibold">{selected.title}</h2>
+                        <p className="mt-1 text-xs text-muted-foreground">{selected.id}</p>
+                      </div>
+                      <Pill className={STATUS_TONE[selected.status] ?? 'bg-muted text-muted-foreground'}>{statusLabel(selected.status)}</Pill>
+                    </div>
+                  </div>
+
+                  <div className="min-h-0 flex-1 space-y-4 overflow-y-auto p-4 text-sm">
+                    {selected.summary ? <p className="text-muted-foreground">{selected.summary}</p> : null}
+                    <dl className="grid grid-cols-2 gap-3 text-xs">
+                      <div><dt className="text-muted-foreground">Source</dt><dd>{selected.source}</dd></div>
+                      <div><dt className="text-muted-foreground">Priority</dt><dd>{selected.priority}</dd></div>
+                      <div><dt className="text-muted-foreground">Updated</dt><dd>{formatWhen(selected.updated_at)}</dd></div>
+                      <div><dt className="text-muted-foreground">Due</dt><dd>{formatWhen(selected.due_at)}</dd></div>
+                      {selected.actor ? <div><dt className="text-muted-foreground">Actor</dt><dd>{selected.actor}</dd></div> : null}
+                      {selected.client_name ? <div><dt className="text-muted-foreground">Client</dt><dd>{selected.client_name}</dd></div> : null}
+                    </dl>
+                    {selected.detail ? (
+                      <pre className="max-h-80 overflow-auto whitespace-pre-wrap rounded-md bg-muted p-3 text-xs text-muted-foreground">{selected.detail}</pre>
+                    ) : null}
+                  </div>
+
+                  <div className="flex flex-wrap gap-2 border-t p-4">
+                    {selected.source_url ? <Button onClick={openSelected} size="sm">Open</Button> : null}
+                    <Button onClick={() => void mutate(() => updateWorkQueueItem(selected.id, { status: 'done' }), 'Marked done')} size="sm" variant="outline">Mark done</Button>
+                    <Button onClick={() => void mutate(() => archiveWorkQueueItem(selected.id), 'Archived')} size="sm" variant="outline">Archive</Button>
+                    <Button
+                      onClick={() => void mutate(() => snoozeWorkQueueItem(selected.id, new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString()), 'Snoozed for 24 hours')}
+                      size="sm"
+                      variant="outline"
+                    >
+                      Snooze
+                    </Button>
+                  </div>
+                </div>
+              ) : null}
+            </aside>
+          </div>
+        )}
+      </div>
+    </OverlayView>
+  )
+}

--- a/apps/desktop/src/hermes.ts
+++ b/apps/desktop/src/hermes.ts
@@ -39,7 +39,11 @@ import type {
   SkillInfo,
   StatusResponse,
   ToolsetConfig,
-  ToolsetInfo
+  ToolsetInfo,
+  WorkQueueItem,
+  WorkQueueItemCreatePayload,
+  WorkQueueItemPatchPayload,
+  WorkQueueResponse
 } from '@/types/hermes'
 
 const DEFAULT_GATEWAY_REQUEST_TIMEOUT_MS = 30_000
@@ -101,7 +105,11 @@ export type {
   StaleAuxAssignment,
   StatusResponse,
   ToolsetConfig,
-  ToolsetInfo
+  ToolsetInfo,
+  WorkQueueItem,
+  WorkQueueItemCreatePayload,
+  WorkQueueItemPatchPayload,
+  WorkQueueResponse
 } from '@/types/hermes'
 
 export class HermesGateway extends JsonRpcGatewayClient {
@@ -518,6 +526,43 @@ export function testMessagingPlatform(platformId: string): Promise<MessagingPlat
   return window.hermesDesktop.api<MessagingPlatformTestResponse>({
     path: `/api/messaging/platforms/${encodeURIComponent(platformId)}/test`,
     method: 'POST'
+  })
+}
+
+export function getWorkQueue(): Promise<WorkQueueResponse> {
+  return window.hermesDesktop.api<WorkQueueResponse>({
+    path: '/api/work-queue'
+  })
+}
+
+export function createWorkQueueItem(body: WorkQueueItemCreatePayload): Promise<WorkQueueItem> {
+  return window.hermesDesktop.api<WorkQueueItem>({
+    path: '/api/work-queue/items',
+    method: 'POST',
+    body
+  })
+}
+
+export function updateWorkQueueItem(itemId: string, body: WorkQueueItemPatchPayload): Promise<WorkQueueItem> {
+  return window.hermesDesktop.api<WorkQueueItem>({
+    path: `/api/work-queue/items/${encodeURIComponent(itemId)}`,
+    method: 'PATCH',
+    body
+  })
+}
+
+export function archiveWorkQueueItem(itemId: string): Promise<WorkQueueItem> {
+  return window.hermesDesktop.api<WorkQueueItem>({
+    path: `/api/work-queue/items/${encodeURIComponent(itemId)}/archive`,
+    method: 'POST'
+  })
+}
+
+export function snoozeWorkQueueItem(itemId: string, snoozedUntil: string): Promise<WorkQueueItem> {
+  return window.hermesDesktop.api<WorkQueueItem>({
+    path: `/api/work-queue/items/${encodeURIComponent(itemId)}/snooze`,
+    method: 'POST',
+    body: { snoozed_until: snoozedUntil }
   })
 }
 

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -1148,6 +1148,7 @@ export const en: Translations = {
       'new-session': 'New session',
       skills: 'Skills & Tools',
       messaging: 'Messaging',
+      'work-queue': 'Work Queue',
       artifacts: 'Artifacts'
     },
     searchAria: 'Search sessions',

--- a/apps/desktop/src/types/hermes.ts
+++ b/apps/desktop/src/types/hermes.ts
@@ -437,6 +437,65 @@ export interface AnalyticsTotals {
   total_sessions: number
 }
 
+export type WorkQueueSource = 'action' | 'cron' | 'email' | 'ignition' | 'manual' | 'messaging' | 'qbo' | 'session' | string
+export type WorkQueueStatus = 'archived' | 'blocked' | 'done' | 'failed' | 'needs_review' | 'running' | 'scheduled' | 'snoozed' | string
+export type WorkQueuePriority = 'high' | 'low' | 'normal' | 'urgent' | string
+
+export interface WorkQueueItem {
+  actions: string[]
+  actor?: null | string
+  client_name?: null | string
+  created_at: string
+  derived?: boolean
+  detail?: string
+  due_at?: null | string
+  id: string
+  metadata?: Record<string, unknown>
+  priority: WorkQueuePriority
+  session_id?: null | string
+  snoozed_until?: null | string
+  source: WorkQueueSource
+  source_url?: null | string
+  status: WorkQueueStatus
+  summary?: string
+  title: string
+  updated_at: string
+}
+
+export interface WorkQueueResponse {
+  items: WorkQueueItem[]
+}
+
+export interface WorkQueueItemCreatePayload {
+  actions?: string[]
+  actor?: string
+  client_name?: string
+  detail?: string
+  due_at?: string
+  priority?: string
+  session_id?: string
+  source?: string
+  source_url?: string
+  status?: string
+  summary?: string
+  title: string
+}
+
+export interface WorkQueueItemPatchPayload {
+  actions?: string[]
+  actor?: string
+  client_name?: string
+  detail?: string
+  due_at?: string
+  priority?: string
+  session_id?: string
+  snoozed_until?: string
+  source_url?: string
+  status?: string
+  summary?: string
+  title?: string
+}
+
 export interface CronJob {
   deliver?: null | string
   enabled: boolean

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -77,7 +77,7 @@ try:
     from fastapi.middleware.cors import CORSMiddleware
     from fastapi.responses import FileResponse, HTMLResponse, JSONResponse, Response
     from fastapi.staticfiles import StaticFiles
-    from pydantic import BaseModel
+    from pydantic import BaseModel, Field
 except ImportError:
     # First try lazy-installing the dashboard extras. Only the user actually
     # running `hermes dashboard` needs fastapi+uvicorn; lazy install keeps
@@ -92,7 +92,7 @@ except ImportError:
         from fastapi.middleware.cors import CORSMiddleware
         from fastapi.responses import FileResponse, HTMLResponse, JSONResponse, Response
         from fastapi.staticfiles import StaticFiles
-        from pydantic import BaseModel
+        from pydantic import BaseModel, Field
     except Exception:
         raise SystemExit(
             "Web UI requires fastapi and uvicorn.\n"
@@ -7130,6 +7130,326 @@ def _find_cron_job_profile(job_id: str) -> Optional[str]:
         if any(j.get("id") == job_id or j.get("name") == job_id for j in jobs):
             return name
     return None
+
+
+# ---------------------------------------------------------------------------
+# Work queue endpoints — canonical cockpit read model for desktop.
+# ---------------------------------------------------------------------------
+
+_WORK_QUEUE_DIRNAME = "work_queue"
+_WORK_QUEUE_ITEMS_FILE = "items.json"
+
+
+class WorkQueueItemCreate(BaseModel):
+    title: str
+    summary: Optional[str] = None
+    detail: Optional[str] = None
+    source: str = "manual"
+    status: str = "needs_review"
+    priority: str = "normal"
+    actor: Optional[str] = None
+    client_name: Optional[str] = None
+    source_url: Optional[str] = None
+    session_id: Optional[str] = None
+    due_at: Optional[str] = None
+    actions: List[str] = Field(default_factory=list)
+
+
+class WorkQueueItemPatch(BaseModel):
+    title: Optional[str] = None
+    summary: Optional[str] = None
+    detail: Optional[str] = None
+    status: Optional[str] = None
+    priority: Optional[str] = None
+    actor: Optional[str] = None
+    client_name: Optional[str] = None
+    source_url: Optional[str] = None
+    session_id: Optional[str] = None
+    due_at: Optional[str] = None
+    snoozed_until: Optional[str] = None
+    actions: Optional[List[str]] = None
+
+
+def _model_patch_dict(model: BaseModel) -> Dict[str, Any]:
+    if hasattr(model, "model_dump"):
+        return model.model_dump(exclude_unset=True)
+    return model.dict(exclude_unset=True)
+
+
+def _utc_now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def _work_queue_file() -> Path:
+    return get_hermes_home() / _WORK_QUEUE_DIRNAME / _WORK_QUEUE_ITEMS_FILE
+
+
+def _load_manual_work_items() -> List[Dict[str, Any]]:
+    path = _work_queue_file()
+    if not path.exists():
+        return []
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        _log.exception("Failed to read work queue items")
+        return []
+    items = data.get("items") if isinstance(data, dict) else data
+    return [item for item in items if isinstance(item, dict)] if isinstance(items, list) else []
+
+
+def _save_manual_work_items(items: List[Dict[str, Any]]) -> None:
+    path = _work_queue_file()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps({"items": items}, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def _work_item(
+    *,
+    id: str,
+    source: str,
+    status: str,
+    priority: str,
+    title: str,
+    summary: str = "",
+    detail: str = "",
+    created_at: Optional[str] = None,
+    updated_at: Optional[str] = None,
+    due_at: Optional[str] = None,
+    actor: Optional[str] = None,
+    client_name: Optional[str] = None,
+    source_url: Optional[str] = None,
+    session_id: Optional[str] = None,
+    actions: Optional[List[str]] = None,
+    metadata: Optional[Dict[str, Any]] = None,
+    derived: bool = True,
+) -> Dict[str, Any]:
+    now = _utc_now_iso()
+    return {
+        "id": id,
+        "source": source,
+        "status": status,
+        "priority": priority,
+        "title": title,
+        "summary": summary,
+        "detail": detail,
+        "created_at": created_at or updated_at or now,
+        "updated_at": updated_at or created_at or now,
+        "due_at": due_at,
+        "actor": actor,
+        "client_name": client_name,
+        "source_url": source_url,
+        "session_id": session_id,
+        "actions": actions or ["open", "archive"],
+        "metadata": metadata or {},
+        "derived": derived,
+    }
+
+
+def _cron_work_items() -> List[Dict[str, Any]]:
+    items: List[Dict[str, Any]] = []
+    try:
+        cron_jobs_list: List[Dict[str, Any]] = []
+        for profile in _cron_profile_dicts():
+            name = str(profile.get("name") or "")
+            if not name:
+                continue
+            try:
+                cron_jobs_list.extend(_call_cron_for_profile(name, "list_jobs", True))
+            except Exception:
+                _log.exception("Work queue failed to list cron jobs for profile %s", name)
+        for job in cron_jobs_list:
+            job_id = str(job.get("id") or job.get("name") or "")
+            if not job_id:
+                continue
+            name = str(job.get("name") or job.get("prompt") or job_id)
+            state = str(job.get("state") or ("disabled" if job.get("enabled") is False else "scheduled"))
+            last_status = str(job.get("last_status") or "")
+            last_error = str(job.get("last_error") or "")
+            profile_name = str(job.get("profile") or "default")
+            if last_error or last_status == "error" or state == "error":
+                items.append(_work_item(
+                    id=f"cron:failed:{profile_name}:{job_id}", source="cron", status="failed", priority="high",
+                    title=f"Cron failed: {name}", summary=last_error or "Last cron run failed.", detail=json.dumps(job, indent=2, default=str),
+                    updated_at=job.get("last_run_at") or job.get("updated_at"), due_at=job.get("next_run_at"),
+                    source_url=f"/cron?job={urllib.parse.quote(job_id)}", actions=["open", "archive"], metadata={"job_id": job_id, "profile": profile_name},
+                ))
+            elif state in {"paused", "disabled"} or job.get("enabled") is False:
+                items.append(_work_item(
+                    id=f"cron:paused:{profile_name}:{job_id}", source="cron", status="blocked", priority="normal",
+                    title=f"Cron paused: {name}", summary="This scheduled job is not currently running.", detail=json.dumps(job, indent=2, default=str),
+                    updated_at=job.get("updated_at") or job.get("last_run_at"), due_at=job.get("next_run_at"),
+                    source_url=f"/cron?job={urllib.parse.quote(job_id)}", actions=["open", "archive"], metadata={"job_id": job_id, "profile": profile_name},
+                ))
+    except Exception:
+        _log.exception("Failed to build cron work queue items")
+    return items
+
+
+def _session_work_items() -> List[Dict[str, Any]]:
+    items: List[Dict[str, Any]] = []
+    try:
+        from hermes_state import SessionDB
+        db = SessionDB()
+        try:
+            sessions = db.list_sessions_rich(limit=20, offset=0, min_message_count=0, order_by_last_active=True)
+        finally:
+            db.close()
+        now = time.time()
+        for session in sessions:
+            last_active = float(session.get("last_active") or session.get("started_at") or 0)
+            if session.get("ended_at") is None and last_active and now - last_active < 300:
+                sid = str(session.get("id") or "")
+                if not sid:
+                    continue
+                title = str(session.get("title") or session.get("preview") or sid)
+                items.append(_work_item(
+                    id=f"session:running:{sid}", source="session", status="running", priority="normal",
+                    title=f"Running session: {title}", summary=str(session.get("preview") or "Hermes session active in the last 5 minutes."),
+                    updated_at=datetime.fromtimestamp(last_active, tz=timezone.utc).isoformat().replace("+00:00", "Z"),
+                    source_url=f"/{urllib.parse.quote(sid)}", session_id=sid, actions=["open"], metadata={"session": session},
+                ))
+    except Exception:
+        _log.exception("Failed to build session work queue items")
+    return items
+
+
+def _action_work_items() -> List[Dict[str, Any]]:
+    items: List[Dict[str, Any]] = []
+    names = sorted(set(_ACTION_LOG_FILES) | set(_ACTION_PROCS) | set(_ACTION_RESULTS))
+    for name in names:
+        proc = _ACTION_PROCS.get(name)
+        result = _ACTION_RESULTS.get(name)
+        if proc is not None:
+            exit_code = proc.poll()
+            if exit_code is None:
+                items.append(_work_item(
+                    id=f"action:running:{name}", source="action", status="running", priority="normal",
+                    title=f"Action running: {name.replace('-', ' ')}", summary="Desktop action is still running.",
+                    detail="\n".join(_tail_lines(_ACTION_LOG_DIR / _ACTION_LOG_FILES[name], 80)), actions=["open"], metadata={"action": name},
+                ))
+            elif exit_code != 0:
+                items.append(_work_item(
+                    id=f"action:failed:{name}", source="action", status="failed", priority="high",
+                    title=f"Action failed: {name.replace('-', ' ')}", summary=f"Exited with code {exit_code}.",
+                    detail="\n".join(_tail_lines(_ACTION_LOG_DIR / _ACTION_LOG_FILES[name], 80)), actions=["open", "archive"], metadata={"action": name, "exit_code": exit_code},
+                ))
+        elif result and result.get("exit_code") not in (None, 0):
+            items.append(_work_item(
+                id=f"action:failed:{name}", source="action", status="failed", priority="high",
+                title=f"Action failed: {name.replace('-', ' ')}", summary=f"Exited with code {result.get('exit_code')}.",
+                detail="\n".join(_tail_lines(_ACTION_LOG_DIR / _ACTION_LOG_FILES[name], 80)), actions=["open", "archive"], metadata={"action": name, **result},
+            ))
+    return items
+
+
+def _derived_work_items() -> List[Dict[str, Any]]:
+    return [*_cron_work_items(), *_session_work_items(), *_action_work_items()]
+
+
+def _is_derived_override(item: Dict[str, Any]) -> bool:
+    return bool(item.get("derived")) and item.get("source") != "manual"
+
+
+def _all_work_items() -> List[Dict[str, Any]]:
+    manual = _load_manual_work_items()
+    derived = _derived_work_items()
+    overrides = {str(item.get("id")): item for item in manual if _is_derived_override(item)}
+    derived_ids = {str(item.get("id")) for item in derived}
+
+    items = [item for item in manual if not _is_derived_override(item)]
+    for item in derived:
+        item_id = str(item.get("id") or "")
+        override = overrides.get(item_id)
+        if override:
+            if override.get("status") == "archived":
+                continue
+            merged = {**item, **override, "id": item_id, "derived": True, "metadata": {**item.get("metadata", {}), **override.get("metadata", {})}}
+            items.append(merged)
+        else:
+            items.append(item)
+
+    # Preserve derived overrides whose underlying source is no longer active so
+    # completed/snoozed decisions remain visible until archived.
+    for item_id, override in overrides.items():
+        if item_id not in derived_ids and override.get("status") != "archived":
+            items.append(override)
+    return sorted(items, key=lambda item: str(item.get("updated_at") or item.get("created_at") or ""), reverse=True)
+
+
+@app.get("/api/work-queue")
+async def list_work_queue(status: Optional[str] = None, source: Optional[str] = None):
+    items = _all_work_items()
+    if status:
+        allowed = {part.strip() for part in status.split(",") if part.strip()}
+        items = [item for item in items if item.get("status") in allowed]
+    if source:
+        allowed = {part.strip() for part in source.split(",") if part.strip()}
+        items = [item for item in items if item.get("source") in allowed]
+    return {"items": items}
+
+
+@app.post("/api/work-queue/items")
+async def create_work_queue_item(body: WorkQueueItemCreate):
+    now = _utc_now_iso()
+    item = _work_item(
+        id=f"manual:{secrets.token_urlsafe(12)}", source=body.source, status=body.status, priority=body.priority,
+        title=body.title, summary=body.summary or "", detail=body.detail or "", created_at=now, updated_at=now,
+        due_at=body.due_at, actor=body.actor, client_name=body.client_name, source_url=body.source_url,
+        session_id=body.session_id, actions=body.actions or ["open", "archive", "snooze", "mark_done"], derived=False,
+    )
+    items = _load_manual_work_items()
+    items.append(item)
+    _save_manual_work_items(items)
+    return item
+
+
+def _upsert_manual_patch(item_id: str, patch: Dict[str, Any]) -> Dict[str, Any]:
+    items = _load_manual_work_items()
+    now = _utc_now_iso()
+    for item in items:
+        if item.get("id") == item_id:
+            item.update({k: v for k, v in patch.items() if v is not None})
+            item["updated_at"] = now
+            _save_manual_work_items(items)
+            return item
+
+    base = next((item for item in _derived_work_items() if item.get("id") == item_id), None)
+    if base:
+        item = {**base, **{k: v for k, v in patch.items() if v is not None}, "id": item_id, "derived": True, "updated_at": now}
+        item.setdefault("created_at", base.get("created_at") or now)
+    else:
+        item = {
+            "id": item_id,
+            "source": "derived",
+            "status": "needs_review",
+            "priority": "normal",
+            "title": item_id,
+            "summary": "",
+            "detail": "",
+            "created_at": now,
+            "updated_at": now,
+            "derived": True,
+            **{k: v for k, v in patch.items() if v is not None},
+        }
+    items.append(item)
+    _save_manual_work_items(items)
+    return item
+
+
+@app.patch("/api/work-queue/items/{item_id:path}")
+async def patch_work_queue_item(item_id: str, body: WorkQueueItemPatch):
+    return _upsert_manual_patch(item_id, _model_patch_dict(body))
+
+
+@app.post("/api/work-queue/items/{item_id:path}/archive")
+async def archive_work_queue_item(item_id: str):
+    return _upsert_manual_patch(item_id, {"status": "archived"})
+
+
+@app.post("/api/work-queue/items/{item_id:path}/snooze")
+async def snooze_work_queue_item(item_id: str, body: WorkQueueItemPatch):
+    until = body.snoozed_until or body.due_at
+    return _upsert_manual_patch(item_id, {"status": "snoozed", "snoozed_until": until})
 
 
 @app.get("/api/cron/jobs")

--- a/tests/hermes_cli/test_web_server_work_queue.py
+++ b/tests/hermes_cli/test_web_server_work_queue.py
@@ -1,0 +1,99 @@
+"""Tests for the Desktop Work Queue API."""
+
+import pytest
+
+
+def _client(monkeypatch, _isolate_hermes_home):
+    try:
+        from starlette.testclient import TestClient
+    except ImportError:  # pragma: no cover - dependency guard
+        pytest.skip("fastapi/starlette not installed")
+
+    import hermes_state
+    from hermes_constants import get_hermes_home
+    from hermes_cli import web_server
+
+    monkeypatch.setattr(hermes_state, "DEFAULT_DB_PATH", get_hermes_home() / "state.db")
+    client = TestClient(web_server.app)
+    client.headers[web_server._SESSION_HEADER_NAME] = web_server._SESSION_TOKEN
+    return client, web_server
+
+
+def test_work_queue_manual_item_round_trip(monkeypatch, _isolate_hermes_home):
+    client, _web_server = _client(monkeypatch, _isolate_hermes_home)
+
+    resp = client.get("/api/work-queue")
+    assert resp.status_code == 200
+    assert resp.json() == {"items": []}
+
+    resp = client.post(
+        "/api/work-queue/items",
+        json={"title": "Call client", "summary": "Needs follow-up", "priority": "high"},
+    )
+    assert resp.status_code == 200
+    item = resp.json()
+    assert item["id"].startswith("manual:")
+    assert item["title"] == "Call client"
+    assert item["priority"] == "high"
+    assert item["derived"] is False
+
+    resp = client.patch(f"/api/work-queue/items/{item['id']}", json={"status": "done"})
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "done"
+
+    resp = client.post(
+        f"/api/work-queue/items/{item['id']}/snooze",
+        json={"snoozed_until": "2030-01-01T00:00:00Z"},
+    )
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "snoozed"
+    assert resp.json()["snoozed_until"] == "2030-01-01T00:00:00Z"
+
+    resp = client.get("/api/work-queue?status=snoozed")
+    assert resp.status_code == 200
+    assert [row["id"] for row in resp.json()["items"]] == [item["id"]]
+
+
+def test_work_queue_derived_overrides_merge_and_archive(monkeypatch, _isolate_hermes_home):
+    client, web_server = _client(monkeypatch, _isolate_hermes_home)
+
+    def fake_derived():
+        return [
+            web_server._work_item(
+                id="cron:failed:default:abc",
+                source="cron",
+                status="failed",
+                priority="high",
+                title="Cron failed: abc",
+                metadata={"job_id": "abc"},
+            )
+        ]
+
+    monkeypatch.setattr(web_server, "_derived_work_items", fake_derived)
+
+    resp = client.get("/api/work-queue")
+    assert resp.status_code == 200
+    rows = [row for row in resp.json()["items"] if row["id"] == "cron:failed:default:abc"]
+    assert len(rows) == 1
+    assert rows[0]["status"] == "failed"
+
+    resp = client.patch("/api/work-queue/items/cron:failed:default:abc", json={"status": "done"})
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "done"
+    assert resp.json()["title"] == "Cron failed: abc"
+
+    resp = client.get("/api/work-queue")
+    assert resp.status_code == 200
+    rows = [row for row in resp.json()["items"] if row["id"] == "cron:failed:default:abc"]
+    assert len(rows) == 1
+    assert rows[0]["status"] == "done"
+    assert rows[0]["metadata"]["job_id"] == "abc"
+
+    resp = client.post("/api/work-queue/items/cron:failed:default:abc/archive")
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "archived"
+
+    resp = client.get("/api/work-queue")
+    assert resp.status_code == 200
+    rows = [row for row in resp.json()["items"] if row["id"] == "cron:failed:default:abc"]
+    assert rows == []


### PR DESCRIPTION
## Summary

Adds a Desktop Work Queue MVP: a unified overlay page for actionable Hermes-native items, backed by a small API and persistent manual-item store.

## What changed

- Adds `/api/work-queue` read/write endpoints for manual queue items and derived items.
- Derives queue items from failed/paused cron jobs, running sessions, and running/failed desktop actions.
- Persists manual queue items and derived-item overrides under `~/.hermes/work_queue/items.json`.
- Adds Desktop TypeScript types and API client wrappers.
- Adds a new `/work-queue` overlay route and sidebar entry.
- Adds a Work Queue UI with grouped sections, detail panel, refresh, mark done, archive, and snooze actions.
- Adds backend tests for manual items, filtering, derived override merge, and derived archive suppression.

## Verification

- `python3 -m pytest tests/hermes_cli/test_web_server_work_queue.py -q -o 'addopts='` -> 2 passed
- `npm run typecheck` -> passed
- `npx eslint src/app/work-queue/index.tsx src/app/routes.ts src/app/shell/hooks/use-overlay-routing.ts src/app/desktop-controller.tsx src/app/chat/sidebar/index.tsx src/hermes.ts src/types/hermes.ts` -> passed
- `npm run build` -> passed
- `git diff --check` -> passed

## Notes

This intentionally starts with Hermes-native sources only. External adapters such as Gmail, QBO, Ignition, Telegram, and OpenClaw can feed the same queue model later without expanding the Desktop surface area for each integration.
