### PR TITLE
fix(desktop): extend profile startup REST timeouts (#48504)

### DIFF
--- a/apps/desktop/src/hermes.test.ts
+++ b/apps/desktop/src/hermes.test.ts
@@ -1,6 +1,12 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-import { getSessionMessages, listAllProfileSessions, listSessions } from './hermes'
+import {
+  getProfiles,
+  getSessionMessages,
+  listAllProfileSessions,
+  listSessions
+} from './hermes'
+import { refreshActiveProfile } from './store/profile'
 
 const emptySessionsResponse = {
   limit: 0,
@@ -42,6 +48,42 @@ describe('Hermes REST session helpers', () => {
     expect(api).toHaveBeenCalledWith(
       expect.objectContaining({
         path: '/api/profiles/sessions?limit=50&offset=0&min_messages=1&archived=exclude&order=recent&profile=all',
+        timeoutMs: 60_000
+      })
+    )
+  })
+
+  it('uses a longer timeout for profile listing during desktop startup', async () => {
+    api.mockResolvedValue({ profiles: [] })
+
+    await getProfiles()
+
+    expect(api).toHaveBeenCalledWith(
+      expect.objectContaining({
+        path: '/api/profiles',
+        timeoutMs: 60_000
+      })
+    )
+  })
+
+  it('uses a longer timeout for active profile refresh during desktop startup', async () => {
+    api
+      .mockResolvedValueOnce({ current: 'default' })
+      .mockResolvedValueOnce({ profiles: [] })
+
+    await refreshActiveProfile()
+
+    expect(api).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        path: '/api/profiles/active',
+        timeoutMs: 60_000
+      })
+    )
+    expect(api).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        path: '/api/profiles',
         timeoutMs: 60_000
       })
     )

--- a/apps/desktop/src/hermes.ts
+++ b/apps/desktop/src/hermes.ts
@@ -42,6 +42,7 @@ import type {
   ToolsetInfo
 } from '@/types/hermes'
 
+export const STARTUP_PROFILE_REQUEST_TIMEOUT_MS = 60_000
 const DEFAULT_GATEWAY_REQUEST_TIMEOUT_MS = 30_000
 const SESSION_LIST_REQUEST_TIMEOUT_MS = 60_000
 
@@ -587,7 +588,8 @@ export function deleteCronJob(jobId: string): Promise<{ ok: boolean }> {
 
 export function getProfiles(): Promise<ProfilesResponse> {
   return window.hermesDesktop.api<ProfilesResponse>({
-    path: '/api/profiles'
+    path: '/api/profiles',
+    timeoutMs: STARTUP_PROFILE_REQUEST_TIMEOUT_MS
   })
 }
 

--- a/apps/desktop/src/store/profile.ts
+++ b/apps/desktop/src/store/profile.ts
@@ -1,6 +1,6 @@
 import { atom, computed } from 'nanostores'
 
-import { getProfiles, setApiRequestProfile } from '@/hermes'
+import { getProfiles, setApiRequestProfile, STARTUP_PROFILE_REQUEST_TIMEOUT_MS } from '@/hermes'
 import { queryClient } from '@/lib/query-client'
 import {
   arraysEqual,
@@ -102,7 +102,10 @@ interface ActiveProfileResponse {
 // Best-effort: failures (backend not up yet) leave the prior values intact.
 export async function refreshActiveProfile(): Promise<void> {
   try {
-    const res = await window.hermesDesktop.api<ActiveProfileResponse>({ path: '/api/profiles/active' })
+    const res = await window.hermesDesktop.api<ActiveProfileResponse>({
+      path: '/api/profiles/active',
+      timeoutMs: STARTUP_PROFILE_REQUEST_TIMEOUT_MS
+    })
 
     setActiveProfile(res.current || 'default')
   } catch {


### PR DESCRIPTION
## Summary
- extend Desktop startup profile REST calls to a 60s timeout, matching the existing session-list startup helpers
- apply the longer timeout to both `/api/profiles` and `/api/profiles/active` so remote Desktop startup does not fail after a successful backend readiness check on large multi-profile installs
- add focused renderer tests covering both startup profile calls

## Verification
- `npm run test:ui -- src/hermes.test.ts` — 5 passed
- `npm run typecheck` — passed
- regression proof on upstream/main: the two new Vitest assertions fail without the production changes because `/api/profiles` and `/api/profiles/active` are called without `timeoutMs`

## Duplicate / competitor check
- no open Tranquil-Flow PR referencing #48504
- no open head branch matching `fix/48504*`
- no open PRs found for `48504`, `desktop profiles timeout`, or `api/profiles timeoutMs`

Auto-published by Moonsong via Path B automated pipeline.