### PR TITLE
fix(wecom): guard text batch delay env vars against malformed values

### DIFF
--- a/gateway/platforms/wecom.py
+++ b/gateway/platforms/wecom.py
@@ -68,6 +68,7 @@ from gateway.platforms.base import (
     cache_document_from_bytes,
     cache_image_from_bytes,
 )
+from utils import env_float
 
 logger = logging.getLogger(__name__)
 
@@ -186,8 +187,8 @@ class WeComAdapter(BasePlatformAdapter):
 
         # Text batching: merge rapid successive messages (Telegram-style).
         # WeCom clients split long messages around 4000 chars.
-        self._text_batch_delay_seconds = float(os.getenv("HERMES_WECOM_TEXT_BATCH_DELAY_SECONDS", "0.6"))
-        self._text_batch_split_delay_seconds = float(os.getenv("HERMES_WECOM_TEXT_BATCH_SPLIT_DELAY_SECONDS", "2.0"))
+        self._text_batch_delay_seconds = env_float("HERMES_WECOM_TEXT_BATCH_DELAY_SECONDS", 0.6)
+        self._text_batch_split_delay_seconds = env_float("HERMES_WECOM_TEXT_BATCH_SPLIT_DELAY_SECONDS", 2.0)
         self._pending_text_batches: Dict[str, MessageEvent] = {}
         self._pending_text_batch_tasks: Dict[str, asyncio.Task] = {}
         self._device_id = uuid.uuid4().hex


### PR DESCRIPTION
## Summary

Replace bare float(os.getenv(...)) with env_float(...) for 2 env vars in gateway/platforms/wecom.py:

- HERMES_WECOM_TEXT_BATCH_DELAY_SECONDS (line 189)
- HERMES_WECOM_TEXT_BATCH_SPLIT_DELAY_SECONDS (line 190)

A malformed value causes a ValueError crash when the WeCom adapter initializes.

## Changes

- gateway/platforms/wecom.py: Add env_float import from utils, replace 2 bare float(os.getenv) calls

## Test Plan

- [x] Lint clean

## Context

Part of systemic env var guard issue. Related: PR #48735, #48740, #48745, #48748.