### PR TITLE
fix(cron): extend one-shot grace window 120s → 600s

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -58,7 +58,7 @@ JOBS_FILE = CRON_DIR / "jobs.json"
 _jobs_file_lock = threading.RLock()
 _jobs_lock_state = threading.local()
 OUTPUT_DIR = CRON_DIR / "output"
-ONESHOT_GRACE_SECONDS = 120
+ONESHOT_GRACE_SECONDS = 600  # 10 min — see _recoverable_oneshot_run_at for rationale
 
 
 def _jobs_lock_file() -> Path:
@@ -402,9 +402,20 @@ def _recoverable_oneshot_run_at(
 ) -> Optional[str]:
     """Return a one-shot run time if it is still eligible to fire.
 
-    One-shot jobs get a small grace window so jobs created a few seconds after
-    their requested minute still run on the next tick. Once a one-shot has
-    already run, it is never eligible again.
+    One-shot jobs get a grace window so jobs whose ``run_at`` is a few minutes
+    in the past still run on the next tick.  The window is needed because:
+
+    1. The 60 s scheduler tick may not align with the requested ``run_at`` —
+       a one-shot created at 14:55:30 with ``run_at`` 14:57:00 will not be
+       eligible to fire until the tick at 14:56:30 at the earliest.
+    2. ``tick()`` uses ``flock(..., LOCK_NB)`` and silently skips a tick if
+       another process is writing ``jobs.json`` at that moment (e.g. a CLI
+       ``hermes cron create`` from a separate shell).  A few skipped ticks
+       are normal under load.
+    3. Interactive use cases (e.g. emergency one-shots to backfill a missed
+       report) routinely need a "create with run_at ≈ now + 1 min" window.
+
+    Once a one-shot has already run, it is never eligible again.
     """
     if schedule.get("kind") != "once":
         return None

--- a/tests/cron/test_jobs.py
+++ b/tests/cron/test_jobs.py
@@ -130,6 +130,28 @@ class TestComputeNextRun:
 
         assert compute_next_run(schedule) == run_at
 
+    def test_once_within_10min_grace_returns_time(self, monkeypatch):
+        """One-shot created with run_at up to 10 min in the past must still fire.
+
+        Regression test: ONESHOT_GRACE_SECONDS used to be 120s, which dropped
+        one-shots whenever a 60s tick + a jobs.json write lock contention
+        aligned.  See _recoverable_oneshot_run_at docstring.
+        """
+        from cron.jobs import ONESHOT_GRACE_SECONDS
+        assert ONESHOT_GRACE_SECONDS >= 300, (
+            f"ONESHOT_GRACE_SECONDS={ONESHOT_GRACE_SECONDS} is too small; "
+            f"see _recoverable_oneshot_run_at docstring for rationale"
+        )
+
+        now = datetime(2026, 6, 19, 15, 5, 0, tzinfo=timezone.utc)
+        # 5 min in the past — well past the old 2 min grace
+        run_at = "2026-06-19T15:00:00+00:00"
+        monkeypatch.setattr("cron.jobs._hermes_now", lambda: now)
+
+        schedule = {"kind": "once", "run_at": run_at}
+
+        assert compute_next_run(schedule) == run_at
+
     def test_once_past_returns_none(self):
         past = (datetime.now() - timedelta(hours=1)).isoformat()
         schedule = {"kind": "once", "run_at": past}
@@ -760,8 +782,8 @@ class TestGetDueJobs:
                 "id": "oneshot-stale",
                 "name": "Too old",
                 "prompt": "Word of the day",
-                "schedule": {"kind": "once", "run_at": "2026-03-18T04:22:00+00:00", "display": "once at 2026-03-18 04:22"},
-                "schedule_display": "once at 2026-03-18 04:22",
+                "schedule": {"kind": "once", "run_at": "2026-03-18T04:12:00+00:00", "display": "once at 2026-03-18 04:12"},
+                "schedule_display": "once at 2026-03-18 04:12",
                 "repeat": {"times": 1, "completed": 0},
                 "enabled": True,
                 "state": "scheduled",


### PR DESCRIPTION
## Problem

A one-shot cron job created with `run_at` within a couple of minutes of "now" could be **permanently dropped** if a 60 s scheduler tick + a `jobs.json` write lock contention aligned badly.

Reproduction (2026-06-19, real incident):
- 14:55:00 — `cronjob create one-shot`, `run_at` 14:57:00
- 14:55-15:00 — daemon's 60 s ticker ran ~5 times; `get_due_jobs()` should have recovered the one-shot at the 14:56:30 tick, written `next_run_at = 14:57` to disk, and fired at the 14:57:30 tick.
- 15:00:00 — daemon fired the MGC London KZ 早段复测 (15:00 recurring) — no log of the one-shot ever being attempted.
- 15:00:15 — even if a tick finally noticed, `14:57 - 15:00 = -180s > ONESHOT_GRACE_SECONDS(120s)` → `_recoverable_oneshot_run_at` returns `None` → one-shot **permanently skipped**.

## Root cause

`cron/jobs.py:61` hard-codes `ONESHOT_GRACE_SECONDS = 120`. The grace window needs to absorb at least:
1. 60 s tick alignment (a `run_at` between two ticks can take up to 60 s to be seen).
2. 1-2 LOCK_NB-skipped ticks under load (`scheduler.py:1994` uses `fcntl.flock(..., LOCK_NB)` and silently skips a tick if another process holds the `jobs.json` write lock).
3. Interactive use cases (`hermes cron create 5m` from a shell, or 应急 one-shots with `run_at = now + 1 min`).

120 s only barely covers (1) and not (2)/(3).

## Fix

`ONESHOT_GRACE_SECONDS: 120 → 600` (10 min).

10 min gives operators headroom for the three above without becoming a "never-fire" trap. A one-shot more than 10 min late is genuinely broken (operator error, gateway down for hours, etc.) and should not fire.

## Test

- New `test_once_within_10min_grace_returns_time` — asserts that a one-shot 5 min in the past still recovers (would have failed under the old 120 s grace).
- Existing `test_broken_stale_one_shot_without_next_run_is_not_recovered` updated to use 15-min-stale `run_at` so it stays clearly outside the new grace.

## Verification

```
$ python -m pytest tests/cron/test_jobs.py -k TestComputeNextRun -v
tests/cron/test_jobs.py::TestComputeNextRun::test_once_future_returns_time PASSED
tests/cron/test_jobs.py::TestComputeNextRun::test_once_recent_past_within_grace_returns_time PASSED
tests/cron/test_jobs.py::TestComputeNextRun::test_once_within_10min_grace_returns_time PASSED  # new
tests/cron/test_jobs.py::TestComputeNextRun::test_once_past_returns_none PASSED
tests/cron/test_jobs.py::TestComputeNextRun::test_once_with_last_run_returns_none_even_within_grace PASSED
... 9 passed
```

Full `tests/cron/` suite: 438 passed, 1 pre-existing failure unrelated to this change (test_all_token_case_insensitive expects no weixin platform, fails on main before this PR too).

## Out of scope (intentionally)

- **`tick()` LOCK_NB skip on contention** — correct design; a non-blocking lock prevents deadlocks under load. Not addressed here.
- **`tick()` frequency (60 s default)** — already reasonable; 60 s × `N` skipped ticks is now absorbed by the 10 min grace.
- **`cronjob create` waking the daemon** — would require a signaling layer; left for a follow-up if it becomes a recurring problem.

🤖 Generated with [Claude Code](https://claude.com/claude-code)