### PR TITLE
fix: strip timestamp field from messages before sending to strict providers

### DIFF
--- a/agent/transports/chat_completions.py
+++ b/agent/transports/chat_completions.py
@@ -150,6 +150,14 @@ class ChatCompletionsTransport(ProviderTransport):
           ``Extra inputs are not permitted, field: 'messages[N].tool_name'``.
           Permissive providers (OpenRouter, MiniMax) silently ignore the
           field, which masked the bug for months.
+        - ``timestamp`` on every message — written by
+          ``get_messages_as_conversation()`` (a float Unix epoch from
+          ``time.time()``) when the gateway restores conversation history
+          from the SQLite session store. Not part of the Chat Completions
+          schema. Strict providers (Fireworks, Moonshot/Kimi, strict
+          OpenAI-compatible gateways) reject it with
+          ``Extra inputs are not permitted, field: 'messages[N].timestamp'``.
+          Permissive providers (real OpenAI, OpenRouter) silently ignore it.
         - Hermes-internal scaffolding markers — any top-level message key
           starting with ``_`` (e.g. ``_empty_recovery_synthetic``,
           ``_empty_terminal_sentinel``, ``_thinking_prefill``). These are
@@ -172,6 +180,7 @@ class ChatCompletionsTransport(ProviderTransport):
                 "codex_reasoning_items" in msg
                 or "codex_message_items" in msg
                 or "tool_name" in msg
+                or "timestamp" in msg
             ):
                 needs_sanitize = True
                 break
@@ -201,6 +210,7 @@ class ChatCompletionsTransport(ProviderTransport):
             msg.pop("codex_reasoning_items", None)
             msg.pop("codex_message_items", None)
             msg.pop("tool_name", None)
+            msg.pop("timestamp", None)
             # Drop all Hermes-internal scaffolding markers (``_``-prefixed).
             # OpenAI's message schema has no ``_``-prefixed fields, so this
             # is safe and future-proofs against new markers being added.

--- a/tests/agent/transports/test_chat_completions.py
+++ b/tests/agent/transports/test_chat_completions.py
@@ -104,6 +104,56 @@ class TestChatCompletionsBasic:
         # Original list untouched (deepcopy-on-demand)
         assert msgs[2]["tool_name"] == "execute_code"
 
+    def test_convert_messages_strips_timestamp(self, transport):
+        """The SQLite session store attaches a float ``timestamp`` to every
+        message when restoring conversation history via
+        ``get_messages_as_conversation()``. It is not part of the Chat
+        Completions schema. Strict providers (Fireworks, Moonshot/Kimi,
+        strict OpenAI-compatible gateways) reject it with HTTP 400
+        'Extra inputs are not permitted, field: messages[N].timestamp'.
+        Permissive providers (real OpenAI, OpenRouter) silently ignore it,
+        which masked the bug until a strict custom Fireworks proxy surfaced it.
+        """
+        msgs = [
+            {"role": "system", "content": "sys", "timestamp": 1781818044.0},
+            {"role": "user", "content": "hello", "timestamp": 1781818045.0},
+            {"role": "assistant", "content": "hi", "timestamp": 1781818046.0},
+        ]
+        result = transport.convert_messages(msgs)
+        for m in result:
+            assert "timestamp" not in m, m
+        # Visible content preserved
+        assert result[1]["content"] == "hello"
+        # Original list untouched (deepcopy-on-demand)
+        assert msgs[1]["timestamp"] == 1781818045.0
+
+    def test_convert_messages_strips_timestamp_and_tool_name_together(self, transport):
+        """timestamp and tool_name are stripped in the same sanitization pass."""
+        msgs = [
+            {"role": "user", "content": "do thing", "timestamp": 1781818044.0},
+            {"role": "tool", "tool_call_id": "tc1", "content": "ok",
+             "timestamp": 1781818045.0, "tool_name": "terminal"},
+        ]
+        result = transport.convert_messages(msgs)
+        for m in result:
+            assert "timestamp" not in m, m
+            assert "tool_name" not in m, m
+
+    def test_convert_messages_strips_timestamp_for_gemini_too(self, transport):
+        """Gemini models also need timestamp stripped (extra_content kept)."""
+        msgs = [
+            {"role": "assistant", "content": None, "timestamp": 1781818044.0,
+             "tool_calls": [
+                 {"id": "tc1", "type": "function",
+                  "function": {"name": "foo", "arguments": "{}"},
+                  "extra_content": "sig"},
+             ]},
+        ]
+        result = transport.convert_messages(msgs, model="gemini-2.5-flash")
+        assert "timestamp" not in result[0]
+        # extra_content is KEPT for Gemini models
+        assert result[0]["tool_calls"][0]["extra_content"] == "sig"
+
     def test_convert_messages_strips_internal_scaffolding_markers(self, transport):
         """Hermes-internal ``_``-prefixed markers must never reach the wire.
 


### PR DESCRIPTION
## What does this PR do?

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->

Strips the `timestamp` field from message dicts before they're sent to OpenAI-compatible providers via `convert_messages()` in `agent/transports/chat_completions.py`.

The field — a float Unix epoch from `time.time()` — is attached to every message by `get_messages_as_conversation()` in `hermes_state.py:2903-2904` when the gateway restores conversation history from the SQLite session store. It is not part of the OpenAI Chat Completions schema. Strict providers (Fireworks, Moonshot/Kimi, strict OpenAI-compatible gateways) reject it with:

```
HTTP 400: Extra inputs are not permitted, field: 'messages[N].timestamp'
```

Permissive providers (real OpenAI, OpenRouter) silently ignore unknown message keys, which masked the bug — the same pattern as `tool_name` (documented in the same function, lines 148-152). The fix adds `timestamp` to the existing detection check and sanitization pass, alongside the existing stripping of `codex_reasoning_items`, `tool_name`, `_-prefixed scaffolding markers`, and `extra_content`.

## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

N/A

## Type of Change

<!-- Check the one that applies. -->

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- `agent/transports/chat_completions.py`: Added `timestamp` to the detection check (line 183) and sanitization pass (line 213) in `convert_messages()`. Updated the docstring to document the new field.
- `tests/agent/transports/test_chat_completions.py`: Added three regression tests: `test_convert_messages_strips_timestamp`, `test_convert_messages_strips_timestamp_and_tool_name_together`, `test_convert_messages_strips_timestamp_for_gemini_too`.

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. `python -m pytest tests/agent/transports/test_chat_completions.py -k timestamp -v`
2. Reproduce the original bug: configure a custom provider pointing at a strict OpenAI-compatible endpoint (e.g. a Fireworks proxy with Pydantic validation), send a message via the gateway, observe `HTTP 400: Extra inputs are not permitted, field: 'messages[1].timestamp', value: 1781818044.0` on the second turn when history is replayed from the session store
3. Apply this fix and verify the error no longer occurs — `timestamp` is stripped before the payload reaches the provider

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass *(pytest not available in stripped install venv; tests verified manually — see How to Test)*
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu (Linux 6.12.93)

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [x] I've updated relevant documentation (docstring in `convert_messages()` updated) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

<!-- Only fill this out if you're adding a skill. Delete this section otherwise. -->

- [ ] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [ ] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

Original error from a strict Fireworks proxy:
```
HTTP 400: Extra inputs are not permitted, field: 'messages[1].timestamp', value: 1781818044.0
```

After fix — `timestamp` is stripped from all messages before they reach the wire:
```
msg[0] role=system, has_timestamp=False
msg[1] role=user, has_timestamp=False
msg[2] role=assistant, has_timestamp=False
msg[3] role=user, has_timestamp=False
```
