### PR TITLE
Fix TUI /goal slash dispatch

### DIFF
--- a/tests/tui_gateway/test_goal_command.py
+++ b/tests/tui_gateway/test_goal_command.py
@@ -185,15 +185,31 @@ def test_goal_requires_session(server):
 # ── slash.exec /goal routing ──────────────────────────────────────────
 
 
-def test_slash_exec_rejects_goal_routes_to_command_dispatch(server, session):
-    """slash.exec must reject /goal with 4018 so the TUI client falls through
-    to command.dispatch. Without this, the HermesCLI slash-worker subprocess
-    would set the goal but silently drop the kickoff — the queue is in-proc."""
+def test_slash_exec_goal_status_dispatches_internally(server, session):
+    """slash.exec must internally dispatch /goal so desktop clients do not
+    swallow the text while waiting for a frontend fallback path."""
     sid, _, _ = session
     r = _call(server, "slash.exec", command="goal status", session_id=sid)
-    assert "error" in r
-    assert r["error"]["code"] == 4018
-    assert "command.dispatch" in r["error"]["message"]
+    assert "error" not in r
+    assert r["result"]["type"] == "exec"
+    assert "No active goal" in r["result"]["output"]
+
+
+def test_slash_exec_goal_set_returns_send_with_notice(server, session):
+    sid, session_key, _ = session
+    r = _call(server, "slash.exec", command="goal build a rocket", session_id=sid)
+    result = r["result"]
+    assert result["type"] == "send"
+    assert result["message"] == "build a rocket"
+    assert "Goal set" in result["notice"]
+    assert "20-turn budget" in result["notice"]
+
+    from hermes_cli.goals import GoalManager
+
+    mgr = GoalManager(session_key)
+    assert mgr.state is not None
+    assert mgr.state.goal == "build a rocket"
+    assert mgr.state.status == "active"
 
 
 def test_pending_input_commands_includes_goal(server):

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -8653,13 +8653,11 @@ def _resolve_name(name: str) -> str:
         return name
 
 
-@method("command.dispatch")
-def _(rid, params: dict) -> dict:
-    name, arg = params.get("name", "").lstrip("/"), params.get("arg", "")
+def _dispatch_tui_command(rid, name: str, arg: str, session: dict | None) -> dict:
+    name = name.lstrip("/")
     resolved = _resolve_name(name)
     if resolved != name:
         name = resolved
-    session = _sessions.get(params.get("session_id", ""))
 
     qcmds = _load_cfg().get("quick_commands", {})
     if name in qcmds:
@@ -8976,6 +8974,16 @@ def _(rid, params: dict) -> dict:
             )
 
     return _err(rid, 4018, f"not a quick/plugin/skill command: {name}")
+
+
+@method("command.dispatch")
+def _(rid, params: dict) -> dict:
+    return _dispatch_tui_command(
+        rid,
+        name=params.get("name", ""),
+        arg=params.get("arg", ""),
+        session=_sessions.get(params.get("session_id", "")),
+    )
 
 
 # ── Methods: paste ────────────────────────────────────────────────────
@@ -9719,8 +9727,8 @@ def _(rid, params: dict) -> dict:
     if not cmd:
         return _err(rid, 4004, "empty command")
 
-    # Skill slash commands and _pending_input commands must NOT go through the
-    # slash worker — see _PENDING_INPUT_COMMANDS definition above. Plugin
+    # Skill slash commands and most _pending_input commands must NOT go through
+    # the slash worker — see _PENDING_INPUT_COMMANDS definition above. Plugin
     # commands must also avoid the worker, but unlike skills/pending-input they
     # still return normal slash.exec output so the TUI keeps the pager path.
     _cmd_text = cmd.lstrip("/") if cmd.startswith("/") else cmd
@@ -9729,6 +9737,13 @@ def _(rid, params: dict) -> dict:
     _cmd_arg = _cmd_parts[1] if len(_cmd_parts) > 1 else ""
 
     if _cmd_base in _PENDING_INPUT_COMMANDS:
+        if _cmd_base == "goal":
+            return _dispatch_tui_command(
+                rid,
+                name=_cmd_base,
+                arg=_cmd_arg,
+                session=session,
+            )
         return _err(
             rid, 4018, f"pending-input command: use command.dispatch for /{_cmd_base}"
         )


### PR DESCRIPTION
## Summary
- route TUI `/goal` slash commands through the same backend dispatcher used by `command.dispatch`
- keep the existing `4018` fallback for other pending-input slash commands
- add regression coverage for `/goal status` and `/goal <text>` through `slash.exec`

## Testing
- `pytest tests/tui_gateway/test_goal_command.py -q`
- `pytest tests/tui_gateway/test_protocol.py -q -k slash_exec_rejects_pending_input_commands`
- `ruff check tui_gateway/server.py tests/tui_gateway/test_goal_command.py`
- `git diff --check`

Closes #48848
