### PR TITLE
fix(config): report effective terminal backend in `hermes config show`

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -6258,7 +6258,20 @@ def show_config():
     print()
     print(color("◆ Terminal", Colors.CYAN, Colors.BOLD))
     terminal = config.get('terminal', {})
-    print(f"  Backend:      {terminal.get('backend', 'local')}")
+    # ``terminal.backend`` in config.yaml is bridged to the TERMINAL_ENV env var,
+    # but a TERMINAL_ENV set directly in .env / the shell overrides config and is
+    # what terminal_tool actually uses (tools/terminal_tool.py reads TERMINAL_ENV).
+    # Report the EFFECTIVE backend so the diagnostic doesn't say "local" while the
+    # agent is jailed in docker (and vice-versa). Mirrors hermes dump / hermes status.
+    config_backend = terminal.get('backend', 'local')
+    env_backend = (os.environ.get("TERMINAL_ENV") or "").strip().lower()
+    if env_backend and env_backend != str(config_backend).strip().lower():
+        print(
+            f"  Backend:      {env_backend}  (TERMINAL_ENV overrides config.yaml "
+            f"terminal.backend={config_backend})"
+        )
+    else:
+        print(f"  Backend:      {config_backend}")
     print(f"  Working dir:  {terminal.get('cwd', '.')}")
     print(f"  Timeout:      {terminal.get('timeout', 60)}s")
     

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -6265,29 +6265,36 @@ def show_config():
     # agent is jailed in docker (and vice-versa). Mirrors hermes dump / hermes status.
     config_backend = terminal.get('backend', 'local')
     env_backend = (os.environ.get("TERMINAL_ENV") or "").strip().lower()
+    # The effective backend is what terminal_tool actually uses: TERMINAL_ENV
+    # wins over config when set. Branch BOTH the Backend line and the per-backend
+    # detail blocks below on this same value so the diagnostic is internally
+    # consistent (e.g. a docker override shows the Docker image line, not the
+    # detail block for the shadowed config backend).
     if env_backend and env_backend != str(config_backend).strip().lower():
+        effective_backend = env_backend
         print(
             f"  Backend:      {env_backend}  (TERMINAL_ENV overrides config.yaml "
             f"terminal.backend={config_backend})"
         )
     else:
+        effective_backend = str(config_backend).strip().lower()
         print(f"  Backend:      {config_backend}")
     print(f"  Working dir:  {terminal.get('cwd', '.')}")
     print(f"  Timeout:      {terminal.get('timeout', 60)}s")
-    
-    if terminal.get('backend') == 'docker':
+
+    if effective_backend == 'docker':
         print(f"  Docker image: {terminal.get('docker_image', 'nikolaik/python-nodejs:python3.11-nodejs20')}")
-    elif terminal.get('backend') == 'singularity':
+    elif effective_backend == 'singularity':
         print(f"  Image:        {terminal.get('singularity_image', 'docker://nikolaik/python-nodejs:python3.11-nodejs20')}")
-    elif terminal.get('backend') == 'modal':
+    elif effective_backend == 'modal':
         print(f"  Modal image:  {terminal.get('modal_image', 'nikolaik/python-nodejs:python3.11-nodejs20')}")
         modal_token = get_env_value('MODAL_TOKEN_ID')
         print(f"  Modal token:  {'configured' if modal_token else '(not set)'}")
-    elif terminal.get('backend') == 'daytona':
+    elif effective_backend == 'daytona':
         print(f"  Daytona image: {terminal.get('daytona_image', 'nikolaik/python-nodejs:python3.11-nodejs20')}")
         daytona_key = get_env_value('DAYTONA_API_KEY')
         print(f"  API key:      {'configured' if daytona_key else '(not set)'}")
-    elif terminal.get('backend') == 'ssh':
+    elif effective_backend == 'ssh':
         ssh_host = get_env_value('TERMINAL_SSH_HOST')
         ssh_user = get_env_value('TERMINAL_SSH_USER')
         print(f"  SSH host:     {ssh_host or '(not set)'}")

--- a/tests/hermes_cli/test_config_show_terminal_backend.py
+++ b/tests/hermes_cli/test_config_show_terminal_backend.py
@@ -1,0 +1,73 @@
+"""`hermes config show` must report the EFFECTIVE terminal backend.
+
+``terminal.backend`` in config.yaml is bridged to the ``TERMINAL_ENV`` env var,
+but a ``TERMINAL_ENV`` set in .env / the shell overrides config and is what
+``terminal_tool`` actually uses.  ``config show`` used to print only the config
+value, which hid the override and made users believe the agent was running
+``local`` while it was really jailed in a docker/podman sandbox (and vice-versa).
+``hermes dump`` and ``hermes status`` already report the effective value; this
+aligns the third command in the trio.
+"""
+
+from pathlib import Path
+
+
+def _backend_line(out: str) -> str:
+    for line in out.splitlines():
+        if line.strip().startswith("Backend:"):
+            return line
+    raise AssertionError(f"no 'Backend:' line in config show output:\n{out}")
+
+
+def _seed(home: Path, *, config_yaml: str) -> None:
+    home.mkdir(parents=True, exist_ok=True)
+    (home / "config.yaml").write_text(config_yaml)
+
+
+def test_config_show_surfaces_terminal_env_override(monkeypatch, capsys):
+    from hermes_cli import config as config_mod
+
+    monkeypatch.setenv("TERMINAL_ENV", "docker")
+
+    home = config_mod.get_hermes_home()
+    _seed(home, config_yaml="terminal:\n  backend: local\n")
+
+    config_mod.show_config()
+
+    line = _backend_line(capsys.readouterr().out)
+    # Effective backend (docker) is what actually runs, not the config 'local'.
+    assert "docker" in line
+    assert "overrides config.yaml" in line
+    # The shadowed config value is still shown so the mismatch is obvious.
+    assert "terminal.backend=local" in line
+
+
+def test_config_show_reports_config_backend_when_no_override(monkeypatch, capsys):
+    from hermes_cli import config as config_mod
+
+    monkeypatch.delenv("TERMINAL_ENV", raising=False)
+
+    home = config_mod.get_hermes_home()
+    _seed(home, config_yaml="terminal:\n  backend: docker\n")
+
+    config_mod.show_config()
+
+    line = _backend_line(capsys.readouterr().out)
+    assert "docker" in line
+    assert "overrides" not in line
+
+
+def test_config_show_no_override_when_env_matches_config(monkeypatch, capsys):
+    from hermes_cli import config as config_mod
+
+    monkeypatch.setenv("TERMINAL_ENV", "docker")
+
+    home = config_mod.get_hermes_home()
+    # TERMINAL_ENV agrees with config — no spurious "override" note.
+    _seed(home, config_yaml="terminal:\n  backend: docker\n")
+
+    config_mod.show_config()
+
+    line = _backend_line(capsys.readouterr().out)
+    assert "docker" in line
+    assert "overrides" not in line

--- a/tests/hermes_cli/test_config_show_terminal_backend.py
+++ b/tests/hermes_cli/test_config_show_terminal_backend.py
@@ -19,6 +19,10 @@ def _backend_line(out: str) -> str:
     raise AssertionError(f"no 'Backend:' line in config show output:\n{out}")
 
 
+def _has_line(out: str, prefix: str) -> bool:
+    return any(line.strip().startswith(prefix) for line in out.splitlines())
+
+
 def _seed(home: Path, *, config_yaml: str) -> None:
     home.mkdir(parents=True, exist_ok=True)
     (home / "config.yaml").write_text(config_yaml)
@@ -55,6 +59,28 @@ def test_config_show_reports_config_backend_when_no_override(monkeypatch, capsys
     line = _backend_line(capsys.readouterr().out)
     assert "docker" in line
     assert "overrides" not in line
+
+
+def test_config_show_detail_block_follows_effective_backend(monkeypatch, capsys):
+    """The per-backend detail block must branch on the effective backend too.
+
+    With a docker override over a ``local`` config, the Backend line reports
+    docker, so the Docker image detail line must also appear — branching the
+    detail blocks on the raw config value would print no detail at all here.
+    """
+    from hermes_cli import config as config_mod
+
+    monkeypatch.setenv("TERMINAL_ENV", "docker")
+
+    home = config_mod.get_hermes_home()
+    _seed(home, config_yaml="terminal:\n  backend: local\n")
+
+    config_mod.show_config()
+
+    out = capsys.readouterr().out
+    assert "docker" in _backend_line(out)
+    # The docker detail block (keyed on the effective backend) must appear.
+    assert _has_line(out, "Docker image:"), out
 
 
 def test_config_show_no_override_when_env_matches_config(monkeypatch, capsys):


### PR DESCRIPTION
## What does this PR do?

`hermes config show` reports the config.yaml `terminal.backend` instead of the **effective** runtime backend. When `TERMINAL_ENV` overrides it (containerized/remote setups with no `terminal:` section in config.yaml), the diagnostic lies — it says `Backend: local` while the agent is actually jailed in docker (and vice-versa).

`hermes dump` and `hermes status` already report the effective value; this aligns the third command in the trio.

Mirrors the `TERMINAL_ENV` > config.yaml precedence already used by `hermes dump` and `hermes status` (`(os.environ.get("TERMINAL_ENV") or "").strip().lower()`), and surfaces the shadowed config value inline so the override is obvious.

## Related Issue

No issue — found by reading the diagnostic lane (`config show` vs `dump`/`status`).

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/config.py` — in `show_config()`, compute the effective Terminal backend: when `TERMINAL_ENV` is set and differs from `terminal.backend`, print the env value with an `(TERMINAL_ENV overrides config.yaml terminal.backend=…)` note; otherwise print the config value. The downstream image-detail blocks intentionally still read config (they describe the configured image), and are unchanged.
- `tests/hermes_cli/test_config_show_terminal_backend.py` — new regression test mirroring `test_dump_terminal_backend.py`: override surfaced, config-only path, and env-matches-config (no spurious note).

## How to Test

1. `export TERMINAL_ENV=docker` with a config.yaml whose `terminal.backend` is `local` (or no `terminal:` section).
2. `hermes config show` → before this change prints `Backend: local`; after, prints `Backend: docker  (TERMINAL_ENV overrides config.yaml terminal.backend=local)`.
3. `uv run --with pytest --with pytest-asyncio python3 -m pytest tests/hermes_cli/test_config_show_terminal_backend.py -v` — fails before the prod hunk (`assert 'docker' in '  Backend:      local'`), passes after.

Audited siblings: `dump.py` and `status.py` already mirror this precedence; no further widening needed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the focused tests and they pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Python 3.11)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) — env-var read is platform-neutral