### PR TITLE
fix(delegate): honor api_key_env for direct endpoints

### DIFF
--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -1024,6 +1024,34 @@ class TestDelegationCredentialResolution(unittest.TestCase):
         self.assertIsNone(creds["api_key"])
         self.assertEqual(creds["provider"], "custom")
 
+    def test_direct_endpoint_uses_configured_api_key_env(self):
+        # Direct endpoints can be non-OpenAI providers. When api_key_env is set,
+        # delegation must use that key instead of inheriting the parent's key.
+        parent = _make_mock_parent(depth=0)
+        cfg = {
+            "model": "glm-5.2",
+            "provider": "custom",
+            "base_url": "https://api.z.ai/api/coding/paas/v4",
+            "api_key_env": "GLM_API_KEY",
+        }
+        with patch.dict(os.environ, {"GLM_API_KEY": "glm-key-from-env"}, clear=False):
+            creds = _resolve_delegation_credentials(cfg, parent)
+        self.assertEqual(creds["api_key"], "glm-key-from-env")
+        self.assertEqual(creds["provider"], "custom")
+        self.assertEqual(creds["base_url"], "https://api.z.ai/api/coding/paas/v4")
+
+    def test_direct_endpoint_configured_api_key_env_missing_raises(self):
+        parent = _make_mock_parent(depth=0)
+        cfg = {
+            "model": "glm-5.2",
+            "provider": "custom",
+            "base_url": "https://api.z.ai/api/coding/paas/v4",
+            "api_key_env": "GLM_API_KEY",
+        }
+        with patch.dict(os.environ, {"GLM_API_KEY": "   "}, clear=False):
+            with self.assertRaisesRegex(ValueError, "delegation.api_key_env"):
+                _resolve_delegation_credentials(cfg, parent)
+
     def test_direct_endpoint_no_raise_when_only_provider_env_key_present(self):
         # Even if OPENAI_API_KEY is absent, no ValueError — _build_child_agent uses parent key.
         parent = _make_mock_parent(depth=0)

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -2652,12 +2652,13 @@ def _resolve_delegation_credentials(cfg: dict, parent_agent) -> dict:
     """Resolve credentials for subagent delegation.
 
     If ``delegation.base_url`` is configured, subagents use that direct
-    OpenAI-compatible endpoint. ``delegation.api_key`` overrides the key; when
-    omitted, ``api_key`` is returned as ``None`` so ``_build_child_agent``
-    inherits the parent agent's key (``effective_api_key = override_api_key or
-    parent_api_key``). This lets providers that store their key outside
-    ``OPENAI_API_KEY`` (e.g. ``MINIMAX_API_KEY``, ``DASHSCOPE_API_KEY``) work
-    without a duplicate config entry.
+    OpenAI-compatible endpoint. ``delegation.api_key`` overrides the key;
+    otherwise ``delegation.api_key_env`` can name the provider-specific env var
+    to read. If that env var is configured but missing, raise instead of
+    silently inheriting the parent agent's unrelated key. When neither key
+    source is configured, ``api_key`` is returned as ``None`` so
+    ``_build_child_agent`` inherits the parent agent's key
+    (``effective_api_key = override_api_key or parent_api_key``).
 
     Otherwise, if ``delegation.provider`` is configured, the full credential
     bundle (base_url, api_key, api_mode, provider) is resolved via the runtime
@@ -2673,16 +2674,24 @@ def _resolve_delegation_credentials(cfg: dict, parent_agent) -> dict:
     configured_provider = str(cfg.get("provider") or "").strip() or None
     configured_base_url = str(cfg.get("base_url") or "").strip() or None
     configured_api_key = str(cfg.get("api_key") or "").strip() or None
+    configured_api_key_env = str(cfg.get("api_key_env") or "").strip() or None
     configured_api_mode = str(cfg.get("api_mode") or "").strip().lower() or None
 
     if configured_base_url:
-        # When delegation.api_key is not set, return None so _build_child_agent
-        # falls back to the parent agent's API key via the credential inheritance
-        # path (effective_api_key = override_api_key or parent_api_key). This
-        # lets providers that store their key in a non-OPENAI_API_KEY env var
-        # (e.g. MINIMAX_API_KEY, DASHSCOPE_API_KEY) work without requiring
-        # callers to duplicate the key under delegation.api_key.
-        api_key = configured_api_key  # None → inherited from parent in _build_child_agent
+        # Direct endpoints may need a provider-specific env key (for example
+        # GLM_API_KEY for Z.AI coding-plan). Prefer an explicit api_key, then
+        # delegation.api_key_env, and only inherit the parent key when neither
+        # is configured. Without the missing-env guard, a custom delegation
+        # endpoint can receive the parent's unrelated key and fail with 401.
+        api_key = configured_api_key
+        if not api_key and configured_api_key_env:
+            raw_api_key = os.getenv(configured_api_key_env)
+            api_key = raw_api_key.strip() if raw_api_key else None
+            if not api_key:
+                raise ValueError(
+                    f"delegation.api_key_env is set to {configured_api_key_env!r}, "
+                    "but that environment variable is not set"
+                )
 
         # Use the shared URL-based api_mode detector (same path the main agent's
         # runtime resolver uses) so Anthropic-compatible direct endpoints with a


### PR DESCRIPTION
## Summary
- Honor `delegation.api_key_env` for delegated subagents using a direct `base_url`.
- Preserve parent-key inheritance when no direct key source is configured.
- Add regression coverage for env-based key resolution and configured-but-missing env vars.

## Problem
Direct delegation endpoints can point at providers that use a provider-specific credential env var. If `delegation.api_key_env` is ignored, the child can inherit the parent provider key and fail with a 401 or use the wrong credential.

## Change
Credential precedence for direct `base_url` delegation is now:
1. `delegation.api_key`
2. `delegation.api_key_env`
3. parent key inheritance only when neither key source is configured

If `api_key_env` is configured but missing/blank, Hermes raises a clear `ValueError` instead of silently falling back to the parent key.

## Tests
- `python -m py_compile tools/delegate_tool.py tests/tools/test_delegate.py`
- `python -m pytest tests/tools/test_delegate.py::TestDelegationCredentialResolution -q -o 'addopts='` → 18 passed
- `python -m ruff check tools/delegate_tool.py tests/tools/test_delegate.py`
- `git diff --check origin/main...HEAD`
- `gitleaks git --log-opts='origin/main..HEAD' --no-banner --redact` → no leaks found
