### PR TITLE
docs: remove unresolved run agent comment placeholder

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -1515,7 +1515,7 @@ class AIAgent:
         a raw ``tool`` message and the next user turn lands as
         ``...tool, user, user`` — a protocol-invalid sequence that most
         providers silently reject (returns empty content), causing the
-        empty-retry loop to fire forever. See #<TBD>.
+        empty-retry loop to fire forever.
         """
         # Pass 1: strip the flagged scaffolding messages themselves.
         dropped_scaffolding = False


### PR DESCRIPTION
## Summary

Removes an unresolved `#<TBD>` placeholder from a comment in `run_agent.py`.

This is a comment-only cleanup and does not change runtime behavior.

References #32848
