### PR TITLE
fix(tui): keep hosted dashboard chat alive on /exit (salvage #48739)

### DIFF
--- a/ui-tui/src/__tests__/createSlashHandler.test.ts
+++ b/ui-tui/src/__tests__/createSlashHandler.test.ts
@@ -2,17 +2,30 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { createSlashHandler } from '../app/createSlashHandler.js'
 import { getOverlayState, resetOverlayState } from '../app/overlayStore.js'
+import { DASHBOARD_EXIT_DISABLED_MESSAGE } from '../app/slash/commands/core.js'
 import { getUiState, patchUiState, resetUiState } from '../app/uiStore.js'
 import { TUI_SESSION_MODEL_FLAG } from '../domain/slash.js'
+
+// DASHBOARD_TUI_MODE resolves once at module load from HERMES_TUI_DASHBOARD,
+// so toggling process.env in a test body can't move it. Mock just that one
+// export (everything else stays real) and flip the holder per test.
+const envState = { dashboardTuiMode: false }
+vi.mock('../config/env.js', async importActual => {
+  const actual = await importActual<typeof import('../config/env.js')>()
+
+  return {
+    ...actual,
+    get DASHBOARD_TUI_MODE() {
+      return envState.dashboardTuiMode
+    }
+  }
+})
 
 describe('createSlashHandler', () => {
   beforeEach(() => {
     resetOverlayState()
     resetUiState()
-    delete process.env.HERMES_TUI_INLINE
-    delete process.env.HERMES_HOME
-    delete process.env.HERMES_WRITE_SAFE_ROOT
-    delete process.env.HERMES_DISABLE_LAZY_INSTALLS
+    envState.dashboardTuiMode = false
   })
 
   it('opens the unified sessions overlay for /resume', () => {
@@ -73,25 +86,17 @@ describe('createSlashHandler', () => {
   })
 
   it('keeps hosted dashboard chat alive for /exit', () => {
-    process.env.HERMES_TUI_INLINE = '1'
-    process.env.HERMES_HOME = '/opt/data/profiles/worker'
-    process.env.HERMES_WRITE_SAFE_ROOT = '/opt/data'
-    process.env.HERMES_DISABLE_LAZY_INSTALLS = '1'
+    envState.dashboardTuiMode = true
     const ctx = buildCtx()
 
     expect(createSlashHandler(ctx)('/exit')).toBe(true)
     expect(ctx.session.die).not.toHaveBeenCalled()
     expect(ctx.gateway.gw.request).not.toHaveBeenCalled()
-    expect(ctx.transcript.sys).toHaveBeenCalledWith(
-      'exit is disabled in hosted dashboard chat — use /new to start a fresh session'
-    )
+    expect(ctx.transcript.sys).toHaveBeenCalledWith(DASHBOARD_EXIT_DISABLED_MESSAGE)
   })
 
   it('keeps /quit available outside hosted dashboard chat', () => {
-    process.env.HERMES_TUI_INLINE = '1'
-    process.env.HERMES_HOME = '/Users/example/.hermes'
-    process.env.HERMES_WRITE_SAFE_ROOT = '/Users/example/.hermes'
-    process.env.HERMES_DISABLE_LAZY_INSTALLS = '1'
+    envState.dashboardTuiMode = false
     const ctx = buildCtx()
 
     expect(createSlashHandler(ctx)('/quit')).toBe(true)

--- a/ui-tui/src/__tests__/createSlashHandler.test.ts
+++ b/ui-tui/src/__tests__/createSlashHandler.test.ts
@@ -9,6 +9,10 @@ describe('createSlashHandler', () => {
   beforeEach(() => {
     resetOverlayState()
     resetUiState()
+    delete process.env.HERMES_TUI_INLINE
+    delete process.env.HERMES_HOME
+    delete process.env.HERMES_WRITE_SAFE_ROOT
+    delete process.env.HERMES_DISABLE_LAZY_INSTALLS
   })
 
   it('opens the unified sessions overlay for /resume', () => {
@@ -66,6 +70,32 @@ describe('createSlashHandler', () => {
     expect(createSlashHandler(ctx)('/quit')).toBe(true)
     expect(ctx.session.die).toHaveBeenCalledTimes(1)
     expect(ctx.gateway.gw.request).not.toHaveBeenCalled()
+  })
+
+  it('keeps hosted dashboard chat alive for /exit', () => {
+    process.env.HERMES_TUI_INLINE = '1'
+    process.env.HERMES_HOME = '/opt/data/profiles/worker'
+    process.env.HERMES_WRITE_SAFE_ROOT = '/opt/data'
+    process.env.HERMES_DISABLE_LAZY_INSTALLS = '1'
+    const ctx = buildCtx()
+
+    expect(createSlashHandler(ctx)('/exit')).toBe(true)
+    expect(ctx.session.die).not.toHaveBeenCalled()
+    expect(ctx.gateway.gw.request).not.toHaveBeenCalled()
+    expect(ctx.transcript.sys).toHaveBeenCalledWith(
+      'exit is disabled in hosted dashboard chat — use /new to start a fresh session'
+    )
+  })
+
+  it('keeps /quit available outside hosted dashboard chat', () => {
+    process.env.HERMES_TUI_INLINE = '1'
+    process.env.HERMES_HOME = '/Users/example/.hermes'
+    process.env.HERMES_WRITE_SAFE_ROOT = '/Users/example/.hermes'
+    process.env.HERMES_DISABLE_LAZY_INSTALLS = '1'
+    const ctx = buildCtx()
+
+    expect(createSlashHandler(ctx)('/quit')).toBe(true)
+    expect(ctx.session.die).toHaveBeenCalledTimes(1)
   })
 
   it('handles /update locally and exits with code 42 via dieWithCode', () => {

--- a/ui-tui/src/app/slash/commands/core.ts
+++ b/ui-tui/src/app/slash/commands/core.ts
@@ -76,6 +76,20 @@ const DETAILS_USAGE =
 
 const DETAILS_SECTION_USAGE = 'usage: /details <section> [hidden|collapsed|expanded|reset]'
 
+const truthyEnv = (v?: string) => /^(?:1|true|yes|on)$/i.test((v ?? '').trim())
+
+const hostedInlineDashboardChat = () => {
+  const hermesHome = (process.env.HERMES_HOME ?? '').trim()
+  const hostedHome = hermesHome === '/opt/data' || hermesHome.startsWith('/opt/data/')
+
+  return (
+    process.env.HERMES_TUI_INLINE === '1' &&
+    hostedHome &&
+    process.env.HERMES_WRITE_SAFE_ROOT === '/opt/data' &&
+    truthyEnv(process.env.HERMES_DISABLE_LAZY_INSTALLS)
+  )
+}
+
 export const coreCommands: SlashCommand[] = [
   {
     help: 'list commands + hotkeys',
@@ -113,7 +127,15 @@ export const coreCommands: SlashCommand[] = [
     aliases: ['exit'],
     help: 'exit hermes',
     name: 'quit',
-    run: (_arg, ctx) => ctx.session.die()
+    run: (_arg, ctx) => {
+      if (hostedInlineDashboardChat()) {
+        ctx.transcript.sys('exit is disabled in hosted dashboard chat — use /new to start a fresh session')
+
+        return
+      }
+
+      ctx.session.die()
+    }
   },
 
   {

--- a/ui-tui/src/app/slash/commands/core.ts
+++ b/ui-tui/src/app/slash/commands/core.ts
@@ -1,6 +1,6 @@
 import { forceRedraw, type MouseTrackingMode } from '@hermes/ink'
 
-import { NO_CONFIRM_DESTRUCTIVE } from '../../../config/env.js'
+import { DASHBOARD_TUI_MODE, NO_CONFIRM_DESTRUCTIVE } from '../../../config/env.js'
 import { dailyFortune, randomFortune } from '../../../content/fortunes.js'
 import { HOTKEYS } from '../../../content/hotkeys.js'
 import { isSectionName, nextDetailsMode, parseDetailsMode, SECTION_NAMES } from '../../../domain/details.js'
@@ -76,19 +76,10 @@ const DETAILS_USAGE =
 
 const DETAILS_SECTION_USAGE = 'usage: /details <section> [hidden|collapsed|expanded|reset]'
 
-const truthyEnv = (v?: string) => /^(?:1|true|yes|on)$/i.test((v ?? '').trim())
-
-const hostedInlineDashboardChat = () => {
-  const hermesHome = (process.env.HERMES_HOME ?? '').trim()
-  const hostedHome = hermesHome === '/opt/data' || hermesHome.startsWith('/opt/data/')
-
-  return (
-    process.env.HERMES_TUI_INLINE === '1' &&
-    hostedHome &&
-    process.env.HERMES_WRITE_SAFE_ROOT === '/opt/data' &&
-    truthyEnv(process.env.HERMES_DISABLE_LAZY_INSTALLS)
-  )
-}
+// Shown when /exit or /quit is refused in the hosted dashboard chat. Kept as a
+// constant so the test asserts against the same source of truth as production.
+export const DASHBOARD_EXIT_DISABLED_MESSAGE =
+  'exit is disabled in hosted dashboard chat — use /new to start a fresh session'
 
 export const coreCommands: SlashCommand[] = [
   {
@@ -128,8 +119,15 @@ export const coreCommands: SlashCommand[] = [
     help: 'exit hermes',
     name: 'quit',
     run: (_arg, ctx) => {
-      if (hostedInlineDashboardChat()) {
-        ctx.transcript.sys('exit is disabled in hosted dashboard chat — use /new to start a fresh session')
+      // In the hosted dashboard chat there is no in-page restart path after
+      // the PTY child exits, so quitting bricks the tab until a refresh. The
+      // keyboard idle-exit (Ctrl+C / Ctrl+D) and SIGINT handling already refuse
+      // to die in this mode (see useInputHandlers + entry.tsx); gate /exit and
+      // /quit on the same DASHBOARD_TUI_MODE flag. Unlike the keyboard path
+      // (which auto-starts a fresh chat), the explicit quit command refuses and
+      // instructs the user to run /new themselves.
+      if (DASHBOARD_TUI_MODE) {
+        ctx.transcript.sys(DASHBOARD_EXIT_DISABLED_MESSAGE)
 
         return
       }


### PR DESCRIPTION
## Summary

Salvage of #48739 (NS-524): typing `/exit` or `/quit` in the hosted browser dashboard chat killed the backing PTY and bricked the tab until a page refresh. Now those commands refuse in hosted mode and point the user at `/new`.

The one substantive change from the original PR: instead of a bespoke 4-env-var fingerprint, this reuses the existing `DASHBOARD_TUI_MODE` flag (`HERMES_TUI_DASHBOARD`) that the keyboard idle-exit (`useInputHandlers`) and SIGINT-ignore (`entry.tsx`) paths already key on — one hosted-detection mechanism instead of two divergent ones.

## Changes

- `ui-tui/src/app/slash/commands/core.ts`: `/quit` (alias `/exit`) early-returns with a refusal message when `DASHBOARD_TUI_MODE` is set, instead of `ctx.session.die()`. Refusal text extracted to exported `DASHBOARD_EXIT_DISABLED_MESSAGE`.
- `ui-tui/src/__tests__/createSlashHandler.test.ts`: two tests (hosted `/exit` refuses; non-hosted `/quit` still dies), mocking only the `DASHBOARD_TUI_MODE` export via `importActual` so other env exports stay real. Asserts against the exported constant (no change-detector on the literal).

## Why reuse `DASHBOARD_TUI_MODE` (vs the original PR's fingerprint)

The original PR detected hosted mode via `HERMES_TUI_INLINE=1` + `/opt/data` `HERMES_HOME` + `HERMES_WRITE_SAFE_ROOT=/opt/data` + `HERMES_DISABLE_LAZY_INSTALLS=1`. That fingerprint is correct (matches the Dockerfile + `web_server.py`), but the codebase **already** had a single hosted flag — `DASHBOARD_TUI_MODE = truthy(process.env.HERMES_TUI_DASHBOARD)` — and the sibling keyboard-exit and SIGINT paths already use it. Adding a second, divergent detector for the slash path would let the two disagree. This salvage keeps all three hosted-exit paths (Ctrl+C/Ctrl+D, SIGINT, `/exit`/`/quit`) on one flag.

UX note: the keyboard path auto-starts a fresh chat; the explicit quit command refuses and instructs the user to run `/new` — intentional (explicit command vs accidental keystroke), documented in the code comment.

## Validation

| | Result |
|---|---|
| `tsc --noEmit -p tsconfig.json` (ui-tui) | clean (exit 0) |
| `vitest run createSlashHandler.test.ts` | 60/60 passed |
| Mutation check (defeat the guard) | hosted test fails as expected — guard has teeth |

## Follow-up (not in this PR)

`/update` (`dieWithCode(42)`) is **not** gated on `DASHBOARD_TUI_MODE`, so it would brick the hosted tab the same way — same defect class, different command, out of scope for NS-524. Worth a separate decision (gate it, or block self-update in hosted chat entirely).

Closes #48739. Contributor commit cherry-picked with authorship preserved (@shannonsands).
