### PR TITLE
fix(agent): persist_session mutates copy, not live messages (#48677)

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -1500,12 +1500,25 @@ class AIAgent:
         """Save session state to both JSON log and SQLite on any exit path.
 
         Ensures conversations are never lost, even on errors or early returns.
+
+        Operates on a *shallow copy* of *messages* so that the persist
+        override (``_apply_persist_user_message_override``) does not mutate
+        the live message list used by the API call.  Without this, the
+        early-crash-resilience persist strips observed group-chat context
+        from the user message *before* ``api_messages`` is built, silently
+        dropping it (#48677).
         """
-        self._drop_trailing_empty_response_scaffolding(messages)
-        self._apply_persist_user_message_override(messages)
-        self._session_messages = messages
-        self._save_session_log(messages)
-        self._flush_messages_to_session_db(messages, conversation_history)
+        # Shallow-copy: each dict is a new dict pointing at the same
+        # inner values.  _apply_persist_user_message_override only
+        # overwrites string-valued ``content`` keys, so a shallow copy
+        # is sufficient — the override's ``msg["content"] = override``
+        # writes to the copy, not the original.
+        persist_messages = [m.copy() for m in messages]
+        self._drop_trailing_empty_response_scaffolding(persist_messages)
+        self._apply_persist_user_message_override(persist_messages)
+        self._session_messages = persist_messages
+        self._save_session_log(persist_messages)
+        self._flush_messages_to_session_db(persist_messages, conversation_history)
 
     def _drop_trailing_empty_response_scaffolding(self, messages: List[Dict]) -> None:
         """Remove private empty-response retry/failure scaffolding from transcript tails.

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -6243,7 +6243,15 @@ class TestPersistUserMessageOverride:
 
         agent._persist_session(messages, [])
 
-        assert messages[0]["content"] == "Hello there"
+        # The original messages list must NOT be mutated — the persist
+        # override operates on a shallow copy so the live list keeps the
+        # original content for the API call (#48677).
+        assert (
+            messages[0]["content"]
+            == "[Voice input — respond concisely and conversationally, "
+            "2-3 sentences max. No code blocks or markdown.] Hello there"
+        )
+        # But the DB write must get the override.
         first_db_write = agent._session_db.append_message.call_args_list[0].kwargs
         assert first_db_write["content"] == "Hello there"
 


### PR DESCRIPTION
Fixes #48677. The early-crash-resilience persist in build_turn_context called _apply_persist_user_message_override on the live messages list, stripping observed group-chat context before the API call was built. Now _persist_session works on a shallow copy so the override only affects persistence, not the API request.