### PR TITLE
fix(compression): preserve messages across session rotation (flush-before-rotate + /compress rewrite guard)

### DIFF
--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -512,6 +512,16 @@ def compress_context(
             old_title = agent._session_db.get_session_title(agent.session_id)
             # Trigger memory extraction on the old session before it rotates.
             agent.commit_memory_session(messages)
+            # Flush any un-persisted messages from the current turn to the
+            # old session *before* rotating.  compress_context() can be
+            # called mid-turn (auto-compress when context exceeds threshold)
+            # at a point when _flush_messages_to_session_db() has not yet
+            # run.  Without this, messages generated during the current turn
+            # are silently lost on session rotation (#47202).
+            try:
+                agent._flush_messages_to_session_db(messages)
+            except Exception:
+                pass  # best-effort — don't block compression on a flush error
             agent._session_db.end_session(agent.session_id, "compression")
             old_session_id = agent.session_id
             agent.session_id = f"{datetime.now().strftime('%Y%m%d_%H%M%S')}_{uuid.uuid4().hex[:6]}"

--- a/cli.py
+++ b/cli.py
@@ -5957,6 +5957,18 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
 
         old_session_id = self.session_id
         if self._session_db and old_session_id:
+            # Flush any un-persisted messages from the current turn to the
+            # old session *before* rotating.  /new can be called mid-turn
+            # when _flush_messages_to_session_db() has not yet run — without
+            # this, messages generated during the current turn are silently
+            # lost on session rotation (#47202).
+            if self.agent:
+                try:
+                    self.agent._flush_messages_to_session_db(
+                        self.conversation_history
+                    )
+                except Exception:
+                    pass  # best-effort
             try:
                 self._session_db.end_session(old_session_id, "new_session")
             except Exception:

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -2588,14 +2588,29 @@ class GatewaySlashCommandsMixin:
                 # session_id for the continuation.  Write the compressed messages
                 # into the NEW session so the original history stays searchable.
                 new_session_id = tmp_agent.session_id
-                if new_session_id != session_entry.session_id:
+                rotated = new_session_id != session_entry.session_id
+                if rotated:
                     session_entry.session_id = new_session_id
                     self.session_store._save()
                     self._sync_telegram_topic_binding(
                         source, session_entry, reason="compress-command",
                     )
 
-                self.session_store.rewrite_transcript(new_session_id, compressed)
+                # Only rewrite the transcript when rotation actually produced a
+                # NEW session id. If _compress_context could not rotate (e.g.
+                # _session_db unavailable, or the DB split raised), session_id
+                # is unchanged and rewrite_transcript() would DELETE the
+                # original messages and replace them with only the compressed
+                # summary — permanent data loss (#44794, #39704). In that case
+                # leave the original transcript intact.
+                if rotated:
+                    self.session_store.rewrite_transcript(new_session_id, compressed)
+                else:
+                    logger.warning(
+                        "Manual /compress: session rotation did not occur "
+                        "(session_id unchanged) — preserving original transcript "
+                        "instead of overwriting it (#44794)."
+                    )
                 # Reset stored token count — transcript changed, old value is stale
                 self.session_store.update_session(
                     session_entry.session_key, last_prompt_tokens=0


### PR DESCRIPTION
## Summary
Compression and `/compress` no longer lose conversation messages from `state.db` when a session rotates. Two distinct data-loss paths in the same family are closed.

## Changes
- `agent/conversation_compression.py` + `cli.py`: flush un-persisted current-turn messages to the **old** session *before* `end_session()` rotates the session id. Auto-compression (and `/new`) can fire mid-turn before `_persist_session` runs at turn-exit, so the turn's messages were never written to SQLite and were lost on rotation. (Salvaged from @kyssta-exe's #47215, fixes #47202 and #46567.)
- `gateway/slash_commands.py`: guard the manual `/compress` `rewrite_transcript()` on **actual rotation**. When `_compress_context()` can't rotate (e.g. `_session_db` unavailable or the DB split raised), `session_id` is unchanged and the unconditional `rewrite_transcript()` would DELETE the original messages and replace them with only the compressed summary — permanent data loss. Now the rewrite only runs when rotation produced a new session id; otherwise the original transcript is left intact. (Fixes #44794, #39704.)

## Validation
| | Before | After |
|---|---|---|
| Mid-turn auto-compress | turn messages dropped from old session | all current-turn messages flushed before rotation |
| `/compress` with rotation skipped | original transcript overwritten with summary | original transcript preserved, warning logged |

- Real-SQLite E2E (temp `HERMES_HOME`, real `SessionDB` + real `_flush_messages_to_session_db`): 3 current-turn messages incl. final answer persist to the old session before `end_session`; 2 history messages correctly skipped by identity tracking.
- Existing suite: `tests/gateway/test_compress_command.py`, `test_compression_session_id_persistence.py`, `test_compression_failure_session_sync.py` — 9/9 pass.

## Issues
Fixes #47202, #46567, #44794, #39704.

Authorship: first commit is @kyssta-exe's (cherry-picked, #47215); rewrite-guard commit is ours.

## Infographic

![compression-flush-before-rotate](https://v3b.fal.media/files/b/0a9ed2b2/ORpcs50yWu8YN0bbzmr81_YPjhX9IV.png)
