### PR TITLE
fix(gateway): stop strip_markdown from eating bullets and literal asterisks (#48150)

### DIFF
--- a/gateway/platforms/helpers.py
+++ b/gateway/platforms/helpers.py
@@ -166,8 +166,13 @@ class TextBatchAggregator:
 # ─── Markdown Stripping ──────────────────────────────────────────────────────
 
 # Pre-compiled regexes for performance
-_RE_BOLD = re.compile(r"\*\*(.+?)\*\*", re.DOTALL)
-_RE_ITALIC_STAR = re.compile(r"\*(.+?)\*", re.DOTALL)
+# The inside-edge guards (?![\s*]) / (?<![\s*]) keep the star variants from
+# treating list bullets ("* item") or literal asterisks ("a * b", a "**" glob)
+# as emphasis spans — a real *italic* / **bold** span has a non-whitespace,
+# non-asterisk character against each delimiter. This mirrors the underscore
+# variants below, which already carry the equivalent guards.
+_RE_BOLD = re.compile(r"\*\*(?![\s*])(.+?)(?<![\s*])\*\*", re.DOTALL)
+_RE_ITALIC_STAR = re.compile(r"\*(?![\s*])(.+?)(?<![\s*])\*", re.DOTALL)
 _RE_BOLD_UNDER = re.compile(r"\b__(?![\s_])(.+?)(?<![\s_])__\b", re.DOTALL)
 _RE_ITALIC_UNDER = re.compile(r"\b_(?![\s_])(.+?)(?<![\s_])_\b", re.DOTALL)
 _RE_CODE_BLOCK = re.compile(r"```[a-zA-Z0-9_+-]*\n?")

--- a/tests/gateway/test_strip_markdown.py
+++ b/tests/gateway/test_strip_markdown.py
@@ -1,0 +1,41 @@
+"""Regression tests for ``strip_markdown`` star-emphasis handling.
+
+The star (``*``) emphasis regexes used to lack the inside-edge guards that the
+underscore variants already had, so a run of list bullets or a couple of
+literal asterisks was mistaken for an italic/bold span and silently removed.
+See the bullet-list / literal-asterisk cases below — they corrupt on the
+unguarded regexes and pass once the ``(?![\\s*])`` / ``(?<![\\s*])`` guards are
+added.
+"""
+
+from gateway.platforms.helpers import strip_markdown
+
+
+def test_bullet_list_markers_preserved():
+    text = "Here are steps:\n* Install deps\n* Run tests\n* Ship it"
+    assert strip_markdown(text) == text
+
+
+def test_two_bullet_list_preserved():
+    assert strip_markdown("* first item\n* second item") == "* first item\n* second item"
+
+
+def test_literal_asterisks_preserved():
+    assert strip_markdown("Compute a * b * c for the area") == "Compute a * b * c for the area"
+
+
+def test_wildcard_and_glob_literals_preserved():
+    assert strip_markdown("Use the * wildcard and the ** glob") == "Use the * wildcard and the ** glob"
+
+
+def test_real_italic_still_unwrapped():
+    assert strip_markdown("*italic*") == "italic"
+
+
+def test_real_bold_still_unwrapped():
+    assert strip_markdown("**bold**") == "bold"
+
+
+def test_mixed_emphasis_and_bullets():
+    text = "Summary:\n* uses **bold** here\n* and *italic* there"
+    assert strip_markdown(text) == "Summary:\n* uses bold here\n* and italic there"


### PR DESCRIPTION
## Summary

Fixes #48150.

`strip_markdown` in `gateway/platforms/helpers.py` (shared by the SMS, iMessage/BlueBubbles, Feishu, QQ Bot, and Photon plain-text adapters) treated any two `*` in a run of text as an emphasis span and removed them — so bullet lists and literal asterisks came out corrupted:

```
strip_markdown("Here are steps:\n* Install deps\n* Run tests\n* Ship it")
# -> "Here are steps:\n Install deps\n Run tests\n* Ship it"   (bullets eaten)

strip_markdown("Compute a * b * c for the area")
# -> "Compute a  b  c for the area"
```

## Root cause

The underscore emphasis regexes already guard the inside edge of the span, but the star variants didn't:

```python
_RE_BOLD        = re.compile(r"\*\*(.+?)\*\*", re.DOTALL)
_RE_ITALIC_STAR = re.compile(r"\*(.+?)\*", re.DOTALL)
```

A real `*italic*` / `**bold**` span has a non-whitespace, non-asterisk character against each delimiter; a `*` bullet is always `*`+space and a literal `a * b` has spaces on both sides. Adding the same `(?![\s*])` / `(?<![\s*])` guards the underscore variants use makes the star regexes match emphasis only.

## Verification

Added `tests/gateway/test_strip_markdown.py` covering bullet lists, literal asterisks, wildcard/glob literals, and that real `*italic*` / `**bold**` (including mixed with bullets) is still unwrapped. The bullet/asterisk cases fail on current `main` and pass with this change; emphasis-unwrapping behavior is unchanged.

Scope kept tight to the gateway helper. The same unguarded pattern exists in a couple of sibling copies (TTS stripper, IRC/LINE adapters) and can be a separate follow-up.