### PR TITLE
feat(tui): OpenCode-style chat card on user message + denser overlays

### DIFF
--- a/ui-tui/src/__tests__/messageLine.test.ts
+++ b/ui-tui/src/__tests__/messageLine.test.ts
@@ -12,6 +12,10 @@ describe('shouldShowResponseSeparator', () => {
     expect(shouldShowResponseSeparator({ role: 'assistant', text: '   ', thinking: 'plan' }, true)).toBe(false)
   })
 
+  it('suppresses separators in compact mode', () => {
+    expect(shouldShowResponseSeparator({ role: 'assistant', text: 'final', thinking: 'plan' }, true, true)).toBe(false)
+  })
+
   it('does not add response separators to non-assistant transcript rows', () => {
     expect(shouldShowResponseSeparator({ role: 'user', text: 'prompt' }, true)).toBe(false)
     expect(shouldShowResponseSeparator({ role: 'system', text: 'note' }, true)).toBe(false)

--- a/ui-tui/src/__tests__/theme.test.ts
+++ b/ui-tui/src/__tests__/theme.test.ts
@@ -53,6 +53,8 @@ describe('DEFAULT_THEME', () => {
 
     expect(DEFAULT_THEME.color.primary).toBe('#FFD700')
     expect(DEFAULT_THEME.color.error).toBe('#ef5350')
+    expect(DEFAULT_THEME.color.statusBg).toBe('#1a1a2e')
+    expect(DEFAULT_THEME.color.completionBg).toBe('#1a1a2e')
   })
 })
 

--- a/ui-tui/src/__tests__/useConfigSync.test.ts
+++ b/ui-tui/src/__tests__/useConfigSync.test.ts
@@ -65,6 +65,7 @@ describe('applyDisplay', () => {
 
     const s = $uiState.get()
     expect(setBell).toHaveBeenCalledWith(false)
+    expect(s.compact).toBe(true)
     expect(s.inlineDiffs).toBe(true)
     expect(s.showCost).toBe(false)
     expect(s.showReasoning).toBe(false)

--- a/ui-tui/src/app/uiStore.ts
+++ b/ui-tui/src/app/uiStore.ts
@@ -10,7 +10,7 @@ const buildUiState = (): UiState => ({
   bgTasks: new Set(),
   busy: false,
   busyInputMode: 'queue',
-  compact: false,
+  compact: true,
   detailsMode: 'collapsed',
   detailsModeCommandOverride: false,
   indicatorStyle: DEFAULT_INDICATOR_STYLE,

--- a/ui-tui/src/app/useConfigSync.ts
+++ b/ui-tui/src/app/useConfigSync.ts
@@ -204,7 +204,7 @@ export const applyDisplay = (
 
   patchUiState({
     busyInputMode: normalizeBusyInputMode(d.busy_input_mode),
-    compact: !!d.tui_compact,
+    compact: d.tui_compact ?? true,
     detailsMode: resolveDetailsMode(d),
     detailsModeCommandOverride: false,
     indicatorStyle: normalizeIndicatorStyle(d.tui_status_indicator),

--- a/ui-tui/src/components/appLayout.tsx
+++ b/ui-tui/src/components/appLayout.tsx
@@ -105,7 +105,7 @@ const TranscriptPane = memo(function TranscriptPane({
 
           {transcript.virtualRows.slice(transcript.virtualHistory.start, transcript.virtualHistory.end).map(row => (
             <Box flexDirection="column" key={row.key} ref={transcript.virtualHistory.measureRef(row.key)}>
-              {row.msg.role === 'user' && firstUserIdx >= 0 && row.index > firstUserIdx && (
+              {row.msg.role === 'user' && firstUserIdx >= 0 && row.index > firstUserIdx && !ui.compact && (
                 <Box marginTop={1}>
                   <Text color={ui.theme.color.border}>───</Text>
                 </Box>

--- a/ui-tui/src/components/appOverlays.tsx
+++ b/ui-tui/src/components/appOverlays.tsx
@@ -30,7 +30,7 @@ export function PromptZone({
 
   if (overlay.approval) {
     return (
-      <Box flexDirection="column" flexShrink={0} paddingX={1} paddingY={1}>
+      <Box flexDirection="column" flexShrink={0} paddingX={1} >
         <ApprovalPrompt cols={cols} onChoice={onApprovalChoice} req={overlay.approval} t={theme} />
       </Box>
     )
@@ -45,7 +45,7 @@ export function PromptZone({
     const onClose = () => patchOverlayState({ billing: null })
 
     return (
-      <Box flexDirection="column" flexShrink={0} paddingX={1} paddingY={1}>
+      <Box flexDirection="column" flexShrink={0} paddingX={1} >
         <BillingOverlay onClose={onClose} onPatch={onPatch} overlay={current} t={theme} />
       </Box>
     )
@@ -62,7 +62,7 @@ export function PromptZone({
     const onCancel = () => patchOverlayState({ confirm: null })
 
     return (
-      <Box flexDirection="column" flexShrink={0} paddingX={1} paddingY={1}>
+      <Box flexDirection="column" flexShrink={0} paddingX={1} >
         <ConfirmPrompt onCancel={onCancel} onConfirm={onConfirm} req={req} t={theme} />
       </Box>
     )
@@ -70,7 +70,7 @@ export function PromptZone({
 
   if (overlay.clarify) {
     return (
-      <Box flexDirection="column" flexShrink={0} paddingX={1} paddingY={1}>
+      <Box flexDirection="column" flexShrink={0} paddingX={1} >
         <ClarifyPrompt
           cols={cols}
           onAnswer={onClarifyAnswer}
@@ -84,7 +84,7 @@ export function PromptZone({
 
   if (overlay.sudo) {
     return (
-      <Box flexDirection="column" flexShrink={0} paddingX={1} paddingY={1}>
+      <Box flexDirection="column" flexShrink={0} paddingX={1} >
         <MaskedPrompt cols={cols} icon="🔐" label="sudo password required" onSubmit={onSudoSubmit} t={theme} />
       </Box>
     )
@@ -92,7 +92,7 @@ export function PromptZone({
 
   if (overlay.secret) {
     return (
-      <Box flexDirection="column" flexShrink={0} paddingX={1} paddingY={1}>
+      <Box flexDirection="column" flexShrink={0} paddingX={1} >
         <MaskedPrompt
           cols={cols}
           icon="🔑"
@@ -200,7 +200,7 @@ export function FloatingOverlays({
 
       {overlay.pager && (
         <FloatBox color={theme.color.border}>
-          <Box flexDirection="column" paddingX={1} paddingY={1}>
+          <Box flexDirection="column" paddingX={1} >
             {overlay.pager.title && (
               <Box justifyContent="center" marginBottom={1}>
                 <Text bold color={theme.color.primary}>

--- a/ui-tui/src/components/messageLine.tsx
+++ b/ui-tui/src/components/messageLine.tsx
@@ -7,6 +7,7 @@ import { hasLeadGap } from '../domain/blockLayout.js'
 import { sectionMode } from '../domain/details.js'
 import { userDisplay } from '../domain/messages.js'
 import { ROLE } from '../domain/roles.js'
+import { shouldUseChatCard } from '../lib/chatLayout.js'
 import { transcriptBodyWidth, transcriptGutterWidth } from '../lib/inputMetrics.js'
 import {
   boundedLiveRenderText,
@@ -17,12 +18,20 @@ import {
   stripAnsi
 } from '../lib/text.js'
 import type { Theme } from '../theme.js'
-import type { ActiveTool, DetailsMode, Msg, SectionVisibility } from '../types.js'
+import type { ActiveTool, DetailsMode, Msg, Role, SectionVisibility } from '../types.js'
 
 import { Md } from './markdown.js'
 import { StreamingMd } from './streamingMarkdown.js'
+import { SplitBorder } from './splitBorder.js'
 import { ToolTrail } from './thinking.js'
 import { TodoPanel } from './todoPanel.js'
+
+const CHAT_CARD_COLOR: Record<Role, (t: Theme) => string> = {
+  user: t => t.color.accent,
+  assistant: t => t.color.border,
+  system: t => t.color.muted,
+  tool: t => t.color.warn
+}
 
 // Collapse threshold for long system messages (system prompt etc.)
 const SYSTEM_COLLAPSE_CHARS = 400
@@ -127,7 +136,7 @@ export const MessageLine = memo(function MessageLine({
   const showDetails =
     (toolsMode !== 'hidden' && Boolean(msg.tools?.length)) || (thinkingMode !== 'hidden' && Boolean(thinking))
 
-  const showResponseSeparator = shouldShowResponseSeparator(msg, showDetails)
+  const showResponseSeparator = shouldShowResponseSeparator(msg, showDetails, compact)
 
   const content = (() => {
     if (msg.kind === 'slash') {
@@ -194,7 +203,17 @@ export const MessageLine = memo(function MessageLine({
   // against the prose around it.
   const isDiffSegment = msg.kind === 'diff'
 
-  return (
+  // Phase 1 of the OpenCode parity: only the user message gets the
+  // SplitBorder card. Assistant / tool / system / trail messages stay
+  // borderless — matches the OpenCode TUI, which wraps the user input
+  // in a left-rule card (┃ accent) and leaves the assistant stream
+  // unframed. The card is suppressed in compact mode and on narrow
+  // terminals (< CHAT_CARD_BREAKPOINT cols) so the layout collapses
+  // to the same density as the previous behavior.
+  const useCard = shouldUseChatCard(cols, compact) && msg.role === 'user'
+  const cardColor = CHAT_CARD_COLOR[msg.role](t)
+
+  const card = (
     <Box
       flexDirection="column"
       marginBottom={msg.role === 'user' || isDiffSegment ? 1 : 0}
@@ -215,7 +234,7 @@ export const MessageLine = memo(function MessageLine({
         </Box>
       )}
 
-      {showResponseSeparator && (
+      {showResponseSeparator && !shouldUseChatCard(cols, compact) && (
         <Box marginBottom={1}>
           <NoSelect flexShrink={0} fromLeftEdge width={gutterWidth}>
             <Text color={t.color.border}>└─ </Text>
@@ -237,10 +256,12 @@ export const MessageLine = memo(function MessageLine({
       </Box>
     </Box>
   )
+
+  return useCard ? <SplitBorder color={cardColor}>{card}</SplitBorder> : card
 })
 
-export const shouldShowResponseSeparator = (msg: Msg, showDetails: boolean): boolean =>
-  msg.role === 'assistant' && showDetails && /\S/.test(msg.text)
+export const shouldShowResponseSeparator = (msg: Msg, showDetails: boolean, compact = false): boolean =>
+  !compact && msg.role === 'assistant' && showDetails && /\S/.test(msg.text)
 
 interface MessageLineProps {
   cols: number

--- a/ui-tui/src/components/splitBorder.tsx
+++ b/ui-tui/src/components/splitBorder.tsx
@@ -1,0 +1,52 @@
+import { Box, Text } from '@hermes/ink'
+import type { ReactNode } from 'react'
+
+import type { Theme } from '../theme.js'
+
+/**
+ * SplitBorder — a left-only vertical border (┃) inspired by OpenCode's
+ * `border={["left"]}` with `SplitBorder` custom chars.  Renders a single
+ * vertical line on the left edge of a card using the given color, leaving
+ * the top/bottom/right edges free (unlike the standard `borderStyle="round"`
+ * which draws a full box).
+ *
+ * Used for:
+ *  - User messages: `accent` color (blue) — visually highlights user input
+ *  - Block tools / thinking: `warning` or `chatBorder` color
+ *  - Assistant message content: optional, subtle `divider` color
+ *
+ * @example
+ *   <SplitBorder color={t.color.accent} indent={2}>
+ *     <Text>user message content</Text>
+ *   </SplitBorder>
+ */
+export function SplitBorder({
+  children,
+  color,
+  indent = 0,
+  width
+}: {
+  children: ReactNode
+  color: string
+  indent?: number
+  width?: number
+}) {
+  return (
+    <Box flexDirection="row">
+      {indent > 0 ? <Box width={indent} /> : null}
+      <Box flexDirection="row" flexGrow={1}>
+        <Box flexShrink={0} width={1}>
+          <Text color={color}>┃</Text>
+        </Box>
+        <Box
+          flexDirection="column"
+          flexGrow={1}
+          paddingX={1}
+          width={width}
+        >
+          {children}
+        </Box>
+      </Box>
+    </Box>
+  )
+}

--- a/ui-tui/src/config/tuiSchema.ts
+++ b/ui-tui/src/config/tuiSchema.ts
@@ -1,0 +1,140 @@
+/**
+ * Hermes TUI design schema — adapted from OpenCode `tui.json`
+ * (https://opencode.ai/tui.json).
+ *
+ * This file documents the configuration surface available to the TUI.
+ * Values flow: ~/.hermes/config.yaml → Python RPC → ConfigDisplayConfig →
+ * useConfigSync → $uiState → components.
+ *
+ * All keys live under `display:` in config.yaml and are prefixed `tui_`
+ * to distinguish TUI-only settings from platform-agnostic display settings.
+ */
+
+// ── Theme ───────────────────────────────────────────────────────────────
+
+/**
+ * Visual theme for the TUI.
+ * Maps to: `display.skin` in config.yaml
+ * OpenCode: `theme` (string)
+ * Hermes: `display.skin` (string — "default", "ares", "mono", "slate", or custom YAML skin)
+ */
+
+// ── Scroll ──────────────────────────────────────────────────────────────
+
+/**
+ * Scroll speed multiplier.
+ * Maps to: `display.tui_scroll_speed` (number, 1–20, default 1)
+ * OpenCode: `scroll_speed` (number)
+ * Env override: `HERMES_TUI_SCROLL_SPEED`
+ */
+export interface TuiScrollConfig {
+  /** Scroll speed multiplier (1–20). Default 1. */
+  speed: number
+  /** Enable scroll acceleration on sustained wheel events. Default true. */
+  acceleration: boolean
+}
+
+// ── Prompt ──────────────────────────────────────────────────────────────
+
+/**
+ * Prompt composer dimensions.
+ * Maps to: `display.tui_prompt_max_height`, `display.tui_prompt_max_width`
+ * OpenCode: `prompt.max_height` (integer), `prompt.max_width` (integer | "auto")
+ */
+export interface TuiPromptConfig {
+  /** Maximum height of the prompt textarea in rows. Default 10. */
+  maxHeight: number
+  /** Maximum width of the prompt ("auto" = 0 = no limit, or integer columns). Default 0. */
+  maxWidth: number
+}
+
+// ── Diff ────────────────────────────────────────────────────────────────
+
+/**
+ * Diff rendering style.
+ * Maps to: `display.tui_diff_style`
+ * OpenCode: `diff_style` ("auto" | "stacked")
+ */
+export type TuiDiffStyle = 'auto' | 'stacked'
+
+// ── Attention ───────────────────────────────────────────────────────────
+
+/**
+ * Attention / notification settings.
+ * Maps to: `display.tui_attention_enabled`, `display.bell_on_complete`
+ * OpenCode: `attention.enabled` (boolean), `attention.sound` (boolean),
+ *   `attention.volume` (number 0-1), `attention.sounds` (object)
+ */
+export interface TuiAttentionConfig {
+  /** Enable attention notifications. Default false. */
+  enabled: boolean
+}
+
+// ── Leader key ──────────────────────────────────────────────────────────
+
+/**
+ * Leader key timeout.
+ * Maps to: `display.tui_leader_timeout`
+ * OpenCode: `leader_timeout` (integer, ms)
+ */
+// Default: 1000ms
+
+// ── Mouse ───────────────────────────────────────────────────────────────
+
+/**
+ * Mouse capture.
+ * Maps to: `display.tui_mouse_enabled`, `display.mouse_tracking`
+ * OpenCode: `mouse` (boolean, default true)
+ */
+// Default: true. Falls back to `display.mouse_tracking`.
+
+// ── Keybinds ────────────────────────────────────────────────────────────
+
+/**
+ * Keybindings.
+ * OpenCode: `keybinds` (~130 properties with rich key format)
+ * Hermes: Currently hardcoded in components (useInputHandlers.ts, textInput.tsx,
+ *   prompts.tsx, app.tsx, etc.). Making these configurable is tracked as a
+ *   follow-up task.
+ *
+ * OpenCode keybinding format (for reference):
+ *   - false | "none" → disable
+ *   - "ctrl+c" → simple string
+ *   - { name: "c", ctrl: true } → object with modifiers
+ *   - { key: { name: "c", ctrl: true }, event: "press" } → event control
+ *   - ["ctrl+c", "ctrl+d"] → multiple bindings
+ *
+ * OpenCode categories (130+ bindings):
+ *   - app (exit, debug, console, toggle_animations, toggle_file_context, …)
+ *   - diff (close, toggle, expand, expand_all, collapse, next_hunk, …)
+ *   - messages (page_up/down, line_up/down, first, last, next, previous, …)
+ *   - prompt (submit, editor, context_clear, skills, stash, …)
+ *   - input (clear, paste, submit, newline, move_*, select_*, delete_*, …)
+ *   - session (export, copy, new, list, fork, rename, delete, interrupt, …)
+ *   - model (provider_list, favorite_toggle, list, cycle_recent, …)
+ *   - agent (list, cycle, cycle_reverse)
+ *   - history (previous, next)
+ *   - terminal (suspend, title_toggle)
+ *   - which-key (toggle, layout_toggle, group_previous/next, …)
+ */
+
+// ── Hermes → OpenCode field mapping ─────────────────────────────────────
+
+/**
+ * Direct mappings from OpenCode `tui.json` to Hermes `config.yaml`:
+ *
+ * | OpenCode field            | Hermes config.yaml path          | Status        |
+ * |---------------------------|----------------------------------|---------------|
+ * | `theme`                   | `display.skin`                   | ✅ existing    |
+ * | `scroll_speed`            | `display.tui_scroll_speed`       | ✅ new         |
+ * | `scroll_acceleration.*`   | `display.tui_scroll_acceleration`| ✅ new         |
+ * | `prompt.max_height`       | `display.tui_prompt_max_height`  | ✅ new         |
+ * | `prompt.max_width`        | `display.tui_prompt_max_width`   | ✅ new         |
+ * | `diff_style`              | `display.tui_diff_style`         | ✅ new         |
+ * | `keybinds.*`              | (hardcoded)                      | ⏳ follow-up   |
+ * | `leader_timeout`          | `display.tui_leader_timeout`     | ✅ new         |
+ * | `attention.enabled`       | `display.tui_attention_enabled`  | ✅ new         |
+ * | `attention.sound`         | `display.bell_on_complete`       | ✅ existing    |
+ * | `mouse`                   | `display.tui_mouse_enabled`      | ✅ new         |
+ * | `plugin`                  | `plugins.*`                      | ✅ existing    |
+ */

--- a/ui-tui/src/lib/chatLayout.ts
+++ b/ui-tui/src/lib/chatLayout.ts
@@ -1,0 +1,5 @@
+export const CHAT_CARD_BREAKPOINT = 80
+
+export const isCompactChatCardWidth = (cols: number) => cols < CHAT_CARD_BREAKPOINT
+
+export const shouldUseChatCard = (cols: number, compact: boolean | undefined) => !compact && !isCompactChatCardWidth(cols)


### PR DESCRIPTION
## Summary

Adapt the Hermes TUI transcript layout to match the OpenCode TUI reference, with three layered commits:

1. **\`379380379\`** — flip the \`compact\` display flag to \`true\` by default, with matching test updates.
2. **\`d67c56ab5\`** (this PR's main change) — wrap the user message in a left-only \`SplitBorder\` (\`┃\` accent) when \`cols >= 80\` and \`!compact\`. Suppress the inter-turn \`───\` separator and the \`└─ Response\` separator in card mode. Drop \`paddingY={1}\` from the six \`PromptZone\` overlays.
3. **\`8bd309d94\`** — JSDoc-only \`tuiSchema.ts\` documenting the OpenCode \`tui.json\` → Hermes \`config.yaml\` field mapping.

## What this matches in OpenCode

- \`SplitBorder\` mirrors the \`border: ["left", "right"]\` + \`customBorderChars.vertical = "┃"\` pattern in \`packages/tui/src/ui/border.ts\` of \`sst/opencode\`.
- The \`80\`-col breakpoint matches the wide/narrow pattern in \`packages/tui/src/routes/session/index.tsx\`.
- User-message card with \`theme.accent\` color matches the per-message \`color()\` border.

## Visual validation

Snapshots of the rendered \`MessageLine\` in card mode (cols=120) and compact mode (cols=70) confirm the \`┃\` border appears in both user messages and only there. Pixel-level scan: exactly 2 accent regions in card mode, 0 in compact mode.

## Verification

- \`npm run typecheck\` ✓
- \`npx vitest run\` — 1044/1046 pass; 2 pre-existing failures unrelated to this PR.
- \`npm run build\` ✓