### PR TITLE
fix(cli): default Windows subprocess text decoding

### DIFF
--- a/hermes_cli/__init__.py
+++ b/hermes_cli/__init__.py
@@ -12,6 +12,7 @@ Provides subcommands for:
 """
 
 import os
+import subprocess
 import sys
 
 __version__ = "0.16.0"
@@ -89,4 +90,43 @@ def _ensure_utf8():
         os.environ.setdefault("PYTHONIOENCODING", "utf-8")
 
 
+def _ensure_windows_subprocess_text_decoding():
+    """Make Windows text-mode subprocess pipes decode lossily instead of crashing.
+
+    On Windows, localized command output can contain bytes that do not match the
+    process locale selected by Python's ``subprocess`` text-mode pipe reader.
+    If a caller uses ``text=True`` / ``universal_newlines=True`` without an
+    explicit ``errors=`` policy, CPython's internal reader thread can raise
+    ``UnicodeDecodeError`` and silently drop the captured output.
+
+    Preserve explicit caller choices, but default Hermes CLI subprocesses to the
+    same UTF-8 + replacement policy used for stdio whenever text mode is enabled.
+    This is intentionally Windows-only to avoid changing POSIX locale behavior.
+    """
+    if sys.platform != "win32":
+        return
+
+    current_init = subprocess.Popen.__init__
+    if getattr(current_init, "_hermes_text_decode_defaults", False):
+        return
+
+    def _hermes_popen_init(self, *args, **kwargs):
+        positional_universal_newlines = len(args) > 11 and args[11]
+        text_mode = (
+            kwargs.get("text")
+            or kwargs.get("universal_newlines")
+            or positional_universal_newlines
+            or kwargs.get("encoding") is not None
+            or kwargs.get("errors") is not None
+        )
+        if text_mode:
+            kwargs.setdefault("encoding", "utf-8")
+            kwargs.setdefault("errors", "replace")
+        return current_init(self, *args, **kwargs)
+
+    _hermes_popen_init._hermes_text_decode_defaults = True  # type: ignore[attr-defined]
+    subprocess.Popen.__init__ = _hermes_popen_init
+
+
 _ensure_utf8()
+_ensure_windows_subprocess_text_decoding()

--- a/tests/hermes_cli/test_windows_subprocess_text_decoding.py
+++ b/tests/hermes_cli/test_windows_subprocess_text_decoding.py
@@ -1,0 +1,147 @@
+import subprocess
+import sys
+
+import hermes_cli
+
+
+def test_windows_text_subprocess_defaults_to_lossy_utf8(monkeypatch):
+    original_init = subprocess.Popen.__init__
+    calls = []
+
+    def fake_init(self, *args, **kwargs):
+        calls.append(kwargs)
+        return None
+
+    try:
+        monkeypatch.setattr(sys, "platform", "win32")
+        monkeypatch.setattr(subprocess.Popen, "__init__", fake_init)
+
+        hermes_cli._ensure_windows_subprocess_text_decoding()
+        subprocess.Popen.__init__(object(), ["cmd"], text=True)
+
+        assert calls[-1]["encoding"] == "utf-8"
+        assert calls[-1]["errors"] == "replace"
+    finally:
+        subprocess.Popen.__init__ = original_init
+
+
+def test_windows_text_subprocess_preserves_explicit_decode_policy(monkeypatch):
+    original_init = subprocess.Popen.__init__
+    calls = []
+
+    def fake_init(self, *args, **kwargs):
+        calls.append(kwargs)
+        return None
+
+    try:
+        monkeypatch.setattr(sys, "platform", "win32")
+        monkeypatch.setattr(subprocess.Popen, "__init__", fake_init)
+
+        hermes_cli._ensure_windows_subprocess_text_decoding()
+        subprocess.Popen.__init__(
+            object(),
+            ["cmd"],
+            text=True,
+            encoding="cp936",
+            errors="surrogateescape",
+        )
+
+        assert calls[-1]["encoding"] == "cp936"
+        assert calls[-1]["errors"] == "surrogateescape"
+    finally:
+        subprocess.Popen.__init__ = original_init
+
+
+def test_windows_positional_universal_newlines_gets_lossy_utf8(monkeypatch):
+    original_init = subprocess.Popen.__init__
+    calls = []
+
+    def fake_init(self, *args, **kwargs):
+        calls.append((args, kwargs))
+        return None
+
+    try:
+        monkeypatch.setattr(sys, "platform", "win32")
+        monkeypatch.setattr(subprocess.Popen, "__init__", fake_init)
+
+        hermes_cli._ensure_windows_subprocess_text_decoding()
+        # Popen.__init__ positional index 11 is universal_newlines.
+        subprocess.Popen.__init__(
+            object(),
+            ["cmd"],
+            -1,
+            None,
+            None,
+            subprocess.PIPE,
+            subprocess.PIPE,
+            None,
+            True,
+            False,
+            None,
+            None,
+            True,
+        )
+
+        assert calls[-1][1]["encoding"] == "utf-8"
+        assert calls[-1][1]["errors"] == "replace"
+    finally:
+        subprocess.Popen.__init__ = original_init
+
+
+def test_windows_encoding_only_text_mode_gets_replace_errors(monkeypatch):
+    original_init = subprocess.Popen.__init__
+    calls = []
+
+    def fake_init(self, *args, **kwargs):
+        calls.append(kwargs)
+        return None
+
+    try:
+        monkeypatch.setattr(sys, "platform", "win32")
+        monkeypatch.setattr(subprocess.Popen, "__init__", fake_init)
+
+        hermes_cli._ensure_windows_subprocess_text_decoding()
+        subprocess.Popen.__init__(object(), ["cmd"], encoding="cp936")
+
+        assert calls[-1]["encoding"] == "cp936"
+        assert calls[-1]["errors"] == "replace"
+    finally:
+        subprocess.Popen.__init__ = original_init
+
+
+def test_windows_errors_only_text_mode_gets_utf8_encoding(monkeypatch):
+    original_init = subprocess.Popen.__init__
+    calls = []
+
+    def fake_init(self, *args, **kwargs):
+        calls.append(kwargs)
+        return None
+
+    try:
+        monkeypatch.setattr(sys, "platform", "win32")
+        monkeypatch.setattr(subprocess.Popen, "__init__", fake_init)
+
+        hermes_cli._ensure_windows_subprocess_text_decoding()
+        subprocess.Popen.__init__(object(), ["cmd"], errors="backslashreplace")
+
+        assert calls[-1]["encoding"] == "utf-8"
+        assert calls[-1]["errors"] == "backslashreplace"
+    finally:
+        subprocess.Popen.__init__ = original_init
+
+
+def test_non_windows_subprocess_init_is_left_unchanged(monkeypatch):
+    original_init = subprocess.Popen.__init__
+
+    def fake_init(self, *args, **kwargs):
+        return None
+
+    try:
+        monkeypatch.setattr(sys, "platform", "linux")
+        monkeypatch.setattr(subprocess.Popen, "__init__", fake_init)
+
+        hermes_cli._ensure_windows_subprocess_text_decoding()
+
+        assert subprocess.Popen.__init__ is fake_init
+    finally:
+        subprocess.Popen.__init__ = original_init


### PR DESCRIPTION
## Summary
- Adds a Windows-only guard that defaults Hermes CLI text-mode subprocess pipes to UTF-8 with replacement decoding.
- Preserves explicit caller-provided `encoding` / `errors` choices.
- Covers `text=True`, `universal_newlines=True`, positional `universal_newlines`, and encoding/errors-triggered text mode.

Closes #47939

## Verification
- `scripts/run_tests.sh tests/hermes_cli/test_windows_subprocess_text_decoding.py` ✅ (6 passed)
- `python scripts/check-windows-footguns.py --all` ✅
- Added-line static scan for secrets, shell injection, eval/exec, pickle, and SQL formatting: no findings
- Independent delegated code review: passed

Codex was attempted first for repo-safe implementation, but it hit the known hidden-workspace / CA-bundle sandbox failures and could not inspect the checkout, so Hermes handled the fallback implementation and verification directly.
