### PR TITLE
Add guarded action preflight for reversibility receipts

### DIFF
--- a/model_tools.py
+++ b/model_tools.py
@@ -570,6 +570,82 @@ _AGENT_LOOP_TOOLS = {"todo", "memory", "session_search", "delegate_task"}
 _READ_SEARCH_TOOLS = {"read_file", "search_files"}
 
 
+def _truthy_config_value(value: Any) -> bool:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, (int, float)):
+        return bool(value)
+    if isinstance(value, str):
+        return value.strip().lower() in {"1", "true", "yes", "on", "enabled"}
+    return False
+
+
+def _action_preflight_enabled() -> bool:
+    """Return whether the Phase 2 dispatch-boundary hook is active.
+
+    Default is intentionally off for blast-radius control. Operators can enable
+    it with ``security.action_preflight.enabled: true`` or the test/ops env var
+    ``HERMES_ACTION_PREFLIGHT_ENABLED=1``.
+    """
+    env_value = os.getenv("HERMES_ACTION_PREFLIGHT_ENABLED")
+    if env_value is not None:
+        return _truthy_config_value(env_value)
+    try:
+        from hermes_cli.config import load_config
+        cfg = load_config() or {}
+    except Exception as exc:
+        logger.debug("action_preflight config lookup failed: %s", exc)
+        return False
+    security = cfg.get("security") if isinstance(cfg, dict) else {}
+    if not isinstance(security, dict):
+        return False
+    action_preflight = security.get("action_preflight")
+    if isinstance(action_preflight, dict):
+        return _truthy_config_value(action_preflight.get("enabled"))
+    return _truthy_config_value(action_preflight)
+
+
+def _trusted_action_decision_parts(decision: Any):
+    if decision is None:
+        return None, False
+    try:
+        from tools.action_preflight import SemanticReceipt, TrustedActionDecision
+    except Exception:
+        return None, False
+    if isinstance(decision, TrustedActionDecision):
+        return decision.receipt, bool(decision.trusted and decision.source)
+    if isinstance(decision, SemanticReceipt):
+        # Backward-compatible test seam only: a bare receipt is not a trusted
+        # decision, because it lacks a runtime-owned source.
+        return decision, False
+    if isinstance(decision, dict):
+        receipt = decision.get("receipt")
+        trusted = bool(decision.get("trusted", False)) and bool(decision.get("source"))
+        if isinstance(receipt, SemanticReceipt):
+            return receipt, trusted
+    return None, False
+
+def _action_preflight_block_message(
+    function_name: str,
+    function_args: Dict[str, Any],
+    *,
+    trusted_action_decision: Optional[Any] = None,
+) -> Optional[str]:
+    if not _action_preflight_enabled():
+        return None
+    try:
+        from tools.action_preflight import classify_tool_action, validate_receipt
+        preflight = classify_tool_action(function_name, function_args or {}, workspace_root=os.getcwd())
+        receipt, trusted = _trusted_action_decision_parts(trusted_action_decision)
+        result = validate_receipt(preflight, receipt, trusted_decision=trusted)
+    except Exception as exc:
+        logger.exception("action_preflight failed closed for %s: %s", function_name, exc)
+        return "action_preflight failed closed before dispatch"
+    if result.allowed:
+        return None
+    return f"action_preflight blocked {function_name}: {result.reason}"
+
+
 # =========================================================================
 # Tool error sanitization
 # =========================================================================
@@ -888,6 +964,7 @@ def handle_function_call(
     tool_request_middleware_trace: Optional[List[Dict[str, Any]]] = None,
     enabled_toolsets: Optional[List[str]] = None,
     disabled_toolsets: Optional[List[str]] = None,
+    trusted_action_decision: Optional[Any] = None,
 ) -> str:
     """
     Main function call dispatcher that routes calls to the tool registry.
@@ -909,6 +986,8 @@ def handle_function_call(
                        matching ``get_tool_definitions`` semantics.
         disabled_toolsets: The session's disabled toolsets, applied as a
                        subtraction when scoping the bridge catalog.
+        trusted_action_decision: Runtime-owned action_preflight decision. This
+                       is deliberately separate from model-supplied args.
 
     Returns:
         Function result as a JSON string.
@@ -992,6 +1071,7 @@ def handle_function_call(
                 tool_request_middleware_trace=list(_tool_middleware_trace),
                 enabled_toolsets=enabled_toolsets,
                 disabled_toolsets=disabled_toolsets,
+                trusted_action_decision=trusted_action_decision,
             )
 
     _tool_original_args = dict(function_args)
@@ -1076,6 +1156,14 @@ def handle_function_call(
             logger.debug("ACP edit approval guard error: %s", _edit_approval_err)
             if function_name in {"write_file", "patch"}:
                 return json.dumps({"error": "Edit approval denied: approval guard failed"}, ensure_ascii=False)
+
+        preflight_block = _action_preflight_block_message(
+            function_name,
+            function_args,
+            trusted_action_decision=trusted_action_decision,
+        )
+        if preflight_block is not None:
+            return json.dumps({"error": preflight_block}, ensure_ascii=False)
 
         # Notify the read-loop tracker when a non-read/search tool runs,
         # so the *consecutive* counter resets (reads after other work are fine).

--- a/tests/test_model_tools_action_preflight.py
+++ b/tests/test_model_tools_action_preflight.py
@@ -1,0 +1,192 @@
+"""Integration coverage for action_preflight at the model_tools dispatch boundary."""
+
+import json
+
+import model_tools
+from tools.action_preflight import SemanticReceipt, TrustedActionDecision, classify_tool_action
+
+
+def _noop_unrelated_hooks(monkeypatch):
+    monkeypatch.setattr(
+        "acp_adapter.edit_approval.maybe_require_edit_approval",
+        lambda name, args: None,
+    )
+    monkeypatch.setattr(
+        "hermes_cli.plugins.invoke_hook",
+        lambda hook_name, **kwargs: [],
+    )
+
+
+def _dispatch_spy(monkeypatch):
+    from tools.registry import registry
+
+    dispatched = []
+
+    def _dispatch(name, args, **kwargs):
+        dispatched.append((name, args, kwargs))
+        return json.dumps({"ok": True, "tool": name})
+
+    monkeypatch.setattr(registry, "dispatch", _dispatch)
+    return dispatched
+
+
+def _enable_action_preflight(monkeypatch):
+    monkeypatch.setenv("HERMES_ACTION_PREFLIGHT_ENABLED", "1")
+
+
+def test_default_action_preflight_is_off_and_documented_by_dispatch(monkeypatch):
+    _noop_unrelated_hooks(monkeypatch)
+    monkeypatch.delenv("HERMES_ACTION_PREFLIGHT_ENABLED", raising=False)
+    monkeypatch.setattr("hermes_cli.config.load_config", lambda: {})
+    dispatched = _dispatch_spy(monkeypatch)
+
+    out = model_tools.handle_function_call(
+        "send_message",
+        {"action": "send", "target": "discord:#ops", "message": "hello"},
+        skip_pre_tool_call_hook=True,
+    )
+
+    assert json.loads(out) == {"ok": True, "tool": "send_message"}
+    assert [call[0] for call in dispatched] == ["send_message"]
+
+
+def test_config_can_enable_action_preflight_without_env(monkeypatch):
+    _noop_unrelated_hooks(monkeypatch)
+    monkeypatch.delenv("HERMES_ACTION_PREFLIGHT_ENABLED", raising=False)
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config",
+        lambda: {"security": {"action_preflight": {"enabled": True}}},
+    )
+    dispatched = _dispatch_spy(monkeypatch)
+
+    out = model_tools.handle_function_call(
+        "send_message",
+        {"action": "send", "target": "discord:#ops", "message": "hello"},
+        skip_pre_tool_call_hook=True,
+    )
+
+    payload = json.loads(out)
+    assert "error" in payload
+    assert "approval receipt required" in payload["error"]
+    assert dispatched == []
+
+
+def test_read_only_tool_dispatches_with_active_preflight_without_receipt(monkeypatch):
+    _enable_action_preflight(monkeypatch)
+    _noop_unrelated_hooks(monkeypatch)
+    dispatched = _dispatch_spy(monkeypatch)
+
+    out = model_tools.handle_function_call(
+        "read_file",
+        {"path": "README.md"},
+        skip_pre_tool_call_hook=True,
+    )
+
+    assert json.loads(out) == {"ok": True, "tool": "read_file"}
+    assert [call[0] for call in dispatched] == ["read_file"]
+
+
+def test_publish_call_with_active_preflight_fails_closed_before_dispatch(monkeypatch):
+    _enable_action_preflight(monkeypatch)
+    _noop_unrelated_hooks(monkeypatch)
+    dispatched = _dispatch_spy(monkeypatch)
+
+    out = model_tools.handle_function_call(
+        "send_message",
+        {"action": "send", "target": "discord:#ops", "message": "hello"},
+        skip_pre_tool_call_hook=True,
+    )
+
+    payload = json.loads(out)
+    assert "error" in payload
+    assert "approval receipt required" in payload["error"]
+    assert dispatched == []
+
+
+def test_model_supplied_approval_status_does_not_count_as_trusted_decision(monkeypatch):
+    _enable_action_preflight(monkeypatch)
+    _noop_unrelated_hooks(monkeypatch)
+    dispatched = _dispatch_spy(monkeypatch)
+
+    out = model_tools.handle_function_call(
+        "send_message",
+        {
+            "action": "send",
+            "target": "discord:#ops",
+            "message": "hello",
+            "approval_status": "approved",
+        },
+        skip_pre_tool_call_hook=True,
+    )
+
+    payload = json.loads(out)
+    assert "error" in payload
+    assert "trusted" in payload["error"] or "receipt" in payload["error"]
+    assert dispatched == []
+
+
+def test_trusted_decision_with_matching_payload_hash_reaches_dispatch(monkeypatch):
+    _enable_action_preflight(monkeypatch)
+    _noop_unrelated_hooks(monkeypatch)
+    dispatched = _dispatch_spy(monkeypatch)
+    args = {"action": "send", "target": "discord:#ops", "message": "hello"}
+    preflight = classify_tool_action("send_message", args)
+    decision = TrustedActionDecision(
+        receipt=SemanticReceipt.for_preflight(preflight, approved=True),
+        source="test-trusted-store",
+    )
+
+    out = model_tools.handle_function_call(
+        "send_message",
+        args,
+        trusted_action_decision=decision,
+        skip_pre_tool_call_hook=True,
+    )
+
+    assert json.loads(out) == {"ok": True, "tool": "send_message"}
+    assert [call[0] for call in dispatched] == ["send_message"]
+
+
+def test_payload_hash_mismatch_after_approval_fails_before_dispatch(monkeypatch):
+    _enable_action_preflight(monkeypatch)
+    _noop_unrelated_hooks(monkeypatch)
+    dispatched = _dispatch_spy(monkeypatch)
+    approved_args = {"action": "send", "target": "discord:#ops", "message": "old"}
+    mutated_args = {"action": "send", "target": "discord:#ops", "message": "mutated"}
+    approved_preflight = classify_tool_action("send_message", approved_args)
+    decision = TrustedActionDecision(
+        receipt=SemanticReceipt.for_preflight(approved_preflight, approved=True),
+        source="test-trusted-store",
+    )
+
+    out = model_tools.handle_function_call(
+        "send_message",
+        mutated_args,
+        trusted_action_decision=decision,
+        skip_pre_tool_call_hook=True,
+    )
+
+    payload = json.loads(out)
+    assert "error" in payload
+    assert "payload hash mismatch" in payload["error"]
+    assert dispatched == []
+
+
+def test_terminal_hardline_guard_remains_in_terminal_tool_not_replaced(monkeypatch):
+    # Default action_preflight is off, so terminal dispatch still reaches the
+    # existing tools.approval hardline guard, which must block independently.
+    _noop_unrelated_hooks(monkeypatch)
+    monkeypatch.delenv("HERMES_ACTION_PREFLIGHT_ENABLED", raising=False)
+    monkeypatch.setattr("hermes_cli.config.load_config", lambda: {})
+    import tools.terminal_tool  # noqa: F401 - ensure registry registration
+
+    out = model_tools.handle_function_call(
+        "terminal",
+        {"command": "rm -rf /", "timeout": 1},
+        skip_pre_tool_call_hook=True,
+    )
+
+    payload = json.loads(out)
+    text = json.dumps(payload).lower()
+    assert "hardline" in text
+    assert "blocked" in text

--- a/tests/tools/test_action_preflight.py
+++ b/tests/tools/test_action_preflight.py
@@ -1,0 +1,182 @@
+"""Test-only skeleton for reversibility-tier semantic receipts.
+
+These tests intentionally exercise an isolated module only. They must not prove
+or require any production dispatch hook integration yet.
+"""
+
+from pathlib import Path
+
+from tools.action_preflight import (
+    ReversibilityTier,
+    SemanticReceipt,
+    classify_tool_action,
+    validate_receipt,
+)
+
+
+def test_read_only_passthrough_without_receipt():
+    for tool_name, args in [
+        ("read_file", {"path": "README.md"}),
+        ("search_files", {"pattern": "foo"}),
+        ("send_message", {"action": "list"}),
+    ]:
+        preflight = classify_tool_action(tool_name, args)
+        result = validate_receipt(preflight, receipt=None, trusted_decision=False)
+
+        assert preflight.tier is ReversibilityTier.READ_ONLY
+        assert result.allowed is True
+
+
+def test_send_message_send_requires_trusted_receipt():
+    preflight = classify_tool_action(
+        "send_message",
+        {"action": "send", "target": "discord:#general", "message": "hello"},
+    )
+
+    assert preflight.tier is ReversibilityTier.EXTERNALLY_VISIBLE_PUBLISH
+    assert validate_receipt(preflight, None, trusted_decision=False).allowed is False
+    assert validate_receipt(
+        preflight,
+        SemanticReceipt.for_preflight(preflight, approved=True),
+        trusted_decision=True,
+    ).allowed is True
+
+
+def test_destructive_delete_requires_trusted_approval():
+    preflight = classify_tool_action("delete_file", {"path": "old.txt"})
+
+    assert preflight.tier is ReversibilityTier.DESTRUCTIVE_DELETE
+    assert validate_receipt(
+        preflight,
+        SemanticReceipt.for_preflight(preflight, approved=True),
+        trusted_decision=False,
+    ).allowed is False
+    assert validate_receipt(
+        preflight,
+        SemanticReceipt.for_preflight(preflight, approved=True),
+        trusted_decision=True,
+    ).allowed is True
+
+
+def test_secret_credential_paths_and_args_escalate_and_receipt_redacts_values(tmp_path):
+    secret_value = "sk-live-super-secret-token"
+    preflight = classify_tool_action(
+        "write_file",
+        {"path": str(tmp_path / ".env"), "content": f"API_TOKEN={secret_value}\n"},
+    )
+    receipt = SemanticReceipt.for_preflight(
+        preflight,
+        approved=True,
+        summary=f"approved token {secret_value}",
+    )
+
+    assert preflight.tier is ReversibilityTier.SECRET_CREDENTIAL_HANDLING
+    assert secret_value not in repr(receipt)
+    assert secret_value not in str(receipt.to_dict())
+
+    token_preflight = classify_tool_action(
+        "configure_provider",
+        {"api_token": secret_value, "path": "config/auth.yaml"},
+    )
+    assert token_preflight.tier is ReversibilityTier.SECRET_CREDENTIAL_HANDLING
+
+
+def test_staged_workspace_write_requires_pre_state_and_expected_delta(tmp_path):
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    preflight = classify_tool_action(
+        "write_file",
+        {"path": str(workspace / "notes.txt"), "content": "hello"},
+        workspace_root=workspace,
+    )
+
+    assert preflight.tier is ReversibilityTier.STAGED_LOCAL_CHANGE
+    assert validate_receipt(
+        preflight,
+        SemanticReceipt.for_preflight(preflight, approved=True),
+        trusted_decision=True,
+    ).allowed is False
+    assert validate_receipt(
+        preflight,
+        SemanticReceipt.for_preflight(
+            preflight,
+            approved=True,
+            pre_state_ref="sha256:before",
+            expected_delta="create notes.txt",
+        ),
+        trusted_decision=True,
+    ).allowed is True
+
+
+def test_unknown_risky_write_publish_fails_closed():
+    for tool_name in ["publish_blog", "write_remote_config", "post_remote_update"]:
+        preflight = classify_tool_action(tool_name, {"value": "x"})
+        result = validate_receipt(preflight, None, trusted_decision=False)
+
+        assert preflight.tier is ReversibilityTier.UNKNOWN_RISKY
+        assert result.allowed is False
+
+
+def test_self_asserted_approval_status_in_model_args_is_ignored():
+    preflight = classify_tool_action(
+        "send_message",
+        {
+            "action": "send",
+            "target": "discord:#general",
+            "message": "hello",
+            "approval_status": "approved",
+        },
+    )
+    receipt = SemanticReceipt.for_preflight(preflight, approved=True)
+
+    assert validate_receipt(preflight, receipt, trusted_decision=False).allowed is False
+
+
+def test_payload_hash_mismatch_and_toctou_mutation_fail():
+    preflight = classify_tool_action("send_message", {"action": "send", "message": "old"})
+    changed_after_approval = classify_tool_action(
+        "send_message",
+        {"action": "send", "message": "mutated by plugin pre_tool_call"},
+    )
+    receipt = SemanticReceipt.for_preflight(preflight, approved=True)
+
+    assert receipt.payload_hash != changed_after_approval.payload_hash
+    assert validate_receipt(changed_after_approval, receipt, trusted_decision=True).allowed is False
+
+
+def test_patch_path_traversal_and_symlink_outside_workspace_escalate(tmp_path):
+    workspace = tmp_path / "workspace"
+    outside = tmp_path / "outside"
+    workspace.mkdir()
+    outside.mkdir()
+
+    traversal = classify_tool_action(
+        "patch",
+        {"path": "../outside/target.txt", "old_string": "a", "new_string": "b"},
+        workspace_root=workspace,
+    )
+    assert traversal.tier is ReversibilityTier.UNKNOWN_RISKY
+
+    target = outside / "secret.txt"
+    target.write_text("secret")
+    link = workspace / "link.txt"
+    link.symlink_to(target)
+    symlink = classify_tool_action(
+        "patch",
+        {"path": str(link), "old_string": "secret", "new_string": "x"},
+        workspace_root=workspace,
+    )
+    assert symlink.tier is ReversibilityTier.UNKNOWN_RISKY
+
+
+def test_write_file_to_auth_config_escalates_to_secret_handling(tmp_path):
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+
+    preflight = classify_tool_action(
+        "write_file",
+        {"path": str(workspace / "config" / "credentials.yaml"), "content": "token: x"},
+        workspace_root=workspace,
+    )
+
+    assert preflight.tier is ReversibilityTier.SECRET_CREDENTIAL_HANDLING

--- a/tools/action_preflight.py
+++ b/tools/action_preflight.py
@@ -1,0 +1,300 @@
+"""Reversibility-tier preflight helpers for tool dispatch.
+
+Receipts intentionally carry only semantic metadata plus a payload hash.  The
+trusted approval decision must be supplied by the runtime boundary separately
+from model-provided tool arguments.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+import re
+from dataclasses import dataclass
+from enum import Enum
+from pathlib import Path
+from typing import Any, Mapping
+
+
+class ReversibilityTier(str, Enum):
+    """Coarse approval tier for a prospective tool action."""
+
+    READ_ONLY = "read_only"
+    STAGED_LOCAL_CHANGE = "staged_local_change"
+    EXTERNALLY_VISIBLE_PUBLISH = "externally_visible_publish"
+    SECRET_CREDENTIAL_HANDLING = "secret_credential_handling"
+    DESTRUCTIVE_DELETE = "destructive_delete"
+    UNKNOWN_RISKY = "unknown_risky"
+
+
+_SECRET_KEY_RE = re.compile(
+    r"(secret|token|credential|password|passwd|api[_-]?key|access[_-]?key|auth)",
+    re.IGNORECASE,
+)
+_SECRET_PATH_RE = re.compile(
+    r"(^|[/\\.])(?:\.env(?:\.|$)|auth(?:[/\\.]|$)|credentials?(?:[/\\.]|$)|"
+    r"secrets?(?:[/\\.]|$)|token(?:[/\\.]|$)|keychain|credential_store)",
+    re.IGNORECASE,
+)
+_RISKY_WRITE_RE = re.compile(r"(write|patch|edit|update|create|upload|publish|post|send)", re.IGNORECASE)
+_DESTRUCTIVE_RE = re.compile(r"(delete|remove|destroy|drop|purge|wipe|truncate)", re.IGNORECASE)
+_PUBLISH_RE = re.compile(r"(publish|post|send|message|tweet|email|notify|webhook)", re.IGNORECASE)
+
+_READ_ONLY_TOOLS = frozenset({"read_file", "search_files"})
+_STAGED_WRITE_TOOLS = frozenset({"write_file", "patch"})
+_DESTRUCTIVE_TOOLS = frozenset({"delete_file", "remove_file", "rm", "unlink"})
+
+
+@dataclass(frozen=True)
+class ActionPreflight:
+    """Pure classification output for one tool name + argument payload."""
+
+    tool_name: str
+    tier: ReversibilityTier
+    payload_hash: str
+    reason: str
+
+
+@dataclass(frozen=True)
+class ValidationResult:
+    allowed: bool
+    reason: str
+
+
+@dataclass(frozen=True)
+class TrustedActionDecision:
+    """Runtime-owned approval decision, never parsed from model tool args."""
+
+    receipt: "SemanticReceipt"
+    source: str
+    trusted: bool = True
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "source", _redact_text(self.source) or "")
+
+
+@dataclass(frozen=True)
+class SemanticReceipt:
+    """Approval receipt without raw args or secret values.
+
+    Only payload_hash binds the approved payload to the later execution attempt;
+    raw tool arguments are intentionally absent from the receipt.
+    """
+
+    tool_name: str
+    tier: ReversibilityTier
+    payload_hash: str
+    approved: bool = False
+    pre_state_ref: str | None = None
+    expected_delta: str | None = None
+    summary: str | None = None
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "summary", _redact_text(self.summary))
+        object.__setattr__(self, "pre_state_ref", _redact_text(self.pre_state_ref))
+        object.__setattr__(self, "expected_delta", _redact_text(self.expected_delta))
+
+    @classmethod
+    def for_preflight(
+        cls,
+        preflight: ActionPreflight,
+        *,
+        approved: bool,
+        pre_state_ref: str | None = None,
+        expected_delta: str | None = None,
+        summary: str | None = None,
+    ) -> "SemanticReceipt":
+        return cls(
+            tool_name=preflight.tool_name,
+            tier=preflight.tier,
+            payload_hash=preflight.payload_hash,
+            approved=approved,
+            pre_state_ref=pre_state_ref,
+            expected_delta=expected_delta,
+            summary=summary,
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "tool_name": self.tool_name,
+            "tier": self.tier.value,
+            "payload_hash": self.payload_hash,
+            "approved": self.approved,
+            "pre_state_ref": self.pre_state_ref,
+            "expected_delta": self.expected_delta,
+            "summary": self.summary,
+        }
+
+
+def classify_tool_action(
+    tool_name: str,
+    args: Mapping[str, Any] | None,
+    *,
+    workspace_root: str | Path | None = None,
+) -> ActionPreflight:
+    """Classify a prospective tool call, failing closed for risky unknowns."""
+
+    normalized_name = (tool_name or "").strip()
+    payload_hash = _payload_hash(normalized_name, args or {})
+    reason = "default"
+
+    if _contains_secret_material(args or {}):
+        return ActionPreflight(
+            normalized_name,
+            ReversibilityTier.SECRET_CREDENTIAL_HANDLING,
+            payload_hash,
+            "secret-like argument key or path",
+        )
+
+    path_state = _path_state(args or {}, workspace_root)
+    if path_state == "secret":
+        return ActionPreflight(
+            normalized_name,
+            ReversibilityTier.SECRET_CREDENTIAL_HANDLING,
+            payload_hash,
+            "secret-like destination path",
+        )
+    if path_state == "outside_workspace":
+        return ActionPreflight(
+            normalized_name,
+            ReversibilityTier.UNKNOWN_RISKY,
+            payload_hash,
+            "path resolves outside workspace",
+        )
+
+    if normalized_name in _READ_ONLY_TOOLS:
+        return ActionPreflight(normalized_name, ReversibilityTier.READ_ONLY, payload_hash, "read-only tool")
+
+    if normalized_name == "send_message":
+        action = str((args or {}).get("action", "send")).lower()
+        tier = ReversibilityTier.READ_ONLY if action == "list" else ReversibilityTier.EXTERNALLY_VISIBLE_PUBLISH
+        reason = "send_message list" if tier is ReversibilityTier.READ_ONLY else "externally visible send"
+        return ActionPreflight(normalized_name, tier, payload_hash, reason)
+
+    if normalized_name in _DESTRUCTIVE_TOOLS or _DESTRUCTIVE_RE.search(normalized_name):
+        return ActionPreflight(
+            normalized_name,
+            ReversibilityTier.DESTRUCTIVE_DELETE,
+            payload_hash,
+            "destructive tool name",
+        )
+
+    if normalized_name in _STAGED_WRITE_TOOLS:
+        return ActionPreflight(
+            normalized_name,
+            ReversibilityTier.STAGED_LOCAL_CHANGE,
+            payload_hash,
+            "workspace-local staged change",
+        )
+
+    if _PUBLISH_RE.search(normalized_name) or _RISKY_WRITE_RE.search(normalized_name):
+        return ActionPreflight(
+            normalized_name,
+            ReversibilityTier.UNKNOWN_RISKY,
+            payload_hash,
+            "unknown risky write/publish tool",
+        )
+
+    return ActionPreflight(normalized_name, ReversibilityTier.UNKNOWN_RISKY, payload_hash, reason)
+
+
+def validate_receipt(
+    preflight: ActionPreflight,
+    receipt: SemanticReceipt | None,
+    trusted_decision: bool,
+) -> ValidationResult:
+    """Validate receipt binding and trusted approval status for a preflight."""
+
+    if preflight.tier is ReversibilityTier.READ_ONLY:
+        return ValidationResult(True, "read-only passthrough")
+
+    if receipt is None:
+        return ValidationResult(False, "approval receipt required")
+    if not trusted_decision:
+        return ValidationResult(False, "trusted approval decision required")
+    if not receipt.approved:
+        return ValidationResult(False, "receipt is not approved")
+    if receipt.tool_name != preflight.tool_name:
+        return ValidationResult(False, "receipt tool mismatch")
+    if receipt.tier is not preflight.tier:
+        return ValidationResult(False, "receipt tier mismatch")
+    if not hmac.compare_digest(receipt.payload_hash, preflight.payload_hash):
+        return ValidationResult(False, "payload hash mismatch")
+
+    if preflight.tier is ReversibilityTier.STAGED_LOCAL_CHANGE:
+        if not receipt.pre_state_ref or not receipt.expected_delta:
+            return ValidationResult(False, "staged changes require pre_state_ref and expected_delta")
+
+    if preflight.tier in {
+        ReversibilityTier.EXTERNALLY_VISIBLE_PUBLISH,
+        ReversibilityTier.SECRET_CREDENTIAL_HANDLING,
+        ReversibilityTier.DESTRUCTIVE_DELETE,
+        ReversibilityTier.STAGED_LOCAL_CHANGE,
+    }:
+        return ValidationResult(True, "trusted receipt accepted")
+
+    return ValidationResult(False, "fail closed for unknown risky action")
+
+
+def _payload_hash(tool_name: str, args: Mapping[str, Any]) -> str:
+    canonical = json.dumps(
+        {"tool_name": tool_name, "args": args},
+        sort_keys=True,
+        separators=(",", ":"),
+        default=str,
+    )
+    return "sha256:" + hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+def _contains_secret_material(value: Any) -> bool:
+    if isinstance(value, Mapping):
+        for key, child in value.items():
+            key_text = str(key)
+            if _SECRET_KEY_RE.search(key_text):
+                return True
+            if key_text.lower() in {"path", "filepath", "file_path", "dest", "destination"} and _SECRET_PATH_RE.search(str(child)):
+                return True
+            if _contains_secret_material(child):
+                return True
+    elif isinstance(value, (list, tuple, set)):
+        return any(_contains_secret_material(item) for item in value)
+    return False
+
+
+def _path_state(args: Mapping[str, Any], workspace_root: str | Path | None) -> str | None:
+    raw_path = _extract_path(args)
+    if not raw_path:
+        return None
+    if _SECRET_PATH_RE.search(raw_path):
+        return "secret"
+    if workspace_root is None:
+        return None
+
+    root = Path(workspace_root).expanduser().resolve()
+    candidate = Path(raw_path).expanduser()
+    if not candidate.is_absolute():
+        candidate = root / candidate
+    resolved = candidate.resolve(strict=False)
+    try:
+        resolved.relative_to(root)
+    except ValueError:
+        return "outside_workspace"
+    return None
+
+
+def _extract_path(args: Mapping[str, Any]) -> str | None:
+    for key in ("path", "filepath", "file_path", "target_path", "dest", "destination"):
+        value = args.get(key)
+        if value:
+            return str(value)
+    return None
+
+
+def _redact_text(value: str | None) -> str | None:
+    if value is None:
+        return None
+    text = str(value)
+    text = re.sub(r"(?i)(api[_-]?key|access[_-]?token|auth[_-]?token|token|secret|password|credential)\s*[:=]\s*\S+", r"\1=***", text)
+    text = re.sub(r"(?i)\b(sk-[A-Za-z0-9._-]{6,}|[A-Za-z0-9._-]*token[A-Za-z0-9._-]*)\b", "***", text)
+    return text


### PR DESCRIPTION
## Summary
- Add `tools/action_preflight.py` with `ReversibilityTier`, `SemanticReceipt`, `TrustedActionDecision`, action classification, and receipt validation.
- Add guarded action-preflight hook in `model_tools.handle_function_call`.
- Keep hook default-off; enable via `security.action_preflight.enabled: true` or `HERMES_ACTION_PREFLIGHT_ENABLED=1`.
- Fail closed for risky publish/delete/secret/unknown-write actions when enabled unless a trusted decision + matching payload hash is present.

## Safety
- Model-supplied `approval_status` is not trusted.
- Trusted decision is passed separately from model args.
- Payload hash is re-validated immediately before dispatch to catch TOCTOU/plugin mutation.
- Terminal hardline guard remains unchanged.
- No raw secret values are stored in receipts.

## Tests
Clean worktree rebased onto current `origin/main`:
- `python -m pytest tests/tools/test_action_preflight.py tests/test_model_tools_action_preflight.py -q -o 'addopts='`
  - `18 passed, 1 warning in 1.52s`
- `python -m py_compile tools/action_preflight.py model_tools.py tests/test_model_tools_action_preflight.py tests/tools/test_action_preflight.py`
  - OK

Original dirty-worktree validation before clean rebase:
- `python -m pytest tests/tools/test_action_preflight.py tests/agent/test_runtime_policy.py tests/test_model_tools_runtime_policy.py tests/test_model_tools_action_preflight.py -q -o 'addopts='`
  - `26 passed, 1 warning`

## Notes
The source checkout had unrelated dirty local changes. The PR branch was rebuilt from current `origin/main` in a clean worktree and contains only:
- `model_tools.py`
- `tools/action_preflight.py`
- `tests/tools/test_action_preflight.py`
- `tests/test_model_tools_action_preflight.py`
