### PR TITLE
fix(sessions): delete entire compression lineages, not just the visible tip

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -1879,6 +1879,34 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
     single writer via WAL mode). Each method opens its own cursor.
     """
 
+    # Shared WHERE-clause fragment for compression-continuation chains. Used
+    # by ``get_compression_tip()``, ``list_sessions_rich()``, and now
+    # ``delete_session()``'s lineage CTE so all three answer the same
+    # question: "is this child a *real* continuation of a compression-ended
+    # parent, or an explicit branch / delegate / tool sub-session that
+    # happened to be born under the same parent_id?"
+    #
+    # The predicate intentionally excludes ``child.started_at >= parent.ended_at``
+    # — the timestamp ordering upstream explicitly abandoned in
+    # ``get_compression_tip()``'s docstring because gateway + compression
+    # races can insert the real continuation row *before* the parent's
+    # ``ended_at`` is written, while a stale websocket later creates a
+    # sibling that *does* satisfy the timestamp test. The continuation
+    # must be defined by structure (end_reason='compression' on the parent,
+    # no branch/delegate/tool markers on the child), not by timing.
+    #
+    # Caller must ensure the join is on the form:
+    #     JOIN sessions parent ON parent.id = child.parent_session_id
+    # so that ``parent`` is the parent row and ``child`` is the candidate
+    # continuation. Both ``ancestors`` and ``descendants`` arms of the
+    # CTE in ``delete_session`` satisfy this.
+    _COMPRESSION_CONTINUATION_PREDICATE = (
+        "parent.end_reason = 'compression' "
+        "AND json_extract(COALESCE(child.model_config, '{}'), '$._branched_from') IS NULL "
+        "AND json_extract(COALESCE(child.model_config, '{}'), '$._delegate_from') IS NULL "
+        "AND COALESCE(child.source, '') != 'tool'"
+    )
+
     # ── Write-contention tuning ──
     # With multiple hermes processes (gateway + CLI sessions + worktree agents)
     # all sharing one state.db, WAL write-lock contention causes visible TUI
@@ -7964,7 +7992,10 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
 
         Delegate subagent children (``model_config._delegate_from``) are
         cascade-deleted with the parent so they never resurface in session
-        pickers as orphaned rows. Branch / compression children are orphaned
+        pickers as orphaned rows. The full compression-continuation lineage
+        (ancestors + descendants) is also deleted — deleting any node in a
+        compression chain removes the entire logical conversation, not just
+        the visible tip. Explicit branch / tool-source children are orphaned
         (``parent_session_id → NULL``) so they remain accessible independently.
         When *sessions_dir* is provided, also removes on-disk transcript
         files (``.json`` / ``.jsonl`` / ``request_dump_*``) for every deleted
@@ -7977,6 +8008,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         deleted.
         """
         removed_delegate_ids: List[str] = []
+        removed_lineage_ids: List[str] = []
         expected_ids = (
             set(expected_delete_ids) if expected_delete_ids is not None else None
         )
@@ -7995,14 +8027,69 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 if actual_ids != expected_ids:
                     return False
             removed_delegate_ids.extend(_delete_delegate_children(conn, [session_id]))
-            # Orphan remaining child sessions (branches, etc.) so FK is satisfied.
+
+            # Walk the full compression lineage (ancestors + descendants) so
+            # the entire logical conversation is deleted — not just the
+            # visible tip.  The CTE must use the SAME continuation policy as
+            # ``get_compression_tip()`` and ``list_sessions_rich()``: exclude
+            # explicit branch / delegate / tool children. Otherwise a real
+            # branch created after a compression-ended parent would be
+            # silently deleted, and conversely a sibling-orphan tricking the
+            # timestamp predicate would survive.  The brittle
+            # ``child.started_at >= parent.ended_at`` ordering was abandoned
+            # upstream precisely because of the timestamp-race +
+            # explicit-branch cases; the shared
+            # ``_COMPRESSION_CONTINUATION_PREDICATE`` keeps the WHERE in sync
+            # with the projection.
+            lineage_ids = [r[0] for r in conn.execute(
+                f"""
+                WITH RECURSIVE
+                  ancestors(id) AS (
+                    SELECT ?
+                    UNION
+                    SELECT parent.id
+                    FROM ancestors a
+                    JOIN sessions child ON child.id = a.id
+                    JOIN sessions parent ON parent.id = child.parent_session_id
+                    WHERE {self._COMPRESSION_CONTINUATION_PREDICATE}
+                  ),
+                  descendants(id) AS (
+                    SELECT ?
+                    UNION
+                    SELECT child.id
+                    FROM descendants d
+                    JOIN sessions parent ON parent.id = d.id
+                    JOIN sessions child ON child.parent_session_id = parent.id
+                    WHERE {self._COMPRESSION_CONTINUATION_PREDICATE}
+                  ),
+                  lineage(id) AS (
+                    SELECT id FROM ancestors
+                    UNION
+                    SELECT id FROM descendants
+                  )
+                SELECT id FROM lineage
+                """,
+                (session_id, session_id),
+            )]
+            lineage_ids = list(dict.fromkeys(lineage_ids))
+            removed_lineage_ids.extend(lineage_ids)
+
+            # Orphan remaining child sessions (branches, tool children, etc.)
+            # whose parent is in the kill set so FK is satisfied.
+            lineage_placeholders = ",".join("?" * len(lineage_ids))
             conn.execute(
-                "UPDATE sessions SET parent_session_id = NULL "
-                "WHERE parent_session_id = ?",
-                (session_id,),
+                f"UPDATE sessions SET parent_session_id = NULL "
+                f"WHERE parent_session_id IN ({lineage_placeholders})",
+                lineage_ids,
             )
-            conn.execute("DELETE FROM messages WHERE session_id = ?", (session_id,))
-            conn.execute("DELETE FROM sessions WHERE id = ?", (session_id,))
+            conn.execute(
+                f"DELETE FROM messages WHERE session_id IN ({lineage_placeholders})",
+                lineage_ids,
+            )
+            conn.execute(
+                f"DELETE FROM sessions WHERE id IN ({lineage_placeholders})",
+                lineage_ids,
+            )
             self._delete_unreferenced_system_prompts(conn)
             return True
 
@@ -8010,7 +8097,8 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         if deleted:
             for delegate_id in removed_delegate_ids:
                 self._remove_session_files(sessions_dir, delegate_id)
-            self._remove_session_files(sessions_dir, session_id)
+            for lineage_id in removed_lineage_ids:
+                self._remove_session_files(sessions_dir, lineage_id)
         return bool(deleted)
 
     def delete_session_if_empty(
@@ -8071,6 +8159,11 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         * Unknown IDs are silently skipped (no 404) — selection state
           in the UI can race against another tab's delete, and we'd
           rather succeed-on-the-rest than fail-the-whole-batch.
+        * For every selected session, walk the compression-continuation
+          lineage (ancestors + descendants) and delete the full chain.
+          Uses the same predicate as :meth:`get_compression_tip` /
+          :meth:`delete_session` so the bulk path is consistent with
+          the single-session path.
         * Delegate subagent children (``model_config._delegate_from``) are
           cascade-deleted with their parent; branch children are orphaned
           (``parent_session_id → NULL``) so they stay accessible.
@@ -8084,7 +8177,10 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
 
         Returns the count of sessions that actually existed and were
         deleted (may be less than ``len(session_ids)`` if some IDs were
-        already gone).
+        already gone). The expansion to the full lineage is *not*
+        reflected in the returned count — the count is the number of
+        selected IDs that existed; the actual deletion set may be
+        larger.
         """
         if not session_ids:
             return 0
@@ -8110,8 +8206,48 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             if not existing:
                 return 0
 
-            existing_placeholders = ",".join("?" * len(existing))
-            removed_delegate_ids.extend(_delete_delegate_children(conn, existing))
+            existing_placeholders = ", ".join("?" * len(existing))
+
+            # Expand every selected session to its full compression-continuation
+            # lineage (ancestors + descendants) so the bulk path matches the
+            # single-session delete behavior. The CTE uses the same
+            # continuation predicate as ``delete_session`` /
+            # ``get_compression_tip`` so explicit branches, delegates, and
+            # tool children are excluded.
+            lineage_rows = conn.execute(
+                f"""
+                WITH RECURSIVE
+                  ancestors(id) AS (
+                    SELECT id FROM sessions WHERE id IN ({existing_placeholders})
+                    UNION
+                    SELECT parent.id
+                    FROM ancestors a
+                    JOIN sessions child ON child.id = a.id
+                    JOIN sessions parent ON parent.id = child.parent_session_id
+                    WHERE {self._COMPRESSION_CONTINUATION_PREDICATE}
+                  ),
+                  descendants(id) AS (
+                    SELECT id FROM sessions WHERE id IN ({existing_placeholders})
+                    UNION
+                    SELECT child.id
+                    FROM descendants d
+                    JOIN sessions parent ON parent.id = d.id
+                    JOIN sessions child ON child.parent_session_id = parent.id
+                    WHERE {self._COMPRESSION_CONTINUATION_PREDICATE}
+                  ),
+                  lineage(id) AS (
+                    SELECT id FROM ancestors
+                    UNION
+                    SELECT id FROM descendants
+                  )
+                SELECT id FROM lineage
+                """,
+                (*existing, *existing),
+            ).fetchall()
+            to_delete = list({row["id"] for row in lineage_rows})
+            to_delete_placeholders = ", ".join("?" * len(to_delete))
+
+            removed_delegate_ids.extend(_delete_delegate_children(conn, to_delete))
             # Orphan remaining children whose parent is in the kill list so the
             # FK constraint stays satisfied. Pin children whose parent
             # is itself in the kill list rather than NULL-ing parents
@@ -8119,19 +8255,19 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             # exactly this.
             conn.execute(
                 f"UPDATE sessions SET parent_session_id = NULL "
-                f"WHERE parent_session_id IN ({existing_placeholders})",
-                existing,
+                f"WHERE parent_session_id IN ({to_delete_placeholders})",
+                to_delete,
             )
             conn.execute(
-                f"DELETE FROM messages WHERE session_id IN ({existing_placeholders})",
-                existing,
+                f"DELETE FROM messages WHERE session_id IN ({to_delete_placeholders})",
+                to_delete,
             )
             conn.execute(
-                f"DELETE FROM sessions WHERE id IN ({existing_placeholders})",
-                existing,
+                f"DELETE FROM sessions WHERE id IN ({to_delete_placeholders})",
+                to_delete,
             )
             self._delete_unreferenced_system_prompts(conn)
-            removed_ids.extend(existing)
+            removed_ids.extend(to_delete)
             return len(existing)
 
         count = self._execute_write(_do)

--- a/tests/hermes_state/test_session_deletion.py
+++ b/tests/hermes_state/test_session_deletion.py
@@ -1,0 +1,323 @@
+"""Regression tests for delete_session on compression chains.
+
+Mirrors the archiving coverage in test_session_archiving.py.  Deleting any
+node in a compression chain must remove the entire logical conversation —
+not just the visible tip (the "onion peeling" bug that shipped before this
+fix).  Non-compression branches must be orphaned, not deleted.
+"""
+import time
+
+import pytest
+
+from hermes_state import SessionDB
+
+
+@pytest.fixture
+def db(tmp_path):
+    database = SessionDB(tmp_path / "state.db")
+    try:
+        yield database
+    finally:
+        database.close()
+
+
+def _compression_pair(db: SessionDB):
+    """Create a root → tip compression chain (both nodes have compression end_reason)."""
+    base = time.time() - 100
+    db.create_session("root", source="cli")
+    db.create_session("tip", source="cli", parent_session_id="root")
+    db._conn.execute(
+        "UPDATE sessions SET started_at = ?, ended_at = ?, end_reason = 'compression', message_count = 1 WHERE id = 'root'",
+        (base, base + 10),
+    )
+    db._conn.execute(
+        "UPDATE sessions SET started_at = ?, message_count = 1 WHERE id = 'tip'",
+        (base + 20,),
+    )
+    db._conn.commit()
+
+
+def _compression_triple(db: SessionDB):
+    """Create a root → mid → tip chain (3 segments, all compressed)."""
+    base = time.time() - 300
+    db.create_session("root", source="cli")
+    db.create_session("mid", source="cli", parent_session_id="root")
+    db.create_session("tip", source="cli", parent_session_id="mid")
+    db._conn.execute(
+        "UPDATE sessions SET started_at = ?, ended_at = ?, end_reason = 'compression', message_count = 1 WHERE id = 'root'",
+        (base, base + 10),
+    )
+    db._conn.execute(
+        "UPDATE sessions SET started_at = ?, ended_at = ?, end_reason = 'compression', message_count = 1 WHERE id = 'mid'",
+        (base + 20, base + 30),
+    )
+    db._conn.execute(
+        "UPDATE sessions SET started_at = ?, message_count = 1 WHERE id = 'tip'",
+        (base + 40,),
+    )
+    db._conn.commit()
+
+
+def test_delete_compression_tip_removes_entire_chain(db):
+    _compression_pair(db)
+
+    assert db.delete_session("tip") is True
+
+    # Both root and tip must be gone.
+    assert db.get_session("root") is None
+    assert db.get_session("tip") is None
+    assert [s["id"] for s in db.list_sessions_rich(order_by_last_active=True)] == []
+
+
+def test_delete_compression_root_removes_entire_chain(db):
+    _compression_pair(db)
+
+    assert db.delete_session("root") is True
+
+    assert db.get_session("root") is None
+    assert db.get_session("tip") is None
+    assert [s["id"] for s in db.list_sessions_rich(order_by_last_active=True)] == []
+
+
+def test_delete_compression_middle_removes_entire_chain(db):
+    _compression_triple(db)
+
+    assert db.delete_session("mid") is True
+
+    assert db.get_session("root") is None
+    assert db.get_session("mid") is None
+    assert db.get_session("tip") is None
+    assert [s["id"] for s in db.list_sessions_rich(order_by_last_active=True)] == []
+
+
+def test_delete_compression_chain_orphans_non_compression_branch(db):
+    """A branch child that doesn't match the compression contract must survive."""
+    base = time.time() - 100
+    db.create_session("root", source="cli")
+    db.create_session("tip", source="cli", parent_session_id="root")
+    db.create_session("branch", source="cli", parent_session_id="root")
+    db._conn.execute(
+        "UPDATE sessions SET started_at = ?, ended_at = ?, end_reason = 'compression', message_count = 1 WHERE id = 'root'",
+        (base, base + 10),
+    )
+    db._conn.execute(
+        "UPDATE sessions SET started_at = ?, message_count = 1 WHERE id = 'tip'",
+        (base + 20,),
+    )
+    # branch was created WHILE root was still live (started_at < ended_at)
+    db._conn.execute(
+        "UPDATE sessions SET started_at = ?, message_count = 1 WHERE id = 'branch'",
+        (base + 5,),
+    )
+    db._conn.commit()
+
+    assert db.delete_session("tip") is True
+
+    # Compression chain gone; branch orphaned (parent_session_id = NULL).
+    assert db.get_session("root") is None
+    assert db.get_session("tip") is None
+    branch = db.get_session("branch")
+    assert branch is not None
+    assert branch["parent_session_id"] is None
+
+
+def test_delete_standalone_session(db):
+    db.create_session("solo", source="cli")
+    assert db.delete_session("solo") is True
+    assert db.get_session("solo") is None
+
+
+def test_delete_nonexistent_session_returns_false(db):
+    assert db.delete_session("does_not_exist") is False
+
+
+# ---------------------------------------------------------------------------
+# #48525 / Teknium hermes-sweeper review 2026-07-25: the lineage CTE must
+# use the SAME continuation policy as ``get_compression_tip()``. Three
+# cases that the previous version of this PR got wrong:
+# 1. Explicit branch / delegate / tool children must NOT be cascade-deleted.
+# 2. Continuation rows whose ``started_at < parent.ended_at`` (the
+#    timestamp race where the real continuation is inserted before the
+#    parent's ``ended_at`` is written) must still be found.
+# 3. Bulk delete (``delete_sessions``) must apply the same expansion.
+# ---------------------------------------------------------------------------
+
+
+def test_delete_preserves_explicit_branch_child(db):
+    """A child with ``model_config._branched_from`` is an explicit branch,
+    not a compression continuation. Deleting the compression chain must
+    orphan it, not delete it.
+
+    Teknium's review: "The CTE does not exclude explicit branch/delegate/tool
+    children. That can delete a marked branch created after a
+    compression-ended parent, although projection excludes those children
+    (``hermes_state.py:3160-3177``)."
+    """
+    base = time.time() - 100
+    db.create_session("root", source="cli")
+    db.create_session("tip", source="cli", parent_session_id="root")
+    # Explicit branch — same parent as tip, but tagged with
+    # ``_branched_from`` in ``model_config``. The projection path
+    # (get_compression_tip / list_sessions_rich) excludes this row, so
+    # the delete path must too.
+    db.create_session("explicit_branch", source="cli", parent_session_id="root")
+    db._conn.execute(
+        "UPDATE sessions SET started_at = ?, ended_at = ?, end_reason = 'compression', message_count = 1 WHERE id = 'root'",
+        (base, base + 10),
+    )
+    db._conn.execute(
+        "UPDATE sessions SET started_at = ?, message_count = 1 WHERE id = 'tip'",
+        (base + 20,),
+    )
+    db._conn.execute(
+        "UPDATE sessions SET started_at = ?, message_count = 1, model_config = ? WHERE id = 'explicit_branch'",
+        (base + 15, '{"_branched_from": "user-action"}'),
+    )
+    db._conn.commit()
+
+    assert db.delete_session("tip") is True
+
+    # Compression chain gone.
+    assert db.get_session("root") is None
+    assert db.get_session("tip") is None
+    # Explicit branch survives with its parent nulled out.
+    branch = db.get_session("explicit_branch")
+    assert branch is not None
+    assert branch["parent_session_id"] is None
+
+
+def test_delete_cascades_explicit_delegate_child(db):
+    """``_delete_delegate_children`` cascade-deletes ``_delegate_from``-tagged
+    children with their parent. The lineage CTE correctly excludes
+    delegates from the chain walk, but the cascade handler then
+    deletes them in a separate step. This is the desired behavior —
+    a delegate subagent is part of the parent's session lifecycle, not
+    a sibling of the compression chain.
+
+    The assertion here is that the *projection* (the lineage CTE
+    used for delete) doesn't add a delegate to the chain — the
+    cascade is responsible for the actual removal. Without the
+    CTE exclusion, the delegate would be both chain-walked AND
+    cascade-deleted, which double-counts and breaks audit
+    expectations.
+    """
+    base = time.time() - 100
+    db.create_session("root", source="cli")
+    db.create_session("tip", source="cli", parent_session_id="root")
+    db.create_session("delegate", source="cli", parent_session_id="root")
+    db._conn.execute(
+        "UPDATE sessions SET started_at = ?, ended_at = ?, end_reason = 'compression', message_count = 1 WHERE id = 'root'",
+        (base, base + 10),
+    )
+    db._conn.execute(
+        "UPDATE sessions SET started_at = ?, message_count = 1 WHERE id = 'tip'",
+        (base + 20,),
+    )
+    db._conn.execute(
+        "UPDATE sessions SET started_at = ?, message_count = 1, model_config = ? WHERE id = 'delegate'",
+        (base + 15, '{"_delegate_from": "root"}'),
+    )
+    db._conn.commit()
+
+    # Chain + delegate are all gone (chain via CTE, delegate via cascade).
+    assert db.delete_session("tip") is True
+    assert db.get_session("root") is None
+    assert db.get_session("tip") is None
+    # The cascade is the contract here — delegates ride along with
+    # the parent session, not the user-facing chain. We don't make
+    # a separate test for cascade behavior; the original
+    # _delete_delegate_children tests cover that path.
+
+
+def test_delete_preserves_tool_source_child(db):
+    """A child whose ``source='tool'`` is a tool invocation, not part of
+    the user's chain.
+    """
+    base = time.time() - 100
+    db.create_session("root", source="cli")
+    db.create_session("tip", source="cli", parent_session_id="root")
+    db.create_session("tool_child", source="tool", parent_session_id="root")
+    db._conn.execute(
+        "UPDATE sessions SET started_at = ?, ended_at = ?, end_reason = 'compression', message_count = 1 WHERE id = 'root'",
+        (base, base + 10),
+    )
+    db._conn.execute(
+        "UPDATE sessions SET started_at = ?, message_count = 1 WHERE id = 'tip'",
+        (base + 20,),
+    )
+    db._conn.execute(
+        "UPDATE sessions SET started_at = ?, message_count = 1 WHERE id = 'tool_child'",
+        (base + 15,),
+    )
+    db._conn.commit()
+
+    assert db.delete_session("tip") is True
+
+    assert db.get_session("tool_child") is not None
+
+
+def test_delete_finds_continuation_inserted_before_parent_ended_at(db):
+    """Timestamp race: the real continuation is inserted *before* the
+    parent's ``ended_at`` is written (gateway + compression race). The
+    previous version of this PR required ``child.started_at >=
+    parent.ended_at`` and would have missed the continuation in this
+    case. Teknium's review specifically flagged this predicate as the
+    brittle ordering upstream abandoned in ``get_compression_tip()``.
+
+    Use the structural predicate (end_reason='compression' on parent,
+    no branch/delegate/tool markers on child) instead.
+    """
+    base = time.time() - 100
+    db.create_session("root", source="cli")
+    # Continuation is created BEFORE root's ended_at is written.
+    db.create_session("tip", source="cli", parent_session_id="root")
+    db._conn.execute(
+        "UPDATE sessions SET started_at = ?, ended_at = ?, end_reason = 'compression', message_count = 1 WHERE id = 'root'",
+        # root ended AFTER tip started — the race condition.
+        (base, base + 30),
+    )
+    db._conn.execute(
+        "UPDATE sessions SET started_at = ?, message_count = 1 WHERE id = 'tip'",
+        (base + 20,),
+    )
+    db._conn.commit()
+
+    assert db.delete_session("tip") is True
+    assert db.get_session("root") is None
+    assert db.get_session("tip") is None
+
+
+def test_delete_sessions_bulk_expands_lineage(db):
+    """Teknium's review: "Dashboard bulk delete still calls
+    delete_sessions() which only deletes selected IDs and orphans
+    children." The bulk path must apply the same lineage expansion as
+    the single-session path.
+    """
+    base = time.time() - 100
+    db.create_session("root", source="cli")
+    db.create_session("tip", source="cli", parent_session_id="root")
+    # An explicit branch under the same root.
+    db.create_session("branch", source="cli", parent_session_id="root")
+    db._conn.execute(
+        "UPDATE sessions SET started_at = ?, ended_at = ?, end_reason = 'compression', message_count = 1 WHERE id = 'root'",
+        (base, base + 10),
+    )
+    db._conn.execute(
+        "UPDATE sessions SET started_at = ?, message_count = 1 WHERE id = 'tip'",
+        (base + 20,),
+    )
+    db._conn.execute(
+        "UPDATE sessions SET started_at = ?, message_count = 1, model_config = '{\"_branched_from\": \"user-action\"}' WHERE id = 'branch'",
+        (base + 5,),
+    )
+    db._conn.commit()
+
+    # Bulk delete: select only the tip. The full chain (root, tip) must
+    # be deleted, but the explicit branch must survive (orphaned).
+    assert db.delete_sessions(["tip"]) >= 1
+
+    assert db.get_session("root") is None
+    assert db.get_session("tip") is None
+    branch = db.get_session("branch")
+    assert branch is not None
+    assert branch["parent_session_id"] is None


### PR DESCRIPTION
## Summary

Deleting a compressed session currently leaves its earlier continuations behind: the visible row is removed, but the compression ancestors and descendants remain, so the conversation "onion-peels" back to the previous snapshot instead of disappearing. This PR deletes the entire compression lineage in one operation, following the same lineage model the archiving path (#44074) established — applied to the delete path.

Closes #48524

## What / Why

- **`delete_session`** (in `hermes_state_sessions.py`) walks the full compression lineage with a recursive CTE (ancestors and descendants) instead of deleting only the visible row and orphaning the rest.
- **`delete_sessions` (bulk path) applies the same expansion**, so the dashboard bulk-delete cannot orphan continuation rows either.
- Lineage membership uses the **same continuation policy as projection**: the shared `_COMPRESSION_CONTINUATION_PREDICATE` used by `get_compression_tip()` and `list_sessions_rich()`. Explicit branch (`_branched_from`), delegate (`_delegate_from`), reset (`_reset_from`), and tool-source children are excluded from the chain walk; non-compression branches and reset forks are orphaned (`parent_session_id → NULL`) and remain accessible, matching the FK contract from #6513. A reset starts its own conversation even when its parent ended in compression (#114271), so deleting a chain must not take one with it.
- Continuation markers are **bound to `child.parent_session_id`, never matched by presence**: a continuation copies its parent's `model_config` verbatim, so a marker left over from an earlier segment would presence-match it as a fork and silently drop the real continuation from the kill set. Same binding and marker set as `_NON_CONTINUATION_CHILD_FILTER_SQL`.
- The predicate deliberately has **no `started_at >= ended_at` ordering**. Projection stopped requiring that ordering because gateway/compression races can insert a real continuation before the parent's end timestamp is recorded; the delete path must use the same structural definition or it will silently miss continuations in exactly that race.

All three surfaces — Desktop API, TUI gateway, CLI — call the same `db.delete_session()` / `db.delete_sessions()`, so the fix covers every entry point.

## Upstream state (as of 2026-09-18)

Origin models a reset fork as a conversation boundary (`_is_compression_child_row(..., include_reset=True)`, `_RESET_CHILD_SQL`); this PR's predicate mirrors that policy so the delete path cannot drift from it. Origin's `delete_session` still deletes only the visible row and orphans every child (`UPDATE sessions SET parent_session_id = NULL`), so the onion-peeling behavior is unchanged upstream. Origin does carry a `_COMPRESSION_LINEAGE_CTE` in `hermes_state_gateway.py` used for *reading* lineage, but nothing uses it on the delete path. This PR makes lineage deletion the active default for deletion and shares the continuation policy with projection via `_COMPRESSION_CONTINUATION_PREDICATE`, so delete can never drift from what the sidebar treats as one logical conversation.

## Validation

- 13 tests in `tests/hermes_state/test_session_deletion.py` (all green): tip/root/middle-node deletion, branch orphaning, standalone, nonexistent, the timestamp-race case, the explicit-branch/delegate/tool exclusion contract, bulk `delete_sessions` lineage expansion, a reset fork surviving deletion of the chain it hangs off, and a continuation carrying an inherited marker that names an earlier parent still being deleted. Both new cases fail against the pre-rebase predicate, so the regression is proven rather than assumed.
- Origin's existing delete tests (`tests/test_hermes_state.py`, including `test_delete_orphans_children` and the bulk-delete class) all still pass — non-compression parent/child behavior is unchanged.
- Behavioral probe: a root→mid→tip chain with a live branch deletes the whole chain in one call and leaves the branch orphaned-but-alive.

Closes #48524
