### PR TITLE
fix(desktop): clicking a background task now always shows its output

### DIFF
--- a/apps/desktop/src/app/chat/composer/status-stack/status-row.test.tsx
+++ b/apps/desktop/src/app/chat/composer/status-stack/status-row.test.tsx
@@ -1,0 +1,62 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it } from 'vitest'
+
+import type { ComposerStatusItem } from '@/store/composer-status'
+
+import { StatusItemRow } from './status-row'
+
+afterEach(cleanup)
+
+function bgItem(overrides: Partial<ComposerStatusItem> = {}): ComposerStatusItem {
+  return {
+    id: 'bg-1',
+    type: 'background',
+    title: 'cd ~/project && npm run build',
+    state: 'running',
+    ...overrides
+  } as ComposerStatusItem
+}
+
+describe('StatusItemRow — background task output', () => {
+  it('a running background task with no output yet is still clickable', () => {
+    render(<StatusItemRow item={bgItem()} />)
+
+    // The row is activatable (role=button) even before any output arrives —
+    // this is the regression: it used to be a dead no-op click.
+    const row = screen.getByRole('button')
+    expect(row).toBeTruthy()
+  })
+
+  it('clicking a running task with no output reveals the waiting placeholder', () => {
+    render(<StatusItemRow item={bgItem()} />)
+
+    expect(screen.queryByText('Waiting for output…')).toBeNull()
+    fireEvent.click(screen.getByRole('button'))
+    expect(screen.getByText('Waiting for output…')).toBeTruthy()
+  })
+
+  it('clicking a task with captured output shows the output, not a placeholder', () => {
+    render(<StatusItemRow item={bgItem({ output: 'line 1\nline 2\n' })} />)
+
+    fireEvent.click(screen.getByRole('button'))
+    expect(screen.getByText(/line 1/)).toBeTruthy()
+    expect(screen.queryByText('Waiting for output…')).toBeNull()
+  })
+
+  it('a finished task with no output shows the no-output placeholder when expanded', () => {
+    render(<StatusItemRow item={bgItem({ state: 'done' })} />)
+
+    fireEvent.click(screen.getByRole('button'))
+    expect(screen.getByText('No output captured.')).toBeTruthy()
+  })
+
+  it('toggles the output region closed on a second click', () => {
+    render(<StatusItemRow item={bgItem({ output: 'hello' })} />)
+
+    const row = screen.getByRole('button')
+    fireEvent.click(row)
+    expect(screen.getByText(/hello/)).toBeTruthy()
+    fireEvent.click(row)
+    expect(screen.queryByText(/hello/)).toBeNull()
+  })
+})

--- a/apps/desktop/src/app/chat/composer/status-stack/status-row.tsx
+++ b/apps/desktop/src/app/chat/composer/status-stack/status-row.tsx
@@ -95,8 +95,13 @@ export const StatusItemRow = memo(function StatusItemRow({ item, onDismiss, onOp
       : null
 
   const canOpen = item.type === 'subagent' && !!onOpen
-  const hasOutput = item.type === 'background' && !!item.output
-  const onActivate = canOpen ? onOpen : hasOutput ? () => setOutputOpen(open => !open) : undefined
+  // Every background task is expandable — clicking toggles its captured output
+  // inline (the gateway's process `output_tail`, which live-tails as it grows).
+  // A running task whose first output hasn't arrived yet still expands, showing
+  // a "waiting for output" placeholder, so the click is never a dead no-op
+  // (the "clicking a background task does nothing" bug).
+  const isBackground = item.type === 'background'
+  const onActivate = canOpen ? onOpen : isBackground ? () => setOutputOpen(open => !open) : undefined
 
   return (
     <Fragment>
@@ -147,9 +152,14 @@ export const StatusItemRow = memo(function StatusItemRow({ item, onDismiss, onOp
             {s.exit(item.exitCode)}
           </span>
         )}
-        {hasOutput && <DisclosureCaret className="shrink-0 text-muted-foreground/45" open={outputOpen} size="0.8em" />}
+        {isBackground && <DisclosureCaret className="shrink-0 text-muted-foreground/45" open={outputOpen} size="0.8em" />}
       </StatusRow>
-      {hasOutput && outputOpen && <TerminalOutput className="mx-auto mb-1 max-w-[90%]" text={item.output!} />}
+      {isBackground && outputOpen && (
+        <TerminalOutput
+          className="mx-auto mb-1 max-w-[90%]"
+          text={item.output || (running ? s.waitingForOutput : s.noOutput)}
+        />
+      )}
     </Fragment>
   )
 })

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -1335,6 +1335,8 @@ export const en: Translations = {
     running: 'Running',
     stop: 'Stop',
     dismiss: 'Dismiss',
+    waitingForOutput: 'Waiting for output…',
+    noOutput: 'No output captured.',
     exit: code => `exit ${code}`
   },
 

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -1463,6 +1463,8 @@ export const ja = defineLocale({
     running: '実行中',
     stop: '停止',
     dismiss: '閉じる',
+    waitingForOutput: '出力を待っています…',
+    noOutput: '出力はありません。',
     exit: code => `終了コード ${code}`
   },
 

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -1015,6 +1015,8 @@ export interface Translations {
     running: string
     stop: string
     dismiss: string
+    waitingForOutput: string
+    noOutput: string
     exit: (code: number) => string
   }
 

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -1417,6 +1417,8 @@ export const zhHant = defineLocale({
     running: '執行中',
     stop: '停止',
     dismiss: '關閉',
+    waitingForOutput: '正在等待輸出…',
+    noOutput: '未擷取輸出。',
     exit: code => `結束碼 ${code}`
   },
 

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -1522,6 +1522,8 @@ export const zh: Translations = {
     running: '运行中',
     stop: '停止',
     dismiss: '关闭',
+    waitingForOutput: '正在等待输出…',
+    noOutput: '未捕获输出。',
     exit: code => `退出码 ${code}`
   },
 


### PR DESCRIPTION
## Symptom

Clicking a running background task in the composer status stack did **nothing** — no output appeared anywhere.

## Root cause

A background row was only made activatable when it *already* had captured output:

```ts
const hasOutput = item.type === 'background' && !!item.output
const onActivate = canOpen ? onOpen : hasOutput ? () => setOutputOpen(...) : undefined
```

A **running** task whose first `output_tail` chunk hadn't arrived yet had `hasOutput === false`, so the row had **no click handler and no disclosure caret** — the click was a dead no-op. The output region and caret were likewise gated on `hasOutput`.

## Fix

- **Every background task is activatable** (`isBackground`), so the click always toggles its inline output — running or finished.
- When expanded with **no output yet**, show a live placeholder (**"Waiting for output…"** while running, **"No output captured."** once done) that fills in as the gateway's `output_tail` streams — `TerminalOutput` already tails on growth.
- Disclosure caret shows for any background row, not just ones with output.

## Tests

`status-row.test.tsx` (new, **5 tests**): a running task with no output is clickable (`role=button`); clicking reveals the waiting placeholder; a task with output shows the output (no placeholder); a finished empty task shows the no-output placeholder; a second click collapses it.

`tsc --noEmit` clean, `eslint` clean.

## Note

This is the inline-output path (the gateway-tracked agent background process, distinct from the xterm terminal panel — those are separate terminals, so surfacing the agent's `output_tail` inline is the correct target).
