### PR TITLE
feat: add contextual dashboard home

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -32,7 +32,9 @@ import {
   FileText,
   Globe,
   Heart,
+  Home,
   KeyRound,
+  LayoutDashboard,
   Menu,
   MessageSquare,
   Package,
@@ -72,6 +74,7 @@ import { ProfileSwitcher } from "@/components/ProfileSwitcher";
 import { ProfileScopeBanner } from "@/components/ProfileScopeBanner";
 import { useSystemActions } from "@/contexts/useSystemActions";
 import type { SystemAction } from "@/contexts/system-actions-context";
+import DashboardPage from "@/pages/DashboardPage";
 import ConfigPage from "@/pages/ConfigPage";
 import DocsPage from "@/pages/DocsPage";
 import EnvPage from "@/pages/EnvPage";
@@ -88,6 +91,7 @@ import PluginsPage from "@/pages/PluginsPage";
 import McpPage from "@/pages/McpPage";
 import PairingPage from "@/pages/PairingPage";
 import ChannelsPage from "@/pages/ChannelsPage";
+import RoomHubsPage from "@/pages/RoomHubsPage";
 import WebhooksPage from "@/pages/WebhooksPage";
 import SystemPage from "@/pages/SystemPage";
 import ChatPage from "@/pages/ChatPage";
@@ -103,7 +107,7 @@ import { api } from "@/lib/api";
 import type { StatusResponse } from "@/lib/api";
 
 function RootRedirect() {
-  return <Navigate to="/sessions" replace />;
+  return <Navigate to="/dashboard" replace />;
 }
 
 function UnknownRouteFallback({ pluginsLoading }: { pluginsLoading: boolean }) {
@@ -113,6 +117,12 @@ function UnknownRouteFallback({ pluginsLoading }: { pluginsLoading: boolean }) {
   }
   return <Navigate to="/sessions" replace />;
 }
+
+const DASHBOARD_NAV_ITEM: NavItem = {
+  path: "/dashboard",
+  label: "Dashboard",
+  icon: LayoutDashboard,
+};
 
 const CHAT_NAV_ITEM: NavItem = {
   path: "/chat",
@@ -132,6 +142,7 @@ const CHAT_NAV_ITEM: NavItem = {
  */
 const BUILTIN_ROUTES_CORE: Record<string, ComponentType> = {
   "/": RootRedirect,
+  "/dashboard": DashboardPage,
   "/sessions": SessionsPage,
   "/files": FilesPage,
   "/analytics": AnalyticsPage,
@@ -143,6 +154,7 @@ const BUILTIN_ROUTES_CORE: Record<string, ComponentType> = {
   "/mcp": McpPage,
   "/pairing": PairingPage,
   "/channels": ChannelsPage,
+  "/hubs": RoomHubsPage,
   "/webhooks": WebhooksPage,
   "/system": SystemPage,
   "/profiles": ProfilesPage,
@@ -185,6 +197,7 @@ const BUILTIN_NAV_REST: NavItem[] = [
   { path: "/skills", labelKey: "skills", label: "Skills", icon: Package },
   { path: "/plugins", labelKey: "plugins", label: "Plugins", icon: Puzzle },
   { path: "/mcp", label: "MCP", icon: Plug },
+  { path: "/hubs", label: "Room Hubs", icon: Home },
   { path: "/channels", label: "Channels", icon: Radio },
   { path: "/webhooks", label: "Webhooks", icon: Webhook },
   { path: "/pairing", label: "Pairing", icon: ShieldCheck },
@@ -221,9 +234,11 @@ const ICON_MAP: Record<string, ComponentType<{ className?: string }>> = {
   Wrench,
   Zap,
   Heart,
+  Home,
   Star,
   Code,
   Eye,
+  LayoutDashboard,
 };
 
 function resolveIcon(name: string): ComponentType<{ className?: string }> {
@@ -428,8 +443,8 @@ export default function App() {
 
   const builtinNav = useMemo(() => {
     const base = embeddedChat
-      ? [CHAT_NAV_ITEM, ...BUILTIN_NAV_REST]
-      : BUILTIN_NAV_REST;
+      ? [DASHBOARD_NAV_ITEM, CHAT_NAV_ITEM, ...BUILTIN_NAV_REST]
+      : [DASHBOARD_NAV_ITEM, ...BUILTIN_NAV_REST];
     return showTokenAnalytics
       ? base
       : base.filter((n) => n.path !== "/analytics");

--- a/web/src/lib/resolve-page-title.ts
+++ b/web/src/lib/resolve-page-title.ts
@@ -1,6 +1,7 @@
 import type { Translations } from "@/i18n/types";
 
-const BUILTIN: Record<string, keyof Translations["app"]["nav"]> = {
+const BUILTIN: Record<string, keyof Translations["app"]["nav"] | "__dashboard" | "__hubs"> = {
+  "/dashboard": "__dashboard",
   "/chat": "chat",
   "/sessions": "sessions",
   "/analytics": "analytics",
@@ -9,6 +10,7 @@ const BUILTIN: Record<string, keyof Translations["app"]["nav"]> = {
   "/cron": "cron",
   "/skills": "skills",
   "/plugins": "plugins",
+  "/hubs": "__hubs",
   "/profiles": "profiles",
   "/config": "config",
   "/env": "keys",
@@ -29,8 +31,14 @@ export function resolvePageTitle(
     return plugin.label;
   }
   const key = BUILTIN[normalized];
-  if (key) {
-    return t.app.nav[key];
+  if (key === "__dashboard") {
+    return "Dashboard";
+  }
+  if (key === "__hubs") {
+    return "Room Hubs";
+  }
+  if (key && key in t.app.nav) {
+    return t.app.nav[key as keyof Translations["app"]["nav"]];
   }
   // Derive title from pathname: "/profiles" → "Profiles"
   const segment = normalized.slice(1);

--- a/web/src/pages/DashboardPage.tsx
+++ b/web/src/pages/DashboardPage.tsx
@@ -1,0 +1,379 @@
+import { useEffect, useMemo, useState, type ComponentType, type ReactNode } from "react";
+import { Link } from "react-router-dom";
+import {
+  Activity,
+  ArrowRight,
+  Clock,
+  Cpu,
+  MessageSquare,
+  PlugZap,
+  Radio,
+  Settings,
+  ShieldCheck,
+  Sparkles,
+  Terminal,
+  Workflow,
+} from "lucide-react";
+import { Badge } from "@nous-research/ui/ui/components/badge";
+import { Card, CardContent, CardHeader, CardTitle } from "@nous-research/ui/ui/components/card";
+import { Spinner } from "@nous-research/ui/ui/components/spinner";
+import { api } from "@/lib/api";
+import type {
+  MessagingPlatform,
+  ModelInfoResponse,
+  PaginatedSessions,
+  SessionStoreStats,
+  StatusResponse,
+} from "@/lib/api";
+
+interface DashboardData {
+  channels: MessagingPlatform[];
+  model: ModelInfoResponse | null;
+  sessions: PaginatedSessions | null;
+  stats: SessionStoreStats | null;
+  status: StatusResponse | null;
+}
+
+const emptyData: DashboardData = {
+  channels: [],
+  model: null,
+  sessions: null,
+  stats: null,
+  status: null,
+};
+
+const gatewayTone: Record<string, "success" | "warning" | "destructive" | "outline"> = {
+  running: "success",
+  starting: "warning",
+  startup_failed: "destructive",
+  stopped: "outline",
+};
+
+function gatewayLabel(status: StatusResponse | null): string {
+  if (!status) return "Unknown";
+  if (status.gateway_state) return status.gateway_state.replace(/_/g, " ");
+  return status.gateway_running ? "running" : "off";
+}
+
+function formatTime(seconds: number | null | undefined): string {
+  if (!seconds) return "—";
+  const date = new Date(seconds * 1000);
+  return date.toLocaleString(undefined, {
+    month: "short",
+    day: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}
+
+export default function DashboardPage() {
+  const [data, setData] = useState<DashboardData>(emptyData);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    Promise.allSettled([
+      api.getStatus(),
+      api.getSessions(5),
+      api.getMessagingPlatforms(),
+      api.getModelInfo(),
+      api.getSessionStats(),
+    ])
+      .then(([status, sessions, messaging, model, stats]) => {
+        if (cancelled) return;
+        setData({
+          status: status.status === "fulfilled" ? status.value : null,
+          sessions: sessions.status === "fulfilled" ? sessions.value : null,
+          channels: messaging.status === "fulfilled" ? messaging.value.platforms : [],
+          model: model.status === "fulfilled" ? model.value : null,
+          stats: stats.status === "fulfilled" ? stats.value : null,
+        });
+        const firstError = [status, sessions, messaging, model, stats].find(
+          (result) => result.status === "rejected",
+        );
+        setError(firstError?.status === "rejected" ? String(firstError.reason) : null);
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const connectedChannels = useMemo(
+    () => data.channels.filter((channel) => channel.state === "connected"),
+    [data.channels],
+  );
+  const homeChannels = useMemo(
+    () => data.channels.filter((channel) => channel.home_channel !== null),
+    [data.channels],
+  );
+  const recentSessions = data.sessions?.sessions ?? [];
+  const statusTone = gatewayTone[data.status?.gateway_state ?? ""] ?? (
+    data.status?.gateway_running ? "success" : "outline"
+  );
+
+  if (loading) {
+    return (
+      <div className="flex min-h-[18rem] items-center justify-center">
+        <Spinner className="text-2xl text-primary" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-5 pb-6">
+      {error ? (
+        <Card className="border-warning/40">
+          <CardContent className="p-4 text-sm text-muted-foreground">
+            Some dashboard data could not be loaded: {error}
+          </CardContent>
+        </Card>
+      ) : null}
+
+      <section className="grid gap-4 xl:grid-cols-[minmax(0,1.45fr)_minmax(20rem,0.75fr)]">
+        <Card className="overflow-hidden border-midground/30 bg-card/70">
+          <CardContent className="relative p-5 sm:p-6">
+            <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_18%_20%,rgba(69,229,214,0.16),transparent_32%),radial-gradient(circle_at_82%_0%,rgba(255,255,255,0.06),transparent_28%)]" />
+            <div className="relative flex flex-col gap-5">
+              <div className="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
+                <div className="space-y-2">
+                  <Badge tone="outline" className="w-fit uppercase tracking-[0.16em]">
+                    contextual command deck
+                  </Badge>
+                  <h2 className="font-expanded text-2xl font-bold tracking-[0.06em] text-midground sm:text-3xl">
+                    One screen for the work; deeper rooms one click away.
+                  </h2>
+                  <p className="max-w-2xl text-sm leading-6 text-muted-foreground">
+                    A mixed layout: status, recent context, and the next likely actions stay visible here. Room Hubs moved into their own page so the main dashboard does not become a railway timetable in a waistcoat.
+                  </p>
+                </div>
+                <Link
+                  to="/chat"
+                  className="inline-flex shrink-0 items-center justify-center gap-2 rounded-sm border border-midground/40 bg-midground px-4 py-2 text-sm font-medium uppercase tracking-[0.08em] text-background transition-colors hover:bg-midground/90"
+                >
+                  <Terminal className="h-4 w-4" />
+                  Open chat
+                </Link>
+              </div>
+
+              <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
+                <MetricCard
+                  icon={Activity}
+                  label="Gateway"
+                  value={gatewayLabel(data.status)}
+                  badge={<Badge tone={statusTone}>{data.status?.gateway_running ? "live" : "idle"}</Badge>}
+                />
+                <MetricCard
+                  icon={MessageSquare}
+                  label="Active sessions"
+                  value={String(data.status?.active_sessions ?? 0)}
+                  detail={`${data.stats?.total ?? data.sessions?.total ?? 0} total`}
+                />
+                <MetricCard
+                  icon={Radio}
+                  label="Channels"
+                  value={`${connectedChannels.length}/${data.channels.length}`}
+                  detail="connected"
+                />
+                <MetricCard
+                  icon={Cpu}
+                  label="Model"
+                  value={data.model?.provider || "—"}
+                  detail={data.model?.model || "not configured"}
+                />
+              </div>
+            </div>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader className="pb-2">
+            <CardTitle className="flex items-center gap-2 text-base">
+              <Sparkles className="h-4 w-4 text-midground" />
+              Context rail
+            </CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-3">
+            <ContextAction
+              icon={Clock}
+              title="Resume"
+              detail={recentSessions[0]?.title || recentSessions[0]?.preview || "No recent session yet"}
+              to="/sessions"
+            />
+            <ContextAction
+              icon={Workflow}
+              title="Automate"
+              detail="Cron, webhooks, and gateway actions"
+              to="/cron"
+            />
+            <ContextAction
+              icon={PlugZap}
+              title="Connect"
+              detail={`${homeChannels.length} home hub${homeChannels.length === 1 ? "" : "s"} configured`}
+              to="/hubs"
+            />
+            <ContextAction
+              icon={Settings}
+              title="Tune"
+              detail="Models, skills, config, and keys"
+              to="/models"
+            />
+          </CardContent>
+        </Card>
+      </section>
+
+      <section className="grid gap-4 lg:grid-cols-[minmax(0,1fr)_minmax(0,1fr)] 2xl:grid-cols-[minmax(0,1fr)_minmax(0,1fr)_minmax(0,1fr)]">
+        <Card>
+          <CardHeader className="pb-2">
+            <CardTitle className="flex items-center justify-between gap-2 text-base">
+              Recent context
+              <Link className="text-xs font-normal text-primary hover:underline" to="/sessions">
+                All sessions
+              </Link>
+            </CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-2">
+            {recentSessions.length > 0 ? recentSessions.slice(0, 4).map((session) => (
+              <Link
+                key={session.id}
+                to="/sessions"
+                className="block rounded-sm border border-border/70 bg-background/30 p-3 transition-colors hover:border-midground/50 hover:bg-midground/5"
+              >
+                <div className="flex items-center justify-between gap-3">
+                  <p className="truncate text-sm font-medium text-foreground">
+                    {session.title || session.preview || "Untitled session"}
+                  </p>
+                  {session.is_active ? <Badge tone="success">active</Badge> : null}
+                </div>
+                <p className="mt-1 truncate text-xs text-muted-foreground">
+                  {session.source || "session"} · {formatTime(session.last_active)}
+                </p>
+              </Link>
+            )) : (
+              <EmptyLine>No context yet. Admirably clean, suspiciously quiet.</EmptyLine>
+            )}
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader className="pb-2">
+            <CardTitle className="flex items-center justify-between gap-2 text-base">
+              Room Hubs
+              <Link className="text-xs font-normal text-primary hover:underline" to="/hubs">
+                Open hubs
+              </Link>
+            </CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-2">
+            {homeChannels.length > 0 ? homeChannels.slice(0, 4).map((platform) => (
+              <div key={platform.id} className="rounded-sm border border-border/70 bg-background/30 p-3">
+                <div className="flex items-center justify-between gap-3">
+                  <p className="truncate text-sm font-medium text-foreground">
+                    {platform.home_channel?.name || platform.name}
+                  </p>
+                  <Badge tone={platform.state === "connected" ? "success" : "outline"}>
+                    {platform.state.replace(/_/g, " ")}
+                  </Badge>
+                </div>
+                <p className="mt-1 truncate font-courier text-xs text-muted-foreground">
+                  {platform.name} · {platform.home_channel?.chat_id}
+                </p>
+              </div>
+            )) : (
+              <EmptyLine>No home channels yet. Set one from a messaging room.</EmptyLine>
+            )}
+          </CardContent>
+        </Card>
+
+        <Card className="lg:col-span-2 2xl:col-span-1">
+          <CardHeader className="pb-2">
+            <CardTitle className="flex items-center gap-2 text-base">
+              <ShieldCheck className="h-4 w-4 text-midground" />
+              System posture
+            </CardTitle>
+          </CardHeader>
+          <CardContent className="grid gap-3 sm:grid-cols-2 2xl:grid-cols-1">
+            <PostureLine label="Auth gate" value={data.status?.auth_required ? "enabled" : "loopback / local"} />
+            <PostureLine label="Config" value={`${data.status?.config_version ?? "—"}/${data.status?.latest_config_version ?? "—"}`} />
+            <PostureLine label="Hermes" value={data.status?.version ?? "—"} />
+            <PostureLine label="Release" value={data.status?.release_date ?? "—"} />
+          </CardContent>
+        </Card>
+      </section>
+    </div>
+  );
+}
+
+function MetricCard({
+  badge,
+  detail,
+  icon: Icon,
+  label,
+  value,
+}: {
+  badge?: ReactNode;
+  detail?: string;
+  icon: typeof Activity;
+  label: string;
+  value: string;
+}) {
+  return (
+    <div className="rounded-sm border border-border/70 bg-background/40 p-3 backdrop-blur-sm">
+      <div className="flex items-start justify-between gap-3">
+        <Icon className="mt-0.5 h-4 w-4 shrink-0 text-midground" />
+        {badge}
+      </div>
+      <p className="mt-3 text-xs uppercase tracking-[0.14em] text-muted-foreground">{label}</p>
+      <p className="mt-1 truncate text-lg font-semibold text-foreground">{value}</p>
+      {detail ? <p className="truncate text-xs text-muted-foreground">{detail}</p> : null}
+    </div>
+  );
+}
+
+function ContextAction({
+  detail,
+  icon: Icon,
+  title,
+  to,
+}: {
+  detail: string;
+  icon: ComponentType<{ className?: string }>;
+  title: string;
+  to: string;
+}) {
+  return (
+    <Link
+      to={to}
+      className="flex w-full items-center justify-between gap-3 rounded-sm border border-border/70 bg-background/30 px-3 py-3 text-left transition-colors hover:border-midground/50 hover:bg-midground/5"
+    >
+        <span className="flex min-w-0 items-center gap-3">
+          <Icon className="h-4 w-4 shrink-0 text-midground" />
+          <span className="min-w-0">
+            <span className="block text-sm font-medium text-foreground">{title}</span>
+            <span className="block truncate text-xs font-normal text-muted-foreground">{detail}</span>
+          </span>
+        </span>
+        <ArrowRight className="h-4 w-4 shrink-0 text-muted-foreground" />
+    </Link>
+  );
+}
+
+function PostureLine({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="rounded-sm border border-border/70 bg-background/30 p-3">
+      <p className="text-xs uppercase tracking-[0.14em] text-muted-foreground">{label}</p>
+      <p className="mt-1 truncate text-sm text-foreground">{value}</p>
+    </div>
+  );
+}
+
+function EmptyLine({ children }: { children: ReactNode }) {
+  return (
+    <p className="rounded-sm border border-dashed border-border/70 p-4 text-sm text-muted-foreground">
+      {children}
+    </p>
+  );
+}

--- a/web/src/pages/RoomHubsPage.tsx
+++ b/web/src/pages/RoomHubsPage.tsx
@@ -1,0 +1,260 @@
+import { useEffect, useMemo, useState } from "react";
+import { Link } from "react-router-dom";
+import {
+  AlertTriangle,
+  CheckCircle2,
+  ExternalLink,
+  Home,
+  MessageSquare,
+  Radio,
+  RotateCw,
+  WifiOff,
+} from "lucide-react";
+import { Badge } from "@nous-research/ui/ui/components/badge";
+import { Card, CardContent, CardHeader, CardTitle } from "@nous-research/ui/ui/components/card";
+import { Spinner } from "@nous-research/ui/ui/components/spinner";
+import { api } from "@/lib/api";
+import type { MessagingPlatform } from "@/lib/api";
+import { cn } from "@/lib/utils";
+
+const stateTone: Record<string, "success" | "warning" | "destructive" | "secondary" | "outline"> = {
+  connected: "success",
+  disabled: "secondary",
+  disconnected: "warning",
+  fatal: "destructive",
+  gateway_stopped: "warning",
+  not_configured: "outline",
+  pending_restart: "warning",
+  startup_failed: "destructive",
+};
+
+function formatState(state: string): string {
+  return state.replace(/_/g, " ");
+}
+
+export default function RoomHubsPage() {
+  const [platforms, setPlatforms] = useState<MessagingPlatform[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    api
+      .getMessagingPlatforms()
+      .then((res) => {
+        if (!cancelled) setPlatforms(res.platforms);
+      })
+      .catch((err) => {
+        if (!cancelled) setError(String(err));
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const hubs = useMemo(
+    () => platforms.filter((platform) => platform.home_channel !== null),
+    [platforms],
+  );
+  const configured = useMemo(
+    () => platforms.filter((platform) => platform.configured),
+    [platforms],
+  );
+  const connected = useMemo(
+    () => platforms.filter((platform) => platform.state === "connected"),
+    [platforms],
+  );
+
+  if (loading) {
+    return (
+      <div className="flex min-h-[18rem] items-center justify-center">
+        <Spinner className="text-2xl text-primary" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-5 pb-6">
+      <section className="grid gap-4 xl:grid-cols-[minmax(0,1fr)_22rem]">
+        <Card className="border-midground/25 bg-card/70">
+          <CardContent className="p-5 sm:p-6">
+            <div className="flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
+              <div className="space-y-2">
+                <Badge tone="outline" className="w-fit uppercase tracking-[0.16em]">
+                  room hubs
+                </Badge>
+                <h2 className="font-expanded text-2xl font-bold tracking-[0.06em] text-midground sm:text-3xl">
+                  Messaging rooms, kept deliberately off the main screen.
+                </h2>
+                <p className="max-w-3xl text-sm leading-6 text-muted-foreground">
+                  This page collects home channels and configured platforms. The dashboard gets the quick signal; this page gets the room-level plumbing.
+                </p>
+              </div>
+              <Link
+                to="/channels"
+                className="inline-flex shrink-0 items-center justify-center gap-2 rounded-sm border border-border px-3 py-2 text-sm font-medium uppercase tracking-[0.08em] text-foreground transition-colors hover:border-midground/50 hover:bg-midground/5"
+              >
+                <Radio className="h-4 w-4" />
+                Configure channels
+              </Link>
+            </div>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader className="pb-2">
+            <CardTitle className="text-base">Hub summary</CardTitle>
+          </CardHeader>
+          <CardContent className="grid grid-cols-3 gap-2 xl:grid-cols-1">
+            <Summary label="Home hubs" value={String(hubs.length)} icon={Home} />
+            <Summary label="Connected" value={String(connected.length)} icon={CheckCircle2} />
+            <Summary label="Configured" value={`${configured.length}/${platforms.length}`} icon={MessageSquare} />
+          </CardContent>
+        </Card>
+      </section>
+
+      {error ? (
+        <Card className="border-destructive/50">
+          <CardContent className="flex items-center gap-2 p-4 text-sm text-destructive">
+            <AlertTriangle className="h-4 w-4 shrink-0" />
+            Failed to load hubs: {error}
+          </CardContent>
+        </Card>
+      ) : null}
+
+      <section className="grid gap-4 lg:grid-cols-[minmax(0,1fr)_minmax(0,1fr)]">
+        <Card>
+          <CardHeader className="pb-2">
+            <CardTitle className="flex items-center gap-2 text-base">
+              <Home className="h-4 w-4 text-midground" />
+              Home hubs
+            </CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-3">
+            {hubs.length > 0 ? hubs.map((platform) => (
+              <HubCard key={platform.id} platform={platform} prominent />
+            )) : (
+              <EmptyState
+                icon={WifiOff}
+                title="No home room yet"
+                detail="Use /sethome from a messaging room, then this page becomes the map. Very cartographic."
+              />
+            )}
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader className="pb-2">
+            <CardTitle className="flex items-center gap-2 text-base">
+              <Radio className="h-4 w-4 text-midground" />
+              Channel connectors
+            </CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-3">
+            {platforms.map((platform) => (
+              <HubCard key={platform.id} platform={platform} />
+            ))}
+          </CardContent>
+        </Card>
+      </section>
+    </div>
+  );
+}
+
+function HubCard({ platform, prominent = false }: { platform: MessagingPlatform; prominent?: boolean }) {
+  const home = platform.home_channel;
+  const missingRequired = platform.env_vars.filter((env) => env.required && !env.is_set);
+  const badgeTone = stateTone[platform.state] ?? "outline";
+
+  return (
+    <div
+      className={cn(
+        "rounded-sm border bg-background/30 p-3 transition-colors",
+        prominent ? "border-midground/35" : "border-border/70",
+      )}
+    >
+      <div className="flex items-start justify-between gap-3">
+        <div className="min-w-0">
+          <p className="truncate text-sm font-medium text-foreground">
+            {home?.name || platform.name}
+          </p>
+          <p className="mt-1 truncate text-xs text-muted-foreground">
+            {platform.description}
+          </p>
+        </div>
+        <Badge tone={badgeTone}>{formatState(platform.state)}</Badge>
+      </div>
+
+      <dl className="mt-3 grid gap-2 text-xs sm:grid-cols-2">
+        <HubDetail label="Platform" value={platform.name} />
+        <HubDetail label="Home" value={home ? "yes" : "not set"} />
+        {home ? <HubDetail label="Room" value={home.chat_id} mono /> : null}
+        {home?.thread_id ? <HubDetail label="Thread" value={home.thread_id} mono /> : null}
+      </dl>
+
+      <div className="mt-3 flex flex-wrap items-center gap-2">
+        {platform.docs_url ? (
+          <a
+            href={platform.docs_url}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-flex items-center gap-1.5 rounded-sm border border-border px-2.5 py-1.5 text-xs font-medium uppercase tracking-[0.08em] text-foreground transition-colors hover:border-midground/50 hover:bg-midground/5"
+          >
+            <ExternalLink className="h-3.5 w-3.5" />
+            Docs
+          </a>
+        ) : null}
+        {platform.state === "pending_restart" ? (
+          <span className="inline-flex items-center gap-1 text-xs text-warning">
+            <RotateCw className="h-3.5 w-3.5" /> Restart gateway to apply
+          </span>
+        ) : null}
+        {missingRequired.length > 0 ? (
+          <span className="inline-flex items-center gap-1 text-xs text-muted-foreground">
+            <AlertTriangle className="h-3.5 w-3.5" /> Missing {missingRequired.length} required value{missingRequired.length === 1 ? "" : "s"}
+          </span>
+        ) : null}
+      </div>
+    </div>
+  );
+}
+
+function HubDetail({ label, mono = false, value }: { label: string; mono?: boolean; value: string }) {
+  return (
+    <div className="min-w-0 rounded-sm border border-border/60 bg-card/30 px-2 py-1.5">
+      <dt className="uppercase tracking-[0.14em] text-muted-foreground">{label}</dt>
+      <dd className={cn("mt-0.5 truncate text-foreground", mono && "font-courier")}>{value}</dd>
+    </div>
+  );
+}
+
+function Summary({ icon: Icon, label, value }: { icon: typeof Home; label: string; value: string }) {
+  return (
+    <div className="rounded-sm border border-border/70 bg-background/30 p-3">
+      <Icon className="h-4 w-4 text-midground" />
+      <p className="mt-3 text-xs uppercase tracking-[0.14em] text-muted-foreground">{label}</p>
+      <p className="mt-1 text-lg font-semibold text-foreground">{value}</p>
+    </div>
+  );
+}
+
+function EmptyState({
+  detail,
+  icon: Icon,
+  title,
+}: {
+  detail: string;
+  icon: typeof WifiOff;
+  title: string;
+}) {
+  return (
+    <div className="rounded-sm border border-dashed border-border/70 p-5 text-center">
+      <Icon className="mx-auto h-6 w-6 text-muted-foreground" />
+      <p className="mt-3 text-sm font-medium text-foreground">{title}</p>
+      <p className="mt-1 text-sm text-muted-foreground">{detail}</p>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add a new single-screen Dashboard landing page with gateway/model/session/channel context and quick action rail
- add a dedicated Room Hubs page for home channels and channel connector details
- route `/` to the Dashboard and add Dashboard / Room Hubs to navigation and page titles

## Verification
- `npm run typecheck --workspace web`
- `npm run build --workspace web`
- `npx eslint src/App.tsx src/lib/resolve-page-title.ts src/pages/DashboardPage.tsx src/pages/RoomHubsPage.tsx` from `web/`
- launched `hermes dashboard --host 127.0.0.1 --port 9127 --no-open --skip-build` and verified `/dashboard` and `/hubs` in browser
