### PR TITLE
feat: add Slack async intent routing

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -983,6 +983,8 @@ def load_gateway_config() -> GatewayConfig:
                     bridged["group_user_allowed_commands"] = platform_cfg["group_user_allowed_commands"]
                 if plat in {Platform.DISCORD, Platform.SLACK} and "channel_skill_bindings" in platform_cfg:
                     bridged["channel_skill_bindings"] = platform_cfg["channel_skill_bindings"]
+                if plat == Platform.SLACK and "async_routing" in platform_cfg:
+                    bridged["async_routing"] = platform_cfg["async_routing"]
                 if "channel_prompts" in platform_cfg:
                     channel_prompts = platform_cfg["channel_prompts"]
                     if isinstance(channel_prompts, dict):
@@ -1041,6 +1043,12 @@ def load_gateway_config() -> GatewayConfig:
             # Slack settings → env vars (env vars take precedence)
             slack_cfg = yaml_cfg.get("slack", {})
             if isinstance(slack_cfg, dict):
+                if "async_routing" in slack_cfg:
+                    _, _slack_extra = _ensure_platform_extra_dict(
+                        platforms_data,
+                        Platform.SLACK.value,
+                    )
+                    _slack_extra.setdefault("async_routing", slack_cfg["async_routing"])
                 if "require_mention" in slack_cfg and not os.getenv("SLACK_REQUIRE_MENTION"):
                     os.environ["SLACK_REQUIRE_MENTION"] = str(slack_cfg["require_mention"]).lower()
                 if "strict_mention" in slack_cfg and not os.getenv("SLACK_STRICT_MENTION"):

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2483,6 +2483,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
         # Track background tasks to prevent garbage collection mid-execution
         self._background_tasks: set = set()
+        # Best-effort duplicate suppression for Slack async handoffs within
+        # this gateway process. Slack event dedup runs in the adapter; this
+        # covers direct runner tests and any future adapter path that reaches
+        # the runner with the same event twice.
+        self._slack_async_handoffs: Dict[str, float] = {}
 
 
     def _wire_teams_pipeline_runtime(self) -> None:
@@ -3714,6 +3719,269 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             )
             return "all"
         return mode
+
+    @staticmethod
+    def _slack_async_policy_from_config():
+        from gateway.slack_intent import policy_from_config
+
+        return policy_from_config(_load_gateway_config())
+
+    @staticmethod
+    def _slack_prune_handoff_ledger(ledger: Dict[str, float]) -> None:
+        if not ledger:
+            return
+        now = time.time()
+        for key, ts in list(ledger.items()):
+            if now - ts > 3600:
+                ledger.pop(key, None)
+        if len(ledger) > 512:
+            for key in list(ledger)[: len(ledger) - 256]:
+                ledger.pop(key, None)
+
+    def _slack_handoff_key(self, event: MessageEvent, route: str) -> str:
+        source = event.source
+        return "|".join(
+            [
+                "slack",
+                route,
+                str(getattr(source, "chat_id", "") or ""),
+                str(getattr(source, "thread_id", "") or ""),
+                str(getattr(event, "message_id", "") or ""),
+                str(getattr(event, "text", "") or "")[:500],
+            ]
+        )
+
+    async def _start_slack_background_handoff(
+        self,
+        *,
+        event: MessageEvent,
+        prompt: str,
+        ack: str,
+        route: str,
+    ) -> str:
+        """Schedule an isolated Slack background task and return the ack text."""
+        from gateway.slack_intent import stable_slack_handoff_id
+
+        if not hasattr(self, "_slack_async_handoffs"):
+            self._slack_async_handoffs = {}
+        self._slack_prune_handoff_ledger(self._slack_async_handoffs)
+
+        key = self._slack_handoff_key(event, route)
+        source = event.source
+        task_id = stable_slack_handoff_id(
+            route,
+            getattr(source, "chat_id", ""),
+            getattr(source, "thread_id", ""),
+            getattr(event, "message_id", ""),
+            prompt,
+        )
+        if key in self._slack_async_handoffs:
+            return f"{ack}\nTask ID: `{task_id}`"
+
+        self._slack_async_handoffs[key] = time.time()
+        if not hasattr(self, "_background_tasks") or self._background_tasks is None:
+            self._background_tasks = set()
+        _task = asyncio.create_task(
+            self._run_background_task(
+                prompt,
+                source,
+                task_id,
+                event_message_id=self._reply_anchor_for_event(event),
+                media_urls=list(event.media_urls) if event.media_urls else [],
+                media_types=list(event.media_types) if event.media_types else [],
+            )
+        )
+        self._background_tasks.add(_task)
+        _task.add_done_callback(self._background_tasks.discard)
+        return f"{ack}\nTask ID: `{task_id}`"
+
+    def _slack_project_kanban_available(self, policy: Any) -> bool:
+        if str(getattr(policy, "project_routing", "auto") or "auto") == "background":
+            return False
+        if str(getattr(policy, "project_routing", "auto") or "auto") == "foreground":
+            return False
+        if not getattr(policy, "project_assignee", ""):
+            return False
+        try:
+            cfg = _load_gateway_config()
+            kanban_cfg = cfg.get("kanban") if isinstance(cfg.get("kanban"), dict) else {}
+            if kanban_cfg.get("dispatch_in_gateway", True) is False:
+                return False
+            from hermes_cli.kanban import run_slash as _run_slash  # noqa: F401
+            return True
+        except Exception:
+            return False
+
+    async def _route_slack_project_intent(
+        self,
+        event: MessageEvent,
+        decision: Any,
+        policy: Any,
+    ) -> str:
+        source = event.source
+        try:
+            denied = self._check_slash_access(source, "kanban")
+        except Exception:
+            denied = None
+        if denied is None and self._slack_project_kanban_available(policy):
+            from gateway.slack_intent import build_kanban_create_text
+
+            command_text = build_kanban_create_text(
+                decision=decision,
+                policy=policy,
+                chat_id=str(getattr(source, "chat_id", "") or ""),
+                thread_id=str(getattr(source, "thread_id", "") or ""),
+                message_id=str(getattr(event, "message_id", "") or ""),
+                user_id=str(getattr(source, "user_id", "") or ""),
+            )
+            routed_event = dataclasses.replace(
+                event,
+                text=command_text,
+                message_type=MessageType.COMMAND,
+            )
+            return await self._handle_kanban_command(routed_event)
+
+        fallback_reason = "kanban unavailable"
+        if denied is not None:
+            fallback_reason = "kanban command not allowed"
+        project_mode = str(getattr(policy, "project_routing", "auto") or "auto")
+        if project_mode == "kanban":
+            logger.info(
+                "Slack project intent could not route to kanban (%s): chat=%s thread=%s",
+                fallback_reason,
+                getattr(source, "chat_id", "") or "",
+                getattr(source, "thread_id", "") or "",
+            )
+            return (
+                "I recognized this as project work, but kanban worker routing "
+                f"is not available here ({fallback_reason}). I did not start a "
+                "background fallback because `project_routing` is set to `kanban`."
+            )
+        logger.info(
+            "Slack project intent falling back to background (%s): chat=%s thread=%s",
+            fallback_reason,
+            getattr(source, "chat_id", "") or "",
+            getattr(source, "thread_id", "") or "",
+        )
+        ack = (
+            f"{getattr(policy, 'project_ack_prefix', 'Queued for project work')} "
+            f"(background fallback)."
+        )
+        return await self._start_slack_background_handoff(
+            event=event,
+            prompt=decision.text,
+            ack=ack,
+            route="project-background",
+        )
+
+    async def _maybe_route_slack_async_intent(
+        self,
+        event: MessageEvent,
+    ) -> tuple[Optional[str], Optional[Any], Optional[Any]]:
+        """Return ``(response, decision, policy)`` for Slack async routing."""
+        source = event.source
+        if getattr(source, "platform", None) != Platform.SLACK:
+            return None, None, None
+        if event.message_type == MessageType.COMMAND or event.get_command():
+            return None, None, None
+
+        policy = self._slack_async_policy_from_config()
+        if not getattr(policy, "enabled", True):
+            return None, None, policy
+
+        from gateway.slack_intent import SlackIntentKind, classify_slack_intent
+
+        decision = classify_slack_intent(event.text or "", policy)
+        if decision.text != (event.text or ""):
+            try:
+                event.text = decision.text
+            except Exception:
+                event = dataclasses.replace(event, text=decision.text)
+
+        if decision.kind == SlackIntentKind.LONG_AD_HOC:
+            response = await self._start_slack_background_handoff(
+                event=event,
+                prompt=decision.text,
+                ack=getattr(policy, "ad_hoc_ack", "I'll report back here."),
+                route="ad-hoc",
+            )
+            return response, decision, policy
+
+        if decision.kind == SlackIntentKind.PROJECT_CODE:
+            project_mode = str(getattr(policy, "project_routing", "auto") or "auto")
+            if project_mode == "foreground":
+                return None, decision, policy
+            if project_mode == "background":
+                response = await self._start_slack_background_handoff(
+                    event=event,
+                    prompt=decision.text,
+                    ack=(
+                        f"{getattr(policy, 'project_ack_prefix', 'Queued for project work')} "
+                        "(background)."
+                    ),
+                    route="project-background",
+                )
+                return response, decision, policy
+            response = await self._route_slack_project_intent(event, decision, policy)
+            return response, decision, policy
+
+        return None, decision, policy
+
+    @staticmethod
+    def _slack_foreground_iteration_budget(decision: Any, policy: Any) -> Optional[int]:
+        if decision is None or policy is None:
+            return None
+        try:
+            from gateway.slack_intent import SlackIntentKind
+
+            if decision.kind != SlackIntentKind.QUICK:
+                return None
+        except Exception:
+            return None
+        value = int(getattr(policy, "foreground_max_iterations", 0) or 0)
+        return value if value > 0 else None
+
+    @staticmethod
+    def _slack_budget_exceeded(agent_result: Any, policy: Any) -> bool:
+        if not isinstance(agent_result, dict) or policy is None:
+            return False
+        if not getattr(policy, "async_on_budget_exceeded", True):
+            return False
+        cap = int(getattr(policy, "foreground_max_iterations", 0) or 0)
+        if cap <= 0:
+            return False
+        api_calls = int(agent_result.get("api_calls") or 0)
+        if api_calls < cap:
+            return False
+        response = str(agent_result.get("final_response") or "").lower()
+        if "maximum iterations" in response or "maximum tool-iteration" in response:
+            return True
+        if "iteration/cost budget" in response or "per-turn iteration" in response:
+            return True
+        return bool(agent_result.get("failed")) and not agent_result.get("completed")
+
+    async def _handoff_slack_budget_exceeded(
+        self,
+        event: MessageEvent,
+        agent_result: Dict[str, Any],
+        policy: Any,
+    ) -> str:
+        original = event.text or ""
+        foreground = str(agent_result.get("final_response") or "").strip()
+        prompt = (
+            "Continue and finish this Slack request asynchronously. "
+            "If the foreground attempt already completed part of it, summarize "
+            "that briefly and finish the remaining work.\n\n"
+            f"Original request:\n{original}"
+        )
+        if foreground:
+            prompt += f"\n\nForeground result before handoff:\n{foreground}"
+        return await self._start_slack_background_handoff(
+            event=event,
+            prompt=prompt,
+            ack=getattr(policy, "budget_ack", "I'll continue in the background and report back here."),
+            route="budget",
+        )
 
     @staticmethod
     def _load_provider_routing() -> dict:
@@ -7927,6 +8195,17 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # No bare text matching — "yes" in normal conversation must not trigger
         # execution of a dangerous command.
 
+        _slack_intent_decision = None
+        _slack_async_policy = None
+        if not command:
+            (
+                _slack_route_response,
+                _slack_intent_decision,
+                _slack_async_policy,
+            ) = await self._maybe_route_slack_async_intent(event)
+            if _slack_route_response is not None:
+                return _slack_route_response
+
         if self._is_telegram_topic_root_lobby(source):
             # Debounce the lobby reminder so a user who forgets about
             # topic mode and fires ten prompts doesn't get ten copies.
@@ -7958,9 +8237,28 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         self._running_agents[_quick_key] = _AGENT_PENDING_SENTINEL
         self._running_agents_ts[_quick_key] = time.time()
         _run_generation = self._begin_session_run_generation(_quick_key)
+        _slack_foreground_max_iterations = self._slack_foreground_iteration_budget(
+            _slack_intent_decision,
+            _slack_async_policy,
+        )
 
         try:
-            _agent_result = await self._handle_message_with_agent(event, source, _quick_key, _run_generation)
+            _agent_kwargs = {}
+            if _slack_foreground_max_iterations is not None:
+                _agent_kwargs["foreground_max_iterations"] = _slack_foreground_max_iterations
+            _agent_result = await self._handle_message_with_agent(
+                event,
+                source,
+                _quick_key,
+                _run_generation,
+                **_agent_kwargs,
+            )
+            if self._slack_budget_exceeded(_agent_result, _slack_async_policy):
+                return await self._handoff_slack_budget_exceeded(
+                    event,
+                    _agent_result,
+                    _slack_async_policy,
+                )
             # Goal continuation: after the agent returns a final response
             # for this turn, check any standing /goal — the judge will
             # either mark it done, pause it (budget), or enqueue a
@@ -8312,7 +8610,14 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 pass
         return source
 
-    async def _handle_message_with_agent(self, event, source, _quick_key: str, run_generation: int):
+    async def _handle_message_with_agent(
+        self,
+        event,
+        source,
+        _quick_key: str,
+        run_generation: int,
+        foreground_max_iterations: Optional[int] = None,
+    ):
         """Inner handler that runs under the _running_agents sentinel guard."""
         _msg_start_time = time.time()
         _platform_name = source.platform.value if hasattr(source.platform, "value") else str(source.platform)
@@ -9033,6 +9338,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 channel_prompt=event.channel_prompt,
                 persist_user_message=persist_user_message,
                 persist_user_timestamp=persist_user_timestamp,
+                max_iterations_override=foreground_max_iterations,
             )
 
             # Stop persistent typing indicator now that the agent is done
@@ -13739,6 +14045,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         channel_prompt: Optional[str] = None,
         persist_user_message: Optional[str] = None,
         persist_user_timestamp: Optional[float] = None,
+        max_iterations_override: Optional[int] = None,
     ) -> Dict[str, Any]:
         """
         Run the agent with the given message and context.
@@ -14581,8 +14888,17 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # (concurrency-safe). Keep os.environ as fallback for CLI/cron.
             os.environ["HERMES_SESSION_KEY"] = session_key or ""
 
-            # Read from env var or use default (same as CLI)
+            # Read from env var or use default (same as CLI).  Slack foreground
+            # routing can pass a lower per-turn cap; keep the lower of the two
+            # so operator-wide limits still win.
             max_iterations = int(os.getenv("HERMES_MAX_ITERATIONS", "90"))
+            if max_iterations_override is not None:
+                try:
+                    _override_iters = int(max_iterations_override)
+                except (TypeError, ValueError):
+                    _override_iters = 0
+                if _override_iters > 0:
+                    max_iterations = min(max_iterations, _override_iters)
             
             # Map platform enum to the platform hint key the agent understands.
             # Platform.LOCAL ("local") maps to "cli"; others pass through as-is.
@@ -15260,6 +15576,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 if _srn:
                     message = _srn + "\n\n" + message
 
+            _previous_max_iterations = getattr(agent, "max_iterations", None)
+            if max_iterations > 0:
+                agent.max_iterations = max_iterations
+
             _approval_session_key = session_key or ""
             _approval_session_token = set_current_session_key(_approval_session_key)
             register_gateway_notify(_approval_session_key, _approval_notify_sync)
@@ -15311,6 +15631,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     _conversation_kwargs["persist_user_timestamp"] = _persist_user_timestamp_override
                 result = agent.run_conversation(_api_run_message, **_conversation_kwargs)
             finally:
+                if _previous_max_iterations is not None:
+                    agent.max_iterations = _previous_max_iterations
                 unregister_gateway_notify(_approval_session_key)
                 # Cancel any pending clarify entries so blocked agent
                 # threads don't hang past the end of the run (interrupt,

--- a/gateway/slack_intent.py
+++ b/gateway/slack_intent.py
@@ -1,0 +1,453 @@
+"""Deterministic Slack intent routing helpers.
+
+This module keeps Slack async-routing policy and classification in one place so
+the gateway runner does not grow scattered phrase checks.  The first
+implementation is intentionally local and deterministic: it handles obvious
+force prefixes, control/clarify replies, project/code work, and long ad-hoc
+work without making an LLM call before dispatch.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import shlex
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any, Iterable, Optional
+
+
+class SlackIntentKind(str, Enum):
+    QUICK = "quick"
+    LONG_AD_HOC = "long_ad_hoc"
+    PROJECT_CODE = "project_code"
+    CONTROL = "control"
+    CLARIFICATION = "clarification"
+
+
+@dataclass(frozen=True)
+class SlackIntentDecision:
+    kind: SlackIntentKind
+    reason: str
+    text: str
+    forced: bool = False
+
+    @property
+    def should_foreground(self) -> bool:
+        return self.kind in {
+            SlackIntentKind.QUICK,
+            SlackIntentKind.CONTROL,
+            SlackIntentKind.CLARIFICATION,
+        }
+
+
+@dataclass(frozen=True)
+class SlackAsyncPolicy:
+    enabled: bool = True
+    foreground_max_iterations: int = 6
+    async_on_budget_exceeded: bool = True
+    long_word_threshold: int = 55
+    project_routing: str = "auto"  # auto | kanban | background | foreground
+    project_assignee: str = ""
+    project_workspace: str = "scratch"
+    project_board: str = ""
+    project_goal: bool = True
+    project_goal_max_turns: int = 12
+    project_max_runtime: str = "2h"
+    project_skills: tuple[str, ...] = ()
+    ad_hoc_ack: str = "I'll take this into the background and report back here."
+    budget_ack: str = "This is running past the Slack foreground budget, so I'll continue in the background and report back here."
+    project_ack_prefix: str = "Queued for project work"
+    foreground_prefixes: tuple[str, ...] = ("fg:", "quick:", "foreground:")
+    background_prefixes: tuple[str, ...] = ("bg:", "background:", "async:")
+    project_prefixes: tuple[str, ...] = ("project:", "kanban:", "code:")
+    long_markers: tuple[str, ...] = field(default_factory=tuple)
+    project_markers: tuple[str, ...] = field(default_factory=tuple)
+    quick_markers: tuple[str, ...] = field(default_factory=tuple)
+    control_markers: tuple[str, ...] = field(default_factory=tuple)
+    clarification_markers: tuple[str, ...] = field(default_factory=tuple)
+
+
+DEFAULT_LONG_MARKERS = (
+    "take your time",
+    "when you have time",
+    "in the background",
+    "run in background",
+    "background task",
+    "deep dive",
+    "thorough",
+    "comprehensive",
+    "write a report",
+    "full report",
+    "find every",
+    "look through all",
+    "analyze all",
+    "summarize the whole",
+)
+
+DEFAULT_PROJECT_MARKERS = (
+    "implement",
+    "fix the bug",
+    "fix this bug",
+    "debug this",
+    "refactor",
+    "add tests",
+    "write tests",
+    "run tests",
+    "open a pr",
+    "pull request",
+    "make a pr",
+    "create a pr",
+    "commit",
+    "push branch",
+    "codebase",
+    "repo",
+    "repository",
+    "failing test",
+    "ci failure",
+    "regression",
+    "deploy",
+    "migration",
+)
+
+DEFAULT_QUICK_MARKERS = (
+    "quick",
+    "brief",
+    "tl;dr",
+    "tldr",
+    "what is",
+    "who is",
+    "when is",
+    "where is",
+    "why is",
+    "why did",
+    "what does",
+    "can you explain",
+    "how do i",
+    "explain",
+)
+
+DEFAULT_CONTROL_MARKERS = (
+    "status",
+    "stop",
+    "cancel",
+    "nevermind",
+    "never mind",
+    "done",
+    "pause",
+    "resume",
+)
+
+DEFAULT_CLARIFICATION_MARKERS = (
+    "yes",
+    "no",
+    "ok",
+    "okay",
+    "that one",
+    "the first",
+    "the second",
+    "option 1",
+    "option 2",
+    "option 3",
+)
+
+
+def _boolish(value: Any, default: bool) -> bool:
+    if value is None:
+        return default
+    if isinstance(value, str):
+        lowered = value.strip().lower()
+        if lowered in {"1", "true", "yes", "on"}:
+            return True
+        if lowered in {"0", "false", "no", "off"}:
+            return False
+        return default
+    return bool(value)
+
+
+def _intish(value: Any, default: int, *, minimum: Optional[int] = None) -> int:
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        parsed = default
+    if minimum is not None:
+        parsed = max(minimum, parsed)
+    return parsed
+
+
+def _string_tuple(value: Any, default: Iterable[str] = ()) -> tuple[str, ...]:
+    if value is None:
+        return tuple(default)
+    if isinstance(value, str):
+        parts = [p.strip() for p in value.split(",")]
+    elif isinstance(value, (list, tuple, set)):
+        parts = [str(p).strip() for p in value]
+    else:
+        parts = [str(value).strip()]
+    return tuple(p for p in parts if p)
+
+
+def _policy_block(config: dict[str, Any]) -> dict[str, Any]:
+    candidates: list[Any] = []
+    slack = config.get("slack") if isinstance(config.get("slack"), dict) else {}
+    candidates.append(slack.get("async_routing"))
+    gateway = config.get("gateway") if isinstance(config.get("gateway"), dict) else {}
+    gateway_platforms = gateway.get("platforms") if isinstance(gateway.get("platforms"), dict) else {}
+    gateway_slack = gateway_platforms.get("slack") if isinstance(gateway_platforms.get("slack"), dict) else {}
+    candidates.append(gateway_slack.get("async_routing"))
+    platforms = config.get("platforms") if isinstance(config.get("platforms"), dict) else {}
+    platforms_slack = platforms.get("slack") if isinstance(platforms.get("slack"), dict) else {}
+    candidates.append(platforms_slack.get("async_routing"))
+    extra = platforms_slack.get("extra") if isinstance(platforms_slack.get("extra"), dict) else {}
+    candidates.append(extra.get("async_routing"))
+
+    merged: dict[str, Any] = {}
+    for candidate in candidates:
+        if isinstance(candidate, dict):
+            merged.update(candidate)
+    return merged
+
+
+def policy_from_config(config: Optional[dict[str, Any]]) -> SlackAsyncPolicy:
+    config = config if isinstance(config, dict) else {}
+    block = _policy_block(config)
+    kanban_cfg = config.get("kanban") if isinstance(config.get("kanban"), dict) else {}
+
+    project_assignee = str(
+        block.get("project_assignee")
+        or block.get("kanban_assignee")
+        or kanban_cfg.get("default_assignee")
+        or ""
+    ).strip()
+
+    def markers(name: str, default: tuple[str, ...]) -> tuple[str, ...]:
+        if name in block:
+            base = _string_tuple(block.get(name), default)
+        else:
+            base = default
+        extra = _string_tuple(block.get(f"additional_{name}"))
+        return tuple(dict.fromkeys([*base, *extra]))
+
+    return SlackAsyncPolicy(
+        enabled=_boolish(block.get("enabled"), True),
+        foreground_max_iterations=_intish(
+            block.get("foreground_max_iterations"),
+            6,
+            minimum=1,
+        ),
+        async_on_budget_exceeded=_boolish(
+            block.get("async_on_budget_exceeded"),
+            True,
+        ),
+        long_word_threshold=_intish(block.get("long_word_threshold"), 55, minimum=1),
+        project_routing=str(block.get("project_routing") or "auto").strip().lower(),
+        project_assignee=project_assignee,
+        project_workspace=str(block.get("project_workspace") or "scratch").strip() or "scratch",
+        project_board=str(block.get("project_board") or block.get("kanban_board") or "").strip(),
+        project_goal=_boolish(block.get("project_goal"), True),
+        project_goal_max_turns=_intish(block.get("project_goal_max_turns"), 12, minimum=1),
+        project_max_runtime=str(block.get("project_max_runtime") or "2h").strip() or "2h",
+        project_skills=_string_tuple(block.get("project_skills")),
+        ad_hoc_ack=str(
+            block.get("ad_hoc_ack")
+            or "I'll take this into the background and report back here."
+        ).strip(),
+        budget_ack=str(
+            block.get("budget_ack")
+            or "This is running past the Slack foreground budget, so I'll continue in the background and report back here."
+        ).strip(),
+        project_ack_prefix=str(block.get("project_ack_prefix") or "Queued for project work").strip(),
+        foreground_prefixes=_string_tuple(
+            block.get("foreground_prefixes"),
+            ("fg:", "quick:", "foreground:"),
+        ),
+        background_prefixes=_string_tuple(
+            block.get("background_prefixes"),
+            ("bg:", "background:", "async:"),
+        ),
+        project_prefixes=_string_tuple(
+            block.get("project_prefixes"),
+            ("project:", "kanban:", "code:"),
+        ),
+        long_markers=markers("long_markers", DEFAULT_LONG_MARKERS),
+        project_markers=markers("project_markers", DEFAULT_PROJECT_MARKERS),
+        quick_markers=markers("quick_markers", DEFAULT_QUICK_MARKERS),
+        control_markers=markers("control_markers", DEFAULT_CONTROL_MARKERS),
+        clarification_markers=markers(
+            "clarification_markers",
+            DEFAULT_CLARIFICATION_MARKERS,
+        ),
+    )
+
+
+def _normalize_text(text: str) -> str:
+    return " ".join(str(text or "").strip().lower().split())
+
+
+def _strip_force_prefix(text: str, prefixes: Iterable[str]) -> tuple[bool, str, str]:
+    raw = str(text or "").lstrip()
+    lowered = raw.lower()
+    for prefix in prefixes:
+        p = str(prefix or "").strip().lower()
+        if p and lowered.startswith(p):
+            return True, raw[len(prefix):].lstrip(), p
+    return False, str(text or ""), ""
+
+
+def _contains_any(normalized: str, markers: Iterable[str]) -> Optional[str]:
+    for marker in markers:
+        needle = _normalize_text(marker)
+        if needle and needle in normalized:
+            return marker
+    return None
+
+
+def classify_slack_intent(
+    text: str,
+    policy: Optional[SlackAsyncPolicy] = None,
+) -> SlackIntentDecision:
+    policy = policy or SlackAsyncPolicy()
+    raw = str(text or "").strip()
+
+    forced, cleaned, prefix = _strip_force_prefix(raw, policy.foreground_prefixes)
+    if forced:
+        return SlackIntentDecision(
+            SlackIntentKind.QUICK,
+            f"forced foreground prefix {prefix}",
+            cleaned,
+            forced=True,
+        )
+    forced, cleaned, prefix = _strip_force_prefix(raw, policy.background_prefixes)
+    if forced:
+        return SlackIntentDecision(
+            SlackIntentKind.LONG_AD_HOC,
+            f"forced background prefix {prefix}",
+            cleaned,
+            forced=True,
+        )
+    forced, cleaned, prefix = _strip_force_prefix(raw, policy.project_prefixes)
+    if forced:
+        return SlackIntentDecision(
+            SlackIntentKind.PROJECT_CODE,
+            f"forced project prefix {prefix}",
+            cleaned,
+            forced=True,
+        )
+
+    normalized = _normalize_text(raw)
+    if not normalized:
+        return SlackIntentDecision(SlackIntentKind.QUICK, "empty text", raw)
+
+    if normalized in {_normalize_text(m) for m in (policy.control_markers or DEFAULT_CONTROL_MARKERS)}:
+        return SlackIntentDecision(SlackIntentKind.CONTROL, "control word", raw)
+    if normalized in {_normalize_text(m) for m in (policy.clarification_markers or DEFAULT_CLARIFICATION_MARKERS)}:
+        return SlackIntentDecision(
+            SlackIntentKind.CLARIFICATION,
+            "clarification reply",
+            raw,
+        )
+
+    quick_marker = _contains_any(normalized, policy.quick_markers or DEFAULT_QUICK_MARKERS)
+    project_marker = _contains_any(normalized, policy.project_markers or DEFAULT_PROJECT_MARKERS)
+    quick_project_question = bool(
+        quick_marker
+        and normalized.startswith(
+            (
+                "how do i ",
+                "how would i ",
+                "how can i ",
+                "what is ",
+                "what does ",
+                "why is ",
+                "why did ",
+                "where is ",
+                "can you explain ",
+                "explain ",
+            )
+        )
+    )
+    if project_marker and not quick_project_question:
+        return SlackIntentDecision(
+            SlackIntentKind.PROJECT_CODE,
+            f"project marker {project_marker!r}",
+            raw,
+        )
+
+    long_marker = _contains_any(normalized, policy.long_markers or DEFAULT_LONG_MARKERS)
+    if long_marker:
+        return SlackIntentDecision(
+            SlackIntentKind.LONG_AD_HOC,
+            f"long marker {long_marker!r}",
+            raw,
+        )
+
+    words = normalized.split()
+    work_verbs = (
+        "investigate",
+        "research",
+        "audit",
+        "analyze",
+        "compare",
+        "summarize",
+        "review",
+        "trace",
+    )
+    if len(words) >= policy.long_word_threshold and any(v in normalized for v in work_verbs):
+        return SlackIntentDecision(
+            SlackIntentKind.LONG_AD_HOC,
+            f"word threshold {len(words)}",
+            raw,
+        )
+
+    return SlackIntentDecision(SlackIntentKind.QUICK, "default quick", raw)
+
+
+def stable_slack_handoff_id(*parts: Any, prefix: str = "slack_bg") -> str:
+    raw = ":".join(str(p or "") for p in parts)
+    digest = hashlib.sha256(raw.encode("utf-8", "surrogatepass")).hexdigest()[:12]
+    return f"{prefix}_{digest}"
+
+
+def slack_idempotency_key(*parts: Any) -> str:
+    raw = ":".join(str(p or "") for p in parts)
+    digest = hashlib.sha256(raw.encode("utf-8", "surrogatepass")).hexdigest()[:24]
+    return f"slack:{digest}"
+
+
+def build_kanban_create_text(
+    *,
+    decision: SlackIntentDecision,
+    policy: SlackAsyncPolicy,
+    chat_id: str,
+    thread_id: str,
+    message_id: str,
+    user_id: str,
+) -> str:
+    """Build a public `/kanban create ...` command for Slack project routing."""
+    body = decision.text.strip()
+    title = body.splitlines()[0].strip() if body else "Slack project task"
+    if len(title) > 140:
+        title = title[:137].rstrip() + "..."
+    idem = slack_idempotency_key(chat_id, thread_id, message_id, body)
+
+    parts: list[str] = ["/kanban"]
+    if policy.project_board:
+        parts.extend(["--board", policy.project_board])
+    parts.extend(["create", title])
+    if body:
+        parts.extend(["--body", body])
+    if policy.project_assignee:
+        parts.extend(["--assignee", policy.project_assignee])
+    if policy.project_workspace:
+        parts.extend(["--workspace", policy.project_workspace])
+    if policy.project_max_runtime:
+        parts.extend(["--max-runtime", policy.project_max_runtime])
+    if policy.project_goal:
+        parts.append("--goal")
+        parts.extend(["--goal-max-turns", str(policy.project_goal_max_turns)])
+    for skill in policy.project_skills:
+        parts.extend(["--skill", skill])
+    if user_id:
+        parts.extend(["--created-by", f"slack:{user_id}"])
+    parts.extend(["--idempotency-key", idem])
+
+    return " ".join(shlex.quote(part) for part in parts)

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2023,6 +2023,25 @@ DEFAULT_CONFIG = {
         "free_response_channels": "",  # Comma-separated channel IDs where bot responds without mention
         "allowed_channels": "",        # If set, bot ONLY responds in these channel IDs (whitelist)
         "channel_prompts": {},         # Per-channel ephemeral system prompts
+        # Keep Slack conversational: quick asks run inline, obvious long asks
+        # acknowledge immediately and continue in the background, and project
+        # work can be promoted into kanban/workers when an assignee is set.
+        "async_routing": {
+            "enabled": True,
+            "foreground_max_iterations": 6,
+            "async_on_budget_exceeded": True,
+            "long_word_threshold": 55,
+            # auto | kanban | background | foreground. auto uses kanban only
+            # when project_assignee/default kanban assignee exists.
+            "project_routing": "auto",
+            "project_assignee": "",
+            "project_workspace": "scratch",
+            "project_board": "",
+            "project_goal": True,
+            "project_goal_max_turns": 12,
+            "project_max_runtime": "2h",
+            "project_skills": [],
+        },
     },
 
     # Discord platform settings (gateway mode)

--- a/tests/gateway/test_slack_async_routing.py
+++ b/tests/gateway/test_slack_async_routing.py
@@ -1,0 +1,199 @@
+import asyncio
+from unittest.mock import AsyncMock
+
+import pytest
+
+from gateway.config import GatewayConfig, Platform, PlatformConfig
+from gateway.platforms.base import MessageEvent, MessageType
+from gateway.run import GatewayRunner
+from gateway.session import SessionSource
+from gateway.slack_intent import (
+    SlackAsyncPolicy,
+    SlackIntentKind,
+    build_kanban_create_text,
+    classify_slack_intent,
+    policy_from_config,
+)
+
+
+def _make_runner():
+    runner = object.__new__(GatewayRunner)
+    runner.config = GatewayConfig(
+        platforms={Platform.SLACK: PlatformConfig(enabled=True, token="xoxb-test")}
+    )
+    runner.adapters = {}
+    runner._background_tasks = set()
+    runner._slack_async_handoffs = {}
+    runner._check_slash_access = lambda _source, _command: None
+    return runner
+
+
+def _make_event(text="research this deeply", message_id="1700000000.000100"):
+    source = SessionSource(
+        platform=Platform.SLACK,
+        chat_id="C123",
+        chat_type="group",
+        user_id="U123",
+        thread_id="1700000000.000000",
+    )
+    return MessageEvent(
+        text=text,
+        message_type=MessageType.TEXT,
+        source=source,
+        message_id=message_id,
+    )
+
+
+def test_slack_intent_classifier_separates_quick_long_project_and_forced_prefixes():
+    policy = SlackAsyncPolicy()
+
+    quick = classify_slack_intent("quick take: why is CI red?", policy)
+    assert quick.kind == SlackIntentKind.QUICK
+
+    long = classify_slack_intent("please do a deep dive on these logs", policy)
+    assert long.kind == SlackIntentKind.LONG_AD_HOC
+
+    short_research = classify_slack_intent("research postgres locks", policy)
+    assert short_research.kind == SlackIntentKind.QUICK
+
+    project_question = classify_slack_intent("why did tests fail in this repo?", policy)
+    assert project_question.kind == SlackIntentKind.QUICK
+
+    project = classify_slack_intent("fix this bug and open a PR", policy)
+    assert project.kind == SlackIntentKind.PROJECT_CODE
+
+    forced = classify_slack_intent("fg: implement is being used hypothetically", policy)
+    assert forced.kind == SlackIntentKind.QUICK
+    assert forced.text == "implement is being used hypothetically"
+    assert forced.forced is True
+
+
+def test_policy_from_config_reads_slack_async_routing_defaults_and_overrides():
+    policy = policy_from_config(
+        {
+            "slack": {
+                "async_routing": {
+                    "foreground_max_iterations": 4,
+                    "project_routing": "background",
+                    "project_assignee": "worker-a",
+                    "project_skills": ["github-pr-workflow"],
+                }
+            }
+        }
+    )
+
+    assert policy.enabled is True
+    assert policy.foreground_max_iterations == 4
+    assert policy.project_routing == "background"
+    assert policy.project_assignee == "worker-a"
+    assert policy.project_skills == ("github-pr-workflow",)
+
+
+@pytest.mark.asyncio
+async def test_long_ad_hoc_slack_intent_acknowledges_and_schedules_background(monkeypatch):
+    runner = _make_runner()
+    event = _make_event("please research this thoroughly in the background")
+    runner._run_background_task = AsyncMock()
+    monkeypatch.setattr(
+        GatewayRunner,
+        "_slack_async_policy_from_config",
+        staticmethod(lambda: SlackAsyncPolicy()),
+    )
+
+    response, decision, _policy = await runner._maybe_route_slack_async_intent(event)
+
+    assert "report back here" in response
+    assert "background" in response
+    assert "Task ID:" in response
+    assert decision.kind == SlackIntentKind.LONG_AD_HOC
+    assert len(runner._background_tasks) == 1
+    await asyncio.gather(*runner._background_tasks)
+    runner._run_background_task.assert_awaited_once()
+    kwargs = runner._run_background_task.await_args.kwargs
+    assert kwargs["event_message_id"] == event.message_id
+
+
+@pytest.mark.asyncio
+async def test_project_intent_can_use_background_mode_without_foreground_block(monkeypatch):
+    runner = _make_runner()
+    event = _make_event("fix this bug and open a PR")
+    runner._run_background_task = AsyncMock()
+    policy = SlackAsyncPolicy(project_routing="background")
+    monkeypatch.setattr(
+        GatewayRunner,
+        "_slack_async_policy_from_config",
+        staticmethod(lambda: policy),
+    )
+
+    response, decision, _policy = await runner._maybe_route_slack_async_intent(event)
+
+    assert "Queued for project work" in response
+    assert "background" in response
+    assert decision.kind == SlackIntentKind.PROJECT_CODE
+    await asyncio.gather(*runner._background_tasks)
+    runner._run_background_task.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_explicit_kanban_project_mode_does_not_silently_fallback(monkeypatch):
+    runner = _make_runner()
+    event = _make_event("fix this bug and open a PR")
+    runner._run_background_task = AsyncMock()
+    policy = SlackAsyncPolicy(project_routing="kanban", project_assignee="worker-a")
+    monkeypatch.setattr(
+        GatewayRunner,
+        "_slack_async_policy_from_config",
+        staticmethod(lambda: policy),
+    )
+    monkeypatch.setattr(runner, "_slack_project_kanban_available", lambda _policy: False)
+
+    response, decision, _policy = await runner._maybe_route_slack_async_intent(event)
+
+    assert "kanban worker routing is not available" in response
+    assert "did not start a background fallback" in response
+    assert decision.kind == SlackIntentKind.PROJECT_CODE
+    assert runner._background_tasks == set()
+    runner._run_background_task.assert_not_called()
+
+
+def test_build_kanban_create_text_preserves_thread_identity_and_idempotency():
+    policy = SlackAsyncPolicy(
+        project_assignee="codex-worker",
+        project_workspace="scratch",
+        project_goal=True,
+        project_skills=("github-pr-workflow",),
+    )
+    decision = classify_slack_intent("fix this bug and open a PR", policy)
+
+    text = build_kanban_create_text(
+        decision=decision,
+        policy=policy,
+        chat_id="C123",
+        thread_id="1700000000.000000",
+        message_id="1700000000.000100",
+        user_id="U123",
+    )
+
+    assert text.startswith("/kanban create")
+    assert "--assignee codex-worker" in text
+    assert "--created-by slack:U123" in text
+    assert "--idempotency-key slack:" in text
+    assert "--skill github-pr-workflow" in text
+
+
+@pytest.mark.asyncio
+async def test_budget_exceeded_slack_quick_turn_hands_off_to_background(monkeypatch):
+    runner = _make_runner()
+    event = _make_event("quickly compare these two options")
+    runner._run_background_task = AsyncMock()
+    policy = SlackAsyncPolicy(foreground_max_iterations=2, async_on_budget_exceeded=True)
+
+    result = {"api_calls": 2, "final_response": "maximum iterations reached", "failed": True}
+    assert runner._slack_budget_exceeded(result, policy) is True
+
+    response = await runner._handoff_slack_budget_exceeded(event, result, policy)
+
+    assert "foreground budget" in response
+    assert "Task ID:" in response
+    await asyncio.gather(*runner._background_tasks)
+    runner._run_background_task.assert_awaited_once()


### PR DESCRIPTION
## Summary
- Add deterministic Slack intent routing for quick vs long ad-hoc vs project/code asks.
- Long ad-hoc Slack asks now acknowledge immediately and continue as gateway background tasks that report back to the originating thread.
- Project/code asks route to kanban/workers when configured, with safe background fallback for auto mode and explicit failure for `project_routing: kanban` when unavailable.
- Add Slack foreground iteration budget so quick asks stay conversational and can be handed off async if they hit the budget.

## Test plan
- `PYTHONPATH=. /tmp/hermes-test-venv/bin/python -m pytest tests/gateway/test_slack_async_routing.py -q -o 'addopts='`
- `PYTHONPATH=. /tmp/hermes-test-venv/bin/python -m pytest tests/gateway/test_slack.py tests/gateway/test_slack_async_routing.py tests/gateway/test_session_race_guard.py tests/gateway/test_background_command.py tests/gateway/test_config.py tests/gateway/test_config_env_bridge_authority.py -q -o 'addopts='`
- `PYTHONPATH=. /tmp/hermes-test-venv/bin/python -m py_compile gateway/slack_intent.py gateway/run.py gateway/config.py hermes_cli/config.py`
- `git diff --check`

Agent-Session: cli-humorbot-slack-async-intent-budget
