### PR TITLE
fix(service_manager): validate lifecycle name on host backends

### DIFF
--- a/hermes_cli/service_manager.py
+++ b/hermes_cli/service_manager.py
@@ -164,19 +164,64 @@ def _s6_running() -> bool:
 #
 # These adapters are thin facades over the existing module-level functions
 # in ``hermes_cli.gateway`` (systemd/launchd) and ``hermes_cli.gateway_windows``
-# (Windows Scheduled Tasks). The protocol's ``name`` parameter is currently
-# unused for host backends — they operate on whichever profile is currently
-# active (set via the ``hermes -p <profile>`` flag before the call). This
-# matches existing host-side semantics; the parameter shape is designed
-# for s6 where each profile maps to a distinct service directory.
+# (Windows Scheduled Tasks).
+#
+# Host backends (systemd / launchd / Windows) only manage a single service:
+# the gateway for the active profile. Generic (backend-agnostic) callers —
+# Phase 4 profile hooks, the s6 dispatch path — pass the name produced by
+# ``_expected_service_name()`` (or s6's ``_service_name()``). The lifecycle
+# methods validate the name up front and raise ``ValueError`` if it does
+# not match the active profile's gateway service. This makes the
+# ``name`` parameter honest: passing a different name (e.g. an s6-style
+# ``gateway-<profile>`` on a systemd host) used to be silently dropped and
+# start the wrong service — a quiet correctness bug for any future generic
+# caller that forgets to branch on ``detect_service_manager()``.
 # ---------------------------------------------------------------------------
 
 
 class _RegistrationUnsupportedMixin:
-    """Mixin for host backends that don't support runtime registration."""
+    """Mixin for host backends that don't support runtime registration.
+
+    Also provides the name validation used by every lifecycle method on
+    host backends — see the module-level comment above.
+    """
 
     def supports_runtime_registration(self) -> bool:
         return False
+
+    def _expected_service_name(self) -> str:
+        """Return the gateway service name for the active profile.
+
+        The host-backend convention is ``hermes-gateway[-<profile>]``,
+        derived from the active ``HERMES_HOME`` (see
+        :func:`hermes_cli.gateway.get_service_name`). Generic callers
+        should pass the value returned here so the host backend can
+        confirm the call targets the service it can actually manage.
+        """
+        from hermes_cli.gateway import get_service_name
+
+        return get_service_name()
+
+    def _validate_lifecycle_name(self, name: str) -> None:
+        """Raise ``ValueError`` if ``name`` is not the gateway service
+        this backend can manage.
+
+        Without this check, ``SystemdServiceManager().start("anything")``
+        silently calls the underlying ``systemd_start()`` and starts
+        the active profile's gateway service regardless of the passed
+        name. That is the kind of footgun that is invisible in the
+        current code (every caller checks ``detect_service_manager() ==
+        "s6"`` first) and bites the first future caller that forgets
+        to gate on backend kind.
+        """
+        expected = self._expected_service_name()
+        if name != expected:
+            raise ValueError(
+                f"{type(self).__name__} only manages the gateway service "
+                f"for the active profile (expected {expected!r}, got "
+                f"{name!r}). Use _expected_service_name() to derive the "
+                f"correct value for backend-agnostic callers."
+            )
 
     def register_profile_gateway(
         self,
@@ -211,18 +256,22 @@ class SystemdServiceManager(_RegistrationUnsupportedMixin):
     kind: ServiceManagerKind = "systemd"
 
     def start(self, name: str) -> None:
+        self._validate_lifecycle_name(name)
         from hermes_cli.gateway import systemd_start
         systemd_start()
 
     def stop(self, name: str) -> None:
+        self._validate_lifecycle_name(name)
         from hermes_cli.gateway import systemd_stop
         systemd_stop()
 
     def restart(self, name: str) -> None:
+        self._validate_lifecycle_name(name)
         from hermes_cli.gateway import systemd_restart
         systemd_restart()
 
     def is_running(self, name: str) -> bool:
+        self._validate_lifecycle_name(name)
         from hermes_cli.gateway import _probe_systemd_service_running
         _, running = _probe_systemd_service_running()
         return running
@@ -234,18 +283,22 @@ class LaunchdServiceManager(_RegistrationUnsupportedMixin):
     kind: ServiceManagerKind = "launchd"
 
     def start(self, name: str) -> None:
+        self._validate_lifecycle_name(name)
         from hermes_cli.gateway import launchd_start
         launchd_start()
 
     def stop(self, name: str) -> None:
+        self._validate_lifecycle_name(name)
         from hermes_cli.gateway import launchd_stop
         launchd_stop()
 
     def restart(self, name: str) -> None:
+        self._validate_lifecycle_name(name)
         from hermes_cli.gateway import launchd_restart
         launchd_restart()
 
     def is_running(self, name: str) -> bool:
+        self._validate_lifecycle_name(name)
         from hermes_cli.gateway import _probe_launchd_service_running
         return _probe_launchd_service_running()
 
@@ -281,18 +334,22 @@ class WindowsServiceManager(_RegistrationUnsupportedMixin):
         )
 
     def start(self, name: str) -> None:
+        self._validate_lifecycle_name(name)
         from hermes_cli import gateway_windows
         gateway_windows.start()
 
     def stop(self, name: str) -> None:
+        self._validate_lifecycle_name(name)
         from hermes_cli import gateway_windows
         gateway_windows.stop()
 
     def restart(self, name: str) -> None:
+        self._validate_lifecycle_name(name)
         from hermes_cli import gateway_windows
         gateway_windows.restart()
 
     def is_running(self, name: str) -> bool:
+        self._validate_lifecycle_name(name)
         from hermes_cli import gateway_windows
         from hermes_cli.gateway import find_gateway_pids
         if not gateway_windows.is_installed():

--- a/tests/hermes_cli/test_service_manager.py
+++ b/tests/hermes_cli/test_service_manager.py
@@ -235,12 +235,15 @@ def test_systemd_manager_lifecycle_delegates(monkeypatch: pytest.MonkeyPatch) ->
         "hermes_cli.gateway._probe_systemd_service_running",
         lambda *a, **kw: (False, True),
     )
+    monkeypatch.setattr(
+        "hermes_cli.gateway.get_service_name", lambda: "hermes-gateway",
+    )
     mgr = SystemdServiceManager()
-    mgr.start("ignored")
-    mgr.stop("ignored")
-    mgr.restart("ignored")
+    mgr.start("hermes-gateway")
+    mgr.stop("hermes-gateway")
+    mgr.restart("hermes-gateway")
     assert called == ["start", "stop", "restart"]
-    assert mgr.is_running("ignored") is True
+    assert mgr.is_running("hermes-gateway") is True
 
 
 def test_launchd_manager_lifecycle_delegates(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -257,12 +260,15 @@ def test_launchd_manager_lifecycle_delegates(monkeypatch: pytest.MonkeyPatch) ->
     monkeypatch.setattr(
         "hermes_cli.gateway._probe_launchd_service_running", lambda: False,
     )
+    monkeypatch.setattr(
+        "hermes_cli.gateway.get_service_name", lambda: "hermes-gateway",
+    )
     mgr = LaunchdServiceManager()
-    mgr.start("ignored")
-    mgr.stop("ignored")
-    mgr.restart("ignored")
+    mgr.start("hermes-gateway")
+    mgr.stop("hermes-gateway")
+    mgr.restart("hermes-gateway")
     assert called == ["start", "stop", "restart"]
-    assert mgr.is_running("ignored") is False
+    assert mgr.is_running("hermes-gateway") is False
 
 
 def test_windows_manager_lifecycle_delegates(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -287,12 +293,15 @@ def test_windows_manager_lifecycle_delegates(monkeypatch: pytest.MonkeyPatch) ->
         "hermes_cli.gateway.find_gateway_pids",
         lambda **kw: [12345],
     )
+    monkeypatch.setattr(
+        "hermes_cli.gateway.get_service_name", lambda: "hermes-gateway",
+    )
     mgr = WindowsServiceManager()
-    mgr.start("ignored")
-    mgr.stop("ignored")
-    mgr.restart("ignored")
+    mgr.start("hermes-gateway")
+    mgr.stop("hermes-gateway")
+    mgr.restart("hermes-gateway")
     assert called == ["start", "stop", "restart"]
-    assert mgr.is_running("ignored") is True
+    assert mgr.is_running("hermes-gateway") is True
 
 
 def test_windows_manager_is_running_false_when_not_installed(
@@ -309,7 +318,135 @@ def test_windows_manager_is_running_false_when_not_installed(
         "hermes_cli.gateway.find_gateway_pids",
         lambda **kw: [12345],  # PIDs would otherwise vote "running"
     )
-    assert WindowsServiceManager().is_running("ignored") is False
+    monkeypatch.setattr(
+        "hermes_cli.gateway.get_service_name", lambda: "hermes-gateway",
+    )
+    assert WindowsServiceManager().is_running("hermes-gateway") is False
+
+
+# ---------------------------------------------------------------------------
+# Lifecycle name validation — host backends only manage the active profile's
+# gateway service, so a wrong ``name`` must fail loudly instead of silently
+# starting the wrong service.
+# ---------------------------------------------------------------------------
+
+
+def test_systemd_manager_lifecycle_rejects_wrong_name(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Regression: previously the ``name`` argument was silently dropped,
+    so a future caller that forgot to gate on backend kind would start
+    the gateway service regardless of the value passed in."""
+    called: list[str] = []
+    monkeypatch.setattr(
+        "hermes_cli.gateway.systemd_start", lambda: called.append("start"),
+    )
+    monkeypatch.setattr(
+        "hermes_cli.gateway.systemd_stop", lambda: called.append("stop"),
+    )
+    monkeypatch.setattr(
+        "hermes_cli.gateway.systemd_restart", lambda: called.append("restart"),
+    )
+    monkeypatch.setattr(
+        "hermes_cli.gateway._probe_systemd_service_running",
+        lambda *a, **kw: (False, False),
+    )
+    monkeypatch.setattr(
+        "hermes_cli.gateway.get_service_name", lambda: "hermes-gateway",
+    )
+    mgr = SystemdServiceManager()
+    # s6-style name on a host backend — must be rejected.
+    with pytest.raises(ValueError, match="hermes-gateway"):
+        mgr.start("gateway-coder")
+    with pytest.raises(ValueError, match="hermes-gateway"):
+        mgr.stop("gateway-coder")
+    with pytest.raises(ValueError, match="hermes-gateway"):
+        mgr.restart("gateway-coder")
+    with pytest.raises(ValueError, match="hermes-gateway"):
+        mgr.is_running("gateway-coder")
+    assert called == [], "no underlying call should have run"
+
+
+def test_launchd_manager_lifecycle_rejects_wrong_name(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    called: list[str] = []
+    monkeypatch.setattr(
+        "hermes_cli.gateway.launchd_start", lambda: called.append("start"),
+    )
+    monkeypatch.setattr(
+        "hermes_cli.gateway.launchd_stop", lambda: called.append("stop"),
+    )
+    monkeypatch.setattr(
+        "hermes_cli.gateway.launchd_restart", lambda: called.append("restart"),
+    )
+    monkeypatch.setattr(
+        "hermes_cli.gateway._probe_launchd_service_running", lambda: False,
+    )
+    monkeypatch.setattr(
+        "hermes_cli.gateway.get_service_name", lambda: "hermes-gateway-coder",
+    )
+    mgr = LaunchdServiceManager()
+    # Default-profile name on a coder profile — must be rejected.
+    with pytest.raises(ValueError, match="hermes-gateway-coder"):
+        mgr.start("hermes-gateway")
+    with pytest.raises(ValueError, match="hermes-gateway-coder"):
+        mgr.stop("hermes-gateway")
+    with pytest.raises(ValueError, match="hermes-gateway-coder"):
+        mgr.restart("hermes-gateway")
+    with pytest.raises(ValueError, match="hermes-gateway-coder"):
+        mgr.is_running("hermes-gateway")
+    assert called == []
+
+
+def test_windows_manager_lifecycle_rejects_wrong_name(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    called: list[str] = []
+    import hermes_cli.gateway_windows  # noqa: F401
+
+    class _FakeWindowsModule:
+        @staticmethod
+        def start() -> None: called.append("start")
+        @staticmethod
+        def stop() -> None: called.append("stop")
+        @staticmethod
+        def restart() -> None: called.append("restart")
+        @staticmethod
+        def is_installed() -> bool: return True
+
+    monkeypatch.setattr("hermes_cli.gateway_windows", _FakeWindowsModule)
+    monkeypatch.setattr(
+        "hermes_cli.gateway.find_gateway_pids", lambda **kw: [12345],
+    )
+    monkeypatch.setattr(
+        "hermes_cli.gateway.get_service_name", lambda: "hermes-gateway",
+    )
+    mgr = WindowsServiceManager()
+    with pytest.raises(ValueError, match="hermes-gateway"):
+        mgr.start("hermes-gateway-dashboard")
+    with pytest.raises(ValueError, match="hermes-gateway"):
+        mgr.stop("hermes-gateway-dashboard")
+    with pytest.raises(ValueError, match="hermes-gateway"):
+        mgr.restart("hermes-gateway-dashboard")
+    with pytest.raises(ValueError, match="hermes-gateway"):
+        mgr.is_running("hermes-gateway-dashboard")
+    assert called == []
+
+
+def test_host_backends_accept_active_profile_name(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The active profile's service name should always be accepted."""
+    called: list[str] = []
+    monkeypatch.setattr(
+        "hermes_cli.gateway.systemd_start", lambda: called.append("start"),
+    )
+    monkeypatch.setattr(
+        "hermes_cli.gateway.get_service_name", lambda: "hermes-gateway-coder",
+    )
+    SystemdServiceManager().start("hermes-gateway-coder")
+    assert called == ["start"]
 
 
 def test_windows_manager_install_forwards_kwargs(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## What was the dead code

`ServiceManager` (the Protocol in `hermes_cli/service_manager.py`) declares:

```python
def start(self, name: str) -> None: ...
def stop(self, name: str) -> None: ...
def restart(self, name: str) -> None: ...
def is_running(self, name: str) -> bool: ...
```

The `s6` backend (`S6ServiceManager`) honours `name` — each profile maps to a distinct s6 service directory (`gateway-<profile>`). But the host backends silently dropped it:

```python
class SystemdServiceManager(_RegistrationUnsupportedMixin):
    def start(self, name: str) -> None:
        from hermes_cli.gateway import systemd_start
        systemd_start()  # name is ignored
```

`systemd_start()`, `launchd_start()`, and `gateway_windows.start()` all operate on a single hardcoded service derived from `HERMES_HOME` (`hermes-gateway[-<profile>]`). So `name` was dead. The source comment admitted it ("currently unused for host backends"), and the test suite confirmed it — the existing tests pass the literal string `"ignored"` as the name.

## Why it matters

Today this is invisible: every caller that uses the host backends checks `detect_service_manager() == "s6"` first and never reaches them. But any future backend-agnostic caller that forgets to gate on backend kind would silently start the wrong service (e.g. an s6-style `gateway-coder` on a systemd host) with no error — a quiet correctness bug.

## Fix

Add `_expected_service_name()` / `_validate_lifecycle_name()` to the `_RegistrationUnsupportedMixin` and call the validator at the start of every host lifecycle method. A wrong `name` now raises `ValueError` with the expected vs actual value:

```python
SystemdServiceManager().start("gateway-coder")
# ValueError: SystemdServiceManager only manages the gateway service for
# the active profile (expected 'hermes-gateway', got 'gateway-coder').
# Use _expected_service_name() to derive the correct value for
# backend-agnostic callers.
```

The `name` parameter is now honest: a wrong value is rejected loudly instead of dropped silently.

## Tests

- Replace literal `"ignored"` placeholders in the existing delegation tests with the mocked active name
- Add per-backend coverage that wrong names raise `ValueError` and the underlying helper is **not** invoked
- Add coverage that the active profile's name (`hermes-gateway-coder`) is accepted, so the existing happy path still works

All 49 lifecycle / kind / registration tests pass on this branch. (9 pre-existing `os.chown`-related failures on Windows in the s6 registration tests are unrelated — they fail on `main` too.)