### PR TITLE
fix(desktop): honor profile-scoped HERMES_HOME when launching backend

### DIFF
--- a/apps/desktop/electron/backend-env.test.ts
+++ b/apps/desktop/electron/backend-env.test.ts
@@ -9,7 +9,8 @@ import {
   buildDesktopBackendPath,
   normalizeHermesHomeRoot,
   pathEnvKey,
-  POSIX_SANE_PATH_ENTRIES
+  POSIX_SANE_PATH_ENTRIES,
+  splitHermesHomeRootAndProfile
 } from './backend-env'
 
 test('desktop backend PATH adds Hermes-managed bins and missing POSIX sane entries', () => {
@@ -78,6 +79,30 @@ test('normalizeHermesHomeRoot maps profile homes back to the global Hermes root'
     'C:\\Users\\test\\AppData\\Local\\hermes'
   )
   assert.equal(normalizeHermesHomeRoot('/Users/test/.hermes', { pathModule: path.posix }), '/Users/test/.hermes')
+})
+
+test('splitHermesHomeRootAndProfile extracts profile hints from profile-scoped homes', () => {
+  assert.deepEqual(splitHermesHomeRootAndProfile('/Users/test/.hermes/profiles/oracle', { pathModule: path.posix }), {
+    profileHint: 'oracle',
+    root: '/Users/test/.hermes'
+  })
+
+  assert.deepEqual(
+    splitHermesHomeRootAndProfile('C:\\Users\\test\\AppData\\Local\\hermes\\profiles\\coder', {
+      pathModule: path.win32
+    }),
+    {
+      profileHint: 'coder',
+      root: 'C:\\Users\\test\\AppData\\Local\\hermes'
+    }
+  )
+})
+
+test('splitHermesHomeRootAndProfile returns null profile hint for global homes', () => {
+  assert.deepEqual(splitHermesHomeRootAndProfile('/Users/test/.hermes', { pathModule: path.posix }), {
+    profileHint: null,
+    root: '/Users/test/.hermes'
+  })
 })
 
 test('Windows PATH casing and delimiter are preserved without POSIX sane entries', () => {

--- a/apps/desktop/electron/backend-env.ts
+++ b/apps/desktop/electron/backend-env.ts
@@ -75,19 +75,29 @@ function buildDesktopBackendPath({
   return appendUniquePathEntries([hermesNodeBin, venvBin, currentPath, saneEntries], { delimiter })
 }
 
-function normalizeHermesHomeRoot(hermesHome, { pathModule = pathModuleForPlatform(process.platform) }: any = {}) {
+function splitHermesHomeRootAndProfile(
+  hermesHome,
+  { pathModule = pathModuleForPlatform(process.platform) }: any = {}
+) {
   if (!hermesHome) {
-    return hermesHome
+    return { profileHint: null, root: hermesHome }
   }
 
   const resolved = pathModule.resolve(String(hermesHome))
   const parent = pathModule.dirname(resolved)
 
   if (pathModule.basename(parent).toLowerCase() === 'profiles') {
-    return pathModule.dirname(parent)
+    return {
+      profileHint: pathModule.basename(resolved) || null,
+      root: pathModule.dirname(parent)
+    }
   }
 
-  return resolved
+  return { profileHint: null, root: resolved }
+}
+
+function normalizeHermesHomeRoot(hermesHome, { pathModule = pathModuleForPlatform(process.platform) }: any = {}) {
+  return splitHermesHomeRootAndProfile(hermesHome, { pathModule }).root
 }
 
 function buildDesktopBackendEnv({
@@ -121,5 +131,6 @@ export {
   delimiterForPlatform,
   normalizeHermesHomeRoot,
   pathEnvKey,
-  POSIX_SANE_PATH_ENTRIES
+  POSIX_SANE_PATH_ENTRIES,
+  splitHermesHomeRootAndProfile
 }

--- a/apps/desktop/electron/desktop-launch-profile.test.ts
+++ b/apps/desktop/electron/desktop-launch-profile.test.ts
@@ -1,0 +1,60 @@
+import assert from 'node:assert/strict'
+import path from 'node:path'
+
+import { test } from 'vitest'
+
+import { splitHermesHomeRootAndProfile } from './backend-env'
+import {
+  preferredDesktopLaunchProfile,
+  primaryBackendArgsFromLaunch,
+  primaryProfileKeyFromLaunch,
+  sanitizeProfileHint
+} from './desktop-launch-profile'
+
+test('sanitizeProfileHint accepts default and valid profile ids', () => {
+  assert.equal(sanitizeProfileHint('Oracle'), 'oracle')
+  assert.equal(sanitizeProfileHint('default'), 'default')
+  assert.equal(sanitizeProfileHint('bad name'), null)
+  assert.equal(sanitizeProfileHint(''), null)
+})
+
+test('preferredDesktopLaunchProfile prefers env hint over desktop preference', () => {
+  assert.equal(
+    preferredDesktopLaunchProfile({ profileHint: 'oracle', preference: 'coder' }),
+    'oracle'
+  )
+  assert.equal(preferredDesktopLaunchProfile({ profileHint: null, preference: 'coder' }), 'coder')
+  assert.equal(preferredDesktopLaunchProfile({ profileHint: null, preference: null }), null)
+})
+
+test('launch contract: inferred profiles/<name> selects primary and --profile when preference unset', () => {
+  const parsed = splitHermesHomeRootAndProfile('/Users/test/.hermes/profiles/oracle', {
+    pathModule: path.posix
+  })
+  const profileHint = sanitizeProfileHint(parsed.profileHint)
+  const preference = null
+
+  assert.equal(parsed.root, '/Users/test/.hermes')
+  assert.equal(profileHint, 'oracle')
+  assert.equal(primaryProfileKeyFromLaunch({ profileHint, preference }), 'oracle')
+  assert.deepEqual(primaryBackendArgsFromLaunch({ profileHint, preference }), [
+    '--profile',
+    'oracle',
+    'serve',
+    '--host',
+    '127.0.0.1',
+    '--port',
+    '0'
+  ])
+})
+
+test('launch contract: unset hint + unset preference keeps legacy launch (no --profile)', () => {
+  assert.equal(primaryProfileKeyFromLaunch({ profileHint: null, preference: null }), 'default')
+  assert.deepEqual(primaryBackendArgsFromLaunch({ profileHint: null, preference: null }), [
+    'serve',
+    '--host',
+    '127.0.0.1',
+    '--port',
+    '0'
+  ])
+})

--- a/apps/desktop/electron/desktop-launch-profile.ts
+++ b/apps/desktop/electron/desktop-launch-profile.ts
@@ -1,0 +1,62 @@
+'use strict'
+
+// Pure helpers for which Hermes profile the desktop primary backend launches
+// as. Kept outside main.ts so the launch contract can be unit-tested without
+// Electron: a profile-scoped HERMES_HOME (.../profiles/<name>) must produce
+// `--profile <name>` when the desktop preference is unset.
+
+import { serveBackendArgs } from './backend-command'
+
+/** Mirrors hermes_cli.profiles._PROFILE_ID_RE. */
+export const PROFILE_NAME_RE = /^[a-z0-9][a-z0-9_-]{0,63}$/
+
+export function sanitizeProfileHint(raw: unknown): string | null {
+  const candidate = String(raw || '')
+    .trim()
+    .toLowerCase()
+
+  if (!candidate) {
+    return null
+  }
+
+  if (candidate === 'default' || PROFILE_NAME_RE.test(candidate)) {
+    return candidate
+  }
+
+  return null
+}
+
+/**
+ * Prefer an environment-derived profile hint (from a profile-scoped
+ * HERMES_HOME) over the desktop's stored preference. Either may be null.
+ */
+export function preferredDesktopLaunchProfile({
+  profileHint = null,
+  preference = null
+}: {
+  profileHint?: string | null
+  preference?: string | null
+} = {}): string | null {
+  return profileHint || preference || null
+}
+
+export function primaryProfileKeyFromLaunch(options?: {
+  profileHint?: string | null
+  preference?: string | null
+}): string {
+  return preferredDesktopLaunchProfile(options) || 'default'
+}
+
+/**
+ * Argv the primary (window) backend should spawn with for a given
+ * hint + preference. Matches startHermes(): unset preference + no hint keeps
+ * the legacy launch (no `--profile`); otherwise pin via `--profile`.
+ */
+export function primaryBackendArgsFromLaunch(options?: {
+  profileHint?: string | null
+  preference?: string | null
+}): string[] {
+  const active = preferredDesktopLaunchProfile(options)
+
+  return serveBackendArgs(active || undefined)
+}

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -31,7 +31,13 @@ import nodePty from 'node-pty'
 
 import { stopBackendChild as stopBackendChildImpl } from './backend-child'
 import { dashboardFallbackArgs, sourceDeclaresServe } from './backend-command'
-import { buildDesktopBackendEnv, normalizeHermesHomeRoot } from './backend-env'
+import { buildDesktopBackendEnv, splitHermesHomeRootAndProfile } from './backend-env'
+import {
+  preferredDesktopLaunchProfile,
+  primaryProfileKeyFromLaunch,
+  PROFILE_NAME_RE,
+  sanitizeProfileHint
+} from './desktop-launch-profile'
 import { canImportHermesCli, verifyHermesCli } from './backend-probes'
 import { waitForDashboardPortAnnouncement } from './backend-ready'
 import { detectRemoteDisplay, isWindowsBinaryPathInWsl, isWslEnvironment } from './bootstrap-platform'
@@ -290,13 +296,15 @@ if (INSTALL_STAMP) {
 // HERMES_DESKTOP_USER_DATA_DIR (used by test:desktop:fresh) puts the sandbox
 // HERMES_HOME beneath the throwaway userData dir so a fresh-install run never
 // touches the user's real ~/.hermes / %LOCALAPPDATA%\hermes.
-function resolveHermesHome() {
+function resolveHermesHomeContext() {
   if (process.env.HERMES_HOME) {
-    return normalizeHermesHomeRoot(process.env.HERMES_HOME)
+    const parsed = splitHermesHomeRootAndProfile(process.env.HERMES_HOME)
+
+    return { profileHint: parsed.profileHint, home: parsed.root }
   }
 
   if (USER_DATA_OVERRIDE) {
-    return path.join(path.resolve(USER_DATA_OVERRIDE), 'hermes-home')
+    return { profileHint: null, home: path.join(path.resolve(USER_DATA_OVERRIDE), 'hermes-home') }
   }
 
   if (IS_WINDOWS) {
@@ -309,7 +317,9 @@ function resolveHermesHome() {
     const fromRegistry = readWindowsUserEnvVar('HERMES_HOME')
 
     if (fromRegistry) {
-      return normalizeHermesHomeRoot(fromRegistry)
+      const parsed = splitHermesHomeRootAndProfile(fromRegistry)
+
+      return { profileHint: parsed.profileHint, home: parsed.root }
     }
   }
 
@@ -320,16 +330,16 @@ function resolveHermesHome() {
     // Migrate transparently to LOCALAPPDATA, but honour an existing legacy
     // ~/.hermes setup (no LOCALAPPDATA install yet) so users don't lose state.
     if (!directoryExists(localappdata) && directoryExists(legacy)) {
-      return legacy
+      return { profileHint: null, home: legacy }
     }
 
-    return localappdata
+    return { profileHint: null, home: localappdata }
   }
 
-  return path.join(app.getPath('home'), '.hermes')
+  return { profileHint: null, home: path.join(app.getPath('home'), '.hermes') }
 }
 
-const HERMES_HOME = resolveHermesHome()
+const { home: HERMES_HOME, profileHint: HERMES_HOME_PROFILE_HINT_RAW } = resolveHermesHomeContext()
 
 function hermesManagedNodePathEntries() {
   // NOTE: keep this ordering in sync with iter_hermes_node_dirs() in
@@ -377,8 +387,9 @@ const DESKTOP_WINDOW_STATE_PATH = path.join(app.getPath('userData'), 'window-sta
 // no --profile flag, so the backend honors active_profile / default.
 const DESKTOP_PROFILE_CONFIG_PATH = path.join(app.getPath('userData'), 'active-profile.json')
 // Mirrors hermes_cli.profiles._PROFILE_ID_RE so we never hand the backend a
-// value its profile resolver would reject and exit on.
-const PROFILE_NAME_RE = /^[a-z0-9][a-z0-9_-]{0,63}$/
+// value its profile resolver would reject and exit on. Shared with the pure
+// desktop-launch-profile helpers so tests cover the same contract.
+const HERMES_HOME_PROFILE_HINT = sanitizeProfileHint(HERMES_HOME_PROFILE_HINT_RAW)
 // Branch we track for self-update. The GUI work has merged to main, so this
 // tracks main. User can also override at runtime via
 // hermesDesktop.updates.setBranch().
@@ -6370,11 +6381,21 @@ async function waitForBackendExit(child, timeoutMs = 5000) {
   })
 }
 
-// The profile the primary (window) backend runs as. readActiveDesktopProfile()
-// returns the desktop's stored preference, or null when unset (legacy launch
-// that defers to active_profile / default).
+// The profile the primary (window) backend runs as. Prefer an env-derived
+// profiles/<name> hint (when HERMES_HOME itself is profile-scoped) over the
+// desktop's stored preference; null falls back to 'default'.
 function primaryProfileKey() {
-  return readActiveDesktopProfile() || 'default'
+  return primaryProfileKeyFromLaunch({
+    profileHint: HERMES_HOME_PROFILE_HINT,
+    preference: readActiveDesktopProfile()
+  })
+}
+
+function preferredPrimaryLaunchProfile() {
+  return preferredDesktopLaunchProfile({
+    profileHint: HERMES_HOME_PROFILE_HINT,
+    preference: readActiveDesktopProfile()
+  })
 }
 
 // Resolve a backend connection for the given profile. Routes the primary
@@ -6733,8 +6754,9 @@ async function startHermes() {
     // deterministic (it wins over the sticky ~/.hermes/active_profile file) and
     // resolves HERMES_HOME the same way `hermes -p <name>` does on the CLI. An
     // unset preference keeps the legacy launch so existing installs are
-    // unaffected.
-    const activeProfile = readActiveDesktopProfile()
+    // unaffected — unless HERMES_HOME itself is profile-scoped, in which case
+    // the inferred profiles/<name> hint supplies the pin.
+    const activeProfile = preferredPrimaryLaunchProfile()
 
     if (activeProfile) {
       backendArgs.unshift('--profile', activeProfile)


### PR DESCRIPTION
## What does this PR do?

Fixes a desktop-only regression where the Electron launcher could ignore a profile-scoped `HERMES_HOME` (for example `~/.hermes/profiles/oracle`) and start the backend against default/root profile state.

That mismatch can surface as provider setup failures in desktop (`No inference/Hermes provider configured`) while CLI/TUI still work in the intended profile.

## Root cause

Desktop normalized `HERMES_HOME` from `.../profiles/<name>` to the global root and dropped the `<name>` information. If no `active-profile.json` override existed, desktop launched without `--profile`, so backend resolution could fall back to the wrong profile.

## Changes made

- Added `splitHermesHomeRootAndProfile()` in `apps/desktop/electron/backend-env.cjs` to parse:
  - normalized root home
  - optional profile hint from `.../profiles/<name>`
- Updated desktop main process startup in `apps/desktop/electron/main.cjs` to:
  - keep normalized root `HERMES_HOME` behavior
  - preserve and validate a profile hint from env/registry home
  - prefer that hint when selecting the primary launch profile and when adding `--profile`

## Tests

- Extended `apps/desktop/electron/backend-env.test.cjs` with regression coverage for:
  - profile hint extraction on POSIX and Windows-style profile homes
  - null profile hint on global homes

Run locally:

```bash
node --test apps/desktop/electron/backend-env.test.cjs
node --check apps/desktop/electron/main.cjs
node --check apps/desktop/electron/backend-env.cjs
```

## Type of change

- [x] Bug fix
- [x] Tests
