### PR TITLE
fix(auth): allow user plugins to override inference_base_url (#48450)

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -472,6 +472,10 @@ try:
     from providers import list_providers as _list_providers_for_registry
     for _pp in _list_providers_for_registry():
         if _pp.name in PROVIDER_REGISTRY:
+            # Allow user plugins to override inference_base_url for
+            # hardcoded providers (e.g. region-specific endpoints).
+            if _pp.base_url and PROVIDER_REGISTRY[_pp.name].inference_base_url != _pp.base_url:
+                PROVIDER_REGISTRY[_pp.name].inference_base_url = _pp.base_url
             continue
         if _pp.auth_type != "api_key" or not _pp.env_vars:
             continue


### PR DESCRIPTION
Fixes #48450. User plugins can register providers with custom base_url but when the same provider name was already hardcoded in PROVIDER_REGISTRY, the auto-extend loop skipped it entirely. Now updates inference_base_url on existing entries when a plugin provides a different value.