### PR TITLE
fix(desktop): open chat file/media links that are relative, ~, or have special chars

### DIFF
--- a/apps/desktop/electron/main.cjs
+++ b/apps/desktop/electron/main.cjs
@@ -35,6 +35,7 @@ const {
 } = require('./session-windows.cjs')
 const { canImportHermesCli, verifyHermesCli } = require('./backend-probes.cjs')
 const { probeGatewayWebSocket } = require('./gateway-ws-probe.cjs')
+const { classifyOpenTarget } = require('./open-target.cjs')
 const { adoptServedDashboardToken } = require('./dashboard-token.cjs')
 const { waitForDashboardPort } = require('./backend-ready.cjs')
 const { serializeJsonBody, setJsonRequestHeaders } = require('./oauth-net-request.cjs')
@@ -834,54 +835,22 @@ function rememberLog(chunk) {
 }
 
 function openExternalUrl(rawUrl) {
-  const raw = String(rawUrl || '').trim()
-  if (!raw) return false
+  // Pure classification (parse + scheme rules) lives in open-target.cjs so it's
+  // unit-testable without Electron; the side-effecting shell.* calls stay here.
+  const target = classifyOpenTarget(rawUrl)
 
-  let parsed
-  try {
-    parsed = new URL(raw)
-  } catch {
+  if (target.kind === 'reject') {
     return false
   }
 
-  // `file://` URLs come from the artifacts panel (the renderer can't open
-  // them itself because Chromium blocks file:// navigation from the app
-  // origin). Hand them to `shell.openPath`, which dispatches to the OS
-  // file association. If the OS can't open it (`error` is a non-empty
-  // string), fall back to revealing the file in the system file manager.
-  if (parsed.protocol === 'file:') {
-    let localPath
-    try {
-      localPath = resolveRequestedPathForIpc(parsed.toString(), { purpose: 'Open external file' })
-    } catch {
-      return false
-    }
-
-    void shell
-      .openPath(localPath)
-      .then(error => {
-        if (!error) {
-          return
-        }
-
-        rememberLog(`[file] openPath failed: ${error}; revealing in folder instead`)
-
-        try {
-          shell.showItemInFolder(localPath)
-        } catch (revealError) {
-          rememberLog(`[file] showItemInFolder failed: ${revealError.message}`)
-        }
-      })
-      .catch(error => rememberLog(`[file] openPath rejected: ${error.message}`))
-
-    return true
+  // `file://` URLs (artifacts panel) and scheme-less local paths (relative or
+  // `~`, which the renderer can't safely turn into a file:// URL) both open via
+  // shell.openPath, which dispatches to the OS file association.
+  if (target.kind === 'file') {
+    return openLocalFilePath(target.path)
   }
 
-  if (!['http:', 'https:', 'mailto:'].includes(parsed.protocol)) {
-    return false
-  }
-
-  const url = parsed.toString()
+  const url = target.url
 
   if (IS_WSL) {
     rememberLog(`[link] opening via WSL→Windows: ${url}`)
@@ -900,6 +869,37 @@ function openExternalUrl(rawUrl) {
   }
 
   shell.openExternal(url).catch(error => rememberLog(`[link] openExternal failed: ${error.message}`))
+
+  return true
+}
+
+// Open a local file (file:// URL or a plain/relative/~ path) via the OS file
+// association, falling back to revealing it in the file manager if the OS
+// can't open it. Returns false only when the path can't be resolved at all.
+function openLocalFilePath(pathOrFileUrl) {
+  let localPath
+  try {
+    localPath = resolveRequestedPathForIpc(pathOrFileUrl, { purpose: 'Open external file' })
+  } catch {
+    return false
+  }
+
+  void shell
+    .openPath(localPath)
+    .then(error => {
+      if (!error) {
+        return
+      }
+
+      rememberLog(`[file] openPath failed: ${error}; revealing in folder instead`)
+
+      try {
+        shell.showItemInFolder(localPath)
+      } catch (revealError) {
+        rememberLog(`[file] showItemInFolder failed: ${revealError.message}`)
+      }
+    })
+    .catch(error => rememberLog(`[file] openPath rejected: ${error.message}`))
 
   return true
 }

--- a/apps/desktop/electron/open-target.cjs
+++ b/apps/desktop/electron/open-target.cjs
@@ -1,0 +1,60 @@
+/**
+ * Pure classification for "what does this href mean when the user clicks /
+ * opens it" — the decision half of main.cjs's openExternalUrl, split out so it
+ * can be unit-tested without an Electron runtime (shell.openPath / openExternal
+ * stay in main.cjs as the side-effecting half).
+ *
+ * Returns one of:
+ *   { kind: 'file',  path }   — a local file to hand to shell.openPath. `path`
+ *                               is a file:// URL string OR a raw scheme-less
+ *                               path (relative / ~), both of which
+ *                               resolveRequestedPathForIpc accepts.
+ *   { kind: 'web',   url }    — an http/https/mailto URL for shell.openExternal.
+ *   { kind: 'reject' }        — empty, or a URL with an unknown scheme.
+ *
+ * Why scheme-less paths matter: the renderer cannot always build a file:// URL
+ * for a media link. A relative path (`out/a.png`) or a `~/...` path has no
+ * cwd/home in the renderer, and `file://<relative>` mis-parses the first
+ * segment as a URL host (rejected on macOS/Linux). Those arrive here raw and
+ * are classified as files so the main process can resolve them against a real
+ * base. See lib/media.ts::toLocalFileUrl for the renderer side.
+ */
+
+const WEB_PROTOCOLS = new Set(['http:', 'https:', 'mailto:'])
+
+// A scheme-less, non-URL string that looks like a local path (relative or ~).
+// We deliberately reject strings that DO carry a `scheme://` so a genuinely
+// broken or unknown-scheme link can't masquerade as a file path.
+const HAS_URL_SCHEME_RE = /^[a-z][a-z0-9+.-]*:\/\//i
+
+function classifyOpenTarget(rawUrl) {
+  const raw = String(rawUrl == null ? '' : rawUrl).trim()
+  if (!raw) {
+    return { kind: 'reject' }
+  }
+
+  let parsed
+  try {
+    parsed = new URL(raw)
+  } catch {
+    // Not a parseable URL. Treat a scheme-less string as a local path; reject
+    // anything that still looks like `scheme://...` (unknown/broken scheme).
+    if (HAS_URL_SCHEME_RE.test(raw)) {
+      return { kind: 'reject' }
+    }
+
+    return { kind: 'file', path: raw }
+  }
+
+  if (parsed.protocol === 'file:') {
+    return { kind: 'file', path: parsed.toString() }
+  }
+
+  if (WEB_PROTOCOLS.has(parsed.protocol)) {
+    return { kind: 'web', url: parsed.toString() }
+  }
+
+  return { kind: 'reject' }
+}
+
+module.exports = { classifyOpenTarget }

--- a/apps/desktop/electron/open-target.test.cjs
+++ b/apps/desktop/electron/open-target.test.cjs
@@ -1,0 +1,84 @@
+/**
+ * Tests for electron/open-target.cjs.
+ *
+ * Run with: node --test electron/open-target.test.cjs
+ * (Wired into npm test:desktop:platforms in package.json.)
+ *
+ * classifyOpenTarget is the pure decision behind main.cjs::openExternalUrl —
+ * it decides whether an href is a local file (shell.openPath), a web URL
+ * (shell.openExternal), or should be rejected. This is the main-process half
+ * of the "chat file link is a silent dead end" fix.
+ */
+
+const test = require('node:test')
+const assert = require('node:assert/strict')
+
+const { classifyOpenTarget } = require('./open-target.cjs')
+
+test('rejects empty / nullish input', () => {
+  assert.deepEqual(classifyOpenTarget(''), { kind: 'reject' })
+  assert.deepEqual(classifyOpenTarget('   '), { kind: 'reject' })
+  assert.deepEqual(classifyOpenTarget(null), { kind: 'reject' })
+  assert.deepEqual(classifyOpenTarget(undefined), { kind: 'reject' })
+})
+
+test('classifies http/https/mailto as web', () => {
+  assert.deepEqual(classifyOpenTarget('https://example.com/a'), {
+    kind: 'web',
+    url: 'https://example.com/a'
+  })
+  assert.equal(classifyOpenTarget('http://example.com').kind, 'web')
+  assert.equal(classifyOpenTarget('mailto:me@example.com').kind, 'web')
+})
+
+test('classifies a file:// URL as file, preserving encoded special chars', () => {
+  // The renderer now percent-encodes path segments; we must NOT lose them.
+  const res = classifyOpenTarget('file:///tmp/weird%23name%3F.png')
+  assert.equal(res.kind, 'file')
+  assert.equal(res.path, 'file:///tmp/weird%23name%3F.png')
+})
+
+test('classifies a file:// URL with spaces as file', () => {
+  const res = classifyOpenTarget('file:///Users/c/Application%20Support/x.png')
+  assert.equal(res.kind, 'file')
+  assert.equal(res.path, 'file:///Users/c/Application%20Support/x.png')
+})
+
+test('classifies a scheme-less RELATIVE path as file (raw, for main to resolve)', () => {
+  // The screenshot case: the renderer hands these over raw because
+  // file://<relative> mis-parses the filename as a URL host.
+  assert.deepEqual(classifyOpenTarget('hermes-support-slack.png'), {
+    kind: 'file',
+    path: 'hermes-support-slack.png'
+  })
+  assert.deepEqual(classifyOpenTarget('out/report.png'), {
+    kind: 'file',
+    path: 'out/report.png'
+  })
+})
+
+test('classifies a ~ path as file (raw, for main to expand home)', () => {
+  assert.deepEqual(classifyOpenTarget('~/Desktop/foo.png'), {
+    kind: 'file',
+    path: '~/Desktop/foo.png'
+  })
+})
+
+test('classifies an absolute POSIX path as file', () => {
+  assert.deepEqual(classifyOpenTarget('/var/log/x.txt'), {
+    kind: 'file',
+    path: '/var/log/x.txt'
+  })
+})
+
+test('rejects an unknown URL scheme (cannot masquerade as a path)', () => {
+  // Guards against e.g. custom-protocol abuse: a real scheme://... that we
+  // don't allow must reject, not fall through to openPath.
+  assert.deepEqual(classifyOpenTarget('bitbrowser://open?x=1'), { kind: 'reject' })
+  assert.deepEqual(classifyOpenTarget('javascript://alert(1)'), { kind: 'reject' })
+})
+
+test('trims surrounding whitespace before classifying', () => {
+  assert.equal(classifyOpenTarget('  https://example.com  ').kind, 'web')
+  assert.deepEqual(classifyOpenTarget('  ./a.png  '), { kind: 'file', path: './a.png' })
+})

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -37,7 +37,7 @@
     "test:desktop:nsis": "node scripts/test-desktop.mjs nsis",
     "test:desktop:existing": "node scripts/test-desktop.mjs existing",
     "test:desktop:fresh": "node scripts/test-desktop.mjs fresh",
-    "test:desktop:platforms": "node --test electron/bootstrap-platform.test.cjs electron/hardening.test.cjs electron/backend-env.test.cjs electron/backend-probes.test.cjs electron/bootstrap-runner.test.cjs electron/connection-config.test.cjs electron/dashboard-token.test.cjs electron/gateway-ws-probe.test.cjs electron/oauth-net-request.test.cjs electron/desktop-uninstall.test.cjs electron/session-windows.test.cjs electron/workspace-cwd.test.cjs electron/fs-read-dir.test.cjs electron/git-root.test.cjs electron/windows-child-process.test.cjs electron/update-remote.test.cjs electron/update-rebuild.test.cjs electron/windows-user-env.test.cjs",
+    "test:desktop:platforms": "node --test electron/bootstrap-platform.test.cjs electron/hardening.test.cjs electron/backend-env.test.cjs electron/backend-probes.test.cjs electron/bootstrap-runner.test.cjs electron/connection-config.test.cjs electron/dashboard-token.test.cjs electron/gateway-ws-probe.test.cjs electron/oauth-net-request.test.cjs electron/desktop-uninstall.test.cjs electron/session-windows.test.cjs electron/workspace-cwd.test.cjs electron/fs-read-dir.test.cjs electron/git-root.test.cjs electron/windows-child-process.test.cjs electron/update-remote.test.cjs electron/update-rebuild.test.cjs electron/windows-user-env.test.cjs electron/open-target.test.cjs",
     "typecheck": "tsc -p . --noEmit",
     "lint": "eslint src/ electron/",
     "lint:fix": "eslint src/ electron/ --fix",

--- a/apps/desktop/src/lib/media.remote.test.ts
+++ b/apps/desktop/src/lib/media.remote.test.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { $connection } from '@/store/session'
 
-import { filePathFromMediaPath, gatewayMediaDataUrl, isRemoteGateway, mediaExternalUrl } from './media'
+import { filePathFromMediaPath, gatewayMediaDataUrl, isRemoteGateway, mediaExternalUrl, toLocalFileUrl } from './media'
 
 describe('isRemoteGateway', () => {
   afterEach(() => {
@@ -86,5 +86,65 @@ describe('gatewayMediaDataUrl', () => {
     expect(api).toHaveBeenCalledWith({
       path: '/api/media?path=%2Fhome%2Fu%2F.hermes%2Fimages%2Fa%20b.png'
     })
+  })
+})
+
+describe('toLocalFileUrl', () => {
+  // Round-trip every produced file:// URL through the same WHATWG parser the
+  // Electron main process uses (`new URL` + fileURLToPath), asserting the path
+  // survives intact. This is the regression guard for the "chat file link is a
+  // silent dead end" bug.
+  const roundTrip = (fileUrl: string): string => {
+    const u = new URL(fileUrl)
+    // Mirror Node's fileURLToPath for the POSIX cases under test.
+    return decodeURIComponent(u.pathname)
+  }
+
+  it('encodes a plain absolute path (unchanged for simple paths)', () => {
+    expect(toLocalFileUrl('/tmp/a.png')).toBe('file:///tmp/a.png')
+    expect(roundTrip('file:///tmp/a.png')).toBe('/tmp/a.png')
+  })
+
+  it('preserves spaces in an absolute path (Application Support case)', () => {
+    const p = '/Users/cary/Library/Application Support/Hermes/x.png'
+    const url = toLocalFileUrl(p)
+
+    expect(url).toBe('file:///Users/cary/Library/Application%20Support/Hermes/x.png')
+    expect(roundTrip(url)).toBe(p)
+  })
+
+  it('preserves URL-special characters instead of truncating at # or ?', () => {
+    // Old `file://${path}` concat truncated this to `/tmp/weird` (the rest was
+    // parsed as fragment/query) — the shell then opened the wrong file.
+    const p = '/tmp/weird#name?.png'
+    const url = toLocalFileUrl(p)
+
+    expect(url).toBe('file:///tmp/weird%23name%3F.png')
+    expect(roundTrip(url)).toBe(p)
+  })
+
+  it('preserves unicode characters', () => {
+    const p = '/tmp/café.png'
+    expect(roundTrip(toLocalFileUrl(p))).toBe(p)
+  })
+
+  it('passes a file:// URL through unchanged', () => {
+    expect(toLocalFileUrl('file:///tmp/a.png')).toBe('file:///tmp/a.png')
+  })
+
+  it('returns a RELATIVE path raw (main process resolves it, never file://<host>)', () => {
+    // The screenshot case: `file://hermes-support-slack.png` would parse the
+    // filename as a host and get rejected. Raw passthrough lets the main
+    // process resolve it against the session cwd.
+    expect(toLocalFileUrl('hermes-support-slack.png')).toBe('hermes-support-slack.png')
+    expect(toLocalFileUrl('out/report.png')).toBe('out/report.png')
+  })
+
+  it('returns a ~ path raw (main process expands the home dir)', () => {
+    expect(toLocalFileUrl('~/Desktop/foo.png')).toBe('~/Desktop/foo.png')
+  })
+
+  it('builds a canonical file URL for a Windows drive path', () => {
+    expect(toLocalFileUrl('C:\\Users\\me\\a b.png')).toBe('file:///C:/Users/me/a%20b.png')
   })
 })

--- a/apps/desktop/src/lib/media.ts
+++ b/apps/desktop/src/lib/media.ts
@@ -56,6 +56,59 @@ export function mediaMarkdownHref(path: string): string {
   return `#media:${encodeURIComponent(path)}`
 }
 
+// Build a `file://` URL from a local absolute path with per-segment encoding.
+//
+// The old `file://${path}` string concat broke three ways, all of which made a
+// chat link a silent dead end (the main process rejects the malformed URL and
+// the click/copy does nothing):
+//   1. A path with URL-special chars (`#`, `?`, spaces) was truncated at the
+//      first `#`/`?` — `new URL('file:///tmp/a#b.png')` drops `#b.png` as a
+//      fragment, so the shell opened the wrong path (or ENOENT'd).
+//   2. A RELATIVE path (`hermes-support-slack.png`) became
+//      `file://hermes-support-slack.png`, where the filename is parsed as the
+//      URL *host* — rejected on macOS/Linux ("file URL host must be empty").
+//   3. A `~/...` path hit the same host-parse failure.
+//
+// Per-segment `encodeURIComponent` keeps each path component intact (spaces,
+// `#`, `?`, unicode all survive a `new URL()` round-trip). Relative and `~`
+// paths are returned RAW so the main process can resolve them with a real
+// home-dir/cwd base (`resolveRequestedPathForIpc`) — `new URL` can't.
+export function toLocalFileUrl(path: string): string {
+  if (/^file:/i.test(path)) {
+    return path
+  }
+
+  // Normalize Windows separators so segment-splitting is uniform.
+  let p = path.replace(/\\/g, '/')
+
+  // Windows drive path (`C:/...`) → `/C:/...` so it parses as an absolute
+  // file URL. The drive-letter colon stays literal (canonical Node form).
+  const driveMatch = /^([a-zA-Z]):(\/.*)?$/.exec(p)
+
+  if (driveMatch) {
+    const rest = (driveMatch[2] ?? '/')
+      .split('/')
+      .map(seg => encodeURIComponent(seg))
+      .join('/')
+
+    return `file:///${driveMatch[1]}:${rest}`
+  }
+
+  // Relative or tilde path: the renderer can't resolve it (no cwd/home), and
+  // `file://<relative>` mis-parses the first segment as a host. Hand the raw
+  // path to the main process, which expands `~` and resolves against a base.
+  if (!p.startsWith('/')) {
+    return p
+  }
+
+  const encoded = p
+    .split('/')
+    .map(seg => encodeURIComponent(seg))
+    .join('/')
+
+  return `file://${encoded}`
+}
+
 // Resolve a media path to a URL the shell can open. Remote mode rewrites
 // gateway-local paths to an authenticated /api/files/download URL (the file
 // lives on the gateway, not this disk); local mode keeps the file:// form.
@@ -74,7 +127,7 @@ export function mediaExternalUrl(path: string): string {
     }
   }
 
-  return /^file:/i.test(path) ? path : `file://${path}`
+  return toLocalFileUrl(path)
 }
 
 // Custom Electron scheme (registered in electron/main.cjs) that streams a local


### PR DESCRIPTION
## Problem

Clicking (or copying) a file/media link in the desktop chat transcript is a **silent dead end** for three path shapes. Reproduced on macOS (Electron 40); `~/.hermes/logs/desktop.log` shows repeated `[file] openPath failed: Failed to open path`.

All three stem from `mediaExternalUrl`'s naive `file://${path}` string concatenation:

1. **Absolute path with URL-special chars** (`#`, `?`, spaces) — `new URL('file:///tmp/a#b.png')` drops `#b.png` as a fragment, so the path is truncated and the shell opens the wrong file (or ENOENTs).
2. **Relative path** (e.g. a generated `hermes-support-slack.png`) — becomes `file://hermes-support-slack.png`, where the filename parses as the URL **host**, rejected on macOS/Linux (`file URL host must be "localhost" or empty`). The `openExternal` IPC then throws "Invalid external URL" and the click does nothing.
3. **`~/...` path** — same host-parse failure.

Copying such a link and pasting into a browser also fails, since the copied `file://…` string is itself malformed.

## Fix

**Renderer (`apps/desktop/src/lib/media.ts`)** — new `toLocalFileUrl()`:
- Per-segment `encodeURIComponent`, so spaces / `#` / `?` / unicode survive a `new URL()` round-trip.
- Relative and `~` paths are returned **raw** — the renderer has no cwd/home to resolve them, and `file://<relative>` mis-parses; the main process is the right place to resolve them.
- Canonical handling for Windows drive paths.

**Main (`apps/desktop/electron/main.cjs`)**:
- Extracted the parse/scheme decision into a pure, unit-testable `electron/open-target.cjs` (`classifyOpenTarget` → file / web / reject).
- Added a scheme-less local-path branch: relative/`~` paths now resolve via the existing `resolveRequestedPathForIpc` (expands `~`, resolves against a base) and open with `shell.openPath`.
- Unknown `scheme://` links still reject, so a broken/custom-scheme link can't masquerade as a path.

## Tests

- `media.remote.test.ts` (+8): round-trips every produced file URL through the WHATWG parser, asserting the path survives intact (spaces, `#`/`?`, unicode), plus raw passthrough for relative/`~` and canonical Windows drive URLs.
- `open-target.test.cjs` (new, 9 tests): web / file / relative / tilde / unknown-scheme / empty classification. Wired into `test:desktop:platforms`.
- `tsc --noEmit` clean. Renderer + platforms suites green (the one failing `windows-child-process` test is pre-existing on `main` and unrelated — it is a Windows-only test running on a macOS host).
- **Verified end-to-end in a real Electron context**: all three previously-dead link types resolve to the correct on-disk file and the OS open call succeeds.
