### PR TITLE
fix(file-tools): expand ~ via profile HOME, not gateway process HOME

### DIFF
--- a/tests/tools/test_file_tools_cwd_resolution.py
+++ b/tests/tools/test_file_tools_cwd_resolution.py
@@ -314,3 +314,108 @@ def test_patch_reports_resolved_absolute_path(_isolated_cwd, monkeypatch):
     assert "WORKSPACE_PATCHED" in (workspace / "target.py").read_text()
     # And the decoy copy is untouched.
     assert (decoy / "target.py").read_text() == "DECOY_ORIGINAL\n"
+
+
+# ── Issue #48552: in-process file tools expand ~ via the PROCESS HOME, not the
+# profile HOME, so cron jobs running inside a gateway (Docker/systemd/s6) whose
+# HOME differs from the interactive session's HOME resolve ``~`` to the wrong
+# directory and file ops fail. The terminal tool already routes HOME through
+# ``hermes_constants.get_subprocess_home``; the file tools must agree with it so
+# ``~`` points at the same place in-process as it does in a terminal subprocess.
+
+
+def test_expand_user_honors_profile_home_when_override_present(monkeypatch):
+    """A leading ``~`` expands to the profile HOME the terminal tool would use.
+
+    This is the core of the bug: under a gateway the file tool must NOT use the
+    raw process HOME for ``~``. We pin the helper to the same contract as
+    ``get_subprocess_home`` by faking an override and asserting ``~`` lands on it.
+    """
+    monkeypatch.setattr(ft, "_effective_home", lambda: "/opt/data/profiles/coder/home")
+
+    assert ft._expand_user("~") == "/opt/data/profiles/coder/home"
+    assert ft._expand_user("~/scratch/saber-docs/notes.md") == (
+        "/opt/data/profiles/coder/home/scratch/saber-docs/notes.md"
+    )
+
+
+def test_expand_user_falls_back_to_stdlib_on_host(monkeypatch):
+    """When no override applies (host install) behaviour is unchanged.
+
+    ``get_subprocess_home`` returns None on host installs; the helper must then
+    be byte-for-byte ``os.path.expanduser`` so we introduce zero behaviour change
+    for the common case.
+    """
+    monkeypatch.setattr(ft, "_effective_home", lambda: None)
+
+    assert ft._expand_user("~/x.txt") == os.path.expanduser("~/x.txt")
+    assert ft._expand_user("~") == os.path.expanduser("~")
+
+
+def test_expand_user_named_account_keeps_stdlib_semantics(monkeypatch):
+    """``~otheruser`` names a specific account and must not be profile-scoped.
+
+    Only the current-user form (``~`` / ``~/...``) redirects to the profile HOME;
+    ``~root/x`` must still defer to stdlib so a named account resolves correctly.
+    """
+    monkeypatch.setattr(ft, "_effective_home", lambda: "/opt/data/profiles/coder/home")
+
+    # Whatever stdlib does with ~root (resolve or leave verbatim), we match it —
+    # we must NOT join it onto the profile home.
+    assert ft._expand_user("~root/x") == os.path.expanduser("~root/x")
+    assert not ft._expand_user("~root/x").startswith("/opt/data/profiles/coder/home")
+
+
+def test_expand_user_non_tilde_paths_untouched(monkeypatch):
+    """Absolute and relative non-tilde paths pass through verbatim."""
+    monkeypatch.setattr(ft, "_effective_home", lambda: "/opt/data/profiles/coder/home")
+
+    assert ft._expand_user("/etc/hosts") == "/etc/hosts"
+    assert ft._expand_user("relative/sub/file.txt") == "relative/sub/file.txt"
+    assert ft._expand_user("") == ""
+
+
+def test_resolve_path_for_task_tilde_uses_profile_home(monkeypatch):
+    """End-to-end: the path resolver honours the profile HOME for ``~`` paths.
+
+    This is the user-visible failure in #48552 — ``write_file('~/x')`` inside a
+    cron job must resolve under the profile HOME, not the gateway's HOME.
+    """
+    monkeypatch.setattr(ft, "_effective_home", lambda: "/opt/data/profiles/coder/home")
+
+    resolved = ft._resolve_path_for_task("~/scratch/notes.md", task_id="default")
+
+    assert resolved == Path("/opt/data/profiles/coder/home/scratch/notes.md")
+
+
+def test_resolve_path_for_task_tilde_host_fallback_unchanged(monkeypatch):
+    """On host installs the resolver's ``~`` handling is identical to before."""
+    monkeypatch.setattr(ft, "_effective_home", lambda: None)
+
+    resolved = ft._resolve_path_for_task("~/scratch/notes.md", task_id="default")
+
+    assert resolved == Path("~/scratch/notes.md").expanduser().resolve()
+
+
+def test_effective_home_matches_get_subprocess_home_under_profile(monkeypatch, tmp_path):
+    """Value-truth: ``_effective_home`` returns the SAME HOME the terminal tool
+    would use, exercised through the real ``get_subprocess_home`` (no mock of the
+    boundary under test).
+
+    Mirrors the bug's environment: a profile whose ``{HERMES_HOME}/home`` exists
+    and ``TERMINAL_HOME_MODE=profile`` (the isolation a gateway cron wants).
+    """
+    import hermes_constants
+
+    hermes_home = tmp_path / "profiles" / "coder"
+    profile_home = hermes_home / "home"
+    profile_home.mkdir(parents=True)
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.setenv("HOME", str(tmp_path / "gateway_home"))
+    monkeypatch.setenv("TERMINAL_HOME_MODE", "profile")
+    # Clear any context-local override so the env vars above are authoritative.
+    monkeypatch.setattr(hermes_constants, "get_hermes_home_override", lambda: None)
+
+    assert ft._effective_home() == str(profile_home)
+    # And the raw process HOME would have produced the WRONG answer (the bug):
+    assert ft._effective_home() != os.path.expanduser("~")

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -78,6 +78,58 @@ _BLOCKED_DEVICE_PATHS = frozenset({
 })
 
 
+def _effective_home() -> str | None:
+    """Return the HOME that ``~`` should expand to for in-process file tools.
+
+    In-process file tools historically expanded ``~`` with stdlib
+    ``os.path.expanduser``, which reads the *process* ``HOME``. When Hermes runs
+    under a gateway (Docker/systemd/s6) the gateway process ``HOME`` often
+    differs from the interactive session's ``HOME`` — in profile mode the session
+    wrapper sets ``HOME={HERMES_HOME}/home``. A cron job running in-process then
+    resolved ``~`` against the gateway's ``HOME`` and wrote to the wrong place
+    (issue #48552).
+
+    The terminal tool already normalises subprocess ``HOME`` via
+    ``hermes_constants.get_subprocess_home``. We reuse that exact contract so
+    ``~`` points at the same directory in-process as it does in a terminal
+    subprocess. Returns ``None`` when no override applies (the common host-install
+    case), signalling the caller to fall back to stdlib ``expanduser`` — i.e. zero
+    behaviour change off the gateway/profile path.
+    """
+    try:
+        from hermes_constants import get_subprocess_home
+
+        return get_subprocess_home(dict(os.environ))
+    except Exception:
+        # Never let HOME resolution raise out of a file op; degrade to stdlib.
+        return None
+
+
+def _expand_user(path: str) -> str:
+    """``os.path.expanduser`` that honours the profile HOME (issue #48552).
+
+    Only the *current-user* tilde form (``~`` or ``~/...``) is redirected to the
+    profile HOME returned by :func:`_effective_home`. A named-account form
+    (``~otheruser/...``) names a specific account and is left to stdlib so it
+    resolves correctly. Non-tilde paths pass through untouched.
+
+    When :func:`_effective_home` returns ``None`` (host install, no override) the
+    result is byte-for-byte ``os.path.expanduser(path)``.
+    """
+    if not path or not path.startswith("~"):
+        return path
+    # Named-account form (~user/...) — not ours to redirect; defer to stdlib.
+    if len(path) > 1 and path[1] not in ("/", os.sep):
+        return os.path.expanduser(path)
+    home = _effective_home()
+    if not home:
+        return os.path.expanduser(path)
+    if path == "~":
+        return home
+    # path starts with "~/" (or "~\\" on Windows) — splice in the profile HOME.
+    return os.path.join(home, path[2:])
+
+
 def _resolve_path(filepath: str, task_id: str = "default") -> Path:
     """Resolve a path relative to TERMINAL_CWD (the worktree base directory)
     instead of the main repository root.
@@ -238,8 +290,11 @@ def _resolve_path_for_task(filepath: str, task_id: str = "default") -> Path:
 
     See :func:`_resolve_base_dir` for how the base is chosen. Absolute input
     paths are returned resolved-but-unanchored.
+
+    ``~`` is expanded via :func:`_expand_user` so it honours the profile HOME the
+    terminal tool uses, not the raw process HOME (issue #48552).
     """
-    p = Path(filepath).expanduser()
+    p = Path(_expand_user(filepath))
     if p.is_absolute():
         return p.resolve()
     return (_resolve_base_dir(task_id) / p).resolve()


### PR DESCRIPTION
Fixes #48552.

## Why

In-process file tools (`read_file`, `write_file`, `patch`, `search_files`) expand `~` with stdlib `os.path.expanduser`, which reads the **process** `HOME`. When Hermes runs under a gateway (Docker, systemd, s6), the gateway process `HOME` often differs from the interactive session's `HOME` — in profile mode the session wrapper sets `HOME={HERMES_HOME}/home`. A cron job runs in-process inside the gateway (`cron/scheduler.py` constructs `AIAgent()` directly), inheriting the gateway's `HOME`, so a prompt referencing `~/scratch/...` expands to a non-existent path under the *gateway's* HOME and `write_file` fails with `No such file or directory`. The file-mutation verifier correctly reports the file unmodified, but the root cause (HOME mismatch) is opaque.

The `terminal.home_mode` policy already normalises subprocess `HOME` via `hermes_constants.get_subprocess_home` — but only the terminal tool's subprocesses honour it. The in-process file tools bypass it entirely and use raw `os.path.expanduser`. So `~` means two different directories depending on whether you reach it through `terminal()` or `write_file()` in the same session — and inside a gateway the file-tool answer is the wrong one.

## What

Make the file tools agree with the terminal tool on what `~` means — the reporter's preferred **Option A**.

- **`_effective_home()`** — delegates to `get_subprocess_home(os.environ)`, the exact contract the terminal tool already uses (honouring `terminal.home_mode` = `auto`/`real`/`profile`). Returns `None` when no override applies (host installs), and never raises out of a file op (degrades to stdlib on any import/lookup error).
- **`_expand_user()`** — a profile-aware `expanduser`. Only the *current-user* form (`~`, `~/...`) is redirected to the profile HOME; named-account forms (`~root/...`) defer to stdlib so they resolve to the right account; non-tilde paths pass through verbatim. When `_effective_home()` is `None`, the result is byte-for-byte `os.path.expanduser`.
- Route the central resolver **`_resolve_path_for_task()`** through `_expand_user`. All four file tools resolve relative/tilde paths through this one function, so the whole bug class is fixed at a single point (verified: `read_file_tool`, `write_file_tool`, `patch_tool`, and the `search_tool` all reach `_resolve_path_for_task`, directly or via the `_resolve_path` wrapper).

## Behaviour change footprint

**Zero on host installs.** `get_subprocess_home` returns `None` outside the gateway/profile-home configuration, so `_expand_user` is byte-for-byte `os.path.expanduser` and `_resolve_path_for_task` is unchanged. The fix only changes the path that is currently broken: a gateway/cron process whose `HOME` differs from the profile HOME. There it makes `~` resolve to the same directory the terminal tool would use.

This deliberately does **not** touch the other `expanduser` call sites in `file_tools.py` — they operate on already-absolute system anchors (`TERMINAL_CWD`, workspace roots, the resolved Hermes config path, device-block normalisation) where the process `HOME` is not the relevant base. Narrowing the change to user-supplied path resolution keeps the footprint minimal.

## Test coverage

Added to `tests/tools/test_file_tools_cwd_resolution.py` (the existing home for path-resolution invariants), +7:

| Test | What it covers |
|---|---|
| `test_expand_user_honors_profile_home_when_override_present` | `~` / `~/...` redirect to the profile HOME |
| `test_expand_user_falls_back_to_stdlib_on_host` | no override → byte-for-byte stdlib `expanduser` |
| `test_expand_user_named_account_keeps_stdlib_semantics` | `~root/...` stays stdlib, never profile-scoped |
| `test_expand_user_non_tilde_paths_untouched` | absolute / relative / empty pass through verbatim |
| `test_resolve_path_for_task_tilde_uses_profile_home` | end-to-end: resolver lands `~` under profile HOME |
| `test_resolve_path_for_task_tilde_host_fallback_unchanged` | host resolver path identical to before |
| `test_effective_home_matches_get_subprocess_home_under_profile` | value-truth: `_effective_home` equals `get_subprocess_home` under a **real** profile env (no mock of the boundary under test) |

The last test exercises the real `get_subprocess_home` against a `tmp_path` profile with `{HERMES_HOME}/home` present and `TERMINAL_HOME_MODE=profile` — the actual environment from the bug report — and asserts the raw process `HOME` would have produced the wrong answer.

Local results (`-o addopts=""` to strip the repo's signal-based pytest timeout that the local runner rejects):

- New + existing file: **30 passed** in `tests/tools/test_file_tools_cwd_resolution.py` (23 pre-existing + 7 new).
- Broader: **71 passed** across `test_file_tools.py` + `test_file_tools_cwd_resolution.py` + `test_file_tools_container_config.py`.
- Pristine-vs-branch failure diff across the whole `tests/tools/` directory: **zero new failures** (the one pre-existing `test_clipboard.py` collection error is present on pristine `main` and unrelated).

## Out of scope

- **Option B** (have the gateway set `HOME` to `get_subprocess_home()` at startup in `gateway/run.py`) — broader blast radius, would change `HOME` for *every* in-process consumer, not just path expansion. Option A is the surgical fix; B can be considered separately if a wider HOME-normalisation is wanted.
- The other `expanduser` sites in `file_tools.py` (system anchors) — see Behaviour change footprint above; intentionally untouched.
