### PR TITLE
fix(uninstall): strip the orphaned `export PATH` line the installer writes

### DIFF
--- a/hermes_cli/uninstall.py
+++ b/hermes_cli/uninstall.py
@@ -69,7 +69,14 @@ def remove_path_from_shell_configs():
                 if '# Hermes Agent' in line or '# hermes-agent' in line:
                     skip_next = True
                     continue
-                if skip_next and ('hermes' in line.lower() and 'PATH' in line):
+                # The "# Hermes Agent" comment guarantees the next line is the
+                # PATH entry the installer wrote directly beneath it. install.sh
+                # writes a GENERIC `export PATH="$HOME/.local/bin:$PATH"` (or the
+                # `/usr/local/bin` / fish `fish_add_path` variant) with no
+                # `hermes` substring, so the old `'hermes' in line` guard left it
+                # orphaned on every uninstall. Drop a PATH-setting line directly
+                # under our comment without requiring a `hermes` substring.
+                if skip_next and (('PATH=' in line) or ('fish_add_path' in line)):
                     skip_next = False
                     continue
                 skip_next = False

--- a/hermes_cli/uninstall.py
+++ b/hermes_cli/uninstall.py
@@ -41,6 +41,11 @@ def find_shell_configs() -> list:
         home / ".profile",
         home / ".zshrc",
         home / ".zprofile",
+        # scripts/install.sh writes `fish_add_path "$HOME/.local/bin"` (under our
+        # `# Hermes Agent` comment) to this fish rc file. Without it here the
+        # fish_add_path removal branch below is dead code and a fish user's
+        # PATH entry is orphaned on uninstall.
+        home / ".config" / "fish" / "config.fish",
     ]
     
     for config in candidates:

--- a/tests/hermes_cli/test_uninstall_shell_config_path.py
+++ b/tests/hermes_cli/test_uninstall_shell_config_path.py
@@ -1,0 +1,80 @@
+"""Tests for hermes_cli.uninstall.remove_path_from_shell_configs.
+
+The POSIX installer (scripts/install.sh) appends a ``# Hermes Agent`` comment
+followed by a GENERIC PATH line to the user's shell rc file, e.g.::
+
+    # Hermes Agent — ensure ~/.local/bin is on PATH
+    export PATH="$HOME/.local/bin:$PATH"
+
+The export line carries no ``hermes`` substring, so the old removal heuristic
+(which required ``'hermes' in line``) deleted only the comment and left the
+``export PATH`` line orphaned — accumulating on every install/uninstall cycle
+while the function still reported the rc file "updated". Uninstall must strip
+the PATH line that sits directly under our comment too.
+"""
+
+from pathlib import Path
+
+import pytest
+
+import hermes_cli.uninstall as uninstall
+
+
+@pytest.fixture
+def fake_home(tmp_path, monkeypatch):
+    """Redirect Path.home() so find_shell_configs() reads our temp rc files."""
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: home))
+    return home
+
+
+def test_strips_orphaned_local_bin_export(fake_home):
+    """The `~/.local/bin` installer block (comment + bare export PATH) is gone."""
+    zshrc = fake_home / ".zshrc"
+    zshrc.write_text(
+        "export EDITOR=vim\n"
+        "\n"
+        "# Hermes Agent — ensure ~/.local/bin is on PATH\n"
+        'export PATH="$HOME/.local/bin:$PATH"\n'
+    )
+
+    uninstall.remove_path_from_shell_configs()
+
+    content = zshrc.read_text()
+    assert 'export PATH="$HOME/.local/bin:$PATH"' not in content
+    assert "Hermes Agent" not in content
+    # Unrelated user config must survive untouched.
+    assert "export EDITOR=vim" in content
+
+
+def test_strips_orphaned_usr_local_bin_export(fake_home):
+    """The RHEL `/usr/local/bin` variant is stripped too."""
+    bashrc = fake_home / ".bashrc"
+    bashrc.write_text(
+        "# Hermes Agent — ensure /usr/local/bin is on PATH (RHEL non-login shells)\n"
+        'export PATH="/usr/local/bin:$PATH"\n'
+        "export EDITOR=nano\n"
+    )
+
+    uninstall.remove_path_from_shell_configs()
+
+    content = bashrc.read_text()
+    assert 'export PATH="/usr/local/bin:$PATH"' not in content
+    assert "Hermes Agent" not in content
+    assert "export EDITOR=nano" in content
+
+
+def test_leaves_unrelated_path_export_untouched(fake_home):
+    """A user's own non-Hermes PATH export (no preceding comment) survives."""
+    zshrc = fake_home / ".zshrc"
+    zshrc.write_text(
+        'export PATH="$HOME/mybin:$PATH"\n'
+        "export EDITOR=vim\n"
+    )
+
+    uninstall.remove_path_from_shell_configs()
+
+    content = zshrc.read_text()
+    assert 'export PATH="$HOME/mybin:$PATH"' in content
+    assert "export EDITOR=vim" in content

--- a/tests/hermes_cli/test_uninstall_shell_config_path.py
+++ b/tests/hermes_cli/test_uninstall_shell_config_path.py
@@ -65,6 +65,31 @@ def test_strips_orphaned_usr_local_bin_export(fake_home):
     assert "export EDITOR=nano" in content
 
 
+def test_strips_orphaned_fish_add_path(fake_home):
+    """The fish installer block (comment + fish_add_path) is stripped too.
+
+    scripts/install.sh writes the fish PATH entry to ~/.config/fish/config.fish,
+    which find_shell_configs() must scan or the fish_add_path removal branch is
+    dead code and the entry is orphaned on uninstall.
+    """
+    fish_config = fake_home / ".config" / "fish" / "config.fish"
+    fish_config.parent.mkdir(parents=True)
+    fish_config.write_text(
+        "set -x EDITOR vim\n"
+        "\n"
+        "# Hermes Agent — ensure ~/.local/bin is on PATH\n"
+        'fish_add_path "$HOME/.local/bin"\n'
+    )
+
+    uninstall.remove_path_from_shell_configs()
+
+    content = fish_config.read_text()
+    assert 'fish_add_path "$HOME/.local/bin"' not in content
+    assert "Hermes Agent" not in content
+    # Unrelated user config must survive untouched.
+    assert "set -x EDITOR vim" in content
+
+
 def test_leaves_unrelated_path_export_untouched(fake_home):
     """A user's own non-Hermes PATH export (no preceding comment) survives."""
     zshrc = fake_home / ".zshrc"


### PR DESCRIPTION
## What does this PR do?

`hermes uninstall` removes the `# Hermes Agent` comment from shell rc files but leaves the `export PATH="$HOME/.local/bin:$PATH"` line the installer wrote directly beneath it. The removal heuristic in `remove_path_from_shell_configs()` required a `hermes` substring, but `scripts/install.sh` writes a **generic** PATH line:

```
# Hermes Agent — ensure ~/.local/bin is on PATH
export PATH="$HOME/.local/bin:$PATH"
```

The export line has no `hermes` substring, so it's left orphaned on every uninstall and accumulates on each install/uninstall round-trip — while the function still reports the file "updated".

The fix: when we've just seen the `# Hermes Agent` comment (so the next line is Hermes-owned), drop a PATH-setting line without requiring a `hermes` substring. The same condition also catches the RHEL `/usr/local/bin` variant and the fish `fish_add_path "$HOME/.local/bin"` line (both written under the same comment by install.sh). The line-78 fallthrough filter is unchanged, so a user's own non-Hermes PATH export (with no preceding Hermes comment) still survives.

## Related Issue

No issue — found by comparing `scripts/install.sh`'s rc-file writes against `uninstall.remove_path_from_shell_configs`.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/uninstall.py` — when `skip_next` is set (immediately after the `# Hermes Agent` comment), strip a line containing `PATH=` or `fish_add_path` regardless of whether it mentions `hermes`.
- `tests/hermes_cli/test_uninstall_shell_config_path.py` — new regression test (mirrors `test_uninstall_node_symlinks.py`'s `Path.home` monkeypatch): the `~/.local/bin` export block and the `/usr/local/bin` RHEL variant are both removed, unrelated config (`export EDITOR=…`) is preserved, and a user's own non-Hermes PATH export with no preceding comment is left untouched.

## How to Test

1. Add to `~/.zshrc`:
   ```
   # Hermes Agent — ensure ~/.local/bin is on PATH
   export PATH="$HOME/.local/bin:$PATH"
   ```
2. `hermes uninstall` (or call `remove_path_from_shell_configs()`) → before this change the `export PATH` line remains; after, both the comment and the export line are gone.
3. `uv run --with pytest --with pytest-asyncio python3 -m pytest tests/hermes_cli/test_uninstall_shell_config_path.py -v` — the two stripping tests fail before the prod hunk (orphan remains), pass after.

Sibling code paths that may need the same fix: the fish-shell `fish_add_path` variant is handled by the same condition; the Windows registry PATH path (`install.ps1` Set-PathVariable) is separate and intentionally out of scope here.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the focused tests and they pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Python 3.11)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact — POSIX rc files (zsh/bash/fish); Windows registry PATH is separate and out of scope