### PR TITLE
fix(memory): discover category-nested user providers

### DIFF
--- a/plugins/memory/__init__.py
+++ b/plugins/memory/__init__.py
@@ -3,7 +3,8 @@
 Scans two directories for memory provider plugins:
 
 1. Bundled providers: ``plugins/memory/<name>/`` (shipped with hermes-agent)
-2. User-installed providers: ``$HERMES_HOME/plugins/<name>/``
+2. User-installed providers: ``$HERMES_HOME/plugins/<name>/`` and
+   ``$HERMES_HOME/plugins/<category>/<name>/``
 
 Each subdirectory must contain ``__init__.py`` with a class implementing
 the MemoryProvider ABC.  On name collisions, bundled providers take
@@ -106,17 +107,32 @@ def _iter_provider_dirs() -> List[Tuple[str, Path]]:
             seen.add(child.name)
             dirs.append((child.name, child))
 
-    # 2. User-installed providers ($HERMES_HOME/plugins/<name>/)
+    # 2. User-installed providers:
+    #    $HERMES_HOME/plugins/<name>/ and $HERMES_HOME/plugins/<category>/<name>/
     user_dir = _get_user_plugins_dir()
     if user_dir:
         for child in sorted(user_dir.iterdir()):
             if not child.is_dir() or child.name.startswith(("_", ".")):
                 continue
-            if child.name in seen:
-                continue  # bundled takes precedence
-            if not _is_memory_provider_dir(child):
-                continue  # skip non-memory plugins
-            dirs.append((child.name, child))
+            if _is_memory_provider_dir(child):
+                if child.name in seen:
+                    continue  # bundled takes precedence
+                seen.add(child.name)
+                dirs.append((child.name, child))
+                continue
+
+            # Mirror the runtime plugin loader's category-aware layout:
+            # a top-level directory without plugin files may be a namespace
+            # such as plugins/memory/<provider>/.
+            for grandchild in sorted(child.iterdir()):
+                if not grandchild.is_dir() or grandchild.name.startswith(("_", ".")):
+                    continue
+                if grandchild.name in seen:
+                    continue
+                if not _is_memory_provider_dir(grandchild):
+                    continue
+                seen.add(grandchild.name)
+                dirs.append((grandchild.name, grandchild))
 
     return dirs
 
@@ -136,6 +152,12 @@ def find_provider_dir(name: str) -> Optional[Path]:
         user = user_dir / name
         if user.is_dir() and _is_memory_provider_dir(user):
             return user
+        for category_dir in sorted(user_dir.iterdir()):
+            if not category_dir.is_dir() or category_dir.name.startswith(("_", ".")):
+                continue
+            nested = category_dir / name
+            if nested.is_dir() and _is_memory_provider_dir(nested):
+                return nested
     return None
 
 

--- a/tests/agent/test_memory_provider.py
+++ b/tests/agent/test_memory_provider.py
@@ -444,9 +444,12 @@ class TestUserInstalledProviderDiscovery:
     directory, ignoring user-installed plugins.
     """
 
-    def _make_user_memory_plugin(self, tmp_path, name="myprovider"):
+    def _make_user_memory_plugin(self, tmp_path, name="myprovider", parts=None):
         """Create a minimal user memory provider plugin."""
-        plugin_dir = tmp_path / "plugins" / name
+        rel_parts = list(parts) if parts is not None else [name]
+        plugin_dir = tmp_path / "plugins"
+        for part in rel_parts:
+            plugin_dir /= part
         plugin_dir.mkdir(parents=True)
         (plugin_dir / "__init__.py").write_text(
             "from agent.memory_provider import MemoryProvider\n"
@@ -477,6 +480,20 @@ class TestUserInstalledProviderDiscovery:
         assert "myexternal" in names
         assert "holographic" in names  # bundled still found
 
+    def test_discover_finds_category_nested_user_plugins(self, tmp_path, monkeypatch):
+        """discover_memory_providers() descends one user-plugin category level."""
+        from plugins.memory import discover_memory_providers
+        self._make_user_memory_plugin(
+            tmp_path, "myexternal", parts=["memory", "myexternal"]
+        )
+        monkeypatch.setattr(
+            "plugins.memory._get_user_plugins_dir",
+            lambda: tmp_path / "plugins",
+        )
+        providers = discover_memory_providers()
+        names = [n for n, _, _ in providers]
+        assert "myexternal" in names
+
     def test_load_user_plugin(self, tmp_path, monkeypatch):
         """load_memory_provider() can load from $HERMES_HOME/plugins/."""
         from plugins.memory import load_memory_provider
@@ -485,6 +502,22 @@ class TestUserInstalledProviderDiscovery:
             "plugins.memory._get_user_plugins_dir",
             lambda: tmp_path / "plugins",
         )
+        p = load_memory_provider("myexternal")
+        assert p is not None
+        assert p.name == "myexternal"
+        assert p.is_available()
+
+    def test_load_category_nested_user_plugin(self, tmp_path, monkeypatch):
+        """load_memory_provider() resolves category-nested user plugins."""
+        from plugins.memory import find_provider_dir, load_memory_provider
+        plugin_dir = self._make_user_memory_plugin(
+            tmp_path, "myexternal", parts=["memory", "myexternal"]
+        )
+        monkeypatch.setattr(
+            "plugins.memory._get_user_plugins_dir",
+            lambda: tmp_path / "plugins",
+        )
+        assert find_provider_dir("myexternal") == plugin_dir
         p = load_memory_provider("myexternal")
         assert p is not None
         assert p.name == "myexternal"


### PR DESCRIPTION
## Summary
- make memory provider discovery descend one category level under user plugins to match the runtime plugin loader
- teach `find_provider_dir()` to resolve providers installed at `~/.hermes/plugins/<category>/<name>/`
- add regression coverage for nested user-provider discovery and loading

## Testing
- pytest tests/agent/test_memory_provider.py -q -k "UserInstalledProviderDiscovery"
- ruff check plugins/memory/__init__.py tests/agent/test_memory_provider.py
- git diff --check

Closes #48822