### PR TITLE
fix(agent): use stream aggregation for Anthropic-compatible streaming-only gateways

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -1041,7 +1041,12 @@ class _AnthropicCompletionsAdapter:
             if not _forbids_sampling_params(model):
                 anthropic_kwargs["temperature"] = temperature
 
-        response = self._client.messages.create(**anthropic_kwargs)
+        # Some Anthropic-compatible gateways are streaming-only and never
+        # honor non-streaming requests; aggregate the stream instead. This
+        # matches the main turn path and is a no-op for native Anthropic.
+        anthropic_kwargs.pop("stream", None)
+        with self._client.messages.stream(**anthropic_kwargs) as _stream:
+            response = _stream.get_final_message()
         _transport = get_transport("anthropic_messages")
         _nr = _transport.normalize_response(
             response, strip_tool_prefix=self._is_oauth

--- a/run_agent.py
+++ b/run_agent.py
@@ -4080,7 +4080,12 @@ class AIAgent:
         sanitize_anthropic_kwargs(
             api_kwargs, log_prefix=getattr(self, "log_prefix", "")
         )
-        return self._anthropic_client.messages.create(**api_kwargs)
+        # Some Anthropic-compatible gateways are streaming-only and never
+        # honor non-streaming requests; aggregate the stream instead. This
+        # matches the main turn path and is a no-op for native Anthropic.
+        api_kwargs.pop("stream", None)
+        with self._anthropic_client.messages.stream(**api_kwargs) as _stream:
+            return _stream.get_final_message()
 
     def _rebuild_anthropic_client(self) -> None:
         """Rebuild the Anthropic client after an interrupt or stale call.

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -5813,13 +5813,19 @@ class TestAnthropicCredentialRefresh:
 
         response = SimpleNamespace(content=[])
         agent._anthropic_client = MagicMock()
-        agent._anthropic_client.messages.create.return_value = response
+        stream_ctx = MagicMock()
+        stream_ctx.__enter__ = MagicMock(return_value=stream_ctx)
+        stream_ctx.__exit__ = MagicMock(return_value=False)
+        stream_ctx.get_final_message.return_value = response
+        agent._anthropic_client.messages.stream.return_value = stream_ctx
 
         with patch.object(agent, "_try_refresh_anthropic_client_credentials", return_value=True) as refresh:
             result = agent._anthropic_messages_create({"model": "claude-sonnet-4-20250514"})
 
         refresh.assert_called_once_with()
-        agent._anthropic_client.messages.create.assert_called_once_with(model="claude-sonnet-4-20250514")
+        agent._anthropic_client.messages.stream.assert_called_once_with(model="claude-sonnet-4-20250514")
+        stream_ctx.__enter__.assert_called_once_with()
+        stream_ctx.get_final_message.assert_called_once_with()
         assert result is response
 
 


### PR DESCRIPTION
## Summary

Fixes #48923

When `api_mode` is `anthropic_messages` and the endpoint only supports SSE streaming (e.g., some Anthropic-compatible gateways), the non-streaming `messages.create()` call fails with an `AttributeError`.

## Changes

Replace `messages.create(**api_kwargs)` with `messages.stream(**api_kwargs).get_final_message()` in two locations:

1. **`run_agent.py`** — `AIAgent._anthropic_messages_create()` method
2. **`agent/auxiliary_client.py`** — `_AnthropicCompletionsAdapter.create()` method

This approach:
- **Matches the main turn path** which already uses `messages.stream()`
- **Is a no-op for native Anthropic endpoints** (Anthropic recommends streaming for long requests anyway)
- **Fixes compatibility with streaming-only gateways** by aggregating the SSE stream into a proper `Message` object

## Testing

- Updated `test_anthropic_messages_create_preflights_refresh` to verify `messages.stream` is called instead of `messages.create`
- All related tests pass via `scripts/run_tests.sh`

## Compliance

Follows [CONTRIBUTING.md](link) guidelines:
- ✅ Branch naming: `fix/anthropic-streaming-only-gateway`
- ✅ Commit message: Conventional Commits format
- ✅ Tests run via `scripts/run_tests.sh`
- ✅ Single logical change per PR
- ✅ No new dependencies added