### PR TITLE
feat(gateway): add 'gateway reload' subcommand to trigger hot-reload via SIGUSR2

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -6806,6 +6806,22 @@ def _gateway_command_inner(args):
             print("Starting gateway...")
             run_gateway(verbose=0)
 
+    elif subcmd == "reload":
+        snapshot = get_gateway_runtime_snapshot(system=False)
+        pids = snapshot.gateway_pids
+        if not pids:
+            print("✗ Gateway is not running (nothing to reload)")
+            sys.exit(1)
+
+        for pid in pids:
+            try:
+                # SIGUSR2 is caught by the gateway to hot-reload substrate (MCP/Skills)
+                print(f"Reloading gateway (PID {pid})...")
+                os.kill(pid, signal.SIGUSR2)
+                print("✓ Hot reload signal sent.")
+            except Exception as e:
+                print(f"✗ Failed to send reload signal to {pid}: {e}")
+
     elif subcmd == "status":
         deep = getattr(args, "deep", False)
         full = getattr(args, "full", False)

--- a/hermes_cli/subcommands/gateway.py
+++ b/hermes_cli/subcommands/gateway.py
@@ -104,6 +104,11 @@ def build_gateway_parser(subparsers, *, cmd_gateway: Callable, cmd_proxy: Callab
         help="Kill ALL gateway processes across all profiles before restarting",
     )
 
+    # gateway reload
+    gateway_subparsers.add_parser(
+        "reload", help="Reload MCP servers and skills mid-turn without restarting"
+    )
+
     # gateway status
     gateway_status = gateway_subparsers.add_parser("status", help="Show gateway status")
     gateway_status.add_argument("--deep", action="store_true", help="Deep status check")


### PR DESCRIPTION
This pull request adds a `gateway reload` subcommand to the `hermes` CLI.

### Summary
Currently, developers or system managers have to hard-restart the gateway daemon to apply MCP, configuration, or skill updates. This subcommand targets running gateway PIDs and signals them via `SIGUSR2` to hot-reload their runtimes (MCP servers & skills catalog) in-place without dropping connections/restarting the active process.

### Changes
1. **`hermes_cli/gateway.py`**: Added subcmd option `reload` targeting running gateway PIDs.
2. **`hermes_cli/subcommands/gateway.py`**: Added parser config for the new `reload` sub-command.

Contributed by @CarlitoDon