### PR TITLE
feat(slack): per-instance command name + single-command mode for multi-tenant workspaces

### DIFF
--- a/gateway/platforms/slack.py
+++ b/gateway/platforms/slack.py
@@ -3317,8 +3317,12 @@ class SlackAdapter(BasePlatformAdapter):
         if team_id and channel_id:
             self._channel_team[channel_id] = team_id
 
-        if slash_name in {"hermes", ""}:
-            # Legacy /hermes <subcommand> [args] routing + free-form questions.
+        # The configurable catch-all (default "hermes"; per-instance for multi-tenant
+        # Slack, ADR-0037) routes the "/<name> <subcommand> [args]" + free-form form.
+        from hermes_cli.commands import slack_command_name as _slack_command_name
+
+        if slash_name in {_slack_command_name(), "hermes", ""}:
+            # /<name> <subcommand> [args] routing + free-form questions.
             # Empty slash_name falls into this branch for backward compat
             # with any caller that didn't populate command["command"].
             from hermes_cli.commands import slack_subcommand_map

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -1032,6 +1032,51 @@ def _sanitize_slack_name(raw: str) -> str:
     return name[:_SLACK_NAME_LIMIT]
 
 
+def slack_command_name() -> str:
+    """The top-level Slack slash command name (the ``/<name> <subcommand>`` catch-all).
+
+    Defaults to ``hermes``. Make it per-instance so multiple Hermes agents can share
+    one Slack workspace without colliding: Slack slash commands are a workspace-global,
+    single-owner namespace (unlike Telegram's per-bot or Discord's per-app), so two
+    agents both claiming ``/hermes`` clash (sadee-and-co ADR-0037). Resolution order:
+    env ``HERMES_SLACK_COMMAND`` → config ``slack.command_name`` → ``hermes``.
+    """
+    raw = os.environ.get("HERMES_SLACK_COMMAND") or ""
+    if not raw:
+        try:
+            from hermes_cli.config import read_raw_config
+
+            cfg = read_raw_config()
+            slack_cfg = cfg.get("slack") if isinstance(cfg, dict) else None
+            if isinstance(slack_cfg, dict):
+                raw = str(slack_cfg.get("command_name") or "")
+        except Exception:
+            raw = ""
+    return _sanitize_slack_name(raw) or "hermes"
+
+
+def _slack_single_command_mode() -> bool:
+    """When true, expose ONLY the single :func:`slack_command_name` slash (its
+    subcommands still route via :func:`slack_subcommand_map`) instead of all ~50
+    commands — required for a Slack workspace shared by multiple Hermes agents
+    (ADR-0037), where 50 global slashes would each collide. Resolution: env
+    ``HERMES_SLACK_SINGLE_COMMAND`` → config ``slack.single_command`` → ``False``
+    (unchanged single-tenant behaviour)."""
+    env = os.environ.get("HERMES_SLACK_SINGLE_COMMAND")
+    if env not in (None, ""):
+        return is_truthy_value(env, default=False)
+    try:
+        from hermes_cli.config import read_raw_config
+
+        cfg = read_raw_config()
+        slack_cfg = cfg.get("slack") if isinstance(cfg, dict) else None
+        if isinstance(slack_cfg, dict):
+            return is_truthy_value(slack_cfg.get("single_command"), default=False)
+    except Exception:
+        pass
+    return False
+
+
 def slack_native_slashes() -> list[tuple[str, str, str]]:
     """Return (slash_name, description, usage_hint) triples for Slack.
 
@@ -1057,9 +1102,18 @@ def slack_native_slashes() -> list[tuple[str, str, str]]:
     entries: list[tuple[str, str, str]] = []
     seen: set[str] = set()
 
-    # Reserve /hermes as the catch-all top-level command.
-    entries.append(("hermes", "Talk to Hermes or run a subcommand", "[subcommand] [args]"))
-    seen.add("hermes")
+    # Reserve the catch-all top-level command. Its name is configurable (default
+    # "hermes") so multiple Hermes agents can share one Slack workspace without
+    # colliding on a slash command (Slack slashes are workspace-global; ADR-0037).
+    cmd_name = slack_command_name()
+    entries.append((cmd_name, "Talk to Hermes or run a subcommand", "[subcommand] [args]"))
+    seen.add(cmd_name)
+
+    # Multi-tenant Slack mode: expose ONLY the single catch-all slash. Its
+    # subcommands still route via slack_subcommand_map (e.g. "/welchman model ..."),
+    # so functionality is preserved while two agents in one workspace never collide.
+    if _slack_single_command_mode():
+        return entries
 
     def _add(name: str, desc: str, hint: str) -> None:
         slack_name = _sanitize_slack_name(name)

--- a/tests/hermes_cli/test_slack_multitenant.py
+++ b/tests/hermes_cli/test_slack_multitenant.py
@@ -1,0 +1,34 @@
+"""Multi-tenant Slack namespacing (sadee-and-co ADR-0037): a per-instance command
+name + a single-command mode, so multiple Hermes agents can share one Slack
+workspace without colliding on slash commands (which are a workspace-global,
+single-owner namespace — unlike Telegram's per-bot or Discord's per-app)."""
+from __future__ import annotations
+
+from hermes_cli.commands import (
+    slack_app_manifest,
+    slack_command_name,
+    slack_native_slashes,
+)
+
+
+def test_env_overrides_and_sanitizes_command_name(monkeypatch):
+    monkeypatch.setenv("HERMES_SLACK_COMMAND", "Welchman!")  # uppercase + invalid char
+    assert slack_command_name() == "welchman"
+
+
+def test_default_mode_exposes_the_full_command_set(monkeypatch):
+    monkeypatch.delenv("HERMES_SLACK_SINGLE_COMMAND", raising=False)
+    monkeypatch.setenv("HERMES_SLACK_COMMAND", "hermes")
+    slashes = slack_native_slashes()
+    assert slashes[0][0] == "hermes"  # catch-all reserved first
+    assert len(slashes) > 1  # plus individual commands (single-tenant behaviour preserved)
+
+
+def test_single_command_mode_exposes_only_the_handle(monkeypatch):
+    monkeypatch.setenv("HERMES_SLACK_COMMAND", "welchman")
+    monkeypatch.setenv("HERMES_SLACK_SINGLE_COMMAND", "1")
+    slashes = slack_native_slashes()
+    assert slashes == [("welchman", "Talk to Hermes or run a subcommand", "[subcommand] [args]")]
+    # the generated manifest then declares exactly one command — nothing to collide
+    manifest = slack_app_manifest()["features"]["slash_commands"]
+    assert [c["command"] for c in manifest] == ["/welchman"]


### PR DESCRIPTION
## Problem

Slack slash commands are a **workspace-global, single-owner namespace** — only one app can own `/model` in a given workspace. This is unlike Telegram (per-bot command menus) and Discord (per-app slash commands), where multiple bots coexist automatically.

`hermes slack manifest` registers every `COMMAND_REGISTRY` command (~50) as a global slash. So when two Hermes instances are installed in the **same** Slack workspace, every shared command collides and Slack notifies the workspace of the conflict — once per command. Today there's no clean way to run more than one Hermes in a single Slack workspace.

## Change

Two opt-in knobs; **default behaviour is unchanged**:

- **`slack_command_name()`** — the top-level catch-all command (the `/<name> <subcommand>` entry point), configurable via env `HERMES_SLACK_COMMAND` or config `slack.command_name`, defaulting to `hermes`.
- **single-command mode** — env `HERMES_SLACK_SINGLE_COMMAND` or config `slack.single_command`. When on, `slack_native_slashes()` returns **only** the single catch-all; its subcommands still route through `slack_subcommand_map` (`/<name> model …`), and `@mention`/DM are unaffected.

The router's catch-all branch now also matches the configured name (alongside `hermes`/empty, for back-compat), and the manifest + slash regex both derive from `slack_native_slashes()`, so no other wiring changes are needed.

Result: an operator can give each Hermes instance a **unique** command (`/welchman`, `/lawrence`, …) — or none (mention/DM only) — so any number of Hermes agents share one Slack workspace without slash-command collisions.

## Compatibility

- No env/config set → identical to today (`/hermes` reserved + the ~50 commands).
- Single-tenant installs are unaffected.

## Testing

- New `tests/hermes_cli/test_slack_multitenant.py`: env override + name sanitization; default full set preserved; single-command mode emits exactly one command + a one-command manifest.
- Existing Slack suite green: `tests/gateway/test_slack.py`, `test_slack_mention.py`, `tests/hermes_cli/test_slack_cli.py` (252 passed).
