### PR TITLE
fix: preserve headers on Codex auxiliary wrappers

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -944,6 +944,16 @@ class CodexAuxiliaryClient:
         self.chat = _CodexChatShim(adapter)
         self.api_key = real_client.api_key
         self.base_url = real_client.base_url
+        # Mirror headers from the wrapped OpenAI SDK client. Fallback activation
+        # and async conversion inspect the outer CodexAuxiliaryClient, not the
+        # inner client; without this, a Responses-API fallback to a gateway that
+        # needs custom headers rebuilds request clients without those headers.
+        custom_headers = getattr(real_client, "_custom_headers", None)
+        if custom_headers:
+            self._custom_headers = dict(custom_headers)
+        default_headers = getattr(real_client, "default_headers", None)
+        if default_headers:
+            self.default_headers = dict(default_headers)
 
     def close(self):
         self._real_client.close()

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -3303,6 +3303,40 @@ class TestAuxiliaryClientPoisonedCacheEviction:
             with _client_cache_lock:
                 _client_cache.clear()
 
+    def test_codex_wrapper_preserves_inner_client_headers(self):
+        """Fallback activation reads headers from the Codex wrapper, not the inner client."""
+        from agent.auxiliary_client import CodexAuxiliaryClient
+
+        real = SimpleNamespace(
+            api_key="k",
+            base_url="https://gateway.example.test/v1",
+            responses=SimpleNamespace(stream=lambda **k: None),
+            close=lambda: None,
+            _custom_headers={"User-Agent": "HermesAgent/1.0"},
+        )
+
+        wrapper = CodexAuxiliaryClient(real, "gpt-5.5")
+
+        assert wrapper._custom_headers == {"User-Agent": "HermesAgent/1.0"}
+        assert wrapper._custom_headers is not real._custom_headers
+
+    def test_codex_wrapper_preserves_inner_client_default_headers(self):
+        """Some fallback paths inspect default_headers instead of _custom_headers."""
+        from agent.auxiliary_client import CodexAuxiliaryClient
+
+        real = SimpleNamespace(
+            api_key="k",
+            base_url="https://gateway.example.test/v1",
+            responses=SimpleNamespace(stream=lambda **k: None),
+            close=lambda: None,
+            default_headers={"User-Agent": "HermesAgent/1.0"},
+        )
+
+        wrapper = CodexAuxiliaryClient(real, "gpt-5.5")
+
+        assert wrapper.default_headers == {"User-Agent": "HermesAgent/1.0"}
+        assert wrapper.default_headers is not real.default_headers
+
     def test_evict_cached_client_instance_handles_none_and_misses(self):
         from agent.auxiliary_client import _evict_cached_client_instance
 


### PR DESCRIPTION
## Summary

Preserve OpenAI client headers when wrapping a client in `CodexAuxiliaryClient`.

`resolve_provider_client()` can build an OpenAI client with custom/default headers, then wrap it in `CodexAuxiliaryClient` for Responses API routing. Some fallback/client-rebuild paths inspect the outer wrapper for `_custom_headers` or `default_headers`. Before this change, those headers existed only on the wrapped inner OpenAI client, so fallback activation could rebuild request clients without required custom headers.

This copies `_custom_headers` and `default_headers` from the wrapped client onto the wrapper as independent dicts.

## Why

Custom OpenAI-compatible gateways may require request headers such as a specific `User-Agent`. Without preserving those headers on the wrapper, fallback into a Responses-backed provider can lose the configured headers and fail before auth reaches the upstream service.

## Test Plan

- Added unit tests:
  - `test_codex_wrapper_preserves_inner_client_headers`
  - `test_codex_wrapper_preserves_inner_client_default_headers`

- Ran:

  `uv run --with pytest --with pytest-xdist --with pyyaml --with openai --with httpx pytest tests/agent/test_auxiliary_client.py::TestAuxiliaryClientPoisonedCacheEviction::test_codex_wrapper_preserves_inner_client_headers tests/agent/test_auxiliary_client.py::TestAuxiliaryClientPoisonedCacheEviction::test_codex_wrapper_preserves_inner_client_default_headers tests/agent/test_auxiliary_user_default_headers.py -q -n 0`

  Result: `10 passed, 8 warnings`

- Live regression proof:
  - clean HEAD fallback into a Responses-backed custom provider lost headers and hit HTTP 403
  - patched branch preserved headers and fallback succeeded
