### PR TITLE
fix(agent): preserve paragraph breaks when removing @ context references

### DIFF
--- a/agent/context_references.py
+++ b/agent/context_references.py
@@ -420,8 +420,14 @@ def _remove_reference_tokens(message: str, refs: list[ContextReference]) -> str:
         cursor = ref.end
     pieces.append(message[cursor:])
     text = "".join(pieces)
-    text = re.sub(r"\s{2,}", " ", text)
-    text = re.sub(r"\s+([,.;:!?])", r"\1", text)
+    # Only collapse horizontal whitespace (spaces/tabs), not newlines.
+    # Using \s would match \n and destroy paragraph breaks.
+    text = re.sub(r"[ \t]+", " ", text)
+    text = re.sub(r"[ \t]+([,.;:!?])", r"\1", text)
+    # Clean per-line: strip trailing/leading horizontal whitespace.
+    text = "\n".join(line.strip() for line in text.split("\n"))
+    # Collapse 3+ consecutive newlines down to 2 (paragraph break).
+    text = re.sub(r"(\n[ \t]*){3,}", "\n\n", text)
     return text.strip()
 
 

--- a/tests/agent/test_context_references.py
+++ b/tests/agent/test_context_references.py
@@ -353,3 +353,62 @@ async def test_blocks_sensitive_home_and_hermes_paths(tmp_path: Path, monkeypatc
     assert "API_KEY=super-secret" not in result.message
     assert "PRIVATE-KEY" not in result.message
     assert any("sensitive credential" in warning for warning in result.warnings)
+
+
+
+# --- _remove_reference_tokens: paragraph preservation (issue #48484) ---
+
+
+def test_remove_reference_tokens_preserves_paragraph_breaks():
+    """Removing @file tokens must not collapse blank lines."""
+    from agent.context_references import _remove_reference_tokens, parse_context_references
+
+    msg = (
+        "Please refactor the auth module.\n\n"
+        "@file:auth.py\n\n"
+        "Make these changes:\n1. Add logging\n2. Handle timeouts\n\n"
+        "Keep the public API stable."
+    )
+    refs = parse_context_references(msg)
+    result = _remove_reference_tokens(msg, refs)
+
+    # Paragraph breaks (double newline) must survive.
+    assert "\n\n" in result
+    parts = result.split("\n\n")
+    assert len(parts) == 3
+    assert parts[0] == "Please refactor the auth module."
+    assert parts[1] == "Make these changes:\n1. Add logging\n2. Handle timeouts"
+    assert parts[2] == "Keep the public API stable."
+
+
+def test_remove_reference_tokens_collapses_excess_blank_lines():
+    """Three or more consecutive blank lines collapse to one blank line."""
+    from agent.context_references import _remove_reference_tokens, parse_context_references
+
+    msg = "Hello\n\n\n\n\nWorld"
+    refs = parse_context_references(msg)
+    result = _remove_reference_tokens(msg, refs)
+
+    assert result == "Hello\n\nWorld"
+
+
+def test_remove_reference_tokens_still_collapses_horizontal_whitespace():
+    """Runs of spaces/tabs within a line still collapse to a single space."""
+    from agent.context_references import _remove_reference_tokens, parse_context_references
+
+    msg = "Hello   world\t\tthere"
+    refs = parse_context_references(msg)
+    result = _remove_reference_tokens(msg, refs)
+
+    assert result == "Hello world there"
+
+
+def test_remove_reference_tokens_punctuation_cleanup():
+    """Space before punctuation is still stripped."""
+    from agent.context_references import _remove_reference_tokens, parse_context_references
+
+    msg = "Hello , world !"
+    refs = parse_context_references(msg)
+    result = _remove_reference_tokens(msg, refs)
+
+    assert result == "Hello, world!"


### PR DESCRIPTION
## What does this PR do?

Fixes `_remove_reference_tokens` in `agent/context_references.py` so that removing `@file`, `@folder`, `@diff`, and other `@` context reference tokens preserves paragraph breaks (blank lines) in the user's message. Previously, the `\s{2,}` regex matched newlines, collapsing all multi-line whitespace into single spaces and flattening the message into a single block.

## Related Issue

Fixes #48484

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/context_references.py`: Replaced `\s{2,}` with `[ \t]+` to only collapse horizontal whitespace. Added per-line stripping and 3+-newline normalization to handle artifacts left by token removal.
- `tests/agent/test_context_references.py`: Added 4 regression tests covering paragraph preservation, excess blank line collapsing, horizontal whitespace collapsing, and punctuation cleanup.

## How to Test

1. Run the context references tests: `python -m pytest tests/agent/test_context_references.py -q`
2. Verify the exact repro from the issue:
   ```python
   from agent.context_references import _remove_reference_tokens, parse_context_references
   msg = "Please refactor the auth module.\n\n@file:auth.py\n\nMake these changes:\n1. Add logging\n2. Handle timeouts\n\nKeep the public API stable."
   refs = parse_context_references(msg)
   result = _remove_reference_tokens(msg, refs)
   assert "\n\n" in result  # paragraph breaks preserved
   ```
3. Confirm horizontal whitespace within lines is still collapsed (e.g., `"hello   world"` → `"hello world"`)

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/agent/test_context_references.py -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation and Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `agent/context_references.py::_remove_reference_tokens` (called by `preprocess_context_references` at L188)
- Blast radius: LOW — isolated cleanup function, only called during message preprocessing
- Related patterns: `\s` vs `[ \t]` regex discipline for multi-line text processing
