### PR TITLE
fix(desktop): close TOCTOU race in readFileDataUrl IPC handler

### DIFF
--- a/apps/desktop/electron/hardening.cjs
+++ b/apps/desktop/electron/hardening.cjs
@@ -270,6 +270,7 @@ module.exports = {
   DEFAULT_FETCH_TIMEOUT_MS,
   TEXT_PREVIEW_SOURCE_MAX_BYTES,
   encryptDesktopSecret,
+  ipcPathError,
   rejectUnsafePathSyntax,
   resolveDirectoryForIpc,
   resolveReadableFileForIpc,

--- a/apps/desktop/electron/main.cjs
+++ b/apps/desktop/electron/main.cjs
@@ -76,6 +76,7 @@ const {
   DEFAULT_FETCH_TIMEOUT_MS,
   TEXT_PREVIEW_SOURCE_MAX_BYTES,
   encryptDesktopSecret: encryptDesktopSecretStrict,
+  ipcPathError,
   resolveReadableFileForIpc,
   resolveRequestedPathForIpc,
   resolveTimeoutMs
@@ -5656,12 +5657,27 @@ ipcMain.handle('hermes:notify', (_event, payload) => {
 })
 
 ipcMain.handle('hermes:readFileDataUrl', async (_event, filePath) => {
-  const { resolvedPath } = await resolveReadableFileForIpc(filePath, {
+  const { resolvedPath, stat } = await resolveReadableFileForIpc(filePath, {
     maxBytes: DATA_URL_READ_MAX_BYTES,
     purpose: 'File preview'
   })
-  const data = await fs.promises.readFile(resolvedPath)
-  return `data:${mimeTypeForPath(resolvedPath)};base64,${data.toString('base64')}`
+  const handle = await fs.promises.open(resolvedPath, 'r')
+
+  try {
+    const liveStat = await handle.stat()
+    if (liveStat.size > DATA_URL_READ_MAX_BYTES) {
+      throw ipcPathError('EFBIG', `File preview failed: file is too large (${liveStat.size} bytes; limit ${DATA_URL_READ_MAX_BYTES} bytes).`)
+    }
+
+    const bytesToRead = Math.min(stat.size, DATA_URL_READ_MAX_BYTES)
+    const buffer = Buffer.alloc(bytesToRead)
+    const { bytesRead } = await handle.read(buffer, 0, bytesToRead, 0)
+    const data = buffer.subarray(0, bytesRead)
+
+    return `data:${mimeTypeForPath(resolvedPath)};base64,${data.toString('base64')}`
+  } finally {
+    await handle.close()
+  }
 })
 
 ipcMain.handle('hermes:readFileText', async (_event, filePath) => {


### PR DESCRIPTION
## What does this PR do?

The `hermes:readFileDataUrl` IPC handler validates file size via `resolveReadableFileForIpc` (stat + `maxBytes` check against `DATA_URL_READ_MAX_BYTES`), but then calls `fs.promises.readFile(resolvedPath)`, which re-opens the path by name and reads the entire file. Between the initial `stat()` and this re-open, the file on disk could grow (symlink swap, concurrent write), bypassing the size cap and loading an arbitrarily large file into memory.

The sibling handler `hermes:readFileText` already avoids this correctly by opening a file handle once and reading a bounded number of bytes from it. This PR applies the same pattern to `readFileDataUrl`:

- Opens a single file handle via `fs.promises.open`
- Re-stats via `handle.stat()` immediately after opening as a defense-in-depth check against growth between the two stat calls
- Reads only `Math.min(stat.size, DATA_URL_READ_MAX_BYTES)` bytes from that handle
- Closes the handle in a `finally` block
- Throws the existing `EFBIG` `ipcPathError` if the re-stat shows the file now exceeds the cap

`ipcPathError` was used internally in `hardening.cjs` but not exported — added a one-line export so `main.cjs` can reuse it consistently with how it already reuses other hardening helpers.

External behavior (return shape, mime type detection) is unchanged.

## Note for reviewer

Two other open PRs touch the `DATA_URL_READ_MAX_BYTES` constant in the same handler area: #46008 (raises cap to 25MB) and #47834 (raises cap to 128MB). Neither touches the read logic itself — they only change the cap value. This PR fixes the TOCTOU race independent of whatever the cap ends up being, but whichever of those two merges first will likely need a small rebase against this one (or vice versa) since we're editing adjacent lines in the same handler.

## Related Issue

N/A

## Type of Change

- [x] 🔒 Security fix

## Changes Made

- `apps/desktop/electron/hardening.cjs` — export `ipcPathError`
- `apps/desktop/electron/main.cjs` — rewrite `hermes:readFileDataUrl` to use open-handle + bounded-read pattern with re-stat guard

## How to Test

1. `node --test apps/desktop/electron/hardening.test.cjs`
2. Manually: attach/preview an image file in Desktop chat composer, confirm it still renders correctly
3. Confirm a file exceeding `DATA_URL_READ_MAX_BYTES` still gets rejected with the EFBIG error

## Checklist

- [x] Contributing Guide read
- [x] Conventional Commits format
- [x] Duplicate PR check done (searched readFileDataUrl/TOCTOU/DATA_URL_READ_MAX_BYTES — no existing PR addresses the race condition itself)
- [x] `node --test apps/desktop/electron/hardening.test.cjs` passed
- [x] Platform: Windows 11 + WSL2 Ubuntu