### PR TITLE
fix: rehydrate TUI background process status after refresh

### DIFF
--- a/ui-tui/src/__tests__/processes.test.ts
+++ b/ui-tui/src/__tests__/processes.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest'
+
+import { countRunningProcesses, visibleBackgroundTaskCount } from '../domain/processes.js'
+
+describe('countRunningProcesses', () => {
+  it('counts only running registry entries', () => {
+    expect(
+      countRunningProcesses([
+        { session_id: 'proc-1', status: 'running' },
+        { session_id: 'proc-2', status: 'exited' },
+        { session_id: 'proc-3', status: 'running' },
+        { session_id: 'proc-4', status: 'killed' }
+      ])
+    ).toBe(2)
+  })
+})
+
+describe('visibleBackgroundTaskCount', () => {
+  it('keeps registry-backed processes visible after the in-memory task set is smaller', () => {
+    expect(visibleBackgroundTaskCount(0, 2)).toBe(2)
+    expect(visibleBackgroundTaskCount(1, 3)).toBe(3)
+  })
+})

--- a/ui-tui/src/app/interfaces.ts
+++ b/ui-tui/src/app/interfaces.ts
@@ -156,6 +156,7 @@ export interface TranscriptRow {
 }
 
 export interface UiState {
+  backgroundProcessCount: number
   bgTasks: Set<string>
   busy: boolean
   busyInputMode: BusyInputMode

--- a/ui-tui/src/app/uiStore.ts
+++ b/ui-tui/src/app/uiStore.ts
@@ -7,6 +7,7 @@ import { DEFAULT_THEME } from '../theme.js'
 import { DEFAULT_INDICATOR_STYLE, type UiState } from './interfaces.js'
 
 const buildUiState = (): UiState => ({
+  backgroundProcessCount: 0,
   bgTasks: new Set(),
   busy: false,
   busyInputMode: 'queue',

--- a/ui-tui/src/app/useMainApp.ts
+++ b/ui-tui/src/app/useMainApp.ts
@@ -8,12 +8,14 @@ import { hasLeadGap, prevRenderedMsg } from '../domain/blockLayout.js'
 import { SECTION_NAMES, sectionMode } from '../domain/details.js'
 import { attachedImageNotice, imageTokenMeta } from '../domain/messages.js'
 import { composeTabTitle, fmtCwdBranch, shortCwd } from '../domain/paths.js'
+import { countRunningProcesses } from '../domain/processes.js'
 import { type GatewayClient } from '../gatewayClient.js'
 import type {
   ClarifyRespondResponse,
   ClipboardPasteResponse,
   ConfigSetResponse,
   GatewayEvent,
+  ProcessListResponse,
   SessionActiveListResponse,
   SessionCloseResponse,
   TerminalResizeResponse
@@ -514,7 +516,7 @@ export function useMainApp(gw: GatewayClient) {
 
   useEffect(() => {
     if (!ui.sid) {
-      patchUiState({ liveSessionCount: 0 })
+      patchUiState({ backgroundProcessCount: 0, liveSessionCount: 0 })
 
       return
     }
@@ -522,30 +524,46 @@ export function useMainApp(gw: GatewayClient) {
     let stopped = false
 
     const refresh = () => {
-      gw.request<SessionActiveListResponse>('session.active_list', { current_session_id: getUiState().sid })
-        .then(raw => {
-          const result = asRpcResult<SessionActiveListResponse>(raw)
+      const currentSid = getUiState().sid
 
-          if (!stopped && result?.sessions) {
-            const liveSessionCount = result.sessions.length
+      if (!currentSid) {
+        return
+      }
 
-            // Surface the current session's (auto-)title for the terminal
-            // titlebar. The active_list poll already carries it, so no extra
-            // round-trip is needed.
-            const currentSid = getUiState().sid
+      Promise.allSettled([
+        gw.request<SessionActiveListResponse>('session.active_list', { current_session_id: currentSid }),
+        gw.request<ProcessListResponse>('process.list', { session_id: currentSid })
+      ])
+        .then(([activeListResult, processListResult]) => {
+          if (stopped) {
+            return
+          }
 
-            const sessionTitle =
-              result.sessions.find(s => s.current || s.id === currentSid)?.title?.trim() ?? ''
+          const activeList =
+            activeListResult.status === 'fulfilled' ? asRpcResult<SessionActiveListResponse>(activeListResult.value) : null
 
-            // Only patch when something actually changed. patchUiState always
-            // produces a new state object, which notifies every $uiState
-            // subscriber; patching unconditionally on each 1.5s poll re-renders
-            // the whole TUI and causes idle flicker.
-            const prev = getUiState()
+          const processList =
+            processListResult.status === 'fulfilled' ? asRpcResult<ProcessListResponse>(processListResult.value) : null
 
-            if (prev.liveSessionCount !== liveSessionCount || prev.sessionTitle !== sessionTitle) {
-              patchUiState({ liveSessionCount, sessionTitle })
-            }
+          const liveSessionCount = activeList?.sessions?.length ?? 0
+
+          const sessionTitle =
+            activeList?.sessions?.find(s => s.current || s.id === currentSid)?.title?.trim() ?? ''
+
+          const backgroundProcessCount = countRunningProcesses(processList?.processes)
+
+          // Only patch when something actually changed. patchUiState always
+          // produces a new state object, which notifies every $uiState
+          // subscriber; patching unconditionally on each 1.5s poll re-renders
+          // the whole TUI and causes idle flicker.
+          const prev = getUiState()
+
+          if (
+            prev.backgroundProcessCount !== backgroundProcessCount ||
+            prev.liveSessionCount !== liveSessionCount ||
+            prev.sessionTitle !== sessionTitle
+          ) {
+            patchUiState({ backgroundProcessCount, liveSessionCount, sessionTitle })
           }
         })
         .catch(() => {})

--- a/ui-tui/src/app/useSessionLifecycle.ts
+++ b/ui-tui/src/app/useSessionLifecycle.ts
@@ -125,7 +125,7 @@ export function useSessionLifecycle(opts: UseSessionLifecycleOptions) {
     turnController.fullReset()
     setVoiceRecording(false)
     setVoiceProcessing(false)
-    patchUiState({ bgTasks: new Set(), info: null, sid: null, usage: ZERO })
+    patchUiState({ backgroundProcessCount: 0, bgTasks: new Set(), info: null, sid: null, usage: ZERO })
     setHistoryItems([])
     setLastUserMsg('')
     setStickyPrompt('')

--- a/ui-tui/src/components/appLayout.tsx
+++ b/ui-tui/src/components/appLayout.tsx
@@ -9,6 +9,7 @@ import { $uiState } from '../app/uiStore.js'
 import { INLINE_MODE, SHOW_FPS, TERMUX_TUI_MODE } from '../config/env.js'
 import { PLACEHOLDER } from '../content/placeholders.js'
 import { prevRenderedMsg } from '../domain/blockLayout.js'
+import { visibleBackgroundTaskCount } from '../domain/processes.js'
 import {
   COMPOSER_PROMPT_GAP_WIDTH,
   composerPromptWidth,
@@ -175,6 +176,7 @@ const ComposerPane = memo(function ComposerPane({
 }: Pick<AppLayoutProps, 'actions' | 'composer' | 'status'>) {
   const ui = useStore($uiState)
   const isBlocked = useStore($isBlocked)
+  const backgroundCount = visibleBackgroundTaskCount(ui.bgTasks.size, ui.backgroundProcessCount)
   const sh = (composer.inputBuf[0] ?? composer.input).startsWith('!')
   const promptText = composerPromptText(ui.theme.brand.prompt, ui.info?.profile_name, sh, TERMUX_TUI_MODE, composer.cols)
   const promptWidth = composerPromptWidth(promptText)
@@ -236,9 +238,9 @@ const ComposerPane = memo(function ComposerPane({
         t={ui.theme}
       />
 
-      {ui.bgTasks.size > 0 && (
+      {backgroundCount > 0 && (
         <Text color={ui.theme.color.muted}>
-          {ui.bgTasks.size} background {ui.bgTasks.size === 1 ? 'task' : 'tasks'} running
+          {backgroundCount} background {backgroundCount === 1 ? 'task' : 'tasks'} running
         </Text>
       )}
 
@@ -353,6 +355,7 @@ const StatusRulePane = memo(function StatusRulePane({
   status
 }: Pick<AppLayoutProps, 'composer' | 'status'> & { at: 'bottom' | 'top' }) {
   const ui = useStore($uiState)
+  const backgroundCount = visibleBackgroundTaskCount(ui.bgTasks.size, ui.backgroundProcessCount)
 
   if (ui.statusBar !== at) {
     return null
@@ -361,7 +364,7 @@ const StatusRulePane = memo(function StatusRulePane({
   return (
     <Box marginTop={at === 'top' ? 1 : 0}>
       <StatusRule
-        bgCount={ui.bgTasks.size}
+        bgCount={backgroundCount}
         busy={ui.busy}
         cols={composer.cols}
         cwdLabel={status.cwdLabel}

--- a/ui-tui/src/domain/processes.ts
+++ b/ui-tui/src/domain/processes.ts
@@ -1,0 +1,7 @@
+import type { ProcessListItem } from '../gatewayTypes.js'
+
+export const countRunningProcesses = (processes?: ProcessListItem[]) =>
+  processes?.filter(process => process.status === 'running').length ?? 0
+
+export const visibleBackgroundTaskCount = (bgTaskCount: number, backgroundProcessCount: number) =>
+  Math.max(bgTaskCount, backgroundProcessCount)

--- a/ui-tui/src/gatewayTypes.ts
+++ b/ui-tui/src/gatewayTypes.ts
@@ -253,6 +253,15 @@ export interface SessionActiveListResponse {
   sessions?: SessionActiveItem[]
 }
 
+export interface ProcessListItem {
+  session_id?: string
+  status?: string
+}
+
+export interface ProcessListResponse {
+  processes?: ProcessListItem[]
+}
+
 export interface SessionInflightTurn {
   assistant?: string
   streaming?: boolean


### PR DESCRIPTION
## Summary
- rehydrate the TUI background-task indicator from `process.list` during the existing live-session poll
- keep the displayed count in sync across refreshes and session switches by combining registry state with the in-memory task set
- add a focused unit test for the background-process counting helper

## Verification
- `npm run test -- --run src/__tests__/processes.test.ts`
- `git diff --check`
- touched-file eslint run completed with only preexisting `react-hooks/exhaustive-deps` warnings in `ui-tui/src/app/useMainApp.ts`
- `npm run typecheck` still fails on preexisting unrelated baseline issues in `../../.base/ui-tui/packages/hermes-ink/src/utils/execFileNoThrow.ts` and `ui-tui/src/gatewayClient.ts`

Fixes #48339