### PR TITLE
fix(auth): anthropic OAuth login falls back to current token endpoint

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -1349,18 +1349,33 @@ def run_hermes_oauth_login_pure() -> Optional[Dict[str, Any]]:
             "code_verifier": verifier,
         }).encode()
 
-        req = urllib.request.Request(
-            _OAUTH_TOKEN_URL,
-            data=exchange_data,
-            headers={
-                "Content-Type": "application/json",
-                "User-Agent": f"claude-cli/{_get_claude_code_version()} (external, cli)",
-            },
-            method="POST",
-        )
-
-        with urllib.request.urlopen(req, timeout=15) as resp:
-            result = json.loads(resp.read().decode())
+        # Try current endpoint first, then legacy console endpoint (stale-URL fix).
+        _token_endpoints = [
+            "https://platform.claude.com/v1/oauth/token",
+            "https://console.anthropic.com/v1/oauth/token",
+        ]
+        result = None
+        last_exc = None
+        for _endpoint in _token_endpoints:
+            try:
+                req = urllib.request.Request(
+                    _endpoint,
+                    data=exchange_data,
+                    headers={
+                        "Content-Type": "application/json",
+                        "User-Agent": f"claude-cli/{_get_claude_code_version()} (external, cli)",
+                    },
+                    method="POST",
+                )
+                with urllib.request.urlopen(req, timeout=15) as resp:
+                    result = json.loads(resp.read().decode())
+                if result:
+                    break
+            except Exception as e:  # noqa: PERF203 — small fixed list, clarity over micro-perf
+                last_exc = e
+                continue
+        if result is None:
+            raise last_exc if last_exc else RuntimeError("token exchange failed")
     except Exception as e:
         print(f"Token exchange failed: {e}")
         return None

--- a/tests/agent/test_anthropic_oauth_pkce.py
+++ b/tests/agent/test_anthropic_oauth_pkce.py
@@ -174,3 +174,89 @@ def test_callback_state_mismatch_aborts(monkeypatch, tmp_path, caplog):
     assert "url" not in captured_token, (
         "token exchange must NOT happen when state mismatches"
     )
+
+
+def test_token_exchange_falls_back_to_legacy_endpoint(monkeypatch, tmp_path):
+    """The initial code->token exchange must try the current
+    ``platform.claude.com`` endpoint first and fall back to the legacy
+    ``console.anthropic.com`` endpoint when the first returns 404.
+
+    The legacy ``console.anthropic.com/v1/oauth/token`` URL began returning
+    HTTP 404, breaking ``hermes auth add anthropic --type oauth`` with
+    "Token exchange failed: HTTP Error 404: Not Found". The refresh path
+    already tried ``platform.claude.com`` first; the login path did not.
+    """
+    import urllib.error
+    import urllib.request
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    attempted: list[str] = []
+
+    class _FakeResponse:
+        def __init__(self, body: bytes) -> None:
+            self._body = body
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_exc):
+            return False
+
+        def read(self):
+            return self._body
+
+    def fake_urlopen(req, *_a, **_kw):
+        attempted.append(req.full_url)
+        # Simulate the current breakage inverted for fallback coverage: the
+        # FIRST endpoint tried (platform.claude.com) fails, so the flow must
+        # advance to the legacy console endpoint, which succeeds.
+        if "platform.claude.com" in req.full_url:
+            raise urllib.error.HTTPError(
+                req.full_url, 404, "Not Found", hdrs=None, fp=None
+            )
+        body = json.dumps(
+            {
+                "access_token": "sk-ant...cess",
+                "refresh_token": "sk-ant...resh",
+                "expires_in": 3600,
+            }
+        ).encode()
+        return _FakeResponse(body)
+
+    monkeypatch.setattr("webbrowser.open", lambda *_a, **_kw: True)
+    monkeypatch.setattr(
+        "hermes_cli.auth._can_open_graphical_browser", lambda: True
+    )
+    monkeypatch.setattr(urllib.request, "urlopen", fake_urlopen)
+
+    captured_url: Dict[str, str] = {}
+
+    def fake_open(url):
+        captured_url["url"] = url
+        return True
+
+    monkeypatch.setattr("webbrowser.open", fake_open)
+
+    def fake_input(*_a, **_kw):
+        qs = parse_qs(urlparse(captured_url.get("url", "")).query)
+        state = qs.get("state", [""])[0]
+        return f"auth-code-from-anthropic#{state}"
+
+    monkeypatch.setattr("builtins.input", fake_input)
+
+    from agent.anthropic_adapter import run_hermes_oauth_login_pure
+
+    result = run_hermes_oauth_login_pure()
+
+    assert result is not None, (
+        "login must succeed by falling back to the legacy endpoint"
+    )
+    assert result["access_token"] == "sk-ant...cess"
+    # platform.claude.com must be tried first, console.anthropic.com second.
+    assert attempted[0].startswith("https://platform.claude.com/"), (
+        f"current endpoint must be tried first, got {attempted!r}"
+    )
+    assert any("console.anthropic.com" in u for u in attempted), (
+        "legacy endpoint must be attempted as a fallback"
+    )


### PR DESCRIPTION
## Summary

`hermes auth add anthropic --type oauth` fails at the code→token exchange with:

```
Token exchange failed: HTTP Error 404: Not Found
Anthropic OAuth login did not return credentials.
```

Root cause: `run_hermes_oauth_login_pure()` in `agent/anthropic_adapter.py` exchanges the authorization code against **only** the legacy `https://console.anthropic.com/v1/oauth/token` endpoint, which now returns HTTP 404.

The token **refresh** path (`refresh_anthropic_oauth_pure`, the `token_endpoints` list around L997) already tries `https://platform.claude.com/v1/oauth/token` first and falls back to the console URL — but the **login** path was never updated to match. So a fresh subscription login is broken even though refresh works.

## Fix

Mirror the same ordered-fallback list in the login exchange: try `platform.claude.com` first, fall back to `console.anthropic.com`, and only surface the error if every endpoint fails. Minimal, scoped to the one broken function.

## Test

Adds `test_token_exchange_falls_back_to_legacy_endpoint` to `tests/agent/test_anthropic_oauth_pkce.py`, asserting the current endpoint is tried first and the legacy endpoint is used as a fallback when the first fails.

```
$ python -m pytest tests/agent/test_anthropic_oauth_pkce.py -o 'addopts=' -q
...                                                                      [100%]
3 passed in 0.74s
```

## Notes

- Reproduced on a real macOS install (Hermes v0.16.0) — the login 404'd, the patch made it complete and store the OAuth credential successfully.
- No behavior change for users already on the working endpoint; this only adds a fallback when the first endpoint errors.
