### PR TITLE
feat(slack): App Home tab (bot intro, how-to, command list)

### DIFF
--- a/gateway/platforms/slack.py
+++ b/gateway/platforms/slack.py
@@ -300,6 +300,49 @@ def _resolve_slack_proxy_url() -> Optional[str]:
     return proxy_url
 
 
+def build_app_home_view(
+    bot_name: str,
+    command_name: str,
+    commands: list[tuple[str, str]],
+) -> dict:
+    """Build the Slack App Home (Home tab) view — a read-only orientation surface:
+    who the bot is, how to talk to it (DM / @mention / ``/<command>``), and the list
+    of available commands. Especially useful when slash commands are collapsed to a
+    single ``/<command>`` (multi-tenant mode), where this tab restores command
+    discovery. Respects Slack's caps (section text <= 3000 chars; <= 100 blocks).
+    """
+    intro = (
+        f"Hi — I'm *{bot_name}*, your Hermes agent. Talk to me by *DM*, by *@mention* "
+        f"in any channel I'm in, or with `/{command_name} <command> [args]`. In a DM you "
+        f"can just message me normally — no command needed."
+    )
+    blocks: list[dict] = [
+        {"type": "header", "text": {"type": "plain_text", "text": f"👋 {bot_name}", "emoji": True}},
+        {"type": "section", "text": {"type": "mrkdwn", "text": intro}},
+        {"type": "divider"},
+        {"type": "section", "text": {"type": "mrkdwn", "text": f"*Commands* — `/{command_name} <command>`"}},
+    ]
+    # Chunk the command list into section blocks, each within Slack's 3000-char cap.
+    chunk: list[str] = []
+    length = 0
+
+    def _flush() -> None:
+        nonlocal chunk, length
+        if chunk:
+            blocks.append({"type": "section", "text": {"type": "mrkdwn", "text": "\n".join(chunk)}})
+            chunk, length = [], 0
+
+    for name, desc in commands:
+        line = f"• `{name}` — {desc}".strip()[:200]
+        if length + len(line) + 1 > 2900 or len(chunk) >= 40:
+            _flush()
+        chunk.append(line)
+        length += len(line) + 1
+    _flush()
+    blocks.append({"type": "context", "elements": [{"type": "mrkdwn", "text": "Hermes · run a command above, or just message me."}]})
+    return {"type": "home", "blocks": blocks[:100]}
+
+
 class SlackAdapter(BasePlatformAdapter):
     """
     Slack bot adapter using Socket Mode.
@@ -892,6 +935,27 @@ class SlackAdapter(BasePlatformAdapter):
             @self._app.event("assistant_thread_context_changed")
             async def handle_assistant_thread_context_changed(event, say):
                 await self._handle_assistant_thread_lifecycle_event(event)
+
+            # App Home tab: publish a read-only orientation view (who I am, how to
+            # reach me, the command list). Closes over `bot_name` from the auth above.
+            @self._app.event("app_home_opened")
+            async def handle_app_home_opened(event, client):
+                if event.get("tab") != "home":
+                    return  # ignore the Messages tab open
+                try:
+                    from hermes_cli.commands import (
+                        gateway_command_summaries,
+                        slack_command_name,
+                    )
+
+                    view = build_app_home_view(
+                        bot_name or "Hermes",
+                        slack_command_name(),
+                        gateway_command_summaries(),
+                    )
+                    await client.views_publish(user_id=event["user"], view=view)
+                except Exception as exc:  # never let a Home-tab open error escalate
+                    logger.warning("[Slack] app_home_opened publish failed: %s", exc)
 
             # Register slash command handler(s)
             #

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -1095,6 +1095,22 @@ def slack_native_slashes() -> list[tuple[str, str, str]]:
     return entries
 
 
+def gateway_command_summaries() -> list[tuple[str, str]]:
+    """Return ``(name, description)`` for every gateway-available command (canonical
+    names only, deduped). For surfaces that *list* commands — e.g. the Slack App Home
+    tab — independent of how they are invoked. Honours the same config gates as
+    ``slack_native_slashes``."""
+    overrides = _resolve_config_gates()
+    out: list[tuple[str, str]] = []
+    seen: set[str] = set()
+    for cmd in COMMAND_REGISTRY:
+        if not _is_gateway_available(cmd, overrides) or cmd.name in seen:
+            continue
+        seen.add(cmd.name)
+        out.append((cmd.name, cmd.description or ""))
+    return out
+
+
 def slack_app_manifest(request_url: str = "https://hermes-agent.local/slack/commands") -> dict[str, Any]:
     """Generate a Slack app manifest with all gateway commands as slashes.
 

--- a/hermes_cli/slack_cli.py
+++ b/hermes_cli/slack_cli.py
@@ -49,7 +49,7 @@ def _build_full_manifest(bot_name: str, bot_description: str) -> dict:
         },
         "features": {
             "app_home": {
-                "home_tab_enabled": False,
+                "home_tab_enabled": True,
                 "messages_tab_enabled": True,
                 "messages_tab_read_only_enabled": False,
             },
@@ -85,6 +85,7 @@ def _build_full_manifest(bot_name: str, bot_description: str) -> dict:
         "settings": {
             "event_subscriptions": {
                 "bot_events": [
+                    "app_home_opened",
                     "app_mention",
                     "assistant_thread_context_changed",
                     "assistant_thread_started",

--- a/tests/gateway/test_slack_app_home.py
+++ b/tests/gateway/test_slack_app_home.py
@@ -1,0 +1,33 @@
+"""Slack App Home tab — a read-only orientation view (identity, how-to, command list)."""
+from __future__ import annotations
+
+from gateway.platforms.slack import build_app_home_view
+from hermes_cli.commands import gateway_command_summaries
+
+
+def test_gateway_command_summaries_nonempty_and_unique():
+    summaries = gateway_command_summaries()
+    assert len(summaries) > 1
+    names = [n for n, _ in summaries]
+    assert len(names) == len(set(names))  # canonical names, deduped
+    assert all(isinstance(n, str) and isinstance(d, str) for n, d in summaries)
+
+
+def test_app_home_view_shape_and_content():
+    view = build_app_home_view("Welchman", "welchman", [("model", "Set the model"), ("stop", "Stop the run")])
+    assert view["type"] == "home"
+    blocks = view["blocks"]
+    assert blocks[0]["type"] == "header" and "Welchman" in blocks[0]["text"]["text"]
+    section_text = " ".join(b.get("text", {}).get("text", "") for b in blocks if b.get("type") == "section")
+    assert "/welchman" in section_text  # how-to references the configured command
+    assert "`model`" in section_text and "`stop`" in section_text  # commands are listed
+
+
+def test_app_home_view_respects_slack_caps():
+    # a huge command list with long descriptions must still fit Slack's limits
+    big = [(f"cmd{i}", "d" * 300) for i in range(500)]
+    view = build_app_home_view("Bot", "bot", big)
+    assert len(view["blocks"]) <= 100  # home view block cap
+    for b in view["blocks"]:
+        if b.get("type") == "section":
+            assert len(b["text"]["text"]) <= 3000  # section text cap

--- a/tests/hermes_cli/test_slack_cli.py
+++ b/tests/hermes_cli/test_slack_cli.py
@@ -10,7 +10,7 @@ class TestSlackFullManifest:
         manifest = _build_full_manifest("Hermes", "Your Hermes agent on Slack")
 
         assert manifest["features"]["app_home"] == {
-            "home_tab_enabled": False,
+            "home_tab_enabled": True,
             "messages_tab_enabled": True,
             "messages_tab_read_only_enabled": False,
         }


### PR DESCRIPTION
## What

Adds a read-only Slack **App Home** tab. On `app_home_opened`, the bot publishes a Home view with: its identity, how to reach it (DM / @mention / `/<command>`), and the list of gateway commands.

## Why

App Home is the natural per-app place to orient a Slack user. It's also valuable when an operator reduces the slash surface to a single `/<command>` (e.g. to share a workspace cleanly with other apps): the Home tab restores the command discovery the full slash menu would otherwise provide. Independent of — and complementary to — the per-instance-command PR (#48642); either can merge on its own.

## Change

- **Manifest** (`hermes slack manifest`): enable `home_tab_enabled` and subscribe `app_home_opened`.
- **`gateway/platforms/slack.py`**: `build_app_home_view()` (pure; respects Slack's ≤100-block / ≤3000-char-per-section caps) + an `app_home_opened` handler that publishes it. Publish failures are logged, never escalated.
- **`hermes_cli/commands.py`**: `gateway_command_summaries()` — `(name, description)` for gateway-available commands, for any surface that lists them.

## Compatibility

Additive. No change to existing message/slash/mention handling. The Home tab is read-only (no interactive controls yet — a natural follow-up).

## Testing

- New `tests/gateway/test_slack_app_home.py`: view shape + content, the Slack block/char caps, and the command-summary invariants.
- Existing Slack suite green — 255 passed (incl. the manifest assertion updated for the now-enabled Home tab).
