### PR TITLE
fix(clarify): readable multi-choice prompts (no truncated dict reprs)

### DIFF
--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -4599,9 +4599,24 @@ class DiscordAdapter(BasePlatformAdapter):
             clean_choices = clean_choices[:24]
 
             if clean_choices:
+                # List the full choice text in the embed body. Discord caps
+                # button labels at 80 chars, so a long option renders as an
+                # unreadable "1. Read 3 — keep deferring nic..." stub on the
+                # button itself; without the full list here users are left
+                # guessing what each numbered option actually says. The embed
+                # field value caps at 1024 chars, so budget each line.
+                per_line_cap = max(40, (1024 - 80) // max(1, len(clean_choices)))
+                listed = []
+                for idx, choice in enumerate(clean_choices):
+                    text = choice if len(choice) <= per_line_cap else choice[: per_line_cap - 1] + "…"
+                    listed.append(f"**{idx + 1}.** {text}")
+                listed.append("✏️ **Other** — click the button below to type a custom answer.")
+                value = "\n".join(listed)
+                if len(value) > 1024:
+                    value = value[:1023] + "…"
                 embed.add_field(
                     name="Choices",
-                    value="Pick one below, or click ✏️ Other to type a custom answer.",
+                    value=value,
                     inline=False,
                 )
                 view = ClarifyChoiceView(

--- a/tests/gateway/test_discord_clarify_buttons.py
+++ b/tests/gateway/test_discord_clarify_buttons.py
@@ -384,6 +384,44 @@ class TestDiscordSendClarify:
         assert "Not connected" in (result.error or "")
 
     @pytest.mark.asyncio
+    async def test_embed_body_lists_full_choice_text(self):
+        """Buttons cap at 80 chars; the embed body must carry the full option
+        text so a long choice is readable instead of a truncated stub."""
+        adapter = _make_adapter()
+        channel = MagicMock()
+        sent_msg = MagicMock()
+        sent_msg.id = 555
+        channel.send = AsyncMock(return_value=sent_msg)
+        adapter._client.get_channel = MagicMock(return_value=channel)
+
+        long_choice = (
+            "Read 3 — keep deferring the niche lock and ship the current "
+            "milestone before committing to a single operator hat"
+        )
+        await adapter.send_clarify(
+            chat_id="9001",
+            question="Which path?",
+            choices=[long_choice, "Lock the niche now"],
+            clarify_id="cidL",
+            session_key="sk-L",
+        )
+
+        kwargs = channel.send.call_args.kwargs
+        embed = kwargs["embed"]
+        # The "Choices" field value should contain the full (untruncated)
+        # text of the long option — far longer than the 80-char button cap.
+        field_values = [
+            f.get("value", "")
+            for f in embed.fields
+            if f.get("name") == "Choices"
+        ]
+        assert field_values, "expected a Choices field"
+        value = field_values[0]
+        assert "ship the current milestone before committing" in value
+        assert "**1.**" in value and "**2.**" in value
+        assert "Other" in value
+
+    @pytest.mark.asyncio
     async def test_filters_empty_and_whitespace_choices(self):
         adapter = _make_adapter()
         channel = MagicMock()

--- a/tests/tools/test_clarify_tool.py
+++ b/tests/tools/test_clarify_tool.py
@@ -123,6 +123,61 @@ class TestClarifyToolChoicesValidation:
         assert choices_received == ["1", "2", "3"]
 
 
+class TestClarifyToolStructuredChoices:
+    """Models often pass choices as objects instead of plain strings; the tool
+    must render them as readable text, never as a Python dict repr."""
+
+    def _capture(self, choices):
+        received = []
+
+        def mock_callback(question: str, choices_in: Optional[List[str]]) -> str:
+            received.extend(choices_in or [])
+            return "answer"
+
+        clarify_tool("Pick", choices=choices, callback=mock_callback)  # type: ignore
+        return received
+
+    def test_dict_choice_never_renders_python_repr(self):
+        """A {'choice','description'} object must not become a dict repr."""
+        received = self._capture(
+            [{"choice": "a", "description": "Keep deferring the niche lock."}]
+        )
+        assert len(received) == 1
+        assert "{'" not in received[0]  # no Python dict repr leaked through
+        assert "Keep deferring the niche lock." in received[0]
+
+    def test_label_and_description_combined(self):
+        """Both halves present → 'label: description'."""
+        received = self._capture(
+            [{"choice": "a", "description": "Read 3 — keep deferring."}]
+        )
+        assert received == ["a: Read 3 — keep deferring."]
+
+    def test_description_only(self):
+        received = self._capture([{"description": "Just the description."}])
+        assert received == ["Just the description."]
+
+    def test_label_only(self):
+        received = self._capture([{"label": "Option A"}])
+        assert received == ["Option A"]
+
+    def test_duplicate_label_and_description_not_doubled(self):
+        received = self._capture([{"text": "Same", "description": "same"}])
+        assert received == ["Same"]
+
+    def test_unknown_shape_falls_back_to_json_not_repr(self):
+        """An object with no known keys still avoids single-quote dict noise."""
+        received = self._capture([{"foo": "bar"}])
+        assert received == ['{"foo": "bar"}']
+        assert "{'" not in received[0]
+
+    def test_mixed_string_and_object_choices(self):
+        received = self._capture(
+            ["plain string", {"choice": "b", "description": "structured"}]
+        )
+        assert received == ["plain string", "b: structured"]
+
+
 class TestClarifyToolCallbackHandling:
     """Tests for callback error handling."""
 

--- a/tools/clarify_tool.py
+++ b/tools/clarify_tool.py
@@ -19,6 +19,48 @@ from typing import List, Optional, Callable
 # A 5th "Other (type your answer)" option is always appended by the UI.
 MAX_CHOICES = 4
 
+# Keys models commonly use when they pass a choice as a structured object
+# instead of a plain string. Ordered by preference for the short "label" half
+# and the longer "description" half.
+_CHOICE_LABEL_KEYS = ("label", "title", "name", "text", "option", "choice", "id", "value")
+_CHOICE_DESC_KEYS = ("description", "detail", "details", "summary", "explanation", "value")
+
+
+def _coerce_choice(choice) -> str:
+    """Render a single choice as a readable string.
+
+    Models frequently ignore the "array of strings" schema and pass choices as
+    structured objects (e.g. ``{"choice": "a", "description": "..."}``). Doing a
+    naive ``str(choice)`` on those yields a Python dict repr
+    (``{'choice': 'a', 'description': '...'}``) that is noise in the CLI and
+    gets hard-truncated to an unreadable stub on platforms with short button
+    labels (Discord caps button text at 80 chars). Normalize dict-shaped
+    choices into a clean ``label: description`` (or whichever half is present)
+    so every platform shows the actual option text.
+    """
+    if isinstance(choice, str):
+        return choice.strip()
+    if isinstance(choice, dict):
+        def _first(keys):
+            for key in keys:
+                val = choice.get(key)
+                if val not in (None, "") and not isinstance(val, (dict, list)):
+                    text = str(val).strip()
+                    if text:
+                        return text
+            return ""
+
+        label = _first(_CHOICE_LABEL_KEYS)
+        desc = _first(_CHOICE_DESC_KEYS)
+        if label and desc and label.lower() != desc.lower():
+            return f"{label}: {desc}"
+        if label or desc:
+            return label or desc
+        # Fall back to a JSON object (still better than a Python repr) so the
+        # text is at least valid and free of single-quote ``{'k': 'v'}`` noise.
+        return json.dumps(choice, ensure_ascii=False)
+    return str(choice).strip()
+
 
 def clarify_tool(
     question: str,
@@ -48,7 +90,7 @@ def clarify_tool(
     if choices is not None:
         if not isinstance(choices, list):
             return tool_error("choices must be a list of strings.")
-        choices = [str(c).strip() for c in choices if str(c).strip()]
+        choices = [text for c in choices if (text := _coerce_choice(c))]
         if len(choices) > MAX_CHOICES:
             choices = choices[:MAX_CHOICES]
         if not choices:


### PR DESCRIPTION
## Summary

Reported on Discord (and reproduced in the CLI): when Hermes asks a
multiple-choice `clarify` question, the option text is cut off / unreadable,
leaving the user guessing. The prompt showed choices like
`1. {'choice': 'a', 'description': 'Read 3 — keep deferring niche lock. Ship...'`.

Two independent root causes, both reproducible on current `main`:

1. **Structured choices stringified as Python dict reprs.** Models routinely
   ignore the "array of strings" schema and pass choices as objects
   (`{"choice": "a", "description": "..."}`). `clarify_tool` did `str(c)` on
   each item, yielding `{'choice': 'a', 'description': '...'}` — noise in the
   CLI and a long string that gets hard-truncated on platforms with short
   button labels. **Fixed at the single tool-layer choke point**, so every
   surface (CLI + all gateway adapters) benefits: dict choices normalize to a
   clean `label: description` (or whichever half is present).

2. **Discord buttons cap labels at 80 chars and showed the text nowhere else.**
   Even with clean strings, a long option renders as an unreadable button stub.
   The Discord adapter now lists every numbered choice (and the Other hint) in
   the embed's `Choices` field, where the 1024-char budget fits the full text.

## Changes

- `tools/clarify_tool.py` — `_coerce_choice()` normalizes dict/object choices
  into readable strings instead of Python reprs.
- `plugins/platforms/discord/adapter.py` — `send_clarify` renders the full
  numbered choice list in the embed body.

## Test plan

- [x] `tests/tools/test_clarify_tool.py` — structured/dict choice normalization
- [x] `tests/gateway/test_discord_clarify_buttons.py` — embed body carries full
      choice text beyond the 80-char button cap
- [x] Existing clarify suites (tool, gateway, discord, telegram) still pass