### PR TITLE
feat: premium Liquid Glass UI redesign

### DIFF
--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -1345,3 +1345,486 @@ canvas {
     animation: none;
   }
 }
+
+/* Liquid Glass desktop surfaces — premium dark/light pass for the app shell. */
+:root[data-hermes-theme='liquid-glass'],
+:root[data-hermes-theme='liquid-glass-light'] {
+  --radius-scalar: 0.78;
+  --dt-border: rgba(255, 230, 203, 0.16);
+  --dt-card: rgba(255, 230, 203, 0.075);
+  --dt-card-foreground: #fff7ef;
+  --dt-muted: rgba(255, 230, 203, 0.08);
+  --dt-popover: rgba(13, 16, 28, 0.92);
+  --dt-primary: var(--dt-midground);
+  --dt-secondary: rgba(255, 230, 203, 0.1);
+  --dt-accent: rgba(0, 212, 255, 0.14);
+  --dt-ring: #00d4ff;
+  --dt-input: rgba(255, 230, 203, 0.13);
+  --dt-sidebar-bg: rgba(7, 9, 20, 0.82);
+  --dt-sidebar-border: rgba(255, 230, 203, 0.12);
+  --ui-bg-card: rgba(255, 230, 203, 0.07);
+  --ui-bg-elevated: rgba(13, 16, 28, 0.82);
+  --ui-bg-primary: rgba(255, 230, 203, 0.16);
+  --ui-bg-secondary: rgba(255, 230, 203, 0.1);
+  --ui-bg-tertiary: rgba(255, 230, 203, 0.08);
+  --ui-bg-quaternary: rgba(255, 230, 203, 0.06);
+  --ui-bg-quinary: rgba(255, 230, 203, 0.045);
+  --ui-row-hover-background: rgba(255, 230, 203, 0.08);
+  --ui-row-active-background: rgba(0, 212, 255, 0.12);
+  --ui-control-hover-background: rgba(255, 230, 203, 0.1);
+  --ui-control-active-background: rgba(0, 212, 255, 0.14);
+  --ui-chat-bubble-background: rgba(255, 230, 203, 0.12);
+  --ui-chat-bubble-opaque-background: rgba(13, 16, 28, 0.78);
+  --ui-inline-code-background: rgba(255, 230, 203, 0.08);
+  --ui-inline-code-border: rgba(255, 230, 203, 0.12);
+  --ui-inline-code-foreground: #ffe6cb;
+  --ui-selection-background: rgba(0, 212, 255, 0.24);
+  --ui-stroke-primary: rgba(255, 230, 203, 0.2);
+  --ui-stroke-secondary: rgba(255, 230, 203, 0.14);
+  --ui-stroke-tertiary: rgba(255, 230, 203, 0.09);
+  --ui-stroke-quaternary: rgba(255, 230, 203, 0.06);
+  --ui-sash-hover-border: rgba(0, 212, 255, 0.3);
+  --ui-sash-hover-background: rgba(0, 212, 255, 0.1);
+  --warm-glow: rgba(255, 230, 203, 0.28);
+}
+
+:root[data-hermes-theme='liquid-glass-light'] {
+  --dt-border: rgba(0, 83, 253, 0.16);
+  --dt-card: rgba(255, 255, 255, 0.76);
+  --dt-card-foreground: #111827;
+  --dt-muted: rgba(0, 83, 253, 0.07);
+  --dt-popover: rgba(255, 255, 255, 0.92);
+  --dt-primary: #0053fd;
+  --dt-secondary: rgba(0, 83, 253, 0.08);
+  --dt-accent: rgba(255, 172, 2, 0.14);
+  --dt-ring: #0053fd;
+  --dt-input: rgba(0, 83, 253, 0.12);
+  --dt-sidebar-bg: rgba(255, 255, 255, 0.7);
+  --dt-sidebar-border: rgba(0, 83, 253, 0.12);
+  --ui-bg-card: rgba(255, 255, 255, 0.7);
+  --ui-bg-elevated: rgba(255, 255, 255, 0.86);
+  --ui-bg-primary: rgba(0, 83, 253, 0.1);
+  --ui-bg-secondary: rgba(0, 83, 253, 0.07);
+  --ui-bg-tertiary: rgba(0, 83, 253, 0.055);
+  --ui-bg-quaternary: rgba(0, 83, 253, 0.045);
+  --ui-bg-quinary: rgba(0, 83, 253, 0.035);
+  --ui-row-hover-background: rgba(0, 83, 253, 0.07);
+  --ui-row-active-background: rgba(255, 172, 2, 0.12);
+  --ui-control-hover-background: rgba(0, 83, 253, 0.08);
+  --ui-control-active-background: rgba(255, 172, 2, 0.12);
+  --ui-chat-bubble-background: rgba(0, 83, 253, 0.08);
+  --ui-chat-bubble-opaque-background: rgba(255, 255, 255, 0.88);
+  --ui-inline-code-background: rgba(0, 83, 253, 0.06);
+  --ui-inline-code-border: rgba(0, 83, 253, 0.12);
+  --ui-inline-code-foreground: #111827;
+  --ui-selection-background: rgba(255, 172, 2, 0.24);
+  --ui-stroke-primary: rgba(0, 83, 253, 0.18);
+  --ui-stroke-secondary: rgba(0, 83, 253, 0.14);
+  --ui-stroke-tertiary: rgba(0, 83, 253, 0.08);
+  --ui-stroke-quaternary: rgba(0, 83, 253, 0.055);
+  --ui-sash-hover-border: rgba(0, 83, 253, 0.26);
+  --ui-sash-hover-background: rgba(0, 83, 253, 0.08);
+  --warm-glow: rgba(255, 172, 2, 0.22);
+}
+
+:root[data-hermes-theme='liquid-glass'] {
+  --liquid-glass-orb-a: rgba(0, 212, 255, 0.24);
+  --liquid-glass-orb-b: rgba(255, 172, 2, 0.16);
+  --liquid-glass-orb-c: rgba(255, 230, 203, 0.08);
+}
+
+:root[data-hermes-theme='liquid-glass-light'] {
+  --liquid-glass-orb-a: rgba(0, 83, 253, 0.18);
+  --liquid-glass-orb-b: rgba(255, 172, 2, 0.2);
+  --liquid-glass-orb-c: rgba(255, 255, 255, 0.7);
+}
+
+body::before {
+  content: '';
+  position: fixed;
+  inset: 0;
+  z-index: 0;
+  pointer-events: none;
+  background:
+    radial-gradient(circle at 12% -10%, var(--liquid-glass-orb-a), transparent 30rem),
+    radial-gradient(circle at 88% 4%, var(--liquid-glass-orb-b), transparent 28rem),
+    radial-gradient(circle at 52% 118%, var(--liquid-glass-orb-c), transparent 34rem);
+}
+
+:root[data-hermes-theme='liquid-glass'] body::before {
+  background:
+    radial-gradient(circle at 12% -10%, rgba(0, 212, 255, 0.24), transparent 30rem),
+    radial-gradient(circle at 88% 4%, rgba(255, 172, 2, 0.16), transparent 28rem),
+    radial-gradient(circle at 52% 118%, rgba(255, 230, 203, 0.08), transparent 34rem);
+}
+
+:root[data-hermes-theme='liquid-glass-light'] body::before {
+  background:
+    radial-gradient(circle at 12% -10%, rgba(0, 83, 253, 0.18), transparent 30rem),
+    radial-gradient(circle at 88% 4%, rgba(255, 172, 2, 0.2), transparent 28rem),
+    radial-gradient(circle at 52% 118%, rgba(255, 255, 255, 0.7), transparent 34rem);
+}
+
+:root[data-hermes-theme='liquid-glass'] body,
+:root[data-hermes-theme='liquid-glass-light'] body {
+  background: linear-gradient(
+    135deg,
+    var(--dt-background) 0%,
+    color-mix(in srgb, var(--dt-midground) 7%, var(--dt-background)) 46%,
+    var(--dt-background) 100%
+  );
+}
+
+#root {
+  position: relative;
+  z-index: 1;
+  isolation: isolate;
+}
+
+.h-screen.min-h-0.flex-col.bg-background {
+  background: transparent !important;
+}
+
+:root[data-hermes-theme='liquid-glass'] .h-screen.min-h-0.flex-col.bg-background,
+:root[data-hermes-theme='liquid-glass-light'] .h-screen.min-h-0.flex-col.bg-background {
+  background: transparent !important;
+}
+
+[data-pane-id][data-pane-open='true'],
+[data-slot='sidebar'],
+[data-slot='sidebar-inner'],
+[data-slot='sidebar-content'],
+[data-slot='command'],
+[data-slot='dialog-content'],
+[data-slot='sheet-content'],
+[data-slot='popover-content'],
+[data-slot='context-menu-content'],
+[data-slot='dropdown-menu-content'],
+[data-slot='select-content'],
+[data-slot='tooltip-content'],
+[data-slot='composer-surface'],
+[data-slot='composer-root'],
+[data-slot='aui_assistant-message-root'],
+[data-slot='aui_user-message-root'],
+[data-slot='aui_system-message-root'],
+[data-slot='aui_thread-content'],
+[data-slot='aui_msg-actions'] {
+  border-color: var(--dt-border) !important;
+  background: linear-gradient(
+    135deg,
+    color-mix(in srgb, var(--dt-card) 88%, rgba(255, 255, 255, 0.1)),
+    var(--dt-card)
+  ) !important;
+  box-shadow:
+    inset 0 0.0625rem 0 rgba(255, 255, 255, 0.08),
+    inset 0 -0.0625rem 0 rgba(0, 0, 0, 0.08),
+    0 1rem 2.5rem rgba(0, 0, 0, 0.16) !important;
+  backdrop-filter: blur(1.25rem) saturate(1.18);
+  -webkit-backdrop-filter: blur(1.25rem) saturate(1.18);
+}
+
+:root[data-hermes-theme='liquid-glass-light'] [data-pane-id][data-pane-open='true'],
+:root[data-hermes-theme='liquid-glass-light'] [data-slot='sidebar'],
+:root[data-hermes-theme='liquid-glass-light'] [data-slot='sidebar-inner'],
+:root[data-hermes-theme='liquid-glass-light'] [data-slot='sidebar-content'],
+:root[data-hermes-theme='liquid-glass-light'] [data-slot='command'],
+:root[data-hermes-theme='liquid-glass-light'] [data-slot='dialog-content'],
+:root[data-hermes-theme='liquid-glass-light'] [data-slot='sheet-content'],
+:root[data-hermes-theme='liquid-glass-light'] [data-slot='popover-content'],
+:root[data-hermes-theme='liquid-glass-light'] [data-slot='context-menu-content'],
+:root[data-hermes-theme='liquid-glass-light'] [data-slot='dropdown-menu-content'],
+:root[data-hermes-theme='liquid-glass-light'] [data-slot='select-content'],
+:root[data-hermes-theme='liquid-glass-light'] [data-slot='tooltip-content'],
+:root[data-hermes-theme='liquid-glass-light'] [data-slot='composer-surface'],
+:root[data-hermes-theme='liquid-glass-light'] [data-slot='composer-root'],
+:root[data-hermes-theme='liquid-glass-light'] [data-slot='aui_assistant-message-root'],
+:root[data-hermes-theme='liquid-glass-light'] [data-slot='aui_user-message-root'],
+:root[data-hermes-theme='liquid-glass-light'] [data-slot='aui_system-message-root'],
+:root[data-hermes-theme='liquid-glass-light'] [data-slot='aui_thread-content'],
+:root[data-hermes-theme='liquid-glass-light'] [data-slot='aui_msg-actions'] {
+  background: linear-gradient(135deg, rgba(255, 255, 255, 0.92), rgba(255, 255, 255, 0.7)) !important;
+  box-shadow:
+    inset 0 0.0625rem 0 rgba(255, 255, 255, 0.82),
+    inset 0 -0.0625rem 0 rgba(0, 83, 253, 0.05),
+    0 1rem 2.5rem rgba(17, 24, 39, 0.1) !important;
+}
+
+[data-slot='sidebar'],
+[data-slot='sidebar-inner'],
+[data-slot='sidebar-content'] {
+  background: linear-gradient(
+    180deg,
+    var(--dt-sidebar-bg),
+    color-mix(in srgb, var(--dt-sidebar-bg) 72%, transparent)
+  ) !important;
+}
+
+[data-pane-id][data-pane-open='true'] {
+  border-right-color: var(--dt-sidebar-border) !important;
+  border-left-color: var(--dt-sidebar-border) !important;
+}
+
+[data-slot='sidebar-separator'],
+[data-slot='separator'],
+[data-slot='command-separator'],
+[data-slot='dropdown-menu-separator'],
+[data-slot='context-menu-separator'] {
+  background: var(--ui-stroke-tertiary) !important;
+}
+
+[data-slot='button'] {
+  border-color: color-mix(in srgb, var(--dt-ring) 18%, transparent) !important;
+  box-shadow:
+    inset 0 0.0625rem 0 rgba(255, 255, 255, 0.1),
+    0 0.375rem 1rem rgba(0, 0, 0, 0.08) !important;
+}
+
+[data-slot='button'][data-variant='default'] {
+  background: linear-gradient(
+    135deg,
+    color-mix(in srgb, var(--dt-primary) 88%, #fff),
+    color-mix(in srgb, var(--dt-primary) 72%, #000)
+  ) !important;
+  color: var(--dt-primary-foreground) !important;
+}
+
+[data-slot='button'][data-variant='outline'] {
+  background: color-mix(in srgb, var(--dt-card) 72%, transparent) !important;
+  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--dt-border) 72%, transparent) !important;
+}
+
+[data-slot='button'][data-variant='ghost'],
+[data-slot='button'][data-variant='secondary'] {
+  background: color-mix(in srgb, var(--dt-muted) 72%, transparent) !important;
+}
+
+[data-slot='input'],
+[data-slot='textarea'],
+[data-slot='select-trigger'],
+[data-slot='search-field'],
+[data-slot='command-input'],
+[data-slot='command-input-wrapper'] {
+  border-color: var(--dt-input) !important;
+  background: color-mix(in srgb, var(--dt-card) 70%, transparent) !important;
+  box-shadow: inset 0 0.0625rem 0 rgba(255, 255, 255, 0.06) !important;
+  backdrop-filter: blur(1rem);
+  -webkit-backdrop-filter: blur(1rem);
+}
+
+[data-slot='input']:focus-visible,
+[data-slot='textarea']:focus-visible,
+[data-slot='select-trigger']:focus-visible,
+[data-slot='search-field']:focus-visible,
+[data-slot='command-input']:focus-visible {
+  border-color: var(--dt-ring) !important;
+  box-shadow: 0 0 0 0.1875rem color-mix(in srgb, var(--dt-ring) 18%, transparent) !important;
+}
+
+[data-slot='badge'] {
+  border-color: color-mix(in srgb, var(--dt-ring) 24%, transparent) !important;
+  background: linear-gradient(135deg, var(--dt-accent), var(--dt-muted)) !important;
+  box-shadow: inset 0 0.0625rem 0 rgba(255, 255, 255, 0.08);
+}
+
+[data-slot='kbd'] {
+  border-color: color-mix(in srgb, var(--dt-foreground) 22%, transparent) !important;
+  background: color-mix(in srgb, var(--dt-card) 78%, transparent) !important;
+  box-shadow: inset 0 -0.125rem 0 rgba(0, 0, 0, 0.12);
+}
+
+[data-slot='scroll-area-scrollbar'] {
+  width: 0.625rem !important;
+  background: transparent !important;
+}
+
+[data-slot='scroll-area-thumb'] {
+  border-radius: 9999px !important;
+  background: color-mix(in srgb, var(--dt-ring) 28%, transparent) !important;
+}
+
+[data-slot='aui_assistant-message-root'],
+[data-slot='aui_user-message-root'],
+[data-slot='aui_system-message-root'] {
+  border-radius: var(--radius-xl) !important;
+}
+
+[data-slot='aui_thread-content'] {
+  padding-block: 0.5rem !important;
+}
+
+[data-slot='aui_msg-actions'] {
+  border-radius: 0.75rem !important;
+}
+
+[data-slot='aui_generated-image'] {
+  border-color: var(--dt-border) !important;
+  border-radius: var(--radius-xl) !important;
+  box-shadow: 0 1rem 2.5rem rgba(0, 0, 0, 0.2);
+}
+
+[data-slot='aui_intro'] {
+  border-color: var(--dt-border) !important;
+  border-radius: var(--radius-2xl) !important;
+  background:
+    radial-gradient(circle at 12% 0%, color-mix(in srgb, var(--dt-ring) 16%, transparent), transparent 42%),
+    linear-gradient(135deg, var(--dt-card), color-mix(in srgb, var(--dt-card) 58%, transparent)) !important;
+}
+
+[data-slot='dialog-overlay'],
+[data-slot='sheet-overlay'],
+[data-slot='popover-content'] {
+  backdrop-filter: blur(1.25rem) saturate(1.15);
+  -webkit-backdrop-filter: blur(1.25rem) saturate(1.15);
+}
+
+[data-slot='dialog-content'] {
+  border-radius: var(--radius-2xl) !important;
+}
+
+[data-slot='sheet-content'] {
+  border-radius: var(--radius-2xl) var(--radius-2xl) 0 0 !important;
+}
+
+[data-slot='command'] {
+  border-radius: var(--radius-2xl) !important;
+}
+
+[data-slot='command-input-wrapper'] {
+  border-bottom-color: var(--ui-stroke-tertiary) !important;
+}
+
+[data-slot='command-item'] {
+  border-radius: var(--radius-lg) !important;
+}
+
+[data-slot='command-item'][data-selected='true'] {
+  background: linear-gradient(135deg, var(--ui-row-active-background), var(--dt-accent)) !important;
+}
+
+[data-slot='dropdown-menu-item'],
+[data-slot='context-menu-item'],
+[data-slot='select-item'] {
+  border-radius: var(--radius-md) !important;
+}
+
+[data-slot='dropdown-menu-item'][data-highlighted='true'],
+[data-slot='context-menu-item'][data-highlighted='true'],
+[data-slot='select-item'][data-highlighted='true'] {
+  background: var(--ui-row-active-background) !important;
+}
+
+[data-slot='tabs-trigger'] {
+  border-radius: var(--radius-lg) !important;
+}
+
+[data-slot='tabs-trigger'][data-state='active'] {
+  background: linear-gradient(135deg, var(--dt-accent), color-mix(in srgb, var(--dt-card) 72%, transparent)) !important;
+  box-shadow: inset 0 0.0625rem 0 rgba(255, 255, 255, 0.08);
+}
+
+[data-slot='switch'] {
+  border-color: var(--dt-input) !important;
+  background: color-mix(in srgb, var(--dt-muted) 82%, transparent) !important;
+}
+
+[data-slot='switch'][data-state='checked'] {
+  background: color-mix(in srgb, var(--dt-ring) 48%, var(--dt-card)) !important;
+}
+
+[data-slot='checkbox'] {
+  border-color: var(--dt-input) !important;
+  background: color-mix(in srgb, var(--dt-card) 74%, transparent) !important;
+}
+
+[data-slot='checkbox'][data-state='checked'] {
+  background: var(--dt-ring) !important;
+}
+
+[data-slot='sidebar-menu-button'],
+[data-slot='sidebar-menu-sub-button'] {
+  border-radius: var(--radius-lg) !important;
+}
+
+[data-slot='sidebar-menu-button'][data-active='true'],
+[data-slot='sidebar-menu-sub-button'][data-active='true'] {
+  background: linear-gradient(135deg, var(--ui-row-active-background), var(--dt-accent)) !important;
+}
+
+:root[data-hermes-theme='liquid-glass'] [data-slot='sidebar-menu-button'],
+:root[data-hermes-theme='liquid-glass'] [data-slot='sidebar-menu-sub-button'] {
+  color: #ffe6cb !important;
+}
+
+:root[data-hermes-theme='liquid-glass-light'] [data-slot='sidebar-menu-button'],
+:root[data-hermes-theme='liquid-glass-light'] [data-slot='sidebar-menu-sub-button'] {
+  color: #111827 !important;
+}
+
+[data-slot='alert'] {
+  border-color: var(--dt-border) !important;
+  border-radius: var(--radius-xl) !important;
+  background:
+    radial-gradient(circle at 12% 0%, color-mix(in srgb, var(--dt-ring) 16%, transparent), transparent 42%),
+    linear-gradient(135deg, var(--dt-card), color-mix(in srgb, var(--dt-card) 62%, transparent)) !important;
+}
+
+[data-slot='error-state'] {
+  border-color: var(--dt-border) !important;
+  border-radius: var(--radius-2xl) !important;
+  background: linear-gradient(135deg, var(--dt-card), color-mix(in srgb, var(--dt-card) 62%, transparent)) !important;
+}
+
+[data-slot='aui_response-loading'] {
+  border-color: var(--dt-border) !important;
+  border-radius: var(--radius-xl) !important;
+  background: linear-gradient(135deg, var(--dt-muted), transparent) !important;
+}
+
+[data-slot='aui_stream-stall'] {
+  border-color: color-mix(in srgb, var(--ui-yellow) 40%, var(--dt-border)) !important;
+  border-radius: var(--radius-xl) !important;
+  background: color-mix(in srgb, var(--ui-yellow) 12%, var(--dt-card)) !important;
+}
+
+:root[data-hermes-theme='liquid-glass'] [data-slot='aui_stream-stall'] {
+  box-shadow: 0 0 2rem rgba(255, 172, 2, 0.1);
+}
+
+[data-slot='pagination-button'],
+[data-slot='pagination-previous'],
+[data-slot='pagination-next'] {
+  border-radius: var(--radius-md) !important;
+}
+
+[data-slot='pagination-button'][aria-current='page'],
+[data-slot='pagination-previous'][aria-disabled='false'],
+[data-slot='pagination-next'][aria-disabled='false'] {
+  background: var(--ui-row-active-background) !important;
+}
+
+:root[data-hermes-theme='liquid-glass'] [data-slot='aui_assistant-message-content'] .aui-md pre,
+:root[data-hermes-theme='liquid-glass-light'] [data-slot='aui_assistant-message-content'] .aui-md pre,
+:root[data-hermes-theme='liquid-glass'] [data-slot='code-card'],
+:root[data-hermes-theme='liquid-glass-light'] [data-slot='code-card'] {
+  border-color: var(--dt-border) !important;
+  border-radius: var(--radius-xl) !important;
+  background:
+    linear-gradient(180deg, rgba(0, 0, 0, 0.2), rgba(0, 0, 0, 0.05)), color-mix(in srgb, var(--dt-card) 84%, #000) !important;
+  box-shadow: inset 0 0.0625rem 0 rgba(255, 255, 255, 0.06);
+}
+
+:root[data-hermes-theme='liquid-glass-light'] [data-slot='aui_assistant-message-content'] .aui-md pre,
+:root[data-hermes-theme='liquid-glass-light'] [data-slot='code-card'] {
+  background:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.45), rgba(255, 255, 255, 0.18)),
+    color-mix(in srgb, var(--dt-card) 84%, #fff) !important;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  :root[data-hermes-theme='liquid-glass'] *,
+  :root[data-hermes-theme='liquid-glass-light'] * {
+    transition-duration: 0.01ms !important;
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+  }
+}

--- a/apps/desktop/src/themes/presets.ts
+++ b/apps/desktop/src/themes/presets.ts
@@ -9,8 +9,7 @@ import type { DesktopTheme, DesktopThemeTypography } from './types'
 // text/mono fonts carry emoji glyphs, so without this emoji render as tofu
 // boxes on platforms whose default text font lacks them (e.g. Linux/#40364).
 // Covers macOS, Windows, Linux, plus the `emoji` generic for anything else.
-export const EMOJI_FALLBACK =
-  '"Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji", emoji'
+export const EMOJI_FALLBACK = '"Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji", emoji'
 
 const SYSTEM_SANS =
   '"Segoe WPC", "Segoe UI", -apple-system, BlinkMacSystemFont, "SF Pro Text", "SF Pro Display", system-ui, sans-serif, ' +
@@ -95,6 +94,113 @@ export const nousTheme: DesktopTheme = {
     fontSans: SYSTEM_SANS,
     fontMono: `"Courier Prime", ${SYSTEM_MONO}`,
     fontUrl: 'https://fonts.googleapis.com/css2?family=Courier+Prime:wght@400;700&display=swap'
+  }
+}
+
+/** Premium dark glass with luminous Hermes accents. */
+export const liquidGlassTheme: DesktopTheme = {
+  name: 'liquid-glass',
+  label: 'Liquid Glass',
+  description: 'Premium dark glass surfaces with luminous Hermes accents',
+  colors: {
+    background: '#070914',
+    foreground: '#FFE6CB',
+    card: 'rgba(255, 230, 203, 0.075)',
+    cardForeground: '#FFF7EF',
+    muted: 'rgba(255, 230, 203, 0.08)',
+    mutedForeground: '#C9B7A3',
+    popover: 'rgba(13, 16, 28, 0.92)',
+    popoverForeground: '#FFF7EF',
+    primary: '#FFE6CB',
+    primaryForeground: '#070914',
+    secondary: 'rgba(255, 230, 203, 0.10)',
+    secondaryForeground: '#FFE6CB',
+    accent: '#00D4FF',
+    accentForeground: '#061018',
+    border: 'rgba(255, 230, 203, 0.16)',
+    input: 'rgba(255, 230, 203, 0.13)',
+    ring: '#00D4FF',
+    midground: '#FFE6CB',
+    composerRing: '#00D4FF',
+    destructive: '#FB2C36',
+    destructiveForeground: '#FFFFFF',
+    sidebarBackground: 'rgba(7, 9, 20, 0.82)',
+    sidebarBorder: 'rgba(255, 230, 203, 0.12)',
+    userBubble: 'rgba(255, 230, 203, 0.12)',
+    userBubbleBorder: 'rgba(255, 230, 203, 0.18)'
+  },
+  darkColors: {
+    background: '#070914',
+    foreground: '#FFE6CB',
+    card: 'rgba(255, 230, 203, 0.09)',
+    cardForeground: '#FFF7EF',
+    muted: 'rgba(255, 230, 203, 0.10)',
+    mutedForeground: '#C9B7A3',
+    popover: 'rgba(13, 16, 28, 0.94)',
+    popoverForeground: '#FFF7EF',
+    primary: '#FFE6CB',
+    primaryForeground: '#070914',
+    secondary: 'rgba(255, 230, 203, 0.12)',
+    secondaryForeground: '#FFE6CB',
+    accent: '#00D4FF',
+    accentForeground: '#061018',
+    border: 'rgba(255, 230, 203, 0.18)',
+    input: 'rgba(255, 230, 203, 0.14)',
+    ring: '#00D4FF',
+    midground: '#FFE6CB',
+    composerRing: '#00D4FF',
+    destructive: '#FB2C36',
+    destructiveForeground: '#FFFFFF',
+    sidebarBackground: 'rgba(7, 9, 20, 0.86)',
+    sidebarBorder: 'rgba(255, 230, 203, 0.14)',
+    userBubble: 'rgba(255, 230, 203, 0.14)',
+    userBubbleBorder: 'rgba(255, 230, 203, 0.20)'
+  },
+  typography: {
+    fontSans: '"Inter", ' + SYSTEM_SANS,
+    fontMono: '"JetBrains Mono", ' + SYSTEM_MONO,
+    fontUrl:
+      'https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500;700&display=swap'
+  }
+}
+
+/** Bright glass variant with Nous-blue accents and a cream canvas. */
+export const liquidGlassLightTheme: DesktopTheme = {
+  name: 'liquid-glass-light',
+  label: 'Liquid Glass Light',
+  description: 'Bright glass surfaces with Nous-blue accents and cream canvas',
+  colors: {
+    background: '#F7F2EA',
+    foreground: '#111827',
+    card: 'rgba(255, 255, 255, 0.76)',
+    cardForeground: '#111827',
+    muted: 'rgba(0, 83, 253, 0.07)',
+    mutedForeground: '#5B6475',
+    popover: 'rgba(255, 255, 255, 0.92)',
+    popoverForeground: '#111827',
+    primary: '#0053FD',
+    primaryForeground: '#FFFFFF',
+    secondary: 'rgba(0, 83, 253, 0.08)',
+    secondaryForeground: '#003EA8',
+    accent: '#FFAC02',
+    accentForeground: '#1A1200',
+    border: 'rgba(0, 83, 253, 0.16)',
+    input: 'rgba(0, 83, 253, 0.12)',
+    ring: '#0053FD',
+    midground: '#0053FD',
+    composerRing: '#0053FD',
+    destructive: '#C72E4D',
+    destructiveForeground: '#FFFFFF',
+    sidebarBackground: 'rgba(255, 255, 255, 0.70)',
+    sidebarBorder: 'rgba(0, 83, 253, 0.12)',
+    userBubble: 'rgba(0, 83, 253, 0.08)',
+    userBubbleBorder: 'rgba(0, 83, 253, 0.16)'
+  },
+  typography: {
+    fontSans: '"Inter", ' + SYSTEM_SANS,
+    fontMono: '"JetBrains Mono", ' + SYSTEM_MONO,
+    fontUrl:
+      'https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500;700&display=swap'
   }
 }
 
@@ -279,6 +385,8 @@ export const slateTheme: DesktopTheme = {
 }
 
 export const BUILTIN_THEMES: Record<string, DesktopTheme> = {
+  'liquid-glass': liquidGlassTheme,
+  'liquid-glass-light': liquidGlassLightTheme,
   nous: nousTheme,
   midnight: midnightTheme,
   ember: emberTheme,
@@ -290,4 +398,4 @@ export const BUILTIN_THEMES: Record<string, DesktopTheme> = {
 export const BUILTIN_THEME_LIST = Object.values(BUILTIN_THEMES)
 
 /** Skin used when nothing is persisted or the persisted name is retired. */
-export const DEFAULT_SKIN_NAME = 'nous'
+export const DEFAULT_SKIN_NAME = 'liquid-glass'

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -11372,14 +11372,15 @@ def mount_spa(application: FastAPI):
 # Built-in dashboard themes — label + description only.  The actual color
 # definitions live in the frontend (web/src/themes/presets.ts).
 _BUILTIN_DASHBOARD_THEMES = [
-    {"name": "default",       "label": "Hermes Teal",         "description": "Classic dark teal — the canonical Hermes look"},
-    {"name": "default-large", "label": "Hermes Teal (Large)", "description": "Hermes Teal with bigger fonts and roomier spacing"},
-    {"name": "nous-blue",     "label": "Nous Blue",           "description": "Light mode — vivid Nous-blue accents on cream canvas"},
-    {"name": "midnight",      "label": "Midnight",            "description": "Deep blue-violet with cool accents"},
-    {"name": "ember",     "label": "Ember",          "description": "Warm crimson and bronze — forge vibes"},
-    {"name": "mono",      "label": "Mono",           "description": "Clean grayscale — minimal and focused"},
-    {"name": "cyberpunk", "label": "Cyberpunk",      "description": "Neon green on black — matrix terminal"},
-    {"name": "rose",      "label": "Rosé",           "description": "Soft pink and warm ivory — easy on the eyes"},
+    {"name": "default",          "label": "Liquid Glass",             "description": "Premium dark glass surfaces with luminous Hermes accents"},
+    {"name": "default-large",    "label": "Liquid Glass (Large)",     "description": "Liquid Glass with bigger fonts and roomier spacing"},
+    {"name": "liquid-glass-light","label": "Liquid Glass Light",      "description": "Bright glass surfaces with Nous-blue accents and cream canvas"},
+    {"name": "nous-blue",        "label": "Nous Blue",                "description": "Light mode — vivid Nous-blue accents on cream canvas"},
+    {"name": "midnight",         "label": "Midnight",                 "description": "Deep blue-violet with cool accents"},
+    {"name": "ember",            "label": "Ember",                    "description": "Warm crimson and bronze — forge vibes"},
+    {"name": "mono",             "label": "Mono",                     "description": "Clean grayscale — minimal and focused"},
+    {"name": "cyberpunk",        "label": "Cyberpunk",                "description": "Neon green on black — matrix terminal"},
+    {"name": "rose",             "label": "Rosé",                     "description": "Soft pink and warm ivory — easy on the eyes"},
 ]
 
 

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -1,12 +1,12 @@
-@import 'tailwindcss';
+@import "tailwindcss";
 /* `fonts.css` must come BEFORE `globals.css`: as of @nous-research/ui 0.14.x,
    `globals.css` only declares the `--font-*` CSS variables (Collapse, Rules
    Compressed/Expanded, Mondwest). The `@font-face` registrations live in
    `fonts.css`, so without this import the DS variables resolve to font
    families the browser never loads and components fall back to a system
    stack (Tabs, Segmented, Typography, Buttons, etc. all look unstyled). */
-@import '@nous-research/ui/styles/fonts.css';
-@import '@nous-research/ui/styles/globals.css';
+@import "@nous-research/ui/styles/fonts.css";
+@import "@nous-research/ui/styles/globals.css";
 
 /* Scan the published design-system bundle so its utility classes survive
    Tailwind's JIT purge. */
@@ -21,25 +21,25 @@
 /* ------------------------------------------------------------------ */
 
 @font-face {
-  font-family: 'JetBrains Mono';
+  font-family: "JetBrains Mono";
   font-style: normal;
   font-weight: 400;
   font-display: swap;
-  src: url('/fonts-terminal/JetBrainsMono-Regular.woff2') format('woff2');
+  src: url("/fonts-terminal/JetBrainsMono-Regular.woff2") format("woff2");
 }
 @font-face {
-  font-family: 'JetBrains Mono';
+  font-family: "JetBrains Mono";
   font-style: normal;
   font-weight: 700;
   font-display: swap;
-  src: url('/fonts-terminal/JetBrainsMono-Bold.woff2') format('woff2');
+  src: url("/fonts-terminal/JetBrainsMono-Bold.woff2") format("woff2");
 }
 @font-face {
-  font-family: 'JetBrains Mono';
+  font-family: "JetBrains Mono";
   font-style: italic;
   font-weight: 400;
   font-display: swap;
-  src: url('/fonts-terminal/JetBrainsMono-Italic.woff2') format('woff2');
+  src: url("/fonts-terminal/JetBrainsMono-Italic.woff2") format("woff2");
 }
 
 /* ------------------------------------------------------------------ */
@@ -69,10 +69,11 @@
 
   /* Typography tokens — rewritten by ThemeProvider. Defaults match the
      system stack so themes that don't override look native. */
-  --theme-font-sans: system-ui, -apple-system, "Segoe UI", Roboto,
-    "Helvetica Neue", Arial, sans-serif;
-  --theme-font-mono: ui-monospace, "SF Mono", "Cascadia Mono", Menlo,
-    Consolas, monospace;
+  --theme-font-sans:
+    system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", Arial,
+    sans-serif;
+  --theme-font-mono:
+    ui-monospace, "SF Mono", "Cascadia Mono", Menlo, Consolas, monospace;
   --theme-font-display: var(--theme-font-sans);
   --theme-base-size: 15px;
   --theme-line-height: 1.55;
@@ -114,7 +115,12 @@ body {
   overflow: hidden;
 }
 
-code, kbd, pre, samp, .font-mono, .font-mono-ui {
+code,
+kbd,
+pre,
+samp,
+.font-mono,
+.font-mono-ui {
   font-family: var(--theme-font-mono);
 }
 
@@ -149,8 +155,12 @@ code, kbd, pre, samp, .font-mono, .font-mono-ui {
 
 /* Nousnet's hermes-agent layout bumps `small` and `code` to readable
    dashboard sizes. Keep in sync. */
-small { font-size: 1.0625rem; }
-code { font-size: 0.875rem; }
+small {
+  font-size: 1.0625rem;
+}
+code {
+  font-size: 0.875rem;
+}
 
 /* Shadcn-compat tokens.
    The dashboard's page code predates the Nous DS and uses shadcn-style
@@ -162,19 +172,35 @@ code { font-size: 0.875rem; }
      stay visible — in LENS_0, `--foreground` itself has alpha 0. */
   --color-foreground: var(--midground);
 
-  --color-card: color-mix(in srgb, var(--midground-base) 4%, var(--background-base));
+  --color-card: color-mix(
+    in srgb,
+    var(--midground-base) 4%,
+    var(--background-base)
+  );
   --color-card-foreground: var(--midground);
   --color-primary: var(--midground);
   --color-primary-foreground: var(--background-base);
-  --color-secondary: color-mix(in srgb, var(--midground-base) 6%, var(--background-base));
+  --color-secondary: color-mix(
+    in srgb,
+    var(--midground-base) 6%,
+    var(--background-base)
+  );
   --color-secondary-foreground: var(--midground);
-  --color-muted: color-mix(in srgb, var(--midground-base) 8%, var(--background-base));
+  --color-muted: color-mix(
+    in srgb,
+    var(--midground-base) 8%,
+    var(--background-base)
+  );
   /* Routes the shadcn `muted-foreground` slot through the DS semantic
      text-secondary token (defaults to midground 80%) so legacy call
      sites that use `text-muted-foreground` get a readable color
      instead of the old 55%-transparent default. */
   --color-muted-foreground: var(--color-text-secondary);
-  --color-accent: color-mix(in srgb, var(--midground-base) 10%, var(--background-base));
+  --color-accent: color-mix(
+    in srgb,
+    var(--midground-base) 10%,
+    var(--background-base)
+  );
   --color-accent-foreground: var(--midground);
   --color-destructive: #fb2c36;
   --color-destructive-foreground: #ffffff;
@@ -183,7 +209,11 @@ code { font-size: 0.875rem; }
   --color-border: color-mix(in srgb, var(--midground-base) 15%, transparent);
   --color-input: color-mix(in srgb, var(--midground-base) 15%, transparent);
   --color-ring: var(--midground);
-  --color-popover: color-mix(in srgb, var(--midground-base) 4%, var(--background-base));
+  --color-popover: color-mix(
+    in srgb,
+    var(--midground-base) 4%,
+    var(--background-base)
+  );
   --color-popover-foreground: var(--midground);
 
   --radius-sm: calc(var(--theme-radius) - 4px);
@@ -192,31 +222,58 @@ code { font-size: 0.875rem; }
   --radius-xl: calc(var(--theme-radius) + 4px);
 }
 
-
 /* Collapsed sidebar tooltip entrance — skipped when moving between items. */
 @keyframes sidebar-tooltip-in {
-  from { opacity: 0; transform: translateY(-50%) translateX(-4px); }
-  to   { opacity: 1; transform: translateY(-50%) translateX(0); }
+  from {
+    opacity: 0;
+    transform: translateY(-50%) translateX(-4px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(-50%) translateX(0);
+  }
 }
 
 /* Toast animations used by `components/Toast.tsx`. */
 @keyframes toast-in {
-  from { opacity: 0; transform: translateX(16px); }
-  to   { opacity: 1; transform: translateX(0); }
+  from {
+    opacity: 0;
+    transform: translateX(16px);
+  }
+  to {
+    opacity: 1;
+    transform: translateX(0);
+  }
 }
 @keyframes toast-out {
-  from { opacity: 1; transform: translateX(0); }
-  to   { opacity: 0; transform: translateX(16px); }
+  from {
+    opacity: 1;
+    transform: translateX(0);
+  }
+  to {
+    opacity: 0;
+    transform: translateX(16px);
+  }
 }
 
 /* Generic fade + dialog entrance used by popovers and confirm dialogs. */
 @keyframes fade-in {
-  from { opacity: 0; }
-  to   { opacity: 1; }
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
 }
 @keyframes dialog-in {
-  from { opacity: 0; transform: translateY(4px) scale(0.98); }
-  to   { opacity: 1; transform: translateY(0) scale(1); }
+  from {
+    opacity: 0;
+    transform: translateY(4px) scale(0.98);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
 }
 
 /* Hide scrollbar utility — used by the header's overflow-x nav row. */
@@ -247,7 +304,7 @@ code { font-size: 0.875rem; }
   position: relative;
 }
 .grain::after {
-  content: '';
+  content: "";
   position: absolute;
   inset: 0;
   opacity: 0.12;
@@ -263,7 +320,377 @@ code { font-size: 0.875rem; }
 :root:not([style*="--theme-asset-bg:"]) .theme-default-filler {
   display: block;
 }
-:root[style*="--theme-asset-bg:"] .theme-default-filler {
+:root[style*="--background-base:#170d02"] .theme-default-filler {
   display: none;
 }
+:root[style*="--background-base:#170d02"] {
+  --liquid-accent: #0053fd;
+  --liquid-accent-2: #ffac02;
+  --liquid-surface: rgba(255, 255, 255, 0.62);
+  --liquid-surface-strong: rgba(255, 255, 255, 0.78);
+  --liquid-border: rgba(0, 83, 253, 0.18);
+  --liquid-border-soft: rgba(0, 83, 253, 0.11);
+  --liquid-shadow: 0 24px 80px rgba(15, 23, 42, 0.14);
+  --liquid-text-shadow: 0 0 34px rgba(0, 83, 253, 0.16);
+}
 
+/* ── Premium “Liquid Glass” design pass ───────────────────────────────────
+   Applies across the dashboard shell, routed pages, and shared UI surfaces.
+   This intentionally uses CSS variables and broad semantic selectors so the
+   redesign reaches all 19 dashboard pages without rewriting each route. */
+:root {
+  --liquid-accent: var(--midground);
+  --liquid-accent-2: #00d4ff;
+  --liquid-violet: #a78bfa;
+  --liquid-surface: color-mix(in srgb, var(--midground-base) 5%, transparent);
+  --liquid-surface-strong: color-mix(
+    in srgb,
+    var(--midground-base) 10%,
+    transparent
+  );
+  --liquid-border: color-mix(in srgb, var(--midground-base) 22%, transparent);
+  --liquid-border-soft: color-mix(
+    in srgb,
+    var(--midground-base) 12%,
+    transparent
+  );
+  --liquid-shadow: 0 24px 80px
+    color-mix(in srgb, var(--midground-base) 18%, transparent);
+  --liquid-shadow-soft: 0 14px 44px
+    color-mix(in srgb, var(--midground-base) 12%, transparent);
+  --liquid-text-shadow: 0 0 40px
+    color-mix(in srgb, var(--midground-base) 18%, transparent);
+  --liquid-radius: max(var(--theme-radius), 1.125rem);
+}
+
+body,
+body::selection {
+  background-color: var(--background-base);
+}
+
+body {
+  background:
+    radial-gradient(
+      circle at 12% 8%,
+      color-mix(in srgb, var(--liquid-accent) 24%, transparent),
+      transparent 30rem
+    ),
+    radial-gradient(
+      circle at 88% 12%,
+      color-mix(in srgb, var(--liquid-accent-2) 18%, transparent),
+      transparent 28rem
+    ),
+    radial-gradient(
+      circle at 72% 88%,
+      color-mix(in srgb, var(--liquid-violet) 16%, transparent),
+      transparent 32rem
+    ),
+    linear-gradient(
+      135deg,
+      var(--background-base),
+      color-mix(in srgb, var(--background-base) 88%, #000)
+    );
+}
+
+#app-sidebar,
+header[role="banner"],
+[data-slot="card"],
+.card,
+[data-slot="popover"],
+.popover,
+[data-slot="dialog"],
+.dialog,
+[data-slot="sheet"],
+.sheet {
+  position: relative;
+  isolation: isolate;
+  border-color: var(--liquid-border) !important;
+  box-shadow: var(--liquid-shadow-soft);
+  backdrop-filter: blur(22px) saturate(145%);
+  -webkit-backdrop-filter: blur(22px) saturate(145%);
+}
+
+#app-sidebar {
+  overflow: hidden;
+  background: linear-gradient(
+    180deg,
+    color-mix(in srgb, var(--midground-base) 8%, transparent),
+    color-mix(in srgb, var(--background-base) 68%, transparent)
+  ) !important;
+  border-right-color: var(--liquid-border-soft) !important;
+}
+
+#app-sidebar::before,
+header[role="banner"]::before,
+[data-slot="card"]::before,
+.card::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  z-index: -1;
+  pointer-events: none;
+  background:
+    linear-gradient(
+      135deg,
+      color-mix(in srgb, var(--liquid-accent) 18%, transparent),
+      transparent 34%
+    ),
+    radial-gradient(
+      circle at 16% 0%,
+      color-mix(in srgb, var(--liquid-accent-2) 16%, transparent),
+      transparent 24rem
+    );
+  opacity: 0.62;
+}
+
+#app-sidebar > *,
+header[role="banner"] > *,
+[data-slot="card"] > *,
+.card > * {
+  position: relative;
+  z-index: 1;
+}
+
+header[role="banner"] {
+  background: linear-gradient(
+    90deg,
+    color-mix(in srgb, var(--background-base) 42%, transparent),
+    color-mix(in srgb, var(--liquid-accent) 5%, transparent)
+  ) !important;
+  border-bottom-color: var(--liquid-border-soft) !important;
+}
+
+header[role="banner"] h1 {
+  text-shadow: var(--liquid-text-shadow);
+  letter-spacing: 0.095em;
+}
+
+main {
+  scrollbar-color: color-mix(in srgb, var(--liquid-accent) 42%, transparent)
+    transparent;
+}
+
+main > * {
+  animation: liquid-page-in 180ms ease-out both;
+}
+
+@keyframes liquid-page-in {
+  from {
+    opacity: 0;
+    transform: translateY(8px) scale(0.992);
+    filter: blur(4px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+    filter: blur(0);
+  }
+}
+
+[data-slot="card"],
+.card {
+  border-radius: var(--liquid-radius) !important;
+  background: linear-gradient(
+    180deg,
+    var(--liquid-surface-strong),
+    var(--liquid-surface)
+  ) !important;
+}
+
+[data-slot="card"] + [data-slot="card"],
+.card + .card,
+.card + [data-slot="card"],
+[data-slot="card"] + .card {
+  margin-top: 0.75rem;
+}
+
+[data-slot="card-header"],
+.card-header {
+  padding: 1.1rem 1.2rem 0.65rem !important;
+}
+
+[data-slot="card-title"],
+.card-title {
+  color: var(--midground) !important;
+  font-weight: 760 !important;
+  letter-spacing: 0.035em !important;
+  text-transform: uppercase !important;
+}
+
+[data-slot="card-content"],
+.card-content {
+  padding: 1rem 1.2rem 1.2rem !important;
+}
+
+[data-slot="button"],
+.button,
+button,
+[class*="button"] {
+  border-radius: 999px !important;
+  border-color: var(--liquid-border) !important;
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.12),
+    0 10px 24px color-mix(in srgb, var(--liquid-accent) 12%, transparent);
+  transition:
+    transform 160ms ease,
+    border-color 160ms ease,
+    background 160ms ease,
+    box-shadow 160ms ease !important;
+}
+
+[data-slot="button"]:not(:disabled):hover,
+.button:not(:disabled):hover,
+button:not(:disabled):hover,
+[class*="button"]:not(:disabled):hover {
+  transform: translateY(-1px);
+  border-color: var(--liquid-accent) !important;
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.18),
+    0 14px 32px color-mix(in srgb, var(--liquid-accent) 18%, transparent);
+}
+
+[data-slot="input"],
+.input,
+input,
+textarea,
+select {
+  border-color: var(--liquid-border) !important;
+  border-radius: 999px !important;
+  background: color-mix(
+    in srgb,
+    var(--background-base) 54%,
+    transparent
+  ) !important;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.08) !important;
+  transition:
+    border-color 160ms ease,
+    box-shadow 160ms ease,
+    background 160ms ease !important;
+}
+
+[data-slot="input"]:focus,
+.input:focus,
+input:focus,
+textarea:focus,
+select:focus {
+  border-color: var(--liquid-accent) !important;
+  box-shadow:
+    0 0 0 3px color-mix(in srgb, var(--liquid-accent) 22%, transparent),
+    inset 0 1px 0 rgba(255, 255, 255, 0.12) !important;
+}
+
+[data-slot="badge"],
+.badge,
+[class*="badge"] {
+  border: 1px solid var(--liquid-border-soft) !important;
+  border-radius: 999px !important;
+  background: color-mix(
+    in srgb,
+    var(--liquid-accent) 12%,
+    transparent
+  ) !important;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.08);
+}
+
+table {
+  border-collapse: separate !important;
+  border-spacing: 0 !important;
+  overflow: hidden;
+  border-radius: var(--liquid-radius) !important;
+}
+
+table thead th {
+  background: color-mix(
+    in srgb,
+    var(--liquid-accent) 10%,
+    transparent
+  ) !important;
+  border-bottom-color: var(--liquid-border) !important;
+  color: var(--midground) !important;
+  text-transform: uppercase !important;
+  letter-spacing: 0.06em !important;
+}
+
+table tbody tr {
+  transition:
+    background 160ms ease,
+    transform 160ms ease !important;
+}
+
+table tbody tr:hover {
+  background: color-mix(
+    in srgb,
+    var(--liquid-accent) 8%,
+    transparent
+  ) !important;
+}
+
+[data-slot="tabs-list"],
+.tabs-list,
+[role="tablist"] {
+  border-color: var(--liquid-border-soft) !important;
+  background: color-mix(
+    in srgb,
+    var(--background-base) 40%,
+    transparent
+  ) !important;
+  border-radius: 999px !important;
+  padding: 0.25rem !important;
+}
+
+[role="tab"] {
+  border-radius: 999px !important;
+}
+
+[role="tab"][aria-selected="true"] {
+  color: var(--background-base) !important;
+  background: var(--liquid-accent) !important;
+  box-shadow: 0 10px 24px
+    color-mix(in srgb, var(--liquid-accent) 18%, transparent);
+}
+
+[data-slot="alert"],
+.alert,
+[data-slot="toast"],
+.toast {
+  border-color: var(--liquid-border) !important;
+  border-radius: var(--liquid-radius) !important;
+  background: linear-gradient(
+    180deg,
+    var(--liquid-surface-strong),
+    var(--liquid-surface)
+  ) !important;
+  box-shadow: var(--liquid-shadow-soft);
+}
+
+.progress,
+[data-slot="progress"],
+[role="progressbar"] {
+  overflow: hidden;
+  border-radius: 999px !important;
+  background: color-mix(
+    in srgb,
+    var(--liquid-accent) 10%,
+    transparent
+  ) !important;
+}
+
+.progress > *,
+[data-slot="progress"] > *,
+[role="progressbar"] > * {
+  border-radius: 999px !important;
+  background: linear-gradient(
+    90deg,
+    var(--liquid-accent),
+    var(--liquid-accent-2)
+  ) !important;
+  box-shadow: 0 0 24px color-mix(in srgb, var(--liquid-accent) 40%, transparent);
+}
+
+/* Keep terminal and docs surfaces readable while still using the premium shell. */
+[data-chat-active="true"] iframe,
+iframe[title*="Documentation" i] {
+  border-color: var(--liquid-border) !important;
+  border-radius: var(--liquid-radius) !important;
+  box-shadow: var(--liquid-shadow);
+}

--- a/web/src/themes/presets.ts
+++ b/web/src/themes/presets.ts
@@ -40,18 +40,59 @@ const DEFAULT_LAYOUT: ThemeLayout = {
 
 export const defaultTheme: DashboardTheme = {
   name: "default",
-  label: "Hermes Teal",
-  description: "Classic dark teal — the canonical Hermes look",
+  label: "Liquid Glass",
+  description: "Premium dark glass surfaces with luminous Hermes accents",
   palette: {
-    background: { hex: "#041c1c", alpha: 1 },
-    midground: { hex: "#ffe6cb", alpha: 1 },
+    background: { hex: "#070914", alpha: 1 },
+    midground: { hex: "#FFE6CB", alpha: 1 },
     foreground: { hex: "#ffffff", alpha: 0 },
-    warmGlow: "rgba(255, 189, 56, 0.35)",
-    noiseOpacity: 1,
+    warmGlow: "rgba(255, 230, 203, 0.34)",
+    noiseOpacity: 0.72,
   },
-  typography: DEFAULT_TYPOGRAPHY,
-  layout: DEFAULT_LAYOUT,
-  terminalBackground: "#000000",
+  typography: {
+    ...DEFAULT_TYPOGRAPHY,
+    fontSans: `"Inter", ${SYSTEM_SANS}`,
+    fontMono: `"JetBrains Mono", ${SYSTEM_MONO}`,
+    fontUrl:
+      "https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500;700&display=swap",
+    letterSpacing: "-0.01em",
+  },
+  layout: {
+    ...DEFAULT_LAYOUT,
+    radius: "1rem",
+  },
+  componentStyles: {
+    backdrop: {
+      fillerOpacity: "0.055",
+    },
+    card: {
+      borderRadius: "1.25rem",
+      background:
+        "linear-gradient(180deg, rgba(255,230,203,0.10), rgba(255,230,203,0.045))",
+      border: "1px solid rgba(255,230,203,0.16)",
+    },
+    sidebar: {
+      background:
+        "linear-gradient(180deg, rgba(255,230,203,0.09), rgba(7,9,20,0.78))",
+      borderImage:
+        "linear-gradient(180deg, rgba(255,230,203,0.18), rgba(255,230,203,0.04)) 1",
+    },
+    header: {
+      background:
+        "linear-gradient(90deg, rgba(255,230,203,0.07), rgba(7,9,20,0.48))",
+      borderImage:
+        "linear-gradient(90deg, rgba(255,230,203,0.18), rgba(255,230,203,0.03)) 1",
+    },
+    page: {
+      radius: "1.25rem",
+    },
+  },
+  seriesColors: {
+    inputTokenAccent: "#FFE6CB",
+    outputTokenAccent: "#00D4FF",
+  },
+  swatchColors: ["#FFE6CB", "#00D4FF", "#070914"],
+  terminalBackground: "#050711",
 };
 
 export const midnightTheme: DashboardTheme = {
@@ -285,23 +326,86 @@ export const nousBlueTheme: DashboardTheme = {
  */
 export const defaultLargeTheme: DashboardTheme = {
   name: "default-large",
-  label: "Hermes Teal (Large)",
-  description: "Hermes Teal with bigger fonts and roomier spacing",
+  label: "Liquid Glass (Large)",
+  description: "Liquid Glass with bigger fonts and roomier spacing",
   palette: defaultTheme.palette,
   typography: {
     ...DEFAULT_TYPOGRAPHY,
+    fontSans: `"Inter", ${SYSTEM_SANS}`,
+    fontMono: `"JetBrains Mono", ${SYSTEM_MONO}`,
     baseSize: "18px",
     lineHeight: "1.65",
   },
   layout: {
     ...DEFAULT_LAYOUT,
+    radius: "1.15rem",
     density: "spacious",
   },
+  componentStyles: defaultTheme.componentStyles,
+  seriesColors: defaultTheme.seriesColors,
+  swatchColors: defaultTheme.swatchColors,
+  terminalBackground: defaultTheme.terminalBackground,
+};
+
+export const liquidGlassLightTheme: DashboardTheme = {
+  name: "liquid-glass-light",
+  label: "Liquid Glass Light",
+  description: "Bright glass surfaces with Nous-blue accents and cream canvas",
+  palette: {
+    background: { hex: "#F7F2EA", alpha: 1 },
+    midground: { hex: "#0053FD", alpha: 1 },
+    foreground: { hex: "#FFFFFF", alpha: 0 },
+    warmGlow: "rgba(0, 83, 253, 0.22)",
+    noiseOpacity: 0.42,
+  },
+  typography: {
+    ...DEFAULT_TYPOGRAPHY,
+    fontSans: `"Inter", ${SYSTEM_SANS}`,
+    fontMono: `"JetBrains Mono", ${SYSTEM_MONO}`,
+    letterSpacing: "-0.01em",
+  },
+  layout: {
+    ...DEFAULT_LAYOUT,
+    radius: "1rem",
+  },
+  componentStyles: {
+    backdrop: {
+      fillerOpacity: "0.035",
+    },
+    card: {
+      borderRadius: "1.25rem",
+      background:
+        "linear-gradient(180deg, rgba(255,255,255,0.82), rgba(255,255,255,0.62))",
+      border: "1px solid rgba(0,83,253,0.16)",
+    },
+    sidebar: {
+      background:
+        "linear-gradient(180deg, rgba(255,255,255,0.78), rgba(247,242,234,0.68))",
+      borderImage:
+        "linear-gradient(180deg, rgba(0,83,253,0.18), rgba(0,83,253,0.04)) 1",
+    },
+    header: {
+      background:
+        "linear-gradient(90deg, rgba(255,255,255,0.72), rgba(247,242,234,0.58))",
+      borderImage:
+        "linear-gradient(90deg, rgba(0,83,253,0.18), rgba(0,83,253,0.03)) 1",
+    },
+    page: {
+      radius: "1.25rem",
+    },
+  },
+  seriesColors: {
+    inputTokenAccent: "#0053FD",
+    outputTokenAccent: "#FFAC02",
+  },
+  swatchColors: ["#F7F2EA", "#0053FD", "#FFAC02"],
+  terminalBackground: "#FFFFFF",
 };
 
 export const BUILTIN_THEMES: Record<string, DashboardTheme> = {
   default: defaultTheme,
   "default-large": defaultLargeTheme,
+  "liquid-glass-light": liquidGlassLightTheme,
   "nous-blue": nousBlueTheme,
   midnight: midnightTheme,
   ember: emberTheme,

--- a/website/docs/index.mdx
+++ b/website/docs/index.mdx
@@ -9,56 +9,48 @@ displayed_sidebar: docs
 
 import Link from "@docusaurus/Link";
 
-# Hermes Agent
+<div className="hero--hermes">
+  <p className="hero-eyebrow">Premium AI agent OS · Liquid Glass UI</p>
+  <h1>Hermes Agent</h1>
+  <p className="hero-lead">
+    The self-improving AI agent built by <a href="https://nousresearch.com">Nous Research</a>. Hermes creates skills from experience, improves them during use, persists memory across sessions, and gives you one intelligent agent across CLI, Telegram, web, desktop, and automation workflows.
+  </p>
 
-The self-improving AI agent built by [Nous Research](https://nousresearch.com). The only agent with a built-in learning loop — it creates skills from experience, improves them during use, nudges itself to persist knowledge, and builds a deepening model of who you are across sessions.
-
-<div
-  style={{
-    display: "flex",
-    gap: "1rem",
-    marginBottom: "2rem",
-    flexWrap: "wrap",
-  }}
->
+<div className="hero-actions">
   <Link
+    className="button button--primary button--lg"
     to="/getting-started/installation"
-    style={{
-      display: "inline-block",
-      padding: "0.6rem 1.2rem",
-      backgroundColor: "#FFD700",
-      color: "#07070d",
-      borderRadius: "8px",
-      fontWeight: 600,
-      textDecoration: "none",
-    }}
   >
     Get Started →
   </Link>
   <a
+    className="button button--secondary button--lg"
     href="https://hermes-agent.nousresearch.com/"
-    style={{
-      display: "inline-block",
-      padding: "0.6rem 1.2rem",
-      border: "1px solid rgba(255,215,0,0.2)",
-      borderRadius: "8px",
-      textDecoration: "none",
-    }}
   >
     Download Desktop
   </a>
   <a
+    className="button button--secondary button--lg"
     href="https://github.com/NousResearch/hermes-agent"
-    style={{
-      display: "inline-block",
-      padding: "0.6rem 1.2rem",
-      border: "1px solid rgba(255,215,0,0.2)",
-      borderRadius: "8px",
-      textDecoration: "none",
-    }}
   >
     View on GitHub
   </a>
+</div>
+
+  <div className="hero-stats" aria-label="Hermes Agent highlights">
+    <div className="hero-stat">
+      <strong>20+</strong>
+      <span>platforms from one gateway</span>
+    </div>
+    <div className="hero-stat">
+      <strong>60+</strong>
+      <span>built-in tools and MCP-ready workflows</span>
+    </div>
+    <div className="hero-stat">
+      <strong>Closed loop</strong>
+      <span>memory, skills, and self-improvement baked in</span>
+    </div>
+  </div>
 </div>
 
 ## Install

--- a/website/src/components/AutomationBlueprintsCatalog/index.tsx
+++ b/website/src/components/AutomationBlueprintsCatalog/index.tsx
@@ -25,7 +25,7 @@ interface Blueprint {
 
 const INDEX_URL = "/docs/api/automation-blueprints-index.json";
 
-function CopyButton({ text }: { text: string }): JSX.Element {
+function CopyButton({ text }: { text: string }): React.ReactElement {
   const [copied, setCopied] = useState(false);
   return (
     <button
@@ -44,7 +44,7 @@ function CopyButton({ text }: { text: string }): JSX.Element {
   );
 }
 
-function BlueprintCard({ blueprint }: { blueprint: Blueprint }): JSX.Element {
+function BlueprintCard({ blueprint }: { blueprint: Blueprint }): React.ReactElement {
   return (
     <div className={styles.card}>
       <div className={styles.cardHead}>
@@ -78,7 +78,7 @@ function BlueprintCard({ blueprint }: { blueprint: Blueprint }): JSX.Element {
   );
 }
 
-export default function AutomationBlueprintsCatalog(): JSX.Element {
+export default function AutomationBlueprintsCatalog(): React.ReactElement {
   const [blueprints, setBlueprints] = useState<Blueprint[] | null>(null);
   const [error, setError] = useState<string | null>(null);
 

--- a/website/src/components/UserStoriesCollage/index.tsx
+++ b/website/src/components/UserStoriesCollage/index.tsx
@@ -145,7 +145,7 @@ function sourceColor(source: string): string {
   }
 }
 
-export default function UserStoriesCollage(): JSX.Element {
+export default function UserStoriesCollage(): React.ReactElement {
   const [activeCategory, setActiveCategory] = useState<string>('all');
   const [activeSource, setActiveSource] = useState<string>('all');
 

--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -5,42 +5,44 @@
  */
 
 /* Import fonts to match landing page */
-@import url('https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap');
+@import url("https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap");
 
 :root {
   /* Dark amber palette for light mode — readable on white (WCAG AA compliant)
      Current gold #FFD700 has only 1.4:1 contrast on white; these tones pass 4.5:1+ */
-  --ifm-color-primary: #8B6508;
-  --ifm-color-primary-dark: #7A5800;
-  --ifm-color-primary-darker: #6E4F00;
-  --ifm-color-primary-darkest: #5A4100;
-  --ifm-color-primary-light: #9E7410;
-  --ifm-color-primary-lighter: #B38319;
-  --ifm-color-primary-lightest: #C89222;
+  --ifm-color-primary: #8b6508;
+  --ifm-color-primary-dark: #7a5800;
+  --ifm-color-primary-darker: #6e4f00;
+  --ifm-color-primary-darkest: #5a4100;
+  --ifm-color-primary-light: #9e7410;
+  --ifm-color-primary-lighter: #b38319;
+  --ifm-color-primary-lightest: #c89222;
 
-  --ifm-font-family-base: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
-  --ifm-font-family-monospace: 'JetBrains Mono', 'Fira Code', 'Cascadia Code', monospace;
+  --ifm-font-family-base:
+    "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  --ifm-font-family-monospace:
+    "JetBrains Mono", "Fira Code", "Cascadia Code", monospace;
 
   --ifm-code-font-size: 90%;
   --ifm-heading-font-weight: 600;
 
-  --ifm-link-color: #7A5800;
-  --ifm-link-hover-color: #5A4100;
+  --ifm-link-color: #7a5800;
+  --ifm-link-hover-color: #5a4100;
 }
 
 /* Dark mode — the PRIMARY mode, matches landing page */
-[data-theme='dark'] {
-  --ifm-color-primary: #FFD700;
-  --ifm-color-primary-dark: #E6C200;
-  --ifm-color-primary-darker: #D9B700;
-  --ifm-color-primary-darkest: #B39600;
-  --ifm-color-primary-light: #FFDD33;
-  --ifm-color-primary-lighter: #FFE14D;
-  --ifm-color-primary-lightest: #FFEB80;
+[data-theme="dark"] {
+  --ifm-color-primary: #ffd700;
+  --ifm-color-primary-dark: #e6c200;
+  --ifm-color-primary-darker: #d9b700;
+  --ifm-color-primary-darkest: #b39600;
+  --ifm-color-primary-light: #ffdd33;
+  --ifm-color-primary-lighter: #ffe14d;
+  --ifm-color-primary-lightest: #ffeb80;
 
   --ifm-background-color: #07070d;
   --ifm-background-surface-color: #0f0f18;
-  --ifm-navbar-background-color: #07070dEE;
+  --ifm-navbar-background-color: #07070dee;
   --ifm-footer-background-color: #050509;
   --ifm-color-emphasis-100: #14142a;
   --ifm-color-emphasis-200: #1a1a30;
@@ -48,8 +50,8 @@
   --ifm-font-color-base: #e8e4dc;
   --ifm-font-color-secondary: #9a968e;
 
-  --ifm-link-color: #FFD700;
-  --ifm-link-hover-color: #FFBF00;
+  --ifm-link-color: #ffd700;
+  --ifm-link-hover-color: #ffbf00;
 
   --ifm-code-background: #0f0f18;
 
@@ -60,8 +62,11 @@
 }
 
 /* Subtle dot grid background matching landing page */
-[data-theme='dark'] .main-wrapper {
-  background-image: radial-gradient(rgba(255, 215, 0, 0.02) 1px, transparent 1px);
+[data-theme="dark"] .main-wrapper {
+  background-image: radial-gradient(
+    rgba(255, 215, 0, 0.02) 1px,
+    transparent 1px
+  );
   background-size: 32px 32px;
 }
 
@@ -85,25 +90,25 @@
 }
 
 /* Sidebar tweaks */
-[data-theme='dark'] .menu {
+[data-theme="dark"] .menu {
   background-color: transparent;
 }
 
-[data-theme='dark'] .menu__link--active:not(.menu__link--sublist) {
+[data-theme="dark"] .menu__link--active:not(.menu__link--sublist) {
   background-color: rgba(255, 215, 0, 0.08);
-  border-left: 3px solid #FFD700;
+  border-left: 3px solid #ffd700;
   padding-left: calc(var(--ifm-menu-link-padding-horizontal) - 3px);
 }
 
 /* Light mode sidebar active */
-[data-theme='light'] .menu__link--active:not(.menu__link--sublist) {
+[data-theme="light"] .menu__link--active:not(.menu__link--sublist) {
   background-color: rgba(139, 101, 8, 0.08);
-  border-left: 3px solid #8B6508;
+  border-left: 3px solid #8b6508;
   padding-left: calc(var(--ifm-menu-link-padding-horizontal) - 3px);
 }
 
 /* Code blocks */
-[data-theme='dark'] .prism-code {
+[data-theme="dark"] .prism-code {
   background-color: #0a0a12 !important;
   border: 1px solid rgba(255, 215, 0, 0.06);
 }
@@ -116,9 +121,13 @@ pre.prism-code.language-ascii {
   white-space: pre;
   overflow-x: auto;
   line-height: 1.35;
-  font-family: 'JetBrains Mono', 'Cascadia Mono', 'Cascadia Code', 'Fira Code', 'SFMono-Regular', 'DejaVu Sans Mono', 'Liberation Mono', monospace;
+  font-family:
+    "JetBrains Mono", "Cascadia Mono", "Cascadia Code", "Fira Code",
+    "SFMono-Regular", "DejaVu Sans Mono", "Liberation Mono", monospace;
   font-variant-ligatures: none;
-  font-feature-settings: "liga" 0, "calt" 0;
+  font-feature-settings:
+    "liga" 0,
+    "calt" 0;
   text-rendering: optimizeSpeed;
 }
 
@@ -128,7 +137,9 @@ pre.prism-code.language-txt code,
 pre.prism-code.language-ascii code {
   white-space: pre;
   font-variant-ligatures: none;
-  font-feature-settings: "liga" 0, "calt" 0;
+  font-feature-settings:
+    "liga" 0,
+    "calt" 0;
 }
 
 .theme-mermaid {
@@ -159,33 +170,33 @@ pre.prism-code.language-ascii code {
 }
 
 /* Admonitions — gold-tinted */
-[data-theme='dark'] .alert--info {
+[data-theme="dark"] .alert--info {
   --ifm-alert-background-color: rgba(255, 215, 0, 0.05);
   --ifm-alert-border-color: rgba(255, 215, 0, 0.15);
 }
 
 /* Table styling */
-[data-theme='dark'] table {
+[data-theme="dark"] table {
   border-collapse: collapse;
 }
 
-[data-theme='dark'] table th {
+[data-theme="dark"] table th {
   background-color: rgba(255, 215, 0, 0.06);
   border-color: rgba(255, 215, 0, 0.12);
 }
 
-[data-theme='dark'] table td {
+[data-theme="dark"] table td {
   border-color: rgba(255, 215, 0, 0.06);
 }
 
 /* Light mode table styling */
-[data-theme='light'] table th {
+[data-theme="light"] table th {
   background-color: rgba(139, 101, 8, 0.06);
   border-color: rgba(139, 101, 8, 0.15);
 }
 
-[data-theme='light'] table td {
-  border-color: rgba(139, 101, 8, 0.10);
+[data-theme="light"] table td {
+  border-color: rgba(139, 101, 8, 0.1);
 }
 
 /* Footer */
@@ -198,37 +209,37 @@ pre.prism-code.language-ascii code {
   transition: color 0.2s;
 }
 
-[data-theme='dark'] .footer a:hover {
-  color: #FFD700;
+[data-theme="dark"] .footer a:hover {
+  color: #ffd700;
   text-decoration: none;
 }
 
-[data-theme='light'] .footer a:hover {
-  color: #7A5800;
+[data-theme="light"] .footer a:hover {
+  color: #7a5800;
   text-decoration: none;
 }
 
 /* Scrollbar */
-[data-theme='dark'] ::-webkit-scrollbar {
+[data-theme="dark"] ::-webkit-scrollbar {
   width: 8px;
   height: 8px;
 }
 
-[data-theme='dark'] ::-webkit-scrollbar-track {
+[data-theme="dark"] ::-webkit-scrollbar-track {
   background: #07070d;
 }
 
-[data-theme='dark'] ::-webkit-scrollbar-thumb {
+[data-theme="dark"] ::-webkit-scrollbar-thumb {
   background: #1a1a30;
   border-radius: 4px;
 }
 
-[data-theme='dark'] ::-webkit-scrollbar-thumb:hover {
+[data-theme="dark"] ::-webkit-scrollbar-thumb:hover {
   background: #2a2a40;
 }
 
 /* Search bar */
-[data-theme='dark'] .DocSearch-Button {
+[data-theme="dark"] .DocSearch-Button {
   background-color: #0f0f18;
   border: 1px solid rgba(255, 215, 0, 0.08);
 }
@@ -277,4 +288,509 @@ pre.prism-code.language-ascii code {
 .hero--hermes {
   background: linear-gradient(135deg, #07070d 0%, #0f0f18 100%);
   padding: 4rem 0;
+}
+
+/* Liquid Glass docs redesign */
+:root {
+  --liquid-glass-primary: #8b6508;
+  --liquid-glass-accent: #0053fd;
+  --liquid-glass-warm: #cf806d;
+  --liquid-glass-surface: rgba(255, 255, 255, 0.76);
+  --liquid-glass-surface-strong: rgba(255, 255, 255, 0.9);
+  --liquid-glass-border: rgba(139, 101, 8, 0.16);
+  --liquid-glass-glow: rgba(255, 215, 0, 0.18);
+}
+
+[data-theme="dark"] {
+  --liquid-glass-primary: #ffe6cb;
+  --liquid-glass-accent: #00d4ff;
+  --liquid-glass-warm: #ffac02;
+  --liquid-glass-surface: rgba(255, 230, 203, 0.075);
+  --liquid-glass-surface-strong: rgba(13, 16, 28, 0.9);
+  --liquid-glass-border: rgba(255, 230, 203, 0.16);
+  --liquid-glass-glow: rgba(0, 212, 255, 0.22);
+  --ifm-color-primary: var(--liquid-glass-primary);
+  --ifm-color-primary-dark: #e8c7a3;
+  --ifm-color-primary-darker: #d6ad78;
+  --ifm-color-primary-darkest: #c4914d;
+  --ifm-color-primary-light: #fff0dd;
+  --ifm-color-primary-lighter: #fff7ef;
+  --ifm-color-primary-lightest: #fffaf6;
+  --ifm-background-color: #070914;
+  --ifm-background-surface-color: rgba(7, 9, 20, 0.84);
+  --ifm-navbar-background-color: rgba(7, 9, 20, 0.78);
+  --ifm-footer-background-color: rgba(5, 7, 13, 0.88);
+  --ifm-color-emphasis-100: rgba(255, 230, 203, 0.08);
+  --ifm-color-emphasis-200: rgba(255, 230, 203, 0.13);
+  --ifm-font-color-base: #ffe6cb;
+  --ifm-font-color-secondary: #c9b7a3;
+  --ifm-link-color: #ffe6cb;
+  --ifm-link-hover-color: #00d4ff;
+  --ifm-code-background: rgba(255, 230, 203, 0.08);
+  --ifm-toc-border-color: rgba(255, 230, 203, 0.1);
+  --ifm-hr-border-color: rgba(255, 230, 203, 0.1);
+  --docusaurus-highlighted-code-line-bg: rgba(0, 212, 255, 0.12);
+}
+
+[data-theme="light"] {
+  --ifm-color-primary: var(--liquid-glass-accent);
+  --ifm-color-primary-dark: #003ea8;
+  --ifm-color-primary-darker: #003180;
+  --ifm-color-primary-darkest: #00245a;
+  --ifm-color-primary-light: #1d69ff;
+  --ifm-color-primary-lighter: #3a7cff;
+  --ifm-color-primary-lightest: #5792ff;
+  --ifm-background-color: #f7f2ea;
+  --ifm-background-surface-color: rgba(255, 255, 255, 0.78);
+  --ifm-navbar-background-color: rgba(255, 255, 255, 0.78);
+  --ifm-footer-background-color: rgba(247, 242, 234, 0.9);
+  --ifm-color-emphasis-100: rgba(0, 83, 253, 0.07);
+  --ifm-color-emphasis-200: rgba(0, 83, 253, 0.12);
+  --ifm-font-color-base: #111827;
+  --ifm-font-color-secondary: #5b6475;
+  --ifm-link-color: #0053fd;
+  --ifm-link-hover-color: #ffac02;
+  --ifm-code-background: rgba(0, 83, 253, 0.06);
+  --ifm-toc-border-color: rgba(0, 83, 253, 0.12);
+  --ifm-hr-border-color: rgba(0, 83, 253, 0.1);
+  --docusaurus-highlighted-code-line-bg: rgba(255, 172, 2, 0.12);
+}
+
+body::before {
+  content: "";
+  position: fixed;
+  inset: 0;
+  z-index: -1;
+  pointer-events: none;
+  background:
+    radial-gradient(
+      circle at 12% -10%,
+      var(--liquid-glass-glow),
+      transparent 30rem
+    ),
+    radial-gradient(
+      circle at 88% 4%,
+      rgba(255, 172, 2, 0.14),
+      transparent 28rem
+    ),
+    radial-gradient(
+      circle at 52% 118%,
+      rgba(255, 255, 255, 0.1),
+      transparent 34rem
+    );
+}
+
+[data-theme="dark"] body::before {
+  background:
+    radial-gradient(
+      circle at 12% -10%,
+      rgba(0, 212, 255, 0.24),
+      transparent 30rem
+    ),
+    radial-gradient(
+      circle at 88% 4%,
+      rgba(255, 172, 2, 0.16),
+      transparent 28rem
+    ),
+    radial-gradient(
+      circle at 52% 118%,
+      rgba(255, 230, 203, 0.08),
+      transparent 34rem
+    );
+}
+
+[data-theme="light"] body::before {
+  background:
+    radial-gradient(
+      circle at 12% -10%,
+      rgba(0, 83, 253, 0.18),
+      transparent 30rem
+    ),
+    radial-gradient(
+      circle at 88% 4%,
+      rgba(255, 172, 2, 0.2),
+      transparent 28rem
+    ),
+    radial-gradient(
+      circle at 52% 118%,
+      rgba(255, 255, 255, 0.7),
+      transparent 34rem
+    );
+}
+
+body,
+.main-wrapper {
+  background: linear-gradient(
+    135deg,
+    var(--ifm-background-color),
+    color-mix(in srgb, var(--ifm-color-primary) 8%, var(--ifm-background-color))
+  );
+}
+
+.navbar {
+  border-bottom: 1px solid var(--liquid-glass-border);
+  background: color-mix(
+    in srgb,
+    var(--ifm-navbar-background-color) 92%,
+    transparent
+  ) !important;
+  box-shadow: 0 1rem 2.5rem rgba(0, 0, 0, 0.12);
+  backdrop-filter: blur(1.25rem) saturate(1.15);
+  -webkit-backdrop-filter: blur(1.25rem) saturate(1.15);
+}
+
+[data-theme="light"] .navbar {
+  box-shadow: 0 1rem 2.5rem rgba(17, 24, 39, 0.08);
+}
+
+.menu,
+.table-of-contents,
+.theme-doc-sidebar-container,
+.pagination-nav,
+.markdown > h1,
+.markdown > h2,
+.markdown > h3,
+.markdown > h4,
+.markdown > h5,
+.markdown > h6,
+.alert,
+.card,
+article,
+.table-of-contents__left-border,
+.table-of-contents__right-border {
+  border-color: var(--liquid-glass-border) !important;
+}
+
+.menu,
+.table-of-contents,
+.theme-doc-sidebar-container,
+.pagination-nav,
+.alert,
+.card,
+article,
+table,
+code {
+  background: color-mix(
+    in srgb,
+    var(--liquid-glass-surface) 92%,
+    transparent
+  ) !important;
+  backdrop-filter: blur(1rem);
+  -webkit-backdrop-filter: blur(1rem);
+}
+
+.menu__link--active:not(.menu__link--sublist) {
+  border-color: var(--liquid-glass-primary) !important;
+  background: color-mix(
+    in srgb,
+    var(--liquid-glass-primary) 12%,
+    transparent
+  ) !important;
+}
+
+.menu__link:hover,
+.table-of-contents__link:hover,
+.pagination-nav__link:hover {
+  background: color-mix(
+    in srgb,
+    var(--liquid-glass-primary) 8%,
+    transparent
+  ) !important;
+}
+
+.pagination-nav__link,
+.table-of-contents,
+.menu {
+  border-radius: var(--ifm-global-radius) !important;
+  box-shadow:
+    inset 0 0.0625rem 0 rgba(255, 255, 255, 0.08),
+    0 1rem 2rem rgba(0, 0, 0, 0.08);
+}
+
+.markdown {
+  border-radius: var(--ifm-global-radius);
+}
+
+.markdown > h1,
+.markdown > h2,
+.markdown > h3,
+.markdown > h4,
+.markdown > h5,
+.markdown > h6 {
+  letter-spacing: -0.03em;
+}
+
+.markdown a {
+  text-decoration-thickness: 0.08em;
+  text-underline-offset: 0.2em;
+}
+
+.prism-code,
+.theme-code-block {
+  border: 1px solid var(--liquid-glass-border) !important;
+  border-radius: var(--ifm-global-radius) !important;
+  box-shadow:
+    inset 0 0.0625rem 0 rgba(255, 255, 255, 0.06),
+    0 1rem 2rem rgba(0, 0, 0, 0.1);
+}
+
+[data-theme="dark"] .prism-code {
+  background-color: rgba(10, 10, 18, 0.9) !important;
+}
+
+.alert {
+  border-radius: var(--ifm-alert-border-radius);
+  box-shadow: inset 0 0.0625rem 0 rgba(255, 255, 255, 0.06);
+}
+
+[data-theme="dark"] .alert--info {
+  --ifm-alert-background-color: rgba(0, 212, 255, 0.08);
+  --ifm-alert-border-color: rgba(0, 212, 255, 0.2);
+}
+
+[data-theme="dark"] table th,
+[data-theme="dark"] table td,
+[data-theme="light"] table th,
+[data-theme="light"] table td {
+  border-color: var(--liquid-glass-border) !important;
+}
+
+[data-theme="dark"] table th,
+[data-theme="light"] table th {
+  background-color: color-mix(
+    in srgb,
+    var(--liquid-glass-primary) 8%,
+    transparent
+  ) !important;
+}
+
+.DocSearch-Button {
+  border: 1px solid var(--liquid-glass-border) !important;
+  background: color-mix(
+    in srgb,
+    var(--liquid-glass-surface) 92%,
+    transparent
+  ) !important;
+  box-shadow: inset 0 0.0625rem 0 rgba(255, 255, 255, 0.08);
+}
+
+.DocSearch-Button:hover {
+  box-shadow:
+    0 0 0 0.1875rem
+      color-mix(in srgb, var(--liquid-glass-primary) 14%, transparent),
+    inset 0 0.0625rem 0 rgba(255, 255, 255, 0.08);
+}
+
+.footer {
+  border-color: var(--liquid-glass-border) !important;
+  background: var(--ifm-footer-background-color) !important;
+}
+
+.hero--hermes {
+  position: relative;
+  overflow: hidden;
+  padding: 5rem 0 4rem;
+  border-bottom: 1px solid var(--liquid-glass-border);
+  background:
+    radial-gradient(
+      circle at 18% 0%,
+      var(--liquid-glass-glow),
+      transparent 30rem
+    ),
+    radial-gradient(
+      circle at 82% 8%,
+      rgba(255, 172, 2, 0.14),
+      transparent 26rem
+    ),
+    linear-gradient(
+      135deg,
+      var(--ifm-background-color),
+      color-mix(
+        in srgb,
+        var(--liquid-glass-primary) 10%,
+        var(--ifm-background-color)
+      )
+    );
+}
+
+.hero--hermes::before,
+.hero--hermes::after {
+  content: "";
+  position: absolute;
+  border-radius: 999px;
+  pointer-events: none;
+  filter: blur(4px);
+}
+
+.hero--hermes::before {
+  inset: 12% auto auto 8%;
+  width: 18rem;
+  height: 18rem;
+  background: var(--liquid-glass-glow);
+}
+
+.hero--hermes::after {
+  inset: 18% 10% auto auto;
+  width: 14rem;
+  height: 14rem;
+  background: rgba(255, 172, 2, 0.14);
+}
+
+.hero--hermes > * {
+  position: relative;
+  z-index: 1;
+}
+
+.hero-eyebrow {
+  display: inline-flex;
+  width: max-content;
+  max-width: 100%;
+  margin-bottom: 1rem;
+  padding: 0.45rem 0.8rem;
+  border: 1px solid var(--liquid-glass-border);
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--liquid-glass-surface) 82%, transparent);
+  color: var(--liquid-glass-primary);
+  font-size: 0.8rem;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  box-shadow: inset 0 0.0625rem 0 rgba(255, 255, 255, 0.08);
+  backdrop-filter: blur(1rem);
+  -webkit-backdrop-filter: blur(1rem);
+}
+
+.hero--hermes h1 {
+  font-size: clamp(3rem, 8vw, 6.5rem);
+  line-height: 0.92;
+  letter-spacing: -0.07em;
+  margin-bottom: 1.25rem;
+  background: linear-gradient(
+    135deg,
+    var(--liquid-glass-primary),
+    var(--liquid-glass-accent)
+  );
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+}
+
+.hero-lead {
+  max-width: 62rem;
+  color: var(--ifm-font-color-secondary) !important;
+  font-size: clamp(1.1rem, 2vw, 1.35rem);
+  line-height: 1.7;
+  margin-bottom: 2rem;
+}
+
+.hero-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.85rem;
+  margin-bottom: 2rem;
+}
+
+.hero-actions .button {
+  border-radius: 999px;
+  border-color: var(--liquid-glass-border) !important;
+  box-shadow:
+    inset 0 0.0625rem 0 rgba(255, 255, 255, 0.08),
+    0 1rem 2rem rgba(0, 0, 0, 0.12);
+  backdrop-filter: blur(1rem);
+  -webkit-backdrop-filter: blur(1rem);
+}
+
+.hero-actions .button--primary {
+  background: linear-gradient(
+    135deg,
+    var(--liquid-glass-primary),
+    var(--liquid-glass-warm)
+  ) !important;
+  color: #070914 !important;
+  border-color: transparent !important;
+}
+
+[data-theme="light"] .hero-actions .button--primary {
+  background: linear-gradient(
+    135deg,
+    var(--liquid-glass-accent),
+    #1d69ff
+  ) !important;
+  color: #ffffff !important;
+}
+
+.hero-stats {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 1rem;
+  max-width: 62rem;
+  margin-top: 1.5rem;
+}
+
+.hero-stat {
+  padding: 1rem;
+  border: 1px solid var(--liquid-glass-border);
+  border-radius: var(--ifm-global-radius);
+  background: color-mix(in srgb, var(--liquid-glass-surface) 86%, transparent);
+  box-shadow: inset 0 0.0625rem 0 rgba(255, 255, 255, 0.08);
+  backdrop-filter: blur(1rem);
+  -webkit-backdrop-filter: blur(1rem);
+}
+
+.hero-stat strong {
+  display: block;
+  font-size: 1.35rem;
+  color: var(--liquid-glass-primary);
+  letter-spacing: -0.03em;
+}
+
+.hero-stat span {
+  color: var(--ifm-font-color-secondary);
+  font-size: 0.9rem;
+}
+
+.quick-link-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 1rem;
+  margin: 2rem 0;
+}
+
+.quick-link-grid a {
+  display: block;
+  padding: 1rem;
+  border: 1px solid var(--liquid-glass-border);
+  border-radius: var(--ifm-global-radius);
+  background: color-mix(in srgb, var(--liquid-glass-surface) 84%, transparent);
+  color: var(--ifm-font-color-base) !important;
+  box-shadow: inset 0 0.0625rem 0 rgba(255, 255, 255, 0.06);
+  transition:
+    transform 0.18s ease,
+    border-color 0.18s ease,
+    background 0.18s ease;
+}
+
+.quick-link-grid a:hover {
+  transform: translateY(-2px);
+  border-color: var(--liquid-glass-primary);
+  background: color-mix(in srgb, var(--liquid-glass-primary) 10%, transparent);
+}
+
+@media (max-width: 768px) {
+  .hero-stats,
+  .quick-link-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .hero-actions {
+    flex-direction: column;
+    align-items: stretch;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .quick-link-grid a,
+  .hero-actions .button {
+    transition: none !important;
+  }
 }

--- a/website/src/types/site-data.d.ts
+++ b/website/src/types/site-data.d.ts
@@ -1,0 +1,4 @@
+declare module "@site/src/data/userStories.json" {
+  const stories: unknown[];
+  export default stories;
+}

--- a/website/tsconfig.json
+++ b/website/tsconfig.json
@@ -1,5 +1,7 @@
 {
-  // This file is not used in compilation. It is here just for a nice editor experience.
   "extends": "@docusaurus/tsconfig",
+  "compilerOptions": {
+    "ignoreDeprecations": "6.0"
+  },
   "exclude": [".docusaurus", "build"]
 }


### PR DESCRIPTION
## Summary
Implemented a premium dark/light "Liquid Glass" design system across the web dashboard, desktop app, and docs site.

## Scope
- Web dashboard theme tokens and global Liquid Glass surfaces
- Desktop app theme tokens and global Liquid Glass surfaces
- Website/docs landing redesign with hero, quick links, and stats cards
- Synced dashboard theme metadata from the backend
- Small validation fixes needed for the redesigned docs site

## Validation
Passed:
- `npm --workspace web run typecheck`
- `npm --workspace apps/desktop run typecheck`
- `npm run typecheck` in `website/`
- `npm --workspace web run build`
- `npm --workspace apps/desktop run build`
- `npm run build` in `website/`
- `git diff --check`
- Prettier check on touched CSS/MDX/TS files

Notes:
- Full repo lint currently fails on existing repo-wide issues unrelated to this redesign.
- Website build passes but reports existing broken docs links/anchors unrelated to this redesign.
- `website lint:diagrams` could not run because `ascii-guard` is not installed.