### PR TITLE
feat(desktop): add artifact preview MVP

### DIFF
--- a/apps/desktop/electron/main.cjs
+++ b/apps/desktop/electron/main.cjs
@@ -20,7 +20,6 @@ const crypto = require('node:crypto')
 const fs = require('node:fs')
 const http = require('node:http')
 const https = require('node:https')
-const net = require('node:net')
 const path = require('node:path')
 const { pathToFileURL } = require('node:url')
 const { execFileSync, spawn } = require('node:child_process')
@@ -5792,6 +5791,15 @@ ipcMain.handle('hermes:openExternal', (_event, url) => {
   if (!openExternalUrl(url)) {
     throw new Error('Invalid external URL')
   }
+})
+
+ipcMain.handle('hermes:path:reveal', async (_event, filePath) => {
+  const target = typeof filePath === 'string' ? filePath.trim() : ''
+  if (!target || !path.isAbsolute(target)) {
+    throw new Error('Path must be absolute')
+  }
+  shell.showItemInFolder(target)
+  return { ok: true, path: target }
 })
 
 // User-configurable default project directory. The renderer reads this on

--- a/apps/desktop/electron/preload.cjs
+++ b/apps/desktop/electron/preload.cjs
@@ -44,6 +44,7 @@ contextBridge.exposeInMainWorld('hermesDesktop', {
   setTranslucency: payload => ipcRenderer.send('hermes:translucency', payload),
   setPreviewShortcutActive: active => ipcRenderer.send('hermes:previewShortcutActive', Boolean(active)),
   openExternal: url => ipcRenderer.invoke('hermes:openExternal', url),
+  revealPath: filePath => ipcRenderer.invoke('hermes:path:reveal', filePath),
   fetchLinkTitle: url => ipcRenderer.invoke('hermes:fetchLinkTitle', url),
   sanitizeWorkspaceCwd: cwd => ipcRenderer.invoke('hermes:workspace:sanitize', cwd),
   settings: {

--- a/apps/desktop/src/app/artifacts/index.test.ts
+++ b/apps/desktop/src/app/artifacts/index.test.ts
@@ -41,6 +41,22 @@ describe('collectArtifactsForSession', () => {
     })
   })
 
+  it('resolves relative artifact preview paths against the session cwd', () => {
+    const artifacts = collectArtifactsForSession(makeSession({ cwd: '/Users/vlad/project' }), [
+      {
+        content: 'Saved report at ./dist/report.pdf',
+        role: 'assistant',
+        timestamp: 2000
+      }
+    ])
+
+    expect(artifacts).toHaveLength(1)
+    expect(artifacts[0]).toMatchObject({
+      previewPath: '/Users/vlad/project/dist/report.pdf',
+      value: './dist/report.pdf'
+    })
+  })
+
   it('indexes http links present in tool JSON payloads', () => {
     const messages: SessionMessage[] = [
       {

--- a/apps/desktop/src/app/artifacts/index.tsx
+++ b/apps/desktop/src/app/artifacts/index.tsx
@@ -2,11 +2,13 @@ import type * as React from 'react'
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 
+import { CompactMarkdown } from '@/components/chat/compact-markdown'
 import { ZoomableImage } from '@/components/chat/zoomable-image'
 import { PageLoader } from '@/components/page-loader'
 import { Button } from '@/components/ui/button'
 import { Codicon } from '@/components/ui/codicon'
 import { CopyButton } from '@/components/ui/copy-button'
+import { Input } from '@/components/ui/input'
 import {
   Pagination,
   PaginationButton,
@@ -18,15 +20,15 @@ import {
 } from '@/components/ui/pagination'
 import { TextTab, TextTabMeta } from '@/components/ui/text-tab'
 import { Tip } from '@/components/ui/tooltip'
-import { getSessionMessages, listAllProfileSessions } from '@/hermes'
+import { getSessionMessages, listAllProfileSessions, previewArtifact } from '@/hermes'
 import { type Translations, useI18n } from '@/i18n'
 import { sessionTitle } from '@/lib/chat-runtime'
 import { ExternalLink, ExternalLinkIcon, hostPathLabel, urlSlugTitleLabel, useLinkTitle } from '@/lib/external-link'
 import { FileImage, FileText, FolderOpen, Link2 } from '@/lib/icons'
-import { mediaExternalUrl } from '@/lib/media'
+import { filePathFromMediaPath, mediaExternalUrl } from '@/lib/media'
 import { cn } from '@/lib/utils'
 import { notifyError } from '@/store/notifications'
-import type { SessionInfo, SessionMessage } from '@/types/hermes'
+import type { ArtifactPreviewResponse, SessionInfo, SessionMessage } from '@/types/hermes'
 
 import { useRefreshHotkey } from '../hooks/use-refresh-hotkey'
 import { useRouteEnumParam } from '../hooks/use-route-enum-param'
@@ -349,13 +351,14 @@ function paginationItems(page: number, pageCount: number): Array<number | 'ellip
 type CellCtx = {
   onOpen: (href: string) => void | Promise<void>
   onOpenChat: (sessionId: string) => void
+  onPreview: (path: string) => void | Promise<void>
 }
 
 interface ArtifactColumn {
   Cell: (props: { artifact: ArtifactRecord; ctx: CellCtx }) => React.ReactElement
   bodyClassName: string
   header: (filter: ArtifactFilter, a: Translations['artifacts']) => string
-  id: 'location' | 'primary' | 'session'
+  id: 'actions' | 'location' | 'primary' | 'session'
   width: (filter: ArtifactFilter) => string
 }
 
@@ -379,6 +382,29 @@ export function ArtifactsView({ setStatusbarItemGroup: _setStatusbarItemGroup, .
   const [failedImageIds, setFailedImageIds] = useState<Set<string>>(() => new Set())
   const [imagePage, setImagePage] = useState(1)
   const [filePage, setFilePage] = useState(1)
+  const [manualPreviewPath, setManualPreviewPath] = useState('')
+  const [preview, setPreview] = useState<ArtifactPreviewResponse | null>(null)
+  const [previewLoading, setPreviewLoading] = useState(false)
+
+  const loadPreview = useCallback(async (rawPath: string) => {
+    const path = rawPath.trim()
+
+    if (!path) {
+      return
+    }
+
+    setPreviewLoading(true)
+
+    try {
+      const normalizedPath = filePathFromMediaPath(path)
+      setManualPreviewPath(normalizedPath)
+      setPreview(await previewArtifact(normalizedPath))
+    } catch (err) {
+      notifyError(err, 'Artifact preview failed')
+    } finally {
+      setPreviewLoading(false)
+    }
+  }, [])
 
   const refreshArtifacts = useCallback(async () => {
     setRefreshing(true)
@@ -499,9 +525,22 @@ export function ArtifactsView({ setStatusbarItemGroup: _setStatusbarItemGroup, .
     })
   }, [])
 
+  const revealPreview = useCallback(async (path: string) => {
+    if (!window.hermesDesktop?.revealPath) {
+      return
+    }
+
+    try {
+      await window.hermesDesktop.revealPath(path)
+    } catch (err) {
+      notifyError(err, 'Reveal in Finder failed')
+    }
+  }, [])
+
   const cellCtx: CellCtx = {
     onOpen: openArtifact,
-    onOpenChat: sessionId => navigate(sessionRoute(sessionId))
+    onOpenChat: sessionId => navigate(sessionRoute(sessionId)),
+    onPreview: loadPreview
   }
 
   return (
@@ -542,76 +581,107 @@ export function ArtifactsView({ setStatusbarItemGroup: _setStatusbarItemGroup, .
         </>
       }
     >
-      {!artifacts ? (
-        <PageLoader label={a.indexing} />
-      ) : visibleArtifacts.length === 0 ? (
-        <div className="grid h-full place-items-center px-6 text-center">
-          <div>
-            <div className="text-sm font-medium">{a.noArtifactsTitle}</div>
-            <div className="mt-1 text-xs text-muted-foreground">{a.noArtifactsDesc}</div>
-          </div>
-        </div>
-      ) : (
-        <div className="h-full overflow-y-auto">
-          <div className={cn('flex flex-col gap-3 pb-2', PAGE_INSET_X)}>
-            {visibleImageArtifacts.length > 0 && (
-              <section className="flex flex-col">
-                <div
-                  className={cn(
-                    'sticky top-0 z-10 flex h-7 items-center gap-3 overflow-x-auto bg-background',
-                    PAGE_INSET_NEG_X,
-                    PAGE_INSET_X
-                  )}
-                >
-                  <ArtifactsPagination
-                    className="ml-auto justify-end px-0"
-                    itemLabel={a.itemsImage}
-                    onPageChange={setImagePage}
-                    page={currentImagePage}
-                    pageSize={24}
-                    total={visibleImageArtifacts.length}
-                  />
-                </div>
-                <div className="grid grid-cols-[repeat(auto-fill,minmax(11rem,1fr))] items-start gap-2 pt-1.5">
-                  {pagedImageArtifacts.map(artifact => (
-                    <ArtifactImageCard
-                      artifact={artifact}
-                      failedImage={failedImageIds.has(artifact.id)}
-                      key={artifact.id}
-                      onImageError={markImageFailed}
-                      onOpenChat={sessionId => navigate(sessionRoute(sessionId))}
-                    />
-                  ))}
-                </div>
-              </section>
-            )}
+      <div className="flex h-full min-h-0 gap-3 px-3 pb-3">
+        <div className="flex min-w-0 flex-1 flex-col gap-2">
+          <form
+            className="flex shrink-0 items-center gap-2"
+            onSubmit={event => {
+              event.preventDefault()
+              void loadPreview(manualPreviewPath)
+            }}
+          >
+            <Input
+              aria-label="Preview file path"
+              className="h-8 min-w-0 flex-1 text-xs"
+              onChange={event => setManualPreviewPath(event.target.value)}
+              placeholder="Paste a local file path to preview it here"
+              value={manualPreviewPath}
+            />
+            <Button disabled={previewLoading || !manualPreviewPath.trim()} size="sm" type="submit" variant="secondary">
+              {previewLoading ? 'Loading…' : 'Preview'}
+            </Button>
+          </form>
 
-            {visibleFileArtifacts.length > 0 && (
-              <section className="flex flex-col">
-                <div
-                  className={cn(
-                    'sticky top-0 z-10 flex h-7 items-center gap-3 overflow-x-auto bg-background',
-                    PAGE_INSET_NEG_X,
-                    PAGE_INSET_X
-                  )}
-                >
-                  <ArtifactsPagination
-                    className="ml-auto justify-end px-0"
-                    itemLabel={itemsLabel(kindFilter, a)}
-                    onPageChange={setFilePage}
-                    page={currentFilePage}
-                    pageSize={100}
-                    total={visibleFileArtifacts.length}
-                  />
-                </div>
-                <div className="overflow-x-auto rounded-lg border border-(--ui-stroke-tertiary) bg-(--ui-chat-bubble-background)">
-                  <ArtifactTable artifacts={pagedFileArtifacts} ctx={cellCtx} filter={kindFilter} />
-                </div>
-              </section>
-            )}
-          </div>
+          {!artifacts ? (
+            <PageLoader label={a.indexing} />
+          ) : visibleArtifacts.length === 0 ? (
+            <div className="grid h-full place-items-center px-6 text-center">
+              <div>
+                <div className="text-sm font-medium">{a.noArtifactsTitle}</div>
+                <div className="mt-1 text-xs text-muted-foreground">{a.noArtifactsDesc}</div>
+              </div>
+            </div>
+          ) : (
+            <div className="h-full overflow-y-auto">
+              <div className={cn('flex flex-col gap-3 pb-2', PAGE_INSET_X)}>
+                {visibleImageArtifacts.length > 0 && (
+                  <section className="flex flex-col">
+                    <div
+                      className={cn(
+                        'sticky top-0 z-10 flex h-7 items-center gap-3 overflow-x-auto bg-background',
+                        PAGE_INSET_NEG_X,
+                        PAGE_INSET_X
+                      )}
+                    >
+                      <ArtifactsPagination
+                        className="ml-auto justify-end px-0"
+                        itemLabel={a.itemsImage}
+                        onPageChange={setImagePage}
+                        page={currentImagePage}
+                        pageSize={24}
+                        total={visibleImageArtifacts.length}
+                      />
+                    </div>
+                    <div className="grid grid-cols-[repeat(auto-fill,minmax(11rem,1fr))] items-start gap-2 pt-1.5">
+                      {pagedImageArtifacts.map(artifact => (
+                        <ArtifactImageCard
+                          artifact={artifact}
+                          failedImage={failedImageIds.has(artifact.id)}
+                          key={artifact.id}
+                          onImageError={markImageFailed}
+                          onOpenChat={sessionId => navigate(sessionRoute(sessionId))}
+                          onPreview={loadPreview}
+                        />
+                      ))}
+                    </div>
+                  </section>
+                )}
+
+                {visibleFileArtifacts.length > 0 && (
+                  <section className="flex flex-col">
+                    <div
+                      className={cn(
+                        'sticky top-0 z-10 flex h-7 items-center gap-3 overflow-x-auto bg-background',
+                        PAGE_INSET_NEG_X,
+                        PAGE_INSET_X
+                      )}
+                    >
+                      <ArtifactsPagination
+                        className="ml-auto justify-end px-0"
+                        itemLabel={itemsLabel(kindFilter, a)}
+                        onPageChange={setFilePage}
+                        page={currentFilePage}
+                        pageSize={100}
+                        total={visibleFileArtifacts.length}
+                      />
+                    </div>
+                    <div className="overflow-x-auto rounded-lg border border-(--ui-stroke-tertiary) bg-(--ui-chat-bubble-background)">
+                      <ArtifactTable artifacts={pagedFileArtifacts} ctx={cellCtx} filter={kindFilter} />
+                    </div>
+                  </section>
+                )}
+              </div>
+            </div>
+          )}
         </div>
-      )}
+
+        <ArtifactPreviewPanel
+          loading={previewLoading}
+          onOpen={path => void openArtifact(mediaExternalUrl(path))}
+          onReveal={path => void revealPreview(path)}
+          preview={preview}
+        />
+      </div>
     </PageSearchShell>
   )
 }
@@ -674,9 +744,10 @@ interface ArtifactImageCardProps {
   failedImage: boolean
   onImageError: (id: string) => void
   onOpenChat: (sessionId: string) => void
+  onPreview: (path: string) => void | Promise<void>
 }
 
-function ArtifactImageCard({ artifact, failedImage, onImageError, onOpenChat }: ArtifactImageCardProps) {
+function ArtifactImageCard({ artifact, failedImage, onImageError, onOpenChat, onPreview }: ArtifactImageCardProps) {
   const { t } = useI18n()
   const a = t.artifacts
   const kindLabel = artifact.kind === 'image' ? a.kindImage : artifact.kind === 'file' ? a.kindFile : a.kindLink
@@ -720,6 +791,10 @@ function ArtifactImageCard({ artifact, failedImage, onImageError, onOpenChat }: 
         </div>
 
         <div className="flex flex-wrap gap-1.5">
+          <Button onClick={() => void onPreview(artifact.value)} size="xs" type="button" variant="secondary">
+            <FileText className="size-3" />
+            Preview
+          </Button>
           <Button onClick={() => onOpenChat(artifact.sessionId)} size="xs" type="button" variant="textStrong">
             <FolderOpen className="size-3" />
             {a.chat}
@@ -835,13 +910,29 @@ function SessionCell({ artifact, ctx }: { artifact: ArtifactRecord; ctx: CellCtx
   )
 }
 
+function ActionCell({ artifact, ctx }: { artifact: ArtifactRecord; ctx: CellCtx }) {
+  if (artifact.kind === 'link') {
+    return (
+      <ArtifactCellAction href={artifact.href} title="Open link">
+        <span>Open</span>
+      </ArtifactCellAction>
+    )
+  }
+
+  return (
+    <ArtifactCellAction onClick={() => void ctx.onPreview(artifact.value)} title="Preview artifact">
+      <span>Preview</span>
+    </ArtifactCellAction>
+  )
+}
+
 const ARTIFACT_COLUMNS: readonly ArtifactColumn[] = [
   {
     Cell: PrimaryCell,
     bodyClassName: 'p-0',
     header: (filter, a) => (filter === 'link' ? a.colTitleLink : filter === 'file' ? a.colTitleFile : a.colTitleDefault),
     id: 'primary',
-    width: filter => (filter === 'link' ? 'w-[50%]' : 'w-[35%]')
+    width: filter => (filter === 'link' ? 'w-[44%]' : 'w-[30%]')
   },
   {
     Cell: LocationCell,
@@ -849,7 +940,7 @@ const ARTIFACT_COLUMNS: readonly ArtifactColumn[] = [
     header: (filter, a) =>
       filter === 'link' ? a.colLocationLink : filter === 'file' ? a.colLocationFile : a.colLocationDefault,
     id: 'location',
-    width: filter => (filter === 'link' ? 'w-[30%]' : 'w-[41%]')
+    width: filter => (filter === 'link' ? 'w-[28%]' : 'w-[34%]')
   },
   {
     Cell: SessionCell,
@@ -857,8 +948,105 @@ const ARTIFACT_COLUMNS: readonly ArtifactColumn[] = [
     header: (_filter, a) => a.colSession,
     id: 'session',
     width: filter => (filter === 'link' ? 'w-[20%]' : 'w-[24%]')
+  },
+  {
+    Cell: ActionCell,
+    bodyClassName: 'p-0',
+    header: () => 'Action',
+    id: 'actions',
+    width: filter => (filter === 'link' ? 'w-[8%]' : 'w-[12%]')
   }
 ]
+
+function formatBytes(bytes: number): string {
+  if (!Number.isFinite(bytes) || bytes < 0) {
+    return 'Unknown size'
+  }
+
+  const units = ['B', 'KB', 'MB', 'GB']
+  let value = bytes
+  let unitIndex = 0
+
+  while (value >= 1024 && unitIndex < units.length - 1) {
+    value /= 1024
+    unitIndex += 1
+  }
+
+  return `${value >= 10 || unitIndex === 0 ? value.toFixed(0) : value.toFixed(1)} ${units[unitIndex]}`
+}
+
+function ArtifactPreviewPanel({
+  loading,
+  onOpen,
+  onReveal,
+  preview
+}: {
+  loading: boolean
+  onOpen: (path: string) => void
+  onReveal: (path: string) => void
+  preview: ArtifactPreviewResponse | null
+}) {
+  return (
+    <aside className="flex min-h-0 w-[26rem] shrink-0 flex-col overflow-hidden rounded-lg border border-(--ui-stroke-tertiary) bg-(--ui-chat-bubble-background)">
+      <div className="flex h-10 shrink-0 items-center justify-between gap-2 border-b border-(--ui-stroke-tertiary) px-3">
+        <div className="min-w-0">
+          <div className="truncate text-sm font-medium">{preview?.name || 'Artifact preview'}</div>
+          <div className="truncate text-[0.625rem] text-(--ui-text-tertiary)">
+            {preview ? `${formatBytes(preview.size)} · ${preview.mime_type}` : 'PDF, images, Markdown, and text files'}
+          </div>
+        </div>
+        {preview && (
+          <div className="flex shrink-0 items-center gap-1">
+            <CopyButton appearance="icon" buttonSize="icon-xs" label="Copy path" text={preview.path} title="Copy path" />
+            <Button onClick={() => onReveal(preview.path)} size="icon-xs" title="Reveal in Finder" type="button" variant="ghost">
+              <FolderOpen className="size-3.5" />
+            </Button>
+            <Button onClick={() => onOpen(preview.path)} size="icon-xs" title="Open externally" type="button" variant="ghost">
+              <ExternalLinkIcon />
+            </Button>
+          </div>
+        )}
+      </div>
+
+      <div className="min-h-0 flex-1 overflow-auto p-3">
+        {loading ? (
+          <PageLoader label="Loading preview…" />
+        ) : !preview ? (
+          <div className="grid h-full place-items-center text-center text-xs text-muted-foreground">
+            Select a file from the table or paste a path to preview it here.
+          </div>
+        ) : preview.preview_type === 'image' && preview.data_url ? (
+          <div className="grid h-full place-items-center">
+            <ZoomableImage
+              alt={preview.name}
+              className="max-h-full max-w-full cursor-zoom-in rounded-md object-contain"
+              containerClassName="max-h-full"
+              decoding="async"
+              slot="artifact-preview"
+              src={preview.data_url}
+            />
+          </div>
+        ) : preview.preview_type === 'pdf' && preview.data_url ? (
+          <iframe className="h-full min-h-[28rem] w-full rounded-md border-0 bg-white" src={preview.data_url} title={preview.name} />
+        ) : preview.preview_type === 'markdown' ? (
+          <div className="prose prose-sm max-w-none dark:prose-invert">
+            <CompactMarkdown text={preview.text || ''} />
+          </div>
+        ) : preview.preview_type === 'text' ? (
+          <pre className="whitespace-pre-wrap break-words text-xs leading-relaxed text-(--ui-text-secondary)">{preview.text}</pre>
+        ) : preview.preview_type === 'too_large' ? (
+          <div className="grid h-full place-items-center text-center text-xs text-muted-foreground">
+            This file is too large to preview in-app. Open it externally or reveal it in Finder.
+          </div>
+        ) : (
+          <div className="grid h-full place-items-center text-center text-xs text-muted-foreground">
+            This file type cannot be previewed yet. Open it externally or reveal it in Finder.
+          </div>
+        )}
+      </div>
+    </aside>
+  )
+}
 
 function ArtifactTable({
   artifacts,

--- a/apps/desktop/src/app/artifacts/index.tsx
+++ b/apps/desktop/src/app/artifacts/index.tsx
@@ -45,6 +45,7 @@ interface ArtifactRecord {
   id: string
   kind: ArtifactKind
   value: string
+  previewPath: string
   href: string
   label: string
   sessionId: string
@@ -136,6 +137,40 @@ function artifactHref(value: string): string {
   }
 
   return value
+}
+
+function isAbsoluteLocalPath(value: string): boolean {
+  return value.startsWith('/') || /^[a-zA-Z]:[\\/]/.test(value)
+}
+
+function resolveArtifactPreviewPath(value: string, cwd?: null | string): string {
+  const path = filePathFromMediaPath(value)
+
+  if (isAbsoluteLocalPath(path) || path.startsWith('~/')) {
+    return path
+  }
+
+  if ((path.startsWith('./') || path.startsWith('../')) && cwd && isAbsoluteLocalPath(cwd)) {
+    const parts = cwd.split(/[\\/]+/).filter(Boolean)
+
+    for (const part of path.split(/[\\/]+/)) {
+      if (!part || part === '.') {
+        continue
+      }
+
+      if (part === '..') {
+        parts.pop()
+      } else {
+        parts.push(part)
+      }
+    }
+
+    const prefix = cwd.startsWith('/') ? '/' : ''
+
+    return `${prefix}${parts.join('/')}`
+  }
+
+  return path
 }
 
 function artifactLabel(value: string): string {
@@ -295,6 +330,7 @@ export function collectArtifactsForSession(session: SessionInfo, messages: Sessi
         id: key,
         kind: artifactKind(value),
         value,
+        previewPath: resolveArtifactPreviewPath(value, session.cwd),
         href: artifactHref(value),
         label: artifactLabel(value),
         sessionId: session.id,
@@ -791,7 +827,7 @@ function ArtifactImageCard({ artifact, failedImage, onImageError, onOpenChat, on
         </div>
 
         <div className="flex flex-wrap gap-1.5">
-          <Button onClick={() => void onPreview(artifact.value)} size="xs" type="button" variant="secondary">
+          <Button onClick={() => void onPreview(artifact.previewPath)} size="xs" type="button" variant="secondary">
             <FileText className="size-3" />
             Preview
           </Button>
@@ -920,7 +956,7 @@ function ActionCell({ artifact, ctx }: { artifact: ArtifactRecord; ctx: CellCtx 
   }
 
   return (
-    <ArtifactCellAction onClick={() => void ctx.onPreview(artifact.value)} title="Preview artifact">
+    <ArtifactCellAction onClick={() => void ctx.onPreview(artifact.previewPath)} title="Preview artifact">
       <span>Preview</span>
     </ArtifactCellAction>
   )

--- a/apps/desktop/src/global.d.ts
+++ b/apps/desktop/src/global.d.ts
@@ -60,6 +60,7 @@ declare global {
       setTranslucency?: (payload: { intensity: number }) => void
       setPreviewShortcutActive?: (active: boolean) => void
       openExternal: (url: string) => Promise<void>
+      revealPath?: (path: string) => Promise<{ ok: boolean; path: string }>
       fetchLinkTitle: (url: string) => Promise<string>
       sanitizeWorkspaceCwd: (cwd?: null | string) => Promise<{ cwd: string; sanitized: boolean }>
       settings: {

--- a/apps/desktop/src/hermes.ts
+++ b/apps/desktop/src/hermes.ts
@@ -4,6 +4,7 @@ import type {
   ActionResponse,
   ActionStatusResponse,
   AnalyticsResponse,
+  ArtifactPreviewResponse,
   AudioSpeakResponse,
   AudioTranscriptionResponse,
   AuxiliaryModelsResponse,
@@ -54,6 +55,7 @@ export type {
   AnalyticsSkillEntry,
   AnalyticsSkillsSummary,
   AnalyticsTotals,
+  ArtifactPreviewResponse,
   AudioSpeakResponse,
   AudioTranscriptionResponse,
   AuxiliaryModelsResponse,
@@ -717,6 +719,12 @@ export function updateHermes(): Promise<ActionResponse> {
 export function checkHermesUpdate(force = false): Promise<BackendUpdateCheckResponse> {
   return window.hermesDesktop.api<BackendUpdateCheckResponse>({
     path: `/api/hermes/update/check${force ? '?force=true' : ''}`
+  })
+}
+
+export function previewArtifact(path: string): Promise<ArtifactPreviewResponse> {
+  return window.hermesDesktop.api<ArtifactPreviewResponse>({
+    path: `/api/artifacts/preview?path=${encodeURIComponent(path)}`
   })
 }
 

--- a/apps/desktop/src/types/hermes.ts
+++ b/apps/desktop/src/types/hermes.ts
@@ -1,3 +1,20 @@
+export type ArtifactPreviewType = 'image' | 'markdown' | 'pdf' | 'text' | 'too_large' | 'unsupported'
+
+export interface ArtifactPreviewResponse {
+  can_change_path?: boolean
+  data_url?: string
+  locked_root?: null | string
+  max_preview_bytes?: number
+  mime_type: string
+  mtime: number
+  name: string
+  path: string
+  preview_type: ArtifactPreviewType
+  root?: null | string
+  size: number
+  text?: string
+}
+
 export interface ConfigFieldSchema {
   category?: string
   description?: string

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -1433,6 +1433,112 @@ async def read_managed_file(request: Request, path: str):
     }
 
 
+_ARTIFACT_PREVIEW_TEXT_MAX_BYTES = 1 * 1024 * 1024
+_ARTIFACT_PREVIEW_BINARY_MAX_BYTES = 25 * 1024 * 1024
+_ARTIFACT_TEXT_EXTENSIONS = {
+    ".cfg",
+    ".conf",
+    ".css",
+    ".csv",
+    ".env",
+    ".html",
+    ".ini",
+    ".js",
+    ".json",
+    ".jsx",
+    ".log",
+    ".md",
+    ".py",
+    ".rst",
+    ".toml",
+    ".ts",
+    ".tsx",
+    ".txt",
+    ".xml",
+    ".yaml",
+    ".yml",
+}
+_ARTIFACT_IMAGE_EXTENSIONS = {".bmp", ".gif", ".jpeg", ".jpg", ".png", ".svg", ".webp"}
+
+
+def _artifact_preview_type(target: Path, mime_type: str) -> str:
+    suffix = target.suffix.lower()
+    normalized_mime = (mime_type or "").split(";", 1)[0].lower()
+    if suffix in _ARTIFACT_IMAGE_EXTENSIONS or normalized_mime.startswith("image/"):
+        return "image"
+    if suffix == ".pdf" or normalized_mime == "application/pdf":
+        return "pdf"
+    if suffix == ".md" or normalized_mime in {"text/markdown", "text/x-markdown"}:
+        return "markdown"
+    if normalized_mime.startswith("text/") or suffix in _ARTIFACT_TEXT_EXTENSIONS:
+        return "text"
+    return "unsupported"
+
+
+@app.get("/api/artifacts/preview")
+async def preview_artifact(request: Request, path: str):
+    """Return a safe in-app preview payload for a local artifact path.
+
+    Uses the same managed-files policy as /api/files so local dashboards can
+    preview files under the user's home directory and hosted dashboards stay
+    locked to their configured files root. Text/Markdown are returned as UTF-8
+    text with a 1MB cap. PDF/image previews are returned as data URLs with a
+    25MB cap. Unsupported files return metadata only.
+    """
+    policy, target, display_path = _resolve_managed_path(path, request)
+    if not target.exists():
+        raise HTTPException(status_code=404, detail="File not found")
+    if not target.is_file():
+        raise HTTPException(status_code=400, detail="Path is not a file")
+
+    try:
+        stat_result = target.stat()
+    except OSError as exc:
+        raise HTTPException(status_code=500, detail=f"Could not stat file: {exc}")
+
+    size = stat_result.st_size
+    mime_type = mimetypes.guess_type(target.name)[0] or "application/octet-stream"
+    preview_type = _artifact_preview_type(target, mime_type)
+    response: Dict[str, Any] = {
+        "name": target.name,
+        "path": display_path,
+        "size": size,
+        "mtime": stat_result.st_mtime,
+        "mime_type": mime_type,
+        "preview_type": preview_type,
+        **_managed_response_meta(policy),
+    }
+
+    if preview_type in {"text", "markdown"}:
+        if size > _ARTIFACT_PREVIEW_TEXT_MAX_BYTES:
+            response["preview_type"] = "too_large"
+            response["max_preview_bytes"] = _ARTIFACT_PREVIEW_TEXT_MAX_BYTES
+            return response
+        try:
+            response["text"] = target.read_text(encoding="utf-8", errors="replace")
+        except PermissionError:
+            raise HTTPException(status_code=403, detail="File is not readable")
+        except OSError as exc:
+            raise HTTPException(status_code=500, detail=f"Could not read file: {exc}")
+        return response
+
+    if preview_type in {"image", "pdf"}:
+        if size > _ARTIFACT_PREVIEW_BINARY_MAX_BYTES:
+            response["preview_type"] = "too_large"
+            response["max_preview_bytes"] = _ARTIFACT_PREVIEW_BINARY_MAX_BYTES
+            return response
+        try:
+            encoded = base64.b64encode(target.read_bytes()).decode("ascii")
+        except PermissionError:
+            raise HTTPException(status_code=403, detail="File is not readable")
+        except OSError as exc:
+            raise HTTPException(status_code=500, detail=f"Could not read file: {exc}")
+        response["data_url"] = f"data:{mime_type};base64,{encoded}"
+        return response
+
+    return response
+
+
 @app.get("/api/files/download")
 async def download_managed_file(request: Request, path: str):
     """Stream a managed file as an attachment download.

--- a/tests/hermes_cli/test_web_server_artifact_preview.py
+++ b/tests/hermes_cli/test_web_server_artifact_preview.py
@@ -1,0 +1,85 @@
+import base64
+
+import pytest
+
+
+@pytest.fixture()
+def client(monkeypatch, tmp_path):
+    from starlette.testclient import TestClient
+
+    import hermes_cli.web_server as web_server
+
+    root = tmp_path / "files"
+    root.mkdir()
+    monkeypatch.setenv("HERMES_DASHBOARD_FILES_ROOT", str(root))
+    web_server.app.state.bound_host = "127.0.0.1"
+    web_server.app.state.bound_port = 9119
+    test_client = TestClient(web_server.app, base_url="http://127.0.0.1:9119")
+    test_client.headers[web_server._SESSION_HEADER_NAME] = web_server._SESSION_TOKEN
+    return test_client, root
+
+
+def test_preview_markdown_returns_text(client):
+    test_client, root = client
+    doc = root / "note.md"
+    doc.write_text("# Hello\n\nArtifact viewer", encoding="utf-8")
+
+    resp = test_client.get("/api/artifacts/preview", params={"path": str(doc)})
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["name"] == "note.md"
+    assert data["preview_type"] == "markdown"
+    assert data["text"] == "# Hello\n\nArtifact viewer"
+    assert data["data_url"] is None if "data_url" in data else True
+
+
+def test_preview_image_returns_data_url(client):
+    test_client, root = client
+    img = root / "pixel.png"
+    img.write_bytes(b"\x89PNG\r\n\x1a\n" + b"\x00" * 8)
+
+    resp = test_client.get("/api/artifacts/preview", params={"path": str(img)})
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["preview_type"] == "image"
+    assert data["data_url"].startswith("data:image/png;base64,")
+    assert base64.b64decode(data["data_url"].split(",", 1)[1]).startswith(b"\x89PNG")
+
+
+def test_preview_pdf_returns_data_url(client):
+    test_client, root = client
+    pdf = root / "report.pdf"
+    pdf.write_bytes(b"%PDF-1.4\n%test\n")
+
+    resp = test_client.get("/api/artifacts/preview", params={"path": str(pdf)})
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["preview_type"] == "pdf"
+    assert data["data_url"].startswith("data:application/pdf;base64,")
+
+
+def test_preview_unsupported_returns_metadata_only(client):
+    test_client, root = client
+    blob = root / "archive.zip"
+    blob.write_bytes(b"PK\x03\x04")
+
+    resp = test_client.get("/api/artifacts/preview", params={"path": str(blob)})
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["preview_type"] == "unsupported"
+    assert "text" not in data
+    assert "data_url" not in data
+
+
+def test_preview_rejects_path_outside_locked_root(client, tmp_path):
+    test_client, _root = client
+    outside = tmp_path / "outside.txt"
+    outside.write_text("secret", encoding="utf-8")
+
+    resp = test_client.get("/api/artifacts/preview", params={"path": str(outside)})
+
+    assert resp.status_code == 403


### PR DESCRIPTION
## Summary

Adds an in-app artifact preview MVP to the existing Hermes Desktop `/artifacts` route.

This keeps the first slice intentionally small: one explicit-path preview endpoint, a preview panel in the existing Artifacts page, and read/open-only desktop actions.

## What changed

- Added `GET /api/artifacts/preview?path=<path>` using the existing managed-files policy.
- Supports in-app previews for:
  - PDF files via data URL
  - images via data URL
  - Markdown as rendered text
  - plain text/log/config/code files as text
- Returns metadata-only responses for unsupported files.
- Caps preview payloads:
  - text/Markdown: 1 MB
  - PDF/images: 25 MB
- Upgraded the existing Desktop Artifacts page with:
  - manual path input
  - right-side preview panel
  - row/card Preview actions
  - Copy path
  - Open externally
  - Reveal in Finder
- Added a narrow Electron IPC bridge for `Reveal in Finder` using `shell.showItemInFolder()`.
- Added backend tests for markdown, image, PDF, unsupported file, and locked-root rejection.

## Deferred intentionally

- DOCX/XLSX rendering
- diff viewer
- annotations/comments
- Nextcloud/version history
- Work Queue or approval-center integration
- broad filesystem indexing

Those should be follow-up slices after the explicit-path preview primitive is stable.

## Verification

- `python3 -m py_compile hermes_cli/web_server.py`
- `python3 -m pytest tests/hermes_cli/test_web_server_artifact_preview.py -q -o 'addopts='`
  - 5 passed
- `npm run typecheck`
  - passed
- `npx eslint src/app/artifacts/index.tsx src/hermes.ts src/types/hermes.ts src/global.d.ts electron/main.cjs electron/preload.cjs`
  - passed
- `npm run build`
  - passed
- `git diff --check`
  - passed
