### PR TITLE
feat(cli): lock hermes worktrees so concurrent processes can't clobber them

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -1340,6 +1340,17 @@ def _setup_worktree(repo_root: str = None) -> Optional[Dict[str, str]]:
         except Exception as e:
             logger.debug("Error copying .worktreeinclude entries: %s", e)
 
+    # Lock the worktree so other processes (and `git worktree remove`) can see
+    # it is actively in use.  Fail-soft: a lock failure never blocks the session.
+    try:
+        subprocess.run(
+            ["git", "worktree", "lock", "--reason", f"hermes pid={os.getpid()}", str(wt_path)],
+            capture_output=True, text=True, timeout=10, cwd=repo_root,
+        )
+        logger.debug("Worktree locked: %s (pid=%s)", wt_path, os.getpid())
+    except Exception as e:
+        logger.debug("git worktree lock failed (non-fatal): %s", e)
+
     info = {
         "path": str(wt_path),
         "branch": branch_name,
@@ -1415,6 +1426,16 @@ def _cleanup_worktree(info: Dict[str, str] = None) -> None:
 
     # Remove worktree (even if working tree is dirty — uncommitted
     # changes without unpushed commits are just artifacts)
+    # Unlock first so `git worktree remove` isn't blocked by the lock we
+    # placed at creation time.  Fail-soft — never block cleanup.
+    try:
+        subprocess.run(
+            ["git", "worktree", "unlock", wt_path],
+            capture_output=True, text=True, timeout=10, cwd=repo_root,
+        )
+    except Exception as e:
+        logger.debug("git worktree unlock failed (non-fatal): %s", e)
+
     try:
         subprocess.run(
             ["git", "worktree", "remove", wt_path, "--force"],

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -46,6 +46,7 @@ ACP_REGISTRY_MANIFEST = REPO_ROOT / "acp_registry" / "agent.json"
 # Auto-extracted from noreply emails + manual overrides
 AUTHOR_MAP = {
     "victor@rocketfueldev.com": "victor-kyriazakos",
+    "87440198+JoaoMarcos44@users.noreply.github.com": "JoaoMarcos44",
     "286497132+srojk34@users.noreply.github.com": "srojk34",
     "59806492+sitkarev@users.noreply.github.com": "sitkarev",
     "zheng@omegasys.eu": "omegazheng",


### PR DESCRIPTION
## Summary
Hermes-created git worktrees (`hermes -w`) are now locked while in use, so a second hermes process or a stray `git worktree remove`/`prune` can't silently delete an isolated worktree out from under a running session.

## Changes
- `cli.py` `_setup_worktree`: `git worktree lock --reason "hermes pid=<pid>"` right after the worktree is provisioned.
- `cli.py` `_cleanup_worktree`: `git worktree unlock` on the actual-removal path (before `remove --force`), so a preserved worktree with unpushed commits stays locked while in use. Both lock and unlock are fail-soft — an error never blocks the session or cleanup.

## Validation
Real-repo E2E: a locked worktree refuses `git worktree remove --force` (rc 128, "is locked"); unlock-then-remove succeeds and the worktree is gone.

| | locked | after unlock |
|---|---|---|
| `git worktree remove --force` | rc 128 (blocked) | rc 0 (removed) |

## Provenance
Salvaged from #47029 (Issue #46303), @JoaoMarcos44's authorship preserved. Only the worktree lock/unlock hardening is taken here — the rest of #47029 (system-prompt injection of concurrent-session notes, which breaks the byte-stable system-prompt invariant; a default flip of the Honcho `session_strategy`; and a concurrency-warning path that is dead unless `max_concurrent_sessions` is set) is intentionally left out.

## Infographic

![worktree-lock](https://v3b.fal.media/files/b/0a9ed8c5/pWqrkbyU_K-F49l-cl4uh_2hrmkIEo.png)
