### PR TITLE
fix(picker): remove max_models=50 cap in interactive model pickers

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -6930,7 +6930,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
             try:
                 if ctx is None:
                     raise RuntimeError("inventory context unavailable")
-                providers = build_models_payload(ctx, max_models=50)["providers"]
+                providers = build_models_payload(ctx)["providers"]
             except Exception:
                 providers = []
 

--- a/hermes_cli/inventory.py
+++ b/hermes_cli/inventory.py
@@ -117,7 +117,7 @@ def build_models_payload(
     pricing: bool = False,
     capabilities: bool = False,
     force_fresh_nous_tier: bool = False,
-    max_models: int = 50,
+    max_models: int | None = None,
 ) -> dict:
     """Build the ``{providers, model, provider}`` shape every consumer
     needs from a single substrate call.

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -1188,7 +1188,6 @@ def prewarm_picker_cache_async() -> Optional["_threading.Thread"]:
                 current_model=ctx.current_model,
                 user_providers=ctx.user_providers,
                 custom_providers=ctx.custom_providers,
-                max_models=50,
             )
         except Exception:
             # Best-effort warmup — never surface errors into the session.
@@ -1206,7 +1205,7 @@ def list_authenticated_providers(
     custom_providers: list | None = None,
     *,
     force_fresh_nous_tier: bool = False,
-    max_models: int = 8,
+    max_models: int | None = None,
     current_model: str = "",
 ) -> List[dict]:
     """Detect which providers have credentials and list their curated models.
@@ -1426,7 +1425,7 @@ def list_authenticated_providers(
             if hermes_id in _MODELS_DEV_PREFERRED:
                 model_ids = _merge_with_models_dev(hermes_id, model_ids)
         total = len(model_ids)
-        top = model_ids[:max_models]
+        top = model_ids[:max_models] if max_models else model_ids
 
         slug = hermes_id
         pinfo = _mdev_pinfo(mdev_id)
@@ -1589,7 +1588,7 @@ def list_authenticated_providers(
                 if hermes_slug in _MODELS_DEV_PREFERRED:
                     model_ids = _merge_with_models_dev(hermes_slug, model_ids)
         total = len(model_ids)
-        top = model_ids[:max_models]
+        top = model_ids[:max_models] if max_models else model_ids
 
         results.append({
             "slug": hermes_slug,
@@ -1664,7 +1663,7 @@ def list_authenticated_providers(
             if not _cp_model_ids:
                 _cp_model_ids = curated.get(_cp.slug, [])
         _cp_total = len(_cp_model_ids)
-        _cp_top = _cp_model_ids[:max_models]
+        _cp_top = _cp_model_ids[:max_models] if max_models else _cp_model_ids
 
         results.append({
             "slug": _cp.slug,
@@ -2040,7 +2039,7 @@ def list_picker_providers(
     current_base_url: str = "",
     user_providers: dict = None,
     custom_providers: list | None = None,
-    max_models: int = 8,
+    max_models: int | None = None,
     current_model: str = "",
 ) -> List[dict]:
     """Interactive-picker variant of :func:`list_authenticated_providers`.
@@ -2083,7 +2082,7 @@ def list_picker_providers(
             except Exception:
                 live_ids = list(p.get("models", []))
             p = dict(p)
-            p["models"] = live_ids[:max_models]
+            p["models"] = live_ids[:max_models] if max_models else live_ids
             p["total_models"] = len(live_ids)
 
         has_models = bool(p.get("models"))

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -1425,7 +1425,7 @@ def list_authenticated_providers(
             if hermes_id in _MODELS_DEV_PREFERRED:
                 model_ids = _merge_with_models_dev(hermes_id, model_ids)
         total = len(model_ids)
-        top = model_ids[:max_models] if max_models else model_ids
+        top = model_ids[:max_models] if max_models is not None else model_ids
 
         slug = hermes_id
         pinfo = _mdev_pinfo(mdev_id)
@@ -1588,7 +1588,7 @@ def list_authenticated_providers(
                 if hermes_slug in _MODELS_DEV_PREFERRED:
                     model_ids = _merge_with_models_dev(hermes_slug, model_ids)
         total = len(model_ids)
-        top = model_ids[:max_models] if max_models else model_ids
+        top = model_ids[:max_models] if max_models is not None else model_ids
 
         results.append({
             "slug": hermes_slug,
@@ -1663,7 +1663,7 @@ def list_authenticated_providers(
             if not _cp_model_ids:
                 _cp_model_ids = curated.get(_cp.slug, [])
         _cp_total = len(_cp_model_ids)
-        _cp_top = _cp_model_ids[:max_models] if max_models else _cp_model_ids
+        _cp_top = _cp_model_ids[:max_models] if max_models is not None else _cp_model_ids
 
         results.append({
             "slug": _cp.slug,
@@ -1812,7 +1812,7 @@ def list_authenticated_providers(
             "name": "Custom endpoint",
             "is_current": True,
             "is_user_defined": True,
-            "models": _models[:max_models] if max_models else _models,
+            "models": _models[:max_models] if max_models is not None else _models,
             "total_models": len(_models),
             "source": "model-config",
             "api_url": str(current_base_url).strip().rstrip("/"),
@@ -2082,7 +2082,7 @@ def list_picker_providers(
             except Exception:
                 live_ids = list(p.get("models", []))
             p = dict(p)
-            p["models"] = live_ids[:max_models] if max_models else live_ids
+            p["models"] = live_ids[:max_models] if max_models is not None else live_ids
             p["total_models"] = len(live_ids)
 
         has_models = bool(p.get("models"))

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -3323,7 +3323,6 @@ def get_model_options(profile: Optional[str] = None):
         with _profile_scope(profile):
             return build_models_payload(
                 load_picker_context(),
-                max_models=50,
                 include_unconfigured=True,
                 picker_hints=True,
                 canonical_order=True,
@@ -3398,7 +3397,7 @@ def get_recommended_default_model(provider: str = ""):
     try:
         from hermes_cli.inventory import build_models_payload, load_picker_context
 
-        payload = build_models_payload(load_picker_context(), max_models=50)
+        payload = build_models_payload(load_picker_context())
         for row in payload.get("providers", []):
             if str(row.get("slug", "")).lower() == slug:
                 models = row.get("models") or []

--- a/tests/hermes_cli/test_inventory.py
+++ b/tests/hermes_cli/test_inventory.py
@@ -660,3 +660,31 @@ def test_two_custom_providers_with_overlap_both_survive():
     assert a_row["total_models"] == 2
     assert b_row["total_models"] == 2
 
+
+def test_build_models_payload_no_max_models_returns_full_list():
+    """When max_models is not passed (None), build_models_payload must
+    return the full model list — not truncate to the old default of 50.
+    Regression for #48279: Kilo Gateway picker was capped at 50 of 336
+    models, making most models undiscoverable via search."""
+    full_models = [f"model-{i}" for i in range(100)]
+    rows = [
+        {
+            "slug": "kilocode",
+            "name": "Kilo Code",
+            "models": full_models,
+            "total_models": len(full_models),
+            "is_current": False,
+            "is_user_defined": False,
+            "source": "built-in",
+        },
+    ]
+    ctx = _empty_ctx()
+    with _list_auth_returning(rows):
+        # No max_models argument — should return all 100 models
+        payload = build_models_payload(ctx)
+
+    kilo_row = next(r for r in payload["providers"] if r["slug"] == "kilocode")
+    assert kilo_row["models"] == full_models
+    assert kilo_row["total_models"] == 100
+    assert len(kilo_row["models"]) == 100
+

--- a/tests/hermes_cli/test_model_catalog.py
+++ b/tests/hermes_cli/test_model_catalog.py
@@ -423,6 +423,71 @@ class TestIntegrationWithModelsModule:
         assert nous_row is not None, "nous row must appear when authed"
         assert nous_row["models"] == expected
 
+    def test_picker_max_models_cap_semantics(self, tmp_path, monkeypatch):
+        """The cap argument has three distinct meanings on the real slicing
+        path: ``None`` = unlimited (the cap-removal fix, #48297), ``0`` = no
+        models (preserved for slug-only callers), an int N = first N. Guards
+        the ``is not None`` distinction the cap-removal follow-up introduced —
+        a ``if max_models`` (falsy) check would conflate ``0`` with unlimited.
+        """
+        import importlib
+        from hermes_cli import model_catalog
+        from hermes_cli.models import get_curated_nous_model_ids
+        importlib.reload(model_catalog)
+        try:
+            from hermes_cli.model_switch import (
+                list_authenticated_providers,
+                list_picker_providers,
+            )
+
+            active_home = Path(os.environ["HERMES_HOME"])
+            (active_home / "auth.json").write_text(
+                json.dumps(
+                    {
+                        "providers": {"nous": {"access_token": "fake"}},
+                        "credential_pool": {},
+                    }
+                )
+            )
+            with patch.object(
+                model_catalog, "_fetch_manifest", return_value=_valid_manifest()
+            ), patch("hermes_cli.models.check_nous_free_tier", return_value=False), patch(
+                "hermes_cli.models.union_with_portal_free_recommendations",
+                side_effect=lambda ids, *a, **k: (ids, {}),
+            ), patch(
+                "hermes_cli.models.union_with_portal_paid_recommendations",
+                side_effect=lambda ids, *a, **k: (ids, {}),
+            ):
+                expected = get_curated_nous_model_ids()
+                full = list_picker_providers(current_provider="nous", max_models=None)
+                one = list_picker_providers(current_provider="nous", max_models=1)
+                # 0 is exercised on list_authenticated_providers (the slug-only
+                # path); the picker variant drops empty-model rows entirely, so
+                # the empty-list contract lives on the auth-providers call.
+                zero = list_authenticated_providers(
+                    current_provider="nous", max_models=0
+                )
+        finally:
+            model_catalog.reset_cache()
+
+        def _nous(rows):
+            return next((r for r in rows if r["slug"] == "nous"), None)
+
+        # Only meaningful when the curated list actually exceeds 1 entry.
+        assert len(expected) > 1, "test needs a multi-model curated nous list"
+
+        full_row = _nous(full)
+        assert full_row is not None and full_row["models"] == expected
+
+        one_row = _nous(one)
+        assert one_row is not None and one_row["models"] == expected[:1]
+
+        zero_row = _nous(zero)
+        # 0 means an empty model list — NOT unlimited. total_models still real.
+        assert zero_row is not None
+        assert zero_row["models"] == []
+        assert zero_row["total_models"] == len(expected)
+
 
 # -----------------------------------------------------------------------------
 # Drift guard — prevent the in-repo curated lists from going out of sync with

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -9280,7 +9280,6 @@ def _(rid, params: dict) -> dict:
             canonical_order=True,
             pricing=True,
             capabilities=True,
-            max_models=50,
         )
         return _ok(rid, payload)
     except Exception as e:


### PR DESCRIPTION
## Summary

The interactive model pickers no longer cap at 50 models — large provider catalogs (e.g. Kilo Gateway's 336) are now fully searchable. Searching for a model that existed in cache but ranked past the first 50 previously returned zero results.

Salvages #48297 by @islam666 (cherry-picked, authorship preserved) plus a follow-up correctness fix on top.

## Changes

- `build_models_payload()` / `list_authenticated_providers()` / `list_picker_providers()`: default `max_models` → `None` (unlimited)
- Removed the explicit `max_models=50` from the 5 interactive picker callers: Desktop `/api/model/options`, Desktop recommended-default, picker prewarm, TUI `model.options`, CLI `/model`
- Telegram/Discord inline keyboard picker keeps its cap — **unchanged by design** (inline keyboards need a bound)
- **Follow-up (ours):** tightened the slicing guard from `if max_models` to `if max_models is not None` at all 5 sites, so `max_models=0` keeps its "empty model list" meaning for the slug-only callers instead of being conflated with unlimited

## Validation

| `max_models` | Before | After |
|---|---|---|
| default (interactive) | 50 (truncated) | unlimited |
| `None` | n/a | full list |
| `0` | empty | empty (preserved) |
| `N` | first N | first N |

Regression tests: contributor's `test_build_models_payload_no_max_models_returns_full_list` (None=unlimited) + new `test_picker_max_models_cap_semantics` locking the three-way contract (None=full, 0=empty, N=first N) on the real slicing path. `tests/hermes_cli/` (7130) and `tests/tui_gateway/` (148) all green.

## Test plan
- `scripts/run_tests.sh tests/hermes_cli tests/tui_gateway` → all passed

Supersedes the duplicate cluster: #35446, #35447, #40765, #42496, #27914, #41029.

## Infographic

![Model picker cap removed — before/after roster grid, 5 interactive pickers uncapped, cap modes none=ALL/0=NONE/N=first N, inline keyboard still capped by design](https://v3b.fal.media/files/b/0a9ed433/D51A8rxmGsRBF1k4cv-PD_oCyoJrAY.png)
