### PR TITLE
feat: add watchlist freshness brief helper

### DIFF
--- a/docs/nightly-watchlist-freshness-brief-spec.md
+++ b/docs/nightly-watchlist-freshness-brief-spec.md
@@ -1,0 +1,83 @@
+# Nightly Watchlist Freshness Brief Spec
+
+## Goal
+
+Give Joe a local-first way to keep investor / AI / developer watchlists from silently going stale. The helper reads a human-maintained Markdown watchlist and an optional JSON state file, then reports which accounts are overdue for review, which are due soon, and which entries are missing tracking state.
+
+## Non-goals
+
+- No network requests.
+- No platform login.
+- No liking, replying, following, posting, messaging, or other human interaction.
+- No mutation of the watchlist or state file.
+
+## Inputs
+
+### Watchlist Markdown
+
+Default: `~/.hermes/memories/INVESTOR_SOCIAL_WATCHLIST.md`.
+
+The parser extracts bullet entries that contain a URL, for example:
+
+```markdown
+## Threads accounts
+- james93.lin — https://www.threads.com/@james93.lin
+- market.sherlock - https://www.threads.com/@market.sherlock
+```
+
+It must ignore instructional sections that do not contain URLs.
+
+### State JSON
+
+Optional file containing either:
+
+```json
+{
+  "items": {
+    "https://www.threads.com/@james93.lin": {
+      "last_checked": "2026-06-01",
+      "cadence_days": 14,
+      "priority": "high",
+      "notes": "portfolio framework"
+    }
+  }
+}
+```
+
+or a flat URL-keyed mapping:
+
+```json
+{
+  "https://www.threads.com/@james93.lin": {"last_checked": "2026-06-01"}
+}
+```
+
+Defaults: `cadence_days = 14`, `priority = normal`.
+
+## Output contract
+
+Markdown by default:
+
+- `Overdue` entries: `today - last_checked > cadence_days`
+- `Due soon` entries: due within `--soon-days`
+- `Missing tracking state` entries: watchlist URLs with no state entry or no valid `last_checked`
+- If there are no overdue, due-soon, or missing-state entries, output exactly `[SILENT]`
+
+`--json` emits a machine-readable payload with `overdue`, `due_soon`, `missing_state`, and `summary`.
+
+## CLI
+
+```bash
+python scripts/watchlist_freshness_brief.py \
+  --watchlist ~/.hermes/memories/INVESTOR_SOCIAL_WATCHLIST.md \
+  --state ~/.hermes/state/watchlist_freshness.json \
+  --today 2026-06-19 \
+  --soon-days 3
+```
+
+## Verification plan
+
+- Unit tests for parser behavior, including instructional Markdown sections.
+- Unit tests for overdue / due-soon / missing-state classification.
+- Unit tests for exact `[SILENT]` behavior when nothing needs attention.
+- Smoke check against Joe's local investor watchlist in read-only mode.

--- a/scripts/watchlist_freshness_brief.py
+++ b/scripts/watchlist_freshness_brief.py
@@ -1,0 +1,294 @@
+#!/usr/bin/env python3
+"""Local-first freshness brief for human-maintained social watchlists.
+
+This script intentionally performs no network requests and mutates no files.
+It helps cron jobs decide whether a watchlist needs manual review.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from dataclasses import dataclass
+from datetime import date, datetime, timedelta
+from pathlib import Path
+from typing import Any
+
+URL_RE = re.compile(r"https?://[^\s)>,]+")
+BULLET_RE = re.compile(r"^\s*[-*]\s+(?:\[[ xX]\]\s*)?(?P<body>.+?)\s*$")
+HEADING_RE = re.compile(r"^#{1,6}\s+(?P<title>.+?)\s*$")
+
+
+@dataclass(frozen=True)
+class WatchlistEntry:
+    label: str
+    url: str
+    section: str
+
+
+@dataclass(frozen=True)
+class FreshnessItem:
+    entry: WatchlistEntry
+    last_checked: date
+    due_date: date
+    cadence_days: int
+    priority: str
+    notes: str
+
+    def days_overdue_as_of(self, today: date) -> int:
+        return max(0, (today - self.due_date).days)
+
+    def days_until_due_as_of(self, today: date) -> int:
+        return max(0, (self.due_date - today).days)
+
+
+@dataclass(frozen=True)
+class FreshnessBrief:
+    today: date
+    overdue: list[FreshnessItem]
+    due_soon: list[FreshnessItem]
+    missing_state: list[WatchlistEntry]
+
+    @property
+    def has_work(self) -> bool:
+        return bool(self.overdue or self.due_soon or self.missing_state)
+
+
+def parse_date(value: str) -> date:
+    try:
+        return datetime.strptime(value, "%Y-%m-%d").date()
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError(f"invalid date {value!r}; expected YYYY-MM-DD") from exc
+
+
+def parse_watchlist(path: Path) -> list[WatchlistEntry]:
+    entries: list[WatchlistEntry] = []
+    section = "Uncategorized"
+
+    for line in path.read_text(encoding="utf-8").splitlines():
+        heading = HEADING_RE.match(line)
+        if heading:
+            section = heading.group("title").strip()
+            continue
+
+        bullet = BULLET_RE.match(line)
+        if not bullet:
+            continue
+
+        body = bullet.group("body").strip()
+        url_match = URL_RE.search(body)
+        if not url_match:
+            continue
+
+        url = url_match.group(0).rstrip(".,;")
+        label_part = body[: url_match.start()].strip(" -–—:|")
+        label = label_part or url
+        entries.append(WatchlistEntry(label=label, url=url, section=section))
+
+    return entries
+
+
+def load_state(path: Path | None) -> dict[str, dict[str, Any]]:
+    if path is None or not path.exists():
+        return {}
+
+    raw = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(raw, dict):
+        raise ValueError("state JSON must be an object")
+
+    items = raw.get("items", raw)
+    if not isinstance(items, dict):
+        raise ValueError("state JSON 'items' must be an object")
+
+    normalized: dict[str, dict[str, Any]] = {}
+    for url, metadata in items.items():
+        if not isinstance(url, str):
+            continue
+        if isinstance(metadata, dict):
+            normalized[url] = dict(metadata)
+        else:
+            normalized[url] = {}
+    return normalized
+
+
+def _metadata_for(entry: WatchlistEntry, state: dict[str, dict[str, Any]]) -> dict[str, Any] | None:
+    return state.get(entry.url) or state.get(entry.label)
+
+
+def _coerce_cadence_days(value: Any, default: int = 14) -> int:
+    try:
+        cadence = int(value)
+    except (TypeError, ValueError):
+        return default
+    return cadence if cadence > 0 else default
+
+
+def build_brief(
+    entries: list[WatchlistEntry],
+    state: dict[str, dict[str, Any]],
+    *,
+    today: date,
+    soon_days: int = 3,
+    default_cadence_days: int = 14,
+) -> FreshnessBrief:
+    overdue: list[FreshnessItem] = []
+    due_soon: list[FreshnessItem] = []
+    missing_state: list[WatchlistEntry] = []
+    soon_cutoff = today + timedelta(days=max(0, soon_days))
+
+    seen_urls: set[str] = set()
+    for entry in entries:
+        if entry.url in seen_urls:
+            continue
+        seen_urls.add(entry.url)
+
+        metadata = _metadata_for(entry, state)
+        last_checked_raw = metadata.get("last_checked") if metadata else None
+        if not isinstance(last_checked_raw, str):
+            missing_state.append(entry)
+            continue
+
+        try:
+            last_checked = parse_date(last_checked_raw)
+        except argparse.ArgumentTypeError:
+            missing_state.append(entry)
+            continue
+
+        cadence_days = _coerce_cadence_days(
+            metadata.get("cadence_days") if metadata else None,
+            default=default_cadence_days,
+        )
+        due_date = last_checked + timedelta(days=cadence_days)
+        item = FreshnessItem(
+            entry=entry,
+            last_checked=last_checked,
+            due_date=due_date,
+            cadence_days=cadence_days,
+            priority=str(metadata.get("priority", "normal") if metadata else "normal"),
+            notes=str(metadata.get("notes", "") if metadata else ""),
+        )
+
+        if due_date < today:
+            overdue.append(item)
+        elif due_date <= soon_cutoff:
+            due_soon.append(item)
+
+    overdue.sort(key=lambda item: (item.due_date, item.entry.section, item.entry.label.lower()))
+    due_soon.sort(key=lambda item: (item.due_date, item.entry.section, item.entry.label.lower()))
+    missing_state.sort(key=lambda entry: (entry.section, entry.label.lower()))
+    return FreshnessBrief(today=today, overdue=overdue, due_soon=due_soon, missing_state=missing_state)
+
+
+def _item_to_dict(item: FreshnessItem, today: date) -> dict[str, Any]:
+    return {
+        "label": item.entry.label,
+        "url": item.entry.url,
+        "section": item.entry.section,
+        "last_checked": item.last_checked.isoformat(),
+        "due_date": item.due_date.isoformat(),
+        "cadence_days": item.cadence_days,
+        "priority": item.priority,
+        "notes": item.notes,
+        "days_overdue": item.days_overdue_as_of(today),
+        "days_until_due": item.days_until_due_as_of(today),
+    }
+
+
+def brief_to_dict(brief: FreshnessBrief) -> dict[str, Any]:
+    return {
+        "today": brief.today.isoformat(),
+        "summary": {
+            "overdue": len(brief.overdue),
+            "due_soon": len(brief.due_soon),
+            "missing_state": len(brief.missing_state),
+        },
+        "overdue": [_item_to_dict(item, brief.today) for item in brief.overdue],
+        "due_soon": [_item_to_dict(item, brief.today) for item in brief.due_soon],
+        "missing_state": [entry.__dict__ for entry in brief.missing_state],
+    }
+
+
+def render_markdown(brief: FreshnessBrief) -> str:
+    if not brief.has_work:
+        return "[SILENT]"
+
+    lines = ["# Watchlist Freshness Brief", "", f"Date: {brief.today.isoformat()}", ""]
+    lines.append(
+        "Summary: "
+        f"{len(brief.overdue)} overdue, "
+        f"{len(brief.due_soon)} due soon, "
+        f"{len(brief.missing_state)} missing tracking state."
+    )
+
+    if brief.overdue:
+        lines.extend(["", "## Overdue"])
+        for item in brief.overdue:
+            lines.append(
+                f"- **{item.entry.label}** ({item.entry.section}) — "
+                f"due {item.due_date.isoformat()} "
+                f"({item.days_overdue_as_of(brief.today)}d overdue), "
+                f"priority: {item.priority}; {item.entry.url}"
+            )
+            if item.notes:
+                lines.append(f"  - Notes: {item.notes}")
+
+    if brief.due_soon:
+        lines.extend(["", "## Due soon"])
+        for item in brief.due_soon:
+            lines.append(
+                f"- **{item.entry.label}** ({item.entry.section}) — "
+                f"due {item.due_date.isoformat()} "
+                f"(in {item.days_until_due_as_of(brief.today)}d); {item.entry.url}"
+            )
+
+    if brief.missing_state:
+        lines.extend(["", "## Missing tracking state"])
+        for entry in brief.missing_state:
+            lines.append(f"- **{entry.label}** ({entry.section}) — {entry.url}")
+
+    lines.extend(
+        [
+            "",
+            "Next action: review overdue items manually, then record `last_checked` in the state file.",
+            "Safety: read-only brief; no platform interactions were performed.",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def default_watchlist_path() -> Path:
+    return Path.home() / ".hermes" / "memories" / "INVESTOR_SOCIAL_WATCHLIST.md"
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Generate a local watchlist freshness brief.")
+    parser.add_argument("--watchlist", type=Path, default=default_watchlist_path())
+    parser.add_argument("--state", type=Path, default=None)
+    parser.add_argument("--today", type=parse_date, default=date.today())
+    parser.add_argument("--soon-days", type=int, default=3)
+    parser.add_argument("--default-cadence-days", type=int, default=14)
+    parser.add_argument("--json", action="store_true", help="Emit machine-readable JSON")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    entries = parse_watchlist(args.watchlist)
+    state = load_state(args.state)
+    brief = build_brief(
+        entries,
+        state,
+        today=args.today,
+        soon_days=args.soon_days,
+        default_cadence_days=args.default_cadence_days,
+    )
+    if args.json:
+        print(json.dumps(brief_to_dict(brief), indent=2, sort_keys=True))
+    else:
+        print(render_markdown(brief))
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/tests/scripts/test_watchlist_freshness_brief.py
+++ b/tests/scripts/test_watchlist_freshness_brief.py
@@ -1,0 +1,103 @@
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+
+def load_module():
+    path = Path(__file__).resolve().parents[2] / "scripts" / "watchlist_freshness_brief.py"
+    spec = importlib.util.spec_from_file_location("watchlist_freshness_brief", path)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_parse_watchlist_entries_ignores_instructional_sections(tmp_path):
+    mod = load_module()
+    watchlist = tmp_path / "watchlist.md"
+    watchlist.write_text(
+        """# Investor Social Watchlist
+
+## Threads accounts
+- james93.lin — https://www.threads.com/@james93.lin
+- market.sherlock - https://www.threads.com/@market.sherlock
+
+## Intended output format for future monitoring
+- New notable posts since last check
+- Confidence / evidence label:
+  - Fact: directly observed from post
+
+## Safety / permission notes
+- Do not like, reply, repost, follow, DM, or otherwise interact with real people.
+""",
+        encoding="utf-8",
+    )
+
+    entries = mod.parse_watchlist(watchlist)
+
+    assert [(entry.label, entry.url, entry.section) for entry in entries] == [
+        ("james93.lin", "https://www.threads.com/@james93.lin", "Threads accounts"),
+        ("market.sherlock", "https://www.threads.com/@market.sherlock", "Threads accounts"),
+    ]
+
+
+def test_classify_entries_overdue_due_soon_and_missing_state(tmp_path):
+    mod = load_module()
+    entries = [
+        mod.WatchlistEntry(label="old", url="https://example.com/old", section="X"),
+        mod.WatchlistEntry(label="soon", url="https://example.com/soon", section="X"),
+        mod.WatchlistEntry(label="fresh", url="https://example.com/fresh", section="X"),
+        mod.WatchlistEntry(label="missing", url="https://example.com/missing", section="X"),
+    ]
+    state = {
+        "https://example.com/old": {"last_checked": "2026-06-01", "cadence_days": 14, "priority": "high"},
+        "https://example.com/soon": {"last_checked": "2026-06-08", "cadence_days": 14},
+        "https://example.com/fresh": {"last_checked": "2026-06-15", "cadence_days": 14},
+    }
+
+    brief = mod.build_brief(entries, state, today=mod.parse_date("2026-06-19"), soon_days=3)
+
+    assert [item.entry.label for item in brief.overdue] == ["old"]
+    assert brief.overdue[0].days_overdue_as_of(mod.parse_date("2026-06-19")) == 4
+    assert [item.entry.label for item in brief.due_soon] == ["soon"]
+    assert brief.due_soon[0].days_until_due_as_of(mod.parse_date("2026-06-19")) == 3
+    assert [entry.label for entry in brief.missing_state] == ["missing"]
+
+
+def test_render_markdown_returns_silent_when_nothing_to_report():
+    mod = load_module()
+    entries = [mod.WatchlistEntry(label="fresh", url="https://example.com/fresh", section="X")]
+    state = {"https://example.com/fresh": {"last_checked": "2026-06-18", "cadence_days": 14}}
+
+    brief = mod.build_brief(entries, state, today=mod.parse_date("2026-06-19"), soon_days=3)
+
+    assert mod.render_markdown(brief) == "[SILENT]"
+
+
+def test_cli_json_output(tmp_path, capsys):
+    mod = load_module()
+    watchlist = tmp_path / "watchlist.md"
+    state_file = tmp_path / "state.json"
+    watchlist.write_text("- old — https://example.com/old\n", encoding="utf-8")
+    state_file.write_text(
+        json.dumps({"items": {"https://example.com/old": {"last_checked": "2026-06-01", "cadence_days": 14}}}),
+        encoding="utf-8",
+    )
+
+    exit_code = mod.main([
+        "--watchlist",
+        str(watchlist),
+        "--state",
+        str(state_file),
+        "--today",
+        "2026-06-19",
+        "--json",
+    ])
+
+    assert exit_code == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["summary"]["overdue"] == 1
+    assert payload["overdue"][0]["label"] == "old"


### PR DESCRIPTION
## Summary

- Add `scripts/watchlist_freshness_brief.py`, a local-only helper for Markdown social/investor watchlists.
- Add a spec documenting input/state/output contracts and safety non-goals.
- Add focused tests for Markdown parsing, stale/due/missing classification, JSON output, and exact `[SILENT]` behavior.

## Why

Joe's local investor watchlist exists, but without freshness state it can silently decay. This helper makes the missing tracking state explicit without network access or any human/platform interaction.

## Tests

- `scripts/run_tests.sh tests/scripts/test_watchlist_freshness_brief.py`
- `python -m compileall -q scripts/watchlist_freshness_brief.py`
- `scripts/run_tests.sh tests/scripts/`

## Smoke check

Read-only smoke against `/Users/hyc/.hermes/memories/INVESTOR_SOCIAL_WATCHLIST.md` reported 7 watchlist entries missing tracking state and performed no network or platform actions.
