### PR TITLE
fix(usage): avoid 60s/60m in format_duration_compact (boundary rounding)

### DIFF
--- a/agent/usage_pricing.py
+++ b/agent/usage_pricing.py
@@ -870,10 +870,10 @@ def has_known_pricing(
 
 def format_duration_compact(seconds: float) -> str:
     if seconds < 60:
-        return f"{seconds:.0f}s"
+        return f"{int(seconds)}s"
     minutes = seconds / 60
     if minutes < 60:
-        return f"{minutes:.0f}m"
+        return f"{int(minutes)}m"
     hours = minutes / 60
     if hours < 24:
         remaining_min = int(minutes % 60)


### PR DESCRIPTION
## Bug

`format_duration_compact()` in `agent/usage_pricing.py` (used by `/usage` and
the insights report) formats the seconds and minutes buckets with `:.0f`, which
**rounds**:

```python
if seconds < 60:
    return f"{seconds:.0f}s"     # 59.5-59.99 ? "60s"
minutes = seconds / 60
if minutes < 60:
    return f"{minutes:.0f}m"     # 59.5-59.99 min ? "60m"
hours = minutes / 60
if hours < 24:
    remaining_min = int(minutes % 60)          # ? hours bucket TRUNCATES
    return f"{int(hours)}h {remaining_min}m" if remaining_min else f"{int(hours)}h"
```

Because the value is selected for the seconds/minutes bucket by an *unrounded*
comparison (`seconds < 60`, `minutes < 60`) but then *rounded* for display, a
value just below the boundary rounds **up onto the boundary of the same unit**:

- `59.6` seconds ? `"60s"` (should read `"1m"`)
- `59.6` minutes (~3576 s) ? `"60m"` (should read `"1h"`)

So the formatter emits `"60s"` / `"60m"` - values it is specifically structured
never to show, since anything ? 60 of a unit is meant to roll into the next one.

Note the **internal inconsistency**: the hours bucket already uses truncation
(`int(hours)`, `int(minutes % 60)`), so it never overflows. Only the seconds and
minutes buckets round.

## Fix

Truncate the seconds and minutes buckets too, matching the hours bucket:

```python
if seconds < 60:
    return f"{int(seconds)}s"
...
if minutes < 60:
    return f"{int(minutes)}m"
```

Now the displayed number can never reach the next unit''s boundary:
`59.6s ? "59s"`, `59.6m ? "59m"`, fully consistent with how the hours bucket
already behaves.

## Verification

- Confirmed on current `main`: seconds/minutes use `:.0f` (rounding) while the
  hours bucket uses `int(...)` (truncation).
- `format_duration_compact(59.6)` returns `"60s"` before the fix, `"59s"` after.
- No behavior change for whole-second/minute inputs or any value ? 60 of a unit.
- No open PR touches `format_duration` (checked before opening).