### PR TITLE
fix(discord): avoid duplicate auto-thread seed posts

### DIFF
--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -4363,24 +4363,41 @@ class DiscordAdapter(BasePlatformAdapter):
             thread = await message.create_thread(name=thread_name, auto_archive_duration=1440)
             return thread
         except Exception as direct_error:
-            display_name = getattr(getattr(message, "author", None), "display_name", None) or "unknown user"
-            reason = f"Auto-threaded from mention by {display_name}"
-            try:
-                seed_msg = await message.channel.send(f"\U0001f9f5 Thread created by Hermes: **{thread_name}**")
-                thread = await seed_msg.create_thread(
-                    name=thread_name,
-                    auto_archive_duration=1440,
-                    reason=reason,
-                )
-                return thread
-            except Exception as fallback_error:
-                logger.warning(
-                    "[%s] Auto-thread creation failed. Direct error: %s. Fallback error: %s",
-                    self.name,
-                    direct_error,
-                    fallback_error,
-                )
-                return None
+            # If another client/bot already created a thread from this starter
+            # message, Discord rejects a second `message.create_thread()` call.
+            # Reuse that existing thread instead of creating a new top-level
+            # seed message, which visibly duplicates the user's topic.
+            existing_thread = getattr(message, "thread", None)
+            if existing_thread is not None:
+                return existing_thread
+            if self._client is not None:
+                try:
+                    existing_thread = self._client.get_channel(int(message.id))
+                    if existing_thread is None:
+                        existing_thread = await self._client.fetch_channel(int(message.id))
+                    if existing_thread is not None:
+                        return existing_thread
+                except Exception:
+                    logger.debug(
+                        "[%s] Could not resolve existing Discord thread for starter message %s",
+                        self.name,
+                        getattr(message, "id", "unknown"),
+                        exc_info=True,
+                    )
+
+            # Do not fall back to sending a new top-level seed message here.
+            # Auto-threading is triggered by an existing user message; if
+            # Discord rejects `message.create_thread()` and we cannot resolve a
+            # pre-existing thread for that starter message, posting a fresh seed
+            # message creates a visible duplicate topic. Prefer a normal channel
+            # reply over manufacturing a second top-level thread.
+            logger.warning(
+                "[%s] Auto-thread creation failed for starter message %s; not posting seed-message fallback to avoid duplicate top-level threads. Direct error: %s",
+                self.name,
+                getattr(message, "id", "unknown"),
+                direct_error,
+            )
+            return None
 
     async def create_handoff_thread(
         self,

--- a/tests/gateway/test_discord_slash_commands.py
+++ b/tests/gateway/test_discord_slash_commands.py
@@ -626,24 +626,37 @@ async def test_auto_create_thread_truncates_long_names(adapter):
 
 
 @pytest.mark.asyncio
-async def test_auto_create_thread_falls_back_to_seed_message(adapter):
+async def test_auto_create_thread_reuses_existing_thread_when_direct_create_loses_race(adapter):
     thread = SimpleNamespace(id=555, name="Hello")
-    seed_message = SimpleNamespace(create_thread=AsyncMock(return_value=thread))
     message = SimpleNamespace(
+        id=555,
         content="Hello",
-        create_thread=AsyncMock(side_effect=RuntimeError("no perms")),
-        channel=SimpleNamespace(send=AsyncMock(return_value=seed_message)),
+        thread=thread,
+        create_thread=AsyncMock(side_effect=RuntimeError("already has thread")),
+        channel=SimpleNamespace(send=AsyncMock()),
         author=SimpleNamespace(display_name="Jezza"),
     )
 
     result = await adapter._auto_create_thread(message)
     assert result is thread
-    message.channel.send.assert_awaited_once_with("🧵 Thread created by Hermes: **Hello**")
-    seed_message.create_thread.assert_awaited_once_with(
-        name="Hello",
-        auto_archive_duration=1440,
-        reason="Auto-threaded from mention by Jezza",
+    message.channel.send.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_auto_create_thread_does_not_post_seed_message_when_direct_create_fails(adapter):
+    message = SimpleNamespace(
+        id=123,
+        content="Hello",
+        create_thread=AsyncMock(side_effect=RuntimeError("no perms")),
+        channel=SimpleNamespace(send=AsyncMock()),
+        author=SimpleNamespace(display_name="Jezza"),
     )
+    adapter._client.get_channel = lambda _id: None
+    adapter._client.fetch_channel = AsyncMock(side_effect=RuntimeError("not found"))
+
+    result = await adapter._auto_create_thread(message)
+    assert result is None
+    message.channel.send.assert_not_awaited()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- reuse an existing Discord thread when auto-thread creation loses a race against another client/bot
- stop auto-threading from posting a fallback top-level seed message when direct thread creation fails
- update regression coverage so failed auto-thread creation does not create duplicate visible topics

## Why
In a Discord channel with auto-threading, a user top-level message can already have a thread. If Hermes then fails a second `message.create_thread()` attempt, the old fallback posted `🧵 Thread created by Hermes: ...` as a new top-level message and created a second thread. That is noisier than simply replying in-channel/threadless.

## Verification
- `/Users/jeeves/.hermes/hermes-agent/venv/bin/python -m py_compile plugins/platforms/discord/adapter.py`
- `/Users/jeeves/.hermes/hermes-agent/venv/bin/python -m pytest tests/gateway/test_discord_slash_commands.py -q -k 'auto_create_thread'`
