### PR TITLE
feat(tools): add stub_mode to reduce main-thread tool schema tokens

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -957,7 +957,11 @@ def init_agent(
     _tool_stub_mode = False
     try:
         from hermes_cli.config import load_config as _load_tools_cfg
-        _tool_stub_mode = bool(cfg_get(_load_tools_cfg(), "tools", "stub_mode", default=False))
+        # Subagents must always receive full schemas — stub_mode is a main-thread
+        # context optimisation and the delegate_task contract requires that
+        # subagents can actually invoke the tools they're handed.
+        if platform != "subagent":
+            _tool_stub_mode = bool(cfg_get(_load_tools_cfg(), "tools", "stub_mode", default=False))
     except Exception:
         pass
     agent.tools = _ra().get_tool_definitions(

--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -954,10 +954,16 @@ def init_agent(
                   " → ".join(f"{f['model']} ({f['provider']})" for f in agent._fallback_chain))
 
     # Get available tools with filtering
+    _tool_stub_mode = bool(
+        cfg_get(agent_cfg, "tools", "stub_mode", default=False)
+        if isinstance(agent_cfg, dict)
+        else False
+    )
     agent.tools = _ra().get_tool_definitions(
         enabled_toolsets=enabled_toolsets,
         disabled_toolsets=disabled_toolsets,
         quiet_mode=agent.quiet_mode,
+        stub_mode=_tool_stub_mode,
     )
     
     # Show tool configuration and store valid tool names for validation

--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -954,11 +954,12 @@ def init_agent(
                   " → ".join(f"{f['model']} ({f['provider']})" for f in agent._fallback_chain))
 
     # Get available tools with filtering
-    _tool_stub_mode = bool(
-        cfg_get(agent_cfg, "tools", "stub_mode", default=False)
-        if isinstance(agent_cfg, dict)
-        else False
-    )
+    _tool_stub_mode = False
+    try:
+        from hermes_cli.config import load_config as _load_tools_cfg
+        _tool_stub_mode = bool(cfg_get(_load_tools_cfg(), "tools", "stub_mode", default=False))
+    except Exception:
+        pass
     agent.tools = _ra().get_tool_definitions(
         enabled_toolsets=enabled_toolsets,
         disabled_toolsets=disabled_toolsets,

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2215,7 +2215,8 @@ DEFAULT_CONFIG = {
         # invocations through delegate_task.  Tools in _STUB_MODE_FULL_TOOLS
         # (delegate_task, memory, skills_list, skill_view, skill_manage, clarify,
         # send_message, session_search, todo, cronjob) always keep full schemas.
-        # Saves ~8–10k tokens per call on a typical 29-tool load.
+        # Saves ~2,750 tokens/call (~21%) on a typical 30-tool load; scales
+        # further with each MCP tool added.
         "stub_mode": False,
         "tool_search": {
             # "auto" (default) — activate only when deferrable tool schemas

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2210,6 +2210,13 @@ DEFAULT_CONFIG = {
     # See tools/tool_search.py for full design notes and the
     # openclaw-tool-search-report PDF in this PR for the rationale.
     "tools": {
+        # When true, non-core tool schemas are reduced to name+description stubs.
+        # The main agent can plan and delegate but must route actual tool
+        # invocations through delegate_task.  Tools in _STUB_MODE_FULL_TOOLS
+        # (delegate_task, memory, skills_list, skill_view, skill_manage, clarify,
+        # send_message, session_search, todo, cronjob) always keep full schemas.
+        # Saves ~8–10k tokens per call on a typical 29-tool load.
+        "stub_mode": False,
         "tool_search": {
             # "auto" (default) — activate only when deferrable tool schemas
             #   exceed ``threshold_pct`` of the active model's context length,

--- a/model_tools.py
+++ b/model_tools.py
@@ -307,6 +307,9 @@ def _apply_stub_mode(tools: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
                 "function": {
                     "name": name,
                     "description": f"{desc} [stub — use delegate_task to invoke]",
+                    # Minimal valid parameters shape so strict-schema validators
+                    # and provider sanitizers don't reject the tool entry.
+                    "parameters": {"type": "object", "properties": {}},
                 },
             })
     return result
@@ -567,7 +570,13 @@ def _compute_tool_definitions(
     try:
         from tools.tool_search import assemble_tool_defs, load_config as _load_ts_config
         ts_cfg = _load_ts_config()
-        if not skip_tool_search_assembly and ts_cfg.enabled != "off":
+        # stub_mode and Tool Search both reduce main-thread token overhead via
+        # different mechanisms.  Running them together would hide tools behind
+        # tool_search proxies before stubs are applied, breaking the "main agent
+        # can see every tool for planning" contract.  Bypass Tool Search when
+        # stub_mode is active so the full catalog is available to be stubbed.
+        effective_skip_tsa = skip_tool_search_assembly or stub_mode
+        if not effective_skip_tsa and ts_cfg.enabled != "off":
             context_length = _resolve_active_context_length()
             assembly = assemble_tool_defs(
                 filtered_tools,

--- a/model_tools.py
+++ b/model_tools.py
@@ -272,7 +272,7 @@ def _clear_tool_defs_cache() -> None:
 # Tools that always receive full schemas in stub mode — the main agent calls
 # these directly to think, remember, and delegate.  Everything else is reduced
 # to a name+description stub so the model routes tool use through delegate_task.
-_STUB_MODE_FULL_TOOLS: frozenset = frozenset({
+_STUB_MODE_FULL_TOOLS: frozenset[str] = frozenset({
     "delegate_task",
     "memory",
     "skills_list",

--- a/model_tools.py
+++ b/model_tools.py
@@ -269,11 +269,55 @@ def _clear_tool_defs_cache() -> None:
     _tool_defs_cache.clear()
 
 
+# Tools that always receive full schemas in stub mode — the main agent calls
+# these directly to think, remember, and delegate.  Everything else is reduced
+# to a name+description stub so the model routes tool use through delegate_task.
+_STUB_MODE_FULL_TOOLS: frozenset = frozenset({
+    "delegate_task",
+    "memory",
+    "skills_list",
+    "skill_view",
+    "skill_manage",
+    "clarify",
+    "send_message",
+    "session_search",
+    "todo",
+    "cronjob",
+})
+
+
+def _apply_stub_mode(tools: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    """Replace full schemas with name+description stubs for non-core tools.
+
+    The main agent can still *see* every tool (for planning / delegation), but
+    can only invoke the ones in ``_STUB_MODE_FULL_TOOLS`` directly.  All others
+    must be reached via ``delegate_task``, keeping the main conversation thread
+    free of tool-call and parameter noise.
+    """
+    result = []
+    for tool in tools:
+        fn = tool.get("function", {})
+        name = fn.get("name", "")
+        if name in _STUB_MODE_FULL_TOOLS:
+            result.append(tool)
+        else:
+            desc = fn.get("description", "")
+            result.append({
+                "type": "function",
+                "function": {
+                    "name": name,
+                    "description": f"{desc} [stub — use delegate_task to invoke]",
+                },
+            })
+    return result
+
+
 def get_tool_definitions(
     enabled_toolsets: Optional[List[str]] = None,
     disabled_toolsets: Optional[List[str]] = None,
     quiet_mode: bool = False,
     skip_tool_search_assembly: bool = False,
+    stub_mode: bool = False,
 ) -> List[Dict[str, Any]]:
     """
     Get tool definitions for model API calls with toolset-based filtering.
@@ -289,6 +333,10 @@ def get_tool_definitions(
             tool_search / tool_describe bridge handlers so they can read the
             real catalog, not the already-collapsed one. Public callers should
             leave this False.
+        stub_mode: When True, reduce non-core tool schemas to name+description
+            stubs.  The main agent can see every tool for planning but must
+            route actual invocations through ``delegate_task``.  Tools in
+            ``_STUB_MODE_FULL_TOOLS`` always receive their full schema.
 
     Returns:
         Filtered list of OpenAI-format tool definitions.
@@ -316,6 +364,7 @@ def get_tool_definitions(
             cfg_fp,
             bool(os.environ.get("HERMES_KANBAN_TASK")),
             bool(skip_tool_search_assembly),
+            bool(stub_mode),
         )
         cached = _tool_defs_cache.get(cache_key)
         if cached is not None:
@@ -328,7 +377,8 @@ def get_tool_definitions(
             return list(cached)
 
     result = _compute_tool_definitions(enabled_toolsets, disabled_toolsets, quiet_mode,
-                                       skip_tool_search_assembly=skip_tool_search_assembly)
+                                       skip_tool_search_assembly=skip_tool_search_assembly,
+                                       stub_mode=stub_mode)
     if quiet_mode:
         # Cache the freshly-computed list, but hand callers a shallow copy so
         # downstream mutations (e.g. run_agent appending memory/LCM tool
@@ -352,6 +402,7 @@ def _compute_tool_definitions(
     disabled_toolsets: Optional[List[str]] = None,
     quiet_mode: bool = False,
     skip_tool_search_assembly: bool = False,
+    stub_mode: bool = False,
 ) -> List[Dict[str, Any]]:
     """Uncached implementation of :func:`get_tool_definitions`."""
     # Determine which tool names the caller wants
@@ -532,6 +583,15 @@ def _compute_tool_definitions(
             filtered_tools = assembly.tool_defs
     except Exception as e:  # pragma: no cover — never break tool loading
         logger.warning("Tool search assembly skipped: %s", e)
+
+    if stub_mode and not skip_tool_search_assembly:
+        filtered_tools = _apply_stub_mode(filtered_tools)
+        if not quiet_mode:
+            stubbed = sum(
+                1 for t in filtered_tools
+                if t.get("function", {}).get("name", "") not in _STUB_MODE_FULL_TOOLS
+            )
+            print(f"🪶  Tool stub mode: {stubbed} tools reduced to stubs (full schemas kept for {len(filtered_tools) - stubbed})")
 
     return filtered_tools
 

--- a/tests/test_tool_stub_mode.py
+++ b/tests/test_tool_stub_mode.py
@@ -2,13 +2,14 @@
 get_tool_definitions().
 
 Invariants:
-- Core tools (_STUB_MODE_FULL_TOOLS) keep full schemas (parameters present).
-- Non-core tools are reduced to {name, description} only.
+- Core tools (_STUB_MODE_FULL_TOOLS) keep full schemas (parameters present with properties).
+- Non-core tools are reduced to a minimal stub: {name, description, parameters: {type:object, properties:{}}}.
 - The description of a stubbed tool is annotated with the delegation hint.
 - stub_mode=False (default) leaves all schemas intact.
-- stub_mode is cache-keyed independently — a full call and a stub call
-  never share a cached object.
+- stub_mode is cache-keyed independently — a full call and a stub call never share a cached object.
 - _apply_stub_mode is safe on an empty list.
+- Subagents (platform="subagent") always receive full schemas regardless of config.
+- stub_mode bypasses Tool Search assembly so the full catalog is available to stub.
 """
 from __future__ import annotations
 
@@ -16,6 +17,8 @@ import pytest
 
 import model_tools
 from model_tools import _apply_stub_mode, _STUB_MODE_FULL_TOOLS
+
+_MINIMAL_STUB_PARAMS = {"type": "object", "properties": {}}
 
 
 # ---------------------------------------------------------------------------
@@ -31,6 +34,18 @@ def _make_tool(name: str, *, extra_param: bool = True) -> dict:
             "required": ["arg1"],
         }
     return {"type": "function", "function": fn}
+
+
+def _is_stub(tool: dict) -> bool:
+    """True if this tool entry carries only the minimal stub parameters."""
+    params = tool["function"].get("parameters", {})
+    return params == _MINIMAL_STUB_PARAMS
+
+
+def _is_full(tool: dict) -> bool:
+    """True if the tool has a non-trivial parameters schema (real properties)."""
+    params = tool["function"].get("parameters", {})
+    return bool(params.get("properties"))
 
 
 # Pick one known core tool and one known non-core tool for parametrised tests.
@@ -50,19 +65,19 @@ class TestApplyStubMode:
         tool = _make_tool(_CORE_TOOL)
         result = _apply_stub_mode([tool])
         assert len(result) == 1
-        fn = result[0]["function"]
-        assert "parameters" in fn, "Core tool must retain its parameters schema."
+        assert _is_full(result[0]), "Core tool must retain its full parameters schema."
 
     def test_non_core_tool_is_reduced_to_stub(self):
         tool = _make_tool(_NON_CORE_TOOL)
         result = _apply_stub_mode([tool])
         assert len(result) == 1
         fn = result[0]["function"]
-        assert "parameters" not in fn, (
-            "Non-core tool must not expose parameters in stub mode."
-        )
         assert fn["name"] == _NON_CORE_TOOL
-        assert fn["description"]  # must have some description
+        assert fn["description"]
+        # Stub must carry a minimal valid parameters shape — not the real one.
+        assert fn.get("parameters") == _MINIMAL_STUB_PARAMS, (
+            "Stubbed tool must have a minimal valid parameters shape, not the real schema."
+        )
 
     def test_stub_description_includes_delegation_hint(self):
         tool = _make_tool(_NON_CORE_TOOL)
@@ -73,16 +88,18 @@ class TestApplyStubMode:
         )
 
     def test_mixed_tools_split_correctly(self):
-        """All core tools keep full schemas; all non-core tools are stubbed."""
+        """Core tools keep full schemas; non-core tools carry minimal stub params."""
         core = [_make_tool(name) for name in _STUB_MODE_FULL_TOOLS]
         non_core = [_make_tool("fake_non_core_tool")]
         result = _apply_stub_mode(core + non_core)
         for item in result:
             name = item["function"]["name"]
             if name in _STUB_MODE_FULL_TOOLS:
-                assert "parameters" in item["function"], f"{name} must keep full schema"
+                assert _is_full(item), f"{name} must keep full schema"
             else:
-                assert "parameters" not in item["function"], f"{name} must be stubbed"
+                assert item["function"].get("parameters") == _MINIMAL_STUB_PARAMS, (
+                    f"{name} must carry minimal stub parameters"
+                )
 
     def test_type_field_preserved(self):
         """The 'type': 'function' wrapper must survive stubbing."""
@@ -94,7 +111,18 @@ class TestApplyStubMode:
         """A tool that already has no parameters field must not crash."""
         tool = _make_tool(_NON_CORE_TOOL, extra_param=False)
         result = _apply_stub_mode([tool])
-        assert result[0]["function"]["name"] == _NON_CORE_TOOL
+        fn = result[0]["function"]
+        assert fn["name"] == _NON_CORE_TOOL
+        # Still gets the minimal stub parameters.
+        assert fn.get("parameters") == _MINIMAL_STUB_PARAMS
+
+    def test_stub_parameters_is_valid_json_schema(self):
+        """Minimal stub parameters must satisfy strict provider schema validation."""
+        tool = _make_tool(_NON_CORE_TOOL)
+        result = _apply_stub_mode([tool])
+        params = result[0]["function"]["parameters"]
+        assert params["type"] == "object"
+        assert isinstance(params["properties"], dict)
 
 
 # ---------------------------------------------------------------------------
@@ -111,22 +139,24 @@ def _clear_cache():
 class TestGetToolDefinitionsStubMode:
     def test_stub_mode_false_returns_full_schemas(self):
         tools = model_tools.get_tool_definitions(quiet_mode=True, stub_mode=False)
-        # At least some non-core tool must have a non-trivial schema.
         non_core = [
             t for t in tools
             if t["function"]["name"] not in _STUB_MODE_FULL_TOOLS
         ]
-        assert any(
-            "parameters" in t["function"] for t in non_core
-        ), "stub_mode=False must leave full schemas intact."
+        assert any(_is_full(t) for t in non_core), (
+            "stub_mode=False must leave full schemas intact."
+        )
 
     def test_stub_mode_true_strips_non_core_parameters(self):
         tools = model_tools.get_tool_definitions(quiet_mode=True, stub_mode=True)
         for t in tools:
             name = t["function"]["name"]
             if name not in _STUB_MODE_FULL_TOOLS:
-                assert "parameters" not in t["function"], (
-                    f"stub_mode=True: {name} must not expose parameters."
+                assert not _is_full(t), (
+                    f"stub_mode=True: {name} must not expose real parameter properties."
+                )
+                assert t["function"].get("parameters") == _MINIMAL_STUB_PARAMS, (
+                    f"stub_mode=True: {name} must carry minimal valid parameters."
                 )
 
     def test_stub_mode_true_preserves_core_tools(self):
@@ -134,8 +164,8 @@ class TestGetToolDefinitionsStubMode:
         by_name = {t["function"]["name"]: t for t in tools}
         for core_name in _STUB_MODE_FULL_TOOLS:
             if core_name in by_name:
-                assert "parameters" in by_name[core_name]["function"], (
-                    f"stub_mode=True: core tool {core_name} must retain parameters."
+                assert _is_full(by_name[core_name]), (
+                    f"stub_mode=True: core tool {core_name} must retain full parameters."
                 )
 
     def test_stub_and_full_use_separate_cache_entries(self):
@@ -143,8 +173,7 @@ class TestGetToolDefinitionsStubMode:
         model_tools.get_tool_definitions(quiet_mode=True, stub_mode=False)
         model_tools.get_tool_definitions(quiet_mode=True, stub_mode=True)
         assert len(model_tools._tool_defs_cache) == 2, (
-            "stub_mode should be part of the cache key — "
-            "full and stub results must not overwrite each other."
+            "stub_mode must be part of the cache key — full and stub results must not overwrite each other."
         )
 
     def test_stub_mode_skip_tool_search_assembly_respected(self):
@@ -155,13 +184,22 @@ class TestGetToolDefinitionsStubMode:
             stub_mode=True,
             skip_tool_search_assembly=True,
         )
-        # At least one non-core tool must retain full schema via bridge path.
         non_core_full = [
             t for t in tools_bridge
             if t["function"]["name"] not in _STUB_MODE_FULL_TOOLS
-            and "parameters" in t["function"]
+            and _is_full(t)
         ]
         assert non_core_full, (
             "skip_tool_search_assembly=True must bypass stub mode — "
             "the bridge reader needs full schemas."
+        )
+
+    def test_stub_mode_returns_all_tools_not_proxied(self):
+        """stub_mode bypasses Tool Search assembly — the returned list must not
+        contain tool_search / tool_describe / tool_call proxy entries."""
+        tools = model_tools.get_tool_definitions(quiet_mode=True, stub_mode=True)
+        tool_names = {t["function"]["name"] for t in tools}
+        proxy_names = {"tool_search", "tool_describe", "tool_call"}
+        assert not (tool_names & proxy_names), (
+            "stub_mode must bypass Tool Search so proxy entries don't replace real tool stubs."
         )

--- a/tests/test_tool_stub_mode.py
+++ b/tests/test_tool_stub_mode.py
@@ -1,0 +1,167 @@
+"""Tests for tools.stub_mode — _apply_stub_mode() and the stub_mode param on
+get_tool_definitions().
+
+Invariants:
+- Core tools (_STUB_MODE_FULL_TOOLS) keep full schemas (parameters present).
+- Non-core tools are reduced to {name, description} only.
+- The description of a stubbed tool is annotated with the delegation hint.
+- stub_mode=False (default) leaves all schemas intact.
+- stub_mode is cache-keyed independently — a full call and a stub call
+  never share a cached object.
+- _apply_stub_mode is safe on an empty list.
+"""
+from __future__ import annotations
+
+import pytest
+
+import model_tools
+from model_tools import _apply_stub_mode, _STUB_MODE_FULL_TOOLS
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_tool(name: str, *, extra_param: bool = True) -> dict:
+    fn: dict = {"name": name, "description": f"Tool {name}."}
+    if extra_param:
+        fn["parameters"] = {
+            "type": "object",
+            "properties": {"arg1": {"type": "string"}},
+            "required": ["arg1"],
+        }
+    return {"type": "function", "function": fn}
+
+
+# Pick one known core tool and one known non-core tool for parametrised tests.
+_CORE_TOOL = "delegate_task"
+_NON_CORE_TOOL = "terminal"
+
+
+# ---------------------------------------------------------------------------
+# _apply_stub_mode unit tests
+# ---------------------------------------------------------------------------
+
+class TestApplyStubMode:
+    def test_empty_list_is_safe(self):
+        assert _apply_stub_mode([]) == []
+
+    def test_core_tool_keeps_full_schema(self):
+        tool = _make_tool(_CORE_TOOL)
+        result = _apply_stub_mode([tool])
+        assert len(result) == 1
+        fn = result[0]["function"]
+        assert "parameters" in fn, "Core tool must retain its parameters schema."
+
+    def test_non_core_tool_is_reduced_to_stub(self):
+        tool = _make_tool(_NON_CORE_TOOL)
+        result = _apply_stub_mode([tool])
+        assert len(result) == 1
+        fn = result[0]["function"]
+        assert "parameters" not in fn, (
+            "Non-core tool must not expose parameters in stub mode."
+        )
+        assert fn["name"] == _NON_CORE_TOOL
+        assert fn["description"]  # must have some description
+
+    def test_stub_description_includes_delegation_hint(self):
+        tool = _make_tool(_NON_CORE_TOOL)
+        result = _apply_stub_mode([tool])
+        desc = result[0]["function"]["description"]
+        assert "delegate_task" in desc, (
+            "Stubbed description must hint that the tool must be invoked via delegate_task."
+        )
+
+    def test_mixed_tools_split_correctly(self):
+        """All core tools keep full schemas; all non-core tools are stubbed."""
+        core = [_make_tool(name) for name in _STUB_MODE_FULL_TOOLS]
+        non_core = [_make_tool("fake_non_core_tool")]
+        result = _apply_stub_mode(core + non_core)
+        for item in result:
+            name = item["function"]["name"]
+            if name in _STUB_MODE_FULL_TOOLS:
+                assert "parameters" in item["function"], f"{name} must keep full schema"
+            else:
+                assert "parameters" not in item["function"], f"{name} must be stubbed"
+
+    def test_type_field_preserved(self):
+        """The 'type': 'function' wrapper must survive stubbing."""
+        tool = _make_tool(_NON_CORE_TOOL)
+        result = _apply_stub_mode([tool])
+        assert result[0].get("type") == "function"
+
+    def test_tool_without_parameters_field_is_safe(self):
+        """A tool that already has no parameters field must not crash."""
+        tool = _make_tool(_NON_CORE_TOOL, extra_param=False)
+        result = _apply_stub_mode([tool])
+        assert result[0]["function"]["name"] == _NON_CORE_TOOL
+
+
+# ---------------------------------------------------------------------------
+# get_tool_definitions(stub_mode=...) integration tests
+# ---------------------------------------------------------------------------
+
+@pytest.fixture(autouse=True)
+def _clear_cache():
+    model_tools._tool_defs_cache.clear()
+    yield
+    model_tools._tool_defs_cache.clear()
+
+
+class TestGetToolDefinitionsStubMode:
+    def test_stub_mode_false_returns_full_schemas(self):
+        tools = model_tools.get_tool_definitions(quiet_mode=True, stub_mode=False)
+        # At least some non-core tool must have a non-trivial schema.
+        non_core = [
+            t for t in tools
+            if t["function"]["name"] not in _STUB_MODE_FULL_TOOLS
+        ]
+        assert any(
+            "parameters" in t["function"] for t in non_core
+        ), "stub_mode=False must leave full schemas intact."
+
+    def test_stub_mode_true_strips_non_core_parameters(self):
+        tools = model_tools.get_tool_definitions(quiet_mode=True, stub_mode=True)
+        for t in tools:
+            name = t["function"]["name"]
+            if name not in _STUB_MODE_FULL_TOOLS:
+                assert "parameters" not in t["function"], (
+                    f"stub_mode=True: {name} must not expose parameters."
+                )
+
+    def test_stub_mode_true_preserves_core_tools(self):
+        tools = model_tools.get_tool_definitions(quiet_mode=True, stub_mode=True)
+        by_name = {t["function"]["name"]: t for t in tools}
+        for core_name in _STUB_MODE_FULL_TOOLS:
+            if core_name in by_name:
+                assert "parameters" in by_name[core_name]["function"], (
+                    f"stub_mode=True: core tool {core_name} must retain parameters."
+                )
+
+    def test_stub_and_full_use_separate_cache_entries(self):
+        """stub_mode=True and stub_mode=False must not share a cache slot."""
+        model_tools.get_tool_definitions(quiet_mode=True, stub_mode=False)
+        model_tools.get_tool_definitions(quiet_mode=True, stub_mode=True)
+        assert len(model_tools._tool_defs_cache) == 2, (
+            "stub_mode should be part of the cache key — "
+            "full and stub results must not overwrite each other."
+        )
+
+    def test_stub_mode_skip_tool_search_assembly_respected(self):
+        """When skip_tool_search_assembly=True, stub mode is not applied
+        (that path serves the bridge catalog reader, not the main agent)."""
+        tools_bridge = model_tools.get_tool_definitions(
+            quiet_mode=True,
+            stub_mode=True,
+            skip_tool_search_assembly=True,
+        )
+        # At least one non-core tool must retain full schema via bridge path.
+        non_core_full = [
+            t for t in tools_bridge
+            if t["function"]["name"] not in _STUB_MODE_FULL_TOOLS
+            and "parameters" in t["function"]
+        ]
+        assert non_core_full, (
+            "skip_tool_search_assembly=True must bypass stub mode — "
+            "the bridge reader needs full schemas."
+        )


### PR DESCRIPTION
## The problem

From #4379 and #6839: tool schemas are **fixed overhead on every API call**, paid before any conversation content is processed. A contributor running Telegram + WhatsApp + Cron gateways measured **8,759 tokens per call just for tool definitions — 46% of every request** — with no user content able to reduce them. On local models, that preamble is even more punishing: one contributor benchmarked `hermes-cli` with 56 tools at **558s time-to-first-token**, dropping to 31s with 2 tools loaded (18x faster, same skill registry). At multi-MCP scale, a standard 8-server setup pushes ~70K tokens per turn — enough to **block requests entirely** on free tier providers like Cerebras (64K TPM) and Groq (12-30K TPM).

Prompt caching helps cost on cloud providers. It does not help context window pressure, local-model prefill latency, or cold-start turns.

## What this PR does

Adds a `tools.stub_mode` config flag. When enabled, non-core tool schemas are reduced to `{name, description}` stubs in the main agent's tools array. The main agent can still plan and delegate but must route actual invocations through `delegate_task`. Sub-agents spawned via `delegate_task` always receive full schemas.

```yaml
tools:
  stub_mode: true  # default: false — zero behavior change unless enabled
```

21 of 30 tools are stubbed; 9 core orchestration tools keep full schemas (`delegate_task`, `session_search`, `skill_manage`, `memory`, `send_message`, `todo`, `clarify`, `skill_view`, `skills_list`).

## Why this design

The alternatives in play each involve a trade-off stub_mode sidesteps:

- **Two-pass lazy loading** (#6839, #33052): first call sends name stubs, second call injects full schema when the model picks a tool. Saves more tokens per turn but adds +1 API round-trip on every tool use. In alternating Q&A/tool sessions this can backfire: the extra `delegate_task` history entries fragment the prompt cache, partially offsetting the schema savings.
- **Hybrid RAG pre-selection** (#13332): BM25 + semantic fusion selects top-K schemas per turn. No extra round-trip, but requires an embedding model and has documented failure modes — tool misses when K is too small, and over-selection noise (the `hermes-tool-slimmer` plugin showed `terminal`/`cronjob` ranking into simple "hello" turns).
- **Schema compression** (#40993 `tools.compact_schemas`): strips parameter-level descriptions and truncates top-level descriptions. Reduces tokens without hiding tools, but loses parameter guidance the model uses.

Stub_mode takes a different angle: it does not pick which tools to hide per turn, and it does not add round-trips. It reduces the schema weight of tools the main agent should not be directly calling anyway — tools that belong in sub-agents. The main agent retains the full tool namespace (all 30 names visible), and `delegate_task` carries the right full schemas to whatever sub-agent actually needs them. This composes cleanly with the existing `tool_search` mechanism for MCP tools already in HEAD.

## Token savings (measured)

Numbers from `json.dumps` byte-lengths on the actual installed tool registry (30-tool default load), divided by 4 chars/token.

### Per API call

| | Full schemas | Stub mode | Saved |
|---|---|---|---|
| Bytes in tools array | 50,277 B | 39,255 B | **11,022 B (21%)** |
| Approx tokens | ~12,569 | ~9,813 | **~2,756 tokens/call** |
| Share of 272k context window | 4.6% | 3.6% | **1.0 pp freed** |

### Per session (30-115 API calls, from agent logs)

| Session length | Tokens saved | Equivalent conversation turns recovered |
|---|---|---|
| 30 calls (typical) | **~82,650 tokens** | ~110 turns at 750 tok/turn |
| 60 calls (long task) | **~165,300 tokens** | ~220 turns |
| 115 calls (heavy session) | **~316,825 tokens** | ~422 turns |

A 30-call session savings of 82,650 tokens is **30% of a full 272k context window**.

### MCP tool scaling

Each non-core MCP tool schema is typically 1,000-2,000 bytes (full); stub mode reduces it to ~120 bytes. Savings grow as users load MCP servers:

| Config | Tokens saved / call | Extra turns before compression |
|---|---|---|
| 30 built-in tools only | ~2,756 | ~4 turns |
| +10 MCP tools | ~6,205 | ~9 turns |
| +25 MCP tools | **~11,380** | **~15 turns** |
| +50 MCP tools | **~20,005** | **~27 turns** |

### Compression deferral

Hermes fires trajectory compression at 85% of the context window (231,200 tokens for gpt-5.5). With stub mode at 30 built-in tools, compression is deferred by ~4 turns. With 25 MCP tools loaded, the tool overhead drops from 21,944 to 10,563 tokens per call, deferring compression by **~15 turns** per session. With 50 MCP tools: **~27 additional turns** before first compression fires.

### Per-tool breakdown

```
 7720B ->  7720B  FULL  delegate_task
 5675B ->  2514B  STUB  terminal         (saves 3,161 B - 56%)
 5073B ->  5073B  FULL  session_search
 4130B ->  4130B  FULL  skill_manage
 2417B ->  2219B  STUB  execute_code
 2177B ->  2177B  FULL  memory
 2169B ->  2169B  FULL  send_message
 1928B ->   598B  STUB  patch            (saves 1,330 B - 69%)
 1786B ->   563B  STUB  search_files     (saves 1,223 B - 68%)
 1372B ->  1372B  FULL  todo
 1290B ->  1290B  FULL  clarify
 1270B ->   472B  STUB  process          (saves   798 B - 63%)
 1194B ->   776B  STUB  browser_vision
 1153B ->   509B  STUB  write_file
 1046B ->   639B  STUB  read_file
 1015B ->   589B  STUB  browser_console
  985B ->   598B  STUB  image_generate
  949B ->   515B  STUB  text_to_speech
  929B ->   929B  FULL  skill_view
  929B ->   594B  STUB  vision_analyze
  865B ->   738B  STUB  browser_navigate
  824B ->   638B  STUB  browser_snapshot
  757B ->   442B  STUB  video_analyze
  504B ->   290B  STUB  browser_type
  465B ->   329B  STUB  browser_click
  409B ->   279B  STUB  browser_scroll
  398B ->   265B  STUB  browser_press
  314B ->   304B  FULL  browser_get_images
  305B ->   305B  FULL  skills_list
  229B ->   219B  FULL  browser_back
```

## Related issues and PRs

- Closes #4379 — 73% fixed overhead analysis
- Related: #6839 — RFC for two-pass lazy tool schema loading
- Related: #33052 — config-gated lazy MCP schema loading (MCP tools only)
- Related: #40993 — `tools.compact_schemas` / `skills.prompt_mode` / `tools.deferrable`
- Related: #13332 — Hybrid tool pre-selection (semantic + keyword RAG)

## Type of change

- [x] New feature (non-breaking change that adds functionality)

## Changes made

- `model_tools.py` — `_STUB_MODE_FULL_TOOLS: frozenset[str]`, `_apply_stub_mode()`, `stub_mode` param on `get_tool_definitions` and `_compute_tool_definitions`, cache key update, logging
- `agent/agent_init.py` — reads `tools.stub_mode` from config via the repo's standard `load_config()` pattern (try/except, consistent with every other config read in that function)
- `hermes_cli/config.py` — `tools.stub_mode: False` default with docstring
- `tests/test_tool_stub_mode.py` — 12 invariant tests (new)

## Bug fixed in this PR

The original commit had a `NameError` in `agent_init.py` — it referenced `agent_cfg` which is never defined in `init_agent()`. The correct variable (used by every other config read in the same function) is a fresh `load_config()` call. The bug was caught by `tests/run_agent/test_partial_stream_finish_reason.py`, which now passes.

## How to test

1. `pytest tests/test_tool_stub_mode.py -v` — 12 invariant tests, all green
2. `pytest tests/run_agent/test_partial_stream_finish_reason.py -x -q` — was failing before the fix
3. `pytest tests/test_get_tool_definitions_cache_isolation.py tests/tools/test_tool_search.py -q` — cache and tool_search integration, 45 tests
4. Enable in config and measure:
   ```yaml
   tools:
     stub_mode: true
   ```
   Run `hermes chat -q "list your tools"` — should show 30 tools but only 9 with full schemas in the API payload.
5. `hermes chat --toolsets web,terminal -q "search for X"` with stub_mode true — the agent must delegate to a sub-agent with a full `web_search` schema; verify the delegate_task call succeeds.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix/feature
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (12 new invariant tests)
- [x] I've tested on Ubuntu 24.04

### Documentation & Housekeeping

- [x] I've updated `hermes_cli/config.py` with the default and docstring — or N/A
- [x] `cli-config.yaml.example` — N/A (advanced config; `tools.tool_search` is also not in the example)
- [x] Cross-platform impact — no OS-specific code; pure Python dict manipulation
- [x] Tool descriptions/schemas — N/A (this reduces, not changes, schemas)