### PR TITLE
fix(delegate): tighten background task contract

### DIFF
--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -124,6 +124,24 @@ class TestDelegateRequirements(unittest.TestCase):
         self.assertIn(f"up to {_get_max_concurrent_children()}", fn["description"])
         self.assertIn(f"max_spawn_depth={_get_max_spawn_depth()}", fn["description"])
 
+    def test_background_schema_describes_short_non_durable_async_work(self):
+        """The model-facing contract must not steer long/durable work into
+        background delegation when there is no status/log/collect surface.
+        """
+        from tools.registry import registry
+
+        defs = registry.get_definitions({"delegate_task"})
+        self.assertEqual(len(defs), 1)
+        fn = defs[0]["function"]
+        background_desc = fn["parameters"]["properties"]["background"]["description"]
+        full_contract = f"{fn['description']}\n{background_desc}"
+
+        self.assertNotIn("long-running independent work", full_contract)
+        self.assertNotIn("durable long-running work", full_contract)
+        self.assertIn("short async", background_desc.lower())
+        self.assertIn("not durable", full_contract.lower())
+        self.assertIn("terminal(background=True, notify_on_complete=True)", full_contract)
+
 
 class TestChildSystemPrompt(unittest.TestCase):
     def test_goal_only(self):
@@ -215,6 +233,28 @@ class TestDelegateTask(unittest.TestCase):
         self.assertEqual(result["results"][0]["summary"], "Result A")
         self.assertEqual(result["results"][1]["summary"], "Result B")
         self.assertIn("total_duration_seconds", result)
+
+    def test_background_dispatch_note_describes_short_non_durable_async_work(self):
+        parent = _make_mock_parent()
+        with patch("run_agent.AIAgent") as MockAgent, patch(
+            "tools.async_delegation.dispatch_async_delegation"
+        ) as mock_dispatch:
+            MockAgent.return_value = MagicMock()
+            mock_dispatch.return_value = {
+                "status": "dispatched",
+                "delegation_id": "deleg_test",
+            }
+
+            result = json.loads(
+                delegate_task(goal="Quick check", parent_agent=parent, background=True)
+            )
+
+        self.assertEqual(result["status"], "dispatched")
+        note = result["note"]
+        self.assertIn("short async", note.lower())
+        self.assertIn("not durable", note.lower())
+        self.assertNotIn("long-running independent work", note)
+        self.assertNotIn("Do not wait or poll", note)
 
     @patch("tools.delegate_tool._run_single_child")
     def test_batch_mode_accepts_json_string_tasks(self, mock_run):

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -2322,11 +2322,13 @@ def delegate_task(
                         "goal": _t["goal"],
                         "mode": "background",
                         "note": (
-                            "Subagent is running in the background. You and the "
-                            "user can keep working; the full task source and "
-                            "result will re-enter the conversation as a new "
-                            "message when it finishes. Do not wait or poll — "
-                            "just continue."
+                            "Short async subtask dispatched. You and the user "
+                            "can keep working; the task source and result will "
+                            "re-enter the conversation as a new message when it "
+                            "finishes. This is not durable and has no model-facing "
+                            "status/log/collect surface; use terminal background, "
+                            "cron, or a spawned Hermes process for longer work. "
+                            "Do not poll after dispatch — continue useful work."
                         ),
                     },
                     ensure_ascii=False,
@@ -2855,13 +2857,13 @@ def _build_top_level_description() -> str:
         "- Mechanical multi-step work with no reasoning needed -> use execute_code\n"
         "- Single tool call -> just call the tool directly\n"
         "- Tasks needing user interaction -> subagents cannot use clarify\n"
-        "- Durable long-running work that must outlive the current turn -> "
-        "use cronjob (action='create') or terminal(background=True, "
-        "notify_on_complete=True) instead. delegate_task runs SYNCHRONOUSLY "
-        "inside the parent turn: if the parent is interrupted (user sends a "
-        "new message, /stop, /new) the child is cancelled with status="
-        "'interrupted' and its work is discarded. Children cannot continue "
-        "in the background.\n\n"
+        "- Durable or long-running jobs that need live status/logs, cancellation, "
+        "collection, or must survive process/session shutdown -> use cronjob "
+        "(action='create'), terminal(background=True, notify_on_complete=True), "
+        "or a spawned Hermes process instead. Synchronous delegate_task blocks "
+        "the parent turn and is interrupted when the parent is interrupted; "
+        "background=true only detaches a single short async subtask enough to "
+        "return a later completion event, not a durable job manager.\n\n"
         "IMPORTANT:\n"
         "- Subagents have NO memory of your conversation. Pass all relevant "
         "info (file paths, error messages, constraints) via the 'context' field.\n"
@@ -3058,19 +3060,21 @@ DELEGATE_TASK_SCHEMA = {
             "background": {
                 "type": "boolean",
                 "description": (
-                    "Run the subagent asynchronously in the BACKGROUND "
-                    "instead of blocking this turn. When true, delegate_task "
-                    "returns immediately with a delegation_id; you and the "
-                    "user keep working while the subagent runs, and its full "
-                    "result re-enters the conversation as a new message when "
-                    "it finishes (similar to terminal background=true + "
-                    "notify_on_complete). The re-injected message includes the "
-                    "original goal/context so you can act on it even after "
-                    "moving on. Single-task only — cannot be combined with the "
-                    "'tasks' batch array. Use for long-running independent work "
-                    "the user shouldn't have to wait on (research, builds, "
-                    "multi-step investigations). Do NOT poll or wait after "
-                    "dispatching — just continue; the result will come to you."
+                    "Run one short async subtask without blocking this turn. "
+                    "When true, delegate_task returns immediately with a "
+                    "delegation_id; you and the user can keep working, and a "
+                    "completion event with the original goal/context is "
+                    "re-injected as a new message when the child finishes. "
+                    "This is not durable: there is no status/log/collect/cancel "
+                    "tool surface for the model, and it should not be used for "
+                    "repo-discovery + implementation + test/report lanes or "
+                    "anything likely to take more than a few minutes. For "
+                    "longer-running independent work, use "
+                    "terminal(background=True, notify_on_complete=True), cronjob, "
+                    "or a spawned Hermes process instead. Single-task only — "
+                    "cannot be combined with the 'tasks' batch array. Do not "
+                    "poll or wait after dispatching; either continue useful work "
+                    "or choose a durable primitive before dispatch."
                 ),
             },
             "acp_command": {


### PR DESCRIPTION
## Summary
- Reword the model-facing `delegate_task` contract so `background=true` is described as a short async subtask, not a durable/long-running job primitive.
- Route longer work explicitly to `terminal(background=True, notify_on_complete=True)`, cron, or a spawned Hermes process.
- Align the immediate background-dispatch tool result with the same contract.

## Scope
Deliberately tight: no new delegate tools, timeout knobs, journaling, or durable task manager in this PR. This just fixes the prompt/schema mismatch that steers agents into the wrong primitive.

## Tests
- `uv run python -m pytest tests/tools/test_delegate.py tests/tools/test_async_delegation.py -q -o 'addopts='`

Addresses #48796.
