### PR TITLE
fix(desktop): reseed stale composer model from profile default

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-model-controls.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-model-controls.test.tsx
@@ -59,6 +59,7 @@ function Harness({
 
 describe('useModelControls', () => {
   beforeEach(() => {
+    window.localStorage.clear()
     $activeSessionId.set(null)
     setCurrentModel('')
     setCurrentProvider('')
@@ -67,6 +68,7 @@ describe('useModelControls', () => {
   afterEach(() => {
     cleanup()
     vi.restoreAllMocks()
+    window.localStorage.clear()
     $activeSessionId.set(null)
     setCurrentModel('')
     setCurrentProvider('')
@@ -194,5 +196,104 @@ describe('useModelControls', () => {
     // A profile swap forces a reseed to the new profile's default.
     await result.current.refreshCurrentModel(true)
     expect($currentModel.get()).toBe('openai/gpt-5.5')
+  })
+
+  it('reseeds stale composer state when the profile default changes', async () => {
+    vi.mocked(getGlobalModelInfo).mockResolvedValueOnce({
+      model: 'openai/gpt-5.5',
+      provider: 'openai-codex'
+    })
+
+    const { result } = renderHook(() =>
+      useModelControls({
+        activeSessionId: null,
+        queryClient: new QueryClient(),
+        requestGateway: vi.fn()
+      })
+    )
+
+    await result.current.refreshCurrentModel()
+    expect($currentModel.get()).toBe('openai/gpt-5.5')
+    expect($currentProvider.get()).toBe('openai-codex')
+
+    vi.mocked(getGlobalModelInfo).mockResolvedValueOnce({
+      model: 'openrouter/fusion',
+      provider: 'openrouter'
+    })
+
+    await result.current.refreshCurrentModel()
+
+    expect($currentModel.get()).toBe('openrouter/fusion')
+    expect($currentProvider.get()).toBe('openrouter')
+  })
+
+  it('replaces the legacy desktop default slug when no baseline has been recorded', async () => {
+    setCurrentModel('gpt-5.5')
+    setCurrentProvider('openai-codex')
+    vi.mocked(getGlobalModelInfo).mockResolvedValue({
+      model: 'openrouter/fusion',
+      provider: 'openrouter'
+    })
+
+    const { result } = renderHook(() =>
+      useModelControls({
+        activeSessionId: null,
+        queryClient: new QueryClient(),
+        requestGateway: vi.fn()
+      })
+    )
+
+    await result.current.refreshCurrentModel()
+
+    expect($currentModel.get()).toBe('openrouter/fusion')
+    expect($currentProvider.get()).toBe('openrouter')
+  })
+
+  it('replaces the legacy desktop OpenAI-prefixed default when no baseline has been recorded', async () => {
+    setCurrentModel('openai/gpt-5.5')
+    setCurrentProvider('openai-codex')
+    vi.mocked(getGlobalModelInfo).mockResolvedValue({
+      model: 'openrouter/fusion',
+      provider: 'openrouter'
+    })
+
+    const { result } = renderHook(() =>
+      useModelControls({
+        activeSessionId: null,
+        queryClient: new QueryClient(),
+        requestGateway: vi.fn()
+      })
+    )
+
+    await result.current.refreshCurrentModel()
+
+    expect($currentModel.get()).toBe('openrouter/fusion')
+    expect($currentProvider.get()).toBe('openrouter')
+  })
+
+  it('does not clobber a same-profile user pick on routine refresh', async () => {
+    vi.mocked(getGlobalModelInfo).mockResolvedValue({
+      model: 'openrouter/fusion',
+      provider: 'openrouter'
+    })
+
+    const { result } = renderHook(() =>
+      useModelControls({
+        activeSessionId: null,
+        queryClient: new QueryClient(),
+        requestGateway: vi.fn()
+      })
+    )
+
+    await result.current.refreshCurrentModel()
+
+    await result.current.selectModel({
+      model: 'anthropic/claude-sonnet-4.6',
+      provider: 'openrouter'
+    })
+    await result.current.refreshCurrentModel()
+
+    expect($currentModel.get()).toBe('anthropic/claude-sonnet-4.6')
+    expect($currentProvider.get()).toBe('openrouter')
   })
 })

--- a/apps/desktop/src/app/session/hooks/use-model-controls.ts
+++ b/apps/desktop/src/app/session/hooks/use-model-controls.ts
@@ -3,6 +3,7 @@ import { useCallback } from 'react'
 
 import { getGlobalModelInfo } from '@/hermes'
 import { useI18n } from '@/i18n'
+import { persistString, storedString } from '@/lib/storage'
 import { notifyError } from '@/store/notifications'
 import {
   $activeSessionId,
@@ -16,6 +17,50 @@ import type { ModelOptionsResponse } from '@/types/hermes'
 interface ModelSelection {
   model: string
   provider: string
+}
+
+const COMPOSER_DEFAULT_BASELINE_KEY = 'hermes.desktop.composer.default-baseline'
+
+const LEGACY_DESKTOP_DEFAULTS: readonly ModelSelection[] = [
+  { model: 'gpt-5.5', provider: 'openai-codex' },
+  { model: 'openai/gpt-5.5', provider: 'openai-codex' }
+]
+
+function sameSelection(left: ModelSelection, right: ModelSelection): boolean {
+  return left.model === right.model && left.provider === right.provider
+}
+
+function normalizedSelection(selection: ModelSelection): ModelSelection {
+  return {
+    model: selection.model.trim(),
+    provider: selection.provider.trim()
+  }
+}
+
+function readComposerDefaultBaseline(): ModelSelection | null {
+  const raw = storedString(COMPOSER_DEFAULT_BASELINE_KEY)
+
+  if (!raw) {
+    return null
+  }
+
+  try {
+    const parsed = JSON.parse(raw) as Partial<ModelSelection>
+    const model = typeof parsed.model === 'string' ? parsed.model.trim() : ''
+    const provider = typeof parsed.provider === 'string' ? parsed.provider.trim() : ''
+
+    return model ? { model, provider } : null
+  } catch {
+    return null
+  }
+}
+
+function writeComposerDefaultBaseline(selection: ModelSelection): void {
+  persistString(COMPOSER_DEFAULT_BASELINE_KEY, JSON.stringify(normalizedSelection(selection)))
+}
+
+function isLegacyDesktopDefault(selection: ModelSelection): boolean {
+  return LEGACY_DESKTOP_DEFAULTS.some(defaultSelection => sameSelection(selection, defaultSelection))
 }
 
 interface ModelControlsOptions {
@@ -42,33 +87,46 @@ export function useModelControls({ activeSessionId, queryClient, requestGateway 
   )
 
   // Seed the composer's model state from the profile default. `force` reseeds
-  // for a profile swap (the new profile has its own default); otherwise this
-  // only fills an EMPTY selection so a user's pick (plain UI state in
-  // $currentModel) survives the lifecycle refreshes that fire on boot / fresh
-  // draft / session events. A live session owns the footer, so skip entirely.
+  // for a profile swap (the new profile has its own default). Routine refreshes
+  // may also reseed when the composer still matches the last default we seeded
+  // and the profile default has changed; once a user picks a different model,
+  // that plain UI state survives boot / fresh draft / session-event refreshes.
+  // A live session owns the footer, so skip entirely.
   const refreshCurrentModel = useCallback(async (force = false) => {
     try {
       if ($activeSessionId.get()) {
         return
       }
 
-      if (!force && $currentModel.get()) {
-        return
-      }
-
       const result = await getGlobalModelInfo()
+      const nextDefault = normalizedSelection({
+        model: typeof result.model === 'string' ? result.model : '',
+        provider: typeof result.provider === 'string' ? result.provider : ''
+      })
 
-      if ($activeSessionId.get() || (!force && $currentModel.get())) {
+      if ($activeSessionId.get() || !nextDefault.model) {
         return
       }
 
-      if (typeof result.model === 'string') {
-        setCurrentModel(result.model)
+      const current = normalizedSelection({
+        model: $currentModel.get(),
+        provider: $currentProvider.get()
+      })
+      const baseline = readComposerDefaultBaseline()
+      const shouldReseed =
+        force ||
+        !current.model ||
+        sameSelection(current, nextDefault) ||
+        (baseline != null && sameSelection(current, baseline) && !sameSelection(baseline, nextDefault)) ||
+        (baseline == null && isLegacyDesktopDefault(current) && !sameSelection(current, nextDefault))
+
+      if (!shouldReseed) {
+        return
       }
 
-      if (typeof result.provider === 'string') {
-        setCurrentProvider(result.provider)
-      }
+      setCurrentModel(nextDefault.model)
+      setCurrentProvider(nextDefault.provider)
+      writeComposerDefaultBaseline(nextDefault)
     } catch {
       // The delayed session.info event still updates this once the agent is ready.
     }

--- a/apps/desktop/src/lib/model-status-label.test.ts
+++ b/apps/desktop/src/lib/model-status-label.test.ts
@@ -8,6 +8,7 @@ describe('model-status-label', () => {
     expect(displayModelName('openai/gpt-5.5-fast')).toBe('GPT-5.5')
     expect(displayModelName('deepseek/deepseek-v4-pro-thinking')).toBe('Deepseek V4 Pro')
     expect(displayModelName('openai/gpt-5.5')).toBe('GPT-5.5')
+    expect(displayModelName('openrouter/fusion')).toBe('OpenRouter Fusion')
   })
 
   it('strips trailing date-pin snapshots from the display name', () => {
@@ -30,6 +31,7 @@ describe('model-status-label', () => {
   it('always surfaces the effort (default medium) so the level is visible', () => {
     expect(formatModelStatusLabel('openai/gpt-5.5', { reasoningEffort: 'medium' })).toBe('GPT-5.5 · Med')
     expect(formatModelStatusLabel('openai/gpt-5.5')).toBe('GPT-5.5 · Med')
+    expect(formatModelStatusLabel('openrouter/fusion')).toBe('OpenRouter Fusion · Med')
   })
 
   it('returns just the placeholder name when there is no model', () => {

--- a/apps/desktop/src/lib/model-status-label.ts
+++ b/apps/desktop/src/lib/model-status-label.ts
@@ -51,6 +51,10 @@ const VARIANT_TAGS: ReadonlyArray<readonly [RegExp, string]> = [
   [/-latest$/i, 'Latest']
 ]
 
+const MODEL_DISPLAY_NAMES: Record<string, string> = {
+  'openrouter/fusion': 'OpenRouter Fusion'
+}
+
 const titleCase = (text: string): string => text.replace(/\b\w/g, char => char.toUpperCase()).trim()
 
 function prettifyBase(base: string): string {
@@ -72,6 +76,12 @@ function prettifyBase(base: string): string {
 /** Split a model id into a clean display name plus an optional grayed variant
  *  tag, so distinct ids (e.g. `…-4.8` vs `…-4.8-fast`) don't collapse. */
 export function modelDisplayParts(model: string): { name: string; tag: string } {
+  const override = MODEL_DISPLAY_NAMES[model.trim().toLowerCase()]
+
+  if (override) {
+    return { name: override, tag: '' }
+  }
+
   let base = modelBaseId(model)
   let tag = ''
 


### PR DESCRIPTION
## Summary

A Desktop profile configured as `openrouter / openrouter/fusion` could still create brand-new chats with stale `gpt-5.5 / openai-codex` composer state. Fresh no-session composer state now reseeds from the active profile default when it still matches the last default (or the legacy GPT-5.5 default), while deliberate same-profile model picks continue to survive routine refreshes.

This also gives the router slug a readable Desktop label: `openrouter/fusion` renders as **OpenRouter Fusion** instead of the generic `Fusion`.

## Root cause

Desktop has two model-selection layers:

| Layer | Scope | Persistence | Used by |
|---|---|---|---|
| Profile default | per profile | `config.yaml` | new non-Desktop sessions, settings defaults, backend resolution |
| Composer pick | Desktop UI state | `localStorage` | Desktop `session.create` per-session overrides |

The composer layer is intentionally sticky, but the refresh path only seeded when the current model was empty (or on a forced profile swap). If a user changed a profile default outside that composer state — for example to `openrouter / openrouter/fusion` — the stale persisted composer value (`gpt-5.5 / openai-codex`) kept winning and was sent with `session.create` for brand-new Desktop chats.

## Changes

- `apps/desktop/src/app/session/hooks/use-model-controls.ts`
  - records the last profile default used to seed the no-session composer
  - reseeds when the composer still matches that baseline and the profile default changes
  - explicitly migrates legacy Desktop defaults (`gpt-5.5` and `openai/gpt-5.5` with `openai-codex`) when no baseline exists
  - still skips active runtime sessions, so live chats are not mutated mid-turn
  - still preserves deliberate same-profile user picks on routine refresh
- `apps/desktop/src/lib/model-status-label.ts`
  - maps `openrouter/fusion` to `OpenRouter Fusion`
- tests cover stale default reseeding, both legacy GPT-5.5 spellings, user-pick preservation, and the display label

## Related work

This PR is intentionally Desktop-only. The OpenRouter catalog/router-alias picker side is already covered by:

- #47485 — adds `openrouter/fusion` to the OpenRouter picker/catalog path
- #46067 — surfaces OpenRouter router models that report `supported_parameters: []`

Those PRs make the slug selectable; this PR makes Desktop honor the active profile default instead of letting stale composer state override it.

## Validation

| Check | Result |
|---|---|
| `npm --workspace apps/desktop run test:ui -- src/app/session/hooks/use-model-controls.test.tsx src/lib/model-status-label.test.ts src/store/model-visibility.test.ts` | 3 files / 26 tests passed |
| `npm --workspace apps/desktop run build` | passed (`vite build` + `assert-dist-built`) |
| `git diff --check` | clean |
| Rebased on current `origin/main` | yes; PR head `8a17d824f7433375995cae38dbd603660695b232` |

Draft until source-launched Desktop manual QA is exercised from `apps/desktop` (not `/Applications/Hermes.app`).
