### PR TITLE
fix(gateway): fall back when agent sqlite persistence fails

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1081,6 +1081,7 @@ def init_agent(
     agent._parent_session_id = parent_session_id
     agent._last_flushed_db_idx = 0  # tracks DB-write cursor to prevent duplicate writes
     agent._session_db_created = False  # DB row deferred to run_conversation()
+    agent._session_db_persisted_this_turn = False
     agent._session_init_model_config = {
         "max_iterations": agent.max_iterations,
         "reasoning_config": reasoning_config,

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -9347,7 +9347,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # The agent already persisted these messages to SQLite via
             # _flush_messages_to_session_db(), so skip the DB write here
             # to prevent the duplicate-write bug (#860 / #42039).
-            agent_persisted = self._session_db is not None
+            agent_persisted = bool(agent_result.get("session_db_persisted"))
 
             # Find only the NEW messages from this turn (skip history we loaded).
             # Use the filtered history length (history_offset) that was actually

--- a/run_agent.py
+++ b/run_agent.py
@@ -1574,6 +1574,7 @@ class AIAgent:
         can drift after message-sequence repair.
         """
         if not self._session_db:
+            self._session_db_persisted_this_turn = False
             return
         self._apply_persist_user_message_override(messages)
         try:
@@ -1656,7 +1657,9 @@ class AIAgent:
                 )
                 flushed_ids.add(msg_id)
             self._last_flushed_db_idx = len(messages)
+            self._session_db_persisted_this_turn = True
         except Exception as e:
+            self._session_db_persisted_this_turn = False
             logger.warning("Session DB append_message failed: %s", e)
 
     def _get_messages_up_to_last_assistant(self, messages: List[Dict]) -> List[Dict]:
@@ -5236,7 +5239,8 @@ class AIAgent:
     ) -> Dict[str, Any]:
         """Forwarder — see ``agent.conversation_loop.run_conversation``."""
         from agent.conversation_loop import run_conversation
-        return run_conversation(
+        self._session_db_persisted_this_turn = False
+        result = run_conversation(
             self,
             user_message,
             system_message,
@@ -5246,6 +5250,11 @@ class AIAgent:
             persist_user_message,
             persist_user_timestamp,
         )
+        if isinstance(result, dict):
+            result["session_db_persisted"] = bool(
+                getattr(self, "_session_db_persisted_this_turn", False)
+            )
+        return result
 
     def chat(self, message: str, stream_callback: Optional[callable] = None) -> str:
         """

--- a/tests/gateway/test_42039_duplicate_user_message.py
+++ b/tests/gateway/test_42039_duplicate_user_message.py
@@ -12,6 +12,8 @@ This test covers the two fallback paths that previously lacked
 1. ``agent_failed_early`` path — transient 429/timeout failures
 2. ``not new_messages`` path — edge case where ``history_offset`` exceeds
    the actual message count
+3. Gateway fallback only skips its own write when the agent reports that
+   SQLite persistence actually succeeded this turn
 """
 
 import sys
@@ -138,6 +140,7 @@ async def test_agent_failed_early_skip_db_when_agent_has_session_db(
             "messages": [],
             "history_offset": 0,
             "last_prompt_tokens": 0,
+            "session_db_persisted": True,
         }
     )
 
@@ -168,6 +171,7 @@ async def test_agent_failed_early_no_skip_db_when_no_session_db(
             "messages": [],
             "history_offset": 0,
             "last_prompt_tokens": 0,
+            "session_db_persisted": False,
         }
     )
 
@@ -197,6 +201,7 @@ async def test_not_new_messages_skip_db_when_agent_has_session_db(
             "tools": [],
             "history_offset": 1,  # equals len(messages) → new_messages=[]
             "last_prompt_tokens": 0,
+            "session_db_persisted": True,
         }
     )
 
@@ -229,6 +234,7 @@ async def test_normal_path_skip_db_when_agent_has_session_db(
             "tools": [],
             "history_offset": 0,
             "last_prompt_tokens": 0,
+            "session_db_persisted": True,
         }
     )
 
@@ -238,4 +244,34 @@ async def test_normal_path_skip_db_when_agent_has_session_db(
 
     _assert_user_call_has_skip_db(
         runner.session_store.append_to_transcript.call_args_list, True
+    )
+
+
+@pytest.mark.asyncio
+async def test_gateway_fallback_writes_db_when_agent_persistence_failed(
+    monkeypatch, tmp_path
+):
+    runner = _bootstrap(monkeypatch, tmp_path)
+
+    # Gateway has a DB handle, but the agent reports that its own flush failed.
+    runner._run_agent = AsyncMock(
+        return_value={
+            "final_response": "Hello!",
+            "messages": [
+                {"role": "user", "content": "hi"},
+                {"role": "assistant", "content": "Hello!"},
+            ],
+            "tools": [],
+            "history_offset": 0,
+            "last_prompt_tokens": 0,
+            "session_db_persisted": False,
+        }
+    )
+
+    await runner._handle_message_with_agent(
+        _event(), _source(), "agent:main:telegram:group:-1001:12345", 1
+    )
+
+    _assert_user_call_has_skip_db(
+        runner.session_store.append_to_transcript.call_args_list, False
     )

--- a/tests/test_run_agent_session_db_persisted.py
+++ b/tests/test_run_agent_session_db_persisted.py
@@ -1,0 +1,34 @@
+from types import SimpleNamespace
+
+import run_agent
+
+
+def test_run_conversation_reports_successful_session_db_persist(monkeypatch):
+    fake_agent = SimpleNamespace(_session_db_persisted_this_turn=False)
+
+    def _fake_run_conversation(agent, *args, **kwargs):
+        agent._session_db_persisted_this_turn = True
+        return {"final_response": "ok"}
+
+    from agent import conversation_loop
+
+    monkeypatch.setattr(conversation_loop, "run_conversation", _fake_run_conversation)
+    result = run_agent.AIAgent.run_conversation(fake_agent, "hello")
+
+    assert result["final_response"] == "ok"
+    assert result["session_db_persisted"] is True
+
+
+def test_run_conversation_reports_failed_session_db_persist(monkeypatch):
+    fake_agent = SimpleNamespace(_session_db_persisted_this_turn=True)
+
+    def _fake_run_conversation(agent, *args, **kwargs):
+        agent._session_db_persisted_this_turn = False
+        return {"final_response": "ok"}
+
+    from agent import conversation_loop
+
+    monkeypatch.setattr(conversation_loop, "run_conversation", _fake_run_conversation)
+    result = run_agent.AIAgent.run_conversation(fake_agent, "hello")
+
+    assert result["session_db_persisted"] is False


### PR DESCRIPTION
## What does this PR do?

Fixes the sub-profile gateway data-loss path where `gateway/run.py` skipped its own SQLite transcript write whenever the gateway had a `SessionDB` handle, even if the per-turn `AIAgent` never actually flushed rows to `state.db`. The agent now reports whether session DB persistence succeeded for that turn, and the gateway only uses `skip_db=True` when that explicit success signal is present.

## Related Issue

Fixes #48519

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `run_agent.py`: track whether `_flush_messages_to_session_db()` successfully persisted rows during the current turn and expose that outcome on the `run_conversation()` result as `session_db_persisted`.
- `agent/agent_init.py`: initialize the per-turn session DB persistence flag on agent construction.
- `gateway/run.py`: stop inferring agent persistence from `self._session_db is not None`; use the explicit `agent_result["session_db_persisted"]` signal instead so gateway fallback writes still happen after agent-side SQLite failures.
- `tests/gateway/test_42039_duplicate_user_message.py`: keep the duplicate-write regression coverage and add the inverse regression proving the gateway writes through when the agent reports failed DB persistence.
- `tests/test_run_agent_session_db_persisted.py`: add a direct unit test for the `AIAgent.run_conversation()` wrapper result flag.

## Addressing maintainer feedback

- `#47002` (trigram-init crash): not part of this PR; left untouched.
- `#41386` (live-only fallback): not part of this PR; left untouched.
- Maintainer note on #48519: this PR implements the suggested contract fix by keying gateway `skip_db` behavior on successful agent persistence rather than mere gateway DB-handle presence.

## How to Test

1. Run the covering subset for the changed paths:
   `pytest tests/gateway/test_42039_duplicate_user_message.py tests/test_run_agent_session_db_persisted.py -q`
2. Run the safety checks on the touched Python files:
   `python scripts/check-windows-footguns.py agent/agent_init.py gateway/run.py run_agent.py tests/gateway/test_42039_duplicate_user_message.py tests/test_run_agent_session_db_persisted.py`
3. Run `git diff --check` to confirm no whitespace/conflict-marker issues.
4. Optional manual repro: start a gateway under a sub-profile `HERMES_HOME`, force the agent-side SQLite flush path to fail, and confirm the gateway still writes the turn transcript into that profile's `state.db` instead of leaving the session empty.
5. Broad-suite note: `/opt/homebrew/bin/timeout -k 30 480 sh -c 'pytest tests/ -q -x --timeout=60 "$@"' sh` stops early in this environment on a pre-existing missing dependency (`ModuleNotFoundError: fastapi` while collecting `tests/hermes_cli/test_dashboard_auth_401_reauth.py`).

## What platforms tested on

- macOS on darwin-arm64 (local worker environment)

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS darwin-arm64

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

- Focused covering subset: `7 passed in 5.75s`
- Scoped lint: `ruff check` passed on changed Python files
- Windows compatibility scan: `No Windows footguns found (5 file(s) scanned)`
- Broad suite environment blocker: `ModuleNotFoundError: No module named 'fastapi'` while collecting `tests/hermes_cli/test_dashboard_auth_401_reauth.py`

<!-- autocontrib:worker-id=issue-new-403db8f5 kind=pr-open -->