### PR TITLE
fix(agent): summarize structured provider error messages

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -1841,6 +1841,35 @@ class AIAgent:
         return f"{detail}{hint}"
 
     @staticmethod
+    def _coerce_api_error_detail(value: Any) -> str:
+        """Return a display-safe string for structured provider error fields."""
+        if isinstance(value, str):
+            return value
+        if isinstance(value, dict):
+            for key in ("message", "detail", "error", "code", "type"):
+                nested = value.get(key)
+                if isinstance(nested, str) and nested.strip():
+                    return nested
+            for key in ("message", "detail", "error", "code", "type"):
+                if key in value:
+                    nested_detail = AIAgent._coerce_api_error_detail(value[key])
+                    if nested_detail:
+                        return nested_detail
+            try:
+                return json.dumps(value, ensure_ascii=False, sort_keys=True)
+            except TypeError:
+                return str(value)
+        if isinstance(value, (list, tuple)):
+            parts = [
+                AIAgent._coerce_api_error_detail(item)
+                for item in value
+            ]
+            return "; ".join(part for part in parts if part)
+        if value is None:
+            return ""
+        return str(value)
+
+    @staticmethod
     def _summarize_api_error(error: Exception) -> str:
         """Extract a human-readable one-liner from an API error.
 
@@ -1879,6 +1908,7 @@ class AIAgent:
             if msg:
                 status_code = getattr(error, "status_code", None)
                 prefix = f"HTTP {status_code}: " if status_code else ""
+                msg = AIAgent._coerce_api_error_detail(msg)
                 return AIAgent._decorate_xai_entitlement_error(f"{prefix}{msg[:300]}")
 
         # Fallback: truncate the raw string but give more room than 200 chars

--- a/tests/run_agent/test_codex_xai_oauth_recovery.py
+++ b/tests/run_agent/test_codex_xai_oauth_recovery.py
@@ -252,6 +252,35 @@ def test_summarize_api_error_decorates_xai_body_message():
     assert "X Premium+ does NOT include" in summary
 
 
+def test_summarize_api_error_handles_nested_provider_message():
+    """HF router may put a structured object in error.message."""
+    from run_agent import AIAgent
+
+    class _NestedProviderErr(Exception):
+        status_code = 400
+        body = {
+            "error": {
+                "message": {
+                    "type": "Bad Request",
+                    "code": "context_length_exceeded",
+                    "message": (
+                        "This model's maximum context length is 262144 tokens. "
+                        "Please reduce the length of the messages."
+                    ),
+                    "param": None,
+                },
+                "type": "invalid_request_error",
+                "param": None,
+                "code": None,
+            }
+        }
+
+    summary = AIAgent._summarize_api_error(_NestedProviderErr("400"))
+    assert "HTTP 400" in summary
+    assert "maximum context length is 262144 tokens" in summary
+    assert "context_length_exceeded" not in summary
+
+
 def test_summarize_api_error_idempotent_for_entitlement_hint():
     """Decorating twice must not double up the hint."""
     from run_agent import AIAgent


### PR DESCRIPTION
## What does this PR do?

Normalizes structured provider error message fields before summarizing API errors.

Some OpenAI-compatible providers can return `body.error.message` as an object instead of a string. The HuggingFace router context-length error reported in Discord used that shape, so `_summarize_api_error()` attempted `msg[:300]` on a dict and crashed the gateway turn dispatcher with `KeyError: slice(None, 300, None)` while trying to report the original provider error.

This keeps the existing summary/decorator flow, but first converts nested provider error fields into a display-safe string. For the HF router shape, it surfaces the nested `message.message` text instead of crashing.

## Related Issue

Fixes #

Discord support thread: https://discord.com/channels/1053877538025386074/1517295409402220686

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `run_agent.py`: add `_coerce_api_error_detail()` and use it before truncating SDK/body error messages.
- `tests/run_agent/test_codex_xai_oauth_recovery.py`: add a regression test for nested provider `error.message` objects like the HF router context-length response.

## How to Test

1. Trigger `_summarize_api_error()` with an error object whose `body.error.message` is a dict containing a nested `message` string.
2. Confirm the summary returns `HTTP 400: ...262144 tokens...` instead of raising `KeyError: slice(None, 300, None)`.
3. Run the focused regression test when the test runner supports the repo's parallel flag.

Focused checks performed locally:

- `python3 -m py_compile run_agent.py tests/run_agent/test_codex_xai_oauth_recovery.py`
- Windows venv direct regression check through `C:\Users\btgil\AppData\Local\hermes\hermes-agent\.venv\Scripts\python.exe`, confirming the nested HF-shaped error summarizes as `HTTP 400: ...262144 tokens...`.

Attempted but not completed locally:

- `python -m pytest -j 4 tests\run_agent\test_codex_xai_oauth_recovery.py -k nested_provider_message`
- The local Windows pytest environment rejected `-j` as an unrecognized argument. I did not rerun pytest without `-j` because this workstation's Hermes test guidance requires `-j 4` or no pytest run.

## Checklist

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11 / WSL-driven AppData checkout with Windows uv-managed venv

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

N/A

## Screenshots / Logs

Direct regression check output:

```text
HTTP 400: This model maximum context length is 262144 tokens. Please reduce the length of the messages.
```
