### PR TITLE
fix(anthropic): preserve docs URL in OAuth sanitizer

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -15,6 +15,7 @@ import json
 import logging
 import os
 import platform
+import re
 import secrets
 import stat
 import subprocess
@@ -373,6 +374,14 @@ def _detect_claude_code_version() -> str:
 
 _CLAUDE_CODE_SYSTEM_PREFIX = "You are Claude Code, Anthropic's official CLI for Claude."
 _MCP_TOOL_PREFIX = "mcp__"
+
+
+def _sanitize_oauth_system_prompt_text(text: str) -> str:
+    text = text.replace("Hermes Agent", "Claude Code")
+    text = text.replace("Hermes agent", "Claude Code")
+    text = re.sub(r"\bhermes-agent\b(?!\.nousresearch\.com)", "claude-code", text)
+    text = text.replace("Nous Research", "Anthropic")
+    return text
 
 
 def _get_claude_code_version() -> str:
@@ -2342,12 +2351,7 @@ def build_anthropic_kwargs(
         #    to avoid Anthropic's server-side content filters.
         for block in system:
             if isinstance(block, dict) and block.get("type") == "text":
-                text = block.get("text", "")
-                text = text.replace("Hermes Agent", "Claude Code")
-                text = text.replace("Hermes agent", "Claude Code")
-                text = text.replace("hermes-agent", "claude-code")
-                text = text.replace("Nous Research", "Anthropic")
-                block["text"] = text
+                block["text"] = _sanitize_oauth_system_prompt_text(block.get("text", ""))
 
         # 3. Normalize tool names so NOTHING goes on the OAuth wire with a
         #    single-underscore ``mcp_`` prefix.  Anthropic's subscription/OAuth

--- a/tests/agent/test_anthropic_adapter.py
+++ b/tests/agent/test_anthropic_adapter.py
@@ -1090,6 +1090,30 @@ class TestBuildAnthropicKwargs:
         assert "oauth-2025-04-20" in betas
         assert "context-1m-2025-08-07" not in betas
 
+    def test_oauth_system_prompt_sanitizer_preserves_docs_url(self):
+        kwargs = build_anthropic_kwargs(
+            model="claude-sonnet-4-20250514",
+            messages=[
+                {
+                    "role": "system",
+                    "content": (
+                        "Hermes Agent by Nous Research uses hermes-agent skills. "
+                        "Docs: https://hermes-agent.nousresearch.com/docs"
+                    ),
+                },
+                {"role": "user", "content": "Hi"},
+            ],
+            tools=None,
+            max_tokens=4096,
+            reasoning_config=None,
+            is_oauth=True,
+        )
+
+        system_text = "\n".join(block["text"] for block in kwargs["system"])
+        assert "Claude Code by Anthropic uses claude-code skills." in system_text
+        assert "https://hermes-agent.nousresearch.com/docs" in system_text
+        assert "claude-code.nousresearch.com" not in system_text
+
     def test_fast_mode_oauth_drop_context_1m_beta_strips_only_1m(self):
         """drop_context_1m_beta=True strips context-1m from fast-mode
         extra_headers while preserving every other OAuth + fast-mode beta."""


### PR DESCRIPTION
## Summary
- extract OAuth system prompt sanitization into a focused helper
- keep the canonical `hermes-agent.nousresearch.com` docs host intact while still sanitizing non-URL product slug mentions
- add a regression test through `build_anthropic_kwargs` for the OAuth path

Fixes #48860.

## Verification
- `/Users/gauravsaxena/Projects/open-source-contribution/hermes-agent/.venv/bin/python -m pytest tests/agent/test_anthropic_adapter.py::TestBuildAnthropicKwargs -q`