### PR TITLE
fix(update): approve npm install scripts used by update

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,12 @@
     "@streamdown/math": "^1.0.2",
     "agent-browser": "^0.26.0"
   },
+  "allowScripts": {
+    "agent-browser@0.26.0": true,
+    "esbuild@0.28.1": true,
+    "fsevents@2.3.3": true,
+    "unicode-animations@1.0.3": true
+  },
   "overrides": {
     "lodash": "4.18.1",
     "@assistant-ui/store": "0.2.13",


### PR DESCRIPTION
## Summary
- add pinned `allowScripts` entries for the packages Hermes update currently installs
- cover both the repo-root `--workspaces=false` install and the `ui-tui`/`web` workspace install path
- keep the policy limited to the exact versions currently exercised on main

## Testing
- `npm install --dry-run --no-fund --no-audit --progress=false --workspaces=false`
- `npm install --dry-run --no-fund --no-audit --progress=false --workspace ui-tui --workspace web`
- `git diff --check`

Closes #43997