### PR TITLE
fix(dump): report the effective inference model, not just config

### DIFF
--- a/hermes_cli/dump.py
+++ b/hermes_cli/dump.py
@@ -268,6 +268,18 @@ def run_dump(args):
         config = {}
 
     model, provider = _get_model_and_provider(config)
+    # The dump shows config.yaml model.default, but the CLI runtime resolves
+    # HERMES_INFERENCE_MODEL (env) OVER config — see oneshot.py:
+    #   effective_model = explicit_arg or env_model or cfg_model.
+    # run_dump() has already loaded .env above, so os.environ reflects the real
+    # override here.  Surface it so the diagnostic matches what the agent
+    # actually runs (same shape as the terminal-backend block below).
+    env_model = (os.environ.get("HERMES_INFERENCE_MODEL") or "").strip()
+    if env_model and env_model != str(model).strip():
+        model = (
+            f"{env_model}  (HERMES_INFERENCE_MODEL overrides config.yaml "
+            f"model.default={model})"
+        )
 
     # Profile
     try:

--- a/hermes_cli/dump.py
+++ b/hermes_cli/dump.py
@@ -276,10 +276,15 @@ def run_dump(args):
     # actually runs (same shape as the terminal-backend block below).
     env_model = (os.environ.get("HERMES_INFERENCE_MODEL") or "").strip()
     if env_model and env_model != str(model).strip():
-        model = (
-            f"{env_model}  (HERMES_INFERENCE_MODEL overrides config.yaml "
-            f"model.default={model})"
-        )
+        if model == "(not set)":
+            # config configures no model — env isn't "overriding" a value, it IS
+            # the effective model (the env-only setup).  Mirror the provider line.
+            model = f"{env_model}  (HERMES_INFERENCE_MODEL, config sets none)"
+        else:
+            model = (
+                f"{env_model}  (HERMES_INFERENCE_MODEL overrides config.yaml "
+                f"model.default={model})"
+            )
 
     # Profile
     try:

--- a/tests/hermes_cli/test_dump_inference_model.py
+++ b/tests/hermes_cli/test_dump_inference_model.py
@@ -1,0 +1,90 @@
+"""`hermes dump` must report the EFFECTIVE inference model.
+
+`hermes dump` prints `model:` from config.yaml (`model.default`), but the CLI
+runtime resolves ``HERMES_INFERENCE_MODEL`` (env) OVER config — see
+``oneshot.py``: ``effective_model = explicit_arg or env_model or cfg_model``.
+Since ``run_dump()`` loads .env first, an operator who sets
+``HERMES_INFERENCE_MODEL`` saw a dump claiming the config model while the agent
+ran the env one — the same misleading-diagnostic class already fixed for the
+terminal backend.
+"""
+
+from pathlib import Path
+from types import SimpleNamespace
+
+
+def _model_line(out: str) -> str:
+    for line in out.splitlines():
+        if line.startswith("model:"):
+            return line
+    raise AssertionError(f"no 'model:' line in dump output:\n{out}")
+
+
+def _seed(home: Path, *, config_yaml: str, env_text: str) -> None:
+    home.mkdir(parents=True, exist_ok=True)
+    (home / "config.yaml").write_text(config_yaml)
+    (home / ".env").write_text(env_text)
+
+
+def test_dump_surfaces_inference_model_env_override(monkeypatch, capsys, tmp_path):
+    from hermes_cli import dump
+    from hermes_cli.config import get_hermes_home
+
+    monkeypatch.delenv("HERMES_INFERENCE_MODEL", raising=False)
+    # Keep run_dump's project-.env fallback from touching the real repo.
+    monkeypatch.setattr(dump, "get_project_root", lambda: tmp_path / "noproject")
+
+    home = get_hermes_home()
+    _seed(
+        home,
+        config_yaml="model:\n  default: hermes-4-405b\n",
+        env_text="HERMES_INFERENCE_MODEL=anthropic/claude-opus-4\n",
+    )
+
+    dump.run_dump(SimpleNamespace(show_keys=False))
+
+    line = _model_line(capsys.readouterr().out)
+    # Effective model (env) is what actually runs, not the config default.
+    assert "anthropic/claude-opus-4" in line
+    assert "overrides config.yaml" in line
+    # The shadowed config value is still shown so the mismatch is obvious.
+    assert "model.default=hermes-4-405b" in line
+
+
+def test_dump_reports_config_model_when_no_override(monkeypatch, capsys, tmp_path):
+    from hermes_cli import dump
+    from hermes_cli.config import get_hermes_home
+
+    monkeypatch.delenv("HERMES_INFERENCE_MODEL", raising=False)
+    monkeypatch.setattr(dump, "get_project_root", lambda: tmp_path / "noproject")
+
+    home = get_hermes_home()
+    _seed(home, config_yaml="model:\n  default: hermes-4-405b\n", env_text="")
+
+    dump.run_dump(SimpleNamespace(show_keys=False))
+
+    line = _model_line(capsys.readouterr().out)
+    assert "hermes-4-405b" in line
+    assert "overrides" not in line
+
+
+def test_dump_no_override_when_env_matches_config(monkeypatch, capsys, tmp_path):
+    from hermes_cli import dump
+    from hermes_cli.config import get_hermes_home
+
+    monkeypatch.delenv("HERMES_INFERENCE_MODEL", raising=False)
+    monkeypatch.setattr(dump, "get_project_root", lambda: tmp_path / "noproject")
+
+    home = get_hermes_home()
+    # HERMES_INFERENCE_MODEL agrees with config — no spurious "override" note.
+    _seed(
+        home,
+        config_yaml="model:\n  default: hermes-4-405b\n",
+        env_text="HERMES_INFERENCE_MODEL=hermes-4-405b\n",
+    )
+
+    dump.run_dump(SimpleNamespace(show_keys=False))
+
+    line = _model_line(capsys.readouterr().out)
+    assert "hermes-4-405b" in line
+    assert "overrides" not in line

--- a/tests/hermes_cli/test_dump_inference_model.py
+++ b/tests/hermes_cli/test_dump_inference_model.py
@@ -68,6 +68,37 @@ def test_dump_reports_config_model_when_no_override(monkeypatch, capsys, tmp_pat
     assert "overrides" not in line
 
 
+def test_dump_reports_env_model_when_config_sets_none(monkeypatch, capsys, tmp_path):
+    """Env-only setup: config configures no model, HERMES_INFERENCE_MODEL is set.
+
+    The env value is the effective model, so it must be surfaced — but framed as
+    "config sets none" rather than "overrides config.yaml model.default=(not
+    set)", which would be a misleading diagnostic.
+    """
+    from hermes_cli import dump
+    from hermes_cli.config import get_hermes_home
+
+    monkeypatch.delenv("HERMES_INFERENCE_MODEL", raising=False)
+    monkeypatch.setattr(dump, "get_project_root", lambda: tmp_path / "noproject")
+
+    home = get_hermes_home()
+    # No `model:` section at all in config.
+    _seed(
+        home,
+        config_yaml="agent:\n  max_turns: 90\n",
+        env_text="HERMES_INFERENCE_MODEL=anthropic/claude-opus-4\n",
+    )
+
+    dump.run_dump(SimpleNamespace(show_keys=False))
+
+    line = _model_line(capsys.readouterr().out)
+    assert "anthropic/claude-opus-4" in line
+    assert "config sets none" in line
+    # Must NOT claim it overrides a configured default that doesn't exist.
+    assert "overrides config.yaml" not in line
+    assert "(not set)" not in line
+
+
 def test_dump_no_override_when_env_matches_config(monkeypatch, capsys, tmp_path):
     from hermes_cli import dump
     from hermes_cli.config import get_hermes_home


### PR DESCRIPTION
## What does this PR do?

`hermes dump` prints the `model:` line from `config.yaml` (`model.default`), but the CLI runtime resolves `HERMES_INFERENCE_MODEL` (env) **over** config (`oneshot.py`: `effective_model = explicit_arg or env_model or cfg_model`). Since `run_dump()` loads `.env` before reading config, an operator who sets `HERMES_INFERENCE_MODEL` sees a dump claiming the wrong model while the agent actually runs the env one — the same misleading-diagnostic class already fixed for the **terminal backend** (merged) and **provider** (#48710). The adjacent model field was left lying.

This surfaces the effective model and keeps the shadowed config value visible, mirroring the existing `terminal:` override block in the same file.

Runtime-resolver mirror: matches `oneshot.py` `effective_model` precedence — `explicit arg > HERMES_INFERENCE_MODEL > config`.

> Audited siblings: `hermes status` (`status.py:_configured_model_label`) has the same config-only model display; intentionally left out to keep this diff to one file — happy to widen if preferred.

## Related Issue

Fixes #

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/dump.py`: after resolving the config model, surface `HERMES_INFERENCE_MODEL` when it differs, annotating the shadowed `model.default` — mirroring the existing terminal-backend block.
- `tests/hermes_cli/test_dump_inference_model.py`: new regression tests (mirrors `test_dump_terminal_backend.py`).

## How to Test

1. `printf 'model:\n  default: hermes-4-405b\n' > "$HERMES_HOME/config.yaml"` and `echo 'HERMES_INFERENCE_MODEL=anthropic/claude-opus-4' > "$HERMES_HOME/.env"`.
2. `hermes dump` — before this change the `model:` line shows `hermes-4-405b`; after, it shows `anthropic/claude-opus-4  (HERMES_INFERENCE_MODEL overrides config.yaml model.default=hermes-4-405b)`.
3. `uv run --with pytest python3 -m pytest tests/hermes_cli/test_dump_inference_model.py -q` — fails before the production hunk, passes after.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A