### PR TITLE
fix(tui): preserve config.yaml key order on save (#48388)

### DIFF
--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -684,7 +684,7 @@ def _save_cfg(cfg: dict):
 
     path = _hermes_home / "config.yaml"
     with open(path, "w", encoding="utf-8") as f:
-        yaml.safe_dump(cfg, f)
+        yaml.safe_dump(cfg, f, sort_keys=False)
     with _cfg_lock:
         _cfg_cache = copy.deepcopy(cfg)
         _cfg_path = path


### PR DESCRIPTION
Fixes #48388. The _save_cfg() function in tui_gateway/server.py called yaml.safe_dump() without sort_keys=False, causing every config save to alphabetically sort all top-level keys and destroy user-defined ordering. Added sort_keys=False to preserve original key order.