### PR TITLE
fix(guardrails): catch no-progress loops on terminal and execute_code

### DIFF
--- a/agent/tool_guardrails.py
+++ b/agent/tool_guardrails.py
@@ -60,6 +60,17 @@ MUTATING_TOOL_NAMES = frozenset(
 )
 
 
+# Mutating tools whose identical (args -> result) repeat still signals no progress:
+# a deterministic command re-run that returns the same output made no headway,
+# unlike write_file/send_message where an identical "ok" hides a real side effect.
+NO_PROGRESS_MUTATING_TOOLS = frozenset(
+    {
+        "terminal",
+        "execute_code",
+    }
+)
+
+
 @dataclass(frozen=True)
 class ToolCallGuardrailConfig:
     """Thresholds for per-turn tool-call loop detection.
@@ -260,7 +271,7 @@ class ToolCallGuardrailController:
             self._halt_decision = decision
             return decision
 
-        if self._is_idempotent(tool_name):
+        if self._tracks_no_progress(tool_name):
             record = self._no_progress.get(signature)
             if record is not None:
                 _result_hash, repeat_count = record
@@ -347,7 +358,7 @@ class ToolCallGuardrailController:
         self._exact_failure_counts.pop(signature, None)
         self._same_tool_failure_counts.pop(tool_name, None)
 
-        if not self._is_idempotent(tool_name):
+        if not self._tracks_no_progress(tool_name):
             self._no_progress.pop(signature, None)
             return ToolGuardrailDecision(tool_name=tool_name, signature=signature)
 
@@ -373,6 +384,11 @@ class ToolCallGuardrailController:
             )
 
         return ToolGuardrailDecision(tool_name=tool_name, count=repeat_count, signature=signature)
+
+    def _tracks_no_progress(self, tool_name: str) -> bool:
+        if tool_name in NO_PROGRESS_MUTATING_TOOLS:
+            return True
+        return self._is_idempotent(tool_name)
 
     def _is_idempotent(self, tool_name: str) -> bool:
         if tool_name in self.config.mutating_tools:

--- a/tests/agent/test_tool_guardrails.py
+++ b/tests/agent/test_tool_guardrails.py
@@ -256,3 +256,47 @@ def test_reset_for_turn_clears_bounded_guardrail_state():
 
     assert controller.before_call("web_search", {"query": "same"}).action == "allow"
     assert controller.before_call("read_file", {"path": "/tmp/x"}).action == "allow"
+
+
+def test_terminal_identical_output_warns_then_hard_stops():
+    controller = ToolCallGuardrailController(
+        ToolCallGuardrailConfig(
+            hard_stop_enabled=True,
+            no_progress_warn_after=2,
+            no_progress_block_after=2,
+        )
+    )
+    args = {"command": "echo same"}
+    result = '{"exit_code": 0, "output": "same"}'
+
+    assert controller.before_call("terminal", args).action == "allow"
+    assert controller.after_call("terminal", args, result, failed=False).action == "allow"
+    assert controller.before_call("terminal", args).action == "allow"
+    warn = controller.after_call("terminal", args, result, failed=False)
+    assert warn.action == "warn"
+    assert warn.code == "idempotent_no_progress_warning"
+
+    blocked = controller.before_call("terminal", args)
+    assert blocked.action == "block"
+    assert blocked.code == "idempotent_no_progress_block"
+
+
+def test_execute_code_tracks_no_progress_but_changing_output_is_not_flagged():
+    controller = ToolCallGuardrailController(
+        ToolCallGuardrailConfig(
+            hard_stop_enabled=True,
+            no_progress_warn_after=2,
+            no_progress_block_after=2,
+        )
+    )
+    code_args = {"code": "print('x')"}
+
+    controller.after_call("execute_code", code_args, "x", failed=False)
+    controller.after_call("execute_code", code_args, "x", failed=False)
+    assert controller.before_call("execute_code", code_args).action == "block"
+
+    controller.reset_for_turn()
+    for index in range(5):
+        assert controller.before_call("terminal", {"command": "date"}).action == "allow"
+        changing = controller.after_call("terminal", {"command": "date"}, str(index), failed=False)
+        assert changing.action == "allow"


### PR DESCRIPTION
## Problem

The tool-loop guardrail already detects "no progress" by hashing a tool call's args and result and counting identical repeats, but it only does this for idempotent (read-only) tools. `terminal` and `execute_code` are in `MUTATING_TOOL_NAMES`, so `after_call` pops their tracking state and `before_call` never blocks them. A model that re-runs the same shell command and keeps getting the same output is therefore never warned or stopped, and with `hard_stop_enabled` set it still loops until `max_turns`. This is the common shape of the doom loop in #512

## Fix

Add `NO_PROGRESS_MUTATING_TOOLS = {terminal, execute_code}` and a `_tracks_no_progress` predicate that is true for those tools and for idempotent tools, then use it at the two no-progress call sites. An allowlist rather than tracking every mutating tool is deliberate: an identical `"ok"` from `write_file` or `send_message` can hide a real side effect, whereas a deterministic shell command that returns the same output made no headway. A command whose output changes resets the counter, so legitimate polling is unaffected

With the existing thresholds, identical `terminal`/`execute_code` output warns at `no_progress_warn_after` and, when `hard_stop_enabled` is set, blocks at `no_progress_block_after`

## Tests

`tests/agent/test_tool_guardrails.py` gains two cases: `terminal` identical output warns then hard-stops, and `execute_code` identical output blocks while changing output is never flagged. Both fail on the pre-fix code (identical `terminal` output returns `allow`) and pass with the change. The existing `write_file`/`custom_tool` no-track test is unchanged and still passes

Refs #512
