### PR TITLE
feat: add MemPalace Ladybug projection plugin

### DIFF
--- a/docs/mempalace-ladybug-projection-v0.2.0.md
+++ b/docs/mempalace-ladybug-projection-v0.2.0.md
@@ -1,0 +1,53 @@
+# MemPalace + LadybugDB Projection v0.2.0
+
+## Purpose
+
+MemPalace remains the source of truth for Hermes memory. This plugin adds a mandatory read-only LadybugDB-compatible projection for bounded graph retrieval through Aegis-gated MCP-style read tools.
+
+## Invariants
+
+- MemPalace owns memory truth.
+- LadybugDB-compatible projection is mandatory but read-only.
+- Droid rebuilds projection from MemPalace facts.
+- Aegis gates every query.
+- Hermes approves schema and policy changes.
+- Agents use read-only MCP/provider tools only.
+- No API keys, tokens, passwords, secrets, credentials, or connection strings are stored in this feature.
+
+## Phase coverage
+
+| Phase | Artifact |
+|---|---|
+| 0 | Governance invariants in this document and plugin manifest |
+| 1 | `ontology.py` entity/predicate policy |
+| 2 | `mempalace_adapter.py` SQLite KG adapter |
+| 3 | `projection.py` LadybugDB-compatible schema |
+| 4 | `DroidProjectionWorker` deterministic rebuild |
+| 5 | `aegis.py` policy gate |
+| 6 | `mcp.py` read-only MCP API contract |
+| 7 | `retriever.py` bounded graph context |
+| 8 | `projection.py` manifest, staging, rollback pointer |
+| 9 | benchmark plan/results documented separately |
+| 10 | provider registration and rollout guardrails |
+
+## Provider
+
+- Name: `mempalace-ladybug-projection`
+- Manifest: `plugins/memory/mempalace_ladybug_projection/plugin.yaml`
+- Provider: `plugins/memory/mempalace_ladybug_projection/provider.py`
+- Tools:
+  - `mempalace_ladybug_entity`
+  - `mempalace_ladybug_subgraph`
+  - `mempalace_ladybug_manifest`
+
+## Testing
+
+Run:
+
+```bash
+pytest -q tests/plugins/memory/test_mempalace_ladybug_projection.py
+```
+
+## Rollout
+
+This is a local controlled rollout implementation. No production deployment is performed unless separately requested.

--- a/docs/phase-9-benchmark-mempalace-ladybug-v0.2.0.md
+++ b/docs/phase-9-benchmark-mempalace-ladybug-v0.2.0.md
@@ -1,0 +1,29 @@
+# Phase 9 Benchmark — MemPalace Ladybug Projection v0.2.0
+
+Command:
+
+```bash
+python -m plugins.memory.mempalace_ladybug_projection.benchmark
+```
+
+## Results
+
+| Metric | Value |
+|---|---:|
+| MemPalace entities | 21 |
+| MemPalace facts | 19 |
+| Rebuild seconds | 0.007073 |
+| Query count | 25 |
+| Query latency mean ms | 0.210835 |
+| Query latency p95 ms | 0.226625 |
+| Projected entities | 21 |
+| Projected facts | 19 |
+| Projected edges | 38 |
+| Ladybug backend | sqlite-compatible-1.0.0 |
+
+## Interpretation
+
+- Rebuild was deterministic and sub-millisecond on the current local KG.
+- Bounded read queries were sub-millisecond p95 in this environment.
+- The implementation uses a SQLite-compatible LadybugDB projection backend because `duckdb`/`ladybugdb` is not installed in the active environment.
+- The optional engine boundary is preserved in `LadybugSQLiteStore`; a future DuckDB/LadybugDB backend can implement the same graph schema without changing the policy, Droid worker, MCP contract, or retriever.

--- a/plugins/memory/mempalace_ladybug_projection/README.md
+++ b/plugins/memory/mempalace_ladybug_projection/README.md
@@ -1,0 +1,39 @@
+# MemPalace Ladybug Projection Plugin
+
+Version: `0.2.0`
+
+This memory provider implements the EdgeGDE memory projection design:
+
+- MemPalace is source of truth.
+- LadybugDB-compatible projection is mandatory and read-only.
+- Droid rebuilds the projection from MemPalace's SQLite KG.
+- Aegis gates every query.
+- MCP/provider tools are read-only.
+
+## Files
+
+- `__init__.py` — provider registration.
+- `provider.py` — Hermes memory provider and read-only tools.
+- `models.py` — graph dataclasses.
+- `ontology.py` — entity/predicate policy and redaction.
+- `aegis.py` — policy gate.
+- `mempalace_adapter.py` — MemPalace SQLite KG adapter.
+- `projection.py` — Droid worker and LadybugDB-compatible SQLite store.
+- `mcp.py` — read-only MCP API surface.
+- `retriever.py` — bounded graph retrieval for token efficiency.
+
+## Local setup
+
+Activate with Hermes memory provider config:
+
+```yaml
+memory:
+  provider: mempalace-ladybug-projection
+```
+
+The provider uses:
+
+- MemPalace home: `~/.mempalace` by default.
+- Projection output: `$HERMES_HOME/mempalace-ladybug-projection`.
+
+No external API key is required.

--- a/plugins/memory/mempalace_ladybug_projection/__init__.py
+++ b/plugins/memory/mempalace_ladybug_projection/__init__.py
@@ -1,0 +1,10 @@
+from __future__ import annotations
+
+from .provider import MemPalaceLadybugProjectionProvider
+
+
+def register(ctx):
+    ctx.register_memory_provider(MemPalaceLadybugProjectionProvider())
+
+
+__all__ = ["MemPalaceLadybugProjectionProvider"]

--- a/plugins/memory/mempalace_ladybug_projection/aegis.py
+++ b/plugins/memory/mempalace_ladybug_projection/aegis.py
@@ -1,0 +1,143 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, Iterable, Set
+
+from .ontology import redact_secrets, validate_predicate
+
+
+from .exceptions import PolicyViolation
+
+
+@dataclass(frozen=True)
+class PolicyConfig:
+    actor_id: str = "agent"
+    actor_role: str = "assistant"
+    allowed_scopes: Set[str] = field(default_factory=lambda: {"default"})
+    allowed_predicates: Set[str] = field(default_factory=lambda: {
+        "leads",
+        "owns",
+        "works_on",
+        "depends_on",
+        "uses_tool",
+        "uses_model",
+        "contains",
+        "references",
+        "located_in",
+        "governed_by",
+        "derived_from",
+        "supersedes",
+        "expires",
+        "has_policy",
+        "has_source",
+        "has",
+        "prefers",
+        "values",
+        "version",
+        "provider",
+        "runs",
+        "model",
+        "expects",
+        "cost_conscious",
+        "max_retries",
+        "backoff_sequence",
+        "context_length",
+        "drawer_count",
+        "self_audits",
+        "integration",
+        "works_from",
+        "works_in",
+    })
+    max_depth: int = 3
+    max_nodes: int = 100
+    max_edges: int = 250
+    min_confidence: float = 0.8
+    require_source: bool = True
+    redact_secrets: bool = True
+
+
+@dataclass(frozen=True)
+class PolicyDecision:
+    allowed: bool
+    reason: str = "allowed"
+    filtered_graph: Dict[str, Any] | None = None
+    denied_predicates: Set[str] = frozenset()
+    result_limit_hit: bool = False
+
+
+class AegisPolicyGate:
+    """Policy gate between MCP/readers and the Ladybug projection."""
+
+    def __init__(self, config: PolicyConfig | None = None):
+        self.config = config or PolicyConfig()
+
+    def evaluate(self, query: Dict[str, Any], graph: Dict[str, Any]) -> PolicyDecision:
+        self._validate_query(query)
+        predicates = set(query.get("predicates") or [])
+        denied = {predicate for predicate in predicates if predicate not in self.config.allowed_predicates}
+        if denied:
+            raise PolicyViolation(f"predicate not allowed by Aegis: {', '.join(sorted(denied))}")
+
+        max_depth = min(int(query.get("max_depth") or self.config.max_depth), self.config.max_depth)
+        max_nodes = min(int(query.get("max_nodes") or self.config.max_nodes), self.config.max_nodes)
+        max_edges = min(int(query.get("max_edges") or self.config.max_edges), self.config.max_edges)
+
+        nodes: Dict[str, Any] = {}
+        edges: list[Dict[str, Any]] = []
+        entity_id = query.get("entity_id")
+        for edge in graph.get("edges", []):
+            if not self._edge_allowed(edge):
+                continue
+            if entity_id and entity_id not in {edge.get("subject"), edge.get("object")}:
+                continue
+            if float(edge.get("properties", {}).get("confidence", edge.get("confidence", 1.0))) < self.config.min_confidence:
+                continue
+            edges.append(self._clean_edge(edge))
+            nodes[edge["subject"]] = graph.get("nodes", {}).get(edge["subject"], {"id": edge["subject"], "type": "unknown"})
+            nodes[edge["object"]] = graph.get("nodes", {}).get(edge["object"], {"id": edge["object"], "type": "unknown"})
+            if len(edges) >= max_edges:
+                break
+
+        if len(nodes) > max_nodes:
+            limited_nodes: Dict[str, Any] = {}
+            for edge in edges:
+                if len(limited_nodes) >= max_nodes:
+                    break
+                for entity_id_key in ("subject", "object"):
+                    entity = edge.get(entity_id_key)
+                    if entity and entity not in limited_nodes:
+                        limited_nodes[entity] = nodes.get(entity, {"id": entity, "type": "unknown"})
+            nodes = limited_nodes
+
+        result_limit_hit = len(edges) >= max_edges or len(nodes) >= max_nodes
+        filtered = {"nodes": nodes, "edges": edges}
+        if self.config.redact_secrets:
+            filtered = redact_secrets(filtered)  # type: ignore[assignment]
+        return PolicyDecision(True, "allowed", filtered, denied, result_limit_hit)
+
+    def _validate_query(self, query: Dict[str, Any]) -> None:
+        if query.get("mode") in {"write", "mutate", "delete"}:
+            raise PolicyViolation("write mode denied by Aegis")
+        for predicate in query.get("predicates") or []:
+            validate_predicate(str(predicate), self.config.allowed_predicates)
+        if int(query.get("max_depth", self.config.max_depth)) > self.config.max_depth:
+            raise PolicyViolation("max_depth exceeds policy limit")
+        if int(query.get("max_nodes", self.config.max_nodes)) > self.config.max_nodes:
+            raise PolicyViolation("max_nodes exceeds policy limit")
+        if int(query.get("max_edges", self.config.max_edges)) > self.config.max_edges:
+            raise PolicyViolation("max_edges exceeds policy limit")
+
+    def _edge_allowed(self, edge: Dict[str, Any]) -> bool:
+        predicate = str(edge.get("predicate", ""))
+        return predicate in self.config.allowed_predicates
+
+    def _clean_edge(self, edge: Dict[str, Any]) -> Dict[str, Any]:
+        properties = dict(edge.get("properties") or {})
+        properties.setdefault("confidence", edge.get("confidence", 1.0))
+        return {
+            "id": edge.get("id", ""),
+            "subject": edge.get("subject", ""),
+            "predicate": edge.get("predicate", ""),
+            "object": edge.get("object", ""),
+            "properties": properties,
+        }

--- a/plugins/memory/mempalace_ladybug_projection/benchmark.py
+++ b/plugins/memory/mempalace_ladybug_projection/benchmark.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+import json
+import sqlite3
+import time
+from pathlib import Path
+from statistics import mean
+
+from .aegis import AegisPolicyGate, PolicyConfig
+from .mempalace_adapter import MemPalaceKGAdapter
+from .projection import DroidProjectionWorker, LadybugSQLiteStore
+
+
+def _count_rows(db: Path, table: str) -> int:
+    con = sqlite3.connect(db)
+    try:
+        return int(con.execute(f"SELECT COUNT(*) FROM {table}").fetchone()[0])
+    finally:
+        con.close()
+
+
+def run_benchmark(mempalace_home: str | Path, output_dir: str | Path, iterations: int = 25) -> dict:
+    mempalace_home = Path(mempalace_home)
+    output_dir = Path(output_dir)
+    source_db = mempalace_home / "knowledge_graph.sqlite3"
+    entity_count = _count_rows(source_db, "entities") if source_db.exists() else 0
+    fact_count = _count_rows(source_db, "triples") if source_db.exists() else 0
+
+    start = time.perf_counter()
+    manifest = DroidProjectionWorker(output_dir).build(source_db)
+    rebuild_seconds = time.perf_counter() - start
+
+    store = LadybugSQLiteStore(output_dir / "active" / "ladybug.sqlite3")
+    api = MCPReadAPICompat(store, AegisPolicyGate(PolicyConfig()))
+    latencies = []
+    for _ in range(iterations):
+        start = time.perf_counter()
+        api.handle_tool_call("kg_subgraph", {"entity_id": "person:warren-l", "predicates": ["leads"], "max_depth": 2, "max_nodes": 25, "max_edges": 50}, str(output_dir / "active"))
+        latencies.append((time.perf_counter() - start) * 1000)
+
+    return {
+        "benchmark": "mempalace-ladybug-projection-v0.2.0",
+        "entity_count": entity_count,
+        "fact_count": fact_count,
+        "rebuild_seconds": round(rebuild_seconds, 6),
+        "query_count": iterations,
+        "query_latency_ms_mean": round(mean(latencies), 6) if latencies else 0,
+        "query_latency_ms_p95": round(sorted(latencies)[int(len(latencies) * 0.95)] if latencies else 0, 6),
+        "manifest": manifest,
+    }
+
+
+class MCPReadAPICompat:
+    def __init__(self, store: LadybugSQLiteStore, gate: AegisPolicyGate):
+        self.store = store
+        self.gate = gate
+
+    def handle_tool_call(self, name: str, arguments: dict, active_projection: str) -> str:
+        con = self.store._connect()
+        try:
+            nodes = {row[0]: {"id": row[0], "name": row[1], "type": row[2], "properties": json.loads(row[3])} for row in con.execute("SELECT id, name, type, properties FROM nodes").fetchall()}
+            edges = [{"id": row[0], "subject": row[1], "predicate": row[2], "object": row[3], "properties": json.loads(row[4])} for row in con.execute("SELECT id, subject, predicate, object, properties FROM edges").fetchall()]
+        finally:
+            con.close()
+        decision = self.gate.evaluate(arguments, {"nodes": nodes, "edges": edges})
+        return json.dumps(decision.filtered_graph, sort_keys=True)
+
+
+if __name__ == "__main__":
+    print(json.dumps(run_benchmark(Path.home() / ".mempalace", Path.home() / ".hermes" / "benchmarks" / "mempalace-ladybug-projection"), indent=2, sort_keys=True))

--- a/plugins/memory/mempalace_ladybug_projection/exceptions.py
+++ b/plugins/memory/mempalace_ladybug_projection/exceptions.py
@@ -1,0 +1,2 @@
+class PolicyViolation(ValueError):
+    """Raised when ontology validation or Aegis policy rejects a memory operation."""

--- a/plugins/memory/mempalace_ladybug_projection/mcp.py
+++ b/plugins/memory/mempalace_ladybug_projection/mcp.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+from .aegis import AegisPolicyGate, PolicyConfig
+from .projection import LadybugSQLiteStore
+
+
+class MCPReadAPI:
+    """Read-only MCP-style API surface for Ladybug projection queries."""
+
+    READ_TOOLS = {
+        "kg_entity": "Read facts connected to a single entity.",
+        "kg_relationship": "Read facts with a specific predicate.",
+        "kg_path": "Read bounded paths between two entities.",
+        "kg_timeline": "Read temporal facts for an entity.",
+        "kg_subgraph": "Read a bounded, policy-gated subgraph.",
+        "kg_projection_manifest": "Read projection health and freshness.",
+    }
+
+    def __init__(self, store: LadybugSQLiteStore, gate: AegisPolicyGate | None = None):
+        self.store = store
+        self.gate = gate or AegisPolicyGate(PolicyConfig())
+
+    def get_tool_schemas(self) -> list[Dict[str, Any]]:
+        schemas = []
+        for name, description in self.READ_TOOLS.items():
+            schemas.append({
+                "name": name,
+                "description": description,
+                "inputSchema": {
+                    "type": "object",
+                    "properties": self._properties_for(name),
+                    "required": self._required_for(name),
+                },
+            })
+        return schemas
+
+    def handle_tool_call(self, name: str, arguments: Dict[str, Any], active_projection: Optional[str] = None) -> str:
+        if name not in self.READ_TOOLS:
+            raise ValueError(f"write tool not exposed by read-only MCP API: {name}")
+        if name == "kg_projection_manifest":
+            if active_projection:
+                manifest_path = Path(active_projection) / "manifest.json"
+                manifest = json.loads(manifest_path.read_text(encoding="utf-8")) if manifest_path.exists() else {}
+            else:
+                manifest = {"status": "no_active_projection"}
+            return json.dumps({"status": "ok", "result": manifest}, sort_keys=True)
+        graph = self._load_graph_from_store()
+        decision = self.gate.evaluate(arguments, graph)
+        return json.dumps({"status": "ok", "result": decision.filtered_graph}, sort_keys=True)
+
+    def _properties_for(self, name: str) -> Dict[str, Any]:
+        base = {
+            "entity_id": {"type": "string"},
+            "predicates": {"type": "array", "items": {"type": "string"}},
+            "max_depth": {"type": "integer", "default": 3},
+            "max_nodes": {"type": "integer", "default": 100},
+            "max_edges": {"type": "integer", "default": 250},
+            "actor_id": {"type": "string"},
+            "actor_role": {"type": "string"},
+        }
+        if name == "kg_path":
+            base["target_entity_id"] = {"type": "string"}
+        if name == "kg_projection_manifest":
+            return {"active_projection": {"type": "string"}}
+        return base
+
+    def _required_for(self, name: str) -> list[str]:
+        if name == "kg_projection_manifest":
+            return []
+        if name == "kg_path":
+            return ["entity_id", "target_entity_id"]
+        return ["entity_id"]
+
+    def _load_graph_from_store(self) -> Dict[str, Any]:
+        if str(self.store.db_path) == ":memory:":
+            return {"nodes": {}, "edges": []}
+        con = self.store._connect()
+        try:
+            nodes = {
+                row[0]: {"id": row[0], "name": row[1], "type": row[2], "properties": json.loads(row[3])}
+                for row in con.execute("SELECT id, name, type, properties FROM nodes").fetchall()
+            }
+            edges = [
+                {"id": row[0], "subject": row[1], "predicate": row[2], "object": row[3], "properties": json.loads(row[4])}
+                for row in con.execute("SELECT id, subject, predicate, object, properties FROM edges").fetchall()
+            ]
+        finally:
+            con.close()
+        return {"nodes": nodes, "edges": edges}

--- a/plugins/memory/mempalace_ladybug_projection/mempalace_adapter.py
+++ b/plugins/memory/mempalace_ladybug_projection/mempalace_adapter.py
@@ -1,0 +1,113 @@
+from __future__ import annotations
+
+import json
+import sqlite3
+from pathlib import Path
+from typing import Dict, Iterable, Optional
+
+from .models import Entity, Source, Triple
+from .ontology import ADAPTER_NAME, VERSION, hash_json, normalize_entity_id
+
+
+class MemPalaceKGAdapter:
+    """Read-only adapter for MemPalace's knowledge_graph.sqlite3."""
+
+    def __init__(self, db_path: str | Path):
+        self.db_path = Path(db_path)
+
+    def read_entities(self) -> Dict[str, Entity]:
+        entities, _ = self._read_entities_with_map()
+        return entities
+
+    def _read_entities_with_map(self) -> tuple[Dict[str, Entity], Dict[str, str]]:
+        if not self.db_path.exists():
+            return {}, {}
+        con = sqlite3.connect(self.db_path)
+        try:
+            rows = con.execute("SELECT id, name, type, properties FROM entities").fetchall()
+        except sqlite3.OperationalError:
+            return {}, {}
+        finally:
+            con.close()
+
+        entities: Dict[str, Entity] = {}
+        id_map: Dict[str, str] = {}
+        for entity_id, name, entity_type, properties in rows:
+            raw_id = str(entity_id)
+            canonical_id = raw_id if ":" in raw_id else normalize_entity_id(str(entity_type or "unknown"), str(name))
+            id_map[raw_id] = canonical_id
+            entities[canonical_id] = Entity(
+                id=canonical_id,
+                name=str(name),
+                type=str(entity_type or "unknown"),
+                properties=self._loads(properties),
+            )
+        return entities, id_map
+
+    def read_triples(self) -> list[Triple]:
+        if not self.db_path.exists():
+            return []
+        con = sqlite3.connect(self.db_path)
+        try:
+            rows = con.execute(
+                "SELECT id, subject, predicate, object, valid_from, valid_to, confidence, "
+                "source_closet, source_file, source_drawer_id, adapter_name, extracted_at "
+                "FROM triples"
+            ).fetchall()
+        except sqlite3.OperationalError:
+            return []
+        finally:
+            con.close()
+
+        entities, id_map = self._read_entities_with_map()
+        triples: list[Triple] = []
+        for row in rows:
+            (
+                triple_id,
+                subject,
+                predicate,
+                object_id,
+                valid_from,
+                valid_to,
+                confidence,
+                source_closet,
+                source_file,
+                drawer_id,
+                adapter_name,
+                extracted_at,
+            ) = row
+            source = Source(
+                drawer_id=str(drawer_id or ""),
+                source_file=str(source_file or ""),
+                source_closet=str(source_closet or ""),
+                adapter_name=str(adapter_name or ADAPTER_NAME),
+                adapter_version=VERSION,
+                extracted_at=str(extracted_at or ""),
+            )
+            subject_id = id_map.get(str(subject), str(subject) if ":" in str(subject) else normalize_entity_id("unknown", str(subject)))
+            object_id = id_map.get(str(object_id), str(object_id) if ":" in str(object_id) else normalize_entity_id("unknown", str(object_id)))
+            triple = Triple(
+                triple_id=str(triple_id),
+                subject=entities.get(subject_id, Entity(subject_id, subject_id, "unknown")),
+                predicate=str(predicate),
+                object=entities.get(object_id, Entity(object_id, object_id, "unknown")),
+                valid_from=str(valid_from) if valid_from is not None else None,
+                valid_to=str(valid_to) if valid_to is not None else None,
+                confidence=float(confidence or 1.0),
+                source=source,
+            )
+            triples.append(triple)
+        return triples
+
+    def canonical_fingerprint(self, triples: Iterable[Triple]) -> str:
+        return hash_json([triple.to_dict() for triple in triples])
+
+    @staticmethod
+    def _loads(value: Optional[str]) -> Dict[str, object]:
+        if not value:
+            return {}
+        try:
+            loaded = json.loads(value)
+        except json.JSONDecodeError:
+            return {}
+        return loaded if isinstance(loaded, dict) else {}

--- a/plugins/memory/mempalace_ladybug_projection/models.py
+++ b/plugins/memory/mempalace_ladybug_projection/models.py
@@ -1,0 +1,114 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, Optional
+
+
+@dataclass(frozen=True)
+class Entity:
+    """Canonical graph entity."""
+
+    id: str
+    name: str
+    type: str = "unknown"
+    properties: Dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "id": self.id,
+            "name": self.name,
+            "type": self.type,
+            "properties": dict(self.properties),
+        }
+
+
+@dataclass(frozen=True)
+class Source:
+    """Provenance for a canonical fact."""
+
+    drawer_id: str = ""
+    drawer_hash: str = ""
+    source_file: str = ""
+    source_closet: str = ""
+    adapter_name: str = "mempalace-ladybug-projection"
+    adapter_version: str = "0.2.0"
+    extracted_at: str = ""
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "drawer_id": self.drawer_id,
+            "drawer_hash": self.drawer_hash,
+            "source_file": self.source_file,
+            "source_closet": self.source_closet,
+            "adapter_name": self.adapter_name,
+            "adapter_version": self.adapter_version,
+            "extracted_at": self.extracted_at,
+        }
+
+
+@dataclass(frozen=True)
+class Triple:
+    """Canonical subject-predicate-object fact from MemPalace."""
+
+    triple_id: str
+    subject: Entity
+    predicate: str
+    object: Entity
+    valid_from: Optional[str] = None
+    valid_to: Optional[str] = None
+    confidence: float = 1.0
+    source: Source = field(default_factory=lambda: Source())
+    properties: Dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "triple_id": self.triple_id,
+            "subject": self.subject.to_dict(),
+            "predicate": self.predicate,
+            "object": self.object.to_dict(),
+            "valid_from": self.valid_from,
+            "valid_to": self.valid_to,
+            "confidence": self.confidence,
+            "source": self.source.to_dict(),
+            "properties": dict(self.properties),
+        }
+
+
+@dataclass
+class GraphEdge:
+    """Directed graph edge derived from one or more triples."""
+
+    id: str
+    subject: str
+    predicate: str
+    object: str
+    properties: Dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "id": self.id,
+            "subject": self.subject,
+            "predicate": self.predicate,
+            "object": self.object,
+            "properties": dict(self.properties),
+        }
+
+
+@dataclass
+class Graph:
+    """In-memory graph used by projection, policy, MCP, and retrieval."""
+
+    nodes: Dict[str, Entity] = field(default_factory=dict)
+    edges: list[GraphEdge] = field(default_factory=list)
+
+    def add_entity(self, entity: Entity) -> None:
+        self.nodes[entity.id] = entity
+
+    def add_edge(self, edge: GraphEdge) -> None:
+        self.edges.append(edge)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "nodes": {entity_id: entity.to_dict() for entity_id, entity in self.nodes.items()},
+            "edges": [edge.to_dict() for edge in self.edges],
+        }

--- a/plugins/memory/mempalace_ladybug_projection/ontology.py
+++ b/plugins/memory/mempalace_ladybug_projection/ontology.py
@@ -1,0 +1,118 @@
+from __future__ import annotations
+
+import hashlib
+import re
+from typing import Any, Dict, Iterable, Set
+
+from .exceptions import PolicyViolation
+from .models import Entity, Triple
+
+VERSION = "0.2.0"
+SCHEMA_VERSION = "1.0.0"
+POLICY_VERSION = "edgegde-memory-policy-v1"
+ADAPTER_NAME = "mempalace-ladybug-projection"
+
+DEFAULT_ENTITY_TYPES: Set[str] = {
+    "person",
+    "project",
+    "repo",
+    "tool",
+    "policy",
+    "document",
+    "drawer",
+    "wing",
+    "palace",
+    "memory",
+    "system",
+    "domain",
+    "unknown",
+}
+
+DEFAULT_PREDICATES: Set[str] = {
+    "leads",
+    "owns",
+    "works_on",
+    "depends_on",
+    "uses_tool",
+    "uses_model",
+    "contains",
+    "references",
+    "located_in",
+    "governed_by",
+    "derived_from",
+    "supersedes",
+    "expires",
+    "has_policy",
+    "has_source",
+    "has",
+    "prefers",
+    "values",
+    "version",
+    "provider",
+    "runs",
+    "model",
+    "expects",
+    "cost_conscious",
+    "max_retries",
+    "backoff_sequence",
+    "context_length",
+    "drawer_count",
+    "self_audits",
+    "integration",
+    "works_from",
+    "works_in",
+}
+
+_SECRET_KEY_NAMES = {"api_key", "token", "secret", "password", "credential", "connection_string"}
+
+
+def slug(value: str) -> str:
+    value = value.strip().lower()
+    value = re.sub(r"[^a-z0-9]+", "-", value)
+    return value.strip("-") or "unknown"
+
+
+def normalize_entity_id(kind: str, name: str) -> str:
+    return f"{slug(kind)}:{slug(name)}"
+
+
+def validate_entity(entity: Entity, allowed_types: Iterable[str]) -> None:
+    allowed = set(allowed_types)
+    if entity.type not in allowed:
+        raise PolicyViolation(f"unknown entity type: {entity.type}")
+    if not entity.id or ":" not in entity.id:
+        raise PolicyViolation(f"invalid entity id: {entity.id}")
+
+
+def validate_predicate(predicate: str, allowed_predicates: Iterable[str]) -> None:
+    if predicate not in set(allowed_predicates):
+        raise PolicyViolation(f"unknown predicate: {predicate}")
+
+
+def validate_triple(triple: Triple, allowed_types: Iterable[str], allowed_predicates: Iterable[str]) -> None:
+    validate_entity(triple.subject, allowed_types)
+    validate_entity(triple.object, allowed_types)
+    validate_predicate(triple.predicate, allowed_predicates)
+    if not 0.0 <= float(triple.confidence) <= 1.0:
+        raise PolicyViolation(f"confidence out of range: {triple.confidence}")
+
+
+def hash_json(data: Any) -> str:
+    import json
+
+    payload = json.dumps(data, sort_keys=True, separators=(",", ":"), default=str).encode("utf-8")
+    return hashlib.sha256(payload).hexdigest()
+
+
+def redact_secrets(data: Any) -> Any:
+    if isinstance(data, dict):
+        redacted: Dict[str, Any] = {}
+        for key, value in data.items():
+            if str(key).lower() in _SECRET_KEY_NAMES or "secret" in str(key).lower() or "token" in str(key).lower():
+                redacted[key] = "[REDACTED]"
+            else:
+                redacted[key] = redact_secrets(value)
+        return redacted
+    if isinstance(data, list):
+        return [redact_secrets(item) for item in data]
+    return data

--- a/plugins/memory/mempalace_ladybug_projection/plugin.yaml
+++ b/plugins/memory/mempalace_ladybug_projection/plugin.yaml
@@ -1,0 +1,12 @@
+name: mempalace_ladybug_projection
+version: 0.2.0
+description: MemPalace source-of-truth memory with mandatory read-only LadybugDB-compatible projection, Droid rebuilds, Aegis policy gate, and MCP read tools.
+kind: exclusive
+category: memory
+author: Warren L / EdgeGDE
+provides_tools:
+  - mempalace_ladybug_entity
+  - mempalace_ladybug_subgraph
+  - mempalace_ladybug_manifest
+pip_dependencies: []
+external_dependencies: []

--- a/plugins/memory/mempalace_ladybug_projection/projection.py
+++ b/plugins/memory/mempalace_ladybug_projection/projection.py
@@ -1,0 +1,252 @@
+from __future__ import annotations
+
+import json
+import shutil
+import sqlite3
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, Iterable, Optional
+
+from .aegis import PolicyConfig
+from .mempalace_adapter import MemPalaceKGAdapter
+from .models import Entity, Graph, GraphEdge, Triple
+from .ontology import ADAPTER_NAME, DEFAULT_ENTITY_TYPES, POLICY_VERSION, SCHEMA_VERSION, VERSION, hash_json, validate_triple
+
+
+class LadybugSQLiteStore:
+    """SQLite-backed LadybugDB-compatible projection store.
+
+    The optional DuckDB/LadybugDB engine path is intentionally abstracted. In
+    environments without the optional binary package, this store provides a
+    dependency-free graph projection using the same node/edge schema.
+    """
+
+    def __init__(self, db_path: str | Path):
+        self.db_path = Path(db_path)
+        if str(db_path) != ":memory:":
+            self.db_path.parent.mkdir(parents=True, exist_ok=True)
+        self._init_schema()
+
+    def _connect(self) -> sqlite3.Connection:
+        return sqlite3.connect(self.db_path)
+
+    def _init_schema(self) -> None:
+        con = self._connect()
+        try:
+            con.executescript(
+                """
+                CREATE TABLE IF NOT EXISTS nodes (
+                    id TEXT PRIMARY KEY,
+                    name TEXT NOT NULL,
+                    type TEXT NOT NULL,
+                    properties TEXT NOT NULL DEFAULT '{}'
+                );
+                CREATE TABLE IF NOT EXISTS edges (
+                    id TEXT PRIMARY KEY,
+                    subject TEXT NOT NULL,
+                    predicate TEXT NOT NULL,
+                    object TEXT NOT NULL,
+                    properties TEXT NOT NULL DEFAULT '{}',
+                    FOREIGN KEY(subject) REFERENCES nodes(id),
+                    FOREIGN KEY(object) REFERENCES nodes(id)
+                );
+                CREATE TABLE IF NOT EXISTS facts (
+                    triple_id TEXT PRIMARY KEY,
+                    subject TEXT NOT NULL,
+                    predicate TEXT NOT NULL,
+                    object TEXT NOT NULL,
+                    valid_from TEXT,
+                    valid_to TEXT,
+                    confidence REAL NOT NULL DEFAULT 1.0,
+                    source TEXT NOT NULL DEFAULT '{}',
+                    properties TEXT NOT NULL DEFAULT '{}'
+                );
+                CREATE TABLE IF NOT EXISTS predicates (
+                    name TEXT PRIMARY KEY
+                );
+                CREATE TABLE IF NOT EXISTS drawers (
+                    id TEXT PRIMARY KEY,
+                    drawer_hash TEXT,
+                    source_file TEXT,
+                    source_closet TEXT
+                );
+                CREATE TABLE IF NOT EXISTS projection_manifests (
+                    projection_id TEXT PRIMARY KEY,
+                    manifest TEXT NOT NULL
+                );
+                """
+            )
+            con.commit()
+        finally:
+            con.close()
+
+    def write_graph(self, graph: Graph, facts: Iterable[Triple]) -> None:
+        con = self._connect()
+        try:
+            con.execute("DELETE FROM edges")
+            con.execute("DELETE FROM facts")
+            con.execute("DELETE FROM predicates")
+            con.execute("DELETE FROM nodes")
+            for entity in graph.nodes.values():
+                con.execute(
+                    "INSERT INTO nodes(id, name, type, properties) VALUES (?, ?, ?, ?)",
+                    (entity.id, entity.name, entity.type, json.dumps(entity.properties, sort_keys=True)),
+                )
+            for edge in graph.edges:
+                con.execute(
+                    "INSERT INTO edges(id, subject, predicate, object, properties) VALUES (?, ?, ?, ?, ?)",
+                    (edge.id, edge.subject, edge.predicate, edge.object, json.dumps(edge.properties, sort_keys=True)),
+                )
+                con.execute("INSERT OR IGNORE INTO predicates(name) VALUES (?)", (edge.predicate,))
+            for fact in facts:
+                con.execute(
+                    "INSERT INTO facts(triple_id, subject, predicate, object, valid_from, valid_to, confidence, source, properties) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                    (
+                        fact.triple_id,
+                        fact.subject.id,
+                        fact.predicate,
+                        fact.object.id,
+                        fact.valid_from,
+                        fact.valid_to,
+                        fact.confidence,
+                        json.dumps(fact.source.to_dict(), sort_keys=True),
+                        json.dumps(fact.properties, sort_keys=True),
+                    ),
+                )
+            con.commit()
+        finally:
+            con.close()
+
+    def count_nodes(self) -> int:
+        if str(self.db_path) == ":memory:":
+            return 0
+        con = self._connect()
+        try:
+            return int(con.execute("SELECT COUNT(*) FROM nodes").fetchone()[0])
+        finally:
+            con.close()
+
+    def count_edges(self) -> int:
+        if str(self.db_path) == ":memory:":
+            return 0
+        con = self._connect()
+        try:
+            return int(con.execute("SELECT COUNT(*) FROM edges").fetchone()[0])
+        finally:
+            con.close()
+
+
+class DroidProjectionWorker:
+    """Deterministic projection worker from MemPalace KG to LadybugDB-compatible output."""
+
+    def __init__(self, output_dir: str | Path, policy_config: PolicyConfig | None = None):
+        self.output_dir = Path(output_dir)
+        self.policy_config = policy_config or PolicyConfig()
+
+    def build(self, source_db: str | Path, policy_version: str = POLICY_VERSION) -> Dict[str, Any]:
+        self.output_dir.mkdir(parents=True, exist_ok=True)
+        active_dir = self.output_dir / "active"
+        if active_dir.exists():
+            previous_manifest = active_dir / "manifest.json"
+        else:
+            previous_manifest = None
+
+        staging_dir = self.output_dir / ".staging"
+        if staging_dir.exists():
+            shutil.rmtree(staging_dir)
+        staging_dir.mkdir(parents=True)
+
+        adapter = MemPalaceKGAdapter(source_db)
+        triples = adapter.read_triples()
+        for triple in triples:
+            validate_triple(triple, DEFAULT_ENTITY_TYPES, self.policy_config.allowed_predicates)
+
+        graph = self._graph_from_triples(triples)
+        manifest = self._manifest(triples, graph, policy_version, previous_manifest)
+        (staging_dir / "manifest.json").write_text(json.dumps(manifest, indent=2, sort_keys=True), encoding="utf-8")
+        (staging_dir / "graph.json").write_text(json.dumps(graph.to_dict(), indent=2, sort_keys=True), encoding="utf-8")
+        LadybugSQLiteStore(staging_dir / "ladybug.sqlite3").write_graph(graph, triples)
+        (staging_dir / "projection.jsonl").write_text(
+            "".join(json.dumps(triple.to_dict(), sort_keys=True) + "\n" for triple in triples),
+            encoding="utf-8",
+        )
+
+        active_dir.mkdir(parents=True, exist_ok=True)
+        for child in staging_dir.iterdir():
+            destination = active_dir / child.name
+            if child.is_dir():
+                shutil.copytree(child, destination, dirs_exist_ok=True)
+            else:
+                shutil.copy2(child, destination)
+        shutil.rmtree(staging_dir)
+        (self.output_dir / "active.json").write_text(json.dumps({"projection_id": manifest["projection_id"], "active_dir": "active"}, indent=2, sort_keys=True), encoding="utf-8")
+
+        if previous_manifest is not None and previous_manifest.exists():
+            previous_id = json.loads(previous_manifest.read_text(encoding="utf-8")).get("projection_id", "")
+            (self.output_dir / "active_previous.json").write_text(json.dumps({"projection_id": previous_id}, indent=2), encoding="utf-8")
+        return manifest
+
+    def _graph_from_triples(self, triples: Iterable[Triple]) -> Graph:
+        graph = Graph()
+        for triple in triples:
+            graph.add_entity(triple.subject)
+            graph.add_entity(triple.object)
+            edge_id = hash_json({"triple_id": triple.triple_id, "direction": "subject_object"})
+            graph.add_edge(GraphEdge(
+                id=edge_id,
+                subject=triple.subject.id,
+                predicate=triple.predicate,
+                object=triple.object.id,
+                properties={
+                    "fact_id": triple.triple_id,
+                    "valid_from": triple.valid_from,
+                    "valid_to": triple.valid_to,
+                    "confidence": triple.confidence,
+                    "source_drawer_id": triple.source.drawer_id,
+                    "adapter_version": triple.source.adapter_version,
+                    "policy_version": POLICY_VERSION,
+                },
+            ))
+            reverse_id = hash_json({"triple_id": triple.triple_id, "direction": "object_subject"})
+            graph.add_edge(GraphEdge(
+                id=reverse_id,
+                subject=triple.object.id,
+                predicate=f"inverse:{triple.predicate}",
+                object=triple.subject.id,
+                properties={
+                    "fact_id": triple.triple_id,
+                    "valid_from": triple.valid_from,
+                    "valid_to": triple.valid_to,
+                    "confidence": triple.confidence,
+                    "source_drawer_id": triple.source.drawer_id,
+                    "adapter_version": triple.source.adapter_version,
+                    "policy_version": POLICY_VERSION,
+                    "inverse_of": triple.predicate,
+                },
+            ))
+        return graph
+
+    def _manifest(self, triples: list[Triple], graph: Graph, policy_version: str, previous_manifest: Optional[Path]) -> Dict[str, Any]:
+        previous_id = ""
+        if previous_manifest is not None and previous_manifest.exists():
+            previous_id = json.loads(previous_manifest.read_text(encoding="utf-8")).get("projection_id", "")
+        payload = {
+            "projection_id": f"mempalace-ladybug-{datetime.now(timezone.utc).strftime('%Y%m%dT%H%M%SZ')}",
+            "schema_version": SCHEMA_VERSION,
+            "adapter_version": VERSION,
+            "mempalace_version": "3.3.3",
+            "ladybug_version": "sqlite-compatible-1.0.0",
+            "source_drawer_count": len({triple.source.drawer_id for triple in triples if triple.source.drawer_id}),
+            "changed_drawer_count": len({triple.source.drawer_id for triple in triples if triple.source.drawer_id}),
+            "entity_count": len(graph.nodes),
+            "fact_count": len(triples),
+            "edge_count": len(graph.edges),
+            "policy_version": policy_version,
+            "created_at": datetime.now(timezone.utc).isoformat(),
+            "created_by": "droid",
+            "approved_by": "hermes",
+            "source_hash": hash_json([triple.to_dict() for triple in triples]),
+            "projection_hash": hash_json(graph.to_dict()),
+            "rollback_to": previous_id,
+        }
+        return payload

--- a/plugins/memory/mempalace_ladybug_projection/provider.py
+++ b/plugins/memory/mempalace_ladybug_projection/provider.py
@@ -1,0 +1,134 @@
+from __future__ import annotations
+
+import json
+import sqlite3
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from agent.memory_provider import MemoryProvider
+
+from .aegis import AegisPolicyGate, PolicyConfig
+from .mcp import MCPReadAPI
+from .projection import DroidProjectionWorker, LadybugSQLiteStore
+from .retriever import GraphRetriever, TokenBudgetPolicy
+
+
+class MemPalaceLadybugProjectionProvider(MemoryProvider):
+    """Local read-only memory provider backed by MemPalace and Ladybug projection."""
+
+    @property
+    def name(self) -> str:
+        return "mempalace-ladybug-projection"
+
+    def __init__(self) -> None:
+        self._session_id = ""
+        self._hermes_home: Optional[Path] = None
+        self._mempalace_home: Optional[Path] = None
+        self._output_dir: Optional[Path] = None
+        self._active_projection: Optional[Path] = None
+        self._api: Optional[MCPReadAPI] = None
+        self._retriever = GraphRetriever(TokenBudgetPolicy())
+        self._gate = AegisPolicyGate(PolicyConfig())
+
+    def is_available(self) -> bool:
+        return True
+
+    def initialize(self, session_id: str, **kwargs: Any) -> None:
+        self._session_id = session_id
+        self._hermes_home = Path(kwargs.get("hermes_home") or Path.home() / ".hermes")
+        hermes_home = Path(kwargs.get("hermes_home") or Path.home() / ".hermes")
+        self._output_dir = Path(kwargs.get("mempalace_ladybug_output_dir") or hermes_home / "mempalace-ladybug-projection")
+        self._mempalace_home = Path(kwargs.get("mempalace_home") or self._mempalace_home or Path.home() / ".mempalace")
+        source_db = self._mempalace_home / "knowledge_graph.sqlite3"
+        if source_db.exists():
+            manifest = DroidProjectionWorker(self._output_dir).build(source_db)
+            self._active_projection = self._output_dir / "active"
+            self._api = MCPReadAPI(LadybugSQLiteStore(self._active_projection / "ladybug.sqlite3"), self._gate)
+            (self._output_dir / "last_manifest.json").write_text(json.dumps(manifest, indent=2, sort_keys=True), encoding="utf-8")
+
+    def system_prompt_block(self) -> str:
+        return (
+            "\nMemory read-only projection policy:\n"
+            "- MemPalace is the source of truth for user memory.\n"
+            "- LadybugDB-compatible projection is a mandatory read-only graph cache.\n"
+            "- Do not claim you wrote memory facts unless a user explicitly asked for Hermes memory maintenance.\n"
+            "- Use bounded graph context and cite projection manifest freshness when relevant.\n"
+        )
+
+    def prefetch(self, query: str, *, session_id: str = "") -> str:
+        if not self._active_projection:
+            return ""
+        graph = self._api._load_graph_from_store() if self._api else {"nodes": {}, "edges": []}
+        context = self._retriever.retrieve(graph, entity_id="person:warren-l", query=query)
+        return self._retriever.format_context(context)
+
+    def get_tool_schemas(self) -> List[Dict[str, Any]]:
+        return [
+            {
+                "name": "mempalace_ladybug_entity",
+                "description": "Read bounded facts connected to a memory entity from the read-only Ladybug projection.",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "entity_id": {"type": "string"},
+                        "predicates": {"type": "array", "items": {"type": "string"}},
+                        "max_nodes": {"type": "integer", "default": 25},
+                        "max_edges": {"type": "integer", "default": 50},
+                    },
+                    "required": ["entity_id"],
+                },
+            },
+            {
+                "name": "mempalace_ladybug_subgraph",
+                "description": "Read a bounded, policy-gated subgraph from the read-only Ladybug projection.",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "entity_id": {"type": "string"},
+                        "predicates": {"type": "array", "items": {"type": "string"}},
+                        "max_depth": {"type": "integer", "default": 2},
+                        "max_nodes": {"type": "integer", "default": 50},
+                        "max_edges": {"type": "integer", "default": 100},
+                    },
+                    "required": ["entity_id"],
+                },
+            },
+            {
+                "name": "mempalace_ladybug_manifest",
+                "description": "Read the read-only memory projection manifest for freshness, counts, and rollback pointer.",
+                "parameters": {"type": "object", "properties": {}, "required": []},
+            },
+        ]
+
+    def handle_tool_call(self, tool_name: str, args: Dict[str, Any], **kwargs: Any) -> str:
+        if tool_name == "mempalace_ladybug_manifest":
+            manifest_path = self._output_dir / "last_manifest.json" if self._output_dir else None
+            manifest = json.loads(manifest_path.read_text(encoding="utf-8")) if manifest_path and manifest_path.exists() else {}
+            return json.dumps({"status": "ok", "result": manifest}, sort_keys=True)
+        if tool_name not in {"mempalace_ladybug_entity", "mempalace_ladybug_subgraph"}:
+            raise ValueError(f"write tool not exposed by read-only memory provider: {tool_name}")
+        if not self._api:
+            return json.dumps({"status": "error", "error": "projection not initialized"}, sort_keys=True)
+        graph = self._api._load_graph_from_store()
+        decision = self._gate.evaluate(args, graph)
+        return json.dumps({"status": "ok", "result": decision.filtered_graph}, sort_keys=True)
+
+    def on_memory_write(self, action: str, target: str, content: str, metadata: Optional[Dict[str, Any]] = None) -> None:
+        """Mirror built-in memory writes by invalidating projection freshness.
+
+        The built-in memory write still owns MemPalace. Droid rebuilds the
+        read-only projection on next initialize/build pass.
+        """
+        if not self._output_dir:
+            return
+        self._output_dir.mkdir(parents=True, exist_ok=True)
+        stale = self._output_dir / "stale_after_memory_write.json"
+        stale.write_text(json.dumps({
+            "action": action,
+            "target": target,
+            "metadata": metadata or {},
+            "projection_status": "stale_until_droid_rebuild",
+        }, indent=2, sort_keys=True), encoding="utf-8")
+
+    def shutdown(self) -> None:
+        return

--- a/plugins/memory/mempalace_ladybug_projection/retriever.py
+++ b/plugins/memory/mempalace_ladybug_projection/retriever.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict
+
+
+@dataclass(frozen=True)
+class TokenBudgetPolicy:
+    max_nodes: int = 100
+    max_edges: int = 250
+    max_source_snippets: int = 10
+    max_snippet_chars: int = 500
+
+
+class GraphRetriever:
+    """Bounded graph retriever that avoids raw drawer dumps."""
+
+    def __init__(self, policy: TokenBudgetPolicy | None = None):
+        self.policy = policy or TokenBudgetPolicy()
+
+    def retrieve(self, graph: Dict[str, Any], entity_id: str, query: str) -> Dict[str, Any]:
+        nodes = graph.get("nodes", {})
+        edges = graph.get("edges", [])
+        selected_nodes: Dict[str, Any] = {}
+        selected_edges: list[Dict[str, Any]] = []
+        if entity_id in nodes:
+            selected_nodes[entity_id] = nodes[entity_id]
+        for edge in edges:
+            if edge.get("subject") == entity_id or edge.get("object") == entity_id:
+                if len(selected_edges) >= self.policy.max_edges:
+                    break
+                selected_edges.append(edge)
+                selected_nodes[edge["subject"]] = nodes.get(edge["subject"], {"id": edge["subject"], "type": "unknown"})
+                selected_nodes[edge["object"]] = nodes.get(edge["object"], {"id": edge["object"], "type": "unknown"})
+                if len(selected_nodes) >= self.policy.max_nodes:
+                    break
+        return {
+            "query": query,
+            "entity_id": entity_id,
+            "nodes": dict(list(selected_nodes.items())[: self.policy.max_nodes]),
+            "edges": selected_edges[: self.policy.max_edges],
+            "source_snippets": [],
+            "token_policy": {
+                "max_nodes": self.policy.max_nodes,
+                "max_edges": self.policy.max_edges,
+                "max_source_snippets": self.policy.max_source_snippets,
+                "max_snippet_chars": self.policy.max_snippet_chars,
+            },
+        }
+
+    def format_context(self, context: Dict[str, Any]) -> str:
+        lines = [f"Memory graph context for {context.get('entity_id')}"]
+        for entity in context.get("nodes", {}).values():
+            if hasattr(entity, "to_dict"):
+                entity = entity.to_dict()
+            lines.append(f"- {entity.get('id')}: {entity.get('name') or entity.get('id')} ({entity.get('type')})")
+        for edge in context.get("edges", []):
+            lines.append(
+                f"- {edge.get('subject')} --{edge.get('predicate')}--> {edge.get('object')} "
+                f"[confidence={edge.get('properties', {}).get('confidence', 1.0)}]"
+            )
+        return "\n".join(lines)

--- a/tests/plugins/memory/test_mempalace_ladybug_projection.py
+++ b/tests/plugins/memory/test_mempalace_ladybug_projection.py
@@ -1,0 +1,163 @@
+import json
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from plugins.memory.mempalace_ladybug_projection.models import Entity, Source, Triple
+from plugins.memory.mempalace_ladybug_projection.ontology import (
+    DEFAULT_PREDICATES,
+    DEFAULT_ENTITY_TYPES,
+    normalize_entity_id,
+    validate_entity,
+    validate_predicate,
+)
+from plugins.memory.mempalace_ladybug_projection.aegis import AegisPolicyGate, PolicyConfig, PolicyViolation
+from plugins.memory.mempalace_ladybug_projection.mempalace_adapter import MemPalaceKGAdapter
+from plugins.memory.mempalace_ladybug_projection.projection import DroidProjectionWorker, LadybugSQLiteStore
+from plugins.memory.mempalace_ladybug_projection.mcp import MCPReadAPI
+from plugins.memory.mempalace_ladybug_projection.retriever import GraphRetriever, TokenBudgetPolicy
+from plugins.memory.mempalace_ladybug_projection.provider import MemPalaceLadybugProjectionProvider
+
+
+def test_ontology_normalizes_entities_and_rejects_unknown_predicates():
+    entity = Entity(id="person:warren-l", name="Warren L", type="person")
+    assert validate_entity(entity, DEFAULT_ENTITY_TYPES) is None
+
+    assert normalize_entity_id("person", "Warren L") == "person:warren-l"
+    assert validate_predicate("leads", DEFAULT_PREDICATES) is None
+    with pytest.raises(PolicyViolation, match="unknown predicate"):
+        validate_predicate("secret_write", DEFAULT_PREDICATES)
+
+
+def test_aegis_denies_unauthorized_predicate_and_redacts_secrets(tmp_path):
+    graph = {
+        "nodes": {
+            "person:warren-l": Entity(id="person:warren-l", name="Warren L", type="person"),
+            "project:edgegde": Entity(id="project:edgegde", name="EdgeGDE", type="project"),
+        },
+        "edges": [
+            {
+                "id": "edge-1",
+                "subject": "person:warren-l",
+                "predicate": "leads",
+                "object": "project:edgegde",
+                "properties": {"confidence": 1.0, "valid_from": "2026-06-18", "api_key": "sk-secret"},
+            }
+        ],
+    }
+    gate = AegisPolicyGate(PolicyConfig(
+        actor_id="agent",
+        actor_role="assistant",
+        allowed_predicates={"leads"},
+        max_depth=2,
+        max_nodes=10,
+        max_edges=10,
+        min_confidence=0.8,
+        require_source=True,
+        redact_secrets=True,
+    ))
+
+    with pytest.raises(PolicyViolation, match="predicate"):
+        gate.evaluate({"predicates": ["secret_write"], "max_depth": 1, "max_nodes": 10, "max_edges": 10}, graph)
+
+    decision = gate.evaluate({"predicates": ["leads"], "max_depth": 1, "max_nodes": 10, "max_edges": 10}, graph)
+    assert decision.allowed
+    assert decision.filtered_graph["edges"][0]["properties"]["api_key"] == "[REDACTED]"
+
+
+def test_mempalace_adapter_reads_sqlite_kg(tmp_path):
+    db = tmp_path / "knowledge_graph.sqlite3"
+    con = sqlite3.connect(db)
+    con.execute("CREATE TABLE entities (id TEXT PRIMARY KEY, name TEXT NOT NULL, type TEXT DEFAULT 'unknown', properties TEXT DEFAULT '{}', created_at TEXT DEFAULT CURRENT_TIMESTAMP)")
+    con.execute("CREATE TABLE triples (id TEXT PRIMARY KEY, subject TEXT NOT NULL, predicate TEXT NOT NULL, object TEXT NOT NULL, valid_from TEXT, valid_to TEXT, confidence REAL DEFAULT 1.0, source_closet TEXT, source_file TEXT, source_drawer_id TEXT, adapter_name TEXT, extracted_at TEXT DEFAULT CURRENT_TIMESTAMP)")
+    con.execute("INSERT INTO entities VALUES (?, ?, ?, ?, ?)", ("person:warren-l", "Warren L", "person", "{}", "2026-06-18T00:00:00Z"))
+    con.execute("INSERT INTO triples VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)", ("triple-1", "person:warren-l", "leads", "project:edgegde", "2026-06-18", None, 1.0, "memory-reference", "drawer.md", "drawer-1", "mempalace", "2026-06-18T00:00:00Z"))
+    con.commit()
+    con.close()
+
+    adapter = MemPalaceKGAdapter(db)
+    triples = adapter.read_triples()
+    assert len(triples) == 1
+    assert triples[0].subject.id == "person:warren-l"
+    assert triples[0].predicate == "leads"
+    assert triples[0].source.drawer_id == "drawer-1"
+
+
+def test_projection_worker_builds_manifest_and_ladybug_sqlite_projection(tmp_path):
+    source_db = tmp_path / "source.sqlite3"
+    con = sqlite3.connect(source_db)
+    con.execute("CREATE TABLE entities (id TEXT PRIMARY KEY, name TEXT NOT NULL, type TEXT DEFAULT 'unknown', properties TEXT DEFAULT '{}', created_at TEXT DEFAULT CURRENT_TIMESTAMP)")
+    con.execute("CREATE TABLE triples (id TEXT PRIMARY KEY, subject TEXT NOT NULL, predicate TEXT NOT NULL, object TEXT NOT NULL, valid_from TEXT, valid_to TEXT, confidence REAL DEFAULT 1.0, source_closet TEXT, source_file TEXT, source_drawer_id TEXT, adapter_name TEXT, extracted_at TEXT DEFAULT CURRENT_TIMESTAMP)")
+    con.execute("INSERT INTO entities VALUES (?, ?, ?, ?, ?)", ("person:warren-l", "Warren L", "person", "{}", "2026-06-18T00:00:00Z"))
+    con.execute("INSERT INTO entities VALUES (?, ?, ?, ?, ?)", ("project:edgegde", "EdgeGDE", "project", "{}", "2026-06-18T00:00:00Z"))
+    con.execute("INSERT INTO triples VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)", ("triple-1", "person:warren-l", "leads", "project:edgegde", "2026-06-18", None, 1.0, "memory-reference", "drawer.md", "drawer-1", "mempalace", "2026-06-18T00:00:00Z"))
+    con.commit()
+    con.close()
+
+    output = tmp_path / "ladybug"
+    worker = DroidProjectionWorker(output_dir=output)
+    manifest = worker.build(source_db=source_db)
+
+    assert manifest["entity_count"] == 2
+    assert manifest["fact_count"] == 1
+    assert manifest["edge_count"] == 2
+    assert (output / "active.json").exists()
+    assert (output / "active" / "manifest.json").exists()
+
+    store = LadybugSQLiteStore(output / "active" / "ladybug.sqlite3")
+    assert store.count_nodes() == 2
+    assert store.count_edges() == 2
+
+
+def test_mcp_read_api_exposes_only_read_tools_and_rejects_writes():
+    api = MCPReadAPI(LadybugSQLiteStore(":memory:"))
+    names = {schema["name"] for schema in api.get_tool_schemas()}
+    assert "kg_entity" in names
+    assert "kg_relationship" in names
+    assert "kg_subgraph" in names
+    assert "kg_add_fact" not in names
+
+    with pytest.raises(ValueError, match="write tool"):
+        api.handle_tool_call("kg_add_fact", {}, active_projection=None)
+
+
+def test_retriever_bounds_graph_context_and_formats_compact_context():
+    graph = {
+        "nodes": {
+            "person:warren-l": Entity(id="person:warren-l", name="Warren L", type="person"),
+            "project:edgegde": Entity(id="project:edgegde", name="EdgeGDE", type="project"),
+            "tool:hermes": Entity(id="tool:hermes", name="Hermes", type="tool"),
+        },
+        "edges": [
+            {"id": "edge-1", "subject": "person:warren-l", "predicate": "leads", "object": "project:edgegde", "properties": {"confidence": 1.0}},
+            {"id": "edge-2", "subject": "project:edgegde", "predicate": "uses_tool", "object": "tool:hermes", "properties": {"confidence": 1.0}},
+        ],
+    }
+    retriever = GraphRetriever(TokenBudgetPolicy(max_nodes=2, max_edges=1, max_source_snippets=1))
+    context = retriever.retrieve(graph, entity_id="person:warren-l", query="what does Warren lead?")
+
+    assert len(context["nodes"]) <= 2
+    assert len(context["edges"]) <= 1
+    assert "Warren L" in retriever.format_context(context)
+
+
+def test_provider_registers_read_only_tools_and_system_prompt(tmp_path):
+    provider = MemPalaceLadybugProjectionProvider()
+    provider._output_dir = tmp_path / "projection"
+    provider._mempalace_home = tmp_path / "mempalace"
+    provider._mempalace_home.mkdir()
+    db = provider._mempalace_home / "knowledge_graph.sqlite3"
+    con = sqlite3.connect(db)
+    con.execute("CREATE TABLE entities (id TEXT PRIMARY KEY, name TEXT NOT NULL, type TEXT DEFAULT 'unknown', properties TEXT DEFAULT '{}', created_at TEXT DEFAULT CURRENT_TIMESTAMP)")
+    con.execute("CREATE TABLE triples (id TEXT PRIMARY KEY, subject TEXT NOT NULL, predicate TEXT NOT NULL, object TEXT NOT NULL, valid_from TEXT, valid_to TEXT, confidence REAL DEFAULT 1.0, source_closet TEXT, source_file TEXT, source_drawer_id TEXT, adapter_name TEXT, extracted_at TEXT DEFAULT CURRENT_TIMESTAMP)")
+    con.commit()
+    con.close()
+
+    provider.initialize(session_id="test", hermes_home=tmp_path)
+    schemas = provider.get_tool_schemas()
+    names = {schema["name"] for schema in schemas}
+    assert "mempalace_ladybug_entity" in names
+    assert "mempalace_ladybug_manifest" in names
+    assert "mempalace_ladybug_add_fact" not in names
+    assert "read-only" in provider.system_prompt_block()


### PR DESCRIPTION
MemPalace remains the source of truth; LadybugDB-compatible projection is mandatory and read-only.

### What this adds
- Plugin: `plugins/memory/mempalace_ladybug_projection/`
- Deterministic MemPalace SQLite KG adapter
- Droid projection worker with manifest/rollback metadata
- Aegis policy gate for read queries
- MCP/provider read-only tools
- Graph retriever with token-budget controls
- Benchmark and docs
- TDD tests for ontology, policy, projection, MCP, retrieval, and provider behavior

### Verification
- `pytest -q tests/plugins/memory/test_mempalace_ladybug_projection.py` -> 7 passed, 1 warning
- `python -m plugins.memory.mempalace_ladybug_projection.benchmark` -> 25 queries, p95 0.295958ms

### Caveat
The environment does not have a real DuckDB/LadybugDB backend installed, so the committed implementation uses a LadybugDB-compatible SQLite store behind the projection boundary.