### PR TITLE
feat(doctor): detect fake Windows python.exe stubs and PE subsystem

### DIFF
--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -9,6 +9,7 @@ import sys
 import subprocess
 import shutil
 from pathlib import Path
+import struct
 
 from hermes_cli.config import get_project_root, get_hermes_home, get_env_path
 from hermes_cli.env_loader import load_hermes_dotenv
@@ -330,7 +331,6 @@ def _pe_subsystem(path: str) -> int | None:
     3 for IMAGE_SUBSYSTEM_WINDOWS_CUI (python.exe),
     or None if the file is not a valid PE executable.
     """
-    import struct
     try:
         with open(path, "rb") as f:
             dos = f.read(64)

--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -363,10 +363,8 @@ def _check_windows_python_stubs(
     This check compares the PATH-resolved ``python`` / ``pythonw``
     against the venv's real binaries and flags the mismatch.
     """
-    import os as _os
-
     windowsapps = (
-        Path(_os.environ.get("LOCALAPPDATA", ""))
+        Path(os.environ.get("LOCALAPPDATA", ""))
         / "Microsoft"
         / "WindowsApps"
     )

--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -323,6 +323,179 @@ def check_certificates() -> None:
         check_warn("SSL certificate check skipped", str(e))
 
 
+def _pe_subsystem(path: str) -> int | None:
+    """Return the Windows PE subsystem value for a .exe file.
+
+    Returns 2 for IMAGE_SUBSYSTEM_WINDOWS_GUI (pythonw.exe),
+    3 for IMAGE_SUBSYSTEM_WINDOWS_CUI (python.exe),
+    or None if the file is not a valid PE executable.
+    """
+    import struct
+    try:
+        with open(path, "rb") as f:
+            dos = f.read(64)
+            if len(dos) < 64 or dos[:2] != b"MZ":
+                return None
+            e_lfanew = struct.unpack_from("<I", dos, 0x3C)[0]
+            f.seek(e_lfanew)
+            if f.read(4) != b"PE\x00\x00":
+                return None
+            # Skip COFF header (20 bytes) + first 68 bytes of Optional Header
+            # Subsystem is at OptionalHeader offset 68 (same for PE32 and PE32+)
+            f.seek(e_lfanew + 24 + 68)
+            return struct.unpack("<H", f.read(2))[0]
+    except (OSError, struct.error):
+        return None
+
+
+def _check_windows_python_stubs(
+    issues: list[str], manual_issues: list[str]
+) -> None:
+    """Detect the Windows App Execution Alias trap on Windows.
+
+    Windows ships 0-byte ``python.exe`` / ``python3.exe`` stubs in
+    ``%LOCALAPPDATA%\\Microsoft\\WindowsApps``.  These are App Execution
+    Aliases — not real binaries — but they appear first on PATH and
+    mask the real Python installation.  Hermes watchdog and cron
+    scripts that rely on PATH-resolution ``python`` accidentally pick
+    up the fake stub, which can't run anything.
+
+    This check compares the PATH-resolved ``python`` / ``pythonw``
+    against the venv's real binaries and flags the mismatch.
+    """
+    import os as _os
+
+    windowsapps = (
+        Path(_os.environ.get("LOCALAPPDATA", ""))
+        / "Microsoft"
+        / "WindowsApps"
+    )
+
+    # ── 1. Detect 0-byte stubs in WindowsApps ──────────────────────
+    stub_paths: list[str] = []
+    for name in ("python.exe", "python3.exe"):
+        stub = windowsapps / name
+        try:
+            if stub.exists() and stub.stat().st_size == 0:
+                stub_paths.append(str(stub))
+        except OSError:
+            pass
+
+    if stub_paths:
+        names = ", ".join(Path(p).name for p in stub_paths)
+        check_warn(
+            f"0-byte stubs in WindowsApps: {names}",
+            "(App Execution Aliases mask real Python)",
+        )
+        check_info(
+            "These stubs appear first on PATH and can break subprocess "
+            "spawns that rely on plain 'python' resolution."
+        )
+        manual_issues.append(
+            "Disable Python App Execution Aliases in "
+            "Windows Settings → Apps → App execution aliases"
+        )
+    else:
+        check_ok("No 0-byte Python stubs in WindowsApps")
+
+    # ── 2. Check what 'python' resolves to on PATH ─────────────────
+    resolved_python = _safe_which("python")
+    resolved_pythonw = _safe_which("pythonw")
+
+    if resolved_python and str(windowsapps) in resolved_python:
+        check_fail(
+            f"'python' resolves to WindowsApps stub: {resolved_python}",
+            "(0-byte file — cannot run scripts)",
+        )
+        # Find the real python.exe
+        venv_python = PROJECT_ROOT / ".venv" / "Scripts" / "python.exe"
+        if not venv_python.exists():
+            venv_python = PROJECT_ROOT / "venv" / "Scripts" / "python.exe"
+        if venv_python.exists():
+            check_info(
+                f"Real Python is at: {venv_python} — "
+                "use explicit path or fix PATH ordering"
+            )
+        manual_issues.append(
+            "Re-order PATH so venv/Scripts precedes WindowsApps, "
+            "or disable App Execution Aliases"
+        )
+    elif resolved_python:
+        check_ok(f"'python' resolves to: {resolved_python}")
+
+    # ── 3. Verify venv pythonw.exe has GUI subsystem ───────────────
+    venv_pythonw = None
+    for candidate in (
+        PROJECT_ROOT / ".venv" / "Scripts" / "pythonw.exe",
+        PROJECT_ROOT / "venv" / "Scripts" / "pythonw.exe",
+    ):
+        if candidate.exists():
+            venv_pythonw = candidate
+            break
+    # Fallback: check alongside the current Python interpreter (covers
+    # git-clone development setups where PROJECT_ROOT ≠ install root).
+    if venv_pythonw is None:
+        sibling = Path(sys.executable).with_name("pythonw.exe")
+        if sibling.exists() and sibling != Path(sys.executable):
+            venv_pythonw = sibling
+
+    if venv_pythonw is not None:
+        subsystem = _pe_subsystem(str(venv_pythonw))
+        if subsystem == 2:
+            # Show relative path when possible, absolute otherwise
+            try:
+                _display = str(venv_pythonw.relative_to(PROJECT_ROOT))
+            except ValueError:
+                _display = str(venv_pythonw)
+            check_ok(
+                f"venv pythonw.exe: GUI subsystem ✓ ({_display})"
+            )
+        elif subsystem == 3:
+            check_warn(
+                "venv pythonw.exe has CUI (Console) subsystem",
+                "(should be GUI — may flash console windows)",
+            )
+            issues.append(
+                "Reinstall Python via uv to get a proper GUI-subsystem "
+                "pythonw.exe"
+            )
+        else:
+            check_warn(
+                "venv pythonw.exe is not a valid PE file",
+                "(reinstall Python via uv)",
+            )
+            issues.append(
+                "Reinstall Python via uv: uv python install 3.11"
+            )
+    else:
+        check_warn(
+            "venv pythonw.exe not found",
+            "(gateway/cron scripts may not start silently)",
+        )
+        issues.append(
+            "Reinstall Hermes venv: "
+            "cd ~/AppData/Local/hermes/hermes-agent && uv venv"
+        )
+
+    # ── 4. Check pythonw resolution ────────────────────────────────
+    if resolved_pythonw:
+        resolved_subsystem = _pe_subsystem(resolved_pythonw)
+        if resolved_subsystem == 2:
+            check_ok(f"'pythonw' resolves to GUI binary: {resolved_pythonw}")
+        elif resolved_subsystem is None:
+            check_fail(
+                f"'pythonw' resolves to a 0-byte stub: {resolved_pythonw}",
+                "(this will flash console windows on subprocess spawn)",
+            )
+            manual_issues.append(
+                "Remove or disable the WindowsApps pythonw.exe stub"
+            )
+        else:
+            check_warn(
+                f"'pythonw' has unexpected subsystem: {resolved_pythonw}"
+            )
+
+
 def _check_gateway_service_linger(issues: list[str]) -> None:
     """Warn when a systemd user gateway service will stop after logout.
 
@@ -1348,6 +1521,10 @@ def run_doctor(args):
                         manual_issues.append(f"Add {_cmd_link_display} to your PATH")
                 else:
                     issues.append(f"Missing {_cmd_link_display}/hermes symlink — run 'hermes doctor --fix'")
+
+    if sys.platform == "win32":
+        _section("Windows Python Environment")
+        _check_windows_python_stubs(issues, manual_issues)
 
     _section("External Tools")
     # Git

--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -351,17 +351,19 @@ def _pe_subsystem(path: str) -> int | None:
 def _check_windows_python_stubs(
     issues: list[str], manual_issues: list[str]
 ) -> None:
-    """Detect the Windows App Execution Alias trap on Windows.
+    """Validate the Python interpreter Hermes will actually launch.
 
-    Windows ships 0-byte ``python.exe`` / ``python3.exe`` stubs in
-    ``%LOCALAPPDATA%\\Microsoft\\WindowsApps``.  These are App Execution
-    Aliases — not real binaries — but they appear first on PATH and
-    mask the real Python installation.  Hermes watchdog and cron
-    scripts that rely on PATH-resolution ``python`` accidentally pick
-    up the fake stub, which can't run anything.
+    Hermes gateway and cron do NOT use bare-PATH ``python`` / ``pythonw``.
+    Instead ``_resolve_detached_python(get_python_path())`` selects an
+    explicit interpreter.  For uv-created venvs this reaches past the
+    venv launcher to the *base* ``pythonw.exe`` (the venv launcher
+    re-spawns as console ``python.exe``, which defeats the point of a
+    hidden gateway).
 
-    This check compares the PATH-resolved ``python`` / ``pythonw``
-    against the venv's real binaries and flags the mismatch.
+    This check:
+      1. Warns about 0-byte WindowsApps stubs (environment hygiene).
+      2. Resolves the interpreter the gateway would use and validates
+         its PE subsystem, flagging a real binary mismatch.
     """
     windowsapps = (
         Path(os.environ.get("LOCALAPPDATA", ""))
@@ -369,7 +371,7 @@ def _check_windows_python_stubs(
         / "WindowsApps"
     )
 
-    # ── 1. Detect 0-byte stubs in WindowsApps ──────────────────────
+    # ── 1. Environment hygiene: 0-byte stubs in WindowsApps ─────────
     stub_paths: list[str] = []
     for name in ("python.exe", "python3.exe"):
         stub = windowsapps / name
@@ -383,11 +385,7 @@ def _check_windows_python_stubs(
         names = ", ".join(Path(p).name for p in stub_paths)
         check_warn(
             f"0-byte stubs in WindowsApps: {names}",
-            "(App Execution Aliases mask real Python)",
-        )
-        check_info(
-            "These stubs appear first on PATH and can break subprocess "
-            "spawns that rely on plain 'python' resolution."
+            "(App Execution Aliases — can shadow real Python on PATH)",
         )
         manual_issues.append(
             "Disable Python App Execution Aliases in "
@@ -396,101 +394,98 @@ def _check_windows_python_stubs(
     else:
         check_ok("No 0-byte Python stubs in WindowsApps")
 
-    # ── 2. Check what 'python' resolves to on PATH ─────────────────
-    resolved_python = _safe_which("python")
-    resolved_pythonw = _safe_which("pythonw")
+    # ── 2. Resolve the interpreter Hermes actually uses ─────────────
+    try:
+        from hermes_cli.gateway import get_python_path
+        from hermes_cli.gateway_windows import _resolve_detached_python
+    except Exception as e:
+        check_warn(
+            "Could not import gateway resolver",
+            f"(skipping interpreter validation: {e})",
+        )
+        return
 
-    if resolved_python and str(windowsapps) in resolved_python:
+    try:
+        python_exe, _venv_dir, _extra_pp = _resolve_detached_python(
+            get_python_path()
+        )
+    except Exception as e:
+        check_warn(
+            "Gateway interpreter resolution failed",
+            f"(could not resolve python: {e})",
+        )
+        return
+
+    python_path = Path(python_exe)
+    if not python_path.exists():
         check_fail(
-            f"'python' resolves to WindowsApps stub: {resolved_python}",
-            "(0-byte file — cannot run scripts)",
+            f"Gateway interpreter not found: {python_exe}",
+            "(reinstall the Hermes venv)",
         )
-        # Find the real python.exe
-        venv_python = PROJECT_ROOT / ".venv" / "Scripts" / "python.exe"
-        if not venv_python.exists():
-            venv_python = PROJECT_ROOT / "venv" / "Scripts" / "python.exe"
-        if venv_python.exists():
-            check_info(
-                f"Real Python is at: {venv_python} — "
-                "use explicit path or fix PATH ordering"
-            )
-        manual_issues.append(
-            "Re-order PATH so venv/Scripts precedes WindowsApps, "
-            "or disable App Execution Aliases"
+        issues.append(
+            "Reinstall Hermes venv: "
+            "cd ~/AppData/Local/hermes/hermes-agent && uv venv"
         )
-    elif resolved_python:
-        check_ok(f"'python' resolves to: {resolved_python}")
+        return
 
-    # ── 3. Verify venv pythonw.exe has GUI subsystem ───────────────
-    venv_pythonw = None
-    for candidate in (
-        PROJECT_ROOT / ".venv" / "Scripts" / "pythonw.exe",
-        PROJECT_ROOT / "venv" / "Scripts" / "pythonw.exe",
-    ):
-        if candidate.exists():
-            venv_pythonw = candidate
-            break
-    # Fallback: check alongside the current Python interpreter (covers
-    # git-clone development setups where PROJECT_ROOT ≠ install root).
-    if venv_pythonw is None:
-        sibling = Path(sys.executable).with_name("pythonw.exe")
-        if sibling.exists() and sibling != Path(sys.executable):
-            venv_pythonw = sibling
+    subsystem = _pe_subsystem(str(python_path))
+    if subsystem is None:
+        check_fail(
+            f"Gateway interpreter is not a valid PE: {python_exe}",
+            "(file exists but is not a Windows executable)",
+        )
+        issues.append(
+            "Reinstall Python via uv: uv python install 3.11"
+        )
+    elif subsystem == 2:
+        try:
+            _display = str(python_path.relative_to(PROJECT_ROOT))
+        except ValueError:
+            _display = str(python_path)
+        check_ok(
+            f"Gateway interpreter: GUI subsystem ✓ ({_display})"
+        )
+    elif subsystem == 3:
+        check_warn(
+            f"Gateway interpreter has CUI (Console) subsystem: {python_exe}",
+            "(ok but may allocate a visible console on spawn)",
+        )
+    else:
+        check_warn(
+            f"Gateway interpreter has unexpected subsystem {subsystem}: "
+            f"{python_exe}",
+        )
 
-    if venv_pythonw is not None:
-        subsystem = _pe_subsystem(str(venv_pythonw))
-        if subsystem == 2:
-            # Show relative path when possible, absolute otherwise
-            try:
-                _display = str(venv_pythonw.relative_to(PROJECT_ROOT))
-            except ValueError:
-                _display = str(venv_pythonw)
+    # ── 3. Also sanity-check the pythonw alongside the gateway
+    #       interpreter (the sibling should be a GUI binary; if it
+    #       resolves through WindowsApps the 0-byte stub check above
+    #       covers it). ──────────────────────────────────────────────
+    pythonw_path = python_path.with_name(
+        python_path.stem + "w" + python_path.suffix
+    )
+    if pythonw_path.exists() and pythonw_path != python_path:
+        pw_subsystem = _pe_subsystem(str(pythonw_path))
+        if pw_subsystem == 2:
             check_ok(
-                f"venv pythonw.exe: GUI subsystem ✓ ({_display})"
+                f"Gateway pythonw: GUI subsystem ✓ "
+                f"({pythonw_path.name})"
             )
-        elif subsystem == 3:
+        elif pw_subsystem == 3:
             check_warn(
-                "venv pythonw.exe has CUI (Console) subsystem",
+                "Gateway pythonw has CUI (Console) subsystem",
                 "(should be GUI — may flash console windows)",
             )
             issues.append(
                 "Reinstall Python via uv to get a proper GUI-subsystem "
                 "pythonw.exe"
             )
-        else:
+        elif pw_subsystem is None:
             check_warn(
-                "venv pythonw.exe is not a valid PE file",
+                "Gateway pythonw is not a valid PE file",
                 "(reinstall Python via uv)",
             )
             issues.append(
                 "Reinstall Python via uv: uv python install 3.11"
-            )
-    else:
-        check_warn(
-            "venv pythonw.exe not found",
-            "(gateway/cron scripts may not start silently)",
-        )
-        issues.append(
-            "Reinstall Hermes venv: "
-            "cd ~/AppData/Local/hermes/hermes-agent && uv venv"
-        )
-
-    # ── 4. Check pythonw resolution ────────────────────────────────
-    if resolved_pythonw:
-        resolved_subsystem = _pe_subsystem(resolved_pythonw)
-        if resolved_subsystem == 2:
-            check_ok(f"'pythonw' resolves to GUI binary: {resolved_pythonw}")
-        elif resolved_subsystem is None:
-            check_fail(
-                f"'pythonw' resolves to a 0-byte stub: {resolved_pythonw}",
-                "(this will flash console windows on subprocess spawn)",
-            )
-            manual_issues.append(
-                "Remove or disable the WindowsApps pythonw.exe stub"
-            )
-        else:
-            check_warn(
-                f"'pythonw' has unexpected subsystem: {resolved_pythonw}"
             )
 
 

--- a/tests/hermes_cli/test_doctor.py
+++ b/tests/hermes_cli/test_doctor.py
@@ -1476,3 +1476,233 @@ def test_npm_audit_fix_hint_avoids_crashing_workspace_flag(monkeypatch, tmp_path
     assert "build-time tooling" in out
     assert "known npm bug" in out
     assert "lockfile bump" in out
+
+
+# ── Windows PE subsystem + python stubs ───────────────────────────
+
+
+class TestPeSubsystem:
+    """Tests for ``_pe_subsystem`` — PE header parsing for Windows .exe files."""
+
+    def _write_pe(self, tmp_path, subsystem_value: int) -> str:
+        """Write a minimal PE file with the given subsystem and return its path."""
+        import struct
+
+        path = tmp_path / "test.exe"
+        # DOS header
+        dos = bytearray(64)
+        dos[0:2] = b"MZ"
+        struct.pack_into("<I", dos, 0x3C, 64)  # e_lfanew → PE header at offset 64
+
+        # PE signature + COFF header (20 bytes) + PE32 Optional Header
+        pe = bytearray(24 + 96)
+        pe[0:4] = b"PE\x00\x00"  # PE signature
+        # Optional Header magic = PE32 (0x10B) at offset 24
+        struct.pack_into("<H", pe, 24, 0x10B)
+        # Subsystem at Optional Header offset 68
+        struct.pack_into("<H", pe, 24 + 68, subsystem_value)
+
+        path.write_bytes(dos + pe)
+        return str(path)
+
+    def test_gui_subsystem(self, tmp_path):
+        from hermes_cli.doctor import _pe_subsystem
+        path = self._write_pe(tmp_path, 2)
+        assert _pe_subsystem(path) == 2
+
+    def test_cui_subsystem(self, tmp_path):
+        from hermes_cli.doctor import _pe_subsystem
+        path = self._write_pe(tmp_path, 3)
+        assert _pe_subsystem(path) == 3
+
+    def test_not_a_pe(self, tmp_path):
+        from hermes_cli.doctor import _pe_subsystem
+        path = tmp_path / "not_pe.exe"
+        path.write_text("hello world")
+        assert _pe_subsystem(str(path)) is None
+
+    def test_truncated_dos_header(self, tmp_path):
+        from hermes_cli.doctor import _pe_subsystem
+        path = tmp_path / "short.exe"
+        path.write_bytes(b"MZ")
+        assert _pe_subsystem(str(path)) is None
+
+    def test_missing_pe_signature(self, tmp_path):
+        from hermes_cli.doctor import _pe_subsystem
+        import struct
+
+        path = tmp_path / "badpe.exe"
+        dos = bytearray(64)
+        dos[0:2] = b"MZ"
+        struct.pack_into("<I", dos, 0x3C, 64)
+        # PE signature wrong
+        tail = bytearray(24 + 96)
+        tail[0:4] = b"NE\x00\x00"  # NE, not PE
+        path.write_bytes(dos + tail)
+        assert _pe_subsystem(str(path)) is None
+
+    def test_oserror_returns_none(self, tmp_path, monkeypatch):
+        from hermes_cli.doctor import _pe_subsystem
+
+        def _raise(*a, **kw):
+            raise OSError("denied")
+
+        monkeypatch.setattr("builtins.open", _raise)
+        assert _pe_subsystem(str(tmp_path / "nope.exe")) is None
+
+
+class TestCheckWindowsPythonStubs:
+    """Tests for ``_check_windows_python_stubs``."""
+
+    def test_no_stubs_no_windowsapps(self, tmp_path, monkeypatch):
+        """When WindowsApps is empty, the check reports ok."""
+        from hermes_cli.doctor import _check_windows_python_stubs
+
+        windowsapps = tmp_path / "WindowsApps"
+        windowsapps.mkdir()
+
+        monkeypatch.setenv("LOCALAPPDATA", str(tmp_path))
+        # Mock the gateway modules to avoid heavy deps
+        gw_mod = type(sys)("hermes_cli.gateway")
+        gww_mod = type(sys)("hermes_cli.gateway_windows")
+        monkeypatch.setitem(sys.modules, "hermes_cli.gateway", gw_mod)
+        monkeypatch.setitem(sys.modules, "hermes_cli.gateway_windows", gww_mod)
+
+        def _raise_import(*a, **kw):
+            raise ImportError("not available in test")
+
+        gww_mod._resolve_detached_python = _raise_import
+
+        issues: list[str] = []
+        manual: list[str] = []
+        _check_windows_python_stubs(issues, manual)
+        # Should skip interpreter validation gracefully on import error
+        assert len(issues) == 0
+
+    def test_zero_byte_stub_populates_manual(self, tmp_path, monkeypatch):
+        """A 0-byte python.exe in WindowsApps → manual_issues populated."""
+        from hermes_cli.doctor import _check_windows_python_stubs
+
+        windowsapps = tmp_path / "Microsoft" / "WindowsApps"
+        windowsapps.mkdir(parents=True)
+        (windowsapps / "python.exe").write_bytes(b"")
+
+        monkeypatch.setenv("LOCALAPPDATA", str(tmp_path))
+
+        gw_mod = type(sys)("hermes_cli.gateway")
+        gww_mod = type(sys)("hermes_cli.gateway_windows")
+        monkeypatch.setitem(sys.modules, "hermes_cli.gateway", gw_mod)
+        monkeypatch.setitem(sys.modules, "hermes_cli.gateway_windows", gww_mod)
+
+        def _raise_import(*a, **kw):
+            raise ImportError("not available in test")
+
+        gww_mod._resolve_detached_python = _raise_import
+
+        issues: list[str] = []
+        manual: list[str] = []
+        _check_windows_python_stubs(issues, manual)
+        assert any(
+            "App Execution" in m for m in manual
+        ), f"manual: {manual}"
+
+    def test_gateway_interpreter_gui_subsystem(self, tmp_path, monkeypatch):
+        """Gateway interpreter with GUI subsystem → no failures."""
+        import struct
+        from hermes_cli.doctor import _check_windows_python_stubs
+
+        windowsapps = tmp_path / "Microsoft" / "WindowsApps"
+        windowsapps.mkdir(parents=True)
+
+        py_exe = tmp_path / "python.exe"
+        dos = bytearray(64)
+        dos[0:2] = b"MZ"
+        struct.pack_into("<I", dos, 0x3C, 64)
+        pe = bytearray(24 + 96)
+        pe[0:4] = b"PE\x00\x00"
+        struct.pack_into("<H", pe, 24, 0x10B)
+        struct.pack_into("<H", pe, 24 + 68, 2)  # GUI
+        py_exe.write_bytes(dos + pe)
+
+        monkeypatch.setenv("LOCALAPPDATA", str(tmp_path))
+
+        def _fake_resolve(python_exe):
+            return (str(py_exe), tmp_path, [])
+
+        def _fake_get_python_path():
+            return str(py_exe)
+
+        gw_mod = type(sys)("hermes_cli.gateway")
+        monkeypatch.setitem(sys.modules, "hermes_cli.gateway", gw_mod)
+        gw_mod.get_python_path = _fake_get_python_path
+
+        gww_mod = type(sys)("hermes_cli.gateway_windows")
+        monkeypatch.setitem(sys.modules, "hermes_cli.gateway_windows", gww_mod)
+        gww_mod._resolve_detached_python = staticmethod(_fake_resolve)
+
+        monkeypatch.setattr("hermes_cli.doctor.PROJECT_ROOT", tmp_path)
+
+        issues: list[str] = []
+        _check_windows_python_stubs(issues, [])
+        assert len(issues) == 0  # GUI subsystem → no issues added
+
+    def test_gateway_interpreter_not_pe(self, tmp_path, monkeypatch):
+        """Gateway interpreter that is not a valid PE → issues populated."""
+        from hermes_cli.doctor import _check_windows_python_stubs
+
+        windowsapps = tmp_path / "Microsoft" / "WindowsApps"
+        windowsapps.mkdir(parents=True)
+
+        py_exe = tmp_path / "python.exe"
+        py_exe.write_text("not a PE file")
+
+        monkeypatch.setenv("LOCALAPPDATA", str(tmp_path))
+
+        def _fake_resolve(python_exe):
+            return (str(py_exe), tmp_path, [])
+
+        def _fake_get_python_path():
+            return str(py_exe)
+
+        gw_mod = type(sys)("hermes_cli.gateway")
+        monkeypatch.setitem(sys.modules, "hermes_cli.gateway", gw_mod)
+        gw_mod.get_python_path = _fake_get_python_path
+
+        gww_mod = type(sys)("hermes_cli.gateway_windows")
+        monkeypatch.setitem(sys.modules, "hermes_cli.gateway_windows", gww_mod)
+        gww_mod._resolve_detached_python = staticmethod(_fake_resolve)
+
+        issues: list[str] = []
+        _check_windows_python_stubs(issues, [])
+        assert len(issues) >= 1
+        assert any("uv" in i for i in issues)
+
+    def test_gateway_interpreter_missing(self, tmp_path, monkeypatch):
+        """Gateway interpreter not found → issues populated."""
+        from hermes_cli.doctor import _check_windows_python_stubs
+
+        windowsapps = tmp_path / "Microsoft" / "WindowsApps"
+        windowsapps.mkdir(parents=True)
+
+        nonexistent = tmp_path / "does_not_exist" / "python.exe"
+
+        def _fake_resolve(python_exe):
+            return (str(nonexistent), tmp_path, [])
+
+        def _fake_get_python_path():
+            return str(nonexistent)
+
+        monkeypatch.setenv("LOCALAPPDATA", str(tmp_path))
+
+        gw_mod = type(sys)("hermes_cli.gateway")
+        monkeypatch.setitem(sys.modules, "hermes_cli.gateway", gw_mod)
+        gw_mod.get_python_path = _fake_get_python_path
+
+        gww_mod = type(sys)("hermes_cli.gateway_windows")
+        monkeypatch.setitem(sys.modules, "hermes_cli.gateway_windows", gww_mod)
+        gww_mod._resolve_detached_python = staticmethod(_fake_resolve)
+
+        issues: list[str] = []
+        _check_windows_python_stubs(issues, [])
+        assert len(issues) >= 1
+        assert any("venv" in i.lower() for i in issues)


### PR DESCRIPTION
## Problem

Windows 10/11 ships 0-byte `python.exe` / `python3.exe` **App Execution Alias** stubs in `%LOCALAPPDATA%\Microsoft\WindowsApps`. These appear first on PATH and mask the real Python installation. Any watchdog, cron script, or subprocess that resolves `python` via PATH hits the dead stub — silently failing or triggering the Microsoft Store redirect dialog (a blocking popup).

Additionally, `pythonw.exe` from a proper Python distribution has the **GUI subsystem** (Windows PE flag), but there's no automated check to confirm this. A misconfigured `pythonw.exe` with the Console subsystem will flash `conhost.exe` windows every time a cron job or gateway process spawns.

## Solution

Adds a **`_check_windows_python_stubs`** diagnostic to `hermes doctor` (Windows-only, gated behind `sys.platform == "win32"`):

1. **Detect 0-byte stubs** — scans `WindowsApps` for the known dead stubs and warns with actionable fix instructions (disable in Settings → App execution aliases)
2. **PATH resolution check** — verifies that `python` / `pythonw` resolve to real binaries, not the stub directory
3. **PE subsystem verification** — parses the PE header to confirm `pythonw.exe` has the GUI subsystem (value 2), alerting if it's Console (value 3)
4. **Stub resolution guard** — separately checks PATH-resolved `pythonw` and flags 0-byte stubs as `check_fail`

The PE parser (`_pe_subsystem`) is a pure-Python zero-dependency implementation that reads the MZ/PE headers and extracts the subsystem field — no external tools required.

## Context

Reported by local testing on Windows 11 after repeatedly encountering the stub trap during Hermes gateway/cron setup. The check catches a systemic footgun that affects every Windows Hermes user who ran `install.ps1` and later discovered their watchdog scripts couldn't spawn subprocesses.