### PR TITLE
fix(desktop): recover onboarding from missing credentials

### DIFF
--- a/apps/desktop/src/components/desktop-onboarding-overlay.test.tsx
+++ b/apps/desktop/src/components/desktop-onboarding-overlay.test.tsx
@@ -1,10 +1,10 @@
 import { cleanup, fireEvent, render, screen } from '@testing-library/react'
-import { afterEach, describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 
 import { $desktopOnboarding, type DesktopOnboardingState, type OnboardingContext } from '@/store/onboarding'
 import type { OAuthProvider } from '@/types/hermes'
 
-import { Picker } from './desktop-onboarding-overlay'
+import { FlowPanel, Picker } from './desktop-onboarding-overlay'
 
 function provider(id: string, name = id): OAuthProvider {
   return {
@@ -32,6 +32,29 @@ function setProviders(providers: OAuthProvider[]) {
 }
 
 const ctx: OnboardingContext = { requestGateway: async () => undefined as never }
+
+function ensureLocalStorage() {
+  if (window.localStorage) {
+    return
+  }
+
+  const store = new Map<string, string>()
+  Object.defineProperty(window, 'localStorage', {
+    configurable: true,
+    value: {
+      clear: () => store.clear(),
+      getItem: (key: string) => store.get(key) ?? null,
+      removeItem: (key: string) => store.delete(key),
+      setItem: (key: string, value: string) => {
+        store.set(key, String(value))
+      }
+    }
+  })
+}
+
+beforeEach(() => {
+  ensureLocalStorage()
+})
 
 afterEach(() => {
   cleanup()
@@ -98,5 +121,53 @@ describe('onboarding Picker', () => {
     render(<Picker ctx={ctx} />)
 
     expect(screen.queryByRole('button', { name: "I'll choose a provider later" })).toBeNull()
+  })
+})
+
+describe('onboarding FlowPanel error recovery', () => {
+  it('offers direct API-key recovery for missing provider credentials', () => {
+    $desktopOnboarding.set({
+      configured: false,
+      flow: {
+        status: 'error',
+        message:
+          'Connected, but Hermes still cannot resolve a usable provider. No usable credentials found for openrouter.'
+      },
+      mode: 'oauth',
+      providers: [provider('nous', 'Nous Portal')],
+      reason: null,
+      requested: true,
+      firstRunSkipped: false,
+      manual: false,
+      localEndpoint: false
+    })
+
+    render(
+      <FlowPanel
+        ctx={ctx}
+        flow={$desktopOnboarding.get().flow}
+        leaving={false}
+        onBegin={() => undefined}
+      />
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'I have an API key' }))
+
+    expect($desktopOnboarding.get().flow.status).toBe('idle')
+    expect($desktopOnboarding.get().mode).toBe('apikey')
+  })
+
+  it('does not show API-key recovery for non-credential runtime errors', () => {
+    render(
+      <FlowPanel
+        ctx={ctx}
+        flow={{ status: 'error', message: 'Selected runtime is not available.' }}
+        leaving={false}
+        onBegin={() => undefined}
+      />
+    )
+
+    expect(screen.queryByRole('button', { name: 'I have an API key' })).toBeNull()
+    expect(screen.getByRole('button', { name: 'Pick a different provider' })).toBeTruthy()
   })
 })

--- a/apps/desktop/src/components/desktop-onboarding-overlay.tsx
+++ b/apps/desktop/src/components/desktop-onboarding-overlay.tsx
@@ -814,7 +814,7 @@ export function ApiKeyForm({
   )
 }
 
-function FlowPanel({
+export function FlowPanel({
   ctx,
   flow,
   leaving,
@@ -847,13 +847,24 @@ function FlowPanel({
   }
 
   if (flow.status === 'error') {
+    const showApiKeyRecovery = isProviderSetupErrorMessage(flow.message)
+    const openApiKeyForm = () => {
+      cancelOnboardingFlow()
+      setOnboardingMode('apikey')
+    }
+
     return (
       <div className="grid gap-3">
         <div className="flex items-center gap-1.5 text-sm text-destructive">
           <ErrorIcon className="shrink-0" size="0.875rem" />
           <span>{flow.message || t.onboarding.signInFailed}</span>
         </div>
-        <div className="flex justify-end">
+        <div className="flex justify-end gap-2">
+          {showApiKeyRecovery ? (
+            <Button onClick={openApiKeyForm} variant="outline">
+              {t.onboarding.haveApiKey}
+            </Button>
+          ) : null}
           <Button onClick={cancelOnboardingFlow} variant="outline">
             {t.onboarding.pickDifferentProvider}
           </Button>

--- a/apps/desktop/src/lib/provider-setup-errors.test.ts
+++ b/apps/desktop/src/lib/provider-setup-errors.test.ts
@@ -9,6 +9,7 @@ describe('isProviderSetupErrorMessage', () => {
     )
     expect(isProviderSetupErrorMessage('No inference provider is configured.')).toBe(true)
     expect(isProviderSetupErrorMessage('No Hermes provider is configured.')).toBe(true)
+    expect(isProviderSetupErrorMessage('No usable credentials found for openrouter.')).toBe(true)
     expect(isProviderSetupErrorMessage('set an API key (OPENROUTER_API_KEY) in ~/.hermes/.env')).toBe(true)
   })
 

--- a/apps/desktop/src/lib/provider-setup-errors.ts
+++ b/apps/desktop/src/lib/provider-setup-errors.ts
@@ -1,5 +1,5 @@
 const PROVIDER_SETUP_ERROR_RE =
-  /No (?:inference|Hermes) provider(?: is)? configured|no_provider_configured|OPENROUTER_API_KEY|OPENAI_API_KEY|ANTHROPIC_API_KEY|set an API key/i
+  /No (?:inference|Hermes) provider(?: is)? configured|No usable credentials found for \S+|no_provider_configured|OPENROUTER_API_KEY|OPENAI_API_KEY|ANTHROPIC_API_KEY|set an API key/i
 
 export function isProviderSetupErrorMessage(message: null | string | undefined): boolean {
   const text = message?.trim()


### PR DESCRIPTION
Fixes #48022.

## Summary
- classify the desktop runtime-check `No usable credentials found for ...` error as a provider setup failure
- add a direct `I have an API key` recovery action in the onboarding error panel
- route that action into the existing API-key form instead of forcing users back through only provider selection
- keep non-credential runtime mismatch errors on the existing `Pick a different provider` path

## Tests
- `npm --workspace apps/desktop run test:ui -- src/components/desktop-onboarding-overlay.test.tsx src/lib/provider-setup-errors.test.ts src/lib/runtime-readiness.test.ts`
- `npm --workspace apps/desktop run typecheck`
- `npm --workspace apps/desktop exec eslint -- --quiet src/components/desktop-onboarding-overlay.tsx src/components/desktop-onboarding-overlay.test.tsx src/lib/provider-setup-errors.ts src/lib/provider-setup-errors.test.ts && git diff --check`

## Review
- Subagent review found no blockers; narrowed the credential-error matcher after review feedback.