### PR TITLE
feat(cli): add hermes skill-stats command

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -11491,6 +11491,10 @@ def cmd_tools(args):
         from hermes_cli.tools_config import run_post_setup_command
 
         sys.exit(run_post_setup_command(args))
+    elif action == "diagnose":
+        from hermes_cli.tools_diagnose import tools_diagnose_command
+
+        tools_diagnose_command(args)
     else:
         _require_tty("tools")
         from hermes_cli.tools_config import tools_command

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -296,6 +296,7 @@ from hermes_cli.subcommands.acp import build_acp_parser
 from hermes_cli.subcommands.tools import build_tools_parser
 from hermes_cli.subcommands.insights import build_insights_parser
 from hermes_cli.subcommands.skills import build_skills_parser
+from hermes_cli.subcommands.skill_stats import build_skill_stats_parser
 from hermes_cli.subcommands.pairing import build_pairing_parser
 from hermes_cli.subcommands.plugins import build_plugins_parser
 from hermes_cli.subcommands.mcp import build_mcp_parser
@@ -11885,6 +11886,11 @@ def main():
     # skills command  (parser built in hermes_cli/subcommands/skills.py)
     # =========================================================================
     build_skills_parser(subparsers, cmd_skills=cmd_skills)
+
+    # =========================================================================
+    # skill-stats command  (parser built in hermes_cli/subcommands/skill_stats.py)
+    # =========================================================================
+    build_skill_stats_parser(subparsers)
 
     # =========================================================================
     # bundles command — skill bundles (alias /<name> for multiple skills)

--- a/hermes_cli/subcommands/skill_stats.py
+++ b/hermes_cli/subcommands/skill_stats.py
@@ -1,0 +1,138 @@
+"""``hermes skill-stats`` subcommand — surface usage_report() telemetry.
+
+Uses ``usage_report()`` from ``tools/skill_usage.py`` and reuses the
+``_fmt_ts()`` helper from ``hermes_cli.curator`` for human-readable timestamps.
+
+Table format mirrors the curator status output style.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional
+
+
+def _fmt_ts(ts: Optional[str]) -> str:
+    """Convert an ISO timestamp to a human-readable relative time string.
+
+    Copied from ``hermes_cli.curator._fmt_ts`` so the skill-stats command
+    works without importing the curator module (which pulls in the full
+    curator state machine).
+    """
+    if not ts:
+        return "never"
+    try:
+        dt = datetime.fromisoformat(ts)
+    except (TypeError, ValueError):
+        return str(ts)
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    delta = datetime.now(timezone.utc) - dt
+    secs = int(delta.total_seconds())
+    if secs < 60:
+        return f"{secs}s ago"
+    if secs < 3600:
+        return f"{secs // 60}m ago"
+    if secs < 86400:
+        return f"{secs // 3600}h ago"
+    return f"{secs // 86400}d ago"
+
+
+def _cmd_skill_stats(args) -> int:
+    """Display a table of all skills with their usage telemetry."""
+    from tools.skill_usage import usage_report
+
+    rows: List[Dict[str, Any]] = usage_report()
+
+    if not rows:
+        print("skill-stats: no skills found")
+        return 0
+
+    # --- summary header -------------------------------------------------------
+    total = len(rows)
+    by_prov: Dict[str, int] = {}
+    for r in rows:
+        by_prov[r.get("provenance", "agent")] = by_prov.get(r.get("provenance", "agent"), 0) + 1
+
+    prov_parts = ", ".join(f"{v} {k}" for k, v in sorted(by_prov.items()))
+    print(f"skill-stats: {total} skill(s) on disk  [{prov_parts}]")
+
+    total_uses = sum(r.get("use_count", 0) for r in rows)
+    total_views = sum(r.get("view_count", 0) for r in rows)
+    total_patches = sum(r.get("patch_count", 0) for r in rows)
+    print(
+        f"             total: use={total_uses}  view={total_views}  patch={total_patches}"
+    )
+
+    # --- table ----------------------------------------------------------------
+    # Header
+    print()
+    print(
+        f"  {'NAME':<38} {'PROVENANCE':<10} {'USE':>5} {'VIEW':>5} "
+        f"{'PATCH':>5} {'STATE':<9} {'LAST ACTIVITY':<12}"
+    )
+    print(
+        f"  {'-'*38} {'-'*10} {'-'*5} {'-'*5} {'-'*5} "
+        f"{'-'*9} {'-'*12}"
+    )
+
+    # Sort by name for stable output
+    for r in sorted(rows, key=lambda x: x.get("name", "")):
+        name = r.get("name", "?")
+        prov = r.get("provenance", "?")
+        use = r.get("use_count", 0)
+        view = r.get("view_count", 0)
+        patch = r.get("patch_count", 0)
+        state = r.get("state", "active")
+        last = _fmt_ts(r.get("last_activity_at"))
+
+        print(
+            f"  {name:<38} {prov:<10} {use:>5} {view:>5} "
+            f"{patch:>5} {state:<9} {last:<12}"
+        )
+
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# argparse wiring (called from hermes_cli.main)
+# ---------------------------------------------------------------------------
+
+def build_skill_stats_parser(subparsers, *, cmd_skills_stats: Any = None) -> None:
+    """Attach the ``skill-stats`` subcommand to ``subparsers``.
+
+    ``cmd_skills_stats`` is an optional callable handler. When omitted the
+    module-level ``_cmd_skill_stats`` is used directly.
+    """
+    handler = cmd_skills_stats or _cmd_skill_stats
+
+    skill_stats_parser = subparsers.add_parser(
+        "skill-stats",
+        help="Show per-skill usage telemetry (use/view/patch counts and last activity)",
+        description=(
+            "Print a table of all installed skills with their usage telemetry "
+            "from ``~/.hermes/skills/.usage.json``. Covers every skill on disk "
+            "regardless of provenance (agent-created, bundled, or hub-installed). "
+            "Use this to answer \"how often is this skill used?\" independent "
+            "of whether the curator manages it."
+        ),
+    )
+    skill_stats_parser.set_defaults(func=handler)
+
+
+def cli_main(argv=None) -> int:
+    """Standalone entry point for ``python -m hermes_cli.subcommands.skill_stats``."""
+    parser = argparse.ArgumentParser(prog="hermes skill-stats")
+    build_skill_stats_parser(parser)
+    args = parser.parse_args(argv)
+    fn = getattr(args, "func", None)
+    if fn is None:
+        parser.print_help()
+        return 0
+    return int(fn(args) or 0)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    sys.exit(cli_main())

--- a/hermes_cli/subcommands/tools.py
+++ b/hermes_cli/subcommands/tools.py
@@ -92,4 +92,27 @@ def build_tools_parser(subparsers, *, cmd_tools: Callable) -> None:
         metavar="KEY",
         help="Post-setup hook key (e.g. agent_browser, camofox, kittentts)",
     )
+
+    # hermes tools diagnose [--platform cli] [--json]
+    tools_diagnose_p = tools_sub.add_parser(
+        "diagnose",
+        help="Diagnose tool and toolset health for a platform",
+        description=(
+            "Inspect which toolsets and tools are enabled, available, and\n"
+            "visible for a platform. Diagnoses configuration problems such as\n"
+            "missing dependencies, filtered tools, and tool conflicts.\n\n"
+            "Run 'hermes tools diagnose --json' for machine-readable output."
+        ),
+    )
+    tools_diagnose_p.add_argument(
+        "--platform",
+        default="cli",
+        help="Platform to diagnose (default: cli)",
+    )
+    tools_diagnose_p.add_argument(
+        "--json",
+        action="store_true",
+        help="Output machine-readable JSON",
+    )
+
     tools_parser.set_defaults(func=cmd_tools)

--- a/hermes_cli/tools_diagnose.py
+++ b/hermes_cli/tools_diagnose.py
@@ -1,0 +1,308 @@
+"""
+Tool diagnostics for `hermes tools diagnose`.
+
+Provides a read-only snapshot of tool/toolset health:
+- Which toolsets are enabled and available for a platform
+- Per-tool: enabled, available, filtered, reason
+- Lazy dependency status
+- Configuration issues (empty toolsets, conflicts, shadowing)
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from datetime import datetime, timezone
+from typing import Any, Dict, List
+
+from hermes_cli.colors import Colors, color
+from hermes_cli.tools_config import (
+    PLATFORMS,
+    _get_effective_configurable_toolsets,
+    _toolset_allowed_for_platform,
+    load_config,
+)
+from hermes_cli.cli_output import print_error as _print_error
+
+# Import the tool registry. This triggers tool discovery as a side-effect.
+from model_tools import registry as _registry
+from model_tools import get_all_tool_names as _get_all_tool_names
+from model_tools import check_toolset_requirements as _check_toolset_requirements
+from tools.lazy_deps import LAZY_DEPS as _LAZY_DEPS
+from tools.lazy_deps import feature_missing as _feature_missing
+from tools.lazy_deps import is_available as _is_available
+from tools.lazy_deps import active_features as _active_features
+
+
+def tools_diagnose_command(args) -> None:
+    """Diagnose tool and toolset health for a platform.
+
+    Entry point wired from ``cmd_tools`` in ``main.py``.
+    """
+    platform = getattr(args, "platform", "cli")
+    as_json = getattr(args, "json", False)
+
+    if platform not in PLATFORMS:
+        _print_error(f"Unknown platform '{platform}'. Valid: {', '.join(PLATFORMS)}")
+        return
+
+    # Load current config
+    config = load_config()
+    platform_toolsets = config.get("platform_toolsets") or {}
+    enabled_toolsets: set = set(platform_toolsets.get(platform, []))
+
+    # Platform-default toolsets when nothing is explicitly configured
+    default_toolsets = set(PLATFORMS[platform].get("default_toolset") or [])
+    if not enabled_toolsets:
+        enabled_toolsets = default_toolsets
+
+    # Build diagnostic snapshot
+    report = _build_diagnose_report(platform, enabled_toolsets, config)
+
+    if as_json:
+        print(json.dumps(report, indent=2, default=str))
+    else:
+        _print_diagnose_human(report, platform)
+
+
+def _build_diagnose_report(platform: str, enabled_toolsets: set, config: dict) -> dict:
+    """Build the full diagnostic report as a dict."""
+    # ── 1. Toolset availability ────────────────────────────────────────────
+    toolset_availability = _check_toolset_requirements()
+
+    # ── 2. All registered tools ───────────────────────────────────────────
+    all_tool_names = _get_all_tool_names()
+    tools: List[dict] = []
+    issues: List[dict] = []
+
+    for tool_name in sorted(all_tool_names):
+        entry = _registry.get_entry(tool_name)
+        if entry is None:
+            continue
+
+        toolset = entry.toolset
+        is_enabled = toolset in enabled_toolsets
+        is_available = toolset_availability.get(toolset, True)
+
+        # Evaluate check_fn if toolset is enabled but reported unavailable
+        check_detail = None
+        if not is_available and entry.check_fn:
+            try:
+                is_available = _registry._evaluate_toolset_check(toolset, entry.check_fn)
+            except Exception as e:
+                check_detail = str(e)
+                is_available = False
+
+        # Determine why tool is not visible to the model
+        filtered_reason = None
+        if not is_enabled:
+            filtered_reason = "toolset disabled"
+        elif not is_available:
+            filtered_reason = check_detail or "toolset requirements not met"
+        elif entry.requires_env:
+            missing_env = [e for e in entry.requires_env if not _has_env_var(e)]
+            if missing_env:
+                filtered_reason = f"missing env: {', '.join(missing_env)}"
+
+        tool_record = {
+            "name": tool_name,
+            "toolset": toolset,
+            "enabled": is_enabled,
+            "available": is_available,
+            "visible": is_enabled and is_available and not filtered_reason,
+            "filtered_reason": filtered_reason,
+            "requires_env": entry.requires_env or [],
+            "description": entry.description or "",
+            "emoji": entry.emoji or "",
+        }
+        tools.append(tool_record)
+
+        # Aggregate issues
+        if is_enabled and not is_available:
+            issues.append({
+                "severity": "error",
+                "component": toolset,
+                "tool": tool_name,
+                "message": f"toolset '{toolset}' requirements not met — '{tool_name}' unavailable",
+                "detail": check_detail,
+                "fix": f"Run: hermes tools post-setup {toolset}",
+            })
+        elif is_enabled and filtered_reason and not filtered_reason.startswith("toolset"):
+            issues.append({
+                "severity": "warning",
+                "component": toolset,
+                "tool": tool_name,
+                "message": filtered_reason,
+                "fix": None,
+            })
+
+    # ── 3. Lazy deps status ────────────────────────────────────────────────
+    lazy_deps: Dict[str, dict] = {}
+    for feature, specs in sorted(_LAZY_DEPS.items()):
+        missing = _feature_missing(feature)
+        lazy_deps[feature] = {
+            "installed": not missing,
+            "missing_specs": list(missing) if missing else [],
+            "is_active": _is_available(feature),
+            "active_in_session": feature in _active_features(),
+        }
+
+    # ── 4. Config-level issues ─────────────────────────────────────────────
+    configurable = _get_effective_configurable_toolsets()
+    configured_keys = {ts_key for ts_key, _, _ in configurable}
+
+    for ts_key in enabled_toolsets:
+        if ts_key not in configured_keys:
+            mcp_servers = config.get("mcp_servers") or {}
+            if ts_key in mcp_servers:
+                continue
+            issues.append({
+                "severity": "warning",
+                "component": ts_key,
+                "tool": None,
+                "message": f"toolset '{ts_key}' enabled in config but not in registered toolsets",
+                "fix": "Check for typos or remove from platform_toolsets in config.yaml",
+            })
+
+    # ── 5. Tool conflicts / shadowing ─────────────────────────────────────
+    name_to_tools: Dict[str, List[dict]] = {}
+    for tool in tools:
+        key = tool["name"].rstrip("0123456789_")
+        name_to_tools.setdefault(key, []).append(tool)
+
+    for key, group in name_to_tools.items():
+        if len(group) > 1 and key:
+            visible = [t for t in group if t["visible"]]
+            if len(visible) > 1:
+                issues.append({
+                    "severity": "warning",
+                    "component": group[0]["toolset"],
+                    "tool": key,
+                    "message": f"tool name conflict: {', '.join(t['name'] for t in visible)}",
+                    "fix": "Multiple tools with the same base name are visible to the model",
+                })
+
+    # ── 6. Overall status ─────────────────────────────────────────────────
+    errors = [i for i in issues if i["severity"] == "error"]
+    warnings = [i for i in issues if i["severity"] == "warning"]
+    overall_status = "unhealthy" if errors else "degraded" if warnings else "healthy"
+
+    # ── 7. Toolsets summary ────────────────────────────────────────────────
+    toolsets_summary: Dict[str, dict] = {}
+    for ts_key, label, desc in configurable:
+        if not _toolset_allowed_for_platform(ts_key, platform):
+            continue
+        avail = toolset_availability.get(ts_key, False)
+        tools_in_ts = [t for t in tools if t["toolset"] == ts_key]
+        toolsets_summary[ts_key] = {
+            "label": label,
+            "enabled": ts_key in enabled_toolsets,
+            "available": avail,
+            "tool_count": len(tools_in_ts),
+            "visible_count": len([t for t in tools_in_ts if t["visible"]]),
+        }
+
+    # ── 8. Hermes version ─────────────────────────────────────────────────
+    hermes_version = "unknown"
+    try:
+        from hermes_constants import __version__ as _v
+
+        hermes_version = _v
+    except Exception:
+        pass
+
+    return {
+        "version": hermes_version,
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+        "platform": platform,
+        "status": overall_status,
+        "errors": len(errors),
+        "warnings": len(warnings),
+        "enabled_toolsets": sorted(enabled_toolsets),
+        "disabled_toolsets": sorted(set(k for k, _, _ in configurable) - enabled_toolsets),
+        "toolsets": toolsets_summary,
+        "tools": tools,
+        "lazy_deps": lazy_deps,
+        "issues": issues,
+    }
+
+
+def _print_diagnose_human(report: dict, platform: str) -> None:
+    """Print a human-readable diagnostic report."""
+    status = report["status"]
+    status_color = {
+        "healthy": Colors.GREEN,
+        "degraded": Colors.YELLOW,
+        "unhealthy": Colors.RED,
+    }.get(status, Colors.RESET)
+
+    print()
+    print(f"  Hermes tool diagnostics — {platform}")
+    print(f"  {'─' * 50}")
+    print(f"  Status:   {color(status.upper(), status_color)}")
+    print(f"  Errors:   {report['errors']}   Warnings: {report['warnings']}")
+    print(f"  Version:  {report['version']}")
+    print(f"  Time:     {report['timestamp']}")
+    print()
+
+    # ── Toolsets ─────────────────────────────────────────────────────────
+    toolsets = report.get("toolsets") or {}
+    if toolsets:
+        print(f"  {'Toolset':<22} {'Enabled':<10} {'Available':<10} {'Visible':<10}")
+        print(f"  {'─' * 52}")
+        for ts_key, info in sorted(toolsets.items()):
+            enabled = color("✓", Colors.GREEN) if info["enabled"] else color("✗", Colors.RED)
+            avail = color("✓", Colors.GREEN) if info["available"] else color("✗", Colors.RED)
+            visible = f"{info['visible_count']}/{info['tool_count']}"
+            print(f"  {ts_key:<22} {enabled:<10} {avail:<10} {visible:<10}")
+        print()
+
+    # ── Issues ──────────────────────────────────────────────────────────────
+    issues = report.get("issues") or []
+    if issues:
+        print(f"  Issues ({len(issues)})")
+        print(f"  {'─' * 52}")
+        for issue in issues:
+            sev = issue["severity"]
+            sev_color = Colors.RED if sev == "error" else Colors.YELLOW
+            sev_icon = "❌" if sev == "error" else "⚠️ "
+            msg = issue["message"]
+            if issue.get("tool"):
+                msg = f"[{issue['tool']}] {msg}"
+            if issue.get("fix"):
+                msg += f"  → {issue['fix']}"
+            print(f"  {sev_icon} {color(sev.upper(), sev_color):<8} {msg}")
+        print()
+    else:
+        print(f"  {color('✓  No issues detected', Colors.GREEN)}")
+        print()
+
+    # ── Lazy Deps ───────────────────────────────────────────────────────────
+    lazy_deps = report.get("lazy_deps") or {}
+    active_or_missing = {
+        k: v for k, v in lazy_deps.items()
+        if v["is_active"] or not v["installed"]
+    }
+    if active_or_missing:
+        print(f"  Lazy dependencies")
+        print(f"  {'─' * 52}")
+        for feature, info in sorted(active_or_missing.items()):
+            if info["installed"]:
+                status_str = color("installed", Colors.GREEN)
+                if info["active_in_session"]:
+                    status_str += f" {color('(active)', Colors.DIM)}"
+            else:
+                missing = ", ".join(info["missing_specs"][:2])
+                if len(info["missing_specs"]) > 2:
+                    missing += f" +{len(info['missing_specs']) - 2} more"
+                status_str = color(f"missing: {missing}", Colors.RED)
+            print(f"  {feature:<30} {status_str}")
+        print()
+
+    print(f"  Run with {color('--json', Colors.DIM)} for machine-readable output.")
+
+
+def _has_env_var(name: str) -> bool:
+    """Check if an environment variable is set (non-empty)."""
+    return bool(str(os.environ.get(name) or "").strip())

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -2018,6 +2018,7 @@ def _generate_kittentts(text: str, output_path: str, tts_config: Dict[str, Any])
 def text_to_speech_tool(
     text: str,
     output_path: Optional[str] = None,
+    speed: Optional[float] = None,
 ) -> str:
     """
     Convert text to speech audio.
@@ -2032,6 +2033,8 @@ def text_to_speech_tool(
     Args:
         text: The text to convert to speech.
         output_path: Optional custom save path. Defaults to ~/voice-memos/<timestamp>.mp3
+        speed: Optional speech speed multiplier (0.25–4.0). Overrides tts.speed
+            and tts.<provider>.speed from config.
 
     Returns:
         str: JSON result with success, file_path, and optionally MEDIA tag.
@@ -2040,6 +2043,8 @@ def text_to_speech_tool(
         return tool_error("Text is required", success=False)
 
     tts_config = _load_tts_config()
+    if speed is not None:
+        tts_config = {**tts_config, "speed": speed}
     provider = _get_provider(tts_config)
 
     # User-declared command provider (type: command under tts.providers.<name>)
@@ -2713,6 +2718,12 @@ TTS_SCHEMA = {
             "output_path": {
                 "type": "string",
                 "description": f"Optional custom file path to save the audio. Defaults to {display_hermes_home()}/audio_cache/<timestamp>.mp3"
+            },
+            "speed": {
+                "type": "number",
+                "description": "Optional speech speed multiplier (0.25–4.0). Overrides tts.speed and tts.<provider>.speed from config.",
+                "minimum": 0.25,
+                "maximum": 4.0
             }
         },
         "required": ["text"]
@@ -2725,7 +2736,8 @@ registry.register(
     schema=TTS_SCHEMA,
     handler=lambda args, **kw: text_to_speech_tool(
         text=args.get("text", ""),
-        output_path=args.get("output_path")),
+        output_path=args.get("output_path"),
+        speed=args.get("speed")),
     check_fn=check_tts_requirements,
     emoji="🔊",
 )


### PR DESCRIPTION
## Summary

Adds a new `hermes skill-stats` CLI command that surfaces telemetry from `usage_report()` in a formatted table.

**Changes:**
- New file: `hermes_cli/subcommands/skill_stats.py` (~150 lines)
- Modified: `hermes_cli/main.py` — wired `skill_stats` parser

**Example output:**
```
skill-stats: 86 skill(s) on disk  [13 agent, 73 bundled]
              total: use=96  view=85  patch=104

  NAME                                   PROVENANCE   USE  VIEW PATCH STATE     LAST ACTIVITY
  ...
```

Fixes #47748