### PR TITLE
fix(gateway): skip transcriptless restart resumes

### DIFF
--- a/gateway/platforms/slack.py
+++ b/gateway/platforms/slack.py
@@ -2486,6 +2486,22 @@ class SlackAdapter(BasePlatformAdapter):
         is_mentioned = bot_uid and f"<@{bot_uid}>" in routing_text
         event_thread_ts = event.get("thread_ts")
         is_thread_reply = bool(event_thread_ts and event_thread_ts != ts)
+        files = event.get("files", [])
+
+        # Slack can redeliver metadata-only thread events during restart /
+        # rehydration windows. They carry routing fields but no user payload,
+        # so letting them through creates blank sessions that later suppress
+        # thread-context recovery. Check before fetching thread context, since
+        # context injection must not turn a contentless event into a user turn.
+        if not text.strip() and not files:
+            logger.debug(
+                "[Slack] Ignoring contentless message event channel=%s ts=%s thread_ts=%s subtype=%s",
+                channel_id,
+                ts,
+                thread_ts,
+                subtype or "",
+            )
+            return
 
         if not is_dm and bot_uid:
             # Check allowed channels — if set, only respond in these channels (whitelist)
@@ -2563,7 +2579,6 @@ class SlackAdapter(BasePlatformAdapter):
         media_urls = []
         media_types = []
         attachment_notices: List[str] = []
-        files = event.get("files", [])
         for f in files:
             # Slack Connect channels return stub file objects with
             # file_access="check_file_info" and no URL fields. We must
@@ -2782,6 +2797,16 @@ class SlackAdapter(BasePlatformAdapter):
                 msg_type = MessageType.VOICE
             else:
                 msg_type = MessageType.DOCUMENT
+
+        if not text.strip() and not media_urls:
+            logger.debug(
+                "[Slack] Ignoring contentless message event channel=%s ts=%s thread_ts=%s subtype=%s",
+                channel_id,
+                ts,
+                thread_ts,
+                subtype or "",
+            )
+            return
 
         # Resolve user display name (cached after first lookup)
         user_name = await self._resolve_user_name(user_id, chat_id=channel_id)
@@ -3631,7 +3656,13 @@ class SlackAdapter(BasePlatformAdapter):
             )
 
             session_store._ensure_loaded()
-            return session_key in session_store._entries
+            entry = session_store._entries.get(session_key)
+            if entry is None:
+                return False
+            try:
+                return bool(session_store.has_meaningful_transcript(entry.session_id))
+            except Exception:
+                return True
         except Exception:
             return False
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -4887,6 +4887,24 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 )
                 continue
 
+            try:
+                has_history = bool(
+                    self.session_store.has_meaningful_transcript(entry.session_id)
+                )
+            except Exception as exc:
+                logger.debug(
+                    "Could not inspect transcript before auto-resume for %s: %s",
+                    entry.session_key,
+                    exc,
+                )
+                has_history = True
+            if not has_history:
+                logger.debug(
+                    "Skipping auto-resume for %s: transcript has no meaningful content",
+                    entry.session_key,
+                )
+                continue
+
             # Claim the session slot *before* spawning the task so that an
             # inbound message arriving between task creation and the task's
             # first await (where _process_message_background sets the real

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -1407,6 +1407,60 @@ class SessionStore:
             "target_text": target_text,
         }
 
+    def has_meaningful_transcript(self, session_id: str) -> bool:
+        """Return True when the transcript contains at least one real turn.
+
+        Empty placeholder rows can be created by metadata-only platform events.
+        Those should not count as active conversational context for restart
+        recovery or thread-session routing.
+        """
+        history = self.load_transcript(session_id)
+        for message in history:
+            if not isinstance(message, dict):
+                if message:
+                    return True
+                continue
+
+            role = message.get("role")
+            if role in {"system", "session_meta"} or message.get("observed"):
+                continue
+
+            content = message.get("content")
+            if isinstance(content, str):
+                if content.strip():
+                    return True
+            elif isinstance(content, list):
+                for part in content:
+                    if isinstance(part, str):
+                        if part.strip():
+                            return True
+                        continue
+                    if not isinstance(part, dict):
+                        if part:
+                            return True
+                        continue
+
+                    part_type = str(part.get("type") or "")
+                    if part_type not in {"", "text", "input_text", "output_text"}:
+                        return True
+
+                    part_text = part.get("text")
+                    if isinstance(part_text, str):
+                        if part_text.strip():
+                            return True
+                    elif part_text:
+                        return True
+
+                    if part.get("image_url") or part.get("file_url") or part.get("source"):
+                        return True
+            elif content:
+                return True
+
+            if message.get("tool_calls") or message.get("tool_call_id"):
+                return True
+
+        return False
+
 
 def build_session_context(
     source: SessionSource,

--- a/tests/gateway/test_restart_resume_pending.py
+++ b/tests/gateway/test_restart_resume_pending.py
@@ -887,7 +887,7 @@ async def test_drain_timeout_skips_pending_sentinel_sessions():
 
 
 @pytest.mark.asyncio
-async def test_startup_auto_resume_schedules_fresh_pending_sessions():
+async def test_startup_auto_resume_schedules_fresh_pending_sessions(monkeypatch):
     """Fresh resume_pending sessions should continue automatically after startup.
 
     This closes the UX gap where restart recovery only happened if the user sent
@@ -908,7 +908,11 @@ async def test_startup_auto_resume_schedules_fresh_pending_sessions():
         last_resume_marked_at=datetime.now(),
     )
     runner.session_store._entries = {pending_entry.session_key: pending_entry}
-    runner.session_store.has_meaningful_transcript = MagicMock(return_value=True)
+    monkeypatch.setattr(
+        runner.session_store,
+        "has_meaningful_transcript",
+        lambda _session_id: True,
+    )
     adapter.handle_message = AsyncMock()
 
     scheduled = runner._schedule_resume_pending_sessions()

--- a/tests/gateway/test_restart_resume_pending.py
+++ b/tests/gateway/test_restart_resume_pending.py
@@ -320,6 +320,25 @@ class TestClearResumePending:
         assert store.clear_resume_pending("no-such-key") is False
 
 
+class TestMeaningfulTranscript:
+    def test_system_only_transcript_is_not_meaningful(self, tmp_path):
+        store = _make_store(tmp_path)
+        store.load_transcript = MagicMock(return_value=[
+            {"role": "session_meta", "content": "tools:{}"},
+            {"role": "system", "content": "gateway bookkeeping"},
+        ])
+
+        assert store.has_meaningful_transcript("sid") is False
+
+    def test_user_text_transcript_is_meaningful(self, tmp_path):
+        store = _make_store(tmp_path)
+        store.load_transcript = MagicMock(return_value=[
+            {"role": "user", "content": "keep going"}
+        ])
+
+        assert store.has_meaningful_transcript("sid") is True
+
+
 # ---------------------------------------------------------------------------
 # SessionStore.get_or_create_session resume_pending behaviour
 # ---------------------------------------------------------------------------
@@ -889,6 +908,7 @@ async def test_startup_auto_resume_schedules_fresh_pending_sessions():
         last_resume_marked_at=datetime.now(),
     )
     runner.session_store._entries = {pending_entry.session_key: pending_entry}
+    runner.session_store.has_meaningful_transcript = MagicMock(return_value=True)
     adapter.handle_message = AsyncMock()
 
     scheduled = runner._schedule_resume_pending_sessions()
@@ -931,6 +951,7 @@ async def test_startup_auto_resume_includes_crash_recovery():
         last_resume_marked_at=datetime.now(),
     )
     runner.session_store._entries = {pending_entry.session_key: pending_entry}
+    runner.session_store.has_meaningful_transcript = MagicMock(return_value=True)
     adapter.handle_message = AsyncMock()
 
     scheduled = runner._schedule_resume_pending_sessions()
@@ -967,6 +988,40 @@ async def test_startup_auto_resume_skips_stale_entries():
 
     assert scheduled == 0
     adapter.handle_message.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_startup_auto_resume_skips_transcriptless_entries():
+    """Resume-pending placeholders with no transcript should not auto-run."""
+    runner, adapter = make_restart_runner()
+    source = make_restart_source(chat_id="empty-chat")
+    empty_entry = SessionEntry(
+        session_key="agent:main:telegram:dm:empty-chat",
+        session_id="sid-empty",
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+        origin=source,
+        platform=Platform.TELEGRAM,
+        chat_type="dm",
+        resume_pending=True,
+        resume_reason="restart_timeout",
+        last_resume_marked_at=datetime.now(),
+    )
+    session_store = MagicMock()
+    session_store._lock = MagicMock()
+    session_store._lock.__enter__.return_value = None
+    session_store._lock.__exit__.return_value = None
+    session_store._entries = {empty_entry.session_key: empty_entry}
+    session_store._ensure_loaded_locked = MagicMock()
+    session_store.has_meaningful_transcript = MagicMock(return_value=False)
+    runner.session_store = session_store
+    adapter.handle_message = AsyncMock()
+
+    scheduled = runner._schedule_resume_pending_sessions()
+
+    assert scheduled == 0
+    adapter.handle_message.assert_not_called()
+    session_store.has_meaningful_transcript.assert_called_once_with("sid-empty")
 
 
 @pytest.mark.asyncio

--- a/tests/gateway/test_restart_resume_pending.py
+++ b/tests/gateway/test_restart_resume_pending.py
@@ -928,7 +928,7 @@ async def test_startup_auto_resume_schedules_fresh_pending_sessions():
 
 
 @pytest.mark.asyncio
-async def test_startup_auto_resume_includes_crash_recovery():
+async def test_startup_auto_resume_includes_crash_recovery(monkeypatch):
     """Crash-recovered sessions (reason=restart_interrupted) are also auto-resumed.
 
     suspend_recently_active() marks in-flight sessions with resume_reason
@@ -951,7 +951,11 @@ async def test_startup_auto_resume_includes_crash_recovery():
         last_resume_marked_at=datetime.now(),
     )
     runner.session_store._entries = {pending_entry.session_key: pending_entry}
-    runner.session_store.has_meaningful_transcript = MagicMock(return_value=True)
+    monkeypatch.setattr(
+        runner.session_store,
+        "has_meaningful_transcript",
+        lambda _session_id: True,
+    )
     adapter.handle_message = AsyncMock()
 
     scheduled = runner._schedule_resume_pending_sessions()

--- a/tests/gateway/test_shutdown_cache_cleanup.py
+++ b/tests/gateway/test_shutdown_cache_cleanup.py
@@ -63,6 +63,9 @@ class _FakeGateway:
     async def _drain_active_agents(self, timeout):
         return {}, False
 
+    async def _drain_session_delivery(self, session_keys, timeout):
+        return False, []
+
     def _finalize_shutdown_agents(self, agents):
         for agent in agents.values():
             self._cleanup_agent_resources(agent)

--- a/tests/gateway/test_slack.py
+++ b/tests/gateway/test_slack.py
@@ -2596,6 +2596,7 @@ class TestThreadReplyHandling:
         store = MagicMock()
         store._entries = {}
         store._ensure_loaded = MagicMock()
+        store.has_meaningful_transcript = MagicMock(return_value=True)
         store.config = MagicMock()
         store.config.group_sessions_per_user = True
         return store
@@ -2719,6 +2720,85 @@ class TestThreadReplyHandling:
         }
         await adapter._handle_slack_message(event)
         adapter.handle_message.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_transcriptless_session_does_not_block_thread_context_recovery(
+        self, adapter_with_session_store, mock_session_store
+    ):
+        """Empty placeholder sessions should not suppress thread rehydration."""
+        session_key = "agent:main:slack:group:C123:123.000"
+        mock_session_store._entries = {
+            session_key: MagicMock(session_id="sid-empty")
+        }
+        mock_session_store.config.group_sessions_per_user = False
+        mock_session_store.has_meaningful_transcript.return_value = False
+
+        adapter_with_session_store._bot_message_ts.add("123.000")
+        adapter_with_session_store._fetch_thread_context = AsyncMock(
+            return_value="[Thread context]\n"
+        )
+        adapter_with_session_store._fetch_thread_parent_text = AsyncMock(
+            return_value="Earlier question"
+        )
+        adapter_with_session_store._resolve_user_name = AsyncMock(
+            return_value="Sawyer Beckett"
+        )
+
+        event = {
+            "text": "Yes save and continue",
+            "user": "U_USER",
+            "channel": "C123",
+            "ts": "123.456",
+            "thread_ts": "123.000",
+            "channel_type": "channel",
+            "team": "T_TEAM",
+        }
+        await adapter_with_session_store._handle_slack_message(event)
+
+        adapter_with_session_store._fetch_thread_context.assert_awaited_once()
+        adapter_with_session_store.handle_message.assert_called_once()
+        msg_event = adapter_with_session_store.handle_message.call_args[0][0]
+        assert msg_event.text.startswith("[Thread context]\n")
+
+    @pytest.mark.asyncio
+    async def test_contentless_thread_event_is_ignored_before_thread_recovery(
+        self, adapter_with_session_store
+    ):
+        """Metadata-only thread events should not fetch context or create sessions."""
+        adapter_with_session_store._bot_message_ts.add("123.000")
+        adapter_with_session_store._fetch_thread_context = AsyncMock()
+
+        event = {
+            "text": "",
+            "user": "U_USER",
+            "channel": "C123",
+            "ts": "123.456",
+            "thread_ts": "123.000",
+            "channel_type": "channel",
+            "team": "T_TEAM",
+        }
+        await adapter_with_session_store._handle_slack_message(event)
+
+        adapter_with_session_store._fetch_thread_context.assert_not_called()
+        adapter_with_session_store.handle_message.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_contentless_dm_message_event_is_ignored(adapter):
+    """Metadata-only Slack message events must not create a user turn."""
+    event = {
+        "text": "",
+        "user": "U_USER",
+        "channel": "D123",
+        "ts": "171.111",
+        "thread_ts": "171.000",
+        "channel_type": "im",
+        "team": "T_TEAM",
+    }
+
+    await adapter._handle_slack_message(event)
+
+    adapter.handle_message.assert_not_called()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/run_agent/test_create_openai_client_proxy_env.py
+++ b/tests/run_agent/test_create_openai_client_proxy_env.py
@@ -34,6 +34,7 @@ def _make_agent():
         quiet_mode=True,
         skip_context_files=True,
         skip_memory=True,
+        enabled_toolsets=[],
     )
 
 


### PR DESCRIPTION
## Summary
- skip startup auto-resume for resume_pending sessions that have no meaningful transcript
- preserve upstream's startup resume slot-claim guard while replaying the fork PR #2 change onto current upstream main
- fix ty invalid-assignment warnings in the new restart-resume tests and keep related CI test doubles current

## Verification
- scripts/run_tests.sh tests/gateway/test_restart_resume_pending.py tests/gateway/test_slack.py tests/gateway/test_shutdown_cache_cleanup.py tests/run_agent/test_create_openai_client_proxy_env.py
- /Users/sawbeck/.hermes/hermes-agent/venv/bin/python -m ruff check gateway/run.py gateway/platforms/slack.py gateway/session.py tests/gateway/test_restart_resume_pending.py tests/gateway/test_slack.py tests/gateway/test_shutdown_cache_cleanup.py tests/run_agent/test_create_openai_client_proxy_env.py
- git diff --check
- CI-style touched-file lint diff vs upstream/main: ruff no new issues, ty no new issues

## CI note
GitHub currently marks the fork-origin workflow runs as action_required, so an upstream maintainer needs to approve CI before the hosted checks can run.

Supersedes the fork-only follow-up PR uncfreak1255-code/hermes-agent#4.