### PR TITLE
fix(gateway): stop early persist from dropping observed context before the API call

### DIFF
--- a/agent/turn_context.py
+++ b/agent/turn_context.py
@@ -123,6 +123,9 @@ def build_turn_context(
     agent._persist_user_message_idx = None
     agent._persist_user_message_override = persist_user_message
     agent._persist_user_message_timestamp = persist_user_timestamp
+    # Identity cache for the clean persist-override copy; reset each turn so a
+    # previous turn's user dict can never be matched by stale identity.
+    agent._persist_user_message_clean_cache = None
     # Generate unique task_id if not provided to isolate VMs between tasks.
     effective_task_id = task_id or str(uuid.uuid4())
     agent._current_task_id = effective_task_id

--- a/run_agent.py
+++ b/run_agent.py
@@ -1496,15 +1496,68 @@ class AIAgent:
                 if timestamp is not None:
                     msg["timestamp"] = timestamp
 
+    def _messages_for_persistence(self, messages: List[Dict]) -> List[Dict]:
+        """Return a persist-only view of ``messages`` with the current-turn user
+        message replaced by its clean override variant — without mutating the
+        live list or any of its dicts.
+
+        The crash-resilience early persist (``build_turn_context``) runs on the
+        *same* ``messages`` list that the model request is later built from.
+        Mutating ``messages[idx]["content"]`` in place there strips the
+        API-facing user message (observed-group context, voice prefix, …)
+        before it reaches the model, silently dropping context (#48677).
+
+        We instead swap a *copy* of the affected message into a copied list.
+        The clean copy is cached by identity for the active turn so repeated
+        persistence points (early + terminal, plus direct flush callers) reuse
+        one object — keeping the SQLite identity-dedup in
+        ``_flush_messages_to_session_db`` from writing duplicate user rows.
+        """
+        idx = getattr(self, "_persist_user_message_idx", None)
+        override = getattr(self, "_persist_user_message_override", None)
+        timestamp = getattr(self, "_persist_user_message_timestamp", None)
+        if idx is None or (override is None and timestamp is None):
+            return messages
+        if not (0 <= idx < len(messages)):
+            return messages
+        msg = messages[idx]
+        if not (isinstance(msg, dict) and msg.get("role") == "user"):
+            return messages
+        # Multimodal turns keep image/audio blocks in the live messages list.
+        # Do not replace those with the text-only override; the paired
+        # timestamp override still applies — it is metadata, not content.
+        if override is not None and isinstance(msg.get("content"), list):
+            override = None
+        if override is None and timestamp is None:
+            return messages
+
+        cache = getattr(self, "_persist_user_message_clean_cache", None)
+        if cache is not None and cache[0] is msg:
+            clean = cache[1]
+        else:
+            clean = dict(msg)
+            if override is not None:
+                clean["content"] = override
+            if timestamp is not None:
+                clean["timestamp"] = timestamp
+            self._persist_user_message_clean_cache = (msg, clean)
+
+        out = list(messages)
+        out[idx] = clean
+        return out
+
     def _persist_session(self, messages: List[Dict], conversation_history: List[Dict] = None):
         """Save session state to both JSON log and SQLite on any exit path.
 
         Ensures conversations are never lost, even on errors or early returns.
         """
         self._drop_trailing_empty_response_scaffolding(messages)
-        self._apply_persist_user_message_override(messages)
-        self._session_messages = messages
-        self._save_session_log(messages)
+        persist_messages = self._messages_for_persistence(messages)
+        self._session_messages = persist_messages
+        self._save_session_log(persist_messages)
+        # Pass the live list; the flush applies the same persist-override view
+        # itself so direct callers stay correct and the identity-dedup keys on
+        # the cached clean copy.
         self._flush_messages_to_session_db(messages, conversation_history)
 
     def _drop_trailing_empty_response_scaffolding(self, messages: List[Dict]) -> None:
@@ -1575,7 +1628,7 @@ class AIAgent:
         """
         if not self._session_db:
             return
-        self._apply_persist_user_message_override(messages)
+        messages = self._messages_for_persistence(messages)
         try:
             # Retry row creation if the earlier attempt failed transiently.
             if not self._session_db_created:

--- a/tests/run_agent/test_persist_override_aliasing.py
+++ b/tests/run_agent/test_persist_override_aliasing.py
@@ -1,0 +1,105 @@
+"""Regression tests for the persist-override aliasing bug (#48677).
+
+The crash-resilience early persist runs on the *same* ``messages`` list the
+model request is later built from. Applying the clean persist-override in place
+there stripped the API-facing user message (observed-group context, voice
+prefix, …) before it reached the model — silently dropping context.
+
+These tests pin the contract: persistence sees the clean override, but the live
+``messages`` list and its dicts are never mutated, and the SQLite row is written
+exactly once.
+"""
+
+import os
+import tempfile
+from pathlib import Path
+from unittest.mock import patch
+
+SESSION_ID = "test-persist-override-aliasing"
+
+
+def _make_agent(session_db):
+    with patch.dict(os.environ, {"OPENROUTER_API_KEY": "test-key"}):
+        from run_agent import AIAgent
+
+        agent = AIAgent(
+            api_key="test-key",
+            base_url="https://openrouter.ai/api/v1",
+            model="test/model",
+            quiet_mode=True,
+            session_db=session_db,
+            session_id=SESSION_ID,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+    agent._ensure_db_session()
+    return agent
+
+
+def _user_contents(db):
+    return [
+        row["content"]
+        for row in db.get_messages(SESSION_ID)
+        if row["role"] == "user"
+    ]
+
+
+def test_early_persist_does_not_strip_api_facing_user_message():
+    """The live message keeps its wrapped content; the DB row is clean."""
+    from hermes_state import SessionDB
+
+    wrapped = (
+        "<observed_context>\n[Alice] did you see the deploy?\n</observed_context>\n"
+        "what do you think of this?"
+    )
+    bare = "what do you think of this?"
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        db = SessionDB(db_path=Path(tmpdir) / "t.db")
+        try:
+            agent = _make_agent(db)
+
+            user_msg = {"role": "user", "content": wrapped}
+            messages = [user_msg]
+            agent._persist_user_message_idx = 0
+            agent._persist_user_message_override = bare
+            agent._persist_user_message_clean_cache = None
+
+            # Crash-resilience early persist (before the model request is built).
+            agent._persist_session(messages, conversation_history=[])
+
+            # The live list/dict the API request is built from is untouched.
+            assert messages[0] is user_msg
+            assert messages[0]["content"] == wrapped
+
+            # The persisted transcript is clean.
+            assert _user_contents(db) == [bare]
+        finally:
+            db.close()
+
+
+def test_repeated_persist_points_write_user_row_once():
+    """Early + terminal persist must not duplicate the user row."""
+    from hermes_state import SessionDB
+
+    wrapped = "API-only synthetic prefix\nhello"
+    bare = "hello"
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        db = SessionDB(db_path=Path(tmpdir) / "t.db")
+        try:
+            agent = _make_agent(db)
+
+            user_msg = {"role": "user", "content": wrapped}
+            messages = [user_msg]
+            agent._persist_user_message_idx = 0
+            agent._persist_user_message_override = bare
+            agent._persist_user_message_clean_cache = None
+
+            agent._persist_session(messages, conversation_history=[])
+            agent._persist_session(messages, conversation_history=[])
+
+            assert _user_contents(db) == [bare]
+            assert messages[0]["content"] == wrapped
+        finally:
+            db.close()


### PR DESCRIPTION
## Summary

When `observe_unmentioned_group_messages` is enabled, observed group context wrapped into the current user message was silently dropped before the request reached the model — no error, no log line. Fixes #48677.

Root cause is a shared-mutable-state aliasing bug. The crash-resilience early persist in `build_turn_context` runs on the **same** `messages` list the model request is later built from, and it ran `_apply_persist_user_message_override`, which mutated `messages[idx]["content"]` in place to the bare `persist_user_message` **before** `api_messages` was built from that list. So the wrapped context reached neither the current message, nor history, nor `system`. The same aliasing also stripped voice-prefix style synthetic prompts.

## Fix

Apply the persist-override through a non-mutating view (`_messages_for_persistence`) instead of mutating in place:

- The live `messages` list and its dicts are never touched, so the model receives the full wrapped message.
- Transcripts/history persist the clean variant, as before.
- The clean copy is cached by identity for the turn, so the SQLite identity-dedup in `_flush_messages_to_session_db` still writes the user row exactly once across the early and terminal persistence points.

## Tests

`tests/run_agent/test_persist_override_aliasing.py`:
- The live message keeps its wrapped (API-facing) content after early persist, while the persisted DB row is the clean override.
- Repeated persistence points write the user row exactly once (no duplicate).

Existing `test_run_agent` override tests and the identity-flush / dedup suites stay green.
