### PR TITLE
fix(gateway): initialize SSL_CERT_FILE before any HTTP-library import

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -13,6 +13,85 @@ Usage:
     python cli.py --gateway
 """
 
+# ---------------------------------------------------------------------------
+# SSL certificate auto-detection.
+#
+# Must run BEFORE any HTTP library (aiohttp, httpx, discord.py, etc.) is
+# imported, otherwise long-lived clients that cache an SSL context at module
+# load time will use whatever the default verify paths resolved to back then.
+#
+# Distros where Python's compiled-in default CA path (typically
+# ``/etc/ssl/cert.pem``) does not exist — Debian/Ubuntu without
+# ``ca-certificates`` exposing that exact path, NixOS, Alpine without the
+# Mozilla bundle, certain minimal containers — would otherwise fail the
+# Discord/Telegram TLS handshake with::
+#
+#     ssl.SSLCertVerificationError: [SSL: CERTIFICATE_VERIFY_FAILED]
+#     certificate verify failed: unable to get local issuer certificate
+#
+# This block runs eagerly at module import so every subsequent import sees
+# a valid ``SSL_CERT_FILE``.
+# ---------------------------------------------------------------------------
+import os as _os
+import logging as _logging
+
+
+def _ensure_ssl_certs() -> None:
+    """Set ``SSL_CERT_FILE`` if the system doesn't expose CA certs to Python.
+
+    Some startup paths (Windows installer children, Scheduled Tasks, and the
+    occasional desktop launcher) inherit a stale ``SSL_CERT_FILE`` pointing at
+    a path that no longer exists. Returning early just because the variable is
+    *present* makes every later httpx/aiohttp client construction fail with
+    ``FileNotFoundError`` from ``ssl.load_verify_locations()``. Treat a missing
+    path as unset and fall through to the discovery chain below.
+    """
+    configured_cert = _os.environ.get("SSL_CERT_FILE")
+    if configured_cert:
+        if _os.path.exists(configured_cert):
+            return  # user already configured it to a real file
+        _logging.getLogger(__name__).warning(
+            "Ignoring stale SSL_CERT_FILE=%r because the path does not exist",
+            configured_cert,
+        )
+        _os.environ.pop("SSL_CERT_FILE", None)
+
+    import ssl
+
+    # 1. Python's compiled-in defaults
+    paths = ssl.get_default_verify_paths()
+    for candidate in (paths.cafile, paths.openssl_cafile):
+        if candidate and _os.path.exists(candidate):
+            _os.environ["SSL_CERT_FILE"] = candidate
+            return
+
+    # 2. certifi (ships its own Mozilla bundle; vendored in the venv)
+    try:
+        import certifi
+        _os.environ["SSL_CERT_FILE"] = certifi.where()
+        return
+    except ImportError:
+        pass
+
+    # 3. Common distro / macOS locations
+    for candidate in (
+        "/etc/ssl/certs/ca-certificates.crt",                # Debian/Ubuntu/Gentoo
+        "/etc/pki/tls/certs/ca-bundle.crt",                  # RHEL/CentOS 7
+        "/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem", # RHEL/CentOS 8+
+        "/etc/ssl/ca-bundle.pem",                            # SUSE/OpenSUSE
+        "/etc/ssl/cert.pem",                                 # Alpine / macOS
+        "/etc/pki/tls/cert.pem",                             # Fedora
+        "/usr/local/etc/openssl@1.1/cert.pem",               # macOS Homebrew Intel
+        "/opt/homebrew/etc/openssl@1.1/cert.pem",            # macOS Homebrew ARM
+    ):
+        if _os.path.exists(candidate):
+            _os.environ["SSL_CERT_FILE"] = candidate
+            return
+
+
+_ensure_ssl_certs()
+del _ensure_ssl_certs
+
 # IMPORTANT: hermes_bootstrap must be the very first import — UTF-8 stdio
 # on Windows.  No-op on POSIX.  See hermes_bootstrap.py for full rationale.
 try:
@@ -1051,61 +1130,6 @@ def _collect_auto_append_media_tags(
 
     return media_tags, has_voice_directive
 
-# ---------------------------------------------------------------------------
-# SSL certificate auto-detection for NixOS and other non-standard systems.
-# Must run BEFORE any HTTP library (discord, aiohttp, etc.) is imported.
-# ---------------------------------------------------------------------------
-def _ensure_ssl_certs() -> None:
-    """Set SSL_CERT_FILE if the system doesn't expose CA certs to Python.
-
-    Windows startup paths (Desktop, Scheduled Tasks, installer children) can
-    occasionally inherit a stale SSL_CERT_FILE. Returning just because the
-    variable is present makes every later httpx/OpenAI client construction fail
-    with FileNotFoundError from ssl.load_verify_locations(). Treat a missing
-    path as unset and fall back to certifi instead.
-    """
-    configured_cert = os.environ.get("SSL_CERT_FILE")
-    if configured_cert:
-        if os.path.exists(configured_cert):
-            return  # user already configured it to a real file
-        logging.getLogger(__name__).warning(
-            "Ignoring stale SSL_CERT_FILE=%r because the path does not exist",
-            configured_cert,
-        )
-        os.environ.pop("SSL_CERT_FILE", None)
-
-    import ssl
-
-    # 1. Python's compiled-in defaults
-    paths = ssl.get_default_verify_paths()
-    for candidate in (paths.cafile, paths.openssl_cafile):
-        if candidate and os.path.exists(candidate):
-            os.environ["SSL_CERT_FILE"] = candidate
-            return
-
-    # 2. certifi (ships its own Mozilla bundle)
-    try:
-        import certifi
-        os.environ["SSL_CERT_FILE"] = certifi.where()
-        return
-    except ImportError:
-        pass
-
-    # 3. Common distro / macOS locations
-    for candidate in (
-        "/etc/ssl/certs/ca-certificates.crt",               # Debian/Ubuntu/Gentoo
-        "/etc/pki/tls/certs/ca-bundle.crt",                 # RHEL/CentOS 7
-        "/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem", # RHEL/CentOS 8+
-        "/etc/ssl/ca-bundle.pem",                            # SUSE/OpenSUSE
-        "/etc/ssl/cert.pem",                                 # Alpine / macOS
-        "/etc/pki/tls/cert.pem",                             # Fedora
-        "/usr/local/etc/openssl@1.1/cert.pem",               # macOS Homebrew Intel
-        "/opt/homebrew/etc/openssl@1.1/cert.pem",            # macOS Homebrew ARM
-    ):
-        if os.path.exists(candidate):
-            os.environ["SSL_CERT_FILE"] = candidate
-            return
-
 def _home_target_env_var(platform_name: str) -> str:
     """Return the configured home-target env var for a platform.
 
@@ -1147,8 +1171,6 @@ def _clear_planned_restart_notification() -> None:
 # Mark this process as a gateway so cli.py's module-level load_cli_config()
 # knows not to clobber TERMINAL_CWD if lazily imported.
 os.environ["_HERMES_GATEWAY"] = "1"
-
-_ensure_ssl_certs()
 
 # Add parent directory to path
 sys.path.insert(0, str(Path(__file__).parent.parent))


### PR DESCRIPTION
## Problem

The gateway's `_ensure_ssl_certs()` helper is defined and invoked *after*
the top-of-file `from agent.account_usage import ...` (which transitively
imports `httpx`). On Linux distros where Python's compiled-in default CA
path (typically `/etc/ssl/cert.pem`) does not exist, that ordering means
the SSL stack is touched before `SSL_CERT_FILE` is configured, and the
Discord adapter then fails to log in with:

```
aiohttp.client_exceptions.ClientConnectorCertificateError:
Cannot connect to host discord.com:443 ssl:True [SSLCertVerificationError:
(1, '[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed:
unable to get local issuer certificate (_ssl.c:1016)')]
```

Affected environments I've reproduced or confirmed by inspection:

- Debian/Ubuntu installs where `ca-certificates` is present but
  `/etc/ssl/cert.pem` is not exposed (Python's `ssl.get_default_verify_paths()`
  returns `cafile=None, openssl_cafile='/etc/ssl/cert.pem'` and the latter
  is missing).
- NixOS (long-standing pattern, hence the original "for NixOS" comment).
- Minimal containers / Alpine without the Mozilla CA bundle in the default
  path.

The platforms affected in practice are Discord (aiohttp) and Telegram /
others that build a `ClientSession` once per process — they cache an SSL
context the first time they connect, so a late `SSL_CERT_FILE` doesn't
help them.

## Fix

Move the helper to the very top of `gateway/run.py`, before
`hermes_bootstrap` and before any project import, so `SSL_CERT_FILE` is
set the moment any downstream module touches the `ssl` stack. The helper
itself is unchanged — same fallback chain:

1. Python's compiled-in `ssl.get_default_verify_paths()`.
2. `certifi` (vendored in the venv).
3. Common distro / macOS locations.

Implementation details:

- Local aliases `_os` / `_logging` are used because the regular
  `import os` / `import logging` happen later in the file (line ~27).
  After running the helper we `del _ensure_ssl_certs` so the aliases
  remain only as small private references.
- The body of the function is identical to the original; only its
  *placement* moved.
- The stale-`SSL_CERT_FILE` warning behaviour (Windows installer
  children sometimes inherit a path that no longer exists) is preserved.

## Verification

Reproduced the failure on a Debian-family host where
`/etc/ssl/cert.pem` is absent, then applied this patch and confirmed:

1. `python3 -c "exec(open('gateway/run.py').read().split('# IMPORTANT')[0])"`
   sets `SSL_CERT_FILE` to the certifi bundle before any HTTP library
   is loaded.
2. The Discord adapter logs in cleanly after the gateway restart, and
   the `ClientConnectorCertificateError` no longer appears in
   `journalctl -u hermes-gateway`.
3. `python -m py_compile gateway/run.py` passes; ruff / pyflakes are
   clean for the touched lines.

## Risk

- Diff is purely a code-move within one file (+79/-57). No behaviour
  change for hosts where `SSL_CERT_FILE` was already set or where the
  Python defaults already point at a real CA bundle.
- The helper now runs before `hermes_bootstrap`, but it only does
  filesystem reads + `os.environ` writes — no stdio, no Hermes
  modules, no Windows-specific paths. Safe to run that early.
- Pyright/Pylint may flag `_os` / `_logging` as unconventional, but
  they're necessary for the "before any normal import" constraint and
  scoped private (leading underscore).
