### PR TITLE
fix: reduce stale doctor audit and oauth noise

### DIFF
--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -158,7 +158,7 @@ def _has_healthy_oauth_fallback_for_apikey_provider(provider_label: str) -> bool
     that direct-key problem into the final blocking summary.
     """
     normalized = (provider_label or "").strip().lower()
-    if normalized in {"google / gemini", "gemini"}:
+    if normalized in {"google / gemini", "gemini", "google ai studio"}:
         try:
             from hermes_cli.auth import get_gemini_oauth_auth_status
             return bool((get_gemini_oauth_auth_status() or {}).get("logged_in"))
@@ -1575,7 +1575,7 @@ def run_doctor(args):
                 # Use resolved absolute path so Windows can execute
                 # npm.cmd (CreateProcessW can't run bare .cmd names).
                 audit_result = subprocess.run(
-                    [_npm_bin, "audit", "--json", *audit_extra],
+                    [_npm_bin, "audit", "--omit=dev", "--json", *audit_extra],
                     cwd=str(npm_dir),
                     capture_output=True, text=True, timeout=30,
                 )
@@ -1860,6 +1860,13 @@ def run_doctor(args):
                     [],
                 )
             if r.status_code == 401:
+                if _has_healthy_oauth_fallback_for_apikey_provider(pname):
+                    return _ConnectivityResult(
+                        pname,
+                        [(color("✓", Colors.GREEN), label,
+                          color("(OAuth path healthy; direct API key skipped)", Colors.DIM))],
+                        [],
+                    )
                 return _ConnectivityResult(
                     pname,
                     [(color("✗", Colors.RED), label,
@@ -2070,8 +2077,6 @@ def run_doctor(args):
             else:
                 print(f"  {_glyph} {_label}")
         _issues_to_add = list(_r.issues)
-        if _issues_to_add and _has_healthy_oauth_fallback_for_apikey_provider(_r.label):
-            _issues_to_add = []
         for _issue in _issues_to_add:
             issues.append(_issue)
 

--- a/tests/hermes_cli/test_doctor.py
+++ b/tests/hermes_cli/test_doctor.py
@@ -972,7 +972,15 @@ def _run_doctor_with_healthy_oauth_fallback(
 
 
 @pytest.mark.parametrize(
-    ("env_key", "bad_key", "failing_host", "gemini_oauth_status", "minimax_oauth_status", "xai_oauth_status", "unexpected_issue"),
+    (
+        "env_key",
+        "bad_key",
+        "failing_host",
+        "gemini_oauth_status",
+        "minimax_oauth_status",
+        "xai_oauth_status",
+        "unexpected_issue",
+    ),
     [
         (
             "GOOGLE_API_KEY",
@@ -1025,13 +1033,78 @@ def test_run_doctor_ignores_invalid_direct_keys_when_oauth_fallback_is_healthy(
         xai_oauth_status=xai_oauth_status,
     )
 
-    assert "invalid API key" in out
+    assert "OAuth path healthy; direct API key skipped" in out
     assert unexpected_issue not in out
 
 
 def test_has_healthy_oauth_fallback_returns_false_for_unknown_provider():
     from hermes_cli.doctor import _has_healthy_oauth_fallback_for_apikey_provider
     assert _has_healthy_oauth_fallback_for_apikey_provider("unknown-provider") is False
+
+
+def test_has_healthy_oauth_fallback_recognizes_google_ai_studio_label(monkeypatch):
+    from hermes_cli import auth as _auth_mod
+
+    monkeypatch.setattr(
+        _auth_mod,
+        "get_gemini_oauth_auth_status",
+        lambda: {"logged_in": True},
+    )
+
+    from hermes_cli.doctor import _has_healthy_oauth_fallback_for_apikey_provider
+
+    assert _has_healthy_oauth_fallback_for_apikey_provider("Google AI Studio") is True
+
+
+def test_run_doctor_npm_audit_omits_dev_dependencies(monkeypatch, tmp_path):
+    home = tmp_path / ".hermes"
+    home.mkdir(parents=True, exist_ok=True)
+    (home / "config.yaml").write_text("memory: {}\n", encoding="utf-8")
+
+    project = tmp_path / "project"
+    project.mkdir(exist_ok=True)
+    (project / "node_modules").mkdir()
+    (project / "scripts" / "whatsapp-bridge").mkdir(parents=True, exist_ok=True)
+
+    monkeypatch.setattr(doctor_mod, "HERMES_HOME", home)
+    monkeypatch.setattr(doctor_mod, "PROJECT_ROOT", project)
+    monkeypatch.setattr(doctor_mod, "_DHH", str(home))
+    monkeypatch.setattr(
+        doctor_mod,
+        "_safe_which",
+        lambda cmd: "/usr/bin/npm" if cmd == "npm" else None,
+    )
+    monkeypatch.setattr(doctor_mod, "_check_gateway_service_linger", lambda issues: None)
+    monkeypatch.setattr(doctor_mod, "_check_s6_supervision", lambda issues: None)
+
+    fake_model_tools = types.SimpleNamespace(
+        check_tool_availability=lambda *a, **kw: ([], []),
+        TOOLSET_REQUIREMENTS={},
+    )
+    monkeypatch.setitem(sys.modules, "model_tools", fake_model_tools)
+
+    audit_calls = []
+
+    def fake_run(cmd, **kwargs):
+        if cmd[:2] == ["/usr/bin/npm", "audit"]:
+            audit_calls.append(cmd)
+            return types.SimpleNamespace(
+                returncode=0,
+                stdout='{"metadata":{"vulnerabilities":{"critical":0,"high":0,"moderate":0}}}',
+                stderr="",
+            )
+        return types.SimpleNamespace(returncode=1, stdout="", stderr="")
+
+    import subprocess
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    buf = io.StringIO()
+    with contextlib.redirect_stdout(buf):
+        doctor_mod.run_doctor(Namespace(fix=False))
+
+    assert audit_calls
+    assert all("--omit=dev" in call for call in audit_calls)
 
 
 class TestHasHealthyOauthFallbackForXai:


### PR DESCRIPTION
## What does this PR do?

Fixes two noisy `hermes doctor` paths reported in #48689:

- suppresses the direct API-key failure row for Gemini/MiniMax/xAI when the OAuth path is already healthy
- runs `npm audit` with `--omit=dev` so the routine doctor output does not surface stale dev-only `ui-tui` advisories

## Related Issue

Fixes #48689

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- updated [`hermes_cli/doctor.py`](hermes_cli/doctor.py) to treat healthy OAuth fallbacks as non-blocking for direct API-key probes
- broadened Gemini fallback matching to cover the `Google AI Studio` provider label
- updated the `npm audit` doctor check to use `--omit=dev`
- added targeted regression tests in [`tests/hermes_cli/test_doctor.py`](tests/hermes_cli/test_doctor.py)

## How to Test

1. Run `/Users/leongong/Desktop/LeonProjects/worktrees/hermes-agent/.base/.venv/bin/python -m pytest tests/hermes_cli/test_doctor.py -k 'oauth_fallback or google_ai_studio_label or npm_audit_omits_dev_dependencies'`
2. Run `git diff --check`
3. Run `/Users/leongong/Desktop/LeonProjects/worktrees/hermes-agent/.base/.venv/bin/python -m py_compile hermes_cli/doctor.py tests/hermes_cli/test_doctor.py`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

- [ ] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [ ] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

- Targeted proof: `.paperclip_artifacts/quality-gate/proof-e93c572f3fc49ac455564fd933480f07c7994723.json`
