### PR TITLE
fix(api-server): guard HERMES_MAX_ITERATIONS against malformed env var

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -58,6 +58,7 @@ from gateway.platforms.base import (
     SendResult,
     is_network_accessible,
 )
+from utils import env_int
 
 logger = logging.getLogger(__name__)
 
@@ -1043,7 +1044,7 @@ class APIServerAdapter(BasePlatformAdapter):
         user_config = _load_gateway_config()
         enabled_toolsets = sorted(_get_platform_tools(user_config, "api_server"))
 
-        max_iterations = int(os.getenv("HERMES_MAX_ITERATIONS", "90"))
+        max_iterations = env_int("HERMES_MAX_ITERATIONS", 90)
 
         # Load fallback provider chain so the API server platform has the
         # same fallback behaviour as Telegram/Discord/Slack (fixes #4954).

--- a/utils.py
+++ b/utils.py
@@ -323,6 +323,17 @@ def env_int(key: str, default: int = 0) -> int:
         return default
 
 
+def env_float(key: str, default: float = 0.0) -> float:
+    """Read an environment variable as a float, with fallback."""
+    raw = os.getenv(key, "").strip()
+    if not raw:
+        return default
+    try:
+        return float(raw)
+    except (ValueError, TypeError):
+        return default
+
+
 def env_bool(key: str, default: bool = False) -> bool:
     """Read an environment variable as a boolean."""
     return is_truthy_value(os.getenv(key, ""), default=default)


### PR DESCRIPTION
## Summary

Replace bare `int(os.getenv("HERMES_MAX_ITERATIONS", "90"))` with `env_int("HERMES_MAX_ITERATIONS", 90)` in `api_server.py`.

A malformed `HERMES_MAX_ITERATIONS` env var (e.g. `"abc"`) causes a `ValueError` crash at startup. The `env_int()` helper in `utils.py` catches `ValueError`/`TypeError` and returns the default value.

Also adds `env_float()` to `utils.py` alongside the existing `env_int()` for consistency — future patches can use it to guard float env vars.

## Changes

- `utils.py`: Add `env_float(key, default)` helper (mirrors existing `env_int`)
- `gateway/platforms/api_server.py`: Import `env_int` from `utils`, replace bare `int(os.getenv(...))` on line 1047

## Test Plan

- [x] `pytest tests/ -xvs -k 'api_server or env_int'` passes
- [x] Lint clean on both modified files

## Context

This is part of a systemic issue — there are ~20 bare `int(os.getenv())` / `float(os.getenv())` calls across the gateway that can crash on malformed env vars. This PR fixes the highest-traffic one (`HERMES_MAX_ITERATIONS` in the API server). Follow-up PRs can address the remaining call sites.
