### PR TITLE
fix(gateway): only buffer tag prefixes of length >= 2 in stream consumer (#48869)

### DIFF
--- a/gateway/stream_consumer.py
+++ b/gateway/stream_consumer.py
@@ -1,4 +1,4 @@
-"""Gateway streaming consumer — bridges sync agent callbacks to async platform delivery.
+﻿"""Gateway streaming consumer — bridges sync agent callbacks to async platform delivery.
 
 The agent fires stream_delta_callback(text) synchronously from its worker thread.
 GatewayStreamConsumer:
@@ -419,7 +419,7 @@ class GatewayStreamConsumer:
                     # No opening tag — check for a partial tag at the tail
                     held_back = 0
                     for tag in self._OPEN_THINK_TAGS:
-                        for i in range(1, len(tag)):
+                        for i in range(2, len(tag)):
                             if buf.endswith(tag[:i]) and i > held_back:
                                 held_back = i
                     if held_back:

--- a/tests/gateway/test_stream_consumer.py
+++ b/tests/gateway/test_stream_consumer.py
@@ -1,4 +1,4 @@
-"""Tests for GatewayStreamConsumer — media directive stripping in streaming."""
+﻿"""Tests for GatewayStreamConsumer — media directive stripping in streaming."""
 
 import asyncio
 from types import SimpleNamespace
@@ -1948,3 +1948,46 @@ class TestUtf16OverflowDetection:
         # this file passing — they all use MagicMock adapters.
         assert consumer is not None
 
+
+
+class TestFilterAndAccumulateLtChar:
+    """Regression tests for issue #48869.
+
+    A standalone '<' character must never be held back in _think_buffer.
+    Only prefixes of length >= 2 (e.g. '<t', '</') should be buffered.
+    """
+
+    def test_standalone_lt_passes_through_immediately(self):
+        """A bare '<' must not be clipped from the stream."""
+        c = _make_consumer()
+        c._filter_and_accumulate("Use a < b for comparison")
+        assert c._accumulated == "Use a < b for comparison"
+        assert c._think_buffer == ""
+
+    def test_lt_at_end_of_chunk_passes_through(self):
+        """'<' at the end of a chunk must flush, not stall the stream."""
+        c = _make_consumer()
+        c._filter_and_accumulate("value <")
+        assert c._accumulated == "value <"
+        assert c._think_buffer == ""
+
+    def test_lt_followed_by_non_tag_char_passes_through(self):
+        """'<3' (heart emoji text) must not be buffered as a tag prefix."""
+        c = _make_consumer()
+        c._filter_and_accumulate("I <3 you")
+        assert c._accumulated == "I <3 you"
+        assert c._think_buffer == ""
+
+    def test_valid_partial_tag_still_buffered(self):
+        """'<th' is a valid prefix of '<think>' and must still be held back."""
+        c = _make_consumer()
+        c._filter_and_accumulate("before <th")
+        assert c._think_buffer == "<th"
+        assert c._accumulated == "before "
+
+    def test_full_think_tag_still_filtered_after_fix(self):
+        """Complete think blocks must still be stripped after the fix."""
+        c = _make_consumer()
+        c._filter_and_accumulate("<think>hidden</think>visible")
+        assert c._accumulated == "visible"
+        assert "hidden" not in c._accumulated


### PR DESCRIPTION
Fixes #48869

## Problem

`GatewayStreamConsumer._filter_and_accumulate` used `range(1, len(tag))`
when scanning for partial thinking-tag prefixes at the tail of a chunk.
Since every thinking tag starts with `<`, a standalone `<` character
matched `tag[:1]` for all tags, setting `held_back=1` and stashing the
`<` into `_think_buffer`. The character (and everything after it) was
invisible in the stream until `finalize()` flushed the buffer at the
very end, making the message appear clipped mid-sentence.

## Fix

Changed `range(1, len(tag))` to `range(2, len(tag))` so the minimum
bufferable prefix is 2 characters (e.g. `<t`, `</`). A bare `<` or
`<3` now flushes immediately. Real partial tags like `<thi` or `</th`
still buffer correctly.

## Changes

- `gateway/stream_consumer.py`: `range(1,` → `range(2,` in the held-back loop
- `tests/gateway/test_stream_consumer.py`: add `TestFilterAndAccumulateLtChar` (5 cases)

## Tests