### PR TITLE
fix(agent): preserve paragraph structure when removing @ context refs (#48484)

### DIFF
--- a/agent/context_references.py
+++ b/agent/context_references.py
@@ -412,7 +412,8 @@ def _remove_reference_tokens(message: str, refs: list[ContextReference]) -> str:
         cursor = ref.end
     pieces.append(message[cursor:])
     text = "".join(pieces)
-    text = re.sub(r"\s{2,}", " ", text)
+    text = re.sub(r"[^\S\n]{2,}", " ", text)
+    text = re.sub(r"\n{3,}", "\n\n", text)
     text = re.sub(r"\s+([,.;:!?])", r"\1", text)
     return text.strip()
 


### PR DESCRIPTION
Fixes #48484. The whitespace cleanup in _remove_reference_tokens used \s{2,} which matches newlines, collapsing blank lines and paragraph breaks into single spaces when removing @ context reference tokens. Changed to [^\S\n]{2,} to only collapse horizontal whitespace, and capped consecutive blank lines at one.