### PR TITLE
fix(tui): guard /update against hosted dashboard mode

### DIFF
--- a/ui-tui/src/__tests__/createSlashHandler.test.ts
+++ b/ui-tui/src/__tests__/createSlashHandler.test.ts
@@ -2,7 +2,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { createSlashHandler } from '../app/createSlashHandler.js'
 import { getOverlayState, resetOverlayState } from '../app/overlayStore.js'
-import { DASHBOARD_EXIT_DISABLED_MESSAGE } from '../app/slash/commands/core.js'
+import { DASHBOARD_EXIT_DISABLED_MESSAGE, DASHBOARD_UPDATE_DISABLED_MESSAGE } from '../app/slash/commands/core.js'
 import { getUiState, patchUiState, resetUiState } from '../app/uiStore.js'
 import { TUI_SESSION_MODEL_FLAG } from '../domain/slash.js'
 
@@ -114,6 +114,22 @@ describe('createSlashHandler', () => {
     // Advance past the 100ms setTimeout
     vi.advanceTimersByTime(150)
     expect(ctx.session.dieWithCode).toHaveBeenCalledWith(42)
+
+    vi.useRealTimers()
+  })
+
+  it('refuses /update in hosted dashboard chat instead of killing the PTY', () => {
+    vi.useFakeTimers()
+    envState.dashboardTuiMode = true
+    const ctx = buildCtx()
+
+    expect(createSlashHandler(ctx)('/update')).toBe(true)
+    expect(ctx.session.dieWithCode).not.toHaveBeenCalled()
+    expect(ctx.gateway.gw.request).not.toHaveBeenCalled()
+    expect(ctx.transcript.sys).toHaveBeenCalledWith(DASHBOARD_UPDATE_DISABLED_MESSAGE)
+
+    vi.advanceTimersByTime(150)
+    expect(ctx.session.dieWithCode).not.toHaveBeenCalled()
 
     vi.useRealTimers()
   })

--- a/ui-tui/src/app/slash/commands/core.ts
+++ b/ui-tui/src/app/slash/commands/core.ts
@@ -81,6 +81,9 @@ const DETAILS_SECTION_USAGE = 'usage: /details <section> [hidden|collapsed|expan
 export const DASHBOARD_EXIT_DISABLED_MESSAGE =
   'exit is disabled in hosted dashboard chat — use /new to start a fresh session'
 
+export const DASHBOARD_UPDATE_DISABLED_MESSAGE =
+  'update is disabled in hosted dashboard chat — the hosted environment is managed separately'
+
 export const coreCommands: SlashCommand[] = [
   {
     help: 'list commands + hotkeys',
@@ -140,6 +143,12 @@ export const coreCommands: SlashCommand[] = [
     help: 'update Hermes Agent to the latest version (exits TUI)',
     name: 'update',
     run: (_arg, ctx) => {
+      if (DASHBOARD_TUI_MODE) {
+        ctx.transcript.sys(DASHBOARD_UPDATE_DISABLED_MESSAGE)
+
+        return
+      }
+
       ctx.transcript.sys('exiting TUI to run update...')
       // Exit code 42 signals the Python wrapper to exec `hermes update`.
       // Use dieWithCode for proper cleanup (gateway kill + Ink unmount).


### PR DESCRIPTION
## Summary

`/update` calls `dieWithCode(42)` which tears down the gateway and hard-exits the Node process — the same PTY-killing path that `/exit` and `/quit` use. In the hosted dashboard chat there is no Python update wrapper to catch exit code 42, and the PTY death bricks the tab until a browser refresh.

This is the sibling of #48882: that PR guarded `/exit` and `/quit` on `DASHBOARD_TUI_MODE`, but `/update` was missed. The fix mirrors the same early-return guard.

## Changes

- `ui-tui/src/app/slash/commands/core.ts`: `/update` checks `DASHBOARD_TUI_MODE` and refuses with an explanatory message before reaching `dieWithCode(42)`. Adds `DASHBOARD_UPDATE_DISABLED_MESSAGE` as an exported constant (matching the existing `DASHBOARD_EXIT_DISABLED_MESSAGE` pattern).
- `ui-tui/src/__tests__/createSlashHandler.test.ts`: regression test confirming `/update` refuses in hosted mode (asserts `dieWithCode` is never called, even after the 100ms `setTimeout` fires) and that the refusal message matches the exported constant.

## Validation

| Scenario | Before | After |
|---|---|---|
| `/update` in hosted dashboard | `dieWithCode(42)` → PTY killed → tab bricked | refused with message, tab stays alive |
| `/update` outside hosted mode | exits with code 42 (update flow) | unchanged |

61/61 tests pass (`vitest run createSlashHandler.test.ts`).