### PR TITLE
fix(email): guard EMAIL_IMAP_PORT/SMTP_PORT/POLL_INTERVAL against malformed env var

### DIFF
--- a/gateway/platforms/email.py
+++ b/gateway/platforms/email.py
@@ -43,6 +43,7 @@ from gateway.platforms.base import (
     cache_image_from_bytes,
 )
 from gateway.config import Platform, PlatformConfig
+from utils import env_int
 
 logger = logging.getLogger(__name__)
 # Automated sender patterns — emails from these are silently ignored
@@ -309,10 +310,10 @@ class EmailAdapter(BasePlatformAdapter):
         self._address = os.getenv("EMAIL_ADDRESS", "")
         self._password = os.getenv("EMAIL_PASSWORD", "")
         self._imap_host = os.getenv("EMAIL_IMAP_HOST", "")
-        self._imap_port = int(os.getenv("EMAIL_IMAP_PORT", "993"))
+        self._imap_port = env_int("EMAIL_IMAP_PORT", 993)
         self._smtp_host = os.getenv("EMAIL_SMTP_HOST", "")
-        self._smtp_port = int(os.getenv("EMAIL_SMTP_PORT", "587"))
-        self._poll_interval = int(os.getenv("EMAIL_POLL_INTERVAL", "15"))
+        self._smtp_port = env_int("EMAIL_SMTP_PORT", 587)
+        self._poll_interval = env_int("EMAIL_POLL_INTERVAL", 15)
 
         # Skip attachments — configured via config.yaml:
         #   platforms:


### PR DESCRIPTION
## Summary

Replace bare int(os.getenv(...)) with env_int(...) for 3 env vars in gateway/platforms/email.py __init__:

- EMAIL_IMAP_PORT (line 312)
- EMAIL_SMTP_PORT (line 314)
- EMAIL_POLL_INTERVAL (line 315)

A malformed value (e.g. EMAIL_IMAP_PORT=abc) causes a ValueError crash when the email platform adapter initializes. The env_int() helper in utils.py catches ValueError/TypeError and returns the default value.

## Changes

- gateway/platforms/email.py: Add env_int import from utils, replace 3 bare int(os.getenv) calls

## Test Plan

- [x] pytest email tests pass
- [x] Lint clean

## Context

Part of systemic env var guard issue (~25 bare int/float os.getenv calls across gateway).
Related: PR #48735 (api_server.py), PR #48740 (run.py).