### PR TITLE
fix(desktop): persist and restore main window size/position (closes #48539)

### DIFF
--- a/apps/desktop/electron/main.cjs
+++ b/apps/desktop/electron/main.cjs
@@ -12,6 +12,7 @@ const {
   powerMonitor,
   protocol,
   safeStorage,
+  screen,
   session,
   shell,
   systemPreferences
@@ -25,6 +26,7 @@ const path = require('node:path')
 const { pathToFileURL } = require('node:url')
 const { execFileSync, spawn } = require('node:child_process')
 const { detectRemoteDisplay, isWindowsBinaryPathInWsl, isWslEnvironment } = require('./bootstrap-platform.cjs')
+const { resolveInitialBounds } = require('./window-bounds.cjs')
 const { runBootstrap } = require('./bootstrap-runner.cjs')
 const {
   buildSessionWindowUrl,
@@ -427,6 +429,62 @@ function writePersistedTranslucency(intensity) {
 }
 
 let translucencyIntensity = readPersistedTranslucency()
+
+// ─── Main window size/position persistence ─────────────────────────
+// The window bounds are mirrored to a small JSON file under userData so the
+// window reopens where the user last left it, like a normal desktop app.
+// Decision logic (validation + off-screen recovery) lives in the pure,
+// unit-tested window-bounds.cjs.
+const WINDOW_BOUNDS_CONFIG_PATH = path.join(app.getPath('userData'), 'window-bounds.json')
+
+function readPersistedWindowBounds() {
+  try {
+    return JSON.parse(fs.readFileSync(WINDOW_BOUNDS_CONFIG_PATH, 'utf8'))
+  } catch {
+    return null
+  }
+}
+
+function writePersistedWindowBounds(bounds) {
+  try {
+    fs.mkdirSync(path.dirname(WINDOW_BOUNDS_CONFIG_PATH), { recursive: true })
+    writeFileAtomic(WINDOW_BOUNDS_CONFIG_PATH, JSON.stringify(bounds, null, 2), 'utf8')
+  } catch (error) {
+    rememberLog(`[window-bounds] write failed: ${error?.message || error}`)
+  }
+}
+
+// Capture the window's current geometry. When maximized/fullscreen we keep the
+// pre-maximize rectangle (getNormalBounds) so un-maximizing later restores a
+// sane size.
+function captureWindowBounds(window) {
+  if (!window || window.isDestroyed()) return
+  try {
+    const isMaximized = Boolean(window.isMaximized?.())
+    const normal = window.getNormalBounds?.() || window.getBounds?.()
+    if (!normal) return
+    writePersistedWindowBounds({
+      x: normal.x,
+      y: normal.y,
+      width: normal.width,
+      height: normal.height,
+      isMaximized
+    })
+  } catch (error) {
+    rememberLog(`[window-bounds] capture failed: ${error?.message || error}`)
+  }
+}
+
+let windowBoundsSaveTimer = null
+
+// Debounced so a drag-resize doesn't write the file on every pixel.
+function scheduleWindowBoundsSave(window) {
+  if (windowBoundsSaveTimer) clearTimeout(windowBoundsSaveTimer)
+  windowBoundsSaveTimer = setTimeout(() => {
+    windowBoundsSaveTimer = null
+    captureWindowBounds(window)
+  }, 400)
+}
 
 // Map the 0–100 lever to a window opacity. Floor at 0.3 so the most see-through
 // setting is still usable rather than nearly invisible. 0 → fully opaque.
@@ -5156,9 +5214,20 @@ function createNewSessionWindow() {
 
 function createWindow() {
   const icon = getAppIconPath()
+  const displays = (() => {
+    try {
+      return screen.getAllDisplays()
+    } catch {
+      return []
+    }
+  })()
+  const initialBounds = resolveInitialBounds(readPersistedWindowBounds(), displays)
   mainWindow = new BrowserWindow({
-    width: 1220,
-    height: 800,
+    width: initialBounds.width,
+    height: initialBounds.height,
+    ...(Number.isFinite(initialBounds.x) && Number.isFinite(initialBounds.y)
+      ? { x: initialBounds.x, y: initialBounds.y }
+      : {}),
     minWidth: 400,
     minHeight: 620,
     title: 'Hermes',
@@ -5205,6 +5274,21 @@ function createWindow() {
   mainWindow.once('ready-to-show', () => {
     if (mainWindow && !mainWindow.isDestroyed()) mainWindow.show()
   })
+
+  if (initialBounds.isMaximized) {
+    // Electron has no `maximized` constructor option; maximize once the window
+    // is ready so the restored "normal" bounds are remembered underneath.
+    mainWindow.once('ready-to-show', () => {
+      if (mainWindow && !mainWindow.isDestroyed()) mainWindow.maximize()
+    })
+  }
+
+  // Persist size/position so the window reopens where the user left it (#48539).
+  mainWindow.on('resize', () => scheduleWindowBoundsSave(mainWindow))
+  mainWindow.on('move', () => scheduleWindowBoundsSave(mainWindow))
+  mainWindow.on('maximize', () => scheduleWindowBoundsSave(mainWindow))
+  mainWindow.on('unmaximize', () => scheduleWindowBoundsSave(mainWindow))
+  mainWindow.on('close', () => captureWindowBounds(mainWindow))
 
   mainWindow.on('will-enter-full-screen', () => sendWindowStateChanged(true))
   mainWindow.on('enter-full-screen', () => sendWindowStateChanged(true))

--- a/apps/desktop/electron/window-bounds.cjs
+++ b/apps/desktop/electron/window-bounds.cjs
@@ -1,0 +1,151 @@
+// Pure helpers for persisting and restoring the main window's size/position.
+//
+// The Electron main process owns the live BrowserWindow, but all of the
+// decision logic (what is a valid saved bounds payload, and whether those
+// bounds are still visible on a currently-attached display) is pure and lives
+// here so it can be unit-tested without spinning up Electron. See
+// window-bounds.test.cjs.
+
+const DEFAULT_BOUNDS = Object.freeze({ width: 1220, height: 800 })
+
+// Minimums must match the BrowserWindow `minWidth`/`minHeight` in main.cjs so
+// we never restore a window smaller than the renderer can lay out.
+const MIN_WIDTH = 400
+const MIN_HEIGHT = 620
+
+function isFiniteNumber(value) {
+  return typeof value === 'number' && Number.isFinite(value)
+}
+
+/**
+ * Validate and normalize a raw saved-bounds payload (e.g. parsed JSON from
+ * disk). Returns a clean { x, y, width, height, isMaximized } object, or null
+ * when the payload is missing required fields / is malformed.
+ *
+ * width/height are clamped to the window minimums. x/y are optional (a
+ * payload may legitimately omit them, e.g. an OS that didn't report a
+ * position); when present they must be finite integers.
+ */
+function sanitizeBounds(raw) {
+  if (!raw || typeof raw !== 'object') {
+    return null
+  }
+
+  if (!isFiniteNumber(raw.width) || !isFiniteNumber(raw.height)) {
+    return null
+  }
+
+  const width = Math.max(MIN_WIDTH, Math.round(raw.width))
+  const height = Math.max(MIN_HEIGHT, Math.round(raw.height))
+
+  const out = {
+    width,
+    height,
+    isMaximized: Boolean(raw.isMaximized)
+  }
+
+  if (isFiniteNumber(raw.x) && isFiniteNumber(raw.y)) {
+    out.x = Math.round(raw.x)
+    out.y = Math.round(raw.y)
+  }
+
+  return out
+}
+
+/**
+ * True when at least part of `bounds` overlaps the visible work area of one of
+ * the supplied displays. Used to discard saved positions that would place the
+ * window entirely off-screen (e.g. an external monitor that has since been
+ * unplugged) so the window doesn't reopen invisible.
+ *
+ * `displays` is the shape returned by Electron's `screen.getAllDisplays()`:
+ * each entry has a `workArea` (or `bounds`) of { x, y, width, height }.
+ * A bounds with no x/y is treated as visible (the OS will place it).
+ */
+function isVisibleOnDisplays(bounds, displays) {
+  if (!bounds) {
+    return false
+  }
+
+  if (!isFiniteNumber(bounds.x) || !isFiniteNumber(bounds.y)) {
+    // No stored position — let the OS/Electron pick a default placement.
+    return true
+  }
+
+  if (!Array.isArray(displays) || displays.length === 0) {
+    return false
+  }
+
+  const left = bounds.x
+  const top = bounds.y
+  const right = bounds.x + bounds.width
+  const bottom = bounds.y + bounds.height
+
+  // Require a minimum visible patch so a 1px sliver on a removed monitor
+  // doesn't count as "visible".
+  const MIN_VISIBLE = 48
+
+  for (const display of displays) {
+    const area = display?.workArea || display?.bounds
+    if (
+      !area ||
+      !isFiniteNumber(area.x) ||
+      !isFiniteNumber(area.y) ||
+      !isFiniteNumber(area.width) ||
+      !isFiniteNumber(area.height)
+    ) {
+      continue
+    }
+
+    const overlapX = Math.min(right, area.x + area.width) - Math.max(left, area.x)
+    const overlapY = Math.min(bottom, area.y + area.height) - Math.max(top, area.y)
+
+    if (overlapX >= MIN_VISIBLE && overlapY >= MIN_VISIBLE) {
+      return true
+    }
+  }
+
+  return false
+}
+
+/**
+ * Compute the BrowserWindow constructor options for size/position from a saved
+ * payload, falling back to defaults when the payload is missing, malformed, or
+ * would land off-screen.
+ *
+ * Returns { width, height, x?, y?, isMaximized }. `isMaximized` is advisory —
+ * the caller maximizes the window after creation rather than via constructor
+ * options (Electron has no `maximized` option).
+ */
+function resolveInitialBounds(raw, displays, defaults = DEFAULT_BOUNDS) {
+  const fallback = {
+    width: defaults.width,
+    height: defaults.height,
+    isMaximized: false
+  }
+
+  const sanitized = sanitizeBounds(raw)
+  if (!sanitized) {
+    return fallback
+  }
+
+  if (!isVisibleOnDisplays(sanitized, displays)) {
+    // Keep the remembered size, drop the off-screen position.
+    return {
+      width: sanitized.width,
+      height: sanitized.height,
+      isMaximized: sanitized.isMaximized
+    }
+  }
+
+  return sanitized
+}
+
+module.exports = {
+  DEFAULT_BOUNDS,
+  MIN_WIDTH,
+  MIN_HEIGHT,
+  sanitizeBounds,
+  isVisibleOnDisplays,
+  resolveInitialBounds
+}

--- a/apps/desktop/electron/window-bounds.test.cjs
+++ b/apps/desktop/electron/window-bounds.test.cjs
@@ -1,0 +1,106 @@
+/**
+ * Tests for electron/window-bounds.cjs.
+ *
+ * Run with: node --test electron/window-bounds.test.cjs
+ */
+
+const test = require('node:test')
+const assert = require('node:assert/strict')
+
+const {
+  DEFAULT_BOUNDS,
+  MIN_WIDTH,
+  MIN_HEIGHT,
+  sanitizeBounds,
+  isVisibleOnDisplays,
+  resolveInitialBounds
+} = require('./window-bounds.cjs')
+
+const primaryDisplay = { workArea: { x: 0, y: 0, width: 1920, height: 1080 } }
+
+test('sanitizeBounds returns null for missing/malformed payloads', () => {
+  assert.equal(sanitizeBounds(null), null)
+  assert.equal(sanitizeBounds(undefined), null)
+  assert.equal(sanitizeBounds('1220x800'), null)
+  assert.equal(sanitizeBounds({}), null)
+  assert.equal(sanitizeBounds({ width: 1220 }), null) // height missing
+  assert.equal(sanitizeBounds({ width: 'a', height: 'b' }), null)
+  assert.equal(sanitizeBounds({ width: NaN, height: 800 }), null)
+})
+
+test('sanitizeBounds clamps width/height to the window minimums', () => {
+  const out = sanitizeBounds({ width: 100, height: 100 })
+  assert.equal(out.width, MIN_WIDTH)
+  assert.equal(out.height, MIN_HEIGHT)
+  assert.equal(out.isMaximized, false)
+  assert.equal('x' in out, false)
+})
+
+test('sanitizeBounds rounds and preserves a valid position', () => {
+  const out = sanitizeBounds({ x: 12.7, y: -4.2, width: 1300.6, height: 900.1, isMaximized: true })
+  assert.deepEqual(out, { x: 13, y: -4, width: 1301, height: 900, isMaximized: true })
+})
+
+test('sanitizeBounds drops position when only one of x/y is finite', () => {
+  const out = sanitizeBounds({ x: 100, width: 1220, height: 800 })
+  assert.equal('x' in out, false)
+  assert.equal('y' in out, false)
+})
+
+test('isVisibleOnDisplays treats position-less bounds as visible', () => {
+  assert.equal(isVisibleOnDisplays({ width: 1220, height: 800 }, [primaryDisplay]), true)
+})
+
+test('isVisibleOnDisplays detects on-screen bounds', () => {
+  const bounds = { x: 100, y: 100, width: 1220, height: 800 }
+  assert.equal(isVisibleOnDisplays(bounds, [primaryDisplay]), true)
+})
+
+test('isVisibleOnDisplays rejects bounds on a removed monitor', () => {
+  // Saved on a second monitor at x=2200 that is no longer attached.
+  const bounds = { x: 2200, y: 200, width: 1220, height: 800 }
+  assert.equal(isVisibleOnDisplays(bounds, [primaryDisplay]), false)
+})
+
+test('isVisibleOnDisplays rejects a tiny off-screen sliver', () => {
+  // Only 10px of the window overlaps the right edge of the work area.
+  const bounds = { x: 1910, y: 100, width: 1220, height: 800 }
+  assert.equal(isVisibleOnDisplays(bounds, [primaryDisplay]), false)
+})
+
+test('isVisibleOnDisplays returns false with no displays and a stored position', () => {
+  const bounds = { x: 100, y: 100, width: 1220, height: 800 }
+  assert.equal(isVisibleOnDisplays(bounds, []), false)
+})
+
+test('resolveInitialBounds falls back to defaults on malformed payload', () => {
+  assert.deepEqual(resolveInitialBounds(null, [primaryDisplay]), {
+    width: DEFAULT_BOUNDS.width,
+    height: DEFAULT_BOUNDS.height,
+    isMaximized: false
+  })
+})
+
+test('resolveInitialBounds restores valid on-screen bounds verbatim', () => {
+  const raw = { x: 200, y: 150, width: 1400, height: 900, isMaximized: false }
+  assert.deepEqual(resolveInitialBounds(raw, [primaryDisplay]), {
+    x: 200,
+    y: 150,
+    width: 1400,
+    height: 900,
+    isMaximized: false
+  })
+})
+
+test('resolveInitialBounds keeps size but drops an off-screen position', () => {
+  const raw = { x: 5000, y: 5000, width: 1400, height: 900, isMaximized: false }
+  const out = resolveInitialBounds(raw, [primaryDisplay])
+  assert.deepEqual(out, { width: 1400, height: 900, isMaximized: false })
+  assert.equal('x' in out, false)
+})
+
+test('resolveInitialBounds carries the maximized flag through', () => {
+  const raw = { x: 0, y: 0, width: 1220, height: 800, isMaximized: true }
+  const out = resolveInitialBounds(raw, [primaryDisplay])
+  assert.equal(out.isMaximized, true)
+})

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -37,7 +37,7 @@
     "test:desktop:nsis": "node scripts/test-desktop.mjs nsis",
     "test:desktop:existing": "node scripts/test-desktop.mjs existing",
     "test:desktop:fresh": "node scripts/test-desktop.mjs fresh",
-    "test:desktop:platforms": "node --test electron/bootstrap-platform.test.cjs electron/hardening.test.cjs electron/backend-env.test.cjs electron/backend-probes.test.cjs electron/bootstrap-runner.test.cjs electron/connection-config.test.cjs electron/dashboard-token.test.cjs electron/gateway-ws-probe.test.cjs electron/oauth-net-request.test.cjs electron/desktop-uninstall.test.cjs electron/session-windows.test.cjs electron/workspace-cwd.test.cjs electron/fs-read-dir.test.cjs electron/git-root.test.cjs electron/windows-child-process.test.cjs electron/update-remote.test.cjs electron/update-rebuild.test.cjs electron/windows-user-env.test.cjs",
+    "test:desktop:platforms": "node --test electron/bootstrap-platform.test.cjs electron/hardening.test.cjs electron/backend-env.test.cjs electron/backend-probes.test.cjs electron/bootstrap-runner.test.cjs electron/connection-config.test.cjs electron/dashboard-token.test.cjs electron/gateway-ws-probe.test.cjs electron/oauth-net-request.test.cjs electron/desktop-uninstall.test.cjs electron/session-windows.test.cjs electron/workspace-cwd.test.cjs electron/fs-read-dir.test.cjs electron/git-root.test.cjs electron/windows-child-process.test.cjs electron/update-remote.test.cjs electron/update-rebuild.test.cjs electron/windows-user-env.test.cjs electron/window-bounds.test.cjs",
     "typecheck": "tsc -p . --noEmit",
     "lint": "eslint src/ electron/",
     "lint:fix": "eslint src/ electron/ --fix",


### PR DESCRIPTION
## Summary

- The Hermes Desktop main window now remembers its size and position across restarts (including update-triggered restarts) instead of snapping back to the hardcoded default.

## Motivation

Closes #48539.

`createWindow()` built the main `BrowserWindow` with hardcoded `width: 1220, height: 800` and there was no bounds persistence anywhere — no `getBounds`/`setBounds` save/restore, no `resize`/`move`/`close` listeners, and no window-bounds file under `userData`. Other settings (translucency, native theme, connection) persist because they each write their own JSON file under `app.getPath('userData')`; window geometry was simply never wired into that, so every launch fell back to the default. The reporter root-caused this precisely in the issue.

## Fix

New pure, unit-tested helper `apps/desktop/electron/window-bounds.cjs`:

- `sanitizeBounds()` — validates a saved payload, clamps width/height to the existing window minimums (400×620), drops a partial position.
- `isVisibleOnDisplays()` — rejects bounds that would land entirely off-screen (e.g. an external monitor that's been unplugged) so the window never reopens invisible. Position-less payloads are treated as "let the OS place it."
- `resolveInitialBounds()` — combines both: restore valid on-screen bounds verbatim; keep the remembered size but drop an off-screen position; fall back to defaults on missing/malformed input.

`main.cjs` wires it in, mirroring the existing `userData` JSON persistence pattern:

- Reads `window-bounds.json` and seeds the `BrowserWindow` constructor from `resolveInitialBounds(...)`.
- Persists via the existing atomic `writeFileAtomic` helper, debounced (400 ms) on `resize`/`move`, plus `maximize`/`unmaximize`/`close`.
- Uses `getNormalBounds()` so the pre-maximize rectangle is stored; re-maximizes after `ready-to-show` when the last state was maximized (Electron has no `maximized` constructor option).

All decision logic lives in the pure module so it is testable without launching Electron; `main.cjs` only does the live BrowserWindow plumbing.

## Verification

- `node --test electron/window-bounds.test.cjs` — **13 passed** (validation, off-screen recovery, off-screen-sliver rejection, maximized flag, default fallback).
- Added `window-bounds.test.cjs` to the `test:desktop:platforms` npm script.
- Full platforms suite green on my branch (the pre-existing `windows-child-process.test.cjs` failure is Windows-specific, present on clean `main` when run on a non-Windows host, and untouched by this change — not absorbed here).
- `node --check electron/main.cjs` — clean.

## Real behavior proof

- **Behavior addressed:** window always reopened at 1220×800 at the default position regardless of last size/position.
- **Environment:** node v25 on macOS (pure helper + main.cjs syntax check; Electron runtime not launched in CI).
- **Commands run after the patch:**
  ```
  node --check electron/main.cjs
  node --test electron/window-bounds.test.cjs
  ```
- **Captured output AFTER fix:**
  ```
  ✔ resolveInitialBounds restores valid on-screen bounds verbatim
  ✔ resolveInitialBounds keeps size but drops an off-screen position
  ✔ resolveInitialBounds carries the maximized flag through
  ℹ tests 13
  ℹ pass 13
  ℹ fail 0
  ```
- **Regression test:** `window-bounds.test.cjs` asserts the new restore behavior and fails against the old hardcoded path (there was no restore logic at all before).
- **What was NOT tested:** the live Electron `resize`/`move`/`close` event plumbing in `main.cjs` (not unit-testable without launching Electron); the pure decision logic that drives it is fully covered.
