### PR TITLE
fix(tui): default import signal-exit instead of named import

### DIFF
--- a/ui-tui/packages/hermes-ink/src/ink/ink.tsx
+++ b/ui-tui/packages/hermes-ink/src/ink/ink.tsx
@@ -7,7 +7,7 @@ import throttle from 'lodash-es/throttle.js'
 import React, { type ReactNode } from 'react'
 import type { FiberRoot } from 'react-reconciler'
 import { ConcurrentRoot } from 'react-reconciler/constants.js'
-import { onExit } from 'signal-exit'
+import onExit from 'signal-exit'
 
 import { flushInteractionTime } from '../bootstrap/state.js'
 import { getYogaCounters } from '../native-ts/yoga-layout/index.js'


### PR DESCRIPTION
The named import `{ onExit }` crashes in some Node/bundler configs during the TUI build - the bundler tries to resolve a named export that signal-exit does not expose at that level. The default import is what the package actually ships and works across every setup.

One-liner, zero behavioral change.