### PR TITLE
fix(gateway): suppress repeated Codex compaction notice

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -69,12 +69,14 @@ def _ra():
 
 
 def _build_codex_gpt55_autoraise_notice(autoraise: Dict[str, float]) -> str:
-    """Build the one-time notice shown when Codex gpt-5.5 raises compaction.
+    """Build the CLI notice shown when Codex gpt-5.5 raises compaction.
 
-    ``autoraise`` is ``{"from": <old_ratio>, "to": <new_ratio>}``. The same
-    text is printed inline for CLI users and replayed via ``status_callback``
-    for gateway users, so it must be self-contained and include the exact
-    opt-back-out command.
+    ``autoraise`` is ``{"from": <old_ratio>, "to": <new_ratio>}``. The text is
+    printed inline for CLI users, so it must be self-contained and include the
+    exact opt-back-out command. Gateway sessions intentionally do not replay it:
+    gateway agents are rebuilt across long Discord/Telegram conversations, so a
+    per-agent "one-time" notice becomes repeated user-visible noise while the
+    underlying context-window behaviour remains unchanged.
     """
     from_pct = int(round(autoraise["from"] * 100))
     to_pct = int(round(autoraise["to"] * 100))
@@ -1667,10 +1669,10 @@ def init_agent(
             print(f"📊 Context limit: {agent.context_compressor.context_length:,} tokens (compress at {int(compression_threshold*100)}% = {agent.context_compressor.threshold_tokens:,})")
         else:
             print(f"📊 Context limit: {agent.context_compressor.context_length:,} tokens (auto-compression disabled)")
-        # One-time notice when the Codex gpt-5.5 autoraise kicked in, with the
-        # exact opt-back-out command. Printed inline at startup for CLI users;
-        # gateway users get the same text replayed via _compression_warning on
-        # turn 1 (set below, after the warning slot is initialized).
+        # CLI-only notice when the Codex gpt-5.5 autoraise kicked in, with the
+        # exact opt-back-out command. Do not replay this through gateway status:
+        # gateway agents are rebuilt often enough that "one-time per agent"
+        # becomes repeated Discord/Telegram noise.
         _autoraise = getattr(agent, "_compression_threshold_autoraised", None)
         if _autoraise and compression_enabled:
             print(_build_codex_gpt55_autoraise_notice(_autoraise))
@@ -1679,12 +1681,12 @@ def init_agent(
     # Gateway status_callback is not yet wired, so any warning is stored
     # in _compression_warning and replayed in the first run_conversation().
     agent._compression_warning = None
-    # Gateway parity for the Codex gpt-5.5 autoraise notice: the startup print
-    # above only reaches the CLI, so stash the same text here to be replayed
-    # through status_callback on the first turn (Telegram/Discord/Slack/etc.).
+    # Do not stash the Codex gpt-5.5 autoraise notice for gateway replay. It is
+    # useful CLI startup context, but in gateway mode it repeats whenever the
+    # agent object is rebuilt while the same chat continues. Feasibility and
+    # failure warnings still use _compression_warning below when there is a real
+    # user-actionable compression problem.
     _autoraise = getattr(agent, "_compression_threshold_autoraised", None)
-    if _autoraise and compression_enabled:
-        agent._compression_warning = _build_codex_gpt55_autoraise_notice(_autoraise)
     # Lazy feasibility check: deferred to the first turn that approaches the
     # compression threshold. Running it eagerly here costs ~400ms cold (network
     # probe of the auxiliary provider chain + /models lookup) on every agent

--- a/tests/agent/test_codex_gpt55_gateway_notice.py
+++ b/tests/agent/test_codex_gpt55_gateway_notice.py
@@ -1,0 +1,58 @@
+"""Regression coverage for Codex gpt-5.5 autoraise notice routing.
+
+The autoraise is still useful, but its explanatory notice must not be replayed
+through gateway ``status_callback``. Gateway agent objects are rebuilt often, so
+"one-time per agent" becomes repeated Discord/Telegram noise.
+"""
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+
+AGENT_INIT = Path(__file__).resolve().parents[2] / "agent" / "agent_init.py"
+
+
+def _agent_init_tree() -> ast.Module:
+    return ast.parse(AGENT_INIT.read_text(encoding="utf-8"))
+
+
+def test_codex_gpt55_autoraise_notice_is_not_stashed_for_gateway_replay() -> None:
+    """Do not assign the informational autoraise notice to _compression_warning.
+
+    ``_compression_warning`` is replayed to messaging platforms on the first
+    turn. The Codex gpt-5.5 autoraise message is informational only and repeats
+    whenever the gateway rebuilds an agent, so it should stay CLI-only.
+    """
+    tree = _agent_init_tree()
+    offenders: list[int] = []
+
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Assign):
+            continue
+        assigns_compression_warning = any(
+            isinstance(target, ast.Attribute)
+            and target.attr == "_compression_warning"
+            for target in node.targets
+        )
+        if not assigns_compression_warning:
+            continue
+        calls_notice_builder = any(
+            isinstance(child, ast.Call)
+            and isinstance(child.func, ast.Name)
+            and child.func.id == "_build_codex_gpt55_autoraise_notice"
+            for child in ast.walk(node.value)
+        )
+        if calls_notice_builder:
+            offenders.append(node.lineno)
+
+    assert offenders == [], (
+        "Codex gpt-5.5 autoraise notice must not be stored in "
+        f"agent._compression_warning for gateway replay; offending lines: {offenders}"
+    )
+
+
+def test_codex_gpt55_autoraise_notice_remains_available_for_cli_startup() -> None:
+    source = AGENT_INIT.read_text(encoding="utf-8")
+    assert "_build_codex_gpt55_autoraise_notice(_autoraise)" in source
+    assert "Opt back out: hermes config set compression.codex_gpt55_autoraise false" in source


### PR DESCRIPTION
## Summary
- keep the Codex gpt-5.5 compaction threshold autoraise behavior intact
- stop replaying its informational notice through gateway `_compression_warning`
- add regression coverage so the notice remains CLI-only and is not stashed for gateway replay

## Why
The autoraise notice is useful during CLI startup, but gateway agents can be rebuilt during long messaging conversations. Storing this informational notice in `_compression_warning` makes it replay via `status_callback` on the first turn of each rebuilt gateway agent, causing repeated Discord/Telegram noise even though no user action is required.

## Tests
- `python -m pytest tests/agent/test_codex_gpt55_gateway_notice.py tests/agent/test_arcee_trinity_overrides.py -q -o 'addopts='`
