### PR TITLE
fix(oneshot): run memory-provider teardown on `-z` to stop SIGABRT (exit 134) at shutdown

### DIFF
--- a/hermes_cli/oneshot.py
+++ b/hermes_cli/oneshot.py
@@ -211,19 +211,57 @@ def run_oneshot(
             raise failure
         real_stderr.write(f"hermes -z: agent failed: {failure}\n")
         real_stderr.flush()
-        return 1
+        _hard_exit(1)
 
     if not (response or "").strip():
         real_stderr.write("hermes -z: no final response was produced; treating the run as failed.\n")
         real_stderr.flush()
-        return 1
+        _hard_exit(1)
 
     assert response is not None  # narrowed by the empty-response guard above
     real_stdout.write(response)
     if not response.endswith("\n"):
         real_stdout.write("\n")
     real_stdout.flush()
-    return 0
+    _hard_exit(0)
+
+
+def _hard_exit(code: int) -> "int":
+    """Flush stdio/logging and terminate via ``os._exit``, bypassing
+    interpreter finalization.
+
+    ``_run_agent`` already ran the session-end teardown to flush memory and
+    join the memory provider's tracked background threads. But that provider
+    (Honcho) also spawns *untracked* fire-and-forget daemon threads for
+    mem-write / dialectic prefetch that can't be reliably joined; if one is
+    still blocked in an httpx request when ``Py_FinalizeEx`` runs, CPython
+    aborts the process ("Fatal Python error: Aborted", SIGABRT / exit 134)
+    while tearing that daemon thread down. The model output and the memory
+    write have both already completed by this point, so skipping the
+    daemon-thread teardown is safe and eliminates the cosmetic abort. Mirrors
+    the existing ``os._exit`` worker-exit pattern in cli.py. A SIGALRM deadman
+    guards the flush against the rare blocking-I/O case.
+
+    Returns its argument for type-checkers; in practice it never returns.
+    """
+    try:
+        import signal as _sig_mod
+        if hasattr(_sig_mod, "SIGALRM"):
+            _sig_mod.signal(_sig_mod.SIGALRM, lambda *_: os._exit(code))
+            _sig_mod.alarm(2)
+    except Exception:
+        pass
+    try:
+        logging.shutdown()
+    except Exception:
+        pass
+    for _stream in (sys.stdout, sys.stderr):
+        try:
+            _stream.flush()
+        except Exception:
+            pass
+    os._exit(code)
+    return code  # unreachable; keeps the return-type contract
 
 
 def _create_session_db_for_oneshot():
@@ -364,7 +402,30 @@ def _run_agent(
     agent.stream_delta_callback = None
     agent.tool_gen_callback = None
 
-    return agent.chat(prompt) or ""
+    response = agent.chat(prompt) or ""
+
+    # Oneshot is a real session boundary: there's no REPL loop and no
+    # cli.py finalizer behind us (this path "bypasses cli.py entirely"),
+    # so the session-end teardown that the interactive / `-q` paths run
+    # via ``_finalize_single_query`` never fires here. Run it explicitly
+    # so memory providers flush their session and quiesce the background
+    # daemon threads they spawn (Honcho's prefetch / sync / dialectic /
+    # mem-write workers make blocking httpx calls). Without this, one of
+    # those daemon threads is still mid-request when ``Py_FinalizeEx``
+    # runs at process exit; CPython routes the live daemon thread through
+    # ``PyThread_exit_thread`` → ``pthread_exit``, which glibc turns into
+    # "Fatal Python error: Aborted" (SIGABRT / exit 134). Best-effort: a
+    # failure here must never mask the response we already produced.
+    try:
+        _msgs = getattr(agent, "_session_messages", None)
+        if isinstance(_msgs, list):
+            agent.shutdown_memory_provider(_msgs)
+        else:
+            agent.shutdown_memory_provider()
+    except Exception:
+        pass
+
+    return response
 
 
 def _oneshot_clarify_callback(question: str, choices=None) -> str:


### PR DESCRIPTION
## Problem

Running a one-shot prompt with `hermes -z` exits with **134 (SIGABRT, "Fatal Python error: Aborted")** during interpreter shutdown when a memory provider that spawns background daemon threads is active (reproduced with the Honcho provider). The model response and the memory write both complete successfully first — the abort happens only as the process tears down, so it's cosmetic but produces a nonzero exit code and an alarming traceback.

### Root cause

The `-z` oneshot path (`hermes_cli/oneshot.py` → `_run_agent`) bypasses `cli.py` entirely and returns right after `agent.chat()`, so it never runs the session-end teardown that the interactive / `-q` paths run via `_finalize_single_query` / `shutdown_memory_provider`. The Honcho provider spawns several fire-and-forget daemon threads (prefetch / sync / dialectic / mem-write) that make blocking httpx calls. With no teardown, one can still be mid-request when `Py_FinalizeEx` runs; CPython routes the live daemon thread through `PyThread_exit_thread` → `pthread_exit`, which glibc turns into the fatal abort.

Native backtrace (from `coredumpctl`), identical across crashes:

```
abort (libc)
pthread_exit (libc)
PyThread_exit_thread (python3.11)
PyEval_RestoreThread        # daemon thread re-acquiring the GIL after a blocking call
... pydantic_core / httpx ...  # mid-serialize of a Honcho request
```

Confirmed by toggling the provider: `enabled: false` → exit 0; re-enabling → exit 134. Switching Honcho's `writeFrequency` async→session was **not** sufficient (other untracked daemon threads remain), so this needs a code fix, not config.

## Fix

`hermes_cli/oneshot.py`:

1. `_run_agent` now calls `agent.shutdown_memory_provider(...)` after `agent.chat()` — the session-end teardown the oneshot path was missing — so providers flush their session and join their *tracked* threads (matching the interactive path). Best-effort: a failure here never masks the response already produced.
2. A new `_hard_exit(code)` helper replaces the three post-agent `return`s in `run_oneshot`: it flushes logging + stdio (guarded by a SIGALRM deadman) then calls `os._exit(code)`, bypassing `Py_FinalizeEx` so any *untracked* straggler daemon thread can't trigger the abort. This mirrors the existing `os._exit` worker-exit pattern already in `cli.py`. The early `--provider`/`--toolsets` validation `return`s (which run before any agent/threads exist) are left as plain returns.

## Testing

- `hermes -p <profile> -z "Reply with exactly: ok"` → prints `ok`, **exit 0**, no core dump. Reproduced cleanly across repeated runs, including the worst case with `writeFrequency: async` (async-writer daemon thread present).
- Memory writes still land — the provider's session flush runs before exit (verified message count increasing in the Honcho store across runs).

Happy to adjust the approach — e.g. if you'd prefer to quiesce/join the provider's untracked daemon threads inside `shutdown_memory_provider` rather than hard-exit. The `os._exit` approach is the minimal, low-risk fix given the response + memory write are already complete at that point.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
