### PR TITLE
Update Stripe Projects skill docs

### DIFF
--- a/optional-skills/payments/stripe-projects/SKILL.md
+++ b/optional-skills/payments/stripe-projects/SKILL.md
@@ -26,13 +26,13 @@ Trigger phrases:
 - "manage my stack credentials", "rotate this key", "upgrade my plan"
 - "what providers can I add?"
 
-If the user already has the service set up manually and just wants to use it, this skill is not the right entry point.
+If the user already has a provider account, this skill can still connect it with `stripe projects link <provider>`. If the user wants to use an existing provider resource, such as an existing database or Vercel project, check provider support first; many providers currently support provisioning new resources but not importing existing ones.
 
 ## Prerequisites
 
 - Stripe CLI installed (Homebrew on macOS, package manager on Linux, or download from https://docs.stripe.com/stripe-cli/install)
 - Stripe Projects plugin installed
-- A Stripe account, logged in via `stripe login`
+- A Stripe account. If the user doesn't have one yet, the CLI can guide them through sign-in or account creation in the browser during setup.
 
 ## Install
 

--- a/website/docs/user-guide/skills/optional/payments/payments-stripe-projects.md
+++ b/website/docs/user-guide/skills/optional/payments/payments-stripe-projects.md
@@ -44,13 +44,13 @@ Trigger phrases:
 - "manage my stack credentials", "rotate this key", "upgrade my plan"
 - "what providers can I add?"
 
-If the user already has the service set up manually and just wants to use it, this skill is not the right entry point.
+If the user already has a provider account, this skill can still connect it with `stripe projects link &lt;provider>`. If the user wants to use an existing provider resource, such as an existing database or Vercel project, check provider support first; many providers currently support provisioning new resources but not importing existing ones.
 
 ## Prerequisites
 
 - Stripe CLI installed (Homebrew on macOS, package manager on Linux, or download from https://docs.stripe.com/stripe-cli/install)
 - Stripe Projects plugin installed
-- A Stripe account, logged in via `stripe login`
+- A Stripe account. If the user doesn't have one yet, the CLI can guide them through sign-in or account creation in the browser during setup.
 
 ## Install
 


### PR DESCRIPTION
## What does this PR do?
  - Clarifies the Stripe Projects optional skill docs around existing provider accounts and Stripe account setup.

  This avoids implying that users cannot use Stripe Projects when they already have a provider account, while still noting that importing existing provider resources may not be supported by every provider yet. It
  also softens the Stripe account prerequisite to explain that users can create or sign in to a Stripe account through the guided browser flow.

  ## Related Issue

  N/A

  ## Type of Change

  - [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
  - [ ] ✨ New feature (non-breaking change that adds functionality)
  - [ ] 🔒 Security fix
  - [x] 📝 Documentation update
  - [ ] ✅ Tests (adding or improving test coverage)
  - [ ] ♻️ Refactor (no behavior change)
  - [ ] 🎯 New skill (bundled or hub)

  ## Changes Made

  - Updated `optional-skills/payments/stripe-projects/SKILL.md`
    - Clarified that existing provider accounts can be connected with `stripe projects link <provider>`.
    - Clarified that existing provider resources may not be importable unless the provider supports it.
    - Reworded the Stripe account prerequisite to mention guided browser sign-in/account creation.
  - Updated generated docs page `website/docs/user-guide/skills/optional/payments/payments-stripe-projects.md` with the same wording.

  ## How to Test

  1. Review the rendered Markdown for the Stripe Projects skill docs.
  2. Confirm the source skill and generated website page contain the same wording.
  3. Confirm this is documentation-only and does not change runtime behavior.

  ## Checklist

  ### Code

  - [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
  - [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
  - [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
  - [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
  - [ ] I've run `pytest tests/ -q` and all tests pass
  - [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
  - [x] I've tested on my platform: macOS

  ### Documentation & Housekeeping

  - [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
  - [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
  - [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
  - [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
  - [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

  ## Screenshots / Logs

  N/A