### PR TITLE
fix(model-picker): support model-keyed user providers

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -3968,6 +3968,52 @@ def _normalize_custom_provider_entry(
         "request_timeout_seconds", "stale_timeout_seconds",
         "discover_models", "extra_body",
     }
+    model_keyed_entries: Dict[str, Dict[str, Any]] = {}
+    model_keyed_base_url = ""
+    model_keyed_api_key = ""
+    model_keyed_key_env = ""
+    model_keyed_api_mode = ""
+    for raw_model, raw_cfg in entry.items():
+        if raw_model in _KNOWN_KEYS or raw_model in _CAMEL_ALIASES:
+            continue
+        if not isinstance(raw_model, str) or not isinstance(raw_cfg, dict):
+            continue
+        nested_url = (
+            raw_cfg.get("base_url")
+            or raw_cfg.get("url")
+            or raw_cfg.get("api")
+            or ""
+        )
+        if not isinstance(nested_url, str) or not nested_url.strip():
+            continue
+        if (
+            str(raw_cfg.get("enabled", "true")).strip().lower()
+            in {"false", "0", "no"}
+        ):
+            continue
+        model_key = raw_model.strip()
+        if not model_key:
+            continue
+        if not model_keyed_base_url:
+            model_keyed_base_url = nested_url.strip()
+        if (
+            nested_url.strip().rstrip("/").lower()
+            != model_keyed_base_url.rstrip("/").lower()
+        ):
+            continue
+        model_meta: Dict[str, Any] = {}
+        context_length = raw_cfg.get("context_length") or raw_cfg.get("context_window")
+        if isinstance(context_length, int) and context_length > 0:
+            model_meta["context_length"] = context_length
+        model_keyed_entries[model_key] = model_meta
+        if not model_keyed_api_key and isinstance(raw_cfg.get("api_key"), str):
+            model_keyed_api_key = raw_cfg["api_key"].strip()
+        if not model_keyed_key_env and isinstance(raw_cfg.get("key_env"), str):
+            model_keyed_key_env = raw_cfg["key_env"].strip()
+        nested_api_mode = raw_cfg.get("api_mode") or raw_cfg.get("transport")
+        if not model_keyed_api_mode and isinstance(nested_api_mode, str):
+            model_keyed_api_mode = nested_api_mode.strip()
+
     for camel, snake in _CAMEL_ALIASES.items():
         if camel in entry and snake not in entry:
             logger.warning(
@@ -3976,7 +4022,12 @@ def _normalize_custom_provider_entry(
                 provider_key or "?", camel, snake,
             )
             entry[snake] = entry[camel]
-    unknown = set(entry.keys()) - _KNOWN_KEYS - set(_CAMEL_ALIASES.keys())
+    unknown = (
+        set(entry.keys())
+        - _KNOWN_KEYS
+        - set(_CAMEL_ALIASES.keys())
+        - set(model_keyed_entries.keys())
+    )
     if unknown:
         logger.warning(
             "providers.%s: unknown config keys ignored: %s",
@@ -4000,6 +4051,8 @@ def _normalize_custom_provider_entry(
                     "(no scheme or host) — skipped",
                     provider_key or "?", url_key, candidate,
                 )
+    if not base_url and model_keyed_base_url:
+        base_url = model_keyed_base_url
     if not base_url:
         return None
 
@@ -4024,18 +4077,26 @@ def _normalize_custom_provider_entry(
     api_key = entry.get("api_key")
     if isinstance(api_key, str) and api_key.strip():
         normalized["api_key"] = api_key.strip()
+    elif model_keyed_api_key:
+        normalized["api_key"] = model_keyed_api_key
 
     key_env = entry.get("key_env")
     if isinstance(key_env, str) and key_env.strip():
         normalized["key_env"] = key_env.strip()
+    elif model_keyed_key_env:
+        normalized["key_env"] = model_keyed_key_env
 
     api_mode = entry.get("api_mode") or entry.get("transport")
     if isinstance(api_mode, str) and api_mode.strip():
         normalized["api_mode"] = api_mode.strip()
+    elif model_keyed_api_mode:
+        normalized["api_mode"] = model_keyed_api_mode
 
     model_name = entry.get("model") or entry.get("default_model")
     if isinstance(model_name, str) and model_name.strip():
         normalized["model"] = model_name.strip()
+    elif model_keyed_entries:
+        normalized["model"] = next(iter(model_keyed_entries))
 
     models = entry.get("models")
     if isinstance(models, dict) and models:
@@ -4048,6 +4109,8 @@ def _normalize_custom_provider_entry(
         normalized["models"] = {
             str(m): {} for m in models if isinstance(m, str) and m.strip()
         }
+    elif model_keyed_entries:
+        normalized["models"] = model_keyed_entries
 
     context_length = entry.get("context_length")
     if isinstance(context_length, int) and context_length > 0:

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -64,6 +64,90 @@ def _bare_custom_provider_def(current_base_url: str) -> Optional[ProviderDef]:
     )
 
 
+def _norm_url(url: str) -> str:
+    return str(url or "").strip().rstrip("/").lower()
+
+
+def _user_provider_details(cfg: dict) -> dict:
+    """Extract endpoint, credential, and model list from a providers: entry."""
+    if not isinstance(cfg, dict):
+        return {
+            "api_url": "",
+            "api_key": "",
+            "key_env": "",
+            "api_mode": "",
+            "models": [],
+        }
+
+    api_url = (
+        cfg.get("base_url", "")
+        or cfg.get("api", "")
+        or cfg.get("url", "")
+        or ""
+    )
+    api_key = str(cfg.get("api_key", "") or "").strip()
+    key_env = str(cfg.get("key_env", "") or "").strip()
+    api_mode = str(cfg.get("api_mode", "") or cfg.get("transport", "") or "").strip()
+    models: list[str] = []
+
+    default_model = cfg.get("default_model", "") or cfg.get("model", "")
+    if isinstance(default_model, str) and default_model.strip():
+        models.append(default_model.strip())
+
+    cfg_models = cfg.get("models", [])
+    if isinstance(cfg_models, dict):
+        for model in cfg_models:
+            if model and model not in models:
+                models.append(model)
+    elif isinstance(cfg_models, list):
+        for model in cfg_models:
+            if isinstance(model, str) and model and model not in models:
+                models.append(model)
+            elif isinstance(model, dict) and model.get("name") not in models:
+                name = model.get("name")
+                if isinstance(name, str) and name:
+                    models.append(name)
+
+    for model_id, model_cfg in cfg.items():
+        if not isinstance(model_id, str) or not isinstance(model_cfg, dict):
+            continue
+        nested_url = (
+            model_cfg.get("base_url", "")
+            or model_cfg.get("api", "")
+            or model_cfg.get("url", "")
+            or ""
+        )
+        if not nested_url:
+            continue
+        if (
+            str(model_cfg.get("enabled", "true")).strip().lower()
+            in {"false", "0", "no"}
+        ):
+            continue
+        if not api_url:
+            api_url = nested_url
+        if _norm_url(nested_url) != _norm_url(api_url):
+            continue
+        model_name = model_id.strip()
+        if model_name and model_name not in models:
+            models.append(model_name)
+        if not api_key and isinstance(model_cfg.get("api_key"), str):
+            api_key = model_cfg["api_key"].strip()
+        if not key_env and isinstance(model_cfg.get("key_env"), str):
+            key_env = model_cfg["key_env"].strip()
+        nested_api_mode = model_cfg.get("api_mode") or model_cfg.get("transport")
+        if not api_mode and isinstance(nested_api_mode, str):
+            api_mode = nested_api_mode.strip()
+
+    return {
+        "api_url": str(api_url or "").strip(),
+        "api_key": api_key,
+        "key_env": key_env,
+        "api_mode": api_mode,
+        "models": models,
+    }
+
+
 # ---------------------------------------------------------------------------
 # Non-agentic model warning
 # ---------------------------------------------------------------------------
@@ -933,11 +1017,12 @@ def switch_model(
         if _user_pdef is not None and _user_pdef.base_url:
             _ucfg = (user_providers or {}).get(explicit_provider.strip().lower()) \
                 or (user_providers or {}).get(target_provider) or {}
-            _ukey = str(_ucfg.get("api_key", "") or "").strip()
+            _udetails = _user_provider_details(_ucfg)
+            _ukey = str(_udetails.get("api_key", "") or "").strip()
             if _ukey.startswith("${") and _ukey.endswith("}"):
                 _ukey = os.environ.get(_ukey[2:-1], "").strip()
             if not _ukey:
-                _kenv = str(_ucfg.get("key_env", "") or "").strip()
+                _kenv = str(_udetails.get("key_env", "") or "").strip()
                 if _kenv:
                     _ukey = os.environ.get(_kenv, "").strip()
             try:
@@ -953,7 +1038,10 @@ def switch_model(
             except Exception:
                 api_key = _ukey
                 base_url = _user_pdef.base_url
-                api_mode = ""
+                api_mode = (
+                    str(_udetails.get("api_mode", "") or "").strip()
+                    or determine_api_mode(target_provider, base_url)
+                )
         elif target_provider == "custom" and current_base_url:
             api_key = current_api_key
             base_url = current_base_url
@@ -1032,16 +1120,9 @@ def switch_model(
             # user_providers is a dict: {provider_slug: config_dict}
             for slug, cfg in user_providers.items():
                 if slug == target_provider:
-                    cfg_models = cfg.get("models", {})
-                    # Direct membership works for dict (keys) and list (strings)
-                    if new_model in cfg_models:
+                    if new_model in _user_provider_details(cfg).get("models", []):
                         override = True
                         break
-                    # Also accept if models is a list of dicts with 'name' field
-                    if isinstance(cfg_models, list):
-                        if any(m.get("name") == new_model for m in cfg_models if isinstance(m, dict)):
-                            override = True
-                            break
         # Also check custom_providers list — models declared there should be accepted
         # even if the remote /v1/models endpoint doesn't list them.
         if not override and custom_providers and isinstance(custom_providers, list):
@@ -1722,6 +1803,9 @@ def list_authenticated_providers(
                 or ep_cfg.get("url", "")
                 or ""
             )
+            details = _user_provider_details(ep_cfg)
+            if not api_url:
+                api_url = details["api_url"]
             # ``default_model`` is the legacy key; ``model`` matches what
             # custom_providers entries use, so accept either.
             default_model = ep_cfg.get("default_model", "") or ep_cfg.get("model", "")
@@ -1743,6 +1827,9 @@ def list_authenticated_providers(
                 for m in cfg_models:
                     if m and m not in models_list:
                         models_list.append(m)
+            for m in details["models"]:
+                if m and m not in models_list:
+                    models_list.append(m)
 
             # Official OpenAI API rows in providers: often have base_url but no
             # explicit models: dict — avoid a misleading zero count in /model.
@@ -1764,7 +1851,11 @@ def list_authenticated_providers(
             #   still show their full model catalog.
             api_key = str(ep_cfg.get("api_key", "") or "").strip()
             if not api_key:
+                api_key = details["api_key"]
+            if not api_key:
                 key_env = str(ep_cfg.get("key_env", "") or "").strip()
+                if not key_env:
+                    key_env = details["key_env"]
                 api_key = os.environ.get(key_env, "").strip() if key_env else ""
             discover = ep_cfg.get("discover_models", True)
             if isinstance(discover, str):

--- a/hermes_cli/providers.py
+++ b/hermes_cli/providers.py
@@ -565,6 +565,33 @@ def resolve_user_provider(name: str, user_config: Dict[str, Any]) -> Optional[Pr
     api_url = entry.get("api", "") or entry.get("url", "") or entry.get("base_url", "") or ""
     key_env = entry.get("key_env", "") or ""
     transport = entry.get("transport", "openai_chat") or "openai_chat"
+    if not api_url:
+        for model_id, model_cfg in entry.items():
+            if not isinstance(model_id, str) or not isinstance(model_cfg, dict):
+                continue
+            nested_url = (
+                model_cfg.get("base_url", "")
+                or model_cfg.get("api", "")
+                or model_cfg.get("url", "")
+                or ""
+            )
+            if not nested_url:
+                continue
+            if (
+                str(model_cfg.get("enabled", "true")).strip().lower()
+                in {"false", "0", "no"}
+            ):
+                continue
+            api_url = str(nested_url).strip()
+            key_env = str(model_cfg.get("key_env", "") or key_env or "")
+            transport = (
+                model_cfg.get("transport", "")
+                or model_cfg.get("api_mode", "")
+                or transport
+            )
+            break
+    if not api_url:
+        return None
 
     env_vars: List[str] = []
     if key_env:

--- a/tests/hermes_cli/test_user_providers_model_switch.py
+++ b/tests/hermes_cli/test_user_providers_model_switch.py
@@ -212,6 +212,133 @@ def test_list_authenticated_providers_dict_models_without_default_model(monkeypa
     assert set(user_prov["models"]) == {"alpha", "beta"}
 
 
+def test_list_authenticated_providers_enumerates_model_keyed_provider_entries(monkeypatch):
+    """Some hand-written local-provider configs key endpoint settings by model.
+
+    The desktop picker still needs a provider row even when ``providers.<name>``
+    has no top-level base_url/default_model and instead stores:
+    ``providers.<name>.<model>.base_url``.
+    """
+    monkeypatch.setattr("agent.models_dev.fetch_models_dev", lambda: {})
+    monkeypatch.setattr("hermes_cli.providers.HERMES_OVERLAYS", {})
+
+    fetch_calls = []
+
+    def fake_fetch_api_models(api_key, base_url):
+        fetch_calls.append((api_key, base_url))
+        return []
+
+    monkeypatch.setattr("hermes_cli.models.fetch_api_models", fake_fetch_api_models)
+
+    user_providers = {
+        "hounddog_local": {
+            "gemma-4-e4b-it-qat": {
+                "enabled": True,
+                "base_url": "http://127.0.0.1:1234/v1",
+                "api_key": "not-required",
+                "context_window": 8192,
+            }
+        }
+    }
+
+    providers = list_authenticated_providers(
+        current_provider="hounddog_local",
+        user_providers=user_providers,
+        custom_providers=[],
+    )
+
+    user_prov = next(
+        (
+            p
+            for p in providers
+            if p.get("is_user_defined") and p["slug"] == "hounddog_local"
+        ),
+        None,
+    )
+
+    assert user_prov is not None
+    assert user_prov["is_current"] is True
+    assert user_prov["api_url"] == "http://127.0.0.1:1234/v1"
+    assert user_prov["models"] == ["gemma-4-e4b-it-qat"]
+    assert user_prov["total_models"] == 1
+    assert fetch_calls == [("not-required", "http://127.0.0.1:1234/v1")]
+
+
+def test_switch_model_resolves_model_keyed_user_provider(monkeypatch):
+    """Selecting a model-keyed providers: row should resolve its endpoint."""
+    monkeypatch.setattr(
+        "hermes_cli.models.validate_requested_model",
+        lambda *a, **k: {
+            "accepted": True,
+            "persist": True,
+            "recognized": True,
+            "message": None,
+        },
+    )
+    monkeypatch.setattr("hermes_cli.model_switch.get_model_info", lambda *a, **k: None)
+    monkeypatch.setattr(
+        "hermes_cli.model_switch.get_model_capabilities",
+        lambda *a, **k: None,
+    )
+
+    user_providers = {
+        "hounddog_local": {
+            "gemma-4-e4b-it-qat": {
+                "enabled": True,
+                "base_url": "http://127.0.0.1:1234/v1",
+                "api_key": "not-required",
+            }
+        }
+    }
+
+    result = switch_model(
+        raw_input="gemma-4-e4b-it-qat",
+        current_provider="openrouter",
+        current_model="old/model",
+        explicit_provider="hounddog_local",
+        user_providers=user_providers,
+        custom_providers=[],
+    )
+
+    assert result.success is True
+    assert result.target_provider == "hounddog_local"
+    assert result.new_model == "gemma-4-e4b-it-qat"
+    assert result.base_url == "http://127.0.0.1:1234/v1"
+    assert result.api_key == "not-required"
+
+
+def test_runtime_provider_resolves_model_keyed_providers_dict(monkeypatch):
+    """Session rebuilds should resolve the same model-keyed providers: config."""
+    config = {
+        "model": {
+            "provider": "hounddog_local",
+            "default": "gemma-4-e4b-it-qat",
+        },
+        "providers": {
+            "hounddog_local": {
+                "gemma-4-e4b-it-qat": {
+                    "enabled": True,
+                    "base_url": "http://127.0.0.1:1234/v1",
+                    "api_key": "not-required",
+                    "context_window": 8192,
+                }
+            }
+        },
+    }
+    monkeypatch.setattr(rp, "load_config", lambda: config)
+
+    runtime = rp.resolve_runtime_provider(
+        requested="hounddog_local",
+        target_model="gemma-4-e4b-it-qat",
+    )
+
+    assert runtime["provider"] == "custom"
+    assert runtime["requested_provider"] == "hounddog_local"
+    assert runtime["base_url"] == "http://127.0.0.1:1234/v1"
+    assert runtime["api_key"] == "not-required"
+    assert runtime["model"] == "gemma-4-e4b-it-qat"
+
+
 def test_list_authenticated_providers_dict_models_dedupe_with_default(monkeypatch):
     """When ``default_model`` is also a key in the ``models:`` dict, it must
     appear exactly once (list already had this for list-format models)."""

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -3335,6 +3335,90 @@ def test_config_set_model_explicit_provider_surfaces_selected_provider_errors(mo
         server._sessions.pop("sid", None)
 
 
+def test_config_set_model_accepts_model_keyed_user_provider(monkeypatch):
+    """Desktop model picker selection should switch model-keyed providers."""
+    config = {
+        "model": {
+            "provider": "hounddog_local",
+            "default": "gemma-4-e4b-it-qat",
+        },
+        "providers": {
+            "hounddog_local": {
+                "gemma-4-e4b-it-qat": {
+                    "enabled": True,
+                    "base_url": "http://127.0.0.1:1234/v1",
+                    "api_key": "not-required",
+                }
+            }
+        },
+    }
+    seen = {"build": 0, "wait": 0}
+    session = _session()
+    session["agent"] = None
+    server._sessions["sid"] = session
+    monkeypatch.setattr(server, "_load_cfg", lambda: config)
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config",
+        lambda: config,
+    )
+    monkeypatch.setattr(
+        "hermes_cli.runtime_provider.load_config",
+        lambda: config,
+    )
+    monkeypatch.setattr("agent.models_dev.fetch_models_dev", lambda: {})
+    monkeypatch.setattr(
+        "hermes_cli.models.validate_requested_model",
+        lambda *a, **k: {
+            "accepted": True,
+            "persist": True,
+            "recognized": True,
+            "message": None,
+        },
+    )
+    monkeypatch.setattr("hermes_cli.model_switch.get_model_info", lambda *a, **k: None)
+    monkeypatch.setattr(
+        "hermes_cli.model_switch.get_model_capabilities",
+        lambda *a, **k: None,
+    )
+    monkeypatch.setattr(
+        "hermes_cli.model_cost_guard.expensive_model_warning",
+        lambda *a, **k: None,
+    )
+    monkeypatch.setattr(
+        server,
+        "_start_agent_build",
+        lambda *_args: seen.__setitem__("build", seen["build"] + 1),
+    )
+    monkeypatch.setattr(
+        server,
+        "_wait_agent",
+        lambda *_args: seen.__setitem__("wait", seen["wait"] + 1),
+    )
+
+    try:
+        resp = server.handle_request(
+            {
+                "id": "1",
+                "method": "config.set",
+                "params": {
+                    "session_id": "sid",
+                    "key": "model",
+                    "value": "gemma-4-e4b-it-qat --provider hounddog_local",
+                },
+            }
+        )
+
+        assert resp["result"]["value"] == "gemma-4-e4b-it-qat"
+        assert seen["build"] == 0
+        assert seen["wait"] == 0
+        assert session["model_override"]["provider"] == "hounddog_local"
+        assert session["model_override"]["model"] == "gemma-4-e4b-it-qat"
+        assert session["model_override"]["base_url"] == "http://127.0.0.1:1234/v1"
+        assert session["model_override"]["api_key"] == "not-required"
+    finally:
+        server._sessions.pop("sid", None)
+
+
 def test_config_set_model_does_not_leak_inference_provider_env(monkeypatch):
     """A /model switch must NOT mutate process-global env vars. The desktop /
     dashboard tui_gateway backend hosts every same-profile session in one
@@ -5515,6 +5599,48 @@ def test_model_options_propagates_list_exception(monkeypatch):
     assert "error" in resp
     assert resp["error"]["code"] == 5033
     assert "catalog blew up" in resp["error"]["message"]
+
+
+def test_model_options_includes_model_keyed_user_provider(monkeypatch):
+    """Desktop model.options must surface local providers declared per model."""
+    config = {
+        "model": {
+            "provider": "hounddog_local",
+            "default": "gemma-4-e4b-it-qat",
+        },
+        "providers": {
+            "hounddog_local": {
+                "gemma-4-e4b-it-qat": {
+                    "enabled": True,
+                    "base_url": "http://127.0.0.1:1234/v1",
+                    "api_key": "not-required",
+                    "context_window": 8192,
+                }
+            }
+        },
+    }
+
+    monkeypatch.setattr("hermes_cli.config.load_config", lambda: config)
+    monkeypatch.setattr("agent.models_dev.fetch_models_dev", lambda: {})
+    monkeypatch.setattr("hermes_cli.providers.HERMES_OVERLAYS", {})
+    monkeypatch.setattr("hermes_cli.models.fetch_api_models", lambda *_args, **_kwargs: [])
+    monkeypatch.setattr("hermes_cli.models.get_pricing_for_provider", lambda *_args, **_kwargs: {})
+
+    resp = server._methods["model.options"](88, {"session_id": ""})
+
+    assert "result" in resp, resp
+    provider = next(
+        (
+            row
+            for row in resp["result"]["providers"]
+            if row.get("slug") == "hounddog_local"
+        ),
+        None,
+    )
+    assert provider is not None
+    assert provider["is_current"] is True
+    assert provider["models"] == ["gemma-4-e4b-it-qat"]
+    assert provider["api_url"] == "http://127.0.0.1:1234/v1"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Fixes #48885

## Summary
- normalize providers entries that store endpoint settings under model ids, e.g. providers.hounddog_local.gemma-4-e4b-it-qat.base_url
- make model.options, explicit model switching, desktop config.set, and session rebuilds all resolve that model-keyed provider shape
- add regression coverage for listing, selecting, and rebuilding model-keyed local providers

## Test plan
- pytest tests/hermes_cli/test_user_providers_model_switch.py -q
- pytest tests/test_tui_gateway_server.py::test_model_options_includes_model_keyed_user_provider tests/test_tui_gateway_server.py::test_config_set_model_accepts_model_keyed_user_provider -q
- ruff check hermes_cli/config.py hermes_cli/providers.py hermes_cli/model_switch.py tests/hermes_cli/test_user_providers_model_switch.py tests/test_tui_gateway_server.py
