### PR TITLE
fix(gateway): harden Windows watchdog, env-override, and proxy routing (#48820)

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -558,6 +558,15 @@ class GatewayConfig:
     # fresh session exactly as if the reset policy had fired.  0 = disabled.
     session_store_max_age_days: int = 90
 
+    # Proxy trust (issue #48820, Bug 3). When False (default), gateway HTTP
+    # clients do NOT inherit ``HTTP_PROXY``/``HTTPS_PROXY`` from the process
+    # environment — a Windows Scheduled Task / non-interactive launch can
+    # inherit a proxy var the user never set for the gateway, breaking polls
+    # with connection-refused loops. Set either flag True (or the
+    # ``GATEWAY_TRUST_PROXY``/``GATEWAY_TRUST_ENV`` env vars) to opt back in.
+    trust_proxy: bool = False
+    trust_env: bool = False
+
     def get_connected_platforms(self) -> List[Platform]:
         """Return list of platforms that are enabled and configured."""
         connected = []
@@ -653,6 +662,8 @@ class GatewayConfig:
             "unauthorized_dm_behavior": self.unauthorized_dm_behavior,
             "streaming": self.streaming.to_dict(),
             "session_store_max_age_days": self.session_store_max_age_days,
+            "trust_proxy": self.trust_proxy,
+            "trust_env": self.trust_env,
         }
     
     @classmethod
@@ -736,6 +747,8 @@ class GatewayConfig:
             unauthorized_dm_behavior=unauthorized_dm_behavior,
             streaming=StreamingConfig.from_dict(data.get("streaming", {})),
             session_store_max_age_days=session_store_max_age_days,
+            trust_proxy=_coerce_bool(data.get("trust_proxy"), False),
+            trust_env=_coerce_bool(data.get("trust_env"), False),
         )
 
     def get_unauthorized_dm_behavior(self, platform: Optional[Platform] = None) -> str:
@@ -854,6 +867,17 @@ def load_gateway_config() -> GatewayConfig:
                     yaml_cfg.get("unauthorized_dm_behavior"),
                     "pair",
                 )
+
+            # Proxy-trust flags (#48820 Bug 3). Accept both top-level keys and
+            # the nested ``gateway.*`` form written by ``hermes config set``.
+            _gateway_section = yaml_cfg.get("gateway")
+            if not isinstance(_gateway_section, dict):
+                _gateway_section = {}
+            for _trust_key in ("trust_proxy", "trust_env"):
+                if _trust_key in yaml_cfg:
+                    gw_data[_trust_key] = yaml_cfg[_trust_key]
+                elif _trust_key in _gateway_section:
+                    gw_data[_trust_key] = _gateway_section[_trust_key]
 
             # Merge platform config into gw_data so runtime-only settings under
             # ``gateway.platforms`` are loaded the same way as top-level
@@ -997,7 +1021,11 @@ def load_gateway_config() -> GatewayConfig:
                 plat_data, extra = _ensure_platform_extra_dict(platforms_data, plat.value)
                 if enabled_was_explicit:
                     plat_data["enabled"] = platform_cfg["enabled"]
-                if plat == Platform.SLACK and enabled_was_explicit:
+                    # Track explicit-disable intent for ALL platforms (#48820
+                    # Bug 2). Previously only Slack recorded this, so an
+                    # ``enabled: false`` on any other platform was silently
+                    # force-enabled by a matching env var. ``_enable_from_env``
+                    # consults this marker before flipping ``enabled = True``.
                     extra["_enabled_explicit"] = True
                 extra.update(bridged)
 
@@ -1356,21 +1384,37 @@ def _validate_gateway_config(config: "GatewayConfig") -> None:
 def _apply_env_overrides(config: GatewayConfig) -> None:
     """Apply environment variable overrides to config."""
 
-    def _enable_from_env(platform: Platform) -> PlatformConfig:
+    def _enable_from_env(platform: Platform, env_trigger: str) -> PlatformConfig:
         if platform not in config.platforms:
             config.platforms[platform] = PlatformConfig(enabled=True)
             return config.platforms[platform]
 
         platform_config = config.platforms[platform]
-        enabled_was_explicit = bool(platform_config.extra.pop("_enabled_explicit", False))
-        if not platform_config.enabled and not enabled_was_explicit:
+        # Read (do NOT pop) the explicit-disable marker: a platform can be
+        # processed more than once within a single _apply_env_overrides pass
+        # (e.g. a plugin platform hit by both its hardcoded env block and the
+        # registry-driven loop). Popping here would drop the marker after the
+        # first call and let the second force-enable it. The marker is cleaned
+        # up once at the end of _apply_env_overrides.
+        enabled_was_explicit = bool(platform_config.extra.get("_enabled_explicit", False))
+        if not platform_config.enabled and enabled_was_explicit:
+            # User explicitly set ``enabled: false`` in config.yaml — respect
+            # that over a matching env var instead of force-enabling (#48820
+            # Bug 2). The credential is still stored on the config so skills
+            # can use it without activating the gateway adapter.
+            logger.warning(
+                "Environment variable %s is set but platform '%s' remains "
+                "disabled because config.yaml explicitly set enabled: false.",
+                env_trigger, platform.value,
+            )
+        elif not platform_config.enabled:
             platform_config.enabled = True
         return platform_config
     
     # Telegram
     telegram_token = os.getenv("TELEGRAM_BOT_TOKEN")
     if telegram_token:
-        telegram_config = _enable_from_env(Platform.TELEGRAM)
+        telegram_config = _enable_from_env(Platform.TELEGRAM, "TELEGRAM_BOT_TOKEN")
         telegram_config.token = telegram_token
     
     # Reply threading mode for Telegram (off/first/all)
@@ -1400,7 +1444,7 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
     # Discord
     discord_token = os.getenv("DISCORD_BOT_TOKEN")
     if discord_token:
-        discord_config = _enable_from_env(Platform.DISCORD)
+        discord_config = _enable_from_env(Platform.DISCORD, "DISCORD_BOT_TOKEN")
         discord_config.token = discord_token
     
     discord_home = os.getenv("DISCORD_HOME_CHANNEL")
@@ -1422,16 +1466,11 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
     # WhatsApp (typically uses different auth mechanism)
     whatsapp_enabled = os.getenv("WHATSAPP_ENABLED", "").lower() in {"true", "1", "yes"}
     whatsapp_disabled_explicitly = os.getenv("WHATSAPP_ENABLED", "").lower() in {"false", "0", "no"}
-    if Platform.WHATSAPP in config.platforms:
-        # YAML config exists — respect explicit disable
-        wa_cfg = config.platforms[Platform.WHATSAPP]
-        if whatsapp_disabled_explicitly:
-            wa_cfg.enabled = False
-        elif whatsapp_enabled:
-            wa_cfg.enabled = True
-        # else: keep whatever the YAML set
+    if whatsapp_disabled_explicitly:
+        if Platform.WHATSAPP in config.platforms:
+            config.platforms[Platform.WHATSAPP].enabled = False
     elif whatsapp_enabled:
-        config.platforms[Platform.WHATSAPP] = PlatformConfig(enabled=True)
+        _enable_from_env(Platform.WHATSAPP, "WHATSAPP_ENABLED")
     whatsapp_home = os.getenv("WHATSAPP_HOME_CHANNEL")
     if whatsapp_home and Platform.WHATSAPP in config.platforms:
         config.platforms[Platform.WHATSAPP].home_channel = HomeChannel(
@@ -1448,45 +1487,43 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
     whatsapp_cloud_phone_id = os.getenv("WHATSAPP_CLOUD_PHONE_NUMBER_ID")
     whatsapp_cloud_token = os.getenv("WHATSAPP_CLOUD_ACCESS_TOKEN")
     if whatsapp_cloud_phone_id and whatsapp_cloud_token:
-        if Platform.WHATSAPP_CLOUD not in config.platforms:
-            config.platforms[Platform.WHATSAPP_CLOUD] = PlatformConfig()
-        config.platforms[Platform.WHATSAPP_CLOUD].enabled = True
-        config.platforms[Platform.WHATSAPP_CLOUD].extra.update({
+        whatsapp_cloud_config = _enable_from_env(Platform.WHATSAPP_CLOUD, "WHATSAPP_CLOUD_PHONE_NUMBER_ID / WHATSAPP_CLOUD_ACCESS_TOKEN")
+        whatsapp_cloud_config.extra.update({
             "phone_number_id": whatsapp_cloud_phone_id,
             "access_token": whatsapp_cloud_token,
         })
         # Optional: app_id / app_secret (signature verification)
         wa_cloud_app_id = os.getenv("WHATSAPP_CLOUD_APP_ID")
         if wa_cloud_app_id:
-            config.platforms[Platform.WHATSAPP_CLOUD].extra["app_id"] = wa_cloud_app_id
+            whatsapp_cloud_config.extra["app_id"] = wa_cloud_app_id
         wa_cloud_app_secret = os.getenv("WHATSAPP_CLOUD_APP_SECRET")
         if wa_cloud_app_secret:
-            config.platforms[Platform.WHATSAPP_CLOUD].extra["app_secret"] = wa_cloud_app_secret
+            whatsapp_cloud_config.extra["app_secret"] = wa_cloud_app_secret
         # Optional: WABA id (analytics, future use)
         wa_cloud_waba_id = os.getenv("WHATSAPP_CLOUD_WABA_ID")
         if wa_cloud_waba_id:
-            config.platforms[Platform.WHATSAPP_CLOUD].extra["waba_id"] = wa_cloud_waba_id
+            whatsapp_cloud_config.extra["waba_id"] = wa_cloud_waba_id
         # Webhook verify token — Meta hub.verify_token shared secret
         wa_cloud_verify_token = os.getenv("WHATSAPP_CLOUD_VERIFY_TOKEN")
         if wa_cloud_verify_token:
-            config.platforms[Platform.WHATSAPP_CLOUD].extra["verify_token"] = wa_cloud_verify_token
+            whatsapp_cloud_config.extra["verify_token"] = wa_cloud_verify_token
         # Webhook server bind config (defaults baked into the adapter)
         wa_cloud_host = os.getenv("WHATSAPP_CLOUD_WEBHOOK_HOST")
         if wa_cloud_host:
-            config.platforms[Platform.WHATSAPP_CLOUD].extra["webhook_host"] = wa_cloud_host
+            whatsapp_cloud_config.extra["webhook_host"] = wa_cloud_host
         wa_cloud_port = os.getenv("WHATSAPP_CLOUD_WEBHOOK_PORT")
         if wa_cloud_port:
             try:
-                config.platforms[Platform.WHATSAPP_CLOUD].extra["webhook_port"] = int(wa_cloud_port)
+                whatsapp_cloud_config.extra["webhook_port"] = int(wa_cloud_port)
             except ValueError:
                 pass
         wa_cloud_path = os.getenv("WHATSAPP_CLOUD_WEBHOOK_PATH")
         if wa_cloud_path:
-            config.platforms[Platform.WHATSAPP_CLOUD].extra["webhook_path"] = wa_cloud_path
+            whatsapp_cloud_config.extra["webhook_path"] = wa_cloud_path
         # Graph API version override (rarely needed)
         wa_cloud_api_version = os.getenv("WHATSAPP_CLOUD_API_VERSION")
         if wa_cloud_api_version:
-            config.platforms[Platform.WHATSAPP_CLOUD].extra["api_version"] = wa_cloud_api_version
+            whatsapp_cloud_config.extra["api_version"] = wa_cloud_api_version
     whatsapp_cloud_home = os.getenv("WHATSAPP_CLOUD_HOME_CHANNEL")
     if whatsapp_cloud_home and Platform.WHATSAPP_CLOUD in config.platforms:
         config.platforms[Platform.WHATSAPP_CLOUD].home_channel = HomeChannel(
@@ -1499,22 +1536,8 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
     # Slack
     slack_token = os.getenv("SLACK_BOT_TOKEN")
     if slack_token:
-        if Platform.SLACK not in config.platforms:
-            # No yaml config for Slack — env-only setup, enable it
-            config.platforms[Platform.SLACK] = PlatformConfig()
-            config.platforms[Platform.SLACK].enabled = True
-        else:
-            slack_config = config.platforms[Platform.SLACK]
-            enabled_was_explicit = bool(slack_config.extra.pop("_enabled_explicit", False))
-            if not slack_config.enabled and not enabled_was_explicit:
-                # Top-level Slack settings such as channel prompts should not
-                # turn an env-token setup into a disabled platform. Only an
-                # explicit slack.enabled/platforms.slack.enabled false should.
-                slack_config.enabled = True
-        # If yaml config exists, respect its enabled flag (don't override
-        # explicit enabled: false). Token is still stored so skills that
-        # send Slack messages can use it without activating the gateway adapter.
-        config.platforms[Platform.SLACK].token = slack_token
+        slack_config = _enable_from_env(Platform.SLACK, "SLACK_BOT_TOKEN")
+        slack_config.token = slack_token
     slack_home = os.getenv("SLACK_HOME_CHANNEL")
     if slack_home and Platform.SLACK in config.platforms:
         config.platforms[Platform.SLACK].home_channel = HomeChannel(
@@ -1528,7 +1551,7 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
     signal_url = os.getenv("SIGNAL_HTTP_URL")
     signal_account = os.getenv("SIGNAL_ACCOUNT")
     if signal_url and signal_account:
-        signal_config = _enable_from_env(Platform.SIGNAL)
+        signal_config = _enable_from_env(Platform.SIGNAL, "SIGNAL_HTTP_URL / SIGNAL_ACCOUNT")
         signal_config.extra.update({
             "http_url": signal_url,
             "account": signal_account,
@@ -1549,7 +1572,7 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
         mattermost_url = os.getenv("MATTERMOST_URL", "")
         if not mattermost_url:
             logger.warning("MATTERMOST_TOKEN set but MATTERMOST_URL is missing")
-        mattermost_config = _enable_from_env(Platform.MATTERMOST)
+        mattermost_config = _enable_from_env(Platform.MATTERMOST, "MATTERMOST_TOKEN")
         mattermost_config.token = mattermost_token
         mattermost_config.extra["url"] = mattermost_url
     mattermost_home = os.getenv("MATTERMOST_HOME_CHANNEL")
@@ -1567,7 +1590,7 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
     if matrix_token or os.getenv("MATRIX_PASSWORD"):
         if not matrix_homeserver:
             logger.warning("MATRIX_ACCESS_TOKEN/MATRIX_PASSWORD set but MATRIX_HOMESERVER is missing")
-        matrix_config = _enable_from_env(Platform.MATRIX)
+        matrix_config = _enable_from_env(Platform.MATRIX, "MATRIX_ACCESS_TOKEN / MATRIX_PASSWORD")
         if matrix_token:
             matrix_config.token = matrix_token
         matrix_config.extra["homeserver"] = matrix_homeserver
@@ -1600,13 +1623,11 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
     # Home Assistant
     hass_token = os.getenv("HASS_TOKEN")
     if hass_token:
-        if Platform.HOMEASSISTANT not in config.platforms:
-            config.platforms[Platform.HOMEASSISTANT] = PlatformConfig()
-        config.platforms[Platform.HOMEASSISTANT].enabled = True
-        config.platforms[Platform.HOMEASSISTANT].token = hass_token
+        hass_config = _enable_from_env(Platform.HOMEASSISTANT, "HASS_TOKEN")
+        hass_config.token = hass_token
         hass_url = os.getenv("HASS_URL")
         if hass_url:
-            config.platforms[Platform.HOMEASSISTANT].extra["url"] = hass_url
+            hass_config.extra["url"] = hass_url
 
     # Email
     email_addr = os.getenv("EMAIL_ADDRESS")
@@ -1614,10 +1635,8 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
     email_imap = os.getenv("EMAIL_IMAP_HOST")
     email_smtp = os.getenv("EMAIL_SMTP_HOST")
     if all([email_addr, email_pwd, email_imap, email_smtp]):
-        if Platform.EMAIL not in config.platforms:
-            config.platforms[Platform.EMAIL] = PlatformConfig()
-        config.platforms[Platform.EMAIL].enabled = True
-        config.platforms[Platform.EMAIL].extra.update({
+        email_config = _enable_from_env(Platform.EMAIL, "EMAIL_ADDRESS / EMAIL_PASSWORD / EMAIL_IMAP_HOST / EMAIL_SMTP_HOST")
+        email_config.extra.update({
             "address": email_addr,
             "imap_host": email_imap,
             "smtp_host": email_smtp,
@@ -1634,10 +1653,8 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
     # SMS (Twilio)
     twilio_sid = os.getenv("TWILIO_ACCOUNT_SID")
     if twilio_sid:
-        if Platform.SMS not in config.platforms:
-            config.platforms[Platform.SMS] = PlatformConfig()
-        config.platforms[Platform.SMS].enabled = True
-        config.platforms[Platform.SMS].api_key = os.getenv("TWILIO_AUTH_TOKEN", "")
+        sms_config = _enable_from_env(Platform.SMS, "TWILIO_ACCOUNT_SID")
+        sms_config.api_key = os.getenv("TWILIO_AUTH_TOKEN", "")
     sms_home = os.getenv("SMS_HOME_CHANNEL")
     if sms_home and Platform.SMS in config.platforms:
         config.platforms[Platform.SMS].home_channel = HomeChannel(
@@ -1654,41 +1671,37 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
     api_server_port = os.getenv("API_SERVER_PORT")
     api_server_host = os.getenv("API_SERVER_HOST")
     if api_server_enabled or api_server_key:
-        if Platform.API_SERVER not in config.platforms:
-            config.platforms[Platform.API_SERVER] = PlatformConfig()
-        config.platforms[Platform.API_SERVER].enabled = True
+        api_server_config = _enable_from_env(Platform.API_SERVER, "API_SERVER_ENABLED / API_SERVER_KEY")
         if api_server_key:
-            config.platforms[Platform.API_SERVER].extra["key"] = api_server_key
+            api_server_config.extra["key"] = api_server_key
         if api_server_cors_origins:
             origins = [origin.strip() for origin in api_server_cors_origins.split(",") if origin.strip()]
             if origins:
-                config.platforms[Platform.API_SERVER].extra["cors_origins"] = origins
+                api_server_config.extra["cors_origins"] = origins
         if api_server_port:
             try:
-                config.platforms[Platform.API_SERVER].extra["port"] = int(api_server_port)
+                api_server_config.extra["port"] = int(api_server_port)
             except ValueError:
                 pass
         if api_server_host:
-            config.platforms[Platform.API_SERVER].extra["host"] = api_server_host
+            api_server_config.extra["host"] = api_server_host
         api_server_model_name = os.getenv("API_SERVER_MODEL_NAME", "")
         if api_server_model_name:
-            config.platforms[Platform.API_SERVER].extra["model_name"] = api_server_model_name
+            api_server_config.extra["model_name"] = api_server_model_name
 
     # Webhook platform
     webhook_enabled = os.getenv("WEBHOOK_ENABLED", "").lower() in {"true", "1", "yes"}
     webhook_port = os.getenv("WEBHOOK_PORT")
     webhook_secret = os.getenv("WEBHOOK_SECRET", "")
     if webhook_enabled:
-        if Platform.WEBHOOK not in config.platforms:
-            config.platforms[Platform.WEBHOOK] = PlatformConfig()
-        config.platforms[Platform.WEBHOOK].enabled = True
+        webhook_config = _enable_from_env(Platform.WEBHOOK, "WEBHOOK_ENABLED")
         if webhook_port:
             try:
-                config.platforms[Platform.WEBHOOK].extra["port"] = int(webhook_port)
+                webhook_config.extra["port"] = int(webhook_port)
             except ValueError:
                 pass
         if webhook_secret:
-            config.platforms[Platform.WEBHOOK].extra["secret"] = webhook_secret
+            webhook_config.extra["secret"] = webhook_secret
 
     # Microsoft Graph webhook platform
     msgraph_webhook_enabled = os.getenv("MSGRAPH_WEBHOOK_ENABLED", "").lower() in {
@@ -1710,19 +1723,21 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
         or msgraph_webhook_resources
         or msgraph_webhook_allowed_cidrs
     ):
-        if Platform.MSGRAPH_WEBHOOK not in config.platforms:
-            config.platforms[Platform.MSGRAPH_WEBHOOK] = PlatformConfig()
         if msgraph_webhook_enabled:
-            config.platforms[Platform.MSGRAPH_WEBHOOK].enabled = True
+            msgraph_config = _enable_from_env(Platform.MSGRAPH_WEBHOOK, "MSGRAPH_WEBHOOK_ENABLED")
+        else:
+            if Platform.MSGRAPH_WEBHOOK not in config.platforms:
+                config.platforms[Platform.MSGRAPH_WEBHOOK] = PlatformConfig()
+            msgraph_config = config.platforms[Platform.MSGRAPH_WEBHOOK]
         if msgraph_webhook_port:
             try:
-                config.platforms[Platform.MSGRAPH_WEBHOOK].extra["port"] = int(
+                msgraph_config.extra["port"] = int(
                     msgraph_webhook_port
                 )
             except ValueError:
                 pass
         if msgraph_webhook_client_state:
-            config.platforms[Platform.MSGRAPH_WEBHOOK].extra["client_state"] = (
+            msgraph_config.extra["client_state"] = (
                 msgraph_webhook_client_state
             )
         if msgraph_webhook_resources:
@@ -1732,7 +1747,7 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
                 if resource.strip()
             ]
             if resources:
-                config.platforms[Platform.MSGRAPH_WEBHOOK].extra[
+                msgraph_config.extra[
                     "accepted_resources"
                 ] = resources
         if msgraph_webhook_allowed_cidrs:
@@ -1742,7 +1757,7 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
                 if cidr.strip()
             ]
             if cidrs:
-                config.platforms[Platform.MSGRAPH_WEBHOOK].extra[
+                msgraph_config.extra[
                     "allowed_source_cidrs"
                 ] = cidrs
 
@@ -1750,16 +1765,14 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
     dingtalk_client_id = os.getenv("DINGTALK_CLIENT_ID")
     dingtalk_client_secret = os.getenv("DINGTALK_CLIENT_SECRET")
     if dingtalk_client_id and dingtalk_client_secret:
-        if Platform.DINGTALK not in config.platforms:
-            config.platforms[Platform.DINGTALK] = PlatformConfig()
-        config.platforms[Platform.DINGTALK].enabled = True
-        config.platforms[Platform.DINGTALK].extra.update({
+        dingtalk_config = _enable_from_env(Platform.DINGTALK, "DINGTALK_CLIENT_ID / DINGTALK_CLIENT_SECRET")
+        dingtalk_config.extra.update({
             "client_id": dingtalk_client_id,
             "client_secret": dingtalk_client_secret,
         })
         dingtalk_home = os.getenv("DINGTALK_HOME_CHANNEL")
         if dingtalk_home:
-            config.platforms[Platform.DINGTALK].home_channel = HomeChannel(
+            dingtalk_config.home_channel = HomeChannel(
                 platform=Platform.DINGTALK,
                 chat_id=dingtalk_home,
                 name=os.getenv("DINGTALK_HOME_CHANNEL_NAME", "Home"),
@@ -1770,10 +1783,8 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
     feishu_app_id = os.getenv("FEISHU_APP_ID")
     feishu_app_secret = os.getenv("FEISHU_APP_SECRET")
     if feishu_app_id and feishu_app_secret:
-        if Platform.FEISHU not in config.platforms:
-            config.platforms[Platform.FEISHU] = PlatformConfig()
-        config.platforms[Platform.FEISHU].enabled = True
-        config.platforms[Platform.FEISHU].extra.update({
+        feishu_config = _enable_from_env(Platform.FEISHU, "FEISHU_APP_ID / FEISHU_APP_SECRET")
+        feishu_config.extra.update({
             "app_id": feishu_app_id,
             "app_secret": feishu_app_secret,
             "domain": os.getenv("FEISHU_DOMAIN", "feishu"),
@@ -1781,13 +1792,13 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
         })
         feishu_encrypt_key = os.getenv("FEISHU_ENCRYPT_KEY", "")
         if feishu_encrypt_key:
-            config.platforms[Platform.FEISHU].extra["encrypt_key"] = feishu_encrypt_key
+            feishu_config.extra["encrypt_key"] = feishu_encrypt_key
         feishu_verification_token = os.getenv("FEISHU_VERIFICATION_TOKEN", "")
         if feishu_verification_token:
-            config.platforms[Platform.FEISHU].extra["verification_token"] = feishu_verification_token
+            feishu_config.extra["verification_token"] = feishu_verification_token
         feishu_home = os.getenv("FEISHU_HOME_CHANNEL")
         if feishu_home:
-            config.platforms[Platform.FEISHU].home_channel = HomeChannel(
+            feishu_config.home_channel = HomeChannel(
                 platform=Platform.FEISHU,
                 chat_id=feishu_home,
                 name=os.getenv("FEISHU_HOME_CHANNEL_NAME", "Home"),
@@ -1798,19 +1809,17 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
     wecom_bot_id = os.getenv("WECOM_BOT_ID")
     wecom_secret = os.getenv("WECOM_SECRET")
     if wecom_bot_id and wecom_secret:
-        if Platform.WECOM not in config.platforms:
-            config.platforms[Platform.WECOM] = PlatformConfig()
-        config.platforms[Platform.WECOM].enabled = True
-        config.platforms[Platform.WECOM].extra.update({
+        wecom_config = _enable_from_env(Platform.WECOM, "WECOM_BOT_ID / WECOM_SECRET")
+        wecom_config.extra.update({
             "bot_id": wecom_bot_id,
             "secret": wecom_secret,
         })
         wecom_ws_url = os.getenv("WECOM_WEBSOCKET_URL", "")
         if wecom_ws_url:
-            config.platforms[Platform.WECOM].extra["websocket_url"] = wecom_ws_url
+            wecom_config.extra["websocket_url"] = wecom_ws_url
         wecom_home = os.getenv("WECOM_HOME_CHANNEL")
         if wecom_home:
-            config.platforms[Platform.WECOM].home_channel = HomeChannel(
+            wecom_config.home_channel = HomeChannel(
                 platform=Platform.WECOM,
                 chat_id=wecom_home,
                 name=os.getenv("WECOM_HOME_CHANNEL_NAME", "Home"),
@@ -1821,10 +1830,8 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
     wecom_callback_corp_id = os.getenv("WECOM_CALLBACK_CORP_ID")
     wecom_callback_corp_secret = os.getenv("WECOM_CALLBACK_CORP_SECRET")
     if wecom_callback_corp_id and wecom_callback_corp_secret:
-        if Platform.WECOM_CALLBACK not in config.platforms:
-            config.platforms[Platform.WECOM_CALLBACK] = PlatformConfig()
-        config.platforms[Platform.WECOM_CALLBACK].enabled = True
-        config.platforms[Platform.WECOM_CALLBACK].extra.update({
+        wecom_callback_config = _enable_from_env(Platform.WECOM_CALLBACK, "WECOM_CALLBACK_CORP_ID / WECOM_CALLBACK_CORP_SECRET")
+        wecom_callback_config.extra.update({
             "corp_id": wecom_callback_corp_id,
             "corp_secret": wecom_callback_corp_secret,
             "agent_id": os.getenv("WECOM_CALLBACK_AGENT_ID", ""),
@@ -1838,12 +1845,10 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
     weixin_token = os.getenv("WEIXIN_TOKEN")
     weixin_account_id = os.getenv("WEIXIN_ACCOUNT_ID")
     if weixin_token or weixin_account_id:
-        if Platform.WEIXIN not in config.platforms:
-            config.platforms[Platform.WEIXIN] = PlatformConfig()
-        config.platforms[Platform.WEIXIN].enabled = True
+        weixin_config = _enable_from_env(Platform.WEIXIN, "WEIXIN_TOKEN / WEIXIN_ACCOUNT_ID")
         if weixin_token:
-            config.platforms[Platform.WEIXIN].token = weixin_token
-        extra = config.platforms[Platform.WEIXIN].extra
+            weixin_config.token = weixin_token
+        extra = weixin_config.extra
         if weixin_account_id:
             extra["account_id"] = weixin_account_id
         weixin_base_url = os.getenv("WEIXIN_BASE_URL", "").strip()
@@ -1869,7 +1874,7 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
             extra["split_multiline_messages"] = weixin_split_multiline
         weixin_home = os.getenv("WEIXIN_HOME_CHANNEL", "").strip()
         if weixin_home:
-            config.platforms[Platform.WEIXIN].home_channel = HomeChannel(
+            weixin_config.home_channel = HomeChannel(
                 platform=Platform.WEIXIN,
                 chat_id=weixin_home,
                 name=os.getenv("WEIXIN_HOME_CHANNEL_NAME", "Home"),
@@ -1880,10 +1885,8 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
     bluebubbles_server_url = os.getenv("BLUEBUBBLES_SERVER_URL")
     bluebubbles_password = os.getenv("BLUEBUBBLES_PASSWORD")
     if bluebubbles_server_url and bluebubbles_password:
-        if Platform.BLUEBUBBLES not in config.platforms:
-            config.platforms[Platform.BLUEBUBBLES] = PlatformConfig()
-        config.platforms[Platform.BLUEBUBBLES].enabled = True
-        config.platforms[Platform.BLUEBUBBLES].extra.update({
+        bluebubbles_config = _enable_from_env(Platform.BLUEBUBBLES, "BLUEBUBBLES_SERVER_URL / BLUEBUBBLES_PASSWORD")
+        bluebubbles_config.extra.update({
             "server_url": bluebubbles_server_url.rstrip("/"),
             "password": bluebubbles_password,
             "webhook_host": os.getenv("BLUEBUBBLES_WEBHOOK_HOST", "127.0.0.1"),
@@ -1893,7 +1896,7 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
         })
         bluebubbles_require_mention = os.getenv("BLUEBUBBLES_REQUIRE_MENTION")
         if bluebubbles_require_mention is not None:
-            config.platforms[Platform.BLUEBUBBLES].extra["require_mention"] = (
+            bluebubbles_config.extra["require_mention"] = (
                 bluebubbles_require_mention.lower() in {"true", "1", "yes", "on"}
             )
         bluebubbles_mention_patterns = os.getenv("BLUEBUBBLES_MENTION_PATTERNS")
@@ -1906,7 +1909,7 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
                     for part in bluebubbles_mention_patterns.replace("\n", ",").split(",")
                     if part.strip()
                 ]
-            config.platforms[Platform.BLUEBUBBLES].extra["mention_patterns"] = parsed_patterns
+            bluebubbles_config.extra["mention_patterns"] = parsed_patterns
     bluebubbles_home = os.getenv("BLUEBUBBLES_HOME_CHANNEL")
     if bluebubbles_home and Platform.BLUEBUBBLES in config.platforms:
         config.platforms[Platform.BLUEBUBBLES].home_channel = HomeChannel(
@@ -1920,10 +1923,8 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
     qq_app_id = os.getenv("QQ_APP_ID")
     qq_client_secret = os.getenv("QQ_CLIENT_SECRET")
     if qq_app_id or qq_client_secret:
-        if Platform.QQBOT not in config.platforms:
-            config.platforms[Platform.QQBOT] = PlatformConfig()
-        config.platforms[Platform.QQBOT].enabled = True
-        extra = config.platforms[Platform.QQBOT].extra
+        qq_config = _enable_from_env(Platform.QQBOT, "QQ_APP_ID / QQ_CLIENT_SECRET")
+        extra = qq_config.extra
         if qq_app_id:
             extra["app_id"] = qq_app_id
         if qq_client_secret:
@@ -1962,10 +1963,8 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
     yuanbao_app_id = os.getenv("YUANBAO_APP_ID") or os.getenv("YUANBAO_APP_KEY")
     yuanbao_app_secret = os.getenv("YUANBAO_APP_SECRET")
     if yuanbao_app_id and yuanbao_app_secret:
-        if Platform.YUANBAO not in config.platforms:
-            config.platforms[Platform.YUANBAO] = PlatformConfig()
-        config.platforms[Platform.YUANBAO].enabled = True
-        extra = config.platforms[Platform.YUANBAO].extra
+        yuanbao_config = _enable_from_env(Platform.YUANBAO, "YUANBAO_APP_ID / YUANBAO_APP_SECRET")
+        extra = yuanbao_config.extra
         extra["app_id"] = yuanbao_app_id
         extra["app_secret"] = yuanbao_app_secret
         yuanbao_bot_id = os.getenv("YUANBAO_BOT_ID")
@@ -1982,7 +1981,7 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
             extra["route_env"] = yuanbao_route_env
         yuanbao_home = os.getenv("YUANBAO_HOME_CHANNEL")
         if yuanbao_home:
-            config.platforms[Platform.YUANBAO].home_channel = HomeChannel(
+            yuanbao_config.home_channel = HomeChannel(
                 platform=Platform.YUANBAO,
                 chat_id=yuanbao_home,
                 name=os.getenv("YUANBAO_HOME_CHANNEL_NAME", "Home"),
@@ -2117,8 +2116,12 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
                         )
                         continue
             if platform not in config.platforms:
-                config.platforms[platform] = PlatformConfig()
-            config.platforms[platform].enabled = True
+                config.platforms[platform] = PlatformConfig(enabled=True)
+            else:
+                # Honor an explicit ``enabled: false`` for plugin platforms too
+                # (#48820 Bug 2): the credentials being present (check_fn /
+                # is_connected) must not override the user's disable intent.
+                _enable_from_env(platform, f"plugin '{entry.name}' credentials")
             # Commit env-seeded extras onto the now-enabled platform.
             # We've already called ``env_enablement_fn`` above (for the
             # probe); reuse that result instead of calling it twice.
@@ -2159,7 +2162,7 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
         relay_url_yaml = str(existing_relay.extra.get("relay_url") or "").strip()
     relay_url_val = relay_url_env or relay_url_yaml
     if relay_url_val:
-        relay_config = _enable_from_env(Platform.RELAY)
+        relay_config = _enable_from_env(Platform.RELAY, "RELAY_URL")
         relay_config.extra["relay_url"] = relay_url_val.rstrip("/")
 
     for platform_config in config.platforms.values():

--- a/gateway/config.py
+++ b/gateway/config.py
@@ -562,10 +562,9 @@ class GatewayConfig:
     # clients do NOT inherit ``HTTP_PROXY``/``HTTPS_PROXY`` from the process
     # environment — a Windows Scheduled Task / non-interactive launch can
     # inherit a proxy var the user never set for the gateway, breaking polls
-    # with connection-refused loops. Set either flag True (or the
-    # ``GATEWAY_TRUST_PROXY``/``GATEWAY_TRUST_ENV`` env vars) to opt back in.
+    # with connection-refused loops. Set ``gateway.trust_proxy: true`` (or the
+    # internal ``GATEWAY_TRUST_PROXY`` escape-hatch env var) to opt back in.
     trust_proxy: bool = False
-    trust_env: bool = False
 
     def get_connected_platforms(self) -> List[Platform]:
         """Return list of platforms that are enabled and configured."""
@@ -663,7 +662,6 @@ class GatewayConfig:
             "streaming": self.streaming.to_dict(),
             "session_store_max_age_days": self.session_store_max_age_days,
             "trust_proxy": self.trust_proxy,
-            "trust_env": self.trust_env,
         }
     
     @classmethod
@@ -747,8 +745,10 @@ class GatewayConfig:
             unauthorized_dm_behavior=unauthorized_dm_behavior,
             streaming=StreamingConfig.from_dict(data.get("streaming", {})),
             session_store_max_age_days=session_store_max_age_days,
-            trust_proxy=_coerce_bool(data.get("trust_proxy"), False),
-            trust_env=_coerce_bool(data.get("trust_env"), False),
+            # Accept legacy ``trust_env`` as a read-only alias of ``trust_proxy``.
+            trust_proxy=_coerce_bool(
+                data.get("trust_proxy", data.get("trust_env")), False
+            ),
         )
 
     def get_unauthorized_dm_behavior(self, platform: Optional[Platform] = None) -> str:
@@ -868,16 +868,19 @@ def load_gateway_config() -> GatewayConfig:
                     "pair",
                 )
 
-            # Proxy-trust flags (#48820 Bug 3). Accept both top-level keys and
-            # the nested ``gateway.*`` form written by ``hermes config set``.
+            # Proxy-trust flag (#48820 Bug 3). Accept top-level or nested
+            # ``gateway.*`` form, and the legacy ``trust_env`` alias, all mapped
+            # to the canonical ``trust_proxy``.
             _gateway_section = yaml_cfg.get("gateway")
             if not isinstance(_gateway_section, dict):
                 _gateway_section = {}
-            for _trust_key in ("trust_proxy", "trust_env"):
-                if _trust_key in yaml_cfg:
-                    gw_data[_trust_key] = yaml_cfg[_trust_key]
-                elif _trust_key in _gateway_section:
-                    gw_data[_trust_key] = _gateway_section[_trust_key]
+            for _src_key in ("trust_proxy", "trust_env"):
+                if _src_key in yaml_cfg:
+                    gw_data["trust_proxy"] = yaml_cfg[_src_key]
+                    break
+                if _src_key in _gateway_section:
+                    gw_data["trust_proxy"] = _gateway_section[_src_key]
+                    break
 
             # Merge platform config into gw_data so runtime-only settings under
             # ``gateway.platforms`` are loaded the same way as top-level

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -345,6 +345,40 @@ def should_bypass_proxy(target_hosts: str | list[str] | tuple[str, ...] | set[st
     return False
 
 
+_TRUTHY = {"true", "1", "yes", "on"}
+
+
+def trust_env_for_gateway() -> bool:
+    """Whether gateway HTTP clients should inherit proxy settings from the env.
+
+    Default is **False**: a gateway launched from a Windows Scheduled Task (or
+    any non-interactive session) can silently inherit ``HTTP_PROXY`` /
+    ``HTTPS_PROXY`` pointing at a local proxy (e.g. ``127.0.0.1:7890``) that the
+    user's interactive shells never see. When that proxy isn't running, every
+    platform poll fails with a connection-refused loop (issue #48820, Bug 3).
+
+    Opt back in (restoring the historical ``trust_env=True`` behavior, which
+    also re-enables ``SSL_CERT_FILE`` pickup) via either:
+      * env ``GATEWAY_TRUST_PROXY`` / ``GATEWAY_TRUST_ENV`` set to a truthy value
+      * ``gateway.trust_proxy: true`` / ``gateway.trust_env: true`` in config.yaml
+
+    Explicit per-platform proxy vars (e.g. ``DISCORD_PROXY``, ``TELEGRAM_PROXY``)
+    are honored regardless of this setting — they are an explicit user choice,
+    not implicit environment inheritance.
+    """
+    for var in ("GATEWAY_TRUST_PROXY", "GATEWAY_TRUST_ENV"):
+        if os.environ.get(var, "").strip().lower() in _TRUTHY:
+            return True
+    try:
+        from gateway.config import load_gateway_config
+        gw_cfg = load_gateway_config()
+        if getattr(gw_cfg, "trust_proxy", False) or getattr(gw_cfg, "trust_env", False):
+            return True
+    except Exception:
+        pass
+    return False
+
+
 def resolve_proxy_url(
     platform_env_var: str | None = None,
     *,
@@ -353,9 +387,12 @@ def resolve_proxy_url(
     """Return a proxy URL from env vars, or macOS system proxy.
 
     Check order:
-      0. *platform_env_var* (e.g. ``DISCORD_PROXY``) — highest priority
-      1. HTTPS_PROXY / HTTP_PROXY / ALL_PROXY (and lowercase variants)
-      2. macOS system proxy via ``scutil --proxy`` (auto-detect)
+      0. *platform_env_var* (e.g. ``DISCORD_PROXY``) — highest priority, always
+         honored (explicit user choice)
+      1. HTTPS_PROXY / HTTP_PROXY / ALL_PROXY (and lowercase variants) — only
+         when ``trust_env_for_gateway()`` is True (default False; see #48820)
+      2. macOS system proxy via ``scutil --proxy`` (auto-detect) — only when
+         ``trust_env_for_gateway()`` is True
 
     Returns *None* if no proxy is found, or if NO_PROXY/no_proxy matches one
     of ``target_hosts``.
@@ -366,6 +403,12 @@ def resolve_proxy_url(
             if should_bypass_proxy(target_hosts):
                 return None
             return normalize_proxy_url(value)
+    # Generic environment proxy inheritance is gated: a non-interactive launch
+    # (Windows Scheduled Task, systemd) must not silently route through an
+    # inherited proxy the user never configured for the gateway. Explicit
+    # per-platform vars above are exempt.
+    if not trust_env_for_gateway():
+        return None
     for key in ("HTTPS_PROXY", "HTTP_PROXY", "ALL_PROXY",
                 "https_proxy", "http_proxy", "all_proxy"):
         value = (os.environ.get(key) or "").strip()

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -6,6 +6,7 @@ and implement the required methods.
 """
 
 import asyncio
+import functools
 import inspect
 import ipaddress
 import logging
@@ -20,7 +21,7 @@ import uuid
 from abc import ABC, abstractmethod
 from urllib.parse import urlsplit
 
-from utils import normalize_proxy_url
+from utils import is_truthy_value, normalize_proxy_url
 
 logger = logging.getLogger(__name__)
 
@@ -345,9 +346,6 @@ def should_bypass_proxy(target_hosts: str | list[str] | tuple[str, ...] | set[st
     return False
 
 
-_TRUTHY = {"true", "1", "yes", "on"}
-
-
 def trust_env_for_gateway() -> bool:
     """Whether gateway HTTP clients should inherit proxy settings from the env.
 
@@ -358,25 +356,37 @@ def trust_env_for_gateway() -> bool:
     platform poll fails with a connection-refused loop (issue #48820, Bug 3).
 
     Opt back in (restoring the historical ``trust_env=True`` behavior, which
-    also re-enables ``SSL_CERT_FILE`` pickup) via either:
-      * env ``GATEWAY_TRUST_PROXY`` / ``GATEWAY_TRUST_ENV`` set to a truthy value
-      * ``gateway.trust_proxy: true`` / ``gateway.trust_env: true`` in config.yaml
+    also re-enables ``SSL_CERT_FILE`` pickup) by setting ``gateway.trust_proxy:
+    true`` in ``config.yaml`` — the canonical, documented surface for this
+    behavioral toggle. ``GATEWAY_TRUST_PROXY`` is honored as an internal
+    escape-hatch env var (e.g. for ad-hoc/CI overrides) but config.yaml is the
+    user-facing path.
 
     Explicit per-platform proxy vars (e.g. ``DISCORD_PROXY``, ``TELEGRAM_PROXY``)
     are honored regardless of this setting — they are an explicit user choice,
     not implicit environment inheritance.
     """
-    for var in ("GATEWAY_TRUST_PROXY", "GATEWAY_TRUST_ENV"):
-        if os.environ.get(var, "").strip().lower() in _TRUTHY:
-            return True
+    if is_truthy_value(os.environ.get("GATEWAY_TRUST_PROXY")):
+        return True
+    return _config_trust_proxy()
+
+
+@functools.lru_cache(maxsize=1)
+def _config_trust_proxy() -> bool:
+    """Read ``gateway.trust_proxy`` from config.yaml (cached).
+
+    Cached because ``load_gateway_config()`` does a full disk read + YAML parse
+    + plugin discovery, and ``trust_env_for_gateway()`` is called per HTTP
+    client construction. ``trust_proxy`` is a restart-time toggle (the gateway
+    re-reads config.yaml on restart, not live), so a process-lifetime cache
+    introduces no staleness regression.
+    """
     try:
         from gateway.config import load_gateway_config
         gw_cfg = load_gateway_config()
-        if getattr(gw_cfg, "trust_proxy", False) or getattr(gw_cfg, "trust_env", False):
-            return True
+        return bool(getattr(gw_cfg, "trust_proxy", False))
     except Exception:
-        pass
-    return False
+        return False
 
 
 def resolve_proxy_url(

--- a/gateway/platforms/matrix.py
+++ b/gateway/platforms/matrix.py
@@ -128,6 +128,7 @@ from gateway.platforms.base import (
     SendResult,
     resolve_proxy_url,
     proxy_kwargs_for_aiohttp,
+    trust_env_for_gateway,
 )
 from gateway.platforms.helpers import ThreadParticipationTracker
 
@@ -465,7 +466,7 @@ def _create_matrix_session(proxy_url: str | None):
     import aiohttp
 
     if not proxy_url:
-        return aiohttp.ClientSession(trust_env=True)
+        return aiohttp.ClientSession(trust_env=trust_env_for_gateway())
 
     if proxy_url.split("://")[0].lower().startswith("socks"):
         try:
@@ -480,7 +481,7 @@ def _create_matrix_session(proxy_url: str | None):
                 "Run: pip install aiohttp-socks",
                 proxy_url,
             )
-            return aiohttp.ClientSession(trust_env=True)
+            return aiohttp.ClientSession(trust_env=trust_env_for_gateway())
 
     return aiohttp.ClientSession(proxy=proxy_url)
 

--- a/gateway/platforms/qqbot/adapter.py
+++ b/gateway/platforms/qqbot/adapter.py
@@ -69,6 +69,7 @@ from gateway.platforms.base import (
     _ssrf_redirect_guard,
     cache_document_from_bytes,
     cache_image_from_bytes,
+    trust_env_for_gateway,
 )
 from gateway.platforms.helpers import strip_markdown
 
@@ -455,17 +456,19 @@ class QQAdapter(BasePlatformAdapter):
             await self._session.close()
         self._session = None
 
-        # Honor WSL proxy env for QQ WebSocket. Hermes upgrades overwrite this
-        # local patch, so QQ can regress to direct-connect timeouts after update.
-        self._session = aiohttp.ClientSession(trust_env=True)
-        ws_proxy = (
-            os.getenv("WSS_PROXY")
-            or os.getenv("wss_proxy")
-            or os.getenv("HTTPS_PROXY")
-            or os.getenv("https_proxy")
-            or os.getenv("ALL_PROXY")
-            or os.getenv("all_proxy")
-        )
+        # Honor an explicit WSS proxy always (deliberate user choice). Generic
+        # inherited env proxies (HTTPS_PROXY/ALL_PROXY) are only used when the
+        # gateway is configured to trust the environment — a Windows Scheduled
+        # Task can otherwise inherit a stray proxy and misroute the WS (#48820).
+        self._session = aiohttp.ClientSession(trust_env=trust_env_for_gateway())
+        ws_proxy = os.getenv("WSS_PROXY") or os.getenv("wss_proxy")
+        if not ws_proxy and trust_env_for_gateway():
+            ws_proxy = (
+                os.getenv("HTTPS_PROXY")
+                or os.getenv("https_proxy")
+                or os.getenv("ALL_PROXY")
+                or os.getenv("all_proxy")
+            )
         self._ws = await self._session.ws_connect(
             gateway_url,
             headers={

--- a/gateway/platforms/qqbot/adapter.py
+++ b/gateway/platforms/qqbot/adapter.py
@@ -460,9 +460,10 @@ class QQAdapter(BasePlatformAdapter):
         # inherited env proxies (HTTPS_PROXY/ALL_PROXY) are only used when the
         # gateway is configured to trust the environment — a Windows Scheduled
         # Task can otherwise inherit a stray proxy and misroute the WS (#48820).
-        self._session = aiohttp.ClientSession(trust_env=trust_env_for_gateway())
+        _trust_env = trust_env_for_gateway()
+        self._session = aiohttp.ClientSession(trust_env=_trust_env)
         ws_proxy = os.getenv("WSS_PROXY") or os.getenv("wss_proxy")
-        if not ws_proxy and trust_env_for_gateway():
+        if not ws_proxy and _trust_env:
             ws_proxy = (
                 os.getenv("HTTPS_PROXY")
                 or os.getenv("https_proxy")

--- a/gateway/platforms/slack.py
+++ b/gateway/platforms/slack.py
@@ -51,6 +51,7 @@ from gateway.platforms.base import (
     safe_url_for_log,
     cache_document_from_bytes,
     cache_video_from_bytes,
+    trust_env_for_gateway,
 )
 
 
@@ -711,7 +712,7 @@ class SlackAdapter(BasePlatformAdapter):
             "text": text,
         }
         try:
-            async with aiohttp.ClientSession(trust_env=True) as session:
+            async with aiohttp.ClientSession(trust_env=trust_env_for_gateway()) as session:
                 async with session.post(
                     ctx["response_url"],
                     json=payload,

--- a/gateway/platforms/sms.py
+++ b/gateway/platforms/sms.py
@@ -33,6 +33,7 @@ from gateway.platforms.base import (
     MessageEvent,
     MessageType,
     SendResult,
+    trust_env_for_gateway,
 )
 from gateway.platforms.helpers import redact_phone, strip_markdown
 
@@ -128,7 +129,7 @@ class SmsAdapter(BasePlatformAdapter):
         await site.start()
         self._http_session = aiohttp.ClientSession(
             timeout=aiohttp.ClientTimeout(total=30),
-            trust_env=True,
+            trust_env=trust_env_for_gateway(),
         )
         self._running = True
 
@@ -170,7 +171,7 @@ class SmsAdapter(BasePlatformAdapter):
 
         session = self._http_session or aiohttp.ClientSession(
             timeout=aiohttp.ClientTimeout(total=30),
-            trust_env=True,
+            trust_env=trust_env_for_gateway(),
         )
         try:
             for chunk in chunks:

--- a/gateway/platforms/wecom.py
+++ b/gateway/platforms/wecom.py
@@ -67,6 +67,7 @@ from gateway.platforms.base import (
     SendResult,
     cache_document_from_bytes,
     cache_image_from_bytes,
+    trust_env_for_gateway,
 )
 
 logger = logging.getLogger(__name__)
@@ -281,7 +282,7 @@ class WeComAdapter(BasePlatformAdapter):
     async def _open_connection(self) -> None:
         """Open and authenticate a websocket connection."""
         await self._cleanup_ws()
-        self._session = aiohttp.ClientSession(trust_env=True)
+        self._session = aiohttp.ClientSession(trust_env=trust_env_for_gateway())
         self._ws = await self._session.ws_connect(
             self._ws_url,
             heartbeat=HEARTBEAT_INTERVAL_SECONDS * 2,

--- a/gateway/platforms/weixin.py
+++ b/gateway/platforms/weixin.py
@@ -65,6 +65,7 @@ from gateway.platforms.base import (
     cache_audio_from_bytes,
     cache_document_from_bytes,
     cache_image_from_bytes,
+    trust_env_for_gateway,
 )
 from hermes_constants import get_hermes_home
 from utils import atomic_json_write
@@ -121,8 +122,10 @@ def _make_ssl_connector() -> Optional["aiohttp.TCPConnector"]:
     Tencent's iLink server (``ilinkai.weixin.qq.com``) is not verifiable against
     some system CA stores (notably Homebrew's OpenSSL on macOS Apple Silicon).
     When ``certifi`` is installed, use its Mozilla CA bundle to guarantee
-    verification. Otherwise fall back to aiohttp's default (which honors
-    ``SSL_CERT_FILE`` env var via ``trust_env=True``).
+    verification. Otherwise fall back to aiohttp's default. Note that
+    ``SSL_CERT_FILE`` pickup requires ``trust_env=True``, which is now gated
+    behind ``trust_env_for_gateway()`` (off by default, see #48820) — the
+    certifi bundle above keeps verification working regardless.
     """
     try:
         import ssl
@@ -1014,7 +1017,7 @@ async def qr_login(
     if not AIOHTTP_AVAILABLE:
         raise RuntimeError("aiohttp is required for Weixin QR login")
 
-    async with aiohttp.ClientSession(trust_env=True, connector=_make_ssl_connector()) as session:
+    async with aiohttp.ClientSession(trust_env=trust_env_for_gateway(), connector=_make_ssl_connector()) as session:
         try:
             qr_resp = await _api_get(
                 session,
@@ -1283,13 +1286,13 @@ class WeixinAdapter(BasePlatformAdapter):
         except Exception as exc:
             logger.debug("[%s] Token lock unavailable (non-fatal): %s", self.name, exc)
 
-        self._poll_session = aiohttp.ClientSession(trust_env=True, connector=_make_ssl_connector())
+        self._poll_session = aiohttp.ClientSession(trust_env=trust_env_for_gateway(), connector=_make_ssl_connector())
         # Disable aiohttp's built-in ClientTimeout (total=None) to prevent
         # "Timeout context manager should be used inside a task" errors when
         # send() is invoked via asyncio.run_coroutine_threadsafe() from cron.
         # Timeout is managed externally via asyncio.wait_for() in _api_post/_api_get.
         _no_aiohttp_timeout = aiohttp.ClientTimeout(total=None, connect=None, sock_connect=None, sock_read=None)
-        self._send_session = aiohttp.ClientSession(trust_env=True, connector=_make_ssl_connector(), timeout=_no_aiohttp_timeout)
+        self._send_session = aiohttp.ClientSession(trust_env=trust_env_for_gateway(), connector=_make_ssl_connector(), timeout=_no_aiohttp_timeout)
         self._token_store.restore(self._account_id)
         self._poll_task = asyncio.create_task(self._poll_loop(), name="weixin-poll")
         self._mark_connected()
@@ -2312,7 +2315,7 @@ async def send_weixin_direct(
             "context_token_used": bool(context_token),
         }
 
-    async with aiohttp.ClientSession(trust_env=True, connector=_make_ssl_connector()) as session:
+    async with aiohttp.ClientSession(trust_env=trust_env_for_gateway(), connector=_make_ssl_connector()) as session:
         adapter = WeixinAdapter(
             PlatformConfig(
                 enabled=True,

--- a/hermes_cli/gateway_windows.py
+++ b/hermes_cli/gateway_windows.py
@@ -544,6 +544,20 @@ def _derive_venv_pythonw(python_exe: str) -> str:
     return python_exe
 
 
+def _derive_console_python(pythonw_exe: str) -> str:
+    """Inverse of ``_derive_venv_pythonw``: map ``pythonw.exe`` → ``python.exe``.
+
+    The watchdog runs as ``pythonw.exe`` (no console) but spawns the actual
+    gateway worker as ``python.exe`` so the worker's stdout/stderr can be
+    captured to ``gateway-stdio.log``. Returns the path unchanged if it isn't a
+    ``*w`` variant (e.g. already ``python.exe``, or a uv base interpreter).
+    """
+    p = Path(pythonw_exe)
+    if p.stem.endswith("w"):
+        return str(p.with_name(p.stem[:-1] + p.suffix))
+    return pythonw_exe
+
+
 def _read_pyvenv_cfg(venv_dir: Path) -> dict[str, str]:
     cfg_path = venv_dir / "pyvenv.cfg"
     try:
@@ -1498,15 +1512,26 @@ def run_watchdog(working_dir: str, argv: list[str], env_overlay: dict) -> int:
     # Derive python.exe from the watchdog's python (which is pythonw.exe so it
     # runs without a console). The worker also runs windowless via CREATE_NO_WINDOW.
     child_argv = list(argv)
-    if child_argv and child_argv[0].lower().endswith("pythonw.exe"):
-        child_argv[0] = child_argv[0][:-len("pythonw.exe")] + "python.exe"
+    if child_argv:
+        child_argv[0] = _derive_console_python(child_argv[0])
 
     _log(f"starting (pid {os.getpid()}); worker: {child_argv}")
 
     backoff = _WATCHDOG_BACKOFF_START_S
     crash_times: list[float] = []
+    _job_handle = None
 
     while True:
+        # Close the previous iteration's Job Object handle (the worker it was
+        # tied to has already exited by now). Without this, each respawn leaks
+        # one kernel job handle over the supervisor's lifetime.
+        if _job_handle:
+            try:
+                import ctypes
+                ctypes.windll.kernel32.CloseHandle(_job_handle)
+            except Exception:
+                pass
+            _job_handle = None
         started_at = _time.monotonic()
         try:
             with open(stray_log, "ab", buffering=0) as log_fh:

--- a/hermes_cli/gateway_windows.py
+++ b/hermes_cli/gateway_windows.py
@@ -29,6 +29,7 @@ Design notes
 from __future__ import annotations
 
 import ctypes
+import json
 import locale
 import os
 import re
@@ -368,13 +369,37 @@ def _build_gateway_cmd_script(
     if profile_arg:
         prog_args.extend(profile_arg.split())
     prog_args.extend(["gateway", "run"])
+
+    # Launch the gateway under a Python-native watchdog (issue #48820, Bug 1).
+    # A Logon-trigger Scheduled Task fires only once; if the worker dies
+    # (crash, network dropout, SIGINT) nothing restarts it and the gateway
+    # silently goes dark. The watchdog supervises the worker and respawns it
+    # with capped exponential backoff + a crash-loop circuit breaker.
+    env_overlay = {
+        "HERMES_HOME": hermes_home,
+        "PYTHONIOENCODING": "utf-8",
+        "HERMES_GATEWAY_DETACHED": "1",
+        "VIRTUAL_ENV": venv_dir,
+    }
+    watchdog_args = [
+        pythonw_path,
+        "-m",
+        "hermes_cli.gateway_windows",
+        "watchdog",
+        "--working-dir",
+        working_dir,
+        "--argv",
+        json.dumps(prog_args),
+        "--env",
+        json.dumps(env_overlay),
+    ]
     # `pythonw.exe` is a GUI-subsystem executable: cmd.exe launches it and
     # returns immediately, so the Scheduled Task action finishes without a
     # visible console window. Do NOT use `start` here; that creates an extra
     # wrapper process and made gateway lifecycle/status harder to reason about.
     # Do NOT use `--replace` for service-managed starts; repeated /Run calls
     # should be idempotent, not churn parent/child takeover loops.
-    lines.append(" ".join(_quote_cmd_script_arg(a) for a in prog_args))
+    lines.append(" ".join(_quote_cmd_script_arg(a) for a in watchdog_args))
     lines.append("exit /b 0")
     return "\r\n".join(lines) + "\r\n"
 
@@ -625,8 +650,26 @@ def _spawn_detached(script_path: Path | None = None) -> int:
     _assert_windows()
     argv, working_dir, env_overlay = _build_gateway_argv()
 
-    # Inherit PATH etc. from the current env, overlay our required vars.
-    env = {**os.environ, **env_overlay}
+    # Wrap the gateway argv in the watchdog supervisor (issue #48820, Bug 1)
+    # so a detached gateway started outside the Scheduled Task path
+    # (``hermes gateway start``) is also auto-restarted on crash. The watchdog
+    # itself runs pythonw (no console) and re-spawns the worker with capped
+    # backoff + crash-loop protection.
+    watchdog_argv = [
+        argv[0],
+        "-m",
+        "hermes_cli.gateway_windows",
+        "watchdog",
+        "--working-dir",
+        working_dir,
+        "--argv",
+        json.dumps(argv),
+        "--env",
+        json.dumps(env_overlay),
+    ]
+    # The watchdog re-applies ``env_overlay`` onto its own environment before
+    # spawning the worker, so we only need to pass the current process env here.
+    env = dict(os.environ)
 
     # DETACHED_PROCESS        0x00000008  — no console attached to child
     # CREATE_NEW_PROCESS_GROUP 0x00000200 — child gets its own group, won't
@@ -652,7 +695,7 @@ def _spawn_detached(script_path: Path | None = None) -> int:
     try:
         with open(stray_log, "ab", buffering=0) as log_fh:
             proc = subprocess.Popen(
-                argv,
+                watchdog_argv,
                 cwd=working_dir,
                 env=env,
                 creationflags=flags,
@@ -669,7 +712,7 @@ def _spawn_detached(script_path: Path | None = None) -> int:
         flags_no_breakaway = flags & ~0x01000000
         with open(stray_log, "ab", buffering=0) as log_fh:
             proc = subprocess.Popen(
-                argv,
+                watchdog_argv,
                 cwd=working_dir,
                 env=env,
                 creationflags=flags_no_breakaway,
@@ -1309,3 +1352,253 @@ def restart() -> None:
     # Give Windows a moment to release the listening port.
     time.sleep(1.0)
     start()
+
+
+# ── Windows gateway watchdog (issue #48820, Bug 1) ────────────────────────────
+#
+# A Logon-trigger Scheduled Task fires once at login. If the gateway worker
+# dies (crash, network dropout, SIGINT from a GUI healthcheck), nothing
+# restarts it and inbound messages silently stop. This watchdog supervises the
+# worker the way systemd's ``Restart=`` + ``RestartForceExitStatus=75`` does on
+# Linux: respawn on unexpected exit, stop on a clean exit, respawn immediately
+# on a service-restart request (exit code 75), with capped exponential backoff
+# and a crash-loop circuit breaker so a permanently-broken worker (bad config,
+# port taken) surfaces an error instead of spinning forever.
+
+# Backoff / circuit-breaker tuning. Mirrors systemd defaults
+# (StartLimitIntervalSec=10s window, StartLimitBurst=5) and Kubernetes-style
+# capped exponential backoff.
+_WATCHDOG_BACKOFF_START_S = 1.0
+_WATCHDOG_BACKOFF_CAP_S = 60.0
+_WATCHDOG_HEALTHY_RUN_S = 60.0   # a run this long resets the backoff/burst counter
+_WATCHDOG_BURST_LIMIT = 5        # >N crashes inside the window → give up
+_WATCHDOG_BURST_WINDOW_S = 60.0
+_WATCHDOG_LOG_MAX_BYTES = 5 * 1024 * 1024  # rotate gateway-stdio.log past this
+
+
+def _watchdog_assign_job_object(pid: int):
+    """Best-effort: put *pid* in a Job Object that kills children on close.
+
+    Windows has no Unix process tree; orphaned worker children (and the worker
+    itself if the watchdog is killed) would otherwise leak. A Job Object with
+    ``JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE`` ties the worker's lifetime to the
+    watchdog. Returns the job handle (kept alive by the caller) or None.
+    """
+    try:
+        import ctypes
+        from ctypes import wintypes
+
+        kernel32 = ctypes.windll.kernel32
+        job = kernel32.CreateJobObjectW(None, None)
+        if not job:
+            return None
+
+        # JOBOBJECT_EXTENDED_LIMIT_INFORMATION with KILL_ON_JOB_CLOSE (0x2000).
+        class _JOBOBJECT_BASIC_LIMIT_INFORMATION(ctypes.Structure):
+            _fields_ = [
+                ("PerProcessUserTimeLimit", wintypes.LARGE_INTEGER),
+                ("PerJobUserTimeLimit", wintypes.LARGE_INTEGER),
+                ("LimitFlags", wintypes.DWORD),
+                ("MinimumWorkingSetSize", ctypes.c_size_t),
+                ("MaximumWorkingSetSize", ctypes.c_size_t),
+                ("ActiveProcessLimit", wintypes.DWORD),
+                ("Affinity", ctypes.POINTER(wintypes.ULONG)),
+                ("PriorityClass", wintypes.DWORD),
+                ("SchedulingClass", wintypes.DWORD),
+            ]
+
+        class _IO_COUNTERS(ctypes.Structure):
+            _fields_ = [(n, ctypes.c_ulonglong) for n in (
+                "ReadOperationCount", "WriteOperationCount", "OtherOperationCount",
+                "ReadTransferCount", "WriteTransferCount", "OtherTransferCount")]
+
+        class _JOBOBJECT_EXTENDED_LIMIT_INFORMATION(ctypes.Structure):
+            _fields_ = [
+                ("BasicLimitInformation", _JOBOBJECT_BASIC_LIMIT_INFORMATION),
+                ("IoInfo", _IO_COUNTERS),
+                ("ProcessMemoryLimit", ctypes.c_size_t),
+                ("JobMemoryLimit", ctypes.c_size_t),
+                ("PeakProcessMemoryUsed", ctypes.c_size_t),
+                ("PeakJobMemoryUsed", ctypes.c_size_t),
+            ]
+
+        info = _JOBOBJECT_EXTENDED_LIMIT_INFORMATION()
+        info.BasicLimitInformation.LimitFlags = 0x2000  # KILL_ON_JOB_CLOSE
+        if not kernel32.SetInformationJobObject(
+            job, 9, ctypes.byref(info), ctypes.sizeof(info)
+        ):  # 9 = JobObjectExtendedLimitInformation
+            kernel32.CloseHandle(job)
+            return None
+
+        PROCESS_SET_QUOTA = 0x0100
+        PROCESS_TERMINATE = 0x0001
+        handle = kernel32.OpenProcess(PROCESS_SET_QUOTA | PROCESS_TERMINATE, False, pid)
+        if not handle:
+            kernel32.CloseHandle(job)
+            return None
+        ok = kernel32.AssignProcessToJobObject(job, handle)
+        kernel32.CloseHandle(handle)
+        if not ok:
+            kernel32.CloseHandle(job)
+            return None
+        return job
+    except Exception:
+        return None
+
+
+def run_watchdog(working_dir: str, argv: list[str], env_overlay: dict) -> int:
+    """Supervise the gateway worker, respawning it on unexpected exit.
+
+    Returns the process exit code to propagate (0 on clean stop / give-up).
+    """
+    import time as _time
+
+    env = {**os.environ, **(env_overlay or {})}
+    hermes_home = env.get("HERMES_HOME")
+    if not hermes_home:
+        try:
+            from hermes_cli.config import get_hermes_home
+            hermes_home = str(get_hermes_home())
+        except Exception:
+            hermes_home = str(Path.home() / ".hermes")
+
+    log_dir = Path(hermes_home) / "logs"
+    try:
+        log_dir.mkdir(parents=True, exist_ok=True)
+    except Exception:
+        pass
+    stray_log = log_dir / "gateway-stdio.log"
+
+    try:
+        from gateway.restart import GATEWAY_SERVICE_RESTART_EXIT_CODE
+    except Exception:
+        GATEWAY_SERVICE_RESTART_EXIT_CODE = 75
+
+    def _log(message: str) -> None:
+        ts = _time.strftime("%Y-%m-%d %H:%M:%S")
+        line = f"[{ts}] [watchdog] {message}\n"
+        try:
+            sys.stdout.write(line)
+            sys.stdout.flush()
+        except Exception:
+            pass
+        try:
+            # Bounded log: rotate once it grows past the cap so a crash loop
+            # can't fill the disk.
+            if stray_log.exists() and stray_log.stat().st_size > _WATCHDOG_LOG_MAX_BYTES:
+                try:
+                    stray_log.replace(stray_log.with_suffix(".log.1"))
+                except Exception:
+                    pass
+            with open(stray_log, "a", encoding="utf-8") as fh:
+                fh.write(line)
+        except Exception:
+            pass
+
+    # Derive python.exe from the watchdog's python (which is pythonw.exe so it
+    # runs without a console). The worker also runs windowless via CREATE_NO_WINDOW.
+    child_argv = list(argv)
+    if child_argv and child_argv[0].lower().endswith("pythonw.exe"):
+        child_argv[0] = child_argv[0][:-len("pythonw.exe")] + "python.exe"
+
+    _log(f"starting (pid {os.getpid()}); worker: {child_argv}")
+
+    backoff = _WATCHDOG_BACKOFF_START_S
+    crash_times: list[float] = []
+
+    while True:
+        started_at = _time.monotonic()
+        try:
+            with open(stray_log, "ab", buffering=0) as log_fh:
+                proc = subprocess.Popen(
+                    child_argv,
+                    cwd=working_dir,
+                    env=env,
+                    creationflags=0x08000000,  # CREATE_NO_WINDOW
+                    close_fds=True,
+                    stdin=subprocess.DEVNULL,
+                    stdout=log_fh,
+                    stderr=log_fh,
+                )
+        except Exception as exc:  # pragma: no cover - spawn failure
+            _log(f"failed to spawn worker: {exc}; retrying in {backoff:.0f}s")
+            _time.sleep(backoff)
+            backoff = min(backoff * 2, _WATCHDOG_BACKOFF_CAP_S)
+            continue
+
+        # Tie the worker (and its children) to a kill-on-close Job Object so
+        # nothing leaks if the watchdog itself is terminated.
+        _job_handle = _watchdog_assign_job_object(proc.pid)
+        _log(f"spawned worker (pid {proc.pid})")
+
+        try:
+            exit_code = proc.wait()
+        except KeyboardInterrupt:
+            _log("interrupted; terminating worker and exiting")
+            try:
+                proc.terminate()
+            except Exception:
+                pass
+            return 0
+
+        ran_for = _time.monotonic() - started_at
+
+        if exit_code == 0:
+            _log("worker exited cleanly (0); watchdog stopping")
+            return 0
+        if exit_code == GATEWAY_SERVICE_RESTART_EXIT_CODE:
+            _log(f"worker requested restart ({exit_code}); respawning now")
+            backoff = _WATCHDOG_BACKOFF_START_S
+            crash_times.clear()
+            continue
+
+        # Unexpected exit. A run that lasted long enough is treated as healthy:
+        # reset backoff and the crash-burst counter.
+        if ran_for >= _WATCHDOG_HEALTHY_RUN_S:
+            backoff = _WATCHDOG_BACKOFF_START_S
+            crash_times.clear()
+
+        now = _time.monotonic()
+        crash_times.append(now)
+        crash_times[:] = [t for t in crash_times if now - t <= _WATCHDOG_BURST_WINDOW_S]
+        if len(crash_times) > _WATCHDOG_BURST_LIMIT:
+            _log(
+                f"worker crashed {len(crash_times)} times within "
+                f"{_WATCHDOG_BURST_WINDOW_S:.0f}s (last exit {exit_code}); "
+                "giving up. Fix the underlying error (check gateway.log) and "
+                "restart with `hermes gateway restart`."
+            )
+            return exit_code if exit_code else 1
+
+        _log(f"worker exited with {exit_code} after {ran_for:.0f}s; respawning in {backoff:.0f}s")
+        _time.sleep(backoff)
+        backoff = min(backoff * 2, _WATCHDOG_BACKOFF_CAP_S)
+
+
+def _watchdog_main(raw_args: list[str]) -> int:
+    import argparse
+
+    parser = argparse.ArgumentParser(prog="hermes_cli.gateway_windows watchdog")
+    parser.add_argument("command", choices=["watchdog"])
+    parser.add_argument("--working-dir", required=True)
+    parser.add_argument("--argv", required=True, help="JSON-encoded worker argv")
+    parser.add_argument("--env", required=True, help="JSON-encoded env overlay")
+    args = parser.parse_args(raw_args)
+
+    try:
+        worker_argv = json.loads(args.argv)
+        env_overlay = json.loads(args.env)
+    except Exception as exc:
+        print(f"watchdog: invalid arguments: {exc}", file=sys.stderr)
+        return 2
+    if not isinstance(worker_argv, list) or not worker_argv:
+        print("watchdog: --argv must be a non-empty JSON list", file=sys.stderr)
+        return 2
+    if not isinstance(env_overlay, dict):
+        env_overlay = {}
+    return run_watchdog(args.working_dir, worker_argv, env_overlay)
+
+
+if __name__ == "__main__":
+    if len(sys.argv) > 1 and sys.argv[1] == "watchdog":
+        raise SystemExit(_watchdog_main(sys.argv[1:]))

--- a/plugins/platforms/google_chat/adapter.py
+++ b/plugins/platforms/google_chat/adapter.py
@@ -138,6 +138,7 @@ from gateway.platforms.base import (
     cache_document_from_bytes,
     cache_image_from_bytes,
     cache_video_from_bytes,
+    trust_env_for_gateway,
 )
 
 
@@ -3252,7 +3253,7 @@ async def _standalone_send(
         return {"error": "Google Chat standalone send: aiohttp not installed"}
 
     try:
-        async with _aiohttp.ClientSession(timeout=_aiohttp.ClientTimeout(total=30.0), trust_env=True) as session:
+        async with _aiohttp.ClientSession(timeout=_aiohttp.ClientTimeout(total=30.0), trust_env=trust_env_for_gateway()) as session:
             async with session.post(
                 url,
                 json=body,

--- a/plugins/platforms/line/adapter.py
+++ b/plugins/platforms/line/adapter.py
@@ -93,6 +93,7 @@ from gateway.platforms.base import (
     MessageType,
     SendResult,
     cache_image_from_bytes,
+    trust_env_for_gateway,
 )
 from gateway.config import Platform
 
@@ -461,7 +462,7 @@ class _LineClient:
     async def reply(self, reply_token: str, messages: List[Dict[str, Any]]) -> None:
         import aiohttp
         timeout = aiohttp.ClientTimeout(total=self._timeout)
-        async with aiohttp.ClientSession(timeout=timeout, trust_env=True) as session:
+        async with aiohttp.ClientSession(timeout=timeout, trust_env=trust_env_for_gateway()) as session:
             async with session.post(
                 LINE_REPLY_URL,
                 headers=self._headers,
@@ -474,7 +475,7 @@ class _LineClient:
     async def push(self, chat_id: str, messages: List[Dict[str, Any]]) -> None:
         import aiohttp
         timeout = aiohttp.ClientTimeout(total=self._timeout)
-        async with aiohttp.ClientSession(timeout=timeout, trust_env=True) as session:
+        async with aiohttp.ClientSession(timeout=timeout, trust_env=trust_env_for_gateway()) as session:
             async with session.post(
                 LINE_PUSH_URL,
                 headers=self._headers,
@@ -493,7 +494,7 @@ class _LineClient:
         clamped = max(5, min(60, (seconds // 5) * 5 or 5))
         try:
             timeout = aiohttp.ClientTimeout(total=5.0)
-            async with aiohttp.ClientSession(timeout=timeout, trust_env=True) as session:
+            async with aiohttp.ClientSession(timeout=timeout, trust_env=trust_env_for_gateway()) as session:
                 await session.post(
                     LINE_LOADING_URL,
                     headers=self._headers,
@@ -507,7 +508,7 @@ class _LineClient:
         import aiohttp
         url = LINE_CONTENT_URL_FMT.format(message_id=message_id)
         timeout = aiohttp.ClientTimeout(total=30.0)
-        async with aiohttp.ClientSession(timeout=timeout, trust_env=True) as session:
+        async with aiohttp.ClientSession(timeout=timeout, trust_env=trust_env_for_gateway()) as session:
             async with session.get(url, headers={"Authorization": f"Bearer {self._token}"}) as resp:
                 if resp.status >= 400:
                     raise RuntimeError(f"LINE content {resp.status}")
@@ -518,7 +519,7 @@ class _LineClient:
         import aiohttp
         timeout = aiohttp.ClientTimeout(total=10.0)
         try:
-            async with aiohttp.ClientSession(timeout=timeout, trust_env=True) as session:
+            async with aiohttp.ClientSession(timeout=timeout, trust_env=trust_env_for_gateway()) as session:
                 async with session.get(LINE_BOT_INFO_URL, headers=self._headers) as resp:
                     if resp.status >= 400:
                         return None

--- a/plugins/platforms/teams/adapter.py
+++ b/plugins/platforms/teams/adapter.py
@@ -97,6 +97,7 @@ from gateway.platforms.base import (
     SendResult,
     cache_image_from_url,
     cache_media_bytes,
+    trust_env_for_gateway,
 )
 
 logger = logging.getLogger(__name__)
@@ -567,7 +568,7 @@ async def _standalone_send(
         # Per-request timeouts so a slow STS endpoint cannot starve the
         # subsequent activity POST of its budget.
         per_request_timeout = _aiohttp.ClientTimeout(total=15.0)
-        async with _aiohttp.ClientSession(trust_env=True) as session:
+        async with _aiohttp.ClientSession(trust_env=trust_env_for_gateway()) as session:
             async with session.post(
                 token_url,
                 data={

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -47,6 +47,7 @@ ACP_REGISTRY_MANIFEST = REPO_ROOT / "acp_registry" / "agent.json"
 AUTHOR_MAP = {
     "victor@rocketfueldev.com": "victor-kyriazakos",
     "87440198+JoaoMarcos44@users.noreply.github.com": "JoaoMarcos44",
+    "joaomarcosdias444@gmail.com": "JoaoMarcos44",
     "286497132+srojk34@users.noreply.github.com": "srojk34",
     "59806492+sitkarev@users.noreply.github.com": "sitkarev",
     "zheng@omegasys.eu": "omegazheng",

--- a/tests/gateway/test_matrix.py
+++ b/tests/gateway/test_matrix.py
@@ -4308,9 +4308,21 @@ class TestMatrixProxyConfig:
         assert adapter._proxy_url == "socks5://proxy:1080"
 
     def test_generic_proxy_fallback(self, monkeypatch):
+        # Generic env proxy inheritance is gated off by default (#48820 Bug 3);
+        # opt in so the fallback path is exercised.
+        monkeypatch.setenv("GATEWAY_TRUST_PROXY", "true")
         adapter = self._make_adapter(monkeypatch,
                                      proxy_env={"HTTPS_PROXY": "http://corp:8080"})
         assert adapter._proxy_url == "http://corp:8080"
+
+    def test_generic_proxy_ignored_without_optin(self, monkeypatch):
+        # Without opt-in, an inherited HTTPS_PROXY must NOT be picked up — this
+        # is the core of the Windows Scheduled Task misroute fix (#48820).
+        monkeypatch.delenv("GATEWAY_TRUST_PROXY", raising=False)
+        monkeypatch.delenv("GATEWAY_TRUST_ENV", raising=False)
+        adapter = self._make_adapter(monkeypatch,
+                                     proxy_env={"HTTPS_PROXY": "http://corp:8080"})
+        assert adapter._proxy_url is None
 
     def test_matrix_proxy_takes_priority(self, monkeypatch):
         adapter = self._make_adapter(monkeypatch,
@@ -4323,7 +4335,23 @@ class TestCreateMatrixSession:
     """Verify _create_matrix_session applies proxy at the session level."""
 
     @pytest.mark.asyncio
-    async def test_no_proxy_returns_trust_env_session(self):
+    async def test_no_proxy_returns_gated_trust_env_session(self, monkeypatch):
+        # trust_env now defaults OFF (#48820 Bug 3) so a Windows Scheduled Task
+        # can't inherit a stray HTTP_PROXY. It only flips on with an explicit
+        # opt-in.
+        monkeypatch.delenv("GATEWAY_TRUST_PROXY", raising=False)
+        monkeypatch.delenv("GATEWAY_TRUST_ENV", raising=False)
+        with patch.dict("sys.modules", _make_fake_mautrix()):
+            from gateway.platforms.matrix import _create_matrix_session
+            session = _create_matrix_session(None)
+            try:
+                assert session.trust_env is False
+            finally:
+                await session.close()
+
+    @pytest.mark.asyncio
+    async def test_no_proxy_trust_env_optin(self, monkeypatch):
+        monkeypatch.setenv("GATEWAY_TRUST_PROXY", "true")
         with patch.dict("sys.modules", _make_fake_mautrix()):
             from gateway.platforms.matrix import _create_matrix_session
             session = _create_matrix_session(None)

--- a/tests/gateway/test_proxy_mode.py
+++ b/tests/gateway/test_proxy_mode.py
@@ -136,6 +136,7 @@ class TestResolveProxyUrl:
         for key in ("HTTPS_PROXY", "HTTP_PROXY", "ALL_PROXY",
                     "https_proxy", "http_proxy", "all_proxy", "NO_PROXY", "no_proxy"):
             monkeypatch.delenv(key, raising=False)
+        monkeypatch.setenv("GATEWAY_TRUST_PROXY", "true")  # opt in to env proxy (#48820)
         monkeypatch.setenv("ALL_PROXY", "socks://127.0.0.1:1080/")
         assert resolve_proxy_url() == "socks5://127.0.0.1:1080/"
 
@@ -143,6 +144,7 @@ class TestResolveProxyUrl:
         for key in ("HTTPS_PROXY", "HTTP_PROXY", "ALL_PROXY",
                     "https_proxy", "http_proxy", "all_proxy", "NO_PROXY", "no_proxy"):
             monkeypatch.delenv(key, raising=False)
+        monkeypatch.setenv("GATEWAY_TRUST_PROXY", "true")  # opt in to env proxy (#48820)
         monkeypatch.setenv("HTTPS_PROXY", "http://proxy.example:8080")
         monkeypatch.setenv("NO_PROXY", "api.telegram.org")
 
@@ -152,6 +154,7 @@ class TestResolveProxyUrl:
         for key in ("HTTPS_PROXY", "HTTP_PROXY", "ALL_PROXY",
                     "https_proxy", "http_proxy", "all_proxy", "NO_PROXY", "no_proxy"):
             monkeypatch.delenv(key, raising=False)
+        monkeypatch.setenv("GATEWAY_TRUST_PROXY", "true")  # opt in to env proxy (#48820)
         monkeypatch.setenv("HTTPS_PROXY", "http://proxy.example:8080")
         monkeypatch.setenv("NO_PROXY", "149.154.160.0/20")
 
@@ -161,6 +164,7 @@ class TestResolveProxyUrl:
         for key in ("HTTPS_PROXY", "HTTP_PROXY", "ALL_PROXY",
                     "https_proxy", "http_proxy", "all_proxy", "NO_PROXY", "no_proxy"):
             monkeypatch.delenv(key, raising=False)
+        monkeypatch.setenv("GATEWAY_TRUST_PROXY", "true")  # opt in to env proxy (#48820)
         monkeypatch.setenv("HTTPS_PROXY", "http://proxy.example:8080")
         monkeypatch.setenv("NO_PROXY", "*")
 

--- a/tests/gateway/test_qqbot.py
+++ b/tests/gateway/test_qqbot.py
@@ -209,6 +209,7 @@ class TestQQWebSocketProxy:
             "all_proxy",
         ):
             monkeypatch.delenv(key, raising=False)
+        monkeypatch.setenv("GATEWAY_TRUST_PROXY", "true")  # opt in to env proxy (#48820)
         monkeypatch.setenv("HTTPS_PROXY", "http://127.0.0.1:7897")
 
         adapter = QQAdapter(_make_config(app_id="a", client_secret="b"))
@@ -233,6 +234,64 @@ class TestQQWebSocketProxy:
 
         assert seen_session_kwargs.get("trust_env") is True
         assert seen_ws_kwargs.get("proxy") == "http://127.0.0.1:7897"
+
+    @pytest.mark.asyncio
+    async def test_open_ws_ignores_inherited_proxy_without_optin(self, monkeypatch):
+        """Inherited HTTPS_PROXY must NOT route the WS unless opted in (#48820)."""
+        from gateway.platforms.qqbot import QQAdapter
+
+        for key in ("WSS_PROXY", "wss_proxy", "HTTPS_PROXY", "https_proxy",
+                    "ALL_PROXY", "all_proxy", "GATEWAY_TRUST_PROXY", "GATEWAY_TRUST_ENV"):
+            monkeypatch.delenv(key, raising=False)
+        monkeypatch.setenv("HTTPS_PROXY", "http://127.0.0.1:7897")
+
+        adapter = QQAdapter(_make_config(app_id="a", client_secret="b"))
+        seen_ws_kwargs = {}
+
+        class FakeSession:
+            def __init__(self, **kwargs):
+                self.closed = False
+
+            async def close(self):
+                self.closed = True
+
+            async def ws_connect(self, *args, **kwargs):
+                seen_ws_kwargs.update(kwargs)
+                return mock.AsyncMock(closed=False)
+
+        with mock.patch("gateway.platforms.qqbot.adapter.aiohttp.ClientSession", side_effect=FakeSession):
+            await adapter._open_ws("wss://api.sgroup.qq.com/websocket")
+
+        assert seen_ws_kwargs.get("proxy") is None
+
+    @pytest.mark.asyncio
+    async def test_open_ws_explicit_wss_proxy_always_honored(self, monkeypatch):
+        """An explicit WSS_PROXY is a deliberate choice — honored without opt-in."""
+        from gateway.platforms.qqbot import QQAdapter
+
+        for key in ("HTTPS_PROXY", "https_proxy", "ALL_PROXY", "all_proxy",
+                    "GATEWAY_TRUST_PROXY", "GATEWAY_TRUST_ENV"):
+            monkeypatch.delenv(key, raising=False)
+        monkeypatch.setenv("WSS_PROXY", "http://127.0.0.1:1080")
+
+        adapter = QQAdapter(_make_config(app_id="a", client_secret="b"))
+        seen_ws_kwargs = {}
+
+        class FakeSession:
+            def __init__(self, **kwargs):
+                self.closed = False
+
+            async def close(self):
+                self.closed = True
+
+            async def ws_connect(self, *args, **kwargs):
+                seen_ws_kwargs.update(kwargs)
+                return mock.AsyncMock(closed=False)
+
+        with mock.patch("gateway.platforms.qqbot.adapter.aiohttp.ClientSession", side_effect=FakeSession):
+            await adapter._open_ws("wss://api.sgroup.qq.com/websocket")
+
+        assert seen_ws_kwargs.get("proxy") == "http://127.0.0.1:1080"
 
 # ---------------------------------------------------------------------------
 # _strip_at_mention

--- a/tests/gateway/test_telegram_network.py
+++ b/tests/gateway/test_telegram_network.py
@@ -326,6 +326,7 @@ class TestFallbackTransportInit:
 
         for key in ("HTTPS_PROXY", "HTTP_PROXY", "ALL_PROXY", "https_proxy", "http_proxy", "all_proxy", "TELEGRAM_PROXY", "NO_PROXY", "no_proxy"):
             monkeypatch.delenv(key, raising=False)
+        monkeypatch.setenv("GATEWAY_TRUST_PROXY", "true")  # opt in to env proxy (#48820)
         monkeypatch.setenv("HTTPS_PROXY", "http://proxy.example:8080")
         monkeypatch.setattr(tnet.httpx, "AsyncHTTPTransport", factory)
 
@@ -334,6 +335,25 @@ class TestFallbackTransportInit:
         assert transport._fallback_ips == ["149.154.167.220"]
         assert len(seen_kwargs) == 2
         assert all(kwargs["proxy"] == "http://proxy.example:8080" for kwargs in seen_kwargs)
+
+    def test_inherited_proxy_ignored_without_optin(self, monkeypatch):
+        # #48820 Bug 3: an inherited HTTPS_PROXY must NOT be used unless opted
+        # in — the core of the Windows Scheduled Task misroute fix.
+        seen_kwargs = []
+
+        def factory(**kwargs):
+            seen_kwargs.append(kwargs.copy())
+            return FakeTransport([], {})
+
+        for key in ("HTTPS_PROXY", "HTTP_PROXY", "ALL_PROXY", "https_proxy", "http_proxy", "all_proxy", "TELEGRAM_PROXY", "NO_PROXY", "no_proxy", "GATEWAY_TRUST_PROXY", "GATEWAY_TRUST_ENV"):
+            monkeypatch.delenv(key, raising=False)
+        monkeypatch.setenv("HTTPS_PROXY", "http://proxy.example:8080")
+        monkeypatch.setattr(tnet.httpx, "AsyncHTTPTransport", factory)
+
+        transport = tnet.TelegramFallbackTransport(["149.154.167.220"])
+
+        assert transport._fallback_ips == ["149.154.167.220"]
+        assert all("proxy" not in kwargs for kwargs in seen_kwargs)
 
     def test_no_proxy_bypasses_fallback_ip_cidr(self, monkeypatch):
         seen_kwargs = []
@@ -344,6 +364,7 @@ class TestFallbackTransportInit:
 
         for key in ("HTTPS_PROXY", "HTTP_PROXY", "ALL_PROXY", "https_proxy", "http_proxy", "all_proxy", "TELEGRAM_PROXY", "NO_PROXY", "no_proxy"):
             monkeypatch.delenv(key, raising=False)
+        monkeypatch.setenv("GATEWAY_TRUST_PROXY", "true")  # opt in so the NO_PROXY bypass path is exercised (#48820)
         monkeypatch.setenv("HTTPS_PROXY", "http://proxy.example:8080")
         monkeypatch.setenv("NO_PROXY", "149.154.160.0/20")
         monkeypatch.setattr(tnet.httpx, "AsyncHTTPTransport", factory)

--- a/tests/gateway/test_windows_gateway_fixes_48820.py
+++ b/tests/gateway/test_windows_gateway_fixes_48820.py
@@ -21,6 +21,16 @@ from gateway.platforms import base as base_mod
 from gateway.platforms.base import resolve_proxy_url, trust_env_for_gateway
 
 
+@pytest.fixture(autouse=True)
+def _clear_trust_proxy_cache():
+    """trust_env_for_gateway() caches the config read; clear it around each
+    test so config-patching tests don't leak state to (or from) others."""
+    from gateway.platforms.base import _config_trust_proxy
+    _config_trust_proxy.cache_clear()
+    yield
+    _config_trust_proxy.cache_clear()
+
+
 # ---------------------------------------------------------------------------
 # Bug 2 — explicit enabled: false wins over env vars (all platforms)
 # ---------------------------------------------------------------------------
@@ -96,13 +106,17 @@ class TestProxyTrustGating:
         self._clear(monkeypatch)
         monkeypatch.setenv("HTTPS_PROXY", "http://127.0.0.1:7890")
 
-        # trust_env_for_gateway imports load_gateway_config lazily from
-        # gateway.config, so patch it there.
+        # _config_trust_proxy is lru_cached; clear it so the patch takes effect.
+        from gateway.platforms.base import _config_trust_proxy
+        _config_trust_proxy.cache_clear()
         import gateway.config as gw_config
         monkeypatch.setattr(gw_config, "load_gateway_config",
                             lambda: GatewayConfig(trust_proxy=True))
-        assert trust_env_for_gateway() is True
-        assert resolve_proxy_url() == "http://127.0.0.1:7890"
+        try:
+            assert trust_env_for_gateway() is True
+            assert resolve_proxy_url() == "http://127.0.0.1:7890"
+        finally:
+            _config_trust_proxy.cache_clear()
 
     def test_explicit_platform_proxy_var_always_honored(self, monkeypatch):
         """Explicit per-platform proxy vars bypass the gate — they are a
@@ -112,15 +126,18 @@ class TestProxyTrustGating:
         # No GATEWAY_TRUST_* opt-in, yet the explicit var is honored.
         assert resolve_proxy_url("DISCORD_PROXY") == "http://127.0.0.1:1080"
 
-    def test_config_roundtrip_includes_trust_flags(self):
-        cfg = GatewayConfig(trust_proxy=True, trust_env=True)
+    def test_config_roundtrip_preserves_trust_proxy(self):
+        cfg = GatewayConfig(trust_proxy=True)
         restored = GatewayConfig.from_dict(cfg.to_dict())
         assert restored.trust_proxy is True
-        assert restored.trust_env is True
+
+    def test_legacy_trust_env_alias_maps_to_trust_proxy(self):
+        # Back-compat: a config that wrote the old ``trust_env`` key still opts in.
+        restored = GatewayConfig.from_dict({"trust_env": True})
+        assert restored.trust_proxy is True
 
     def test_trust_flags_default_false(self):
         assert GatewayConfig().trust_proxy is False
-        assert GatewayConfig().trust_env is False
 
 
 # ---------------------------------------------------------------------------

--- a/tests/gateway/test_windows_gateway_fixes_48820.py
+++ b/tests/gateway/test_windows_gateway_fixes_48820.py
@@ -1,0 +1,239 @@
+"""Regression tests for the three Windows gateway fixes (issue #48820).
+
+Bug 2: ``platforms.<x>.enabled: false`` in config.yaml must win over a
+       matching env var (the env var must NOT force-enable the platform).
+Bug 3: gateway HTTP clients must not inherit ``HTTP_PROXY``/``HTTPS_PROXY``
+       from the process environment unless explicitly opted in
+       (``trust_env_for_gateway()`` / ``resolve_proxy_url`` gating).
+Bug 1: the Windows watchdog must respawn the worker with capped backoff,
+       a crash-loop circuit breaker, and exit-code handling (0 = stop,
+       75 = restart now).
+"""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from gateway.config import GatewayConfig, Platform, PlatformConfig, _apply_env_overrides
+from gateway.platforms import base as base_mod
+from gateway.platforms.base import resolve_proxy_url, trust_env_for_gateway
+
+
+# ---------------------------------------------------------------------------
+# Bug 2 — explicit enabled: false wins over env vars (all platforms)
+# ---------------------------------------------------------------------------
+class TestEnabledFalseWinsOverEnv:
+    def test_explicit_disable_blocks_env_enable(self, monkeypatch, caplog):
+        """A platform marked enabled: false in YAML stays disabled even when
+        its env token is present; the credential is still stored."""
+        monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "env-token")
+        config = GatewayConfig(
+            platforms={
+                Platform.TELEGRAM: PlatformConfig(
+                    enabled=False, extra={"_enabled_explicit": True}
+                ),
+            },
+        )
+        with caplog.at_level(logging.WARNING):
+            _apply_env_overrides(config)
+
+        tg = config.platforms[Platform.TELEGRAM]
+        assert tg.enabled is False
+        # Token still stored so skills can use it without the adapter running.
+        assert tg.token == "env-token"
+        assert any("remains" in r.message and "disabled" in r.message
+                   for r in caplog.records)
+
+    def test_env_enables_when_not_explicitly_disabled(self, monkeypatch):
+        """Without an explicit disable marker, the env token enables it."""
+        monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "env-token")
+        config = GatewayConfig(platforms={})
+        _apply_env_overrides(config)
+        assert config.platforms[Platform.TELEGRAM].enabled is True
+
+    def test_explicit_disable_blocks_env_enable_non_slack(self, monkeypatch):
+        """Bug 2 was previously Slack-only; verify it now holds for an
+        arbitrary other platform (Home Assistant)."""
+        monkeypatch.setenv("HASS_TOKEN", "hass-tok")
+        config = GatewayConfig(
+            platforms={
+                Platform.HOMEASSISTANT: PlatformConfig(
+                    enabled=False, extra={"_enabled_explicit": True}
+                ),
+            },
+        )
+        _apply_env_overrides(config)
+        assert config.platforms[Platform.HOMEASSISTANT].enabled is False
+
+
+# ---------------------------------------------------------------------------
+# Bug 3 — proxy env inheritance is gated (default off)
+# ---------------------------------------------------------------------------
+class TestProxyTrustGating:
+    def _clear(self, monkeypatch):
+        for k in ("HTTPS_PROXY", "HTTP_PROXY", "ALL_PROXY", "https_proxy",
+                  "http_proxy", "all_proxy", "GATEWAY_TRUST_PROXY",
+                  "GATEWAY_TRUST_ENV", "NO_PROXY", "no_proxy"):
+            monkeypatch.delenv(k, raising=False)
+
+    def test_generic_env_proxy_ignored_by_default(self, monkeypatch):
+        self._clear(monkeypatch)
+        monkeypatch.setenv("HTTPS_PROXY", "http://127.0.0.1:7890")
+        # No opt-in → must not return the inherited proxy.
+        assert resolve_proxy_url() is None
+        assert trust_env_for_gateway() is False
+
+    def test_env_optin_restores_proxy(self, monkeypatch):
+        self._clear(monkeypatch)
+        monkeypatch.setenv("HTTPS_PROXY", "http://127.0.0.1:7890")
+        monkeypatch.setenv("GATEWAY_TRUST_PROXY", "true")
+        assert trust_env_for_gateway() is True
+        assert resolve_proxy_url() == "http://127.0.0.1:7890"
+
+    def test_config_optin_restores_proxy(self, monkeypatch):
+        self._clear(monkeypatch)
+        monkeypatch.setenv("HTTPS_PROXY", "http://127.0.0.1:7890")
+
+        # trust_env_for_gateway imports load_gateway_config lazily from
+        # gateway.config, so patch it there.
+        import gateway.config as gw_config
+        monkeypatch.setattr(gw_config, "load_gateway_config",
+                            lambda: GatewayConfig(trust_proxy=True))
+        assert trust_env_for_gateway() is True
+        assert resolve_proxy_url() == "http://127.0.0.1:7890"
+
+    def test_explicit_platform_proxy_var_always_honored(self, monkeypatch):
+        """Explicit per-platform proxy vars bypass the gate — they are a
+        deliberate user choice, not implicit inheritance."""
+        self._clear(monkeypatch)
+        monkeypatch.setenv("DISCORD_PROXY", "http://127.0.0.1:1080")
+        # No GATEWAY_TRUST_* opt-in, yet the explicit var is honored.
+        assert resolve_proxy_url("DISCORD_PROXY") == "http://127.0.0.1:1080"
+
+    def test_config_roundtrip_includes_trust_flags(self):
+        cfg = GatewayConfig(trust_proxy=True, trust_env=True)
+        restored = GatewayConfig.from_dict(cfg.to_dict())
+        assert restored.trust_proxy is True
+        assert restored.trust_env is True
+
+    def test_trust_flags_default_false(self):
+        assert GatewayConfig().trust_proxy is False
+        assert GatewayConfig().trust_env is False
+
+
+# ---------------------------------------------------------------------------
+# Bug 1 — Windows watchdog supervision logic
+# ---------------------------------------------------------------------------
+class _FakeProc:
+    def __init__(self, exit_code, pid=4321):
+        self._exit_code = exit_code
+        self.pid = pid
+
+    def wait(self):
+        return self._exit_code
+
+    def terminate(self):
+        pass
+
+
+class TestWatchdog:
+    def _patch_common(self, monkeypatch, tmp_path):
+        from hermes_cli import gateway_windows as gw
+
+        monkeypatch.setattr(gw, "_watchdog_assign_job_object", lambda pid: None)
+        sleeps: list[float] = []
+        monkeypatch.setattr(gw.time, "sleep", lambda s: sleeps.append(s))
+        return gw, sleeps
+
+    def test_clean_exit_stops_watchdog(self, monkeypatch, tmp_path):
+        gw, sleeps = self._patch_common(monkeypatch, tmp_path)
+        spawned = []
+
+        def fake_popen(argv, **kwargs):
+            spawned.append(argv)
+            return _FakeProc(0)
+
+        monkeypatch.setattr(gw.subprocess, "Popen", fake_popen)
+        rc = gw.run_watchdog(str(tmp_path), [r"C:\py\pythonw.exe", "-m",
+                             "hermes_cli.main", "gateway", "run"],
+                             {"HERMES_HOME": str(tmp_path)})
+        assert rc == 0
+        assert len(spawned) == 1  # spawned once, exited clean, no respawn
+        # python.exe substituted for pythonw.exe for the worker.
+        assert spawned[0][0].endswith("python.exe")
+        assert not sleeps
+
+    def test_restart_code_respawns_immediately(self, monkeypatch, tmp_path):
+        gw, sleeps = self._patch_common(monkeypatch, tmp_path)
+        results = iter([75, 0])  # restart-request then clean stop
+
+        def fake_popen(argv, **kwargs):
+            return _FakeProc(next(results))
+
+        monkeypatch.setattr(gw.subprocess, "Popen", fake_popen)
+        rc = gw.run_watchdog(str(tmp_path), ["pythonw.exe", "-m",
+                             "hermes_cli.main", "gateway", "run"], {})
+        assert rc == 0
+        # Restart (75) must NOT incur a backoff sleep.
+        assert not sleeps
+
+    def test_crash_loop_circuit_breaker(self, monkeypatch, tmp_path):
+        gw, sleeps = self._patch_common(monkeypatch, tmp_path)
+        spawned = {"n": 0}
+
+        def fake_popen(argv, **kwargs):
+            spawned["n"] += 1
+            return _FakeProc(1)  # always crashes immediately
+
+        monkeypatch.setattr(gw.subprocess, "Popen", fake_popen)
+        # monotonic stays effectively still → all crashes land in one window
+        # and ran_for stays under the healthy threshold.
+        monkeypatch.setattr(gw.time, "monotonic", lambda: 100.0)
+
+        rc = gw.run_watchdog(str(tmp_path), ["pythonw.exe", "-m",
+                             "hermes_cli.main", "gateway", "run"], {})
+        # Gives up after the burst limit instead of looping forever.
+        assert rc == 1
+        assert spawned["n"] == gw._WATCHDOG_BURST_LIMIT + 1
+
+    def test_backoff_is_capped_and_exponential(self, monkeypatch, tmp_path):
+        gw, sleeps = self._patch_common(monkeypatch, tmp_path)
+        # run_watchdog reads monotonic() 3x per failed iteration:
+        #   started_at, ran_for(=now-started_at), now(crash-window stamp).
+        # Keep all three equal within an iteration → ran_for == 0 (unhealthy,
+        # so backoff grows); jump +200s between iterations → crashes stay
+        # outside the 60s burst window so the breaker never trips. The final
+        # clean-exit iteration reads monotonic once (started_at) then returns.
+        clock = {"t": 0.0}
+        reads = iter([
+            0, 0, 0,          # crash 1
+            200, 200, 200,    # crash 2
+            400, 400, 400,    # crash 3
+            600, 600, 600,    # crash 4
+        ])
+
+        def _mono():
+            return float(next(reads, 9999.0))
+
+        monkeypatch.setattr(gw.time, "monotonic", _mono)
+        results = iter([1, 1, 1, 1, 0])
+
+        def fake_popen(argv, **kwargs):
+            return _FakeProc(next(results))
+
+        monkeypatch.setattr(gw.subprocess, "Popen", fake_popen)
+        gw.run_watchdog(str(tmp_path), ["pythonw.exe", "-m",
+                        "hermes_cli.main", "gateway", "run"], {})
+        # Four crashes → four backoff sleeps, exponential and capped.
+        assert sleeps == [1.0, 2.0, 4.0, 8.0]
+        assert all(s <= gw._WATCHDOG_BACKOFF_CAP_S for s in sleeps)
+
+
+def test_watchdog_main_rejects_bad_args(monkeypatch):
+    from hermes_cli import gateway_windows as gw
+    # invalid JSON → return code 2 (no spawn)
+    rc = gw._watchdog_main(["watchdog", "--working-dir", ".",
+                            "--argv", "not-json", "--env", "{}"])
+    assert rc == 2

--- a/tests/hermes_cli/test_gateway_windows.py
+++ b/tests/hermes_cli/test_gateway_windows.py
@@ -200,7 +200,14 @@ def test_gateway_cmd_script_uses_pythonw_without_replace_or_start_churn(monkeypa
     )
 
     assert "pythonw.exe" in content
-    assert "gateway run" in content
+    # The Scheduled Task now launches the gateway under the watchdog supervisor
+    # (issue #48820, Bug 1) rather than invoking `gateway run` directly. The
+    # worker command is embedded as a JSON --argv blob the watchdog spawns.
+    assert "hermes_cli.gateway_windows" in content
+    assert "watchdog" in content
+    assert "--argv" in content
+    # The worker argv is embedded as cmd-quoted JSON (inner quotes doubled).
+    assert '""gateway"", ""run""' in content
     assert "--replace" not in content
     assert "start \"\"" not in content
     assert "exit /b 0" in content


### PR DESCRIPTION
## Summary

Fixes the three Windows messaging-gateway fragility bugs in #48820 — the gateway now auto-restarts on crash, honors `enabled: false` over env vars, and no longer misroutes through an inherited system proxy under a Scheduled Task.

Salvage of #48852 (@JoaoMarcos44). Bug 2 is salvaged; Bug 1 and Bug 3 are reworked because the original mechanisms had regressions (details below).

## Changes

**Bug 1 — watchdog (`hermes_cli/gateway_windows.py`)**
- Python-native supervisor (`run_watchdog`) launched by `gateway.cmd` + `_spawn_detached`. A Logon-trigger Scheduled Task fires once; a crashed/SIGINT'd worker otherwise never restarts.
- Capped exponential backoff (1→60s), crash-loop circuit breaker (give up + log after 5 crashes/60s, not infinite loop), backoff reset after a healthy run, kill-on-close Job Object so worker children don't orphan, bounded/rotated logging, exit-code handling matching systemd (`0` = stop, `75` = restart, via the real `GATEWAY_SERVICE_RESTART_EXIT_CODE`).

**Bug 2 — `enabled: false` ignored (`gateway/config.py`)**
- The explicit-disable marker was Slack-only; generalized `_enabled_explicit` to all platforms and routed every env-override enable through `_enable_from_env` (stores the credential, keeps the adapter disabled, warns). Reads the marker without popping so platforms processed twice (hardcoded block + plugin-registry loop) stay disabled.

**Bug 3 — `trust_env` proxy misroute (`gateway/platforms/*`, plugin platforms, `gateway/config.py`)**
- New `trust_env_for_gateway()` (default off; opt in via `GATEWAY_TRUST_PROXY`/`GATEWAY_TRUST_ENV` or `gateway.trust_proxy`/`gateway.trust_env` in config.yaml). All `trust_env=True` aiohttp sites and the qqbot WS env-proxy read are gated through it. `resolve_proxy_url` ignores generic env proxies unless trusted but always honors explicit per-platform vars (`DISCORD_PROXY`, `WSS_PROXY`, …).

### Why Bug 1 & Bug 3 were reworked rather than carried as-is
- The original watchdog was an infinite fixed-5s respawn loop (no cap, no max-retries) — a worker that crashes on bad config crash-loops forever.
- The original Bug 3 fix monkeypatched `aiohttp.ClientSession.__init__` and `httpx.AsyncClient.__init__` process-wide at gateway startup. That is process-global: it would have flipped the agent's own auxiliary async LLM client (`AsyncOpenAI` → internal `httpx.AsyncClient`) to `trust_env=False`, silently breaking proxy-dependent users' compression/vision/memory-flush calls — while its `if "trust_env" not in kwargs` guard skipped every actual `trust_env=True` platform site, so it missed the real bug. It also branched on `PYTEST_CURRENT_TEST`, making the security default untestable. Gating at the construction sites fixes the real bug class without the blast radius.

## Validation

| | Before | After |
|---|---|---|
| gateway crashes under Scheduled Task | dies silently, no restart | watchdog respawns w/ capped backoff; gives up + logs after crash-loop |
| `platforms.x.enabled: false` + env token | force-enabled | stays disabled (warns; credential still stored) |
| inherited `HTTPS_PROXY`, no opt-in | routed through it (misroute) | ignored |
| `GATEWAY_TRUST_PROXY=true` / config opt-in | n/a | env proxy honored |
| explicit `DISCORD_PROXY`/`WSS_PROXY` | honored | honored (unchanged) |

- New `tests/gateway/test_windows_gateway_fixes_48820.py` (14 tests) covering all three bugs.
- Updated matrix/qqbot/proxy_mode/gateway_windows tests for the `trust_env` default flip + watchdog wrapping.
- All touched test files green per-file. E2E-verified the proxy gating (env + config.yaml opt-in, explicit-var bypass) and the watchdog respawn/backoff/exit-code path with real imports against a temp `HERMES_HOME`.

Closes #48820. Co-authored with @JoaoMarcos44 (salvaged from #48852).
