### PR TITLE
fix(tools): read vision model from config.yaml as fallback to env var

### DIFF
--- a/tests/tools/test_vision_tools.py
+++ b/tests/tools/test_vision_tools.py
@@ -260,6 +260,112 @@ class TestHandleVisionAnalyze:
 
 
 # ---------------------------------------------------------------------------
+# Vision model resolution from config.yaml (#48269)
+# ---------------------------------------------------------------------------
+# In the Hermes Desktop (Electron) build the env var
+# ``AUXILIARY_VISION_MODEL`` is captured at app launch and never
+# refreshed. The fix is to read ``auxiliary.vision.model`` from
+# ``~/.hermes/config.yaml`` as a fallback when the env var is unset,
+# so a config edit takes effect on the next vision call rather than
+# the next app restart. The env var still wins (override semantics).
+
+
+class TestVisionModelResolution:
+    """``_resolve_vision_model`` env > config precedence (#48269)."""
+
+    def setup_method(self):
+        # Snapshot env so each test can mutate freely.
+        self._env_backup = os.environ.copy()
+
+    def teardown_method(self):
+        # Restore env exactly as the test started.
+        os.environ.clear()
+        os.environ.update(self._env_backup)
+
+    def test_env_var_wins_over_config(self):
+        """When ``AUXILIARY_VISION_MODEL`` is set, it wins (override)."""
+        os.environ["AUXILIARY_VISION_MODEL"] = "env-model"
+        with patch(
+            "hermes_cli.config.load_config",
+            return_value={"auxiliary": {"vision": {"model": "config-model"}}},
+        ):
+            from tools.vision_tools import _resolve_vision_model
+            assert _resolve_vision_model() == "env-model"
+
+    def test_config_fallback_when_env_unset(self):
+        """When env is unset and config has ``auxiliary.vision.model``,
+        the config value is used.
+        """
+        os.environ.pop("AUXILIARY_VISION_MODEL", None)
+        with patch(
+            "hermes_cli.config.load_config",
+            return_value={"auxiliary": {"vision": {"model": "gemma4:31b-cloud"}}},
+        ):
+            from tools.vision_tools import _resolve_vision_model
+            assert _resolve_vision_model() == "gemma4:31b-cloud"
+
+    def test_returns_none_when_neither_set(self):
+        """When neither env nor config has a model, returns None (the
+        ``call_llm`` router falls through to its built-in default).
+        """
+        os.environ.pop("AUXILIARY_VISION_MODEL", None)
+        with patch(
+            "hermes_cli.config.load_config",
+            return_value={"auxiliary": {"vision": {}}},
+        ):
+            from tools.vision_tools import _resolve_vision_model
+            assert _resolve_vision_model() is None
+
+    def test_config_load_failure_silently_returns_none(self):
+        """If ``load_config`` raises (corrupt config, missing file, etc.),
+        the resolver returns None rather than blowing up the vision call.
+        """
+        os.environ.pop("AUXILIARY_VISION_MODEL", None)
+        with patch(
+            "hermes_cli.config.load_config",
+            side_effect=RuntimeError("config corrupt"),
+        ):
+            from tools.vision_tools import _resolve_vision_model
+            assert _resolve_vision_model() is None
+
+    def test_empty_env_falls_back_to_config(self):
+        """Empty-string env var is treated as unset (matches the existing
+        ``os.getenv(..., '').strip() or None`` pattern at the original
+        call sites).
+        """
+        os.environ["AUXILIARY_VISION_MODEL"] = ""
+        with patch(
+            "hermes_cli.config.load_config",
+            return_value={"auxiliary": {"vision": {"model": "config-model"}}},
+        ):
+            from tools.vision_tools import _resolve_vision_model
+            assert _resolve_vision_model() == "config-model"
+
+    def test_handle_vision_analyze_uses_config_fallback(self):
+        """End-to-end: ``_handle_vision_analyze`` resolves the model
+        from config when env is unset — the exact Hermes Desktop
+        Electron failure mode in #48269.
+        """
+        os.environ.pop("AUXILIARY_VISION_MODEL", None)
+        with (
+            patch(
+                "tools.vision_tools.vision_analyze_tool", new_callable=AsyncMock
+            ) as mock_tool,
+            patch(
+                "hermes_cli.config.load_config",
+                return_value={"auxiliary": {"vision": {"model": "gemma4:31b-cloud"}}},
+            ),
+        ):
+            mock_tool.return_value = json.dumps({"result": "ok"})
+            coro = _handle_vision_analyze(
+                {"image_url": "https://example.com/img.png", "question": "test"}
+            )
+            coro.close()
+            call_args = mock_tool.call_args
+            assert call_args[0][2] == "gemma4:31b-cloud"
+
+
+# ---------------------------------------------------------------------------
 # Error logging with exc_info — verify tracebacks are logged
 # ---------------------------------------------------------------------------
 

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -223,8 +223,35 @@ def _get_command_timeout() -> int:
 
 
 def _get_vision_model() -> Optional[str]:
-    """Model for browser_vision (screenshot analysis — multimodal)."""
-    return os.getenv("AUXILIARY_VISION_MODEL", "").strip() or None
+    """Model for browser_vision (screenshot analysis — multimodal).
+
+    Env var ``AUXILIARY_VISION_MODEL`` wins (override). When unset,
+    falls back to ``~/.hermes/config.yaml``'s ``auxiliary.vision.model``
+    setting — important for the Hermes Desktop (Electron) build where
+    the env is captured at app launch and config edits don't propagate
+    to the running process (#48269).
+    """
+    env_model = os.getenv("AUXILIARY_VISION_MODEL", "").strip()
+    if env_model:
+        return env_model
+    try:
+        from hermes_cli.config import load_config as _load_cfg
+        cfg = _load_cfg()
+    except Exception:
+        return None
+    if not isinstance(cfg, dict):
+        return None
+    aux = cfg.get("auxiliary", {})
+    if not isinstance(aux, dict):
+        return None
+    vision_cfg = aux.get("vision", {})
+    if not isinstance(vision_cfg, dict):
+        return None
+    config_model = vision_cfg.get("model")
+    if not isinstance(config_model, str):
+        return None
+    config_model = config_model.strip()
+    return config_model or None
 
 
 def _get_extraction_model() -> Optional[str]:

--- a/tools/vision_tools.py
+++ b/tools/vision_tools.py
@@ -1213,8 +1213,49 @@ def _handle_vision_analyze(args: Dict[str, Any], **kw: Any) -> Awaitable[str]:
         "Fully describe and explain everything about this image, then answer the "
         f"following question:\n\n{question}"
     )
-    model = os.getenv("AUXILIARY_VISION_MODEL", "").strip() or None
+    model = _resolve_vision_model()
     return vision_analyze_tool(image_url, full_prompt, model)
+
+
+def _resolve_vision_model() -> Optional[str]:
+    """Resolve the vision model name with env > config precedence.
+
+    The env var ``AUXILIARY_VISION_MODEL`` is the override (highest
+    precedence) — when set, it wins. When unset, falls back to
+    ``~/.hermes/config.yaml``'s ``auxiliary.vision.model`` setting.
+
+    The config fallback is the fix for the Hermes Desktop (Electron)
+    build where the env var is captured at app launch and never
+    refreshed when the user edits the config — the running Electron
+    main process keeps using the baked-in env value. Reading
+    ``auxiliary.vision.model`` from config directly means config edits
+    take effect on the next vision call, not on the next app restart
+    (#48269).
+
+    Returns None when neither source is set (the default
+    ``call_llm`` resolver then falls through to its built-in default).
+    """
+    env_model = os.getenv("AUXILIARY_VISION_MODEL", "").strip()
+    if env_model:
+        return env_model
+    try:
+        from hermes_cli.config import load_config
+        cfg = load_config()
+    except Exception:
+        return None
+    if not isinstance(cfg, dict):
+        return None
+    aux = cfg.get("auxiliary", {})
+    if not isinstance(aux, dict):
+        return None
+    vision_cfg = aux.get("vision", {})
+    if not isinstance(vision_cfg, dict):
+        return None
+    config_model = vision_cfg.get("model")
+    if not isinstance(config_model, str):
+        return None
+    config_model = config_model.strip()
+    return config_model or None
 
 
 registry.register(
@@ -1576,7 +1617,8 @@ def _handle_video_analyze(args: Dict[str, Any], **kw: Any) -> Awaitable[str]:
         "including visual content, motion, audio cues, text overlays, and scene "
         f"transitions. Then answer the following question:\n\n{question}"
     )
-    model = os.getenv("AUXILIARY_VIDEO_MODEL", "").strip() or os.getenv("AUXILIARY_VISION_MODEL", "").strip() or None
+    video_env = os.getenv("AUXILIARY_VIDEO_MODEL", "").strip()
+    model = video_env or _resolve_vision_model()
     return video_analyze_tool(video_url, full_prompt, model)
 
 


### PR DESCRIPTION
## Summary

In the Hermes Desktop (Electron) build, `AUXILIARY_VISION_MODEL` is captured
at app launch and never refreshed when the user edits
`~/.hermes/config.yaml`'s `auxiliary.vision.model` setting. The running
Electron main process kept using the baked-in env value, so the vision tool
called a retired model and every request returned `410` (#48269).

`vision_analyze`, `video_analyze`, and `browser_tool._get_vision_model` all
read the model from `os.getenv("AUXILIARY_VISION_MODEL")` — a single missing
bridge between config and runtime. Reading `auxiliary.vision.model` from config
directly means a config edit takes effect on the next vision call — the natural
operator mental model.

---

## Changes

- `tools/vision_tools.py` (L1220-1261) — new `_resolve_vision_model()` helper
  with `env > config` precedence. `AUXILIARY_VISION_MODEL` is the
  highest-priority override; when unset, falls back to
  `config.yaml`'s `auxiliary.vision.model`. Defensive `try/except` around
  `load_config` and `isinstance` checks keep the vision call safe with a
  corrupt or missing config.
- `tools/vision_tools.py` (L1216, L1577-1580) — two call sites updated:
  - `_handle_vision_analyze` → `_resolve_vision_model()`
  - `_handle_video_analyze` → video env wins, else `_resolve_vision_model()`
- `tools/browser_tool.py` (L225-260) — `_get_vision_model()` follows the same
  `env > config` precedence pattern; `load_config` imported lazily to avoid a
  circular import.
- `tests/tools/test_vision_tools.py` (L264-368) — 6 new regression tests in
  `TestVisionModelResolution`:
  - `test_env_var_wins_over_config` — env > config precedence preserved.
  - `test_config_fallback_when_env_unset` — the fix; config value used when
    env is unset.
  - `test_returns_none_when_neither_set` — graceful no-op; `call_llm` router
    falls through to its built-in default.
  - `test_config_load_failure_silently_returns_none` — corrupt/missing config
    does not blow up the vision call.
  - `test_empty_env_falls_back_to_config` — empty-string env var treated as
    unset.
  - `test_handle_vision_analyze_uses_config_fallback` — end-to-end repro of
    the #48269 scenario.

---

## How to Test

```bash
# New tests
pytest tests/tools/test_vision_tools.py -v
# ✅ 113/113 passed (107 existing + 6 new)

# Regression suite
pytest \
  tests/tools/test_vision_tools.py \
  tests/tools/test_video_analyze.py \
  tests/tools/test_browser_console.py \
  tests/tools/test_vision_native_fast_path.py \
  tests/agent/test_auxiliary_config_bridge.py
# ✅ 182/182 passed

# Lint
ruff check tools/vision_tools.py tools/browser_tool.py
# ✅ All checks passed
```

---

## Checklist

- [x] Tests pass — 113/113 in `test_vision_tools.py`, 182/182 regression suite
- [x] `ruff check` — PASS, 0 warnings
- [x] Follows Conventional Commits
- [x] Changes scoped to this fix only — 3 files

---

## Risk & Impact

**Low.** Purely additive — the fallback path fires only when the env var is
unset. Users who set `AUXILIARY_VISION_MODEL` see byte-for-byte unchanged
behavior (`env > config > None`). The helper is defensive: `load_config`
failures degrade to `None`, not a hard error. Public method signatures are
unchanged.

**Type:** 🐛 Bug fix (config-runtime bridge)  
**Closes:** #48269