### PR TITLE
fix(matrix): treat m.direct as authoritative for DM classification (#48551)

### DIFF
--- a/gateway/platforms/matrix.py
+++ b/gateway/platforms/matrix.py
@@ -3674,7 +3674,7 @@ class MatrixAdapter(BasePlatformAdapter):
         has_explicit_name = bool(room_name)
         is_direct = bool(self._dm_rooms.get(room_id, False))
         conflict = bool(is_direct and has_explicit_name)
-        chat_type = "dm" if is_direct and not has_explicit_name else "room"
+        chat_type = "dm" if is_direct else "room"
         display_name = room_name or canonical_alias or room_id
 
         identity = MatrixRoomIdentity(

--- a/tests/gateway/test_matrix.py
+++ b/tests/gateway/test_matrix.py
@@ -525,13 +525,18 @@ class TestMatrixDmDetection:
         assert await self.adapter._is_dm_room("!project:ex.org") is False
 
     @pytest.mark.asyncio
-    async def test_named_room_overrides_stale_dm_cache(self):
-        """Explicit room names should defeat stale/conflicting m.direct data."""
+    async def test_named_dm_room_still_dm_with_conflict(self):
+        """Rooms in m.direct with explicit names are still classified as DM.
+
+        Most Matrix clients auto-set DM room names (e.g. 'Alice & Bot'),
+        so m.direct must remain authoritative.  The conflict flag tracks
+        the mismatch for downstream consumers.
+        """
         self.adapter._joined_rooms = {"!stale:ex.org"}
         self.adapter._dm_rooms = {"!stale:ex.org": True}
         self.adapter._client = MagicMock()
         self.adapter._client.get_state_event = AsyncMock(
-            side_effect=lambda room_id, event_type: {"content": {"name": "Ops Room"}}
+            side_effect=lambda room_id, event_type: {"content": {"name": "Alice & Bot"}}
             if event_type == "m.room.name"
             else (_ for _ in ()).throw(Exception("no alias"))
         )
@@ -540,9 +545,9 @@ class TestMatrixDmDetection:
 
         identity = await self.adapter._resolve_room_identity("!stale:ex.org")
 
-        assert identity.chat_type == "room"
+        assert identity.chat_type == "dm"
         assert identity.conflict is True
-        assert await self.adapter._is_dm_room("!stale:ex.org") is False
+        assert await self.adapter._is_dm_room("!stale:ex.org") is True
 
     @pytest.mark.asyncio
     async def test_canonical_alias_used_when_name_missing(self):


### PR DESCRIPTION
Fixes #48551. Matrix DM rooms with auto-set names were incorrectly classified as chat_type='room' instead of 'dm', forcing @mentions in 1-on-1 DMs. The m.direct account data is the authoritative signal for DM classification; the conflict flag still tracks the mismatch.