### PR TITLE
fix(run_agent): stamp session lineage in JSON snapshots

### DIFF
--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -525,6 +525,8 @@ def compress_context(
             agent._session_db.end_session(agent.session_id, "compression")
             old_session_id = agent.session_id
             agent.session_id = f"{datetime.now().strftime('%Y%m%d_%H%M%S')}_{uuid.uuid4().hex[:6]}"
+            agent._session_type = "compression_split"
+            agent._parent_session_id = old_session_id
             # Ordering contract: the agent thread updates the contextvar here;
             # the gateway propagates to SessionEntry after run_in_executor returns.
             try:

--- a/run_agent.py
+++ b/run_agent.py
@@ -1927,6 +1927,26 @@ class AIAgent:
             return "***"
         return f"{key[:8]}...{key[-4:]}"
 
+    def _classify_session_type(self) -> str:
+        """Return a stable label for session JSON snapshots."""
+        explicit = getattr(self, "_session_type", None)
+        if isinstance(explicit, str) and explicit.strip():
+            return explicit
+
+        if (
+            getattr(self, "_memory_write_origin", None) == "background_review"
+            or getattr(self, "_memory_write_context", None) == "background_review"
+        ):
+            return "review_agent"
+
+        if getattr(self, "_subagent_id", None) or int(getattr(self, "_delegate_depth", 0) or 0) > 0:
+            return "subagent"
+
+        if getattr(self, "platform", None) == "cron":
+            return "cron"
+
+        return "user"
+
     def _clean_error_message(self, error_msg: str) -> str:
         """
         Clean up error messages for user display, removing HTML content and truncating.
@@ -2337,6 +2357,8 @@ class AIAgent:
 
             entry = {
                 "session_id": self.session_id,
+                "session_type": self._classify_session_type(),
+                "parent_session_id": getattr(self, "_parent_session_id", None) or None,
                 "model": self.model,
                 "base_url": self.base_url,
                 "platform": self.platform,

--- a/tests/agent/test_compression_logging_session_context.py
+++ b/tests/agent/test_compression_logging_session_context.py
@@ -68,6 +68,8 @@ def test_logging_session_context_follows_compression_rotation(tmp_path: Path) ->
 
         # The id actually rotated (sanity — otherwise the assertion is vacuous).
         assert agent.session_id != parent_sid
+        assert agent._session_type == "compression_split"
+        assert agent._parent_session_id == parent_sid
 
         # The logging context must now match the NEW id, not the stale one.
         current = getattr(hermes_logging._session_context, "session_id", None)

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -629,6 +629,51 @@ class TestSessionJsonSnapshotOptIn:
         assert hasattr(agent, "logs_dir")
 
 
+class TestSaveSessionLogTypeMetadata:
+    def _write_snapshot(self, agent, tmp_path, messages=None):
+        agent._session_json_enabled = True
+        agent.logs_dir = tmp_path
+        agent._save_session_log(messages or [{"role": "user", "content": "hello"}])
+        return json.loads((tmp_path / f"session_{agent.session_id}.json").read_text(encoding="utf-8"))
+
+    def test_defaults_to_user_and_null_parent(self, agent, tmp_path):
+        snapshot = self._write_snapshot(agent, tmp_path)
+        assert snapshot["session_type"] == "user"
+        assert snapshot["parent_session_id"] is None
+
+    def test_uses_cron_platform_when_not_otherwise_classified(self, agent, tmp_path):
+        agent.platform = "cron"
+        snapshot = self._write_snapshot(agent, tmp_path)
+        assert snapshot["session_type"] == "cron"
+
+    def test_marks_background_review_from_write_origin(self, agent, tmp_path):
+        agent._memory_write_origin = "background_review"
+        agent._parent_session_id = "parent-123"
+        snapshot = self._write_snapshot(agent, tmp_path)
+        assert snapshot["session_type"] == "review_agent"
+        assert snapshot["parent_session_id"] == "parent-123"
+
+    def test_marks_subagent_from_id(self, agent, tmp_path):
+        agent._subagent_id = "subagent-7"
+        agent._parent_session_id = "parent-123"
+        snapshot = self._write_snapshot(agent, tmp_path)
+        assert snapshot["session_type"] == "subagent"
+        assert snapshot["parent_session_id"] == "parent-123"
+
+    def test_review_agent_wins_over_delegate_depth(self, agent, tmp_path):
+        agent._memory_write_context = "background_review"
+        agent._delegate_depth = 2
+        snapshot = self._write_snapshot(agent, tmp_path)
+        assert snapshot["session_type"] == "review_agent"
+
+    def test_explicit_override_marks_compression_split(self, agent, tmp_path):
+        agent._session_type = "compression_split"
+        agent._parent_session_id = "sid-before-compress"
+        snapshot = self._write_snapshot(agent, tmp_path)
+        assert snapshot["session_type"] == "compression_split"
+        assert snapshot["parent_session_id"] == "sid-before-compress"
+
+
 class TestSaveSessionLogRedactsSecrets:
     """Regression: session_*.json must not contain plaintext credentials (#19798, #19845)."""
 


### PR DESCRIPTION
## Summary
- add `session_type` and `parent_session_id` to `session_{sid}.json` snapshots written by `_save_session_log()`
- classify snapshots as `user`, `cron`, `review_agent`, `subagent`, or `compression_split` from existing runtime signals
- persist compression continuation lineage on the live agent so post-rotation snapshots point back to the pre-compression session

## Testing
- `pytest tests/run_agent/test_run_agent.py -q -k 'SessionJsonSnapshotOptIn or SaveSessionLogTypeMetadata'`\n- `pytest tests/agent/test_compression_logging_session_context.py -q`\n- `ruff check run_agent.py agent/conversation_compression.py tests/run_agent/test_run_agent.py tests/agent/test_compression_logging_session_context.py`\n- `python3 -m py_compile run_agent.py agent/conversation_compression.py tests/run_agent/test_run_agent.py tests/agent/test_compression_logging_session_context.py`\n- `git diff --check`\n\nFixes #26952.