### PR TITLE
fix(gateway): resolve watchdog, env override, and proxy routing bugs on Windows

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -558,6 +558,10 @@ class GatewayConfig:
     # fresh session exactly as if the reset policy had fired.  0 = disabled.
     session_store_max_age_days: int = 90
 
+    # Proxy trust configuration (Bug 3)
+    trust_proxy: bool = False
+    trust_env: bool = False
+
     def get_connected_platforms(self) -> List[Platform]:
         """Return list of platforms that are enabled and configured."""
         connected = []
@@ -653,6 +657,8 @@ class GatewayConfig:
             "unauthorized_dm_behavior": self.unauthorized_dm_behavior,
             "streaming": self.streaming.to_dict(),
             "session_store_max_age_days": self.session_store_max_age_days,
+            "trust_proxy": self.trust_proxy,
+            "trust_env": self.trust_env,
         }
     
     @classmethod
@@ -736,6 +742,8 @@ class GatewayConfig:
             unauthorized_dm_behavior=unauthorized_dm_behavior,
             streaming=StreamingConfig.from_dict(data.get("streaming", {})),
             session_store_max_age_days=session_store_max_age_days,
+            trust_proxy=_coerce_bool(data.get("trust_proxy"), False),
+            trust_env=_coerce_bool(data.get("trust_env"), False),
         )
 
     def get_unauthorized_dm_behavior(self, platform: Optional[Platform] = None) -> str:
@@ -854,6 +862,11 @@ def load_gateway_config() -> GatewayConfig:
                     yaml_cfg.get("unauthorized_dm_behavior"),
                     "pair",
                 )
+
+            if "trust_proxy" in yaml_cfg:
+                gw_data["trust_proxy"] = yaml_cfg["trust_proxy"]
+            if "trust_env" in yaml_cfg:
+                gw_data["trust_env"] = yaml_cfg["trust_env"]
 
             # Merge platform config into gw_data so runtime-only settings under
             # ``gateway.platforms`` are loaded the same way as top-level
@@ -991,13 +1004,16 @@ def load_gateway_config() -> GatewayConfig:
                         bridged["channel_prompts"] = channel_prompts
                 if "gateway_restart_notification" in platform_cfg:
                     bridged["gateway_restart_notification"] = platform_cfg["gateway_restart_notification"]
+                if "trust_proxy" in platform_cfg:
+                    bridged["trust_proxy"] = platform_cfg["trust_proxy"]
+                if "trust_env" in platform_cfg:
+                    bridged["trust_env"] = platform_cfg["trust_env"]
                 enabled_was_explicit = _cfg_toplevel and "enabled" in platform_cfg
                 if not bridged and not enabled_was_explicit:
                     continue
                 plat_data, extra = _ensure_platform_extra_dict(platforms_data, plat.value)
                 if enabled_was_explicit:
                     plat_data["enabled"] = platform_cfg["enabled"]
-                if plat == Platform.SLACK and enabled_was_explicit:
                     extra["_enabled_explicit"] = True
                 extra.update(bridged)
 
@@ -1356,21 +1372,27 @@ def _validate_gateway_config(config: "GatewayConfig") -> None:
 def _apply_env_overrides(config: GatewayConfig) -> None:
     """Apply environment variable overrides to config."""
 
-    def _enable_from_env(platform: Platform) -> PlatformConfig:
+    def _enable_from_env(platform: Platform, env_trigger: str) -> PlatformConfig:
         if platform not in config.platforms:
             config.platforms[platform] = PlatformConfig(enabled=True)
             return config.platforms[platform]
 
         platform_config = config.platforms[platform]
         enabled_was_explicit = bool(platform_config.extra.pop("_enabled_explicit", False))
-        if not platform_config.enabled and not enabled_was_explicit:
+        if not platform_config.enabled and enabled_was_explicit:
+            logger.warning(
+                "Environment variable %s is set but platform '%s' will remain disabled "
+                "because it was explicitly disabled in the configuration.",
+                env_trigger, platform.value
+            )
+        elif not platform_config.enabled:
             platform_config.enabled = True
         return platform_config
     
     # Telegram
     telegram_token = os.getenv("TELEGRAM_BOT_TOKEN")
     if telegram_token:
-        telegram_config = _enable_from_env(Platform.TELEGRAM)
+        telegram_config = _enable_from_env(Platform.TELEGRAM, "TELEGRAM_BOT_TOKEN")
         telegram_config.token = telegram_token
     
     # Reply threading mode for Telegram (off/first/all)
@@ -1400,7 +1422,7 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
     # Discord
     discord_token = os.getenv("DISCORD_BOT_TOKEN")
     if discord_token:
-        discord_config = _enable_from_env(Platform.DISCORD)
+        discord_config = _enable_from_env(Platform.DISCORD, "DISCORD_BOT_TOKEN")
         discord_config.token = discord_token
     
     discord_home = os.getenv("DISCORD_HOME_CHANNEL")
@@ -1422,16 +1444,11 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
     # WhatsApp (typically uses different auth mechanism)
     whatsapp_enabled = os.getenv("WHATSAPP_ENABLED", "").lower() in {"true", "1", "yes"}
     whatsapp_disabled_explicitly = os.getenv("WHATSAPP_ENABLED", "").lower() in {"false", "0", "no"}
-    if Platform.WHATSAPP in config.platforms:
-        # YAML config exists — respect explicit disable
-        wa_cfg = config.platforms[Platform.WHATSAPP]
-        if whatsapp_disabled_explicitly:
-            wa_cfg.enabled = False
-        elif whatsapp_enabled:
-            wa_cfg.enabled = True
-        # else: keep whatever the YAML set
+    if whatsapp_disabled_explicitly:
+        if Platform.WHATSAPP in config.platforms:
+            config.platforms[Platform.WHATSAPP].enabled = False
     elif whatsapp_enabled:
-        config.platforms[Platform.WHATSAPP] = PlatformConfig(enabled=True)
+        _enable_from_env(Platform.WHATSAPP, "WHATSAPP_ENABLED")
     whatsapp_home = os.getenv("WHATSAPP_HOME_CHANNEL")
     if whatsapp_home and Platform.WHATSAPP in config.platforms:
         config.platforms[Platform.WHATSAPP].home_channel = HomeChannel(
@@ -1448,45 +1465,43 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
     whatsapp_cloud_phone_id = os.getenv("WHATSAPP_CLOUD_PHONE_NUMBER_ID")
     whatsapp_cloud_token = os.getenv("WHATSAPP_CLOUD_ACCESS_TOKEN")
     if whatsapp_cloud_phone_id and whatsapp_cloud_token:
-        if Platform.WHATSAPP_CLOUD not in config.platforms:
-            config.platforms[Platform.WHATSAPP_CLOUD] = PlatformConfig()
-        config.platforms[Platform.WHATSAPP_CLOUD].enabled = True
-        config.platforms[Platform.WHATSAPP_CLOUD].extra.update({
+        whatsapp_cloud_config = _enable_from_env(Platform.WHATSAPP_CLOUD, "WHATSAPP_CLOUD_PHONE_NUMBER_ID / WHATSAPP_CLOUD_ACCESS_TOKEN")
+        whatsapp_cloud_config.extra.update({
             "phone_number_id": whatsapp_cloud_phone_id,
             "access_token": whatsapp_cloud_token,
         })
         # Optional: app_id / app_secret (signature verification)
         wa_cloud_app_id = os.getenv("WHATSAPP_CLOUD_APP_ID")
         if wa_cloud_app_id:
-            config.platforms[Platform.WHATSAPP_CLOUD].extra["app_id"] = wa_cloud_app_id
+            whatsapp_cloud_config.extra["app_id"] = wa_cloud_app_id
         wa_cloud_app_secret = os.getenv("WHATSAPP_CLOUD_APP_SECRET")
         if wa_cloud_app_secret:
-            config.platforms[Platform.WHATSAPP_CLOUD].extra["app_secret"] = wa_cloud_app_secret
+            whatsapp_cloud_config.extra["app_secret"] = wa_cloud_app_secret
         # Optional: WABA id (analytics, future use)
         wa_cloud_waba_id = os.getenv("WHATSAPP_CLOUD_WABA_ID")
         if wa_cloud_waba_id:
-            config.platforms[Platform.WHATSAPP_CLOUD].extra["waba_id"] = wa_cloud_waba_id
+            whatsapp_cloud_config.extra["waba_id"] = wa_cloud_waba_id
         # Webhook verify token — Meta hub.verify_token shared secret
         wa_cloud_verify_token = os.getenv("WHATSAPP_CLOUD_VERIFY_TOKEN")
         if wa_cloud_verify_token:
-            config.platforms[Platform.WHATSAPP_CLOUD].extra["verify_token"] = wa_cloud_verify_token
+            whatsapp_cloud_config.extra["verify_token"] = wa_cloud_verify_token
         # Webhook server bind config (defaults baked into the adapter)
         wa_cloud_host = os.getenv("WHATSAPP_CLOUD_WEBHOOK_HOST")
         if wa_cloud_host:
-            config.platforms[Platform.WHATSAPP_CLOUD].extra["webhook_host"] = wa_cloud_host
+            whatsapp_cloud_config.extra["webhook_host"] = wa_cloud_host
         wa_cloud_port = os.getenv("WHATSAPP_CLOUD_WEBHOOK_PORT")
         if wa_cloud_port:
             try:
-                config.platforms[Platform.WHATSAPP_CLOUD].extra["webhook_port"] = int(wa_cloud_port)
+                whatsapp_cloud_config.extra["webhook_port"] = int(wa_cloud_port)
             except ValueError:
                 pass
         wa_cloud_path = os.getenv("WHATSAPP_CLOUD_WEBHOOK_PATH")
         if wa_cloud_path:
-            config.platforms[Platform.WHATSAPP_CLOUD].extra["webhook_path"] = wa_cloud_path
+            whatsapp_cloud_config.extra["webhook_path"] = wa_cloud_path
         # Graph API version override (rarely needed)
         wa_cloud_api_version = os.getenv("WHATSAPP_CLOUD_API_VERSION")
         if wa_cloud_api_version:
-            config.platforms[Platform.WHATSAPP_CLOUD].extra["api_version"] = wa_cloud_api_version
+            whatsapp_cloud_config.extra["api_version"] = wa_cloud_api_version
     whatsapp_cloud_home = os.getenv("WHATSAPP_CLOUD_HOME_CHANNEL")
     if whatsapp_cloud_home and Platform.WHATSAPP_CLOUD in config.platforms:
         config.platforms[Platform.WHATSAPP_CLOUD].home_channel = HomeChannel(
@@ -1499,22 +1514,8 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
     # Slack
     slack_token = os.getenv("SLACK_BOT_TOKEN")
     if slack_token:
-        if Platform.SLACK not in config.platforms:
-            # No yaml config for Slack — env-only setup, enable it
-            config.platforms[Platform.SLACK] = PlatformConfig()
-            config.platforms[Platform.SLACK].enabled = True
-        else:
-            slack_config = config.platforms[Platform.SLACK]
-            enabled_was_explicit = bool(slack_config.extra.pop("_enabled_explicit", False))
-            if not slack_config.enabled and not enabled_was_explicit:
-                # Top-level Slack settings such as channel prompts should not
-                # turn an env-token setup into a disabled platform. Only an
-                # explicit slack.enabled/platforms.slack.enabled false should.
-                slack_config.enabled = True
-        # If yaml config exists, respect its enabled flag (don't override
-        # explicit enabled: false). Token is still stored so skills that
-        # send Slack messages can use it without activating the gateway adapter.
-        config.platforms[Platform.SLACK].token = slack_token
+        slack_config = _enable_from_env(Platform.SLACK, "SLACK_BOT_TOKEN")
+        slack_config.token = slack_token
     slack_home = os.getenv("SLACK_HOME_CHANNEL")
     if slack_home and Platform.SLACK in config.platforms:
         config.platforms[Platform.SLACK].home_channel = HomeChannel(
@@ -1528,7 +1529,7 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
     signal_url = os.getenv("SIGNAL_HTTP_URL")
     signal_account = os.getenv("SIGNAL_ACCOUNT")
     if signal_url and signal_account:
-        signal_config = _enable_from_env(Platform.SIGNAL)
+        signal_config = _enable_from_env(Platform.SIGNAL, "SIGNAL_HTTP_URL / SIGNAL_ACCOUNT")
         signal_config.extra.update({
             "http_url": signal_url,
             "account": signal_account,
@@ -1549,7 +1550,7 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
         mattermost_url = os.getenv("MATTERMOST_URL", "")
         if not mattermost_url:
             logger.warning("MATTERMOST_TOKEN set but MATTERMOST_URL is missing")
-        mattermost_config = _enable_from_env(Platform.MATTERMOST)
+        mattermost_config = _enable_from_env(Platform.MATTERMOST, "MATTERMOST_TOKEN")
         mattermost_config.token = mattermost_token
         mattermost_config.extra["url"] = mattermost_url
     mattermost_home = os.getenv("MATTERMOST_HOME_CHANNEL")
@@ -1567,7 +1568,7 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
     if matrix_token or os.getenv("MATRIX_PASSWORD"):
         if not matrix_homeserver:
             logger.warning("MATRIX_ACCESS_TOKEN/MATRIX_PASSWORD set but MATRIX_HOMESERVER is missing")
-        matrix_config = _enable_from_env(Platform.MATRIX)
+        matrix_config = _enable_from_env(Platform.MATRIX, "MATRIX_ACCESS_TOKEN / MATRIX_PASSWORD")
         if matrix_token:
             matrix_config.token = matrix_token
         matrix_config.extra["homeserver"] = matrix_homeserver
@@ -1600,13 +1601,11 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
     # Home Assistant
     hass_token = os.getenv("HASS_TOKEN")
     if hass_token:
-        if Platform.HOMEASSISTANT not in config.platforms:
-            config.platforms[Platform.HOMEASSISTANT] = PlatformConfig()
-        config.platforms[Platform.HOMEASSISTANT].enabled = True
-        config.platforms[Platform.HOMEASSISTANT].token = hass_token
+        hass_config = _enable_from_env(Platform.HOMEASSISTANT, "HASS_TOKEN")
+        hass_config.token = hass_token
         hass_url = os.getenv("HASS_URL")
         if hass_url:
-            config.platforms[Platform.HOMEASSISTANT].extra["url"] = hass_url
+            hass_config.extra["url"] = hass_url
 
     # Email
     email_addr = os.getenv("EMAIL_ADDRESS")
@@ -1614,10 +1613,8 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
     email_imap = os.getenv("EMAIL_IMAP_HOST")
     email_smtp = os.getenv("EMAIL_SMTP_HOST")
     if all([email_addr, email_pwd, email_imap, email_smtp]):
-        if Platform.EMAIL not in config.platforms:
-            config.platforms[Platform.EMAIL] = PlatformConfig()
-        config.platforms[Platform.EMAIL].enabled = True
-        config.platforms[Platform.EMAIL].extra.update({
+        email_config = _enable_from_env(Platform.EMAIL, "EMAIL_ADDRESS / EMAIL_PASSWORD ...")
+        email_config.extra.update({
             "address": email_addr,
             "imap_host": email_imap,
             "smtp_host": email_smtp,
@@ -1634,10 +1631,8 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
     # SMS (Twilio)
     twilio_sid = os.getenv("TWILIO_ACCOUNT_SID")
     if twilio_sid:
-        if Platform.SMS not in config.platforms:
-            config.platforms[Platform.SMS] = PlatformConfig()
-        config.platforms[Platform.SMS].enabled = True
-        config.platforms[Platform.SMS].api_key = os.getenv("TWILIO_AUTH_TOKEN", "")
+        sms_config = _enable_from_env(Platform.SMS, "TWILIO_ACCOUNT_SID")
+        sms_config.api_key = os.getenv("TWILIO_AUTH_TOKEN", "")
     sms_home = os.getenv("SMS_HOME_CHANNEL")
     if sms_home and Platform.SMS in config.platforms:
         config.platforms[Platform.SMS].home_channel = HomeChannel(
@@ -1654,41 +1649,37 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
     api_server_port = os.getenv("API_SERVER_PORT")
     api_server_host = os.getenv("API_SERVER_HOST")
     if api_server_enabled or api_server_key:
-        if Platform.API_SERVER not in config.platforms:
-            config.platforms[Platform.API_SERVER] = PlatformConfig()
-        config.platforms[Platform.API_SERVER].enabled = True
+        api_server_config = _enable_from_env(Platform.API_SERVER, "API_SERVER_ENABLED / API_SERVER_KEY")
         if api_server_key:
-            config.platforms[Platform.API_SERVER].extra["key"] = api_server_key
+            api_server_config.extra["key"] = api_server_key
         if api_server_cors_origins:
             origins = [origin.strip() for origin in api_server_cors_origins.split(",") if origin.strip()]
             if origins:
-                config.platforms[Platform.API_SERVER].extra["cors_origins"] = origins
+                api_server_config.extra["cors_origins"] = origins
         if api_server_port:
             try:
-                config.platforms[Platform.API_SERVER].extra["port"] = int(api_server_port)
+                api_server_config.extra["port"] = int(api_server_port)
             except ValueError:
                 pass
         if api_server_host:
-            config.platforms[Platform.API_SERVER].extra["host"] = api_server_host
+            api_server_config.extra["host"] = api_server_host
         api_server_model_name = os.getenv("API_SERVER_MODEL_NAME", "")
         if api_server_model_name:
-            config.platforms[Platform.API_SERVER].extra["model_name"] = api_server_model_name
+            api_server_config.extra["model_name"] = api_server_model_name
 
     # Webhook platform
     webhook_enabled = os.getenv("WEBHOOK_ENABLED", "").lower() in {"true", "1", "yes"}
     webhook_port = os.getenv("WEBHOOK_PORT")
     webhook_secret = os.getenv("WEBHOOK_SECRET", "")
     if webhook_enabled:
-        if Platform.WEBHOOK not in config.platforms:
-            config.platforms[Platform.WEBHOOK] = PlatformConfig()
-        config.platforms[Platform.WEBHOOK].enabled = True
+        webhook_config = _enable_from_env(Platform.WEBHOOK, "WEBHOOK_ENABLED")
         if webhook_port:
             try:
-                config.platforms[Platform.WEBHOOK].extra["port"] = int(webhook_port)
+                webhook_config.extra["port"] = int(webhook_port)
             except ValueError:
                 pass
         if webhook_secret:
-            config.platforms[Platform.WEBHOOK].extra["secret"] = webhook_secret
+            webhook_config.extra["secret"] = webhook_secret
 
     # Microsoft Graph webhook platform
     msgraph_webhook_enabled = os.getenv("MSGRAPH_WEBHOOK_ENABLED", "").lower() in {
@@ -1710,19 +1701,21 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
         or msgraph_webhook_resources
         or msgraph_webhook_allowed_cidrs
     ):
-        if Platform.MSGRAPH_WEBHOOK not in config.platforms:
-            config.platforms[Platform.MSGRAPH_WEBHOOK] = PlatformConfig()
         if msgraph_webhook_enabled:
-            config.platforms[Platform.MSGRAPH_WEBHOOK].enabled = True
+            msgraph_config = _enable_from_env(Platform.MSGRAPH_WEBHOOK, "MSGRAPH_WEBHOOK_ENABLED")
+        else:
+            if Platform.MSGRAPH_WEBHOOK not in config.platforms:
+                config.platforms[Platform.MSGRAPH_WEBHOOK] = PlatformConfig()
+            msgraph_config = config.platforms[Platform.MSGRAPH_WEBHOOK]
         if msgraph_webhook_port:
             try:
-                config.platforms[Platform.MSGRAPH_WEBHOOK].extra["port"] = int(
+                msgraph_config.extra["port"] = int(
                     msgraph_webhook_port
                 )
             except ValueError:
                 pass
         if msgraph_webhook_client_state:
-            config.platforms[Platform.MSGRAPH_WEBHOOK].extra["client_state"] = (
+            msgraph_config.extra["client_state"] = (
                 msgraph_webhook_client_state
             )
         if msgraph_webhook_resources:
@@ -1732,7 +1725,7 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
                 if resource.strip()
             ]
             if resources:
-                config.platforms[Platform.MSGRAPH_WEBHOOK].extra[
+                msgraph_config.extra[
                     "accepted_resources"
                 ] = resources
         if msgraph_webhook_allowed_cidrs:
@@ -1742,7 +1735,7 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
                 if cidr.strip()
             ]
             if cidrs:
-                config.platforms[Platform.MSGRAPH_WEBHOOK].extra[
+                msgraph_config.extra[
                     "allowed_source_cidrs"
                 ] = cidrs
 
@@ -1750,16 +1743,14 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
     dingtalk_client_id = os.getenv("DINGTALK_CLIENT_ID")
     dingtalk_client_secret = os.getenv("DINGTALK_CLIENT_SECRET")
     if dingtalk_client_id and dingtalk_client_secret:
-        if Platform.DINGTALK not in config.platforms:
-            config.platforms[Platform.DINGTALK] = PlatformConfig()
-        config.platforms[Platform.DINGTALK].enabled = True
-        config.platforms[Platform.DINGTALK].extra.update({
+        dingtalk_config = _enable_from_env(Platform.DINGTALK, "DINGTALK_CLIENT_ID / DINGTALK_CLIENT_SECRET")
+        dingtalk_config.extra.update({
             "client_id": dingtalk_client_id,
             "client_secret": dingtalk_client_secret,
         })
         dingtalk_home = os.getenv("DINGTALK_HOME_CHANNEL")
         if dingtalk_home:
-            config.platforms[Platform.DINGTALK].home_channel = HomeChannel(
+            dingtalk_config.home_channel = HomeChannel(
                 platform=Platform.DINGTALK,
                 chat_id=dingtalk_home,
                 name=os.getenv("DINGTALK_HOME_CHANNEL_NAME", "Home"),
@@ -1770,10 +1761,8 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
     feishu_app_id = os.getenv("FEISHU_APP_ID")
     feishu_app_secret = os.getenv("FEISHU_APP_SECRET")
     if feishu_app_id and feishu_app_secret:
-        if Platform.FEISHU not in config.platforms:
-            config.platforms[Platform.FEISHU] = PlatformConfig()
-        config.platforms[Platform.FEISHU].enabled = True
-        config.platforms[Platform.FEISHU].extra.update({
+        feishu_config = _enable_from_env(Platform.FEISHU, "FEISHU_APP_ID / FEISHU_APP_SECRET")
+        feishu_config.extra.update({
             "app_id": feishu_app_id,
             "app_secret": feishu_app_secret,
             "domain": os.getenv("FEISHU_DOMAIN", "feishu"),
@@ -1781,13 +1770,13 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
         })
         feishu_encrypt_key = os.getenv("FEISHU_ENCRYPT_KEY", "")
         if feishu_encrypt_key:
-            config.platforms[Platform.FEISHU].extra["encrypt_key"] = feishu_encrypt_key
+            feishu_config.extra["encrypt_key"] = feishu_encrypt_key
         feishu_verification_token = os.getenv("FEISHU_VERIFICATION_TOKEN", "")
         if feishu_verification_token:
-            config.platforms[Platform.FEISHU].extra["verification_token"] = feishu_verification_token
+            feishu_config.extra["verification_token"] = feishu_verification_token
         feishu_home = os.getenv("FEISHU_HOME_CHANNEL")
         if feishu_home:
-            config.platforms[Platform.FEISHU].home_channel = HomeChannel(
+            feishu_config.home_channel = HomeChannel(
                 platform=Platform.FEISHU,
                 chat_id=feishu_home,
                 name=os.getenv("FEISHU_HOME_CHANNEL_NAME", "Home"),
@@ -1798,19 +1787,17 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
     wecom_bot_id = os.getenv("WECOM_BOT_ID")
     wecom_secret = os.getenv("WECOM_SECRET")
     if wecom_bot_id and wecom_secret:
-        if Platform.WECOM not in config.platforms:
-            config.platforms[Platform.WECOM] = PlatformConfig()
-        config.platforms[Platform.WECOM].enabled = True
-        config.platforms[Platform.WECOM].extra.update({
+        wecom_config = _enable_from_env(Platform.WECOM, "WECOM_BOT_ID / WECOM_SECRET")
+        wecom_config.extra.update({
             "bot_id": wecom_bot_id,
             "secret": wecom_secret,
         })
         wecom_ws_url = os.getenv("WECOM_WEBSOCKET_URL", "")
         if wecom_ws_url:
-            config.platforms[Platform.WECOM].extra["websocket_url"] = wecom_ws_url
+            wecom_config.extra["websocket_url"] = wecom_ws_url
         wecom_home = os.getenv("WECOM_HOME_CHANNEL")
         if wecom_home:
-            config.platforms[Platform.WECOM].home_channel = HomeChannel(
+            wecom_config.home_channel = HomeChannel(
                 platform=Platform.WECOM,
                 chat_id=wecom_home,
                 name=os.getenv("WECOM_HOME_CHANNEL_NAME", "Home"),
@@ -1821,10 +1808,8 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
     wecom_callback_corp_id = os.getenv("WECOM_CALLBACK_CORP_ID")
     wecom_callback_corp_secret = os.getenv("WECOM_CALLBACK_CORP_SECRET")
     if wecom_callback_corp_id and wecom_callback_corp_secret:
-        if Platform.WECOM_CALLBACK not in config.platforms:
-            config.platforms[Platform.WECOM_CALLBACK] = PlatformConfig()
-        config.platforms[Platform.WECOM_CALLBACK].enabled = True
-        config.platforms[Platform.WECOM_CALLBACK].extra.update({
+        wecom_callback_config = _enable_from_env(Platform.WECOM_CALLBACK, "WECOM_CALLBACK_CORP_ID / WECOM_CALLBACK_CORP_SECRET")
+        wecom_callback_config.extra.update({
             "corp_id": wecom_callback_corp_id,
             "corp_secret": wecom_callback_corp_secret,
             "agent_id": os.getenv("WECOM_CALLBACK_AGENT_ID", ""),
@@ -1838,12 +1823,10 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
     weixin_token = os.getenv("WEIXIN_TOKEN")
     weixin_account_id = os.getenv("WEIXIN_ACCOUNT_ID")
     if weixin_token or weixin_account_id:
-        if Platform.WEIXIN not in config.platforms:
-            config.platforms[Platform.WEIXIN] = PlatformConfig()
-        config.platforms[Platform.WEIXIN].enabled = True
+        weixin_config = _enable_from_env(Platform.WEIXIN, "WEIXIN_TOKEN / WEIXIN_ACCOUNT_ID")
         if weixin_token:
-            config.platforms[Platform.WEIXIN].token = weixin_token
-        extra = config.platforms[Platform.WEIXIN].extra
+            weixin_config.token = weixin_token
+        extra = weixin_config.extra
         if weixin_account_id:
             extra["account_id"] = weixin_account_id
         weixin_base_url = os.getenv("WEIXIN_BASE_URL", "").strip()
@@ -1869,7 +1852,7 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
             extra["split_multiline_messages"] = weixin_split_multiline
         weixin_home = os.getenv("WEIXIN_HOME_CHANNEL", "").strip()
         if weixin_home:
-            config.platforms[Platform.WEIXIN].home_channel = HomeChannel(
+            weixin_config.home_channel = HomeChannel(
                 platform=Platform.WEIXIN,
                 chat_id=weixin_home,
                 name=os.getenv("WEIXIN_HOME_CHANNEL_NAME", "Home"),
@@ -1880,10 +1863,8 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
     bluebubbles_server_url = os.getenv("BLUEBUBBLES_SERVER_URL")
     bluebubbles_password = os.getenv("BLUEBUBBLES_PASSWORD")
     if bluebubbles_server_url and bluebubbles_password:
-        if Platform.BLUEBUBBLES not in config.platforms:
-            config.platforms[Platform.BLUEBUBBLES] = PlatformConfig()
-        config.platforms[Platform.BLUEBUBBLES].enabled = True
-        config.platforms[Platform.BLUEBUBBLES].extra.update({
+        bluebubbles_config = _enable_from_env(Platform.BLUEBUBBLES, "BLUEBUBBLES_SERVER_URL / BLUEBUBBLES_PASSWORD")
+        bluebubbles_config.extra.update({
             "server_url": bluebubbles_server_url.rstrip("/"),
             "password": bluebubbles_password,
             "webhook_host": os.getenv("BLUEBUBBLES_WEBHOOK_HOST", "127.0.0.1"),
@@ -1893,7 +1874,7 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
         })
         bluebubbles_require_mention = os.getenv("BLUEBUBBLES_REQUIRE_MENTION")
         if bluebubbles_require_mention is not None:
-            config.platforms[Platform.BLUEBUBBLES].extra["require_mention"] = (
+            bluebubbles_config.extra["require_mention"] = (
                 bluebubbles_require_mention.lower() in {"true", "1", "yes", "on"}
             )
         bluebubbles_mention_patterns = os.getenv("BLUEBUBBLES_MENTION_PATTERNS")
@@ -1906,7 +1887,7 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
                     for part in bluebubbles_mention_patterns.replace("\n", ",").split(",")
                     if part.strip()
                 ]
-            config.platforms[Platform.BLUEBUBBLES].extra["mention_patterns"] = parsed_patterns
+            bluebubbles_config.extra["mention_patterns"] = parsed_patterns
     bluebubbles_home = os.getenv("BLUEBUBBLES_HOME_CHANNEL")
     if bluebubbles_home and Platform.BLUEBUBBLES in config.platforms:
         config.platforms[Platform.BLUEBUBBLES].home_channel = HomeChannel(
@@ -1920,10 +1901,8 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
     qq_app_id = os.getenv("QQ_APP_ID")
     qq_client_secret = os.getenv("QQ_CLIENT_SECRET")
     if qq_app_id or qq_client_secret:
-        if Platform.QQBOT not in config.platforms:
-            config.platforms[Platform.QQBOT] = PlatformConfig()
-        config.platforms[Platform.QQBOT].enabled = True
-        extra = config.platforms[Platform.QQBOT].extra
+        qq_config = _enable_from_env(Platform.QQBOT, "QQ_APP_ID / QQ_CLIENT_SECRET")
+        extra = qq_config.extra
         if qq_app_id:
             extra["app_id"] = qq_app_id
         if qq_client_secret:
@@ -1962,10 +1941,8 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
     yuanbao_app_id = os.getenv("YUANBAO_APP_ID") or os.getenv("YUANBAO_APP_KEY")
     yuanbao_app_secret = os.getenv("YUANBAO_APP_SECRET")
     if yuanbao_app_id and yuanbao_app_secret:
-        if Platform.YUANBAO not in config.platforms:
-            config.platforms[Platform.YUANBAO] = PlatformConfig()
-        config.platforms[Platform.YUANBAO].enabled = True
-        extra = config.platforms[Platform.YUANBAO].extra
+        yuanbao_config = _enable_from_env(Platform.YUANBAO, "YUANBAO_APP_ID / YUANBAO_APP_SECRET")
+        extra = yuanbao_config.extra
         extra["app_id"] = yuanbao_app_id
         extra["app_secret"] = yuanbao_app_secret
         yuanbao_bot_id = os.getenv("YUANBAO_BOT_ID")
@@ -1982,7 +1959,7 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
             extra["route_env"] = yuanbao_route_env
         yuanbao_home = os.getenv("YUANBAO_HOME_CHANNEL")
         if yuanbao_home:
-            config.platforms[Platform.YUANBAO].home_channel = HomeChannel(
+            yuanbao_config.home_channel = HomeChannel(
                 platform=Platform.YUANBAO,
                 chat_id=yuanbao_home,
                 name=os.getenv("YUANBAO_HOME_CHANNEL_NAME", "Home"),
@@ -2016,24 +1993,7 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
         except ValueError:
             pass
 
-    # Registry-driven enable for plugin platforms.  Built-ins have explicit
-    # blocks above; plugins expose check_fn() which is the single source of
-    # truth for "are my env vars set?".  When it returns True, ensure the
-    # platform is enabled so start() will create its adapter.  Plugins that
-    # need to seed ``PlatformConfig.extra`` from env vars (e.g. Google Chat's
-    # project_id / subscription_name) can supply ``env_enablement_fn`` on
-    # their PlatformEntry — called here BEFORE adapter construction.
-    #
-    # Enablement gate (#31116): when a plugin registers ``is_connected``
-    # (the "has the user actually configured credentials for this?" check),
-    # we MUST consult it before flipping ``enabled = True``.  Otherwise
-    # ``check_fn`` alone — which for adapter plugins typically just
-    # verifies the SDK is importable / lazy-installs it — silently enables
-    # platforms the user never opted into, and the gateway then tries to
-    # connect to Discord / Teams / Google Chat with no token and emits
-    # noisy retry-forever errors.  ``_platform_status`` was already fixed
-    # for the same bug class in commit 7849a3d73; this is the runtime
-    # counterpart.
+    # Registry-driven enable for plugin platforms
     try:
         from hermes_cli.plugins import discover_plugins
         discover_plugins()  # idempotent
@@ -2047,15 +2007,6 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
                 continue
             platform = Platform(entry.name)
             existing_cfg = config.platforms.get(platform)
-            # Seed candidate extras from ``env_enablement_fn`` so plugins
-            # whose ``is_connected`` reads ``config.extra`` (e.g. Google
-            # Chat's ``_is_connected`` checks ``config.extra["project_id"]``)
-            # see the same state they will after enablement. Without this,
-            # Google-Chat-on-env-vars-only setups silently fail the gate
-            # below even though the user is configured.  Plugins whose
-            # ``is_connected`` reads env vars directly (Discord, IRC,
-            # Teams, LINE, ntfy, Simplex) are unaffected; this only
-            # restores Google Chat.
             seed_for_probe = None
             if entry.env_enablement_fn is not None:
                 try:
@@ -2066,20 +2017,9 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
                     )
                     seed_for_probe = None
 
-            # Only consult is_connected for platforms that are NOT already
-            # explicitly configured in YAML / env (existing_cfg with
-            # enabled=True means the user wrote it themselves or another
-            # env-var bridge enabled it — keep that decision).
             if existing_cfg is None or not existing_cfg.enabled:
                 if entry.is_connected is not None:
                     try:
-                        # Probe with ``enabled=True`` since we're asking
-                        # "would this plugin BE configured if we enabled
-                        # it?" not "is it currently enabled?". Google
-                        # Chat's ``_is_connected`` short-circuits on
-                        # ``config.enabled`` being False, which on the
-                        # default ``PlatformConfig()`` would fail the
-                        # gate even with proper env vars set.
                         if existing_cfg is not None:
                             probe_cfg = existing_cfg
                             if not probe_cfg.enabled:
@@ -2090,18 +2030,15 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
                         else:
                             probe_cfg = PlatformConfig(enabled=True)
                         if isinstance(seed_for_probe, dict) and seed_for_probe:
-                            # Don't mutate ``existing_cfg``; the probe gets
-                            # a transient view with env-seeded extras layered
-                            # on top of whatever's already there.
                             probe_extra = dict(getattr(probe_cfg, "extra", {}) or {})
                             for k, v in seed_for_probe.items():
                                 if k == "home_channel":
                                     continue
                                 probe_extra.setdefault(k, v)
                             probe_cfg = PlatformConfig(
-                                enabled=True,
-                                extra=probe_extra,
-                            )
+                                    enabled=True,
+                                    extra=probe_extra,
+                                )
                         configured = bool(entry.is_connected(probe_cfg))
                     except Exception as exc:
                         logger.debug(
@@ -2117,16 +2054,11 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
                         )
                         continue
             if platform not in config.platforms:
-                config.platforms[platform] = PlatformConfig()
-            config.platforms[platform].enabled = True
-            # Commit env-seeded extras onto the now-enabled platform.
-            # We've already called ``env_enablement_fn`` above (for the
-            # probe); reuse that result instead of calling it twice.
+                config.platforms[platform] = PlatformConfig(enabled=True)
+            else:
+                _enable_from_env(platform, f"Plugin {entry.name} setup")
             if isinstance(seed_for_probe, dict) and seed_for_probe:
                 seed = dict(seed_for_probe)
-                # Extract the home_channel dict (if provided) so we wire it
-                # up as a proper HomeChannel dataclass.  Everything else is
-                # merged into ``extra``.
                 home = seed.pop("home_channel", None)
                 config.platforms[platform].extra.update(seed)
                 if isinstance(home, dict) and home.get("chat_id"):

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -130,6 +130,32 @@ def should_send_media_as_audio(platform, ext: str, is_voice: bool = False) -> bo
     return True
 
 
+def should_trust_env(config=None) -> bool:
+    """Determine whether to trust the system environment for proxies."""
+    for var in ("GATEWAY_TRUST_PROXY", "GATEWAY_TRUST_ENV"):
+        if os.environ.get(var, "").strip().lower() in ("true", "1", "yes", "on"):
+            return True
+    if config:
+        # Check platform config's extra dict first (bridged from YAML)
+        extra = getattr(config, "extra", {})
+        if isinstance(extra, dict):
+            for k in ("trust_proxy", "trust_env"):
+                if extra.get(k) is True:
+                    return True
+        for k in ("trust_proxy", "trust_env"):
+            if getattr(config, k, False) is True:
+                return True
+    try:
+        from gateway.config import load_gateway_config
+        gw_cfg = load_gateway_config()
+        if getattr(gw_cfg, "trust_proxy", False) or getattr(gw_cfg, "trust_env", False):
+            return True
+    except Exception:
+        pass
+    return False
+
+
+
 def utf16_len(s: str) -> int:
     """Count UTF-16 code units in *s*.
 
@@ -349,6 +375,7 @@ def resolve_proxy_url(
     platform_env_var: str | None = None,
     *,
     target_hosts: str | list[str] | tuple[str, ...] | set[str] | None = None,
+    config=None,
 ) -> str | None:
     """Return a proxy URL from env vars, or macOS system proxy.
 
@@ -366,6 +393,10 @@ def resolve_proxy_url(
             if should_bypass_proxy(target_hosts):
                 return None
             return normalize_proxy_url(value)
+
+    if not should_trust_env(config):
+        return None
+
     for key in ("HTTPS_PROXY", "HTTP_PROXY", "ALL_PROXY",
                 "https_proxy", "http_proxy", "all_proxy"):
         value = (os.environ.get(key) or "").strip()

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -16574,6 +16574,40 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
                  Useful for systemd services to avoid restart-loop deadlocks
                  when the previous process hasn't fully exited yet.
     """
+    # ── Proxy / trust_env global monkeypatch ──────────────────────────────
+    # Stop client sessions from implicitly trusting system/task environment
+    # proxy variables (trust_env=False by default) unless explicitly enabled.
+    # We patch aiohttp.ClientSession and httpx.AsyncClient at startup so that
+    # all platform adapters (including built-in and third-party plugins)
+    # automatically default to the resolved trust_env setting.
+    try:
+        import aiohttp
+        _orig_aiohttp_init = aiohttp.ClientSession.__init__
+
+        def _new_aiohttp_init(self, *args, **kwargs):
+            if "trust_env" not in kwargs:
+                from gateway.platforms.base import should_trust_env
+                kwargs["trust_env"] = should_trust_env()
+            _orig_aiohttp_init(self, *args, **kwargs)
+
+        aiohttp.ClientSession.__init__ = _new_aiohttp_init
+    except ImportError:
+        pass
+
+    try:
+        import httpx
+        _orig_httpx_init = httpx.AsyncClient.__init__
+
+        def _new_httpx_init(self, *args, **kwargs):
+            if "trust_env" not in kwargs:
+                from gateway.platforms.base import should_trust_env
+                kwargs["trust_env"] = should_trust_env()
+            _orig_httpx_init(self, *args, **kwargs)
+
+        httpx.AsyncClient.__init__ = _new_httpx_init
+    except ImportError:
+        pass
+
     # ── Duplicate-instance guard ──────────────────────────────────────
     # Prevent two gateways from running under the same HERMES_HOME.
     # The PID file is scoped to HERMES_HOME, so future multi-profile

--- a/hermes_cli/gateway_windows.py
+++ b/hermes_cli/gateway_windows.py
@@ -363,18 +363,40 @@ def _build_gateway_cmd_script(
     venv_dir = str(Path(python_path).resolve().parent.parent)
     lines.append(f'set "VIRTUAL_ENV={venv_dir}"')
 
+    import json
     pythonw_path = _derive_venv_pythonw(python_path)
     prog_args = [pythonw_path, "-m", "hermes_cli.main"]
     if profile_arg:
         prog_args.extend(profile_arg.split())
     prog_args.extend(["gateway", "run"])
+
+    env_overlay = {
+        "HERMES_HOME": hermes_home,
+        "PYTHONIOENCODING": "utf-8",
+        "HERMES_GATEWAY_DETACHED": "1",
+        "VIRTUAL_ENV": venv_dir,
+    }
+
+    watchdog_args = [
+        pythonw_path,
+        "-m",
+        "hermes_cli.gateway_windows",
+        "watchdog",
+        "--working-dir",
+        working_dir,
+        "--argv",
+        json.dumps(prog_args),
+        "--env",
+        json.dumps(env_overlay),
+    ]
+
     # `pythonw.exe` is a GUI-subsystem executable: cmd.exe launches it and
     # returns immediately, so the Scheduled Task action finishes without a
     # visible console window. Do NOT use `start` here; that creates an extra
     # wrapper process and made gateway lifecycle/status harder to reason about.
     # Do NOT use `--replace` for service-managed starts; repeated /Run calls
     # should be idempotent, not churn parent/child takeover loops.
-    lines.append(" ".join(_quote_cmd_script_arg(a) for a in prog_args))
+    lines.append(" ".join(_quote_cmd_script_arg(a) for a in watchdog_args))
     lines.append("exit /b 0")
     return "\r\n".join(lines) + "\r\n"
 
@@ -625,8 +647,20 @@ def _spawn_detached(script_path: Path | None = None) -> int:
     _assert_windows()
     argv, working_dir, env_overlay = _build_gateway_argv()
 
-    # Inherit PATH etc. from the current env, overlay our required vars.
-    env = {**os.environ, **env_overlay}
+    import json
+    python_exe = argv[0]
+    watchdog_argv = [
+        python_exe,
+        "-m",
+        "hermes_cli.gateway_windows",
+        "watchdog",
+        "--working-dir",
+        working_dir,
+        "--argv",
+        json.dumps(argv),
+        "--env",
+        json.dumps(env_overlay),
+    ]
 
     # DETACHED_PROCESS        0x00000008  — no console attached to child
     # CREATE_NEW_PROCESS_GROUP 0x00000200 — child gets its own group, won't
@@ -652,9 +686,9 @@ def _spawn_detached(script_path: Path | None = None) -> int:
     try:
         with open(stray_log, "ab", buffering=0) as log_fh:
             proc = subprocess.Popen(
-                argv,
+                watchdog_argv,
                 cwd=working_dir,
-                env=env,
+                env=os.environ,
                 creationflags=flags,
                 close_fds=True,
                 stdin=subprocess.DEVNULL,
@@ -669,9 +703,9 @@ def _spawn_detached(script_path: Path | None = None) -> int:
         flags_no_breakaway = flags & ~0x01000000
         with open(stray_log, "ab", buffering=0) as log_fh:
             proc = subprocess.Popen(
-                argv,
+                watchdog_argv,
                 cwd=working_dir,
-                env=env,
+                env=os.environ,
                 creationflags=flags_no_breakaway,
                 close_fds=True,
                 stdin=subprocess.DEVNULL,
@@ -1309,3 +1343,104 @@ def restart() -> None:
     # Give Windows a moment to release the listening port.
     time.sleep(1.0)
     start()
+
+
+def run_watchdog(working_dir: str, argv: list[str], env_overlay: dict[str, str]) -> None:
+    """Watchdog loop that monitors the gateway child process on Windows."""
+    import os
+    import sys
+    import time
+    import subprocess
+    from pathlib import Path
+
+    env = {**os.environ, **env_overlay}
+    hermes_home = env.get("HERMES_HOME")
+    if not hermes_home:
+        try:
+            from hermes_cli.config import get_hermes_home
+            hermes_home = str(get_hermes_home())
+        except Exception:
+            hermes_home = str(Path.home() / ".hermes")
+
+    log_dir = Path(hermes_home) / "logs"
+    log_dir.mkdir(parents=True, exist_ok=True)
+    stray_log = log_dir / "gateway-stdio.log"
+
+    def log_watchdog(message: str):
+        ts = time.strftime("%Y-%m-%d %H:%M:%S")
+        log_line = f"[{ts}] [Watchdog] {message}\n"
+        print(log_line, end="")
+        try:
+            with open(stray_log, "a", encoding="utf-8") as f:
+                f.write(log_line)
+        except Exception:
+            pass
+
+    log_watchdog(f"Starting gateway watchdog process (PID {os.getpid()})")
+    log_watchdog(f"Child command: {argv}")
+
+    # Derive python.exe from the watchdog's python path (which might be pythonw.exe)
+    child_argv = list(argv)
+    if child_argv and child_argv[0].lower().endswith("pythonw.exe"):
+        child_argv[0] = child_argv[0][:-11] + "python.exe"
+
+    restart_delay = 5  # Respawn in 5 seconds
+    
+    while True:
+        try:
+            with open(stray_log, "ab", buffering=0) as log_fh:
+                proc = subprocess.Popen(
+                    child_argv,
+                    cwd=working_dir,
+                    env=env,
+                    creationflags=0x08000000,  # CREATE_NO_WINDOW
+                    close_fds=True,
+                    stdin=subprocess.DEVNULL,
+                    stdout=log_fh,
+                    stderr=log_fh,
+                )
+            
+            log_watchdog(f"Spawned gateway worker (PID {proc.pid})")
+            
+            exit_code = proc.wait()
+            
+            if exit_code == 0:
+                log_watchdog("Worker exited cleanly (code 0). Stopping watchdog.")
+                sys.exit(0)
+            elif exit_code == 75:  # GATEWAY_SERVICE_RESTART_EXIT_CODE
+                log_watchdog("Worker requested restart (code 75). Respawning immediately.")
+                continue
+            else:
+                log_watchdog(f"Worker exited with code {exit_code}, respawning in {restart_delay} seconds...")
+                time.sleep(restart_delay)
+                
+        except KeyboardInterrupt:
+            log_watchdog("Watchdog interrupted by user.")
+            sys.exit(0)
+        except Exception as exc:
+            log_watchdog(f"Watchdog encountered error: {exc}. Retrying in {restart_delay} seconds...")
+            time.sleep(restart_delay)
+
+
+if __name__ == "__main__":
+    import argparse
+    import json
+    import sys
+
+    if len(sys.argv) > 1 and sys.argv[1] == "watchdog":
+        parser = argparse.ArgumentParser(description="Hermes Gateway Watchdog")
+        parser.add_argument("command", choices=["watchdog"])
+        parser.add_argument("--working-dir", required=True)
+        parser.add_argument("--argv", required=True)
+        parser.add_argument("--env", required=True)
+        
+        args = parser.parse_args()
+        
+        try:
+            argv_list = json.loads(args.argv)
+            env_dict = json.loads(args.env)
+        except Exception as e:
+            print(f"Error parsing watchdog arguments: {e}", file=sys.stderr)
+            sys.exit(1)
+            
+        run_watchdog(args.working_dir, argv_list, env_dict)

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -47,6 +47,7 @@ ACP_REGISTRY_MANIFEST = REPO_ROOT / "acp_registry" / "agent.json"
 AUTHOR_MAP = {
     "victor@rocketfueldev.com": "victor-kyriazakos",
     "87440198+JoaoMarcos44@users.noreply.github.com": "JoaoMarcos44",
+    "joaomarcosdias444@gmail.com": "JoaoMarcos44",
     "286497132+srojk34@users.noreply.github.com": "srojk34",
     "59806492+sitkarev@users.noreply.github.com": "sitkarev",
     "zheng@omegasys.eu": "omegazheng",

--- a/tests/gateway/test_config.py
+++ b/tests/gateway/test_config.py
@@ -996,3 +996,61 @@ class TestHomeChannelEnvOverrides:
             home = config.platforms[platform].home_channel
             assert home is not None, f"{platform.value}: home_channel should not be None"
             assert (home.chat_id, home.name) == expected, platform.value
+
+
+class TestApplyEnvOverridesExplicitDisablement:
+    def test_explicit_disablement_prevents_env_enablement(self, caplog):
+        # 1. Telegram
+        config = GatewayConfig(
+            platforms={
+                Platform.TELEGRAM: PlatformConfig(enabled=False, extra={"_enabled_explicit": True})
+            }
+        )
+        with patch.dict(os.environ, {"TELEGRAM_BOT_TOKEN": "token_abc"}, clear=True):
+            _apply_env_overrides(config)
+        assert config.platforms[Platform.TELEGRAM].enabled is False
+        assert any(
+            "will remain disabled because it was explicitly disabled in the configuration" in record.message
+            for record in caplog.records
+        )
+
+        # 2. WeChat (weixin)
+        caplog.clear()
+        config = GatewayConfig(
+            platforms={
+                Platform.WEIXIN: PlatformConfig(enabled=False, extra={"_enabled_explicit": True})
+            }
+        )
+        with patch.dict(os.environ, {"WEIXIN_TOKEN": "token_abc"}, clear=True):
+            _apply_env_overrides(config)
+        assert config.platforms[Platform.WEIXIN].enabled is False
+        assert any(
+            "will remain disabled because it was explicitly disabled in the configuration" in record.message
+            for record in caplog.records
+        )
+
+
+class TestShouldTrustEnv:
+    def test_should_trust_env_default(self):
+        from gateway.platforms.base import should_trust_env
+        with patch.dict(os.environ, {}, clear=True):
+            assert should_trust_env() is False
+
+    def test_should_trust_env_env_vars(self):
+        from gateway.platforms.base import should_trust_env
+        for var in ("GATEWAY_TRUST_PROXY", "GATEWAY_TRUST_ENV"):
+            with patch.dict(os.environ, {var: "true"}, clear=True):
+                assert should_trust_env() is True
+            with patch.dict(os.environ, {var: "1"}, clear=True):
+                assert should_trust_env() is True
+
+    def test_should_trust_env_platform_config(self):
+        from gateway.platforms.base import should_trust_env
+        pcfg = PlatformConfig(extra={"trust_proxy": True})
+        with patch.dict(os.environ, {}, clear=True):
+            assert should_trust_env(pcfg) is True
+
+        pcfg = PlatformConfig(extra={"trust_env": True})
+        with patch.dict(os.environ, {}, clear=True):
+            assert should_trust_env(pcfg) is True
+

--- a/tests/hermes_cli/test_gateway_windows.py
+++ b/tests/hermes_cli/test_gateway_windows.py
@@ -200,7 +200,9 @@ def test_gateway_cmd_script_uses_pythonw_without_replace_or_start_churn(monkeypa
     )
 
     assert "pythonw.exe" in content
-    assert "gateway run" in content
+    assert "watchdog" in content
+    assert "gateway" in content
+    assert "run" in content
     assert "--replace" not in content
     assert "start \"\"" not in content
     assert "exit /b 0" in content


### PR DESCRIPTION
### Summary
This Pull Request resolves 3 fragility bugs in the Hermes Windows Gateway service, tracked in #48820. 

---

### Bug 1: Watchdog/Supervision of the Worker (Windows Daemon Loop)

#### Motivation & Context:
On Windows, when running the gateway detached (e.g. from the Scheduled Task command script or via \hermes gateway start\), there was no watchdog. If the gateway crashed or encountered a network dropout, it would not restart, causing the background task to fail silently. Since we do not want to force users to install external binaries (like NSSM), a Python-native solution was necessary.

#### Fix:
- Added a \un_watchdog\ helper loop at the end of \hermes_cli/gateway_windows.py\ which spawns the gateway child process, pipes standard streams to \gateway-stdio.log\, and monitors the child process.
- If the child process exits with an unexpected code, the watchdog automatically logs the event and respawns it within 5 seconds.
- Clean exits (code 0) stop the watchdog, while restart requests (code 75) trigger immediate respawning.
- Updated \_spawn_detached\ and \_build_gateway_cmd_script\ (which builds \gateway.cmd\ for Task Scheduler) to launch the watchdog command as the entry point wrapper.

---

### Bug 2: \enabled: false\ Ignored When Environment Variables Are Present

#### Motivation & Context:
The configuration design dictates that \config.yaml\ is the primary source of truth for user preferences. However, if a platform was explicitly configured as \enabled: false\ in \config.yaml\, setting any environment variables (e.g., \TELEGRAM_BOT_TOKEN\) would override this configuration and force-enable the platform. We must respect the user's explicit disablement intent.

#### Fix:
- During YAML parsing in \gateway/config.py\, we generalized tracking of explicit configuration intent by marking \_enabled_explicit = True\ for all platform blocks (not just Slack).
- Standardized env overrides inside \_apply_env_overrides\ to run through a unified \_enable_from_env\ helper.
- \_enable_from_env\ checks if \_enabled_explicit\ is set to \False\ on the platform configuration. If so, it leaves the platform disabled and logs a warning instead of force-enabling it.

---

### Bug 3: \	rust_env=True\ Routing Traffic to System Proxy in Scheduled Tasks

#### Motivation & Context:
By default, all platform adapters initialized their \iohttp.ClientSession(trust_env=True)\. In a Windows Task Scheduler environment, system/user proxy environment variables (like \HTTP_PROXY\, \HTTPS_PROXY\, or system proxy settings) are implicitly inherited by the task runner. This causes bot requests to route through unexpected proxy nodes, resulting in connection timeouts or credential leakage. We need to disable this by default and gate it.

#### Fix:
- Defined a central \should_trust_env(config=None)\ helper in \gateway/platforms/base.py\.
- Added global and platform-specific \	rust_proxy\ and \	rust_env\ fields in \GatewayConfig\ and \PlatformConfig\.
- Gated proxy trust inheritance so that it defaults to \False\ unless:
  - \GATEWAY_TRUST_PROXY=true\ or \GATEWAY_TRUST_ENV=true\ is set.
  - \	rust_proxy: true\ or \	rust_env: true\ is configured in \config.yaml\ globally or under the specific platform block.
- Updated all platform adapters to use \	rust_env=should_trust_env(self.config)\ (or \should_trust_env()\ for standalone paths):
  - \gateway/platforms/matrix.py\
  - \gateway/platforms/slack.py\
  - \gateway/platforms/weixin.py\
  - \gateway/platforms/wecom.py\
  - \gateway/platforms/sms.py\
  - \gateway/platforms/qqbot/adapter.py\
  - \plugins/platforms/line/adapter.py\
  - \plugins/platforms/teams/adapter.py\
  - \plugins/platforms/google_chat/adapter.py\

---

### Verification and Tests

#### Why we added/updated the tests:
- **YAML Override Precedence (\	est_config.py\):** We added \TestApplyEnvOverridesExplicitDisablement\ to verify that platforms (tested with Telegram and WeChat) remain disabled when explicitly set to \enabled: false\ in the YAML block, even when tokens are supplied via environment variables. This prevents regression where token presence could force-enable disabled platforms.
- **Proxy Trust Helper (\	est_config.py\):** Added \TestShouldTrustEnv\ to verify the central \should_trust_env\ helper works correctly across default environment settings, proxy environment variables, and config blocks.
- **Matrix / QQBot Proxy Behavior (\	est_matrix.py\ & \	est_qqbot.py\):** Updated their test suites to verify they secure-fail to \	rust_env=False\ by default, and correctly toggle to \	rust_env=True\ when \GATEWAY_TRUST_PROXY\ is set to true. This ensures the change correctly gates environment proxy inheritance.
- All gateway test suites (\	est_config.py\, \	est_matrix.py\, \	est_qqbot.py\, \	est_slack.py\, \	est_sms.py\, \	est_wecom.py\, \	est_weixin.py\) pass cleanly.