### PR TITLE
fix(agent): summarize structured provider error messages instead of crashing

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -1841,6 +1841,35 @@ class AIAgent:
         return f"{detail}{hint}"
 
     @staticmethod
+    def _coerce_api_error_detail(value: Any) -> str:
+        """Return a display-safe string for structured provider error fields."""
+        if isinstance(value, str):
+            return value
+        if isinstance(value, dict):
+            for key in ("message", "detail", "error", "code", "type"):
+                nested = value.get(key)
+                if isinstance(nested, str) and nested.strip():
+                    return nested
+            for key in ("message", "detail", "error", "code", "type"):
+                if key in value:
+                    nested_detail = AIAgent._coerce_api_error_detail(value[key])
+                    if nested_detail:
+                        return nested_detail
+            try:
+                return json.dumps(value, ensure_ascii=False, sort_keys=True)
+            except TypeError:
+                return str(value)
+        if isinstance(value, (list, tuple)):
+            parts = [
+                AIAgent._coerce_api_error_detail(item)
+                for item in value
+            ]
+            return "; ".join(part for part in parts if part)
+        if value is None:
+            return ""
+        return str(value)
+
+    @staticmethod
     def _summarize_api_error(error: Exception) -> str:
         """Extract a human-readable one-liner from an API error.
 
@@ -1879,6 +1908,7 @@ class AIAgent:
             if msg:
                 status_code = getattr(error, "status_code", None)
                 prefix = f"HTTP {status_code}: " if status_code else ""
+                msg = AIAgent._coerce_api_error_detail(msg)
                 return AIAgent._decorate_xai_entitlement_error(f"{prefix}{msg[:300]}")
 
         # Fallback: truncate the raw string but give more room than 200 chars

--- a/tests/run_agent/test_codex_xai_oauth_recovery.py
+++ b/tests/run_agent/test_codex_xai_oauth_recovery.py
@@ -252,6 +252,35 @@ def test_summarize_api_error_decorates_xai_body_message():
     assert "X Premium+ does NOT include" in summary
 
 
+def test_summarize_api_error_handles_nested_provider_message():
+    """HF router may put a structured object in error.message."""
+    from run_agent import AIAgent
+
+    class _NestedProviderErr(Exception):
+        status_code = 400
+        body = {
+            "error": {
+                "message": {
+                    "type": "Bad Request",
+                    "code": "context_length_exceeded",
+                    "message": (
+                        "This model's maximum context length is 262144 tokens. "
+                        "Please reduce the length of the messages."
+                    ),
+                    "param": None,
+                },
+                "type": "invalid_request_error",
+                "param": None,
+                "code": None,
+            }
+        }
+
+    summary = AIAgent._summarize_api_error(_NestedProviderErr("400"))
+    assert "HTTP 400" in summary
+    assert "maximum context length is 262144 tokens" in summary
+    assert "context_length_exceeded" not in summary
+
+
 def test_summarize_api_error_idempotent_for_entitlement_hint():
     """Decorating twice must not double up the hint."""
     from run_agent import AIAgent


### PR DESCRIPTION
## Summary
The gateway turn dispatcher no longer crashes when a provider returns a structured (non-string) `error.message`. The HuggingFace router returns `error.message` as a nested object on context-length errors, and `_summarize_api_error()` sliced it with `msg[:300]` — `KeyError: slice(None, 300, None)` — killing the turn instead of reporting the error.

## Changes
- `run_agent.py`: add `_coerce_api_error_detail()` and call it before truncating SDK/body error messages. Nested provider error objects are flattened to the inner message text (or JSON) before display.
- `tests/run_agent/test_codex_xai_oauth_recovery.py`: regression test for the HF-router nested `error.message` shape.

## Validation
| Input shape | Before | After |
|---|---|---|
| `error.message` = dict (HF router) | `KeyError: slice(...)` crash | `HTTP 400: This model's maximum context length is 262144 tokens...` |
| `error.message` = string | works | works (unchanged) |
| dict without nested `message` | crash | degrades to first string field / JSON |

E2E-reproduced the crash on current `main`, confirmed the fix surfaces the provider error, and confirmed `classify_api_error` (the other consumer of this shape) does not crash — it already string-coerces for pattern matching and still classifies `context_overflow`. 45/45 tests pass via `scripts/run_tests.sh`.

Salvage of #48697 — @helix4u's commit cherry-picked with authorship preserved.
Discord support thread: https://discord.com/channels/1053877538025386074/1517295409402220686

## Infographic

![crash-proof-error-reporting](https://v3b.fal.media/files/b/0a9edeac/4To-vEMaKaTIWNSDE7tBn_thUOUfsB.png)
