### PR TITLE
fix(dashboard): add usage quotas and correct model labels

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -10147,6 +10147,159 @@ async def get_usage_analytics(days: int = 30, profile: Optional[str] = None):
         db.close()
 
 
+def _usage_window_dict(window) -> Dict[str, Any]:
+    reset_at = getattr(window, "reset_at", None)
+    return {
+        "label": getattr(window, "label", ""),
+        "used_percent": getattr(window, "used_percent", None),
+        "reset_at": reset_at.isoformat() if reset_at else None,
+        "detail": getattr(window, "detail", None),
+    }
+
+
+def _account_usage_dict(snapshot) -> Dict[str, Any]:
+    if not snapshot or not getattr(snapshot, "available", False):
+        reason = getattr(snapshot, "unavailable_reason", None) if snapshot else None
+        return {"available": False, "reason": reason or "No live quota endpoint available"}
+    return {
+        "available": True,
+        "title": snapshot.title,
+        "plan": snapshot.plan,
+        "windows": [_usage_window_dict(w) for w in snapshot.windows],
+        "details": list(snapshot.details),
+    }
+
+
+def _provider_auth_summary(provider: str) -> Dict[str, bool]:
+    normalized = str(provider or "").strip().lower()
+    if not normalized:
+        return {"logged_in": False, "configured": False}
+    logged_in = False
+    configured = False
+    try:
+        from hermes_cli.auth import PROVIDER_REGISTRY, get_provider_auth_state
+        state = get_provider_auth_state(normalized) or {}
+        logged_in = bool(state)
+        configured = logged_in
+        pconfig = PROVIDER_REGISTRY.get(normalized)
+        if pconfig:
+            from hermes_cli.config import get_env_value
+            configured = configured or any(
+                bool(str(get_env_value(env_var) or "").strip())
+                for env_var in pconfig.api_key_env_vars
+            )
+    except Exception:
+        _log.debug("usage quotas auth summary failed for %s", provider, exc_info=True)
+    return {"logged_in": logged_in, "configured": configured}
+
+
+def _sum_usage_window(db, *, since: float) -> Dict[str, Any]:
+    row = db._conn.execute(
+        """
+        SELECT COUNT(*) as sessions,
+               COALESCE(SUM(message_count), 0) as messages,
+               COALESCE(SUM(tool_call_count), 0) as tool_calls,
+               COALESCE(SUM(api_call_count), 0) as api_calls,
+               COALESCE(SUM(input_tokens), 0) as input_tokens,
+               COALESCE(SUM(output_tokens), 0) as output_tokens,
+               COALESCE(SUM(cache_read_tokens), 0) as cache_read_tokens,
+               COALESCE(SUM(reasoning_tokens), 0) as reasoning_tokens
+        FROM sessions WHERE started_at > ?
+        """,
+        (since,),
+    ).fetchone()
+    return dict(row or {})
+
+
+@app.get("/api/analytics/usage-quotas")
+async def get_usage_quotas(profile: Optional[str] = None):
+    """Dashboard rollup for the custom Usage & Quotas page."""
+    from agent.account_usage import fetch_account_usage
+    from hermes_cli.fallback_config import get_fallback_chain
+
+    with _profile_scope(profile):
+        config = load_config()
+        model_cfg = config.get("model") if isinstance(config, dict) else {}
+        if isinstance(model_cfg, dict):
+            primary = {
+                "provider": str(model_cfg.get("provider") or ""),
+                "model": str(model_cfg.get("default") or model_cfg.get("name") or ""),
+                "base_url": str(model_cfg.get("base_url") or ""),
+            }
+        else:
+            primary = {"provider": "", "model": str(model_cfg or ""), "base_url": ""}
+        fallback_chain = [
+            {
+                "provider": str(entry.get("provider") or ""),
+                "model": str(entry.get("model") or ""),
+                "base_url": str(entry.get("base_url") or ""),
+            }
+            for entry in get_fallback_chain(config)
+        ]
+
+        provider_names = []
+        for entry in [primary, *fallback_chain]:
+            provider = entry.get("provider") or ""
+            if provider and provider not in provider_names:
+                provider_names.append(provider)
+        provider_auth = {provider: _provider_auth_summary(provider) for provider in provider_names}
+
+        account_usage: Dict[str, Dict[str, Any]] = {}
+        for entry in [primary, *fallback_chain]:
+            provider = entry.get("provider") or ""
+            if not provider or provider in account_usage:
+                continue
+            snapshot = fetch_account_usage(
+                provider,
+                base_url=entry.get("base_url") or None,
+                api_key=str(entry.get("api_key") or "") or None,
+            )
+            account_usage[provider] = _account_usage_dict(snapshot)
+
+    db = _open_session_db_for_profile(profile)
+    try:
+        now = time.time()
+        usage_24h = _sum_usage_window(db, since=now - 86400)
+        usage_7d = _sum_usage_window(db, since=now - (7 * 86400))
+
+        current_row = db._conn.execute(
+            """
+            SELECT id, model, billing_provider, started_at, message_count,
+                   tool_call_count, api_call_count as api_calls, input_tokens, output_tokens,
+                   cache_read_tokens, reasoning_tokens
+            FROM sessions ORDER BY started_at DESC LIMIT 1
+            """
+        ).fetchone()
+        current_session = dict(current_row) if current_row else None
+
+        providers_24h = [
+            dict(row)
+            for row in db._conn.execute(
+                """
+                SELECT COALESCE(NULLIF(billing_provider, ''), 'unknown') as provider,
+                       COUNT(*) as sessions,
+                       COALESCE(SUM(input_tokens + output_tokens), 0) as tokens
+                FROM sessions WHERE started_at > ?
+                GROUP BY provider ORDER BY tokens DESC, sessions DESC
+                """,
+                (now - 86400,),
+            ).fetchall()
+        ]
+    finally:
+        db.close()
+
+    return {
+        "primary": primary,
+        "fallback_chain": fallback_chain,
+        "provider_auth": provider_auth,
+        "account_usage": account_usage,
+        "current_session": current_session,
+        "usage_24h": usage_24h,
+        "usage_7d": usage_7d,
+        "providers_24h": providers_24h,
+    }
+
+
 @app.get("/api/analytics/models")
 async def get_models_analytics(days: int = 30, profile: Optional[str] = None):
     """Rich per-model analytics for the Models dashboard page.

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -35,8 +35,14 @@ REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 # ── Activate venv ───────────────────────────────────────────────────────────
 VENV=""
 for candidate in "$REPO_ROOT/.venv" "$REPO_ROOT/venv" "$HOME/.hermes/hermes-agent/venv"; do
-  if [ -f "$candidate/bin/activate" ]; then
+  if [ -f "$candidate/bin/python" ]; then
     VENV="$candidate"
+    PYTHON="$candidate/bin/python"
+    break
+  fi
+  if [ -f "$candidate/Scripts/python.exe" ]; then
+    VENV="$candidate"
+    PYTHON="$candidate/Scripts/python.exe"
     break
   fi
 done
@@ -45,8 +51,6 @@ if [ -z "$VENV" ]; then
   echo "error: no virtualenv found in $REPO_ROOT/.venv or $REPO_ROOT/venv" >&2
   exit 1
 fi
-
-PYTHON="$VENV/bin/python"
 
 
 # ── Live-gateway plugin (computed before we drop env) ───────────────────────
@@ -69,10 +73,14 @@ cd "$REPO_ROOT"
 exec env -i \
   PATH="$PATH" \
   HOME="$HOME" \
+  USERPROFILE="${USERPROFILE:-$HOME}" \
+  LOCALAPPDATA="${LOCALAPPDATA:-$HOME/AppData/Local}" \
+  APPDATA="${APPDATA:-$HOME/AppData/Roaming}" \
   TZ=UTC \
   LANG=C.UTF-8 \
   LC_ALL=C.UTF-8 \
   PYTHONHASHSEED=0 \
+  PYTHONIOENCODING=utf-8 \
   PYTHONDONTWRITEBYTECODE=1 \
   ${EXTRA_PYTHONPATH:+PYTHONPATH="$EXTRA_PYTHONPATH"} \
   ${EXTRA_PYTEST_PLUGINS:+PYTEST_PLUGINS="$EXTRA_PYTEST_PLUGINS"} \

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -58,6 +58,44 @@ def test_session_create_rejects_at_active_session_limit(monkeypatch, tmp_path):
         reset_hermes_home_override(token)
 
 
+def test_session_create_info_prefers_config_model_over_stale_env(monkeypatch, tmp_path):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    (home / "config.yaml").write_text(
+        "model:\n"
+        "  default: claude-sonnet-4-6\n"
+        "  provider: anthropic\n",
+        encoding="utf-8",
+    )
+    token = set_hermes_home_override(home)
+
+    def _clear_server_sessions():
+        for session in list(server._sessions.values()):
+            server._teardown_session(session)
+        server._sessions.clear()
+
+    try:
+        server._cfg_cache = None
+        server._cfg_mtime = None
+        server._cfg_path = None
+        _clear_server_sessions()
+        monkeypatch.setenv("HERMES_MODEL", "gpt-5.5")
+        monkeypatch.setenv("HERMES_INFERENCE_MODEL", "gpt-5.5")
+        monkeypatch.setattr(server, "_start_agent_build", lambda *args, **kwargs: None)
+        monkeypatch.setattr(server, "_completion_cwd", lambda params=None: str(tmp_path))
+
+        response = server._methods["session.create"]("r1", {"cols": 80})
+
+        assert response["result"]["info"]["model"] == "claude-sonnet-4-6"
+        assert response["result"]["info"]["provider"] == "anthropic"
+    finally:
+        _clear_server_sessions()
+        server._cfg_cache = None
+        server._cfg_mtime = None
+        server._cfg_path = None
+        reset_hermes_home_override(token)
+
+
 def test_session_context_uses_session_cwd(monkeypatch, tmp_path):
     """Desktop/TUI sessions must pin the agent cwd per session.
 
@@ -1946,7 +1984,7 @@ def test_ensure_session_db_row_persists_explicit_cwd(monkeypatch, tmp_path):
             )
 
     monkeypatch.setattr(server, "_get_db", lambda: _FakeDB())
-    monkeypatch.setattr(server, "_resolve_model", lambda: "test-model")
+    monkeypatch.setattr(server, "_config_model_target", lambda: ("test-model", "test-provider"))
 
     server._ensure_session_db_row({"session_key": "k1", "cwd": str(tmp_path), "explicit_cwd": True})
 
@@ -1967,7 +2005,7 @@ def test_ensure_session_db_row_defaults_to_no_workspace(monkeypatch, tmp_path):
             )
 
     monkeypatch.setattr(server, "_get_db", lambda: _FakeDB())
-    monkeypatch.setattr(server, "_resolve_model", lambda: "test-model")
+    monkeypatch.setattr(server, "_config_model_target", lambda: ("test-model", "test-provider"))
 
     server._ensure_session_db_row({"session_key": "k1", "cwd": str(tmp_path)})
 
@@ -2024,7 +2062,7 @@ def test_ensure_session_db_row_no_override_uses_global(monkeypatch):
             created.append({"model": model, "model_config": model_config})
 
     monkeypatch.setattr(server, "_get_db", lambda: _FakeDB())
-    monkeypatch.setattr(server, "_resolve_model", lambda: "global/default")
+    monkeypatch.setattr(server, "_config_model_target", lambda: ("global/default", "global-provider"))
 
     server._ensure_session_db_row({"session_key": "k1", "model_override": None})
 

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -1209,7 +1209,8 @@ def _ensure_session_db_row(session: dict) -> None:
     # so resume restores effort + fast too, not just the model name.
     override = session.get("model_override")
     override = override if isinstance(override, dict) else {}
-    row_model = str(override.get("model") or "").strip() or _resolve_model()
+    config_model, _config_provider = _config_model_target()
+    row_model = str(override.get("model") or "").strip() or config_model
     model_config: dict = {}
     for src_key, cfg_key in (
         ("model", "model"),
@@ -4250,6 +4251,8 @@ def _(rid, params: dict) -> dict:
     build_timer.daemon = True
     build_timer.start()
 
+    config_model, config_provider = _config_model_target()
+
     return _ok(
         rid,
         {
@@ -4261,16 +4264,18 @@ def _(rid, params: dict) -> dict:
                 # Reflect the per-session model override (desktop composer pick)
                 # in the immediate response so the client doesn't briefly clobber
                 # its sticky pick with the global default before the deferred
-                # build's session.info lands.
+                # build's session.info lands. For the global default, read the
+                # profile config before provision-time HERMES_MODEL env seeds so
+                # stale launch env cannot paint the footer with an old model.
                 "model": (
                     session_model_override.get("model")
                     if session_model_override
-                    else _resolve_model()
+                    else config_model
                 ),
                 **(
                     {"provider": session_model_override["provider"]}
                     if session_model_override and session_model_override.get("provider")
-                    else {}
+                    else ({"provider": config_provider} if config_provider else {})
                 ),
                 "tools": {},
                 "skills": {},

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -80,6 +80,7 @@ import SessionsPage from "@/pages/SessionsPage";
 import LogsPage from "@/pages/LogsPage";
 import AnalyticsPage from "@/pages/AnalyticsPage";
 import ModelsPage from "@/pages/ModelsPage";
+import UsagePage from "@/pages/UsagePage";
 import CronPage from "@/pages/CronPage";
 import ProfilesPage from "@/pages/ProfilesPage";
 import ProfileBuilderPage from "@/pages/ProfileBuilderPage";
@@ -134,6 +135,7 @@ const BUILTIN_ROUTES_CORE: Record<string, ComponentType> = {
   "/": RootRedirect,
   "/sessions": SessionsPage,
   "/files": FilesPage,
+  "/usage": UsagePage,
   "/analytics": AnalyticsPage,
   "/models": ModelsPage,
   "/logs": LogsPage,
@@ -168,6 +170,7 @@ const BUILTIN_NAV_REST: NavItem[] = [
     icon: MessageSquare,
   },
   { path: "/files", label: "Files", icon: FolderOpen },
+  { path: "/usage", label: "Usage & Quotas", icon: Activity },
   {
     path: "/analytics",
     labelKey: "analytics",

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -450,6 +450,10 @@ export const api = {
     fetchJSON<AnalyticsResponse>(
       appendProfileParam(`/api/analytics/usage?days=${days}`, profile),
     ),
+  getUsageQuotas: (profile = getManagementProfile()) =>
+    fetchJSON<UsageQuotasResponse>(
+      appendProfileParam("/api/analytics/usage-quotas", profile),
+    ),
   getModelsAnalytics: (days: number, profile = getManagementProfile()) =>
     fetchJSON<ModelsAnalyticsResponse>(
       appendProfileParam(`/api/analytics/models?days=${days}`, profile),
@@ -1803,6 +1807,76 @@ export interface AnalyticsResponse {
     summary: AnalyticsSkillsSummary;
     top_skills: AnalyticsSkillEntry[];
   };
+}
+
+export interface UsageProviderModel {
+  provider: string;
+  model: string;
+  base_url?: string;
+}
+
+export interface UsageProviderAuth {
+  logged_in: boolean;
+  configured: boolean;
+}
+
+export interface UsageQuotaWindow {
+  label: string;
+  used_percent: number | null;
+  reset_at: string | null;
+  detail: string | null;
+}
+
+export type UsageQuotaStatus =
+  | {
+      available: true;
+      title: string;
+      plan: string | null;
+      windows: UsageQuotaWindow[];
+      details: string[];
+    }
+  | { available: false; reason: string };
+
+export interface UsageWindowSummary {
+  sessions: number;
+  messages: number;
+  tool_calls: number;
+  api_calls: number;
+  input_tokens: number;
+  output_tokens: number;
+  cache_read_tokens: number;
+  reasoning_tokens: number;
+}
+
+export interface UsageCurrentSession {
+  id: string;
+  model: string | null;
+  billing_provider: string | null;
+  started_at: number;
+  message_count: number;
+  tool_call_count: number;
+  api_calls: number;
+  input_tokens: number;
+  output_tokens: number;
+  cache_read_tokens: number;
+  reasoning_tokens: number;
+}
+
+export interface UsageProviderBreakdown {
+  provider: string;
+  sessions: number;
+  tokens: number;
+}
+
+export interface UsageQuotasResponse {
+  primary: UsageProviderModel;
+  fallback_chain: UsageProviderModel[];
+  provider_auth: Record<string, UsageProviderAuth>;
+  account_usage: Record<string, UsageQuotaStatus>;
+  current_session: UsageCurrentSession | null;
+  usage_24h: UsageWindowSummary;
+  usage_7d: UsageWindowSummary;
+  providers_24h: UsageProviderBreakdown[];
 }
 
 export interface ActiveProfileInfo {

--- a/web/src/pages/UsagePage.tsx
+++ b/web/src/pages/UsagePage.tsx
@@ -1,0 +1,407 @@
+import { useCallback, useEffect, useLayoutEffect, useState } from "react";
+import {
+  Activity,
+  AlertCircle,
+  BarChart3,
+  Check,
+  Clock,
+  Cpu,
+  RefreshCw,
+  Shield,
+  X,
+  Zap,
+} from "lucide-react";
+import { api } from "@/lib/api";
+import type { UsageQuotasResponse } from "@/lib/api";
+import { timeAgo } from "@/lib/utils";
+import { Button } from "@nous-research/ui/ui/components/button";
+import { Spinner } from "@nous-research/ui/ui/components/spinner";
+import { Stats } from "@nous-research/ui/ui/components/stats";
+import { Card, CardContent, CardHeader, CardTitle } from "@nous-research/ui/ui/components/card";
+import { Badge } from "@nous-research/ui/ui/components/badge";
+import { usePageHeader } from "@/contexts/usePageHeader";
+import { useI18n } from "@/i18n";
+
+function formatTokens(n: number): string {
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
+  if (n >= 1_000) return `${(n / 1_000).toFixed(1)}K`;
+  return String(n);
+}
+
+function AuthBadge({ auth }: { auth?: { logged_in: boolean; configured: boolean } }) {
+  if (!auth) return <Badge tone="secondary">Unknown</Badge>;
+  if (auth.logged_in) {
+    return (
+      <Badge tone="success" className="gap-1">
+        <Check className="h-3 w-3" />
+        Authed
+      </Badge>
+    );
+  }
+  if (auth.configured) {
+    return (
+      <Badge tone="warning" className="gap-1">
+        <Shield className="h-3 w-3" />
+        Configured
+      </Badge>
+    );
+  }
+  return (
+    <Badge tone="destructive" className="gap-1">
+      <X className="h-3 w-3" />
+      Not configured
+    </Badge>
+  );
+}
+
+function ProviderCard({
+  title,
+  provider,
+  model,
+  auth,
+}: {
+  title: string;
+  provider: string;
+  model: string;
+  auth?: { logged_in: boolean; configured: boolean };
+}) {
+  return (
+    <div className="flex items-center justify-between rounded-lg border border-border bg-card px-4 py-3">
+      <div className="flex flex-col gap-0.5">
+        <span className="text-xs text-muted-foreground">{title}</span>
+        <span className="font-mono-ui text-sm">
+          {provider || "—"}
+          {model ? ` / ${model}` : ""}
+        </span>
+      </div>
+      <AuthBadge auth={auth} />
+    </div>
+  );
+}
+
+function QuotaCard({
+  provider,
+  usage,
+}: {
+  provider: string;
+  usage:
+    | { available: true; title: string; plan: string | null; windows: any[]; details: string[] }
+    | { available: false; reason: string };
+}) {
+  if (!usage.available) {
+    return (
+      <Card>
+        <CardContent className="py-6">
+          <div className="flex items-center gap-2 text-sm text-muted-foreground">
+            <AlertCircle className="h-4 w-4" />
+            <span className="font-medium">{provider}</span>
+            <span>— {usage.reason}</span>
+          </div>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <div className="flex items-center justify-between">
+          <CardTitle className="text-base">{usage.title}</CardTitle>
+          {usage.plan && <Badge tone="outline">{usage.plan}</Badge>}
+        </div>
+        <div className="text-xs text-muted-foreground">{provider}</div>
+      </CardHeader>
+      <CardContent className="flex flex-col gap-4">
+        {usage.windows.map((w, i) => (
+          <div key={i} className="flex flex-col gap-1.5">
+            <div className="flex items-center justify-between text-sm">
+              <span className="font-medium">{w.label}</span>
+              <span className="text-muted-foreground">
+                {w.used_percent != null ? `${Math.round(100 - w.used_percent)}% remaining` : w.detail || "—"}
+              </span>
+            </div>
+            {w.used_percent != null && (
+              <div className="h-2 w-full rounded-full bg-secondary">
+                <div
+                  className="h-2 rounded-full bg-primary"
+                  style={{ width: `${Math.min(100, Math.max(0, w.used_percent))}%` }}
+                />
+              </div>
+            )}
+            {w.reset_at && (
+              <span className="text-xs text-muted-foreground">
+                Resets {new Date(w.reset_at).toLocaleString()}
+              </span>
+            )}
+            {w.detail && w.used_percent == null && (
+              <span className="text-xs text-muted-foreground">{w.detail}</span>
+            )}
+          </div>
+        ))}
+        {usage.details.length > 0 && (
+          <ul className="list-disc pl-4 text-xs text-muted-foreground space-y-0.5">
+            {usage.details.map((d, i) => (
+              <li key={i}>{d}</li>
+            ))}
+          </ul>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+export default function UsagePage() {
+  const [data, setData] = useState<UsageQuotasResponse | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const { t } = useI18n();
+  const { setAfterTitle, setEnd } = usePageHeader();
+
+  const load = useCallback(() => {
+    setLoading(true);
+    setError(null);
+    api
+      .getUsageQuotas()
+      .then(setData)
+      .catch((err) => setError(String(err)))
+      .finally(() => setLoading(false));
+  }, []);
+
+  useLayoutEffect(() => {
+    setAfterTitle(
+      <Button
+        type="button"
+        ghost
+        size="icon"
+        className="text-muted-foreground hover:text-foreground"
+        onClick={load}
+        disabled={loading}
+        aria-label={t.common.refresh}
+      >
+        {loading ? <Spinner /> : <RefreshCw />}
+      </Button>,
+    );
+    setEnd(null);
+    return () => {
+      setAfterTitle(null);
+      setEnd(null);
+    };
+  }, [loading, load, setAfterTitle, setEnd, t.common.refresh]);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  const usageEntries = data ? Object.entries(data.account_usage) : [];
+
+  return (
+    <div className="flex flex-col gap-6">
+      {loading && !data && (
+        <div className="flex items-center justify-center py-24">
+          <Spinner className="text-2xl text-primary" />
+        </div>
+      )}
+
+      {error && (
+        <Card>
+          <CardContent className="py-6">
+            <p className="text-sm text-destructive text-center">{error}</p>
+          </CardContent>
+        </Card>
+      )}
+
+      {data && (
+        <>
+          {/* Provider chain */}
+          <div className="grid gap-6 lg:grid-cols-2">
+            <Card>
+              <CardHeader>
+                <div className="flex items-center gap-2">
+                  <Zap className="h-5 w-5 text-muted-foreground" />
+                  <CardTitle className="text-base">Provider Chain</CardTitle>
+                </div>
+              </CardHeader>
+              <CardContent className="flex flex-col gap-3">
+                <ProviderCard
+                  title="Primary"
+                  provider={data.primary.provider}
+                  model={data.primary.model}
+                  auth={data.provider_auth[data.primary.provider]}
+                />
+                {data.fallback_chain.length > 0 && (
+                  <div className="flex flex-col gap-2">
+                    <span className="text-xs text-muted-foreground">Fallback chain</span>
+                    {data.fallback_chain.map((fb, i) => (
+                      <ProviderCard
+                        key={`${fb.provider}-${fb.model}-${i}`}
+                        title={`#${i + 1}`}
+                        provider={fb.provider}
+                        model={fb.model}
+                        auth={data.provider_auth[fb.provider]}
+                      />
+                    ))}
+                  </div>
+                )}
+                {data.fallback_chain.length === 0 && (
+                  <p className="text-xs text-muted-foreground">No fallback providers configured.</p>
+                )}
+              </CardContent>
+            </Card>
+
+            {/* Current session */}
+            <Card>
+              <CardHeader>
+                <div className="flex items-center gap-2">
+                  <Activity className="h-5 w-5 text-muted-foreground" />
+                  <CardTitle className="text-base">Current Session</CardTitle>
+                </div>
+              </CardHeader>
+              <CardContent>
+                {data.current_session ? (
+                  <div className="flex flex-col gap-4">
+                    <div className="flex items-center justify-between text-sm">
+                      <span className="text-muted-foreground">Model</span>
+                      <span className="font-mono-ui">{data.current_session.model || "—"}</span>
+                    </div>
+                    <div className="flex items-center justify-between text-sm">
+                      <span className="text-muted-foreground">Provider</span>
+                      <span className="font-mono-ui">{data.current_session.billing_provider || "—"}</span>
+                    </div>
+                    <div className="flex items-center justify-between text-sm">
+                      <span className="text-muted-foreground">Started</span>
+                      <span>{timeAgo(data.current_session.started_at)}</span>
+                    </div>
+                    <Stats
+                      items={[
+                        { label: "Messages", value: String(data.current_session.message_count) },
+                        { label: "Tool calls", value: String(data.current_session.tool_call_count) },
+                        { label: "API calls", value: String(data.current_session.api_calls) },
+                        {
+                          label: "Tokens",
+                          value: formatTokens(
+                            data.current_session.input_tokens + data.current_session.output_tokens,
+                          ),
+                        },
+                        {
+                          label: "Cache",
+                          value: formatTokens(data.current_session.cache_read_tokens),
+                        },
+                        {
+                          label: "Reasoning",
+                          value: formatTokens(data.current_session.reasoning_tokens),
+                        },
+                      ]}
+                    />
+                  </div>
+                ) : (
+                  <p className="text-sm text-muted-foreground text-center py-6">No session data available.</p>
+                )}
+              </CardContent>
+            </Card>
+          </div>
+
+          {/* Quotas */}
+          {usageEntries.length > 0 && (
+            <div className="grid gap-6 lg:grid-cols-2">
+              {usageEntries.map(([provider, usage]) => (
+                <QuotaCard key={provider} provider={provider} usage={usage} />
+              ))}
+            </div>
+          )}
+
+          {/* Usage windows */}
+          <div className="grid gap-6 lg:grid-cols-2">
+            <Card>
+              <CardHeader>
+                <div className="flex items-center gap-2">
+                  <Clock className="h-5 w-5 text-muted-foreground" />
+                  <CardTitle className="text-base">24h Usage</CardTitle>
+                </div>
+              </CardHeader>
+              <CardContent>
+                <Stats
+                  items={[
+                    { label: "Sessions", value: String(data.usage_24h.sessions) },
+                    { label: "Messages", value: String(data.usage_24h.messages) },
+                    { label: "Tool calls", value: String(data.usage_24h.tool_calls) },
+                    { label: "API calls", value: String(data.usage_24h.api_calls) },
+                    {
+                      label: "Tokens",
+                      value: formatTokens(
+                        data.usage_24h.input_tokens + data.usage_24h.output_tokens,
+                      ),
+                    },
+                  ]}
+                />
+              </CardContent>
+            </Card>
+
+            <Card>
+              <CardHeader>
+                <div className="flex items-center gap-2">
+                  <BarChart3 className="h-5 w-5 text-muted-foreground" />
+                  <CardTitle className="text-base">7d Usage</CardTitle>
+                </div>
+              </CardHeader>
+              <CardContent>
+                <Stats
+                  items={[
+                    { label: "Sessions", value: String(data.usage_7d.sessions) },
+                    { label: "Messages", value: String(data.usage_7d.messages) },
+                    { label: "Tool calls", value: String(data.usage_7d.tool_calls) },
+                    { label: "API calls", value: String(data.usage_7d.api_calls) },
+                    {
+                      label: "Tokens",
+                      value: formatTokens(
+                        data.usage_7d.input_tokens + data.usage_7d.output_tokens,
+                      ),
+                    },
+                  ]}
+                />
+              </CardContent>
+            </Card>
+          </div>
+
+          {/* Per-provider 24h */}
+          {data.providers_24h.length > 0 && (
+            <Card>
+              <CardHeader>
+                <div className="flex items-center gap-2">
+                  <Cpu className="h-5 w-5 text-muted-foreground" />
+                  <CardTitle className="text-base">24h Provider Breakdown</CardTitle>
+                </div>
+              </CardHeader>
+              <CardContent>
+                <div className="overflow-x-auto">
+                  <table className="w-full font-mondwest normal-case text-sm">
+                    <thead>
+                      <tr className="border-b border-border text-muted-foreground text-xs">
+                        <th className="text-left py-2 pr-4 font-medium">Provider</th>
+                        <th className="text-right py-2 px-4 font-medium">Sessions</th>
+                        <th className="text-right py-2 pl-4 font-medium">Tokens</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {data.providers_24h.map((p) => (
+                        <tr
+                          key={p.provider}
+                          className="border-b border-border/50 hover:bg-secondary/20 transition-colors"
+                        >
+                          <td className="py-2 pr-4 font-mono-ui text-xs">{p.provider}</td>
+                          <td className="text-right py-2 px-4 text-muted-foreground">
+                            {p.sessions}
+                          </td>
+                          <td className="text-right py-2 pl-4">{formatTokens(p.tokens)}</td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                </div>
+              </CardContent>
+            </Card>
+          )}
+        </>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Add a dashboard Usage and Quotas page with provider chain, quota windows, current-session usage, and recent provider breakdowns.
- Add `/api/analytics/usage-quotas` and matching typed frontend API contract.
- Fix TUI session startup metadata so visible model labels prefer profile config over stale provisioning env vars.
- Make `scripts/run_tests.sh` work with Windows venv layout and UTF-8 runner output.

## Test Plan
- `scripts/run_tests.sh tests/test_tui_gateway_server.py tests/test_tui_gateway_ws.py -- -q`
- `npm run build` in `web`
- Local `GET /api/analytics/usage-quotas` smoke test returned 200
