### PR TITLE
fix(desktop): only trigger slash commands at input start

### DIFF
--- a/apps/desktop/src/app/chat/composer/text-utils.test.ts
+++ b/apps/desktop/src/app/chat/composer/text-utils.test.ts
@@ -11,6 +11,13 @@ describe('detectTrigger', () => {
     expect(detectTrigger('/skill')).toEqual({ kind: '/', query: 'skill', tokenLength: 6 })
   })
 
+  it('does not detect slash commands after existing message text', () => {
+    expect(detectTrigger('hello /')).toBeNull()
+    expect(detectTrigger('hello /skill')).toBeNull()
+    expect(detectTrigger('不附加文件 /文件夹')).toBeNull()
+    expect(detectTrigger('A / B')).toBeNull()
+  })
+
   it('detects a bare at-mention trigger with an empty query', () => {
     expect(detectTrigger('@')).toEqual({ kind: '@', query: '', tokenLength: 1 })
   })

--- a/apps/desktop/src/app/chat/composer/text-utils.ts
+++ b/apps/desktop/src/app/chat/composer/text-utils.ts
@@ -7,12 +7,13 @@ export interface TriggerState {
 }
 
 // `@` triggers stop at the first whitespace — `@file:path` and `@diff` are
-// single tokens. `/` triggers keep going so the popover stays live while the
-// user types args (`/personality alic` → arg completer suggests `alice`).
+// single tokens. `/` triggers only at the beginning of the input, then keeps
+// going so the popover stays live while the user types args (`/personality
+// alic` → arg completer suggests `alice`).
 // Restricting the slash command name to `[a-zA-Z][\w-]*` avoids matching file
 // paths like `src/foo/bar`.
 const AT_TRIGGER_RE = /(?:^|[\s])(@)([^\s@/]*)$/
-const SLASH_TRIGGER_RE = /(?:^|[\s])(\/)((?:[a-zA-Z][\w-]*(?:\s+\S*)*)?)$/
+const SLASH_TRIGGER_RE = /^(\/)((?:[a-zA-Z][\w-]*(?:\s+\S*)*)?)$/
 
 /** Stable key for paste dedupe — `items` and `files` often mirror the same image as different objects. */
 export function blobDedupeKey(blob: Blob): string {


### PR DESCRIPTION
## Summary
- restrict desktop slash-command trigger detection to the beginning of the composer input
- keep slash argument completions live for leading commands like `/personality alic`
- add regressions for text followed by ` /` so normal message content is not consumed by the command popover

Fixes #48913

## Validation
- `npm run --workspace apps/desktop test:ui -- src/app/chat/composer/text-utils.test.ts src/app/chat/composer/slash-nav-dom-repro.test.tsx src/app/chat/composer/trigger-popover.test.tsx`
- `npm run --workspace apps/desktop typecheck`
- `npm --workspace apps/desktop exec eslint -- src/app/chat/composer/text-utils.ts src/app/chat/composer/text-utils.test.ts`
- `git diff --check`

## Review
- Subagent review completed with no findings.
