### PR TITLE
fix(oauth): change User-Agent for token exchange (#48534)

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -1354,7 +1354,7 @@ def run_hermes_oauth_login_pure() -> Optional[Dict[str, Any]]:
             data=exchange_data,
             headers={
                 "Content-Type": "application/json",
-                "User-Agent": f"claude-cli/{_get_claude_code_version()} (external, cli)",
+                "User-Agent": f"hermes-agent/{_get_claude_code_version()} (external, cli)",
             },
             method="POST",
         )


### PR DESCRIPTION
Fixes #48534. Anthropic now blocks token exchange requests with 'claude-cli/' User-Agent prefix. Changed to 'hermes-agent/' to unblock OAuth token exchange.