### PR TITLE
fix(cli): tolerate undecodable alias lookup output

### DIFF
--- a/hermes_cli/profiles.py
+++ b/hermes_cli/profiles.py
@@ -406,7 +406,7 @@ def check_alias_collision(name: str) -> Optional[str]:
     try:
         result = subprocess.run(
             ["where" if is_windows else "which", canon],
-            capture_output=True, text=True, timeout=5,
+            capture_output=True, text=True, errors="replace", timeout=5,
         )
         if result.returncode == 0:
             existing_path = result.stdout.strip().splitlines()[0]

--- a/tests/hermes_cli/test_profiles.py
+++ b/tests/hermes_cli/test_profiles.py
@@ -812,6 +812,28 @@ class TestAliasCollision:
             result = check_alias_collision("mybot")
         assert result is None
 
+    def test_undecodable_lookup_stderr_is_replaced(self, profile_env, monkeypatch):
+        """A localized where/which error must not crash text-mode decoding."""
+        real_run = profiles.subprocess.run
+        completed = []
+
+        def run_with_undecodable_stderr(_cmd, **kwargs):
+            result = real_run(
+                [
+                    sys.executable,
+                    "-c",
+                    "import os; os.write(2, b'\\x81'); raise SystemExit(1)",
+                ],
+                **kwargs,
+            )
+            completed.append(result)
+            return result
+
+        monkeypatch.setattr(profiles.subprocess, "run", run_with_undecodable_stderr)
+
+        assert check_alias_collision("mybot") is None
+        assert completed[0].stderr == "\N{REPLACEMENT CHARACTER}"
+
     def test_reserved_name_returns_message(self, profile_env):
         result = check_alias_collision("hermes")
         assert result is not None


### PR DESCRIPTION
## What does this PR do?

Fixes the current Windows/profile-alias decoding failure in #47939 without changing process-global subprocess behavior.

`check_alias_collision()` invokes `where`/`which` with `text=True`. If that command emits bytes that the platform-selected text codec cannot decode, `subprocess.run()` can raise `UnicodeDecodeError` before Hermes can handle the lookup result.

This patch adds `errors="replace"` only at that call site. It deliberately preserves Python's platform-default codec for localized Windows command output and avoids the previous import-time `subprocess.Popen.__init__` monkeypatch.

## Related Issue

Fixes #47939

## Type of Change

- [x] 🐛 Bug fix
- [x] ✅ Tests
- [ ] ✨ New feature
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ♻️ Refactor

## Changes Made

- `hermes_cli/profiles.py`: tolerate undecodable bytes from the alias lookup subprocess with a localized `errors="replace"` policy.
- `tests/hermes_cli/test_profiles.py`: exercise the real `check_alias_collision()` path with a subprocess that emits undecodable stderr.

## Validation

- Baseline RED on current `origin/main`: the targeted regression failed in `check_alias_collision()` with `UnicodeDecodeError`.
- Updated branch GREEN: `tests/hermes_cli/test_profiles.py` — **156 passed**.
- Changed-file Ruff — passed.
- `git diff --check` — passed.

## Duplicate / overlap check

- #55339 touches the production call as part of a 76-file encoding sweep, but has no test files or behavioral regression for `check_alias_collision()`.
- #47951, #52249, and #25200 do not modify this call path.
- No recently merged equivalent fix was found on `origin/main`.

## Checklist

- [x] Read the contributing and repository guidance.
- [x] Conventional commit message.
- [x] Searched current main, open PRs, and recently merged PRs for equivalent work.
- [x] Contains only the narrow fix and regression test.
- [x] Added behavior-focused regression coverage.
- [x] Considered Windows/localized subprocess behavior.
- [x] No config, dependency, generated-file, or documentation changes are required.

## Screenshots / Logs

Not applicable; this is a CLI subprocess-decoding path with no UI changes.
