### PR TITLE
fix(cli): keep prompt symbols profile-neutral

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -13389,9 +13389,6 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         ``normal_prompt`` is the full ``branding.prompt_symbol``.
         ``state_suffix`` is what special states (sudo/secret/approval/agent)
         should render after their leading icon.
-
-        When a profile is active (not "default"), the profile name is
-        prepended to the prompt symbol: ``coder ❯`` instead of ``❯``.
         """
         try:
             from hermes_cli.skin_engine import get_active_prompt_symbol
@@ -13400,15 +13397,6 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             symbol = "❯ "
 
         symbol = (symbol or "❯ ").rstrip() + " "
-
-        # Prepend profile name when not default
-        try:
-            from hermes_cli.profiles import get_active_profile_name
-            profile = get_active_profile_name()
-            if profile not in {"default", "custom"}:
-                symbol = f"{profile} {symbol}"
-        except Exception:
-            pass
         stripped = symbol.rstrip()
         if not stripped:
             return "❯ ", "❯ "

--- a/tests/cli/test_cli_skin_integration.py
+++ b/tests/cli/test_cli_skin_integration.py
@@ -42,6 +42,13 @@ class TestCliSkinPromptIntegration:
         set_active_skin("ares")
         assert cli._get_tui_prompt_fragments() == [("class:prompt", "⚔ ")]
 
+    def test_profile_name_is_not_prepended_to_prompt_symbol(self):
+        cli = _make_cli_stub()
+
+        set_active_skin("default")
+        with patch("hermes_cli.profiles.get_active_profile_name", return_value="turing"):
+            assert cli._get_tui_prompt_fragments() == [("class:prompt", "❯ ")]
+
     def test_secret_prompt_fragments_preserve_secret_state(self):
         cli = _make_cli_stub()
         cli._secret_state = {"response_queue": object()}

--- a/tests/test_cli_skin_integration.py
+++ b/tests/test_cli_skin_integration.py
@@ -42,6 +42,13 @@ class TestCliSkinPromptIntegration:
         set_active_skin("ares")
         assert cli._get_tui_prompt_fragments() == [("class:prompt", "⚔ ")]
 
+    def test_profile_name_is_not_prepended_to_prompt_symbol(self):
+        cli = _make_cli_stub()
+
+        set_active_skin("default")
+        with patch("hermes_cli.profiles.get_active_profile_name", return_value="turing"):
+            assert cli._get_tui_prompt_fragments() == [("class:prompt", "❯ ")]
+
     def test_secret_prompt_fragments_preserve_secret_state(self):
         cli = _make_cli_stub()
         cli._secret_state = {"response_queue": object()}


### PR DESCRIPTION
## What does this PR do?

Keeps the CLI input prompt symbol controlled by the active skin only. Non-default profile names are already surfaced elsewhere, so the prompt chrome should not prepend values like `turing` before `❯`.

## Related Issue

No linked GitHub issue. Local dogfood regression: non-default profiles rendered prompt fragments as `turing ❯ ` instead of the active skin's `❯ `.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `cli.py`
  - Removes profile-name prepending from `_get_tui_prompt_symbols()` so `branding.prompt_symbol` remains profile-neutral.
- `tests/cli/test_cli_skin_integration.py`
  - Adds regression coverage that a non-default active profile does not alter the prompt symbol.
- `tests/test_cli_skin_integration.py`
  - Adds the same regression coverage for the legacy skin integration test path.

## How to Test

1. Run focused regression validation:
   ```bash
   scripts/run_tests.sh tests/cli/test_cli_skin_integration.py tests/test_cli_skin_integration.py -- -q --tb=short -k profile_name_is_not_prepended_to_prompt_symbol
   ```
   Result:
   ```text
   2 tests passed, 0 failed
   ```

2. Run the affected skin integration files:
   ```bash
   scripts/run_tests.sh tests/cli/test_cli_skin_integration.py tests/test_cli_skin_integration.py -- -q --tb=short
   ```
   Result:
   ```text
   26 tests passed, 0 failed
   ```

3. Run diff and syntax checks:
   ```bash
   git diff --check origin/main...HEAD
   python -m py_compile cli.py tests/cli/test_cli_skin_integration.py tests/test_cli_skin_integration.py
   ```
   Result:
   ```text
   Both commands exited 0. py_compile emitted the existing cli.py SyntaxWarning about return in finally.
   ```

4. Manual exercise of changed path:
   ```text
   Covered by direct CLI prompt-fragment unit integration tests. No live interactive prompt smoke was needed for this narrow pure rendering helper change.
   ```

## Validation Status

- Focused regression tests: passing.
- Affected file tests: passing.
- Broader suite: not run. This PR is a three-file rendering regression carry.
- GitHub checks: pending after PR creation.
- Full-suite checklist is intentionally unchecked because the full suite was not run locally.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux, Python 3.14

### Documentation and Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior or N/A

## For New Skills

N/A.

## Screenshots / Logs

```text
Open PR duplicate search returned no exact open matches for:
- "keep prompt symbols profile-neutral"
- "profile_name_is_not_prepended_to_prompt_symbol"
- "_get_tui_prompt_symbols" "get_active_profile_name"
- "Prepend profile name when not default"
```
