### PR TITLE
fix(gemini): include thinking tokens in native Gemini output/reasoning accounting

### DIFF
--- a/agent/gemini_native_adapter.py
+++ b/agent/gemini_native_adapter.py
@@ -541,13 +541,23 @@ def translate_gemini_response(resp: Dict[str, Any], model: str) -> SimpleNamespa
 
     finish_reason = "tool_calls" if tool_calls else _map_gemini_finish_reason(str(cand.get("finishReason") or ""))
     usage_meta = resp.get("usageMetadata") or {}
+    # Gemini reports thinking-model tokens separately as ``thoughtsTokenCount``;
+    # ``candidatesTokenCount`` is visible-output only, and
+    # ``totalTokenCount == promptTokenCount + candidatesTokenCount + thoughtsTokenCount``.
+    # Hermes treats ``completion_tokens`` as reasoning-inclusive (OpenAI convention)
+    # and bills output tokens at the output rate, reading ``reasoning_tokens`` from
+    # ``output_tokens_details`` as a subset — so thoughts must be folded into
+    # completion and surfaced as reasoning, else output tokens/cost are undercounted
+    # and ``prompt + completion == total`` breaks for thinking models.
+    thoughts_tokens = int(usage_meta.get("thoughtsTokenCount") or 0)
     usage = SimpleNamespace(
         prompt_tokens=int(usage_meta.get("promptTokenCount") or 0),
-        completion_tokens=int(usage_meta.get("candidatesTokenCount") or 0),
+        completion_tokens=int(usage_meta.get("candidatesTokenCount") or 0) + thoughts_tokens,
         total_tokens=int(usage_meta.get("totalTokenCount") or 0),
         prompt_tokens_details=SimpleNamespace(
             cached_tokens=int(usage_meta.get("cachedContentTokenCount") or 0),
         ),
+        output_tokens_details=SimpleNamespace(reasoning_tokens=thoughts_tokens),
     )
     reasoning = "".join(reasoning_pieces) or None
     message = SimpleNamespace(
@@ -714,13 +724,17 @@ def translate_stream_event(event: Dict[str, Any], model: str, tool_call_indices:
         # non-streaming path in translate_gemini_response).
         usage_meta = event.get("usageMetadata") or {}
         if usage_meta:
+            # Fold ``thoughtsTokenCount`` into completion and surface it as
+            # reasoning, matching the non-streaming path above (see comment there).
+            thoughts_tokens = int(usage_meta.get("thoughtsTokenCount") or 0)
             finish_chunk.usage = SimpleNamespace(
                 prompt_tokens=int(usage_meta.get("promptTokenCount") or 0),
-                completion_tokens=int(usage_meta.get("candidatesTokenCount") or 0),
+                completion_tokens=int(usage_meta.get("candidatesTokenCount") or 0) + thoughts_tokens,
                 total_tokens=int(usage_meta.get("totalTokenCount") or 0),
                 prompt_tokens_details=SimpleNamespace(
                     cached_tokens=int(usage_meta.get("cachedContentTokenCount") or 0),
                 ),
+                output_tokens_details=SimpleNamespace(reasoning_tokens=thoughts_tokens),
             )
         chunks.append(finish_chunk)
     return chunks

--- a/tests/agent/test_gemini_native_adapter.py
+++ b/tests/agent/test_gemini_native_adapter.py
@@ -155,6 +155,69 @@ def test_translate_native_response_surfaces_reasoning_and_tool_calls():
     assert json.loads(choice.message.tool_calls[0].function.arguments) == {"q": "hermes"}
 
 
+def test_translate_native_response_includes_thoughts_tokens():
+    # Gemini thinking models report thinking tokens separately as
+    # ``thoughtsTokenCount``; ``candidatesTokenCount`` is visible-output only and
+    # ``totalTokenCount == prompt + candidates + thoughts``. The adapter must fold
+    # thoughts into reasoning-inclusive ``completion_tokens`` and surface them as
+    # ``output_tokens_details.reasoning_tokens``, else output tokens/cost are
+    # undercounted and ``prompt + completion == total`` breaks.
+    from agent.gemini_native_adapter import translate_gemini_response
+
+    payload = {
+        "candidates": [
+            {
+                "content": {
+                    "parts": [
+                        {"thought": True, "text": "thinking..."},
+                        {"text": "answer"},
+                    ]
+                },
+                "finishReason": "STOP",
+            }
+        ],
+        "usageMetadata": {
+            "promptTokenCount": 10,
+            "candidatesTokenCount": 20,
+            "thoughtsTokenCount": 100,
+            "totalTokenCount": 130,
+        },
+    }
+
+    usage = translate_gemini_response(payload, model="gemini-2.5-flash").usage
+    assert usage.completion_tokens == 120  # 20 visible + 100 thoughts
+    assert usage.output_tokens_details.reasoning_tokens == 100
+    # The adapter's own invariant holds again for thinking models.
+    assert usage.prompt_tokens + usage.completion_tokens == usage.total_tokens
+
+
+def test_stream_finish_chunk_includes_thoughts_tokens():
+    # The streaming finish-chunk usage must fold thoughts in identically to the
+    # non-streaming path so run_agent's streaming loop records the same counts.
+    from agent.gemini_native_adapter import translate_stream_event
+
+    event = {
+        "candidates": [
+            {
+                "content": {"parts": [{"text": "answer"}]},
+                "finishReason": "STOP",
+            }
+        ],
+        "usageMetadata": {
+            "promptTokenCount": 10,
+            "candidatesTokenCount": 20,
+            "thoughtsTokenCount": 100,
+            "totalTokenCount": 130,
+        },
+    }
+
+    chunks = translate_stream_event(event, model="gemini-2.5-flash", tool_call_indices={})
+    finish_usage = chunks[-1].usage
+    assert finish_usage.completion_tokens == 120
+    assert finish_usage.output_tokens_details.reasoning_tokens == 100
+    assert finish_usage.prompt_tokens + finish_usage.completion_tokens == finish_usage.total_tokens
+
+
 def test_native_client_uses_x_goog_api_key_and_native_models_endpoint(monkeypatch):
     from agent.gemini_native_adapter import GeminiNativeClient
 


### PR DESCRIPTION
## What does this PR do?

The native Gemini adapter sets `completion_tokens = candidatesTokenCount` and
never reads `thoughtsTokenCount` — at both the non-streaming translate site
(`translate_gemini_response`) and the streaming finish-chunk site
(`translate_stream_event`). For thinking models, Gemini reports thinking tokens
separately (`totalTokenCount = prompt + candidates + thoughts`), so the current
code undercounts output tokens by the entire thinking budget, leaves
`reasoning_tokens` permanently 0, under-reports cost (Hermes bills `output_tokens`
at the output rate, and Google charges thoughts at the output rate), and breaks
the adapter's own `prompt + completion == total` invariant.

This folds `thoughtsTokenCount` into `completion_tokens` and surfaces it as
`output_tokens_details.reasoning_tokens` at both sites, matching Hermes's
reasoning-inclusive `completion_tokens` convention — `usage_pricing` already reads
`output_tokens_details.reasoning_tokens` as a subset for OpenAI-shaped usage, so
this is purely additive downstream.

Before: `usageMetadata{candidates:20, thoughts:100, total:130}` → completion_tokens=20, reasoning=0, prompt+completion(30) != total(130)
After:  → completion_tokens=120, reasoning=100, prompt+completion(130) == total(130)

## Related Issue

N/A — self-reported accounting regression found during code review.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/gemini_native_adapter.py`: read `thoughtsTokenCount`, add it to
  `completion_tokens`, and surface it as `output_tokens_details.reasoning_tokens`
  at both the non-streaming and streaming usage sites.
- `tests/agent/test_gemini_native_adapter.py`: added
  `test_translate_native_response_includes_thoughts_tokens` and
  `test_stream_finish_chunk_includes_thoughts_tokens`, each asserting
  `completion_tokens` includes thoughts, `reasoning_tokens` is surfaced, and the
  `prompt + completion == total` invariant holds.

## How to Test

1. `pytest tests/agent/test_gemini_native_adapter.py -q` — the two new tests fail
   on `main` (completion_tokens=20, `output_tokens_details` missing) and pass
   with this change.
2. `pytest tests/agent/test_usage_pricing.py -q` — confirms downstream pricing
   still reads `reasoning_tokens` cleanly.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.x

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

> Sibling code path that may need the same fix: `agent/gemini_cloudcode_adapter.py`
> (the gemini-cloudcode adapter has the identical `candidatesTokenCount`-only usage
> at its translate site). Intentionally left out of this PR to keep the diff to the
> native adapter and one test file — happy to widen if preferred.