### PR TITLE
docs(skills): fix himalaya CLI arg order and download flag (closes #48835)

### DIFF
--- a/skills/email/himalaya/SKILL.md
+++ b/skills/email/himalaya/SKILL.md
@@ -213,16 +213,16 @@ Note: `himalaya message write` without piped input opens `$EDITOR`. This works w
 
 ### Move/Copy Emails
 
-Move to folder:
+Move to folder (target folder comes first, then the message ID):
 
 ```bash
-himalaya message move 42 "Archive"
+himalaya message move "Archive" 42
 ```
 
-Copy to folder:
+Copy to folder (target folder comes first, then the message ID):
 
 ```bash
-himalaya message copy 42 "Important"
+himalaya message copy "Important" 42
 ```
 
 ### Delete an Email
@@ -270,7 +270,7 @@ himalaya attachment download 42
 Save to specific directory:
 
 ```bash
-himalaya attachment download 42 --dir ~/Downloads
+himalaya attachment download 42 --downloads-dir ~/Downloads
 ```
 
 ## Output Formats

--- a/website/docs/user-guide/skills/bundled/email/email-himalaya.md
+++ b/website/docs/user-guide/skills/bundled/email/email-himalaya.md
@@ -226,13 +226,13 @@ Note: `himalaya message write` without piped input opens `$EDITOR`. This works w
 Move to folder:
 
 ```bash
-himalaya message move 42 "Archive"
+himalaya message move "Archive" 42
 ```
 
 Copy to folder:
 
 ```bash
-himalaya message copy 42 "Important"
+himalaya message copy "Important" 42
 ```
 
 ### Delete an Email
@@ -280,7 +280,7 @@ himalaya attachment download 42
 Save to specific directory:
 
 ```bash
-himalaya attachment download 42 --dir ~/Downloads
+himalaya attachment download 42 --downloads-dir ~/Downloads
 ```
 
 ## Output Formats

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/skills/bundled/email/email-himalaya.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/skills/bundled/email/email-himalaya.md
@@ -217,13 +217,13 @@ himalaya message write -H "To:recipient@example.com" -H "Subject:Test" "Message 
 移动到文件夹：
 
 ```bash
-himalaya message move 42 "Archive"
+himalaya message move "Archive" 42
 ```
 
 复制到文件夹：
 
 ```bash
-himalaya message copy 42 "Important"
+himalaya message copy "Important" 42
 ```
 
 ### 删除邮件
@@ -271,7 +271,7 @@ himalaya attachment download 42
 保存到指定目录：
 
 ```bash
-himalaya attachment download 42 --dir ~/Downloads
+himalaya attachment download 42 --downloads-dir ~/Downloads
 ```
 
 ## 输出格式


### PR DESCRIPTION
## Summary

- Fixes incorrect `himalaya` CLI examples in the bundled skill and its website docs.
- OpenClaw/Hermes users following the himalaya skill currently get errors because the documented argument order and an attachment flag don't match Himalaya CLI v1.2.0.

## Motivation

Closes #48835.

The bundled `himalaya` skill documents `message move`/`message copy` with the message ID first and the target folder second, and `attachment download` with a `--dir` flag. None of these match the current CLI, so an agent (or user) that follows the skill verbatim issues failing commands.

## Root cause / verification

Verified directly against the [`pimalaya/himalaya` v1.2.0](https://github.com/pimalaya/himalaya/tree/v1.2.0) source (the version named in the issue):

- **`message move`** — `MessageMoveCommand` declares `target_folder` (a positional `TargetFolderNameArg`) **before** `envelopes` (`src/email/message/command/move.rs`), so usage is `message move [OPTIONS] <TARGET> <ID>...`. The doc's `move 42 "Archive"` is reversed; correct is `move "Archive" 42`.
- **`message copy`** — identical positional ordering in `src/email/message/command/copy.rs`.
- **`attachment download`** — `AttachmentDownloadCommand` exposes the override flag as `#[arg(short = 'd', long, ...)] pub downloads_dir` → `-d, --downloads-dir <PATH>` (`src/email/message/attachment/command/download.rs`). There is no `--dir`.

## Fix

Corrected the examples in all three surfaces that carried them (grep-confirmed no other occurrences remain):

- `skills/email/himalaya/SKILL.md`
- `website/docs/user-guide/skills/bundled/email/email-himalaya.md`
- `website/i18n/zh-Hans/.../email-himalaya.md`

Docs-only change; no code paths touched, so no test changes are warranted.

## Differential value

The two existing open PRs touching the himalaya issue space target the OAuth sanitizer (#48865/#48868, unrelated). No open PR addresses #48835.
