### PR TITLE
fix(nous): accept static api keys for runtime auth

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -1276,8 +1276,8 @@ def _read_nous_auth() -> Optional[dict]:
 
 
 def _nous_api_key(provider: dict) -> str:
-    """Extract a usable Nous inference JWT from stored auth state."""
-    from hermes_cli.auth import _nous_invoke_jwt_is_usable
+    """Extract a usable Nous inference credential from stored auth state."""
+    from hermes_cli.auth import _nous_runtime_token_is_usable
 
     for token_key, expiry_key in (
         ("agent_key", "agent_key_expires_at"),
@@ -1286,12 +1286,12 @@ def _nous_api_key(provider: dict) -> str:
         token = provider.get(token_key)
         if not isinstance(token, str) or not token.strip():
             continue
-        if _nous_invoke_jwt_is_usable(
+        if _nous_runtime_token_is_usable(
             token,
             scope=provider.get("scope"),
             expires_at=provider.get(expiry_key),
         ):
-            return token
+            return token.strip()
     return ""
 
 
@@ -1645,7 +1645,7 @@ def _try_nous(vision: bool = False) -> Tuple[Optional[OpenAI], Optional[str]]:
         api_key = _nous_api_key(nous or {})
         if not api_key:
             logger.warning(
-                "Auxiliary Nous client unavailable: no usable inference JWT found "
+                "Auxiliary Nous client unavailable: no usable inference credential found "
                 "(run: hermes auth add nous)."
             )
             _mark_provider_unhealthy("nous", ttl=60)

--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -203,7 +203,7 @@ class PooledCredential:
     def runtime_api_key(self) -> str:
         if self.provider == "nous":
             # Nous stores the runtime inference credential in agent_key for
-            # compatibility. It must be a NAS invoke JWT.
+            # compatibility. It may be a static Portal API key or an invoke JWT.
             for token, expires_at in (
                 (self.agent_key, self.agent_key_expires_at),
                 (self.access_token, self.expires_at),
@@ -211,7 +211,7 @@ class PooledCredential:
                 if (
                     isinstance(token, str)
                     and token.strip()
-                    and auth_mod._nous_invoke_jwt_is_usable(
+                    and auth_mod._nous_runtime_token_is_usable(
                         token,
                         scope=getattr(self, "scope", None),
                         expires_at=expires_at,

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -1816,6 +1816,32 @@ def _nous_invoke_jwt_is_usable(
     )
 
 
+def _nous_static_api_key_is_usable(token: Any) -> bool:
+    """Return True for Portal-issued static inference API keys."""
+    return isinstance(token, str) and token.strip().startswith("sk-")
+
+
+def _nous_runtime_token_is_usable(
+    token: Any,
+    *,
+    scope: Any = None,
+    expires_at: Any = None,
+    min_ttl_seconds: int = NOUS_INVOKE_JWT_MIN_TTL_SECONDS,
+) -> bool:
+    """Accept either a static Nous API key or a valid invoke JWT."""
+    if not isinstance(token, str) or not token.strip():
+        return False
+    token = token.strip()
+    if _nous_static_api_key_is_usable(token):
+        return True
+    return _nous_invoke_jwt_is_usable(
+        token,
+        scope=scope,
+        expires_at=expires_at,
+        min_ttl_seconds=min_ttl_seconds,
+    )
+
+
 def _assert_nous_inference_jwt_usable(
     state: Dict[str, Any],
     *,
@@ -5234,9 +5260,7 @@ def fetch_nous_models(
 
 def _agent_key_is_usable(state: Dict[str, Any], min_ttl_seconds: int) -> bool:
     key = state.get("agent_key")
-    if not isinstance(key, str) or not key.strip():
-        return False
-    return _nous_invoke_jwt_is_usable(
+    return _nous_runtime_token_is_usable(
         key,
         scope=state.get("scope"),
         expires_at=state.get("agent_key_expires_at"),
@@ -5554,11 +5578,12 @@ def resolve_nous_runtime_credentials(
     """
     Resolve Nous inference credentials for runtime use.
 
-    Ensures access_token is a valid inference-scoped JWT, refreshing it when
-    needed. Concurrent processes coordinate through the auth store file lock.
+    Accepts static Portal API keys stored in ``agent_key``. Otherwise ensures
+    access_token is a valid inference-scoped JWT, refreshing it when needed.
+    Concurrent processes coordinate through the auth store file lock.
 
     Returns dict with: provider, base_url, api_key, key_id, expires_at,
-    expires_in, source ("invoke_jwt"), and auth_path.
+    expires_in, source ("api_key" or "invoke_jwt"), and auth_path.
     """
     sequence_id = uuid.uuid4().hex[:12]
 
@@ -5633,6 +5658,35 @@ def resolve_nous_runtime_credentials(
             sequence_id=sequence_id,
             refresh_token_fp=_token_fingerprint(state.get("refresh_token")),
         )
+
+        static_agent_key = state.get("agent_key")
+        if _nous_static_api_key_is_usable(static_agent_key):
+            if force_refresh:
+                raise AuthError(
+                    "Nous API keys cannot be refreshed automatically. "
+                    "Update the key with: hermes auth add nous",
+                    provider="nous",
+                    code="api_key_refresh_unavailable",
+                    relogin_required=True,
+                )
+            api_key = str(static_agent_key).strip()
+            expires_at = state.get("agent_key_expires_at")
+            expires_epoch = _parse_iso_timestamp(expires_at)
+            expires_in = (
+                max(0, int(expires_epoch - time.time()))
+                if expires_epoch is not None
+                else _coerce_ttl_seconds(state.get("agent_key_expires_in"))
+            )
+            return {
+                "provider": "nous",
+                "base_url": inference_base_url,
+                "api_key": api_key,
+                "key_id": state.get("agent_key_id"),
+                "expires_at": expires_at,
+                "expires_in": expires_in,
+                "source": "api_key",
+                "auth_path": "api_key",
+            }
 
         with httpx.Client(timeout=timeout, headers={"Accept": "application/json"}, verify=verify) as client:
             access_token = state.get("access_token")
@@ -5942,9 +5996,10 @@ def _compute_nous_auth_status() -> Dict[str, Any]:
         try:
             creds = resolve_nous_runtime_credentials()
             refreshed_state = get_provider_auth_state("nous") or state
+            runtime_source = str(creds.get("source") or "portal")
             base_status.update(
                 {
-                    "logged_in": True,
+                    "logged_in": bool(refreshed_state.get("access_token")),
                     "portal_base_url": refreshed_state.get("portal_base_url") or base_status.get("portal_base_url"),
                     "inference_base_url": creds.get("base_url")
                     or refreshed_state.get("inference_base_url")
@@ -5956,7 +6011,7 @@ def _compute_nous_auth_status() -> Dict[str, Any]:
                     "has_refresh_token": bool(refreshed_state.get("refresh_token")),
                     "inference_credential_present": True,
                     "credential_source": "auth_store",
-                    "source": f"runtime:{creds.get('source', 'portal')}",
+                    "source": f"runtime:{runtime_source}",
                     "key_id": creds.get("key_id"),
                 }
             )

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -1284,8 +1284,8 @@ def _resolve_explicit_runtime(
             or str(state.get("inference_base_url") or auth_mod.DEFAULT_NOUS_INFERENCE_URL).strip().rstrip("/")
         )
         # Only use the agent_key compatibility field for inference when it
-        # contains a NAS invoke JWT; raw OAuth access_token fallback is handled
-        # by resolve_nous_runtime_credentials().
+        # contains a static API key or usable invoke JWT; raw OAuth
+        # access_token fallback is handled by resolve_nous_runtime_credentials().
         api_key = explicit_api_key or (
             str(state.get("agent_key") or "").strip()
             if _agent_key_is_usable(
@@ -1483,10 +1483,10 @@ def resolve_runtime_provider(
                 or getattr(entry, "access_token", "")
             )
         # For Nous, the pool entry's runtime_api_key is the agent_key
-        # compatibility field. It must be an invoke JWT. The pool doesn't
-        # refresh it during selection (that would trigger network calls in
-        # non-runtime contexts like `hermes auth list`).  If the key is
-        # expired, clear pool_api_key so we fall through to
+        # compatibility field. It may be a static API key or an invoke JWT.
+        # The pool doesn't refresh it during selection (that would trigger
+        # network calls in non-runtime contexts like `hermes auth list`). If
+        # the key is expired, clear pool_api_key so we fall through to
         # resolve_nous_runtime_credentials() which handles refresh.
         if provider == "nous" and entry is not None and pool_api_key:
             min_ttl = max(60, env_int("HERMES_NOUS_MIN_KEY_TTL_SECONDS", 1800))

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -1026,6 +1026,40 @@ class TestAuxiliaryPoolAwareness:
         assert mock_openai.call_args.kwargs["api_key"] == pooled_token
         assert mock_openai.call_args.kwargs["base_url"] == "https://inference.pool.example/v1"
 
+    def test_resolve_nous_runtime_api_returns_none_when_refresh_raises(self):
+        from hermes_cli.auth import AuthError
+        from agent.auxiliary_client import _resolve_nous_runtime_api
+
+        with patch(
+            "hermes_cli.auth.resolve_nous_runtime_credentials",
+            side_effect=AuthError(
+                "stale Nous auth",
+                provider="nous",
+                code="invalid_grant",
+                relogin_required=True,
+            ),
+        ):
+            assert _resolve_nous_runtime_api() is None
+
+    def test_try_nous_uses_static_sk_agent_key_when_runtime_refresh_unavailable(self):
+        with (
+            patch("agent.auxiliary_client._read_nous_auth", return_value={
+                "agent_key": "sk-nous-static-key",
+                "inference_base_url": "https://inference.example.com/v1",
+            }),
+            patch("agent.auxiliary_client._resolve_nous_runtime_api", return_value=None),
+            patch("agent.auxiliary_client.OpenAI") as mock_openai,
+            patch("hermes_cli.models.get_nous_recommended_aux_model", return_value=None),
+        ):
+            from agent.auxiliary_client import _try_nous
+
+            client, model = _try_nous()
+
+        assert client is not None
+        assert model == "google/gemini-3-flash-preview"
+        assert mock_openai.call_args.kwargs["api_key"] == "sk-nous-static-key"
+        assert mock_openai.call_args.kwargs["base_url"] == "https://inference.example.com/v1"
+
     def test_try_nous_uses_portal_recommendation_for_text(self):
         """When the Portal recommends a compaction model, _try_nous honors it."""
         fresh_base = "https://inference-api.nousresearch.com/v1"

--- a/tests/agent/test_credential_pool.py
+++ b/tests/agent/test_credential_pool.py
@@ -1293,6 +1293,26 @@ def test_load_pool_mirrors_nous_invoke_jwt_agent_key_runtime_api_key(tmp_path, m
     assert pool_entry["agent_key_expires_at"] == expires_at
 
 
+def test_nous_runtime_api_key_accepts_static_sk_agent_key():
+    from agent.credential_pool import PooledCredential
+
+    entry = PooledCredential(
+        provider="nous",
+        id="nous-api-key",
+        label="manual",
+        auth_type="api_key",
+        priority=0,
+        source="manual",
+        access_token="",
+        refresh_token=None,
+        agent_key="sk-nous-static-key",
+        agent_key_expires_at=None,
+        extra={"scope": "inference:invoke"},
+    )
+
+    assert entry.runtime_api_key == "sk-nous-static-key"
+
+
 def test_nous_runtime_api_key_rejects_opaque_agent_key():
     from agent.credential_pool import PooledCredential
 

--- a/tests/hermes_cli/test_auth_nous_provider.py
+++ b/tests/hermes_cli/test_auth_nous_provider.py
@@ -645,6 +645,133 @@ def test_get_nous_auth_status_pool_opaque_key_is_not_inference_credential(tmp_pa
     invalidate_nous_auth_status_cache()
 
 
+def test_get_nous_auth_status_pool_static_sk_key_is_inference_credential(tmp_path, monkeypatch):
+    from hermes_cli.auth import get_nous_auth_status, invalidate_nous_auth_status_cache
+
+    hermes_home = tmp_path / "hermes"
+    hermes_home.mkdir(parents=True, exist_ok=True)
+    (hermes_home / "auth.json").write_text(json.dumps({
+        "version": 1,
+        "providers": {},
+    }))
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    invalidate_nous_auth_status_cache()
+
+    from agent.credential_pool import PooledCredential, load_pool
+    pool = load_pool("nous")
+    entry = PooledCredential.from_dict("nous", {
+        "access_token": "",
+        "agent_key": "sk-nous-static-key",
+        "label": "manual api key",
+        "auth_type": "api_key",
+        "source": "manual",
+        "base_url": "https://inference.example.com/v1",
+        "inference_base_url": "https://inference.example.com/v1",
+    })
+    pool.add_entry(entry)
+
+    status = get_nous_auth_status()
+
+    assert status["logged_in"] is False
+    assert status["inference_credential_present"] is True
+    assert status["credential_source"] == "pool:manual api key"
+    assert status["inference_base_url"] == "https://inference.example.com/v1"
+    invalidate_nous_auth_status_cache()
+
+
+def test_get_nous_auth_status_auth_store_static_sk_key_is_not_portal_login(tmp_path, monkeypatch):
+    from hermes_cli.auth import get_nous_auth_status, invalidate_nous_auth_status_cache
+
+    hermes_home = tmp_path / "hermes"
+    hermes_home.mkdir(parents=True, exist_ok=True)
+    (hermes_home / "auth.json").write_text(json.dumps({
+        "version": 1,
+        "active_provider": "nous",
+        "providers": {
+            "nous": {
+                "portal_base_url": "https://portal.example.com",
+                "inference_base_url": "https://inference.example.com/v1",
+                "client_id": "hermes-cli",
+                "token_type": "Bearer",
+                "scope": "inference:invoke",
+                "access_token": "",
+                "refresh_token": "",
+                "agent_key": "sk-nous-static-key",
+                "agent_key_expires_at": None,
+            }
+        },
+    }))
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    invalidate_nous_auth_status_cache()
+
+    status = get_nous_auth_status()
+
+    assert status["logged_in"] is False
+    assert status["inference_credential_present"] is True
+    assert status["credential_source"] == "auth_store"
+    assert status["source"] == "runtime:api_key"
+    assert status["inference_base_url"] == "https://inference.example.com/v1"
+    invalidate_nous_auth_status_cache()
+
+
+def test_resolve_nous_runtime_credentials_accepts_static_sk_agent_key(tmp_path, monkeypatch):
+    hermes_home = tmp_path / "hermes"
+    hermes_home.mkdir(parents=True, exist_ok=True)
+    (hermes_home / "auth.json").write_text(json.dumps({
+        "version": 1,
+        "active_provider": "nous",
+        "providers": {
+            "nous": {
+                "portal_base_url": "https://portal.example.com",
+                "inference_base_url": "https://inference.example.com/v1",
+                "client_id": "hermes-cli",
+                "token_type": "Bearer",
+                "scope": "inference:invoke",
+                "access_token": "",
+                "refresh_token": "",
+                "agent_key": "sk-nous-static-key",
+                "agent_key_expires_at": None,
+            }
+        },
+    }))
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    creds = resolve_nous_runtime_credentials()
+
+    assert creds["api_key"] == "sk-nous-static-key"
+    assert creds["base_url"] == "https://inference.example.com/v1"
+    assert creds["source"] == "api_key"
+    assert creds["auth_path"] == "api_key"
+
+
+def test_resolve_nous_runtime_credentials_cannot_force_refresh_static_sk_key(tmp_path, monkeypatch):
+    hermes_home = tmp_path / "hermes"
+    hermes_home.mkdir(parents=True, exist_ok=True)
+    (hermes_home / "auth.json").write_text(json.dumps({
+        "version": 1,
+        "active_provider": "nous",
+        "providers": {
+            "nous": {
+                "portal_base_url": "https://portal.example.com",
+                "inference_base_url": "https://inference.example.com/v1",
+                "client_id": "hermes-cli",
+                "token_type": "Bearer",
+                "scope": "inference:invoke",
+                "access_token": "",
+                "refresh_token": "",
+                "agent_key": "sk-nous-static-key",
+                "agent_key_expires_at": None,
+            }
+        },
+    }))
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    with pytest.raises(AuthError) as exc:
+        resolve_nous_runtime_credentials(force_refresh=True)
+
+    assert exc.value.code == "api_key_refresh_unavailable"
+
+
 def test_get_nous_auth_status_auth_store_fallback(tmp_path, monkeypatch):
     """get_nous_auth_status() falls back to auth store when credential
     pool is empty.

--- a/tests/hermes_cli/test_runtime_provider_resolution.py
+++ b/tests/hermes_cli/test_runtime_provider_resolution.py
@@ -1,3 +1,5 @@
+import json
+
 import pytest
 
 from hermes_cli import runtime_provider as rp
@@ -975,6 +977,80 @@ def test_named_custom_provider_does_not_shadow_builtin_provider(monkeypatch):
     assert resolved["base_url"] == "https://inference-api.nousresearch.com/v1"
     assert resolved["api_key"] == "nous-runtime-key"
     assert resolved["requested_provider"] == "nous"
+
+
+def test_resolve_runtime_provider_nous_uses_static_auth_store_agent_key(tmp_path, monkeypatch):
+    hermes_home = tmp_path / "hermes"
+    hermes_home.mkdir(parents=True, exist_ok=True)
+    (hermes_home / "auth.json").write_text(json.dumps({
+        "version": 1,
+        "active_provider": "nous",
+        "providers": {
+            "nous": {
+                "portal_base_url": "https://portal.example.com",
+                "inference_base_url": "https://inference.example.com/v1",
+                "client_id": "hermes-cli",
+                "token_type": "Bearer",
+                "scope": "inference:invoke",
+                "access_token": "",
+                "refresh_token": "",
+                "agent_key": "sk-nous-static-key",
+                "agent_key_expires_at": None,
+            }
+        },
+    }))
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "nous")
+    monkeypatch.setattr(rp, "_get_model_config", lambda: {"provider": "nous"})
+    monkeypatch.setattr(
+        rp,
+        "load_pool",
+        lambda provider: type("Pool", (), {"has_credentials": lambda self: False})(),
+    )
+
+    resolved = rp.resolve_runtime_provider(requested="nous")
+
+    assert resolved["provider"] == "nous"
+    assert resolved["base_url"] == "https://inference.example.com/v1"
+    assert resolved["api_key"] == "sk-nous-static-key"
+    assert resolved["source"] == "api_key"
+
+
+def test_resolve_runtime_provider_nous_uses_static_pool_agent_key(monkeypatch):
+    class _Entry:
+        agent_key = "sk-nous-pool-key"
+        runtime_api_key = "sk-nous-pool-key"
+        agent_key_expires_at = None
+        scope = "inference:invoke"
+        source = "manual"
+        base_url = "https://inference.pool.example/v1"
+        runtime_base_url = "https://inference.pool.example/v1"
+
+    class _Pool:
+        def has_credentials(self):
+            return True
+
+        def select(self):
+            return _Entry()
+
+    monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "nous")
+    monkeypatch.setattr(rp, "_get_model_config", lambda: {"provider": "nous"})
+    monkeypatch.setattr(rp, "load_pool", lambda provider: _Pool())
+    monkeypatch.setattr(
+        rp,
+        "resolve_nous_runtime_credentials",
+        lambda **kwargs: (_ for _ in ()).throw(
+            AssertionError("static Nous pool key should not trigger JWT refresh")
+        ),
+    )
+
+    resolved = rp.resolve_runtime_provider(requested="nous")
+
+    assert resolved["provider"] == "nous"
+    assert resolved["base_url"] == "https://inference.pool.example/v1"
+    assert resolved["api_key"] == "sk-nous-pool-key"
+    assert resolved["source"] == "manual"
+    assert resolved.get("credential_pool") is not None
 
 
 def test_named_custom_provider_wins_over_builtin_alias(monkeypatch):


### PR DESCRIPTION
## Summary
- accept Portal static `sk-` API keys as Nous runtime bearer credentials alongside invoke JWTs
- keep opaque non-`sk-` agent keys rejected and keep API-key-only state from reporting Portal OAuth login
- align auth-store, credential-pool, runtime-provider, and auxiliary-client paths

Fixes #47950

## Testing
- `scripts/run_tests.sh tests/hermes_cli/test_auth_nous_provider.py tests/agent/test_credential_pool.py tests/agent/test_auxiliary_client.py tests/hermes_cli/test_runtime_provider_resolution.py -- -q`
- `.venv/bin/ruff check hermes_cli/auth.py hermes_cli/runtime_provider.py agent/credential_pool.py agent/auxiliary_client.py tests/hermes_cli/test_auth_nous_provider.py tests/hermes_cli/test_runtime_provider_resolution.py tests/agent/test_credential_pool.py tests/agent/test_auxiliary_client.py`
- `git diff --check`

## Review
- Subagent review confirmed static `sk-` keys are accepted without admitting opaque tokens or misreporting API-key-only state as Portal OAuth login.
- Follow-up subagent review requested runtime-provider and auxiliary fallback tests; those tests were added and the follow-up review reported no issues.