### PR TITLE
fix(telegram): truncate mid-stream overflow instead of splitting

### DIFF
--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -2685,9 +2685,22 @@ class TelegramAdapter(BasePlatformAdapter):
         # Pre-flight: if content already exceeds the limit, split-and-deliver
         # without round-tripping a doomed edit.
         if utf16_len(content) > self.MAX_MESSAGE_LENGTH:
-            return await self._edit_overflow_split(
-                chat_id, message_id, content, finalize=finalize, metadata=metadata,
-            )
+            if not finalize:
+                # Mid-stream overflow: truncate the preview instead of
+                # spawning continuation messages.  _edit_overflow_split
+                # sends chunks[1:] as new messages and updates the active
+                # message_id; the next token edit carries the full
+                # accumulated text (still > limit), triggering another
+                # split → infinite reply chain (#48648).  Truncate to
+                # 4000 code-units (safe margin below the 4096 cap) so the
+                # preview keeps updating on the same message until the
+                # stream finishes and finalize=True does the real split.
+                truncated = content[:4000]
+                content = truncated
+            else:
+                return await self._edit_overflow_split(
+                    chat_id, message_id, content, finalize=finalize, metadata=metadata,
+                )
 
         try:
             if not finalize:

--- a/tests/gateway/test_telegram_format.py
+++ b/tests/gateway/test_telegram_format.py
@@ -839,45 +839,63 @@ class TestEditMessageStreamingSafety:
         }
 
     @pytest.mark.asyncio
-    async def test_message_too_long_splits_into_continuations_not_silent_truncation(self):
-        """When edit_message_text exceeds Telegram's 4096 UTF-16 limit, the
-        adapter must split the content across the existing message + new
-        continuation messages so the user gets the full reply.  Previously
-        the adapter best-effort truncated the content with '…' and returned
-        success=True, dropping everything past the truncation boundary
-        (#19537)."""
+    async def test_mid_stream_overflow_truncates_not_splits(self):
+        """When finalize=False and content exceeds the 4096 UTF-16 limit,
+        edit_message must truncate the preview instead of spawning continuation
+        messages.  Splitting during streaming triggers an infinite reply chain
+        because the next token edit carries the full accumulated text (#48648).
+        """
         adapter = TelegramAdapter(PlatformConfig(enabled=True, token="fake-token"))
         adapter._bot = MagicMock()
         adapter._bot.edit_message_text = AsyncMock()
-        # Continuation sends return monotonically increasing message ids.
-        _next_id = [1000]
-        async def _fake_send(**kwargs):
-            _next_id[0] += 1
-            return SimpleNamespace(message_id=_next_id[0])
-        adapter._bot.send_message = AsyncMock(side_effect=_fake_send)
+        adapter._bot.send_message = AsyncMock()
 
         # 6000-char content well over the 4096 UTF-16 limit.
         oversized = "x" * 6000
         result = await adapter.edit_message("123", "456", oversized, finalize=False)
 
-        # Adapter reports success with continuations populated.
+        # Adapter reports success.
         assert result.success is True
         assert result.error is None
-        assert len(result.continuation_message_ids) >= 1, (
-            "expected at least one continuation message"
-        )
-        # The reported message_id is the LAST visible message (the final
-        # continuation), so subsequent edits target the most recent.
-        assert result.message_id == result.continuation_message_ids[-1]
-        # Original message_id (456) was edited with chunk 1.
+        # No continuations — truncation keeps everything on the same message.
+        assert len(result.continuation_message_ids) == 0
+        # send_message was NOT called (no overflow continuations).
+        adapter._bot.send_message.assert_not_called()
+        # The edit used truncated content (≤ 4000 chars).
         first_edit = adapter._bot.edit_message_text.call_args
+        edited_text = first_edit.kwargs.get("text") or first_edit[1].get("text")
+        assert len(edited_text) <= 4000
+        # Original message_id was used (not a continuation).
         assert first_edit.kwargs["message_id"] == 456
-        # Continuations were sent threaded as replies for visual grouping.
-        assert adapter._bot.send_message.await_count == len(result.continuation_message_ids)
 
     @pytest.mark.asyncio
-    async def test_message_too_long_continuations_preserve_topic_metadata(self):
-        """Overflow continuations should stay in the originating Telegram topic."""
+    async def test_finalize_true_still_splits_into_continuations(self):
+        """When finalize=True and content exceeds the limit, the adapter must
+        still split into continuation messages (the real delivery path)."""
+        adapter = TelegramAdapter(PlatformConfig(enabled=True, token="fake-token"))
+        adapter._bot = MagicMock()
+        adapter._bot.edit_message_text = AsyncMock()
+        _next_id = [1000]
+
+        async def _fake_send(**kwargs):
+            _next_id[0] += 1
+            return SimpleNamespace(message_id=_next_id[0])
+
+        adapter._bot.send_message = AsyncMock(side_effect=_fake_send)
+
+        oversized = "x" * 6000
+        result = await adapter.edit_message("123", "456", oversized, finalize=True)
+
+        assert result.success is True
+        assert len(result.continuation_message_ids) >= 1, (
+            "expected at least one continuation message on finalize"
+        )
+        assert adapter._bot.send_message.await_count >= 1
+
+    @pytest.mark.asyncio
+    async def test_finalize_true_continuations_preserve_topic_metadata(self):
+        """When finalize=True, overflow continuations should stay in the
+        originating Telegram topic (thread_id propagated)."""
         adapter = TelegramAdapter(PlatformConfig(enabled=True, token="fake-token"))
         adapter._bot = MagicMock()
         adapter._bot.edit_message_text = AsyncMock()
@@ -893,12 +911,12 @@ class TestEditMessageStreamingSafety:
             "-100123",
             "456",
             "x" * 6000,
-            finalize=False,
+            finalize=True,
             metadata={"thread_id": "17585"},
         )
 
         assert result.success is True
-        assert sent_kwargs, "expected at least one overflow continuation"
+        assert sent_kwargs, "expected at least one overflow continuation on finalize"
         assert all(kwargs.get("message_thread_id") == 17585 for kwargs in sent_kwargs)
         assert sent_kwargs[0]["reply_to_message_id"] == 456
 

--- a/tests/gateway/test_telegram_overflow_truncation.py
+++ b/tests/gateway/test_telegram_overflow_truncation.py
@@ -1,0 +1,115 @@
+"""Regression test for #48648 — Telegram infinite reply chain on mid-stream overflow.
+
+When streamed content exceeds Telegram's 4096 UTF-16 code-unit limit,
+edit_message must NOT call _edit_overflow_split during streaming
+(finalize=False) because that spawns continuation messages, updates the
+active message_id, and the next token edit carries the full accumulated
+text (still > limit) → infinite reply chain.  Instead the preview must be
+truncated to keep updating the same message until finalize=True does the
+real split.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+def _make_adapter():
+    """Create a minimal TelegramAdapter with a mocked bot."""
+    from gateway.platforms.telegram import TelegramAdapter
+
+    adapter = object.__new__(TelegramAdapter)
+    adapter._bot = MagicMock()
+    adapter.MAX_MESSAGE_LENGTH = 4096
+    adapter._metadata_thread_id = MagicMock(return_value=None)
+    adapter._thread_kwargs_for_send = MagicMock(return_value={})
+    adapter._rich_eligible = MagicMock(return_value=False)
+    # name is a read-only property on the base class; mock it at class level
+    type(adapter).name = property(lambda self: "telegram")
+    return adapter
+
+
+class TestMidStreamOverflowTruncation:
+    """#48648: mid-stream overflow must truncate, not split."""
+
+    @pytest.mark.asyncio
+    async def test_finalize_false_truncates_instead_of_splitting(self):
+        """When finalize=False and content > 4096, edit_message must truncate
+        the content and edit the same message — NOT call _edit_overflow_split."""
+        adapter = _make_adapter()
+        long_content = "x" * 5000  # exceeds 4096
+
+        # Mock edit_message_text to succeed
+        adapter._bot.edit_message_text = AsyncMock()
+
+        # Mock _edit_overflow_split — should NOT be called
+        adapter._edit_overflow_split = AsyncMock()
+
+        from gateway.platforms.base import SendResult
+
+        result = await adapter.edit_message(
+            chat_id="12345",
+            message_id="999",
+            content=long_content,
+            finalize=False,
+        )
+
+        # Must NOT have called _edit_overflow_split
+        adapter._edit_overflow_split.assert_not_called()
+
+        # Must have edited with truncated content (≤ 4000 chars)
+        call_args = adapter._bot.edit_message_text.call_args
+        edited_text = call_args.kwargs.get("text") or call_args[1].get("text")
+        assert len(edited_text) <= 4000, (
+            f"expected truncated content ≤ 4000, got {len(edited_text)}"
+        )
+        assert result.success is True
+        assert result.message_id == "999"  # same message, not a continuation
+
+    @pytest.mark.asyncio
+    async def test_finalize_true_splits_normally(self):
+        """When finalize=True and content > 4096, edit_message must still call
+        _edit_overflow_split to deliver all segments."""
+        adapter = _make_adapter()
+        long_content = "x" * 5000
+
+        # Mock _edit_overflow_split to return a success result
+        from gateway.platforms.base import SendResult
+
+        adapter._edit_overflow_split = AsyncMock(
+            return_value=SendResult(success=True, message_id="1001")
+        )
+
+        result = await adapter.edit_message(
+            chat_id="12345",
+            message_id="999",
+            content=long_content,
+            finalize=True,
+        )
+
+        # Must have called _edit_overflow_split
+        adapter._edit_overflow_split.assert_called_once()
+        assert result.message_id == "1001"
+
+    @pytest.mark.asyncio
+    async def test_under_limit_unchanged(self):
+        """Content under the limit should not be truncated."""
+        adapter = _make_adapter()
+        short_content = "hello"  # well under 4096
+
+        adapter._bot.edit_message_text = AsyncMock()
+        adapter._edit_overflow_split = AsyncMock()
+
+        result = await adapter.edit_message(
+            chat_id="12345",
+            message_id="999",
+            content=short_content,
+            finalize=False,
+        )
+
+        adapter._edit_overflow_split.assert_not_called()
+        call_args = adapter._bot.edit_message_text.call_args
+        edited_text = call_args.kwargs.get("text") or call_args[1].get("text")
+        assert edited_text == "hello"
+        assert result.success is True


### PR DESCRIPTION
## What does this PR do?

Fixes an infinite message duplication loop in the Telegram adapter when streamed content exceeds the 4096 UTF-16 code-unit limit. During streaming (`finalize=False`), the pre-flight overflow check unconditionally called `_edit_overflow_split`, which spawned continuation messages and updated the active `message_id`. On the next token, the full accumulated text (still > 4096) was edited to the new message, triggering another split — creating an infinite chain of duplicate replies.

The fix: when `finalize=False` and content exceeds the limit, truncate the preview to 4000 code-units (safe margin below 4096) and fall through to the normal edit path. The real split only happens when `finalize=True` (stream complete).

## Related Issue

Fixes #48648

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/platforms/telegram.py`: In `edit_message()`, when `finalize=False` and content exceeds `MAX_MESSAGE_LENGTH`, truncate to 4000 code-units instead of calling `_edit_overflow_split`. The split path is preserved for `finalize=True`.
- `tests/gateway/test_telegram_overflow_truncation.py`: 3 regression tests — mid-stream truncation, finalize-True split, and under-limit passthrough.

## How to Test

1. Run `python -m pytest tests/gateway/test_telegram_overflow_truncation.py -v` — all 3 tests should pass
2. On Telegram: start a streaming response that grows past 4096 chars. Before this fix, you'd see infinite nested replies. After: the preview truncates at 4000 chars and the final message splits cleanly.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

⚠️ GitNexus unavailable — grep-based fallback used.
- Analyzed: `gateway/platforms/telegram.py::edit_message` (callers: stream_consumer, gateway run.py)
- Blast radius: LOW — only affects mid-stream overflow path; finalize-True and under-limit paths unchanged
- Related patterns: `_edit_overflow_split` at L2804 handles chunked delivery on finalize; this fix defers to it
