### PR TITLE
fix(transport): strip replay metadata from chat messages (#48523)

### DIFF
--- a/agent/transports/chat_completions.py
+++ b/agent/transports/chat_completions.py
@@ -19,6 +19,17 @@ from agent.transports.base import ProviderTransport
 from agent.transports.types import NormalizedResponse, ToolCall, Usage
 
 
+_STRIP_TOP_LEVEL_MESSAGE_KEYS = (
+    "codex_reasoning_items",
+    "codex_message_items",
+    "tool_name",
+    "timestamp",
+    "message_id",
+    "observed",
+    "finish_reason",
+)
+
+
 def _build_gemini_thinking_config(model: str, reasoning_config: dict | None) -> dict | None:
     """Translate Hermes/OpenRouter-style reasoning config to Gemini thinkingConfig."""
     if reasoning_config is None or not isinstance(reasoning_config, dict):
@@ -150,6 +161,10 @@ class ChatCompletionsTransport(ProviderTransport):
           ``Extra inputs are not permitted, field: 'messages[N].tool_name'``.
           Permissive providers (OpenRouter, MiniMax) silently ignore the
           field, which masked the bug for months.
+        - SQLite session replay metadata: ``timestamp``, ``message_id``,
+          ``observed``, and ``finish_reason``. These fields are useful for
+          local persistence/history but are not part of the Chat Completions
+          message schema and strict providers reject them as extra inputs.
         - Hermes-internal scaffolding markers — any top-level message key
           starting with ``_`` (e.g. ``_empty_recovery_synthetic``,
           ``_empty_terminal_sentinel``, ``_thinking_prefill``). These are
@@ -168,11 +183,7 @@ class ChatCompletionsTransport(ProviderTransport):
         for msg in messages:
             if not isinstance(msg, dict):
                 continue
-            if (
-                "codex_reasoning_items" in msg
-                or "codex_message_items" in msg
-                or "tool_name" in msg
-            ):
+            if any(key in msg for key in _STRIP_TOP_LEVEL_MESSAGE_KEYS):
                 needs_sanitize = True
                 break
             if any(isinstance(k, str) and k.startswith("_") for k in msg):
@@ -198,9 +209,8 @@ class ChatCompletionsTransport(ProviderTransport):
         for msg in sanitized:
             if not isinstance(msg, dict):
                 continue
-            msg.pop("codex_reasoning_items", None)
-            msg.pop("codex_message_items", None)
-            msg.pop("tool_name", None)
+            for key in _STRIP_TOP_LEVEL_MESSAGE_KEYS:
+                msg.pop(key, None)
             # Drop all Hermes-internal scaffolding markers (``_``-prefixed).
             # OpenAI's message schema has no ``_``-prefixed fields, so this
             # is safe and future-proofs against new markers being added.

--- a/tests/agent/transports/test_chat_completions.py
+++ b/tests/agent/transports/test_chat_completions.py
@@ -128,6 +128,35 @@ class TestChatCompletionsBasic:
         # Original list untouched (deepcopy-on-demand)
         assert msgs[1]["_empty_recovery_synthetic"] is True
 
+    def test_convert_messages_strips_session_replay_metadata(self, transport):
+        """SQLite session replay metadata is internal and strict providers
+        reject it when it leaks into Chat Completions payloads.
+        """
+        msgs = [
+            {
+                "role": "user",
+                "content": "continue",
+                "timestamp": 1781799468.409,
+                "message_id": "msg-user-1",
+                "observed": True,
+            },
+            {
+                "role": "assistant",
+                "content": "done",
+                "timestamp": 1781799469.012,
+                "message_id": "msg-assistant-1",
+                "finish_reason": "stop",
+            },
+        ]
+        result = transport.convert_messages(msgs)
+        for msg in result:
+            assert not ({"timestamp", "message_id", "observed", "finish_reason"} & msg.keys())
+        assert result[0] == {"role": "user", "content": "continue"}
+        assert result[1] == {"role": "assistant", "content": "done"}
+        # Original list untouched (deepcopy-on-demand)
+        assert msgs[0]["timestamp"] == 1781799468.409
+        assert msgs[1]["finish_reason"] == "stop"
+
     def test_convert_messages_clean_list_is_identity(self, transport):
         """A list with no internal/codex keys is returned as-is (no copy)."""
         msgs = [


### PR DESCRIPTION
## Summary

- Strip SQLite session replay metadata (`timestamp`, `message_id`, `observed`, `finish_reason`) from Chat Completions messages before provider calls.
- Keep the existing copy-on-sanitize behavior so original replayed messages remain untouched while strict providers receive schema-clean payloads.
- Consolidate top-level stripped message fields into one private tuple to avoid future drift between detection and removal.

## Verification

- RED proof on upstream/main: `tests/agent/transports/test_chat_completions.py::TestChatCompletionsBasic::test_convert_messages_strips_session_replay_metadata` failed because replay metadata reached `convert_messages()` output.
- Focused regression after fix: 3 passed (`test_convert_messages_strips_session_replay_metadata`, `test_convert_messages_clean_list_is_identity`, `test_convert_messages_strips_internal_scaffolding_markers`).
- Nearby suite after reviewer improvement/rebase: `/Users/evinova-self/.hermes/hermes-agent/venv/bin/python3 -m pytest tests/agent/transports/test_chat_completions.py -v -o "addopts=" --tb=short` → 82 passed.
- Branch verification: `git rev-list --left-right --count upstream/main...HEAD` → `0 1`.

## Duplicate / competitor check

- No open Tranquil-Flow PR found for issue #48523 by issue search or `fix/48523*` head branch.
- No focused open competitor found for `48523` or distinctive keywords (`convert_messages timestamp message_id strict providers`).

Auto-published by Moonsong via Path B automated pipeline.