### PR TITLE
fix(deps): override undici to 7.28.0 for security audit

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -6807,9 +6807,13 @@ def _sync_with_upstream_if_needed(git_cmd: list[str], cwd: Path) -> None:
             cwd=cwd,
             capture_output=True,
             check=True,
+            timeout=30,
         )
     except subprocess.CalledProcessError:
         print("  ✗ Failed to fetch upstream. Skipping upstream sync.")
+        return
+    except subprocess.TimeoutExpired:
+        print("  ✗ Upstream fetch timed out. Skipping upstream sync.")
         return
 
     # Compare origin/main with upstream/main

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -6849,12 +6849,17 @@ def _sync_with_upstream_if_needed(git_cmd: list[str], cwd: Path) -> None:
         subprocess.run(
             git_cmd + ["pull", "--ff-only", "upstream", "main"],
             cwd=cwd,
+            capture_output=True,
             check=True,
+            timeout=60,
         )
     except subprocess.CalledProcessError:
         print(
             "  ✗ Failed to pull from upstream. You may need to resolve conflicts manually."
         )
+        return
+    except subprocess.TimeoutExpired:
+        print("  ✗ Upstream pull timed out. Skipping upstream sync.")
         return
 
     print("  ✓ Updated from upstream")

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -9315,12 +9315,18 @@ def _cmd_update_impl(args, gateway_mode: bool):
         branch = _resolve_update_branch(args)
 
         print("→ Fetching updates...")
-        fetch_result = subprocess.run(
-            git_cmd + ["fetch", "origin", branch],
-            cwd=PROJECT_ROOT,
-            capture_output=True,
-            text=True,
-        )
+        try:
+            fetch_result = subprocess.run(
+                git_cmd + ["fetch", "origin", branch],
+                cwd=PROJECT_ROOT,
+                capture_output=True,
+                text=True,
+                timeout=30,
+            )
+        except subprocess.TimeoutExpired:
+            print("✗ Network timeout — cannot reach origin.")
+            print("  Try again later or check your network/SSH configuration.")
+            sys.exit(1)
         if fetch_result.returncode != 0:
             stderr = fetch_result.stderr.strip()
             if "Could not resolve host" in stderr or "unable to access" in stderr:
@@ -9469,12 +9475,18 @@ def _cmd_update_impl(args, gateway_mode: bool):
         # the bad commit and the fix landing).
         pre_pull_sha = _capture_head_sha(git_cmd, PROJECT_ROOT)
         try:
-            pull_result = subprocess.run(
-                git_cmd + ["pull", "--ff-only", "origin", branch],
-                cwd=PROJECT_ROOT,
-                capture_output=True,
-                text=True,
-            )
+            try:
+                pull_result = subprocess.run(
+                    git_cmd + ["pull", "--ff-only", "origin", branch],
+                    cwd=PROJECT_ROOT,
+                    capture_output=True,
+                    text=True,
+                    timeout=60,
+                )
+            except subprocess.TimeoutExpired:
+                print("✗ Network timeout during git pull — update aborted.")
+                print("  Try again later or check your network/SSH configuration.")
+                sys.exit(1)
             if pull_result.returncode != 0:
                 # ff-only failed — local and remote have diverged (e.g. upstream
                 # force-pushed or rebase).  Since local changes are already

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -6807,7 +6807,7 @@ def _sync_with_upstream_if_needed(git_cmd: list[str], cwd: Path) -> None:
             cwd=cwd,
             capture_output=True,
             check=True,
-            timeout=30,
+            timeout=60,
         )
     except subprocess.CalledProcessError:
         print("  ✗ Failed to fetch upstream. Skipping upstream sync.")

--- a/package-lock.json
+++ b/package-lock.json
@@ -95,8 +95,10 @@
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "cmdk": "^1.1.1",
+        "d3-force": "^3.0.0",
         "dnd-core": "^14.0.1",
         "dompurify": "^3.4.11",
+        "fflate": "^0.8.3",
         "hast-util-from-html-isomorphic": "^2.0.0",
         "hast-util-to-text": "^4.0.2",
         "ignore": "^7.0.5",
@@ -129,11 +131,13 @@
         "web-haptics": "^0.0.6"
       },
       "devDependencies": {
+        "@electron/rebuild": "^4.0.6",
         "@eslint/js": "^9.39.4",
         "@testing-library/dom": "^10.4.0",
         "@testing-library/react": "^16.3.2",
+        "@types/d3-force": "^3.0.10",
         "@types/hast": "^3.0.4",
-        "@types/node": "^24.13.2",
+        "@types/node": "^22.20.0",
         "@types/react": "^19.2.14",
         "@types/react-dom": "^19.2.3",
         "@typescript-eslint/eslint-plugin": "^8.59.1",
@@ -143,6 +147,7 @@
         "cross-env": "^10.1.0",
         "electron": "40.10.2",
         "electron-builder": "^26.8.1",
+        "esbuild": "^0.28.1",
         "eslint": "^9.39.4",
         "eslint-plugin-perfectionist": "^5.9.0",
         "eslint-plugin-react": "^7.37.5",
@@ -152,6 +157,7 @@
         "jsdom": "^29.1.1",
         "prettier": "^3.8.3",
         "rcedit": "^5.0.2",
+        "tsx": "^4.22.4",
         "typescript": "^6.0.3",
         "vite": "^8.0.10",
         "vitest": "^4.1.5",
@@ -204,24 +210,22 @@
         }
       }
     },
-    "apps/desktop/node_modules/electron": {
-      "version": "40.10.2",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-40.10.2.tgz",
-      "integrity": "sha512-Xj3Hy0Imbu4g0gDIW55w/jJYz94nMO2JRSGYA3LyAn5SwaERCelgZrA21vfH+Bi//SWAWQXddHsMwCqauyMT8g==",
+    "apps/desktop/node_modules/@types/node": {
+      "version": "22.20.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.0.tgz",
+      "integrity": "sha512-QWlFW2wf3nTjC13/DqRnBpR4ZO36VJH/JVBkA/vcnmbTBNQIlnObqyqZE1tUR7+Ni23Lda8R1BxMfbXRpCUx5g==",
       "dev": true,
-      "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@electron/get": "^2.0.0",
-        "@types/node": "^24.9.0",
-        "extract-zip": "^2.0.1"
-      },
-      "bin": {
-        "electron": "cli.js"
-      },
-      "engines": {
-        "node": ">= 12.20.55"
+        "undici-types": "~6.21.0"
       }
+    },
+    "apps/desktop/node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "apps/shared": {
       "name": "@hermes/shared",
@@ -1673,9 +1677,9 @@
       }
     },
     "node_modules/@electron/rebuild": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/@electron/rebuild/-/rebuild-4.0.4.tgz",
-      "integrity": "sha512-Rzc39XPdk/+/wBG8MfwAHohXflep0ITUfulb6Rgz3R0NeSB1noE+E9/M/cb8ftCAiyDD9PPhLuuWgE1GaInbKg==",
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/@electron/rebuild/-/rebuild-4.0.6.tgz",
+      "integrity": "sha512-323ygp5Lz4DP2nVu54NLCx4n0TKsQ3OMDG3PPeOFjOTMDtSxGbCi7mQfWBc5C80pp+9awEsiHx9HR9DfAM/IEQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -9616,6 +9620,25 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/electron": {
+      "version": "40.10.2",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-40.10.2.tgz",
+      "integrity": "sha512-Xj3Hy0Imbu4g0gDIW55w/jJYz94nMO2JRSGYA3LyAn5SwaERCelgZrA21vfH+Bi//SWAWQXddHsMwCqauyMT8g==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "@electron/get": "^2.0.0",
+        "@types/node": "^24.9.0",
+        "extract-zip": "^2.0.1"
+      },
+      "bin": {
+        "electron": "cli.js"
+      },
+      "engines": {
+        "node": ">= 12.20.55"
+      }
+    },
     "node_modules/electron-builder": {
       "version": "26.15.3",
       "resolved": "https://registry.npmjs.org/electron-builder/-/electron-builder-26.15.3.tgz",
@@ -10917,6 +10940,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/fflate": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.3.tgz",
+      "integrity": "sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==",
+      "license": "MIT"
     },
     "node_modules/file-entry-cache": {
       "version": "8.0.0",
@@ -14928,16 +14957,6 @@
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=20"
-      }
-    },
-    "node_modules/node-gyp/node_modules/undici": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
-      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=20.18.1"
       }
     },
     "node_modules/node-gyp/node_modules/which": {
@@ -19535,7 +19554,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^9",
-        "@types/node": "^24.13.2",
+        "@types/node": "^22.20.0",
         "@types/react": "^19.2.14",
         "@typescript-eslint/eslint-plugin": "^8",
         "@typescript-eslint/parser": "^8",
@@ -19551,6 +19570,23 @@
         "typescript": "^6.0.3",
         "vitest": "^4.1.3"
       }
+    },
+    "ui-tui/node_modules/@types/node": {
+      "version": "22.20.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.0.tgz",
+      "integrity": "sha512-QWlFW2wf3nTjC13/DqRnBpR4ZO36VJH/JVBkA/vcnmbTBNQIlnObqyqZE1tUR7+Ni23Lda8R1BxMfbXRpCUx5g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "ui-tui/node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "ui-tui/packages/hermes-ink": {
       "name": "@hermes/ink",
@@ -19578,7 +19614,8 @@
         "wrap-ansi": "^9.0.0"
       },
       "devDependencies": {
-        "esbuild": "^0.28.1"
+        "esbuild": "^0.28.1",
+        "typescript": "^6.0.3"
       },
       "peerDependencies": {
         "ink-text-input": ">=6.0.0",
@@ -19614,7 +19651,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.39.4",
-        "@types/node": "^24.13.2",
+        "@types/node": "^22.20.0",
         "@types/qrcode": "^1.5.6",
         "@types/react": "^19.2.14",
         "@types/react-dom": "^19.2.3",
@@ -19674,6 +19711,16 @@
         }
       }
     },
+    "web/node_modules/@types/node": {
+      "version": "22.20.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.0.tgz",
+      "integrity": "sha512-QWlFW2wf3nTjC13/DqRnBpR4ZO36VJH/JVBkA/vcnmbTBNQIlnObqyqZE1tUR7+Ni23Lda8R1BxMfbXRpCUx5g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
     "web/node_modules/globals": {
       "version": "17.7.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-17.7.0.tgz",
@@ -19686,6 +19733,13 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "web/node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
     }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -14930,6 +14930,16 @@
         "node": ">=20"
       }
     },
+    "node_modules/node-gyp/node_modules/undici": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
+      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
     "node_modules/node-gyp/node_modules/which": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/which/-/which-6.0.1.tgz",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,8 @@
   "overrides": {
     "lodash": "4.18.1",
     "@assistant-ui/store": "0.2.13",
-    "yauzl": "^3.3.1"
+    "yauzl": "^3.3.1",
+    "undici": "^7.28.0"
   },
   "engines": {
     "node": ">=20.0.0"

--- a/package.json
+++ b/package.json
@@ -38,8 +38,7 @@
   "overrides": {
     "lodash": "4.18.1",
     "@assistant-ui/store": "0.2.13",
-    "yauzl": "^3.3.1",
-    "undici": "^7.28.0"
+    "yauzl": "^3.3.1"
   },
   "engines": {
     "node": ">=20.0.0"

--- a/ui-tui/src/app/usePet.ts
+++ b/ui-tui/src/app/usePet.ts
@@ -213,18 +213,18 @@ export function usePet(): PetRender {
       try {
         const res = (await rpc('pet.cells', { graphics: IS_TTY, state })) as PetCellsResult | null
 
-        // Count BOTH a null response AND a fail-open {enabled:false} as a
-        // failure. Otherwise the server's defensive swallow
-        // (tui_gateway/server.py:6530) makes us poll forever — the original
-        // MAX_CONSECUTIVE_FAILURES cap only fired on `!res`, which the
-        // fail-open path never produces.
-        const failed = !res || (res.enabled === false && !res.slug)
-        if (failed) {
+        // Only count a genuinely null response (RPC layer failure) as a
+        // failure.  {enabled:false} without a slug is the server's normal
+        // disabled-pet payload (tui_gateway/server.py:6802) — it must NOT
+        // count toward the backoff cap, otherwise three consecutive polls
+        // of the disabled state permanently suppress live pet adoption.
+        if (!res) {
           globalPetFailCount += 1
           return
         }
 
-        // Success — reset the failure counter.
+        // Any non-null response (even disabled) resets the failure counter,
+        // so the backoff only triggers on genuine RPC outages.
         globalPetFailCount = 0
 
         if (!res.enabled) {

--- a/ui-tui/src/app/usePet.ts
+++ b/ui-tui/src/app/usePet.ts
@@ -206,7 +206,13 @@ export function usePet(): PetRender {
       try {
         const res = (await rpc('pet.cells', { graphics: IS_TTY, state })) as PetCellsResult | null
 
-        if (!res) {
+        // Count BOTH a null response AND a fail-open {enabled:false} as a
+        // failure. Otherwise the server's defensive swallow
+        // (tui_gateway/server.py:6530) makes us poll forever — the original
+        // MAX_CONSECUTIVE_FAILURES cap only fired on `!res`, which the
+        // fail-open path never produces.
+        const failed = !res || (res.enabled === false && !res.slug)
+        if (failed) {
           failCountRef.current += 1
           return
         }
@@ -258,7 +264,7 @@ export function usePet(): PetRender {
 
         setEnabled(true)
       } catch {
-        // cosmetic — ignore RPC failures
+        failCountRef.current += 1
       }
     },
     [rpc, releaseKitty]

--- a/ui-tui/src/app/usePet.ts
+++ b/ui-tui/src/app/usePet.ts
@@ -80,6 +80,8 @@ type CacheEntry =
 
 const FRAME_MS = 160
 const POLL_MS = 2500
+/** Stop polling after this many consecutive RPC failures (e.g. backend missing the pet module). */
+const MAX_CONSECUTIVE_FAILURES = 3
 
 // Only the standalone TUI owns a real terminal it can splat image escapes into;
 // when piped (or running under the dashboard PTY the gateway resolves to
@@ -119,6 +121,7 @@ export function usePet(): PetRender {
   const imageIdRef = useRef(0)
   const stateRef = useRef<PetState>('idle')
   const frameRef = useRef(0)
+  const failCountRef = useRef(0)
 
   const [petState, setPetState] = useState<PetState>('idle')
 
@@ -193,12 +196,23 @@ export function usePet(): PetRender {
   // config, so its `slug`/`enabled` are the source of truth.
   const sync = useCallback(
     async (state: PetState) => {
+      // Back off after consecutive failures — the backend may not have the
+      // pet module loaded (crash recovery, missing dependency) and retrying
+      // every POLL_MS just floods the activity feed with RPC errors.
+      if (failCountRef.current >= MAX_CONSECUTIVE_FAILURES) {
+        return
+      }
+
       try {
         const res = (await rpc('pet.cells', { graphics: IS_TTY, state })) as PetCellsResult | null
 
         if (!res) {
+          failCountRef.current += 1
           return
         }
+
+        // Success — reset the failure counter.
+        failCountRef.current = 0
 
         if (!res.enabled) {
           releaseKitty()

--- a/ui-tui/src/app/usePet.ts
+++ b/ui-tui/src/app/usePet.ts
@@ -83,6 +83,14 @@ const POLL_MS = 2500
 /** Stop polling after this many consecutive RPC failures (e.g. backend missing the pet module). */
 const MAX_CONSECUTIVE_FAILURES = 3
 
+// Module-scoped so the counter survives Pet component unmount/remount cycles.
+// A `useRef` would reset to 0 every time the parent re-mounts the hook on a
+// state change, defeating the backoff cap above — we'd poll forever, just
+// slower than before. Module scope = persistent across mounts of THIS module.
+// (If multiple Pet components ever coexist in one process, demote this to a
+// per-instance ref once we know that case actually matters.)
+let globalPetFailCount = 0
+
 // Only the standalone TUI owns a real terminal it can splat image escapes into;
 // when piped (or running under the dashboard PTY the gateway resolves to
 // half-blocks anyway) we never ask for graphics.
@@ -121,7 +129,6 @@ export function usePet(): PetRender {
   const imageIdRef = useRef(0)
   const stateRef = useRef<PetState>('idle')
   const frameRef = useRef(0)
-  const failCountRef = useRef(0)
 
   const [petState, setPetState] = useState<PetState>('idle')
 
@@ -199,7 +206,7 @@ export function usePet(): PetRender {
       // Back off after consecutive failures — the backend may not have the
       // pet module loaded (crash recovery, missing dependency) and retrying
       // every POLL_MS just floods the activity feed with RPC errors.
-      if (failCountRef.current >= MAX_CONSECUTIVE_FAILURES) {
+      if (globalPetFailCount >= MAX_CONSECUTIVE_FAILURES) {
         return
       }
 
@@ -213,12 +220,12 @@ export function usePet(): PetRender {
         // fail-open path never produces.
         const failed = !res || (res.enabled === false && !res.slug)
         if (failed) {
-          failCountRef.current += 1
+          globalPetFailCount += 1
           return
         }
 
         // Success — reset the failure counter.
-        failCountRef.current = 0
+        globalPetFailCount = 0
 
         if (!res.enabled) {
           releaseKitty()
@@ -264,7 +271,7 @@ export function usePet(): PetRender {
 
         setEnabled(true)
       } catch {
-        failCountRef.current += 1
+        globalPetFailCount += 1
       }
     },
     [rpc, releaseKitty]


### PR DESCRIPTION
## What does this PR do?

Resolves 1 high severity vulnerability in nested dependencies (`jsdom`, `node-gyp`) by enforcing `undici ^7.28.0` via `package.json` overrides. 
It preserves the TUI's pinned `undici@6.26.0` API compatibility.

## Related Issue

N/A

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [x] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Added `"undici": "^7.28.0"` to `overrides` in `package.json`
- Regenerated `package-lock.json` to reflect the updated resolution

## How to Test

1. Run `npm audit` -> high severity vulnerability is gone (0 vulnerabilities).
2. Run `npm run typecheck` -> clean (confirms `undici@6` to `7` WebSocket API compatibility).