### PR TITLE
feat(desktop): linkify file paths inside inline / one-line code spans (follow-up to #48859)

### DIFF
--- a/apps/desktop/electron/hardening.cjs
+++ b/apps/desktop/electron/hardening.cjs
@@ -186,7 +186,10 @@ async function statForIpc(fsImpl, resolvedPath, purpose, typeLabel) {
     if (code === 'ENOENT' || code === 'ENOTDIR') {
       throw ipcPathError(code || 'ENOENT', `${purpose} failed: ${typeLabel} does not exist.`)
     }
-    throw ipcPathError(code || 'read-error', `${purpose} failed: ${error instanceof Error ? error.message : String(error)}`)
+    throw ipcPathError(
+      code || 'read-error',
+      `${purpose} failed: ${error instanceof Error ? error.message : String(error)}`
+    )
   }
 }
 
@@ -201,7 +204,10 @@ async function realpathForIpc(fsImpl, resolvedPath, purpose) {
     return realPath
   } catch (error) {
     const code = error && typeof error === 'object' ? error.code : ''
-    throw ipcPathError(code || 'read-error', `${purpose} failed: ${error instanceof Error ? error.message : String(error)}`)
+    throw ipcPathError(
+      code || 'read-error',
+      `${purpose} failed: ${error instanceof Error ? error.message : String(error)}`
+    )
   }
 }
 
@@ -265,13 +271,169 @@ async function resolveReadableFileForIpc(filePath, options = {}) {
   return { realPath, resolvedPath, stat }
 }
 
+// Files we are willing to hand to the OS "open in default app" handler
+// (shell.openPath) when a chat-/LLM-supplied path is clicked. This is a strict
+// ALLOWLIST of inert document/media types — never executables, scripts,
+// shortcuts, or launchers. A path emitted in chat is an attacker-influenced
+// string (SECURITY.md: the LLM is assumed potentially adversarial), and the
+// agent can write the very file it links, so opening one by OS file
+// association is a code-execution primitive unless the type is provably inert.
+// `.html`/`.svg` are excluded on purpose: they execute with a file:// origin in
+// the OS browser, so the renderer routes them to the sandboxed preview pane.
+const OPENABLE_DEFAULT_APP_EXTENSIONS = new Set([
+  '.aac',
+  '.avi',
+  '.avif',
+  '.bmp',
+  '.conf',
+  '.csv',
+  '.flac',
+  '.gif',
+  '.heic',
+  '.ico',
+  '.ini',
+  '.jpeg',
+  '.jpg',
+  '.json',
+  '.log',
+  '.m4a',
+  '.m4v',
+  '.markdown',
+  '.md',
+  '.mkv',
+  '.mov',
+  '.mp3',
+  '.mp4',
+  '.ogg',
+  '.pdf',
+  '.png',
+  '.rtf',
+  '.text',
+  '.tif',
+  '.tiff',
+  '.toml',
+  '.tsv',
+  '.txt',
+  '.wav',
+  '.webm',
+  '.webp',
+  '.xml',
+  '.yaml',
+  '.yml'
+])
+
+// Reject network / UNC paths (`\\host\share`, `//host/share`). rejectUnsafe-
+// PathSyntax already blocks Windows device paths; this closes the SMB/NTLM-leak
+// and remote-exec surface for the open/reveal handlers.
+function rejectRemotePathSyntax(filePath, purpose = 'Open file') {
+  const normalized = String(filePath || '').replace(/\\/g, '/')
+
+  if (normalized.startsWith('//')) {
+    throw ipcPathError('remote-path', `${purpose} blocked: network/UNC paths are not allowed.`)
+  }
+
+  return filePath
+}
+
+// Reject paths containing control characters. rejectUnsafePathSyntax already
+// blocks NUL; this also blocks newlines/tabs/etc. so a chat-supplied filename
+// like `safe.pdf\n\n\n<scary text>.pdf` can't spoof the open-confirm dialog
+// (which renders newlines as line breaks and would scroll the real path away).
+function rejectControlCharPath(filePath, purpose = 'Open file') {
+  // eslint-disable-next-line no-control-regex
+  if (/[\u0000-\u001f]/.test(String(filePath || ''))) {
+    throw ipcPathError('invalid-path', `${purpose} blocked: path contains control characters.`)
+  }
+
+  return filePath
+}
+
+// Confine `target` to an already-resolved `base` (the session workspace). Used
+// only on the open-in-default-app path so a chat-supplied absolute path can't
+// reach arbitrary host files. Callers compare the pre-symlink path against the
+// resolved base AND the realpath against the realpath'd base, so a symlinked
+// workspace root (e.g. macOS /var → /private/var) doesn't false-reject.
+function assertPathWithinBase(target, base, purpose) {
+  const rel = path.relative(base, target)
+
+  if (rel === '..' || rel.startsWith(`..${path.sep}`) || path.isAbsolute(rel)) {
+    throw ipcPathError('outside-workspace', `${purpose} blocked: file is outside the current workspace.`)
+  }
+}
+
+function assertOpenableInDefaultApp(filePath, purpose = 'Open file') {
+  const ext = path.extname(String(filePath || '')).toLowerCase()
+
+  if (!ext || !OPENABLE_DEFAULT_APP_EXTENSIONS.has(ext)) {
+    throw ipcPathError(
+      'not-openable',
+      `${purpose} blocked: "${ext || 'this file type'}" cannot be opened in the OS default app.`
+    )
+  }
+}
+
+// Resolve + harden an agent-/chat-supplied path for an OS-level "open" or
+// "reveal" action. Rejects null-byte / device / UNC paths, blocks sensitive
+// files (.ssh, .env, private keys, ...), requires a real existing regular file,
+// resolves symlinks (realpath) and re-checks on the real path, and — when
+// `requireWithinBase` is set — confines the file to `baseDir`. Does NOT enforce
+// the open-in-default-app extension allowlist; callers that launch via
+// shell.openPath must additionally call assertOpenableInDefaultApp().
+async function resolveOpenablePathForIpc(filePath, options = {}) {
+  const purpose = String(options.purpose || 'Open file')
+  const fsImpl = options.fs || fs
+  const resolvedPath = resolveRequestedPathForIpc(filePath, { baseDir: options.baseDir, purpose })
+
+  rejectControlCharPath(resolvedPath, purpose)
+  rejectRemotePathSyntax(resolvedPath, purpose)
+  rejectSensitiveFilePath(resolvedPath, purpose)
+
+  const stat = await statForIpc(fsImpl, resolvedPath, purpose, 'file')
+
+  if (stat.isDirectory()) {
+    throw ipcPathError('EISDIR', `${purpose} failed: path points to a directory.`)
+  }
+
+  if (!stat.isFile()) {
+    throw ipcPathError('EINVAL', `${purpose} failed: only regular files can be opened.`)
+  }
+
+  const realPath = await realpathForIpc(fsImpl, resolvedPath, purpose)
+
+  rejectControlCharPath(realPath, purpose)
+  rejectRemotePathSyntax(realPath, purpose)
+  rejectSensitiveFilePath(realPath, purpose)
+
+  if (options.requireWithinBase) {
+    const baseInput = typeof options.baseDir === 'string' && options.baseDir.trim() ? options.baseDir : process.cwd()
+    const resolvedBase = path.resolve(rejectUnsafePathSyntax(baseInput, purpose))
+    let realBase = resolvedBase
+
+    try {
+      realBase = await realpathForIpc(fsImpl, resolvedBase, purpose)
+    } catch {
+      realBase = resolvedBase
+    }
+
+    assertPathWithinBase(resolvedPath, resolvedBase, purpose)
+    assertPathWithinBase(realPath, realBase, purpose)
+  }
+
+  return { realPath, resolvedPath, stat }
+}
+
 module.exports = {
   DATA_URL_READ_MAX_BYTES,
   DEFAULT_FETCH_TIMEOUT_MS,
+  OPENABLE_DEFAULT_APP_EXTENSIONS,
   TEXT_PREVIEW_SOURCE_MAX_BYTES,
+  assertOpenableInDefaultApp,
   encryptDesktopSecret,
+  rejectRemotePathSyntax,
+  rejectSensitiveFilePath,
   rejectUnsafePathSyntax,
   resolveDirectoryForIpc,
+  resolveOpenablePathForIpc,
   resolveReadableFileForIpc,
   resolveRequestedPathForIpc,
   resolveTimeoutMs,

--- a/apps/desktop/electron/main.cjs
+++ b/apps/desktop/electron/main.cjs
@@ -75,7 +75,9 @@ const {
   DATA_URL_READ_MAX_BYTES,
   DEFAULT_FETCH_TIMEOUT_MS,
   TEXT_PREVIEW_SOURCE_MAX_BYTES,
+  assertOpenableInDefaultApp,
   encryptDesktopSecret: encryptDesktopSecretStrict,
+  resolveOpenablePathForIpc,
   resolveReadableFileForIpc,
   resolveRequestedPathForIpc,
   resolveTimeoutMs
@@ -1879,7 +1881,9 @@ async function handOffWindowsBootstrapRecovery(reason) {
   })
   child.unref()
 
-  rememberLog(`[bootstrap] handed off ${reason} recovery to updater: ${updater} ${updaterArgs.join(' ')}; exiting desktop to release app.asar`)
+  rememberLog(
+    `[bootstrap] handed off ${reason} recovery to updater: ${updater} ${updaterArgs.join(' ')}; exiting desktop to release app.asar`
+  )
   setTimeout(() => {
     app.quit()
   }, 600)
@@ -2489,7 +2493,9 @@ async function ensureRuntime(backend) {
     rememberLog('[bootstrap] no Hermes install found; starting first-launch bootstrap')
 
     if (await handOffWindowsBootstrapRecovery('bootstrap-needed')) {
-      const handoffError = new Error('Hermes recovery was handed off to Hermes Setup. The desktop will restart when recovery completes.')
+      const handoffError = new Error(
+        'Hermes recovery was handed off to Hermes Setup. The desktop will restart when recovery completes.'
+      )
       handoffError.isBootstrapFailure = true
       handoffError.bootstrapHandedOff = true
       bootstrapFailure = handoffError
@@ -2624,7 +2630,6 @@ async function ensureRuntime(backend) {
   })
   return backend
 }
-
 
 function fetchJson(url, token, options = {}) {
   return new Promise((resolve, reject) => {
@@ -5791,6 +5796,102 @@ ipcMain.on('hermes:translucency', (_event, payload) => {
 ipcMain.handle('hermes:openExternal', (_event, url) => {
   if (!openExternalUrl(url)) {
     throw new Error('Invalid external URL')
+  }
+})
+
+// Open a chat-referenced file in the OS default application. Unlike the
+// artifacts-panel `openExternalUrl` file: branch (which only path-resolves),
+// this is the hardened path used for auto-linkified chat file paths:
+// resolveOpenablePathForIpc confines the file to the session workspace, blocks
+// sensitive files, resolves symlinks, and rejects device/UNC paths;
+// assertOpenableInDefaultApp then enforces an inert-extension allowlist so an
+// agent-written .command/.sh/.app/.html can never be launched by association.
+// An optional `confirm` (localized copy from the renderer) shows the fully
+// resolved real path before launch, defusing label spoofing.
+//
+// NOTE (follow-up, see PR): the older openExternalUrl file: branch shares the
+// same launch primitive without these guards. Routing it through this helper
+// would close that latent gap, but is left out of this PR to keep the change
+// scoped to the new feature.
+ipcMain.handle('hermes:openPath', async (event, filePath, options = {}) => {
+  const purpose = 'Open file'
+  const baseDir = typeof options.baseDir === 'string' ? options.baseDir : undefined
+
+  // Full validation: resolve + confine + symlink-resolve + sensitive-block +
+  // (on the realpath) inert-extension allowlist. resolveOpenablePathForIpc also
+  // rejects control-char paths, so a newline-laden filename can't reach the
+  // dialog and spoof the displayed path.
+  async function validateOpenable() {
+    const { realPath } = await resolveOpenablePathForIpc(filePath, { baseDir, purpose, requireWithinBase: true })
+
+    assertOpenableInDefaultApp(realPath, purpose)
+
+    return realPath
+  }
+
+  try {
+    const realPath = await validateOpenable()
+
+    const confirm = options.confirm
+
+    if (confirm && typeof confirm === 'object') {
+      const win = BrowserWindow.fromWebContents(event.sender)
+      const messageOptions = {
+        type: 'question',
+        buttons: [String(confirm.confirmLabel || 'Open'), String(confirm.cancelLabel || 'Cancel')],
+        cancelId: 1,
+        defaultId: 0,
+        detail: `${confirm.detail ? `${confirm.detail}\n\n` : ''}${realPath}`,
+        message: String(confirm.title || 'Open file in its default app?'),
+        noLink: true
+      }
+      const { response } = win
+        ? await dialog.showMessageBox(win, messageOptions)
+        : await dialog.showMessageBox(messageOptions)
+
+      if (response !== 0) {
+        return { ok: false, reason: 'canceled' }
+      }
+    }
+
+    // Re-validate immediately before launch. The agent runs concurrently and
+    // can swap the file for a symlink to a .command/.app during the (user-
+    // paced) confirm dialog; re-resolving realpath and re-running the
+    // allowlist/confinement here collapses that TOCTOU window to the few
+    // microseconds before shell.openPath (an irreducible residual, since
+    // shell.openPath re-resolves the path string itself).
+    const launchPath = await validateOpenable()
+    const openError = await shell.openPath(launchPath)
+
+    if (openError) {
+      return { error: openError, ok: false, reason: 'open-failed' }
+    }
+
+    return { ok: true, path: launchPath }
+  } catch (error) {
+    return { error: error?.message, ok: false, reason: error?.code || 'error' }
+  }
+})
+
+// Reveal a chat-referenced file in the OS file manager. Reveal never launches
+// the file, so it is not workspace-confined (generated files often live in a
+// temp dir), but it still resolves symlinks, blocks sensitive files, and
+// rejects device/UNC paths.
+ipcMain.handle('hermes:revealInFolder', async (_event, filePath, options = {}) => {
+  const purpose = 'Reveal file'
+
+  try {
+    const { realPath } = await resolveOpenablePathForIpc(filePath, {
+      baseDir: typeof options.baseDir === 'string' ? options.baseDir : undefined,
+      purpose,
+      requireWithinBase: false
+    })
+
+    shell.showItemInFolder(realPath)
+
+    return { ok: true, path: realPath }
+  } catch (error) {
+    return { error: error?.message, ok: false, reason: error?.code || 'error' }
   }
 })
 

--- a/apps/desktop/electron/open-path.test.cjs
+++ b/apps/desktop/electron/open-path.test.cjs
@@ -1,0 +1,137 @@
+// Hardening tests for the chat file-path "open in default app" / "reveal"
+// handlers (see main.cjs hermes:openPath / hermes:revealInFolder). These cover
+// resolveOpenablePathForIpc + assertOpenableInDefaultApp from hardening.cjs;
+// they run under plain `node --test` (no Electron) because hardening.cjs only
+// requires node builtins.
+
+const assert = require('node:assert/strict')
+const fs = require('node:fs')
+const os = require('node:os')
+const path = require('node:path')
+const test = require('node:test')
+
+const {
+  OPENABLE_DEFAULT_APP_EXTENSIONS,
+  assertOpenableInDefaultApp,
+  rejectRemotePathSyntax,
+  resolveOpenablePathForIpc
+} = require('./hardening.cjs')
+
+function tmpDir(prefix) {
+  return fs.mkdtempSync(path.join(os.tmpdir(), prefix))
+}
+
+test('opens an allowlisted file confined to the workspace', async () => {
+  const dir = tmpDir('hermes-openpath-')
+  const file = path.join(dir, 'report.pdf')
+  fs.writeFileSync(file, '%PDF-1.4')
+
+  const { realPath } = await resolveOpenablePathForIpc(file, {
+    baseDir: dir,
+    purpose: 'Open file',
+    requireWithinBase: true
+  })
+
+  assert.equal(realPath, fs.realpathSync(file))
+  assert.doesNotThrow(() => assertOpenableInDefaultApp(realPath))
+})
+
+test('blocks executable / script / launcher / web extensions from open-in-default-app', () => {
+  for (const name of ['evil.command', 'evil.sh', 'evil.app', 'evil.desktop', 'evil.bat', 'evil.html', 'evil.svg']) {
+    assert.throws(() => assertOpenableInDefaultApp(`/ws/${name}`), /not-openable|cannot be opened/i)
+  }
+})
+
+test('the open allowlist excludes html and svg but includes inert media/docs', () => {
+  assert.ok(!OPENABLE_DEFAULT_APP_EXTENSIONS.has('.html'))
+  assert.ok(!OPENABLE_DEFAULT_APP_EXTENSIONS.has('.svg'))
+  assert.ok(OPENABLE_DEFAULT_APP_EXTENSIONS.has('.png'))
+  assert.ok(OPENABLE_DEFAULT_APP_EXTENSIONS.has('.pdf'))
+})
+
+test('rejects a path outside the workspace when confinement is required', async () => {
+  const dir = tmpDir('hermes-openpath-')
+  const outside = tmpDir('hermes-outside-')
+  const file = path.join(outside, 'note.txt')
+  fs.writeFileSync(file, 'x')
+
+  await assert.rejects(
+    () => resolveOpenablePathForIpc(file, { baseDir: dir, purpose: 'Open file', requireWithinBase: true }),
+    /outside the current workspace|outside-workspace/i
+  )
+})
+
+test('blocks sensitive files (.env) even inside the workspace', async () => {
+  const dir = tmpDir('hermes-openpath-')
+  const env = path.join(dir, '.env')
+  fs.writeFileSync(env, 'SECRET=1')
+
+  await assert.rejects(
+    () => resolveOpenablePathForIpc(env, { baseDir: dir, purpose: 'Open file', requireWithinBase: true }),
+    /sensitive/i
+  )
+})
+
+test('follows symlinks and re-checks the real path (workspace escape blocked)', async () => {
+  const dir = tmpDir('hermes-openpath-')
+  const outside = tmpDir('hermes-outside-')
+  const realFile = path.join(outside, 'secret.pdf')
+  fs.writeFileSync(realFile, '%PDF')
+  const link = path.join(dir, 'innocent.pdf')
+
+  try {
+    fs.symlinkSync(realFile, link)
+  } catch {
+    return // symlink creation may be unavailable (unprivileged CI); skip.
+  }
+
+  await assert.rejects(
+    () => resolveOpenablePathForIpc(link, { baseDir: dir, purpose: 'Open file', requireWithinBase: true }),
+    /outside the current workspace|outside-workspace/i
+  )
+})
+
+test('rejects network / UNC paths', () => {
+  assert.throws(() => rejectRemotePathSyntax('\\\\server\\share\\x.txt'), /network|unc|remote/i)
+  assert.throws(() => rejectRemotePathSyntax('//server/share/x.txt'), /network|unc|remote/i)
+})
+
+test('reveal allows a file outside the workspace (requireWithinBase: false)', async () => {
+  const dir = tmpDir('hermes-reveal-')
+  const file = path.join(dir, 'note.txt')
+  fs.writeFileSync(file, 'hi')
+
+  const { realPath } = await resolveOpenablePathForIpc(file, { purpose: 'Reveal file', requireWithinBase: false })
+
+  assert.equal(realPath, fs.realpathSync(file))
+})
+
+test('rejects paths containing control characters (open-dialog spoofing guard)', async () => {
+  const dir = tmpDir('hermes-openpath-')
+  let file
+
+  try {
+    file = path.join(dir, 'evil\nreport.pdf')
+    fs.writeFileSync(file, '%PDF')
+  } catch {
+    return // some filesystems disallow newline filenames; skip.
+  }
+
+  await assert.rejects(
+    () => resolveOpenablePathForIpc(file, { baseDir: dir, purpose: 'Open file', requireWithinBase: true }),
+    /control character/i
+  )
+})
+
+test('rejects a directory and a missing file', async () => {
+  const dir = tmpDir('hermes-openpath-')
+
+  await assert.rejects(
+    () => resolveOpenablePathForIpc(dir, { baseDir: dir, purpose: 'Open file', requireWithinBase: true }),
+    /directory/i
+  )
+  await assert.rejects(
+    () => resolveOpenablePathForIpc(path.join(dir, 'nope.pdf'), { baseDir: dir, purpose: 'Open file' }),
+    /does not exist/i
+  )
+})

--- a/apps/desktop/electron/preload.cjs
+++ b/apps/desktop/electron/preload.cjs
@@ -44,6 +44,8 @@ contextBridge.exposeInMainWorld('hermesDesktop', {
   setTranslucency: payload => ipcRenderer.send('hermes:translucency', payload),
   setPreviewShortcutActive: active => ipcRenderer.send('hermes:previewShortcutActive', Boolean(active)),
   openExternal: url => ipcRenderer.invoke('hermes:openExternal', url),
+  openPath: (filePath, options) => ipcRenderer.invoke('hermes:openPath', filePath, options),
+  revealPath: (filePath, options) => ipcRenderer.invoke('hermes:revealInFolder', filePath, options),
   fetchLinkTitle: url => ipcRenderer.invoke('hermes:fetchLinkTitle', url),
   sanitizeWorkspaceCwd: cwd => ipcRenderer.invoke('hermes:workspace:sanitize', cwd),
   settings: {

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -37,7 +37,7 @@
     "test:desktop:nsis": "node scripts/test-desktop.mjs nsis",
     "test:desktop:existing": "node scripts/test-desktop.mjs existing",
     "test:desktop:fresh": "node scripts/test-desktop.mjs fresh",
-    "test:desktop:platforms": "node --test electron/bootstrap-platform.test.cjs electron/hardening.test.cjs electron/backend-env.test.cjs electron/backend-probes.test.cjs electron/bootstrap-runner.test.cjs electron/connection-config.test.cjs electron/dashboard-token.test.cjs electron/gateway-ws-probe.test.cjs electron/oauth-net-request.test.cjs electron/desktop-uninstall.test.cjs electron/session-windows.test.cjs electron/workspace-cwd.test.cjs electron/fs-read-dir.test.cjs electron/git-root.test.cjs electron/windows-child-process.test.cjs electron/update-remote.test.cjs electron/update-rebuild.test.cjs electron/windows-user-env.test.cjs",
+    "test:desktop:platforms": "node --test electron/bootstrap-platform.test.cjs electron/hardening.test.cjs electron/open-path.test.cjs electron/backend-env.test.cjs electron/backend-probes.test.cjs electron/bootstrap-runner.test.cjs electron/connection-config.test.cjs electron/dashboard-token.test.cjs electron/gateway-ws-probe.test.cjs electron/oauth-net-request.test.cjs electron/desktop-uninstall.test.cjs electron/session-windows.test.cjs electron/workspace-cwd.test.cjs electron/fs-read-dir.test.cjs electron/git-root.test.cjs electron/windows-child-process.test.cjs electron/update-remote.test.cjs electron/update-rebuild.test.cjs electron/windows-user-env.test.cjs",
     "typecheck": "tsc -p . --noEmit",
     "lint": "eslint src/ electron/",
     "lint:fix": "eslint src/ electron/ --fix",

--- a/apps/desktop/src/components/assistant-ui/markdown-text.tsx
+++ b/apps/desktop/src/components/assistant-ui/markdown-text.tsx
@@ -20,10 +20,12 @@ import {
 } from 'react'
 
 import { ExpandableBlock } from '@/components/chat/expandable-block'
+import { FilePathLink } from '@/components/chat/file-path-link'
 import { PreviewAttachment } from '@/components/chat/preview-attachment'
 import { chunkByLines, SyntaxHighlighter } from '@/components/chat/shiki-highlighter'
 import { ZoomableImage } from '@/components/chat/zoomable-image'
 import { normalizeExternalUrl, openExternalLink, PrettyLink } from '@/lib/external-link'
+import { filePathFromMarkdownHref } from '@/lib/file-path-links'
 import { createMemoizedMathPlugin } from '@/lib/katex-memo'
 import { preprocessMarkdown } from '@/lib/markdown-preprocess'
 import {
@@ -242,6 +244,12 @@ function MarkdownLink({ children, className, href, ...props }: ComponentProps<'a
 
   if (mediaPath) {
     return <MediaAttachment path={mediaPath} />
+  }
+
+  const filePathTarget = filePathFromMarkdownHref(href)
+
+  if (filePathTarget) {
+    return <FilePathLink target={filePathTarget} />
   }
 
   const previewTarget = previewTargetFromMarkdownHref(href)

--- a/apps/desktop/src/components/chat/file-path-link.tsx
+++ b/apps/desktop/src/components/chat/file-path-link.tsx
@@ -1,0 +1,147 @@
+import { useStore } from '@nanostores/react'
+import { useRef, useState } from 'react'
+
+import {
+  ContextMenu,
+  ContextMenuContent,
+  ContextMenuItem,
+  ContextMenuSeparator,
+  ContextMenuTrigger
+} from '@/components/ui/context-menu'
+import { useI18n } from '@/i18n'
+import { splitFilePathSuffix } from '@/lib/file-path-links'
+import { normalizeOrLocalPreviewTarget } from '@/lib/local-preview'
+import { cn } from '@/lib/utils'
+import { notifyError } from '@/store/notifications'
+import { setCurrentSessionPreviewTarget } from '@/store/preview'
+import { $currentCwd } from '@/store/session'
+
+// A bare file path the agent mentioned in chat, rendered inline and clickable.
+// Left-click opens the file in the in-app sandboxed preview pane; the
+// right-click menu offers the hardened OS actions (open in default app / reveal
+// in file manager) plus copy. The `:line[:col]` suffix is shown but stripped
+// before opening, since the preview pane has no line target in v1.
+export function FilePathLink({ target }: { target: string }) {
+  const { t } = useI18n()
+  const cwd = useStore($currentCwd)
+  const [opening, setOpening] = useState(false)
+  const openingRef = useRef(false)
+  const { display, path } = splitFilePathSuffix(target)
+  const bridge = typeof window === 'undefined' ? undefined : window.hermesDesktop
+
+  function openErrorMessage(reason?: string): string {
+    if (reason === 'not-openable') {
+      return t.filePath.openBlocked
+    }
+
+    if (reason === 'outside-workspace') {
+      return t.filePath.outsideWorkspace
+    }
+
+    if (reason === 'sensitive-file') {
+      return t.filePath.blockedSensitive
+    }
+
+    return t.filePath.openFailed
+  }
+
+  async function openPreview() {
+    if (openingRef.current) {
+      return
+    }
+
+    openingRef.current = true
+    setOpening(true)
+
+    try {
+      const preview = await normalizeOrLocalPreviewTarget(path, cwd || undefined)
+
+      if (!preview) {
+        throw new Error(`Could not open preview: ${path}`)
+      }
+
+      setCurrentSessionPreviewTarget(preview, 'chat-path', path)
+    } catch (error) {
+      notifyError(error, t.preview.unavailable)
+    } finally {
+      openingRef.current = false
+      setOpening(false)
+    }
+  }
+
+  async function openInDefaultApp() {
+    if (!bridge?.openPath) {
+      return
+    }
+
+    const result = await bridge.openPath(path, {
+      baseDir: cwd || undefined,
+      confirm: {
+        cancelLabel: t.common.cancel,
+        confirmLabel: t.filePath.confirmOpen,
+        detail: t.filePath.confirmDetail,
+        title: t.filePath.confirmTitle
+      }
+    })
+
+    if (!result?.ok && result?.reason && result.reason !== 'canceled') {
+      notifyError(result.error || result.reason, openErrorMessage(result.reason))
+    }
+  }
+
+  async function reveal() {
+    if (!bridge?.revealPath) {
+      return
+    }
+
+    const result = await bridge.revealPath(path, { baseDir: cwd || undefined })
+
+    if (!result?.ok && result?.reason) {
+      notifyError(result.error || result.reason, t.filePath.revealFailed)
+    }
+  }
+
+  async function copyPath() {
+    try {
+      if (bridge?.writeClipboard) {
+        await bridge.writeClipboard(path)
+      } else {
+        await navigator.clipboard?.writeText(path)
+      }
+    } catch (error) {
+      notifyError(error, t.common.copyFailed)
+    }
+  }
+
+  return (
+    <ContextMenu>
+      <ContextMenuTrigger asChild>
+        <a
+          aria-busy={opening || undefined}
+          className={cn(
+            'cursor-pointer font-mono text-[0.9em] text-foreground underline decoration-current/25 underline-offset-2 transition-colors wrap-anywhere hover:decoration-current/60'
+          )}
+          href="#"
+          onClick={event => {
+            event.preventDefault()
+            void openPreview()
+          }}
+          title={t.filePath.tooltip}
+        >
+          {display}
+        </a>
+      </ContextMenuTrigger>
+      <ContextMenuContent>
+        <ContextMenuItem onSelect={() => void openPreview()}>{t.preview.openPreview}</ContextMenuItem>
+        {bridge?.openPath ? (
+          <ContextMenuItem onSelect={() => void openInDefaultApp()}>{t.filePath.openInDefaultApp}</ContextMenuItem>
+        ) : null}
+        {bridge?.revealPath ? (
+          <ContextMenuItem onSelect={() => void reveal()}>{t.filePath.revealInFolder}</ContextMenuItem>
+        ) : null}
+        <ContextMenuSeparator />
+        <ContextMenuItem onSelect={() => void copyPath()}>{t.filePath.copyPath}</ContextMenuItem>
+      </ContextMenuContent>
+    </ContextMenu>
+  )
+}

--- a/apps/desktop/src/global.d.ts
+++ b/apps/desktop/src/global.d.ts
@@ -60,6 +60,11 @@ declare global {
       setTranslucency?: (payload: { intensity: number }) => void
       setPreviewShortcutActive?: (active: boolean) => void
       openExternal: (url: string) => Promise<void>
+      // Open a chat-referenced file in the OS default app (hardened: workspace-
+      // confined + inert-extension allowlist + symlink/sensitive-file checks).
+      openPath: (path: string, options?: HermesOpenPathOptions) => Promise<HermesOpenPathResult>
+      // Reveal a chat-referenced file in the OS file manager.
+      revealPath: (path: string, options?: HermesOpenPathOptions) => Promise<HermesOpenPathResult>
       fetchLinkTitle: (url: string) => Promise<string>
       sanitizeWorkspaceCwd: (cwd?: null | string) => Promise<{ cwd: string; sanitized: boolean }>
       settings: {
@@ -487,6 +492,31 @@ export interface HermesSelectPathsOptions {
   directories?: boolean
   multiple?: boolean
   filters?: Array<{ name: string; extensions: string[] }>
+}
+
+export interface HermesOpenPathConfirm {
+  title?: string
+  detail?: string
+  confirmLabel?: string
+  cancelLabel?: string
+}
+
+export interface HermesOpenPathOptions {
+  // The session workspace root. open (but not reveal) is confined to it.
+  baseDir?: string
+  // When set, a native confirm dialog (showing the resolved real path) is shown
+  // before launching. Copy is supplied by the renderer so it stays localized.
+  confirm?: HermesOpenPathConfirm
+}
+
+export interface HermesOpenPathResult {
+  ok: boolean
+  // The fully resolved real path that was opened/revealed.
+  path?: string
+  // Machine-readable failure code: 'canceled' | 'not-openable' |
+  // 'outside-workspace' | 'sensitive-file' | 'open-failed' | ...
+  reason?: string
+  error?: string
 }
 
 export interface BackendExit {

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -1722,6 +1722,21 @@ export const en: Translations = {
     }
   },
 
+  filePath: {
+    tooltip: 'Click to preview · right-click for more',
+    openInDefaultApp: 'Open in default app',
+    revealInFolder: 'Reveal in folder',
+    copyPath: 'Copy path',
+    confirmTitle: 'Open file in its default app?',
+    confirmDetail: 'Hermes will open this file in your default application:',
+    confirmOpen: 'Open',
+    openFailed: 'Could not open this file.',
+    openBlocked: 'This file type cannot be opened directly. Reveal it in your file manager instead.',
+    blockedSensitive: 'This file is blocked because it may contain secrets.',
+    outsideWorkspace: 'This file is outside the current workspace.',
+    revealFailed: 'Could not reveal this file.'
+  },
+
   assistant: {
     thread: {
       loadingSession: 'Loading session',
@@ -1746,7 +1761,8 @@ export const en: Translations = {
       restoreCheckpoint: 'Restore checkpoint',
       restoreFromHere: 'Restore checkpoint — rerun from this prompt',
       restoreTitle: 'Restore to this checkpoint?',
-      restoreBody: 'Everything after this prompt is removed from the conversation, and the prompt runs again from here.',
+      restoreBody:
+        'Everything after this prompt is removed from the conversation, and the prompt runs again from here.',
       restoreConfirm: 'Restore & rerun',
       restoreNext: 'Restore next checkpoint',
       goForward: 'Go forward',
@@ -1845,7 +1861,8 @@ export const en: Translations = {
     editFailed: 'Edit failed',
     resumeFailed: 'Resume failed',
     resumeStrandedTitle: "Couldn't load this session",
-    resumeStrandedBody: 'The connection to this session failed and automatic retries gave up. Check that the gateway is running, then try again.',
+    resumeStrandedBody:
+      'The connection to this session failed and automatic retries gave up. Check that the gateway is running, then try again.',
     resumeRetry: 'Retry',
     nothingToBranch: 'Nothing to branch',
     branchNeedsChat: 'Start or resume a chat before branching.',

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -194,8 +194,7 @@ export const ja = defineLocale({
     },
     notifications: {
       title: '通知',
-      intro:
-        'アプリ内トーストとは別の、ネイティブのデスクトップ通知です。設定は端末ごとに保存されます。',
+      intro: 'アプリ内トーストとは別の、ネイティブのデスクトップ通知です。設定は端末ごとに保存されます。',
       enableAll: '通知を有効にする',
       enableAllDesc: 'マスタースイッチ。オフにすると以下のすべての通知を無効にします。',
       focusedHint: '完了通知は Hermes がバックグラウンドにあるときのみ表示されます。',
@@ -1410,7 +1409,8 @@ export const ja = defineLocale({
     queueSend: '送信',
     queueDelete: '削除',
     queueStuckTitle: 'キュー内のメッセージを送信できません',
-    queueStuckBody: 'キューに入れたターンの送信が繰り返し失敗しました。まだキューに残っています。もう一度送信してください。',
+    queueStuckBody:
+      'キューに入れたターンの送信が繰り返し失敗しました。まだキューに残っています。もう一度送信してください。',
     previewUnavailable: 'プレビューは利用できません',
     previewLabel: label => `${label} のプレビュー`,
     couldNotPreview: label => `${label} をプレビューできませんでした`,
@@ -1853,6 +1853,21 @@ export const ja = defineLocale({
     }
   },
 
+  filePath: {
+    tooltip: 'クリックでプレビュー · 右クリックでその他の操作',
+    openInDefaultApp: '既定のアプリで開く',
+    revealInFolder: 'フォルダーで表示',
+    copyPath: 'パスをコピー',
+    confirmTitle: '既定のアプリでファイルを開きますか？',
+    confirmDetail: 'Hermes はこのファイルをシステムの既定のアプリケーションで開きます：',
+    confirmOpen: '開く',
+    openFailed: 'このファイルを開けませんでした。',
+    openBlocked: 'この種類のファイルは直接開けません。代わりにファイルマネージャーで表示してください。',
+    blockedSensitive: 'このファイルは機密情報を含む可能性があるためブロックされました。',
+    outsideWorkspace: 'このファイルは現在のワークスペースの外にあります。',
+    revealFailed: 'このファイルを表示できませんでした。'
+  },
+
   assistant: {
     thread: {
       loadingSession: 'セッションを読み込み中',
@@ -1976,7 +1991,8 @@ export const ja = defineLocale({
     editFailed: '編集に失敗しました',
     resumeFailed: '再開に失敗しました',
     resumeStrandedTitle: 'このセッションを読み込めませんでした',
-    resumeStrandedBody: 'このセッションへの接続に失敗し、自動再試行も停止しました。ゲートウェイが実行中か確認してから、もう一度お試しください。',
+    resumeStrandedBody:
+      'このセッションへの接続に失敗し、自動再試行も停止しました。ゲートウェイが実行中か確認してから、もう一度お試しください。',
     resumeRetry: '再試行',
     nothingToBranch: 'ブランチするものがありません',
     branchNeedsChat: 'ブランチする前にチャットを開始または再開してください。',

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -1362,6 +1362,21 @@ export interface Translations {
     }
   }
 
+  filePath: {
+    tooltip: string
+    openInDefaultApp: string
+    revealInFolder: string
+    copyPath: string
+    confirmTitle: string
+    confirmDetail: string
+    confirmOpen: string
+    openFailed: string
+    openBlocked: string
+    blockedSensitive: string
+    outsideWorkspace: string
+    revealFailed: string
+  }
+
   assistant: {
     thread: {
       loadingSession: string

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -1795,6 +1795,21 @@ export const zhHant = defineLocale({
     }
   },
 
+  filePath: {
+    tooltip: '點擊預覽 · 右鍵查看更多',
+    openInDefaultApp: '以預設應用程式開啟',
+    revealInFolder: '在資料夾中顯示',
+    copyPath: '複製路徑',
+    confirmTitle: '以預設應用程式開啟此檔案？',
+    confirmDetail: 'Hermes 將以系統預設的應用程式開啟此檔案：',
+    confirmOpen: '開啟',
+    openFailed: '無法開啟此檔案。',
+    openBlocked: '此檔案類型無法直接開啟。請改為在檔案管理員中顯示。',
+    blockedSensitive: '此檔案可能包含機密資訊，已被封鎖。',
+    outsideWorkspace: '此檔案不在目前的工作區內。',
+    revealFailed: '無法顯示此檔案。'
+  },
+
   assistant: {
     thread: {
       loadingSession: '正在載入工作階段',

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -1901,6 +1901,21 @@ export const zh: Translations = {
     }
   },
 
+  filePath: {
+    tooltip: '点击预览 · 右键查看更多',
+    openInDefaultApp: '用默认应用打开',
+    revealInFolder: '在文件夹中显示',
+    copyPath: '复制路径',
+    confirmTitle: '用默认应用打开此文件？',
+    confirmDetail: 'Hermes 将使用系统默认应用打开此文件：',
+    confirmOpen: '打开',
+    openFailed: '无法打开此文件。',
+    openBlocked: '此文件类型无法直接打开。请改为在文件管理器中显示。',
+    blockedSensitive: '此文件可能包含机密信息，已被阻止。',
+    outsideWorkspace: '此文件不在当前工作区内。',
+    revealFailed: '无法显示此文件。'
+  },
+
   assistant: {
     thread: {
       loadingSession: '正在加载会话',

--- a/apps/desktop/src/lib/file-path-links.test.ts
+++ b/apps/desktop/src/lib/file-path-links.test.ts
@@ -1,0 +1,140 @@
+import { describe, expect, it } from 'vitest'
+
+import { filePathFromMarkdownHref, linkifyFilePaths, splitFilePathSuffix } from './file-path-links'
+import { preprocessMarkdown } from './markdown-preprocess'
+
+function hrefIn(markdown: string): null | string {
+  const match = markdown.match(/\(#file\/[^)]+\)/)
+
+  return match ? match[0].slice(1, -1) : null
+}
+
+describe('linkifyFilePaths', () => {
+  it('linkifies an absolute POSIX path', () => {
+    const out = linkifyFilePaths('saved to /Users/me/out.ts done')
+
+    expect(out).toContain('[/Users/me/out.ts](#file/')
+    expect(filePathFromMarkdownHref(hrefIn(out))).toBe('/Users/me/out.ts')
+  })
+
+  it('linkifies a ~/ home path', () => {
+    const out = linkifyFilePaths('see ~/notes/todo.md please')
+
+    expect(filePathFromMarkdownHref(hrefIn(out))).toBe('~/notes/todo.md')
+  })
+
+  it('keeps a :line:col suffix in the visible label', () => {
+    const out = linkifyFilePaths('error at /a/b.ts:42:7 now')
+
+    expect(out).toContain('[/a/b.ts:42:7](#file/')
+    expect(filePathFromMarkdownHref(hrefIn(out))).toBe('/a/b.ts:42:7')
+  })
+
+  it('linkifies a Windows drive path', () => {
+    const out = linkifyFilePaths('wrote C:\\Users\\me\\out.txt ok')
+
+    expect(out).toContain('](#file/')
+    expect(filePathFromMarkdownHref(hrefIn(out))).toBe('C:\\Users\\me\\out.txt')
+  })
+
+  it('does not linkify relative paths', () => {
+    expect(linkifyFilePaths('edit src/app/x.tsx now')).toBe('edit src/app/x.tsx now')
+  })
+
+  it('does not linkify directories or extensionless paths', () => {
+    expect(linkifyFilePaths('cd /usr/local/bin here')).toBe('cd /usr/local/bin here')
+  })
+
+  it('does not linkify domain paths (no scheme)', () => {
+    expect(linkifyFilePaths('visit example.com/docs/intro.html now')).toBe('visit example.com/docs/intro.html now')
+  })
+
+  it('does not rewrite a path already inside a markdown link', () => {
+    const input = '[label](/a/b.png)'
+
+    expect(linkifyFilePaths(input)).toBe(input)
+  })
+
+  it('does not rewrite a path inside an autolink', () => {
+    const input = '<https://example.com/a/b.ts>'
+
+    expect(linkifyFilePaths(input)).toBe(input)
+  })
+
+  it('encodes parentheses so the markdown target stays intact', () => {
+    const out = linkifyFilePaths('see /tmp/build(1)/out.txt now')
+
+    expect(filePathFromMarkdownHref(hrefIn(out))).toBe('/tmp/build(1)/out.txt')
+  })
+})
+
+describe('linkifyFilePaths — review-hardening regressions', () => {
+  it('does not corrupt an existing markdown link whose target contains parentheses', () => {
+    const input = 'See [the report](/Users/me/build(1)/out/result.json) for details.'
+
+    expect(linkifyFilePaths(input)).toBe(input)
+  })
+
+  it('does not corrupt a #preview link target containing parentheses', () => {
+    const input = '[r](#preview/path(x)/index.html)'
+
+    expect(linkifyFilePaths(input)).toBe(input)
+  })
+
+  it('linkifies a long (>8 char) extension in full, not truncated', () => {
+    const out = linkifyFilePaths('the file /home/user/data.properties now')
+
+    expect(filePathFromMarkdownHref(hrefIn(out))).toBe('/home/user/data.properties')
+    expect(out).not.toContain('data.properti]') // no truncated link
+    expect(out).not.toContain(')es ') // no stray tail leaked as prose
+  })
+
+  it('handles iOS extensions (.storyboard, .entitlements) without truncation', () => {
+    expect(filePathFromMarkdownHref(hrefIn(linkifyFilePaths('open /a/Main.storyboard now')))).toBe('/a/Main.storyboard')
+    expect(filePathFromMarkdownHref(hrefIn(linkifyFilePaths('see /a/App.entitlements here')))).toBe(
+      '/a/App.entitlements'
+    )
+  })
+
+  it('does not truncate/corrupt a path with a hyphen after the extension', () => {
+    // `/a/b.c-d` is ambiguous; the safe outcome is to leave it untouched rather
+    // than emit a link to the truncated `/a/b.c`.
+    const input = 'value /a/b.c-d here'
+
+    expect(linkifyFilePaths(input)).toBe(input)
+  })
+
+  it('peels a trailing sentence period off the path', () => {
+    const out = linkifyFilePaths('saved to /Users/me/out.ts.')
+
+    expect(filePathFromMarkdownHref(hrefIn(out))).toBe('/Users/me/out.ts')
+    expect(out).toContain('](#file/')
+    expect(out.endsWith('.')).toBe(true) // the period stays as prose
+  })
+})
+
+describe('splitFilePathSuffix', () => {
+  it('strips :line:col for the open target while keeping the display', () => {
+    expect(splitFilePathSuffix('/a/b.ts:42:7')).toEqual({ display: '/a/b.ts:42:7', path: '/a/b.ts' })
+  })
+
+  it('leaves a plain path untouched', () => {
+    expect(splitFilePathSuffix('/a/b.ts')).toEqual({ display: '/a/b.ts', path: '/a/b.ts' })
+  })
+})
+
+describe('preprocessMarkdown file-path linkification', () => {
+  it('linkifies a path in prose but not inside a fenced code block', () => {
+    const out = preprocessMarkdown('open /Users/me/a.txt\n\n```bash\ncat /Users/me/b.txt\n```\n')
+
+    expect(out).toContain('[/Users/me/a.txt](#file/')
+    expect(out).toContain('/Users/me/b.txt')
+    expect(out).not.toContain('[/Users/me/b.txt](#file/')
+  })
+
+  it('does not linkify a path inside inline code', () => {
+    const out = preprocessMarkdown('run `/Users/me/c.txt` please')
+
+    expect(out).not.toContain('#file/')
+  })
+})

--- a/apps/desktop/src/lib/file-path-links.test.ts
+++ b/apps/desktop/src/lib/file-path-links.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import { filePathFromMarkdownHref, linkifyFilePaths, splitFilePathSuffix } from './file-path-links'
+import { filePathFromMarkdownHref, isLoneFilePath, linkifyFilePaths, splitFilePathSuffix } from './file-path-links'
 import { preprocessMarkdown } from './markdown-preprocess'
 
 function hrefIn(markdown: string): null | string {
@@ -132,9 +132,52 @@ describe('preprocessMarkdown file-path linkification', () => {
     expect(out).not.toContain('[/Users/me/b.txt](#file/')
   })
 
-  it('does not linkify a path inside inline code', () => {
+  it('linkifies a lone path inside inline code (follow-up #1)', () => {
     const out = preprocessMarkdown('run `/Users/me/c.txt` please')
 
+    expect(out).toContain('[/Users/me/c.txt](#file/')
+  })
+
+  it('does not linkify inline code that is a command, not a lone path', () => {
+    const out = preprocessMarkdown('run `cat /Users/me/c.txt` please')
+
     expect(out).not.toContain('#file/')
+  })
+})
+
+describe('code-span path linkification (follow-up #1)', () => {
+  it('isLoneFilePath recognizes exactly-one-path strings', () => {
+    expect(isLoneFilePath('/Users/me/out.ts')).toBe(true)
+    expect(isLoneFilePath('/Users/me/out.ts:42:7')).toBe(true)
+    expect(isLoneFilePath('~/notes/todo.md')).toBe(true)
+    expect(isLoneFilePath('C:\\Users\\me\\out.txt')).toBe(true)
+    expect(isLoneFilePath('  /a/b.json  ')).toBe(true)
+  })
+
+  it('isLoneFilePath rejects commands, prose, and extensionless/relative paths', () => {
+    expect(isLoneFilePath('cat /a/b.ts')).toBe(false)
+    expect(isLoneFilePath('/a/b.ts and more')).toBe(false)
+    expect(isLoneFilePath('/usr/local/bin')).toBe(false)
+    expect(isLoneFilePath('src/app/x.tsx')).toBe(false)
+  })
+
+  it('linkifies a path emitted as a one-line code block', () => {
+    const out = preprocessMarkdown('Here it is:\n\n```\n/Users/me/out.ts\n```\n')
+
+    expect(out).toContain('[/Users/me/out.ts](#file/')
+    expect(out).not.toContain('```')
+  })
+
+  it('linkifies a one-line code block that carries a language tag', () => {
+    const out = preprocessMarkdown('```text\n/Users/me/report.pdf\n```')
+
+    expect(out).toContain('[/Users/me/report.pdf](#file/')
+  })
+
+  it('does NOT linkify paths inside a multi-line code block', () => {
+    const out = preprocessMarkdown('```bash\ncd /Users/me\ncat /Users/me/b.txt\n```')
+
+    expect(out).not.toContain('#file/')
+    expect(out).toContain('/Users/me/b.txt')
   })
 })

--- a/apps/desktop/src/lib/file-path-links.ts
+++ b/apps/desktop/src/lib/file-path-links.ts
@@ -49,6 +49,12 @@ const WINDOWS_PATH = `[A-Za-z]:[\\\\/](?:${SEGMENT}+[\\\\/])*${SEGMENT}+${EXTENS
 
 const FILE_PATH_RE = new RegExp(`${PATH_BOUNDARY}(?:${WINDOWS_PATH}|${POSIX_PATH})${LINE_SUFFIX}${END_BOUNDARY}`, 'g')
 
+// Anchored variant: matches a string that is EXACTLY one absolute file path
+// (plus optional :line[:col]) and nothing else. Used to linkify a path the
+// agent wrapped in inline code / a one-line code block, without touching code
+// that merely contains a path (commands, snippets, flags).
+const WHOLE_FILE_PATH_RE = new RegExp(`^(?:${WINDOWS_PATH}|${POSIX_PATH})${LINE_SUFFIX}$`)
+
 // Existing markdown links `[text](target)` and autolinks `<…>`. Captured so
 // linkification leaves them untouched and only rewrites the plain-text gaps.
 // The destination class allows one level of balanced parens so a link target
@@ -99,6 +105,18 @@ function escapeMarkdownLinkLabel(value: string): string {
   return value.replace(/[[\]]/g, '\\$&')
 }
 
+// Build the `[label](#file/…)` markdown a detected path becomes.
+export function fileLinkMarkdown(value: string): string {
+  return `[${escapeMarkdownLinkLabel(value)}](${filePathMarkdownHref(value)})`
+}
+
+// True when `value` is exactly one absolute file path. Lets callers linkify a
+// path the agent wrapped in inline code / a one-line code block while leaving
+// code that only contains a path (e.g. `cat /a/b.ts`) untouched.
+export function isLoneFilePath(value: string): boolean {
+  return WHOLE_FILE_PATH_RE.test(value.trim())
+}
+
 export function linkifyFilePaths(text: string): string {
   if (!text.includes('/') && !/[A-Za-z]:[\\/]/.test(text)) {
     return text
@@ -112,7 +130,7 @@ export function linkifyFilePaths(text: string): string {
         return part
       }
 
-      return part.replace(FILE_PATH_RE, match => `[${escapeMarkdownLinkLabel(match)}](${filePathMarkdownHref(match)})`)
+      return part.replace(FILE_PATH_RE, match => fileLinkMarkdown(match))
     })
     .join('')
 }

--- a/apps/desktop/src/lib/file-path-links.ts
+++ b/apps/desktop/src/lib/file-path-links.ts
@@ -1,0 +1,118 @@
+// Detect bare file paths in assistant chat prose and turn them into clickable
+// links. The desktop renderer routes these through MarkdownLink → FilePathLink:
+// left-click opens the file in the in-app sandboxed preview pane; the
+// right-click menu offers "Open in default app" / "Reveal in folder" through a
+// hardened main-process IPC (see electron/hardening.cjs).
+//
+// Scope (v1) is deliberately narrow to keep false positives near zero:
+//   - ABSOLUTE paths only — POSIX (`/…`, `~/…`) and Windows drive (`C:\…`,
+//     `C:/…`). Relative paths (`src/app/x.tsx`) are NOT matched because, without
+//     the session cwd, prose like "and/or" or "n/a" is too easy to mis-link.
+//   - the path must end in a real filename WITH an extension; directories and
+//     extensionless names (`/usr/local/bin`, `Makefile`) are skipped, and so
+//     are dotfiles whose only dot is the leading one (`.env`, `.gitignore`).
+//   - an optional `:line[:col]` suffix is kept in the visible label.
+//
+// Detection runs on prose only: fenced and inline code are split out upstream
+// (markdown-preprocess.ts), and existing markdown links / autolinks are skipped
+// here so we never rewrite a target that is already a link.
+
+const FILE_PATH_HREF_PREFIX = '#file/'
+
+// A single path-segment character: anything but whitespace, the separators, a
+// colon (so a trailing `:line` is not swallowed and the Windows drive colon
+// stays at the front), wildcards, quotes, angle brackets, and pipe.
+const SEGMENT = '[^\\s/\\\\:*?"<>|]'
+const LINE_SUFFIX = '(?::\\d+(?::\\d+)?)?'
+// Extension: a dot + up to 16 alnum chars (covers `.properties`, `.storyboard`,
+// `.entitlements`, ...). The END_BOUNDARY below makes an over-long or
+// punctuation-continued tail (e.g. `.c-d`) fail the whole match cleanly instead
+// of truncating to a wrong path.
+const EXTENSION = '\\.[A-Za-z0-9]{1,16}'
+
+// The matched path must END at a real boundary: whitespace, a path separator,
+// quote/pipe/wildcard, or trailing sentence punctuation. This EXCLUDES
+// segment-continuation chars (alnum, `-`, `_`), so the match can never stop in
+// the middle of a filename — an over-long extension fails the match rather than
+// truncating it. The class also ends a path before a closing quote (U+0027)
+// or backtick (U+0060), listed by code point to avoid source-quoting issues.
+const END_BOUNDARY = '(?=[\\s/\\\\:*?"<>|.,;!?)\\]}\\u0027\\u0060]|$)'
+
+// The char immediately before a match must NOT be a word char, dot, tilde,
+// colon, or a separator. This anchors matches to true absolute paths and skips
+// relative `a/b.ts`, scheme-prefixed `file:/…`/`http:/…`, and the inner slashes
+// of a longer token.
+const PATH_BOUNDARY = '(?<![\\w.~:/\\\\])'
+
+const POSIX_PATH = `~?(?:/${SEGMENT}+)+${EXTENSION}`
+const WINDOWS_PATH = `[A-Za-z]:[\\\\/](?:${SEGMENT}+[\\\\/])*${SEGMENT}+${EXTENSION}`
+
+const FILE_PATH_RE = new RegExp(`${PATH_BOUNDARY}(?:${WINDOWS_PATH}|${POSIX_PATH})${LINE_SUFFIX}${END_BOUNDARY}`, 'g')
+
+// Existing markdown links `[text](target)` and autolinks `<…>`. Captured so
+// linkification leaves them untouched and only rewrites the plain-text gaps.
+// The destination class allows one level of balanced parens so a link target
+// like `/build(1)/out.json` (or a `#preview/path(x)/…` href) is captured whole
+// instead of being split at the first `)` and re-linkified into broken markup.
+const MARKDOWN_LINK_OR_AUTOLINK_RE = /(\[[^\]]*\]\([^()]*(?:\([^()]*\)[^()]*)*\)|<[^\s>]+>)/g
+
+const LINE_SUFFIX_RE = /:\d+(?::\d+)?$/
+
+export interface FilePathParts {
+  /** The full matched token, e.g. `/Users/me/out.ts:42` — shown as the label. */
+  display: string
+  /** The path with any `:line[:col]` suffix stripped — used to open/preview. */
+  path: string
+}
+
+export function splitFilePathSuffix(value: string): FilePathParts {
+  const path = value.replace(LINE_SUFFIX_RE, '')
+
+  return { display: value, path: path || value }
+}
+
+export function filePathMarkdownHref(value: string): string {
+  // encodeURIComponent leaves `(` and `)` unescaped, which would break the
+  // markdown `(target)` wrapper — encode them too so the lexer keeps the href
+  // intact.
+  const encoded = encodeURIComponent(value).replace(/\(/g, '%28').replace(/\)/g, '%29')
+
+  return `${FILE_PATH_HREF_PREFIX}${encoded}`
+}
+
+export function filePathFromMarkdownHref(href?: null | string): null | string {
+  if (!href?.startsWith(FILE_PATH_HREF_PREFIX)) {
+    return null
+  }
+
+  try {
+    return decodeURIComponent(href.slice(FILE_PATH_HREF_PREFIX.length))
+  } catch {
+    return null
+  }
+}
+
+// Only `[` and `]` can break the `[label]` wrapper. The visible label is
+// re-rendered from the decoded href by FilePathLink, so this escaping only
+// matters as a plain-markdown fallback.
+function escapeMarkdownLinkLabel(value: string): string {
+  return value.replace(/[[\]]/g, '\\$&')
+}
+
+export function linkifyFilePaths(text: string): string {
+  if (!text.includes('/') && !/[A-Za-z]:[\\/]/.test(text)) {
+    return text
+  }
+
+  return text
+    .split(MARKDOWN_LINK_OR_AUTOLINK_RE)
+    .map((part, index) => {
+      // Odd indices are the captured links/autolinks — leave them untouched.
+      if (index % 2 === 1) {
+        return part
+      }
+
+      return part.replace(FILE_PATH_RE, match => `[${escapeMarkdownLinkLabel(match)}](${filePathMarkdownHref(match)})`)
+    })
+    .join('')
+}

--- a/apps/desktop/src/lib/markdown-preprocess.ts
+++ b/apps/desktop/src/lib/markdown-preprocess.ts
@@ -1,3 +1,4 @@
+import { linkifyFilePaths } from '@/lib/file-path-links'
 import { isLikelyProseFence, sanitizeLanguageTag } from '@/lib/markdown-code'
 import { stripPreviewTargets } from '@/lib/preview-targets'
 
@@ -144,8 +145,10 @@ function normalizeVisibleProse(text: string): string {
     .map(part =>
       part.startsWith('`')
         ? part
-        : autoLinkRawUrls(
-            part.replace(/`{3,}/g, '').replace(LOCAL_PREVIEW_URL_RE, '$1').replace(CITATION_MARKER_RE, '')
+        : linkifyFilePaths(
+            autoLinkRawUrls(
+              part.replace(/`{3,}/g, '').replace(LOCAL_PREVIEW_URL_RE, '$1').replace(CITATION_MARKER_RE, '')
+            )
           )
     )
     .join('')

--- a/apps/desktop/src/lib/markdown-preprocess.ts
+++ b/apps/desktop/src/lib/markdown-preprocess.ts
@@ -1,4 +1,4 @@
-import { linkifyFilePaths } from '@/lib/file-path-links'
+import { fileLinkMarkdown, isLoneFilePath, linkifyFilePaths } from '@/lib/file-path-links'
 import { isLikelyProseFence, sanitizeLanguageTag } from '@/lib/markdown-code'
 import { stripPreviewTargets } from '@/lib/preview-targets'
 
@@ -139,12 +139,33 @@ function autoLinkRawUrls(text: string): string {
   })
 }
 
+// A fenced block that is exactly one path line, e.g. ```\n/Users/me/out.ts\n```.
+const SINGLE_LINE_FENCE_RE = /^(?:`{3,}|~{3,})[^\n]*\n([^\n]+)\n(?:`{3,}|~{3,})[ \t]*$/
+
+// An inline-code span (`…`) whose entire content is one file path becomes a
+// clickable link, so a path the agent wrapped in backticks is still openable.
+// Spans that merely contain a path (commands, flags) stay plain code.
+function linkifyInlineCodePath(span: string): string {
+  const inner = span.slice(1, -1)
+
+  return isLoneFilePath(inner) ? fileLinkMarkdown(inner.trim()) : span
+}
+
+// A fenced block whose only content is one file path becomes a clickable link
+// (the agent sometimes emits a path as a one-line code card). Multi-line blocks
+// and blocks containing anything else pass through untouched.
+function linkifyLoneFencedPath(part: string): string {
+  const match = part.match(SINGLE_LINE_FENCE_RE)
+
+  return match && isLoneFilePath(match[1]) ? fileLinkMarkdown(match[1].trim()) : part
+}
+
 function normalizeVisibleProse(text: string): string {
   return text
     .split(INLINE_CODE_SPLIT_RE)
     .map(part =>
       part.startsWith('`')
-        ? part
+        ? linkifyInlineCodePath(part)
         : linkifyFilePaths(
             autoLinkRawUrls(
               part.replace(/`{3,}/g, '').replace(LOCAL_PREVIEW_URL_RE, '$1').replace(CITATION_MARKER_RE, '')
@@ -357,9 +378,10 @@ export function preprocessMarkdown(text: string): string {
   return strippedEmptyFences
     .split(CODE_FENCE_SPLIT_RE)
     .map(part => {
-      // Fence blocks pass through untouched.
+      // A fenced block that is just one file path becomes a clickable link;
+      // other fenced blocks pass through untouched.
       if (/^(?:```|~~~)/.test(part)) {
-        return part
+        return linkifyLoneFencedPath(part)
       }
 
       // Whitespace-only segments (e.g. the `\n\n` between two adjacent

--- a/apps/desktop/src/store/preview.ts
+++ b/apps/desktop/src/store/preview.ts
@@ -30,7 +30,7 @@ export interface PreviewServerRestart {
   url: string
 }
 
-export type PreviewRecordSource = 'explicit-link' | 'file-browser' | 'manual' | 'tool-result'
+export type PreviewRecordSource = 'chat-path' | 'explicit-link' | 'file-browser' | 'manual' | 'tool-result'
 
 export interface SessionPreviewRecord {
   autoOpen?: boolean
@@ -118,10 +118,11 @@ function openFilePreviewTarget(target: PreviewTarget) {
   selectRightRailTab(id)
 }
 
-// Manual/file-browser opens are "peeking at a file" → source view in the file
-// pane. Tool/explicit-link opens are runnable artifacts → live preview pane.
+// Manual/file-browser/chat-path opens are "peeking at a file" → source view in
+// the file pane. Tool/explicit-link opens are runnable artifacts → live preview
+// pane.
 function isFilePreviewSource(source: PreviewRecordSource): boolean {
-  return source === 'file-browser' || source === 'manual'
+  return source === 'chat-path' || source === 'file-browser' || source === 'manual'
 }
 
 function previewTargetForSource(target: PreviewTarget, source: PreviewRecordSource): PreviewTarget {
@@ -169,7 +170,7 @@ function isPreviewRecord(value: unknown): value is SessionPreviewRecord {
     typeof r.id === 'string' &&
     isPreviewTarget(r.normalized) &&
     typeof r.sessionId === 'string' &&
-    ['explicit-link', 'file-browser', 'manual', 'tool-result'].includes(String(r.source)) &&
+    ['chat-path', 'explicit-link', 'file-browser', 'manual', 'tool-result'].includes(String(r.source)) &&
     typeof r.target === 'string' &&
     (r.dismissedAt === undefined || typeof r.dismissedAt === 'number')
   )


### PR DESCRIPTION
## Follow-up to #48859 — Linkify file paths inside inline / one-line code spans

**Improves [#48859](https://github.com/NousResearch/hermes-agent/pull/48859)** ("make chat file paths clickable", [#48313](https://github.com/NousResearch/hermes-agent/issues/48313)).

> ⚠️ **Stacked on #48859.** This branch is built on top of #48859's branch, so until #48859 merges, the diff against `main` includes **both** commits. **Review the second commit** (`feat(desktop): linkify file paths inside inline / one-line code spans`) — the first is #48859. Rebase onto `main` once #48859 lands and the diff becomes a single commit.

### Why

#48859 makes absolute file paths clickable, but it deliberately skips anything inside code. In **live testing**, the agent almost always formats a path as `` `inline code` `` or a one-line code card — so the clickable chip rarely appeared in practice. (See the comment on #48859 for the testing notes.)

This makes the feature **format-agnostic** for the common case: an **inline-code span** or a **single-line fenced block whose entire content is one absolute file path** is now linkified too, through the same `FilePathLink` → preview / hardened-open chain.

Conservative by construction:
- Code that merely *contains* a path (`` `cat /a/b.ts` ``, flags) stays plain code.
- **Multi-line** code blocks (real listings/scripts) are untouched.
- Only a span that is **exactly one** absolute path (optionally `:line[:col]`) is converted.

Renderer-only — does not change what the agent emits, so it can't interact with the gateway's messaging auto-attachment.

### Relationship to the other follow-ups (reviewers decide)

Three independent follow-ups came out of testing #48859. They can be merged in **any combination** — all, some, or none — once #48859 is accepted:

| | Mechanism | Robustness | This PR |
|---|---|---|---|
| **#1 (this)** linkify code-span paths | renderer | high | ✅ |
| **#2** tool-result file chip *(prepared, not opened)* | renderer | guaranteed | — |
| **#3** prompt nudge | prompt | probabilistic | — |

#1 is the robust default; #3 nudges the model toward prose (cheap, probabilistic); #2 guarantees an affordance from the tool result regardless of prose. They're complementary, not mutually exclusive.

## Type of Change

- [x] ✨ New feature (extends #48859; non-breaking)

## Behavior change to note

#48859 asserted a path inside inline code is **not** clickable. This PR reverses that **for lone-path spans only** — that test is updated accordingly. Multi-line and mixed-content code is unaffected.

## Changes Made

- `apps/desktop/src/lib/file-path-links.ts` — `isLoneFilePath()` (anchored whole-string match) + `fileLinkMarkdown()` (shared link builder).
- `apps/desktop/src/lib/markdown-preprocess.ts` — `linkifyInlineCodePath()` (inline-code branch) + `linkifyLoneFencedPath()` (one-line fence branch).
- `apps/desktop/src/lib/file-path-links.test.ts` — updated the prior "inline code not linkified" case + 6 new cases.

## How to Test

```bash
cd apps/desktop
npm run typecheck
npx vitest run --environment jsdom src/lib/file-path-links.test.ts   # 26 pass
```
Manual (dev build): ask the agent for a path it formats as `` `…/x.md` `` or a one-line code card → it renders as a clickable chip; a command or multi-line block stays plain code.

## Checklist

- [x] Read the Contributing Guide; Conventional Commits; scoped to this change
- [ ] `pytest tests/ -q` — **N/A** (TS-only; ran desktop vitest instead)
- [x] Added tests (26 vitest cases pass)
- [x] Tested on macOS (Darwin 23.5); chip render confirmed live in the dev build
- Verified locally: `typecheck` ✓, `vite build` ✓, eslint on changed files clean
