### PR TITLE
fix(weixin): replace 5 bare asserts with proper error handling

### DIFF
--- a/gateway/platforms/weixin.py
+++ b/gateway/platforms/weixin.py
@@ -1334,7 +1334,8 @@ class WeixinAdapter(BasePlatformAdapter):
         logger.info("[%s] Disconnected", self.name)
 
     async def _poll_loop(self) -> None:
-        assert self._poll_session is not None
+        if self._poll_session is None:
+            raise RuntimeError("_poll_loop called before _poll_session is initialized")
         sync_buf = _load_sync_buf(self._hermes_home, self._account_id)
         timeout_ms = LONG_POLL_TIMEOUT_MS
         consecutive_failures = 0
@@ -1400,7 +1401,8 @@ class WeixinAdapter(BasePlatformAdapter):
             logger.error("[%s] unhandled inbound error from=%s: %s", self.name, _safe_id(message.get("from_user_id")), exc, exc_info=True)
 
     async def _process_message(self, message: Dict[str, Any]) -> None:
-        assert self._poll_session is not None
+        if self._poll_session is None:
+            raise RuntimeError("_process_message called before _poll_session is initialized")
         sender_id = str(message.get("from_user_id") or "").strip()
         if not sender_id:
             return
@@ -1812,7 +1814,8 @@ class WeixinAdapter(BasePlatformAdapter):
                 )
                 if wait > 0:
                     await asyncio.sleep(wait)
-        assert last_error is not None
+        if last_error is None:
+            raise RuntimeError("_send_chunk_with_retry exited without error — this should not happen")
         raise last_error
 
     async def send(
@@ -2067,7 +2070,8 @@ class WeixinAdapter(BasePlatformAdapter):
         if not is_safe_url(url):
             raise ValueError(f"Blocked unsafe URL (SSRF protection): {url}")
 
-        assert self._send_session is not None
+        if self._send_session is None:
+            raise RuntimeError("_download_remote_media called before _send_session is initialized")
         # Use asyncio.wait_for() instead of aiohttp ClientTimeout to avoid
         # "Timeout context manager should be used inside a task" errors.
         async def _do_fetch():
@@ -2087,7 +2091,8 @@ class WeixinAdapter(BasePlatformAdapter):
         caption: str,
         force_file_attachment: bool = False,
     ) -> str:
-        assert self._send_session is not None and self._token is not None
+        if self._send_session is None or self._token is None:
+            raise RuntimeError("_send_file called before _send_session or _token is initialized")
         plaintext = Path(path).read_bytes()
         media_type, item_builder = self._outbound_media_builder(path, force_file_attachment=force_file_attachment)
         filekey = secrets.token_hex(16)


### PR DESCRIPTION
## Summary

Replace 5 bare assert statements in gateway/platforms/weixin.py with explicit if/raise RuntimeError guards.

assert statements are stripped when Python runs with -O flag, silently removing safety checks. These asserts guard critical session state (_poll_session, _send_session, _token) used in async network operations.

## Changes
- Lines 1337, 1403, 2070, 2090: Replace assert X is not None with if X is None: raise RuntimeError(msg)
- Line 1815: Replace assert last_error is not None with explicit check

## Test Plan
- [x] Lint clean

## Context
First PR targeting assert-in-production pattern. Other files with similar asserts: tools/browser_cdp_tool.py, tools/environments/docker.py, tools/browser_supervisor.py, agent/transports/codex_app_server_session.py.