### PR TITLE
feat(agent): nudge webui/desktop agent to state file paths in plain prose (follow-up to #48859)

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -724,7 +724,11 @@ PLATFORM_HINTS = {
         "controls), video, PDFs, HTML, CSV, diffs/patches, and Excalidraw files "
         "render as rich previews. Do not use Markdown image syntax like "
         "![alt](/path) for local files; local paths are not served that way. "
-        "Use MEDIA:/absolute/path instead."
+        "Use MEDIA:/absolute/path instead. "
+        "When you reference a file you created or changed, also state its "
+        "absolute path in plain prose (not only inside a code block) — Hermes "
+        "Desktop renders such paths as clickable links the user can preview or "
+        "open in their editor."
     ),
 }
 

--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -1068,6 +1068,10 @@ class TestPromptBuilderConstants:
         assert "MEDIA:" in hint
         assert "Markdown" in hint
         assert "absolute" in hint
+        # Nudge the agent to state created/changed paths in plain prose so the
+        # desktop's clickable-file-path feature can linkify them.
+        assert "clickable" in hint
+        assert "plain prose" in hint
 
 
 # =========================================================================


### PR DESCRIPTION
## Follow-up to #48859 — Nudge the agent to state file paths in plain prose

**Improves [#48859](https://github.com/NousResearch/hermes-agent/pull/48859)** ("make chat file paths clickable", [#48313](https://github.com/NousResearch/hermes-agent/issues/48313)). Prompt-only; based on `main` (clean one-commit diff).

### Why

#48859 makes a file path clickable **only when it appears as plain prose**. But in live testing the agent almost always formats paths as `` `inline code` `` or one-line code cards, where the feature deliberately doesn't fire — so the clickable chip rarely showed up. (See the comment on #48859 for the testing notes.)

This is the cheapest of three complementary follow-ups: it nudges the model to *also* state a created/changed file's absolute path in plain prose, so #48859's linkifier catches it.

### What

One sentence added to the **`webui`** platform hint in `agent/prompt_builder.py` — the platform the desktop chat reports (`X-Hermes-Session-Key: webui:…`):

> "When you reference a file you created or changed, also state its absolute path in plain prose (not only inside a code block) — Hermes Desktop renders such paths as clickable links the user can preview or open in their editor."

- Scoped to the `webui` hint; CLI/messaging platforms keep their own hints (the CLI hint already says to use plain-text paths). No behavior change elsewhere.
- It's a *nudge*, so it's **probabilistic** — it improves the common case but doesn't guarantee a chip. The renderer-side follow-up (#1) is the robust complement; the tool-result follow-up (#2) is the deterministic one.

### Relationship to the other follow-ups (reviewers decide)

Three independent follow-ups came out of testing #48859. They can be merged in **any combination** — all, some, or none — once #48859 is accepted:

| | Mechanism | Robustness | Depends on #48859 code? |
|---|---|---|---|
| **#1** linkify code-span paths | renderer | high | yes (stacked) |
| **#2** tool-result file chip *(prepared, not opened)* | renderer | guaranteed | yes |
| **#3 (this)** prompt nudge | prompt | probabilistic | no (prompt-only) |

This PR is harmless on its own (it just changes guidance text) and only becomes useful once #48859 lands.

## Type of Change

- [x] ✨ New feature (extends #48859; non-breaking) — prompt text only

## Changes Made

- `agent/prompt_builder.py` — one sentence appended to the `webui` `PLATFORM_HINTS` entry.
- `tests/agent/test_prompt_builder.py` — extends `test_platform_hints_webui` to assert the nudge is present.

## How to Test

```bash
venv/bin/python -m pytest tests/agent/test_prompt_builder.py -q   # passes
```
Manual (with #48859 + a built desktop): ask the agent to create a file; it now tends to mention the absolute path in prose, which renders as a clickable chip.

## Checklist

- [x] Read the Contributing Guide; Conventional Commits; scoped to this change
- [x] `pytest tests/agent/test_prompt_builder.py -q` passes; `ruff check` clean
- [x] Added/extended a test
- [x] Cross-platform: prompt-text only, no path logic
- Note: this is a `.py` change; the commit author is a GitHub noreply address (auto-skipped by `contributor-check`), so no `AUTHOR_MAP` entry is needed.
