### PR TITLE
fix(codex): resolve codex binary via shutil.which so Windows .CMD is found (fixes #48510)

### DIFF
--- a/agent/transports/codex_app_server.py
+++ b/agent/transports/codex_app_server.py
@@ -41,7 +41,10 @@ def _resolve_codex_bin(codex_bin: str) -> str:
     (e.g. `codex.CMD`); fall back to the original name so the existing
     not-found handling still fires when codex genuinely isn't installed.
     """
-    return shutil.which(codex_bin) or codex_bin
+    if os.path.isabs(codex_bin) and os.path.isfile(codex_bin):
+        return codex_bin
+    resolved = shutil.which(codex_bin)
+    return resolved or codex_bin
 
 
 @dataclass
@@ -87,7 +90,7 @@ class CodexAppServerClient:
         extra_args: Optional[list[str]] = None,
         env: Optional[dict[str, str]] = None,
     ) -> None:
-        self._codex_bin = codex_bin
+        self._codex_bin = _resolve_codex_bin(codex_bin)
         spawn_env = os.environ.copy()
         if env:
             spawn_env.update(env)
@@ -124,7 +127,7 @@ class CodexAppServerClient:
                 ]
             )
 
-        cmd = [_resolve_codex_bin(codex_bin), "app-server"] + app_server_args
+        cmd = [self._codex_bin, "app-server"] + app_server_args
         # Codex emits tracing to stderr; default WARN keeps it quiet for users.
         spawn_env.setdefault("RUST_LOG", "warn")
 
@@ -386,16 +389,18 @@ def check_codex_binary(
     """Verify codex CLI is installed and meets minimum version.
 
     Returns (ok, message). Used by setup wizard and runtime startup."""
+    resolved_bin = _resolve_codex_bin(codex_bin)
     try:
         proc = subprocess.run(
-            [_resolve_codex_bin(codex_bin), "--version"],
+            [resolved_bin, "--version"],
             capture_output=True,
             text=True,
             timeout=10,
+            stdin=subprocess.DEVNULL,
         )
     except FileNotFoundError:
         return False, (
-            f"codex CLI not found at {codex_bin!r}. Install with: "
+            f"codex CLI not found at {resolved_bin!r}. Install with: "
             f"npm i -g @openai/codex"
         )
     except subprocess.TimeoutExpired:

--- a/agent/transports/codex_app_server.py
+++ b/agent/transports/codex_app_server.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 import json
 import os
 import queue
+import shutil
 import subprocess
 import threading
 import time
@@ -28,6 +29,19 @@ from typing import Any, Optional
 # Default minimum codex version we test against. The PR sets this from the
 # `codex --version` parsed at install time; bumping is a one-line change here.
 MIN_CODEX_VERSION = (0, 125, 0)
+
+
+def _resolve_codex_bin(codex_bin: str) -> str:
+    """Resolve a bare command name to its full path for subprocess use.
+
+    On Windows, `npm i -g @openai/codex` installs `codex.CMD` (not
+    `codex.exe`). Passing the bare name `"codex"` to subprocess without
+    `shell=True` fails with `[WinError 2]` because `CreateProcess` does
+    not search `PATHEXT`. `shutil.which` resolves the real launcher
+    (e.g. `codex.CMD`); fall back to the original name so the existing
+    not-found handling still fires when codex genuinely isn't installed.
+    """
+    return shutil.which(codex_bin) or codex_bin
 
 
 @dataclass
@@ -110,7 +124,7 @@ class CodexAppServerClient:
                 ]
             )
 
-        cmd = [codex_bin, "app-server"] + app_server_args
+        cmd = [_resolve_codex_bin(codex_bin), "app-server"] + app_server_args
         # Codex emits tracing to stderr; default WARN keeps it quiet for users.
         spawn_env.setdefault("RUST_LOG", "warn")
 
@@ -374,7 +388,7 @@ def check_codex_binary(
     Returns (ok, message). Used by setup wizard and runtime startup."""
     try:
         proc = subprocess.run(
-            [codex_bin, "--version"],
+            [_resolve_codex_bin(codex_bin), "--version"],
             capture_output=True,
             text=True,
             timeout=10,

--- a/tests/agent/transports/test_codex_app_server_runtime.py
+++ b/tests/agent/transports/test_codex_app_server_runtime.py
@@ -135,6 +135,96 @@ class TestCodexAppServerModule:
         assert ok is False
         assert "not found" in msg.lower() or "no such" in msg.lower()
 
+    def test_resolve_codex_bin_uses_which_for_bare_name(self, monkeypatch) -> None:
+        from agent.transports.codex_app_server import _resolve_codex_bin
+
+        monkeypatch.setattr(
+            "agent.transports.codex_app_server.shutil.which",
+            lambda name: r"C:\Users\alice\AppData\Roaming\npm\codex.CMD"
+            if name == "codex"
+            else None,
+        )
+        assert (
+            _resolve_codex_bin("codex")
+            == r"C:\Users\alice\AppData\Roaming\npm\codex.CMD"
+        )
+
+    def test_resolve_codex_bin_keeps_existing_absolute_path(self, tmp_path) -> None:
+        from agent.transports.codex_app_server import _resolve_codex_bin
+
+        codex_path = tmp_path / "codex.CMD"
+        codex_path.write_text("@echo off\n", encoding="utf-8")
+        assert _resolve_codex_bin(str(codex_path)) == str(codex_path)
+
+    def test_check_codex_binary_spawns_resolved_path(self, monkeypatch) -> None:
+        import subprocess
+
+        from agent.transports.codex_app_server import check_codex_binary
+
+        resolved = r"C:\Users\alice\AppData\Roaming\npm\codex.CMD"
+        monkeypatch.setattr(
+            "agent.transports.codex_app_server.shutil.which",
+            lambda name: resolved if name == "codex" else None,
+        )
+
+        captured: dict[str, list[str]] = {}
+
+        def fake_run(cmd, **kwargs):
+            captured["cmd"] = list(cmd)
+
+            class _Proc:
+                returncode = 0
+                stdout = "codex-cli 0.139.0"
+                stderr = ""
+
+            return _Proc()
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+        ok, msg = check_codex_binary(codex_bin="codex")
+        assert ok is True
+        assert captured["cmd"] == [resolved, "--version"]
+        assert msg == "0.139.0"
+
+    def test_client_spawn_uses_resolved_codex_path(self, monkeypatch) -> None:
+        import subprocess
+
+        from agent.transports import codex_app_server as cas
+
+        resolved = r"C:\Users\alice\AppData\Roaming\npm\codex.CMD"
+        monkeypatch.setattr(
+            "agent.transports.codex_app_server.shutil.which",
+            lambda name: resolved if name == "codex" else None,
+        )
+
+        captured: dict[str, list[str]] = {}
+
+        class FakePopen:
+            def __init__(self, cmd, *args, **kwargs):
+                captured["cmd"] = list(cmd)
+                self.stdin = None
+                self.stdout = None
+                self.stderr = None
+                self.pid = 1
+                self.returncode = None
+
+            def poll(self):
+                return None
+
+            def terminate(self):
+                pass
+
+            def wait(self, timeout=None):
+                return 0
+
+            def kill(self):
+                pass
+
+        monkeypatch.setattr(subprocess, "Popen", FakePopen)
+        client = cas.CodexAppServerClient(codex_bin="codex")
+        client._closed = True
+
+        assert captured["cmd"][:2] == [resolved, "app-server"]
+
     def test_codex_error_class_is_runtimeerror(self) -> None:
         from agent.transports.codex_app_server import CodexAppServerError
 


### PR DESCRIPTION
Fixes #48510.

## Bug

On Windows, `agent/transports/codex_app_server.py` can't find the `codex` CLI even when it's installed and on `PATH`.

`npm i -g @openai/codex` installs **`codex.CMD`**, not `codex.exe`. Passing the bare name `"codex"` to `subprocess` *without* `shell=True` goes through `CreateProcess`, which does **not** search `PATHEXT` for `.CMD`/`.BAT`, so it raises `[WinError 2] The system cannot find the file specified` - even though `shutil.which("codex")` resolves it correctly:

```python
shutil.which("codex")            # -> C:\Users\<u>\AppData\Roaming\npm\codex.CMD  ?
subprocess.run(["codex", ...])   # -> [WinError 2]                                 ?
```

Result: `/codex-runtime` reports `codex CLI not found` and codex-runtime is unusable on Windows.

## Two affected call sites

The bug hits **both** places that launch codex by bare name:

1. `check_codex_binary()` - `subprocess.run([codex_bin, "--version"], ...)` (the reported detection failure).
2. `CodexAppServerClient.__init__()` - `subprocess.Popen([codex_bin, "app-server"] + ...)` (the actual server spawn). Fixing only detection would make "not found" go away but then the spawn would fail with the same `WinError 2`.

## Fix

Resolve the command to its real path before handing it to `subprocess`, via a small shared helper:

```python
def _resolve_codex_bin(codex_bin: str) -> str:
    return shutil.which(codex_bin) or codex_bin
```

Applied at both call sites. `shutil.which` finds `codex.CMD` on Windows (and the real binary on macOS/Linux); the `or codex_bin` fallback preserves the existing behavior when codex genuinely isn't installed, so the `FileNotFoundError` ? "codex CLI not found. Install with: npm i -g @openai/codex" message still fires.

## Why this is safe cross-platform

- On macOS/Linux `shutil.which("codex")` returns the resolved absolute path; passing an absolute path to subprocess is equivalent to passing the bare name that was already on `PATH` - no behavior change.
- No `shell=True` is introduced (avoids quoting/injection concerns); the argument list stays a list.
- `shutil` is the only new import.

## Verification

- Confirmed on current `main`: both `check_codex_binary` (line ~377) and the `__init__` spawn (line ~113) pass the bare `codex_bin` to subprocess, and `shutil` was not imported.
- Matches Option 1 from the issue's proposed fixes, extended to also cover the spawn path so codex-runtime actually starts (not just passes detection).
- No open PR addresses this (checked before opening).