### PR TITLE
fix(skills): elevate skill discovery parse-error logging from DEBUG to WARNING

### DIFF
--- a/tests/tools/test_skills_tool.py
+++ b/tests/tools/test_skills_tool.py
@@ -1,6 +1,7 @@
 """Tests for tools/skills_tool.py — skill discovery and viewing."""
 
 import json
+import logging
 import os
 from pathlib import Path
 from unittest.mock import patch
@@ -250,6 +251,55 @@ class TestFindAllSkills:
 
         assert [s["name"] for s in skills] == ["knowledge-brain"]
         assert skills[0]["category"] == "linked"
+
+    def test_read_failure_is_skipped_with_warning(self, tmp_path, caplog):
+        _make_skill(tmp_path, "good-skill")
+        bad_skill_dir = _make_skill(tmp_path, "bad-skill")
+        bad_skill_file = bad_skill_dir / "SKILL.md"
+        original_read_text = type(bad_skill_file).read_text
+
+        def fake_read_text(path, *args, **kwargs):
+            if path == bad_skill_file:
+                raise PermissionError("read denied")
+            return original_read_text(path, *args, **kwargs)
+
+        with (
+            patch("tools.skills_tool.SKILLS_DIR", tmp_path),
+            patch.object(type(bad_skill_file), "read_text", fake_read_text),
+            caplog.at_level(logging.WARNING, logger="tools.skills_tool"),
+        ):
+            skills = _find_all_skills()
+
+        assert [s["name"] for s in skills] == ["good-skill"]
+        assert any(
+            "Failed to read skill file" in record.message
+            and str(bad_skill_file) in record.message
+            for record in caplog.records
+        )
+
+    def test_parse_failure_is_skipped_with_warning(self, tmp_path, caplog):
+        _make_skill(tmp_path, "good-skill")
+        _make_skill(tmp_path, "bad-skill")
+        original_parse_frontmatter = skills_tool_module._parse_frontmatter
+
+        def fake_parse_frontmatter(content):
+            if "name: bad-skill" in content:
+                raise ValueError("frontmatter exploded")
+            return original_parse_frontmatter(content)
+
+        with (
+            patch("tools.skills_tool.SKILLS_DIR", tmp_path),
+            patch("tools.skills_tool._parse_frontmatter", fake_parse_frontmatter),
+            caplog.at_level(logging.WARNING, logger="tools.skills_tool"),
+        ):
+            skills = _find_all_skills()
+
+        assert [s["name"] for s in skills] == ["good-skill"]
+        assert any(
+            "failed to parse" in record.message
+            and "bad-skill" in record.message
+            for record in caplog.records
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/tools/skills_tool.py
+++ b/tools/skills_tool.py
@@ -765,10 +765,10 @@ def _find_all_skills(*, skip_disabled: bool = False) -> List[Dict[str, Any]]:
                 })
 
             except (UnicodeDecodeError, PermissionError) as e:
-                logger.debug("Failed to read skill file %s: %s", skill_md, e)
+                logger.warning("Failed to read skill file %s: %s", skill_md, e)
                 continue
             except Exception as e:
-                logger.debug(
+                logger.warning(
                     "Skipping skill at %s: failed to parse: %s", skill_md, e, exc_info=True
                 )
                 continue


### PR DESCRIPTION
Related to #48877

Elevate parse-error logging in _find_all_skills() from DEBUG to WARNING level.

**Root cause:** _find_all_skills() catches all parse exceptions (PermissionError, UnicodeDecodeError, generic Exception) at DEBUG level only, making skill discovery failures invisible after updates/syncs that may cause transient file locks. Users only see "Skill not found" with no actionable hint.

This PR addresses ONE facet of #48877 — the silent frontmatter/read drop. The underlying disappearance causes (&-in-dirname, seed_profile_skills manifest race) are not fixed here and will need separate PRs, so #48877 should stay open.

**Changes:** logger.debug to logger.warning in two exception handlers in _find_all_skills():
- UnicodeDecodeError/PermissionError (file read failures)
- Generic Exception (frontmatter parse failures)

**Tests:** test_skills_tool.py 87/87 pass.