### PR TITLE
fix(constants): exclude host Docker storage from is_container (#48594)

### DIFF
--- a/hermes_constants.py
+++ b/hermes_constants.py
@@ -502,12 +502,29 @@ def is_container() -> bool:
     # cgroup v2: /proc/1/cgroup is just "0::/" with no marker. The container
     # runtime still shows up in the mount table (overlay rootfs, runtime mount
     # paths), so scan mountinfo as a last resort.
+    #
+    # Guard against false positives on Docker-ENGINE hosts: the host's
+    # /proc/self/mountinfo contains lines whose *mount point* or super-options
+    # reference /var/lib/containerd or /var/lib/docker, but the root field (4th
+    # column) is "/".  Real container mounts have a non-trivial root like
+    # "/containerd/.../rootfs".  We parse each line and only match when the
+    # root field contains the marker AND the mount point does NOT start with
+    # /var/lib/docker or /var/lib/containerd (host-side storage paths).
     try:
         with open("/proc/self/mountinfo", "r", encoding="utf-8") as f:
-            mountinfo = f.read()
-            if any(marker in mountinfo for marker in ("kubepods", "containerd", "crio")):
-                _container_detected = True
-                return True
+            for line in f:
+                parts = line.split()
+                if len(parts) < 6:
+                    continue
+                root = parts[3]       # 4th field: root of the mount
+                mount_point = parts[4] # 5th field: mount point
+                # Skip host-side Docker/containerd storage mounts
+                if mount_point.startswith("/var/lib/docker") or mount_point.startswith("/var/lib/containerd"):
+                    continue
+                for marker in ("kubepods", "containerd", "crio"):
+                    if marker in root:
+                        _container_detected = True
+                        return True
     except OSError:
         pass
     _container_detected = False


### PR DESCRIPTION
Fixes #48594. is_container() in hermes_constants.py scanned /proc/self/mountinfo for 'containerd' marker, which matched host-side Docker/containerd storage mounts under /var/lib/docker or /var/lib/containerd. This falsely classified normal Linux hosts with Docker installed as containers, hiding the dashboard update controls. Fixed by scanning mountinfo line-by-line and skipping entries under /var/lib/docker/ or /var/lib/containerd/.