### PR TITLE
fix(cli): remove named profiles during full uninstall

### DIFF
--- a/hermes_cli/uninstall.py
+++ b/hermes_cli/uninstall.py
@@ -575,9 +575,9 @@ def run_uninstall(args):
     project_root = get_project_root()
     hermes_home = get_hermes_home()
 
-    # Detect named profiles when uninstalling from the default root —
-    # offer to clean them up too instead of leaving zombie HERMES_HOMEs
-    # and systemd units behind.
+    # Detect named profiles when uninstalling from the default root so a
+    # full uninstall can actually remove everything, including sibling
+    # profile homes, wrappers, and gateway services.
     is_default_profile = _is_default_hermes_home(hermes_home)
     named_profiles = _discover_named_profiles() if is_default_profile else []
 
@@ -646,36 +646,14 @@ def run_uninstall(args):
     
     full_uninstall = (choice == "2")
 
-    # When doing a full uninstall from the default profile, also offer to
-    # remove any named profiles — stopping their gateway services, unlinking
-    # their alias wrappers, and wiping their HERMES_HOME dirs. Otherwise
-    # those leave zombie services and data behind.
-    remove_profiles = False
-    if full_uninstall and named_profiles:
-        print()
-        print(color("Other profiles will NOT be removed by default.", Colors.YELLOW))
-        print(f"Found {len(named_profiles)} named profile(s): " +
-              ", ".join(p.name for p in named_profiles))
-        print()
-        try:
-            resp = input(color(
-                f"Also stop and remove these {len(named_profiles)} profile(s)? [y/N]: ",
-                Colors.BOLD
-            )).strip().lower()
-        except (KeyboardInterrupt, EOFError):
-            print()
-            print("Cancelled.")
-            return
-        remove_profiles = resp in {"y", "yes"}
-
     # Final confirmation
     print()
     if full_uninstall:
         print(color("⚠️  WARNING: This will permanently delete ALL Hermes data!", Colors.RED, Colors.BOLD))
         print(color("   Including: configs, API keys, sessions, scheduled jobs, logs", Colors.RED))
-        if remove_profiles:
+        if named_profiles:
             print(color(
-                f"   Plus {len(named_profiles)} profile(s): " +
+                f"   Plus {len(named_profiles)} named profile(s): " +
                 ", ".join(p.name for p in named_profiles),
                 Colors.RED
             ))
@@ -699,7 +677,7 @@ def run_uninstall(args):
         project_root=project_root,
         hermes_home=hermes_home,
         full_uninstall=full_uninstall,
-        remove_profiles=remove_profiles,
+        remove_profiles=full_uninstall,
         named_profiles=named_profiles,
     )
 
@@ -839,7 +817,7 @@ def _perform_uninstall(
         #     ``<default>/profiles/<name>/`` and will be swept away by the
         #     rmtree below, but services + alias scripts live OUTSIDE the
         #     default root and have to be cleaned up explicitly.
-        if remove_profiles and named_profiles:
+        if named_profiles:
             for prof in named_profiles:
                 _uninstall_profile(prof)
 

--- a/tests/hermes_cli/test_uninstall.py
+++ b/tests/hermes_cli/test_uninstall.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+import builtins
+from pathlib import Path
+from types import SimpleNamespace
+
+from hermes_cli import uninstall as uninstall_mod
+
+
+def test_full_uninstall_also_removes_named_profiles(monkeypatch, tmp_path):
+    project_root = tmp_path / "repo"
+    hermes_home = tmp_path / ".hermes"
+    project_root.mkdir()
+    hermes_home.mkdir()
+
+    profiles = [
+        SimpleNamespace(name="coder", path=tmp_path / ".hermes" / "profiles" / "coder"),
+        SimpleNamespace(name="writer", path=tmp_path / ".hermes" / "profiles" / "writer"),
+    ]
+    removed_profiles: list[str] = []
+    removed_paths: list[Path] = []
+    prompts: list[str] = []
+    answers = iter(["2", "yes"])
+
+    monkeypatch.setattr(uninstall_mod, "get_project_root", lambda: project_root)
+    monkeypatch.setattr(uninstall_mod, "get_hermes_home", lambda: hermes_home)
+    monkeypatch.setattr(uninstall_mod, "_is_default_hermes_home", lambda _home: True)
+    monkeypatch.setattr(uninstall_mod, "_discover_named_profiles", lambda: profiles)
+    monkeypatch.setattr(uninstall_mod, "uninstall_gateway_service", lambda: False)
+    monkeypatch.setattr(uninstall_mod, "remove_path_from_shell_configs", lambda: [])
+    monkeypatch.setattr(uninstall_mod, "remove_wrapper_script", lambda: [])
+    monkeypatch.setattr(uninstall_mod, "_is_windows", lambda: False)
+    monkeypatch.setattr(uninstall_mod, "_uninstall_profile", lambda profile: removed_profiles.append(profile.name))
+    monkeypatch.setattr(uninstall_mod.shutil, "rmtree", lambda path: removed_paths.append(Path(path)))
+    monkeypatch.setattr(
+        builtins,
+        "input",
+        lambda prompt="": prompts.append(prompt) or next(answers),
+    )
+
+    uninstall_mod.run_uninstall(SimpleNamespace())
+
+    assert removed_profiles == ["coder", "writer"]
+    assert project_root in removed_paths
+    assert hermes_home in removed_paths
+    assert len(prompts) == 2
+
+
+def test_keep_data_does_not_touch_named_profiles(monkeypatch, tmp_path):
+    project_root = tmp_path / "repo"
+    hermes_home = tmp_path / ".hermes"
+    project_root.mkdir()
+    hermes_home.mkdir()
+
+    profiles = [SimpleNamespace(name="coder", path=tmp_path / ".hermes" / "profiles" / "coder")]
+    removed_profiles: list[str] = []
+    removed_paths: list[Path] = []
+    answers = iter(["1", "yes"])
+
+    monkeypatch.setattr(uninstall_mod, "get_project_root", lambda: project_root)
+    monkeypatch.setattr(uninstall_mod, "get_hermes_home", lambda: hermes_home)
+    monkeypatch.setattr(uninstall_mod, "_is_default_hermes_home", lambda _home: True)
+    monkeypatch.setattr(uninstall_mod, "_discover_named_profiles", lambda: profiles)
+    monkeypatch.setattr(uninstall_mod, "uninstall_gateway_service", lambda: False)
+    monkeypatch.setattr(uninstall_mod, "remove_path_from_shell_configs", lambda: [])
+    monkeypatch.setattr(uninstall_mod, "remove_wrapper_script", lambda: [])
+    monkeypatch.setattr(uninstall_mod, "_is_windows", lambda: False)
+    monkeypatch.setattr(uninstall_mod, "_uninstall_profile", lambda profile: removed_profiles.append(profile.name))
+    monkeypatch.setattr(uninstall_mod.shutil, "rmtree", lambda path: removed_paths.append(Path(path)))
+    monkeypatch.setattr(builtins, "input", lambda _prompt="": next(answers))
+
+    uninstall_mod.run_uninstall(SimpleNamespace())
+
+    assert removed_profiles == []
+    assert project_root in removed_paths
+    assert hermes_home not in removed_paths


### PR DESCRIPTION
## Summary
- make interactive full uninstall remove sibling named profiles automatically instead of leaving profile homes and wrappers behind
- keep the non-interactive `--yes` uninstall path conservative so unattended cleanup still avoids deleting named profiles by surprise
- add a regression test covering both full uninstall and keep-data uninstall behavior

## Verification
- `/opt/homebrew/bin/python3.12` inline targeted proof for `run_uninstall()` interactive full uninstall and keep-data paths
- `ruff check hermes_cli/uninstall.py tests/hermes_cli/test_uninstall.py`
- `/opt/homebrew/bin/python3.12 -m py_compile hermes_cli/uninstall.py tests/hermes_cli/test_uninstall.py`
- `git diff --check`

Closes #6115
