### PR TITLE
fix(gateway): don't resolve node symlink into profile dir (multi-profile flap)

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -2322,7 +2322,15 @@ def generate_systemd_unit(system: bool = False, run_as_user: str | None = None) 
     path_entries = _build_service_path_dirs()
     resolved_node = shutil.which("node")
     if resolved_node:
-        resolved_node_dir = str(Path(resolved_node).resolve().parent)
+        # Use the directory where ``node`` is *found on PATH*, NOT the
+        # symlink's resolved target. ``~/.local/bin/node`` is often a symlink
+        # into a specific profile's node install (e.g. profiles/jarvis/node/
+        # bin/node); calling .resolve() here would chase that symlink and bake
+        # one profile's node path into *every* profile's service unit. That
+        # cross-profile leak makes systemd_unit_is_current() perpetually false,
+        # so each gateway rewrites its unit + daemon-reload on every boot. Using
+        # the symlink's own parent keeps the generated unit profile-agnostic.
+        resolved_node_dir = str(Path(resolved_node).parent)
         if resolved_node_dir not in path_entries:
             path_entries.append(resolved_node_dir)
 
@@ -3030,7 +3038,13 @@ def generate_launchd_plist() -> str:
     priority_dirs = _build_service_path_dirs()
     resolved_node = shutil.which("node")
     if resolved_node:
-        resolved_node_dir = str(Path(resolved_node).resolve().parent)
+        # Use the directory where ``node`` is *found on PATH*, NOT the symlink's
+        # resolved target. ``~/.local/bin/node`` is often a symlink into a
+        # specific profile's node install; calling .resolve() would chase it and
+        # bake one profile's path into every profile's service definition,
+        # breaking profile isolation and causing perpetual unit rewrites. See
+        # the matching fix in generate_systemd_unit().
+        resolved_node_dir = str(Path(resolved_node).parent)
         if resolved_node_dir not in priority_dirs:
             priority_dirs.append(resolved_node_dir)
     sane_path = ":".join(


### PR DESCRIPTION
fix(gateway): don't resolve node symlink into profile dir (multi-profile flap)

## Summary

In a multi-profile setup, two or more `hermes-gateway*.service` units enter a
~5-minute restart loop. Each gateway rewrites its own systemd unit and runs
`daemon-reload` on **every** boot, logging:

    ↻ Updated gateway user service definition to match the current Hermes install

Observed `NRestarts` climbed to ~1600 on each of two gateways before diagnosis.

## Root cause

`generate_systemd_unit()` (and the macOS twin `generate_launchd_plist()`) build the
service PATH by locating the node binary:

```python
resolved_node = shutil.which("node")
if resolved_node:
    resolved_node_dir = str(Path(resolved_node).resolve().parent)   # <-- bug
```

`shutil.which("node")` typically returns `~/.local/bin/node`. On multi-profile
installs that path is a **symlink into a specific profile's node install**, e.g.

    ~/.local/bin/node -> ~/.hermes/profiles/<profile>/node/bin/node

`.resolve()` follows the symlink to its real target, so `resolved_node_dir` becomes
`~/.hermes/profiles/<profile>/node/bin`. That **profile-specific** path then gets
baked into the PATH of *every* profile's service definition — including other
profiles and the default profile.

Consequences:
1. **Profile isolation is violated** — one profile's path leaks into all units.
2. `systemd_unit_is_current()` compares the installed unit against a freshly
   generated one. Because the generated PATH now contains the leaked profile path,
   installed != generated → returns False on every boot → `refresh_systemd_unit_if_needed()`
   rewrites the unit + `daemon-reload`, which destabilizes the services into a
   continuous restart loop.

## Fix

Use the directory where `node` is *found on PATH* rather than the symlink's
resolved target:

```python
resolved_node_dir = str(Path(resolved_node).parent)
```

This keeps the generated service definition profile-agnostic and deterministic, so
`systemd_unit_is_current()` stabilizes and the per-boot rewrite stops. Applied to
**both** `generate_systemd_unit()` (systemd/Linux) and `generate_launchd_plist()`
(launchd/macOS), which carried the identical pattern.

## Reproduction

1. Run Hermes with the default profile + at least one named profile.
2. Have `~/.local/bin/node` be a symlink into one profile's `node/bin/` (this is how
   a profile-scoped node bootstrap sets it up).
3. Enable both `hermes-gateway.service` and `hermes-gateway-<profile>.service`.
4. Observe both services restarting every ~5 min; `journalctl --user -u 'hermes-gateway*'`
   shows "↻ Updated gateway ... service definition" on every start; `NRestarts` climbs.

## Verification

After the fix (and/or repointing the node symlink to a profile-neutral location such
as `~/.hermes/node/bin`), both gateways hold at `NRestarts=0` past the flap interval,
and the default profile's unit PATH no longer contains any `profiles/<name>/` entry.

## Notes

- One gateway service per profile is by design (`get_service_name()` is profile-aware);
  the dual services are correct — the flap is the bug.
- A complementary hardening (not in this PR) is to ensure a profile-scoped node
  bootstrap never plants a global `~/.local/bin/node` symlink pointing *into* a
  profile dir, which is what triggers the latent `.resolve()` issue in the first place.
