### PR TITLE
feat(composer): @symbol: context mention — fuzzy jump to a code symbol

### DIFF
--- a/apps/desktop/src/app/chat/composer/hooks/use-at-completions.ts
+++ b/apps/desktop/src/app/chat/composer/hooks/use-at-completions.ts
@@ -6,12 +6,13 @@ import type { HermesGateway } from '@/hermes'
 import type { CompletionEntry, CompletionPayload } from './use-live-completion-adapter'
 import { useLiveCompletionAdapter } from './use-live-completion-adapter'
 
-const KIND_RE = /^@(file|folder|url|image|tool|git):(.*)$/
-const REF_STARTERS = new Set(['file', 'folder', 'url', 'image', 'tool', 'git'])
+const KIND_RE = /^@(file|folder|url|image|tool|git|symbol):(.*)$/
+const REF_STARTERS = new Set(['file', 'folder', 'symbol', 'url', 'image', 'tool', 'git'])
 
 const STARTER_META: Record<string, string> = {
   file: 'Attach a file reference',
   folder: 'Attach a folder reference',
+  symbol: 'Jump to a symbol',
   url: 'Attach a URL reference',
   image: 'Attach an image reference',
   tool: 'Attach a tool reference',

--- a/apps/desktop/src/app/chat/composer/trigger-popover.tsx
+++ b/apps/desktop/src/app/chat/composer/trigger-popover.tsx
@@ -16,6 +16,7 @@ const AT_ICON_BY_TYPE: Record<string, string> = {
   image: 'file-media',
   simple: 'symbol-misc',
   staged: 'diff-added',
+  symbol: 'symbol-method',
   tool: 'tools',
   url: 'globe'
 }

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -7859,3 +7859,85 @@ def test_start_agent_build_passes_session_model_override(monkeypatch):
         assert session["agent"].model == "claude-sonnet-4.6"
     finally:
         server._sessions.clear()
+
+
+def _init_symbol_repo(tmp_path):
+    """A small multi-language repo for symbol-scan tests."""
+    root = tmp_path / "symrepo"
+    root.mkdir()
+    subprocess.run(["git", "init", "-q"], cwd=root, check=True)
+    (root / "mod.py").write_text(
+        "def alpha_fn():\n    pass\n\nclass BetaClass:\n    def gamma_method(self):\n        pass\n",
+        encoding="utf-8",
+    )
+    (root / "app.ts").write_text(
+        "export function deltaFn() {}\n"
+        "export const epsilonArrow = () => 1\n"
+        "export class ZetaClass {}\n"
+        "export interface EtaShape { x: number }\n",
+        encoding="utf-8",
+    )
+    (root / "lib.go").write_text(
+        "package lib\n\nfunc ThetaFunc() {}\n\ntype IotaStruct struct {}\n",
+        encoding="utf-8",
+    )
+    # Stage so git ls-files sees them.
+    subprocess.run(["git", "add", "-A"], cwd=root, check=True)
+    return str(root)
+
+
+def test_scan_symbols_extracts_multilang_definitions(tmp_path):
+    root = _init_symbol_repo(tmp_path)
+    server._symbol_cache.clear()
+
+    syms = server._scan_symbols(root)
+    by_name = {name: (kind, rel) for name, kind, rel in syms}
+
+    # Python
+    assert "alpha_fn" in by_name and by_name["alpha_fn"][1] == "mod.py"
+    assert "BetaClass" in by_name
+    assert "gamma_method" in by_name
+    # TypeScript
+    assert "deltaFn" in by_name and by_name["deltaFn"][1] == "app.ts"
+    assert "epsilonArrow" in by_name
+    assert "ZetaClass" in by_name
+    assert "EtaShape" in by_name
+    # Go
+    assert "ThetaFunc" in by_name and by_name["ThetaFunc"][1] == "lib.go"
+    assert "IotaStruct" in by_name
+
+
+def test_scan_symbols_is_cached(tmp_path):
+    root = _init_symbol_repo(tmp_path)
+    server._symbol_cache.clear()
+
+    first = server._scan_symbols(root)
+    # A second call within the TTL returns the same cached list object.
+    second = server._scan_symbols(root)
+    assert first is second
+
+
+def test_complete_path_symbol_query_returns_file_refs(tmp_path):
+    root = _init_symbol_repo(tmp_path)
+    server._symbol_cache.clear()
+
+    with patch.object(server, "_completion_cwd", return_value=root):
+        res = server._methods["complete.path"]("r-sym", {"word": "@symbol:Beta", "cwd": root})
+
+    items = res["result"]["items"]
+    # The fuzzy query 'Beta' should surface BetaClass, inserting a @file ref.
+    betas = [it for it in items if it.get("display") == "BetaClass"]
+    assert betas, f"BetaClass not found in {[i.get('display') for i in items]}"
+    assert betas[0]["text"].startswith("@file:")
+    assert "mod.py" in betas[0]["text"]
+    assert "class" in betas[0]["meta"]
+
+
+def test_complete_path_empty_at_lists_symbol_starter(tmp_path):
+    root = _init_symbol_repo(tmp_path)
+    with patch.object(server, "_completion_cwd", return_value=root):
+        res = server._methods["complete.path"]("r-at", {"word": "@", "cwd": root})
+
+    texts = {it["text"] for it in res["result"]["items"]}
+    assert "@symbol:" in texts
+

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -8,6 +8,7 @@ import json
 import logging
 import os
 import queue
+import re
 import subprocess
 import sys
 import threading
@@ -9036,6 +9037,96 @@ _FUZZY_FALLBACK_EXCLUDES = frozenset(
 _fuzzy_cache_lock = threading.Lock()
 _fuzzy_cache: dict[str, tuple[float, list[str]]] = {}
 
+# Symbol index for `@symbol:` completion. Cached per-root with a longer TTL than
+# the file list (symbol scans are heavier). Each entry: (name, kind, relpath).
+_SYMBOL_CACHE_TTL_S = 15.0
+_SYMBOL_MAX_FILES = 4000
+_SYMBOL_MAX_RESULTS = 4000
+_symbol_cache_lock = threading.Lock()
+_symbol_cache: dict[str, tuple[float, list[tuple[str, str, str]]]] = {}
+
+# Language-agnostic-ish symbol patterns: definitions of functions / classes /
+# types / methods across common languages. Regex-based (no parser dependency) —
+# a pragmatic mini-ctags. Each pattern's group(1) is the symbol name.
+_SYMBOL_PATTERNS: tuple[tuple[str, "re.Pattern[str]"], ...] = (
+    # Python
+    ("def", re.compile(r"^\s*(?:async\s+)?def\s+([A-Za-z_]\w*)")),
+    ("class", re.compile(r"^\s*class\s+([A-Za-z_]\w*)")),
+    # JS / TS — function decls, classes, exported const arrow fns, TS types
+    ("func", re.compile(r"^\s*(?:export\s+)?(?:async\s+)?function\s+([A-Za-z_$][\w$]*)")),
+    ("class", re.compile(r"^\s*(?:export\s+(?:default\s+)?)?(?:abstract\s+)?class\s+([A-Za-z_$][\w$]*)")),
+    ("const", re.compile(r"^\s*(?:export\s+)?const\s+([A-Za-z_$][\w$]*)\s*=\s*(?:async\s*)?(?:\([^)]*\)|[A-Za-z_$][\w$]*)\s*=>")),
+    ("type", re.compile(r"^\s*(?:export\s+)?(?:type|interface)\s+([A-Za-z_$][\w$]*)")),
+    # Go
+    ("func", re.compile(r"^\s*func\s+(?:\([^)]*\)\s*)?([A-Za-z_]\w*)")),
+    ("type", re.compile(r"^\s*type\s+([A-Za-z_]\w*)\s+(?:struct|interface)")),
+    # Rust
+    ("fn", re.compile(r"^\s*(?:pub\s+)?(?:async\s+)?fn\s+([A-Za-z_]\w*)")),
+    ("struct", re.compile(r"^\s*(?:pub\s+)?(?:struct|enum|trait)\s+([A-Za-z_]\w*)")),
+    # Ruby
+    ("def", re.compile(r"^\s*def\s+([A-Za-z_]\w*[!?=]?)")),
+    # Java / C# / C++ — best-effort method/type signatures
+    ("type", re.compile(r"^\s*(?:public|private|protected|internal)?\s*(?:static\s+)?(?:final\s+)?(?:class|interface|enum|struct)\s+([A-Za-z_]\w*)")),
+)
+
+_SYMBOL_EXTS = {
+    ".py", ".pyi", ".js", ".jsx", ".ts", ".tsx", ".mjs", ".cjs",
+    ".go", ".rs", ".rb", ".java", ".cs", ".cc", ".cpp", ".cxx",
+    ".h", ".hpp", ".c", ".kt", ".swift", ".php", ".scala",
+}
+
+
+def _scan_symbols(root: str) -> list[tuple[str, str, str]]:
+    """Return ``(name, kind, relpath)`` symbol definitions across the repo.
+
+    Regex-based, bounded, cached per-root. Reuses ``_list_repo_files`` for the
+    file set (so it honours git ignore + the workspace scope), reads only files
+    with a known source extension, and stops at ``_SYMBOL_MAX_RESULTS``.
+    """
+    now = time.monotonic()
+    with _symbol_cache_lock:
+        cached = _symbol_cache.get(root)
+        if cached and now - cached[0] < _SYMBOL_CACHE_TTL_S:
+            return cached[1]
+
+    out: list[tuple[str, str, str]] = []
+    seen: set[tuple[str, str]] = set()
+    files = [f for f in _list_repo_files(root) if os.path.splitext(f)[1].lower() in _SYMBOL_EXTS]
+
+    for rel in files[:_SYMBOL_MAX_FILES]:
+        if len(out) >= _SYMBOL_MAX_RESULTS:
+            break
+        abs_path = os.path.join(root, rel)
+        try:
+            # Bound per-file work: skip very large files, cap lines scanned.
+            if os.path.getsize(abs_path) > 1_500_000:
+                continue
+            with open(abs_path, "r", encoding="utf-8", errors="ignore") as fh:
+                for i, line in enumerate(fh):
+                    if i > 6000:
+                        break
+                    if len(line) > 400:
+                        continue
+                    for kind, pattern in _SYMBOL_PATTERNS:
+                        m = pattern.match(line)
+                        if m:
+                            name = m.group(1)
+                            key = (name, rel)
+                            if key in seen:
+                                continue
+                            seen.add(key)
+                            out.append((name, kind, rel))
+                            break
+                    if len(out) >= _SYMBOL_MAX_RESULTS:
+                        break
+        except (OSError, ValueError):
+            continue
+
+    with _symbol_cache_lock:
+        _symbol_cache[root] = (now, out)
+
+    return out
+
 
 def _list_repo_files(root: str) -> list[str]:
     """Return file paths relative to ``root``.
@@ -9200,9 +9291,45 @@ def _(rid, params: dict) -> dict:
                 {"text": "@staged", "display": "@staged", "meta": "staged diff"},
                 {"text": "@file:", "display": "@file:", "meta": "attach file"},
                 {"text": "@folder:", "display": "@folder:", "meta": "attach folder"},
+                {"text": "@symbol:", "display": "@symbol:", "meta": "jump to a symbol"},
                 {"text": "@url:", "display": "@url:", "meta": "fetch url"},
                 {"text": "@git:", "display": "@git:", "meta": "git log"},
             ]
+            return _ok(rid, {"items": items})
+
+        # `@symbol:` — fuzzy search over a regex-scanned symbol index. Picking an
+        # item inserts a `@file:` ref to the symbol's file, so the agent gets the
+        # right file context (reusing the existing ref-resolution path) while the
+        # popover shows symbol names + their location.
+        if is_context and query in {"symbol", "symbols"}:
+            sym_query = ""
+            is_symbol = True
+        elif is_context and query.startswith(("symbol:", "symbols:")):
+            _, _, sym_query = query.partition(":")
+            is_symbol = True
+        else:
+            is_symbol = False
+            sym_query = ""
+
+        if is_symbol:
+            ranked_syms: list[tuple[tuple[int, int], str, str, str]] = []
+            for name, kind, rel in _scan_symbols(root):
+                rank = _fuzzy_basename_rank(name, sym_query.strip())
+                if rank is None:
+                    continue
+                ranked_syms.append((rank, name, kind, rel))
+
+            ranked_syms.sort(key=lambda r: (r[0], len(r[1]), r[1]))
+            for _rank, name, kind, rel in ranked_syms[:50]:
+                items.append(
+                    {
+                        # Insert a @file ref so the agent loads the file; the
+                        # display shows the symbol name + kind + location.
+                        "text": f"@file:{_format_ref_value(rel)}",
+                        "display": name,
+                        "meta": f"{kind} · {rel}",
+                    }
+                )
             return _ok(rid, {"items": items})
 
         # Accept both `@folder:path` and the bare `@folder` form so the user


### PR DESCRIPTION
## What

The composer already supports a rich set of context mentions — `@file:` (with Cmd-P-style fuzzy basename search), `@folder:`, `@url:`, `@git:`, `@image:`, `@tool:`, `@diff`, `@staged`. This adds the one Cursor mention that was missing: **`@symbol:`** — fuzzy-search a **function / class / type definition** across the repo and attach its file.

## Gateway — `tui_gateway/server.py`

- **`_scan_symbols(root)`** — a regex-based mini-ctags over the existing `_list_repo_files` (so it honours git-ignore + the workspace scope). Extracts function / class / type / method definitions across **Python, JS/TS, Go, Rust, Ruby, Java/C#/C++** and friends. Fully **bounded** (file count, file size, lines/file, result cap) and **cached per-root** with a 15s TTL, mirroring the existing file-list cache. No parser dependency.
- **`complete.path`** — `@symbol:` (and bare `@symbol`) fuzzy-ranks the index via the existing `_fuzzy_basename_rank` and returns items whose `text` is a **`@file:` ref to the symbol's file** (reusing the existing ref-resolution path) while `display` is the symbol name and `meta` is `"kind · path"`. `@symbol:` is also added to the empty-`@` starter list.
- Added a module-level `import re` — the file previously imported `re` only locally (as `_re`) inside functions; the new module-level symbol patterns need it. No conflict with the aliased local imports.

## Renderer

- `use-at-completions.ts` — `symbol` added to `KIND_RE` + `REF_STARTERS` + starter meta so `@symbol:` is offered and classified.
- `trigger-popover.tsx` — `symbol-method` codicon for the new type.

## Tests

- `test_tui_gateway_server.py`: `_scan_symbols` extracts multi-language defs (Python/TS/Go), is cached (identity check), `@symbol:Beta` returns a `@file:` ref to the right file with the right kind, and `@` lists the `@symbol:` starter. **4 new, all green.**

`py_compile` clean, `tsc --noEmit` clean, `eslint` clean.

## Design notes

- **Why `@symbol:` inserts a `@file:` ref** rather than a new ref kind: it reuses the entire existing ref-resolution + attachment pipeline, so the agent gets the symbol's file as context with zero new wiring. The popover still shows the symbol name and location, so it reads like a symbol jump.
- **Regex, not tree-sitter** — deliberate. It's dependency-free, fast, bounded, and good enough for "find the def named X." A parser-backed index (or Puppetmaster CodeGraph, which Cary already runs) could later replace `_scan_symbols` behind the same RPC without touching the renderer.
- Validated via unit tests against real temp repos; not yet click-tested in a packaged build.
