### PR TITLE
fix(install): only warn about a fallback dependency tier when one was used

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1521,7 +1521,7 @@ PY
         exit 1
     fi
 
-    if [ "$_tier_name" != "all (with RL/matrix extras)" ]; then
+    if [ "$_tier_name" != "all" ]; then
         log_warn "Note: installed via fallback tier ($_tier_name)."
         log_info "Some optional features may be missing. After resolving any"
         log_info "PyPI/network issue, re-run: $UV_CMD pip install -e '.[all]'"

--- a/tests/test_install_sh_fallback_tier_warning.py
+++ b/tests/test_install_sh_fallback_tier_warning.py
@@ -1,0 +1,94 @@
+"""Regression: install.sh must only warn about a fallback dependency tier
+when one was actually used.
+
+The post-install warning guarded on ``_tier_name != "all (with RL/matrix
+extras)"``, but ``_tier_name`` is only ever ``"all"``, ``"all minus
+known-broken (...)"``, or ``"core only (no extras)"`` (the three
+``install_tier`` names). The sentinel ``"all (with RL/matrix extras)"`` is a
+stale tier name from before the 2026-05-12 lazy-install migration and is never
+produced, so the condition was always true and a fully successful ``.[all]``
+install printed a false ``installed via fallback tier (all). Some optional
+features may be missing.`` warning. The fix compares against the real primary
+tier name ``"all"``.
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+INSTALL_SH = REPO_ROOT / "scripts" / "install.sh"
+
+
+def test_dead_sentinel_gone_and_guard_uses_primary_tier_name() -> None:
+    """Static guard: the stale sentinel is gone, the guard compares to "all"."""
+    text = INSTALL_SH.read_text()
+    assert "all (with RL/matrix extras)" not in text, (
+        "the stale fallback-tier sentinel must be removed — _tier_name is "
+        'never that string, so the guard was always true'
+    )
+    assert 'if [ "$_tier_name" != "all" ]; then' in text, (
+        "the fallback-tier warning must guard on the real primary tier name "
+        '"all"'
+    )
+
+
+def _extract_fallback_warning_block() -> str:
+    """Return the post-install fallback-tier warning block from install.sh."""
+    text = INSTALL_SH.read_text()
+    # Match the guard regardless of the compared value so the behavioral test
+    # reproduces the real bug: before the fix the block warns even for "all".
+    match = re.search(
+        r'(?P<block>if \[ "\$_tier_name" != ".*?" \]; then.*?\n    fi)',
+        text,
+        re.DOTALL,
+    )
+    assert match is not None, (
+        "Could not locate the fallback-tier warning block in scripts/install.sh"
+    )
+    return match["block"]
+
+
+def _run_block(tier_name: str) -> str:
+    """Run the warning block under bash with log_* stubbed, return combined output."""
+    block = _extract_fallback_warning_block()
+    script = (
+        "set -e\n"
+        'log_warn() { echo "WARN: $*"; }\n'
+        'log_info() { echo "INFO: $*"; }\n'
+        'log_error() { echo "ERROR: $*"; }\n'
+        'log_success() { echo "OK: $*"; }\n'
+        "_installed=true\n"
+        f'_tier_name="{tier_name}"\n'
+        'UV_CMD="uv"\n'
+        f"{block}\n"
+    )
+    result = subprocess.run(
+        ["bash", "-c", script],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, (
+        f"warning block failed:\nstdout={result.stdout}\nstderr={result.stderr}"
+    )
+    return result.stdout + result.stderr
+
+
+def test_no_warning_for_primary_all_tier() -> None:
+    """A successful primary `.[all]` install must NOT print the fallback warning."""
+    out = _run_block("all")
+    assert "installed via fallback tier" not in out, (
+        "the fallback-tier warning must be suppressed when the primary "
+        '"all" tier succeeded'
+    )
+
+
+def test_warning_for_fallback_tier() -> None:
+    """A genuine fallback tier must still print the warning."""
+    out = _run_block("core only (no extras)")
+    assert "installed via fallback tier" in out, (
+        "the warning must still fire for a real fallback tier"
+    )


### PR DESCRIPTION
## What does this PR do?

`install.sh`'s post-install warning guards on `_tier_name != "all (with RL/matrix extras)"`, but `_tier_name` is only ever assigned one of the three `install_tier` names — `"all"`, `"all minus known-broken (…)"`, or `"core only (no extras)"`. The sentinel `"all (with RL/matrix extras)"` is a stale tier name from before the 2026-05-12 lazy-install migration removed the RL/matrix tiers, so it is never produced and the condition is always true.

As a result, a fully successful `.[all]` install (on the non-`uv.lock` path, e.g. source installs without a synced lockfile) prints a false `installed via fallback tier (all). Some optional features may be missing.` warning plus a bogus re-run instruction. The fix compares against the real primary tier name `"all"`, so the warning fires only for the genuine fallback tiers.

## Related Issue

Fixes #

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `scripts/install.sh`: change the fallback-tier warning guard from the dead sentinel `"all (with RL/matrix extras)"` to the actual primary tier name `"all"` (one line).
- `tests/test_install_sh_fallback_tier_warning.py`: new regression test — static check that the dead sentinel is gone and the guard compares to `"all"`, plus a behavioral check (extract + run the warning block under `bash`) that the warning is suppressed for `_tier_name="all"` and still fires for a fallback tier.

## How to Test

1. On the non-`uv.lock` install path, a successful `.[all]` install previously printed `Note: installed via fallback tier (all). Some optional features may be missing.` — after this change it does not.
2. `uv run --with pytest python3 -m pytest tests/test_install_sh_fallback_tier_warning.py -q` — fails before the production hunk, passes after.
3. `bash -n scripts/install.sh` — syntax check passes.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A