### PR TITLE
fix(desktop): resume latest compression continuation

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -46,8 +46,7 @@ _BRANCH_CHILD_SQL = (
 _COMPRESSION_CHILD_SQL = (
     "EXISTS (SELECT 1 FROM sessions p"
     "        WHERE p.id = {a}.parent_session_id"
-    "        AND p.end_reason = 'compression'"
-    "        AND {a}.started_at >= p.ended_at)"
+    "        AND p.end_reason = 'compression')"
 )
 
 # Rows that surface in pickers: roots + branch children (subagent runs and
@@ -1838,7 +1837,6 @@ class SessionDB:
                     JOIN sessions child ON child.id = a.id
                     JOIN sessions parent ON parent.id = child.parent_session_id
                     WHERE parent.end_reason = 'compression'
-                      AND child.started_at >= parent.ended_at
                   ),
                   descendants(id) AS (
                     SELECT ?
@@ -1848,7 +1846,6 @@ class SessionDB:
                     JOIN sessions parent ON parent.id = d.id
                     JOIN sessions child ON child.parent_session_id = parent.id
                     WHERE parent.end_reason = 'compression'
-                      AND child.started_at >= parent.ended_at
                   ),
                   lineage(id) AS (
                     SELECT id FROM ancestors
@@ -1944,37 +1941,64 @@ class SessionDB:
     def get_compression_tip(self, session_id: str) -> Optional[str]:
         """Walk the compression-continuation chain forward and return the tip.
 
-        A compression continuation is a child session where:
-        1. The parent's ``end_reason = 'compression'``
-        2. The child was created AFTER the parent was ended (started_at >= ended_at)
+        A compression continuation is a child of a session whose
+        ``end_reason = 'compression'``.  Older builds tried to distinguish
+        continuations from branches/subagents by requiring
+        ``child.started_at >= parent.ended_at``.  That ordering is too brittle:
+        gateway + compression races can insert the real continuation row before
+        the parent row's ``ended_at`` is written, while a stale websocket later
+        creates/reuses a sibling that *does* satisfy the timestamp test.  The
+        visible symptom is brutal: desktop resume follows the stale sibling and
+        the user's latest messages look "lost" even though they are persisted in
+        the real continuation chain.
 
-        The second condition distinguishes compression continuations from
-        delegate subagents or branch children, which can also have a
-        ``parent_session_id`` but were created while the parent was still live.
-
-        Returns the session_id of the latest continuation in the chain, or the
-        input ``session_id`` if it isn't part of a compression chain (or if the
-        input itself doesn't exist).
+        Instead, only follow children of compression-ended parents, exclude
+        explicit branch/delegate/tool children, and prefer children that are
+        themselves continuing the compression chain (``end_reason='compression'``)
+        or still live over stale closed siblings such as ``ws_orphan_reap``.
+        Returns the latest continuation tip, or the input id when no
+        continuation exists.
         """
         current = session_id
+        seen = {current} if current else set()
         # Bound the walk defensively — compression chains this deep are
         # pathological and shouldn't happen in practice. 100 = plenty.
         for _ in range(100):
             with self._lock:
                 cursor = self._conn.execute(
-                    "SELECT id FROM sessions "
-                    "WHERE parent_session_id = ? "
-                    "  AND started_at >= ("
-                    "      SELECT ended_at FROM sessions "
-                    "      WHERE id = ? AND end_reason = 'compression'"
-                    "  ) "
-                    "ORDER BY started_at DESC LIMIT 1",
-                    (current, current),
+                    """
+                    SELECT child.id
+                    FROM sessions parent
+                    JOIN sessions child ON child.parent_session_id = parent.id
+                    WHERE parent.id = ?
+                      AND parent.end_reason = 'compression'
+                      AND json_extract(COALESCE(child.model_config, '{}'), '$._branched_from') IS NULL
+                      AND json_extract(COALESCE(child.model_config, '{}'), '$._delegate_from') IS NULL
+                      AND COALESCE(child.source, '') != 'tool'
+                    ORDER BY
+                      CASE
+                        WHEN child.end_reason = 'compression' THEN 0
+                        WHEN child.ended_at IS NULL THEN 1
+                        ELSE 2
+                      END,
+                      COALESCE(
+                        (SELECT MAX(m.timestamp) FROM messages m WHERE m.session_id = child.id),
+                        child.started_at
+                      ) DESC,
+                      child.started_at DESC,
+                      child.id DESC
+                    LIMIT 1
+                    """,
+                    (current,),
                 )
                 row = cursor.fetchone()
             if row is None:
                 return current
-            current = row["id"]
+            child_id = row["id"]
+            if not child_id or child_id in seen:
+                return current
+            seen.add(child_id)
+            current = child_id
         return current
 
     def list_sessions_rich(
@@ -2073,10 +2097,12 @@ class SessionDB:
             # still surfacing old compression roots whose live tip is fresh.
             #
             # The CTE seeds from rows the outer WHERE admits (roots + branch
-            # children), then recursively joins forward through
-            # compression-continuation edges using the same criteria as
-            # get_compression_tip (parent.end_reason='compression' AND
-            # child.started_at >= parent.ended_at).
+            # children), then recursively joins forward through robust
+            # compression-continuation edges. Do NOT require
+            # child.started_at >= parent.ended_at here: real desktop/gateway
+            # races can insert the continuation row before the parent's
+            # ended_at is written, while stale websocket siblings may satisfy
+            # the timestamp test and hijack resume/list projection.
             outer_where = where_sql
             id_params: List[Any] = []
             if id_needle:
@@ -2108,7 +2134,9 @@ class SessionDB:
                     JOIN sessions parent ON parent.id = c.cur_id
                     JOIN sessions child ON child.parent_session_id = c.cur_id
                     WHERE parent.end_reason = 'compression'
-                      AND child.started_at >= parent.ended_at
+                      AND json_extract(COALESCE(child.model_config, '{{}}'), '$._branched_from') IS NULL
+                      AND json_extract(COALESCE(child.model_config, '{{}}'), '$._delegate_from') IS NULL
+                      AND COALESCE(child.source, '') != 'tool'
                 ),
                 chain_max AS (
                     SELECT

--- a/tests/hermes_state/test_resolve_resume_session_id.py
+++ b/tests/hermes_state/test_resolve_resume_session_id.py
@@ -138,3 +138,50 @@ def test_prefers_most_recent_child_when_fork_exists(db):
     ])
     db.append_message("newer_fork", role="user", content="x")
     assert db.resolve_resume_session_id("parent") == "newer_fork"
+
+
+def test_compression_tip_handles_pre_ended_real_child_and_ws_orphan_sibling(db):
+    # Real desktop repro shape from a long GUI session:
+    #
+    #   root --compression--> real continuation --compression--> live tip
+    #     \
+    #      `-- stale websocket sibling ended by ws_orphan_reap
+    #
+    # The real continuation row can be inserted before root.ended_at is written,
+    # so the old child.started_at >= parent.ended_at discriminator rejects it and
+    # follows the stale websocket sibling instead. That makes the GUI look like
+    # the latest conversation was lost. Resuming root must land on live_tip.
+    base = int(time.time()) - 10_000
+    db.create_session("root", source="tui")
+    db.append_message("root", role="user", content="pre-compression")
+    db.end_session("root", "compression")
+
+    db.create_session("real_cont", source="tui", parent_session_id="root")
+    db.append_message("real_cont", role="user", content="real continuation")
+    db.end_session("real_cont", "compression")
+
+    db.create_session("ws_orphan", source="tui", parent_session_id="root")
+    db.append_message("ws_orphan", role="user", content="stale websocket")
+    db.end_session("ws_orphan", "ws_orphan_reap")
+
+    db.create_session("live_tip", source="tui", parent_session_id="real_cont")
+    db.append_message("live_tip", role="user", content="latest real turn")
+
+    conn = db._conn
+    assert conn is not None
+    conn.execute("UPDATE sessions SET started_at = ?, ended_at = ? WHERE id = 'root'", (base, base + 1000))
+    # The real continuation starts before root.ended_at, exactly the race that
+    # broke the old timestamp-based chain walk.
+    conn.execute("UPDATE sessions SET started_at = ?, ended_at = ? WHERE id = 'real_cont'", (base + 500, base + 2000))
+    conn.execute("UPDATE sessions SET started_at = ?, ended_at = ? WHERE id = 'ws_orphan'", (base + 1000, base + 3000))
+    conn.execute("UPDATE sessions SET started_at = ? WHERE id = 'live_tip'", (base + 2000,))
+    conn.commit()
+
+    assert db.get_compression_tip("root") == "live_tip"
+    assert db.resolve_resume_session_id("root") == "live_tip"
+
+    listed = db.list_sessions_rich(limit=10, order_by_last_active=True)
+    ids = {row["id"] for row in listed}
+    assert "live_tip" in ids
+    assert "real_cont" not in ids
+    assert "ws_orphan" not in ids

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -4307,7 +4307,7 @@ def _(rid, params: dict) -> dict:
         fetch_limit = max(limit * 2, 200)
         rows = [
             s
-            for s in db.list_sessions_rich(source=None, limit=fetch_limit)
+            for s in db.list_sessions_rich(source=None, limit=fetch_limit, order_by_last_active=True)
             if (s.get("source") or "").strip().lower() not in deny
         ][:limit]
         return _ok(
@@ -4354,7 +4354,7 @@ def _(rid, params: dict) -> dict:
         # users (lots of recent ``tool`` rows) don't get a false
         # "no eligible session" answer.  ``session.list`` uses a
         # similar over-fetch strategy.
-        rows = db.list_sessions_rich(source=None, limit=200)
+        rows = db.list_sessions_rich(source=None, limit=200, order_by_last_active=True)
         for row in rows:
             src = (row.get("source") or "").strip().lower()
             if src in deny:


### PR DESCRIPTION
## Summary

Fixes desktop/TUI session resume for long conversations split by context compression.

The old compression-continuation detection required:

```text
child.started_at >= parent.ended_at
```

That ordering is brittle in the gateway/desktop path. In real sessions, the true continuation row can be inserted before the parent session's `ended_at` is finalized, while a stale websocket sibling may later satisfy the timestamp predicate and hijack resume/list projection. The user-visible result is that clicking an old desktop session appears to "lose" the latest conversation, even though the messages are persisted in a different child session.

This PR changes compression tip resolution to:

- follow children of parents ended with `end_reason='compression'`;
- exclude explicit branch/delegate/tool children;
- prefer children that continue the compression chain, then live children, over stale closed siblings such as `ws_orphan_reap`;
- order desktop session list and auto-resume by last active time so surfaced rows point at the latest continuation.

## What changed

- `hermes_state.py`
  - makes compression child detection robust to parent/child timestamp races;
  - updates `get_compression_tip()` to avoid stale websocket sibling hijacking;
  - updates rich session listing chain traversal to match the resolver.
- `tui_gateway/server.py`
  - makes `session.list` and `session.most_recent` use `order_by_last_active=True`.
- `tests/hermes_state/test_resolve_resume_session_id.py`
  - adds a regression test for the real desktop repro shape:

```text
root --compression--> real continuation --compression--> live tip
  \
   `-- stale websocket sibling ended by ws_orphan_reap
```

## Test plan

```bash
uv run --with pytest python -m pytest tests/hermes_state/test_resolve_resume_session_id.py -q
```

Result:

```text
11 passed in 3.16s
```

Also verified:

```bash
git diff --check origin/main...HEAD
PYTHONPATH=. python3 -m py_compile hermes_state.py tui_gateway/server.py
```
