### PR TITLE
fix(cron): resolve cron + skills paths against the active profile HOME (#48649)

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -48,22 +48,73 @@ except ImportError:
 # Configuration
 # =============================================================================
 
-HERMES_DIR = get_hermes_home().resolve()
-CRON_DIR = HERMES_DIR / "cron"
-JOBS_FILE = CRON_DIR / "jobs.json"
+# Cron storage paths are resolved DYNAMICALLY from get_hermes_home() rather
+# than frozen at import time (issue #48649). In-session the active profile is
+# applied via the _HERMES_HOME_OVERRIDE ContextVar, which is set AFTER this
+# module imports; freezing the paths here pinned a profile session's cron jobs
+# to the default home. The private accessors below re-resolve on every call so
+# the override (or the HERMES_HOME env var) is always honored. They also pick
+# up an EXPLICIT override first — a test that monkeypatches `cron.jobs.JOBS_FILE`
+# or the dashboard's `_call_cron_for_profile` retarget binds a real module
+# attribute, which both the accessors (via globals()) and external readers
+# honor. The public CRON_DIR / JOBS_FILE / OUTPUT_DIR names are exposed to
+# external callers via module __getattr__ (PEP 562).
+
+
+def _cron_dir() -> Path:
+    """Current cron directory, honoring an explicit module override if assigned.
+
+    Order: explicit ``cron.jobs.CRON_DIR`` assignment / test monkeypatch (the
+    dashboard ``_call_cron_for_profile`` retarget relies on this) → dynamic
+    resolution from the current ``get_hermes_home()``.
+    """
+    override = globals().get("CRON_DIR")
+    if override is not None:
+        return override
+    return get_hermes_home().resolve() / "cron"
+
+
+def _jobs_file() -> Path:
+    override = globals().get("JOBS_FILE")
+    if override is not None:
+        return override
+    return _cron_dir() / "jobs.json"
+
+
+def _output_dir() -> Path:
+    override = globals().get("OUTPUT_DIR")
+    if override is not None:
+        return override
+    return _cron_dir() / "output"
+
+
+def __getattr__(name: str):
+    # PEP 562 module-level attribute hook. Only fires for names NOT already
+    # bound as real module attributes, so an explicit `cron_jobs.JOBS_FILE = ...`
+    # assignment (dashboard profile retarget) shadows these and is restored
+    # normally afterwards.
+    if name == "CRON_DIR":
+        return _cron_dir()
+    if name == "JOBS_FILE":
+        return _jobs_file()
+    if name == "OUTPUT_DIR":
+        return _output_dir()
+    if name == "HERMES_DIR":
+        return get_hermes_home().resolve()
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
 
 # In-process lock protecting load_jobs→modify→save_jobs cycles.
 # Required when tick() runs jobs in parallel threads — without this,
 # concurrent mark_job_run / advance_next_run calls can clobber each other.
 _jobs_file_lock = threading.RLock()
 _jobs_lock_state = threading.local()
-OUTPUT_DIR = CRON_DIR / "output"
 ONESHOT_GRACE_SECONDS = 120
 
 
 def _jobs_lock_file() -> Path:
     """Return the advisory lock path for the current cron directory."""
-    return CRON_DIR / ".jobs.lock"
+    return _cron_dir() / ".jobs.lock"
 
 
 @contextlib.contextmanager
@@ -148,7 +199,7 @@ def _job_output_dir(job_id: str) -> Path:
         raise ValueError(f"Invalid cron job id for output path: {job_id!r}")
     if Path(text).is_absolute() or Path(text).drive:
         raise ValueError(f"Invalid cron job id for output path: {job_id!r}")
-    return OUTPUT_DIR / text
+    return _output_dir() / text
 
 
 def _normalize_skill_list(skill: Optional[str] = None, skills: Optional[Any] = None) -> List[str]:
@@ -255,10 +306,12 @@ def _secure_file(path: Path):
 
 def ensure_dirs():
     """Ensure cron directories exist with secure permissions."""
-    CRON_DIR.mkdir(parents=True, exist_ok=True)
-    OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
-    _secure_dir(CRON_DIR)
-    _secure_dir(OUTPUT_DIR)
+    cron_dir = _cron_dir()
+    output_dir = _output_dir()
+    cron_dir.mkdir(parents=True, exist_ok=True)
+    output_dir.mkdir(parents=True, exist_ok=True)
+    _secure_dir(cron_dir)
+    _secure_dir(output_dir)
 
 
 # =============================================================================
@@ -506,19 +559,20 @@ def compute_next_run(schedule: Dict[str, Any], last_run_at: Optional[str] = None
 def load_jobs() -> List[Dict[str, Any]]:
     """Load all jobs from storage."""
     ensure_dirs()
-    if not JOBS_FILE.exists():
+    jobs_file = _jobs_file()
+    if not jobs_file.exists():
         return []
 
     _strict_retry = False  # track whether we used the strict=False fallback
 
     try:
-        with open(JOBS_FILE, 'r', encoding='utf-8') as f:
+        with open(jobs_file, 'r', encoding='utf-8') as f:
             data = json.load(f)
     except json.JSONDecodeError:
         # Retry with strict=False to handle bare control chars in string values
         _strict_retry = True
         try:
-            with open(JOBS_FILE, 'r', encoding='utf-8') as f:
+            with open(jobs_file, 'r', encoding='utf-8') as f:
                 data = json.loads(f.read(), strict=False)
         except Exception as e:
             logger.error("Failed to auto-repair jobs.json: %s", e)
@@ -554,14 +608,15 @@ def load_jobs() -> List[Dict[str, Any]]:
 def _save_jobs_unlocked(jobs: List[Dict[str, Any]]):
     """Save all jobs to storage. Caller must hold _jobs_lock()."""
     ensure_dirs()
-    fd, tmp_path = tempfile.mkstemp(dir=str(JOBS_FILE.parent), suffix='.tmp', prefix='.jobs_')
+    jobs_file = _jobs_file()
+    fd, tmp_path = tempfile.mkstemp(dir=str(jobs_file.parent), suffix='.tmp', prefix='.jobs_')
     try:
         with os.fdopen(fd, 'w', encoding='utf-8') as f:
             json.dump({"jobs": jobs, "updated_at": _hermes_now().isoformat()}, f, indent=2)
             f.flush()
             os.fsync(f.fileno())
-        atomic_replace(tmp_path, JOBS_FILE)
-        _secure_file(JOBS_FILE)
+        atomic_replace(tmp_path, jobs_file)
+        _secure_file(jobs_file)
     except BaseException:
         try:
             os.unlink(tmp_path)

--- a/tests/cron/test_profile_aware_paths.py
+++ b/tests/cron/test_profile_aware_paths.py
@@ -1,0 +1,158 @@
+"""Regression tests for #48649 — cron jobs + skill resolution must honor the
+active profile HOME, not the import-time default.
+
+Root cause: ``cron/jobs.py`` and ``tools/skills_tool.py`` froze their path
+globals (``JOBS_FILE``/``CRON_DIR``/``OUTPUT_DIR`` and ``SKILLS_DIR``) at import
+time from ``get_hermes_home()``. When a profile is applied in-session via the
+``_HERMES_HOME_OVERRIDE`` ContextVar (set AFTER those modules import), the frozen
+globals still pointed at the default home, so a profile session's ``cronjob``
+tool wrote to the global cron dir and the scheduler resolved skills from the
+global skills dir (profile skills silently skipped).
+
+These tests assert the path globals resolve DYNAMICALLY against the current
+``get_hermes_home()`` so an override is honored, while remaining byte-identical
+to the platform default when no override is active.
+"""
+
+import importlib
+
+import pytest
+
+import hermes_constants
+
+
+@pytest.fixture(autouse=True)
+def _clear_path_attribute_pollution():
+    """Strip any real CRON_DIR/JOBS_FILE/OUTPUT_DIR/SKILLS_DIR/HERMES_HOME module
+    attributes left behind by other tests' monkeypatching.
+
+    Those names are normally served dynamically via module ``__getattr__`` (PEP
+    562). ``monkeypatch.setattr`` on a dynamic name captures the resolved value
+    and, on teardown, restores it as a REAL attribute — which then shadows the
+    dynamic resolution for every later test in the same process. We delete the
+    shadow before and after each test here so these tests observe the real
+    dynamic behavior regardless of suite ordering.
+    """
+    from cron import jobs as cron_jobs
+    from tools import skills_tool
+
+    def _strip():
+        for mod, names in (
+            (cron_jobs, ("CRON_DIR", "JOBS_FILE", "OUTPUT_DIR", "HERMES_DIR")),
+            (skills_tool, ("SKILLS_DIR", "HERMES_HOME")),
+        ):
+            for n in names:
+                if n in vars(mod):
+                    delattr(mod, n)
+
+    _strip()
+    yield
+    _strip()
+
+
+@pytest.fixture()
+def profile_home(tmp_path, monkeypatch):
+    """A tmp profile home with cron/ and skills/ dirs, applied via the override."""
+    home = tmp_path / ".hermes" / "profiles" / "worker_alpha"
+    (home / "cron").mkdir(parents=True, exist_ok=True)
+    (home / "skills").mkdir(parents=True, exist_ok=True)
+    # Ensure no stray env var interferes with the ContextVar-override path.
+    monkeypatch.delenv("HERMES_HOME", raising=False)
+    return home
+
+
+def _set_override(home):
+    """Apply the profile HOME via the public ContextVar override seam."""
+    return hermes_constants.set_hermes_home_override(str(home))
+
+
+def _reset_override(token):
+    hermes_constants.reset_hermes_home_override(token)
+
+
+# ---------------------------------------------------------------------------
+# cron/jobs.py — path globals must track the override
+# ---------------------------------------------------------------------------
+
+
+def test_cron_jobs_paths_follow_profile_override(profile_home):
+    from cron import jobs as cron_jobs
+
+    token = _set_override(profile_home)
+    try:
+        assert cron_jobs.CRON_DIR == profile_home / "cron"
+        assert cron_jobs.JOBS_FILE == profile_home / "cron" / "jobs.json"
+        assert cron_jobs.OUTPUT_DIR == profile_home / "cron" / "output"
+    finally:
+        _reset_override(token)
+
+
+def test_create_job_writes_to_profile_cron_dir(profile_home, tmp_path):
+    from cron import jobs as cron_jobs
+
+    default_jobs = tmp_path / "default-jobs-should-not-exist.json"
+    token = _set_override(profile_home)
+    try:
+        cron_jobs.create_job(prompt="profile scan", schedule="every 1h", name="alpha")
+    finally:
+        _reset_override(token)
+
+    # Job landed in the profile's cron dir, not the default home.
+    profile_jobs = profile_home / "cron" / "jobs.json"
+    assert profile_jobs.exists(), "create_job did not write to the profile cron dir"
+    assert not default_jobs.exists()
+
+
+def test_cron_jobs_paths_default_when_no_override(monkeypatch, tmp_path):
+    """No override + no env var → resolves to the platform default home (no change)."""
+    from cron import jobs as cron_jobs
+
+    monkeypatch.delenv("HERMES_HOME", raising=False)
+    expected = hermes_constants.get_hermes_home() / "cron" / "jobs.json"
+    assert cron_jobs.JOBS_FILE == expected
+
+
+# ---------------------------------------------------------------------------
+# tools/skills_tool.py — SKILLS_DIR must track the override
+# ---------------------------------------------------------------------------
+
+
+def test_skills_dir_follows_profile_override(profile_home):
+    from tools import skills_tool
+
+    token = _set_override(profile_home)
+    try:
+        assert skills_tool.SKILLS_DIR == profile_home / "skills"
+    finally:
+        _reset_override(token)
+
+
+def test_skill_view_resolves_profile_skill(profile_home):
+    """A skill that exists ONLY in the profile is found when the override is active."""
+    import json
+
+    from tools import skills_tool
+
+    skill_dir = profile_home / "skills" / "demo" / "profile-only-skill"
+    skill_dir.mkdir(parents=True, exist_ok=True)
+    (skill_dir / "SKILL.md").write_text(
+        "---\nname: profile-only-skill\ndescription: present only in the profile\n---\n\nBody.\n",
+        encoding="utf-8",
+    )
+
+    token = _set_override(profile_home)
+    try:
+        result = json.loads(skills_tool.skill_view("profile-only-skill"))
+    finally:
+        _reset_override(token)
+
+    assert result.get("success") is True, f"profile skill not resolved: {result.get('error')}"
+    assert result.get("name") == "profile-only-skill"
+
+
+def test_skills_dir_default_when_no_override(monkeypatch):
+    from tools import skills_tool
+
+    monkeypatch.delenv("HERMES_HOME", raising=False)
+    expected = hermes_constants.get_hermes_home() / "skills"
+    assert skills_tool.SKILLS_DIR == expected

--- a/tools/skills_tool.py
+++ b/tools/skills_tool.py
@@ -90,8 +90,52 @@ logger = logging.getLogger(__name__)
 # All skills live in ~/.hermes/skills/ (seeded from bundled skills/ on install).
 # This is the single source of truth -- agent edits, hub installs, and bundled
 # skills all coexist here without polluting the git repo.
-HERMES_HOME = get_hermes_home()
-SKILLS_DIR = HERMES_HOME / "skills"
+#
+# HERMES_HOME / SKILLS_DIR are resolved DYNAMICALLY (issue #48649) instead of
+# being frozen at import. In-session the active profile is applied via the
+# _HERMES_HOME_OVERRIDE ContextVar, which is set AFTER this module imports;
+# freezing SKILLS_DIR here made a profile session (e.g. a cron job) resolve
+# skills against the default home, so profile-only skills were silently
+# skipped.
+#
+# The public HERMES_HOME / SKILLS_DIR names are served via module __getattr__
+# (PEP 562). Internal code reads them through _current_skills_dir() /
+# _current_hermes_home(), which honor an EXPLICIT override first — a test that
+# monkeypatches `skills_tool.SKILLS_DIR`, or the dashboard's profile-retarget
+# assignment, binds a real module attribute that both shadows __getattr__ for
+# external readers AND is picked up here for internal readers — then fall back
+# to dynamic resolution from the current get_hermes_home().
+
+
+def _current_hermes_home() -> Path:
+    """Active HERMES_HOME, honoring an explicit module override if assigned."""
+    override = globals().get("HERMES_HOME")
+    if override is not None:
+        return override
+    return get_hermes_home()
+
+
+def _current_skills_dir() -> Path:
+    """Active skills dir, honoring an explicit module override if assigned."""
+    override = globals().get("SKILLS_DIR")
+    if override is not None:
+        return override
+    return _current_hermes_home() / "skills"
+
+
+def _skills_dir() -> Path:
+    """Backwards-compatible alias for the dynamic skills dir."""
+    return _current_skills_dir()
+
+
+def __getattr__(name: str):
+    # PEP 562 module attribute hook — fires only for names not bound as real
+    # module attributes, so an explicit assignment/monkeypatch shadows these.
+    if name == "HERMES_HOME":
+        return get_hermes_home()
+    if name == "SKILLS_DIR":
+        return get_hermes_home() / "skills"
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 # Anthropic-recommended limits for progressive disclosure efficiency
 MAX_NAME_LENGTH = 64
@@ -499,9 +543,9 @@ def _get_category_from_path(skill_path: Path) -> Optional[str]:
     For paths like: ~/.hermes/skills/mlops/axolotl/SKILL.md -> "mlops"
     Also works for external skill dirs configured via skills.external_dirs.
     """
-    # Try the module-level SKILLS_DIR first (respects monkeypatching in tests),
-    # then fall back to external dirs from config.
-    dirs_to_check = [SKILLS_DIR]
+    # Try the module-level SKILLS_DIR first (respects monkeypatching in tests
+    # and the active-profile override), then fall back to external dirs.
+    dirs_to_check = [_current_skills_dir()]
     try:
         from agent.skill_utils import get_external_skills_dirs
         dirs_to_check.extend(get_external_skills_dirs())
@@ -620,8 +664,9 @@ def _find_all_skills(*, skip_disabled: bool = False) -> List[Dict[str, Any]]:
 
     # Scan local dir first, then external dirs (local takes precedence)
     dirs_to_scan = []
-    if SKILLS_DIR.exists():
-        dirs_to_scan.append(SKILLS_DIR)
+    _skills_dir_local = _current_skills_dir()
+    if _skills_dir_local.exists():
+        dirs_to_scan.append(_skills_dir_local)
     dirs_to_scan.extend(get_external_skills_dirs())
 
     for scan_dir in dirs_to_scan:
@@ -699,8 +744,9 @@ def skills_list(category: str = None, task_id: str = None) -> str:
         JSON string with minimal skill info: name, description, category
     """
     try:
-        if not SKILLS_DIR.exists():
-            SKILLS_DIR.mkdir(parents=True, exist_ok=True)
+        _skills_dir_local = _current_skills_dir()
+        if not _skills_dir_local.exists():
+            _skills_dir_local.mkdir(parents=True, exist_ok=True)
             return json.dumps(
                 {
                     "success": True,
@@ -982,8 +1028,9 @@ def skill_view(
 
         # Build list of all skill directories to search
         all_dirs = []
-        if SKILLS_DIR.exists():
-            all_dirs.append(SKILLS_DIR)
+        _skills_dir_local = _current_skills_dir()
+        if _skills_dir_local.exists():
+            all_dirs.append(_skills_dir_local)
         all_dirs.extend(get_external_skills_dirs())
 
         if not all_dirs:
@@ -1133,7 +1180,7 @@ def skill_view(
         # Security: warn if skill is loaded from outside trusted directories
         # (local skills dir + configured external_dirs are all trusted)
         _outside_skills_dir = True
-        _trusted_dirs = [SKILLS_DIR.resolve()]
+        _trusted_dirs = [_current_skills_dir().resolve()]
         try:
             _trusted_dirs.extend(d.resolve() for d in all_dirs[1:])
         except Exception:
@@ -1362,7 +1409,7 @@ def skill_view(
             linked_files["scripts"] = script_files
 
         try:
-            rel_path = str(skill_md.relative_to(SKILLS_DIR))
+            rel_path = str(skill_md.relative_to(_current_skills_dir()))
         except ValueError:
             # External skill — use path relative to the skill's own parent dir
             rel_path = str(skill_md.relative_to(skill_md.parent.parent)) if skill_md.parent.parent else skill_md.name


### PR DESCRIPTION
fix(cron): resolve cron + skills paths against the active profile HOME

Fixes #48649.

`cron/jobs.py` and `tools/skills_tool.py` froze their storage/resolution
path globals at import time:

    HERMES_DIR = get_hermes_home().resolve()
    CRON_DIR = HERMES_DIR / "cron"; JOBS_FILE = CRON_DIR / "jobs.json"
    HERMES_HOME = get_hermes_home(); SKILLS_DIR = HERMES_HOME / "skills"

`get_hermes_home()` resolves an active profile from (1) the
`_HERMES_HOME_OVERRIDE` ContextVar, (2) the `HERMES_HOME` env var, then
(3) the platform default. In-session the profile is applied via the
ContextVar override, which is set AFTER these modules import — so the
frozen globals kept pointing at the DEFAULT home. Consequences for a
cron job created from a non-default profile:

* the `cronjob` tool wrote jobs to the global `~/.hermes/cron/jobs.json`
  instead of `~/.hermes/profiles/<name>/cron/jobs.json` (job invisible in
  the profile's WebUI cron dashboard), and
* the scheduler's `skill_view()` resolved skills against the global
  `~/.hermes/skills/`, so a skill that exists only in the profile was
  reported "not found" and silently skipped at execution time.

## What

Resolve the path constants DYNAMICALLY instead of freezing them:

* `cron/jobs.py`: private `_cron_dir()` / `_jobs_file()` / `_output_dir()`
  accessors re-resolve from `get_hermes_home()` on every call; all
  internal references route through them. The public `CRON_DIR` /
  `JOBS_FILE` / `OUTPUT_DIR` / `HERMES_DIR` names are served to external
  callers via module `__getattr__` (PEP 562).
* `tools/skills_tool.py`: same shape with `_current_skills_dir()` /
  `_current_hermes_home()`, public `SKILLS_DIR` / `HERMES_HOME` via
  `__getattr__`.

This generalizes the pattern the dashboard already uses
(`_call_cron_for_profile` temporarily retargets the `cron.jobs` globals):
the accessors check for an EXPLICIT override first — a test that
monkeypatches `JOBS_FILE`/`SKILLS_DIR`, or the dashboard's retarget
assignment, binds a real module attribute that both the accessors (via
`globals()`) and external readers honor — then fall back to dynamic
resolution. So the existing retarget call sites and the ~10 test modules
that monkeypatch these names keep working unchanged.

## Behaviour change footprint

Zero behaviour change on the common path. With no override and no
`HERMES_HOME` env var (default profile / host install), the dynamic
resolution returns byte-for-byte the same default paths as the old
import-time constants — covered by the `*_default_when_no_override`
tests. The override path only bites when a profile is actually active,
which is exactly the broken case.

This does NOT change how the standalone per-profile gateway schedules
jobs (that process already has `HERMES_HOME` set in-env and resolves
correctly); cross-profile scheduler iteration is intentionally out of
scope.

## Test coverage

New `tests/cron/test_profile_aware_paths.py`:

| Test | Asserts |
|---|---|
| `test_cron_jobs_paths_follow_profile_override` | CRON_DIR/JOBS_FILE/OUTPUT_DIR track the override |
| `test_create_job_writes_to_profile_cron_dir` | create_job writes to the profile cron dir, not default |
| `test_cron_jobs_paths_default_when_no_override` | no override → platform default (no change) |
| `test_skills_dir_follows_profile_override` | SKILLS_DIR tracks the override |
| `test_skill_view_resolves_profile_skill` | a profile-only skill is found via real `skill_view()` (E2E, not mocked) |
| `test_skills_dir_default_when_no_override` | no override → platform default (no change) |

An autouse fixture strips any real path attributes left behind by other
suites' `monkeypatch.setattr` on these now-dynamic names, so the tests
are order-independent. Baseline-vs-branch diff over the cron + skills +
web-server-profile suites shows zero new failures (pre-existing
optional-dep collection errors and 3 pre-existing failures unchanged).

## Out of scope

* Multi-profile scheduler iteration (one ticker discovering every
  profile's jobs) — separate design with real tradeoffs.
* No new env var / config knob / tool.
