### PR TITLE
fix(honcho): honcho_search returns empty in directional observation mode

### DIFF
--- a/plugins/memory/honcho/session.py
+++ b/plugins/memory/honcho/session.py
@@ -1134,6 +1134,12 @@ class HonchoSessionManager:
                 search_query=query,
                 target=target,
             )
+            # In directional observation mode the observer->target slot
+            # (e.g. hermes-about-Jesse) is often empty while the data lives
+            # on the target peer's own self-representation. Mirror the
+            # get_peer_card fallback so semantic search still returns results.
+            if not ctx["representation"] and not ctx["card"] and target and target != observer_peer_id:
+                ctx = self._fetch_peer_context(target, search_query=query)
             parts = []
             if ctx["representation"]:
                 parts.append(ctx["representation"])

--- a/tests/honcho_plugin/test_session.py
+++ b/tests/honcho_plugin/test_session.py
@@ -297,6 +297,44 @@ class TestPeerLookupHelpers:
             search_query="assistant",
         )
 
+    def test_search_context_falls_back_to_target_self_context_when_directional_empty(self):
+        # In directional mode the observer->target slot (assistant-about-user)
+        # is often empty because conclusions are auto-derived onto the target
+        # peer's own self-representation, not written through the directional
+        # path. Mirror the get_peer_card fallback: when the directional fetch
+        # yields no representation and no card, refetch the target peer's own
+        # self-context so honcho_search still returns results.
+        mgr, session = self._make_cached_manager()
+        assistant_peer = MagicMock()
+        assistant_peer.context.return_value = SimpleNamespace(
+            representation="",  # directional observer->target slot empty
+            peer_card=[],
+        )
+        assistant_peer.representation.return_value = ""
+        assistant_peer.get_card.return_value = None  # directional card slot empty
+        user_peer = MagicMock()
+        user_peer.context.return_value = SimpleNamespace(
+            representation="Robert runs neuralancer",
+            peer_card=["Location: Melbourne"],
+        )
+
+        def _peer(peer_id: str) -> MagicMock:
+            return assistant_peer if peer_id == session.assistant_peer_id else user_peer
+
+        mgr._get_or_create_peer = MagicMock(side_effect=_peer)
+
+        result = mgr.search_context(session.key, "neuralancer")
+
+        assert "Robert runs neuralancer" in result
+        assert "- Location: Melbourne" in result
+        # Directional fetch attempted first against the user target...
+        assistant_peer.context.assert_called_once_with(
+            target=session.user_peer_id,
+            search_query="neuralancer",
+        )
+        # ...then fell back to the target peer's own self-context.
+        user_peer.context.assert_called_once_with(search_query="neuralancer")
+
     def test_get_prefetch_context_fetches_user_and_ai_from_peer_api(self):
         mgr, session = self._make_cached_manager()
         user_peer = MagicMock()

--- a/tests/honcho_plugin/test_session.py
+++ b/tests/honcho_plugin/test_session.py
@@ -335,6 +335,35 @@ class TestPeerLookupHelpers:
         # ...then fell back to the target peer's own self-context.
         user_peer.context.assert_called_once_with(search_query="neuralancer")
 
+    def test_search_context_does_not_fall_back_when_directional_slot_populated(self):
+        # Guard the happy path: when the observer->target directional fetch
+        # returns data, search_context must NOT make a second fetch against
+        # the target peer. Protects against regressing existing behavior and
+        # against a redundant network call.
+        mgr, session = self._make_cached_manager()
+        assistant_peer = MagicMock()
+        assistant_peer.context.return_value = SimpleNamespace(
+            representation="Robert runs neuralancer",
+            peer_card=["Location: Melbourne"],
+        )
+        user_peer = MagicMock()
+
+        def _peer(peer_id: str) -> MagicMock:
+            return assistant_peer if peer_id == session.assistant_peer_id else user_peer
+
+        mgr._get_or_create_peer = MagicMock(side_effect=_peer)
+
+        result = mgr.search_context(session.key, "neuralancer")
+
+        assert "Robert runs neuralancer" in result
+        assert "- Location: Melbourne" in result
+        # Directional fetch served the result; the target peer was never touched.
+        assistant_peer.context.assert_called_once_with(
+            target=session.user_peer_id,
+            search_query="neuralancer",
+        )
+        user_peer.context.assert_not_called()
+
     def test_get_prefetch_context_fetches_user_and_ai_from_peer_api(self):
         mgr, session = self._make_cached_manager()
         user_peer = MagicMock()


### PR DESCRIPTION
## Summary

`honcho_search` returns empty for every query in **directional observation mode** (the default), even when Honcho has rich data about the user. `honcho_profile`, `honcho_context`, and `honcho_reasoning` all work — only `honcho_search` comes back empty.

## Root cause

In directional mode, `_resolve_observer_target("user")` resolves to observer=`assistant`, target=`user`, so `search_context()` queries the **assistant→user directional slot** via `peer.context(target=user, search_query=...)`.

That slot is only populated when conclusions are written through the directional path (`create_conclusion` in directional mode). But the user's substantive data — the auto-derived representation and peer card — lives on the **user peer's own self-representation**, which Honcho builds from the message stream. So the directional fetch returns empty and `search_context()` returns `""`.

`get_peer_card()` already anticipates exactly this split and has a target-peer fallback (added in a118b94a8):

```python
# Some backends store cards directly on the target peer, not the
# observer-target slot. Fall back so honcho_profile still works.
if target_peer_id:
    return self._fetch_peer_card(target_peer_id)
```

`search_context()` was missing the equivalent fallback, which is why `honcho_profile` works but `honcho_search` doesn't.

## Fix

Mirror the `get_peer_card()` fallback in `search_context()`: when the directional fetch yields no representation **and** no card, refetch the target peer's own self-context.

```python
if not ctx["representation"] and not ctx["card"] and target and target != observer_peer_id:
    ctx = self._fetch_peer_context(target, search_query=query)
```

- Preserves directional precedence — the observer→target slot is still tried first, so if it's populated it wins.
- No-op for the `ai` peer path, where observer == target (the condition short-circuits).
- 6 lines, no new mechanism — reuses the existing `_fetch_peer_context` helper and matches the pattern already shipping in `get_peer_card`.

## Validation

Reproduced against a live Honcho cloud workspace in directional mode. Before the fix, `peer.context(target=user, search_query=q)` returns `representation len: 0` for every query. The user's own `peer.context(search_query=q)` returns 1840–2949 chars for the same queries. After the fix, `honcho_search` returns those results.

New regression test `test_search_context_falls_back_to_target_self_context_when_directional_empty` covers the directional-empty → user-self-context fallback (parallel to the existing `test_get_peer_card_falls_back_to_target_peer_own_card`).

```
pytest tests/honcho_plugin/test_session.py -k "search_context or peer_card" -q
9 passed
```

Full `tests/honcho_plugin/test_session.py` passes. (3 unrelated failures in `test_pin_peer_name.py::TestPinTransition` are pre-existing on `main` — confirmed by stashing this change and re-running; they concern cache-busting signatures, not retrieval.)

## Prior art

This is a recurrence of the symptom from **#5667 / PR #5658** ("align honcho_search retrieval with observation direction"), which was closed unmerged and superseded by the tool-surface overhaul in #10619. That overhaul absorbed the `target=` plumbing but dropped the fallback, reintroducing empty results for users whose data is Honcho-derived rather than written via `honcho_conclude`. This fix restores read/write alignment while also covering the auto-derived-representation case that #5658 would not have (it read the directional slot only).
