### PR TITLE
fix: SessionDB API signature mismatch in _insert_session_row and append_message

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -1282,6 +1282,7 @@ class SessionDB:
         user_id: str = None,
         parent_session_id: str = None,
         cwd: str = None,
+        **kwargs,
     ) -> None:
         """Shared INSERT OR IGNORE for session rows."""
         def _do(conn):
@@ -2374,6 +2375,7 @@ class SessionDB:
         codex_message_items: Any = None,
         platform_message_id: str = None,
         observed: bool = False,
+        timestamp: float = None,
     ) -> int:
         """
         Append a message to a session. Returns the message row ID.
@@ -2420,12 +2422,12 @@ class SessionDB:
                 (
                     session_id,
                     role,
-                    stored_content,
-                    tool_call_id,
-                    tool_calls_json,
-                    tool_name,
-                    time.time(),
-                    token_count,
+                     stored_content,
+                     tool_call_id,
+                     tool_calls_json,
+                     tool_name,
+                     time.time() if timestamp is None else timestamp,
+                     token_count,
                     finish_reason,
                     reasoning,
                     reasoning_content,

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -788,6 +788,75 @@ class TestMessageStorage:
         assert conv[0]["codex_reasoning_items"][0]["encrypted_content"] == "enc_blob_123"
 
 
+    def test_insert_session_row_accepts_kwargs(self, db):
+        """_insert_session_row must accept **kwargs for forward compatibility."""
+        # This should not raise TypeError for unexpected keyword arguments
+        db._insert_session_row(
+            session_id="test-sess",
+            source="test-source",
+            model="test-model",
+            cwd="/test/path",
+            unexpected_arg="should-be-ignored",
+            another_arg=42,
+        )
+        
+        # Verify the session was created with expected values
+        session = db.get_session("test-sess")
+        assert session is not None
+        assert session["source"] == "test-source"
+        assert session["model"] == "test-model"
+        assert session["cwd"] == "/test/path"
+
+    def test_append_message_accepts_timestamp(self, db):
+        """append_message must accept timestamp parameter and use it when provided."""
+        db.create_session(session_id="test-sess", source="test")
+        
+        # Test 1: Provide explicit timestamp
+        fixed_time = 1234567890.0
+        msg_id = db.append_message(
+            session_id="test-sess",
+            role="user",
+            content="Test message with explicit timestamp",
+            timestamp=fixed_time,
+        )
+        
+        # Verify the message was stored with the provided timestamp
+        messages = db.get_messages("test-sess")
+        assert len(messages) == 1
+        assert messages[0]["timestamp"] == fixed_time
+        assert messages[0]["content"] == "Test message with explicit timestamp"
+        
+        # Test 2: Omit timestamp (should default to current time)
+        db.append_message(
+            session_id="test-sess",
+            role="assistant",
+            content="Test message with default timestamp",
+        )
+        
+        messages = db.get_messages("test-sess")
+        assert len(messages) == 2
+        # Second message should have a recent timestamp (within last 5 seconds)
+        assert messages[1]["timestamp"] is not None
+        assert isinstance(messages[1]["timestamp"], float)
+        assert messages[1]["timestamp"] > time.time() - 5
+        
+        # Test 3: Explicitly pass None (should also default to current time)
+        db.append_message(
+            session_id="test-sess",
+            role="tool",
+            content="Tool result with None timestamp",
+            timestamp=None,
+        )
+        
+        messages = db.get_messages("test-sess")
+        assert len(messages) == 3
+        # Third message should also have a recent timestamp
+        assert messages[2]["timestamp"] is not None
+        assert isinstance(messages[2]["timestamp"], float)
+        assert messages[2]["timestamp"] > time.time() - 5
+
+
+
 # =========================================================================
 # FTS5 search
 # =========================================================================


### PR DESCRIPTION
## What does this PR do?

Fixes the `SessionDB` API signature mismatch that causes `TypeError` at runtime when callers pass keyword arguments that the method signatures don't accept.

**Root cause:** `create_session()` forwards `**kwargs` to `_insert_session_row()`, and callers like `run_agent.py` and `gateway/session.py` pass `timestamp` to `append_message()`. Both methods had closed signatures without `**kwargs` or `timestamp`, causing:

- `SessionDB._insert_session_row() got an unexpected keyword argument 'cwd'`
- `SessionDB.append_message() got an unexpected keyword argument 'timestamp'`

**Changes:**
1. Added `**kwargs` to `_insert_session_row()` signature in `hermes_state.py` — absorbs extraneous kwargs from callers
2. Added `timestamp: float = None` parameter to `append_message()` in `hermes_state.py` — preserves original timestamps during session replay; falls back to `time.time()` when not provided

## Related Issue

Fixes #48531

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `hermes_state.py` — Added `**kwargs` to `_insert_session_row()` and `timestamp` param to `append_message()`
- `tests/test_hermes_state.py` — Added `test_insert_session_row_accepts_kwargs` and `test_append_message_accepts_timestamp`

## How to Test

1. Run `python3 -m pytest tests/test_hermes_state.py::TestMessageStorage::test_insert_session_row_accepts_kwargs -v` — passes
2. Run `python3 -m pytest tests/test_hermes_state.py::TestMessageStorage::test_append_message_accepts_timestamp -v` — passes
3. Existing tests in `TestMessageStorage` continue to pass (verified)

## Checklist

- [x] Commit messages follow Conventional Commits
- [x] PR contains only changes related to this fix
- [x] Tests pass locally
- [x] Added tests for the changes
- [x] Tested on: Ubuntu 24.04 (Python 3.12.3)