### PR TITLE
feat(desktop): roomy live process-output modal for running background jobs

### DIFF
--- a/apps/desktop/src/app/chat/composer/status-stack/index.tsx
+++ b/apps/desktop/src/app/chat/composer/status-stack/index.tsx
@@ -1,5 +1,5 @@
 import { useStore } from '@nanostores/react'
-import { type ReactNode, useEffect, useLayoutEffect, useMemo, useRef } from 'react'
+import { type ReactNode, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 
 import { blurComposerInput } from '@/app/chat/composer/focus'
@@ -19,9 +19,11 @@ import {
   type StatusGroup,
   stopBackgroundProcess
 } from '@/store/composer-status'
+import { $workingSessionIds } from '@/store/session'
 import { $threadScrolledUp } from '@/store/thread-scroll'
 import { openSessionInNewWindow } from '@/store/windows'
 
+import { ProcessOutputModal } from './process-output-modal'
 import { StatusItemRow } from './status-row'
 
 // Slow safety-net poll for silent exits (processes without notify_on_complete
@@ -53,6 +55,17 @@ export function ComposerStatusStack({ queue, sessionId }: ComposerStatusStackPro
   const navigate = useNavigate()
   const itemsBySession = useStore($statusItemsBySession)
   const scrolledUp = useStore($threadScrolledUp)
+  const workingSessionIds = useStore($workingSessionIds)
+
+  // Whether THIS session's turn is actively running. A todo marked
+  // `in_progress` only deserves a live spinner while the agent is working — if
+  // the turn ends (or the agent stops to ask the user something) mid-plan, the
+  // spinner must settle instead of grinding forever (the "task pane hangs at
+  // the end" report). Off-session / no-session → not working.
+  const sessionWorking = !!sessionId && workingSessionIds.includes(sessionId)
+
+  // Which background task's roomy live-output modal is open (by id), if any.
+  const [outputModalId, setOutputModalId] = useState<null | string>(null)
 
   const groups = useMemo(
     () => groupStatusItems(sessionId ? (itemsBySession[sessionId] ?? []) : []),
@@ -115,7 +128,9 @@ export function ComposerStatusStack({ queue, sessionId }: ComposerStatusStackPro
             key={item.id}
             onDismiss={sessionId ? id => dismissBackgroundProcess(sessionId, id) : undefined}
             onOpen={() => openSubagent(item)}
+            onOpenOutput={setOutputModalId}
             onStop={sessionId ? id => stopBackgroundProcess(sessionId, id) : undefined}
+            sessionWorking={sessionWorking}
           />
         ))}
       </StatusSection>
@@ -165,11 +180,17 @@ export function ComposerStatusStack({ queue, sessionId }: ComposerStatusStackPro
   }, [visible])
 
   if (!visible) {
-    return null
+    return outputModalId ? (
+      <ProcessOutputModal itemId={outputModalId} onClose={() => setOutputModalId(null)} />
+    ) : null
   }
 
   return (
-    <div
+    <>
+      {outputModalId && (
+        <ProcessOutputModal itemId={outputModalId} onClose={() => setOutputModalId(null)} />
+      )}
+      <div
       // Sits above the composer (bottom-full), nudged down by the shell's 0.5rem
       // top pad (pt-2 on composer-root) plus 1px so its bottom edge overlaps the
       // composer surface's top border. z BELOW the surface (z-4) so the surface's
@@ -198,5 +219,6 @@ export function ComposerStatusStack({ queue, sessionId }: ComposerStatusStackPro
         </div>
       </div>
     </div>
+    </>
   )
 }

--- a/apps/desktop/src/app/chat/composer/status-stack/process-output-modal.test.tsx
+++ b/apps/desktop/src/app/chat/composer/status-stack/process-output-modal.test.tsx
@@ -85,4 +85,20 @@ describe('ProcessOutputModal', () => {
     expect(container.querySelector('[data-slot]')).toBeNull()
     expect(screen.queryByText('npm run build')).toBeNull()
   })
+
+  it('portals the overlay to document.body so fixed-positioning escapes the composer containing block', () => {
+    seed([bg({ output: 'building…\n' })])
+    const { container } = renderModal('bg-1')
+
+    // The overlay content must NOT live inside the in-place render container
+    // (which sits in the composer subtree, trapped by backdrop-filter +
+    // contain:paint). It is portaled to body, so the title resolves via the
+    // document but is absent from `container`.
+    expect(container.textContent).not.toContain('npm run build')
+    expect(screen.getByText('npm run build')).toBeTruthy()
+    // The fixed full-screen scrim is a direct child of body, not of container.
+    const scrim = document.body.querySelector('.fixed.inset-0')
+    expect(scrim).toBeTruthy()
+    expect(container.contains(scrim)).toBe(false)
+  })
 })

--- a/apps/desktop/src/app/chat/composer/status-stack/process-output-modal.test.tsx
+++ b/apps/desktop/src/app/chat/composer/status-stack/process-output-modal.test.tsx
@@ -1,0 +1,82 @@
+import { act, cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+
+import { I18nProvider } from '@/i18n'
+import { $backgroundStatusBySession, type ComposerStatusItem } from '@/store/composer-status'
+import { $activeSessionId } from '@/store/session'
+
+import { ProcessOutputModal } from './process-output-modal'
+
+const SID = 'sess-1'
+
+function seed(items: ComposerStatusItem[]) {
+  $activeSessionId.set(SID)
+  $backgroundStatusBySession.set({ [SID]: items })
+}
+
+function bg(overrides: Partial<ComposerStatusItem> = {}): ComposerStatusItem {
+  return {
+    id: 'bg-1',
+    type: 'background',
+    title: 'npm run build',
+    state: 'running',
+    ...overrides
+  } as ComposerStatusItem
+}
+
+function renderModal(itemId: string, onClose = () => {}) {
+  return render(
+    <I18nProvider configClient={null}>
+      <ProcessOutputModal itemId={itemId} onClose={onClose} />
+    </I18nProvider>
+  )
+}
+
+afterEach(() => {
+  cleanup()
+  $backgroundStatusBySession.set({})
+  $activeSessionId.set(null)
+})
+
+describe('ProcessOutputModal', () => {
+  beforeEach(() => seed([bg({ output: 'building...\nstep 2\n' })]))
+
+  it('renders the task title and its live output', () => {
+    renderModal('bg-1')
+    expect(screen.getByText('npm run build')).toBeTruthy()
+    expect(screen.getByText(/building/)).toBeTruthy()
+  })
+
+  it('shows the waiting placeholder when a running task has no output yet', () => {
+    seed([bg({ output: undefined })])
+    renderModal('bg-1')
+    expect(screen.getByText('Waiting for output…')).toBeTruthy()
+  })
+
+  it('reflects live store updates (output_tail poll) without remount', () => {
+    const { container } = renderModal('bg-1')
+    expect(container.textContent).not.toContain('done in 4s')
+
+    // Simulate a process.list poll appending output + finishing the task.
+    act(() => {
+      $backgroundStatusBySession.set({
+        [SID]: [bg({ output: 'building...\nstep 2\ndone in 4s\n', state: 'done', exitCode: 0 })]
+      })
+    })
+
+    expect(container.textContent).toContain('done in 4s')
+  })
+
+  it('renders nothing when the task id is no longer in the registry', () => {
+    const { container } = renderModal('does-not-exist')
+    expect(container.textContent).toBe('')
+  })
+
+  it('calls onClose from the close control', () => {
+    let closed = false
+    renderModal('bg-1', () => (closed = true))
+    // OverlayView renders a labeled close button.
+    fireEvent.click(screen.getByLabelText('Close'))
+    expect(closed).toBe(true)
+  })
+})

--- a/apps/desktop/src/app/chat/composer/status-stack/process-output-modal.test.tsx
+++ b/apps/desktop/src/app/chat/composer/status-stack/process-output-modal.test.tsx
@@ -1,5 +1,5 @@
-import { act, cleanup, fireEvent, render, screen } from '@testing-library/react'
-import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { cleanup, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it } from 'vitest'
 
 import { I18nProvider } from '@/i18n'
 import { $backgroundStatusBySession, type ComposerStatusItem } from '@/store/composer-status'
@@ -35,48 +35,54 @@ function renderModal(itemId: string, onClose = () => {}) {
 afterEach(() => {
   cleanup()
   $backgroundStatusBySession.set({})
-  $activeSessionId.set(null)
 })
 
 describe('ProcessOutputModal', () => {
-  beforeEach(() => seed([bg({ output: 'building...\nstep 2\n' })]))
-
-  it('renders the task title and its live output', () => {
+  it('renders the running task title and its live output', () => {
+    seed([bg({ output: 'building…\nstep 2\n' })])
     renderModal('bg-1')
+
     expect(screen.getByText('npm run build')).toBeTruthy()
-    expect(screen.getByText(/building/)).toBeTruthy()
+    expect(screen.getByText(/building…/)).toBeTruthy()
   })
 
-  it('shows the waiting placeholder when a running task has no output yet', () => {
-    seed([bg({ output: undefined })])
+  it('shows the waiting placeholder for a running task with no output yet', () => {
+    seed([bg({ output: undefined, state: 'running' })])
     renderModal('bg-1')
+
     expect(screen.getByText('Waiting for output…')).toBeTruthy()
   })
 
-  it('reflects live store updates (output_tail poll) without remount', () => {
-    const { container } = renderModal('bg-1')
-    expect(container.textContent).not.toContain('done in 4s')
+  it('shows the no-output placeholder for a finished task that captured nothing', () => {
+    seed([bg({ output: undefined, state: 'done' })])
+    renderModal('bg-1')
 
-    // Simulate a process.list poll appending output + finishing the task.
-    act(() => {
-      $backgroundStatusBySession.set({
-        [SID]: [bg({ output: 'building...\nstep 2\ndone in 4s\n', state: 'done', exitCode: 0 })]
-      })
-    })
+    expect(screen.getByText('No output captured.')).toBeTruthy()
+  })
 
-    expect(container.textContent).toContain('done in 4s')
+  it('reflects the latest store snapshot (stays live via id lookup, not a snapshot)', () => {
+    seed([bg({ output: 'first\n' })])
+    const { rerender } = renderModal('bg-1')
+
+    expect(screen.getByText(/first/)).toBeTruthy()
+
+    // Simulate the 5s process.list poll updating the task's output_tail.
+    $backgroundStatusBySession.set({ [SID]: [bg({ output: 'first\nsecond\n' })] })
+    rerender(
+      <I18nProvider configClient={null}>
+        <ProcessOutputModal itemId="bg-1" onClose={() => {}} />
+      </I18nProvider>
+    )
+
+    expect(screen.getByText(/second/)).toBeTruthy()
   })
 
   it('renders nothing when the task id is no longer in the registry', () => {
-    const { container } = renderModal('does-not-exist')
-    expect(container.textContent).toBe('')
-  })
+    seed([bg({ id: 'bg-1' })])
+    const { container } = renderModal('bg-GONE')
 
-  it('calls onClose from the close control', () => {
-    let closed = false
-    renderModal('bg-1', () => (closed = true))
-    // OverlayView renders a labeled close button.
-    fireEvent.click(screen.getByLabelText('Close'))
-    expect(closed).toBe(true)
+    // No task → null render (the overlay is not mounted).
+    expect(container.querySelector('[data-slot]')).toBeNull()
+    expect(screen.queryByText('npm run build')).toBeNull()
   })
 })

--- a/apps/desktop/src/app/chat/composer/status-stack/process-output-modal.tsx
+++ b/apps/desktop/src/app/chat/composer/status-stack/process-output-modal.tsx
@@ -41,6 +41,7 @@ export function ProcessOutputModal({ itemId, onClose }: { itemId: string; onClos
       closeLabel={t.common?.close ?? 'Close'}
       contentClassName="flex min-h-0 flex-1 flex-col px-4 pt-4 pb-3 sm:px-5"
       onClose={onClose}
+      portal
       rootClassName="mx-auto flex h-[80vh] max-h-[80vh] w-full max-w-3xl flex-col"
     >
       <header className="mb-2 flex shrink-0 items-center gap-2">

--- a/apps/desktop/src/app/chat/composer/status-stack/process-output-modal.tsx
+++ b/apps/desktop/src/app/chat/composer/status-stack/process-output-modal.tsx
@@ -1,0 +1,82 @@
+import { useStore } from '@nanostores/react'
+import { useMemo } from 'react'
+
+import { TerminalOutput } from '@/components/chat/terminal-output'
+import { Codicon } from '@/components/ui/codicon'
+import { useI18n } from '@/i18n'
+import { cn } from '@/lib/utils'
+import { $backgroundStatusBySession, type ComposerStatusItem } from '@/store/composer-status'
+import { $activeSessionId } from '@/store/session'
+
+import { OverlayView } from '../../../overlays/overlay-view'
+
+/**
+ * Roomy, live-tailing viewer for a single background task's output — opened by
+ * clicking a *running* job row in the status stack. Unlike the cramped inline
+ * disclosure, this gives a full-height terminal view, and stays live because it
+ * re-reads the task from the store (refreshed every 5s by the process.list
+ * poll) by id rather than capturing a snapshot.
+ */
+export function ProcessOutputModal({ itemId, onClose }: { itemId: string; onClose: () => void }) {
+  const { t } = useI18n()
+  const s = t.statusStack
+  const sessionId = useStore($activeSessionId) ?? ''
+  const bySession = useStore($backgroundStatusBySession)
+
+  const item: ComposerStatusItem | undefined = useMemo(
+    () => (bySession[sessionId] ?? []).find(row => row.id === itemId),
+    [bySession, sessionId, itemId]
+  )
+
+  // The task vanished from the registry (dismissed / reaped) — close out.
+  if (!item) {
+    return null
+  }
+
+  const running = item.state === 'running'
+  const failed = item.state === 'failed'
+
+  return (
+    <OverlayView
+      closeLabel={t.common?.close ?? 'Close'}
+      contentClassName="flex min-h-0 flex-1 flex-col px-4 pt-4 pb-3 sm:px-5"
+      onClose={onClose}
+      rootClassName="mx-auto flex h-[80vh] max-h-[80vh] w-full max-w-3xl flex-col"
+    >
+      <header className="mb-2 flex shrink-0 items-center gap-2">
+        <Codicon
+          className={cn(
+            'shrink-0',
+            running ? 'text-emerald-500' : failed ? 'text-destructive' : 'text-muted-foreground/70'
+          )}
+          name={running ? 'pulse' : failed ? 'error' : 'check'}
+          size="0.95rem"
+          spinning={running}
+        />
+        <span className="min-w-0 flex-1 truncate font-mono text-[0.8rem] text-foreground" title={item.title}>
+          {item.title}
+        </span>
+        {typeof item.exitCode === 'number' && (
+          <span
+            className={cn(
+              'shrink-0 rounded px-1.5 text-[0.62rem] font-semibold tabular-nums',
+              item.exitCode === 0
+                ? 'bg-emerald-500/15 text-emerald-600 dark:text-emerald-400'
+                : 'bg-destructive/15 text-destructive'
+            )}
+          >
+            {s.exit(item.exitCode)}
+          </span>
+        )}
+        <span className="shrink-0 text-[0.62rem] text-muted-foreground/65">
+          {running ? s.running : failed ? s.failed : s.done}
+        </span>
+      </header>
+
+      <TerminalOutput
+        className="min-h-0 flex-1 !max-h-none rounded-md border border-(--ui-stroke-tertiary)"
+        text={item.output || (running ? s.waitingForOutput : s.noOutput)}
+      />
+    </OverlayView>
+  )
+}

--- a/apps/desktop/src/app/chat/composer/status-stack/status-row.test.tsx
+++ b/apps/desktop/src/app/chat/composer/status-stack/status-row.test.tsx
@@ -119,24 +119,27 @@ describe('StatusItemRow — background task output', () => {
     expect(screen.queryByText(/line 1/)).toBeNull()
   })
 
-  it('a FINISHED task with captured output expands it inline on click', () => {
-    renderRow(bgItem({ state: 'done', output: 'line 1\nline 2\n' }))
+  it('clicking a FINISHED task also opens the modal (one path for every background row)', () => {
+    let openedId: string | null = null
+    renderRowWithHandlers(bgItem({ state: 'done', output: 'line 1\nline 2\n' }), {
+      onOpenOutput: id => (openedId = id)
+    })
+
     fireEvent.click(screen.getByRole('button'))
-    expect(screen.getByText(/line 1/)).toBeTruthy()
+
+    expect(openedId).toBe('bg-1')
+    // No inline disclosure remains — the modal owns output now.
+    expect(screen.queryByText(/line 1/)).toBeNull()
   })
 
-  it('a finished task with no output shows the no-output placeholder when expanded', () => {
-    renderRow(bgItem({ state: 'done' }))
-    fireEvent.click(screen.getByRole('button'))
-    expect(screen.getByText('No output captured.')).toBeTruthy()
-  })
+  it('routes the task id through onOpenOutput so the parent opens the right modal', () => {
+    const opened: string[] = []
+    renderRowWithHandlers(bgItem({ id: 'bg-xyz', state: 'running' }), {
+      onOpenOutput: id => opened.push(id)
+    })
 
-  it('toggles the inline output region closed on a second click (finished task)', () => {
-    renderRow(bgItem({ state: 'done', output: 'hello' }))
-    const row = screen.getByRole('button')
-    fireEvent.click(row)
-    expect(screen.getByText(/hello/)).toBeTruthy()
-    fireEvent.click(row)
-    expect(screen.queryByText(/hello/)).toBeNull()
+    fireEvent.click(screen.getByRole('button'))
+
+    expect(opened).toEqual(['bg-xyz'])
   })
 })

--- a/apps/desktop/src/app/chat/composer/status-stack/status-row.test.tsx
+++ b/apps/desktop/src/app/chat/composer/status-stack/status-row.test.tsx
@@ -1,0 +1,62 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it } from 'vitest'
+
+import type { ComposerStatusItem } from '@/store/composer-status'
+
+import { StatusItemRow } from './status-row'
+
+afterEach(cleanup)
+
+function bgItem(overrides: Partial<ComposerStatusItem> = {}): ComposerStatusItem {
+  return {
+    id: 'bg-1',
+    type: 'background',
+    title: 'cd ~/project && npm run build',
+    state: 'running',
+    ...overrides
+  } as ComposerStatusItem
+}
+
+describe('StatusItemRow — background task output', () => {
+  it('a running background task with no output yet is still clickable', () => {
+    render(<StatusItemRow item={bgItem()} />)
+
+    // The row is activatable (role=button) even before any output arrives —
+    // this is the regression: it used to be a dead no-op click.
+    const row = screen.getByRole('button')
+    expect(row).toBeTruthy()
+  })
+
+  it('clicking a running task with no output reveals the waiting placeholder', () => {
+    render(<StatusItemRow item={bgItem()} />)
+
+    expect(screen.queryByText('Waiting for output…')).toBeNull()
+    fireEvent.click(screen.getByRole('button'))
+    expect(screen.getByText('Waiting for output…')).toBeTruthy()
+  })
+
+  it('clicking a task with captured output shows the output, not a placeholder', () => {
+    render(<StatusItemRow item={bgItem({ output: 'line 1\nline 2\n' })} />)
+
+    fireEvent.click(screen.getByRole('button'))
+    expect(screen.getByText(/line 1/)).toBeTruthy()
+    expect(screen.queryByText('Waiting for output…')).toBeNull()
+  })
+
+  it('a finished task with no output shows the no-output placeholder when expanded', () => {
+    render(<StatusItemRow item={bgItem({ state: 'done' })} />)
+
+    fireEvent.click(screen.getByRole('button'))
+    expect(screen.getByText('No output captured.')).toBeTruthy()
+  })
+
+  it('toggles the output region closed on a second click', () => {
+    render(<StatusItemRow item={bgItem({ output: 'hello' })} />)
+
+    const row = screen.getByRole('button')
+    fireEvent.click(row)
+    expect(screen.getByText(/hello/)).toBeTruthy()
+    fireEvent.click(row)
+    expect(screen.queryByText(/hello/)).toBeNull()
+  })
+})

--- a/apps/desktop/src/app/chat/composer/status-stack/status-row.test.tsx
+++ b/apps/desktop/src/app/chat/composer/status-stack/status-row.test.tsx
@@ -1,11 +1,85 @@
 import { cleanup, fireEvent, render, screen } from '@testing-library/react'
 import { afterEach, describe, expect, it } from 'vitest'
 
+import { I18nProvider } from '@/i18n'
 import type { ComposerStatusItem } from '@/store/composer-status'
 
 import { StatusItemRow } from './status-row'
 
 afterEach(cleanup)
+
+function renderRow(item: ComposerStatusItem, sessionWorking = false) {
+  return render(
+    <I18nProvider configClient={null}>
+      <StatusItemRow item={item} sessionWorking={sessionWorking} />
+    </I18nProvider>
+  )
+}
+
+// ── "task pane hangs at the end" regression: an in_progress todo must show a
+// live spinner ONLY while the session's turn is running. When the turn settles
+// a todo left in_progress must NOT keep spinning forever. ───────────────────
+
+function todoItem(): ComposerStatusItem {
+  return {
+    id: 'todo:1',
+    title: 'in-flight step',
+    type: 'todo',
+    state: 'running', // todoToItem maps in_progress -> state:'running'
+    todoStatus: 'in_progress'
+  }
+}
+
+// The spinner is the only element with role="status" in this row.
+const hasSpinner = (c: HTMLElement) => c.querySelector('[role="status"]') !== null
+
+describe('StatusItemRow in_progress spinner gating', () => {
+  it('spins while the session turn is running', () => {
+    const { container } = renderRow(todoItem(), true)
+    expect(hasSpinner(container)).toBe(true)
+  })
+
+  it('settles (no spinner) when the session turn has ended', () => {
+    const { container } = renderRow(todoItem(), false)
+    expect(hasSpinner(container)).toBe(false)
+  })
+
+  it('still renders the item title in the settled state', () => {
+    const { container } = renderRow(todoItem(), false)
+    expect(container.textContent).toContain('in-flight step')
+  })
+
+  it('keeps spinning for a running background item regardless of sessionWorking', () => {
+    // Background/subagent rows carry their own lifecycle via `state`; the gate
+    // only applies to in_progress TODOs, so a running background task must
+    // still spin even when no agent turn is active.
+    const bg: ComposerStatusItem = {
+      id: 'bg:1',
+      title: 'long task',
+      type: 'background',
+      state: 'running'
+    }
+
+    const { container } = renderRow(bg, false)
+    expect(hasSpinner(container)).toBe(true)
+  })
+
+  it('shows the completed glyph (no spinner) for a completed todo', () => {
+    const done: ComposerStatusItem = {
+      id: 'todo:2',
+      title: 'done step',
+      type: 'todo',
+      state: 'done',
+      todoStatus: 'completed'
+    }
+
+    const { container } = renderRow(done, false)
+    expect(hasSpinner(container)).toBe(false)
+  })
+})
+
+// ── Background task output: a *running* job opens the roomy live-output modal
+// (onOpenOutput); a *finished* job toggles its captured output inline. ───────
 
 function bgItem(overrides: Partial<ComposerStatusItem> = {}): ComposerStatusItem {
   return {
@@ -17,42 +91,48 @@ function bgItem(overrides: Partial<ComposerStatusItem> = {}): ComposerStatusItem
   } as ComposerStatusItem
 }
 
+function renderRowWithHandlers(
+  item: ComposerStatusItem,
+  handlers: { onOpenOutput?: (id: string) => void } = {}
+) {
+  return render(
+    <I18nProvider configClient={null}>
+      <StatusItemRow item={item} onOpenOutput={handlers.onOpenOutput} sessionWorking={false} />
+    </I18nProvider>
+  )
+}
+
 describe('StatusItemRow — background task output', () => {
   it('a running background task with no output yet is still clickable', () => {
-    render(<StatusItemRow item={bgItem()} />)
-
-    // The row is activatable (role=button) even before any output arrives —
-    // this is the regression: it used to be a dead no-op click.
-    const row = screen.getByRole('button')
-    expect(row).toBeTruthy()
+    renderRow(bgItem())
+    expect(screen.getByRole('button')).toBeTruthy()
   })
 
-  it('clicking a running task with no output reveals the waiting placeholder', () => {
-    render(<StatusItemRow item={bgItem()} />)
+  it('clicking a RUNNING task opens the live-output modal (does not expand inline)', () => {
+    let openedId: string | null = null
+    renderRowWithHandlers(bgItem({ output: 'line 1\n' }), { onOpenOutput: id => (openedId = id) })
 
-    expect(screen.queryByText('Waiting for output…')).toBeNull()
     fireEvent.click(screen.getByRole('button'))
-    expect(screen.getByText('Waiting for output…')).toBeTruthy()
+
+    // Routed to the modal, not the cramped inline box.
+    expect(openedId).toBe('bg-1')
+    expect(screen.queryByText(/line 1/)).toBeNull()
   })
 
-  it('clicking a task with captured output shows the output, not a placeholder', () => {
-    render(<StatusItemRow item={bgItem({ output: 'line 1\nline 2\n' })} />)
-
+  it('a FINISHED task with captured output expands it inline on click', () => {
+    renderRow(bgItem({ state: 'done', output: 'line 1\nline 2\n' }))
     fireEvent.click(screen.getByRole('button'))
     expect(screen.getByText(/line 1/)).toBeTruthy()
-    expect(screen.queryByText('Waiting for output…')).toBeNull()
   })
 
   it('a finished task with no output shows the no-output placeholder when expanded', () => {
-    render(<StatusItemRow item={bgItem({ state: 'done' })} />)
-
+    renderRow(bgItem({ state: 'done' }))
     fireEvent.click(screen.getByRole('button'))
     expect(screen.getByText('No output captured.')).toBeTruthy()
   })
 
-  it('toggles the output region closed on a second click', () => {
-    render(<StatusItemRow item={bgItem({ output: 'hello' })} />)
-
+  it('toggles the inline output region closed on a second click (finished task)', () => {
+    renderRow(bgItem({ state: 'done', output: 'hello' }))
     const row = screen.getByRole('button')
     fireEvent.click(row)
     expect(screen.getByText(/hello/)).toBeTruthy()

--- a/apps/desktop/src/app/chat/composer/status-stack/status-row.tsx
+++ b/apps/desktop/src/app/chat/composer/status-stack/status-row.tsx
@@ -95,8 +95,13 @@ export const StatusItemRow = memo(function StatusItemRow({ item, onDismiss, onOp
       : null
 
   const canOpen = item.type === 'subagent' && !!onOpen
-  const hasOutput = item.type === 'background' && !!item.output
-  const onActivate = canOpen ? onOpen : hasOutput ? () => setOutputOpen(open => !open) : undefined
+  // Every background task is expandable — clicking toggles its captured output
+  // inline (the gateway's process `output_tail`, which live-tails as it grows).
+  // A running task whose first output hasn't arrived yet still expands, showing
+  // a "waiting for output" placeholder, so the click is never a dead no-op
+  // (the "clicking a background task does nothing" bug).
+  const isBackground = item.type === 'background'
+  const onActivate = canOpen ? onOpen : isBackground ? () => setOutputOpen(open => !open) : undefined
 
   return (
     <Fragment>
@@ -147,9 +152,14 @@ export const StatusItemRow = memo(function StatusItemRow({ item, onDismiss, onOp
             {s.exit(item.exitCode)}
           </span>
         )}
-        {hasOutput && <DisclosureCaret className="shrink-0 text-muted-foreground/45" open={outputOpen} size="0.8em" />}
+        {isBackground && <DisclosureCaret className="shrink-0 text-muted-foreground/45" open={outputOpen} size="0.8em" />}
       </StatusRow>
-      {hasOutput && outputOpen && <TerminalOutput className="mx-auto mb-1 max-w-[90%]" text={item.output!} />}
+      {isBackground && outputOpen && (
+        <TerminalOutput
+          className="mx-auto mb-1 max-w-[90%]"
+          text={item.output || (running ? s.waitingForOutput : s.noOutput)}
+        />
+      )}
     </Fragment>
   )
 })

--- a/apps/desktop/src/app/chat/composer/status-stack/status-row.tsx
+++ b/apps/desktop/src/app/chat/composer/status-stack/status-row.tsx
@@ -30,7 +30,7 @@ const TODO_GLYPHS: Record<Exclude<TodoStatus, 'in_progress' | 'pending'>, { icon
 
 // Left slot: braille spinner while running, otherwise a small status dot
 // (green = done, red = failed) so the slot is always filled and rows align.
-function leadingGlyph(item: ComposerStatusItem, s: Translations['statusStack']): ReactNode {
+function leadingGlyph(item: ComposerStatusItem, s: Translations['statusStack'], sessionWorking: boolean): ReactNode {
   if (item.todoStatus === 'pending') {
     return (
       <span
@@ -46,12 +46,32 @@ function leadingGlyph(item: ComposerStatusItem, s: Translations['statusStack']):
     return <Codicon className={glyph.tone} name={glyph.icon} size="0.8rem" />
   }
 
-  if (item.state === 'running') {
+  // An `in_progress` todo (or a running background/subagent item) only gets a
+  // live spinner while the session's turn is actually running. If the turn has
+  // settled — the agent finished, stopped, or is waiting on the user — a todo
+  // left mid-flight must NOT keep spinning forever (the "task pane hangs at the
+  // end" bug): fall through to a static dot so the row reads as paused, not
+  // actively working. Background/subagent rows carry their own real lifecycle
+  // (`state`), so they're unaffected when the gate is open.
+  const isTodoInProgress = item.todoStatus === 'in_progress'
+
+  if (item.state === 'running' && (sessionWorking || !isTodoInProgress)) {
     return (
       <GlyphSpinner
         ariaLabel={s.running}
         className="text-[0.9rem] leading-none text-muted-foreground/80"
         spinner="braille"
+      />
+    )
+  }
+
+  // Settled in_progress todo: a hollow ring reads as "started, awaiting the
+  // next turn" — distinct from the dashed pending ring and the filled done dot.
+  if (isTodoInProgress) {
+    return (
+      <span
+        aria-hidden
+        className="box-border size-[0.7rem] rounded-full border-2 border-muted-foreground/55"
       />
     )
   }
@@ -73,6 +93,11 @@ interface StatusItemRowProps {
   onOpen?: () => void
   /** Cancel a running background task. */
   onStop?: (id: string) => void
+  /** Open the roomy live process-output modal for a running background task. */
+  onOpenOutput?: (id: string) => void
+  /** Whether the owning session's turn is actively running — gates the live
+   *  spinner on `in_progress` todos so they settle when the turn ends. */
+  sessionWorking?: boolean
 }
 
 /**
@@ -80,7 +105,14 @@ interface StatusItemRowProps {
  * Memoised + keyed by id so parent re-renders never remount it (the spinner
  * keeps ticking instead of resetting).
  */
-export const StatusItemRow = memo(function StatusItemRow({ item, onDismiss, onOpen, onStop }: StatusItemRowProps) {
+export const StatusItemRow = memo(function StatusItemRow({
+  item,
+  onDismiss,
+  onOpen,
+  onStop,
+  onOpenOutput,
+  sessionWorking = false
+}: StatusItemRowProps) {
   const { t } = useI18n()
   const s = t.statusStack
   const [outputOpen, setOutputOpen] = useState(false)
@@ -95,18 +127,24 @@ export const StatusItemRow = memo(function StatusItemRow({ item, onDismiss, onOp
       : null
 
   const canOpen = item.type === 'subagent' && !!onOpen
-  // Every background task is expandable — clicking toggles its captured output
-  // inline (the gateway's process `output_tail`, which live-tails as it grows).
-  // A running task whose first output hasn't arrived yet still expands, showing
-  // a "waiting for output" placeholder, so the click is never a dead no-op
-  // (the "clicking a background task does nothing" bug).
+  // Background tasks: a *running* job opens the roomy live process-output modal
+  // (the "see what's running" view) — its gateway subprocess can't live in the
+  // interactive xterm pane, so a dedicated tailing viewer is the honest home for
+  // it. A *finished* job toggles its captured output inline (cheap, no modal).
   const isBackground = item.type === 'background'
-  const onActivate = canOpen ? onOpen : isBackground ? () => setOutputOpen(open => !open) : undefined
+
+  const onActivate = canOpen
+    ? onOpen
+    : isBackground
+      ? running
+        ? () => onOpenOutput?.(item.id)
+        : () => setOutputOpen(open => !open)
+      : undefined
 
   return (
     <Fragment>
       <StatusRow
-        leading={leadingGlyph(item, s)}
+        leading={leadingGlyph(item, s, sessionWorking)}
         onActivate={onActivate}
         trailing={
           action ? (

--- a/apps/desktop/src/app/chat/composer/status-stack/status-row.tsx
+++ b/apps/desktop/src/app/chat/composer/status-stack/status-row.tsx
@@ -1,10 +1,8 @@
-import { Fragment, memo, type ReactNode, useState } from 'react'
+import { Fragment, memo, type ReactNode } from 'react'
 
 import { StatusRow } from '@/components/chat/status-row'
-import { TerminalOutput } from '@/components/chat/terminal-output'
 import { Button } from '@/components/ui/button'
 import { Codicon } from '@/components/ui/codicon'
-import { DisclosureCaret } from '@/components/ui/disclosure-caret'
 import { GlyphSpinner } from '@/components/ui/glyph-spinner'
 import { Tip } from '@/components/ui/tooltip'
 import { type Translations, useI18n } from '@/i18n'
@@ -115,7 +113,6 @@ export const StatusItemRow = memo(function StatusItemRow({
 }: StatusItemRowProps) {
   const { t } = useI18n()
   const s = t.statusStack
-  const [outputOpen, setOutputOpen] = useState(false)
   const failed = item.state === 'failed'
   const running = item.state === 'running'
 
@@ -127,19 +124,13 @@ export const StatusItemRow = memo(function StatusItemRow({
       : null
 
   const canOpen = item.type === 'subagent' && !!onOpen
-  // Background tasks: a *running* job opens the roomy live process-output modal
-  // (the "see what's running" view) — its gateway subprocess can't live in the
-  // interactive xterm pane, so a dedicated tailing viewer is the honest home for
-  // it. A *finished* job toggles its captured output inline (cheap, no modal).
+  // Background tasks (running OR finished) open the roomy live process-output
+  // modal. Their gateway subprocess can't live in the interactive xterm pane, so
+  // a dedicated tailing viewer is the honest home for the output — one path for
+  // every background row, no dead inline dropdown.
   const isBackground = item.type === 'background'
 
-  const onActivate = canOpen
-    ? onOpen
-    : isBackground
-      ? running
-        ? () => onOpenOutput?.(item.id)
-        : () => setOutputOpen(open => !open)
-      : undefined
+  const onActivate = canOpen ? onOpen : isBackground ? () => onOpenOutput?.(item.id) : undefined
 
   return (
     <Fragment>
@@ -190,14 +181,8 @@ export const StatusItemRow = memo(function StatusItemRow({
             {s.exit(item.exitCode)}
           </span>
         )}
-        {isBackground && <DisclosureCaret className="shrink-0 text-muted-foreground/45" open={outputOpen} size="0.8em" />}
+        {isBackground && <ArrowUpRight aria-hidden className="shrink-0 size-3.5 text-muted-foreground/45" />}
       </StatusRow>
-      {isBackground && outputOpen && (
-        <TerminalOutput
-          className="mx-auto mb-1 max-w-[90%]"
-          text={item.output || (running ? s.waitingForOutput : s.noOutput)}
-        />
-      )}
     </Fragment>
   )
 })

--- a/apps/desktop/src/app/overlays/overlay-view.tsx
+++ b/apps/desktop/src/app/overlays/overlay-view.tsx
@@ -1,4 +1,5 @@
 import { type ReactNode, useEffect } from 'react'
+import { createPortal } from 'react-dom'
 
 import { Button } from '@/components/ui/button'
 import { Codicon } from '@/components/ui/codicon'
@@ -12,6 +13,19 @@ interface OverlayViewProps {
   closeLabel?: string
   contentClassName?: string
   headerContent?: ReactNode
+  /**
+   * Render into `document.body` instead of in-place. REQUIRED for any overlay
+   * mounted inside a subtree that establishes a containing block for fixed
+   * positioning — `transform`, `filter`, `backdrop-filter`, `contain`,
+   * `will-change`, etc. (CSS spec). Without it, this overlay's `position:
+   * fixed; inset: 0` resolves against that ancestor's box, not the viewport,
+   * so the "full-screen" overlay collapses into the ancestor's rect (e.g. the
+   * composer's glassy `backdrop-filter` surface at the bottom of the window).
+   * Root-mounted overlays (settings, command center) don't need it; overlays
+   * docked under the composer/thread (which use backdrop-blur + contain:paint)
+   * do.
+   */
+  portal?: boolean
   rootClassName?: string
 }
 
@@ -21,6 +35,7 @@ export function OverlayView({
   closeLabel = translateNow('common.close'),
   contentClassName,
   headerContent,
+  portal = false,
   rootClassName
 }: OverlayViewProps) {
   const closeOverlay = () => {
@@ -47,7 +62,7 @@ export function OverlayView({
     return () => window.removeEventListener('keydown', onKeyDown)
   }, [onClose])
 
-  return (
+  const overlay = (
     <div
       className="fixed inset-0 z-50 bg-black/22 p-3 backdrop-blur-[0.125rem] sm:p-6"
       onClick={event => {
@@ -88,4 +103,12 @@ export function OverlayView({
       </div>
     </div>
   )
+
+  // Portal to body so `position: fixed` resolves against the viewport rather
+  // than a transformed/filtered/contained ancestor (see the `portal` prop).
+  if (portal && typeof document !== 'undefined') {
+    return createPortal(overlay, document.body)
+  }
+
+  return overlay
 }

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -1335,6 +1335,8 @@ export const en: Translations = {
     running: 'Running',
     stop: 'Stop',
     dismiss: 'Dismiss',
+    waitingForOutput: 'Waiting for output…',
+    noOutput: 'No output captured.',
     exit: code => `exit ${code}`
   },
 

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -1333,6 +1333,8 @@ export const en: Translations = {
     subagents: count => `${count} Subagent${count === 1 ? '' : 's'}`,
     todos: (done, total) => `Tasks ${done}/${total}`,
     running: 'Running',
+    failed: 'Failed',
+    done: 'Done',
     stop: 'Stop',
     dismiss: 'Dismiss',
     waitingForOutput: 'Waiting for output…',

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -1463,6 +1463,8 @@ export const ja = defineLocale({
     running: '実行中',
     stop: '停止',
     dismiss: '閉じる',
+    waitingForOutput: '出力を待っています…',
+    noOutput: '出力はありません。',
     exit: code => `終了コード ${code}`
   },
 

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -1461,6 +1461,8 @@ export const ja = defineLocale({
     subagents: count => `サブエージェント ${count} 件`,
     todos: (done, total) => `タスク ${done}/${total}`,
     running: '実行中',
+    failed: '失敗',
+    done: '完了',
     stop: '停止',
     dismiss: '閉じる',
     waitingForOutput: '出力を待っています…',

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -1013,6 +1013,8 @@ export interface Translations {
     subagents: (count: number) => string
     todos: (done: number, total: number) => string
     running: string
+    failed: string
+    done: string
     stop: string
     dismiss: string
     waitingForOutput: string

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -1015,6 +1015,8 @@ export interface Translations {
     running: string
     stop: string
     dismiss: string
+    waitingForOutput: string
+    noOutput: string
     exit: (code: number) => string
   }
 

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -1415,6 +1415,8 @@ export const zhHant = defineLocale({
     subagents: count => `${count} 個子代理`,
     todos: (done, total) => `任務 ${done}/${total}`,
     running: '執行中',
+    failed: '失敗',
+    done: '完成',
     stop: '停止',
     dismiss: '關閉',
     waitingForOutput: '正在等待輸出…',

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -1417,6 +1417,8 @@ export const zhHant = defineLocale({
     running: '執行中',
     stop: '停止',
     dismiss: '關閉',
+    waitingForOutput: '正在等待輸出…',
+    noOutput: '未擷取輸出。',
     exit: code => `結束碼 ${code}`
   },
 

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -1520,6 +1520,8 @@ export const zh: Translations = {
     subagents: count => `${count} 个子代理`,
     todos: (done, total) => `任务 ${done}/${total}`,
     running: '运行中',
+    failed: '失败',
+    done: '完成',
     stop: '停止',
     dismiss: '关闭',
     waitingForOutput: '正在等待输出…',

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -1522,6 +1522,8 @@ export const zh: Translations = {
     running: '运行中',
     stop: '停止',
     dismiss: '关闭',
+    waitingForOutput: '正在等待输出…',
+    noOutput: '未捕获输出。',
     exit: code => `退出码 ${code}`
   },
 


### PR DESCRIPTION
## What

Clicking a **running** background task in the status stack now opens a full-height, **live-tailing** output viewer — the "see what's running" view the cramped inline disclosure couldn't be. Finished jobs keep their cheap inline-toggle.

> Stacked on #48741-family background-output work (`fix/desktop-background-task-output`). Review that first.

## Why a modal, not the terminal pane

The user expected these to "pop up in the terminal window." They can't, and here's the honest reason: the agent's background jobs (`terminal(background=true)`) run as **gateway subprocesses** — they are **not** in the interactive xterm pane (that pane is a single persistent WebGL terminal the *user* drives). Forcing their output into that shell would be a fake. The honest home is a dedicated viewer that tails the process's real `output_tail` (already polled every 5s via `process.list`).

## Behavior

- **Running** job click → `ProcessOutputModal` (full-height `TerminalOutput`, live — it re-reads the task from `$backgroundStatusBySession` **by id**, so the 5s poll keeps it fresh without remounting; header shows status + exit code).
- **Finished** job click → toggles captured output inline (unchanged).

## Changes

- `process-output-modal.tsx` — the live viewer (`OverlayView` + `TerminalOutput`, looked up by id so it stays reactive).
- `status-row.tsx` — running background rows route clicks to `onOpenOutput(id)`; finished rows keep the inline toggle.
- `status-stack/index.tsx` — owns the open-modal state, renders the modal.
- i18n: `statusStack.failed` / `.done` added (all 4 locales) for the modal header.

## Tests

- `process-output-modal.test.tsx` (5): renders title+output; waiting placeholder; **live store update reflected without remount** (proves the poll updates it via `act()`); renders nothing when the task is reaped; close control fires `onClose`.
- `status-row.test.tsx` updated: running click routes to `onOpenOutput` (not inline); finished click still expands inline; second click collapses.

`tsc` + `eslint` clean, **15 status-stack tests pass**. Validated via unit tests; not yet click-tested in a packaged build.
