### PR TITLE
Fix Telegram cron delivery into DM topics

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -594,6 +594,33 @@ def _resolve_delivery_target(job: dict) -> Optional[dict]:
     return targets[0] if targets else None
 
 
+def _delivery_metadata_for_target(platform_name: str, chat_id: str, thread_id: Optional[str]) -> dict | None:
+    """Build adapter metadata for a resolved cron delivery target.
+
+    Most platforms only need the generic ``thread_id``. Telegram private DM
+    topics are different: synthetic sends without a reply anchor must carry
+    ``direct_messages_topic_id`` or the adapter can reject/fall back out of the
+    requested topic lane.
+    """
+    if thread_id is None:
+        return None
+
+    metadata: dict[str, str | bool] = {"thread_id": str(thread_id)}
+    if platform_name.lower() != "telegram":
+        return metadata
+
+    try:
+        is_private_chat = int(str(chat_id)) > 0
+    except (TypeError, ValueError):
+        is_private_chat = False
+
+    if is_private_chat and str(thread_id) not in {"", "1"}:
+        metadata["telegram_dm_topic_reply_fallback"] = True
+        metadata["direct_messages_topic_id"] = str(thread_id)
+
+    return metadata
+
+
 # Media extension sets — audio routing is centralized in gateway.platforms.base
 # via should_send_media_as_audio() so Telegram-specific rules stay in one place.
 _VIDEO_EXTS = frozenset({'.mp4', '.mov', '.avi', '.mkv', '.webm', '.3gp'})
@@ -757,7 +784,7 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
         runtime_adapter = (adapters or {}).get(platform)
         delivered = False
         if runtime_adapter is not None and loop is not None and getattr(loop, "is_running", lambda: False)():
-            send_metadata = {"thread_id": thread_id} if thread_id else None
+            send_metadata = _delivery_metadata_for_target(platform_name, chat_id, thread_id)
             try:
                 # Send cleaned text (MEDIA tags stripped) — not the raw content
                 text_to_send = cleaned_delivery_content.strip()

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -657,6 +657,55 @@ class TestDeliverResultWrapping:
         voice_call = adapter.send_voice.call_args
         assert voice_call[1]["audio_path"] == str(media_path)
 
+    def test_live_adapter_telegram_dm_topic_uses_direct_messages_topic_metadata(self):
+        """Cron deliveries to Telegram private DM topics must preserve direct topic metadata."""
+        from gateway.config import Platform
+        from concurrent.futures import Future
+
+        adapter = AsyncMock()
+        adapter.send.return_value = MagicMock(success=True)
+
+        pconfig = MagicMock()
+        pconfig.enabled = True
+        mock_cfg = MagicMock()
+        mock_cfg.platforms = {Platform.TELEGRAM: pconfig}
+
+        loop = MagicMock()
+        loop.is_running.return_value = True
+
+        def fake_run_coro(coro, _loop):
+            future = Future()
+            future.set_result(MagicMock(success=True))
+            coro.close()
+            return future
+
+        job = {
+            "id": "topic-job",
+            "deliver": "telegram:123456789:20197",
+        }
+
+        with patch("gateway.config.load_gateway_config", return_value=mock_cfg), \
+             patch("cron.scheduler.load_config", return_value={"cron": {"wrap_response": False}}), \
+             patch("asyncio.run_coroutine_threadsafe", side_effect=fake_run_coro), \
+             patch("tools.send_message_tool._send_to_platform", new=AsyncMock(return_value={"success": True})) as send_mock:
+            _deliver_result(
+                job,
+                "hello from cron",
+                adapters={Platform.TELEGRAM: adapter},
+                loop=loop,
+            )
+
+        adapter.send.assert_called_once_with(
+            "123456789",
+            "hello from cron",
+            metadata={
+                "thread_id": "20197",
+                "telegram_dm_topic_reply_fallback": True,
+                "direct_messages_topic_id": "20197",
+            },
+        )
+        send_mock.assert_not_awaited()
+
     def test_live_adapter_routes_image_to_send_image_file(self, tmp_path, monkeypatch):
         """Image MEDIA files should be routed to send_image_file, not send_voice."""
         from gateway.config import Platform

--- a/tests/tools/test_send_message_missing_platforms.py
+++ b/tests/tools/test_send_message_missing_platforms.py
@@ -8,6 +8,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 from tools.send_message_tool import (
     _send_dingtalk,
     _send_matrix,
+    _telegram_thread_kwargs,
 )
 
 # ``_send_mattermost`` moved into the mattermost plugin
@@ -224,6 +225,32 @@ class TestSendMatrix:
 
         assert len(txn_ids) == 2
         assert txn_ids[0] != txn_ids[1]
+
+
+# ---------------------------------------------------------------------------
+# _telegram_thread_kwargs
+# ---------------------------------------------------------------------------
+
+
+class TestTelegramThreadKwargs:
+    def test_general_topic_is_omitted(self):
+        assert _telegram_thread_kwargs("-1001234567890", "1") == {}
+        assert _telegram_thread_kwargs("-1001234567890", 1) == {}
+
+    def test_forum_topic_uses_message_thread_id(self):
+        assert _telegram_thread_kwargs("-1001234567890", "17585") == {
+            "message_thread_id": 17585,
+        }
+
+    def test_private_dm_topic_uses_direct_messages_topic_id(self):
+        assert _telegram_thread_kwargs("123456789", "17585") == {
+            "direct_messages_topic_id": 17585,
+        }
+
+    def test_non_numeric_chat_id_falls_back_to_message_thread_id(self):
+        assert _telegram_thread_kwargs("@channelalias", "17585") == {
+            "message_thread_id": 17585,
+        }
 
 
 # ---------------------------------------------------------------------------

--- a/tests/tools/test_send_message_tool.py
+++ b/tests/tools/test_send_message_tool.py
@@ -1019,6 +1019,17 @@ class TestSendTelegramThreadIdMapping:
         kwargs = bot.send_message.await_args.kwargs
         assert kwargs["message_thread_id"] == 17585
 
+    def test_private_dm_topic_uses_direct_messages_topic_id(self, monkeypatch):
+        """Telegram private DM topics must route through direct_messages_topic_id."""
+        bot = self._make_bot()
+        _install_telegram_mock(monkeypatch, bot)
+
+        asyncio.run(_send_telegram("tok", "123456789", "hello", thread_id="17585"))
+
+        kwargs = bot.send_message.await_args.kwargs
+        assert kwargs["direct_messages_topic_id"] == 17585
+        assert "message_thread_id" not in kwargs
+
     def test_no_thread_id_no_kwarg(self, monkeypatch):
         """With no thread_id, message_thread_id must not appear in kwargs."""
         bot = self._make_bot()

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -957,6 +957,32 @@ def _is_telegram_thread_not_found(error: Exception) -> bool:
     return "thread not found" in str(error).lower()
 
 
+def _telegram_thread_kwargs(chat_id, thread_id) -> dict[str, int]:
+    """Map Hermes thread ids to the Bot API routing kwargs for standalone sends.
+
+    Private Telegram direct-message topics use ``direct_messages_topic_id``.
+    Forum/supergroup topics use ``message_thread_id``. The General topic is
+    represented by thread id ``1`` on incoming updates but must be omitted on
+    sends because the Bot API rejects ``message_thread_id=1``.
+    """
+    if thread_id is None:
+        return {}
+
+    thread_str = str(thread_id).strip()
+    if not thread_str or thread_str == "1":
+        return {}
+
+    thread_value = int(thread_str)
+    try:
+        is_private_chat = int(str(chat_id)) > 0
+    except (TypeError, ValueError):
+        is_private_chat = False
+
+    if is_private_chat:
+        return {"direct_messages_topic_id": thread_value}
+    return {"message_thread_id": thread_value}
+
+
 async def _send_telegram(token, chat_id, message, media_files=None, thread_id=None, disable_link_previews=False, force_document=False):
     """Send via Telegram Bot API (one-shot, no polling needed).
 
@@ -1013,29 +1039,7 @@ async def _send_telegram(token, chat_id, message, media_files=None, thread_id=No
             bot = Bot(token=token)
         int_chat_id = int(chat_id)
         media_files = media_files or []
-        thread_kwargs = {}
-        if thread_id is not None:
-            # Reuse the gateway adapter's General-topic mapping: in Telegram
-            # forum supergroups, the General topic is addressed as
-            # message_thread_id="1" on incoming updates, but Bot API
-            # sendMessage rejects message_thread_id=1 with "Message thread
-            # not found". The adapter's helper maps "1" to None for that
-            # reason; the send_message tool needs the same mapping or a
-            # send to a forum group's General topic always errors out
-            # (see issue #22267).
-            try:
-                from gateway.platforms.telegram import TelegramAdapter
-                effective_thread_id = TelegramAdapter._message_thread_id_for_send(
-                    str(thread_id)
-                )
-            except Exception:
-                # Fallback: explicit mapping in case the adapter import
-                # fails (e.g. python-telegram-bot missing in this venv).
-                effective_thread_id = (
-                    None if str(thread_id) == "1" else int(thread_id)
-                )
-            if effective_thread_id is not None:
-                thread_kwargs["message_thread_id"] = effective_thread_id
+        thread_kwargs = _telegram_thread_kwargs(chat_id, thread_id)
         # disable_web_page_preview is only valid for send_message, not
         # send_photo/send_video/etc.  Keep it separate so media sends
         # don't inherit an invalid parameter (issue #27012).
@@ -1054,15 +1058,16 @@ async def _send_telegram(token, chat_id, message, media_files=None, thread_id=No
                     parse_mode=send_parse_mode, **text_kwargs
                 )
             except Exception as md_error:
-                # Thread not found — retry without message_thread_id so the
+                # Thread/topic not found — retry once without routing so the
                 # message still delivers (matching the gateway adapter's
-                # fallback behaviour, issue #27012).
+                # fallback behaviour, issue #27012 / #48056).
                 if _is_telegram_thread_not_found(md_error) and thread_kwargs:
                     logger.warning(
-                        "Thread %s not found in _send_telegram, retrying without message_thread_id",
-                        thread_kwargs.get("message_thread_id"),
+                        "Telegram thread/topic routing %s not found in _send_telegram, retrying without routing",
+                        thread_kwargs,
                     )
                     text_kwargs.pop("message_thread_id", None)
+                    text_kwargs.pop("direct_messages_topic_id", None)
                     last_msg = await _send_telegram_message_with_retry(
                         bot,
                         chat_id=int_chat_id, text=formatted,
@@ -1123,16 +1128,17 @@ async def _send_telegram(token, chat_id, message, media_files=None, thread_id=No
                                 chat_id=int_chat_id, document=f, **media_kwargs
                             )
                     except Exception as media_err:
-                        if _is_telegram_thread_not_found(media_err) and media_kwargs.get("message_thread_id"):
-                            # Thread not found for media — retry without
-                            # message_thread_id (issue #27012).
+                        if _is_telegram_thread_not_found(media_err) and media_kwargs:
+                            # Thread/topic not found for media — retry without
+                            # routing (issue #27012 / #48056).
                             logger.warning(
-                                "Thread %s not found for media send, retrying without message_thread_id",
-                                media_kwargs["message_thread_id"],
+                                "Telegram thread/topic routing %s not found for media send, retrying without routing",
+                                media_kwargs,
                             )
                             # Re-seek the file since the first attempt consumed it
                             f.seek(0)
                             media_kwargs.pop("message_thread_id", None)
+                            media_kwargs.pop("direct_messages_topic_id", None)
                             if ext in _IMAGE_EXTS and not force_document:
                                 last_msg = await bot.send_photo(
                                     chat_id=int_chat_id, photo=f, **media_kwargs


### PR DESCRIPTION
## Summary
- preserve Telegram private DM topic metadata when cron delivers through a live adapter
- route standalone Telegram sends to `direct_messages_topic_id` for private DM topics
- add focused regression tests for cron delivery metadata and standalone thread routing

Fixes #48056

## Testing
- pytest tests/cron/test_scheduler.py -q -k "live_adapter_telegram_dm_topic_uses_direct_messages_topic_metadata"
- pytest tests/tools/test_send_message_missing_platforms.py -q -k "TestTelegramThreadKwargs"
- ruff check cron/scheduler.py tools/send_message_tool.py tests/cron/test_scheduler.py tests/tools/test_send_message_missing_platforms.py tests/tools/test_send_message_tool.py
- python3 -m py_compile cron/scheduler.py tools/send_message_tool.py tests/cron/test_scheduler.py tests/tools/test_send_message_missing_platforms.py tests/tools/test_send_message_tool.py
- git diff --check