### PR TITLE
fix: honor platform toolsets and ignore archived sessions in search

### DIFF
--- a/hermes_cli/prompt_size.py
+++ b/hermes_cli/prompt_size.py
@@ -29,15 +29,20 @@ def _build_inspection_agent(platform: str) -> Any:
     """Construct an offline AIAgent for prompt inspection.
 
     Dummy ``api_key`` + ``base_url`` force the direct-construction path in
-    ``run_agent.py`` (no provider auto-detection, no network). Toolsets and
-    platform come from the caller so the breakdown matches a real session.
+    ``run_agent.py`` (no provider auto-detection, no network).  Resolve the
+    platform's configured toolsets the same way normal CLI/gateway startup
+    does; otherwise ``AIAgent`` receives ``enabled_toolsets=None`` and
+    ``get_tool_definitions`` falls back to every available toolset, overstating
+    tool-schema size for narrowed profiles.
     """
     from run_agent import AIAgent
     from hermes_cli.config import load_config
+    from hermes_cli.tools_config import _get_platform_tools
 
     cfg = load_config()
     model_cfg = cfg.get("model", {}) if isinstance(cfg.get("model"), dict) else {}
     model = model_cfg.get("default") or model_cfg.get("model") or ""
+    enabled_toolsets = sorted(_get_platform_tools(cfg, platform))
 
     return AIAgent(
         model=model,
@@ -46,6 +51,7 @@ def _build_inspection_agent(platform: str) -> Any:
         quiet_mode=True,
         save_trajectories=False,
         platform=platform,
+        enabled_toolsets=enabled_toolsets,
     )
 
 

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -3262,6 +3262,7 @@ class SessionDB:
         offset: int = 0,
         sort: str = None,
         include_inactive: bool = False,
+        include_archived: bool = False,
     ) -> List[Dict[str, Any]]:
         """
         Full-text search across session messages using FTS5.
@@ -3286,6 +3287,12 @@ class SessionDB:
 
         Rewound (``active=0``) rows are excluded by default. Pass
         ``include_inactive=True`` to search every row.
+
+        Soft-archived sessions are excluded by default so session_search can be
+        used as a context-governance control: archived historical project
+        sessions remain recoverable by direct id/listing, but no longer poison
+        broad full-text discovery. Pass ``include_archived=True`` for admin or
+        forensic searches.
         """
         if not self._fts_enabled:
             return []
@@ -3321,6 +3328,8 @@ class SessionDB:
         params: list = [query]
         if not include_inactive:
             where_clauses.append("m.active = 1")
+        if not include_archived:
+            where_clauses.append("s.archived = 0")
 
         if source_filter is not None:
             source_placeholders = ",".join("?" for _ in source_filter)
@@ -3402,6 +3411,8 @@ class SessionDB:
                 tri_params: list = [trigram_query]
                 if not include_inactive:
                     tri_where.append("m.active = 1")
+                if not include_archived:
+                    tri_where.append("s.archived = 0")
                 if source_filter is not None:
                     tri_where.append(f"s.source IN ({','.join('?' for _ in source_filter)})")
                     tri_params.extend(source_filter)
@@ -3457,6 +3468,10 @@ class SessionDB:
                     )
                     like_params += [f"%{esc}%", f"%{esc}%", f"%{esc}%"]
                 like_where = [f"({' OR '.join(token_clauses)})"]
+                if not include_inactive:
+                    like_where.append("m.active = 1")
+                if not include_archived:
+                    like_where.append("s.archived = 0")
                 if source_filter is not None:
                     like_where.append(f"s.source IN ({','.join('?' for _ in source_filter)})")
                     like_params.extend(source_filter)

--- a/tests/hermes_cli/test_prompt_size.py
+++ b/tests/hermes_cli/test_prompt_size.py
@@ -116,3 +116,16 @@ def test_json_serializable(isolated_home):
     data = compute_prompt_breakdown("cli")
     # Round-trips cleanly for ``--json`` output.
     assert json.loads(json.dumps(data)) == json.loads(json.dumps(data))
+
+
+def test_prompt_size_respects_platform_toolsets(isolated_home):
+    """Narrow platform toolsets should reduce the inspected tool schema."""
+    import yaml
+
+    (isolated_home / "config.yaml").write_text(
+        yaml.safe_dump({"platform_toolsets": {"cli": ["skills", "todo"]}}),
+        encoding="utf-8",
+    )
+
+    data = compute_prompt_breakdown("cli")
+    assert data["tools"]["count"] == 4

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -856,6 +856,19 @@ class TestFTS5Search:
         found_sources = {r["source"] for r in results}
         assert found_sources == {"cli", "telegram", "signal", "homeassistant", "acp", "matrix"}
 
+    def test_search_excludes_archived_sessions_by_default(self, db):
+        db.create_session(session_id="active", source="cli")
+        db.append_message("active", role="user", content="needle active")
+        db.create_session(session_id="archived", source="cli")
+        db.append_message("archived", role="user", content="needle archived")
+        db.set_session_archived("archived", True)
+
+        default_results = db.search_messages("needle")
+        assert {r["session_id"] for r in default_results} == {"active"}
+
+        all_results = db.search_messages("needle", include_archived=True)
+        assert {r["session_id"] for r in all_results} == {"active", "archived"}
+
     def test_search_with_role_filter(self, db):
         db.create_session(session_id="s1", source="cli")
         db.append_message("s1", role="user", content="What is FastAPI?")


### PR DESCRIPTION
## Summary

This PR fixes two context-governance issues found while reducing profile prompt footprint and historical session retrieval contamination.

### 1. `hermes prompt-size` ignores configured platform toolsets

`hermes_cli/prompt_size.py::_build_inspection_agent()` constructs an offline `AIAgent` without passing `enabled_toolsets`.

As a result, `get_tool_definitions(enabled_toolsets=None)` falls back to all available toolsets, so `hermes prompt-size --platform cli --json` overstates `tools.count` and `tools.json_bytes` for profiles that correctly configure `platform_toolsets`.

Fix:
- Resolve platform toolsets with `_get_platform_tools(cfg, platform)`.
- Pass `enabled_toolsets=enabled_toolsets` into `AIAgent`.

Validation:
- Added regression coverage showing a profile with `platform_toolsets.cli=[skills,todo]` reports the narrowed tool schema.

### 2. `session_search` returns archived sessions

Soft-archived sessions (`sessions.archived=1`) are still returned by `SessionDB.search_messages()` because the search paths do not filter `s.archived=0`.

This weakens archive-based session governance: old sessions remain discoverable through broad full-text retrieval and can poison context.

Fix:
- Add `include_archived: bool = False` to `SessionDB.search_messages()`.
- Apply `s.archived=0` filter in FTS5, trigram, and LIKE fallback paths.
- Keep admin/forensic access possible via `include_archived=True`.

Validation:
- Added regression coverage proving archived sessions are hidden by default and returned with `include_archived=True`.
- Runtime isolated `SessionDB` verification passes.

## Local validation

- `py_compile` passed for changed files.
- Runtime `SessionDB.search_messages()` archive behavior verified.
- Full pytest was not available in the local installed venv because pytest is not installed.
