### PR TITLE
fix(chat): preserve native Option text input on macOS

### DIFF
--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -38,6 +38,12 @@ import { api } from "@/lib/api";
 import { PluginSlot } from "@/plugins";
 import { useTheme } from "@/themes";
 import { useProfileScope } from "@/contexts/useProfileScope";
+import {
+  createChatTerminalOptions,
+  terminalFontSizeForWidth,
+  terminalLineHeightForWidth,
+  TERMINAL_THEME_STATIC,
+} from "@/pages/chatTerminalOptions";
 
 function buildWsUrl(
   authParam: [string, string],
@@ -69,19 +75,6 @@ function generateChannelId(): string {
   return `chat-${Math.random().toString(36).slice(2)}-${Date.now().toString(36)}`;
 }
 
-// Colors for the terminal body.  Matches the dashboard's dark teal canvas
-// with cream foreground — we intentionally don't pick monokai or a loud
-// theme, because the TUI's skin engine already paints the content; the
-// terminal chrome just needs to sit quietly inside the dashboard.
-// `background` is omitted here — it's supplied dynamically from the active
-// theme's `terminalBackground` field so users can control it via YAML themes.
-const TERMINAL_THEME_STATIC = {
-  foreground: "#f0e6d2",
-  cursor: "#f0e6d2",
-  cursorAccent: "#0d2626",
-  selectionBackground: "#f0e6d244",
-};
-
 /**
  * CSS width for xterm font tiers.
  *
@@ -99,20 +92,6 @@ function terminalTierWidthPx(host: HTMLElement | null): number {
   const vvw = vv?.width ?? inner;
   const layout = Math.min(inner, vvw, doc > 0 ? doc : inner);
   return Math.max(1, Math.round(layout));
-}
-
-function terminalFontSizeForWidth(layoutWidthPx: number): number {
-  if (layoutWidthPx < 300) return 7;
-  if (layoutWidthPx < 360) return 8;
-  if (layoutWidthPx < 420) return 9;
-  if (layoutWidthPx < 520) return 10;
-  if (layoutWidthPx < 720) return 11;
-  if (layoutWidthPx < 1024) return 12;
-  return 14;
-}
-
-function terminalLineHeightForWidth(layoutWidthPx: number): number {
-  return layoutWidthPx < 1024 ? 1.02 : 1.15;
 }
 
 export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
@@ -185,6 +164,11 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
     () => ({ ...TERMINAL_THEME_STATIC, background: terminalBg }),
     [terminalBg],
   );
+  const terminalThemeRef = useRef(terminalTheme);
+
+  useEffect(() => {
+    terminalThemeRef.current = terminalTheme;
+  }, [terminalTheme]);
 
   // The dashboard keeps ChatPage mounted persistently so the PTY survives tab
   // switches. That is great for ordinary /chat navigation, but it means query
@@ -320,33 +304,9 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
     }
 
     const tierW0 = terminalTierWidthPx(host);
-    const term = new Terminal({
-      allowProposedApi: true,
-      cursorBlink: true,
-      fontFamily:
-        "'JetBrains Mono', 'Cascadia Mono', 'Fira Code', 'MesloLGS NF', 'Source Code Pro', Menlo, Consolas, 'DejaVu Sans Mono', monospace",
-      fontSize: terminalFontSizeForWidth(tierW0),
-      lineHeight: terminalLineHeightForWidth(tierW0),
-      letterSpacing: 0,
-      fontWeight: "400",
-      fontWeightBold: "700",
-      macOptionIsMeta: true,
-      // Hold Option (Alt on Linux/Windows) to force native text selection
-      // even when the inner Hermes TUI has enabled xterm mouse-events
-      // mode (CSI ?1000h family). Without this, click-and-drag in the
-      // chat canvas selects nothing and Cmd+C falls back to copying the
-      // entire visible buffer, which is rarely what the user wants.
-      // See #25720.
-      macOptionClickForcesSelection: true,
-      // Right-click selects the word under the pointer. xterm.js default
-      // is false; enabling it gives users a single-action selection
-      // path on top of the modifier-based bypass above.
-      rightClickSelectsWord: true,
-      // Browser-embedded chat runs the TUI in inline mode. Keep transcript
-      // history in xterm.js so the browser wheel can scroll it directly.
-      scrollback: 5000,
-      theme: terminalTheme,
-    });
+    const term = new Terminal(
+      createChatTerminalOptions(tierW0, terminalThemeRef.current),
+    );
     termRef.current = term;
 
     // --- Clipboard integration ---------------------------------------

--- a/web/src/pages/chatTerminalOptions.ts
+++ b/web/src/pages/chatTerminalOptions.ts
@@ -1,0 +1,52 @@
+import type { ITerminalOptions, ITheme } from "@xterm/xterm";
+
+export const TERMINAL_THEME_STATIC = {
+  foreground: "#f0e6d2",
+  cursor: "#f0e6d2",
+  cursorAccent: "#0d2626",
+  selectionBackground: "#f0e6d244",
+} as const satisfies ITheme;
+
+export type ChatTerminalTheme = ITheme & { background: string };
+
+const TERMINAL_FONT_FAMILY =
+  "'JetBrains Mono', 'Cascadia Mono', 'Fira Code', 'MesloLGS NF', 'Source Code Pro', Menlo, Consolas, 'DejaVu Sans Mono', monospace";
+
+export function terminalFontSizeForWidth(layoutWidthPx: number): number {
+  if (layoutWidthPx < 300) return 7;
+  if (layoutWidthPx < 360) return 8;
+  if (layoutWidthPx < 420) return 9;
+  if (layoutWidthPx < 520) return 10;
+  if (layoutWidthPx < 720) return 11;
+  if (layoutWidthPx < 1024) return 12;
+  return 14;
+}
+
+export function terminalLineHeightForWidth(layoutWidthPx: number): number {
+  return layoutWidthPx < 1024 ? 1.02 : 1.15;
+}
+
+export function createChatTerminalOptions(
+  layoutWidthPx: number,
+  theme: ChatTerminalTheme,
+): ITerminalOptions {
+  return {
+    allowProposedApi: true,
+    cursorBlink: true,
+    fontFamily: TERMINAL_FONT_FAMILY,
+    fontSize: terminalFontSizeForWidth(layoutWidthPx),
+    lineHeight: terminalLineHeightForWidth(layoutWidthPx),
+    letterSpacing: 0,
+    fontWeight: "400",
+    fontWeightBold: "700",
+    // Preserve native macOS Option+key text composition for layouts where
+    // printable characters like "@" require Option instead of US-Alt chords.
+    macOptionIsMeta: false,
+    // Keep the selection bypass for mouse mode even though plain Option+key
+    // chords now prioritize text input over terminal meta shortcuts.
+    macOptionClickForcesSelection: true,
+    rightClickSelectsWord: true,
+    scrollback: 5000,
+    theme,
+  };
+}


### PR DESCRIPTION
## What does this PR do?

Preserves native macOS `Option` text composition in the embedded Hermes chat terminal so non-US keyboard layouts can still type characters like `@` with `⌥+<key>`. The xterm setup now keeps `macOptionClickForcesSelection` for mouse-mode selection, but stops forcing plain `Option` keypresses into terminal meta chords.

## Related Issue

Fixes #48549

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Extracted chat terminal option construction into `web/src/pages/chatTerminalOptions.ts`
- Switched the embedded chat xterm config from `macOptionIsMeta: true` to `false`
- Kept `macOptionClickForcesSelection` enabled so Option+drag still bypasses mouse-reporting selection issues
- Reused the extracted helpers from `web/src/pages/ChatPage.tsx` without changing the broader chat lifecycle

## How to Test

1. On macOS with a keyboard layout that uses `Option` for printable characters (for example Spanish `⌥+2 -> @`), open Hermes chat in the dashboard.
2. Type an address-like string such as `kali@kali.home` and confirm the `@` is inserted instead of the base key character.
3. Verify Option+drag selection still works in the embedded terminal when mouse reporting is active.
4. Optional local proof from this branch:
   - `node /Users/leongong/Desktop/LeonProjects/worktrees/hermes-agent/.base/ui-tui/node_modules/tsx/dist/cli.mjs --eval "import { createChatTerminalOptions, TERMINAL_THEME_STATIC } from './web/src/pages/chatTerminalOptions.ts'; const opts=createChatTerminalOptions(375,{...TERMINAL_THEME_STATIC,background:'#000'}); console.log(JSON.stringify(opts))"`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS worktree verification via targeted xterm option proof, `git diff --check`, and focused eslint

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

- Helper proof passed with `macOptionIsMeta: false`, `macOptionClickForcesSelection: true`, `fontSize: 9`
- `git diff --check` passed
- `eslint` on touched files reported one existing `ChatPage` exhaustive-deps warning and no errors
- `cd web && node ./node_modules/typescript/bin/tsc -p tsconfig.app.json --noEmit` in the worktree reported an unrelated `src/pages/ChannelsPage.tsx` -> `qrcode` resolution failure outside the touched files
