### PR TITLE
fix(oauth): scope hermes-agent slug replace to avoid mangling docs URL host (#48860)

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -1,4 +1,4 @@
-﻿"""Anthropic Messages API adapter for Hermes Agent.
+"""Anthropic Messages API adapter for Hermes Agent.
 
 Translates between Hermes's internal OpenAI-style message format and
 Anthropic's Messages API. Follows the same pattern as the codex_responses

--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -1,4 +1,4 @@
-"""Anthropic Messages API adapter for Hermes Agent.
+﻿"""Anthropic Messages API adapter for Hermes Agent.
 
 Translates between Hermes's internal OpenAI-style message format and
 Anthropic's Messages API. Follows the same pattern as the codex_responses
@@ -15,6 +15,7 @@ import json
 import logging
 import os
 import platform
+import re
 import secrets
 import stat
 import subprocess
@@ -2345,7 +2346,7 @@ def build_anthropic_kwargs(
                 text = block.get("text", "")
                 text = text.replace("Hermes Agent", "Claude Code")
                 text = text.replace("Hermes agent", "Claude Code")
-                text = text.replace("hermes-agent", "claude-code")
+                text = re.sub(r"(?<![:/\w])hermes-agent(?!\.nousresearch\.com)", "claude-code", text)
                 text = text.replace("Nous Research", "Anthropic")
                 block["text"] = text
 

--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -2346,7 +2346,12 @@ def build_anthropic_kwargs(
                 text = block.get("text", "")
                 text = text.replace("Hermes Agent", "Claude Code")
                 text = text.replace("Hermes agent", "Claude Code")
-                text = re.sub(r"(?<![:/\w])hermes-agent(?!\.nousresearch\.com)", "claude-code", text)
+                # Lookbehind excludes ':' '/' '\' and word chars so the slug is
+                # left untouched inside URLs, POSIX paths (/.../hermes-agent/...)
+                # AND Windows paths (\...\hermes-agent\...). Without the backslash
+                # here, Windows venv/install paths get silently rewritten to a
+                # nonexistent directory (see issue #48860 thread, chazmaniandinkle).
+                text = re.sub(r"(?<![:/\\\w])hermes-agent(?!\.nousresearch\.com)", "claude-code", text)
                 text = text.replace("Nous Research", "Anthropic")
                 block["text"] = text
 

--- a/tests/agent/test_anthropic_adapter.py
+++ b/tests/agent/test_anthropic_adapter.py
@@ -1,4 +1,4 @@
-"""Tests for agent/anthropic_adapter.py — Anthropic Messages API adapter."""
+﻿"""Tests for agent/anthropic_adapter.py — Anthropic Messages API adapter."""
 
 import json
 import sys
@@ -2166,3 +2166,50 @@ class TestConvertToolsToAnthropicDedup:
 
     def test_none_tools_returns_empty(self):
         assert convert_tools_to_anthropic(None) == []
+
+
+class TestOAuthSanitizerUrlPreservation:
+    """Regression tests for issue #48860.
+
+    The OAuth system-prompt sanitizer must NOT rewrite the docs host
+    hermes-agent.nousresearch.com when replacing the product-name slug.
+    """
+
+    def _apply_sanitizer(self, text: str) -> str:
+        import re
+        text = text.replace("Hermes Agent", "Claude Code")
+        text = text.replace("Hermes agent", "Claude Code")
+        text = re.sub(r"(?<![:/\w])hermes-agent(?!\.nousresearch\.com)", "claude-code", text)
+        text = text.replace("Nous Research", "Anthropic")
+        return text
+
+    def test_docs_url_host_is_preserved(self):
+        """hermes-agent.nousresearch.com must survive sanitization intact."""
+        prompt = (
+            "Consult the documentation at "
+            "https://hermes-agent.nousresearch.com/docs for details."
+        )
+        result = self._apply_sanitizer(prompt)
+        assert "hermes-agent.nousresearch.com" in result, (
+            "Docs URL host was corrupted by the OAuth sanitizer"
+        )
+        assert "claude-code.nousresearch.com" not in result
+
+    def test_product_name_is_still_replaced(self):
+        """Non-URL occurrences of the slug must still be rewritten."""
+        prompt = "Welcome to Hermes Agent, powered by Nous Research."
+        result = self._apply_sanitizer(prompt)
+        assert "Claude Code" in result
+        assert "Anthropic" in result
+        assert "Hermes Agent" not in result
+        assert "Nous Research" not in result
+
+    def test_url_host_preserved_and_name_replaced_together(self):
+        """Both rules must hold when the prompt contains the URL and the product name."""
+        prompt = (
+            "Hermes Agent help: https://hermes-agent.nousresearch.com/docs"
+        )
+        result = self._apply_sanitizer(prompt)
+        assert "Claude Code" in result
+        assert "hermes-agent.nousresearch.com" in result
+        assert "claude-code.nousresearch.com" not in result

--- a/tests/agent/test_anthropic_adapter.py
+++ b/tests/agent/test_anthropic_adapter.py
@@ -1,4 +1,4 @@
-﻿"""Tests for agent/anthropic_adapter.py — Anthropic Messages API adapter."""
+"""Tests for agent/anthropic_adapter.py — Anthropic Messages API adapter."""
 
 import json
 import sys

--- a/tests/agent/test_anthropic_adapter.py
+++ b/tests/agent/test_anthropic_adapter.py
@@ -2173,15 +2173,38 @@ class TestOAuthSanitizerUrlPreservation:
 
     The OAuth system-prompt sanitizer must NOT rewrite the docs host
     hermes-agent.nousresearch.com when replacing the product-name slug.
+
+    These tests exercise the real production path,
+    ``build_anthropic_kwargs(..., is_oauth=True)``, and assert on the
+    returned ``kwargs["system"]`` rather than reimplementing the sanitizer
+    locally — a local reimplementation could pass even if the live
+    sanitizer in agent/anthropic_adapter.py regressed (see teknium1's
+    review on #48868).
     """
 
-    def _apply_sanitizer(self, text: str) -> str:
-        import re
-        text = text.replace("Hermes Agent", "Claude Code")
-        text = text.replace("Hermes agent", "Claude Code")
-        text = re.sub(r"(?<![:/\w])hermes-agent(?!\.nousresearch\.com)", "claude-code", text)
-        text = text.replace("Nous Research", "Anthropic")
-        return text
+    def _sanitized_system_text(self, prompt: str) -> str:
+        """Run the prompt through the real OAuth path and return the
+        sanitized text block (excluding the prepended Claude Code identity
+        block, which is unrelated to this sanitizer)."""
+        kwargs = build_anthropic_kwargs(
+            model="claude-sonnet-4-20250514",
+            messages=[
+                {"role": "system", "content": prompt},
+                {"role": "user", "content": "Hi"},
+            ],
+            tools=None,
+            max_tokens=4096,
+            reasoning_config=None,
+            is_oauth=True,
+        )
+        system = kwargs["system"]
+        assert isinstance(system, list), (
+            "OAuth system prompt should be a list of content blocks"
+        )
+        # First block is the prepended Claude Code identity prefix; the
+        # original (sanitized) prompt is the block after it.
+        assert len(system) >= 2
+        return system[-1]["text"]
 
     def test_docs_url_host_is_preserved(self):
         """hermes-agent.nousresearch.com must survive sanitization intact."""
@@ -2189,7 +2212,7 @@ class TestOAuthSanitizerUrlPreservation:
             "Consult the documentation at "
             "https://hermes-agent.nousresearch.com/docs for details."
         )
-        result = self._apply_sanitizer(prompt)
+        result = self._sanitized_system_text(prompt)
         assert "hermes-agent.nousresearch.com" in result, (
             "Docs URL host was corrupted by the OAuth sanitizer"
         )
@@ -2198,7 +2221,7 @@ class TestOAuthSanitizerUrlPreservation:
     def test_product_name_is_still_replaced(self):
         """Non-URL occurrences of the slug must still be rewritten."""
         prompt = "Welcome to Hermes Agent, powered by Nous Research."
-        result = self._apply_sanitizer(prompt)
+        result = self._sanitized_system_text(prompt)
         assert "Claude Code" in result
         assert "Anthropic" in result
         assert "Hermes Agent" not in result
@@ -2209,7 +2232,7 @@ class TestOAuthSanitizerUrlPreservation:
         prompt = (
             "Hermes Agent help: https://hermes-agent.nousresearch.com/docs"
         )
-        result = self._apply_sanitizer(prompt)
+        result = self._sanitized_system_text(prompt)
         assert "Claude Code" in result
         assert "hermes-agent.nousresearch.com" in result
         assert "claude-code.nousresearch.com" not in result

--- a/tests/agent/test_anthropic_adapter.py
+++ b/tests/agent/test_anthropic_adapter.py
@@ -2236,3 +2236,32 @@ class TestOAuthSanitizerUrlPreservation:
         assert "Claude Code" in result
         assert "hermes-agent.nousresearch.com" in result
         assert "claude-code.nousresearch.com" not in result
+
+    def test_windows_path_is_preserved(self):
+        """Windows-style backslash paths must survive sanitization intact.
+
+        Without a backslash in the sanitizer's lookbehind, Windows venv/
+        install paths (the default layout on Windows) get silently rewritten
+        to a directory that does not exist, causing the agent to load or
+        execute against a nonexistent path (see chazmaniandinkle's comment
+        on issue #48860)."""
+        prompt = (
+            r"Interpreter: C:\Users\me\.hermes\hermes-agent\venv\Scripts\python.exe"
+        )
+        result = self._sanitized_system_text(prompt)
+        assert r"\.hermes\hermes-agent\venv\Scripts\python.exe" in result, (
+            "Windows path was corrupted by the OAuth sanitizer"
+        )
+        assert "claude-code" not in result
+
+    def test_word_char_prefixed_slug_is_preserved(self):
+        """A slug that is part of a longer identifier must not be rewritten.
+
+        Guards the lookbehind's \\w (word-character) branch specifically:
+        adding backslash support to the character class must not accidentally
+        break the existing word-character exclusion."""
+        prompt = "See myhermes-agent-thing for details."
+        result = self._sanitized_system_text(prompt)
+        assert "myhermes-agent-thing" in result, (
+            "Word-character-prefixed slug was incorrectly rewritten"
+        )


### PR DESCRIPTION
Fixes #48860

## Problem

The OAuth system-prompt sanitizer in `agent/anthropic_adapter.py` used a blanket `str.replace("hermes-agent", "claude-code")` that is not URL-aware. This also rewrote the substring inside the docs URL, turning the valid host `hermes-agent.nousresearch.com` into the NXDOMAIN `claude-code.nousresearch.com`. Every OAuth/subscription user received a broken docs pointer in their system prompt.

## Fix

Replaced the greedy `str.replace` with a `re.sub` using:
- negative lookbehind `(?<![:/\w])` — skips occurrences preceded by URL scheme characters or word chars
- negative lookahead `(?!\.nousresearch\.com)` — explicitly protects the docs host

This rewrites the product-name slug in prose contexts while leaving `hermes-agent.nousresearch.com` intact.

Also added `import re` (alphabetically between `platform` and `secrets`).

## Changes

- `agent/anthropic_adapter.py`: replace greedy slug swap with scoped `re.sub`; add `import re`
- `tests/agent/test_anthropic_adapter.py`: add `TestOAuthSanitizerUrlPreservation` (3 cases)

## Tests

```
tests/agent/test_anthropic_adapter.py::TestOAuthSanitizerUrlPreservation::test_docs_url_host_is_preserved PASSED
tests/agent/test_anthropic_adapter.py::TestOAuthSanitizerUrlPreservation::test_product_name_is_still_replaced PASSED
tests/agent/test_anthropic_adapter.py::TestOAuthSanitizerUrlPreservation::test_url_host_preserved_and_name_replaced_together PASSED
```