### PR TITLE
fix(desktop): route notification clicks by stored session id

### DIFF
--- a/apps/desktop/electron/main.cjs
+++ b/apps/desktop/electron/main.cjs
@@ -5640,8 +5640,14 @@ ipcMain.handle('hermes:notify', (_event, payload) => {
   notification.on('click', () => {
     if (!mainWindow || mainWindow.isDestroyed()) return
     focusWindow(mainWindow)
-    if (payload?.sessionId) {
-      mainWindow.webContents.send('hermes:focus-session', payload.sessionId)
+    const focusSessionId =
+      typeof payload?.focusSessionId === 'string' && payload.focusSessionId
+        ? payload.focusSessionId
+        : typeof payload?.sessionId === 'string' && payload.sessionId
+          ? payload.sessionId
+          : ''
+    if (focusSessionId) {
+      mainWindow.webContents.send('hermes:focus-session', focusSessionId)
     }
   })
   notification.on('action', (_actionEvent, index) => {

--- a/apps/desktop/src/app/session/hooks/use-message-stream.test.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest'
+
+import { focusSessionIdForNotification } from './use-message-stream'
+
+describe('focusSessionIdForNotification', () => {
+  it('maps a runtime session id to its stored session id for notification focus', () => {
+    const sessionStateByRuntimeId = new Map([
+      ['runtime-1', { storedSessionId: 'stored-1' }]
+    ])
+
+    expect(focusSessionIdForNotification('runtime-1', sessionStateByRuntimeId)).toBe('stored-1')
+  })
+
+  it('returns undefined when the runtime session has no stored session id yet', () => {
+    const sessionStateByRuntimeId = new Map([
+      ['runtime-1', { storedSessionId: null }]
+    ])
+
+    expect(focusSessionIdForNotification('runtime-1', sessionStateByRuntimeId)).toBeUndefined()
+  })
+
+  it('returns undefined when there is no runtime session id', () => {
+    const sessionStateByRuntimeId = new Map([
+      ['runtime-1', { storedSessionId: 'stored-1' }]
+    ])
+
+    expect(focusSessionIdForNotification(undefined, sessionStateByRuntimeId)).toBeUndefined()
+  })
+})

--- a/apps/desktop/src/app/session/hooks/use-message-stream.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream.ts
@@ -86,6 +86,17 @@ type SessionRuntimeStatePatch = Partial<
   >
 >
 
+export function focusSessionIdForNotification(
+  runtimeSessionId: null | string | undefined,
+  sessionStateByRuntimeId: ReadonlyMap<string, Pick<ClientSessionState, 'storedSessionId'>>
+): string | undefined {
+  if (!runtimeSessionId) {
+    return undefined
+  }
+
+  return sessionStateByRuntimeId.get(runtimeSessionId)?.storedSessionId ?? undefined
+}
+
 function sessionInfoStatePatch(payload: GatewayEventPayload | undefined): SessionRuntimeStatePatch {
   const patch: SessionRuntimeStatePatch = {}
 
@@ -263,6 +274,23 @@ export function useMessageStream({
   sessionStateByRuntimeIdRef,
   updateSessionState
 }: MessageStreamOptions) {
+  const notifySession = useCallback(
+    (
+      input: Omit<Parameters<typeof dispatchNativeNotification>[0], 'focusSessionId'> & {
+        focusSessionId?: null | string
+      }
+    ) => {
+      dispatchNativeNotification({
+        ...input,
+        focusSessionId:
+          input.focusSessionId ??
+          focusSessionIdForNotification(input.sessionId, sessionStateByRuntimeIdRef.current) ??
+          undefined
+      })
+    },
+    [sessionStateByRuntimeIdRef]
+  )
+
   const sessionInterrupted = useCallback(
     (sessionId: string) => sessionStateByRuntimeIdRef.current.get(sessionId)?.interrupted ?? false,
     [sessionStateByRuntimeIdRef]
@@ -655,14 +683,14 @@ export function useMessageStream({
         void hydrateFromStoredSession(3, completedState.storedSessionId, sessionId)
       }
 
-      dispatchNativeNotification({
+      notifySession({
         body: text.slice(0, 140) || translateNow('notifications.native.turnDoneBody'),
         kind: 'turnDone',
         sessionId,
         title: translateNow('notifications.native.turnDoneTitle')
       })
     },
-    [hydrateFromStoredSession, refreshSessions, updateSessionState]
+    [hydrateFromStoredSession, notifySession, refreshSessions, updateSessionState]
   )
 
   const failAssistantMessage = useCallback(
@@ -972,7 +1000,7 @@ export function useMessageStream({
             updateSessionState(sessionId, state => ({ ...state, needsInput: true }))
           }
 
-          dispatchNativeNotification({
+          notifySession({
             body: question,
             kind: 'input',
             sessionId,
@@ -1001,7 +1029,7 @@ export function useMessageStream({
           updateSessionState(sessionId, state => ({ ...state, needsInput: true }))
         }
 
-        dispatchNativeNotification({
+        notifySession({
           actions: [
             { id: 'approve', text: translateNow('notifications.native.approveAction') },
             { id: 'reject', text: translateNow('notifications.native.rejectAction') }
@@ -1023,7 +1051,7 @@ export function useMessageStream({
             updateSessionState(sessionId, state => ({ ...state, needsInput: true }))
           }
 
-          dispatchNativeNotification({
+          notifySession({
             body: translateNow('notifications.native.inputBody'),
             kind: 'input',
             sessionId,
@@ -1050,7 +1078,7 @@ export function useMessageStream({
             updateSessionState(sessionId, state => ({ ...state, needsInput: true }))
           }
 
-          dispatchNativeNotification({
+          notifySession({
             body: promptText || envVar || translateNow('notifications.native.inputBody'),
             kind: 'input',
             sessionId,
@@ -1120,7 +1148,7 @@ export function useMessageStream({
           compactedTurnRef.current.delete(sessionId)
         }
 
-        dispatchNativeNotification({
+        notifySession({
           body: errorMessage,
           kind: 'turnError',
           sessionId,
@@ -1159,6 +1187,7 @@ export function useMessageStream({
       completeAssistantMessage,
       failAssistantMessage,
       flushQueuedDeltas,
+      notifySession,
       queryClient,
       refreshHermesConfig,
       sessionInterrupted,

--- a/apps/desktop/src/global.d.ts
+++ b/apps/desktop/src/global.d.ts
@@ -419,6 +419,7 @@ export interface HermesNotification {
   silent?: boolean
   kind?: string
   sessionId?: string
+  focusSessionId?: string
   actions?: { id: string; text: string }[]
 }
 

--- a/apps/desktop/src/store/native-notifications.test.ts
+++ b/apps/desktop/src/store/native-notifications.test.ts
@@ -117,11 +117,23 @@ describe('dispatchNativeNotification preferences', () => {
     expect(notify).toHaveBeenCalledTimes(1)
   })
 
-  it('forwards kind and sessionId to the bridge', () => {
+  it('forwards kind, runtime sessionId, and focusSessionId to the bridge', () => {
     setActiveSessionId('abc')
-    dispatchNativeNotification({ body: 'hi', kind: 'turnError', sessionId: 'abc', title: 'boom' })
+    dispatchNativeNotification({
+      body: 'hi',
+      focusSessionId: 'stored-abc',
+      kind: 'turnError',
+      sessionId: 'abc',
+      title: 'boom'
+    })
     expect(notify).toHaveBeenCalledWith(
-      expect.objectContaining({ body: 'hi', kind: 'turnError', sessionId: 'abc', title: 'boom' })
+      expect.objectContaining({
+        body: 'hi',
+        focusSessionId: 'stored-abc',
+        kind: 'turnError',
+        sessionId: 'abc',
+        title: 'boom'
+      })
     )
   })
 })

--- a/apps/desktop/src/store/native-notifications.ts
+++ b/apps/desktop/src/store/native-notifications.ts
@@ -134,6 +134,7 @@ export interface NativeNotificationInput {
   title: string
   body?: string
   sessionId?: null | string
+  focusSessionId?: null | string
   silent?: boolean
   actions?: NativeNotificationAction[]
 }
@@ -156,6 +157,7 @@ export function dispatchNativeNotification(input: NativeNotificationInput): void
   void window.hermesDesktop?.notify({
     actions: input.actions,
     body: input.body,
+    focusSessionId: input.focusSessionId ?? undefined,
     kind: input.kind,
     sessionId: input.sessionId ?? undefined,
     silent: input.silent,


### PR DESCRIPTION
## What does this PR do?

Fixes desktop notification clicks routing to `session not found` by separating the session id used for notification actions from the id used for session navigation.

Notification clicks were forwarding the live runtime session id into the route-resume path, but that path expects a stored session id. When the runtime id no longer matched a resumable stored session, Desktop focused the window and then failed to load the target chat. This change preserves the runtime id for approval actions while sending notification body clicks through a dedicated `focusSessionId` field derived from the stored session id.

## Related Issue

Fixes #48808

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- add `focusSessionId` to desktop native notification payloads and bridge types
- derive `focusSessionId` from the runtime->stored session mapping in `use-message-stream`
- keep notification action handlers on the existing runtime `sessionId`
- route notification body clicks through `focusSessionId` first, with a fallback to the legacy field
- add focused tests covering notification payload forwarding and runtime->stored focus mapping

## How to Test

1. Run `npm run test:ui -- src/store/native-notifications.test.ts src/app/session/hooks/use-message-stream.test.ts` from `apps/desktop`.
2. Confirm the notification bridge test preserves `sessionId` and forwards `focusSessionId`.
3. Confirm the `focusSessionIdForNotification` test maps a runtime session id to the stored session id used by route resume.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform:

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Not applicable.
