### PR TITLE
feat: add semantic index staging tool

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1105,6 +1105,15 @@ DEFAULT_CONFIG = {
         "dimensions": 0,          # optional OpenAI embeddings dimensions override; 0 => provider default
     },
 
+    "codebase_index": {
+        "path": "",              # local LanceDB path; empty => semantic_index.path or HERMES_HOME/semantic/lancedb
+        "table": "codebase_chunks",
+        "model": "text-embedding-3-small",
+        "dimensions": 0,          # optional OpenAI embeddings dimensions override; 0 => provider default
+        "max_file_bytes": 200000,
+        "max_chunk_chars": 6000,
+    },
+
     "browser": {
         "inactivity_timeout": 120,
         "command_timeout": 30,  # Timeout for browser commands in seconds (screenshot, navigate, etc.)

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1098,6 +1098,13 @@ DEFAULT_CONFIG = {
         "extract_backend": "",   # per-capability override for web_extract (e.g. "native")
     },
 
+    "semantic_index": {
+        "path": "",              # local LanceDB path; empty => HERMES_HOME/semantic/lancedb
+        "table": "semantic_chunks",
+        "model": "text-embedding-3-small",
+        "dimensions": 0,          # optional OpenAI embeddings dimensions override; 0 => provider default
+    },
+
     "browser": {
         "inactivity_timeout": 120,
         "command_timeout": 30,  # Timeout for browser commands in seconds (screenshot, navigate, etc.)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -154,6 +154,7 @@ edge-tts = ["edge-tts==7.2.7"]
 modal = ["modal==1.3.4"]
 daytona = ["daytona==0.155.0"]
 hindsight = ["hindsight-client==0.6.1"]
+semantic = ["lancedb==0.33.0"]
 dev = ["debugpy==1.8.20", "pytest==9.0.2", "pytest-asyncio==1.3.0", "mcp==1.26.0", "starlette==1.0.1", "ty==0.0.21", "ruff==0.15.10", "setuptools==81.0.0"]  # starlette: CVE-2026-48710; setuptools: latest <82 (torch >=2.11 caps setuptools<82)
 messaging = ["python-telegram-bot[webhooks]==22.6", "discord.py[voice]==2.7.1", "aiohttp==3.13.4", "brotlicffi==1.2.0.1", "slack-bolt==1.27.0", "slack-sdk==3.40.1", "qrcode==7.4.2"]  # aiohttp: CVE-2026-34513/34518/34519/34520/34525
 cron = []  # croniter is now a core dependency; this extra kept for back-compat

--- a/tests/tools/test_codebase_index.py
+++ b/tests/tools/test_codebase_index.py
@@ -1,0 +1,320 @@
+import json
+import re
+from types import SimpleNamespace
+
+from tools.codebase_index_tool import (
+    CODEBASE_INDEX_SCHEMA,
+    CODEBASE_SEARCH_SCHEMA,
+    codebase_index,
+    codebase_search,
+)
+
+
+class _FakeEmbeddings:
+    def __init__(self):
+        self.calls = []
+
+    def create(self, **kwargs):
+        self.calls.append(kwargs)
+        inputs = kwargs["input"]
+        vectors = []
+        for index, text in enumerate(inputs):
+            base = float(len(text) % 10)
+            vectors.append(SimpleNamespace(index=index, embedding=[base, 1.0, 0.5]))
+        return SimpleNamespace(
+            data=vectors,
+            usage=SimpleNamespace(prompt_tokens=len(inputs), total_tokens=len(inputs)),
+        )
+
+
+class _FakeOpenAI:
+    embeddings = _FakeEmbeddings()
+
+    def __init__(self, **kwargs):
+        self.kwargs = kwargs
+
+
+class _FakeSearch:
+    def __init__(self, rows):
+        self.rows = rows
+        self.n = 5
+
+    def limit(self, n):
+        self.n = n
+        return self
+
+    def to_list(self):
+        return [dict(row, _distance=0.1) for row in self.rows[: self.n]]
+
+
+class _FakeTable:
+    def __init__(self, rows=None):
+        self.rows = list(rows or [])
+
+    def add(self, rows):
+        self.rows.extend(rows)
+
+    def count_rows(self):
+        return len(self.rows)
+
+    def head(self, n):
+        return [dict(row) for row in self.rows[:n]]
+
+    def search(self, _vector):
+        return _FakeSearch(self.rows)
+
+    def limit(self, n):
+        return _FakeSearch(self.rows).limit(n)
+
+    def delete(self, predicate):
+        repo_match = re.search(r"repo_id = '([^']+)'", predicate)
+        path_match = re.search(r"path = '([^']+)'", predicate)
+        repo_id = repo_match.group(1) if repo_match else None
+        path = path_match.group(1) if path_match else None
+        self.rows = [
+            row
+            for row in self.rows
+            if not (
+                (repo_id is None or row.get("repo_id") == repo_id)
+                and (path is None or row.get("path") == path)
+            )
+        ]
+
+
+class _FakeDB:
+    def __init__(self):
+        self.tables = {}
+
+    def table_names(self):
+        return list(self.tables)
+
+    def open_table(self, name):
+        return self.tables[name]
+
+    def create_table(self, name, data):
+        table = _FakeTable(data)
+        self.tables[name] = table
+        return table
+
+
+class _FakeLanceDB:
+    def __init__(self):
+        self.dbs = {}
+
+    def connect(self, path):
+        return self.dbs.setdefault(path, _FakeDB())
+
+
+def _write_sample_repo(tmp_path, text=None):
+    source = text or '''
+"""sample module"""
+
+import os
+
+
+def greet(name):
+    return f"hello {name}"
+
+
+class Worker:
+    def run(self):
+        return "semantic codebase search"
+'''
+    path = tmp_path / "app.py"
+    path.write_text(source.strip() + "\n")
+    (tmp_path / "README.md").write_text("# Search Notes\n\nLanceDB stores code chunks.\n")
+    return tmp_path
+
+
+def test_codebase_index_schema_exposes_safe_actions():
+    params = CODEBASE_INDEX_SCHEMA["parameters"]["properties"]
+    assert params["action"]["enum"] == ["dry_run", "index", "stats"]
+    assert params["embed"]["default"] is False
+    assert CODEBASE_SEARCH_SCHEMA["parameters"]["properties"]["mode"]["default"] == "hybrid"
+
+
+def test_codebase_index_dry_run_chunks_python_and_markdown(tmp_path):
+    root = _write_sample_repo(tmp_path)
+    result = json.loads(
+        codebase_index(
+            root=str(root),
+            scope="repo",
+            max_files=10,
+            max_chunks=20,
+            db_path=str(tmp_path / "db"),
+        )
+    )
+    assert result["success"] is True
+    assert result["would_call_openai"] is False
+    assert result["chunk_count"] >= 3
+    kinds = {chunk["chunk_kind"] for chunk in result["sample_chunks"]}
+    assert {"module_context", "function"} & kinds
+
+
+def test_codebase_index_requires_explicit_embed_true(tmp_path):
+    root = _write_sample_repo(tmp_path)
+    result = json.loads(
+        codebase_index(
+            action="index",
+            root=str(root),
+            scope="paths",
+            paths=["app.py"],
+            db_path=str(tmp_path / "db"),
+        )
+    )
+    assert result["success"] is False
+    assert "embed=true" in result["error"]
+
+
+def test_codebase_index_embeds_rows_and_stats_hides_vectors(tmp_path, monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+    root = _write_sample_repo(tmp_path)
+    fake_lancedb = _FakeLanceDB()
+
+    result = json.loads(
+        codebase_index(
+            action="index",
+            embed=True,
+            root=str(root),
+            scope="paths",
+            paths=["app.py"],
+            db_path=str(tmp_path / "db"),
+            lancedb_module=fake_lancedb,
+            openai_client_cls=_FakeOpenAI,
+        )
+    )
+    assert result["success"] is True
+    assert result["stored_chunk_count"] >= 2
+    assert result["dimensions"] == 3
+    assert result["row_count"] == result["stored_chunk_count"]
+
+    stats = json.loads(
+        codebase_index(
+            action="stats",
+            db_path=str(tmp_path / "db"),
+            lancedb_module=fake_lancedb,
+        )
+    )
+    assert stats["table_exists"] is True
+    assert "vector" not in stats["sample"][0]
+    assert stats["sample"][0]["vector_dimensions"] == 3
+
+
+def test_codebase_index_deletes_stale_rows_for_reindexed_paths(tmp_path, monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+    root = _write_sample_repo(tmp_path, "def alpha():\n    return 'old'\n")
+    fake_lancedb = _FakeLanceDB()
+
+    first = json.loads(
+        codebase_index(
+            action="index",
+            embed=True,
+            root=str(root),
+            scope="paths",
+            paths=["app.py"],
+            db_path=str(tmp_path / "db"),
+            lancedb_module=fake_lancedb,
+            openai_client_cls=_FakeOpenAI,
+        )
+    )
+    (tmp_path / "app.py").write_text("def beta():\n    return 'new semantic body'\n")
+    second = json.loads(
+        codebase_index(
+            action="index",
+            embed=True,
+            root=str(root),
+            scope="paths",
+            paths=["app.py"],
+            db_path=str(tmp_path / "db"),
+            lancedb_module=fake_lancedb,
+            openai_client_cls=_FakeOpenAI,
+        )
+    )
+    assert first["row_count"] == first["stored_chunk_count"]
+    assert second["row_count"] == second["stored_chunk_count"]
+
+
+def test_codebase_index_deletes_rows_for_deleted_paths(tmp_path, monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+    root = _write_sample_repo(tmp_path, "def alpha():\n    return 'old'\n")
+    fake_lancedb = _FakeLanceDB()
+
+    first = json.loads(
+        codebase_index(
+            action="index",
+            embed=True,
+            root=str(root),
+            scope="paths",
+            paths=["app.py"],
+            db_path=str(tmp_path / "db"),
+            lancedb_module=fake_lancedb,
+            openai_client_cls=_FakeOpenAI,
+        )
+    )
+    (tmp_path / "app.py").unlink()
+    second = json.loads(
+        codebase_index(
+            action="index",
+            embed=True,
+            root=str(root),
+            scope="paths",
+            paths=["app.py"],
+            db_path=str(tmp_path / "db"),
+            lancedb_module=fake_lancedb,
+            openai_client_cls=_FakeOpenAI,
+        )
+    )
+    assert first["row_count"] > 0
+    assert second["stored_chunk_count"] == 0
+    assert second["row_count"] == 0
+
+
+def test_codebase_search_hybrid_falls_back_to_keyword(tmp_path):
+    root = _write_sample_repo(tmp_path)
+    result = json.loads(
+        codebase_search(
+            query="where is LanceDB mentioned",
+            root=str(root),
+            mode="hybrid",
+            paths=["README.md"],
+            db_path=str(tmp_path / "missing-db"),
+            max_files=10,
+            max_chunks=20,
+        )
+    )
+    assert result["success"] is True
+    assert result["semantic_available"] is False
+    assert result["semantic_error"]
+    assert result["results"][0]["path"] == "README.md"
+
+
+def test_codebase_search_semantic_returns_indexed_rows(tmp_path, monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+    root = _write_sample_repo(tmp_path)
+    fake_lancedb = _FakeLanceDB()
+    json.loads(
+        codebase_index(
+            action="index",
+            embed=True,
+            root=str(root),
+            scope="paths",
+            paths=["app.py"],
+            db_path=str(tmp_path / "db"),
+            lancedb_module=fake_lancedb,
+            openai_client_cls=_FakeOpenAI,
+        )
+    )
+    result = json.loads(
+        codebase_search(
+            query="semantic codebase search worker",
+            root=str(root),
+            mode="semantic",
+            db_path=str(tmp_path / "db"),
+            lancedb_module=fake_lancedb,
+            openai_client_cls=_FakeOpenAI,
+        )
+    )
+    assert result["success"] is True
+    assert result["count"] >= 1
+    assert result["results"][0]["path"] == "app.py"
+    assert result["results"][0]["vector_dimensions"] == 3

--- a/tests/tools/test_semantic_index.py
+++ b/tests/tools/test_semantic_index.py
@@ -1,0 +1,171 @@
+import json
+from types import SimpleNamespace
+
+from tools.semantic_index_tool import SEMANTIC_INDEX_SCHEMA, semantic_index
+
+
+class _FakeEmbeddings:
+    def __init__(self):
+        self.calls = []
+
+    def create(self, **kwargs):
+        self.calls.append(kwargs)
+        text = kwargs["input"][0]
+        base = float(len(text) % 10)
+        vector = [base, 1.0, 0.5]
+        return SimpleNamespace(
+            data=[SimpleNamespace(index=0, embedding=vector)],
+            usage=SimpleNamespace(prompt_tokens=4, total_tokens=4),
+        )
+
+
+class _FakeOpenAI:
+    embeddings = _FakeEmbeddings()
+
+    def __init__(self, **kwargs):
+        self.kwargs = kwargs
+
+
+class _FakeSearch:
+    def __init__(self, rows):
+        self.rows = rows
+        self.n = 5
+
+    def limit(self, n):
+        self.n = n
+        return self
+
+    def to_list(self):
+        return [dict(row, _distance=0.0) for row in self.rows[: self.n]]
+
+
+class _FakeTable:
+    def __init__(self, rows=None):
+        self.rows = list(rows or [])
+
+    def add(self, rows):
+        self.rows.extend(rows)
+
+    def count_rows(self):
+        return len(self.rows)
+
+    def head(self, n):
+        return [dict(row) for row in self.rows[:n]]
+
+    def search(self, _vector):
+        return _FakeSearch(self.rows)
+
+    def limit(self, n):
+        return _FakeSearch(self.rows).limit(n)
+
+
+class _FakeDB:
+    def __init__(self):
+        self.tables = {}
+
+    def table_names(self):
+        return list(self.tables)
+
+    def open_table(self, name):
+        return self.tables[name]
+
+    def create_table(self, name, data):
+        table = _FakeTable(data)
+        self.tables[name] = table
+        return table
+
+
+class _FakeLanceDB:
+    def __init__(self):
+        self.dbs = {}
+
+    def connect(self, path):
+        return self.dbs.setdefault(path, _FakeDB())
+
+
+def test_schema_exposes_safe_first_stage_actions():
+    params = SEMANTIC_INDEX_SCHEMA["parameters"]["properties"]
+    assert params["action"]["enum"] == ["dry_run", "stage", "query", "stats"]
+    assert params["embed"]["default"] is False
+    assert "payload" in params
+
+
+def test_dry_run_does_not_require_embedding_or_lancedb(tmp_path):
+    result = json.loads(semantic_index(payload="hello semantic world", db_path=str(tmp_path)))
+    assert result["success"] is True
+    assert result["action"] == "dry_run"
+    assert result["would_call_openai"] is False
+    assert result["would_write_lancedb"] is False
+    assert result["payload"]["char_count"] == len("hello semantic world")
+
+
+def test_stage_requires_explicit_embed_true(tmp_path):
+    result = json.loads(semantic_index(action="stage", payload="hello", db_path=str(tmp_path)))
+    assert result["success"] is False
+    assert "embed=true" in result["error"]
+
+
+def test_stage_refuses_secret_like_payload(tmp_path, monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+    result = json.loads(semantic_index(
+        action="stage",
+        embed=True,
+        payload="OPENAI_API_KEY=sk-supersecretvalue1234567890",
+        db_path=str(tmp_path),
+        lancedb_module=_FakeLanceDB(),
+        openai_client_cls=_FakeOpenAI,
+    ))
+    assert result["success"] is False
+    assert "credentials" in result["error"]
+
+
+def test_stage_embeds_and_writes_lancedb(tmp_path, monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+    fake_lancedb = _FakeLanceDB()
+    result = json.loads(semantic_index(
+        action="stage",
+        embed=True,
+        payload="tiny payload for vector storage",
+        corpus="manual",
+        uri="manual://tiny",
+        db_path=str(tmp_path),
+        lancedb_module=fake_lancedb,
+        openai_client_cls=_FakeOpenAI,
+    ))
+    assert result["success"] is True
+    assert result["dimensions"] == 3
+    assert result["row_count"] == 1
+    assert result["record"]["uri"] == "manual://tiny"
+
+    stats = json.loads(semantic_index(
+        action="stats",
+        db_path=str(tmp_path),
+        lancedb_module=fake_lancedb,
+    ))
+    assert stats["table_exists"] is True
+    assert stats["row_count"] == 1
+    assert stats["sample"][0]["vector_dimensions"] == 3
+
+
+def test_query_embeds_query_and_returns_vector_db_rows(tmp_path, monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+    fake_lancedb = _FakeLanceDB()
+    json.loads(semantic_index(
+        action="stage",
+        embed=True,
+        payload="find me with semantic query",
+        db_path=str(tmp_path),
+        lancedb_module=fake_lancedb,
+        openai_client_cls=_FakeOpenAI,
+    ))
+    result = json.loads(semantic_index(
+        action="query",
+        query="semantic query",
+        db_path=str(tmp_path),
+        lancedb_module=fake_lancedb,
+        openai_client_cls=_FakeOpenAI,
+    ))
+    assert result["success"] is True
+    assert result["count"] == 1
+    assert result["results"][0]["vector_dimensions"] == 3
+    assert "semantic query" in result["results"][0]["text_preview"]

--- a/tools/codebase_index_tool.py
+++ b/tools/codebase_index_tool.py
@@ -1,0 +1,1431 @@
+#!/usr/bin/env python3
+"""Repo-aware semantic codebase index and hybrid search tools.
+
+The lower-level ``semantic_index`` tool proves LanceDB/OpenAI plumbing for a
+single payload.  This module is the agent-facing layer: discover code files,
+chunk them with stable metadata, embed changed chunks into LanceDB, and search
+with a keyword/semantic hybrid that degrades cleanly when embeddings are not
+available.
+"""
+
+from __future__ import annotations
+
+import ast
+import fnmatch
+import hashlib
+import json
+import logging
+import os
+import re
+import subprocess
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Optional, Sequence, Tuple
+
+from hermes_constants import get_hermes_home
+from tools.semantic_index_tool import (
+    DEFAULT_MODEL,
+    _content_hash,
+    _embedding_dimensions,
+    _embed_openai,
+    _import_lancedb,
+    _preview,
+    _secret_warning,
+    _table_names,
+)
+
+logger = logging.getLogger(__name__)
+
+CODEBASE_CORPUS = "codebase"
+DEFAULT_TABLE = "codebase_chunks"
+CHUNKER_VERSION = "codebase-v1"
+DEFAULT_MAX_FILE_BYTES = 200_000
+DEFAULT_MAX_CHUNK_CHARS = 6_000
+DEFAULT_INDEX_CHUNKS = 500
+DEFAULT_SEARCH_CHUNKS = 5_000
+EMBED_BATCH_SIZE = 64
+
+_EXCLUDE_DIRS = {
+    ".git",
+    ".hermes",
+    ".hg",
+    ".svn",
+    ".cache",
+    ".mypy_cache",
+    ".pytest_cache",
+    ".ruff_cache",
+    ".tox",
+    ".venv",
+    "venv",
+    "__pycache__",
+    "node_modules",
+    "dist",
+    "build",
+    "coverage",
+    ".next",
+    ".turbo",
+}
+
+_LANGUAGE_BY_EXT = {
+    ".py": "python",
+    ".md": "markdown",
+    ".rst": "rst",
+    ".txt": "text",
+    ".toml": "toml",
+    ".yaml": "yaml",
+    ".yml": "yaml",
+    ".json": "json",
+    ".jsonl": "jsonl",
+    ".js": "javascript",
+    ".jsx": "javascript",
+    ".ts": "typescript",
+    ".tsx": "typescript",
+    ".css": "css",
+    ".html": "html",
+    ".sh": "shell",
+    ".bash": "shell",
+    ".zsh": "shell",
+    ".go": "go",
+    ".rs": "rust",
+    ".java": "java",
+    ".c": "c",
+    ".cc": "cpp",
+    ".cpp": "cpp",
+    ".h": "c",
+    ".hpp": "cpp",
+    ".sql": "sql",
+}
+
+_SPECIAL_TEXT_NAMES = {
+    "AGENTS.md",
+    "CLAUDE.md",
+    "README",
+    "LICENSE",
+    "NOTICE",
+    "Makefile",
+    "Dockerfile",
+}
+
+
+@dataclass(frozen=True)
+class CodeChunk:
+    path: str
+    language: str
+    chunk_kind: str
+    symbol: str
+    start_line: int
+    end_line: int
+    text: str
+
+    @property
+    def content_hash(self) -> str:
+        return _content_hash(self.text)
+
+
+def _json(data: Dict[str, Any]) -> str:
+    return json.dumps(data, ensure_ascii=False)
+
+
+def _load_config() -> Dict[str, Any]:
+    try:
+        from hermes_cli.config import load_config
+
+        return load_config() or {}
+    except Exception:
+        logger.debug("codebase index config load failed", exc_info=True)
+        return {}
+
+
+def _codebase_config() -> Dict[str, Any]:
+    return dict(_load_config().get("codebase_index") or {})
+
+
+def _semantic_config() -> Dict[str, Any]:
+    return dict(_load_config().get("semantic_index") or {})
+
+
+def _db_path(path_override: Optional[str] = None) -> Path:
+    if path_override and str(path_override).strip():
+        return Path(path_override).expanduser()
+    cfg = _codebase_config()
+    cfg_path = str(cfg.get("path") or "").strip()
+    if cfg_path:
+        return Path(cfg_path).expanduser()
+    semantic_path = str(_semantic_config().get("path") or "").strip()
+    if semantic_path:
+        return Path(semantic_path).expanduser()
+    return get_hermes_home() / "semantic" / "lancedb"
+
+
+def _table_name(table: Optional[str] = None) -> str:
+    raw = str(table or _codebase_config().get("table") or DEFAULT_TABLE).strip()
+    if not raw:
+        return DEFAULT_TABLE
+    return re.sub(r"[^A-Za-z0-9_]", "_", raw)[:64] or DEFAULT_TABLE
+
+
+def _embedding_model(model: Optional[str] = None) -> str:
+    raw = str(
+        model
+        or _codebase_config().get("model")
+        or _semantic_config().get("model")
+        or DEFAULT_MODEL
+    ).strip()
+    return raw or DEFAULT_MODEL
+
+
+def _embedding_dims(dimensions: Optional[int] = None) -> Optional[int]:
+    if dimensions is not None:
+        return _embedding_dimensions(dimensions)
+    cfg = _codebase_config()
+    if cfg.get("dimensions") not in (None, "", 0):
+        return _embedding_dimensions(cfg.get("dimensions"))
+    return _embedding_dimensions(_semantic_config().get("dimensions"))
+
+
+def _configured_int(name: str, default: int) -> int:
+    try:
+        value = int(_codebase_config().get(name) or default)
+    except (TypeError, ValueError):
+        return default
+    return value if value > 0 else default
+
+
+def _run_git(root: Path, args: Sequence[str]) -> Optional[str]:
+    try:
+        proc = subprocess.run(
+            ["git", *args],
+            cwd=str(root),
+            text=True,
+            capture_output=True,
+            timeout=10,
+            check=False,
+        )
+    except Exception:
+        return None
+    if proc.returncode != 0:
+        return None
+    return proc.stdout.strip()
+
+
+def _repo_root(root: Optional[str] = None) -> Path:
+    start = Path(root or os.getcwd()).expanduser().resolve()
+    if start.is_file():
+        start = start.parent
+    git_root = _run_git(start, ["rev-parse", "--show-toplevel"])
+    if git_root:
+        return Path(git_root).resolve()
+    return start
+
+
+def _repo_metadata(root: Path) -> Dict[str, str]:
+    commit = _run_git(root, ["rev-parse", "HEAD"]) or ""
+    branch = _run_git(root, ["branch", "--show-current"]) or ""
+    repo_id = hashlib.sha256(str(root).encode("utf-8", errors="replace")).hexdigest()[:16]
+    return {
+        "repo_root": str(root),
+        "repo_id": repo_id,
+        "git_commit": commit,
+        "git_branch": branch,
+    }
+
+
+def _safe_relpath(root: Path, value: str) -> Optional[str]:
+    candidate = (root / value).resolve() if not Path(value).is_absolute() else Path(value).resolve()
+    try:
+        rel = candidate.relative_to(root)
+    except ValueError:
+        return None
+    return rel.as_posix()
+
+
+def _walk_files(root: Path) -> List[str]:
+    paths: List[str] = []
+    for path in root.rglob("*"):
+        if not path.is_file():
+            continue
+        try:
+            rel = path.relative_to(root).as_posix()
+        except ValueError:
+            continue
+        if any(part in _EXCLUDE_DIRS for part in rel.split("/")):
+            continue
+        paths.append(rel)
+    return sorted(paths)
+
+
+def _git_files(root: Path, scope: str) -> Optional[List[str]]:
+    if scope == "changed":
+        tracked = _run_git(root, ["diff", "--name-only", "HEAD"])
+        staged = _run_git(root, ["diff", "--name-only", "--cached"])
+        untracked = _run_git(root, ["ls-files", "--others", "--exclude-standard"])
+        if tracked is None and staged is None and untracked is None:
+            return None
+        names = set()
+        for text in (tracked, staged, untracked):
+            if text:
+                names.update(line.strip() for line in text.splitlines() if line.strip())
+        return sorted(names)
+
+    tracked = _run_git(root, ["ls-files", "--cached", "--others", "--exclude-standard"])
+    if tracked is None:
+        return None
+    return sorted(line.strip() for line in tracked.splitlines() if line.strip())
+
+
+def _candidate_paths(
+    *,
+    root: Path,
+    scope: str,
+    paths: Optional[Sequence[str]],
+) -> Tuple[List[str], List[str]]:
+    skipped: List[str] = []
+    if scope == "paths":
+        resolved = []
+        seen = set()
+        for raw in paths or []:
+            rel = _safe_relpath(root, str(raw))
+            if rel is None:
+                skipped.append(f"{raw}: outside repo root")
+            elif rel not in seen:
+                seen.add(rel)
+                resolved.append(rel)
+        return resolved, skipped
+
+    files = _git_files(root, scope)
+    if files is None:
+        files = _walk_files(root)
+    return sorted(set(files)), skipped
+
+
+def _matches_any(path: str, patterns: Optional[Sequence[str]]) -> bool:
+    return bool(patterns) and any(fnmatch.fnmatch(path, pattern) for pattern in patterns or [])
+
+
+def _looks_textual(data: bytes) -> bool:
+    if b"\x00" in data:
+        return False
+    if not data:
+        return True
+    sample = data[:4096]
+    control = sum(1 for b in sample if b < 32 and b not in (9, 10, 12, 13))
+    return control / max(1, len(sample)) < 0.10
+
+
+def _read_text_file(path: Path, max_file_bytes: int) -> Tuple[Optional[str], Optional[str]]:
+    try:
+        stat = path.stat()
+    except OSError as exc:
+        return None, f"stat failed: {exc}"
+    if stat.st_size > max_file_bytes:
+        return None, f"too large: {stat.st_size} bytes > {max_file_bytes}"
+    try:
+        data = path.read_bytes()
+    except OSError as exc:
+        return None, f"read failed: {exc}"
+    if not _looks_textual(data):
+        return None, "binary-looking content"
+    return data.decode("utf-8", errors="replace"), None
+
+
+def _language_for_path(path: str) -> str:
+    rel = Path(path)
+    if rel.name in _SPECIAL_TEXT_NAMES:
+        if rel.suffix == ".md":
+            return "markdown"
+        return "text"
+    return _LANGUAGE_BY_EXT.get(rel.suffix.lower(), "text")
+
+
+def _is_indexable_path(
+    *,
+    rel_path: str,
+    abs_path: Path,
+    include_globs: Optional[Sequence[str]],
+    exclude_globs: Optional[Sequence[str]],
+) -> Tuple[bool, Optional[str]]:
+    parts = rel_path.split("/")
+    if any(part in _EXCLUDE_DIRS for part in parts):
+        return False, "excluded directory"
+    if include_globs and not _matches_any(rel_path, include_globs):
+        return False, "does not match include_globs"
+    if _matches_any(rel_path, exclude_globs):
+        return False, "matches exclude_globs"
+    if not abs_path.exists() or not abs_path.is_file():
+        return False, "not a file"
+    return True, None
+
+
+def _line_slice(lines: List[str], start_line: int, end_line: int) -> str:
+    return "\n".join(lines[start_line - 1 : end_line]).strip()
+
+
+def _split_by_chars(
+    *,
+    rel_path: str,
+    language: str,
+    chunk_kind: str,
+    symbol: str,
+    start_line: int,
+    text: str,
+    max_chunk_chars: int,
+) -> List[CodeChunk]:
+    lines = text.splitlines()
+    chunks: List[CodeChunk] = []
+    current: List[str] = []
+    current_start = start_line
+    current_len = 0
+    for idx, line in enumerate(lines, start=start_line):
+        extra = len(line) + 1
+        if current and current_len + extra > max_chunk_chars:
+            chunks.append(
+                CodeChunk(
+                    path=rel_path,
+                    language=language,
+                    chunk_kind=chunk_kind,
+                    symbol=symbol,
+                    start_line=current_start,
+                    end_line=idx - 1,
+                    text="\n".join(current).strip(),
+                )
+            )
+            current = []
+            current_start = idx
+            current_len = 0
+        current.append(line)
+        current_len += extra
+    if current:
+        chunks.append(
+            CodeChunk(
+                path=rel_path,
+                language=language,
+                chunk_kind=chunk_kind,
+                symbol=symbol,
+                start_line=current_start,
+                end_line=start_line + len(lines) - 1,
+                text="\n".join(current).strip(),
+            )
+        )
+    return [chunk for chunk in chunks if chunk.text]
+
+
+def _node_start(node: ast.AST) -> int:
+    decorators = getattr(node, "decorator_list", None) or []
+    lines = [getattr(node, "lineno", 1)]
+    lines.extend(getattr(item, "lineno", lines[0]) for item in decorators)
+    return max(1, min(lines))
+
+
+def _python_chunks(rel_path: str, text: str, max_chunk_chars: int) -> List[CodeChunk]:
+    lines = text.splitlines()
+    try:
+        tree = ast.parse(text)
+    except SyntaxError:
+        return _fallback_chunks(rel_path, "python", text, max_chunk_chars)
+
+    chunks: List[CodeChunk] = []
+    leading_end = 0
+    for node in tree.body:
+        is_doc = (
+            isinstance(node, ast.Expr)
+            and isinstance(getattr(node, "value", None), ast.Constant)
+            and isinstance(getattr(node.value, "value", None), str)
+        )
+        if is_doc or isinstance(node, (ast.Import, ast.ImportFrom)):
+            leading_end = max(leading_end, getattr(node, "end_lineno", getattr(node, "lineno", 1)))
+            continue
+        break
+    if leading_end:
+        module_text = _line_slice(lines, 1, leading_end)
+        if module_text:
+            chunks.extend(
+                _split_by_chars(
+                    rel_path=rel_path,
+                    language="python",
+                    chunk_kind="module_context",
+                    symbol=Path(rel_path).stem,
+                    start_line=1,
+                    text=module_text,
+                    max_chunk_chars=max_chunk_chars,
+                )
+            )
+
+    for node in tree.body:
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            start = _node_start(node)
+            end = getattr(node, "end_lineno", start)
+            chunks.extend(
+                _split_by_chars(
+                    rel_path=rel_path,
+                    language="python",
+                    chunk_kind="function",
+                    symbol=node.name,
+                    start_line=start,
+                    text=_line_slice(lines, start, end),
+                    max_chunk_chars=max_chunk_chars,
+                )
+            )
+            continue
+        if isinstance(node, ast.ClassDef):
+            start = _node_start(node)
+            end = getattr(node, "end_lineno", start)
+            class_text = _line_slice(lines, start, end)
+            if len(class_text) <= max_chunk_chars:
+                chunks.append(
+                    CodeChunk(rel_path, "python", "class", node.name, start, end, class_text)
+                )
+            else:
+                header_end = start
+                for child in node.body:
+                    if isinstance(child, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                        break
+                    header_end = max(header_end, getattr(child, "end_lineno", header_end))
+                header_text = _line_slice(lines, start, header_end)
+                if header_text:
+                    chunks.append(
+                        CodeChunk(
+                            rel_path,
+                            "python",
+                            "class_context",
+                            node.name,
+                            start,
+                            header_end,
+                            header_text,
+                        )
+                    )
+            for child in node.body:
+                if isinstance(child, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                    method_start = _node_start(child)
+                    method_end = getattr(child, "end_lineno", method_start)
+                    chunks.extend(
+                        _split_by_chars(
+                            rel_path=rel_path,
+                            language="python",
+                            chunk_kind="method",
+                            symbol=f"{node.name}.{child.name}",
+                            start_line=method_start,
+                            text=_line_slice(lines, method_start, method_end),
+                            max_chunk_chars=max_chunk_chars,
+                        )
+                    )
+
+    if not chunks:
+        return _fallback_chunks(rel_path, "python", text, max_chunk_chars)
+    return chunks
+
+
+_HEADING_RE = re.compile(r"^(#{1,6})\s+(.+?)\s*$")
+
+
+def _markdown_chunks(rel_path: str, text: str, max_chunk_chars: int) -> List[CodeChunk]:
+    lines = text.splitlines()
+    starts: List[Tuple[int, str]] = []
+    for idx, line in enumerate(lines, start=1):
+        match = _HEADING_RE.match(line)
+        if match:
+            starts.append((idx, match.group(2).strip()))
+    if not starts:
+        return _fallback_chunks(rel_path, "markdown", text, max_chunk_chars)
+
+    chunks: List[CodeChunk] = []
+    if starts[0][0] > 1:
+        preface = _line_slice(lines, 1, starts[0][0] - 1)
+        chunks.extend(
+            _split_by_chars(
+                rel_path=rel_path,
+                language="markdown",
+                chunk_kind="doc_preface",
+                symbol=Path(rel_path).name,
+                start_line=1,
+                text=preface,
+                max_chunk_chars=max_chunk_chars,
+            )
+        )
+    for index, (start, title) in enumerate(starts):
+        end = starts[index + 1][0] - 1 if index + 1 < len(starts) else len(lines)
+        section = _line_slice(lines, start, end)
+        chunks.extend(
+            _split_by_chars(
+                rel_path=rel_path,
+                language="markdown",
+                chunk_kind="doc_section",
+                symbol=title[:160],
+                start_line=start,
+                text=section,
+                max_chunk_chars=max_chunk_chars,
+            )
+        )
+    return chunks
+
+
+def _fallback_chunks(rel_path: str, language: str, text: str, max_chunk_chars: int) -> List[CodeChunk]:
+    return _split_by_chars(
+        rel_path=rel_path,
+        language=language,
+        chunk_kind="file_chunk",
+        symbol=Path(rel_path).name,
+        start_line=1,
+        text=text,
+        max_chunk_chars=max_chunk_chars,
+    )
+
+
+def _chunk_file(rel_path: str, text: str, max_chunk_chars: int) -> List[CodeChunk]:
+    language = _language_for_path(rel_path)
+    if language == "python":
+        return _python_chunks(rel_path, text, max_chunk_chars)
+    if language == "markdown":
+        return _markdown_chunks(rel_path, text, max_chunk_chars)
+    return _fallback_chunks(rel_path, language, text, max_chunk_chars)
+
+
+def _chunk_id(repo_id: str, chunk: CodeChunk) -> str:
+    raw = (
+        f"{repo_id}\n{chunk.path}\n{chunk.chunk_kind}\n{chunk.symbol}\n"
+        f"{chunk.start_line}:{chunk.end_line}\n{chunk.content_hash}"
+    )
+    return hashlib.sha256(raw.encode("utf-8", errors="replace")).hexdigest()[:32]
+
+
+def _uri(root: Path, chunk: CodeChunk) -> str:
+    return f"file://{root / chunk.path}#L{chunk.start_line}-L{chunk.end_line}"
+
+
+def _record_for_chunk(
+    *,
+    root: Path,
+    repo: Dict[str, str],
+    chunk: CodeChunk,
+    vector: Sequence[float],
+    model: str,
+    provider: str = "openai",
+) -> Dict[str, Any]:
+    return {
+        "id": _chunk_id(repo["repo_id"], chunk),
+        "corpus": CODEBASE_CORPUS,
+        "source_type": "codebase_chunk",
+        "repo_root": repo["repo_root"],
+        "repo_id": repo["repo_id"],
+        "git_commit": repo["git_commit"],
+        "git_branch": repo["git_branch"],
+        "path": chunk.path,
+        "language": chunk.language,
+        "chunk_kind": chunk.chunk_kind,
+        "symbol": chunk.symbol,
+        "start_line": int(chunk.start_line),
+        "end_line": int(chunk.end_line),
+        "uri": _uri(root, chunk),
+        "content_hash": chunk.content_hash,
+        "embedding_provider": provider,
+        "embedding_model": model,
+        "dimensions": len(vector),
+        "text": chunk.text,
+        "metadata_json": json.dumps(
+            {"chunker_version": CHUNKER_VERSION},
+            sort_keys=True,
+            ensure_ascii=False,
+        ),
+        "vector": [float(v) for v in vector],
+        "indexed_at": time.time(),
+    }
+
+
+def _sanitize_row(row: Dict[str, Any], include_text: bool = False) -> Dict[str, Any]:
+    data = dict(row)
+    vector = data.pop("vector", None)
+    text = str(data.get("text") or "")
+    if not include_text:
+        data.pop("text", None)
+    data["text_preview"] = _preview(text, limit=500)
+    data["vector_dimensions"] = len(vector) if hasattr(vector, "__len__") else data.get("dimensions")
+    return data
+
+
+def _collect_chunks(
+    *,
+    root: Path,
+    scope: str,
+    paths: Optional[Sequence[str]],
+    include_globs: Optional[Sequence[str]],
+    exclude_globs: Optional[Sequence[str]],
+    max_files: int,
+    max_chunks: int,
+    max_file_bytes: int,
+    max_chunk_chars: int,
+) -> Dict[str, Any]:
+    candidates, skipped = _candidate_paths(root=root, scope=scope, paths=paths)
+    files_seen = 0
+    chunks: List[CodeChunk] = []
+    skipped_files: List[str] = list(skipped)
+    for rel_path in candidates:
+        abs_path = root / rel_path
+        ok, reason = _is_indexable_path(
+            rel_path=rel_path,
+            abs_path=abs_path,
+            include_globs=include_globs,
+            exclude_globs=exclude_globs,
+        )
+        if not ok:
+            skipped_files.append(f"{rel_path}: {reason}")
+            continue
+        if files_seen >= max_files:
+            skipped_files.append(f"{rel_path}: max_files reached")
+            continue
+        text, read_error = _read_text_file(abs_path, max_file_bytes)
+        if read_error:
+            skipped_files.append(f"{rel_path}: {read_error}")
+            continue
+        files_seen += 1
+        file_chunks = _chunk_file(rel_path, text or "", max_chunk_chars)
+        for chunk in file_chunks:
+            if len(chunks) >= max_chunks:
+                skipped_files.append(f"{rel_path}: max_chunks reached")
+                break
+            chunks.append(chunk)
+    return {
+        "chunks": chunks,
+        "candidate_paths": candidates,
+        "candidate_file_count": len(candidates),
+        "indexed_file_count": files_seen,
+        "skipped_files": skipped_files,
+        "truncated": files_seen >= max_files or len(chunks) >= max_chunks,
+    }
+
+
+def _open_table(db: Any, table_name: str) -> Any:
+    if table_name not in _table_names(db):
+        return None
+    return db.open_table(table_name)
+
+
+def _sql_quote(value: str) -> str:
+    return "'" + value.replace("'", "''") + "'"
+
+
+def _delete_stale_rows(table: Any, repo_id: str, paths: Iterable[str]) -> List[str]:
+    warnings: List[str] = []
+    for path in sorted(set(paths)):
+        predicate = (
+            f"corpus = {_sql_quote(CODEBASE_CORPUS)} AND "
+            f"repo_id = {_sql_quote(repo_id)} AND path = {_sql_quote(path)}"
+        )
+        try:
+            table.delete(predicate)
+        except Exception as exc:
+            warnings.append(f"{path}: stale-row delete failed: {exc}")
+    return warnings
+
+
+def _embed_openai_batch(
+    texts: Sequence[str],
+    *,
+    model: str,
+    dimensions: Optional[int],
+    base_url: Optional[str],
+    api_key: Optional[str],
+    timeout: int,
+    openai_client_cls: Any = None,
+) -> Dict[str, Any]:
+    if not texts:
+        return {"vectors": [], "usage": {"prompt_tokens": 0, "total_tokens": 0}}
+    key = (api_key or os.getenv("OPENAI_API_KEY") or "").strip()
+    if not key:
+        raise RuntimeError("OPENAI_API_KEY is required for codebase indexing")
+
+    if openai_client_cls is None:
+        from openai import OpenAI
+
+        openai_client_cls = OpenAI
+
+    client = openai_client_cls(
+        api_key=key,
+        base_url=(base_url or os.getenv("OPENAI_BASE_URL") or None),
+        timeout=timeout,
+        max_retries=0,
+    )
+    vectors: List[List[float]] = []
+    usage = {"prompt_tokens": 0, "total_tokens": 0}
+    for start in range(0, len(texts), EMBED_BATCH_SIZE):
+        batch = list(texts[start : start + EMBED_BATCH_SIZE])
+        kwargs: Dict[str, Any] = {"model": model, "input": batch}
+        if dimensions:
+            kwargs["dimensions"] = dimensions
+        response = client.embeddings.create(**kwargs)
+        for item in sorted(response.data, key=lambda data: data.index):
+            vectors.append([float(v) for v in item.embedding])
+        response_usage = getattr(response, "usage", None)
+        usage["prompt_tokens"] += int(getattr(response_usage, "prompt_tokens", 0) or 0)
+        usage["total_tokens"] += int(getattr(response_usage, "total_tokens", 0) or 0)
+    return {"vectors": vectors, "usage": usage}
+
+
+def _index_chunks(
+    *,
+    root: Path,
+    repo: Dict[str, str],
+    chunks: Sequence[CodeChunk],
+    stale_paths: Sequence[str],
+    table_name: str,
+    db_path: Path,
+    model: str,
+    dimensions: Optional[int],
+    base_url: Optional[str],
+    api_key: Optional[str],
+    timeout: int,
+    lancedb_module: Any = None,
+    openai_client_cls: Any = None,
+) -> Dict[str, Any]:
+    safe_chunks = []
+    skipped_secret = []
+    for chunk in chunks:
+        warning = _secret_warning(chunk.text)
+        if warning:
+            skipped_secret.append(chunk.path)
+            continue
+        safe_chunks.append(chunk)
+
+    embedded = _embed_openai_batch(
+        [chunk.text for chunk in safe_chunks],
+        model=model,
+        dimensions=dimensions,
+        base_url=base_url,
+        api_key=api_key,
+        timeout=timeout,
+        openai_client_cls=openai_client_cls,
+    )
+    vectors = embedded["vectors"]
+    if len(vectors) != len(safe_chunks):
+        raise RuntimeError(f"embedding count mismatch: got {len(vectors)} for {len(safe_chunks)} chunks")
+
+    records = [
+        _record_for_chunk(root=root, repo=repo, chunk=chunk, vector=vector, model=model)
+        for chunk, vector in zip(safe_chunks, vectors)
+    ]
+    lancedb_module = lancedb_module or _import_lancedb()
+    db_path.mkdir(parents=True, exist_ok=True)
+    db = lancedb_module.connect(str(db_path))
+    table = _open_table(db, table_name)
+    delete_warnings: List[str] = []
+    if table is None:
+        table = db.create_table(table_name, data=records) if records else None
+    else:
+        delete_warnings = _delete_stale_rows(table, repo["repo_id"], stale_paths)
+        if records:
+            table.add(records)
+
+    row_count = int(table.count_rows()) if table is not None else 0
+    return {
+        "records": records,
+        "row_count": row_count,
+        "usage": embedded["usage"],
+        "skipped_secret_count": len(skipped_secret),
+        "delete_warnings": delete_warnings,
+    }
+
+
+def _chunk_summary(repo: Dict[str, str], root: Path, chunk: CodeChunk) -> Dict[str, Any]:
+    return {
+        "id": _chunk_id(repo["repo_id"], chunk),
+        "path": chunk.path,
+        "language": chunk.language,
+        "chunk_kind": chunk.chunk_kind,
+        "symbol": chunk.symbol,
+        "start_line": chunk.start_line,
+        "end_line": chunk.end_line,
+        "char_count": len(chunk.text),
+        "content_hash": chunk.content_hash,
+        "uri": _uri(root, chunk),
+        "text_preview": _preview(chunk.text, limit=320),
+    }
+
+
+def codebase_index(
+    action: str = "dry_run",
+    root: str = None,
+    scope: str = "repo",
+    paths: List[str] = None,
+    include_globs: List[str] = None,
+    exclude_globs: List[str] = None,
+    table: str = None,
+    db_path: str = None,
+    model: str = None,
+    dimensions: int = None,
+    max_files: int = 200,
+    max_chunks: int = DEFAULT_INDEX_CHUNKS,
+    max_file_bytes: int = None,
+    max_chunk_chars: int = None,
+    embed: bool = False,
+    base_url: str = None,
+    api_key: str = None,
+    timeout: int = 60,
+    lancedb_module: Any = None,
+    openai_client_cls: Any = None,
+) -> str:
+    """Dry-run, index, or inspect a repository-level codebase vector table."""
+    action_norm = str(action or "dry_run").strip().lower()
+    if action_norm in {"dryrun", "preview"}:
+        action_norm = "dry_run"
+    if action_norm == "inspect":
+        action_norm = "stats"
+    scope_norm = str(scope or "repo").strip().lower()
+    if scope_norm not in {"repo", "changed", "paths"}:
+        return _json({"success": False, "error": "scope must be one of: repo, changed, paths"})
+
+    repo_root = _repo_root(root)
+    repo = _repo_metadata(repo_root)
+    table_name = _table_name(table)
+    path = _db_path(db_path)
+    model_name = _embedding_model(model)
+    dims = _embedding_dims(dimensions)
+
+    if action_norm == "stats":
+        return _json(_stats(table_name, path, lancedb_module=lancedb_module))
+
+    max_files_int = max(1, int(max_files or 200))
+    max_chunks_int = max(1, int(max_chunks or DEFAULT_INDEX_CHUNKS))
+    max_file_bytes_int = int(max_file_bytes or _configured_int("max_file_bytes", DEFAULT_MAX_FILE_BYTES))
+    max_chunk_chars_int = int(max_chunk_chars or _configured_int("max_chunk_chars", DEFAULT_MAX_CHUNK_CHARS))
+
+    collected = _collect_chunks(
+        root=repo_root,
+        scope=scope_norm,
+        paths=paths,
+        include_globs=include_globs,
+        exclude_globs=exclude_globs,
+        max_files=max_files_int,
+        max_chunks=max_chunks_int,
+        max_file_bytes=max_file_bytes_int,
+        max_chunk_chars=max_chunk_chars_int,
+    )
+    chunks: List[CodeChunk] = collected["chunks"]
+    sample_chunks = [_chunk_summary(repo, repo_root, chunk) for chunk in chunks[:5]]
+
+    if action_norm == "dry_run":
+        return _json(
+            {
+                "success": True,
+                "action": "dry_run",
+                "dry_run": True,
+                "would_call_openai": False,
+                "would_write_lancedb": False,
+                "repo": repo,
+                "scope": scope_norm,
+                "db_path": str(path),
+                "table": table_name,
+                "model": model_name,
+                "dimensions": dims,
+                "candidate_file_count": collected["candidate_file_count"],
+                "indexed_file_count": collected["indexed_file_count"],
+                "chunk_count": len(chunks),
+                "truncated": collected["truncated"],
+                "skipped_files_sample": collected["skipped_files"][:20],
+                "sample_chunks": sample_chunks,
+                "next_step": (
+                    "Call codebase_index(action='index', embed=true, scope=...) "
+                    "to send bounded chunks to OpenAI and store vectors in LanceDB."
+                ),
+            }
+        )
+
+    if action_norm != "index":
+        return _json({"success": False, "error": "Unknown action. Use dry_run, index, or stats."})
+    if not embed:
+        return _json(
+            {
+                "success": False,
+                "error": "index requires embed=true so external OpenAI usage is explicit",
+                "dry_run_hint": "Call codebase_index(action='dry_run', scope=...) first.",
+            }
+        )
+
+    try:
+        indexed = _index_chunks(
+            root=repo_root,
+            repo=repo,
+            chunks=chunks,
+            stale_paths=collected["candidate_paths"],
+            table_name=table_name,
+            db_path=path,
+            model=model_name,
+            dimensions=dims,
+            base_url=base_url,
+            api_key=api_key,
+            timeout=int(timeout or 60),
+            lancedb_module=lancedb_module,
+            openai_client_cls=openai_client_cls,
+        )
+    except Exception as exc:
+        return _json({"success": False, "action": "index", "error": str(exc)})
+
+    return _json(
+        {
+            "success": True,
+            "action": "index",
+            "dry_run": False,
+            "repo": repo,
+            "scope": scope_norm,
+            "db_path": str(path),
+            "table": table_name,
+            "model": model_name,
+            "dimensions": indexed["records"][0]["dimensions"] if indexed["records"] else dims,
+            "candidate_file_count": collected["candidate_file_count"],
+            "indexed_file_count": collected["indexed_file_count"],
+            "chunk_count": len(chunks),
+            "stored_chunk_count": len(indexed["records"]),
+            "row_count": indexed["row_count"],
+            "usage": indexed["usage"],
+            "truncated": collected["truncated"],
+            "skipped_files_sample": collected["skipped_files"][:20],
+            "skipped_secret_count": indexed["skipped_secret_count"],
+            "delete_warnings": indexed["delete_warnings"][:20],
+            "sample_chunks": sample_chunks,
+        }
+    )
+
+
+def _query_tokens(query: str) -> List[str]:
+    return [token for token in re.findall(r"[A-Za-z0-9_./-]+", query.lower()) if len(token) > 1]
+
+
+def _lexical_score(query: str, tokens: Sequence[str], chunk: CodeChunk) -> float:
+    haystack = f"{chunk.path}\n{chunk.symbol}\n{chunk.chunk_kind}\n{chunk.text}".lower()
+    score = 0.0
+    phrase = query.strip().lower()
+    if phrase and phrase in haystack:
+        score += 8.0
+    for token in tokens:
+        count = haystack.count(token)
+        if count:
+            score += min(5.0, float(count))
+        if token in chunk.path.lower():
+            score += 3.0
+        if token in chunk.symbol.lower():
+            score += 4.0
+    return min(1.0, score / 24.0)
+
+
+def _keyword_results(
+    *,
+    root: Path,
+    repo: Dict[str, str],
+    query: str,
+    paths: Optional[Sequence[str]],
+    include_globs: Optional[Sequence[str]],
+    exclude_globs: Optional[Sequence[str]],
+    max_files: int,
+    max_chunks: int,
+    max_file_bytes: int,
+    max_chunk_chars: int,
+) -> Dict[str, Any]:
+    tokens = _query_tokens(query)
+    if not tokens and not query.strip():
+        return {"results": [], "scanned_chunk_count": 0}
+    collected = _collect_chunks(
+        root=root,
+        scope="paths" if paths else "repo",
+        paths=paths,
+        include_globs=include_globs,
+        exclude_globs=exclude_globs,
+        max_files=max_files,
+        max_chunks=max_chunks,
+        max_file_bytes=max_file_bytes,
+        max_chunk_chars=max_chunk_chars,
+    )
+    results = []
+    for chunk in collected["chunks"]:
+        score = _lexical_score(query, tokens, chunk)
+        if score <= 0:
+            continue
+        summary = _chunk_summary(repo, root, chunk)
+        summary.update({"score": score, "keyword_score": score, "match_source": "keyword"})
+        results.append(summary)
+    results.sort(key=lambda item: item["score"], reverse=True)
+    return {"results": results, "scanned_chunk_count": len(collected["chunks"])}
+
+
+def _semantic_results(
+    *,
+    root: Path,
+    repo: Dict[str, str],
+    query: str,
+    table_name: str,
+    db_path: Path,
+    model: str,
+    dimensions: Optional[int],
+    limit: int,
+    base_url: Optional[str],
+    api_key: Optional[str],
+    timeout: int,
+    lancedb_module: Any = None,
+    openai_client_cls: Any = None,
+) -> Dict[str, Any]:
+    lancedb_module = lancedb_module or _import_lancedb()
+    db = lancedb_module.connect(str(db_path))
+    table = _open_table(db, table_name)
+    if table is None:
+        raise RuntimeError(f"table '{table_name}' does not exist")
+
+    embedded = _embed_openai(
+        query,
+        model=model,
+        dimensions=dimensions,
+        base_url=base_url,
+        api_key=api_key,
+        timeout=timeout,
+        openai_client_cls=openai_client_cls,
+    )
+    raw_rows = table.search(embedded["vector"]).limit(max(limit * 5, limit)).to_list()
+    results = []
+    for raw in raw_rows:
+        row = dict(raw)
+        if row.get("corpus") != CODEBASE_CORPUS or row.get("repo_id") != repo["repo_id"]:
+            continue
+        distance = float(row.get("_distance", 0.0) or 0.0)
+        sanitized = _sanitize_row(row)
+        sanitized.update(
+            {
+                "score": 1.0 / (1.0 + max(0.0, distance)),
+                "semantic_score": 1.0 / (1.0 + max(0.0, distance)),
+                "match_source": "semantic",
+            }
+        )
+        results.append(sanitized)
+        if len(results) >= limit:
+            break
+    return {"results": results, "usage": embedded["usage"]}
+
+
+def _merge_hybrid(keyword: Sequence[Dict[str, Any]], semantic: Sequence[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    merged: Dict[str, Dict[str, Any]] = {}
+    for item in keyword:
+        merged[item["id"]] = dict(item)
+    for item in semantic:
+        existing = merged.get(item["id"], {})
+        combined = {**item, **existing}
+        combined["semantic_score"] = float(item.get("semantic_score", 0.0) or 0.0)
+        combined["keyword_score"] = float(existing.get("keyword_score", 0.0) or 0.0)
+        if combined["keyword_score"] and combined["semantic_score"]:
+            combined["match_source"] = "hybrid"
+            combined["score"] = 0.65 * combined["semantic_score"] + 0.35 * combined["keyword_score"]
+        elif combined["semantic_score"]:
+            combined["score"] = combined["semantic_score"]
+            combined["match_source"] = "semantic"
+        else:
+            combined["score"] = combined["keyword_score"]
+            combined["match_source"] = "keyword"
+        merged[item["id"]] = combined
+    return sorted(merged.values(), key=lambda item: item.get("score", 0.0), reverse=True)
+
+
+def codebase_search(
+    query: str,
+    root: str = None,
+    mode: str = "hybrid",
+    paths: List[str] = None,
+    include_globs: List[str] = None,
+    exclude_globs: List[str] = None,
+    table: str = None,
+    db_path: str = None,
+    model: str = None,
+    dimensions: int = None,
+    limit: int = 8,
+    max_files: int = 1000,
+    max_chunks: int = DEFAULT_SEARCH_CHUNKS,
+    max_file_bytes: int = None,
+    max_chunk_chars: int = None,
+    include_text: bool = False,
+    base_url: str = None,
+    api_key: str = None,
+    timeout: int = 30,
+    lancedb_module: Any = None,
+    openai_client_cls: Any = None,
+) -> str:
+    """Search a codebase with keyword, semantic, or hybrid retrieval."""
+    if not str(query or "").strip():
+        return _json({"success": False, "error": "query is required"})
+    mode_norm = str(mode or "hybrid").strip().lower()
+    if mode_norm not in {"keyword", "semantic", "hybrid"}:
+        return _json({"success": False, "error": "mode must be keyword, semantic, or hybrid"})
+
+    repo_root = _repo_root(root)
+    repo = _repo_metadata(repo_root)
+    table_name = _table_name(table)
+    path = _db_path(db_path)
+    model_name = _embedding_model(model)
+    dims = _embedding_dims(dimensions)
+    limit_int = max(1, min(int(limit or 8), 30))
+    max_file_bytes_int = int(max_file_bytes or _configured_int("max_file_bytes", DEFAULT_MAX_FILE_BYTES))
+    max_chunk_chars_int = int(max_chunk_chars or _configured_int("max_chunk_chars", DEFAULT_MAX_CHUNK_CHARS))
+
+    keyword_payload = {"results": [], "scanned_chunk_count": 0}
+    if mode_norm in {"keyword", "hybrid"}:
+        keyword_payload = _keyword_results(
+            root=repo_root,
+            repo=repo,
+            query=query,
+            paths=paths,
+            include_globs=include_globs,
+            exclude_globs=exclude_globs,
+            max_files=max(1, int(max_files or 1000)),
+            max_chunks=max(1, int(max_chunks or DEFAULT_SEARCH_CHUNKS)),
+            max_file_bytes=max_file_bytes_int,
+            max_chunk_chars=max_chunk_chars_int,
+        )
+
+    semantic_payload = {"results": [], "usage": None}
+    semantic_error = None
+    if mode_norm in {"semantic", "hybrid"}:
+        try:
+            semantic_payload = _semantic_results(
+                root=repo_root,
+                repo=repo,
+                query=query,
+                table_name=table_name,
+                db_path=path,
+                model=model_name,
+                dimensions=dims,
+                limit=limit_int,
+                base_url=base_url,
+                api_key=api_key,
+                timeout=int(timeout or 30),
+                lancedb_module=lancedb_module,
+                openai_client_cls=openai_client_cls,
+            )
+        except Exception as exc:
+            semantic_error = str(exc)
+            if mode_norm == "semantic":
+                return _json(
+                    {
+                        "success": False,
+                        "action": "search",
+                        "mode": mode_norm,
+                        "repo": repo,
+                        "db_path": str(path),
+                        "table": table_name,
+                        "error": semantic_error,
+                    }
+                )
+
+    merged = _merge_hybrid(keyword_payload["results"], semantic_payload["results"])
+    results = merged[:limit_int]
+    if not include_text:
+        for item in results:
+            item.pop("text", None)
+
+    return _json(
+        {
+            "success": True,
+            "action": "search",
+            "mode": mode_norm,
+            "repo": repo,
+            "db_path": str(path),
+            "table": table_name,
+            "model": model_name,
+            "dimensions": dims,
+            "count": len(results),
+            "results": results,
+            "semantic_available": semantic_error is None if mode_norm in {"semantic", "hybrid"} else False,
+            "semantic_error": semantic_error,
+            "keyword_scanned_chunk_count": keyword_payload["scanned_chunk_count"],
+            "usage": semantic_payload.get("usage"),
+        }
+    )
+
+
+def _stats(table_name: str, db_path: Path, lancedb_module: Any = None) -> Dict[str, Any]:
+    try:
+        lancedb_module = lancedb_module or _import_lancedb()
+    except Exception as exc:
+        return {
+            "success": True,
+            "action": "stats",
+            "lancedb_available": False,
+            "db_path": str(db_path),
+            "table": table_name,
+            "error": str(exc),
+        }
+    db = lancedb_module.connect(str(db_path))
+    tables = _table_names(db)
+    if table_name not in tables:
+        return {
+            "success": True,
+            "action": "stats",
+            "lancedb_available": True,
+            "db_path": str(db_path),
+            "tables": tables,
+            "table": table_name,
+            "table_exists": False,
+            "row_count": 0,
+        }
+    table = db.open_table(table_name)
+    sample = []
+    raw = table.head(5) if hasattr(table, "head") else table.limit(5).to_list()
+    rows = raw.to_pylist() if hasattr(raw, "to_pylist") else raw
+    for row in rows:
+        sample.append(_sanitize_row(dict(row)))
+    return {
+        "success": True,
+        "action": "stats",
+        "lancedb_available": True,
+        "db_path": str(db_path),
+        "tables": tables,
+        "table": table_name,
+        "table_exists": True,
+        "row_count": int(table.count_rows()),
+        "sample": sample,
+    }
+
+
+def check_codebase_index_requirements() -> bool:
+    return get_hermes_home().exists()
+
+
+CODEBASE_INDEX_SCHEMA = {
+    "name": "codebase_index",
+    "description": (
+        "Dry-run, embed, and inspect a repository-scoped codebase index. "
+        "Default dry_run never calls OpenAI or writes LanceDB. Use action='index' "
+        "with embed=true after inspecting chunk counts."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "action": {
+                "type": "string",
+                "enum": ["dry_run", "index", "stats"],
+                "description": "dry_run previews chunks; index embeds+writes; stats inspects LanceDB.",
+                "default": "dry_run",
+            },
+            "root": {"type": "string", "description": "Repo root or path inside a repo. Defaults to cwd."},
+            "scope": {
+                "type": "string",
+                "enum": ["repo", "changed", "paths"],
+                "description": "Repo-wide, git-changed/untracked, or explicit paths.",
+                "default": "repo",
+            },
+            "paths": {"type": "array", "items": {"type": "string"}},
+            "include_globs": {"type": "array", "items": {"type": "string"}},
+            "exclude_globs": {"type": "array", "items": {"type": "string"}},
+            "embed": {
+                "type": "boolean",
+                "description": "Required true for action='index' to make OpenAI usage explicit.",
+                "default": False,
+            },
+            "table": {"type": "string", "description": "LanceDB table. Defaults to codebase_chunks."},
+            "db_path": {"type": "string", "description": "Override LanceDB path."},
+            "model": {"type": "string", "description": "OpenAI embedding model."},
+            "dimensions": {"type": "integer", "description": "Optional embedding dimensions override."},
+            "max_files": {"type": "integer", "default": 200},
+            "max_chunks": {"type": "integer", "default": DEFAULT_INDEX_CHUNKS},
+            "max_file_bytes": {"type": "integer", "default": DEFAULT_MAX_FILE_BYTES},
+            "max_chunk_chars": {"type": "integer", "default": DEFAULT_MAX_CHUNK_CHARS},
+        },
+        "required": [],
+    },
+}
+
+
+CODEBASE_SEARCH_SCHEMA = {
+    "name": "codebase_search",
+    "description": (
+        "Search the current codebase with keyword, semantic, or hybrid retrieval. "
+        "Hybrid uses LanceDB/OpenAI when available and falls back to keyword search "
+        "without failing the agent turn."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "query": {"type": "string", "description": "Natural-language or symbol-oriented query."},
+            "root": {"type": "string", "description": "Repo root or path inside a repo. Defaults to cwd."},
+            "mode": {
+                "type": "string",
+                "enum": ["hybrid", "semantic", "keyword"],
+                "description": "Retrieval mode. Hybrid is the default agent mode.",
+                "default": "hybrid",
+            },
+            "paths": {"type": "array", "items": {"type": "string"}},
+            "include_globs": {"type": "array", "items": {"type": "string"}},
+            "exclude_globs": {"type": "array", "items": {"type": "string"}},
+            "table": {"type": "string", "description": "LanceDB table. Defaults to codebase_chunks."},
+            "db_path": {"type": "string", "description": "Override LanceDB path."},
+            "model": {"type": "string", "description": "OpenAI embedding model."},
+            "dimensions": {"type": "integer", "description": "Optional embedding dimensions override."},
+            "limit": {"type": "integer", "description": "Max results, clamped to [1, 30].", "default": 8},
+            "include_text": {
+                "type": "boolean",
+                "description": "Include full chunk text. Default false returns previews only.",
+                "default": False,
+            },
+            "max_files": {"type": "integer", "default": 1000},
+            "max_chunks": {"type": "integer", "default": DEFAULT_SEARCH_CHUNKS},
+            "max_file_bytes": {"type": "integer", "default": DEFAULT_MAX_FILE_BYTES},
+            "max_chunk_chars": {"type": "integer", "default": DEFAULT_MAX_CHUNK_CHARS},
+        },
+        "required": ["query"],
+    },
+}
+
+
+from tools.registry import registry
+
+registry.register(
+    name="codebase_index",
+    toolset="codebase_search",
+    schema=CODEBASE_INDEX_SCHEMA,
+    handler=lambda args, **kw: codebase_index(
+        action=args.get("action", "dry_run"),
+        root=args.get("root"),
+        scope=args.get("scope", "repo"),
+        paths=args.get("paths"),
+        include_globs=args.get("include_globs"),
+        exclude_globs=args.get("exclude_globs"),
+        table=args.get("table"),
+        db_path=args.get("db_path"),
+        model=args.get("model"),
+        dimensions=args.get("dimensions"),
+        max_files=args.get("max_files", 200),
+        max_chunks=args.get("max_chunks", DEFAULT_INDEX_CHUNKS),
+        max_file_bytes=args.get("max_file_bytes"),
+        max_chunk_chars=args.get("max_chunk_chars"),
+        embed=args.get("embed", False),
+        base_url=args.get("base_url"),
+        api_key=args.get("api_key"),
+        timeout=args.get("timeout", 60),
+        lancedb_module=kw.get("lancedb_module"),
+        openai_client_cls=kw.get("openai_client_cls"),
+    ),
+    check_fn=check_codebase_index_requirements,
+    emoji="",
+)
+
+registry.register(
+    name="codebase_search",
+    toolset="codebase_search",
+    schema=CODEBASE_SEARCH_SCHEMA,
+    handler=lambda args, **kw: codebase_search(
+        query=args.get("query", ""),
+        root=args.get("root"),
+        mode=args.get("mode", "hybrid"),
+        paths=args.get("paths"),
+        include_globs=args.get("include_globs"),
+        exclude_globs=args.get("exclude_globs"),
+        table=args.get("table"),
+        db_path=args.get("db_path"),
+        model=args.get("model"),
+        dimensions=args.get("dimensions"),
+        limit=args.get("limit", 8),
+        max_files=args.get("max_files", 1000),
+        max_chunks=args.get("max_chunks", DEFAULT_SEARCH_CHUNKS),
+        max_file_bytes=args.get("max_file_bytes"),
+        max_chunk_chars=args.get("max_chunk_chars"),
+        include_text=args.get("include_text", False),
+        base_url=args.get("base_url"),
+        api_key=args.get("api_key"),
+        timeout=args.get("timeout", 30),
+        lancedb_module=kw.get("lancedb_module"),
+        openai_client_cls=kw.get("openai_client_cls"),
+    ),
+    check_fn=check_codebase_index_requirements,
+    emoji="",
+)

--- a/tools/lazy_deps.py
+++ b/tools/lazy_deps.py
@@ -173,6 +173,8 @@ LAZY_DEPS: dict[str, tuple[str, ...]] = {
     # ─── Tools ─────────────────────────────────────────────────────────────
     # ACP adapter (VS Code / Zed / JetBrains integration)
     "tool.acp": ("agent-client-protocol==0.9.0",),
+    # Local semantic index storage for code/doc payloads.
+    "tool.semantic_index": ("lancedb==0.33.0",),
     # Dashboard (`hermes dashboard`)
     "tool.dashboard": (
         "fastapi==0.133.1",

--- a/tools/semantic_index_tool.py
+++ b/tools/semantic_index_tool.py
@@ -1,0 +1,562 @@
+#!/usr/bin/env python3
+"""Tiny first slice of the profile-scoped semantic index.
+
+This tool deliberately starts with a single staged text payload instead of a
+repo crawler.  It proves the contract: dry-run first, explicit external OpenAI
+embedding, local LanceDB persistence, and inspectable DB state.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import os
+import re
+import time
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from hermes_constants import get_hermes_home
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_TABLE = "semantic_chunks"
+DEFAULT_MODEL = "text-embedding-3-small"
+DEFAULT_PAYLOAD = (
+    "Hermes semantic index smoke payload: a tiny codebase memory chunk used "
+    "to verify OpenAI embeddings and local LanceDB storage."
+)
+MAX_STAGE_CHARS = 2_000
+
+_SECRET_PATTERNS = (
+    re.compile(r"-----BEGIN [A-Z ]*PRIVATE KEY-----"),
+    re.compile(r"\bsk-[A-Za-z0-9_\-]{16,}"),
+    re.compile(r"\bgh[pousr]_[A-Za-z0-9_]{20,}"),
+    re.compile(r"\bAKIA[0-9A-Z]{16}\b"),
+    re.compile(r"(?i)\b(api[_-]?key|token|secret|password)\s*[:=]\s*['\"]?[^'\"\s]{12,}"),
+)
+
+
+def _json(data: Dict[str, Any]) -> str:
+    return json.dumps(data, ensure_ascii=False)
+
+
+def _load_config() -> Dict[str, Any]:
+    try:
+        from hermes_cli.config import load_config
+        cfg = load_config() or {}
+        return cfg.get("semantic_index") or {}
+    except Exception:
+        logger.debug("semantic_index config load failed", exc_info=True)
+        return {}
+
+
+def _index_dir(path_override: Optional[str] = None) -> Path:
+    if path_override and str(path_override).strip():
+        return Path(path_override).expanduser()
+    cfg_path = str(_load_config().get("path") or "").strip()
+    if cfg_path:
+        return Path(cfg_path).expanduser()
+    return get_hermes_home() / "semantic" / "lancedb"
+
+
+def _table_name(table: Optional[str] = None) -> str:
+    raw = str(table or _load_config().get("table") or DEFAULT_TABLE).strip()
+    if not raw:
+        return DEFAULT_TABLE
+    return re.sub(r"[^A-Za-z0-9_]", "_", raw)[:64] or DEFAULT_TABLE
+
+
+def _embedding_model(model: Optional[str] = None) -> str:
+    return str(model or _load_config().get("model") or DEFAULT_MODEL).strip() or DEFAULT_MODEL
+
+
+def _embedding_dimensions(dimensions: Optional[int] = None) -> Optional[int]:
+    value = dimensions if dimensions is not None else _load_config().get("dimensions")
+    if value in (None, "", 0):
+        return None
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        return None
+    return parsed if parsed > 0 else None
+
+
+def _payload_text(payload: Optional[str]) -> str:
+    text = DEFAULT_PAYLOAD if payload is None or not str(payload).strip() else str(payload)
+    return text.strip()
+
+
+def _content_hash(text: str) -> str:
+    return hashlib.sha256(text.encode("utf-8", errors="replace")).hexdigest()
+
+
+def _stable_id(corpus: str, uri: str, text: str) -> str:
+    digest = _content_hash(f"{corpus}\n{uri}\n{_content_hash(text)}")
+    return digest[:32]
+
+
+def _secret_warning(text: str) -> Optional[str]:
+    for pattern in _SECRET_PATTERNS:
+        if pattern.search(text):
+            return "payload looks like it may contain credentials; refusing to send it to OpenAI"
+    return None
+
+
+def _preview(text: str, limit: int = 240) -> str:
+    compact = " ".join(text.split())
+    if len(compact) <= limit:
+        return compact
+    return compact[: limit - 3] + "..."
+
+
+def _record_for_payload(
+    *,
+    payload: str,
+    vector: List[float],
+    corpus: str,
+    uri: str,
+    model: str,
+    provider: str = "openai",
+    metadata: Optional[Dict[str, Any]] = None,
+) -> Dict[str, Any]:
+    now = time.time()
+    return {
+        "id": _stable_id(corpus, uri, payload),
+        "corpus": corpus,
+        "source_type": "manual_payload",
+        "uri": uri,
+        "content_hash": _content_hash(payload),
+        "embedding_provider": provider,
+        "embedding_model": model,
+        "dimensions": len(vector),
+        "text": payload,
+        "metadata_json": json.dumps(metadata or {}, sort_keys=True, ensure_ascii=False),
+        "vector": [float(v) for v in vector],
+        "indexed_at": now,
+    }
+
+
+def _import_lancedb():
+    try:
+        import lancedb  # type: ignore
+        return lancedb
+    except ImportError:
+        from tools.lazy_deps import ensure
+        ensure("tool.semantic_index", prompt=False)
+        import lancedb  # type: ignore
+        return lancedb
+
+
+def _table_names(db: Any) -> List[str]:
+    names = db.table_names()
+    return list(names() if callable(names) else names)
+
+
+def _sample_rows(table: Any, limit: int = 3) -> List[Dict[str, Any]]:
+    if hasattr(table, "head"):
+        raw = table.head(limit)
+        if hasattr(raw, "to_pylist"):
+            return [dict(row) for row in raw.to_pylist()]
+        if hasattr(raw, "to_dict"):
+            return [dict(row) for row in raw.to_dict(orient="records")]
+        return [dict(row) for row in raw]
+    return [dict(row) for row in table.limit(limit).to_list()]
+
+
+def _add_record(lancedb_module: Any, db_path: Path, table: str, record: Dict[str, Any]) -> Dict[str, Any]:
+    db_path.mkdir(parents=True, exist_ok=True)
+    db = lancedb_module.connect(str(db_path))
+    if table in _table_names(db):
+        tbl = db.open_table(table)
+        tbl.add([record])
+    else:
+        tbl = db.create_table(table, data=[record])
+    try:
+        count = int(tbl.count_rows())
+    except Exception:
+        count = None
+    return {"table": table, "row_count": count}
+
+
+def _embed_openai(
+    text: str,
+    *,
+    model: str,
+    dimensions: Optional[int],
+    base_url: Optional[str],
+    api_key: Optional[str],
+    timeout: int,
+    openai_client_cls: Any = None,
+) -> Dict[str, Any]:
+    key = (api_key or os.getenv("OPENAI_API_KEY") or "").strip()
+    if not key:
+        raise RuntimeError("OPENAI_API_KEY is required for action='stage' or action='query'")
+
+    if openai_client_cls is None:
+        from openai import OpenAI
+        openai_client_cls = OpenAI
+
+    client = openai_client_cls(
+        api_key=key,
+        base_url=(base_url or os.getenv("OPENAI_BASE_URL") or None),
+        timeout=timeout,
+        max_retries=0,
+    )
+    kwargs: Dict[str, Any] = {"model": model, "input": [text]}
+    if dimensions:
+        kwargs["dimensions"] = dimensions
+    response = client.embeddings.create(**kwargs)
+    data = sorted(response.data, key=lambda item: item.index)
+    vector = list(data[0].embedding)
+    usage = getattr(response, "usage", None)
+    return {
+        "vector": vector,
+        "usage": {
+            "prompt_tokens": getattr(usage, "prompt_tokens", None),
+            "total_tokens": getattr(usage, "total_tokens", None),
+        },
+    }
+
+
+def _stage_payload(
+    *,
+    payload: str,
+    corpus: str,
+    uri: str,
+    table: str,
+    db_path: Path,
+    model: str,
+    dimensions: Optional[int],
+    metadata: Optional[Dict[str, Any]],
+    base_url: Optional[str],
+    api_key: Optional[str],
+    timeout: int,
+    lancedb_module: Any = None,
+    openai_client_cls: Any = None,
+) -> Dict[str, Any]:
+    warning = _secret_warning(payload)
+    if warning:
+        return {"success": False, "error": warning}
+    if len(payload) > MAX_STAGE_CHARS:
+        return {
+            "success": False,
+            "error": f"payload is {len(payload)} chars; max for this first-stage tool is {MAX_STAGE_CHARS}",
+        }
+
+    embedded = _embed_openai(
+        payload,
+        model=model,
+        dimensions=dimensions,
+        base_url=base_url,
+        api_key=api_key,
+        timeout=timeout,
+        openai_client_cls=openai_client_cls,
+    )
+    vector = embedded["vector"]
+    record = _record_for_payload(
+        payload=payload,
+        vector=vector,
+        corpus=corpus,
+        uri=uri,
+        model=model,
+        metadata=metadata,
+    )
+    lancedb_module = lancedb_module or _import_lancedb()
+    storage = _add_record(lancedb_module, db_path, table, record)
+    return {
+        "success": True,
+        "action": "stage",
+        "dry_run": False,
+        "provider": "openai",
+        "model": model,
+        "dimensions": len(vector),
+        "usage": embedded["usage"],
+        "db_path": str(db_path),
+        "table": table,
+        "row_count": storage["row_count"],
+        "record": {
+            "id": record["id"],
+            "corpus": corpus,
+            "uri": uri,
+            "content_hash": record["content_hash"],
+            "text_preview": _preview(payload),
+        },
+    }
+
+
+def _query_index(
+    *,
+    query: str,
+    table: str,
+    db_path: Path,
+    model: str,
+    dimensions: Optional[int],
+    limit: int,
+    base_url: Optional[str],
+    api_key: Optional[str],
+    timeout: int,
+    lancedb_module: Any = None,
+    openai_client_cls: Any = None,
+) -> Dict[str, Any]:
+    if not query.strip():
+        return {"success": False, "error": "query is required for action='query'"}
+    lancedb_module = lancedb_module or _import_lancedb()
+    db = lancedb_module.connect(str(db_path))
+    if table not in _table_names(db):
+        return {"success": False, "error": f"table '{table}' does not exist", "db_path": str(db_path)}
+    embedded = _embed_openai(
+        query,
+        model=model,
+        dimensions=dimensions,
+        base_url=base_url,
+        api_key=api_key,
+        timeout=timeout,
+        openai_client_cls=openai_client_cls,
+    )
+    rows = db.open_table(table).search(embedded["vector"]).limit(max(1, min(int(limit or 5), 20))).to_list()
+    results = []
+    for row in rows:
+        vector = row.pop("vector", None)
+        results.append({
+            **row,
+            "text_preview": _preview(str(row.get("text") or "")),
+            "vector_dimensions": len(vector) if isinstance(vector, list) else row.get("dimensions"),
+        })
+    return {
+        "success": True,
+        "action": "query",
+        "provider": "openai",
+        "model": model,
+        "db_path": str(db_path),
+        "table": table,
+        "count": len(results),
+        "results": results,
+        "usage": embedded["usage"],
+    }
+
+
+def _stats(table: str, db_path: Path, lancedb_module: Any = None) -> Dict[str, Any]:
+    try:
+        lancedb_module = lancedb_module or _import_lancedb()
+    except Exception as exc:
+        return {
+            "success": True,
+            "action": "stats",
+            "lancedb_available": False,
+            "db_path": str(db_path),
+            "table": table,
+            "error": str(exc),
+        }
+    db = lancedb_module.connect(str(db_path))
+    tables = _table_names(db)
+    if table not in tables:
+        return {
+            "success": True,
+            "action": "stats",
+            "lancedb_available": True,
+            "db_path": str(db_path),
+            "tables": tables,
+            "table": table,
+            "table_exists": False,
+            "row_count": 0,
+        }
+    tbl = db.open_table(table)
+    sample = _sample_rows(tbl, limit=3)
+    for row in sample:
+        vector = row.pop("vector", None)
+        row["vector_dimensions"] = len(vector) if hasattr(vector, "__len__") else row.get("dimensions")
+        row["text_preview"] = _preview(str(row.get("text") or ""))
+        row.pop("text", None)
+    return {
+        "success": True,
+        "action": "stats",
+        "lancedb_available": True,
+        "db_path": str(db_path),
+        "tables": tables,
+        "table": table,
+        "table_exists": True,
+        "row_count": int(tbl.count_rows()),
+        "sample": sample,
+    }
+
+
+def semantic_index(
+    action: str = "dry_run",
+    payload: str = None,
+    query: str = "",
+    corpus: str = "manual",
+    uri: str = "manual://semantic-index-smoke",
+    metadata: Dict[str, Any] = None,
+    table: str = None,
+    db_path: str = None,
+    model: str = None,
+    dimensions: int = None,
+    limit: int = 5,
+    embed: bool = False,
+    base_url: str = None,
+    api_key: str = None,
+    timeout: int = 30,
+    lancedb_module: Any = None,
+    openai_client_cls: Any = None,
+) -> str:
+    """Dry-run, stage, query, or inspect the local LanceDB semantic index."""
+    action_norm = str(action or "dry_run").strip().lower()
+    table_name = _table_name(table)
+    model_name = _embedding_model(model)
+    dims = _embedding_dimensions(dimensions)
+    path = _index_dir(db_path)
+    text = _payload_text(payload)
+    corpus_norm = str(corpus or "manual").strip() or "manual"
+    uri_norm = str(uri or "manual://semantic-index-smoke").strip() or "manual://semantic-index-smoke"
+
+    if action_norm in {"dryrun", "preview"}:
+        action_norm = "dry_run"
+
+    if action_norm == "dry_run":
+        return _json({
+            "success": True,
+            "action": "dry_run",
+            "dry_run": True,
+            "would_call_openai": False,
+            "would_write_lancedb": False,
+            "provider": "openai",
+            "model": model_name,
+            "dimensions": dims,
+            "db_path": str(path),
+            "table": table_name,
+            "payload": {
+                "corpus": corpus_norm,
+                "uri": uri_norm,
+                "char_count": len(text),
+                "content_hash": _content_hash(text),
+                "id": _stable_id(corpus_norm, uri_norm, text),
+                "text_preview": _preview(text),
+                "secret_blocker": _secret_warning(text),
+            },
+            "next_step": "Call semantic_index(action='stage', embed=true, payload=...) to send this tiny payload to OpenAI and store it in LanceDB.",
+        })
+
+    if action_norm == "stage":
+        if not embed:
+            return _json({
+                "success": False,
+                "error": "stage requires embed=true so external OpenAI usage is explicit",
+                "dry_run_hint": "Call semantic_index(action='dry_run', payload=...) first to inspect the payload.",
+            })
+        return _json(_stage_payload(
+            payload=text,
+            corpus=corpus_norm,
+            uri=uri_norm,
+            table=table_name,
+            db_path=path,
+            model=model_name,
+            dimensions=dims,
+            metadata=metadata,
+            base_url=base_url,
+            api_key=api_key,
+            timeout=int(timeout or 30),
+            lancedb_module=lancedb_module,
+            openai_client_cls=openai_client_cls,
+        ))
+
+    if action_norm == "query":
+        return _json(_query_index(
+            query=str(query or ""),
+            table=table_name,
+            db_path=path,
+            model=model_name,
+            dimensions=dims,
+            limit=limit,
+            base_url=base_url,
+            api_key=api_key,
+            timeout=int(timeout or 30),
+            lancedb_module=lancedb_module,
+            openai_client_cls=openai_client_cls,
+        ))
+
+    if action_norm == "stats":
+        return _json(_stats(table_name, path, lancedb_module=lancedb_module))
+
+    return _json({"success": False, "error": f"Unknown action '{action}'. Use dry_run, stage, query, or stats."})
+
+
+def check_semantic_index_requirements() -> bool:
+    return get_hermes_home().exists()
+
+
+SEMANTIC_INDEX_SCHEMA = {
+    "name": "semantic_index",
+    "description": (
+        "Dry-run and stage tiny text payloads into the local LanceDB semantic index. "
+        "The default action is dry_run and never calls OpenAI or writes LanceDB. "
+        "Use action='stage' with embed=true only after inspecting the payload; this "
+        "sends the text to OpenAI embeddings and stores the resulting vector locally. "
+        "Use action='query' to embed a query and search the table, and action='stats' "
+        "to inspect the vector database."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "action": {
+                "type": "string",
+                "enum": ["dry_run", "stage", "query", "stats"],
+                "description": "dry_run previews only; stage embeds+writes; query searches; stats inspects LanceDB.",
+                "default": "dry_run",
+            },
+            "payload": {
+                "type": "string",
+                "description": "Tiny text payload to preview or stage. Omit for a built-in smoke payload.",
+            },
+            "query": {
+                "type": "string",
+                "description": "Semantic query text for action='query'.",
+            },
+            "embed": {
+                "type": "boolean",
+                "description": "Required true for action='stage' to make OpenAI usage explicit.",
+                "default": False,
+            },
+            "corpus": {"type": "string", "description": "Logical corpus name, e.g. 'manual' or 'codebase'."},
+            "uri": {"type": "string", "description": "Stable source URI for the staged payload."},
+            "metadata": {"type": "object", "description": "Small JSON metadata object stored with the chunk."},
+            "table": {"type": "string", "description": "LanceDB table name. Defaults to semantic_chunks."},
+            "db_path": {"type": "string", "description": "Override LanceDB path. Defaults to profile semantic/lancedb."},
+            "model": {"type": "string", "description": "OpenAI embedding model. Defaults to text-embedding-3-small."},
+            "dimensions": {"type": "integer", "description": "Optional OpenAI embedding dimensions override."},
+            "limit": {"type": "integer", "description": "Max query results, clamped to [1, 20].", "default": 5},
+        },
+        "required": [],
+    },
+}
+
+
+from tools.registry import registry
+
+registry.register(
+    name="semantic_index",
+    toolset="semantic_index",
+    schema=SEMANTIC_INDEX_SCHEMA,
+    handler=lambda args, **kw: semantic_index(
+        action=args.get("action", "dry_run"),
+        payload=args.get("payload"),
+        query=args.get("query", ""),
+        corpus=args.get("corpus", "manual"),
+        uri=args.get("uri", "manual://semantic-index-smoke"),
+        metadata=args.get("metadata"),
+        table=args.get("table"),
+        db_path=args.get("db_path"),
+        model=args.get("model"),
+        dimensions=args.get("dimensions"),
+        limit=args.get("limit", 5),
+        embed=args.get("embed", False),
+        base_url=args.get("base_url"),
+        api_key=args.get("api_key"),
+        timeout=args.get("timeout", 30),
+        lancedb_module=kw.get("lancedb_module"),
+        openai_client_cls=kw.get("openai_client_cls"),
+    ),
+    check_fn=check_semantic_index_requirements,
+    emoji="",
+)

--- a/toolsets.py
+++ b/toolsets.py
@@ -55,6 +55,8 @@ _HERMES_CORE_TOOLS = [
     "session_search",
     # Local semantic index dry-run/stage/query
     "semantic_index",
+    # Repo-aware codebase index/search over LanceDB + keyword fallback
+    "codebase_index", "codebase_search",
     # Clarifying questions
     "clarify",
     # Code execution + delegation
@@ -230,6 +232,12 @@ TOOLSETS = {
         "tools": ["semantic_index"],
         "includes": []
     },
+
+    "codebase_search": {
+        "description": "Index and search local codebases with keyword, semantic, or hybrid retrieval",
+        "tools": ["codebase_index", "codebase_search"],
+        "includes": []
+    },
     
     "clarify": {
         "description": "Ask the user clarifying questions (multiple-choice or open-ended)",
@@ -357,7 +365,7 @@ TOOLSETS = {
             "browser_press", "browser_get_images",
             "browser_vision", "browser_console", "browser_cdp", "browser_dialog",
             "todo", "memory",
-            "session_search", "clarify",
+            "session_search", "semantic_index", "codebase_index", "codebase_search", "clarify",
             "execute_code", "delegate_task",
         ],
         "includes": [],
@@ -389,7 +397,7 @@ TOOLSETS = {
             "browser_press", "browser_get_images",
             "browser_vision", "browser_console", "browser_cdp", "browser_dialog",
             "todo", "memory",
-            "session_search",
+            "session_search", "semantic_index", "codebase_index", "codebase_search",
             "execute_code", "delegate_task",
         ],
         "includes": []
@@ -417,6 +425,8 @@ TOOLSETS = {
             "todo", "memory",
             # Session history search
             "session_search",
+            # Local semantic/codebase search
+            "semantic_index", "codebase_index", "codebase_search",
             # Code execution + delegation
             "execute_code", "delegate_task",
             # Cronjob management

--- a/toolsets.py
+++ b/toolsets.py
@@ -53,6 +53,8 @@ _HERMES_CORE_TOOLS = [
     "todo", "memory",
     # Session history search
     "session_search",
+    # Local semantic index dry-run/stage/query
+    "semantic_index",
     # Clarifying questions
     "clarify",
     # Code execution + delegation
@@ -220,6 +222,12 @@ TOOLSETS = {
     "session_search": {
         "description": "Search and recall past conversations with summarization",
         "tools": ["session_search"],
+        "includes": []
+    },
+
+    "semantic_index": {
+        "description": "Dry-run, stage, query, and inspect the local LanceDB semantic index",
+        "tools": ["semantic_index"],
         "includes": []
     },
     

--- a/uv.lock
+++ b/uv.lock
@@ -1007,6 +1007,18 @@ wheels = [
 ]
 
 [[package]]
+name = "deprecation"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "packaging" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5a/d3/8ae2869247df154b64c1884d7346d412fed0c49df84db635aab2d1c40e62/deprecation-2.1.0.tar.gz", hash = "sha256:72b3bde64e5d778694b0cf68178aed03d15e15477116add3fb773e581f9518ff", size = 173788, upload-time = "2020-04-20T14:23:38.738Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/02/c3/253a89ee03fc9b9682f1541728eb66db7db22148cd94f89ab22528cd1e1b/deprecation-2.1.0-py2.py3-none-any.whl", hash = "sha256:a10811591210e1fb0e768a8c25517cabeabcba6f0bf96564f8ff45189f90b14a", size = 11178, upload-time = "2020-04-20T14:23:36.581Z" },
+]
+
+[[package]]
 name = "dingtalk-stream"
 version = "0.24.3"
 source = { registry = "https://pypi.org/simple" }
@@ -1571,6 +1583,9 @@ nemo-relay = [
 parallel-web = [
     { name = "parallel-web" },
 ]
+semantic = [
+    { name = "lancedb" },
+]
 slack = [
     { name = "aiohttp" },
     { name = "slack-bolt" },
@@ -1688,6 +1703,7 @@ requires-dist = [
     { name = "honcho-ai", marker = "extra == 'honcho'", specifier = "==2.0.1" },
     { name = "httpx", extras = ["socks"], specifier = "==0.28.1" },
     { name = "jinja2", specifier = "==3.1.6" },
+    { name = "lancedb", marker = "extra == 'semantic'", specifier = "==0.33.0" },
     { name = "lark-oapi", marker = "extra == 'feishu'", specifier = "==1.5.3" },
     { name = "markdown", specifier = "==3.10.2" },
     { name = "mautrix", extras = ["encryption"], marker = "extra == 'matrix'", specifier = "==0.21.0" },
@@ -1745,7 +1761,7 @@ requires-dist = [
     { name = "websockets", specifier = "==15.0.1" },
     { name = "youtube-transcript-api", marker = "extra == 'youtube'", specifier = "==1.2.4" },
 ]
-provides-extras = ["anthropic", "exa", "firecrawl", "parallel-web", "fal", "edge-tts", "modal", "daytona", "hindsight", "dev", "messaging", "cron", "slack", "matrix", "wecom", "cli", "tts-premium", "voice", "pty", "honcho", "vision", "mcp", "nemo-relay", "homeassistant", "sms", "teams", "computer-use", "acp", "mistral", "bedrock", "azure-identity", "termux", "termux-all", "dingtalk", "feishu", "google", "youtube", "web", "all"]
+provides-extras = ["anthropic", "exa", "firecrawl", "parallel-web", "fal", "edge-tts", "modal", "daytona", "hindsight", "semantic", "dev", "messaging", "cron", "slack", "matrix", "wecom", "cli", "tts-premium", "voice", "pty", "honcho", "vision", "mcp", "nemo-relay", "homeassistant", "sms", "teams", "computer-use", "acp", "mistral", "bedrock", "azure-identity", "termux", "termux-all", "dingtalk", "feishu", "google", "youtube", "web", "all"]
 
 [[package]]
 name = "hf-xet"
@@ -2069,6 +2085,56 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/19/74/a633ee74eb36c44aa6d1095e7cc5569bebf04342ee146178e2d36600708b/jsonschema_specifications-2025.9.1.tar.gz", hash = "sha256:b540987f239e745613c7a9176f3edb72b832a4ac465cf02712288397832b5e8d", size = 32855, upload-time = "2025-09-08T01:34:59.186Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/41/45/1a4ed80516f02155c51f51e8cedb3c1902296743db0bbc66608a0db2814f/jsonschema_specifications-2025.9.1-py3-none-any.whl", hash = "sha256:98802fee3a11ee76ecaca44429fda8a41bff98b00a0f2838151b113f210cc6fe", size = 18437, upload-time = "2025-09-08T01:34:57.871Z" },
+]
+
+[[package]]
+name = "lance-namespace"
+version = "0.8.6"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "lance-namespace-urllib3-client" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/af/12/f7ab93b29be3edbf5fc3610714bf2d06088e7f4524bfb38dfd6852458b08/lance_namespace-0.8.6.tar.gz", hash = "sha256:18232e721c8188145f4ec9389cc2dfbeeabf54a619d94885ea1b3375bee9f4af", size = 11529, upload-time = "2026-06-12T17:36:41.651Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/1b/5b1668ee2dc8910965f390640359112a31157092fcf8e000b89c79b58708/lance_namespace-0.8.6-py3-none-any.whl", hash = "sha256:571eae34f9aad70e5b05020416c2860889b9ec82993ccd0eb015e7b39c3ea309", size = 13383, upload-time = "2026-06-12T17:36:43.456Z" },
+]
+
+[[package]]
+name = "lance-namespace-urllib3-client"
+version = "0.8.6"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic" },
+    { name = "python-dateutil" },
+    { name = "typing-extensions" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c7/80/fb224b4a89c1c1638cde949cb6cce6c3aca7759effbfea46a3d9c3960b21/lance_namespace_urllib3_client-0.8.6.tar.gz", hash = "sha256:b6fb1d306e74a7576e5309919020be744527de484a63dbf5eed10f8b368548df", size = 228772, upload-time = "2026-06-12T17:36:42.609Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c5/90/1e27de15cd1b16785a1c7312beb0a59e75c8344a815f600f58173a565bd1/lance_namespace_urllib3_client-0.8.6-py3-none-any.whl", hash = "sha256:9d78249c3fb15aa3d15d668f78f04a275af3d08d800a7027492f37996ac4968b", size = 369950, upload-time = "2026-06-12T17:36:40.438Z" },
+]
+
+[[package]]
+name = "lancedb"
+version = "0.33.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "deprecation" },
+    { name = "lance-namespace" },
+    { name = "numpy" },
+    { name = "overrides", marker = "python_full_version < '3.12'" },
+    { name = "packaging" },
+    { name = "pyarrow" },
+    { name = "pydantic" },
+    { name = "tqdm" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/09/2f/d5a4b2a5bb1f800936c76a6d8a4daf127a86fcab621eeb70b574a5adc774/lancedb-0.33.0-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:d4eaf6fa7c2eac619208f1d396f4de635ee0f535673067118a31c1181575c48b", size = 48338115, upload-time = "2026-05-28T20:37:55.88Z" },
+    { url = "https://files.pythonhosted.org/packages/07/12/31787b93a856b2c31382c7771dc22fb05575b70b87c9efe454269f4f0948/lancedb-0.33.0-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6c6c2402ed2744245ae76c4167c0461da0a7a80f1608e0ec491c1548ea2b4302", size = 51162262, upload-time = "2026-05-28T20:37:59.101Z" },
+    { url = "https://files.pythonhosted.org/packages/49/b7/081cc29f8e06bf12191b99ab3fe702aceebdb0914476b821a8c0445cacc8/lancedb-0.33.0-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7ebf1ffad811e6254a93931a79489ba1f21f48564bdfa06abae846f5fcaaf3e8", size = 54381368, upload-time = "2026-05-28T20:38:02.2Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/bd/e0f4bd621f10ecf96a801b0166e87799ed7ca5a9dbabcef9a6c766a58ef3/lancedb-0.33.0-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:13da39f80adfea59e5831fe64e4166b2d70a2f843e6507bf644c4fe4c350087c", size = 51188986, upload-time = "2026-05-28T20:38:05.375Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/1a/a8647a432ac6aa59cdce1fc061a7050ea4278bcab364539b78af2ecf72d2/lancedb-0.33.0-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:21b712825f0a00225e8974a41352c4ea84b0899ef8c23b17f672fadc38bd8346", size = 54440958, upload-time = "2026-05-28T20:38:08.474Z" },
+    { url = "https://files.pythonhosted.org/packages/08/6c/d0cc8da784cd7ed3b4940a5d1f3e7702e2d99a0a348ba81a376eed782810/lancedb-0.33.0-cp39-abi3-win_amd64.whl", hash = "sha256:4ba78c6202b0f6c2ce8edc7aa470e550d2da56271c7cbdd10428613f1f7126f9", size = 58751944, upload-time = "2026-05-28T20:38:11.549Z" },
 ]
 
 [[package]]
@@ -2787,6 +2853,15 @@ wheels = [
 ]
 
 [[package]]
+name = "overrides"
+version = "7.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/36/86/b585f53236dec60aba864e050778b25045f857e17f6e5ea0ae95fe80edd2/overrides-7.7.0.tar.gz", hash = "sha256:55158fa3d93b98cc75299b1e67078ad9003ca27945c76162c1c0766d6f91820a", size = 22812, upload-time = "2024-01-27T21:01:33.423Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2c/ab/fc8290c6a4c722e5514d80f62b2dc4c4df1a68a41d1364e625c35990fcf3/overrides-7.7.0-py3-none-any.whl", hash = "sha256:c7ed9d062f78b8e4c1a7b70bd8796b35ead4d9f510227ef9c5dc7626c60d7e49", size = 17832, upload-time = "2024-01-27T21:01:31.393Z" },
+]
+
+[[package]]
 name = "packaging"
 version = "26.0"
 source = { registry = "https://pypi.org/simple" }
@@ -3041,6 +3116,42 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/20/e5/16ff212c1e452235a90aeb09066144d0c5a6a8c0834397e03f5224495c4e/ptyprocess-0.7.0.tar.gz", hash = "sha256:5c5d0a3b48ceee0b48485e0c26037c0acd7d29765ca3fbb5cb3831d347423220", size = 70762, upload-time = "2020-12-28T15:15:30.155Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/22/a6/858897256d0deac81a172289110f31629fc4cee19b6f01283303e18c8db3/ptyprocess-0.7.0-py2.py3-none-any.whl", hash = "sha256:4b41f3967fce3af57cc7e94b888626c18bf37a083e3651ca8feeb66d492fef35", size = 13993, upload-time = "2020-12-28T15:15:28.35Z" },
+]
+
+[[package]]
+name = "pyarrow"
+version = "24.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/91/13/13e1069b351bdc3881266e11147ffccf687505dbb0ea74036237f5d454a5/pyarrow-24.0.0.tar.gz", hash = "sha256:85fe721a14dd823aca09127acbb06c3ca723efbd436c004f16bca601b04dcc83", size = 1180261, upload-time = "2026-04-21T10:51:25.837Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/62/c9/a47ab7ece0d86cbe6678418a0fbd1ac4bb493b9184a3891dfa0e7f287ae0/pyarrow-24.0.0-cp311-cp311-macosx_12_0_arm64.whl", hash = "sha256:b0e131f880cda8d04e076cee175a46fc0e8bc8b65c99c6c09dff6669335fde74", size = 35068898, upload-time = "2026-04-21T10:46:36.599Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/bc/8db86617a9a58008acf8913d6fed68ea2a46acb6de928db28d724c891a68/pyarrow-24.0.0-cp311-cp311-macosx_12_0_x86_64.whl", hash = "sha256:1b2fe7f9a5566401a0ef2571f197eb92358925c1f0c8dba305d6e43ea0871bb3", size = 36679915, upload-time = "2026-04-21T10:46:42.602Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/8e/fb178720400ef69db251eb4a9c3ccf4af269bc1feb5055529b8fc87170d1/pyarrow-24.0.0-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:0b3537c00fb8d384f15ac1e79b6eb6db04a16514c8c1d22e59a9b95c8ba42868", size = 45697931, upload-time = "2026-04-21T10:46:48.403Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/27/99c42abe8e21b44f4917f62631f3aa31404882a2c41d8a4cd5c110e13d52/pyarrow-24.0.0-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:14e31a3c9e35f1ab6356c6378f6f72830e6d2d5f1791df3774a7b097d18a6a1e", size = 48837449, upload-time = "2026-04-21T10:46:55.329Z" },
+    { url = "https://files.pythonhosted.org/packages/36/b6/333749e2666e9032891125bf9c691146e92901bece62030ac1430e2e7c88/pyarrow-24.0.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:b7d9a514e73bc42711e6a35aaccf3587c520024fe0a25d830a1a8a27c15f4f57", size = 49395949, upload-time = "2026-04-21T10:47:01.869Z" },
+    { url = "https://files.pythonhosted.org/packages/17/25/c5201706a2dd374e8ba6ee3fd7a8c89fb7ffc16eed5217a91fd2bd7f7626/pyarrow-24.0.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:b196eb3f931862af3fa84c2a253514d859c08e0d8fe020e07be12e75a5a9780c", size = 51912986, upload-time = "2026-04-21T10:47:09.872Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/d2/4d1bbba65320b21a49678d6fbdc6ff7c649251359fdcfc03568c4136231d/pyarrow-24.0.0-cp311-cp311-win_amd64.whl", hash = "sha256:35405aecb474e683fb36af650618fd5340ee5471fc65a21b36076a18bbc6c981", size = 27255371, upload-time = "2026-04-21T10:47:15.943Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/a9/9686d9f07837f91f775e8932659192e02c74f9d8920524b480b85212cc68/pyarrow-24.0.0-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:6233c9ed9ab9d1db47de57d9753256d9dcffbf42db341576099f0fd9f6bf4810", size = 34981559, upload-time = "2026-04-21T10:47:22.17Z" },
+    { url = "https://files.pythonhosted.org/packages/80/b6/0ddf0e9b6ead3474ab087ae598c76b031fc45532bf6a63f3a553440fb258/pyarrow-24.0.0-cp312-cp312-macosx_12_0_x86_64.whl", hash = "sha256:f7616236ec1bc2b15bfdec22a71ab38851c86f8f05ff64f379e1278cf20c634a", size = 36663654, upload-time = "2026-04-21T10:47:28.315Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/3b/926382efe8ce27ba729071d3566ade6dfb86bdf112f366000196b2f5780a/pyarrow-24.0.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:1617043b99bd33e5318ae18eb2919af09c71322ef1ca46566cdafc6e6712fb66", size = 45679394, upload-time = "2026-04-21T10:47:34.821Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/7a/829f7d9dfd37c207206081d6dad474d81dde29952401f07f2ba507814818/pyarrow-24.0.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:6165461f55ef6314f026de6638d661188e3455d3ec49834556a0ebbdbace18bb", size = 48863122, upload-time = "2026-04-21T10:47:42.056Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/e8/f88ce625fe8babaae64e8db2d417c7653adb3019b08aae85c5ed787dc816/pyarrow-24.0.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:3b13dedfe76a0ad2d1d859b0811b53827a4e9d93a0bcb05cf59333ab4980cc7e", size = 49376032, upload-time = "2026-04-21T10:47:48.967Z" },
+    { url = "https://files.pythonhosted.org/packages/36/7a/82c363caa145fff88fb475da50d3bf52bb024f61917be5424c3392eaf878/pyarrow-24.0.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:25ea65d868eb04015cd18e6df2fbe98f07e5bda2abefabcb88fce39a947716f6", size = 51929490, upload-time = "2026-04-21T10:47:55.981Z" },
+    { url = "https://files.pythonhosted.org/packages/66/1c/e3e72c8014ad2743ca64a701652c733cc5cbcee15c0463a32a8c55518d9e/pyarrow-24.0.0-cp312-cp312-win_amd64.whl", hash = "sha256:295f0a7f2e242dabd513737cf076007dc5b2d59237e3eca37b05c0c6446f3826", size = 27355660, upload-time = "2026-04-21T10:48:01.718Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/d3/a1abf004482026ddc17f4503db227787fa3cfe41ec5091ff20e4fea55e57/pyarrow-24.0.0-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:02b001b3ed4723caa44f6cd1af2d5c86aa2cf9971dacc2ffa55b21237713dfba", size = 34976759, upload-time = "2026-04-21T10:48:07.258Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/4a/34f0a36d28a2dd32225301b79daad44e243dc1a2bb77d43b60749be255c4/pyarrow-24.0.0-cp313-cp313-macosx_12_0_x86_64.whl", hash = "sha256:04920d6a71aabd08a0417709efce97d45ea8e6fb733d9ca9ecffb13c67839f68", size = 36658471, upload-time = "2026-04-21T10:48:13.347Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/78/543b94712ae8bb1a6023bcc1acf1a740fbff8286747c289cd9468fced2a5/pyarrow-24.0.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:a964266397740257f16f7bb2e4f08a0c81454004beab8ff59dd531b73610e9f2", size = 45675981, upload-time = "2026-04-21T10:48:20.201Z" },
+    { url = "https://files.pythonhosted.org/packages/84/9f/8fb7c222b100d314137fa40ec050de56cd8c6d957d1cfff685ce72f15b17/pyarrow-24.0.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:6f066b179d68c413374294bc1735f68475457c933258df594443bb9d88ddc2a0", size = 48859172, upload-time = "2026-04-21T10:48:27.541Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/d3/1ea72538e6c8b3b475ed78d1049a2c518e655761ea50fe1171fc855fcab7/pyarrow-24.0.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:1183baeb14c5f587b1ec52831e665718ce632caab84b7cd6b85fd44f96114495", size = 49385733, upload-time = "2026-04-21T10:48:34.7Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/be/c3d8b06a1ba35f2260f8e1f771abbee7d5e345c0937aab90675706b1690a/pyarrow-24.0.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:806f24b4085453c197a5078218d1ee08783ebbba271badd153d1ae22a3ee804f", size = 51934335, upload-time = "2026-04-21T10:48:42.099Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/62/89e07a1e7329d2cde3e3c6994ba0839a24977a2beda8be6005ea3d860b99/pyarrow-24.0.0-cp313-cp313-win_amd64.whl", hash = "sha256:e4505fc6583f7b05ab854934896bcac8253b04ac1171a77dfb73efef92076d91", size = 27271748, upload-time = "2026-04-21T10:49:42.532Z" },
+    { url = "https://files.pythonhosted.org/packages/17/1a/cff3a59f80b5b1658549d46611b67163f65e0664431c076ad728bf9d5af4/pyarrow-24.0.0-cp313-cp313t-macosx_12_0_arm64.whl", hash = "sha256:1a4e45017efbf115032e4475ee876d525e0e36c742214fbe405332480ecd6275", size = 35238554, upload-time = "2026-04-21T10:48:48.526Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/99/cce0f42a327bfef2c420fb6078a3eb834826e5d6697bf3009fe11d2ad051/pyarrow-24.0.0-cp313-cp313t-macosx_12_0_x86_64.whl", hash = "sha256:7986f1fa71cee060ad00758bcc79d3a93bab8559bf978fab9e53472a2e25a17b", size = 36782301, upload-time = "2026-04-21T10:48:55.181Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/66/8e560d5ff6793ca29aca213c53eec0dd482dd46cb93b2819e5aab52e4252/pyarrow-24.0.0-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:d3e0b61e8efb24ed38898e5cdc5fffa9124be480008d401a1f8071500494ae42", size = 45721929, upload-time = "2026-04-21T10:49:03.676Z" },
+    { url = "https://files.pythonhosted.org/packages/27/0c/a26e25505d030716e078d9f16eb74973cbf0b33b672884e9f9da1c83b871/pyarrow-24.0.0-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:55a3bc1e3df3b5567b7d27ef551b2283f0c68a5e86f1cd56abc569da4f31335b", size = 48825365, upload-time = "2026-04-21T10:49:11.714Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/eb/771f9ecb0c65e73fe9dccdd1717901b9594f08c4515d000c7c62df573811/pyarrow-24.0.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:641f795b361874ac9da5294f8f443dfdbee355cf2bd9e3b8d97aaac2306b9b37", size = 49451819, upload-time = "2026-04-21T10:49:21.474Z" },
+    { url = "https://files.pythonhosted.org/packages/48/da/61ae89a88732f5a785646f3ec6125dbb640fa98a540eb2b9889caa561403/pyarrow-24.0.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:8adc8e6ce5fccf5dc707046ae4914fd537def529709cc0d285d37a7f9cd442ca", size = 51909252, upload-time = "2026-04-21T10:49:31.164Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/1a/8dd5cafab7b66573fa91c03d06d213356ad4edd71813aa75e08ce2b3a844/pyarrow-24.0.0-cp313-cp313t-win_amd64.whl", hash = "sha256:9b18371ad2f44044b81a8d23bc2d8a9b6a6226dca775e8e16cfee640473d6c5d", size = 27388127, upload-time = "2026-04-21T10:49:37.334Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- add `semantic_index` as the low-level LanceDB/OpenAI staging primitive for dry-run, stage, query, and stats
- add first-class codebase tools: `codebase_index` for repo chunking/indexing/stats and `codebase_search` for keyword, semantic, or hybrid retrieval
- chunk Python with AST functions/classes/methods, Markdown by headings, and other text files by bounded line windows
- store repo/path/language/symbol/line-range/hash/model metadata in LanceDB while hiding raw vectors from stats/search output by default
- expose codebase tools in core, coding, ACP, API-server, and dedicated `codebase_search` toolsets

## Safety
- dry-run defaults never call OpenAI and never write LanceDB
- `semantic_index(action=stage)` and `codebase_index(action=index)` both require `embed=true`
- codebase indexing is bounded by `max_files`, `max_chunks`, `max_file_bytes`, and `max_chunk_chars`
- credential-looking chunks are skipped before OpenAI embedding
- stale rows are deleted for reindexed paths, including deleted files explicitly passed by path
- hybrid codebase search gracefully falls back to keyword search when embeddings/config/API/LanceDB are unavailable

## Validation
- `UV_CACHE_DIR=/tmp/hermes-uv-cache uv lock --check`
- `UV_CACHE_DIR=/tmp/hermes-uv-cache uv sync --extra dev --extra semantic`
- `.venv/bin/python -m py_compile tools/codebase_index_tool.py tools/semantic_index_tool.py tests/tools/test_codebase_index.py tests/tools/test_semantic_index.py hermes_cli/config.py toolsets.py tools/lazy_deps.py`
- `.venv/bin/python -m ruff check tools/codebase_index_tool.py tests/tools/test_codebase_index.py tools/semantic_index_tool.py tests/tools/test_semantic_index.py hermes_cli/config.py toolsets.py tools/lazy_deps.py`
- `scripts/run_tests.sh tests/tools/test_codebase_index.py tests/tools/test_semantic_index.py tests/tools/test_registry.py` (45 passed)
- `git diff --check`
- real LanceDB API smoke: wrote one fake-vector row and verified `stats` sample output
- real OpenAI + LanceDB semantic smoke: dry-run avoided external calls/writes; explicit `stage` embedded a 73-char payload with `text-embedding-3-small`, wrote one 1536-dimensional row, `stats` hid raw vectors, and semantic `query` returned the staged row
- real OpenAI + LanceDB codebase smoke: dry-run avoided external calls/writes; `codebase_index(action=index, embed=true)` embedded 30 bounded chunks into `codebase_chunks` with 1536-dimensional vectors; `codebase_search(mode=hybrid)` returned indexed code chunks