### PR TITLE
fix(desktop): avoid linux hidden titlebar freeze

### DIFF
--- a/apps/desktop/electron/main.cjs
+++ b/apps/desktop/electron/main.cjs
@@ -20,7 +20,6 @@ const crypto = require('node:crypto')
 const fs = require('node:fs')
 const http = require('node:http')
 const https = require('node:https')
-const net = require('node:net')
 const path = require('node:path')
 const { pathToFileURL } = require('node:url')
 const { execFileSync, spawn } = require('node:child_process')
@@ -33,6 +32,11 @@ const {
   SESSION_WINDOW_MIN_HEIGHT,
   SESSION_WINDOW_MIN_WIDTH
 } = require('./session-windows.cjs')
+const {
+  chatWindowChromeOptions,
+  nativeOverlayWidthForPlatform,
+  usesNativeSystemTitleBar
+} = require('./window-chrome.cjs')
 const { canImportHermesCli, verifyHermesCli } = require('./backend-probes.cjs')
 const { probeGatewayWebSocket } = require('./gateway-ws-probe.cjs')
 const { adoptServedDashboardToken } = require('./dashboard-token.cjs')
@@ -483,6 +487,23 @@ function getTitleBarOverlayOptions() {
     height: TITLEBAR_HEIGHT,
     symbolColor: useDarkColors ? '#f7f7f7' : '#242424'
   }
+}
+
+function getChatWindowChromeOptions() {
+  return chatWindowChromeOptions({
+    platform: process.platform,
+    isMac: IS_MAC,
+    titleBarOverlay: getTitleBarOverlayOptions(),
+    trafficLightPosition: WINDOW_BUTTON_POSITION
+  })
+}
+
+function applyTitleBarOverlay(win) {
+  if (usesNativeSystemTitleBar(process.platform)) {
+    return
+  }
+
+  win?.setTitleBarOverlay?.(getTitleBarOverlayOptions())
 }
 
 const MEDIA_MIME_TYPES = {
@@ -3298,16 +3319,22 @@ function getWindowButtonPosition() {
 
 function getNativeOverlayWidth() {
   // macOS reports traffic-light coords via windowButtonPosition; the
-  // titlebarOverlay there doesn't reserve right-edge space. Windows/Linux
-  // render the native window-controls overlay on the right, so the renderer
-  // needs to inset its right cluster by this much to clear them.
-  return IS_MAC ? 0 : NATIVE_OVERLAY_BUTTON_WIDTH
+  // titlebarOverlay there doesn't reserve right-edge space. Windows renders the
+  // native window-controls overlay on the right, so the renderer needs to inset
+  // its right cluster by this much to clear them. Linux keeps the system
+  // titlebar, so there is no renderer overlay to clear.
+  return nativeOverlayWidthForPlatform({
+    platform: process.platform,
+    isMac: IS_MAC,
+    nativeOverlayButtonWidth: NATIVE_OVERLAY_BUTTON_WIDTH
+  })
 }
 
 function getWindowState() {
   return {
     isFullscreen: Boolean(mainWindow?.isFullScreen?.()),
     nativeOverlayWidth: getNativeOverlayWidth(),
+    usesNativeTitleBar: usesNativeSystemTitleBar(process.platform),
     windowButtonPosition: getWindowButtonPosition()
   }
 }
@@ -5098,9 +5125,7 @@ function spawnSecondaryWindow({ sessionId, watch, newSession } = {}) {
     minWidth: SESSION_WINDOW_MIN_WIDTH,
     minHeight: SESSION_WINDOW_MIN_HEIGHT,
     title: 'Hermes',
-    titleBarStyle: 'hidden',
-    titleBarOverlay: getTitleBarOverlayOptions(),
-    trafficLightPosition: IS_MAC ? WINDOW_BUTTON_POSITION : undefined,
+    ...getChatWindowChromeOptions(),
     vibrancy: IS_MAC ? 'sidebar' : undefined,
     opacity: windowOpacity(),
     icon,
@@ -5162,15 +5187,12 @@ function createWindow() {
     minWidth: 400,
     minHeight: 620,
     title: 'Hermes',
-    // Frameless title bar on every platform so the renderer can paint the
-    // "hide sidebar" button (and other left-side titlebar tools) flush with
-    // the top edge — matching the macOS layout where the traffic lights sit
-    // inside the same band. On Windows/Linux, titleBarOverlay tells Electron
-    // to paint native min/max/close in the top-right of the renderer; on
-    // macOS it just reserves a content inset alongside the traffic lights.
-    titleBarStyle: 'hidden',
-    titleBarOverlay: getTitleBarOverlayOptions(),
-    trafficLightPosition: IS_MAC ? WINDOW_BUTTON_POSITION : undefined,
+    // Frameless title bar where Electron's custom chrome is stable so the
+    // renderer can paint the "hide sidebar" button (and other left-side
+    // titlebar tools) flush with the top edge. Linux uses the system titlebar:
+    // on GNOME/X11 the hidden-titlebar drag region can expose a window menu
+    // whose selected actions freeze the desktop session.
+    ...getChatWindowChromeOptions(),
     vibrancy: IS_MAC ? 'sidebar' : undefined,
     opacity: windowOpacity(),
     icon,
@@ -5197,7 +5219,7 @@ function createWindow() {
     if (!nativeThemeListenerInstalled) {
       nativeThemeListenerInstalled = true
       nativeTheme.on('updated', () => {
-        mainWindow?.setTitleBarOverlay?.(getTitleBarOverlayOptions())
+        applyTitleBarOverlay(mainWindow)
       })
     }
   }
@@ -5756,7 +5778,7 @@ ipcMain.on('hermes:titlebar-theme', (_event, payload) => {
     background: payload.background,
     foreground: payload.foreground
   }
-  mainWindow?.setTitleBarOverlay?.(getTitleBarOverlayOptions())
+  applyTitleBarOverlay(mainWindow)
 })
 
 // Pin the native appearance to the app theme (see NATIVE_THEME_CONFIG_PATH).

--- a/apps/desktop/electron/window-chrome.cjs
+++ b/apps/desktop/electron/window-chrome.cjs
@@ -1,0 +1,41 @@
+// BrowserWindow titlebar/chrome policy kept pure so platform-specific choices
+// can be tested without booting Electron.
+
+function usesNativeSystemTitleBar(platform = process.platform) {
+  return platform === 'linux'
+}
+
+function chatWindowChromeOptions({
+  platform = process.platform,
+  isMac = platform === 'darwin',
+  titleBarOverlay,
+  trafficLightPosition
+} = {}) {
+  if (usesNativeSystemTitleBar(platform)) {
+    return {}
+  }
+
+  return {
+    titleBarStyle: 'hidden',
+    titleBarOverlay,
+    trafficLightPosition: isMac ? trafficLightPosition : undefined
+  }
+}
+
+function nativeOverlayWidthForPlatform({
+  platform = process.platform,
+  isMac = platform === 'darwin',
+  nativeOverlayButtonWidth
+} = {}) {
+  if (isMac || usesNativeSystemTitleBar(platform)) {
+    return 0
+  }
+
+  return nativeOverlayButtonWidth
+}
+
+module.exports = {
+  chatWindowChromeOptions,
+  nativeOverlayWidthForPlatform,
+  usesNativeSystemTitleBar
+}

--- a/apps/desktop/electron/window-chrome.test.cjs
+++ b/apps/desktop/electron/window-chrome.test.cjs
@@ -1,0 +1,63 @@
+const assert = require('node:assert/strict')
+const test = require('node:test')
+
+const {
+  chatWindowChromeOptions,
+  nativeOverlayWidthForPlatform,
+  usesNativeSystemTitleBar
+} = require('./window-chrome.cjs')
+
+const overlay = { color: '#111111', height: 34, symbolColor: '#f7f7f7' }
+const trafficLightPosition = { x: 24, y: 10 }
+
+test('Linux keeps the system titlebar and avoids Electron titlebar overlay', () => {
+  const options = chatWindowChromeOptions({
+    platform: 'linux',
+    titleBarOverlay: overlay,
+    trafficLightPosition
+  })
+
+  assert.deepEqual(options, {})
+  assert.equal(usesNativeSystemTitleBar('linux'), true)
+})
+
+test('macOS keeps the hidden titlebar and traffic-light placement', () => {
+  const options = chatWindowChromeOptions({
+    platform: 'darwin',
+    isMac: true,
+    titleBarOverlay: { height: 34 },
+    trafficLightPosition
+  })
+
+  assert.deepEqual(options, {
+    titleBarStyle: 'hidden',
+    titleBarOverlay: { height: 34 },
+    trafficLightPosition
+  })
+})
+
+test('Windows keeps hidden titlebar overlay without macOS traffic-light options', () => {
+  const options = chatWindowChromeOptions({
+    platform: 'win32',
+    isMac: false,
+    titleBarOverlay: overlay,
+    trafficLightPosition
+  })
+
+  assert.deepEqual(options, {
+    titleBarStyle: 'hidden',
+    titleBarOverlay: overlay,
+    trafficLightPosition: undefined
+  })
+})
+
+test('native overlay width is reserved only for non-Linux non-macOS overlay chrome', () => {
+  const width = 144
+
+  assert.equal(nativeOverlayWidthForPlatform({ platform: 'darwin', isMac: true, nativeOverlayButtonWidth: width }), 0)
+  assert.equal(nativeOverlayWidthForPlatform({ platform: 'linux', isMac: false, nativeOverlayButtonWidth: width }), 0)
+  assert.equal(
+    nativeOverlayWidthForPlatform({ platform: 'win32', isMac: false, nativeOverlayButtonWidth: width }),
+    width
+  )
+})

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -37,7 +37,7 @@
     "test:desktop:nsis": "node scripts/test-desktop.mjs nsis",
     "test:desktop:existing": "node scripts/test-desktop.mjs existing",
     "test:desktop:fresh": "node scripts/test-desktop.mjs fresh",
-    "test:desktop:platforms": "node --test electron/bootstrap-platform.test.cjs electron/hardening.test.cjs electron/backend-env.test.cjs electron/backend-probes.test.cjs electron/bootstrap-runner.test.cjs electron/connection-config.test.cjs electron/dashboard-token.test.cjs electron/gateway-ws-probe.test.cjs electron/oauth-net-request.test.cjs electron/desktop-uninstall.test.cjs electron/session-windows.test.cjs electron/workspace-cwd.test.cjs electron/fs-read-dir.test.cjs electron/git-root.test.cjs electron/windows-child-process.test.cjs electron/update-remote.test.cjs electron/update-rebuild.test.cjs electron/windows-user-env.test.cjs",
+    "test:desktop:platforms": "node --test electron/bootstrap-platform.test.cjs electron/hardening.test.cjs electron/backend-env.test.cjs electron/backend-probes.test.cjs electron/bootstrap-runner.test.cjs electron/connection-config.test.cjs electron/dashboard-token.test.cjs electron/gateway-ws-probe.test.cjs electron/oauth-net-request.test.cjs electron/desktop-uninstall.test.cjs electron/session-windows.test.cjs electron/window-chrome.test.cjs electron/workspace-cwd.test.cjs electron/fs-read-dir.test.cjs electron/git-root.test.cjs electron/windows-child-process.test.cjs electron/update-remote.test.cjs electron/update-rebuild.test.cjs electron/windows-user-env.test.cjs",
     "typecheck": "tsc -p . --noEmit",
     "lint": "eslint src/ electron/",
     "lint:fix": "eslint src/ electron/ --fix",

--- a/apps/desktop/src/app/overlays/overlay-view.tsx
+++ b/apps/desktop/src/app/overlays/overlay-view.tsx
@@ -1,3 +1,4 @@
+import { useStore } from '@nanostores/react'
 import { type ReactNode, useEffect } from 'react'
 
 import { Button } from '@/components/ui/button'
@@ -5,6 +6,7 @@ import { Codicon } from '@/components/ui/codicon'
 import { translateNow } from '@/i18n'
 import { triggerHaptic } from '@/lib/haptics'
 import { cn } from '@/lib/utils'
+import { $connection } from '@/store/session'
 
 interface OverlayViewProps {
   children: ReactNode
@@ -23,6 +25,8 @@ export function OverlayView({
   headerContent,
   rootClassName
 }: OverlayViewProps) {
+  const usesNativeTitleBar = Boolean(useStore($connection)?.usesNativeTitleBar)
+
   const closeOverlay = () => {
     triggerHaptic('close')
     onClose()
@@ -63,7 +67,12 @@ export function OverlayView({
           rootClassName
         )}
       >
-        <div className="pointer-events-none absolute inset-x-0 top-0 z-10 h-[calc(var(--titlebar-height)+0.1875rem)] [-webkit-app-region:drag]">
+        <div
+          className={cn(
+            'pointer-events-none absolute inset-x-0 top-0 z-10 h-[calc(var(--titlebar-height)+0.1875rem)]',
+            !usesNativeTitleBar && '[-webkit-app-region:drag]'
+          )}
+        >
           {headerContent && (
             <div className="pointer-events-auto absolute left-1/2 top-[calc(0.5rem+var(--titlebar-height)/2)] -translate-x-1/2 -translate-y-1/2 [-webkit-app-region:no-drag]">
               {headerContent}

--- a/apps/desktop/src/app/shell/app-shell.tsx
+++ b/apps/desktop/src/app/shell/app-shell.tsx
@@ -6,6 +6,7 @@ import { NotificationStack } from '@/components/notifications'
 import { PaneShell } from '@/components/pane-shell'
 import { SidebarProvider } from '@/components/ui/sidebar'
 import { useMediaQuery } from '@/hooks/use-media-query'
+import { cn } from '@/lib/utils'
 import {
   $fileBrowserOpen,
   $panesFlipped,
@@ -78,6 +79,7 @@ export function AppShell({
   const narrowViewport = useMediaQuery(SIDEBAR_COLLAPSE_MEDIA_QUERY)
   const fileBrowserWidthOverride = useStore($paneWidthOverride(FILE_BROWSER_PANE_ID))
   const connection = useStore($connection)
+  const usesNativeTitleBar = Boolean(connection?.usesNativeTitleBar)
   const viewportFullscreen = useSyncExternalStore(subscribeWindowSize, viewportIsFullscreen, () => false)
   const isFullscreen = Boolean(connection?.isFullscreen) || viewportFullscreen
   // Every secondary window (new-session scratch, subagent watch, cmd-click
@@ -174,11 +176,17 @@ export function AppShell({
         <PaneShell className="min-h-0 flex-1">
           <div
             aria-hidden="true"
-            className="pointer-events-none absolute left-0 top-0 z-1 h-(--titlebar-height) w-(--titlebar-controls-left) [-webkit-app-region:drag]"
+            className={cn(
+              'pointer-events-none absolute left-0 top-0 z-1 h-(--titlebar-height) w-(--titlebar-controls-left)',
+              !usesNativeTitleBar && '[-webkit-app-region:drag]'
+            )}
           />
           <div
             aria-hidden="true"
-            className="pointer-events-none absolute top-0 z-1 h-(--titlebar-height) left-[calc(var(--titlebar-controls-left)+(var(--titlebar-control-size)*2)+0.75rem)] right-[calc(var(--titlebar-tools-right)+var(--titlebar-tools-width)+0.75rem)] [-webkit-app-region:drag]"
+            className={cn(
+              'pointer-events-none absolute top-0 z-1 h-(--titlebar-height) left-[calc(var(--titlebar-controls-left)+(var(--titlebar-control-size)*2)+0.75rem)] right-[calc(var(--titlebar-tools-right)+var(--titlebar-tools-width)+0.75rem)]',
+              !usesNativeTitleBar && '[-webkit-app-region:drag]'
+            )}
           />
 
           {children}

--- a/apps/desktop/src/app/shell/titlebar.ts
+++ b/apps/desktop/src/app/shell/titlebar.ts
@@ -8,8 +8,9 @@ export const TITLEBAR_CONTROL_HEIGHT = 22
 export const TITLEBAR_CONTROLS_TOP = (TITLEBAR_HEIGHT - TITLEBAR_CONTROL_HEIGHT) / 2
 export const TITLEBAR_FALLBACK_WINDOW_BUTTON_X = 24
 // Edge inset used when no left-side native controls take up that space —
-// Windows/Linux (native overlay is on the right) and macOS fullscreen
-// (traffic lights are hidden). Matches the right-cluster's 0.75rem padding.
+// Windows (native overlay is on the right), Linux (system titlebar is outside
+// the renderer), and macOS fullscreen (traffic lights are hidden). Matches the
+// right-cluster's 0.75rem padding.
 export const TITLEBAR_EDGE_INSET = 14
 
 // Titlebar palette only. All sizing/radius/cursor/centering come from the
@@ -34,7 +35,8 @@ export function titlebarControlsPosition(
   const top = Math.max(0, TITLEBAR_CONTROLS_TOP)
 
   // No left-side native controls to dodge:
-  //   - Windows/Linux: native min/max/close render on the right via titleBarOverlay.
+  //   - Windows: native min/max/close render on the right via titleBarOverlay.
+  //   - Linux: the system titlebar is outside the renderer.
   //   - macOS fullscreen: traffic lights are hidden.
   // In both cases, pin the cluster to the edge with a small inset.
   if (windowButtonPosition === null || isFullscreen) {

--- a/apps/desktop/src/components/assistant-ui/thread-list.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread-list.tsx
@@ -1,7 +1,8 @@
 import { ThreadPrimitive, useAuiEvent, useAuiState } from '@assistant-ui/react'
+import { useStore } from '@nanostores/react'
 import {
-  type CSSProperties,
   type ComponentProps,
+  type CSSProperties,
   type FC,
   memo,
   type ReactNode,
@@ -15,6 +16,7 @@ import { useStickToBottom } from 'use-stick-to-bottom'
 
 import { useI18n } from '@/i18n'
 import { cn } from '@/lib/utils'
+import { $connection } from '@/store/session'
 import {
   onScrollToBottomRequest,
   onThreadEditClose,
@@ -138,6 +140,7 @@ const ThreadMessageListInner: FC<ThreadMessageListProps> = ({
   // hide the titlebar tool cluster + session header, but the OS traffic lights
   // still sit in the top-left, so reserve the titlebar gap above the transcript.
   const secondaryWindow = isSecondaryWindow()
+  const usesNativeTitleBar = Boolean(useStore($connection)?.usesNativeTitleBar)
   // NB: CSS calc() requires whitespace around the +/- operator. This string is
   // assigned verbatim to the --sticky-human-top inline style below (it does not
   // go through Tailwind, which would auto-space it), so the spaces are load-
@@ -145,6 +148,7 @@ const ThreadMessageListInner: FC<ThreadMessageListProps> = ({
   // sticky user bubble falls back to its ~4px default and slides under the OS
   // traffic lights.
   const secondaryTitlebarGap = 'calc(var(--titlebar-height) + 0.75rem)'
+
   const threadContentTopPad = secondaryWindow
     ? 'pt-[calc(var(--titlebar-height)+0.75rem)]'
     : 'pt-[calc(var(--titlebar-height)-0.5rem)]'
@@ -262,11 +266,16 @@ const ThreadMessageListInner: FC<ThreadMessageListProps> = ({
         // Secondary windows hide the titlebar chrome, so the scroller runs to
         // the window's top edge and streamed text slides up under the OS
         // traffic lights. Content padding alone scrolls away with the text — a
-        // fixed opaque strip (the titlebar's drag region) masks anything behind
-        // it and keeps the window draggable, matching the main window's header.
+        // fixed opaque strip masks anything behind it. It doubles as a drag
+        // region only when the renderer owns custom chrome; Linux keeps the
+        // system titlebar outside the renderer to avoid the GNOME/X11 window
+        // menu freeze.
         <div
           aria-hidden="true"
-          className="absolute inset-x-0 top-0 z-10 h-(--titlebar-height) bg-background [-webkit-app-region:drag]"
+          className={cn(
+            'absolute inset-x-0 top-0 z-10 h-(--titlebar-height) bg-background',
+            !usesNativeTitleBar && '[-webkit-app-region:drag]'
+          )}
         />
       )}
       <div

--- a/apps/desktop/src/global.d.ts
+++ b/apps/desktop/src/global.d.ts
@@ -248,6 +248,7 @@ export interface HermesConnection {
   nativeOverlayWidth: number
   source?: 'env' | 'local' | 'settings'
   token: string
+  usesNativeTitleBar: boolean
   wsUrl: string
   logs: string[]
   // Set for pool (non-primary) backends so the renderer knows which profile a
@@ -264,6 +265,7 @@ export interface HermesTitleBarTheme {
 export interface HermesWindowState {
   isFullscreen: boolean
   nativeOverlayWidth: number
+  usesNativeTitleBar: boolean
   windowButtonPosition: { x: number; y: number } | null
 }
 

--- a/apps/desktop/src/store/updates.test.ts
+++ b/apps/desktop/src/store/updates.test.ts
@@ -41,7 +41,15 @@ vi.mock('@/hermes', () => ({
   getActionStatus: (...args: unknown[]) => getActionStatusSpy(...args)
 }))
 
-const { maybeNotifyUpdateAvailable, checkBackendUpdates, $backendUpdateStatus, applyBackendUpdate, $backendUpdateApply, reportBackendContract } = await import('./updates')
+const {
+  maybeNotifyUpdateAvailable,
+  checkBackendUpdates,
+  $backendUpdateStatus,
+  applyBackendUpdate,
+  $backendUpdateApply,
+  reportBackendContract
+} = await import('./updates')
+
 const { setConnection } = await import('./session')
 
 const status = (over: Partial<DesktopUpdateStatus> = {}): DesktopUpdateStatus => ({
@@ -166,6 +174,7 @@ describe('checkBackendUpdates', () => {
       mode: on ? 'remote' : 'local',
       nativeOverlayWidth: 0,
       token: 't',
+      usesNativeTitleBar: false,
       wsUrl: 'ws://box:9119',
       logs: [],
       windowButtonPosition: null
@@ -224,7 +233,15 @@ describe('applyBackendUpdate recovery', () => {
     checkHermesUpdateSpy.mockReset()
     updateHermesSpy.mockReset()
     getActionStatusSpy.mockReset()
-    $backendUpdateApply.set({ applying: false, stage: 'idle', message: '', percent: null, error: null, command: null, log: [] })
+    $backendUpdateApply.set({
+      applying: false,
+      stage: 'idle',
+      message: '',
+      percent: null,
+      error: null,
+      command: null,
+      log: []
+    })
     vi.useFakeTimers()
   })
 
@@ -235,7 +252,15 @@ describe('applyBackendUpdate recovery', () => {
   it('waits for the backend to return after the restart drops the connection, then clears the overlay', async () => {
     updateHermesSpy.mockResolvedValue({ ok: true, name: 'update', pid: 1 })
     getActionStatusSpy.mockRejectedValue(new Error('ECONNREFUSED'))
-    checkHermesUpdateSpy.mockResolvedValue({ install_method: 'git', current_version: '0.16.0', behind: 0, update_available: false, can_apply: true, update_command: 'hermes update', message: null })
+    checkHermesUpdateSpy.mockResolvedValue({
+      install_method: 'git',
+      current_version: '0.16.0',
+      behind: 0,
+      update_available: false,
+      can_apply: true,
+      update_command: 'hermes update',
+      message: null
+    })
 
     const promise = applyBackendUpdate()
     await vi.advanceTimersByTimeAsync(5000)
@@ -259,4 +284,3 @@ describe('applyBackendUpdate recovery', () => {
     expect($backendUpdateApply.get().stage).toBe('error')
   })
 })
-


### PR DESCRIPTION
## Summary
- Use native system titlebars on Linux desktop windows instead of Electron `titleBarStyle: hidden` / `titleBarOverlay`.
- Gate renderer `-webkit-app-region:drag` strips when Linux uses native titlebars, covering the main shell, secondary chat windows, and route overlays.
- Add pure Electron-free coverage for the desktop window chrome policy across Linux, macOS, and Windows.

Fixes #48515.

## Validation
- `cd apps/desktop && node --test electron/window-chrome.test.cjs`
- `npm run typecheck --workspace apps/desktop`
- `cd apps/desktop && npx eslint electron/main.cjs electron/window-chrome.cjs electron/window-chrome.test.cjs src/app/shell/app-shell.tsx src/app/shell/titlebar.ts src/store/updates.test.ts src/components/assistant-ui/thread-list.tsx src/app/overlays/overlay-view.tsx`
- `cd apps/desktop && npx prettier --check electron/window-chrome.cjs electron/window-chrome.test.cjs src/app/shell/app-shell.tsx src/app/shell/titlebar.ts src/app/overlays/overlay-view.tsx src/components/assistant-ui/thread-list.tsx src/global.d.ts src/store/updates.test.ts package.json`
- `npm run test:ui --workspace apps/desktop -- src/app/shell/titlebar.test.ts src/store/updates.test.ts`
- `git diff --check`

## Notes
- `npm run test:desktop:platforms --workspace apps/desktop` still fails on an existing unrelated static-scan expectation in `electron/windows-child-process.test.cjs`: it looks for the literal substring `execFileSync(pyExe`, while current `main.cjs` has that call split over multiple lines on `origin/main`.
- I could not run a live Ubuntu 22.04 GNOME/X11 smoke test in this environment.
