### PR TITLE
fix(gateway): forward-resolve compressed session to tip on resident non-Telegram platforms

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -8319,6 +8319,39 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         session_entry = self.session_store.get_or_create_session(source)
         session_key = session_entry.session_key
         self._cache_session_source(session_key, source)
+        # Heal session_key -> session_id mappings that still point at a
+        # pre-compression parent on resident non-Telegram platforms
+        # (Discord/Slack/etc.): walk the compression-continuation chain forward
+        # to its tip so the next message resumes the compressed child instead of
+        # reloading the oversized parent transcript. Without this, compaction's
+        # session rotation forks the conversation on every turn — the stale
+        # parent is reloaded, re-grows past the context cap, and spawns orphan
+        # child sessions in an endless preflight-compression loop
+        # (#44004/#38763/#25921). Telegram topic lanes do their own
+        # binding-based healing below, so skip them here. get_compression_tip
+        # only follows end_reason='compression' chains and returns the input
+        # unchanged otherwise, so this is cheap and safe for fresh/branch
+        # sessions.
+        if (
+            self._session_db is not None
+            and session_entry is not None
+            and not self._is_telegram_topic_lane(source)
+        ):
+            try:
+                _tip = self._session_db.get_compression_tip(
+                    session_entry.session_id,
+                )
+            except Exception:
+                logger.debug(
+                    "compression-tip lookup failed for %s",
+                    session_entry.session_id, exc_info=True,
+                )
+                _tip = None
+            if _tip and _tip != session_entry.session_id:
+                switched = self.session_store.switch_session(session_key, _tip)
+                if switched is not None:
+                    session_entry = switched
+                    session_key = session_entry.session_key
         if self._is_telegram_topic_lane(source):
             try:
                 binding = self._session_db.get_telegram_topic_binding(


### PR DESCRIPTION
## Summary

Fixes the resident-gateway (Discord/Slack) slice of the compaction session-fork bug (#44004): on a self-hosted Discord/Slack gateway, a long conversation keeps rotating its `session_id` on every auto-compression, forking orphan child sessions and reloading the oversized pre-compression parent on each turn — an endless preflight-compression loop where one session was observed climbing past the model's context cap and spawning multiple orphan lineages in minutes.

## Why existing fixes don't cover this path

The same #44004 root cause has **three distinct intake paths**, each needing its own forward-resolution to the compression tip:

- **#48633 (merged)** — `SessionDB.resolve_resume_session_id()` + TUI/desktop resume (`tui_gateway/server.py`).
- **#44103 (open)** — `gateway/platforms/api_server.py`, stateless OpenAI-compatible clients.
- **this PR** — the resident gateway message path `GatewayRunner._handle_message()` → `session_store.get_or_create_session()` in `gateway/run.py`.

The resident gateway path never calls `resolve_resume_session_id()` (only slash-commands / TUI / api_server do), and `get_or_create_session()` returns the stored `session_key → session_id` mapping verbatim without following the compression chain. The only forward-resolution in `gateway/run.py` lived **inside the Telegram-topic-lane branch**, so Discord/Slack resident lanes reloaded the pre-compression parent after every rotation.

## Change

Right after `get_or_create_session()`, apply the same lineage-aware `get_compression_tip()` walk the Telegram lane already uses — for all non-Telegram resident platforms — and `switch_session()` the `session_key` forward to the tip. Telegram keeps its own binding-based healing. `get_compression_tip()` only follows `end_reason='compression'` chains and returns the input unchanged otherwise, so it's a no-op for fresh/branch/delegate sessions.

## Verification

- `tests/test_hermes_state.py -k compression_tip` (4 passed) — the primitive.
- `tests/gateway/test_telegram_topic_mode.py` (44 passed) — the mirrored healing pattern, no regression.
- Live: on a Discord gateway exhibiting the fork loop, after this patch a compaction split now continues on the child tip (subsequent turns route to the child), the parent ends and stops re-growing, orphan-session count stays flat across repeated compactions, and no session exceeds the context cap.

Refs #44004, complements #48633 and #44103.
