### PR TITLE
fix(codex): resolve codex.CMD via shutil.which before subprocess spawn (Fixes #48510)

### DIFF
--- a/agent/transports/codex_app_server.py
+++ b/agent/transports/codex_app_server.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 import json
 import os
 import queue
+import shutil
 import subprocess
 import threading
 import time
@@ -28,6 +29,21 @@ from typing import Any, Optional
 # Default minimum codex version we test against. The PR sets this from the
 # `codex --version` parsed at install time; bumping is a one-line change here.
 MIN_CODEX_VERSION = (0, 125, 0)
+
+
+def resolve_codex_bin(codex_bin: str) -> str:
+    """Resolve a codex CLI name to an executable path before subprocess spawn.
+
+    On Windows, ``npm i -g @openai/codex`` installs ``codex.CMD``.  List-form
+    ``subprocess.run/Popen(["codex", ...])`` uses CreateProcess directly and
+    does not honor PATHEXT, so the bare name fails even when ``shutil.which``
+    finds the shim.  Resolving once here mirrors the Node-ecosystem pattern in
+    ``hermes_cli._subprocess_compat.resolve_node_command``.
+    """
+    if os.path.isabs(codex_bin) and os.path.isfile(codex_bin):
+        return codex_bin
+    resolved = shutil.which(codex_bin)
+    return resolved or codex_bin
 
 
 @dataclass
@@ -73,7 +89,7 @@ class CodexAppServerClient:
         extra_args: Optional[list[str]] = None,
         env: Optional[dict[str, str]] = None,
     ) -> None:
-        self._codex_bin = codex_bin
+        self._codex_bin = resolve_codex_bin(codex_bin)
         spawn_env = os.environ.copy()
         if env:
             spawn_env.update(env)
@@ -110,7 +126,7 @@ class CodexAppServerClient:
                 ]
             )
 
-        cmd = [codex_bin, "app-server"] + app_server_args
+        cmd = [self._codex_bin, "app-server"] + app_server_args
         # Codex emits tracing to stderr; default WARN keeps it quiet for users.
         spawn_env.setdefault("RUST_LOG", "warn")
 
@@ -372,9 +388,10 @@ def check_codex_binary(
     """Verify codex CLI is installed and meets minimum version.
 
     Returns (ok, message). Used by setup wizard and runtime startup."""
+    resolved_bin = resolve_codex_bin(codex_bin)
     try:
         proc = subprocess.run(
-            [codex_bin, "--version"],
+            [resolved_bin, "--version"],
             capture_output=True,
             text=True,
             timeout=10,
@@ -382,7 +399,7 @@ def check_codex_binary(
         )
     except FileNotFoundError:
         return False, (
-            f"codex CLI not found at {codex_bin!r}. Install with: "
+            f"codex CLI not found at {resolved_bin!r}. Install with: "
             f"npm i -g @openai/codex"
         )
     except subprocess.TimeoutExpired:

--- a/agent/transports/codex_app_server_session.py
+++ b/agent/transports/codex_app_server_session.py
@@ -36,6 +36,7 @@ from agent.redact import redact_sensitive_text
 from agent.transports.codex_app_server import (
     CodexAppServerClient,
     CodexAppServerError,
+    resolve_codex_bin,
 )
 from agent.transports.codex_event_projector import CodexEventProjector
 
@@ -210,7 +211,7 @@ class CodexAppServerSession:
         client_factory: Optional[Callable[..., CodexAppServerClient]] = None,
     ) -> None:
         self._cwd = cwd or os.getcwd()
-        self._codex_bin = codex_bin
+        self._codex_bin = resolve_codex_bin(codex_bin)
         self._codex_home = codex_home
         self._permission_profile = (
             permission_profile or _HERMES_TO_CODEX_PERMISSION_PROFILE.get(

--- a/tests/agent/transports/test_codex_app_server_runtime.py
+++ b/tests/agent/transports/test_codex_app_server_runtime.py
@@ -135,6 +135,96 @@ class TestCodexAppServerModule:
         assert ok is False
         assert "not found" in msg.lower() or "no such" in msg.lower()
 
+    def test_resolve_codex_bin_uses_which_for_bare_name(self, monkeypatch) -> None:
+        from agent.transports.codex_app_server import resolve_codex_bin
+
+        monkeypatch.setattr(
+            "agent.transports.codex_app_server.shutil.which",
+            lambda name: r"C:\Users\alice\AppData\Roaming\npm\codex.CMD"
+            if name == "codex"
+            else None,
+        )
+        assert (
+            resolve_codex_bin("codex")
+            == r"C:\Users\alice\AppData\Roaming\npm\codex.CMD"
+        )
+
+    def test_resolve_codex_bin_keeps_existing_absolute_path(self, tmp_path) -> None:
+        from agent.transports.codex_app_server import resolve_codex_bin
+
+        codex_path = tmp_path / "codex.CMD"
+        codex_path.write_text("@echo off\n", encoding="utf-8")
+        assert resolve_codex_bin(str(codex_path)) == str(codex_path)
+
+    def test_check_codex_binary_spawns_resolved_path(self, monkeypatch) -> None:
+        import subprocess
+
+        from agent.transports.codex_app_server import check_codex_binary
+
+        resolved = r"C:\Users\alice\AppData\Roaming\npm\codex.CMD"
+        monkeypatch.setattr(
+            "agent.transports.codex_app_server.shutil.which",
+            lambda name: resolved if name == "codex" else None,
+        )
+
+        captured: dict[str, list[str]] = {}
+
+        def fake_run(cmd, **kwargs):
+            captured["cmd"] = list(cmd)
+
+            class _Proc:
+                returncode = 0
+                stdout = "codex-cli 0.139.0"
+                stderr = ""
+
+            return _Proc()
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+        ok, msg = check_codex_binary(codex_bin="codex")
+        assert ok is True
+        assert captured["cmd"] == [resolved, "--version"]
+        assert msg == "0.139.0"
+
+    def test_client_spawn_uses_resolved_codex_path(self, monkeypatch) -> None:
+        import subprocess
+
+        from agent.transports import codex_app_server as cas
+
+        resolved = r"C:\Users\alice\AppData\Roaming\npm\codex.CMD"
+        monkeypatch.setattr(
+            "agent.transports.codex_app_server.shutil.which",
+            lambda name: resolved if name == "codex" else None,
+        )
+
+        captured: dict[str, list[str]] = {}
+
+        class FakePopen:
+            def __init__(self, cmd, *args, **kwargs):
+                captured["cmd"] = list(cmd)
+                self.stdin = None
+                self.stdout = None
+                self.stderr = None
+                self.pid = 1
+                self.returncode = None
+
+            def poll(self):
+                return None
+
+            def terminate(self):
+                pass
+
+            def wait(self, timeout=None):
+                return 0
+
+            def kill(self):
+                pass
+
+        monkeypatch.setattr(subprocess, "Popen", FakePopen)
+        client = cas.CodexAppServerClient(codex_bin="codex")
+        client._closed = True
+
+        assert captured["cmd"][:2] == [resolved, "app-server"]
+
     def test_codex_error_class_is_runtimeerror(self) -> None:
         from agent.transports.codex_app_server import CodexAppServerError
 


### PR DESCRIPTION
## Summary
- Add `resolve_codex_bin()` to resolve the codex CLI through `shutil.which()` before any list-form `subprocess.run` / `Popen` call
- On Windows, `npm i -g @openai/codex` installs `codex.CMD`; CreateProcess does not honor PATHEXT, so bare "codex"` failed even when on PATH
- Applies to `check_codex_binary()`, `CodexAppServerClient`, and `CodexAppServerSession` — fixes `/codex-runtime` detection and `codex_app_server` spawn

Fixes #48510

## Test plan
- [x] `pytest tests/agent/transports/test_codex_app_server_runtime.py::TestCodexAppServerModule -q` (9 passed)
- [x] `pytest tests/agent/transports/test_codex_app_server_session.py tests/hermes_cli/test_codex_runtime_switch.py -q` (88 passed)
- [ ] Manual (Windows): `npm i -g @openai/codex` then verify `/codex-runtime` reports codex installed