### PR TITLE
fix(feishu): honor FEISHU_ALLOW_ALL_USERS in approval card handler

### DIFF
--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -2599,7 +2599,11 @@ class FeishuAdapter(BasePlatformAdapter):
         operator = getattr(event, "operator", None)
         open_id = str(getattr(operator, "open_id", "") or "")
         sender_id = SimpleNamespace(open_id=open_id, user_id=str(getattr(operator, "user_id", "") or ""))
-        if not self._allow_group_message(sender_id, state.get("chat_id", ""), is_bot=False):
+        allow_all = (
+            os.getenv("FEISHU_ALLOW_ALL_USERS", "").lower() in {"true", "1", "yes"}
+            or os.getenv("GATEWAY_ALLOW_ALL_USERS", "").lower() in {"true", "1", "yes"}
+        )
+        if not allow_all and not self._allow_group_message(sender_id, state.get("chat_id", ""), is_bot=False):
             logger.warning("[Feishu] Unauthorized approval click by %s", open_id or "<unknown>")
             return P2CardActionTriggerResponse() if P2CardActionTriggerResponse else None
 


### PR DESCRIPTION
## Problem

The `_handle_approval_card_action` method in `gateway/platforms/feishu.py` calls `_allow_group_message` to authorize approval button clicks, but it doesn't check `FEISHU_ALLOW_ALL_USERS` or `GATEWAY_ALLOW_ALL_USERS` environment variables.

When `FEISHU_ALLOW_ALL_USERS=true` is set (common setup for single-user bots), normal messages work fine via `authz_mixin`, but approval button clicks are **silently rejected** with:

```
[Feishu] Unauthorized approval click by ou_xxxxx
```

This was introduced in commit `bdb97b857`.

## Fix

Added the same `allow_all` check that `authz_mixin` uses for normal messages, so approval cards use the same authorization logic as regular messages.

## Test Plan

- [ ] Set `FEISHU_ALLOW_ALL_USERS=true`, send a command that requires approval, verify the approval button works
- [ ] Without `FEISHU_ALLOW_ALL_USERS`, verify approval still requires allowlist membership