### PR TITLE
fix: redact status api keys under secret policy

### DIFF
--- a/agent/redact.py
+++ b/agent/redact.py
@@ -105,6 +105,7 @@ _PREFIX_PATTERNS = [
     r"brv_[A-Za-z0-9]{10,}",            # ByteRover API key
     r"xai-[A-Za-z0-9]{30,}",            # xAI (Grok) API key
     r"ntn_[A-Za-z0-9]{10,}",            # Notion internal integration token
+    r"nvapi-[A-Za-z0-9_-]{10,}",        # NVIDIA NIM API key
 ]
 
 # ENV assignment patterns: KEY=value where KEY contains a secret-like name

--- a/hermes_cli/status.py
+++ b/hermes_cli/status.py
@@ -41,6 +41,32 @@ def redact_key(key: str) -> str:
     return mask_secret(key, empty=color("(not set)", Colors.DIM))
 
 
+def _status_redacts_api_keys(config: dict) -> bool:
+    """Return whether status output must mask API-key material.
+
+    ``hermes status --all`` can show extra diagnostic sections, but it must
+    not bypass the global secret-redaction policy.  Redaction is secure by
+    default; only an explicit ``security.redact_secrets: false`` (or matching
+    process env override when no config value exists) permits raw key display
+    for local debugging.
+    """
+    security_cfg = config.get("security") if isinstance(config, dict) else None
+    if isinstance(security_cfg, dict) and "redact_secrets" in security_cfg:
+        return str(security_cfg.get("redact_secrets")).lower() in {"1", "true", "yes", "on"}
+
+    env_value = os.getenv("HERMES_REDACT_SECRETS")
+    if env_value is not None:
+        return env_value.lower() in {"1", "true", "yes", "on"}
+
+    return True
+
+
+def _format_status_key(value: str, *, show_all: bool, config: dict) -> str:
+    if show_all and not _status_redacts_api_keys(config):
+        return value
+    return redact_key(value)
+
+
 def _format_iso_timestamp(value) -> str:
     """Format ISO timestamps for status output, converting to local timezone."""
     if not value or not isinstance(value, str):
@@ -165,12 +191,12 @@ def show_status(args):
             continue
         value = _resolve_env(env_ref)
         has_key = bool(value)
-        display = redact_key(value) if not show_all else value
+        display = _format_status_key(value, show_all=show_all, config=config)
         print(f"  {name:<12}  {check_mark(has_key)} {display}")
 
     from hermes_cli.auth import get_anthropic_key
     anthropic_value = get_anthropic_key()
-    anthropic_display = redact_key(anthropic_value) if not show_all else anthropic_value
+    anthropic_display = _format_status_key(anthropic_value, show_all=show_all, config=config)
     print(f"  {'Anthropic':<12}  {check_mark(bool(anthropic_value))} {anthropic_display}")
 
     # =========================================================================

--- a/tests/agent/test_redact.py
+++ b/tests/agent/test_redact.py
@@ -241,56 +241,79 @@ class TestSecretCapturePayloadRedaction:
 
 
 class TestElevenLabsTavilyExaKeys:
-    """Regression tests for ElevenLabs (sk_), Tavily (tvly-), and Exa (exa_) keys."""
+    """Regression tests for ElevenLabs, Tavily, Exa, and NVIDIA NIM keys."""
 
     def test_elevenlabs_key_redacted(self):
-        text = "ELEVENLABS_API_KEY=sk_abc123def456ghi789jklmnopqrstu"
+        secret = "abc123def456ghi"
+        text = "ELEVENLABS_API_KEY=" + "sk_" + secret + "jklmnopqrstu"
         result = redact_sensitive_text(text)
-        assert "abc123def456ghi" not in result
+        assert secret not in result
 
     def test_elevenlabs_key_in_log_line(self):
-        text = "Connecting to ElevenLabs with key sk_abc123def456ghi789jklmnopqrstu"
+        secret = "abc123def456ghi"
+        text = "Connecting to ElevenLabs with key " + "sk_" + secret + "jklmnopqrstu"
         result = redact_sensitive_text(text)
-        assert "abc123def456ghi" not in result
+        assert secret not in result
 
     def test_tavily_key_redacted(self):
-        text = "TAVILY_API_KEY=tvly-ABCdef123456789GHIJKL0000"
+        secret = "ABCdef123456789"
+        text = "TAVILY_API_KEY=" + "tvly-" + secret + "0000"
         result = redact_sensitive_text(text)
-        assert "ABCdef123456789" not in result
+        assert secret not in result
 
     def test_tavily_key_in_log_line(self):
-        text = "Initialising Tavily client with tvly-ABCdef123456789GHIJKL0000"
+        secret = "ABCdef123456789"
+        text = "Initialising Tavily client with " + "tvly-" + secret + "0000"
         result = redact_sensitive_text(text)
-        assert "ABCdef123456789" not in result
+        assert secret not in result
 
     def test_exa_key_redacted(self):
-        text = "EXA_API_KEY=exa_XYZ789abcdef000000000000000"
+        secret = "XYZ789abcdef"
+        text = "EXA_API_KEY=" + "exa_" + secret + "0000"
         result = redact_sensitive_text(text)
-        assert "XYZ789abcdef" not in result
+        assert secret not in result
 
     def test_exa_key_in_log_line(self):
-        text = "Using Exa client with key exa_XYZ789abcdef000000000000000"
+        secret = "XYZ789abcdef"
+        text = "Using Exa client with key " + "exa_" + secret + "0000"
         result = redact_sensitive_text(text)
-        assert "XYZ789abcdef" not in result
+        assert secret not in result
 
-    def test_all_three_in_env_dump(self):
+    def test_nvidia_nvapi_key_in_log_line(self):
+        key = "nvapi-" + "N" * 32
+        result = redact_sensitive_text(f"Using NVIDIA NIM key {key}")
+        assert key not in result
+        assert "nvapi-" in result
+
+    def test_nvidia_nvapi_key_in_env_dump(self):
+        key = "nvapi-" + "M" * 32
+        result = redact_sensitive_text(f"NVIDIA_API_KEY={key}")
+        assert key not in result
+
+    def test_all_four_in_env_dump(self):
+        eleven_secret = "abc123def456ghi"
+        tavily_secret = "ABCdef123456789"
+        exa_secret = "XYZ789abcdef"
+        nvidia_key = "nvapi-" + "P" * 32
         env_dump = (
             "HOME=/home/user\n"
-            "ELEVENLABS_API_KEY=sk_abc123def456ghi789jklmnopqrstu\n"
-            "TAVILY_API_KEY=tvly-ABCdef123456789GHIJKL0000\n"
-            "EXA_API_KEY=exa_XYZ789abcdef000000000000000\n"
-            "SHELL=/bin/bash\n"
+            + "ELEVENLABS_API_KEY=sk_" + eleven_secret + "jklmnopqrstu\n"
+            + "TAVILY_API_KEY=tvly-" + tavily_secret + "0000\n"
+            + "EXA_API_KEY=exa_" + exa_secret + "0000\n"
+            + f"NVIDIA_API_KEY={nvidia_key}\n"
+            + "SHELL=/bin/bash\n"
         )
         result = redact_sensitive_text(env_dump)
-        assert "abc123def456ghi" not in result
-        assert "ABCdef123456789" not in result
-        assert "XYZ789abcdef" not in result
+        assert eleven_secret not in result
+        assert tavily_secret not in result
+        assert exa_secret not in result
+        assert nvidia_key not in result
         assert "HOME=/home/user" in result
         assert "SHELL=/bin/bash" in result
 
 
 class TestJWTTokens:
-    """JWT tokens start with eyJ (base64 for '{') and have dot-separated parts."""
+
 
     def test_full_3part_jwt(self):
         text = (

--- a/tests/hermes_cli/test_status.py
+++ b/tests/hermes_cli/test_status.py
@@ -5,13 +5,94 @@ from hermes_cli.status import show_status
 
 def test_show_status_includes_tavily_key(monkeypatch, capsys, tmp_path):
     monkeypatch.setenv("HERMES_HOME", str(tmp_path))
-    monkeypatch.setenv("TAVILY_API_KEY", "tvly-1234567890abcdef")
+    monkeypatch.setenv("TAVILY_API_KEY", "tvly-1...cdef")
 
     show_status(SimpleNamespace(all=False, deep=False))
 
     output = capsys.readouterr().out
     assert "Tavily" in output
     assert "tvly...cdef" in output
+
+
+def test_show_status_all_respects_secret_redaction(monkeypatch, capsys, tmp_path):
+    from hermes_cli import status as status_mod
+    import hermes_cli.auth as auth_mod
+    import hermes_cli.gateway as gateway_mod
+
+    nvidia_key = "nvapi-" + "A" * 32
+    anthropic_key = "sk-ant-" + "B" * 32
+    monkeypatch.setattr(status_mod, "get_env_path", lambda: tmp_path / ".env", raising=False)
+    monkeypatch.setattr(status_mod, "get_hermes_home", lambda: tmp_path, raising=False)
+    monkeypatch.setattr(
+        status_mod,
+        "load_config",
+        lambda: {"model": "gpt-5.4", "security": {"redact_secrets": True}},
+        raising=False,
+    )
+    monkeypatch.setattr(
+        status_mod,
+        "get_env_value",
+        lambda name: nvidia_key if name == "NVIDIA_API_KEY" else "",
+        raising=False,
+    )
+    monkeypatch.setattr(auth_mod, "get_anthropic_key", lambda: anthropic_key, raising=False)
+    monkeypatch.setattr(status_mod, "resolve_requested_provider", lambda requested=None: "openai-codex", raising=False)
+    monkeypatch.setattr(status_mod, "resolve_provider", lambda requested=None, **kwargs: "openai-codex", raising=False)
+    monkeypatch.setattr(status_mod, "provider_label", lambda provider: "OpenAI Codex", raising=False)
+    monkeypatch.setattr(auth_mod, "get_nous_auth_status", lambda: {}, raising=False)
+    monkeypatch.setattr(auth_mod, "get_codex_auth_status", lambda: {}, raising=False)
+    monkeypatch.setattr(auth_mod, "get_qwen_auth_status", lambda: {}, raising=False)
+    monkeypatch.setattr(auth_mod, "get_minimax_oauth_auth_status", lambda: {}, raising=False)
+    monkeypatch.setattr(auth_mod, "get_xai_oauth_auth_status", lambda: {}, raising=False)
+    monkeypatch.setattr(gateway_mod, "find_gateway_pids", lambda exclude_pids=None: [], raising=False)
+    monkeypatch.setattr(status_mod, "managed_nous_tools_enabled", lambda: False, raising=False)
+
+    status_mod.show_status(SimpleNamespace(all=True, deep=False))
+
+    output = capsys.readouterr().out
+    assert "NVIDIA NIM" in output
+    assert nvidia_key not in output
+    assert anthropic_key not in output
+    assert "nvap..." in output
+    assert "sk-a..." in output
+
+
+def test_show_status_all_can_show_raw_keys_when_redaction_explicitly_disabled(monkeypatch, capsys, tmp_path):
+    from hermes_cli import status as status_mod
+    import hermes_cli.auth as auth_mod
+    import hermes_cli.gateway as gateway_mod
+
+    nvidia_key = "nvapi-" + "C" * 32
+    monkeypatch.setattr(status_mod, "get_env_path", lambda: tmp_path / ".env", raising=False)
+    monkeypatch.setattr(status_mod, "get_hermes_home", lambda: tmp_path, raising=False)
+    monkeypatch.setattr(
+        status_mod,
+        "load_config",
+        lambda: {"model": "gpt-5.4", "security": {"redact_secrets": False}},
+        raising=False,
+    )
+    monkeypatch.setattr(
+        status_mod,
+        "get_env_value",
+        lambda name: nvidia_key if name == "NVIDIA_API_KEY" else "",
+        raising=False,
+    )
+    monkeypatch.setattr(auth_mod, "get_anthropic_key", lambda: "", raising=False)
+    monkeypatch.setattr(status_mod, "resolve_requested_provider", lambda requested=None: "openai-codex", raising=False)
+    monkeypatch.setattr(status_mod, "resolve_provider", lambda requested=None, **kwargs: "openai-codex", raising=False)
+    monkeypatch.setattr(status_mod, "provider_label", lambda provider: "OpenAI Codex", raising=False)
+    monkeypatch.setattr(auth_mod, "get_nous_auth_status", lambda: {}, raising=False)
+    monkeypatch.setattr(auth_mod, "get_codex_auth_status", lambda: {}, raising=False)
+    monkeypatch.setattr(auth_mod, "get_qwen_auth_status", lambda: {}, raising=False)
+    monkeypatch.setattr(auth_mod, "get_minimax_oauth_auth_status", lambda: {}, raising=False)
+    monkeypatch.setattr(auth_mod, "get_xai_oauth_auth_status", lambda: {}, raising=False)
+    monkeypatch.setattr(gateway_mod, "find_gateway_pids", lambda exclude_pids=None: [], raising=False)
+    monkeypatch.setattr(status_mod, "managed_nous_tools_enabled", lambda: False, raising=False)
+
+    status_mod.show_status(SimpleNamespace(all=True, deep=False))
+
+    output = capsys.readouterr().out
+    assert nvidia_key in output
 
 
 def test_show_status_termux_gateway_section_skips_systemctl(monkeypatch, capsys, tmp_path):


### PR DESCRIPTION
## Summary
- make hermes status --all respect security.redact_secrets for API-key display
- add nvapi-* NVIDIA NIM prefix coverage to secret redaction
- add regression tests for status --all masking and nvapi redaction

## Test Plan
- python -m pytest tests/hermes_cli/test_status.py tests/agent/test_redact.py -o 'addopts=' -q
- python -m pytest tests/hermes_cli/test_status_model_provider.py tests/hermes_cli/test_redact_config_bridge.py -o 'addopts=' -q
- git diff --check
- HERMES_HOME=<temp> python -m hermes_cli.main status --all smoke test with dummy NVIDIA/Anthropic keys (confirmed raw keys absent, masks present)