### PR TITLE
fix(telegram): stop typing indicator after response delivery

### DIFF
--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -462,6 +462,13 @@ class TelegramAdapter(BasePlatformAdapter):
         self._polling_error_task: Optional[asyncio.Task] = None
         self._polling_conflict_count: int = 0
         self._polling_network_error_count: int = 0
+        # Typing indicator task management (mirrors SignalAdapter pattern).
+        # The base adapter's _keep_typing loop is the primary mechanism, but
+        # gateway/run.py also calls stop_typing() directly — without these
+        # dicts that call is a no-op and any residual typing state persists.
+        self._typing_tasks: Dict[str, asyncio.Task] = {}
+        self._typing_failures: Dict[str, int] = {}
+        self._typing_skip_until: Dict[str, float] = {}
         self._polling_error_callback_ref = None
         # After sustained reconnect storms the PTB httpx pool can return
         # SendResult(success=True) for sends that never actually transmit.
@@ -2293,6 +2300,11 @@ class TelegramAdapter(BasePlatformAdapter):
         self._pending_photo_batch_tasks.clear()
         self._pending_photo_batches.clear()
 
+        # Cancel all typing tasks on shutdown
+        for task in self._typing_tasks.values():
+            task.cancel()
+        self._typing_tasks.clear()
+
         self._mark_disconnected()
         self._app = None
         self._bot = None
@@ -2347,11 +2359,7 @@ class TelegramAdapter(BasePlatformAdapter):
                 rich_result = await self._try_send_rich(chat_id, content, reply_to, metadata)
                 if rich_result is not None:
                     if rich_result.success:
-                        # Re-trigger typing like the legacy success path does.
-                        try:
-                            await self.send_typing(chat_id, metadata=metadata)
-                        except Exception:
-                            pass  # Typing failures are non-fatal
+                        pass  # _keep_typing loop handles typing indicator refresh
                     return rich_result
 
             # Format and split message if needed
@@ -2568,16 +2576,6 @@ class TelegramAdapter(BasePlatformAdapter):
                                 continue
                         raise
                 message_ids.append(str(msg.message_id))
-
-            # Re-trigger typing indicator after sending a message.
-            # Telegram clears the typing state when a new message is delivered,
-            # so without this the "...typing" bubble disappears mid-response
-            # (especially noticeable when the agent sends intermediate progress
-            # messages like "Checking:" before running tools).
-            try:
-                await self.send_typing(chat_id, metadata=metadata)
-            except Exception:
-                pass  # Typing failures are non-fatal
 
             return SendResult(
                 success=True,
@@ -4969,6 +4967,26 @@ class TelegramAdapter(BasePlatformAdapter):
                     e,
                     exc_info=True,
                 )
+
+    async def _stop_typing_indicator(self, chat_id: str) -> None:
+        """Stop a typing indicator loop for a chat."""
+        task = self._typing_tasks.pop(chat_id, None)
+        if task:
+            task.cancel()
+            try:
+                await task
+            except asyncio.CancelledError:
+                pass
+        # Reset per-chat typing backoff state so the next agent turn starts fresh
+        self._typing_failures.pop(chat_id, None)
+        self._typing_skip_until.pop(chat_id, None)
+
+    async def stop_typing(self, chat_id: str) -> None:
+        """Public interface for stopping typing — called by base adapter's
+        _keep_typing finally block and by gateway/run.py to clean up
+        platform-level typing tasks.
+        """
+        await self._stop_typing_indicator(chat_id)
 
     async def get_chat_info(self, chat_id: str) -> Dict[str, Any]:
         """Get information about a Telegram chat."""


### PR DESCRIPTION
## Problem

The Telegram typing indicator ("...typing") persists indefinitely after the agent delivers a response. Reported on DM conversations with tool-calling agents.

## Root Cause

`TelegramAdapter.send()` called `send_typing()` after every message send — both on the rich-message fast-path (line ~2362) and at the end of the legacy MarkdownV2 path (line ~2584). These calls re-triggered `send_chat_action(action="typing")` **after** the base adapter's `_keep_typing` loop was already cancelled in `_process_message_background`'s `finally` block.

Since `send_chat_action` resets Telegram's ~5-second typing timer on each call, and nothing subsequently cancelled it, the indicator persisted until the user sent another message or the client timed out.

## Fix

The base adapter already manages the typing lifecycle correctly:
- `_keep_typing` refreshes every 2s during agent processing
- `_stop_typing_refresh` cancels the task in the `finally` block
- `gateway/run.py` calls `stop_typing()` for cleanup

The `send()` calls were redundant. This PR:

1. **Removes** `send_typing()` from the rich-message success path in `send()`
2. **Removes** the "Re-trigger typing indicator" block at the end of `send()`
3. **Adds** `_typing_tasks`, `_typing_failures`, `_typing_skip_until` dicts in `__init__` (mirrors SignalAdapter pattern) so `gateway/run.py`'s `stop_typing()` calls have effect
4. **Adds** task cleanup in `disconnect()`
5. **Adds** `_stop_typing_indicator()` and `stop_typing()` methods

## Why This Is Safe

- The Signal adapter already follows this exact pattern — `send()` never calls `send_typing()`
- The base adapter's `_keep_typing` loop is the single source of typing refresh during processing
- No behavioral change for end users except the typing indicator correctly disappearing after response delivery

## Testing

- Verified typing indicator appears during processing (via trace logging)
- Verified indicator disappears within 5 seconds of response delivery
- Verified tool-calling agents with progress messages don't re-trigger the indicator