### PR TITLE
fix(update): reuse an existing uv on Termux instead of source-building

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -7619,7 +7619,13 @@ def _ensure_uv_for_termux(pip_cmd: list[str]) -> str | None:
         return None
     try:
         print("  → Termux detected: trying to install uv for faster dependency updates...")
-        subprocess.run(pip_cmd + ["install", "uv"], cwd=PROJECT_ROOT, check=False)
+        result = subprocess.run(
+            pip_cmd + ["install", "uv", "--only-binary", ":all:"],
+            cwd=PROJECT_ROOT,
+            check=False,
+        )
+        if result.returncode != 0:
+            return None
     except Exception:
         pass
     # After pip install, check managed path first, then PATH

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -7607,8 +7607,9 @@ def _ensure_uv_for_termux(pip_cmd: list[str]) -> str | None:
 
     The normal path (``ensure_uv()`` in managed_uv) installs the managed
     standalone uv into ``$HERMES_HOME/bin/uv``, but on Termux the official
-    installer may not work (glibc vs bionic).  Fall back to ``pip install uv``
-    which gets a Termux-compatible binary.
+    installer may not work (glibc vs bionic).  Prefer a uv already on PATH
+    (e.g. ``pkg install uv``); only if there is none do we fall back to a
+    wheel-only ``pip install uv`` so we never source-build the Rust crate.
     """
     from hermes_cli.managed_uv import resolve_uv
 
@@ -7617,6 +7618,12 @@ def _ensure_uv_for_termux(pip_cmd: list[str]) -> str | None:
         return existing
     if not _is_termux_env():
         return None
+    # A Termux-packaged uv lands on PATH but not in the managed bin dir, so
+    # resolve_uv() misses it. Use it before pip, which has no Android wheel and
+    # would otherwise build uv from source on a low-memory device.
+    system_uv = shutil.which("uv")
+    if system_uv:
+        return system_uv
     try:
         print("  → Termux detected: trying to install uv for faster dependency updates...")
         result = subprocess.run(

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -911,6 +911,7 @@ AUTHOR_MAP = {
     "hmbown@gmail.com": "Hmbown",
     "iacobs@m0n5t3r.info": "m0n5t3r",
     "jiayuw794@gmail.com": "JiayuuWang",
+    "jinhyuk9714@gmail.com": "sjh9714",
     "jonny@nousresearch.com": "yoniebans",
     "jake@nousresearch.com": "simpolism",
     "juan.ovalle@mistral.ai": "jjovalle99",

--- a/tests/hermes_cli/test_cmd_update.py
+++ b/tests/hermes_cli/test_cmd_update.py
@@ -138,6 +138,23 @@ class TestCmdUpdateTermuxUvBootstrap:
         assert mock_run.call_args.kwargs["cwd"] == PROJECT_ROOT
         assert mock_run.call_args.kwargs["check"] is False
 
+    @patch("subprocess.run")
+    def test_termux_reuses_existing_path_uv_without_pip(self, mock_run, monkeypatch):
+        """A uv already on PATH (e.g. ``pkg install uv``) is reused before pip runs."""
+        from hermes_cli import main as hm
+
+        pkg_uv = "/data/data/com.termux/files/usr/bin/uv"
+        monkeypatch.setattr(hm, "_is_termux_env", lambda env=None: True)
+        # Production resolve_uv only checks $HERMES_HOME/bin/uv; model an empty
+        # managed dir so the PATH probe is what surfaces the packaged uv.
+        monkeypatch.setattr("hermes_cli.managed_uv.resolve_uv", lambda: None)
+        monkeypatch.setattr("shutil.which", lambda name: pkg_uv if name == "uv" else None)
+
+        uv_bin = hm._ensure_uv_for_termux(["/termux/python", "-m", "pip"])
+
+        assert uv_bin == pkg_uv
+        mock_run.assert_not_called()
+
 
 class TestCmdUpdateBranchFallback:
     """cmd_update falls back to main when current branch has no remote counterpart."""

--- a/tests/hermes_cli/test_cmd_update.py
+++ b/tests/hermes_cli/test_cmd_update.py
@@ -109,6 +109,36 @@ class TestCmdUpdatePip:
         assert "env" not in mock_run.call_args.kwargs
 
 
+class TestCmdUpdateTermuxUvBootstrap:
+    """Regression tests for Termux-specific uv bootstrap behavior."""
+
+    @patch("shutil.which", return_value=None)
+    @patch("subprocess.run")
+    def test_termux_uv_bootstrap_uses_binary_only_install(
+        self, mock_run, _mock_which, monkeypatch
+    ):
+        from hermes_cli import main as hm
+
+        mock_run.return_value = subprocess.CompletedProcess([], 1, stdout="", stderr="")
+        monkeypatch.setattr(hm, "_is_termux_env", lambda env=None: True)
+
+        uv_bin = hm._ensure_uv_for_termux(["/termux/python", "-m", "pip"])
+
+        assert uv_bin is None
+        assert mock_run.call_count == 1
+        assert mock_run.call_args.args[0] == [
+            "/termux/python",
+            "-m",
+            "pip",
+            "install",
+            "uv",
+            "--only-binary",
+            ":all:",
+        ]
+        assert mock_run.call_args.kwargs["cwd"] == PROJECT_ROOT
+        assert mock_run.call_args.kwargs["check"] is False
+
+
 class TestCmdUpdateBranchFallback:
     """cmd_update falls back to main when current branch has no remote counterpart."""
 


### PR DESCRIPTION
On Termux, `hermes update` could compile uv from source and OOM-kill low-memory devices. `_ensure_uv_for_termux` resolved uv only via `resolve_uv()` (the managed `$HERMES_HOME/bin/uv`, never PATH), so a uv installed with `pkg install uv` was invisible and the helper went straight to `pip install uv`, which has no Android wheel and built the Rust crate from source. The check that used to catch an existing uv was dropped in the single-managed-path refactor (commit 4df280d5).

## Changes
- Cherry-picks #39152 (credit @jinhyuk9714): the pip fallback uses `--only-binary :all:` so it can never source-build, and returns None on failure.
- Adds a `shutil.which("uv")` probe right after the Termux guard, so an already-installed uv is reused before any pip attempt. This stays inside `_ensure_uv_for_termux` and does not touch `resolve_uv`, so the single-managed-path invariant is preserved.
- Regression test: with `resolve_uv()` returning None (production behavior) and a uv on PATH, the helper returns that uv and never calls pip.

Supersedes #39152.

Fixes #39118.
