### PR TITLE
fix(gateway): guard HERMES_MAX_ITERATIONS in run.py against malformed env var

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1155,7 +1155,7 @@ sys.path.insert(0, str(Path(__file__).parent.parent))
 
 # Resolve Hermes home directory (respects HERMES_HOME override)
 from hermes_constants import get_hermes_home
-from utils import atomic_json_write, atomic_yaml_write, base_url_host_matches, is_truthy_value
+from utils import atomic_json_write, atomic_yaml_write, base_url_host_matches, env_int, is_truthy_value
 _hermes_home = get_hermes_home()
 
 # Load environment variables from ~/.hermes/.env first.
@@ -10633,7 +10633,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             disabled_toolsets = agent_cfg.get("disabled_toolsets") or None
 
             pr = self._provider_routing
-            max_iterations = int(os.getenv("HERMES_MAX_ITERATIONS", "90"))
+            max_iterations = env_int("HERMES_MAX_ITERATIONS", 90)
             reasoning_config = self._resolve_session_reasoning_config(source=source)
             self._reasoning_config = reasoning_config
             self._service_tier = self._load_service_tier()
@@ -14583,7 +14583,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             os.environ["HERMES_SESSION_KEY"] = session_key or ""
 
             # Read from env var or use default (same as CLI)
-            max_iterations = int(os.getenv("HERMES_MAX_ITERATIONS", "90"))
+            max_iterations = env_int("HERMES_MAX_ITERATIONS", 90)
             
             # Map platform enum to the platform hint key the agent understands.
             # Platform.LOCAL ("local") maps to "cli"; others pass through as-is.


### PR DESCRIPTION
## Summary

Replace bare int(os.getenv("HERMES_MAX_ITERATIONS", "90")) with env_int("HERMES_MAX_ITERATIONS", 90) at two call sites in gateway/run.py (lines 10636 and 14586).

A malformed HERMES_MAX_ITERATIONS env var (e.g. "abc") causes a ValueError crash. The env_int() helper in utils.py catches ValueError/TypeError and returns the default value.

Note: Line 4965 already has a try/except guard so it is left as-is.

## Changes

- gateway/run.py: Add env_int to existing utils import, replace 2 bare int(os.getenv(...)) calls

## Test Plan

- [x] pytest passes (unrelated failure in test_copilot_acp_client is pre-existing)
- [x] Lint clean

## Context

This is part of a systemic issue with ~25 bare int(os.getenv)/float(os.getenv) calls across the gateway. Related: PR #48735 (api_server.py + env_float addition to utils.py).
