### PR TITLE
fix(windows): add retry-with-backoff for venv .pyd deletion on Windows

### DIFF
--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -1440,7 +1440,34 @@ function Install-Venv {
             & taskkill /F /T /IM hermes.exe /FI "PID ne $myPid" 2>$null | Out-Null
             Start-Sleep -Milliseconds 800
         }
-        Remove-Item -Recurse -Force "venv"
+        # Retry-with-backoff: .pyd files are loaded as DLLs on Windows; the OS may
+        # take >800ms to unload them after taskkill. AV/Defender can also briefly
+        # lock .pyd files for scanning. A single Remove-Item -Recurse fails on
+        # the first locked file; retrying file-by-file isolates the stragglers
+        # and lets the bulk of the venv be deleted.
+        $venvDeleted = $false
+        for ($retry = 0; $retry -lt 5 -and -not $venvDeleted; $retry++) {
+            try {
+                Remove-Item -Recurse -Force "venv" -ErrorAction Stop
+                $venvDeleted = $true
+            } catch {
+                if ($retry -lt 4) {
+                    # Bulk delete failed — delete file-by-file (leaves empty dirs)
+                    Get-ChildItem -Path "venv" -Recurse -File -ErrorAction SilentlyContinue | ForEach-Object {
+                        try { Remove-Item -LiteralPath $_.FullName -Force -ErrorAction Stop } catch {}
+                    }
+                    # Remove empty dirs bottom-up (longest path first)
+                    Get-ChildItem -Path "venv" -Recurse -Directory -ErrorAction SilentlyContinue |
+                        Sort-Object { $_.FullName.Length } -Descending |
+                        ForEach-Object {
+                            try { Remove-Item -LiteralPath $_.FullName -Recurse -Force -ErrorAction Stop } catch {}
+                        }
+                    Start-Sleep -Milliseconds 600
+                } else {
+                    throw
+                }
+            }
+        }
     }
     
     # uv creates the venv and pins the Python version in one step


### PR DESCRIPTION
## Problem

On Windows, `install.ps1` recreates the Python virtual environment on every bootstrap. The old venv is deleted with a single `Remove-Item -Recurse -Force "venv"` call. However, `.pyd` files (Python C extensions) are loaded as DLLs by Hermes processes. Even after `taskkill /F /T /IM hermes.exe`, Windows may take >800ms to unload these DLL handles. Additionally, antivirus/Defender can briefly lock `.pyd` files for scanning.

When any single `.pyd` file remains locked, the entire `Remove-Item -Recurse` fails with "Access Denied", causing the installation to fail with "INSTALL DIDN'T FINISH".

Evidence from user logs shows different `.pyd` files failing on different retries:
- `mask.cp311-win_amd64.pyd`
- `_http_parser.cp311-win_amd64.pyd`

This is a classic race condition, not a permanent permission issue.

## Solution

Replace the single `Remove-Item -Recurse -Force` call with a retry loop (up to 5 attempts with 600ms backoff):

1. Attempt 1: Bulk `Remove-Item -Recurse -Force`
2. On failure (attempts 1-4): Delete files one-by-one catching individual failures, so locked files don't block the rest. Then remove empty directories bottom-up.
3. Attempt 5: Final bulk attempt, throw on failure.

## Testing

- Manually verified on Windows 10 with Python 3.11 venv containing `aiohttp`, `Pillow`, `bcrypt`, and other packages with `.pyd` extensions
- The bootstrap cache has been running this fix in production for the reporter without further failures
