### PR TITLE
feat(desktop): show working folder in composer controls bar

### DIFF
--- a/apps/desktop/src/app/chat/composer/controls.tsx
+++ b/apps/desktop/src/app/chat/composer/controls.tsx
@@ -8,6 +8,7 @@ import { AudioLines, Layers3, Loader2, Square, SteeringWheel } from '@/lib/icons
 import { formatCombo } from '@/lib/keybinds/combo'
 import { cn } from '@/lib/utils'
 
+import { CwdPill } from './cwd-pill'
 import type { ConversationStatus } from './hooks/use-voice-conversation'
 import { ModelPill } from './model-pill'
 import type { ChatBarState, VoiceStatus } from './types'
@@ -44,6 +45,7 @@ export function ComposerControls({
   canSteer,
   canSubmit,
   conversation,
+  cwd,
   disabled,
   hasComposerPayload,
   state,
@@ -56,6 +58,7 @@ export function ComposerControls({
   canSteer: boolean
   canSubmit: boolean
   conversation: ConversationProps
+  cwd?: null | string
   disabled: boolean
   hasComposerPayload: boolean
   state: ChatBarState
@@ -139,6 +142,7 @@ export function ComposerControls({
           </Button>
         </Tip>
       )}
+      <CwdPill cwd={cwd} />
     </div>
   )
 }

--- a/apps/desktop/src/app/chat/composer/cwd-pill.test.tsx
+++ b/apps/desktop/src/app/chat/composer/cwd-pill.test.tsx
@@ -1,0 +1,63 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+
+import { CwdPill, folderName } from './cwd-pill'
+
+describe('folderName', () => {
+  it('returns the last path segment of a POSIX path', () => {
+    expect(folderName('/Users/yates/code/hermes-agent')).toBe('hermes-agent')
+  })
+
+  it('returns the last path segment of a Windows path', () => {
+    expect(folderName('C:\\Users\\yates\\projects\\app')).toBe('app')
+  })
+
+  it('returns the segment for a relative path', () => {
+    expect(folderName('code/hermes-agent')).toBe('hermes-agent')
+  })
+
+  it('returns the input verbatim when there is no separator', () => {
+    expect(folderName('my-folder')).toBe('my-folder')
+  })
+
+  it('returns empty string for empty / whitespace-only input', () => {
+    expect(folderName('')).toBe('')
+    expect(folderName('   ')).toBe('')
+  })
+
+  it('returns the last non-empty segment for trailing slashes', () => {
+    expect(folderName('/Users/yates/code/hermes-agent/')).toBe('hermes-agent')
+  })
+})
+
+describe('CwdPill', () => {
+  it('renders the folder basename', () => {
+    render(<CwdPill cwd="/Users/yates/code/hermes-agent" />)
+
+    expect(screen.getByText('hermes-agent')).toBeTruthy()
+  })
+
+  it('renders nothing when cwd is null', () => {
+    const { container } = render(<CwdPill cwd={null} />)
+
+    expect(container.textContent).toBe('')
+  })
+
+  it('renders nothing when cwd is undefined', () => {
+    const { container } = render(<CwdPill cwd={undefined} />)
+
+    expect(container.textContent).toBe('')
+  })
+
+  it('renders nothing when cwd is an empty string', () => {
+    const { container } = render(<CwdPill cwd="" />)
+
+    expect(container.textContent).toBe('')
+  })
+
+  it('renders the folder icon', () => {
+    const { container } = render(<CwdPill cwd="/home/user/project" />)
+
+    expect(container.querySelector('svg')).toBeTruthy()
+  })
+})

--- a/apps/desktop/src/app/chat/composer/cwd-pill.tsx
+++ b/apps/desktop/src/app/chat/composer/cwd-pill.tsx
@@ -1,0 +1,51 @@
+import { Button } from '@/components/ui/button'
+import { Tip } from '@/components/ui/tooltip'
+import { FolderOpen } from '@/lib/icons'
+import { cn } from '@/lib/utils'
+
+const PILL = cn(
+  'h-(--composer-control-size) max-w-40 shrink-0 gap-1 rounded-md px-2 text-xs font-normal',
+  'text-(--ui-text-tertiary) hover:bg-(--chrome-action-hover) hover:text-foreground',
+  // Divider separating the folder read-out from the action buttons to its left.
+  'border-l border-(--ui-stroke-tertiary) pl-(--composer-control-gap)'
+)
+
+/** Basename of a path — the last segment after the final `/` (or `\` on
+ *  Windows). Returns the original string when it has no separator so a bare
+ *  folder name is shown verbatim. */
+export function folderName(cwd: string): string {
+  const trimmed = cwd.trim()
+
+  if (!trimmed) {
+    return ''
+  }
+
+  // Handle both POSIX and Windows separators so the pill reads correctly
+  // regardless of the gateway's OS.
+  const segments = trimmed.split(/[/\\]/).filter(Boolean)
+
+  return segments[segments.length - 1] ?? trimmed
+}
+
+/**
+ * Composer folder indicator — sits at the far right of the controls row,
+ * separated from the action buttons by a divider. Shows the working
+ * directory's basename (the folder name) with the full path in a tooltip.
+ * Hidden entirely when no cwd is set.
+ */
+export function CwdPill({ cwd }: { cwd: null | string | undefined }) {
+  const name = folderName(cwd ?? '')
+
+  if (!name) {
+    return null
+  }
+
+  return (
+    <Tip label={cwd ?? name}>
+      <Button className={PILL} disabled type="button" variant="ghost">
+        <FolderOpen className="size-3 shrink-0" />
+        <span className="truncate">{name}</span>
+      </Button>
+    </Tip>
+  )
+}

--- a/apps/desktop/src/app/chat/composer/index.tsx
+++ b/apps/desktop/src/app/chat/composer/index.tsx
@@ -1733,6 +1733,7 @@ export function ChatBar({
         onToggleMute: conversation.toggleMute,
         status: conversation.status
       }}
+      cwd={cwd ?? null}
       disabled={disabled}
       hasComposerPayload={hasComposerPayload}
       onDictate={dictate}


### PR DESCRIPTION
## Preview

![CwdPill in composer controls bar](https://github.com/yatesfr/hermes-agent/raw/pr-assets/cwd-pill-preview.png)

The folder pill (📁 `hermes-agent`) appears at the far right of the composer controls row, separated from the send button by a divider. The full path is shown in a tooltip.

---

## Summary

Adds a small folder indicator at the far right of the desktop app's composer controls row (the bar above the text input that shows the model info), separated from the action buttons by a divider.

**What it shows:** a folder-open icon + the basename of the current working directory (e.g. `hermes-agent`), with the full path in a tooltip. Hidden entirely when no cwd is set.

## Why

The desktop composer already receives `cwd` as a prop (used for `@`-completions and dropped-file refs) but never displays it. This surfaces it so the user can see which folder they're working in at a glance — matching the TUI's status-bar cwd label.

## Changes

- **New:** `apps/desktop/src/app/chat/composer/cwd-pill.tsx` — `CwdPill` component + `folderName()` helper (handles POSIX and Windows paths, trailing slashes, empty input).
- **Modified:** `apps/desktop/src/app/chat/composer/controls.tsx` — added `cwd` prop to `ComposerControls`, renders `<CwdPill>` at the far right of the controls row (after the send/voice button) with a `border-l` divider.
- **Modified:** `apps/desktop/src/app/chat/composer/index.tsx` — passes `cwd` through from `ChatBar` to `ComposerControls`.
- **New:** `apps/desktop/src/app/chat/composer/cwd-pill.test.tsx` — 11 tests covering `folderName()` path parsing + `CwdPill` rendering (shows basename, hides on null/undefined/empty, renders icon).

## Verification

```
✓ npx vitest run --environment jsdom src/app/chat/composer/    # 40 tests pass (7 files)
✓ npx tsc --noEmit                                             # clean
✓ npx eslint src/app/chat/composer/{cwd-pill,controls,index}*  # clean
```

## Scope

Minimal, focused change. No new dependencies, no config changes, no core tool surface affected. The pill is a read-only display element (no click handler) — it just shows where you are.