### PR TITLE
fix(messaging): link Google Chat setup guide

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -4280,6 +4280,11 @@ _PLATFORM_OVERRIDES: dict[str, dict[str, Any]] = {
         ),
         "required_env": ("FEISHU_APP_ID", "FEISHU_APP_SECRET"),
     },
+    "google_chat": {
+        "name": "Google Chat",
+        "description": "Connect Hermes to Google Chat via Cloud Pub/Sub.",
+        "docs_url": "https://hermes-agent.nousresearch.com/docs/user-guide/messaging/google_chat",
+    },
     "wecom": {
         "name": "WeCom (group bot)",
         "description": "Send-only WeCom group bot via webhook.",
@@ -4373,6 +4378,7 @@ _PLATFORM_ORDER: tuple[str, ...] = (
     "sms",
     "dingtalk",
     "feishu",
+    "google_chat",
     "wecom",
     "wecom_callback",
     "weixin",

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -1573,6 +1573,20 @@ class TestWebServerEndpoints:
         assert "App-Level Tokens" in fields["SLACK_APP_TOKEN"]["help"]
         assert "Copy member ID" in fields["SLACK_ALLOWED_USERS"]["help"]
 
+    def test_google_chat_messaging_metadata_links_setup_guide(self):
+        resp = self.client.get("/api/messaging/platforms")
+
+        assert resp.status_code == 200
+        google_chat = next(
+            platform
+            for platform in resp.json()["platforms"]
+            if platform["id"] == "google_chat"
+        )
+        assert google_chat["name"] == "Google Chat"
+        assert google_chat["docs_url"] == (
+            "https://hermes-agent.nousresearch.com/docs/user-guide/messaging/google_chat"
+        )
+
     def test_weixin_messaging_metadata_describes_personal_ilink_setup(self):
         resp = self.client.get("/api/messaging/platforms")
 


### PR DESCRIPTION
## Summary
Fixes the Google Chat "Open setup guide" link in the desktop messaging settings.

## Change
Adds Google Chat messaging catalog metadata with the setup guide URL:
https://hermes-agent.nousresearch.com/docs/user-guide/messaging/google_chat

Adds a regression test to verify the Google Chat docs URL is exposed by the messaging platforms API.

## Test
Attempted:
```bash
pytest tests/hermes_cli/test_web_server.py -q
python -m pytest tests/hermes_cli/test_web_server.py -q
```

Could not run locally because pytest is not installed in the active environment:
```text
pytest: command not found
No module named pytest
```