### PR TITLE
fix(telegram): allow per-chat rich message fallback

### DIFF
--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -426,6 +426,12 @@ class TelegramAdapter(BasePlatformAdapter):
         # clients that accept but render rich messages poorly via
         # platforms.telegram.extra.rich_messages: false.
         self._rich_messages_enabled: bool = self._coerce_bool_extra("rich_messages", True)
+        # Allow operators to pin known-problem chats back to the legacy
+        # MarkdownV2/sendMessageDraft path without disabling rich delivery
+        # globally for every Telegram chat.
+        self._rich_messages_disable_chats: set[str] = self._config_chat_id_set(
+            "rich_messages_disable_chats"
+        )
         # Latched off after a capability failure on sendRichMessage /
         # sendRichMessageDraft (e.g. older python-telegram-bot without the
         # endpoint) so later sends skip the doomed rich attempt entirely.
@@ -981,6 +987,18 @@ class TelegramAdapter(BasePlatformAdapter):
                 return True
         return False
 
+    def _config_chat_id_set(self, key: str) -> set[str]:
+        raw = self.config.extra.get(key) if getattr(self.config, "extra", None) else None
+        if raw is None:
+            return set()
+        if isinstance(raw, list):
+            return {str(part).strip() for part in raw if str(part).strip()}
+        return {part.strip() for part in str(raw).split(",") if part.strip()}
+
+    def _rich_messages_disabled_for_chat(self, chat_id: Optional[str]) -> bool:
+        normalized = str(chat_id or "").strip()
+        return bool(normalized and normalized in self._rich_messages_disable_chats)
+
     def _needs_rich_rendering(self, content: str) -> bool:
         """Return True for markdown constructs that the legacy path degrades.
 
@@ -1003,7 +1021,7 @@ class TelegramAdapter(BasePlatformAdapter):
             return True
         return False
 
-    def _rich_eligible(self, content: str) -> bool:
+    def _rich_eligible(self, content: str, chat_id: Optional[str] = None) -> bool:
         """Capability/content eligibility for rich, ignoring ``expect_edits``.
 
         Shared core of :meth:`_should_attempt_rich` minus the per-call
@@ -1015,6 +1033,7 @@ class TelegramAdapter(BasePlatformAdapter):
         return bool(
             getattr(self, "_rich_messages_enabled", True)
             and not getattr(self, "_rich_send_disabled", False)
+            and not self._rich_messages_disabled_for_chat(chat_id)
             and content
             and content.strip()
             and self._needs_rich_rendering(content)
@@ -1024,11 +1043,14 @@ class TelegramAdapter(BasePlatformAdapter):
         )
 
     def _should_attempt_rich(
-        self, content: str, metadata: Optional[Dict[str, Any]] = None
+        self,
+        content: str,
+        metadata: Optional[Dict[str, Any]] = None,
+        chat_id: Optional[str] = None,
     ) -> bool:
         return bool(
             not (metadata or {}).get("expect_edits")
-            and self._rich_eligible(content)
+            and self._rich_eligible(content, chat_id=chat_id)
         )
 
     def prefers_fresh_final_streaming(
@@ -1329,6 +1351,12 @@ class TelegramAdapter(BasePlatformAdapter):
             and not self._has_telegram_desktop_details_math_crash_shape(content)
             and self._content_fits_rich_limits(content)
             and self._bot_supports_rich()
+        )
+
+    def _should_attempt_rich_draft_for_chat(self, chat_id: str, content: str) -> bool:
+        return bool(
+            not self._rich_messages_disabled_for_chat(chat_id)
+            and self._should_attempt_rich_draft(content)
         )
 
     async def _try_send_rich_draft(
@@ -2343,7 +2371,7 @@ class TelegramAdapter(BasePlatformAdapter):
             # through to the legacy MarkdownV2 path on permanent/capability
             # errors or DM-topic routing skips; returns directly on success or
             # on a transient failure (which must NOT be legacy-resent).
-            if self._should_attempt_rich(content, metadata=metadata):
+            if self._should_attempt_rich(content, metadata=metadata, chat_id=chat_id):
                 rich_result = await self._try_send_rich(chat_id, content, reply_to, metadata)
                 if rich_result is not None:
                     if rich_result.success:
@@ -2677,7 +2705,7 @@ class TelegramAdapter(BasePlatformAdapter):
         # table that exceeds the MarkdownV2 limit must not be split into legacy
         # chunks.  Falls back to the legacy edit path (overflow split included)
         # on capability/permanent rejection.
-        if finalize and self._rich_eligible(content):
+        if finalize and self._rich_eligible(content, chat_id=chat_id):
             rich_result = await self._try_edit_rich(chat_id, message_id, content)
             if rich_result is not None:
                 return rich_result
@@ -3069,7 +3097,7 @@ class TelegramAdapter(BasePlatformAdapter):
         # streaming preview with the same raw markdown the final
         # sendRichMessage will persist, so the animated draft matches the final
         # message. Any failure degrades to the legacy plain-text draft below.
-        if self._should_attempt_rich_draft(content):
+        if self._should_attempt_rich_draft_for_chat(chat_id, content):
             if await self._try_send_rich_draft(chat_id, draft_id, content, metadata):
                 # Drafts have no message_id; report success without one.
                 return SendResult(success=True, message_id=None)

--- a/tests/gateway/test_config.py
+++ b/tests/gateway/test_config.py
@@ -881,6 +881,30 @@ class TestLoadGatewayConfig:
 
         assert config.platforms[Platform.TELEGRAM].extra["rich_messages"] is False
 
+    def test_loads_telegram_rich_messages_disable_chats_from_gateway_platform_extra(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        config_path = hermes_home / "config.yaml"
+        config_path.write_text(
+            "gateway:\n"
+            "  platforms:\n"
+            "    telegram:\n"
+            "      extra:\n"
+            "        rich_messages_disable_chats:\n"
+            "          - \"12345\"\n"
+            "          - \"67890\"\n",
+            encoding="utf-8",
+        )
+
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        config = load_gateway_config()
+
+        assert config.platforms[Platform.TELEGRAM].extra["rich_messages_disable_chats"] == [
+            "12345",
+            "67890",
+        ]
+
     def test_load_config_default_enables_telegram_rich_messages(self, tmp_path, monkeypatch):
         hermes_home = tmp_path / ".hermes"
         hermes_home.mkdir()

--- a/tests/gateway/test_telegram_rich_messages.py
+++ b/tests/gateway/test_telegram_rich_messages.py
@@ -186,6 +186,32 @@ async def test_rich_messages_opt_out_accepts_string_false():
 
 
 @pytest.mark.asyncio
+async def test_rich_messages_disable_chats_forces_legacy_send_path():
+    adapter = _make_adapter(extra={"rich_messages_disable_chats": ["12345"]})
+
+    result = await adapter.send("12345", RICH_CONTENT)
+
+    assert result.success is True
+    bot = adapter._bot
+    assert bot is not None
+    bot.do_api_request.assert_not_called()
+    bot.send_message.assert_awaited()
+
+
+@pytest.mark.asyncio
+async def test_rich_messages_disable_chats_accepts_comma_string():
+    adapter = _make_adapter(extra={"rich_messages_disable_chats": "12345, 67890"})
+
+    result = await adapter.send("67890", RICH_CONTENT)
+
+    assert result.success is True
+    bot = adapter._bot
+    assert bot is not None
+    bot.do_api_request.assert_not_called()
+    bot.send_message.assert_awaited()
+
+
+@pytest.mark.asyncio
 async def test_rich_messages_default_is_enabled():
     """Rich messages are on by default (Bot API 10.1); rich-eligible content
     (tables/task lists/details/math) goes through sendRichMessage without the
@@ -571,6 +597,19 @@ async def test_rich_draft_oversized_uses_legacy():
     assert result.success is True
     adapter._bot.do_api_request.assert_not_called()
     adapter._bot.send_message_draft.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_rich_draft_disable_chats_uses_legacy_draft():
+    adapter = _make_adapter(extra={"rich_messages_disable_chats": ["12345"]})
+
+    result = await adapter.send_draft("12345", draft_id=7, content=RICH_CONTENT)
+
+    assert result.success is True
+    bot = adapter._bot
+    assert bot is not None
+    bot.do_api_request.assert_not_called()
+    bot.send_message_draft.assert_awaited_once()
 
 
 # ----------------------------------------------------------------------

--- a/website/docs/user-guide/messaging/telegram.md
+++ b/website/docs/user-guide/messaging/telegram.md
@@ -919,6 +919,18 @@ gateway:
         rich_messages: false
 ```
 
+If only specific chats need the compatibility fallback, keep rich messages
+enabled globally and disable them per chat:
+
+```yaml
+gateway:
+  platforms:
+    telegram:
+      extra:
+        rich_messages_disable_chats:
+          - "8494310760"
+```
+
 This setting is for client-rendering compatibility; Hermes already falls back automatically when Telegram rejects the rich API call. If you only want the legacy "always code-block" table behavior while keeping rich messages enabled, disable table normalization by setting `telegram.pretty_tables: false` in `config.yaml` (default: `true`).
 
 **Link previews.** Telegram auto-generates link previews for URLs in bot messages. If you'd rather suppress those (long `/tools` output, agent reply that mentions ten links, etc.):


### PR DESCRIPTION
## What does this PR do?

Adds a Telegram per-chat compatibility fallback for Bot API 10.1 rich delivery. Operators can now set `gateway.platforms.telegram.extra.rich_messages_disable_chats` to keep known-problem chats on the legacy MarkdownV2 and `sendMessageDraft` paths while leaving rich messages enabled elsewhere.

## Related Issue

Fixes #48841

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Added `telegram.extra.rich_messages_disable_chats` handling in [`gateway/platforms/telegram.py`](gateway/platforms/telegram.py) so rich final sends, rich finalize edits, and rich draft previews are skipped for configured chat IDs.
- Added regression coverage in [`tests/gateway/test_telegram_rich_messages.py`](tests/gateway/test_telegram_rich_messages.py) for list-form and comma-string chat blocklists plus the rich-draft fallback path.
- Added config-load coverage in [`tests/gateway/test_config.py`](tests/gateway/test_config.py).
- Documented the per-chat fallback in [`website/docs/user-guide/messaging/telegram.md`](website/docs/user-guide/messaging/telegram.md).

## How to Test

1. Run `/Users/leongong/Desktop/LeonProjects/worktrees/hermes-agent/.base/.venv/bin/python -m pytest tests/gateway/test_telegram_rich_messages.py tests/gateway/test_config.py -q`.
2. Configure `gateway.platforms.telegram.extra.rich_messages_disable_chats` with a DM chat ID that reproduces the desktop rendering issue.
3. Verify that rich-eligible Telegram replies in that chat use the legacy MarkdownV2 / `sendMessageDraft` path, while rich delivery still works in other chats.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 / Python 3.11.14

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

- `126 passed in 7.44s` from `tests/gateway/test_telegram_rich_messages.py tests/gateway/test_config.py`
