### PR TITLE
fix(cron): make cron jobs and skills profile-aware (#48649)

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -45,25 +45,42 @@ except ImportError:
     HAS_CRONITER = False
 
 # =============================================================================
-# Configuration
+# Configuration — paths resolved dynamically at call time so profiles work.
 # =============================================================================
 
+def _get_hermes_dir() -> Path:
+    """Return the Hermes home directory, resolved dynamically for profile support."""
+    return get_hermes_home().resolve()
+
+def _get_cron_dir() -> Path:
+    """Return the cron directory, resolved dynamically for profile support."""
+    return _get_hermes_dir() / "cron"
+
+def _get_jobs_file() -> Path:
+    """Return the jobs.json path, resolved dynamically for profile support."""
+    return _get_cron_dir() / "jobs.json"
+
+def _get_output_dir() -> Path:
+    """Return the output directory, resolved dynamically for profile support."""
+    return _get_cron_dir() / "output"
+
+# Legacy constants for backward compatibility (deprecated — use functions above).
 HERMES_DIR = get_hermes_home().resolve()
 CRON_DIR = HERMES_DIR / "cron"
 JOBS_FILE = CRON_DIR / "jobs.json"
+OUTPUT_DIR = CRON_DIR / "output"
 
 # In-process lock protecting load_jobs→modify→save_jobs cycles.
 # Required when tick() runs jobs in parallel threads — without this,
 # concurrent mark_job_run / advance_next_run calls can clobber each other.
 _jobs_file_lock = threading.RLock()
 _jobs_lock_state = threading.local()
-OUTPUT_DIR = CRON_DIR / "output"
 ONESHOT_GRACE_SECONDS = 120
 
 
 def _jobs_lock_file() -> Path:
     """Return the advisory lock path for the current cron directory."""
-    return CRON_DIR / ".jobs.lock"
+    return _get_cron_dir() / ".jobs.lock"
 
 
 @contextlib.contextmanager
@@ -148,7 +165,7 @@ def _job_output_dir(job_id: str) -> Path:
         raise ValueError(f"Invalid cron job id for output path: {job_id!r}")
     if Path(text).is_absolute() or Path(text).drive:
         raise ValueError(f"Invalid cron job id for output path: {job_id!r}")
-    return OUTPUT_DIR / text
+    return _get_output_dir() / text
 
 
 def _normalize_skill_list(skill: Optional[str] = None, skills: Optional[Any] = None) -> List[str]:
@@ -255,10 +272,12 @@ def _secure_file(path: Path):
 
 def ensure_dirs():
     """Ensure cron directories exist with secure permissions."""
-    CRON_DIR.mkdir(parents=True, exist_ok=True)
-    OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
-    _secure_dir(CRON_DIR)
-    _secure_dir(OUTPUT_DIR)
+    cron_dir = _get_cron_dir()
+    output_dir = _get_output_dir()
+    cron_dir.mkdir(parents=True, exist_ok=True)
+    output_dir.mkdir(parents=True, exist_ok=True)
+    _secure_dir(cron_dir)
+    _secure_dir(output_dir)
 
 
 # =============================================================================
@@ -506,19 +525,20 @@ def compute_next_run(schedule: Dict[str, Any], last_run_at: Optional[str] = None
 def load_jobs() -> List[Dict[str, Any]]:
     """Load all jobs from storage."""
     ensure_dirs()
-    if not JOBS_FILE.exists():
+    jobs_file = _get_jobs_file()
+    if not jobs_file.exists():
         return []
 
     _strict_retry = False  # track whether we used the strict=False fallback
 
     try:
-        with open(JOBS_FILE, 'r', encoding='utf-8') as f:
+        with open(jobs_file, 'r', encoding='utf-8') as f:
             data = json.load(f)
     except json.JSONDecodeError:
         # Retry with strict=False to handle bare control chars in string values
         _strict_retry = True
         try:
-            with open(JOBS_FILE, 'r', encoding='utf-8') as f:
+            with open(jobs_file, 'r', encoding='utf-8') as f:
                 data = json.loads(f.read(), strict=False)
         except Exception as e:
             logger.error("Failed to auto-repair jobs.json: %s", e)
@@ -554,14 +574,15 @@ def load_jobs() -> List[Dict[str, Any]]:
 def _save_jobs_unlocked(jobs: List[Dict[str, Any]]):
     """Save all jobs to storage. Caller must hold _jobs_lock()."""
     ensure_dirs()
-    fd, tmp_path = tempfile.mkstemp(dir=str(JOBS_FILE.parent), suffix='.tmp', prefix='.jobs_')
+    jobs_file = _get_jobs_file()
+    fd, tmp_path = tempfile.mkstemp(dir=str(jobs_file.parent), suffix='.tmp', prefix='.jobs_')
     try:
         with os.fdopen(fd, 'w', encoding='utf-8') as f:
             json.dump({"jobs": jobs, "updated_at": _hermes_now().isoformat()}, f, indent=2)
             f.flush()
             os.fsync(f.fileno())
-        atomic_replace(tmp_path, JOBS_FILE)
-        _secure_file(JOBS_FILE)
+        atomic_replace(tmp_path, jobs_file)
+        _secure_file(jobs_file)
     except BaseException:
         try:
             os.unlink(tmp_path)

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -1083,7 +1083,7 @@ def _build_job_prompt(job: dict, prerun_script: Optional[tuple] = None) -> str:
     # Inject output from referenced cron jobs as context.
     context_from = job.get("context_from")
     if context_from:
-        from cron.jobs import OUTPUT_DIR
+        from cron.jobs import _get_output_dir
         if isinstance(context_from, str):
             context_from = [context_from]
         for source_job_id in context_from:
@@ -1098,7 +1098,7 @@ def _build_job_prompt(job: dict, prerun_script: Optional[tuple] = None) -> str:
                 )
                 continue
             try:
-                job_output_dir = OUTPUT_DIR / source_job_id
+                job_output_dir = _get_output_dir() / source_job_id
                 if not job_output_dir.exists():
                     continue  # silent skip — no output yet
                 output_files = sorted(

--- a/tests/tools/test_skill_view_traversal.py
+++ b/tests/tools/test_skill_view_traversal.py
@@ -27,9 +27,9 @@ def fake_skills(tmp_path):
     (refs / "api.md").write_text("API docs here")
 
     # Create a sensitive file outside skills dir (simulating .env)
-    (tmp_path / ".env").write_text("SECRET_API_KEY=sk-do-not-leak")
+    (tmp_path / ".env").write_text("SECRET_API_KEY=***")
 
-    with patch("tools.skills_tool.SKILLS_DIR", skills_dir):
+    with patch("tools.skills_tool.get_hermes_home", return_value=tmp_path):
         yield {"skills_dir": skills_dir, "skill_dir": skill_dir, "tmp_path": tmp_path}
 
 

--- a/tools/skills_tool.py
+++ b/tools/skills_tool.py
@@ -91,6 +91,12 @@ logger = logging.getLogger(__name__)
 # This is the single source of truth -- agent edits, hub installs, and bundled
 # skills all coexist here without polluting the git repo.
 HERMES_HOME = get_hermes_home()
+
+def _get_skills_dir() -> Path:
+    """Return the skills directory, resolved dynamically for profile support."""
+    return get_hermes_home() / "skills"
+
+# Legacy constant for backward compatibility (deprecated — use _get_skills_dir()).
 SKILLS_DIR = HERMES_HOME / "skills"
 
 # Anthropic-recommended limits for progressive disclosure efficiency
@@ -499,9 +505,9 @@ def _get_category_from_path(skill_path: Path) -> Optional[str]:
     For paths like: ~/.hermes/skills/mlops/axolotl/SKILL.md -> "mlops"
     Also works for external skill dirs configured via skills.external_dirs.
     """
-    # Try the module-level SKILLS_DIR first (respects monkeypatching in tests),
-    # then fall back to external dirs from config.
-    dirs_to_check = [SKILLS_DIR]
+    # Use dynamic skills directory for profile support.
+    # Fall back to external dirs from config.
+    dirs_to_check = [_get_skills_dir()]
     try:
         from agent.skill_utils import get_external_skills_dirs
         dirs_to_check.extend(get_external_skills_dirs())
@@ -620,8 +626,9 @@ def _find_all_skills(*, skip_disabled: bool = False) -> List[Dict[str, Any]]:
 
     # Scan local dir first, then external dirs (local takes precedence)
     dirs_to_scan = []
-    if SKILLS_DIR.exists():
-        dirs_to_scan.append(SKILLS_DIR)
+    skills_dir = _get_skills_dir()
+    if skills_dir.exists():
+        dirs_to_scan.append(skills_dir)
     dirs_to_scan.extend(get_external_skills_dirs())
 
     for scan_dir in dirs_to_scan:
@@ -699,8 +706,9 @@ def skills_list(category: str = None, task_id: str = None) -> str:
         JSON string with minimal skill info: name, description, category
     """
     try:
-        if not SKILLS_DIR.exists():
-            SKILLS_DIR.mkdir(parents=True, exist_ok=True)
+        skills_dir = _get_skills_dir()
+        if not skills_dir.exists():
+            skills_dir.mkdir(parents=True, exist_ok=True)
             return json.dumps(
                 {
                     "success": True,
@@ -982,8 +990,9 @@ def skill_view(
 
         # Build list of all skill directories to search
         all_dirs = []
-        if SKILLS_DIR.exists():
-            all_dirs.append(SKILLS_DIR)
+        skills_dir = _get_skills_dir()
+        if skills_dir.exists():
+            all_dirs.append(skills_dir)
         all_dirs.extend(get_external_skills_dirs())
 
         if not all_dirs:
@@ -1133,7 +1142,7 @@ def skill_view(
         # Security: warn if skill is loaded from outside trusted directories
         # (local skills dir + configured external_dirs are all trusted)
         _outside_skills_dir = True
-        _trusted_dirs = [SKILLS_DIR.resolve()]
+        _trusted_dirs = [_get_skills_dir().resolve()]
         try:
             _trusted_dirs.extend(d.resolve() for d in all_dirs[1:])
         except Exception:
@@ -1362,7 +1371,7 @@ def skill_view(
             linked_files["scripts"] = script_files
 
         try:
-            rel_path = str(skill_md.relative_to(SKILLS_DIR))
+            rel_path = str(skill_md.relative_to(_get_skills_dir()))
         except ValueError:
             # External skill — use path relative to the skill's own parent dir
             rel_path = str(skill_md.relative_to(skill_md.parent.parent)) if skill_md.parent.parent else skill_md.name


### PR DESCRIPTION
Fixes #48649. When a cron job is created from a non-default profile, it was stored in the global cron directory (~/.hermes/cron/jobs.json) instead of the profile-specific directory. Additionally, the scheduler used HERMES_HOME to resolve skills, which pointed to the global skills directory. Fix: converted JOBS_FILE, CRON_DIR, OUTPUT_DIR, and SKILLS_DIR to dynamic functions that resolve at call time using get_hermes_home(), ensuring profile-specific paths are used when HERMES_HOME is set for a non-default profile.