### PR TITLE
feat(cli): add tools diagnose command

### DIFF
--- a/acp_adapter/server.py
+++ b/acp_adapter/server.py
@@ -1161,31 +1161,27 @@ class HermesACPAgent(acp.Agent):
             return
 
         try:
-            from model_tools import get_tool_definitions
-            from agent.memory_manager import inject_memory_provider_tools
+            from tools.mcp_tool import refresh_agent_mcp_tools
 
             enabled_toolsets = _expand_acp_enabled_toolsets(
                 getattr(state.agent, "enabled_toolsets", None) or ["hermes-acp"],
                 mcp_server_names=[server.name for server in mcp_servers],
             )
-            state.agent.enabled_toolsets = enabled_toolsets
             disabled_toolsets = getattr(state.agent, "disabled_toolsets", None)
-            state.agent.tools = get_tool_definitions(
-                enabled_toolsets=enabled_toolsets,
-                disabled_toolsets=disabled_toolsets,
-                quiet_mode=True,
+            refresh_agent_mcp_tools(
+                state.agent,
+                enabled_override=enabled_toolsets,
+                disabled_override=disabled_toolsets,
             )
-            state.agent.valid_tool_names = {
-                tool["function"]["name"] for tool in state.agent.tools or []
-            }
-            inject_memory_provider_tools(state.agent)
             invalidate = getattr(state.agent, "_invalidate_system_prompt", None)
             if callable(invalidate):
                 invalidate()
+            from agent.tool_surface import get_agent_tool_surface
+
             logger.info(
                 "Session %s: refreshed tool surface after ACP MCP registration (%d tools)",
                 state.session_id,
-                len(state.agent.tools or []),
+                len(get_agent_tool_surface(state.agent).tool_defs),
             )
         except Exception:
             logger.warning(
@@ -2345,26 +2341,7 @@ class HermesACPAgent(acp.Agent):
 
     def _cmd_tools(self, args: str, state: SessionState) -> str:
         try:
-            from model_tools import get_tool_definitions
-            from types import SimpleNamespace
-            from agent.memory_manager import inject_memory_provider_tools
-
-            toolsets = _expand_acp_enabled_toolsets(
-                getattr(state.agent, "enabled_toolsets", None) or ["hermes-acp"]
-            )
-            tools = get_tool_definitions(enabled_toolsets=toolsets, quiet_mode=True)
-            tool_view = SimpleNamespace(
-                tools=list(tools or []),
-                valid_tool_names={
-                    tool.get("function", {}).get("name")
-                    for tool in tools or []
-                    if isinstance(tool, dict)
-                },
-                enabled_toolsets=toolsets,
-                _memory_manager=getattr(state.agent, "_memory_manager", None),
-            )
-            inject_memory_provider_tools(tool_view)
-            tools = tool_view.tools
+            tools = list(getattr(state.agent, "tools", None) or [])
             if not tools:
                 return "No tools available."
             lines = [f"Available tools ({len(tools)}):"]

--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1192,11 +1192,17 @@ def init_agent(
         agent._tool_snapshot_generation = _snapshot_registry._generation
     except Exception:
         agent._tool_snapshot_generation = 0
-    agent.tools = _ra().get_tool_definitions(
+    _base_tool_defs = _ra().get_tool_definitions(
         enabled_toolsets=enabled_toolsets,
         disabled_toolsets=disabled_toolsets,
         quiet_mode=agent.quiet_mode,
+        skip_tool_search_assembly=True,
+        record_resolved_names=False,
     )
+    # Agent init has not loaded external provider/context schemas yet. Keep the
+    # pre-assembly catalog local and publish the final model-facing list only
+    # after those families are available below.
+    agent.tools = list(_base_tool_defs)
     
     # Show tool configuration and store valid tool names for validation
     agent.valid_tool_names = set()
@@ -1459,9 +1465,6 @@ def init_agent(
         except Exception as _mpe:
             _ra().logger.warning("Memory provider plugin init failed: %s", _mpe)
             agent._memory_manager = None
-
-    from agent.memory_manager import inject_memory_provider_tools as _inject_memory_provider_tools
-    _inject_memory_provider_tools(agent)
 
     # Skills config: nudge interval for skill creation reminders
     agent._skill_nudge_interval = 10
@@ -1921,56 +1924,36 @@ def init_agent(
         except Exception:
             pass
 
-    # Inject context engine tool schemas (e.g. lcm_grep, lcm_describe, lcm_expand).
-    # Skip names that are already present — the _ra().get_tool_definitions()
-    # quiet_mode cache returned a shared list pre-#17335, so a stray
-    # mutation here would poison subsequent agent inits in the same
-    # Gateway process and trip provider-side 'duplicate tool name'
-    # errors. Even with the cache fix, dedup is the right defense
-    # against plugin paths that may register the same schemas via
-    # ctx.register_tool(). Mirrors the memory tools dedup above.
-    #
-    # Respect the platform's enabled_toolsets configuration (#5544):
-    # context engine tools follow the same gating pattern as memory
-    # provider tools — without the gate, `platform_toolsets: telegram: []`
-    # would still leak lcm_* tools into the tool surface and incur the
-    # same local-model latency penalty.
+    # Assemble the complete surface after external memory/context providers are
+    # ready. The shared helper copies and sanitizes every family, preserves
+    # toolset gates, deduplicates names, then applies tool search exactly once.
     agent._context_engine_tool_names: set = set()
-    if (
-        hasattr(agent, "context_compressor")
-        and agent.context_compressor
-        and agent.tools is not None
-        and (
-            agent.enabled_toolsets is None
-            or "context_engine" in agent.enabled_toolsets
+    try:
+        from agent.tool_surface import assemble_agent_tool_surface
+        from model_tools import record_resolved_tool_names
+
+        _full_tool_surface = assemble_agent_tool_surface(
+            agent,
+            _base_tool_defs,
+            quiet_mode=agent.quiet_mode,
         )
-    ):
-        _existing_tool_names = {
-            t.get("function", {}).get("name")
-            for t in agent.tools
-            if isinstance(t, dict)
+        agent.tools = _full_tool_surface.tool_defs
+        agent.valid_tool_names = {
+            tool["function"]["name"] for tool in agent.tools
         }
-        from agent.memory_manager import normalize_tool_schema as _normalize_tool_schema
-        for _raw_schema in agent.context_compressor.get_tool_schemas():
-            _schema = _normalize_tool_schema(_raw_schema)
-            if _schema is None:
-                # A schema with no resolvable name (e.g. an already-wrapped
-                # entry) would append a nameless tool that strict providers
-                # 400 on, disabling the whole toolset (#47707). Skip it.
-                _ra().logger.warning(
-                    "Context engine returned a tool schema with no resolvable "
-                    "name; skipping to avoid poisoning the request (%r)",
-                    _raw_schema,
-                )
-                continue
-            _tname = _schema["name"]
-            if _tname in _existing_tool_names:
-                continue  # already registered via plugin/cache path
-            _wrapped = {"type": "function", "function": _schema}
-            agent.tools.append(_wrapped)
-            agent.valid_tool_names.add(_tname)
-            agent._context_engine_tool_names.add(_tname)
-            _existing_tool_names.add(_tname)
+        agent._context_engine_tool_names = set(
+            _full_tool_surface.injected_names["context_engine"]
+        )
+        record_resolved_tool_names(agent.tools)
+    except Exception as _surface_error:
+        _ra().logger.warning(
+            "Full tool-surface assembly failed; keeping prior tool list: %s",
+            _surface_error,
+        )
+        # Preserve the legacy resolved-name contract even on fail-soft fallback.
+        from model_tools import record_resolved_tool_names as _record_fallback_names
+
+        _record_fallback_names(agent.tools or [])
 
     # Notify context engine of session start
     if hasattr(agent, "context_compressor") and agent.context_compressor:

--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -989,6 +989,8 @@ def init_agent(
     # late/concurrent refresh reject a stale (older-generation) rebuild instead
     # of clobbering a newer one. Set adjacent to the tool snapshot below.
     agent._tool_snapshot_generation = 0
+    agent._tool_selection_revision = 0
+    agent._tool_surface_snapshot = None
     # Rate limit tracking — updated from x-ratelimit-* response headers
     # after each API call.  Accessed by /usage slash command.
     agent._rate_limit_state: Optional["RateLimitState"] = None
@@ -1516,26 +1518,21 @@ def init_agent(
         agent._tool_snapshot_generation = _snapshot_registry._generation
     except Exception:
         agent._tool_snapshot_generation = 0
-    agent.tools = _ra().get_tool_definitions(
+    _base_tool_defs = _ra().get_tool_definitions(
         enabled_toolsets=enabled_toolsets,
         disabled_toolsets=disabled_toolsets,
         quiet_mode=agent.quiet_mode,
+        skip_tool_search_assembly=True,
+        record_resolved_names=False,
     )
+    agent.tools = list(_base_tool_defs)
     
-    # Show tool configuration and store valid tool names for validation
+    # Keep the pre-assembly names available during initialization. The final
+    # model-facing snapshot and user-visible status are published below after
+    # external provider/context schemas are ready.
     agent.valid_tool_names = set()
     if agent.tools:
         agent.valid_tool_names = {tool["function"]["name"] for tool in agent.tools}
-        tool_names = sorted(agent.valid_tool_names)
-        if not agent.quiet_mode:
-            print(f"🛠️  Loaded {len(agent.tools)} tools: {', '.join(tool_names)}")
-            # Show filtering info if applied
-            if enabled_toolsets:
-                print(f"   ✅ Enabled toolsets: {', '.join(enabled_toolsets)}")
-            if disabled_toolsets:
-                print(f"   ❌ Disabled toolsets: {', '.join(disabled_toolsets)}")
-    elif not agent.quiet_mode:
-        print("🛠️  No tools loaded (all tools filtered out or unavailable)")
 
     # Kanban worker/orchestrator lifecycle guidance is session-static:
     # the dispatcher decides at spawn time whether this process is a kanban
@@ -1543,18 +1540,8 @@ def init_agent(
     # Resolving the ~835-token block once here avoids re-running the
     # membership test + reference on every system-prompt rebuild
     # (init + each context compression).
-    from agent.prompt_builder import KANBAN_GUIDANCE
-    agent._kanban_worker_guidance = (
-        KANBAN_GUIDANCE if "kanban_show" in agent.valid_tool_names else ""
-    )
+    agent._kanban_worker_guidance = ""
 
-    # Check tool requirements
-    if agent.tools and not agent.quiet_mode:
-        requirements = _ra().check_toolset_requirements()
-        missing_reqs = [name for name, available in requirements.items() if not available]
-        if missing_reqs:
-            print(f"⚠️  Some tools may not work due to missing requirements: {missing_reqs}")
-    
     # Show trajectory saving status
     if agent.save_trajectories and not agent.quiet_mode:
         print("📝 Trajectory saving enabled")
@@ -1873,9 +1860,6 @@ def init_agent(
         except Exception as _mpe:
             _ra().logger.warning("Memory provider plugin init failed: %s", _mpe)
             agent._memory_manager = None
-
-    from agent.memory_manager import inject_memory_provider_tools as _inject_memory_provider_tools
-    _inject_memory_provider_tools(agent)
 
     # Skills config: nudge interval for skill creation reminders
     agent._skill_nudge_interval = 10
@@ -2736,56 +2720,86 @@ def init_agent(
         except Exception:
             pass
 
-    # Inject context engine tool schemas (e.g. lcm_grep, lcm_describe, lcm_expand).
-    # Skip names that are already present — the _ra().get_tool_definitions()
-    # quiet_mode cache returned a shared list pre-#17335, so a stray
-    # mutation here would poison subsequent agent inits in the same
-    # Gateway process and trip provider-side 'duplicate tool name'
-    # errors. Even with the cache fix, dedup is the right defense
-    # against plugin paths that may register the same schemas via
-    # ctx.register_tool(). Mirrors the memory tools dedup above.
-    #
-    # Respect the platform's enabled_toolsets configuration (#5544):
-    # context engine tools follow the same gating pattern as memory
-    # provider tools — without the gate, `platform_toolsets: telegram: []`
-    # would still leak lcm_* tools into the tool surface and incur the
-    # same local-model latency penalty.
-    agent._context_engine_tool_names: set = set()
-    if (
-        hasattr(agent, "context_compressor")
-        and agent.context_compressor
-        and agent.tools is not None
-        and (
-            agent.enabled_toolsets is None
-            or "context_engine" in agent.enabled_toolsets
+    # Finalize registry + external memory/context schemas through one shared
+    # path, then publish the complete model-facing snapshot.
+    agent._memory_provider_tool_names = set()
+    agent._context_engine_tool_names = set()
+    try:
+        from tools.mcp_tool import refresh_agent_mcp_tools
+
+        refresh_agent_mcp_tools(
+            agent,
+            quiet_mode=agent.quiet_mode,
+            get_tool_definitions_fn=_ra().get_tool_definitions,
         )
+    except Exception as _surface_error:
+        _ra().logger.warning(
+            "Fresh tool-surface resolution failed; using the startup catalog: %s",
+            _surface_error,
+        )
+        from agent.tool_surface import (
+            AgentToolSurfaceSnapshot,
+            assemble_agent_tool_surface,
+            publish_agent_tool_surface_for_generation,
+        )
+
+        _fallback_surface = assemble_agent_tool_surface(
+            agent,
+            _base_tool_defs,
+            quiet_mode=agent.quiet_mode,
+            toolset_selection=(enabled_toolsets, disabled_toolsets),
+        )
+        _published_fallback = publish_agent_tool_surface_for_generation(
+            agent,
+            _fallback_surface.tool_defs,
+            memory_provider_tool_names=_fallback_surface.injected_names["memory"],
+            context_engine_tool_names=_fallback_surface.injected_names[
+                "context_engine"
+            ],
+            catalog_tool_defs=_fallback_surface.pre_assembly_tool_defs,
+            deferred_tool_names=_fallback_surface.deferred_names,
+            expected_registry_generation=agent._tool_snapshot_generation,
+            selection_revision=agent._tool_selection_revision,
+            enabled_toolsets=enabled_toolsets,
+            disabled_toolsets=disabled_toolsets,
+        )
+        if _published_fallback is None:
+            raise RuntimeError(
+                "Tool registry changed while recovering agent initialization"
+            ) from _surface_error
+    from agent.prompt_builder import KANBAN_GUIDANCE
+    from agent.tool_surface import AgentToolSurfaceSnapshot
+
+    if not isinstance(
+        getattr(agent, "_tool_surface_snapshot", None),
+        AgentToolSurfaceSnapshot,
     ):
-        _existing_tool_names = {
-            t.get("function", {}).get("name")
-            for t in agent.tools
-            if isinstance(t, dict)
-        }
-        from agent.memory_manager import normalize_tool_schema as _normalize_tool_schema
-        for _raw_schema in agent.context_compressor.get_tool_schemas():
-            _schema = _normalize_tool_schema(_raw_schema)
-            if _schema is None:
-                # A schema with no resolvable name (e.g. an already-wrapped
-                # entry) would append a nameless tool that strict providers
-                # 400 on, disabling the whole toolset (#47707). Skip it.
-                _ra().logger.warning(
-                    "Context engine returned a tool schema with no resolvable "
-                    "name; skipping to avoid poisoning the request (%r)",
-                    _raw_schema,
+        raise RuntimeError(
+            "Tool registry changed continuously during agent initialization"
+        )
+    agent._kanban_worker_guidance = (
+        KANBAN_GUIDANCE if "kanban_show" in agent.valid_tool_names else ""
+    )
+
+    if not agent.quiet_mode:
+        if agent.tools:
+            tool_names = sorted(agent.valid_tool_names)
+            print(f"🛠️  Loaded {len(agent.tools)} tools: {', '.join(tool_names)}")
+            if enabled_toolsets:
+                print(f"   ✅ Enabled toolsets: {', '.join(enabled_toolsets)}")
+            if disabled_toolsets:
+                print(f"   ❌ Disabled toolsets: {', '.join(disabled_toolsets)}")
+            requirements = _ra().check_toolset_requirements()
+            missing_reqs = [
+                name for name, available in requirements.items() if not available
+            ]
+            if missing_reqs:
+                print(
+                    "⚠️  Some tools may not work due to missing requirements: "
+                    f"{missing_reqs}"
                 )
-                continue
-            _tname = _schema["name"]
-            if _tname in _existing_tool_names:
-                continue  # already registered via plugin/cache path
-            _wrapped = {"type": "function", "function": _schema}
-            agent.tools.append(_wrapped)
-            agent.valid_tool_names.add(_tname)
-            agent._context_engine_tool_names.add(_tname)
-            _existing_tool_names.add(_tname)
+        else:
+            print("🛠️  No tools loaded (all tools filtered out or unavailable)")
 
     # Notify context engine of session start
     if hasattr(agent, "context_compressor") and agent.context_compressor:

--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -107,7 +107,9 @@ def agent_runtime_owns_post_tool_hook(agent: Any, function_name: str) -> bool:
     """Return True when an agent-level tool path emits its own post hook."""
     if function_name in AGENT_RUNTIME_POST_HOOK_TOOL_NAMES:
         return True
-    if getattr(agent, "_context_engine_tool_names", None) and function_name in agent._context_engine_tool_names:
+    from agent.tool_surface import get_agent_tool_surface
+
+    if function_name in get_agent_tool_surface(agent).context_engine_tool_names:
         return True
     memory_manager = getattr(agent, "_memory_manager", None)
     return bool(memory_manager and memory_manager.has_tool(function_name))
@@ -3040,15 +3042,29 @@ def invoke_tool(agent, function_name: str, function_args: dict, effective_task_i
                  pre_tool_block_checked: bool = False,
                  skip_tool_request_middleware: bool = False,
                  tool_request_middleware_trace: Optional[List[Dict[str, Any]]] = None,
-                 skip_tool_execution_middleware: bool = False) -> str:
+                 skip_tool_execution_middleware: bool = False,
+                 tool_surface=None) -> str:
     """Invoke a single tool and return the result string. No display logic.
 
     Handles both agent-level tools (todo, memory, etc.) and registry-dispatched
     tools. Used by the concurrent execution path; the sequential path retains
     its own inline invocation for backward-compatible display handling.
     """
+    from agent.tool_surface import (
+        get_agent_tool_surface,
+        tool_surface_registration_error,
+    )
+
+    execution_surface = tool_surface or get_agent_tool_surface(agent)
     if not isinstance(function_args, dict):
         function_args = {}
+
+    registration_error = tool_surface_registration_error(
+        execution_surface,
+        function_name,
+    )
+    if registration_error is not None:
+        return json.dumps({"error": registration_error}, ensure_ascii=False)
 
     _tool_middleware_trace = list(tool_request_middleware_trace or [])
     try:
@@ -3179,8 +3195,8 @@ def invoke_tool(agent, function_name: str, function_args: dict, effective_task_i
             # Mirror successful built-in memory writes to external providers.
             # All gating/op-expansion lives behind the manager interface
             # (MemoryManager.notify_memory_tool_write).
-            if agent._memory_manager:
-                agent._memory_manager.notify_memory_tool_write(
+            if execution_surface.memory_manager:
+                execution_surface.memory_manager.notify_memory_tool_write(
                     result,
                     next_args,
                     build_metadata=lambda: agent._build_memory_write_metadata(
@@ -3189,9 +3205,17 @@ def invoke_tool(agent, function_name: str, function_args: dict, effective_task_i
                     ),
                 )
             return _finish_agent_tool(result, next_args)
-    elif agent._memory_manager and agent._memory_manager.has_tool(function_name):
+    elif (
+        execution_surface.memory_manager
+        and function_name in execution_surface.memory_provider_tool_names
+    ):
         def _execute(next_args: dict) -> Any:
-            return _finish_agent_tool(agent._memory_manager.handle_tool_call(function_name, next_args), next_args)
+            return _finish_agent_tool(
+                execution_surface.memory_manager.handle_tool_call(
+                    function_name, next_args
+                ),
+                next_args,
+            )
     elif function_name == "clarify":
         def _execute(next_args: dict) -> Any:
             from tools.clarify_tool import clarify_tool as _clarify_tool
@@ -3267,19 +3291,38 @@ def invoke_tool(agent, function_name: str, function_args: dict, effective_task_i
             )
     elif function_name == "delegate_task":
         def _execute(next_args: dict) -> Any:
-            return _finish_agent_tool(agent._dispatch_delegate_task(next_args), next_args)
+            return _finish_agent_tool(
+                agent._dispatch_delegate_task(
+                    next_args, tool_surface=execution_surface
+                ),
+                next_args,
+            )
     else:
         def _execute(next_args: dict) -> Any:
-            dispatch_kwargs = dict(
+            dispatch_kwargs: Dict[str, Any] = dict(
                 tool_call_id=tool_call_id,
                 session_id=agent.session_id or "",
                 turn_id=getattr(agent, "_current_turn_id", "") or "",
                 api_request_id=getattr(agent, "_current_api_request_id", "") or "",
-                enabled_tools=list(agent.valid_tool_names) if agent.valid_tool_names else None,
+                enabled_tools=(
+                    list(execution_surface.valid_tool_names)
+                    if execution_surface.valid_tool_names
+                    else None
+                ),
                 skip_pre_tool_call_hook=True,
                 skip_tool_request_middleware=True,
-                enabled_toolsets=getattr(agent, "enabled_toolsets", None),
-                disabled_toolsets=getattr(agent, "disabled_toolsets", None),
+                enabled_toolsets=(
+                    list(execution_surface.enabled_toolsets)
+                    if execution_surface.enabled_toolsets is not None
+                    else None
+                ),
+                disabled_toolsets=(
+                    list(execution_surface.disabled_toolsets)
+                    if execution_surface.disabled_toolsets is not None
+                    else None
+                ),
+                catalog_tool_defs=list(execution_surface.catalog_tool_defs),
+                expected_registry_entries=dict(execution_surface.registry_entries),
                 tool_request_middleware_trace=list(_tool_middleware_trace),
             )
             if skip_tool_execution_middleware:
@@ -3310,7 +3353,11 @@ def invoke_tool(agent, function_name: str, function_args: dict, effective_task_i
 
 
 
-def repair_tool_call(agent, tool_name: str) -> str | None:
+def repair_tool_call(
+    agent,
+    tool_name: str,
+    valid_tool_names=None,
+) -> str | None:
     """Attempt to repair a mismatched tool name before aborting.
 
     Models sometimes emit variants of a tool name that differ only
@@ -3333,6 +3380,11 @@ def repair_tool_call(agent, tool_name: str) -> str | None:
     """
     import re
     from difflib import get_close_matches
+
+    if valid_tool_names is None:
+        from agent.tool_surface import get_agent_tool_surface
+
+        valid_tool_names = get_agent_tool_surface(agent).valid_tool_names
 
     if not tool_name:
         return None
@@ -3373,10 +3425,10 @@ def repair_tool_call(agent, tool_name: str) -> str | None:
 
     # Cheap fast-paths first — these cover the common case.
     lowered = tool_name.lower()
-    if lowered in agent.valid_tool_names:
+    if lowered in valid_tool_names:
         return lowered
     normalized = _norm(tool_name)
-    if normalized in agent.valid_tool_names:
+    if normalized in valid_tool_names:
         return normalized
 
     # Build the full candidate set for class-like emissions.
@@ -3393,11 +3445,11 @@ def repair_tool_call(agent, tool_name: str) -> str | None:
         cands |= extra
 
     for c in cands:
-        if c and c in agent.valid_tool_names:
+        if c and c in valid_tool_names:
             return c
 
     # Fuzzy match as last resort.
-    matches = get_close_matches(lowered, agent.valid_tool_names, n=1, cutoff=0.7)
+    matches = get_close_matches(lowered, valid_tool_names, n=1, cutoff=0.7)
     if matches:
         return matches[0]
 

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -2442,12 +2442,104 @@ def _maybe_wrap_anthropic(
     )
 
 
+def _load_auth_store_snapshot(path: Optional[Path]) -> Dict[str, Any]:
+    """Read one auth store without migration, locking, or persistence."""
+    if path is None or not path.exists():
+        return {}
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8-sig"))
+    except (OSError, UnicodeError, json.JSONDecodeError):
+        return {}
+    return payload if isinstance(payload, dict) else {}
+
+
+def _nous_singleton_from_snapshot(store: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+    providers = store.get("providers")
+    if isinstance(providers, dict):
+        provider = providers.get("nous")
+        if isinstance(provider, dict):
+            return dict(provider)
+    systems = store.get("systems")
+    if isinstance(systems, dict):
+        provider = systems.get("nous_portal")
+        if isinstance(provider, dict):
+            return dict(provider)
+    return None
+
+
+def _nous_auth_has_runtime_material(provider: Dict[str, Any]) -> bool:
+    return any(
+        isinstance(provider.get(key), str) and provider[key].strip()
+        for key in ("agent_key", "access_token", "refresh_token")
+    )
+
+
+def _read_nous_auth_snapshot() -> Optional[Dict[str, Any]]:
+    """Project persisted Nous credentials without changing auth state."""
+    try:
+        from hermes_cli.auth import _auth_file_path, _global_auth_file_path
+
+        local_store = _load_auth_store_snapshot(_auth_file_path())
+        global_store = _load_auth_store_snapshot(_global_auth_file_path())
+    except Exception:
+        local_store = _load_auth_store_snapshot(get_hermes_home() / "auth.json")
+        global_store = {}
+
+    local_pool_store = local_store.get("credential_pool")
+    global_pool_store = global_store.get("credential_pool")
+    local_pool = (
+        local_pool_store.get("nous", [])
+        if isinstance(local_pool_store, dict)
+        else []
+    )
+    global_pool = (
+        global_pool_store.get("nous", [])
+        if isinstance(global_pool_store, dict)
+        else []
+    )
+    pool_entries = local_pool if isinstance(local_pool, list) and local_pool else global_pool
+    if isinstance(pool_entries, list):
+        indexed_entries = [
+            (index, entry)
+            for index, entry in enumerate(pool_entries)
+            if isinstance(entry, dict)
+        ]
+
+        def _priority(item: Tuple[int, Dict[str, Any]]) -> Tuple[int, int]:
+            index, entry = item
+            try:
+                return int(entry.get("priority", index)), index
+            except (TypeError, ValueError):
+                return index, index
+
+        for _, entry in sorted(indexed_entries, key=_priority):
+            if str(entry.get("last_status") or "").lower() == "dead":
+                continue
+            provider = dict(entry)
+            if _nous_auth_has_runtime_material(provider):
+                return provider
+
+    for store in (local_store, global_store):
+        provider = _nous_singleton_from_snapshot(store)
+        if provider is not None and _nous_auth_has_runtime_material(provider):
+            return provider
+    return None
+
+
 def _read_nous_auth() -> Optional[dict]:
     """Read and validate ~/.hermes/auth.json for an active Nous provider.
 
     Returns the provider state dict if Nous is active with tokens,
     otherwise None.
     """
+    try:
+        from tools.registry import is_read_only_tool_inspection
+
+        if is_read_only_tool_inspection():
+            return _read_nous_auth_snapshot()
+    except Exception:
+        pass
+
     pool_present, entry = _select_pool_entry("nous")
     if pool_present:
         if entry is None:
@@ -2564,6 +2656,28 @@ def _resolve_nous_runtime_api(*, force_refresh: bool = False) -> Optional[tuple[
     relying only on whatever raw tokens happen to be sitting in auth.json
     or the credential pool.
     """
+    if _aux_probe_active():
+        try:
+            from tools.registry import is_read_only_tool_inspection
+
+            read_only_probe = is_read_only_tool_inspection()
+        except Exception:
+            read_only_probe = False
+        if read_only_probe:
+            provider = _read_nous_auth()
+            if provider is None:
+                return None
+            has_runtime_material = bool(
+                _nous_api_key(provider)
+                or str(provider.get("refresh_token") or "").strip()
+            )
+            base_url = str(
+                provider.get("inference_base_url") or _nous_base_url()
+            ).strip().rstrip("/")
+            if not has_runtime_material or not base_url:
+                return None
+            return "<read-only-probe>", base_url
+
     pooled = _resolve_nous_pool_runtime_api(force_refresh=force_refresh)
     if pooled is not None:
         return pooled

--- a/agent/background_review.py
+++ b/agent/background_review.py
@@ -1017,6 +1017,9 @@ def _run_review_in_thread(
                     _pref_val = getattr(agent, _pref_attr, None)
                     if _pref_val:
                         _fork_kwargs[_pref_attr] = _pref_val
+            from agent.tool_surface import get_agent_tool_surface
+
+            tool_surface = get_agent_tool_surface(agent)
             review_agent = AIAgent(
                 model=_rt.get("model") or agent.model,
                 max_iterations=_REVIEW_MAX_ITERATIONS,
@@ -1029,8 +1032,16 @@ def _run_review_in_thread(
                 credential_pool=_rt.get("credential_pool"),
                 request_overrides=_rt.get("request_overrides") or {},
                 parent_session_id=agent.session_id,
-                enabled_toolsets=getattr(agent, "enabled_toolsets", None),
-                disabled_toolsets=getattr(agent, "disabled_toolsets", None),
+                enabled_toolsets=(
+                    list(tool_surface.enabled_toolsets)
+                    if tool_surface.enabled_toolsets is not None
+                    else None
+                ),
+                disabled_toolsets=(
+                    list(tool_surface.disabled_toolsets)
+                    if tool_surface.disabled_toolsets is not None
+                    else None
+                ),
                 skip_memory=True,
                 **_fork_kwargs,
             )

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -1825,7 +1825,13 @@ def interruptible_api_call(agent, api_kwargs: dict):
 def build_api_kwargs(agent, api_messages: list, tools_for_api: list | None = None) -> dict:
     """Build the keyword arguments dict for the active API mode."""
     if tools_for_api is None:
-        tools_for_api = agent.tools
+        import copy as _copy
+
+        from agent.tool_surface import get_agent_tool_surface
+
+        tools_for_api = _copy.deepcopy(
+            list(get_agent_tool_surface(agent).tool_defs)
+        )
 
     if agent.api_mode == "anthropic_messages":
         _transport = agent._get_transport()
@@ -1911,14 +1917,11 @@ def build_api_kwargs(agent, api_messages: list, tools_for_api: list | None = Non
         # like ``Qwen/Qwen3.5-0.8B`` shipped by MCP servers) — same 400 with
         # the same opaque message; strip those enums too.
         #
-        # Deep-copy ``tools_for_api`` before sanitizing: the sanitizers
+        # Deep-copy ``tools_for_api`` before sanitizing because the sanitizers
         # mutate in place (documented contract on ``strip_slash_enum`` /
-        # ``strip_pattern_and_format``), and ``tools_for_api`` is a direct
-        # reference to ``agent.tools``.  Without the copy, the first xAI
-        # request permanently strips constraints from the shared per-agent
-        # tool registry — every subsequent non-xAI call from the same
-        # agent (auxiliary task routed to Anthropic, OpenRouter fallback,
-        # main-model swap) sees the already-stripped schema.  See #27907.
+        # ``strip_pattern_and_format``). Keep provider transformations on a
+        # request-local copy so the atomically published surface stays stable.
+        # See #27907.
         if is_xai_responses:
             try:
                 import copy as _copy

--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -882,11 +882,13 @@ def run_codex_app_server_turn(
 
     # Now check the skill nudge AFTER iters were incremented — same
     # pattern the chat_completions path uses (line ~15432).
+    from agent.tool_surface import get_agent_tool_surface
+
     should_review_skills = False
     if (
         agent._skill_nudge_interval > 0
         and agent._iters_since_skill >= agent._skill_nudge_interval
-        and "skill_manage" in agent.valid_tool_names
+        and "skill_manage" in get_agent_tool_surface(agent).valid_tool_names
     ):
         should_review_skills = True
         agent._iters_since_skill = 0

--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -3855,10 +3855,12 @@ def compress_context(
         # Keep the post-compression rough estimate for diagnostics, but do not
         # treat it as provider-reported prompt usage. Schema-heavy rough estimates
         # can remain above threshold even after the next real API request fits.
+        from agent.tool_surface import get_agent_tool_surface
+
         _compressed_est = estimate_request_tokens_rough(
             compressed,
             system_prompt=new_system_prompt or "",
-            tools=agent.tools or None,
+            tools=list(get_agent_tool_surface(agent).tool_defs) or None,
         )
         agent.context_compressor.last_compression_rough_tokens = _compressed_est
         agent.context_compressor.last_prompt_tokens = -1

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -17,12 +17,14 @@ resolved through :func:`_ra` so those patches keep working.
 from __future__ import annotations
 
 import json
+import inspect
 import logging
 import os
 import random
 import re
 import ssl
 import time
+from copy import deepcopy
 from typing import Any, Dict, List, Optional
 
 from agent.codex_responses_adapter import _summarize_user_message_for_log
@@ -482,6 +484,22 @@ def _ra():
     """
     import run_agent
     return run_agent
+
+
+def _executor_supports_tool_surface(executor: Any) -> bool:
+    """Preserve legacy/test overrides while pinning native request dispatch."""
+    candidate = getattr(executor, "side_effect", None)
+    if not callable(candidate):
+        candidate = executor
+    try:
+        parameters = inspect.signature(candidate).parameters.values()
+    except (TypeError, ValueError):
+        return True
+    return any(
+        parameter.name == "tool_surface"
+        or parameter.kind is inspect.Parameter.VAR_KEYWORD
+        for parameter in parameters
+    )
 
 
 def _nous_entitlement_message(capability: str) -> str:
@@ -1986,8 +2004,10 @@ def run_conversation(
 
         # Track tool-calling iterations for skill nudge.
         # Counter resets whenever skill_manage is actually used.
+        from agent.tool_surface import get_agent_tool_surface
+
         if (agent._skill_nudge_interval > 0
-                and "skill_manage" in agent.valid_tool_names):
+                and "skill_manage" in get_agent_tool_surface(agent).valid_tool_names):
             agent._iters_since_skill += 1
         
         # ── Pre-API-call /steer drain ──────────────────────────────────
@@ -2415,7 +2435,12 @@ def run_conversation(
         # exactly the point the breakpoints were meant to protect. Marking
         # last also keeps breakpoints off messages that the orphan sweep or
         # the thinking-only drop is about to remove or merge away.
-        tools_for_api = agent.tools
+        _request_tool_surface = get_agent_tool_surface(agent)
+        tools_for_api = deepcopy(list(_request_tool_surface.tool_defs))
+        if getattr(agent, "_strip_tool_schema_patterns", False):
+            from tools.schema_sanitizer import strip_pattern_and_format
+
+            tools_for_api, _ = strip_pattern_and_format(tools_for_api)
         if agent._use_prompt_caching and agent.provider != "moa":
             _static_system_prefix = getattr(agent, "_cached_system_prompt_static", None)
             _initial_cache_plan = build_prompt_cache_plan(
@@ -2469,7 +2494,7 @@ def run_conversation(
         # total_chars is a rough (~) proxy — verbose log + hook metric only.
         approx_tokens = estimate_messages_tokens_rough(api_messages)
         request_pressure_tokens = approx_tokens + (
-            _estimate_tools_tokens_rough(agent.tools) if agent.tools else 0
+            _estimate_tools_tokens_rough(tools_for_api) if tools_for_api else 0
         )
         total_chars = approx_tokens * 4
         # Stash this request's rough estimate so update_from_response() can
@@ -2705,7 +2730,7 @@ def run_conversation(
         if not agent.quiet_mode:
             agent._vprint(f"\n{agent.log_prefix}🔄 Making API call #{api_call_count}/{agent.max_iterations}...")
             agent._vprint(f"{agent.log_prefix}   📊 Request size: {len(api_messages)} messages, ~{approx_tokens:,} tokens (~{total_chars:,} chars)")
-            agent._vprint(f"{agent.log_prefix}   🔧 Available tools: {len(agent.tools) if agent.tools else 0}")
+            agent._vprint(f"{agent.log_prefix}   🔧 Available tools: {len(tools_for_api or [])}")
         else:
             # Animated thinking spinner in quiet mode
             face = random.choice(KawaiiSpinner.get_thinking_faces())
@@ -2723,7 +2748,7 @@ def run_conversation(
         
         # Log request details if verbose
         if agent.verbose_logging:
-            logging.debug(f"API Request - Model: {agent.model}, Messages: {len(messages)}, Tools: {len(agent.tools) if agent.tools else 0}")
+            logging.debug(f"API Request - Model: {agent.model}, Messages: {len(messages)}, Tools: {len(tools_for_api or [])}")
             logging.debug(f"Last message role: {messages[-1]['role'] if messages else 'none'}")
             logging.debug(f"Total message size: ~{approx_tokens:,} tokens")
         
@@ -2813,13 +2838,10 @@ def run_conversation(
                         tools_for_api=tools_for_api,
                     )
                 )
-                if tools_for_api == agent.tools:
-                    api_kwargs = agent._build_api_kwargs(api_messages)
-                else:
-                    api_kwargs = agent._build_api_kwargs(
-                        api_messages,
-                        tools_for_api=tools_for_api,
-                    )
+                api_kwargs = agent._build_api_kwargs(
+                    api_messages,
+                    tools_for_api=tools_for_api,
+                )
                 # Outbound-request surrogate chokepoint (#50959): the messages
                 # were scrubbed above, but the rest of the request body —
                 # tool/function descriptions (session_search's ±-heavy text is
@@ -2925,7 +2947,7 @@ def run_conversation(
                             else [],
                             system_prompt=system_prompt_for_hooks,
                             message_count=len(api_messages),
-                            tool_count=len(agent.tools or []),
+                            tool_count=len(tools_for_api or []),
                             approx_input_tokens=approx_tokens,
                             request_char_count=total_chars,
                             max_tokens=agent.max_tokens,
@@ -4379,8 +4401,8 @@ def run_conversation(
                             _prefill_sanitized = _sanitize_messages_non_ascii(agent.prefill_messages)
 
                         _tools_sanitized = False
-                        if isinstance(getattr(agent, "tools", None), list):
-                            _tools_sanitized = _sanitize_tools_non_ascii(agent.tools)
+                        if isinstance(tools_for_api, list):
+                            _tools_sanitized = _sanitize_tools_non_ascii(tools_for_api)
 
                         _system_sanitized = False
                         if isinstance(active_system_prompt, str):
@@ -4958,8 +4980,9 @@ def run_conversation(
                 # regex escape classes (``\d``, ``\w``, ``\s``) and most
                 # ``format`` values in tool schemas.  MCP servers emit
                 # these routinely for date/phone/email params.  Recovery:
-                # strip ``pattern``/``format`` from ``agent.tools`` and
-                # retry once.  We keep the keywords by default so cloud
+                # strip ``pattern``/``format`` from this request's tools and
+                # retain that provider-compatibility mode for the session. We
+                # keep the keywords by default so cloud
                 # providers get the full prompting hints; this branch
                 # fires only for users on llama.cpp's OAI server.
                 if (
@@ -4969,7 +4992,9 @@ def run_conversation(
                     _retry.llama_cpp_grammar_retry_attempted = True
                     try:
                         from tools.schema_sanitizer import strip_pattern_and_format
-                        _, _stripped = strip_pattern_and_format(agent.tools)
+                        tools_for_api, _stripped = strip_pattern_and_format(
+                            tools_for_api
+                        )
                     except Exception as _strip_exc:  # pragma: no cover — defensive
                         logger.warning(
                             "%sllama.cpp grammar recovery: strip helper failed: %s",
@@ -4977,6 +5002,7 @@ def run_conversation(
                         )
                         _stripped = 0
                     if _stripped:
+                        agent._strip_tool_schema_patterns = True
                         agent._vprint(
                             f"{agent.log_prefix}⚠️  llama.cpp rejected tool schema grammar — "
                             f"stripped {_stripped} pattern/format keyword(s), retrying...",
@@ -5208,7 +5234,7 @@ def run_conversation(
                         # the true request (msgs + tools + system), not the tool-blind message count.
                         messages, active_system_prompt = agent._compress_context(
                             messages, system_message,
-                            approx_tokens=estimate_request_tokens_rough(api_messages, tools=agent.tools or None),
+                            approx_tokens=estimate_request_tokens_rough(api_messages, tools=tools_for_api or None),
                             task_id=effective_task_id,
                         )
                         conversation_history = conversation_history_after_compression(
@@ -5477,7 +5503,7 @@ def run_conversation(
                     # true request (msgs + tools + system), not the tool-blind message count.
                     messages, active_system_prompt = agent._compress_context(
                         messages, system_message,
-                        approx_tokens=estimate_request_tokens_rough(api_messages, tools=agent.tools or None),
+                        approx_tokens=estimate_request_tokens_rough(api_messages, tools=tools_for_api or None),
                         task_id=effective_task_id,
                     )
                     if messages is _overflow_input and compression_skipped_due_to_lock(agent):
@@ -5574,7 +5600,7 @@ def run_conversation(
                         # messages.  Use the smaller budget and apply a small
                         # safety margin.  Do not alter context_length.
                         request_input_estimate = estimate_request_tokens_rough(
-                            api_messages, tools=agent.tools or None,
+                            api_messages, tools=tools_for_api or None,
                         )
                         local_available_out = old_ctx - request_input_estimate
                         if local_available_out > 0:
@@ -5778,7 +5804,7 @@ def run_conversation(
                     # _should_force_overflow_recovery. (approx_tokens stays for the status display.)
                     messages, active_system_prompt = agent._compress_context(
                         messages, system_message,
-                        approx_tokens=estimate_request_tokens_rough(api_messages, tools=agent.tools or None),
+                        approx_tokens=estimate_request_tokens_rough(api_messages, tools=tools_for_api or None),
                         task_id=effective_task_id,
                     )
                     if messages is _overflow_input and compression_skipped_due_to_lock(agent):
@@ -6837,15 +6863,19 @@ def run_conversation(
 
                 # Validate tool call names - detect model hallucinations
                 # Repair mismatched tool names before validating
+                _valid_tool_names = _request_tool_surface.valid_tool_names
                 for tc in assistant_message.tool_calls:
-                    if tc.function.name not in agent.valid_tool_names:
-                        repaired = agent._repair_tool_call(tc.function.name)
+                    if tc.function.name not in _valid_tool_names:
+                        repaired = agent._repair_tool_call(
+                            tc.function.name,
+                            _valid_tool_names,
+                        )
                         if repaired:
                             print(f"{agent.log_prefix}🔧 Auto-repaired tool name: '{tc.function.name}' -> '{repaired}'")
                             tc.function.name = repaired
                 invalid_tool_calls = [
                     tc.function.name for tc in assistant_message.tool_calls
-                    if tc.function.name not in agent.valid_tool_names
+                    if tc.function.name not in _valid_tool_names
                 ]
                 # Mixed batch: at least one valid call alongside the invalid
                 # one(s). Degrading models (observed with gpt-5.6 at very
@@ -6859,7 +6889,7 @@ def run_conversation(
                 # model still halts at 3 while a mostly-coherent one keeps
                 # working.
                 _mixed_invalid_batch = bool(invalid_tool_calls) and any(
-                    tc.function.name in agent.valid_tool_names
+                    tc.function.name in _valid_tool_names
                     for tc in assistant_message.tool_calls
                 )
                 if _mixed_invalid_batch:
@@ -6868,7 +6898,7 @@ def run_conversation(
                     invalid_preview = invalid_name[:80] + "..." if len(invalid_name) > 80 else invalid_name
                     _n_valid = sum(
                         1 for tc in assistant_message.tool_calls
-                        if tc.function.name in agent.valid_tool_names
+                        if tc.function.name in _valid_tool_names
                     )
                     agent._buffer_vprint(
                         f"⚠️  Unknown tool '{invalid_preview}' in batch — erroring that call, "
@@ -6907,11 +6937,11 @@ def run_conversation(
                     append_message(messages, assistant_msg)
                     for tc in assistant_message.tool_calls:
                         _tc_name = tc.function.name
-                        if _tc_name not in agent.valid_tool_names:
+                        if _tc_name not in _valid_tool_names:
                             # See _invalid_tool_name_error_content for the
                             # blank-name anti-priming rationale (#47967).
                             content = _invalid_tool_name_error_content(
-                                _tc_name, agent.valid_tool_names
+                                _tc_name, _valid_tool_names
                             )
                         else:
                             content = "Skipped: another tool call in this turn used an invalid name. Please retry this tool call."
@@ -6945,7 +6975,7 @@ def run_conversation(
                     except json.JSONDecodeError as e:
                         if (
                             _mixed_invalid_batch
-                            and tc.function.name not in agent.valid_tool_names
+                            and tc.function.name not in _valid_tool_names
                         ):
                             # This call never executes — it gets an
                             # invalid-name error result below. Don't let its
@@ -7047,7 +7077,7 @@ def run_conversation(
                 if _mixed_invalid_batch:
                     _invalid_batch_calls = [
                         tc for tc in assistant_message.tool_calls
-                        if tc.function.name not in agent.valid_tool_names
+                        if tc.function.name not in _valid_tool_names
                     ]
 
                 assistant_msg = agent._build_assistant_message(assistant_message, finish_reason)
@@ -7172,12 +7202,12 @@ def run_conversation(
                             "name": tc.function.name,
                             "tool_call_id": tc.id,
                             "content": _invalid_tool_name_error_content(
-                                tc.function.name, agent.valid_tool_names
+                                tc.function.name, _valid_tool_names
                             ),
                         })
                     assistant_message.tool_calls = [
                         tc for tc in assistant_message.tool_calls
-                        if tc.function.name in agent.valid_tool_names
+                        if tc.function.name in _valid_tool_names
                     ]
 
                 _tool_turn_persisted = None
@@ -7234,7 +7264,22 @@ def run_conversation(
                     except Exception:
                         pass
 
-                agent._execute_tool_calls(assistant_message, messages, effective_task_id, api_call_count)
+                _execute_tool_calls = agent._execute_tool_calls
+                if _executor_supports_tool_surface(_execute_tool_calls):
+                    _execute_tool_calls(
+                        assistant_message,
+                        messages,
+                        effective_task_id,
+                        api_call_count,
+                        tool_surface=_request_tool_surface,
+                    )
+                else:
+                    _execute_tool_calls(
+                        assistant_message,
+                        messages,
+                        effective_task_id,
+                        api_call_count,
+                    )
 
                 if getattr(agent, "_incremental_persistence_failed", False):
                     # A tool result could not be made canonical. Do not send
@@ -7321,7 +7366,7 @@ def run_conversation(
                     # estimate misses, which can skip compression
                     # past the configured threshold (#14695).
                     _real_tokens = estimate_request_tokens_rough(
-                        messages, tools=agent.tools or None
+                        messages, tools=tools_for_api or None
                     )
 
                 if (
@@ -7869,7 +7914,7 @@ def run_conversation(
                 _ack_mode = intent_ack_continuation_mode(agent)
                 if (
                     _ack_mode != "off"
-                    and agent.valid_tool_names
+                    and _request_tool_surface.valid_tool_names
                     and codex_ack_continuations < 2
                     and agent._looks_like_codex_intermediate_ack(
                         user_message=user_message,

--- a/agent/system_prompt.py
+++ b/agent/system_prompt.py
@@ -357,6 +357,9 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
     # patch ``run_agent.get_toolset_for_tool`` and similar helpers, so
     # we resolve through ``_ra()`` to honor those patches.
     _r = _ra()
+    from agent.tool_surface import get_agent_tool_surface
+
+    valid_tool_names = set(get_agent_tool_surface(agent).valid_tool_names)
 
     # Resolve the model's context window once so context-file caps can scale
     # to it (dynamic cap — see prompt_builder._dynamic_context_file_max_chars).
@@ -398,7 +401,7 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
     # path is blocked) are not model-family specific.  Gated only by
     # config.yaml ``agent.task_completion_guidance`` (default True) so
     # users who want a leaner prompt can turn it off.
-    if getattr(agent, "_task_completion_guidance", True) and agent.valid_tool_names:
+    if getattr(agent, "_task_completion_guidance", True) and valid_tool_names:
         stable_parts.append(TASK_COMPLETION_GUIDANCE)
 
     # Universal parallel-tool-call guidance.  Tells the model to batch
@@ -409,16 +412,16 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
     # round-trips and the resent-context cost that compounds over a long
     # conversation.  Gated by config.yaml ``agent.parallel_tool_call_guidance``
     # (default True) and only injected when tools are actually loaded.
-    if getattr(agent, "_parallel_tool_call_guidance", True) and agent.valid_tool_names:
+    if getattr(agent, "_parallel_tool_call_guidance", True) and valid_tool_names:
         stable_parts.append(PARALLEL_TOOL_CALL_GUIDANCE)
 
     # Tool-aware behavioral guidance: only inject when the tools are loaded
     tool_guidance = []
-    if "memory" in agent.valid_tool_names:
+    if "memory" in valid_tool_names:
         tool_guidance.append(MEMORY_GUIDANCE)
-    if "session_search" in agent.valid_tool_names:
+    if "session_search" in valid_tool_names:
         tool_guidance.append(SESSION_SEARCH_GUIDANCE)
-    if "skill_manage" in agent.valid_tool_names:
+    if "skill_manage" in valid_tool_names:
         tool_guidance.append(SKILLS_GUIDANCE)
     # Kanban worker/orchestrator lifecycle — only present when the
     # dispatcher spawned this process (kanban_show check_fn gates on
@@ -427,7 +430,7 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
     _kanban_guidance = getattr(agent, "_kanban_worker_guidance", None)
     if _kanban_guidance:
         tool_guidance.append(_kanban_guidance)
-    elif _kanban_guidance is None and "kanban_show" in agent.valid_tool_names:
+    elif _kanban_guidance is None and "kanban_show" in valid_tool_names:
         # Fallback for code paths that bypass agent_init (rare).
         tool_guidance.append(KANBAN_GUIDANCE)
     if tool_guidance:
@@ -435,18 +438,18 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
 
     # Steering only lands inside tool results, so it's only reachable when the
     # agent has tools. Static text → byte-stable prompt (no cache hit).
-    if agent.valid_tool_names:
+    if valid_tool_names:
         stable_parts.append(STEER_CHANNEL_NOTE)
 
     # Computer-use — goes in as its own block rather than being merged into
     # tool_guidance because the content is multi-paragraph. The guidance is
     # rendered for the host platform so Windows/Linux hosts don't see
     # macOS-only wording (Mac, Space, cmd+s).
-    if "computer_use" in agent.valid_tool_names:
+    if "computer_use" in valid_tool_names:
         from agent.prompt_builder import computer_use_guidance
         stable_parts.append(computer_use_guidance())
 
-    nous_subscription_prompt = _r.build_nous_subscription_prompt(agent.valid_tool_names)
+    nous_subscription_prompt = _r.build_nous_subscription_prompt(valid_tool_names)
     if nous_subscription_prompt:
         stable_parts.append(nous_subscription_prompt)
     # Tool-use enforcement: tells the model to actually call tools instead
@@ -456,7 +459,7 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
     #   true  — always inject (all models)
     #   false — never inject
     #   list  — custom model-name substrings to match
-    if agent.valid_tool_names:
+    if valid_tool_names:
         _enforce = agent._tool_use_enforcement
         _inject = False
         if _enforce is True or (isinstance(_enforce, str) and _enforce.lower() in {"true", "always", "yes", "on"}):
@@ -485,12 +488,12 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
             if "gpt" in _model_lower or "codex" in _model_lower or "grok" in _model_lower:
                 stable_parts.append(OPENAI_MODEL_EXECUTION_GUIDANCE)
 
-    has_skills_tools = any(name in agent.valid_tool_names for name in ['skills_list', 'skill_view', 'skill_manage'])
+    has_skills_tools = any(name in valid_tool_names for name in ['skills_list', 'skill_view', 'skill_manage'])
     if has_skills_tools:
         avail_toolsets = {
             toolset
             for toolset in (
-                _r.get_toolset_for_tool(tool_name) for tool_name in agent.valid_tool_names
+                _r.get_toolset_for_tool(tool_name) for tool_name in valid_tool_names
             )
             if toolset
         }
@@ -508,7 +511,7 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
         except Exception:
             _compact_cats = frozenset()
         skills_prompt = _r.build_skills_system_prompt(
-            available_tools=agent.valid_tool_names,
+            available_tools=valid_tool_names,
             available_toolsets=avail_toolsets,
             compact_categories=_compact_cats or None,
             skills_dir_override=_agent_skills_dir(agent),
@@ -544,7 +547,7 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
     # stay in their historical position after the workspace snapshot.
     coding_workspace_parts: List[str] = []
     coding_trailing_parts: List[str] = []
-    if agent.valid_tool_names:
+    if valid_tool_names:
         try:
             from agent.coding_context import coding_system_prompt_parts
 
@@ -963,12 +966,15 @@ def format_tools_for_system_message(agent: Any) -> str:
     Returns:
         str: JSON string representation of tool definitions
     """
-    if not agent.tools:
+    from agent.tool_surface import get_agent_tool_surface
+
+    tool_defs = get_agent_tool_surface(agent).tool_defs
+    if not tool_defs:
         return "[]"
 
     # Convert tool definitions to the format expected in trajectories
     formatted_tools = []
-    for tool in agent.tools:
+    for tool in tool_defs:
         func = tool["function"]
         formatted_tool = {
             "name": func["name"],

--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -253,6 +253,7 @@ def _tool_search_scoped_names(agent) -> frozenset:
             disabled_toolsets=disabled,
             quiet_mode=True,
             skip_tool_search_assembly=True,
+            record_resolved_names=False,
         ) or []
         names = _ts.scoped_deferrable_names(scoped_defs)
     except Exception:

--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -329,54 +329,12 @@ def _emit_cancelled_terminal_post_tool_call(
     return result
 
 
-def _tool_search_scoped_names(agent) -> frozenset:
-    """Return the deferrable tool names the session may invoke via tool_call.
+def _tool_search_scoped_names(agent, tool_surface=None) -> frozenset:
+    """Return deferrable names from the request's pinned catalog."""
+    from agent.tool_surface import get_agent_tool_surface
 
-    The Tool Search unwrap dispatches the underlying tool directly, bypassing
-    the bridge branch (and its scope check) in
-    ``model_tools.handle_function_call``. To keep a restricted-toolset session
-    (subagent, kanban worker, curated gateway session) from reaching tools it
-    was never granted, the unwrap validates the underlying name against this
-    set: the deferrable subset of the session's own enabled/disabled toolset
-    scope.
-
-    Result is cached on the agent and refreshed when the tool registry's
-    generation changes (e.g. an MCP server reconnects), so the common case is
-    a dict lookup, not a full tool-defs rebuild on every tool call.
-    """
-    try:
-        import model_tools
-        from tools import tool_search as _ts
-        from tools.registry import registry as _registry
-    except Exception:
-        return frozenset()
-
-    enabled = getattr(agent, "enabled_toolsets", None)
-    disabled = getattr(agent, "disabled_toolsets", None)
-    cache_key = (
-        _registry.current_scope_key(),
-        getattr(_registry, "_generation", 0),
-        frozenset(enabled) if enabled is not None else None,
-        frozenset(disabled) if disabled is not None else None,
-    )
-    cached = getattr(agent, "_tool_search_scope_cache", None)
-    if cached is not None and cached[0] == cache_key:
-        return cached[1]
-    try:
-        scoped_defs = model_tools.get_tool_definitions(
-            enabled_toolsets=enabled,
-            disabled_toolsets=disabled,
-            quiet_mode=True,
-            skip_tool_search_assembly=True,
-        ) or []
-        names = _ts.scoped_deferrable_names(scoped_defs)
-    except Exception:
-        names = frozenset()
-    try:
-        agent._tool_search_scope_cache = (cache_key, names)
-    except Exception:
-        pass
-    return names
+    surface = tool_surface or get_agent_tool_surface(agent)
+    return surface.deferred_tool_names
 
 
 @dataclass
@@ -552,6 +510,15 @@ def _run_agent_tool_execution_middleware(
     authorization_gate: _ConcurrentToolAuthorizationGate | None = None,
 ) -> _ManagedToolResult:
     """Run Relay rewrites before Hermes policy and dispatch exactly once."""
+    if scope_block is not None:
+        return _ManagedToolResult(
+            result=json.dumps({"error": scope_block}, ensure_ascii=False),
+            args=function_args,
+            middleware_trace=list(middleware_trace or []),
+            blocked=True,
+            dispatched=False,
+        )
+
     from agent import relay_tools
     from hermes_cli.middleware import (
         apply_tool_request_middleware,
@@ -1045,7 +1012,7 @@ def _begin_tool_execution(
             pass
 
 
-def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effective_task_id: str, api_call_count: int = 0, *, finalize: bool = True) -> None:
+def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effective_task_id: str, api_call_count: int = 0, *, finalize: bool = True, tool_surface=None) -> None:
     """Execute multiple tool calls concurrently using a thread pool.
 
     Results are collected in the original tool-call order and appended to
@@ -1057,6 +1024,9 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
     """
     tool_calls = assistant_message.tool_calls
     num_tools = len(tool_calls)
+    from agent.tool_surface import get_agent_tool_surface
+
+    _execution_tool_surface = tool_surface or get_agent_tool_surface(agent)
 
     # Resolve the context-scaled tool-output budget once per turn (cheap, but
     # avoids rebuilding it per result inside the loop below).
@@ -1138,13 +1108,22 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
         try:
             from tools import tool_search as _ts
             if function_name == _ts.TOOL_CALL_NAME:
-                _underlying, _underlying_args, _err = _ts.resolve_underlying_call(function_args)
+                _underlying, _underlying_args, _err = _ts.resolve_underlying_call(
+                    function_args,
+                    allowed_names=_tool_search_scoped_names(
+                        agent, _execution_tool_surface
+                    ),
+                )
                 if not _err and _underlying:
-                    if _underlying in _tool_search_scoped_names(agent):
+                    if _underlying in _tool_search_scoped_names(agent, _execution_tool_surface):
                         # Probe-validate before unwrapping (ironclaw#5149):
                         # missing required args return the parameter schema
                         # instead of dispatching into an opaque failure.
-                        _probe_err = _ts.validate_deferred_call_args(_underlying, _underlying_args)
+                        _probe_err = _ts.validate_deferred_call_args(
+                            _underlying,
+                            _underlying_args,
+                            list(_execution_tool_surface.catalog_tool_defs),
+                        )
                         if _probe_err is not None:
                             _ts_scope_block = _probe_err
                         else:
@@ -1157,6 +1136,14 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
                         )
         except Exception:
             pass
+
+        if _ts_scope_block is None:
+            from agent.tool_surface import tool_surface_registration_error
+
+            _ts_scope_block = tool_surface_registration_error(
+                _execution_tool_surface,
+                function_name,
+            )
 
         parsed_calls.append(
             (tool_call, function_name, function_args, [], None, _ts_scope_block)
@@ -1327,6 +1314,7 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
                         skip_tool_request_middleware=True,
                         skip_tool_execution_middleware=True,
                         tool_request_middleware_trace=list(middleware_trace),
+                        tool_surface=_execution_tool_surface,
                     )
 
                 managed = _run_agent_tool_execution_middleware(
@@ -1890,7 +1878,7 @@ def _append_cancelled_tool_results(messages: list, tool_calls, *, reason: str) -
         ))
 
 
-def execute_tool_calls_sequential(agent, assistant_message, messages: list, effective_task_id: str, api_call_count: int = 0, *, finalize: bool = True) -> None:
+def execute_tool_calls_sequential(agent, assistant_message, messages: list, effective_task_id: str, api_call_count: int = 0, *, finalize: bool = True, tool_surface=None) -> None:
     """Execute tool calls sequentially (original behavior). Used for single calls or interactive tools.
 
     ``finalize=False`` skips the end-of-batch aggregate budget enforcement
@@ -1899,6 +1887,24 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
     """
     # Resolve the context-scaled tool-output budget once per turn.
     _tool_budget = _budget_for_agent(agent)
+    from agent.tool_surface import get_agent_tool_surface
+
+    _execution_tool_surface = tool_surface or get_agent_tool_surface(agent)
+    _memory_provider_tool_names = (
+        _execution_tool_surface.memory_provider_tool_names
+    )
+    _context_engine_tool_names = _execution_tool_surface.context_engine_tool_names
+    _valid_tool_names = _execution_tool_surface.valid_tool_names
+    _enabled_toolsets = (
+        list(_execution_tool_surface.enabled_toolsets)
+        if _execution_tool_surface.enabled_toolsets is not None
+        else None
+    )
+    _disabled_toolsets = (
+        list(_execution_tool_surface.disabled_toolsets)
+        if _execution_tool_surface.disabled_toolsets is not None
+        else None
+    )
 
     # Keep every runtime-tool branch on one bounded execution funnel without
     # duplicating timeout policy across the branch-specific callbacks below.
@@ -1985,13 +1991,22 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
         try:
             from tools import tool_search as _ts
             if function_name == _ts.TOOL_CALL_NAME:
-                _underlying, _underlying_args, _err = _ts.resolve_underlying_call(function_args)
+                _underlying, _underlying_args, _err = _ts.resolve_underlying_call(
+                    function_args,
+                    allowed_names=_tool_search_scoped_names(
+                        agent, _execution_tool_surface
+                    ),
+                )
                 if not _err and _underlying:
-                    if _underlying in _tool_search_scoped_names(agent):
+                    if _underlying in _tool_search_scoped_names(agent, _execution_tool_surface):
                         # Probe-validate before unwrapping (ironclaw#5149):
                         # missing required args return the parameter schema
                         # instead of dispatching into an opaque failure.
-                        _probe_err = _ts.validate_deferred_call_args(_underlying, _underlying_args)
+                        _probe_err = _ts.validate_deferred_call_args(
+                            _underlying,
+                            _underlying_args,
+                            list(_execution_tool_surface.catalog_tool_defs),
+                        )
                         if _probe_err is not None:
                             # This path wraps _block_msg in {"error": ...} —
                             # flatten the probe payload to one plain string.
@@ -2014,6 +2029,14 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
                         )
         except Exception:
             pass
+
+        if _ts_scope_block is None:
+            from agent.tool_surface import tool_surface_registration_error
+
+            _ts_scope_block = tool_surface_registration_error(
+                _execution_tool_surface,
+                function_name,
+            )
 
         middleware_trace: list[dict[str, Any]] = []
         _execution_blocked = False
@@ -2090,8 +2113,8 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
                 # Mirror successful built-in memory writes to external
                 # providers. All gating/op-expansion lives behind the manager
                 # interface (MemoryManager.notify_memory_tool_write).
-                if agent._memory_manager:
-                    agent._memory_manager.notify_memory_tool_write(
+                if _execution_tool_surface.memory_manager:
+                    _execution_tool_surface.memory_manager.notify_memory_tool_write(
                         result,
                         next_args,
                         build_metadata=lambda: agent._build_memory_write_metadata(
@@ -2269,7 +2292,9 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
             _delegate_result = None
             try:
                 def _execute(next_args: dict) -> Any:
-                    return agent._dispatch_delegate_task(next_args)
+                    return agent._dispatch_delegate_task(
+                        next_args, tool_surface=_execution_tool_surface
+                    )
                 function_result, function_args, middleware_trace, _execution_blocked, _execution_dispatched = _managed_values(_run_agent_tool_execution_middleware(
                     agent,
                     function_name=function_name,
@@ -2289,7 +2314,10 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
                     spinner.stop(cute_msg)
                 elif agent._should_emit_quiet_tool_messages():
                     agent._vprint(f"  {cute_msg}")
-        elif agent._context_engine_tool_names and function_name in agent._context_engine_tool_names:
+        elif (
+            _execution_tool_surface.context_engine
+            and function_name in _context_engine_tool_names
+        ):
             # Context engine tools (lcm_grep, lcm_describe, lcm_expand, etc.)
             spinner = None
             if agent._should_emit_quiet_tool_messages():
@@ -2302,7 +2330,9 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
             _ce_result = None
             try:
                 def _execute(next_args: dict) -> Any:
-                    return agent.context_compressor.handle_tool_call(function_name, next_args, messages=messages)
+                    return _execution_tool_surface.context_engine.handle_tool_call(
+                        function_name, next_args, messages=messages
+                    )
                 function_result, function_args, middleware_trace, _execution_blocked, _execution_dispatched = _managed_values(_run_agent_tool_execution_middleware(
                     agent,
                     function_name=function_name,
@@ -2324,7 +2354,10 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
                     spinner.stop(cute_msg)
                 elif agent._should_emit_quiet_tool_messages():
                     agent._vprint(f"  {cute_msg}")
-        elif agent._memory_manager and agent._memory_manager.has_tool(function_name):
+        elif (
+            _execution_tool_surface.memory_manager
+            and function_name in _memory_provider_tool_names
+        ):
             # Memory provider tools (hindsight_retain, honcho_search, etc.)
             # These are not in the tool registry — route through MemoryManager.
             spinner = None
@@ -2338,7 +2371,9 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
             _mem_result = None
             try:
                 def _execute(next_args: dict) -> Any:
-                    return agent._memory_manager.handle_tool_call(function_name, next_args)
+                    return _execution_tool_surface.memory_manager.handle_tool_call(
+                        function_name, next_args
+                    )
                 function_result, function_args, middleware_trace, _execution_blocked, _execution_dispatched = _managed_values(_run_agent_tool_execution_middleware(
                     agent,
                     function_name=function_name,
@@ -2385,16 +2420,22 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
                             api_request_id=getattr(agent, "_current_api_request_id", "")
                             or "",
                             enabled_tools=(
-                                list(agent.valid_tool_names)
-                                if agent.valid_tool_names
+                                list(_valid_tool_names)
+                                if _valid_tool_names
                                 else None
                             ),
                             skip_pre_tool_call_hook=True,
                             skip_tool_request_middleware=True,
                             skip_tool_execution_middleware=True,
                             tool_request_middleware_trace=list(middleware_trace),
-                            enabled_toolsets=getattr(agent, "enabled_toolsets", None),
-                            disabled_toolsets=getattr(agent, "disabled_toolsets", None),
+                            enabled_toolsets=_enabled_toolsets,
+                            disabled_toolsets=_disabled_toolsets,
+                            catalog_tool_defs=list(
+                                _execution_tool_surface.catalog_tool_defs
+                            ),
+                            expected_registry_entries=dict(
+                                _execution_tool_surface.registry_entries
+                            ),
                         )
 
                 (
@@ -2467,16 +2508,22 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
                             api_request_id=getattr(agent, "_current_api_request_id", "")
                             or "",
                             enabled_tools=(
-                                list(agent.valid_tool_names)
-                                if agent.valid_tool_names
+                                list(_valid_tool_names)
+                                if _valid_tool_names
                                 else None
                             ),
                             skip_pre_tool_call_hook=True,
                             skip_tool_request_middleware=True,
                             skip_tool_execution_middleware=True,
                             tool_request_middleware_trace=list(middleware_trace),
-                            enabled_toolsets=getattr(agent, "enabled_toolsets", None),
-                            disabled_toolsets=getattr(agent, "disabled_toolsets", None),
+                            enabled_toolsets=_enabled_toolsets,
+                            disabled_toolsets=_disabled_toolsets,
+                            catalog_tool_defs=list(
+                                _execution_tool_surface.catalog_tool_defs
+                            ),
+                            expected_registry_entries=dict(
+                                _execution_tool_surface.registry_entries
+                            ),
                         )
 
                 (
@@ -2723,7 +2770,7 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
 
 
 
-def execute_tool_calls_segmented(agent, assistant_message, messages: list, effective_task_id: str, api_call_count: int = 0, segments=None) -> None:
+def execute_tool_calls_segmented(agent, assistant_message, messages: list, effective_task_id: str, api_call_count: int = 0, segments=None, *, tool_surface=None) -> None:
     """Execute a mixed tool-call batch as ordered parallel/sequential segments.
 
     ``segments`` is the ``(kind, calls)`` plan from
@@ -2761,11 +2808,13 @@ def execute_tool_calls_segmented(agent, assistant_message, messages: list, effec
             execute_tool_calls_concurrent(
                 agent, segment_message, messages, effective_task_id, api_call_count,
                 finalize=False,
+                tool_surface=tool_surface,
             )
         else:
             execute_tool_calls_sequential(
                 agent, segment_message, messages, effective_task_id, api_call_count,
                 finalize=False,
+                tool_surface=tool_surface,
             )
 
         if getattr(agent, "_incremental_persistence_failed", False):

--- a/agent/tool_surface.py
+++ b/agent/tool_surface.py
@@ -38,7 +38,32 @@ def _tool_name(tool_def: Dict[str, Any]) -> str:
     return name if isinstance(name, str) else ""
 
 
-def _family_enabled(family: str, enabled_toolsets: Optional[List[str]]) -> bool:
+def _family_enabled(
+    family: str,
+    enabled_toolsets: Optional[List[str]],
+    disabled_toolsets: Optional[List[str]],
+) -> bool:
+    if disabled_toolsets:
+        if family in disabled_toolsets:
+            return False
+        try:
+            from toolsets import get_toolset, resolve_toolset
+
+            for toolset in disabled_toolsets:
+                # Match model_tools subtraction semantics: platform bundles and
+                # posture toolsets preserve shared core tools.
+                if toolset.startswith("hermes-") or (
+                    get_toolset(toolset) or {}
+                ).get("posture"):
+                    continue
+                if family in resolve_toolset(toolset):
+                    return False
+        except Exception:
+            logger.debug(
+                "Failed to resolve disabled toolsets for %s tools",
+                family,
+                exc_info=True,
+            )
     if family == "memory":
         from agent.memory_manager import memory_provider_tools_enabled
 
@@ -55,12 +80,13 @@ def _append_family(
     family: str,
     schemas: Iterable[Any],
     enabled_toolsets: Optional[List[str]],
+    disabled_toolsets: Optional[List[str]],
     injected_names: Dict[str, List[str]],
     skipped: Dict[str, List[Dict[str, str]]],
 ) -> None:
     from agent.memory_manager import normalize_tool_schema
 
-    allowed = _family_enabled(family, enabled_toolsets)
+    allowed = _family_enabled(family, enabled_toolsets, disabled_toolsets)
     for raw_schema in schemas:
         schema = normalize_tool_schema(raw_schema)
         if schema is None:
@@ -87,6 +113,7 @@ def assemble_full_tool_surface(
     base_tool_defs: Iterable[Dict[str, Any]],
     *,
     enabled_toolsets: Optional[List[str]] = None,
+    disabled_toolsets: Optional[List[str]] = None,
     memory_tool_schemas: Iterable[Any] = (),
     context_engine_tool_schemas: Iterable[Any] = (),
     apply_tool_search: bool = True,
@@ -116,6 +143,7 @@ def assemble_full_tool_surface(
         family="memory",
         schemas=memory_tool_schemas,
         enabled_toolsets=enabled_toolsets,
+        disabled_toolsets=disabled_toolsets,
         injected_names=injected_names,
         skipped=skipped,
     )
@@ -125,11 +153,16 @@ def assemble_full_tool_surface(
         family="context_engine",
         schemas=context_engine_tool_schemas,
         enabled_toolsets=enabled_toolsets,
+        disabled_toolsets=disabled_toolsets,
         injected_names=injected_names,
         skipped=skipped,
     )
 
-    sanitized = sanitize_tool_schemas(staged)
+    try:
+        sanitized = sanitize_tool_schemas(staged)
+    except Exception as exc:  # pragma: no cover - preserve fail-soft loading
+        logger.warning("Schema sanitization skipped: %s", exc)
+        sanitized = list(staged)
     pre_assembly = list(sanitized)
     if not apply_tool_search:
         return FullToolSurface(
@@ -220,6 +253,7 @@ def assemble_agent_tool_surface(
     return assemble_full_tool_surface(
         base_tool_defs,
         enabled_toolsets=getattr(agent, "enabled_toolsets", None),
+        disabled_toolsets=getattr(agent, "disabled_toolsets", None),
         memory_tool_schemas=memory_schemas,
         context_engine_tool_schemas=context_schemas,
         context_length=getattr(

--- a/agent/tool_surface.py
+++ b/agent/tool_surface.py
@@ -1,0 +1,229 @@
+"""Non-mutating assembly of the complete model-facing tool surface.
+
+Registry tools are resolved first. External memory providers and context
+engines expose schemas outside the registry, so callers pass those families
+here before schema sanitization and tool-search replacement. Keeping this as
+one final assembly step prevents diagnostics, agent initialization, and MCP
+refreshes from disagreeing about the tools sent to the model.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+import logging
+from typing import Any, Dict, Iterable, List, Optional
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class FullToolSurface:
+    """Result and diagnostics from one complete tool-surface assembly."""
+
+    tool_defs: List[Dict[str, Any]]
+    pre_assembly_tool_defs: List[Dict[str, Any]]
+    injected_names: Dict[str, List[str]] = field(default_factory=dict)
+    skipped: Dict[str, List[Dict[str, str]]] = field(default_factory=dict)
+    tool_search_activated: bool = False
+    deferred_names: List[str] = field(default_factory=list)
+    deferred_tokens: int = 0
+    threshold_tokens: int = 0
+
+
+def _tool_name(tool_def: Dict[str, Any]) -> str:
+    function = tool_def.get("function") if isinstance(tool_def, dict) else None
+    if not isinstance(function, dict):
+        return ""
+    name = function.get("name")
+    return name if isinstance(name, str) else ""
+
+
+def _family_enabled(family: str, enabled_toolsets: Optional[List[str]]) -> bool:
+    if family == "memory":
+        from agent.memory_manager import memory_provider_tools_enabled
+
+        return memory_provider_tools_enabled(enabled_toolsets)
+    if family == "context_engine":
+        return enabled_toolsets is None or "context_engine" in enabled_toolsets
+    return True
+
+
+def _append_family(
+    tool_defs: List[Dict[str, Any]],
+    existing_names: set[str],
+    *,
+    family: str,
+    schemas: Iterable[Any],
+    enabled_toolsets: Optional[List[str]],
+    injected_names: Dict[str, List[str]],
+    skipped: Dict[str, List[Dict[str, str]]],
+) -> None:
+    from agent.memory_manager import normalize_tool_schema
+
+    allowed = _family_enabled(family, enabled_toolsets)
+    for raw_schema in schemas:
+        schema = normalize_tool_schema(raw_schema)
+        if schema is None:
+            logger.warning(
+                "%s returned a tool schema with no resolvable name; skipping (%r)",
+                family.replace("_", " ").title(),
+                raw_schema,
+            )
+            skipped[family].append({"tool": "", "reason": "invalid schema"})
+            continue
+        name = schema["name"]
+        if not allowed:
+            skipped[family].append({"tool": name, "reason": "toolset disabled"})
+            continue
+        if name in existing_names:
+            skipped[family].append({"tool": name, "reason": "duplicate tool name"})
+            continue
+        tool_defs.append({"type": "function", "function": schema})
+        existing_names.add(name)
+        injected_names[family].append(name)
+
+
+def assemble_full_tool_surface(
+    base_tool_defs: Iterable[Dict[str, Any]],
+    *,
+    enabled_toolsets: Optional[List[str]] = None,
+    memory_tool_schemas: Iterable[Any] = (),
+    context_engine_tool_schemas: Iterable[Any] = (),
+    apply_tool_search: bool = True,
+    context_length: Optional[int] = None,
+    tool_search_config: Any = None,
+    quiet_mode: bool = True,
+) -> FullToolSurface:
+    """Return the final model-facing tool list without mutating any input.
+
+    The order matches runtime behavior: copy registry definitions, normalize
+    and deduplicate externally injected families, sanitize the combined schema
+    list, then apply tool-search replacement once at the end.
+    """
+    from tools.schema_sanitizer import sanitize_tool_schemas
+
+    # The sanitizer deep-copies each definition. Running it after injection
+    # gives every family identical backend-compatibility treatment and makes
+    # the non-mutation guarantee explicit.
+    staged = [tool for tool in base_tool_defs if isinstance(tool, dict)]
+    existing_names = {name for name in map(_tool_name, staged) if name}
+    injected_names = {"memory": [], "context_engine": []}
+    skipped = {"memory": [], "context_engine": []}
+
+    _append_family(
+        staged,
+        existing_names,
+        family="memory",
+        schemas=memory_tool_schemas,
+        enabled_toolsets=enabled_toolsets,
+        injected_names=injected_names,
+        skipped=skipped,
+    )
+    _append_family(
+        staged,
+        existing_names,
+        family="context_engine",
+        schemas=context_engine_tool_schemas,
+        enabled_toolsets=enabled_toolsets,
+        injected_names=injected_names,
+        skipped=skipped,
+    )
+
+    sanitized = sanitize_tool_schemas(staged)
+    pre_assembly = list(sanitized)
+    if not apply_tool_search:
+        return FullToolSurface(
+            tool_defs=sanitized,
+            pre_assembly_tool_defs=pre_assembly,
+            injected_names=injected_names,
+            skipped=skipped,
+        )
+
+    try:
+        from tools.tool_search import (
+            assemble_tool_defs,
+            classify_tools,
+            load_config as load_tool_search_config,
+        )
+
+        config = tool_search_config or load_tool_search_config()
+        assembly = assemble_tool_defs(
+            sanitized,
+            context_length=context_length,
+            config=config,
+        )
+        deferred_names: List[str] = []
+        if assembly.activated:
+            _, deferred = classify_tools(sanitized)
+            deferred_names = sorted(
+                name for name in map(_tool_name, deferred) if name
+            )
+            if not quiet_mode:
+                print(
+                    f"🔎 Tool Search: {assembly.deferred_count} MCP/plugin tools deferred "
+                    f"(~{assembly.deferred_tokens} tokens) behind tool_search/describe/call. "
+                    f"Threshold ~{assembly.threshold_tokens} tokens."
+                )
+        return FullToolSurface(
+            tool_defs=assembly.tool_defs,
+            pre_assembly_tool_defs=pre_assembly,
+            injected_names=injected_names,
+            skipped=skipped,
+            tool_search_activated=assembly.activated,
+            deferred_names=deferred_names,
+            deferred_tokens=assembly.deferred_tokens,
+            threshold_tokens=assembly.threshold_tokens,
+        )
+    except Exception as exc:  # pragma: no cover - tool loading must fail soft
+        logger.warning("Tool search assembly skipped: %s", exc)
+        return FullToolSurface(
+            tool_defs=sanitized,
+            pre_assembly_tool_defs=pre_assembly,
+            injected_names=injected_names,
+            skipped=skipped,
+        )
+
+
+def assemble_agent_tool_surface(
+    agent: Any,
+    base_tool_defs: Iterable[Dict[str, Any]],
+    *,
+    quiet_mode: bool = True,
+) -> FullToolSurface:
+    """Read an agent's external schema providers and assemble a staged copy."""
+    memory_schemas: List[Dict[str, Any]] = []
+    try:
+        memory_manager = getattr(agent, "_memory_manager", None)
+        get_schemas = getattr(
+            memory_manager, "get_all_tool_schemas", None
+        ) if memory_manager else None
+        if callable(get_schemas):
+            result = get_schemas()
+            if isinstance(result, (list, tuple)):
+                memory_schemas = list(result)
+    except Exception:
+        logger.debug("Memory-provider tool collection skipped", exc_info=True)
+
+    context_schemas: List[Dict[str, Any]] = []
+    try:
+        compressor = getattr(agent, "context_compressor", None)
+        get_schemas = getattr(
+            compressor, "get_tool_schemas", None
+        ) if compressor else None
+        if callable(get_schemas):
+            result = get_schemas()
+            if isinstance(result, (list, tuple)):
+                context_schemas = list(result)
+    except Exception:
+        logger.debug("Context-engine tool collection skipped", exc_info=True)
+
+    return assemble_full_tool_surface(
+        base_tool_defs,
+        enabled_toolsets=getattr(agent, "enabled_toolsets", None),
+        memory_tool_schemas=memory_schemas,
+        context_engine_tool_schemas=context_schemas,
+        context_length=getattr(
+            getattr(agent, "context_compressor", None), "context_length", None
+        ),
+        quiet_mode=quiet_mode,
+    )

--- a/agent/tool_surface.py
+++ b/agent/tool_surface.py
@@ -1,0 +1,868 @@
+"""Shared, non-mutating assembly for the complete model-facing tool surface."""
+
+from __future__ import annotations
+
+import functools
+import logging
+import threading
+import types
+from copy import deepcopy
+from dataclasses import dataclass, field
+from typing import Any, Callable, Dict, Iterable, List, Optional, cast
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class FullToolSurface:
+    """Result of assembling registry and externally provided tool schemas."""
+
+    tool_defs: List[Dict[str, Any]]
+    pre_assembly_tool_defs: List[Dict[str, Any]]
+    injected_names: Dict[str, List[str]] = field(
+        default_factory=lambda: {"memory": [], "context_engine": []}
+    )
+    skipped: Dict[str, List[Dict[str, str]]] = field(
+        default_factory=lambda: {"memory": [], "context_engine": []}
+    )
+    tool_search_activated: bool = False
+    deferred_names: List[str] = field(default_factory=list)
+    deferred_tokens: int = 0
+    threshold_tokens: int = 0
+    tool_search_tier: int = 0
+    tool_search_listing_form: str = "none"
+
+
+@dataclass(frozen=True)
+class AgentToolSurfaceSnapshot:
+    """Atomically published envelope consumed by runtime tool readers."""
+
+    tool_defs: tuple[Dict[str, Any], ...]
+    catalog_tool_defs: tuple[Dict[str, Any], ...]
+    valid_tool_names: frozenset[str]
+    memory_provider_tool_names: frozenset[str]
+    context_engine_tool_names: frozenset[str]
+    deferred_tool_names: frozenset[str]
+    registry_entries: tuple[tuple[str, Any], ...]
+    memory_manager: Any
+    context_engine: Any
+    registry_generation: int
+    selection_revision: int
+    enabled_toolsets: Optional[tuple[str, ...]]
+    disabled_toolsets: Optional[tuple[str, ...]]
+    context_engine_provenance: Any = None
+
+
+_surface_lock_creation = threading.Lock()
+_fallback_surface_lock = threading.RLock()
+
+
+def _agent_surface_lock(agent: Any):
+    lock = getattr(agent, "_tool_surface_lock", None)
+    if lock is not None:
+        return lock
+    with _surface_lock_creation:
+        lock = getattr(agent, "_tool_surface_lock", None)
+        if lock is None:
+            lock = threading.RLock()
+            try:
+                agent._tool_surface_lock = lock
+            except Exception:
+                return _fallback_surface_lock
+    return lock
+
+
+def _capture_registry_entries(
+    tool_defs: Iterable[Dict[str, Any]],
+    *,
+    external_names: Iterable[str],
+) -> tuple[tuple[str, Any], ...]:
+    from tools.registry import registry
+
+    external = set(external_names)
+    names: list[str] = []
+    seen: set[str] = set()
+    for tool in tool_defs:
+        name = _tool_name(tool)
+        if not name or name in seen or name in external:
+            continue
+        seen.add(name)
+        names.append(name)
+    captured = registry.snapshot_entries_by_name(names)
+    return captured[1] if captured is not None else ()
+
+
+def _capture_registry_entries_by_name(
+    names: Iterable[str],
+    *,
+    external_names: Iterable[str],
+) -> tuple[tuple[str, Any], ...]:
+    from tools.registry import registry
+
+    external = frozenset(external_names)
+    captured = registry.snapshot_entries_by_name(
+        name for name in sorted(set(names)) if name and name not in external
+    )
+    return captured[1] if captured is not None else ()
+
+
+def capture_registry_entries_for_generation(
+    tool_defs: Iterable[Dict[str, Any]],
+    *,
+    external_names: Iterable[str],
+    expected_generation: int,
+) -> Optional[tuple[tuple[str, Any], ...]]:
+    """Capture dispatch entries only if schemas still match the registry."""
+    from tools.registry import registry
+
+    external = set(external_names)
+    names: list[str] = []
+    seen: set[str] = set()
+    for tool in tool_defs:
+        name = _tool_name(tool)
+        if not name or name in seen or name in external:
+            continue
+        seen.add(name)
+        names.append(name)
+    captured = registry.snapshot_entries_by_name(
+        names,
+        expected_generation=expected_generation,
+    )
+    return captured[1] if captured is not None else None
+
+
+def _catalog_deferred_names(
+    tool_defs: Iterable[Dict[str, Any]],
+) -> frozenset[str]:
+    try:
+        from tools.tool_search import scoped_deferrable_names
+
+        return scoped_deferrable_names(list(tool_defs))
+    except Exception:
+        return frozenset()
+
+
+def _freeze_selection(value: Optional[Iterable[str]]) -> Optional[tuple[str, ...]]:
+    if value is None:
+        return None
+    return tuple(str(item) for item in value)
+
+
+def _pinned_provider_or_live(agent: Any, ceiling_attr: str, live_attr: str) -> Any:
+    """Return an explicit provider ceiling, including an explicit ``None``."""
+    state = getattr(agent, "__dict__", None)
+    if isinstance(state, dict) and ceiling_attr in state:
+        return state[ceiling_attr]
+    return getattr(agent, live_attr, None)
+
+
+def _callable_provenance(value: Any) -> Any:
+    if not callable(value):
+        return None
+    if isinstance(value, types.MethodType):
+        return ("method", value.__func__)
+    if isinstance(value, types.BuiltinMethodType):
+        return ("builtin_method", type(value.__self__), value.__name__)
+    if isinstance(value, functools.partial):
+        return ("partial", _callable_provenance(value.func))
+    if isinstance(value, (types.FunctionType, types.BuiltinFunctionType)):
+        return ("callable", value)
+    return ("callable_type", type(value), getattr(type(value), "__call__", None))
+
+
+def context_engine_provenance(engine: Any) -> Any:
+    """Return stable code provenance for legitimate per-agent engine instances."""
+    if engine is None:
+        return None
+    engine_type = type(engine)
+    schema_impl = _callable_provenance(getattr(engine, "get_tool_schemas", None))
+    handler_impl = _callable_provenance(getattr(engine, "handle_tool_call", None))
+    if schema_impl is None or handler_impl is None:
+        return None
+    try:
+        name = str(getattr(engine, "name", "") or "")
+    except Exception:
+        return None
+    return (engine_type, name, schema_impl, handler_impl)
+
+
+def get_agent_tool_surface(agent: Any) -> AgentToolSurfaceSnapshot:
+    """Read one coherent surface, falling back for legacy/test agents."""
+    with _agent_surface_lock(agent):
+        snapshot = getattr(agent, "_tool_surface_snapshot", None)
+        if isinstance(snapshot, AgentToolSurfaceSnapshot):
+            legacy_tools = getattr(agent, "tools", None)
+            tools_replaced = (
+                legacy_tools is not None
+                and id(legacy_tools)
+                != getattr(agent, "_tool_surface_legacy_tools_id", id(legacy_tools))
+            )
+            legacy_valid = frozenset(
+                getattr(agent, "valid_tool_names", None) or ()
+            )
+            legacy_memory = frozenset(
+                getattr(agent, "_memory_provider_tool_names", None) or ()
+            )
+            legacy_context = frozenset(
+                getattr(agent, "_context_engine_tool_names", None) or ()
+            )
+            legacy_memory_manager = _pinned_provider_or_live(
+                agent,
+                "_tool_surface_memory_manager_ceiling",
+                "_memory_manager",
+            )
+            legacy_context_engine = _pinned_provider_or_live(
+                agent,
+                "_tool_surface_context_engine_ceiling",
+                "context_compressor",
+            )
+            if (
+                tools_replaced
+                or legacy_valid != snapshot.valid_tool_names
+                or legacy_memory != snapshot.memory_provider_tool_names
+                or legacy_context != snapshot.context_engine_tool_names
+                or legacy_memory_manager is not snapshot.memory_manager
+                or legacy_context_engine is not snapshot.context_engine
+            ):
+                tool_defs = tuple(legacy_tools or ())
+                valid_names = legacy_valid
+                if tools_replaced and legacy_valid == snapshot.valid_tool_names:
+                    valid_names = frozenset(
+                        name for tool in tool_defs if (name := _tool_name(tool))
+                    )
+                catalog_defs = (
+                    tool_defs if tools_replaced else snapshot.catalog_tool_defs
+                )
+                return AgentToolSurfaceSnapshot(
+                    tool_defs=tool_defs,
+                    catalog_tool_defs=catalog_defs,
+                    valid_tool_names=valid_names,
+                    memory_provider_tool_names=legacy_memory,
+                    context_engine_tool_names=legacy_context,
+                    deferred_tool_names=(
+                        _catalog_deferred_names(catalog_defs)
+                        if tools_replaced
+                        else snapshot.deferred_tool_names
+                    ),
+                    registry_entries=(
+                        _capture_registry_entries_by_name(
+                            set(valid_names)
+                            | {
+                                name
+                                for tool in catalog_defs
+                                if (name := _tool_name(tool))
+                            },
+                            external_names=legacy_memory | legacy_context,
+                        )
+                        if tools_replaced
+                        or legacy_valid != snapshot.valid_tool_names
+                        or legacy_memory != snapshot.memory_provider_tool_names
+                        or legacy_context != snapshot.context_engine_tool_names
+                        else snapshot.registry_entries
+                    ),
+                    memory_manager=legacy_memory_manager,
+                    context_engine=legacy_context_engine,
+                    registry_generation=snapshot.registry_generation,
+                    selection_revision=snapshot.selection_revision,
+                    enabled_toolsets=snapshot.enabled_toolsets,
+                    disabled_toolsets=snapshot.disabled_toolsets,
+                    context_engine_provenance=(
+                        snapshot.context_engine_provenance
+                        if legacy_context_engine is snapshot.context_engine
+                        else context_engine_provenance(legacy_context_engine)
+                    ),
+                )
+            return snapshot
+
+        tool_defs = tuple(getattr(agent, "tools", None) or ())
+        valid_names = getattr(agent, "valid_tool_names", None)
+        if valid_names is None:
+            valid_names = {_tool_name(tool) for tool in tool_defs if _tool_name(tool)}
+        memory_names = frozenset(
+            getattr(agent, "_memory_provider_tool_names", None) or ()
+        )
+        context_names = frozenset(
+            getattr(agent, "_context_engine_tool_names", None) or ()
+        )
+        registry_generation = getattr(agent, "_tool_snapshot_generation", 0)
+        selection_revision = getattr(agent, "_tool_selection_revision", 0)
+        fallback_context_engine = _pinned_provider_or_live(
+            agent,
+            "_tool_surface_context_engine_ceiling",
+            "context_compressor",
+        )
+        return AgentToolSurfaceSnapshot(
+            tool_defs=tool_defs,
+            catalog_tool_defs=tool_defs,
+            valid_tool_names=frozenset(valid_names),
+            memory_provider_tool_names=memory_names,
+            context_engine_tool_names=context_names,
+            deferred_tool_names=_catalog_deferred_names(tool_defs),
+            registry_entries=_capture_registry_entries(
+                tool_defs,
+                external_names=memory_names | context_names,
+            ),
+            memory_manager=_pinned_provider_or_live(
+                agent,
+                "_tool_surface_memory_manager_ceiling",
+                "_memory_manager",
+            ),
+            context_engine=fallback_context_engine,
+            registry_generation=(
+                registry_generation if isinstance(registry_generation, int) else 0
+            ),
+            selection_revision=(
+                selection_revision if isinstance(selection_revision, int) else 0
+            ),
+            enabled_toolsets=_freeze_selection(
+                getattr(agent, "enabled_toolsets", None)
+            ),
+            disabled_toolsets=_freeze_selection(
+                getattr(agent, "disabled_toolsets", None)
+            ),
+            context_engine_provenance=context_engine_provenance(
+                fallback_context_engine
+            ),
+        )
+
+
+def tool_surface_registration_error(
+    surface: AgentToolSurfaceSnapshot,
+    name: str,
+) -> Optional[str]:
+    """Fail closed when a pinned non-provider tool lost registry ownership."""
+    if name in surface.memory_provider_tool_names:
+        if surface.memory_manager is not None:
+            return None
+        return (
+            f"Tool provider is unavailable for this request snapshot: {name}. "
+            "Retry the request."
+        )
+    if name in surface.context_engine_tool_names:
+        if surface.context_engine is not None:
+            return None
+        return (
+            f"Tool provider is unavailable for this request snapshot: {name}. "
+            "Retry the request."
+        )
+
+    expected_entry = dict(surface.registry_entries).get(name)
+    if expected_entry is None:
+        if name in surface.valid_tool_names or name in surface.deferred_tool_names:
+            return (
+                f"Tool registration is unavailable for this request: {name}. "
+                "Retry the request."
+            )
+        return None
+
+    from tools.registry import registry
+
+    return registry.expected_entry_error(name, expected_entry)
+
+
+def publish_agent_tool_surface(
+    agent: Any,
+    tool_defs: Iterable[Dict[str, Any]],
+    *,
+    catalog_tool_defs: Optional[Iterable[Dict[str, Any]]] = None,
+    memory_provider_tool_names: Iterable[str] = (),
+    context_engine_tool_names: Iterable[str],
+    deferred_tool_names: Optional[Iterable[str]] = None,
+    registry_entries: Optional[Iterable[tuple[str, Any]]] = None,
+    registry_generation: int,
+    selection_revision: int,
+    enabled_toolsets: Optional[Iterable[str]],
+    disabled_toolsets: Optional[Iterable[str]],
+) -> AgentToolSurfaceSnapshot:
+    """Publish legacy attributes, then expose them as one atomic snapshot."""
+    staged_defs = list(tool_defs)
+    staged_catalog = (
+        list(catalog_tool_defs)
+        if catalog_tool_defs is not None
+        else list(staged_defs)
+    )
+    raw_valid_name_ceiling = getattr(
+        agent,
+        "_tool_surface_valid_name_ceiling",
+        None,
+    )
+    valid_name_ceiling = (
+        frozenset(raw_valid_name_ceiling)
+        if isinstance(raw_valid_name_ceiling, (set, frozenset, tuple, list))
+        else None
+    )
+    raw_catalog_name_ceiling = getattr(
+        agent,
+        "_tool_surface_catalog_name_ceiling",
+        valid_name_ceiling,
+    )
+    catalog_name_ceiling = (
+        frozenset(raw_catalog_name_ceiling)
+        if isinstance(raw_catalog_name_ceiling, (set, frozenset, tuple, list))
+        else valid_name_ceiling
+    )
+    if valid_name_ceiling is not None:
+        allowed = set(valid_name_ceiling)
+        staged_defs = [tool for tool in staged_defs if _tool_name(tool) in allowed]
+    if catalog_name_ceiling is not None:
+        allowed_catalog = set(catalog_name_ceiling)
+        staged_catalog = [
+            tool for tool in staged_catalog if _tool_name(tool) in allowed_catalog
+        ]
+    raw_visible_definition_ceiling = getattr(
+        agent,
+        "_tool_surface_visible_definition_ceiling",
+        None,
+    )
+    if isinstance(raw_visible_definition_ceiling, dict):
+        staged_defs = [
+            raw_visible_definition_ceiling[name]
+            for tool in staged_defs
+            if (name := _tool_name(tool)) in raw_visible_definition_ceiling
+        ]
+    raw_catalog_definition_ceiling = getattr(
+        agent,
+        "_tool_surface_catalog_definition_ceiling",
+        None,
+    )
+    if isinstance(raw_catalog_definition_ceiling, dict):
+        staged_catalog = [
+            raw_catalog_definition_ceiling[name]
+            for tool in staged_catalog
+            if (name := _tool_name(tool)) in raw_catalog_definition_ceiling
+        ]
+    frozen_defs = tuple(deepcopy(staged_defs))
+    frozen_catalog = tuple(deepcopy(staged_catalog))
+    memory_names = frozenset(memory_provider_tool_names)
+    context_names = frozenset(context_engine_tool_names)
+    if valid_name_ceiling is not None:
+        memory_names &= frozenset(valid_name_ceiling)
+        context_names &= frozenset(valid_name_ceiling)
+    raw_memory_name_ceiling = getattr(
+        agent,
+        "_tool_surface_memory_provider_name_ceiling",
+        None,
+    )
+    if isinstance(raw_memory_name_ceiling, (set, frozenset, tuple, list)):
+        memory_names &= frozenset(raw_memory_name_ceiling)
+    raw_context_name_ceiling = getattr(
+        agent,
+        "_tool_surface_context_engine_name_ceiling",
+        None,
+    )
+    if isinstance(raw_context_name_ceiling, (set, frozenset, tuple, list)):
+        context_names &= frozenset(raw_context_name_ceiling)
+    frozen_deferred_names = (
+        frozenset(deferred_tool_names)
+        if deferred_tool_names is not None
+        else _catalog_deferred_names(frozen_catalog)
+    )
+    if catalog_name_ceiling is not None:
+        frozen_deferred_names &= frozenset(catalog_name_ceiling)
+    frozen_registry_entries = (
+        tuple(registry_entries)
+        if registry_entries is not None
+        else _capture_registry_entries(
+            list(frozen_catalog) + list(frozen_defs),
+            external_names=memory_names | context_names,
+        )
+    )
+    if catalog_name_ceiling is not None:
+        allowed_entry_names = frozenset(catalog_name_ceiling) | frozenset(
+            valid_name_ceiling or ()
+        )
+        frozen_registry_entries = tuple(
+            (name, entry)
+            for name, entry in frozen_registry_entries
+            if name in allowed_entry_names
+        )
+    raw_registry_entry_ceiling = getattr(
+        agent,
+        "_tool_surface_registry_entry_ceiling",
+        None,
+    )
+    if isinstance(raw_registry_entry_ceiling, dict):
+        surfaced_names = {
+            name
+            for tool in (*frozen_defs, *frozen_catalog)
+            if (name := _tool_name(tool))
+        }
+        frozen_registry_entries = tuple(
+            (name, entry)
+            for name, entry in raw_registry_entry_ceiling.items()
+            if name in surfaced_names
+        )
+    pinned_context_engine = _pinned_provider_or_live(
+        agent,
+        "_tool_surface_context_engine_ceiling",
+        "context_compressor",
+    )
+    pinned_context_engine_provenance = _pinned_provider_or_live(
+        agent,
+        "_tool_surface_context_engine_provenance_ceiling",
+        "_context_engine_provenance",
+    )
+    if pinned_context_engine_provenance is None:
+        pinned_context_engine_provenance = context_engine_provenance(
+            pinned_context_engine
+        )
+    snapshot = AgentToolSurfaceSnapshot(
+        tool_defs=frozen_defs,
+        catalog_tool_defs=frozen_catalog,
+        valid_tool_names=frozenset(
+            name for tool in frozen_defs if (name := _tool_name(tool))
+        ),
+        memory_provider_tool_names=memory_names,
+        context_engine_tool_names=context_names,
+        deferred_tool_names=frozen_deferred_names,
+        registry_entries=frozen_registry_entries,
+        memory_manager=_pinned_provider_or_live(
+            agent,
+            "_tool_surface_memory_manager_ceiling",
+            "_memory_manager",
+        ),
+        context_engine=pinned_context_engine,
+        registry_generation=registry_generation,
+        selection_revision=selection_revision,
+        enabled_toolsets=_freeze_selection(enabled_toolsets),
+        disabled_toolsets=_freeze_selection(disabled_toolsets),
+        context_engine_provenance=pinned_context_engine_provenance,
+    )
+
+    # Runtime accessors continue reading the prior snapshot until this complete
+    # compatibility publication is done. The final single snapshot assignment
+    # is the visibility boundary for concurrent readers.
+    from model_tools import record_resolved_tool_names
+
+    with _agent_surface_lock(agent):
+        agent._tool_surface_publish_in_progress = True
+        try:
+            agent.tools = deepcopy(list(snapshot.tool_defs))
+            agent.valid_tool_names = set(snapshot.valid_tool_names)
+            agent._memory_provider_tool_names = set(
+                snapshot.memory_provider_tool_names
+            )
+            agent._context_engine_tool_names = set(
+                snapshot.context_engine_tool_names
+            )
+            agent._tool_snapshot_generation = snapshot.registry_generation
+            agent._tool_selection_revision = snapshot.selection_revision
+            agent.enabled_toolsets = (
+                list(snapshot.enabled_toolsets)
+                if snapshot.enabled_toolsets is not None
+                else None
+            )
+            agent.disabled_toolsets = (
+                list(snapshot.disabled_toolsets)
+                if snapshot.disabled_toolsets is not None
+                else None
+            )
+            agent._tool_surface_legacy_tools_id = id(agent.tools)
+            record_resolved_tool_names(list(snapshot.tool_defs))
+            agent._tool_surface_snapshot = snapshot
+        finally:
+            agent._tool_surface_publish_in_progress = False
+    return snapshot
+
+
+def publish_agent_tool_surface_for_generation(
+    agent: Any,
+    tool_defs: Iterable[Dict[str, Any]],
+    *,
+    catalog_tool_defs: Iterable[Dict[str, Any]],
+    memory_provider_tool_names: Iterable[str] = (),
+    context_engine_tool_names: Iterable[str],
+    deferred_tool_names: Optional[Iterable[str]] = None,
+    expected_registry_generation: int,
+    selection_revision: int,
+    enabled_toolsets: Optional[Iterable[str]],
+    disabled_toolsets: Optional[Iterable[str]],
+) -> Optional[AgentToolSurfaceSnapshot]:
+    """Capture registry entries and publish them under one generation lease."""
+    from tools.registry import registry
+
+    staged_defs = list(tool_defs)
+    staged_catalog = list(catalog_tool_defs)
+    memory_names = frozenset(memory_provider_tool_names)
+    context_names = frozenset(context_engine_tool_names)
+    external_names = memory_names | context_names
+    names: list[str] = []
+    seen: set[str] = set()
+    for tool in (*staged_catalog, *staged_defs):
+        name = _tool_name(tool)
+        if not name or name in seen or name in external_names:
+            continue
+        seen.add(name)
+        names.append(name)
+
+    def _publish(
+        generation: int,
+        entries: tuple[tuple[str, Any], ...],
+    ) -> AgentToolSurfaceSnapshot:
+        return publish_agent_tool_surface(
+            agent,
+            staged_defs,
+            catalog_tool_defs=staged_catalog,
+            memory_provider_tool_names=memory_names,
+            context_engine_tool_names=context_names,
+            deferred_tool_names=deferred_tool_names,
+            registry_entries=entries,
+            registry_generation=generation,
+            selection_revision=selection_revision,
+            enabled_toolsets=enabled_toolsets,
+            disabled_toolsets=disabled_toolsets,
+        )
+
+    # Match get_agent_tool_surface's lock order so legacy fallback capture and
+    # publication cannot deadlock while the registry generation is leased.
+    with _agent_surface_lock(agent):
+        return registry.run_with_entries_snapshot_by_name(
+            names,
+            _publish,
+            expected_generation=expected_registry_generation,
+        )
+
+
+def _tool_name(tool: Dict[str, Any]) -> str:
+    function = tool.get("function") if isinstance(tool, dict) else None
+    if not isinstance(function, dict):
+        return ""
+    name = function.get("name")
+    return name if isinstance(name, str) else ""
+
+
+def _family_enabled(
+    family: str,
+    enabled_toolsets: Optional[Iterable[str]],
+    disabled_toolsets: Optional[Iterable[str]],
+    base_names: set[str],
+) -> bool:
+    """Resolve an external family with disabled selections taking precedence."""
+    disabled = {str(name) for name in (disabled_toolsets or [])}
+    if family in disabled:
+        return False
+
+    try:
+        from toolsets import resolve_toolset
+
+        if any(family in resolve_toolset(name) for name in disabled):
+            return False
+    except Exception:
+        logger.debug(
+            "Failed to resolve disabled toolsets for %s", family, exc_info=True
+        )
+
+    if enabled_toolsets is None:
+        return True
+    enabled = {str(name) for name in enabled_toolsets}
+    if not enabled:
+        return False
+    if family in enabled or family in base_names:
+        return True
+
+    try:
+        from toolsets import resolve_toolset
+
+        return any(family in resolve_toolset(name) for name in enabled)
+    except Exception:
+        logger.debug("Failed to resolve enabled toolsets for %s", family, exc_info=True)
+        return False
+
+
+def _append_external_family(
+    staged: List[Dict[str, Any]],
+    existing_names: set[str],
+    family: str,
+    schemas: Iterable[Dict[str, Any]],
+    *,
+    enabled: bool,
+    result: FullToolSurface,
+) -> None:
+    from agent.memory_manager import normalize_tool_schema
+
+    for raw_schema in schemas:
+        schema = normalize_tool_schema(raw_schema)
+        raw_name = ""
+        if isinstance(raw_schema, dict):
+            candidate = raw_schema.get("name")
+            if isinstance(candidate, str):
+                raw_name = candidate
+        if schema is None:
+            result.skipped[family].append({
+                "tool": raw_name or "<unnamed>",
+                "reason": "invalid schema",
+            })
+            continue
+
+        name = schema["name"]
+        if not enabled:
+            result.skipped[family].append({"tool": name, "reason": "toolset disabled"})
+            continue
+        if name in existing_names:
+            result.skipped[family].append({
+                "tool": name,
+                "reason": "duplicate tool name",
+            })
+            continue
+
+        staged.append({"type": "function", "function": schema})
+        existing_names.add(name)
+        result.injected_names[family].append(name)
+
+
+def assemble_full_tool_surface(
+    base_tool_defs: Iterable[Dict[str, Any]],
+    *,
+    enabled_toolsets: Optional[Iterable[str]] = None,
+    disabled_toolsets: Optional[Iterable[str]] = None,
+    memory_tool_schemas: Optional[Iterable[Dict[str, Any]]] = None,
+    context_engine_tool_schemas: Optional[Iterable[Dict[str, Any]]] = None,
+    apply_tool_search: bool = True,
+    context_length: Optional[int] = None,
+    tool_search_config: Any = None,
+    quiet_mode: bool = True,
+) -> FullToolSurface:
+    """Assemble a complete surface without mutating inputs or runtime globals."""
+    staged = list(base_tool_defs or [])
+    existing_names = {name for tool in staged if (name := _tool_name(tool))}
+    result = FullToolSurface(tool_defs=[], pre_assembly_tool_defs=[])
+
+    _append_external_family(
+        staged,
+        existing_names,
+        "memory",
+        memory_tool_schemas or [],
+        enabled=_family_enabled(
+            "memory", enabled_toolsets, disabled_toolsets, existing_names
+        ),
+        result=result,
+    )
+    _append_external_family(
+        staged,
+        existing_names,
+        "context_engine",
+        context_engine_tool_schemas or [],
+        enabled=_family_enabled(
+            "context_engine", enabled_toolsets, disabled_toolsets, existing_names
+        ),
+        result=result,
+    )
+
+    try:
+        from tools.schema_sanitizer import sanitize_tool_schemas
+
+        staged = sanitize_tool_schemas(staged)
+    except Exception as exc:  # pragma: no cover - defensive fail-soft path
+        logger.warning("Schema sanitization skipped: %s", exc)
+        staged = list(staged)
+
+    result.pre_assembly_tool_defs = list(staged)
+    result.tool_defs = list(staged)
+    if not apply_tool_search:
+        return result
+
+    try:
+        from tools.tool_search import (
+            assemble_tool_defs,
+            classify_tools,
+            load_config,
+        )
+
+        config = tool_search_config if tool_search_config is not None else load_config()
+        if config.enabled == "off":
+            return result
+        assembly = assemble_tool_defs(
+            staged,
+            context_length=context_length,
+            config=config,
+        )
+        result.tool_defs = assembly.tool_defs
+        result.tool_search_activated = assembly.activated
+        result.deferred_tokens = assembly.deferred_tokens
+        result.threshold_tokens = assembly.threshold_tokens
+        result.tool_search_tier = assembly.tier
+        result.tool_search_listing_form = assembly.listing_form
+        if assembly.activated:
+            _, deferred = classify_tools(staged)
+            result.deferred_names = sorted(
+                name for tool in deferred if (name := _tool_name(tool))
+            )
+            if not quiet_mode:
+                forms = {
+                    "full": "catalog listing embedded",
+                    "names": "names-only listing embedded",
+                    "mixed": "listing embedded (oversized servers summarized)",
+                    "groups": "server summary embedded (search-only discovery)",
+                    "none": "no listing (search-only)",
+                }
+                print(
+                    f"🔎 Tool Search (tier {assembly.tier}): "
+                    f"{assembly.deferred_count} MCP/plugin tools deferred "
+                    f"(~{assembly.deferred_tokens} tokens) behind "
+                    "tool_search/describe/call — "
+                    f"{forms.get(assembly.listing_form, assembly.listing_form)}."
+                )
+    except Exception as exc:  # pragma: no cover - never break tool loading
+        logger.warning("Tool search assembly skipped: %s", exc)
+
+    return result
+
+
+def assemble_agent_tool_surface(
+    agent: Any,
+    base_tool_defs: Iterable[Dict[str, Any]],
+    *,
+    quiet_mode: bool = True,
+    toolset_selection: Optional[
+        tuple[Optional[Iterable[str]], Optional[Iterable[str]]]
+    ] = None,
+) -> FullToolSurface:
+    """Collect an agent's external schemas and assemble its final tool surface."""
+    memory_schemas: List[Dict[str, Any]] = []
+    memory_manager = getattr(agent, "_memory_manager", None)
+    get_memory_schemas = (
+        getattr(memory_manager, "get_all_tool_schemas", None)
+        if memory_manager is not None
+        else None
+    )
+    if callable(get_memory_schemas):
+        try:
+            collect_memory = cast(
+                Callable[[], Iterable[Dict[str, Any]]], get_memory_schemas
+            )
+            memory_schemas = list(collect_memory() or [])
+        except Exception:
+            logger.debug("Memory-provider schema collection skipped", exc_info=True)
+
+    context_schemas: List[Dict[str, Any]] = []
+    compressor = getattr(agent, "context_compressor", None)
+    get_context_schemas = (
+        getattr(compressor, "get_tool_schemas", None)
+        if compressor is not None
+        else None
+    )
+    if callable(get_context_schemas):
+        try:
+            collect_context = cast(
+                Callable[[], Iterable[Dict[str, Any]]], get_context_schemas
+            )
+            context_schemas = list(collect_context() or [])
+        except Exception:
+            logger.debug("Context-engine schema collection skipped", exc_info=True)
+
+    context_length = getattr(compressor, "context_length", None)
+    if toolset_selection is None:
+        enabled_toolsets = getattr(agent, "enabled_toolsets", None)
+        disabled_toolsets = getattr(agent, "disabled_toolsets", None)
+    else:
+        enabled_toolsets, disabled_toolsets = toolset_selection
+
+    return assemble_full_tool_surface(
+        base_tool_defs,
+        enabled_toolsets=enabled_toolsets,
+        disabled_toolsets=disabled_toolsets,
+        memory_tool_schemas=memory_schemas,
+        context_engine_tool_schemas=context_schemas,
+        context_length=context_length,
+        quiet_mode=quiet_mode,
+    )

--- a/agent/turn_context.py
+++ b/agent/turn_context.py
@@ -517,10 +517,9 @@ def build_turn_context(
     # snapshot.  This is cache-safe by construction: it runs in the per-turn
     # prologue, before this turn's first API call assembles ``tools=``, so it
     # only ever extends a fresh request prefix — it never mutates the cached
-    # prefix of an in-flight turn.  No-op when no MCP servers are registered
-    # (the common case, gated by the cheap ``has_registered_mcp_tools`` check)
-    # or when the tool set is unchanged (``refresh_agent_mcp_tools`` diffs by
-    # name and leaves the snapshot untouched on no-change).
+    # prefix of an in-flight turn. The common no-MCP case is gated by the cheap
+    # ``has_registered_mcp_tools`` check; equivalent rebuilds report no added
+    # names and produce no user notification.
     try:
         if not getattr(agent, "_skip_mcp_refresh", False):
             # Import-cost gate: ``tools.mcp_tool`` pulls in the whole ``mcp``
@@ -538,6 +537,10 @@ def build_turn_context(
                     refresh_agent_mcp_tools(agent, quiet_mode=True)
     except Exception:
         logger.debug("between-turns MCP tool refresh skipped", exc_info=True)
+
+    from agent.tool_surface import get_agent_tool_surface
+
+    tool_surface = get_agent_tool_surface(agent)
 
     # Sanitize surrogate characters from user input.
     if isinstance(user_message, str):
@@ -703,7 +706,7 @@ def build_turn_context(
     # Track memory nudge trigger (turn-based, checked here).
     should_review_memory = False
     if (agent._memory_nudge_interval > 0
-            and "memory" in agent.valid_tool_names
+            and "memory" in tool_surface.valid_tool_names
             and agent._memory_store):
         agent._turns_since_memory += 1
         if agent._turns_since_memory >= agent._memory_nudge_interval:
@@ -787,7 +790,7 @@ def build_turn_context(
             _idle_tokens = estimate_request_tokens_rough(
                 messages,
                 system_prompt=active_system_prompt or "",
-                tools=agent.tools or None,
+                tools=list(tool_surface.tool_defs) or None,
             )
             # Post-compression target size: don't summarise a thread already
             # below what compaction would reduce it to.
@@ -866,7 +869,7 @@ def build_turn_context(
         _preflight_tokens = estimate_request_tokens_rough(
             messages,
             system_prompt=active_system_prompt or "",
-            tools=agent.tools or None,
+            tools=list(tool_surface.tool_defs) or None,
         )
         _compressor = agent.context_compressor
         # getattr guard: minimal compressor doubles (SimpleNamespace in the
@@ -1030,7 +1033,7 @@ def build_turn_context(
                 _preflight_tokens = estimate_request_tokens_rough(
                     messages,
                     system_prompt=active_system_prompt or "",
-                    tools=agent.tools or None,
+                    tools=list(tool_surface.tool_defs) or None,
                 )
                 if not _compression_made_progress(
                     _orig_len, len(messages), _orig_tokens, _preflight_tokens

--- a/agent/turn_finalizer.py
+++ b/agent/turn_finalizer.py
@@ -768,10 +768,12 @@ def finalize_turn(
     agent._stream_callback = None
 
     # Check skill trigger NOW — based on how many tool iterations THIS turn used.
+    from agent.tool_surface import get_agent_tool_surface
+
     _should_review_skills = False
     if (agent._skill_nudge_interval > 0
             and agent._iters_since_skill >= agent._skill_nudge_interval
-            and "skill_manage" in agent.valid_tool_names):
+            and "skill_manage" in get_agent_tool_surface(agent).valid_tool_names):
         _should_review_skills = True
         agent._iters_since_skill = 0
 

--- a/hermes_cli/_parser.py
+++ b/hermes_cli/_parser.py
@@ -12,6 +12,8 @@ because its dispatch is tightly coupled to module-level ``cmd_*`` functions.
 
 import argparse
 
+from hermes_cli.profile_names import is_valid_profile_name
+
 
 # `--profile` / `-p` is consumed by ``main._apply_profile_override`` before
 # argparse runs (it sets ``HERMES_HOME`` and strips itself from ``sys.argv``),
@@ -34,7 +36,58 @@ def _inherited_flag(parser, *args, **kwargs):
     """
     action = parser.add_argument(*args, **kwargs)
     action.inherit_on_relaunch = True
+    setattr(action, "safe_before_tools_diagnose", True)
     return action
+
+
+def normalize_tools_diagnose_argv(argv: list[str]) -> list[str] | None:
+    """Return exact diagnose argv after parser-declared safe global flags."""
+    parser, _, _ = build_top_level_parser()
+    preparse_options = dict(PRE_ARGPARSE_INHERITED_FLAGS)
+    args = list(argv[1:])
+    while args:
+        if args[:2] == ["tools", "diagnose"]:
+            return args
+        raw = args[0]
+        profile_option = False
+        if raw in preparse_options:
+            takes_value = preparse_options[raw]
+            explicit_value = None
+            profile_option = raw in {"--profile", "-p"}
+        elif raw.startswith("--profile="):
+            takes_value = True
+            explicit_value = raw.partition("=")[2]
+            profile_option = True
+        else:
+            if not raw.startswith("-"):
+                return None
+            option_tuples = parser._get_option_tuples(raw)
+            if len(option_tuples) != 1:
+                return None
+            option_tuple = option_tuples[0]
+            action = option_tuple[0]
+            explicit_value = (
+                None if raw in action.option_strings else option_tuple[-1]
+            )
+            if not getattr(action, "safe_before_tools_diagnose", False):
+                return None
+            takes_value = action.nargs != 0
+            profile_option = action.dest == "profile"
+        if explicit_value is not None:
+            if not takes_value:
+                return None
+            if profile_option and not is_valid_profile_name(explicit_value):
+                return None
+            args = args[1:]
+        elif takes_value:
+            if len(args) < 2 or parser._parse_optional(args[1]) is not None:
+                return None
+            if profile_option and not is_valid_profile_name(args[1]):
+                return None
+            args = args[2:]
+        else:
+            args = args[1:]
+    return None
 
 
 _EPILOGUE = """
@@ -161,12 +214,13 @@ def build_top_level_parser():
             "(or per-model under agent.reasoning_overrides)."
         ),
     )
-    parser.add_argument(
+    toolsets_action = parser.add_argument(
         "-t",
         "--toolsets",
         default=None,
         help="Comma-separated toolsets to enable for this invocation. Applies to -z/--oneshot and --tui.",
     )
+    setattr(toolsets_action, "safe_before_tools_diagnose", True)
     parser.add_argument(
         "--resume",
         "-r",

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -14,6 +14,7 @@ This module provides:
 - hermes config wizard   - Re-run setup wizard
 """
 
+import contextlib
 import copy
 import json
 import logging
@@ -28,6 +29,7 @@ import tempfile
 import threading
 import time
 import unicodedata
+from contextvars import ContextVar
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Dict, Any, Optional, List, Tuple, Set
@@ -41,6 +43,28 @@ logger = logging.getLogger(__name__)
 # so concurrent CLI/gateway loads of a broken config.yaml don't spam stderr
 # every time. Cleared automatically when the file changes (different mtime).
 _CONFIG_PARSE_WARNED: set = set()
+
+_DIAGNOSTIC_CONFIG_INSPECTION: ContextVar[bool] = ContextVar(
+    "diagnostic_config_inspection", default=False
+)
+
+
+@contextlib.contextmanager
+def diagnostic_config_inspection():
+    """Make every config read in this context cache- and write-free."""
+    token = _DIAGNOSTIC_CONFIG_INSPECTION.set(True)
+    try:
+        yield
+    finally:
+        _DIAGNOSTIC_CONFIG_INSPECTION.reset(token)
+
+
+def _diagnostic_config_inspection_active() -> bool:
+    """Cover both scoped calls and exact diagnostic-process child threads."""
+    return (
+        _DIAGNOSTIC_CONFIG_INSPECTION.get()
+        or os.environ.get("HERMES_TOOLS_DIAGNOSE_READ_ONLY") == "1"
+    )
 
 
 def _backup_corrupt_config(config_path: Path) -> Optional[Path]:
@@ -3176,6 +3200,12 @@ def read_raw_config() -> Dict[str, Any]:
     ``load_config()``. Returns a deepcopy on every call since some callers
     mutate the result before passing to ``save_config()``.
     """
+    if _diagnostic_config_inspection_active():
+        try:
+            return read_user_config_raw()
+        except Exception:
+            return {}
+
     with _CONFIG_LOCK:
         try:
             config_path = get_config_path()
@@ -3266,6 +3296,12 @@ def read_raw_config_readonly() -> Dict[str, Any]:
     Same (mtime_ns, size) freshness key as ``read_raw_config()`` — an edited
     config.yaml is picked up on the next call.
     """
+    if _diagnostic_config_inspection_active():
+        try:
+            return read_user_config_raw()
+        except Exception:
+            return {}
+
     with _CONFIG_LOCK:
         try:
             config_path = get_config_path()
@@ -3346,6 +3382,11 @@ def atomic_config_write(config_path: Path, data: Any, **kwargs: Any) -> None:
     atomic_yaml_write(config_path, data, **kwargs)
 
 
+def _tools_diagnose_read_only() -> bool:
+    """Whether config loads must avoid bootstrapping the Hermes home tree."""
+    return _diagnostic_config_inspection_active()
+
+
 def load_config() -> Dict[str, Any]:
     """Load configuration from ~/.hermes/config.yaml.
 
@@ -3360,7 +3401,10 @@ def load_config() -> Dict[str, Any]:
     defensive deepcopy — that path matters in agent-loop hot spots like
     ``get_provider_request_timeout`` which is called once per API turn.
     """
-    return _load_config_impl(want_deepcopy=True)
+    return _load_config_impl(
+        want_deepcopy=True,
+        side_effect_free=_diagnostic_config_inspection_active(),
+    )
 
 
 def load_config_readonly() -> Dict[str, Any]:
@@ -3383,7 +3427,15 @@ def load_config_readonly() -> Dict[str, Any]:
     existing ``isinstance(x, dict)`` guards downstream keep working. The
     safety guarantee is purely documented, not enforced — be careful.
     """
-    return _load_config_impl(want_deepcopy=False)
+    return _load_config_impl(
+        want_deepcopy=False,
+        side_effect_free=_diagnostic_config_inspection_active(),
+    )
+
+
+def load_config_for_diagnostics() -> Dict[str, Any]:
+    """Load an effective config snapshot without writes or cache mutation."""
+    return _load_config_impl(want_deepcopy=False, side_effect_free=True)
 
 
 def write_platform_config_field(
@@ -3538,9 +3590,12 @@ def apply_terminal_config_to_env(
     return target
 
 
-def _load_config_impl(*, want_deepcopy: bool) -> Dict[str, Any]:
+def _load_config_impl(
+    *, want_deepcopy: bool, side_effect_free: bool = False
+) -> Dict[str, Any]:
     with _CONFIG_LOCK:
-        ensure_hermes_home()
+        if not side_effect_free:
+            ensure_hermes_home()
         config_path = get_config_path()
         path_key = str(config_path)
 
@@ -3577,7 +3632,7 @@ def _load_config_impl(*, want_deepcopy: bool) -> Dict[str, Any]:
         else:
             cache_sig = None
 
-        cached = _LOAD_CONFIG_CACHE.get(path_key)
+        cached = None if side_effect_free else _LOAD_CONFIG_CACHE.get(path_key)
         if cached is not None and cache_sig is not None and cached[:4] == cache_sig:
             # File signatures match, but the cached expansion is only valid if
             # every ${VAR} it was expanded against still has the same value.
@@ -3616,12 +3671,19 @@ def _load_config_impl(*, want_deepcopy: bool) -> Dict[str, Any]:
                 # loaded config — keep serving it until the file is fixed.
                 # Fresh processes with no last-known-good keep the existing
                 # DEFAULT_CONFIG fallback.
-                lkg = _LAST_EXPANDED_CONFIG_BY_PATH.get(path_key)
-                _warn_config_parse_failure(
-                    config_path,
-                    e,
-                    fallback="last-known-good" if lkg is not None else "defaults",
+                lkg = (
+                    None
+                    if side_effect_free
+                    else _LAST_EXPANDED_CONFIG_BY_PATH.get(path_key)
                 )
+                if not side_effect_free:
+                    _warn_config_parse_failure(
+                        config_path,
+                        e,
+                        fallback=(
+                            "last-known-good" if lkg is not None else "defaults"
+                        ),
+                    )
                 if lkg is not None:
                     # save_config() stores the pre-expansion normalized dict
                     # (env-ref templates preserved); the load path stores the
@@ -3651,7 +3713,23 @@ def _load_config_impl(*, want_deepcopy: bool) -> Dict[str, Any]:
         # against the process environment, never against user-config-defined refs.
         # This deliberately inverts the usual env-over-config precedence for the
         # keys the managed layer pins — see docs/design/managed-scope.md §4.1.
-        managed_config = managed_scope.load_managed_config()
+        managed_config: Dict[str, Any]
+        if side_effect_free:
+            if managed_cfg_path is None:
+                managed_config = {}
+            else:
+                try:
+                    with open(managed_cfg_path, encoding="utf-8") as f:
+                        raw_managed_config = fast_safe_load(f) or {}
+                    managed_config = (
+                        raw_managed_config
+                        if isinstance(raw_managed_config, dict)
+                        else {}
+                    )
+                except Exception:
+                    managed_config = {}
+        else:
+            managed_config = managed_scope.load_managed_config()
         if managed_config:
             # Normalize the managed overlay through the same canonicalization as
             # the user config BEFORE merging (parity with
@@ -3666,6 +3744,9 @@ def _load_config_impl(*, want_deepcopy: bool) -> Dict[str, Any]:
                 managed_normalized["model"] = {"default": managed_normalized["model"]}
             managed_expanded = _expand_env_vars(managed_normalized)
             expanded = _deep_merge(expanded, managed_expanded)
+        if side_effect_free:
+            return copy.deepcopy(expanded) if want_deepcopy else expanded
+
         _LAST_EXPANDED_CONFIG_BY_PATH[path_key] = copy.deepcopy(expanded)
         if cache_sig is not None:
             # Cache stores a separate deepcopy so subsequent ``load_config()``
@@ -5826,8 +5907,11 @@ def _inject_profile_env_vars() -> None:
         pass
 
 
-# Eagerly inject so that OPTIONAL_ENV_VARS is fully populated at import time.
-_inject_profile_env_vars()
+# Provider discovery may import enabled third-party entry points. Diagnostics
+# defer that work until their guarded assembly path rather than running plugin
+# code while config.py itself is still importing.
+if not _tools_diagnose_read_only():
+    _inject_profile_env_vars()
 
 
 # ── Platform-plugin env var injection ────────────────────────────────────────

--- a/hermes_cli/env_loader.py
+++ b/hermes_cli/env_loader.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import codecs
+import contextlib
 import io
 import os
 import sys
@@ -360,6 +361,24 @@ def _load_dotenv_with_fallback(path: Path, *, override: bool) -> None:
     _sanitize_loaded_credentials()
 
 
+def _load_dotenv_for_mode(
+    path: Path, *, override: bool, read_only: bool
+) -> None:
+    """Load dotenv, rolling back malformed-file effects during inspection."""
+    if not read_only:
+        _load_dotenv_with_fallback(path, override=override)
+        return
+
+    env_before = dict(os.environ)
+    sink = io.StringIO()
+    try:
+        with contextlib.redirect_stdout(sink), contextlib.redirect_stderr(sink):
+            _load_dotenv_with_fallback(path, override=override)
+    except Exception:
+        os.environ.clear()
+        os.environ.update(env_before)
+
+
 def _sanitize_env_file_if_needed(path: Path) -> None:
     """Pre-sanitize a .env file before python-dotenv reads it.
 
@@ -472,6 +491,7 @@ def load_hermes_dotenv(
     hermes_home: str | os.PathLike | None = None,
     project_env: str | os.PathLike | None = None,
     load_external_secrets: bool = True,
+    read_only: bool = False,
 ) -> list[Path]:
     """Load Hermes environment files with user config taking precedence.
 
@@ -483,6 +503,8 @@ def load_hermes_dotenv(
     - callers that only maintain the installation can set
       ``load_external_secrets=False`` to avoid loading optional secret-manager
       dependencies into the process that replaces that same environment.
+    - diagnostic callers can set ``read_only=True`` to suppress file repair,
+      external secret resolution, and the config-to-env terminal bridge.
     """
     loaded: list[Path] = []
 
@@ -491,17 +513,34 @@ def load_hermes_dotenv(
     project_env_path = Path(project_env) if project_env else None
 
     # Normalize safe formatting and remove invalid NUL bytes before parsing.
-    if user_env.exists():
+    if user_env.exists() and not read_only:
         _sanitize_env_file_if_needed(user_env)
-    if project_env_path and project_env_path.exists():
+    if project_env_path and project_env_path.exists() and not read_only:
         _sanitize_env_file_if_needed(project_env_path)
 
     if user_env.exists():
-        _load_dotenv_with_fallback(user_env, override=True)
+        _load_dotenv_for_mode(
+            user_env,
+            override=True,
+            read_only=read_only,
+        )
         loaded.append(user_env)
         # Mirror reload_env() known-key cleanup so inherited Hermes keys
         # absent from this profile's .env do not leak into the runtime.
-        _clear_known_keys_missing_from_dotenv(user_env)
+        if read_only:
+            env_before = dict(os.environ)
+            sink = io.StringIO()
+            try:
+                with (
+                    contextlib.redirect_stdout(sink),
+                    contextlib.redirect_stderr(sink),
+                ):
+                    _clear_known_keys_missing_from_dotenv(user_env)
+            except Exception:
+                os.environ.clear()
+                os.environ.update(env_before)
+        else:
+            _clear_known_keys_missing_from_dotenv(user_env)
 
     # Load .op.env AFTER .env so that .env values win, but the bootstrap
     # token (OP_SERVICE_ACCOUNT_TOKEN) becomes available for
@@ -515,10 +554,18 @@ def load_hermes_dotenv(
     # ensures .op.env never clobbers a token already in the environment).
     op_env = home_path / ".op.env"
     if op_env.exists() and not os.environ.get("OP_SERVICE_ACCOUNT_TOKEN"):
-        _load_dotenv_with_fallback(op_env, override=False)
+        _load_dotenv_for_mode(
+            op_env,
+            override=False,
+            read_only=read_only,
+        )
 
     if project_env_path and project_env_path.exists():
-        _load_dotenv_with_fallback(project_env_path, override=not loaded)
+        _load_dotenv_for_mode(
+            project_env_path,
+            override=not loaded,
+            read_only=read_only,
+        )
         loaded.append(project_env_path)
 
     # External secret sources are skipped in two updater situations:
@@ -534,9 +581,13 @@ def load_hermes_dotenv(
     # resolution is unnecessary for the updater.
     from hermes_cli import _early_recovery
 
-    if load_external_secrets and not _early_recovery._should_skip_external_secret_sources():
+    if (
+        load_external_secrets
+        and not read_only
+        and not _early_recovery._should_skip_external_secret_sources()
+    ):
         _apply_external_secret_sources(home_path)
-    _apply_managed_env()
+    _apply_managed_env(read_only=read_only)
 
     # config.yaml is the documented source of truth for terminal.* settings,
     # but the dotenv loads above run with override=True — so a stale
@@ -550,7 +601,8 @@ def load_hermes_dotenv(
     # the documented config path always wins. Runs after _apply_managed_env()
     # so the merged config (which already carries the managed overlay) is
     # what lands in the env.
-    _reapply_terminal_config_bridge(home_path)
+    if not read_only:
+        _reapply_terminal_config_bridge(home_path)
 
     return loaded
 
@@ -582,7 +634,7 @@ def _reapply_terminal_config_bridge(home_path: Path) -> None:
         pass
 
 
-def _apply_managed_env() -> None:
+def _apply_managed_env(*, read_only: bool = False) -> None:
     """Apply the managed-scope .env last, with override, so it beats user/shell.
 
     Managed scope is machine-global (independent of HERMES_HOME / profile). v1
@@ -610,8 +662,13 @@ def _apply_managed_env() -> None:
     managed_env = managed_dir / ".env"
     if not managed_env.exists():
         return
-    _sanitize_env_file_if_needed(managed_env)
-    _load_dotenv_with_fallback(managed_env, override=True)
+    if not read_only:
+        _sanitize_env_file_if_needed(managed_env)
+    _load_dotenv_for_mode(
+        managed_env,
+        override=True,
+        read_only=read_only,
+    )
 
 
 def _apply_external_secret_sources(home_path: Path) -> None:

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -12836,6 +12836,10 @@ def cmd_tools(args):
         from hermes_cli.tools_config import tools_disable_enable_command
 
         tools_disable_enable_command(args)
+    elif action == "diagnose":
+        from hermes_cli.tools_config import tools_diagnose_command
+
+        tools_diagnose_command(args)
     elif action == "post-setup":
         from hermes_cli.tools_config import run_post_setup_command
 

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -82,6 +82,24 @@ if _bootstrap_root not in sys.path:
     sys.path.insert(0, _bootstrap_root)
 from hermes_cli import _startup_fast  # noqa: E402
 
+
+def _normalized_tools_diagnose_argv(argv: list[str]) -> list[str] | None:
+    """Return exact diagnose argv after recognized global flags, or None."""
+    from hermes_cli._parser import normalize_tools_diagnose_argv
+
+    return normalize_tools_diagnose_argv(argv)
+
+
+def _is_tools_diagnose_argv(argv: list[str]) -> bool:
+    return _normalized_tools_diagnose_argv(argv) is not None
+
+
+_TOOLS_DIAGNOSE_READ_ONLY = _is_tools_diagnose_argv(sys.argv)
+if _TOOLS_DIAGNOSE_READ_ONLY:
+    os.environ["HERMES_TOOLS_DIAGNOSE_READ_ONLY"] = "1"
+else:
+    os.environ.pop("HERMES_TOOLS_DIAGNOSE_READ_ONLY", None)
+
 # Early venv self-heal — MUST run before any third-party import below.  When
 # a prior ``hermes update`` left a recovery marker and a core package's import
 # files were wiped (#57828 — failed lazy backend refresh), the module-level
@@ -96,10 +114,11 @@ from hermes_cli import _startup_fast  # noqa: E402
 # the full recovery path below.
 from hermes_cli import _early_recovery as _early_recovery_mod
 
-try:
-    _early_recovery_mod.recover_if_needed()
-except Exception:
-    pass
+if not _TOOLS_DIAGNOSE_READ_ONLY:
+    try:
+        _early_recovery_mod.recover_if_needed()
+    except Exception:
+        pass
 
 
 def _exit_after_oneshot(rc: object) -> None:
@@ -610,14 +629,12 @@ def _apply_profile_override() -> None:
         else:
             i += 1
 
-    # 1b. Reject values that can't be valid profile names (e.g. pytest's
-    # "-p no:xdist" would be misread as profile "no:xdist" otherwise).
-    # Mirrors hermes_cli.profiles._PROFILE_ID_RE so we never call
-    # resolve_profile_env() with a value it must reject + sys.exit on.
-    if profile_name is not None and consume == 2:
-        import re as _re
+    # 1b. Reject values that are not canonical profile identifiers before
+    # importing profile state or changing HERMES_HOME.
+    if profile_name is not None and consume > 0:
+        from hermes_cli.profile_names import is_valid_profile_name
 
-        if not _re.match(r"^[a-z0-9][a-z0-9_-]{0,63}$", profile_name):
+        if not is_valid_profile_name(profile_name):
             profile_name = None
             consume = 0
             profile_index = None
@@ -691,6 +708,17 @@ def _apply_profile_override() -> None:
 
 _apply_profile_override()
 
+_TOOLS_DIAGNOSE_READ_ONLY = (
+    _TOOLS_DIAGNOSE_READ_ONLY
+    or _is_tools_diagnose_argv(sys.argv)
+)
+if _TOOLS_DIAGNOSE_READ_ONLY:
+    # This process renders a pre-startup projection. Config loads must not
+    # bootstrap HERMES_HOME, and child imports inherit the same constraint.
+    os.environ["HERMES_TOOLS_DIAGNOSE_READ_ONLY"] = "1"
+else:
+    os.environ.pop("HERMES_TOOLS_DIAGNOSE_READ_ONLY", None)
+
 # Load .env from ~/.hermes/.env first, then project root as dev fallback.
 # User-managed env files should override stale shell exports on restart.
 from hermes_cli.config import get_hermes_home
@@ -705,8 +733,15 @@ from hermes_cli.env_loader import load_hermes_dotenv
 # only external secret fetches are unnecessary for installation maintenance.
 load_hermes_dotenv(
     project_env=PROJECT_ROOT / ".env",
-    load_external_secrets=sys.argv[1:2] != ["update"],
+    load_external_secrets=(
+        sys.argv[1:2] != ["update"] and not _TOOLS_DIAGNOSE_READ_ONLY
+    ),
+    read_only=_TOOLS_DIAGNOSE_READ_ONLY,
 )
+if _TOOLS_DIAGNOSE_READ_ONLY:
+    os.environ["HERMES_TOOLS_DIAGNOSE_READ_ONLY"] = "1"
+else:
+    os.environ.pop("HERMES_TOOLS_DIAGNOSE_READ_ONLY", None)
 
 # Bridge security.redact_secrets from config.yaml → HERMES_REDACT_SECRETS env
 # var BEFORE hermes_logging imports agent.redact (which snapshots the flag at
@@ -718,57 +753,59 @@ load_hermes_dotenv(
 # separate config.yaml reads (saves ~17ms on every CLI startup — the second
 # `load_config()` was doing a full deep-merge for one boolean lookup).
 _FORCE_IPV4_EARLY = False
-try:
-    # Reuse read_raw_config()'s (mtime, size)-keyed cache instead of a bespoke
-    # yaml.load — the SAME parse then serves hermes_logging's
-    # _read_logging_config and any later raw reads in this process, collapsing
-    # 3-4 config.yaml parses per invocation into one.
-    from hermes_cli.config import read_raw_config as _read_raw_early
+if not _TOOLS_DIAGNOSE_READ_ONLY:
+    try:
+        # Reuse read_raw_config()'s (mtime, size)-keyed cache instead of a bespoke
+        # yaml.load — the SAME parse then serves hermes_logging's
+        # _read_logging_config and any later raw reads in this process, collapsing
+        # 3-4 config.yaml parses per invocation into one.
+        from hermes_cli.config import read_raw_config as _read_raw_early
 
-    _cfg_path = get_hermes_home() / "config.yaml"
-    if _cfg_path.exists():
-        _early_cfg_raw = _read_raw_early() or {}
-        # Managed scope: overlay administrator-pinned values so a managed
-        # security.redact_secrets / network.force_ipv4 wins here too. This early
-        # bridge reads config.yaml directly (before load_config is usable), so
-        # without the overlay a managed redact_secrets toggle would be ignored.
-        # Fail-open via the shared helper.
-        try:
-            from hermes_cli import managed_scope
-            _early_cfg_raw = managed_scope.apply_managed_overlay(_early_cfg_raw)
-        except Exception:
-            pass
-        if "HERMES_REDACT_SECRETS" not in os.environ:
-            _early_sec_cfg = _early_cfg_raw.get("security", {})
-            if isinstance(_early_sec_cfg, dict):
-                _early_redact = _early_sec_cfg.get("redact_secrets")
-                if _early_redact is not None:
-                    os.environ["HERMES_REDACT_SECRETS"] = str(_early_redact).lower()
-        _early_net_cfg = _early_cfg_raw.get("network", {})
-        if isinstance(_early_net_cfg, dict) and _early_net_cfg.get("force_ipv4"):
-            _FORCE_IPV4_EARLY = True
-        del _early_cfg_raw
-    del _cfg_path
-except Exception:
-    pass  # best-effort — redaction stays at default (enabled) on config errors
+        _cfg_path = get_hermes_home() / "config.yaml"
+        if _cfg_path.exists():
+            _early_cfg_raw = _read_raw_early() or {}
+            # Managed scope: overlay administrator-pinned values so a managed
+            # security.redact_secrets / network.force_ipv4 wins here too. This early
+            # bridge reads config.yaml directly (before load_config is usable), so
+            # without the overlay a managed redact_secrets toggle would be ignored.
+            # Fail-open via the shared helper.
+            try:
+                from hermes_cli import managed_scope
+                _early_cfg_raw = managed_scope.apply_managed_overlay(_early_cfg_raw)
+            except Exception:
+                pass
+            if "HERMES_REDACT_SECRETS" not in os.environ:
+                _early_sec_cfg = _early_cfg_raw.get("security", {})
+                if isinstance(_early_sec_cfg, dict):
+                    _early_redact = _early_sec_cfg.get("redact_secrets")
+                    if _early_redact is not None:
+                        os.environ["HERMES_REDACT_SECRETS"] = str(_early_redact).lower()
+            _early_net_cfg = _early_cfg_raw.get("network", {})
+            if isinstance(_early_net_cfg, dict) and _early_net_cfg.get("force_ipv4"):
+                _FORCE_IPV4_EARLY = True
+            del _early_cfg_raw
+        del _cfg_path
+    except Exception:
+        pass  # best-effort — redaction stays at default (enabled) on config errors
 
-# Initialize centralized file logging early — all `hermes` subcommands
-# (chat, setup, gateway, config, etc.) write to agent.log + errors.log.
+# Initialize centralized file logging early for stateful `hermes` subcommands.
+# `tools diagnose` is a zero-write projection and intentionally skips it.
 # Dashboard entrypoints bootstrap with GUI mode so gui.log is always present
 # during GUI testing, including pre-dispatch startup failures.
-try:
-    from hermes_logging import setup_logging as _setup_logging
+if not _TOOLS_DIAGNOSE_READ_ONLY:
+    try:
+        from hermes_logging import setup_logging as _setup_logging
 
-    _setup_logging(
-        mode=(
-            "gui"
-            if next((arg for arg in sys.argv[1:] if not arg.startswith("-")), "")
-            in {"dashboard", "serve", "gui", "desktop"}
-            else "cli"
+        _setup_logging(
+            mode=(
+                "gui"
+                if next((arg for arg in sys.argv[1:] if not arg.startswith("-")), "")
+                in {"dashboard", "serve", "gui", "desktop"}
+                else "cli"
+            )
         )
-    )
-except Exception:
-    pass  # best-effort — don't crash the CLI if logging setup fails
+    except Exception:
+        pass  # best-effort — don't crash the CLI if logging setup fails
 
 # Apply IPv4 preference early, before any HTTP clients are created.
 # We already determined whether to force IPv4 from the raw yaml read above —
@@ -780,6 +817,28 @@ if _FORCE_IPV4_EARLY:
         _apply_ipv4(force=True)
     except Exception:
         pass  # best-effort — don't crash if hermes_constants not importable yet
+
+if _TOOLS_DIAGNOSE_READ_ONLY:
+    import argparse as _argparse
+
+    from hermes_cli.subcommands.tools import build_tools_parser as _build_tools_parser
+
+    def _run_tools_diagnose_early(args):
+        from hermes_cli.tools_config import tools_diagnose_command
+
+        return tools_diagnose_command(args)
+
+    _early_parser = _argparse.ArgumentParser(prog="hermes")
+    _early_subparsers = _early_parser.add_subparsers(dest="command")
+    _build_tools_parser(
+        _early_subparsers,
+        cmd_tools=_run_tools_diagnose_early,
+    )
+    _diagnose_argv = _normalized_tools_diagnose_argv(sys.argv)
+    if _diagnose_argv is None:
+        raise RuntimeError("tools diagnose bootstrap route lost its command argv")
+    _early_args = _early_parser.parse_args(_diagnose_argv)
+    raise SystemExit(_early_args.func(_early_args))
 
 import logging
 import threading
@@ -12018,6 +12077,10 @@ def cmd_tools(args):
         from hermes_cli.tools_config import tools_disable_enable_command
 
         tools_disable_enable_command(args)
+    elif action == "diagnose":
+        from hermes_cli.tools_config import tools_diagnose_command
+
+        return tools_diagnose_command(args)
     elif action == "post-setup":
         from hermes_cli.tools_config import run_post_setup_command
 

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -46,8 +46,10 @@ import queue
 import re
 import sys
 import threading
+import time
 import types
-from contextlib import contextmanager
+from contextlib import contextmanager, nullcontext
+from contextvars import ContextVar
 from dataclasses import dataclass, field
 from functools import wraps
 from pathlib import Path
@@ -546,8 +548,19 @@ def _serialized_replacement(method):
     """Make snapshot → write → lease attachment one atomic transaction."""
     @wraps(method)
     def wrapped(*args, **kwargs):
-        with replacement_coordinator.transaction():
-            return method(*args, **kwargs)
+        owner = args[0]
+        manager = getattr(owner, "_manager", owner)
+        lock = getattr(manager, "_discovery_lock", nullcontext())
+        with lock:
+            if getattr(manager, "_diagnostic_inspection_closed", False):
+                return None
+            if (
+                getattr(manager, "_diagnostic_registry_binding", None) is not None
+                and method.__name__ not in {"register_tool", "register_platform"}
+            ):
+                return None
+            with replacement_coordinator.transaction():
+                return method(*args, **kwargs)
 
     return wrapped
 
@@ -567,6 +580,19 @@ def _env_enabled(name: str) -> bool:
     return env_var_enabled(name)
 
 
+def _load_plugin_config() -> dict:
+    """Use the side-effect-free config snapshot during tool inspection."""
+    from hermes_cli.config import load_config, load_config_for_diagnostics
+    from tools.registry import is_read_only_tool_inspection
+
+    loader = (
+        load_config_for_diagnostics
+        if is_read_only_tool_inspection()
+        else load_config
+    )
+    return loader()
+
+
 def _get_disabled_plugins() -> set:
     """Read the disabled plugins list from config.yaml.
 
@@ -575,8 +601,7 @@ def _get_disabled_plugins() -> set:
     ``plugins.enabled``.
     """
     try:
-        from hermes_cli.config import load_config
-        config = load_config()
+        config = _load_plugin_config()
         disabled = cfg_get(config, "plugins", "disabled", default=[])
         return set(disabled) if isinstance(disabled, list) else set()
     except Exception:
@@ -598,8 +623,7 @@ def _get_enabled_plugins() -> Optional[set]:
     * ``set(...)`` — the concrete allow-list.
     """
     try:
-        from hermes_cli.config import load_config
-        config = load_config()
+        config = _load_plugin_config()
         plugins_cfg = config.get("plugins")
         if not isinstance(plugins_cfg, dict):
             return None
@@ -1360,12 +1384,16 @@ class PluginState:
     def get(self, key: str, default: Any = None) -> Any:
         """Read a JSON value, returning *default* when the key is absent."""
         self._validate_key(key)
+        if os.environ.get("HERMES_TOOLS_DIAGNOSE_READ_ONLY") == "1":
+            return self._read_unlocked().get(key, default)
         with _locked_plugin_state(self.path):
             return self._read_unlocked().get(key, default)
 
     def set(self, key: str, value: Any) -> None:
         """Atomically set one JSON value without dropping concurrent updates."""
         self._validate_key(key)
+        if os.environ.get("HERMES_TOOLS_DIAGNOSE_READ_ONLY") == "1":
+            return
         with _locked_plugin_state(self.path):
             data = self._read_unlocked()
             data[key] = value
@@ -1456,6 +1484,8 @@ class PluginContext:
                 "Rejected config path %r from plugin %s", key, self.plugin_id
             )
             raise
+        if self._manager._diagnostic_registry_binding is not None:
+            return
         from hermes_cli import config as config_mod
 
         if config_mod.is_managed():
@@ -1734,11 +1764,36 @@ class PluginContext:
                 f"in config.yaml to allow this plugin to replace built-in tools."
             )
 
-        from tools.registry import registry
+        from tools.registry import (
+            bind_read_only_tool_inspection_to_current_thread,
+            registry,
+        )
+
+        diagnostic_registry_binding = getattr(
+            self._manager,
+            "_diagnostic_registry_binding",
+            None,
+        )
+        if diagnostic_registry_binding is not None:
+            bind_read_only_tool_inspection_to_current_thread(
+                diagnostic_registry_binding
+            )
+        elif _diagnostic_thread_fallback() is not None:
+            bind_read_only_tool_inspection_to_current_thread()
 
         scope = self._manager.scope_key
         previous = registry.snapshot_registration(name, scope=scope)
         effective = registry.get_entry(name, scope=scope)
+        if (
+            effective is not None
+            and effective.toolset != toolset
+            and not override
+        ):
+            _record_diagnostic_plugin_conflict(
+                name=name,
+                reason="plugin tool conflicts with existing registry tool",
+                source=self.manifest.key or self.manifest.name,
+            )
         if previous is None and effective is not None and not override:
             logger.warning(
                 "Plugin %s tried to shadow global tool %s without override=True",
@@ -1765,6 +1820,12 @@ class PluginContext:
             and registered is not previous
             and registered.handler is handler
         ):
+            if effective is not None:
+                _record_diagnostic_plugin_conflict(
+                    name=name,
+                    reason="plugin tool overrides existing registry tool",
+                    source=self.manifest.key or self.manifest.name,
+                )
             self._manager._plugin_tool_names.add(name)
             def _restore_tool(replacement: Any) -> bool:
                 return registry.restore_registration(
@@ -2255,6 +2316,8 @@ class PluginContext:
         creates ``@issue:...``).  Built-in prefixes (diff, staged, file,
         folder, git, url) are reserved and will be rejected.
         """
+        if self._manager._diagnostic_registry_binding is not None:
+            return
         from agent.context_references import (
             ContextReferenceProvider as _CRP,
             register_context_reference_provider as _register,
@@ -2811,6 +2874,9 @@ class PluginContext:
                 setup_fn=irc_interactive_setup,
             )
         """
+        if self._manager._diagnostic_registry_binding is not None:
+            self._manager._plugin_platform_names.add(str(name))
+            return None
         from gateway.platform_registry import platform_registry, PlatformEntry
 
         entry_kwargs.setdefault("plugin_name", self.manifest.name)
@@ -3088,6 +3154,8 @@ class PluginContext:
 
         Returns the number of patterns accepted.
         """
+        if self._manager._diagnostic_registry_binding is not None:
+            return 0
         from agent.redact import register_redaction_patterns as _register
 
         try:
@@ -3394,6 +3462,8 @@ class PluginManager:
         # original scope.
         self.scope_key = scope_key or hermes_home_key()
         self.home_path = Path(self.scope_key)
+        self._diagnostic_registry_binding: Optional[Any] = None
+        self._diagnostic_inspection_closed = False
         self._discovery_lock = threading.RLock()
         self._plugins: Dict[str, LoadedPlugin] = {}
         self._hooks: Dict[str, List[Callable]] = {}
@@ -3485,8 +3555,12 @@ class PluginManager:
         registration._on_dispose = lambda disposed: self._forget_registrations(
             [disposed]
         )
-        self._ownership_ledger.setdefault(plugin_key, []).append(registration)
-        self._registration_order.append(registration)
+        with self._discovery_lock:
+            if self._diagnostic_inspection_closed:
+                registration.dispose()
+                return registration
+            self._ownership_ledger.setdefault(plugin_key, []).append(registration)
+            self._registration_order.append(registration)
         return registration
 
     @staticmethod
@@ -3828,6 +3902,15 @@ class PluginManager:
         No-op when only bundled sources exist or none are enabled.
         Fail-open: never raise into discover_and_load.
         """
+        if os.environ.get("HERMES_TOOLS_DIAGNOSE_READ_ONLY") == "1":
+            return
+        try:
+            from tools.registry import is_read_only_tool_inspection
+
+            if is_read_only_tool_inspection():
+                return
+        except Exception:
+            pass
         try:
             from agent.secret_sources.registry import list_plugin_sources
             from hermes_cli.env_loader import load_hermes_dotenv, reset_secret_source_cache
@@ -5546,6 +5629,146 @@ _plugin_manager: Optional[PluginManager] = None
 # imported) instead of rebuilding from scratch every switch.
 _plugin_managers_by_home: Dict[Path, PluginManager] = {}
 _plugin_managers_lock = threading.RLock()
+_diagnostic_plugin_manager: ContextVar[Optional[PluginManager]] = ContextVar(
+    "diagnostic_plugin_manager", default=None
+)
+_diagnostic_plugin_conflicts: ContextVar[
+    Optional[List[Dict[str, str]]]
+] = ContextVar("diagnostic_plugin_conflicts", default=None)
+_diagnostic_plugin_thread_fallback: Optional[
+    tuple[PluginManager, List[Dict[str, str]], frozenset[int]]
+] = None
+
+
+def _diagnostic_thread_fallback():
+    fallback = _diagnostic_plugin_thread_fallback
+    if fallback is None or threading.get_ident() in fallback[2]:
+        return None
+    return fallback
+
+
+def _record_diagnostic_plugin_conflict(
+    *, name: str, reason: str, source: str
+) -> None:
+    conflicts = _diagnostic_plugin_conflicts.get()
+    if conflicts is None:
+        fallback = _diagnostic_thread_fallback()
+        conflicts = fallback[1] if fallback is not None else None
+    if conflicts is None:
+        return
+    record = {"tool": name, "reason": reason, "source": source}
+    if record not in conflicts:
+        conflicts.append(record)
+
+
+def get_diagnostic_plugin_conflicts() -> List[Dict[str, str]]:
+    """Return plugin-name conflicts observed in this diagnostic scope."""
+    return [dict(item) for item in (_diagnostic_plugin_conflicts.get() or [])]
+
+
+def _drain_diagnostic_plugin_threads(
+    existing_thread_ids: frozenset[int],
+    *,
+    timeout: float = 1.0,
+) -> None:
+    """Drain cooperative diagnostic threads while output FDs stay quarantined.
+
+    Process-entry diagnostics emit through saved descriptors and terminate with
+    ``os._exit`` after this bounded grace period, so remaining plugin threads
+    cannot outlive the quarantine or corrupt the machine-readable document.
+    """
+    deadline = time.monotonic() + timeout
+    current = threading.current_thread()
+    while True:
+        threads = [
+            thread
+            for thread in threading.enumerate()
+            if thread is not current
+            and thread.ident is not None
+            and thread.ident not in existing_thread_ids
+            and thread.is_alive()
+        ]
+        if not threads:
+            return
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            logger.warning(
+                "diagnostic plugin threads still running after output quarantine: %s",
+                ", ".join(thread.name for thread in threads),
+            )
+            return
+        for thread in threads:
+            thread.join(min(remaining, 0.05))
+
+
+@contextmanager
+def diagnostic_plugin_inspection():
+    """Isolate plugin discovery performed while projecting a tool surface.
+
+    A previously discovered manager is already stable and can be read directly.
+    Otherwise discovery runs through a context-local disposable manager whose
+    ledger-backed registrations and imported directory modules are removed on
+    exit. The process-global manager pointer and cache are never published.
+    """
+    with _plugin_managers_lock:
+        current_home = _plugin_home_key()
+        manager_before = _plugin_managers_by_home.get(current_home)
+    disposable = manager_before is None or not manager_before._discovered
+    manager = (
+        PluginManager(scope_key=hermes_home_key(current_home))
+        if disposable
+        else manager_before
+    )
+    assert manager is not None
+    if disposable:
+        from tools.registry import capture_read_only_tool_inspection_binding
+
+        manager._diagnostic_registry_binding = (
+            capture_read_only_tool_inspection_binding()
+        )
+    conflicts: List[Dict[str, str]] = []
+    token = _diagnostic_plugin_manager.set(manager)
+    conflicts_token = _diagnostic_plugin_conflicts.set(conflicts)
+    global _diagnostic_plugin_thread_fallback
+    with _plugin_managers_lock:
+        fallback_before = _diagnostic_plugin_thread_fallback
+        existing_threads = frozenset(
+            thread.ident
+            for thread in threading.enumerate()
+            if thread.ident is not None
+        )
+        _diagnostic_plugin_thread_fallback = (
+            manager,
+            conflicts,
+            existing_threads,
+        )
+
+    try:
+        yield manager
+    finally:
+        try:
+            if disposable:
+                with manager._discovery_lock:
+                    manager._diagnostic_inspection_closed = True
+                    try:
+                        _clear_plugin_submodules(manager)
+                    finally:
+                        try:
+                            manager.unload()
+                        except Exception:
+                            logger.debug(
+                                "diagnostic plugin unload failed", exc_info=True
+                            )
+                _drain_diagnostic_plugin_threads(existing_threads)
+        finally:
+            try:
+                _diagnostic_plugin_manager.reset(token)
+            finally:
+                try:
+                    _diagnostic_plugin_conflicts.reset(conflicts_token)
+                finally:
+                    with _plugin_managers_lock:
+                        _diagnostic_plugin_thread_fallback = fallback_before
 
 
 def _plugin_home_key() -> Path:
@@ -5608,6 +5831,16 @@ def get_plugin_manager() -> PluginManager:
     plugin submodules, instead of silently inheriting another profile's
     context engine or stale relative-import state.
     """
+    diagnostic_manager = _diagnostic_plugin_manager.get()
+    if diagnostic_manager is not None:
+        return diagnostic_manager
+    diagnostic_fallback = _diagnostic_thread_fallback()
+    if diagnostic_fallback is not None:
+        from tools.registry import bind_read_only_tool_inspection_to_current_thread
+
+        bind_read_only_tool_inspection_to_current_thread()
+        return diagnostic_fallback[0]
+
     global _plugin_manager
     current_home = _plugin_home_key()
 
@@ -6514,6 +6747,11 @@ def get_plugin_subscriptions() -> Dict[str, List[Callable]]:
             event: [entry.callback for entry in entries]
             for event, entries in manager._subscriptions.items()
         }
+
+
+def get_plugin_tool_names() -> Set[str]:
+    """Return active tool names registered through the current plugin manager."""
+    return set(get_plugin_manager()._plugin_tool_names)
 
 
 def get_plugin_toolsets() -> List[tuple]:

--- a/hermes_cli/profile_names.py
+++ b/hermes_cli/profile_names.py
@@ -1,0 +1,34 @@
+"""Canonical, stdlib-only profile identifier validation."""
+
+from __future__ import annotations
+
+import re
+
+PROFILE_ID_RE = re.compile(r"^[a-z0-9][a-z0-9_-]{0,63}$")
+RESERVED_PROFILE_NAMES = frozenset(
+    {"hermes", "default", "test", "tmp", "root", "sudo"}
+)
+
+
+def is_valid_profile_name(name: str) -> bool:
+    """Return whether *name* is a canonical on-disk profile identifier."""
+    if name == "default":
+        return True
+    return bool(PROFILE_ID_RE.fullmatch(name)) and name not in RESERVED_PROFILE_NAMES
+
+
+def validate_profile_name(name: str) -> None:
+    """Raise ``ValueError`` unless *name* is a canonical profile identifier."""
+    if name == "default":
+        return
+    if not PROFILE_ID_RE.fullmatch(name):
+        raise ValueError(
+            f"Invalid profile name {name!r}. Must match "
+            f"[a-z0-9][a-z0-9_-]{{0,63}}"
+        )
+    if name in RESERVED_PROFILE_NAMES:
+        raise ValueError(
+            f"Profile name {name!r} is reserved — it collides with either "
+            "the Hermes installation itself or a common system binary.  "
+            "Pick a different name."
+        )

--- a/hermes_cli/profiles.py
+++ b/hermes_cli/profiles.py
@@ -34,10 +34,14 @@ from pathlib import Path, PurePosixPath, PureWindowsPath
 from typing import Dict, List, Optional, Tuple
 
 from agent.skill_utils import is_excluded_skill_path
+from hermes_cli.profile_names import (
+    PROFILE_ID_RE as _PROFILE_ID_RE,
+    RESERVED_PROFILE_NAMES as _RESERVED_NAMES,
+    validate_profile_name,
+)
 
 logger = logging.getLogger(__name__)
 
-_PROFILE_ID_RE = re.compile(r"^[a-z0-9][a-z0-9_-]{0,63}$")
 _WARNED_MISSING_ALLOWLIST_ENTRIES: set[tuple[str, ...]] = set()
 
 # Directories bootstrapped inside every new profile
@@ -250,11 +254,6 @@ _DEFAULT_EXPORT_INCLUDE_ROOT = frozenset({
     "plugins", "memories", "knowledge", "preferences",
 })
 
-# Names that cannot be used as profile aliases
-_RESERVED_NAMES = frozenset({
-    "hermes", "default", "test", "tmp", "root", "sudo",
-})
-
 # Hermes subcommands that cannot be used as profile names/aliases
 _HERMES_SUBCOMMANDS = frozenset({
     "chat", "model", "gateway", "setup", "whatsapp", "login", "logout",
@@ -323,36 +322,6 @@ def normalize_profile_name(name: str) -> str:
     if stripped.casefold() == "default":
         return "default"
     return stripped.lower()
-
-
-def validate_profile_name(name: str) -> None:
-    """Raise ``ValueError`` if *name* is not a valid profile identifier.
-
-    Validates the input as-given — strict lowercase match. Callers that accept
-    mixed-case or title-cased input from users (dashboard UI, CLI args) should
-    call :func:`normalize_profile_name` first. This separation keeps validate
-    honest about what the on-disk directory name must look like, while
-    ingress-point normalization handles UX flexibility (see #18498).
-
-    Also rejects names in :data:`_RESERVED_NAMES` (``hermes``, ``test``,
-    ``tmp``, ``root``, ``sudo``) that would create confusing on-disk
-    collisions (a ``hermes`` profile inside ``~/.hermes/``) or get refused
-    at alias-creation time anyway. ``default`` is a special pass-through —
-    it's a valid alias for the built-in root profile.
-    """
-    if name == "default":
-        return  # special alias for ~/.hermes
-    if not _PROFILE_ID_RE.match(name):
-        raise ValueError(
-            f"Invalid profile name {name!r}. Must match "
-            f"[a-z0-9][a-z0-9_-]{{0,63}}"
-        )
-    if name in _RESERVED_NAMES:
-        raise ValueError(
-            f"Profile name {name!r} is reserved — it collides with either "
-            f"the Hermes installation itself or a common system binary.  "
-            f"Pick a different name."
-        )
 
 
 def validate_alias_name(name: str) -> None:

--- a/hermes_cli/subcommands/tools.py
+++ b/hermes_cli/subcommands/tools.py
@@ -73,6 +73,22 @@ def build_tools_parser(subparsers, *, cmd_tools: Callable) -> None:
         help="Platform to apply to (default: cli)",
     )
 
+    # hermes tools diagnose [--platform cli] [--json]
+    tools_diag_p = tools_sub.add_parser(
+        "diagnose",
+        help="Diagnose the resolved model-facing tool surface",
+    )
+    tools_diag_p.add_argument(
+        "--platform",
+        default="cli",
+        help="Platform to diagnose (default: cli)",
+    )
+    tools_diag_p.add_argument(
+        "--json",
+        action="store_true",
+        help="Print machine-readable diagnostics JSON",
+    )
+
     # hermes tools post-setup <key>
     tools_postsetup_p = tools_sub.add_parser(
         "post-setup",

--- a/hermes_cli/subcommands/tools.py
+++ b/hermes_cli/subcommands/tools.py
@@ -73,6 +73,22 @@ def build_tools_parser(subparsers, *, cmd_tools: Callable) -> None:
         help="Platform to apply to (default: cli)",
     )
 
+    # hermes tools diagnose [--platform cli] [--json]
+    tools_diag_p = tools_sub.add_parser(
+        "diagnose",
+        help="Project the pre-startup model-facing tool surface",
+    )
+    tools_diag_p.add_argument(
+        "--platform",
+        default="cli",
+        help="Platform to diagnose (default: cli)",
+    )
+    tools_diag_p.add_argument(
+        "--json",
+        action="store_true",
+        help="Print machine-readable diagnostics JSON",
+    )
+
     # hermes tools post-setup <key>
     tools_postsetup_p = tools_sub.add_parser(
         "post-setup",

--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -16,7 +16,7 @@ import shutil
 import subprocess
 import sys
 from pathlib import Path
-from typing import Dict, List, Optional, Set
+from typing import Any, Dict, List, Optional, Set
 
 
 from hermes_cli.config import (
@@ -4451,6 +4451,234 @@ def _print_tools_list(enabled_toolsets: set, mcp_servers: dict, platform: str = 
                 _print_info(f"{srv_name}  [excluded: {color(', '.join(exclude), Colors.YELLOW)}]")
             else:
                 _print_info(f"{srv_name}  {color('all tools enabled', Colors.DIM)}")
+
+
+def _visible_tool_names(enabled_toolsets: Set[str]) -> List[str]:
+    """Return model-visible tool names for an enabled toolset selection."""
+    from model_tools import get_tool_definitions
+
+    definitions = get_tool_definitions(
+        enabled_toolsets=sorted(enabled_toolsets),
+        quiet_mode=True,
+        skip_tool_search_assembly=True,
+    )
+    return sorted(
+        td.get("function", {}).get("name")
+        for td in definitions
+        if td.get("function", {}).get("name")
+    )
+
+
+def _disabled_toolsets_for_diagnostics(enabled_toolsets: Set[str], platform: str) -> List[str]:
+    """Return configurable/plugin toolsets disabled for ``platform``."""
+    all_toolsets = {
+        ts_key
+        for ts_key, _, _ in CONFIGURABLE_TOOLSETS
+        if _toolset_allowed_for_platform(ts_key, platform)
+    }
+    all_toolsets |= _get_plugin_toolset_keys()
+    return sorted(all_toolsets - enabled_toolsets)
+
+
+def _tool_skipped_reason(toolset: str, enabled_toolsets: Set[str], visible_tools: Set[str], tool_name: str) -> Optional[str]:
+    """Explain why a registered tool is not visible in diagnostics."""
+    if tool_name in visible_tools:
+        return None
+    if toolset not in enabled_toolsets:
+        return "toolset disabled"
+    return "availability check failed"
+
+
+def _provider_tool_status(
+    *,
+    provider: str,
+    toolset: str,
+    enabled_toolsets: Set[str],
+    visible_tools: Set[str],
+    tools_by_toolset: Dict[str, List[str]],
+) -> Dict[str, Any]:
+    """Build a compact provider-injected tool status block."""
+    schemas = len(tools_by_toolset.get(toolset, []))
+    injected = len(set(tools_by_toolset.get(toolset, [])) & visible_tools)
+    skipped_reason = None
+    if schemas and injected == 0:
+        skipped_reason = "toolset disabled" if toolset not in enabled_toolsets else "availability check failed"
+    return {
+        "provider": provider,
+        "schemas": schemas,
+        "injected": injected,
+        "skipped_reason": skipped_reason,
+    }
+
+
+def build_tools_diagnostics(config: dict, platform: str) -> Dict[str, Any]:
+    """Return low-noise diagnostics for the model-facing tool surface.
+
+    The command intentionally reports resolved runtime facts rather than only
+    saved config: enabled toolsets after platform/default/global filtering,
+    model-visible tools after registry check_fn filtering, registered tools
+    filtered out by toolset or availability checks, and provider-injected tool
+    families such as memory, MCP, context-engine, and plugins.
+    """
+    from toolsets import resolve_toolset
+    from tools.registry import registry
+
+    enabled_toolsets = _get_platform_tools(config, platform)
+    platform_toolsets = config.get("platform_toolsets") or {}
+    explicit_platform_config = (
+        isinstance(platform_toolsets, dict)
+        and isinstance(platform_toolsets.get(platform), list)
+    )
+    agent_cfg = config.get("agent") or {}
+    config_sources = {
+        "toolset_selection": (
+            f"platform_toolsets.{platform}"
+            if explicit_platform_config
+            else f"platform default ({PLATFORMS.get(platform, {}).get('default_toolset', f'hermes-{platform}')})"
+        ),
+        "global_disabled_toolsets": sorted(str(ts) for ts in (agent_cfg.get("disabled_toolsets") or []))
+        if isinstance(agent_cfg, dict)
+        else [],
+    }
+    disabled_toolsets = _disabled_toolsets_for_diagnostics(enabled_toolsets, platform)
+    tools_visible = _visible_tool_names(enabled_toolsets)
+    visible_set = set(tools_visible)
+
+    all_tool_names = registry.get_all_tool_names()
+    tools_by_toolset: Dict[str, List[str]] = {}
+    filtered = []
+    for tool_name in all_tool_names:
+        toolset = registry.get_toolset_for_tool(tool_name) or ""
+        tools_by_toolset.setdefault(toolset, []).append(tool_name)
+        reason = _tool_skipped_reason(toolset, enabled_toolsets, visible_set, tool_name)
+        if reason:
+            filtered.append({"tool": tool_name, "toolset": toolset, "reason": reason})
+
+    # Include unresolved names from enabled toolsets as a wiring diagnostic.
+    registered = set(all_tool_names)
+    for toolset in sorted(enabled_toolsets):
+        for tool_name in sorted(resolve_toolset(toolset)):
+            if tool_name not in registered:
+                filtered.append({
+                    "tool": tool_name,
+                    "toolset": toolset,
+                    "reason": "not registered",
+                })
+
+    provider_tools: Dict[str, Dict[str, Any]] = {}
+    memory_cfg = config.get("memory") or {}
+    memory_provider = "built_in"
+    if isinstance(memory_cfg, dict):
+        memory_provider = str(memory_cfg.get("provider") or memory_provider)
+    provider_tools["memory"] = _provider_tool_status(
+        provider=memory_provider,
+        toolset="memory",
+        enabled_toolsets=enabled_toolsets,
+        visible_tools=visible_set,
+        tools_by_toolset=tools_by_toolset,
+    )
+
+    context_cfg = config.get("context") or {}
+    context_provider = "compressor"
+    if isinstance(context_cfg, dict):
+        context_provider = str(context_cfg.get("engine") or context_provider)
+    provider_tools["context_engine"] = _provider_tool_status(
+        provider=context_provider,
+        toolset="context_engine",
+        enabled_toolsets=enabled_toolsets,
+        visible_tools=visible_set,
+        tools_by_toolset=tools_by_toolset,
+    )
+
+    mcp_servers = config.get("mcp_servers") or {}
+    provider_tools["mcp"] = {
+        "provider": "mcp",
+        "schemas": sum(len(tools) for ts, tools in tools_by_toolset.items() if ts.startswith("mcp-")),
+        "injected": sum(1 for name in visible_set if (registry.get_toolset_for_tool(name) or "").startswith("mcp-")),
+        "configured_servers": sorted(str(name) for name in mcp_servers) if isinstance(mcp_servers, dict) else [],
+        "skipped_reason": None,
+    }
+
+    plugin_toolsets = sorted(_get_plugin_toolset_keys())
+    provider_tools["plugins"] = {
+        "provider": "plugins",
+        "schemas": sum(len(tools_by_toolset.get(ts, [])) for ts in plugin_toolsets),
+        "injected": sum(
+            1 for name in visible_set
+            if (registry.get_toolset_for_tool(name) or "") in plugin_toolsets
+        ),
+        "toolsets": plugin_toolsets,
+        "skipped_reason": None,
+    }
+
+    duplicate_names = sorted({name for name in tools_visible if tools_visible.count(name) > 1})
+    conflicts = [{"tool": name, "reason": "duplicate visible tool name"} for name in duplicate_names]
+
+    return {
+        "platform": platform,
+        "enabled_toolsets": sorted(enabled_toolsets),
+        "disabled_toolsets": disabled_toolsets,
+        "config_sources": config_sources,
+        "tools_visible": tools_visible,
+        "provider_tools": provider_tools,
+        "filtered": sorted(filtered, key=lambda item: (item["reason"], item["toolset"], item["tool"])),
+        "conflicts": conflicts,
+    }
+
+
+def _print_tools_diagnostics(diag: Dict[str, Any]) -> None:
+    """Render diagnostics in a low-noise human-readable format."""
+    print(f"Tool diagnostics ({diag['platform']}):")
+    print(f"  Enabled toolsets ({len(diag['enabled_toolsets'])}): {', '.join(diag['enabled_toolsets']) or '-'}")
+    config_sources = diag.get("config_sources") or {}
+    if config_sources:
+        print(f"  Config source: {config_sources.get('toolset_selection', '-')}")
+        disabled = config_sources.get("global_disabled_toolsets") or []
+        if disabled:
+            print(f"  Globally disabled: {', '.join(disabled)}")
+    print(f"  Visible tools ({len(diag['tools_visible'])}): {', '.join(diag['tools_visible']) or '-'}")
+
+    provider_tools = diag.get("provider_tools") or {}
+    if provider_tools:
+        print("  Provider tools:")
+        for name, info in provider_tools.items():
+            skipped = info.get("skipped_reason") or "ok"
+            extra = ""
+            if name == "mcp" and info.get("configured_servers"):
+                extra = f" servers={','.join(info['configured_servers'])}"
+            elif name == "plugins" and info.get("toolsets"):
+                extra = f" toolsets={','.join(info['toolsets'])}"
+            print(
+                f"    {name}: provider={info.get('provider')} "
+                f"schemas={info.get('schemas', 0)} injected={info.get('injected', 0)} "
+                f"status={skipped}{extra}"
+            )
+
+    filtered = diag.get("filtered") or []
+    print(f"  Filtered tools ({len(filtered)}):")
+    for item in filtered[:50]:
+        print(f"    {item['tool']} ({item['toolset']}): {item['reason']}")
+    if len(filtered) > 50:
+        print(f"    ... {len(filtered) - 50} more; use --json for full output")
+
+    conflicts = diag.get("conflicts") or []
+    print(f"  Conflicts ({len(conflicts)}):")
+    for item in conflicts:
+        print(f"    {item['tool']}: {item['reason']}")
+
+
+def tools_diagnose_command(args):
+    """Print resolved tool-surface diagnostics for a platform."""
+    platform = getattr(args, "platform", "cli")
+    config = load_config()
+    if platform not in PLATFORMS:
+        _print_error(f"Unknown platform '{platform}'. Valid: {', '.join(PLATFORMS)}")
+        return
+    diag = build_tools_diagnostics(config, platform)
+    if getattr(args, "json", False):
+        print(_json.dumps(diag, indent=2, sort_keys=True))
+    else:
+        _print_tools_diagnostics(diag)
 
 
 def tools_disable_enable_command(args):

--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -4493,11 +4493,19 @@ def _diagnostic_context_engine(config: dict) -> tuple[str, List[Dict[str, Any]],
 
         engine = load_context_engine(engine_name)
         if engine is None:
+            import copy
+
             from hermes_cli.plugins import get_plugin_context_engine
 
             candidate = get_plugin_context_engine()
             if candidate is not None and getattr(candidate, "name", None) == engine_name:
-                engine = candidate
+                try:
+                    engine = copy.deepcopy(candidate)
+                except Exception:
+                    logger.debug(
+                        "Context-engine diagnostic copy failed", exc_info=True
+                    )
+                    return engine_name, [], "engine cannot be copied safely"
         if engine is None:
             return engine_name, [], "engine not found"
         get_schemas = getattr(engine, "get_tool_schemas", None)
@@ -4539,19 +4547,21 @@ def build_tools_diagnostics(config: dict, platform: str) -> Dict[str, Any]:
         and isinstance(platform_toolsets.get(platform), list)
     )
     agent_cfg = config.get("agent") or {}
+    disabled_list = sorted(
+        str(toolset) for toolset in (agent_cfg.get("disabled_toolsets") or [])
+    ) if isinstance(agent_cfg, dict) else []
     config_sources = {
         "toolset_selection": (
             f"platform_toolsets.{platform}"
             if explicit_platform_config
             else f"platform default ({PLATFORMS.get(platform, {}).get('default_toolset', f'hermes-{platform}')})"
         ),
-        "global_disabled_toolsets": sorted(
-            str(toolset) for toolset in (agent_cfg.get("disabled_toolsets") or [])
-        ) if isinstance(agent_cfg, dict) else [],
+        "global_disabled_toolsets": disabled_list,
     }
 
     base_tool_defs = get_tool_definitions(
         enabled_toolsets=enabled_list,
+        disabled_toolsets=disabled_list,
         quiet_mode=True,
         skip_tool_search_assembly=True,
         record_resolved_names=False,
@@ -4570,6 +4580,7 @@ def build_tools_diagnostics(config: dict, platform: str) -> Dict[str, Any]:
     surface = assemble_full_tool_surface(
         base_tool_defs,
         enabled_toolsets=enabled_list,
+        disabled_toolsets=disabled_list,
         memory_tool_schemas=memory_schemas,
         context_engine_tool_schemas=context_schemas,
         context_length=context_length,

--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -4453,20 +4453,63 @@ def _print_tools_list(enabled_toolsets: set, mcp_servers: dict, platform: str = 
                 _print_info(f"{srv_name}  {color('all tools enabled', Colors.DIM)}")
 
 
-def _visible_tool_names(enabled_toolsets: Set[str]) -> List[str]:
-    """Return model-visible tool names for an enabled toolset selection."""
-    from model_tools import get_tool_definitions
+def _diagnostic_memory_provider(config: dict) -> tuple[str, List[Dict[str, Any]], Optional[str]]:
+    """Load configured external memory schemas without initializing a session."""
+    memory_cfg = config.get("memory") or {}
+    provider_name = ""
+    if isinstance(memory_cfg, dict):
+        provider_name = str(memory_cfg.get("provider") or "").strip()
+    if not provider_name:
+        return "built_in", [], None
 
-    definitions = get_tool_definitions(
-        enabled_toolsets=sorted(enabled_toolsets),
-        quiet_mode=True,
-        skip_tool_search_assembly=True,
-    )
-    return sorted(
-        td.get("function", {}).get("name")
-        for td in definitions
-        if td.get("function", {}).get("name")
-    )
+    try:
+        from agent.memory_manager import MemoryManager
+        from plugins.memory import load_memory_provider
+
+        provider = load_memory_provider(provider_name)
+        if provider is None:
+            return provider_name, [], "provider not found"
+        if not provider.is_available():
+            return provider_name, [], "provider unavailable"
+        manager = MemoryManager()
+        manager.add_provider(provider)
+        return provider_name, manager.get_all_tool_schemas(), None
+    except Exception:
+        logger.debug("Memory provider diagnostics failed", exc_info=True)
+        return provider_name, [], "provider inspection failed"
+
+
+def _diagnostic_context_engine(config: dict) -> tuple[str, List[Dict[str, Any]], Optional[str]]:
+    """Load configured context-engine schemas without model/session mutation."""
+    context_cfg = config.get("context") or {}
+    engine_name = "compressor"
+    if isinstance(context_cfg, dict):
+        engine_name = str(context_cfg.get("engine") or engine_name).strip()
+    if not engine_name or engine_name == "compressor":
+        return "compressor", [], None
+
+    try:
+        from plugins.context_engine import load_context_engine
+
+        engine = load_context_engine(engine_name)
+        if engine is None:
+            from hermes_cli.plugins import get_plugin_context_engine
+
+            candidate = get_plugin_context_engine()
+            if candidate is not None and getattr(candidate, "name", None) == engine_name:
+                engine = candidate
+        if engine is None:
+            return engine_name, [], "engine not found"
+        get_schemas = getattr(engine, "get_tool_schemas", None)
+        if not callable(get_schemas):
+            return engine_name, [], "engine exposes no tool schemas"
+        schemas = get_schemas()
+        if not isinstance(schemas, (list, tuple)):
+            return engine_name, [], "engine returned invalid tool schemas"
+        return engine_name, list(schemas), None
+    except Exception:
+        logger.debug("Context-engine diagnostics failed", exc_info=True)
+        return engine_name, [], "engine inspection failed"
 
 
 def _disabled_toolsets_for_diagnostics(enabled_toolsets: Set[str], platform: str) -> List[str]:
@@ -4480,50 +4523,16 @@ def _disabled_toolsets_for_diagnostics(enabled_toolsets: Set[str], platform: str
     return sorted(all_toolsets - enabled_toolsets)
 
 
-def _tool_skipped_reason(toolset: str, enabled_toolsets: Set[str], visible_tools: Set[str], tool_name: str) -> Optional[str]:
-    """Explain why a registered tool is not visible in diagnostics."""
-    if tool_name in visible_tools:
-        return None
-    if toolset not in enabled_toolsets:
-        return "toolset disabled"
-    return "availability check failed"
-
-
-def _provider_tool_status(
-    *,
-    provider: str,
-    toolset: str,
-    enabled_toolsets: Set[str],
-    visible_tools: Set[str],
-    tools_by_toolset: Dict[str, List[str]],
-) -> Dict[str, Any]:
-    """Build a compact provider-injected tool status block."""
-    schemas = len(tools_by_toolset.get(toolset, []))
-    injected = len(set(tools_by_toolset.get(toolset, [])) & visible_tools)
-    skipped_reason = None
-    if schemas and injected == 0:
-        skipped_reason = "toolset disabled" if toolset not in enabled_toolsets else "availability check failed"
-    return {
-        "provider": provider,
-        "schemas": schemas,
-        "injected": injected,
-        "skipped_reason": skipped_reason,
-    }
-
-
 def build_tools_diagnostics(config: dict, platform: str) -> Dict[str, Any]:
-    """Return low-noise diagnostics for the model-facing tool surface.
-
-    The command intentionally reports resolved runtime facts rather than only
-    saved config: enabled toolsets after platform/default/global filtering,
-    model-visible tools after registry check_fn filtering, registered tools
-    filtered out by toolset or availability checks, and provider-injected tool
-    families such as memory, MCP, context-engine, and plugins.
-    """
+    """Return diagnostics for the complete model-facing tool surface."""
+    from agent.tool_surface import assemble_full_tool_surface
+    from model_tools import _resolve_active_context_length, get_tool_definitions
     from toolsets import resolve_toolset
     from tools.registry import registry
+    from tools.tool_search import ToolSearchConfig
 
     enabled_toolsets = _get_platform_tools(config, platform)
+    enabled_list = sorted(enabled_toolsets)
     platform_toolsets = config.get("platform_toolsets") or {}
     explicit_platform_config = (
         isinstance(platform_toolsets, dict)
@@ -4536,13 +4545,48 @@ def build_tools_diagnostics(config: dict, platform: str) -> Dict[str, Any]:
             if explicit_platform_config
             else f"platform default ({PLATFORMS.get(platform, {}).get('default_toolset', f'hermes-{platform}')})"
         ),
-        "global_disabled_toolsets": sorted(str(ts) for ts in (agent_cfg.get("disabled_toolsets") or []))
-        if isinstance(agent_cfg, dict)
-        else [],
+        "global_disabled_toolsets": sorted(
+            str(toolset) for toolset in (agent_cfg.get("disabled_toolsets") or [])
+        ) if isinstance(agent_cfg, dict) else [],
     }
-    disabled_toolsets = _disabled_toolsets_for_diagnostics(enabled_toolsets, platform)
-    tools_visible = _visible_tool_names(enabled_toolsets)
+
+    base_tool_defs = get_tool_definitions(
+        enabled_toolsets=enabled_list,
+        quiet_mode=True,
+        skip_tool_search_assembly=True,
+        record_resolved_names=False,
+    )
+    memory_provider, memory_schemas, memory_error = _diagnostic_memory_provider(config)
+    context_provider, context_schemas, context_error = _diagnostic_context_engine(config)
+
+    tools_cfg = config.get("tools") or {}
+    if not isinstance(tools_cfg, dict):
+        tools_cfg = {}
+    tool_search_config = ToolSearchConfig.from_raw(tools_cfg.get("tool_search"))
+    context_length = None
+    if tool_search_config.enabled != "off":
+        context_length = _resolve_active_context_length(config)
+
+    surface = assemble_full_tool_surface(
+        base_tool_defs,
+        enabled_toolsets=enabled_list,
+        memory_tool_schemas=memory_schemas,
+        context_engine_tool_schemas=context_schemas,
+        context_length=context_length,
+        tool_search_config=tool_search_config,
+    )
+    tools_visible = sorted(
+        tool.get("function", {}).get("name")
+        for tool in surface.tool_defs
+        if tool.get("function", {}).get("name")
+    )
     visible_set = set(tools_visible)
+    pre_assembly_names = {
+        tool.get("function", {}).get("name")
+        for tool in surface.pre_assembly_tool_defs
+        if tool.get("function", {}).get("name")
+    }
+    deferred_set = set(surface.deferred_names)
 
     all_tool_names = registry.get_all_tool_names()
     tools_by_toolset: Dict[str, List[str]] = {}
@@ -4550,13 +4594,23 @@ def build_tools_diagnostics(config: dict, platform: str) -> Dict[str, Any]:
     for tool_name in all_tool_names:
         toolset = registry.get_toolset_for_tool(tool_name) or ""
         tools_by_toolset.setdefault(toolset, []).append(tool_name)
-        reason = _tool_skipped_reason(toolset, enabled_toolsets, visible_set, tool_name)
-        if reason:
-            filtered.append({"tool": tool_name, "toolset": toolset, "reason": reason})
+        if tool_name in visible_set:
+            continue
+        if tool_name in deferred_set:
+            reason = "deferred by tool search"
+        elif tool_name not in pre_assembly_names:
+            reason = (
+                "toolset disabled"
+                if toolset not in enabled_toolsets
+                else "availability check failed"
+            )
+        else:
+            reason = "not model-visible"
+        filtered.append({"tool": tool_name, "toolset": toolset, "reason": reason})
 
     # Include unresolved names from enabled toolsets as a wiring diagnostic.
     registered = set(all_tool_names)
-    for toolset in sorted(enabled_toolsets):
+    for toolset in enabled_list:
         for tool_name in sorted(resolve_toolset(toolset)):
             if tool_name not in registered:
                 filtered.append({
@@ -4565,63 +4619,96 @@ def build_tools_diagnostics(config: dict, platform: str) -> Dict[str, Any]:
                     "reason": "not registered",
                 })
 
-    provider_tools: Dict[str, Dict[str, Any]] = {}
-    memory_cfg = config.get("memory") or {}
-    memory_provider = "built_in"
-    if isinstance(memory_cfg, dict):
-        memory_provider = str(memory_cfg.get("provider") or memory_provider)
-    provider_tools["memory"] = _provider_tool_status(
-        provider=memory_provider,
-        toolset="memory",
-        enabled_toolsets=enabled_toolsets,
-        visible_tools=visible_set,
-        tools_by_toolset=tools_by_toolset,
-    )
+    def _external_status(
+        family: str,
+        provider: str,
+        schemas: List[Dict[str, Any]],
+        inspection_error: Optional[str],
+    ) -> Dict[str, Any]:
+        injected_names = surface.injected_names[family]
+        skipped = surface.skipped[family]
+        skipped_reason = inspection_error
+        if skipped_reason is None and skipped and not injected_names:
+            skipped_reason = skipped[0]["reason"]
+        return {
+            "provider": provider,
+            "schemas": len(schemas),
+            "injected": len(set(injected_names) & visible_set),
+            "skipped_reason": skipped_reason,
+            "skipped": skipped,
+        }
 
-    context_cfg = config.get("context") or {}
-    context_provider = "compressor"
-    if isinstance(context_cfg, dict):
-        context_provider = str(context_cfg.get("engine") or context_provider)
-    provider_tools["context_engine"] = _provider_tool_status(
-        provider=context_provider,
-        toolset="context_engine",
-        enabled_toolsets=enabled_toolsets,
-        visible_tools=visible_set,
-        tools_by_toolset=tools_by_toolset,
-    )
+    provider_tools: Dict[str, Dict[str, Any]] = {
+        "memory": _external_status(
+            "memory", memory_provider, memory_schemas, memory_error
+        ),
+        "context_engine": _external_status(
+            "context_engine", context_provider, context_schemas, context_error
+        ),
+    }
 
+    mcp_names = {
+        name
+        for toolset, names in tools_by_toolset.items()
+        if toolset.startswith("mcp-")
+        for name in names
+    }
     mcp_servers = config.get("mcp_servers") or {}
     provider_tools["mcp"] = {
         "provider": "mcp",
-        "schemas": sum(len(tools) for ts, tools in tools_by_toolset.items() if ts.startswith("mcp-")),
-        "injected": sum(1 for name in visible_set if (registry.get_toolset_for_tool(name) or "").startswith("mcp-")),
-        "configured_servers": sorted(str(name) for name in mcp_servers) if isinstance(mcp_servers, dict) else [],
+        "schemas": len(mcp_names),
+        "injected": len(mcp_names & visible_set),
+        "deferred": len(mcp_names & deferred_set),
+        "configured_servers": (
+            sorted(str(name) for name in mcp_servers)
+            if isinstance(mcp_servers, dict)
+            else []
+        ),
         "skipped_reason": None,
     }
 
     plugin_toolsets = sorted(_get_plugin_toolset_keys())
+    plugin_names = {
+        name
+        for toolset in plugin_toolsets
+        for name in tools_by_toolset.get(toolset, [])
+    }
     provider_tools["plugins"] = {
         "provider": "plugins",
-        "schemas": sum(len(tools_by_toolset.get(ts, [])) for ts in plugin_toolsets),
-        "injected": sum(
-            1 for name in visible_set
-            if (registry.get_toolset_for_tool(name) or "") in plugin_toolsets
-        ),
+        "schemas": len(plugin_names),
+        "injected": len(plugin_names & visible_set),
+        "deferred": len(plugin_names & deferred_set),
         "toolsets": plugin_toolsets,
         "skipped_reason": None,
     }
 
-    duplicate_names = sorted({name for name in tools_visible if tools_visible.count(name) > 1})
-    conflicts = [{"tool": name, "reason": "duplicate visible tool name"} for name in duplicate_names]
+    duplicate_names = sorted({
+        name for name in tools_visible if tools_visible.count(name) > 1
+    })
+    conflicts = [
+        {"tool": name, "reason": "duplicate visible tool name"}
+        for name in duplicate_names
+    ]
 
     return {
         "platform": platform,
-        "enabled_toolsets": sorted(enabled_toolsets),
-        "disabled_toolsets": disabled_toolsets,
+        "enabled_toolsets": enabled_list,
+        "disabled_toolsets": _disabled_toolsets_for_diagnostics(
+            enabled_toolsets, platform
+        ),
         "config_sources": config_sources,
         "tools_visible": tools_visible,
+        "tool_search": {
+            "activated": surface.tool_search_activated,
+            "deferred": len(surface.deferred_names),
+            "deferred_tokens": surface.deferred_tokens,
+            "threshold_tokens": surface.threshold_tokens,
+        },
         "provider_tools": provider_tools,
-        "filtered": sorted(filtered, key=lambda item: (item["reason"], item["toolset"], item["tool"])),
+        "filtered": sorted(
+            filtered,
+            key=lambda item: (item["reason"], item["toolset"], item["tool"]),
+        ),
         "conflicts": conflicts,
     }
 
@@ -4637,6 +4724,13 @@ def _print_tools_diagnostics(diag: Dict[str, Any]) -> None:
         if disabled:
             print(f"  Globally disabled: {', '.join(disabled)}")
     print(f"  Visible tools ({len(diag['tools_visible'])}): {', '.join(diag['tools_visible']) or '-'}")
+    tool_search = diag.get("tool_search") or {}
+    if tool_search:
+        state = "active" if tool_search.get("activated") else "inactive"
+        print(
+            f"  Tool search: {state}; deferred={tool_search.get('deferred', 0)} "
+            f"tokens~{tool_search.get('deferred_tokens', 0)}"
+        )
 
     provider_tools = diag.get("provider_tools") or {}
     if provider_tools:

--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -9,19 +9,28 @@ Saves per-platform tool configuration to ~/.hermes/config.yaml under
 the `platform_toolsets` key.
 """
 
+import contextlib
+import io
 import json as _json
 import logging
 import os
 import shutil
 import subprocess
 import sys
+import threading
+from copy import deepcopy
 from pathlib import Path
-from typing import Dict, List, Optional, Set
+from typing import Any, Dict, List, Optional, Set
 
 
 from hermes_cli.config import (
     cfg_get,
-    load_config, save_config, get_env_value, save_env_value,
+    diagnostic_config_inspection,
+    get_env_value,
+    load_config,
+    load_config_for_diagnostics,
+    save_config,
+    save_env_value,
 )
 from hermes_cli.colors import Colors, color
 from hermes_cli.nous_subscription import (
@@ -35,6 +44,19 @@ from tools.tool_backend_helpers import fal_key_is_configured
 from utils import base_url_hostname, is_truthy_value
 
 logger = logging.getLogger(__name__)
+_diagnostic_output_lock = threading.RLock()
+
+
+@contextlib.contextmanager
+def _diagnostic_tool_module_inspection():
+    """Rollback tool modules imported only to project a diagnostic surface."""
+    modules_before = set(sys.modules)
+    try:
+        yield
+    finally:
+        for name in set(sys.modules) - modules_before:
+            if name == "model_tools" or name.startswith("tools."):
+                sys.modules.pop(name, None)
 
 
 def _post_setup_no_window_flags(*, streams_to_console: bool = False) -> int:
@@ -178,8 +200,9 @@ def _xai_credentials_present() -> bool:
     """
     try:
         from hermes_cli.auth import _read_xai_oauth_tokens
+        from tools.registry import is_read_only_tool_inspection
 
-        _read_xai_oauth_tokens()
+        _read_xai_oauth_tokens(_lock=not is_read_only_tool_inspection())
         return True
     except Exception:
         pass
@@ -5732,16 +5755,578 @@ def _known_tool_platforms() -> set[str]:
     """
     known = set(PLATFORMS)
     try:
-        from hermes_cli.plugins import discover_plugins
+        from hermes_cli.plugins import discover_plugins, get_plugin_manager
         from gateway.platform_registry import platform_registry
 
         discover_plugins()  # idempotent
+        known.update(get_plugin_manager()._plugin_platform_names)
         known.update(platform_registry.registered_names())
     except Exception:
         # Plugin discovery is optional. Preserve the built-in CLI path when a
         # third-party plugin is malformed or its dependencies are unavailable.
         pass
     return known
+
+
+def _diagnostic_memory_provider(
+    config: dict,
+) -> tuple[str, List[Dict[str, Any]], Optional[str]]:
+    """Load configured external memory schemas without initializing a session."""
+    memory_cfg = config.get("memory") or {}
+    provider_name = ""
+    if isinstance(memory_cfg, dict):
+        provider_name = str(memory_cfg.get("provider") or "").strip()
+    if not provider_name:
+        return "built_in", [], None
+
+    try:
+        from agent.memory_manager import MemoryManager
+        from plugins.memory import load_memory_provider
+
+        provider = load_memory_provider(provider_name, register_skills=False)
+        if provider is None:
+            return provider_name, [], "provider not found"
+        if not provider.is_available():
+            return provider_name, [], "provider unavailable"
+        manager = MemoryManager()
+        manager.add_provider(provider)
+        return provider_name, manager.get_all_tool_schemas(), None
+    except Exception:
+        logger.debug("Memory provider diagnostics failed", exc_info=True)
+        return provider_name, [], "provider inspection failed"
+
+
+def _diagnostic_context_engine(
+    config: dict,
+) -> tuple[str, List[Dict[str, Any]], Optional[str]]:
+    """Load configured context-engine schemas without model/session mutation."""
+    context_cfg = config.get("context") or {}
+    engine_name = "compressor"
+    if isinstance(context_cfg, dict):
+        engine_name = str(context_cfg.get("engine") or engine_name).strip()
+    if not engine_name or engine_name == "compressor":
+        return "compressor", [], None
+
+    try:
+        from plugins.context_engine import load_context_engine
+
+        engine = load_context_engine(engine_name, register_commands=False)
+        if engine is None:
+            import copy
+
+            from hermes_cli.plugins import get_plugin_context_engine
+
+            candidate = get_plugin_context_engine()
+            if candidate is not None and getattr(candidate, "name", None) == engine_name:
+                try:
+                    engine = copy.deepcopy(candidate)
+                except Exception:
+                    logger.debug(
+                        "Context-engine diagnostic copy failed", exc_info=True
+                    )
+                    return engine_name, [], "engine cannot be copied safely"
+        if engine is None:
+            return engine_name, [], "engine not found"
+        get_schemas = getattr(engine, "get_tool_schemas", None)
+        if not callable(get_schemas):
+            return engine_name, [], "engine exposes no tool schemas"
+        schemas = get_schemas()
+        if not isinstance(schemas, (list, tuple)):
+            return engine_name, [], "engine returned invalid tool schemas"
+        return engine_name, list(schemas), None
+    except Exception:
+        logger.debug("Context-engine diagnostics failed", exc_info=True)
+        return engine_name, [], "engine inspection failed"
+
+
+def _disabled_toolsets_for_diagnostics(
+    enabled_toolsets: Set[str], platform: str
+) -> List[str]:
+    """Return configurable toolsets disabled for ``platform``."""
+    all_toolsets = {
+        toolset
+        for toolset, _, _ in _get_effective_configurable_toolsets()
+        if _toolset_allowed_for_platform(toolset, platform)
+    }
+    return sorted(all_toolsets - enabled_toolsets)
+
+
+def build_tools_diagnostics(config: dict, platform: str) -> Dict[str, Any]:
+    """Return a pre-startup projection of the platform's tool surface."""
+    from agent.skill_utils import parse_config_string_list
+    from agent.tool_surface import assemble_full_tool_surface
+    from model_tools import (
+        _resolve_active_context_length,
+        get_tool_definitions,
+        resolve_disabled_tool_names,
+    )
+    from toolsets import resolve_toolset
+    from tools.registry import registry
+    from tools.tool_search import ToolSearchConfig
+
+    enabled_toolsets = _get_platform_tools(config, platform)
+    enabled_list = sorted(enabled_toolsets)
+    platform_toolsets = config.get("platform_toolsets") or {}
+    explicit_platform_config = (
+        isinstance(platform_toolsets, dict)
+        and isinstance(platform_toolsets.get(platform), list)
+    )
+    agent_cfg = config.get("agent") or {}
+    disabled_raw = (
+        agent_cfg.get("disabled_toolsets") or []
+        if isinstance(agent_cfg, dict)
+        else []
+    )
+    disabled_list = sorted(
+        {
+            name.strip()
+            for name in parse_config_string_list(disabled_raw)
+            if name.strip()
+        }
+    )
+    disabled_tool_names = resolve_disabled_tool_names(disabled_list)
+    default_toolset = PLATFORMS.get(platform, {}).get(
+        "default_toolset", f"hermes-{platform}"
+    )
+    config_sources = {
+        "toolset_selection": (
+            f"platform_toolsets.{platform}"
+            if explicit_platform_config
+            else f"platform default ({default_toolset})"
+        ),
+        "global_disabled_toolsets": disabled_list,
+    }
+
+    base_tool_defs = get_tool_definitions(
+        enabled_toolsets=enabled_list,
+        disabled_toolsets=disabled_list,
+        quiet_mode=True,
+        skip_tool_search_assembly=True,
+        record_resolved_names=False,
+        cache_result=False,
+        cache_availability_checks=False,
+    )
+    memory_provider, memory_schemas, memory_error = _diagnostic_memory_provider(
+        config
+    )
+    context_provider, context_schemas, context_error = _diagnostic_context_engine(
+        config
+    )
+
+    tools_cfg = config.get("tools") or {}
+    if not isinstance(tools_cfg, dict):
+        tools_cfg = {}
+    tool_search_config = ToolSearchConfig.from_raw(tools_cfg.get("tool_search"))
+    context_length = None
+    if tool_search_config.enabled != "off":
+        context_length = _resolve_active_context_length(config)
+
+    surface = assemble_full_tool_surface(
+        base_tool_defs,
+        enabled_toolsets=enabled_list,
+        disabled_toolsets=disabled_list,
+        memory_tool_schemas=memory_schemas,
+        context_engine_tool_schemas=context_schemas,
+        context_length=context_length,
+        tool_search_config=tool_search_config,
+    )
+    tools_visible = sorted(
+        name
+        for tool in surface.tool_defs
+        if (name := tool.get("function", {}).get("name"))
+    )
+    visible_set = set(tools_visible)
+    pre_assembly_names = {
+        name
+        for tool in surface.pre_assembly_tool_defs
+        if (name := tool.get("function", {}).get("name"))
+    }
+    deferred_set = set(surface.deferred_names)
+
+    all_tool_names = registry.get_all_tool_names()
+    tools_by_toolset: Dict[str, List[str]] = {}
+    filtered = []
+    for tool_name in all_tool_names:
+        toolset = registry.get_toolset_for_tool(tool_name) or ""
+        tools_by_toolset.setdefault(toolset, []).append(tool_name)
+        if tool_name in visible_set:
+            continue
+        if tool_name in deferred_set:
+            reason = "deferred by tool search"
+        elif tool_name not in pre_assembly_names:
+            reason = (
+                "toolset disabled"
+                if toolset not in enabled_toolsets
+                or tool_name in disabled_tool_names
+                else "availability check failed"
+            )
+        else:
+            reason = "not model-visible"
+        filtered.append(
+            {"tool": tool_name, "toolset": toolset, "reason": reason}
+        )
+
+    registered = set(all_tool_names)
+    for toolset in enabled_list:
+        for tool_name in sorted(resolve_toolset(toolset)):
+            if tool_name not in registered:
+                filtered.append(
+                    {
+                        "tool": tool_name,
+                        "toolset": toolset,
+                        "reason": "not registered",
+                    }
+                )
+
+    def _external_status(
+        family: str,
+        provider: str,
+        schemas: List[Dict[str, Any]],
+        inspection_error: Optional[str],
+    ) -> Dict[str, Any]:
+        injected_names = surface.injected_names[family]
+        skipped = surface.skipped[family]
+        skipped_reason = inspection_error
+        if skipped_reason is None and skipped:
+            skipped_reason = skipped[0]["reason"]
+        return {
+            "provider": provider,
+            "schemas": len(schemas),
+            "injected": len(set(injected_names) & visible_set),
+            "skipped_reason": skipped_reason,
+            "skipped": skipped,
+        }
+
+    provider_tools: Dict[str, Dict[str, Any]] = {
+        "memory": _external_status(
+            "memory", memory_provider, memory_schemas, memory_error
+        ),
+        "context_engine": _external_status(
+            "context_engine", context_provider, context_schemas, context_error
+        ),
+    }
+
+    mcp_names = {
+        name
+        for toolset, names in tools_by_toolset.items()
+        if toolset.startswith("mcp-")
+        for name in names
+    }
+    mcp_servers = config.get("mcp_servers") or {}
+    configured_servers = (
+        sorted(str(name) for name in mcp_servers)
+        if isinstance(mcp_servers, dict)
+        else []
+    )
+    provider_tools["mcp"] = {
+        "provider": "mcp",
+        "schemas": len(mcp_names),
+        "injected": len(mcp_names & visible_set),
+        "deferred": len(mcp_names & deferred_set),
+        "configured_servers": configured_servers,
+        "skipped_reason": (
+            "no MCP tools registered in this process"
+            if configured_servers and not mcp_names
+            else None
+        ),
+    }
+
+    try:
+        from hermes_cli.plugins import get_plugin_tool_names
+
+        plugin_names = set(get_plugin_tool_names()) & registered
+    except Exception:
+        logger.debug("Plugin tool ownership inspection failed", exc_info=True)
+        plugin_names = set()
+    plugin_toolsets = sorted(
+        {
+            toolset
+            for name in plugin_names
+            if (toolset := registry.get_toolset_for_tool(name))
+        }
+    )
+    provider_tools["plugins"] = {
+        "provider": "plugins",
+        "schemas": len(plugin_names),
+        "injected": len(plugin_names & visible_set),
+        "deferred": len(plugin_names & deferred_set),
+        "toolsets": plugin_toolsets,
+        "skipped_reason": None,
+    }
+
+    seen_names: set[str] = set()
+    duplicate_names: set[str] = set()
+    for name in tools_visible:
+        if name in seen_names:
+            duplicate_names.add(name)
+        seen_names.add(name)
+
+    conflicts = [
+        {
+            "tool": item.get("tool", ""),
+            "reason": item.get("reason", "external schema conflict"),
+            "source": family,
+        }
+        for family in ("memory", "context_engine")
+        for item in surface.skipped[family]
+    ]
+    conflicts.extend(
+        {"tool": name, "reason": "duplicate visible tool name"}
+        for name in sorted(duplicate_names)
+    )
+    try:
+        from hermes_cli.plugins import get_diagnostic_plugin_conflicts
+
+        conflicts.extend(get_diagnostic_plugin_conflicts())
+    except Exception:
+        logger.debug("Plugin conflict inspection failed", exc_info=True)
+
+    return {
+        "platform": platform,
+        "resolution": {
+            "phase": "pre_startup",
+            "detail": (
+                "Projects the startup surface; MCP tools must already be "
+                "registered in this process."
+            ),
+        },
+        "enabled_toolsets": enabled_list,
+        "disabled_toolsets": _disabled_toolsets_for_diagnostics(
+            enabled_toolsets, platform
+        ),
+        "config_sources": config_sources,
+        "tools_visible": tools_visible,
+        "tool_search": {
+            "activated": surface.tool_search_activated,
+            "deferred": len(surface.deferred_names),
+            "deferred_tokens": surface.deferred_tokens,
+            "threshold_tokens": surface.threshold_tokens,
+            "tier": surface.tool_search_tier,
+            "listing_form": surface.tool_search_listing_form,
+        },
+        "provider_tools": provider_tools,
+        "filtered": sorted(
+            filtered,
+            key=lambda item: (item["reason"], item["toolset"], item["tool"]),
+        ),
+        "conflicts": conflicts,
+    }
+
+
+def _terminal_safe_text(value: Any) -> str:
+    """Escape terminal controls while preserving printable Unicode."""
+    text = str(value)
+    return "".join(
+        char if char.isprintable() else repr(char)[1:-1]
+        for char in text
+    )
+
+
+def _print_tools_diagnostics(diag: Dict[str, Any]) -> None:
+    """Render diagnostics in a low-noise human-readable format."""
+    safe = _terminal_safe_text
+    print(f"Tool diagnostics ({safe(diag['platform'])}):")
+    resolution = diag.get("resolution") or {}
+    if resolution:
+        print(
+            f"  Resolution: {safe(resolution.get('phase', '-'))}; "
+            f"{safe(resolution.get('detail', '-'))}"
+        )
+    enabled = ", ".join(safe(value) for value in diag["enabled_toolsets"]) or "-"
+    visible = ", ".join(safe(value) for value in diag["tools_visible"]) or "-"
+    print(f"  Enabled toolsets ({len(diag['enabled_toolsets'])}): {enabled}")
+    config_sources = diag.get("config_sources") or {}
+    if config_sources:
+        print(
+            "  Config source: "
+            f"{safe(config_sources.get('toolset_selection', '-'))}"
+        )
+        disabled = config_sources.get("global_disabled_toolsets") or []
+        if disabled:
+            print(
+                "  Globally disabled: "
+                + ", ".join(safe(value) for value in disabled)
+            )
+    print(f"  Visible tools ({len(diag['tools_visible'])}): {visible}")
+    tool_search = diag.get("tool_search") or {}
+    if tool_search:
+        state = "active" if tool_search.get("activated") else "inactive"
+        print(
+            f"  Tool search: {state}; deferred={tool_search.get('deferred', 0)} "
+            f"tokens~{tool_search.get('deferred_tokens', 0)} "
+            f"tier={tool_search.get('tier', 0)} "
+            f"listing={safe(tool_search.get('listing_form', 'none'))}"
+        )
+
+    provider_tools = diag.get("provider_tools") or {}
+    if provider_tools:
+        print("  Provider tools:")
+        for name, info in provider_tools.items():
+            status = safe(info.get("skipped_reason") or "ok")
+            extra = ""
+            if name == "mcp" and info.get("configured_servers"):
+                extra = " servers=" + ",".join(
+                    safe(value) for value in info["configured_servers"]
+                )
+            elif name == "plugins" and info.get("toolsets"):
+                extra = " toolsets=" + ",".join(
+                    safe(value) for value in info["toolsets"]
+                )
+            print(
+                f"    {safe(name)}: provider={safe(info.get('provider'))} "
+                f"schemas={info.get('schemas', 0)} "
+                f"injected={info.get('injected', 0)} "
+                f"status={status}{extra}"
+            )
+
+    filtered = diag.get("filtered") or []
+    print(f"  Filtered tools ({len(filtered)}):")
+    for item in filtered[:50]:
+        print(
+            f"    {safe(item['tool'])} ({safe(item['toolset'])}): "
+            f"{safe(item['reason'])}"
+        )
+    if len(filtered) > 50:
+        print(f"    ... {len(filtered) - 50} more; use --json for full output")
+
+    conflicts = diag.get("conflicts") or []
+    print(f"  Conflicts ({len(conflicts)}):")
+    for item in conflicts:
+        print(f"    {safe(item['tool'])}: {safe(item['reason'])}")
+
+
+@contextlib.contextmanager
+def _suppress_diagnostic_output():
+    """Discard provider output and expose a safe original-FD emitter."""
+    with _diagnostic_output_lock, open(os.devnull, "w", encoding="utf-8") as sink:
+        for stream in (sys.stdout, sys.stderr):
+            try:
+                stream.flush()
+            except Exception:
+                pass
+
+        saved_fds = {}
+        try:
+            for fd in (1, 2):
+                saved_fds[fd] = os.dup(fd)
+            for fd in (1, 2):
+                os.dup2(sink.fileno(), fd)
+        except OSError as exc:
+            for fd, saved_fd in saved_fds.items():
+                try:
+                    os.dup2(saved_fd, fd)
+                except OSError:
+                    pass
+            for saved_fd in saved_fds.values():
+                try:
+                    os.close(saved_fd)
+                except OSError:
+                    pass
+            raise RuntimeError("could not quarantine diagnostic output") from exc
+
+        def emit(stdout_text: str = "", stderr_text: str = "") -> None:
+            for fd, text in ((1, stdout_text), (2, stderr_text)):
+                if not text:
+                    continue
+                pending = memoryview(text.encode("utf-8", errors="replace"))
+                while pending:
+                    try:
+                        written = os.write(saved_fds[fd], pending)
+                    except InterruptedError:
+                        continue
+                    pending = pending[written:]
+
+        try:
+            with contextlib.redirect_stdout(sink), contextlib.redirect_stderr(sink):
+                yield emit
+        finally:
+            try:
+                sink.flush()
+            except Exception:
+                pass
+            for fd, saved_fd in saved_fds.items():
+                try:
+                    os.dup2(saved_fd, fd)
+                except OSError:
+                    pass
+            for saved_fd in saved_fds.values():
+                try:
+                    os.close(saved_fd)
+                except OSError:
+                    pass
+
+
+def _render_tools_diagnose_result(diag, platform, json_mode, valid_platforms):
+    stdout = io.StringIO()
+    stderr = io.StringIO()
+    with contextlib.redirect_stdout(stdout), contextlib.redirect_stderr(stderr):
+        if diag is not None:
+            if json_mode:
+                print(_json.dumps(diag, indent=2, sort_keys=True))
+            else:
+                _print_tools_diagnostics(diag)
+            return stdout.getvalue(), stderr.getvalue(), 0
+
+        valid = sorted(valid_platforms)
+        message = f"Unknown platform '{platform}'. Valid: {', '.join(valid)}"
+        if json_mode:
+            print(
+                _json.dumps(
+                    {
+                        "error": {
+                            "code": "unknown_platform",
+                            "message": message,
+                            "platform": platform,
+                            "valid_platforms": valid,
+                        }
+                    },
+                    indent=2,
+                    sort_keys=True,
+                )
+            )
+        else:
+            print(f"✗ {_terminal_safe_text(message)}", file=sys.stderr)
+    return stdout.getvalue(), stderr.getvalue(), 2
+
+
+def tools_diagnose_command(args):
+    """Print a pre-startup projection of one platform's tool surface."""
+    platform = getattr(args, "platform", "cli")
+    json_mode = bool(getattr(args, "json", False))
+
+    from hermes_cli.plugins import diagnostic_plugin_inspection
+    from tools.registry import read_only_tool_inspection
+
+    with _suppress_diagnostic_output() as emit:
+        with (
+            diagnostic_config_inspection(),
+            _diagnostic_tool_module_inspection(),
+            read_only_tool_inspection(),
+            diagnostic_plugin_inspection(),
+        ):
+            config = load_config_for_diagnostics()
+            from tools.registry import discover_builtin_tools
+
+            discover_builtin_tools()
+            valid_platforms = _known_tool_platforms()
+            diag = (
+                build_tools_diagnostics(config, platform)
+                if platform in valid_platforms
+                else None
+            )
+        stdout_text, stderr_text, result = _render_tools_diagnose_result(
+            diag,
+            platform,
+            json_mode,
+            valid_platforms,
+        )
+        if os.environ.get("HERMES_TOOLS_DIAGNOSE_READ_ONLY") == "1":
+            emit(stdout_text, stderr_text)
+            os._exit(result)
+
+    sys.stdout.write(stdout_text)
+    sys.stderr.write(stderr_text)
+    return result
 
 
 def tools_disable_enable_command(args):

--- a/model_tools.py
+++ b/model_tools.py
@@ -221,6 +221,22 @@ TOOLSET_REQUIREMENTS: Dict[str, dict] = registry.get_toolset_requirements()
 _last_resolved_tool_names: List[str] = []
 
 
+def record_resolved_tool_names(tool_defs: List[Dict[str, Any]]) -> None:
+    """Publish a finalized runtime surface for legacy process-global callers.
+
+    Pure diagnostics intentionally do not call this; agent/runtime assembly
+    publishes only after the complete surface is ready.
+    """
+    global _last_resolved_tool_names
+    _last_resolved_tool_names = [
+        tool["function"]["name"]
+        for tool in tool_defs
+        if isinstance(tool, dict)
+        and isinstance(tool.get("function"), dict)
+        and tool["function"].get("name")
+    ]
+
+
 # =============================================================================
 # Legacy toolset name mapping  (old _tools-suffixed names -> tool name lists)
 # =============================================================================
@@ -248,7 +264,8 @@ _LEGACY_TOOLSET_MAP = {
 # =============================================================================
 
 # Module-level memoization for get_tool_definitions(). Keyed on
-# (frozenset(enabled_toolsets), frozenset(disabled_toolsets), registry._generation).
+# (frozenset(enabled_toolsets), frozenset(disabled_toolsets), registry generation,
+# config fingerprint, kanban mode, skip_tool_search_assembly).
 # Hot callers (gateway runner, AIAgent.__init__) invoke this on every turn
 # with quiet_mode=True; caching avoids ~7 ms of registry walking + schema
 # filtering + check_fn probing per call. Only active when quiet_mode=True
@@ -281,6 +298,7 @@ def get_tool_definitions(
     disabled_toolsets: Optional[List[str]] = None,
     quiet_mode: bool = False,
     skip_tool_search_assembly: bool = False,
+    record_resolved_names: bool = True,
 ) -> List[Dict[str, Any]]:
     """
     Get tool definitions for model API calls with toolset-based filtering.
@@ -296,6 +314,8 @@ def get_tool_definitions(
             tool_search / tool_describe bridge handlers so they can read the
             real catalog, not the already-collapsed one. Public callers should
             leave this False.
+        record_resolved_names: Update the legacy process-global resolved-name
+            list. Pure inspection callers should pass False.
 
     Returns:
         Filtered list of OpenAI-format tool definitions.
@@ -328,14 +348,19 @@ def get_tool_definitions(
         if cached is not None:
             # Update _last_resolved_tool_names so downstream callers see
             # consistent state even on a cache hit.
-            global _last_resolved_tool_names
-            _last_resolved_tool_names = [t["function"]["name"] for t in cached]
+            if record_resolved_names:
+                record_resolved_tool_names(cached)
             # Return a shallow copy of the list but share the dict references —
             # schemas are treated as read-only by all known callers.
             return list(cached)
 
-    result = _compute_tool_definitions(enabled_toolsets, disabled_toolsets, quiet_mode,
-                                       skip_tool_search_assembly=skip_tool_search_assembly)
+    result = _compute_tool_definitions(
+        enabled_toolsets,
+        disabled_toolsets,
+        quiet_mode,
+        skip_tool_search_assembly=skip_tool_search_assembly,
+        record_resolved_names=record_resolved_names,
+    )
     if quiet_mode:
         # Cache the freshly-computed list, but hand callers a shallow copy so
         # downstream mutations (e.g. run_agent appending memory/LCM tool
@@ -359,6 +384,7 @@ def _compute_tool_definitions(
     disabled_toolsets: Optional[List[str]] = None,
     quiet_mode: bool = False,
     skip_tool_search_assembly: bool = False,
+    record_resolved_names: bool = True,
 ) -> List[Dict[str, Any]]:
     """Uncached implementation of :func:`get_tool_definitions`."""
     # Determine which tool names the caller wants
@@ -519,63 +545,52 @@ def _compute_tool_definitions(
         else:
             print("🛠️  No tools selected (all filtered out or unavailable)")
 
-    global _last_resolved_tool_names
-    _last_resolved_tool_names = [t["function"]["name"] for t in filtered_tools]
+    # Finalize through the same non-mutating path used by agent initialization,
+    # MCP refreshes, and `hermes tools diagnose`. External provider/context
+    # schemas are supplied by those callers; normal registry resolution has no
+    # additional families to append here.
+    from agent.tool_surface import assemble_full_tool_surface
 
-    # Sanitize schemas for broad backend compatibility. llama.cpp's
-    # json-schema-to-grammar converter (used by its OAI server to build
-    # GBNF tool-call parsers) rejects some shapes that cloud providers
-    # silently accept — bare "type": "object" with no properties,
-    # string-valued schema nodes from malformed MCP servers, etc. This
-    # is a no-op for schemas that are already well-formed.
-    try:
-        from tools.schema_sanitizer import sanitize_tool_schemas
-        filtered_tools = sanitize_tool_schemas(filtered_tools)
-    except Exception as e:  # pragma: no cover — defensive
-        logger.warning("Schema sanitization skipped: %s", e)
+    tool_search_config = None
+    context_length = None
+    if not skip_tool_search_assembly:
+        try:
+            from tools.tool_search import load_config as _load_ts_config
 
-    # ── Tool Search (progressive disclosure) ────────────────────────────
-    # Conditionally replace MCP + plugin (non-core) tools with three bridge
-    # tools (tool_search / tool_describe / tool_call) when the deferrable
-    # surface exceeds the configured threshold (default 10% of context
-    # window). Core Hermes tools (toolsets._HERMES_CORE_TOOLS) are NEVER
-    # deferred. See tools/tool_search.py for full design notes.
-    #
-    # This is deliberately the last step before returning — sanitization
-    # has already normalized schemas, and the assembly is idempotent in
-    # case some caller invokes get_tool_definitions twice.
-    try:
-        from tools.tool_search import assemble_tool_defs, load_config as _load_ts_config
-        ts_cfg = _load_ts_config()
-        if not skip_tool_search_assembly and ts_cfg.enabled != "off":
-            context_length = _resolve_active_context_length()
-            assembly = assemble_tool_defs(
-                filtered_tools,
-                context_length=context_length,
-                config=ts_cfg,
-            )
-            if assembly.activated and not quiet_mode:
-                print(
-                    f"🔎 Tool Search: {assembly.deferred_count} MCP/plugin tools deferred "
-                    f"(~{assembly.deferred_tokens} tokens) behind tool_search/describe/call. "
-                    f"Threshold ~{assembly.threshold_tokens} tokens."
-                )
-            filtered_tools = assembly.tool_defs
-    except Exception as e:  # pragma: no cover — never break tool loading
-        logger.warning("Tool search assembly skipped: %s", e)
+            tool_search_config = _load_ts_config()
+            if tool_search_config.enabled != "off":
+                context_length = _resolve_active_context_length()
+        except Exception as exc:  # pragma: no cover - fail soft as before
+            logger.warning("Tool search config load skipped: %s", exc)
 
+    full_surface = assemble_full_tool_surface(
+        filtered_tools,
+        apply_tool_search=not skip_tool_search_assembly,
+        context_length=context_length,
+        tool_search_config=tool_search_config,
+        quiet_mode=quiet_mode,
+    )
+    filtered_tools = full_surface.tool_defs
+    if record_resolved_names:
+        record_resolved_tool_names(filtered_tools)
     return filtered_tools
 
 
-def _resolve_active_context_length() -> int:
+def _resolve_active_context_length(config: Optional[Dict[str, Any]] = None) -> int:
     """Look up the active model's context length for the tool-search gate.
 
-    Returns 0 when the model can't be resolved — ``should_activate`` falls
-    back to a fixed token cutoff in that case.
+    ``config`` lets inspection callers resolve the exact snapshot they are
+    reporting without re-reading mutable on-disk state. Returns 0 when the
+    model can't be resolved, so ``should_activate`` falls back to its fixed
+    token cutoff.
     """
     try:
-        from hermes_cli.config import load_config as _load
-        cfg = _load() or {}
+        if config is None:
+            from hermes_cli.config import load_config as _load
+
+            cfg = _load() or {}
+        else:
+            cfg = config
         model_cfg = cfg.get("model") if isinstance(cfg.get("model"), dict) else {}
         if not isinstance(model_cfg, dict):
             model_cfg = {}

--- a/model_tools.py
+++ b/model_tools.py
@@ -1113,6 +1113,7 @@ def handle_function_call(
                 enabled_toolsets=enabled_toolsets,
                 disabled_toolsets=disabled_toolsets,
                 quiet_mode=True, skip_tool_search_assembly=True,
+                record_resolved_names=False,
             ) or []
         except Exception:
             current_defs = []

--- a/model_tools.py
+++ b/model_tools.py
@@ -29,6 +29,7 @@ from contextvars import ContextVar
 import logging
 import threading
 import time
+from copy import deepcopy
 from typing import Dict, Any, List, Optional, Tuple
 
 from tools.registry import (
@@ -263,6 +264,18 @@ TOOLSET_REQUIREMENTS: Dict[str, dict] = registry.get_toolset_requirements()
 _last_resolved_tool_names: List[str] = []
 
 
+def record_resolved_tool_names(tool_defs: List[Dict[str, Any]]) -> None:
+    """Publish a finalized runtime surface for legacy process-global callers."""
+    global _last_resolved_tool_names
+    _last_resolved_tool_names = [
+        tool["function"]["name"]
+        for tool in tool_defs
+        if isinstance(tool, dict)
+        and isinstance(tool.get("function"), dict)
+        and tool["function"].get("name")
+    ]
+
+
 # =============================================================================
 # Legacy toolset name mapping  (old _tools-suffixed names -> tool name lists)
 # =============================================================================
@@ -325,6 +338,9 @@ def get_tool_definitions(
     disabled_toolsets: Optional[List[str]] = None,
     quiet_mode: bool = False,
     skip_tool_search_assembly: bool = False,
+    record_resolved_names: bool = True,
+    cache_result: bool = True,
+    cache_availability_checks: bool = True,
 ) -> List[Dict[str, Any]]:
     """
     Get tool definitions for model API calls with toolset-based filtering.
@@ -340,6 +356,12 @@ def get_tool_definitions(
             tool_search / tool_describe bridge handlers so they can read the
             real catalog, not the already-collapsed one. Public callers should
             leave this False.
+        record_resolved_names: Publish the result to the legacy process-global
+            resolved-name list. Pure inspection callers should pass False.
+        cache_result: Allow memoizing a cache miss. Pure inspection callers
+            should pass False to avoid process-global cache mutation.
+        cache_availability_checks: Allow fresh availability probes to populate
+            the registry TTL cache. Pure inspection callers should pass False.
 
     Returns:
         Filtered list of OpenAI-format tool definitions.
@@ -353,7 +375,7 @@ def get_tool_definitions(
     # mode, discord action allowlist, etc.) without needing an explicit
     # invalidate hook on every config-writer.
     cache_key = None
-    if quiet_mode:
+    if quiet_mode and cache_result:
         try:
             from hermes_cli.config import get_config_path
             cfg_path = get_config_path()
@@ -380,15 +402,21 @@ def get_tool_definitions(
         if cached is not None:
             # Update _last_resolved_tool_names so downstream callers see
             # consistent state even on a cache hit.
-            global _last_resolved_tool_names
-            _last_resolved_tool_names = [t["function"]["name"] for t in cached]
+            if record_resolved_names:
+                record_resolved_tool_names(cached)
             # Return a shallow copy of the list but share the dict references —
             # schemas are treated as read-only by all known callers.
             return list(cached)
 
-    result = _compute_tool_definitions(enabled_toolsets, disabled_toolsets, quiet_mode,
-                                       skip_tool_search_assembly=skip_tool_search_assembly)
-    if quiet_mode and cache_key is not None:
+    result = _compute_tool_definitions(
+        enabled_toolsets,
+        disabled_toolsets,
+        quiet_mode,
+        skip_tool_search_assembly=skip_tool_search_assembly,
+        record_resolved_names=record_resolved_names,
+        cache_availability_checks=cache_availability_checks,
+    )
+    if quiet_mode and cache_key is not None and cache_result:
         # Cache the freshly-computed list, but hand callers a shallow copy so
         # downstream mutations (e.g. run_agent appending memory/LCM tool
         # schemas to self.tools) don't poison the cache. Without this, a
@@ -419,6 +447,8 @@ def _compute_tool_definitions(
     disabled_toolsets: Optional[List[str]] = None,
     quiet_mode: bool = False,
     skip_tool_search_assembly: bool = False,
+    record_resolved_names: bool = True,
+    cache_availability_checks: bool = True,
 ) -> List[Dict[str, Any]]:
     """Uncached implementation of :func:`get_tool_definitions`."""
     # Determine which tool names the caller wants
@@ -507,7 +537,14 @@ def _compute_tool_definitions(
     # other toolset.
 
     # Ask the registry for schemas (only returns tools whose check_fn passes)
-    filtered_tools = registry.get_definitions(tools_to_include, quiet=quiet_mode)
+    if cache_availability_checks:
+        filtered_tools = registry.get_definitions(tools_to_include, quiet=quiet_mode)
+    else:
+        filtered_tools = registry.get_definitions(
+            tools_to_include,
+            quiet=quiet_mode,
+            cache_checks=False,
+        )
 
     # The set of tool names that actually passed check_fn filtering.
     # Use this (not tools_to_include) for any downstream schema that references
@@ -599,68 +636,66 @@ def _compute_tool_definitions(
         else:
             print("🛠️  No tools selected (all filtered out or unavailable)")
 
-    global _last_resolved_tool_names
-    _last_resolved_tool_names = [t["function"]["name"] for t in filtered_tools]
+    from agent.tool_surface import assemble_full_tool_surface
 
-    # Sanitize schemas for broad backend compatibility. llama.cpp's
-    # json-schema-to-grammar converter (used by its OAI server to build
-    # GBNF tool-call parsers) rejects some shapes that cloud providers
-    # silently accept — bare "type": "object" with no properties,
-    # string-valued schema nodes from malformed MCP servers, etc. This
-    # is a no-op for schemas that are already well-formed.
-    try:
-        from tools.schema_sanitizer import sanitize_tool_schemas
-        filtered_tools = sanitize_tool_schemas(filtered_tools)
-    except Exception as e:  # pragma: no cover — defensive
-        logger.warning("Schema sanitization skipped: %s", e)
+    tool_search_config = None
+    context_length = None
+    if not skip_tool_search_assembly:
+        try:
+            from tools.tool_search import load_config as _load_ts_config
 
-    # ── Tool Search (progressive disclosure) ────────────────────────────
-    # Conditionally replace MCP + plugin (non-core) tools with three bridge
-    # tools (tool_search / tool_describe / tool_call) when the deferrable
-    # surface exceeds the configured threshold (default 10% of context
-    # window). Core Hermes tools (toolsets._HERMES_CORE_TOOLS) are NEVER
-    # deferred. See tools/tool_search.py for full design notes.
-    #
-    # This is deliberately the last step before returning — sanitization
-    # has already normalized schemas, and the assembly is idempotent in
-    # case some caller invokes get_tool_definitions twice.
-    try:
-        from tools.tool_search import assemble_tool_defs, load_config as _load_ts_config
-        ts_cfg = _load_ts_config()
-        if not skip_tool_search_assembly and ts_cfg.enabled != "off":
-            context_length = _resolve_active_context_length()
-            assembly = assemble_tool_defs(
-                filtered_tools,
-                context_length=context_length,
-                config=ts_cfg,
-            )
-            if assembly.activated and not quiet_mode:
-                _forms = {"full": "catalog listing embedded",
-                          "names": "names-only listing embedded",
-                          "mixed": "listing embedded (oversized servers summarized)",
-                          "groups": "server summary embedded (search-only discovery)",
-                          "none": "no listing (search-only)"}
-                print(
-                    f"🔎 Tool Search (tier {assembly.tier}): {assembly.deferred_count} "
-                    f"MCP/plugin tools deferred (~{assembly.deferred_tokens} tokens) behind "
-                    f"tool_search/describe/call — {_forms.get(assembly.listing_form, assembly.listing_form)}."
-                )
-            filtered_tools = assembly.tool_defs
-    except Exception as e:  # pragma: no cover — never break tool loading
-        logger.warning("Tool search assembly skipped: %s", e)
+            tool_search_config = _load_ts_config()
+            if tool_search_config.enabled != "off":
+                context_length = _resolve_active_context_length()
+        except Exception as exc:  # pragma: no cover - fail soft as before
+            logger.warning("Tool search config load skipped: %s", exc)
+
+    surface = assemble_full_tool_surface(
+        filtered_tools,
+        apply_tool_search=not skip_tool_search_assembly,
+        context_length=context_length,
+        tool_search_config=tool_search_config,
+        quiet_mode=quiet_mode,
+    )
+    filtered_tools = surface.tool_defs
+    if record_resolved_names:
+        record_resolved_tool_names(filtered_tools)
 
     return filtered_tools
 
 
-def _resolve_active_context_length() -> int:
+def resolve_disabled_tool_names(disabled_toolsets: Optional[List[str]]) -> set[str]:
+    """Resolve the effective tool-name subtraction for disabled toolsets."""
+    disabled_names: set[str] = set()
+    for toolset_name in disabled_toolsets or []:
+        if validate_toolset(toolset_name):
+            from toolsets import bundle_non_core_tools, get_toolset
+
+            if toolset_name.startswith("hermes-") or (
+                get_toolset(toolset_name) or {}
+            ).get("posture"):
+                disabled_names.update(bundle_non_core_tools(toolset_name))
+            else:
+                disabled_names.update(resolve_toolset(toolset_name))
+        elif toolset_name in _LEGACY_TOOLSET_MAP:
+            disabled_names.update(_LEGACY_TOOLSET_MAP[toolset_name])
+    return disabled_names
+
+
+def _resolve_active_context_length(config: Optional[Dict[str, Any]] = None) -> int:
     """Look up the active model's context length for the tool-search gate.
 
-    Returns 0 when the model can't be resolved — ``should_activate`` falls
-    back to a fixed token cutoff in that case.
+    ``config`` lets inspection callers resolve the exact snapshot they are
+    reporting without re-reading mutable on-disk state. Returns 0 when the
+    model can't be resolved, so the disclosure budget uses its fixed fallback.
     """
     try:
-        from hermes_cli.config import load_config as _load
-        cfg = _load() or {}
+        if config is None:
+            from hermes_cli.config import load_config as _load
+
+            cfg = _load() or {}
+        else:
+            cfg = config
         model_cfg = cfg.get("model") if isinstance(cfg.get("model"), dict) else {}
         if not isinstance(model_cfg, dict):
             model_cfg = {}
@@ -794,7 +829,12 @@ def _sanitize_tool_error(error_msg: str) -> str:
 # Tool argument type coercion
 # =========================================================================
 
-def coerce_tool_args(tool_name: str, args: Dict[str, Any]) -> Dict[str, Any]:
+def coerce_tool_args(
+    tool_name: str,
+    args: Dict[str, Any],
+    *,
+    schema: Optional[Dict[str, Any]] = None,
+) -> Dict[str, Any]:
     """Coerce tool call arguments to match their JSON Schema types.
 
     LLMs frequently return numbers as strings (``"42"`` instead of ``42``)
@@ -815,7 +855,8 @@ def coerce_tool_args(tool_name: str, args: Dict[str, Any]) -> Dict[str, Any]:
     if not args or not isinstance(args, dict):
         return args
 
-    schema = registry.get_schema(tool_name)
+    if schema is None:
+        schema = registry.get_schema(tool_name)
     if not schema:
         return args
 
@@ -1205,6 +1246,8 @@ def handle_function_call(
     tool_request_middleware_trace: Optional[List[Dict[str, Any]]] = None,
     enabled_toolsets: Optional[List[str]] = None,
     disabled_toolsets: Optional[List[str]] = None,
+    catalog_tool_defs: Optional[List[dict]] = None,
+    expected_registry_entries: Optional[Dict[str, Any]] = None,
 ) -> str:
     """
     Main function call dispatcher that routes calls to the tool registry.
@@ -1230,8 +1273,23 @@ def handle_function_call(
     Returns:
         Function result as a JSON string.
     """
-    # Coerce string arguments to their schema-declared types (e.g. "42"→42)
-    function_args = coerce_tool_args(function_name, function_args)
+    expected_entry = (expected_registry_entries or {}).get(function_name)
+    if expected_entry is not None:
+        registration_error = registry.expected_entry_error(
+            function_name,
+            expected_entry,
+        )
+        if registration_error is not None:
+            return tool_error(registration_error)
+    # Coerce against the same registration generation that dispatch validates.
+    # A same-name refresh may replace the live schema while this request is in
+    # flight; consulting it would transform arguments against a tool the model
+    # never saw.
+    function_args = coerce_tool_args(
+        function_name,
+        function_args,
+        schema=expected_entry.schema if expected_entry is not None else None,
+    )
     if not isinstance(function_args, dict):
         function_args = {}
     _tool_middleware_trace = list(tool_request_middleware_trace or [])
@@ -1279,18 +1337,31 @@ def handle_function_call(
             # the deferred catalog identical to the deferrable subset of the
             # session's own tool list, and avoids polluting the process-global
             # _last_resolved_tool_names with out-of-scope tools.
-            current_defs = get_tool_definitions(
-                enabled_toolsets=enabled_toolsets,
-                disabled_toolsets=disabled_toolsets,
-                quiet_mode=True, skip_tool_search_assembly=True,
-            ) or []
+            current_defs = (
+                deepcopy(catalog_tool_defs)
+                if catalog_tool_defs is not None
+                else get_tool_definitions(
+                    enabled_toolsets=enabled_toolsets,
+                    disabled_toolsets=disabled_toolsets,
+                    quiet_mode=True,
+                    skip_tool_search_assembly=True,
+                    record_resolved_names=False,
+                )
+                or []
+            )
         except Exception:
             current_defs = []
+        deferred_sources = None
+        if expected_registry_entries is not None:
+            deferred_sources = _ts_mod.deferred_sources_from_registry_entries(
+                expected_registry_entries
+            )
         if function_name == _ts_mod.TOOL_SEARCH_NAME:
             return _return_bridge_result(
                 _ts_mod.dispatch_tool_search(
                     function_args or {},
                     current_tool_defs=current_defs,
+                    deferred_sources=deferred_sources,
                 )
             )
         if function_name == _ts_mod.TOOL_DESCRIBE_NAME:
@@ -1298,22 +1369,28 @@ def handle_function_call(
                 _ts_mod.dispatch_tool_describe(
                     function_args or {},
                     current_tool_defs=current_defs,
+                    deferred_sources=deferred_sources,
                 )
             )
         if function_name == _ts_mod.TOOL_CALL_NAME:
-            underlying_name, underlying_args, err = _ts_mod.resolve_underlying_call(function_args or {})
+            allowed_names = (
+                frozenset(deferred_sources)
+                if deferred_sources is not None
+                else _ts_mod.scoped_deferrable_names(current_defs)
+            )
+            underlying_name, underlying_args, err = _ts_mod.resolve_underlying_call(
+                function_args or {},
+                allowed_names=allowed_names,
+            )
             if err or not underlying_name:
                 return _return_bridge_result(
                     tool_error(err or "tool_call could not be resolved")
                 )
-            # Defense in depth: the underlying tool MUST be in the session's
-            # scoped deferrable catalog. resolve_underlying_call() only checks
-            # that the name is deferrable in the global registry; this gate
-            # additionally rejects any tool the session was not granted, so a
-            # restricted session can never invoke an out-of-scope tool through
-            # the bridge even if the catalog scoping above regressed.
-            _scoped_deferrable = _ts_mod.scoped_deferrable_names(current_defs)
-            if underlying_name not in _scoped_deferrable:
+            # Defense in depth: retain an explicit dispatcher-side scope gate
+            # even though resolve_underlying_call() receives the same request-
+            # pinned allowlist. This prevents an out-of-scope tool from reaching
+            # dispatch if the resolver's validation later regresses.
+            if underlying_name not in allowed_names:
                 return _return_bridge_result(
                     tool_error(
                         f"'{underlying_name}' is not available in this session. "
@@ -1323,7 +1400,11 @@ def handle_function_call(
             # Probe-validate against the deferred tool's schema (ironclaw#5149):
             # a blind call missing required arguments returns the parameter
             # schema instead of dispatching into an opaque downstream failure.
-            _probe_err = _ts_mod.validate_deferred_call_args(underlying_name, underlying_args)
+            _probe_err = _ts_mod.validate_deferred_call_args(
+                underlying_name,
+                underlying_args,
+                current_defs,
+            )
             if _probe_err is not None:
                 return _return_bridge_result(_probe_err)
             # Recurse with the underlying tool. All hooks fire against the
@@ -1344,6 +1425,8 @@ def handle_function_call(
                 tool_request_middleware_trace=list(_tool_middleware_trace),
                 enabled_toolsets=enabled_toolsets,
                 disabled_toolsets=disabled_toolsets,
+                catalog_tool_defs=catalog_tool_defs,
+                expected_registry_entries=expected_registry_entries,
             )
 
     _tool_original_args = dict(function_args)
@@ -1500,6 +1583,7 @@ def handle_function_call(
                         task_id=task_id,
                         session_id=session_id,
                         enabled_tools=sandbox_enabled,
+                        expected_entry=expected_entry,
                     )
             else:
                 def _dispatch(next_args: Dict[str, Any]) -> Any:
@@ -1508,6 +1592,7 @@ def handle_function_call(
                         task_id=task_id,
                         session_id=session_id,
                         user_task=user_task,
+                        expected_entry=expected_entry,
                     )
             if skip_tool_execution_middleware:
                 result = _dispatch(function_args)

--- a/plugins/context_engine/__init__.py
+++ b/plugins/context_engine/__init__.py
@@ -76,7 +76,11 @@ def discover_context_engines() -> List[Tuple[str, str, bool]]:
     return results
 
 
-def load_context_engine(name: str) -> Optional["ContextEngine"]:
+def load_context_engine(
+    name: str,
+    *,
+    register_commands: bool = True,
+) -> Optional["ContextEngine"]:
     """Load and return a ContextEngine instance by name.
 
     Returns None if the engine is not found or fails to load.
@@ -87,7 +91,10 @@ def load_context_engine(name: str) -> Optional["ContextEngine"]:
         return None
 
     try:
-        engine = _load_engine_from_dir(engine_dir)
+        engine = _load_engine_from_dir(
+            engine_dir,
+            register_commands=register_commands,
+        )
         if engine:
             return engine
         logger.warning("Context engine '%s' loaded but no engine instance found", name)
@@ -97,7 +104,11 @@ def load_context_engine(name: str) -> Optional["ContextEngine"]:
         return None
 
 
-def _load_engine_from_dir(engine_dir: Path) -> Optional["ContextEngine"]:
+def _load_engine_from_dir(
+    engine_dir: Path,
+    *,
+    register_commands: bool = True,
+) -> Optional["ContextEngine"]:
     """Import an engine module and extract the ContextEngine instance.
 
     The module must have either:
@@ -174,7 +185,10 @@ def _load_engine_from_dir(engine_dir: Path) -> Optional["ContextEngine"]:
 
     # Try register(ctx) pattern first (how plugins are written)
     if hasattr(mod, "register"):
-        collector = _EngineCollector(engine_name=name)
+        collector = _EngineCollector(
+            engine_name=name,
+            register_commands=register_commands,
+        )
         try:
             mod.register(collector)
             if collector.engine:
@@ -205,9 +219,15 @@ class _EngineCollector:
     behave identically to commands registered by normal plugins.
     """
 
-    def __init__(self, engine_name: str = ""):
+    def __init__(
+        self,
+        engine_name: str = "",
+        *,
+        register_commands: bool = True,
+    ):
         self.engine = None
         self._engine_name = engine_name or "context_engine"
+        self._register_commands = register_commands
         self._registered_commands: list[str] = []
 
     def register_context_engine(self, engine):
@@ -221,6 +241,8 @@ class _EngineCollector:
         args_hint: str = "",
     ) -> None:
         """Forward to the global plugin command registry."""
+        if not self._register_commands:
+            return
         clean = (name or "").lower().strip().lstrip("/").replace(" ", "-")
         if not clean:
             logger.warning(

--- a/run_agent.py
+++ b/run_agent.py
@@ -4950,10 +4950,15 @@ class AIAgent:
         """
         return _sanitize_uniquify_tool_call_ids(tool_calls)
 
-    def _repair_tool_call(self, tool_name: str) -> str | None:
+    def _repair_tool_call(
+        self,
+        tool_name: str,
+        valid_tool_names: set[str] | frozenset[str] | None = None,
+    ) -> str | None:
         """Forwarder — see ``agent.agent_runtime_helpers.repair_tool_call``."""
         from agent.agent_runtime_helpers import repair_tool_call
-        return repair_tool_call(self, tool_name)
+
+        return repair_tool_call(self, tool_name, valid_tool_names)
 
     def _invalidate_system_prompt(self):
         """Forwarder — see ``agent.system_prompt.invalidate_system_prompt``."""
@@ -8167,7 +8172,7 @@ class AIAgent:
         self._set_tool_guardrail_halt(decision)
         return toolguard_synthetic_result(decision)
 
-    def _execute_tool_calls(self, assistant_message, messages: list, effective_task_id: str, api_call_count: int = 0) -> None:
+    def _execute_tool_calls(self, assistant_message, messages: list, effective_task_id: str, api_call_count: int = 0, *, tool_surface=None) -> None:
         """Execute tool calls from the assistant message and append results to messages.
 
         The segment planner splits the batch into maximal contiguous runs of
@@ -8185,7 +8190,11 @@ class AIAgent:
         try:
             if len(tool_calls) <= 1:
                 return self._execute_tool_calls_sequential(
-                    assistant_message, messages, effective_task_id, api_call_count
+                    assistant_message,
+                    messages,
+                    effective_task_id,
+                    api_call_count,
+                    tool_surface=tool_surface,
                 )
 
             from agent.tool_dispatch_helpers import _plan_tool_batch_segments
@@ -8197,21 +8206,36 @@ class AIAgent:
                 kind = segments[0][0]
                 if kind == "parallel":
                     return self._execute_tool_calls_concurrent(
-                        assistant_message, messages, effective_task_id, api_call_count
+                        assistant_message,
+                        messages,
+                        effective_task_id,
+                        api_call_count,
+                        tool_surface=tool_surface,
                     )
                 return self._execute_tool_calls_sequential(
-                    assistant_message, messages, effective_task_id, api_call_count
+                    assistant_message,
+                    messages,
+                    effective_task_id,
+                    api_call_count,
+                    tool_surface=tool_surface,
                 )
 
             from agent.tool_executor import execute_tool_calls_segmented
             return execute_tool_calls_segmented(
-                self, assistant_message, messages, effective_task_id, api_call_count,
+                self,
+                assistant_message,
+                messages,
+                effective_task_id,
+                api_call_count,
                 segments=segments,
+                tool_surface=tool_surface,
             )
         finally:
             self._executing_tools = False
 
-    def _dispatch_delegate_task(self, function_args: dict) -> str:
+    def _dispatch_delegate_task(
+        self, function_args: dict, *, tool_surface=None
+    ) -> str:
         """Single call site for delegate_task dispatch.
 
         New DELEGATE_TASK_SCHEMA fields only need to be added here to reach all
@@ -8244,6 +8268,7 @@ class AIAgent:
             subagent_id=function_args.get("subagent_id"),
             message=function_args.get("message"),
             parent_agent=self,
+            parent_tool_surface=tool_surface,
         )
 
     def _invoke_tool(self, function_name: str, function_args: dict, effective_task_id: str,
@@ -8251,7 +8276,8 @@ class AIAgent:
                      pre_tool_block_checked: bool = False,
                      skip_tool_request_middleware: bool = False,
                      tool_request_middleware_trace: Optional[list[dict[str, Any]]] = None,
-                     skip_tool_execution_middleware: bool = False) -> str:
+                     skip_tool_execution_middleware: bool = False,
+                     tool_surface=None) -> str:
         """Forwarder — see ``agent.agent_runtime_helpers.invoke_tool``."""
         from agent.agent_runtime_helpers import invoke_tool
         return invoke_tool(
@@ -8265,6 +8291,7 @@ class AIAgent:
             skip_tool_request_middleware,
             tool_request_middleware_trace,
             skip_tool_execution_middleware,
+            tool_surface,
         )
 
     @staticmethod
@@ -8292,15 +8319,29 @@ class AIAgent:
         body = ("\n" + indent).join(out_lines)
         return f"{indent}{label}{body}"
 
-    def _execute_tool_calls_concurrent(self, assistant_message, messages: list, effective_task_id: str, api_call_count: int = 0) -> None:
+    def _execute_tool_calls_concurrent(self, assistant_message, messages: list, effective_task_id: str, api_call_count: int = 0, *, tool_surface=None) -> None:
         """Forwarder — see ``agent.tool_executor.execute_tool_calls_concurrent``."""
         from agent.tool_executor import execute_tool_calls_concurrent
-        return execute_tool_calls_concurrent(self, assistant_message, messages, effective_task_id, api_call_count)
+        return execute_tool_calls_concurrent(
+            self,
+            assistant_message,
+            messages,
+            effective_task_id,
+            api_call_count,
+            tool_surface=tool_surface,
+        )
 
-    def _execute_tool_calls_sequential(self, assistant_message, messages: list, effective_task_id: str, api_call_count: int = 0) -> None:
+    def _execute_tool_calls_sequential(self, assistant_message, messages: list, effective_task_id: str, api_call_count: int = 0, *, tool_surface=None) -> None:
         """Forwarder — see ``agent.tool_executor.execute_tool_calls_sequential``."""
         from agent.tool_executor import execute_tool_calls_sequential
-        return execute_tool_calls_sequential(self, assistant_message, messages, effective_task_id, api_call_count)
+        return execute_tool_calls_sequential(
+            self,
+            assistant_message,
+            messages,
+            effective_task_id,
+            api_call_count,
+            tool_surface=tool_surface,
+        )
 
     def _handle_max_iterations(self, messages: list, api_call_count: int) -> str:
         """Forwarder — see ``agent.chat_completion_helpers.handle_max_iterations``."""

--- a/skills/autonomous-ai-agents/hermes-agent/references/cli-reference.md
+++ b/skills/autonomous-ai-agents/hermes-agent/references/cli-reference.md
@@ -52,7 +52,7 @@ hermes status [--all]       Component status
 ### Tools & Skills
 
 ```
-hermes tools [list|enable NAME|disable NAME]   Per-platform toolsets (curses UI with no args)
+hermes tools [list|diagnose|enable NAME|disable NAME]   Per-platform toolsets (curses UI with no args)
 
 hermes skills list|browse|search QUERY|inspect ID
 hermes skills install ID    Hub identifier OR a direct https://…/SKILL.md URL

--- a/tests/acp/test_mcp_e2e.py
+++ b/tests/acp/test_mcp_e2e.py
@@ -76,10 +76,19 @@ class TestMcpRegistrationE2E:
             return ["mcp_test_fs_read", "mcp_test_fs_write", "mcp_test_api_search"]
 
         fake_tools = [
-            {"function": {"name": "mcp_test_fs_read"}},
-            {"function": {"name": "mcp_test_fs_write"}},
-            {"function": {"name": "mcp_test_api_search"}},
-            {"function": {"name": "terminal"}},
+            {
+                "type": "function",
+                "function": {
+                    "name": name,
+                    "parameters": {"type": "object", "properties": {}},
+                },
+            }
+            for name in (
+                "mcp_test_fs_read",
+                "mcp_test_fs_write",
+                "mcp_test_api_search",
+                "terminal",
+            )
         ]
 
         with patch("tools.mcp_tool.register_mcp_servers", side_effect=mock_register), \

--- a/tests/acp/test_server.py
+++ b/tests/acp/test_server.py
@@ -665,7 +665,11 @@ class TestRegisterSessionMcpServers:
         state.agent._cached_system_prompt = "old prompt"
         state.agent._memory_manager = SimpleNamespace(
             get_all_tool_schemas=lambda: [
-                {"name": "hindsight_recall", "description": "Recall", "parameters": {}}
+                {
+                    "name": "hindsight_recall",
+                    "description": "Recall",
+                    "parameters": {"type": "object", "properties": {}},
+                }
             ]
         )
 
@@ -677,9 +681,14 @@ class TestRegisterSessionMcpServers:
         )
 
         fake_tools = [
-            {"function": {"name": "mcp_srv_search"}},
-            {"function": {"name": "memory"}},
-            {"function": {"name": "terminal"}},
+            {
+                "type": "function",
+                "function": {
+                    "name": name,
+                    "parameters": {"type": "object", "properties": {}},
+                },
+            }
+            for name in ("mcp_srv_search", "memory", "terminal")
         ]
 
         with patch("tools.mcp_tool.register_mcp_servers", return_value=["mcp_srv_search"]), \
@@ -690,15 +699,17 @@ class TestRegisterSessionMcpServers:
             enabled_toolsets=["hermes-acp", "mcp-srv"],
             disabled_toolsets=None,
             quiet_mode=True,
+            skip_tool_search_assembly=True,
+            record_resolved_names=False,
         )
         assert state.agent.enabled_toolsets == ["hermes-acp", "mcp-srv"]
-        assert state.agent.tools is fake_tools
+        assert state.agent.tools[:3] == fake_tools
         assert state.agent.tools[-1] == {
             "type": "function",
             "function": {
                 "name": "hindsight_recall",
                 "description": "Recall",
-                "parameters": {},
+                "parameters": {"type": "object", "properties": {}},
             },
         }
         assert state.agent.valid_tool_names == {

--- a/tests/agent/test_context_engine_host_contract.py
+++ b/tests/agent/test_context_engine_host_contract.py
@@ -191,3 +191,21 @@ def test_engine_collector_forwards_register_command_to_plugin_manager():
         manager._plugin_commands.pop("my-lcm-test-cmd", None)
 
 
+def test_engine_collector_can_disable_global_command_registration():
+    """Read-only probes collect schemas without mutating plugin commands."""
+    from plugins.context_engine import _EngineCollector
+    from hermes_cli.plugins import get_plugin_manager
+
+    manager = get_plugin_manager()
+    before = dict(manager._plugin_commands)
+    collector = _EngineCollector(
+        engine_name="diagnostic",
+        register_commands=False,
+    )
+
+    collector.register_command("diagnostic-only", lambda _args: "ignored")
+
+    assert manager._plugin_commands == before
+    assert collector._registered_commands == []
+
+

--- a/tests/agent/test_surrogate_chokepoints.py
+++ b/tests/agent/test_surrogate_chokepoints.py
@@ -177,7 +177,7 @@ def test_conversation_loop_sanitizes_api_kwargs_after_build():
     import agent.conversation_loop as cl
 
     src = inspect.getsource(cl.run_conversation)
-    build_idx = src.index("api_kwargs = agent._build_api_kwargs(api_messages)")
+    build_idx = src.index("api_kwargs = agent._build_api_kwargs(")
     sanitize_idx = src.index("_sanitize_structure_surrogates(api_kwargs)")
     perform_idx = src.index("def _perform_api_call")
     assert build_idx < sanitize_idx < perform_idx

--- a/tests/agent/test_tool_surface.py
+++ b/tests/agent/test_tool_surface.py
@@ -104,3 +104,39 @@ def test_tool_search_runs_after_external_families_are_injected():
     assert {"surface_memory_recall", "surface_context_expand"}.issubset(names)
     assert surface.tool_search_activated is True
     assert surface.deferred_names == [deferred_name]
+
+
+def test_disabled_toolsets_override_enabled_external_families():
+    surface = assemble_full_tool_surface(
+        [_tool("read_file")],
+        enabled_toolsets=["file", "memory", "context_engine"],
+        disabled_toolsets=["memory", "context_engine"],
+        memory_tool_schemas=[_schema("disabled_memory")],
+        context_engine_tool_schemas=[_schema("disabled_context")],
+        tool_search_config=ToolSearchConfig.from_raw({"enabled": "off"}),
+    )
+
+    names = {tool["function"]["name"] for tool in surface.tool_defs}
+    assert names == {"read_file"}
+    assert surface.skipped == {
+        "memory": [{"tool": "disabled_memory", "reason": "toolset disabled"}],
+        "context_engine": [
+            {"tool": "disabled_context", "reason": "toolset disabled"}
+        ],
+    }
+
+
+def test_schema_sanitization_failure_is_fail_soft(monkeypatch):
+    def _raise(_schemas):
+        raise TypeError("non-copyable schema")
+
+    monkeypatch.setattr("tools.schema_sanitizer.sanitize_tool_schemas", _raise)
+
+    surface = assemble_full_tool_surface(
+        [_tool("read_file")],
+        apply_tool_search=False,
+    )
+
+    assert [tool["function"]["name"] for tool in surface.tool_defs] == [
+        "read_file"
+    ]

--- a/tests/agent/test_tool_surface.py
+++ b/tests/agent/test_tool_surface.py
@@ -1,0 +1,106 @@
+"""Behavior contracts for complete tool-surface assembly."""
+
+from copy import deepcopy
+
+from agent.tool_surface import assemble_full_tool_surface
+from tools.tool_search import ToolSearchConfig
+
+
+def _tool(name: str) -> dict:
+    return {
+        "type": "function",
+        "function": {
+            "name": name,
+            "description": name,
+            "parameters": {"type": "object", "properties": {}},
+        },
+    }
+
+
+def _schema(name: str) -> dict:
+    return {
+        "name": name,
+        "description": name,
+        "parameters": {"type": "object", "properties": {}},
+    }
+
+
+def test_full_surface_is_non_mutating_and_deduplicates_injected_families():
+    base = [_tool("read_file")]
+    memory = [_schema("read_file"), _schema("memory_recall")]
+    context = [_schema("context_expand")]
+    original_base = deepcopy(base)
+    original_memory = deepcopy(memory)
+    original_context = deepcopy(context)
+
+    surface = assemble_full_tool_surface(
+        base,
+        enabled_toolsets=["file", "memory", "context_engine"],
+        memory_tool_schemas=memory,
+        context_engine_tool_schemas=context,
+        tool_search_config=ToolSearchConfig.from_raw({"enabled": "off"}),
+    )
+
+    names = [tool["function"]["name"] for tool in surface.tool_defs]
+    assert names == ["read_file", "memory_recall", "context_expand"]
+    assert surface.injected_names == {
+        "memory": ["memory_recall"],
+        "context_engine": ["context_expand"],
+    }
+    assert surface.skipped["memory"] == [
+        {"tool": "read_file", "reason": "duplicate tool name"}
+    ]
+    assert base == original_base
+    assert memory == original_memory
+    assert context == original_context
+
+
+def test_full_surface_records_toolset_gates_without_mutating_schemas():
+    memory = [_schema("memory_recall")]
+    context = [_schema("context_expand")]
+
+    surface = assemble_full_tool_surface(
+        [_tool("read_file")],
+        enabled_toolsets=["file"],
+        memory_tool_schemas=memory,
+        context_engine_tool_schemas=context,
+        tool_search_config=ToolSearchConfig.from_raw({"enabled": "off"}),
+    )
+
+    names = {tool["function"]["name"] for tool in surface.tool_defs}
+    assert names == {"read_file"}
+    assert surface.skipped == {
+        "memory": [{"tool": "memory_recall", "reason": "toolset disabled"}],
+        "context_engine": [
+            {"tool": "context_expand", "reason": "toolset disabled"}
+        ],
+    }
+
+
+def test_tool_search_runs_after_external_families_are_injected():
+    from tools.registry import registry
+
+    deferred_name = "surface_deferred_mcp_tool"
+    registry.register(
+        name=deferred_name,
+        handler=lambda args, **kwargs: "{}",
+        schema=_schema(deferred_name),
+        toolset="mcp-surface-test",
+    )
+    try:
+        surface = assemble_full_tool_surface(
+            [_tool(deferred_name)],
+            enabled_toolsets=["mcp-surface-test", "memory", "context_engine"],
+            memory_tool_schemas=[_schema("surface_memory_recall")],
+            context_engine_tool_schemas=[_schema("surface_context_expand")],
+            tool_search_config=ToolSearchConfig.from_raw({"enabled": "on"}),
+        )
+    finally:
+        registry.deregister(deferred_name)
+
+    names = {tool["function"]["name"] for tool in surface.tool_defs}
+    assert deferred_name not in names
+    assert {"tool_search", "tool_describe", "tool_call"}.issubset(names)
+    assert {"surface_memory_recall", "surface_context_expand"}.issubset(names)
+    assert surface.tool_search_activated is True
+    assert surface.deferred_names == [deferred_name]

--- a/tests/agent/test_tool_surface.py
+++ b/tests/agent/test_tool_surface.py
@@ -1,0 +1,428 @@
+"""Behavior contracts for complete tool-surface assembly."""
+
+from copy import deepcopy
+import threading
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from agent.tool_surface import (
+    AgentToolSurfaceSnapshot,
+    assemble_full_tool_surface,
+    get_agent_tool_surface,
+    publish_agent_tool_surface,
+)
+from tools.tool_search import ToolSearchConfig
+
+
+def _tool(name: str) -> dict:
+    return {
+        "type": "function",
+        "function": {
+            "name": name,
+            "description": name,
+            "parameters": {"type": "object", "properties": {}},
+        },
+    }
+
+
+def _schema(name: str) -> dict:
+    return {
+        "name": name,
+        "description": name,
+        "parameters": {"type": "object", "properties": {}},
+    }
+
+
+def test_full_surface_is_non_mutating_and_deduplicates_injected_families():
+    base = [_tool("read_file")]
+    memory = [_schema("read_file"), _schema("memory_recall")]
+    context = [_schema("context_expand")]
+    original_base = deepcopy(base)
+    original_memory = deepcopy(memory)
+    original_context = deepcopy(context)
+
+    surface = assemble_full_tool_surface(
+        base,
+        enabled_toolsets=["file", "memory", "context_engine"],
+        memory_tool_schemas=memory,
+        context_engine_tool_schemas=context,
+        tool_search_config=ToolSearchConfig.from_raw({"enabled": "off"}),
+    )
+
+    names = [tool["function"]["name"] for tool in surface.tool_defs]
+    assert names == ["read_file", "memory_recall", "context_expand"]
+    assert surface.injected_names == {
+        "memory": ["memory_recall"],
+        "context_engine": ["context_expand"],
+    }
+    assert surface.skipped["memory"] == [
+        {"tool": "read_file", "reason": "duplicate tool name"}
+    ]
+    assert base == original_base
+    assert memory == original_memory
+    assert context == original_context
+
+
+def test_published_ownership_excludes_rejected_memory_collision():
+    memory_manager = object()
+    agent = SimpleNamespace(_memory_manager=memory_manager)
+    surface = assemble_full_tool_surface(
+        [_tool("read_file")],
+        enabled_toolsets=["file", "memory"],
+        memory_tool_schemas=[
+            _schema("read_file"),
+            _schema("memory_recall"),
+        ],
+        tool_search_config=ToolSearchConfig.from_raw({"enabled": "off"}),
+    )
+
+    snapshot = publish_agent_tool_surface(
+        agent,
+        surface.tool_defs,
+        catalog_tool_defs=surface.pre_assembly_tool_defs,
+        memory_provider_tool_names=surface.injected_names["memory"],
+        context_engine_tool_names=set(),
+        deferred_tool_names=surface.deferred_names,
+        registry_generation=1,
+        selection_revision=0,
+        enabled_toolsets=["file", "memory"],
+        disabled_toolsets=None,
+    )
+
+    assert snapshot.memory_provider_tool_names == frozenset({"memory_recall"})
+    assert "read_file" not in snapshot.memory_provider_tool_names
+    assert snapshot.memory_manager is memory_manager
+
+
+def test_legacy_valid_name_addition_pins_current_registry_entry():
+    from tools.registry import registry
+
+    name = "legacy_valid_name_probe"
+    registry.register(
+        name=name,
+        handler=lambda args, **kwargs: "{}",
+        schema=_schema(name),
+        toolset="legacy-surface-test",
+    )
+    try:
+        entry = registry.get_entry(name)
+        agent = SimpleNamespace()
+        publish_agent_tool_surface(
+            agent,
+            [],
+            context_engine_tool_names=set(),
+            registry_entries=[],
+            registry_generation=registry._generation,
+            selection_revision=0,
+            enabled_toolsets=None,
+            disabled_toolsets=None,
+        )
+        agent.valid_tool_names.add(name)
+
+        snapshot = get_agent_tool_surface(agent)
+    finally:
+        registry.deregister(name)
+
+    assert dict(snapshot.registry_entries)[name] is entry
+
+
+def test_legacy_context_engine_replacement_recomputes_provenance():
+    class EngineA:
+        name = "engine-a"
+
+        def get_tool_schemas(self):
+            return []
+
+        def handle_tool_call(self, _name, _args, **_kwargs):
+            return "a"
+
+    class EngineB:
+        name = "engine-b"
+
+        def get_tool_schemas(self):
+            return []
+
+        def handle_tool_call(self, _name, _args, **_kwargs):
+            return "b"
+
+    engine_a = EngineA()
+    engine_b = EngineB()
+    agent = SimpleNamespace(
+        tools=[],
+        valid_tool_names=set(),
+        _memory_provider_tool_names=set(),
+        _context_engine_tool_names=set(),
+        _memory_manager=None,
+        context_compressor=engine_a,
+        _tool_snapshot_generation=0,
+        _tool_selection_revision=0,
+        enabled_toolsets=[],
+        disabled_toolsets=[],
+    )
+    original = publish_agent_tool_surface(
+        agent,
+        [],
+        context_engine_tool_names=set(),
+        registry_generation=0,
+        selection_revision=0,
+        enabled_toolsets=(),
+        disabled_toolsets=(),
+    )
+
+    agent.context_compressor = engine_b
+    replaced = get_agent_tool_surface(agent)
+
+    assert replaced.context_engine is engine_b
+    assert replaced.context_engine_provenance != original.context_engine_provenance
+
+
+def test_context_engine_provenance_does_not_recurse_through_dynamic_mock_attrs():
+    from agent.tool_surface import context_engine_provenance
+
+    provenance = context_engine_provenance(MagicMock())
+
+    assert provenance is not None
+
+
+def test_full_surface_records_toolset_gates_without_mutating_schemas():
+    memory = [_schema("memory_recall")]
+    context = [_schema("context_expand")]
+
+    surface = assemble_full_tool_surface(
+        [_tool("read_file")],
+        enabled_toolsets=["file"],
+        memory_tool_schemas=memory,
+        context_engine_tool_schemas=context,
+        tool_search_config=ToolSearchConfig.from_raw({"enabled": "off"}),
+    )
+
+    names = {tool["function"]["name"] for tool in surface.tool_defs}
+    assert names == {"read_file"}
+    assert surface.skipped == {
+        "memory": [{"tool": "memory_recall", "reason": "toolset disabled"}],
+        "context_engine": [{"tool": "context_expand", "reason": "toolset disabled"}],
+    }
+
+
+def test_tool_search_runs_after_external_families_are_injected():
+    from tools.registry import registry
+
+    deferred_name = "surface_deferred_mcp_tool"
+    registry.register(
+        name=deferred_name,
+        handler=lambda args, **kwargs: "{}",
+        schema=_schema(deferred_name),
+        toolset="mcp-surface-test",
+    )
+    try:
+        surface = assemble_full_tool_surface(
+            [_tool(deferred_name)],
+            enabled_toolsets=["mcp-surface-test", "memory", "context_engine"],
+            memory_tool_schemas=[_schema("surface_memory_recall")],
+            context_engine_tool_schemas=[_schema("surface_context_expand")],
+            tool_search_config=ToolSearchConfig.from_raw({"enabled": "on"}),
+        )
+    finally:
+        registry.deregister(deferred_name)
+
+    names = {tool["function"]["name"] for tool in surface.tool_defs}
+    assert deferred_name not in names
+    assert {"tool_search", "tool_describe", "tool_call"}.issubset(names)
+    assert {"surface_memory_recall", "surface_context_expand"}.issubset(names)
+    assert surface.tool_search_activated is True
+    assert surface.deferred_names == [deferred_name]
+
+
+def test_disabled_toolsets_override_enabled_external_families():
+    surface = assemble_full_tool_surface(
+        [_tool("read_file")],
+        enabled_toolsets=["file", "memory", "context_engine"],
+        disabled_toolsets=["memory", "context_engine"],
+        memory_tool_schemas=[_schema("disabled_memory")],
+        context_engine_tool_schemas=[_schema("disabled_context")],
+        tool_search_config=ToolSearchConfig.from_raw({"enabled": "off"}),
+    )
+
+    names = {tool["function"]["name"] for tool in surface.tool_defs}
+    assert names == {"read_file"}
+    assert surface.skipped == {
+        "memory": [{"tool": "disabled_memory", "reason": "toolset disabled"}],
+        "context_engine": [{"tool": "disabled_context", "reason": "toolset disabled"}],
+    }
+
+
+def test_schema_sanitization_failure_is_fail_soft(monkeypatch):
+    def _raise(_schemas):
+        raise TypeError("non-copyable schema")
+
+    monkeypatch.setattr("tools.schema_sanitizer.sanitize_tool_schemas", _raise)
+
+    surface = assemble_full_tool_surface(
+        [_tool("read_file")],
+        apply_tool_search=False,
+    )
+
+    assert [tool["function"]["name"] for tool in surface.tool_defs] == ["read_file"]
+
+
+def test_published_snapshot_stays_atomic_during_legacy_attribute_updates():
+    """Readers block across publication and observe one complete generation."""
+    setter_blocked = threading.Event()
+    release_setter = threading.Event()
+    reader_finished = threading.Event()
+    observed = []
+
+    class InterleavingAgent:
+        block_publication = False
+
+        def __setattr__(self, name, value):
+            object.__setattr__(self, name, value)
+            if self.block_publication and name == "tools":
+                setter_blocked.set()
+                assert release_setter.wait(timeout=5)
+
+    agent = InterleavingAgent()
+    publish_agent_tool_surface(
+        agent,
+        [_tool("old")],
+        context_engine_tool_names=set(),
+        registry_generation=1,
+        selection_revision=0,
+        enabled_toolsets=["all"],
+        disabled_toolsets=None,
+    )
+    old_snapshot = get_agent_tool_surface(agent)
+    agent.block_publication = True
+
+    publisher = threading.Thread(
+        target=publish_agent_tool_surface,
+        kwargs={
+            "agent": agent,
+            "tool_defs": [_tool("new")],
+            "context_engine_tool_names": {"new"},
+            "registry_generation": 2,
+            "selection_revision": 1,
+            "enabled_toolsets": ["file"],
+            "disabled_toolsets": ["terminal"],
+        },
+    )
+    publisher.start()
+    assert setter_blocked.wait(timeout=5)
+
+    def _read():
+        observed.append(get_agent_tool_surface(agent))
+        reader_finished.set()
+
+    reader = threading.Thread(target=_read)
+    reader.start()
+    assert not reader_finished.wait(timeout=0.05)
+    assert old_snapshot.valid_tool_names == frozenset({"old"})
+
+    release_setter.set()
+    publisher.join(timeout=5)
+    reader.join(timeout=5)
+    assert not publisher.is_alive()
+    assert not reader.is_alive()
+
+    new_snapshot = observed[0]
+    assert isinstance(new_snapshot, AgentToolSurfaceSnapshot)
+    assert new_snapshot is get_agent_tool_surface(agent)
+    assert new_snapshot.valid_tool_names == frozenset({"new"})
+    assert new_snapshot.context_engine_tool_names == frozenset({"new"})
+    assert new_snapshot.selection_revision == 1
+
+
+def test_snapshot_is_not_visible_until_global_name_publication_finishes(monkeypatch):
+    import model_tools
+
+    agent = type("Agent", (), {})()
+    old_snapshot = publish_agent_tool_surface(
+        agent,
+        [_tool("old")],
+        context_engine_tool_names=set(),
+        registry_generation=1,
+        selection_revision=0,
+        enabled_toolsets=["all"],
+        disabled_toolsets=None,
+    )
+    record_blocked = threading.Event()
+    release_record = threading.Event()
+    reader_finished = threading.Event()
+    observed = []
+
+    def _record(_tool_defs):
+        record_blocked.set()
+        assert release_record.wait(timeout=5)
+
+    monkeypatch.setattr(model_tools, "record_resolved_tool_names", _record)
+    publisher = threading.Thread(
+        target=publish_agent_tool_surface,
+        kwargs={
+            "agent": agent,
+            "tool_defs": [_tool("new")],
+            "context_engine_tool_names": set(),
+            "registry_generation": 2,
+            "selection_revision": 1,
+            "enabled_toolsets": ["all"],
+            "disabled_toolsets": None,
+        },
+    )
+    publisher.start()
+    assert record_blocked.wait(timeout=5)
+    assert getattr(agent, "_tool_surface_snapshot") is old_snapshot
+
+    def _read():
+        observed.append(get_agent_tool_surface(agent))
+        reader_finished.set()
+
+    reader = threading.Thread(target=_read)
+    reader.start()
+    assert not reader_finished.wait(timeout=0.05)
+
+    release_record.set()
+    publisher.join(timeout=5)
+    reader.join(timeout=5)
+    assert not publisher.is_alive()
+    assert not reader.is_alive()
+    assert observed[0].valid_tool_names == frozenset({"new"})
+
+
+def test_published_snapshot_does_not_share_mutable_schemas_with_legacy_list():
+    agent = type("Agent", (), {})()
+    source = [_tool("stable")]
+
+    snapshot = publish_agent_tool_surface(
+        agent,
+        source,
+        context_engine_tool_names=set(),
+        registry_generation=1,
+        selection_revision=0,
+        enabled_toolsets=["all"],
+        disabled_toolsets=None,
+    )
+    source[0]["function"]["description"] = "source-mutated"
+    agent.tools[0]["function"]["description"] = "legacy-mutated"
+
+    assert snapshot.tool_defs[0]["function"]["description"] == "stable"
+
+
+def test_explicit_legacy_surface_replacement_gets_a_coherent_compatibility_view():
+    agent = type("Agent", (), {})()
+    publish_agent_tool_surface(
+        agent,
+        [_tool("old")],
+        context_engine_tool_names={"old"},
+        registry_generation=1,
+        selection_revision=0,
+        enabled_toolsets=["all"],
+        disabled_toolsets=None,
+    )
+
+    agent.tools = [_tool("new")]
+    agent.valid_tool_names = {"new"}
+    agent._context_engine_tool_names = {"new"}
+
+    compat = get_agent_tool_surface(agent)
+    assert [tool["function"]["name"] for tool in compat.tool_defs] == ["new"]
+    assert compat.valid_tool_names == frozenset({"new"})
+    assert compat.context_engine_tool_names == frozenset({"new"})

--- a/tests/gateway/test_mcp_reload_refreshes_cached_agents.py
+++ b/tests/gateway/test_mcp_reload_refreshes_cached_agents.py
@@ -97,11 +97,19 @@ async def test_reload_mcp_refreshes_cached_agent_tools():
     fresh_tool_defs = [
         {
             "type": "function",
-            "function": {"name": "HassTurnOn", "description": "Turns on a device"},
+            "function": {
+                "name": "HassTurnOn",
+                "description": "Turns on a device",
+                "parameters": {"type": "object", "properties": {}},
+            },
         },
         {
             "type": "function",
-            "function": {"name": "HassTurnOff", "description": "Turns off a device"},
+            "function": {
+                "name": "HassTurnOff",
+                "description": "Turns off a device",
+                "parameters": {"type": "object", "properties": {}},
+            },
         },
     ]
 

--- a/tests/hermes_cli/test_config.py
+++ b/tests/hermes_cli/test_config.py
@@ -1,6 +1,7 @@
 """Tests for hermes_cli configuration management."""
 
 import os
+from copy import deepcopy
 from pathlib import Path
 from unittest.mock import patch
 
@@ -10,6 +11,7 @@ import yaml
 from hermes_cli.config import (
     DEFAULT_CONFIG,
     check_config_version,
+    diagnostic_config_inspection,
     get_hermes_home,
     ensure_hermes_home,
     get_compatible_custom_providers,
@@ -17,9 +19,11 @@ from hermes_cli.config import (
     _normalize_max_turns_config,
     is_provider_enabled,
     load_config,
+    load_config_for_diagnostics,
     load_env,
     migrate_config,
     read_raw_config,
+    read_raw_config_readonly,
     remove_env_value,
     save_config,
     save_env_value,
@@ -84,6 +88,101 @@ class TestLoadConfigDefaults:
             config = load_config()
             assert config["agent"]["max_turns"] == 42
             assert "max_turns" not in config
+
+
+class TestLoadConfigForDiagnostics:
+    def test_effective_snapshot_does_not_mutate_files_or_caches(self, tmp_path):
+        from hermes_cli import config as config_mod
+        from hermes_cli import managed_scope
+
+        hermes_home = tmp_path / "hermes"
+        hermes_home.mkdir()
+        (hermes_home / "config.yaml").write_text("agent:\n  max_turns: 7\n")
+        managed_home = tmp_path / "managed"
+        managed_home.mkdir()
+        (managed_home / "config.yaml").write_text("agent:\n  max_turns: 9\n")
+        tree_before = {
+            str(path.relative_to(tmp_path)): (
+                path.read_bytes() if path.is_file() else None
+            )
+            for path in tmp_path.rglob("*")
+        }
+        caches_before = (
+            deepcopy(config_mod._LOAD_CONFIG_CACHE),
+            deepcopy(config_mod._RAW_CONFIG_CACHE),
+            deepcopy(config_mod._LAST_EXPANDED_CONFIG_BY_PATH),
+            deepcopy(config_mod._CONFIG_PARSE_WARNED),
+            deepcopy(managed_scope._CONFIG_CACHE),
+        )
+
+        with patch.dict(
+            os.environ,
+            {
+                "HERMES_HOME": str(hermes_home),
+                "HERMES_MANAGED_DIR": str(managed_home),
+            },
+        ), patch.object(
+            config_mod,
+            "ensure_hermes_home",
+            side_effect=AssertionError("diagnostic load bootstrapped HERMES_HOME"),
+        ):
+            config = load_config_for_diagnostics()
+            with diagnostic_config_inspection():
+                scoped_config = load_config()
+                scoped_raw = read_raw_config()
+                scoped_raw_readonly = read_raw_config_readonly()
+
+        tree_after = {
+            str(path.relative_to(tmp_path)): (
+                path.read_bytes() if path.is_file() else None
+            )
+            for path in tmp_path.rglob("*")
+        }
+        assert config["agent"]["max_turns"] == 9
+        assert scoped_config["agent"]["max_turns"] == 9
+        assert scoped_raw["agent"]["max_turns"] == 7
+        assert scoped_raw_readonly["agent"]["max_turns"] == 7
+        assert tree_after == tree_before
+        assert config_mod._LOAD_CONFIG_CACHE == caches_before[0]
+        assert config_mod._RAW_CONFIG_CACHE == caches_before[1]
+        assert config_mod._LAST_EXPANDED_CONFIG_BY_PATH == caches_before[2]
+        assert config_mod._CONFIG_PARSE_WARNED == caches_before[3]
+        assert managed_scope._CONFIG_CACHE == caches_before[4]
+
+    def test_process_marker_covers_child_thread_config_reads(
+        self, tmp_path, monkeypatch
+    ):
+        import threading
+
+        from hermes_cli import config as config_mod
+
+        hermes_home = tmp_path / "missing-hermes"
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.setenv("HERMES_TOOLS_DIAGNOSE_READ_ONLY", "1")
+        results = []
+        errors = []
+
+        def load_in_thread():
+            try:
+                results.append(config_mod.load_config())
+                results.append(config_mod.read_raw_config())
+            except BaseException as exc:
+                errors.append(exc)
+
+        with patch.object(
+            config_mod,
+            "ensure_hermes_home",
+            side_effect=AssertionError("child thread bootstrapped HERMES_HOME"),
+        ):
+            thread = threading.Thread(target=load_in_thread)
+            thread.start()
+            thread.join(timeout=10)
+
+        assert not thread.is_alive()
+        assert errors == []
+        assert results[0]["agent"]["max_turns"] == DEFAULT_CONFIG["agent"]["max_turns"]
+        assert results[1] == {}
+        assert not hermes_home.exists()
 
 
 class TestLoadConfigParseFailure:

--- a/tests/hermes_cli/test_early_recovery.py
+++ b/tests/hermes_cli/test_early_recovery.py
@@ -99,6 +99,135 @@ def test_broken_dotenv_crashes_main_import_without_repair(tmp_path):
     assert "wiped mid-install" in result.stderr
 
 
+@pytest.mark.parametrize(
+    "argv",
+    [
+        ["hermes", "tools", "diagnose", "--json"],
+        ["hermes", "--profile=default", "tools", "diagnose", "--json"],
+        ["hermes", "--profile", "default", "tools", "diagnose", "--json"],
+        ["hermes", "-p", "default", "tools", "diagnose", "--json"],
+        ["hermes", "--yolo", "tools", "diagnose", "--json"],
+        ["hermes", "--safe-mode", "tools", "diagnose", "--json"],
+        ["hermes", "--model", "openai/test", "tools", "diagnose", "--json"],
+        ["hermes", "-mopenai/test", "tools", "diagnose", "--json"],
+        ["hermes", "--m=openai/test", "tools", "diagnose", "--json"],
+        ["hermes", "--reasoning=high", "tools", "diagnose", "--json"],
+        ["hermes", "-t", "file,web", "tools", "diagnose", "--json"],
+        ["hermes", "-tfile,web", "tools", "diagnose", "--json"],
+        ["hermes", "--model", "-1", "tools", "diagnose", "--json"],
+        ["hermes", "--provider", "-1", "tools", "diagnose", "--json"],
+        ["hermes", "--reasoning", "-1", "tools", "diagnose", "--json"],
+        ["hermes", "-t", "-1", "tools", "diagnose", "--json"],
+        [
+            "hermes",
+            "--profile=default",
+            "--yolo",
+            "tools",
+            "diagnose",
+            "--json",
+        ],
+        [
+            "hermes",
+            "--yolo",
+            "--profile",
+            "default",
+            "tools",
+            "diagnose",
+            "--json",
+        ],
+    ],
+)
+def test_tools_diagnose_skips_import_time_recovery(tmp_path, argv):
+    script = tmp_path / "diagnose_no_recovery.py"
+    script.write_text(
+        textwrap.dedent(
+            """
+            import sys
+            from pathlib import Path
+            import hermes_cli._early_recovery as er
+
+            marker = Path({marker!r})
+            er.recover_if_needed = lambda *args, **kwargs: marker.write_text("called")
+            sys.argv = {argv!r}
+            import hermes_cli.main  # noqa: F401
+            """.format(
+                marker=str(tmp_path / "recovery-called"),
+                argv=argv,
+            )
+        ),
+        encoding="utf-8",
+    )
+    env = {
+        **os.environ,
+        "PYTHONPATH": str(REPO_ROOT),
+        "HOME": str(tmp_path),
+        "HERMES_HOME": str(tmp_path / "missing-home"),
+    }
+    result = subprocess.run(
+        [sys.executable, str(script)],
+        capture_output=True,
+        text=True,
+        cwd=REPO_ROOT,
+        env=env,
+        timeout=120,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert not (tmp_path / "recovery-called").exists()
+    assert not (tmp_path / "missing-home").exists()
+
+
+@pytest.mark.parametrize(
+    "argv",
+    [
+        ["hermes", "--version", "tools", "diagnose"],
+        ["hermes", "--model", "--safe-mode", "tools", "diagnose"],
+        ["hermes", "--p=probe", "tools", "diagnose"],
+        ["hermes", "--profile=", "tools", "diagnose", "--json"],
+        ["hermes", "--prof=", "tools", "diagnose", "--json"],
+        ["hermes", "--profile", "", "tools", "diagnose", "--json"],
+        ["hermes", "--profile=--yolo", "tools", "diagnose", "--json"],
+        ["hermes", "--profile=bad/name", "tools", "diagnose", "--json"],
+        ["hermes", "--profile=Upper", "tools", "diagnose", "--json"],
+        ["hermes", "--profile=test", "tools", "diagnose", "--json"],
+        ["hermes", "--profile", "Upper", "tools", "diagnose", "--json"],
+    ],
+)
+def test_tools_diagnose_detector_does_not_consume_command_changing_flags(
+    tmp_path, argv
+):
+    script = tmp_path / "nonexact_diagnose_route.py"
+    marker = tmp_path / "recovery-called"
+    script.write_text(
+        textwrap.dedent(
+            f"""
+            import sys
+            from pathlib import Path
+            import hermes_cli._early_recovery as er
+
+            marker = Path({str(marker)!r})
+            er.recover_if_needed = lambda *args, **kwargs: marker.write_text("called")
+            sys.argv = {argv!r}
+            try:
+                import hermes_cli.main  # noqa: F401
+            except SystemExit:
+                pass
+            """
+        ),
+        encoding="utf-8",
+    )
+    result = subprocess.run(
+        [sys.executable, str(script)],
+        capture_output=True,
+        text=True,
+        cwd=REPO_ROOT,
+        env={**os.environ, "PYTHONPATH": str(REPO_ROOT)},
+        timeout=120,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert marker.read_text(encoding="utf-8") == "called"
+
 
 
 def test_early_recovery_module_is_stdlib_only(tmp_path):

--- a/tests/hermes_cli/test_env_loader.py
+++ b/tests/hermes_cli/test_env_loader.py
@@ -6,6 +6,44 @@ import sys
 from hermes_cli.env_loader import load_hermes_dotenv
 
 
+def test_read_only_load_preserves_user_and_managed_env_files(
+    tmp_path, monkeypatch
+):
+    import hermes_cli.env_loader as env_loader
+
+    home = tmp_path / "hermes"
+    home.mkdir()
+    user_env = home / ".env"
+    user_env.write_text("READ_ONLY_USER_ENV=loaded\n")
+    managed = tmp_path / "managed"
+    managed.mkdir()
+    managed_env = managed / ".env"
+    managed_env.write_text("READ_ONLY_MANAGED_ENV=loaded\n")
+    before = {
+        user_env: (user_env.read_bytes(), user_env.stat().st_mtime_ns),
+        managed_env: (managed_env.read_bytes(), managed_env.stat().st_mtime_ns),
+    }
+    monkeypatch.setenv("HERMES_MANAGED_DIR", str(managed))
+    monkeypatch.delenv("READ_ONLY_USER_ENV", raising=False)
+    monkeypatch.delenv("READ_ONLY_MANAGED_ENV", raising=False)
+
+    def unexpected(*_args, **_kwargs):
+        raise AssertionError("read-only dotenv load invoked a mutating hook")
+
+    monkeypatch.setattr(env_loader, "_sanitize_env_file_if_needed", unexpected)
+    monkeypatch.setattr(env_loader, "_apply_external_secret_sources", unexpected)
+    monkeypatch.setattr(env_loader, "_reapply_terminal_config_bridge", unexpected)
+
+    loaded = load_hermes_dotenv(hermes_home=home, read_only=True)
+
+    assert loaded == [user_env]
+    assert os.environ["READ_ONLY_USER_ENV"] == "loaded"
+    assert os.environ["READ_ONLY_MANAGED_ENV"] == "loaded"
+    for path, (contents, mtime_ns) in before.items():
+        assert path.read_bytes() == contents
+        assert path.stat().st_mtime_ns == mtime_ns
+
+
 def test_recovered_update_retry_skips_external_secret_sources(tmp_path, monkeypatch):
     """The post-recovery updater must not remap native vault dependencies."""
     import hermes_cli.env_loader as env_loader

--- a/tests/hermes_cli/test_plugins.py
+++ b/tests/hermes_cli/test_plugins.py
@@ -1825,6 +1825,398 @@ class TestPluginCommands:
             reset_hermes_home_override(token_a2)
         assert manager_a2 is manager_a
 
+    def test_diagnostic_thread_drain_completes_before_output_restore(self, capfd):
+        import os
+        import threading
+
+        from hermes_cli.plugins import _drain_diagnostic_plugin_threads
+        from hermes_cli.tools_config import _suppress_diagnostic_output
+
+        existing = frozenset(
+            thread.ident
+            for thread in threading.enumerate()
+            if thread.ident is not None
+        )
+        release = threading.Event()
+
+        def delayed_output() -> None:
+            assert release.wait(timeout=1)
+            os.write(1, b"delayed-diagnostic-stdout\n")
+            os.write(2, b"delayed-diagnostic-stderr\n")
+
+        with _suppress_diagnostic_output():
+            thread = threading.Thread(target=delayed_output)
+            thread.start()
+            release.set()
+            _drain_diagnostic_plugin_threads(existing)
+
+        thread.join(timeout=1)
+        assert not thread.is_alive()
+        captured = capfd.readouterr()
+        assert "delayed-diagnostic" not in captured.out
+        assert "delayed-diagnostic" not in captured.err
+
+    def test_process_entry_diagnose_terminates_noncooperative_plugin_threads(
+        self, tmp_path
+    ):
+        import os
+        import subprocess
+
+        home = tmp_path / "diagnostic-home"
+        plugin_dir = home / "plugins" / "long_delay_probe"
+        plugin_dir.mkdir(parents=True)
+        (plugin_dir / "plugin.yaml").write_text(
+            yaml.safe_dump(
+                {
+                    "name": "long_delay_probe",
+                    "version": "1.0.0",
+                    "description": "Delayed output probe",
+                }
+            ),
+            encoding="utf-8",
+        )
+        (plugin_dir / "__init__.py").write_text(
+            """
+import os
+import threading
+import time
+
+
+def _late():
+    time.sleep(3.0)
+    os.write(1, b"LONG_DELAY_STDOUT_CANARY\\n")
+    os.write(2, b"LONG_DELAY_STDERR_CANARY\\n")
+
+
+def _handler(args, **kwargs):
+    return "{}"
+
+
+def register(ctx):
+    ctx.register_tool(
+        name="long_delay_probe_tool",
+        toolset="long_delay_probe",
+        schema={
+            "name": "long_delay_probe_tool",
+            "description": "probe",
+            "parameters": {"type": "object", "properties": {}},
+        },
+        handler=_handler,
+    )
+    ctx.register_platform(
+        "long-delay-probe-platform",
+        "Long Delay Probe",
+        lambda **kwargs: object(),
+        lambda cfg: True,
+    )
+    threading.Thread(
+        target=_late,
+        name="long-delay-probe-writer",
+        daemon=False,
+    ).start()
+""",
+            encoding="utf-8",
+        )
+        (home / "config.yaml").write_text(
+            yaml.safe_dump(
+                {
+                    "plugins": {"enabled": ["long_delay_probe"]},
+                    "platform_toolsets": {
+                        "long-delay-probe-platform": ["long_delay_probe"]
+                    },
+                }
+            ),
+            encoding="utf-8",
+        )
+        repo_root = Path(__file__).resolve().parents[2]
+        result = subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "hermes_cli.main",
+                "tools",
+                "diagnose",
+                "--platform",
+                "long-delay-probe-platform",
+                "--json",
+            ],
+            cwd=repo_root,
+            env={
+                **os.environ,
+                "HOME": str(tmp_path / "home"),
+                "HERMES_HOME": str(home),
+                "PYTHONDONTWRITEBYTECODE": "1",
+            },
+            capture_output=True,
+            text=True,
+            timeout=15,
+        )
+
+        assert result.returncode == 0, result.stderr
+        payload = json.loads(result.stdout)
+        names = {
+            item.get("tool")
+            for key in ("visible", "filtered")
+            for item in payload.get(key, [])
+            if isinstance(item, dict)
+        }
+        assert payload["platform"] == "long-delay-probe-platform"
+        assert "long_delay_probe_tool" in names
+        assert result.stderr == ""
+        assert "LONG_DELAY" not in result.stdout
+        assert "LONG_DELAY" not in result.stderr
+
+    def test_diagnostic_plugin_manager_is_context_local(
+        self, tmp_path, monkeypatch
+    ):
+        import threading
+
+        import hermes_cli.plugins as plugins_mod
+        from gateway.platform_registry import platform_registry
+        from tools.registry import read_only_tool_inspection, registry
+
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / "diagnostic-home"))
+        monkeypatch.setenv("HERMES_TOOLS_DIAGNOSE_READ_ONLY", "1")
+        existing = PluginManager(scope_key="existing")
+        tool_name = "diagnostic_child_thread_tool"
+        platform_name = "diagnostic_child_thread_platform"
+        generation_before = registry._generation
+
+        with (
+            patch.object(plugins_mod, "_plugin_manager", existing),
+            patch.dict(plugins_mod._plugin_managers_by_home, {}, clear=True),
+        ):
+            observed = {}
+            delayed_observed = {}
+            delayed_started = threading.Event()
+            release_delayed = threading.Event()
+            with read_only_tool_inspection(), plugins_mod.diagnostic_plugin_inspection() as diagnostic:
+                assert diagnostic is not existing
+                assert plugins_mod.get_plugin_manager() is diagnostic
+
+                def observe_globals() -> None:
+                    observed["pointer"] = plugins_mod._plugin_manager
+                    observed["managers"] = dict(
+                        plugins_mod._plugin_managers_by_home
+                    )
+                    observed["manager"] = plugins_mod.get_plugin_manager()
+                    registry.register(
+                        name=tool_name,
+                        toolset="diagnostic-child",
+                        schema={
+                            "type": "function",
+                            "function": {"name": tool_name, "parameters": {}},
+                        },
+                        handler=lambda **kwargs: kwargs,
+                        scope=diagnostic.scope_key,
+                    )
+                    observed["registered"] = (
+                        registry.get_entry(tool_name, scope=diagnostic.scope_key)
+                        is not None
+                    )
+
+                thread = threading.Thread(target=observe_globals)
+                thread.start()
+                thread.join(timeout=1)
+                assert not thread.is_alive()
+
+                assert observed == {
+                    "pointer": existing,
+                    "managers": {},
+                    "manager": diagnostic,
+                    "registered": True,
+                }
+
+                active_context = PluginContext(
+                    PluginManifest(name="active-diagnostic", source="bundled"),
+                    diagnostic,
+                )
+                assert active_context.register_platform(
+                    name=platform_name,
+                    label="Diagnostic child thread",
+                    adapter_factory=lambda config: config,
+                    check_fn=lambda: True,
+                ) is None
+                assert platform_name in diagnostic._plugin_platform_names
+                assert platform_registry.snapshot_registration(
+                    platform_name,
+                    scope=diagnostic.scope_key,
+                ) == (None, None)
+                assert active_context.register_context_reference(object()) is None
+                assert (
+                    active_context.register_redaction_patterns([r"diag-[a-z]+"]) == 0
+                )
+                active_context.set_config("probe", True)
+                assert active_context.state.get("probe") is None
+                active_context.state.set("probe", True)
+                assert not active_context.state.path.exists()
+
+                delayed_context = PluginContext(
+                    PluginManifest(name="delayed-diagnostic", source="bundled"),
+                    diagnostic,
+                )
+
+                def register_after_scope() -> None:
+                    delayed_started.set()
+                    assert release_delayed.wait(timeout=2)
+                    delayed_observed["handle"] = delayed_context.register_tool(
+                        name=f"{tool_name}_delayed",
+                        toolset="diagnostic-child",
+                        schema={
+                            "type": "function",
+                            "function": {
+                                "name": f"{tool_name}_delayed",
+                                "parameters": {},
+                            },
+                        },
+                        handler=lambda **kwargs: kwargs,
+                    )
+                    delayed_observed["registered"] = (
+                        registry.get_entry(
+                            f"{tool_name}_delayed",
+                            scope=diagnostic.scope_key,
+                        )
+                        is not None
+                    )
+                    delayed_observed["platform_handle"] = (
+                        delayed_context.register_platform(
+                            name=platform_name,
+                            label="Diagnostic child thread",
+                            adapter_factory=lambda config: config,
+                            check_fn=lambda: True,
+                        )
+                    )
+                    delayed_observed["platform_registration"] = (
+                        platform_registry.snapshot_registration(
+                            platform_name,
+                            scope=diagnostic.scope_key,
+                        )
+                    )
+
+                delayed_thread = threading.Thread(target=register_after_scope)
+                delayed_thread.start()
+                assert delayed_started.wait(timeout=1)
+
+            assert plugins_mod._plugin_manager is existing
+            assert plugins_mod._plugin_managers_by_home == {}
+            release_delayed.set()
+            delayed_thread.join(timeout=2)
+            assert not delayed_thread.is_alive()
+            assert delayed_observed["handle"] is None
+            assert delayed_observed["registered"] is False
+            assert delayed_observed["platform_handle"] is None
+            assert delayed_observed["platform_registration"] == (None, None)
+            assert registry._generation == generation_before
+            assert registry.get_entry(tool_name, scope=diagnostic.scope_key) is None
+            assert (
+                registry.get_entry(
+                    f"{tool_name}_delayed",
+                    scope=diagnostic.scope_key,
+                )
+                is None
+            )
+            assert platform_registry.snapshot_registration(
+                platform_name,
+                scope=diagnostic.scope_key,
+            ) == (None, None)
+
+    def test_diagnostic_discovery_does_not_reapply_secret_sources(
+        self, monkeypatch
+    ):
+        from tools.registry import read_only_tool_inspection
+
+        manager = PluginManager()
+        source = MagicMock(name="diagnostic-secret-source")
+        source.name = "diagnostic-secret-source"
+        source.is_enabled.return_value = True
+
+        with patch(
+            "agent.secret_sources.registry.list_plugin_sources",
+            return_value=[source],
+        ), patch(
+            "hermes_cli.config.load_config",
+            return_value={
+                "secrets": {"diagnostic-secret-source": {"enabled": True}}
+            },
+        ), patch(
+            "hermes_cli.env_loader.reset_secret_source_cache"
+        ) as reset_cache, patch(
+            "hermes_cli.env_loader.load_hermes_dotenv"
+        ) as load_dotenv, read_only_tool_inspection():
+            manager._refresh_secret_sources_after_discovery()
+
+        reset_cache.assert_not_called()
+        load_dotenv.assert_not_called()
+
+    def test_diagnostic_plugin_override_records_pre_dedup_conflict(
+        self, tmp_path, monkeypatch
+    ):
+        import hermes_cli.plugins as plugins_mod
+        from tools.registry import registry
+
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+        name = "diagnostic_plugin_conflict_target"
+        registry.register(
+            name=name,
+            toolset="file",
+            schema={"name": name, "parameters": {"type": "object"}},
+            handler=lambda args, **kwargs: "built-in",
+        )
+        try:
+            with plugins_mod.diagnostic_plugin_inspection() as manager:
+                context = PluginContext(
+                    PluginManifest(name="conflict-plugin", source="bundled"),
+                    manager,
+                )
+                context.register_tool(
+                    name=name,
+                    toolset="plugin-conflict",
+                    schema={"name": name, "parameters": {"type": "object"}},
+                    handler=lambda args, **kwargs: "plugin",
+                    override=True,
+                )
+
+                assert {
+                    "tool": name,
+                    "reason": "plugin tool overrides existing registry tool",
+                    "source": "conflict-plugin",
+                } in plugins_mod.get_diagnostic_plugin_conflicts()
+        finally:
+            registry.deregister(name)
+
+    def test_diagnostic_rejected_plugin_collision_records_conflict(
+        self, tmp_path, monkeypatch
+    ):
+        import hermes_cli.plugins as plugins_mod
+
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+        name = "diagnostic_plugin_rejected_conflict"
+        with plugins_mod.diagnostic_plugin_inspection() as manager:
+            first = PluginContext(
+                PluginManifest(name="first-plugin", source="bundled"), manager
+            )
+            second = PluginContext(
+                PluginManifest(name="second-plugin", source="bundled"), manager
+            )
+            first.register_tool(
+                name=name,
+                toolset="first-toolset",
+                schema={"name": name, "parameters": {"type": "object"}},
+                handler=lambda args, **kwargs: "first",
+            )
+            assert second.register_tool(
+                name=name,
+                toolset="second-toolset",
+                schema={"name": name, "parameters": {"type": "object"}},
+                handler=lambda args, **kwargs: "second",
+            ) is None
+
+            assert {
+                "tool": name,
+                "reason": "plugin tool conflicts with existing registry tool",
+                "source": "second-plugin",
+            } in plugins_mod.get_diagnostic_plugin_conflicts()
+
     def test_relative_import_not_leaked_across_home_switch(self, tmp_path):
         """A same-slug plugin's relative import must not reuse the prior home's submodule.
 

--- a/tests/hermes_cli/test_subcommands_followup.py
+++ b/tests/hermes_cli/test_subcommands_followup.py
@@ -64,3 +64,29 @@ def test_mcp_and_acp_accept_hooks_flag():
     # acp takes --accept-hooks at top level
     ns = parser.parse_args(["acp", "--accept-hooks"])
     assert ns.accept_hooks is True
+
+
+def test_tools_diagnose_accepts_platform_and_json_flags():
+    parser = argparse.ArgumentParser(prog="hermes")
+    sub = parser.add_subparsers(dest="command")
+    handler = _h("tools")
+    build_tools_parser(sub, cmd_tools=handler)
+
+    ns = parser.parse_args(["tools", "diagnose", "--platform", "telegram", "--json"])
+
+    assert ns.command == "tools"
+    assert ns.tools_action == "diagnose"
+    assert ns.platform == "telegram"
+    assert ns.json is True
+    assert ns.func is handler
+
+
+def test_cmd_tools_propagates_diagnose_status(monkeypatch):
+    from hermes_cli.main import cmd_tools
+
+    monkeypatch.setattr(
+        "hermes_cli.tools_config.tools_diagnose_command",
+        lambda args: 2,
+    )
+
+    assert cmd_tools(argparse.Namespace(tools_action="diagnose")) == 2

--- a/tests/hermes_cli/test_tools_disable_enable.py
+++ b/tests/hermes_cli/test_tools_disable_enable.py
@@ -2,7 +2,7 @@
 from argparse import Namespace
 from unittest.mock import patch
 
-from hermes_cli.tools_config import tools_disable_enable_command
+from hermes_cli.tools_config import build_tools_diagnostics, tools_disable_enable_command
 
 
 # ── Built-in toolset disable ────────────────────────────────────────────────
@@ -174,6 +174,39 @@ class TestToolsList:
         out = capsys.readouterr().out
         assert "github" in out
         assert "create_issue" in out
+
+
+# ── Diagnostics ──────────────────────────────────────────────────────────────
+
+
+class TestToolsDiagnose:
+
+    def test_build_diagnostics_reports_visible_and_disabled_tools(self):
+        config = {"platform_toolsets": {"cli": ["file"]}}
+
+        diag = build_tools_diagnostics(config, "cli")
+
+        assert diag["platform"] == "cli"
+        assert "file" in diag["enabled_toolsets"]
+        assert "read_file" in diag["tools_visible"]
+        assert {
+            "tool": "terminal",
+            "toolset": "terminal",
+            "reason": "toolset disabled",
+        } in diag["filtered"]
+
+    def test_build_diagnostics_reports_memory_provider_status(self):
+        config = {
+            "memory": {"provider": "mnemosyne"},
+            "platform_toolsets": {"cli": ["file"]},
+        }
+
+        diag = build_tools_diagnostics(config, "cli")
+
+        assert diag["provider_tools"]["memory"]["provider"] == "mnemosyne"
+        assert diag["provider_tools"]["memory"]["schemas"] >= 1
+        assert diag["provider_tools"]["memory"]["injected"] == 0
+        assert diag["provider_tools"]["memory"]["skipped_reason"] == "toolset disabled"
 
 
 # ── Validation ───────────────────────────────────────────────────────────────

--- a/tests/hermes_cli/test_tools_disable_enable.py
+++ b/tests/hermes_cli/test_tools_disable_enable.py
@@ -2,7 +2,11 @@
 from argparse import Namespace
 from unittest.mock import patch
 
-from hermes_cli.tools_config import build_tools_diagnostics, tools_disable_enable_command
+from hermes_cli.tools_config import (
+    _diagnostic_context_engine,
+    build_tools_diagnostics,
+    tools_disable_enable_command,
+)
 
 
 # ── Built-in toolset disable ────────────────────────────────────────────────
@@ -180,6 +184,30 @@ class TestToolsList:
 
 
 class TestToolsDiagnose:
+
+    def test_context_engine_diagnostics_rejects_uncopyable_plugin_singleton(self):
+        class _UncopyableEngine:
+            name = "uncopyable"
+
+            def __deepcopy__(self, memo):
+                raise TypeError("contains a lock")
+
+            def get_tool_schemas(self):
+                return [{"name": "should_not_be_visible"}]
+
+        with patch(
+            "plugins.context_engine.load_context_engine", return_value=None
+        ), patch(
+            "hermes_cli.plugins.get_plugin_context_engine",
+            return_value=_UncopyableEngine(),
+        ):
+            provider, schemas, error = _diagnostic_context_engine(
+                {"context": {"engine": "uncopyable"}}
+            )
+
+        assert provider == "uncopyable"
+        assert schemas == []
+        assert error == "engine cannot be copied safely"
 
     def test_build_diagnostics_reports_visible_and_disabled_tools(self):
         config = {

--- a/tests/hermes_cli/test_tools_disable_enable.py
+++ b/tests/hermes_cli/test_tools_disable_enable.py
@@ -182,7 +182,10 @@ class TestToolsList:
 class TestToolsDiagnose:
 
     def test_build_diagnostics_reports_visible_and_disabled_tools(self):
-        config = {"platform_toolsets": {"cli": ["file"]}}
+        config = {
+            "platform_toolsets": {"cli": ["file"]},
+            "tools": {"tool_search": {"enabled": "off"}},
+        }
 
         diag = build_tools_diagnostics(config, "cli")
 
@@ -195,18 +198,118 @@ class TestToolsDiagnose:
             "reason": "toolset disabled",
         } in diag["filtered"]
 
-    def test_build_diagnostics_reports_memory_provider_status(self):
+    def test_build_diagnostics_reports_external_memory_and_context_tools(self):
         config = {
-            "memory": {"provider": "mnemosyne"},
-            "platform_toolsets": {"cli": ["file"]},
+            "memory": {"provider": "stub-memory"},
+            "context": {"engine": "stub-context"},
+            "platform_toolsets": {
+                "cli": ["file", "memory", "context_engine"]
+            },
+            "tools": {"tool_search": {"enabled": "off"}},
+        }
+        memory_schema = {
+            "name": "stub_memory_recall",
+            "description": "Recall",
+            "parameters": {"type": "object", "properties": {}},
+        }
+        context_schema = {
+            "name": "stub_context_expand",
+            "description": "Expand",
+            "parameters": {"type": "object", "properties": {}},
         }
 
-        diag = build_tools_diagnostics(config, "cli")
+        with patch(
+            "hermes_cli.tools_config._diagnostic_memory_provider",
+            return_value=("stub-memory", [memory_schema], None),
+        ), patch(
+            "hermes_cli.tools_config._diagnostic_context_engine",
+            return_value=("stub-context", [context_schema], None),
+        ):
+            diag = build_tools_diagnostics(config, "cli")
 
-        assert diag["provider_tools"]["memory"]["provider"] == "mnemosyne"
-        assert diag["provider_tools"]["memory"]["schemas"] >= 1
-        assert diag["provider_tools"]["memory"]["injected"] == 0
+        assert "stub_memory_recall" in diag["tools_visible"]
+        assert "stub_context_expand" in diag["tools_visible"]
+        assert diag["provider_tools"]["memory"]["injected"] == 1
+        assert diag["provider_tools"]["context_engine"]["injected"] == 1
+
+    def test_build_diagnostics_reports_external_family_toolset_gates(self):
+        config = {
+            "memory": {"provider": "stub-memory"},
+            "context": {"engine": "stub-context"},
+            "platform_toolsets": {"cli": ["file"]},
+            "agent": {"disabled_toolsets": ["memory", "context_engine"]},
+            "tools": {"tool_search": {"enabled": "off"}},
+        }
+        memory_schema = {"name": "gated_memory", "parameters": {}}
+        context_schema = {"name": "gated_context", "parameters": {}}
+
+        with patch(
+            "hermes_cli.tools_config._diagnostic_memory_provider",
+            return_value=("stub-memory", [memory_schema], None),
+        ), patch(
+            "hermes_cli.tools_config._diagnostic_context_engine",
+            return_value=("stub-context", [context_schema], None),
+        ):
+            diag = build_tools_diagnostics(config, "cli")
+
+        assert "gated_memory" not in diag["tools_visible"]
+        assert "gated_context" not in diag["tools_visible"]
         assert diag["provider_tools"]["memory"]["skipped_reason"] == "toolset disabled"
+        assert diag["provider_tools"]["context_engine"]["skipped_reason"] == "toolset disabled"
+
+    def test_build_diagnostics_reports_activated_tool_search(self):
+        from tools.registry import registry
+
+        tool_name = "diagnose_deferred_tool"
+        toolset = "mcp-diagnose-test"
+        registry.register(
+            name=tool_name,
+            handler=lambda args, **kwargs: "{}",
+            schema={
+                "name": tool_name,
+                "description": "Deferred diagnostic tool",
+                "parameters": {"type": "object", "properties": {}},
+            },
+            toolset=toolset,
+        )
+        try:
+            config = {
+                "platform_toolsets": {"cli": [toolset]},
+                "tools": {"tool_search": {"enabled": "on"}},
+            }
+            with patch(
+                "hermes_cli.tools_config._get_platform_tools",
+                return_value={toolset},
+            ):
+                diag = build_tools_diagnostics(config, "cli")
+        finally:
+            registry.deregister(tool_name)
+
+        assert diag["tool_search"]["activated"] is True
+        assert tool_name not in diag["tools_visible"]
+        assert {"tool_search", "tool_describe", "tool_call"}.issubset(
+            diag["tools_visible"]
+        )
+        assert {
+            "tool": tool_name,
+            "toolset": toolset,
+            "reason": "deferred by tool search",
+        } in diag["filtered"]
+
+    def test_build_diagnostics_does_not_publish_process_global_resolution(
+        self, monkeypatch
+    ):
+        import model_tools
+
+        monkeypatch.setattr(model_tools, "_last_resolved_tool_names", ["runtime_tool"])
+        config = {
+            "platform_toolsets": {"cli": ["file"]},
+            "tools": {"tool_search": {"enabled": "off"}},
+        }
+
+        build_tools_diagnostics(config, "cli")
+
+        assert model_tools._last_resolved_tool_names == ["runtime_tool"]
 
 
 # ── Validation ───────────────────────────────────────────────────────────────

--- a/tests/hermes_cli/test_tools_disable_enable.py
+++ b/tests/hermes_cli/test_tools_disable_enable.py
@@ -1,11 +1,25 @@
 """Tests for hermes tools disable/enable/list command (backend)."""
+import json
+import os
+import subprocess
+import sys
 from argparse import Namespace
+from copy import deepcopy
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
 
 from gateway.platform_registry import platform_registry
-from hermes_cli.tools_config import tools_disable_enable_command
+from hermes_cli.tools_config import (
+    _diagnostic_memory_provider,
+    _diagnostic_context_engine,
+    _known_tool_platforms,
+    _print_tools_diagnostics,
+    build_tools_diagnostics,
+    tools_diagnose_command,
+    tools_disable_enable_command,
+)
 
 
 # ── Built-in toolset disable ────────────────────────────────────────────────
@@ -64,6 +78,782 @@ class TestToolsList:
         out = capsys.readouterr().out
         assert "github" in out
         assert "create_issue" in out
+
+
+# ── Diagnostics ──────────────────────────────────────────────────────────────
+
+
+class TestToolsDiagnose:
+
+    def test_known_platforms_include_disposable_manager_registrations(self):
+        manager = MagicMock()
+        manager._plugin_platform_names = {"late-probe-platform"}
+        with patch("hermes_cli.plugins.discover_plugins"), patch(
+            "hermes_cli.plugins.get_plugin_manager", return_value=manager
+        ), patch.object(platform_registry, "registered_names", return_value=set()):
+            assert "late-probe-platform" in _known_tool_platforms()
+
+    def test_unknown_platform_json_is_structured_and_fails(self, capsys):
+        args = Namespace(platform="definitely-invalid", json=True)
+
+        result = tools_diagnose_command(args)
+
+        assert result == 2
+        payload = json.loads(capsys.readouterr().out)
+        assert payload["error"]["code"] == "unknown_platform"
+        assert payload["error"]["platform"] == "definitely-invalid"
+        assert "cli" in payload["error"]["valid_platforms"]
+
+    def test_unknown_platform_human_error_uses_stderr(self, capsys):
+        result = tools_diagnose_command(
+            Namespace(platform="definitely-invalid", json=False)
+        )
+
+        captured = capsys.readouterr()
+        assert result == 2
+        assert captured.out == ""
+        assert "Unknown platform" in captured.err
+
+    def test_json_output_isolated_from_provider_stdout(self, capsys):
+        def _noisy_build(_config, _platform):
+            print("provider-noise")
+            return {"platform": "cli", "ok": True}
+
+        with patch(
+            "hermes_cli.tools_config.load_config_for_diagnostics", return_value={}
+        ), patch(
+            "hermes_cli.tools_config._known_tool_platforms", return_value={"cli"}
+        ), patch(
+            "hermes_cli.tools_config.build_tools_diagnostics",
+            side_effect=_noisy_build,
+        ):
+            result = tools_diagnose_command(Namespace(platform="cli", json=True))
+
+        captured = capsys.readouterr()
+        assert result == 0
+        assert json.loads(captured.out) == {"platform": "cli", "ok": True}
+        assert "provider-noise" not in captured.out
+        assert captured.err == ""
+
+    def test_human_output_isolated_from_provider_terminal_controls(self, capsys):
+        diag = {
+            "platform": "cli",
+            "resolution": {},
+            "enabled_toolsets": [],
+            "config_sources": {},
+            "tools_visible": [],
+            "tool_search": {},
+            "provider_tools": {},
+            "filtered": [],
+            "conflicts": [],
+        }
+
+        def _noisy_build(_config, _platform):
+            print("\x1b]0;provider-controlled\x07")
+            return diag
+
+        with patch(
+            "hermes_cli.tools_config.load_config_for_diagnostics", return_value={}
+        ), patch(
+            "hermes_cli.tools_config._known_tool_platforms", return_value={"cli"}
+        ), patch(
+            "hermes_cli.tools_config.build_tools_diagnostics",
+            side_effect=_noisy_build,
+        ):
+            result = tools_diagnose_command(Namespace(platform="cli", json=False))
+
+        captured = capsys.readouterr()
+        assert result == 0
+        assert captured.out.startswith("Tool diagnostics (cli):")
+        assert "provider-controlled" not in captured.out
+        assert "\x1b" not in captured.out
+        assert "\x07" not in captured.out
+        assert captured.err == ""
+
+    def test_output_isolates_raw_descriptors_and_inherited_children(self, capfd):
+        import os
+        import subprocess
+        import sys
+
+        diag = {
+            "platform": "cli",
+            "resolution": {},
+            "enabled_toolsets": [],
+            "config_sources": {},
+            "tools_visible": [],
+            "tool_search": {},
+            "provider_tools": {},
+            "filtered": [],
+            "conflicts": [],
+        }
+
+        def _noisy_build(_config, _platform):
+            os.write(1, b"fd-stdout-noise\n")
+            os.write(2, b"fd-stderr-noise\n")
+            subprocess.run(
+                [
+                    sys.executable,
+                    "-c",
+                    "import os; os.write(1, b'child-stdout-noise\\n'); "
+                    "os.write(2, b'child-stderr-noise\\n')",
+                ],
+                check=True,
+            )
+            return diag
+
+        with patch(
+            "hermes_cli.tools_config.load_config_for_diagnostics", return_value={}
+        ), patch(
+            "hermes_cli.tools_config._known_tool_platforms", return_value={"cli"}
+        ), patch(
+            "hermes_cli.tools_config.build_tools_diagnostics",
+            side_effect=_noisy_build,
+        ):
+            assert tools_diagnose_command(Namespace(platform="cli", json=True)) == 0
+            json_output = capfd.readouterr()
+            assert json.loads(json_output.out) == diag
+            assert json_output.err == ""
+
+            assert tools_diagnose_command(Namespace(platform="cli", json=False)) == 0
+            human_output = capfd.readouterr()
+            assert human_output.out.startswith("Tool diagnostics (cli):")
+            assert human_output.err == ""
+
+        combined = json_output.out + human_output.out
+        assert "fd-stdout-noise" not in combined
+        assert "fd-stderr-noise" not in combined
+        assert "child-stdout-noise" not in combined
+        assert "child-stderr-noise" not in combined
+
+    def test_memory_diagnostics_never_register_provider_skills(self):
+        with patch(
+            "plugins.memory.load_memory_provider", return_value=None
+        ) as load_provider:
+            _diagnostic_memory_provider(
+                {"memory": {"provider": "stub-memory"}}
+            )
+
+        load_provider.assert_called_once_with(
+            "stub-memory", register_skills=False
+        )
+
+    def test_context_diagnostics_never_register_plugin_commands(self):
+        with patch(
+            "plugins.context_engine.load_context_engine", return_value=None
+        ) as load_engine, patch(
+            "hermes_cli.plugins.get_plugin_context_engine", return_value=None
+        ):
+            _diagnostic_context_engine(
+                {"context": {"engine": "stub-context"}}
+            )
+
+        load_engine.assert_called_once_with(
+            "stub-context", register_commands=False
+        )
+
+    def test_context_engine_diagnostics_rejects_uncopyable_plugin_singleton(self):
+        class _UncopyableEngine:
+            name = "uncopyable"
+
+            def __deepcopy__(self, memo):
+                raise TypeError("contains a lock")
+
+            def get_tool_schemas(self):
+                return [{"name": "should_not_be_visible"}]
+
+        with patch(
+            "plugins.context_engine.load_context_engine", return_value=None
+        ), patch(
+            "hermes_cli.plugins.get_plugin_context_engine",
+            return_value=_UncopyableEngine(),
+        ):
+            provider, schemas, error = _diagnostic_context_engine(
+                {"context": {"engine": "uncopyable"}}
+            )
+
+        assert provider == "uncopyable"
+        assert schemas == []
+        assert error == "engine cannot be copied safely"
+
+    def test_build_diagnostics_reports_visible_and_disabled_tools(self):
+        config = {
+            "platform_toolsets": {"cli": ["file"]},
+            "tools": {"tool_search": {"enabled": "off"}},
+        }
+
+        diag = build_tools_diagnostics(config, "cli")
+
+        assert diag["platform"] == "cli"
+        assert diag["resolution"]["phase"] == "pre_startup"
+        assert "file" in diag["enabled_toolsets"]
+        assert "read_file" in diag["tools_visible"]
+        assert {
+            "tool": "terminal",
+            "toolset": "terminal",
+            "reason": "toolset disabled",
+        } in diag["filtered"]
+
+    def test_composite_disabled_toolset_reports_policy_reason(self):
+        config = {
+            "platform_toolsets": {"cli": ["file", "terminal", "web"]},
+            "agent": {"disabled_toolsets": ["debugging"]},
+            "tools": {"tool_search": {"enabled": "off"}},
+        }
+
+        diag = build_tools_diagnostics(config, "cli")
+        reasons = {
+            row["tool"]: row["reason"]
+            for row in diag["filtered"]
+            if row["tool"] in {"read_file", "terminal", "web_search"}
+        }
+
+        assert reasons == {
+            "read_file": "toolset disabled",
+            "terminal": "toolset disabled",
+            "web_search": "toolset disabled",
+        }
+
+    def test_build_diagnostics_reports_external_memory_and_context_tools(self):
+        config = {
+            "memory": {"provider": "stub-memory"},
+            "context": {"engine": "stub-context"},
+            "platform_toolsets": {
+                "cli": ["file", "memory", "context_engine"]
+            },
+            "tools": {"tool_search": {"enabled": "off"}},
+        }
+        memory_schema = {
+            "name": "stub_memory_recall",
+            "description": "Recall",
+            "parameters": {"type": "object", "properties": {}},
+        }
+        context_schema = {
+            "name": "stub_context_expand",
+            "description": "Expand",
+            "parameters": {"type": "object", "properties": {}},
+        }
+
+        with patch(
+            "hermes_cli.tools_config._diagnostic_memory_provider",
+            return_value=("stub-memory", [memory_schema], None),
+        ), patch(
+            "hermes_cli.tools_config._diagnostic_context_engine",
+            return_value=("stub-context", [context_schema], None),
+        ):
+            diag = build_tools_diagnostics(config, "cli")
+
+        assert "stub_memory_recall" in diag["tools_visible"]
+        assert "stub_context_expand" in diag["tools_visible"]
+        assert diag["provider_tools"]["memory"]["injected"] == 1
+        assert diag["provider_tools"]["context_engine"]["injected"] == 1
+
+    def test_duplicate_external_schema_is_a_top_level_conflict(self):
+        config = {
+            "platform_toolsets": {"cli": ["file", "memory"]},
+            "tools": {"tool_search": {"enabled": "off"}},
+        }
+        duplicate = {
+            "name": "read_file",
+            "parameters": {"type": "object", "properties": {}},
+        }
+        unique = {
+            "name": "memory_unique",
+            "parameters": {"type": "object", "properties": {}},
+        }
+
+        with patch(
+            "hermes_cli.tools_config._diagnostic_memory_provider",
+            return_value=("stub-memory", [duplicate, unique], None),
+        ), patch(
+            "hermes_cli.tools_config._diagnostic_context_engine",
+            return_value=("compressor", [], None),
+        ):
+            diag = build_tools_diagnostics(config, "cli")
+
+        assert {
+            "tool": "read_file",
+            "reason": "duplicate tool name",
+            "source": "memory",
+        } in diag["conflicts"]
+        assert (
+            diag["provider_tools"]["memory"]["skipped_reason"]
+            == "duplicate tool name"
+        )
+
+    def test_plugin_registration_conflicts_are_reported_before_dedup(self):
+        config = {
+            "platform_toolsets": {"cli": ["file"]},
+            "tools": {"tool_search": {"enabled": "off"}},
+        }
+        conflict = {
+            "tool": "read_file",
+            "reason": "plugin tool overrides existing registry tool",
+            "source": "stub-plugin",
+        }
+
+        with patch(
+            "hermes_cli.plugins.get_diagnostic_plugin_conflicts",
+            return_value=[conflict],
+            create=True,
+        ):
+            diag = build_tools_diagnostics(config, "cli")
+
+        assert conflict in diag["conflicts"]
+
+    def test_in_process_diagnose_preserves_cold_registry_state(self, tmp_path):
+        code = r'''
+import contextlib
+import io
+import json
+from argparse import Namespace
+from hermes_cli.tools_config import tools_diagnose_command
+from tools.registry import registry
+
+before = {
+    "generation": registry._generation,
+    "names": registry.get_all_tool_names(),
+    "aliases": registry.get_registered_toolset_aliases(),
+}
+with contextlib.redirect_stdout(io.StringIO()):
+    rc = tools_diagnose_command(Namespace(platform="cli", json=True))
+after = {
+    "generation": registry._generation,
+    "names": registry.get_all_tool_names(),
+    "aliases": registry.get_registered_toolset_aliases(),
+}
+print(json.dumps({"rc": rc, "same": before == after}))
+'''
+        env = {
+            **os.environ,
+            "HOME": str(tmp_path),
+            "HERMES_HOME": str(tmp_path / "missing-home"),
+            "PYTHONPATH": str(Path(__file__).resolve().parents[2]),
+            "PYTHONDONTWRITEBYTECODE": "1",
+        }
+        result = subprocess.run(
+            [sys.executable, "-c", code],
+            capture_output=True,
+            text=True,
+            env=env,
+            timeout=120,
+        )
+
+        assert result.returncode == 0, result.stderr
+        assert json.loads(result.stdout) == {"rc": 0, "same": True}
+
+    def test_human_renderer_escapes_provider_control_characters(self, capsys):
+        diag = {
+            "platform": "cli",
+            "resolution": {"phase": "pre_startup", "detail": "projection"},
+            "enabled_toolsets": ["file"],
+            "disabled_toolsets": [],
+            "config_sources": {},
+            "tools_visible": ["evil\x1b[31m\nFORGED"],
+            "tool_search": {},
+            "provider_tools": {},
+            "filtered": [],
+            "conflicts": [],
+        }
+
+        _print_tools_diagnostics(diag)
+
+        out = capsys.readouterr().out
+        assert "\x1b" not in out
+        assert "\nFORGED" not in out
+        assert r"\x1b" in out
+        assert r"\nFORGED" in out
+
+    def test_build_diagnostics_reports_external_family_toolset_gates(self):
+        config = {
+            "memory": {"provider": "stub-memory"},
+            "context": {"engine": "stub-context"},
+            "platform_toolsets": {"cli": ["file"]},
+            "agent": {
+                "disabled_toolsets": '["memory", "context_engine"]'
+            },
+            "tools": {"tool_search": {"enabled": "off"}},
+        }
+        memory_schema = {"name": "gated_memory", "parameters": {}}
+        context_schema = {"name": "gated_context", "parameters": {}}
+
+        with patch(
+            "hermes_cli.tools_config._diagnostic_memory_provider",
+            return_value=("stub-memory", [memory_schema], None),
+        ), patch(
+            "hermes_cli.tools_config._diagnostic_context_engine",
+            return_value=("stub-context", [context_schema], None),
+        ):
+            diag = build_tools_diagnostics(config, "cli")
+
+        assert "gated_memory" not in diag["tools_visible"]
+        assert "gated_context" not in diag["tools_visible"]
+        assert diag["provider_tools"]["memory"]["skipped_reason"] == "toolset disabled"
+        assert diag["provider_tools"]["context_engine"]["skipped_reason"] == "toolset disabled"
+
+    def test_plugin_provider_counts_owned_names_not_shared_toolset_members(self):
+        from tools.registry import registry
+
+        tool_name = "diagnose_owned_plugin_tool"
+        registry.register(
+            name=tool_name,
+            handler=lambda args, **kwargs: "{}",
+            schema={
+                "name": tool_name,
+                "description": "Plugin-owned file helper",
+                "parameters": {"type": "object", "properties": {}},
+            },
+            toolset="file",
+        )
+        config = {
+            "platform_toolsets": {"cli": ["file"]},
+            "tools": {"tool_search": {"enabled": "off"}},
+        }
+
+        try:
+            with patch(
+                "hermes_cli.tools_config._get_plugin_toolset_keys",
+                return_value={"file"},
+            ), patch(
+                "hermes_cli.plugins.get_plugin_tool_names",
+                return_value={tool_name},
+                create=True,
+            ):
+                diag = build_tools_diagnostics(config, "cli")
+        finally:
+            registry.deregister(tool_name)
+
+        plugins = diag["provider_tools"]["plugins"]
+        assert plugins["schemas"] == 1
+        assert plugins["injected"] == 1
+        assert plugins["toolsets"] == ["file"]
+
+    def test_build_diagnostics_reports_activated_tool_search(self):
+        from tools.registry import registry
+
+        tool_name = "diagnose_deferred_tool"
+        toolset = "mcp-diagnose-test"
+        registry.register(
+            name=tool_name,
+            handler=lambda args, **kwargs: "{}",
+            schema={
+                "name": tool_name,
+                "description": "Deferred diagnostic tool",
+                "parameters": {"type": "object", "properties": {}},
+            },
+            toolset=toolset,
+        )
+        try:
+            config = {
+                "platform_toolsets": {"cli": [toolset]},
+                "tools": {"tool_search": {"enabled": "on"}},
+            }
+            with patch(
+                "hermes_cli.tools_config._get_platform_tools",
+                return_value={toolset},
+            ):
+                diag = build_tools_diagnostics(config, "cli")
+        finally:
+            registry.deregister(tool_name)
+
+        assert diag["tool_search"]["activated"] is True
+        assert tool_name not in diag["tools_visible"]
+        assert {"tool_search", "tool_describe", "tool_call"}.issubset(
+            diag["tools_visible"]
+        )
+        assert {
+            "tool": tool_name,
+            "toolset": toolset,
+            "reason": "deferred by tool search",
+        } in diag["filtered"]
+
+    def test_build_diagnostics_does_not_publish_or_populate_global_state(
+        self, monkeypatch
+    ):
+        import model_tools
+        import tools.registry as registry_module
+
+        monkeypatch.setattr(
+            model_tools, "_last_resolved_tool_names", ["runtime_tool"]
+        )
+        model_tools._clear_tool_defs_cache()
+        check_cache_before = dict(registry_module._check_fn_cache)
+        last_good_before = dict(registry_module._check_fn_last_good)
+        config = {
+            "platform_toolsets": {"cli": ["file"]},
+            "tools": {"tool_search": {"enabled": "off"}},
+        }
+        original_config = deepcopy(config)
+
+        build_tools_diagnostics(config, "cli")
+
+        assert config == original_config
+        assert model_tools._last_resolved_tool_names == ["runtime_tool"]
+        assert model_tools._tool_defs_cache == {}
+        assert registry_module._check_fn_cache == check_cache_before
+        assert registry_module._check_fn_last_good == last_good_before
+
+    def test_diagnose_command_does_not_mutate_config_caches(
+        self, tmp_path, monkeypatch, capsys
+    ):
+        from hermes_cli import config as config_mod
+        from hermes_cli import managed_scope
+        from hermes_cli import plugins as plugins_mod
+
+        hermes_home = tmp_path / "hermes"
+        hermes_home.mkdir()
+        (hermes_home / "config.yaml").write_text("agent:\n  max_turns: 7\n")
+        managed_home = tmp_path / "managed"
+        managed_home.mkdir()
+        (managed_home / "config.yaml").write_text("agent:\n  max_turns: 9\n")
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.setenv("HERMES_MANAGED_DIR", str(managed_home))
+        before = (
+            deepcopy(config_mod._LOAD_CONFIG_CACHE),
+            deepcopy(config_mod._RAW_CONFIG_CACHE),
+            deepcopy(config_mod._LAST_EXPANDED_CONFIG_BY_PATH),
+            deepcopy(config_mod._CONFIG_PARSE_WARNED),
+            deepcopy(managed_scope._CONFIG_CACHE),
+            dict(plugins_mod._plugin_managers_by_home),
+            plugins_mod._plugin_manager,
+        )
+        assert tools_diagnose_command(Namespace(platform="cli", json=True)) == 0
+        json.loads(capsys.readouterr().out)
+
+        assert config_mod._LOAD_CONFIG_CACHE == before[0]
+        assert config_mod._RAW_CONFIG_CACHE == before[1]
+        assert config_mod._LAST_EXPANDED_CONFIG_BY_PATH == before[2]
+        assert config_mod._CONFIG_PARSE_WARNED == before[3]
+        assert managed_scope._CONFIG_CACHE == before[4]
+        assert plugins_mod._plugin_managers_by_home == before[5]
+        assert plugins_mod._plugin_manager is before[6]
+
+    def test_diagnose_fresh_process_does_not_create_runtime_state(self, tmp_path):
+        hermes_home = tmp_path / "hermes"
+        env = dict(os.environ)
+        env["HERMES_HOME"] = str(hermes_home)
+        env["PYTHONDONTWRITEBYTECODE"] = "1"
+        env.pop("HERMES_PROFILE", None)
+
+        result = subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "hermes_cli.main",
+                "tools",
+                "diagnose",
+                "--json",
+            ],
+            cwd=str(Path(__file__).resolve().parents[2]),
+            env=env,
+            capture_output=True,
+            text=True,
+            timeout=120,
+            check=False,
+        )
+
+        assert result.returncode == 0, result.stderr
+        diagnostics = json.loads(result.stdout)
+        assert "session_search" in diagnostics["tools_visible"]
+        assert not hermes_home.exists()
+
+    def test_diagnose_invalid_platform_fresh_process_is_zero_write(self, tmp_path):
+        hermes_home = tmp_path / "hermes"
+        env = dict(os.environ)
+        env["HOME"] = str(tmp_path)
+        env["HERMES_HOME"] = str(hermes_home)
+        env["PYTHONDONTWRITEBYTECODE"] = "1"
+        env.pop("HERMES_PROFILE", None)
+
+        result = subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "hermes_cli.main",
+                "tools",
+                "diagnose",
+                "--platform",
+                "definitely-invalid",
+                "--json",
+            ],
+            cwd=str(Path(__file__).resolve().parents[2]),
+            env=env,
+            capture_output=True,
+            text=True,
+            timeout=120,
+            check=False,
+        )
+
+        assert result.returncode == 2, result.stderr
+        assert json.loads(result.stdout)["error"]["code"] == "unknown_platform"
+        assert result.stderr == ""
+        assert not hermes_home.exists()
+
+    def test_diagnose_malformed_config_is_zero_write_and_machine_safe(
+        self, tmp_path
+    ):
+        hermes_home = tmp_path / "hermes"
+        hermes_home.mkdir()
+        config_path = hermes_home / "config.yaml"
+        config_path.write_text("platform_toolsets: [unterminated\n")
+        before_tree = {
+            str(path.relative_to(hermes_home)): (
+                path.read_bytes() if path.is_file() else None
+            )
+            for path in hermes_home.rglob("*")
+        }
+        env = dict(os.environ)
+        env["HOME"] = str(tmp_path)
+        env["HERMES_HOME"] = str(hermes_home)
+        env["PYTHONDONTWRITEBYTECODE"] = "1"
+        env.pop("HERMES_PROFILE", None)
+
+        result = subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "hermes_cli.main",
+                "tools",
+                "diagnose",
+                "--json",
+            ],
+            cwd=str(Path(__file__).resolve().parents[2]),
+            env=env,
+            capture_output=True,
+            text=True,
+            timeout=120,
+            check=False,
+        )
+        after_tree = {
+            str(path.relative_to(hermes_home)): (
+                path.read_bytes() if path.is_file() else None
+            )
+            for path in hermes_home.rglob("*")
+        }
+
+        assert result.returncode == 0
+        json.loads(result.stdout)
+        assert result.stderr == ""
+        assert after_tree == before_tree
+
+    def test_diagnose_existing_env_is_byte_and_tree_read_only(self, tmp_path):
+        hermes_home = tmp_path / "hermes"
+        hermes_home.mkdir()
+        env_path = hermes_home / ".env"
+        env_path.write_bytes("NOUS_API_KEY=opaque\n".encode("utf-16-le"))
+        before_bytes = env_path.read_bytes()
+        before_stat = env_path.stat()
+        before_tree = {
+            str(path.relative_to(hermes_home)) for path in hermes_home.rglob("*")
+        }
+        env = dict(os.environ)
+        env["HOME"] = str(tmp_path)
+        env["HERMES_HOME"] = str(hermes_home)
+        env["PYTHONDONTWRITEBYTECODE"] = "1"
+        env.pop("HERMES_PROFILE", None)
+
+        result = subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "hermes_cli.main",
+                "tools",
+                "diagnose",
+                "--json",
+            ],
+            cwd=str(Path(__file__).resolve().parents[2]),
+            env=env,
+            capture_output=True,
+            text=True,
+            timeout=120,
+            check=False,
+        )
+
+        assert result.returncode == 0, result.stderr
+        json.loads(result.stdout)
+        after_stat = env_path.stat()
+        after_tree = {
+            str(path.relative_to(hermes_home)) for path in hermes_home.rglob("*")
+        }
+        assert result.stderr == ""
+        assert env_path.read_bytes() == before_bytes
+        assert after_stat.st_mode == before_stat.st_mode
+        assert after_stat.st_mtime_ns == before_stat.st_mtime_ns
+        assert after_tree == before_tree
+
+    def test_diagnose_existing_nous_auth_is_byte_and_tree_read_only(self, tmp_path):
+        hermes_home = tmp_path / "hermes"
+        env = dict(os.environ)
+        env["HOME"] = str(tmp_path)
+        env["HERMES_HOME"] = str(hermes_home)
+        env["PYTHONDONTWRITEBYTECODE"] = "1"
+        env.pop("HERMES_PROFILE", None)
+        for name in (
+            "NOUS_API_KEY",
+            "NOUS_INFERENCE_API_KEY",
+            "NOUS_INFERENCE_BASE_URL",
+        ):
+            env.pop(name, None)
+
+        command = [
+            sys.executable,
+            "-m",
+            "hermes_cli.main",
+            "tools",
+            "diagnose",
+            "--platform",
+            "cli",
+            "--json",
+        ]
+        repo_root = str(Path(__file__).resolve().parents[2])
+
+        hermes_home.mkdir(parents=True)
+        auth_path = hermes_home / "auth.json"
+        auth_path.write_text(
+            json.dumps(
+                {
+                    "version": 1,
+                    "active_provider": "nous",
+                    "providers": {
+                        "nous": {
+                            "access_token": "opaque-access-token",
+                            "refresh_token": "refresh-token",
+                            "inference_base_url": (
+                                "https://inference-api.nousresearch.com/v1"
+                            ),
+                        }
+                    },
+                },
+                indent=2,
+            )
+            + "\n"
+        )
+        auth_path.chmod(0o600)
+        before_bytes = auth_path.read_bytes()
+        before_stat = auth_path.stat()
+        before_tree = {
+            str(path.relative_to(hermes_home)) for path in hermes_home.rglob("*")
+        }
+
+        result = subprocess.run(
+            command,
+            cwd=repo_root,
+            env=env,
+            capture_output=True,
+            text=True,
+            timeout=120,
+            check=False,
+        )
+
+        assert result.returncode == 0, result.stderr
+        json.loads(result.stdout)
+        after_stat = auth_path.stat()
+        after_tree = {
+            str(path.relative_to(hermes_home)) for path in hermes_home.rglob("*")
+        }
+        assert auth_path.read_bytes() == before_bytes
+        assert after_stat.st_mode == before_stat.st_mode
+        assert after_stat.st_mtime_ns == before_stat.st_mtime_ns
+        assert after_tree == before_tree
 
 
 # ── Validation ───────────────────────────────────────────────────────────────

--- a/tests/run_agent/test_repair_tool_call_name.py
+++ b/tests/run_agent/test_repair_tool_call_name.py
@@ -50,6 +50,14 @@ class TestExistingBehaviorStillWorks:
     def test_lowercase_already_matches(self, repair):
         assert repair("browser_click") == "browser_click"
 
+    def test_request_snapshot_names_override_legacy_agent_names(self):
+        from run_agent import AIAgent
+
+        stub = SimpleNamespace(valid_tool_names={"legacy_only"})
+        repair = AIAgent._repair_tool_call.__get__(stub, AIAgent)
+
+        assert repair("SnapshotOnly", frozenset({"snapshot_only"})) == "snapshot_only"
+
 
 
 

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -201,6 +201,40 @@ def agent_with_memory_tool():
         return a
 
 
+def test_agent_init_refresh_failure_uses_complete_surface_fallback():
+    from agent import tool_surface
+
+    with (
+        patch(
+            "run_agent.get_tool_definitions",
+            return_value=_make_tool_defs("web_search"),
+        ),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI"),
+        patch(
+            "tools.mcp_tool.refresh_agent_mcp_tools",
+            side_effect=RuntimeError("transient refresh failure"),
+        ),
+        patch(
+            "agent.tool_surface.assemble_agent_tool_surface",
+            wraps=tool_surface.assemble_agent_tool_surface,
+        ) as assemble_surface,
+    ):
+        initialized = AIAgent(
+            api_key="test-key-1234567890",
+            base_url="https://openrouter.ai/api/v1",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+
+    assemble_surface.assert_called_once()
+    snapshot = tool_surface.get_agent_tool_surface(initialized)
+    assert snapshot.valid_tool_names == frozenset({"web_search"})
+    assert snapshot.catalog_tool_defs
+    assert getattr(initialized, "valid_tool_names") == {"web_search"}
+
+
 def test_aiagent_reuses_existing_errors_log_handler():
     """Repeated AIAgent init should not accumulate duplicate errors.log handlers."""
     root_logger = logging.getLogger()
@@ -1965,6 +1999,9 @@ class TestConcurrentToolExecution:
 
     def test_invoke_tool_dispatches_to_handle_function_call(self, agent):
         """_invoke_tool should route regular tools through handle_function_call."""
+        from agent.tool_surface import get_agent_tool_surface
+
+        surface = get_agent_tool_surface(agent)
         with patch("run_agent.handle_function_call", return_value="result") as mock_hfc:
             result = agent._invoke_tool("web_search", {"q": "test"}, "task-1")
             mock_hfc.assert_called_once_with(
@@ -1978,9 +2015,461 @@ class TestConcurrentToolExecution:
                 skip_tool_request_middleware=True,
                 enabled_toolsets=agent.enabled_toolsets,
                 disabled_toolsets=agent.disabled_toolsets,
+                catalog_tool_defs=list(surface.catalog_tool_defs),
+                expected_registry_entries=dict(surface.registry_entries),
                 tool_request_middleware_trace=[],
             )
             assert result == "result"
+
+    def test_memory_manager_cannot_shadow_registry_tool_without_snapshot_ownership(
+        self, agent
+    ):
+        from agent.tool_surface import publish_agent_tool_surface
+
+        manager = MagicMock()
+        manager.has_tool.return_value = True
+        manager.handle_tool_call.return_value = "memory-result"
+        agent._memory_manager = manager
+        surface = publish_agent_tool_surface(
+            agent,
+            agent.tools,
+            catalog_tool_defs=agent.tools,
+            memory_provider_tool_names=set(),
+            context_engine_tool_names=set(),
+            registry_generation=1,
+            selection_revision=0,
+            enabled_toolsets=None,
+            disabled_toolsets=None,
+        )
+
+        with patch(
+            "run_agent.handle_function_call", return_value="registry-result"
+        ) as dispatch:
+            result = agent._invoke_tool(
+                "web_search", {}, "task-1", tool_surface=surface
+            )
+
+        assert result == "registry-result"
+        dispatch.assert_called_once()
+        manager.handle_tool_call.assert_not_called()
+
+    def test_sequential_dispatch_uses_snapshot_memory_ownership(self, agent):
+        from agent.tool_surface import publish_agent_tool_surface
+
+        manager = MagicMock()
+        manager.has_tool.return_value = True
+        agent._memory_manager = manager
+        surface = publish_agent_tool_surface(
+            agent,
+            agent.tools,
+            catalog_tool_defs=agent.tools,
+            memory_provider_tool_names=set(),
+            context_engine_tool_names=set(),
+            registry_generation=1,
+            selection_revision=0,
+            enabled_toolsets=None,
+            disabled_toolsets=None,
+        )
+        message = _mock_assistant_msg(
+            content="",
+            tool_calls=[_mock_tool_call(name="web_search", call_id="c1")],
+        )
+
+        with patch(
+            "run_agent.handle_function_call", return_value="registry-result"
+        ) as dispatch:
+            agent._execute_tool_calls_sequential(
+                message, [], "task-1", tool_surface=surface
+            )
+
+        dispatch.assert_called_once()
+        manager.handle_tool_call.assert_not_called()
+
+    def test_request_snapshot_pins_memory_owner_and_manager(self, agent):
+        from agent.tool_surface import publish_agent_tool_surface
+
+        memory_tool = {
+            "type": "function",
+            "function": {
+                "name": "external_memory_test",
+                "description": "test",
+                "parameters": {"type": "object", "properties": {}},
+            },
+        }
+        old_manager = MagicMock()
+        old_manager.handle_tool_call.return_value = "old-memory"
+        agent._memory_manager = old_manager
+        old_surface = publish_agent_tool_surface(
+            agent,
+            [memory_tool],
+            catalog_tool_defs=[memory_tool],
+            memory_provider_tool_names={"external_memory_test"},
+            context_engine_tool_names=set(),
+            registry_generation=1,
+            selection_revision=0,
+            enabled_toolsets=["memory"],
+            disabled_toolsets=None,
+        )
+
+        new_manager = MagicMock()
+        agent._memory_manager = new_manager
+        publish_agent_tool_surface(
+            agent,
+            agent.tools,
+            memory_provider_tool_names=set(),
+            context_engine_tool_names=set(),
+            registry_generation=2,
+            selection_revision=0,
+            enabled_toolsets=None,
+            disabled_toolsets=None,
+        )
+
+        result = agent._invoke_tool(
+            "external_memory_test", {}, "task-1", tool_surface=old_surface
+        )
+
+        assert result == "old-memory"
+        old_manager.handle_tool_call.assert_called_once_with(
+            "external_memory_test", {}
+        )
+        new_manager.handle_tool_call.assert_not_called()
+
+    def test_request_snapshot_pins_builtin_memory_write_mirror(self, agent):
+        from agent.tool_surface import publish_agent_tool_surface
+
+        memory_tool = {
+            "type": "function",
+            "function": {
+                "name": "memory",
+                "description": "test",
+                "parameters": {"type": "object", "properties": {}},
+            },
+        }
+        old_manager = MagicMock()
+        agent._memory_manager = old_manager
+        old_surface = publish_agent_tool_surface(
+            agent,
+            [memory_tool],
+            catalog_tool_defs=[memory_tool],
+            context_engine_tool_names=set(),
+            registry_generation=1,
+            selection_revision=0,
+            enabled_toolsets=["memory"],
+            disabled_toolsets=None,
+        )
+
+        new_manager = MagicMock()
+        agent._memory_manager = new_manager
+        publish_agent_tool_surface(
+            agent,
+            [memory_tool],
+            catalog_tool_defs=[memory_tool],
+            context_engine_tool_names=set(),
+            registry_generation=2,
+            selection_revision=0,
+            enabled_toolsets=["memory"],
+            disabled_toolsets=None,
+        )
+        message = _mock_assistant_msg(
+            content="",
+            tool_calls=[
+                _mock_tool_call(
+                    name="memory",
+                    arguments=json.dumps(
+                        {"action": "add", "target": "memory", "content": "fact"}
+                    ),
+                )
+            ],
+        )
+
+        with patch(
+            "tools.memory_tool.memory_tool",
+            return_value=json.dumps({"success": True}),
+        ):
+            agent._execute_tool_calls_sequential(
+                message, [], "task-1", tool_surface=old_surface
+            )
+
+        old_manager.notify_memory_tool_write.assert_called_once()
+        new_manager.notify_memory_tool_write.assert_not_called()
+
+    def test_request_snapshot_rejects_replaced_registry_entry(self, agent):
+        from agent.tool_surface import publish_agent_tool_surface
+        from tools.registry import registry
+
+        name = "snapshot_registry_identity_test"
+        old_handler = MagicMock(return_value="old")
+        new_handler = MagicMock(return_value="new")
+        schema = {
+            "name": name,
+            "description": "test",
+            "parameters": {"type": "object", "properties": {}},
+        }
+        tool_def = {"type": "function", "function": schema}
+        registry.register(
+            name=name,
+            handler=old_handler,
+            schema=schema,
+            toolset="snapshot-test",
+        )
+        try:
+            surface = publish_agent_tool_surface(
+                agent,
+                [tool_def],
+                catalog_tool_defs=[tool_def],
+                context_engine_tool_names=set(),
+                registry_generation=registry._generation,
+                selection_revision=0,
+                enabled_toolsets=["snapshot-test"],
+                disabled_toolsets=None,
+            )
+            registry.deregister(name)
+            registry.register(
+                name=name,
+                handler=new_handler,
+                schema=schema,
+                toolset="snapshot-test",
+            )
+
+            with (
+                patch(
+                    "hermes_cli.middleware.apply_tool_request_middleware"
+                ) as request_middleware,
+                patch(
+                    "hermes_cli.plugins._dispatch_pre_tool_call_hooks"
+                ) as pre_tool_hook,
+                patch(
+                    "hermes_cli.middleware.run_tool_execution_middleware"
+                ) as execution_middleware,
+            ):
+                result = agent._invoke_tool(
+                    name, {}, "task-1", tool_surface=surface
+                )
+        finally:
+            registry.deregister(name)
+
+        assert "registration changed during the request" in result
+        request_middleware.assert_not_called()
+        pre_tool_hook.assert_not_called()
+        execution_middleware.assert_not_called()
+        old_handler.assert_not_called()
+        new_handler.assert_not_called()
+
+    def test_request_snapshot_rejects_replaced_direct_delegate_before_middleware(
+        self, agent
+    ):
+        from agent.tool_surface import publish_agent_tool_surface
+        from tools.registry import registry
+
+        delegate_def = {
+            "type": "function",
+            "function": {
+                "name": "delegate_task",
+                "description": "test",
+                "parameters": {"type": "object", "properties": {}},
+            },
+        }
+        expected_entry = object()
+        surface = publish_agent_tool_surface(
+            agent,
+            [delegate_def],
+            catalog_tool_defs=[delegate_def],
+            context_engine_tool_names=set(),
+            registry_entries=[("delegate_task", expected_entry)],
+            registry_generation=1,
+            selection_revision=0,
+            enabled_toolsets=["delegation"],
+            disabled_toolsets=None,
+        )
+
+        replacement_entry = object()
+        original_get_entry = registry.get_entry
+
+        def replaced_get_entry(name, *, scope=None):
+            if name == "delegate_task":
+                return replacement_entry
+            return original_get_entry(name, scope=scope)
+
+        with (
+            patch.object(registry, "get_entry", side_effect=replaced_get_entry),
+            patch.object(agent, "_dispatch_delegate_task") as dispatch_delegate,
+            patch(
+                "hermes_cli.middleware.apply_tool_request_middleware"
+            ) as request_middleware,
+            patch(
+                "hermes_cli.plugins._dispatch_pre_tool_call_hooks"
+            ) as pre_tool_hook,
+            patch(
+                "hermes_cli.middleware.run_tool_execution_middleware"
+            ) as execution_middleware,
+        ):
+            result = agent._invoke_tool(
+                "delegate_task",
+                {"goal": "must not run"},
+                "task-1",
+                tool_surface=surface,
+            )
+
+        assert "registration changed during the request" in result
+        dispatch_delegate.assert_not_called()
+        request_middleware.assert_not_called()
+        pre_tool_hook.assert_not_called()
+        execution_middleware.assert_not_called()
+
+    def test_unowned_provider_name_cannot_fall_through_to_live_registry(
+        self, agent
+    ):
+        from agent.tool_surface import publish_agent_tool_surface
+        from tools.registry import registry
+
+        name = "provider_registry_fallback_probe"
+        live_handler = MagicMock(return_value="live-registry")
+        schema = {
+            "name": name,
+            "description": "test",
+            "parameters": {"type": "object", "properties": {}},
+        }
+        tool_def = {"type": "function", "function": schema}
+        registry.register(
+            name=name,
+            handler=live_handler,
+            schema=schema,
+            toolset="provider-fallback-test",
+        )
+        try:
+            surface = publish_agent_tool_surface(
+                agent,
+                [tool_def],
+                catalog_tool_defs=[tool_def],
+                memory_provider_tool_names=set(),
+                context_engine_tool_names=set(),
+                registry_entries=[],
+                registry_generation=registry._generation,
+                selection_revision=0,
+                enabled_toolsets=["provider-fallback-test"],
+                disabled_toolsets=None,
+            )
+            result = agent._invoke_tool(
+                name,
+                {},
+                "task-1",
+                tool_surface=surface,
+            )
+            assert "registration is unavailable for this request" in result
+            live_handler.assert_not_called()
+
+            agent._tool_surface_memory_manager_ceiling = None
+            classified_surface = publish_agent_tool_surface(
+                agent,
+                [tool_def],
+                catalog_tool_defs=[tool_def],
+                memory_provider_tool_names={name},
+                context_engine_tool_names=set(),
+                deferred_tool_names=set(),
+                registry_entries=[],
+                registry_generation=registry._generation,
+                selection_revision=43,
+                enabled_toolsets=None,
+                disabled_toolsets=None,
+            )
+            classified_result = agent._invoke_tool(
+                name,
+                {},
+                "task-1",
+                "call-1",
+                tool_surface=classified_surface,
+            )
+            assert (
+                "provider is unavailable for this request snapshot"
+                in classified_result
+            )
+            live_handler.assert_not_called()
+        finally:
+            registry.deregister(name)
+
+    def test_sequential_rejects_replaced_direct_delegate_before_middleware(
+        self, agent
+    ):
+        from agent.tool_surface import publish_agent_tool_surface
+        from tools.registry import registry
+
+        delegate_def = {
+            "type": "function",
+            "function": {
+                "name": "delegate_task",
+                "description": "test",
+                "parameters": {"type": "object", "properties": {}},
+            },
+        }
+        expected_entry = object()
+        surface = publish_agent_tool_surface(
+            agent,
+            [delegate_def],
+            catalog_tool_defs=[delegate_def],
+            context_engine_tool_names=set(),
+            registry_entries=[("delegate_task", expected_entry)],
+            registry_generation=1,
+            selection_revision=0,
+            enabled_toolsets=["delegation"],
+            disabled_toolsets=None,
+        )
+        message = _mock_assistant_msg(
+            content="",
+            tool_calls=[
+                _mock_tool_call(
+                    name="delegate_task",
+                    arguments='{"goal":"must not run"}',
+                    call_id="c1",
+                )
+            ],
+        )
+        messages = []
+
+        replacement_entry = SimpleNamespace(max_result_size_chars=None)
+        with (
+            patch.object(registry, "get_entry", return_value=replacement_entry),
+            patch.object(agent, "_dispatch_delegate_task") as dispatch_delegate,
+            patch(
+                "hermes_cli.middleware.apply_tool_request_middleware"
+            ) as request_middleware,
+            patch(
+                "hermes_cli.plugins._dispatch_pre_tool_call_hooks"
+            ) as pre_tool_hook,
+            patch(
+                "hermes_cli.middleware.run_tool_execution_middleware"
+            ) as execution_middleware,
+        ):
+            agent._execute_tool_calls_sequential(
+                message,
+                messages,
+                "task-1",
+                tool_surface=surface,
+            )
+
+        assert "registration changed during the request" in messages[-1]["content"]
+        dispatch_delegate.assert_not_called()
+        request_middleware.assert_not_called()
+        pre_tool_hook.assert_not_called()
+        execution_middleware.assert_not_called()
+
+    def test_execute_tool_calls_forwards_request_snapshot(self, agent):
+        surface = object()
+        message = _mock_assistant_msg(
+            content="",
+            tool_calls=[_mock_tool_call(name="web_search")],
+        )
+        with patch.object(agent, "_execute_tool_calls_sequential") as execute:
+            agent._execute_tool_calls(
+                message, [], "task-1", tool_surface=surface
+            )
+
+        execute.assert_called_once_with(
+            message,
+            [],
+            "task-1",
+            0,
+            tool_surface=surface,
+        )
 
     def test_sequential_tool_callbacks_fire_in_order(self, agent):
         tool_call = _mock_tool_call(name="web_search", arguments='{"query":"hello"}', call_id="c1")
@@ -2373,7 +2862,7 @@ class TestAgentRuntimePostHookOwnershipSync:
         monkeypatch.setattr(
             agent,
             "_dispatch_delegate_task",
-            lambda args: '{"ok":true}',
+            lambda args, **kwargs: '{"ok":true}',
         )
         agent._memory_manager = None
 
@@ -4003,7 +4492,7 @@ class TestRunConversation:
         agent.max_tokens = None
         requested_caps = []
 
-        def _fake_build_api_kwargs(api_messages):
+        def _fake_build_api_kwargs(api_messages, tools_for_api=None):
             ephemeral = getattr(agent, "_ephemeral_max_output_tokens", None)
             if ephemeral is not None:
                 agent._ephemeral_max_output_tokens = None

--- a/tests/run_agent/test_tool_arg_coercion.py
+++ b/tests/run_agent/test_tool_arg_coercion.py
@@ -10,12 +10,14 @@ from unittest.mock import patch
 
 from model_tools import (
     coerce_tool_args,
+    handle_function_call,
     _coerce_value,
     _coerce_number,
     _coerce_boolean,
     _schema_accepts_kind,
     _normalize_json_strings_for_schema,
 )
+from tools.registry import registry
 
 
 # ── Low-level coercion helpers ────────────────────────────────────────────
@@ -157,6 +159,61 @@ class TestCoerceToolArgs:
         assert isinstance(result["offset"], int)
         assert result["limit"] == 100
         assert isinstance(result["limit"], int)
+
+    def test_same_name_replacement_is_rejected_before_coercion(self):
+        name = "coercion_snapshot_race_tool"
+        integer_schema = self._mock_schema({"limit": {"type": "integer"}})
+        integer_schema["name"] = name
+        string_schema = self._mock_schema({"limit": {"type": "string"}})
+        string_schema["name"] = name
+
+        registry.register(
+            name=name,
+            toolset="mcp-coercion-race",
+            schema=integer_schema,
+            handler=lambda args, **kwargs: "{}",
+        )
+        pinned_entry = registry.get_entry(name)
+        assert pinned_entry is not None
+        registry.register(
+            name=name,
+            toolset="mcp-coercion-race",
+            schema=string_schema,
+            handler=lambda args, **kwargs: "{}",
+        )
+
+        captured = {}
+
+        def _dispatch(_name, args, **kwargs):
+            captured.update(args)
+            assert kwargs["expected_entry"] is pinned_entry
+            return "{}"
+
+        try:
+            with (
+                patch.object(registry, "dispatch", side_effect=_dispatch),
+                patch(
+                    "hermes_cli.middleware.apply_tool_request_middleware"
+                ) as request_middleware,
+                patch(
+                    "hermes_cli.plugins._dispatch_pre_tool_call_hooks"
+                ) as pre_tool_hook,
+                patch(
+                    "hermes_cli.middleware.run_tool_execution_middleware"
+                ) as execution_middleware,
+            ):
+                handle_function_call(
+                    name,
+                    {"limit": "10"},
+                    expected_registry_entries={name: pinned_entry},
+                )
+        finally:
+            registry.deregister(name)
+
+        assert captured == {}
+        request_middleware.assert_not_called()
+        pre_tool_hook.assert_not_called()
+        execution_middleware.assert_not_called()
 
 
 # ── Schema-guided nested JSON-string normalization (cline/cline#11803) ─────

--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -210,6 +210,373 @@ class TestStripBlockedTools(unittest.TestCase):
         self.assertTrue(names & {"terminal", "read_file", "web_search"})
         self.assertTrue(DELEGATE_BLOCKED_TOOLS.isdisjoint(names))
 
+    def test_child_inherits_request_pinned_surface_not_live_parent(self):
+        from agent.tool_surface import (
+            AgentToolSurfaceSnapshot,
+            publish_agent_tool_surface,
+        )
+
+        parent = _make_mock_parent()
+        parent.enabled_toolsets = ["browser"]
+        parent.disabled_toolsets = ["terminal"]
+        pinned_tool = {
+            "type": "function",
+            "function": {
+                "name": "read_file",
+                "parameters": {"properties": {"snapshot": {"const": "A"}}},
+            },
+        }
+        live_replacement_tool = {
+            "type": "function",
+            "function": {
+                "name": "read_file",
+                "parameters": {"properties": {"snapshot": {"const": "B"}}},
+            },
+        }
+        live_tool = {
+            "type": "function",
+            "function": {"name": "live_file_extra", "parameters": {}},
+        }
+        pinned_entry = object()
+        live_entry = object()
+        surface = types.SimpleNamespace(
+            tool_defs=(pinned_tool,),
+            catalog_tool_defs=(pinned_tool,),
+            valid_tool_names=frozenset({"read_file"}),
+            memory_provider_tool_names=frozenset(),
+            context_engine_tool_names=frozenset(),
+            deferred_tool_names=frozenset(),
+            registry_entries=(("read_file", pinned_entry),),
+            registry_generation=3,
+            selection_revision=7,
+            enabled_toolsets=("file",),
+            disabled_toolsets=("web",),
+        )
+        child = types.SimpleNamespace(
+            tools=[live_replacement_tool, live_tool],
+            valid_tool_names={"read_file", "live_file_extra"},
+            _memory_provider_tool_names=set(),
+            _context_engine_tool_names=set(),
+            _tool_snapshot_generation=4,
+            _tool_selection_revision=8,
+            enabled_toolsets=["file"],
+            disabled_toolsets=["web"],
+            _memory_manager=None,
+            context_compressor=None,
+        )
+        child._tool_surface_snapshot = AgentToolSurfaceSnapshot(
+            tool_defs=(live_replacement_tool, live_tool),
+            catalog_tool_defs=(live_replacement_tool, live_tool),
+            valid_tool_names=frozenset({"read_file", "live_file_extra"}),
+            memory_provider_tool_names=frozenset(),
+            context_engine_tool_names=frozenset(),
+            deferred_tool_names=frozenset(),
+            registry_entries=(
+                ("read_file", live_entry),
+                ("live_file_extra", object()),
+            ),
+            memory_manager=None,
+            context_engine=None,
+            registry_generation=4,
+            selection_revision=8,
+            enabled_toolsets=("file",),
+            disabled_toolsets=("web",),
+        )
+        child._tool_surface_legacy_tools_id = id(child.tools)
+
+        with patch("run_agent.AIAgent", return_value=child) as MockAgent:
+            result = _build_child_agent(
+                task_index=0,
+                goal="Inspect pinned tools",
+                context=None,
+                toolsets=None,
+                model=None,
+                max_iterations=10,
+                parent_agent=parent,
+                parent_tool_surface=surface,
+                task_count=1,
+                role="leaf",
+            )
+
+        _, kwargs = MockAgent.call_args
+        self.assertEqual(kwargs["enabled_toolsets"], ["file"])
+        self.assertIn("web", kwargs["disabled_toolsets"])
+        self.assertNotIn("terminal", kwargs["disabled_toolsets"])
+        self.assertIs(result, child)
+        self.assertEqual(child.valid_tool_names, {"read_file"})
+        self.assertEqual(child.tools, [pinned_tool])
+        self.assertIs(
+            dict(child._tool_surface_snapshot.registry_entries)["read_file"],
+            pinned_entry,
+        )
+
+        child._memory_manager = object()
+        child.context_compressor = object()
+        publish_agent_tool_surface(
+            child,
+            [live_replacement_tool, live_tool],
+            catalog_tool_defs=[live_replacement_tool, live_tool],
+            memory_provider_tool_names=("read_file",),
+            context_engine_tool_names=("read_file",),
+            registry_entries=(("read_file", live_entry),),
+            registry_generation=5,
+            selection_revision=9,
+            enabled_toolsets=("file",),
+            disabled_toolsets=("web",),
+        )
+        self.assertEqual(child.valid_tool_names, {"read_file"})
+        self.assertEqual(child.tools, [pinned_tool])
+        self.assertIs(
+            dict(child._tool_surface_snapshot.registry_entries)["read_file"],
+            pinned_entry,
+        )
+        self.assertEqual(
+            child._tool_surface_snapshot.memory_provider_tool_names,
+            frozenset(),
+        )
+        self.assertEqual(
+            child._tool_surface_snapshot.context_engine_tool_names,
+            frozenset(),
+        )
+        self.assertIsNone(child._tool_surface_snapshot.memory_manager)
+        self.assertIsNone(child._tool_surface_snapshot.context_engine)
+
+    def test_child_drops_external_provider_when_handler_identity_differs(self):
+        from agent.tool_surface import (
+            AgentToolSurfaceSnapshot,
+            publish_agent_tool_surface,
+        )
+        from tools.delegate_tool import _restrict_child_to_parent_surface
+
+        provider_tool = {
+            "type": "function",
+            "function": {"name": "memory_lookup", "parameters": {}},
+        }
+        manager_a = object()
+        manager_b = object()
+        parent_surface = AgentToolSurfaceSnapshot(
+            tool_defs=(provider_tool,),
+            catalog_tool_defs=(provider_tool,),
+            valid_tool_names=frozenset({"memory_lookup"}),
+            memory_provider_tool_names=frozenset({"memory_lookup"}),
+            context_engine_tool_names=frozenset(),
+            deferred_tool_names=frozenset(),
+            registry_entries=(),
+            memory_manager=manager_a,
+            context_engine=None,
+            registry_generation=3,
+            selection_revision=7,
+            enabled_toolsets=("memory",),
+            disabled_toolsets=(),
+        )
+
+        def make_child(manager):
+            child = types.SimpleNamespace(
+                tools=[provider_tool],
+                valid_tool_names={"memory_lookup"},
+                _memory_provider_tool_names={"memory_lookup"},
+                _context_engine_tool_names=set(),
+                _memory_manager=manager,
+                context_compressor=None,
+                _tool_snapshot_generation=4,
+                _tool_selection_revision=8,
+                enabled_toolsets=["memory"],
+                disabled_toolsets=[],
+            )
+            child._tool_surface_snapshot = AgentToolSurfaceSnapshot(
+                tool_defs=(provider_tool,),
+                catalog_tool_defs=(provider_tool,),
+                valid_tool_names=frozenset({"memory_lookup"}),
+                memory_provider_tool_names=frozenset({"memory_lookup"}),
+                context_engine_tool_names=frozenset(),
+                deferred_tool_names=frozenset(),
+                registry_entries=(),
+                memory_manager=manager,
+                context_engine=None,
+                registry_generation=4,
+                selection_revision=8,
+                enabled_toolsets=("memory",),
+                disabled_toolsets=(),
+            )
+            child._tool_surface_legacy_tools_id = id(child.tools)
+            return child
+
+        mismatch_child = make_child(manager_b)
+        _restrict_child_to_parent_surface(
+            mismatch_child,
+            parent_surface,
+            allow_delegation=False,
+        )
+        self.assertEqual(mismatch_child.tools, [])
+        self.assertEqual(mismatch_child.valid_tool_names, set())
+        self.assertEqual(
+            mismatch_child._tool_surface_snapshot.memory_provider_tool_names,
+            frozenset(),
+        )
+
+        pinned_child = make_child(manager_a)
+        _restrict_child_to_parent_surface(
+            pinned_child,
+            parent_surface,
+            allow_delegation=False,
+        )
+        self.assertIs(pinned_child._tool_surface_snapshot.memory_manager, manager_a)
+        pinned_child._memory_manager = manager_b
+        publish_agent_tool_surface(
+            pinned_child,
+            [provider_tool],
+            catalog_tool_defs=[provider_tool],
+            memory_provider_tool_names=("memory_lookup",),
+            context_engine_tool_names=(),
+            registry_entries=(),
+            registry_generation=5,
+            selection_revision=9,
+            enabled_toolsets=("memory",),
+            disabled_toolsets=(),
+        )
+        self.assertEqual(pinned_child.valid_tool_names, {"memory_lookup"})
+        self.assertIs(pinned_child._tool_surface_snapshot.memory_manager, manager_a)
+
+    def test_child_context_engine_uses_stable_implementation_provenance(self):
+        from agent.tool_surface import (
+            AgentToolSurfaceSnapshot,
+            publish_agent_tool_surface,
+        )
+        from tools.delegate_tool import _restrict_child_to_parent_surface
+
+        context_tool = {
+            "type": "function",
+            "function": {"name": "context_lookup", "parameters": {}},
+        }
+
+        class Engine:
+            name = "test-context"
+
+            def __init__(self, label):
+                self.label = label
+
+            def get_tool_schemas(self):
+                return [context_tool["function"]]
+
+            def handle_tool_call(self, _name, _args, **_kwargs):
+                return self.label
+
+        class OtherEngine(Engine):
+            pass
+
+        def surface(engine, generation):
+            return AgentToolSurfaceSnapshot(
+                tool_defs=(context_tool,),
+                catalog_tool_defs=(context_tool,),
+                valid_tool_names=frozenset({"context_lookup"}),
+                memory_provider_tool_names=frozenset(),
+                context_engine_tool_names=frozenset({"context_lookup"}),
+                deferred_tool_names=frozenset(),
+                registry_entries=(),
+                memory_manager=None,
+                context_engine=engine,
+                registry_generation=generation,
+                selection_revision=7,
+                enabled_toolsets=("context_engine",),
+                disabled_toolsets=(),
+            )
+
+        parent_engine = Engine("parent")
+        child_engine = Engine("child")
+        parent_surface = surface(parent_engine, 3)
+        child = types.SimpleNamespace(
+            tools=[context_tool],
+            valid_tool_names={"context_lookup"},
+            _memory_provider_tool_names=set(),
+            _context_engine_tool_names={"context_lookup"},
+            _memory_manager=None,
+            context_compressor=child_engine,
+            _tool_snapshot_generation=4,
+            _tool_selection_revision=8,
+            enabled_toolsets=["context_engine"],
+            disabled_toolsets=[],
+        )
+        child._tool_surface_snapshot = surface(child_engine, 4)
+        child._tool_surface_legacy_tools_id = id(child.tools)
+
+        _restrict_child_to_parent_surface(
+            child,
+            parent_surface,
+            allow_delegation=False,
+        )
+
+        self.assertEqual(child.valid_tool_names, {"context_lookup"})
+        self.assertIs(child._tool_surface_snapshot.context_engine, child_engine)
+        self.assertEqual(
+            child._tool_surface_snapshot.context_engine.handle_tool_call(
+                "context_lookup", {}
+            ),
+            "child",
+        )
+
+        replacement = Engine("replacement")
+        child.context_compressor = replacement
+        publish_agent_tool_surface(
+            child,
+            [context_tool],
+            catalog_tool_defs=[context_tool],
+            memory_provider_tool_names=(),
+            context_engine_tool_names=("context_lookup",),
+            registry_entries=(),
+            registry_generation=5,
+            selection_revision=9,
+            enabled_toolsets=("context_engine",),
+            disabled_toolsets=(),
+        )
+        self.assertIs(child._tool_surface_snapshot.context_engine, child_engine)
+
+        mismatch_engine = OtherEngine("other")
+        mismatch_child = types.SimpleNamespace(
+            tools=[context_tool],
+            valid_tool_names={"context_lookup"},
+            _memory_provider_tool_names=set(),
+            _context_engine_tool_names={"context_lookup"},
+            _memory_manager=None,
+            context_compressor=mismatch_engine,
+            _tool_snapshot_generation=4,
+            _tool_selection_revision=8,
+            enabled_toolsets=["context_engine"],
+            disabled_toolsets=[],
+        )
+        mismatch_child._tool_surface_snapshot = surface(mismatch_engine, 4)
+        mismatch_child._tool_surface_legacy_tools_id = id(mismatch_child.tools)
+        _restrict_child_to_parent_surface(
+            mismatch_child,
+            parent_surface,
+            allow_delegation=False,
+        )
+        self.assertEqual(mismatch_child.valid_tool_names, set())
+        self.assertIsNone(mismatch_child._tool_surface_snapshot.context_engine)
+
+        spoofed_engine = Engine("spoofed")
+        spoofed_engine.handle_tool_call = lambda *_args, **_kwargs: "spoofed"
+        spoofed_child = types.SimpleNamespace(
+            tools=[context_tool],
+            valid_tool_names={"context_lookup"},
+            _memory_provider_tool_names=set(),
+            _context_engine_tool_names={"context_lookup"},
+            _memory_manager=None,
+            context_compressor=spoofed_engine,
+            _tool_snapshot_generation=4,
+            _tool_selection_revision=8,
+            enabled_toolsets=["context_engine"],
+            disabled_toolsets=[],
+        )
+        spoofed_child._tool_surface_snapshot = surface(spoofed_engine, 4)
+        spoofed_child._tool_surface_legacy_tools_id = id(spoofed_child.tools)
+        _restrict_child_to_parent_surface(
+            spoofed_child,
+            parent_surface,
+            allow_delegation=False,
+        )
+        self.assertEqual(spoofed_child.valid_tool_names, set())
+        self.assertIsNone(spoofed_child._tool_surface_snapshot.context_engine)
+
     def test_orchestrator_composite_regains_only_delegate_task(self):
         import model_tools
 
@@ -1383,6 +1750,26 @@ class TestDispatchDelegateTask(unittest.TestCase):
         self.assertEqual(captured["goal"], "test")
         self.assertNotIn("acp_command", captured["tasks"][0])
         self.assertNotIn("acp_args", captured["tasks"][0])
+
+    def test_request_pinned_surface_is_forwarded(self):
+        import run_agent
+
+        captured = {}
+
+        def fake_delegate_task(**kwargs):
+            captured.update(kwargs)
+            return "{}"
+
+        parent = _make_mock_parent(depth=0)
+        surface = object()
+        with patch("tools.delegate_tool.delegate_task", fake_delegate_task):
+            run_agent.AIAgent._dispatch_delegate_task(
+                parent,
+                {"goal": "test"},
+                tool_surface=surface,
+            )
+
+        self.assertIs(captured["parent_tool_surface"], surface)
 
 class TestDelegateEventEnum(unittest.TestCase):
     """Tests for DelegateEvent enum and back-compat aliases."""

--- a/tests/tools/test_refresh_agent_mcp_tools.py
+++ b/tests/tools/test_refresh_agent_mcp_tools.py
@@ -44,6 +44,31 @@ def test_refresh_adds_late_landing_tools(monkeypatch):
     assert len(agent.tools) == 3
 
 
+def test_refresh_respects_inherited_exact_name_ceiling(monkeypatch):
+    agent = _agent(["review_pin_anchor"], enabled=["file"])
+    agent._tool_surface_valid_name_ceiling = frozenset({"review_pin_anchor"})
+    agent._tool_surface_catalog_name_ceiling = frozenset({"review_pin_anchor"})
+
+    import model_tools
+
+    monkeypatch.setattr(
+        model_tools,
+        "get_tool_definitions",
+        lambda **kw: [
+            _tool("review_pin_anchor"),
+            _tool("review_live_b_extra"),
+        ],
+    )
+
+    added = mcp_tool.refresh_agent_mcp_tools(agent)
+
+    assert added == set()
+    assert agent.valid_tool_names == {"review_pin_anchor"}
+    assert [tool["function"]["name"] for tool in agent.tools] == [
+        "review_pin_anchor"
+    ]
+
+
 def test_refresh_preserves_memory_provider_and_context_engine_tools(monkeypatch):
     """B1 regression: a rebuild must NOT drop post-build-injected tools.
 
@@ -185,10 +210,11 @@ def test_refresh_is_thread_safe_under_concurrent_calls(monkeypatch):
         try:
             for _ in range(50):
                 mcp_tool.refresh_agent_mcp_tools(agent)
-                # Coherence invariant: the name set must match the tool list
-                # at every observation, never a torn cross-attribute state.
-                names = {t["function"]["name"] for t in agent.tools}
-                assert agent.valid_tool_names == names
+                from agent.tool_surface import get_agent_tool_surface
+
+                snapshot = get_agent_tool_surface(agent)
+                names = {t["function"]["name"] for t in snapshot.tool_defs}
+                assert snapshot.valid_tool_names == names
                 assert names in ({"a", "b"}, {"a", "c"})
         except Exception as exc:  # pragma: no cover - failure path
             errors.append(exc)
@@ -201,6 +227,167 @@ def test_refresh_is_thread_safe_under_concurrent_calls(monkeypatch):
 
     assert not errors
     assert agent.valid_tool_names in ({"a", "b"}, {"a", "c"})
+
+
+def test_explicit_selection_wins_over_inflight_automatic_refresh(monkeypatch):
+    """A stale automatic rebuild cannot overwrite a newer explicit selection."""
+    agent = _agent(["read_file", "terminal"], enabled=["all"])
+    automatic_started = threading.Event()
+    release_automatic = threading.Event()
+
+    def _gtd(*, enabled_toolsets=None, **kwargs):
+        if enabled_toolsets == ["all"]:
+            automatic_started.set()
+            assert release_automatic.wait(timeout=5)
+            return [_tool("read_file"), _tool("terminal")]
+        assert enabled_toolsets == ["file"]
+        return [_tool("read_file")]
+
+    import model_tools
+
+    monkeypatch.setattr(model_tools, "get_tool_definitions", _gtd)
+
+    automatic = threading.Thread(
+        target=mcp_tool.refresh_agent_mcp_tools,
+        args=(agent,),
+    )
+    automatic.start()
+    assert automatic_started.wait(timeout=5)
+
+    mcp_tool.refresh_agent_mcp_tools(agent, enabled_override=["file"])
+    release_automatic.set()
+    automatic.join(timeout=5)
+
+    assert not automatic.is_alive()
+    assert agent.enabled_toolsets == ["file"]
+    assert agent.valid_tool_names == {"read_file"}
+    assert [tool["function"]["name"] for tool in agent.tools] == ["read_file"]
+
+
+def test_refresh_retries_when_registry_generation_changes_during_assembly(monkeypatch):
+    """A generation change discards the staged surface instead of publishing it."""
+    from tools.registry import registry
+
+    agent = _agent(["read_file"])
+    calls = 0
+    original_generation = registry._generation
+    monkeypatch.setattr(registry, "_generation", original_generation)
+
+    def _gtd(**_kwargs):
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            registry._generation += 1
+            return [_tool("stale_tool")]
+        return [_tool("fresh_tool")]
+
+    import model_tools
+
+    monkeypatch.setattr(model_tools, "get_tool_definitions", _gtd)
+
+    added = mcp_tool.refresh_agent_mcp_tools(agent)
+
+    assert calls == 2
+    assert added == {"fresh_tool"}
+    assert agent.valid_tool_names == {"fresh_tool"}
+    assert agent._tool_surface_snapshot.registry_generation == original_generation + 1
+
+
+def test_refresh_does_not_publish_under_continuous_registry_churn(monkeypatch):
+    """Bounded retries leave the prior coherent surface intact under churn."""
+    from tools.registry import registry
+
+    agent = _agent(["read_file"])
+    calls = 0
+    original_generation = registry._generation
+    monkeypatch.setattr(registry, "_generation", original_generation)
+
+    def _gtd(**_kwargs):
+        nonlocal calls
+        calls += 1
+        registry._generation += 1
+        return [_tool(f"unstable_{calls}")]
+
+    import model_tools
+
+    monkeypatch.setattr(model_tools, "get_tool_definitions", _gtd)
+
+    assert mcp_tool.refresh_agent_mcp_tools(agent) == set()
+    assert calls == 3
+    assert agent.valid_tool_names == {"read_file"}
+    assert [tool["function"]["name"] for tool in agent.tools] == ["read_file"]
+
+
+def test_refresh_retries_when_generation_changes_at_entry_capture(monkeypatch):
+    """The final schema/handler capture is a registry-generation CAS."""
+    from tools.registry import registry
+
+    agent = _agent(["read_file"])
+    build_calls = 0
+    cas_calls = 0
+    original_generation = registry._generation
+    original_run = registry.run_with_entries_snapshot_by_name
+    monkeypatch.setattr(registry, "_generation", original_generation)
+
+    def _gtd(**_kwargs):
+        nonlocal build_calls
+        build_calls += 1
+        return [_tool(f"surface_{build_calls}")]
+
+    def _run(names, callback, *, expected_generation, scope=None):
+        nonlocal cas_calls
+        cas_calls += 1
+        if cas_calls == 1:
+            registry._generation += 1
+        return original_run(
+            names,
+            callback,
+            expected_generation=expected_generation,
+            scope=scope,
+        )
+
+    import model_tools
+
+    monkeypatch.setattr(model_tools, "get_tool_definitions", _gtd)
+    monkeypatch.setattr(registry, "run_with_entries_snapshot_by_name", _run)
+
+    added = mcp_tool.refresh_agent_mcp_tools(agent)
+
+    assert build_calls == 2
+    assert cas_calls == 2
+    assert added == {"surface_2"}
+    assert agent.valid_tool_names == {"surface_2"}
+    assert agent._tool_surface_snapshot.registry_generation == original_generation + 1
+
+
+def test_equal_name_refresh_publishes_schema_and_routing_together(monkeypatch):
+    """Equal names can still carry a changed schema or routing owner."""
+    agent = _agent(["lcm_grep"])
+    agent.tools[0]["function"]["description"] = "old"
+    agent.context_compressor = types.SimpleNamespace(
+        get_tool_schemas=lambda: [
+            {
+                "name": "lcm_grep",
+                "description": "new",
+                "parameters": {},
+            }
+        ]
+    )
+    agent._context_engine_tool_names = set()
+
+    import model_tools
+
+    monkeypatch.setattr(model_tools, "get_tool_definitions", lambda **kwargs: [])
+
+    added = mcp_tool.refresh_agent_mcp_tools(agent)
+
+    from agent.tool_surface import get_agent_tool_surface
+
+    snapshot = get_agent_tool_surface(agent)
+    assert added == set()
+    assert snapshot.context_engine_tool_names == frozenset({"lcm_grep"})
+    assert snapshot.tool_defs[0]["function"]["description"] == "new"
+    assert agent.tools[0]["function"]["description"] == "new"
 
 
 # ── discovery-wait bound (mcp_discovery_timeout config) ──────────────────────

--- a/tests/tools/test_registry.py
+++ b/tests/tools/test_registry.py
@@ -92,6 +92,48 @@ class TestRegisterAndDispatch:
             for record in caplog.records
         )
 
+    def test_entry_snapshot_lease_blocks_mutation_until_publication(self):
+        reg = ToolRegistry()
+        reg.register(
+            name="leased",
+            toolset="core",
+            schema=_make_schema("leased"),
+            handler=_dummy_handler,
+        )
+        original_entry = reg.get_entry("leased")
+        generation = reg._generation
+        mutation_started = threading.Event()
+        mutation_finished = threading.Event()
+        mutation_thread = None
+
+        def _publish(captured_generation, entries):
+            nonlocal mutation_thread
+
+            def _mutate():
+                mutation_started.set()
+                reg.deregister("leased")
+                mutation_finished.set()
+
+            mutation_thread = threading.Thread(target=_mutate)
+            mutation_thread.start()
+            assert mutation_started.wait(timeout=1)
+            assert not mutation_finished.wait(timeout=0.05)
+            assert captured_generation == generation
+            assert entries == (("leased", original_entry),)
+            return entries
+
+        captured = reg.run_with_entries_snapshot_by_name(
+            ["leased"],
+            _publish,
+            expected_generation=generation,
+        )
+
+        assert mutation_thread is not None
+        mutation_thread.join(timeout=1)
+        assert not mutation_thread.is_alive()
+        assert mutation_finished.is_set()
+        assert captured == (("leased", original_entry),)
+
 class TestGetDefinitions:
     def test_returns_openai_format(self):
         reg = ToolRegistry()

--- a/tests/tools/test_startup_latency_regressions.py
+++ b/tests/tools/test_startup_latency_regressions.py
@@ -82,6 +82,29 @@ class TestAuxProbeMode:
         assert client is stub
         assert model == "m"
 
+    def test_read_only_tool_probe_does_not_refresh_nous_credentials(self):
+        import agent.auxiliary_client as aux
+        from tools.registry import read_only_tool_inspection
+
+        provider = {
+            "refresh_token": "secret-refresh-token",
+            "inference_base_url": "https://inference.example/v1",
+        }
+        with (
+            patch.object(aux, "_read_nous_auth", return_value=provider),
+            patch.object(aux, "_resolve_nous_pool_runtime_api") as pool_resolver,
+            patch(
+                "hermes_cli.auth.resolve_nous_runtime_credentials"
+            ) as runtime_resolver,
+            aux.aux_probe_mode(),
+            read_only_tool_inspection(),
+        ):
+            api = aux._resolve_nous_runtime_api()
+
+        assert api == ("<read-only-probe>", "https://inference.example/v1")
+        pool_resolver.assert_not_called()
+        runtime_resolver.assert_not_called()
+
 
 class TestVisionCheckUsesProbeMode:
     def test_check_vision_requirements_enters_probe_mode(self):

--- a/tests/tools/test_terminal_tool_requirements.py
+++ b/tests/tools/test_terminal_tool_requirements.py
@@ -134,6 +134,42 @@ class TestCheckFnTransientFailureSuppression:
         t["now"] += reg._CHECK_FN_FAILURE_GRACE_SECONDS + 1
         assert reg._check_fn_cached(probe) is False
 
+    def test_readonly_probe_does_not_populate_caches(self):
+        import tools.registry as reg
+
+        calls = {"n": 0}
+
+        def probe():
+            calls["n"] += 1
+            return True
+
+        assert reg._check_fn_readonly(probe) is True
+        assert calls["n"] == 1
+        assert reg._check_fn_cache == {}
+        assert reg._check_fn_last_good == {}
+
+    def test_readonly_probe_preserves_expired_cache_and_last_good(
+        self, monkeypatch
+    ):
+        import tools.registry as reg
+
+        state = {"ok": True}
+
+        def probe():
+            return state["ok"]
+
+        clock = {"now": 1000.0}
+        monkeypatch.setattr(reg.time, "monotonic", lambda: clock["now"])
+        assert reg._check_fn_cached(probe) is True
+        cached_before = dict(reg._check_fn_cache)
+        last_good_before = dict(reg._check_fn_last_good)
+
+        state["ok"] = False
+        clock["now"] += reg._CHECK_FN_TTL_SECONDS + 1
+        assert reg._check_fn_readonly(probe) is True
+        assert reg._check_fn_cache == cached_before
+        assert reg._check_fn_last_good == last_good_before
+
     def test_profile_scoped_availability_does_not_cross_multiplex_profiles(
         self, tmp_path
     ):

--- a/tests/tools/test_tool_search.py
+++ b/tests/tools/test_tool_search.py
@@ -318,6 +318,82 @@ class TestBridgeDispatch:
         assert "remain available" in result["hint"]
         assert "before concluding" in result["hint"]
 
+    def test_search_and_describe_use_request_pinned_catalog_metadata(
+        self, monkeypatch
+    ):
+        import model_tools
+        from tools.registry import registry
+
+        name = "mcp_pinned_catalog_race_probe"
+        toolset = "mcp-pinned-race"
+        tool_def = _td(name, "Pinned catalog race probe")
+        registry.register(
+            name=name,
+            handler=lambda args, **kwargs: "{}",
+            schema=tool_def["function"],
+            toolset=toolset,
+        )
+        pinned_entry = registry.get_entry(name)
+        assert pinned_entry is not None
+        registry.deregister(name)
+
+        common = {
+            "catalog_tool_defs": [tool_def],
+            "expected_registry_entries": {name: pinned_entry},
+            "skip_pre_tool_call_hook": True,
+            "skip_tool_request_middleware": True,
+            "skip_tool_execution_middleware": True,
+        }
+        search = json.loads(
+            model_tools.handle_function_call(
+                "tool_search",
+                {"query": "pinned catalog race"},
+                **common,
+            )
+        )
+        describe = json.loads(
+            model_tools.handle_function_call(
+                "tool_describe",
+                {"name": name},
+                **common,
+            )
+        )
+        dispatched = {}
+
+        def _dispatch(call_name, call_args, **kwargs):
+            dispatched.update(
+                name=call_name,
+                arguments=call_args,
+                expected_entry=kwargs.get("expected_entry"),
+            )
+            return json.dumps({"dispatched": True})
+
+        monkeypatch.setattr(registry, "dispatch", _dispatch)
+        call_result = json.loads(
+            model_tools.handle_function_call(
+                "tool_call",
+                {"name": name, "arguments": {}},
+                **common,
+            )
+        )
+
+        assert search["total_available"] == 1
+        assert search["matches"] == [
+            {
+                "name": name,
+                "source": "mcp",
+                "source_name": toolset,
+                "description": "Pinned catalog race probe",
+            }
+        ]
+        assert describe == {
+            "name": name,
+            "description": "Pinned catalog race probe",
+            "parameters": {"type": "object", "properties": {}},
+        }
+        assert "registration changed during the request" in call_result["error"]
+        assert dispatched == {}
+
 
     def test_resolve_underlying_call_parses_object_args(self):
         from tools.tool_search import resolve_underlying_call
@@ -327,6 +403,21 @@ class TestBridgeDispatch:
         })
         # Will fail classification because unknown_xxx isn't deferrable.
         assert err is not None
+
+    def test_resolve_underlying_call_uses_request_allowed_names(self):
+        from tools.tool_search import resolve_underlying_call
+
+        name, args, err = resolve_underlying_call(
+            {
+                "name": "removed_after_request_tool",
+                "arguments": {"foo": "bar"},
+            },
+            allowed_names={"removed_after_request_tool"},
+        )
+
+        assert err is None
+        assert name == "removed_after_request_tool"
+        assert args == {"foo": "bar"}
 
 
     def test_resolve_underlying_call_rejects_recursion(self):
@@ -656,6 +747,31 @@ class TestDeferredCallSchemaProbe:
         assert "NOT invoked" in parsed["error"]
         assert parsed["parameters"]["required"] == ["document_id"]
         assert "document_id" in parsed["parameters"]["properties"]
+
+    def test_validator_uses_request_catalog_after_registry_change(self):
+        from tools.tool_search import validate_deferred_call_args
+
+        catalog = [
+            {
+                "type": "function",
+                "function": {
+                    "name": "removed_after_request_tool",
+                    "description": "test",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {"request_id": {"type": "string"}},
+                        "required": ["request_id"],
+                    },
+                },
+            }
+        ]
+
+        err = validate_deferred_call_args(
+            "removed_after_request_tool", {}, catalog
+        )
+
+        assert err is not None
+        assert json.loads(err)["parameters"]["required"] == ["request_id"]
 
 
     def test_validator_never_blocks_unvalidatable_tools(self):

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -1575,6 +1575,151 @@ def _inherit_parent_base_url(parent_agent, fallback_base_url: Optional[str]) -> 
     return fallback_base_url or None
 
 
+def _surface_tool_name(tool: Dict[str, Any]) -> str:
+    function = tool.get("function") if isinstance(tool, dict) else None
+    if not isinstance(function, dict):
+        return ""
+    name = function.get("name")
+    return name if isinstance(name, str) else ""
+
+
+def _restrict_child_to_parent_surface(
+    child,
+    parent_surface,
+    *,
+    allow_delegation: bool,
+) -> None:
+    """Prevent child construction from widening a request-pinned surface."""
+    from agent.tool_surface import (
+        context_engine_provenance,
+        get_agent_tool_surface,
+        publish_agent_tool_surface,
+    )
+
+    child_surface = get_agent_tool_surface(child)
+    child_visible_defs = {
+        name: tool
+        for tool in child_surface.tool_defs
+        if (name := _surface_tool_name(tool))
+    }
+    child_catalog_defs = {
+        name: tool
+        for tool in child_surface.catalog_tool_defs
+        if (name := _surface_tool_name(tool))
+    }
+    parent_visible_defs = {
+        name: tool
+        for tool in parent_surface.tool_defs
+        if (name := _surface_tool_name(tool))
+    }
+    parent_catalog_defs = {
+        name: tool
+        for tool in parent_surface.catalog_tool_defs
+        if (name := _surface_tool_name(tool))
+    }
+    parent_memory_manager = getattr(parent_surface, "memory_manager", None)
+    parent_context_engine = getattr(parent_surface, "context_engine", None)
+    parent_context_provenance = getattr(
+        parent_surface,
+        "context_engine_provenance",
+        None,
+    ) or context_engine_provenance(parent_context_engine)
+    child_context_provenance = getattr(
+        child_surface,
+        "context_engine_provenance",
+        None,
+    ) or context_engine_provenance(child_surface.context_engine)
+    context_engine_matches = (
+        child_surface.context_engine is parent_context_engine
+        or (
+            parent_context_provenance is not None
+            and child_context_provenance == parent_context_provenance
+        )
+    )
+    authorized_child_context_engine = (
+        child_surface.context_engine if context_engine_matches else None
+    )
+    unavailable_external_names = set()
+    if child_surface.memory_manager is not parent_memory_manager:
+        unavailable_external_names.update(parent_surface.memory_provider_tool_names)
+    if not context_engine_matches:
+        unavailable_external_names.update(parent_surface.context_engine_tool_names)
+    visible_definition_ceiling = {
+        name: tool
+        for name, tool in parent_visible_defs.items()
+        if name in child_visible_defs and name not in unavailable_external_names
+    }
+    catalog_definition_ceiling = {
+        name: tool
+        for name, tool in parent_catalog_defs.items()
+        if name in child_catalog_defs and name not in unavailable_external_names
+    }
+    if allow_delegation and "delegate_task" in child_visible_defs:
+        visible_definition_ceiling["delegate_task"] = child_visible_defs[
+            "delegate_task"
+        ]
+        catalog_definition_ceiling["delegate_task"] = child_catalog_defs.get(
+            "delegate_task",
+            child_visible_defs["delegate_task"],
+        )
+    allowed_visible = set(visible_definition_ceiling)
+    allowed_catalog = set(catalog_definition_ceiling) | allowed_visible
+    child._tool_surface_valid_name_ceiling = frozenset(allowed_visible)
+    child._tool_surface_catalog_name_ceiling = frozenset(allowed_catalog)
+    child._tool_surface_visible_definition_ceiling = visible_definition_ceiling
+    child._tool_surface_catalog_definition_ceiling = catalog_definition_ceiling
+    child._tool_surface_memory_provider_name_ceiling = frozenset(
+        parent_surface.memory_provider_tool_names & allowed_visible
+    )
+    child._tool_surface_context_engine_name_ceiling = frozenset(
+        parent_surface.context_engine_tool_names & allowed_visible
+    )
+    child._tool_surface_memory_manager_ceiling = parent_memory_manager
+    child._tool_surface_context_engine_ceiling = authorized_child_context_engine
+    child._tool_surface_context_engine_provenance_ceiling = (
+        parent_context_provenance if context_engine_matches else None
+    )
+    parent_entries = dict(parent_surface.registry_entries)
+    child_entries = dict(child_surface.registry_entries)
+    registry_entry_ceiling = {
+        name: entry
+        for name, entry in parent_entries.items()
+        if name in allowed_visible or name in allowed_catalog
+    }
+    if allow_delegation and "delegate_task" in child_entries:
+        registry_entry_ceiling["delegate_task"] = child_entries["delegate_task"]
+    child._tool_surface_registry_entry_ceiling = registry_entry_ceiling
+    tool_defs = list(visible_definition_ceiling.values())
+    catalog_tool_defs = list(catalog_definition_ceiling.values())
+    visible_names = {
+        name for tool in tool_defs if (name := _surface_tool_name(tool))
+    }
+    catalog_names = {
+        name
+        for tool in catalog_tool_defs
+        if (name := _surface_tool_name(tool))
+    }
+    publish_agent_tool_surface(
+        child,
+        tool_defs,
+        catalog_tool_defs=catalog_tool_defs,
+        memory_provider_tool_names=(
+            parent_surface.memory_provider_tool_names & visible_names
+        ),
+        context_engine_tool_names=(
+            parent_surface.context_engine_tool_names & visible_names
+        ),
+        deferred_tool_names=(
+            parent_surface.deferred_tool_names & catalog_names
+        ),
+        registry_entries=registry_entry_ceiling.items(),
+        registry_generation=child_surface.registry_generation,
+        selection_revision=child_surface.selection_revision,
+        enabled_toolsets=child_surface.enabled_toolsets,
+        disabled_toolsets=child_surface.disabled_toolsets,
+    )
+
+
 def _build_child_agent(
     task_index: int,
     goal: str,
@@ -1584,6 +1729,7 @@ def _build_child_agent(
     max_iterations: int,
     task_count: int,
     parent_agent,
+    parent_tool_surface=None,
     # Credential overrides from delegation config (provider:model resolution)
     override_provider: Optional[str] = None,
     override_base_url: Optional[str] = None,
@@ -1637,9 +1783,21 @@ def _build_child_agent(
     # so disabled tools (e.g. web) don't leak to subagents.
     # Note: enabled_toolsets=None means "all tools enabled" (the default),
     # so we must derive effective toolsets from the parent's loaded tools.
-    parent_enabled = getattr(parent_agent, "enabled_toolsets", None)
+    parent_enabled = (
+        parent_tool_surface.enabled_toolsets
+        if parent_tool_surface is not None
+        else getattr(parent_agent, "enabled_toolsets", None)
+    )
     if parent_enabled is not None:
         parent_toolsets = set(parent_enabled)
+    elif parent_tool_surface is not None:
+        import model_tools
+
+        parent_toolsets = {
+            ts
+            for name in parent_tool_surface.valid_tool_names
+            if (ts := model_tools.get_toolset_for_tool(name)) is not None
+        }
     elif parent_agent and hasattr(parent_agent, "valid_tool_names"):
         # enabled_toolsets is None (all tools) — derive from loaded tool names
         import model_tools
@@ -1675,7 +1833,11 @@ def _build_child_agent(
     # carry useful tools too. Pass exact one-tool deny toolsets through to the
     # child so model_tools subtracts the blocked names AFTER composite
     # expansion, and the restriction survives later registry/MCP refreshes.
-    raw_parent_disabled = getattr(parent_agent, "disabled_toolsets", None)
+    raw_parent_disabled = (
+        parent_tool_surface.disabled_toolsets
+        if parent_tool_surface is not None
+        else getattr(parent_agent, "disabled_toolsets", None)
+    )
     if isinstance(raw_parent_disabled, (list, tuple, set)):
         inherited_disabled = [str(name) for name in raw_parent_disabled]
     else:
@@ -1985,6 +2147,12 @@ def _build_child_agent(
                 except Exception:
                     pass
             raise
+        if parent_tool_surface is not None:
+            _restrict_child_to_parent_surface(
+                child,
+                parent_tool_surface,
+                allow_delegation=effective_role == "orchestrator",
+            )
     child._print_fn = getattr(parent_agent, "_print_fn", None)
     # Ownership transfer for the dedicated handle: the child's close() must
     # release it (nothing else holds a reference), and no parent teardown can
@@ -3606,6 +3774,7 @@ def delegate_task(
     subagent_id: Optional[str] = None,
     message: Optional[str] = None,
     parent_agent=None,
+    parent_tool_surface=None,
 ) -> str:
     """
     Spawn one or more child agents to handle delegated tasks, or control
@@ -3849,6 +4018,7 @@ def delegate_task(
                 max_iterations=effective_max_iter,
                 task_count=n_tasks,
                 parent_agent=parent_agent,
+                parent_tool_surface=parent_tool_surface,
                 override_provider=creds["provider"],
                 override_base_url=creds["base_url"],
                 override_api_key=creds["api_key"],

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -5251,16 +5251,12 @@ def refresh_agent_mcp_tools(
     tool **name** (not count — a count compare misses an equal-size add/remove
     swap).
 
-    Crucially it is **additive-preserving**: ``get_tool_definitions`` returns
-    only the registry-derived tools, but ``agent_init`` appends two further
-    families directly onto ``agent.tools`` *after* that — external
-    memory-provider tools (mem0/honcho/…) and context-engine tools
-    (``lcm_*``).  A naive ``agent.tools = get_tool_definitions(...)`` would
-    silently DELETE those.  So after rebuilding the registry set we re-run the
-    same post-build injectors ``agent_init`` used, reconstructing the full
-    surface.  The new ``(tools, valid_tool_names)`` pair is published together
-    under ``_agent_tools_lock`` so a concurrent reader never sees a
-    cross-attribute half-swap.
+    Crucially it preserves the two schema families that live outside the
+    registry — external memory-provider tools (mem0/honcho/…) and context-engine
+    tools (``lcm_*``). The same complete-surface assembler used at agent init
+    reconstructs registry and injected families together before the new
+    ``(tools, valid_tool_names)`` pair is published under ``_agent_tools_lock``
+    so a concurrent reader never sees a cross-attribute half-swap.
 
     Returns the set of newly-added tool names (empty when nothing changed), so
     callers can decide whether to notify the user / re-emit session info.  The
@@ -5269,7 +5265,7 @@ def refresh_agent_mcp_tools(
     explicit user consent; the late-binding and between-turns paths only rebuild
     at a turn boundary, before that turn's ``tools=`` prefix is assembled).
     """
-    from model_tools import get_tool_definitions
+    from model_tools import get_tool_definitions, record_resolved_tool_names
     from tools.registry import registry
 
     # Explicit reloads (/reload-mcp) pass freshly-resolved toolsets so a server
@@ -5302,20 +5298,16 @@ def refresh_agent_mcp_tools(
             enabled_toolsets=enabled,
             disabled_toolsets=disabled,
             quiet_mode=quiet_mode,
+            skip_tool_search_assembly=True,
+            record_resolved_names=False,
         )
         or []
     )
-    new_names = {t["function"]["name"] for t in new_defs}
 
-    # Re-append the post-build injected families that get_tool_definitions does
-    # NOT reproduce, so a refresh never strips them (memory-provider + context-
-    # engine tools). Staged entirely on LOCALS — the live ``agent.tools`` /
-    # ``valid_tool_names`` / ``_context_engine_tool_names`` are never touched
-    # until the single atomic publish below, so a concurrent reader
-    # (``build_api_kwargs``) can't see a partial rebuild or a cross-attribute
-    # half-swap. ``staged_engine_names`` are the context-engine routing names
-    # this rebuild actually appended (matching agent_init's dedup-aware add).
-    staged_engine_names = _reinject_post_build_tools(agent, new_defs, new_names)
+    # Assemble registry + external families through the same final path used at
+    # agent init and by diagnostics, then publish the completed snapshot.
+    new_defs, staged_engine_names = _assemble_post_build_tools(agent, new_defs)
+    new_names = {t["function"]["name"] for t in new_defs}
 
     # Single atomic read-diff-publish so the returned ``added`` is consistent
     # with what was actually published, even under concurrent callers, and a
@@ -5341,6 +5333,7 @@ def refresh_agent_mcp_tools(
             return set()
         agent.tools = new_defs
         agent.valid_tool_names = new_names
+        record_resolved_tool_names(new_defs)
         # Publish context-engine routing names atomically with the snapshot.
         engine_names = getattr(agent, "_context_engine_tool_names", None)
         if isinstance(engine_names, set):
@@ -5350,69 +5343,15 @@ def refresh_agent_mcp_tools(
         return new_names - current
 
 
-def _reinject_post_build_tools(agent, tools_list: list, name_set: set) -> set:
-    """Append memory-provider and context-engine tools onto staged locals.
+def _assemble_post_build_tools(agent, base_tool_defs: list) -> tuple[list, set]:
+    """Assemble a complete staged surface for an existing agent."""
+    from agent.tool_surface import assemble_agent_tool_surface
 
-    Mirrors the post-``get_tool_definitions`` injection in ``agent_init`` so a
-    snapshot rebuild reconstructs the FULL tool surface, not just the
-    registry-derived subset. Operates ONLY on the caller's staged ``tools_list``
-    / ``name_set`` (never the live agent attributes) so the rebuild stays atomic.
-    Idempotent (skips names already present) and fail-soft.
-
-    Returns the set of context-engine routing names actually appended by THIS
-    rebuild — matching ``agent_init``'s dedup behavior (a name already provided
-    by a registry/plugin tool is NOT claimed for context-engine routing). The
-    caller publishes this into ``agent._context_engine_tool_names`` atomically
-    with the snapshot.
-    """
-    def _add(schema: dict) -> bool:
-        name = schema.get("name", "")
-        if not name or name in name_set:
-            return False
-        tools_list.append({"type": "function", "function": schema})
-        name_set.add(name)
-        return True
-
-    # Memory-provider tools (mem0/honcho/byterover/supermemory/…).
-    try:
-        memory_manager = getattr(agent, "_memory_manager", None)
-        get_mem_schemas = getattr(memory_manager, "get_all_tool_schemas", None) if memory_manager else None
-        if callable(get_mem_schemas):
-            # Honor the same enablement gate inject_memory_provider_tools uses.
-            from agent.memory_manager import memory_provider_tools_enabled
-            if "memory" in name_set or memory_provider_tools_enabled(getattr(agent, "enabled_toolsets", None)):
-                for schema in get_mem_schemas():
-                    if isinstance(schema, dict):
-                        _add(schema)
-    except Exception:
-        logger.debug("Memory-provider tool re-injection skipped", exc_info=True)
-
-    # Context-engine tools (lcm_grep/lcm_describe/…) — the `context_engine`
-    # toolset is intentionally empty, so these only exist via this append.
-    # Honor the same enabled_toolsets gate agent_init uses (#5544): without it a
-    # restricted-toolset platform (e.g. platform_toolsets: telegram: []) would
-    # re-leak lcm_* tools the build deliberately excluded, and pay the local-
-    # model latency penalty.
-    staged_engine_names: set = set()
-    try:
-        enabled = getattr(agent, "enabled_toolsets", None)
-        context_engine_allowed = enabled is None or "context_engine" in enabled
-        compressor = getattr(agent, "context_compressor", None)
-        get_schemas = getattr(compressor, "get_tool_schemas", None) if compressor else None
-        if context_engine_allowed and callable(get_schemas):
-            for schema in get_schemas():
-                if not isinstance(schema, dict):
-                    continue
-                name = schema.get("name", "")
-                # Only claim the routing name when WE appended the schema, so a
-                # name already owned by a registry/plugin tool keeps its own
-                # dispatch (matches agent_init.py's `continue`-before-claim).
-                if _add(schema) and name:
-                    staged_engine_names.add(name)
-    except Exception:
-        logger.debug("Context-engine tool re-injection skipped", exc_info=True)
-
-    return staged_engine_names
+    surface = assemble_agent_tool_surface(agent, base_tool_defs)
+    return (
+        surface.tool_defs,
+        set(surface.injected_names["context_engine"]),
+    )
 
 
 def shutdown_mcp_servers():

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -5254,9 +5254,10 @@ def refresh_agent_mcp_tools(
     Crucially it preserves the two schema families that live outside the
     registry — external memory-provider tools (mem0/honcho/…) and context-engine
     tools (``lcm_*``). The same complete-surface assembler used at agent init
-    reconstructs registry and injected families together before the new
-    ``(tools, valid_tool_names)`` pair is published under ``_agent_tools_lock``
-    so a concurrent reader never sees a cross-attribute half-swap.
+    reconstructs registry and injected families together. Writers serialize the
+    ``tools``, ``valid_tool_names``, and context-routing update under
+    ``_agent_tools_lock``; callers must invoke refresh only at the safe turn
+    boundaries described below.
 
     Returns the set of newly-added tool names (empty when nothing changed), so
     callers can decide whether to notify the user / re-emit session info.  The
@@ -5334,11 +5335,8 @@ def refresh_agent_mcp_tools(
         agent.tools = new_defs
         agent.valid_tool_names = new_names
         record_resolved_tool_names(new_defs)
-        # Publish context-engine routing names atomically with the snapshot.
-        engine_names = getattr(agent, "_context_engine_tool_names", None)
-        if isinstance(engine_names, set):
-            engine_names.clear()
-            engine_names.update(staged_engine_names)
+        # One assignment avoids exposing a transient empty routing set.
+        agent._context_engine_tool_names = set(staged_engine_names)
         agent._tool_snapshot_generation = max(published_gen, snapshot_generation)
         return new_names - current
 

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -7632,11 +7632,9 @@ def probe_mcp_server_tools() -> Dict[str, List[tuple]]:
     return result
 
 
-# Serializes in-place mutation of an agent's tool snapshot.  The reload RPC,
-# the gateway reload, and the late-binding refresh thread all swap
-# ``agent.tools`` / ``agent.valid_tool_names`` after the agent was built; the
-# agent's run loop reads those during tool iteration, so a concurrent write
-# mid-read could otherwise expose a half-updated list.
+# Serializes selection revisions and publication writers. Runtime readers use
+# the immutable envelope from ``agent.tool_surface.get_agent_tool_surface``;
+# legacy attributes remain synchronized for compatibility.
 _agent_tools_lock = threading.Lock()
 
 
@@ -7675,6 +7673,7 @@ def refresh_agent_mcp_tools(
     enabled_override=None,
     disabled_override=None,
     quiet_mode: bool = True,
+    get_tool_definitions_fn=None,
 ) -> set:
     """Re-derive an already-built agent's tool snapshot from the live registry.
 
@@ -7688,20 +7687,14 @@ def refresh_agent_mcp_tools(
     apart again.
 
     The rebuild respects the agent's own ``enabled_toolsets`` /
-    ``disabled_toolsets`` (the same filtering it was built with) and diffs by
-    tool **name** (not count — a count compare misses an equal-size add/remove
-    swap).
+    ``disabled_toolsets`` (the same filtering it was built with). It reports
+    additions by tool **name** while still republishing equal-name schema or
+    routing changes.
 
-    Crucially it is **additive-preserving**: ``get_tool_definitions`` returns
-    only the registry-derived tools, but ``agent_init`` appends two further
-    families directly onto ``agent.tools`` *after* that — external
-    memory-provider tools (mem0/honcho/…) and context-engine tools
-    (``lcm_*``).  A naive ``agent.tools = get_tool_definitions(...)`` would
-    silently DELETE those.  So after rebuilding the registry set we re-run the
-    same post-build injectors ``agent_init`` used, reconstructing the full
-    surface.  The new ``(tools, valid_tool_names)`` pair is published together
-    under ``_agent_tools_lock`` so a concurrent reader never sees a
-    cross-attribute half-swap.
+    The shared complete-surface assembler reconstructs registry, external
+    memory-provider, and context-engine tools together before publication. The
+    new immutable envelope is published under ``_agent_tools_lock`` so runtime
+    readers observe either the complete old surface or the complete new one.
 
     Returns the set of newly-added tool names (empty when nothing changed), so
     callers can decide whether to notify the user / re-emit session info.  The
@@ -7710,154 +7703,114 @@ def refresh_agent_mcp_tools(
     explicit user consent; the late-binding and between-turns paths only rebuild
     at a turn boundary, before that turn's ``tools=`` prefix is assembled).
     """
-    from model_tools import get_tool_definitions
+    from agent.tool_surface import (
+        get_agent_tool_surface,
+        publish_agent_tool_surface_for_generation,
+    )
+    from model_tools import get_tool_definitions as _default_get_tool_definitions
     from tools.registry import registry
 
-    # Explicit reloads (/reload-mcp) pass freshly-resolved toolsets so a server
-    # the user just ENABLED in config is picked up; the agent's stored selection
-    # is then updated to match. The automatic paths (between-turns, late-binding)
-    # pass nothing and reuse the agent's build-time selection unchanged.
-    if enabled_override is not None or disabled_override is not None:
-        enabled = enabled_override if enabled_override is not None else getattr(agent, "enabled_toolsets", None)
-        disabled = disabled_override if disabled_override is not None else getattr(agent, "disabled_toolsets", None)
-        agent.enabled_toolsets = enabled
-        agent.disabled_toolsets = disabled
-    else:
-        enabled = getattr(agent, "enabled_toolsets", None)
-        disabled = getattr(agent, "disabled_toolsets", None)
+    get_tool_definitions = get_tool_definitions_fn or _default_get_tool_definitions
 
-    # Capture the registry generation this rebuild is derived from BEFORE the
-    # (potentially slow) get_tool_definitions call. Used at publish time to
-    # reject a stale write: if two callers race (e.g. the late-refresh daemon
-    # and the between-turns prologue around turn 1), a slower caller that
-    # computed an OLDER set must not clobber a newer set another caller already
-    # published. ``registry._generation`` bumps on every (de)register.
-    snapshot_generation = registry._generation
+    # Selection changes and automatic selection captures share one revisioned
+    # critical section. Slow assembly happens outside the lock; publication
+    # rejects a result if a newer explicit selection won in the meantime.
+    with _agent_tools_lock:
+        revision_raw = getattr(agent, "_tool_selection_revision", 0)
+        selection_revision = revision_raw if isinstance(revision_raw, int) else 0
+        if enabled_override is not None or disabled_override is not None:
+            enabled_source = (
+                enabled_override
+                if enabled_override is not None
+                else getattr(agent, "enabled_toolsets", None)
+            )
+            disabled_source = (
+                disabled_override
+                if disabled_override is not None
+                else getattr(agent, "disabled_toolsets", None)
+            )
+            selection_revision += 1
+            agent._tool_selection_revision = selection_revision
+        else:
+            enabled_source = getattr(agent, "enabled_toolsets", None)
+            disabled_source = getattr(agent, "disabled_toolsets", None)
 
-    # Registry-derived tools (built-ins + MCP), filtered to the agent's toolsets.
-    # Computed OUTSIDE the lock (get_tool_definitions can be slow); the diff and
-    # publish below happen together in ONE critical section so two concurrent
-    # callers can't torn-publish or compute overlapping ``added`` sets.
-    new_defs = list(
-        get_tool_definitions(
+        enabled = list(enabled_source) if enabled_source is not None else None
+        disabled = list(disabled_source) if disabled_source is not None else None
+        if enabled_override is not None or disabled_override is not None:
+            agent.enabled_toolsets = enabled
+            agent.disabled_toolsets = disabled
+
+    for _attempt in range(3):
+        snapshot_generation = registry._generation
+        new_defs = list(
+            get_tool_definitions(
+                enabled_toolsets=enabled,
+                disabled_toolsets=disabled,
+                quiet_mode=quiet_mode,
+                skip_tool_search_assembly=True,
+                record_resolved_names=False,
+            )
+            or []
+        )
+        staged_surface = _assemble_post_build_tools(
+            agent,
+            new_defs,
             enabled_toolsets=enabled,
             disabled_toolsets=disabled,
-            quiet_mode=quiet_mode,
         )
-        or []
+        new_defs = staged_surface.tool_defs
+
+        with _agent_tools_lock:
+            current_revision_raw = getattr(agent, "_tool_selection_revision", 0)
+            current_revision = (
+                current_revision_raw if isinstance(current_revision_raw, int) else 0
+            )
+            if selection_revision != current_revision:
+                return set()
+
+            current_snapshot = get_agent_tool_surface(agent)
+            if snapshot_generation < current_snapshot.registry_generation:
+                return set()
+
+            current_names = set(current_snapshot.valid_tool_names)
+            published_surface = publish_agent_tool_surface_for_generation(
+                agent,
+                new_defs,
+                catalog_tool_defs=staged_surface.pre_assembly_tool_defs,
+                memory_provider_tool_names=staged_surface.injected_names["memory"],
+                deferred_tool_names=staged_surface.deferred_names,
+                context_engine_tool_names=staged_surface.injected_names[
+                    "context_engine"
+                ],
+                expected_registry_generation=snapshot_generation,
+                selection_revision=selection_revision,
+                enabled_toolsets=enabled,
+                disabled_toolsets=disabled,
+            )
+            if published_surface is None:
+                continue
+            return set(published_surface.valid_tool_names) - current_names
+
+    return set()
+
+
+def _assemble_post_build_tools(
+    agent,
+    base_tool_defs: list,
+    *,
+    enabled_toolsets=None,
+    disabled_toolsets=None,
+) -> Any:
+    """Assemble a complete staged surface for an existing agent."""
+    from agent.tool_surface import assemble_agent_tool_surface
+
+    surface = assemble_agent_tool_surface(
+        agent,
+        base_tool_defs,
+        toolset_selection=(enabled_toolsets, disabled_toolsets),
     )
-    new_names = {t["function"]["name"] for t in new_defs}
-
-    # Re-append the post-build injected families that get_tool_definitions does
-    # NOT reproduce, so a refresh never strips them (memory-provider + context-
-    # engine tools). Staged entirely on LOCALS — the live ``agent.tools`` /
-    # ``valid_tool_names`` / ``_context_engine_tool_names`` are never touched
-    # until the single atomic publish below, so a concurrent reader
-    # (``build_api_kwargs``) can't see a partial rebuild or a cross-attribute
-    # half-swap. ``staged_engine_names`` are the context-engine routing names
-    # this rebuild actually appended (matching agent_init's dedup-aware add).
-    staged_engine_names = _reinject_post_build_tools(agent, new_defs, new_names)
-
-    # Single atomic read-diff-publish so the returned ``added`` is consistent
-    # with what was actually published, even under concurrent callers, and a
-    # stale (older-generation) rebuild can't overwrite a newer published one.
-    with _agent_tools_lock:
-        # Defensive: the published generation should be an int, but tolerate an
-        # agent that never set it (or set a non-int, e.g. a test mock) rather
-        # than throwing TypeError on the comparison and silently failing the
-        # whole refresh.
-        published_gen_raw = getattr(agent, "_tool_snapshot_generation", -1)
-        published_gen = published_gen_raw if isinstance(published_gen_raw, int) else -1
-        if snapshot_generation < published_gen:
-            # A newer snapshot already won; our set is stale — drop it.
-            return set()
-        current = {
-            t["function"]["name"]
-            for t in (getattr(agent, "tools", None) or [])
-        }
-        if new_names == current:
-            # No change → leave the live snapshot untouched (no churn), but
-            # record the generation so an in-flight older caller can't clobber.
-            agent._tool_snapshot_generation = max(published_gen, snapshot_generation)
-            return set()
-        agent.tools = new_defs
-        agent.valid_tool_names = new_names
-        # Publish context-engine routing names atomically with the snapshot.
-        engine_names = getattr(agent, "_context_engine_tool_names", None)
-        if isinstance(engine_names, set):
-            engine_names.clear()
-            engine_names.update(staged_engine_names)
-        agent._tool_snapshot_generation = max(published_gen, snapshot_generation)
-        return new_names - current
-
-
-def _reinject_post_build_tools(agent, tools_list: list, name_set: set) -> set:
-    """Append memory-provider and context-engine tools onto staged locals.
-
-    Mirrors the post-``get_tool_definitions`` injection in ``agent_init`` so a
-    snapshot rebuild reconstructs the FULL tool surface, not just the
-    registry-derived subset. Operates ONLY on the caller's staged ``tools_list``
-    / ``name_set`` (never the live agent attributes) so the rebuild stays atomic.
-    Idempotent (skips names already present) and fail-soft.
-
-    Returns the set of context-engine routing names actually appended by THIS
-    rebuild — matching ``agent_init``'s dedup behavior (a name already provided
-    by a registry/plugin tool is NOT claimed for context-engine routing). The
-    caller publishes this into ``agent._context_engine_tool_names`` atomically
-    with the snapshot.
-    """
-    def _add(schema: dict) -> bool:
-        name = schema.get("name", "")
-        if not name or name in name_set:
-            return False
-        tools_list.append({"type": "function", "function": schema})
-        name_set.add(name)
-        return True
-
-    # Memory-provider tools (mem0/honcho/byterover/supermemory/…).
-    try:
-        memory_manager = getattr(agent, "_memory_manager", None)
-        get_mem_schemas = getattr(memory_manager, "get_all_tool_schemas", None) if memory_manager else None
-        if callable(get_mem_schemas):
-            # Honor the same toolset gate inject_memory_provider_tools uses.
-            from agent.memory_manager import memory_provider_tools_enabled
-            if memory_provider_tools_enabled(
-                getattr(agent, "enabled_toolsets", None),
-                getattr(agent, "disabled_toolsets", None),
-                memory_tool_present="memory" in name_set,
-            ):
-                for schema in get_mem_schemas():
-                    if isinstance(schema, dict):
-                        _add(schema)
-    except Exception:
-        logger.debug("Memory-provider tool re-injection skipped", exc_info=True)
-
-    # Context-engine tools (lcm_grep/lcm_describe/…) — the `context_engine`
-    # toolset is intentionally empty, so these only exist via this append.
-    # Honor the same enabled_toolsets gate agent_init uses (#5544): without it a
-    # restricted-toolset platform (e.g. platform_toolsets: telegram: []) would
-    # re-leak lcm_* tools the build deliberately excluded, and pay the local-
-    # model latency penalty.
-    staged_engine_names: set = set()
-    try:
-        enabled = getattr(agent, "enabled_toolsets", None)
-        context_engine_allowed = enabled is None or "context_engine" in enabled
-        compressor = getattr(agent, "context_compressor", None)
-        get_schemas = getattr(compressor, "get_tool_schemas", None) if compressor else None
-        if context_engine_allowed and callable(get_schemas):
-            for schema in get_schemas():
-                if not isinstance(schema, dict):
-                    continue
-                name = schema.get("name", "")
-                # Only claim the routing name when WE appended the schema, so a
-                # name already owned by a registry/plugin tool keeps its own
-                # dispatch (matches agent_init.py's `continue`-before-claim).
-                if _add(schema) and name:
-                    staged_engine_names.add(name)
-    except Exception:
-        logger.debug("Context-engine tool re-injection skipped", exc_info=True)
-
-    return staged_engine_names
+    return surface
 
 
 def shutdown_mcp_servers():

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -453,13 +453,19 @@ class ProcessRegistry:
         # gateway drain this after each agent turn to auto-trigger new turns.
         import queue as _queue_mod
         self.completion_queue: _queue_mod.Queue = _queue_mod.Queue()
-        # Rehydrate durable delegation completions only at registry startup.
-        # Consumers still inject them as fresh turns through this existing rail.
-        try:
-            from tools.async_delegation import restore_undelivered_completions
-            restore_undelivered_completions(self.completion_queue)
-        except Exception as exc:
-            logger.warning("Could not restore async delegation completions: %s", exc)
+        # Rehydrate durable delegation completions only at runtime startup.
+        # Read-only tool inspection imports this module only to collect schemas.
+        from tools.registry import is_read_only_tool_inspection
+
+        if not is_read_only_tool_inspection():
+            try:
+                from tools.async_delegation import restore_undelivered_completions
+
+                restore_undelivered_completions(self.completion_queue)
+            except Exception as exc:
+                logger.warning(
+                    "Could not restore async delegation completions: %s", exc
+                )
 
         # Track sessions whose completion was already consumed by the agent
         # via wait/log.  Drain loops AND gateway/tui watchers skip notifications

--- a/tools/registry.py
+++ b/tools/registry.py
@@ -15,6 +15,7 @@ Import chain (circular-import safe):
 """
 
 import ast
+import contextlib
 import functools
 import importlib
 import json
@@ -22,12 +23,85 @@ import logging
 import sys
 import threading
 import time
+import weakref
+from contextvars import ContextVar
 from pathlib import Path
-from typing import Callable, Dict, List, Optional, Set
+from typing import Any, Callable, Dict, Iterable, List, Optional, Set
 
 from hermes_constants import hermes_home_key
 
 logger = logging.getLogger(__name__)
+
+_read_only_tool_inspection: ContextVar[bool] = ContextVar(
+    "read_only_tool_inspection", default=False
+)
+_registry_inspection_state: ContextVar[Optional[Any]] = ContextVar(
+    "registry_inspection_state", default=None
+)
+_registry_inspection_binding_lock = threading.RLock()
+_registry_inspection_binding_state: Optional[Any] = None
+_registry_inspection_bound_threads: weakref.WeakKeyDictionary = (
+    weakref.WeakKeyDictionary()
+)
+
+
+def _active_registry_inspection_state():
+    state = _registry_inspection_state.get()
+    if state is not None:
+        return state
+    with _registry_inspection_binding_lock:
+        return _registry_inspection_bound_threads.get(threading.current_thread())
+
+
+def capture_read_only_tool_inspection_binding():
+    """Return the current isolated registry state as an opaque binding token."""
+    return _active_registry_inspection_state()
+
+
+def bind_read_only_tool_inspection_to_current_thread(state=None) -> bool:
+    """Bind a diagnostic plugin child thread to the isolated registry clone."""
+    active_state = _registry_inspection_state.get()
+    with _registry_inspection_binding_lock:
+        binding_state = (
+            state if state is not None else _registry_inspection_binding_state
+        )
+        if binding_state is None:
+            return False
+        if active_state is binding_state:
+            return True
+        _registry_inspection_bound_threads[threading.current_thread()] = binding_state
+        return True
+
+
+@contextlib.contextmanager
+def read_only_tool_inspection():
+    """Prevent tool discovery from persisting runtime state in this context."""
+    global _registry_inspection_binding_state
+    token = _read_only_tool_inspection.set(True)
+    state_token = None
+    binding_state_before = None
+    if _registry_inspection_state.get() is None:
+        state = registry._copy_inspection_state()
+        state_token = _registry_inspection_state.set(state)
+        with _registry_inspection_binding_lock:
+            binding_state_before = _registry_inspection_binding_state
+            _registry_inspection_binding_state = state
+    try:
+        yield
+    finally:
+        if state_token is not None:
+            with _registry_inspection_binding_lock:
+                _registry_inspection_binding_state = binding_state_before
+            _registry_inspection_state.reset(state_token)
+        _read_only_tool_inspection.reset(token)
+
+
+def is_read_only_tool_inspection() -> bool:
+    return (
+        _read_only_tool_inspection.get()
+        or _active_registry_inspection_state() is not None
+    )
+
 
 # Cap on a tool error body; only trims runaway interpolated exceptions (static msgs are ~115 chars).
 _MAX_TOOL_ERROR_CHARS = 2048
@@ -149,7 +223,9 @@ def discover_builtin_tools(tools_dir: Optional[Path] = None) -> List[str]:
             module_names.append(f"tools.{path.stem}")
 
     # Drop entries for files that no longer exist; rewrite only when changed.
-    if cache_dirty or set(fresh_cache) != set(cache):
+    if (
+        cache_dirty or set(fresh_cache) != set(cache)
+    ) and not is_read_only_tool_inspection():
         _save_discovery_cache(fresh_cache)
 
     imported: List[str] = []
@@ -391,6 +467,58 @@ def _check_fn_cached(fn: Callable) -> bool:
         return False
 
 
+def _check_fn_readonly(fn: Callable) -> bool:
+    """Mirror availability semantics without mutating either TTL cache."""
+    now = time.monotonic()
+    scope = check_fn_cache_scope()
+    if scope == CHECK_FN_CACHE_BYPASS:
+        try:
+            return bool(fn())
+        except Exception:
+            logger.warning(
+                "check_fn %s raised during read-only inspection; "
+                "dependent tools will be reported unavailable",
+                getattr(fn, "__qualname__", fn),
+                exc_info=True,
+            )
+            return False
+
+    cache_key = (fn, scope)
+    with _check_fn_cache_lock:
+        cached = _check_fn_cache.get(cache_key)
+        last_good = _check_fn_last_good.get(cache_key)
+    if cached is not None:
+        timestamp, value = cached
+        if now - timestamp < _CHECK_FN_TTL_SECONDS:
+            return value
+
+    raised = False
+    try:
+        value = bool(fn())
+    except Exception:
+        value = False
+        raised = True
+    if value:
+        return True
+    if last_good is not None and now - last_good < _CHECK_FN_FAILURE_GRACE_SECONDS:
+        logger.warning(
+            "check_fn %s failed (%s) within %.0fs of last success during "
+            "read-only inspection; keeping tool(s) available",
+            getattr(fn, "__qualname__", fn),
+            "raised" if raised else "returned False",
+            _CHECK_FN_FAILURE_GRACE_SECONDS,
+        )
+        return True
+
+    logger.warning(
+        "check_fn %s %s during read-only inspection; dependent tools will "
+        "be reported unavailable",
+        getattr(fn, "__qualname__", fn),
+        "raised" if raised else "returned False",
+    )
+    return False
+
+
 def invalidate_check_fn_cache() -> None:
     """Drop all cached ``check_fn`` results. Call after config changes that
     affect tool availability (e.g. ``hermes tools enable``)."""
@@ -428,21 +556,21 @@ class ToolRegistry:
 
     def __init__(self):
         # Built-in and other process-global registrations.
-        self._tools: Dict[str, ToolEntry] = {}
+        self._base_tools: Dict[str, ToolEntry] = {}
         # Plugin registrations are overlays keyed by resolved HERMES_HOME. A
         # profile sees its own overlay first and then the global built-ins.
-        self._scoped_tools: Dict[str, Dict[str, ToolEntry]] = {}
+        self._base_scoped_tools: Dict[str, Dict[str, ToolEntry]] = {}
         # Plugin module namespace -> operator opt-in for built-in override.
         # Authorization records are lifecycle-managed; the separate scope map
         # remains durable so delayed callbacks stay profile-confined.
-        self._plugin_override_policy: Dict[
+        self._base_plugin_override_policy: Dict[
             tuple[Optional[str], str], _PluginOverridePolicy
         ] = {}
         # Scope attribution stays durable after policy removal so delayed code
         # remains confined to the profile where its module was loaded.
-        self._plugin_module_scopes: Dict[str, Set[Optional[str]]] = {}
-        self._toolset_checks: Dict[str, Callable] = {}
-        self._toolset_aliases: Dict[str, str] = {}
+        self._base_plugin_module_scopes: Dict[str, Set[Optional[str]]] = {}
+        self._base_toolset_checks: Dict[str, Callable] = {}
+        self._base_toolset_aliases: Dict[str, str] = {}
         # MCP dynamic refresh can mutate the registry while other threads are
         # reading tool metadata, so keep mutations serialized and readers on
         # stable snapshots.
@@ -452,7 +580,131 @@ class ToolRegistry:
         # refresh). External callers (e.g. get_tool_definitions) can memoize
         # against it: a cache entry keyed on the generation is valid for as
         # long as the generation hasn't changed.
-        self._generation: int = 0
+        self._base_generation: int = 0
+
+    def _inspection_state(self):
+        state = _active_registry_inspection_state()
+        return state if state is not None and state["owner"] is self else None
+
+    def _copy_inspection_state(self) -> Dict[str, Any]:
+        with self._lock:
+            return {
+                "owner": self,
+                "tools": dict(self._base_tools),
+                "scoped_tools": {
+                    scope: dict(entries)
+                    for scope, entries in self._base_scoped_tools.items()
+                },
+                "plugin_override_policy": dict(
+                    self._base_plugin_override_policy
+                ),
+                "plugin_module_scopes": {
+                    module: set(scopes)
+                    for module, scopes in self._base_plugin_module_scopes.items()
+                },
+                "toolset_checks": dict(self._base_toolset_checks),
+                "toolset_aliases": dict(self._base_toolset_aliases),
+                "generation": self._base_generation,
+            }
+
+    @property
+    def _tools(self) -> Dict[str, ToolEntry]:
+        state = self._inspection_state()
+        return state["tools"] if state is not None else self._base_tools
+
+    @_tools.setter
+    def _tools(self, value: Dict[str, ToolEntry]) -> None:
+        state = self._inspection_state()
+        if state is not None:
+            state["tools"] = value
+        else:
+            self._base_tools = value
+
+    @property
+    def _scoped_tools(self) -> Dict[str, Dict[str, ToolEntry]]:
+        state = self._inspection_state()
+        return state["scoped_tools"] if state is not None else self._base_scoped_tools
+
+    @_scoped_tools.setter
+    def _scoped_tools(self, value: Dict[str, Dict[str, ToolEntry]]) -> None:
+        state = self._inspection_state()
+        if state is not None:
+            state["scoped_tools"] = value
+        else:
+            self._base_scoped_tools = value
+
+    @property
+    def _plugin_override_policy(self):
+        state = self._inspection_state()
+        return (
+            state["plugin_override_policy"]
+            if state is not None
+            else self._base_plugin_override_policy
+        )
+
+    @_plugin_override_policy.setter
+    def _plugin_override_policy(self, value) -> None:
+        state = self._inspection_state()
+        if state is not None:
+            state["plugin_override_policy"] = value
+        else:
+            self._base_plugin_override_policy = value
+
+    @property
+    def _plugin_module_scopes(self):
+        state = self._inspection_state()
+        return (
+            state["plugin_module_scopes"]
+            if state is not None
+            else self._base_plugin_module_scopes
+        )
+
+    @_plugin_module_scopes.setter
+    def _plugin_module_scopes(self, value) -> None:
+        state = self._inspection_state()
+        if state is not None:
+            state["plugin_module_scopes"] = value
+        else:
+            self._base_plugin_module_scopes = value
+
+    @property
+    def _toolset_checks(self) -> Dict[str, Callable]:
+        state = self._inspection_state()
+        return state["toolset_checks"] if state is not None else self._base_toolset_checks
+
+    @_toolset_checks.setter
+    def _toolset_checks(self, value: Dict[str, Callable]) -> None:
+        state = self._inspection_state()
+        if state is not None:
+            state["toolset_checks"] = value
+        else:
+            self._base_toolset_checks = value
+
+    @property
+    def _toolset_aliases(self) -> Dict[str, str]:
+        state = self._inspection_state()
+        return state["toolset_aliases"] if state is not None else self._base_toolset_aliases
+
+    @_toolset_aliases.setter
+    def _toolset_aliases(self, value: Dict[str, str]) -> None:
+        state = self._inspection_state()
+        if state is not None:
+            state["toolset_aliases"] = value
+        else:
+            self._base_toolset_aliases = value
+
+    @property
+    def _generation(self) -> int:
+        state = self._inspection_state()
+        return state["generation"] if state is not None else self._base_generation
+
+    @_generation.setter
+    def _generation(self, value: int) -> None:
+        state = self._inspection_state()
+        if state is not None:
+            state["generation"] = value
+        else:
+            self._base_generation = value
 
     @staticmethod
     def current_scope_key() -> str:
@@ -527,6 +779,48 @@ class ToolRegistry:
         with self._lock:
             target = self._tools if scope is None else self._scoped_tools.get(scope, {})
             return target.get(name)
+
+    def snapshot_entries_by_name(
+        self,
+        names: Iterable[str],
+        *,
+        expected_generation: Optional[int] = None,
+        scope: Optional[str] = None,
+    ) -> Optional[tuple[int, tuple[tuple[str, ToolEntry], ...]]]:
+        """Atomically capture named entries, optionally as a generation CAS."""
+        with self._lock:
+            if (
+                expected_generation is not None
+                and self._generation != expected_generation
+            ):
+                return None
+            merged = self._merged_tools(scope)
+            entries = tuple(
+                (name, entry)
+                for name in names
+                if (entry := merged.get(name)) is not None
+            )
+            return self._generation, entries
+
+    def run_with_entries_snapshot_by_name(
+        self,
+        names: Iterable[str],
+        callback: Callable[[int, tuple[tuple[str, ToolEntry], ...]], Any],
+        *,
+        expected_generation: int,
+        scope: Optional[str] = None,
+    ) -> Optional[Any]:
+        """Run a short publication callback while a generation snapshot is leased."""
+        with self._lock:
+            if self._generation != expected_generation:
+                return None
+            merged = self._merged_tools(scope)
+            entries = tuple(
+                (name, entry)
+                for name in names
+                if (entry := merged.get(name)) is not None
+            )
+            return callback(self._generation, entries)
 
     def get_registered_toolset_names(self) -> List[str]:
         """Return sorted unique toolset names present in the registry."""
@@ -1015,7 +1309,13 @@ class ToolRegistry:
     # Schema retrieval
     # ------------------------------------------------------------------
 
-    def get_definitions(self, tool_names: Set[str], quiet: bool = False) -> List[dict]:
+    def get_definitions(
+        self,
+        tool_names: Set[str],
+        quiet: bool = False,
+        *,
+        cache_checks: bool = True,
+    ) -> List[dict]:
         """Return OpenAI-format tool schemas for the requested tool names.
 
         Only tools whose ``check_fn()`` returns True (or have no check_fn)
@@ -1024,13 +1324,16 @@ class ToolRegistry:
         requirements probes modal/docker, browser checks probe playwright,
         etc.); TTL chosen so env-var changes (``hermes tools enable foo``)
         still take effect in near-real-time without forcing a full cache
-        flush on every call.
+        flush on every call. Read-only diagnostic callers can pass
+        ``cache_checks=False`` to preserve the same cached/last-good semantics
+        without publishing fresh probe results.
         """
         result = []
         # Per-call cache on top of the 30 s TTL — handles repeat probes of the
         # same check_fn within one definitions pass without re-reading the
         # TTL clock.
         check_results: Dict[Callable, bool] = {}
+        check = _check_fn_cached if cache_checks else _check_fn_readonly
         entries_by_name = {entry.name: entry for entry in self._snapshot_entries()}
         for name in sorted(tool_names):
             entry = entries_by_name.get(name)
@@ -1038,7 +1341,7 @@ class ToolRegistry:
                 continue
             if entry.check_fn:
                 if entry.check_fn not in check_results:
-                    check_results[entry.check_fn] = _check_fn_cached(entry.check_fn)
+                    check_results[entry.check_fn] = check(entry.check_fn)
                 if not check_results[entry.check_fn]:
                     if not quiet:
                         logger.debug("Tool %s unavailable (check failed)", name)
@@ -1105,6 +1408,7 @@ class ToolRegistry:
         args: dict,
         *,
         scope: Optional[str] = None,
+        expected_entry: Optional[ToolEntry] = None,
         **kwargs,
     ) -> str | dict:
         """Execute a tool handler by name.
@@ -1118,6 +1422,10 @@ class ToolRegistry:
         entry = self.get_entry(name, scope=scope)
         if not entry:
             return tool_error(f"Unknown tool: {name}")
+        if expected_entry is not None and entry is not expected_entry:
+            return tool_error(
+                f"Tool registration changed during the request: {name}. Retry the request."
+            )
         try:
             if entry.is_async:
                 from model_tools import _run_async
@@ -1140,6 +1448,19 @@ class ToolRegistry:
             except Exception:
                 sanitized = raw  # defensive: never let the sanitizer block error propagation
             return tool_error(sanitized)
+
+    def expected_entry_error(
+        self,
+        name: str,
+        expected_entry: ToolEntry,
+        *,
+        scope: Optional[str] = None,
+    ) -> Optional[str]:
+        """Return an error when a request-pinned registration is no longer live."""
+        entry = self.get_entry(name, scope=scope)
+        if entry is expected_entry:
+            return None
+        return f"Tool registration changed during the request: {name}. Retry the request."
 
     # ------------------------------------------------------------------
     # Query helpers  (replace redundant dicts in model_tools.py)

--- a/tools/session_search_tool.py
+++ b/tools/session_search_tool.py
@@ -1117,10 +1117,11 @@ def session_search(
 
 
 def check_session_search_requirements() -> bool:
-    """Requires the SQLite state database."""
+    """Require the SQLite state capability, not a startup-created directory."""
     try:
         from hermes_state import _default_db_path
-        return _default_db_path().parent.exists()
+
+        return callable(_default_db_path)
     except ImportError:
         return False
 

--- a/tools/tool_backend_helpers.py
+++ b/tools/tool_backend_helpers.py
@@ -31,6 +31,14 @@ def managed_nous_tools_enabled(*, force_fresh: bool = False) -> bool:
     reflect a just-purchased subscription, credits, or pool grant immediately.
     """
     try:
+        from tools.registry import is_read_only_tool_inspection
+
+        if is_read_only_tool_inspection():
+            return False
+    except Exception:
+        pass
+
+    try:
         from hermes_cli.nous_account import get_nous_portal_account_info
 
         if force_fresh:

--- a/tools/tool_search.py
+++ b/tools/tool_search.py
@@ -47,7 +47,7 @@ import logging
 import math
 import re
 from dataclasses import dataclass, field
-from typing import Any, Dict, Iterable, List, Optional, Tuple
+from typing import Any, Dict, FrozenSet, Iterable, List, Mapping, Optional, Set, Tuple
 
 from tools.registry import tool_error
 
@@ -385,7 +385,26 @@ def _classify_source(name: str) -> Tuple[str, str]:
         return ("other", "")
 
 
-def build_catalog(tool_defs: List[Dict[str, Any]]) -> List[CatalogEntry]:
+def deferred_sources_from_registry_entries(
+    entries: Mapping[str, Any],
+) -> Dict[str, Tuple[str, str]]:
+    """Derive deferred source labels from request-pinned registry entries."""
+    core_names = _core_tool_names()
+    sources: Dict[str, Tuple[str, str]] = {}
+    for name, entry in entries.items():
+        if name in core_names or name in BRIDGE_TOOL_NAMES:
+            continue
+        toolset = str(getattr(entry, "toolset", "") or "")
+        source = "mcp" if toolset.startswith("mcp-") else "plugin"
+        sources[name] = (source, toolset)
+    return sources
+
+
+def build_catalog(
+    tool_defs: List[Dict[str, Any]],
+    *,
+    deferred_sources: Optional[Mapping[str, Tuple[str, str]]] = None,
+) -> List[CatalogEntry]:
     """Build the deferred-tool catalog from a tool-defs list.
 
     Caller is expected to pass only the deferrable subset (``classify_tools``
@@ -398,7 +417,10 @@ def build_catalog(tool_defs: List[Dict[str, Any]]) -> List[CatalogEntry]:
         if not name:
             continue
         desc = fn.get("description", "") or ""
-        source, source_name = _classify_source(name)
+        if deferred_sources is None:
+            source, source_name = _classify_source(name)
+        else:
+            source, source_name = deferred_sources.get(name, ("other", ""))
         entry = CatalogEntry(
             name=name,
             description=desc,
@@ -894,10 +916,13 @@ def _available_source_summary(catalog: List[CatalogEntry]) -> List[Dict[str, Any
     ]
 
 
-def dispatch_tool_search(args: Dict[str, Any],
-                         *,
-                         current_tool_defs: List[Dict[str, Any]],
-                         config: Optional[ToolSearchConfig] = None) -> str:
+def dispatch_tool_search(
+    args: Dict[str, Any],
+    *,
+    current_tool_defs: List[Dict[str, Any]],
+    config: Optional[ToolSearchConfig] = None,
+    deferred_sources: Optional[Mapping[str, Tuple[str, str]]] = None,
+) -> str:
     """Execute the ``tool_search`` bridge tool. Returns a JSON string."""
     if config is None:
         config = load_config()
@@ -911,8 +936,15 @@ def dispatch_tool_search(args: Dict[str, Any],
     else:
         limit = max(1, min(config.max_search_limit, _safe_int(raw_limit, config.search_default_limit)))
 
-    _, deferrable = classify_tools(current_tool_defs)
-    catalog = build_catalog(deferrable)
+    if deferred_sources is None:
+        _, deferrable = classify_tools(current_tool_defs)
+    else:
+        deferrable = [
+            td
+            for td in current_tool_defs
+            if (td.get("function") or {}).get("name") in deferred_sources
+        ]
+    catalog = build_catalog(deferrable, deferred_sources=deferred_sources)
     hits = search_catalog(catalog, query, limit=limit)
     result: Dict[str, Any] = {
         "query": query,
@@ -930,19 +962,34 @@ def dispatch_tool_search(args: Dict[str, Any],
     return json.dumps(result, ensure_ascii=False)
 
 
-def dispatch_tool_describe(args: Dict[str, Any],
-                           *,
-                           current_tool_defs: List[Dict[str, Any]]) -> str:
+def dispatch_tool_describe(
+    args: Dict[str, Any],
+    *,
+    current_tool_defs: List[Dict[str, Any]],
+    deferred_sources: Optional[Mapping[str, Tuple[str, str]]] = None,
+) -> str:
     """Execute the ``tool_describe`` bridge tool. Returns a JSON string."""
     name = str(args.get("name") or "").strip()
     if not name:
         return tool_error("name is required")
-    if not is_deferrable_tool_name(name):
+    is_deferred = (
+        is_deferrable_tool_name(name)
+        if deferred_sources is None
+        else name in deferred_sources
+    )
+    if not is_deferred:
         return tool_error(
             f"'{name}' is not a deferrable tool. If you see it in the tools list "
             "already, call it directly; otherwise check the spelling against tool_search."
         )
-    _, deferrable = classify_tools(current_tool_defs)
+    if deferred_sources is None:
+        _, deferrable = classify_tools(current_tool_defs)
+    else:
+        deferrable = [
+            td
+            for td in current_tool_defs
+            if (td.get("function") or {}).get("name") in deferred_sources
+        ]
     for td in deferrable:
         fn = td.get("function") or {}
         if fn.get("name") == name:
@@ -976,7 +1023,11 @@ def scoped_deferrable_names(tool_defs: List[Dict[str, Any]]) -> frozenset[str]:
     return frozenset(names)
 
 
-def validate_deferred_call_args(name: str, args: Dict[str, Any]) -> Optional[str]:
+def validate_deferred_call_args(
+    name: str,
+    args: Dict[str, Any],
+    tool_defs: Optional[List[Dict[str, Any]]] = None,
+) -> Optional[str]:
     """Probe-validate ``tool_call`` arguments against the deferred tool's schema.
 
     A deferred tool's parameter schema is invisible to the model until it
@@ -999,8 +1050,19 @@ def validate_deferred_call_args(name: str, args: Dict[str, Any]) -> Optional[str
     call should dispatch.
     """
     try:
-        from tools.registry import registry as _registry
-        schema = _registry.get_schema(name)
+        if tool_defs is None:
+            from tools.registry import registry as _registry
+
+            schema = _registry.get_schema(name)
+        else:
+            schema = next(
+                (
+                    tool
+                    for tool in tool_defs
+                    if (tool.get("function") or {}).get("name") == name
+                ),
+                None,
+            )
         if not isinstance(schema, dict):
             return None
         fn = schema.get("function") if schema.get("type") == "function" else schema
@@ -1029,7 +1091,10 @@ def validate_deferred_call_args(name: str, args: Dict[str, Any]) -> Optional[str
         return None
 
 
-def resolve_underlying_call(args: Dict[str, Any]) -> Tuple[Optional[str], Dict[str, Any], Optional[str]]:
+def resolve_underlying_call(
+    args: Dict[str, Any],
+    allowed_names=None,
+) -> Tuple[Optional[str], Dict[str, Any], Optional[str]]:
     """Parse a ``tool_call`` invocation into (underlying_name, args, error_msg).
 
     Used by:
@@ -1054,7 +1119,11 @@ def resolve_underlying_call(args: Dict[str, Any]) -> Tuple[Optional[str], Dict[s
             return None, {}, f"tool_call 'arguments' is not valid JSON: {e}"
     if not isinstance(raw_args, dict):
         return None, {}, "tool_call 'arguments' must be an object"
-    if not is_deferrable_tool_name(name):
+    if (
+        name not in allowed_names
+        if allowed_names is not None
+        else not is_deferrable_tool_name(name)
+    ):
         return None, {}, (
             f"'{name}' is not a deferrable tool. If it appears in the model-facing tools "
             "list already, call it directly instead of via tool_call."

--- a/website/docs/reference/toolsets-reference.md
+++ b/website/docs/reference/toolsets-reference.md
@@ -38,6 +38,9 @@ toolsets:
 
 ```bash
 hermes tools                            # curses UI to enable/disable per platform
+hermes tools list --platform cli        # show saved enabled/disabled toolsets
+hermes tools diagnose --platform cli    # explain the resolved model-facing tool surface
+hermes tools diagnose --json            # machine-readable diagnostics
 ```
 
 Or in-session:

--- a/website/docs/reference/toolsets-reference.md
+++ b/website/docs/reference/toolsets-reference.md
@@ -43,6 +43,12 @@ hermes tools diagnose --platform cli    # explain the resolved model-facing tool
 hermes tools diagnose --json            # machine-readable diagnostics
 ```
 
+`diagnose` reports the final schemas sent to the model after availability
+checks, external memory-provider/context-engine injection, deduplication,
+schema sanitization, and tool-search replacement. Provider-family counts and
+tool-search deferrals are included so a pre-assembly catalog is not mistaken
+for the live model-facing surface.
+
 Or in-session:
 
 ```

--- a/website/docs/reference/toolsets-reference.md
+++ b/website/docs/reference/toolsets-reference.md
@@ -38,7 +38,14 @@ toolsets:
 
 ```bash
 hermes tools                            # curses UI to enable/disable per platform
+hermes tools list --platform cli        # show saved enabled/disabled toolsets
+hermes tools diagnose --platform cli    # project the pre-startup tool surface
+hermes tools diagnose --json            # machine-readable diagnostics
 ```
+
+`diagnose` is a read-only pre-startup projection. MCP schemas appear only when
+those tools are already registered in the current process; it does not start or
+connect configured MCP servers.
 
 Or in-session:
 


### PR DESCRIPTION
## Summary

- add `hermes tools diagnose` with human and machine-readable pre-startup tool-surface diagnostics
- keep diagnostics read-only from process entry across recovery, config, auth, env, logging, plugin manager, registry, module imports, runtime, stdout/stderr, raw FDs, and inherited child output; emit through saved descriptors and terminate lingering plugin threads after a bounded grace period
- capture one immutable, generation-consistent tool-surface snapshot per request and use it for validation, coercion, Tool Search, routing, dispatch, delegation, and memory post-write
- reject stale registry ownership before coercion, middleware, hooks, approvals, or direct agent-loop dispatch; publish refreshed surfaces while holding a generation lease
- preserve exact inherited tool definitions, registry entries, routing classes, and provider provenance across delegated-child construction and every refresh; allow same-implementation child-local context engines while dropping differing or monkeypatched handlers
- normalize safe global flags with argparse's real negative-number semantics and accept only canonical profile identifiers before the protected diagnose route
- report plugin tool-name conflicts before registry deduplication and suppress plugin secret-source refresh during diagnostics

Closes #47404.

## Verification

Current candidate base: `6c6c17e0fc1fdb48cd4f7b50d5e263ec86acee5d`

- affected regression matrix: **1,197 passed / 0 failed**
- focused hostile plugin probes: external secret fetch **not invoked**; override conflict retained; plugin platform recognized; 3-second non-daemon stdout/stderr canaries absent
- cold in-process probe: registry generation, names, aliases, plugin manager/cache all preserved
- fresh-HOME process audit: **0 writes**, HOME absent, stderr empty, parseable JSON, `session_search` visible
- invalid-platform live audit: human/JSON both exit **2**; human output contains no raw ESC, JSON is parseable `unknown_platform` with empty stderr, **0 writes**
- static: Ruff exit 0, compileall pass, targeted `ty` pass, `git diff --check` pass
- canonical full suite: **17 failures across 12 files** (nonzero; not reported as green)
- exact clean-base comparator reproduced the 16 deterministic failures, and the remaining tool-activity heartbeat timing failure reproduced on the fifth isolated clean-base run
- deterministic candidate-only regressions: **0**
- exact candidate identity: `176e93d66c95d14203ac9d401dab52c71e09bc3a56424e2ad21c95ee52affcc8`
- exact runtime/concurrency review: **PASS**
- exact CLI/security review: **PASS**

The full-suite failures are existing macOS/environment/timing failures and are not reported as green.
