### PR TITLE
fix(dump): report the effective inference provider, not just config

### DIFF
--- a/hermes_cli/dump.py
+++ b/hermes_cli/dump.py
@@ -295,6 +295,20 @@ def run_dump(args):
     else:
         backend = config_backend
 
+    # Provider — report the EFFECTIVE provider, not just config.yaml.
+    # config.model.provider wins per runtime_provider.resolve_requested_provider
+    # (explicit > config.model.provider > HERMES_INFERENCE_PROVIDER > auto), but
+    # when config sets no provider an HERMES_INFERENCE_PROVIDER in .env / the shell
+    # is what the agent actually resolves to. run_dump() has already loaded .env,
+    # so os.environ reflects the real override here. Reporting only "(auto)" hides
+    # it from support triage — the same failure the effective-terminal-backend
+    # line above fixes (note the precedence is the opposite direction: config wins
+    # over env here, whereas TERMINAL_ENV overrides config).
+    if provider == "(auto)":
+        env_provider = (os.environ.get("HERMES_INFERENCE_PROVIDER") or "").strip()
+        if env_provider:
+            provider = f"{env_provider}  (HERMES_INFERENCE_PROVIDER, config sets none)"
+
     # OpenAI SDK version
     try:
         import openai

--- a/tests/hermes_cli/test_dump_terminal_backend.py
+++ b/tests/hermes_cli/test_dump_terminal_backend.py
@@ -18,6 +18,13 @@ def _terminal_line(out: str) -> str:
     raise AssertionError(f"no 'terminal:' line in dump output:\n{out}")
 
 
+def _provider_line(out: str) -> str:
+    for line in out.splitlines():
+        if line.startswith("provider:"):
+            return line
+    raise AssertionError(f"no 'provider:' line in dump output:\n{out}")
+
+
 def _seed(home: Path, *, config_yaml: str, env_text: str) -> None:
     home.mkdir(parents=True, exist_ok=True)
     (home / "config.yaml").write_text(config_yaml)
@@ -60,6 +67,57 @@ def test_dump_reports_config_backend_when_no_override(monkeypatch, capsys, tmp_p
     line = _terminal_line(capsys.readouterr().out)
     assert "docker" in line
     assert "overrides" not in line
+
+
+def test_dump_surfaces_inference_provider_env_override(monkeypatch, capsys, tmp_path):
+    """When config sets no model.provider, the dump must surface the effective
+    HERMES_INFERENCE_PROVIDER override instead of the bare "(auto)" sentinel —
+    that env value is what the agent actually resolves to."""
+    from hermes_cli import dump
+    from hermes_cli.config import get_hermes_home
+
+    monkeypatch.delenv("HERMES_INFERENCE_PROVIDER", raising=False)
+    monkeypatch.setattr(dump, "get_project_root", lambda: tmp_path / "noproject")
+
+    home = get_hermes_home()
+    # No model.provider in config; only the env override is set.
+    _seed(
+        home,
+        config_yaml="model:\n  default: hermes-4-405b\n",
+        env_text="HERMES_INFERENCE_PROVIDER=nous\n",
+    )
+
+    dump.run_dump(SimpleNamespace(show_keys=False))
+
+    line = _provider_line(capsys.readouterr().out)
+    assert "nous" in line
+    assert "(auto)" not in line
+    assert "HERMES_INFERENCE_PROVIDER" in line
+
+
+def test_dump_provider_config_wins_over_env(monkeypatch, capsys, tmp_path):
+    """Guard rail: config.model.provider wins over HERMES_INFERENCE_PROVIDER
+    (resolve_requested_provider precedence). The env override must NOT shadow a
+    provider explicitly set in config.yaml."""
+    from hermes_cli import dump
+    from hermes_cli.config import get_hermes_home
+
+    monkeypatch.delenv("HERMES_INFERENCE_PROVIDER", raising=False)
+    monkeypatch.setattr(dump, "get_project_root", lambda: tmp_path / "noproject")
+
+    home = get_hermes_home()
+    _seed(
+        home,
+        config_yaml="model:\n  default: hermes-4-405b\n  provider: openrouter\n",
+        env_text="HERMES_INFERENCE_PROVIDER=nous\n",
+    )
+
+    dump.run_dump(SimpleNamespace(show_keys=False))
+
+    line = _provider_line(capsys.readouterr().out)
+    assert "openrouter" in line
+    assert "nous" not in line
+    assert "HERMES_INFERENCE_PROVIDER" not in line
 
 
 def test_dump_no_override_when_env_matches_config(monkeypatch, capsys, tmp_path):


### PR DESCRIPTION
## What does this PR do?

`hermes dump` prints `provider: (auto)` whenever `model.provider` is unset in
config.yaml — even when `HERMES_INFERENCE_PROVIDER` is set in `.env`/the shell
and the agent actually resolves to that provider. `run_dump()` already loads
`.env` into the environment, so the override is live at print time but never
consulted. This is the same support-triage failure the effective-terminal-backend
line (just above it) was added to fix: the diagnostic output lies about what's
actually running.

This mirrors `runtime_provider.resolve_requested_provider`'s precedence
(`explicit > config.model.provider > HERMES_INFERENCE_PROVIDER > auto`): when
config sets a provider we show it (config wins — note this is the opposite
direction from `TERMINAL_ENV`, which overrides config); only when config sets
none do we surface the `HERMES_INFERENCE_PROVIDER` override, annotated.

Before: `provider:         (auto)`  (while the agent runs `nous`)
After:  `provider:         nous  (HERMES_INFERENCE_PROVIDER, config sets none)`

## Related Issue

N/A — self-reported diagnostic regression found during code review; sibling to
the effective-terminal-backend reporting already on main.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/dump.py`: in `run_dump`, when `_get_model_and_provider` returns the
  `(auto)` sentinel (config sets no provider), surface a non-empty
  `HERMES_INFERENCE_PROVIDER` from the already-loaded environment, annotated. A
  provider explicitly set in config.yaml is left untouched (config wins).
- `tests/hermes_cli/test_dump_terminal_backend.py`: added
  `test_dump_surfaces_inference_provider_env_override` (env surfaced when config
  sets none) and `test_dump_provider_config_wins_over_env` (guard rail: config
  wins over env, so the fix can't invert precedence).

## How to Test

1. In `~/.hermes/config.yaml` set `model.default` but no `model.provider`; in
   `.env` set `HERMES_INFERENCE_PROVIDER=nous`.
2. Run `hermes dump` — the `provider:` line now reads
   `nous  (HERMES_INFERENCE_PROVIDER, config sets none)` instead of `(auto)`.
3. Add `model.provider: openrouter` to config.yaml and re-run — it reads
   `openrouter` (config wins; env does not shadow it).
4. `pytest tests/hermes_cli/test_dump_terminal_backend.py -q`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.x

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

> Audited siblings: the `terminal:` line already reports its effective value;
> `model:` is a literal config echo with no runtime override path. No widening
> needed beyond the `provider:` line.