### PR TITLE
fix(gateway): match multi-word timezone names in message timestamp strip (#48133)

### DIFF
--- a/gateway/message_timestamps.py
+++ b/gateway/message_timestamps.py
@@ -13,11 +13,16 @@ from typing import Any, Optional, Tuple
 
 
 # Current gateway format: [Tue 2026-04-28 13:40:53 CEST]
+# The tz token allows spaces between word runs so multi-word zone names match
+# too: strftime("%Z") returns a short abbreviation ("CEST") on Linux/macOS but
+# the full descriptive name with spaces ("Pacific Daylight Time") on Windows
+# when no timezone is configured. The closing "]" bounds the match, so it never
+# spills into a following "[sender]" segment.
 _HUMAN_TIMESTAMP_RE = re.compile(
     r"^\[(?P<dow>[A-Z][a-z]{2}) "
     r"(?P<date>\d{4}-\d{2}-\d{2}) "
     r"(?P<time>\d{2}:\d{2}:\d{2})"
-    r"(?: (?P<tz>[A-Za-z0-9_+\-/:]+))?\]\s*"
+    r"(?: (?P<tz>[A-Za-z0-9_+\-/:]+(?: [A-Za-z0-9_+\-/:]+)*))?\]\s*"
 )
 
 # Older gateway format: [2026-04-13T17:02:06+0200] or [+02:00]

--- a/tests/gateway/test_message_timestamps.py
+++ b/tests/gateway/test_message_timestamps.py
@@ -61,6 +61,22 @@ def test_strip_leading_message_timestamps_removes_multiple_prefixes_and_prefers_
     assert embedded_ts == _epoch(2026, 4, 27, 15, 54, 44)
 
 
+def test_strip_leading_message_timestamps_handles_multiword_zone_name():
+    # strftime("%Z") yields a spaced, descriptive zone name on Windows
+    # ("Pacific Daylight Time") when no timezone is configured. The strip must
+    # still recognise a prefix the module itself formatted, and must not spill
+    # the match into the following "[sender]" segment.
+    content = (
+        "[Tue 2026-04-28 13:40:53 Pacific Daylight Time] "
+        "[Example User] hello"
+    )
+
+    stripped, embedded_ts = strip_leading_message_timestamps(content, tz=BERLIN)
+
+    assert stripped == "[Example User] hello"
+    assert embedded_ts == _epoch(2026, 4, 28, 13, 40, 53)
+
+
 def test_coerce_message_timestamp_accepts_datetime_and_epoch():
     dt = datetime(2026, 4, 28, 13, 40, 53, tzinfo=BERLIN)
 


### PR DESCRIPTION
## Summary

Fixes #48133.

`format_message_timestamp` builds the timezone part of a gateway timestamp from `strftime("%Z")`, but `strip_leading_message_timestamps` reads it back with `_HUMAN_TIMESTAMP_RE`, whose tz token forbids spaces:

```python
r"(?: (?P<tz>[A-Za-z0-9_+\-/:]+))?\]\s*"
```

On Linux/macOS `%Z` returns a short abbreviation (`CEST`) that matches. On **Windows with no configured timezone** (`HERMES_TIMEZONE` unset, no `timezone` in config — the common default), `%Z` returns the full descriptive name with spaces (`Pacific Daylight Time`), which the regex can't match — so the strip fails on a prefix the module itself formatted.

```
strip_leading_message_timestamps("[Tue 2026-04-28 13:40:53 Pacific Daylight Time] [Example User] hello")
# main: returned unchanged, embedded_ts=None  ->  prefix never removed
```

Consequences: the documented contaminated legacy rows (`[processing time] [platform time] [sender] message`) are never cleaned on Windows, and with the `gateway.message_timestamps.enabled` render toggle on, a second timestamp stacks onto an already-prefixed row instead of replacing it.

## Fix

Allow the tz token to span space-separated word runs (`[A-Za-z0-9_+\-/:]+(?: [A-Za-z0-9_+\-/:]+)*`). The closing `]` still bounds the match, so it never spills into a following `[sender]` segment. The tz group isn't used for parsing (only `date`/`time` are), so this only affects recognition. Abbreviations and offset forms (`CEST`, `UTC+05:30`) are unchanged.

## Verification

Added a regression test for the multi-word zone case (strips correctly and doesn't over-match into the following `[sender]`). Existing abbreviation/offset behavior is preserved.