### PR TITLE
feat(desktop): first-class Plan mode toggle in the composer

### DIFF
--- a/apps/desktop/src/app/chat/composer/controls.tsx
+++ b/apps/desktop/src/app/chat/composer/controls.tsx
@@ -10,6 +10,7 @@ import { cn } from '@/lib/utils'
 
 import type { ConversationStatus } from './hooks/use-voice-conversation'
 import { ModelPill } from './model-pill'
+import { PlanModePill } from './plan-mode-pill'
 import type { ChatBarState, VoiceStatus } from './types'
 
 export const ICON_BTN = 'size-(--composer-control-size) shrink-0 rounded-md'
@@ -83,6 +84,7 @@ export function ComposerControls({
 
   return (
     <div className="ml-auto flex shrink-0 items-center gap-(--composer-control-gap)">
+      <PlanModePill disabled={disabled} />
       <ModelPill disabled={disabled} model={state.model} />
       {/* While the agent runs and the user is typing, steer takes over the mic's
           slot rather than crowding the row with an extra button. */}

--- a/apps/desktop/src/app/chat/composer/index.tsx
+++ b/apps/desktop/src/app/chat/composer/index.tsx
@@ -53,6 +53,7 @@ import {
 } from '@/store/composer-queue'
 import { $statusItemsBySession } from '@/store/composer-status'
 import { notify } from '@/store/notifications'
+import { applyPlanMode } from '@/store/plan-mode'
 import { $gatewayState, $messages, setSessionPickerOpen } from '@/store/session'
 import { $threadScrolledUp } from '@/store/thread-scroll'
 import { useTheme } from '@/themes'
@@ -1546,13 +1547,16 @@ export function ChatBar({
     setQueueEdit(null)
   }, [activeQueueSessionKey, editingQueuedPrompt, queueEdit]) // eslint-disable-line react-hooks/exhaustive-deps
 
-  const dispatchSubmit = (text: string, attachments?: ComposerAttachment[]) => {
+  const dispatchSubmit = (rawText: string, attachments?: ComposerAttachment[]) => {
+    // Plan mode (when on) routes the message through the /plan skill — applied
+    // here so it covers every submit path (Enter, send button, queue drain).
+    const text = applyPlanMode(rawText)
     const submittedScope = activeQueueSessionKeyRef.current
     const submittedAttachments = attachments ?? []
 
     const restore = () => {
-      loadIntoComposer(text, submittedAttachments)
-      stashAt(activeQueueSessionKeyRef.current, text, submittedAttachments)
+      loadIntoComposer(rawText, submittedAttachments)
+      stashAt(activeQueueSessionKeyRef.current, rawText, submittedAttachments)
     }
 
     void Promise.resolve(attachments ? onSubmit(text, { attachments }) : onSubmit(text))

--- a/apps/desktop/src/app/chat/composer/plan-mode-pill.tsx
+++ b/apps/desktop/src/app/chat/composer/plan-mode-pill.tsx
@@ -1,0 +1,41 @@
+import { useStore } from '@nanostores/react'
+
+import { Button } from '@/components/ui/button'
+import { Codicon } from '@/components/ui/codicon'
+import { Tip } from '@/components/ui/tooltip'
+import { useI18n } from '@/i18n'
+import { cn } from '@/lib/utils'
+import { $planMode, togglePlanMode } from '@/store/plan-mode'
+
+/**
+ * Plan-mode toggle pill (Cursor-style). When on, the composer routes each
+ * message through the `/plan` skill — the agent writes an actionable plan to
+ * `.hermes/plans/` instead of executing. Cache-safe: it only prepends `/plan`
+ * to the submitted text.
+ */
+export function PlanModePill({ disabled }: { disabled: boolean }) {
+  const c = useI18n().t.composer
+  const on = useStore($planMode)
+
+  return (
+    <Tip label={on ? c.planModeOnHint : c.planModeOffHint}>
+      <Button
+        aria-label={c.planMode}
+        aria-pressed={on}
+        className={cn(
+          'h-(--composer-control-size) shrink-0 gap-1 rounded-md px-2 text-xs font-normal transition-colors',
+          on
+            ? 'bg-(--ui-accent,#3b82f6)/15 text-(--ui-accent,#3b82f6) hover:bg-(--ui-accent,#3b82f6)/25'
+            : 'text-(--ui-text-tertiary) hover:bg-(--chrome-action-hover) hover:text-foreground'
+        )}
+        disabled={disabled}
+        onClick={() => togglePlanMode()}
+        type="button"
+        variant="ghost"
+      >
+        <Codicon name="checklist" size="0.85rem" />
+        <span>{c.planMode}</span>
+      </Button>
+    </Tip>
+  )
+}

--- a/apps/desktop/src/app/hooks/use-keybinds.ts
+++ b/apps/desktop/src/app/hooks/use-keybinds.ts
@@ -17,6 +17,7 @@ import {
   togglePanesFlipped,
   toggleSidebarOpen
 } from '@/store/layout'
+import { togglePlanMode } from '@/store/plan-mode'
 import {
   $newChatProfile,
   cycleProfile,
@@ -155,6 +156,7 @@ export function useKeybinds(deps: KeybindRuntimeDeps): void {
       }
     },
     'view.showFiles': showFiles,
+    'view.togglePlanMode': () => togglePlanMode(),
     'view.showTerminal': () => setTerminalTakeover(!$terminalTakeover.get()),
     'view.flipPanes': togglePanesFlipped,
 

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -208,6 +208,7 @@ export const en: Translations = {
       'view.toggleSidebar': 'Toggle sessions sidebar',
       'view.toggleRightSidebar': 'Toggle file browser',
       'view.showFiles': 'Show file browser',
+      'view.togglePlanMode': 'Toggle plan mode',
       'view.showTerminal': 'Show terminal',
       'view.terminalSelection': 'Send terminal selection to composer',
       'view.closePreviewTab': 'Close preview tab',
@@ -1223,6 +1224,9 @@ export const en: Translations = {
       'Adjust or continue'
     ],
     startVoice: 'Start voice conversation',
+    planMode: 'Plan',
+    planModeOnHint: 'Plan mode on — messages are routed to /plan (writes a plan, no execution). Click to turn off.',
+    planModeOffHint: 'Plan mode — route messages to /plan to get an actionable plan instead of execution.',
     queueMessage: 'Queue message',
     steer: 'Steer the current run',
     stop: 'Stop',

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -1352,6 +1352,9 @@ export const ja = defineLocale({
       '調整または続行'
     ],
     startVoice: '音声会話を開始',
+    planMode: 'プラン',
+    planModeOnHint: 'プランモード オン — メッセージは /plan に送られます（実行せずプランを作成）。クリックでオフ。',
+    planModeOffHint: 'プランモード — メッセージを /plan に送り、実行の代わりに実行可能なプランを取得します。',
     queueMessage: 'メッセージをキューに入れる',
     stop: '停止',
     send: '送信',

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -935,6 +935,9 @@ export interface Translations {
     newSessionPlaceholders: readonly string[]
     followUpPlaceholders: readonly string[]
     startVoice: string
+    planMode: string
+    planModeOnHint: string
+    planModeOffHint: string
     queueMessage: string
     steer: string
     stop: string

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -1306,6 +1306,9 @@ export const zhHant = defineLocale({
       '調整或繼續'
     ],
     startVoice: '開始語音對話',
+    planMode: '計畫',
+    planModeOnHint: '計畫模式已開啟 — 訊息將路由到 /plan（撰寫計畫，不執行）。點擊關閉。',
+    planModeOffHint: '計畫模式 — 將訊息路由到 /plan，取得可執行的計畫而非直接執行。',
     queueMessage: '排隊訊息',
     stop: '停止',
     send: '傳送',

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -1410,6 +1410,9 @@ export const zh: Translations = {
       '调整或继续'
     ],
     startVoice: '开始语音对话',
+    planMode: '计划',
+    planModeOnHint: '计划模式已开启 — 消息将路由到 /plan（编写计划，不执行）。点击关闭。',
+    planModeOffHint: '计划模式 — 将消息路由到 /plan，获取可执行的计划而非直接执行。',
     queueMessage: '排队消息',
     steer: '引导当前运行',
     stop: '停止',

--- a/apps/desktop/src/lib/keybinds/actions.ts
+++ b/apps/desktop/src/lib/keybinds/actions.ts
@@ -90,6 +90,7 @@ export const KEYBIND_ACTIONS: readonly KeybindActionMeta[] = [
   { id: 'view.toggleSidebar', category: 'view', defaults: ['mod+b'] },
   { id: 'view.toggleRightSidebar', category: 'view', defaults: ['mod+j'] },
   { id: 'view.showFiles', category: 'view', defaults: [] },
+  { id: 'view.togglePlanMode', category: 'view', defaults: ['mod+shift+p'] },
   { id: 'view.showTerminal', category: 'view', defaults: TERMINAL_TOGGLE_DEFAULTS },
   // ⌘\ — the backslash reads like a mirror line flipping the layout.
   { id: 'view.flipPanes', category: 'view', defaults: ['mod+\\'] },

--- a/apps/desktop/src/store/plan-mode.test.ts
+++ b/apps/desktop/src/store/plan-mode.test.ts
@@ -1,0 +1,57 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+
+import { $planMode, applyPlanMode, setPlanMode, togglePlanMode } from './plan-mode'
+
+beforeEach(() => {
+  setPlanMode(false)
+})
+
+afterEach(() => {
+  setPlanMode(false)
+})
+
+describe('plan mode toggle', () => {
+  it('toggles on and off', () => {
+    expect($planMode.get()).toBe(false)
+    togglePlanMode()
+    expect($planMode.get()).toBe(true)
+    togglePlanMode()
+    expect($planMode.get()).toBe(false)
+  })
+})
+
+describe('applyPlanMode', () => {
+  it('is a no-op when plan mode is off', () => {
+    setPlanMode(false)
+    expect(applyPlanMode('build the thing')).toBe('build the thing')
+  })
+
+  it('prepends /plan when on', () => {
+    setPlanMode(true)
+    expect(applyPlanMode('build the thing')).toBe('/plan build the thing')
+  })
+
+  it('preserves leading whitespace in the original text', () => {
+    setPlanMode(true)
+    // The raw text is kept after the directive (only trimStart is inspected).
+    expect(applyPlanMode('  hello')).toBe('/plan   hello')
+  })
+
+  it('never hijacks an explicit slash command', () => {
+    setPlanMode(true)
+    expect(applyPlanMode('/help')).toBe('/help')
+    expect(applyPlanMode('  /resume abc')).toBe('  /resume abc')
+  })
+
+  it('leaves an empty / whitespace-only submission untouched', () => {
+    setPlanMode(true)
+    expect(applyPlanMode('')).toBe('')
+    expect(applyPlanMode('   ')).toBe('   ')
+  })
+
+  it('does not double-prefix a message that already starts with /plan', () => {
+    setPlanMode(true)
+    // /plan starts with '/', so the slash-guard prevents a second prefix.
+    expect(applyPlanMode('/plan do x')).toBe('/plan do x')
+  })
+})

--- a/apps/desktop/src/store/plan-mode.ts
+++ b/apps/desktop/src/store/plan-mode.ts
@@ -1,0 +1,44 @@
+import { atom } from 'nanostores'
+
+import { persistBoolean, storedBoolean } from '@/lib/storage'
+
+// Plan mode (Cursor-style): when on, each submitted message is routed through
+// the `/plan` skill — the agent writes an actionable markdown plan to
+// `.hermes/plans/` instead of executing. This is purely a composer-side
+// affordance: it prepends the `/plan` directive to the message text, so it is
+// cache-safe (no system-prompt mutation, no toolset swap mid-conversation).
+
+const PLAN_MODE_KEY = 'hermes.desktop.planMode'
+
+export const $planMode = atom(storedBoolean(PLAN_MODE_KEY, false))
+
+$planMode.subscribe(on => persistBoolean(PLAN_MODE_KEY, on))
+
+export function setPlanMode(on: boolean): void {
+  $planMode.set(on)
+}
+
+export function togglePlanMode(): void {
+  $planMode.set(!$planMode.get())
+}
+
+/**
+ * Apply plan-mode routing to a raw composer submission. When plan mode is on
+ * and the text isn't already a slash command (so an explicit `/help`, `/resume`,
+ * etc. still wins), prefix it with `/plan ` so the gateway dispatches the plan
+ * skill. A bare empty submission is left untouched.
+ */
+export function applyPlanMode(text: string): string {
+  if (!$planMode.get()) {
+    return text
+  }
+
+  const trimmedStart = text.trimStart()
+
+  // Don't double-prefix, and never hijack an explicit slash command.
+  if (!trimmedStart || trimmedStart.startsWith('/')) {
+    return text
+  }
+
+  return `/plan ${text}`
+}


### PR DESCRIPTION
## What

A Cursor-style **Plan mode**: a toggle pill in the composer control row (and a **⌘⇧P** hotkey) that routes each message through the `/plan` skill — the agent writes an actionable plan to `.hermes/plans/` instead of executing.

## Cache-safe by design

Plan mode is purely a **composer-side affordance**. When on, the submit path prepends `/plan ` to the message text — **no system-prompt mutation, no toolset swap mid-conversation**, so per-conversation prompt caching is preserved (per AGENTS.md). The `/plan` skill already exists and is dispatched by the gateway; this just surfaces it as a **sticky mode** instead of a one-off slash command.

## Changes

- **`store/plan-mode.ts`** — `$planMode` (persisted via `storedBoolean`), toggle/set, and `applyPlanMode`: prepends `/plan ` only when on, the text isn't empty, and isn't already an explicit slash command (so `/help`, `/resume`, an explicit `/plan` still win; no double-prefix).
- **`composer/index.tsx`** — `dispatchSubmit` applies plan-mode routing to the raw text, covering every submit path (Enter, send button, queue drain). A rejected submit restores the original (un-prefixed) text.
- **`composer/plan-mode-pill.tsx` + `controls.tsx`** — the toggle pill, left of the model pill, accented when on, with on/off tooltips.
- **⌘⇧P** hotkey (`view.togglePlanMode`) + keybind-cheatsheet label.
- i18n: `planMode` / `planModeOnHint` / `planModeOffHint` in all 4 locales.

## Tests

- `store/plan-mode.test.ts` (7): toggle, no-op when off, prepend when on, whitespace preserved, never hijacks a slash command, empty untouched, no double-prefix.

`tsc --noEmit` clean, `eslint` clean.

## Design notes

- **Why a sticky mode and not just `/plan`** — Cursor's value is that you flip planning on and *stay* in it across several messages while you iterate on the plan, then flip it off to execute. Typing `/plan` every message is the friction this removes.
- **No backend change** — the plan skill, its `.hermes/plans/` output, and the slash dispatch already exist. This is the missing UI affordance only.
- Validated via unit tests; not yet click-tested in a packaged build.
