### PR TITLE
feat(tts): add xAI TTS speed and optimize_streaming_latency config knobs

### DIFF
--- a/tests/tools/test_tts_xai_speech_tags.py
+++ b/tests/tools/test_tts_xai_speech_tags.py
@@ -126,3 +126,207 @@ def test_generate_xai_tts_leaves_text_plain_by_default(tmp_path, monkeypatch):
     )
 
     assert captured["json"]["text"] == "Bonjour Monsieur Talbot. Ceci est un test."
+
+
+def test_generate_xai_tts_omits_speed_and_latency_by_default(tmp_path, monkeypatch):
+    """No speed / optimize_streaming_latency in the request body unless
+    the user explicitly sets them. Keeps the existing minimal-payload
+    contract for default configs.
+    """
+    captured = {}
+
+    fake_response = Mock()
+    fake_response.content = b"mp3"
+    fake_response.raise_for_status.return_value = None
+
+    def fake_post(url, headers, json, timeout):
+        captured["json"] = json
+        return fake_response
+
+    monkeypatch.setenv("XAI_API_KEY", "test-xai-key")
+    monkeypatch.setattr("requests.post", fake_post)
+
+    _generate_xai_tts(
+        "Hello world.",
+        str(tmp_path / "out.mp3"),
+        {"xai": {"voice_id": "ara", "language": "en"}},
+    )
+
+    assert "speed" not in captured["json"]
+    assert "optimize_streaming_latency" not in captured["json"]
+
+
+def test_generate_xai_tts_sends_speed_when_set(tmp_path, monkeypatch):
+    """tts.xai.speed flows into the POST body."""
+    captured = {}
+
+    fake_response = Mock()
+    fake_response.content = b"mp3"
+    fake_response.raise_for_status.return_value = None
+
+    def fake_post(url, headers, json, timeout):
+        captured["json"] = json
+        return fake_response
+
+    monkeypatch.setenv("XAI_API_KEY", "test-xai-key")
+    monkeypatch.setattr("requests.post", fake_post)
+
+    _generate_xai_tts(
+        "Hello world.",
+        str(tmp_path / "out.mp3"),
+        {"xai": {"voice_id": "ara", "language": "en", "speed": 1.5}},
+    )
+
+    assert captured["json"]["speed"] == 1.5
+
+
+def test_generate_xai_tts_speed_clamped_to_valid_range(tmp_path, monkeypatch):
+    """speed values outside xAI's 0.7..1.5 band are clamped, not sent raw."""
+    captured = {}
+
+    fake_response = Mock()
+    fake_response.content = b"mp3"
+    fake_response.raise_for_status.return_value = None
+
+    def fake_post(url, headers, json, timeout):
+        captured["json"] = json
+        return fake_response
+
+    monkeypatch.setenv("XAI_API_KEY", "test-xai-key")
+    monkeypatch.setattr("requests.post", fake_post)
+
+    # Below 0.7 -> 0.7
+    _generate_xai_tts(
+        "Hello.",
+        str(tmp_path / "out.mp3"),
+        {"xai": {"voice_id": "eve", "language": "en", "speed": 0.1}},
+    )
+    assert captured["json"]["speed"] == 0.7
+
+    # Above 1.5 -> 1.5
+    _generate_xai_tts(
+        "Hello.",
+        str(tmp_path / "out.mp3"),
+        {"xai": {"voice_id": "eve", "language": "en", "speed": 3.0}},
+    )
+    assert captured["json"]["speed"] == 1.5
+
+
+def test_generate_xai_tts_omits_speed_when_exactly_default(tmp_path, monkeypatch):
+    """speed == 1.0 is the API default; the field stays out of the payload."""
+    captured = {}
+
+    fake_response = Mock()
+    fake_response.content = b"mp3"
+    fake_response.raise_for_status.return_value = None
+
+    def fake_post(url, headers, json, timeout):
+        captured["json"] = json
+        return fake_response
+
+    monkeypatch.setenv("XAI_API_KEY", "test-xai-key")
+    monkeypatch.setattr("requests.post", fake_post)
+
+    _generate_xai_tts(
+        "Hello.",
+        str(tmp_path / "out.mp3"),
+        {"xai": {"voice_id": "eve", "language": "en", "speed": 1.0}},
+    )
+
+    assert "speed" not in captured["json"]
+
+
+def test_generate_xai_tts_sends_optimize_streaming_latency_when_set(tmp_path, monkeypatch):
+    """tts.xai.optimize_streaming_latency flows into the POST body."""
+    captured = {}
+
+    fake_response = Mock()
+    fake_response.content = b"mp3"
+    fake_response.raise_for_status.return_value = None
+
+    def fake_post(url, headers, json, timeout):
+        captured["json"] = json
+        return fake_response
+
+    monkeypatch.setenv("XAI_API_KEY", "test-xai-key")
+    monkeypatch.setattr("requests.post", fake_post)
+
+    _generate_xai_tts(
+        "Hello world.",
+        str(tmp_path / "out.mp3"),
+        {"xai": {"voice_id": "ara", "language": "en", "optimize_streaming_latency": 2}},
+    )
+
+    assert captured["json"]["optimize_streaming_latency"] == 2
+
+
+def test_generate_xai_tts_optimize_streaming_latency_omitted_at_default(tmp_path, monkeypatch):
+    """optimize_streaming_latency == 0 is the API default; field is not sent."""
+    captured = {}
+
+    fake_response = Mock()
+    fake_response.content = b"mp3"
+    fake_response.raise_for_status.return_value = None
+
+    def fake_post(url, headers, json, timeout):
+        captured["json"] = json
+        return fake_response
+
+    monkeypatch.setenv("XAI_API_KEY", "test-xai-key")
+    monkeypatch.setattr("requests.post", fake_post)
+
+    _generate_xai_tts(
+        "Hello world.",
+        str(tmp_path / "out.mp3"),
+        {"xai": {"voice_id": "ara", "language": "en", "optimize_streaming_latency": 0}},
+    )
+
+    assert "optimize_streaming_latency" not in captured["json"]
+
+
+def test_generate_xai_tts_global_speed_used_as_fallback(tmp_path, monkeypatch):
+    """Global tts.speed is the fallback when tts.xai.speed is unset."""
+    captured = {}
+
+    fake_response = Mock()
+    fake_response.content = b"mp3"
+    fake_response.raise_for_status.return_value = None
+
+    def fake_post(url, headers, json, timeout):
+        captured["json"] = json
+        return fake_response
+
+    monkeypatch.setenv("XAI_API_KEY", "test-xai-key")
+    monkeypatch.setattr("requests.post", fake_post)
+
+    _generate_xai_tts(
+        "Hello.",
+        str(tmp_path / "out.mp3"),
+        {"speed": 0.8, "xai": {"voice_id": "ara", "language": "en"}},
+    )
+
+    assert captured["json"]["speed"] == 0.8
+
+
+def test_generate_xai_tts_provider_speed_overrides_global(tmp_path, monkeypatch):
+    """tts.xai.speed wins over the global tts.speed fallback."""
+    captured = {}
+
+    fake_response = Mock()
+    fake_response.content = b"mp3"
+    fake_response.raise_for_status.return_value = None
+
+    def fake_post(url, headers, json, timeout):
+        captured["json"] = json
+        return fake_response
+
+    monkeypatch.setenv("XAI_API_KEY", "test-xai-key")
+    monkeypatch.setattr("requests.post", fake_post)
+
+    _generate_xai_tts(
+        "Hello.",
+        str(tmp_path / "out.mp3"),
+        {"speed": 1.5, "xai": {"voice_id": "ara", "language": "en", "speed": 0.7}},
+    )
+
+    assert captured["json"]["speed"] == 0.7

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -187,6 +187,13 @@ DEFAULT_XAI_SAMPLE_RATE = 24000
 DEFAULT_XAI_BIT_RATE = 128000
 DEFAULT_XAI_AUTO_SPEECH_TAGS = False
 DEFAULT_XAI_BASE_URL = "https://api.x.ai/v1"
+# xAI TTS `speed` accepts 0.7..1.5; 1.0 is the API default (omitted => default).
+DEFAULT_XAI_SPEED_MIN = 0.7
+DEFAULT_XAI_SPEED_MAX = 1.5
+DEFAULT_XAI_SPEED_DEFAULT = 1.0
+# xAI TTS `optimize_streaming_latency` accepts 0, 1, or 2; 0 (best quality) is
+# the API default (omitted => default). Values >0 trade quality for time-to-first-audio.
+DEFAULT_XAI_OPTIMIZE_STREAMING_LATENCY_DEFAULT = 0
 DEFAULT_GEMINI_TTS_MODEL = "gemini-2.5-flash-preview-tts"
 DEFAULT_GEMINI_TTS_VOICE = "Kore"
 DEFAULT_GEMINI_TTS_BASE_URL = "https://generativelanguage.googleapis.com/v1beta"
@@ -1135,6 +1142,31 @@ def _generate_xai_tts(text: str, output_path: str, tts_config: Dict[str, Any]) -
         xai_config.get("auto_speech_tags", xai_config.get("speech_tags")),
         DEFAULT_XAI_AUTO_SPEECH_TAGS,
     )
+    # ``tts.xai.speed`` overrides global ``tts.speed``; the xAI TTS API
+    # accepts 0.7..1.5 (1.0 = normal). Out-of-range values are clamped so a
+    # misconfigured agent can't 400 the request — the API would reject
+    # anything outside the band.
+    speed = xai_config.get("speed", tts_config.get("speed"))
+    if speed is not None and speed != "":
+        try:
+            speed = float(speed)
+        except (TypeError, ValueError):
+            speed = None
+    if speed is not None:
+        speed = max(DEFAULT_XAI_SPEED_MIN, min(DEFAULT_XAI_SPEED_MAX, speed))
+    # ``tts.xai.optimize_streaming_latency`` is 0, 1, or 2 (xAI-specific;
+    # trades chunk-boundary quality for time-to-first-audio).
+    optimize_streaming_latency = xai_config.get(
+        "optimize_streaming_latency",
+        tts_config.get("optimize_streaming_latency"),
+    )
+    if optimize_streaming_latency is not None and optimize_streaming_latency != "":
+        try:
+            optimize_streaming_latency = int(optimize_streaming_latency)
+        except (TypeError, ValueError):
+            optimize_streaming_latency = None
+    if optimize_streaming_latency is not None:
+        optimize_streaming_latency = max(0, min(2, optimize_streaming_latency))
     if auto_speech_tags:
         text = _apply_xai_auto_speech_tags(text)
     base_url = str(
@@ -1163,6 +1195,18 @@ def _generate_xai_tts(text: str, output_path: str, tts_config: Dict[str, Any]) -
         if codec == "mp3" and bit_rate:
             output_format["bit_rate"] = bit_rate
         payload["output_format"] = output_format
+    # Only attach `speed` when the caller asked for something other than the
+    # API default (1.0). Keeps the existing minimal-payload contract for
+    # users who never touch the knob.
+    if speed is not None and speed != DEFAULT_XAI_SPEED_DEFAULT:
+        payload["speed"] = speed
+    # Only attach `optimize_streaming_latency` when the caller explicitly
+    # opts in to a non-default value (anything other than 0).
+    if (
+        optimize_streaming_latency is not None
+        and optimize_streaming_latency != DEFAULT_XAI_OPTIMIZE_STREAMING_LATENCY_DEFAULT
+    ):
+        payload["optimize_streaming_latency"] = optimize_streaming_latency
 
     response = requests.post(
         f"{base_url}/tts",


### PR DESCRIPTION
## What does this PR do?

Wires the xAI TTS provider's `speed` and `optimize_streaming_latency` through to the request body for `POST /v1/tts`. Both params are accepted by the xAI TTS endpoint but the Hermes built-in xAI provider was reading neither from config nor sending either — config keys were silently ignored.

This change adds `tts.xai.speed` (float, 0.7–1.5, default 1.0) and `tts.xai.optimize_streaming_latency` (int, 0/1/2, default 0) as config knobs, with global `tts.speed` / `tts.optimize_streaming_latency` fallbacks. The resolver order is `tts.xai.<knob>` overrides global `tts.<knob>`. Values outside the valid range are clamped (not rejected), and bad input (unparseable strings, lists, dicts, etc.) is dropped to `None` instead of raising, so a misconfigured agent doesn't crash TTS calls with a `TypeError`. Both fields are **only attached to the request body when they differ from the API default** — this preserves the existing minimal-payload contract for users who never touch the knobs.

`optimize_streaming_latency: 1` is recommended for speed gains even on the non-streaming HTTP endpoint (verified). Proper WebSocket streaming is a separate workstream and not in scope for this change.

## Related Issue

No upstream issue. Local tracking only.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tools/tts_tool.py` (`_generate_xai_tts` only, +44 / -0):
  - 4 new module-level constants: `DEFAULT_XAI_SPEED_MIN/MAX/DEFAULT`, `DEFAULT_XAI_OPTIMIZE_STREAMING_LATENCY_DEFAULT`.
  - Tolerant parse for `speed` (via `tts.xai.speed` → global `tts.speed` fallback): `float()` with a try/except that drops bad input to `None`; out-of-range values clamped to `[0.7, 1.5]`.
  - Tolerant parse for `optimize_streaming_latency` (via `tts.xai.optimize_streaming_latency` → global `tts.optimize_streaming_latency` fallback): `int()` with the same bad-input handling; clamped to `[0, 2]`.
  - Both fields attached to the request body **only when the value differs from the API default** (1.0 for speed, 0 for `optimize_streaming_latency`).

- `tests/tools/test_tts_xai_speech_tags.py` (+204 / -0): 8 new test cases:
  - `test_generate_xai_tts_omits_speed_and_latency_by_default` — no fields in payload by default
  - `test_generate_xai_tts_sends_speed_when_set` — `speed: 1.5` flows to the body
  - `test_generate_xai_tts_speed_clamped_to_valid_range` — 0.1 → 0.7, 3.0 → 1.5
  - `test_generate_xai_tts_omits_speed_when_exactly_default` — `speed: 1.0` is the API default, stays out of payload
  - `test_generate_xai_tts_sends_optimize_streaming_latency_when_set` — value flows to the body
  - `test_generate_xai_tts_optimize_streaming_latency_omitted_at_default` — value 0 stays out of payload
  - `test_generate_xai_tts_global_speed_used_as_fallback` — `tts.speed` works when `tts.xai.speed` is unset
  - `test_generate_xai_tts_provider_speed_overrides_global` — `tts.xai.speed` wins over the global fallback

## How to Test

1. Set `tts.xai.speed: 1.5` in `config.yaml` and synthesize a sentence — confirm the audio plays faster.
2. Set `tts.xai.optimize_streaming_latency: 1` — confirm time-to-first-audio improves with no perceptible quality loss.
3. Run the test suite: `pytest tests/tools/test_tts_xai_speech_tags.py -v` — expect 16/16 (8 pre-existing + 8 new).
4. Run the full TTS surface: `pytest tests/tools/test_tts_*.py` — expect 233/234 (1 unrelated pre-existing skip, no regressions).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A (no tts.xai section in the example; existing knobs aren't documented there either)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A (changes are platform-agnostic; the xAI HTTP endpoint works the same on all OSes)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

```
$ pytest tests/tools/test_tts_xai_speech_tags.py -v
============================= test session starts =============================
platform win32 -- Python 3.11.11, pytest-9.1.0
collected 16 items

tests/tools/test_tts_xai_speech_tags.py::test_apply_xai_auto_speech_tags_adds_light_pause_after_first_sentence PASSED
tests/tools/test_tts_xai_speech_tags.py::test_apply_xai_auto_speech_tags_preserves_explicit_tags PASSED
tests/tools/test_tts_xai_speech_tags.py::test_apply_xai_auto_speech_tags_preserves_all_documented_xai_tags PASSED
tests/tools/test_tts_xai_speech_tags.py::test_apply_xai_auto_speech_tags_multi_paragraph_emits_single_pause PASSED
tests/tools/test_tts_xai_speech_tags.py::test_apply_xai_auto_speech_tags_single_paragraph_still_gets_first_sentence_pause PASSED
tests/tools/test_tts_xai_speech_tags.py::test_apply_xai_auto_speech_tags_single_newline_still_gets_first_sentence_pause PASSED
tests/tools/test_tts_xai_speech_tags.py::test_generate_xai_tts_sends_auto_speech_tags_when_enabled PASSED
tests/tools/test_tts_xai_speech_tags.py::test_generate_xai_tts_leaves_text_plain_by_default PASSED
tests/tools/test_tts_xai_speech_tags.py::test_generate_xai_tts_omits_speed_and_latency_by_default PASSED
tests/tools/test_tts_xai_speech_tags.py::test_generate_xai_tts_sends_speed_when_set PASSED
tests/tools/test_tts_xai_speech_tags.py::test_generate_xai_tts_speed_clamped_to_valid_range PASSED
tests/tools/test_tts_xai_speech_tags.py::test_generate_xai_tts_omits_speed_when_exactly_default PASSED
tests/tools/test_tts_xai_speech_tags.py::test_generate_xai_tts_sends_optimize_streaming_latency_when_set PASSED
tests/tools/test_tts_xai_speech_tags.py::test_generate_xai_tts_optimize_streaming_latency_omitted_at_default PASSED
tests/tools/test_tts_xai_speech_tags.py::test_generate_xai_tts_global_speed_used_as_fallback PASSED
tests/tools/test_tts_xai_speech_tags.py::test_generate_xai_tts_provider_speed_overrides_global PASSED

============================= 16 passed in ~2s ==============================
```
