### PR TITLE
fix: replace command -v with cross-platform check for Windows compatibility

### DIFF
--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -27,6 +27,7 @@ Usage:
 
 import os
 import re
+import platform
 import difflib
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
@@ -797,7 +798,10 @@ class ShellFileOperations(FileOperations):
     def _has_command(self, cmd: str) -> bool:
         """Check if a command exists in the environment (cached)."""
         if cmd not in self._command_cache:
-            result = self._exec(f"command -v {cmd} >/dev/null 2>&1 && echo 'yes'")
+            if platform.system() == "Windows":
+                result = self._exec(f"where {cmd} >nul 2>&1 && echo 'yes'")
+            else:
+                result = self._exec(f"command -v {cmd} >/dev/null 2>&1 && echo 'yes'")
             self._command_cache[cmd] = result.stdout.strip() == 'yes'
         return self._command_cache[cmd]
     


### PR DESCRIPTION
## Problem

`_has_command()` uses `command -v` to check if a tool (e.g. `rg`, `fd`) exists in the environment. `command -v` is a **bash built-in** — it does not exist in Windows `cmd.exe`. This means `search_files` and other file tools always fail to detect `rg` on Windows, even when it's on PATH.

## Fix

Use `platform.system()` to branch between Windows and Unix:

- **Windows:** `where {cmd} >nul 2>&1`
- **Unix:** `command -v {cmd} >/dev/null 2>&1`

## Testing

Confirmed on Windows 11: `where rg` returns the correct path, `where nonexistent` sets exit code and outputs nothing to stdout — matching the existing `stdout.strip() == 'yes'` check.

Reported-by: https://github.com/wuykjl