### PR TITLE
fix(gateway): honor REQUIRE_MENTION env vars over YAML defaults in extra

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -236,6 +236,31 @@ class Platform(Enum):
 # Used to distinguish real platforms from arbitrary strings.
 _BUILTIN_PLATFORM_VALUES = frozenset(m.value for m in Platform.__members__.values())
 
+# Platforms whose adapters fall back to a *_REQUIRE_MENTION env var when
+# ``require_mention`` is absent from PlatformConfig.extra.  When that env var
+# is already set, the shared-key YAML bridge must not copy the YAML value into
+# extra — otherwise config.yaml defaults (require_mention: true) shadow an
+# explicit .env override (MATRIX_REQUIRE_MENTION=false, etc.).  Regression for
+# #48493.
+_REQUIRE_MENTION_ENV_BY_PLATFORM: dict[Platform, str] = {
+    Platform.MATRIX: "MATRIX_REQUIRE_MENTION",
+    Platform.SLACK: "SLACK_REQUIRE_MENTION",
+    Platform.TELEGRAM: "TELEGRAM_REQUIRE_MENTION",
+    Platform.WHATSAPP: "WHATSAPP_REQUIRE_MENTION",
+    Platform.SIGNAL: "SIGNAL_REQUIRE_MENTION",
+    Platform.DINGTALK: "DINGTALK_REQUIRE_MENTION",
+    Platform.BLUEBUBBLES: "BLUEBUBBLES_REQUIRE_MENTION",
+    Platform.FEISHU: "FEISHU_REQUIRE_MENTION",
+}
+
+
+def _yaml_require_mention_bridges_to_extra(plat: Platform) -> bool:
+    """Return whether YAML ``require_mention`` may be copied into extra."""
+    env_key = _REQUIRE_MENTION_ENV_BY_PLATFORM.get(plat)
+    if env_key and os.getenv(env_key) is not None:
+        return False
+    return True
+
 
 @dataclass
 class HomeChannel:
@@ -949,7 +974,7 @@ def load_gateway_config() -> GatewayConfig:
                     bridged["reply_prefix"] = platform_cfg["reply_prefix"]
                 if "reply_in_thread" in platform_cfg:
                     bridged["reply_in_thread"] = platform_cfg["reply_in_thread"]
-                if "require_mention" in platform_cfg:
+                if "require_mention" in platform_cfg and _yaml_require_mention_bridges_to_extra(plat):
                     bridged["require_mention"] = platform_cfg["require_mention"]
                 if plat == Platform.TELEGRAM and "allowed_chats" in platform_cfg:
                     bridged["allowed_chats"] = platform_cfg["allowed_chats"]

--- a/tests/gateway/test_config.py
+++ b/tests/gateway/test_config.py
@@ -623,6 +623,57 @@ class TestLoadGatewayConfig:
         )
         assert telegram.extra.get("require_mention") is False
 
+    def test_require_mention_env_not_shadowed_by_yaml_in_extra(self, tmp_path, monkeypatch):
+        """Regression #48493: MATRIX_REQUIRE_MENTION=false in .env must work even
+        when config.yaml sets matrix.require_mention: true.
+
+        The shared-key loop used to always copy the YAML value into
+        PlatformConfig.extra, so adapters read extra first and ignored the env
+        override that users set in .env.
+        """
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        config_path = hermes_home / "config.yaml"
+        config_path.write_text(
+            "matrix:\n"
+            "  require_mention: true\n",
+            encoding="utf-8",
+        )
+
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.setenv("MATRIX_REQUIRE_MENTION", "false")
+        monkeypatch.setenv("MATRIX_ACCESS_TOKEN", "syt_test")
+        monkeypatch.setenv("MATRIX_HOMESERVER", "https://matrix.example.org")
+
+        config = load_gateway_config()
+
+        matrix = config.platforms[Platform.MATRIX]
+        assert matrix.extra.get("require_mention") is None
+        from gateway.platforms.matrix import MatrixAdapter
+
+        assert MatrixAdapter(matrix)._require_mention is False
+
+    def test_require_mention_yaml_still_bridges_when_env_unset(self, tmp_path, monkeypatch):
+        """Explicit YAML require_mention must still reach extra when no env override."""
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        config_path = hermes_home / "config.yaml"
+        config_path.write_text(
+            "matrix:\n"
+            "  require_mention: false\n",
+            encoding="utf-8",
+        )
+
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.delenv("MATRIX_REQUIRE_MENTION", raising=False)
+        monkeypatch.setenv("MATRIX_ACCESS_TOKEN", "syt_test")
+        monkeypatch.setenv("MATRIX_HOMESERVER", "https://matrix.example.org")
+
+        config = load_gateway_config()
+
+        matrix = config.platforms[Platform.MATRIX]
+        assert matrix.extra.get("require_mention") is False
+
     def test_bridges_quoted_false_session_notify_from_config_yaml(self, tmp_path, monkeypatch):
         hermes_home = tmp_path / ".hermes"
         hermes_home.mkdir()


### PR DESCRIPTION
## Summary
- Fix `MATRIX_REQUIRE_MENTION=false` (and sibling `*_REQUIRE_MENTION` env vars) being ignored when `config.yaml` sets `require_mention: true`
- Root cause: the shared-key YAML bridge always copied `require_mention` into `PlatformConfig.extra`, and platform adapters read `extra` before falling back to the env var
- Skip bridging `require_mention` into `extra` when the platform's env override is already set, so the adapter's env fallback path is used

Fixes #48493

## Why this is likely the reported bug
The reporter set `MATRIX_REQUIRE_MENTION=false` in `.env` and restarted the gateway, but group rooms still required @mentions. Gateway logs already document the env var (`set MATRIX_REQUIRE_MENTION=false to disable`), and the yaml→env bridge correctly preserves an existing env value — but the parallel yaml→extra bridge shadowed it.

## Test plan
- [x] Smoke-tested `load_gateway_config()` + `MatrixAdapter._require_mention` with yaml `true` + env `false`
- [ ] `scripts/run_tests.sh tests/gateway/test_config.py::TestLoadGatewayConfig::test_require_mention_env_not_shadowed_by_yaml_in_extra`
- [ ] `scripts/run_tests.sh tests/gateway/test_config.py::TestLoadGatewayConfig::test_require_mention_yaml_still_bridges_when_env_unset`
- [ ] `scripts/run_tests.sh tests/gateway/test_matrix.py::TestMatrixRequireMention`
- [ ] Manual: set `MATRIX_REQUIRE_MENTION=false` in `.env` with default `matrix.require_mention: true` in config, restart gateway, confirm unmentioned group messages are processed


Made with [Cursor](https://cursor.com)