### PR TITLE
fix(core): normalize paths in cross-profile guard

### DIFF
--- a/agent/file_safety.py
+++ b/agent/file_safety.py
@@ -2,9 +2,12 @@
 
 from __future__ import annotations
 
+import logging
 import os
 from pathlib import Path
 from typing import Optional
+
+logger = logging.getLogger(__name__)
 
 
 def _hermes_home_path() -> Path:
@@ -395,9 +398,52 @@ def classify_cross_profile_target(path: str) -> Optional[dict]:
         return None
 
     active_profile = _resolve_active_profile_name()
+
+    # ── Path normalization: resolve symlinks on both sides ──────────────
+    # The profile-name comparison below can false-positive when path
+    # resolution disagrees with the profile-name inference (symlinks,
+    # relative paths, HERMES_HOME vs active_profile file mismatch).
+    # Before comparing names, check if the resolved target actually
+    # lives under the active profile's resolved home directory.
+    # NOTE: only applies when active_profile is a named profile —
+    # when it's "default", home_real IS the root which contains all
+    # profiles, so ancestry alone is insufficient to distinguish.
+    try:
+        home_real = _hermes_home_path().resolve()
+    except (OSError, RuntimeError):
+        home_real = None
+
+    if (
+        active_profile != "default"
+        and home_real is not None
+    ):
+        try:
+            target.relative_to(home_real)
+            # Target resolves inside the active named profile's home dir
+            # — definitively in-profile regardless of name inference.
+            logger.debug(
+                "In-profile write (path check): active_profile=%r "
+                "home_real=%s target=%s",
+                active_profile, home_real, target,
+            )
+            return None
+        except ValueError:
+            pass
+
     if target_profile == active_profile:
         # In-profile write — not a cross-profile event.
+        logger.debug(
+            "In-profile write (name match): active_profile=%r "
+            "target_profile=%r home_real=%s target=%s",
+            active_profile, target_profile, home_real, target,
+        )
         return None
+
+    logger.debug(
+        "Cross-profile write guard: active_profile=%r "
+        "target_profile=%r area=%r home_real=%s target=%s",
+        active_profile, target_profile, area, home_real, target,
+    )
 
     return {
         "active_profile": active_profile,

--- a/tests/agent/test_file_safety_cross_profile.py
+++ b/tests/agent/test_file_safety_cross_profile.py
@@ -180,6 +180,90 @@ class TestClassifyCrossProfileTarget:
 
 
 # ---------------------------------------------------------------------------
+# Early-return regression tests (PR #48784)
+# ---------------------------------------------------------------------------
+# The fix in d7e30dcd2 added a path-normalization early return before the
+# name comparison. When active_profile is a named profile and the resolved
+# target path lives under the active profile's home directory, the guard
+# returns None immediately — even if the name inference would have matched
+# a different profile. These tests verify the early return is correct and
+# does not accidentally suppress genuine cross-profile warnings.
+# ---------------------------------------------------------------------------
+
+
+class TestCrossProfileGuardEarlyReturn:
+    """Regression: the path-normalization early return must not suppress
+    genuine cross-profile warnings, and must correctly identify in-profile
+    writes when paths resolve through symlinks or relative prefixes."""
+
+    def test_same_profile_path_returns_none_through_early_return(
+        self, fake_hermes, monkeypatch
+    ):
+        """When active_profile is a named profile and the target path
+        resolves inside the active profile's home, the early return fires
+        and returns None — even when the path doesn't go through the
+        name-comparison path."""
+        import agent.file_safety as fs
+
+        _set_active_home(monkeypatch, fake_hermes["security_home"])
+        # Target inside the active profile's own home directory
+        result = fs.classify_cross_profile_target(
+            str(fake_hermes["security_home"] / "skills" / "foo" / "SKILL.md")
+        )
+        assert result is None
+
+    def test_other_profile_target_is_still_blocked(
+        self, fake_hermes, monkeypatch
+    ):
+        """A genuine path into another profile's scoped area must still
+        be flagged — the early return must not be too broad."""
+        _set_active_home(monkeypatch, fake_hermes["security_home"])
+        from agent.file_safety import classify_cross_profile_target
+
+        result = classify_cross_profile_target(
+            str(fake_hermes["coder_home"] / "skills" / "foo" / "SKILL.md")
+        )
+        assert result is not None
+        assert result["target_profile"] == "coder"
+
+    def test_symlink_to_other_profile_does_not_early_return(
+        self, fake_hermes, monkeypatch, tmp_path
+    ):
+        """A symlink pointing to a different profile's area must still
+        be flagged — the early return uses the resolved path and must
+        detect that the resolved path is not inside the active profile."""
+        import agent.file_safety as fs
+
+        _set_active_home(monkeypatch, fake_hermes["security_home"])
+
+        # Symlink from tmp_path to the coder profile's skills
+        symlink = tmp_path / "link-to-coder-skills"
+        symlink.symlink_to(fake_hermes["coder_home"] / "skills")
+
+        result = fs.classify_cross_profile_target(
+            str(symlink / "some-skill.md")
+        )
+        assert result is not None
+        assert result["target_profile"] == "coder"
+
+    def test_default_profile_skips_early_return_when_writing_named_profile(
+        self, fake_hermes, monkeypatch
+    ):
+        """When active_profile is 'default', the early return is skipped
+        (active_profile != 'default' is False), so the name comparison
+        must still detect cross-profile writes correctly."""
+        _set_active_home(monkeypatch, fake_hermes["default_home"])
+        from agent.file_safety import classify_cross_profile_target
+
+        result = classify_cross_profile_target(
+            str(fake_hermes["security_home"] / "skills" / "foo" / "SKILL.md")
+        )
+        assert result is not None
+        assert result["active_profile"] == "default"
+        assert result["target_profile"] == "hermes-security"
+
+
+# ---------------------------------------------------------------------------
 # get_cross_profile_warning
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Fixes false positives where the cross-profile guard blocks writes to the current profile due to symlink/resolution mismatches. Adds debug logging.