### PR TITLE
fix: make automatic provider fallback ephemeral (retry primary each turn)

### DIFF
--- a/hermes_cli/cli_agent_setup_mixin.py
+++ b/hermes_cli/cli_agent_setup_mixin.py
@@ -35,6 +35,17 @@ class CLIAgentSetupMixin:
             format_runtime_provider_error,
         )
 
+        # Re-anchor to the configured primary each turn so an automatic
+        # fallback from a previous turn doesn't stick. The fallback path
+        # below sets _auto_fallback_active when it mutates us; here we undo
+        # that mutation so the primary is retried first every turn. Only
+        # auto-fallbacks are reverted — user-initiated /model switches don't
+        # set the flag, so they remain sticky across turns.
+        if getattr(self, "_auto_fallback_active", False):
+            self.requested_provider = self._pre_fallback_provider
+            self.model = self._pre_fallback_model
+            self._auto_fallback_active = False
+
         _primary_exc = None
         runtime = None
         try:
@@ -63,8 +74,16 @@ class CLIAgentSetupMixin:
                             _primary_exc, _fb_provider, _fb_model,
                         )
                         _cprint(f"⚠️  Primary auth failed — switching to fallback: {_fb_provider} / {_fb_model}")
+                        # Capture the intended primary so the next turn can
+                        # retry it first. Only capture on the first fallback
+                        # of a streak so a re-fallback (primary still down)
+                        # preserves the original primary, not the fallback.
+                        if not getattr(self, "_auto_fallback_active", False):
+                            self._pre_fallback_provider = self.requested_provider
+                            self._pre_fallback_model = self.model
                         self.requested_provider = _fb_provider
                         self.model = _fb_model
+                        self._auto_fallback_active = True
                         _primary_exc = None
                         break
                     except Exception:

--- a/tests/cli/test_cli_provider_resolution.py
+++ b/tests/cli/test_cli_provider_resolution.py
@@ -172,6 +172,66 @@ def test_runtime_resolution_failure_is_not_sticky(monkeypatch):
     assert shell.agent is not None
 
 
+def test_auto_fallback_is_ephemeral_retries_primary_next_turn(monkeypatch):
+    """An automatic fallback (primary AuthError → secondary) must not stick
+    across turns: the next turn re-anchors to the configured primary and
+    retries it first, so a transient primary blip self-heals instead of
+    stranding the session on the fallback until restart. User-initiated
+    /model switches are unaffected — they don't set _auto_fallback_active."""
+    cli = _import_cli()
+    calls = {"count": 0}
+
+    primary_runtime = {
+        "provider": "openrouter",
+        "api_mode": "chat_completions",
+        "base_url": "https://primary.example/v1",
+        "api_key": "primary-key",
+        "source": "config",
+    }
+    fallback_runtime = {
+        "provider": "openai-codex",
+        "api_mode": "chat_completions",
+        "base_url": "https://fallback.example/v1",
+        "api_key": "fallback-key",
+        "source": "config",
+    }
+
+    def _runtime_resolve(**kwargs):
+        calls["count"] += 1
+        requested = (kwargs.get("requested") or "").strip().lower()
+        if requested == "openrouter":
+            # Transient blip: fail turn 1, recover by turn 2.
+            if calls["count"] <= 1:
+                raise AuthError("primary auth failed (transient)")
+            return primary_runtime
+        if requested == "openai-codex":
+            return fallback_runtime
+        raise AuthError(f"unknown provider {requested!r}")
+
+    monkeypatch.setattr("hermes_cli.runtime_provider.resolve_runtime_provider", _runtime_resolve)
+    monkeypatch.setattr("hermes_cli.runtime_provider.format_runtime_provider_error", lambda exc: str(exc))
+
+    shell = cli.HermesCLI(model="gpt-5", compact=True, max_turns=1)
+    shell.requested_provider = "openrouter"
+    shell.provider = "openrouter"
+    shell.api_mode = "chat_completions"
+    shell.base_url = "https://primary.example/v1"
+    shell.api_key = "primary-key"
+    shell._fallback_model = [{"provider": "openai-codex", "model": "gpt-5.5"}]
+
+    # Turn 1: primary fails with AuthError → fall back to openai-codex/gpt-5.5.
+    assert shell._ensure_runtime_credentials() is True
+    assert shell.requested_provider == "openai-codex"
+    assert shell.model == "gpt-5.5"
+    assert shell._auto_fallback_active is True
+
+    # Turn 2: fallback is ephemeral — primary is retried first and now succeeds.
+    assert shell._ensure_runtime_credentials() is True
+    assert shell.requested_provider == "openrouter"
+    assert shell.model == "gpt-5"
+    assert shell._auto_fallback_active is False
+
+
 def test_runtime_resolution_rebuilds_agent_on_routing_change(monkeypatch):
     cli = _import_cli()
 


### PR DESCRIPTION
## Problem

When the primary provider fails with `AuthError`, `_ensure_runtime_credentials()` falls back to a secondary provider and mutates `self.requested_provider` / `self.model` **in place**. Because this method runs **per turn** and re-resolves from those attributes, a single transient primary failure (a 403 that recovers seconds later, a brief network blip) stranded the session on the fallback **until the gateway was restarted** — even though the primary had recovered.

## Fix

Track automatic fallbacks via an `_auto_fallback_active` flag:

- On fallback, capture the pre-fallback primary (`_pre_fallback_provider` / `_pre_fallback_model`) — only on the first fallback of a streak, so a re-fallback (primary still down) preserves the original primary rather than the fallback.
- At the top of each turn, if the flag is set, restore the primary and retry it first. The primary self-heals on the next turn instead of stranding the session.

Only **automatic** fallbacks are reverted. User-initiated `/model` switches do not set the flag, so they remain sticky across turns — no behavior change for the deliberate-switch path.

## Why now

`_ensure_runtime_credentials()` already runs per-turn (`run()` → line ~9649 in `cli.py`), so re-anchoring to the primary each turn is a natural, low-cost retry. The stickiness was a latent footgun that became acute with custom primary providers whose auth can blip transiently.

## Test

Adds `test_auto_fallback_is_ephemeral_retries_primary_next_turn` covering the `AuthError → fallback → retry-primary` path. The existing `test_runtime_resolution_failure_is_not_sticky` raises `RuntimeError` (not `AuthError`), so it never enters the fallback block and did not cover this.

Verified the test is meaningful: reverting only the `cli_agent_setup_mixin.py` change makes it fail (`_auto_fallback_active` absent); with the fix it passes.

## Files

- `hermes_cli/cli_agent_setup_mixin.py` — the fix (12 lines, 2 hunks)
- `tests/cli/test_cli_provider_resolution.py` — regression test

Assisted-by: vasyl+hermes-agent:GLM-5.2