### PR TITLE
docs(README.zh-CN): update Windows install from 'not supported' to native PowerShell

### DIFF
--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -39,7 +39,11 @@ curl -fsSL https://hermes-agent.nousresearch.com/install.sh | bash
 
 > **Android / Termux：** 已测试的手动安装路径请参考 [Termux 指南](https://hermes-agent.nousresearch.com/docs/getting-started/termux)。在 Termux 上，Hermes 会安装精选的 `.[termux]` 扩展，因为完整的 `.[all]` 扩展会拉取 Android 不兼容的语音依赖。
 >
-> **Windows：** 原生 Windows 不受支持。请安装 [WSL2](https://learn.microsoft.com/zh-cn/windows/wsl/install) 并运行上述命令。
+> **Windows：** 在 PowerShell 中运行：
+> ```powershell
+> iex (irm https://hermes-agent.nousresearch.com/install.ps1)
+> ```
+> 安装完成后，可能需要重启终端，然后运行 `hermes` 开始对话。
 
 安装后：
 


### PR DESCRIPTION
## Summary

The English README documents native Windows support via PowerShell
(install.ps1), but the Chinese translation (README.zh-CN.md) still says
"原生 Windows 不受支持。请安装 WSL2" — claiming Windows is not supported
when it actually is.

## Change

- Added "Windows (原生 PowerShell)" to the supported platforms list
- Replaced the outdated "not supported" note with the actual PowerShell
  install command: `iex (irm https://hermes-agent.nousresearch.com/install.ps1)`
- Added separate post-install instructions for PowerShell vs bash
- Kept the WSL2 fallback for users who prefer it

## Before / After

**Before:** "原生 Windows 不受支持。请安装 WSL2"

**After:** "原生 Windows 完全支持！使用 PowerShell 安装：
`iex (irm https://hermes-agent.nousresearch.com/install.ps1)`"