### PR TITLE
fix(prompt): honor explicit system prompt timestamp config

### DIFF
--- a/agent/system_prompt.py
+++ b/agent/system_prompt.py
@@ -61,6 +61,34 @@ def _ra():
     return run_agent
 
 
+def _should_include_system_prompt_timestamp() -> bool:
+    """Honor explicit config for the prompt's date line.
+
+    Keep the historical default (enabled) unless the user explicitly wrote a
+    raw config override. ``agent.system_prompt_timestamp`` is the dedicated
+    switch; explicit legacy ``display.timestamps`` also disables/enables it
+    for backward compatibility with existing user expectations.
+    """
+    try:
+        from hermes_cli.config import read_raw_config
+
+        raw_cfg = read_raw_config()
+        if not isinstance(raw_cfg, dict):
+            return True
+
+        agent_cfg = raw_cfg.get("agent")
+        if isinstance(agent_cfg, dict) and "system_prompt_timestamp" in agent_cfg:
+            return bool(agent_cfg.get("system_prompt_timestamp"))
+
+        display_cfg = raw_cfg.get("display")
+        if isinstance(display_cfg, dict) and "timestamps" in display_cfg:
+            return bool(display_cfg.get("timestamps"))
+    except Exception:
+        pass
+
+    return True
+
+
 def _resolve_platform_hint(agent: Any, platform_key: str, default_hint: str) -> str:
     """Apply a per-platform prompt-hint override to the default hint.
 
@@ -449,14 +477,19 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
     # session resume without a stored prompt).  The model can still query the
     # exact wall-clock time via tools when it actually needs it.
     # Credit: @iamfoz (PR #20451).
-    timestamp_line = f"Conversation started: {now.strftime('%A, %B %d, %Y')}"
+    timestamp_lines: List[str] = []
+    if _should_include_system_prompt_timestamp():
+        timestamp_lines.append(
+            f"Conversation started: {now.strftime('%A, %B %d, %Y')}"
+        )
     if agent.pass_session_id and agent.session_id:
-        timestamp_line += f"\nSession ID: {agent.session_id}"
+        timestamp_lines.append(f"Session ID: {agent.session_id}")
     if agent.model:
-        timestamp_line += f"\nModel: {agent.model}"
+        timestamp_lines.append(f"Model: {agent.model}")
     if agent.provider:
-        timestamp_line += f"\nProvider: {agent.provider}"
-    volatile_parts.append(timestamp_line)
+        timestamp_lines.append(f"Provider: {agent.provider}")
+    if timestamp_lines:
+        volatile_parts.append("\n".join(timestamp_lines))
 
     return {
         "stable":   "\n\n".join(p.strip() for p in stable_parts   if p and p.strip()),
@@ -527,6 +560,7 @@ def format_tools_for_system_message(agent: Any) -> str:
 
 
 __all__ = [
+    "_should_include_system_prompt_timestamp",
     "build_system_prompt_parts",
     "build_system_prompt",
     "invalidate_system_prompt",

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -629,6 +629,10 @@ agent:
   # Controls how much "thinking" the model does before responding.
   # Options: "xhigh" (max), "high", "medium", "low", "minimal", "none" (disable)
   reasoning_effort: "medium"
+
+  # Include the cached system prompt's "Conversation started: ..." date line.
+  # Set false if a provider or proxy rejects that prompt content.
+  # system_prompt_timestamp: true
   
   # Predefined personalities (use with /personality command)
   personalities:

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -913,6 +913,10 @@ DEFAULT_CONFIG = {
         # provider hiccups on a single provider.
         "api_max_retries": 3,
         "service_tier": "",
+        # Include the "Conversation started: ..." date line in the cached
+        # system prompt. Set False to suppress it for providers/endpoints
+        # that reject or mishandle that prompt content.
+        "system_prompt_timestamp": True,
         # Tool-use enforcement: injects system prompt guidance that tells the
         # model to actually call tools instead of describing intended actions.
         # Values: "auto" (default — applies to gpt/codex models), true/false

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -1137,6 +1137,33 @@ class TestBuildSystemPrompt:
         else:
             assert False, "Expected a 'Conversation started:' line in the system prompt"
 
+    def test_explicit_display_timestamps_false_disables_prompt_date_line(self, agent):
+        with patch("hermes_cli.config.read_raw_config", return_value={"display": {"timestamps": False}}):
+            prompt = agent._build_system_prompt()
+
+        assert "Conversation started:" not in prompt
+
+    def test_explicit_agent_system_prompt_timestamp_false_disables_prompt_date_line(self, agent):
+        with patch(
+            "hermes_cli.config.read_raw_config",
+            return_value={"agent": {"system_prompt_timestamp": False}},
+        ):
+            prompt = agent._build_system_prompt()
+
+        assert "Conversation started:" not in prompt
+
+    def test_agent_system_prompt_timestamp_overrides_legacy_display_setting(self, agent):
+        with patch(
+            "hermes_cli.config.read_raw_config",
+            return_value={
+                "agent": {"system_prompt_timestamp": True},
+                "display": {"timestamps": False},
+            },
+        ):
+            prompt = agent._build_system_prompt()
+
+        assert "Conversation started:" in prompt
+
     def test_includes_nous_subscription_prompt(self, agent, monkeypatch):
         monkeypatch.setattr(run_agent, "build_nous_subscription_prompt", lambda tool_names: "NOUS SUBSCRIPTION BLOCK")
         prompt = agent._build_system_prompt()


### PR DESCRIPTION
## What does this PR do?

Fixes a config regression where the cached system prompt always injected the `Conversation started: ...` date line, even when users had explicitly disabled timestamps in `config.yaml`.

This PR adds a dedicated `agent.system_prompt_timestamp` switch and also honors an explicit legacy `display.timestamps` setting from the raw user config for backward compatibility.

## Related Issue

Fixes #48772

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/system_prompt.py`: conditionally omits the cached system prompt date line based on explicit raw config, while preserving `Session ID`, `Model`, and `Provider` lines when present.
- `agent/system_prompt.py`: prefers the dedicated `agent.system_prompt_timestamp` key and falls back to explicit legacy `display.timestamps` for backward compatibility.
- `hermes_cli/config.py`: adds the new `agent.system_prompt_timestamp` default.
- `cli-config.yaml.example`: documents the new config key.
- `tests/run_agent/test_run_agent.py`: adds regression tests for the dedicated override, the legacy setting, and the precedence rule.

## How to Test

1. Set either `agent.system_prompt_timestamp: false` or `display.timestamps: false` in `~/.hermes/config.yaml`.
2. Start a fresh Hermes session and confirm the cached system prompt no longer includes `Conversation started: ...`.
3. Run:
   - `/Users/leongong/Desktop/LeonProjects/worktrees/hermes-agent/.base/.venv/bin/python -m py_compile agent/system_prompt.py hermes_cli/config.py tests/run_agent/test_run_agent.py`
   - `/Users/leongong/Desktop/LeonProjects/worktrees/hermes-agent/.base/.venv/bin/python -m pytest tests/run_agent/test_run_agent.py -q -k 'datetime or system_prompt_timestamp or legacy_display_setting'`

## Checklist

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.4.1

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

- `git diff --check` passed
- `py_compile` passed for the touched Python files
- `pytest tests/run_agent/test_run_agent.py -q -k 'datetime or system_prompt_timestamp or legacy_display_setting'` → `4 passed, 379 deselected in 15.89s`
