### PR TITLE
fix(lmstudio): use detected context for runtime preload when no override is set

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -658,11 +658,22 @@ class AIAgent:
         if (self.provider or "").strip().lower() != "lmstudio":
             return
         try:
-            from agent.model_metadata import MINIMUM_CONTEXT_LENGTH
+            from agent.model_metadata import MINIMUM_CONTEXT_LENGTH, get_model_context_length
             from hermes_cli.models import ensure_lmstudio_model_loaded
             if config_context_length is None:
                 config_context_length = getattr(self, "_config_context_length", None)
-            target_ctx = max(config_context_length or 0, MINIMUM_CONTEXT_LENGTH)
+            if config_context_length:
+                target_ctx = max(config_context_length, MINIMUM_CONTEXT_LENGTH)
+            else:
+                detected_ctx = get_model_context_length(
+                    self.model,
+                    base_url=self.base_url,
+                    api_key=getattr(self, "api_key", ""),
+                    config_context_length=None,
+                    provider=self.provider,
+                    custom_providers=getattr(self, "_custom_providers", None),
+                )
+                target_ctx = max(MINIMUM_CONTEXT_LENGTH, detected_ctx or 0)
             loaded_ctx = ensure_lmstudio_model_loaded(
                 self.model, self.base_url, getattr(self, "api_key", ""), target_ctx,
             )

--- a/tests/agent/test_lmstudio_runtime_load.py
+++ b/tests/agent/test_lmstudio_runtime_load.py
@@ -1,0 +1,69 @@
+from types import SimpleNamespace
+from typing import Any, cast
+from unittest.mock import patch
+
+from run_agent import AIAgent
+
+
+class TestEnsureLmstudioRuntimeLoaded:
+    def _agent(self):
+        return SimpleNamespace(
+            provider="lmstudio",
+            model="qwen3.6-35b-a3b-uncensored-heretic-native-mtp-preserved",
+            base_url="http://192.168.1.209:1234/v1",
+            api_key="",
+            api_mode="chat_completions",
+            _config_context_length=None,
+            _custom_providers=None,
+            context_compressor=None,
+            quiet_mode=True,
+        )
+
+    def test_uses_detected_context_when_no_explicit_override(self):
+        agent = cast(Any, self._agent())
+        with patch("agent.model_metadata.get_model_context_length", return_value=262144) as mock_ctx:
+            with patch("hermes_cli.models.ensure_lmstudio_model_loaded", return_value=262144) as mock_load:
+                AIAgent._ensure_lmstudio_runtime_loaded(agent, None)
+
+        mock_ctx.assert_called_once_with(
+            agent.model,
+            base_url=agent.base_url,
+            api_key=agent.api_key,
+            config_context_length=None,
+            provider=agent.provider,
+            custom_providers=agent._custom_providers,
+        )
+        mock_load.assert_called_once_with(
+            agent.model,
+            agent.base_url,
+            agent.api_key,
+            262144,
+        )
+
+    def test_explicit_override_beats_detected_context(self):
+        agent = cast(Any, self._agent())
+        with patch("agent.model_metadata.get_model_context_length", return_value=262144) as mock_ctx:
+            with patch("hermes_cli.models.ensure_lmstudio_model_loaded", return_value=131072) as mock_load:
+                AIAgent._ensure_lmstudio_runtime_loaded(agent, 131072)
+
+        mock_ctx.assert_not_called()
+        mock_load.assert_called_once_with(
+            agent.model,
+            agent.base_url,
+            agent.api_key,
+            131072,
+        )
+
+    def test_falls_back_to_minimum_when_detected_context_missing(self):
+        agent = cast(Any, self._agent())
+        with patch("agent.model_metadata.get_model_context_length", return_value=None) as mock_ctx:
+            with patch("hermes_cli.models.ensure_lmstudio_model_loaded", return_value=64000) as mock_load:
+                AIAgent._ensure_lmstudio_runtime_loaded(agent, None)
+
+        mock_ctx.assert_called_once()
+        mock_load.assert_called_once_with(
+            agent.model,
+            agent.base_url,
+            agent.api_key,
+            64000,
+        )


### PR DESCRIPTION
## Summary
- use the detected LM Studio context window for runtime preload when `model.context_length` is not explicitly set
- keep explicit `model.context_length` overrides authoritative
- add regression tests covering runtime preload target selection

## Problem
Hermes resolved the larger LM Studio context window correctly for budgeting/display, but `_ensure_lmstudio_runtime_loaded()` still preloaded LM Studio models with:

```python
target_ctx = max(config_context_length or 0, MINIMUM_CONTEXT_LENGTH)
```

When no explicit override was set, that forced the runtime load target to Hermes' 64K minimum even when `get_model_context_length(...)` resolved a larger LM Studio `max_context_length`.

In practice this meant:
- autodetection could report the correct larger context
- but LM Studio was still actually loaded at 64K

## Fix
If `model.context_length` is explicitly set, keep using it.

Otherwise, resolve the model context via `get_model_context_length(...)` and use that detected value as the LM Studio preload target, floored at `MINIMUM_CONTEXT_LENGTH` only as a fallback.

## Why this is separate from #45037
PR #45037 fixes the **autodetection/reporting** path when LM Studio is already loaded at the default 64K.

This PR fixes the **runtime preload/load-target** path that was still forcing LM Studio to load at 64K when no explicit override was set.

## Tests
```bash
python -m pytest tests/agent/test_lmstudio_runtime_load.py -q -o addopts=''
python -m pytest tests/agent/test_model_metadata_local_ctx.py -q -o addopts=''
```

## Related
- fixes #25989
- related to #45037
- related to #30178
