### PR TITLE
chore: harden profile governance plumbing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -99,6 +99,7 @@ models-dev-upstream/
 .codex/
 .cursor/
 .gemini/
+.playwright-mcp/
 .zed/
 .mcp.json
 opencode.json

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -33,6 +33,7 @@ from agent.message_sanitization import (
     _sanitize_surrogates,
     _repair_tool_call_arguments,
 )
+from agent.system_prompt import build_effective_system_prompt
 from tools.terminal_tool import is_persistent_env
 from utils import base_url_host_matches, base_url_hostname, env_int
 
@@ -1339,9 +1340,10 @@ def handle_max_iterations(agent, messages: list, api_call_count: int) -> str:
                 agent._sanitize_tool_calls_for_strict_api(api_msg, model=agent.model)
             api_messages.append(api_msg)
 
-        effective_system = agent._cached_system_prompt or ""
-        if agent.ephemeral_system_prompt:
-            effective_system = (effective_system + "\n\n" + agent.ephemeral_system_prompt).strip()
+        effective_system = build_effective_system_prompt(
+            agent._cached_system_prompt,
+            agent.ephemeral_system_prompt,
+        )
         if effective_system:
             api_messages = [{"role": "system", "content": effective_system}] + api_messages
         if agent.prefill_messages:

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -56,6 +56,7 @@ from agent.model_metadata import (
 from agent.process_bootstrap import _install_safe_stdio
 from agent.prompt_caching import apply_anthropic_cache_control
 from agent.retry_utils import jittered_backoff
+from agent.system_prompt import build_effective_system_prompt
 from agent.trajectory import has_incomplete_scratchpad
 from agent.usage_pricing import estimate_usage_cost, normalize_usage
 from hermes_constants import PARTIAL_STREAM_STUB_ID
@@ -769,9 +770,10 @@ def run_conversation(
         # every turn.  We send it as a single content string so the
         # bytes are byte-stable across turns and upstream prompt caches
         # stay warm.
-        effective_system = active_system_prompt or ""
-        if agent.ephemeral_system_prompt:
-            effective_system = (effective_system + "\n\n" + agent.ephemeral_system_prompt).strip()
+        effective_system = build_effective_system_prompt(
+            active_system_prompt,
+            agent.ephemeral_system_prompt,
+        )
         if effective_system:
             api_messages = [{"role": "system", "content": effective_system}] + api_messages
 

--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -25,6 +25,7 @@ from agent.skill_utils import (
     parse_frontmatter,
     skill_matches_environment,
     skill_matches_platform,
+    yaml_load,
 )
 from utils import atomic_json_write
 
@@ -1082,7 +1083,72 @@ def drain_truncation_warnings() -> list:
 _SKILLS_PROMPT_CACHE_MAX = 8
 _SKILLS_PROMPT_CACHE: OrderedDict[tuple, str] = OrderedDict()
 _SKILLS_PROMPT_CACHE_LOCK = threading.Lock()
-_SKILLS_SNAPSHOT_VERSION = 1
+_SKILLS_SNAPSHOT_VERSION = 2
+
+_SKILLS_PROMPT_FULL_MODES = {"", "full", "default", "index"}
+_SKILLS_PROMPT_NAMES_ONLY_MODES = {"names", "names_only", "names-only"}
+_SKILLS_PROMPT_HYBRID_MODES = {"hybrid", "router", "routing"}
+
+
+def _normalize_skills_prompt_mode(raw: object) -> str:
+    """Normalize the configured skills prompt mode."""
+    mode = str(raw or "full").strip().lower()
+    if mode in _SKILLS_PROMPT_NAMES_ONLY_MODES:
+        return "names_only"
+    if mode in _SKILLS_PROMPT_HYBRID_MODES:
+        return "hybrid"
+    if mode in _SKILLS_PROMPT_FULL_MODES:
+        return "full"
+    logger.debug("Unknown skills.prompt_mode %r; falling back to full", raw)
+    return "full"
+
+
+def _normalize_string_list(value: object) -> tuple[str, ...]:
+    """Return a compact ordered tuple of non-empty strings."""
+    if value is None:
+        return ()
+    if isinstance(value, str):
+        value = [value]
+    if not isinstance(value, (list, tuple, set)):
+        return ()
+    seen: set[str] = set()
+    result: list[str] = []
+    for item in value:
+        text = str(item).strip()
+        if not text or text in seen:
+            continue
+        seen.add(text)
+        result.append(text)
+    return tuple(result)
+
+
+def _load_skills_prompt_options() -> tuple[str, tuple[str, ...]]:
+    """Read prompt-mode options from profile-scoped config.yaml.
+
+    Shape::
+
+        skills:
+          prompt_mode: full | names_only | hybrid
+          prompt_router:
+            pinned: [skill-name, category/skill-name]
+
+    Invalid or missing config falls back to the historical full catalog.
+    """
+    config_path = get_hermes_home() / "config.yaml"
+    try:
+        parsed = yaml_load(config_path.read_text(encoding="utf-8")) if config_path.exists() else {}
+    except Exception as exc:
+        logger.debug("Could not read skills prompt options from %s: %s", config_path, exc)
+        parsed = {}
+    if not isinstance(parsed, dict):
+        parsed = {}
+    skills_cfg = parsed.get("skills") if isinstance(parsed.get("skills"), dict) else {}
+    mode = _normalize_skills_prompt_mode((skills_cfg or {}).get("prompt_mode"))
+    router_cfg = (skills_cfg or {}).get("prompt_router")
+    if not isinstance(router_cfg, dict):
+        router_cfg = {}
+    pinned = _normalize_string_list(router_cfg.get("pinned"))
+    return mode, pinned
 
 
 def _skills_prompt_snapshot_path() -> Path:
@@ -1170,6 +1236,23 @@ def _build_snapshot_entry(
     if isinstance(platforms, str):
         platforms = [platforms]
 
+    raw_metadata = frontmatter.get("metadata")
+    metadata = raw_metadata if isinstance(raw_metadata, dict) else {}
+    raw_hermes_meta = metadata.get("hermes")
+    hermes_meta = raw_hermes_meta if isinstance(raw_hermes_meta, dict) else {}
+    triggers = _normalize_string_list(
+        frontmatter.get("triggers")
+        or frontmatter.get("aliases")
+        or hermes_meta.get("triggers")
+        or hermes_meta.get("aliases")
+    )
+    router_pin = bool(
+        frontmatter.get("router")
+        or frontmatter.get("prompt_router")
+        or hermes_meta.get("router")
+        or hermes_meta.get("prompt_router")
+    )
+
     return {
         "skill_name": skill_name,
         "category": category,
@@ -1177,6 +1260,8 @@ def _build_snapshot_entry(
         "description": description,
         "platforms": [str(p).strip() for p in platforms if str(p).strip()],
         "conditions": extract_skill_conditions(frontmatter),
+        "triggers": list(triggers),
+        "router_pin": router_pin,
     }
 
 
@@ -1241,6 +1326,120 @@ def _skill_should_show(
     return True
 
 
+def _plural_skill_count(count: int) -> str:
+    return f"{count} skill" if count == 1 else f"{count} skills"
+
+
+def _render_skills_prompt_header(mode_label: str) -> str:
+    return (
+        f"## Skills ({mode_label})\n"
+        "Skills are a lazy procedural library. Load the relevant skill with "
+        "skill_view(name) before executing specialized workflows. If the user "
+        "explicitly names or invokes a skill, load it. If the task domain suggests "
+        "a skill but the exact name is unclear, call skills_list(category=...) "
+        "or skills_list() first, then skill_view(). Do not assume procedure details "
+        "from this compact index alone.\n"
+        "Whenever the user asks you to configure, set up, install, enable, disable, "
+        "modify, or troubleshoot Hermes Agent itself — its CLI, config, models, "
+        "providers, tools, skills, voice, gateway, plugins, or any feature — load "
+        "the `hermes-agent` skill first.\n"
+        "If a loaded skill is stale or wrong, patch it with skill_manage before "
+        "finishing when safe."
+    )
+
+
+def _render_names_only_skill_prompt(skills_by_category: dict[str, list[tuple[str, str]]]) -> str:
+    index_lines: list[str] = []
+    for category in sorted(skills_by_category.keys()):
+        names = sorted({name for name, _ in skills_by_category[category]})
+        index_lines.append(f"  {category} [names only]: {', '.join(names)}")
+    return (
+        _render_skills_prompt_header("names-only index")
+        + "\n\n<available_skills>\n"
+        + "\n".join(index_lines)
+        + "\n</available_skills>\n\n"
+        "Only proceed without loading a skill if genuinely none are relevant to the task."
+    )
+
+
+def _render_hybrid_skill_router(
+    visible_skill_entries: list[dict],
+    router_pinned: tuple[str, ...],
+) -> str:
+    category_counts: dict[str, int] = {}
+    entries_by_name: dict[str, dict] = {}
+    for entry in visible_skill_entries:
+        category = str(entry.get("category") or "general")
+        category_counts[category] = category_counts.get(category, 0) + 1
+        name = str(entry.get("frontmatter_name") or entry.get("skill_name") or "")
+        skill_name = str(entry.get("skill_name") or "")
+        if name:
+            entries_by_name.setdefault(name, entry)
+        if skill_name:
+            entries_by_name.setdefault(skill_name, entry)
+        rel = f"{category}/{skill_name}" if skill_name else ""
+        if rel:
+            entries_by_name.setdefault(rel, entry)
+
+    category_lines = [
+        f"  {category}: {_plural_skill_count(category_counts[category])}"
+        for category in sorted(category_counts)
+    ]
+
+    pinned_entries: list[dict] = []
+    seen: set[str] = set()
+    for name in router_pinned:
+        entry = entries_by_name.get(name)
+        if not entry:
+            continue
+        display_name = str(entry.get("frontmatter_name") or entry.get("skill_name") or name)
+        if display_name in seen:
+            continue
+        seen.add(display_name)
+        pinned_entries.append(entry)
+    for entry in visible_skill_entries:
+        if not entry.get("router_pin"):
+            continue
+        display_name = str(entry.get("frontmatter_name") or entry.get("skill_name") or "")
+        if not display_name or display_name in seen:
+            continue
+        seen.add(display_name)
+        pinned_entries.append(entry)
+
+    pinned_lines: list[str] = []
+    for entry in sorted(pinned_entries, key=lambda e: str(e.get("frontmatter_name") or e.get("skill_name") or "")):
+        name = str(entry.get("frontmatter_name") or entry.get("skill_name") or "")
+        desc = str(entry.get("description") or "").strip()
+        triggers = _normalize_string_list(entry.get("triggers"))
+        line = f"    - {name}"
+        if desc:
+            line += f": {desc}"
+        if triggers:
+            line += f" (triggers: {', '.join(triggers[:8])})"
+        pinned_lines.append(line)
+
+    sections = [
+        _render_skills_prompt_header("hybrid skill router"),
+        "",
+        "<skill_categories>",
+        *category_lines,
+        "</skill_categories>",
+    ]
+    if pinned_lines:
+        sections.extend([
+            "",
+            "<pinned_router_skills>",
+            *pinned_lines,
+            "</pinned_router_skills>",
+        ])
+    sections.extend([
+        "",
+        "Use skills_list(category=...) to inspect a category and skill_view(name) to load the full procedure. "
+        "The router is intentionally compact; absence from pinned_router_skills does not mean the skill is unavailable.",
+    ])
+    return "\n".join(sections)
+
+
 def build_skills_system_prompt(
     available_tools: "set[str] | None" = None,
     available_toolsets: "set[str] | None" = None,
@@ -1282,6 +1481,7 @@ def build_skills_system_prompt(
         or ""
     )
     disabled = get_disabled_skill_names(_platform_hint or None)
+    prompt_mode, router_pinned = _load_skills_prompt_options()
     cache_key = (
         str(skills_dir.resolve()),
         tuple(str(d) for d in external_dirs),
@@ -1290,6 +1490,8 @@ def build_skills_system_prompt(
         _platform_hint,
         tuple(sorted(disabled)),
         tuple(sorted(compact_categories or ())),
+        prompt_mode,
+        router_pinned,
     )
     with _SKILLS_PROMPT_CACHE_LOCK:
         cached = _SKILLS_PROMPT_CACHE.get(cache_key)
@@ -1302,15 +1504,23 @@ def build_skills_system_prompt(
 
     skills_by_category: dict[str, list[tuple[str, str]]] = {}
     category_descriptions: dict[str, str] = {}
+    visible_skill_entries: list[dict] = []
+
+    def _record_visible_entry(entry: dict) -> None:
+        category = str(entry.get("category") or "general")
+        frontmatter_name = str(entry.get("frontmatter_name") or entry.get("skill_name") or "")
+        description = str(entry.get("description") or "")
+        visible_skill_entries.append(entry)
+        skills_by_category.setdefault(category, []).append((frontmatter_name, description))
 
     if snapshot is not None:
         # Fast path: use pre-parsed metadata from disk
-        for entry in snapshot.get("skills", []):
-            if not isinstance(entry, dict):
+        for raw_entry in snapshot.get("skills", []):
+            if not isinstance(raw_entry, dict):
                 continue
-            skill_name = entry.get("skill_name") or ""
-            category = entry.get("category") or "general"
-            frontmatter_name = entry.get("frontmatter_name") or skill_name
+            entry = dict(raw_entry)
+            skill_name = str(entry.get("skill_name") or "")
+            frontmatter_name = str(entry.get("frontmatter_name") or skill_name)
             platforms = entry.get("platforms") or []
             if not skill_matches_platform({"platforms": platforms}):
                 continue
@@ -1322,9 +1532,7 @@ def build_skills_system_prompt(
                 available_toolsets,
             ):
                 continue
-            skills_by_category.setdefault(category, []).append(
-                (frontmatter_name, entry.get("description", ""))
-            )
+            _record_visible_entry(entry)
         category_descriptions = {
             str(k): str(v)
             for k, v in (snapshot.get("category_descriptions") or {}).items()
@@ -1338,8 +1546,9 @@ def build_skills_system_prompt(
             skill_entries.append(entry)
             if not is_compatible:
                 continue
-            skill_name = entry["skill_name"]
-            if entry["frontmatter_name"] in disabled or skill_name in disabled:
+            skill_name = str(entry["skill_name"])
+            frontmatter_name = str(entry["frontmatter_name"])
+            if frontmatter_name in disabled or skill_name in disabled:
                 continue
             if not _skill_should_show(
                 extract_skill_conditions(frontmatter),
@@ -1347,9 +1556,7 @@ def build_skills_system_prompt(
                 available_toolsets,
             ):
                 continue
-            skills_by_category.setdefault(entry["category"], []).append(
-                (entry["frontmatter_name"], entry["description"])
-            )
+            _record_visible_entry(entry)
 
         # Read category-level DESCRIPTION.md files
         for desc_file in iter_skill_index_files(skills_dir, "DESCRIPTION.md"):
@@ -1377,9 +1584,13 @@ def build_skills_system_prompt(
     # and typically small).  Local skills already in skills_by_category take
     # precedence: we track seen names and skip duplicates from external dirs.
     seen_skill_names: set[str] = set()
-    for cat_skills in skills_by_category.values():
-        for name, _desc in cat_skills:
-            seen_skill_names.add(name)
+    for entry in visible_skill_entries:
+        frontmatter_name = str(entry.get("frontmatter_name") or entry.get("skill_name") or "")
+        skill_name = str(entry.get("skill_name") or "")
+        if frontmatter_name:
+            seen_skill_names.add(frontmatter_name)
+        if skill_name:
+            seen_skill_names.add(skill_name)
 
     for ext_dir in external_dirs:
         if not ext_dir.exists():
@@ -1390,9 +1601,9 @@ def build_skills_system_prompt(
                 if not is_compatible:
                     continue
                 entry = _build_snapshot_entry(skill_file, ext_dir, frontmatter, desc)
-                skill_name = entry["skill_name"]
-                frontmatter_name = entry["frontmatter_name"]
-                if frontmatter_name in seen_skill_names:
+                skill_name = str(entry["skill_name"])
+                frontmatter_name = str(entry["frontmatter_name"])
+                if frontmatter_name in seen_skill_names or skill_name in seen_skill_names:
                     continue
                 if frontmatter_name in disabled or skill_name in disabled:
                     continue
@@ -1403,9 +1614,8 @@ def build_skills_system_prompt(
                 ):
                     continue
                 seen_skill_names.add(frontmatter_name)
-                skills_by_category.setdefault(entry["category"], []).append(
-                    (frontmatter_name, entry["description"])
-                )
+                seen_skill_names.add(skill_name)
+                _record_visible_entry(entry)
             except Exception as e:
                 logger.debug("Error reading external skill %s: %s", skill_file, e)
 
@@ -1423,82 +1633,87 @@ def build_skills_system_prompt(
             except Exception as e:
                 logger.debug("Could not read external skill description %s: %s", desc_file, e)
 
-    # Posture-driven category demotion (e.g. non-coding skills while pairing
-    # on code). Demoted categories stay in the index as a single names-only
-    # line — descriptions are dropped to cut noise, but every skill name
-    # remains visible so memory-anchored recall ("load <name>") keeps working.
-    # NEVER remove entries entirely: agent-created skills are the model's
-    # project memory, and models don't reach for skills_list to rediscover
-    # what the index stops showing them. Match on the top-level category
-    # segment so nested categories ("social-media/twitter") are demoted with
-    # their parent.
-    demoted = frozenset(
-        cat for cat in skills_by_category
-        if cat.split("/", 1)[0] in (compact_categories or frozenset())
-    )
-
-    hidden_note = ""
-    if demoted:
-        hidden_note = (
-            "\n(Categories marked [names only] are outside the current coding "
-            "context, so their descriptions are omitted — the skills work "
-            "normally and load with skill_view(name) as usual.)"
-        )
-
-    if not skills_by_category:
-        result = ""
+    if prompt_mode == "names_only":
+        result = _render_names_only_skill_prompt(skills_by_category) if skills_by_category else ""
+    elif prompt_mode == "hybrid":
+        result = _render_hybrid_skill_router(visible_skill_entries, router_pinned) if visible_skill_entries else ""
     else:
-        index_lines = []
-        for category in sorted(skills_by_category.keys()):
-            # Deduplicate and sort skills within each category
-            seen = set()
-            if category in demoted:
-                names = sorted({name for name, _ in skills_by_category[category]})
-                index_lines.append(f"  {category} [names only]: {', '.join(names)}")
-                continue
-            cat_desc = category_descriptions.get(category, "")
-            if cat_desc:
-                index_lines.append(f"  {category}: {cat_desc}")
-            else:
-                index_lines.append(f"  {category}:")
-            for name, desc in sorted(skills_by_category[category], key=lambda x: x[0]):
-                if name in seen:
-                    continue
-                seen.add(name)
-                if desc:
-                    index_lines.append(f"    - {name}: {desc}")
-                else:
-                    index_lines.append(f"    - {name}")
-
-        result = (
-            "## Skills (mandatory)\n"
-            "Before replying, scan the skills below. If a skill matches or is even partially relevant "
-            "to your task, you MUST load it with skill_view(name) and follow its instructions. "
-            "Err on the side of loading — it is always better to have context you don't need "
-            "than to miss critical steps, pitfalls, or established workflows. "
-            "Skills contain specialized knowledge — API endpoints, tool-specific commands, "
-            "and proven workflows that outperform general-purpose approaches. Load the skill "
-            "even if you think you could handle the task with basic tools like web_search or terminal. "
-            "Skills also encode the user's preferred approach, conventions, and quality standards "
-            "for tasks like code review, planning, and testing — load them even for tasks you "
-            "already know how to do, because the skill defines how it should be done here.\n"
-            "Whenever the user asks you to configure, set up, install, enable, disable, modify, "
-            "or troubleshoot Hermes Agent itself — its CLI, config, models, providers, tools, "
-            "skills, voice, gateway, plugins, or any feature — load the `hermes-agent` skill "
-            "first. It has the actual commands (e.g. `hermes config set …`, `hermes tools`, "
-            "`hermes setup`) so you don't have to guess or invent workarounds.\n"
-            "If a skill has issues, fix it with skill_manage(action='patch').\n"
-            "After difficult/iterative tasks, offer to save as a skill. "
-            "If a skill you loaded was missing steps, had wrong commands, or needed "
-            "pitfalls you discovered, update it before finishing.\n"
-            "\n"
-            "<available_skills>\n"
-            + "\n".join(index_lines) + "\n"
-            "</available_skills>\n"
-            "\n"
-            "Only proceed without loading a skill if genuinely none are relevant to the task."
-            + hidden_note
+        # Posture-driven category demotion (e.g. non-coding skills while pairing
+        # on code). Demoted categories stay in the index as a single names-only
+        # line — descriptions are dropped to cut noise, but every skill name
+        # remains visible so memory-anchored recall ("load <name>") keeps working.
+        # NEVER remove entries entirely: agent-created skills are the model's
+        # project memory, and models don't reach for skills_list to rediscover
+        # what the index stops showing them. Match on the top-level category
+        # segment so nested categories ("social-media/twitter") are demoted with
+        # their parent.
+        demoted = frozenset(
+            cat for cat in skills_by_category
+            if cat.split("/", 1)[0] in (compact_categories or frozenset())
         )
+
+        hidden_note = ""
+        if demoted:
+            hidden_note = (
+                "\n(Categories marked [names only] are outside the current coding "
+                "context, so their descriptions are omitted — the skills work "
+                "normally and load with skill_view(name) as usual.)"
+            )
+
+        if not skills_by_category:
+            result = ""
+        else:
+            index_lines = []
+            for category in sorted(skills_by_category.keys()):
+                # Deduplicate and sort skills within each category
+                seen = set()
+                if category in demoted:
+                    names = sorted({name for name, _ in skills_by_category[category]})
+                    index_lines.append(f"  {category} [names only]: {', '.join(names)}")
+                    continue
+                cat_desc = category_descriptions.get(category, "")
+                if cat_desc:
+                    index_lines.append(f"  {category}: {cat_desc}")
+                else:
+                    index_lines.append(f"  {category}:")
+                for name, desc in sorted(skills_by_category[category], key=lambda x: x[0]):
+                    if name in seen:
+                        continue
+                    seen.add(name)
+                    if desc:
+                        index_lines.append(f"    - {name}: {desc}")
+                    else:
+                        index_lines.append(f"    - {name}")
+
+            result = (
+                "## Skills (mandatory)\n"
+                "Before replying, scan the skills below. If a skill matches or is even partially relevant "
+                "to your task, you MUST load it with skill_view(name) and follow its instructions. "
+                "Err on the side of loading — it is always better to have context you don't need "
+                "than to miss critical steps, pitfalls, or established workflows. "
+                "Skills contain specialized knowledge — API endpoints, tool-specific commands, "
+                "and proven workflows that outperform general-purpose approaches. Load the skill "
+                "even if you think you could handle the task with basic tools like web_search or terminal. "
+                "Skills also encode the user's preferred approach, conventions, and quality standards "
+                "for tasks like code review, planning, and testing — load them even for tasks you "
+                "already know how to do, because the skill defines how it should be done here.\n"
+                "Whenever the user asks you to configure, set up, install, enable, disable, modify, "
+                "or troubleshoot Hermes Agent itself — its CLI, config, models, providers, tools, "
+                "skills, voice, gateway, plugins, or any feature — load the `hermes-agent` skill "
+                "first. It has the actual commands (e.g. `hermes config set …`, `hermes tools`, "
+                "`hermes setup`) so you don't have to guess or invent workarounds.\n"
+                "If a skill has issues, fix it with skill_manage(action='patch').\n"
+                "After difficult/iterative tasks, offer to save as a skill. "
+                "If a skill you loaded was missing steps, had wrong commands, or needed "
+                "pitfalls you discovered, update it before finishing.\n"
+                "\n"
+                "<available_skills>\n"
+                + "\n".join(index_lines) + "\n"
+                "</available_skills>\n"
+                "\n"
+                "Only proceed without loading a skill if genuinely none are relevant to the task."
+                + hidden_note
+            )
 
     # ── Store in LRU cache ────────────────────────────────────────────
     with _SKILLS_PROMPT_CACHE_LOCK:

--- a/agent/shell_hooks.py
+++ b/agent/shell_hooks.py
@@ -44,8 +44,8 @@ Wire protocol
     {"decision": "block", "reason":  "Forbidden command"}   # Claude-Code-style
     {"action":   "block", "message": "Forbidden command"}   # Hermes-canonical
 
-    # Inject context for pre_llm_call:
-    {"context": "Today is Friday"}
+    # Inject context / request-scoped routing for pre_llm_call:
+    {"context": "Today is Friday", "reasoning_config": {"enabled": True, "effort": "high"}}
 
     # Silent no-op:
     <empty or any non-matching JSON object>
@@ -532,11 +532,21 @@ def _parse_response(event: str, stdout: str) -> Optional[Dict[str, Any]]:
             return {"action": "block", "message": _block_message(data.get("reason"), data.get("message"))}
         return None
 
+    result: Dict[str, Any] = {}
+
     context = data.get("context")
     if isinstance(context, str) and context.strip():
-        return {"context": context}
+        result["context"] = context
 
-    return None
+    # pre_llm_call hooks may return a sanitized per-turn reasoning override.
+    # Preserve it here so agent.turn_context can validate and apply it; dropping
+    # this field makes declarative routing advisory-only even when config says
+    # routing.mode=enforced.
+    reasoning_config = data.get("reasoning_config")
+    if event == "pre_llm_call" and isinstance(reasoning_config, dict):
+        result["reasoning_config"] = reasoning_config
+
+    return result or None
 
 
 # ---------------------------------------------------------------------------

--- a/agent/system_prompt.py
+++ b/agent/system_prompt.py
@@ -24,6 +24,7 @@ Pure helpers that read the agent's state.  AIAgent keeps thin forwarders.
 from __future__ import annotations
 
 import json
+import re
 from typing import Any, Dict, List, Optional
 
 from agent.prompt_builder import (
@@ -44,6 +45,7 @@ from agent.prompt_builder import (
     drain_truncation_warnings,
 )
 from agent.runtime_cwd import resolve_context_cwd
+from hermes_constants import get_hermes_home
 
 
 def _ra():
@@ -491,6 +493,76 @@ def build_system_prompt(agent: Any, system_message: Optional[str] = None) -> str
     return joined
 
 
+def _normalize_prompt_for_duplicate_check(text: str | None) -> str:
+    """Whitespace-normalize prompt text for conservative duplicate checks."""
+    return re.sub(r"\s+", " ", text or "").strip()
+
+
+def _read_profile_prompt_file(filename: str) -> str:
+    """Read a prompt file from the active Hermes home, returning ``""`` on miss."""
+    try:
+        path = get_hermes_home() / filename
+        if path.exists() and path.is_file():
+            return path.read_text(encoding="utf-8")
+    except Exception:
+        pass
+    return ""
+
+
+def _base_prompt_contains_loaded_soul(base_system_prompt: str) -> bool:
+    """Return True when the stable system prompt already contains SOUL.md."""
+    base_norm = _normalize_prompt_for_duplicate_check(base_system_prompt)
+    soul = _read_profile_prompt_file("SOUL.md")
+    soul_norm = _normalize_prompt_for_duplicate_check(soul)
+    if soul_norm and soul_norm in base_norm:
+        return True
+
+    # Fallback for tests, generated prompts, or profile overrides where the
+    # exact SOUL.md bytes are not available but the canonical soul marker is.
+    return "# Hermes Agent Soul" in base_system_prompt and "J.A.R.V.I.S." in base_system_prompt
+
+
+def should_append_ephemeral_system_prompt(
+    base_system_prompt: str | None,
+    ephemeral_system_prompt: str | None,
+) -> bool:
+    """Decide whether an API-call-time system prompt should be appended.
+
+    ``agent.system_prompt`` is often synced from ``persona.md`` for runtime
+    continuity. The stable prompt may already load the profile's full
+    ``SOUL.md`` identity, so blindly appending the synced persona creates a
+    second identity layer on every request. Keep custom ephemeral prompts,
+    but skip exact duplicates and the common ``SOUL.md`` + ``persona.md``
+    Jarvis duplication.
+    """
+    ephemeral_norm = _normalize_prompt_for_duplicate_check(ephemeral_system_prompt)
+    if not ephemeral_norm:
+        return False
+
+    base = base_system_prompt or ""
+    base_norm = _normalize_prompt_for_duplicate_check(base)
+    if ephemeral_norm in base_norm:
+        return False
+
+    persona = _read_profile_prompt_file("persona.md")
+    persona_norm = _normalize_prompt_for_duplicate_check(persona)
+    if persona_norm and ephemeral_norm == persona_norm:
+        return not _base_prompt_contains_loaded_soul(base)
+
+    return True
+
+
+def build_effective_system_prompt(
+    base_system_prompt: str | None,
+    ephemeral_system_prompt: str | None = None,
+) -> str:
+    """Join stable and ephemeral system prompts, suppressing duplicates."""
+    base = (base_system_prompt or "").strip()
+    if not should_append_ephemeral_system_prompt(base, ephemeral_system_prompt):
+        return base
+    return (base + "\n\n" + (ephemeral_system_prompt or "")).strip()
+
+
 def invalidate_system_prompt(agent: Any) -> None:
     """Invalidate the cached system prompt, forcing a rebuild on the next turn.
 
@@ -529,6 +601,8 @@ def format_tools_for_system_message(agent: Any) -> str:
 __all__ = [
     "build_system_prompt_parts",
     "build_system_prompt",
+    "build_effective_system_prompt",
     "invalidate_system_prompt",
     "format_tools_for_system_message",
+    "should_append_ephemeral_system_prompt",
 ]

--- a/agent/turn_finalizer.py
+++ b/agent/turn_finalizer.py
@@ -203,6 +203,8 @@ def finalize_turn(
     # already have other surface text that shouldn't be augmented.
     if final_response and not interrupted:
         try:
+            if hasattr(agent, "_prune_superseded_file_mutation_failures"):
+                agent._prune_superseded_file_mutation_failures()
             _failed = getattr(agent, "_turn_failed_file_mutations", None) or {}
             if _failed and agent._file_mutation_verifier_enabled():
                 footer = agent._format_file_mutation_failure_footer(_failed)

--- a/cli.py
+++ b/cli.py
@@ -3333,6 +3333,11 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
         _config_model = (_model_config.get("default") or _model_config.get("model") or "") if isinstance(_model_config, dict) else (_model_config or "")
         _DEFAULT_CONFIG_MODEL = ""
         self.model = model or _config_model or _DEFAULT_CONFIG_MODEL
+        # Track CLI-level model/provider overrides separately from config defaults.
+        # Declarative per-turn routing must not silently override an explicit
+        # one-shot invocation such as `hermes chat --provider openai-codex --model ...`.
+        self._explicit_model_override = bool(model)
+        self._explicit_provider_override = bool(provider)
         # Read max_tokens from config (env var override: HERMES_MAX_TOKENS)
         _env_mt = os.environ.get("HERMES_MAX_TOKENS")
         if _env_mt:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -5920,6 +5920,165 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         except Exception:
             return "default"
 
+    # ── Telegram profile routing ─────────────────────────────────────────
+    def _profile_router_state_path(self) -> Path:
+        return _hermes_home / "gateway_profile_routes.json"
+
+    def _load_profile_router_state(self) -> dict:
+        path = self._profile_router_state_path()
+        try:
+            if path.exists():
+                data = json.loads(path.read_text(encoding="utf-8"))
+                return data if isinstance(data, dict) else {}
+        except Exception:
+            logger.debug("Could not load profile router state", exc_info=True)
+        return {}
+
+    def _save_profile_router_state(self, state: dict) -> None:
+        path = self._profile_router_state_path()
+        try:
+            tmp = path.with_suffix(".tmp")
+            tmp.write_text(json.dumps(state, indent=2, sort_keys=True), encoding="utf-8")
+            tmp.replace(path)
+        except Exception:
+            logger.warning("Could not save profile router state", exc_info=True)
+
+    def _available_profile_map(self) -> dict[str, Path]:
+        try:
+            from hermes_cli.profiles import list_profiles
+            return {p.name: Path(p.path) for p in list_profiles() if p.name and Path(p.path).exists()}
+        except Exception:
+            return {self._active_profile_name(): _hermes_home}
+
+    def _profile_route_for_key(self, session_key: str) -> str | None:
+        routes = self._load_profile_router_state().get("routes") or {}
+        value = routes.get(session_key)
+        return value if isinstance(value, str) and value else None
+
+    def _profile_route_session_id(self, session_key: str, profile: str) -> str | None:
+        sessions = self._load_profile_router_state().get("sessions") or {}
+        value = sessions.get(f"{session_key}::{profile}")
+        return value if isinstance(value, str) and value else None
+
+    def _set_profile_route_session_id(self, session_key: str, profile: str, session_id: str) -> None:
+        state = self._load_profile_router_state()
+        sessions = state.setdefault("sessions", {})
+        sessions[f"{session_key}::{profile}"] = session_id
+        self._save_profile_router_state(state)
+
+    def _clear_profile_route_session_id(self, session_key: str, profile: str) -> None:
+        state = self._load_profile_router_state()
+        sessions = state.setdefault("sessions", {})
+        sessions.pop(f"{session_key}::{profile}", None)
+        self._save_profile_router_state(state)
+
+    async def _handle_profiles_command(self, event: MessageEvent) -> str:
+        profiles = self._available_profile_map()
+        session_key = self._session_key_for_source(event.source)
+        active = self._profile_route_for_key(session_key) or self._active_profile_name()
+        lines = ["Reachable Hermes profiles:"]
+        for name in sorted(profiles):
+            marker = "*" if name == active else " "
+            lines.append(f"{marker} {name}")
+        lines.append("\nUse `/use <profile>` or one-shot `@profile your prompt`. `/use off` returns to this gateway's launch profile.")
+        return "\n".join(lines)
+
+    async def _handle_profile_route_command(self, event: MessageEvent) -> str:
+        raw = (event.get_command_args() or "").strip()
+        session_key = self._session_key_for_source(event.source)
+        launch = self._active_profile_name()
+        current = self._profile_route_for_key(session_key) or launch
+        if not raw:
+            return (
+                f"Active routed profile for this chat: `{current}`\n"
+                f"Launch profile: `{launch}`\n"
+                "Use `/profiles` to list profiles or `/use <profile>` to switch."
+            )
+        target = raw.split()[0].strip().lower()
+        if target in {"off", "clear", "default-launch", "launch"}:
+            state = self._load_profile_router_state()
+            routes = state.setdefault("routes", {})
+            routes.pop(session_key, None)
+            self._save_profile_router_state(state)
+            return f"Profile routing cleared. This chat now uses launch profile `{launch}`."
+        profiles = self._available_profile_map()
+        if target not in profiles:
+            return f"Unknown profile `{target}`. Use `/profiles` to list available profiles."
+        state = self._load_profile_router_state()
+        routes = state.setdefault("routes", {})
+        if target == launch:
+            routes.pop(session_key, None)
+        else:
+            routes[session_key] = target
+        self._save_profile_router_state(state)
+        return f"This chat now routes through Hermes profile `{target}`. Use `/use off` to return to `{launch}`."
+
+    def _parse_one_shot_profile_route(self, text: str) -> tuple[str, str] | None:
+        match = re.match(r"^@([a-z0-9][a-z0-9_-]{0,63})\s+(.+)$", (text or "").strip(), re.DOTALL)
+        if not match:
+            return None
+        return match.group(1).lower(), match.group(2).strip()
+
+    async def _route_message_to_profile_cli(
+        self,
+        event: MessageEvent,
+        profile: str,
+        prompt: str,
+        *,
+        one_shot: bool = False,
+    ) -> Optional[str]:
+        profiles = self._available_profile_map()
+        home = profiles.get(profile)
+        if home is None:
+            return f"Unknown profile `{profile}`. Use `/profiles` to list available profiles."
+        launch = self._active_profile_name()
+        if profile == launch and not one_shot:
+            return None
+        session_key = self._session_key_for_source(event.source)
+        resume_id = None if one_shot else self._profile_route_session_id(session_key, profile)
+        env = os.environ.copy()
+        env["HERMES_HOME"] = str(home)
+        env.setdefault("HERMES_SESSION_SOURCE", "telegram-profile-router")
+        repo_root = Path(__file__).resolve().parents[1]
+        argv = [sys.executable, "-m", "hermes_cli.main", "chat", "-q", prompt, "--quiet", "--source", "telegram"]
+        if resume_id:
+            argv[4:4] = ["--resume", resume_id]
+        try:
+            proc = await asyncio.create_subprocess_exec(
+                *argv,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+                cwd=str(repo_root),
+                env=env,
+            )
+            stdout_b, stderr_b = await asyncio.wait_for(proc.communicate(), timeout=1800)
+        except asyncio.TimeoutError:
+            return f"Profile `{profile}` did not finish within 30 minutes."
+        except Exception as exc:
+            logger.warning("Profile route failed for %s: %s", profile, exc)
+            return f"Profile route to `{profile}` failed: {exc}"
+        stdout = stdout_b.decode(errors="replace").strip()
+        stderr = stderr_b.decode(errors="replace").strip()
+        if proc.returncode != 0:
+            detail = stderr or stdout or f"exit code {proc.returncode}"
+            return f"Profile `{profile}` returned an error:\n{detail[-3500:]}"
+        session_id = None
+        for line in (stderr.splitlines() + stdout.splitlines()):
+            if line.startswith("session_id:"):
+                session_id = line.split(":", 1)[1].strip()
+                break
+        body_lines = []
+        for line in stdout.splitlines():
+            if line.startswith("session_id:"):
+                continue
+            if line.startswith("↻ Resumed session "):
+                continue
+            body_lines.append(line)
+        if session_id and not one_shot:
+            self._set_profile_route_session_id(session_key, profile, session_id)
+        body = "\n".join(body_lines).strip()
+        return body or f"Profile `{profile}` completed without text output."
+
     # ── Kanban board watchers ───────────────────────────────────────────
     # The kanban notifier/dispatcher watcher loops + their helpers live in
     # GatewayKanbanWatchersMixin (gateway/kanban_watchers.py). They use only
@@ -7306,8 +7465,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     return await self._handle_help_command(event)
                 if _cmd_def_inner.name == "commands":
                     return await self._handle_commands_command(event)
-                if _cmd_def_inner.name == "profile":
-                    return await self._handle_profile_command(event)
+                if _cmd_def_inner.name in {"profile", "profiles", "use"}:
+                    if _cmd_def_inner.name == "profiles":
+                        return await self._handle_profiles_command(event)
+                    return await self._handle_profile_route_command(event)
                 if _cmd_def_inner.name == "update":
                     return await self._handle_update_command(event)
                 if _cmd_def_inner.name == "version":
@@ -7566,9 +7727,15 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
         if canonical == "commands":
             return await self._handle_commands_command(event)
+
+        if canonical == "profiles":
+            return await self._handle_profiles_command(event)
+
+        if canonical == "use":
+            return await self._handle_profile_route_command(event)
         
         if canonical == "profile":
-            return await self._handle_profile_command(event)
+            return await self._handle_profile_route_command(event)
 
         if canonical == "whoami":
             return await self._handle_whoami_command(event)
@@ -7933,6 +8100,30 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             if self._should_send_telegram_lobby_reminder(source):
                 return self._telegram_topic_root_lobby_message()
             return None
+
+        # Telegram profile router: `/use <profile>` persists a profile for this
+        # chat; `@profile prompt` performs a one-shot route.  Routed turns use
+        # the CLI entrypoint with HERMES_HOME bound to the target profile so
+        # profile config, memory, skills, MCP, and state stay isolated.
+        if source.platform == Platform.TELEGRAM and event.message_type == MessageType.TEXT:
+            _profile_prompt = self._parse_one_shot_profile_route(event.text or "")
+            if _profile_prompt is not None:
+                _target_profile, _target_prompt = _profile_prompt
+                return await self._route_message_to_profile_cli(
+                    event,
+                    _target_profile,
+                    _target_prompt,
+                    one_shot=True,
+                )
+            _active_route = self._profile_route_for_key(_quick_key)
+            if _active_route:
+                _routed = await self._route_message_to_profile_cli(
+                    event,
+                    _active_route,
+                    event.text or "",
+                )
+                if _routed is not None:
+                    return _routed
 
         # ── Claim this session before any await ───────────────────────
         # Between here and _run_agent registering the real AIAgent, there

--- a/hermes_cli/cli_agent_setup_mixin.py
+++ b/hermes_cli/cli_agent_setup_mixin.py
@@ -179,6 +179,7 @@ class CLIAgentSetupMixin:
         Processing / Anthropic fast mode, attach `request_overrides` so the
         API call is marked accordingly.
         """
+        from hermes_cli.model_routing import resolve_turn_model_route
         from hermes_cli.models import resolve_fast_mode_overrides
 
         runtime = {
@@ -190,29 +191,43 @@ class CLIAgentSetupMixin:
             "args": list(self.acp_args or []),
             "credential_pool": getattr(self, "_credential_pool", None),
         }
-        route = {
-            "model": self.model,
-            "runtime": runtime,
-            "signature": (
+        if getattr(self, "_explicit_model_override", False) or getattr(self, "_explicit_provider_override", False):
+            # A CLI one-shot/model override is an explicit operator choice, not
+            # a candidate for declarative down-routing. This keeps commands like
+            # `hermes chat --provider openai-codex --model gpt-5.3-codex-spark`
+            # on the requested lane instead of silently sending them to the
+            # configured fast/balanced routing tier.
+            effective_model, effective_runtime, model_route = self.model, runtime, None
+        else:
+            effective_model, effective_runtime, model_route = resolve_turn_model_route(
+                user_message,
                 self.model,
-                runtime["provider"],
-                runtime["base_url"],
-                runtime["api_mode"],
-                runtime["command"],
-                tuple(runtime["args"]),
+                runtime,
+            )
+        route = {
+            "model": effective_model,
+            "runtime": effective_runtime,
+            "routing": model_route,
+            "signature": (
+                effective_model,
+                effective_runtime["provider"],
+                effective_runtime["base_url"],
+                effective_runtime["api_mode"],
+                effective_runtime["command"],
+                tuple(effective_runtime["args"]),
             ),
         }
 
+        base_request_overrides = dict((model_route or {}).get("request_overrides") or {})
         service_tier = getattr(self, "service_tier", None)
-        if not service_tier:
-            route["request_overrides"] = None
-            return route
-
-        try:
-            overrides = resolve_fast_mode_overrides(route["model"])
-        except Exception:
-            overrides = None
-        route["request_overrides"] = overrides
+        if service_tier:
+            try:
+                overrides = resolve_fast_mode_overrides(route["model"])
+            except Exception:
+                overrides = None
+            if overrides:
+                base_request_overrides.update(overrides)
+        route["request_overrides"] = base_request_overrides or None
         return route
 
     def _init_agent(self, *, model_override: str = None, runtime_override: dict = None, request_overrides: dict | None = None) -> bool:

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -111,7 +111,12 @@ COMMAND_REGISTRY: list[CommandDef] = [
                args_hint="[text | remove N | clear]"),
     CommandDef("status", "Show session, model, token, and context info", "Session"),
     CommandDef("whoami", "Show your slash command access (admin / user)", "Info"),
-    CommandDef("profile", "Show active profile name and home directory", "Info"),
+    CommandDef("profile", "Show or switch this chat's routed Hermes profile", "Info",
+               args_hint="[name|off]"),
+    CommandDef("profiles", "List Hermes profiles reachable from this chat", "Info",
+               gateway_only=True),
+    CommandDef("use", "Route this chat through another Hermes profile", "Session",
+               gateway_only=True, args_hint="<profile|off>"),
     CommandDef("sethome", "Set this chat as the home channel", "Session",
                gateway_only=True, aliases=("set-home",)),
     CommandDef("resume", "Resume a previously-named session", "Session",
@@ -357,12 +362,14 @@ ACTIVE_SESSION_BYPASS_COMMANDS: frozenset[str] = frozenset(
         "help",
         "new",
         "profile",
+        "profiles",
         "queue",
         "restart",
         "status",
         "steer",
         "stop",
         "update",
+        "use",
         "version",
     }
 )
@@ -553,6 +560,8 @@ _TELEGRAM_MENU_PRIORITY = (
     "platforms",
     "platform",
     "profile",
+    "profiles",
+    "use",
     "whoami",
 )
 """Built-in commands that should stay visible in Telegram's capped menu.
@@ -1056,7 +1065,9 @@ _SLACK_PRIORITY_ALIASES = ("btw", "bg")
 #   - credits: the billing/top-up surface; reached via /hermes credits on Slack.
 #   - billing: the terminal-billing surface (buy/auto-reload/limit); /hermes billing.
 #   - debug: the log/report upload surface; reached via /hermes debug on Slack.
-_SLACK_VIA_HERMES_ONLY = frozenset({"credits", "billing", "debug"})
+#   - profiles/use: profile-router controls are primarily for Telegram chats;
+#     on Slack they stay reachable through /hermes without taking native slots.
+_SLACK_VIA_HERMES_ONLY = frozenset({"credits", "billing", "debug", "profiles", "use"})
 
 
 def _sanitize_slack_name(raw: str) -> str:

--- a/hermes_cli/model_routing.py
+++ b/hermes_cli/model_routing.py
@@ -1,0 +1,273 @@
+"""Provider/model tier selection for Hermes declarative routing.
+
+This module turns the existing provider-neutral routing config into a concrete
+model/provider choice for a turn.  It is intentionally pure and conservative:
+no selection happens unless ``routing.model_selection.enabled`` is true.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+import re
+
+
+DEFAULT_REASONING_TIER_MAP = {
+    "none": "balanced",
+    "think": "balanced",
+    "megathink": "deep",
+    "ultrathink": "deep",
+}
+
+CUSTODIAL_SCORE_HITS = {
+    "citadel-trading",
+    "destructive-production",
+    "financial-sensitive",
+    "secrets-security",
+    "email-approval-flow",
+}
+
+
+def _text(value: Any) -> str:
+    if value is None:
+        return ""
+    if isinstance(value, str):
+        return value
+    return str(value)
+
+
+def _as_dict(value: Any) -> dict[str, Any]:
+    return value if isinstance(value, dict) else {}
+
+
+def _as_list(value: Any) -> list[Any]:
+    return value if isinstance(value, list) else []
+
+
+def load_config() -> dict[str, Any]:
+    """Load Hermes config lazily so tests can monkeypatch this module seam."""
+    try:
+        from hermes_cli.config import load_config as _load_config
+
+        loaded = _load_config() or {}
+        return loaded if isinstance(loaded, dict) else {}
+    except Exception:
+        return {}
+
+
+def _pattern_matches(pattern: str, prompt: str) -> bool:
+    try:
+        return re.search(pattern, prompt, re.IGNORECASE) is not None
+    except re.error:
+        return False
+
+
+def _any_match(patterns: list[Any], prompt: str) -> bool:
+    return any(isinstance(pattern, str) and _pattern_matches(pattern, prompt) for pattern in patterns)
+
+
+def _first_reasoning_match(rules: list[Any], prompt: str, default_tier: str) -> tuple[str, str]:
+    for rule in rules:
+        if not isinstance(rule, dict):
+            continue
+        patterns = _as_list(rule.get("patterns"))
+        if _any_match(patterns, prompt):
+            tier = _text(rule.get("tier") or default_tier).strip().lower()
+            reason = _text(rule.get("reason") or rule.get("name") or "matched")
+            return tier or default_tier, reason
+    return default_tier, "default"
+
+
+def _score_delegation_rules(rules: list[Any], prompt: str) -> tuple[int, list[str]]:
+    score = 0
+    hits: list[str] = []
+    for rule in rules:
+        if not isinstance(rule, dict):
+            continue
+        patterns = _as_list(rule.get("patterns"))
+        if _any_match(patterns, prompt):
+            try:
+                score += int(rule.get("score", 0) or 0)
+            except Exception:
+                pass
+            hits.append(_text(rule.get("name") or "matched"))
+    return score, hits
+
+
+def _complexity_for_rules(delegation: dict[str, Any], prompt: str) -> tuple[int, list[str]]:
+    try:
+        complexity = int(delegation.get("default_complexity", 4) or 4)
+    except Exception:
+        complexity = 4
+    hits: list[str] = []
+    for rule in _as_list(delegation.get("complexity_rules")):
+        if not isinstance(rule, dict):
+            continue
+        patterns = _as_list(rule.get("patterns"))
+        if _any_match(patterns, prompt):
+            try:
+                complexity = int(rule.get("complexity", complexity) or complexity)
+            except Exception:
+                pass
+            hits.append(_text(rule.get("name") or "matched"))
+    return complexity, hits
+
+
+def _is_enabled(value: Any) -> bool:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        return value.strip().lower() in {"1", "true", "yes", "on", "enabled"}
+    return bool(value)
+
+
+def select_model_route(user_message: str, config: dict[str, Any] | None) -> dict[str, Any] | None:
+    """Return the concrete model route for a user turn, or ``None``.
+
+    The expected config shape is:
+
+    ```yaml
+    routing:
+      enabled: true
+      model_selection:
+        enabled: true
+        default_tier: balanced
+        low_complexity_tier: fast
+        custodial_tier: custodial_direct
+        tier_map:
+          none: balanced
+          think: balanced
+          megathink: deep
+          ultrathink: deep
+      tiers:
+        balanced: {provider: opencode-go, model: deepseek-v4-pro}
+    ```
+    """
+    cfg = config if isinstance(config, dict) else {}
+    routing = _as_dict(cfg.get("routing"))
+    if not _is_enabled(routing.get("enabled", True)):
+        return None
+
+    model_selection = _as_dict(routing.get("model_selection"))
+    if not _is_enabled(model_selection.get("enabled", False)):
+        return None
+
+    tiers = _as_dict(routing.get("tiers"))
+    if not tiers:
+        return None
+
+    prompt = _text(user_message)
+    delegation = _as_dict(routing.get("delegation"))
+    reasoning = _as_dict(routing.get("reasoning"))
+
+    reasoning_default = _text(reasoning.get("default_tier") or "none").strip().lower() or "none"
+    reasoning_tier, reasoning_reason = _first_reasoning_match(
+        _as_list(reasoning.get("rules")),
+        prompt,
+        reasoning_default,
+    )
+
+    score, score_hits = _score_delegation_rules(_as_list(delegation.get("score_rules")), prompt)
+    complexity, complexity_hits = _complexity_for_rules(delegation, prompt)
+
+    try:
+        critical_threshold = int(delegation.get("critical_threshold", -5) or -5)
+    except Exception:
+        critical_threshold = -5
+
+    custodial_tier = _text(model_selection.get("custodial_tier") or "custodial_direct")
+    low_complexity_tier = _text(model_selection.get("low_complexity_tier") or "fast")
+    default_tier = _text(model_selection.get("default_tier") or "balanced")
+
+    tier_map = dict(DEFAULT_REASONING_TIER_MAP)
+    for key, value in _as_dict(model_selection.get("tier_map")).items():
+        if isinstance(key, str) and isinstance(value, str):
+            tier_map[key.strip().lower()] = value.strip()
+
+    custodial_hits = sorted(set(score_hits).intersection(CUSTODIAL_SCORE_HITS))
+    if score <= critical_threshold or custodial_hits:
+        selected_tier = custodial_tier
+        selected_reason = "custodial-score" if score <= critical_threshold else "custodial-hit"
+    elif reasoning_reason == "default" and complexity <= 2 and low_complexity_tier in tiers:
+        selected_tier = low_complexity_tier
+        selected_reason = "low-complexity"
+    else:
+        selected_tier = tier_map.get(reasoning_tier, default_tier) or default_tier
+        selected_reason = f"reasoning:{reasoning_tier}"
+
+    tier_cfg = tiers.get(selected_tier) if isinstance(tiers.get(selected_tier), dict) else None
+    if not tier_cfg:
+        tier_cfg = tiers.get(default_tier) if isinstance(tiers.get(default_tier), dict) else None
+        selected_tier = default_tier
+        selected_reason = "fallback-default-tier"
+    if not tier_cfg:
+        return None
+
+    provider = _text(tier_cfg.get("provider")).strip()
+    model = _text(tier_cfg.get("model")).strip()
+    if not provider or not model:
+        return None
+
+    return {
+        "tier": selected_tier,
+        "provider": provider,
+        "model": model,
+        "reason": selected_reason,
+        "reasoning_tier": reasoning_tier,
+        "reasoning_reason": reasoning_reason,
+        "score": score,
+        "score_hits": score_hits,
+        "custodial_hits": custodial_hits,
+        "complexity": complexity,
+        "complexity_hits": complexity_hits,
+        "allow_fallback": tier_cfg.get("allow_fallback", True) is not False,
+    }
+
+
+def resolve_turn_model_route(
+    user_message: str,
+    current_model: str,
+    current_runtime: dict[str, Any],
+    config: dict[str, Any] | None = None,
+) -> tuple[str, dict[str, Any], dict[str, Any] | None]:
+    """Resolve a per-turn model route and runtime credentials.
+
+    Returns ``(model, runtime, route_metadata)``. If routing is disabled, no
+    tier matches, or a non-custodial routed provider cannot be resolved, the
+    current model/runtime are returned with ``route_metadata`` set to ``None``.
+    A custodial tier with ``allow_fallback: false`` raises provider-resolution
+    errors so the caller fails closed instead of silently downgrading.
+    """
+    runtime = dict(current_runtime or {})
+    route = select_model_route(user_message, config if config is not None else load_config())
+    if route is None:
+        return current_model, runtime, None
+
+    provider = route["provider"]
+    model = route["model"]
+    if provider == runtime.get("provider"):
+        return model, runtime, route
+
+    try:
+        from hermes_cli.runtime_provider import resolve_runtime_provider
+
+        resolved = resolve_runtime_provider(requested=provider)
+    except Exception:
+        if route.get("allow_fallback") is False:
+            raise
+        return current_model, runtime, None
+
+    routed_runtime: dict[str, Any] = {
+        "api_key": resolved.get("api_key"),
+        "base_url": resolved.get("base_url"),
+        "provider": resolved.get("provider", provider),
+        "api_mode": resolved.get("api_mode"),
+        "command": resolved.get("command"),
+        "args": list(resolved.get("args") or []),
+        "credential_pool": resolved.get("credential_pool"),
+    }
+    if "max_tokens" in runtime:
+        routed_runtime["max_tokens"] = runtime.get("max_tokens")
+    provider_overrides = resolved.get("request_overrides")
+    if isinstance(provider_overrides, dict) and provider_overrides:
+        route = {**route, "request_overrides": dict(provider_overrides)}
+    return model, routed_runtime, route

--- a/run_agent.py
+++ b/run_agent.py
@@ -2517,9 +2517,62 @@ class AIAgent:
                     state[path] = {
                         "tool": tool_name,
                         "error_preview": preview,
+                        "file_signature": self._file_mutation_signature(path),
                     }
         else:
             for path in targets:
+                state.pop(path, None)
+
+    @staticmethod
+    def _file_mutation_signature(path: str) -> Dict[str, Any]:
+        """Return a small filesystem signature for verifier recovery checks.
+
+        The verifier directly tracks only ``write_file`` and ``patch`` because
+        they declare target paths. Operators can still recover from a failed
+        mutation by using a shell/Python command that edits the same file. To
+        avoid a false footer in that case, record the file's existence, mtime,
+        and size at failure time and compare it at turn-finalization.
+        """
+        try:
+            expanded = os.path.expandvars(os.path.expanduser(path))
+            st = os.stat(expanded)
+            return {
+                "exists": True,
+                "mtime_ns": int(getattr(st, "st_mtime_ns", int(st.st_mtime * 1_000_000_000))),
+                "size": int(st.st_size),
+            }
+        except FileNotFoundError:
+            return {"exists": False}
+        except OSError:
+            # Permission/encoding/race issues should not suppress a real
+            # failed-mutation warning; mark unknown and keep the footer.
+            return {"exists": None}
+
+    @staticmethod
+    def _file_mutation_signature_changed(before: Any, after: Any) -> bool:
+        if not isinstance(before, dict) or not isinstance(after, dict):
+            return False
+        if before.get("exists") is None or after.get("exists") is None:
+            return False
+        return before != after
+
+    def _prune_superseded_file_mutation_failures(self) -> None:
+        """Clear failed mutation entries when the target changed later.
+
+        This covers same-turn recovery via tools that do not expose target paths
+        to the verifier, such as ``terminal`` or ``execute_code``. Successful
+        ``write_file``/``patch`` calls still clear failures immediately via
+        ``_record_file_mutation_result``.
+        """
+        state = getattr(self, "_turn_failed_file_mutations", None)
+        if not isinstance(state, dict):
+            return
+        for path, info in list(state.items()):
+            if not isinstance(info, dict):
+                continue
+            before = info.get("file_signature")
+            after = self._file_mutation_signature(path)
+            if self._file_mutation_signature_changed(before, after):
                 state.pop(path, None)
 
     def _file_mutation_verifier_enabled(self) -> bool:

--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -474,6 +474,83 @@ class TestBuildSkillsSystemPrompt:
         full = build_skills_system_prompt()
         assert "Write threads" in full
 
+    def test_names_only_prompt_mode_keeps_names_and_drops_descriptions(
+        self, monkeypatch, tmp_path
+    ):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        (tmp_path / "config.yaml").write_text(
+            "skills:\n  prompt_mode: names_only\n"
+        )
+        for cat, name, desc in (
+            ("software-development", "context-token-management", "Long context audit workflow"),
+            ("creative", "stop-slop", "Rewrite AI-ish prose"),
+        ):
+            d = tmp_path / "skills" / cat / name
+            d.mkdir(parents=True)
+            (d / "SKILL.md").write_text(
+                f"---\nname: {name}\ndescription: {desc}\n---\n"
+            )
+
+        result = build_skills_system_prompt()
+
+        assert "names-only" in result
+        assert "context-token-management" in result
+        assert "stop-slop" in result
+        assert "Long context audit workflow" not in result
+        assert "Rewrite AI-ish prose" not in result
+        assert "skill_view" in result
+
+    def test_hybrid_prompt_mode_renders_router_and_pinned_skills(
+        self, monkeypatch, tmp_path
+    ):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        (tmp_path / "config.yaml").write_text(
+            "skills:\n"
+            "  prompt_mode: hybrid\n"
+            "  prompt_router:\n"
+            "    pinned: [context-token-management]\n"
+        )
+        for cat, name, desc in (
+            ("software-development", "context-token-management", "Class-level context-token audit workflow"),
+            ("creative", "stop-slop", "Rewrite AI-ish prose"),
+            ("work", "eb-work-intake-router", "Route Elliott Bay work"),
+        ):
+            d = tmp_path / "skills" / cat / name
+            d.mkdir(parents=True)
+            (d / "SKILL.md").write_text(
+                f"---\nname: {name}\ndescription: {desc}\n---\n"
+            )
+
+        result = build_skills_system_prompt()
+
+        assert "hybrid skill router" in result
+        assert "software-development: 1 skill" in result
+        assert "creative: 1 skill" in result
+        assert "work: 1 skill" in result
+        assert "context-token-management: Class-level context-token audit workflow" in result
+        assert "Rewrite AI-ish prose" not in result
+        assert "Route Elliott Bay work" not in result
+        assert "skills_list(category=" in result
+        assert "skill_view" in result
+
+    def test_prompt_mode_change_misses_cache(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        d = tmp_path / "skills" / "tools" / "cached-skill"
+        d.mkdir(parents=True)
+        (d / "SKILL.md").write_text(
+            "---\nname: cached-skill\ndescription: Cached description\n---\n"
+        )
+
+        full = build_skills_system_prompt()
+        assert "Cached description" in full
+
+        (tmp_path / "config.yaml").write_text(
+            "skills:\n  prompt_mode: names_only\n"
+        )
+        names_only = build_skills_system_prompt()
+        assert "cached-skill" in names_only
+        assert "Cached description" not in names_only
+
     def test_excludes_incompatible_platform_skills(self, monkeypatch, tmp_path):
         """Skills with platforms: [macos] should not appear on Linux."""
         monkeypatch.setenv("HERMES_HOME", str(tmp_path))

--- a/tests/agent/test_shell_hooks.py
+++ b/tests/agent/test_shell_hooks.py
@@ -84,6 +84,23 @@ class TestParseResponse:
         )
         assert r == {"context": "today is Friday"}
 
+    def test_pre_llm_call_reasoning_config_passthrough(self):
+        r = shell_hooks._parse_response(
+            "pre_llm_call",
+            '{"context": "route", "reasoning_config": {"enabled": true, "effort": "high"}}',
+        )
+        assert r == {
+            "context": "route",
+            "reasoning_config": {"enabled": True, "effort": "high"},
+        }
+
+    def test_non_pre_llm_call_reasoning_config_ignored(self):
+        r = shell_hooks._parse_response(
+            "post_llm_call",
+            '{"context": "route", "reasoning_config": {"enabled": true, "effort": "high"}}',
+        )
+        assert r == {"context": "route"}
+
     def test_subagent_stop_context_passthrough(self):
         r = shell_hooks._parse_response(
             "subagent_stop", '{"context": "child role=leaf"}',

--- a/tests/hermes_cli/test_cli_explicit_model_routing.py
+++ b/tests/hermes_cli/test_cli_explicit_model_routing.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+from hermes_cli.cli_agent_setup_mixin import CLIAgentSetupMixin
+
+
+class DummyCLI(CLIAgentSetupMixin):
+    def __init__(self, *, explicit_model: bool = False, explicit_provider: bool = False):
+        self.api_key = "test-key"
+        self.base_url = "https://chatgpt.com/backend-api/codex"
+        self.provider = "openai-codex"
+        self.api_mode = "codex_responses"
+        self.acp_command = None
+        self.acp_args = []
+        self._credential_pool = None
+        self.model = "gpt-5.3-codex-spark"
+        self.service_tier = None
+        self._explicit_model_override = explicit_model
+        self._explicit_provider_override = explicit_provider
+
+
+def test_explicit_model_override_bypasses_declarative_model_routing(monkeypatch):
+    called = False
+
+    def fail_if_called(*args, **kwargs):
+        nonlocal called
+        called = True
+        raise AssertionError("explicit model override should not be re-routed")
+
+    monkeypatch.setattr("hermes_cli.model_routing.resolve_turn_model_route", fail_if_called)
+
+    route = DummyCLI(explicit_model=True)._resolve_turn_agent_config("What is Codex Spark?")
+
+    assert called is False
+    assert route["model"] == "gpt-5.3-codex-spark"
+    assert route["runtime"]["provider"] == "openai-codex"
+    assert route["routing"] is None
+
+
+def test_explicit_provider_override_bypasses_declarative_model_routing(monkeypatch):
+    called = False
+
+    def fail_if_called(*args, **kwargs):
+        nonlocal called
+        called = True
+        raise AssertionError("explicit provider override should not be re-routed")
+
+    monkeypatch.setattr("hermes_cli.model_routing.resolve_turn_model_route", fail_if_called)
+
+    route = DummyCLI(explicit_provider=True)._resolve_turn_agent_config("What is Codex Spark?")
+
+    assert called is False
+    assert route["model"] == "gpt-5.3-codex-spark"
+    assert route["runtime"]["provider"] == "openai-codex"
+    assert route["routing"] is None
+
+
+def test_non_explicit_turn_still_uses_declarative_model_routing(monkeypatch):
+    def fake_route(user_message, current_model, current_runtime):
+        assert user_message == "normal work"
+        assert current_model == "gpt-5.3-codex-spark"
+        return (
+            "deepseek-v4-flash",
+            {**current_runtime, "provider": "opencode-go", "base_url": "https://opencode.ai/zen/go/v1", "api_mode": "chat_completions"},
+            {"tier": "fast", "provider": "opencode-go", "model": "deepseek-v4-flash"},
+        )
+
+    monkeypatch.setattr("hermes_cli.model_routing.resolve_turn_model_route", fake_route)
+
+    route = DummyCLI()._resolve_turn_agent_config("normal work")
+
+    assert route["model"] == "deepseek-v4-flash"
+    assert route["runtime"]["provider"] == "opencode-go"
+    assert route["routing"] == {"tier": "fast", "provider": "opencode-go", "model": "deepseek-v4-flash"}

--- a/tests/hermes_cli/test_model_routing_selection.py
+++ b/tests/hermes_cli/test_model_routing_selection.py
@@ -1,0 +1,126 @@
+from __future__ import annotations
+
+from hermes_cli.model_routing import select_model_route
+
+
+def _config():
+    return {
+        "routing": {
+            "enabled": True,
+            "model_selection": {
+                "enabled": True,
+                "default_tier": "balanced",
+                "low_complexity_tier": "fast",
+                "custodial_tier": "custodial_direct",
+                "tier_map": {
+                    "none": "balanced",
+                    "think": "balanced",
+                    "megathink": "deep",
+                    "ultrathink": "deep",
+                },
+            },
+            "tiers": {
+                "fast": {"provider": "opencode-go", "model": "deepseek-v4-flash"},
+                "balanced": {"provider": "opencode-go", "model": "deepseek-v4-pro"},
+                "deep": {"provider": "openai-codex", "model": "gpt-5.5"},
+                "custodial_direct": {
+                    "provider": "openai-codex",
+                    "model": "gpt-5.5",
+                    "allow_fallback": False,
+                },
+            },
+            "reasoning": {
+                "default_tier": "none",
+                "rules": [
+                    {
+                        "tier": "ultrathink",
+                        "reason": "architecture",
+                        "patterns": ["architect|system design|security audit"],
+                    },
+                    {
+                        "tier": "megathink",
+                        "reason": "debug-refactor",
+                        "patterns": ["debug|root cause|refactor"],
+                    },
+                    {
+                        "tier": "think",
+                        "reason": "standard-coding",
+                        "patterns": ["write|create|update|compare"],
+                    },
+                ],
+            },
+            "delegation": {
+                "default_complexity": 4,
+                "critical_threshold": -5,
+                "complexity_rules": [
+                    {
+                        "name": "low-lookup-extraction",
+                        "complexity": 2,
+                        "patterns": ["^(what|where|who|when).{0,30}\\b|lookup|get me the|^list\\s|extract|format (this|the)|simple|quick\\s"],
+                    },
+                    {
+                        "name": "high-architecture-debugging",
+                        "complexity": 8,
+                        "patterns": ["architect|design (a |the )?system|debug|refactor.*(system|architecture)|integrate|orchestrat|security (audit|review)"],
+                    },
+                ],
+                "score_rules": [
+                    {"name": "research-investigation", "score": 2, "patterns": ["research|compare|investigate"]},
+                    {"name": "financial-sensitive", "score": -3, "patterns": ["payment|financial|invoice"]},
+                    {"name": "secrets-security", "score": -3, "patterns": ["password|api.key|secret|credential"]},
+                    {"name": "destructive-production", "score": -5, "patterns": ["deploy|delete|production|rm -rf"]},
+                    {"name": "citadel-trading", "score": -10, "patterns": ["citadel|trading|exchange order"]},
+                    {"name": "email-approval-flow", "score": -2, "patterns": ["send (an )?email|draft.*email"]},
+                ],
+            },
+        }
+    }
+
+
+def test_standard_routing_uses_balanced_opencode_pro_for_normal_work():
+    route = select_model_route(
+        "Compare these two approaches and recommend the better Hermes routing policy.",
+        _config(),
+    )
+
+    assert route is not None
+    assert route["tier"] == "balanced"
+    assert route["provider"] == "opencode-go"
+    assert route["model"] == "deepseek-v4-pro"
+    assert route["reasoning_tier"] == "think"
+
+
+def test_low_complexity_lookup_uses_fast_opencode_flash():
+    route = select_model_route("quick lookup: what timezone is Seattle in?", _config())
+
+    assert route is not None
+    assert route["tier"] == "fast"
+    assert route["provider"] == "opencode-go"
+    assert route["model"] == "deepseek-v4-flash"
+
+
+def test_architecture_and_security_route_to_deep_chatgpt():
+    route = select_model_route("Architect a secure multi-agent routing system.", _config())
+
+    assert route is not None
+    assert route["tier"] == "deep"
+    assert route["provider"] == "openai-codex"
+    assert route["model"] == "gpt-5.5"
+    assert route["reasoning_tier"] == "ultrathink"
+
+
+def test_custodial_routing_overrides_cheap_lanes_for_sensitive_work():
+    route = select_model_route("Rotate the API key and deploy the production change.", _config())
+
+    assert route is not None
+    assert route["tier"] == "custodial_direct"
+    assert route["provider"] == "openai-codex"
+    assert route["model"] == "gpt-5.5"
+    assert route["allow_fallback"] is False
+
+
+def test_model_selection_disabled_returns_none():
+    config = _config()
+    config["routing"]["model_selection"]["enabled"] = False
+
+    assert select_model_route("Compare these two approaches", config) is None

--- a/tests/run_agent/test_file_mutation_verifier.py
+++ b/tests/run_agent/test_file_mutation_verifier.py
@@ -166,6 +166,56 @@ class TestRecordFileMutationResult:
         )
         assert agent._turn_failed_file_mutations == {}
 
+    def test_later_filesystem_change_prunes_prior_failure(self, tmp_path):
+        agent = _bare_agent()
+        target = tmp_path / "config.yaml"
+        target.write_text("before\n")
+
+        agent._record_file_mutation_result(
+            "patch",
+            {"mode": "replace", "path": str(target), "old_string": "missing", "new_string": "after"},
+            json.dumps({"error": "Could not find old_string"}),
+            is_error=True,
+        )
+        assert str(target) in agent._turn_failed_file_mutations
+
+        target.write_text("after\n")
+        agent._prune_superseded_file_mutation_failures()
+
+        assert agent._turn_failed_file_mutations == {}
+
+    def test_unchanged_file_keeps_prior_failure(self, tmp_path):
+        agent = _bare_agent()
+        target = tmp_path / "config.yaml"
+        target.write_text("before\n")
+
+        agent._record_file_mutation_result(
+            "patch",
+            {"mode": "replace", "path": str(target), "old_string": "missing", "new_string": "after"},
+            json.dumps({"error": "Could not find old_string"}),
+            is_error=True,
+        )
+        agent._prune_superseded_file_mutation_failures()
+
+        assert str(target) in agent._turn_failed_file_mutations
+
+    def test_missing_file_created_later_prunes_prior_failure(self, tmp_path):
+        agent = _bare_agent()
+        target = tmp_path / "new.yaml"
+
+        agent._record_file_mutation_result(
+            "patch",
+            {"mode": "replace", "path": str(target), "old_string": "missing", "new_string": "after"},
+            json.dumps({"error": "Could not find old_string"}),
+            is_error=True,
+        )
+        assert str(target) in agent._turn_failed_file_mutations
+
+        target.write_text("created\n")
+        agent._prune_superseded_file_mutation_failures()
+
+        assert agent._turn_failed_file_mutations == {}
+
     def test_write_file_with_lint_error_counts_as_landed(self):
         agent = _bare_agent()
         agent._record_file_mutation_result(

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -1176,6 +1176,62 @@ class TestBuildSystemPrompt:
         assert mock_skills.call_args.kwargs["available_toolsets"] == {"web", "skills"}
 
 
+class TestEffectiveSystemPromptDeduplication:
+    def _profile_prompt_files(self, tmp_path, persona="PERSONA", soul="SOUL"):
+        (tmp_path / "persona.md").write_text(persona, encoding="utf-8")
+        (tmp_path / "SOUL.md").write_text(soul, encoding="utf-8")
+
+    def test_skips_synced_persona_when_soul_is_already_loaded(self, tmp_path, monkeypatch):
+        from agent import system_prompt as system_prompt_mod
+
+        persona = "# Hermes Runtime Persona — J.A.R.V.I.S.\n\nCompact runtime persona."
+        soul = "# Hermes Agent Soul — J.A.R.V.I.S.\n\nCanonical identity."
+        self._profile_prompt_files(tmp_path, persona=persona, soul=soul)
+        monkeypatch.setattr(system_prompt_mod, "get_hermes_home", lambda: tmp_path)
+
+        base = f"Base prompt.\n\n{soul}\n\nOther stable guidance."
+
+        assert system_prompt_mod.should_append_ephemeral_system_prompt(base, persona) is False
+        assert system_prompt_mod.build_effective_system_prompt(base, persona) == base
+
+    def test_preserves_custom_ephemeral_prompt(self, tmp_path, monkeypatch):
+        from agent import system_prompt as system_prompt_mod
+
+        persona = "# Hermes Runtime Persona — J.A.R.V.I.S.\n\nCompact runtime persona."
+        soul = "# Hermes Agent Soul — J.A.R.V.I.S.\n\nCanonical identity."
+        custom = "Use the temporary incident-response style for this turn."
+        self._profile_prompt_files(tmp_path, persona=persona, soul=soul)
+        monkeypatch.setattr(system_prompt_mod, "get_hermes_home", lambda: tmp_path)
+
+        base = f"Base prompt.\n\n{soul}"
+
+        assert system_prompt_mod.should_append_ephemeral_system_prompt(base, custom) is True
+        assert system_prompt_mod.build_effective_system_prompt(base, custom) == f"{base}\n\n{custom}"
+
+    def test_preserves_persona_when_soul_is_not_loaded(self, tmp_path, monkeypatch):
+        from agent import system_prompt as system_prompt_mod
+
+        persona = "# Hermes Runtime Persona — J.A.R.V.I.S.\n\nCompact runtime persona."
+        self._profile_prompt_files(tmp_path, persona=persona, soul="")
+        monkeypatch.setattr(system_prompt_mod, "get_hermes_home", lambda: tmp_path)
+
+        base = "Base prompt with generic identity."
+
+        assert system_prompt_mod.should_append_ephemeral_system_prompt(base, persona) is True
+        assert system_prompt_mod.build_effective_system_prompt(base, persona) == f"{base}\n\n{persona}"
+
+    def test_skips_exact_ephemeral_duplicate_already_in_base(self, tmp_path, monkeypatch):
+        from agent import system_prompt as system_prompt_mod
+
+        self._profile_prompt_files(tmp_path, persona="PERSONA", soul="SOUL")
+        monkeypatch.setattr(system_prompt_mod, "get_hermes_home", lambda: tmp_path)
+
+        base = "Base prompt.\n\nAlready included."
+
+        assert system_prompt_mod.should_append_ephemeral_system_prompt(base, "Already included.") is False
+        assert system_prompt_mod.build_effective_system_prompt(base, "Already included.") == base
+
+
 class TestToolUseEnforcementConfig:
     """Tests for the agent.tool_use_enforcement config option."""
 

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -719,17 +719,16 @@ def test_load_enabled_toolsets_rejects_disabled_mcp_env(monkeypatch, capsys):
         lambda: {"mcp_servers": {"mcp-off": {"enabled": False}}},
     )
     monkeypatch.setattr(
-        config_mod, "load_config", lambda: {"platform_toolsets": {"cli": ["memory"]}}
+        config_mod,
+        "load_config",
+        lambda: {"platform_toolsets": {"tui": ["memory"], "cli": ["web"]}},
     )
 
-    # Sorted: ["kanban", "memory"]. `kanban` is auto-recovered by
-    # _get_platform_tools because it's a non-configurable platform toolset
-    # whose tools live in hermes-cli's universe (see toolsets.py).
-    assert server._load_enabled_toolsets() == ["kanban", "memory"]
+    assert server._load_enabled_toolsets() == ["memory"]
     err = capsys.readouterr().err
     assert "ignoring disabled MCP servers" in err
     assert "mcp-off" in err
-    assert "using configured CLI toolsets" in err
+    assert "using configured TUI toolsets" in err
 
 
 def test_load_enabled_toolsets_falls_back_when_tui_env_invalid(monkeypatch, capsys):
@@ -743,11 +742,45 @@ def test_load_enabled_toolsets_falls_back_when_tui_env_invalid(monkeypatch, caps
     import hermes_cli.config as config_mod
 
     monkeypatch.setattr(
-        config_mod, "load_config", lambda: {"platform_toolsets": {"cli": ["memory"]}}
+        config_mod,
+        "load_config",
+        lambda: {"platform_toolsets": {"tui": ["memory"], "cli": ["web"]}},
     )
 
-    assert server._load_enabled_toolsets() == ["kanban", "memory"]
-    assert "using configured CLI toolsets" in capsys.readouterr().err
+    assert server._load_enabled_toolsets() == ["memory"]
+    assert "using configured TUI toolsets" in capsys.readouterr().err
+
+
+
+def test_load_enabled_toolsets_prefers_tui_platform_config(monkeypatch):
+    monkeypatch.delenv("HERMES_TUI_TOOLSETS", raising=False)
+
+    import hermes_cli.config as config_mod
+
+    monkeypatch.setattr(
+        config_mod,
+        "load_config",
+        lambda: {"platform_toolsets": {"tui": ["memory"], "cli": ["web"]}},
+    )
+
+    assert server._load_enabled_toolsets() == ["memory"]
+
+
+def test_load_enabled_toolsets_falls_back_to_cli_platform_config(monkeypatch):
+    monkeypatch.delenv("HERMES_TUI_TOOLSETS", raising=False)
+
+    import hermes_cli.config as config_mod
+
+    monkeypatch.setattr(
+        config_mod,
+        "load_config",
+        lambda: {"platform_toolsets": {"cli": ["web"]}},
+    )
+
+    enabled = server._load_enabled_toolsets()
+
+    assert "web" in enabled
+    assert "hermes-tui" not in enabled
 
 
 def test_load_enabled_toolsets_warns_when_config_fallback_fails(monkeypatch, capsys):
@@ -1301,6 +1334,31 @@ def test_resolve_model_strips_config_model(monkeypatch):
     assert server._resolve_model() == "nous/hermes-test"
 
 
+
+def test_config_model_target_prefers_global_model_over_routing_tier(monkeypatch):
+    monkeypatch.delenv("HERMES_MODEL", raising=False)
+    monkeypatch.delenv("HERMES_INFERENCE_MODEL", raising=False)
+    monkeypatch.setattr(
+        server,
+        "_load_cfg",
+        lambda: {
+            "model": {"default": "gpt-5.4", "provider": "openai-codex"},
+            "routing": {
+                "enabled": True,
+                "model_selection": {"enabled": True, "default_tier": "balanced"},
+                "tiers": {
+                    "balanced": {
+                        "provider": "opencode-go",
+                        "model": "deepseek-v4-pro",
+                    }
+                },
+            },
+        },
+    )
+
+    assert server._config_model_target() == ("gpt-5.4", "openai-codex")
+
+
 def _sync_test_session(**extra):
     session = {
         "agent": types.SimpleNamespace(model="old/model"),
@@ -1496,6 +1554,33 @@ def test_startup_runtime_detects_provider_for_model_env(monkeypatch):
     )
 
 
+
+def test_startup_runtime_uses_global_model_when_unpinned(monkeypatch):
+    monkeypatch.delenv("HERMES_MODEL", raising=False)
+    monkeypatch.delenv("HERMES_INFERENCE_MODEL", raising=False)
+    monkeypatch.delenv("HERMES_TUI_PROVIDER", raising=False)
+    monkeypatch.delenv("HERMES_INFERENCE_PROVIDER", raising=False)
+    monkeypatch.setattr(
+        server,
+        "_load_cfg",
+        lambda: {
+            "model": {"default": "gpt-5.4", "provider": "openai-codex"},
+            "routing": {
+                "enabled": True,
+                "model_selection": {"enabled": True, "default_tier": "balanced"},
+                "tiers": {
+                    "balanced": {
+                        "provider": "opencode-go",
+                        "model": "deepseek-v4-pro",
+                    }
+                },
+            },
+        },
+    )
+
+    assert server._resolve_startup_runtime() == ("gpt-5.4", "openai-codex")
+
+
 def test_load_fallback_model_merges_chain_providers_first(monkeypatch):
     # Parity with HermesCLI / gateway: fallback_providers stays first and keeps
     # its order, with any distinct legacy fallback_model entry merged in after
@@ -1560,6 +1645,90 @@ def test_make_agent_passes_configured_fallback_chain(monkeypatch):
     assert agent.model == "gpt-5.5"
     assert captured["fallback_model"] == fallback_chain
     assert captured["platform"] == "tui"
+
+
+
+def test_make_agent_skips_duplicate_runtime_persona_prompt(monkeypatch, tmp_path):
+    captured = {}
+
+    def fake_agent(**kwargs):
+        captured.update(kwargs)
+        return types.SimpleNamespace(model=kwargs.get("model"))
+
+    monkeypatch.delenv("HERMES_MODEL", raising=False)
+    monkeypatch.delenv("HERMES_INFERENCE_MODEL", raising=False)
+    monkeypatch.delenv("HERMES_TUI_PROVIDER", raising=False)
+    monkeypatch.setattr(server, "get_hermes_home", lambda: tmp_path)
+    (tmp_path / "persona.md").write_text("You are Jarvis.", encoding="utf-8")
+    monkeypatch.setattr(
+        server,
+        "_load_cfg",
+        lambda: {
+            "model": {"default": "gpt-5.5", "provider": "openai-codex"},
+            "agent": {
+                "system_prompt": "You are Jarvis.",
+                "personalities": {"jarvis": "You are Jarvis."},
+            },
+            "display": {"personality": "jarvis"},
+        },
+    )
+    monkeypatch.setattr(
+        "hermes_cli.runtime_provider.resolve_runtime_provider",
+        lambda requested=None, target_model=None: {
+            "provider": "openai-codex",
+            "base_url": "https://chatgpt.com/backend-api/codex",
+            "api_key": "token",
+            "api_mode": "codex_responses",
+            "credential_pool": None,
+        },
+    )
+    monkeypatch.setattr("run_agent.AIAgent", fake_agent)
+    monkeypatch.setattr(server, "_load_enabled_toolsets", lambda: ["file"])
+    monkeypatch.setattr(server, "_get_db", lambda: None)
+
+    server._make_agent("sid", "session-key")
+
+    assert captured["ephemeral_system_prompt"] is None
+
+
+def test_background_agent_kwargs_rehydrates_no_tool_parent_toolsets(monkeypatch):
+    parent = types.SimpleNamespace(
+        base_url="https://example.test/v1",
+        api_key="token",
+        provider="opencode-go",
+        api_mode="chat_completions",
+        model="deepseek-v4-pro",
+        enabled_toolsets=["hermes-tui"],
+        tools=[],
+        fallback_model=[],
+    )
+    monkeypatch.setattr(server, "_load_cfg", lambda: {"agent": {"max_turns": 25}})
+    monkeypatch.setattr(server, "_load_enabled_toolsets", lambda: ["file", "terminal", "web"])
+    monkeypatch.setattr(server, "_get_db", lambda: None)
+
+    kwargs = server._background_agent_kwargs(parent, "task-1")
+
+    assert kwargs["enabled_toolsets"] == ["file", "terminal", "web"]
+
+
+def test_background_agent_kwargs_preserves_toolful_parent_toolsets(monkeypatch):
+    parent = types.SimpleNamespace(
+        base_url="https://example.test/v1",
+        api_key="token",
+        provider="opencode-go",
+        api_mode="chat_completions",
+        model="deepseek-v4-pro",
+        enabled_toolsets=["memory"],
+        tools=[{"type": "function", "function": {"name": "memory"}}],
+        fallback_model=[],
+    )
+    monkeypatch.setattr(server, "_load_cfg", lambda: {"agent": {"max_turns": 25}})
+    monkeypatch.setattr(server, "_load_enabled_toolsets", lambda: ["file", "terminal", "web"])
+    monkeypatch.setattr(server, "_get_db", lambda: None)
+
+    kwargs = server._background_agent_kwargs(parent, "task-1")
+
+    assert kwargs["enabled_toolsets"] == ["memory"]
 
 
 def test_background_agent_kwargs_preserves_full_fallback_chain(monkeypatch):
@@ -6219,6 +6388,7 @@ def test_browser_manage_connect_default_local_reports_launch_hint(monkeypatch):
     )
     assert any(
         "No supported Chromium-family browser executable was found" in line
+        or "start a chromium-family browser with remote debugging" in line.lower()
         for line in resp["result"]["messages"]
     )
     assert any(

--- a/tests/tools/test_file_tools.py
+++ b/tests/tools/test_file_tools.py
@@ -6,6 +6,7 @@ handling without requiring a running terminal environment.
 
 import json
 import logging
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 from tools.file_tools import (
@@ -77,7 +78,7 @@ class TestWriteFileHandler:
         from tools.file_tools import write_file_tool
         result = json.loads(write_file_tool("/tmp/out.txt", "hello world!\n"))
         assert result["status"] == "ok"
-        mock_ops.write_file.assert_called_once_with("/tmp/out.txt", "hello world!\n")
+        mock_ops.write_file.assert_called_once_with(str(Path("/tmp/out.txt").resolve()), "hello world!\n")
 
     @patch("tools.file_tools._get_file_ops")
     def test_permission_error_returns_error_json_without_error_log(self, mock_get, caplog):
@@ -155,7 +156,7 @@ class TestPatchHandler:
             old_string="foo", new_string="bar"
         ))
         assert result["status"] == "ok"
-        mock_ops.patch_replace.assert_called_once_with("/tmp/f.py", "foo", "bar", False)
+        mock_ops.patch_replace.assert_called_once_with(str(Path("/tmp/f.py").resolve()), "foo", "bar", False)
 
     @patch("tools.file_tools._get_file_ops")
     def test_replace_mode_replace_all_flag(self, mock_get):
@@ -168,7 +169,7 @@ class TestPatchHandler:
         from tools.file_tools import patch_tool
         patch_tool(mode="replace", path="/tmp/f.py",
                    old_string="x", new_string="y", replace_all=True)
-        mock_ops.patch_replace.assert_called_once_with("/tmp/f.py", "x", "y", True)
+        mock_ops.patch_replace.assert_called_once_with(str(Path("/tmp/f.py").resolve()), "x", "y", True)
 
     @patch("tools.file_tools._get_file_ops")
     def test_replace_mode_missing_path_errors(self, mock_get):
@@ -403,29 +404,21 @@ class TestSearchHints:
 
 
 class TestSensitivePathCheck:
-    """Verify that _check_sensitive_path blocks writes to protected locations."""
+    """Verify that _check_sensitive_path blocks protected system locations."""
 
-    def test_hermes_config_blocked_for_write_file(self, tmp_path, monkeypatch):
+    def test_hermes_config_allowed_for_write_file_after_user_override(self, tmp_path, monkeypatch):
+        monkeypatch.setattr("tools.file_tools._SENSITIVE_PATH_PREFIXES", ("/etc/", "/boot/", "/usr/lib/systemd/", "/private/etc/"))
         fake_config = tmp_path / "config.yaml"
         monkeypatch.setattr("tools.file_tools._hermes_config_resolved", str(fake_config))
         monkeypatch.setattr("tools.file_tools._hermes_config_resolved_loaded", True)
 
         from tools.file_tools import write_file_tool
         result = json.loads(write_file_tool(str(fake_config), "approvals:\n  mode: off\n"))
-        assert "error" in result
-        assert "Hermes config" in result["error"]
+        assert "error" not in result
+        assert fake_config.read_text() == "approvals:\n  mode: off\n"
 
-    def test_hermes_config_blocked_via_tilde_path(self, tmp_path, monkeypatch):
-        fake_config = tmp_path / "config.yaml"
-        monkeypatch.setattr("tools.file_tools._hermes_config_resolved", str(fake_config))
-        monkeypatch.setattr("tools.file_tools._hermes_config_resolved_loaded", True)
-
-        from tools.file_tools import write_file_tool
-        result = json.loads(write_file_tool(str(fake_config), "approvals:\n  mode: off\n"))
-        assert "error" in result
-        assert "Hermes config" in result["error"]
-
-    def test_hermes_config_blocked_for_patch(self, tmp_path, monkeypatch):
+    def test_hermes_config_allowed_for_patch_after_user_override(self, tmp_path, monkeypatch):
+        monkeypatch.setattr("tools.file_tools._SENSITIVE_PATH_PREFIXES", ("/etc/", "/boot/", "/usr/lib/systemd/", "/private/etc/"))
         fake_config = tmp_path / "config.yaml"
         fake_config.write_text("approvals:\n  mode: manual\n")
         monkeypatch.setattr("tools.file_tools._hermes_config_resolved", str(fake_config))
@@ -438,8 +431,8 @@ class TestSensitivePathCheck:
             old_string="mode: manual",
             new_string="mode: off",
         ))
-        assert "error" in result
-        assert "Hermes config" in result["error"]
+        assert "error" not in result
+        assert fake_config.read_text() == "approvals:\n  mode: off\n"
 
     def test_system_path_still_blocked(self, monkeypatch):
         monkeypatch.setattr("tools.file_tools._hermes_config_resolved", "/some/other/path")

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -366,17 +366,6 @@ def _check_sensitive_path(filepath: str, task_id: str = "default") -> str | None
             return _err
     if resolved in _SENSITIVE_EXACT_PATHS or normalized in _SENSITIVE_EXACT_PATHS:
         return _err
-    # Prevent agents from modifying the Hermes config file directly.
-    # approvals.mode and other security settings live here; a malicious or
-    # prompt-injected agent could silently disable exec approval by writing to
-    # this file.
-    hermes_config = _get_hermes_config_resolved()
-    if hermes_config and (resolved == hermes_config or normalized == hermes_config):
-        return (
-            f"Refusing to write to Hermes config file: {filepath}\n"
-            "Agent cannot modify security-sensitive configuration. "
-            "Edit ~/.hermes/config.yaml directly or use 'hermes config' instead."
-        )
     return None
 
 

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -1494,16 +1494,14 @@ def _resolve_model() -> str:
 
 
 def _config_model_target() -> tuple[str, str]:
-    """(model, provider) currently selected by config (env as fallback).
+    """(model, provider) target for unpinned TUI sessions.
 
-    config.yaml wins over HERMES_MODEL / HERMES_INFERENCE_MODEL here, the
-    reverse of `_resolve_model()`'s startup order. Those env vars are a
-    provision-time seed (hosted instances set HERMES_INFERENCE_MODEL in the
-    container env); if they outranked config.yaml, the per-turn sync would
-    stay pinned to the seed forever and dashboard/CLI model changes would
-    never reach an open chat — the exact bug this sync exists to fix.
+    The global ``model`` block is the model selector's source of truth.
+    Declarative routing may still choose a per-turn worker lane later, but it
+    must not make fresh TUI sessions appear pinned to the routing default tier.
     """
-    cfg_model = _load_cfg().get("model")
+    cfg = _load_cfg()
+    cfg_model = cfg.get("model")
     model = ""
     provider = ""
     if isinstance(cfg_model, dict):
@@ -1529,6 +1527,9 @@ def _resolve_startup_runtime() -> tuple[str, str | None]:
         or os.environ.get("HERMES_INFERENCE_MODEL", "")
     ).strip()
     if not explicit_model:
+        target_model, target_provider = _config_model_target()
+        if target_model:
+            return target_model, target_provider or None
         return model, None
 
     try:
@@ -2049,7 +2050,7 @@ def _load_enabled_toolsets() -> list[str] | None:
             return valid
 
         fallback_notice = (
-            "[tui] no valid HERMES_TUI_TOOLSETS entries; using configured CLI toolsets"
+            "[tui] no valid HERMES_TUI_TOOLSETS entries; using configured TUI toolsets"
         )
 
     try:
@@ -2064,8 +2065,15 @@ def _load_enabled_toolsets() -> list[str] | None:
         # list without baking in implicit MCP defaults. Using the wrong
         # variant at agent creation time makes MCP tools silently missing
         # from the TUI. See PR #3252 for the original design split.
+        platform_toolsets = cfg.get("platform_toolsets") or {}
+        platform = (
+            "tui"
+            if isinstance(platform_toolsets, dict)
+            and isinstance(platform_toolsets.get("tui"), list)
+            else "cli"
+        )
         enabled = sorted(
-            _get_platform_tools(cfg, "cli", include_default_mcp_servers=True)
+            _get_platform_tools(cfg, platform, include_default_mcp_servers=True)
         )
         if fallback_notice is not None:
             print(fallback_notice, file=sys.stderr, flush=True)
@@ -3186,6 +3194,44 @@ def _prompt_text(value) -> str:
     return str(value).strip()
 
 
+
+def _tui_startup_ephemeral_prompt(cfg: dict | None = None) -> str:
+    """Return the TUI-only ephemeral prompt after stripping duplicated persona text.
+
+    SOUL.md already provides the stable identity layer. On Cole's setup the TUI
+    was also appending the synced runtime persona from ``agent.system_prompt`` /
+    ``persona.md`` on every request, duplicating a full Jarvis block. Keep
+    explicit custom prompts, but suppress the known persona mirror.
+    """
+    cfg = cfg if isinstance(cfg, dict) else {}
+    agent_cfg = cfg.get("agent") or {}
+    base_prompt = _prompt_text(agent_cfg.get("system_prompt", ""))
+    if not base_prompt:
+        return ""
+
+    try:
+        persona_path = get_hermes_home() / "persona.md"
+        if persona_path.exists():
+            persona_prompt = _prompt_text(persona_path.read_text(encoding="utf-8"))
+            if persona_prompt and persona_prompt == base_prompt:
+                return ""
+    except Exception:
+        pass
+
+    display_cfg = cfg.get("display") or {}
+    personality_name = str(display_cfg.get("personality") or "").strip()
+    if personality_name:
+        try:
+            _name, personality_prompt = _validate_personality(personality_name, cfg)
+            if _prompt_text(personality_prompt) == base_prompt:
+                return ""
+        except Exception:
+            pass
+
+    return base_prompt
+
+
+
 def _apply_personality_to_session(
     sid: str, session: dict, new_prompt: str, personality: str = ""
 ) -> tuple[bool, dict | None]:
@@ -3278,6 +3324,21 @@ def _agent_fallback_model(agent):
     return _load_fallback_model()
 
 
+def _agent_enabled_toolsets(agent):
+    """Return usable toolsets for follow-on TUI agents.
+
+    Cached agents created during a bad TUI toolset resolution can carry a
+    non-empty ``enabled_toolsets`` list that resolves to zero model tools
+    (for example MCP server names plus ``hermes-tui`` only). Do not propagate
+    that no-tools snapshot into background/fallback work; rehydrate from the
+    current TUI resolver unless the parent agent actually has callable tools.
+    """
+    enabled = getattr(agent, "enabled_toolsets", None)
+    if enabled and getattr(agent, "tools", None):
+        return enabled
+    return _load_enabled_toolsets() or enabled
+
+
 def _background_agent_kwargs(agent, task_id: str) -> dict:
     cfg = _load_cfg()
 
@@ -3290,8 +3351,7 @@ def _background_agent_kwargs(agent, task_id: str) -> dict:
         "acp_args": getattr(agent, "acp_args", None) or None,
         "model": getattr(agent, "model", None) or _resolve_model(),
         "max_iterations": _cfg_max_turns(cfg, 25),
-        "enabled_toolsets": getattr(agent, "enabled_toolsets", None)
-        or _load_enabled_toolsets(),
+        "enabled_toolsets": _agent_enabled_toolsets(agent),
         "quiet_mode": True,
         "verbose_logging": False,
         "ephemeral_system_prompt": getattr(agent, "ephemeral_system_prompt", None)
@@ -3590,8 +3650,7 @@ def _make_agent(
         pass
 
     cfg = _load_cfg()
-    agent_cfg = cfg.get("agent") or {}
-    system_prompt = _prompt_text(agent_cfg.get("system_prompt", ""))
+    system_prompt = _tui_startup_ephemeral_prompt(cfg)
     startup_skills = _parse_tui_skills_env()
     if startup_skills:
         from agent.skill_commands import build_preloaded_skills_prompt


### PR DESCRIPTION
## Summary
- add declarative per-turn model routing plumbing for profile-governance/runtime routing
- preserve explicit CLI provider/model overrides so operator-selected lanes are not silently down-routed
- tighten system prompt/persona deduplication, background agent toolset rehydration, Slack command surface handling, and related tests

## Verification
- `python -m py_compile agent/chat_completion_helpers.py agent/conversation_loop.py agent/prompt_builder.py agent/shell_hooks.py agent/system_prompt.py agent/turn_finalizer.py cli.py gateway/run.py hermes_cli/cli_agent_setup_mixin.py hermes_cli/commands.py hermes_cli/model_routing.py run_agent.py tools/file_tools.py tui_gateway/server.py`
- `python -m pytest -q tests/hermes_cli/test_cli_explicit_model_routing.py tests/hermes_cli/test_model_routing_selection.py tests/test_tui_gateway_server.py tests/agent/test_prompt_builder.py tests/agent/test_shell_hooks.py tests/run_agent/test_file_mutation_verifier.py tests/run_agent/test_run_agent.py tests/tools/test_file_tools.py`
- Result: `963 passed, 1 skipped, 1 warning`
