### PR TITLE
fix(models-dev): send explicit headers for models.dev catalog fetch

### DIFF
--- a/agent/models_dev.py
+++ b/agent/models_dev.py
@@ -33,6 +33,10 @@ logger = logging.getLogger(__name__)
 
 MODELS_DEV_URL = "https://models.dev/api.json"
 _MODELS_DEV_CACHE_TTL = 3600  # 1 hour in-memory
+_MODELS_DEV_HEADERS = {
+    "Accept": "application/json",
+    "User-Agent": "HermesAgent/1.0 (+https://github.com/NousResearch/hermes-agent)",
+}
 
 # In-memory cache
 _models_dev_cache: Dict[str, Any] = {}
@@ -290,7 +294,7 @@ def fetch_models_dev(force_refresh: bool = False) -> Dict[str, Any]:
 
     # Stage 3: network fetch.
     try:
-        response = requests.get(MODELS_DEV_URL, timeout=15)
+        response = requests.get(MODELS_DEV_URL, timeout=15, headers=_MODELS_DEV_HEADERS)
         response.raise_for_status()
         data = response.json()
         if isinstance(data, dict) and data:

--- a/tests/agent/test_models_dev.py
+++ b/tests/agent/test_models_dev.py
@@ -184,6 +184,33 @@ class TestFetchModelsDev:
         assert len(result) == len(SAMPLE_REGISTRY)
 
     @patch("agent.models_dev.requests.get")
+    def test_fetch_uses_explicit_headers(self, mock_get):
+        """models.dev requests should include explicit headers.
+
+        models.dev may reject default client fingerprints with HTTP 403. Keep
+        a stable User-Agent/Accept header contract so fetch_models_dev does not
+        fall back to stale curated lists during transient anti-bot filtering.
+        """
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = SAMPLE_REGISTRY
+        mock_resp.raise_for_status = MagicMock()
+        mock_get.return_value = mock_resp
+
+        import agent.models_dev as md
+        md._models_dev_cache = {}
+        md._models_dev_cache_time = 0
+
+        with patch.object(md, "_save_disk_cache"):
+            _ = fetch_models_dev(force_refresh=True)
+
+        mock_get.assert_called_once_with(
+            md.MODELS_DEV_URL,
+            timeout=15,
+            headers=md._MODELS_DEV_HEADERS,
+        )
+
+    @patch("agent.models_dev.requests.get")
     def test_fetch_failure_returns_stale_cache(self, mock_get):
         mock_get.side_effect = Exception("network error")
 


### PR DESCRIPTION
## What does this PR do?

Fixes a model-catalog freshness issue that could make Hermes Desktop show stale OpenCode Zen models (missing entries like `deepseek-v4-flash-free`).

## Root cause

`agent/models_dev.py` fetched `https://models.dev/api.json` with default HTTP client headers. In some environments this request can be rejected (HTTP 403), causing Hermes to fall back to curated/static provider lists. For OpenCode Zen that fallback omits newer/free models present in models.dev.

## Changes

- Add explicit request headers (`Accept: application/json`, stable `User-Agent`) for models.dev fetches.
- Keep existing cache/fallback behavior unchanged.

## Tests

- Add regression test asserting `fetch_models_dev(force_refresh=True)` calls `requests.get()` with the explicit header contract.

## Type of change

- [x] Bug fix
- [x] Tests

## Validation

- `scripts/run_tests.sh tests/agent/test_models_dev.py -q` could not run in this worktree because no project virtualenv is present.
- Syntax check passed: `python3 -m py_compile agent/models_dev.py tests/agent/test_models_dev.py`.
