### PR TITLE
feat: add semantic session search

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1098,6 +1098,21 @@ DEFAULT_CONFIG = {
         "extract_backend": "",   # per-capability override for web_extract (e.g. "native")
     },
 
+    "session_search": {
+        "semantic": {
+            # Opt-in: keyword FTS remains the default. Semantic/hybrid tool
+            # calls use this OpenAI-compatible embedding profile when enabled.
+            "enabled": False,
+            "provider": "openai",
+            "base_url": "https://api.openai.com/v1",
+            "model": "text-embedding-3-small",
+            "timeout": 30,
+            "batch_size": 32,
+            "backfill_limit": 200,
+            "min_score": 0.0,
+        },
+    },
+
     "browser": {
         "inactivity_timeout": 120,
         "command_timeout": 30,  # Timeout for browser commands in seconds (screenshot, navigate, etc.)

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -16,9 +16,11 @@ Key design decisions:
 
 import json
 import logging
+import math
 import random
 import re
 import sqlite3
+import struct
 import threading
 import time
 from pathlib import Path
@@ -581,12 +583,33 @@ CREATE TABLE IF NOT EXISTS compression_locks (
     expires_at REAL NOT NULL
 );
 
+CREATE TABLE IF NOT EXISTS message_embeddings (
+    message_id INTEGER NOT NULL REFERENCES messages(id) ON DELETE CASCADE,
+    provider TEXT NOT NULL,
+    model TEXT NOT NULL,
+    content_hash TEXT NOT NULL,
+    dimensions INTEGER NOT NULL,
+    vector BLOB NOT NULL,
+    indexed_at REAL NOT NULL,
+    PRIMARY KEY (message_id, provider, model)
+);
+
 CREATE INDEX IF NOT EXISTS idx_sessions_source ON sessions(source);
 CREATE INDEX IF NOT EXISTS idx_sessions_source_id ON sessions(source, id);
 CREATE INDEX IF NOT EXISTS idx_sessions_parent ON sessions(parent_session_id);
 CREATE INDEX IF NOT EXISTS idx_sessions_started ON sessions(started_at DESC);
 CREATE INDEX IF NOT EXISTS idx_messages_session ON messages(session_id, timestamp);
 CREATE INDEX IF NOT EXISTS idx_compression_locks_expires ON compression_locks(expires_at);
+CREATE INDEX IF NOT EXISTS idx_message_embeddings_provider_model
+ON message_embeddings(provider, model);
+
+CREATE TRIGGER IF NOT EXISTS message_embeddings_delete AFTER DELETE ON messages BEGIN
+    DELETE FROM message_embeddings WHERE message_id = old.id;
+END;
+
+CREATE TRIGGER IF NOT EXISTS message_embeddings_invalidate AFTER UPDATE OF content, tool_name, tool_calls ON messages BEGIN
+    DELETE FROM message_embeddings WHERE message_id = old.id;
+END;
 """
 
 # Indexes that reference columns added in later schema versions must be
@@ -3609,6 +3632,249 @@ class SessionDB:
             key=lambda item: (score(item[1]), item[0]),
         )
         return [row for _, row in ranked[:limit]]
+
+    @staticmethod
+    def _embedding_content_hash(text: str) -> str:
+        import hashlib
+        return hashlib.sha256(text.encode("utf-8", errors="replace")).hexdigest()
+
+    @staticmethod
+    def _pack_embedding(vector: List[float]) -> bytes:
+        return struct.pack(f"{len(vector)}f", *[float(v) for v in vector])
+
+    @staticmethod
+    def _unpack_embedding(blob: bytes, dimensions: int) -> Tuple[float, ...]:
+        if not blob or dimensions <= 0:
+            return ()
+        try:
+            return struct.unpack(f"{dimensions}f", blob)
+        except struct.error:
+            return ()
+
+    @staticmethod
+    def _semantic_search_text(row: sqlite3.Row) -> str:
+        parts: List[str] = []
+        content = SessionDB._decode_content(row["content"])
+        if isinstance(content, list):
+            for part in content:
+                if isinstance(part, dict) and part.get("type") == "text":
+                    txt = part.get("text")
+                    if txt:
+                        parts.append(str(txt))
+        elif content is not None:
+            parts.append(str(content))
+        if row["tool_name"]:
+            parts.append(str(row["tool_name"]))
+        if row["tool_calls"]:
+            parts.append(str(row["tool_calls"]))
+        return " ".join(p for p in parts if p).strip()
+
+    @staticmethod
+    def _cosine_similarity(left: Tuple[float, ...], right: List[float]) -> float:
+        if not left or not right or len(left) != len(right):
+            return 0.0
+        dot = 0.0
+        left_norm = 0.0
+        right_norm = 0.0
+        for a, b in zip(left, right):
+            fa = float(a)
+            fb = float(b)
+            dot += fa * fb
+            left_norm += fa * fa
+            right_norm += fb * fb
+        if left_norm <= 0.0 or right_norm <= 0.0:
+            return 0.0
+        return dot / (math.sqrt(left_norm) * math.sqrt(right_norm))
+
+    def semantic_index_stats(
+        self,
+        provider: str,
+        model: str,
+        role_filter: List[str] = None,
+        exclude_sources: List[str] = None,
+    ) -> Dict[str, int]:
+        """Return indexed/pending counts for a semantic embedding profile."""
+        where = ["m.active = 1", "length(COALESCE(m.content, '')) > 0"]
+        params: List[Any] = []
+        if role_filter:
+            where.append(f"m.role IN ({','.join('?' for _ in role_filter)})")
+            params.extend(role_filter)
+        if exclude_sources:
+            where.append(f"s.source NOT IN ({','.join('?' for _ in exclude_sources)})")
+            params.extend(exclude_sources)
+        where_sql = " AND ".join(where)
+        with self._lock:
+            total = self._conn.execute(
+                f"SELECT COUNT(*) FROM messages m JOIN sessions s ON s.id = m.session_id "
+                f"WHERE {where_sql}",
+                params,
+            ).fetchone()[0]
+            indexed = self._conn.execute(
+                f"SELECT COUNT(*) FROM messages m "
+                f"JOIN sessions s ON s.id = m.session_id "
+                f"JOIN message_embeddings e ON e.message_id = m.id "
+                f"WHERE {where_sql} AND e.provider = ? AND e.model = ?",
+                [*params, provider, model],
+            ).fetchone()[0]
+        return {"total": int(total), "indexed": int(indexed), "pending": max(0, int(total) - int(indexed))}
+
+    def messages_needing_semantic_index(
+        self,
+        provider: str,
+        model: str,
+        role_filter: List[str] = None,
+        exclude_sources: List[str] = None,
+        limit: int = 200,
+    ) -> List[Dict[str, Any]]:
+        """Return message text rows whose current content lacks an embedding."""
+        where = ["m.active = 1", "length(COALESCE(m.content, '')) > 0"]
+        params: List[Any] = []
+        if role_filter:
+            where.append(f"m.role IN ({','.join('?' for _ in role_filter)})")
+            params.extend(role_filter)
+        if exclude_sources:
+            where.append(f"s.source NOT IN ({','.join('?' for _ in exclude_sources)})")
+            params.extend(exclude_sources)
+        where_sql = " AND ".join(where)
+        try:
+            limit = int(limit or 0)
+        except (TypeError, ValueError):
+            limit = 200
+        limit = max(0, min(limit, 1000))
+        if limit == 0:
+            return []
+
+        sql = f"""
+            SELECT m.id, m.session_id, m.role, m.content, m.tool_name, m.tool_calls, e.content_hash
+            FROM messages m
+            JOIN sessions s ON s.id = m.session_id
+            LEFT JOIN message_embeddings e
+              ON e.message_id = m.id AND e.provider = ? AND e.model = ?
+            WHERE {where_sql}
+            ORDER BY m.id ASC
+            LIMIT ?
+        """
+        with self._lock:
+            rows = self._conn.execute(sql, [provider, model, *params, limit * 4]).fetchall()
+        out: List[Dict[str, Any]] = []
+        for row in rows:
+            text = self._semantic_search_text(row)
+            if not text:
+                continue
+            digest = self._embedding_content_hash(text)
+            if row["content_hash"] == digest:
+                continue
+            out.append({
+                "id": row["id"],
+                "session_id": row["session_id"],
+                "role": row["role"],
+                "text": text,
+                "content_hash": digest,
+            })
+            if len(out) >= limit:
+                break
+        return out
+
+    def upsert_message_embedding(
+        self,
+        message_id: int,
+        provider: str,
+        model: str,
+        content_hash: str,
+        vector: List[float],
+    ) -> None:
+        """Store or replace one message embedding."""
+        if not vector:
+            return
+        packed = self._pack_embedding(vector)
+        dimensions = len(vector)
+
+        def _do(conn):
+            conn.execute(
+                """INSERT INTO message_embeddings
+                   (message_id, provider, model, content_hash, dimensions, vector, indexed_at)
+                   VALUES (?, ?, ?, ?, ?, ?, ?)
+                   ON CONFLICT(message_id, provider, model) DO UPDATE SET
+                       provider = excluded.provider,
+                       model = excluded.model,
+                       content_hash = excluded.content_hash,
+                       dimensions = excluded.dimensions,
+                       vector = excluded.vector,
+                       indexed_at = excluded.indexed_at""",
+                (message_id, provider, model, content_hash, dimensions, packed, time.time()),
+            )
+
+        self._execute_write(_do)
+
+    def search_message_embeddings(
+        self,
+        query_vector: List[float],
+        provider: str,
+        model: str,
+        source_filter: List[str] = None,
+        exclude_sources: List[str] = None,
+        role_filter: List[str] = None,
+        limit: int = 20,
+        offset: int = 0,
+        sort: str = None,
+        min_score: float = 0.0,
+    ) -> List[Dict[str, Any]]:
+        """Semantic search over indexed message embeddings."""
+        if not query_vector:
+            return []
+        where = ["e.provider = ?", "e.model = ?", "m.active = 1"]
+        params: List[Any] = [provider, model]
+        if source_filter is not None:
+            where.append(f"s.source IN ({','.join('?' for _ in source_filter)})")
+            params.extend(source_filter)
+        if exclude_sources is not None:
+            where.append(f"s.source NOT IN ({','.join('?' for _ in exclude_sources)})")
+            params.extend(exclude_sources)
+        if role_filter:
+            where.append(f"m.role IN ({','.join('?' for _ in role_filter)})")
+            params.extend(role_filter)
+        sql = f"""
+            SELECT
+                m.id, m.session_id, m.role, m.content, m.timestamp, m.tool_name, m.tool_calls,
+                s.source, s.model, s.started_at AS session_started,
+                e.vector, e.dimensions
+            FROM message_embeddings e
+            JOIN messages m ON m.id = e.message_id
+            JOIN sessions s ON s.id = m.session_id
+            WHERE {' AND '.join(where)}
+        """
+        with self._lock:
+            rows = self._conn.execute(sql, params).fetchall()
+
+        matches: List[Dict[str, Any]] = []
+        for row in rows:
+            vector = self._unpack_embedding(row["vector"], int(row["dimensions"]))
+            score = self._cosine_similarity(vector, query_vector)
+            if score < min_score:
+                continue
+            content = self._semantic_search_text(row)
+            snippet = content[:220] + ("..." if len(content) > 220 else "")
+            matches.append({
+                "id": row["id"],
+                "session_id": row["session_id"],
+                "role": row["role"],
+                "snippet": snippet,
+                "timestamp": row["timestamp"],
+                "tool_name": row["tool_name"],
+                "source": row["source"],
+                "model": row["model"],
+                "session_started": row["session_started"],
+                "semantic_score": score,
+            })
+
+        sort_norm = sort.strip().lower() if isinstance(sort, str) else None
+        if sort_norm == "newest":
+            matches.sort(key=lambda r: (r.get("timestamp") or 0, r["semantic_score"]), reverse=True)
+        elif sort_norm == "oldest":
+            matches.sort(key=lambda r: (r.get("timestamp") or 0, -r["semantic_score"]))
+        else:
+            matches.sort(key=lambda r: r["semantic_score"], reverse=True)
+        return matches[offset:offset + limit]
 
     def search_sessions(
         self,

--- a/tests/tools/test_session_search.py
+++ b/tests/tools/test_session_search.py
@@ -9,6 +9,7 @@ All run zero LLM calls.
 """
 import json
 import time
+from typing import Any
 
 import pytest
 
@@ -579,6 +580,7 @@ class TestCrossProfileRead:
         other_home.mkdir()
         other = SessionDB(other_home / "state.db")
         other.create_session("s_other", source="cli")
+        assert other._conn is not None
         other._conn.execute(
             "UPDATE sessions SET title = ? WHERE id = ?", ("Other Profile Chat", "s_other")
         )
@@ -601,6 +603,7 @@ class TestCrossProfileRead:
         other = SessionDB(other_home / "state.db")
         other.create_session("s_far", source="cli")
         other.append_message("s_far", role="user", content="hi")
+        assert other._conn is not None
         other._conn.commit()
 
         from collections import namedtuple
@@ -629,16 +632,18 @@ class TestCrossProfileRead:
         other = SessionDB(other_home / "state.db")
         other.create_session("s_other", source="cli")
         other.append_message("s_other", role="user", content="hi")
+        assert other._conn is not None
         other._conn.commit()
 
         self._patch_profiles(monkeypatch, other_home)
 
         # Every permutation the model might send must resolve to (asdf, s_other).
-        for kwargs in (
+        cases: tuple[dict[str, Any], ...] = (
             {"session_id": "asdf/s_other"},                    # full value, no profile
             {"session_id": "asdf/s_other", "profile": "asdf"},  # full value AND profile
             {"session_id": "s_other", "profile": "asdf"},       # bare id + profile
-        ):
+        )
+        for kwargs in cases:
             result = json.loads(session_search(db=db, **kwargs))
             assert result["success"] is True, kwargs
             assert result["mode"] == "read"

--- a/tests/tools/test_session_search.py
+++ b/tests/tools/test_session_search.py
@@ -69,6 +69,9 @@ class TestSchema:
         assert "query" in params
         assert "limit" in params
         assert "sort" in params
+        assert "search_mode" in params
+        assert "backfill_semantic_index" in params
+        assert "semantic_backfill_limit" in params
         # Scroll shape
         assert "session_id" in params
         assert "around_message_id" in params
@@ -84,6 +87,10 @@ class TestSchema:
     def test_sort_enum(self):
         params = SESSION_SEARCH_SCHEMA["parameters"]["properties"]
         assert params["sort"]["enum"] == ["newest", "oldest"]
+
+    def test_search_mode_enum(self):
+        params = SESSION_SEARCH_SCHEMA["parameters"]["properties"]
+        assert params["search_mode"]["enum"] == ["keyword", "semantic", "hybrid"]
 
     def test_schema_description_teaches_scroll(self):
         desc = SESSION_SEARCH_SCHEMA["description"]
@@ -180,6 +187,7 @@ class TestDiscoveryShape:
         assert result["success"] is True
         assert result["results"] == []
         assert result["count"] == 0
+        assert "search_mode" not in result
 
     def test_limit_clamped_to_max_10(self, db):
         _seed_modpack_sessions(db)
@@ -224,6 +232,121 @@ class TestDiscoverySort:
         # Should not error
         result = json.loads(session_search(query="modpack", sort="bogus", db=db))
         assert result["success"] is True
+
+
+class _FakeEmbedder:
+    provider = "fake"
+    model = "fake-embed-v1"
+
+    def embed_texts(self, texts):
+        return [self._embed(t) for t in texts]
+
+    @staticmethod
+    def _embed(text):
+        text = (text or "").lower()
+        if any(term in text for term in ("oauth", "token", "credential", "auth", "login")):
+            return [1.0, 0.0, 0.0]
+        if any(term in text for term in ("modpack", "minecraft", "neoforge")):
+            return [0.0, 1.0, 0.0]
+        return [0.0, 0.0, 1.0]
+
+
+class TestSemanticDiscovery:
+    def test_semantic_mode_backfills_and_finds_related_session_without_keyword_overlap(self, db):
+        db.create_session("s_auth", source="cli")
+        db.append_message("s_auth", role="user", content="OAuth token refresh keeps failing in the mobile login flow")
+        db.append_message("s_auth", role="assistant", content="Rotate the client secret and retry the refresh grant.")
+
+        db.create_session("s_modpack", source="cli")
+        db.append_message("s_modpack", role="user", content="Tune the Minecraft modpack spawn weights")
+
+        # Keyword FTS has no literal "credentials" hit.
+        keyword = json.loads(session_search(query="credentials", db=db))
+        assert keyword["count"] == 0
+
+        semantic = json.loads(session_search(
+            query="credentials",
+            search_mode="semantic",
+            backfill_semantic_index=True,
+            db=db,
+            embedder=_FakeEmbedder(),
+        ))
+        assert semantic["success"] is True
+        assert semantic["search_mode"] == "semantic"
+        assert semantic["count"] >= 1
+        assert semantic["results"][0]["session_id"] == "s_auth"
+        assert semantic["results"][0]["semantic_score"] > 0.9
+        assert semantic["semantic_index"]["backfilled"] >= 2
+
+    def test_hybrid_appends_keyword_hits(self, db):
+        db.create_session("s_auth", source="cli")
+        db.append_message("s_auth", role="user", content="OAuth token refresh keeps failing")
+        db.create_session("s_literal", source="cli")
+        db.append_message("s_literal", role="user", content="credentials inventory cleanup")
+
+        result = json.loads(session_search(
+            query="credentials",
+            search_mode="hybrid",
+            backfill_semantic_index=True,
+            limit=5,
+            db=db,
+            embedder=_FakeEmbedder(),
+        ))
+        assert result["success"] is True
+        assert result["search_mode"] == "hybrid"
+        sids = [r["session_id"] for r in result["results"]]
+        assert "s_auth" in sids
+        assert "s_literal" in sids
+
+    def test_semantic_unavailable_falls_back_to_keyword(self, db, monkeypatch):
+        _seed_modpack_sessions(db)
+        monkeypatch.setattr(
+            "tools.session_search_tool._load_semantic_embedder",
+            lambda: (None, "test provider unavailable"),
+        )
+        result = json.loads(session_search(
+            query="modpack",
+            search_mode="semantic",
+            db=db,
+        ))
+        assert result["success"] is True
+        assert result["search_mode"] == "keyword_fallback"
+        assert result["count"] >= 1
+        assert "test provider unavailable" in result["warning"]
+
+    def test_semantic_backfill_limit_is_bounded(self, db):
+        db.create_session("s_auth", source="cli")
+        db.append_message("s_auth", role="user", content="OAuth token refresh keeps failing")
+
+        result = json.loads(session_search(
+            query="credentials",
+            search_mode="semantic",
+            backfill_semantic_index=True,
+            semantic_backfill_limit=-1,
+            db=db,
+            embedder=_FakeEmbedder(),
+        ))
+        assert result["success"] is True
+        assert result["semantic_index"]["backfilled"] == 0
+
+    def test_semantic_backfill_refreshes_changed_message_content(self, db):
+        db.create_session("s_auth", source="cli")
+        message_id = db.append_message("s_auth", role="user", content="OAuth token refresh keeps failing")
+        assert db.messages_needing_semantic_index("fake", "fake-embed-v1", limit=10)
+        db.upsert_message_embedding(
+            message_id=message_id,
+            provider="fake",
+            model="fake-embed-v1",
+            content_hash=db._embedding_content_hash("OAuth token refresh keeps failing"),
+            vector=[1.0, 0.0, 0.0],
+        )
+        assert db.messages_needing_semantic_index("fake", "fake-embed-v1", limit=10) == []
+
+        db._conn.execute("UPDATE messages SET content = ? WHERE id = ?", ("Minecraft spawn tuning", message_id))
+        db._conn.commit()
+
+        stale = db.messages_needing_semantic_index("fake", "fake-embed-v1", limit=10)
+        assert [row["id"] for row in stale] == [message_id]
 
 
 class TestRoleFilter:

--- a/tools/session_search_tool.py
+++ b/tools/session_search_tool.py
@@ -32,6 +32,7 @@ support.
 import json
 import logging
 import os
+from importlib import import_module
 from typing import Any, Dict, List, Optional, Union
 
 # Sources that are excluded from session browsing/searching by default.
@@ -61,7 +62,7 @@ class _SessionSearchEmbedder:
         self.batch_size = max(1, min(int(batch_size or 32), 128))
 
     def embed_texts(self, texts: List[str]) -> List[List[float]]:
-        from openai import OpenAI
+        OpenAI = import_module("openai").OpenAI
 
         client = OpenAI(
             api_key=self.api_key,
@@ -313,7 +314,7 @@ def _read_session(db, session_id: str, head: int = 20, tail: int = 10) -> str:
     return json.dumps(response, ensure_ascii=False)
 
 
-def _list_recent_sessions(db, limit: int, current_session_id: str = None) -> str:
+def _list_recent_sessions(db, limit: int, current_session_id: Optional[str] = None) -> str:
     """Return metadata for the most recent sessions (no LLM calls, no FTS5)."""
     try:
         sessions = db.list_sessions_rich(
@@ -359,9 +360,9 @@ def _list_recent_sessions(db, limit: int, current_session_id: str = None) -> str
 def _scroll(
     db,
     session_id: str,
-    around_message_id: int,
-    window: int = 5,
-    current_session_id: str = None,
+    around_message_id: Union[int, str],
+    window: Union[int, str] = 5,
+    current_session_id: Optional[str] = None,
 ) -> str:
     """Scroll shape: return a window of messages centered on an anchor.
 
@@ -485,13 +486,13 @@ def _shape_discovery_response(
     query: str,
     raw_results: List[Dict[str, Any]],
     limit: int,
-    current_session_id: str = None,
+    current_session_id: Optional[str] = None,
     search_mode: str = "keyword",
     warning: Optional[str] = None,
     semantic_index: Optional[Dict[str, Any]] = None,
 ) -> str:
     if not raw_results:
-        payload = {
+        payload: Dict[str, Any] = {
             "success": True,
             "mode": "discover",
             "query": query,
@@ -566,7 +567,7 @@ def _shape_discovery_response(
             entry["parent_session_id"] = lineage_root
         results.append(entry)
 
-    payload = {
+    payload: Dict[str, Any] = {
         "success": True,
         "mode": "discover",
         "query": query,
@@ -589,7 +590,7 @@ def _discover_keyword(
     role_filter: Optional[List[str]],
     limit: int,
     sort: Optional[str],
-    current_session_id: str = None,
+    current_session_id: Optional[str] = None,
     warning: Optional[str] = None,
     search_mode: str = "keyword",
 ) -> str:
@@ -669,10 +670,10 @@ def _discover_semantic(
     role_filter: Optional[List[str]],
     limit: int,
     sort: Optional[str],
-    current_session_id: str = None,
+    current_session_id: Optional[str] = None,
     search_mode: str = "semantic",
     backfill_semantic_index: bool = False,
-    semantic_backfill_limit: Optional[int] = None,
+    semantic_backfill_limit: Optional[Union[int, str]] = None,
     embedder=None,
 ) -> str:
     role_list = role_filter if role_filter else ["user", "assistant"]
@@ -777,22 +778,22 @@ def _discover_semantic(
 
 def session_search(
     query: str = "",
-    role_filter: str = None,
-    limit: int = 3,
+    role_filter: Optional[str] = None,
+    limit: Union[int, str] = 3,
     db=None,
-    current_session_id: str = None,
+    current_session_id: Optional[str] = None,
     # Scroll shape
-    session_id: str = None,
-    around_message_id: int = None,
-    window: int = 5,
+    session_id: Optional[str] = None,
+    around_message_id: Optional[Union[int, str]] = None,
+    window: Union[int, str] = 5,
     # Discovery shape
-    sort: str = None,
+    sort: Optional[str] = None,
     search_mode: str = "keyword",
     backfill_semantic_index: bool = False,
-    semantic_backfill_limit: int = None,
+    semantic_backfill_limit: Optional[Union[int, str]] = None,
     embedder=None,
     # Cross-profile (any shape)
-    profile: str = None,
+    profile: Optional[str] = None,
 ) -> str:
     """Single-shape tool. Mode inferred from which args are set.
 
@@ -932,7 +933,7 @@ def check_session_search_requirements() -> bool:
         return False
 
 
-SESSION_SEARCH_SCHEMA = {
+SESSION_SEARCH_SCHEMA: Dict[str, Any] = {
     "name": "session_search",
     "description": (
         "Search past sessions stored in the local session DB, or scroll inside one. "

--- a/tools/session_search_tool.py
+++ b/tools/session_search_tool.py
@@ -31,6 +31,7 @@ support.
 
 import json
 import logging
+import os
 from typing import Any, Dict, List, Optional, Union
 
 # Sources that are excluded from session browsing/searching by default.
@@ -38,6 +39,94 @@ from typing import Any, Dict, List, Optional, Union
 # delegate subagent runs are tagged "subagent" — neither belongs in the
 # user's session history.
 _HIDDEN_SESSION_SOURCES = ("subagent", "tool")
+
+
+class _SessionSearchEmbedder:
+    """Small OpenAI-compatible embedding client for opt-in semantic search."""
+
+    def __init__(
+        self,
+        provider: str,
+        model: str,
+        base_url: str,
+        api_key: str,
+        timeout: int = 30,
+        batch_size: int = 32,
+    ):
+        self.provider = provider or "openai"
+        self.model = model
+        self.base_url = base_url
+        self.api_key = api_key
+        self.timeout = timeout
+        self.batch_size = max(1, min(int(batch_size or 32), 128))
+
+    def embed_texts(self, texts: List[str]) -> List[List[float]]:
+        from openai import OpenAI
+
+        client = OpenAI(
+            api_key=self.api_key,
+            base_url=self.base_url or None,
+            timeout=self.timeout,
+            max_retries=0,
+        )
+        vectors: List[List[float]] = []
+        for i in range(0, len(texts), self.batch_size):
+            batch = texts[i:i + self.batch_size]
+            resp = client.embeddings.create(model=self.model, input=batch)
+            data = sorted(resp.data, key=lambda item: item.index)
+            vectors.extend([list(item.embedding) for item in data])
+        return vectors
+
+
+def _load_semantic_embedder():
+    """Resolve the semantic embedding profile, returning (embedder, reason)."""
+    cfg: Dict[str, Any] = {}
+    try:
+        from hermes_cli.config import load_config
+        loaded = load_config() or {}
+        cfg = ((loaded.get("session_search") or {}).get("semantic") or {})
+    except Exception as exc:
+        logging.debug("session_search semantic config load failed: %s", exc, exc_info=True)
+
+    enabled = bool(cfg.get("enabled")) or os.getenv("HERMES_SESSION_SEARCH_SEMANTIC") == "1"
+    if not enabled:
+        return None, "semantic search is disabled; set session_search.semantic.enabled=true"
+
+    model = (cfg.get("model") or os.getenv("HERMES_SESSION_SEARCH_EMBEDDING_MODEL") or "").strip()
+    if not model:
+        return None, "session_search.semantic.model is not configured"
+    api_key = (os.getenv("OPENAI_API_KEY") or "").strip()
+    if not api_key:
+        return None, "no embedding API key configured (set OPENAI_API_KEY)"
+
+    return _SessionSearchEmbedder(
+        provider=(cfg.get("provider") or "openai"),
+        model=model,
+        base_url=(cfg.get("base_url") or os.getenv("OPENAI_BASE_URL") or "https://api.openai.com/v1"),
+        api_key=api_key,
+        timeout=int(cfg.get("timeout") or 30),
+        batch_size=int(cfg.get("batch_size") or 32),
+    ), None
+
+
+def _semantic_config_defaults() -> Dict[str, Any]:
+    try:
+        from hermes_cli.config import load_config
+        cfg = (((load_config() or {}).get("session_search") or {}).get("semantic") or {})
+        return {
+            "backfill_limit": _clamp_semantic_backfill_limit(cfg.get("backfill_limit"), default=200),
+            "min_score": float(cfg.get("min_score") or 0.0),
+        }
+    except Exception:
+        return {"backfill_limit": 200, "min_score": 0.0}
+
+
+def _clamp_semantic_backfill_limit(value: Any, default: int = 200) -> int:
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        parsed = default
+    return max(0, min(parsed, 1000))
 
 
 def _format_timestamp(ts: Union[int, float, str, None]) -> str:
@@ -391,39 +480,32 @@ def _scroll(
     return json.dumps(response, ensure_ascii=False)
 
 
-def _discover(
+def _shape_discovery_response(
     db,
     query: str,
-    role_filter: Optional[List[str]],
+    raw_results: List[Dict[str, Any]],
     limit: int,
-    sort: Optional[str],
     current_session_id: str = None,
+    search_mode: str = "keyword",
+    warning: Optional[str] = None,
+    semantic_index: Optional[Dict[str, Any]] = None,
 ) -> str:
-    """Discovery shape: FTS5 + anchored window + bookends per hit. Single call."""
-    role_list = role_filter if role_filter else ["user", "assistant"]
-
-    try:
-        raw_results = db.search_messages(
-            query=query,
-            role_filter=role_list,
-            exclude_sources=list(_HIDDEN_SESSION_SOURCES),
-            limit=50,  # widen so dedup-by-lineage can find distinct sessions
-            offset=0,
-            sort=sort,
-        )
-    except Exception as e:
-        logging.error("FTS5 search failed: %s", e, exc_info=True)
-        return tool_error(f"Search failed: {e}", success=False)
-
     if not raw_results:
-        return json.dumps({
+        payload = {
             "success": True,
             "mode": "discover",
             "query": query,
             "results": [],
             "count": 0,
             "message": "No matching sessions found.",
-        }, ensure_ascii=False)
+        }
+        if search_mode != "keyword":
+            payload["search_mode"] = search_mode
+        if warning:
+            payload["warning"] = warning
+        if semantic_index:
+            payload["semantic_index"] = semantic_index
+        return json.dumps(payload, ensure_ascii=False)
 
     current_lineage_root = _resolve_to_parent(db, current_session_id) if current_session_id else None
 
@@ -478,18 +560,219 @@ def _discover(
             "messages_before": view.get("messages_before", 0),
             "messages_after": view.get("messages_after", 0),
         }
+        if "semantic_score" in match_info:
+            entry["semantic_score"] = round(float(match_info["semantic_score"]), 6)
         if lineage_root and lineage_root != hit_sid:
             entry["parent_session_id"] = lineage_root
         results.append(entry)
 
-    return json.dumps({
+    payload = {
         "success": True,
         "mode": "discover",
         "query": query,
         "results": results,
         "count": len(results),
         "sessions_searched": len(seen_sessions),
-    }, ensure_ascii=False)
+    }
+    if search_mode != "keyword":
+        payload["search_mode"] = search_mode
+    if warning:
+        payload["warning"] = warning
+    if semantic_index:
+        payload["semantic_index"] = semantic_index
+    return json.dumps(payload, ensure_ascii=False)
+
+
+def _discover_keyword(
+    db,
+    query: str,
+    role_filter: Optional[List[str]],
+    limit: int,
+    sort: Optional[str],
+    current_session_id: str = None,
+    warning: Optional[str] = None,
+    search_mode: str = "keyword",
+) -> str:
+    """Discovery shape: FTS5 + anchored window + bookends per hit. Single call."""
+    role_list = role_filter if role_filter else ["user", "assistant"]
+
+    try:
+        raw_results = db.search_messages(
+            query=query,
+            role_filter=role_list,
+            exclude_sources=list(_HIDDEN_SESSION_SOURCES),
+            limit=50,  # widen so dedup-by-lineage can find distinct sessions
+            offset=0,
+            sort=sort,
+        )
+    except Exception as e:
+        logging.error("FTS5 search failed: %s", e, exc_info=True)
+        return tool_error(f"Search failed: {e}", success=False)
+
+    return _shape_discovery_response(
+        db=db,
+        query=query,
+        raw_results=raw_results,
+        limit=limit,
+        current_session_id=current_session_id,
+        search_mode=search_mode,
+        warning=warning,
+    )
+
+
+def _backfill_semantic_index(
+    db,
+    embedder,
+    role_list: List[str],
+    limit: int,
+) -> Dict[str, Any]:
+    rows = db.messages_needing_semantic_index(
+        provider=embedder.provider,
+        model=embedder.model,
+        role_filter=role_list,
+        exclude_sources=list(_HIDDEN_SESSION_SOURCES),
+        limit=limit,
+    )
+    if not rows:
+        stats = db.semantic_index_stats(
+            provider=embedder.provider,
+            model=embedder.model,
+            role_filter=role_list,
+            exclude_sources=list(_HIDDEN_SESSION_SOURCES),
+        )
+        return {"backfilled": 0, **stats}
+
+    vectors = embedder.embed_texts([r["text"] for r in rows])
+    stored = 0
+    for row, vector in zip(rows, vectors):
+        db.upsert_message_embedding(
+            message_id=row["id"],
+            provider=embedder.provider,
+            model=embedder.model,
+            content_hash=row["content_hash"],
+            vector=vector,
+        )
+        stored += 1
+
+    stats = db.semantic_index_stats(
+        provider=embedder.provider,
+        model=embedder.model,
+        role_filter=role_list,
+        exclude_sources=list(_HIDDEN_SESSION_SOURCES),
+    )
+    return {"backfilled": stored, **stats}
+
+
+def _discover_semantic(
+    db,
+    query: str,
+    role_filter: Optional[List[str]],
+    limit: int,
+    sort: Optional[str],
+    current_session_id: str = None,
+    search_mode: str = "semantic",
+    backfill_semantic_index: bool = False,
+    semantic_backfill_limit: Optional[int] = None,
+    embedder=None,
+) -> str:
+    role_list = role_filter if role_filter else ["user", "assistant"]
+    defaults = _semantic_config_defaults()
+    if embedder is None:
+        embedder, unavailable = _load_semantic_embedder()
+    else:
+        unavailable = None
+    if embedder is None:
+        return _discover_keyword(
+            db=db,
+            query=query,
+            role_filter=role_filter,
+            limit=limit,
+            sort=sort,
+            current_session_id=current_session_id,
+            warning=f"semantic search unavailable: {unavailable}; used keyword FTS instead",
+            search_mode="keyword_fallback",
+        )
+
+    semantic_index = None
+    if backfill_semantic_index:
+        try:
+            semantic_index = _backfill_semantic_index(
+                db=db,
+                embedder=embedder,
+                role_list=role_list,
+                limit=_clamp_semantic_backfill_limit(
+                    semantic_backfill_limit,
+                    default=int(defaults["backfill_limit"]),
+                ),
+            )
+        except Exception as exc:
+            logging.warning("semantic index backfill failed: %s", exc, exc_info=True)
+            return _discover_keyword(
+                db=db,
+                query=query,
+                role_filter=role_filter,
+                limit=limit,
+                sort=sort,
+                current_session_id=current_session_id,
+                warning=f"semantic backfill failed: {exc}; used keyword FTS instead",
+                search_mode="keyword_fallback",
+            )
+
+    try:
+        query_vector = embedder.embed_texts([query])[0]
+        raw_results = db.search_message_embeddings(
+            query_vector=query_vector,
+            provider=embedder.provider,
+            model=embedder.model,
+            role_filter=role_list,
+            exclude_sources=list(_HIDDEN_SESSION_SOURCES),
+            limit=50,
+            offset=0,
+            sort=sort,
+            min_score=float(defaults["min_score"]),
+        )
+    except Exception as exc:
+        logging.warning("semantic search failed: %s", exc, exc_info=True)
+        return _discover_keyword(
+            db=db,
+            query=query,
+            role_filter=role_filter,
+            limit=limit,
+            sort=sort,
+            current_session_id=current_session_id,
+            warning=f"semantic search failed: {exc}; used keyword FTS instead",
+            search_mode="keyword_fallback",
+        )
+
+    if search_mode == "hybrid":
+        try:
+            keyword_results = db.search_messages(
+                query=query,
+                role_filter=role_list,
+                exclude_sources=list(_HIDDEN_SESSION_SOURCES),
+                limit=50,
+                offset=0,
+                sort=sort,
+            )
+        except Exception:
+            keyword_results = []
+        seen_ids = {r.get("id") for r in raw_results}
+        raw_results.extend([r for r in keyword_results if r.get("id") not in seen_ids])
+
+    warning = None
+    if not raw_results and not backfill_semantic_index:
+        warning = "semantic index has no matching rows; pass backfill_semantic_index=true to index stored sessions"
+
+    return _shape_discovery_response(
+        db=db,
+        query=query,
+        raw_results=raw_results,
+        limit=limit,
+        current_session_id=current_session_id,
+        search_mode=search_mode,
+        warning=warning,
+        semantic_index=semantic_index,
+    )
 
 
 def session_search(
@@ -504,6 +787,10 @@ def session_search(
     window: int = 5,
     # Discovery shape
     sort: str = None,
+    search_mode: str = "keyword",
+    backfill_semantic_index: bool = False,
+    semantic_backfill_limit: int = None,
+    embedder=None,
     # Cross-profile (any shape)
     profile: str = None,
 ) -> str:
@@ -606,7 +893,27 @@ def session_search(
         if candidate in ("newest", "oldest"):
             sort_norm = candidate
 
-    return _discover(
+    mode_norm = "keyword"
+    if isinstance(search_mode, str):
+        candidate = search_mode.strip().lower()
+        if candidate in ("keyword", "semantic", "hybrid"):
+            mode_norm = candidate
+
+    if mode_norm in ("semantic", "hybrid"):
+        return _discover_semantic(
+            db=db,
+            query=query.strip(),
+            role_filter=role_list,
+            limit=limit,
+            sort=sort_norm,
+            current_session_id=current_session_id,
+            search_mode=mode_norm,
+            backfill_semantic_index=bool(backfill_semantic_index),
+            semantic_backfill_limit=semantic_backfill_limit,
+            embedder=embedder,
+        )
+
+    return _discover_keyword(
         db=db,
         query=query.strip(),
         role_filter=role_list,
@@ -629,12 +936,14 @@ SESSION_SEARCH_SCHEMA = {
     "name": "session_search",
     "description": (
         "Search past sessions stored in the local session DB, or scroll inside one. "
-        "FTS5-backed retrieval over the SQLite message store. No LLM calls — every "
-        "shape returns actual messages from the DB.\n\n"
+        "Keyword retrieval is FTS5-backed over the SQLite message store. Semantic "
+        "and hybrid retrieval are opt-in and use the user's configured embedding "
+        "provider only when available; otherwise they fall back to keyword FTS. "
+        "No LLM summarization calls — every shape returns actual messages from the DB.\n\n"
         "FOUR CALLING SHAPES\n\n"
         "  1) DISCOVERY — pass `query`:\n"
         "     session_search(query=\"auth refactor\", limit=3)\n"
-        "     Runs FTS5, dedupes hits by session lineage, returns the top N sessions. "
+        "     Runs keyword FTS by default, dedupes hits by session lineage, returns the top N sessions. "
         "Each result carries:\n"
         "       - session_id, title, when, source\n"
         "       - snippet: FTS5-highlighted match excerpt\n"
@@ -672,6 +981,12 @@ SESSION_SEARCH_SCHEMA = {
         "for broader recall (`alpha OR beta OR gamma`), quoted phrases for exact match "
         "(`\"docker networking\"`), boolean (`python NOT java`), or prefix wildcards "
         "(`deploy*`).\n\n"
+        "SEMANTIC SEARCH\n\n"
+        "  Pass search_mode='semantic' for vector-only retrieval, or 'hybrid' to put "
+        "semantic hits first and append exact keyword hits. Set "
+        "backfill_semantic_index=true when the user asks to index/backfill their "
+        "stored sessions. If embeddings are disabled or credentials are missing, "
+        "the tool returns keyword results with a warning instead of failing.\n\n"
         "WHEN TO USE\n\n"
         "  Reach for this on any \"what did we do about X\" / \"where did we leave Y\" / "
         "\"find the session where Z\" question — before gh, web search, or filesystem "
@@ -710,6 +1025,38 @@ SESSION_SEARCH_SCHEMA = {
                     "origin-shaped questions (\"how did X start\"). Ignored in scroll "
                     "and browse shapes."
                 ),
+            },
+            "search_mode": {
+                "type": "string",
+                "enum": ["keyword", "semantic", "hybrid"],
+                "description": (
+                    "Discovery shape only. 'keyword' (default) preserves existing "
+                    "FTS5 behavior. 'semantic' searches the optional local embedding "
+                    "index. 'hybrid' ranks semantic hits first and appends keyword "
+                    "hits. Semantic/hybrid gracefully fall back to keyword when the "
+                    "embedding provider or index is unavailable."
+                ),
+                "default": "keyword",
+            },
+            "backfill_semantic_index": {
+                "type": "boolean",
+                "description": (
+                    "Discovery shape only. When true with search_mode semantic/hybrid, "
+                    "embed a bounded batch of unindexed session messages before "
+                    "searching. Use for explicit user requests to enable/backfill "
+                    "semantic recall. Requires session_search.semantic config or "
+                    "HERMES_SESSION_SEARCH_SEMANTIC=1 plus OPENAI_API_KEY."
+                ),
+                "default": False,
+            },
+            "semantic_backfill_limit": {
+                "type": "integer",
+                "description": (
+                    "Optional cap for one semantic backfill call. Defaults to "
+                    "session_search.semantic.backfill_limit (200). Keep bounded to "
+                    "avoid surprise embedding cost."
+                ),
+                "default": 200,
             },
             "session_id": {
                 "type": "string",
@@ -775,6 +1122,9 @@ registry.register(
         around_message_id=args.get("around_message_id"),
         window=args.get("window", 5),
         sort=args.get("sort"),
+        search_mode=args.get("search_mode", "keyword"),
+        backfill_semantic_index=args.get("backfill_semantic_index", False),
+        semantic_backfill_limit=args.get("semantic_backfill_limit"),
         profile=args.get("profile"),
         db=kw.get("db"),
         current_session_id=kw.get("current_session_id"),

--- a/website/docs/reference/tools-reference.md
+++ b/website/docs/reference/tools-reference.md
@@ -154,7 +154,7 @@ Registered when the agent is either (a) spawned by the kanban dispatcher (`HERME
 
 | Tool | Description | Requires environment |
 |------|-------------|----------------------|
-| `session_search` | Search past sessions stored in the local session DB, or scroll inside one. FTS5-backed retrieval; returns actual messages from the DB (no LLM calls). Three shapes: discovery (pass `query`), scroll (pass `session_id` + `around_message_id`), browse (no args). | — |
+| `session_search` | Search past sessions stored in the local session DB, or scroll inside one. Keyword mode is FTS5-backed and remains the default; optional `search_mode="semantic"` / `"hybrid"` uses the configured embedding index and falls back to keyword with a warning when unavailable. Three shapes: discovery (pass `query`), scroll (pass `session_id` + `around_message_id`), browse (no args). | Optional for semantic: `OPENAI_API_KEY` |
 
 ## `skills` toolset
 
@@ -266,5 +266,3 @@ Registered only on the `hermes-yuanbao` platform toolset. Yuanbao is Tencent's c
 | `yb_send_dm` | Send a private/direct message to a user in a group, with optional media files. | Yuanbao credentials |
 | `yb_search_sticker` | Search the built-in Yuanbao sticker (TIM face) catalogue by keyword. | Yuanbao credentials |
 | `yb_send_sticker` | Send a built-in sticker to the current Yuanbao chat. | Yuanbao credentials |
-
-

--- a/website/docs/user-guide/sessions.md
+++ b/website/docs/user-guide/sessions.md
@@ -370,7 +370,7 @@ For deeper analytics — token usage, cost estimates, tool breakdown, and activi
 
 ## Session Search Tool
 
-The agent has a built-in `session_search` tool that performs full-text search across all past conversations using SQLite's FTS5 engine — and lets the agent scroll through any session it finds. No LLM calls, no summarization, no truncation. Every shape returns actual messages from the DB.
+The agent has a built-in `session_search` tool that performs full-text search across all past conversations using SQLite's FTS5 engine — and lets the agent scroll through any session it finds. Optional semantic search adds a local embedding index over the same message rows. No LLM summarization, no truncation. Every shape returns actual messages from the DB.
 
 ### Three calling shapes
 
@@ -382,7 +382,7 @@ The tool infers what you want from which arguments you set. There's no `mode` pa
 session_search(query="auth refactor", limit=3)
 ```
 
-Runs FTS5, dedupes hits by session lineage, returns the top N sessions. Each result carries:
+Runs FTS5 by default, dedupes hits by session lineage, returns the top N sessions. Each result carries:
 
 - `session_id`, `title`, `when`, `source`
 - `snippet` — FTS5-highlighted match excerpt
@@ -429,6 +429,40 @@ The keyword mode supports standard FTS5 query syntax:
 
 - `sort` — `newest` or `oldest`, on top of FTS5 ranking. Omit for relevance-only ordering (the default; suitable for exploratory recall). Use `newest` for "where did we leave X" questions, `oldest` for "how did X start" questions.
 - `role_filter` — comma-separated roles to include. Discovery defaults to `user,assistant` (tool output is usually noise). Pass `user,assistant,tool` to include tool output (debugging tool behaviour) or `tool` to search tool output only.
+- `search_mode` — `keyword` (default), `semantic`, or `hybrid`. Keyword preserves existing FTS5 behavior. Semantic uses the optional embedding index. Hybrid puts semantic hits first and appends exact keyword hits.
+- `backfill_semantic_index` — when true with semantic or hybrid mode, embeds a bounded batch of unindexed stored messages before searching.
+- `semantic_backfill_limit` — overrides the per-call backfill cap. Keep this bounded to avoid surprise embedding cost.
+
+### Semantic Search
+
+Semantic search is opt-in because it calls an embedding provider and stores vectors in `state.db`. Keyword search remains the default and needs no configuration.
+
+Enable an OpenAI-compatible embedding profile in `~/.hermes/config.yaml`:
+
+```yaml
+session_search:
+  semantic:
+    enabled: true
+    provider: openai
+    base_url: https://api.openai.com/v1
+    model: text-embedding-3-small
+    backfill_limit: 200
+```
+
+Set the embedding API key in your environment or `~/.hermes/.env` as `OPENAI_API_KEY`; do not put API keys in `config.yaml`.
+
+Then ask Hermes to use semantic recall, or call the tool directly:
+
+```python
+session_search(
+    query="where did we talk about expired login credentials",
+    search_mode="hybrid",
+    backfill_semantic_index=True,
+    semantic_backfill_limit=200,
+)
+```
+
+Backfill is incremental. Existing `state.db` files do not need a blocking migration: the `message_embeddings` table is created automatically on startup, and vectors are added only when `backfill_semantic_index=true` or future tool calls index more rows. If the embedding provider, API key, or semantic index is unavailable, semantic and hybrid calls return keyword FTS results with a warning instead of failing.
 
 ### When It's Used
 
@@ -508,6 +542,7 @@ Key tables in `state.db`:
 - **sessions** — session metadata (id, source, user_id, model, title, timestamps, token counts). Titles have a unique index (NULL titles allowed, only non-NULL must be unique).
 - **messages** — full message history (role, content, tool_calls, tool_name, token_count)
 - **messages_fts** — FTS5 virtual table for full-text search across message content
+- **message_embeddings** — optional semantic-search vectors keyed by message, provider, and model. Safe to rebuild by running bounded semantic backfills.
 
 ## Session Expiry and Cleanup
 


### PR DESCRIPTION
## Summary
- add opt-in semantic and hybrid modes to `session_search` while keeping keyword FTS as the default
- store optional message embeddings in `state.db` with stale-content invalidation
- add bounded semantic backfill, graceful keyword fallback, docs, and focused coverage

## Notes
- semantic search is disabled unless configured via `session_search.semantic.enabled=true` or `HERMES_SESSION_SEARCH_SEMANTIC=1`
- rebased onto current `NousResearch/main` so the PR contains only the semantic-search patch

## Validation
- `UV_CACHE_DIR=/tmp/hermes-uv-cache uv sync --extra dev`
- `scripts/run_tests.sh tests/tools/test_session_search.py tests/test_hermes_state.py tests/hermes_state/test_get_messages_around.py tests/hermes_state/test_get_anchored_view.py` (343 passed)
- `.venv/bin/python -m ruff check .`
- `.venv/bin/python -m ruff check hermes_cli/config.py hermes_state.py tools/session_search_tool.py tests/tools/test_session_search.py`
- `.venv/bin/python -m py_compile hermes_state.py tools/session_search_tool.py hermes_cli/config.py tests/tools/test_session_search.py`
- import checks for `hermes_state`, `tools.session_search_tool`, `hermes_cli.config`
- `git diff --check nous/main..HEAD`