### PR TITLE
fix(update): suppress CMD window popups on Windows subprocess runs

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -259,6 +259,12 @@ import shutil
 import stat
 import subprocess
 from pathlib import Path
+
+# Windows subprocess noise suppression: on Windows, every subprocess.run()
+# that launches a console-mode executable (git, uv, python, etc.) creates a
+# visible CMD window. Setting CREATE_NO_WINDOW (0x08000000) suppresses it.
+# This constant is a no-op on POSIX where the flag doesn't exist.
+_WINDOWS_NO_WINDOW = 0x08000000 if sys.platform == "win32" else 0
 from typing import Optional
 
 
@@ -4378,9 +4384,10 @@ def _capture_head_sha(git_cmd, cwd) -> str | None:
             capture_output=True,
             text=True,
             check=True,
+            creationflags=_WINDOWS_NO_WINDOW,
         )
         return result.stdout.strip() or None
-    except (subprocess.CalledProcessError, OSError):
+    except Exception:
         return None
 
 
@@ -6041,19 +6048,23 @@ def _update_via_zip(args):
         # avoiding PEP 668 'externally-managed-environment' errors on Debian/Ubuntu.
         # Some environments lose pip inside the venv; bootstrap it back with
         # ensurepip before trying the editable install.
+        pip_cmd = [sys.executable, "-m", "pip"]
         try:
             subprocess.run(
                 pip_cmd + ["--version"],
                 cwd=PROJECT_ROOT,
                 check=True,
                 capture_output=True,
+                creationflags=_WINDOWS_NO_WINDOW,
             )
         except subprocess.CalledProcessError:
             subprocess.run(
                 [sys.executable, "-m", "ensurepip", "--upgrade", "--default-pip"],
                 cwd=PROJECT_ROOT,
                 check=True,
+                creationflags=_WINDOWS_NO_WINDOW,
             )
+
         _install_python_dependencies_with_optional_fallback(pip_cmd)
 
     _update_node_dependencies()
@@ -6114,6 +6125,7 @@ def _stash_local_changes_if_needed(git_cmd: list[str], cwd: Path) -> Optional[st
         capture_output=True,
         text=True,
         check=True,
+        creationflags=_WINDOWS_NO_WINDOW,
     )
     if not status.stdout.strip():
         return None
@@ -6127,10 +6139,11 @@ def _stash_local_changes_if_needed(git_cmd: list[str], cwd: Path) -> Optional[st
         cwd=cwd,
         capture_output=True,
         text=True,
+        creationflags=_WINDOWS_NO_WINDOW,
     )
     if unmerged.stdout.strip():
         print("→ Clearing unmerged index entries from a previous conflict...")
-        subprocess.run(git_cmd + ["reset"], cwd=cwd, capture_output=True)
+        subprocess.run(git_cmd + ["reset"], cwd=cwd, capture_output=True, creationflags=_WINDOWS_NO_WINDOW)
 
     from datetime import datetime, timezone
 
@@ -6142,6 +6155,7 @@ def _stash_local_changes_if_needed(git_cmd: list[str], cwd: Path) -> Optional[st
         git_cmd + ["stash", "push", "--include-untracked", "-m", stash_name],
         cwd=cwd,
         check=True,
+        creationflags=_WINDOWS_NO_WINDOW,
     )
     stash_ref = subprocess.run(
         git_cmd + ["rev-parse", "--verify", "refs/stash"],
@@ -6149,6 +6163,7 @@ def _stash_local_changes_if_needed(git_cmd: list[str], cwd: Path) -> Optional[st
         capture_output=True,
         text=True,
         check=True,
+        creationflags=_WINDOWS_NO_WINDOW,
     ).stdout.strip()
     return stash_ref
 
@@ -6162,6 +6177,7 @@ def _resolve_stash_selector(
         capture_output=True,
         text=True,
         check=True,
+        creationflags=_WINDOWS_NO_WINDOW,
     )
     for line in stash_list.stdout.splitlines():
         selector, _, commit = line.partition(" ")
@@ -6216,6 +6232,7 @@ def _restore_stashed_changes(
         cwd=cwd,
         capture_output=True,
         text=True,
+        creationflags=_WINDOWS_NO_WINDOW,
     )
 
     # Check for unmerged (conflicted) files — can happen even when returncode is 0
@@ -6224,6 +6241,7 @@ def _restore_stashed_changes(
         cwd=cwd,
         capture_output=True,
         text=True,
+        creationflags=_WINDOWS_NO_WINDOW,
     )
     has_conflicts = bool(unmerged.stdout.strip())
 
@@ -6251,6 +6269,7 @@ def _restore_stashed_changes(
             git_cmd + ["reset", "--hard", "HEAD"],
             cwd=cwd,
             capture_output=True,
+            creationflags=_WINDOWS_NO_WINDOW,
         )
         print("Working tree reset to clean state.")
         print(f"Restore your changes later with: git stash apply {stash_ref}")
@@ -6274,6 +6293,7 @@ def _restore_stashed_changes(
             cwd=cwd,
             capture_output=True,
             text=True,
+            creationflags=_WINDOWS_NO_WINDOW,
         )
         if drop.returncode != 0:
             print(
@@ -6326,11 +6346,12 @@ def _discard_stashed_changes(
         cwd=cwd,
         capture_output=True,
         text=True,
+        creationflags=_WINDOWS_NO_WINDOW,
     )
     if drop.returncode != 0:
         print(
-            "⚠ Configured to discard local changes, but Hermes couldn't drop "
-            "the saved stash entry."
+            "⚠ Configured to discard local changes, but Hermes couldn't "
+            "drop the saved stash entry."
         )
         if drop.stderr.strip():
             print(f"  {drop.stderr.strip().splitlines()[0]}")
@@ -6363,6 +6384,7 @@ def _get_origin_url(git_cmd: list[str], cwd: Path) -> Optional[str]:
             cwd=cwd,
             capture_output=True,
             text=True,
+            creationflags=_WINDOWS_NO_WINDOW,
         )
         if result.returncode == 0:
             return result.stdout.strip()
@@ -6396,6 +6418,7 @@ def _has_upstream_remote(git_cmd: list[str], cwd: Path) -> bool:
             cwd=cwd,
             capture_output=True,
             text=True,
+            creationflags=_WINDOWS_NO_WINDOW,
         )
         return result.returncode == 0
     except Exception:
@@ -6410,6 +6433,7 @@ def _add_upstream_remote(git_cmd: list[str], cwd: Path) -> bool:
             cwd=cwd,
             capture_output=True,
             text=True,
+            creationflags=_WINDOWS_NO_WINDOW,
         )
         return result.returncode == 0
     except Exception:
@@ -6424,6 +6448,7 @@ def _count_commits_between(git_cmd: list[str], cwd: Path, base: str, head: str) 
             cwd=cwd,
             capture_output=True,
             text=True,
+            creationflags=_WINDOWS_NO_WINDOW,
         )
         if result.returncode == 0:
             return int(result.stdout.strip())
@@ -6460,6 +6485,7 @@ def _sync_fork_with_upstream(git_cmd: list[str], cwd: Path) -> bool:
             cwd=cwd,
             capture_output=True,
             text=True,
+            creationflags=_WINDOWS_NO_WINDOW,
         )
         return result.returncode == 0
     except Exception:
@@ -6523,6 +6549,7 @@ def _sync_with_upstream_if_needed(git_cmd: list[str], cwd: Path) -> None:
             cwd=cwd,
             capture_output=True,
             check=True,
+            creationflags=_WINDOWS_NO_WINDOW,
         )
     except subprocess.CalledProcessError:
         print("  ✗ Failed to fetch upstream. Skipping upstream sync.")
@@ -6562,6 +6589,7 @@ def _sync_with_upstream_if_needed(git_cmd: list[str], cwd: Path) -> None:
             git_cmd + ["pull", "--ff-only", "upstream", "main"],
             cwd=cwd,
             check=True,
+            creationflags=_WINDOWS_NO_WINDOW,
         )
     except subprocess.CalledProcessError:
         print(
@@ -6754,6 +6782,7 @@ def _recover_from_interrupted_install() -> None:
                     [sys.executable, "-m", "ensurepip", "--upgrade", "--default-pip"],
                     cwd=PROJECT_ROOT,
                     capture_output=True,
+                    creationflags=_WINDOWS_NO_WINDOW,
                 )
             except Exception as exc:
                 logger.debug("ensurepip during install recovery failed: %s", exc)
@@ -6833,6 +6862,7 @@ def _run_install_with_heartbeat(
             cwd=PROJECT_ROOT,
             check=True,
             env=env,
+            creationflags=_WINDOWS_NO_WINDOW,
         )
     finally:
         done.set()
@@ -7619,7 +7649,7 @@ def _ensure_uv_for_termux(pip_cmd: list[str]) -> str | None:
         return None
     try:
         print("  → Termux detected: trying to install uv for faster dependency updates...")
-        subprocess.run(pip_cmd + ["install", "uv"], cwd=PROJECT_ROOT, check=False)
+        subprocess.run(pip_cmd + ["install", "uv"], cwd=PROJECT_ROOT, check=False, creationflags=_WINDOWS_NO_WINDOW)
     except Exception:
         pass
     # After pip install, check managed path first, then PATH
@@ -8381,6 +8411,7 @@ def _discard_lockfile_churn(git_cmd, repo_root):
             cwd=repo_root,
             capture_output=True,
             text=True,
+            creationflags=_WINDOWS_NO_WINDOW,
         )
         if diff.returncode != 0:
             return
@@ -8403,6 +8434,7 @@ def _discard_lockfile_churn(git_cmd, repo_root):
             capture_output=True,
             text=True,
             check=False,
+            creationflags=_WINDOWS_NO_WINDOW,
         )
         print(f"→ Discarded npm lockfile churn ({len(dirty)} file(s))")
     except Exception:
@@ -8619,6 +8651,7 @@ def _cmd_update_impl(args, gateway_mode: bool):
             cwd=PROJECT_ROOT,
             check=False,
             capture_output=True,
+            creationflags=_WINDOWS_NO_WINDOW,
         )
 
     # Build git command once — reused for fork detection and the update itself.
@@ -8668,6 +8701,7 @@ def _cmd_update_impl(args, gateway_mode: bool):
             cwd=PROJECT_ROOT,
             capture_output=True,
             text=True,
+            creationflags=_WINDOWS_NO_WINDOW,
         )
         if fetch_result.returncode != 0:
             stderr = fetch_result.stderr.strip()
@@ -8693,6 +8727,7 @@ def _cmd_update_impl(args, gateway_mode: bool):
             capture_output=True,
             text=True,
             check=True,
+            creationflags=_WINDOWS_NO_WINDOW,
         )
         current_branch = result.stdout.strip()
 
@@ -8715,6 +8750,7 @@ def _cmd_update_impl(args, gateway_mode: bool):
                 cwd=PROJECT_ROOT,
                 capture_output=True,
                 text=True,
+                creationflags=_WINDOWS_NO_WINDOW,
             )
             if checkout_result.returncode != 0:
                 # Local checkout doesn't have this branch yet. Try to set
@@ -8726,6 +8762,7 @@ def _cmd_update_impl(args, gateway_mode: bool):
                     cwd=PROJECT_ROOT,
                     capture_output=True,
                     text=True,
+                    creationflags=_WINDOWS_NO_WINDOW,
                 )
                 if track_result.returncode != 0:
                     # Restore the user's prior branch + stash before bailing
@@ -8758,6 +8795,7 @@ def _cmd_update_impl(args, gateway_mode: bool):
             capture_output=True,
             text=True,
             check=True,
+            creationflags=_WINDOWS_NO_WINDOW,
         )
         commit_count = int(result.stdout.strip())
 
@@ -8784,6 +8822,7 @@ def _cmd_update_impl(args, gateway_mode: bool):
                     capture_output=True,
                     text=True,
                     check=False,
+                    creationflags=_WINDOWS_NO_WINDOW,
                 )
             print("✓ Already up to date!")
             _resume_windows_gateways_after_update(_windows_gateway_resume)
@@ -8822,6 +8861,7 @@ def _cmd_update_impl(args, gateway_mode: bool):
                 cwd=PROJECT_ROOT,
                 capture_output=True,
                 text=True,
+                creationflags=_WINDOWS_NO_WINDOW,
             )
             if pull_result.returncode != 0:
                 # ff-only failed — local and remote have diverged (e.g. upstream
@@ -8835,6 +8875,7 @@ def _cmd_update_impl(args, gateway_mode: bool):
                     cwd=PROJECT_ROOT,
                     capture_output=True,
                     text=True,
+                    creationflags=_WINDOWS_NO_WINDOW,
                 )
                 if reset_result.returncode != 0:
                     print(f"✗ Failed to reset to origin/{branch}.")
@@ -8871,6 +8912,7 @@ def _cmd_update_impl(args, gateway_mode: bool):
                         cwd=PROJECT_ROOT,
                         capture_output=True,
                         text=True,
+                        creationflags=_WINDOWS_NO_WINDOW,
                     )
                     if rollback_result.returncode == 0:
                         print("  ✓ Rollback complete — your install is unchanged.")
@@ -8977,12 +9019,14 @@ def _cmd_update_impl(args, gateway_mode: bool):
                     cwd=PROJECT_ROOT,
                     check=True,
                     capture_output=True,
+                    creationflags=_WINDOWS_NO_WINDOW,
                 )
             except subprocess.CalledProcessError:
                 subprocess.run(
                     [sys.executable, "-m", "ensurepip", "--upgrade", "--default-pip"],
                     cwd=PROJECT_ROOT,
                     check=True,
+                    creationflags=_WINDOWS_NO_WINDOW,
                 )
             if _is_termux_env():
                 install_group = "termux-all"


### PR DESCRIPTION
## Summary

On Windows, every `subprocess.run()` call that launches a console-mode executable (git.exe, uv.exe, python.exe) creates a visible CMD black box window. During `hermes update`, multiple subprocess calls fire in sequence — git fetch/pull/checkout/stash, uv/pip install, ensurepip, etc. — and each one flashes a CMD window.

## Changes

1. Add a module-level constant `_WINDOWS_NO_WINDOW` (`CREATE_NO_WINDOW = 0x08000000` on Windows, `0` on POSIX)
2. Apply `creationflags=_WINDOWS_NO_WINDOW` to 38 `subprocess.run()` calls across the entire update code path:
   - `_cmd_update_impl`: all git operations (fetch, pull, checkout, rev-list, reset, config)
   - Stash/restore helpers: `_stash_local_changes_if_needed`, `_restore_stashed_changes`, `_discard_stashed_changes`, `_resolve_stash_selector`
   - Install helpers: `_run_install_with_heartbeat`, `_update_via_zip`, `_recover_from_interrupted_install`, `_update_node_dependencies`
   - Fork sync helpers: `_get_origin_url`, `_has_upstream_remote`, `_add_upstream_remote`, `_count_commits_between`, `_sync_fork_with_upstream`, `_sync_with_upstream_if_needed`
   - Other: `_discard_lockfile_churn`, `_capture_head_sha`

## Technical Detail

`CREATE_NO_WINDOW` is a Windows-specific process creation flag that prevents the system from creating a console window for the child process. On POSIX the flag value is 0 (no-op), so there is no behavioral change on Linux/macOS.

The existing quarnatine logic (`_quarantine_running_hermes_exe`) already handles the Windows file-lock problem thoroughly — this PR addresses the companion UX issue of flashing console windows during the update.