### PR TITLE
feat(packaging): add langfuse optional extra

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -154,6 +154,9 @@ edge-tts = ["edge-tts==7.2.7"]
 modal = ["modal==1.3.4"]
 daytona = ["daytona==0.155.0"]
 hindsight = ["hindsight-client==0.6.1"]
+# Optional observability plugin dependency. Keep out of [all] so default
+# installs stay unchanged; packagers can opt in with hermes-agent[langfuse].
+langfuse = ["langfuse==4.9.0"]
 dev = ["debugpy==1.8.20", "pytest==9.0.2", "pytest-asyncio==1.3.0", "mcp==1.26.0", "starlette==1.0.1", "ty==0.0.21", "ruff==0.15.10", "setuptools==81.0.0"]  # starlette: CVE-2026-48710; setuptools: latest <82 (torch >=2.11 caps setuptools<82)
 messaging = ["python-telegram-bot[webhooks]==22.6", "discord.py[voice]==2.7.1", "aiohttp==3.13.4", "brotlicffi==1.2.0.1", "slack-bolt==1.27.0", "slack-sdk==3.40.1", "qrcode==7.4.2"]  # aiohttp: CVE-2026-34513/34518/34519/34520/34525
 cron = []  # croniter is now a core dependency; this extra kept for back-compat

--- a/uv.lock
+++ b/uv.lock
@@ -454,6 +454,15 @@ wheels = [
 ]
 
 [[package]]
+name = "backoff"
+version = "2.2.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/47/d7/5bbeb12c44d7c4f2fb5b56abce497eb5ed9f34d85701de869acedd602619/backoff-2.2.1.tar.gz", hash = "sha256:03f829f5bb1923180821643f8753b0502c3b682293992485b0eef2807afa5cba", size = 17001, upload-time = "2022-10-05T19:19:32.061Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/73/b6e24bd22e6720ca8ee9a85a0c4a2971af8497d8f3193fa05390cbd46e09/backoff-2.2.1-py3-none-any.whl", hash = "sha256:63579f9a0628e06278f7e47b7d7d5b6ce20dc65c5e96a6f3ca99a6adca0396e8", size = 15148, upload-time = "2022-10-05T19:19:30.546Z" },
+]
+
+[[package]]
 name = "base58"
 version = "2.1.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1540,6 +1549,9 @@ homeassistant = [
 honcho = [
     { name = "honcho-ai" },
 ]
+langfuse = [
+    { name = "langfuse" },
+]
 matrix = [
     { name = "aiohttp-socks" },
     { name = "aiosqlite" },
@@ -1688,6 +1700,7 @@ requires-dist = [
     { name = "honcho-ai", marker = "extra == 'honcho'", specifier = "==2.0.1" },
     { name = "httpx", extras = ["socks"], specifier = "==0.28.1" },
     { name = "jinja2", specifier = "==3.1.6" },
+    { name = "langfuse", marker = "extra == 'langfuse'", specifier = "==4.9.0" },
     { name = "lark-oapi", marker = "extra == 'feishu'", specifier = "==1.5.3" },
     { name = "markdown", specifier = "==3.10.2" },
     { name = "mautrix", extras = ["encryption"], marker = "extra == 'matrix'", specifier = "==0.21.0" },
@@ -1745,7 +1758,7 @@ requires-dist = [
     { name = "websockets", specifier = "==15.0.1" },
     { name = "youtube-transcript-api", marker = "extra == 'youtube'", specifier = "==1.2.4" },
 ]
-provides-extras = ["anthropic", "exa", "firecrawl", "parallel-web", "fal", "edge-tts", "modal", "daytona", "hindsight", "dev", "messaging", "cron", "slack", "matrix", "wecom", "cli", "tts-premium", "voice", "pty", "honcho", "vision", "mcp", "nemo-relay", "homeassistant", "sms", "teams", "computer-use", "acp", "mistral", "bedrock", "azure-identity", "termux", "termux-all", "dingtalk", "feishu", "google", "youtube", "web", "all"]
+provides-extras = ["anthropic", "exa", "firecrawl", "parallel-web", "fal", "edge-tts", "modal", "daytona", "hindsight", "langfuse", "dev", "messaging", "cron", "slack", "matrix", "wecom", "cli", "tts-premium", "voice", "pty", "honcho", "vision", "mcp", "nemo-relay", "homeassistant", "sms", "teams", "computer-use", "acp", "mistral", "bedrock", "azure-identity", "termux", "termux-all", "dingtalk", "feishu", "google", "youtube", "web", "all"]
 
 [[package]]
 name = "hf-xet"
@@ -2069,6 +2082,25 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/19/74/a633ee74eb36c44aa6d1095e7cc5569bebf04342ee146178e2d36600708b/jsonschema_specifications-2025.9.1.tar.gz", hash = "sha256:b540987f239e745613c7a9176f3edb72b832a4ac465cf02712288397832b5e8d", size = 32855, upload-time = "2025-09-08T01:34:59.186Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/41/45/1a4ed80516f02155c51f51e8cedb3c1902296743db0bbc66608a0db2814f/jsonschema_specifications-2025.9.1-py3-none-any.whl", hash = "sha256:98802fee3a11ee76ecaca44429fda8a41bff98b00a0f2838151b113f210cc6fe", size = 18437, upload-time = "2025-09-08T01:34:57.871Z" },
+]
+
+[[package]]
+name = "langfuse"
+version = "4.9.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "backoff" },
+    { name = "httpx" },
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-exporter-otlp-proto-http" },
+    { name = "opentelemetry-sdk" },
+    { name = "packaging" },
+    { name = "pydantic" },
+    { name = "wrapt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/77/69/4c339bb7cfb4909db340c9b40852bd268fd2bfd93c526e7ac95b7dd725bb/langfuse-4.9.0.tar.gz", hash = "sha256:244d8309cd75d663f29c399f5691e3f04c4a2838e0cc947704e123bdc7233040", size = 339189, upload-time = "2026-06-16T08:44:38.744Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/f0/65735b14e792007381e1e9cf17b4dbd1355be056507c06517e75040102aa/langfuse-4.9.0-py3-none-any.whl", hash = "sha256:ac03eaf7ee6f5fb18036284445833cae92248ae240f3c6068b83d408afb57fe1", size = 599170, upload-time = "2026-06-16T08:44:37.387Z" },
 ]
 
 [[package]]

--- a/website/docs/getting-started/nix-setup.md
+++ b/website/docs/getting-started/nix-setup.md
@@ -679,6 +679,15 @@ services.hermes-agent = {
 };
 ```
 
+```nix
+# Enable the bundled Langfuse observability plugin
+services.hermes-agent = {
+  extraDependencyGroups = [ "langfuse" ];
+  settings.plugins.enabled = [ "observability/langfuse" ];
+  environmentFiles = [ "/run/secrets/hermes-langfuse.env" ];
+};
+```
+
 This is resolved by uv alongside core dependencies — no PYTHONPATH patching, no collision risk. Available groups:
 
 | Group | What it enables |
@@ -693,6 +702,7 @@ This is resolved by uv alongside core dependencies — no PYTHONPATH patching, n
 | `anthropic` | Native Anthropic SDK (not needed via OpenRouter) |
 | `bedrock` | AWS Bedrock (boto3) |
 | `azure-identity` | Azure Entra ID auth |
+| `langfuse` | Langfuse observability plugin SDK |
 | `honcho` | Honcho memory provider |
 | `hindsight` | Hindsight memory provider |
 | `modal` | Modal terminal backend |

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/getting-started/nix-setup.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/getting-started/nix-setup.md
@@ -656,7 +656,16 @@ services.hermes-agent = {
 };
 ```
 
-这由 uv 与核心依赖在单次解析中完成——不需要 PYTHONPATH 补丁，没有冲突风险。可用的组与 `pyproject.toml` 中 `[project.optional-dependencies]` 的键对应（例如 `"hindsight"`、`"honcho"`、`"voice"`、`"matrix"`、`"mistral"`、`"bedrock"`）。
+```nix
+# 启用内置 Langfuse 可观测性插件
+services.hermes-agent = {
+  extraDependencyGroups = [ "langfuse" ];
+  settings.plugins.enabled = [ "observability/langfuse" ];
+  environmentFiles = [ "/run/secrets/hermes-langfuse.env" ];
+};
+```
+
+这由 uv 与核心依赖在单次解析中完成——不需要 PYTHONPATH 补丁，没有冲突风险。可用的组与 `pyproject.toml` 中 `[project.optional-dependencies]` 的键对应（例如 `"hindsight"`、`"honcho"`、`"langfuse"`、`"voice"`、`"matrix"`、`"mistral"`、`"bedrock"`）。
 
 **何时使用哪个：**
 


### PR DESCRIPTION
Fixes #48576

## Summary
- Add a `langfuse` optional dependency extra for the bundled `observability/langfuse` plugin.
- Regenerate `uv.lock`, adding only `langfuse==4.9.0` and its `backoff==2.2.1` transitive dependency.
- Document the NixOS `extraDependencyGroups = [ "langfuse" ]` path for sealed uv2nix/container deployments.

## Notes
- `hermes-agent[langfuse]` is intentionally not included in `[all]`, so default installs remain unchanged.
- No `LAZY_DEPS` entry is added because the target use case is build-time inclusion in a sealed Nix venv, where runtime installation is not available.

## Tests
- `/tmp/hermes-uv-lock-venv/bin/uv lock --check`
- `python3.11 -c "...tomllib structure assertions..."`
- `UV_PROJECT_ENVIRONMENT=/tmp/hermes-langfuse-extra-import-env-rebase /tmp/hermes-uv-lock-venv/bin/uv run --extra langfuse --locked --no-dev python -c "from langfuse import Langfuse, propagate_attributes; print(Langfuse.__name__, callable(propagate_attributes))"`
- `git diff --check origin/main...HEAD`

## Not run
- `cd website && npm run typecheck`: local website dependencies are not installed (`node_modules` missing; Docusaurus packages unresolved).
- `cd website && npm run build`: local website dependencies are not installed (`docusaurus: command not found`); prebuild also reports missing Python `yaml` in this local environment.