### PR TITLE
fix(desktop): early-sent queued message no longer disappears from the transcript

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-prompt-actions.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions.test.tsx
@@ -72,10 +72,13 @@ function Harness({
   storedSessionId?: null | string
 }) {
   const activeSessionIdRef: MutableRefObject<string | null> = { current: RUNTIME_SESSION_ID }
+
   const selectedStoredSessionIdRef: MutableRefObject<string | null> = {
     current: storedSessionId === undefined ? RUNTIME_SESSION_ID : storedSessionId
   }
+
   const localBusyRef = busyRef ?? { current: false }
+
   const stateRef = useRef({
     messages: seedMessages ?? [],
     busy: false,
@@ -130,6 +133,7 @@ describe('usePromptActions /title', () => {
 
   it('renames via the session.title RPC (with the runtime id), updates the sidebar store, and refreshes', async () => {
     const refreshSessions = vi.fn(async () => undefined)
+
     const requestGateway = vi.fn(async (method: string) =>
       (method === 'session.title' ? { pending: false, title: 'New title' } : {}) as never
     )
@@ -153,6 +157,7 @@ describe('usePromptActions /title', () => {
 
   it('reports the queued state when the session row is not persisted yet', async () => {
     const refreshSessions = vi.fn(async () => undefined)
+
     const requestGateway = vi.fn(async (method: string) =>
       (method === 'session.title' ? { pending: true, title: 'Fresh chat' } : {}) as never
     )
@@ -186,6 +191,7 @@ describe('usePromptActions /title', () => {
 
   it('surfaces a rename error without touching the sidebar store', async () => {
     const refreshSessions = vi.fn(async () => undefined)
+
     const requestGateway = vi.fn(async (method: string) => {
       if (method === 'session.title') {
         throw new Error('Title too long')
@@ -239,6 +245,7 @@ describe('usePromptActions desktop slash pickers', () => {
   it('marks a timed-out handoff as failed so the next attempt can retry', async () => {
     vi.useFakeTimers()
     const calls: { method: string; params?: Record<string, unknown> }[] = []
+
     const requestGateway = vi.fn(async (method: string, params?: Record<string, unknown>) => {
       calls.push({ method, params })
 
@@ -325,12 +332,44 @@ describe('usePromptActions submit / queue drain semantics', () => {
     })
   })
 
+  it('seeds the optimistic user message flagged pending (survives a racing hydrate)', async () => {
+    // The optimistic user message must carry pending:true so a hydrate that
+    // races an early-sent queued message preserves it instead of overwriting it
+    // away (the "disappearing message" bug). See preserveLocalAssistantErrors.
+    const seeds: Record<string, unknown>[] = []
+    const requestGateway = vi.fn(async () => ({}) as never)
+
+    let handle: HarnessHandle | null = null
+    render(
+      <Harness
+        onReady={h => (handle = h)}
+        onSeedState={s => seeds.push(s)}
+        refreshSessions={async () => undefined}
+        requestGateway={requestGateway}
+      />
+    )
+
+    await handle!.submitText('sent early', { fromQueue: true })
+
+    const withUser = seeds.find(s => {
+      const messages = (s.messages ?? []) as { role?: string }[]
+
+      return messages.some(m => m.role === 'user')
+    })
+
+    const userMsg = ((withUser?.messages ?? []) as { role?: string; pending?: boolean }[]).find(m => m.role === 'user')
+
+    expect(userMsg).toBeTruthy()
+    expect(userMsg?.pending).toBe(true)
+  })
+
   it('a rejected fromQueue drain returns false (entry stays queued) and a later retry sends it', async () => {
     // A stale-session 404 must not strand the queued entry: submitPrompt returns
     // false on failure so the composer keeps it, and the edge-independent
     // auto-drain re-attempts once the session is idle again. storedSessionId is
     // null so the session.resume recovery path is skipped and the error surfaces.
     let attempt = 0
+
     const requestGateway = vi.fn(async (method: string) => {
       if (method === 'prompt.submit') {
         attempt += 1
@@ -370,6 +409,7 @@ describe('usePromptActions submit / queue drain semantics', () => {
     // gateway accepts, never a red "session busy" bubble.
     let attempt = 0
     const seeds: Record<string, unknown>[] = []
+
     const requestGateway = vi.fn(async (method: string) => {
       if (method === 'prompt.submit') {
         attempt += 1
@@ -546,6 +586,7 @@ describe('usePromptActions restoreToMessage', () => {
     $busy.set(true)
 
     let submitAttempts = 0
+
     const requestGateway = vi.fn(async (method: string) => {
       if (method === 'prompt.submit') {
         submitAttempts += 1
@@ -623,8 +664,10 @@ describe('usePromptActions file attachment sync', () => {
     })
 
     const calls: { method: string; params?: Record<string, unknown> }[] = []
+
     const requestGateway = vi.fn(async (method: string, params?: Record<string, unknown>) => {
       calls.push({ method, params })
+
       if (method === 'file.attach') {
         return {
           attached: true,
@@ -633,6 +676,7 @@ describe('usePromptActions file attachment sync', () => {
           uploaded: true
         } as never
       }
+
       return {} as never
     })
 
@@ -681,8 +725,10 @@ describe('usePromptActions file attachment sync', () => {
     }
 
     const calls: { method: string; params?: Record<string, unknown> }[] = []
+
     const requestGateway = vi.fn(async (method: string, params?: Record<string, unknown>) => {
       calls.push({ method, params })
+
       return {} as never
     })
 
@@ -702,11 +748,14 @@ describe('usePromptActions file attachment sync', () => {
     $connection.set({ mode: 'local' } as never)
 
     const calls: { method: string; params?: Record<string, unknown> }[] = []
+
     const requestGateway = vi.fn(async (method: string, params?: Record<string, unknown>) => {
       calls.push({ method, params })
+
       if (method === 'file.attach') {
         return { attached: true, ref_text: '@file:data/report.txt', uploaded: false } as never
       }
+
       return {} as never
     })
 
@@ -752,15 +801,19 @@ describe('usePromptActions eager-upload races', () => {
 
     let releaseAttach: () => void = () => {}
     const methods: string[] = []
+
     const requestGateway = vi.fn(async (method: string) => {
       methods.push(method)
+
       if (method === 'file.attach') {
         // Block until released so submit runs while the upload is in flight.
         await new Promise<void>(resolve => {
           releaseAttach = resolve
         })
+
         return { attached: true, ref_text: '@file:.hermes/desktop-attachments/doc.pdf', uploaded: true } as never
       }
+
       return {} as never
     })
 
@@ -799,18 +852,24 @@ describe('usePromptActions sleep/wake session recovery', () => {
     // and retries the send transparently.
     const calls: { method: string; params?: Record<string, unknown> }[] = []
     let submitAttempts = 0
+
     const requestGateway = vi.fn(async (method: string, params?: Record<string, unknown>) => {
       calls.push({ method, params })
+
       if (method === 'prompt.submit') {
         submitAttempts += 1
+
         if (submitAttempts === 1) {
           throw new Error('session not found')
         }
+
         return {} as never
       }
+
       if (method === 'session.resume') {
         return { session_id: RECOVERED_SESSION_ID } as never
       }
+
       return {} as never
     })
 
@@ -836,18 +895,24 @@ describe('usePromptActions sleep/wake session recovery', () => {
   it('resumes the stored session and retries once when session.interrupt reports "session not found"', async () => {
     const calls: { method: string; params?: Record<string, unknown> }[] = []
     let interruptAttempts = 0
+
     const requestGateway = vi.fn(async (method: string, params?: Record<string, unknown>) => {
       calls.push({ method, params })
+
       if (method === 'session.interrupt') {
         interruptAttempts += 1
+
         if (interruptAttempts === 1) {
           throw new Error('session not found')
         }
+
         return {} as never
       }
+
       if (method === 'session.resume') {
         return { session_id: RECOVERED_SESSION_ID } as never
       }
+
       return {} as never
     })
 
@@ -873,11 +938,14 @@ describe('usePromptActions sleep/wake session recovery', () => {
   it('surfaces the original error (no resume) when the failure is not "session not found"', async () => {
     const calls: string[] = []
     const states: Record<string, unknown>[] = []
+
     const requestGateway = vi.fn(async (method: string) => {
       calls.push(method)
+
       if (method === 'prompt.submit') {
         throw new Error('gateway exploded')
       }
+
       return {} as never
     })
 
@@ -900,11 +968,14 @@ describe('usePromptActions sleep/wake session recovery', () => {
 
   it('surfaces "session not found" (no resume) when there is no stored session id', async () => {
     const calls: string[] = []
+
     const requestGateway = vi.fn(async (method: string) => {
       calls.push(method)
+
       if (method === 'prompt.submit') {
         throw new Error('session not found')
       }
+
       return {} as never
     })
 
@@ -943,11 +1014,14 @@ describe('usePromptActions eager attachment upload (drop-time)', () => {
     Object.defineProperty(window, 'hermesDesktop', { configurable: true, value: { readFileDataUrl } })
 
     const calls: string[] = []
+
     const requestGateway = vi.fn(async (method: string) => {
       calls.push(method)
+
       if (method === 'file.attach') {
         return { attached: true, ref_text: '@file:.hermes/desktop-attachments/DEVIS_signed.pdf', uploaded: true } as never
       }
+
       return {} as never
     })
 
@@ -977,6 +1051,7 @@ describe('usePromptActions eager attachment upload (drop-time)', () => {
       if (method === 'file.attach') {
         throw new Error('[Errno 13] Permission denied')
       }
+
       return {} as never
     })
 

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions.ts
@@ -57,8 +57,8 @@ import { clearSessionSubagents } from '@/store/subagents'
 import { clearSessionTodos } from '@/store/todos'
 
 import type {
-  ClientSessionState,
   BrowserManageResponse,
+  ClientSessionState,
   FileAttachResponse,
   HandoffFailResponse,
   HandoffRequestResponse,
@@ -590,7 +590,13 @@ export function usePromptActions({
         id: optimisticId,
         role: 'user',
         parts: [textPart(visibleText || (attachmentRefs.length ? '' : attachments.map(a => a.label).join(', ')))],
-        attachmentRefs
+        attachmentRefs,
+        // Marks this as an in-flight optimistic send: its server counterpart
+        // isn't in the stored transcript yet, so a hydrate that races the send
+        // (e.g. an early-sent queued message that interrupts the prior turn)
+        // must preserve it rather than overwrite it away. Cleared when the real
+        // transcript lands.
+        pending: true
       })
 
       const releaseBusy = () => {
@@ -1359,6 +1365,7 @@ export function usePromptActions({
 
   const cancelRun = useCallback(async () => {
     const sessionId = activeSessionId || activeSessionIdRef.current
+
     const releaseBusy = () => {
       setMutableRef(busyRef, false)
       setBusy(false)

--- a/apps/desktop/src/lib/chat-messages.test.ts
+++ b/apps/desktop/src/lib/chat-messages.test.ts
@@ -387,6 +387,78 @@ describe('preserveLocalAssistantErrors', () => {
     expect(assistant?.error).toBe('OpenRouter 403')
     expect(assistant?.pending).toBe(false)
   })
+
+  it('preserves a pending optimistic user tail that hydrate has not caught up to', () => {
+    // Repro for the "early-sent queued message disappears" bug: the user sent a
+    // queued message early (interrupting the prior turn), which fired a hydrate
+    // whose stored transcript doesn't yet include the just-sent message.
+    const nextMessages: ChatMessage[] = [
+      { id: 'stored-user', parts: [{ text: 'earlier', type: 'text' }], role: 'user' },
+      { id: 'stored-assistant', parts: [{ text: 'reply', type: 'text' }], role: 'assistant' }
+    ]
+
+    const currentMessages: ChatMessage[] = [
+      ...nextMessages,
+      { id: 'user-9999', parts: [{ text: 'sent early', type: 'text' }], role: 'user', pending: true }
+    ]
+
+    const merged = preserveLocalAssistantErrors(nextMessages, currentMessages)
+
+    expect(merged.map(m => m.id)).toEqual(['stored-user', 'stored-assistant', 'user-9999'])
+    expect(merged.at(-1)?.pending).toBe(true)
+  })
+
+  it('does not preserve a non-pending orphan user tail (stale leftover)', () => {
+    // A trailing user turn with no pending flag is a stale leftover, not an
+    // in-flight send — it must still be dropped (guards the existing behavior).
+    const nextMessages: ChatMessage[] = [
+      { id: 'stored-user', parts: [{ text: 'earlier', type: 'text' }], role: 'user' }
+    ]
+
+    const currentMessages: ChatMessage[] = [
+      ...nextMessages,
+      { id: 'user-stale', parts: [{ text: 'no longer here', type: 'text' }], role: 'user' }
+    ]
+
+    const merged = preserveLocalAssistantErrors(nextMessages, currentMessages)
+
+    expect(merged.map(m => m.id)).toEqual(['stored-user'])
+  })
+
+  it('does not duplicate a pending user tail the transcript already contains by text', () => {
+    // If hydrate's transcript already has the equivalent user message (server
+    // caught up), don't append a duplicate just because the local copy is still
+    // flagged pending.
+    const nextMessages: ChatMessage[] = [
+      { id: 'stored-user', parts: [{ text: 'sent early', type: 'text' }], role: 'user' }
+    ]
+
+    const currentMessages: ChatMessage[] = [
+      { id: 'user-9999', parts: [{ text: 'sent early', type: 'text' }], role: 'user', pending: true }
+    ]
+
+    const merged = preserveLocalAssistantErrors(nextMessages, currentMessages)
+
+    expect(merged.map(m => m.id)).toEqual(['stored-user'])
+  })
+
+  it('preserves both an assistant-error pair and a separate pending user tail', () => {
+    const nextMessages: ChatMessage[] = [
+      { id: 'stored-user', parts: [{ text: 'earlier', type: 'text' }], role: 'user' }
+    ]
+
+    const currentMessages: ChatMessage[] = [
+      { id: 'err-user', parts: [{ text: 'failed turn', type: 'text' }], role: 'user' },
+      { error: 'OpenRouter 403', id: 'assistant-error-1', parts: [], role: 'assistant' },
+      { id: 'user-pending', parts: [{ text: 'sent early', type: 'text' }], role: 'user', pending: true }
+    ]
+
+    const merged = preserveLocalAssistantErrors(nextMessages, currentMessages)
+
+    expect(merged.map(m => m.id)).toContain('user-pending')
+    expect(merged.map(m => m.id)).toContain('assistant-error-1')
+    expect(merged.at(-1)?.id).toBe('user-pending')
+  })
 })
 
 describe('upsertToolPart', () => {

--- a/apps/desktop/src/lib/chat-messages.ts
+++ b/apps/desktop/src/lib/chat-messages.ts
@@ -901,15 +901,38 @@ export function preserveLocalAssistantErrors(
     }
   }
 
+  // Guard the case that made an early-sent queued message "disappear": a
+  // trailing *pending* optimistic user message (just submitted, its server reply
+  // not yet in the stored transcript) that a racing hydrate would otherwise
+  // overwrite away. Preserve it only when the incoming transcript doesn't
+  // already contain an equivalent user tail (id match via existingIds, text
+  // match via the tail check). Independent of the assistant-error preservation
+  // below, so it holds whether or not there's also an error pair to keep.
+  const trailingLocal = [...currentMessages].reverse().find(message => !message.hidden)
+
+  const pendingUserTail =
+    trailingLocal &&
+    trailingLocal.role === 'user' &&
+    trailingLocal.pending &&
+    !existingIds.has(trailingLocal.id) &&
+    !matchesTailUserInNext(trailingLocal)
+      ? trailingLocal
+      : null
+
   if (preserveIds.size === 0) {
-    return mergedNextMessages
+    return pendingUserTail ? [...mergedNextMessages, { ...pendingUserTail }] : mergedNextMessages
   }
 
   const preserved = currentMessages
     .filter(message => preserveIds.has(message.id))
     .map(message => ({ ...message, pending: false }))
 
-  return [...mergedNextMessages, ...preserved]
+  // Also keep the pending optimistic user tail if it wasn't already captured as
+  // a preserved (pre-error) user turn — so an in-flight send survives hydrate
+  // even when there's a separate assistant-error pair being preserved.
+  const extraPendingTail = pendingUserTail && !preserveIds.has(pendingUserTail.id) ? [{ ...pendingUserTail }] : []
+
+  return [...mergedNextMessages, ...preserved, ...extraPendingTail]
 }
 
 export function branchGroupForUser(userMessage: ChatMessage): string {


### PR DESCRIPTION
## Symptom

Queue a message while the agent is running, then send it early with the arrow ("send now"). The message **vanishes** — it's removed from the queue but never appears in the chat transcript.

## Root cause

Sending a queued message early promotes it to the head and **interrupts** the running turn. The interrupt/settle path fires `hydrateFromStoredSession`, which replaces the in-memory messages with the stored DB transcript via `preserveLocalAssistantErrors(stored, current)`.

That merge only preserves a *local user* message when it directly **precedes a preserved assistant error**. The freshly-sent optimistic user message has no assistant reply yet, and the stored transcript the hydrate fetched hasn't caught up to include it — so it's neither in `stored` nor preserved from `current`, and gets dropped. The message "disappears."

## Fix

- Flag the optimistic user message **`pending: true`** when it's seeded (`use-prompt-actions.ts`) — it's an in-flight send whose server counterpart isn't in the stored transcript yet. (Cleared when the real transcript lands; the existing completion path already resets `pending`.)
- In `preserveLocalAssistantErrors`, **preserve a trailing *pending* optimistic user tail** that the incoming transcript doesn't already contain (by id or by equivalent text). Applies whether or not there's also an assistant-error pair being preserved.

The `pending` flag is the precise discriminator: a **stale orphan** user turn (no pending flag) is still dropped as before — so this doesn't resurrect old leftover turns, it only protects a genuine in-flight send. The existing "does not keep orphan local user turns" test still passes unchanged.

## Tests

- **`chat-messages.test.ts` (+4)**: preserves a pending user tail hydrate hasn't caught up to; still drops a non-pending orphan tail (no regression); no duplicate when the transcript already has it by text; preserves both an error pair *and* a separate pending tail.
- **`use-prompt-actions.test.tsx` (+1)**: the optimistic user message is seeded with `pending: true`.

`tsc --noEmit` clean, `eslint` clean, **66 tests pass**.

## Validation note

Root-caused by tracing the early-send path: `sendQueuedNow` (busy) → promote + interrupt → `completeAssistantMessage`/settle → `hydrateFromStoredSession` → `preserveLocalAssistantErrors`. Covered by unit tests against the exact merge function; not yet click-tested in a packaged build.
