### PR TITLE
feat(whatsapp): add channel_prompts support for per-group ephemeral system prompts

### DIFF
--- a/gateway/platforms/whatsapp.py
+++ b/gateway/platforms/whatsapp.py
@@ -1179,6 +1179,14 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
                         except Exception as e:
                             print(f"[{self.name}] Failed to read document text: {e}", flush=True)
 
+            # Resolve per-group ephemeral system prompt (channel_prompts).
+            # Follows same pattern as Telegram/Discord/Slack adapters.
+            from gateway.platforms.base import resolve_channel_prompt
+            chat_id_str = str(data.get("chatId", ""))
+            channel_prompt = resolve_channel_prompt(
+                self.config.extra, chat_id_str
+            )
+
             return MessageEvent(
                 text=body,
                 message_type=msg_type,
@@ -1187,6 +1195,7 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
                 message_id=data.get("messageId"),
                 media_urls=cached_urls,
                 media_types=media_types,
+                channel_prompt=channel_prompt,
             )
         except Exception as e:
             print(f"[{self.name}] Error building event: {e}")

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2107,6 +2107,7 @@ DEFAULT_CONFIG = {
         # Default (None) uses the built-in "⚕ *Hermes Agent*" header.
         # Set to "" (empty string) to disable the header entirely.
         # Supports \n for newlines, e.g. "🤖 *My Bot*\n──────\n"
+        "channel_prompts": {},         # Per-group ephemeral system prompts (keyed by group JID)
     },
 
     # Telegram platform settings (gateway mode)


### PR DESCRIPTION
Adds `channel_prompts` to the WhatsApp adapter — per-group ephemeral system prompts that are injected at runtime and never persisted to transcript history. Changes take effect immediately on the next message.

Follows the exact same pattern as Discord, Telegram, Slack, and Mattermost (PR #10564). WhatsApp was the last major platform without this feature.

```yaml
whatsapp:
  extra:
    channel_prompts:
      "1234567890@g.us": |
        You are a project manager for team X...
      "0987654321@g.us": |
        You are a friendly assistant...
```

**Changes:**
- `gateway/platforms/whatsapp.py`: Resolves per-group prompts via `resolve_channel_prompt()` before constructing `MessageEvent`, following the exact same pattern as Telegram
- `hermes_cli/config.py`: Added `channel_prompts: {}` default to the WhatsApp config section (keyed by group JID)

**Design:**
- Opt-in — zero behavior change unless user explicitly adds `channel_prompts` entries
- `resolve_channel_prompt()` returns `None` when nothing is configured
- Gateway runner acts only on non-`None` values
- Matches exactly how Telegram/Discord/Slack/Mattermost handle it

Refs PR #10564 (original multi-platform implementation).