### PR TITLE
feat(plugins): generic customize_request_headers hook for outbound requests

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -1360,6 +1360,19 @@ def create_openai_client(agent, client_kwargs: dict, *, reason: str, shared: boo
     # copy locks the contract so future transport/keepalive work can't reintroduce
     # the same class of bug.
     client_kwargs = dict(client_kwargs)
+    # Plugin seam: let plugins add outbound request headers (e.g. conversation/routing hints for a
+    # local gateway). Inert without a plugin and never breaks client creation. Plugins MUST scope
+    # their headers by base_url so identifiers don't leak to third-party providers.
+    try:
+        from hermes_cli.plugins import invoke_hook as _invoke_hook
+        for _hdrs in _invoke_hook("customize_request_headers", agent=agent,
+                                  base_url=str(client_kwargs.get("base_url", "") or "")):
+            if isinstance(_hdrs, dict) and _hdrs:
+                _dh = dict(client_kwargs.get("default_headers") or {})
+                _dh.update({str(k): str(v) for k, v in _hdrs.items()})
+                client_kwargs["default_headers"] = _dh
+    except Exception:  # noqa: BLE001 — header customization must never break client creation
+        pass
     _validate_proxy_env_urls()
     _validate_base_url(client_kwargs.get("base_url"))
     if agent.provider == "copilot-acp" or str(client_kwargs.get("base_url", "")).startswith("acp://copilot"):

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -167,6 +167,11 @@ VALID_HOOKS: Set[str] = {
     #   choice: "once" | "session" | "always" | "deny" | "timeout"
     "pre_approval_request",
     "post_approval_response",
+    # Outbound request headers. Fired in create_openai_client before the client is built. Plugins
+    # return a dict of header -> value to merge into default_headers. Plugins MUST scope by base_url
+    # so identifiers never leak to third-party providers.
+    #   Kwargs: agent, base_url
+    "customize_request_headers",
 }
 
 ENTRY_POINTS_GROUP = "hermes_agent.plugins"


### PR DESCRIPTION
## What

Adds a `customize_request_headers` plugin hook in `create_openai_client`, letting plugins add outbound
request headers before the client is built.

## Why

There's currently no seam for a plugin to add headers to outbound model requests. This is useful for
local gateways/proxies that want conversation or routing hints forwarded on the request (in my case, a
local OpenAI-compatible router that scopes per-conversation memory by an `X-Conversation-Id` header).

## Design

- **Inert by default** — no behavior change unless a plugin registers the hook.
- **Fail-safe** — the call is wrapped in try/except so a plugin error can never break client creation.
- **Scoped by the plugin** — the hook receives `agent` and `base_url`; plugins MUST gate on `base_url`
  so identifiers never leak to third-party providers.

Registered in `VALID_HOOKS`; invoked once in `create_openai_client` after the read-only `client_kwargs`
copy. Returns a dict of `header -> value` merged into `default_headers`.

```python
def register(ctx):
    def add_headers(agent=None, base_url="", **_):
        if not is_my_local_gateway(base_url):
            return None
        return {"X-Conversation-Id": agent.session_id}
    ctx.register_hook("customize_request_headers", add_headers)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)