### PR TITLE
fix(desktop): settle the in-progress todo spinner when the turn ends

### DIFF
--- a/apps/desktop/src/app/chat/composer/status-stack/index.tsx
+++ b/apps/desktop/src/app/chat/composer/status-stack/index.tsx
@@ -20,6 +20,7 @@ import {
   stopBackgroundProcess
 } from '@/store/composer-status'
 import { $threadScrolledUp } from '@/store/thread-scroll'
+import { $workingSessionIds } from '@/store/session'
 import { openSessionInNewWindow } from '@/store/windows'
 
 import { StatusItemRow } from './status-row'
@@ -53,6 +54,14 @@ export function ComposerStatusStack({ queue, sessionId }: ComposerStatusStackPro
   const navigate = useNavigate()
   const itemsBySession = useStore($statusItemsBySession)
   const scrolledUp = useStore($threadScrolledUp)
+  const workingSessionIds = useStore($workingSessionIds)
+
+  // Whether THIS session's turn is actively running. A todo marked
+  // `in_progress` only deserves a live spinner while the agent is working — if
+  // the turn ends (or the agent stops to ask the user something) mid-plan, the
+  // spinner must settle instead of grinding forever (the "task pane hangs at
+  // the end" report). Off-session / no-session → not working.
+  const sessionWorking = !!sessionId && workingSessionIds.includes(sessionId)
 
   const groups = useMemo(
     () => groupStatusItems(sessionId ? (itemsBySession[sessionId] ?? []) : []),
@@ -116,6 +125,7 @@ export function ComposerStatusStack({ queue, sessionId }: ComposerStatusStackPro
             onDismiss={sessionId ? id => dismissBackgroundProcess(sessionId, id) : undefined}
             onOpen={() => openSubagent(item)}
             onStop={sessionId ? id => stopBackgroundProcess(sessionId, id) : undefined}
+            sessionWorking={sessionWorking}
           />
         ))}
       </StatusSection>

--- a/apps/desktop/src/app/chat/composer/status-stack/status-row.test.tsx
+++ b/apps/desktop/src/app/chat/composer/status-stack/status-row.test.tsx
@@ -1,0 +1,76 @@
+import { render } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+
+import { I18nProvider } from '@/i18n'
+import type { ComposerStatusItem } from '@/store/composer-status'
+
+import { StatusItemRow } from './status-row'
+
+// Regression guard for the "task pane hangs at the end" report: an in_progress
+// todo must show a live spinner ONLY while the session's turn is running. When
+// the turn settles (agent finished / stopped / waiting on the user) a todo left
+// in_progress must NOT keep spinning forever.
+
+function todoItem(): ComposerStatusItem {
+  return {
+    id: 'todo:1',
+    title: 'in-flight step',
+    type: 'todo',
+    state: 'running', // todoToItem maps in_progress -> state:'running'
+    todoStatus: 'in_progress'
+  }
+}
+
+function renderRow(item: ComposerStatusItem, sessionWorking: boolean) {
+  return render(
+    <I18nProvider configClient={null}>
+      <StatusItemRow item={item} sessionWorking={sessionWorking} />
+    </I18nProvider>
+  )
+}
+
+// The spinner is the only element with role="status" in this row.
+const hasSpinner = (c: HTMLElement) => c.querySelector('[role="status"]') !== null
+
+describe('StatusItemRow in_progress spinner gating', () => {
+  it('spins while the session turn is running', () => {
+    const { container } = renderRow(todoItem(), true)
+    expect(hasSpinner(container)).toBe(true)
+  })
+
+  it('settles (no spinner) when the session turn has ended', () => {
+    const { container } = renderRow(todoItem(), false)
+    expect(hasSpinner(container)).toBe(false)
+  })
+
+  it('still renders the item title in the settled state', () => {
+    const { container } = renderRow(todoItem(), false)
+    expect(container.textContent).toContain('in-flight step')
+  })
+
+  it('keeps spinning for a running background item regardless of sessionWorking', () => {
+    // Background/subagent rows carry their own lifecycle via `state`; the gate
+    // only applies to in_progress TODOs, so a running background task must
+    // still spin even when no agent turn is active.
+    const bg: ComposerStatusItem = {
+      id: 'bg:1',
+      title: 'long task',
+      type: 'background',
+      state: 'running'
+    }
+    const { container } = renderRow(bg, false)
+    expect(hasSpinner(container)).toBe(true)
+  })
+
+  it('shows the completed glyph (no spinner) for a completed todo', () => {
+    const done: ComposerStatusItem = {
+      id: 'todo:2',
+      title: 'done step',
+      type: 'todo',
+      state: 'done',
+      todoStatus: 'completed'
+    }
+    const { container } = renderRow(done, false)
+    expect(hasSpinner(container)).toBe(false)
+  })
+})

--- a/apps/desktop/src/app/chat/composer/status-stack/status-row.tsx
+++ b/apps/desktop/src/app/chat/composer/status-stack/status-row.tsx
@@ -30,7 +30,7 @@ const TODO_GLYPHS: Record<Exclude<TodoStatus, 'in_progress' | 'pending'>, { icon
 
 // Left slot: braille spinner while running, otherwise a small status dot
 // (green = done, red = failed) so the slot is always filled and rows align.
-function leadingGlyph(item: ComposerStatusItem, s: Translations['statusStack']): ReactNode {
+function leadingGlyph(item: ComposerStatusItem, s: Translations['statusStack'], sessionWorking: boolean): ReactNode {
   if (item.todoStatus === 'pending') {
     return (
       <span
@@ -46,12 +46,32 @@ function leadingGlyph(item: ComposerStatusItem, s: Translations['statusStack']):
     return <Codicon className={glyph.tone} name={glyph.icon} size="0.8rem" />
   }
 
-  if (item.state === 'running') {
+  // An `in_progress` todo (or a running background/subagent item) only gets a
+  // live spinner while the session's turn is actually running. If the turn has
+  // settled — the agent finished, stopped, or is waiting on the user — a todo
+  // left mid-flight must NOT keep spinning forever (the "task pane hangs at the
+  // end" bug): fall through to a static dot so the row reads as paused, not
+  // actively working. Background/subagent rows carry their own real lifecycle
+  // (`state`), so they're unaffected when the gate is open.
+  const isTodoInProgress = item.todoStatus === 'in_progress'
+
+  if (item.state === 'running' && (sessionWorking || !isTodoInProgress)) {
     return (
       <GlyphSpinner
         ariaLabel={s.running}
         className="text-[0.9rem] leading-none text-muted-foreground/80"
         spinner="braille"
+      />
+    )
+  }
+
+  // Settled in_progress todo: a hollow ring reads as "started, awaiting the
+  // next turn" — distinct from the dashed pending ring and the filled done dot.
+  if (isTodoInProgress) {
+    return (
+      <span
+        aria-hidden
+        className="box-border size-[0.7rem] rounded-full border-2 border-muted-foreground/55"
       />
     )
   }
@@ -73,6 +93,9 @@ interface StatusItemRowProps {
   onOpen?: () => void
   /** Cancel a running background task. */
   onStop?: (id: string) => void
+  /** Whether the owning session's turn is actively running — gates the live
+   *  spinner on `in_progress` todos so they settle when the turn ends. */
+  sessionWorking?: boolean
 }
 
 /**
@@ -80,7 +103,13 @@ interface StatusItemRowProps {
  * Memoised + keyed by id so parent re-renders never remount it (the spinner
  * keeps ticking instead of resetting).
  */
-export const StatusItemRow = memo(function StatusItemRow({ item, onDismiss, onOpen, onStop }: StatusItemRowProps) {
+export const StatusItemRow = memo(function StatusItemRow({
+  item,
+  onDismiss,
+  onOpen,
+  onStop,
+  sessionWorking = false
+}: StatusItemRowProps) {
   const { t } = useI18n()
   const s = t.statusStack
   const [outputOpen, setOutputOpen] = useState(false)
@@ -101,7 +130,7 @@ export const StatusItemRow = memo(function StatusItemRow({ item, onDismiss, onOp
   return (
     <Fragment>
       <StatusRow
-        leading={leadingGlyph(item, s)}
+        leading={leadingGlyph(item, s, sessionWorking)}
         onActivate={onActivate}
         trailing={
           action ? (


### PR DESCRIPTION
## Problem

The composer status stack (the "Tasks N/M" pane above the composer) shows a live animated braille spinner for any todo marked `in_progress`. The spinner is driven purely by the item's `state === 'running'` in `status-row.tsx`'s `leadingGlyph`, with **no reference to whether the agent's turn is actually running**.

So when a turn ends with a step still `in_progress` — the agent finishes, stops, or pauses to ask the user something mid-plan — the spinner keeps animating **forever**. A settled, idle pane looks like it's still grinding. This is the "task pane always hangs at the end" symptom: nothing is running, but the UI insists it is.

`message.complete` never reconciles todo state (todos are a plan, intentionally kept visible across turns by `todoListActive`), so nothing stops the spinner on its own.

## Fix

Gate the in-progress spinner on the session's real working state:

- `ComposerStatusStack` reads `$workingSessionIds` and derives `sessionWorking` for its `sessionId`, passing it to each `StatusItemRow`.
- An `in_progress` todo only spins while its session's turn is running. Once the turn settles, it falls back to a static **hollow ring** ("started, awaiting the next turn") — visually distinct from the dashed *pending* ring and the filled *completed* dot.
- Background/subagent rows carry their own real lifecycle via `state`, so they're explicitly unaffected and keep spinning while actually running.

## Tests

`status-row.test.tsx` (new):
- in_progress todo spins while the session turn is running
- in_progress todo settles (no spinner) when the turn has ended
- title still renders in the settled state
- a running background item still spins regardless of `sessionWorking` (gate is todo-only)
- a completed todo shows the check glyph, no spinner

`tsc --noEmit` clean. Existing `todos` / `composer-status` store tests still green.

## Repro notes

Verified the backend/transport is **not** at fault: a WS client against `/api/ws` shows `tool.complete{todos}` frames arriving live across the whole turn (even under continuous no-sleep CPU load), and the store→computed→component render path updates synchronously. The stuck-feeling pane is purely the never-settling spinner on a turn that ends mid-plan, which this addresses.
