### PR TITLE
fix(desktop): expose full model titles

### DIFF
--- a/apps/desktop/src/app/chat/composer/model-pill.test.tsx
+++ b/apps/desktop/src/app/chat/composer/model-pill.test.tsx
@@ -1,0 +1,72 @@
+import { cleanup, render, screen } from '@testing-library/react'
+import type { ReactNode } from 'react'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+
+import { I18nProvider } from '@/i18n'
+import {
+  setCurrentFastMode,
+  setCurrentModel,
+  setCurrentProvider,
+  setCurrentReasoningEffort
+} from '@/store/session'
+
+import { ModelPill } from './model-pill'
+
+function renderModelPill(modelMenuContent: ReactNode = null) {
+  return render(
+    <I18nProvider configClient={null} initialLocale="en">
+      <ModelPill
+        disabled={false}
+        model={{
+          canSwitch: true,
+          model: 'grok/composer-2.5-fast',
+          modelMenuContent,
+          provider: 'xai'
+        }}
+      />
+    </I18nProvider>
+  )
+}
+
+describe('ModelPill', () => {
+  beforeEach(() => {
+    setCurrentModel('grok/composer-2.5-fast')
+    setCurrentProvider('xai')
+    setCurrentFastMode(false)
+    setCurrentReasoningEffort('medium')
+  })
+
+  afterEach(() => {
+    cleanup()
+    setCurrentModel('')
+    setCurrentProvider('')
+    setCurrentFastMode(false)
+    setCurrentReasoningEffort('')
+  })
+
+  it('shows the full current model in the title when the live menu is unavailable', () => {
+    renderModelPill()
+
+    expect(screen.getByRole('button', { name: 'Open model picker' }).getAttribute('title')).toBe(
+      'Model · xai: grok/composer-2.5-fast'
+    )
+  })
+
+  it('keeps the full current model title on the live menu trigger', () => {
+    renderModelPill(<div>menu</div>)
+
+    expect(screen.getByRole('button', { name: 'Open model picker' }).getAttribute('title')).toBe(
+      'Model · xai: grok/composer-2.5-fast'
+    )
+  })
+
+  it('keeps the current model visible while provider state is still loading', () => {
+    setCurrentProvider('')
+
+    renderModelPill()
+
+    expect(screen.getByRole('button', { name: 'Open model picker' }).getAttribute('title')).toBe(
+      'Model · none: grok/composer-2.5-fast'
+    )
+  })
+})

--- a/apps/desktop/src/app/chat/composer/model-pill.tsx
+++ b/apps/desktop/src/app/chat/composer/model-pill.tsx
@@ -51,7 +51,10 @@ export function ModelPill({ disabled, model }: { disabled: boolean; model: ChatB
     </>
   )
 
-  const title = currentProvider ? copy.modelTitle(currentProvider, currentModel || copy.modelNone) : copy.switchModel
+  const title =
+    currentModel.trim() || currentProvider
+      ? copy.modelTitle(currentProvider || copy.modelNone, currentModel || copy.modelNone)
+      : copy.switchModel
 
   if (!model.modelMenuContent) {
     return (
@@ -60,7 +63,7 @@ export function ModelPill({ disabled, model }: { disabled: boolean; model: ChatB
         className={PILL}
         disabled={disabled}
         onClick={() => setModelPickerOpen(true)}
-        title={copy.openModelPicker}
+        title={title}
         type="button"
         variant="ghost"
       >
@@ -72,7 +75,14 @@ export function ModelPill({ disabled, model }: { disabled: boolean; model: ChatB
   return (
     <DropdownMenu onOpenChange={setOpen} open={open}>
       <DropdownMenuTrigger asChild>
-        <Button aria-label={title} className={PILL} disabled={disabled} title={title} type="button" variant="ghost">
+        <Button
+          aria-label={copy.openModelPicker}
+          className={PILL}
+          disabled={disabled}
+          title={title}
+          type="button"
+          variant="ghost"
+        >
           {label}
         </Button>
       </DropdownMenuTrigger>

--- a/apps/desktop/src/app/shell/statusbar-controls.test.tsx
+++ b/apps/desktop/src/app/shell/statusbar-controls.test.tsx
@@ -1,0 +1,82 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { StatusbarControls } from './statusbar-controls'
+
+describe('StatusbarControls', () => {
+  afterEach(() => {
+    cleanup()
+  })
+
+  it('applies item titles to truncated action and text controls', () => {
+    render(
+      <MemoryRouter>
+        <StatusbarControls
+          items={[
+            {
+              id: 'model',
+              label: 'Grok Composer 2.5 · F...',
+              title: 'Model · xai: grok/composer-2.5-fast',
+              variant: 'action'
+            }
+          ]}
+          leftItems={[
+            {
+              id: 'session',
+              label: 'Session name that may truncate',
+              title: 'Session name that may truncate',
+              variant: 'text'
+            }
+          ]}
+        />
+      </MemoryRouter>
+    )
+
+    expect(screen.getByRole('button', { name: 'Grok Composer 2.5 · F...' }).getAttribute('title')).toBe(
+      'Model · xai: grok/composer-2.5-fast'
+    )
+    expect(screen.getByText('Session name that may truncate').closest('div')?.getAttribute('title')).toBe(
+      'Session name that may truncate'
+    )
+  })
+
+  it('applies item titles to menu and link controls', async () => {
+    render(
+      <MemoryRouter>
+        <StatusbarControls
+          items={[
+            {
+              id: 'menu-model',
+              label: 'Grok Composer 2.5 · F...',
+              menuItems: [{ id: 'change', label: 'Change model', title: 'Change the active model' }],
+              title: 'Model · xai: grok/composer-2.5-fast',
+              variant: 'menu'
+            },
+            {
+              href: 'https://example.test',
+              id: 'docs',
+              label: 'Docs',
+              title: 'Open documentation',
+              variant: 'link'
+            }
+          ]}
+        />
+      </MemoryRouter>
+    )
+
+    expect(screen.getByRole('button', { name: 'Grok Composer 2.5 · F...' }).getAttribute('title')).toBe(
+      'Model · xai: grok/composer-2.5-fast'
+    )
+    expect(screen.getByRole('link', { name: 'Docs' }).getAttribute('title')).toBe('Open documentation')
+
+    fireEvent.pointerDown(screen.getByRole('button', { name: 'Grok Composer 2.5 · F...' }), {
+      button: 0,
+      ctrlKey: false
+    })
+
+    expect((await screen.findByText('Change model')).closest('[role="menuitem"]')?.getAttribute('title')).toBe(
+      'Change the active model'
+    )
+  })
+})

--- a/apps/desktop/src/app/shell/statusbar-controls.tsx
+++ b/apps/desktop/src/app/shell/statusbar-controls.tsx
@@ -87,6 +87,8 @@ export function StatusbarControls({ className, leftItems = [], items = [], ...pr
 }
 
 function StatusbarItemView({ item, navigate }: { item: StatusbarItem; navigate: ReturnType<typeof useNavigate> }) {
+  const title = item.title || undefined
+
   const content = (
     <>
       {item.icon}
@@ -99,7 +101,7 @@ function StatusbarItemView({ item, navigate }: { item: StatusbarItem; navigate: 
     return (
       <DropdownMenu>
         <DropdownMenuTrigger asChild>
-          <button className={cn(STATUSBAR_ACTION_CLASS, item.className)} disabled={item.disabled} type="button">
+          <button className={cn(STATUSBAR_ACTION_CLASS, item.className)} disabled={item.disabled} title={title} type="button">
             {content}
           </button>
         </DropdownMenuTrigger>
@@ -125,6 +127,7 @@ function StatusbarItemView({ item, navigate }: { item: StatusbarItem; navigate: 
 
                       menuItem.onSelect?.()
                     }}
+                    title={menuItem.title || undefined}
                   >
                     {menuItem.href ? (
                       <a
@@ -132,6 +135,7 @@ function StatusbarItemView({ item, navigate }: { item: StatusbarItem; navigate: 
                         href={menuItem.href}
                         rel="noreferrer"
                         target="_blank"
+                        title={menuItem.title || undefined}
                       >
                         {menuItem.icon}
                         <span className="truncate">{menuItem.label}</span>
@@ -156,6 +160,7 @@ function StatusbarItemView({ item, navigate }: { item: StatusbarItem; navigate: 
           'inline-flex h-full items-center gap-1 px-1.5 text-[0.6875rem] text-(--ui-text-tertiary)',
           item.className
         )}
+        title={title}
       >
         {content}
       </div>
@@ -164,7 +169,13 @@ function StatusbarItemView({ item, navigate }: { item: StatusbarItem; navigate: 
 
   if (item.href || item.variant === 'link') {
     return (
-      <a className={cn(STATUSBAR_ACTION_CLASS, item.className)} href={item.href} rel="noreferrer" target="_blank">
+      <a
+        className={cn(STATUSBAR_ACTION_CLASS, item.className)}
+        href={item.href}
+        rel="noreferrer"
+        target="_blank"
+        title={title}
+      >
         {content}
       </a>
     )
@@ -181,6 +192,7 @@ function StatusbarItemView({ item, navigate }: { item: StatusbarItem; navigate: 
 
         item.onSelect?.({ shiftKey: event.shiftKey })
       }}
+      title={title}
       type="button"
     >
       {content}


### PR DESCRIPTION
## Summary
- keep the composer model pill's accessible label action-oriented while using its title for the full provider/model value
- expose StatusbarItem and StatusbarMenuItem titles on rendered controls so truncated labels remain inspectable
- add desktop UI regression tests for model pill titles and statusbar title passthrough

Fixes #47975

## Tests
- npm run test:ui -- src/app/chat/composer/model-pill.test.tsx src/app/shell/statusbar-controls.test.tsx
- npx eslint src/app/chat/composer/model-pill.tsx src/app/chat/composer/model-pill.test.tsx src/app/shell/statusbar-controls.tsx src/app/shell/statusbar-controls.test.tsx
- npm run typecheck
- git diff --check

## Review
- Subagent review found the live model pill aria-label was state-like; fixed to keep aria-label action-oriented and title value-focused.
- Subagent review requested menu/link/nested menu item title coverage; added tests and passthrough.
