### PR TITLE
fix: display active model in /status command

### DIFF
--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -481,6 +481,13 @@ class GatewaySlashCommandsMixin:
                 context_used = _int_value(getattr(ctx, "last_prompt_tokens", 0))
                 context_total = _int_value(getattr(ctx, "context_length", 0))
 
+        # Check session model overrides from /model command first
+        session_override = self._session_model_overrides.get(session_key, {})
+        if session_override:
+            model_name = model_name or _clean_str(session_override.get("model", ""))
+            provider_name = provider_name or _clean_str(session_override.get("provider", ""))
+            base_url = base_url or _clean_str(session_override.get("base_url", ""))
+
         model_name = model_name or _clean_str(session_row.get("model"))
         provider_name = provider_name or _clean_str(session_row.get("billing_provider"))
         base_url = base_url or _clean_str(session_row.get("billing_base_url"))


### PR DESCRIPTION
## Summary

The `/status` command was reading the model from the config file, but when users switch models using `/model` without `--global`, the model wasn't being persisted to the config. This caused `/status` to show the old model instead of the active one.

Now `/status` checks `_session_model_overrides` first (where `/model` stores session-specific switches), then falls back to the session database, and finally to the config file.

## Changes

- Added check for `_session_model_overrides` in `_handle_status_command`
- Session-specific model overrides now take precedence over config defaults
- No breaking changes - fully backward compatible

## Test plan

- Start hermes gateway
- Use `/model deepseek/deepseek-v4-pro` to switch model
- Use `/status` to verify the new model is displayed
- Use `/model --global openai/gpt-4o` to switch globally
- Use `/status` to verify the global model is displayed

Closes #48715