### PR TITLE
Fix desktop send crash loops

### DIFF
--- a/apps/desktop/electron/main.cjs
+++ b/apps/desktop/electron/main.cjs
@@ -46,6 +46,7 @@ const { gitRootForIpc } = require('./git-root.cjs')
 const { worktreesForIpc } = require('./git-worktrees.cjs')
 const { OFFICIAL_REPO_HTTPS_URL, isOfficialSshRemote } = require('./update-remote.cjs')
 const { runRebuildWithRetry } = require('./update-rebuild.cjs')
+const { createMessageSendRestartGuard, safeDecodeChunk } = require('./runtime-guards.cjs')
 const {
   buildPosixCleanupScript,
   buildWindowsCleanupScript,
@@ -810,7 +811,7 @@ function scheduleDesktopLogFlush() {
 }
 
 function rememberLog(chunk) {
-  const text = String(chunk || '').trim()
+  const text = safeDecodeChunk(chunk).trim()
   if (!text) return
   const lines = text.split(/\r?\n/).map(line => `[hermes] ${line}`)
   hermesLog.push(...lines)
@@ -1430,12 +1431,12 @@ function runGit(args, options = {}) {
     let stdout = ''
     let stderr = ''
     child.stdout.on('data', chunk => {
-      const text = chunk.toString()
+      const text = safeDecodeChunk(chunk)
       stdout += text
       options.onLine?.('stdout', text)
     })
     child.stderr.on('data', chunk => {
-      const text = chunk.toString()
+      const text = safeDecodeChunk(chunk)
       stderr += text
       options.onLine?.('stderr', text)
     })
@@ -1591,6 +1592,16 @@ async function readCommitLog(cwd, branch) {
 }
 
 let updateInFlight = false
+const messageSendRestartGuard = createMessageSendRestartGuard()
+
+function restartBlockedByMessageSend() {
+  const reason = messageSendRestartGuard.restartBlockReason()
+  if (!reason) return null
+
+  const message = `Deferring desktop restart handoff while a message send is active or has just failed (${reason}).`
+  rememberLog(`[restart-guard] ${message}`)
+  return message
+}
 
 // Resolve the staged updater binary. The Tauri installer copies itself to
 // HERMES_HOME/hermes-setup.exe on a successful install (see
@@ -1761,6 +1772,13 @@ async function applyUpdates(opts = {}) {
   if (updateInFlight) {
     throw new Error('An update is already in progress.')
   }
+
+  const restartBlock = restartBlockedByMessageSend()
+  if (restartBlock) {
+    emitUpdateProgress({ stage: 'error', message: restartBlock, error: 'message-send-active' })
+    return { ok: false, recoverable: true, error: 'message-send-active', message: restartBlock }
+  }
+
   updateInFlight = true
 
   try {
@@ -1852,6 +1870,8 @@ async function applyUpdates(opts = {}) {
 async function handOffWindowsBootstrapRecovery(reason) {
   if (!IS_WINDOWS || !IS_PACKAGED) return false
 
+  if (restartBlockedByMessageSend()) return false
+
   const updater = resolveUpdaterBinary()
   if (!updater) return false
 
@@ -1914,7 +1934,7 @@ function runStreamedUpdate(command, args, { cwd, env, stage } = {}) {
       return
     }
     const emitLines = chunk => {
-      for (const line of chunk.toString().split('\n')) {
+      for (const line of safeDecodeChunk(chunk).split('\n')) {
         const trimmed = line.trim()
         if (trimmed) emitUpdateProgress({ stage, message: trimmed, percent: null })
       }
@@ -5273,6 +5293,7 @@ function createWindow() {
 }
 
 ipcMain.handle('hermes:connection', async (_event, profile) => ensureBackend(profile))
+ipcMain.handle('hermes:message-send:state', async (_event, payload) => messageSendRestartGuard.record(payload))
 // Reconnect-after-wake recovery. A REMOTE primary backend has no child process,
 // so the 'exit'/'error' handlers that would clear a dead connectionPromise never
 // fire — once the remote becomes unreachable across a sleep/wake the renderer
@@ -6237,7 +6258,7 @@ async function getUninstallSummary() {
         })
       )
       child.stdout.on('data', chunk => {
-        stdout += chunk.toString()
+        stdout += safeDecodeChunk(chunk)
       })
       child.on('error', () => done(fallback()))
       child.on('exit', code => {

--- a/apps/desktop/electron/preload.cjs
+++ b/apps/desktop/electron/preload.cjs
@@ -3,7 +3,10 @@ const { contextBridge, ipcRenderer, webUtils } = require('electron')
 contextBridge.exposeInMainWorld('hermesDesktop', {
   getConnection: profile => ipcRenderer.invoke('hermes:connection', profile),
   revalidateConnection: () => ipcRenderer.invoke('hermes:connection:revalidate'),
+  // Keepalive: mark a pool profile backend as recently used so the idle reaper
+  // spares it while its chat is active.
   touchBackend: profile => ipcRenderer.invoke('hermes:backend:touch', profile),
+  setMessageSendState: payload => ipcRenderer.invoke('hermes:message-send:state', payload),
   getGatewayWsUrl: profile => ipcRenderer.invoke('hermes:gateway:ws-url', profile),
   openSessionWindow: (sessionId, opts) => ipcRenderer.invoke('hermes:window:openSession', sessionId, opts),
   openNewSessionWindow: () => ipcRenderer.invoke('hermes:window:openNewSession'),

--- a/apps/desktop/electron/runtime-guards.cjs
+++ b/apps/desktop/electron/runtime-guards.cjs
@@ -1,0 +1,75 @@
+'use strict'
+
+const MESSAGE_SEND_RESTART_BLOCK_MS = 15_000
+
+function safeDecodeChunk(chunk) {
+  if (chunk === null || chunk === undefined) {
+    return ''
+  }
+
+  if (Buffer.isBuffer(chunk)) {
+    return chunk.toString('utf8')
+  }
+
+  if (chunk instanceof Uint8Array) {
+    return Buffer.from(chunk).toString('utf8')
+  }
+
+  try {
+    return String(chunk)
+  } catch {
+    return ''
+  }
+}
+
+function createMessageSendRestartGuard({ graceMs = MESSAGE_SEND_RESTART_BLOCK_MS, now = () => Date.now() } = {}) {
+  let activeCount = 0
+  let lastFailureAt = 0
+
+  const snapshot = () => ({
+    activeCount,
+    blockingRestart: activeCount > 0 || (lastFailureAt > 0 && now() - lastFailureAt < graceMs),
+    lastFailureAt: lastFailureAt || null
+  })
+
+  return {
+    snapshot,
+    record(payload = {}) {
+      switch (payload.state) {
+        case 'begin':
+          activeCount += 1
+          break
+        case 'failure':
+          activeCount = Math.max(0, activeCount - 1)
+          lastFailureAt = now()
+          break
+        case 'success':
+          activeCount = Math.max(0, activeCount - 1)
+          break
+        default:
+          break
+      }
+
+      return snapshot()
+    },
+    restartBlockReason() {
+      const current = snapshot()
+
+      if (current.activeCount > 0) {
+        return `message-send-active:${current.activeCount}`
+      }
+
+      if (current.blockingRestart) {
+        return 'message-send-recent-failure'
+      }
+
+      return null
+    }
+  }
+}
+
+module.exports = {
+  MESSAGE_SEND_RESTART_BLOCK_MS,
+  createMessageSendRestartGuard,
+  safeDecodeChunk
+}

--- a/apps/desktop/electron/runtime-guards.test.cjs
+++ b/apps/desktop/electron/runtime-guards.test.cjs
@@ -1,0 +1,32 @@
+'use strict'
+
+const test = require('node:test')
+const assert = require('node:assert/strict')
+
+const { createMessageSendRestartGuard, safeDecodeChunk } = require('./runtime-guards.cjs')
+
+test('safeDecodeChunk replaces malformed byte sequences instead of throwing', () => {
+  assert.equal(safeDecodeChunk(Buffer.from([0x61, 0x80, 0x62])), 'a�b')
+  assert.equal(safeDecodeChunk(null), '')
+  assert.equal(safeDecodeChunk('plain'), 'plain')
+})
+
+test('message send restart guard blocks during active sends and recent failures only', () => {
+  let now = 1_000
+  const guard = createMessageSendRestartGuard({ graceMs: 500, now: () => now })
+
+  assert.equal(guard.restartBlockReason(), null)
+  assert.deepEqual(guard.record({ state: 'begin' }), { activeCount: 1, blockingRestart: true, lastFailureAt: null })
+  assert.equal(guard.restartBlockReason(), 'message-send-active:1')
+
+  assert.deepEqual(guard.record({ state: 'success' }), { activeCount: 0, blockingRestart: false, lastFailureAt: null })
+  assert.equal(guard.restartBlockReason(), null)
+
+  assert.deepEqual(guard.record({ state: 'begin' }), { activeCount: 1, blockingRestart: true, lastFailureAt: null })
+  assert.deepEqual(guard.record({ state: 'failure' }), { activeCount: 0, blockingRestart: true, lastFailureAt: 1_000 })
+  assert.equal(guard.restartBlockReason(), 'message-send-recent-failure')
+
+  now = 1_501
+  assert.deepEqual(guard.snapshot(), { activeCount: 0, blockingRestart: false, lastFailureAt: 1_000 })
+  assert.equal(guard.restartBlockReason(), null)
+})

--- a/apps/desktop/electron/windows-child-process.test.cjs
+++ b/apps/desktop/electron/windows-child-process.test.cjs
@@ -11,8 +11,32 @@ function readElectronFile(name) {
   return fs.readFileSync(path.join(ELECTRON_DIR, name), 'utf8').replace(/\r\n/g, '\n')
 }
 
+function compactSourceWithMap(source) {
+  let text = ''
+  const map = []
+
+  for (let index = 0; index < source.length; index += 1) {
+    if (/\s/.test(source[index])) continue
+    map[text.length] = index
+    text += source[index]
+  }
+
+  return { text, map }
+}
+
+function sourceIndexOf(source, needle) {
+  const direct = source.indexOf(needle)
+  if (direct !== -1) return direct
+
+  const compactNeedle = needle.replace(/\s+/g, '')
+  const compact = compactSourceWithMap(source)
+  const compactIndex = compact.text.indexOf(compactNeedle)
+
+  return compactIndex === -1 ? -1 : compact.map[compactIndex]
+}
+
 function requireHiddenChildOptions(source, needle) {
-  const index = source.indexOf(needle)
+  const index = sourceIndexOf(source, needle)
   assert.notEqual(index, -1, `missing call site: ${needle}`)
   const snippet = source.slice(index, index + 700)
   assert.match(
@@ -28,10 +52,9 @@ test('desktop background child processes opt into hidden Windows consoles', () =
   assert.match(source, /function hiddenWindowsChildOptions\(options = \{\}\)/)
 
   requireHiddenChildOptions(source, "execFileSync(\n          'reg'")
-  requireHiddenChildOptions(source, 'execFileSync(pyExe')
+  requireHiddenChildOptions(source, 'execFileSync(\n          pyExe')
   requireHiddenChildOptions(source, 'spawn(resolveGitBinary()')
   requireHiddenChildOptions(source, "execFileSync('taskkill'")
-  requireHiddenChildOptions(source, 'spawn(command, args')
   requireHiddenChildOptions(source, "spawn('curl'")
   requireHiddenChildOptions(source, 'spawn(backend.command, backend.args')
   requireHiddenChildOptions(source, 'hermesProcess = spawn(backend.command, backend.args')

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -37,7 +37,7 @@
     "test:desktop:nsis": "node scripts/test-desktop.mjs nsis",
     "test:desktop:existing": "node scripts/test-desktop.mjs existing",
     "test:desktop:fresh": "node scripts/test-desktop.mjs fresh",
-    "test:desktop:platforms": "node --test electron/bootstrap-platform.test.cjs electron/hardening.test.cjs electron/backend-env.test.cjs electron/backend-probes.test.cjs electron/bootstrap-runner.test.cjs electron/connection-config.test.cjs electron/dashboard-token.test.cjs electron/gateway-ws-probe.test.cjs electron/oauth-net-request.test.cjs electron/desktop-uninstall.test.cjs electron/session-windows.test.cjs electron/workspace-cwd.test.cjs electron/fs-read-dir.test.cjs electron/git-root.test.cjs electron/windows-child-process.test.cjs electron/update-remote.test.cjs electron/update-rebuild.test.cjs electron/windows-user-env.test.cjs",
+    "test:desktop:platforms": "node --test electron/bootstrap-platform.test.cjs electron/hardening.test.cjs electron/backend-env.test.cjs electron/backend-probes.test.cjs electron/bootstrap-runner.test.cjs electron/connection-config.test.cjs electron/dashboard-token.test.cjs electron/gateway-ws-probe.test.cjs electron/oauth-net-request.test.cjs electron/desktop-uninstall.test.cjs electron/session-windows.test.cjs electron/workspace-cwd.test.cjs electron/fs-read-dir.test.cjs electron/git-root.test.cjs electron/windows-child-process.test.cjs electron/update-remote.test.cjs electron/update-rebuild.test.cjs electron/runtime-guards.test.cjs electron/windows-user-env.test.cjs",
     "typecheck": "tsc -p . --noEmit",
     "lint": "eslint src/ electron/",
     "lint:fix": "eslint src/ electron/ --fix",

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions.test.tsx
@@ -3,6 +3,7 @@ import type { MutableRefObject } from 'react'
 import { useEffect, useRef } from 'react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
+import { getStatus } from '@/hermes'
 import { textPart } from '@/lib/chat-messages'
 import { $composerAttachments, type ComposerAttachment } from '@/store/composer'
 import { $busy, $connection, $messages, $sessions, setSessions } from '@/store/session'
@@ -12,9 +13,16 @@ import { uploadComposerAttachment, usePromptActions } from './use-prompt-actions
 
 vi.mock('@/hermes', () => ({
   getProfiles: vi.fn(async () => ({ profiles: [] })),
+  getStatus: vi.fn(async () => ({ gateway_running: true, gateway_state: 'running' })),
   setApiRequestProfile: vi.fn(),
   transcribeAudio: vi.fn()
 }))
+
+const getStatusMock = vi.mocked(getStatus)
+
+beforeEach(() => {
+  getStatusMock.mockResolvedValue({ gateway_running: true, gateway_state: 'running' } as never)
+})
 
 // The active id the desktop holds is the *runtime* session id from
 // session.create — deliberately distinct from the stored DB id here, because
@@ -418,6 +426,52 @@ describe('usePromptActions submit / queue drain semantics', () => {
 
     expect(accepted).toBe(false)
     expect(requestGateway).not.toHaveBeenCalledWith('prompt.submit', expect.anything())
+  })
+
+  it('blocks prompt.submit locally when /api/status reports a stopped gateway', async () => {
+    getStatusMock.mockResolvedValue({ gateway_running: false, gateway_state: 'stopped' } as never)
+    const requestGateway = vi.fn(async () => ({}) as never)
+    const seeds: Record<string, unknown>[] = []
+
+    let handle: HarnessHandle | null = null
+    render(
+      <Harness
+        onReady={h => (handle = h)}
+        onSeedState={s => seeds.push(s)}
+        refreshSessions={async () => undefined}
+        requestGateway={requestGateway}
+      />
+    )
+
+    const accepted = await handle!.submitText('should not loop')
+
+    expect(accepted).toBe(false)
+    expect(getStatusMock).toHaveBeenCalled()
+    expect(requestGateway).not.toHaveBeenCalledWith('prompt.submit', expect.anything())
+    expect(seeds).toEqual([])
+  })
+
+  it('filters malformed attachment slots before building refs and prompt context', async () => {
+    const requestGateway = vi.fn(async () => ({}) as never)
+    const validAttachment: ComposerAttachment = {
+      id: 'file:report.txt',
+      kind: 'file',
+      label: 'report.txt',
+      refText: '@file:report.txt'
+    }
+
+    let handle: HarnessHandle | null = null
+    render(<Harness onReady={h => (handle = h)} refreshSessions={async () => undefined} requestGateway={requestGateway} />)
+
+    const accepted = await handle!.submitText('summarize', {
+      attachments: [undefined, null, { kind: 'file' }, validAttachment] as unknown as ComposerAttachment[]
+    })
+
+    expect(accepted).toBe(true)
+    expect(requestGateway).toHaveBeenCalledWith('prompt.submit', {
+      session_id: RUNTIME_SESSION_ID,
+      text: '@file:report.txt\n\nsummarize'
+    })
   })
 })
 

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions.ts
@@ -2,11 +2,12 @@ import type { AppendMessage, ThreadMessage } from '@assistant-ui/react'
 import { useStore } from '@nanostores/react'
 import { type MutableRefObject, useCallback, useEffect, useRef } from 'react'
 
-import { getProfiles, transcribeAudio } from '@/hermes'
+import { getProfiles, getStatus, transcribeAudio } from '@/hermes'
 import { translateNow, type Translations, useI18n } from '@/i18n'
 import { stripAnsi } from '@/lib/ansi'
 import { branchGroupForUser, type ChatMessage, chatMessageText, textPart } from '@/lib/chat-messages'
 import {
+  normalizeComposerAttachments,
   optimisticAttachmentRef,
   parseCommandDispatch,
   parseSlashCommand,
@@ -55,6 +56,7 @@ import {
 } from '@/store/session'
 import { clearSessionSubagents } from '@/store/subagents'
 import { clearSessionTodos } from '@/store/todos'
+import type { StatusResponse } from '@/types/hermes'
 
 import type {
   ClientSessionState,
@@ -110,6 +112,42 @@ function inlineErrorMessage(error: unknown, fallback: string): string {
   const raw = error instanceof Error ? error.message : typeof error === 'string' ? error : fallback
 
   return (raw.match(/Error invoking remote method '[^']+': Error: (.+)$/)?.[1] ?? raw).replace(/^Error:\s*/, '').trim()
+}
+
+const PRE_SEND_BLOCKED_GATEWAY_STATES = new Set(['startup_failed', 'stopped'])
+
+export function preSendGatewayHealthError(status: Pick<StatusResponse, 'gateway_running' | 'gateway_state'>): string | null {
+  const gatewayState = status.gateway_state?.trim().toLowerCase() || null
+
+  if (status.gateway_running && !PRE_SEND_BLOCKED_GATEWAY_STATES.has(gatewayState || '')) {
+    return null
+  }
+
+  const details = [
+    `gateway_running=${status.gateway_running ? 'true' : 'false'}`,
+    gatewayState ? `gateway_state=${gatewayState}` : null
+  ]
+    .filter(Boolean)
+    .join(', ')
+
+  return `Hermes gateway is not ready for sending (${details}). Restart the gateway or wait for it to finish starting, then try again.`
+}
+
+export async function checkPreSendGatewayHealth(
+  fetchStatus: () => Promise<StatusResponse> = getStatus
+): Promise<string | null> {
+  try {
+    return preSendGatewayHealthError(await fetchStatus())
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+
+    return `Could not verify Hermes gateway status before sending: ${message}`
+  }
+}
+
+function markDesktopMessageSendState(state: 'begin' | 'failure' | 'success'): void {
+  const pending = window.hermesDesktop?.setMessageSendState?.({ state })
+  void pending?.catch(() => undefined)
 }
 
 function isSessionNotFoundError(error: unknown): boolean {
@@ -550,7 +588,7 @@ export function usePromptActions({
     async (rawText: string, options?: SubmitTextOptions) => {
       const visibleText = rawText.trim()
       const usingComposerAttachments = !options?.attachments
-      const attachments = options?.attachments ?? $composerAttachments.get()
+      const attachments = normalizeComposerAttachments(options?.attachments ?? $composerAttachments.get())
 
       const terminalContextBlocks = terminalContextBlocksFromDraft(rawText).join('\n\n')
       const hasImage = attachments.some(a => a.kind === 'image')
@@ -583,6 +621,17 @@ export function usePromptActions({
       if (!hasSendable || (!options?.fromQueue && busyRef.current)) {
         return false
       }
+
+      const preSendHealthError = await checkPreSendGatewayHealth()
+      if (preSendHealthError) {
+        clearNotifications()
+        notify({ kind: 'error', title: copy.sessionUnavailable, message: preSendHealthError })
+        markDesktopMessageSendState('failure')
+
+        return false
+      }
+
+      markDesktopMessageSendState('begin')
 
       const optimisticId = `user-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`
 
@@ -673,6 +722,7 @@ export function usePromptActions({
           dropOptimistic(null)
           releaseBusy()
           notifyError(err, copy.sessionUnavailable)
+          markDesktopMessageSendState('failure')
 
           return false
         }
@@ -681,6 +731,7 @@ export function usePromptActions({
           dropOptimistic(null)
           releaseBusy()
           notify({ kind: 'error', title: copy.sessionUnavailable, message: copy.createSessionFailed })
+          markDesktopMessageSendState('failure')
 
           return false
         }
@@ -735,6 +786,8 @@ export function usePromptActions({
           clearComposerAttachments()
         }
 
+        markDesktopMessageSendState('success')
+
         return true
       } catch (err) {
         releaseBusy()
@@ -743,6 +796,8 @@ export function usePromptActions({
         // "session busy" (4009). Don't surface an error bubble/toast — the entry
         // stays queued and the composer's bounded auto-drain retries when idle.
         if (options?.fromQueue && isSessionBusyError(err)) {
+          markDesktopMessageSendState('failure')
+
           return false
         }
 
@@ -768,11 +823,13 @@ export function usePromptActions({
 
         if (isProviderSetupError(err)) {
           requestDesktopOnboarding(copy.providerCredentialRequired)
+          markDesktopMessageSendState('failure')
 
           return false
         }
 
         notifyError(err, copy.promptFailed)
+        markDesktopMessageSendState('failure')
 
         return false
       }
@@ -1329,7 +1386,7 @@ export function usePromptActions({
   const submitText = useCallback(
     async (rawText: string, options?: SubmitTextOptions) => {
       const visibleText = rawText.trim()
-      const attachments = options?.attachments ?? $composerAttachments.get()
+      const attachments = normalizeComposerAttachments(options?.attachments ?? $composerAttachments.get())
 
       if (!attachments.length && SLASH_COMMAND_RE.test(visibleText)) {
         triggerHaptic('selection')

--- a/apps/desktop/src/global.d.ts
+++ b/apps/desktop/src/global.d.ts
@@ -17,6 +17,9 @@ declare global {
       // Keepalive: mark a pool profile backend as recently used so the idle
       // reaper spares it while its chat is active.
       touchBackend: (profile?: string | null) => Promise<{ ok: boolean }>
+      // Renderer -> main process hint used to suppress updater/bootstrap restart
+      // handoff while a chat send is active or has just failed recoverably.
+      setMessageSendState?: (payload: DesktopMessageSendStatePayload) => Promise<DesktopMessageSendStateSnapshot>
       getGatewayWsUrl: (profile?: null | string) => Promise<string>
       // Open (or focus) a standalone OS window for a single chat session so
       // the user can work with multiple chats side by side. Returns ok:false
@@ -123,6 +126,16 @@ declare global {
       }
     }
   }
+}
+
+export interface DesktopMessageSendStatePayload {
+  state: 'begin' | 'failure' | 'success'
+}
+
+export interface DesktopMessageSendStateSnapshot {
+  activeCount: number
+  blockingRestart: boolean
+  lastFailureAt: null | number
 }
 
 export interface DesktopMarketplaceSearchItem {

--- a/apps/desktop/src/lib/chat-runtime.test.ts
+++ b/apps/desktop/src/lib/chat-runtime.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest'
 
 import type { ComposerAttachment } from '@/store/composer'
 
-import { coerceThinkingText, optimisticAttachmentRef } from './chat-runtime'
+import { attachmentDisplayText, coerceThinkingText, normalizeComposerAttachments, optimisticAttachmentRef } from './chat-runtime'
 
 const DATA_URL = 'data:image/png;base64,iVBORw0KGgoAAAANS'
 
@@ -11,6 +11,12 @@ function attachment(overrides: Partial<ComposerAttachment> & Pick<ComposerAttach
 }
 
 describe('optimisticAttachmentRef', () => {
+  it('ignores empty attachment slots instead of throwing', () => {
+    expect(optimisticAttachmentRef(undefined)).toBeNull()
+    expect(optimisticAttachmentRef(null)).toBeNull()
+    expect(attachmentDisplayText(undefined)).toBeNull()
+  })
+
   it('renders an image from its in-hand base64 preview (no @image: path ref)', () => {
     const ref = optimisticAttachmentRef(attachment({ kind: 'image', detail: '/tmp/shot.png', previewUrl: DATA_URL }))
 
@@ -35,6 +41,14 @@ describe('optimisticAttachmentRef', () => {
     expect(optimisticAttachmentRef(attachment({ kind: 'file', refText: '@file:src/a.ts', previewUrl: DATA_URL }))).toBe(
       '@file:src/a.ts'
     )
+  })
+})
+
+describe('normalizeComposerAttachments', () => {
+  it('filters malformed attachment slots before submit-time mapping', () => {
+    const valid = attachment({ kind: 'file', refText: '@file:src/a.ts' })
+
+    expect(normalizeComposerAttachments([undefined, null, { kind: 'file' }, valid])).toEqual([valid])
   })
 })
 

--- a/apps/desktop/src/lib/chat-runtime.ts
+++ b/apps/desktop/src/lib/chat-runtime.ts
@@ -150,11 +150,28 @@ export function attachmentId(kind: ComposerAttachment['kind'], value: string): s
   return `${kind}:${value}`
 }
 
+export function isComposerAttachment(value: unknown): value is ComposerAttachment {
+  return Boolean(
+    value &&
+      typeof value === 'object' &&
+      typeof (value as Partial<ComposerAttachment>).kind === 'string' &&
+      typeof (value as Partial<ComposerAttachment>).label === 'string'
+  )
+}
+
+export function normalizeComposerAttachments(values?: readonly unknown[] | null): ComposerAttachment[] {
+  return Array.isArray(values) ? values.filter(isComposerAttachment) : []
+}
+
 export function pathLabel(path: string): string {
   return path.split(/[\\/]/).filter(Boolean).pop() || path
 }
 
-export function attachmentDisplayText(attachment: ComposerAttachment): string | null {
+export function attachmentDisplayText(attachment: ComposerAttachment | null | undefined): string | null {
+  if (!isComposerAttachment(attachment)) {
+    return null
+  }
+
   if (attachment.kind === 'terminal' && attachment.detail) {
     return `\`\`\`terminal\n${attachment.detail.trim()}\n\`\`\``
   }
@@ -187,7 +204,11 @@ export function attachmentDisplayText(attachment: ComposerAttachment): string | 
  * Everything else (files, folders, terminals, post-sync `@file:` refs) falls
  * through to `attachmentDisplayText`.
  */
-export function optimisticAttachmentRef(attachment: ComposerAttachment): string | null {
+export function optimisticAttachmentRef(attachment: ComposerAttachment | null | undefined): string | null {
+  if (!isComposerAttachment(attachment)) {
+    return null
+  }
+
   if (attachment.kind === 'image' && attachment.previewUrl?.startsWith('data:')) {
     return attachment.previewUrl
   }


### PR DESCRIPTION
## Summary
- Guard desktop chat attachment/session reference handling so undefined `refText` cannot crash the renderer.
- Add a pre-send gateway health gate so stopped/missing gateway state is shown as a local recoverable error instead of starting a send loop.
- Safely decode backend/gateway process output on Windows so stderr drain decode failures cannot crash log handling.
- Suppress updater/bootstrap restart handoff while an active message send is failing.

## Validation
- `npm test` / Vitest targeted desktop tests passed locally.
- `npm run test:desktop:platforms` passed locally.
- `npm run typecheck` passed locally.
- `git diff --check` passed locally.