### PR TITLE
fix: preserve paragraph breaks when removing @ context reference tokens

### DIFF
--- a/agent/context_references.py
+++ b/agent/context_references.py
@@ -420,8 +420,9 @@ def _remove_reference_tokens(message: str, refs: list[ContextReference]) -> str:
         cursor = ref.end
     pieces.append(message[cursor:])
     text = "".join(pieces)
-    text = re.sub(r"\s{2,}", " ", text)
-    text = re.sub(r"\s+([,.;:!?])", r"\1", text)
+    text = re.sub(r"[ \t]{2,}", " ", text)
+    text = re.sub(r"[ \t]+([,.;:!?])", r"\1", text)
+    text = re.sub(r"\n{3,}", "\n\n", text)
     return text.strip()
 
 

--- a/tests/agent/test_context_references.py
+++ b/tests/agent/test_context_references.py
@@ -353,3 +353,35 @@ async def test_blocks_sensitive_home_and_hermes_paths(tmp_path: Path, monkeypatc
     assert "API_KEY=super-secret" not in result.message
     assert "PRIVATE-KEY" not in result.message
     assert any("sensitive credential" in warning for warning in result.warnings)
+
+
+def test_remove_reference_tokens_preserves_paragraphs():
+    """Regression: removing @ tokens must not collapse blank lines/paragraphs (issue #48484)."""
+    from agent.context_references import _remove_reference_tokens, parse_context_references
+
+    msg = (
+        "Please refactor the auth module.\n\n"
+        "@file:auth.py\n\n"
+        "Make these changes:\n1. Add logging\n2. Handle timeouts\n\n"
+        "Keep the public API stable."
+    )
+    refs = parse_context_references(msg)
+    result = _remove_reference_tokens(msg, refs)
+
+    assert "\n\n" in result, "paragraph breaks must be preserved"
+    assert "module.\n\nMake" in result, "blank line between sections must survive"
+    assert "timeouts\n\nKeep" in result, "blank line before closing must survive"
+    # The @ token itself must be gone
+    assert "@file:auth.py" not in result
+
+
+def test_remove_reference_tokens_preserves_single_newlines():
+    """Single newlines in bullet lists must survive reference removal."""
+    from agent.context_references import _remove_reference_tokens, parse_context_references
+
+    msg = "Review this:\n@file:src.py\n\nLine one\nLine two\nLine three"
+    refs = parse_context_references(msg)
+    result = _remove_reference_tokens(msg, refs)
+
+    assert "Line one\nLine two\nLine three" in result
+    assert "@file:src.py" not in result


### PR DESCRIPTION
## What does this PR do?

Fixes the whitespace collapse bug in `_remove_reference_tokens` (`agent/context_references.py`) where using any `@` context reference (`@file`, `@folder`, `@diff`, `@staged`, `@git`, `@url`) caused all blank lines and paragraph breaks in the message to be flattened into single spaces before the text reached the model.

**Root cause:** The cleanup regexes used `\s` which matches newlines, so `\s{2,}` → ` ` collapsed multi-line whitespace runs (paragraph breaks) into single spaces across the entire message.

**Fix (3 lines changed):**
- `re.sub(r"\s{2,}", " ", text)` → `re.sub(r"[ \t]{2,}", " ", text)` — only collapse horizontal whitespace
- `re.sub(r"\s+([,.;:!?])", r"\1", text)` → `re.sub(r"[ \t]+([,.;:!?])", r"\1", text)` — same
- Added `re.sub(r"\n{3,}", "\n\n", text)` — normalize seam artifacts from token removal back to clean paragraph breaks

## Related Issue

Fixes #48484

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `agent/context_references.py` — Scope whitespace cleanup to horizontal whitespace only
- `tests/agent/test_context_references.py` — Added 2 regression tests

## How to Test

```python
from agent.context_references import _remove_reference_tokens, parse_context_references

msg = (
    "Please refactor the auth module.\n\n"
    "@file:auth.py\n\n"
    "Make these changes:\n1. Add logging\n2. Handle timeouts\n\n"
    "Keep the public API stable."
)
refs = parse_context_references(msg)
result = _remove_reference_tokens(msg, refs)
assert "\n\n" in result  # paragraph breaks preserved
```

## Checklist

- [x] Commit messages follow Conventional Commits
- [x] PR contains only changes related to this fix
- [x] All 14 tests in `test_context_references.py` pass
- [x] Added 2 regression tests
- [x] Tested on: Ubuntu 24.04 (Python 3.12.3)