### PR TITLE
fix(install): relax EAP=Stop around native git/uv calls + fail-fast on uv venv failure (#48352, salvage of #48372)

### DIFF
--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -185,6 +185,18 @@ function Write-Err {
     Write-Host "[X] $Message" -ForegroundColor Red
 }
 
+function Invoke-NativeWithRelaxedErrorAction {
+    param([scriptblock]$Script)
+
+    $prevEAP = $ErrorActionPreference
+    $ErrorActionPreference = "Continue"
+    try {
+        & $Script
+    } finally {
+        $ErrorActionPreference = $prevEAP
+    }
+}
+
 # Inspect npm output for a TLS-trust failure and, if found, print actionable
 # remediation. npm/Node surface corporate MITM proxies and missing root CAs as
 # "unable to get local issuer certificate" / "self-signed certificate in
@@ -1306,7 +1318,7 @@ function Install-Repository {
         Write-Info "Trying SSH clone..."
         $env:GIT_SSH_COMMAND = "ssh -o BatchMode=yes -o ConnectTimeout=5"
         try {
-            git -c windows.appendAtomically=false clone --depth 1 --branch $Branch $RepoUrlSsh $InstallDir
+            Invoke-NativeWithRelaxedErrorAction { git -c windows.appendAtomically=false clone --depth 1 --branch $Branch $RepoUrlSsh $InstallDir }
             if ($LASTEXITCODE -eq 0) { $cloneSuccess = $true }
         } catch { }
         $env:GIT_SSH_COMMAND = $null
@@ -1315,7 +1327,7 @@ function Install-Repository {
             if (Test-Path $InstallDir) { Remove-Item -Recurse -Force $InstallDir -ErrorAction SilentlyContinue }
             Write-Info "SSH failed, trying HTTPS..."
             try {
-                git -c windows.appendAtomically=false clone --depth 1 --branch $Branch $RepoUrlHttps $InstallDir
+                Invoke-NativeWithRelaxedErrorAction { git -c windows.appendAtomically=false clone --depth 1 --branch $Branch $RepoUrlHttps $InstallDir }
                 if ($LASTEXITCODE -eq 0) { $cloneSuccess = $true }
             } catch { }
         }
@@ -1443,8 +1455,11 @@ function Install-Venv {
         Remove-Item -Recurse -Force "venv"
     }
     
-    # uv creates the venv and pins the Python version in one step
-    & $UvCmd venv venv --python $PythonVersion
+    # uv creates the venv and pins the Python version in one step.  uv emits
+    # normal progress such as "Using CPython ..." on stderr; under Windows
+    # PowerShell 5.1 with EAP=Stop that stderr is a NativeCommandError unless
+    # we temporarily relax EAP and trust $LASTEXITCODE for real failures.
+    Invoke-NativeWithRelaxedErrorAction { & $UvCmd venv venv --python $PythonVersion }
 
     # Neutralize any inherited UV_PYTHON (e.g. $env:UV_PYTHON = "3.14" left in
     # the user's shell). uv honours UV_PYTHON over an existing venv for the
@@ -1514,7 +1529,7 @@ function Install-Dependencies {
         # in the wrong directory and imports fail with ModuleNotFoundError.
         # (Mirrors the same flag in scripts/install.sh::install_deps.)
         $env:UV_PROJECT_ENVIRONMENT = "$InstallDir\venv"
-        & $UvCmd sync --extra all --locked
+        Invoke-NativeWithRelaxedErrorAction { & $UvCmd sync --extra all --locked }
         if ($LASTEXITCODE -eq 0) {
             Write-Success "Main package installed (hash-verified via uv.lock)"
             $script:InstalledTier = "hash-verified (uv.lock)"
@@ -1589,7 +1604,7 @@ except Exception:
     if (-not $skipPipFallback) {
         foreach ($tier in $installTiers) {
         Write-Info "Trying tier: $($tier.Name) ..."
-        & $UvCmd pip install -e $tier.Spec
+        Invoke-NativeWithRelaxedErrorAction { & $UvCmd pip install -e $tier.Spec }
         if ($LASTEXITCODE -eq 0) {
             Write-Success "Main package installed ($($tier.Name))"
             $script:InstalledTier = $tier.Name

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -1460,6 +1460,15 @@ function Install-Venv {
     # PowerShell 5.1 with EAP=Stop that stderr is a NativeCommandError unless
     # we temporarily relax EAP and trust $LASTEXITCODE for real failures.
     Invoke-NativeWithRelaxedErrorAction { & $UvCmd venv venv --python $PythonVersion }
+    # Relaxing EAP above means a *genuine* uv-venv failure (exit != 0) no longer
+    # aborts on its own. Capture $LASTEXITCODE immediately and fail fast, so the
+    # `venv` stage can't falsely report success (and Invoke-Stage can't emit
+    # ok=true) when the venv was never created.
+    $venvExitCode = $LASTEXITCODE
+    if ($venvExitCode -ne 0) {
+        Pop-Location
+        throw "Failed to create virtual environment (uv venv exited with $venvExitCode)"
+    }
 
     # Neutralize any inherited UV_PYTHON (e.g. $env:UV_PYTHON = "3.14" left in
     # the user's shell). uv honours UV_PYTHON over an existing venv for the

--- a/tests/test_install_ps1_native_stderr_eap.py
+++ b/tests/test_install_ps1_native_stderr_eap.py
@@ -54,6 +54,31 @@ def test_uv_venv_and_dependency_installs_relax_eap() -> None:
     _assert_relaxed_call(text, r"& \$UvCmd pip install -e \$tier\.Spec")
 
 
+def test_uv_venv_failure_is_not_swallowed_after_eap_relax() -> None:
+    """Relaxing EAP must not let a genuine `uv venv` failure pass as success.
+
+    Once EAP is relaxed, a real non-zero `uv venv` exit no longer aborts on its
+    own, so install.ps1 must capture $LASTEXITCODE right after the call and fail
+    fast — otherwise the `venv` stage falsely reports success (Invoke-Stage emits
+    ok=true) when no venv was created. Regression guard for the gap caught while
+    reviewing #48372 (the explicit check originally proposed in #48463).
+    """
+    text = _install_ps1()
+    # The uv-venv invocation, then an exit-code capture, then a throw — all
+    # within a small window after the relaxed call.
+    guard = re.search(
+        r"& \$UvCmd venv venv --python \$PythonVersion[\s\S]{0,400}?"
+        r"\$LASTEXITCODE[\s\S]{0,200}?"
+        r"-ne 0[\s\S]{0,200}?throw",
+        text,
+    )
+    assert guard is not None, (
+        "install.ps1 must capture uv venv's exit code and throw on failure after "
+        "relaxing ErrorActionPreference, so a genuine venv-creation failure isn't "
+        "reported as a successful stage"
+    )
+
+
 def test_native_eap_helper_always_restores_previous_preference() -> None:
     text = _install_ps1()
     m = re.search(

--- a/tests/test_install_ps1_native_stderr_eap.py
+++ b/tests/test_install_ps1_native_stderr_eap.py
@@ -1,0 +1,69 @@
+"""Regression tests for #48352: Windows PowerShell 5.1 native stderr.
+
+PowerShell 5.1 turns stderr from native commands into ``NativeCommandError``
+records when ``$ErrorActionPreference = "Stop"``.  ``scripts/install.ps1`` has a
+few git/uv calls where stderr can be normal progress output, so those calls must
+run with EAP temporarily relaxed and then inspect ``$LASTEXITCODE``.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+INSTALL_PS1 = REPO_ROOT / "scripts" / "install.ps1"
+
+
+def _install_ps1() -> str:
+    return INSTALL_PS1.read_text(encoding="utf-8")
+
+
+def _assert_relaxed_call(text: str, command_pattern: str) -> None:
+    helper_block_pattern = (
+        r"Invoke-NativeWithRelaxedErrorAction\s*\{[^}]*"
+        + command_pattern
+        + r"[^}]*\}"
+    )
+    inline_pattern = (
+        r"\$ErrorActionPreference\s*=\s*\"Continue\"[\s\S]{0,900}?"
+        + command_pattern
+    )
+    assert re.search(helper_block_pattern, text) or re.search(inline_pattern, text), (
+        f"install.ps1 must relax ErrorActionPreference around {command_pattern}"
+    )
+
+
+def test_repository_stage_relieves_eap_for_ssh_and_https_git_clone() -> None:
+    text = _install_ps1()
+    assert "function Invoke-NativeWithRelaxedErrorAction" in text
+    _assert_relaxed_call(
+        text,
+        r"git -c windows\.appendAtomically=false clone --depth 1 --branch \$Branch \$RepoUrlSsh \$InstallDir",
+    )
+    _assert_relaxed_call(
+        text,
+        r"git -c windows\.appendAtomically=false clone --depth 1 --branch \$Branch \$RepoUrlHttps \$InstallDir",
+    )
+
+
+def test_uv_venv_and_dependency_installs_relax_eap() -> None:
+    text = _install_ps1()
+    _assert_relaxed_call(text, r"& \$UvCmd venv venv --python \$PythonVersion")
+    _assert_relaxed_call(text, r"& \$UvCmd sync --extra all --locked")
+    _assert_relaxed_call(text, r"& \$UvCmd pip install -e \$tier\.Spec")
+
+
+def test_native_eap_helper_always_restores_previous_preference() -> None:
+    text = _install_ps1()
+    m = re.search(
+        r"function Invoke-NativeWithRelaxedErrorAction \{(?P<body>[\s\S]*?)^\}",
+        text,
+        re.MULTILINE,
+    )
+    assert m is not None, "expected a shared helper for NativeCommandError-safe calls"
+    body = m.group("body")
+    assert "$prevEAP = $ErrorActionPreference" in body
+    assert '$ErrorActionPreference = "Continue"' in body
+    assert "finally" in body
+    assert "$ErrorActionPreference = $prevEAP" in body


### PR DESCRIPTION
## Summary

User-requested review of #48463 surfaced three open PRs all fixing the same issue (#48352): under Windows PowerShell 5.1 with global `$ErrorActionPreference = "Stop"`, native commands (`git`, `uv`) that write normal progress to **stderr** get wrapped as a terminating `NativeCommandError`, so a *successful* command aborts the install (or falls through to a degraded path). The three PRs are duplicates of each other, not complementary — so this is a pick-the-best + compose-the-gap salvage, not a multi-PR batch.

**This PR salvages #48372 (@Tranquil-Flow) as the base** — it factors a reusable `Invoke-NativeWithRelaxedErrorAction` helper (one place to maintain the EAP dance vs. inlining it at 5 sites) and ships a regression test — **and composes in the one guard it was missing**, which #48463 (@devorun) had: an explicit `uv venv` exit-code check.

## What's included

- **#48372 (@Tranquil-Flow), cherry-picked with authorship preserved** — adds `Invoke-NativeWithRelaxedErrorAction` and wraps all 5 call sites from the issue: `git clone` (SSH + HTTPS), `uv venv`, `uv sync --extra all --locked`, and the `uv pip install -e` tier loop. Each remains gated on `$LASTEXITCODE`.
- **Follow-up commit (mine) — fail fast on genuine `uv venv` failure.** Relaxing EAP around `uv venv` means a *real* non-zero exit no longer aborts on its own: `Install-Venv` would continue, print "Virtual environment ready", and in stage mode `Invoke-Stage` would report `ok=true` even though no venv was created. This captures `$LASTEXITCODE` immediately after the relaxed call and throws (`Pop-Location` first, matching the function's other exit paths). This is the explicit guard @devorun proposed in #48463, composed on top of #48372's helper. Adds a regression test for the capture+throw.

## Why this composition

- `$LASTEXITCODE` is an automatic variable set by the native command and is not function-scoped, so it remains the real exit code after the helper returns and restores EAP — verified against PowerShell semantics and confirmed by adversarial review.
- The helper's `try/finally` restores EAP on both the success and the terminating-error path.
- On the success path (exit 0), behavior is unchanged; in a plain ConsoleHost (where native stderr goes to the console, not `ErrorRecord`s), behavior is also unchanged.

## Supersedes / closes

- **#48372 (@Tranquil-Flow)** — salvaged here as the base, authorship preserved.
- **#48463 (@devorun)** — duplicate mechanism; its unique contribution (the `uv venv` failure guard) is composed in here.
- **#45299 (@lmanchu)** — same intent (`uv venv` guard) but the branch is thousands of commits behind `main` and only covers that one site; fully subsumed.

## Test plan

- `scripts/run_tests.sh tests/test_install_ps1_native_stderr_eap.py` — 4 passed (3 from #48372 + the new uv-venv-failure guard test).
- install.ps1 brace balance + Push/Pop-Location balance verified. (No Linux CI runner executes the .ps1; tests are source-level guards.)
