### PR TITLE
fix(tui): route pending-input commands via command.dispatch (#48848)

### DIFF
--- a/tests/tui_gateway/test_goal_command.py
+++ b/tests/tui_gateway/test_goal_command.py
@@ -185,15 +185,17 @@ def test_goal_requires_session(server):
 # ── slash.exec /goal routing ──────────────────────────────────────────
 
 
-def test_slash_exec_rejects_goal_routes_to_command_dispatch(server, session):
-    """slash.exec must reject /goal with 4018 so the TUI client falls through
-    to command.dispatch. Without this, the HermesCLI slash-worker subprocess
-    would set the goal but silently drop the kickoff — the queue is in-proc."""
+def test_slash_exec_routes_goal_to_command_dispatch(server, session):
+    """slash.exec must route /goal directly to command.dispatch internally
+    instead of returning an error.  Previously the 4018 error required the
+    TUI client to retry via command.dispatch, but some clients failed the
+    fallback, leaving the command empty ("empty command")."""
     sid, _, _ = session
     r = _call(server, "slash.exec", command="goal status", session_id=sid)
-    assert "error" in r
-    assert r["error"]["code"] == 4018
-    assert "command.dispatch" in r["error"]["message"]
+    # Should succeed by routing to command.dispatch internally
+    assert "result" in r
+    assert r["result"]["type"] == "exec"
+    assert "No active goal" in r["result"]["output"]
 
 
 def test_pending_input_commands_includes_goal(server):

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -9728,8 +9728,16 @@ def _(rid, params: dict) -> dict:
     _cmd_arg = _cmd_parts[1] if len(_cmd_parts) > 1 else ""
 
     if _cmd_base in _PENDING_INPUT_COMMANDS:
-        return _err(
-            rid, 4018, f"pending-input command: use command.dispatch for /{_cmd_base}"
+        # Route directly to command.dispatch instead of returning an error
+        # that requires the frontend to retry.  Some TUI clients fail the
+        # fallback, leaving the command empty and showing "empty command".
+        return _methods["command.dispatch"](
+            rid,
+            {
+                "name": _cmd_base,
+                "arg": _cmd_arg,
+                "session_id": params.get("session_id", ""),
+            },
         )
 
     if _cmd_base in _WORKER_BLOCKED_COMMANDS:


### PR DESCRIPTION
Fixes #48848. When /goal (or other pending-input commands) were typed in the TUI desktop app, slash.exec returned error 4018 telling the frontend to fall back to command.dispatch. Some clients failed this fallback, leaving the command empty and showing 'empty command'. Now slash.exec routes pending-input commands to command.dispatch internally, eliminating the fragile client-side fallback.