### PR TITLE
feat(gemini): send required x-goog-api-client header on Gemini API calls

### DIFF
--- a/agent/gemini_native_adapter.py
+++ b/agent/gemini_native_adapter.py
@@ -31,6 +31,11 @@ from agent.gemini_schema import sanitize_gemini_tool_parameters
 
 logger = logging.getLogger(__name__)
 
+try:
+    from hermes_cli import __version__ as _HERMES_VERSION
+except Exception:
+    _HERMES_VERSION = "0.0.0"
+
 DEFAULT_GEMINI_BASE_URL = "https://generativelanguage.googleapis.com/v1beta"
 
 # Published max output-token ceiling shared by every current Gemini text model
@@ -98,7 +103,10 @@ def probe_gemini_tier(
                 url,
                 params={"key": key},
                 json=payload,
-                headers={"Content-Type": "application/json"},
+                headers={
+                    "Content-Type": "application/json",
+                    "X-Goog-Api-Client": f"hermes-agent/{_HERMES_VERSION}",
+                },
             )
     except Exception as exc:
         logger.debug("probe_gemini_tier: network error: %s", exc)
@@ -881,7 +889,8 @@ class GeminiNativeClient:
             "Content-Type": "application/json",
             "Accept": "application/json",
             "x-goog-api-key": self.api_key,
-            "User-Agent": "hermes-agent (gemini-native)",
+            "User-Agent": f"hermes-agent/{_HERMES_VERSION} (gemini-native)",
+            "X-Goog-Api-Client": f"hermes-agent/{_HERMES_VERSION}",
         }
         headers.update(self._default_headers)
         return headers

--- a/agent/gemini_native_adapter.py
+++ b/agent/gemini_native_adapter.py
@@ -889,6 +889,9 @@ class GeminiNativeClient:
             "Content-Type": "application/json",
             "Accept": "application/json",
             "x-goog-api-key": self.api_key,
+            # Google requires platform/library clients to identify themselves
+            # via x-goog-api-client (company-product/version format).
+            # See https://ai.google.dev/gemini-api/docs/partner-integration
             "User-Agent": f"hermes-agent/{_HERMES_VERSION} (gemini-native)",
             "X-Goog-Api-Client": f"hermes-agent/{_HERMES_VERSION}",
         }

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -3417,7 +3417,10 @@ def probe_api_models(
         candidates.append((alternate_base, True))
 
     tried: list[str] = []
-    headers: dict[str, str] = {"User-Agent": _HERMES_USER_AGENT}
+    headers: dict[str, str] = {
+        "User-Agent": _HERMES_USER_AGENT,
+        "X-Goog-Api-Client": f"hermes-agent/{_HERMES_VERSION}",
+    }
     if api_key and api_mode == "anthropic_messages":
         headers["x-api-key"] = api_key
         headers["anthropic-version"] = "2023-06-01"

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -475,6 +475,7 @@ AUTHOR_MAP = {
     "bzarnitz13@gmail.com": "Beandon13",
     "tony@tonysimons.dev": "asimons81",
     "jetha@google.com": "jethac",
+    "dharmadhikari@google.com": "vishal-dharm",
     "jani@0xhoneyjar.xyz": "deep-name",
     # LINE messaging plugin (synthesis PR)
     "32443648+leepoweii@users.noreply.github.com": "leepoweii",

--- a/tests/agent/test_gemini_native_adapter.py
+++ b/tests/agent/test_gemini_native_adapter.py
@@ -408,3 +408,53 @@ def test_explicit_max_tokens_is_respected():
 
     req = build_gemini_request(messages=[{"role": "user", "content": "hi"}], max_tokens=4096)
     assert req["generationConfig"]["maxOutputTokens"] == 4096
+
+
+# ---------------------------------------------------------------------------
+# X-Goog-Api-Client header tests
+# ---------------------------------------------------------------------------
+
+
+def test_x_goog_api_client_header_is_set():
+    """The X-Goog-Api-Client header should be set on inference requests."""
+    from agent.gemini_native_adapter import GeminiNativeClient
+
+    client = GeminiNativeClient(api_key="fake-key", model="gemini-2.0-flash")
+    headers = client._headers()
+
+    assert "X-Goog-Api-Client" in headers, "X-Goog-Api-Client header missing"
+    assert "hermes-agent/" in headers["X-Goog-Api-Client"], (
+        "hermes-agent not found in X-Goog-Api-Client header"
+    )
+
+
+def test_x_goog_api_client_header_format():
+    """Header value should be 'hermes-agent/<version>' matching the package version."""
+    from agent.gemini_native_adapter import GeminiNativeClient, _HERMES_VERSION
+
+    client = GeminiNativeClient(api_key="fake-key", model="gemini-2.0-flash")
+    headers = client._headers()
+
+    expected = f"hermes-agent/{_HERMES_VERSION}"
+    assert headers["X-Goog-Api-Client"] == expected
+
+
+def test_user_agent_contains_version():
+    """User-Agent should include the hermes-agent version."""
+    from agent.gemini_native_adapter import GeminiNativeClient, _HERMES_VERSION
+
+    client = GeminiNativeClient(api_key="fake-key", model="gemini-2.0-flash")
+    headers = client._headers()
+
+    assert f"hermes-agent/{_HERMES_VERSION}" in headers["User-Agent"]
+
+
+def test_hermes_version_is_valid():
+    """_HERMES_VERSION should be a non-empty string."""
+    from agent.gemini_native_adapter import _HERMES_VERSION
+
+    assert isinstance(_HERMES_VERSION, str)
+    assert len(_HERMES_VERSION) > 0
+    assert _HERMES_VERSION != "0.0.0", (
+        "Version should resolve from hermes_cli.__version__, not the fallback"
+    )

--- a/tests/tools/test_tts_gemini.py
+++ b/tests/tools/test_tts_gemini.py
@@ -115,6 +115,19 @@ class TestGenerateGeminiTts:
         # Audio payload should match the PCM we put in
         assert data[44:] == fake_pcm_bytes
 
+    def test_x_goog_api_client_header_is_set(self, tmp_path, monkeypatch, mock_gemini_response):
+        """Google requires platform clients to send x-goog-api-client."""
+        from tools.tts_tool import _generate_gemini_tts
+
+        monkeypatch.setenv("GEMINI_API_KEY", "test-key")
+
+        with patch("requests.post", return_value=mock_gemini_response) as mock_post:
+            _generate_gemini_tts("Hi", str(tmp_path / "test.wav"), {})
+
+        headers = mock_post.call_args[1]["headers"]
+        assert "X-Goog-Api-Client" in headers
+        assert headers["X-Goog-Api-Client"].startswith("hermes-agent/")
+
     def test_default_voice_and_model(self, tmp_path, monkeypatch, mock_gemini_response):
         from tools.tts_tool import (
             DEFAULT_GEMINI_TTS_MODEL,

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -1617,11 +1617,21 @@ def _generate_gemini_tts(text: str, output_path: str, tts_config: Dict[str, Any]
         },
     }
 
+    try:
+        from hermes_cli import __version__ as _hermes_version
+    except Exception:
+        _hermes_version = "0.0.0"
+
     endpoint = f"{base_url}/models/{model}:generateContent"
     response = requests.post(
         endpoint,
         params={"key": api_key},
-        headers={"Content-Type": "application/json"},
+        headers={
+            "Content-Type": "application/json",
+            # Google requires platform/library clients to identify themselves
+            # via x-goog-api-client. See https://ai.google.dev/gemini-api/docs/partner-integration
+            "X-Goog-Api-Client": f"hermes-agent/{_hermes_version}",
+        },
         json=payload,
         timeout=60,
     )


### PR DESCRIPTION
## Summary
Gemini API calls now send the `x-goog-api-client` identifier header Google **requires** of platform/library clients, plus a versioned `User-Agent`.

Salvage of #47385 by @vishal-dharm (Google) onto current `main`, with the missing TTS call site fixed and the requirement documented inline.

Per Google's partner-integration guidance, clients **must** identify themselves via `x-goog-api-client` in `company-product/version` format — this is a vendor requirement, not optional attribution:
> When making calls to the Gemini API as a platform or library, you must identify your client using the `x-goog-api-client` header.
>
> — https://ai.google.dev/gemini-api/docs/partner-integration

## Changes
- `agent/gemini_native_adapter.py`: `x-goog-api-client: hermes-agent/<version>` on inference requests + tier probes; versioned `User-Agent`; inline doc link (contributor's commit + follow-up comment).
- `hermes_cli/models.py`: header added to `probe_api_models()` (contributor's commit).
- `tools/tts_tool.py`: header added to the native Gemini TTS `generateContent` call — sibling site the original PR missed.
- `tests/`: 4 adapter tests (contributor) + 1 TTS header test (follow-up).
- `scripts/release.py`: AUTHOR_MAP entry for `dharmadhikari@google.com`.

## Validation
| | Result |
|---|---|
| `tests/agent/test_gemini_native_adapter.py` | 24 passed |
| `tests/tools/test_tts_gemini.py` | 23 passed (incl. new header test) |
| `tests/hermes_cli/test_gemini_provider.py` | 46 passed |

Closes #47385 — contributor authorship preserved via cherry-pick.

## Infographic

![gemini-x-goog-api-client](https://v3b.fal.media/files/b/0a9edd73/lE7AlLnItRy46Yh4tYnzc_lji8mn7U.png)
