### PR TITLE
feat(gateway): per-chat-type display overrides (dm/group/channel/thread)

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -977,6 +977,27 @@ display:
   # edit-in-place "⏳ Working — N min" heartbeat). Override under
   # display.platforms.telegram.
 
+  # Per-chat-type overrides: vary verbosity by conversation type on the SAME
+  # platform. Add a subdict keyed on the literal chat_type value (dm, group,
+  # channel, thread) under any display.platforms.<platform> entry. The
+  # per-chat-type layer is consulted BEFORE the plain per-platform value, so it
+  # wins when present and otherwise falls through unchanged. Any display key
+  # valid per-platform (tool_progress, interim_assistant_messages,
+  # thinking_progress, show_reasoning, streaming, long_running_notifications,
+  # busy_ack_detail, tool_preview_length, cleanup_progress) is valid inside a
+  # chat_type subdict. Each chat_type is configured independently.
+  # Example — full verbosity in DMs, final-answer-only in channels:
+  #   display:
+  #     platforms:
+  #       slack:
+  #         dm:
+  #           tool_progress: all
+  #           interim_assistant_messages: true
+  #         channel:
+  #           tool_progress: off
+  #           interim_assistant_messages: false
+  #           long_running_notifications: false
+
   # Auto-cleanup of temporary progress bubbles after the final response lands.
   # On platforms that support message deletion (currently Telegram), this
   # removes the tool-progress bubble, "⏳ Still working..." notices, and

--- a/gateway/display_config.py
+++ b/gateway/display_config.py
@@ -4,14 +4,27 @@ Provides ``resolve_display_setting()`` — the single entry-point for reading
 display settings with platform-specific overrides and sensible defaults.
 
 Resolution order (first non-None wins):
-    1. ``display.platforms.<platform>.<key>``  — explicit per-platform user override
-    2. ``display.<key>``                       — global user setting
-    3. ``_PLATFORM_DEFAULTS[<platform>][<key>]``  — built-in sensible default
-    4. ``_GLOBAL_DEFAULTS[<key>]``              — built-in global default
+    1. ``display.platforms.<platform>.<chat_type>.<key>`` — per-chat-type
+       override, where ``<chat_type>`` is the session chat type (``dm``,
+       ``group``, ``channel``, ``thread``, …).  Only consulted when a
+       ``chat_type`` is supplied by the caller.
+    2. ``display.platforms.<platform>.<key>``  — explicit per-platform user override
+    3. ``display.<key>``                       — global user setting
+    4. ``_PLATFORM_DEFAULTS[<platform>][<key>]``  — built-in sensible default
+    5. ``_GLOBAL_DEFAULTS[<key>]``              — built-in global default
+
+The per-chat-type layer (1) lets an operator keep full verbosity in ``dm``
+conversations while staying quiet in ``channel``/``group`` conversations on the
+*same* platform — e.g. ``display.platforms.slack.channel.tool_progress: off``
+with ``dm`` left verbose.  The scope key is the literal ``chat_type`` value, so
+each conversation type is configured independently.  When no ``chat_type`` is
+supplied (CLI sessions, callers that don't thread it through) or no matching
+``<chat_type>`` subdict exists, resolution is byte-for-byte identical to the
+prior per-platform behavior.
 
 Exception: ``display.streaming`` is CLI-only.  Gateway streaming follows the
 top-level ``streaming`` config unless ``display.platforms.<platform>.streaming``
-sets an explicit per-platform override.
+(or a per-chat-type ``...<chat_type>.streaming``) sets an explicit override.
 
 Backward compatibility: ``display.tool_progress_overrides`` is still read as a
 fallback for ``tool_progress`` when no ``display.platforms`` entry exists.  A
@@ -153,6 +166,7 @@ def resolve_display_setting(
     platform_key: str,
     setting: str,
     fallback: Any = None,
+    chat_type: str = "",
 ) -> Any:
     """Resolve a display setting with per-platform override support.
 
@@ -167,16 +181,36 @@ def resolve_display_setting(
         Display setting name (e.g. ``"tool_progress"``, ``"show_reasoning"``).
     fallback : Any
         Fallback value when the setting isn't found anywhere.
+    chat_type : str
+        Optional gateway chat type (``"dm"``, ``"group"``, ``"channel"``,
+        ``"thread"``, …).  When supplied, a per-chat-type override layer
+        (``display.platforms.<platform>.<chat_type>.<key>``) is consulted
+        *before* the plain per-platform override; the scope key is the literal
+        ``chat_type`` value.  When empty (the default) or no matching subdict
+        exists, resolution is identical to the prior per-platform behavior —
+        fully backward compatible.
 
     Returns
     -------
     The resolved value, or *fallback* if nothing is configured.
     """
     display_cfg = user_config.get("display") or {}
-
-    # 1. Explicit per-platform override (display.platforms.<platform>.<key>)
     platforms = display_cfg.get("platforms") or {}
     plat_overrides = platforms.get(platform_key)
+
+    # 0. Per-chat-type override (display.platforms.<platform>.<chat_type>.<key>).
+    #    Most specific layer; only consulted when the caller threads a
+    #    chat_type through and a matching subdict exists.  The scope key is the
+    #    literal chat_type value (e.g. "dm", "group", "channel", "thread").
+    ct = (chat_type or "").strip().lower()
+    if ct and isinstance(plat_overrides, dict):
+        scoped = plat_overrides.get(ct)
+        if isinstance(scoped, dict):
+            val = scoped.get(setting)
+            if val is not None:
+                return _normalise(setting, val)
+
+    # 1. Explicit per-platform override (display.platforms.<platform>.<key>)
     if isinstance(plat_overrides, dict):
         val = plat_overrides.get(setting)
         if val is not None:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -413,8 +413,15 @@ def _resolve_progress_thread_id(platform: Any, source_thread_id: Any, event_mess
     return None
 
 
-def _has_platform_display_override(user_config: dict, platform_key: str, setting: str) -> bool:
-    """Return True when display.platforms.<platform> explicitly sets setting."""
+def _has_platform_display_override(
+    user_config: dict, platform_key: str, setting: str, chat_type: str = ""
+) -> bool:
+    """Return True when display.platforms.<platform> explicitly sets setting.
+
+    When ``chat_type`` is supplied, a per-chat-type subdict
+    (``display.platforms.<platform>.<chat_type>.<setting>``) also counts as an
+    explicit override.
+    """
     display = user_config.get("display") if isinstance(user_config, dict) else None
     if not isinstance(display, dict):
         return False
@@ -422,7 +429,14 @@ def _has_platform_display_override(user_config: dict, platform_key: str, setting
     if not isinstance(platforms, dict):
         return False
     platform_cfg = platforms.get(platform_key)
-    return isinstance(platform_cfg, dict) and setting in platform_cfg
+    if not isinstance(platform_cfg, dict):
+        return False
+    ct = (chat_type or "").strip().lower()
+    if ct:
+        scoped = platform_cfg.get(ct)
+        if isinstance(scoped, dict) and setting in scoped:
+            return True
+    return setting in platform_cfg
 
 
 def _resolve_gateway_display_bool(
@@ -433,6 +447,7 @@ def _resolve_gateway_display_bool(
     default: bool = False,
     platform: Any = None,
     require_platform_override_for: set[Any] | None = None,
+    chat_type: str = "",
 ) -> bool:
     """Resolve a boolean display setting with optional platform-only opt-in.
 
@@ -440,6 +455,10 @@ def _resolve_gateway_display_bool(
     user-facing output.  For high-noise threaded chat surfaces such as
     Mattermost, a global opt-in is too broad: they must be enabled with an
     explicit display.platforms.<platform>.<setting> override.
+
+    When ``chat_type`` is supplied it is threaded through to both the
+    platform-only opt-in check and the resolver, so per-chat-type overrides
+    (``display.platforms.<platform>.<scope>.<setting>``) are honored.
     """
     current_platform = _gateway_platform_value(platform or platform_key)
     platform_only = {
@@ -448,13 +467,17 @@ def _resolve_gateway_display_bool(
     }
     if (
         current_platform in platform_only
-        and not _has_platform_display_override(user_config, platform_key, setting)
+        and not _has_platform_display_override(
+            user_config, platform_key, setting, chat_type
+        )
     ):
         return False
 
     from gateway.display_config import resolve_display_setting
 
-    value = resolve_display_setting(user_config, platform_key, setting, default)
+    value = resolve_display_setting(
+        user_config, platform_key, setting, default, chat_type
+    )
     if isinstance(value, bool):
         return value
     if isinstance(value, str):
@@ -4051,6 +4074,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 _platform_config_key(event.source.platform),
                 "busy_ack_detail",
                 True,
+                chat_type=event.source.chat_type,
             )
         )
 
@@ -9141,6 +9165,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     default=bool(getattr(self, "_show_reasoning", False)),
                     platform=source.platform,
                     require_platform_override_for={Platform.MATTERMOST},
+                    chat_type=source.chat_type,
                 )
             except Exception:
                 _show_reasoning_effective = (
@@ -13526,7 +13551,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         user_config = _load_gateway_config()
         from gateway.display_config import resolve_display_setting
         _plat_streaming = resolve_display_setting(
-            user_config, platform_key, "streaming"
+            user_config, platform_key, "streaming", chat_type=source.chat_type
         )
         _streaming_enabled = (
             _scfg.enabled and _scfg.transport != "off"
@@ -13783,13 +13808,13 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # Apply tool preview length config (0 = no limit)
         try:
             from agent.display import set_tool_preview_max_len
-            _tpl = resolve_display_setting(user_config, platform_key, "tool_preview_length", 0)
+            _tpl = resolve_display_setting(user_config, platform_key, "tool_preview_length", 0, chat_type=source.chat_type)
             set_tool_preview_max_len(int(_tpl) if _tpl else 0)
         except Exception:
             pass
 
         # Tool progress mode — resolved per-platform with env var fallback
-        _resolved_tp = resolve_display_setting(user_config, platform_key, "tool_progress")
+        _resolved_tp = resolve_display_setting(user_config, platform_key, "tool_progress", chat_type=source.chat_type)
         _env_tp = os.getenv("HERMES_TOOL_PROGRESS_MODE")
         _display_cfg = display_config if isinstance(display_config, dict) else {}
         _platforms_cfg = _display_cfg.get("platforms") or {}
@@ -13812,7 +13837,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             else (_resolved_tp or _env_tp or "all")
         )
         # Tool progress grouping: "accumulate" (edit one bubble) or "separate" (one msg per tool)
-        progress_grouping = resolve_display_setting(user_config, platform_key, "tool_progress_grouping") or "accumulate"
+        progress_grouping = resolve_display_setting(user_config, platform_key, "tool_progress_grouping", chat_type=source.chat_type) or "accumulate"
         # Disable tool progress for webhooks - they don't support message editing,
         # so each progress line would be sent as a separate message.
         from gateway.config import Platform
@@ -13829,6 +13854,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 default=True,
                 platform=source.platform,
                 require_platform_override_for={Platform.MATTERMOST},
+                chat_type=source.chat_type,
             )
         )
         # thinking_progress is independent — if enabled, we need the progress
@@ -13842,6 +13868,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             default=False,
             platform=source.platform,
             require_platform_override_for={Platform.MATTERMOST},
+            chat_type=source.chat_type,
         )
         needs_progress_queue = tool_progress_enabled or _thinking_enabled
 
@@ -13904,7 +13931,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # are collected here and deleted after the final response lands.
         # Failed runs skip cleanup so the bubbles remain as breadcrumbs.
         _cleanup_progress = bool(
-            resolve_display_setting(user_config, platform_key, "cleanup_progress")
+            resolve_display_setting(user_config, platform_key, "cleanup_progress", chat_type=source.chat_type)
         )
         _cleanup_adapter = self.adapters.get(source.platform) if _cleanup_progress else None
         if _cleanup_adapter is not None and (
@@ -14629,7 +14656,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # can disable streaming for specific platforms even when the global
             # streaming config is enabled.
             _plat_streaming = resolve_display_setting(
-                user_config, platform_key, "streaming"
+                user_config, platform_key, "streaming", chat_type=source.chat_type
             )
             # None = no per-platform override → follow global config
             _streaming_enabled = (
@@ -15665,6 +15692,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 platform_key,
                 "long_running_notifications",
                 True,
+                chat_type=source.chat_type,
             )
         ):
             _NOTIFY_INTERVAL = None
@@ -15697,6 +15725,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         platform_key,
                         "busy_ack_detail",
                         True,
+                        chat_type=source.chat_type,
                     )
                 )
                 if _agent_ref and hasattr(_agent_ref, "get_activity_summary"):

--- a/tests/gateway/test_per_chat_type_display.py
+++ b/tests/gateway/test_per_chat_type_display.py
@@ -1,0 +1,181 @@
+"""Tests for per-chat-type display override resolution.
+
+Covers ``resolve_display_setting``'s optional ``chat_type`` layer
+(``display.platforms.<platform>.<chat_type>.<key>``).  The central invariant:
+when ``chat_type`` is omitted, or no matching subdict exists, resolution is
+byte-for-byte identical to the prior per-platform behavior.
+"""
+
+import pytest
+
+from gateway.display_config import resolve_display_setting
+
+
+# ---------------------------------------------------------------------------
+# Backward compatibility: no chat_type => identical to per-platform behavior
+# ---------------------------------------------------------------------------
+
+def test_no_chat_type_uses_platform_override():
+    cfg = {"display": {"platforms": {"slack": {"tool_progress": "all"}}}}
+    # Without chat_type, the per-platform override wins (legacy behavior).
+    assert resolve_display_setting(cfg, "slack", "tool_progress") == "all"
+
+
+def test_no_chat_type_falls_through_to_global():
+    cfg = {"display": {"tool_progress": "new"}}
+    assert resolve_display_setting(cfg, "slack", "tool_progress") == "new"
+
+
+def test_empty_config_returns_builtin_default():
+    # slack's built-in default for tool_progress is "off".
+    assert resolve_display_setting({}, "slack", "tool_progress") == "off"
+
+
+def test_unknown_setting_returns_fallback():
+    assert resolve_display_setting({}, "slack", "nonexistent", "FB") == "FB"
+
+
+# ---------------------------------------------------------------------------
+# The new layer: per-chat-type override sits ABOVE per-platform
+# ---------------------------------------------------------------------------
+
+def _split_cfg():
+    """Verbose dm, quiet channel, on the same platform."""
+    return {
+        "display": {
+            "platforms": {
+                "teams": {
+                    # plain per-platform baseline
+                    "tool_progress": "all",
+                    "interim_assistant_messages": True,
+                    # per-chat-type scopes keyed on literal chat_type values
+                    "dm": {
+                        "tool_progress": "all",
+                        "interim_assistant_messages": True,
+                    },
+                    "channel": {
+                        "tool_progress": "off",
+                        "interim_assistant_messages": False,
+                    },
+                }
+            }
+        }
+    }
+
+
+def test_channel_scope_overrides_platform():
+    cfg = _split_cfg()
+    assert resolve_display_setting(cfg, "teams", "tool_progress", chat_type="channel") == "off"
+
+
+def test_dm_scope_keeps_verbose():
+    cfg = _split_cfg()
+    assert resolve_display_setting(cfg, "teams", "tool_progress", chat_type="dm") == "all"
+
+
+def test_chat_type_case_insensitive():
+    cfg = _split_cfg()
+    # gateway chat_type values are lowercase, but normalise defensively.
+    assert resolve_display_setting(cfg, "teams", "tool_progress", chat_type="CHANNEL") == "off"
+
+
+def test_unconfigured_chat_type_falls_through_to_platform():
+    # "group" has no subdict here; falls through to the platform baseline.
+    cfg = _split_cfg()
+    assert resolve_display_setting(cfg, "teams", "tool_progress", chat_type="group") == "all"
+
+
+def test_scope_bool_normalisation():
+    cfg = _split_cfg()
+    assert resolve_display_setting(cfg, "teams", "interim_assistant_messages", chat_type="channel") is False
+    assert resolve_display_setting(cfg, "teams", "interim_assistant_messages", chat_type="dm") is True
+
+
+def test_scope_absent_setting_falls_through_to_platform():
+    # channel scope sets tool_progress but NOT show_reasoning; show_reasoning
+    # should fall through to the platform layer.
+    cfg = {
+        "display": {
+            "platforms": {
+                "teams": {
+                    "show_reasoning": True,
+                    "channel": {"tool_progress": "off"},
+                }
+            }
+        }
+    }
+    assert resolve_display_setting(cfg, "teams", "show_reasoning", chat_type="channel") is True
+
+
+def test_scope_only_no_platform_baseline():
+    # Only a scope subdict, no sibling per-platform key for this setting.
+    cfg = {
+        "display": {
+            "platforms": {
+                "teams": {
+                    "channel": {"tool_progress": "off"},
+                }
+            }
+        }
+    }
+    assert resolve_display_setting(cfg, "teams", "tool_progress", chat_type="channel") == "off"
+    # dm has no scope and no platform key => built-in default path.
+    # (teams has no built-in entry => global default "all")
+    assert resolve_display_setting(cfg, "teams", "tool_progress", chat_type="dm") == "all"
+
+
+def test_chat_type_with_no_platform_dict_is_safe():
+    cfg = {"display": {"tool_progress": "new"}}
+    # No platforms dict at all — chat_type must not raise, falls to global.
+    assert resolve_display_setting(cfg, "teams", "tool_progress", chat_type="channel") == "new"
+
+
+def test_malformed_scope_value_ignored():
+    # scope key present but not a dict — must be ignored, not crash.
+    cfg = {
+        "display": {
+            "platforms": {
+                "teams": {
+                    "tool_progress": "all",
+                    "channel": "not-a-dict",
+                }
+            }
+        }
+    }
+    assert resolve_display_setting(cfg, "teams", "tool_progress", chat_type="channel") == "all"
+
+
+def test_distinct_chat_types_independent():
+    # group and channel configured separately resolve independently.
+    cfg = {
+        "display": {
+            "platforms": {
+                "discord": {
+                    "tool_progress": "all",
+                    "channel": {"tool_progress": "off"},
+                    "thread": {"tool_progress": "new"},
+                }
+            }
+        }
+    }
+    assert resolve_display_setting(cfg, "discord", "tool_progress", chat_type="channel") == "off"
+    assert resolve_display_setting(cfg, "discord", "tool_progress", chat_type="thread") == "new"
+    # group is unconfigured -> platform baseline
+    assert resolve_display_setting(cfg, "discord", "tool_progress", chat_type="group") == "all"
+
+
+def test_streaming_scope_override():
+    # streaming has special handling (skips global display.<key>), but the
+    # per-platform and per-chat-type layers still apply.
+    cfg = {
+        "display": {
+            "platforms": {
+                "teams": {
+                    "streaming": True,
+                    "channel": {"streaming": False},
+                }
+            }
+        }
+    }
+    assert resolve_display_setting(cfg, "teams", "streaming", chat_type="dm") is True
+    assert resolve_display_setting(cfg, "teams", "streaming", chat_type="channel") is False


### PR DESCRIPTION
## What does this PR do?

Adds an optional, opt-in resolution layer to `resolve_display_setting()` so
display/verbosity settings can differ between **`dm`** and
**`group`/`channel`/`thread`** conversations on the same platform:

```yaml
display:
  platforms:
    slack:
      dm:                         # NEW — applies to chat_type "dm"
        tool_progress: all
        interim_assistant_messages: true
      channel:                    # NEW — applies to chat_type "channel"
        tool_progress: off
        interim_assistant_messages: false
        long_running_notifications: false
```

**Why:** today display settings resolve per-platform only — the resolver
receives just `platform_key`, collapsing every chat_type onto one key. So you
cannot keep tool progress / interim messages flowing in `dm` conversations
while posting only the final answer in `channel` conversations on the same
platform. Operators running bots across DMs and shared channels have to pick
one verbosity for both. This adds the missing axis without changing any
existing behavior.

**Approach:** a most-specific override layer
`display.platforms.<platform>.<chat_type>.<key>`, where the scope key is the
literal gateway `chat_type` value (`dm`, `group`, `channel`, `thread`),
consulted before the existing per-platform value. Fully backward compatible:
when no `chat_type` is threaded through (CLI sessions, untouched callers) or no
matching subdict exists, resolution is byte-for-byte identical to the prior
per-platform behavior. No new top-level config keys; subdicts are read freeform
under the existing `display.platforms.<platform>` structure, so existing
configs and the config-migration path are untouched.

## Related Issue

Fixes #48632

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `gateway/display_config.py` — `resolve_display_setting()` gains
  `chat_type: str = ""` and a new most-specific lookup keyed on the literal
  `chat_type` value (`dm`/`group`/`channel`/`thread`); empty/unknown or absent
  subdict skips the layer.
- `gateway/run.py` — `_resolve_gateway_display_bool()` and
  `_has_platform_display_override()` gain matching `chat_type` params; every
  per-turn call site threads `source.chat_type` (tool_progress,
  interim_assistant_messages, thinking_progress, show_reasoning, streaming,
  long_running_notifications, busy_ack_detail, tool_preview_length,
  cleanup_progress, tool_progress_grouping).
- `cli-config.yaml.example` — documents the per-`chat_type` subdicts with a
  worked dm-verbose / channel-quiet example.
- `tests/gateway/test_per_chat_type_display.py` — new, 15 cases.

## How to Test

1. `pytest tests/gateway/test_per_chat_type_display.py -q` → 15 passed.
2. Regression: `pytest tests/gateway/test_display_config.py tests/gateway/test_per_platform_streaming_defaults.py tests/gateway/test_mattermost.py -q` → all pass (Mattermost exercises the modified `_resolve_gateway_display_bool` via real `gateway.run` import).
3. Manual: set `display.platforms.<platform>.channel.tool_progress: off` with `dm.tool_progress: all`; confirm tool-progress bubbles appear in a `dm` but not in a `channel` on the same platform.

## Checklist

### Code
- [x] I've read the Contributing Guide
- [x] Commit messages follow Conventional Commits (`feat(gateway): …`)
- [x] Searched existing PRs for duplicates
- [x] PR contains only changes related to this feature
- [x] Ran the test suite and all pass (126 passed across the affected gateway tests)
- [x] Added tests for my changes
- [x] Tested on my platform: Ubuntu (Linux 6.8)

### Documentation & Housekeeping
- [x] Updated `cli-config.yaml.example` for the new per-chat_type subdicts
- [x] Docstrings updated (`display_config.py` resolution-order + param docs)
- [x] Cross-platform impact considered — platform-agnostic; keys off `chat_type` which every adapter sets; degrades to prior behavior when absent
- [x] N/A — no tool schema changes
- [x] N/A — no architecture/workflow change requiring CONTRIBUTING/AGENTS update