### PR TITLE
fix(cron): interpret naive one-shot timestamps in the configured timezone

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -345,7 +345,15 @@ def parse_schedule(schedule: str) -> Dict[str, Any]:
             # Make naive timestamps timezone-aware at parse time so the stored
             # value doesn't depend on the system timezone matching at check time.
             if dt.tzinfo is None:
-                dt = dt.astimezone()  # Interpret as local timezone
+                # Interpret a bare wall-clock in the user's configured Hermes
+                # timezone (HERMES_TIMEZONE / config `timezone:`), not the server
+                # process's local zone. A bare datetime.astimezone() attaches the
+                # server tz, so a one-shot scheduled as e.g. "2026-07-01T09:00" on
+                # a UTC container with `timezone: Asia/Kolkata` would fire at the
+                # wrong wall-clock hour. _hermes_now().tzinfo is the configured zone,
+                # falling back to server-local when none is set (so single-zone
+                # deployments are unchanged).
+                dt = dt.replace(tzinfo=_hermes_now().tzinfo)
             return {
                 "kind": "once",
                 "run_at": dt.isoformat(),

--- a/tests/cron/test_jobs.py
+++ b/tests/cron/test_jobs.py
@@ -101,6 +101,25 @@ class TestParseSchedule:
         assert result["kind"] == "once"
         assert "2030-01-15" in result["run_at"]
 
+    def test_naive_iso_timestamp_uses_hermes_timezone(self, monkeypatch):
+        # A naive one-shot wall-clock must be interpreted in the configured
+        # HERMES_TIMEZONE, not the server process's local zone. Pinning the env
+        # var makes this deterministic regardless of the CI runner's tz.
+        import hermes_time
+
+        monkeypatch.setenv("HERMES_TIMEZONE", "Asia/Kolkata")
+        hermes_time.reset_cache()
+        try:
+            result = parse_schedule("2026-07-01T09:00:00")
+            dt = datetime.fromisoformat(result["run_at"])
+            # Wall clock is preserved as 09:00 *in IST* (not shifted), and the
+            # stored offset is IST (+05:30), so the encoded instant is correct.
+            assert dt.hour == 9 and dt.minute == 0
+            assert dt.utcoffset() == timedelta(hours=5, minutes=30)
+        finally:
+            monkeypatch.delenv("HERMES_TIMEZONE", raising=False)
+            hermes_time.reset_cache()
+
     def test_invalid_schedule_raises(self):
         with pytest.raises(ValueError):
             parse_schedule("not_a_schedule")


### PR DESCRIPTION
## What does this PR do?

`parse_schedule` makes a naive one-shot timestamp (e.g. `2026-07-01T09:00`)
timezone-aware with a bare `datetime.astimezone()`, which attaches the **server
process's** local timezone instead of the user's configured `HERMES_TIMEZONE` /
config `timezone:`. In the common Docker/VPS case (container in UTC, user
configured a real zone) a one-shot cron created with a bare wall-clock encodes
the wrong instant and fires at the wrong hour — off by the full server↔user
offset (up to ~13h), silently.

This attaches the configured Hermes timezone (`_hermes_now().tzinfo`) instead.
When no zone is configured this equals the server-local tz, so single-zone
deployments are unchanged (the existing tz-agnostic `test_iso_timestamp` still
passes).

Before (server UTC, `timezone: Asia/Kolkata`): `2026-07-01T09:00` stored as
`09:00+00:00` → fires 14:30 IST.
After: stored as `09:00+05:30` → fires 09:00 IST as the user intended.

## Related Issue

N/A — self-reported scheduling regression found during code review.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `cron/jobs.py`: in `parse_schedule`'s ISO-timestamp branch, make a naive
  datetime aware with `dt.replace(tzinfo=_hermes_now().tzinfo)` (the configured
  Hermes zone) instead of a bare `dt.astimezone()` (server-local zone).
- `tests/cron/test_jobs.py`: added
  `test_naive_iso_timestamp_uses_hermes_timezone`, which pins `HERMES_TIMEZONE`
  (deterministic on any CI runner tz) and asserts the stored offset is the
  configured zone's, not the runner's.

## How to Test

1. `pytest tests/cron/test_jobs.py::TestParseSchedule -q`. The new test fails on
   `main` (offset is the runner's local zone) and passes with this change; the
   existing `test_iso_timestamp` continues to pass.
2. Manually: set `timezone: Asia/Kolkata` in config on a UTC host, create a
   one-shot `cron` with `2026-07-01T09:00` — `run_at` is now `09:00+05:30`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.x

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

> Audited siblings: interval and cron-expression schedules already resolve against
> the configured zone via `_hermes_now()`; only the naive one-shot branch regressed
> to server-local. No widening needed.