### PR TITLE
fix(schema): preserve multi-type JSON Schema arrays as anyOf (port opencode#31877)

### DIFF
--- a/tests/tools/test_schema_sanitizer.py
+++ b/tests/tools/test_schema_sanitizer.py
@@ -80,6 +80,65 @@ def test_nullable_type_array_collapsed_to_single_string():
     assert prop.get("nullable") is True
 
 
+def test_multitype_array_becomes_anyof_no_branch_dropped():
+    # Ported from anomalyco/opencode#31877: a genuine multi-type array such as
+    # ["number", "string"] (common in MCP tool schemas) must keep BOTH branches
+    # as an anyOf, not silently drop all but the first. Several backends
+    # (llama.cpp, Gemini via OpenAI-compatible transports) reject the array form.
+    tools = [_tool("t", {
+        "type": "object",
+        "properties": {
+            "status": {"type": ["number", "string"], "description": "status filter"},
+        },
+    })]
+    out = sanitize_tool_schemas(tools)
+    prop = out[0]["function"]["parameters"]["properties"]["status"]
+    assert "type" not in prop
+    assert prop["anyOf"] == [{"type": "number"}, {"type": "string"}]
+    assert prop.get("nullable") is None
+    # Sibling keywords survive alongside the generated anyOf.
+    assert prop["description"] == "status filter"
+
+
+def test_multitype_array_with_null_lifts_nullable():
+    tools = [_tool("t", {
+        "type": "object",
+        "properties": {
+            "v": {"type": ["integer", "boolean", "null"]},
+        },
+    })]
+    out = sanitize_tool_schemas(tools)
+    prop = out[0]["function"]["parameters"]["properties"]["v"]
+    assert "type" not in prop
+    assert prop["anyOf"] == [{"type": "integer"}, {"type": "boolean"}]
+    assert prop.get("nullable") is True
+
+
+def test_all_null_type_array_becomes_null_type():
+    tools = [_tool("t", {
+        "type": "object",
+        "properties": {
+            "n": {"type": ["null"]},
+        },
+    })]
+    out = sanitize_tool_schemas(tools)
+    prop = out[0]["function"]["parameters"]["properties"]["n"]
+    assert prop["type"] == "null"
+
+
+def test_single_element_type_array_unwrapped():
+    tools = [_tool("t", {
+        "type": "object",
+        "properties": {
+            "s": {"type": ["string"]},
+        },
+    })]
+    out = sanitize_tool_schemas(tools)
+    prop = out[0]["function"]["parameters"]["properties"]["s"]
+    assert prop["type"] == "string"
+    assert prop.get("nullable") is None
+
+
 def test_anyof_nested_objects_sanitized():
     tools = [_tool("t", {
         "type": "object",

--- a/tools/schema_sanitizer.py
+++ b/tools/schema_sanitizer.py
@@ -235,7 +235,9 @@ def _sanitize_node(node: Any, path: str) -> Any:
       ``{"type": <value>}`` so downstream consumers see a dict.
     - Injects ``properties: {}`` into object-typed nodes missing it.
     - Normalizes ``type: [X, "null"]`` arrays to single ``type: X`` (keeping
-      ``nullable: true`` as a hint).
+      ``nullable: true`` as a hint), and multi-type arrays like
+      ``["number", "string"]`` to an ``anyOf`` of single-type schemas so no
+      branch is dropped (ported from anomalyco/opencode#31877).
     - Recurses into ``properties``, ``items``, ``additionalProperties``,
       ``anyOf``, ``oneOf``, ``allOf``, and ``$defs`` / ``definitions``.
     """
@@ -268,23 +270,39 @@ def _sanitize_node(node: Any, path: str) -> Any:
 
     out: dict = {}
     for key, value in node.items():
-        # type: [X, "null"] → type: X (the backend's tool-call parser only
-        # accepts singular string types; nullable is lost but the call still
-        # succeeds, and the model can still pass null on its own.)
+        # JSON Schema ``type`` arrays (e.g. ``["number", "string"]``, common
+        # in MCP tool schemas) are rejected by several tool-call backends:
+        #   * llama.cpp's grammar generator only accepts a singular string type.
+        #   * Gemini (including OpenAI-compatible transports such as GitHub
+        #     Copilot proxying to Gemini) rejects the array form outright —
+        #     plain @ai-sdk/google rewrites it, but the OpenAI-compatible path
+        #     forwards it verbatim and the backend 400s.
+        #
+        # Normalize per the SDK's behavior:
+        #   * single non-null type → ``type: X`` (+ ``nullable: true`` if the
+        #     array also contained "null"). No data lost.
+        #   * multiple non-null types → ``anyOf`` of single-type schemas, so
+        #     EVERY branch survives instead of silently dropping all but the
+        #     first. ``null`` is lifted into ``nullable: true``.
+        #   * all-null / empty → ``type: "null"`` (or object fallback).
+        # Ported from anomalyco/opencode#31877.
         if key == "type" and isinstance(value, list):
-            non_null = [t for t in value if t != "null"]
-            if len(non_null) == 1 and isinstance(non_null[0], str):
+            has_null = "null" in value
+            non_null = [t for t in value if isinstance(t, str) and t != "null"]
+            if len(non_null) == 1:
                 out["type"] = non_null[0]
-                if "null" in value:
+                if has_null:
                     out.setdefault("nullable", True)
                 continue
-            # Fallback: pick the first string type, drop the rest.
-            first_str = next((t for t in value if isinstance(t, str) and t != "null"), None)
-            if first_str:
-                out["type"] = first_str
+            if len(non_null) >= 2:
+                # Preserve all branches as a union instead of dropping them.
+                out["anyOf"] = [{"type": t} for t in non_null]
+                if has_null:
+                    out.setdefault("nullable", True)
                 continue
-            # All-null or empty list → treat as object.
-            out["type"] = "object"
+            # No usable non-null type: all-null array → type: "null";
+            # otherwise an empty/garbage array → object fallback.
+            out["type"] = "null" if has_null else "object"
             continue
 
         if key in {"properties", "$defs", "definitions"} and isinstance(value, dict):


### PR DESCRIPTION
## Summary
Multi-type JSON Schema `type` arrays (e.g. `["number","string"]`) now keep every branch as an `anyOf` instead of silently dropping all but the first. These arrays are common in MCP tool schemas, and several tool-call backends reject the array form — llama.cpp's grammar generator and Gemini via OpenAI-compatible transports (GitHub Copilot proxying to Gemini) return HTTP 400.

Ported from [anomalyco/opencode#31877](https://github.com/anomalyco/opencode/pull/31877). OpenCode's `@ai-sdk/google` rewrites these arrays automatically, but their OpenAI-compatible path forwarded them verbatim and the backend rejected them. Hermes already had a sanitizer that normalized `type` arrays, but it picked only the *first* non-null type and dropped the rest — lossy in exactly the multi-type case the OpenCode PR fixes.

## Changes
- `tools/schema_sanitizer.py` `_sanitize_node`: a `type` array now normalizes as
  - single non-null type → `type: X` (+ `nullable: true` if `null` was present) — unchanged
  - **≥2 non-null types → `anyOf` of single-type schemas** (+ `nullable: true` if `null` present) — new, no branch dropped
  - all-null → `type: "null"`; empty/garbage → object fallback
- `tests/tools/test_schema_sanitizer.py`: 4 new tests (multitype→anyOf, multitype+null→nullable, all-null, single-element array).

## Adaptation notes
- OpenCode applies this only on the Gemini provider transform. Hermes applies schema sanitization globally before tools go to any provider (`model_tools.py` → `sanitize_tool_schemas`), so the fix benefits llama.cpp, Gemini, and any other strict backend in one place.
- The generated `anyOf` always lands on a *nested* property (a `type` array can never be the root `type:"object"` schema), so it survives the downstream passes: `_strip_top_level_combinators` is top-level-only, and `strip_nullable_unions` only collapses unions with exactly one surviving non-null branch (multi-type has ≥2).

## Validation
| input `type` | before | after |
|---|---|---|
| `["number","string"]` | `{"type":"number"}` (string dropped) | `{"anyOf":[{number},{string}]}` |
| `["integer","boolean","null"]` | `{"type":"integer"}` (boolean dropped) | `{"anyOf":[{integer},{boolean}],"nullable":true}` |
| `["string","null"]` | `{"type":"string","nullable":true}` | unchanged |
| `["null"]` | `{"type":"object"}` | `{"type":"null"}` |

- `tests/tools/test_schema_sanitizer.py`: 47 passed (4 new).
- `tests/tools/test_mcp_tool.py` + `test_mcp_dynamic_discovery.py`: 210 passed.
- E2E via real `sanitize_tool_schemas` import: nested multitype arrays (object props + array `items`) preserved as `anyOf` through the full pipeline.

🤖 Weekly OpenCode PR scout — autonomous port.


## Infographic
![PR 48711 infographic](https://v3b.fal.media/files/b/0aa147a7/dPmQTJpWr7pjp-lvitAOM_MhaJebTY.png)
