### PR TITLE
fix(anthropic): use platform.claude.com for OAuth token exchange (console.anthropic.com now 404s)

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -1251,7 +1251,15 @@ def run_oauth_setup_token() -> Optional[str]:
 # Stores credentials in ~/.hermes/.anthropic_oauth.json (our own file).
 
 _OAUTH_CLIENT_ID = "9d1c250a-e61b-44d9-88ed-5944d1962f5e"
-_OAUTH_TOKEN_URL = "https://console.anthropic.com/v1/oauth/token"
+# Anthropic migrated the OAuth token endpoint to platform.claude.com;
+# console.anthropic.com now 404s. Callers should iterate _OAUTH_TOKEN_URLS
+# (new host first, console fallback). _OAUTH_TOKEN_URL is kept as the primary
+# for backward compatibility with existing imports and now points at the live host.
+_OAUTH_TOKEN_URLS = [
+    "https://platform.claude.com/v1/oauth/token",
+    "https://console.anthropic.com/v1/oauth/token",
+]
+_OAUTH_TOKEN_URL = _OAUTH_TOKEN_URLS[0]
 _OAUTH_REDIRECT_URI = "https://console.anthropic.com/oauth/code/callback"
 _OAUTH_SCOPES = "org:create_api_key user:profile user:inference"
 _HERMES_OAUTH_FILE = get_hermes_home() / ".anthropic_oauth.json"
@@ -1349,18 +1357,34 @@ def run_hermes_oauth_login_pure() -> Optional[Dict[str, Any]]:
             "code_verifier": verifier,
         }).encode()
 
-        req = urllib.request.Request(
-            _OAUTH_TOKEN_URL,
-            data=exchange_data,
-            headers={
-                "Content-Type": "application/json",
-                "User-Agent": f"claude-cli/{_get_claude_code_version()} (external, cli)",
-            },
-            method="POST",
-        )
+        # Anthropic migrated the OAuth token endpoint to platform.claude.com;
+        # console.anthropic.com now 404s. Try the new host first, then fall
+        # back to console for older deployments (mirrors the refresh path).
+        result = None
+        last_error = None
+        for endpoint in _OAUTH_TOKEN_URLS:
+            req = urllib.request.Request(
+                endpoint,
+                data=exchange_data,
+                headers={
+                    "Content-Type": "application/json",
+                    "User-Agent": f"claude-cli/{_get_claude_code_version()} (external, cli)",
+                },
+                method="POST",
+            )
+            try:
+                with urllib.request.urlopen(req, timeout=15) as resp:
+                    result = json.loads(resp.read().decode())
+                break
+            except Exception as exc:
+                last_error = exc
+                logger.debug("Anthropic token exchange failed at %s: %s", endpoint, exc)
+                continue
 
-        with urllib.request.urlopen(req, timeout=15) as resp:
-            result = json.loads(resp.read().decode())
+        if result is None:
+            raise last_error if last_error is not None else ValueError(
+                "Anthropic token exchange failed"
+            )
     except Exception as e:
         print(f"Token exchange failed: {e}")
         return None

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -5743,6 +5743,7 @@ try:
     from agent.anthropic_adapter import (
         _OAUTH_CLIENT_ID as _ANTHROPIC_OAUTH_CLIENT_ID,
         _OAUTH_TOKEN_URL as _ANTHROPIC_OAUTH_TOKEN_URL,
+        _OAUTH_TOKEN_URLS as _ANTHROPIC_OAUTH_TOKEN_URLS,
         _OAUTH_REDIRECT_URI as _ANTHROPIC_OAUTH_REDIRECT_URI,
         _OAUTH_SCOPES as _ANTHROPIC_OAUTH_SCOPES,
         _generate_pkce as _generate_pkce_pair,
@@ -5931,22 +5932,31 @@ def _submit_anthropic_pkce(
         "redirect_uri": _ANTHROPIC_OAUTH_REDIRECT_URI,
         "code_verifier": sess["verifier"],
     }).encode()
-    req = urllib.request.Request(
-        _ANTHROPIC_OAUTH_TOKEN_URL,
-        data=exchange_data,
-        headers={
-            "Content-Type": "application/json",
-            "User-Agent": "hermes-dashboard/1.0",
-        },
-        method="POST",
-    )
-    try:
-        with urllib.request.urlopen(req, timeout=20) as resp:
-            result = json.loads(resp.read().decode())
-    except Exception as e:
+    # Anthropic migrated the OAuth token endpoint to platform.claude.com;
+    # console.anthropic.com now 404s. Try the new host first, then fall back.
+    result = None
+    last_exc = None
+    for _endpoint in _ANTHROPIC_OAUTH_TOKEN_URLS:
+        req = urllib.request.Request(
+            _endpoint,
+            data=exchange_data,
+            headers={
+                "Content-Type": "application/json",
+                "User-Agent": "hermes-dashboard/1.0",
+            },
+            method="POST",
+        )
+        try:
+            with urllib.request.urlopen(req, timeout=20) as resp:
+                result = json.loads(resp.read().decode())
+            break
+        except Exception as e:
+            last_exc = e
+            continue
+    if result is None:
         with _oauth_sessions_lock:
             sess["status"] = "error"
-            sess["error_message"] = f"Token exchange failed: {e}"
+            sess["error_message"] = f"Token exchange failed: {last_exc}"
         return {"ok": False, "status": "error", "message": sess["error_message"]}
 
     access_token = result.get("access_token", "")


### PR DESCRIPTION
## Problem

Anthropic migrated the OAuth **token** endpoint. As of now:

- `https://console.anthropic.com/v1/oauth/token` → **HTTP 404** (gone)
- `https://platform.claude.com/v1/oauth/token` → **HTTP 400** with a junk code (alive — endpoint exists, just rejects the fake grant)

The token **refresh** path in `agent/anthropic_adapter.py` already iterates both hosts (`platform.claude.com` first, `console` fallback). But the two **initial code-exchange** call sites were hardcoded to the dead `console.anthropic.com` host via `_OAUTH_TOKEN_URL`:

1. `run_hermes_oauth_login_pure()` in `agent/anthropic_adapter.py` (CLI: `hermes auth add anthropic --type oauth`)
2. the desktop dashboard OAuth handler in `hermes_cli/web_server.py`, which imports `_OAUTH_TOKEN_URL`

Result: every **new** Claude OAuth login fails with `Token exchange failed: HTTP Error 404: Not Found` and saves no credential. The state/PKCE validate fine — only the token POST host is wrong. A fresh code with matching state still 404s, so it is not a stale-code or tier problem.

## Fix (whole bug class — both call sites)

- Add `_OAUTH_TOKEN_URLS = [platform.claude.com, console.anthropic.com]` in `agent/anthropic_adapter.py`. `_OAUTH_TOKEN_URL` is kept (now pointing at the live host) for backward-compat with existing imports.
- `run_hermes_oauth_login_pure()` iterates the list, first success wins — mirroring the existing refresh `token_endpoints` logic.
- `hermes_cli/web_server.py` imports and iterates the same list, fixing the GUI login path identically.

## Reproduce / verify

```bash
for url in https://platform.claude.com/v1/oauth/token https://console.anthropic.com/v1/oauth/token; do
  curl -s -o /dev/null -w "%{http_code} $url\n" -X POST "$url" \
    -H 'Content-Type: application/json' \
    -d '{"grant_type":"authorization_code","client_id":"9d1c250a-e61b-44d9-88ed-5944d1962f5e","code":"x","state":"x","redirect_uri":"https://console.anthropic.com/oauth/code/callback","code_verifier":"x"}'
done
# 400 platform.claude.com  (alive)
# 404 console.anthropic.com (gone)
```

Verified a real Claude MAX OAuth login now completes end-to-end via the CLI PTY flow (`Added anthropic OAuth credential`). `_OAUTH_REDIRECT_URI` is the registered callback and is unchanged — only the token POST host moved.

## Notes

- No new tests added (the existing repo has no anthropic-oauth test module and `pytest` isn't vendored in the runtime venv); change is a host-list swap mirroring the already-tested refresh path. Happy to add a unit test asserting both call sites iterate `_OAUTH_TOKEN_URLS` if preferred.
