### PR TITLE
fix(feishu): cancel recalled messages before agent response

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -1837,6 +1837,7 @@ class BasePlatformAdapter(ABC):
         self.config = config
         self.platform = platform
         self._message_handler: Optional[MessageHandler] = None
+        self._message_recall_handler: Optional[Callable[[Platform, str], Awaitable[None] | None]] = None
         # Optional hook (e.g. Telegram DM topic recovery) that rewrites
         # ``event.source.thread_id`` before session keying. Returns the
         # corrected thread_id or None to leave the source untouched.
@@ -2246,6 +2247,13 @@ class BasePlatformAdapter(ABC):
         an optional response string.
         """
         self._message_handler = handler
+
+    def set_message_recall_handler(
+        self,
+        handler: Optional[Callable[[Platform, str], Awaitable[None] | None]],
+    ) -> None:
+        """Set the handler for platform message recall/delete events."""
+        self._message_recall_handler = handler
 
     def set_topic_recovery_fn(
         self,

--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -51,6 +51,7 @@ import asyncio
 import collections
 import hashlib
 import hmac
+import inspect
 import itertools
 import json
 import logging
@@ -241,6 +242,8 @@ _FEISHU_REACTION_FAILURE = "CrossMark"
 # delete-failures, not a capacity plan.
 _FEISHU_PROCESSING_REACTION_CACHE_SIZE = 1024
 _FEISHU_MESSAGE_TEXT_CACHE_SIZE = 512       # LRU cap for reply-context message text lookups
+_FEISHU_RECALLED_MESSAGE_CACHE_SIZE = 2048
+_FEISHU_RECALLED_MESSAGE_TTL_SECONDS = 10 * 60
 
 # QR onboarding constants
 _ONBOARD_ACCOUNTS_URLS = {
@@ -1456,6 +1459,7 @@ class FeishuAdapter(BasePlatformAdapter):
         self._sent_message_id_order: List[str] = []  # LRU order for _sent_message_ids_to_chat
         self._chat_info_cache: Dict[str, Dict[str, Any]] = {}
         self._message_text_cache: "OrderedDict[str, Optional[str]]" = OrderedDict()
+        self._recalled_message_ids: "OrderedDict[str, float]" = OrderedDict()
         self._app_lock_identity: Optional[str] = None
         self._text_batch_state = FeishuBatchState()
         self._pending_text_batches = self._text_batch_state.events
@@ -2419,6 +2423,10 @@ class FeishuAdapter(BasePlatformAdapter):
         if not message_id or self._is_duplicate(message_id):
             logger.debug("[Feishu] Dropping duplicate/missing message_id: %s", message_id)
             return
+        message_id = str(message_id)
+        if self._is_recalled_message_id(message_id):
+            logger.info("[Feishu] Dropping recalled inbound message: %s", message_id)
+            return
 
         reason = self._admit(sender, message)
         if reason is not None:
@@ -2460,7 +2468,165 @@ class FeishuAdapter(BasePlatformAdapter):
         logger.debug("[Feishu] User entered P2P chat with bot")
 
     def _on_message_recalled(self, data: Any) -> None:
-        logger.debug("[Feishu] Message recalled by user")
+        message_id = self._extract_recalled_message_id(data)
+        if not message_id:
+            logger.debug("[Feishu] Message recalled by user (missing message_id)")
+            return
+        self._remember_recalled_message_id(message_id)
+        self._discard_recalled_pending_message(message_id)
+        logger.info("[Feishu] Message recalled by user: %s", message_id)
+
+        if not getattr(self, "_message_recall_handler", None):
+            return
+        loop = self._loop
+        if not self._loop_accepts_callbacks(loop):
+            logger.warning("[Feishu] Dropping recall callback before adapter loop is ready: %s", message_id)
+            return
+        self._submit_on_loop(loop, self._dispatch_message_recalled(message_id))
+
+    @staticmethod
+    def _extract_recalled_message_id(data: Any) -> str:
+        event = getattr(data, "event", None)
+        message = getattr(event, "message", None)
+        return str(
+            getattr(message, "message_id", "")
+            or getattr(event, "message_id", "")
+            or getattr(data, "message_id", "")
+            or ""
+        )
+
+    async def _dispatch_message_recalled(self, message_id: str) -> None:
+        handler = getattr(self, "_message_recall_handler", None)
+        if handler is None or not message_id:
+            return
+        result = handler(self.platform, message_id)
+        if inspect.isawaitable(result):
+            await result
+
+    def _remember_recalled_message_id(self, message_id: str) -> None:
+        if not message_id:
+            return
+        now = time.time()
+        recalled = self._recalled_message_ids
+        recalled[message_id] = now
+        recalled.move_to_end(message_id)
+        self._prune_recalled_message_ids(now)
+
+    def _prune_recalled_message_ids(self, now: Optional[float] = None) -> None:
+        now = time.time() if now is None else now
+        recalled = self._recalled_message_ids
+        expired = [
+            message_id
+            for message_id, seen_at in recalled.items()
+            if now - seen_at > _FEISHU_RECALLED_MESSAGE_TTL_SECONDS
+        ]
+        for message_id in expired:
+            recalled.pop(message_id, None)
+        while len(recalled) > _FEISHU_RECALLED_MESSAGE_CACHE_SIZE:
+            recalled.popitem(last=False)
+
+    def _is_recalled_message_id(self, message_id: str) -> bool:
+        if not message_id:
+            return False
+        self._prune_recalled_message_ids()
+        return message_id in self._recalled_message_ids
+
+    def _discard_recalled_pending_message(self, message_id: str) -> None:
+        """Remove a recalled message from not-yet-flushed Feishu batches."""
+        if not message_id:
+            return
+        for state, counts in (
+            (self._text_batch_state, self._pending_text_batch_counts),
+            (self._media_batch_state, None),
+        ):
+            for key, event in list(state.events.items()):
+                if self._remove_recalled_batch_item(event, message_id):
+                    if self._feishu_batch_items(event):
+                        if counts is not None:
+                            counts[key] = len(self._feishu_batch_items(event))
+                        logger.info("[Feishu] Removed recalled message %s from pending batch %s", message_id, key)
+                        continue
+                    state.events.pop(key, None)
+                    if counts is not None:
+                        counts.pop(key, None)
+                    task = state.tasks.pop(key, None)
+                    if task is not None and not task.done():
+                        task.cancel()
+                    logger.info("[Feishu] Dropped pending batch %s for recalled message %s", key, message_id)
+                    continue
+                if getattr(event, "message_id", None) != message_id:
+                    continue
+                state.events.pop(key, None)
+                if counts is not None:
+                    counts.pop(key, None)
+                task = state.tasks.pop(key, None)
+                if task is not None and not task.done():
+                    task.cancel()
+                logger.info("[Feishu] Dropped pending batch %s for recalled message %s", key, message_id)
+
+    @staticmethod
+    def _feishu_batch_item_from_event(event: MessageEvent) -> Dict[str, Any]:
+        return {
+            "message_id": str(getattr(event, "message_id", "") or ""),
+            "text": event.text or "",
+            "media_urls": list(event.media_urls or []),
+            "media_types": list(event.media_types or []),
+        }
+
+    @staticmethod
+    def _feishu_batch_items(event: MessageEvent) -> List[Dict[str, Any]]:
+        items = getattr(event, "_feishu_batch_items", None)
+        return items if isinstance(items, list) else []
+
+    def _ensure_feishu_batch_items(self, event: MessageEvent) -> List[Dict[str, Any]]:
+        items = self._feishu_batch_items(event)
+        if items:
+            return items
+        items = [self._feishu_batch_item_from_event(event)]
+        event._feishu_batch_items = items  # type: ignore[attr-defined]
+        return items
+
+    def _reset_feishu_batch_items(self, event: MessageEvent) -> None:
+        event._feishu_batch_items = [self._feishu_batch_item_from_event(event)]  # type: ignore[attr-defined]
+
+    def _remove_recalled_batch_item(self, event: MessageEvent, message_id: str) -> bool:
+        items = self._feishu_batch_items(event)
+        if not items:
+            return False
+        remaining = [item for item in items if item.get("message_id") != message_id]
+        if len(remaining) == len(items):
+            return False
+        if not remaining:
+            event._feishu_batch_items = []  # type: ignore[attr-defined]
+            return True
+        self._rebuild_feishu_batch_event(event, remaining)
+        return True
+
+    def _rebuild_feishu_batch_event(self, event: MessageEvent, items: List[Dict[str, Any]]) -> None:
+        event._feishu_batch_items = list(items)  # type: ignore[attr-defined]
+        event.message_id = next(
+            (str(item.get("message_id") or "") for item in reversed(items) if item.get("message_id")),
+            event.message_id,
+        )
+        texts = [str(item.get("text") or "") for item in items if item.get("text")]
+        if event.message_type == MessageType.TEXT:
+            event.text = "\n".join(texts)
+        else:
+            merged_text = ""
+            for text in texts:
+                merged_text = self._merge_caption(merged_text, text)
+            event.text = merged_text
+        event.media_urls = [
+            url
+            for item in items
+            for url in list(item.get("media_urls") or [])
+        ]
+        event.media_types = [
+            media_type
+            for item in items
+            for media_type in list(item.get("media_types") or [])
+        ]
+        event._last_chunk_len = len(str(items[-1].get("text") or ""))  # type: ignore[attr-defined]
 
     def _on_drive_comment_event(self, data: Any) -> None:
         """Handle drive document comment notification (drive.notice.comment_add_v1).
@@ -3219,14 +3385,17 @@ class FeishuAdapter(BasePlatformAdapter):
         key = self._media_batch_key(event)
         existing = self._pending_media_batches.get(key)
         if existing is None:
+            self._reset_feishu_batch_items(event)
             self._pending_media_batches[key] = event
             self._schedule_media_batch_flush(key)
             return
         if not self._media_batch_is_compatible(existing, event):
             await self._flush_media_batch_now(key)
+            self._reset_feishu_batch_items(event)
             self._pending_media_batches[key] = event
             self._schedule_media_batch_flush(key)
             return
+        self._ensure_feishu_batch_items(existing).append(self._feishu_batch_item_from_event(event))
         existing.media_urls.extend(event.media_urls)
         existing.media_types.extend(event.media_types)
         if event.text:
@@ -3510,6 +3679,7 @@ class FeishuAdapter(BasePlatformAdapter):
         existing = self._pending_text_batches.get(key)
         if existing is None:
             event._last_chunk_len = chunk_len  # type: ignore[attr-defined]
+            self._reset_feishu_batch_items(event)
             self._pending_text_batches[key] = event
             self._pending_text_batch_counts[key] = 1
             self._schedule_text_batch_flush(key)
@@ -3517,6 +3687,7 @@ class FeishuAdapter(BasePlatformAdapter):
 
         if not self._text_batch_is_compatible(existing, event):
             await self._flush_text_batch_now(key)
+            self._reset_feishu_batch_items(event)
             self._pending_text_batches[key] = event
             self._pending_text_batch_counts[key] = 1
             self._schedule_text_batch_flush(key)
@@ -3528,11 +3699,13 @@ class FeishuAdapter(BasePlatformAdapter):
         next_text = f"{existing.text}\n{appended_text}" if existing.text and appended_text else (existing.text or appended_text)
         if next_count > self._text_batch_max_messages or len(next_text) > self._text_batch_max_chars:
             await self._flush_text_batch_now(key)
+            self._reset_feishu_batch_items(event)
             self._pending_text_batches[key] = event
             self._pending_text_batch_counts[key] = 1
             self._schedule_text_batch_flush(key)
             return
 
+        self._ensure_feishu_batch_items(existing).append(self._feishu_batch_item_from_event(event))
         existing.text = next_text
         existing._last_chunk_len = chunk_len  # type: ignore[attr-defined]
         existing.timestamp = event.timestamp

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1725,6 +1725,7 @@ _INTERRUPT_REASON_TIMEOUT = "Execution timed out (inactivity)"
 _INTERRUPT_REASON_SSE_DISCONNECT = "SSE client disconnected"
 _INTERRUPT_REASON_GATEWAY_SHUTDOWN = "Gateway shutting down"
 _INTERRUPT_REASON_GATEWAY_RESTART = "Gateway restarting"
+_INTERRUPT_REASON_MESSAGE_RECALLED = "Message recalled"
 
 _CONTROL_INTERRUPT_MESSAGES = frozenset(
     {
@@ -1734,6 +1735,7 @@ _CONTROL_INTERRUPT_MESSAGES = frozenset(
         _INTERRUPT_REASON_SSE_DISCONNECT.lower(),
         _INTERRUPT_REASON_GATEWAY_SHUTDOWN.lower(),
         _INTERRUPT_REASON_GATEWAY_RESTART.lower(),
+        _INTERRUPT_REASON_MESSAGE_RECALLED.lower(),
     }
 )
 
@@ -2316,6 +2318,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         self._pending_native_image_paths_by_session: Dict[str, List[str]] = {}
         self._busy_ack_ts: Dict[str, float] = {}  # last busy-ack timestamp per session (debounce)
         self._session_run_generation: Dict[str, int] = {}
+        self._inbound_message_sessions: Dict[str, str] = {}
+        self._recalled_inbound_messages: Dict[str, float] = {}
         # Startup restore gate: while restart-interrupted sessions are being
         # auto-resumed, real inbound messages are queued instead of competing
         # with the synthetic resume turns for the same session.  The queued
@@ -3326,6 +3330,145 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         if adapter is not None and session_key in getattr(adapter, "_pending_messages", {}):
             depth += 1
         return depth
+
+    @staticmethod
+    def _inbound_message_key(platform: Any, message_id: Any) -> str:
+        platform_name = getattr(platform, "value", platform)
+        return f"{str(platform_name or '').lower()}:{str(message_id or '')}"
+
+    @staticmethod
+    def _event_message_ids(event: MessageEvent) -> List[str]:
+        message_ids: List[str] = []
+
+        def add(message_id: Any) -> None:
+            value = str(message_id or "")
+            if value and value not in message_ids:
+                message_ids.append(value)
+
+        add(getattr(event, "message_id", None))
+        for attr in ("_feishu_batch_items", "_platform_batch_items"):
+            items = getattr(event, attr, None)
+            if not isinstance(items, list):
+                continue
+            for item in items:
+                if isinstance(item, dict):
+                    add(item.get("message_id"))
+                else:
+                    add(getattr(item, "message_id", None))
+        return message_ids
+
+    def _prune_recalled_inbound_messages(self) -> None:
+        recalled = getattr(self, "_recalled_inbound_messages", None)
+        if not isinstance(recalled, dict):
+            self._recalled_inbound_messages = {}
+            return
+        now = time.time()
+        ttl = 10 * 60
+        for key, recalled_at in list(recalled.items()):
+            if now - float(recalled_at or 0) > ttl:
+                recalled.pop(key, None)
+        while len(recalled) > 4096:
+            try:
+                oldest = min(recalled, key=recalled.get)
+            except ValueError:
+                break
+            recalled.pop(oldest, None)
+
+    def _mark_inbound_message_recalled(self, platform: Any, message_id: Any) -> str:
+        key = self._inbound_message_key(platform, message_id)
+        if not key.endswith(":"):
+            if not isinstance(getattr(self, "_recalled_inbound_messages", None), dict):
+                self._recalled_inbound_messages = {}
+            self._recalled_inbound_messages[key] = time.time()
+            self._prune_recalled_inbound_messages()
+        return key
+
+    def _is_inbound_message_recalled(self, platform: Any, message_id: Any) -> bool:
+        if not message_id:
+            return False
+        self._prune_recalled_inbound_messages()
+        recalled = getattr(self, "_recalled_inbound_messages", {})
+        return self._inbound_message_key(platform, message_id) in recalled
+
+    def _register_inbound_message_for_run(self, event: MessageEvent, session_key: str) -> Optional[str]:
+        source = getattr(event, "source", None)
+        platform = getattr(source, "platform", None)
+        message_ids = self._event_message_ids(event)
+        if not message_ids or not platform or not session_key:
+            return None
+        if not isinstance(getattr(self, "_inbound_message_sessions", None), dict):
+            self._inbound_message_sessions = {}
+        first_key = None
+        for message_id in message_ids:
+            key = self._inbound_message_key(platform, message_id)
+            self._inbound_message_sessions[key] = session_key
+            first_key = first_key or key
+        return first_key
+
+    def _clear_inbound_message_mappings_for_session(self, session_key: str) -> None:
+        mapping = getattr(self, "_inbound_message_sessions", None)
+        if not isinstance(mapping, dict) or not session_key:
+            return
+        for key, mapped_session in list(mapping.items()):
+            if mapped_session == session_key:
+                mapping.pop(key, None)
+
+    def _message_recalled_for_event(self, event: MessageEvent) -> bool:
+        source = getattr(event, "source", None)
+        platform = getattr(source, "platform", None)
+        return any(
+            self._is_inbound_message_recalled(platform, message_id)
+            for message_id in self._event_message_ids(event)
+        )
+
+    async def _handle_message_recalled(self, platform: Any, message_id: str) -> bool:
+        """Cancel the active gateway turn tied to a recalled platform message."""
+        if not message_id:
+            return False
+        key = self._mark_inbound_message_recalled(platform, message_id)
+        mapping = getattr(self, "_inbound_message_sessions", {})
+        session_key = mapping.get(key) if isinstance(mapping, dict) else None
+        if not session_key:
+            logger.debug(
+                "Message recall had no active gateway turn: platform=%s message_id=%s",
+                getattr(platform, "value", platform),
+                message_id,
+            )
+            return False
+
+        running_agent = getattr(self, "_running_agents", {}).get(session_key)
+        if running_agent and running_agent is not _AGENT_PENDING_SENTINEL:
+            try:
+                running_agent.interrupt(_INTERRUPT_REASON_MESSAGE_RECALLED)
+            except Exception:
+                logger.debug("Failed to interrupt recalled-message run", exc_info=True)
+
+        adapter = getattr(self, "adapters", {}).get(platform)
+        if adapter is not None:
+            pending = getattr(adapter, "_pending_messages", None)
+            if isinstance(pending, dict):
+                pending.pop(session_key, None)
+            active = getattr(adapter, "_active_sessions", None)
+            if isinstance(active, dict):
+                interrupt_event = active.get(session_key)
+                if interrupt_event is not None:
+                    try:
+                        interrupt_event.set()
+                    except Exception:
+                        pass
+            discard = getattr(adapter, "_discard_text_debounce", None)
+            if callable(discard):
+                try:
+                    discard(session_key)
+                except Exception:
+                    pass
+        logger.info(
+            "Recalled inbound message cancelled active turn: platform=%s message_id=%s session=%s",
+            getattr(platform, "value", platform),
+            message_id,
+            session_key,
+        )
+        return True
 
     @staticmethod
     def _is_goal_continuation_event(event_or_text: Any) -> bool:
@@ -5240,6 +5383,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             
             # Set up message + fatal error handlers
             adapter.set_message_handler(self._handle_message)
+            adapter.set_message_recall_handler(self._handle_message_recalled)
             adapter.set_fatal_error_handler(self._handle_adapter_fatal_error)
             adapter.set_session_store(self.session_store)
             adapter.set_busy_session_handler(self._handle_active_session_busy_message)
@@ -5984,6 +6128,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         continue
 
                     adapter.set_message_handler(self._handle_message)
+                    adapter.set_message_recall_handler(self._handle_message_recalled)
                     adapter.set_fatal_error_handler(self._handle_adapter_fatal_error)
                     adapter.set_session_store(self.session_store)
                     adapter.set_busy_session_handler(self._handle_active_session_busy_message)
@@ -7935,6 +8080,14 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 return self._telegram_topic_root_lobby_message()
             return None
 
+        if self._message_recalled_for_event(event):
+            logger.info(
+                "Dropping recalled inbound message before agent start: platform=%s message_id=%s",
+                getattr(source.platform, "value", source.platform),
+                getattr(event, "message_id", None),
+            )
+            return None
+
         # ── Claim this session before any await ───────────────────────
         # Between here and _run_agent registering the real AIAgent, there
         # are numerous await points (hooks, vision enrichment, STT,
@@ -7958,6 +8111,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             self._active_session_leases[_quick_key] = _active_session_lease
         self._running_agents[_quick_key] = _AGENT_PENDING_SENTINEL
         self._running_agents_ts[_quick_key] = time.time()
+        self._register_inbound_message_for_run(event, _quick_key)
         _run_generation = self._begin_session_run_generation(_quick_key)
 
         try:
@@ -9008,6 +9162,15 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             run_generation,
         )
 
+        if self._message_recalled_for_event(event):
+            logger.info(
+                "Suppressing recalled inbound message before agent run: platform=%s message_id=%s session=%s",
+                getattr(source.platform, "value", source.platform),
+                getattr(event, "message_id", None),
+                session_key,
+            )
+            return None
+
         try:
             # Emit agent:start hook
             hook_ctx = {
@@ -9031,6 +9194,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 session_key=session_key,
                 run_generation=run_generation,
                 event_message_id=self._reply_anchor_for_event(event),
+                event_message_ids=self._event_message_ids(event),
                 channel_prompt=event.channel_prompt,
                 persist_user_message=persist_user_message,
                 persist_user_timestamp=persist_user_timestamp,
@@ -9043,6 +9207,23 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     await _typing_adapter.stop_typing(source.chat_id)
             except Exception:
                 pass
+
+            if self._message_recalled_for_event(event):
+                logger.info(
+                    "Suppressing agent result for recalled inbound message: platform=%s message_id=%s session=%s",
+                    getattr(source.platform, "value", source.platform),
+                    getattr(event, "message_id", None),
+                    session_key,
+                )
+                _stale_adapter = self.adapters.get(source.platform)
+                if getattr(type(_stale_adapter), "pop_post_delivery_callback", None) is not None:
+                    _stale_adapter.pop_post_delivery_callback(
+                        _quick_key,
+                        generation=run_generation,
+                    )
+                elif _stale_adapter and hasattr(_stale_adapter, "_post_delivery_callbacks"):
+                    _stale_adapter._post_delivery_callbacks.pop(_quick_key, None)
+                return None
 
             if not self._is_session_run_current(_quick_key, run_generation):
                 logger.info(
@@ -13002,6 +13183,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         self._running_agents_ts.pop(session_key, None)
         if hasattr(self, "_busy_ack_ts"):
             self._busy_ack_ts.pop(session_key, None)
+        self._clear_inbound_message_mappings_for_session(session_key)
         return True
 
     def _clear_session_boundary_security_state(self, session_key: str) -> None:
@@ -13737,6 +13919,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         run_generation: Optional[int] = None,
         _interrupt_depth: int = 0,
         event_message_id: Optional[str] = None,
+        event_message_ids: Optional[List[str]] = None,
         channel_prompt: Optional[str] = None,
         persist_user_message: Optional[str] = None,
         persist_user_timestamp: Optional[float] = None,
@@ -15030,6 +15213,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             agent.thinking_progress = _thinking_enabled
             # Store agent reference for interrupt support
             agent_holder[0] = agent
+            recalled_check_ids = event_message_ids or ([event_message_id] if event_message_id else [])
+            if any(
+                self._is_inbound_message_recalled(source.platform, message_id)
+                for message_id in recalled_check_ids
+            ):
+                agent.interrupt(_INTERRUPT_REASON_MESSAGE_RECALLED)
             # Capture the full tool definitions for transcript logging
             tools_holder[0] = agent.tools if hasattr(agent, 'tools') else None
             
@@ -16163,6 +16352,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 next_source = source
                 next_message = pending
                 next_message_id = None
+                next_message_ids = []
                 next_channel_prompt = None
                 if pending_event is not None:
                     next_source = getattr(pending_event, "source", None) or source
@@ -16180,6 +16370,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     if next_message is None:
                         return result
                     next_message_id = self._reply_anchor_for_event(pending_event)
+                    next_message_ids = self._event_message_ids(pending_event)
                     next_channel_prompt = getattr(pending_event, "channel_prompt", None)
 
                 # Restart typing indicator so the user sees activity while
@@ -16205,6 +16396,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     run_generation=run_generation,
                     _interrupt_depth=_interrupt_depth + 1,
                     event_message_id=next_message_id,
+                    event_message_ids=next_message_ids,
                     channel_prompt=next_channel_prompt,
                 )
                 return _preserve_queued_followup_history_offset(result, followup_result)

--- a/tests/gateway/test_feishu_message_recall.py
+++ b/tests/gateway/test_feishu_message_recall.py
@@ -1,0 +1,286 @@
+"""Tests for cancelling Feishu gateway work when a user recalls a message."""
+
+from datetime import datetime
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from gateway.config import GatewayConfig, Platform, PlatformConfig
+from gateway.platforms.base import MessageEvent, MessageType
+from gateway.session import SessionEntry, SessionSource, build_session_key
+
+
+def _feishu_source() -> SessionSource:
+    return SessionSource(
+        platform=Platform.FEISHU,
+        chat_id="oc_test_chat",
+        chat_type="dm",
+        user_id="ou_test_user",
+    )
+
+
+def _feishu_event(message_id: str = "om_recalled") -> MessageEvent:
+    return MessageEvent(
+        text="please ignore this if recalled",
+        source=_feishu_source(),
+        message_id=message_id,
+    )
+
+
+def _bootstrap_runner(monkeypatch, tmp_path):
+    import gateway.run as gateway_run
+
+    config = GatewayConfig(
+        platforms={Platform.FEISHU: PlatformConfig(enabled=True, token="fake")}
+    )
+    runner = gateway_run.GatewayRunner(config)
+    runner.adapters = {}
+    runner._running_agents = {}
+    runner._running_agents_ts = {}
+    runner._pending_messages = {}
+    runner._pending_approvals = {}
+    runner._is_user_authorized = lambda _source: True
+    runner._set_session_env = lambda _context: []
+    runner._clear_session_env = lambda _tokens: None
+    runner._recover_telegram_topic_thread_id = lambda _source: None
+    runner._cache_session_source = lambda _key, _source: None
+    runner._is_session_run_current = lambda _key, _gen: True
+    runner._begin_session_run_generation = lambda _key: 1
+    runner._reply_anchor_for_event = lambda event: getattr(event, "message_id", None)
+    runner._get_guild_id = lambda _event: None
+    runner._should_send_voice_reply = lambda *_args, **_kwargs: False
+    runner._deliver_platform_notice = AsyncMock()
+    runner._sync_telegram_topic_binding = MagicMock()
+    runner._record_telegram_topic_binding = MagicMock()
+    runner._format_session_info = lambda: ""
+    runner._resolve_session_agent_runtime = MagicMock(
+        return_value=("test-model", {"api_key": "fake", "provider": "test"})
+    )
+    runner.hooks = MagicMock()
+    runner.hooks.emit = AsyncMock()
+    runner._session_db = None
+
+    session_key = build_session_key(_feishu_source())
+    runner.session_store = MagicMock()
+    runner.session_store.get_or_create_session.return_value = SessionEntry(
+        session_key=session_key,
+        session_id="sess-recall",
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+        platform=Platform.FEISHU,
+        chat_type="dm",
+    )
+    runner.session_store.load_transcript.return_value = []
+    runner.session_store.has_any_sessions.return_value = True
+    runner.session_store.append_to_transcript = MagicMock()
+    runner.session_store.update_session = MagicMock()
+
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    return runner
+
+
+def test_feishu_recall_event_routes_to_registered_handler():
+    from gateway.platforms.feishu import FeishuAdapter
+
+    adapter = FeishuAdapter(PlatformConfig())
+    adapter._loop = object()
+    adapter._message_recall_handler = AsyncMock()
+    payload = SimpleNamespace(
+        event=SimpleNamespace(
+            message=SimpleNamespace(message_id="om_recalled"),
+        ),
+    )
+
+    with patch.object(adapter, "_submit_on_loop", return_value=True) as submit:
+        adapter._on_message_recalled(payload)
+
+    submit.assert_called_once()
+    coro = submit.call_args.args[1]
+    try:
+        import asyncio
+
+        asyncio.run(coro)
+    finally:
+        close = getattr(coro, "close", None)
+        if close:
+            close()
+    adapter._message_recall_handler.assert_awaited_once_with(
+        Platform.FEISHU,
+        "om_recalled",
+    )
+
+
+@pytest.mark.asyncio
+async def test_feishu_recall_removes_recalled_text_from_pending_batch():
+    from gateway.platforms.feishu import FeishuAdapter
+
+    adapter = FeishuAdapter(PlatformConfig())
+    adapter._handle_message_with_guards = AsyncMock()
+    first = _feishu_event("om_first")
+    first.text = "recalled text"
+    second = _feishu_event("om_second")
+    second.text = "kept text"
+
+    await adapter._enqueue_text_event(first)
+    await adapter._enqueue_text_event(second)
+    adapter._on_message_recalled(
+        SimpleNamespace(event=SimpleNamespace(message=SimpleNamespace(message_id="om_first")))
+    )
+    await adapter._flush_text_batch_now(adapter._text_batch_key(first))
+
+    adapter._handle_message_with_guards.assert_awaited_once()
+    flushed = adapter._handle_message_with_guards.await_args.args[0]
+    assert flushed.text == "kept text"
+    assert flushed.message_id == "om_second"
+
+    for task in list(adapter._pending_text_batch_tasks.values()):
+        task.cancel()
+
+
+@pytest.mark.asyncio
+async def test_feishu_recall_removes_recalled_media_from_pending_batch():
+    from gateway.platforms.feishu import FeishuAdapter
+
+    adapter = FeishuAdapter(PlatformConfig())
+    adapter._handle_message_with_guards = AsyncMock()
+    first = MessageEvent(
+        text="recalled caption",
+        message_type=MessageType.PHOTO,
+        source=_feishu_source(),
+        message_id="om_media_first",
+        media_urls=["/tmp/recalled.png"],
+        media_types=["image/png"],
+    )
+    second = MessageEvent(
+        text="kept caption",
+        message_type=MessageType.PHOTO,
+        source=_feishu_source(),
+        message_id="om_media_second",
+        media_urls=["/tmp/kept.png"],
+        media_types=["image/png"],
+    )
+
+    await adapter._enqueue_media_event(first)
+    await adapter._enqueue_media_event(second)
+    adapter._on_message_recalled(
+        SimpleNamespace(event=SimpleNamespace(message=SimpleNamespace(message_id="om_media_first")))
+    )
+    await adapter._flush_media_batch_now(adapter._media_batch_key(first))
+
+    adapter._handle_message_with_guards.assert_awaited_once()
+    flushed = adapter._handle_message_with_guards.await_args.args[0]
+    assert flushed.text == "kept caption"
+    assert flushed.message_id == "om_media_second"
+    assert flushed.media_urls == ["/tmp/kept.png"]
+
+    for task in list(adapter._pending_media_batch_tasks.values()):
+        task.cancel()
+
+
+@pytest.mark.asyncio
+async def test_recalled_feishu_message_does_not_start_agent(monkeypatch, tmp_path):
+    runner = _bootstrap_runner(monkeypatch, tmp_path)
+    event = _feishu_event("om_before_run")
+    session_key = build_session_key(event.source)
+    runner._mark_inbound_message_recalled(Platform.FEISHU, "om_before_run")
+    runner._run_agent = AsyncMock(
+        return_value={
+            "final_response": "this should never be generated",
+            "messages": [],
+            "history_offset": 0,
+        }
+    )
+
+    result = await runner._handle_message_with_agent(event, event.source, session_key, 1)
+
+    assert result is None
+    runner._run_agent.assert_not_called()
+    runner.session_store.append_to_transcript.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_recalled_feishu_batch_item_does_not_start_agent(monkeypatch, tmp_path):
+    runner = _bootstrap_runner(monkeypatch, tmp_path)
+    event = _feishu_event("om_batch_second")
+    event._feishu_batch_items = [  # type: ignore[attr-defined]
+        {"message_id": "om_batch_first", "text": "recalled"},
+        {"message_id": "om_batch_second", "text": "kept"},
+    ]
+    session_key = build_session_key(event.source)
+    runner._mark_inbound_message_recalled(Platform.FEISHU, "om_batch_first")
+    runner._run_agent = AsyncMock(
+        return_value={
+            "final_response": "this should never be generated",
+            "messages": [],
+            "history_offset": 0,
+        }
+    )
+
+    result = await runner._handle_message_with_agent(event, event.source, session_key, 1)
+
+    assert result is None
+    runner._run_agent.assert_not_called()
+    runner.session_store.append_to_transcript.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_feishu_recall_interrupts_inflight_agent(monkeypatch, tmp_path):
+    runner = _bootstrap_runner(monkeypatch, tmp_path)
+    event = _feishu_event("om_live")
+    session_key = build_session_key(event.source)
+    runner._register_inbound_message_for_run(event, session_key)
+    running_agent = MagicMock()
+    runner._running_agents[session_key] = running_agent
+
+    handled = await runner._handle_message_recalled(Platform.FEISHU, "om_live")
+
+    assert handled is True
+    running_agent.interrupt.assert_called_once()
+    assert runner._is_inbound_message_recalled(Platform.FEISHU, "om_live") is True
+
+
+@pytest.mark.asyncio
+async def test_feishu_recall_interrupts_inflight_batched_agent(monkeypatch, tmp_path):
+    runner = _bootstrap_runner(monkeypatch, tmp_path)
+    event = _feishu_event("om_batch_live_second")
+    event._feishu_batch_items = [  # type: ignore[attr-defined]
+        {"message_id": "om_batch_live_first", "text": "recalled"},
+        {"message_id": "om_batch_live_second", "text": "kept"},
+    ]
+    session_key = build_session_key(event.source)
+    runner._register_inbound_message_for_run(event, session_key)
+    running_agent = MagicMock()
+    runner._running_agents[session_key] = running_agent
+
+    handled = await runner._handle_message_recalled(Platform.FEISHU, "om_batch_live_first")
+
+    assert handled is True
+    running_agent.interrupt.assert_called_once()
+    assert runner._is_inbound_message_recalled(Platform.FEISHU, "om_batch_live_first") is True
+
+
+@pytest.mark.asyncio
+async def test_feishu_recall_suppresses_result_that_finishes_late(monkeypatch, tmp_path):
+    runner = _bootstrap_runner(monkeypatch, tmp_path)
+    event = _feishu_event("om_late")
+    session_key = build_session_key(event.source)
+
+    async def fake_run_agent(**_kwargs):
+        runner._mark_inbound_message_recalled(Platform.FEISHU, "om_late")
+        return {
+            "final_response": "late answer should be suppressed",
+            "messages": [
+                {"role": "user", "content": "please ignore this if recalled"},
+                {"role": "assistant", "content": "late answer should be suppressed"},
+            ],
+            "history_offset": 0,
+            "last_prompt_tokens": 0,
+        }
+
+    runner._run_agent = AsyncMock(side_effect=fake_run_agent)
+
+    result = await runner._handle_message_with_agent(event, event.source, session_key, 1)
+
+    assert result is None
+    runner.session_store.append_to_transcript.assert_not_called()


### PR DESCRIPTION
## Summary
- Wire Feishu `message_recalled` events into the gateway instead of treating them as no-op debug logs.
- Track inbound platform message IDs to active sessions so recalls can interrupt in-flight agent runs and suppress late results.
- Remove recalled Feishu text/media chunks from pending batches before they flush to the agent.
- Add focused regression coverage for pre-run, in-flight, late-result, and batched-message recall windows.

## Why
Feishu users expect recalled messages to stop being processed. Before this change, Hermes registered the recall event handler but did not act on it, so a recalled message could still reach the AI and produce a final response.

## Validation
- `scripts/run_tests.sh tests/gateway/test_feishu_message_recall.py -- --tb=short` passed: 8 tests
- `scripts/run_tests.sh tests/gateway/test_feishu.py -- --tb=short` passed: 205 tests
- `scripts/run_tests.sh tests/gateway/test_platform_base.py -- --tb=short` passed: 148 tests
- `scripts/run_tests.sh tests/gateway/test_interrupt_key_match.py -- --tb=short` passed: 6 tests
- `scripts/run_tests.sh tests/gateway/test_duplicate_reply_suppression.py -- --tb=short` passed: 24 tests
- `scripts/run_tests.sh tests/gateway/test_busy_session_ack.py -- --tb=short` passed: 18 tests
- `scripts/run_tests.sh tests/gateway/test_run_progress_interrupt.py -- --tb=short` passed: 2 tests
- `scripts/run_tests.sh tests/gateway/test_run_cleanup_progress.py -- --tb=short` passed: 5 tests
- `scripts/run_tests.sh tests/gateway/test_proxy_mode.py -- --tb=short` passed: 22 tests
- `git diff --check` passed

## Risk
- This cancels/suppresses pending and in-flight responses, but it does not delete bot messages that were already delivered before the recall event arrives.
- Recall tracking is intentionally short-lived in memory; a gateway restart between the original message and recall event may lose the active-run mapping.

## Note
While validating locally before the final rebase, `tests/gateway/test_gateway_shutdown.py::test_gateway_stop_systemd_service_restart_exits_cleanly` failed on macOS because the test expects the systemd exit-code path while darwin keeps the launchd non-zero restart code. I did not change that shutdown behavior in this PR.
