### PR TITLE
fix: replace 4 remaining assert statements with proper error handling

### DIFF
--- a/agent/transports/codex_app_server_session.py
+++ b/agent/transports/codex_app_server_session.py
@@ -396,7 +396,8 @@ class CodexAppServerSession:
             # turn re-spawns cleanly.
             result.should_retire = True
             return result
-        assert self._client is not None and self._thread_id is not None
+        if self._client is None or self._thread_id is None:
+            raise RuntimeError("Codex app-server session not properly initialized after startup")
         result.thread_id = self._thread_id
 
         self._interrupt_event.clear()

--- a/tools/browser_cdp_tool.py
+++ b/tools/browser_cdp_tool.py
@@ -107,7 +107,8 @@ async def _cdp_call(
     works for ``Target.*``, ``Browser.*``, ``Storage.*`` and a few other
     globally-scoped domains.
     """
-    assert websockets is not None  # guarded by _WS_AVAILABLE at call-site
+    if websockets is None:
+        raise RuntimeError("websockets package is required for CDP communication")
 
     async with websockets.connect(
         ws_url,

--- a/tools/browser_supervisor.py
+++ b/tools/browser_supervisor.py
@@ -810,7 +810,8 @@ class CDPSupervisor:
 
     async def _read_loop(self) -> None:
         """Continuously dispatch incoming CDP frames."""
-        assert self._ws is not None
+        if self._ws is None:
+            raise RuntimeError("_read_loop called before WebSocket connection is established")
         try:
             async for raw in self._ws:
                 if self._stop_requested:

--- a/tools/environments/docker.py
+++ b/tools/environments/docker.py
@@ -944,7 +944,8 @@ class DockerEnvironment(BaseEnvironment):
                   timeout: int = 120,
                   stdin_data: str | None = None) -> subprocess.Popen:
         """Spawn a bash process inside the Docker container."""
-        assert self._container_id, "Container not started"
+        if not self._container_id:
+            raise RuntimeError("Container not started — call start() before _run_bash()")
         cmd = [self._docker_exe, "exec"]
         if stdin_data is not None:
             cmd.append("-i")


### PR DESCRIPTION
## Summary

Replace 4 remaining assert statements in production code with explicit if/raise RuntimeError guards.

assert statements are stripped when Python runs with -O flag, silently removing safety checks.

## Changes

- tools/environments/docker.py:947 -- container not started guard
- tools/browser_cdp_tool.py:110 -- websockets import guard
- tools/browser_supervisor.py:813 -- WebSocket connection guard
- agent/transports/codex_app_server_session.py:399 -- session init guard

## Test Plan

- [x] Lint clean on all 4 files

## Context

Follow-up to PR #48779 (weixin.py asserts). This completes the assert-in-production cleanup across the codebase.