### PR TITLE
Fix Anthropic helpers for streaming-only endpoints

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -1041,7 +1041,9 @@ class _AnthropicCompletionsAdapter:
             if not _forbids_sampling_params(model):
                 anthropic_kwargs["temperature"] = temperature
 
-        response = self._client.messages.create(**anthropic_kwargs)
+        anthropic_kwargs.pop("stream", None)
+        with self._client.messages.stream(**anthropic_kwargs) as stream:
+            response = stream.get_final_message()
         _transport = get_transport("anthropic_messages")
         _nr = _transport.normalize_response(
             response, strip_tool_prefix=self._is_oauth

--- a/run_agent.py
+++ b/run_agent.py
@@ -4080,7 +4080,10 @@ class AIAgent:
         sanitize_anthropic_kwargs(
             api_kwargs, log_prefix=getattr(self, "log_prefix", "")
         )
-        return self._anthropic_client.messages.create(**api_kwargs)
+        request_kwargs = dict(api_kwargs)
+        request_kwargs.pop("stream", None)
+        with self._anthropic_client.messages.stream(**request_kwargs) as stream:
+            return stream.get_final_message()
 
     def _rebuild_anthropic_client(self) -> None:
         """Rebuild the Anthropic client after an interrupt or stale call.

--- a/tests/agent/test_auxiliary_client_anthropic_custom.py
+++ b/tests/agent/test_auxiliary_client_anthropic_custom.py
@@ -9,6 +9,7 @@ OpenAI-wire client that speaks the wrong protocol.
 
 from __future__ import annotations
 
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -105,3 +106,46 @@ def test_custom_endpoint_chat_completions_still_uses_openai_wire():
     assert client is not None
     assert model == "my-model"
     assert not isinstance(client, AnthropicAuxiliaryClient)
+
+
+def test_anthropic_completions_adapter_uses_stream_final_message():
+    """Anthropic auxiliary calls must support streaming-only endpoints."""
+    from agent.auxiliary_client import _AnthropicCompletionsAdapter
+
+    final_message = SimpleNamespace(
+        usage=SimpleNamespace(input_tokens=11, output_tokens=7)
+    )
+    normalized = SimpleNamespace(
+        content="streamed final",
+        tool_calls=[],
+        reasoning=None,
+        finish_reason="end_turn",
+    )
+    client = MagicMock()
+    stream_ctx = MagicMock()
+    stream_obj = MagicMock()
+    stream_obj.get_final_message.return_value = final_message
+    stream_ctx.__enter__.return_value = stream_obj
+    stream_ctx.__exit__.return_value = None
+    client.messages.stream.return_value = stream_ctx
+    transport = SimpleNamespace(normalize_response=MagicMock(return_value=normalized))
+
+    with patch(
+        "agent.anthropic_adapter.build_anthropic_kwargs",
+        return_value={"model": "claude", "messages": [], "stream": False},
+    ), patch(
+        "agent.transports.get_transport",
+        return_value=transport,
+    ):
+        result = _AnthropicCompletionsAdapter(client, "claude").create(model="claude")
+
+    client.messages.create.assert_not_called()
+    client.messages.stream.assert_called_once_with(model="claude", messages=[])
+    transport.normalize_response.assert_called_once_with(
+        final_message, strip_tool_prefix=False
+    )
+    assert result.choices[0].message.content == "streamed final"
+    assert result.choices[0].finish_reason == "end_turn"
+    assert result.usage.prompt_tokens == 11
+    assert result.usage.completion_tokens == 7
+    assert result.usage.total_tokens == 18

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -5812,14 +5812,24 @@ class TestAnthropicCredentialRefresh:
             )
 
         response = SimpleNamespace(content=[])
+        stream_ctx = MagicMock()
+        stream_obj = MagicMock()
+        stream_obj.get_final_message.return_value = response
+        stream_ctx.__enter__.return_value = stream_obj
+        stream_ctx.__exit__.return_value = None
         agent._anthropic_client = MagicMock()
-        agent._anthropic_client.messages.create.return_value = response
+        agent._anthropic_client.messages.stream.return_value = stream_ctx
 
         with patch.object(agent, "_try_refresh_anthropic_client_credentials", return_value=True) as refresh:
-            result = agent._anthropic_messages_create({"model": "claude-sonnet-4-20250514"})
+            result = agent._anthropic_messages_create(
+                {"model": "claude-sonnet-4-20250514", "stream": False}
+            )
 
         refresh.assert_called_once_with()
-        agent._anthropic_client.messages.create.assert_called_once_with(model="claude-sonnet-4-20250514")
+        agent._anthropic_client.messages.create.assert_not_called()
+        agent._anthropic_client.messages.stream.assert_called_once_with(
+            model="claude-sonnet-4-20250514"
+        )
         assert result is response
 
 


### PR DESCRIPTION
## Summary
- switch the non-streaming Anthropic helper in `run_agent.py` to `messages.stream(...).get_final_message()`
- do the same for the auxiliary Anthropic adapter so compaction and other side calls work against streaming-only compatible endpoints
- add targeted regressions covering both helper paths and stream kwarg stripping

Fixes #48923

## Testing
- pytest tests/run_agent/test_run_agent.py -q -k anthropic_messages_create_preflights_refresh
- pytest tests/agent/test_auxiliary_client_anthropic_custom.py -q -k stream_final_message
- ruff check run_agent.py agent/auxiliary_client.py tests/run_agent/test_run_agent.py tests/agent/test_auxiliary_client_anthropic_custom.py
- source /Users/leongong/Desktop/LeonProjects/worktrees/hermes-agent/.base/.venv/bin/activate && python -m py_compile run_agent.py agent/auxiliary_client.py tests/run_agent/test_run_agent.py tests/agent/test_auxiliary_client_anthropic_custom.py
- git diff --check