### PR TITLE
fix(tui): register shell hooks in TUI path for parity with CLI and gateway

### DIFF
--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -3589,6 +3589,16 @@ def _make_agent(
     except Exception:
         pass
 
+    # Register declarative shell hooks (parity with cli.py and gateway/run.py).
+    # Without this, hooks like post_llm_call never fire in the TUI path.
+    try:
+        from agent.shell_hooks import register_from_config
+        from hermes_cli.config import load_config
+
+        register_from_config(load_config(), accept_hooks=False)
+    except Exception:
+        pass
+
     cfg = _load_cfg()
     agent_cfg = cfg.get("agent") or {}
     system_prompt = _prompt_text(agent_cfg.get("system_prompt", ""))


### PR DESCRIPTION
## Problem

Shell hooks configured in the `hooks:` block of `config.yaml` (e.g. `post_llm_call`) are silently ignored when running via the TUI. They work correctly in the CLI and gateway paths.

## Root cause

The TUI's agent factory (`_make_agent` in `tui_gateway/server.py`) never calls `register_from_config()`. The other two entry points do:

| Entry point | Calls `register_from_config` | Location |
|---|---|---|
| CLI | ✅ | `cli.py:953` |
| Gateway | ✅ | `gateway/run.py:5124` |
| **TUI** | ❌ | — |

Without this call, shell hook callbacks are never wired into the plugin manager, so `invoke_hook("post_llm_call", ...)` in `agent/turn_finalizer.py` finds zero callbacks and the hook script never runs.

## Fix

Add `register_from_config(load_config(), accept_hooks=False)` to `_make_agent()` in `tui_gateway/server.py`, matching the exact pattern used by the CLI and gateway. The call is:
- **Idempotent** — guarded by the `_registered` set in `shell_hooks.py`, so repeated calls on multiple agent creations are no-ops.
- **Failure-safe** — wrapped in `try/except` so a broken hook never crashes agent init.
- **Consistent** — uses the same `accept_hooks=False` argument, letting `_resolve_effective_accept` pick up `hooks_auto_accept: true` / `HERMES_ACCEPT_HOOKS` env var.

## Verification

```python
# Before fix: TUI process
>>> from hermes_cli.plugins import get_plugin_manager
>>> get_plugin_manager().has_hook("post_llm_call")
False

# After fix: TUI process
>>> get_plugin_manager().has_hook("post_llm_call")
True
>>> get_plugin_manager()._hooks.get("post_llm_call")
[shell_hook[post_llm_call:~/.hermes/agent-hooks/notify-complete.sh]]
```

`hermes hooks doctor` and `hermes hooks test post_llm_call` both pass. The hook script fires correctly on TUI agent responses after restart.