### PR TITLE
fix(agent): halt replayed completed tool calls

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -3892,6 +3892,44 @@ def run_conversation(
                 assistant_message.tool_calls = agent._deduplicate_tool_calls(
                     assistant_message.tool_calls
                 )
+                assistant_message.tool_calls, replayed_tool_calls = (
+                    agent._filter_completed_tool_call_replays(
+                        assistant_message.tool_calls,
+                        messages,
+                    )
+                )
+                if replayed_tool_calls:
+                    replayed_ids = [
+                        _ra().AIAgent._get_tool_call_id_static(tc)
+                        for tc in replayed_tool_calls
+                    ]
+                    logger.warning(
+                        "Skipping %d replayed completed tool call(s): %s",
+                        len(replayed_ids),
+                        ", ".join(cid for cid in replayed_ids if cid),
+                    )
+                    if not assistant_message.tool_calls and not agent._has_content_after_think_block(
+                        assistant_message.content or ""
+                    ):
+                        decision = agent._duplicate_tool_call_halt_decision(
+                            replayed_tool_calls
+                        )
+                        agent._set_tool_guardrail_halt(decision)
+                        _turn_exit_reason = "guardrail_halt"
+                        final_response = agent._toolguard_controlled_halt_response(decision)
+                        agent._emit_status(
+                            f"⚠️ Tool guardrail halted {decision.tool_name}: {decision.code}"
+                        )
+                        messages.append({"role": "assistant", "content": final_response})
+                        if final_response:
+                            agent._safe_print(f"\n{final_response}\n")
+                            if agent.stream_delta_callback:
+                                try:
+                                    agent.stream_delta_callback(final_response)
+                                    agent.stream_delta_callback(None)
+                                except Exception:
+                                    pass
+                        break
 
                 assistant_msg = agent._build_assistant_message(assistant_message, finish_reason)
                 

--- a/run_agent.py
+++ b/run_agent.py
@@ -3425,6 +3425,57 @@ class AIAgent:
                 logger.warning("Removed duplicate tool call: %s", tc.function.name)
         return unique if len(unique) < len(tool_calls) else tool_calls
 
+    @classmethod
+    def _completed_tool_call_ids(cls, messages: List[Dict[str, Any]]) -> set[str]:
+        """Return tool_call IDs that already have a recorded tool result."""
+        completed: set[str] = set()
+        for msg in messages:
+            if not isinstance(msg, dict) or msg.get("role") != "tool":
+                continue
+            cid = msg.get("tool_call_id")
+            if isinstance(cid, str) and cid:
+                completed.add(cid)
+        return completed
+
+    @classmethod
+    def _filter_completed_tool_call_replays(
+        cls,
+        tool_calls: list,
+        messages: List[Dict[str, Any]],
+    ) -> tuple[list, list]:
+        """Split tool calls into fresh calls and already-completed replays."""
+        completed_ids = cls._completed_tool_call_ids(messages)
+        if not completed_ids:
+            return tool_calls, []
+
+        fresh: list = []
+        replayed: list = []
+        for tc in tool_calls:
+            cid = cls._get_tool_call_id_static(tc)
+            if cid and cid in completed_ids:
+                replayed.append(tc)
+            else:
+                fresh.append(tc)
+        return fresh if replayed else tool_calls, replayed
+
+    @classmethod
+    def _duplicate_tool_call_halt_decision(cls, tool_calls: list) -> ToolGuardrailDecision:
+        """Build a controlled-halt decision for replayed completed tool calls."""
+        first = tool_calls[0] if tool_calls else None
+        tool_name = cls._get_tool_call_name_static(first) if first is not None else ""
+        count = len(tool_calls)
+        plural = "s" if count != 1 else ""
+        return ToolGuardrailDecision(
+            action="halt",
+            code="duplicate_completed_tool_call",
+            message=(
+                f"Provider repeated {count} completed tool_call_id{plural}. "
+                "Stop this turn instead of replaying an already-submitted result."
+            ),
+            tool_name=tool_name,
+            count=count,
+        )
+
     def _repair_tool_call(self, tool_name: str) -> str | None:
         """Forwarder — see ``agent.agent_runtime_helpers.repair_tool_call``."""
         from agent.agent_runtime_helpers import repair_tool_call
@@ -5091,6 +5142,12 @@ class AIAgent:
 
     def _toolguard_controlled_halt_response(self, decision: ToolGuardrailDecision) -> str:
         tool = decision.tool_name or "a tool"
+        if decision.code == "duplicate_completed_tool_call":
+            return (
+                f"I stopped because the provider re-issued a completed {tool} "
+                "tool_call_id. Hermes already submitted that result once, so "
+                "replaying it would duplicate side effects or loop the turn."
+            )
         return (
             f"I stopped retrying {tool} because it hit the tool-call guardrail "
             f"({decision.code}) after {decision.count} repeated non-progressing "

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -3456,6 +3456,32 @@ class TestRunConversation:
         assert mock_handle_function_call.call_args.kwargs["tool_call_id"] == "c1"
         assert mock_handle_function_call.call_args.kwargs["session_id"] == agent.session_id
 
+    def test_duplicate_completed_tool_call_id_halts_without_replaying_result(self, agent):
+        self._setup_agent(agent)
+        first = _mock_tool_call(name="web_search", arguments='{"query":"pwd"}', call_id="c1")
+        replay = _mock_tool_call(name="web_search", arguments='{"query":"pwd"}', call_id="c1")
+        resp1 = _mock_response(content="", finish_reason="tool_calls", tool_calls=[first])
+        resp2 = _mock_response(content="", finish_reason="tool_calls", tool_calls=[replay])
+        agent.client.chat.completions.create.side_effect = [resp1, resp2]
+
+        with (
+            patch("run_agent.handle_function_call", return_value='{"results": ["pwd"]}') as mock_handle_function_call,
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+        ):
+            result = agent.run_conversation("run pwd")
+
+        assert mock_handle_function_call.call_count == 1
+        assert result["turn_exit_reason"] == "guardrail_halt"
+        assert result["guardrail"]["code"] == "duplicate_completed_tool_call"
+        assert "re-issued a completed web_search tool_call_id" in result["final_response"]
+        tool_msgs = [
+            m for m in result["messages"]
+            if m.get("role") == "tool" and m.get("tool_call_id") == "c1"
+        ]
+        assert len(tool_msgs) == 1
+
     def test_request_scoped_api_hooks_fire_for_each_api_call(self, agent):
         self._setup_agent(agent)
         tc = _mock_tool_call(name="web_search", arguments="{}", call_id="c1")


### PR DESCRIPTION
## Summary
- stop executing provider-replayed tool calls whose `tool_call_id` already has a completed tool result in history
- halt the turn cleanly when a response only replays completed call IDs, instead of resubmitting duplicate tool results
- add a regression test covering repeated provider-issued tool_call_id across iterations

## Test plan
- `pytest tests/run_agent/test_run_agent.py::TestRunConversation::test_duplicate_completed_tool_call_id_halts_without_replaying_result tests/run_agent/test_tool_call_guardrail_runtime.py::test_config_enabled_hard_stop_run_conversation_returns_controlled_guardrail_halt_without_top_level_error tests/run_agent/test_run_agent.py::TestRunConversation::test_tool_calls_then_stop`
- `ruff check run_agent.py agent/conversation_loop.py tests/run_agent/test_run_agent.py`
- `git diff --check`

Fixes #48765