### PR TITLE
Add Slack allowed users setup field

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -3426,6 +3426,7 @@ OPTIONAL_ENV_VARS = {
                        "Required scopes: chat:write, app_mentions:read, channels:history, groups:history, "
                        "im:history, im:read, im:write, users:read, files:read, files:write",
         "prompt": "Slack Bot Token (xoxb-...)",
+        "help": "In your Slack app, add the required bot scopes, install the app to the workspace, then copy OAuth & Permissions > Bot User OAuth Token.",
         "url": "https://api.slack.com/apps",
         "password": True,
         "category": "messaging",
@@ -3435,6 +3436,7 @@ OPTIONAL_ENV_VARS = {
                        "App-Level Tokens. Also ensure Event Subscriptions include: message.im, "
                        "message.channels, message.groups, app_mention",
         "prompt": "Slack App Token (xapp-...)",
+        "help": "In your Slack app, enable Socket Mode, then create Basic Information > App-Level Tokens with the connections:write scope.",
         "url": "https://api.slack.com/apps",
         "password": True,
         "category": "messaging",
@@ -3442,6 +3444,7 @@ OPTIONAL_ENV_VARS = {
     "SLACK_ALLOWED_USERS": {
         "description": "Comma-separated Slack member IDs allowed to use Hermes, e.g. U01ABC2DEF3. Without this, Slack may connect but deny messages by default.",
         "prompt": "Allowed Slack member IDs",
+        "help": "In Slack, open your profile, choose More or the three-dot menu, then Copy member ID. Add multiple IDs comma-separated.",
         "url": "https://api.slack.com/apps",
         "password": False,
         "category": "messaging",

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -3439,6 +3439,13 @@ OPTIONAL_ENV_VARS = {
         "password": True,
         "category": "messaging",
     },
+    "SLACK_ALLOWED_USERS": {
+        "description": "Comma-separated Slack member IDs allowed to use Hermes, e.g. U01ABC2DEF3. Without this, Slack may connect but deny messages by default.",
+        "prompt": "Allowed Slack member IDs",
+        "url": "https://api.slack.com/apps",
+        "password": False,
+        "category": "messaging",
+    },
     "MATTERMOST_URL": {
         "description": "Mattermost server URL (e.g. https://mm.example.com)",
         "prompt": "Mattermost server URL",

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -2319,6 +2319,23 @@ def _gateway_display_command(profile: Optional[str], verb: str) -> str:
     return " ".join(["hermes", *_gateway_subcommand(profile, verb)])
 
 
+def _validate_messaging_env_value(platform_id: str, key: str, value: str) -> None:
+    """Reject platform credentials that are clearly in the wrong field."""
+    if platform_id != "slack" or not value:
+        return
+
+    if key == "SLACK_BOT_TOKEN" and not value.startswith("xoxb-"):
+        raise HTTPException(
+            status_code=400,
+            detail="Slack Bot Token must start with xoxb-. Paste the bot token from OAuth & Permissions.",
+        )
+    if key == "SLACK_APP_TOKEN" and not value.startswith("xapp-"):
+        raise HTTPException(
+            status_code=400,
+            detail="Slack App Token must start with xapp-. Paste the app-level token from Basic Information > App-Level Tokens.",
+        )
+
+
 def _spawn_gateway_restart(profile: Optional[str] = None) -> Tuple[subprocess.Popen, bool]:
     """Spawn ``hermes gateway restart``, reusing an in-flight restart.
 
@@ -4144,9 +4161,9 @@ _PLATFORM_OVERRIDES: dict[str, dict[str, Any]] = {
     },
     "slack": {
         "name": "Slack",
-        "description": "Use Hermes from Slack via Socket Mode.",
+        "description": "Use Hermes from Slack via Socket Mode. Add allowed Slack member IDs so connected bots can respond.",
         "docs_url": "https://api.slack.com/apps",
-        "env_vars": ("SLACK_BOT_TOKEN", "SLACK_APP_TOKEN"),
+        "env_vars": ("SLACK_BOT_TOKEN", "SLACK_APP_TOKEN", "SLACK_ALLOWED_USERS"),
         "required_env": ("SLACK_BOT_TOKEN", "SLACK_APP_TOKEN"),
     },
     "mattermost": {
@@ -5210,6 +5227,7 @@ async def update_messaging_platform(
                     )
                 trimmed = value.strip()
                 if trimmed:
+                    _validate_messaging_env_value(platform_id, key, trimmed)
                     save_env_value(key, trimmed)
 
             if body.enabled is not None:

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -2334,6 +2334,18 @@ def _validate_messaging_env_value(platform_id: str, key: str, value: str) -> Non
             status_code=400,
             detail="Slack App Token must start with xapp-. Paste the app-level token from Basic Information > App-Level Tokens.",
         )
+    if key == "SLACK_ALLOWED_USERS":
+        user_ids = [part.strip() for part in value.split(",")]
+        invalid = [
+            user_id
+            for user_id in user_ids
+            if not user_id or not re.fullmatch(r"[UW][A-Z0-9]{2,}", user_id)
+        ]
+        if invalid:
+            raise HTTPException(
+                status_code=400,
+                detail="Slack allowed user IDs must be comma-separated member IDs like U01ABC2DEF3.",
+            )
 
 
 def _spawn_gateway_restart(profile: Optional[str] = None) -> Tuple[subprocess.Popen, bool]:
@@ -4648,6 +4660,7 @@ def _messaging_env_info(key: str) -> dict[str, Any]:
     return {
         "description": info.get("description", ""),
         "prompt": info.get("prompt", key),
+        "help": info.get("help", ""),
         "url": info.get("url"),
         "is_password": info.get("password", False),
         "advanced": info.get("advanced", False),

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -1552,6 +1552,24 @@ class TestWebServerEndpoints:
         assert telegram["enabled"] is False
         assert any(field["key"] == "TELEGRAM_BOT_TOKEN" and field["required"] for field in telegram["env_vars"])
 
+    def test_slack_messaging_platform_exposes_user_allowlist(self):
+        resp = self.client.get("/api/messaging/platforms")
+
+        assert resp.status_code == 200
+        platforms = resp.json()["platforms"]
+        slack = next(platform for platform in platforms if platform["id"] == "slack")
+        fields = {field["key"]: field for field in slack["env_vars"]}
+
+        assert "allowed Slack member IDs" in slack["description"]
+        assert set(fields) >= {
+            "SLACK_BOT_TOKEN",
+            "SLACK_APP_TOKEN",
+            "SLACK_ALLOWED_USERS",
+        }
+        assert fields["SLACK_ALLOWED_USERS"]["prompt"] == "Allowed Slack member IDs"
+        assert fields["SLACK_ALLOWED_USERS"]["is_password"] is False
+        assert "member IDs" in fields["SLACK_ALLOWED_USERS"]["description"]
+
     def test_weixin_messaging_metadata_describes_personal_ilink_setup(self):
         resp = self.client.get("/api/messaging/platforms")
 
@@ -1627,6 +1645,35 @@ class TestWebServerEndpoints:
         status = self.client.get("/api/messaging/platforms").json()["platforms"]
         telegram = next(platform for platform in status if platform["id"] == "telegram")
         assert telegram["enabled"] is False
+
+    def test_update_messaging_platform_saves_slack_allowed_users(self):
+        from hermes_cli.config import load_env
+
+        resp = self.client.put(
+            "/api/messaging/platforms/slack",
+            json={"env": {"SLACK_ALLOWED_USERS": "U01ABC2DEF3,U04XYZ5LMN6"}},
+        )
+
+        assert resp.status_code == 200
+        assert load_env()["SLACK_ALLOWED_USERS"] == "U01ABC2DEF3,U04XYZ5LMN6"
+
+    def test_update_messaging_platform_rejects_swapped_slack_bot_token(self):
+        resp = self.client.put(
+            "/api/messaging/platforms/slack",
+            json={"env": {"SLACK_BOT_TOKEN": "xapp-wrong-token-type"}},
+        )
+
+        assert resp.status_code == 400
+        assert "xoxb-" in resp.json()["detail"]
+
+    def test_update_messaging_platform_rejects_swapped_slack_app_token(self):
+        resp = self.client.put(
+            "/api/messaging/platforms/slack",
+            json={"env": {"SLACK_APP_TOKEN": "xoxb-wrong-token-type"}},
+        )
+
+        assert resp.status_code == 400
+        assert "xapp-" in resp.json()["detail"]
 
     def test_messaging_platform_test_reports_missing_required_setup(self):
         resp = self.client.put("/api/messaging/platforms/discord", json={"enabled": True})

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -1569,6 +1569,9 @@ class TestWebServerEndpoints:
         assert fields["SLACK_ALLOWED_USERS"]["prompt"] == "Allowed Slack member IDs"
         assert fields["SLACK_ALLOWED_USERS"]["is_password"] is False
         assert "member IDs" in fields["SLACK_ALLOWED_USERS"]["description"]
+        assert "Bot User OAuth Token" in fields["SLACK_BOT_TOKEN"]["help"]
+        assert "App-Level Tokens" in fields["SLACK_APP_TOKEN"]["help"]
+        assert "Copy member ID" in fields["SLACK_ALLOWED_USERS"]["help"]
 
     def test_weixin_messaging_metadata_describes_personal_ilink_setup(self):
         resp = self.client.get("/api/messaging/platforms")
@@ -1674,6 +1677,15 @@ class TestWebServerEndpoints:
 
         assert resp.status_code == 400
         assert "xapp-" in resp.json()["detail"]
+
+    def test_update_messaging_platform_rejects_invalid_slack_allowed_users(self):
+        resp = self.client.put(
+            "/api/messaging/platforms/slack",
+            json={"env": {"SLACK_ALLOWED_USERS": "U01ABC2DEF3,not-a-user"}},
+        )
+
+        assert resp.status_code == 400
+        assert "member IDs" in resp.json()["detail"]
 
     def test_messaging_platform_test_reports_missing_required_setup(self):
         resp = self.client.put("/api/messaging/platforms/discord", json={"enabled": True})

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1346,6 +1346,7 @@ export interface MessagingPlatformEnvVar {
   redacted_value: string | null;
   description: string;
   prompt: string;
+  help: string;
   url: string | null;
   is_password: boolean;
   advanced: boolean;

--- a/web/src/pages/ChannelsPage.tsx
+++ b/web/src/pages/ChannelsPage.tsx
@@ -4,6 +4,7 @@ import {
   Check,
   CheckCircle2,
   ExternalLink,
+  Info,
   PlugZap,
   QrCode,
   Radio,
@@ -55,6 +56,34 @@ function stateBadge(state: string) {
 }
 
 const TELEGRAM_USER_ID_RE = /^\d+$/;
+const SLACK_MEMBER_ID_RE = /^[UW][A-Z0-9]{2,}$/;
+const SLACK_TOKEN_PREFIXES: Record<string, string> = {
+  SLACK_BOT_TOKEN: "xoxb-",
+  SLACK_APP_TOKEN: "xapp-",
+};
+
+function validateMessagingEnvField(field: MessagingPlatformEnvVar, value: string): string | null {
+  const trimmed = value.trim();
+  if (!trimmed) return null;
+
+  const expectedPrefix = SLACK_TOKEN_PREFIXES[field.key];
+  if (expectedPrefix && !trimmed.startsWith(expectedPrefix)) {
+    return `${field.prompt || field.key} must start with ${expectedPrefix}`;
+  }
+
+  if (field.key === "SLACK_ALLOWED_USERS") {
+    const parts = trimmed.split(",").map((part) => part.trim());
+    if (parts.some((part) => !part)) {
+      return "Slack member IDs must be comma-separated without empty entries.";
+    }
+    const invalid = parts.find((part) => !SLACK_MEMBER_ID_RE.test(part));
+    if (invalid) {
+      return `${invalid} does not look like a Slack member ID. Use IDs like U01ABC2DEF3.`;
+    }
+  }
+
+  return null;
+}
 
 function formatExpiry(expiresAt: string): string {
   const ms = Date.parse(expiresAt) - Date.now();
@@ -83,8 +112,12 @@ export default function ChannelsPage() {
   // Config modal state
   const [editing, setEditing] = useState<MessagingPlatform | null>(null);
   const [draftEnv, setDraftEnv] = useState<Record<string, string>>({});
+  const [fieldErrors, setFieldErrors] = useState<Record<string, string>>({});
   const [saving, setSaving] = useState(false);
-  const closeEdit = useCallback(() => setEditing(null), []);
+  const closeEdit = useCallback(() => {
+    setEditing(null);
+    setFieldErrors({});
+  }, []);
   const editModalRef = useModalBehavior({ open: editing !== null, onClose: closeEdit });
 
   // Per-card busy + restart-needed tracking
@@ -116,6 +149,7 @@ export default function ChannelsPage() {
       initial[v.key] = "";
     });
     setDraftEnv(initial);
+    setFieldErrors({});
     setEditing(platform);
   };
 
@@ -136,6 +170,16 @@ export default function ChannelsPage() {
     );
     if (missing.length > 0) {
       showToast(`${missing[0].prompt || missing[0].key} is required`, "error");
+      return;
+    }
+    const nextFieldErrors: Record<string, string> = {};
+    editing.env_vars.forEach((field) => {
+      const message = validateMessagingEnvField(field, draftEnv[field.key] || "");
+      if (message) nextFieldErrors[field.key] = message;
+    });
+    if (Object.keys(nextFieldErrors).length > 0) {
+      setFieldErrors(nextFieldErrors);
+      showToast("Fix the highlighted fields before saving.", "error");
       return;
     }
     setSaving(true);
@@ -326,10 +370,22 @@ export default function ChannelsPage() {
               </p>
               {editing.env_vars.map((field: MessagingPlatformEnvVar) => (
                 <div className="grid gap-1.5" key={field.key}>
-                  <Label htmlFor={`field-${field.key}`}>
-                    {field.prompt || field.key}
-                    {field.required ? " *" : ""}
-                  </Label>
+                  <div className="flex items-center gap-1.5">
+                    <Label htmlFor={`field-${field.key}`}>
+                      {field.prompt || field.key}
+                      {field.required ? " *" : ""}
+                    </Label>
+                    {field.help && (
+                      <span
+                        aria-label={field.help}
+                        className="inline-flex text-muted-foreground hover:text-foreground"
+                        role="img"
+                        title={field.help}
+                      >
+                        <Info className="h-3.5 w-3.5" />
+                      </span>
+                    )}
+                  </div>
                   {field.description && (
                     <span className="text-xs text-muted-foreground">
                       {field.description}
@@ -344,10 +400,23 @@ export default function ChannelsPage() {
                         : field.key
                     }
                     value={draftEnv[field.key] ?? ""}
-                    onChange={(e) =>
-                      setDraftEnv((prev) => ({ ...prev, [field.key]: e.target.value }))
-                    }
+                    aria-invalid={Boolean(fieldErrors[field.key])}
+                    onChange={(e) => {
+                      const nextValue = e.target.value;
+                      setDraftEnv((prev) => ({ ...prev, [field.key]: nextValue }));
+                      setFieldErrors((prev) => {
+                        if (!prev[field.key]) return prev;
+                        const next = { ...prev };
+                        delete next[field.key];
+                        return next;
+                      });
+                    }}
                   />
+                  {fieldErrors[field.key] && (
+                    <span className="text-xs text-destructive">
+                      {fieldErrors[field.key]}
+                    </span>
+                  )}
                 </div>
               ))}
 


### PR DESCRIPTION
## Summary
- add `SLACK_ALLOWED_USERS` to the Slack dashboard setup fields
- add hover help for the Slack bot token, app token, and allowed user IDs
- validate Slack token prefixes and allowed user ID shapes in the Channels form and API

## Why
Slack Socket Mode can connect while message handling is denied if allowed Slack member IDs are not configured. The dashboard previously collected bot and app tokens only, leaving that required allowlist out of the setup flow. The added hints explain where each Slack value comes from without requiring users to leave the form.

## Validation
- `/Users/shannon/.vulcan/projects/hermes-agent/.venv/bin/python -m pytest tests/hermes_cli/test_web_server.py -q -k "slack_messaging_platform_exposes_user_allowlist or update_messaging_platform_saves_slack_allowed_users or swapped_slack or invalid_slack_allowed_users"`
- `/Users/shannon/.vulcan/projects/hermes-agent/.venv/bin/python -m ruff check hermes_cli/config.py hermes_cli/web_server.py tests/hermes_cli/test_web_server.py`
- `npm run typecheck --workspace web`
- `npm run build --workspace web`
- `git diff --check`