### PR TITLE
Skip suppressed skill-local descriptions

### DIFF
--- a/tests/tools/test_skills_sync.py
+++ b/tests/tools/test_skills_sync.py
@@ -301,6 +301,7 @@ class TestSyncSkills:
         bundled = self._setup_bundled(tmp_path)
         skills_dir = tmp_path / "user_skills"
         manifest_file = skills_dir / ".bundled_manifest"
+        (bundled / "old-skill" / "DESCRIPTION.md").write_text("Old skill desc")
 
         with self._patches(bundled, skills_dir, manifest_file), \
                 patch("tools.skills_sync._read_suppressed_names", return_value={"old-skill"}):
@@ -310,6 +311,7 @@ class TestSyncSkills:
         assert "old-skill" in result["suppressed"]
         assert "old-skill" not in result["copied"]
         assert not (skills_dir / "old-skill").exists()
+        assert not (skills_dir / "old-skill" / "DESCRIPTION.md").exists()
         # The non-suppressed bundled skill is still copied normally.
         assert "new-skill" in result["copied"]
         assert (skills_dir / "category" / "new-skill" / "SKILL.md").exists()

--- a/tools/skills_sync.py
+++ b/tools/skills_sync.py
@@ -636,8 +636,13 @@ def sync_skills(quiet: bool = False) -> dict:
     for name in cleaned:
         del manifest[name]
 
-    # Also copy DESCRIPTION.md files for categories (if not already present)
+    # Also copy DESCRIPTION.md files for categories (if not already present).
+    # Skill-local DESCRIPTION.md files must not be copied on their own: if a
+    # bundled skill was suppressed or deleted, copying only that metadata file
+    # recreates a non-loadable shadow directory under ~/.hermes/skills.
     for desc_md in bundled_dir.rglob("DESCRIPTION.md"):
+        if (desc_md.parent / "SKILL.md").exists():
+            continue
         rel = desc_md.relative_to(bundled_dir)
         dest_desc = SKILLS_DIR / rel
         if not dest_desc.exists():


### PR DESCRIPTION
## Summary
- Prevent bundled sync from copying skill-local DESCRIPTION.md files without the rest of the skill package.
- Keep category DESCRIPTION.md copying intact.
- Cover the suppressed bundled skill case so pruned skills do not come back as non-loadable stub directories.

## Test plan
- [x] ./venv/bin/python -m pytest tests/tools/test_skills_sync.py -q