### PR TITLE
fix(chat_completions): strip timestamp/observed/platform_message_id from API messages

### DIFF
--- a/agent/transports/chat_completions.py
+++ b/agent/transports/chat_completions.py
@@ -164,6 +164,13 @@ class ChatCompletionsTransport(ProviderTransport):
         strip_extra_content = not _model_consumes_thought_signature(
             kwargs.get("model")
         )
+        # Schema-foreign session metadata that strict providers (Fireworks,
+        # Moonshot/Kimi, opencode-go) reject with HTTP 400.  These are
+        # persisted in the messages table but are NOT part of the OpenAI
+        # Chat Completions message schema and must never reach the wire.
+        SESSION_METADATA_KEYS = frozenset(
+            ("timestamp", "observed", "platform_message_id")
+        )
         needs_sanitize = False
         for msg in messages:
             if not isinstance(msg, dict):
@@ -172,6 +179,7 @@ class ChatCompletionsTransport(ProviderTransport):
                 "codex_reasoning_items" in msg
                 or "codex_message_items" in msg
                 or "tool_name" in msg
+                or any(k in msg for k in SESSION_METADATA_KEYS)
             ):
                 needs_sanitize = True
                 break
@@ -201,6 +209,12 @@ class ChatCompletionsTransport(ProviderTransport):
             msg.pop("codex_reasoning_items", None)
             msg.pop("codex_message_items", None)
             msg.pop("tool_name", None)
+            # Drop session metadata fields that are NOT part of the
+            # OpenAI Chat Completions message schema.  Strict providers
+            # (Fireworks, Moonshot/Kimi, opencode-go) reject any payload
+            # containing them with HTTP 400.
+            for k in SESSION_METADATA_KEYS:
+                msg.pop(k, None)
             # Drop all Hermes-internal scaffolding markers (``_``-prefixed).
             # OpenAI's message schema has no ``_``-prefixed fields, so this
             # is safe and future-proofs against new markers being added.


### PR DESCRIPTION
## Problem

Hermes leaks per-message `timestamp`, `observed`, and `platform_message_id` session metadata into OpenAI Chat Completions `messages[]` payloads. Strict providers (Fireworks-backed opencode-go GLM-5.2, Moonshot/Kimi) reject these schema-foreign fields with HTTP 400:

```
Extra inputs are not permitted, field: 'messages[N].timestamp', value: 1781698587
```

Permissive providers (OpenAI, OpenRouter, MiniMax) silently ignore unknown keys, so the bug only surfaces with strict backends.

## Root cause

`ChatCompletionsTransport.convert_messages()` already strips `tool_name`, `codex_reasoning_items`, `codex_message_items`, `_`-prefixed keys, and `call_id`/`response_item_id` from tool_calls — but the `timestamp`/`observed`/`platform_message_id` trio persisted in the messages table was missed. These fields come from `dict(row)` in `hermes_state.py` which converts the full SQLite row to a dict.

## Fix

Add `timestamp`, `observed`, `platform_message_id` to the detection pass (so we deepcopy only when needed) and the stripping loop (so they're removed from sanitized messages).

## Affected models (tested)

| Model | `timestamp` present |
|-------|---------------------|
| `glm-5.2` (opencode-go → Fireworks) | ❌ 400 |
| `kimi-k2.6` (opencode-go → Moonshot) | ❌ 400 |
| `deepseek-v4-flash` | ✅ tolerates |
| `qwen3.7-max` | ✅ tolerates |

Closes #47868