### PR TITLE
fix(npm): lock react-simple-icons to 13.11.1

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -55,7 +55,7 @@
     "@dnd-kit/sortable": "^10.0.0",
     "@dnd-kit/utilities": "^3.2.2",
     "@hermes/shared": "file:../shared",
-    "@icons-pack/react-simple-icons": "^13.13.0",
+    "@icons-pack/react-simple-icons": "=13.11.1",
     "@nanostores/react": "^1.1.0",
     "@nous-research/ui": "^0.13.0",
     "@radix-ui/react-slot": "^1.2.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -69,7 +69,7 @@
         "@dnd-kit/sortable": "^10.0.0",
         "@dnd-kit/utilities": "^3.2.2",
         "@hermes/shared": "file:../shared",
-        "@icons-pack/react-simple-icons": "^13.13.0",
+        "@icons-pack/react-simple-icons": "=13.11.1",
         "@nanostores/react": "^1.1.0",
         "@nous-research/ui": "^0.13.0",
         "@radix-ui/react-slot": "^1.2.4",
@@ -171,6 +171,15 @@
       },
       "optionalDependencies": {
         "global-agent": "^3.0.0"
+      }
+    },
+    "apps/desktop/node_modules/@icons-pack/react-simple-icons": {
+      "version": "13.11.1",
+      "resolved": "https://registry.npmjs.org/@icons-pack/react-simple-icons/-/react-simple-icons-13.11.1.tgz",
+      "integrity": "sha512-WbwN/o7dUHEjDCJh2p3RvDZ4kZ8nhfUSkUSm0bWuPTXIsoKgDJpwD5UkMCG22R/5kZH6lHAZXwuHWsKNtX7fYA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.13 || ^17 || ^18 || ^19"
       }
     },
     "apps/desktop/node_modules/@nous-research/ui": {
@@ -2283,19 +2292,6 @@
         "@antfu/install-pkg": "^1.1.0",
         "@iconify/types": "^2.0.0",
         "import-meta-resolve": "^4.2.0"
-      }
-    },
-    "node_modules/@icons-pack/react-simple-icons": {
-      "version": "13.13.0",
-      "resolved": "https://registry.npmjs.org/@icons-pack/react-simple-icons/-/react-simple-icons-13.13.0.tgz",
-      "integrity": "sha512-B5HhQMIpcSH4z8IZ8HFhD59CboHceKYMpPC9kAwGyKntvPdyJJv26DLu4Z1wAjcCLyrJhf11tMhiQGom9Rxb9g==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=24",
-        "pnpm": ">=10"
-      },
-      "peerDependencies": {
-        "react": "^16.13 || ^17 || ^18 || ^19"
       }
     },
     "node_modules/@isaacs/fs-minipass": {


### PR DESCRIPTION


## What does this PR do?

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->
suppress annoying message about engines that's completely benign but people seem to complain


## Related Issue

## Type of Change

<!-- Check the one that applies. -->

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- locks react-simple-icons to a versions before the node 26 min req was added

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. npm ci
2. no warning about EBADENGINE->

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [ ] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

<!-- Only fill this out if you're adding a skill. Delete this section otherwise. -->

- [ ] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [ ] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

