### PR TITLE
fix(qqbot): allow DM approval button authorization

### DIFF
--- a/gateway/platforms/qqbot/adapter.py
+++ b/gateway/platforms/qqbot/adapter.py
@@ -1092,7 +1092,11 @@ class QQAdapter(BasePlatformAdapter):
 
         chat_type = parsed.get("chat_type", "")
         chat_id = parsed.get("chat_id", "")
-        if chat_type == "c2c":
+        # QQ's raw interaction scene for one-to-one chats is "c2c", but
+        # Hermes session keys historically use the generic "dm" chat type.
+        # Treat them as aliases so approval buttons sent from a QQ DM don't
+        # reject their own owner's click as unauthorized.
+        if chat_type in {"c2c", "dm"}:
             return bool(chat_id) and operator == chat_id
 
         if chat_type in {"group", "guild"}:

--- a/tests/gateway/test_qqbot.py
+++ b/tests/gateway/test_qqbot.py
@@ -1266,6 +1266,37 @@ class TestAdapterInteractionDispatch:
         assert ack_calls == []
         assert callback_calls == []
 
+    def test_dm_session_key_authorizes_c2c_operator(self):
+        """Hermes keys QQ private chats as dm; QQ button events report c2c."""
+        adapter = self._make_adapter()
+        from gateway.platforms.qqbot.keyboards import InteractionEvent
+
+        event = InteractionEvent(
+            id="i-dm",
+            scene="c2c",
+            user_openid="USER123",
+            button_data="approve:agent:main:qqbot:dm:USER123:allow-once",
+        )
+        assert adapter._is_authorized_interaction_for_session(
+            event,
+            "agent:main:qqbot:dm:USER123",
+        )
+
+    def test_dm_session_key_rejects_wrong_c2c_operator(self):
+        adapter = self._make_adapter()
+        from gateway.platforms.qqbot.keyboards import InteractionEvent
+
+        event = InteractionEvent(
+            id="i-dm-bad",
+            scene="c2c",
+            user_openid="OTHER",
+            button_data="approve:agent:main:qqbot:dm:USER123:allow-once",
+        )
+        assert not adapter._is_authorized_interaction_for_session(
+            event,
+            "agent:main:qqbot:dm:USER123",
+        )
+
     @pytest.mark.asyncio
     async def test_callback_exception_does_not_propagate(self):
         adapter = self._make_adapter()


### PR DESCRIPTION
## Summary
- Treat QQ private-chat `dm` session keys as aliases of QQ `c2c` interaction events during approval button authorization.
- Keep the existing operator/openid equality check so other users cannot approve another user's pending action.
- Add regression coverage for the `dm` session key + `c2c` event mismatch.

## Why
QQ private chat messages are stored in Hermes session keys as `agent:main:qqbot:dm:<openid>`, but QQ button interaction events report the scene as `c2c`. The old authorization path only accepted `chat_type == "c2c"`, so the rightful user clicking their own approval button in a DM could be rejected as unauthorized.

Observed symptom:

```text
Rejected unauthorized approval click for session agent:main:qqbot:dm:<openid>
```

## Test plan
- `python3 -m py_compile gateway/platforms/qqbot/adapter.py tests/gateway/test_qqbot.py`
- `uv run --extra dev --extra messaging python -m pytest tests/gateway/test_qqbot.py -q`

Result:

```text
163 passed, 4 warnings in 3.93s
```
