### PR TITLE
fix(gateway): strict gateway command-line matcher + Windows restart verification

### DIFF
--- a/gateway/status.py
+++ b/gateway/status.py
@@ -14,7 +14,7 @@ concurrently under distinct configurations).
 import hashlib
 import json
 import os
-import re
+import shlex
 import signal
 import subprocess
 import sys
@@ -173,36 +173,69 @@ def looks_like_gateway_command_line(command: str | None) -> bool:
     test also matched ``hermes_cli.main gateway status`` and even unrelated
     processes like ``python -m tui_gateway`` -- which made ``restart()`` race
     against a still-draining old process and ``status``/``start`` report false
-    positives.  This requires the actual ``gateway`` subcommand to be followed
-    by ``run`` (or the gateway-dedicated entrypoints), excluding the other
+    positives.  This requires the actual ``gateway`` subcommand followed by
+    ``run`` (or one of the gateway-dedicated entrypoints), excluding the other
     ``gateway`` management subcommands and any process that merely contains the
     word "gateway".
+
+    Tokenizes quote-aware (``shlex``) so quoted Windows paths with spaces
+    (``"C:\\Program Files\\...\\hermes-gateway.exe"``) survive, and strips
+    ``--profile``/``-p`` selectors from anywhere in argv -- Hermes's
+    ``_apply_profile_override`` removes them before argparse, so the profile
+    flag (and a profile literally named ``gateway``) can legally appear on
+    either side of the ``gateway`` subcommand.
     """
     if not command:
         return False
-    normalized = command.replace("\\", "/").lower()
+
+    try:
+        raw_tokens = shlex.split(command, posix=False)
+    except ValueError:
+        raw_tokens = command.split()
+    # Strip surrounding quotes, normalize slashes + case per token.
+    tokens = [t.strip("\"'").replace("\\", "/").lower() for t in raw_tokens]
+    if not tokens:
+        return False
 
     # Gateway-dedicated entrypoints carry no subcommand to inspect.
-    if re.search(r"(^|[/\s])gateway/run\.py(\s|$)", normalized):
-        return True
-    if re.search(r"(^|[/\s])hermes-gateway(?:\.exe)?(\s|$)", normalized):
-        return True
+    for token in tokens:
+        if token == "gateway/run.py" or token.endswith("/gateway/run.py"):
+            return True
+        basename = token.rsplit("/", 1)[-1]
+        if basename in ("hermes-gateway", "hermes-gateway.exe"):
+            return True
 
+    joined = " ".join(tokens)
     has_gateway_entry = (
-        "hermes_cli.main" in normalized
-        or "hermes_cli/main.py" in normalized
-        or re.search(r"(^|[/\s])hermes(?:\.exe)?(\s|$)", normalized) is not None
+        "hermes_cli.main" in joined
+        or "hermes_cli/main.py" in joined
+        or any(t.rsplit("/", 1)[-1] in ("hermes", "hermes.exe") for t in tokens)
     )
     if not has_gateway_entry:
         return False
 
-    tokens = [t.strip("\"'").replace("\\", "/").lower() for t in command.split()]
-    for i, token in enumerate(tokens):
+    # Drop profile selectors anywhere: --profile X / -p X / --profile=X / -p=X.
+    # This consumes a profile VALUE of "gateway" too, so the real subcommand
+    # token is the one we land on below.
+    filtered: list[str] = []
+    skip_next = False
+    for token in tokens:
+        if skip_next:
+            skip_next = False
+            continue
+        if token in ("--profile", "-p"):
+            skip_next = True
+            continue
+        if token.startswith("--profile=") or token.startswith("-p="):
+            continue
+        filtered.append(token)
+
+    for i, token in enumerate(filtered):
         if token != "gateway":
             continue
-        if i + 1 >= len(tokens):
+        if i + 1 >= len(filtered):
             return True  # bare `hermes gateway` defaults to `run`
-        return tokens[i + 1] == "run"
+        return filtered[i + 1] == "run"
     return False
 
 

--- a/gateway/status.py
+++ b/gateway/status.py
@@ -14,6 +14,7 @@ concurrently under distinct configurations).
 import hashlib
 import json
 import os
+import re
 import signal
 import subprocess
 import sys
@@ -164,20 +165,53 @@ def _read_process_cmdline(pid: int) -> Optional[str]:
     return None
 
 
+def looks_like_gateway_command_line(command: str | None) -> bool:
+    """Return True only for a real ``gateway run`` process command line.
+
+    Lifecycle decisions (is the gateway up? did restart relaunch it?) must not
+    fire on loose substring matches.  The previous ``"... gateway" in cmdline``
+    test also matched ``hermes_cli.main gateway status`` and even unrelated
+    processes like ``python -m tui_gateway`` -- which made ``restart()`` race
+    against a still-draining old process and ``status``/``start`` report false
+    positives.  This requires the actual ``gateway`` subcommand to be followed
+    by ``run`` (or the gateway-dedicated entrypoints), excluding the other
+    ``gateway`` management subcommands and any process that merely contains the
+    word "gateway".
+    """
+    if not command:
+        return False
+    normalized = command.replace("\\", "/").lower()
+
+    # Gateway-dedicated entrypoints carry no subcommand to inspect.
+    if re.search(r"(^|[/\s])gateway/run\.py(\s|$)", normalized):
+        return True
+    if re.search(r"(^|[/\s])hermes-gateway(?:\.exe)?(\s|$)", normalized):
+        return True
+
+    has_gateway_entry = (
+        "hermes_cli.main" in normalized
+        or "hermes_cli/main.py" in normalized
+        or re.search(r"(^|[/\s])hermes(?:\.exe)?(\s|$)", normalized) is not None
+    )
+    if not has_gateway_entry:
+        return False
+
+    tokens = [t.strip("\"'").replace("\\", "/").lower() for t in command.split()]
+    for i, token in enumerate(tokens):
+        if token != "gateway":
+            continue
+        if i + 1 >= len(tokens):
+            return True  # bare `hermes gateway` defaults to `run`
+        return tokens[i + 1] == "run"
+    return False
+
+
 def _looks_like_gateway_process(pid: int) -> bool:
     """Return True when the live PID still looks like the Hermes gateway."""
     cmdline = _read_process_cmdline(pid)
     if not cmdline:
         return False
-
-    patterns = (
-        "hermes_cli.main gateway",
-        "hermes_cli/main.py gateway",
-        "hermes gateway",
-        "hermes-gateway",
-        "gateway/run.py",
-    )
-    return any(pattern in cmdline for pattern in patterns)
+    return looks_like_gateway_command_line(cmdline)
 
 
 def _record_looks_like_gateway(record: dict[str, Any]) -> bool:
@@ -189,15 +223,8 @@ def _record_looks_like_gateway(record: dict[str, Any]) -> bool:
     if not isinstance(argv, list) or not argv:
         return False
 
-    # Normalize Windows backslashes so patterns match cross-platform.
-    cmdline = " ".join(str(part) for part in argv).replace("\\", "/")
-    patterns = (
-        "hermes_cli.main gateway",
-        "hermes_cli/main.py gateway",
-        "hermes gateway",
-        "gateway/run.py",
-    )
-    return any(pattern in cmdline for pattern in patterns)
+    cmdline = " ".join(str(part) for part in argv)
+    return looks_like_gateway_command_line(cmdline)
 
 
 def _build_pid_record() -> dict:

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -319,23 +319,12 @@ def _scan_gateway_pids(exclude_pids: set[int], all_profiles: bool = False) -> li
     # gateway.  See #13242.
     exclude_pids = exclude_pids | _get_ancestor_pids()
     pids: list[int] = []
-    patterns = [
-        "hermes_cli.main gateway",
-        "hermes_cli.main --profile",
-        "hermes_cli.main -p",
-        "hermes_cli/main.py gateway",
-        "hermes_cli/main.py --profile",
-        "hermes_cli/main.py -p",
-        "hermes gateway",
-        # Windows: only match invocations that actually carry the ``gateway``
-        # subcommand or the gateway-dedicated console-script shim. Bare
-        # ``hermes.exe --profile`` / ``hermes.exe -p`` would also match
-        # ``hermes.exe --profile foo dashboard`` and other CLI subcommands,
-        # producing false-positive gateway PIDs (Copilot review).
-        "hermes.exe gateway",
-        "hermes-gateway.exe",
-        "gateway/run.py",
-    ]
+    # Strict command-line matcher shared with gateway.status: requires the
+    # actual ``gateway run`` subcommand (or the dedicated entrypoints), so this
+    # scan no longer false-matches ``gateway status``/``dashboard`` siblings or
+    # unrelated processes like ``python -m tui_gateway``. Lazy import mirrors the
+    # circular-import avoidance used elsewhere in this module.
+    from gateway.status import looks_like_gateway_command_line
     current_home = str(get_hermes_home().resolve())
     current_home_lc = current_home.lower()
     current_profile_arg = _profile_arg(current_home)
@@ -430,8 +419,7 @@ def _scan_gateway_pids(exclude_pids: set[int], all_profiles: bool = False) -> li
                     current_cmd = line[len("CommandLine=") :]
                 elif line.startswith("ProcessId="):
                     pid_str = line[len("ProcessId=") :]
-                    current_cmd_lc = current_cmd.lower()
-                    if any(p in current_cmd_lc for p in patterns) and (
+                    if looks_like_gateway_command_line(current_cmd) and (
                         all_profiles or _matches_current_profile(current_cmd)
                     ):
                         try:
@@ -456,8 +444,7 @@ def _scan_gateway_pids(exclude_pids: set[int], all_profiles: bool = False) -> li
                             with open(f"/proc/{pid}/cmdline", "rb") as _f:
                                 cmdline = _f.read().decode("utf-8", errors="replace")
                             cmdline = cmdline.replace("\x00", " ")
-                            cmdline_lc = cmdline.lower()
-                            if any(p in cmdline_lc for p in patterns) and (
+                            if looks_like_gateway_command_line(cmdline) and (
                                 all_profiles or _matches_current_profile(cmdline)
                             ):
                                 _append_unique_pid(pids, pid, exclude_pids)
@@ -500,8 +487,7 @@ def _scan_gateway_pids(exclude_pids: set[int], all_profiles: bool = False) -> li
 
                     if pid is None:
                         continue
-                    command_lc = command.lower()
-                    if any(pattern in command_lc for pattern in patterns) and (
+                    if looks_like_gateway_command_line(command) and (
                         all_profiles or _matches_current_profile(command)
                     ):
                         _append_unique_pid(pids, pid, exclude_pids)

--- a/hermes_cli/gateway_windows.py
+++ b/hermes_cli/gateway_windows.py
@@ -1302,10 +1302,54 @@ def stop() -> None:
         print("✗ No gateway was running")
 
 
+def _wait_for_gateway_absent(timeout_s: float = 30.0, interval_s: float = 0.5) -> bool:
+    """Block until no gateway process is detectable, or the timeout elapses.
+
+    ``stop()`` can return while the previous gateway is still draining
+    in-flight agents (the drain runs up to the restart-drain timeout). Uses the
+    authoritative ``get_running_pid()`` (lock + liveness + start-time +
+    gateway-shape) plus the now-strict ``_gateway_pids()`` scan so a relaunch
+    never races a still-alive old process.
+    """
+    from gateway.status import get_running_pid
+
+    deadline = time.monotonic() + max(timeout_s, interval_s)
+    while time.monotonic() < deadline:
+        if get_running_pid() is None and not _gateway_pids():
+            return True
+        time.sleep(interval_s)
+    return get_running_pid() is None and not _gateway_pids()
+
+
 def restart() -> None:
-    """Stop the gateway then start it again."""
+    """Stop the gateway then start it again.
+
+    Waits for the old gateway to be authoritatively gone before relaunching --
+    otherwise ``start()``'s "already running" guard sees the still-draining old
+    process and no-ops, and when that process later exits nothing replaces it (a
+    silent outage). Fails loudly if the process can't be cleared or the relaunch
+    doesn't produce a running gateway.
+    """
     _assert_windows()
+    from hermes_cli.gateway import kill_gateway_processes
+
     stop()
+
+    if not _wait_for_gateway_absent(timeout_s=30.0):
+        print("⚠ Gateway still present after stop; forcing termination before restart...")
+        kill_gateway_processes(all_profiles=False, force=True)
+        if not _wait_for_gateway_absent(timeout_s=10.0):
+            raise RuntimeError(
+                "Gateway process still detected after force kill; refusing to "
+                "start a duplicate. Investigate stray PIDs before retrying."
+            )
+
     # Give Windows a moment to release the listening port.
     time.sleep(1.0)
     start()
+
+    if not _wait_for_gateway_ready(timeout_s=15.0):
+        raise RuntimeError(
+            "Gateway restart did not produce a running gateway process. "
+            "Check logs/gateway.log and run `hermes gateway status`."
+        )

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -45,6 +45,7 @@ ACP_REGISTRY_MANIFEST = REPO_ROOT / "acp_registry" / "agent.json"
 
 # Auto-extracted from noreply emails + manual overrides
 AUTHOR_MAP = {
+    "charles@salesondemand.io": "salesondemandio",
     "victor@rocketfueldev.com": "victor-kyriazakos",
     "87440198+JoaoMarcos44@users.noreply.github.com": "JoaoMarcos44",
     "286497132+srojk34@users.noreply.github.com": "srojk34",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -534,6 +534,14 @@ def pytest_configure(config):  # noqa: D401 — pytest hook
         "behaviour — e.g. PTY tests that signal their own child).",
     )
 
+    # The pyproject addopts pin ``--timeout-method=signal`` relies on
+    # ``signal.SIGALRM``, which does not exist on Windows — pytest-timeout
+    # raises AttributeError at timer setup and the whole run aborts before any
+    # test executes. Fall back to the thread-based timer on Windows so the
+    # suite runs natively there (POSIX keeps the more reliable signal method).
+    if sys.platform == "win32" and getattr(config.option, "timeout_method", None) == "signal":
+        config.option.timeout_method = "thread"
+
 
 @pytest.fixture(autouse=True)
 def _live_system_guard(request, monkeypatch):

--- a/tests/gateway/test_gateway_command_line_matcher.py
+++ b/tests/gateway/test_gateway_command_line_matcher.py
@@ -1,0 +1,48 @@
+"""Tests for the strict gateway command-line matcher.
+
+Regression guard for the Windows ``hermes gateway restart`` silent-outage bug:
+the previous loose substring match (``"... gateway" in cmdline``) false-matched
+``gateway status``/``dashboard`` siblings and unrelated processes such as
+``python -m tui_gateway``, which let ``restart()`` race a still-draining old
+process and ``status``/``start`` report false positives.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from gateway.status import looks_like_gateway_command_line as matches
+
+
+ACCEPT = [
+    "pythonw.exe -m hermes_cli.main gateway run",
+    r"C:\Users\me\hermes\venv\Scripts\pythonw.exe -m hermes_cli.main gateway run",
+    "python -m hermes_cli.main --profile work gateway run",
+    "python -m hermes_cli.main gateway run --replace",
+    "python -m hermes_cli/main.py gateway run",
+    "python gateway/run.py",
+    "hermes-gateway.exe",
+    "hermes gateway",          # bare `hermes gateway` defaults to run
+    "hermes gateway run",
+]
+
+REJECT = [
+    "python -m tui_gateway",                              # unrelated module
+    "python -m hermes_cli.main gateway status",           # other subcommand
+    "python -m hermes_cli.main gateway restart",
+    "python -m hermes_cli.main gateway stop",
+    "python -m hermes_cli.main --profile x dashboard",    # non-gateway subcommand
+    "some random python -m mygateway thing",
+    "",
+    None,
+]
+
+
+@pytest.mark.parametrize("cmd", ACCEPT)
+def test_accepts_real_gateway_run(cmd):
+    assert matches(cmd) is True
+
+
+@pytest.mark.parametrize("cmd", REJECT)
+def test_rejects_non_gateway_run(cmd):
+    assert matches(cmd) is False

--- a/tests/gateway/test_gateway_command_line_matcher.py
+++ b/tests/gateway/test_gateway_command_line_matcher.py
@@ -24,6 +24,18 @@ ACCEPT = [
     "hermes-gateway.exe",
     "hermes gateway",          # bare `hermes gateway` defaults to run
     "hermes gateway run",
+    # profile selector AFTER the `gateway` token (argv is profile-position
+    # agnostic — _apply_profile_override strips --profile/-p anywhere)
+    "hermes gateway --profile work run",
+    "python -m hermes_cli.main gateway -p work run",
+    "hermes gateway --profile=work run",
+    # a profile literally NAMED "gateway"
+    "hermes -p gateway gateway run",
+    "python -m hermes_cli.main --profile gateway gateway run",
+    # quoted Windows paths with spaces (shlex-aware tokenization)
+    r'"C:\Program Files\Hermes\hermes-gateway.exe"',
+    r'"C:\Program Files\Hermes\gateway\run.py" run',
+    r'"C:\Program Files\Py\pythonw.exe" -m hermes_cli.main gateway run',
 ]
 
 REJECT = [


### PR DESCRIPTION
## Summary
Windows `hermes gateway start` now reliably detects the gateway it just launched, and `restart` no longer silently leaves the gateway down.

Salvage of #42664 by @salesondemandio onto current `main` (the original branch was ~556 commits behind). Root cause: gateway lifecycle decisions identified a running gateway with a loose substring match (`"hermes gateway" in cmdline`), which both **false-negatived** the real `gateway run` process (so `start` reported "no process detected after 6s" while `gateway run` connected fine) and **false-positived** siblings like `gateway status`/`dashboard` and unrelated `python -m tui_gateway`.

## Changes
- `gateway/status.py`: new shared `looks_like_gateway_command_line()` — `shlex`-aware (quoted Windows paths with spaces survive), requires the real `gateway run` subcommand or a dedicated entrypoint (`gateway/run.py`, `hermes-gateway[.exe]`), strips `--profile`/`-p` from anywhere in argv. Both `_looks_like_gateway_process` and `_record_looks_like_gateway` now use it.
- `hermes_cli/gateway.py`: `_scan_gateway_pids` drops its private pattern list and shares the strict matcher across the WMIC / `/proc` / `ps` paths.
- `hermes_cli/gateway_windows.py`: `restart()` now drains the old gateway (`_wait_for_gateway_absent`), force-kills if needed, and verifies the relaunch produced a running process — failing loudly instead of silently no-op'ing while the old process is still draining.
- `tests/conftest.py`: pytest-timeout `signal` method falls back to `thread` on Windows (no `SIGALRM`), so the suite runs natively there.
- `tests/gateway/test_gateway_command_line_matcher.py`: 25-case accept/reject regression guard.

## Validation
| | Before (loose match) | After (strict matcher) |
|---|---|---|
| `pythonw.exe -m hermes_cli.main gateway run` | detected (but raced/missed in field) | **ACCEPT** |
| quoted `"C:\...\hermes-gateway.exe"` | path-with-spaces broke substring | **ACCEPT** |
| `gateway status` / `dashboard` / `tui_gateway` | false-positive | **REJECT** |

- E2E'd the matcher against the reporter's actual Windows command lines (venv `pythonw.exe`, quoted Program Files paths, `hermes.exe gateway run`) — all 5 accept, all 4 sibling false-positives reject.
- `tests/gateway/test_gateway_command_line_matcher.py` 25/25, `test_status.py` + `test_status_command.py` 76/76 green via `scripts/run_tests.sh`.

Closes #42664 (authorship preserved via cherry-pick + rebase merge).

## Infographic

![strict-gateway-matcher](https://v3b.fal.media/files/b/0a9ee0cd/03UvXxE6CGqHTJuUfHzLP_nbhVYQad.png)
