### PR TITLE
fix(comfyui): drop non-node top-level keys so bundled workflows submit (#48139)

### DIFF
--- a/skills/creative/comfyui/scripts/_common.py
+++ b/skills/creative/comfyui/scripts/_common.py
@@ -652,13 +652,28 @@ def is_api_format(workflow: Any) -> bool:
     return False
 
 
+def _drop_non_node_keys(workflow: dict) -> dict:
+    """Drop top-level entries whose value is not a node object.
+
+    ComfyUI's ``/prompt`` validator treats every top-level key as a node and
+    calls ``.get`` on its value, so a documentation key like
+    ``"_comment": "..."`` (a string) raises ``AttributeError: 'str' object has
+    no attribute 'get'`` and the submission fails with HTTP 500. Real API-format
+    nodes are always JSON objects, so keep only dict-valued entries. Returns the
+    input unchanged when there is nothing to drop (avoids a needless copy).
+    """
+    if all(isinstance(v, dict) for v in workflow.values()):
+        return workflow
+    return {k: v for k, v in workflow.items() if isinstance(v, dict)}
+
+
 def unwrap_workflow(payload: Any) -> dict:
     """Unwrap common wrapper variants. Returns API-format workflow or raises ValueError."""
     if isinstance(payload, dict) and is_api_format(payload):
-        return payload
+        return _drop_non_node_keys(payload)
     # Some files wrap workflow under "prompt" key (e.g. saved /prompt payloads)
     if isinstance(payload, dict) and "prompt" in payload and is_api_format(payload["prompt"]):
-        return payload["prompt"]
+        return _drop_non_node_keys(payload["prompt"])
     # Editor format
     if isinstance(payload, dict) and "nodes" in payload and "links" in payload:
         raise ValueError(

--- a/skills/creative/comfyui/tests/test_common.py
+++ b/skills/creative/comfyui/tests/test_common.py
@@ -131,6 +131,27 @@ class TestUnwrapWorkflow:
         with pytest.raises(ValueError):
             unwrap_workflow({"foo": "bar"})
 
+    def test_drops_non_node_comment_key(self):
+        # ComfyUI's /prompt validator calls .get on every top-level value, so a
+        # string-valued documentation key like "_comment" raises a 500. unwrap
+        # must drop non-node entries while keeping the real nodes.
+        wf = {
+            "_comment": "human-readable note that ComfyUI must never see",
+            "3": {"class_type": "KSampler", "inputs": {}},
+        }
+        result = unwrap_workflow(wf)
+        assert "_comment" not in result
+        assert set(result) == {"3"}
+
+    def test_drops_comment_key_under_prompt_wrapper(self):
+        wf = {
+            "_comment": "note",
+            "3": {"class_type": "KSampler", "inputs": {}},
+        }
+        result = unwrap_workflow({"prompt": wf})
+        assert "_comment" not in result
+        assert set(result) == {"3"}
+
 
 class TestIsLink:
     def test_valid_link(self):

--- a/skills/creative/comfyui/workflows/animatediff_video.json
+++ b/skills/creative/comfyui/workflows/animatediff_video.json
@@ -1,5 +1,4 @@
 {
-  "_comment": "AnimateDiff text-to-video at 16 frames. Required: comfyui-animatediff-evolved + comfyui-videohelpersuite custom nodes; SD1.5 checkpoint; AnimateDiff motion module (e.g. mm_sd_v15_v2.ckpt in models/animatediff_models/). Outputs a webp animation.",
   "3": {
     "class_type": "KSampler",
     "_meta": {"title": "KSampler"},

--- a/skills/creative/comfyui/workflows/flux_dev_txt2img.json
+++ b/skills/creative/comfyui/workflows/flux_dev_txt2img.json
@@ -1,5 +1,4 @@
 {
-  "_comment": "Flux Dev text-to-image using the modern sampler chain (BasicScheduler/Guider/SamplerCustomAdvanced). Required: flux1-dev.safetensors (UNET), t5xxl_fp16.safetensors + clip_l.safetensors (CLIP), ae.safetensors (VAE).",
   "6": {
     "class_type": "CLIPTextEncode",
     "_meta": {"title": "Prompt"},

--- a/skills/creative/comfyui/workflows/sd15_txt2img.json
+++ b/skills/creative/comfyui/workflows/sd15_txt2img.json
@@ -1,5 +1,4 @@
 {
-  "_comment": "SD 1.5 text-to-image. Smallest model, fastest. Required model: v1-5-pruned-emaonly.safetensors (or any SD1.5 checkpoint)",
   "3": {
     "class_type": "KSampler",
     "_meta": {"title": "KSampler"},

--- a/skills/creative/comfyui/workflows/sdxl_img2img.json
+++ b/skills/creative/comfyui/workflows/sdxl_img2img.json
@@ -1,5 +1,4 @@
 {
-  "_comment": "SDXL img2img: load an input image, encode to latent, denoise partially. Use --input-image image=./photo.png with run_workflow.py. Lower 'denoise' value preserves more of the source image.",
   "1": {
     "class_type": "LoadImage",
     "_meta": {"title": "Load Source Image"},

--- a/skills/creative/comfyui/workflows/sdxl_inpaint.json
+++ b/skills/creative/comfyui/workflows/sdxl_inpaint.json
@@ -1,5 +1,4 @@
 {
-  "_comment": "SDXL inpainting: given an image + mask, regenerate the masked region. Upload both: --input-image image=./photo.png --input-image mask_image=./mask.png. White pixels in mask = regenerate; black = preserve.",
   "1": {
     "class_type": "LoadImage",
     "_meta": {"title": "Load Source"},

--- a/skills/creative/comfyui/workflows/sdxl_txt2img.json
+++ b/skills/creative/comfyui/workflows/sdxl_txt2img.json
@@ -1,5 +1,4 @@
 {
-  "_comment": "SDXL text-to-image at 1024x1024. Required model: sd_xl_base_1.0.safetensors (or any SDXL checkpoint).",
   "3": {
     "class_type": "KSampler",
     "_meta": {"title": "KSampler"},

--- a/skills/creative/comfyui/workflows/upscale_4x.json
+++ b/skills/creative/comfyui/workflows/upscale_4x.json
@@ -1,5 +1,4 @@
 {
-  "_comment": "Standalone 4x upscale of an input image using ESRGAN. Required model: 4x-UltraSharp.pth (or any upscaler in models/upscale_models/). Upload with --input-image image=./photo.png.",
   "1": {
     "class_type": "LoadImage",
     "_meta": {"title": "Load Image"},

--- a/skills/creative/comfyui/workflows/wan_video_t2v.json
+++ b/skills/creative/comfyui/workflows/wan_video_t2v.json
@@ -1,5 +1,4 @@
 {
-  "_comment": "Wan 2.1 text-to-video. Cloud: confirmed available. Local: download wan2.1_t2v_1.3B_fp16.safetensors → models/diffusion_models/ (or models/unet/), umt5_xxl_fp16.safetensors → models/text_encoders/ (or models/clip/), wan_2.1_vae.safetensors → models/vae/. Output: MP4. Large model — only on cloud or 24 GB+ local GPU.",
   "6": {
     "class_type": "CLIPTextEncode",
     "_meta": {"title": "Prompt"},


### PR DESCRIPTION
## Summary

Fixes #48139.

All eight bundled workflows in `skills/creative/comfyui/workflows/` opened with a top-level `_comment` string. ComfyUI's `/prompt` validator treats every top-level key as a node and calls `.get` on its value, so the string `_comment` raised:

```
AttributeError: 'str' object has no attribute 'get'
  File "execution.py", line 1018, in validate_prompt
    node_title = node_data.get('_meta', {}).get('title')
```

That's an HTTP 500 on **every** workflow submission — the ComfyUI skill was non-functional out of the box.

## Fix

- Remove the `_comment` key from the eight bundled workflow JSONs (one line each).
- Harden `unwrap_workflow()` in `_common.py` to drop any top-level entry whose value is not a node object. ComfyUI nodes are always JSON objects, so this strips a stray `_comment` (or any future non-node key) from **user-authored** workflows too, instead of letting them 500. Already-clean workflows are returned unchanged (no copy), so the existing pass-through behavior is preserved.

## Verification

- Confirmed all eight bundled files parse and submit clean after the change (every top-level value is a node dict).
- Added regression tests covering the dropped-key behavior directly and under the `{"prompt": ...}` wrapper.