### PR TITLE
fix(runtime-provider): guard HERMES_NOUS_TIMEOUT_SECONDS against malformed env var

### DIFF
--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -32,7 +32,7 @@ from hermes_cli.auth import (
 )
 from hermes_cli.config import get_compatible_custom_providers, load_config
 from hermes_constants import OPENROUTER_BASE_URL
-from utils import base_url_host_matches, base_url_hostname, env_int
+from utils import base_url_host_matches, base_url_hostname, env_float, env_int
 
 
 def _normalize_custom_provider_name(value: str) -> str:
@@ -1297,7 +1297,7 @@ def _resolve_explicit_runtime(
         expires_at = state.get("agent_key_expires_at") or state.get("expires_at")
         if not api_key:
             creds = resolve_nous_runtime_credentials(
-                timeout_seconds=float(os.getenv("HERMES_NOUS_TIMEOUT_SECONDS", "15")),
+                timeout_seconds=env_float("HERMES_NOUS_TIMEOUT_SECONDS", 15.0),
             )
             api_key = creds.get("api_key", "")
             expires_at = creds.get("expires_at")
@@ -1511,7 +1511,7 @@ def resolve_runtime_provider(
     if provider == "nous":
         try:
             creds = resolve_nous_runtime_credentials(
-                timeout_seconds=float(os.getenv("HERMES_NOUS_TIMEOUT_SECONDS", "15")),
+                timeout_seconds=env_float("HERMES_NOUS_TIMEOUT_SECONDS", 15.0),
             )
             return {
                 "provider": "nous",

--- a/utils.py
+++ b/utils.py
@@ -323,6 +323,17 @@ def env_int(key: str, default: int = 0) -> int:
         return default
 
 
+def env_float(key: str, default: float = 0.0) -> float:
+    """Read an environment variable as a float, with fallback."""
+    raw = os.getenv(key, "").strip()
+    if not raw:
+        return default
+    try:
+        return float(raw)
+    except (ValueError, TypeError):
+        return default
+
+
 def env_bool(key: str, default: bool = False) -> bool:
     """Read an environment variable as a boolean."""
     return is_truthy_value(os.getenv(key, ""), default=default)


### PR DESCRIPTION
## Summary

Replace bare float(os.getenv) with env_float for HERMES_NOUS_TIMEOUT_SECONDS at 2 call sites in hermes_cli/runtime_provider.py (lines 1300, 1514). A malformed value causes ValueError crash during runtime credential resolution.

## Changes
- hermes_cli/runtime_provider.py: Add env_float to existing utils import, replace 2 bare float(os.getenv) calls

## Test Plan
- [x] Lint clean

## Context
Part of systemic env var guard issue. Related: PR #48735, #48740, #48745, #48748, #48757, #48771, #48773.