### PR TITLE
fix: SessionDB API signature mismatch for _insert_session_row and app…

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -1282,6 +1282,7 @@ class SessionDB:
         user_id: str = None,
         parent_session_id: str = None,
         cwd: str = None,
+        **kwargs,
     ) -> None:
         """Shared INSERT OR IGNORE for session rows."""
         def _do(conn):
@@ -2374,6 +2375,7 @@ class SessionDB:
         codex_message_items: Any = None,
         platform_message_id: str = None,
         observed: bool = False,
+        timestamp: float = None,
     ) -> int:
         """
         Append a message to a session. Returns the message row ID.
@@ -2420,12 +2422,12 @@ class SessionDB:
                 (
                     session_id,
                     role,
-                    stored_content,
-                    tool_call_id,
-                    tool_calls_json,
-                    tool_name,
-                    time.time(),
-                    token_count,
+                     stored_content,
+                     tool_call_id,
+                     tool_calls_json,
+                     tool_name,
+                     time.time() if timestamp is None else timestamp,
+                     token_count,
                     finish_reason,
                     reasoning,
                     reasoning_content,

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -788,6 +788,75 @@ class TestMessageStorage:
         assert conv[0]["codex_reasoning_items"][0]["encrypted_content"] == "enc_blob_123"
 
 
+    def test_insert_session_row_accepts_kwargs(self, db):
+        """_insert_session_row must accept **kwargs for forward compatibility."""
+        # This should not raise TypeError for unexpected keyword arguments
+        db._insert_session_row(
+            session_id="test-sess",
+            source="test-source",
+            model="test-model",
+            cwd="/test/path",
+            unexpected_arg="should-be-ignored",
+            another_arg=42,
+        )
+        
+        # Verify the session was created with expected values
+        session = db.get_session("test-sess")
+        assert session is not None
+        assert session["source"] == "test-source"
+        assert session["model"] == "test-model"
+        assert session["cwd"] == "/test/path"
+
+    def test_append_message_accepts_timestamp(self, db):
+        """append_message must accept timestamp parameter and use it when provided."""
+        db.create_session(session_id="test-sess", source="test")
+        
+        # Test 1: Provide explicit timestamp
+        fixed_time = 1234567890.0
+        msg_id = db.append_message(
+            session_id="test-sess",
+            role="user",
+            content="Test message with explicit timestamp",
+            timestamp=fixed_time,
+        )
+        
+        # Verify the message was stored with the provided timestamp
+        messages = db.get_messages("test-sess")
+        assert len(messages) == 1
+        assert messages[0]["timestamp"] == fixed_time
+        assert messages[0]["content"] == "Test message with explicit timestamp"
+        
+        # Test 2: Omit timestamp (should default to current time)
+        db.append_message(
+            session_id="test-sess",
+            role="assistant",
+            content="Test message with default timestamp",
+        )
+        
+        messages = db.get_messages("test-sess")
+        assert len(messages) == 2
+        # Second message should have a recent timestamp (within last 5 seconds)
+        assert messages[1]["timestamp"] is not None
+        assert isinstance(messages[1]["timestamp"], float)
+        assert messages[1]["timestamp"] > time.time() - 5
+        
+        # Test 3: Explicitly pass None (should also default to current time)
+        db.append_message(
+            session_id="test-sess",
+            role="tool",
+            content="Tool result with None timestamp",
+            timestamp=None,
+        )
+        
+        messages = db.get_messages("test-sess")
+        assert len(messages) == 3
+        # Third message should also have a recent timestamp
+        assert messages[2]["timestamp"] is not None
+        assert isinstance(messages[2]["timestamp"], float)
+        assert messages[2]["timestamp"] > time.time() - 5
+
+
+
 # =========================================================================
 # FTS5 search
 # =========================================================================


### PR DESCRIPTION
…end_message

- Add **kwargs to _insert_session_row to accept caller kwargs like cwd
- Add timestamp parameter to append_message to preserve original timestamps during message replay
- Fixes TypeError when callers pass unexpected keyword arguments
- References issue #48531

## What does this PR do?

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->



## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Fixes #

## Type of Change

<!-- Check the one that applies. -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- 

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. 
2. 
3. 

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [ ] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

<!-- Only fill this out if you're adding a skill. Delete this section otherwise. -->

- [ ] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [ ] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

