### PR TITLE
feat(tts): expose speaker_id on built-in Piper provider

### DIFF
--- a/tests/tools/test_tts_piper.py
+++ b/tests/tools/test_tts_piper.py
@@ -8,6 +8,7 @@ without requiring the ``piper-tts`` package to actually be installed
 
 import json
 import sys
+import types
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -219,7 +220,7 @@ class TestGeneratePiperTts:
 
         # The SynthesisConfig import happens inline inside _generate_piper_tts
         # via ``from piper import SynthesisConfig``. Inject a fake piper
-        # module so that import resolves.
+        # module so that that import resolves.
         monkeypatch.setitem(sys.modules, "piper", FakePiperModule)
 
         config = {
@@ -238,6 +239,96 @@ class TestGeneratePiperTts:
         kwargs = fake_syn_cls.call_args.kwargs
         assert kwargs["length_scale"] == 2.0
         assert kwargs["volume"] == 0.8
+
+    def test_speaker_id_passed_through_to_synconfig(self, tmp_path, monkeypatch):
+        """speaker_id flows from config to SynthesisConfig when set."""
+        model = self._prepare_voice_files(tmp_path)
+        monkeypatch.setattr(tts_tool, "_import_piper", lambda: _StubPiperVoice)
+
+        fake_syn_cls = MagicMock()
+        monkeypatch.setitem(sys.modules, "piper", types.SimpleNamespace(SynthesisConfig=fake_syn_cls))
+
+        config = {"piper": {"voice": str(model), "speaker_id": 2}}
+        tts_tool._generate_piper_tts("hi", str(tmp_path / "out.wav"), config)
+
+        fake_syn_cls.assert_called_once()
+        assert fake_syn_cls.call_args.kwargs["speaker_id"] == 2
+
+    def test_speaker_id_alone_triggers_synconfig(self, tmp_path, monkeypatch):
+        """Setting ONLY speaker_id (no other advanced knobs) still constructs SynthesisConfig.
+
+        Regression guard: has_advanced must include speaker_id, otherwise
+        this knob gets silently dropped on the simplest configuration.
+        """
+        model = self._prepare_voice_files(tmp_path)
+        monkeypatch.setattr(tts_tool, "_import_piper", lambda: _StubPiperVoice)
+
+        fake_syn_cls = MagicMock()
+        monkeypatch.setitem(sys.modules, "piper", types.SimpleNamespace(SynthesisConfig=fake_syn_cls))
+
+        config = {"piper": {"voice": str(model), "speaker_id": 1}}
+        tts_tool._generate_piper_tts("hi", str(tmp_path / "out.wav"), config)
+
+        fake_syn_cls.assert_called_once()
+
+    def test_speaker_id_default_zero_when_unset(self, tmp_path, monkeypatch):
+        """No speaker_id in config → SynthesisConfig.speaker_id == 0 (Piper's default)."""
+        model = self._prepare_voice_files(tmp_path)
+        monkeypatch.setattr(tts_tool, "_import_piper", lambda: _StubPiperVoice)
+
+        fake_syn_cls = MagicMock()
+        monkeypatch.setitem(sys.modules, "piper", types.SimpleNamespace(SynthesisConfig=fake_syn_cls))
+
+        config = {"piper": {"voice": str(model), "length_scale": 1.5}}
+        tts_tool._generate_piper_tts("hi", str(tmp_path / "out.wav"), config)
+
+        assert fake_syn_cls.call_args.kwargs["speaker_id"] == 0
+
+    def test_speaker_id_bool_rejected_to_zero(self, tmp_path, monkeypatch):
+        """True/False would coerce to 1/0 and hide a config mistake — reject outright."""
+        model = self._prepare_voice_files(tmp_path)
+        monkeypatch.setattr(tts_tool, "_import_piper", lambda: _StubPiperVoice)
+
+        fake_syn_cls = MagicMock()
+        monkeypatch.setitem(sys.modules, "piper", types.SimpleNamespace(SynthesisConfig=fake_syn_cls))
+
+        for bad in (True, False):
+            fake_syn_cls.reset_mock()
+            config = {"piper": {"voice": str(model), "speaker_id": bad}}
+            tts_tool._generate_piper_tts("hi", str(tmp_path / f"out-{bad}.wav"), config)
+            assert fake_syn_cls.call_args.kwargs["speaker_id"] == 0
+
+    def test_speaker_id_non_int_dropped_to_zero(self, tmp_path, monkeypatch):
+        """Unparseable config (string, list, dict) drops to 0 instead of raising."""
+        model = self._prepare_voice_files(tmp_path)
+        monkeypatch.setattr(tts_tool, "_import_piper", lambda: _StubPiperVoice)
+
+        fake_syn_cls = MagicMock()
+        monkeypatch.setitem(sys.modules, "piper", types.SimpleNamespace(SynthesisConfig=fake_syn_cls))
+
+        for bad in ("two", [1, 2], {"k": 1}, None):
+            fake_syn_cls.reset_mock()
+            config = {"piper": {"voice": str(model), "speaker_id": bad}}
+            tts_tool._generate_piper_tts("hi", str(tmp_path / f"out-{type(bad).__name__}.wav"), config)
+            assert fake_syn_cls.call_args.kwargs["speaker_id"] == 0
+
+    def test_speaker_id_does_not_invalidate_voice_cache(self, tmp_path, monkeypatch):
+        """Switching speaker_id between calls must NOT trigger a model reload.
+
+        PiperVoice is bound to a model, not a speaker — speaker is applied
+        per-call via syn_config.speaker_id. The voice cache should serve the
+        same PiperVoice instance for the same (model, cuda) regardless of
+        how many distinct speaker_ids the user cycles through.
+        """
+        model = self._prepare_voice_files(tmp_path)
+        monkeypatch.setattr(tts_tool, "_import_piper", lambda: _StubPiperVoice)
+
+        for speaker in (0, 1, 2, 3):
+            config = {"piper": {"voice": str(model), "speaker_id": speaker}}
+            tts_tool._generate_piper_tts("hi", str(tmp_path / f"out-{speaker}.wav"), config)
+
+        # Only one PiperVoice.load() call across four calls with different speakers.
+        assert _StubPiperVoice.loaded == [str(model)]
 
 
 # ---------------------------------------------------------------------------

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -1889,6 +1889,18 @@ def _generate_piper_tts(text: str, output_path: str, tts_config: Dict[str, Any])
 
     model_path = _resolve_piper_voice_path(voice_name, download_dir)
 
+    # Tolerant speaker_id parse: drop bad input (non-int strings, lists, dicts)
+    # to 0 (Piper's own default). Booleans are rejected outright — True/False
+    # would silently coerce to 1/0 and hide a config mistake.
+    _raw_speaker = piper_config.get("speaker_id", 0)
+    if isinstance(_raw_speaker, bool) or not isinstance(_raw_speaker, int):
+        speaker_id = 0
+    else:
+        speaker_id = _raw_speaker
+
+    # speaker_id is applied per-call via syn_config.speaker_id — the same
+    # PiperVoice instance serves all speakers, so it stays out of the cache
+    # key. Multi-speaker workflows share one model load.
     cache_key = f"{model_path}::cuda={use_cuda}"
     global _piper_voice_cache
     if cache_key not in _piper_voice_cache:
@@ -1903,7 +1915,14 @@ def _generate_piper_tts(text: str, output_path: str, tts_config: Dict[str, Any])
     syn_config = None
     has_advanced = any(
         k in piper_config
-        for k in ("length_scale", "noise_scale", "noise_w_scale", "volume", "normalize_audio")
+        for k in (
+            "length_scale",
+            "noise_scale",
+            "noise_w_scale",
+            "volume",
+            "normalize_audio",
+            "speaker_id",
+        )
     )
     if has_advanced:
         try:
@@ -1914,6 +1933,7 @@ def _generate_piper_tts(text: str, output_path: str, tts_config: Dict[str, Any])
                 noise_w_scale=float(piper_config.get("noise_w_scale", 0.8)),
                 volume=float(piper_config.get("volume", 1.0)),
                 normalize_audio=bool(piper_config.get("normalize_audio", True)),
+                speaker_id=speaker_id,
             )
         except ImportError:
             logger.warning(


### PR DESCRIPTION
## What does this PR do?

Wires the built-in Piper TTS provider's `speaker_id` through to `piper.SynthesisConfig.speaker_id`. The Python `piper-tts` package already accepts `speaker_id` as a first-class field on `SynthesisConfig` — the Hermes built-in provider was reading it from neither the user config nor the request, so multi-speaker ONNX models (e.g. `libritts_r`) could not be addressed from config without dropping to the command-provider path.

This change adds `tts.piper.speaker_id` as a config knob (int, default `0` — Piper's own default; single-speaker models ignore the field). It pairs with a tolerant parser that drops bad input (`True`/`False`, unparseable strings, lists, dicts) to `0` instead of raising, so a misconfigured agent doesn't crash TTS calls with a `TypeError`. The `PiperVoice` voice cache is intentionally left keyed on `(model_path, use_cuda)` only — `speaker_id` is applied per-call via `SynthesisConfig`, so the same loaded model serves all speakers in a multi-speaker workflow (verified via `inspect.signature(PiperVoice.load)` and `PiperVoice.synthesize_wav`).

## Related Issue

No upstream issue. Local tracking only.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tools/tts_tool.py` (`_generate_piper_tts` only, +20 / -2):
  - Added `speaker_id` to the `has_advanced` tuple so setting it triggers `SynthesisConfig` construction.
  - Added `speaker_id=speaker_id` to the `SynthesisConfig(...)` call (default 0, Piper's own default).
  - Tolerant parse: bad input (non-int strings, lists, dicts) drops to `0`; booleans rejected outright (`True`/`False` would silently coerce to `1`/`0` and hide a config mistake).
  - Voice cache key intentionally NOT extended — `PiperVoice` is bound to a model, not a speaker; `speaker_id` is applied per-call via `syn_config.speaker_id`.

- `tests/tools/test_tts_piper.py` (+91 / -2):
  - 6 new test cases for the built-in Piper path:
    - `test_speaker_id_passed_through_to_synconfig` — config → `SynthesisConfig.speaker_id`
    - `test_speaker_id_alone_triggers_synconfig` — `has_advanced` gating works when only `speaker_id` is set
    - `test_speaker_id_default_zero_when_unset` — defaults to 0 (Piper's default)
    - `test_speaker_id_bool_rejected_to_zero` — `True`/`False` rejected
    - `test_speaker_id_non_int_dropped_to_zero` — strings/lists/dicts/`None` drop to 0
    - `test_speaker_id_does_not_invalidate_voice_cache` — 4 calls with different `speaker_id` → 1 model load (regression guard for the cache-key invariant)

## How to Test

1. Install a multi-speaker Piper ONNX model (e.g. `en_US-libritts_r-medium.onnx`).
2. Configure: set `tts.piper.speaker_id: 0` in `config.yaml` and synthesize a sentence.
3. Switch to `tts.piper.speaker_id: 1` and synthesize the same sentence.
4. Confirm the two clips are spoken by different voices.
5. Run `pytest tests/tools/test_tts_piper.py -v` — expect 22/22 (16 pre-existing + 6 new).
6. Run `pytest tests/tools/test_tts_*.py` — expect 224/225 (1 unrelated pre-existing skip, no regressions).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A (skill update will land separately)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A (no piper section in the example; existing knobs aren't documented there either)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A (changes are platform-agnostic; the affected code is in the Python `piper-tts` integration which works the same on all OSes)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

```
$ pytest tests/tools/test_tts_piper.py -v
============================= test session starts =============================
platform win32 -- Python 3.11.11, pytest-9.1.0
collected 22 items

tests/tools/test_tts_piper.py::TestPiperRegistration::test_piper_is_a_builtin_provider PASSED
tests/tools/test_tts_piper.py::TestPiperRegistration::test_piper_has_a_text_length_cap PASSED
tests/tools/test_tts_piper.py::TestCheckPiperAvailable::test_returns_bool_without_raising PASSED
tests/tools/test_tts_piper.py::TestResolvePiperVoicePath::test_direct_onnx_path_returned_as_is PASSED
tests/tools/test_tts_piper.py::TestResolvePiperVoicePath::test_cached_voice_name_not_redownloaded PASSED
tests/tools/test_tts_piper.py::TestResolvePiperVoicePath::test_missing_voice_triggers_download PASSED
tests/tools/test_tts_piper.py::TestResolvePiperVoicePath::test_download_failure_raises_runtime PASSED
tests/tools/test_tts_piper.py::TestResolvePiperVoicePath::test_download_success_but_missing_file_raises PASSED
tests/tools/test_tts_piper.py::TestResolvePiperVoicePath::test_empty_voice_falls_back_to_default_name PASSED
tests/tools/test_tts_piper.py::TestGeneratePiperTts::test_loads_voice_and_writes_wav PASSED
tests/tools/test_tts_piper.py::TestGeneratePiperTts::test_voice_cache_reused_across_calls PASSED
tests/tools/test_tts_piper.py::TestGeneratePiperTts::test_voice_name_triggers_download PASSED
tests/tools/test_tts_piper.py::TestGeneratePiperTts::test_advanced_knobs_passed_as_synconfig PASSED
tests/tools/test_tts_piper.py::TestGeneratePiperTts::test_speaker_id_passed_through_to_synconfig PASSED
tests/tools/test_tts_piper.py::TestGeneratePiperTts::test_speaker_id_alone_triggers_synconfig PASSED
tests/tools/test_tts_piper.py::TestGeneratePiperTts::test_speaker_id_default_zero_when_unset PASSED
tests/tools/test_tts_piper.py::TestGeneratePiperTts::test_speaker_id_bool_rejected_to_zero PASSED
tests/tools/test_tts_piper.py::TestGeneratePiperTts::test_speaker_id_non_int_dropped_to_zero PASSED
tests/tools/test_tts_piper.py::TestGeneratePiperTts::test_speaker_id_does_not_invalidate_voice_cache PASSED
tests/tools/test_tts_piper.py::TestTextToSpeechToolWithPiper::test_dispatches_to_piper PASSED
tests/tools/test_tts_piper.py::TestTextToSpeechToolWithPiper::test_missing_package_surfaces_error PASSED
tests/tools/test_tts_piper.py::TestCheckTtsRequirementsPiper::test_piper_install_satisfies_requirements PASSED

============================= 22 passed in 1.78s ==============================
```


