### PR TITLE
fix(api-server): replace assert with proper error handling

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -4165,7 +4165,8 @@ class APIServerAdapter(BasePlatformAdapter):
         try:
             mws = [mw for mw in (cors_middleware, body_limit_middleware, security_headers_middleware) if mw is not None]
             self._app = web.Application(middlewares=mws, client_max_size=MAX_REQUEST_BYTES)
-            assert self._app is not None
+            if self._app is None:
+                raise RuntimeError("web.Application() returned None — aiohttp may be broken")
             self._app.router.add_get("/health", self._handle_health)
             self._app.router.add_get("/health/detailed", self._handle_health_detailed)
             self._app.router.add_get("/v1/health", self._handle_health)


### PR DESCRIPTION
## Summary

Replace assert self._app is not None with if/raise RuntimeError in gateway/platforms/api_server.py line 4168.

assert statements are stripped when Python runs with -O flag.

## Changes
- gateway/platforms/api_server.py: Replace 1 assert with if/raise RuntimeError

## Test Plan
- [x] Lint clean

## Context
Follow-up to PR #48779 (weixin asserts) and #48798 (4 remaining asserts). This completes assert cleanup.