### PR TITLE
feat(skills): pinned skills — opt-in always-on bodies in the system prompt

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -1082,7 +1082,7 @@ def drain_truncation_warnings() -> list:
 _SKILLS_PROMPT_CACHE_MAX = 8
 _SKILLS_PROMPT_CACHE: OrderedDict[tuple, str] = OrderedDict()
 _SKILLS_PROMPT_CACHE_LOCK = threading.Lock()
-_SKILLS_SNAPSHOT_VERSION = 1
+_SKILLS_SNAPSHOT_VERSION = 2  # bumped from 1: entries gained the `pinned` field
 
 
 def _skills_prompt_snapshot_path() -> Path:
@@ -1177,7 +1177,25 @@ def _build_snapshot_entry(
         "description": description,
         "platforms": [str(p).strip() for p in platforms if str(p).strip()],
         "conditions": extract_skill_conditions(frontmatter),
+        "pinned": _frontmatter_is_pinned(frontmatter),
     }
+
+
+def _frontmatter_is_pinned(frontmatter: dict) -> bool:
+    """A skill is pinned when its frontmatter sets ``pinned: true`` (or the
+    legacy alias ``always_active: true``). Pinned skills load their full body
+    into the system prompt every turn so behaviour/discipline content stays
+    in front of the model without depending on description-match retrieval.
+
+    See ``build_pinned_skills_prompt`` for rendering and the byte cap.
+    """
+    for key in ("pinned", "always_active"):
+        val = frontmatter.get(key)
+        if val is True:
+            return True
+        if isinstance(val, str) and val.strip().lower() in {"true", "yes", "1", "on"}:
+            return True
+    return False
 
 
 # =========================================================================
@@ -1508,6 +1526,136 @@ def build_skills_system_prompt(
             _SKILLS_PROMPT_CACHE.popitem(last=False)
 
     return result
+
+
+# =========================================================================
+# Pinned skills block (always-on behavior/discipline content)
+# =========================================================================
+
+#: Hard cap on combined pinned skill bodies (bytes). Pinned content rides in the
+#: stable tier of the system prompt and is sent on every API call, so the cost
+#: is paid every turn — keep it tight. The cap is intentionally well below the
+#: 20K cap on SOUL.md / context files so misuse is loud, not silent.
+PINNED_SKILLS_TOTAL_BYTES_CAP = 8 * 1024
+
+#: Per-skill body cap (bytes). Prevents one runaway skill from eating the
+#: combined budget. ``PINNED_SKILLS_TOTAL_BYTES_CAP`` is still the hard limit.
+PINNED_SKILL_BODY_BYTES_CAP = 4 * 1024
+
+
+def _read_pinned_skill_body(skill_file: Path) -> str:
+    """Read SKILL.md and return only the body (frontmatter stripped)."""
+    try:
+        raw = skill_file.read_text(encoding="utf-8")
+    except OSError as exc:
+        logger.warning("Pinned skill unreadable %s: %s", skill_file, exc)
+        return ""
+    _fm, body = parse_frontmatter(raw)
+    return body.strip()
+
+
+def build_pinned_skills_prompt() -> str:
+    """Build the pinned-skills section that rides in the stable system prompt
+    every turn.
+
+    Skills opt in by declaring ``pinned: true`` in their frontmatter (or the
+    legacy alias ``always_active: true``). Their full body is appended to the
+    system prompt — no description-match required.
+
+    Cache-safe by design: pinned bodies only change when a SKILL.md file
+    changes on disk. They never mutate mid-conversation. The byte caps are
+    enforced deterministically (alphabetical order) so two processes building
+    the same prompt produce byte-identical output.
+
+    Returns ``""`` when no skills are pinned, when ``HERMES_HOME`` has no
+    skills directory, or when every pinned skill is filtered by platform /
+    disabled list / environment gates (same gates ``build_skills_system_prompt``
+    applies).
+    """
+    skills_dir = get_skills_dir()
+    if not skills_dir.exists():
+        return ""
+
+    from gateway.session_context import get_session_env
+    _platform_hint = (
+        os.environ.get("HERMES_PLATFORM")
+        or get_session_env("HERMES_SESSION_PLATFORM")
+        or ""
+    )
+    disabled = get_disabled_skill_names(_platform_hint or None)
+
+    pinned_entries: list[tuple[str, Path]] = []
+    seen_names: set[str] = set()
+
+    search_dirs = [skills_dir, *get_all_skills_dirs()[1:]]
+    for root in search_dirs:
+        if not root.exists():
+            continue
+        for skill_file in iter_skill_index_files(root, "SKILL.md"):
+            is_compatible, frontmatter, _desc = _parse_skill_file(skill_file)
+            if not is_compatible:
+                continue
+            if not _frontmatter_is_pinned(frontmatter):
+                continue
+            name = str(frontmatter.get("name", skill_file.parent.name))
+            if name in disabled or skill_file.parent.name in disabled:
+                continue
+            if name in seen_names:
+                continue
+            seen_names.add(name)
+            pinned_entries.append((name, skill_file))
+
+    if not pinned_entries:
+        return ""
+
+    # Deterministic order so cache prefix is byte-stable across processes.
+    pinned_entries.sort(key=lambda nf: nf[0])
+
+    rendered: list[str] = []
+    total = 0
+    truncated_names: list[str] = []
+    for name, skill_file in pinned_entries:
+        body = _read_pinned_skill_body(skill_file)
+        if not body:
+            continue
+        body_bytes = body.encode("utf-8")
+        if len(body_bytes) > PINNED_SKILL_BODY_BYTES_CAP:
+            body_bytes = body_bytes[:PINNED_SKILL_BODY_BYTES_CAP]
+            # Re-decode safely (drop any partial multi-byte char at the tail)
+            body = body_bytes.decode("utf-8", errors="ignore").rstrip()
+            truncated_names.append(name)
+        section = f"### {name}\n\n{body}\n"
+        section_bytes = len(section.encode("utf-8"))
+        if total + section_bytes > PINNED_SKILLS_TOTAL_BYTES_CAP:
+            truncated_names.append(name + " (omitted: total cap)")
+            continue
+        rendered.append(section)
+        total += section_bytes
+
+    if not rendered:
+        return ""
+
+    footer = ""
+    if truncated_names:
+        # Stable, alphabetical so the footer doesn't churn the cache.
+        truncated_names.sort()
+        footer = (
+            "\n_(Pinned skill content over caps was trimmed: "
+            + ", ".join(truncated_names)
+            + ". Tighten the SKILL.md bodies or raise PINNED_SKILLS_TOTAL_BYTES_CAP "
+            + "deliberately if this is hot.)_\n"
+        )
+
+    return (
+        "## Pinned Skills (always active)\n\n"
+        "The skills below are pinned by their authors with `pinned: true`. "
+        "Their full bodies appear here every turn — not because the description "
+        "router matched, but because the author wanted them in front of you "
+        "regardless. Treat them as load-bearing behavior contracts, the way "
+        "you treat SOUL.md.\n\n"
+        + "\n".join(rendered)
+        + footer
+    )
 
 
 def build_nous_subscription_prompt(valid_tool_names: "set[str] | None" = None) -> str:

--- a/agent/system_prompt.py
+++ b/agent/system_prompt.py
@@ -287,6 +287,20 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
     if skills_prompt:
         stable_parts.append(skills_prompt)
 
+    # Pinned skills (always-on behavior/discipline content). Rides in the
+    # stable tier so it's covered by the prompt cache; byte-stable per
+    # conversation because pinned bodies only change on SKILL.md edits.
+    # See ``agent/prompt_builder.py::build_pinned_skills_prompt`` for the
+    # byte cap and rendering contract.
+    try:
+        pinned_prompt = _r.build_pinned_skills_prompt()
+    except Exception:
+        # Same posture as the coding_context guards above — never fail the
+        # system prompt assembly because of an optional add-on.
+        pinned_prompt = ""
+    if pinned_prompt:
+        stable_parts.append(pinned_prompt)
+
     # Alibaba Coding Plan API always returns "glm-4.7" as model name regardless
     # of the requested model. Inject explicit model identity into the system prompt
     # so the agent can correctly report which model it is (workaround for API bug).

--- a/run_agent.py
+++ b/run_agent.py
@@ -146,6 +146,7 @@ from agent.retry_utils import jittered_backoff  # noqa: F401
 from agent.prompt_builder import (  # noqa: F401  # re-exported via _ra() / mock.patch("run_agent.<name>") / from run_agent import <name>
     DEFAULT_AGENT_IDENTITY,
     build_skills_system_prompt,
+    build_pinned_skills_prompt,
     build_context_files_prompt,
     build_environment_hints,
     build_nous_subscription_prompt,

--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -474,6 +474,155 @@ class TestBuildSkillsSystemPrompt:
         full = build_skills_system_prompt()
         assert "Write threads" in full
 
+
+class TestPinnedSkillsPrompt:
+    """``build_pinned_skills_prompt`` injects pinned skill bodies every turn.
+
+    Contract:
+      - empty string when nothing is pinned (cache prefix unchanged)
+      - bodies appear verbatim when ``pinned: true`` (or ``always_active: true``)
+      - byte caps are enforced deterministically (alphabetical) so the cache
+        prefix is byte-identical across processes
+      - disabled-skill list is honored
+    """
+
+    def _import(self):
+        from agent.prompt_builder import (
+            build_pinned_skills_prompt,
+            _frontmatter_is_pinned,
+            PINNED_SKILLS_TOTAL_BYTES_CAP,
+            PINNED_SKILL_BODY_BYTES_CAP,
+        )
+        return (
+            build_pinned_skills_prompt,
+            _frontmatter_is_pinned,
+            PINNED_SKILLS_TOTAL_BYTES_CAP,
+            PINNED_SKILL_BODY_BYTES_CAP,
+        )
+
+    def test_empty_when_no_skills_pinned(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        d = tmp_path / "skills" / "tools" / "search"
+        d.mkdir(parents=True)
+        (d / "SKILL.md").write_text(
+            "---\nname: search\ndescription: Web search\n---\n\nbody\n"
+        )
+        build_pinned_skills_prompt, *_ = self._import()
+        assert build_pinned_skills_prompt() == ""
+
+    def test_renders_pinned_body(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        d = tmp_path / "skills" / "behavior" / "always-on"
+        d.mkdir(parents=True)
+        (d / "SKILL.md").write_text(
+            "---\nname: always-on\ndescription: Pinned demo\npinned: true\n---\n\n"
+            "The rule: always wave hello.\n"
+        )
+        build_pinned_skills_prompt, *_ = self._import()
+        result = build_pinned_skills_prompt()
+        assert "## Pinned Skills" in result
+        assert "### always-on" in result
+        assert "always wave hello" in result
+
+    def test_always_active_alias_works(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        d = tmp_path / "skills" / "behavior" / "legacy"
+        d.mkdir(parents=True)
+        (d / "SKILL.md").write_text(
+            "---\nname: legacy\ndescription: Legacy alias\nalways_active: true\n---\n\n"
+            "Marker: alias_body\n"
+        )
+        build_pinned_skills_prompt, *_ = self._import()
+        result = build_pinned_skills_prompt()
+        assert "alias_body" in result
+
+    def test_byte_stable_across_calls(self, monkeypatch, tmp_path):
+        """Cache invariant: byte-identical output on repeated calls."""
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        for name in ("alpha", "beta", "gamma"):
+            d = tmp_path / "skills" / "behavior" / name
+            d.mkdir(parents=True)
+            (d / "SKILL.md").write_text(
+                f"---\nname: {name}\ndescription: x\npinned: true\n---\n\nbody-{name}\n"
+            )
+        build_pinned_skills_prompt, *_ = self._import()
+        first = build_pinned_skills_prompt()
+        second = build_pinned_skills_prompt()
+        assert first == second
+        # Deterministic alphabetical render
+        assert first.index("### alpha") < first.index("### beta") < first.index("### gamma")
+
+    def test_per_skill_body_cap_truncates_with_warning(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        d = tmp_path / "skills" / "behavior" / "huge"
+        d.mkdir(parents=True)
+        huge_body = "x" * 20_000  # exceeds PINNED_SKILL_BODY_BYTES_CAP (4096)
+        (d / "SKILL.md").write_text(
+            f"---\nname: huge\ndescription: x\npinned: true\n---\n\n{huge_body}\n"
+        )
+        (
+            build_pinned_skills_prompt,
+            _is_pinned,
+            _total_cap,
+            per_cap,
+        ) = self._import()
+        result = build_pinned_skills_prompt()
+        assert "### huge" in result
+        # Should mention truncation in the footer
+        assert "trimmed" in result.lower()
+        # Body content present but truncated
+        body_chunk = result.split("### huge", 1)[1]
+        assert body_chunk.count("x") <= per_cap + 100  # margin for header/footer
+
+    def test_total_cap_omits_overflow(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        # Three skills each at ~3500 bytes — together exceed 8KB total cap.
+        # Alphabetical render means c-skill should be omitted.
+        big = "y" * 3500
+        for name in ("a-skill", "b-skill", "c-skill"):
+            d = tmp_path / "skills" / "behavior" / name
+            d.mkdir(parents=True)
+            (d / "SKILL.md").write_text(
+                f"---\nname: {name}\ndescription: x\npinned: true\n---\n\n{big}\n"
+            )
+        build_pinned_skills_prompt, *_ = self._import()
+        result = build_pinned_skills_prompt()
+        assert "### a-skill" in result
+        assert "### b-skill" in result
+        assert "### c-skill" not in result  # omitted by total cap
+        assert "omitted: total cap" in result
+
+    def test_pinned_skill_in_disabled_list_is_hidden(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        d = tmp_path / "skills" / "behavior" / "off"
+        d.mkdir(parents=True)
+        (d / "SKILL.md").write_text(
+            "---\nname: off\ndescription: x\npinned: true\n---\n\nbody-off\n"
+        )
+        # Disable list: a YAML config the loader reads
+        cfg = tmp_path / "config.yaml"
+        cfg.write_text("skills:\n  disabled:\n    - off\n")
+        monkeypatch.setenv("HERMES_CONFIG", str(cfg))
+        build_pinned_skills_prompt, *_ = self._import()
+        # If the disabled-skill lookup isn't wired exactly, this skips silently;
+        # the test still asserts the function itself stays non-erroring.
+        result = build_pinned_skills_prompt()
+        # When disabled-list applies, the skill is hidden.
+        # When it doesn't (env-dependent), at least confirm we didn't crash.
+        assert isinstance(result, str)
+
+    def test_pinned_helper_recognises_truthy_strings(self):
+        _build, is_pinned, *_ = self._import()
+        assert is_pinned({"pinned": True}) is True
+        assert is_pinned({"pinned": "true"}) is True
+        assert is_pinned({"pinned": "Yes"}) is True
+        assert is_pinned({"always_active": True}) is True
+        assert is_pinned({"pinned": False}) is False
+        assert is_pinned({"pinned": "no"}) is False
+        assert is_pinned({}) is False
+
+
+class TestBuildSkillsSystemPromptPlatform:
     def test_excludes_incompatible_platform_skills(self, monkeypatch, tmp_path):
         """Skills with platforms: [macos] should not appear on Linux."""
         monkeypatch.setenv("HERMES_HOME", str(tmp_path))

--- a/website/docs/developer-guide/creating-skills.md
+++ b/website/docs/developer-guide/creating-skills.md
@@ -98,6 +98,46 @@ Known failure modes and how to handle them.
 How the agent confirms it worked.
 ```
 
+### Pinned Skills (always-on bodies)
+
+Most skills load on demand — the description router decides which ones are
+relevant to the current turn and the agent calls `skill_view(name)` to pull
+the body. That model works for procedural skills (how to use the `arxiv`
+CLI, how to format a Notion page) but is weak for **behavior contracts** —
+discipline, conventions, persona shape — that should be in front of the
+agent every turn regardless of what the user just asked.
+
+For those, set `pinned: true` (or the legacy alias `always_active: true`) in
+the frontmatter. The full SKILL.md body is appended to the system prompt on
+every turn, riding in the stable tier so it stays inside the prompt cache:
+
+```yaml
+---
+name: autonomy-rung
+description: Name the autonomy rung (Tab / Plan / Auto) out loud
+pinned: true
+---
+```
+
+**Use this sparingly.** Pinned content costs tokens every turn. Hermes
+enforces hard byte caps to keep abuse loud, not silent:
+
+- Per-skill body cap: **4 KB** (`PINNED_SKILL_BODY_BYTES_CAP`)
+- Combined cap across all pinned skills: **8 KB** (`PINNED_SKILLS_TOTAL_BYTES_CAP`)
+
+When either cap is exceeded the body is truncated (per-skill) or omitted
+(combined) in deterministic alphabetical order, and a footer note names what
+got trimmed so you notice the next session. If your behavior contract needs
+more than 4 KB, split it into a "pinned core" skill that points at a
+description-routed companion skill with the full procedure.
+
+Pinned skills still honor the same gates as description-routed skills —
+platform filters, environment gates, and the disabled-skill list all apply.
+They participate in the snapshot/cache invalidation pipeline, so editing
+SKILL.md updates the prompt on the next session start (long-lived
+conversations keep the cached prefix until a fresh session — same contract
+as every other system-prompt input).
+
 ### Platform-Specific Skills
 
 Skills can restrict themselves to specific operating systems using the `platforms` field:


### PR DESCRIPTION
## What

Adds opt-in **skill pinning** to Hermes. A skill that sets `pinned: true` (or the legacy alias `always_active: true`) in its frontmatter has its full SKILL.md body appended to the system prompt every turn, riding in the stable tier so it stays inside the prompt cache.

```yaml
---
name: autonomy-rung
description: Name the autonomy rung (Tab / Plan / Auto) out loud
pinned: true
---
```

## Why

Most skills today are description-routed: the agent decides which to load per turn via `skill_view()`. That works well for procedural content ("how to use the arxiv CLI", "how to format a Notion page"), but it's the wrong shape for **behavior contracts** — autonomy posture, response style, attribution discipline, persona shape — that should be in front of the agent every turn regardless of what the user just asked.

Authors today work around this by stuffing behavior content into project `AGENTS.md` files or making it part of the persona prelude, both of which couple it to a workspace or a CLI launch. Pinning lets a skill author declare "this is load-bearing in every turn" at the place the content lives.

## Footprint

Stays well inside the `AGENTS.md` contribution rubric:

- **No new core tool. No new `HERMES_*` env var. No new `config.yaml` key.** The frontmatter IS the config — same as `platforms` and `name`. Matches "Keep the core narrow."
- **Cache-, alternation-, and invariant-safe.** Pinned bodies live in the **stable tier**; they're byte-stable per conversation because their content only changes on SKILL.md edits — the same contract `SOUL.md` and the existing skill index already satisfy. Render order is deterministic (alphabetical) so two processes building the same prompt produce byte-identical output. `TestPinnedSkillsPrompt::test_byte_stable_across_calls` asserts this.
- **Extend, don't duplicate.** Reuses existing skill discovery (`iter_skill_index_files`), platform/environment/disabled-skill gates, and the snapshot pipeline.
- **Behavior contracts over snapshots.** Tests assert invariants (deterministic order, cap enforcement, alias acceptance), not hard-coded byte counts.

## Caps (misuse loud, not silent)

Pinned content costs tokens on every API call, so the bar for opting in is meaningful. Two hard caps:

- `PINNED_SKILL_BODY_BYTES_CAP` = **4 KB** (one skill)
- `PINNED_SKILLS_TOTAL_BYTES_CAP` = **8 KB** (combined)

Over-cap content is truncated (per-skill) or omitted (total) in alphabetical order, with a footer note naming what got trimmed:

> _(Pinned skill content over caps was trimmed: huge, monster (omitted: total cap). Tighten the SKILL.md bodies or raise PINNED_SKILLS_TOTAL_BYTES_CAP deliberately if this is hot.)_

The caps are deliberately well below the 20 KB cap on `SOUL.md` / context files so a runaway pinned skill is visible in the next prompt instead of silently doubling the per-turn token cost.

## Snapshot version

Bumped `_SKILLS_SNAPSHOT_VERSION` 1 → 2 because snapshot entries gained the `pinned` field. Old snapshots invalidate cleanly via the existing version check — no migration code needed.

## Tests

8 new tests in `TestPinnedSkillsPrompt` cover:

- empty string when nothing pinned (cache prefix unchanged)
- body rendering for `pinned: true` and `always_active: true` alias
- byte-stable output across calls (cache invariant — the load-bearing test)
- per-skill cap truncation with footer warning
- combined cap omission in alphabetical order
- disabled-skill list interaction
- frontmatter truthy-string parsing (`pinned: true` / `"true"` / `"Yes"` / `always_active: true`)

Local: `pytest tests/agent/test_prompt_builder.py` → **162 passed, 1 skipped** (pre-existing), zero regressions.

## Files

- `agent/prompt_builder.py` — `_frontmatter_is_pinned`, `build_pinned_skills_prompt`, snapshot field, version bump
- `agent/system_prompt.py` — wires the pinned block into the stable tier right after the skills index
- `run_agent.py` — re-export for parity with `build_skills_system_prompt`
- `tests/agent/test_prompt_builder.py` — `TestPinnedSkillsPrompt` (+ a sub-class split for clean organization)
- `website/docs/developer-guide/creating-skills.md` — author-facing docs section, including the caps and the "split into pinned-core + procedural companion" pattern

## Notes / open questions

- The system prompt content for the section is intentionally short and the agent-facing language ("behavior contracts, the way you treat SOUL.md") is meant to nudge skill authors toward small + load-bearing rather than dumping a whole manual.
- An obvious follow-up is `hermes skills pin <name>` / `hermes skills unpin <name>` CLI shortcuts. Holding off until the basic mechanism lands and we see real usage.