### PR TITLE
fix(desktop): preserve Linux launchability after update rebuild

### DIFF
--- a/apps/desktop/electron/main.cjs
+++ b/apps/desktop/electron/main.cjs
@@ -5205,6 +5205,14 @@ function createWindow() {
   mainWindow.once('ready-to-show', () => {
     if (mainWindow && !mainWindow.isDestroyed()) mainWindow.show()
   })
+  // Some Linux desktop stacks can complete the backend/renderer boot but still
+  // leave the BrowserWindow hidden if ready-to-show is delayed or the compositor
+  // misses the initial map. Do not let a successful launch look like a no-op.
+  setTimeout(() => {
+    if (mainWindow && !mainWindow.isDestroyed() && !mainWindow.isVisible()) {
+      focusWindow(mainWindow)
+    }
+  }, 4000).unref?.()
 
   mainWindow.on('will-enter-full-screen', () => sendWindowStateChanged(true))
   mainWindow.on('enter-full-screen', () => sendWindowStateChanged(true))
@@ -6467,9 +6475,10 @@ if (!_gotSingleInstanceLock) {
   app.on('second-instance', (_event, argv) => {
     const url = _extractDeepLink(argv)
     if (url) handleDeepLink(url)
-    else if (mainWindow) {
-      if (mainWindow.isMinimized()) mainWindow.restore()
-      mainWindow.focus()
+    else if (mainWindow && !mainWindow.isDestroyed()) {
+      focusWindow(mainWindow)
+    } else if (app.isReady()) {
+      createWindow()
     }
   })
 }

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -5327,6 +5327,31 @@ def _desktop_macos_relaunchable_fixup(desktop_dir: Path) -> None:
         print(f"  (warning: macOS relaunch fixup skipped: {exc})")
 
 
+def _desktop_linux_sandbox_configured(packaged_executable: Path) -> bool:
+    """Return True when Electron's Linux SUID sandbox helper is ready."""
+    if sys.platform != "linux":
+        return True
+
+    sandbox = packaged_executable.parent / "chrome-sandbox"
+    try:
+        sandbox_lstat = sandbox.lstat()
+    except OSError:
+        return False
+    return (
+        stat.S_ISREG(sandbox_lstat.st_mode)
+        and sandbox_lstat.st_uid == 0
+        and stat.S_IMODE(sandbox_lstat.st_mode) == 0o4755
+    )
+
+
+def _desktop_stdio_can_prompt_for_sudo() -> bool:
+    """True when a child ``sudo`` prompt can reasonably ask the user."""
+    try:
+        return bool(sys.stdin.isatty() and sys.stdout.isatty())
+    except Exception:
+        return False
+
+
 def _desktop_linux_sandbox_fixup(packaged_executable: Path) -> bool:
     """Configure Electron's Linux SUID sandbox helper when required."""
     if sys.platform != "linux":
@@ -5349,7 +5374,7 @@ def _desktop_linux_sandbox_fixup(packaged_executable: Path) -> bool:
         print(f"✗ Electron's Linux sandbox helper is not a regular file: {sandbox}")
         return False
 
-    if sandbox_lstat.st_uid == 0 and stat.S_IMODE(sandbox_lstat.st_mode) == 0o4755:
+    if _desktop_linux_sandbox_configured(packaged_executable):
         return True
 
     sudo = shutil.which("sudo")
@@ -5529,6 +5554,24 @@ def cmd_gui(args: argparse.Namespace):
             print("  Expected an unpacked Electron app for the current OS.")
             sys.exit(1)
         else:
+            if sys.platform == "linux":
+                # ``hermes update`` drives ``hermes desktop --build-only`` after
+                # pulling desktop changes. electron-builder restages
+                # ``chrome-sandbox`` as a normal user-owned file, so returning
+                # here without restoring root:4755 leaves the next
+                # ``hermes desktop`` launch broken until it prompts for sudo.
+                # Only prompt when this build-only run is attached to an
+                # interactive terminal; desktop/in-app updates use piped stdio
+                # and should not hang on a password prompt.
+                if _desktop_stdio_can_prompt_for_sudo():
+                    if not _desktop_linux_sandbox_fixup(packaged_executable):
+                        sys.exit(1)
+                elif not _desktop_linux_sandbox_configured(packaged_executable):
+                    print(
+                        "  ⚠ Desktop packaged app built, but Electron's Linux "
+                        "sandbox helper still needs sudo."
+                    )
+                    print("    Run once from a terminal to finish setup:  hermes desktop")
             print(f"✓ Desktop packaged app ready: {packaged_executable} (not launching; --build-only)")
         return
 

--- a/tests/hermes_cli/test_gui_command.py
+++ b/tests/hermes_cli/test_gui_command.py
@@ -222,6 +222,43 @@ def test_gui_linux_skips_fixup_when_already_configured(tmp_path, monkeypatch):
     assert mock_run.call_args.args[0] == [str(packaged_exe)]
 
 
+def test_gui_build_only_configures_linux_sandbox_before_return(tmp_path, monkeypatch):
+    root = _make_desktop_tree(tmp_path)
+    monkeypatch.setattr(cli_main, "PROJECT_ROOT", root)
+    packaged_exe = _make_packaged_executable(root, monkeypatch, platform="linux")
+    sandbox = packaged_exe.parent / "chrome-sandbox"
+    sandbox.write_text("", encoding="utf-8")
+    sandbox.chmod(0o755)
+    ok = subprocess.CompletedProcess([], 0)
+
+    with patch("hermes_cli.main.shutil.which", return_value="/usr/bin/sudo"), \
+         patch("hermes_cli.main._desktop_build_needed", return_value=False), \
+         patch("hermes_cli.main._desktop_stdio_can_prompt_for_sudo", return_value=True), \
+         patch("hermes_cli.main.subprocess.run", return_value=ok) as mock_run:
+        cli_main.cmd_gui(_ns(build_only=True))
+
+    assert mock_run.call_args_list[0].args[0] == ["/usr/bin/sudo", "chown", "root:root", str(sandbox)]
+    assert mock_run.call_args_list[1].args[0] == ["/usr/bin/sudo", "chmod", "4755", str(sandbox)]
+
+
+def test_gui_build_only_noninteractive_warns_when_sandbox_needs_fixup(tmp_path, monkeypatch, capsys):
+    root = _make_desktop_tree(tmp_path)
+    monkeypatch.setattr(cli_main, "PROJECT_ROOT", root)
+    _make_packaged_executable(root, monkeypatch, platform="linux")
+
+    with patch("hermes_cli.main.shutil.which", return_value="/usr/bin/npm"), \
+         patch("hermes_cli.main._desktop_build_needed", return_value=False), \
+         patch("hermes_cli.main._desktop_stdio_can_prompt_for_sudo", return_value=False), \
+         patch("hermes_cli.main._desktop_linux_sandbox_configured", return_value=False), \
+         patch("hermes_cli.main.subprocess.run") as mock_run:
+        cli_main.cmd_gui(_ns(build_only=True))
+
+    mock_run.assert_not_called()
+    out = capsys.readouterr().out
+    assert "sandbox helper still needs sudo" in out
+    assert "hermes desktop" in out
+
+
 def test_gui_source_mode_uses_renderer_build_and_electron(tmp_path, monkeypatch):
     root = _make_desktop_tree(tmp_path)
     desktop_dir = root / "apps" / "desktop"


### PR DESCRIPTION
## Summary
- Configure Electron's Linux `chrome-sandbox` helper during interactive desktop build-only runs, including the rebuild path used by `hermes update`.
- Warn instead of hanging/failing unclearly when build-only runs in a non-interactive context that cannot prompt for sudo.
- Include the Linux/GNOME window-show fallback so a healthy renderer/backend is explicitly shown/raised after launch.

## Why
`hermes update` can rebuild the packaged desktop app with electron-builder. On Linux that restages `chrome-sandbox` as a normal user-owned `0755` file, so the next `hermes desktop` launch can prompt for sudo again or fail in non-interactive launch contexts. Running the sandbox helper configuration from the build-only path preserves launchability after updates.

## Test Plan
- `uv run --with pytest --with pyyaml --with pytest-xdist python -m pytest tests/hermes_cli/test_gui_command.py -q -o 'addopts='`
- `node --check apps/desktop/electron/main.cjs`
- `node --test apps/desktop/electron/session-windows.test.cjs apps/desktop/electron/bootstrap-platform.test.cjs apps/desktop/electron/update-rebuild.test.cjs`

Note: `npm --workspace apps/desktop run test:desktop:platforms` was also run locally; it had one pre-existing failure in `electron/windows-child-process.test.cjs` unrelated to this change.