### PR TITLE
fix(web): preserve Linux copy and middle-click paste

### DIFF
--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -396,6 +396,32 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
 
     const isMac =
       typeof navigator !== "undefined" && /Mac/i.test(navigator.platform);
+    const isLinux =
+      typeof navigator !== "undefined" && /Linux/i.test(navigator.platform);
+
+    const getSelectedText = (): null | { source: "dom" | "term"; text: string } => {
+      const termSelection = term.getSelection();
+      if (termSelection) {
+        return { source: "term", text: termSelection };
+      }
+      const domSelection = window.getSelection()?.toString() ?? "";
+      if (domSelection) {
+        return { source: "dom", text: domSelection };
+      }
+      return null;
+    };
+
+    const copySelectionToClipboard = (
+      selection: { source: "dom" | "term"; text: string },
+    ) => {
+      navigator.clipboard.writeText(selection.text).catch((err) => {
+        console.warn("[dashboard clipboard] direct copy failed:", err.message);
+      });
+      if (selection.source === "term") {
+        // Clear xterm.js's highlight after copy (matches gnome-terminal).
+        term.clearSelection();
+      }
+    };
 
     term.attachCustomKeyEventHandler((ev) => {
       if (ev.type !== "keydown") return true;
@@ -408,23 +434,27 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
       // Paste: Cmd+Shift+V on macOS, Ctrl+Shift+V on others.
       const copyModifier = isMac ? ev.metaKey : ev.ctrlKey && ev.shiftKey;
       const pasteModifier = isMac ? ev.metaKey : ev.ctrlKey && ev.shiftKey;
+      const bareCtrlCopy =
+        !isMac &&
+        ev.ctrlKey &&
+        !ev.shiftKey &&
+        !ev.altKey &&
+        !ev.metaKey &&
+        ev.key.toLowerCase() === "c";
 
-      if (copyModifier && ev.key.toLowerCase() === "c") {
-        const sel = term.getSelection();
-        if (sel) {
+      if ((copyModifier || bareCtrlCopy) && ev.key.toLowerCase() === "c") {
+        const selection = getSelectedText();
+        if (selection) {
           // Direct writeText inside the keydown handler preserves the user
           // gesture — async round-trips through OSC 52 can lose activation
           // and fail with "Document is not focused".
-          navigator.clipboard.writeText(sel).catch((err) => {
-            console.warn("[dashboard clipboard] direct copy failed:", err.message);
-          });
-          // Clear xterm.js's highlight after copy (matches gnome-terminal).
-          term.clearSelection();
+          copySelectionToClipboard(selection);
           ev.preventDefault();
           return false;
         }
-        // No selection → fall through so the TUI receives Ctrl+Shift+C
-        // (or the bare ev if the user used a different modifier).
+        // No selection → fall through so the TUI still receives SIGINT on
+        // bare Ctrl+C, and Ctrl+Shift+C remains available for terminal-side
+        // bindings when nothing is highlighted.
       }
 
       if (pasteModifier && ev.key.toLowerCase() === "v") {
@@ -442,6 +472,21 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
 
       return true;
     });
+
+    const handleLinuxMiddleClickPaste = (ev: MouseEvent) => {
+      if (!isLinux || ev.button !== 1) {
+        return;
+      }
+      const selection = getSelectedText();
+      if (!selection) {
+        return;
+      }
+      ev.preventDefault();
+      ev.stopPropagation();
+      term.focus();
+      term.paste(selection.text);
+    };
+    host.addEventListener("mousedown", handleLinuxMiddleClickPaste, true);
 
     const fit = new FitAddon();
     fitRef.current = fit;
@@ -725,6 +770,7 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
         "resize",
         scheduleSyncTerminalMetrics,
       );
+      host.removeEventListener("mousedown", handleLinuxMiddleClickPaste, true);
       ro.disconnect();
       if (hostSyncRaf) cancelAnimationFrame(hostSyncRaf);
       if (settleRaf1) cancelAnimationFrame(settleRaf1);


### PR DESCRIPTION
## What does this PR do?

Fixes the web dashboard terminal clipboard behavior on Linux by treating bare `Ctrl+C` as copy when text is actually selected and by wiring middle-click paste to the current browser selection inside the embedded xterm. When nothing is selected, bare `Ctrl+C` still falls through to the TUI so SIGINT behavior is preserved.

## Related Issue

Fixes #48366

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Update [`web/src/pages/ChatPage.tsx`](web/src/pages/ChatPage.tsx) to detect either xterm or DOM text selections before deciding whether bare `Ctrl+C` should copy or pass through to the terminal.
- Reuse the same selection-aware copy path for `Ctrl+Shift+C` so copy behavior stays consistent across Linux terminal shortcuts.
- Add a Linux-only middle-click handler that pastes the current browser selection into the embedded terminal via `term.paste(...)`.
- Preserve existing SIGINT behavior when no selection exists and keep the change isolated to the web dashboard terminal wrapper.

## How to Test

1. On Linux, open the Hermes web dashboard chat and select text inside the terminal transcript.
2. Press bare `Ctrl+C` and confirm the text copies instead of closing or interrupting the terminal session.
3. Clear the selection and press bare `Ctrl+C` again; confirm the key still reaches the terminal as SIGINT behavior.
4. Select text in the browser, middle-click inside the embedded terminal, and confirm the selected text is pasted into the chat input.
5. Verification run for this patch:
   - `git diff --check`
   - `cd web && npx tsc --noEmit`
   - `node /Users/leongong/Desktop/LeonProjects/worktrees/hermes-agent/.base/web/node_modules/eslint/bin/eslint.js src/pages/ChatPage.tsx` (passes with two pre-existing hook warnings already present in `ChatPage.tsx`)

## Checklist

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

- No screenshots. This is a focused interaction fix in the embedded terminal wrapper.
