### PR TITLE
fix(desktop): treat artifact timestamps as epoch seconds, not milliseconds

### DIFF
--- a/apps/desktop/src/app/artifacts/index.test.ts
+++ b/apps/desktop/src/app/artifacts/index.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest'
 
 import type { SessionInfo, SessionMessage } from '@/types/hermes'
 
-import { collectArtifactsForSession } from './index'
+import { collectArtifactsForSession, formatArtifactTime } from './index'
 
 function makeSession(overrides: Partial<SessionInfo> = {}): SessionInfo {
   return {
@@ -58,5 +58,38 @@ describe('collectArtifactsForSession', () => {
       kind: 'link',
       value: 'https://example.com/changelog/latest'
     })
+  })
+})
+
+describe('formatArtifactTime', () => {
+  it('treats epoch-seconds timestamps (below 1e12) as seconds and multiplies by 1000', () => {
+    // 1781773226 is 2026-06-18T17:00:26Z in epoch seconds
+    const result = formatArtifactTime(1781773226)
+    // Should show a June date, not Jan 1970
+    expect(result).toContain('Jun')
+    expect(result).not.toContain('Jan')
+  })
+
+  it('handles millisecond timestamps (above 1e12) without double-multiplying', () => {
+    // 1781773226000 is the same date in milliseconds
+    const result = formatArtifactTime(1781773226000)
+    expect(result).toContain('Jun')
+    expect(result).not.toContain('Jan')
+  })
+
+  it('handles typical session timestamps from state.db', () => {
+    // Python's time.time() returns ~1.78e9 in 2026
+    const epochSeconds = 1781773226.453548
+    const result = formatArtifactTime(epochSeconds)
+    // Should not render as Jan 1970 (the bug symptom)
+    expect(result).not.toContain('1970')
+    expect(result).toContain('Jun')
+  })
+
+  it('renders old timestamps correctly when already in milliseconds', () => {
+    // A timestamp from 2024 in milliseconds (well above 1e12)
+    const ts2024 = 1700000000000
+    const result = formatArtifactTime(ts2024)
+    expect(result).toContain('Nov')
   })
 })

--- a/apps/desktop/src/app/artifacts/index.tsx
+++ b/apps/desktop/src/app/artifacts/index.tsx
@@ -305,8 +305,13 @@ export function collectArtifactsForSession(session: SessionInfo, messages: Sessi
   return Array.from(found.values())
 }
 
-function formatArtifactTime(timestamp: number): string {
-  return ARTIFACT_TIME_FMT.format(new Date(timestamp))
+export function formatArtifactTime(timestamp: number): string {
+  // Python backends (state.db) store timestamps as epoch *seconds*;
+  // JavaScript Date() expects milliseconds.  Values below 1e12 are
+  // seconds — multiply by 1000 so Jan-2026 renders correctly instead
+  // of showing as Jan 1970.
+  const ts = timestamp < 1e12 ? timestamp * 1000 : timestamp
+  return ARTIFACT_TIME_FMT.format(new Date(ts))
 }
 
 function pageRangeLabel(total: number, page: number, pageSize: number, a: Translations['artifacts']): string {


### PR DESCRIPTION
## What does this PR do?

Fixes artifact timestamps displaying as Jan 1970 dates by treating Python epoch-seconds timestamps correctly. Python backends (state.db) store timestamps as epoch seconds, but `formatArtifactTime()` passed them directly to JavaScript's `new Date()` which expects milliseconds.

## Related Issue

Fixes #48350

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `apps/desktop/src/app/artifacts/index.tsx`: Added timestamp normalizer in `formatArtifactTime()` — values below 1e12 are treated as epoch seconds and multiplied by 1000. Exported the function for testing.
- `apps/desktop/src/app/artifacts/index.test.ts`: Added 4 regression tests verifying epoch-seconds timestamps render as correct dates (e.g., Jun 2026) instead of Jan 1970.

## How to Test

1. Run the new tests: `cd apps/desktop && npx vitest run src/app/artifacts/index.test.ts`
2. Verify all 6 tests pass (2 existing + 4 new)
3. In Desktop, check that Artifacts page shows correct session dates (e.g., "Jun 18" for today's sessions, not "Jan 21")

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `npx vitest run src/app/artifacts/index.test.ts` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `formatArtifactTime` in `apps/desktop/src/app/artifacts/index.tsx`
- Blast radius: LOW — single function, only affects artifact timestamp display
- Related patterns: Python seconds vs JavaScript milliseconds — common cross-language pitfall
