### PR TITLE
Fix Ollama TUI inventory/runtime sync

### DIFF
--- a/hermes_cli/inventory.py
+++ b/hermes_cli/inventory.py
@@ -162,6 +162,7 @@ def build_models_payload(
         max_models=max_models,
         refresh=refresh,
     )
+    rows = _append_current_local_provider_row(rows, ctx)
 
     # --- Deduplicate: remove models from aggregators that overlap with
     # user-defined providers.  When a local proxy (e.g. litellm-proxy)
@@ -258,6 +259,48 @@ def _apply_capabilities(rows: list[dict]) -> None:
 
 
 # ─── Internal: row post-processing ──────────────────────────────────────
+
+_LOCAL_RUNTIME_PROVIDER_LABELS = {
+    "ollama": "Ollama",
+    "vllm": "vLLM",
+    "llamacpp": "llama.cpp",
+    "llama.cpp": "llama.cpp",
+    "llama-cpp": "llama.cpp",
+}
+
+
+def _append_current_local_provider_row(
+    rows: list[dict], ctx: ConfigContext
+) -> list[dict]:
+    """Keep the active local runtime visible in picker payloads.
+
+    The authenticated provider inventory only knows about configured/API-key
+    backed providers. Bare local runtimes like ``provider: ollama`` can be the
+    live runtime without ever emitting a row, which leaves the picker showing
+    only the ``ollama-cloud`` setup skeleton and makes the UI look unconfigured.
+    """
+    normalized = (ctx.current_provider or "").strip().lower()
+    if normalized not in _LOCAL_RUNTIME_PROVIDER_LABELS:
+        return rows
+
+    seen = {str(row.get("slug", "")).lower() for row in rows}
+    if normalized in seen:
+        return rows
+
+    current_model = (ctx.current_model or "").strip()
+    current_base_url = (ctx.current_base_url or "").strip()
+    row = {
+        "slug": normalized,
+        "name": _LOCAL_RUNTIME_PROVIDER_LABELS[normalized],
+        "is_current": True,
+        "is_user_defined": True,
+        "models": [current_model] if current_model else [],
+        "total_models": 1 if current_model else 0,
+        "source": "runtime-local",
+    }
+    if current_base_url:
+        row["api_url"] = current_base_url
+    return list(rows) + [row]
 
 
 def _append_unconfigured_rows(rows: list[dict], ctx: ConfigContext) -> list[dict]:

--- a/tests/hermes_cli/test_inventory.py
+++ b/tests/hermes_cli/test_inventory.py
@@ -375,6 +375,32 @@ def test_picker_hints_api_key_warning_format():
     assert anthropic["warning"].startswith("paste ")
 
 
+def test_picker_hints_keeps_current_local_ollama_authenticated():
+    """A live local runtime must stay visible even if only the cloud variant
+    has a canonical setup skeleton."""
+    ctx = _empty_ctx(
+        provider="ollama",
+        model="ollama/gemma4:12b-mlx",
+        base_url="http://127.0.0.1:11434/v1",
+    )
+    with _list_auth_returning([]):
+        payload = build_models_payload(
+            ctx, include_unconfigured=True, picker_hints=True,
+        )
+
+    ollama = next(r for r in payload["providers"] if r["slug"] == "ollama")
+    assert ollama["authenticated"] is True
+    assert ollama["is_current"] is True
+    assert ollama["models"] == ["ollama/gemma4:12b-mlx"]
+    assert ollama["source"] == "runtime-local"
+    assert ollama["api_url"] == "http://127.0.0.1:11434/v1"
+
+    ollama_cloud = next(
+        r for r in payload["providers"] if r["slug"] == "ollama-cloud"
+    )
+    assert ollama_cloud["authenticated"] is False
+
+
 # ─── canonical_order ───────────────────────────────────────────────────
 
 
@@ -724,4 +750,3 @@ def test_list_authenticated_providers_refresh_busts_cache():
         assert clear.call_count == 0
         model_switch.list_authenticated_providers(refresh=True)
         assert clear.call_count == 1
-

--- a/tests/tui_gateway/test_make_agent_provider.py
+++ b/tests/tui_gateway/test_make_agent_provider.py
@@ -51,13 +51,54 @@ def test_make_agent_passes_resolved_provider():
         # the patched config may not take effect when the module was already
         # imported by an earlier test.  Assert the stable part of the call.
         mock_resolve.assert_called_once()
-        assert mock_resolve.call_args.kwargs.get("requested") is None
+        assert mock_resolve.call_args.kwargs.get("requested") == "anthropic"
 
         call_kwargs = mock_agent.call_args
         assert call_kwargs.kwargs["provider"] == "anthropic"
         assert call_kwargs.kwargs["base_url"] == "https://api.anthropic.com"
         assert call_kwargs.kwargs["api_key"] == "sk-test-key"
         assert call_kwargs.kwargs["api_mode"] == "anthropic_messages"
+
+
+def test_resolve_model_prefers_config_without_explicit_tui_provider():
+    fake_cfg = {
+        "model": {
+            "default": "ollama/gemma4:12b-mlx",
+            "provider": "ollama",
+        }
+    }
+
+    with (
+        patch.dict(os.environ, {}, clear=True),
+        patch("tui_gateway.server._load_cfg", return_value=fake_cfg),
+    ):
+        os.environ["HERMES_MODEL"] = "deepseek/deepseek-v4-flash"
+
+        from tui_gateway import server
+
+        assert server._resolve_model() == "ollama/gemma4:12b-mlx"
+
+
+def test_resolve_startup_runtime_prefers_config_provider_without_explicit_tui_provider():
+    fake_cfg = {
+        "model": {
+            "default": "ollama/gemma4:12b-mlx",
+            "provider": "ollama",
+        }
+    }
+
+    with (
+        patch.dict(os.environ, {}, clear=True),
+        patch("tui_gateway.server._load_cfg", return_value=fake_cfg),
+    ):
+        os.environ["HERMES_MODEL"] = "deepseek/deepseek-v4-flash"
+
+        from tui_gateway import server
+
+        assert server._resolve_startup_runtime() == (
+            "ollama/gemma4:12b-mlx",
+            "ollama",
+        )
 
 
 def test_make_agent_forwards_provider_routing():

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -1483,13 +1483,18 @@ def _resolve_model() -> str:
         os.environ.get("HERMES_MODEL", "")
         or os.environ.get("HERMES_INFERENCE_MODEL", "")
     ).strip()
-    if env:
+    explicit_provider = os.environ.get("HERMES_TUI_PROVIDER", "").strip()
+    if explicit_provider and env:
         return env
     m = _load_cfg().get("model", "")
     if isinstance(m, dict):
-        return str(m.get("default", "") or "").strip()
-    if isinstance(m, str) and m:
+        model = str(m.get("default", "") or "").strip()
+        if model:
+            return model
+    elif isinstance(m, str) and m:
         return m.strip()
+    if env:
+        return env
     return "anthropic/claude-sonnet-4"
 
 
@@ -1524,6 +1529,19 @@ def _resolve_startup_runtime() -> tuple[str, str | None]:
     if explicit_provider:
         return model, explicit_provider
 
+    cfg_model = _load_cfg().get("model") or {}
+    configured_provider = ""
+    configured_model = ""
+    if isinstance(cfg_model, dict):
+        configured_model = str(cfg_model.get("default", "") or "").strip()
+        configured_provider = str(cfg_model.get("provider") or "").strip()
+        if configured_provider.lower() == "auto":
+            configured_provider = ""
+    elif isinstance(cfg_model, str):
+        configured_model = cfg_model.strip()
+    if configured_provider:
+        return configured_model or model, configured_provider
+
     explicit_model = (
         os.environ.get("HERMES_MODEL", "")
         or os.environ.get("HERMES_INFERENCE_MODEL", "")
@@ -1534,13 +1552,8 @@ def _resolve_startup_runtime() -> tuple[str, str | None]:
     try:
         from hermes_cli.models import detect_static_provider_for_model
 
-        cfg = _load_cfg().get("model") or {}
         current_provider = (
-            (
-                str(cfg.get("provider") or "").strip().lower()
-                if isinstance(cfg, dict)
-                else ""
-            )
+            configured_provider.lower()
             or os.environ.get("HERMES_INFERENCE_PROVIDER", "").strip().lower()
             or "auto"
         )


### PR DESCRIPTION
## Summary
- keep a live local runtime row for ollama/vllm/llama.cpp providers so the picker does not fall back to an unconfigured cloud skeleton
- prefer config-selected model/provider over stale ambient env at TUI startup unless HERMES_TUI_PROVIDER explicitly overrides it
- add regressions for the local ollama picker row and startup runtime resolution

Closes #48840