### PR TITLE
fix: handle SSE-only Anthropic endpoints in auxiliary client

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -527,6 +527,15 @@ class _AnthropicCompletionsAdapter:
                 anthropic_kwargs["temperature"] = temperature
 
         response = self._client.messages.create(**anthropic_kwargs)
+        # Some Anthropic-compatible endpoints are SSE-only — they always
+        # return text/event-stream regardless of the stream flag.  The
+        # Anthropic SDK hands back the raw event text as a bare str
+        # instead of a Message object, causing AttributeError downstream.
+        # Detect this and fall back to streaming mode which handles
+        # SSE-only endpoints correctly.
+        if isinstance(response, str):
+            with self._client.messages.stream(**anthropic_kwargs) as stream:
+                response = stream.get_final_message()
         assistant_message, finish_reason = normalize_anthropic_response(response)
 
         usage = None

--- a/tools/environments/docker.py
+++ b/tools/environments/docker.py
@@ -489,7 +489,8 @@ class DockerEnvironment(BaseEnvironment):
                   timeout: int = 120,
                   stdin_data: str | None = None) -> subprocess.Popen:
         """Spawn a bash process inside the Docker container."""
-        assert self._container_id, "Container not started"
+        if not self._container_id:
+            raise RuntimeError("Container not started")
         cmd = [self._docker_exe, "exec"]
         if stdin_data is not None:
             cmd.append("-i")

--- a/tools/mcp_oauth.py
+++ b/tools/mcp_oauth.py
@@ -320,7 +320,8 @@ async def _wait_for_callback() -> tuple[str, str | None]:
         OAuthNonInteractiveError: If the callback times out (no user present
             to complete the browser auth).
     """
-    assert _oauth_port is not None, "OAuth callback port not set"
+    if _oauth_port is None:
+        raise RuntimeError("OAuth callback port not set")
 
     # The callback server is already running (started in build_oauth_auth).
     # We just need to poll for the result.


### PR DESCRIPTION
## Problem

### Bug 1: Non-streaming Anthropic calls fail with SSE-only endpoints

When using an Anthropic-compatible endpoint that only supports streaming (SSE), the non-streaming `messages.create()` call returns a raw string instead of a Message object. The Anthropic SDK doesn't parse SSE responses in non-streaming mode, so the caller crashes with `AttributeError: 'str' object has no attribute 'content'`.

This affects:
- Context compression (compaction)
- Auxiliary client tasks (title generation, triage, etc.)
- Any non-streaming Anthropic API call

### Bug 2: Assert statements in production code (tools/)

Production code in `tools/mcp_oauth.py` and `tools/environments/docker.py` uses bare `assert` statements for pre-condition checks. When Python runs with optimization (`-O` or `PYTHONOPTIMIZE=1`), all `assert` statements are stripped, causing these checks to silently disappear.

## Changes

### `agent/auxiliary_client.py` (1 fix)
- Add `isinstance(response, str)` check after `messages.create()` to detect SSE-only endpoints
- Fall back to `messages.stream()` when response is a string (SSE-only endpoint)

### `tools/mcp_oauth.py` (1 fix)
- `await_oauth_callback()`: `assert _oauth_port is not None` -> `if ... raise RuntimeError`

### `tools/environments/docker.py` (1 fix)
- `spawn_bash()`: `assert self._container_id` -> `if not ... raise RuntimeError`

## Why these fixes matter

1. **SSE-only endpoints**: Internal/corporate model gateways and reverse proxies often only support streaming. Without this fix, Hermes breaks when used with such endpoints.

2. **Assert statements**: `assert` is stripped by `python -O` (production optimization mode). `RuntimeError` always executes regardless of optimization level.

Fixes #48923