### PR TITLE
fix(qqbot): accept dm chat_type in approval authorization

### DIFF
--- a/gateway/platforms/qqbot/adapter.py
+++ b/gateway/platforms/qqbot/adapter.py
@@ -1092,7 +1092,7 @@ class QQAdapter(BasePlatformAdapter):
 
         chat_type = parsed.get("chat_type", "")
         chat_id = parsed.get("chat_id", "")
-        if chat_type == "c2c":
+        if chat_type in {"c2c", "dm", "private", "direct"}:
             return bool(chat_id) and operator == chat_id
 
         if chat_type in {"group", "guild"}:

--- a/tests/gateway/test_qqbot.py
+++ b/tests/gateway/test_qqbot.py
@@ -2220,3 +2220,66 @@ class TestReadEventsClosedWsGuard:
         adapter._ws = None
         with pytest.raises(RuntimeError):
             asyncio.run(adapter._read_events())
+
+
+class TestIsAuthorizedInteractionForSession:
+    """Authorize approval/update button clicks by session_key + operator.
+
+    Regression: gateway normalizes every platform private (C2C) chat to
+    chat_type "dm" in the session key, but the QQ authorizer only matched
+    "c2c", so every private-chat approval button click was rejected as
+    unauthorized and the gated command timed out as BLOCKED.
+    """
+
+    def _adapter(self):
+        from gateway.platforms.qqbot import QQAdapter
+        return QQAdapter(_make_config(app_id="a", client_secret="b"))
+
+    def _event(self, operator, group_openid="", guild_id=""):
+        return SimpleNamespace(
+            operator_openid=operator,
+            group_openid=group_openid,
+            guild_id=guild_id,
+        )
+
+    def test_dm_private_owner_can_approve(self):
+        a = self._adapter()
+        ev = self._event(operator="USER_A")
+        assert a._is_authorized_interaction_for_session(
+            ev, "agent:main:qqbot:dm:USER_A") is True
+
+    def test_c2c_alias_still_accepted(self):
+        a = self._adapter()
+        ev = self._event(operator="USER_A")
+        assert a._is_authorized_interaction_for_session(
+            ev, "agent:main:qqbot:c2c:USER_A") is True
+
+    def test_dm_wrong_operator_rejected(self):
+        a = self._adapter()
+        ev = self._event(operator="USER_B")
+        assert a._is_authorized_interaction_for_session(
+            ev, "agent:main:qqbot:dm:USER_A") is False
+
+    def test_group_member_match(self):
+        a = self._adapter()
+        ev = self._event(operator="MEM_A", group_openid="GRP")
+        assert a._is_authorized_interaction_for_session(
+            ev, "agent:main:qqbot:group:GRP:MEM_A") is True
+
+    def test_non_qqbot_platform_rejected(self):
+        a = self._adapter()
+        ev = self._event(operator="USER_A")
+        assert a._is_authorized_interaction_for_session(
+            ev, "agent:main:telegram:dm:USER_A") is False
+
+    def test_garbage_key_rejected(self):
+        a = self._adapter()
+        ev = self._event(operator="USER_A")
+        assert a._is_authorized_interaction_for_session(
+            ev, "not-a-real-session-key") is False
+
+    def test_empty_operator_rejected(self):
+        a = self._adapter()
+        ev = self._event(operator="")
+        assert a._is_authorized_interaction_for_session(
+            ev, "agent:main:qqbot:dm:USER_A") is False


### PR DESCRIPTION
The gateway normalizes every platform private (C2C) chat to chat_type "dm" in session keys (e.g. agent:main:qqbot:dm:<openid>), via build_source(chat_type="dm") in _handle_c2c_message and the shared base adapter. However _is_authorized_interaction_for_session only matched the QQ-specific term "c2c", so every private-chat approval/update button click fell through to return False and was rejected as unauthorized.

Symptom: clicking Allow once / Allow always / Deny in a QQ private chat logged "Rejected unauthorized approval click" and never unblocked the agent, so the gated terminal command timed out as BLOCKED. Telegram DMs were unaffected (their authorizer normalizes chat_type to "dm").

Fix: treat dm/private/direct as aliases of c2c in the private-chat authorization branch, matching the gateway-normalized session key. Added unit tests covering dm/c2c acceptance, wrong-operator and group-scene rejection, and malformed session keys.

## What does this PR do?

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->



## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Fixes #

## Type of Change

<!-- Check the one that applies. -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- 

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. 
2. 
3. 

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [ ] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

<!-- Only fill this out if you're adding a skill. Delete this section otherwise. -->

- [ ] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [ ] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

