### PR TITLE
Disable /exit in hosted dashboard chat

### DIFF
--- a/ui-tui/src/__tests__/createSlashHandler.test.ts
+++ b/ui-tui/src/__tests__/createSlashHandler.test.ts
@@ -9,6 +9,10 @@ describe('createSlashHandler', () => {
   beforeEach(() => {
     resetOverlayState()
     resetUiState()
+    delete process.env.HERMES_TUI_INLINE
+    delete process.env.HERMES_HOME
+    delete process.env.HERMES_WRITE_SAFE_ROOT
+    delete process.env.HERMES_DISABLE_LAZY_INSTALLS
   })
 
   it('opens the unified sessions overlay for /resume', () => {
@@ -66,6 +70,32 @@ describe('createSlashHandler', () => {
     expect(createSlashHandler(ctx)('/quit')).toBe(true)
     expect(ctx.session.die).toHaveBeenCalledTimes(1)
     expect(ctx.gateway.gw.request).not.toHaveBeenCalled()
+  })
+
+  it('keeps hosted dashboard chat alive for /exit', () => {
+    process.env.HERMES_TUI_INLINE = '1'
+    process.env.HERMES_HOME = '/opt/data/profiles/worker'
+    process.env.HERMES_WRITE_SAFE_ROOT = '/opt/data'
+    process.env.HERMES_DISABLE_LAZY_INSTALLS = '1'
+    const ctx = buildCtx()
+
+    expect(createSlashHandler(ctx)('/exit')).toBe(true)
+    expect(ctx.session.die).not.toHaveBeenCalled()
+    expect(ctx.gateway.gw.request).not.toHaveBeenCalled()
+    expect(ctx.transcript.sys).toHaveBeenCalledWith(
+      'exit is disabled in hosted dashboard chat — use /new to start a fresh session'
+    )
+  })
+
+  it('keeps /quit available outside hosted dashboard chat', () => {
+    process.env.HERMES_TUI_INLINE = '1'
+    process.env.HERMES_HOME = '/Users/example/.hermes'
+    process.env.HERMES_WRITE_SAFE_ROOT = '/Users/example/.hermes'
+    process.env.HERMES_DISABLE_LAZY_INSTALLS = '1'
+    const ctx = buildCtx()
+
+    expect(createSlashHandler(ctx)('/quit')).toBe(true)
+    expect(ctx.session.die).toHaveBeenCalledTimes(1)
   })
 
   it('handles /update locally and exits with code 42 via dieWithCode', () => {

--- a/ui-tui/src/app/slash/commands/core.ts
+++ b/ui-tui/src/app/slash/commands/core.ts
@@ -76,6 +76,20 @@ const DETAILS_USAGE =
 
 const DETAILS_SECTION_USAGE = 'usage: /details <section> [hidden|collapsed|expanded|reset]'
 
+const truthyEnv = (v?: string) => /^(?:1|true|yes|on)$/i.test((v ?? '').trim())
+
+const hostedInlineDashboardChat = () => {
+  const hermesHome = (process.env.HERMES_HOME ?? '').trim()
+  const hostedHome = hermesHome === '/opt/data' || hermesHome.startsWith('/opt/data/')
+
+  return (
+    process.env.HERMES_TUI_INLINE === '1' &&
+    hostedHome &&
+    process.env.HERMES_WRITE_SAFE_ROOT === '/opt/data' &&
+    truthyEnv(process.env.HERMES_DISABLE_LAZY_INSTALLS)
+  )
+}
+
 export const coreCommands: SlashCommand[] = [
   {
     help: 'list commands + hotkeys',
@@ -113,7 +127,15 @@ export const coreCommands: SlashCommand[] = [
     aliases: ['exit'],
     help: 'exit hermes',
     name: 'quit',
-    run: (_arg, ctx) => ctx.session.die()
+    run: (_arg, ctx) => {
+      if (hostedInlineDashboardChat()) {
+        ctx.transcript.sys('exit is disabled in hosted dashboard chat — use /new to start a fresh session')
+
+        return
+      }
+
+      ctx.session.die()
+    }
   },
 
   {


### PR DESCRIPTION
## Summary

Fixes NS-524 by keeping the embedded hosted dashboard chat process alive when a user types `/exit` or `/quit`.

The dashboard chat uses the TUI local slash-command layer, where `/exit` is an alias for `/quit` and calls `ctx.session.die()` before Python gateway/CLI command handling can intervene. In hosted dashboard chat, that kills the backing PTY/TUI process and leaves the chat tab unusable unless the page is refreshed.

This change detects the existing hosted dashboard env shape (`HERMES_TUI_INLINE=1`, `/opt/data` HERMES_HOME/profile home, `HERMES_WRITE_SAFE_ROOT=/opt/data`, lazy installs disabled) and turns `/exit` into a refusal message that points users to `/new` for a fresh session. Local/self-hosted TUI `/quit` behavior is unchanged.

## Validation

- `npm --workspace ui-tui test -- src/__tests__/createSlashHandler.test.ts`
- `npm --workspace ui-tui run typecheck`
- `npm --workspace ui-tui exec -- eslint src/app/slash/commands/core.ts`
- `git diff --check`
