### PR TITLE
fix(desktop): raise authenticated fetch timeout so profile-heavy remote startup doesn't time out (fixes #48504)

### DIFF
--- a/apps/desktop/electron/hardening.cjs
+++ b/apps/desktop/electron/hardening.cjs
@@ -2,7 +2,14 @@ const fs = require('node:fs')
 const path = require('node:path')
 const { fileURLToPath } = require('node:url')
 
-const DEFAULT_FETCH_TIMEOUT_MS = 15_000
+// Default timeout for authenticated Desktop -> backend API calls. Kept generous
+// because profile-heavy remote installs can make startup data calls (e.g.
+// GET /api/profiles) take ~30s+; the previous 15s value timed out a backend
+// that had already passed the readiness check, surfacing as a spurious
+// "Could not connect to Hermes gateway" (#48504). Readiness/auth probes
+// (/api/status, /api/auth/providers) pass their own short explicit timeouts,
+// so a genuinely-down backend is still detected quickly regardless of this.
+const DEFAULT_FETCH_TIMEOUT_MS = 60_000
 const DATA_URL_READ_MAX_BYTES = 16 * 1024 * 1024
 const TEXT_PREVIEW_SOURCE_MAX_BYTES = 64 * 1024 * 1024
 


### PR DESCRIPTION
Fixes #48504.

## Bug

Hermes Desktop in remote mode proves the backend is reachable (`/api/status`
passes), then still fails startup with:

```
Remote Hermes backend is ready
Timed out connecting to Hermes backend after 15000ms
Could not connect to Hermes gateway
```

The backend isn''t down - the Desktop client is timing out while loading
authenticated **startup data** (notably `GET /api/profiles`) from the
already-ready remote backend. On a profile-heavy install, profile loading can
take ~35s, but every authenticated Desktop?backend call falls back to a
hardcoded **15s** timeout (`DEFAULT_FETCH_TIMEOUT_MS` in
`apps/desktop/electron/hardening.cjs`), so a working remote deployment becomes
unusable from Desktop without a source patch.

## Fix

Raise `DEFAULT_FETCH_TIMEOUT_MS` from `15_000` to `60_000`.

```js
const DEFAULT_FETCH_TIMEOUT_MS = 60_000
```

Every authenticated fetch path (`fetchJson`, `fetchJsonViaOauthSession`, the
per-profile proxy, the renderer IPC proxy) uses this constant as its fallback
via `resolveTimeoutMs(options.timeoutMs, DEFAULT_FETCH_TIMEOUT_MS)`, so this
single change covers whichever path loads profiles at startup - no behavior
change for callers that already pass an explicit `timeoutMs`.

## Why this is safe

- **Down-backend detection is unaffected.** Readiness/auth probes pass their
  own short explicit timeouts and do not rely on this default:
  `/api/status` ? `8_000` (and `2_500` for the liveness poll),
  `/api/auth/providers` ? `8_000`. A genuinely unreachable backend still fails
  fast through those probes *before* startup data loads.
- The default only governs authenticated data calls after readiness has already
  passed - exactly the calls the issue shows being killed prematurely. 60s gives
  large multi-profile installs (the ~35s case in the report, plus headroom)
  room to finish while still bounding a truly-hung request.

## Verification

- Confirmed on current `main`: `DEFAULT_FETCH_TIMEOUT_MS = 15_000`
  (`apps/desktop/electron/hardening.cjs:6`), and the error text
  `Timed out connecting to Hermes backend after ${timeoutMs}ms` is emitted by
  the fetch helpers in `main.cjs` that fall back to it.
- Confirmed the short readiness/auth probes pass explicit `8_000` / `2_500`
  timeouts, so they keep their fast-fail behavior.
- No open PR addresses this (checked before opening).

A follow-up could make this user-configurable from Desktop settings (the
issue''s first suggestion); this change is the minimal, low-risk unblock.