### PR TITLE
fix(aux-client): guard HERMES_NOUS_TIMEOUT_SECONDS against malformed env var

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -102,7 +102,7 @@ OpenAI = _OpenAIProxy()  # module-level name, resolves lazily on call/isinstance
 from agent.credential_pool import load_pool
 from hermes_cli.config import get_hermes_home
 from hermes_constants import OPENROUTER_BASE_URL
-from utils import base_url_host_matches, base_url_hostname, model_forces_max_completion_tokens, normalize_proxy_env_vars
+from utils import base_url_host_matches, base_url_hostname, env_float, model_forces_max_completion_tokens, normalize_proxy_env_vars
 
 logger = logging.getLogger(__name__)
 
@@ -1312,7 +1312,7 @@ def _resolve_nous_runtime_api(*, force_refresh: bool = False) -> Optional[tuple[
         from hermes_cli.auth import resolve_nous_runtime_credentials
 
         creds = resolve_nous_runtime_credentials(
-            timeout_seconds=float(os.getenv("HERMES_NOUS_TIMEOUT_SECONDS", "15")),
+            timeout_seconds=env_float("HERMES_NOUS_TIMEOUT_SECONDS", 15.0),
             force_refresh=force_refresh,
         )
     except Exception as exc:
@@ -2905,7 +2905,7 @@ def _refresh_provider_credentials(provider: str) -> bool:
             from hermes_cli.auth import resolve_nous_runtime_credentials
 
             creds = resolve_nous_runtime_credentials(
-                timeout_seconds=float(os.getenv("HERMES_NOUS_TIMEOUT_SECONDS", "15")),
+                timeout_seconds=env_float("HERMES_NOUS_TIMEOUT_SECONDS", 15.0),
                 force_refresh=True,
             )
             if not str(creds.get("api_key", "") or "").strip():

--- a/utils.py
+++ b/utils.py
@@ -323,6 +323,17 @@ def env_int(key: str, default: int = 0) -> int:
         return default
 
 
+def env_float(key: str, default: float = 0.0) -> float:
+    """Read an environment variable as a float, with fallback."""
+    raw = os.getenv(key, "").strip()
+    if not raw:
+        return default
+    try:
+        return float(raw)
+    except (ValueError, TypeError):
+        return default
+
+
 def env_bool(key: str, default: bool = False) -> bool:
     """Read an environment variable as a boolean."""
     return is_truthy_value(os.getenv(key, ""), default=default)


### PR DESCRIPTION
## Summary

Replace bare float(os.getenv) with env_float for HERMES_NOUS_TIMEOUT_SECONDS at 2 call sites in agent/auxiliary_client.py (lines 1315, 2908). A malformed value causes ValueError crash during auxiliary client credential resolution.

## Changes
- agent/auxiliary_client.py: Add env_float to existing utils import, replace 2 bare float(os.getenv) calls

## Test Plan
- [x] Lint clean

## Context
Part of systemic env var guard issue. Related: PR #48735, #48740, #48745, #48748, #48757, #48771, #48773, #48776.