### PR TITLE
fix(hindsight): persist embed_model config across daemon restarts

### DIFF
--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -488,6 +488,11 @@ def _build_embedded_profile_env(config: dict[str, Any], *, llm_api_key: str | No
         env_values["HINDSIGHT_EMBED_DAEMON_IDLE_TIMEOUT"] = str(
             _parse_int_setting(idle_timeout, _DEFAULT_IDLE_TIMEOUT)
         )
+
+    embed_model = config.get("embed_model") or os.environ.get("HINDSIGHT_API_EMBEDDINGS_LOCAL_MODEL")
+    if embed_model:
+        env_values["HINDSIGHT_API_EMBEDDINGS_LOCAL_MODEL"] = str(embed_model)
+
     return env_values
 
 


### PR DESCRIPTION
## Problem

When using a non-default embedding model (e.g. `BAAI/bge-m3`, 1024 dimensions), the Hindsight embedded daemon fails to start after a restart with:

```
RuntimeError: Cannot change embedding dimension from 1024 to 384:
memory_units table contains N rows with embeddings.
```

**Root cause:** `_materialize_embedded_profile_env()` fully overwrites the profile env file on every daemon restart, but `_build_embedded_profile_env()` only writes LLM-related keys. `HINDSIGHT_API_EMBEDDINGS_LOCAL_MODEL` is never included, so the daemon falls back to the default model (`BAAI/bge-small-en-v1.5`, 384 dim), causing a dimension mismatch with the existing database.

## Fix

Read `embed_model` from the Hindsight config dict (or the `HINDSIGHT_API_EMBEDDINGS_LOCAL_MODEL` env var) and include it in the generated env file.

**5 lines added** to `_build_embedded_profile_env()` in `plugins/memory/hindsight/__init__.py`.

## Usage

Users can configure the embed model via:

```json
// ~/.hermes/hindsight/config.json
{
  "embed_model": "BAAI/bge-m3"
}
```

Or via environment variable: `HINDSIGHT_API_EMBEDDINGS_LOCAL_MODEL=BAAI/bge-m3`