### PR TITLE
fix(dashboard): refresh Sessions list in real time when new sessions are created

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -48,6 +48,7 @@
     "three": "^0.180.0",
     "typescript": "^6.0.3",
     "typescript-eslint": "^8.56.1",
-    "vite": "^8.0.16"
+    "vite": "^8.0.16",
+    "vitest": "^4.1.5"
   }
 }

--- a/web/src/lib/session-refresh.test.ts
+++ b/web/src/lib/session-refresh.test.ts
@@ -1,0 +1,21 @@
+import { describe, it, expect } from "vitest";
+import { shouldRefreshSessions } from "./session-refresh";
+
+describe("shouldRefreshSessions", () => {
+  it("returns false on the first poll (no baseline yet)", () => {
+    expect(shouldRefreshSessions(null, "s2")).toBe(false);
+  });
+
+  it("returns false when the current response has no sessions", () => {
+    expect(shouldRefreshSessions("s1", null)).toBe(false);
+    expect(shouldRefreshSessions(null, null)).toBe(false);
+  });
+
+  it("returns false when the newest session id is unchanged", () => {
+    expect(shouldRefreshSessions("s1", "s1")).toBe(false);
+  });
+
+  it("returns true when a new session appears at the head of the list", () => {
+    expect(shouldRefreshSessions("s1", "s2")).toBe(true);
+  });
+});

--- a/web/src/lib/session-refresh.ts
+++ b/web/src/lib/session-refresh.ts
@@ -1,0 +1,26 @@
+/**
+ * Decide whether the paginated sessions list should be silently
+ * re-fetched after an overview poll.
+ *
+ * The dashboard's FastAPI server and a terminal CLI are separate
+ * processes that share the same SQLite session DB. There is no
+ * inter-process push channel, so the Sessions page polls the 50 newest
+ * sessions every few seconds (the "overview" poll). When that poll
+ * surfaces a session id at the head of the list that we have not seen
+ * before, a new session was created in another process and the
+ * paginated list is stale — refresh it.
+ *
+ * Returns false on the very first poll (no baseline yet) and when
+ * either id is null (empty DB / transient empty response), so we never
+ * trigger a spurious reload on mount or while the DB is empty.
+ */
+export function shouldRefreshSessions(
+  prevNewestId: string | null,
+  currentNewestId: string | null,
+): boolean {
+  return (
+    prevNewestId !== null &&
+    currentNewestId !== null &&
+    prevNewestId !== currentNewestId
+  );
+}

--- a/web/src/pages/SessionsPage.tsx
+++ b/web/src/pages/SessionsPage.tsx
@@ -30,6 +30,7 @@ import {
   Archive,
 } from "lucide-react";
 import { api } from "@/lib/api";
+import { shouldRefreshSessions } from "@/lib/session-refresh";
 import type {
   SessionInfo,
   SessionMessage,
@@ -806,8 +807,12 @@ export default function SessionsPage() {
     };
   }, [setEnd]);
 
-  const loadSessions = useCallback((p: number) => {
-    setLoading(true);
+  const loadSessions = useCallback((p: number, silent = false) => {
+    // ``silent`` skips the loading spinner so background refreshes
+    // (triggered when the overview poll detects a new session from
+    // another process) don't flicker the whole page or drop the user's
+    // scroll position.
+    if (!silent) setLoading(true);
     api
       .getSessions(PAGE_SIZE, p * PAGE_SIZE)
       .then((resp) => {
@@ -815,7 +820,9 @@ export default function SessionsPage() {
         setTotal(resp.total);
       })
       .catch(() => {})
-      .finally(() => setLoading(false));
+      .finally(() => {
+        if (!silent) setLoading(false);
+      });
   }, []);
 
   const loadStats = useCallback(() => {
@@ -828,6 +835,15 @@ export default function SessionsPage() {
   useEffect(() => {
     loadStats();
   }, [loadStats]);
+
+  // Refs for the overview poll's new-session detection. The poll effect
+  // below is mounted once with stable deps, so it reads the current page
+  // and the last-seen newest session id through refs instead of capturing
+  // stale values. ``newestSeenRef`` starts null so the first poll sets a
+  // baseline without triggering a redundant reload (mount already loads).
+  const newestSeenRef = useRef<string | null>(null);
+  const pageRef = useRef(page);
+  pageRef.current = page;
 
   useEffect(() => {
     loadSessions(page);
@@ -842,13 +858,27 @@ export default function SessionsPage() {
         .catch(() => {});
       api
         .getSessions(50)
-        .then((r) => setOverviewSessions(r.sessions))
+        .then((r) => {
+          setOverviewSessions(r.sessions);
+          // The dashboard server and a terminal CLI are separate
+          // processes sharing one session DB — there is no push channel,
+          // so we detect sessions created in another process here. The
+          // overview poll already fetches the 50 newest sessions, so we
+          // reuse its head id as a cheap change signal: when it changes,
+          // silently refresh the paginated list so the new session shows
+          // up in real time without a visible loading flicker.
+          const newest = r.sessions[0]?.id ?? null;
+          if (shouldRefreshSessions(newestSeenRef.current, newest)) {
+            loadSessions(pageRef.current, true);
+          }
+          newestSeenRef.current = newest;
+        })
         .catch(() => {});
     };
     loadOverview();
     const id = setInterval(loadOverview, 5000);
     return () => clearInterval(id);
-  }, []);
+  }, [loadSessions]);
 
   useEffect(() => {
     const el = logScrollRef.current;

--- a/web/vitest.config.ts
+++ b/web/vitest.config.ts
@@ -1,0 +1,16 @@
+import { defineConfig } from "vitest/config";
+import react from "@vitejs/plugin-react";
+import path from "path";
+
+export default defineConfig({
+  plugins: [react()],
+  resolve: {
+    alias: {
+      "@": path.resolve(__dirname, "./src"),
+    },
+  },
+  test: {
+    environment: "node",
+    include: ["src/**/*.test.{ts,tsx}"],
+  },
+});


### PR DESCRIPTION
## Problem

When the Hermes dashboard is open and a new session is started in a separate terminal, that session does **not** appear in the dashboard's Sessions list in real time — it only shows up after navigating pages or deleting a session.

## Root cause

The dashboard's FastAPI server and a terminal CLI are **separate processes** that share the same SQLite session DB. There is no inter-process push channel, so the only way to learn about sessions created elsewhere is to poll.

The Sessions page (`web/src/pages/SessionsPage.tsx`) already ran a 5-second poll for the "overview" card (`/api/sessions?limit=50` -> `overviewSessions`), but the **paginated sessions list** (`loadSessions`) was only re-fetched on mount, page change, or delete. New sessions written by another process were therefore invisible until the user took a manual action.

## Fix

Reuse the existing 5s overview poll as a cheap change signal. The overview poll already fetches the 50 newest sessions; when the **head session id changes**, silently reload the current page of the paginated list.

- `loadSessions(p, silent=false)` — a new `silent` flag skips the loading spinner so background refreshes don't flicker the whole page or drop scroll position. Expanded rows and bulk selection are keyed by session id, so they survive a silent refresh intact.
- The first poll establishes a baseline (`newestSeenRef` starts null) so mount doesn't trigger a redundant reload.
- The detection logic is extracted into a pure `shouldRefreshSessions(prev, current)` helper (`web/src/lib/session-refresh.ts`) so it's unit-testable without React.

This is the narrowest fix: no new HTTP requests (reuses the existing poll), no new WebSocket/event infra, no backend changes.

## Tests

Adds a minimal vitest setup for `web/` (`vitest.config.ts` + `test` script + `vitest` devDep) and a unit test for the pure helper:

```
✓ src/lib/session-refresh.test.ts (4 tests)
```

Covers: first-poll baseline (no spurious reload), empty/null responses, unchanged id, and new-session-detected.

## Verification

- `npm run test` (vitest) — 4/4 pass
- `tsc -p . --noEmit` (typecheck) — clean
- `eslint` on changed files — no new errors (4 pre-existing set-state-in-effect warnings in untouched effects)
- `grep` + `git diff` confirmed the SessionsPage patches persisted to disk

## Scope

Frontend-only. No backend, core, or config changes. No new model tools.
