### PR TITLE
Fix broken Windows hermes launchers after uv installs

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -7457,77 +7457,75 @@ def _verify_core_dependencies_installed(
         return [line.strip() for line in result.stdout.splitlines() if line.strip()]
 
     missing = _missing_deps()
-    if not missing:
-        return
-
-    print(
-        f"  ⚠ Verification: {len(missing)} declared dep(s) missing after install: "
-        f"{', '.join(missing[:8])}{'...' if len(missing) > 8 else ''}"
-    )
-    print("  → Reinstalling base group with --reinstall to repair...")
-
-    # Reinstall base group with --reinstall so uv re-resolves from scratch
-    # against the current pyproject. We don't pass ``[{group}]`` here on
-    # purpose — the missing dep is in *base* deps; rerunning the full all-
-    # extras install can cost minutes and trips on whatever optional extra
-    # was already broken upstream. Base is fast and is what's actually wrong.
-    #
-    # Quarantine the running ``hermes.exe`` first: ``--reinstall -e .``
-    # rewrites the entry-point shims, and on Windows pip can't overwrite the
-    # live launcher, which would leave ``hermes`` off PATH.
-    scripts_dir = _venv_scripts_dir() if _is_windows() else None
-    repair_args = ["install", "--reinstall", "-e", "."]
-    try:
-        _run_quarantined_install(
-            install_cmd_prefix + repair_args, env=env, scripts_dir=scripts_dir
-        )
-    except subprocess.CalledProcessError as e:
-        logger.warning("dep verification: repair install failed: %s", e)
-        print("  ⚠ Repair install failed; check `hermes update` output above.")
-        return
-
-    still_missing = _missing_deps()
-    if not still_missing:
-        print("  ✓ All declared core dependencies now installed")
-        return
-
-    # Last-ditch: install each remaining missing dep with its pin directly.
-    # Useful when uv's resolver thinks the env is satisfied but the on-disk
-    # package metadata says otherwise (rare but observed).
-    name_to_spec = {}
-    for spec in raw_deps:
-        head = spec.split(";", 1)[0].strip()
-        bare = head
-        for op in ("==", ">=", "<=", "~=", ">", "<", "!="):
-            if op in bare:
-                bare = bare.split(op, 1)[0]
-                break
-        name_to_spec[bare.strip().split("[", 1)[0].strip()] = head
-
-    specs = [name_to_spec.get(n, n) for n in still_missing]
-    print(
-        f"  → Force-installing remaining missing dep(s): {', '.join(specs)}"
-    )
-    try:
-        _run_install_with_heartbeat(
-            install_cmd_prefix + ["install", "--reinstall", *specs], env=env
-        )
-    except subprocess.CalledProcessError as e:
-        logger.warning("dep verification: per-package repair failed: %s", e)
+    if missing:
         print(
-            f"  ⚠ Could not install: {', '.join(still_missing)}. "
-            "Run `hermes update --force` after closing other hermes processes."
+            f"  ⚠ Verification: {len(missing)} declared dep(s) missing after install: "
+            f"{', '.join(missing[:8])}{'...' if len(missing) > 8 else ''}"
         )
-        return
+        print("  → Reinstalling base group with --reinstall to repair...")
 
-    final_missing = _missing_deps()
-    if final_missing:
-        print(
-            f"  ⚠ Still missing after repair: {', '.join(final_missing)}. "
-            "Run `hermes update --force` after closing other hermes processes."
-        )
-    else:
+        # Reinstall base group with --reinstall so uv re-resolves from scratch
+        # against the current pyproject. We don't pass ``[{group}]`` here on
+        # purpose — the missing dep is in *base* deps; rerunning the full all-
+        # extras install can cost minutes and trips on whatever optional extra
+        # was already broken upstream. Base is fast and is what's actually wrong.
+        #
+        # Quarantine the running ``hermes.exe`` first: ``--reinstall -e .``
+        # rewrites the entry-point shims, and on Windows pip can't overwrite the
+        # live launcher, which would leave ``hermes`` off PATH.
+        scripts_dir = _venv_scripts_dir() if _is_windows() else None
+        repair_args = ["install", "--reinstall", "-e", "."]
+        try:
+            _run_quarantined_install(
+                install_cmd_prefix + repair_args, env=env, scripts_dir=scripts_dir
+            )
+        except subprocess.CalledProcessError as e:
+            logger.warning("dep verification: repair install failed: %s", e)
+            print("  ⚠ Repair install failed; check `hermes update` output above.")
+            return
+
+        still_missing = _missing_deps()
+        if still_missing:
+            # Last-ditch: install each remaining missing dep with its pin directly.
+            # Useful when uv's resolver thinks the env is satisfied but the on-disk
+            # package metadata says otherwise (rare but observed).
+            name_to_spec = {}
+            for spec in raw_deps:
+                head = spec.split(";", 1)[0].strip()
+                bare = head
+                for op in ("==", ">=", "<=", "~=", ">", "<", "!="):
+                    if op in bare:
+                        bare = bare.split(op, 1)[0]
+                        break
+                name_to_spec[bare.strip().split("[", 1)[0].strip()] = head
+
+            specs = [name_to_spec.get(n, n) for n in still_missing]
+            print(
+                f"  → Force-installing remaining missing dep(s): {', '.join(specs)}"
+            )
+            try:
+                _run_install_with_heartbeat(
+                    install_cmd_prefix + ["install", "--reinstall", *specs], env=env
+                )
+            except subprocess.CalledProcessError as e:
+                logger.warning("dep verification: per-package repair failed: %s", e)
+                print(
+                    f"  ⚠ Could not install: {', '.join(still_missing)}. "
+                    "Run `hermes update --force` after closing other hermes processes."
+                )
+                return
+
+            final_missing = _missing_deps()
+            if final_missing:
+                print(
+                    f"  ⚠ Still missing after repair: {', '.join(final_missing)}. "
+                    "Run `hermes update --force` after closing other hermes processes."
+                )
+                return
+
         print("  ✓ All declared core dependencies now installed")
+
+    _maybe_repair_windows_hermes_launcher(venv_python, env=env)
 
 
 def _resolve_install_target_python(
@@ -7556,6 +7554,110 @@ def _resolve_install_target_python(
             return first
 
     return None
+
+
+def _probe_windows_hermes_launcher(
+    venv_python: Path, *, env: dict[str, str] | None = None
+) -> tuple[bool, str]:
+    """Check whether ``venv\\Scripts\\hermes.exe`` can execute a fast path.
+
+    A healthy Windows launcher should answer ``--version`` immediately. When uv
+    writes a broken trampoline, the venv imports remain fine but the native
+    ``hermes.exe`` dies before Python starts, typically with
+    ``uv trampoline failed to canonicalize script path``.
+    """
+    if not _is_windows():
+        return True, ""
+
+    launcher = venv_python.parent / "hermes.exe"
+    if not launcher.exists():
+        return False, f"{launcher} is missing"
+
+    try:
+        result = subprocess.run(
+            [str(launcher), "--version"],
+            capture_output=True,
+            text=True,
+            check=False,
+            env=env,
+            timeout=15,
+        )
+    except Exception as exc:
+        return False, str(exc)
+
+    if result.returncode == 0:
+        return True, ""
+
+    detail = (result.stderr or result.stdout or "").strip()
+    if detail:
+        detail = detail.splitlines()[0]
+    else:
+        detail = f"exit {result.returncode}"
+    return False, detail
+
+
+def _maybe_repair_windows_hermes_launcher(
+    venv_python: Path, *, env: dict[str, str] | None = None
+) -> None:
+    """Rebuild a broken Windows ``hermes.exe`` launcher with the venv's pip.
+
+    If ``uv pip install -e .`` left behind a bad uv trampoline, rerunning the
+    same uv command tends to reproduce the same broken launcher. Rewriting the
+    entry points via ``python -m pip --force-reinstall --no-deps -e .`` keeps
+    the already-installed dependencies intact but replaces the native shims with
+    pip's distlib-generated launchers.
+    """
+    healthy, detail = _probe_windows_hermes_launcher(venv_python, env=env)
+    if healthy:
+        return
+
+    print(
+        "  ⚠ Windows hermes launcher self-check failed"
+        f"{f': {detail}' if detail else ''}"
+    )
+    print(
+        "  → Rebuilding Windows entry-point shims with the venv's pip to bypass "
+        "the broken uv trampoline..."
+    )
+
+    pip_cmd = [str(venv_python), "-m", "pip"]
+    try:
+        pip_probe = subprocess.run(
+            pip_cmd + ["--version"],
+            capture_output=True,
+            text=True,
+            check=False,
+            env=env,
+        )
+        if pip_probe.returncode != 0:
+            subprocess.run(
+                [str(venv_python), "-m", "ensurepip", "--upgrade", "--default-pip"],
+                cwd=PROJECT_ROOT,
+                check=True,
+                env=env,
+            )
+
+        _run_quarantined_install(
+            pip_cmd + ["install", "--no-deps", "--force-reinstall", "-e", "."],
+            env=env,
+            scripts_dir=_venv_scripts_dir(),
+        )
+    except subprocess.CalledProcessError as exc:
+        logger.warning("launcher repair via venv pip failed: %s", exc)
+        print(
+            "  ⚠ Could not rebuild the Windows launcher automatically. "
+            f"Manual recovery: {' '.join(pip_cmd + ['install', '--no-deps', '--force-reinstall', '-e', '.'])}"
+        )
+        return
+
+    healthy, detail = _probe_windows_hermes_launcher(venv_python, env=env)
+    if healthy:
+        print("  ✓ Rebuilt the Windows hermes launcher")
+    else:
+        print(
+            "  ⚠ Windows hermes launcher still failed after the pip rebuild"
+            f"{f': {detail}' if detail else ''}"
+        )
 
 
 def _is_termux_env(env: dict[str, str] | None = None) -> bool:

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -1694,6 +1694,60 @@ except Exception:
             throw "Baseline imports failed in $InstallDir\venv (dotenv/openai/rich/prompt_toolkit). The install completed but dependencies are not in the venv. $hint"
         }
         Write-Success "Baseline imports verified in venv"
+
+        # The import probe above proves the venv Python is healthy, but it does
+        # NOT prove the native `venv\Scripts\hermes.exe` launcher is healthy.
+        # On some Windows installs uv leaves behind a broken trampoline that
+        # exits immediately with "uv trampoline failed to canonicalize script
+        # path" even though imports via python.exe are fine. Probe the actual
+        # launcher and, if needed, rewrite only the entry-point shims with the
+        # venv's pip-generated launcher.
+        $hermesExe = "$InstallDir\venv\Scripts\hermes.exe"
+        if (Test-Path $hermesExe) {
+            $prevEAP = $ErrorActionPreference
+            $ErrorActionPreference = "Continue"
+            try {
+                & $hermesExe --version 2>&1 | Out-Null
+                $launcherExitCode = $LASTEXITCODE
+            } finally {
+                $ErrorActionPreference = $prevEAP
+            }
+            if ($launcherExitCode -ne 0) {
+                Write-Warn "hermes.exe launcher self-check failed -- rebuilding entry-point shims with venv pip..."
+                $prevEAP = $ErrorActionPreference
+                $ErrorActionPreference = "Continue"
+                try {
+                    & $venvPython -m pip --version 2>&1 | Out-Null
+                    if ($LASTEXITCODE -ne 0) {
+                        Write-Info "Bootstrapping pip into venv for launcher repair..."
+                        & $venvPython -m ensurepip --upgrade 2>&1 | Out-Null
+                        if ($LASTEXITCODE -ne 0) {
+                            throw "Failed to bootstrap pip into venv for launcher repair."
+                        }
+                    }
+                    & $venvPython -m pip install --no-deps --force-reinstall -e . 2>&1 | ForEach-Object { Write-Host "    $_" }
+                    $launcherRepairExitCode = $LASTEXITCODE
+                } finally {
+                    $ErrorActionPreference = $prevEAP
+                }
+                if ($launcherRepairExitCode -ne 0) {
+                    throw "Failed to rebuild Windows hermes.exe launcher. Manual recovery: $venvPython -m pip install --no-deps --force-reinstall -e ."
+                }
+
+                $prevEAP = $ErrorActionPreference
+                $ErrorActionPreference = "Continue"
+                try {
+                    & $hermesExe --version 2>&1 | Out-Null
+                    $launcherExitCode = $LASTEXITCODE
+                } finally {
+                    $ErrorActionPreference = $prevEAP
+                }
+                if ($launcherExitCode -ne 0) {
+                    throw "hermes.exe launcher is still unhealthy after rebuild. Manual recovery: $venvPython -m pip install --no-deps --force-reinstall -e ."
+                }
+            }
+            Write-Success "Windows hermes.exe launcher verified"
+        }
     }
 
     # Verify the dashboard deps specifically -- they're the most common thing

--- a/tests/hermes_cli/test_verify_core_dependencies.py
+++ b/tests/hermes_cli/test_verify_core_dependencies.py
@@ -264,3 +264,100 @@ class TestResolveInstallTargetPython:
                 ["uv", "pip"], env={"VIRTUAL_ENV": str(tmp_path / "does_not_exist")}
             )
             assert result is None
+
+
+class TestWindowsLauncherRepair:
+    def test_broken_uv_trampoline_is_rebuilt_with_venv_pip(
+        self, temp_pyproject, fake_venv_python
+    ):
+        py, venv_root = fake_venv_python
+        env = {"VIRTUAL_ENV": str(venv_root)}
+        scripts_dir = venv_root / "Scripts"
+        launcher = scripts_dir / "hermes.exe"
+        launcher.write_text("fake launcher")
+
+        launcher_checks = {"count": 0}
+
+        def fake_subprocess_run(cmd, **kwargs):
+            if list(cmd[:2]) == [str(py), "-c"]:
+                return MagicMock(returncode=0, stdout="", stderr="")
+            if list(cmd) == [str(launcher), "--version"]:
+                launcher_checks["count"] += 1
+                if launcher_checks["count"] == 1:
+                    return MagicMock(
+                        returncode=1,
+                        stdout="",
+                        stderr="uv trampoline failed to canonicalize script path\n",
+                    )
+                return MagicMock(returncode=0, stdout="hermes 1.2.3\n", stderr="")
+            if list(cmd) == [str(py), "-m", "pip", "--version"]:
+                return MagicMock(returncode=0, stdout="pip 25.0\n", stderr="")
+            raise AssertionError(f"unexpected subprocess.run call: {cmd!r}")
+
+        with patch("hermes_cli.main._resolve_install_target_python", return_value=py), \
+             patch("hermes_cli.main.subprocess.run", side_effect=fake_subprocess_run), \
+             patch("hermes_cli.main._is_windows", return_value=True), \
+             patch("hermes_cli.main._venv_scripts_dir", return_value=scripts_dir), \
+             patch("hermes_cli.main._run_quarantined_install") as mock_rebuild:
+
+            from hermes_cli.main import _verify_core_dependencies_installed
+            _verify_core_dependencies_installed(["uv", "pip"], env=env)
+
+            mock_rebuild.assert_called_once_with(
+                [
+                    str(py),
+                    "-m",
+                    "pip",
+                    "install",
+                    "--no-deps",
+                    "--force-reinstall",
+                    "-e",
+                    ".",
+                ],
+                env=env,
+                scripts_dir=scripts_dir,
+            )
+
+    def test_launcher_rebuild_bootstraps_pip_when_uv_venv_lacks_it(
+        self, temp_pyproject, fake_venv_python
+    ):
+        py, venv_root = fake_venv_python
+        env = {"VIRTUAL_ENV": str(venv_root)}
+        scripts_dir = venv_root / "Scripts"
+        launcher = scripts_dir / "hermes.exe"
+        launcher.write_text("fake launcher")
+
+        launcher_checks = {"count": 0}
+
+        def fake_subprocess_run(cmd, **kwargs):
+            if list(cmd[:2]) == [str(py), "-c"]:
+                return MagicMock(returncode=0, stdout="", stderr="")
+            if list(cmd) == [str(launcher), "--version"]:
+                launcher_checks["count"] += 1
+                if launcher_checks["count"] == 1:
+                    return MagicMock(
+                        returncode=1,
+                        stdout="",
+                        stderr="uv trampoline failed to canonicalize script path\n",
+                    )
+                return MagicMock(returncode=0, stdout="hermes 1.2.3\n", stderr="")
+            if list(cmd) == [str(py), "-m", "pip", "--version"]:
+                return MagicMock(returncode=1, stdout="", stderr="No module named pip")
+            if list(cmd) == [str(py), "-m", "ensurepip", "--upgrade", "--default-pip"]:
+                return MagicMock(returncode=0, stdout="", stderr="")
+            raise AssertionError(f"unexpected subprocess.run call: {cmd!r}")
+
+        with patch("hermes_cli.main._resolve_install_target_python", return_value=py), \
+             patch("hermes_cli.main.subprocess.run", side_effect=fake_subprocess_run) as mock_run, \
+             patch("hermes_cli.main._is_windows", return_value=True), \
+             patch("hermes_cli.main._venv_scripts_dir", return_value=scripts_dir), \
+             patch("hermes_cli.main._run_quarantined_install"):
+
+            from hermes_cli.main import _verify_core_dependencies_installed
+            _verify_core_dependencies_installed(["uv", "pip"], env=env)
+
+            ensurepip_calls = [
+                call for call in mock_run.call_args_list
+                if call.args[0] == [str(py), "-m", "ensurepip", "--upgrade", "--default-pip"]
+            ]
+            assert ensurepip_calls, "launcher repair should bootstrap pip before rebuilding shims"

--- a/tests/test_install_ps1_native_stderr_eap.py
+++ b/tests/test_install_ps1_native_stderr_eap.py
@@ -52,6 +52,11 @@ def test_uv_venv_and_dependency_installs_relax_eap() -> None:
     _assert_relaxed_call(text, r"& \$UvCmd venv venv --python \$PythonVersion")
     _assert_relaxed_call(text, r"& \$UvCmd sync --extra all --locked")
     _assert_relaxed_call(text, r"& \$UvCmd pip install -e \$tier\.Spec")
+    _assert_relaxed_call(text, r"& \$hermesExe --version")
+    _assert_relaxed_call(
+        text,
+        r"& \$venvPython -m pip install --no-deps --force-reinstall -e \.",
+    )
 
 
 def test_uv_venv_failure_is_not_swallowed_after_eap_relax() -> None:
@@ -92,3 +97,18 @@ def test_native_eap_helper_always_restores_previous_preference() -> None:
     assert '$ErrorActionPreference = "Continue"' in body
     assert "finally" in body
     assert "$ErrorActionPreference = $prevEAP" in body
+
+
+def test_windows_launcher_probe_repairs_broken_uv_trampoline() -> None:
+    text = _install_ps1()
+    assert "uv trampoline failed to canonicalize script" in text, (
+        "install.ps1 should document why it probes hermes.exe itself after the "
+        "baseline import check"
+    )
+    assert "Windows hermes.exe launcher verified" in text, (
+        "install.ps1 should verify the native launcher before returning success"
+    )
+    assert "--no-deps --force-reinstall -e ." in text, (
+        "broken Windows launchers should be rebuilt with the venv's pip so we "
+        "rewrite only the entry-point shims instead of repeating the uv trampoline"
+    )


### PR DESCRIPTION
## Summary
- probe the real Windows `hermes.exe` launcher after dependency repair instead of only checking imports through `python.exe`
- rebuild broken uv trampolines with the venv's `pip --no-deps --force-reinstall -e .` in both `hermes update` recovery and `scripts/install.ps1`
- add regression coverage for the Python repair path and the PowerShell installer guard

Closes #48414

## Verification
- /Users/leongong/Desktop/LeonProjects/worktrees/hermes-agent/.base/.venv/bin/python -m pytest tests/hermes_cli/test_verify_core_dependencies.py tests/test_install_ps1_native_stderr_eap.py
- /Users/leongong/Desktop/LeonProjects/worktrees/hermes-agent/.base/.venv/bin/ruff check hermes_cli/main.py tests/hermes_cli/test_verify_core_dependencies.py tests/test_install_ps1_native_stderr_eap.py
- git diff --check