### PR TITLE
fix(auxiliary_client): resolve API keys for inferred custom endpoints

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -3686,6 +3686,41 @@ def resolve_provider_client(
                 or os.getenv("OPENAI_API_KEY", "").strip()
                 or "no-key-required"  # local servers don't need auth
             )
+            # If no explicit key and no OPENAI_API_KEY, try to infer the
+            # provider from the endpoint hostname (e.g.
+            # api.kimi.com/coding/v1 -> kimi-coding) and resolve its built-in
+            # API key from environment variables. This lets users configure
+            # auxiliary.<task>.provider + base_url without duplicating the
+            # api_key in config.yaml.
+            if custom_key == "no-key-required":
+                try:
+                    from agent.model_metadata import _infer_provider_from_url
+                    from hermes_cli.auth import (
+                        PROVIDER_REGISTRY,
+                        resolve_api_key_provider_credentials,
+                    )
+
+                    _inferred_provider = _infer_provider_from_url(custom_base)
+                    if (
+                        _inferred_provider
+                        and _inferred_provider in PROVIDER_REGISTRY
+                        and PROVIDER_REGISTRY[_inferred_provider].auth_type == "api_key"
+                        and _inferred_provider != "openrouter"
+                    ):
+                        _inferred_creds = resolve_api_key_provider_credentials(
+                            _inferred_provider
+                        )
+                        _inferred_key = str(_inferred_creds.get("api_key", "")).strip()
+                        if _inferred_key:
+                            custom_key = _inferred_key
+                            logger.debug(
+                                "resolve_provider_client: resolved %s API key from env "
+                                "for custom endpoint %s",
+                                _inferred_provider,
+                                custom_base,
+                            )
+                except Exception:
+                    pass
             if not custom_base:
                 logger.warning(
                     "resolve_provider_client: explicit custom endpoint requested "
@@ -4165,6 +4200,12 @@ def _main_model_supports_vision(provider: str, model: Optional[str]) -> bool:
     behaviour of attempting the call, so providers we haven't catalogued yet
     don't silently regress to text-only.
     """
+    provider = _normalize_aux_provider(provider)
+    if provider in _PROVIDERS_WITHOUT_VISION:
+        # Known text-only endpoints (e.g. Kimi Coding Plan /coding). The
+        # capability database may report vision for the broader provider
+        # family, but this specific endpoint rejects image input.
+        return False
     try:
         from agent.image_routing import _lookup_supports_vision
         from hermes_cli.config import load_config
@@ -4295,7 +4336,7 @@ def resolve_vision_provider_client(
         #   2. OpenRouter  (vision-capable aggregator fallback)
         #   3. Nous Portal (vision-capable aggregator fallback)
         #   4. Stop
-        main_provider = _read_main_provider()
+        main_provider = _normalize_aux_provider(_read_main_provider())
         main_model = _read_main_model()
         if main_provider and main_provider not in {"auto", ""}:
             vision_model = _PROVIDER_VISION_MODELS.get(main_provider, main_model)

--- a/agent/image_routing.py
+++ b/agent/image_routing.py
@@ -340,6 +340,21 @@ def decide_image_input_mode(
     if _explicit_aux_vision_override(cfg):
         return "text"
 
+    # Built-in providers whose standard endpoint is known to reject image input
+    # (e.g. Kimi Coding Plan /coding). Even if the capability database or a
+    # user override claims vision support, native attachment will fail, so fall
+    # back to the vision_analyze text pipeline.
+    try:
+        from agent.auxiliary_client import (
+            _normalize_aux_provider,
+            _PROVIDERS_WITHOUT_VISION,
+        )
+
+        if _normalize_aux_provider(provider) in _PROVIDERS_WITHOUT_VISION:
+            return "text"
+    except Exception:  # pragma: no cover - defensive
+        pass
+
     supports = _lookup_supports_vision(provider, model, cfg)
     if supports is True:
         return "native"

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -2952,6 +2952,39 @@ class TestVisionAutoSkipsKimiCoding:
         assert provider == "openrouter"
         assert client is fake_or_client
 
+    @pytest.mark.parametrize("alias", ["kimi", "moonshot", "kimi-cn", "moonshot-cn"])
+    def test_kimi_aliases_normalised_and_skipped(self, monkeypatch, alias):
+        """Raw config values like 'kimi' or 'moonshot' alias to 'kimi-coding',
+        so the vision auto path must normalise before checking the skip list.
+        Without normalisation the alias slips through to resolve_provider_client
+        and returns a client for the non-vision /coding endpoint (#17076).
+        """
+        fake_or_client = MagicMock(name="openrouter_client")
+
+        monkeypatch.setattr(
+            "agent.auxiliary_client._read_main_provider", lambda: alias,
+        )
+        monkeypatch.setattr(
+            "agent.auxiliary_client._read_main_model", lambda: "kimi-k2.7-code",
+        )
+        rpc_mock = MagicMock(side_effect=AssertionError(
+            f"resolve_provider_client should NOT be called for {alias!r} "
+            "on the vision auto path"))
+        monkeypatch.setattr(
+            "agent.auxiliary_client.resolve_provider_client", rpc_mock,
+        )
+        monkeypatch.setattr(
+            "agent.auxiliary_client._resolve_strict_vision_backend",
+            lambda p, m=None: (fake_or_client, "google/gemini-3-flash-preview")
+            if p == "openrouter"
+            else (None, None),
+        )
+
+        provider, client, model = resolve_vision_provider_client()
+        assert provider == "openrouter"
+        assert client is fake_or_client
+        assert model == "google/gemini-3-flash-preview"
+
     def test_explicit_override_to_kimi_coding_still_honored(self, monkeypatch):
         """When a user *explicitly* requests kimi-coding for vision (e.g.
         they know what they're doing, or are running a future build that

--- a/tests/agent/test_image_routing.py
+++ b/tests/agent/test_image_routing.py
@@ -6,6 +6,7 @@ import base64
 from pathlib import Path
 from unittest.mock import patch
 
+import pytest
 
 from agent.image_routing import (
     _coerce_capability_bool,
@@ -126,6 +127,23 @@ class TestDecideImageInputMode:
         }
         with patch("agent.models_dev.fetch_models_dev", return_value=registry):
             assert decide_image_input_mode("xiaomi", "mimo-v2.5-pro", {}) == "text"
+
+    @pytest.mark.parametrize("alias", ["kimi", "moonshot", "kimi-cn", "moonshot-cn"])
+    def test_auto_skips_known_text_only_providers_and_their_aliases(self, alias):
+        """Kimi Coding Plan aliases (kimi, moonshot, ...) must never be routed
+        native vision, even if the user set ``model.supports_vision: true``.
+        Their /coding endpoint rejects image input, so the text pipeline is the
+        only safe choice (#17076).
+        """
+        cfg = {"model": {"supports_vision": True}}
+        assert decide_image_input_mode(alias, "kimi-k2.7-code", cfg) == "text"
+
+    def test_auto_still_honours_override_for_other_providers(self):
+        """The text-only guard is scoped to known providers; overrides for
+        providers that can plausibly accept images are still respected.
+        """
+        cfg = {"model": {"supports_vision": True}}
+        assert decide_image_input_mode("anthropic", "claude-sonnet-4", cfg) == "native"
 
 
 # ─── _coerce_capability_bool ─────────────────────────────────────────────────


### PR DESCRIPTION
## Problem

When `auxiliary.<task>` is configured with both a `provider` and a `base_url` but no explicit `api_key`, Hermes routes the request through the custom endpoint branch and falls back to `no-key-required`. This breaks providers like Kimi Coding Plan where users set:

```yaml
auxiliary:
  vision:
    provider: kimi-coding
    model: kimi-for-coding
    base_url: https://api.kimi.com/coding/v1
    api_key: ''
```

and expect `KIMI_API_KEY` (already in the environment) to be used.

## Root Cause

`_resolve_task_provider_model()` converts the combination of `provider + base_url` into `provider: custom`, so the custom branch is entered with `explicit_api_key=None`. The custom branch only checks `OPENAI_API_KEY` before falling back to `no-key-required`, ignoring provider-specific env vars such as `KIMI_API_KEY`.

## Fix

In the custom branch of `resolve_provider_client()`, when no key is found, infer the provider from the endpoint hostname (e.g. `api.kimi.com/coding/v1` → `kimi-coding`) and resolve the key from that provider's standard credential source. The existing host-keyed `User-Agent: claude-code/0.1.0` for `api.kimi.com` is preserved.

Also harden native-vision routing so known text-only providers and their aliases (`kimi`, `moonshot`, `kimi-cn`, `moonshot-cn`) always fall back to the text pipeline, even if a capability override claims vision support.

## Verification

End-to-end tested on a live Kimi Code Plan key (`sk-kimi-*`):

- `resolve_vision_provider_client()` now returns a client whose `api_key` is resolved from `KIMI_API_KEY`.
- `async_call_llm(task='vision', ...)` with a base64 JPEG returns a full image description.
- `vision_analyze_tool('file:///tmp/small_test.jpg', ...)` succeeds.

No plaintext API keys are included in this patch; keys are only read from environment variables at runtime.

Fixes #43617.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
