### PR TITLE
fix(gateway): replace bare asserts with proper error handling in relay/bluebubbles

### DIFF
--- a/gateway/platforms/bluebubbles.py
+++ b/gateway/platforms/bluebubbles.py
@@ -216,13 +216,15 @@ class BlueBubblesAdapter(BasePlatformAdapter):
         return text
 
     async def _api_get(self, path: str) -> Dict[str, Any]:
-        assert self.client is not None
+        if self.client is None:
+            raise RuntimeError("_api_get called before client is initialized")
         res = await self.client.get(self._api_url(path))
         res.raise_for_status()
         return res.json()
 
     async def _api_post(self, path: str, payload: Dict[str, Any]) -> Dict[str, Any]:
-        assert self.client is not None
+        if self.client is None:
+            raise RuntimeError("_api_post called before client is initialized")
         res = await self.client.post(self._api_url(path), json=payload)
         res.raise_for_status()
         return res.json()

--- a/gateway/relay/ws_transport.py
+++ b/gateway/relay/ws_transport.py
@@ -277,7 +277,8 @@ class WebSocketRelayTransport:
         await self._ws.send(json.dumps(frame) + "\n")
 
     async def _read_loop(self) -> None:
-        assert self._ws is not None
+        if self._ws is None:
+            raise RuntimeError("_read_loop called before transport is connected")
         buf = ""
         try:
             async for chunk in self._ws:


### PR DESCRIPTION
## Summary

Replace bare `assert` statements in production gateway code with explicit `if ... raise RuntimeError` guards.

Python's `assert` statements are **stripped** when running with the `-O` (optimize) flag, turning precondition checks into silent no-ops. This leads to confusing `AttributeError` or `NoneType` errors downstream instead of clear error messages.

### Files fixed:
- `gateway/relay/ws_transport.py`: `_read_loop()` — `assert self._ws is not None`
- `gateway/platforms/bluebubbles.py`: `_api_get()` and `_api_post()` — `assert self.client is not None`

### Pattern:
```python
# Before (stripped with python -O):
assert self._ws is not None

# After (always runs):
if self._ws is None:
    raise RuntimeError("_read_loop called before transport is connected")
```

This follows the same pattern established in prior assert-cleanup PRs (#48779, #48798, #48802).

## Test plan
- [x] All 93 relay tests pass
- [x] Lint check passes
- [ ] CI green
