### PR TITLE
feat(providers): add TokenRouter as a built-in provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -23,6 +23,15 @@
 # NOVITA_BASE_URL=https://api.novita.ai/openai/v1  # Override default base URL
 
 # =============================================================================
+# LLM PROVIDER (TokenRouter)
+# =============================================================================
+# TokenRouter — OpenAI-compatible router for models from Anthropic, OpenAI,
+# DeepSeek, Qwen, Moonshot, Z.AI, xAI, MiniMax and others, pay-per-use
+# Get your key at: https://tokenrouter.com
+# TOKENROUTER_API_KEY=
+# TOKENROUTER_BASE_URL=https://api.tokenrouter.com/v1  # Override default base URL
+
+# =============================================================================
 # LLM PROVIDER (Google AI Studio / Gemini)
 # =============================================================================
 # Native Gemini API via Google's OpenAI-compatible endpoint.

--- a/hermes_cli/providers.py
+++ b/hermes_cli/providers.py
@@ -54,6 +54,13 @@ HERMES_OVERLAYS: Dict[str, HermesOverlay] = {
         is_aggregator=True,
         base_url_env_var="OPENROUTER_BASE_URL",
     ),
+    "tokenrouter": HermesOverlay(
+        transport="openai_chat",
+        is_aggregator=True,
+        extra_env_vars=("TOKENROUTER_API_KEY",),
+        base_url_override="https://api.tokenrouter.com/v1",
+        base_url_env_var="TOKENROUTER_BASE_URL",
+    ),
     "nous": HermesOverlay(
         transport="openai_chat",
         auth_type="oauth_device_code",
@@ -241,6 +248,9 @@ ALIASES: Dict[str, str] = {
     # openrouter
     "openai": "openrouter",     # bare "openai" → route through aggregator
 
+    # tokenrouter
+    "token-router": "tokenrouter",
+
     # zai
     "glm": "zai",
     "z-ai": "zai",
@@ -367,6 +377,7 @@ _LABEL_OVERRIDES: Dict[str, str] = {
     "stepfun": "StepFun Step Plan",
     "xiaomi": "Xiaomi MiMo",
     "gmi": "GMI Cloud",
+    "tokenrouter": "TokenRouter",
     "tencent-tokenhub": "Tencent TokenHub",
     "lmstudio": "LM Studio",
     "local": "Local endpoint",

--- a/plugins/model-providers/tokenrouter/__init__.py
+++ b/plugins/model-providers/tokenrouter/__init__.py
@@ -1,0 +1,42 @@
+"""TokenRouter provider profile.
+
+TokenRouter (https://tokenrouter.com) is an OpenAI-compatible multi-model
+router: one API key and base URL front models from Anthropic, OpenAI, DeepSeek,
+Qwen, Moonshot, Z.AI, xAI, MiniMax and others. It speaks standard
+chat-completions with no provider-specific request quirks, so the base
+``ProviderProfile`` handles everything — no subclass needed.
+
+The live model catalog is fetched from ``/v1/models`` via the default
+``ProviderProfile.fetch_models`` (Bearer auth). ``fallback_models`` below is a
+small curated set of tool-calling text models shown in the ``/model`` picker
+only when that live fetch fails; image / video / audio models are omitted.
+
+``TOKENROUTER_BASE_URL`` is listed in ``env_vars`` so the auth registry derives
+a base-URL override env var (see ``hermes_cli/auth.py`` auto-extend), letting a
+user point at a self-hosted / regional gateway without code changes.
+"""
+
+from providers import register_provider
+from providers.base import ProviderProfile
+
+tokenrouter = ProviderProfile(
+    name="tokenrouter",
+    aliases=("token-router",),
+    env_vars=("TOKENROUTER_API_KEY", "TOKENROUTER_BASE_URL"),
+    display_name="TokenRouter",
+    description="TokenRouter — OpenAI-compatible multi-model router",
+    signup_url="https://tokenrouter.com",
+    base_url="https://api.tokenrouter.com/v1",
+    fallback_models=(
+        "anthropic/claude-opus-4.8",
+        "anthropic/claude-sonnet-4.6",
+        "openai/gpt-5.5",
+        "deepseek/deepseek-v4-pro",
+        "moonshotai/kimi-k2.7-code",
+        "qwen/qwen3.7-max",
+        "z-ai/glm-5",
+        "MiniMax-M3",
+    ),
+)
+
+register_provider(tokenrouter)

--- a/plugins/model-providers/tokenrouter/plugin.yaml
+++ b/plugins/model-providers/tokenrouter/plugin.yaml
@@ -1,0 +1,5 @@
+name: tokenrouter-provider
+kind: model-provider
+version: 1.0.0
+description: TokenRouter aggregator
+author: Nous Research

--- a/tests/providers/test_tokenrouter_provider.py
+++ b/tests/providers/test_tokenrouter_provider.py
@@ -1,0 +1,66 @@
+"""TokenRouter built-in provider wiring.
+
+TokenRouter ships as a fast-path API-key provider plugin
+(``plugins/model-providers/tokenrouter/``). Adding only that plugin must wire
+the provider end-to-end via the auto-extend hooks, with no edits to the picker
+or auth registry. These tests pin that contract so a future refactor of the
+auto-extend paths can't silently drop the provider.
+"""
+
+from __future__ import annotations
+
+
+def test_profile_registered_with_expected_identity():
+    from providers import get_provider_profile
+
+    prof = get_provider_profile("tokenrouter")
+    assert prof is not None, "tokenrouter profile not discovered"
+    assert prof.name == "tokenrouter"
+    assert prof.base_url == "https://api.tokenrouter.com/v1"
+    assert prof.display_name == "TokenRouter"
+    assert prof.signup_url == "https://tokenrouter.com"
+    assert "TOKENROUTER_API_KEY" in prof.env_vars
+    # A base-URL override env var must be declared so auth can derive it.
+    assert "TOKENROUTER_BASE_URL" in prof.env_vars
+    # Curated fallback list is non-empty and namespaced like the live catalog.
+    assert prof.fallback_models, "expected a curated fallback model list"
+
+
+def test_alias_resolves():
+    from providers import get_provider_profile
+
+    assert get_provider_profile("token-router") is get_provider_profile("tokenrouter")
+
+
+def test_appears_in_model_picker():
+    """models.py auto-extends CANONICAL_PROVIDERS from the plugin registry."""
+    from hermes_cli.models import _PROVIDER_LABELS
+
+    assert _PROVIDER_LABELS.get("tokenrouter") == "TokenRouter"
+
+
+def test_auth_registry_autowired():
+    """auth.py auto-extends PROVIDER_REGISTRY; base-URL var derived from env_vars."""
+    from hermes_cli.auth import PROVIDER_REGISTRY
+
+    assert "tokenrouter" in PROVIDER_REGISTRY
+    cfg = PROVIDER_REGISTRY["tokenrouter"]
+    assert cfg.auth_type == "api_key"
+    assert cfg.inference_base_url == "https://api.tokenrouter.com/v1"
+    assert cfg.api_key_env_vars == ("TOKENROUTER_API_KEY",)
+    # The *_BASE_URL var is split out as the override, not treated as a key.
+    assert cfg.base_url_env_var == "TOKENROUTER_BASE_URL"
+
+
+def test_provider_identity_overlay():
+    """hermes_cli/providers.py marks it an OpenAI-compatible aggregator."""
+    from hermes_cli.providers import get_provider, is_aggregator, determine_api_mode
+
+    pdef = get_provider("tokenrouter")
+    assert pdef is not None
+    assert pdef.name == "TokenRouter"
+    assert pdef.base_url == "https://api.tokenrouter.com/v1"
+    assert pdef.is_aggregator is True
+    assert is_aggregator("tokenrouter") is True
+    assert is_aggregator("token-router") is True
+    assert determine_api_mode("tokenrouter") == "chat_completions"

--- a/website/docs/integrations/providers.md
+++ b/website/docs/integrations/providers.md
@@ -21,6 +21,7 @@ You need at least one way to connect to an LLM. Use `hermes model` to switch pro
 | **Anthropic** | `hermes model` (Claude Max + extra usage credits via OAuth; also supports Anthropic API key or manual setup-token — see note below) |
 | **OpenRouter** | `OPENROUTER_API_KEY` in `~/.hermes/.env` |
 | **NovitaAI** | `NOVITA_API_KEY` in `~/.hermes/.env` (provider: `novita`, 200+ models, Model API, Agent Sandbox, GPU Cloud) |
+| **TokenRouter** | `TOKENROUTER_API_KEY` in `~/.hermes/.env` (provider: `tokenrouter`; alias: `token-router`; OpenAI-compatible multi-vendor router) |
 | **z.ai / GLM** | `GLM_API_KEY` in `~/.hermes/.env` (provider: `zai`) |
 | **Kimi / Moonshot** | `KIMI_API_KEY` in `~/.hermes/.env` (provider: `kimi-coding`) |
 | **Kimi / Moonshot (China)** | `KIMI_CN_API_KEY` in `~/.hermes/.env` (provider: `kimi-coding-cn`; aliases: `kimi-cn`, `moonshot-cn`) |
@@ -267,7 +268,7 @@ model:
   default: "zai-org/GLM-5.1-FP8"
 ```
 
-Base URLs can be overridden with `NOVITA_BASE_URL`, `GLM_BASE_URL`, `KIMI_BASE_URL`, `MINIMAX_BASE_URL`, `MINIMAX_CN_BASE_URL`, `DASHSCOPE_BASE_URL`, `XIAOMI_BASE_URL`, `GMI_BASE_URL`, or `TOKENHUB_BASE_URL` environment variables.
+Base URLs can be overridden with `NOVITA_BASE_URL`, `TOKENROUTER_BASE_URL`, `GLM_BASE_URL`, `KIMI_BASE_URL`, `MINIMAX_BASE_URL`, `MINIMAX_CN_BASE_URL`, `DASHSCOPE_BASE_URL`, `XIAOMI_BASE_URL`, `GMI_BASE_URL`, or `TOKENHUB_BASE_URL` environment variables.
 
 :::note Z.AI Endpoint Auto-Detection
 When using the Z.AI / GLM provider, Hermes automatically probes multiple endpoints (global, China, coding variants) to find one that accepts your API key. You don't need to set `GLM_BASE_URL` manually — the working endpoint is detected and cached automatically.
@@ -316,6 +317,24 @@ model:
 ```
 
 Get your API key at [novita.ai/settings/key-management](https://novita.ai/settings/key-management). The base URL can be overridden with `NOVITA_BASE_URL`.
+
+### TokenRouter
+
+[TokenRouter](https://tokenrouter.com) is an OpenAI-compatible router: one API key and base URL front models from Anthropic, OpenAI, DeepSeek, Qwen, Moonshot, Z.AI, xAI, MiniMax and others, pay-per-use.
+
+```bash
+hermes chat --provider tokenrouter --model MiniMax-M3
+# Requires: TOKENROUTER_API_KEY in ~/.hermes/.env
+```
+
+```yaml
+# config.yaml
+model:
+  provider: "tokenrouter"
+  default: "anthropic/claude-sonnet-4.6"
+```
+
+Get your API key at [tokenrouter.com](https://tokenrouter.com). Hermes auto-discovers the available models from the live `/v1/models` catalog; the base URL can be overridden with `TOKENROUTER_BASE_URL`.
 
 ### Ollama Cloud — Managed Ollama Models, OAuth + API Key
 

--- a/website/docs/reference/environment-variables.md
+++ b/website/docs/reference/environment-variables.md
@@ -78,6 +78,8 @@ Hermes reads environment variables from the process environment and, for user-ma
 | `DEEPSEEK_BASE_URL` | Custom DeepSeek API base URL |
 | `NOVITA_API_KEY` | NovitaAI API key — AI-native cloud for Model API, Agent Sandbox, and GPU Cloud ([novita.ai/settings/key-management](https://novita.ai/settings/key-management)) |
 | `NOVITA_BASE_URL` | Override NovitaAI base URL (default: `https://api.novita.ai/openai/v1`) |
+| `TOKENROUTER_API_KEY` | TokenRouter API key — OpenAI-compatible multi-vendor router ([tokenrouter.com](https://tokenrouter.com)) |
+| `TOKENROUTER_BASE_URL` | Override TokenRouter base URL (default: `https://api.tokenrouter.com/v1`) |
 | `NVIDIA_API_KEY` | NVIDIA NIM API key — Nemotron and open models ([build.nvidia.com](https://build.nvidia.com)) |
 | `NVIDIA_BASE_URL` | Override NVIDIA base URL (default: `https://integrate.api.nvidia.com/v1`; set to `http://localhost:8000/v1` for a local NIM endpoint) |
 | `STEPFUN_API_KEY` | StepFun API key — Step-series models ([platform.stepfun.com](https://platform.stepfun.com)) |


### PR DESCRIPTION
## What

Adds **TokenRouter** ([tokenrouter.com](https://tokenrouter.com)) as a built-in, first-class inference provider. TokenRouter is an OpenAI-compatible router that fronts models from Anthropic, OpenAI, DeepSeek, Qwen, Moonshot, Z.AI, xAI, MiniMax and others behind a single API key and base URL.

## How

Implemented via the **fast path** for simple API-key providers documented in `website/docs/developer-guide/adding-providers.md` — a self-registering plugin under `plugins/model-providers/tokenrouter/`. Adding only that plugin auto-wires the rest through the existing auto-extend hooks:

- model picker (`CANONICAL_PROVIDERS` in `hermes_cli/models.py`)
- credential resolution (`PROVIDER_REGISTRY` in `hermes_cli/auth.py`)
- the generic `_model_flow_api_key_provider` setup flow
- `--provider` flag and `provider:model` syntax
- runtime resolution (`resolve_runtime_provider`)

A small `HERMES_OVERLAYS` entry in `hermes_cli/providers.py` marks it as an OpenAI-compatible aggregator and declares the `TOKENROUTER_BASE_URL` override.

| | |
|---|---|
| provider id | `tokenrouter` (alias `token-router`) |
| base URL | `https://api.tokenrouter.com/v1` (override: `TOKENROUTER_BASE_URL`) |
| key env var | `TOKENROUTER_API_KEY` |
| api_mode | `chat_completions` |
| models | live `/v1/models` catalog; curated tool-calling fallback list when offline |

## Verification

- Live smoke against `https://api.tokenrouter.com/v1`: `GET /v1/models` → 200 (multi-vendor catalog); `POST /v1/chat/completions` → 200 (OpenAI chat-completions shape confirmed).
- New `tests/providers/test_tokenrouter_provider.py` pins the cross-registry wiring (profile, alias, picker, auth registry, aggregator overlay, `api_mode`).
- `resolve_runtime_provider(requested="tokenrouter")` returns the correct base URL, `api_mode=chat_completions`, and resolves the key from `TOKENROUTER_API_KEY`.
- Provider regression suite green: `tests/providers/test_plugin_discovery.py` + `tests/hermes_cli/test_api_key_providers.py` (169 passed, `-n0`). `ruff check` clean on changed Python.

## Docs

Updated `.env.example`, `website/docs/integrations/providers.md`, and `website/docs/reference/environment-variables.md`.
