### PR TITLE
feat(terminal): add security risk annotations

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -610,6 +610,7 @@ def load_cli_config() -> Dict[str, Any]:
         "env_type": "TERMINAL_ENV",
         "cwd": "TERMINAL_CWD",
         "timeout": "TERMINAL_TIMEOUT",
+        "confirmation_policy": "TERMINAL_CONFIRMATION_POLICY",
         "home_mode": "TERMINAL_HOME_MODE",
         "lifetime_seconds": "TERMINAL_LIFETIME_SECONDS",
         "docker_image": "TERMINAL_DOCKER_IMAGE",

--- a/cli.py
+++ b/cli.py
@@ -652,6 +652,7 @@ def load_cli_config() -> Dict[str, Any]:
         "degraded_mode": "TERMINAL_DEGRADED_MODE",
         "cwd": "TERMINAL_CWD",
         "timeout": "TERMINAL_TIMEOUT",
+        "confirmation_policy": "TERMINAL_CONFIRMATION_POLICY",
         "home_mode": "TERMINAL_HOME_MODE",
         "lifetime_seconds": "TERMINAL_LIFETIME_SECONDS",
         "docker_image": "TERMINAL_DOCKER_IMAGE",

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1512,6 +1512,7 @@ if _config_path.exists():
                 "backend": "TERMINAL_ENV",
                 "cwd": "TERMINAL_CWD",
                 "timeout": "TERMINAL_TIMEOUT",
+                "confirmation_policy": "TERMINAL_CONFIRMATION_POLICY",
                 "home_mode": "TERMINAL_HOME_MODE",
                 "lifetime_seconds": "TERMINAL_LIFETIME_SECONDS",
                 "docker_image": "TERMINAL_DOCKER_IMAGE",

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2357,6 +2357,7 @@ if _config_path.exists():
                 "degraded_mode": "TERMINAL_DEGRADED_MODE",
                 "cwd": "TERMINAL_CWD",
                 "timeout": "TERMINAL_TIMEOUT",
+                "confirmation_policy": "TERMINAL_CONFIRMATION_POLICY",
                 "home_mode": "TERMINAL_HOME_MODE",
                 "lifetime_seconds": "TERMINAL_LIFETIME_SECONDS",
                 "docker_image": "TERMINAL_DOCKER_IMAGE",

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1178,6 +1178,11 @@ DEFAULT_CONFIG = {
         # window so it can't leak indefinitely. 0 disables escalation (SIGTERM
         # only — the historical behavior). Floored internally at 0.
         "daemon_term_grace_seconds": 2.0,
+        # Inline LLM risk annotations for terminal tool calls.
+        #   risky  — confirm only explicit HIGH/UNKNOWN risk annotations
+        #   always — confirm each distinct terminal command
+        #   never  — bypass approval prompts like --yolo / approvals.mode=off
+        "confirmation_policy": "risky",
         # Environment variables to pass through to sandboxed execution
         # (terminal and execute_code).  Skill-declared required_environment_variables
         # are passed through automatically; this list is for non-skill use cases.
@@ -6873,6 +6878,7 @@ TERMINAL_CONFIG_ENV_MAP = {
     "modal_mode": "TERMINAL_MODAL_MODE",
     "cwd": "TERMINAL_CWD",
     "timeout": "TERMINAL_TIMEOUT",
+    "confirmation_policy": "TERMINAL_CONFIRMATION_POLICY",
     "lifetime_seconds": "TERMINAL_LIFETIME_SECONDS",
     "docker_image": "TERMINAL_DOCKER_IMAGE",
     "docker_forward_env": "TERMINAL_DOCKER_FORWARD_ENV",

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1178,10 +1178,13 @@ DEFAULT_CONFIG = {
         # window so it can't leak indefinitely. 0 disables escalation (SIGTERM
         # only — the historical behavior). Floored internally at 0.
         "daemon_term_grace_seconds": 2.0,
-        # Inline LLM risk annotations for terminal tool calls.
-        #   risky  — confirm only explicit HIGH/UNKNOWN risk annotations
+        # Inline LLM risk annotations for terminal tool calls. These are
+        # advisory self-reports, not security scans: LOW/MEDIUM does not
+        # prove a command is safe, and deterministic guards still run.
+        #   risky  — confirm explicit HIGH/UNKNOWN advisory annotations
         #   always — confirm each distinct terminal command
-        #   never  — bypass approval prompts like --yolo / approvals.mode=off
+        #   never  — ignore annotation prompts in trusted environments;
+        #             hardline/sudo-stdin floors still apply
         "confirmation_policy": "risky",
         # Environment variables to pass through to sandboxed execution
         # (terminal and execute_code).  Skill-declared required_environment_variables

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -3642,6 +3642,7 @@ TERMINAL_CONFIG_ENV_MAP = {
     "cwd": "TERMINAL_CWD",
     "temp_dir": "TERMINAL_TEMP_DIR",
     "timeout": "TERMINAL_TIMEOUT",
+    "confirmation_policy": "TERMINAL_CONFIRMATION_POLICY",
     "lifetime_seconds": "TERMINAL_LIFETIME_SECONDS",
     "docker_image": "TERMINAL_DOCKER_IMAGE",
     "docker_forward_env": "TERMINAL_DOCKER_FORWARD_ENV",

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -400,6 +400,11 @@ DEFAULT_CONFIG = {
         # it here without patching the built desktop app.
         "font_family": "",
         "timeout": 180,
+        # Inline LLM risk annotations for terminal tool calls.
+        #   risky  — confirm only explicit HIGH/UNKNOWN risk annotations
+        #   always — confirm each distinct terminal command
+        #   never  — bypass ordinary prompts; deterministic safety floors remain
+        "confirmation_policy": "risky",
         # Bounded grace period (seconds) between SIGTERM and an escalated
         # SIGKILL when terminating a host process tree (browser daemons, etc.).
         # A daemon that stalls in its SIGTERM handler is force-killed after this

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -400,10 +400,13 @@ DEFAULT_CONFIG = {
         # it here without patching the built desktop app.
         "font_family": "",
         "timeout": 180,
-        # Inline LLM risk annotations for terminal tool calls.
-        #   risky  — confirm only explicit HIGH/UNKNOWN risk annotations
+        # Inline LLM risk annotations for terminal tool calls. These are
+        # advisory self-reports, not security scans: LOW/MEDIUM does not
+        # prove a command is safe, and deterministic guards still run.
+        #   risky  — confirm explicit HIGH/UNKNOWN advisory annotations
         #   always — confirm each distinct terminal command
-        #   never  — bypass ordinary prompts; deterministic safety floors remain
+        #   never  — ignore annotation prompts in trusted environments;
+        #             hardline/sudo-stdin floors still apply
         "confirmation_policy": "risky",
         # Bounded grace period (seconds) between SIGTERM and an escalated
         # SIGKILL when terminating a host process tree (browser daemons, etc.).

--- a/tests/hermes_cli/test_gateway_restart_loop.py
+++ b/tests/hermes_cli/test_gateway_restart_loop.py
@@ -351,7 +351,7 @@ class TestTerminalToolGatewayLifecycleGuard:
                 return {"output": "Active: running", "returncode": 0}
 
         self._patch_env(monkeypatch, _FakeEnv(), inside_gateway=True)
-        monkeypatch.setattr(tt, "_check_all_guards", lambda cmd, env, **kwargs: {"approved": True})
+        monkeypatch.setattr(tt, "_check_all_guards", lambda *args, **kwargs: {"approved": True})
 
         result = json.loads(tt.terminal_tool(command="systemctl status nginx"))
 
@@ -371,7 +371,7 @@ class TestTerminalToolGatewayLifecycleGuard:
                 return {"output": "restarting...", "returncode": 0}
 
         self._patch_env(monkeypatch, _FakeEnv(), inside_gateway=False)
-        monkeypatch.setattr(tt, "_check_all_guards", lambda cmd, env, **kwargs: {"approved": True})
+        monkeypatch.setattr(tt, "_check_all_guards", lambda *args, **kwargs: {"approved": True})
 
         result = json.loads(tt.terminal_tool(command="systemctl restart hermes-gateway"))
 

--- a/tests/tools/test_code_execution.py
+++ b/tests/tools/test_code_execution.py
@@ -92,6 +92,12 @@ class TestHermesToolsGeneration(unittest.TestCase):
         self.assertIn("def web_search(", src)
         self.assertNotIn("def read_file(", src)
 
+    def test_terminal_stub_passes_security_risk_annotation(self):
+        src = generate_hermes_tools_module(["terminal"])
+
+        self.assertIn("security_risk: str = None", src)
+        self.assertIn('"security_risk": security_risk', src)
+
     def test_empty_list_generates_nothing(self):
         src = generate_hermes_tools_module([])
         self.assertNotIn("def terminal(", src)

--- a/tests/tools/test_code_execution.py
+++ b/tests/tools/test_code_execution.py
@@ -128,6 +128,12 @@ class TestHermesToolsGeneration(unittest.TestCase):
             self.assertIn(f"def {tool}(", src)
 
 
+    def test_terminal_stub_passes_security_risk_annotation(self):
+        src = generate_hermes_tools_module(["terminal"])
+
+        self.assertIn("security_risk: str = None", src)
+        self.assertIn('"security_risk": security_risk', src)
+
     def test_empty_list_generates_nothing(self):
         src = generate_hermes_tools_module([])
         self.assertNotIn("def terminal(", src)

--- a/tests/tools/test_command_guards.py
+++ b/tests/tools/test_command_guards.py
@@ -126,6 +126,7 @@ class TestSecurityRiskAnnotation:
         assert result["approved"] is True
         cb.assert_called_once()
         assert "HIGH risk" in cb.call_args[0][1]
+        assert "advisory signal, not a security scan" in cb.call_args[0][1]
         assert cb.call_args[1]["allow_permanent"] is False
 
     @patch(_TIRITH_PATCH, return_value=_tirith_result("allow"))

--- a/tests/tools/test_command_guards.py
+++ b/tests/tools/test_command_guards.py
@@ -40,7 +40,13 @@ def _clean_state():
     approval_module._pending.clear()
     approval_module._permanent_approved.clear()
     saved = {}
-    for k in ("HERMES_INTERACTIVE", "HERMES_GATEWAY_SESSION", "HERMES_EXEC_ASK", "HERMES_YOLO_MODE"):
+    for k in (
+        "HERMES_INTERACTIVE",
+        "HERMES_GATEWAY_SESSION",
+        "HERMES_EXEC_ASK",
+        "HERMES_YOLO_MODE",
+        "TERMINAL_CONFIRMATION_POLICY",
+    ):
         if k in os.environ:
             saved[k] = os.environ.pop(k)
     yield
@@ -49,7 +55,13 @@ def _clean_state():
     approval_module._permanent_approved.clear()
     for k, v in saved.items():
         os.environ[k] = v
-    for k in ("HERMES_INTERACTIVE", "HERMES_GATEWAY_SESSION", "HERMES_EXEC_ASK", "HERMES_YOLO_MODE"):
+    for k in (
+        "HERMES_INTERACTIVE",
+        "HERMES_GATEWAY_SESSION",
+        "HERMES_EXEC_ASK",
+        "HERMES_YOLO_MODE",
+        "TERMINAL_CONFIRMATION_POLICY",
+    ):
         os.environ.pop(k, None)
 
 
@@ -91,6 +103,107 @@ class TestTirithAllowSafeCommand:
         result = check_all_command_guards("echo hello", "local")
         assert result["approved"] is True
         mock_tirith.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Optional LLM security_risk annotations
+# ---------------------------------------------------------------------------
+
+class TestSecurityRiskAnnotation:
+    @patch(_TIRITH_PATCH, return_value=_tirith_result("allow"))
+    def test_high_risk_annotation_prompts_through_existing_flow(self, mock_tirith):
+        os.environ["HERMES_INTERACTIVE"] = "1"
+        os.environ["TERMINAL_CONFIRMATION_POLICY"] = "risky"
+        cb = MagicMock(return_value="once")
+
+        result = check_all_command_guards(
+            "python scripts/deploy.py --prod",
+            "local",
+            approval_callback=cb,
+            security_risk="HIGH",
+        )
+
+        assert result["approved"] is True
+        cb.assert_called_once()
+        assert "HIGH risk" in cb.call_args[0][1]
+        assert cb.call_args[1]["allow_permanent"] is False
+
+    @patch(_TIRITH_PATCH, return_value=_tirith_result("allow"))
+    def test_low_and_medium_annotations_do_not_prompt(self, mock_tirith):
+        os.environ["HERMES_INTERACTIVE"] = "1"
+        os.environ["TERMINAL_CONFIRMATION_POLICY"] = "risky"
+        cb = MagicMock(return_value="deny")
+
+        assert check_all_command_guards(
+            "git status", "local", approval_callback=cb, security_risk="LOW"
+        )["approved"] is True
+        assert check_all_command_guards(
+            "python -m pytest tests/unit",
+            "local",
+            approval_callback=cb,
+            security_risk="MEDIUM",
+        )["approved"] is True
+        cb.assert_not_called()
+
+    @patch(_TIRITH_PATCH, return_value=_tirith_result("allow"))
+    def test_missing_annotation_falls_back_to_pattern_matching(self, mock_tirith):
+        os.environ["HERMES_INTERACTIVE"] = "1"
+        cb = MagicMock(return_value="deny")
+
+        result = check_all_command_guards(
+            "rm -rf /tmp/build-cache", "local", approval_callback=cb
+        )
+
+        assert result["approved"] is False
+        cb.assert_called_once()
+        assert cb.call_args[0][1]
+
+    @patch(_TIRITH_PATCH, return_value=_tirith_result("allow"))
+    def test_unknown_annotation_escalates(self, mock_tirith):
+        os.environ["HERMES_INTERACTIVE"] = "1"
+        cb = MagicMock(return_value="once")
+
+        result = check_all_command_guards(
+            "python scripts/migrate.py",
+            "local",
+            approval_callback=cb,
+            security_risk="not-a-level",
+        )
+
+        assert result["approved"] is True
+        cb.assert_called_once()
+        assert "UNKNOWN risk" in cb.call_args[0][1]
+
+    @patch(_TIRITH_PATCH, return_value=_tirith_result("warn", [{"rule_id": "x"}], "x"))
+    def test_never_policy_bypasses_prompt_checks_after_hardline_floor(self, mock_tirith):
+        os.environ["HERMES_INTERACTIVE"] = "1"
+        os.environ["TERMINAL_CONFIRMATION_POLICY"] = "never"
+        cb = MagicMock(return_value="deny")
+
+        result = check_all_command_guards(
+            "rm -rf /tmp/build-cache",
+            "local",
+            approval_callback=cb,
+            security_risk="HIGH",
+        )
+
+        assert result["approved"] is True
+        cb.assert_not_called()
+        mock_tirith.assert_not_called()
+
+    @patch(_TIRITH_PATCH, return_value=_tirith_result("allow"))
+    def test_always_policy_uses_command_specific_session_keys(self, mock_tirith):
+        os.environ["HERMES_INTERACTIVE"] = "1"
+        os.environ["TERMINAL_CONFIRMATION_POLICY"] = "always"
+        cb = MagicMock(return_value="session")
+
+        first = check_all_command_guards("echo first", "local", approval_callback=cb)
+        second = check_all_command_guards("echo second", "local", approval_callback=cb)
+
+        assert first["approved"] is True
+        assert second["approved"] is True
+        assert cb.call_count == 2
+        assert all(call.kwargs["allow_permanent"] is False for call in cb.mock_calls)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/tools/test_command_guards.py
+++ b/tests/tools/test_command_guards.py
@@ -136,6 +136,7 @@ class TestSecurityRiskAnnotation:
         assert result["approved"] is True
         cb.assert_called_once()
         assert "HIGH risk" in cb.call_args[0][1]
+        assert "advisory signal, not a security scan" in cb.call_args[0][1]
         assert cb.call_args[1]["allow_permanent"] is False
 
     @patch(_TIRITH_PATCH, return_value=_tirith_result("allow"))

--- a/tests/tools/test_command_guards.py
+++ b/tests/tools/test_command_guards.py
@@ -53,7 +53,13 @@ def _clean_state():
     approval_module._pending.clear()
     approval_module._permanent_approved.clear()
     saved = {}
-    for k in ("HERMES_INTERACTIVE", "HERMES_GATEWAY_SESSION", "HERMES_EXEC_ASK", "HERMES_YOLO_MODE"):
+    for k in (
+        "HERMES_INTERACTIVE",
+        "HERMES_GATEWAY_SESSION",
+        "HERMES_EXEC_ASK",
+        "HERMES_YOLO_MODE",
+        "TERMINAL_CONFIRMATION_POLICY",
+    ):
         if k in os.environ:
             saved[k] = os.environ.pop(k)
     yield
@@ -62,7 +68,13 @@ def _clean_state():
     approval_module._permanent_approved.clear()
     for k, v in saved.items():
         os.environ[k] = v
-    for k in ("HERMES_INTERACTIVE", "HERMES_GATEWAY_SESSION", "HERMES_EXEC_ASK", "HERMES_YOLO_MODE"):
+    for k in (
+        "HERMES_INTERACTIVE",
+        "HERMES_GATEWAY_SESSION",
+        "HERMES_EXEC_ASK",
+        "HERMES_YOLO_MODE",
+        "TERMINAL_CONFIRMATION_POLICY",
+    ):
         os.environ.pop(k, None)
 
 
@@ -101,6 +113,107 @@ class TestTirithAllowSafeCommand:
         result = check_all_command_guards("echo hello", "local")
         assert result["approved"] is True
         mock_tirith.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Optional LLM security_risk annotations
+# ---------------------------------------------------------------------------
+
+class TestSecurityRiskAnnotation:
+    @patch(_TIRITH_PATCH, return_value=_tirith_result("allow"))
+    def test_high_risk_annotation_prompts_through_existing_flow(self, mock_tirith):
+        os.environ["HERMES_INTERACTIVE"] = "1"
+        os.environ["TERMINAL_CONFIRMATION_POLICY"] = "risky"
+        cb = MagicMock(return_value="once")
+
+        result = check_all_command_guards(
+            "python scripts/deploy.py --prod",
+            "local",
+            approval_callback=cb,
+            security_risk="HIGH",
+        )
+
+        assert result["approved"] is True
+        cb.assert_called_once()
+        assert "HIGH risk" in cb.call_args[0][1]
+        assert cb.call_args[1]["allow_permanent"] is False
+
+    @patch(_TIRITH_PATCH, return_value=_tirith_result("allow"))
+    def test_low_and_medium_annotations_do_not_prompt(self, mock_tirith):
+        os.environ["HERMES_INTERACTIVE"] = "1"
+        os.environ["TERMINAL_CONFIRMATION_POLICY"] = "risky"
+        cb = MagicMock(return_value="deny")
+
+        assert check_all_command_guards(
+            "git status", "local", approval_callback=cb, security_risk="LOW"
+        )["approved"] is True
+        assert check_all_command_guards(
+            "python -m pytest tests/unit",
+            "local",
+            approval_callback=cb,
+            security_risk="MEDIUM",
+        )["approved"] is True
+        cb.assert_not_called()
+
+    @patch(_TIRITH_PATCH, return_value=_tirith_result("allow"))
+    def test_missing_annotation_falls_back_to_pattern_matching(self, mock_tirith):
+        os.environ["HERMES_INTERACTIVE"] = "1"
+        cb = MagicMock(return_value="deny")
+
+        result = check_all_command_guards(
+            "rm -rf /tmp/build-cache", "local", approval_callback=cb
+        )
+
+        assert result["approved"] is False
+        cb.assert_called_once()
+        assert cb.call_args[0][1]
+
+    @patch(_TIRITH_PATCH, return_value=_tirith_result("allow"))
+    def test_unknown_annotation_escalates(self, mock_tirith):
+        os.environ["HERMES_INTERACTIVE"] = "1"
+        cb = MagicMock(return_value="once")
+
+        result = check_all_command_guards(
+            "python scripts/migrate.py",
+            "local",
+            approval_callback=cb,
+            security_risk="not-a-level",
+        )
+
+        assert result["approved"] is True
+        cb.assert_called_once()
+        assert "UNKNOWN risk" in cb.call_args[0][1]
+
+    @patch(_TIRITH_PATCH, return_value=_tirith_result("warn", [{"rule_id": "x"}], "x"))
+    def test_never_policy_bypasses_prompt_checks_after_hardline_floor(self, mock_tirith):
+        os.environ["HERMES_INTERACTIVE"] = "1"
+        os.environ["TERMINAL_CONFIRMATION_POLICY"] = "never"
+        cb = MagicMock(return_value="deny")
+
+        result = check_all_command_guards(
+            "rm -rf /tmp/build-cache",
+            "local",
+            approval_callback=cb,
+            security_risk="HIGH",
+        )
+
+        assert result["approved"] is True
+        cb.assert_not_called()
+        mock_tirith.assert_not_called()
+
+    @patch(_TIRITH_PATCH, return_value=_tirith_result("allow"))
+    def test_always_policy_uses_command_specific_session_keys(self, mock_tirith):
+        os.environ["HERMES_INTERACTIVE"] = "1"
+        os.environ["TERMINAL_CONFIRMATION_POLICY"] = "always"
+        cb = MagicMock(return_value="session")
+
+        first = check_all_command_guards("echo first", "local", approval_callback=cb)
+        second = check_all_command_guards("echo second", "local", approval_callback=cb)
+
+        assert first["approved"] is True
+        assert second["approved"] is True
+        assert cb.call_count == 2
+        assert all(call.kwargs["allow_permanent"] is False for call in cb.mock_calls)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/tools/test_terminal_config_env_sync.py
+++ b/tests/tools/test_terminal_config_env_sync.py
@@ -322,3 +322,20 @@ def test_docker_forward_env_is_bridged_everywhere():
     assert "docker_forward_env" in _gateway_env_map_keys()
     assert "docker_forward_env" in _save_config_env_sync_keys()
     assert "TERMINAL_DOCKER_FORWARD_ENV" in _terminal_tool_env_var_names()
+
+
+def test_confirmation_policy_is_bridged_to_approval_guard():
+    """terminal.confirmation_policy feeds the approval guard via env.
+
+    Unlike backend/timeouts, this env var is consumed in tools.approval rather
+    than tools.terminal_tool, so pin it explicitly instead of relying on the
+    terminal_tool env-var scanner above.
+    """
+    import tools.approval as approval
+
+    source = inspect.getsource(approval)
+
+    assert "confirmation_policy" in _cli_env_map_keys()
+    assert "confirmation_policy" in _gateway_env_map_keys()
+    assert "confirmation_policy" in _save_config_env_sync_keys()
+    assert "TERMINAL_CONFIRMATION_POLICY" in source

--- a/tests/tools/test_terminal_task_cwd.py
+++ b/tests/tools/test_terminal_task_cwd.py
@@ -6,6 +6,10 @@ from types import SimpleNamespace
 import tools.terminal_tool as terminal_tool
 
 
+def _approve_guard(command, env_type, security_risk=None, has_host_access=False):
+    return {"approved": True}
+
+
 def _minimal_terminal_config(cwd="/default"):
     return {
         "env_type": "local",
@@ -34,7 +38,7 @@ def test_foreground_command_uses_registered_task_cwd_for_existing_environment(mo
     monkeypatch.setattr(
         terminal_tool,
         "_check_all_guards",
-        lambda command, env_type, **kwargs: {"approved": True},
+        _approve_guard,
     )
 
     result = json.loads(terminal_tool.terminal_tool(command="pwd", task_id=task_id))
@@ -61,7 +65,7 @@ def test_explicit_workdir_still_wins_over_registered_task_cwd(monkeypatch):
     monkeypatch.setattr(
         terminal_tool,
         "_check_all_guards",
-        lambda command, env_type, **kwargs: {"approved": True},
+        _approve_guard,
     )
 
     result = json.loads(
@@ -98,7 +102,7 @@ def test_foreground_command_prefers_live_env_cwd_over_init_time_cwd(monkeypatch)
     monkeypatch.setattr(
         terminal_tool,
         "_check_all_guards",
-        lambda command, env_type, **kwargs: {"approved": True},
+        _approve_guard,
     )
 
     result = json.loads(terminal_tool.terminal_tool(command="pwd", task_id=task_id))
@@ -136,7 +140,7 @@ def test_background_command_prefers_live_env_cwd_over_init_time_cwd(monkeypatch)
     monkeypatch.setattr(
         terminal_tool,
         "_check_all_guards",
-        lambda command, env_type, **kwargs: {"approved": True},
+        _approve_guard,
     )
     monkeypatch.setattr(process_registry_mod, "process_registry", registry)
 

--- a/tests/tools/test_terminal_task_cwd.py
+++ b/tests/tools/test_terminal_task_cwd.py
@@ -6,6 +6,10 @@ from types import SimpleNamespace
 import tools.terminal_tool as terminal_tool
 
 
+def _approve_guard(command, env_type, security_risk=None, has_host_access=False):
+    return {"approved": True}
+
+
 def _minimal_terminal_config(cwd="/default"):
     return {
         "env_type": "local",
@@ -34,7 +38,7 @@ def test_foreground_command_uses_registered_task_cwd_for_existing_environment(mo
     monkeypatch.setattr(
         terminal_tool,
         "_check_all_guards",
-        lambda command, env_type, **kwargs: {"approved": True},
+        _approve_guard,
     )
 
     result = json.loads(terminal_tool.terminal_tool(command="pwd", task_id=task_id))
@@ -61,7 +65,7 @@ def test_explicit_workdir_still_wins_over_registered_task_cwd(monkeypatch):
     monkeypatch.setattr(
         terminal_tool,
         "_check_all_guards",
-        lambda command, env_type, **kwargs: {"approved": True},
+        _approve_guard,
     )
 
     result = json.loads(
@@ -102,7 +106,7 @@ def test_explicit_workdir_does_not_persist_into_session_cwd(monkeypatch):
     monkeypatch.setattr(
         terminal_tool,
         "_check_all_guards",
-        lambda command, env_type, **kwargs: {"approved": True},
+        _approve_guard,
     )
     monkeypatch.setattr(
         terminal_tool,
@@ -146,7 +150,7 @@ def test_background_command_prefers_recorded_session_cwd_over_init_time_cwd(monk
     monkeypatch.setattr(
         terminal_tool,
         "_check_all_guards",
-        lambda command, env_type, **kwargs: {"approved": True},
+        _approve_guard,
     )
     monkeypatch.setattr(process_registry_mod, "process_registry", registry)
     terminal_tool.record_session_cwd(task_id, "/workspace/live")

--- a/tests/tools/test_terminal_tool.py
+++ b/tests/tools/test_terminal_tool.py
@@ -37,7 +37,11 @@ def test_terminal_schema_exposes_optional_security_risk_annotation():
     assert "security_risk" in props
     assert props["security_risk"]["enum"] == ["LOW", "MEDIUM", "HIGH", "UNKNOWN"]
     assert "security_risk" not in schema["required"]
-    assert "Optional but recommended" in props["security_risk"]["description"]
+    description = props["security_risk"]["description"]
+    assert "Optional but recommended" in description
+    assert "not a security scan" in description
+    assert "LOW/MEDIUM are not proof" in description
+    assert "trusted environments can set that policy to never" in description
 
 
 def test_printf_literal_sudo_does_not_trigger_rewrite(monkeypatch):

--- a/tests/tools/test_terminal_tool.py
+++ b/tests/tools/test_terminal_tool.py
@@ -30,6 +30,16 @@ def test_terminal_schema_advertises_persistent_env_state():
     assert "do not re-source the same environment before every command" in description
 
 
+def test_terminal_schema_exposes_optional_security_risk_annotation():
+    schema = terminal_tool.TERMINAL_SCHEMA["parameters"]
+    props = schema["properties"]
+
+    assert "security_risk" in props
+    assert props["security_risk"]["enum"] == ["LOW", "MEDIUM", "HIGH", "UNKNOWN"]
+    assert "security_risk" not in schema["required"]
+    assert "Optional but recommended" in props["security_risk"]["description"]
+
+
 def test_printf_literal_sudo_does_not_trigger_rewrite(monkeypatch):
     monkeypatch.delenv("SUDO_PASSWORD", raising=False)
     monkeypatch.delenv("HERMES_INTERACTIVE", raising=False)

--- a/tests/tools/test_terminal_tool.py
+++ b/tests/tools/test_terminal_tool.py
@@ -30,6 +30,16 @@ def test_terminal_schema_advertises_persistent_env_state():
     assert "once per session" in description
 
 
+def test_terminal_schema_exposes_optional_security_risk_annotation():
+    schema = terminal_tool.TERMINAL_SCHEMA["parameters"]
+    props = schema["properties"]
+
+    assert "security_risk" in props
+    assert props["security_risk"]["enum"] == ["LOW", "MEDIUM", "HIGH", "UNKNOWN"]
+    assert "security_risk" not in schema["required"]
+    assert "Optional but recommended" in props["security_risk"]["description"]
+
+
 def test_printf_literal_sudo_does_not_trigger_rewrite(monkeypatch):
     monkeypatch.delenv("SUDO_PASSWORD", raising=False)
     monkeypatch.delenv("HERMES_INTERACTIVE", raising=False)

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -1914,6 +1914,68 @@ def _normalize_approval_mode(mode) -> str:
     return "manual"
 
 
+def _normalize_terminal_confirmation_policy(policy) -> str:
+    """Normalize terminal.confirmation_policy / TERMINAL_CONFIRMATION_POLICY."""
+    if isinstance(policy, str):
+        normalized = policy.strip().lower()
+        if normalized in {"never", "risky", "always"}:
+            return normalized
+    return "risky"
+
+
+def _get_terminal_confirmation_policy() -> str:
+    """Read the terminal risk-annotation confirmation policy from env.
+
+    The config bridge sets TERMINAL_CONFIRMATION_POLICY at startup so the
+    hot path does not need to parse config.yaml for every terminal command.
+    """
+    return _normalize_terminal_confirmation_policy(
+        os.getenv("TERMINAL_CONFIRMATION_POLICY", "risky")
+    )
+
+
+def _normalize_security_risk(security_risk) -> Optional[str]:
+    """Normalize optional LLM-provided terminal security_risk annotations."""
+    if security_risk is None:
+        return None
+    if isinstance(security_risk, str):
+        normalized = security_risk.strip().upper()
+        if normalized in {"LOW", "MEDIUM", "HIGH", "UNKNOWN"}:
+            return normalized
+    return "UNKNOWN"
+
+
+def _terminal_policy_key(prefix: str, command: str) -> str:
+    digest = hashlib.sha256((command or "").encode("utf-8", "replace")).hexdigest()
+    return f"terminal:{prefix}:{digest[:16]}"
+
+
+def _security_risk_warning(command: str, security_risk,
+                           confirmation_policy: str) -> tuple[str, str] | None:
+    """Return an approval warning for LLM risk annotations, if policy requires it."""
+    normalized_risk = _normalize_security_risk(security_risk)
+
+    if confirmation_policy == "always":
+        return (
+            _terminal_policy_key("always", command),
+            "terminal confirmation policy requires approval for this command",
+        )
+
+    if confirmation_policy != "risky":
+        return None
+
+    # Missing annotation stays backwards-compatible: existing pattern/Tirith
+    # checks remain the fallback. Explicit UNKNOWN/invalid annotations are
+    # treated as uncertain and escalated.
+    if normalized_risk in {"HIGH", "UNKNOWN"}:
+        return (
+            _terminal_policy_key(f"risk:{normalized_risk.lower()}", command),
+            f"LLM self-annotation marked this terminal command {normalized_risk} risk",
+        )
+
+    return None
+
+
 def _get_approval_config() -> dict:
     """Read the approvals config block. Returns a dict with 'mode', 'timeout', etc."""
     try:
@@ -2634,7 +2696,8 @@ def _await_gateway_decision(session_key: str, notify_cb, approval_data: dict,
 
 def check_all_command_guards(command: str, env_type: str,
                              approval_callback=None,
-                             has_host_access: bool = False) -> dict:
+                             has_host_access: bool = False,
+                             security_risk=None) -> dict:
     """Run all pre-exec security checks and return a single approval decision.
 
     Gathers findings from tirith and dangerous-command detection, then
@@ -2680,10 +2743,18 @@ def check_all_command_guards(command: str, env_type: str,
                        deny_pattern, command[:200])
         return _user_deny_block_result(deny_pattern)
 
-    # --yolo or approvals.mode=off: bypass all approval prompts.
+    # --yolo / approvals.mode=off / confirmation_policy=never:
+    # bypass all approval prompts. Hardline and sudo-stdin guards above still
+    # apply because those are unconditional safety floors.
     # Gateway /yolo is session-scoped; CLI --yolo remains process-scoped.
     approval_mode = _get_approval_mode()
-    if _YOLO_MODE_FROZEN or is_current_session_yolo_enabled() or approval_mode == "off":
+    confirmation_policy = _get_terminal_confirmation_policy()
+    if (
+        _YOLO_MODE_FROZEN
+        or is_current_session_yolo_enabled()
+        or approval_mode == "off"
+        or confirmation_policy == "never"
+    ):
         return {"approved": True, "message": None}
 
     if _command_matches_permanent_allowlist(command):
@@ -2811,7 +2882,7 @@ def check_all_command_guards(command: str, env_type: str,
     # --- Phase 2: Decide ---
 
     # Collect warnings that need approval
-    warnings = []  # list of (pattern_key, description, is_tirith)
+    warnings = []  # list of (pattern_key, description, allow_permanent)
 
     session_key = get_current_session_key()
 
@@ -2825,11 +2896,19 @@ def check_all_command_guards(command: str, env_type: str,
         tirith_key = f"tirith:{rule_id}"
         tirith_desc = _format_tirith_description(tirith_result)
         if not is_approved(session_key, tirith_key):
-            warnings.append((tirith_key, tirith_desc, True))
+            warnings.append((tirith_key, tirith_desc, False))
 
     if is_dangerous:
         if not is_approved(session_key, pattern_key):
-            warnings.append((pattern_key, description, False))
+            warnings.append((pattern_key, description, True))
+
+    risk_warning = _security_risk_warning(
+        command, security_risk, confirmation_policy
+    )
+    if risk_warning is not None:
+        risk_key, risk_desc = risk_warning
+        if not is_approved(session_key, risk_key):
+            warnings.append((risk_key, risk_desc, False))
 
     # Nothing to warn about
     if not warnings:
@@ -2878,7 +2957,7 @@ def check_all_command_guards(command: str, env_type: str,
     combined_desc = "; ".join(desc for _, desc, _ in warnings)
     primary_key = warnings[0][0]
     all_keys = [key for key, _, _ in warnings]
-    has_tirith = any(is_t for _, _, is_t in warnings)
+    allow_permanent = all(allow for _, _, allow in warnings)
 
     # Gateway/async approval — block the agent thread until the user
     # responds with /approve or /deny, mirroring the CLI's synchronous
@@ -2909,7 +2988,9 @@ def check_all_command_guards(command: str, env_type: str,
                 "description": redact_sensitive_text(combined_desc),
                 # Smart DENY overrides are one-operation decisions, so the UI
                 # must not offer a permanent scope.
-                "allow_permanent": not has_tirith and not smart_denied_for_owner,
+                # This also keeps input-specific warnings (Tirith and LLM risk
+                # annotations) from being permanently allowlisted.
+                "allow_permanent": allow_permanent and not smart_denied_for_owner,
             }
             if smart_denied_for_owner:
                 approval_data["smart_denied"] = True
@@ -2969,8 +3050,8 @@ def check_all_command_guards(command: str, env_type: str,
             # older client returns "session" or "always". Manual and ESCALATE
             # choices retain their existing persistence semantics.
             if not smart_denied_for_owner:
-                for key, _, is_tirith in warnings:
-                    if choice == "session" or (choice == "always" and is_tirith):
+                for key, _, can_permanently_allow in warnings:
+                    if choice == "session" or (choice == "always" and not can_permanently_allow):
                         approve_session(session_key, key)
                     elif choice == "always":
                         approve_session(session_key, key)
@@ -3025,7 +3106,7 @@ def check_all_command_guards(command: str, env_type: str,
     choice = prompt_dangerous_approval(
         command,
         combined_desc,
-        allow_permanent=not has_tirith and not smart_denied_for_owner,
+        allow_permanent=allow_permanent and not smart_denied_for_owner,
         smart_denied=smart_denied_for_owner,
         approval_callback=approval_callback,
     )
@@ -3060,8 +3141,8 @@ def check_all_command_guards(command: str, env_type: str,
     # Smart-DENY owner overrides are one-operation scoped. Preserve existing
     # persistence for manual mode and smart ESCALATE.
     if not smart_denied_for_owner:
-        for key, _, is_tirith in warnings:
-            if choice == "session" or (choice == "always" and is_tirith):
+        for key, _, can_permanently_allow in warnings:
+            if choice == "session" or (choice == "always" and not can_permanently_allow):
                 # tirith: session only (no permanent broad allowlisting)
                 approve_session(session_key, key)
             elif choice == "always":

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -1952,7 +1952,7 @@ def _terminal_policy_key(prefix: str, command: str) -> str:
 
 def _security_risk_warning(command: str, security_risk,
                            confirmation_policy: str) -> tuple[str, str] | None:
-    """Return an approval warning for LLM risk annotations, if policy requires it."""
+    """Return an advisory approval warning for LLM risk annotations."""
     normalized_risk = _normalize_security_risk(security_risk)
 
     if confirmation_policy == "always":
@@ -1970,7 +1970,10 @@ def _security_risk_warning(command: str, security_risk,
     if normalized_risk in {"HIGH", "UNKNOWN"}:
         return (
             _terminal_policy_key(f"risk:{normalized_risk.lower()}", command),
-            f"LLM self-annotation marked this terminal command {normalized_risk} risk",
+            (
+                "LLM self-annotation marked this terminal command "
+                f"{normalized_risk} risk (advisory signal, not a security scan)"
+            ),
         )
 
     return None

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -3434,7 +3434,7 @@ def _terminal_policy_key(prefix: str, command: str) -> str:
 
 def _security_risk_warning(command: str, security_risk,
                            confirmation_policy: str) -> tuple[str, str] | None:
-    """Return an approval warning for LLM risk annotations, if policy requires it."""
+    """Return an advisory approval warning for LLM risk annotations."""
     normalized_risk = _normalize_security_risk(security_risk)
 
     if confirmation_policy == "always":
@@ -3452,7 +3452,10 @@ def _security_risk_warning(command: str, security_risk,
     if normalized_risk in {"HIGH", "UNKNOWN"}:
         return (
             _terminal_policy_key(f"risk:{normalized_risk.lower()}", command),
-            f"LLM self-annotation marked this terminal command {normalized_risk} risk",
+            (
+                "LLM self-annotation marked this terminal command "
+                f"{normalized_risk} risk (advisory signal, not a security scan)"
+            ),
         )
 
     return None

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -3396,6 +3396,68 @@ def _normalize_approval_mode(mode) -> str:
     return "manual"
 
 
+def _normalize_terminal_confirmation_policy(policy) -> str:
+    """Normalize terminal.confirmation_policy / TERMINAL_CONFIRMATION_POLICY."""
+    if isinstance(policy, str):
+        normalized = policy.strip().lower()
+        if normalized in {"never", "risky", "always"}:
+            return normalized
+    return "risky"
+
+
+def _get_terminal_confirmation_policy() -> str:
+    """Read the terminal risk-annotation confirmation policy from env.
+
+    The config bridge sets TERMINAL_CONFIRMATION_POLICY at startup so the
+    hot path does not need to parse config.yaml for every terminal command.
+    """
+    return _normalize_terminal_confirmation_policy(
+        os.getenv("TERMINAL_CONFIRMATION_POLICY", "risky")
+    )
+
+
+def _normalize_security_risk(security_risk) -> Optional[str]:
+    """Normalize optional LLM-provided terminal security_risk annotations."""
+    if security_risk is None:
+        return None
+    if isinstance(security_risk, str):
+        normalized = security_risk.strip().upper()
+        if normalized in {"LOW", "MEDIUM", "HIGH", "UNKNOWN"}:
+            return normalized
+    return "UNKNOWN"
+
+
+def _terminal_policy_key(prefix: str, command: str) -> str:
+    digest = hashlib.sha256((command or "").encode("utf-8", "replace")).hexdigest()
+    return f"terminal:{prefix}:{digest[:16]}"
+
+
+def _security_risk_warning(command: str, security_risk,
+                           confirmation_policy: str) -> tuple[str, str] | None:
+    """Return an approval warning for LLM risk annotations, if policy requires it."""
+    normalized_risk = _normalize_security_risk(security_risk)
+
+    if confirmation_policy == "always":
+        return (
+            _terminal_policy_key("always", command),
+            "terminal confirmation policy requires approval for this command",
+        )
+
+    if confirmation_policy != "risky":
+        return None
+
+    # Missing annotation stays backwards-compatible: existing pattern/Tirith
+    # checks remain the fallback. Explicit UNKNOWN/invalid annotations are
+    # treated as uncertain and escalated.
+    if normalized_risk in {"HIGH", "UNKNOWN"}:
+        return (
+            _terminal_policy_key(f"risk:{normalized_risk.lower()}", command),
+            f"LLM self-annotation marked this terminal command {normalized_risk} risk",
+        )
+
+    return None
+
+
 def _get_approval_config() -> dict:
     """Read the approvals config block. Returns a dict with 'mode', 'timeout', etc.
 
@@ -4643,7 +4705,8 @@ def _await_gateway_decision(session_key: str, notify_cb, approval_data: dict,
 
 def check_all_command_guards(command: str, env_type: str,
                              approval_callback=None,
-                             has_host_access: bool = False) -> dict:
+                             has_host_access: bool = False,
+                             security_risk=None) -> dict:
     """Run all pre-exec security checks and return a single approval decision.
 
     Gathers findings from tirith and dangerous-command detection, then
@@ -4689,10 +4752,18 @@ def check_all_command_guards(command: str, env_type: str,
                        deny_pattern, command[:200])
         return _user_deny_block_result(deny_pattern)
 
-    # --yolo or approvals.mode=off: bypass all approval prompts.
+    # --yolo / approvals.mode=off / confirmation_policy=never:
+    # bypass all approval prompts. Hardline and sudo-stdin guards above still
+    # apply because those are unconditional safety floors.
     # Gateway /yolo is session-scoped; CLI --yolo remains process-scoped.
     approval_mode = _get_approval_mode()
-    if _YOLO_MODE_FROZEN or is_current_session_yolo_enabled() or approval_mode == "off":
+    confirmation_policy = _get_terminal_confirmation_policy()
+    if (
+        _YOLO_MODE_FROZEN
+        or is_current_session_yolo_enabled()
+        or approval_mode == "off"
+        or confirmation_policy == "never"
+    ):
         return {"approved": True, "message": None}
 
     if _command_matches_permanent_allowlist(command):
@@ -4900,7 +4971,7 @@ def check_all_command_guards(command: str, env_type: str,
     # --- Phase 2: Decide ---
 
     # Collect warnings that need approval
-    warnings = []  # list of (pattern_key, description, is_tirith)
+    warnings = []  # list of (pattern_key, description, allow_permanent)
 
     session_key = get_current_session_key()
 
@@ -4914,11 +4985,19 @@ def check_all_command_guards(command: str, env_type: str,
         tirith_key = f"tirith:{rule_id}"
         tirith_desc = _format_tirith_description(tirith_result)
         if not is_approved(session_key, tirith_key):
-            warnings.append((tirith_key, tirith_desc, True))
+            warnings.append((tirith_key, tirith_desc, False))
 
     if is_dangerous:
         if not is_approved(session_key, pattern_key):
-            warnings.append((pattern_key, description, False))
+            warnings.append((pattern_key, description, True))
+
+    risk_warning = _security_risk_warning(
+        command, security_risk, confirmation_policy
+    )
+    if risk_warning is not None:
+        risk_key, risk_desc = risk_warning
+        if not is_approved(session_key, risk_key):
+            warnings.append((risk_key, risk_desc, False))
 
     # Nothing to warn about
     if not warnings:
@@ -4975,15 +5054,11 @@ def check_all_command_guards(command: str, env_type: str,
     combined_desc = "; ".join(desc for _, desc, _ in warnings)
     primary_key = warnings[0][0]
     all_keys = [key for key, _, _ in warnings]
-    # "Always" is offered when at least one warning is a dangerous-pattern
-    # key that the persistence layer would actually allowlist permanently.
-    # Pure-tirith findings are session-max by design (no broad permanent
-    # allowlisting of content-level security findings), so a prompt with
-    # ONLY tirith warnings keeps Always hidden.  Mixed prompts (pattern +
-    # tirith) previously hid Always too, even though choosing it would
-    # correctly persist the pattern key and downgrade the tirith key to
-    # session — the UI was stricter than the persistence layer.
-    has_permanent_capable = any(not is_t for _, _, is_t in warnings)
+    # "Always" is offered when at least one warning can actually be persisted.
+    # Input-scoped findings (Tirith and LLM risk annotations) remain session-max;
+    # mixed prompts can still persist a dangerous-pattern key while downgrading
+    # input-scoped keys to session approval.
+    has_permanent_capable = any(can_persist for _, _, can_persist in warnings)
 
     # An explicitly selected plugin transport replaces every built-in prompt
     # surface (CLI/TUI/gateway/ACP). Detection, allowed scopes, persistence,
@@ -5032,9 +5107,9 @@ def check_all_command_guards(command: str, env_type: str,
                     "user_consent": False,
                 }
             if not smart_denied_for_owner:
-                for key, _, is_tirith in warnings:
+                for key, _, can_permanently_allow in warnings:
                     if transport_choice == "session" or (
-                        transport_choice == "always" and is_tirith
+                        transport_choice == "always" and not can_permanently_allow
                     ):
                         approve_session(session_key, key)
                     elif transport_choice == "always":
@@ -5078,12 +5153,12 @@ def check_all_command_guards(command: str, env_type: str,
                 "description": redact_sensitive_text(combined_desc),
                 # Smart DENY overrides are one-operation decisions, so the UI
                 # must not offer a permanent scope.  Otherwise offer Always
-                # whenever any dangerous-pattern warning can actually be
-                # persisted (pure-tirith prompts stay session-max).
+                # whenever any warning can actually be persisted; input-scoped
+                # findings remain capped at session approval.
                 "allow_permanent": has_permanent_capable and not smart_denied_for_owner,
                 # Session approval is safe for every non-Smart-DENY prompt —
-                # including pure-tirith ones, where the persistence layer
-                # already caps scope at session. Adapters use this to render
+                # including input-scoped ones, where the persistence layer
+                # caps scope at session. Adapters use this to render
                 # a session tier independently of the permanent tier.
                 "allow_session": not smart_denied_for_owner,
             }
@@ -5148,8 +5223,8 @@ def check_all_command_guards(command: str, env_type: str,
             # older client returns "session" or "always". Manual and ESCALATE
             # choices retain their existing persistence semantics.
             if not smart_denied_for_owner:
-                for key, _, is_tirith in warnings:
-                    if choice == "session" or (choice == "always" and is_tirith):
+                for key, _, can_permanently_allow in warnings:
+                    if choice == "session" or (choice == "always" and not can_permanently_allow):
                         approve_session(session_key, key)
                     elif choice == "always":
                         approve_session(session_key, key)
@@ -5275,9 +5350,9 @@ def check_all_command_guards(command: str, env_type: str,
     # Smart-DENY owner overrides are one-operation scoped. Preserve existing
     # persistence for manual mode and smart ESCALATE.
     if not smart_denied_for_owner:
-        for key, _, is_tirith in warnings:
-            if choice == "session" or (choice == "always" and is_tirith):
-                # tirith: session only (no permanent broad allowlisting)
+        for key, _, can_permanently_allow in warnings:
+            if choice == "session" or (choice == "always" and not can_permanently_allow):
+                # Input-scoped findings stay session-only.
                 approve_session(session_key, key)
             elif choice == "always":
                 # dangerous patterns: permanent allowed

--- a/tools/code_execution_tool.py
+++ b/tools/code_execution_tool.py
@@ -1795,7 +1795,9 @@ _TOOL_DOC_LINES = [
      "    Replaces old_string with new_string in the file."),
     ("terminal",
      "  terminal(command: str, timeout=None, workdir=None, security_risk=None) -> dict\n"
-     "    Foreground only (no background/pty). security_risk is optional: LOW/MEDIUM/HIGH/UNKNOWN. Returns {\"output\": \"...\", \"exit_code\": N}"),
+     "    Foreground only (no background/pty). security_risk is an optional "
+     "advisory self-annotation, not a security scan: LOW/MEDIUM/HIGH/UNKNOWN. "
+     "Returns {\"output\": \"...\", \"exit_code\": N}"),
 ]
 
 

--- a/tools/code_execution_tool.py
+++ b/tools/code_execution_tool.py
@@ -259,9 +259,9 @@ _TOOL_STUBS = {
     ),
     "terminal": (
         "terminal",
-        "command: str, timeout: int = None, workdir: str = None",
+        "command: str, timeout: int = None, workdir: str = None, security_risk: str = None",
         '"""Run a shell command (foreground only). Returns dict with "output" and "exit_code"."""',
-        '{"command": command, "timeout": timeout, "workdir": workdir}',
+        '{"command": command, "timeout": timeout, "workdir": workdir, "security_risk": security_risk}',
     ),
 }
 
@@ -1794,8 +1794,8 @@ _TOOL_DOC_LINES = [
      "  patch(path: str, old_string: str, new_string: str, replace_all: bool = False) -> dict\n"
      "    Replaces old_string with new_string in the file."),
     ("terminal",
-     "  terminal(command: str, timeout=None, workdir=None) -> dict\n"
-     "    Foreground only (no background/pty). Returns {\"output\": \"...\", \"exit_code\": N}"),
+     "  terminal(command: str, timeout=None, workdir=None, security_risk=None) -> dict\n"
+     "    Foreground only (no background/pty). security_risk is optional: LOW/MEDIUM/HIGH/UNKNOWN. Returns {\"output\": \"...\", \"exit_code\": N}"),
 ]
 
 

--- a/tools/code_execution_tool.py
+++ b/tools/code_execution_tool.py
@@ -420,9 +420,9 @@ _TOOL_STUBS = {
     ),
     "terminal": (
         "terminal",
-        "command: str, timeout: int = None, workdir: str = None",
+        "command: str, timeout: int = None, workdir: str = None, security_risk: str = None",
         '"""Run a shell command (foreground only). Returns dict with "output" and "exit_code"."""',
-        '{"command": command, "timeout": timeout, "workdir": workdir}',
+        '{"command": command, "timeout": timeout, "workdir": workdir, "security_risk": security_risk}',
     ),
 }
 
@@ -2320,8 +2320,8 @@ _TOOL_DOC_LINES = [
      "  patch(path: str, old_string: str, new_string: str, replace_all: bool = False) -> dict\n"
      "    Replaces old_string with new_string in the file."),
     ("terminal",
-     "  terminal(command: str, timeout=None, workdir=None) -> dict\n"
-     "    Foreground only (no background/pty). Returns {\"output\": \"...\", \"exit_code\": N}"),
+     "  terminal(command: str, timeout=None, workdir=None, security_risk=None) -> dict\n"
+     "    Foreground only (no background/pty). security_risk is optional: LOW/MEDIUM/HIGH/UNKNOWN. Returns {\"output\": \"...\", \"exit_code\": N}"),
 ]
 
 

--- a/tools/code_execution_tool.py
+++ b/tools/code_execution_tool.py
@@ -2321,7 +2321,9 @@ _TOOL_DOC_LINES = [
      "    Replaces old_string with new_string in the file."),
     ("terminal",
      "  terminal(command: str, timeout=None, workdir=None, security_risk=None) -> dict\n"
-     "    Foreground only (no background/pty). security_risk is optional: LOW/MEDIUM/HIGH/UNKNOWN. Returns {\"output\": \"...\", \"exit_code\": N}"),
+     "    Foreground only (no background/pty). security_risk is an optional "
+     "advisory self-annotation, not a security scan: LOW/MEDIUM/HIGH/UNKNOWN. "
+     "Returns {\"output\": \"...\", \"exit_code\": N}"),
 ]
 
 

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -279,11 +279,13 @@ def _docker_has_host_access(config: Dict[str, Any]) -> bool:
 
 
 def _check_all_guards(command: str, env_type: str,
+                      security_risk: Optional[str] = None,
                       has_host_access: bool = False) -> dict:
     """Delegate to consolidated guard (tirith + dangerous cmd) with CLI callback."""
     return _check_all_guards_impl(command, env_type,
                                   approval_callback=_get_approval_callback(),
-                                  has_host_access=has_host_access)
+                                  has_host_access=has_host_access,
+                                  security_risk=security_risk)
 
 
 # Allowlist: characters that can legitimately appear in directory paths.
@@ -2036,6 +2038,7 @@ def terminal_tool(
     pty: bool = False,
     notify_on_complete: bool = False,
     watch_patterns: Optional[List[str]] = None,
+    security_risk: Optional[str] = None,
 ) -> str:
     """
     Execute a command in the configured terminal environment.
@@ -2051,6 +2054,7 @@ def terminal_tool(
         pty: If True, use pseudo-terminal for interactive CLI tools (local backend only)
         notify_on_complete: If True and background=True, you'll be notified exactly once when the process exits. The right choice for almost every long task. MUTUALLY EXCLUSIVE with watch_patterns.
         watch_patterns: List of strings to watch for in background output. HARD rate limit: 1 notification per 15s per process. After 3 strike windows in a row, watch_patterns is disabled and the session is auto-promoted to notify_on_complete. Use ONLY for rare, one-shot mid-process signals on long-lived processes (server readiness, migration-done markers). NEVER use in loops/batch jobs — error patterns there will hit the strike limit and get disabled. MUTUALLY EXCLUSIVE with notify_on_complete — set one, not both.
+        security_risk: Optional LLM self-annotation: LOW, MEDIUM, HIGH, or UNKNOWN.
 
     Returns:
         str: JSON string with output, exit_code, and error fields
@@ -2299,6 +2303,7 @@ def terminal_tool(
         if not force:
             approval = _check_all_guards(
                 command, env_type,
+                security_risk=security_risk,
                 has_host_access=_docker_has_host_access(config),
             )
             if not approval["approved"]:
@@ -3030,6 +3035,11 @@ TERMINAL_SCHEMA = {
                 "type": "array",
                 "items": {"type": "string"},
                 "description": "Strings to watch for in background process output. HARD RATE LIMIT: at most 1 notification per 15 seconds per process — matches arriving inside the cooldown are dropped. After 3 consecutive 15-second windows with dropped matches, watch_patterns is automatically disabled for that process and promoted to notify_on_complete behavior (one notification on exit, no more mid-process spam). USE ONLY for truly rare, one-shot mid-process signals on LONG-LIVED processes that will never exit on their own — e.g. ['Application startup complete'] on a server so you know when to hit its endpoint, or ['migration done'] on a daemon. DO NOT use for: (1) end-of-run markers like 'DONE'/'PASS' — use notify_on_complete instead; (2) error patterns like 'ERROR'/'Traceback' in loops or multi-item batch jobs — they fire on every iteration and you'll hit the strike limit fast; (3) anything you'd ever combine with notify_on_complete. When in doubt, choose notify_on_complete. MUTUALLY EXCLUSIVE with notify_on_complete — set one, not both."
+            },
+            "security_risk": {
+                "type": "string",
+                "enum": ["LOW", "MEDIUM", "HIGH", "UNKNOWN"],
+                "description": "Optional but recommended LLM self-annotation for this command's security risk. LOW = read-only or inspection-only commands. MEDIUM = project-scoped changes such as builds, installs, edits, or tests. HIGH = destructive/system-level changes, credential exposure, privileged operations, or data leaving the environment. UNKNOWN = uncertain risk; prefer UNKNOWN over under-classifying. HIGH/UNKNOWN may trigger the existing approval flow depending on terminal.confirmation_policy.",
             }
         },
         "required": ["command"]
@@ -3048,6 +3058,7 @@ def _handle_terminal(args, **kw):
         pty=args.get("pty", False),
         notify_on_complete=args.get("notify_on_complete", False),
         watch_patterns=args.get("watch_patterns"),
+        security_risk=args.get("security_risk"),
     )
 
 

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -2054,7 +2054,8 @@ def terminal_tool(
         pty: If True, use pseudo-terminal for interactive CLI tools (local backend only)
         notify_on_complete: If True and background=True, you'll be notified exactly once when the process exits. The right choice for almost every long task. MUTUALLY EXCLUSIVE with watch_patterns.
         watch_patterns: List of strings to watch for in background output. HARD rate limit: 1 notification per 15s per process. After 3 strike windows in a row, watch_patterns is disabled and the session is auto-promoted to notify_on_complete. Use ONLY for rare, one-shot mid-process signals on long-lived processes (server readiness, migration-done markers). NEVER use in loops/batch jobs — error patterns there will hit the strike limit and get disabled. MUTUALLY EXCLUSIVE with notify_on_complete — set one, not both.
-        security_risk: Optional LLM self-annotation: LOW, MEDIUM, HIGH, or UNKNOWN.
+        security_risk: Optional advisory LLM self-annotation: LOW, MEDIUM,
+            HIGH, or UNKNOWN. This is not a security scan.
 
     Returns:
         str: JSON string with output, exit_code, and error fields
@@ -3039,7 +3040,20 @@ TERMINAL_SCHEMA = {
             "security_risk": {
                 "type": "string",
                 "enum": ["LOW", "MEDIUM", "HIGH", "UNKNOWN"],
-                "description": "Optional but recommended LLM self-annotation for this command's security risk. LOW = read-only or inspection-only commands. MEDIUM = project-scoped changes such as builds, installs, edits, or tests. HIGH = destructive/system-level changes, credential exposure, privileged operations, or data leaving the environment. UNKNOWN = uncertain risk; prefer UNKNOWN over under-classifying. HIGH/UNKNOWN may trigger the existing approval flow depending on terminal.confirmation_policy.",
+                "description": (
+                    "Optional but recommended advisory LLM self-annotation for this "
+                    "command's security risk. This is not a security scan or an "
+                    "authoritative safety decision: LOW/MEDIUM are not proof that a "
+                    "command is safe, and deterministic guards still run separately. "
+                    "LOW = read-only or inspection-only commands. MEDIUM = "
+                    "project-scoped changes such as builds, installs, edits, or "
+                    "tests. HIGH = destructive/system-level changes, credential "
+                    "exposure, privileged operations, or data leaving the environment. "
+                    "UNKNOWN = uncertain risk; prefer UNKNOWN over under-classifying. "
+                    "HIGH/UNKNOWN may trigger the existing approval flow depending on "
+                    "terminal.confirmation_policy; trusted environments can set that "
+                    "policy to never while hardline guards still apply."
+                ),
             }
         },
         "required": ["command"]

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -382,11 +382,13 @@ def _docker_has_host_access(config: Dict[str, Any]) -> bool:
 
 
 def _check_all_guards(command: str, env_type: str,
+                      security_risk: Optional[str] = None,
                       has_host_access: bool = False) -> dict:
     """Delegate to consolidated guard (tirith + dangerous cmd) with CLI callback."""
     return _check_all_guards_impl(command, env_type,
                                   approval_callback=_get_approval_callback(),
-                                  has_host_access=has_host_access)
+                                  has_host_access=has_host_access,
+                                  security_risk=security_risk)
 
 
 # Allowlist: characters that can legitimately appear in directory paths.
@@ -2827,6 +2829,7 @@ def terminal_tool(
     pty: bool = False,
     notify_on_complete: bool = False,
     watch_patterns: Optional[List[str]] = None,
+    security_risk: Optional[str] = None,
     _host_local: bool = False,
 ) -> str:
     """
@@ -2843,6 +2846,7 @@ def terminal_tool(
         pty: If True, use pseudo-terminal for interactive CLI tools (local backend only)
         notify_on_complete: If True and background=True, you'll be notified exactly once when the process exits. The right choice for almost every long task. MUTUALLY EXCLUSIVE with watch_patterns.
         watch_patterns: List of strings to watch for in background output. HARD rate limit: 1 notification per 15s per process. After 3 strike windows in a row — or after a small lifetime cap of delivered matches, however cleanly spaced — watch_patterns is disabled and the session is auto-promoted to notify_on_complete. Use ONLY for rare, one-shot mid-process signals on long-lived processes (server readiness, migration-done markers). NEVER use in loops/batch jobs — error patterns there will hit the strike limit and get disabled. MUTUALLY EXCLUSIVE with notify_on_complete — set one, not both.
+        security_risk: Optional LLM self-annotation: LOW, MEDIUM, HIGH, or UNKNOWN.
 
     Returns:
         str: JSON string with output, exit_code, and error fields
@@ -3241,6 +3245,7 @@ def terminal_tool(
         if not force:
             approval = _check_all_guards(
                 command, env_type,
+                security_risk=security_risk,
                 has_host_access=_docker_has_host_access(config),
             )
             if not approval["approved"]:
@@ -4133,6 +4138,11 @@ TERMINAL_SCHEMA = {
                     {"type": "boolean"},
                     {"type": "array", "items": {"type": "string"}}
                 ]
+            },
+            "security_risk": {
+                "type": "string",
+                "enum": ["LOW", "MEDIUM", "HIGH", "UNKNOWN"],
+                "description": "Optional but recommended LLM self-annotation for this command's security risk. LOW = read-only or inspection-only commands. MEDIUM = project-scoped changes such as builds, installs, edits, or tests. HIGH = destructive/system-level changes, credential exposure, privileged operations, or data leaving the environment. UNKNOWN = uncertain risk; prefer UNKNOWN over under-classifying. HIGH/UNKNOWN may trigger the existing approval flow depending on terminal.confirmation_policy.",
             }
             # Legacy aliases (unadvertised, still accepted): notify_on_complete
             # (bool) and watch_patterns (list). notify=true|[...] maps onto
@@ -4199,6 +4209,7 @@ def _handle_terminal(args, **kw):
         pty=args.get("pty", False),
         notify_on_complete=notify_on_complete,
         watch_patterns=watch_patterns,
+        security_risk=args.get("security_risk"),
     )
 
 

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -2846,7 +2846,8 @@ def terminal_tool(
         pty: If True, use pseudo-terminal for interactive CLI tools (local backend only)
         notify_on_complete: If True and background=True, you'll be notified exactly once when the process exits. The right choice for almost every long task. MUTUALLY EXCLUSIVE with watch_patterns.
         watch_patterns: List of strings to watch for in background output. HARD rate limit: 1 notification per 15s per process. After 3 strike windows in a row — or after a small lifetime cap of delivered matches, however cleanly spaced — watch_patterns is disabled and the session is auto-promoted to notify_on_complete. Use ONLY for rare, one-shot mid-process signals on long-lived processes (server readiness, migration-done markers). NEVER use in loops/batch jobs — error patterns there will hit the strike limit and get disabled. MUTUALLY EXCLUSIVE with notify_on_complete — set one, not both.
-        security_risk: Optional LLM self-annotation: LOW, MEDIUM, HIGH, or UNKNOWN.
+        security_risk: Optional advisory LLM self-annotation: LOW, MEDIUM,
+            HIGH, or UNKNOWN. This is not a security scan.
 
     Returns:
         str: JSON string with output, exit_code, and error fields
@@ -4142,7 +4143,20 @@ TERMINAL_SCHEMA = {
             "security_risk": {
                 "type": "string",
                 "enum": ["LOW", "MEDIUM", "HIGH", "UNKNOWN"],
-                "description": "Optional but recommended LLM self-annotation for this command's security risk. LOW = read-only or inspection-only commands. MEDIUM = project-scoped changes such as builds, installs, edits, or tests. HIGH = destructive/system-level changes, credential exposure, privileged operations, or data leaving the environment. UNKNOWN = uncertain risk; prefer UNKNOWN over under-classifying. HIGH/UNKNOWN may trigger the existing approval flow depending on terminal.confirmation_policy.",
+                "description": (
+                    "Optional but recommended advisory LLM self-annotation for this "
+                    "command's security risk. This is not a security scan or an "
+                    "authoritative safety decision: LOW/MEDIUM are not proof that a "
+                    "command is safe, and deterministic guards still run separately. "
+                    "LOW = read-only or inspection-only commands. MEDIUM = "
+                    "project-scoped changes such as builds, installs, edits, or "
+                    "tests. HIGH = destructive/system-level changes, credential "
+                    "exposure, privileged operations, or data leaving the environment. "
+                    "UNKNOWN = uncertain risk; prefer UNKNOWN over under-classifying. "
+                    "HIGH/UNKNOWN may trigger the existing approval flow depending on "
+                    "terminal.confirmation_policy; trusted environments can set that "
+                    "policy to never while hardline guards still apply."
+                ),
             }
             # Legacy aliases (unadvertised, still accepted): notify_on_complete
             # (bool) and watch_patterns (list). notify=true|[...] maps onto

--- a/website/docs/user-guide/security.md
+++ b/website/docs/user-guide/security.md
@@ -58,6 +58,32 @@ The full set of keys:
 Setting `approvals.mode: off` disables all safety prompts. Use only in trusted environments (CI/CD, containers, etc.).
 :::
 
+### Terminal Confirmation Policy
+
+Terminal calls may include an optional `security_risk` annotation from the
+agent. This is an advisory self-report, not a security scan: `LOW` or `MEDIUM`
+does not prove that a command is safe, and deterministic command guards still
+run independently.
+
+Configure the policy under `terminal`:
+
+```yaml
+terminal:
+  confirmation_policy: risky  # risky | always | never
+```
+
+| Policy | Behavior |
+|---|---|
+| `risky` (default) | Ask for confirmation when the annotation is `HIGH` or `UNKNOWN`. Missing, `LOW`, and `MEDIUM` annotations do not by themselves trigger a prompt. |
+| `always` | Ask for confirmation for each distinct terminal command, regardless of its advisory annotation. |
+| `never` | Skip ordinary terminal approval prompts in a trusted environment. This is a broad bypass similar to YOLO mode, not a security guarantee. |
+
+This setting is separate from `approvals.mode` and the session-scoped
+`--yolo`/`/yolo` controls: those govern the broader approval workflow, while
+`confirmation_policy` controls how terminal commands are confirmed. The
+hardline blocklist, the sudo-stdin guard, and `approvals.deny` remain enforced
+as safety floors under every policy, including `never`.
+
 ### YOLO Mode
 
 YOLO mode bypasses **all** dangerous command approval prompts for the current session. It can be activated three ways:

--- a/website/docs/user-guide/security.md
+++ b/website/docs/user-guide/security.md
@@ -60,6 +60,32 @@ The full set of keys:
 Setting `approvals.mode: off` disables all safety prompts. Use only in trusted environments (CI/CD, containers, etc.).
 :::
 
+### Terminal Confirmation Policy
+
+Terminal calls may include an optional `security_risk` annotation from the
+agent. This is an advisory self-report, not a security scan: `LOW` or `MEDIUM`
+does not prove that a command is safe, and deterministic command guards still
+run independently.
+
+Configure the policy under `terminal`:
+
+```yaml
+terminal:
+  confirmation_policy: risky  # risky | always | never
+```
+
+| Policy | Behavior |
+|---|---|
+| `risky` (default) | Ask for confirmation when the annotation is `HIGH` or `UNKNOWN`. Missing, `LOW`, and `MEDIUM` annotations do not by themselves trigger a prompt. |
+| `always` | Ask for confirmation for each distinct terminal command, regardless of its advisory annotation. |
+| `never` | Skip ordinary terminal approval prompts in a trusted environment. This is a broad bypass similar to YOLO mode, not a security guarantee. |
+
+This setting is separate from `approvals.mode` and the session-scoped
+`--yolo`/`/yolo` controls: those govern the broader approval workflow, while
+`confirmation_policy` controls how terminal commands are confirmed. The
+hardline blocklist, the sudo-stdin guard, and `approvals.deny` remain enforced
+as safety floors under every policy, including `never`.
+
 ### YOLO Mode
 
 YOLO mode bypasses **all** dangerous command approval prompts for the current session. It can be activated three ways:


### PR DESCRIPTION
## Summary
- add optional terminal `security_risk` self-annotation (`LOW`/`MEDIUM`/`HIGH`/`UNKNOWN`)
- route `HIGH`/`UNKNOWN` annotations through the existing approval guard instead of adding a second approval path
- add `terminal.confirmation_policy` with env bridging for CLI/gateway/config-set paths
- pass `security_risk` through the `execute_code` terminal stub

## Notes
This is scoped to Phase 1 from #577. In current main, terminal execution uses `check_all_command_guards()` as the consolidated approval entrypoint, so the annotation is handled there rather than duplicating approval logic in `terminal_tool.py`.

The `always` policy uses command-specific approval keys so approving one command does not silently approve all later commands.

Refs #577

## Tests
- `python3 -m pytest tests/tools/test_command_guards.py tests/tools/test_terminal_tool.py tests/tools/test_terminal_config_env_sync.py tests/tools/test_code_execution.py -q`
- `python3 -m ruff check tools/approval.py tools/terminal_tool.py tools/code_execution_tool.py hermes_cli/config.py cli.py gateway/run.py tests/tools/test_command_guards.py tests/tools/test_terminal_tool.py tests/tools/test_code_execution.py tests/tools/test_terminal_config_env_sync.py`
