### PR TITLE
feat(xiaomi): disable MiMo thinking when reasoning is off

### DIFF
--- a/plugins/model-providers/xiaomi/__init__.py
+++ b/plugins/model-providers/xiaomi/__init__.py
@@ -1,9 +1,38 @@
 """Xiaomi MiMo provider profile."""
 
+from typing import Any
+
 from providers import register_provider
 from providers.base import ProviderProfile
 
-xiaomi = ProviderProfile(
+
+class XiaomiProfile(ProviderProfile):
+    """Xiaomi MiMo — disable thinking via ``extra_body.thinking`` when reasoning is off.
+
+    MiMo (vLLM-served, OpenAI-compatible at ``api.xiaomimimo.com/v1``) reasons by
+    default. Sending ``extra_body={"thinking": {"type": "disabled"}}`` makes it
+    skip the reasoning pass (``reasoning_tokens`` -> 0); verified against
+    ``api.xiaomimimo.com``. MiMo rejects a top-level ``reasoning_effort``
+    (HTTP 400), so it has no effort granularity: any enabled level leaves the
+    server default (thinking on) untouched. Mirrors the disable path used by the
+    opencode-zen / kimi profiles.
+    """
+
+    def build_api_kwargs_extras(
+        self, *, reasoning_config: dict | None = None, **context: Any
+    ) -> tuple[dict[str, Any], dict[str, Any]]:
+        extra_body: dict[str, Any] = {}
+        # reasoning_config is {"enabled": False} for "/reasoning none"; only then
+        # do we override. No config / enabled → leave MiMo's server default.
+        if (
+            isinstance(reasoning_config, dict)
+            and reasoning_config.get("enabled") is False
+        ):
+            extra_body["thinking"] = {"type": "disabled"}
+        return extra_body, {}
+
+
+xiaomi = XiaomiProfile(
     name="xiaomi",
     aliases=("mimo", "xiaomi-mimo"),
     env_vars=("XIAOMI_API_KEY",),

--- a/tests/plugins/model_providers/test_xiaomi_profile.py
+++ b/tests/plugins/model_providers/test_xiaomi_profile.py
@@ -1,0 +1,55 @@
+"""Unit tests for the Xiaomi MiMo provider profile's reasoning wiring.
+
+MiMo (``api.xiaomimimo.com/v1``, OpenAI-compatible) reasons by default. Turning
+reasoning off (``/reasoning none`` -> reasoning_config ``{"enabled": False}``)
+must send ``extra_body={"thinking": {"type": "disabled"}}`` so ``reasoning_tokens``
+drop to 0. Every other state leaves the server default untouched — MiMo rejects a
+top-level ``reasoning_effort`` (HTTP 400), so there is no effort granularity to map.
+
+Mirrors ``tests/plugins/model_providers/test_kimi_profile.py``.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.fixture
+def xiaomi_profile():
+    """Resolve the registered Xiaomi profile via the provider registry.
+
+    Importing ``model_tools`` triggers plugin discovery, which registers the
+    Xiaomi profile. Going through ``get_provider_profile`` keeps the test honest:
+    if the registered class is ever swapped for a plain ``ProviderProfile`` the
+    disable assertion below collapses.
+    """
+    import model_tools  # noqa: F401
+    import providers
+
+    profile = providers.get_provider_profile("xiaomi")
+    assert profile is not None, "xiaomi provider profile must be registered"
+    return profile
+
+
+class TestXiaomiReasoningWireShape:
+    def test_no_config_leaves_server_default(self, xiaomi_profile):
+        extra_body, top_level = xiaomi_profile.build_api_kwargs_extras(
+            reasoning_config=None
+        )
+        assert extra_body == {}
+        assert top_level == {}
+
+    def test_disabled_sends_thinking_disabled(self, xiaomi_profile):
+        extra_body, top_level = xiaomi_profile.build_api_kwargs_extras(
+            reasoning_config={"enabled": False}
+        )
+        assert extra_body == {"thinking": {"type": "disabled"}}
+        assert top_level == {}
+
+    @pytest.mark.parametrize("effort", ["minimal", "low", "medium", "high", "xhigh"])
+    def test_enabled_leaves_default(self, xiaomi_profile, effort):
+        extra_body, top_level = xiaomi_profile.build_api_kwargs_extras(
+            reasoning_config={"enabled": True, "effort": effort}
+        )
+        assert extra_body == {}
+        assert top_level == {}

--- a/tests/plugins/model_providers/test_xiaomi_profile.py
+++ b/tests/plugins/model_providers/test_xiaomi_profile.py
@@ -53,3 +53,60 @@ class TestXiaomiReasoningWireShape:
         )
         assert extra_body == {}
         assert top_level == {}
+
+
+class TestXiaomiFullKwargsIntegration:
+    """End-to-end: the transport's full kwargs carry the reasoning wiring.
+
+    The wire shape tests above call ``build_api_kwargs_extras`` in isolation;
+    these drive the real profile-to-transport merge in
+    ``ChatCompletionsTransport.build_kwargs`` so a regression in the merge (not
+    just the profile) is caught. Mirrors ``TestZaiFullKwargsIntegration`` in
+    ``tests/plugins/model_providers/test_zai_profile.py``.
+    """
+
+    def test_disabled_reaches_the_wire(self, xiaomi_profile):
+        from agent.transports.chat_completions import ChatCompletionsTransport
+
+        kwargs = ChatCompletionsTransport().build_kwargs(
+            model="mimo",
+            messages=[{"role": "user", "content": "ping"}],
+            tools=None,
+            provider_profile=xiaomi_profile,
+            reasoning_config={"enabled": False},
+            base_url="https://api.xiaomimimo.com/v1",
+            provider_name="xiaomi",
+        )
+        assert kwargs["extra_body"]["thinking"] == {"type": "disabled"}
+
+    def test_no_preference_keeps_wire_clean(self, xiaomi_profile):
+        from agent.transports.chat_completions import ChatCompletionsTransport
+
+        kwargs = ChatCompletionsTransport().build_kwargs(
+            model="mimo",
+            messages=[{"role": "user", "content": "ping"}],
+            tools=None,
+            provider_profile=xiaomi_profile,
+            reasoning_config=None,
+            base_url="https://api.xiaomimimo.com/v1",
+            provider_name="xiaomi",
+        )
+        assert "thinking" not in kwargs.get("extra_body", {})
+
+    @pytest.mark.parametrize("effort", ["low", "high", "xhigh"])
+    def test_enabled_keeps_wire_clean(self, xiaomi_profile, effort):
+        # MiMo has no effort granularity (rejects top-level reasoning_effort with
+        # HTTP 400), so any enabled level must leave the server default untouched.
+        from agent.transports.chat_completions import ChatCompletionsTransport
+
+        kwargs = ChatCompletionsTransport().build_kwargs(
+            model="mimo",
+            messages=[{"role": "user", "content": "ping"}],
+            tools=None,
+            provider_profile=xiaomi_profile,
+            reasoning_config={"enabled": True, "effort": effort},
+            base_url="https://api.xiaomimimo.com/v1",
+            provider_name="xiaomi",
+        )
+        assert "thinking" not in kwargs.get("extra_body", {})
+        assert "reasoning_effort" not in kwargs


### PR DESCRIPTION
## What does this PR do?

The Xiaomi MiMo provider profile was a bare `ProviderProfile`, so the
`/reasoning none` toggle (reasoning_config `{"enabled": False}`) had **no effect** —
MiMo kept running its reasoning pass on every call (non-zero `reasoning_tokens`,
extra latency and cost) with no way to turn it off.

This overrides `build_api_kwargs_extras` so that, when reasoning is disabled, the
profile sends `extra_body={"thinking": {"type": "disabled"}}` — the same disable
shape already used by the `opencode-zen` and `kimi` profiles. Every other state
is left untouched: MiMo rejects a top-level `reasoning_effort` (HTTP 400), so it
has no effort granularity, and the default (thinking on) is preserved when no
config is passed.

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `plugins/model-providers/xiaomi/__init__.py`: turn the bare `ProviderProfile`
  into a `XiaomiProfile` subclass that overrides `build_api_kwargs_extras`;
  emits `extra_body.thinking = {"type": "disabled"}` only when
  `reasoning_config["enabled"] is False`.
- `tests/plugins/model_providers/test_xiaomi_profile.py`: unit tests for the
  wire shape (no-config → empty; disabled → thinking disabled; enabled levels →
  untouched). Mirrors `test_kimi_profile.py`.

## How to Test

1. `scripts/run_tests.sh tests/plugins/model_providers/test_xiaomi_profile.py` → **7 passed**.
2. Manual / live: against `api.xiaomimimo.com` (model `mimo-v2.5`), sending the
   profile's emitted `extra_body={"thinking":{"type":"disabled"}}` drops
   `reasoning_tokens` from ~31 to **0** with identical answer content; baseline
   (no override) keeps reasoning on. `reasoning_effort` is rejected by MiMo
   (HTTP 400), confirming why only the `thinking` toggle is used.

## Platforms tested

- macOS (Apple Silicon), Python 3.11.
