### PR TITLE
fix(config): guard WECOM_CALLBACK_PORT/BLUEBUBBLES_WEBHOOK_PORT against malformed env var

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -17,7 +17,7 @@ from typing import Dict, List, Optional, Any, Callable
 from enum import Enum
 
 from hermes_cli.config import get_hermes_home
-from utils import is_truthy_value
+from utils import env_int, is_truthy_value
 
 logger = logging.getLogger(__name__)
 
@@ -1831,7 +1831,7 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
             "token": os.getenv("WECOM_CALLBACK_TOKEN", ""),
             "encoding_aes_key": os.getenv("WECOM_CALLBACK_ENCODING_AES_KEY", ""),
             "host": os.getenv("WECOM_CALLBACK_HOST", "0.0.0.0"),
-            "port": int(os.getenv("WECOM_CALLBACK_PORT", "8645")),
+            "port": env_int("WECOM_CALLBACK_PORT", 8645),
         })
 
     # Weixin (personal WeChat via iLink Bot API)
@@ -1887,7 +1887,7 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
             "server_url": bluebubbles_server_url.rstrip("/"),
             "password": bluebubbles_password,
             "webhook_host": os.getenv("BLUEBUBBLES_WEBHOOK_HOST", "127.0.0.1"),
-            "webhook_port": int(os.getenv("BLUEBUBBLES_WEBHOOK_PORT", "8645")),
+            "webhook_port": env_int("BLUEBUBBLES_WEBHOOK_PORT", 8645),
             "webhook_path": os.getenv("BLUEBUBBLES_WEBHOOK_PATH", "/bluebubbles-webhook"),
             "send_read_receipts": os.getenv("BLUEBUBBLES_SEND_READ_RECEIPTS", "true").lower() in {"true", "1", "yes"},
         })


### PR DESCRIPTION
## Summary

Replace bare int(os.getenv(...)) with env_int(...) for 2 port env vars in gateway/config.py:

- WECOM_CALLBACK_PORT (line 1834)
- BLUEBUBBLES_WEBHOOK_PORT (line 1890)

A malformed value (e.g. WECOM_CALLBACK_PORT=abc) causes a ValueError crash during gateway config loading. The env_int() helper in utils.py catches ValueError/TypeError and returns the default value.

## Changes

- gateway/config.py: Add env_int to existing utils import, replace 2 bare int(os.getenv) calls

## Test Plan

- [x] pytest config/wecom/bluebubbles tests pass
- [x] Lint clean

## Context

Part of systemic env var guard issue. Related: PR #48735 (api_server.py), PR #48740 (run.py), PR #48745 (email.py).