### PR TITLE
fix(codex): stop double-counting cached input tokens in app-server usage accounting

### DIFF
--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -76,8 +76,15 @@ def _record_codex_app_server_usage(agent, turn) -> dict[str, Any]:
 
     from agent.usage_pricing import CanonicalUsage, estimate_usage_cost
 
-    input_tokens = _coerce_usage_int(usage.get("inputTokens"))
+    # codex app-server reports ``inputTokens`` as the FULL prompt total, which
+    # already includes ``cachedInputTokens`` (codex-rs convention:
+    # ``non_cached_input() = input_tokens - cached_input_tokens``). CanonicalUsage
+    # adds cache_read back on top in ``prompt_tokens``, so feeding the full total
+    # in as ``input_tokens`` double-counts cached tokens. Subtract first, exactly
+    # like the codex_responses parser in usage_pricing.py does.
+    input_total = _coerce_usage_int(usage.get("inputTokens"))
     cache_read_tokens = _coerce_usage_int(usage.get("cachedInputTokens"))
+    input_tokens = max(0, input_total - cache_read_tokens)
     output_tokens = _coerce_usage_int(usage.get("outputTokens"))
     reasoning_tokens = _coerce_usage_int(usage.get("reasoningOutputTokens"))
     reported_total = _coerce_usage_int(usage.get("totalTokens"))

--- a/tests/run_agent/test_codex_app_server_integration.py
+++ b/tests/run_agent/test_codex_app_server_integration.py
@@ -109,27 +109,31 @@ class TestRunConversationCodexPath:
         with patch.object(agent, "_spawn_background_review", return_value=None):
             result = agent.run_conversation("hello")
 
+        # codex app-server ``inputTokens`` (80) already INCLUDES the 20 cached
+        # tokens, so the non-cached input is 60 and prompt_tokens is
+        # 60 + 20 (cache_read) + 0 (cache_write) = 80 — not 100. The reported
+        # totalTokens (130) is preserved as-is.
         assert result["api_calls"] == 1
-        assert result["prompt_tokens"] == 100
+        assert result["prompt_tokens"] == 80
         assert result["completion_tokens"] == 25
         assert result["total_tokens"] == 130
-        assert result["input_tokens"] == 80
+        assert result["input_tokens"] == 60
         assert result["output_tokens"] == 25
         assert result["cache_read_tokens"] == 20
         assert result["cache_write_tokens"] == 0
         assert result["reasoning_tokens"] == 5
-        assert result["last_prompt_tokens"] == 100
+        assert result["last_prompt_tokens"] == 80
 
         assert agent.session_api_calls == 1
-        assert agent.session_prompt_tokens == 100
+        assert agent.session_prompt_tokens == 80
         assert agent.session_completion_tokens == 25
         assert agent.session_total_tokens == 130
-        assert agent.session_input_tokens == 80
+        assert agent.session_input_tokens == 60
         assert agent.session_output_tokens == 25
         assert agent.session_cache_read_tokens == 20
         assert agent.session_cache_write_tokens == 0
         assert agent.session_reasoning_tokens == 5
-        assert agent.context_compressor.last_prompt_tokens == 100
+        assert agent.context_compressor.last_prompt_tokens == 80
         assert agent.context_compressor.last_completion_tokens == 25
         assert agent.context_compressor.last_total_tokens == 130
         assert agent.context_compressor.context_length == 200000


### PR DESCRIPTION
## What does this PR do?

The Codex **app-server** usage path double-counts cached input tokens. `agent/codex_runtime.py` reads `inputTokens` and passes it directly into `CanonicalUsage(input_tokens=...)`, then reads back `prompt_tokens` — which is defined as `input_tokens + cache_read_tokens + cache_write_tokens` (`agent/usage_pricing.py`). But codex-rs reports `inputTokens` as the **full** prompt total that already includes `cachedInputTokens` (`non_cached_input() = input_tokens - cached_input_tokens`). So cached tokens are added back a second time.

This inflates `/insights` analytics, the session DB `input_tokens`, the compressor's prompt size (can trigger premature compression), and `estimated_cost_usd`.

The fix mirrors the sibling **Responses-API** path: `usage_pricing.py`'s `codex_responses` branch already does `input_tokens = max(0, input_total - cache_read_tokens - cache_write_tokens)`. This brings the app-server path to the same contract (cache_write stays 0 — the app-server doesn't expose it). The reported `totalTokens` is preserved unchanged.

## Related Issue

No issue — author-found regression in the app-server accounting added by `cb4cc08b0` (2026-06-09).

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/codex_runtime.py` — subtract `cachedInputTokens` from `inputTokens` to get the non-cached input before constructing `CanonicalUsage`, so `prompt_tokens` no longer double-counts cached tokens.
- `tests/run_agent/test_codex_app_server_integration.py` — the existing `test_codex_app_server_token_usage_updates_session_accounting` drives this path with `inputTokens=80, cachedInputTokens=20`. Updated its assertions from the buggy values (`prompt_tokens==100`, `input_tokens==80`) to the correct ones (`prompt_tokens==80`, `input_tokens==60`, `last_prompt_tokens==80`); `cache_read_tokens==20` and `total_tokens==130` are unchanged.

## How to Test

1. `uv run --with pytest --with pytest-asyncio python3 -m pytest tests/run_agent/test_codex_app_server_integration.py -k token_usage_updates_session_accounting -v`
2. Before the prod hunk the updated assertions fail (the code yields `prompt_tokens=100`, `input_tokens=80`); after, they pass (`80`/`60`).
3. Full file: 16 passed.

Audited siblings: the Responses-API path (`usage_pricing.py` `codex_responses` branch) already subtracts cached from the input total; this brings the app-server path to the same contract. No further widening needed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the focused tests and they pass
- [x] I've added tests for my changes (updated the existing regression test to the correct expected values)
- [x] I've tested on my platform: macOS 15 (Python 3.11)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) — pure arithmetic, platform-neutral