### PR TITLE
fix(dashboard): resolve chat TUI argv off event loop

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -142,6 +142,11 @@ def _start_desktop_cron_ticker(stop_event: "threading.Event", interval: int = 60
 async def _lifespan(app: "FastAPI"):
     app.state.event_channels = {}  # dict[str, set]
     app.state.event_lock = asyncio.Lock()
+    # Serializes chat-argv resolution so concurrent /api/pty connections
+    # don't trigger overlapping ``npm install`` / ``npm run build`` work.
+    # On app.state (not a module global) so the Lock binds to the running
+    # event loop during lifespan startup — see _get_event_state's docstring.
+    app.state.chat_argv_lock = asyncio.Lock()
 
     # Desktop-spawned backends (HERMES_DESKTOP=1) fire cron jobs themselves,
     # since the app has no gateway running the scheduler. Server `hermes
@@ -180,6 +185,20 @@ def _get_event_state(app: "FastAPI"):
         app.state.event_channels = {}
         app.state.event_lock = asyncio.Lock()
         return app.state.event_channels, app.state.event_lock
+
+
+def _get_chat_argv_lock(app: "FastAPI") -> asyncio.Lock:
+    """Return the chat-argv resolution lock from app.state.
+
+    Mirrors :func:`_get_event_state`: prefers the lifespan-initialised Lock
+    (created on the correct event loop) but lazily initialises it for
+    non-``with`` TestClient usages.
+    """
+    try:
+        return app.state.chat_argv_lock
+    except AttributeError:
+        app.state.chat_argv_lock = asyncio.Lock()
+        return app.state.chat_argv_lock
 
 
 app = FastAPI(title="Hermes Agent", version=__version__, lifespan=_lifespan)
@@ -10572,12 +10591,8 @@ def _ws_auth_ok(ws: "WebSocket") -> bool:
 # and /api/events (dashboard → browser sidebar).  Keyed by an opaque channel id
 # the chat tab generates on mount; entries auto-evict when the last subscriber
 # drops AND the publisher has disconnected.
-# (Channel state is initialised in _lifespan on app startup — see above.)
-#
-# Serializes chat-argv resolution so concurrent /api/pty connections don't
-# trigger overlapping ``npm install`` / ``npm run build`` work.  Process-wide
-# (not per-app), so it stays a module-level lock rather than app.state.
-_chat_argv_lock = asyncio.Lock()
+# (Channel state and the chat-argv lock are initialised in _lifespan on app
+# startup — see _get_event_state / _get_chat_argv_lock above.)
 
 
 def _resolve_chat_argv(
@@ -10709,7 +10724,7 @@ async def _resolve_chat_argv_async(
     multiple browser tabs connect at once without occupying worker threads
     while queued connections wait.
     """
-    async with _chat_argv_lock:
+    async with _get_chat_argv_lock(app):
         return await asyncio.to_thread(
             _resolve_chat_argv,
             resume=resume,

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -10572,7 +10572,12 @@ def _ws_auth_ok(ws: "WebSocket") -> bool:
 # and /api/events (dashboard → browser sidebar).  Keyed by an opaque channel id
 # the chat tab generates on mount; entries auto-evict when the last subscriber
 # drops AND the publisher has disconnected.
-# (State is initialised in _lifespan on app startup — see above.)
+# (Channel state is initialised in _lifespan on app startup — see above.)
+#
+# Serializes chat-argv resolution so concurrent /api/pty connections don't
+# trigger overlapping ``npm install`` / ``npm run build`` work.  Process-wide
+# (not per-app), so it stays a module-level lock rather than app.state.
+_chat_argv_lock = asyncio.Lock()
 
 
 def _resolve_chat_argv(
@@ -10687,6 +10692,30 @@ def _build_gateway_ws_url() -> Optional[str]:
         qs = urllib.parse.urlencode({"token": _SESSION_TOKEN})
 
     return f"ws://{netloc}/api/ws?{qs}"
+
+
+async def _resolve_chat_argv_async(
+    resume: Optional[str] = None,
+    sidecar_url: Optional[str] = None,
+    profile: Optional[str] = None,
+) -> tuple[list[str], Optional[str], Optional[dict]]:
+    """Resolve chat argv without blocking the dashboard event loop.
+
+    ``_resolve_chat_argv`` may run ``npm install`` / ``npm run build`` through
+    ``_make_tui_argv``.  Keep that synchronous work off the WebSocket event
+    loop so reverse proxies and existing dashboard connections can continue
+    to exchange keepalives while the TUI launch command is prepared.  The
+    async lock preserves the previous one-build-at-a-time behavior when
+    multiple browser tabs connect at once without occupying worker threads
+    while queued connections wait.
+    """
+    async with _chat_argv_lock:
+        return await asyncio.to_thread(
+            _resolve_chat_argv,
+            resume=resume,
+            sidecar_url=sidecar_url,
+            profile=profile,
+        )
 
 
 def _build_sidecar_url(channel: str) -> Optional[str]:
@@ -10819,7 +10848,7 @@ async def pty_ws(ws: WebSocket) -> None:
     sidecar_url = _build_sidecar_url(channel) if channel else None
 
     try:
-        argv, cwd, env = _resolve_chat_argv(
+        argv, cwd, env = await _resolve_chat_argv_async(
             resume=resume, sidecar_url=sidecar_url, profile=profile
         )
     except HTTPException as exc:

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -205,6 +205,7 @@ AUTHOR_MAP = {
     "me@promplate.dev": "CNSeniorious000",
     "yichengqiao21@gmail.com": "YarrowQiao",
     "erhanyasarx@gmail.com": "erhnysr",
+    "draihan@student.ubc.ca": "0xdany",  # PR #26124 salvage (chat argv off event loop)
     "30366221+WorldWriter@users.noreply.github.com": "WorldWriter",
     "dafeng@DafengdeMacBook-Pro.local": "WorldWriter",
     "schepers.zander1@gmail.com": "Strontvod",

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -5016,6 +5016,46 @@ class TestPtyWebSocket:
 
         assert captured["resume"] == "sess-99"
 
+    def test_pty_ws_propagates_systemexit_through_async_wrapper(self, monkeypatch):
+        """SystemExit from _make_tui_argv (node/npm missing) must propagate
+        through asyncio.to_thread + the async wrapper and be caught by
+        pty_ws's ``except SystemExit`` (closes cleanly, no crash)."""
+
+        def boom(resume=None, sidecar_url=None, profile=None):
+            raise SystemExit("node not found")
+
+        # Patch the REAL resolver so the whole _resolve_chat_argv_async ->
+        # to_thread -> lock -> re-raise chain is exercised, not mocked away.
+        monkeypatch.setattr(self.ws_module, "_resolve_chat_argv", boom)
+
+        text = ""
+        with self.client.websocket_connect(self._url()) as conn:
+            try:
+                text = conn.receive_text()
+            except Exception:
+                pass
+        # Existing error path emits the "Chat unavailable" notice and closes.
+        assert "Chat unavailable" in text
+
+    def test_pty_ws_propagates_httpexception_through_async_wrapper(self, monkeypatch):
+        """An invalid-profile HTTPException raised inside the threaded resolver
+        propagates through the wrapper and hits pty_ws's ``except HTTPException``."""
+        from fastapi import HTTPException
+
+        def bad_profile(resume=None, sidecar_url=None, profile=None):
+            raise HTTPException(status_code=404, detail="unknown profile")
+
+        monkeypatch.setattr(self.ws_module, "_resolve_chat_argv", bad_profile)
+
+        text = ""
+        with self.client.websocket_connect(self._url(profile="ghost")) as conn:
+            try:
+                text = conn.receive_text()
+            except Exception:
+                pass
+        assert "Chat unavailable" in text
+        assert "unknown profile" in text
+
     def test_streams_child_stdout_to_client(self, monkeypatch):
         monkeypatch.setattr(
             self.ws_module,

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -1,5 +1,6 @@
 """Tests for hermes_cli.web_server and related config utilities."""
 
+import asyncio
 import os
 import json
 import shutil
@@ -4955,6 +4956,65 @@ class TestPtyWebSocket:
             with self.client.websocket_connect(self._url(token="wrong")):
                 pass
         assert exc.value.code == 4401
+
+    def test_resolve_chat_argv_async_uses_worker_thread(self, monkeypatch):
+        captured: dict = {}
+
+        def fake_resolve(resume=None, sidecar_url=None, profile=None):
+            captured["resume"] = resume
+            captured["sidecar_url"] = sidecar_url
+            captured["profile"] = profile
+            return (["node", "dist/entry.js"], "/tmp/ui-tui", {"NODE_ENV": "production"})
+
+        async def fake_to_thread(fn, *args, **kwargs):
+            captured["thread_fn"] = fn
+            captured["thread_args"] = args
+            captured["thread_kwargs"] = kwargs
+            return fn(*args, **kwargs)
+
+        monkeypatch.setattr(self.ws_module, "_resolve_chat_argv", fake_resolve)
+        monkeypatch.setattr(self.ws_module.asyncio, "to_thread", fake_to_thread)
+
+        argv, cwd, env = asyncio.run(
+            self.ws_module._resolve_chat_argv_async(
+                resume="sess-42",
+                sidecar_url="ws://127.0.0.1:9119/api/pub?channel=abc",
+                profile="worker",
+            )
+        )
+
+        assert callable(captured["thread_fn"])
+        assert captured["thread_args"] == ()
+        assert captured["thread_kwargs"] == {
+            "resume": "sess-42",
+            "sidecar_url": "ws://127.0.0.1:9119/api/pub?channel=abc",
+            "profile": "worker",
+        }
+        assert argv == ["node", "dist/entry.js"]
+        assert cwd == "/tmp/ui-tui"
+        assert env == {"NODE_ENV": "production"}
+        assert captured["resume"] == "sess-42"
+        assert captured["sidecar_url"] == "ws://127.0.0.1:9119/api/pub?channel=abc"
+        assert captured["profile"] == "worker"
+
+    def test_pty_ws_resolves_argv_through_async_wrapper(self, monkeypatch):
+        captured: dict = {}
+
+        async def fake_resolve_async(resume=None, sidecar_url=None, profile=None):
+            captured["resume"] = resume
+            captured["sidecar_url"] = sidecar_url
+            captured["profile"] = profile
+            return (["/bin/sh", "-c", "printf async-resolve-ok"], None, None)
+
+        monkeypatch.setattr(self.ws_module, "_resolve_chat_argv_async", fake_resolve_async)
+
+        with self.client.websocket_connect(self._url(resume="sess-99")) as conn:
+            try:
+                conn.receive_bytes()
+            except Exception:
+                pass
+
+        assert captured["resume"] == "sess-99"
 
     def test_streams_child_stdout_to_client(self, monkeypatch):
         monkeypatch.setattr(

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -5016,26 +5016,35 @@ class TestPtyWebSocket:
 
         assert captured["resume"] == "sess-99"
 
+    def _assert_pty_propagates(self, monkeypatch, raising_resolver, *, profile=None, expect_detail=None):
+        """Drive /api/pty with a resolver that raises, and assert the error
+        propagates through the real _resolve_chat_argv_async -> asyncio.to_thread
+        -> lock -> re-raise chain into pty_ws's handler: the "Chat unavailable"
+        notice is sent and the socket closes with code 1011 (the stable
+        contract — we assert the close code, not the exact notice wording)."""
+        from starlette.websockets import WebSocketDisconnect
+
+        # Patch the REAL resolver so the whole wrapper/to_thread/lock chain runs.
+        monkeypatch.setattr(self.ws_module, "_resolve_chat_argv", raising_resolver)
+
+        url = self._url(profile=profile) if profile else self._url()
+        with self.client.websocket_connect(url) as conn:
+            notice = conn.receive_text()
+            with pytest.raises(WebSocketDisconnect) as exc:
+                conn.receive_text()
+        assert "Chat unavailable" in notice
+        assert exc.value.code == 1011
+        if expect_detail is not None:
+            assert expect_detail in notice
+
     def test_pty_ws_propagates_systemexit_through_async_wrapper(self, monkeypatch):
-        """SystemExit from _make_tui_argv (node/npm missing) must propagate
-        through asyncio.to_thread + the async wrapper and be caught by
-        pty_ws's ``except SystemExit`` (closes cleanly, no crash)."""
+        """SystemExit from _make_tui_argv (node/npm missing) propagates through
+        the async wrapper and is caught by pty_ws's ``except SystemExit``."""
 
         def boom(resume=None, sidecar_url=None, profile=None):
             raise SystemExit("node not found")
 
-        # Patch the REAL resolver so the whole _resolve_chat_argv_async ->
-        # to_thread -> lock -> re-raise chain is exercised, not mocked away.
-        monkeypatch.setattr(self.ws_module, "_resolve_chat_argv", boom)
-
-        text = ""
-        with self.client.websocket_connect(self._url()) as conn:
-            try:
-                text = conn.receive_text()
-            except Exception:
-                pass
-        # Existing error path emits the "Chat unavailable" notice and closes.
-        assert "Chat unavailable" in text
+        self._assert_pty_propagates(monkeypatch, boom)
 
     def test_pty_ws_propagates_httpexception_through_async_wrapper(self, monkeypatch):
         """An invalid-profile HTTPException raised inside the threaded resolver
@@ -5045,16 +5054,9 @@ class TestPtyWebSocket:
         def bad_profile(resume=None, sidecar_url=None, profile=None):
             raise HTTPException(status_code=404, detail="unknown profile")
 
-        monkeypatch.setattr(self.ws_module, "_resolve_chat_argv", bad_profile)
-
-        text = ""
-        with self.client.websocket_connect(self._url(profile="ghost")) as conn:
-            try:
-                text = conn.receive_text()
-            except Exception:
-                pass
-        assert "Chat unavailable" in text
-        assert "unknown profile" in text
+        self._assert_pty_propagates(
+            monkeypatch, bad_profile, profile="ghost", expect_detail="unknown profile"
+        )
 
     def test_streams_child_stdout_to_client(self, monkeypatch):
         monkeypatch.setattr(


### PR DESCRIPTION
## Summary

Salvage of #26124 (by @0xdany), rebased onto current `main`, plus self-review hardening.

Dashboard chat resolves its TUI launch command **synchronously** inside the `/api/pty` WebSocket handler. The resolver (`_resolve_chat_argv` → `_make_tui_argv`) can run `npm install` / `npm run build`, and doing that on the event loop blocks proxy keepalives and other dashboard WebSocket work long enough for reverse-proxy deployments (Cloudflare, nginx, Traefik) to drop the chat connection — the silent `[session ended]` / 502 symptom from #25351.

This moves the potentially slow resolver work to a worker thread via `asyncio.to_thread()`, serialized by a lock so concurrent chat tabs preserve one-build-at-a-time behavior without occupying threadpool workers while queued. The TUI build policy is unchanged (normal launches still `npm run build`; `HERMES_TUI_DIR` stays the prebuilt path); only *where* the resolver runs moves.

The original PR was **approved by @austinpickett**; it only needed a rebase because `_resolve_chat_argv` gained a `profile` parameter and an `HTTPException` branch on `main` after the PR was opened.

## What changed vs. the original PR

1. **`profile` passthrough** — the async wrapper now threads the `profile` parameter `_resolve_chat_argv` gained on `main` (cross-profile dashboard chat), and the `pty_ws` call site keeps the new `HTTPException` (invalid-profile) handler alongside the existing `SystemExit` (node/npm-missing) handler. The two carried-over tests were updated to the current 3-arg signature.

2. **Lock on `app.state`, not a module global** (self-review fix) — the original PR used a module-level `asyncio.Lock()`. That binds to whatever event loop is active at import time, which is exactly the pattern `_get_event_state`'s docstring warns against (breaks across `TestClient` instances / uvicorn reloads — the same reason `event_lock` lives on `app.state`). Moved it to `app.state.chat_argv_lock`, initialised in `_lifespan` with a lazy `_get_chat_argv_lock(app)` fallback, mirroring `event_lock`.

3. **Error-propagation tests** (self-review fix) — added two tests that exercise the real `_resolve_chat_argv_async` → `asyncio.to_thread` → lock → re-raise chain: `SystemExit` and `HTTPException` raised inside the worker thread both propagate out and are caught by `pty_ws`'s existing handlers (closes with the "Chat unavailable" notice). The carried-over tests mocked `asyncio.to_thread` away and never covered this path.

## Changes

- `hermes_cli/web_server.py`: `_resolve_chat_argv_async()` (lock from `app.state` via `_get_chat_argv_lock` + `asyncio.to_thread`, forwarding `resume`/`sidecar_url`/`profile`); `/api/pty` awaits it; `_lifespan` initialises `app.state.chat_argv_lock`.
- `tests/hermes_cli/test_web_server.py`: dispatch-through-`to_thread` + `/api/pty`-routes-through-wrapper tests (with `profile` passthrough) and two new `SystemExit`/`HTTPException` propagation tests.
- `scripts/release.py`: AUTHOR_MAP entry for @0xdany.

## Test plan

```
pytest tests/hermes_cli/test_web_server.py tests/hermes_cli/test_tui_npm_install.py -q
→ 310 passed (3 PTY-streaming tests fail identically on bare main — env needs ptyprocess; pre-existing, not caused by this change)
git diff --check → clean
```

## Related

- Supersedes #26124 (approved by @austinpickett; salvaged here, authorship preserved via `Co-authored-by`).
- Supersedes #26836 (same off-the-event-loop fix via `run_in_executor`).
- Context: #25351 (closed `not_planned`; the container symptom was mitigated by the `HERMES_TUI_DIR` prebuilt Docker path, but the event-loop-blocking resolver was never moved off the loop on `main` — this completes that).

Co-authored-by: 0xdany <draihan@student.ubc.ca>
