### PR TITLE
feat(desktop): add 'Copy full changelog' button to updates overlay

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -2154,7 +2154,7 @@ async function readCommitLog(cwd, branch) {
   const REC = '\x1e'
 
   const { stdout } = await runGit(
-    ['log', `HEAD..origin/${branch}`, `--pretty=format:%H${SEP}%s${SEP}%an${SEP}%at${REC}`],
+    ['log', `HEAD..origin/${branch}`, `--pretty=format:%H${SEP}%s${SEP}%an${SEP}%at${REC}`, '-n', '40'],
     { cwd }
   )
 

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -2154,7 +2154,7 @@ async function readCommitLog(cwd, branch) {
   const REC = '\x1e'
 
   const { stdout } = await runGit(
-    ['log', `HEAD..origin/${branch}`, `--pretty=format:%H${SEP}%s${SEP}%an${SEP}%at${REC}`, '-n', '40'],
+    ['log', `HEAD..origin/${branch}`, `--pretty=format:%H${SEP}%s${SEP}%an${SEP}%at${REC}`],
     { cwd }
   )
 

--- a/apps/desktop/src/app/updates-overlay.tsx
+++ b/apps/desktop/src/app/updates-overlay.tsx
@@ -9,8 +9,8 @@ import { ErrorIcon, ErrorState } from '@/components/ui/error-state'
 import { Loader } from '@/components/ui/loader'
 import type { DesktopUpdateCommit, DesktopUpdateStage, DesktopUpdateStatus } from '@/global'
 import { useI18n } from '@/i18n'
-import { buildCommitChangelog, parseCommitHeader, type CommitGroup } from '@/lib/commit-changelog'
-import { AlertCircle, Check, CheckCircle2, Copy, Terminal } from '@/lib/icons'
+import { buildCommitChangelog, formatFullChangelogText, type CommitGroup } from '@/lib/commit-changelog'
+import { AlertCircle, Check, Copy, Terminal } from '@/lib/icons'
 import { cn } from '@/lib/utils'
 import { resolveUpdateCopy, type UpdateTarget } from '@/lib/update-copy'
 import {
@@ -33,26 +33,6 @@ import {
 
 function totalItems(groups: readonly CommitGroup[]) {
   return groups.reduce((sum, g) => sum + g.items.length, 0)
-}
-
-function formatFullChangelogText(commits: readonly DesktopUpdateCommit[], behind: number, branch: string | undefined): string {
-  const lines: string[] = ['=== Hermes Update Changelog ===']
-  if (behind > 0) {
-    lines.push(`Behind by ${behind} commit${behind === 1 ? '' : 's'}${branch ? ` on branch ${branch}` : ''}`)
-  }
-  lines.push('')
-
-  for (const c of commits) {
-    const parsed = parseCommitHeader(c.summary ?? '')
-    const prefix = parsed.type ? (parsed.breaking ? `${parsed.type}!` : parsed.type) : ''
-    const scope = parsed.scope ? `(${parsed.scope})` : ''
-    const tag = prefix + scope
-    const subject = parsed.subject || c.summary || ''
-    const line = tag ? `${tag}: ${subject} — ${c.author}` : `${subject} — ${c.author}`
-    lines.push(line)
-  }
-
-  return lines.join('\n')
 }
 
 export function UpdatesOverlay() {

--- a/apps/desktop/src/app/updates-overlay.tsx
+++ b/apps/desktop/src/app/updates-overlay.tsx
@@ -9,10 +9,10 @@ import { ErrorIcon, ErrorState } from '@/components/ui/error-state'
 import { Loader } from '@/components/ui/loader'
 import type { DesktopUpdateCommit, DesktopUpdateStage, DesktopUpdateStatus } from '@/global'
 import { useI18n } from '@/i18n'
-import { buildCommitChangelog, type CommitGroup } from '@/lib/commit-changelog'
-import { AlertCircle, Check, Copy, Terminal } from '@/lib/icons'
-import { resolveUpdateCopy, type UpdateTarget } from '@/lib/update-copy'
+import { buildCommitChangelog, parseCommitHeader, type CommitGroup } from '@/lib/commit-changelog'
+import { AlertCircle, Check, CheckCircle2, Copy, Terminal } from '@/lib/icons'
 import { cn } from '@/lib/utils'
+import { resolveUpdateCopy, type UpdateTarget } from '@/lib/update-copy'
 import {
   $backendUpdateApply,
   $backendUpdateChecking,
@@ -33,6 +33,26 @@ import {
 
 function totalItems(groups: readonly CommitGroup[]) {
   return groups.reduce((sum, g) => sum + g.items.length, 0)
+}
+
+function formatFullChangelogText(commits: readonly DesktopUpdateCommit[], behind: number, branch: string | undefined): string {
+  const lines: string[] = ['=== Hermes Update Changelog ===']
+  if (behind > 0) {
+    lines.push(`Behind by ${behind} commit${behind === 1 ? '' : 's'}${branch ? ` on branch ${branch}` : ''}`)
+  }
+  lines.push('')
+
+  for (const c of commits) {
+    const parsed = parseCommitHeader(c.summary ?? '')
+    const prefix = parsed.type ? (parsed.breaking ? `${parsed.type}!` : parsed.type) : ''
+    const scope = parsed.scope ? `(${parsed.scope})` : ''
+    const tag = prefix + scope
+    const subject = parsed.subject || c.summary || ''
+    const line = tag ? `${tag}: ${subject} — ${c.author}` : `${subject} — ${c.author}`
+    lines.push(line)
+  }
+
+  return lines.join('\n')
 }
 
 export function UpdatesOverlay() {
@@ -217,6 +237,15 @@ function IdleView({
   // instead of generic filler.
   const { title, body } = resolveUpdateCopy({ target, shownItems, copy: u })
 
+  const [logCopied, setLogCopied] = useState(false)
+
+  const handleCopyFullLog = () => {
+    void writeClipboardText(formatFullChangelogText(commits, behind, status.branch)).then(() => {
+      setLogCopied(true)
+      window.setTimeout(() => setLogCopied(false), 1800)
+    })
+  }
+
   return (
     <div className="grid gap-5 px-6 pb-6 pt-7 pr-8">
       <div className="flex flex-col items-center gap-3 text-center">
@@ -241,6 +270,26 @@ function IdleView({
           </div>
         ))}
       </div>
+
+      {commits.length > 0 && (
+        <button
+          className="group flex w-full items-center justify-center gap-2 rounded-lg border border-border/50 bg-transparent px-3 py-2 text-xs font-medium text-muted-foreground transition-colors hover:border-border hover:bg-muted/30 hover:text-foreground"
+          onClick={handleCopyFullLog}
+          type="button"
+        >
+          {logCopied ? (
+            <>
+              <Check className="size-3.5 text-emerald-600 dark:text-emerald-400" />
+              {u.copied}
+            </>
+          ) : (
+            <>
+              <Copy className="size-3.5" />
+              {u.copyFullLog}
+            </>
+          )}
+        </button>
+      )}
 
       <div className="grid gap-2">
         <Button className="font-semibold" onClick={onInstall} size="lg">

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -1865,6 +1865,7 @@ export const en: Translations = {
     updateNow: 'Update now',
     maybeLater: 'Maybe later',
     moreChanges: count => `+ ${count} more change${count === 1 ? '' : 's'} included.`,
+    copyFullLog: 'Copy full changelog',
     manualTitle: 'Update from your terminal',
     manualBody: 'You installed Hermes from the command line, so updates run there too. Paste this into your terminal:',
     manualPickedUp: 'Hermes will pick up the new version next time you launch it.',

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -1805,6 +1805,7 @@ export const ja = defineLocale({
     updateNow: '今すぐ更新',
     maybeLater: '後で',
     moreChanges: count => `さらに ${count} 件の変更が含まれています。`,
+    copyFullLog: '完全な変更ログをコピー',
     manualTitle: 'ターミナルから更新',
     manualBody:
       'Hermes をコマンドラインからインストールしたため、更新もそこで実行されます。これをターミナルに貼り付けてください:',

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -1528,6 +1528,7 @@ export interface Translations {
     updateNow: string
     maybeLater: string
     moreChanges: (count: number) => string
+    copyFullLog: string
     manualTitle: string
     manualBody: string
     manualPickedUp: string

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -1753,6 +1753,7 @@ export const zhHant = defineLocale({
     updateNow: '立即更新',
     maybeLater: '稍後再說',
     moreChanges: count => `另有 ${count} 項變更。`,
+    copyFullLog: '複製完整更新日誌',
     manualTitle: '從終端機更新',
     manualBody: '您是從命令列安裝的 Hermes，因此更新也需要在那裡執行。請將此指令貼到終端機：',
     manualPickedUp: '下次啟動 Hermes 時會使用新版本。',

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -2039,6 +2039,7 @@ export const zh: Translations = {
     updateNow: '立即更新',
     maybeLater: '稍后再说',
     moreChanges: count => `另有 ${count} 项更改。`,
+    copyFullLog: '复制完整更新日志',
     manualTitle: '从终端更新',
     manualBody: '你是从命令行安装的 Hermes，因此更新也需要在那里运行。请将此命令粘贴到终端：',
     manualPickedUp: '下次启动 Hermes 时会使用新版本。',

--- a/apps/desktop/src/lib/commit-changelog.test.ts
+++ b/apps/desktop/src/lib/commit-changelog.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import { buildCommitChangelog, parseCommitHeader } from './commit-changelog'
+import { buildCommitChangelog, formatFullChangelogText, parseCommitHeader } from './commit-changelog'
 
 describe('parseCommitHeader', () => {
   it('extracts type, scope, and subject from a conventional header', () => {
@@ -110,5 +110,66 @@ describe('buildCommitChangelog', () => {
 
     const totalItems = groups.reduce((sum, g) => sum + g.items.length, 0)
     expect(totalItems).toBe(3)
+  })
+})
+
+describe('formatFullChangelogText', () => {
+  it('formats conventional commit lines', () => {
+    const result = formatFullChangelogText(
+      [{ sha: 'abc', summary: 'feat: add login', author: 'Alice' }],
+      3,
+      'main'
+    )
+    expect(result).toContain('=== Hermes Update Changelog ===')
+    expect(result).toContain('Behind by 3 commits on branch main')
+    expect(result).toContain('feat: add login — Alice')
+  })
+
+  it('formats scoped commit', () => {
+    const result = formatFullChangelogText(
+      [{ sha: 'abc', summary: 'fix(api): handle timeout', author: 'Bob' }],
+      0,
+      'main'
+    )
+    expect(result).toContain('fix(api): handle timeout — Bob')
+  })
+
+  it('formats breaking commit with bang after scope', () => {
+    const result = formatFullChangelogText(
+      [{ sha: 'abc', summary: 'feat(api)!: change endpoint shape', author: 'Carol' }],
+      0
+    )
+    // Canonical: type(scope)!:  not type!(scope):
+    expect(result).toContain('feat(api)!: change endpoint shape — Carol')
+    expect(result).not.toContain('feat!(api)')
+  })
+
+  it('falls back to raw summary for non-conventional headers', () => {
+    const result = formatFullChangelogText(
+      [{ sha: 'abc', summary: 'fix bug in login', author: 'Dave' }],
+      0
+    )
+    expect(result).toContain('fix bug in login — Dave')
+  })
+
+  it('includes singular behind message when behind === 1', () => {
+    const result = formatFullChangelogText(
+      [{ sha: 'abc', summary: 'fix: minor', author: 'Eve' }],
+      1
+    )
+    expect(result).toContain('Behind by 1 commit')
+  })
+
+  it('omits branch when not provided', () => {
+    const result = formatFullChangelogText(
+      [{ sha: 'abc', summary: 'fix: minor', author: 'Eve' }],
+      0
+    )
+    expect(result).not.toContain('on branch')
+  })
+
+  it('handles empty commits list gracefully', () => {
+    const result = formatFullChangelogText([], 0, 'main')
+    expect(result).toContain('=== Hermes Update Changelog ===')
   })
 })

--- a/apps/desktop/src/lib/commit-changelog.ts
+++ b/apps/desktop/src/lib/commit-changelog.ts
@@ -177,3 +177,37 @@ export function buildCommitChangelog(
 
   return result
 }
+
+/** Format a full changelog text for clipboard copy.
+ *
+ *  Header: `=== Hermes Update Changelog ===`
+ *  Behind header: `Behind by N commits on branch X`
+ *  Each commit: `type(scope)!: subject — author`
+ *  Breaking commits use canonical `type(scope)!:` not `type!(scope):`.
+ */
+export function formatFullChangelogText(
+  commits: readonly { sha?: string; summary?: string; author?: string }[],
+  behind: number,
+  branch?: string
+): string {
+  const lines: string[] = ['=== Hermes Update Changelog ===']
+
+  if (behind > 0) {
+    lines.push(`Behind by ${behind} commit${behind === 1 ? '' : 's'}${branch ? ` on branch ${branch}` : ''}`)
+  }
+
+  lines.push('')
+
+  for (const c of commits) {
+    const parsed = parseCommitHeader(c.summary ?? '')
+    const type = parsed.type ?? ''
+    const scope = parsed.scope ? `(${parsed.scope})` : ''
+    const bang = parsed.breaking ? '!' : ''
+    const tag = type + scope + bang
+    const subject = parsed.subject || c.summary || ''
+    const line = tag ? `${tag}: ${subject} — ${c.author ?? ''}` : `${subject} — ${c.author ?? ''}`
+    lines.push(line)
+  }
+
+  return lines.join('\n')
+}


### PR DESCRIPTION
## Summary

Adds a **"Copy full changelog"** button to the desktop update overlay that copies all pending commits as formatted text (`type(scope): subject — author`) to the clipboard. This lets users paste the full changelog into a translator, AI tool, or share it with others.

Supports i18n: English "Copy full changelog" and Chinese "复制完整更新日志".

## Changes

### `apps/desktop/electron/main.cjs`
- **Remove `-n 40` limit** from `readCommitLog()` so all commits behind are fetched from git, not just the first 40

### `apps/desktop/src/app/updates-overlay.tsx`
- Add `parseCommitHeader` import
- Add `formatFullChangelogText()` — formats all commits as `type(scope): subject — author` per line with a header showing behind count and branch
- Add a **"Copy full changelog"** button in the `IdleView`, between the changelog groups and the action buttons
- Button shows brief "Copied" feedback (1.8s) after copying
- Only renders when `commits.length > 0`
- Uses i18n keys `copyFullLog` / `copied`

### `apps/desktop/src/i18n/en.ts`, `zh.ts`, `types.ts`
- Add `copyFullLog` i18n key with English and Chinese translations

## Before / After

**Before:** 6 short items max, no way to copy or see the rest
**After:** Same 6-item display UI, plus a discreet "Copy full changelog" button that gives you the complete raw changelog

Closes #48654