### PR TITLE
fix(backup): cap per-file size so bulk blobs don't hang or fill the disk

### DIFF
--- a/hermes_cli/backup.py
+++ b/hermes_cli/backup.py
@@ -249,6 +249,90 @@ def _should_skip_backup_file(abs_path: Path, rel_path: Path, out_path: Path) -> 
         return False
 
 
+# Per-file size cap. A backup ships portable config/state, not bulk data
+# (VM images, model weights, datasets) that accumulates inside profile working
+# dirs. Without a cap, a single multi-GB blob -- e.g. a Docker.raw under a
+# profile -- makes the backup hang and can fill the disk.
+#
+# The cap is a user-facing behavioral setting, so its source of truth is
+# ``updates.backup_max_file_mb`` in config.yaml (set to 0 to disable the cap) --
+# NOT a HERMES_* env var, since .env is for secrets only (see AGENTS.md).
+# ``HERMES_BACKUP_MAX_FILE_MB`` is retained ONLY as an internal override for
+# tests/tooling and is intentionally undocumented for users.
+_DEFAULT_MAX_FILE_MB = 2048
+
+# State databases are always backed up regardless of size: they are the whole
+# point of a backup (kanban.db, sessions, memory) and go through the SQLite
+# safe-copy path. A large one must never be silently dropped by the size cap,
+# so these suffixes are exempt.
+_STATE_DB_SUFFIXES = (".db", ".sqlite", ".sqlite3")
+
+
+def _config_max_file_mb() -> float:
+    """Read ``updates.backup_max_file_mb`` (MB) from config.yaml.
+
+    Falls back to :data:`_DEFAULT_MAX_FILE_MB` when the key is missing, the
+    value is non-numeric, or config can't be read -- a backup must never fail
+    or silently drop the cap because of a config typo.
+    """
+    # read_raw_config() reads config.yaml as-is with NO side effects. Using
+    # load_config() here would trigger ensure_hermes_home(), materializing a
+    # default config.yaml inside the very HERMES_HOME being backed up.
+    try:
+        from hermes_cli.config import read_raw_config
+
+        updates_cfg = (read_raw_config() or {}).get("updates", {}) or {}
+        return float(updates_cfg.get("backup_max_file_mb", _DEFAULT_MAX_FILE_MB))
+    except (TypeError, ValueError):
+        return float(_DEFAULT_MAX_FILE_MB)
+    except Exception as exc:  # config read must never break a backup
+        logger.debug("Could not read updates.backup_max_file_mb: %s", exc)
+        return float(_DEFAULT_MAX_FILE_MB)
+
+
+def _max_backup_file_bytes() -> int:
+    """Return the per-file size cap in bytes (0 means no cap).
+
+    Source of truth is ``updates.backup_max_file_mb`` in config.yaml. The
+    internal ``HERMES_BACKUP_MAX_FILE_MB`` env var overrides it for tests and
+    tooling only. Invalid values fall back to the default so a typo never
+    silently disables the cap.
+    """
+    raw = os.getenv("HERMES_BACKUP_MAX_FILE_MB", "").strip()
+    if raw:
+        try:
+            mb = float(raw)
+        except ValueError:
+            mb = float(_DEFAULT_MAX_FILE_MB)
+    else:
+        mb = _config_max_file_mb()
+    if mb <= 0:
+        return 0
+    return int(mb * 1024 * 1024)
+
+
+def _is_state_db(abs_path: Path) -> bool:
+    """State databases are exempt from the size cap (always safe-copied)."""
+    return abs_path.suffix.lower() in _STATE_DB_SUFFIXES
+
+
+def _oversized_backup_bytes(abs_path: Path, max_file_bytes: int) -> Optional[int]:
+    """Return the file's size if it is over the cap and should be skipped.
+
+    Returns ``None`` (keep the file) when the cap is disabled, the file is a
+    state database (always backed up), or its size can't be read. Shared by
+    every backup walker -- the direct walk, the external-provider walk, and the
+    pre-update full-zip path -- so all of them cap identically.
+    """
+    if not max_file_bytes or _is_state_db(abs_path):
+        return None
+    try:
+        size = abs_path.stat().st_size
+    except OSError:
+        return None
+    return size if size > max_file_bytes else None
+
+
 # ---------------------------------------------------------------------------
 # SQLite safe copy
 # ---------------------------------------------------------------------------
@@ -319,6 +403,8 @@ def run_backup(args) -> None:
     print(f"Scanning {display_hermes_home()} ...")
     files_to_add: list[tuple[Path, Path]] = []  # (absolute, relative)
     skipped_dirs = set()
+    skipped_large: list[tuple[Path, int]] = []  # (relative/arcname, size) over the cap
+    max_file_bytes = _max_backup_file_bytes()
 
     for dirpath, dirnames, filenames in os.walk(hermes_root, followlinks=False):
         dp = Path(dirpath)
@@ -343,6 +429,14 @@ def run_backup(args) -> None:
             if _should_skip_backup_file(fpath, rel, out_path):
                 continue
 
+            # Skip oversized files (see _oversized_backup_bytes): a multi-GB
+            # blob under a profile would otherwise hang the backup / fill the
+            # disk. State DBs are exempt and always backed up.
+            oversized = _oversized_backup_bytes(fpath, max_file_bytes)
+            if oversized is not None:
+                skipped_large.append((rel, oversized))
+                continue
+
             files_to_add.append((fpath, rel))
 
     # External memory-provider state (e.g. ~/.honcho, ~/.hindsight) lives
@@ -365,6 +459,12 @@ def run_backup(args) -> None:
             try:
                 rel_to_home = fpath.resolve().relative_to(home_dir)
             except (ValueError, OSError):
+                continue
+            # Same per-file cap as the HERMES_HOME walk: a declared external
+            # provider dir can hold bulk data too. State DBs stay exempt.
+            oversized = _oversized_backup_bytes(fpath, max_file_bytes)
+            if oversized is not None:
+                skipped_large.append((Path(_EXTERNAL_PREFIX + rel_to_home.as_posix()), oversized))
                 continue
             arcname = _EXTERNAL_PREFIX + rel_to_home.as_posix()
             external_to_add.append((fpath, arcname))
@@ -448,6 +548,18 @@ def run_backup(args) -> None:
         )
         for p in sorted(skipped_external)[:10]:
             print(f"    {p}")
+
+    if skipped_large:
+        total_skipped = sum(sz for _, sz in skipped_large)
+        print(
+            f"\n  Skipped {len(skipped_large)} large file(s) over "
+            f"{_format_size(max_file_bytes)} ({_format_size(total_skipped)} total; "
+            f"set updates.backup_max_file_mb in config.yaml to change, 0 to disable):"
+        )
+        for rel, sz in sorted(skipped_large, key=lambda x: -x[1])[:10]:
+            print(f"    {rel} ({_format_size(sz)})")
+        if len(skipped_large) > 10:
+            print(f"    ... and {len(skipped_large) - 10} more")
 
     if skipped_dirs:
         print("\n  Excluded directories:")
@@ -1153,6 +1265,12 @@ def _write_full_zip_backup(out_path: Path, hermes_root: Path) -> Optional[Path]:
     or write error — caller should surface the outcome but not raise).
     """
     files_to_add: list[tuple[Path, Path]] = []
+    # Same per-file size cap as run_backup so ``hermes update --backup`` (which
+    # routes here via create_pre_update_backup) can't hang or fill the disk on a
+    # multi-GB blob. State DBs are exempt. Reported via the logger since this
+    # path has no interactive summary.
+    max_file_bytes = _max_backup_file_bytes()
+    skipped_large = 0
     try:
         for dirpath, dirnames, filenames in os.walk(hermes_root, followlinks=False):
             dp = Path(dirpath)
@@ -1169,10 +1287,25 @@ def _write_full_zip_backup(out_path: Path, hermes_root: Path) -> Optional[Path]:
                 if _should_skip_backup_file(fpath, rel, out_path):
                     continue
 
+                oversized = _oversized_backup_bytes(fpath, max_file_bytes)
+                if oversized is not None:
+                    logger.info(
+                        "Full-zip backup: skipping %s (%s over the %s cap; "
+                        "set updates.backup_max_file_mb to change)",
+                        rel, _format_size(oversized), _format_size(max_file_bytes),
+                    )
+                    skipped_large += 1
+                    continue
+
                 files_to_add.append((fpath, rel))
     except OSError as exc:
         logger.warning("Full-zip backup: walk failed: %s", exc)
         return None
+
+    if skipped_large:
+        logger.info(
+            "Full-zip backup: skipped %d file(s) over the size cap", skipped_large
+        )
 
     if not files_to_add:
         return None

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -3124,6 +3124,14 @@ DEFAULT_CONFIG = {
         # disable backups entirely, set ``pre_update_backup: false`` above
         # rather than ``backup_keep: 0``.
         "backup_keep": 5,
+        # Per-file size cap (in MB) for backups. A backup ships portable
+        # config/state, not bulk data (VM images, model weights, datasets) that
+        # piles up inside profile working dirs -- without a cap a single
+        # multi-GB blob (e.g. a Docker.raw) makes ``hermes backup`` and the
+        # pre-update backup hang and can fill the disk. Files over this size are
+        # skipped; state databases (``.db``/``.sqlite``) are always backed up
+        # regardless. Set to 0 to disable the cap entirely.
+        "backup_max_file_mb": 2048,
         # What `hermes update` does with uncommitted local changes to the
         # source tree when it runs NON-interactively — i.e. triggered from
         # the desktop/chat app or the gateway, where there's no TTY to answer

--- a/tests/hermes_cli/test_backup.py
+++ b/tests/hermes_cli/test_backup.py
@@ -2530,3 +2530,185 @@ class TestMemoryProviderExternalPaths:
 
         paths = HindsightMemoryProvider().backup_paths()
         assert str(tmp_path / ".hindsight") in paths
+
+
+class TestBackupSizeCap:
+    """Per-file size cap keeps bulk data (VM images, model weights, datasets)
+    out of the portable config/state backup.
+
+    Regression guard: a multi-GB ``Docker.raw`` under a profile working dir once
+    made ``hermes update --backup`` hang and nearly fill the disk because the
+    backup walker had only name/suffix/dir exclusions and no size limit. The cap
+    now applies to every backup path -- the direct ``hermes backup`` walk, the
+    external memory-provider walk, and the pre-update full-zip -- while state
+    databases stay exempt so a large kanban.db is never dropped.
+    """
+
+    def _tree_with_big_file(self, home: Path, big_bytes: int) -> None:
+        (home / "config.yaml").write_text("model:\n  default: x\n")
+        prof = home / "profiles" / "p"
+        prof.mkdir(parents=True)
+        (prof / "small.txt").write_text("ok")
+        with open(prof / "blob.bin", "wb") as fh:
+            fh.write(b"\0" * big_bytes)
+
+    def test_skips_file_over_cap(self, tmp_path, monkeypatch):
+        from hermes_cli.backup import run_backup
+
+        home = tmp_path / ".hermes"
+        home.mkdir()
+        self._tree_with_big_file(home, big_bytes=200 * 1024)  # 200 KB
+        monkeypatch.setenv("HERMES_HOME", str(home))
+        monkeypatch.setenv("HERMES_BACKUP_MAX_FILE_MB", "0.05")  # ~50 KB cap
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+
+        out_zip = tmp_path / "backup.zip"
+        run_backup(Namespace(output=str(out_zip)))
+
+        with zipfile.ZipFile(out_zip) as zf:
+            names = zf.namelist()
+        assert "config.yaml" in names
+        assert "profiles/p/small.txt" in names
+        assert "profiles/p/blob.bin" not in names  # over the cap -> skipped
+
+    def test_cap_disabled_includes_large(self, tmp_path, monkeypatch):
+        from hermes_cli.backup import run_backup
+
+        home = tmp_path / ".hermes"
+        home.mkdir()
+        self._tree_with_big_file(home, big_bytes=200 * 1024)
+        monkeypatch.setenv("HERMES_HOME", str(home))
+        monkeypatch.setenv("HERMES_BACKUP_MAX_FILE_MB", "0")  # disabled
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+
+        out_zip = tmp_path / "backup.zip"
+        run_backup(Namespace(output=str(out_zip)))
+
+        with zipfile.ZipFile(out_zip) as zf:
+            assert "profiles/p/blob.bin" in zf.namelist()
+
+    def test_oversized_state_db_is_retained(self, tmp_path, monkeypatch):
+        """State DBs are exempt from the cap. An over-cap ``kanban.db`` must
+        still be backed up -- dropping it would silently lose state on restore,
+        contradicting the "state / DBs are untouched" guarantee."""
+        from hermes_cli.backup import run_backup
+
+        home = tmp_path / ".hermes"
+        home.mkdir()
+        (home / "config.yaml").write_text("model:\n  default: x\n")
+        with open(home / "kanban.db", "wb") as fh:
+            fh.write(b"\0" * (200 * 1024))
+        with open(home / "blob.bin", "wb") as fh:
+            fh.write(b"\0" * (200 * 1024))
+        monkeypatch.setenv("HERMES_HOME", str(home))
+        monkeypatch.setenv("HERMES_BACKUP_MAX_FILE_MB", "0.05")  # ~50 KB cap
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+
+        out_zip = tmp_path / "backup.zip"
+        run_backup(Namespace(output=str(out_zip)))
+
+        with zipfile.ZipFile(out_zip) as zf:
+            names = zf.namelist()
+        assert "kanban.db" in names  # state DB exempt -> always backed up
+        assert "blob.bin" not in names  # plain blob over cap -> skipped
+
+    def test_external_provider_file_over_cap_is_skipped(self, tmp_path, monkeypatch):
+        """The external memory-provider walk caps oversized files too, and keeps
+        its exemption for state DBs (bot review point #4)."""
+        import hermes_cli.backup as backup_mod
+
+        home = tmp_path / ".hermes"
+        home.mkdir()
+        (home / "config.yaml").write_text("model:\n  default: x\n")
+        # External provider dir (e.g. ~/.honcho) under home, with a bulk blob,
+        # a small file, and a state DB -- all well over the cap.
+        honcho = tmp_path / ".honcho"
+        honcho.mkdir()
+        (honcho / "small.json").write_text('{"a":1}')
+        with open(honcho / "blob.bin", "wb") as fh:
+            fh.write(b"\0" * (200 * 1024))
+        with open(honcho / "store.db", "wb") as fh:
+            fh.write(b"\0" * (200 * 1024))
+        monkeypatch.setenv("HERMES_HOME", str(home))
+        monkeypatch.setenv("HERMES_BACKUP_MAX_FILE_MB", "0.05")  # ~50 KB cap
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.setattr(
+            backup_mod, "_collect_memory_provider_external_paths", lambda: [honcho]
+        )
+
+        out_zip = tmp_path / "backup.zip"
+        backup_mod.run_backup(Namespace(output=str(out_zip)))
+
+        with zipfile.ZipFile(out_zip) as zf:
+            names = set(zf.namelist())
+        assert "_external/.honcho/small.json" in names
+        assert "_external/.honcho/store.db" in names  # state DB exempt
+        assert "_external/.honcho/blob.bin" not in names  # over cap -> skipped
+
+    def test_pre_update_backup_applies_cap(self, tmp_path, monkeypatch):
+        """The pre-update path (``hermes update --backup`` ->
+        ``_write_full_zip_backup``) caps oversized files too, not just the
+        direct ``hermes backup`` walker -- that was the reported hang."""
+        from hermes_cli.backup import create_pre_update_backup
+
+        home = tmp_path / ".hermes"
+        home.mkdir()
+        (home / "config.yaml").write_text("model:\n  default: x\n")
+        with open(home / "big.bin", "wb") as fh:
+            fh.write(b"\0" * (200 * 1024))
+        with open(home / "state.db", "wb") as fh:
+            fh.write(b"\0" * (200 * 1024))
+        monkeypatch.setenv("HERMES_BACKUP_MAX_FILE_MB", "0.05")  # ~50 KB cap
+
+        out = create_pre_update_backup(hermes_home=home)
+        assert out is not None
+        with zipfile.ZipFile(out) as zf:
+            names = zf.namelist()
+        assert "config.yaml" in names
+        assert "big.bin" not in names  # over cap -> skipped on the update path
+        assert "state.db" in names  # state DB exempt
+
+    def test_default_cap_value(self, monkeypatch):
+        import hermes_cli.backup as backup_mod
+        import hermes_cli.config as config_mod
+
+        monkeypatch.delenv("HERMES_BACKUP_MAX_FILE_MB", raising=False)
+        # No env and no configured value -> fall back to the default.
+        monkeypatch.setattr(config_mod, "read_raw_config", lambda: {})
+        assert (
+            backup_mod._max_backup_file_bytes()
+            == backup_mod._DEFAULT_MAX_FILE_MB * 1024 * 1024
+        )
+
+    def test_invalid_env_falls_back_to_default(self, monkeypatch):
+        import hermes_cli.backup as backup_mod
+
+        monkeypatch.setenv("HERMES_BACKUP_MAX_FILE_MB", "not-a-number")
+        assert (
+            backup_mod._max_backup_file_bytes()
+            == backup_mod._DEFAULT_MAX_FILE_MB * 1024 * 1024
+        )
+
+    def test_config_value_sets_cap(self, monkeypatch):
+        """Source of truth is ``updates.backup_max_file_mb`` in config.yaml,
+        not a HERMES_* env var (AGENTS.md: .env is for secrets only)."""
+        import hermes_cli.backup as backup_mod
+        import hermes_cli.config as config_mod
+
+        monkeypatch.delenv("HERMES_BACKUP_MAX_FILE_MB", raising=False)
+        monkeypatch.setattr(
+            config_mod, "read_raw_config",
+            lambda: {"updates": {"backup_max_file_mb": 0.05}},
+        )
+        assert backup_mod._max_backup_file_bytes() == int(0.05 * 1024 * 1024)
+
+    def test_config_zero_disables_cap(self, monkeypatch):
+        import hermes_cli.backup as backup_mod
+        import hermes_cli.config as config_mod
+
+        monkeypatch.delenv("HERMES_BACKUP_MAX_FILE_MB", raising=False)
+        monkeypatch.setattr(
+            config_mod, "read_raw_config",
+            lambda: {"updates": {"backup_max_file_mb": 0}},
+        )
+        assert backup_mod._max_backup_file_bytes() == 0


### PR DESCRIPTION
## What does this PR do?

`hermes backup` (and the pre-update `--backup` path) walks the entire Hermes
home with only directory-name / suffix / file-name exclusions — there is **no
per-file size limit**. When a profile working directory accumulates bulk data
(a Docker VM image, model weights, a dataset), the backup tries to compress all
of it.

In practice a ~494 GB `Docker.raw` sitting under a profile made
`hermes update --backup` hang on a single file (the output zip was already past
1 GB and climbing) and threatened to fill the disk.

This adds a per-file size cap: files larger than the cap are skipped and listed
in the summary, while config / state / skills / DBs are untouched. The cap
defaults to **2048 MB**, is overridable via `HERMES_BACKUP_MAX_FILE_MB`, and
`0` disables it (restores the old behavior).

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/backup.py`:
  - add `_DEFAULT_MAX_FILE_MB` (2048) and `_max_backup_file_bytes()` (reads
    `HERMES_BACKUP_MAX_FILE_MB`; `0`/negative → no cap; invalid → default).
  - skip files over the cap while collecting `files_to_add`, recording them in
    `skipped_large`.
  - report skipped large files (count, total size, top offenders) in the
    backup summary.
- `tests/hermes_cli/test_backup.py`: `TestBackupSizeCap` — over-cap file is
  skipped, `=0` includes it, default value, invalid-env fallback.

## How to Test

1. `pytest tests/hermes_cli/test_backup.py` → **118 passed** (4 new).
2. Manual: put a file larger than the cap under `~/.hermes/profiles/<p>/` and run
   `hermes backup` — it is skipped and listed in the summary instead of being
   compressed. `HERMES_BACKUP_MAX_FILE_MB=0 hermes backup` includes it again.

## Platforms tested

- macOS (Apple Silicon), Python 3.11.
