### PR TITLE
fix(desktop): keep custom provider model selections

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -790,7 +790,54 @@ def _normalize_main_model_assignment(provider: str, model: str) -> tuple[str, st
     model_in = (model or "").strip()
     canonical = normalize_provider(prov_in)
 
-    if canonical not in _KNOWN_PROVIDER_NAMES and "/" in model_in:
+    def _is_user_configured_provider() -> bool:
+        """Return True for provider ids owned by config.yaml, not analytics."""
+        prov_norm = prov_in.lower()
+        if prov_norm in {"custom", "local"} or prov_norm.startswith("custom:"):
+            return True
+        try:
+            cfg = load_config()
+        except Exception:
+            return False
+        user_providers = cfg.get("providers")
+        if isinstance(user_providers, dict):
+            for name, entry in user_providers.items():
+                if str(name).strip().lower() != prov_norm:
+                    continue
+                if not isinstance(entry, dict):
+                    continue
+                if (
+                    str(entry.get("base_url") or "").strip()
+                    or str(entry.get("api") or "").strip()
+                    or str(entry.get("url") or "").strip()
+                ):
+                    return True
+        custom_providers = cfg.get("custom_providers")
+        if isinstance(custom_providers, list):
+            try:
+                from hermes_cli.providers import custom_provider_slug
+            except Exception:
+                custom_provider_slug = None
+            for entry in custom_providers:
+                if not isinstance(entry, dict):
+                    continue
+                display_name = str(entry.get("name") or "").strip()
+                if not display_name:
+                    continue
+                names = {display_name.lower()}
+                if custom_provider_slug is not None:
+                    names.add(custom_provider_slug(display_name).lower())
+                if prov_norm in names:
+                    return True
+        return False
+
+    is_user_configured_provider = _is_user_configured_provider()
+
+    if (
+        not is_user_configured_provider
+        and canonical not in _KNOWN_PROVIDER_NAMES
+        and "/" in model_in
+    ):
         # Vendor prefix posing as a provider (analytics fallback). Resolve
         # against the user's current provider when it's an aggregator that
         # serves vendor-prefixed slugs; otherwise default to openrouter.
@@ -812,7 +859,11 @@ def _normalize_main_model_assignment(provider: str, model: str) -> tuple[str, st
 
     # Custom/user-config providers keep the model verbatim — the registry
     # normalizer doesn't know their namespaces.
-    if canonical in _KNOWN_PROVIDER_NAMES and not canonical.startswith("custom"):
+    if (
+        not is_user_configured_provider
+        and canonical in _KNOWN_PROVIDER_NAMES
+        and not canonical.startswith("custom")
+    ):
         try:
             normalized_model = normalize_model_for_provider(model_in, canonical)
             if normalized_model:

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -1275,6 +1275,40 @@ class TestWebServerEndpoints:
         assert cfg["model"]["provider"] == "anthropic"
         assert cfg["model"]["default"] == "claude-opus-4-6"
 
+    def test_model_set_normalizes_native_provider_with_metadata_config(self, monkeypatch):
+        """providers.<name> metadata must not turn built-ins into custom endpoints."""
+        monkeypatch.setattr(
+            "hermes_cli.model_cost_guard.expensive_model_warning",
+            lambda *_args, **_kwargs: None,
+        )
+        from hermes_cli.config import load_config, save_config
+
+        cfg = load_config()
+        cfg["providers"] = {
+            "anthropic": {
+                "request_timeout_seconds": 60,
+                "models": {
+                    "claude-opus-4-6": {"context_length": 200000},
+                },
+            }
+        }
+        save_config(cfg)
+
+        resp = self.client.post(
+            "/api/model/set",
+            json={
+                "scope": "main",
+                "provider": "anthropic",
+                "model": "anthropic/claude-opus-4.6",
+            },
+        )
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["ok"] is True
+        assert data["provider"] == "anthropic"
+        assert data["model"] == "claude-opus-4-6"
+
     def test_model_set_maps_unknown_vendor_to_aggregator(self, monkeypatch):
         """A bare vendor name from analytics rows (no billing_provider) is not
         a Hermes provider — keep the user's aggregator instead of writing a
@@ -1301,6 +1335,51 @@ class TestWebServerEndpoints:
         assert data["ok"] is True
         assert data["provider"] == "openrouter"
         assert data["model"] == "moonshotai/kimi-k2.6"
+
+    def test_model_set_keeps_custom_provider_with_slash_model(self, monkeypatch):
+        """Saved custom providers can serve aggregator-style model ids.
+
+        Settings → Model posts the selected custom provider slug from
+        /api/model/options. That must not be mistaken for the analytics
+        vendor fallback path just because the model id contains a slash.
+        """
+        monkeypatch.setattr(
+            "hermes_cli.model_cost_guard.expensive_model_warning",
+            lambda *_args, **_kwargs: None,
+        )
+        from hermes_cli.config import load_config, save_config
+
+        custom_slug = "custom:omni-(localhost:20128)"
+        cfg = load_config()
+        cfg["custom_providers"] = [
+            {
+                "name": "omni (localhost:20128)",
+                "base_url": "http://localhost:20128/v1",
+                "api_key": "sk-0",
+                "model": "oc/big-pickle",
+                "models": {"tllm/GPT_5_4": {"context_length": 120000}},
+            }
+        ]
+        save_config(cfg)
+
+        resp = self.client.post(
+            "/api/model/set",
+            json={
+                "scope": "main",
+                "provider": custom_slug,
+                "model": "tllm/GPT_5_4",
+            },
+        )
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["ok"] is True
+        assert data["provider"] == custom_slug
+        assert data["model"] == "tllm/GPT_5_4"
+
+        updated = load_config()
+        assert updated["model"]["provider"] == custom_slug
+        assert updated["model"]["default"] == "tllm/GPT_5_4"
 
     def test_model_set_keeps_aggregator_slug_unchanged(self, monkeypatch):
         """The happy path (picker → openrouter + vendor/model) is untouched."""


### PR DESCRIPTION
Fixes #47961

## Summary
- Keep saved custom provider selections intact when their model ids contain vendor-style slashes.
- Limit the desktop model-set vendor fallback to real analytics fallback providers, not config.yaml custom routes.
- Preserve native provider model normalization when providers.<name> only contains metadata such as timeouts or model overrides.

## Tests
- scripts/run_tests.sh tests/hermes_cli/test_web_server.py -- -k "model_set_normalizes_vendor_slug_for_native_provider or model_set_normalizes_native_provider_with_metadata_config or model_set_maps_unknown_vendor_to_aggregator or model_set_keeps_custom_provider_with_slash_model or model_set_keeps_aggregator_slug_unchanged"
- scripts/run_tests.sh tests/hermes_cli/test_timeouts.py tests/hermes_cli/test_web_server.py -- -k "timeout or model_set_normalizes_native_provider_with_metadata_config or model_set_keeps_custom_provider_with_slash_model"
- env -i PATH=$PATH HOME=$HOME TZ=UTC LANG=C.UTF-8 LC_ALL=C.UTF-8 PYTHONHASHSEED=0 PYTHONDONTWRITEBYTECODE=1 /Users/tushaokun/.hermes/hermes-agent/venv/bin/python -m pytest tests/hermes_cli/test_model_switch_custom_providers.py::test_custom_providers_uses_live_models_for_multi_model_endpoint tests/hermes_cli/test_model_switch_custom_providers.py::test_custom_providers_discover_models_false_keeps_explicit_subset
- env -i PATH=$PATH HOME=$HOME TZ=UTC LANG=C.UTF-8 LC_ALL=C.UTF-8 PYTHONHASHSEED=0 PYTHONDONTWRITEBYTECODE=1 /Users/tushaokun/.hermes/hermes-agent/venv/bin/python -m py_compile hermes_cli/web_server.py tests/hermes_cli/test_web_server.py
- git diff --check HEAD~1..HEAD