### PR TITLE
fix(gateway): resume follows the compression tip so post-compression replies render

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -2820,6 +2820,24 @@ class SessionDB:
         if not session_id:
             return session_id
 
+        # Follow the compression-continuation chain forward to the live tip
+        # FIRST. Auto-compression ends the current session and forks a
+        # continuation child, but a long-lived parent keeps its own flushed
+        # message rows — so the empty-head walk below never redirects it, and
+        # resuming the parent id reloads the pre-compression transcript while
+        # the turns generated *after* compression (and their responses) sit in
+        # the continuation. ``get_compression_tip`` is lineage-aware: it only
+        # follows children whose parent ended with ``end_reason='compression'``
+        # (created after the parent was ended), so delegation / branch children
+        # never hijack the resume. This is the fix for the desktop "I came back
+        # and the reply isn't there" report on large sessions.
+        try:
+            tip = self.get_compression_tip(session_id)
+        except Exception:
+            tip = session_id
+        if tip and tip != session_id:
+            session_id = tip
+
         with self._lock:
             # If this session already has messages, nothing to redirect.
             try:

--- a/tests/hermes_state/test_resolve_resume_session_id.py
+++ b/tests/hermes_state/test_resolve_resume_session_id.py
@@ -100,9 +100,11 @@ def test_follows_compression_tip_when_parent_retains_messages(db):
     db.append_message("cont", role="assistant", content="post-compression reply")
     # Force deterministic ordering so the continuation's started_at is clearly
     # at/after the parent's ended_at (the get_compression_tip discriminator).
-    db._conn.execute("UPDATE sessions SET started_at = ?, ended_at = ? WHERE id = 'root'", (base, base + 50))
-    db._conn.execute("UPDATE sessions SET started_at = ? WHERE id = 'cont'", (base + 100,))
-    db._conn.commit()
+    conn = db._conn
+    assert conn is not None
+    conn.execute("UPDATE sessions SET started_at = ?, ended_at = ? WHERE id = 'root'", (base, base + 50))
+    conn.execute("UPDATE sessions SET started_at = ? WHERE id = 'cont'", (base + 100,))
+    conn.commit()
 
     assert db.resolve_resume_session_id("root") == "cont"
 
@@ -116,9 +118,11 @@ def test_compression_tip_not_confused_with_delegation_child(db):
     db.append_message("conv", role="user", content="parent turn")
     db.create_session("subagent", source="cli", parent_session_id="conv")
     db.append_message("subagent", role="assistant", content="delegated work")
-    db._conn.execute("UPDATE sessions SET started_at = ? WHERE id = 'conv'", (base,))
-    db._conn.execute("UPDATE sessions SET started_at = ? WHERE id = 'subagent'", (base + 100,))
-    db._conn.commit()
+    conn = db._conn
+    assert conn is not None
+    conn.execute("UPDATE sessions SET started_at = ? WHERE id = 'conv'", (base,))
+    conn.execute("UPDATE sessions SET started_at = ? WHERE id = 'subagent'", (base + 100,))
+    conn.commit()
 
     assert db.resolve_resume_session_id("conv") == "conv"
 

--- a/tests/hermes_state/test_resolve_resume_session_id.py
+++ b/tests/hermes_state/test_resolve_resume_session_id.py
@@ -83,6 +83,46 @@ def test_walks_from_middle_of_chain(db):
     assert db.resolve_resume_session_id("c") == "d"
 
 
+def test_follows_compression_tip_when_parent_retains_messages(db):
+    # The bug behind the desktop "I came back and the reply isn't there" report
+    # on large sessions: auto-compression ends the live session and forks a
+    # continuation child, but a long parent keeps its own flushed message rows.
+    # The empty-head walk below never redirects a non-empty head, so resuming
+    # the parent id reloaded the pre-compression transcript and the response
+    # generated *after* compression (which lives in the continuation) was
+    # missing. resolve_resume_session_id must follow the compression-tip chain
+    # forward even when the parent still has messages.
+    base = int(time.time()) - 10_000
+    db.create_session("root", source="cli")
+    db.append_message("root", role="user", content="pre-compression turn")
+    db.end_session("root", "compression")
+    db.create_session("cont", source="cli", parent_session_id="root")
+    db.append_message("cont", role="assistant", content="post-compression reply")
+    # Force deterministic ordering so the continuation's started_at is clearly
+    # at/after the parent's ended_at (the get_compression_tip discriminator).
+    db._conn.execute("UPDATE sessions SET started_at = ?, ended_at = ? WHERE id = 'root'", (base, base + 50))
+    db._conn.execute("UPDATE sessions SET started_at = ? WHERE id = 'cont'", (base + 100,))
+    db._conn.commit()
+
+    assert db.resolve_resume_session_id("root") == "cont"
+
+
+def test_compression_tip_not_confused_with_delegation_child(db):
+    # A delegation/branch child is created while the parent is still live (the
+    # parent is NOT ended with end_reason='compression'), so resuming the
+    # parent must stay on the parent, not get hijacked into the subagent branch.
+    base = int(time.time()) - 10_000
+    db.create_session("conv", source="cli")
+    db.append_message("conv", role="user", content="parent turn")
+    db.create_session("subagent", source="cli", parent_session_id="conv")
+    db.append_message("subagent", role="assistant", content="delegated work")
+    db._conn.execute("UPDATE sessions SET started_at = ? WHERE id = 'conv'", (base,))
+    db._conn.execute("UPDATE sessions SET started_at = ? WHERE id = 'subagent'", (base + 100,))
+    db._conn.commit()
+
+    assert db.resolve_resume_session_id("conv") == "conv"
+
+
 def test_prefers_most_recent_child_when_fork_exists(db):
     # If a session was somehow forked (two children), pick the latest one.
     # In practice, compression only produces single-chain shape, but the helper

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -954,6 +954,65 @@ def test_session_resume_uses_parent_lineage_for_display(monkeypatch):
     assert captured["history_calls"] == [("tip", False), ("tip", True)]
 
 
+def test_session_resume_follows_compression_tip(monkeypatch, tmp_path):
+    """Resuming a rotated-out parent id must load the continuation's messages.
+
+    Regression for the desktop "I came back and the reply isn't there" report:
+    auto-compression ends the live session and forks a continuation child, so a
+    resume on the parent id (the desktop's routed id when the chat was opened
+    before it rotated) used to reload the pre-compression transcript and drop
+    the response generated after compression. session.resume must follow the
+    compression tip via resolve_resume_session_id.
+    """
+    from hermes_state import SessionDB
+
+    db = SessionDB(db_path=tmp_path / "state.db")
+    base = int(time.time()) - 10_000
+    db.create_session("parent_root", source="tui")
+    db.append_message("parent_root", role="user", content="pre-compression turn")
+    db.end_session("parent_root", "compression")
+    db.create_session("cont_tip", source="tui", parent_session_id="parent_root")
+    db.append_message("cont_tip", role="assistant", content="post-compression reply")
+    db._conn.execute(
+        "UPDATE sessions SET started_at = ?, ended_at = ? WHERE id = 'parent_root'",
+        (base, base + 50),
+    )
+    db._conn.execute("UPDATE sessions SET started_at = ? WHERE id = 'cont_tip'", (base + 100,))
+    db._conn.commit()
+
+    captured = {}
+
+    def fake_make_agent(sid, key, session_id=None, session_db=None, **kwargs):
+        captured["agent_session_id"] = session_id
+        return types.SimpleNamespace(model="test", provider="test")
+
+    monkeypatch.setattr(server, "_get_db", lambda: db)
+    monkeypatch.setattr(server, "_enable_gateway_prompts", lambda: None)
+    monkeypatch.setattr(server, "_set_session_context", lambda target: [])
+    monkeypatch.setattr(server, "_clear_session_context", lambda tokens: None)
+    monkeypatch.setattr(server, "_make_agent", fake_make_agent)
+    monkeypatch.setattr(
+        server, "_session_info", lambda agent, *a: {"model": "test", "tools": {}, "skills": {}}
+    )
+    monkeypatch.setattr(
+        server, "_init_session", lambda sid, key, agent, history, cols=80, **_kwargs: None
+    )
+
+    try:
+        resp = server.handle_request(
+            {"id": "1", "method": "session.resume", "params": {"session_id": "parent_root"}}
+        )
+    finally:
+        db.close()
+
+    # The agent must bind to the continuation tip, and the returned transcript
+    # must include the post-compression reply (which lives only in the tip).
+    assert resp["result"]["session_key"] == "cont_tip"
+    assert captured["agent_session_id"] == "cont_tip"
+    texts = [m.get("text") for m in resp["result"]["messages"]]
+    assert "post-compression reply" in texts
+
+
 def test_session_resume_passes_stored_runtime_to_agent(monkeypatch):
     captured = {}
 

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -973,12 +973,14 @@ def test_session_resume_follows_compression_tip(monkeypatch, tmp_path):
     db.end_session("parent_root", "compression")
     db.create_session("cont_tip", source="tui", parent_session_id="parent_root")
     db.append_message("cont_tip", role="assistant", content="post-compression reply")
-    db._conn.execute(
+    conn = db._conn
+    assert conn is not None
+    conn.execute(
         "UPDATE sessions SET started_at = ?, ended_at = ? WHERE id = 'parent_root'",
         (base, base + 50),
     )
-    db._conn.execute("UPDATE sessions SET started_at = ? WHERE id = 'cont_tip'", (base + 100,))
-    db._conn.commit()
+    conn.execute("UPDATE sessions SET started_at = ? WHERE id = 'cont_tip'", (base + 100,))
+    conn.commit()
 
     captured = {}
 

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -4419,6 +4419,27 @@ def _(rid, params: dict) -> dict:
             found = {}
         else:
             return _err(rid, 4007, "session not found")
+
+    # Follow the compression-continuation chain to the live tip so a resume on
+    # a rotated-out parent id binds to the descendant that actually holds the
+    # post-compression turns. Auto-compression ends the session and forks a
+    # continuation child; without this, resuming the original id (the desktop's
+    # routed id when the chat was opened before it rotated) reloads the parent
+    # transcript and the response generated after compression is missing — the
+    # "I came back and the reply isn't there" bug on large sessions. Resolving
+    # here also re-anchors the fast path below so a still-live rotated session
+    # is reused (by its new key) instead of rebuilding a duplicate agent on the
+    # stale parent. Skipped for lazy watch windows, which intentionally attach
+    # to the exact child branch they were opened on.
+    if found and not is_truthy_value(params.get("lazy", False)):
+        try:
+            tip = db.resolve_resume_session_id(target)
+        except Exception:
+            tip = target
+        if tip and tip != target:
+            target = tip
+            found = db.get_session(target) or found
+
     profile_resume_cwd = str(found.get("cwd") or "").strip() or _profile_configured_cwd(
         profile_home
     )


### PR DESCRIPTION
## Summary

Fixes the recurring desktop report: *"I send a message, it starts working, I look away, and when I come back the reply isn't there"* — on large sessions, the response is generated and persisted but never shows up under the user's message.

Root cause is **session rotation on auto-compression**, not a render bug:

- Auto-compression ends the live session and forks a continuation child (linked via `parent_session_id`); the turns generated *after* compression — including the assistant's response — land in the **continuation**, not the original session.
- `SessionDB.resolve_resume_session_id()` only redirected an **empty** head to a descendant (the #15000 case). A long-lived parent keeps its own flushed message rows, so it was never redirected — and every resume path anchored on the parent id reloaded the pre-compression transcript, missing the response.
- The desktop's chat is routed on the **pre-rotation** id (the id when the chat was opened), so both the gateway `session.resume` RPC and the REST `/messages` read missed the continuation.

## Changes

- `hermes_state.resolve_resume_session_id()` now follows the compression-continuation chain forward via the existing `get_compression_tip()` **before** its empty-head walk. `get_compression_tip()` is lineage-aware (only follows children whose parent ended with `end_reason='compression'`, created after the parent was ended), so delegation/branch children never hijack a resume. This fixes **every** resume caller at the chokepoint: REST `/messages`, CLI `--resume`, gateway `/resume`.
- `tui_gateway` `session.resume` was the one resume path that bypassed the resolver (it used the raw `target` id). It now routes through `resolve_resume_session_id()` (non-lazy only — lazy watch windows must stay on their exact child branch). Resolving up front also re-anchors the live-session fast path, so a still-live rotated session is reused by its new key instead of rebuilding a duplicate agent on the stale parent.

## Premise verification

`tests/hermes_state/test_resolve_resume_session_id.py::test_follows_compression_tip_when_parent_retains_messages` **fails on current `main`** (`resolve_resume_session_id("root")` returns `"root"`, the pre-compression parent) and passes with this change.

## Test plan

- [x] `resolve_resume_session_id` follows the tip even when the parent retains messages; not confused by a delegation child
- [x] `session.resume` binds the agent to the continuation tip and returns the post-compression reply
- [x] Existing resume callers green: `tests/hermes_cli/test_web_server.py`, `tests/cli/test_cli_resume_command.py`, `tests/cli/test_resume_display.py`, `tests/cli/test_resume_quiet_stderr.py`, `tests/gateway/test_resume_command.py`, `tests/test_lazy_session_regressions.py`, `tests/test_hermes_state.py`, `tests/test_tui_gateway_server.py` (only the unrelated, environment-dependent `test_browser_manage_connect_default_local_reports_launch_hint` fails locally — no Chromium on the box)

## Follow-up (not in this PR, to keep it one idea)

The desktop prefers the REST `/messages` snapshot over the resume payload when non-empty; with the resolver fixed both now agree. A separate cleanup could make the gateway re-anchor `_find_live_session_by_key` to also match a session's pre-rotation id directly, but resolving the tip up front already covers the reuse path.