### PR TITLE
fix(agent): prevent symlink/special-file traversal in curator rollback fallback

### DIFF
--- a/agent/curator_backup.py
+++ b/agent/curator_backup.py
@@ -536,6 +536,52 @@ def _restore_cron_skill_links(snapshot_dir: Path) -> Dict[str, Any]:
 
 
 
+def _safe_extractall_fallback(tf: tarfile.TarFile, dest: Path) -> None:
+    """Manually extract a tar archive, rejecting unsafe members.
+
+    Used on Python < 3.12 where ``TarFile.extractall`` does not accept the
+    ``filter='data'`` safety filter. The archive may only contain regular files
+    and directories; symlinks, hardlinks, devices, fifos, and any path that
+    escapes ``dest`` (including via ``..`` or absolute names) are rejected.
+    """
+    dest_root = dest.resolve()
+    for member in tf.getmembers():
+        name = member.name
+        if not name:
+            raise tarfile.TarError("refusing to extract member with empty name")
+        if name.startswith("/") or ".." in Path(name).parts:
+            raise tarfile.TarError(
+                f"refusing to extract unsafe path: {name!r}"
+            )
+        if member.issym() or member.islnk():
+            raise tarfile.TarError(
+                f"refusing to extract link member: {name!r}"
+            )
+        if not (member.isfile() or member.isdir()):
+            raise tarfile.TarError(
+                f"refusing to extract special member: {name!r}"
+            )
+
+        target = (dest_root / name).resolve()
+        try:
+            target.relative_to(dest_root)
+        except ValueError:
+            raise tarfile.TarError(
+                f"refusing to extract escaped path: {name!r}"
+            )
+
+        if member.isdir():
+            target.mkdir(parents=True, exist_ok=True)
+            continue
+
+        target.parent.mkdir(parents=True, exist_ok=True)
+        extracted = tf.extractfile(member)
+        if extracted is None:
+            raise tarfile.TarError(f"cannot read member: {name!r}")
+        with extracted, open(target, "wb") as dst:
+            shutil.copyfileobj(extracted, dst)
+
+
 def rollback(backup_id: Optional[str] = None) -> Tuple[bool, str, Optional[Path]]:
     """Restore ``~/.hermes/skills/`` from a snapshot.
 
@@ -619,19 +665,14 @@ def rollback(backup_id: Optional[str] = None) -> Tuple[bool, str, Optional[Path]
     try:
         with tarfile.open(archive, "r:gz") as tf:
             # Python 3.12+ supports filter='data' for safer extraction.
-            # Fall back to the unfiltered call for older interpreters but
-            # still reject absolute paths and .. components defensively.
-            for member in tf.getmembers():
-                name = member.name
-                if name.startswith("/") or ".." in Path(name).parts:
-                    raise tarfile.TarError(
-                        f"refusing to extract unsafe path: {name!r}"
-                    )
+            # Fall back to a manual safe extraction for older interpreters
+            # (the project still supports Python 3.11) which also rejects
+            # symlinks, hardlinks, device files, and any path escape.
             try:
                 tf.extractall(str(skills), filter="data")  # type: ignore[call-arg]
             except TypeError:
                 # Python < 3.12 — no filter kwarg
-                tf.extractall(str(skills))
+                _safe_extractall_fallback(tf, skills)
     except (OSError, tarfile.TarError) as e:
         # Best-effort recover: move staged contents back
         for orig, dest in moved:

--- a/tests/agent/test_curator_backup.py
+++ b/tests/agent/test_curator_backup.py
@@ -259,6 +259,53 @@ def test_rollback_rejects_unsafe_tarball(backup_env, monkeypatch):
     assert "unsafe" in msg.lower() or "refus" in msg.lower() or "extract" in msg.lower()
 
 
+def test_rollback_rejects_symlink_tarball(backup_env):
+    """Tarballs containing symlinks must be refused: a symlink member can
+    point outside the extraction directory and let a crafted snapshot read
+    or overwrite arbitrary files on rollback."""
+    cb = backup_env["cb"]
+    skills = backup_env["skills"]
+    _write_skill(skills, "alpha")
+    cb.snapshot_skills(reason="legit")
+
+    rows = cb.list_backups()
+    snap_dir = Path(rows[0]["path"])
+    mal = snap_dir / "skills.tar.gz"
+    mal.unlink()
+    with tarfile.open(mal, "w:gz") as tf:
+        info = tarfile.TarInfo(name="evil-link")
+        info.type = tarfile.SYMTYPE
+        info.linkname = "/etc/passwd"
+        tf.addfile(info)
+
+    ok, msg, _ = cb.rollback()
+    assert not ok
+    assert "link" in msg.lower() or "unsafe" in msg.lower() or "refus" in msg.lower()
+
+
+def test_rollback_rejects_special_file_tarball(backup_env):
+    """Tarballs containing device files, fifos, or other special members
+    must be refused — only regular files and directories are valid skill
+    contents."""
+    cb = backup_env["cb"]
+    skills = backup_env["skills"]
+    _write_skill(skills, "alpha")
+    cb.snapshot_skills(reason="legit")
+
+    rows = cb.list_backups()
+    snap_dir = Path(rows[0]["path"])
+    mal = snap_dir / "skills.tar.gz"
+    mal.unlink()
+    with tarfile.open(mal, "w:gz") as tf:
+        info = tarfile.TarInfo(name="evil-device")
+        info.type = tarfile.BLKTYPE
+        tf.addfile(info)
+
+    ok, msg, _ = cb.rollback()
+    assert not ok
+    assert "special" in msg.lower() or "unsafe" in msg.lower() or "refus" in msg.lower()
+
+
 # ---------------------------------------------------------------------------
 # Integration with run_curator_review
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
Fixes a tar extraction safety gap in `agent/curator_backup.py::rollback()` when running on Python 3.11.

## Problem
The project supports `python >=3.11,<3.14`. The rollback function uses `TarFile.extractall(..., filter="data")`, which is only available on Python 3.12+. On Python 3.11 the `TypeError` fallback calls `tf.extractall(str(skills))` without any filter, allowing a malicious `skills.tar.gz` snapshot to:
- Traverse out of `~/.hermes/skills` via `../` or absolute paths (CWE-22)
- Create symlinks/hardlinks pointing to arbitrary files (CWE-59 / CWE-61)
- Create device files, FIFOs, or other special-file members

## Fix
Introduces `_safe_extractall_fallback()` for Python <3.12 that only extracts regular files and directories, rejects absolute paths, `..` components, link members, and special-file members, and double-checks the resolved target stays inside the destination directory.

Also adds `test_rollback_rejects_symlink_tarball` and `test_rollback_rejects_special_file_tarball` to `tests/agent/test_curator_backup.py`.

## Verification
- `python -m py_compile` passes for both files
- `pytest tests/agent/test_curator_backup.py -x -q` passes
- Manually crafted traversal / symlink / special-file tarballs are all rejected

Fixes: CWE-22 / CWE-59 / CWE-61