### PR TITLE
Fix duplicate send_message after compression

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -31,6 +31,13 @@ from agent.model_metadata import (
     estimate_messages_tokens_rough,
 )
 from agent.redact import redact_sensitive_text
+from agent.side_effect_dedup import (
+    collect_successful_send_message_records,
+    extract_action_log_records,
+    merge_action_log_records,
+    render_action_log_block,
+    strip_action_log_blocks,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -1466,7 +1473,7 @@ Write only the summary body. Do not include any preamble or prefix."""
 You are updating a context compaction summary. A previous compaction produced the summary below. New conversation turns have occurred since then and need to be incorporated.
 
 PREVIOUS SUMMARY:
-{self._previous_summary}
+{strip_action_log_blocks(self._previous_summary)}
 
 NEW TURNS TO INCORPORATE:
 {content_to_summarize}
@@ -2256,6 +2263,9 @@ This compaction should PRIORITISE preserving all information related to the focu
             # into the summarizer prompt via the iterative-update path.
             self._previous_summary = None
 
+        prior_action_records = extract_action_log_records(self._previous_summary or "")
+        new_action_records = collect_successful_send_message_records(turns_to_summarize)
+
         if not self.quiet_mode:
             logger.info(
                 "Context compression triggered (%d tokens >= %d threshold)",
@@ -2335,6 +2345,16 @@ This compaction should PRIORITISE preserving all information related to the focu
                 turns_to_summarize,
                 reason=self._last_summary_error,
             )
+
+        merged_action_records = merge_action_log_records(
+            prior_action_records,
+            new_action_records,
+        )
+        if merged_action_records:
+            summary = strip_action_log_blocks(summary) + render_action_log_block(
+                merged_action_records
+            )
+        self._previous_summary = self._strip_summary_prefix(summary)
 
         _merge_summary_into_tail = False
         last_head_role = messages[compress_start - 1].get("role", "user") if compress_start > 0 else "user"

--- a/agent/side_effect_dedup.py
+++ b/agent/side_effect_dedup.py
@@ -1,0 +1,242 @@
+"""Compression-safe dedup helpers for side-effecting tool calls.
+
+The first guarded surface is ``send_message`` because duplicate outbound
+messages are user-visible and harmful. We persist a compact action log across
+context compaction and consult it before re-executing the same send.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from typing import Any, Iterable, Mapping
+
+ACTION_LOG_BEGIN = "[HERMES_ACTION_LOG_BEGIN]"
+ACTION_LOG_END = "[HERMES_ACTION_LOG_END]"
+
+
+def _message_content_text(content: Any) -> str:
+    if content is None:
+        return ""
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        parts: list[str] = []
+        for item in content:
+            if isinstance(item, str):
+                parts.append(item)
+            elif isinstance(item, dict):
+                text = item.get("text")
+                if isinstance(text, str):
+                    parts.append(text)
+        return "\n".join(part for part in parts if part)
+    return str(content)
+
+
+def _normalize_space(value: Any) -> str:
+    return re.sub(r"\s+", " ", str(value or "").strip())
+
+
+def _send_message_hash(message: Any) -> str:
+    normalized = _normalize_space(message)
+    return hashlib.sha256(normalized.encode("utf-8")).hexdigest()[:16]
+
+
+def build_send_message_record(
+    function_args: Mapping[str, Any] | None,
+    result_payload: Mapping[str, Any] | None = None,
+) -> dict[str, Any] | None:
+    args = dict(function_args or {})
+    action = _normalize_space(args.get("action") or "send").lower()
+    target = _normalize_space(args.get("target"))
+    message = args.get("message")
+    if action != "send" or not target or not _normalize_space(message):
+        return None
+
+    message_sha = _send_message_hash(message)
+    record: dict[str, Any] = {
+        "tool": "send_message",
+        "target": target,
+        "message_sha256": message_sha,
+        "fingerprint": f"send_message:{target}:{message_sha}",
+    }
+    if isinstance(result_payload, Mapping):
+        for src, dst in (
+            ("platform", "platform"),
+            ("chat_id", "chat_id"),
+            ("thread_id", "thread_id"),
+            ("message_id", "message_id"),
+        ):
+            value = result_payload.get(src)
+            if value not in (None, ""):
+                record[dst] = str(value)
+    return record
+
+
+def _coerce_action_log_payload(payload: Any) -> list[dict[str, Any]]:
+    if isinstance(payload, dict):
+        records = payload.get("records")
+    else:
+        records = None
+    if not isinstance(records, list):
+        return []
+    out: list[dict[str, Any]] = []
+    for record in records:
+        if isinstance(record, dict) and record.get("fingerprint"):
+            out.append(record)
+    return out
+
+
+def extract_action_log_records(text: Any) -> list[dict[str, Any]]:
+    rendered = _message_content_text(text)
+    records: list[dict[str, Any]] = []
+    cursor = 0
+    while True:
+        start = rendered.find(ACTION_LOG_BEGIN, cursor)
+        if start == -1:
+            break
+        payload_start = start + len(ACTION_LOG_BEGIN)
+        end = rendered.find(ACTION_LOG_END, payload_start)
+        if end == -1:
+            break
+        payload_text = rendered[payload_start:end].strip()
+        try:
+            payload = json.loads(payload_text)
+        except (TypeError, ValueError):
+            payload = None
+        records.extend(_coerce_action_log_payload(payload))
+        cursor = end + len(ACTION_LOG_END)
+    return records
+
+
+def strip_action_log_blocks(text: Any) -> str:
+    rendered = _message_content_text(text)
+    pattern = re.compile(
+        rf"\n?{re.escape(ACTION_LOG_BEGIN)}\n.*?\n{re.escape(ACTION_LOG_END)}",
+        re.DOTALL,
+    )
+    return pattern.sub("", rendered).rstrip()
+
+
+def merge_action_log_records(*record_lists: Iterable[dict[str, Any]]) -> list[dict[str, Any]]:
+    merged: list[dict[str, Any]] = []
+    seen: set[str] = set()
+    for records in record_lists:
+        for record in records:
+            if not isinstance(record, dict):
+                continue
+            fingerprint = str(record.get("fingerprint") or "").strip()
+            if not fingerprint or fingerprint in seen:
+                continue
+            seen.add(fingerprint)
+            merged.append(record)
+    return merged
+
+
+def render_action_log_block(records: Iterable[dict[str, Any]]) -> str:
+    merged = merge_action_log_records(records)
+    if not merged:
+        return ""
+    payload = {"version": 1, "records": merged}
+    return (
+        f"\n\n{ACTION_LOG_BEGIN}\n"
+        f"{json.dumps(payload, ensure_ascii=False, sort_keys=True)}\n"
+        f"{ACTION_LOG_END}"
+    )
+
+
+def collect_successful_send_message_records(messages: Iterable[Mapping[str, Any]]) -> list[dict[str, Any]]:
+    call_id_to_args: dict[str, Mapping[str, Any]] = {}
+    for msg in messages:
+        if msg.get("role") != "assistant":
+            continue
+        for tc in msg.get("tool_calls") or []:
+            if not isinstance(tc, dict):
+                continue
+            fn = tc.get("function") or {}
+            if fn.get("name") != "send_message":
+                continue
+            call_id = tc.get("id")
+            if not call_id:
+                continue
+            try:
+                args = json.loads(fn.get("arguments") or "{}")
+            except (TypeError, ValueError):
+                args = {}
+            if isinstance(args, dict):
+                call_id_to_args[call_id] = args
+
+    records: list[dict[str, Any]] = []
+    for msg in messages:
+        if msg.get("role") != "tool":
+            continue
+        call_id = msg.get("tool_call_id")
+        if not call_id or call_id not in call_id_to_args:
+            continue
+        content = msg.get("content")
+        if isinstance(content, str):
+            try:
+                payload = json.loads(content)
+            except (TypeError, ValueError):
+                payload = None
+        elif isinstance(content, dict):
+            payload = content
+        else:
+            payload = None
+        if not isinstance(payload, dict):
+            continue
+        if not payload.get("success") or payload.get("skipped"):
+            continue
+        record = build_send_message_record(call_id_to_args[call_id], payload)
+        if record is not None:
+            records.append(record)
+    return merge_action_log_records(records)
+
+
+def collect_summary_action_log_records(messages: Iterable[Mapping[str, Any]]) -> list[dict[str, Any]]:
+    records: list[dict[str, Any]] = []
+    for msg in messages:
+        records.extend(extract_action_log_records(msg.get("content")))
+    return merge_action_log_records(records)
+
+
+def find_prior_duplicate_send_message(
+    messages: Iterable[Mapping[str, Any]],
+    function_args: Mapping[str, Any] | None,
+) -> dict[str, Any] | None:
+    current = build_send_message_record(function_args)
+    if current is None:
+        return None
+    fingerprint = current["fingerprint"]
+    for record in collect_summary_action_log_records(messages):
+        if record.get("fingerprint") == fingerprint:
+            return record
+    return None
+
+
+def build_duplicate_send_message_skip_result(
+    function_args: Mapping[str, Any] | None,
+    prior_record: Mapping[str, Any] | None,
+) -> str | None:
+    if prior_record is None:
+        return None
+    record = build_send_message_record(function_args)
+    if record is None:
+        return None
+    target = str(prior_record.get("target") or record["target"])
+    return json.dumps(
+        {
+            "success": True,
+            "skipped": True,
+            "reason": "compression_duplicate_send_message",
+            "target": target,
+            "fingerprint": record["fingerprint"],
+            "note": (
+                "Skipped duplicate send_message. An identical target/message pair "
+                "already succeeded earlier in this session and was preserved in "
+                "the context-compaction action log."
+            ),
+        },
+        ensure_ascii=False,
+    )

--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -29,6 +29,10 @@ from agent.display import (
     _detect_tool_failure,
 )
 from agent.tool_guardrails import ToolGuardrailDecision
+from agent.side_effect_dedup import (
+    build_duplicate_send_message_skip_result,
+    find_prior_duplicate_send_message,
+)
 from agent.tool_dispatch_helpers import (
     _is_destructive_command,
     _is_multimodal_tool_result,
@@ -238,6 +242,19 @@ def _run_agent_tool_execution_middleware(
         api_request_id=getattr(agent, "_current_api_request_id", "") or "",
     )
     return result, observed_args
+
+
+def _build_compression_duplicate_send_result(
+    messages: list[dict[str, Any]],
+    function_name: str,
+    function_args: dict[str, Any],
+) -> str | None:
+    if function_name != "send_message":
+        return None
+    prior_record = find_prior_duplicate_send_message(messages, function_args)
+    if prior_record is None:
+        return None
+    return build_duplicate_send_message_skip_result(function_args, prior_record)
 
 
 def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effective_task_id: str, api_call_count: int = 0) -> None:
@@ -491,16 +508,20 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
         start = time.time()
         try:
             try:
-                result = agent._invoke_tool(
-                    function_name,
-                    function_args,
-                    effective_task_id,
-                    tool_call.id,
-                    messages=messages,
-                    pre_tool_block_checked=True,
-                    skip_tool_request_middleware=True,
-                    tool_request_middleware_trace=list(middleware_trace),
+                result = _build_compression_duplicate_send_result(
+                    messages, function_name, function_args
                 )
+                if result is None:
+                    result = agent._invoke_tool(
+                        function_name,
+                        function_args,
+                        effective_task_id,
+                        tool_call.id,
+                        messages=messages,
+                        pre_tool_block_checked=True,
+                        skip_tool_request_middleware=True,
+                        tool_request_middleware_trace=list(middleware_trace),
+                    )
             except KeyboardInterrupt:
                 try:
                     agent.interrupt("keyboard interrupt")
@@ -959,6 +980,23 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
                 status="blocked",
                 error_type="guardrail_block",
                 error_message=getattr(_guardrail_block_decision, "message", None) or "Tool blocked by guardrail policy",
+                middleware_trace=list(middleware_trace),
+            )
+        elif (
+            duplicate_skip_result := _build_compression_duplicate_send_result(
+                messages, function_name, function_args
+            )
+        ) is not None:
+            function_result = duplicate_skip_result
+            tool_duration = 0.0
+            _emit_terminal_post_tool_call(
+                agent,
+                function_name=function_name,
+                function_args=function_args,
+                result=function_result,
+                effective_task_id=effective_task_id,
+                tool_call_id=getattr(tool_call, "id", "") or "",
+                status="ok",
                 middleware_trace=list(middleware_trace),
             )
         elif function_name == "todo":

--- a/tests/agent/test_context_compressor_summary_continuity.py
+++ b/tests/agent/test_context_compressor_summary_continuity.py
@@ -1,8 +1,14 @@
 """Regression tests for iterative context-summary continuity."""
 
+import json
 from unittest.mock import MagicMock, patch
 
 from agent.context_compressor import ContextCompressor, SUMMARY_PREFIX
+from agent.side_effect_dedup import (
+    build_send_message_record,
+    extract_action_log_records,
+    render_action_log_block,
+)
 
 
 def _compressor() -> ContextCompressor:
@@ -82,6 +88,83 @@ def test_handoff_in_protected_head_populates_previous_summary_before_update():
     with patch.object(compressor, "_generate_summary", side_effect=fake_generate_summary):
         compressor.compress(_messages_with_handoff(old_summary))
 
-    assert compressor._previous_summary == old_summary
+    assert compressor._previous_summary == "new summary from resumed turns"
     assert seen_turns
     assert all(old_summary not in str(msg.get("content", "")) for msg in seen_turns)
+
+
+def test_compress_merges_send_message_action_log_records_into_updated_summary():
+    compressor = _compressor()
+    prior_record = {
+        "tool": "send_message",
+        "target": "slack:ops",
+        "message_sha256": "abc123",
+        "fingerprint": "send_message:slack:ops:abc123",
+    }
+    prior_summary = (
+        "OLD-SUMMARY-BODY durable continuity facts"
+        + render_action_log_block([prior_record])
+    )
+    send_args = {
+        "action": "send",
+        "target": "slack:builds",
+        "message": "Build failed on main",
+    }
+    send_result = {
+        "success": True,
+        "platform": "slack",
+        "chat_id": "C123",
+        "message_id": "m456",
+    }
+    expected_new_record = build_send_message_record(send_args, send_result)
+    messages = [
+        {"role": "system", "content": "system prompt"},
+        {"role": "user", "content": f"{SUMMARY_PREFIX}\n{prior_summary}"},
+        {"role": "assistant", "content": "resume ack"},
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                {
+                    "id": "call_send_1",
+                    "type": "function",
+                    "function": {
+                        "name": "send_message",
+                        "arguments": json.dumps(send_args),
+                    },
+                }
+            ],
+        },
+        {
+            "role": "tool",
+            "tool_call_id": "call_send_1",
+            "content": json.dumps(send_result),
+        },
+        {"role": "user", "content": "continue after notification"},
+        {"role": "assistant", "content": "latest tail reply"},
+        {"role": "user", "content": "final active request stays in protected tail"},
+    ]
+
+    with (
+        patch.object(compressor, "_find_tail_cut_by_tokens", return_value=7),
+        patch(
+            "agent.context_compressor.call_llm",
+            return_value=_response("updated summary body"),
+        ) as mock_call,
+    ):
+        compressed = compressor.compress(messages)
+
+    prompt = mock_call.call_args.kwargs["messages"][0]["content"]
+    assert "OLD-SUMMARY-BODY durable continuity facts" in prompt
+    assert "[HERMES_ACTION_LOG_BEGIN]" not in prompt
+
+    summary_message = next(
+        msg
+        for msg in compressed
+        if "updated summary body" in str(msg.get("content", ""))
+    )
+    records = extract_action_log_records(summary_message["content"])
+    assert {record["fingerprint"] for record in records} == {
+        prior_record["fingerprint"],
+        expected_new_record["fingerprint"],
+    }

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -19,6 +19,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from agent.codex_responses_adapter import _normalize_codex_response
+from agent.side_effect_dedup import build_send_message_record, render_action_log_block
 
 import run_agent
 from run_agent import AIAgent
@@ -252,6 +253,16 @@ def _mock_tool_call(name="web_search", arguments="{}", call_id=None):
         type="function",
         function=SimpleNamespace(name=name, arguments=arguments),
     )
+
+
+def _summary_action_log_message(*records):
+    return {
+        "role": "assistant",
+        "content": (
+            "[CONTEXT COMPACTION - REFERENCE ONLY]\nsummary"
+            + render_action_log_block(list(records))
+        ),
+    }
 
 
 def _mock_response(
@@ -2524,6 +2535,34 @@ class TestConcurrentToolExecution:
         assert starts == [("c1", "web_search", {"query": "hello"})]
         assert completes == [("c1", "web_search", {"query": "hello"}, '{"success": true}')]
 
+    def test_sequential_skips_duplicate_send_message_from_compaction_log(self, agent):
+        send_args = {
+            "action": "send",
+            "target": "slack:ops",
+            "message": "Build failed on main",
+        }
+        prior_record = build_send_message_record(send_args)
+        tool_call = _mock_tool_call(
+            name="send_message",
+            arguments=json.dumps(send_args),
+            call_id="send-1",
+        )
+        mock_msg = _mock_assistant_msg(content="", tool_calls=[tool_call])
+        messages = [_summary_action_log_message(prior_record)]
+
+        with patch(
+            "run_agent.handle_function_call",
+            side_effect=AssertionError("send_message should be skipped"),
+        ) as mock_handle:
+            agent._execute_tool_calls_sequential(mock_msg, messages, "task-1")
+
+        mock_handle.assert_not_called()
+        result = json.loads(messages[-1]["content"])
+        assert result["success"] is True
+        assert result["skipped"] is True
+        assert result["reason"] == "compression_duplicate_send_message"
+        assert result["target"] == "slack:ops"
+
     def test_concurrent_tool_callbacks_fire_for_each_tool(self, agent):
         tc1 = _mock_tool_call(name="web_search", arguments='{"query":"one"}', call_id="c1")
         tc2 = _mock_tool_call(name="web_search", arguments='{"query":"two"}', call_id="c2")
@@ -2544,6 +2583,34 @@ class TestConcurrentToolExecution:
         assert len(completes) == 2
         assert {entry[0] for entry in completes} == {"c1", "c2"}
         assert {entry[3] for entry in completes} == {'{"id":1}', '{"id":2}'}
+
+    def test_concurrent_skips_duplicate_send_message_from_compaction_log(self, agent):
+        send_args = {
+            "action": "send",
+            "target": "slack:ops",
+            "message": "Build failed on main",
+        }
+        prior_record = build_send_message_record(send_args)
+        tool_call = _mock_tool_call(
+            name="send_message",
+            arguments=json.dumps(send_args),
+            call_id="send-1",
+        )
+        mock_msg = _mock_assistant_msg(content="", tool_calls=[tool_call])
+        messages = [_summary_action_log_message(prior_record)]
+
+        with patch(
+            "run_agent.handle_function_call",
+            side_effect=AssertionError("send_message should be skipped"),
+        ) as mock_handle:
+            agent._execute_tool_calls_concurrent(mock_msg, messages, "task-1")
+
+        mock_handle.assert_not_called()
+        result = json.loads(messages[-1]["content"])
+        assert result["success"] is True
+        assert result["skipped"] is True
+        assert result["reason"] == "compression_duplicate_send_message"
+        assert result["target"] == "slack:ops"
 
     def test_invoke_tool_handles_agent_level_tools(self, agent):
         """_invoke_tool should handle todo tool directly."""


### PR DESCRIPTION
## Summary
- preserve successful `send_message` fingerprints in a machine-readable action log that survives context compaction
- short-circuit sequential and concurrent `send_message` calls when compaction already records an identical successful send
- cover both the summary merge path and duplicate-send skip path with targeted regressions

## Testing
- `uv run --frozen pytest tests/agent/test_context_compressor_summary_continuity.py -q`
- `uv run --frozen pytest tests/run_agent/test_run_agent.py -q -k duplicate_send_message_from_compaction_log`
- `uv run --frozen ruff check agent/side_effect_dedup.py agent/context_compressor.py agent/tool_executor.py tests/agent/test_context_compressor_summary_continuity.py tests/run_agent/test_run_agent.py`
- `python3 -m py_compile agent/side_effect_dedup.py agent/context_compressor.py agent/tool_executor.py tests/agent/test_context_compressor_summary_continuity.py tests/run_agent/test_run_agent.py`
- `git diff --check`

Fixes #48855.
