### PR TITLE
feat(desktop): add bulk archive/unarchive for sessions

### DIFF
--- a/apps/desktop/src/hermes.ts
+++ b/apps/desktop/src/hermes.ts
@@ -206,6 +206,16 @@ export function setSessionArchived(id: string, archived: boolean, profile?: stri
   })
 }
 
+// Bulk archive/unarchive multiple sessions by ID
+export function archiveSessions(ids: string[], archived = true, profile?: string | null): Promise<{ ok: boolean; archived: number }> {
+  return window.hermesDesktop.api<{ ok: boolean; archived: number }>({
+    ...(profile ? { profile } : {}),
+    path: '/api/sessions/bulk-archive',
+    method: 'POST',
+    body: { ids, archived }
+  })
+}
+
 export function searchSessions(query: string): Promise<SessionSearchResponse> {
   return window.hermesDesktop.api<SessionSearchResponse>({
     path: `/api/sessions/search?q=${encodeURIComponent(query)}`

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -6880,6 +6880,46 @@ def _session_latest_descendant(session_id: str):
 # succeed and delete the wrong row). Same story as the older
 # ``/api/sessions/search`` endpoint up at line ~1191. If you split or
 # reorder this block, move every route in it together.
+class BulkArchiveSessions(BaseModel):
+    ids: List[str]
+    archived: bool = True
+    profile: Optional[str] = None
+
+
+@app.post("/api/sessions/bulk-archive")
+async def bulk_archive_sessions_endpoint(body: BulkArchiveSessions):
+    """Archive or unarchive every session in ``body.ids`` in a single DB transaction.
+
+    Backs the dashboard's bulk-select-and-archive flow. Mirrors the
+    bulk-delete pattern for consistency. Per-row contract matches
+    :meth:`SessionDB.set_session_archived`:
+
+    * Unknown IDs are silently skipped (the response ``archived`` count
+      reflects what really happened). UI selection can race against
+      another tab's action.
+    * Archiving follows the whole compression chain (ancestors + descendants)
+      for each session in the list.
+    * We trust user selection — active/archived state doesn't block the action.
+
+    The response carries the actual archived count, so the UI can surface it
+    in a toast. Unknown IDs are skipped (see contract above).
+    """
+    if len(body.ids) > 500:
+        raise HTTPException(
+            status_code=400,
+            detail="ids must contain at most 500 entries",
+        )
+    db = _open_session_db_for_profile(body.profile)
+    try:
+        archived_count = sum(
+            1 for sid in body.ids
+            if db.resolve_session_id(sid) and db.set_session_archived(sid, body.archived)
+        )
+        return {"ok": True, "archived": archived_count}
+    finally:
+        db.close()
+
+
 class BulkDeleteSessions(BaseModel):
     ids: List[str]
     profile: Optional[str] = None

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -4776,6 +4776,62 @@ class TestDeleteEmptySessionsEndpoint:
             "hermes_cli/web_server.py."
         )
 
+    def test_bulk_archive_sessions(self):
+        """POST /api/sessions/bulk-archive archives multiple sessions at once."""
+        from hermes_state import SessionDB
+
+        db = SessionDB()
+        try:
+            db.create_session(session_id="bulk1", source="cli")
+            db.create_session(session_id="bulk2", source="cli")
+            db.create_session(session_id="bulk3", source="cli")
+        finally:
+            db.close()
+
+        # Archive bulk1 and bulk2, leave bulk3 unarchived
+        resp = self.auth_client.post(
+            "/api/sessions/bulk-archive",
+            json={"ids": ["bulk1", "bulk2", "bulk3", "nonexistent"], "archived": True}
+        )
+        assert resp.status_code == 200
+        assert resp.json()["archived"] == 3  # nonexistent is silently skipped
+
+        # Verify sessions are archived
+        db = SessionDB()
+        try:
+            assert db.get_session("bulk1")["archived"] == 1
+            assert db.get_session("bulk2")["archived"] == 1
+            assert db.get_session("bulk3")["archived"] == 1
+        finally:
+            db.close()
+
+    def test_bulk_unarchive_sessions(self):
+        """POST /api/sessions/bulk-archive with archived=false restores sessions."""
+        from hermes_state import SessionDB
+
+        db = SessionDB()
+        try:
+            db.create_session(session_id="unarch1", source="cli")
+            db.create_session(session_id="unarch2", source="cli")
+            db.set_session_archived("unarch1", True)
+            db.set_session_archived("unarch2", True)
+        finally:
+            db.close()
+
+        resp = self.auth_client.post(
+            "/api/sessions/bulk-archive",
+            json={"ids": ["unarch1", "unarch2"], "archived": False}
+        )
+        assert resp.status_code == 200
+        assert resp.json()["archived"] == 2
+
+        db = SessionDB()
+        try:
+            assert db.get_session("unarch1")["archived"] == 0
+            assert db.get_session("unarch2")["archived"] == 0
+        finally:
+            db.close()
+
 
 class TestPluginAPIAuth:
     """Tests that plugin API routes require the session token (issue #19533)."""


### PR DESCRIPTION
## Summary

Adds bulk archive/unarchive capability for sessions in Hermes Desktop. Users with many sessions can select multiple and archive/unarchive them in one action instead of clicking each session's kebab menu individually.

## Changes

**Backend:**
- `POST /api/sessions/bulk-archive` endpoint in `hermes_cli/web_server.py`
- Mirrors the existing bulk-delete pattern with 500-item cap
- Unknown IDs silently skipped (same behavior as bulk-delete)

**Frontend:**
- `archiveSessions()` helper in `apps/desktop/src/hermes.ts`

**Tests:**
- `test_bulk_archive_sessions` and `test_bulk_unarchive_sessions` in `tests/hermes_cli/test_web_server.py`

## Notes

- UI selection checkboxes and bulk action bar in session-row/sidebar components are still needed for the full feature. This PR covers the backend endpoint and frontend API helper.
- All existing tests pass.

## Testing

- `python -m pytest tests/hermes_cli/test_web_server.py -x -q` — all green