### PR TITLE
feat(dashboard): add Observatory theme

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1637,7 +1637,7 @@ DEFAULT_CONFIG = {
 
     # Web dashboard settings
     "dashboard": {
-        "theme": "default",  # Dashboard visual theme: "default", "midnight", "ember", "mono", "cyberpunk", "rose"
+        "theme": "default",  # Dashboard visual theme: "default", "default-large", "nous-blue", "midnight", "ember", "mono", "cyberpunk", "rose", "observatory"
         # Hide the token/cost analytics surfaces (Analytics page, token bars and
         # cost figures on the Models page) by default.  The numbers shown there
         # are a local debug estimate: they only count successful main-agent

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -490,7 +490,10 @@ _SCHEMA_OVERRIDES: Dict[str, Dict[str, Any]] = {
     "dashboard.theme": {
         "type": "select",
         "description": "Web dashboard visual theme",
-        "options": ["default", "midnight", "ember", "mono", "cyberpunk", "rose"],
+        "options": [
+            "default", "default-large", "nous-blue", "midnight", "ember",
+            "mono", "cyberpunk", "rose", "observatory",
+        ],
     },
     "display.resume_display": {
         "type": "select",
@@ -11335,7 +11338,8 @@ _BUILTIN_DASHBOARD_THEMES = [
     {"name": "ember",     "label": "Ember",          "description": "Warm crimson and bronze — forge vibes"},
     {"name": "mono",      "label": "Mono",           "description": "Clean grayscale — minimal and focused"},
     {"name": "cyberpunk", "label": "Cyberpunk",      "description": "Neon green on black — matrix terminal"},
-    {"name": "rose",      "label": "Rosé",           "description": "Soft pink and warm ivory — easy on the eyes"},
+    {"name": "rose",         "label": "Rosé",           "description": "Soft pink and warm ivory — easy on the eyes"},
+    {"name": "observatory",  "label": "Observatory",    "description": "Deep stellar control room — cool blues and violet starlight"},
 ]
 
 
@@ -11564,7 +11568,8 @@ def _discover_user_themes() -> list:
     if not themes_dir.is_dir():
         return []
     result = []
-    for f in sorted(themes_dir.glob("*.yaml")):
+    theme_files = sorted({*themes_dir.glob("*.yaml"), *themes_dir.glob("*.yml")})
+    for f in theme_files:
         try:
             data = yaml.safe_load(f.read_text(encoding="utf-8"))
         except Exception:

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -4129,6 +4129,26 @@ class TestStatusRemoteGateway:
 # ---------------------------------------------------------------------------
 
 
+class TestDashboardBuiltInThemes:
+    def test_observatory_is_listed_as_builtin_theme(self):
+        from hermes_cli import web_server
+
+        themes = {theme["name"]: theme for theme in web_server._BUILTIN_DASHBOARD_THEMES}
+        assert themes["observatory"] == {
+            "name": "observatory",
+            "label": "Observatory",
+            "description": "Deep stellar control room — cool blues and violet starlight",
+        }
+
+    def test_dashboard_theme_config_schema_includes_observatory(self):
+        from hermes_cli import web_server
+
+        options = web_server.CONFIG_SCHEMA["dashboard.theme"]["options"]
+        assert "observatory" in options
+        assert "default-large" in options
+        assert "nous-blue" in options
+
+
 class TestNormaliseThemeDefinition:
     """Tests for _normalise_theme_definition() — parses YAML theme files."""
 
@@ -4292,6 +4312,24 @@ class TestDiscoverUserThemes:
         assert results[0]["layout"]["density"] == "spacious"
         # defaults filled in
         assert "fontSans" in results[0]["typography"]
+
+    def test_loads_yml_extension_documented_as_supported(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        themes_dir = tmp_path / "dashboard-themes"
+        themes_dir.mkdir()
+        (themes_dir / "observatory.yml").write_text(
+            "name: observatory\n"
+            "label: Observatory\n"
+            "palette:\n"
+            "  background: \"#050712\"\n"
+            "  midground: \"#c9e8ff\"\n"
+        )
+
+        from hermes_cli import web_server
+
+        results = web_server._discover_user_themes()
+        assert [r["name"] for r in results] == ["observatory"]
+        assert results[0]["palette"]["background"]["hex"] == "#050712"
 
     def test_malformed_yaml_skipped(self, tmp_path, monkeypatch):
         monkeypatch.setenv("HERMES_HOME", str(tmp_path))

--- a/web/src/themes/presets.ts
+++ b/web/src/themes/presets.ts
@@ -184,6 +184,63 @@ export const roseTheme: DashboardTheme = {
   },
 };
 
+export const observatoryTheme: DashboardTheme = {
+  name: "observatory",
+  label: "Observatory",
+  description: "Deep stellar control room — cool blues and violet starlight",
+  palette: {
+    background: { hex: "#050712", alpha: 1 },
+    midground: { hex: "#c9e8ff", alpha: 1 },
+    foreground: { hex: "#ffffff", alpha: 0.08 },
+    warmGlow: "rgba(118, 92, 255, 0.22)",
+    noiseOpacity: 0.55,
+  },
+  typography: {
+    ...DEFAULT_TYPOGRAPHY,
+    fontSans: `"Inter", ${SYSTEM_SANS}`,
+    fontMono: `"JetBrains Mono", ${SYSTEM_MONO}`,
+    fontDisplay: `"Space Grotesk", ${SYSTEM_SANS}`,
+    fontUrl:
+      "https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;700&family=Space+Grotesk:wght@500;600;700&display=swap",
+    lineHeight: "1.6",
+    letterSpacing: "0.005em",
+  },
+  layout: {
+    ...DEFAULT_LAYOUT,
+    radius: "0.75rem",
+  },
+  assets: {
+    bg:
+      "radial-gradient(circle at 50% 16%, rgba(99, 102, 241, 0.22), transparent 42%)",
+  },
+  componentStyles: {
+    card: {
+      boxShadow:
+        "inset 0 0 0 1px rgba(148, 197, 255, 0.18), 0 18px 60px rgba(0, 0, 0, 0.35)",
+    },
+    header: {
+      background:
+        "linear-gradient(180deg, rgba(9, 13, 32, 0.96), rgba(5, 7, 18, 0.88))",
+    },
+  },
+  colorOverrides: {
+    primary: "#9ddcff",
+    primaryForeground: "#050712",
+    accent: "#7c6dff",
+    accentForeground: "#ffffff",
+    ring: "#9ddcff",
+    success: "#65f2b7",
+    warning: "#f6c177",
+    destructive: "#ff6b8f",
+  },
+  seriesColors: {
+    inputTokenAccent: "#9ddcff",
+    outputTokenAccent: "#7c6dff",
+  },
+  swatchColors: ["#050712", "#9ddcff", "#7c6dff"],
+  terminalBackground: "#02030a",
+};
+
 /**
  * Nous Blue — the inverted "light mode" Hermes look, ported from the
  * LENS_5I overlay preset in `@nous-research/ui`.
@@ -308,4 +365,5 @@ export const BUILTIN_THEMES: Record<string, DashboardTheme> = {
   mono: monoTheme,
   cyberpunk: cyberpunkTheme,
   rose: roseTheme,
+  observatory: observatoryTheme,
 };

--- a/website/docs/user-guide/features/extending-the-dashboard.md
+++ b/website/docs/user-guide/features/extending-the-dashboard.md
@@ -54,7 +54,7 @@ Themes and plugins are independent but synergistic. A theme can stand alone (jus
 
 ## Themes
 
-Themes are YAML files stored in `~/.hermes/dashboard-themes/`. The file name doesn't matter (the theme's `name:` field is what the system uses), but convention is `<name>.yaml`. Every field is optional — missing keys fall back to the built-in `default` theme, so a theme can be as small as one color.
+Themes are YAML files stored in `~/.hermes/dashboard-themes/`. The file name doesn't matter (the theme's `name:` field is what the system uses), but convention is `<name>.yaml`; `.yml` is also supported. Every field is optional — missing keys fall back to the built-in `default` theme, so a theme can be as small as one color.
 
 ### Quick start — your first theme
 
@@ -282,13 +282,15 @@ Each built-in ships its own palette, typography, and layout — switching produc
 |-------|---------|------------|--------|
 | **Hermes Teal** (`default`) | Dark teal + cream | System stack, 15px | 0.5rem radius, comfortable |
 | **Hermes Teal (Large)** (`default-large`) | Same as default | System stack, 18px, line-height 1.65 | 0.5rem radius, spacious |
+| **Nous Blue** (`nous-blue`) | Light cream + vivid Nous-blue | System stack, 15px | 0.5rem radius, comfortable |
 | **Midnight** (`midnight`) | Deep blue-violet | Inter + JetBrains Mono, 14px | 0.75rem radius, comfortable |
 | **Ember** (`ember`) | Warm crimson + bronze | Spectral (serif) + IBM Plex Mono, 15px | 0.25rem radius, comfortable |
 | **Mono** (`mono`) | Grayscale | IBM Plex Sans + IBM Plex Mono, 13px | 0 radius, compact |
 | **Cyberpunk** (`cyberpunk`) | Neon green on black | Share Tech Mono everywhere, 14px | 0 radius, compact |
 | **Rosé** (`rose`) | Pink + ivory | Fraunces (serif) + DM Mono, 16px | 1rem radius, spacious |
+| **Observatory** (`observatory`) | Near-black stellar canvas + cool blue/violet accents | Inter + JetBrains Mono + Space Grotesk, 15px | 0.75rem radius, comfortable |
 
-Themes that reference Google Fonts (all except Hermes Teal) load the stylesheet on demand — the first time you switch to them a `<link>` tag is injected into `<head>`.
+Themes that reference Google Fonts load the stylesheet on demand — the first time you switch to them a `<link>` tag is injected into `<head>`.
 
 ### Full theme YAML reference
 


### PR DESCRIPTION
## Summary
- add the Observatory built-in dashboard theme with cool blue/violet stellar styling
- expose Observatory in dashboard theme config/schema and backend theme listings
- make user dashboard theme discovery honor both .yaml and documented .yml files
- update dashboard extension docs for Observatory, Nous Blue, and .yml support

## Test Plan
- npm run typecheck --prefix web
- npm run build --prefix web
- python -m pytest tests/hermes_cli/test_web_server.py -q -k 'DashboardBuiltInThemes or DiscoverUserThemes' -o 'addopts='
