### PR TITLE
feat(compression): optional quiet mode for the gpt-5.5 autoraise notice

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1277,11 +1277,18 @@ def init_agent(
     _codex_gpt55_autoraise = str(
         _compression_cfg.get("codex_gpt55_autoraise", True)
     ).lower() in {"true", "1", "yes"}
+    # Whether to ANNOUNCE the autoraise. The raise is behavioural and always
+    # applies (see compression_threshold below); this flag governs only the
+    # one-time user-facing notice, so a gateway/product install can keep the
+    # larger window without surfacing system chatter in user chats.
+    _codex_gpt55_autoraise_announce = str(
+        _compression_cfg.get("codex_gpt55_autoraise_announce", True)
+    ).lower() in {"true", "1", "yes"}
     agent._compression_threshold_autoraised = None
     try:
         from agent.auxiliary_client import (
             _compression_threshold_for_model as _cthresh_fn,
-            _is_codex_gpt55 as _is_codex_gpt55_fn,
+            _should_announce_codex_gpt55_autoraise as _should_announce_fn,
         )
         _model_cthresh = _cthresh_fn(
             agent.model,
@@ -1294,10 +1301,14 @@ def init_agent(
             # Notify only for the Codex gpt-5.5 autoraise (the Arcee Trinity
             # override is a long-standing silent default). Skip the notice when
             # the user's global threshold already meets/exceeds the raised
-            # value, since nothing actually changed for them.
-            if (
-                _is_codex_gpt55_fn(agent.model, agent.provider)
-                and _model_cthresh > _prev_threshold + 1e-9
+            # value (nothing changed for them) OR when the announce flag is
+            # off (keep the raised window, suppress the chatter).
+            if _should_announce_fn(
+                agent.model,
+                agent.provider,
+                _prev_threshold,
+                _model_cthresh,
+                announce_enabled=_codex_gpt55_autoraise_announce,
             ):
                 agent._compression_threshold_autoraised = {
                     "from": _prev_threshold,

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -281,6 +281,37 @@ def _compression_threshold_for_model(
         return _CODEX_GPT55_COMPACTION_THRESHOLD
     return None
 
+
+def _should_announce_codex_gpt55_autoraise(
+    model: Optional[str],
+    provider: Optional[str],
+    prev_threshold: float,
+    new_threshold: Optional[float],
+    *,
+    announce_enabled: bool = True,
+) -> bool:
+    """Whether to surface the one-time Codex gpt-5.5 autoraise notice.
+
+    The threshold raise itself is behavioural and applies regardless of this
+    function; this governs ONLY the user-facing notice. A deployment can
+    therefore keep the larger gpt-5.5 window while suppressing the chat
+    notice (e.g. a gateway/product install that does not want system chatter
+    in user DMs) by passing ``announce_enabled=False``.
+
+    Returns True only when announcing is enabled, the model is the Codex
+    gpt-5.5 route, and the threshold actually increased (never announce a
+    no-op, e.g. when the user's global threshold already meets the raised
+    value).
+    """
+    if not announce_enabled:
+        return False
+    if new_threshold is None:
+        return False
+    if not _is_codex_gpt55(model, provider):
+        return False
+    return new_threshold > prev_threshold + 1e-9
+
+
 # Default auxiliary models for direct API-key providers (cheap/fast for side tasks)
 def _get_aux_model_for_provider(provider_id: str) -> str:
     """Return the cheap auxiliary model for a provider.

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1153,6 +1153,12 @@ DEFAULT_CONFIG = {
                                       # exact route is affected — gpt-5.5 on OpenAI's
                                       # direct API, OpenRouter, and Copilot keep the
                                       # global threshold regardless.
+        # codex_gpt55_autoraise_announce: when True (default) show a one-time
+        # notice (CLI print + gateway replay) the first time the autoraise above
+        # kicks in. Set False to KEEP the raised window but suppress the notice —
+        # for gateway/product installs that don't want system chatter in user
+        # DMs. No effect on the raise itself, only on the notice.
+        "codex_gpt55_autoraise_announce": True,
     },
 
     # Anthropic prompt caching (Claude via OpenRouter or native Anthropic API).

--- a/tests/agent/test_codex_gpt55_autoraise_announce.py
+++ b/tests/agent/test_codex_gpt55_autoraise_announce.py
@@ -1,0 +1,83 @@
+"""Tests for the Codex gpt-5.5 autoraise *notice* gate.
+
+The threshold raise to 0.85 is behavioural and is covered elsewhere
+(`_compression_threshold_for_model`). These tests pin the separate decision of
+whether to SURFACE the one-time notice: `_should_announce_codex_gpt55_autoraise`.
+
+Invariant: a deployment can suppress the notice (`announce_enabled=False`)
+without affecting the raise. The helper must also never announce a no-op (the
+threshold did not actually increase) or fire for non-Codex-gpt-5.5 routes.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from agent.auxiliary_client import (
+    _CODEX_GPT55_COMPACTION_THRESHOLD,
+    _should_announce_codex_gpt55_autoraise as should_announce,
+)
+
+CODEX = "openai-codex"
+
+
+def test_announces_when_enabled_and_threshold_rose() -> None:
+    assert (
+        should_announce(
+            "gpt-5.5", CODEX, 0.50, _CODEX_GPT55_COMPACTION_THRESHOLD,
+            announce_enabled=True,
+        )
+        is True
+    )
+
+
+def test_suppressed_when_announce_disabled_but_raise_still_applies() -> None:
+    # announce_enabled=False is the whole point: the caller still applies the
+    # raised threshold; the helper just declines to surface the notice.
+    assert (
+        should_announce(
+            "gpt-5.5", CODEX, 0.50, _CODEX_GPT55_COMPACTION_THRESHOLD,
+            announce_enabled=False,
+        )
+        is False
+    )
+
+
+def test_no_announce_for_non_codex_route() -> None:
+    # Same slug on the direct OpenAI API is not the Codex route → no raise, no notice.
+    assert (
+        should_announce("gpt-5.5", "openai", 0.50, 0.85, announce_enabled=True)
+        is False
+    )
+
+
+@pytest.mark.parametrize("model", ["gpt-5.4", "claude-sonnet-4.6", "", None])
+def test_no_announce_for_other_models(model) -> None:
+    assert should_announce(model, CODEX, 0.50, 0.85, announce_enabled=True) is False
+
+
+def test_no_announce_when_threshold_unchanged() -> None:
+    # User already runs a global threshold at/above the raised value → no-op, no notice.
+    assert (
+        should_announce("gpt-5.5", CODEX, 0.85, 0.85, announce_enabled=True) is False
+    )
+    assert (
+        should_announce("gpt-5.5", CODEX, 0.90, 0.85, announce_enabled=True) is False
+    )
+
+
+def test_no_announce_when_no_override() -> None:
+    # new_threshold is None when the model has no per-model override at all.
+    assert (
+        should_announce("gpt-5.5", CODEX, 0.50, None, announce_enabled=True) is False
+    )
+
+
+@pytest.mark.parametrize(
+    "model",
+    ["gpt-5.5", "gpt-5.5-pro", "gpt-5.5-2026-04-23", "openai/gpt-5.5"],
+)
+def test_announce_tracks_the_gpt55_family(model: str) -> None:
+    assert (
+        should_announce(model, CODEX, 0.50, 0.85, announce_enabled=True) is True
+    )


### PR DESCRIPTION
<!-- Public PR body — generic, no Welchman/Hibon/Sadee references. -->

**Title:** `feat(compression): optional quiet mode for the gpt-5.5 autoraise notice`

---

## What

Adds a `compression.codex_gpt55_autoraise_announce` config flag (default `True`). The Codex gpt-5.5 route already auto-raises the compaction threshold from the global default to 85% (Codex caps the window at 272K, so the default ~50% would compact at ~136K and waste half the usable context). That raise currently prints a one-time notice. This flag lets an operator **keep the raise but suppress the notice**.

## Why

The auto-raise is a good default. The one-time notice, however, is surfaced into the conversation — and for a gateway/bot deployment (Slack / Telegram / Discord / DMs) that's unwanted system chatter in the user's chat. Operators want the larger-window behavior without the banner. Today the two are coupled: the only opt-out (`compression.codex_gpt55_autoraise false`) also gives up the raise. This separates them.

## Change

- **`agent/auxiliary_client.py`** — `_should_announce_codex_gpt55_autoraise()`: a pure helper that decides whether to surface the notice (announce flag on **and** Codex gpt-5.5 route **and** the threshold actually increased). Makes the raise and the notice cleanly separable and unit-testable.
- **`agent/agent_init.py`** — read the new flag; the one-time notice payload (`_compression_threshold_autoraised`) is now set via the helper. The threshold raise itself is unchanged and still always applies. (Drops the now-unused `_is_codex_gpt55` import at that call site.)
- **`hermes_cli/config.py`** — document + default the new key to `True`.

## Compatibility

Fully backward compatible. Default `True` reproduces today's behavior exactly (notice shown). `False` keeps the 85% raise and suppresses only the notice. No effect on any non-Codex-gpt-5.5 route.

## Testing

New `tests/agent/test_codex_gpt55_autoraise_announce.py` covers the gate matrix: announce enabled/disabled, the gpt-5.5 family match (incl. `gpt-5.5-pro`, dated snapshots, `openai/gpt-5.5`), non-Codex routes, no-op (threshold unchanged / already ≥ raised), and no-override (`None`). Existing helper suite stays green — 53 passed locally (incl. the Arcee Trinity overrides suite).
