### PR TITLE
fix(desktop): keep named custom provider working across new chats

### DIFF
--- a/tests/tui_gateway/test_custom_provider_session_persistence.py
+++ b/tests/tui_gateway/test_custom_provider_session_persistence.py
@@ -196,3 +196,84 @@ class TestResumeRoundTrip:
         assert kwargs["provider"] == "custom"
         assert kwargs["base_url"] == "http://127.0.0.1:8000/v1"
         assert kwargs["api_key"] == "no-key-required"
+
+
+class TestSessionInfoReportsCanonicalIdentity:
+    """session.info must report the entry identity, not the bare resolved
+    "custom".
+
+    The desktop composer's model picker is sticky session state: it persists
+    whatever ``session.info`` reports as the live provider and ships it back on
+    the next ``session.create`` as a per-session override (NO base_url — that
+    isn't part of the picker's state). Reporting the bare resolved ``"custom"``
+    for a named ``providers:`` / ``custom_providers:`` entry meant the second
+    and every later chat re-resolved a credential-less endpoint and failed with
+    "No LLM provider configured" — while the very first chat (built from config,
+    not from the round-tripped override) worked. Reporting the canonical
+    ``custom:<name>`` menu key keeps the entry resolvable across the round-trip.
+    """
+
+    def test_helper_maps_resolved_custom_to_menu_key(self, monkeypatch):
+        monkeypatch.setattr(rp, "load_config", lambda: PROVIDERS_DICT_CONFIG)
+
+        from tui_gateway.server import _canonical_provider_identity
+
+        assert _canonical_provider_identity("custom", MIMO_URL) == "custom:mimo-v2.5-pro"
+
+    def test_helper_passes_builtin_providers_through_untouched(self, monkeypatch):
+        def _boom():
+            raise AssertionError("identity lookup must not run for built-ins")
+
+        monkeypatch.setattr(rp, "load_config", _boom)
+
+        from tui_gateway.server import _canonical_provider_identity
+
+        assert (
+            _canonical_provider_identity("anthropic", "https://api.anthropic.com")
+            == "anthropic"
+        )
+
+    def test_helper_keeps_bare_custom_when_no_entry_matches(self, monkeypatch):
+        monkeypatch.setattr(rp, "load_config", lambda: {})
+
+        from tui_gateway.server import _canonical_provider_identity
+
+        assert _canonical_provider_identity("custom", MIMO_URL) == "custom"
+
+    def test_reported_identity_round_trips_to_entry_credentials(self, monkeypatch):
+        """The provider session.info reports for a named-custom agent, shipped
+        back by the composer on session.create WITHOUT a base_url, must still
+        re-resolve the entry's real credentials — the exact round-trip that
+        regressed to "No LLM provider configured"."""
+        monkeypatch.setattr(rp, "load_config", lambda: LEGACY_LIST_CONFIG)
+
+        from tui_gateway.server import _canonical_provider_identity
+
+        reported = _canonical_provider_identity("custom", MIMO_URL)
+        assert reported == "custom:mimo-v2.5-pro"
+
+        kwargs = _make_agent_with_override(
+            {"model": "mimo-v2.5-pro", "provider": reported},
+            monkeypatch,
+            LEGACY_LIST_CONFIG,
+        )
+
+        assert kwargs["provider"] == "custom"
+        assert kwargs["base_url"] == MIMO_URL
+        assert kwargs["api_key"] == MIMO_KEY
+
+    def test_bare_custom_override_without_base_url_loses_entry(self, monkeypatch):
+        """Regression guard documenting the pre-fix failure: the bare resolved
+        "custom" (no base_url) can NOT recover the entry, so it never resolves
+        the entry's key — proving the canonical identity is what fixes the
+        round-trip."""
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+
+        kwargs = _make_agent_with_override(
+            {"model": "mimo-v2.5-pro", "provider": "custom"},
+            monkeypatch,
+            LEGACY_LIST_CONFIG,
+        )
+
+        assert kwargs["api_key"] != MIMO_KEY

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -1601,6 +1601,33 @@ def _stored_session_runtime_overrides(row: dict | None) -> dict:
     return overrides
 
 
+def _canonical_provider_identity(provider: str | None, base_url: str | None) -> str:
+    """Recover a named custom provider's canonical ``custom:<name>`` menu key.
+
+    ``agent.provider`` is the RESOLVED billing class, and for any named
+    ``providers:`` / ``custom_providers:`` entry that is the literal string
+    ``"custom"`` — the entry identity (and with it key_env/api_key resolution)
+    is lost. Map the endpoint URL back to the entry's menu key so the identity
+    survives BOTH being persisted to the session DB (``_runtime_model_config``)
+    AND being reported to the desktop composer via ``session.info``, which
+    persists it and round-trips it back through ``session.create`` as a
+    per-session override. Reporting the bare ``"custom"`` there made every
+    new chat after the first re-resolve to a credential-less endpoint and fail
+    with "No LLM provider configured". Built-in providers and endpoints with no
+    matching config entry pass through unchanged.
+    """
+    provider = str(provider or "").strip()
+    base_url = str(base_url or "").strip()
+    if provider == "custom" and base_url:
+        try:
+            from hermes_cli.runtime_provider import find_custom_provider_identity
+
+            return find_custom_provider_identity(base_url) or provider
+        except Exception:
+            logger.debug("custom provider identity lookup failed", exc_info=True)
+    return provider
+
+
 def _runtime_model_config(agent, existing: dict | None = None) -> dict:
     config = dict(existing or {})
     model = str(getattr(agent, "model", "") or "").strip()
@@ -1613,26 +1640,11 @@ def _runtime_model_config(agent, existing: dict | None = None) -> dict:
     if model:
         config["model"] = model
     if provider:
-        if provider == "custom" and base_url:
-            # ``agent.provider`` is the RESOLVED provider, and for any named
-            # ``providers:`` / ``custom_providers:`` entry that is the literal
-            # string "custom" — persisting it loses the entry identity, so a
-            # later resume/rebuild cannot re-resolve the entry's credentials
-            # (the api_key is deliberately never persisted; see
-            # _stored_session_runtime_overrides). Recover the canonical
-            # ``custom:<name>`` menu key from the endpoint URL so
-            # resolve_runtime_provider() can find the entry again.
-            try:
-                from hermes_cli.runtime_provider import (
-                    find_custom_provider_identity,
-                )
-
-                provider = find_custom_provider_identity(base_url) or provider
-            except Exception:
-                logger.debug(
-                    "custom provider identity lookup failed", exc_info=True
-                )
-        config["provider"] = provider
+        # Persist the entry identity, not the resolved bare "custom" — a later
+        # resume/rebuild cannot re-resolve a named entry's credentials from
+        # "custom" alone (the api_key is deliberately never persisted; see
+        # _stored_session_runtime_overrides).
+        config["provider"] = _canonical_provider_identity(provider, base_url)
     if base_url:
         config["base_url"] = base_url
     else:
@@ -2528,7 +2540,16 @@ def _session_info(agent, session: dict | None = None) -> dict:
         yolo = False
     info: dict = {
         "model": getattr(agent, "model", ""),
-        "provider": getattr(agent, "provider", ""),
+        # Report the canonical ``custom:<name>`` identity for a named custom
+        # provider rather than the bare resolved ``"custom"``. The desktop
+        # composer persists this and ships it back on the next session.create
+        # as a per-session override; bare ``"custom"`` lost the entry identity
+        # and made every new chat after the first fail with "No LLM provider
+        # configured". Keeps the live report in sync with the value persisted
+        # by _runtime_model_config.
+        "provider": _canonical_provider_identity(
+            getattr(agent, "provider", ""), getattr(agent, "base_url", "")
+        ),
         "reasoning_effort": reasoning_effort,
         "service_tier": service_tier,
         "fast": service_tier == "priority",


### PR DESCRIPTION
## Summary

Fixes the **"No LLM provider configured"** error on Hermes Desktop when using a **named custom provider** (a `providers:` / `custom_providers:` entry, e.g. `model.provider: venice`). The first chat after launch works; every chat created after it fails. Using bare `provider: custom` + `base_url` works (config backs the resolution), which is why that workaround is effective.

### Root cause (regression from #46959 / `cb6b4127e`)

The composer model picker became sticky session state: it persists whatever `session.info` reports as the live provider and ships it back on the next `session.create` as a per-session override (with **no** `base_url`).

For a named custom provider, `agent.provider` is the **resolved** bare string `"custom"` — the entry identity (and its key/`key_env` resolution) is lost. `session.info` reported that bare `"custom"`, so:

1. First chat: built from config → resolves the entry → works.
2. `session.info` reports `provider: "custom"` → composer persists it.
3. Next `session.create` ships `{model, provider: "custom"}` (no base_url) → `resolve_runtime_provider("custom")` can't match a named entry → falls through to a credential-less endpoint → **"No LLM provider configured."**

The DB-persistence path (`_runtime_model_config`) already recovered the canonical `custom:<name>` identity via `find_custom_provider_identity`; `session.info` had simply diverged from it.

### Fix

- Extract the recovery into a shared `_canonical_provider_identity(provider, base_url)` helper.
- Report the canonical `custom:<name>` menu key in `session.info` so the composer persists/round-trips an identity that re-resolves the entry's credentials.
- `_runtime_model_config` reuses the same helper, so the live report and the persisted value stay in sync.

### Test gap closed

Existing tests covered the DB persist/resume round-trip but **not** the `session.info → composer → session.create` round-trip. Added `TestSessionInfoReportsCanonicalIdentity`, asserting the reported provider re-resolves a named entry's real credentials (with no base_url, as the composer ships it) and guarding that the pre-fix bare `"custom"` does not.

## Test plan

- [x] `scripts/run_tests.sh tests/tui_gateway/test_custom_provider_session_persistence.py` — 12 passed
- [ ] Manual: set a named `providers:` entry, open Desktop, create a second chat, confirm it no longer errors

Made with [Cursor](https://cursor.com)